### PR TITLE
Give the site a Privacy page, a Terms page, and a footer to reach the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ mounted — every path in it is relative, so it works at the domain root, at
   .nojekyll              stops GitHub Pages running the content through Jekyll
   cloudflare/            the edge config that adds the security headers
   serve.ps1              local dev server
+  privacy/               Privacy and Cookies; uses site.css, not a tool
+    index.html
+  terms/                 Terms of Use; likewise
+    index.html
   images-to-video/       one tool, entirely self-contained
     index.html
     styles.css
@@ -101,6 +105,29 @@ readable and auditable on its own, which is the point when the claim being made 
 The service worker registers with the scope of its own folder, so each tool caches
 only itself and cannot interfere with its neighbours.
 
+## The footer
+
+Every page ends with the same footer: a few columns of plain links, left
+aligned, each under a quiet heading — the tools in one column, Privacy, Terms
+and the source in another. It is the second navigation, for anyone who scrolled
+to the bottom looking for one, and it is the only route to the legal pages.
+
+It exists **six times over** — in `index.html`, in `privacy/` and `terms/`, and
+once in each of the three tools — because tools deliberately share no markup and
+no stylesheet. That is the price of the self-contained rule, paid knowingly:
+
+- The markup is identical everywhere bar two details: the hub links to its
+  neighbours directly while every other page reaches them through `../`, and the
+  three tool pages carry the inlined site mark in the brand column, since they
+  cannot load `logo.svg` from a stylesheet they do not share.
+- The CSS lives in `site.css` for the hub and the legal pages, and is copied into
+  each tool's `styles.css` under a comment saying so.
+
+**A new tool has to be added to six footers, not one.** If that ever becomes the
+thing that stops a tool shipping, the fix is a generated site with one template,
+not a shared stylesheet quietly reintroduced into the tools — the whole point of
+the tools being self-contained is that each can be read on its own.
+
 ---
 
 ## Adding a tool
@@ -110,7 +137,11 @@ only itself and cannot interfere with its neighbours.
    stylesheet, and its own service worker scoped to the folder.
 2. Add one `<li>` card to the matching category in `index.html`. The markup for a
    card is spelled out in a comment right above the categories.
-3. If it belongs to a category that does not exist yet, copy a whole
+3. Add it to the **Tools** column of the footer. That footer is repeated on
+   every page, so this means `index.html`, `privacy/index.html`,
+   `terms/index.html`, and each tool's own `index.html` - six files. See
+   [The footer](#the-footer) for why it is copied rather than shared.
+4. If it belongs to a category that does not exist yet, copy a whole
    `<section class="category">` block and move that name out of the "Planned" list.
 
    Before adding a *new* name to the Planned list, put it through

--- a/compress-image/index.html
+++ b/compress-image/index.html
@@ -704,53 +704,81 @@
 </section>
 
 <footer>
-  <p>
-    Runs in your browser. No accounts, no uploads. Ads by Google.
-    &middot;
-    <!--
-      The site mark, inlined so that this page stays self-contained and works
-      offline. Same shape as the hub's logo.svg; colours come from this page's
-      own stylesheet.
-    -->
-    <a class="home-link" href="../">
-      <svg class="site-logo" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
-        <path class="logo-lid" d="M14 31V13.5A4.5 4.5 0 0 1 18.5 9h27a4.5 4.5 0 0 1 4.5 4.5V31"
-              fill="none" stroke-width="3.2" stroke-linejoin="round"/>
-        <g transform="rotate(-12 18 30)">
-          <rect class="logo-tool" x="16.6" y="17" width="3.2" height="17" rx="1.4"/>
-          <rect class="logo-tool" x="16.2" y="12.2" width="6.8" height="5" rx="1.5"/>
-          <rect class="logo-tool" x="14" y="12.6" width="2.6" height="6.6" rx="1.2" transform="rotate(26 16.2 13)"/>
-        </g>
-        <g transform="rotate(-3 26 30)">
-          <rect class="logo-tool-alt" x="24.6" y="17" width="3.1" height="17" rx="1.4"/>
-          <rect class="logo-tool-alt" x="23.2" y="12" width="2.3" height="6.5" rx="1.1"/>
-          <rect class="logo-tool-alt" x="26.8" y="12" width="2.3" height="6.5" rx="1.1"/>
-          <rect class="logo-tool-alt" x="23.2" y="16.2" width="5.9" height="3.6" rx="1.5"/>
-        </g>
-        <rect class="logo-tool-alt" x="30.6" y="12" width="5" height="8.4" rx="2.2"/>
-        <rect class="logo-tool" x="31.5" y="19.2" width="3.2" height="2.2" rx="0.7"/>
-        <rect class="logo-tool" x="32.1" y="20.5" width="2.1" height="13.5" rx="1"/>
-        <path class="logo-tool" d="M39.4 20.4 37.9 13a1.15 1.15 0 0 1 2.25-.45l1.15 7.6z" transform="rotate(-4 40.5 21)"/>
-        <path class="logo-tool" d="M41.6 20.4 43.1 13a1.15 1.15 0 0 0-2.25-.45l-1.15 7.6z" transform="rotate(4 40.5 21)"/>
-        <rect class="logo-tool" x="38.2" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(-8 40.5 21)"/>
-        <rect class="logo-tool" x="40.4" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(8 40.5 21)"/>
-        <circle class="logo-latch" cx="40.5" cy="20.8" r="1.5"/>
-        <g transform="rotate(14 48 30)">
-          <rect class="logo-tool" x="46.6" y="17.5" width="3.2" height="16.5" rx="1.4"/>
-          <rect class="logo-tool" x="44.6" y="14.2" width="7.4" height="3.4" rx="1.3"/>
-          <rect class="logo-tool" x="44.6" y="9.6" width="4.4" height="3.6" rx="1.1"/>
-          <rect class="logo-latch" x="46.4" y="17.4" width="3.6" height="1.9" rx="0.6"/>
-        </g>
-        <rect class="logo-box" x="8" y="38" width="48" height="15" rx="1.6"/>
-        <rect class="logo-band" x="4" y="31" width="56" height="7.5" rx="1.6"/>
-        <rect class="logo-latch" x="27.5" y="33.5" width="9" height="9" rx="1.8"/>
-      </svg>
-      All tools
-    </a>
-    &middot;
-    <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
-      Read the source
-    </a>
+  <div class="footer-cols">
+    <div class="footer-col footer-brand">
+      <a class="home-link" href="../">
+        <svg class="site-logo" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+          <path class="logo-lid" d="M14 31V13.5A4.5 4.5 0 0 1 18.5 9h27a4.5 4.5 0 0 1 4.5 4.5V31"
+                fill="none" stroke-width="3.2" stroke-linejoin="round"/>
+          <g transform="rotate(-12 18 30)">
+            <rect class="logo-tool" x="16.6" y="17" width="3.2" height="17" rx="1.4"/>
+            <rect class="logo-tool" x="16.2" y="12.2" width="6.8" height="5" rx="1.5"/>
+            <rect class="logo-tool" x="14" y="12.6" width="2.6" height="6.6" rx="1.2" transform="rotate(26 16.2 13)"/>
+          </g>
+          <g transform="rotate(-3 26 30)">
+            <rect class="logo-tool-alt" x="24.6" y="17" width="3.1" height="17" rx="1.4"/>
+            <rect class="logo-tool-alt" x="23.2" y="12" width="2.3" height="6.5" rx="1.1"/>
+            <rect class="logo-tool-alt" x="26.8" y="12" width="2.3" height="6.5" rx="1.1"/>
+            <rect class="logo-tool-alt" x="23.2" y="16.2" width="5.9" height="3.6" rx="1.5"/>
+          </g>
+          <rect class="logo-tool-alt" x="30.6" y="12" width="5" height="8.4" rx="2.2"/>
+          <rect class="logo-tool" x="31.5" y="19.2" width="3.2" height="2.2" rx="0.7"/>
+          <rect class="logo-tool" x="32.1" y="20.5" width="2.1" height="13.5" rx="1"/>
+          <path class="logo-tool" d="M39.4 20.4 37.9 13a1.15 1.15 0 0 1 2.25-.45l1.15 7.6z" transform="rotate(-4 40.5 21)"/>
+          <path class="logo-tool" d="M41.6 20.4 43.1 13a1.15 1.15 0 0 0-2.25-.45l-1.15 7.6z" transform="rotate(4 40.5 21)"/>
+          <rect class="logo-tool" x="38.2" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(-8 40.5 21)"/>
+          <rect class="logo-tool" x="40.4" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(8 40.5 21)"/>
+          <circle class="logo-latch" cx="40.5" cy="20.8" r="1.5"/>
+          <g transform="rotate(14 48 30)">
+            <rect class="logo-tool" x="46.6" y="17.5" width="3.2" height="16.5" rx="1.4"/>
+            <rect class="logo-tool" x="44.6" y="14.2" width="7.4" height="3.4" rx="1.3"/>
+            <rect class="logo-tool" x="44.6" y="9.6" width="4.4" height="3.6" rx="1.1"/>
+            <rect class="logo-latch" x="46.4" y="17.4" width="3.6" height="1.9" rx="0.6"/>
+          </g>
+          <rect class="logo-box" x="8" y="38" width="48" height="15" rx="1.6"/>
+          <rect class="logo-band" x="4" y="31" width="56" height="7.5" rx="1.6"/>
+          <rect class="logo-latch" x="27.5" y="33.5" width="9" height="9" rx="1.8"/>
+        </svg>
+        All tools
+      </a>
+      <p>
+        Runs in your browser. No accounts, no uploads. Ads by Google.
+        Tips are welcome and change nothing.
+      </p>
+    </div>
+
+    <div class="footer-col">
+      <strong>Tools</strong>
+      <ul>
+        <li><a href="../images-to-video/">Images to Video</a></li>
+        <li><a href="../compress-image/">Compress Image</a></li>
+        <li><a href="../exif-editor/">EXIF Editor</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>This site</strong>
+      <ul>
+        <li><a href="../">All tools</a></li>
+        <li><a href="../privacy/">Privacy &amp; Cookies</a></li>
+        <li><a href="../terms/">Terms of Use</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>The source</strong>
+      <ul>
+        <li>
+          <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
+            Read the code on GitHub
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <p class="footer-base">
+    Every claim on this site is meant to be checked, not believed.
   </p>
 </footer>
 

--- a/compress-image/styles.css
+++ b/compress-image/styles.css
@@ -870,16 +870,70 @@ button, .as-button {
   font-size: 0.88em;
 }
 
+/* A link footer in the same shape the hub uses: a few columns of plain links,
+   left aligned, each under a quiet heading, with the legal pages among them.
+   Tools deliberately share no stylesheet, so this block is copied into each of
+   them - if it changes in one, change it in the others and in site.css too. */
+
 footer {
-  text-align: center;
+  margin-top: 2.5rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--border);
   color: var(--text-dim);
-  font-size: 0.82rem;
-  padding-top: 0.5rem;
+  font-size: 0.85rem;
 }
 
