### PR TITLE
Strip the comments and indentation out of what gets served

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ That builds, then compares the result file by file with the `dist` branch —
 the branch GitHub Pages serves. If they differ, the deployed site is not what
 this repository says it is, and that is worth knowing.
 
+The output is minified, so it is not pleasant reading, but it is still
+*checkable*: the build is deterministic, so the same sources produce the same
+bytes on any machine, and that is what makes the comparison above mean
+something. Every generated file also keeps one banner comment naming the
+repository and this command. To read the output instead of verifying it:
+
+```bash
+python build.py --no-minify
+```
+
 > **Do not open a page's `index.html` by double-clicking it.** Browsers block ES
 > modules on `file://` URLs, so `main.js` never runs. The page still renders and the
 > file picker still opens — that part is plain HTML — but choosing images does nothing.
@@ -117,7 +127,7 @@ tools/
     tool.toml            everything particular to this tool: prose, FAQ, metadata
     body.html            the <main> of the page - the interface, and only that
     styles.css           the rules only this tool needs
-    src/*.js             the app itself, copied into dist/ byte for byte
+    src/*.js             the app itself; minified into dist/, never renamed
     og.png               its share card
   crop-video/            the same five things
   exif-editor/           and again
@@ -138,11 +148,38 @@ the domain root, at `/compress-image/`, or nested deeper, with no configuration.
 The service worker registers with the scope of its own folder, so each tool
 caches only itself and cannot interfere with its neighbours.
 
-**The JavaScript is not touched.** `src/*.js` is copied byte for byte — no
-bundler, no minifier, no transpiler — so the code a visitor's browser runs is
-still, character for character, the code in this repository. The build only ever
-assembles HTML, CSS, and the two small generated JS files (`sw.js`,
-`analytics.js`), and it never reaches the network.
+**The JavaScript keeps its shape.** The build strips comments and indentation
+from `src/*.js` and does nothing else to it. There is no bundler and no
+transpiler: every module is still its own file, still an ES module, still
+running the same statements in the same order on the same lines. **Nothing is
+renamed**, so the served code can still be read and grepped — there is no
+`fetch` in it for the same reason there is none in the sources.
+
+That stopping point is deliberate. Renaming identifiers is the part of
+minification that makes code genuinely unreadable, and doing it safely needs a
+real parser with scope analysis, because a name is only safe to change once you
+know every place it is bound and every place it is read. Guessing at that is how
+a build silently corrupts a hand-written EXIF parser, and the failure would not
+show up until somebody's photo came out wrong. If mangled names are ever wanted,
+the honest way to get them is a real toolchain (esbuild, terser) run over
+`dist/`, accepting the dependency and the loss of a build anyone can reproduce
+with nothing installed.
+
+`buildlib/minify.py` checks its own work on every file it writes, and the build
+fails rather than shipping something it is not sure about:
+
+- **Line breaks never move.** JavaScript inserts semicolons at line breaks, so a
+  minifier that joins lines has to know where a statement ends — which again
+  means parsing. Every newline stays exactly where it was, which costs about a
+  byte per line and buys certainty.
+- **The output must re-tokenise to the input's tokens**, in order, with a break
+  between the same pairs of them. A dropped space that turned `a in b` into
+  `ainb`, or `x + +y` into `x++y`, changes that stream and stops the build.
+
+Roughly: HTML 28% smaller, JavaScript 40% smaller. CSS is left alone.
+
+`python build.py --no-minify` gives the readable output back while debugging.
+Whichever way it runs, the build never reaches the network.
 
 ### What the build stopped anyone having to remember
 
@@ -158,6 +195,7 @@ something the build does, and cannot forget to do:
 | "Bump `CACHE_NAME` whenever any listed file changes" | The service worker's asset list is read off the disk, and its cache name is a hash of those files, so it changes exactly when they do. |
 | "Add one `<li>` card to the matching category, and an entry to `sitemap.xml`" | The hub's cards, its `ItemList` structured data and `sitemap.xml` all come from the tools that exist in `tools/`. |
 | Four copies of the repository URL per page | `source_url` in `config/site.toml`. |
+| A cache name to bump by hand when minification changed the bytes | The cache name hashes the files **as emitted**, so turning minifying on or off invalidates the cache by itself. |
 | Nothing at all, which is how a stylesheet change reached returning visitors four hours late | Every page asks for its stylesheet by a URL carrying a hash of that stylesheet, so changing the CSS changes the URL and there is no stale copy to serve. |
 | Three different footers, none of which linked to a privacy policy because there was nowhere to put one | One `templates/partials/footer.html`. Its tool list and legal-page list come from `tools/` and `pages/`, and the only thing that differs per page is whether links start `./` or `../`. |
 
@@ -641,7 +679,8 @@ background tabs. The app warns you if the tab was hidden mid-recording.
 ### About the MP4 muxer
 
 `src/mp4.js` writes the container by hand because there is no bundler to pull in a
-library — the build assembles pages, and never touches `src/`. It is deliberately narrow:
+library — the build assembles pages and minifies them, and never adds code that
+was not written here. It is deliberately narrow:
 
 - one H.264 video track, no audio
 - samples in presentation order, no B-frames, so no `ctts` box is needed

--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ Build the site into dist/.
 
     python build.py              build into dist/
     python build.py --clean      empty dist/ first
+    python build.py --no-minify  leave the output readable, for debugging
     python build.py --check      build, then fail if dist/ differs from git's
                                  copy of the branch it is committed on
 
@@ -31,17 +32,26 @@ Every one of those is now a thing the build does:
   * a service worker's asset list is read off the disk, and its cache name is a
     hash of those files, so it changes exactly when they do.
 
-WHAT IT DOES NOT DO
+WHAT IT DOES TO THE JAVASCRIPT
 
-It does not touch the JavaScript. src/*.js is copied byte for byte: there is no
-bundler, no minifier and no transpiler, so the code a visitor's browser runs is
-still, character for character, the code in this repository. The build only ever
-assembles HTML, CSS and the two small generated JS files (sw.js, analytics.js),
-and it never reaches the network.
+It strips comments and indentation, and nothing else. There is no bundler and
+no transpiler: every module is still its own file, still an ES module, still
+running the same statements in the same order on the same lines. Names are not
+rewritten, so the served code can still be read and grepped - there is no
+`fetch` in it for the same reason there is none in the sources.
+
+That is a deliberate stopping point, not a limitation to be fixed later.
+Renaming identifiers needs a real parser with scope analysis; guessing at it is
+how a build silently corrupts a hand-written EXIF parser. buildlib/minify.py
+says more, and checks its own work on every file: if minifying ever changed a
+token or moved a line break, the build fails instead of shipping it.
+
+Pass --no-minify to get the readable output back while debugging. The site
+never reaches the network at build time either way.
 """
 
 import argparse
-import filecmp
+import hashlib
 import shutil
 import subprocess
 import sys
@@ -49,6 +59,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+from buildlib import minify
 from buildlib import site as sitelib
 from buildlib.template import Loader, TemplateError
 
@@ -64,14 +75,16 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__.split('\n')[1])
     parser.add_argument('--out', default='dist', help='where to write (default: dist)')
     parser.add_argument('--clean', action='store_true', help='empty the output first')
+    parser.add_argument('--no-minify', dest='minify', action='store_false',
+                        help='leave the output readable, for debugging')
     parser.add_argument('--check', action='store_true',
                         help='fail if the output differs from the committed dist branch')
     args = parser.parse_args(argv)
 
     out = (ROOT / args.out).resolve()
     try:
-        pages = build(out, clean=args.clean)
-    except (sitelib.ConfigError, TemplateError) as err:
+        pages = build(out, clean=args.clean, minify_output=args.minify)
+    except (sitelib.ConfigError, TemplateError, minify.MinifyError) as err:
         print(f'build failed: {err}', file=sys.stderr)
         return 1
 
@@ -84,13 +97,14 @@ def main(argv=None):
     return 0
 
 
-def build(out, clean=False):
+def build(out, clean=False, minify_output=True):
     if clean and out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True, exist_ok=True)
 
     templates = Loader(TEMPLATES)
     site = sitelib.load_toml(CONFIG / 'site.toml')
+    emit = Emitter(minify_output, site)
     # The hub and the legal pages share one stylesheet, so they share one
     # version for it. Tool pages each hash their own assembled sheet.
     css_v = sitelib.text_hash((SHARED / 'site.css').read_text(encoding='utf-8'))
@@ -121,14 +135,14 @@ def build(out, clean=False):
 
     written = []
     for tool in tools:
-        build_tool(out, templates, site, tool, footer)
+        build_tool(out, templates, site, tool, footer, emit)
         written.append(f'{tool["slug"]}/index.html')
 
     for page in prose:
-        build_page(out, templates, site, page, footer, css_v)
+        build_page(out, templates, site, page, footer, css_v, emit)
         written.append(f'{page["slug"]}/index.html')
 
-    build_hub(out, templates, site, planned, by_slug, footer, css_v)
+    build_hub(out, templates, site, planned, by_slug, footer, css_v, emit)
     written.append('index.html')
 
     build_sitemap(out, templates, site, tools, prose)
@@ -142,18 +156,26 @@ def build(out, clean=False):
 # One tool
 
 
-def build_tool(out, templates, site, tool, footer):
+def build_tool(out, templates, site, tool, footer, emit):
     dest = out / tool['slug']
     dest.mkdir(parents=True, exist_ok=True)
 
-    # The app code, copied byte for byte. Nothing here rewrites JavaScript.
+    # The app code. Every module keeps its own file and its own name; only the
+    # comments and the indentation come out. See buildlib/minify.py.
     src_dir = tool['dir'] / 'src'
     if not src_dir.is_dir():
         raise sitelib.ConfigError(f'{tool["slug"]}: no src/ folder')
     assets = sorted(src_dir.glob('*.js'))
     if not any(path.name == 'main.js' for path in assets):
         raise sitelib.ConfigError(f'{tool["slug"]}: src/main.js is required')
-    shutil.copytree(src_dir, dest / 'src', dirs_exist_ok=True)
+    (dest / 'src').mkdir(exist_ok=True)
+    for asset in assets:
+        emit.js(dest / 'src' / asset.name,
+                asset.read_text(encoding='utf-8'),
+                where=f'{tool["slug"]}/src/{asset.name}')
+    for extra in sorted(src_dir.iterdir()):
+        if extra.is_file() and extra.suffix != '.js':
+            shutil.copy2(extra, dest / 'src' / extra.name)
 
     body_path = tool['dir'] / 'body.html'
     if not body_path.is_file():
@@ -166,7 +188,7 @@ def build_tool(out, templates, site, tool, footer):
     css = tool_css(tool)
     css_href = f'styles.css?v={sitelib.text_hash(css)}'
 
-    write(dest / 'index.html', templates.render('tool.html', {
+    emit.html(dest / 'index.html', templates.render('tool.html', {
         'site': site,
         'tool': tool,
         'footer': footer,
@@ -179,20 +201,26 @@ def build_tool(out, templates, site, tool, footer):
 
     write(dest / 'styles.css', css)
 
-    write(dest / 'analytics.js', templates.render('analytics.js', {
+    emit.js(dest / 'analytics.js', templates.render('analytics.js', {
         'site': site,
         'words': tool['words'],
-    }))
+    }), where=f'{tool["slug"]}/analytics.js')
 
     # The service worker caches './', its own src/*.js, and analytics.js. The
     # list is read off the disk rather than written down, so a new module is
     # cached the moment it exists.
-    cached = [dest / 'index.html', dest / 'styles.css', dest / 'analytics.js'] + assets
-    write(dest / 'sw.js', templates.render('sw.js', {
+    #
+    # Hashed from the files as emitted, not as authored: minifying changes the
+    # bytes a browser receives, so turning it on or off has to invalidate the
+    # cache. Hashing the sources instead would leave a visitor holding the old
+    # copy of a file that had genuinely changed.
+    cached = ([dest / 'index.html', dest / 'styles.css', dest / 'analytics.js']
+              + [dest / 'src' / asset.name for asset in assets])
+    emit.js(dest / 'sw.js', templates.render('sw.js', {
         'tool': tool,
         'assets': ['index.html', css_href] + [f'src/{p.name}' for p in assets],
         'cache_hash': sitelib.cache_hash(cached),
-    }))
+    }), where=f'{tool["slug"]}/sw.js')
 
     og = tool['dir'] / 'og.png'
     if og.is_file():
@@ -226,7 +254,7 @@ def tool_css(tool):
 # One prose page (the legal ones)
 
 
-def build_page(out, templates, site, page, footer, css_v):
+def build_page(out, templates, site, page, footer, css_v, emit):
     """A legal page: the site frame around a body.html, and nothing else.
 
     No service worker, because there is nothing here worth keeping offline, and
@@ -241,7 +269,7 @@ def build_page(out, templates, site, page, footer, css_v):
     if not body_path.is_file():
         raise sitelib.ConfigError(f'{page["slug"]}: no body.html')
 
-    write(dest / 'index.html', templates.render('page.html', {
+    emit.html(dest / 'index.html', templates.render('page.html', {
         'site': site,
         'page': page,
         'footer': footer,
@@ -251,17 +279,17 @@ def build_page(out, templates, site, page, footer, css_v):
         'body': body_path.read_text(encoding='utf-8').rstrip('\n'),
     }))
 
-    write(dest / 'analytics.js', templates.render('analytics.js', {
+    emit.js(dest / 'analytics.js', templates.render('analytics.js', {
         'site': site,
         'words': {'plural': 'files', 'analytics_extra': ''},
-    }))
+    }), where=f'{page["slug"]}/analytics.js')
 
 
 # ---------------------------------------------------------------------------
 # The hub
 
 
-def build_hub(out, templates, site, planned, by_slug, footer, css_v):
+def build_hub(out, templates, site, planned, by_slug, footer, css_v, emit):
     categories = []
     listed = set()
     for category in site['hub']['categories']:
@@ -290,7 +318,7 @@ def build_hub(out, templates, site, planned, by_slug, footer, css_v):
     for group in planned['group']:
         group['items'] = [{'name': name, 'desc': desc} for name, desc in group['items']]
 
-    write(out / 'index.html', templates.render('hub.html', {
+    emit.html(out / 'index.html', templates.render('hub.html', {
         'site': site,
         'planned': planned,
         'categories': categories,
@@ -301,10 +329,10 @@ def build_hub(out, templates, site, planned, by_slug, footer, css_v):
         'jsonld': sitelib.hub_jsonld(site, ordered),
     }))
 
-    write(out / 'analytics.js', templates.render('analytics.js', {
+    emit.js(out / 'analytics.js', templates.render('analytics.js', {
         'site': site,
         'words': {'plural': 'files', 'analytics_extra': ''},
-    }))
+    }), where='analytics.js')
 
 
 def build_sitemap(out, templates, site, tools, prose):
@@ -340,41 +368,100 @@ def write(path, text):
                     encoding='utf-8', newline='\n')
 
 
+class Emitter:
+    """Writes the HTML and JavaScript, minified or not.
+
+    One object rather than a flag threaded everywhere, because the two things
+    that have to stay together - whether to minify, and what banner to leave
+    behind when we do - belong together.
+
+    The banner is the one comment minifying does not remove. A page that spends
+    four links telling you to go and read the code should not then hand you a
+    file with no way back to it, so every generated file keeps one line saying
+    where it came from and how to prove it.
+    """
+
+    def __init__(self, minify_output, site):
+        self.enabled = bool(minify_output)
+        source = site['source_url']
+        self.js_banner = (f'/* Built from {source} by build.py. '
+                          f'Comments and indentation removed; nothing renamed. '
+                          f'Verify with: python build.py --check */')
+        self.html_banner = (f' Built from {source} by build.py. '
+                            f'Verify with: python build.py --check ')
+
+    def html(self, path, text):
+        write(path, minify.html(text, self.html_banner) if self.enabled else text)
+
+    def js(self, path, text, where):
+        write(path, minify.js(text, self.js_banner, where) if self.enabled else text)
+
+
 def check_against_branch(out, branch='dist'):
