### PR TITLE
Ask for the stylesheet by a URL that changes when the stylesheet does

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ something the build does, and cannot forget to do:
 | "Bump `CACHE_NAME` whenever any listed file changes" | The service worker's asset list is read off the disk, and its cache name is a hash of those files, so it changes exactly when they do. |
 | "Add one `<li>` card to the matching category, and an entry to `sitemap.xml`" | The hub's cards, its `ItemList` structured data and `sitemap.xml` all come from the tools that exist in `tools/`. |
 | Four copies of the repository URL per page | `source_url` in `config/site.toml`. |
+| Nothing at all, which is how a stylesheet change reached returning visitors four hours late | Every page asks for its stylesheet by a URL carrying a hash of that stylesheet, so changing the CSS changes the URL and there is no stale copy to serve. |
 | Three different footers, none of which linked to a privacy policy because there was nowhere to put one | One `templates/partials/footer.html`. Its tool list and legal-page list come from `tools/` and `pages/`, and the only thing that differs per page is whether links start `./` or `../`. |
 
 The build refuses to produce a site rather than produce a broken one. A missing
@@ -337,6 +338,41 @@ Check what is actually being served, from anywhere, with no credentials:
 
 Two configurations to keep in step: if you change `_headers`, change
 `cloudflare/response-headers.json` too, or the two deployments stop agreeing.
+
+### Cache lifetimes, and why the stylesheet URLs carry a hash
+
+GitHub Pages sets its own `Cache-Control`, and it does not set the same one for
+everything:
+
+| Served as | `max-age` |
+|---|---|
+| HTML | 600 (ten minutes) |
+| CSS, JS, images | 14400 (four hours) |
+
+Those two numbers disagreeing is a deploy hazard rather than a detail. A visitor
+who has been here before gets the new markup within ten minutes and keeps the
+old stylesheet for up to four hours, so any deploy that changes both arrives as
+a page wearing the wrong CSS. That is not hypothetical: it is exactly how the
+new footer first reached the live site, as an unstyled column with the site mark
+blown up to the full width of the page, while the deployed files were correct
+the whole time.
+
+So the build gives every stylesheet URL a hash of its own contents:
+
+```
+<link rel="stylesheet" href="site.css?v=cff5cc1753">      the hub, the legal pages
+<link rel="stylesheet" href="styles.css?v=1167009c82">    one per tool
+```
+
+Change the CSS and the URL changes with it, so there is no stale copy to hand
+back. Leave it alone and the URL is identical, so the four-hour cache keeps
+doing its job. Nothing has to be purged by hand at Cloudflare.
+
+**A tool's service worker must precache the versioned URL, not the bare one.**
+It matches on the whole request, query string included, so a worker that cached
+`styles.css` while the page asked for `styles.css?v=...` would leave the tool
+styled online and bare offline. `build.py` passes the same string to both, which
+is the only reason they cannot drift.
 
 ### Canonical URLs
 

--- a/build.py
+++ b/build.py
@@ -91,6 +91,9 @@ def build(out, clean=False):
 
     templates = Loader(TEMPLATES)
     site = sitelib.load_toml(CONFIG / 'site.toml')