-/* The way back to the hub, with the site mark on it. The link is inline in a
-   sentence, so the two sit on the text baseline rather than in a flex row. */
-.home-link { white-space: nowrap; }
+.footer-cols {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+}
+
+.footer-col { flex: 1 1 150px; min-width: 0; }
+.footer-brand { flex: 2 1 240px; }
+
+.footer-col strong {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.footer-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer-brand p { margin: 0.55rem 0 0; max-width: 36ch; }
+
+footer p { margin: 0.35rem 0; }
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+
+.footer-base {
+  margin: 1.75rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+/* The way back to the hub, with the site mark on it. It heads the brand
+   column now rather than sitting inline in a sentence, so it is a flex row
+   and carries its own weight and colour. */
+.home-link {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  color: var(--text);
+  font-weight: 600;
+}
 
 .site-logo {
   width: 1.35em;

--- a/exif-editor/index.html
+++ b/exif-editor/index.html
@@ -724,54 +724,81 @@
 </section>
 
 <footer>
-  <p>
-    Runs in your browser. No accounts, no uploads. Ads by Google.
-    Tips are welcome and change nothing.
-    &middot;
-    <!--
-      The site mark, inlined so that this page stays self-contained and works
-      offline. Same shape as the hub's logo.svg; colours come from this page's
-      own stylesheet.
-    -->
-    <a class="home-link" href="../">
-      <svg class="site-logo" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
-        <path class="logo-lid" d="M14 31V13.5A4.5 4.5 0 0 1 18.5 9h27a4.5 4.5 0 0 1 4.5 4.5V31"
-              fill="none" stroke-width="3.2" stroke-linejoin="round"/>
-        <g transform="rotate(-12 18 30)">
-          <rect class="logo-tool" x="16.6" y="17" width="3.2" height="17" rx="1.4"/>
-          <rect class="logo-tool" x="16.2" y="12.2" width="6.8" height="5" rx="1.5"/>
-          <rect class="logo-tool" x="14" y="12.6" width="2.6" height="6.6" rx="1.2" transform="rotate(26 16.2 13)"/>
-        </g>
-        <g transform="rotate(-3 26 30)">
-          <rect class="logo-tool-alt" x="24.6" y="17" width="3.1" height="17" rx="1.4"/>
-          <rect class="logo-tool-alt" x="23.2" y="12" width="2.3" height="6.5" rx="1.1"/>
-          <rect class="logo-tool-alt" x="26.8" y="12" width="2.3" height="6.5" rx="1.1"/>
-          <rect class="logo-tool-alt" x="23.2" y="16.2" width="5.9" height="3.6" rx="1.5"/>
-        </g>
-        <rect class="logo-tool-alt" x="30.6" y="12" width="5" height="8.4" rx="2.2"/>
-        <rect class="logo-tool" x="31.5" y="19.2" width="3.2" height="2.2" rx="0.7"/>
-        <rect class="logo-tool" x="32.1" y="20.5" width="2.1" height="13.5" rx="1"/>
-        <path class="logo-tool" d="M39.4 20.4 37.9 13a1.15 1.15 0 0 1 2.25-.45l1.15 7.6z" transform="rotate(-4 40.5 21)"/>
-        <path class="logo-tool" d="M41.6 20.4 43.1 13a1.15 1.15 0 0 0-2.25-.45l-1.15 7.6z" transform="rotate(4 40.5 21)"/>
-        <rect class="logo-tool" x="38.2" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(-8 40.5 21)"/>
-        <rect class="logo-tool" x="40.4" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(8 40.5 21)"/>
-        <circle class="logo-latch" cx="40.5" cy="20.8" r="1.5"/>
-        <g transform="rotate(14 48 30)">
-          <rect class="logo-tool" x="46.6" y="17.5" width="3.2" height="16.5" rx="1.4"/>
-          <rect class="logo-tool" x="44.6" y="14.2" width="7.4" height="3.4" rx="1.3"/>
-          <rect class="logo-tool" x="44.6" y="9.6" width="4.4" height="3.6" rx="1.1"/>
-          <rect class="logo-latch" x="46.4" y="17.4" width="3.6" height="1.9" rx="0.6"/>
-        </g>
-        <rect class="logo-box" x="8" y="38" width="48" height="15" rx="1.6"/>
-        <rect class="logo-band" x="4" y="31" width="56" height="7.5" rx="1.6"/>
-        <rect class="logo-latch" x="27.5" y="33.5" width="9" height="9" rx="1.8"/>
-      </svg>
-      All tools
-    </a>
-    &middot;
-    <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
-      Read the source
-    </a>
+  <div class="footer-cols">
+    <div class="footer-col footer-brand">
+      <a class="home-link" href="../">
+        <svg class="site-logo" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+          <path class="logo-lid" d="M14 31V13.5A4.5 4.5 0 0 1 18.5 9h27a4.5 4.5 0 0 1 4.5 4.5V31"
+                fill="none" stroke-width="3.2" stroke-linejoin="round"/>
+          <g transform="rotate(-12 18 30)">
+            <rect class="logo-tool" x="16.6" y="17" width="3.2" height="17" rx="1.4"/>
+            <rect class="logo-tool" x="16.2" y="12.2" width="6.8" height="5" rx="1.5"/>
+            <rect class="logo-tool" x="14" y="12.6" width="2.6" height="6.6" rx="1.2" transform="rotate(26 16.2 13)"/>
+          </g>
+          <g transform="rotate(-3 26 30)">
+            <rect class="logo-tool-alt" x="24.6" y="17" width="3.1" height="17" rx="1.4"/>
+            <rect class="logo-tool-alt" x="23.2" y="12" width="2.3" height="6.5" rx="1.1"/>
+            <rect class="logo-tool-alt" x="26.8" y="12" width="2.3" height="6.5" rx="1.1"/>
+            <rect class="logo-tool-alt" x="23.2" y="16.2" width="5.9" height="3.6" rx="1.5"/>
+          </g>
+          <rect class="logo-tool-alt" x="30.6" y="12" width="5" height="8.4" rx="2.2"/>
+          <rect class="logo-tool" x="31.5" y="19.2" width="3.2" height="2.2" rx="0.7"/>
+          <rect class="logo-tool" x="32.1" y="20.5" width="2.1" height="13.5" rx="1"/>
+          <path class="logo-tool" d="M39.4 20.4 37.9 13a1.15 1.15 0 0 1 2.25-.45l1.15 7.6z" transform="rotate(-4 40.5 21)"/>
+          <path class="logo-tool" d="M41.6 20.4 43.1 13a1.15 1.15 0 0 0-2.25-.45l-1.15 7.6z" transform="rotate(4 40.5 21)"/>
+          <rect class="logo-tool" x="38.2" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(-8 40.5 21)"/>
+          <rect class="logo-tool" x="40.4" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(8 40.5 21)"/>
+          <circle class="logo-latch" cx="40.5" cy="20.8" r="1.5"/>
+          <g transform="rotate(14 48 30)">
+            <rect class="logo-tool" x="46.6" y="17.5" width="3.2" height="16.5" rx="1.4"/>
+            <rect class="logo-tool" x="44.6" y="14.2" width="7.4" height="3.4" rx="1.3"/>
+            <rect class="logo-tool" x="44.6" y="9.6" width="4.4" height="3.6" rx="1.1"/>
+            <rect class="logo-latch" x="46.4" y="17.4" width="3.6" height="1.9" rx="0.6"/>
+          </g>
+          <rect class="logo-box" x="8" y="38" width="48" height="15" rx="1.6"/>
+          <rect class="logo-band" x="4" y="31" width="56" height="7.5" rx="1.6"/>
+          <rect class="logo-latch" x="27.5" y="33.5" width="9" height="9" rx="1.8"/>
+        </svg>
+        All tools
+      </a>
+      <p>
+        Runs in your browser. No accounts, no uploads. Ads by Google.
+        Tips are welcome and change nothing.
+      </p>
+    </div>
+
+    <div class="footer-col">
+      <strong>Tools</strong>
+      <ul>
+        <li><a href="../images-to-video/">Images to Video</a></li>
+        <li><a href="../compress-image/">Compress Image</a></li>
+        <li><a href="../exif-editor/">EXIF Editor</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>This site</strong>
+      <ul>
+        <li><a href="../">All tools</a></li>
+        <li><a href="../privacy/">Privacy &amp; Cookies</a></li>
+        <li><a href="../terms/">Terms of Use</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>The source</strong>
+      <ul>
+        <li>
+          <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
+            Read the code on GitHub
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <p class="footer-base">
+    Every claim on this site is meant to be checked, not believed.
   </p>
 </footer>
 

--- a/exif-editor/styles.css
+++ b/exif-editor/styles.css
@@ -1082,16 +1082,70 @@ button, .as-button {
   font-size: 0.88em;
 }
 
+/* A link footer in the same shape the hub uses: a few columns of plain links,
+   left aligned, each under a quiet heading, with the legal pages among them.
+   Tools deliberately share no stylesheet, so this block is copied into each of
+   them - if it changes in one, change it in the others and in site.css too. */
+
 footer {
-  text-align: center;
+  margin-top: 2.5rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--border);
   color: var(--text-dim);
-  font-size: 0.82rem;
-  padding-top: 0.5rem;
+  font-size: 0.85rem;
 }
 
-/* The way back to the hub, with the site mark on it. The link is inline in a
-   sentence, so the two sit on the text baseline rather than in a flex row. */
-.home-link { white-space: nowrap; }
+.footer-cols {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+}
+
+.footer-col { flex: 1 1 150px; min-width: 0; }
+.footer-brand { flex: 2 1 240px; }
+
+.footer-col strong {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.footer-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer-brand p { margin: 0.55rem 0 0; max-width: 36ch; }
+
+footer p { margin: 0.35rem 0; }
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+
+.footer-base {
+  margin: 1.75rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+/* The way back to the hub, with the site mark on it. It heads the brand
+   column now rather than sitting inline in a sentence, so it is a flex row
+   and carries its own weight and colour. */
+.home-link {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  color: var(--text);
+  font-weight: 600;
+}
 
 .site-logo {
   width: 1.35em;

--- a/images-to-video/index.html
+++ b/images-to-video/index.html
@@ -726,54 +726,81 @@
 </section>
 
 <footer>
-  <p>
-    Runs in your browser. No accounts, no uploads. Ads by Google.
-    Tips are welcome and change nothing.
-    &middot;
-    <!--
-      The site mark, inlined so that this page stays self-contained and works
-      offline. Same shape as the hub's logo.svg; colours come from this page's
-      own stylesheet.
-    -->
-    <a class="home-link" href="../">
-      <svg class="site-logo" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
-        <path class="logo-lid" d="M14 31V13.5A4.5 4.5 0 0 1 18.5 9h27a4.5 4.5 0 0 1 4.5 4.5V31"
-              fill="none" stroke-width="3.2" stroke-linejoin="round"/>
-        <g transform="rotate(-12 18 30)">
-          <rect class="logo-tool" x="16.6" y="17" width="3.2" height="17" rx="1.4"/>
-          <rect class="logo-tool" x="16.2" y="12.2" width="6.8" height="5" rx="1.5"/>
-          <rect class="logo-tool" x="14" y="12.6" width="2.6" height="6.6" rx="1.2" transform="rotate(26 16.2 13)"/>
-        </g>
-        <g transform="rotate(-3 26 30)">
-          <rect class="logo-tool-alt" x="24.6" y="17" width="3.1" height="17" rx="1.4"/>
-          <rect class="logo-tool-alt" x="23.2" y="12" width="2.3" height="6.5" rx="1.1"/>
-          <rect class="logo-tool-alt" x="26.8" y="12" width="2.3" height="6.5" rx="1.1"/>
-          <rect class="logo-tool-alt" x="23.2" y="16.2" width="5.9" height="3.6" rx="1.5"/>
-        </g>
-        <rect class="logo-tool-alt" x="30.6" y="12" width="5" height="8.4" rx="2.2"/>
-        <rect class="logo-tool" x="31.5" y="19.2" width="3.2" height="2.2" rx="0.7"/>
-        <rect class="logo-tool" x="32.1" y="20.5" width="2.1" height="13.5" rx="1"/>
-        <path class="logo-tool" d="M39.4 20.4 37.9 13a1.15 1.15 0 0 1 2.25-.45l1.15 7.6z" transform="rotate(-4 40.5 21)"/>
-        <path class="logo-tool" d="M41.6 20.4 43.1 13a1.15 1.15 0 0 0-2.25-.45l-1.15 7.6z" transform="rotate(4 40.5 21)"/>
-        <rect class="logo-tool" x="38.2" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(-8 40.5 21)"/>
-        <rect class="logo-tool" x="40.4" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(8 40.5 21)"/>
-        <circle class="logo-latch" cx="40.5" cy="20.8" r="1.5"/>
-        <g transform="rotate(14 48 30)">
-          <rect class="logo-tool" x="46.6" y="17.5" width="3.2" height="16.5" rx="1.4"/>
-          <rect class="logo-tool" x="44.6" y="14.2" width="7.4" height="3.4" rx="1.3"/>
-          <rect class="logo-tool" x="44.6" y="9.6" width="4.4" height="3.6" rx="1.1"/>
-          <rect class="logo-latch" x="46.4" y="17.4" width="3.6" height="1.9" rx="0.6"/>
-        </g>
-        <rect class="logo-box" x="8" y="38" width="48" height="15" rx="1.6"/>
-        <rect class="logo-band" x="4" y="31" width="56" height="7.5" rx="1.6"/>
-        <rect class="logo-latch" x="27.5" y="33.5" width="9" height="9" rx="1.8"/>
-      </svg>
-      All tools
-    </a>
-    &middot;
-    <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
-      Read the source
-    </a>
+  <div class="footer-cols">
+    <div class="footer-col footer-brand">
+      <a class="home-link" href="../">
+        <svg class="site-logo" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+          <path class="logo-lid" d="M14 31V13.5A4.5 4.5 0 0 1 18.5 9h27a4.5 4.5 0 0 1 4.5 4.5V31"
+                fill="none" stroke-width="3.2" stroke-linejoin="round"/>
+          <g transform="rotate(-12 18 30)">
+            <rect class="logo-tool" x="16.6" y="17" width="3.2" height="17" rx="1.4"/>
+            <rect class="logo-tool" x="16.2" y="12.2" width="6.8" height="5" rx="1.5"/>
+            <rect class="logo-tool" x="14" y="12.6" width="2.6" height="6.6" rx="1.2" transform="rotate(26 16.2 13)"/>
+          </g>
+          <g transform="rotate(-3 26 30)">
+            <rect class="logo-tool-alt" x="24.6" y="17" width="3.1" height="17" rx="1.4"/>
+            <rect class="logo-tool-alt" x="23.2" y="12" width="2.3" height="6.5" rx="1.1"/>
+            <rect class="logo-tool-alt" x="26.8" y="12" width="2.3" height="6.5" rx="1.1"/>
+            <rect class="logo-tool-alt" x="23.2" y="16.2" width="5.9" height="3.6" rx="1.5"/>
+          </g>
+          <rect class="logo-tool-alt" x="30.6" y="12" width="5" height="8.4" rx="2.2"/>
+          <rect class="logo-tool" x="31.5" y="19.2" width="3.2" height="2.2" rx="0.7"/>
+          <rect class="logo-tool" x="32.1" y="20.5" width="2.1" height="13.5" rx="1"/>
+          <path class="logo-tool" d="M39.4 20.4 37.9 13a1.15 1.15 0 0 1 2.25-.45l1.15 7.6z" transform="rotate(-4 40.5 21)"/>
+          <path class="logo-tool" d="M41.6 20.4 43.1 13a1.15 1.15 0 0 0-2.25-.45l-1.15 7.6z" transform="rotate(4 40.5 21)"/>
+          <rect class="logo-tool" x="38.2" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(-8 40.5 21)"/>
+          <rect class="logo-tool" x="40.4" y="20.5" width="2.9" height="13.5" rx="1.3" transform="rotate(8 40.5 21)"/>
+          <circle class="logo-latch" cx="40.5" cy="20.8" r="1.5"/>
+          <g transform="rotate(14 48 30)">
+            <rect class="logo-tool" x="46.6" y="17.5" width="3.2" height="16.5" rx="1.4"/>
+            <rect class="logo-tool" x="44.6" y="14.2" width="7.4" height="3.4" rx="1.3"/>
+            <rect class="logo-tool" x="44.6" y="9.6" width="4.4" height="3.6" rx="1.1"/>
+            <rect class="logo-latch" x="46.4" y="17.4" width="3.6" height="1.9" rx="0.6"/>
+          </g>
+          <rect class="logo-box" x="8" y="38" width="48" height="15" rx="1.6"/>
+          <rect class="logo-band" x="4" y="31" width="56" height="7.5" rx="1.6"/>
+          <rect class="logo-latch" x="27.5" y="33.5" width="9" height="9" rx="1.8"/>
+        </svg>
+        All tools
+      </a>
+      <p>
+        Runs in your browser. No accounts, no uploads. Ads by Google.
+        Tips are welcome and change nothing.
+      </p>
+    </div>
+
+    <div class="footer-col">
+      <strong>Tools</strong>
+      <ul>
+        <li><a href="../images-to-video/">Images to Video</a></li>
+        <li><a href="../compress-image/">Compress Image</a></li>
+        <li><a href="../exif-editor/">EXIF Editor</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>This site</strong>
+      <ul>
+        <li><a href="../">All tools</a></li>
+        <li><a href="../privacy/">Privacy &amp; Cookies</a></li>
+        <li><a href="../terms/">Terms of Use</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>The source</strong>
+      <ul>
+        <li>
+          <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
+            Read the code on GitHub
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <p class="footer-base">
+    Every claim on this site is meant to be checked, not believed.
   </p>
 </footer>
 

--- a/images-to-video/styles.css
+++ b/images-to-video/styles.css
@@ -1022,16 +1022,70 @@ button, .as-button {
   font-size: 0.88em;
 }
 
+/* A link footer in the same shape the hub uses: a few columns of plain links,
+   left aligned, each under a quiet heading, with the legal pages among them.
+   Tools deliberately share no stylesheet, so this block is copied into each of
+   them - if it changes in one, change it in the others and in site.css too. */
+
 footer {
-  text-align: center;
+  margin-top: 2.5rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--border);
   color: var(--text-dim);
-  font-size: 0.82rem;
-  padding-top: 0.5rem;
+  font-size: 0.85rem;
 }
 
-/* The way back to the hub, with the site mark on it. The link is inline in a
-   sentence, so the two sit on the text baseline rather than in a flex row. */
-.home-link { white-space: nowrap; }
+.footer-cols {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+}
+
+.footer-col { flex: 1 1 150px; min-width: 0; }
+.footer-brand { flex: 2 1 240px; }
+
+.footer-col strong {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.footer-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer-brand p { margin: 0.55rem 0 0; max-width: 36ch; }
+
+footer p { margin: 0.35rem 0; }
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+
+.footer-base {
+  margin: 1.75rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+/* The way back to the hub, with the site mark on it. It heads the brand
+   column now rather than sitting inline in a sentence, so it is a flex row
+   and carries its own weight and colour. */
+.home-link {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  color: var(--text);
+  font-weight: 600;
+}
 
 .site-logo {
   width: 1.35em;

--- a/index.html
+++ b/index.html
@@ -456,15 +456,49 @@
 </main>
 
 <footer>
-  <p>
-    Your files stay on your machine. Every tool here does its work in your browser,
-    on your own hardware, and uploads nothing &mdash; no accounts, no sign-in.
-  </p>
-  <p>
-    <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
-      Read the source
-    </a>
-    &middot;
+  <div class="footer-cols">
+    <div class="footer-col footer-brand">
+      <a class="home-link" href="./">
+        <span class="brand-mark" aria-hidden="true">&#129520;</span>
+        abox.tools
+      </a>
+      <p>
+        Tools that never touch a server. Your files stay on your machine &mdash;
+        nothing to upload, no account to make.
+      </p>
+    </div>
+
+    <div class="footer-col">
+      <strong>Tools</strong>
+      <ul>
+        <li><a href="images-to-video/">Images to Video</a></li>
+        <li><a href="compress-image/">Compress Image</a></li>
+        <li><a href="exif-editor/">EXIF Editor</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>This site</strong>
+      <ul>
+        <li><a href="privacy/">Privacy &amp; Cookies</a></li>
+        <li><a href="terms/">Terms of Use</a></li>
+        <li><a href="sitemap.xml">Sitemap</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>The source</strong>
+      <ul>
+        <li>
+          <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
+            Read the code on GitHub
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <p class="footer-base">
     Every claim on this site is meant to be checked, not believed.
   </p>
 </footer>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!--
+  The same allowlist the rest of the site carries, with one deliberate
+  difference: the two donate-button origins (cdnjs.buymeacoffee.com and
+  fonts.googleapis.com / fonts.gstatic.com) are NOT here, because this page
+  does not draw that button. Keeping them out is the point - a page that lists
+  an origin it never contacts is a wider hole than it needs to be, and this
+  page in particular should be able to describe itself accurately.
+
+  Everything else matches the hub. If the Google list changes there, change it
+  here too.
+
+  Punctuation is written as HTML entities throughout, so this file stays pure
+  ASCII on disk and cannot be mangled by a tool that guesses the encoding.
+-->
+<meta http-equiv="Content-Security-Policy" content="
+  default-src 'none';
+  script-src 'self'
+    https://www.googletagmanager.com
+    https://pagead2.googlesyndication.com
+    https://tpc.googlesyndication.com
+    https://partner.googleadservices.com
+    https://www.googletagservices.com
+    https://adservice.google.com
+    https://ep1.adtrafficquality.google
+    https://ep2.adtrafficquality.google;
+  frame-src
+    https://googleads.g.doubleclick.net
+    https://tpc.googlesyndication.com
+    https://ep1.adtrafficquality.google
+    https://ep2.adtrafficquality.google
+    https://www.google.com;
+  connect-src
+    https://www.google-analytics.com
+    https://*.google-analytics.com
+    https://analytics.google.com
+    https://*.analytics.google.com
+    https://*.googletagmanager.com
+    https://pagead2.googlesyndication.com
+    https://googleads.g.doubleclick.net
+    https://stats.g.doubleclick.net
+    https://www.google.com
+    https://ep1.adtrafficquality.google
+    https://ep2.adtrafficquality.google
+    https://csi.gstatic.com;
+  img-src 'self' data: https:;
+  style-src 'self' 'unsafe-inline';
+  form-action 'none';
+  base-uri 'none';
+">
+<title>Privacy &amp; Cookies &mdash; abox.tools</title>
+<meta name="description" content="What abox.tools does and does not collect. Your files are never uploaded; the ads and the visit counter are Google's and are described here in full.">
+
+<link rel="canonical" href="https://abox.tools/privacy/">
+
+<meta name="google-adsense-account" content="ca-pub-5997711677062324">
+
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5997711677062324"
+        crossorigin="anonymous"></script>
+
+<!-- Google tag (gtag.js). The configuration half lives in analytics.js. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SCBN29XZ31"></script>
+<script src="../analytics.js" defer></script>
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="A Box of Tools">
+<meta property="og:url" content="https://abox.tools/privacy/">
+<meta property="og:title" content="Privacy &amp; Cookies &mdash; abox.tools">
+<meta property="og:description" content="Your files are never uploaded. What is collected, by whom, and how to switch it off.">
+<meta property="og:image" content="https://abox.tools/og.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Privacy &amp; Cookies &mdash; abox.tools">
+<meta name="twitter:description" content="Your files are never uploaded. What is collected, by whom, and how to switch it off.">
+<meta name="twitter:image" content="https://abox.tools/og.png">
+
+<link rel="stylesheet" href="../site.css">
+<link rel="icon" href="/logo.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/icon-180.png">
+</head>
+<body>
+
+<header class="hub-head">
+  <p class="brand"><a class="brand-home" href="../"><span class="brand-mark" aria-hidden="true">&#129520;</span> abox.tools</a></p>
+  <h1>Privacy &amp; Cookies</h1>
+  <p class="lede">
+    The short version: your files are never uploaded, because there is nowhere
+    to upload them to. Everything else on this page is about the ads, the visit
+    counter, and the hosting &mdash; the parts that do involve other companies.
+  </p>
+  <p class="legal-date">Last updated 19 August 2026</p>
+</header>
+
+<main class="legal">
+
+  <section>
+    <h2>Your files</h2>
+    <p>
+      Every tool on this site does its work inside your own browser, on your own
+      hardware. When you choose a file, it is read by the page you already have
+      open. It is not sent to us, because there is no server of ours for it to be
+      sent to &mdash; this site is a set of static files, with no backend, no
+      database, and no storage.
+    </p>
+    <p>
+      That means we never receive, see, store, log, or process:
+    </p>
+    <ul>
+      <li>your files, in whole or in part</li>
+      <li>thumbnails or previews of them</li>
+      <li>their names, sizes, dimensions, or formats</li>
+      <li>how many you chose, or what you did with them</li>
+      <li>anything read out of them, including EXIF and GPS data</li>
+    </ul>
+    <p>
+      This is not a promise about our intentions. Each page carries a
+      <code>Content-Security-Policy</code> that names every address the page is
+      allowed to contact, and the browser enforces it. None of those addresses
+      belong to us. You can read the policy at the top of any page's source, or
+      open your browser's Network tab and watch: no request carries your file.
+    </p>
+    <p>
+      Files you produce with a tool are handed to your browser's own download
+      mechanism and saved wherever you tell it to. We are not involved in that
+      step either.
+    </p>
+  </section>
+
+  <section>
+    <h2>The one exception, and where it applies</h2>
+    <p>
+      The <a href="../images-to-video/">Images to Video</a> tool has an
+      &ldquo;add from a web address&rdquo; feature. If you paste an address into
+      it, your browser fetches that image from whatever server you named, and
+      <strong>that server sees your IP address</strong> and which file you asked
+      for. That is unavoidable and it is the whole nature of the feature.
+    </p>
+    <p>
+      It only ever happens for addresses you type in yourself, it is built so
+      that images can come in but data cannot go out, and the tool's own page
+      explains it in more detail. No other tool on the site can make an outbound
+      request with anything of yours in it.
+    </p>
+  </section>
+
+  <section>
+    <h2>What is collected, and by whom</h2>
+    <p>
+      This site is free and is paid for by advertising. That means two Google
+      products run on these pages, and a donate button runs on some of them.
+      Here is the whole list.
+    </p>
+
+    <h3>Google AdSense &mdash; the ads</h3>
+    <p>
+      Google serves the ads and decides which ones you see. To do that it may
+      set and read cookies or similar identifiers in your browser, and it
+      receives your IP address, your approximate location derived from it, your
+      user agent, and which page you were on. Depending on your settings and
+      where you are, the ads may be personalised using a profile Google holds
+      about you, built largely from your activity on other sites.
+    </p>
+    <p>
+      We do not receive any of that, we cannot see it, and we never send Google
+      anything about your files. Google's own description of how it uses data
+      from sites that run its ads is at
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>.
+    </p>
+
+    <h3>Google Analytics &mdash; the visit counter</h3>
+    <p>
+      We use Google Analytics 4 to count page visits, so we know which tools are
+      worth working on. It records the page you viewed, roughly when, a
+      randomly generated identifier stored in your browser, your approximate
+      location, your device and browser type, and the site that referred you.
+    </p>
+    <p>
+      It is configured to do nothing else. The configuration is a file you can
+      read: <a href="../analytics.js">analytics.js</a>, which sets up a page-view
+      counter and contains no custom events at all. Nothing on this site passes
+      it a file, a filename, a dimension, or a count &mdash; there is no code
+      here that could.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; the donate button</h3>
+    <p>
+      The hub page and the tool pages carry a donate button, which loads from
+      Buy Me a Coffee's servers. Loading it means their CDN sees your IP address
+      and that you were on this site, and the button's lettering is fetched from
+      Google Fonts, which likewise sees your IP address. Nothing else is sent,
+      and nothing happens beyond that unless you actually click the button, at
+      which point you are on their site under their policies. This page and the
+      Terms page do not carry the button at all.
+    </p>
+
+    <h3>Hosting</h3>
+    <p>
+      The site is served by GitHub Pages, behind Cloudflare. Like any web host,
+      they process the requests your browser makes &mdash; which includes your IP
+      address, the page requested, and your user agent &mdash; in order to deliver
+      the page and to keep the service up and secure. We do not have access to
+      per-visitor logs from either of them.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cookies</h2>
+    <p>
+      We do not set any cookies of our own. We have no login, no session, no
+      preferences to remember, and no reason to.
+    </p>
+    <p>
+      Every cookie or similar identifier you may find here belongs to Google, and
+      is set by the advertising and analytics scripts described above. They are
+      used to measure visits and to select and cap ads.
+    </p>
+    <h3>How to switch it off</h3>
+    <ul>
+      <li>
+        Ad personalisation can be turned off, for all sites at once, at
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">My Ad Center</a>.
+      </li>
+      <li>
+        Google Analytics can be blocked everywhere with Google's
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">opt-out browser add-on</a>.
+      </li>
+      <li>
+        Your browser's own settings can block or clear third-party cookies, and
+        any content blocker will stop these scripts loading in the first place.
+      </li>
+    </ul>
+    <p>
+      Blocking all of it is fine by us. <strong>Every tool on this site works
+      with the scripts blocked, and works with the network disconnected
+      entirely.</strong> Nothing here is held back behind an ad.
+    </p>
+  </section>
+
+  <section>
+    <h2>Your rights over the data</h2>
+    <p>
+      We hold no personal data about you, so there is nothing for us to show
+      you, correct, export, or delete &mdash; a request to us would come back
+      empty, honestly.
+    </p>
+    <p>
+      The data described above is held by Google, who act as their own
+      controller for it. Requests about it have to go to them, through
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">your Google account</a>
+      or their privacy contacts.
+    </p>
+  </section>
+
+  <section>
+    <h2>Children</h2>
+    <p>
+      This site is not directed at children and asks nobody for their age,
+      because it asks nobody for anything. We knowingly collect no personal data
+      from anyone, of any age.
+    </p>
+  </section>
+
+  <section>
+    <h2>Changes, and how to contact us</h2>
+    <p>
+      If this page changes, the date at the top changes with it, and the edit is
+      in the public commit history along with everything else.
+    </p>
+    <p>
+      Questions about any of this are best raised as an issue on
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">the repository</a>,
+      where the answer is visible to everyone else wondering the same thing.
+    </p>
+  </section>
+
+</main>
+
+<footer>
+  <div class="footer-cols">
+    <div class="footer-col footer-brand">
+      <a class="home-link" href="../">
+        <span class="brand-mark" aria-hidden="true">&#129520;</span>
+        abox.tools
+      </a>
+      <p>
+        Tools that never touch a server. Your files stay on your machine &mdash;
+        nothing to upload, no account to make.
+      </p>
+    </div>
+
+    <div class="footer-col">
+      <strong>Tools</strong>
+      <ul>
+        <li><a href="../images-to-video/">Images to Video</a></li>
+        <li><a href="../compress-image/">Compress Image</a></li>
+        <li><a href="../exif-editor/">EXIF Editor</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>This site</strong>
+      <ul>
+        <li><a href="../">All tools</a></li>
+        <li><a href="./">Privacy &amp; Cookies</a></li>
+        <li><a href="../terms/">Terms of Use</a></li>
+        <li><a href="/sitemap.xml">Sitemap</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>The source</strong>
+      <ul>
+        <li>
+          <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
+            Read the code on GitHub
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <p class="footer-base">
+    Every claim on this site is meant to be checked, not believed.
+  </p>
+</footer>
+
+</body>
+</html>

--- a/site.css
+++ b/site.css
@@ -1,5 +1,6 @@
-/* Styles for the hub page only. Each tool ships its own stylesheet so that it
-   stays self-contained and can be read, audited, or moved on its own. */
+/* Styles for the hub page and the Privacy and Terms pages. Each tool ships
+   its own stylesheet so that it stays self-contained and can be read,
+   audited, or moved on its own. */
 
 :root {
   color-scheme: light dark;
@@ -239,19 +240,110 @@ code {
 .p-name { font-weight: 600; color: var(--text); }
 .p-desc { font-size: 0.85rem; }
 
-/* ---- footer ------------------------------------------------------------ */
+/* ---- legal pages ------------------------------------------------------- */
 
-footer {
-  margin-top: 2.5rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid var(--border);
-  color: var(--text-dim);
+/* Privacy and Terms. Narrower than the hub, because these are read as prose
+   rather than scanned as a grid. */
+
+.brand-home { color: inherit; text-decoration: none; }
+.brand-home:hover { color: var(--accent); }
+
+.legal-date {
+  margin: 1rem 0 0;
   font-size: 0.82rem;
-  text-align: center;
+  color: var(--text-dim);
 }
 
+.legal { max-width: 68ch; }
+
+.legal section { margin: 0 0 2.25rem; }
+
+.legal h2 {
+  margin: 0 0 0.7rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 1.15rem;
+  letter-spacing: -0.01em;
+}
+
+.legal h3 {
+  margin: 1.5rem 0 0.45rem;
+  font-size: 0.95rem;
+}
+
+.legal p { margin: 0 0 0.85rem; }
+.legal ul { margin: 0 0 0.95rem; padding-left: 1.25rem; }
+.legal li { margin: 0.3rem 0; }
+.legal a { color: var(--accent); }
+
+/* ---- footer ------------------------------------------------------------ */
+
+/* A link footer in the shape the large media-tool sites use: a few columns of
+   plain links, left aligned, each under a quiet heading. It is the second
+   navigation, for people who scrolled to the bottom looking for one, and it is
+   where the legal pages live - a centred line of prose had nowhere to put
+   them.
+
+   Flex rather than grid, so the columns collapse two-up and then one-up on a
+   narrow screen without a media query. The brand column is given twice the
+   basis of a link column, since it carries a sentence rather than a list. */
+
+footer {
+  margin-top: 3rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 0.85rem;
+}
+
+.footer-cols {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+}
+
+.footer-col { flex: 1 1 150px; min-width: 0; }
+.footer-brand { flex: 2 1 240px; }
+
+.footer-col strong {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.footer-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer-brand .home-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.footer-brand p { margin: 0.55rem 0 0; max-width: 34ch; }
+
 footer p { margin: 0.35rem 0; }
-footer a { color: var(--accent); }
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+
+.footer-base {
+  margin: 1.75rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+  text-align: center;
+}
 
 
 /* ------------------------------------------------------------- ad placement */

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -32,4 +32,16 @@
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://abox.tools/privacy/</loc>
+    <lastmod>2026-08-19</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://abox.tools/terms/</loc>
+    <lastmod>2026-08-19</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/terms/index.html
+++ b/terms/index.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!--
+  Same allowlist as the Privacy page, and the same deliberate omission: no
+  donate-button origins, because this page does not draw the button. If the
+  Google list changes on the hub, change it here too.
+
+  Punctuation is written as HTML entities throughout, so this file stays pure
+  ASCII on disk and cannot be mangled by a tool that guesses the encoding.
+-->
+<meta http-equiv="Content-Security-Policy" content="
+  default-src 'none';
+  script-src 'self'
+    https://www.googletagmanager.com
+    https://pagead2.googlesyndication.com
+    https://tpc.googlesyndication.com
+    https://partner.googleadservices.com
+    https://www.googletagservices.com
+    https://adservice.google.com
+    https://ep1.adtrafficquality.google
+    https://ep2.adtrafficquality.google;
+  frame-src
+    https://googleads.g.doubleclick.net
+    https://tpc.googlesyndication.com
+    https://ep1.adtrafficquality.google
+    https://ep2.adtrafficquality.google
+    https://www.google.com;
+  connect-src
+    https://www.google-analytics.com
+    https://*.google-analytics.com
+    https://analytics.google.com
+    https://*.analytics.google.com
+    https://*.googletagmanager.com
+    https://pagead2.googlesyndication.com
+    https://googleads.g.doubleclick.net
+    https://stats.g.doubleclick.net
+    https://www.google.com
+    https://ep1.adtrafficquality.google
+    https://ep2.adtrafficquality.google
+    https://csi.gstatic.com;
+  img-src 'self' data: https:;
+  style-src 'self' 'unsafe-inline';
+  form-action 'none';
+  base-uri 'none';
+">
+<title>Terms of Use &mdash; abox.tools</title>
+<meta name="description" content="The terms this site is offered under: free, as-is, no account, no warranty, and your files remain entirely your own.">
+
+<link rel="canonical" href="https://abox.tools/terms/">
+
+<meta name="google-adsense-account" content="ca-pub-5997711677062324">
+
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5997711677062324"
+        crossorigin="anonymous"></script>
+
+<!-- Google tag (gtag.js). The configuration half lives in analytics.js. -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SCBN29XZ31"></script>
+<script src="../analytics.js" defer></script>
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="A Box of Tools">
+<meta property="og:url" content="https://abox.tools/terms/">
+<meta property="og:title" content="Terms of Use &mdash; abox.tools">
+<meta property="og:description" content="Free, as-is, no account, no warranty. Your files remain entirely your own.">
+<meta property="og:image" content="https://abox.tools/og.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Terms of Use &mdash; abox.tools">
+<meta name="twitter:description" content="Free, as-is, no account, no warranty. Your files remain entirely your own.">
+<meta name="twitter:image" content="https://abox.tools/og.png">
+
+<link rel="stylesheet" href="../site.css">
+<link rel="icon" href="/logo.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/icon-180.png">
+</head>
+<body>
+
+<header class="hub-head">
+  <p class="brand"><a class="brand-home" href="../"><span class="brand-mark" aria-hidden="true">&#129520;</span> abox.tools</a></p>
+  <h1>Terms of Use</h1>
+  <p class="lede">
+    There is no account to open and no agreement to sign, so these are short.
+    They describe what you may expect from this site, and what it does not
+    promise.
+  </p>
+  <p class="legal-date">Last updated 19 August 2026</p>
+</header>
+
+<main class="legal">
+
+  <section>
+    <h2>What this site is</h2>
+    <p>
+      abox.tools is a collection of small utilities that run inside your web
+      browser. They are free to use, for anything, including commercial work.
+      There is nothing to buy, no account to create, no usage limit, and no
+      feature held back.
+    </p>
+    <p>
+      By using the site you accept the terms on this page. If you do not accept
+      them, the remedy is simply to close the tab &mdash; nothing of yours is
+      held here.
+    </p>
+  </section>
+
+  <section>
+    <h2>Your files stay yours</h2>
+    <p>
+      You keep every right you already had in the files you open with these
+      tools, and in whatever you produce with them. We claim no licence, no
+      ownership, and no interest of any kind in either.
+    </p>
+    <p>
+      This is not generosity, it is arithmetic: the tools run entirely in your
+      browser and your files are never transmitted to us, so there is nothing
+      for us to have rights over. The
+      <a href="../privacy/">Privacy page</a> sets out how that works and how to
+      verify it.
+    </p>
+  </section>
+
+  <section>
+    <h2>Using the site responsibly</h2>
+    <p>
+      You are responsible for the files you process and for what you do with the
+      results. In particular, do not use these tools to work on material you have
+      no right to, or to produce anything unlawful.
+    </p>
+    <p>
+      We cannot enforce this and we are not pretending otherwise. We never see
+      your files, so there is no moderation here, no scanning, and no way for us
+      to know what anyone is doing. The obligation is genuinely yours.
+    </p>
+    <p>
+      Please also do not try to interfere with the site itself &mdash; attacking
+      the hosting, or redistributing modified copies in a way that suggests they
+      are the original.
+    </p>
+  </section>
+
+  <section>
+    <h2>No warranty</h2>
+    <p>
+      The site and its tools are provided <strong>as is</strong>, without
+      warranty of any kind, express or implied, including any implied warranty of
+      merchantability, fitness for a particular purpose, or non-infringement.
+    </p>
+    <p>
+      Concretely: a tool may produce a result you did not want, may fail on a
+      file it does not understand, may behave differently between browsers, and
+      may lose work if the tab is closed mid-operation. Nothing you do here is
+      saved anywhere, so <strong>keep your originals</strong>. Do not use these
+      tools on the only copy of anything you care about.
+    </p>
+  </section>
+
+  <section>
+    <h2>Limitation of liability</h2>
+    <p>
+      To the fullest extent the law allows, we are not liable for any loss or
+      damage arising from your use of this site &mdash; including lost, corrupted
+      or unusable files, lost time, lost profits, or any indirect or
+      consequential loss.
+    </p>
+    <p>
+      Nothing here limits liability that cannot lawfully be limited, and if your
+      local consumer law gives you rights that these terms would otherwise
+      restrict, those rights stand.
+    </p>
+  </section>
+
+  <section>
+    <h2>Availability</h2>
+    <p>
+      The site is offered with no promise that it will stay up, stay free, keep
+      any particular tool, or continue to exist at all. Tools may change or be
+      removed without notice.
+    </p>
+    <p>
+      One practical consequence of how these tools are built is worth knowing:
+      once a tool page has loaded, it keeps working offline, and it does not stop
+      working because the site went down. The code is also public, so a tool you
+      depend on can be kept running by you regardless of what happens here.
+    </p>
+  </section>
+
+  <section>
+    <h2>Advertising and other companies</h2>
+    <p>
+      The site carries advertising from Google, counts visits with Google
+      Analytics, and shows a donate button on some pages. What each of those
+      involves is described in full on the
+      <a href="../privacy/">Privacy page</a>.
+    </p>
+    <p>
+      Advertisements, and any site you reach by clicking one, are not ours. We do
+      not select individual ads, do not endorse what they say, and are not
+      responsible for the sites they lead to or for any dealings you have there.
+      The same goes for any other external link on this site.
+    </p>
+  </section>
+
+  <section>
+    <h2>The source code</h2>
+    <p>
+      This site's code is published openly at
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>,
+      because &ldquo;read it and check for yourself&rdquo; is the only real answer
+      to &ldquo;why should I trust this&rdquo;. Reuse of that code is governed by
+      the licence terms stated in the repository, not by this page. These terms
+      cover your use of the website.
+    </p>
+  </section>
+
+  <section>
+    <h2>Changes to these terms</h2>
+    <p>
+      These terms may be updated. When they are, the date at the top changes, and
+      the edit appears in the public commit history like every other change.
+      Continuing to use the site after a change means accepting the updated
+      version.
+    </p>
+    <p>
+      Questions are best raised as an issue on
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">the repository</a>.
+    </p>
+  </section>
+
+</main>
+
+<footer>
+  <div class="footer-cols">
+    <div class="footer-col footer-brand">
+      <a class="home-link" href="../">
+        <span class="brand-mark" aria-hidden="true">&#129520;</span>
+        abox.tools
+      </a>
+      <p>
+        Tools that never touch a server. Your files stay on your machine &mdash;
+        nothing to upload, no account to make.
+      </p>
+    </div>
+
+    <div class="footer-col">
+      <strong>Tools</strong>
+      <ul>
+        <li><a href="../images-to-video/">Images to Video</a></li>
+        <li><a href="../compress-image/">Compress Image</a></li>
+        <li><a href="../exif-editor/">EXIF Editor</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>This site</strong>
+      <ul>
+        <li><a href="../">All tools</a></li>
+        <li><a href="../privacy/">Privacy &amp; Cookies</a></li>
+        <li><a href="./">Terms of Use</a></li>
+        <li><a href="/sitemap.xml">Sitemap</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>The source</strong>
+      <ul>
+        <li>
+          <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">
+            Read the code on GitHub
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <p class="footer-base">
+    Every claim on this site is meant to be checked, not believed.
+  </p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
…m from

The footer was two centred sentences with one link in them. It is now a column of links in the shape the large media-tool sites use: the tools in one column, Privacy, Terms and the source in another, left aligned under quiet headings. It reflows two-up and then one-up on a narrow screen without a media query.

The Privacy page describes what actually happens rather than what would be reassuring. Files never leave the browser and the CSP is offered as the proof. Against that, everything that does involve someone else is named: AdSense and what Google receives, Analytics and what it records, the donate button's CDN and Google Fonts, and the hosting. It says how to switch each of them off, and that every tool still works when you do.

The Terms page is short because there is no account and nothing to sign. It keeps every right in the files with the person who opened them, on the grounds that we never receive them and so have nothing to have rights over. No governing-law clause: naming a jurisdiction is not something to guess at.

Neither legal page lists the donate-button origins in its CSP, because neither draws the button - a page that names an origin it never contacts is wider than it needs to be, and the Privacy page in particular should be able to describe itself accurately.

The footer now exists six times over, since tools share no markup and no stylesheet. README says so, and says that a new tool means six footers, and that the fix if that ever bites is a template rather than a shared stylesheet slipped back into the tools.