### PR TITLE
Add Privacy and Terms, and one footer that can reach them

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,16 @@ config/
 templates/
   hub.html               the hub page
   tool.html              the frame every tool page wears
+  page.html              the frame a prose page wears - the legal ones
   sw.js                  the offline service worker
   analytics.js           the Google Analytics bootstrap
   sitemap.xml
-  partials/              the pieces shared between hub and tool pages
+  partials/              the pieces shared between all three, incl. the footer
 shared/
   css/
     tool-frame.css       the stylesheet every tool page starts from
     file-list.css        an optional part, for tools that show a list of files
-  site.css               the hub's own stylesheet
+  site.css               the stylesheet for the hub and the legal pages
   logo.svg               the site mark; also the favicon, and inlined in the pages
   icon-180.png           the same mark as a PNG, for iOS home screens
   og.png                 the hub's share card
@@ -119,6 +120,11 @@ tools/
     og.png               its share card
   exif-editor/           the same five things
   images-to-video/       and again
+pages/
+  privacy/
+    page.toml            title, description, dates - the frame, not the prose
+    body.html            the <main> of the page
+  terms/                 the same two things
 og-image.ps1             draws the share cards and the icon from shared/logo.svg
 serve.ps1                builds, then serves dist/ locally
 cloudflare/              the edge config that adds the security headers
@@ -150,6 +156,7 @@ something the build does, and cannot forget to do:
 | "Bump `CACHE_NAME` whenever any listed file changes" | The service worker's asset list is read off the disk, and its cache name is a hash of those files, so it changes exactly when they do. |
 | "Add one `<li>` card to the matching category, and an entry to `sitemap.xml`" | The hub's cards, its `ItemList` structured data and `sitemap.xml` all come from the tools that exist in `tools/`. |
 | Four copies of the repository URL per page | `source_url` in `config/site.toml`. |
+| Three different footers, none of which linked to a privacy policy because there was nowhere to put one | One `templates/partials/footer.html`. Its tool list and legal-page list come from `tools/` and `pages/`, and the only thing that differs per page is whether links start `./` or `../`. |
 
 The build refuses to produce a site rather than produce a broken one. A missing
 config key, a tool whose folder and `slug` disagree, a tool listed on the hub
@@ -175,6 +182,11 @@ nothing would link to it — are all errors, not warnings.
 4. If it belongs to a category that does not exist yet, add a
    `[[hub.categories]]` table and move that name out of `config/planned.toml`.
 
