### PR TITLE
Add ads.txt authorising the AdSense publisher account

### DIFF
--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-5997711677062324, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Crawlers only read /ads.txt at the domain root, so it sits beside index.html rather than in a subdirectory. One DIRECT entry for the publisher ID, with Google's certification authority ID as the fourth field.

The file is inert by itself - it authorises a seller, it does not load anything
- so nothing about the site's behaviour changes by adding it. What it does not do is resolve the conflict it implies: no page here can currently run ad code, because the hub has no script-src at all and the tool page has connect-src 'none', and the front page states as checkable facts that nothing is loaded from elsewhere and nothing is uploaded. Serving ads means changing both the policies and those claims, deliberately and together.