+    # The hub and the legal pages share one stylesheet, so they share one
+    # version for it. Tool pages each hash their own assembled sheet.
+    css_v = sitelib.text_hash((SHARED / 'site.css').read_text(encoding='utf-8'))
     planned = sitelib.load_toml(CONFIG / 'planned.toml')
 
     tools = [sitelib.load_tool(path, site)
@@ -122,10 +125,10 @@ def build(out, clean=False):
         written.append(f'{tool["slug"]}/index.html')
 
     for page in prose:
-        build_page(out, templates, site, page, footer)
+        build_page(out, templates, site, page, footer, css_v)
         written.append(f'{page["slug"]}/index.html')
 
-    build_hub(out, templates, site, planned, by_slug, footer)
+    build_hub(out, templates, site, planned, by_slug, footer, css_v)
     written.append('index.html')
 
     build_sitemap(out, templates, site, tools, prose)
@@ -156,17 +159,25 @@ def build_tool(out, templates, site, tool, footer):
     if not body_path.is_file():
         raise sitelib.ConfigError(f'{tool["slug"]}: no body.html')
 
+    # Assembled first, so the page can ask for it by a URL carrying a hash of
+    # what is in it. The service worker below precaches that same URL: it
+    # matches on the whole request, query and all, so a mismatch would leave a
+    # tool styled online and bare offline.
+    css = tool_css(tool)
+    css_href = f'styles.css?v={sitelib.text_hash(css)}'
+
     write(dest / 'index.html', templates.render('tool.html', {
         'site': site,
         'tool': tool,
         'footer': footer,
         'base': '../',
         'csp': sitelib.render_csp(site['csp'], site.get('tool_csp', {}), tool['csp']),
+        'css_href': css_href,
         'jsonld': sitelib.tool_jsonld(site, tool),
         'body': body_path.read_text(encoding='utf-8').rstrip('\n'),
     }))
 
-    write(dest / 'styles.css', tool_css(tool))
+    write(dest / 'styles.css', css)
 
     write(dest / 'analytics.js', templates.render('analytics.js', {
         'site': site,
@@ -179,7 +190,7 @@ def build_tool(out, templates, site, tool, footer):
     cached = [dest / 'index.html', dest / 'styles.css', dest / 'analytics.js'] + assets
     write(dest / 'sw.js', templates.render('sw.js', {
         'tool': tool,
-        'assets': ['index.html', 'styles.css'] + [f'src/{p.name}' for p in assets],
+        'assets': ['index.html', css_href] + [f'src/{p.name}' for p in assets],
         'cache_hash': sitelib.cache_hash(cached),
     }))
 
@@ -215,7 +226,7 @@ def tool_css(tool):
 # One prose page (the legal ones)
 
 
-def build_page(out, templates, site, page, footer):
+def build_page(out, templates, site, page, footer, css_v):
     """A legal page: the site frame around a body.html, and nothing else.
 
     No service worker, because there is nothing here worth keeping offline, and
@@ -235,6 +246,7 @@ def build_page(out, templates, site, page, footer):
         'page': page,
         'footer': footer,
         'base': '../',
+        'css_href': f'../site.css?v={css_v}',
         'csp': sitelib.render_csp(site['csp']),
         'body': body_path.read_text(encoding='utf-8').rstrip('\n'),
     }))
@@ -249,7 +261,7 @@ def build_page(out, templates, site, page, footer):
 # The hub
 
 
-def build_hub(out, templates, site, planned, by_slug, footer):
+def build_hub(out, templates, site, planned, by_slug, footer, css_v):
     categories = []
     listed = set()
     for category in site['hub']['categories']:
@@ -284,6 +296,7 @@ def build_hub(out, templates, site, planned, by_slug, footer):
         'categories': categories,
         'footer': footer,
         'base': './',
+        'css_href': f'site.css?v={css_v}',
         'csp': sitelib.render_csp(site['csp']),
         'jsonld': sitelib.hub_jsonld(site, ordered),
     }))

--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -258,6 +258,19 @@ def load_page(path, site):
     return page
 
 
+def text_hash(text):
+    """A short digest of one generated file's contents, used to version the URL
+    a page asks for it by.
+
+    GitHub Pages serves HTML with max-age=600 and everything else with
+    max-age=14400. A deploy that changes a stylesheet therefore reaches a
+    returning visitor as new markup wearing the stylesheet from four hours ago,
+    which is how the footer arrived on a page unstyled. Naming the file with a
+    hash of what is in it makes that impossible: change the CSS and the URL
+    changes, so there is nothing stale to hand back."""
+    return hashlib.sha256(text.encode('utf-8')).hexdigest()[:10]
+
+
 def cache_hash(paths):
     """A short digest of everything the service worker caches, used as its cache
     name. It changes exactly when one of the cached files changes, which is what

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -77,7 +77,12 @@
 {{ jsonld }}
 </script>
 
-<link rel="stylesheet" href="site.css">
+<!--
+  The stylesheet URL carries a hash of the stylesheet. GitHub Pages serves
+  HTML with max-age=600 and CSS with max-age=14400, so without this a deploy
+  reaches a returning visitor as new markup wearing a four-hour-old sheet.
+-->
+<link rel="stylesheet" href="{{ css_href }}">
 <!--
   The site mark. logo.svg themes itself - it carries a prefers-color-scheme
   block - so the tab icon stays legible in a dark tab strip as well as a light

--- a/templates/page.html
+++ b/templates/page.html
@@ -44,7 +44,12 @@
 <meta name="twitter:description" content="{{ page.og_description }}">
 <meta name="twitter:image" content="{{ site.domain }}og.png">
 
-<link rel="stylesheet" href="../site.css">
+<!--
+  The stylesheet URL carries a hash of the stylesheet. GitHub Pages serves
+  HTML with max-age=600 and CSS with max-age=14400, so without this a deploy
+  reaches a returning visitor as new markup wearing a four-hour-old sheet.
+-->
+<link rel="stylesheet" href="{{ css_href }}">
 <link rel="icon" href="/logo.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/icon-180.png">
 </head>

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -77,7 +77,12 @@
 {{ jsonld }}
 </script>
 
-<link rel="stylesheet" href="styles.css">
+<!--
+  The stylesheet URL carries a hash of the stylesheet. GitHub Pages serves
+  HTML with max-age=600 and CSS with max-age=14400, so without this a deploy
+  reaches a returning visitor as new markup wearing a four-hour-old sheet.
+-->
+<link rel="stylesheet" href="{{ css_href }}">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='14' font-size='14'>{{ tool.favicon }}</text></svg>">
 </head>
 <body>


### PR DESCRIPTION
The footer went out to the live site unstyled: columns stacked, list bullets showing, the site mark blown up to the full width of the page. The deployed files were correct the whole time. What was wrong was which stylesheet a returning visitor had.

GitHub Pages serves HTML with max-age=600 and CSS with max-age=14400. Any deploy that changes both therefore lands, for anyone who has been here in the last four hours, as new markup wearing the old sheet. It went unnoticed until now because no change had altered the markup and the CSS together in a way that made the mismatch visible; the new footer does exactly that - new classes, and the rules that give them meaning arriving four hours later.

So every page now asks for its stylesheet by a URL carrying a hash of that stylesheet's contents. Change the CSS and the URL changes, so there is no stale copy to serve. Leave it alone and the URL is byte for byte the same, so the four-hour cache keeps working and nothing has to be purged by hand.

The one trap is the service worker, which matches on the whole request, query and all. A worker that precached styles.css while its page asked for styles.css?v=... would leave a tool styled online and bare offline. build.py hands the same string to the page and to the worker, so they cannot drift.