+   You do **not** have to touch the footer, the sitemap, or the other pages. The
+   footer's tool list is derived from `tools/` in the order the hub shows them,
+   so a new tool appears in the footer of every page - hub, tool and legal - as
+   soon as it exists.
+
    Before adding a *new* name to the planned list, put it through
    [What can be built here](#what-can-be-built-here) first. That section is
    where the ruled-out ones, and the reasons they were ruled out, live.
@@ -198,6 +210,56 @@ Two things to hold the line on, because the whole site rests on them:
   language, and explains exactly what leaves the machine. Images to Video does this
   for its "add from a web address" feature (see below). What it must not do is
   weaken the site-wide claim quietly.
+
+---
+
+## The legal pages
+
+`pages/` holds the prose pages that are neither the hub nor a tool: Privacy and
+Terms. One is built exactly like a tool page, minus everything a tool needs and
+a page does not.
+
+```
+pages/privacy/
+  page.toml    slug, nav label, title, description, dates, share-card text
+  body.html    the <main> - sections of prose and nothing else
+```
+
+`nav` is the label the footer uses. The page gets the site frame, the site's
+Content-Security-Policy unchanged, an entry in `sitemap.xml` at a low priority,
+and a link in the footer of every page on the site. It gets no service worker,
+because there is nothing here worth keeping offline, and no `blob:` in
+`img-src`, because it never makes one.
+
+**These pages get the same CSP as everywhere else, and that is the point.**
+Written by hand, they carried a narrowed copy that left out the donate button's
+two origins, on the reasoning that a page which never draws the button should
+not name them. That is a defensible argument and it is also exactly the kind of
+argument that produces four policies which disagree. One list in one file ends
+it. If the difference ever matters enough to want back, it belongs in
+`config/site.toml` as a `[page_csp]` table the way `[tool_csp]` already works —
+not as a hand-edit.
+
+### What is in them, and what is not
+
+The Privacy page describes what actually happens rather than what would be
+reassuring: files never leave the browser, with the CSP offered as proof, and
+then every third party named in turn — AdSense, Analytics, the donate button's
+CDN, Google Fonts, and the hosting — each with the way to switch it off, and the
+line that makes those safe to take: every tool still works with all of it
+blocked and the network unplugged.
+
+Two things it does **not** claim, deliberately:
+
+- **There is no cookie consent banner.** The page is honest about the cookies
+  and links to Google's opt-outs, which is not the same thing as consent. If
+  this site takes meaningful EU or UK traffic, AdSense's own policy expects a
+  consent management platform, and that is a real piece of work rather than a
+  paragraph.
+- **The governing-law clause names Canada but not a province.** It says "the
+  laws of Canada and of the province in which the site is operated". Naming the
+  province outright is one line in `pages/terms/body.html` and makes the clause
+  easier to rely on; it was left open rather than guessed at.
 
 ---
 

--- a/build.py
+++ b/build.py
@@ -56,6 +56,7 @@ ROOT = Path(__file__).parent.resolve()
 TEMPLATES = ROOT / 'templates'
 CONFIG = ROOT / 'config'
 TOOLS = ROOT / 'tools'
+PAGES = ROOT / 'pages'
 SHARED = ROOT / 'shared'
 
 
@@ -98,26 +99,47 @@ def build(out, clean=False):
         raise sitelib.ConfigError(f'no tools found under {TOOLS}')
     by_slug = {tool['slug']: tool for tool in tools}
 
-    pages = []
+    prose = [sitelib.load_page(path, site)
+             for path in sorted(PAGES.glob('*/page.toml'))]
+
+    # What the footer on every page is built from. Derived from the folders that
+    # exist rather than written down anywhere, so a new tool or a new legal page
+    # reaches every footer on the site without a second edit.
+    # Tools in the order the hub shows them, not the order the folders happen to
+    # sort in, so the footer and the cards above it agree. A slug named here that
+    # has no tool, or a tool named nowhere, is caught by build_hub below.
+    ordered = [by_slug[slug]
+               for category in site['hub']['categories']
+               for slug in category['order'] if slug in by_slug]
+    footer = {
+        'tools': [{'name': tool['name'], 'slug': tool['slug']} for tool in ordered],
+        'pages': [{'nav': page['nav'], 'slug': page['slug']} for page in prose],
+    }
+
+    written = []
     for tool in tools:
-        build_tool(out, templates, site, tool)
-        pages.append(f'{tool["slug"]}/index.html')
+        build_tool(out, templates, site, tool, footer)
+        written.append(f'{tool["slug"]}/index.html')
 
-    build_hub(out, templates, site, planned, by_slug)
-    pages.append('index.html')
+    for page in prose:
+        build_page(out, templates, site, page, footer)
+        written.append(f'{page["slug"]}/index.html')
 
-    build_sitemap(out, templates, site, tools)
-    pages.append('sitemap.xml')
+    build_hub(out, templates, site, planned, by_slug, footer)
+    written.append('index.html')
+
+    build_sitemap(out, templates, site, tools, prose)
+    written.append('sitemap.xml')
 
     copy_shared(out)
-    return pages
+    return written
 
 
 # ---------------------------------------------------------------------------
 # One tool
 
 
-def build_tool(out, templates, site, tool):
+def build_tool(out, templates, site, tool, footer):
     dest = out / tool['slug']
     dest.mkdir(parents=True, exist_ok=True)
 
@@ -137,6 +159,8 @@ def build_tool(out, templates, site, tool):
     write(dest / 'index.html', templates.render('tool.html', {
         'site': site,
         'tool': tool,
+        'footer': footer,
+        'base': '../',
         'csp': sitelib.render_csp(site['csp'], site.get('tool_csp', {}), tool['csp']),
         'jsonld': sitelib.tool_jsonld(site, tool),
         'body': body_path.read_text(encoding='utf-8').rstrip('\n'),
@@ -188,10 +212,44 @@ def tool_css(tool):
 
 
 # ---------------------------------------------------------------------------
+# One prose page (the legal ones)
+
+
+def build_page(out, templates, site, page, footer):
+    """A legal page: the site frame around a body.html, and nothing else.
+
+    No service worker, because there is nothing here worth keeping offline, and
+    no CSP of its own - it gets the site policy unchanged, which is the point.
+    When these pages were written by hand they carried a hand-narrowed copy that
+    left out the donate button's origins; one policy in one file ended that
+    argument by making it impossible to have."""
+    dest = out / page['slug']
+    dest.mkdir(parents=True, exist_ok=True)
+
+    body_path = page['dir'] / 'body.html'
+    if not body_path.is_file():
+        raise sitelib.ConfigError(f'{page["slug"]}: no body.html')
+
+    write(dest / 'index.html', templates.render('page.html', {
+        'site': site,
+        'page': page,
+        'footer': footer,
+        'base': '../',
+        'csp': sitelib.render_csp(site['csp']),
+        'body': body_path.read_text(encoding='utf-8').rstrip('\n'),
+    }))
+
+    write(dest / 'analytics.js', templates.render('analytics.js', {
+        'site': site,
+        'words': {'plural': 'files', 'analytics_extra': ''},
+    }))
+
+
+# ---------------------------------------------------------------------------
 # The hub
 
 
-def build_hub(out, templates, site, planned, by_slug):
+def build_hub(out, templates, site, planned, by_slug, footer):
     categories = []
     listed = set()
     for category in site['hub']['categories']:
@@ -224,6 +282,8 @@ def build_hub(out, templates, site, planned, by_slug):
         'site': site,
         'planned': planned,
         'categories': categories,
+        'footer': footer,
+        'base': './',
         'csp': sitelib.render_csp(site['csp']),
         'jsonld': sitelib.hub_jsonld(site, ordered),
     }))
@@ -234,11 +294,14 @@ def build_hub(out, templates, site, planned, by_slug):
     }))
 
 