-    """Compare a fresh build with what is committed on the dist branch. Used by
-    CI to answer "is the deployed site really a build of these sources?"."""
-    ref = subprocess.run(['git', 'rev-parse', '--verify', f'{branch}^{{tree}}'],
-                         capture_output=True, text=True, cwd=ROOT)
-    if ref.returncode != 0:
-        print(f'\n  no {branch} branch to check against yet', file=sys.stderr)
+    """Compare a fresh build with what is committed on the dist branch. This is
+    the command the pages point at: it answers "is the deployed site really a
+    build of these sources?", which matters more now that what is served is
+    minified and no longer pleasant to read straight off.
+
+    A fresh clone has the branch only as origin/dist, so try that too rather
+    than shrugging and reporting success.
+    """
+    for ref_name in (branch, f'origin/{branch}'):
+        found = subprocess.run(['git', 'rev-parse', '--verify', f'{ref_name}^{{tree}}'],
+                               capture_output=True, text=True, cwd=ROOT)
+        if found.returncode == 0:
+            branch = ref_name
+            break
+    else:
+        print(f'\n  no {branch} branch here to check against '
+              f'(try: git fetch origin {branch})', file=sys.stderr)
         return 0
-    with_worktree = ROOT / '.dist-check'
-    subprocess.run(['git', 'worktree', 'add', '--detach', str(with_worktree), branch],
-                   check=True, cwd=ROOT, capture_output=True)
-    try:
-        differences = compare(out, with_worktree)
-    finally:
-        subprocess.run(['git', 'worktree', 'remove', '--force', str(with_worktree)],
-                       cwd=ROOT, capture_output=True)
+
+    differences = compare(out, branch)
     if differences:
