### PR TITLE
Draw the roadmap from a catalogue instead of from memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 The source for **[abox.tools](https://abox.tools/)** — a small collection of
 single-purpose web tools that do all of their work **in the browser**. No server,
-no upload, no account, no dependencies, no build step.
+no upload, no account.
 
 The selling proposition is not "we promise not to look at your files", it is
-"there is no code path that could send them anywhere, and you can check that
-yourself in a minute". Everything below is written to keep that true.
+"there is no code path that could send them anywhere". Everything below is
+written to keep that true.
+
+Most of these tools are also small enough to read in one sitting, and that is
+worth keeping wherever it is free. It is not the promise, though. Where the
+browser cannot do a job on its own, a vendored engine that runs on the
+visitor's own machine beats not shipping the tool at all — see
+[What can be built here](#what-can-be-built-here).
 
 ---
 
@@ -95,6 +101,10 @@ only itself and cannot interfere with its neighbours.
 3. If it belongs to a category that does not exist yet, copy a whole
    `<section class="category">` block and move that name out of the "Planned" list.
 
+   Before adding a *new* name to the Planned list, put it through
+   [What can be built here](#what-can-be-built-here) first. That section is
+   where the ruled-out ones, and the reasons they were ruled out, live.
+
 Two things to hold the line on, because the whole site rests on them:
 
 - **Nothing about a user's file is ever read out.** Not to Google, not to
@@ -176,6 +186,90 @@ Each tool page links to this repository in four places — the header button, th
 privacy panel (twice), and the footer — plus once in the hub footer. "Read the code"
 is the only real answer to "why should I trust this", so if the repository ever
 moves, all of them move with it. A dead source link is worse than no link at all.
+
+---
+
+## What can be built here
+
+The "Planned" list on the front page is not a wishlist. It was drawn up by going
+through the tool list of the largest online GIF and video site — the closest
+thing there is to a complete catalogue of what people actually want done to a
+media file — and putting every entry through one test:
+
+> Does all of the work happen on the visitor's own machine, with the file never
+> leaving it, and does the tool still run with the network unplugged?
+
+Note what that test does **not** ask. It does not ask whether the code is small,
+or hand-written, or readable in one sitting. Those are good properties — most of
+this repository has all three, and `src/mp4.js` is why the first tool needed no
+dependency at all — but they are a preference, not the promise. The promise is
+that your file stays on your machine. A tool that keeps that promise with thirty
+megabytes of vendored WebAssembly keeps it exactly as completely as one that
+keeps it with four hundred lines of hand-written muxer.
+
+### What the browser can do on its own
+
+Reach for this first. Where a native API does the job there is no reason to ship
+an engine to do it instead, and these all stay small enough to read.
+
+| Group | What does the work |
+|---|---|
+| Image resize, crop, rotate, convert, compress, filters, text | `createImageBitmap` → `<canvas>` → `canvas.toBlob`. PNG, JPEG and WebP are encoders the browser already has |
+| Metadata viewer and remover | EXIF is a byte structure inside the file: reading it is parsing, and removing it is re-encoding through a canvas, which drops every tag on the way |
+| PNG to ICO, images to PDF | Containers, not codecs — a header wrapped around images that are already encoded. The same trick `src/mp4.js` plays |
+| SVG to PNG | An `<img>` holding an SVG draws to a canvas. Only for SVGs with no external references, which is also what keeps it offline |
+| GIF: make, split, resize, reverse, retime, analyze | LZW and a color quantizer, written out the way the MP4 muxer was. Reading animated GIFs is `ImageDecoder` where it exists and a hand-written parser where it does not |
+| APNG | PNG chunks, with `CompressionStream('deflate')` for the pixel data — the compressor is already in the browser |
+| Video: trim, resize, crop, rotate, reverse, frame grabs, filters, subtitles | `VideoDecoder` and `VideoEncoder`, plus an MP4 *de*muxer to sit beside the muxer that already exists |
+| Audio: trim, fade, speed, volume, waveform | `decodeAudioData` and `OfflineAudioContext`. WAV out is a 44-byte header in front of the samples |
+| QR codes and barcodes | Arithmetic over a string. There is no input file at all |
+
+### What needs a vendored FFmpeg
+
+Everything below is out of reach of the browser's own APIs and in reach of an
+`ffmpeg.wasm` build. It passes the test at the top of this section — the file
+never leaves the machine and the tool works with the network unplugged — so it
+is on the roadmap on that basis.
+
+| Tool | Why it needs the build |
+|---|---|
+| HEIC to JPG or PNG | Only Safari decodes HEIC natively. FFmpeg's HEIF demuxer and HEVC decoder cover everyone else, so the iPhone-photo problem stops being Safari-only. Images to Video currently skips HEIC with a message; that message becomes a link to the converter |
+| Encoding MP3 | No browser ships an MP3 encoder. `libmp3lame` is one, so "anything to MP3" becomes a real converter instead of only "MP3 in, WAV out" |
+| Encoding AVIF | Chromium's `canvas.toBlob` is the only native writer, and everywhere else it quietly hands back a PNG. `libaom` writes it the same way in every browser |
+| Animated WebP | Every browser decodes it and none encode it. `libwebp` does both |
+| JPEG XL, both directions | Chrome 145 and Firefox 152 carry a decoder behind a flag, and only Safari turns it on by default. `libjxl` in the build makes the browser's own support irrelevant |
+
+**What it costs, and what has to change to pay it.** None of this is free, and
+all of it is knowable up front:
+
+- **The core is roughly 25–30 MB, and it is served from this origin.** A CDN
+  copy would put a third party in the path of every visit and could not be
+  cached for offline use, which is the whole point. Vendor it, commit it, and
+  put it in that tool's service worker precache. A tool that downloads its own
+  engine the first time you press the button is not an offline tool.
+- **Two CSP changes, in the tool that needs them and nowhere else.**
+  `script-src` needs `'wasm-unsafe-eval'`, and `connect-src` needs `'self'` —
+  which no page here currently grants. Today `connect-src` names Google's
+  endpoints and nothing else, so an FFmpeg worker could not fetch the `.wasm`
+  file sitting in its own folder. Do not add either to the hub page.
+- **Use the single-threaded core.** The multi-threaded one needs
+  `SharedArrayBuffer`, which needs `Cross-Origin-Opener-Policy: same-origin` and
+  `Cross-Origin-Embedder-Policy: require-corp`. `require-corp` breaks AdSense:
+  Google's scripts and frames do not send the CORP header it demands. It is
+  threads or ads, not both. If a tool ever genuinely needs the threaded build,
+  it gets those two headers *and* no ad slots, and the ad section of this file
+  has to say so out loud.
+- **Say it on the tool's page.** The privacy panel already reports what the page
+  loaded. A tool carrying an engine should name it, give its size, and say
+  plainly that it came from this origin once and contacted nothing afterwards.
+
+### What is still left out
+
+| Ruled out | Why |
+|---|---|
+| Background removal | A segmentation model, not a codec. FFmpeg does not do it and would not help — this needs weights and an inference runtime, which is a separate argument on a separate day |
+| Camera RAW (CR2, NEF, ARW) | FFmpeg does not decode these either. It would take LibRaw or dcraw on top: a second engine, for one family of formats |
+| Raster to vector (image to SVG) | A tracing algorithm, not a conversion: large, and the output disappoints everyone who expected their photo back as shapes |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -269,18 +269,106 @@
     Written as plain text on purpose. A card that links nowhere, or a category
     heading with nothing under it, reads as a broken page rather than an
     honest one. Move a name out of this list when the tool actually ships.
+
+    The media groups below are what is left after walking the tool list of the
+    best-known online GIF and video site and keeping every entry that can be
+    built so that the work happens on the visitor's own machine, and keeps
+    happening with the network unplugged. Most of them run on APIs the browser
+    already ships. A few need an FFmpeg build vendored into the one tool that
+    uses it, which is allowed - the file still never leaves the machine. What
+    that costs, and what was left out anyway, is written down in README.md
+    under "What can be built here". Read it before adding a name back: a few
+    of the obvious-looking gaps are gaps on purpose.
   -->
   <section class="category planned" id="planned" aria-labelledby="planned-h">
     <div class="category-head">
       <h2 id="planned-h">Planned</h2>
       <p class="category-note">Not built yet. Listed so you can see where this is going.</p>
     </div>
-    <ul class="planned-list">
-      <li><span class="p-name">Documents &amp; PDF</span> <span class="p-desc">merge, split, rotate, extract pages</span></li>
-      <li><span class="p-name">Text &amp; code</span> <span class="p-desc">format, diff, encode, convert between formats</span></li>
-      <li><span class="p-name">Data</span> <span class="p-desc">CSV and JSON conversion, cleaning, inspection</span></li>
-      <li><span class="p-name">Privacy &amp; security</span> <span class="p-desc">hashes, checksums, metadata stripping</span></li>
-    </ul>
+
+    <div class="planned-group">
+      <h3>Images</h3>
+      <ul class="planned-list">
+        <li><span class="p-name">Resize</span> <span class="p-desc">one image or a whole folder, by pixels or by percent</span></li>
+        <li><span class="p-name">Crop</span> <span class="p-desc">free, fixed ratio, or an exact pixel box</span></li>
+        <li><span class="p-name">Rotate &amp; flip</span> <span class="p-desc">quarter turns, or straightening by a few degrees</span></li>
+        <li><span class="p-name">Convert format</span> <span class="p-desc">PNG, JPG and WebP, in any direction</span></li>
+        <li><span class="p-name">Compress</span> <span class="p-desc">a quality dial, with the new size shown before you save</span></li>
+        <li><span class="p-name">Add text</span> <span class="p-desc">over the picture, or in a caption box above it</span></li>
+        <li><span class="p-name">Filters</span> <span class="p-desc">brightness, contrast, saturation, blur, grayscale</span></li>
+        <li><span class="p-name">Image to data URI</span> <span class="p-desc">paste the result straight into CSS or HTML</span></li>
+        <li><span class="p-name">Metadata viewer</span> <span class="p-desc">read what a photo says about you, without sending it anywhere</span></li>
+        <li><span class="p-name">Metadata remover</span> <span class="p-desc">EXIF, GPS and camera details out of a photo</span></li>
+        <li><span class="p-name">PNG to ICO</span> <span class="p-desc">a favicon at every size a browser asks for</span></li>
+        <li><span class="p-name">SVG to PNG</span> <span class="p-desc">rasterize a vector at any size</span></li>
+        <li><span class="p-name">HEIC to JPG</span> <span class="p-desc">the photos an iPhone makes, in a format everything opens</span></li>
+        <li><span class="p-name">AVIF &amp; JPEG XL</span> <span class="p-desc">convert either way, in whichever browser you happen to use</span></li>
+      </ul>
+    </div>
+
+    <div class="planned-group">
+      <h3>GIF &amp; animation</h3>
+      <ul class="planned-list">
+        <li><span class="p-name">GIF maker</span> <span class="p-desc">images into an animated GIF</span></li>
+        <li><span class="p-name">Video to GIF</span> <span class="p-desc">pick the section, the size, and the frame rate</span></li>
+        <li><span class="p-name">GIF to MP4 or WebM</span> <span class="p-desc">the same animation, usually a tenth of the size</span></li>
+        <li><span class="p-name">Split a GIF</span> <span class="p-desc">every frame out as its own PNG</span></li>
+        <li><span class="p-name">Resize, crop &amp; rotate GIFs</span> <span class="p-desc">frame by frame, with the timing kept</span></li>
+        <li><span class="p-name">Reverse a GIF</span> <span class="p-desc">last frame first</span></li>
+        <li><span class="p-name">Change GIF speed</span> <span class="p-desc">retime it without re-rendering the frames</span></li>
+        <li><span class="p-name">GIF analyzer</span> <span class="p-desc">frames, delays, palette, and where the bytes went</span></li>
+        <li><span class="p-name">APNG maker</span> <span class="p-desc">animation with real transparency and full color</span></li>
+        <li><span class="p-name">Animated WebP</span> <span class="p-desc">the same animation again, at a fraction of the size</span></li>
+      </ul>
+    </div>
+
+    <div class="planned-group">
+      <h3>Video</h3>
+      <ul class="planned-list">
+        <li><span class="p-name">Trim</span> <span class="p-desc">cut a section out and keep the original quality</span></li>
+        <li><span class="p-name">Resize</span> <span class="p-desc">down to a size that will actually send</span></li>
+        <li><span class="p-name">Crop</span> <span class="p-desc">including squaring up a clip for a feed</span></li>
+        <li><span class="p-name">Rotate</span> <span class="p-desc">for the clip that was filmed sideways</span></li>
+        <li><span class="p-name">Reverse</span> <span class="p-desc">play it backwards</span></li>
+        <li><span class="p-name">Mute, or save the audio</span> <span class="p-desc">drop the sound, or keep it on its own</span></li>
+        <li><span class="p-name">Grab a frame</span> <span class="p-desc">a full-quality still from any point</span></li>
+        <li><span class="p-name">Convert to MP4 or WebM</span> <span class="p-desc">whichever one the site you are posting to insists on</span></li>
+        <li><span class="p-name">Filters</span> <span class="p-desc">brightness, contrast, saturation, blur</span></li>
+        <li><span class="p-name">Burn in subtitles</span> <span class="p-desc">an SRT file drawn into the picture</span></li>
+      </ul>
+    </div>
+
+    <div class="planned-group">
+      <h3>Audio</h3>
+      <ul class="planned-list">
+        <li><span class="p-name">Trim</span> <span class="p-desc">keep the part you wanted</span></li>
+        <li><span class="p-name">Fade in &amp; out</span> <span class="p-desc">so it does not start and stop on a cliff</span></li>
+        <li><span class="p-name">Change speed</span> <span class="p-desc">with or without moving the pitch</span></li>
+        <li><span class="p-name">Normalize or boost volume</span> <span class="p-desc">bring a quiet recording up to a usable level</span></li>
+        <li><span class="p-name">Waveform image</span> <span class="p-desc">draw a track as a picture</span></li>
+        <li><span class="p-name">Convert format</span> <span class="p-desc">MP3, WAV and Opus, in any direction</span></li>
+      </ul>
+    </div>
+
+    <div class="planned-group">
+      <h3>Documents &amp; PDF</h3>
+      <ul class="planned-list">
+        <li><span class="p-name">Images to PDF</span> <span class="p-desc">photos or scans gathered into one document</span></li>
+        <li><span class="p-name">Merge, split &amp; reorder</span> <span class="p-desc">pages moved around without a round trip to a server</span></li>
+        <li><span class="p-name">Rotate &amp; crop pages</span> <span class="p-desc">fix a scan that came in sideways, or trim its margins</span></li>
+        <li><span class="p-name">Extract images</span> <span class="p-desc">pull the pictures back out of a document</span></li>
+      </ul>
+    </div>
+
+    <div class="planned-group">
+      <h3>Beyond media</h3>
+      <ul class="planned-list">
+        <li><span class="p-name">Text &amp; code</span> <span class="p-desc">format, diff, encode, convert between formats</span></li>
+        <li><span class="p-name">Data</span> <span class="p-desc">CSV and JSON conversion, cleaning, inspection</span></li>
+        <li><span class="p-name">Privacy &amp; security</span> <span class="p-desc">hashes, checksums, metadata stripping</span></li>
+        <li><span class="p-name">QR &amp; barcodes</span> <span class="p-desc">generated from a string, with nothing sent to make one</span></li>
+      </ul>
+    </div>
   </section>
 
 </main>

--- a/site.css
+++ b/site.css
@@ -165,6 +165,22 @@ code {
 
 .planned .category-head h2 { color: var(--text-dim); }
 
+/* The planned list is grouped once it is longer than a handful of lines: a
+   flat run of forty names reads as a wishlist, the same names under Images /
+   Video / Audio read as a shape. The heading is deliberately quieter than a
+   category's <h2> so a shipped tool still outranks a planned one visually. */
+
+.planned-group + .planned-group { margin-top: 1.35rem; }
+
+.planned-group h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+
 .planned-list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
The Planned list was four category names. It is now 48 named tools, picked by walking a large online media-tool catalogue and putting every entry through one test: does the work happen on the visitor's own machine, and does the tool still run with the network unplugged?

Records the answers in README.md so they are not re-derived every time: what the browser can already do and which API does it, what needs a vendored FFmpeg build, and what stays out regardless. Background removal, camera RAW and image tracing stay out - FFmpeg does not solve any of the three.

Vendoring an engine is allowed, so the wording that implied otherwise had to go. "No dependencies, no build step" and the "check that yourself in a minute" framing are gone from the intro: small-enough-to-read is worth keeping where it is free, but the promise is that the file stays on the machine, not that the code is short. Where the browser cannot do a job on its own, a local engine beats not shipping the tool.

The costs of that are written down rather than discovered later: the core is committed and precached, script-src needs 'wasm-unsafe-eval', and connect-src needs 'self', which no page here currently grants. The threaded build needs COOP/COEP, and require-corp breaks AdSense, so it is threads or ads and not both.