-def build_sitemap(out, templates, site, tools):
+def build_sitemap(out, templates, site, tools, prose):
     pages = [{'url': site['domain'], 'lastmod': site['lastmod'],
               'changefreq': 'weekly', 'priority': '1.0'}]
     pages += [{'url': tool['url'], 'lastmod': tool['lastmod'],
                'changefreq': 'monthly', 'priority': '0.8'} for tool in tools]
+    # The legal pages last, and low: they matter for trust, not for search.
+    pages += [{'url': page['url'], 'lastmod': page['lastmod'],
+               'changefreq': 'yearly', 'priority': '0.3'} for page in prose]
     write(out / 'sitemap.xml', templates.render('sitemap.xml', {'pages': pages}))
 
 

--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -22,6 +22,12 @@ REQUIRED_TOOL_KEYS = (
 )
 
 
+REQUIRED_PAGE_KEYS = (
+    'slug', 'nav', 'title', 'description', 'heading', 'lede', 'updated',
+    'lastmod', 'og_title', 'og_description', 'og_image_alt',
+)
+
+
 class ConfigError(Exception):
     pass
 
@@ -229,6 +235,27 @@ def load_tool(path, site):
     tool['dir'] = path.parent
     tool.setdefault('csp', {})
     return tool
+
+
+def load_page(path, site):
+    """Read one pages/<slug>/page.toml.
+
+    A page is a prose page that is neither a tool nor the hub - the legal ones.
+    It needs far less than a tool does: no words, no FAQ, no schema, no service
+    worker, and no CSP of its own, because it does nothing the site policy does
+    not already allow."""
+    page = load_toml(path)
+    missing = [key for key in REQUIRED_PAGE_KEYS if key not in page]
+    if missing:
+        raise ConfigError(f'{path}: missing {", ".join(missing)}')
+
+    if page['slug'] != path.parent.name:
+        raise ConfigError(
+            f'{path}: slug is {page["slug"]!r} but the folder is {path.parent.name!r}')
+
+    page['url'] = f'{site["domain"]}{page["slug"]}/'
+    page['dir'] = path.parent
+    return page
 
 
 def cache_hash(paths):

--- a/config/site.toml
+++ b/config/site.toml
@@ -17,6 +17,7 @@ lang = "en"
 lastmod = "2026-08-19"     # the hub page's own sitemap date
 source_url = "https://github.com/A-Box-of-Tools/website"
 source_label = "github.com/A-Box-of-Tools/website"
+contact_email = "hi@abox.tools"
 
 adsense_client = "ca-pub-5997711677062324"
 analytics_id = "G-SCBN29XZ31"
@@ -164,8 +165,18 @@ name = "Images &amp; video"
 note = "Work with pictures and footage without handing them to anyone."
 order = ["images-to-video", "exif-editor", "compress-image"]
 
-[hub.footer]
-line1 = """
-    Your files stay on your machine. Every tool here does its work in your browser,
-    on your own hardware, and uploads nothing &mdash; no accounts, no sign-in."""
-line2 = "Every claim on this site is meant to be checked, not believed."
+#
+# ---------------------------------------------------------------------------
+# The footer, which is now the same on every page - hub, tool and legal alike.
+#
+# The tool list and the legal-page list in it are not written here: build.py
+# derives them from the folders under tools/ and pages/, so a new one appears
+# in the footer of every page without anybody remembering to add it.
+# ---------------------------------------------------------------------------
+#
+
+[footer]
+blurb = """
+        Tools that never touch a server. Your files stay on your machine &mdash;
+        nothing to upload, no account to make."""
+base = "Every claim on this site is meant to be checked, not believed."