-        print(f'\n  dist branch is out of date ({len(differences)} files):', file=sys.stderr)
+        print(f'\n  {branch} is not this build ({len(differences)} files differ):',
+              file=sys.stderr)
         for name in differences[:20]:
             print(f'    {name}', file=sys.stderr)
+        if len(differences) > 20:
+            print(f'    ... and {len(differences) - 20} more', file=sys.stderr)
         return 1
-    print(f'\n  dist branch matches a fresh build')
+    print(f'\n  {branch} matches a fresh build of these sources')
     return 0
 
 
-def compare(built, committed):
-    def files(root):
-        return {p.relative_to(root).as_posix() for p in root.rglob('*')
-                if p.is_file() and '.git' not in p.parts}
-    a, b = files(built), files(committed)
-    out = sorted((a ^ b))
-    for name in sorted(a & b):
-        if not filecmp.cmp(built / name, committed / name, shallow=False):
-            out.append(name)
-    return out
+def compare(built, branch):
+    """Which files differ between the build and a branch, by content.
+
+    Read out of the object store rather than checked out into a worktree.
+    Checking out runs the files through Git's end-of-line filters, and on a
+    machine with core.autocrlf on that rewrites every text file on the way to
+    disk - which made this report all sixty-odd files as changed when not one
+    of them was. A blob id is the bytes as committed, and nothing can filter
+    it on the way past.
+    """
+    listing = subprocess.run(['git', 'ls-tree', '-r', '-z', branch],
+                             capture_output=True, text=True, cwd=ROOT, check=True)
+    committed = {}
+    for entry in listing.stdout.split('\0'):
+        if not entry:
+            continue
+        info, path = entry.split('\t', 1)
+        committed[path] = info.split()[2]
+
+    fresh = {path.relative_to(built).as_posix(): blob_id(path)
+             for path in built.rglob('*') if path.is_file()}
+
+    names = sorted(set(committed) | set(fresh))
+    return [name for name in names if committed.get(name) != fresh.get(name)]
+
+
+def blob_id(path):
+    """The id Git would give this file's contents: sha1 over the bytes with
+    Git's blob header in front. The same rule Git uses, so the two are
+    comparable without shelling out once per file."""
+    data = path.read_bytes()
+    return hashlib.sha1(b'blob %d\0' % len(data) + data).hexdigest()
 
 
 if __name__ == '__main__':

