### PR TITLE
Say the thing people search for, in the places search engines read

### DIFF
--- a/config/site.toml
+++ b/config/site.toml
@@ -115,7 +115,10 @@ font = "Cookie"
 
 [hub]
 title = "Free Browser Tools &mdash; No Upload, No Sign-In | abox.tools"
-description = "Free online tools that run entirely in your browser. Compress an image to a size you name, crop a video to any shape, convert images to video, strip the EXIF and GPS data out of a photo - nothing is uploaded, no account needed, and it works offline."
+# Kept under 155 characters. Google truncates a description around there, and
+# the tail of this one is the part that sells the site, so it cannot be the
+# part that gets cut.
+description = "Free browser tools that never upload your files. Compress an image to an exact size, crop a video, convert images to video, or strip a photo's EXIF data."
 heading = "A box of tools that never touch a server"
 og_title = "A Box of Tools &mdash; tools that never touch a server"
 og_description = "Small, single-purpose tools that run entirely in your browser. Your files never leave your machine."
@@ -123,8 +126,11 @@ og_image_alt = "abox.tools - tools that never touch a server"
 schema_description = "Small, single-purpose utilities that do all of their work inside your browser. Nothing is uploaded and no account is needed."
 schema_about = "Browser-based file utilities that process files locally without uploading them"
 
+# "tools" rather than "utilities": this is the first line of body copy on the
+# site and the only place the phrase people actually search for can appear
+# early without being forced. The sentence is otherwise unchanged.
 lede = """
-    Small, single-purpose utilities that do all of their work inside your
+    Small, single-purpose tools that do all of their work inside your
     browser. Your files stay on your machine: there is nothing to upload,
     no account to make, and nothing to track."""
 

--- a/pages/privacy/page.toml
+++ b/pages/privacy/page.toml
@@ -7,7 +7,7 @@ slug = "privacy"
 nav = "Privacy &amp; Cookies"          # the label used in the footer
 
 title = "Privacy &amp; Cookies &mdash; abox.tools"