--- a/pages/privacy/body.html
+++ b/pages/privacy/body.html
@@ -1,0 +1,180 @@
+  <section>
+    <h2>Your files</h2>
+    <p>
+      Every tool on this site does its work inside your own browser, on your own
+      hardware. When you choose a file, it is read by the page you already have
+      open. It is not sent to us, because there is no server of ours for it to be
+      sent to &mdash; this site is a set of static files, with no backend, no
+      database, and no storage.
+    </p>
+    <p>
+      That means we never receive, see, store, log, or process:
+    </p>
+    <ul>
+      <li>your files, in whole or in part</li>
+      <li>thumbnails or previews of them</li>
+      <li>their names, sizes, dimensions, or formats</li>
+      <li>how many you chose, or what you did with them</li>
+      <li>anything read out of them, including EXIF and GPS data</li>
+    </ul>
+    <p>
+      This is not a promise about our intentions. Each page carries a
+      <code>Content-Security-Policy</code> that names every address the page is
+      allowed to contact, and the browser enforces it. None of those addresses
+      belong to us. You can read the policy at the top of any page's source, or
+      open your browser's Network tab and watch: no request carries your file.
+    </p>
+    <p>
+      Files you produce with a tool are handed to your browser's own download
+      mechanism and saved wherever you tell it to. We are not involved in that
+      step either.
+    </p>
+  </section>
+
+  <section>
+    <h2>The one exception, and where it applies</h2>
+    <p>
+      The <a href="../images-to-video/">Images to Video</a> tool has an
+      &ldquo;add from a web address&rdquo; feature. If you paste an address into
+      it, your browser fetches that image from whatever server you named, and
+      <strong>that server sees your IP address</strong> and which file you asked
+      for. That is unavoidable, and it is the whole nature of the feature.
+    </p>
+    <p>
+      It only ever happens for addresses you type in yourself, it is built so
+      that images can come in but data cannot go out, and that tool's own page
+      explains it in more detail. No other tool on this site can make an outbound
+      request with anything of yours in it.
+    </p>
+  </section>
+
+  <section>
+    <h2>What is collected, and by whom</h2>
+    <p>
+      This site is free and is paid for by advertising. That means two Google
+      products run on these pages, and a donate button runs on most of them.
+      Here is the whole list.
+    </p>
+
+    <h3>Google AdSense &mdash; the ads</h3>
+    <p>
+      Google serves the ads and decides which ones you see. To do that it may
+      set and read cookies or similar identifiers in your browser, and it
+      receives your IP address, an approximate location derived from it, your
+      user agent, and which page you were on. Depending on your settings and
+      where you are, the ads may be personalised using a profile Google holds
+      about you, built largely from your activity on other sites.
+    </p>
+    <p>
+      We do not receive any of that, we cannot see it, and we never send Google
+      anything about your files. Google's own account of how it uses data from
+      sites that run its ads is at
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>.
+    </p>
+
+    <h3>Google Analytics &mdash; the visit counter</h3>
+    <p>
+      We use Google Analytics 4 to count page visits, so we know which tools are
+      worth working on. It records the page you viewed, roughly when, a randomly
+      generated identifier stored in your browser, an approximate location, your
+      device and browser type, and the site that referred you.
+    </p>
+    <p>
+      It is configured to do nothing else, and the configuration is a file you
+      can read: <code>analytics.js</code> beside each page sets up a page-view
+      counter and contains no custom events at all. Nothing on this site passes
+      it a file, a filename, a dimension or a count &mdash; there is no code here
+      that could.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; the donate button</h3>
+    <p>
+      The hub page and the tool pages carry a donate button, which loads from
+      Buy Me a Coffee's servers. Loading it means their CDN sees your IP address
+      and that you were on this site, and the button's lettering is fetched from
+      Google Fonts, which likewise sees your IP address. Nothing else is sent,
+      and nothing further happens unless you actually click it, at which point
+      you are on their site under their policies. This page and the
+      <a href="../terms/">Terms page</a> do not draw the button.
+    </p>
+
+    <h3>Hosting</h3>
+    <p>
+      The site is served by GitHub Pages, behind Cloudflare. Like any web host,
+      they process the requests your browser makes &mdash; which includes your IP
+      address, the page requested, and your user agent &mdash; in order to deliver
+      the page and to keep the service up and secure. We do not have access to
+      per-visitor logs from either of them.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cookies</h2>
+    <p>
+      We do not set any cookies of our own. We have no login, no session, no
+      preferences to remember, and no reason to.
+    </p>
+    <p>
+      Every cookie or similar identifier you may find here belongs to Google and
+      is set by the advertising and analytics scripts described above. They are
+      used to measure visits, and to select and cap ads.
+    </p>
+    <h3>How to switch it off</h3>
+    <ul>
+      <li>
+        Ad personalisation can be turned off, for all sites at once, at
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">My Ad Center</a>.
+      </li>
+      <li>
+        Google Analytics can be blocked everywhere with Google's
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">opt-out browser add-on</a>.
+      </li>
+      <li>
+        Your browser's own settings can block or clear third-party cookies, and
+        any content blocker will stop these scripts loading in the first place.
+      </li>
+    </ul>
+    <p>
+      Blocking all of it is fine by us. <strong>Every tool on this site works
+      with the scripts blocked, and works with the network disconnected
+      entirely.</strong> Nothing here is held back behind an ad.
+    </p>
+  </section>
+
+  <section>
+    <h2>Your rights over the data</h2>
+    <p>
+      We hold no personal data about you, so there is nothing for us to show you,
+      correct, export, or delete &mdash; a request to us would come back empty,
+      honestly.
+    </p>
+    <p>
+      The data described above is held by Google, who act as their own controller
+      for it. Requests about it have to go to them, through
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">your Google account</a>
+      or their privacy contacts.
+    </p>
+  </section>
+
+  <section>
+    <h2>Children</h2>
+    <p>
+      This site is not directed at children and asks nobody for their age,
+      because it asks nobody for anything. We knowingly collect no personal data
+      from anyone, of any age.
+    </p>
+  </section>
+
+  <section>
+    <h2>Changes, and how to reach us</h2>
+    <p>
+      If this page changes, the date at the top changes with it, and the edit is
+      in the public commit history along with everything else.
+    </p>
+    <p>
+      Questions about any of this can go to
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, or be raised as an issue
+      on <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">the repository</a>,
+      where the answer is visible to everyone else wondering the same thing.
+    </p>
+  </section>