--- a/buildlib/minify.py
+++ b/buildlib/minify.py
@@ -1,0 +1,449 @@
+"""
+Minifying the generated HTML and JavaScript.
+
+WHAT THIS DOES, AND WHAT IT DELIBERATELY DOES NOT
+
+It removes comments and whitespace. It does not rename anything.
+
+Renaming identifiers - the part of minification that makes code genuinely
+unreadable - needs a real JavaScript parser with scope analysis to do safely,
+because a name is only safe to change once you know every place it is bound and
+every place it is read. Guessing at that with regular expressions is how a
+build silently corrupts a hand-written EXIF parser or an MP4 muxer, and the
+failure would not show up until somebody's file came out wrong. So this does
+not attempt it. If mangled names are wanted, the honest way to get them is a
+real toolchain (esbuild, terser) - see README.md.
+
+What is left is still substantial: these files are heavily commented, and the
+comments are most of their bytes.
+
+SAFETY
+
+Two invariants, both enforced by `check` below on every file the build emits:
+
+  1. Line terminators are never moved. JavaScript inserts semicolons at line
+     breaks, so a minifier that joins lines has to know where a statement ends -
+     which again means parsing. This one keeps every newline exactly where it
+     was, so automatic semicolon insertion behaves identically before and after.
+     That costs about a byte per line and buys certainty.
+
+  2. Re-tokenising the output gives back the same tokens, in the same order, on
+     the same lines, as tokenising the input. If a space were dropped where one
+     was load-bearing - turning `a in b` into `ainb`, or `x + +y` into `x++y` -
+     the token streams would differ and the build fails rather than shipping it.
+
+DETERMINISM
+
+Nothing here depends on the machine, the clock, or the order a directory
+happens to list in. The same sources minify to the same bytes anywhere, which
+is what keeps `python build.py --check` meaningful.
+"""
+
+import json
+import re
+
+# ---------------------------------------------------------------------------
+# JavaScript
+
+# Longest first: the tokeniser takes the first that matches.
+PUNCTUATORS = sorted([
+    '>>>=', '...', '===', '!==', '**=', '<<=', '>>=', '>>>', '&&=', '||=', '??=',
+    '=>', '==', '!=', '<=', '>=', '&&', '||', '??', '?.', '++', '--', '+=', '-=',
+    '*=', '/=', '%=', '&=', '|=', '^=', '**', '<<', '>>',
+    '{', '}', '(', ')', '[', ']', ';', ',', '<', '>', '+', '-', '*', '/', '%',
+    '&', '|', '^', '!', '~', '?', ':', '=', '.', '#', '@',
+], key=len, reverse=True)
+
+# After one of these, a `/` opens a regular expression rather than dividing.
+REGEX_OK_AFTER_WORD = frozenset("""
+    return typeof instanceof in of new delete void throw case do else yield
+    await return
+""".split())
+
+# ... and after any punctuator except these, which can end an expression.
+REGEX_NOT_AFTER_PUNCT = frozenset([')', ']', '}', '++', '--'])
+
+IDENT_START = re.compile(r'[A-Za-z_$\\]')
+IDENT = re.compile(r'[A-Za-z_$\\][A-Za-z0-9_$\\]*')
+NUMBER = re.compile(r'''
+    0[xX][0-9a-fA-F_]+n?
+  | 0[oO][0-7_]+n?
+  | 0[bB][01_]+n?
+  | (?:\d[\d_]*)?\.\d[\d_]*(?:[eE][+-]?\d+)?
+  | \d[\d_]*\.?(?:[eE][+-]?\d+)?n?
+''', re.X)
+
+TWO_CHAR = frozenset(p for p in PUNCTUATORS if len(p) == 2)
+
+# Everything JavaScript treats as whitespace except a line break. The last
+# two are a no-break space and a byte-order mark: both are legal between
+# tokens, both turn up in text pasted out of an editor, and neither may reach
+# the output. Written as escapes so this file stays readable ASCII.
+JS_SPACE = ' \t\r\f\v\u00a0\ufeff'
+
+
+class MinifyError(Exception):
+    pass
+
+
+def _word_char(ch):
+    return ch.isalnum() or ch in '_$\\'
+
+
+def tokenize_js(source, where='<js>'):
+    """Return [(line, text), ...] for every significant token.
+
+    Comments and whitespace are dropped, but a comment that spanned lines still
+    advances the line counter, because a line terminator inside a block comment
+    counts for semicolon insertion exactly as a bare newline does.
+    """
+    tokens = []
+    i, line, n = 0, 1, len(source)
+    prev = None                      # previous significant token text
+
+    while i < n:
+        ch = source[i]
+
+        if ch == '\n':
+            line += 1
+            i += 1
+            continue
+        if ch in JS_SPACE:
+            i += 1
+            continue
+
+        # Comments
+        if source.startswith('//', i):
+            end = source.find('\n', i)
+            i = n if end < 0 else end
+            continue
+        if source.startswith('/*', i):
+            end = source.find('*/', i + 2)
+            if end < 0:
+                raise MinifyError(f'{where}:{line}: unterminated block comment')
+            line += source.count('\n', i, end)
+            i = end + 2
+            continue
+
+        start, start_line = i, line
+
+        # Strings
+        if ch in '\'"':
+            i = _scan_string(source, i, ch, where, line)
+            line += source.count('\n', start, i)
+        # Template literals, which nest: `a${ `b${c}` }d`
+        elif ch == '`':
+            i = _scan_template(source, i, where, line)
+            line += source.count('\n', start, i)
+        # Regular expression, or division
+        elif ch == '/' and _regex_allowed(prev):
+            i = _scan_regex(source, i, where, line)
+        elif ch.isdigit() or (ch == '.' and i + 1 < n and source[i + 1].isdigit()):
+            match = NUMBER.match(source, i)
+            if not match:
+                raise MinifyError(f'{where}:{line}: cannot read number')
+            i = match.end()
+        elif IDENT_START.match(ch):
+            i = IDENT.match(source, i).end()
+        else:
+            for punct in PUNCTUATORS:
+                if source.startswith(punct, i):
+                    i += len(punct)
+                    break
+            else:
+                raise MinifyError(f'{where}:{line}: unexpected character {ch!r}')
+
+        text = source[start:i]
+        tokens.append((start_line, text))
+        prev = text
+
+    return tokens
+
+
+def _scan_string(source, i, quote, where, line):
+    j = i + 1
+    while j < len(source):
+        c = source[j]
+        if c == '\\':
+            j += 2
+            continue
+        if c == quote:
+            return j + 1
+        if c == '\n':
+            raise MinifyError(f'{where}:{line}: newline inside a string')
+        j += 1
+    raise MinifyError(f'{where}:{line}: unterminated string')
+
+
+def _scan_template(source, i, where, line):
+    j, depth = i + 1, 0
+    while j < len(source):
+        c = source[j]
+        if c == '\\':
+            j += 2
+            continue
+        if depth == 0 and c == '`':
+            return j + 1
+        if depth == 0 and source.startswith('${', j):
+            depth, j = depth + 1, j + 2
+            continue
+        if depth:
+            # Inside ${...}: nested strings and templates have to be skipped
+            # whole, or a `}` inside one would close the substitution early.
+            if c in '\'"':
+                j = _scan_string(source, j, c, where, line)
+                continue
+            if c == '`':
+                j = _scan_template(source, j, where, line)
+                continue
+            if c == '{':
+                depth += 1
+            elif c == '}':
+                depth -= 1
+        j += 1
+    raise MinifyError(f'{where}:{line}: unterminated template literal')
+
+
+def _scan_regex(source, i, where, line):
+    j, in_class = i + 1, False
+    while j < len(source):
+        c = source[j]
+        if c == '\\':
+            j += 2
+            continue
+        if c == '\n':
+            raise MinifyError(f'{where}:{line}: newline inside a regular expression')
+        if c == '[':
+            in_class = True
+        elif c == ']':
+            in_class = False
+        elif c == '/' and not in_class:
+            j += 1
+            while j < len(source) and source[j].isalpha():
+                j += 1
+            return j
+        j += 1
+    raise MinifyError(f'{where}:{line}: unterminated regular expression')
+
+
+def _regex_allowed(prev):
+    """Could a `/` here open a regular expression rather than divide?
+
+    The usual heuristic: not after something that can end an expression. The
+    two cases this gets wrong are `if (x) /re/.test(y)` and a `/re/` opening a
+    statement straight after a block - both need to know what the `)` or `}`
+    closed. Neither appears in this repository, and `check` below would catch
+    the damage if one ever did, because the token streams would stop matching.
+    """
+    if prev is None:
+        return True
+    if prev in REGEX_NOT_AFTER_PUNCT:
+        return False
+    if _word_char(prev[0]):
+        return prev in REGEX_OK_AFTER_WORD
+    if prev[0] in '\'"`/':
+        return False
+    return True
+
+
+def _needs_space(a, b):
+    """Would writing `a` and `b` with nothing between them make a third token?"""
+    if not a or not b:
+        return False
+    left, right = a[-1], b[0]
+    if _word_char(left) and _word_char(right):
+        return True
+    # `1 .toString()` - without the space the dot reads as a decimal point.
+    if a[0].isdigit() and right == '.':
+        return True
+    # `+ +x` / `- -x` must not become `++x`, and `/` beside `/` or `*` would
+    # open a comment.
+    if left in '+-' and right in '+-':
+        return True
+    if left == '/' and right in '/*':
+        return True
+    if not _word_char(left) and not _word_char(right) and (left + right) in TWO_CHAR:
+        return True
+    return False
+
+
+def js(source, banner=None, where='<js>'):
+    """Minify JavaScript. Comments go, indentation goes, newlines stay."""
+    tokens = tokenize_js(source, where)
+    out, current_line, parts = [], None, []
+
+    for line, text in tokens:
+        if current_line is None:
+            current_line = line
+        elif line != current_line:
+            out.append(''.join(parts))
+            parts, current_line = [], line
+        if parts and _needs_space(parts[-1], text):
+            parts.append(' ')
+        parts.append(text)
+    if parts:
+        out.append(''.join(parts))
+
+    result = '\n'.join(out)
+    check(source, result, where)
+    if banner:
+        result = banner + '\n' + result
+    return result + '\n' if result else ''
+
+
+def check(source, minified, where):
+    """The output must tokenise to exactly the input's tokens, in order, with a
+    line break between the same pairs of them.
+
+    Not the same line *numbers* - blank lines and comment-only lines are gone,
+    so every number after the first shifts. What has to hold is whether there
+    is a break between one token and the next, because that, and only that, is
+    what decides where a semicolon gets inserted. Anything else means a space
+    was dropped that was holding two tokens apart, or a regular expression was
+    read as a division.
+    """
+    before = tokenize_js(source, where)
+    after = tokenize_js(minified, where + ' (minified)')
+
+    if len(before) != len(after):
+        raise MinifyError(
+            f'{where}: minifying changed the token count '
+            f'({len(before)} -> {len(after)}); refusing to write it')
+
+    for index, ((line_a, text_a), (line_b, text_b)) in enumerate(zip(before, after)):
+        if text_a != text_b:
+            raise MinifyError(
+                f'{where}: minifying changed a token near line {line_a}: '
+                f'{text_a!r} became {text_b!r}; refusing to write it')
+        if index:
+            broke_a = line_a != before[index - 1][0]
+            broke_b = line_b != after[index - 1][0]
+            if broke_a != broke_b:
+                moved = 'lost' if broke_a else 'gained'
+                raise MinifyError(
+                    f'{where}: minifying {moved} a line break before {text_a!r} '
+                    f'at line {line_a}; refusing to write it')
+
+
+# ---------------------------------------------------------------------------
+# HTML
+#
+# Whitespace between HTML elements can be significant - it is the space between
+# two words when the elements are inline - so runs are collapsed to one space
+# rather than removed. That still takes out every line of indentation, which is
+# where the bytes are. Elements whose content is not whitespace-collapsible are
+# copied through untouched.
+
+RAW_TEXT = ('pre', 'textarea', 'script', 'style')
+TAG = re.compile(r'<(/?)([a-zA-Z][-a-zA-Z0-9]*)')
+LD_JSON = re.compile(
+    r'(<script\b[^>]*\btype\s*=\s*["\']application/ld\+json["\'][^>]*>)(.*?)(</script>)',
+    re.S | re.I)
+
+
+def html(source, banner=None):
+    out = []
+    i, n = 0, len(source)
+
+    while i < n:
+        ch = source[i]
+
+        if source.startswith('<!--', i):
+            end = source.find('-->', i + 4)
+            i = n if end < 0 else end + 3
+            continue
+
+        if ch == '<':
+            match = TAG.match(source, i)
+            if match:
+                end = _end_of_tag(source, i)
+                out.append(_collapse_attrs(source[i:end]))
+                name = match.group(2).lower()
+                if not match.group(1) and name in RAW_TEXT:
+                    close = re.compile(r'</\s*' + re.escape(name) + r'\s*>', re.I)
+                    found = close.search(source, end)
+                    stop = found.end() if found else n
+                    out.append(source[end:stop])
+                    i = stop
+                    continue
+                i = end
+                continue
+            # A bare `<` that is not a tag: text, and legal in HTML.
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch.isspace():
+            j = i
+            while j < n and source[j].isspace():
+                j += 1
+            # Nothing before it and nothing after it means nothing to separate.
+            if out and j < n:
+                out.append(' ')
+            i = j
+            continue
+
+        j = i
+        while j < n and source[j] != '<' and not source[j].isspace():
+            j += 1
+        out.append(source[i:j])
+        i = j
+
+    result = ''.join(out).strip()
+    result = LD_JSON.sub(_compact_ld, result)
+    if banner:
+        result = f'<!--{banner}-->' + result
+    return result + '\n'
+
+
+def _end_of_tag(source, i):
+    """Index just past the `>` closing the tag starting at `i`, respecting
+    quoted attribute values - the favicon on every page is a data: URI with a
+    whole SVG, angle brackets and all, inside one attribute."""
+    j, quote = i + 1, None
+    while j < len(source):
+        c = source[j]
+        if quote:
+            if c == quote:
+                quote = None
+        elif c in '"\'':
+            quote = c
+        elif c == '>':
+            return j + 1
+        j += 1
+    return len(source)
+
+
+def _collapse_attrs(tag):
+    """Squeeze the whitespace between attributes, leaving values alone."""
+    out, i, n = [], 0, len(tag)
+    while i < n:
+        c = tag[i]
+        if c in '"\'':
+            end = tag.find(c, i + 1)
+            end = n if end < 0 else end + 1
+            out.append(tag[i:end])
+            i = end
+            continue
+        if c.isspace():
+            while i < n and tag[i].isspace():
+                i += 1
+            # No space needed before the closing `>` or `/>`.
+            if i < n and tag[i] not in '>/':
+                out.append(' ')
+            continue
+        out.append(c)
+        i += 1
+    return ''.join(out)
+
+
+def _compact_ld(match):
+    """Structured data is JSON, so whitespace outside its strings means
+    nothing. Re-serialising is safer than editing the text."""
+    open_tag, body, close_tag = match.groups()
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as err:
+        raise MinifyError(f'structured data is not valid JSON: {err}') from None
+    compact = json.dumps(data, separators=(',', ':'), ensure_ascii=True)
+    return open_tag + compact + close_tag