-description = "What abox.tools does and does not collect. Your files are never uploaded; the ads, the visit counter and the donate button are described here in full, with the ways to switch each one off."
+description = "What abox.tools does and does not collect. Your files are never uploaded; the ads, the visit counter and the donate button are each described in full."
 
 heading = "Privacy &amp; Cookies"
 lede = """

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -56,7 +56,7 @@ body {
 
 h1, h2 { line-height: 1.25; }
 
-main, .topbar, .privacy, .pledge, .faq, footer {
+main, .topbar, .crumbs, .privacy, .pledge, .faq, footer {
   max-width: 940px;
   margin-inline: auto;
 }
@@ -93,6 +93,26 @@ main, .topbar, .privacy, .pledge, .faq, footer {
   font-size: 0.88em;
 }
 
+/* -------------------------------------------------------------- breadcrumb */
+
+/* Every tool page already carried BreadcrumbList structured data describing a
+   trail that existed nowhere on the page. Google asks that the markup describe
+   what a visitor can actually see, so here is the trail. It doubles as the way
+   back to the hub from the top of the page rather than only from the footer. */
+
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-top: 0.9rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+.crumbs a { color: var(--text-dim); text-decoration: none; }
+.crumbs a:hover { color: var(--accent); text-decoration: underline; }
+.crumbs [aria-current="page"] { color: var(--text); }
+
 /* ------------------------------------------------------------------ topbar */
 
 .topbar {
@@ -107,6 +127,22 @@ main, .topbar, .privacy, .pledge, .faq, footer {
 .brand { display: flex; align-items: center; gap: 0.85rem; }
 .brand-mark { font-size: 2rem; line-height: 1; }
 .brand h1 { margin: 0; font-size: 1.4rem; letter-spacing: -0.01em; }
+
+/* The keyword half of the heading. The <h1> has to contain the phrase people
+   search for, but the product name is what a returning visitor is looking for,
+   so the phrase is set quieter rather than given equal weight. On a narrow
+   screen it takes its own line instead of squeezing the name. */
+.brand h1 .h1-kw {
+  font-weight: 400;
+  font-size: 0.72em;
+  color: var(--text-dim);
+  letter-spacing: 0;
+}
+
+@media (max-width: 620px) {
+  .brand h1 .h1-kw { display: block; }
+}
+
 .tagline { margin: 0.15rem 0 0; color: var(--text-dim); font-size: 0.9rem; }
 
 .topbar-actions { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -119,6 +119,21 @@
   `source_url` in config/site.toml, so moving the repository is one edit.
 -->
 
+<!--
+  The visible half of the BreadcrumbList in the head. The structured data
+  described a trail that appeared nowhere on the page, which Google asks you not
+  to do: markup is meant to describe what a visitor can see.
+
+  `tool.name` is escaped rather than inserted raw because it is a plain string -
+  "EXIF Viewer & Remover" carries a bare ampersand - unlike `tool.heading`,
+  which is written as markup in tool.toml.
+-->
+<nav class="crumbs" aria-label="Breadcrumb">
+  <a href="../">All tools</a>
+  <span aria-hidden="true">&rsaquo;</span>
+  <span aria-current="page">{{ tool.name | e }}</span>
+</nav>
+
 <header class="topbar">
   <div class="brand">
     <span class="brand-mark" aria-hidden="true">{{ tool.icon }}</span>

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -9,7 +9,9 @@
 
 slug = "compress-image"
 name = "Image Compressor"
-heading = "Image&nbsp;Compressor"
+# The trailing span is the phrase people search for. The product name stays the
+# loud half; see .brand h1 .h1-kw in shared/css/tool-frame.css.
+heading = "Image&nbsp;Compressor <span class=\"h1-kw\">&mdash; compress to an exact size</span>"
 tagline = "Name the size. It works out the rest."
 icon = "&#128476;&#65039;"          # the mark beside the page heading
 favicon = "&#128476;"      # the tab icon, drawn into an inline SVG
@@ -24,7 +26,7 @@ lastmod = "2026-08-19"
 # --- what search engines and chat apps are told ------------------------------
 
 title = "Compress Image to a Target Size &mdash; Free, No Upload"
-description = "Say the size you need - 100 KB, 2 MB, anything - and this finds the least compression that gets there. JPEG, PNG and WebP, entirely in your browser: no upload, no account, and it shows you exactly what the compression cost."
+description = "Compress a JPEG, PNG or WebP to an exact size - 100 KB, 2 MB, anything. Runs entirely in your browser: nothing uploaded, no account, works offline."
 og_title = "Compress an image to a size you choose"
 og_description = "Name a target size and this finds the least compression that reaches it, then measures what that cost. Runs on your own machine; nothing is uploaded."
 og_image_alt = "Image Compressor - name a size, keep the quality"

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -9,7 +9,9 @@
 
 slug = "crop-video"
 name = "Video Cropper"
-heading = "Video&nbsp;Cropper"
+# The trailing span is the phrase people search for. The product name stays the
+# loud half; see .brand h1 .h1-kw in shared/css/tool-frame.css.
+heading = "Video&nbsp;Cropper <span class=\"h1-kw\">&mdash; crop a video online</span>"
 tagline = "Cut a clip down to the part that matters."
 icon = "&#9986;&#65039;"          # the mark beside the page heading
 favicon = "&#9986;"      # the tab icon, drawn into an inline SVG
@@ -19,7 +21,7 @@ lastmod = "2026-08-20"
 # --- what search engines and chat apps are told ------------------------------
 
 title = "Crop a Video Online &mdash; Free, No Upload, Works Offline"
-description = "Crop an MP4, MOV or WebM to any shape - square for a feed, 9:16 for a phone, or an exact pixel box - entirely in your browser. Nothing is uploaded, the sound is kept, and it works offline."
+description = "Crop an MP4, MOV or WebM to any shape - square, 9:16, or an exact pixel box. Runs in your browser: nothing uploaded, the sound is kept, works offline."
 og_title = "Video Cropper &mdash; crop a clip without uploading it"
 og_description = "Drag a box over your clip and crop it to any shape. The frames are decoded and re-encoded on your own machine, and the original sound is carried across untouched."
 og_image_alt = "Video Cropper - crop a clip in your browser, with nothing uploaded"

--- a/tools/exif-editor/tool.toml
+++ b/tools/exif-editor/tool.toml
@@ -9,7 +9,9 @@
 
 slug = "exif-editor"
 name = "EXIF Viewer & Remover"
-heading = "EXIF&nbsp;Viewer &amp; Remover"
+# The trailing span is the phrase people search for. The product name stays the
+# loud half; see .brand h1 .h1-kw in shared/css/tool-frame.css.
+heading = "EXIF&nbsp;Viewer &amp; Remover <span class=\"h1-kw\">&mdash; remove photo metadata</span>"
 tagline = "See what a photo says about you. Then take it out."
 icon = "&#127991;&#65039;"          # the mark beside the page heading
 favicon = "&#127991;"      # the tab icon, drawn into an inline SVG
@@ -24,7 +26,7 @@ lastmod = "2026-08-19"
 # --- what search engines and chat apps are told ------------------------------
 
 title = "EXIF Viewer &amp; Remover &mdash; Free Photo Metadata Editor"
-description = "See the EXIF, GPS and hidden metadata in a photo, edit any of it, or strip the lot in one click. JPEG, PNG and WebP, entirely in your browser - no upload, and the picture is never re-encoded."
+description = "See the EXIF and GPS data hidden in a photo, edit it, or strip the lot in one click. In your browser: nothing uploaded, and the photo is never re-encoded."
 og_title = "EXIF Viewer &amp; Remover &mdash; see it, edit it, or strip it"
 og_description = "Read the metadata hidden in a photo and remove all of it in one click. Runs on your own machine; the picture itself is never re-encoded."
 og_image_alt = "EXIF Viewer and Remover - read, edit or strip the metadata in a photo"

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -9,7 +9,9 @@
 
 slug = "images-to-video"
 name = "Images to Video"
-heading = "Images&nbsp;to&nbsp;Video"
+# The trailing span is the phrase people search for. The product name stays the
+# loud half; see .brand h1 .h1-kw in shared/css/tool-frame.css.
+heading = "Images&nbsp;to&nbsp;Video <span class=\"h1-kw\">&mdash; make an MP4 slideshow</span>"
 tagline = "Turn a folder of images into a video."
 icon = "&#127902;&#65039;"          # the mark beside the page heading
 favicon = "&#127902;"      # the tab icon, drawn into an inline SVG


### PR DESCRIPTION
Acts on the on-page findings from the SEO audit. Sources only &mdash; the built pages come out of `python build.py`, and the build was run and the output checked before committing.

## Meta descriptions: 5 of 7 pages were being truncated

Google stops rendering a description at roughly 155 characters. These were 188&ndash;249, so on every one of them the sentence was cut mid-clause, and the half that got cut was the half that sold the page.

| Page | Before | After |
|---|---|---|
| hub | 249 | 153 |
| `compress-image` | 223 | 147 |
| `exif-editor` | 191 | 154 |
| `crop-video` | 188 | 150 |
| `privacy` | 188 | 150 |

`images-to-video` (147) and `terms` (150) were already in range and are untouched.

Getting under the limit meant deciding what each page's one sentence actually is, rather than listing everything the tool does.

## Tool headings now carry the phrase people type

`<h1>` was the product name only &mdash; "Image Compressor", "Video Cropper". That is what to call it once you already know the site; it is not what anyone searches for. The heading now carries both, with the search phrase set quieter than the name:

- Image Compressor &mdash; compress to an exact size
- Video Cropper &mdash; crop a video online
- EXIF Viewer & Remover &mdash; remove photo metadata
- Images to Video &mdash; make an MP4 slideshow

**This is the most arguable change in the PR** and the easiest to revert: four `heading` lines in `tool.toml` and one CSS rule. On screens under 620px the phrase drops to its own line rather than squeezing the name &mdash; checked at 375px, no horizontal overflow.

## Breadcrumbs are now visible

Every tool page carried `BreadcrumbList` structured data describing a trail that existed nowhere on the page. Google asks that markup describe what a visitor can actually see. It also gives the page a way back to the hub from the top rather than only from the footer.

`tool.name` is escaped with `| e` rather than inserted raw, because unlike `heading` it is a plain string and "EXIF Viewer & Remover" carries a bare ampersand.

## One word in the hub lede

"utilities" to "tools". It is the first line of body copy on the site and the only place the word can appear early without being forced.

## Deliberately not in this PR

- **Explicit AdSense slots.** The audit found Auto Ads running on five pages with zero `<ins>` slots declared, so injected units shift layout after paint. Where ads sit on a page is a design and revenue decision, not a defect to quietly fix. The rule that collapses unfilled slots is already in place; declaring positions should be its own change.
- **Search Console verification.** Not something this repository can do &mdash; it needs the account, via DNS or the HTML file method. This is the single highest-impact item in the audit: the site currently does not appear in search for any query, including its own name.

## Checks

- `python build.py --out _site --clean` &rarr; 8 pages, exit 0
- JSON-LD parses on all five pages that carry it
- All built pages still pure ASCII
- Rendered at 1280px and 375px: no horizontal overflow, breadcrumb sits above the topbar, keyword span reflows as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)