--- a/pages/privacy/page.toml
+++ b/pages/privacy/page.toml
@@ -1,0 +1,23 @@
+#
+# The Privacy page. Prose lives next door in body.html; this file is the frame
+# around it - the parts every page needs and no two pages share.
+#
+
+slug = "privacy"
+nav = "Privacy &amp; Cookies"          # the label used in the footer
+
+title = "Privacy &amp; Cookies &mdash; abox.tools"
+description = "What abox.tools does and does not collect. Your files are never uploaded; the ads, the visit counter and the donate button are described here in full, with the ways to switch each one off."
+
+heading = "Privacy &amp; Cookies"
+lede = """
+    The short version: your files are never uploaded, because there is nowhere
+    to upload them to. Everything else on this page is about the ads, the visit
+    counter and the hosting &mdash; the parts that do involve other companies."""
+
+updated = "19 August 2026"     # shown on the page, in words
+lastmod = "2026-08-19"         # the sitemap's machine-readable copy
+
+og_title = "Privacy &amp; Cookies &mdash; abox.tools"
+og_description = "Your files are never uploaded. What is collected, by whom, and how to switch it off."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/pages/terms/body.html
+++ b/pages/terms/body.html
@@ -1,0 +1,149 @@
+  <section>
+    <h2>What this site is</h2>
+    <p>
+      abox.tools is a collection of small utilities that run inside your web
+      browser. They are free to use, for anything, including commercial work.
+      There is nothing to buy, no account to create, no usage limit, and no
+      feature held back.
+    </p>
+    <p>
+      By using the site you accept the terms on this page. If you do not accept
+      them, the remedy is simply to close the tab &mdash; nothing of yours is
+      held here.
+    </p>
+  </section>
+
+  <section>
+    <h2>Your files stay yours</h2>
+    <p>
+      You keep every right you already had in the files you open with these
+      tools, and in whatever you produce with them. We claim no licence, no
+      ownership, and no interest of any kind in either.
+    </p>
+    <p>
+      This is not generosity, it is arithmetic: the tools run entirely in your
+      browser and your files are never transmitted to us, so there is nothing for
+      us to have rights over. The <a href="../privacy/">Privacy page</a> sets out
+      how that works and how to verify it.
+    </p>
+  </section>
+
+  <section>
+    <h2>Using the site responsibly</h2>
+    <p>
+      You are responsible for the files you process and for what you do with the
+      results. In particular, do not use these tools on material you have no
+      right to, or to produce anything unlawful.
+    </p>
+    <p>
+      We cannot enforce this and we are not pretending otherwise. We never see
+      your files, so there is no moderation here, no scanning, and no way for us
+      to know what anyone is doing. The obligation is genuinely yours.
+    </p>
+    <p>
+      Please also do not interfere with the site itself &mdash; attacking the
+      hosting, or redistributing modified copies in a way that suggests they are
+      the original.
+    </p>
+  </section>
+
+  <section>
+    <h2>No warranty</h2>
+    <p>
+      The site and its tools are provided <strong>as is</strong>, without
+      warranty of any kind, express or implied, including any implied warranty of
+      merchantability, fitness for a particular purpose, or non-infringement.
+    </p>
+    <p>
+      Concretely: a tool may produce a result you did not want, may fail on a
+      file it does not understand, may behave differently between browsers, and
+      may lose work if the tab is closed mid-operation. Nothing you do here is
+      saved anywhere, so <strong>keep your originals</strong>. Do not use these
+      tools on the only copy of anything you care about.
+    </p>
+  </section>
+
+  <section>
+    <h2>Limitation of liability</h2>
+    <p>
+      To the fullest extent the law allows, we are not liable for any loss or
+      damage arising from your use of this site &mdash; including lost, corrupted
+      or unusable files, lost time, lost profits, or any indirect or
+      consequential loss.
+    </p>
+    <p>
+      Nothing here limits liability that cannot lawfully be limited.
+    </p>
+  </section>
+
+  <section>
+    <h2>Availability</h2>
+    <p>
+      The site is offered with no promise that it will stay up, stay free, keep
+      any particular tool, or continue to exist at all. Tools may change or be
+      removed without notice.
+    </p>
+    <p>
+      One practical consequence of how these tools are built is worth knowing:
+      once a tool page has loaded, it keeps working offline, and it does not stop
+      working because the site went down. The code is also public, so a tool you
+      depend on can be kept running by you regardless of what happens here.
+    </p>
+  </section>
+
+  <section>
+    <h2>Advertising and other companies</h2>
+    <p>
+      The site carries advertising from Google, counts visits with Google
+      Analytics, and shows a donate button on most pages. What each of those
+      involves is described in full on the
+      <a href="../privacy/">Privacy page</a>.
+    </p>
+    <p>
+      Advertisements, and any site you reach by clicking one, are not ours. We do
+      not select individual ads, do not endorse what they say, and are not
+      responsible for the sites they lead to or for any dealings you have there.
+      The same goes for every other external link on this site.
+    </p>
+  </section>
+
+  <section>
+    <h2>The source code</h2>
+    <p>
+      This site's code is published openly at
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>,
+      because &ldquo;read it and check for yourself&rdquo; is the only real answer
+      to &ldquo;why should I trust this&rdquo;. Reuse of that code is governed by
+      the licence terms stated in the repository, not by this page. These terms
+      cover your use of the website.
+    </p>
+  </section>
+
+  <section>
+    <h2>Governing law</h2>
+    <p>
+      This site is operated from Canada. These terms, and any dispute arising out
+      of them or out of your use of the site, are governed by the laws of Canada
+      and of the province in which the site is operated, without regard to
+      conflict-of-law rules.
+    </p>
+    <p>
+      If the consumer law where you live gives you rights that these terms would
+      otherwise restrict, those rights stand.
+    </p>
+  </section>
+
+  <section>
+    <h2>Changes to these terms</h2>
+    <p>
+      These terms may be updated. When they are, the date at the top changes, and
+      the edit appears in the public commit history like every other change.
+      Continuing to use the site after a change means accepting the updated
+      version.
+    </p>
+    <p>
+      Questions can go to <a href="mailto:hi@abox.tools">hi@abox.tools</a>, or be
+      raised as an issue on
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">the repository</a>.
+    </p>
+  </section>