### PR DESCRIPTION
The generated HTML and JavaScript go out minified. Roughly 28% off the HTML and 40% off the JavaScript; about 200 KB across the site.

WHAT IS REMOVED, AND WHAT IS NOT

Comments and whitespace, and nothing else. There is no bundler and no transpiler: every module is still its own file, still an ES module, still running the same statements in the same order on the same lines. Nothing is renamed, so the served code can still be read and grepped - there is no fetch in it for the same reason there is none in the sources.

Not renaming is a decision, not an unfinished job. Mangling identifiers is the part of minification that makes code genuinely unreadable, and doing it safely needs a real parser with scope analysis, because a name is only safe to change once you know every place it is bound and every place it is read. Guessing at that with regular expressions is how a build silently corrupts a hand-written EXIF parser or an MP4 muxer, and the failure would not show up until somebody's file came out wrong. If mangled names are ever wanted, the honest way to get them is a real toolchain over dist/, accepting the dependency and the loss of a build anyone can reproduce with nothing installed.

HOW IT AVOIDS BREAKING THINGS

buildlib/minify.py checks its own work on every file, and the build fails rather than write something it is not sure about:

  * line breaks never move. JavaScript inserts semicolons at line breaks, so a minifier that joins lines has to know where a statement ends - parsing again. Every newline stays where it was. That costs about a byte per line and buys certainty;
  * the output has to re-tokenise to the input's tokens, in order, with a break between the same pairs of them. A dropped space that turned `a in b` into `ainb`, or `x + +y` into `x++y`, changes that stream and stops the build.

HTML is collapsed rather than stripped, because whitespace between inline elements is the space between two words. Elements whose contents are not collapsible - pre, textarea, script, style - are copied through untouched, and the favicon's data: URI survives having a whole SVG inside one attribute. Structured data is re-serialised as compact JSON rather than edited as text.

The service worker's cache name now hashes the files as emitted rather than as authored, so turning minifying on or off invalidates the cache by itself.

`python build.py --no-minify` gives the readable output back for debugging.

ALSO FIXED

--check has never worked on Windows. It compared a fresh build against a worktree checkout of the dist branch, and checking out runs every file through Git's end-of-line filters, so with core.autocrlf on it reported all sixty-odd files as changed when not one of them was. It now reads blob ids straight out of the object store, which nothing can filter, and falls back to origin/dist when there is no local branch. That command is what the privacy panel points at for proving the deployed site is a build of these sources, and it matters more now that what is served is no longer pleasant to read straight off; it wants to actually work.

Verified: all 33 modules across the four tools load and evaluate; a 1.86 MB image compresses to 98 KB against a 100 KB target; the EXIF parser reads a tag out of a hand-built JPEG; the MP4 muxer produces a file the browser decodes at 640x480. Two builds of the same sources are byte-identical, and an unminified build still matches the deployed dist branch exactly.