--- a/pages/terms/page.toml
+++ b/pages/terms/page.toml
@@ -1,0 +1,22 @@
+#
+# The Terms page. Prose lives next door in body.html.
+#
+
+slug = "terms"
+nav = "Terms of Use"
+
+title = "Terms of Use &mdash; abox.tools"
+description = "The terms this site is offered under: free, as-is, no account, no warranty, and your files remain entirely your own because they are never sent to us."
+
+heading = "Terms of Use"
+lede = """
+    There is no account to open and no agreement to sign, so these are short.
+    They describe what you may expect from this site, and what it does not
+    promise."""
+
+updated = "19 August 2026"
+lastmod = "2026-08-19"
+
+og_title = "Terms of Use &mdash; abox.tools"
+og_description = "Free, as-is, no account, no warranty. Your files remain entirely your own."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -526,21 +526,81 @@ button, .as-button {
   font-size: 0.88em;
 }
 
+/* ---- footer ------------------------------------------------------------ */
+
+/* A link footer in the shape the large media-tool sites use: a few columns of
+   plain links, left aligned, each under a quiet heading. It is the second
+   navigation, for anyone who scrolled to the bottom looking for one, and it is
+   the only route to the legal pages - a centred line of prose had nowhere to
+   put them.
+
+   Flex rather than grid, so the columns fall to two-up and then one-up on a
+   narrow screen without a media query. The brand column gets twice the basis of
+   a link column, because it carries a sentence rather than a list. */
+
 footer {
-  text-align: center;
+  margin-top: 3rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--border);
   color: var(--text-dim);
-  font-size: 0.82rem;
-  padding-top: 0.5rem;
+  font-size: 0.85rem;
 }
 
-/* The way back to the hub, with the site mark on it. The link is inline in a
-   sentence, so the two sit on the text baseline rather than in a flex row. */
-.home-link { white-space: nowrap; }
+.footer-cols {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+}
+
+.footer-col { flex: 1 1 150px; min-width: 0; }
+.footer-brand { flex: 2 1 240px; }
+
+.footer-col strong {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.footer-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer-brand p { margin: 0.55rem 0 0; max-width: 34ch; }
+
+footer p { margin: 0.35rem 0; }
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+
+.footer-base {
+  margin: 1.75rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+/* The way back to the hub, with the site mark on it. It heads the brand column
+   now rather than sitting inline in a sentence, so it is a flex row and carries
+   its own weight and colour. */
+.home-link {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  color: var(--text);
+  font-weight: 600;
+}
 
 .site-logo {
   width: 1.35em;
   height: 1.35em;
-  vertical-align: -0.35em;
   margin-right: 0.15em;
 }
 

--- a/shared/site.css
+++ b/shared/site.css
@@ -1,4 +1,4 @@
-/* Styles for the hub page only. Each tool ships its own stylesheet so that it
+/* Styles for the hub page and the legal pages under pages/. Each tool ships its own stylesheet so that it
    stays self-contained and can be read, audited, or moved on its own. */
 
 :root {
@@ -10,6 +10,8 @@
   --text: #16191d;
   --text-dim: #5d6672;
   --accent: #2b6cb0;
+  --accent-deep: #1d4f83;
+  --accent-pale: #d7e7f7;
   --radius: 10px;
   --shadow: 0 1px 2px rgb(16 24 40 / 6%), 0 4px 12px rgb(16 24 40 / 4%);
 }
@@ -23,6 +25,8 @@
     --text: #e8eaed;
     --text-dim: #9aa4b2;
     --accent: #5b9bd8;
+    --accent-deep: #3772ab;
+    --accent-pale: #cfe3f8;
     --shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 4px 12px rgb(0 0 0 / 20%);
   }
 }
@@ -239,19 +243,132 @@ code {
 .p-name { font-weight: 600; color: var(--text); }
 .p-desc { font-size: 0.85rem; }
 
+/* ---- legal pages ------------------------------------------------------- */
+
+/* Privacy and Terms. Narrower than the hub, because these are read as prose
+   rather than scanned as a grid.
+
+   The site mark below is drawn by the footer's home link. Its rules are the
+   same ones tool pages get from shared/css/tool-frame.css; they are repeated
+   here because site.css is a whole stylesheet rather than one of the parts the
+   build assembles, and the two are small enough that a copy beats a build
+   step. If one changes, change the other. */
+
+.brand-home { color: inherit; text-decoration: none; }
+.brand-home:hover { color: var(--accent); }
+
+.site-logo {
+  width: 1.35em;
+  height: 1.35em;
+  margin-right: 0.15em;
+}
+
+.logo-lid { stroke: var(--accent); }
+.logo-tool { fill: var(--accent-deep); }
+.logo-tool-alt { fill: var(--accent); }
+.logo-box { fill: var(--accent-deep); }
+.logo-band { fill: var(--accent); }
+.logo-latch { fill: var(--accent-pale); }
+
+.legal-date {
+  margin: 1rem 0 0;
+  font-size: 0.82rem;
+  color: var(--text-dim);
+}
+
+.legal { max-width: 68ch; }
+
+.legal section { margin: 0 0 2.25rem; }
+
+.legal h2 {
+  margin: 0 0 0.7rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 1.15rem;
+  letter-spacing: -0.01em;
+}
+
+.legal h3 {
+  margin: 1.5rem 0 0.45rem;
+  font-size: 0.95rem;
+}
+
+.legal p { margin: 0 0 0.85rem; }
+.legal ul { margin: 0 0 0.95rem; padding-left: 1.25rem; }
+.legal li { margin: 0.3rem 0; }
+.legal a { color: var(--accent); }
+
 /* ---- footer ------------------------------------------------------------ */
 
+/* A link footer in the shape the large media-tool sites use: a few columns of
+   plain links, left aligned, each under a quiet heading. It is the second
+   navigation, for anyone who scrolled to the bottom looking for one, and it is
+   the only route to the legal pages - a centred line of prose had nowhere to
+   put them.
+
+   Flex rather than grid, so the columns fall to two-up and then one-up on a
+   narrow screen without a media query. The brand column gets twice the basis of
+   a link column, because it carries a sentence rather than a list. */
+
 footer {
-  margin-top: 2.5rem;
-  padding-top: 1.5rem;
+  margin-top: 3rem;
+  padding-top: 1.75rem;
   border-top: 1px solid var(--border);
   color: var(--text-dim);
-  font-size: 0.82rem;
+  font-size: 0.85rem;
+}
+
+.footer-cols {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+}
+
+.footer-col { flex: 1 1 150px; min-width: 0; }
+.footer-brand { flex: 2 1 240px; }
+
+.footer-col strong {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--text);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.footer-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.footer-brand p { margin: 0.55rem 0 0; max-width: 34ch; }
+
+footer p { margin: 0.35rem 0; }
+footer a { color: var(--accent); text-decoration: none; }
+footer a:hover { text-decoration: underline; }
+
+.footer-base {
+  margin: 1.75rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.8rem;
   text-align: center;
 }
 
-footer p { margin: 0.35rem 0; }
-footer a { color: var(--accent); }
+/* The way back to the hub, with the site mark on it. It heads the brand column
+   now rather than sitting inline in a sentence, so it is a flex row and carries
+   its own weight and colour. */
+.home-link {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  color: var(--text);
+  font-weight: 600;
+}
 
 
 /* ------------------------------------------------------------- ad placement */

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -169,18 +169,7 @@
 
 </main>
 
-<footer>
-  <p>
-{{ site.hub.footer.line1 }}
-  </p>
-  <p>
-    <a href="{{ site.source_url }}" target="_blank" rel="noopener noreferrer">
-      Read the source
-    </a>
-    &middot;
-    {{ site.hub.footer.line2 }}
-  </p>
-</footer>
+{% include "partials/footer.html" %}
 
 </body>
 </html>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="{{ site.lang }}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!--
+  GENERATED FILE - do not edit. Built by build.py from templates/page.html,
+  config/site.toml, and pages/{{ page.slug }}/{page.toml,body.html}.
+  Edit those and run `python build.py`.
+
+  A "page" here is a prose page that is not a tool and not the hub: the legal
+  pages. It gets the site frame, the same Content-Security-Policy as everywhere
+  else, and the same footer, and nothing else - no service worker, because there
+  is nothing to keep working offline, and no blob: in img-src, because it never
+  makes one.
+-->
+<!--
+  This page carries advertising, and ad code cannot run under default-src
+  'none'. The allowlist below is generated from config/site.toml, the same one
+  every other page is built from, so they cannot drift apart. The reasoning
+  behind each entry is written down beside the list in that file.
+-->
+{{ csp }}
+<title>{{ page.title }}</title>
+<meta name="description" content="{{ page.description }}">
+
+<link rel="canonical" href="{{ page.url }}">
+
+<meta name="google-adsense-account" content="{{ site.adsense_client }}">
+
+{% include "partials/head-scripts.html" %}
+
+<meta property="og:type" content="article">
+<meta property="og:site_name" content="{{ site.name }}">
+<meta property="og:url" content="{{ page.url }}">
+<meta property="og:title" content="{{ page.og_title }}">
+<meta property="og:description" content="{{ page.og_description }}">
+<meta property="og:image" content="{{ site.domain }}og.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="{{ page.og_image_alt }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ page.og_title }}">
+<meta name="twitter:description" content="{{ page.og_description }}">
+<meta name="twitter:image" content="{{ site.domain }}og.png">
+
+<link rel="stylesheet" href="../site.css">
+<link rel="icon" href="/logo.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/icon-180.png">
+</head>
+<body>
+
+<header class="hub-head">
+  <p class="brand">
+    <a class="brand-home" href="../">
+      <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
+    </a>
+  </p>
+  <h1>{{ page.heading }}</h1>
+  <p class="lede">
+{{ page.lede }}
+  </p>
+  <p class="legal-date">Last updated {{ page.updated }}</p>
+</header>
+
+<main class="legal">
+{{ body }}
+</main>
+
+{% include "partials/footer.html" %}
+
+</body>
+</html>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -1,0 +1,60 @@
+<!--
+  The footer every page wears: a few columns of plain links, left aligned under
+  quiet headings, in the shape the large media-tool sites use. It is the second
+  navigation, for anyone who scrolled to the bottom looking for one, and it is
+  the only route to the legal pages.
+
+  This used to be three different footers kept in step by hand. It is one now,
+  and the only thing that differs between a hub, a tool and a legal page is
+  `base`: './' at the root, '../' one level down. Every link below is built from
+  it, so nothing here has to know which kind of page it landed on.
+
+  The tool list and the legal-page list are passed in by build.py from the
+  folders that exist, so a new tool or a new page appears here without anybody
+  remembering to add it.
+-->
+<footer>
+  <div class="footer-cols">
+    <div class="footer-col footer-brand">
+      <a class="home-link" href="{{ base }}">
+{% include "partials/site-mark.html" %}
+        abox.tools
+      </a>
+      <p>
+{{ site.footer.blurb }}
+      </p>
+    </div>
+
+    <div class="footer-col">
+      <strong>Tools</strong>
+      <ul>
+{% for t in footer.tools %}        <li><a href="{{ base }}{{ t.slug }}/">{{ t.name | e }}</a></li>
+{% endfor %}      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>This site</strong>
+      <ul>
+        <li><a href="{{ base }}">All tools</a></li>
+{% for p in footer.pages %}        <li><a href="{{ base }}{{ p.slug }}/">{{ p.nav }}</a></li>
+{% endfor %}        <li><a href="/sitemap.xml">Sitemap</a></li>
+      </ul>
+    </div>
+
+    <div class="footer-col">
+      <strong>Get in touch</strong>
+      <ul>
+        <li>
+          <a href="{{ site.source_url }}" target="_blank" rel="noopener noreferrer">
+            Read the code on GitHub
+          </a>
+        </li>
+        <li><a href="mailto:{{ site.contact_email }}">{{ site.contact_email }}</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <p class="footer-base">
+{{ site.footer.base }}
+  </p>
+</footer>

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -240,26 +240,7 @@
 {% endfor %}  </div>
 </section>
 
-<footer>
-  <p>
-    Runs in your browser. No accounts, no uploads. Ads by Google.
-    Tips are welcome and change nothing.
-    &middot;
-    <!--
-      The site mark, inlined so that this page stays self-contained and works
-      offline. Same shape as the hub's logo.svg; colours come from this page's
-      own stylesheet.
-    -->
-    <a class="home-link" href="../">
-{% include "partials/site-mark.html" %}
-      All tools
-    </a>
-    &middot;
-    <a href="{{ site.source_url }}" target="_blank" rel="noopener noreferrer">
-      Read the source
-    </a>
-  </p>
-</footer>
+{% include "partials/footer.html" %}
 
 <script type="module" src="src/main.js"></script>
 </body>


### PR DESCRIPTION
The generator had no idea what a page was that is not a tool and not the hub, so this teaches it one: pages/<slug>/ with a page.toml and a body.html, built by templates/page.html. It gets the site frame, an entry in sitemap.xml, and a link in every footer. It gets no service worker, because there is nothing on a legal page worth keeping offline, and no blob: in img-src, because it never makes one.

The footer was three different ones kept in step by hand, and none of them had anywhere to put a privacy link. It is now a single partial: columns of plain links, left aligned under quiet headings. Its tool list comes from tools/ in the order the hub shows them, and its legal-page list from pages/, so both follow from what exists. The only thing that differs between a hub, a tool and a legal page is whether links start ./ or ../.

The legal pages take the site Content-Security-Policy unchanged, which settles the question of whether they should narrow it to leave out the donate button's two origins. They should not - one list in one file is worth more than a policy that is right about one page and drifting on the other three. If that difference is ever wanted back it belongs in config/site.toml as [page_csp], beside [tool_csp].

The Privacy page names every third party in turn and how to switch each one off, and says that every tool still works once you have. The Terms page keeps every right in the files with the person who opened them, on the grounds that we never receive them. Governing law is Canada, without a province named. Contact is hi@abox.tools, in the footer and on both pages.

Still absent, and written down in README rather than left to be discovered: there is no cookie consent banner, which AdSense's own policy expects for EU and UK traffic.