### PR TITLE
Minify the CSS too, and rename identifiers where esbuild is available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,14 +39,71 @@ jobs:
       - uses: actions/checkout@v4
 
       # The build uses tomllib, which is standard library from 3.11 onwards.
-      # There is nothing to install: no package.json, no requirements.txt, no
-      # lockfile, and no third-party code between these sources and the site.
+      # Python alone produces a working, readable site: that is what plain
+      # `python build.py` does, and it needs nothing installed.
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Build
-        run: python build.py --out _site --clean
+      # esbuild is the one exception, and only for renaming identifiers. The
+      # version is read out of config/site.toml rather than written here as
+      # well, and build.py refuses to run against any other one: two versions of
+      # esbuild need not invent the same names, and `--check` is only worth
+      # something if a fresh build reproduces the deployed bytes exactly.
+      - name: Read the pinned esbuild version
+        id: pin
+        run: |
+          version=$(python -c "import tomllib; print(tomllib.load(open('config/site.toml','rb'))['build']['esbuild_version'])")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "pinned esbuild: $version"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install esbuild
+        run: npm install --global --no-audit --no-fund esbuild@${{ steps.pin.outputs.version }}
+
+      # The readable build, kept as the reference the mangled one is judged
+      # against. Cheap, and it means a file that went missing has something to
+      # go missing from.
+      - name: Build (readable)
+        run: python build.py --out _plain --clean --no-minify
+
+      - name: Build (deployed)
+        run: python build.py --out _site --clean --mangle
+
+      # Renaming is the one step here that could break the site quietly, so it
+      # is checked rather than assumed.
+      #
+      # Every emitted script is parsed by Node as a real ES module - copied to
+      # .mjs first, because a bare .js is read as CommonJS and `import` would be
+      # a syntax error for the wrong reason. A file esbuild had corrupted would
+      # fail here. Then the two builds are compared by filename, so a module
+      # that vanished is caught even if everything left behind parses.
+      - name: Check the mangled output
+        run: |
+          set -euo pipefail
+          work=$(mktemp -d)
+          status=0
+
+          count=0
+          while IFS= read -r script; do
+            cp "$script" "$work/check.mjs"
+            if ! node --check "$work/check.mjs" 2>"$work/err"; then
+              echo "::error file=$script::does not parse after mangling"
+              sed 's/^/    /' "$work/err"
+              status=1
+            fi
+            count=$((count + 1))
+          done < <(find _site -name '*.js' | sort)
+          echo "parsed $count scripts"
+
+          diff <(cd _plain && find . -type f | sort) \
+               <(cd _site  && find . -type f | sort) \
+            || { echo '::error::the two builds do not contain the same files'; status=1; }
+
+          exit $status
 
       - name: Publish to the dist branch
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ python build.py
 ```
 
 Python 3.11 or newer, and nothing to install: the build uses only the standard
-library. There is no `package.json`, no lockfile, and no third-party code
-anywhere between these sources and the site.
+library. There is no `package.json` and no lockfile. The one exception is
+`--mangle`, which renames identifiers and needs esbuild; it is what CI runs and
+what gets deployed, and it is described under
+[What the build does to the output](#what-the-build-does-to-the-output). The
+command above is not that, and never needs it.
 
 To build and serve in one step:
 
@@ -71,6 +74,11 @@ python build.py --check
 That builds, then compares the result file by file with the `dist` branch —
 the branch GitHub Pages serves. If they differ, the deployed site is not what
 this repository says it is, and that is worth knowing.
+
+`--check` implies `--mangle`, so it needs esbuild at the pinned version: the
+deployed branch is mangled, and comparing against it any other way would report
+a difference on every file and mean nothing. The build says which version to
+install if it is missing.
 
 The output is minified, so it is not pleasant reading, but it is still
 *checkable*: the build is deterministic, so the same sources produce the same
@@ -127,7 +135,7 @@ tools/
     tool.toml            everything particular to this tool: prose, FAQ, metadata
     body.html            the <main> of the page - the interface, and only that
     styles.css           the rules only this tool needs
-    src/*.js             the app itself; minified into dist/, never renamed
+    src/*.js             the app itself; minified into dist/, renamed only by --mangle
     og.png               its share card
   crop-video/            the same five things
   exif-editor/           and again
@@ -148,37 +156,85 @@ the domain root, at `/compress-image/`, or nested deeper, with no configuration.
 The service worker registers with the scope of its own folder, so each tool
 caches only itself and cannot interfere with its neighbours.
 
-**The JavaScript keeps its shape.** The build strips comments and indentation
-from `src/*.js` and does nothing else to it. There is no bundler and no
-transpiler: every module is still its own file, still an ES module, still
-running the same statements in the same order on the same lines. **Nothing is
-renamed**, so the served code can still be read and grepped — there is no
-`fetch` in it for the same reason there is none in the sources.
+### What the build does to the output
 
-That stopping point is deliberate. Renaming identifiers is the part of
-minification that makes code genuinely unreadable, and doing it safely needs a
-real parser with scope analysis, because a name is only safe to change once you
-know every place it is bound and every place it is read. Guessing at that is how
-a build silently corrupts a hand-written EXIF parser, and the failure would not
-show up until somebody's photo came out wrong. If mangled names are ever wanted,
-the honest way to get them is a real toolchain (esbuild, terser) run over
-`dist/`, accepting the dependency and the loss of a build anyone can reproduce
-with nothing installed.
+There are two builds, and the difference between them is the point.
 
-`buildlib/minify.py` checks its own work on every file it writes, and the build
-fails rather than shipping something it is not sure about:
+| | `python build.py` | `python build.py --mangle` |
+|---|---|---|
+| Needs | Python 3.11+, nothing else | …and esbuild, at the pinned version |
+| HTML | comments and whitespace out | same |
+| CSS | comments and whitespace out | same |
+| JavaScript | comments and whitespace out, **nothing renamed** | renamed as well |
+| Used by | anyone, anywhere | CI, and so the deployed site |
 
-- **Line breaks never move.** JavaScript inserts semicolons at line breaks, so a
-  minifier that joins lines has to know where a statement ends — which again
-  means parsing. Every newline stays exactly where it was, which costs about a
-  byte per line and buys certainty.
-- **The output must re-tokenise to the input's tokens**, in order, with a break
+The plain build is the default and stays the default. It produces a working,
+readable site with nothing installed, which is what makes the claims on these
+pages checkable by someone who has not already agreed to trust a toolchain.
+
+**Sizes.** HTML 28% smaller, CSS 39%, JavaScript 40% before renaming — about
+36% off the text weight of the site. Renaming takes more off on top of that.
+
+**Nothing is reordered, merged or rewritten.** No shorthand is collapsed, no
+colour re-spelled, no rule moved. Those are the transformations that make a
+minifier impressive and also the ones that occasionally change a page.
+
+#### How it avoids breaking things
+
+`buildlib/minify.py` (HTML and JavaScript) and `buildlib/cssmin.py` check their
+own work, and the build fails rather than write something it is unsure of:
+
+- **Line breaks never move in JavaScript.** The language inserts semicolons at
+  line breaks, so a minifier that joins lines has to know where a statement
+  ends — which means parsing. Every newline stays where it was: about a byte per
+  line, in exchange for certainty.
+- **The JavaScript must re-tokenise to the same tokens**, in order, with a break
   between the same pairs of them. A dropped space that turned `a in b` into
   `ainb`, or `x + +y` into `x++y`, changes that stream and stops the build.
+- **CSS whitespace collapses, it does not vanish.** A space between two
+  selectors is the descendant combinator, and a space between two values is what
+  separates them. A custom property's value is copied across untouched, because
+  it is an unparsed token stream where `--op: +` is a real thing people write.
+- **HTML whitespace collapses to one space** rather than being removed, because
+  between two inline elements it is the space between two words. `pre`,
+  `textarea`, `script` and `style` are copied through whole.
 
-Roughly: HTML 28% smaller, JavaScript 40% smaller. CSS is left alone.
+The CSS is also checked against a real CSS parser rather than against this
+repository's own idea of the answer: load the minified and the readable sheet
+into a browser, and every rule and every custom property comes back the same.
 
-`python build.py --no-minify` gives the readable output back while debugging.
+#### Renaming, and what it costs
+
+`--mangle` hands each module to **esbuild**, which has the parser and the scope
+analysis that renaming safely requires — a name is only safe to change once you
+know every place it is bound and every place it is read. That is not something
+to hand-roll: guessing at it is how a build silently corrupts a hand-written
+EXIF parser, and the failure would not show up until somebody's photo came out
+wrong. Exported names are never renamed, so the module graph is untouched;
+nothing is bundled, so every module keeps its own file.
+
+The cost is real and worth stating. It is the only step in this repository that
+needs something installed, and it is why the plain build still exists.
+
+The version is **pinned in `config/site.toml` and verified**, not merely
+requested. Two versions of esbuild need not invent the same names, and if the
+checker and the deploy disagree then `--check` reports tampering where there was
+none — worse than having no checker. The build refuses to run against any other
+version, and says which one to install.
+
+```bash
+npm install --global esbuild@0.25.0
+```
+
+#### Which command to run
+
+```bash
+python build.py              # readable, no dependencies, the default
+python build.py --no-minify  # readable and unminified, for debugging
+python build.py --mangle     # what CI builds and what is deployed
+python build.py --check      # implies --mangle: it compares against the deploy
+```
+
 Whichever way it runs, the build never reaches the network.
 
 ### What the build stopped anyone having to remember

--- a/build.py
+++ b/build.py
@@ -5,6 +5,7 @@ Build the site into dist/.
     python build.py              build into dist/
     python build.py --clean      empty dist/ first
     python build.py --no-minify  leave the output readable, for debugging
+    python build.py --mangle     rename identifiers too (needs esbuild)
     python build.py --check      build, then fail if dist/ differs from git's
                                  copy of the branch it is committed on
 
@@ -32,22 +33,27 @@ Every one of those is now a thing the build does:
   * a service worker's asset list is read off the disk, and its cache name is a
     hash of those files, so it changes exactly when they do.
 
-WHAT IT DOES TO THE JAVASCRIPT
+WHAT IT DOES TO THE HTML, CSS AND JAVASCRIPT
 
-It strips comments and indentation, and nothing else. There is no bundler and
-no transpiler: every module is still its own file, still an ES module, still
-running the same statements in the same order on the same lines. Names are not
-rewritten, so the served code can still be read and grepped - there is no
-`fetch` in it for the same reason there is none in the sources.
+By default: strips comments and whitespace, and nothing else. No bundler, no
+transpiler, no renaming. Every module is still its own file, still an ES module,
+still running the same statements in the same order on the same lines, and the
+served code can still be read and grepped. buildlib/minify.py and
+buildlib/cssmin.py do that work and explain what they will not touch and why;
+minify.py checks its own output on every file, and the build fails rather than
+ship something whose tokens moved.
 
-That is a deliberate stopping point, not a limitation to be fixed later.
-Renaming identifiers needs a real parser with scope analysis; guessing at it is
-how a build silently corrupts a hand-written EXIF parser. buildlib/minify.py
-says more, and checks its own work on every file: if minifying ever changed a
-token or moved a line break, the build fails instead of shipping it.
+With --mangle: identifiers are renamed as well, by esbuild, pinned to the
+version in config/site.toml. That is what CI runs and what gets deployed, and it
+is the one thing here that needs something installed. Plain `python build.py`
+still needs nothing but Python and still produces a working, readable site -
+which is the point, because a claim nobody can reproduce is not a claim.
+buildlib/mangle.py sets out what that costs.
 
-Pass --no-minify to get the readable output back while debugging. The site
-never reaches the network at build time either way.
+--check implies --mangle, because the deployed branch is mangled and comparing
+against it any other way would report a difference on every file.
+
+The build never reaches the network, whichever way it runs.
 """
 
 import argparse
@@ -59,6 +65,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+from buildlib import cssmin
+from buildlib import mangle
 from buildlib import minify
 from buildlib import site as sitelib
 from buildlib.template import Loader, TemplateError
@@ -77,14 +85,22 @@ def main(argv=None):
     parser.add_argument('--clean', action='store_true', help='empty the output first')
     parser.add_argument('--no-minify', dest='minify', action='store_false',
                         help='leave the output readable, for debugging')
+    parser.add_argument('--mangle', action='store_true',
+                        help='also rename identifiers, using the pinned esbuild')
     parser.add_argument('--check', action='store_true',
                         help='fail if the output differs from the committed dist branch')
     args = parser.parse_args(argv)
 
     out = (ROOT / args.out).resolve()
+    # --check compares against the deployed branch, and the deployed branch is
+    # mangled, so checking without mangling would report a difference on every
+    # file and mean nothing.
+    want_mangle = args.mangle or args.check
     try:
-        pages = build(out, clean=args.clean, minify_output=args.minify)
-    except (sitelib.ConfigError, TemplateError, minify.MinifyError) as err:
+        pages = build(out, clean=args.clean, minify_output=args.minify,
+                      mangle_names=want_mangle)
+    except (sitelib.ConfigError, TemplateError, minify.MinifyError,
+            cssmin.CssError, mangle.MangleError) as err:
         print(f'build failed: {err}', file=sys.stderr)
         return 1
 
@@ -97,17 +113,21 @@ def main(argv=None):
     return 0
 
 
-def build(out, clean=False, minify_output=True):
+def build(out, clean=False, minify_output=True, mangle_names=False):
     if clean and out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True, exist_ok=True)
 
     templates = Loader(TEMPLATES)
     site = sitelib.load_toml(CONFIG / 'site.toml')
-    emit = Emitter(minify_output, site)
+    emit = Emitter(minify_output, site, mangle_names)
     # The hub and the legal pages share one stylesheet, so they share one
     # version for it. Tool pages each hash their own assembled sheet.
-    css_v = sitelib.text_hash((SHARED / 'site.css').read_text(encoding='utf-8'))
+    # Minified first, then hashed: the version in the URL has to be a hash of
+    # the bytes a browser actually receives, or turning minifying on would serve
+    # new CSS under the old version and leave returning visitors on the stale one.
+    site_css = emit.css_text((SHARED / 'site.css').read_text(encoding='utf-8'))
+    css_v = sitelib.text_hash(site_css)
     planned = sitelib.load_toml(CONFIG / 'planned.toml')
 
     tools = [sitelib.load_tool(path, site)
@@ -149,6 +169,7 @@ def build(out, clean=False, minify_output=True):
     written.append('sitemap.xml')
 
     copy_shared(out)
+    write(out / 'site.css', site_css)
     return written
 
 
@@ -185,7 +206,7 @@ def build_tool(out, templates, site, tool, footer, emit):
     # what is in it. The service worker below precaches that same URL: it
     # matches on the whole request, query and all, so a mismatch would leave a
     # tool styled online and bare offline.
-    css = tool_css(tool)
+    css = emit.css_text(tool_css(tool))
     css_href = f'styles.css?v={sitelib.text_hash(css)}'
 
     emit.html(dest / 'index.html', templates.render('tool.html', {
@@ -350,7 +371,10 @@ def copy_shared(out):
     """Everything in shared/ that is served as-is. shared/css is not: it is an
     input to the stylesheets the build assembles, not a file anyone fetches."""
     for path in sorted(SHARED.iterdir()):
-        if path.name == 'css':
+        # shared/css is an input to the stylesheets the build assembles, not a
+        # file anyone fetches; site.css is written separately, minified, by the
+        # caller - copying the source over it here would undo that.
+        if path.name in ('css', 'site.css'):
             continue
         if path.is_dir():
             shutil.copytree(path, out / path.name, dirs_exist_ok=True)
@@ -369,7 +393,7 @@ def write(path, text):
 
 
 class Emitter:
-    """Writes the HTML and JavaScript, minified or not.
+    """Writes the HTML, CSS and JavaScript, minified or not.
 
     One object rather than a flag threaded everywhere, because the two things
     that have to stay together - whether to minify, and what banner to leave
@@ -381,20 +405,53 @@ class Emitter:
     where it came from and how to prove it.
     """
 
-    def __init__(self, minify_output, site):
+    def __init__(self, minify_output, site, mangle_names=False):
         self.enabled = bool(minify_output)
         source = site['source_url']
-        self.js_banner = (f'/* Built from {source} by build.py. '
-                          f'Comments and indentation removed; nothing renamed. '
-                          f'Verify with: python build.py --check */')
-        self.html_banner = (f' Built from {source} by build.py. '
-                            f'Verify with: python build.py --check ')
+
+        # Mangling is opt-in and needs esbuild at the pinned version. Resolved
+        # once, here, so a missing or wrong esbuild stops the build before it
+        # has written half a site rather than partway through.
+        self.esbuild = None
+        if mangle_names:
+            if not self.enabled:
+                raise mangle.MangleError(
+                    '--mangle and --no-minify contradict each other: mangling is '
+                    'minifying, and more of it.')
+            pinned = site.get('build', {}).get('esbuild_version')
+            if not pinned:
+                raise mangle.MangleError(
+                    'no esbuild_version pinned under [build] in config/site.toml, '
+                    'so the build could not be reproduced from it.')
+            self.esbuild = mangle.resolve(pinned)
+            mangle.require_version(self.esbuild, pinned)
+        # The same sentence in three comment syntaxes. Each minifier wraps it
+        # itself, so what is kept here is the text with no delimiters on it.
+        verify = (f'Built from {source} by build.py. '
+                  f'Verify with: python build.py --check')
+        self.js_banner = f'/* {verify} */'
+        self.js_mangled_banner = f'/* {verify} (names mangled by esbuild) */'
+        self.html_banner = f' {verify} '
+        self.css_banner = f' {verify} '
 
     def html(self, path, text):
         write(path, minify.html(text, self.html_banner) if self.enabled else text)
 
     def js(self, path, text, where):
-        write(path, minify.js(text, self.js_banner, where) if self.enabled else text)
+        if self.esbuild:
+            # esbuild does the whitespace as well as the names, so the Python
+            # minifier stands aside rather than running first and being redone.
+            write(path, mangle.js(text, self.esbuild, self.js_mangled_banner, where))
+        elif self.enabled:
+            write(path, minify.js(text, self.js_banner, where))
+        else:
+            write(path, text)
+
+    def css_text(self, text):
+        """Returns rather than writes, because a stylesheet has to be hashed
+        after minifying and before being written - the hash goes in the URL the
+        page asks for it by."""
+        return cssmin.css(text, self.css_banner) if self.enabled else text
 
 
 def check_against_branch(out, branch='dist'):

--- a/buildlib/cssmin.py
+++ b/buildlib/cssmin.py
@@ -1,0 +1,249 @@
+"""
+Minifying CSS.
+
+The same bargain as the JavaScript half: take out what is certainly not needed,
+and leave anything whose meaning depends on context alone.
+
+WHAT IS SAFE TO REMOVE, AND WHAT LOOKS SAFE AND IS NOT
+
+  * Comments, always.
+
+  * Whitespace runs collapse to one space. They do not disappear, because a
+    space between two simple selectors is the descendant combinator - `.a .b`
+    and `.a.b` are different rules - and a space between two values is what
+    separates them: `margin: 1px 2px`, `grid-template-columns: 1fr 2fr`,
+    `font: bold 12px/1.4 serif`.
+
+  * The space around `{`, `}`, `;` and `,` goes. None of those can be part of a
+    value that cares.
+
+  * The space after `:` goes only inside a declaration. In a selector it is a
+    combinator: `a :hover` matches a hovered descendant of `a`, `a:hover`
+    matches a hovered `a`. Telling the two apart needs to know whether the
+    current block holds declarations or more rules, which is what BLOCK_AT_RULES
+    and the depth tracking below are for.
+
+  * The space around `>`, `+` and `~` goes only in a selector. In a value those
+    are arithmetic: `calc(100% - 2rem)` needs its spaces, and `calc(100%-2rem)`
+    is invalid.
+
+  * The last `;` before a `}` goes.
+
+Nothing is reordered, nothing is merged, no shorthand is rewritten and no colour
+is re-spelled. Those are the transformations that make a CSS minifier fast and
+also the ones that occasionally change a page, and the bytes they would save
+here are not worth the argument.
+"""
+
+import re
+
+# At-rules whose body holds rules rather than declarations, so inside them we
+# are still reading selectors and a `:` may be a pseudo-class.
+BLOCK_AT_RULES = frozenset([
+    'media', 'supports', 'document', 'layer', 'container', 'scope', 'starting-style',
+])
+
+AT_RULE = re.compile(r'@([-a-zA-Z]+)')
+
+
+class CssError(Exception):
+    pass
+
+
+def css(source, banner=None):
+    out = []
+    # True while the next `{` will open a block of declarations rather than a
+    # block of rules. Selector context is the default: the top level of a file.
+    stack = []
+    in_declarations = False
+    i, n = 0, len(source)
+    at_rule = None
+
+    while i < n:
+        ch = source[i]
+
+        # Comments
+        if source.startswith('/*', i):
+            end = source.find('*/', i + 2)
+            if end < 0:
+                raise CssError('unterminated comment')
+            i = end + 2
+            continue
+
+        # Strings are copied whole: they may hold anything at all.
+        if ch in '"\'':
+            end = _end_of_string(source, i)
+            out.append(source[i:end])
+            i = end
+            continue
+
+        # url(...) without quotes is its own little grammar, and the thing
+        # inside it may contain characters that mean something everywhere else.
+        if (ch in 'uU' and source[i:i + 4].lower() == 'url('
+                and not _last_is_ident_char(out)):
+            end = source.find(')', i)
+            if end < 0:
+                raise CssError('unterminated url()')
+            out.append('url(' + source[i + 4:end].strip() + ')')
+            i = end + 1
+            continue
+
+        # A custom property's value is not parsed until it is substituted, so it
+        # is an arbitrary run of tokens and every space in it is potentially
+        # load-bearing: `--op: +` exists to be dropped into a calc(). Copy the
+        # whole value across untouched, from the colon to the semicolon that
+        # ends it. Only the whitespace at the two ends goes, which the browser
+        # trims anyway.
+        if (in_declarations and source.startswith('--', i)
+                and _last_char(out) in ('{', ';', '')):
+            colon = source.find(':', i)
+            if colon < 0:
+                raise CssError('custom property with no value')
+            end = _end_of_value(source, colon + 1)
+            out.append(source[i:colon].rstrip() + ':')
+            out.append(source[colon + 1:end].strip())
+            i = end
+            continue
+
+        if ch.isspace():
+            j = i
+            while j < n and source[j].isspace():
+                j += 1
+            nxt = source[j] if j < n else ''
+            if not _drop_space(_last_char(out), nxt, in_declarations):
+                out.append(' ')
+            i = j
+            continue
+
+        if ch == '@':
+            match = AT_RULE.match(source, i)
+            at_rule = match.group(1).lower() if match else None
+
+        if ch == '{':
+            stack.append(in_declarations)
+            # An at-rule with a rule body keeps us reading selectors; anything
+            # else - a normal rule, @font-face, @page, @keyframes' inner steps -
+            # opens declarations.
+            in_declarations = not (at_rule in BLOCK_AT_RULES)
+            at_rule = None
+            _rstrip_space(out)
+            out.append('{')
+            i += 1
+            continue
+
+        if ch == '}':
+            # `;}` -> `}`: the last semicolon in a block is optional.
+            _rstrip_space(out)
+            while out and out[-1] == ';':
+                out.pop()
+            out.append('}')
+            in_declarations = stack.pop() if stack else False
+            at_rule = None
+            i += 1
+            continue
+
+        if ch == ';':
+            _rstrip_space(out)
+            # Never two in a row, and never one straight after `{`.
+            if out and out[-1] in (';', '{'):
+                i += 1
+                continue
+            out.append(';')
+            at_rule = None
+            i += 1
+            continue
+
+        if ch == ',':
+            _rstrip_space(out)
+            out.append(',')
+            i += 1
+            continue
+
+        out.append(ch)
+        i += 1
+
+    result = ''.join(out).strip()
+    if banner:
+        result = f'/*{banner}*/' + result
+    return result + '\n'
+
+
+def _last_char(out):
+    return out[-1][-1] if out and out[-1] else ''
+
+
+def _last_is_ident_char(out):
+    ch = _last_char(out)
+    return ch.isalnum() or ch in '-_'
+
+
+def _rstrip_space(out):
+    while out and out[-1] == ' ':
+        out.pop()
+
+
+def _drop_space(prev, nxt, in_declarations):
+    """Can the whitespace between `prev` and `nxt` simply go?"""
+    if not prev or not nxt:
+        return True
+    # Nothing needs separating from a brace, a semicolon or a comma. A comma is
+    # a delimiter everywhere it can legally appear - between selectors, between
+    # the arguments of a function, between the layers of a shorthand - so the
+    # space beside it is never doing any work. The one place that would not hold
+    # is inside a custom property, and those never reach here: their values are
+    # copied across whole.
+    if prev in '{};,' or nxt in '{};,':
+        return True
+    # `color: red` -> `color:red`, but only where `:` introduces a value.
+    if in_declarations and (prev == ':' or nxt == ':'):
+        return True
+    # Combinators bind selectors; in a value the same characters are arithmetic.
+    if not in_declarations and (prev in '>+~' or nxt in '>+~'):
+        return True
+    # Inside a function call, a space before `)` never matters.
+    if nxt == ')' or prev == '(':
+        return True
+    if prev == '!' or nxt == '!':          # `color: red !important`
+        return prev == '!'
+    return False
+
+
+def _end_of_value(source, i):
+    """Index of the `;` or `}` that ends a declaration value, skipping over
+    anything nested inside brackets or quotes on the way."""
+    depth = 0
+    while i < len(source):
+        ch = source[i]
+        if ch in '"\'':
+            i = _end_of_string(source, i)
+            continue
+        if source.startswith('/*', i):
+            end = source.find('*/', i + 2)
+            if end < 0:
+                raise CssError('unterminated comment')
+            i = end + 2
+            continue
+        if ch in '([{':
+            depth += 1
+        elif ch in ')]':
+            depth -= 1
+        elif ch == '}':
+            if depth == 0:
+                return i
+            depth -= 1
+        elif ch == ';' and depth == 0:
+            return i
+        i += 1
+    return len(source)
+
+
+def _end_of_string(source, i):
+    quote, j = source[i], i + 1
+    while j < len(source):
+        if source[j] == '\\':
+            j += 2
+            continue
+        if source[j] == quote:
+            return j + 1
+        j += 1
+    raise CssError('unterminated string')

--- a/buildlib/mangle.py
+++ b/buildlib/mangle.py
@@ -1,0 +1,120 @@
+"""
+Identifier mangling, via esbuild.
+
+This is the part buildlib/minify.py deliberately refuses to do by hand. Renaming
+a variable is only safe once you know every place it is bound and every place it
+is read, which means a real parser with real scope analysis. esbuild has one.
+
+WHAT THIS COSTS, STATED PLAINLY
+
+Everything else in this repository builds with Python and nothing else, so that
+anyone can check the site's claims without first installing a tree of
+dependencies. This breaks that, for the JavaScript, when it is switched on:
+
+  * `python build.py` still needs nothing but Python, and still produces a
+    readable, working site. That is the default and it stays the default.
+  * `python build.py --mangle` needs esbuild, at the exact version named in
+    config/site.toml. It is what CI runs and what is deployed.
+  * `python build.py --check` therefore needs esbuild too, because it compares
+    against the deployed branch, and the deployed branch is mangled.
+
+The version is pinned and verified rather than merely requested. Two versions of
+esbuild do not have to agree on the names they invent, and if the checker and
+the deploy disagree then `--check` says the site has been tampered with when it
+has not - which is worse than not having a checker at all.
+
+WHAT IS PASSED TO IT, AND WHY
+
+  --minify            whitespace, identifiers and syntax
+  --format=esm        every file here is an ES module and stays one; nothing is
+                      bundled, so each module keeps its own file and its own
+                      imports, and the service worker's asset list still matches
+  --target=esnext     no lowering. The output uses the same syntax the source
+                      does, so nothing is rewritten for a browser that is not
+                      being targeted anyway
+  --legal-comments=none   the banner below is the only comment that survives
+  --sourcefile=       gives esbuild a name to put in an error message, since the
+                      source arrives on stdin
+
+Exported names are never renamed - they cannot be, because another module
+imports them - so the module graph is untouched. What changes is the names of
+things inside a function, which nothing outside can see.
+"""
+
+import shutil
+import subprocess
+
+
+class MangleError(Exception):
+    pass
+
+
+def resolve(pinned, command=None):
+    """Find esbuild, or say clearly what to do about it."""
+    found = shutil.which(command or 'esbuild')
+    if not found:
+        raise MangleError(
+            'esbuild is needed to rename identifiers, and is not on PATH.\n'
+            f'    Install the pinned version:  npm install --global esbuild@{pinned}\n'
+            '    Or leave it out: plain `python build.py` produces a working,\n'
+            '    readable site with nothing but Python.')
+    return found
+
+
+def version(command):
+    try:
+        result = subprocess.run([command, '--version'],
+                                capture_output=True, text=True, timeout=60)
+    except OSError as err:
+        raise MangleError(f'could not run {command}: {err}') from None
+    if result.returncode != 0:
+        raise MangleError(f'{command} --version failed: {result.stderr.strip()}')
+    return result.stdout.strip()
+
+
+def require_version(command, wanted):
+    """Refuse to run against a version other than the pinned one.
+
+    Not pedantry: esbuild does not promise that two versions invent the same
+    names, and the whole value of `--check` is that a fresh build reproduces the
+    deployed bytes exactly. A near-miss version would make it report tampering
+    where there was none.
+    """
+    found = version(command)
+    if found != wanted:
+        raise MangleError(
+            f'esbuild {wanted} is pinned in config/site.toml but {command} is {found}.\n'
+            f'    Install the pinned one:  npm install --global esbuild@{wanted}\n'
+            f'    or change esbuild_version in config/site.toml if you mean to move.')
+    return found
+
+
+def js(source, command, banner=None, sourcefile='input.js'):
+    """Minify and mangle one ES module. Source in, source out, no temp files."""
+    argv = [
+        command,
+        '--minify',
+        '--format=esm',
+        '--target=esnext',
+        '--loader=js',
+        '--legal-comments=none',
+        f'--sourcefile={sourcefile}',
+        '--log-level=warning',
+    ]
+    if banner:
+        argv.append(f'--banner:js={banner}')
+
+    try:
+        result = subprocess.run(argv, input=source, capture_output=True,
+                                text=True, encoding='utf-8', timeout=120)
+    except OSError as err:
+        raise MangleError(f'could not run esbuild on {sourcefile}: {err}') from None
+
+    if result.returncode != 0:
+        raise MangleError(f'esbuild failed on {sourcefile}:\n{result.stderr.strip()}')
+    if result.stderr.strip():
+        # A warning is not a failure, but on this site it is worth reading.
+        print(f'  esbuild on {sourcefile}: {result.stderr.strip()}')
+    if not result.stdout.strip():
+        raise MangleError(f'esbuild produced nothing for {sourcefile}')
+    return result.stdout

--- a/buildlib/mangle.py
+++ b/buildlib/mangle.py
@@ -32,17 +32,22 @@ WHAT IS PASSED TO IT, AND WHY
   --target=esnext     no lowering. The output uses the same syntax the source
                       does, so nothing is rewritten for a browser that is not
                       being targeted anyway
-  --legal-comments=none   the banner below is the only comment that survives
+  --legal-comments=none   no comment survives; the banner is added afterwards,
+                      here, rather than through esbuild's own flag for it
   --sourcefile=       gives esbuild a name to put in an error message, since the
                       source arrives on stdin
 
 Exported names are never renamed - they cannot be, because another module
 imports them - so the module graph is untouched. What changes is the names of
-things inside a function, which nothing outside can see.
+things inside a function, which nothing outside can see. That is asserted rather
+than assumed: check_imports below reads the imports back off the output and
+fails the build if a single specifier moved.
 """
 
 import shutil
 import subprocess
+
+from buildlib import minify
 
 
 class MangleError(Exception):
@@ -101,8 +106,6 @@ def js(source, command, banner=None, sourcefile='input.js'):
         f'--sourcefile={sourcefile}',
         '--log-level=warning',
     ]
-    if banner:
-        argv.append(f'--banner:js={banner}')
 
     try:
         result = subprocess.run(argv, input=source, capture_output=True,
@@ -117,4 +120,61 @@ def js(source, command, banner=None, sourcefile='input.js'):
         print(f'  esbuild on {sourcefile}: {result.stderr.strip()}')
     if not result.stdout.strip():
         raise MangleError(f'esbuild produced nothing for {sourcefile}')
-    return result.stdout
+
+    output = result.stdout
+    check_imports(source, output, sourcefile)
+
+    # The banner is put on here rather than asked of esbuild.
+    #
+    # esbuild spells that flag two ways: `--banner:js=` when it is building
+    # files, and `--banner=` when it is transforming a stream, which is what
+    # this is. Getting it wrong is not a quiet failure - it refused outright -
+    # but its own advice for the mistake is to write `--banner=js=...`, which
+    # would set the banner to the literal text `js=/* ... */` and put a syntax
+    # error at the top of every module on the site. A comment is one string
+    # concatenation; it does not need to be somebody else's flag.
+    if banner:
+        output = banner + '\n' + output.lstrip('\n')
+    return output
+
+
+def specifiers(text, where):
+    """Every module path this file pulls in: `from "x"`, a bare `import "x"`,
+    and `import("x")`.
+
+    Read off the token stream rather than matched in the raw text. `from` is not
+    a reserved word and the word turns up inside strings and template literals
+    all over this repository - "...data from 'this block is unreadable'" is a
+    real line in the EXIF parser - so a regular expression finds imports that
+    are not there, and finds different ones before and after the comments have
+    been taken out. The tokeniser steps over strings and comments by
+    construction, which is the whole reason it exists.
+    """
+    tokens = [text for _, text in minify.tokenize_js(text, where)]
+    found = []
+    for index, token in enumerate(tokens):
+        rest = tokens[index + 1:index + 3]
+        if token in ('from', 'import') and rest and rest[0][:1] in '"\'':
+            found.append(rest[0][1:-1])
+        elif token == 'import' and len(rest) == 2 and rest[0] == '(' and rest[1][:1] in '"\'':
+            found.append(rest[1][1:-1])
+    return sorted(found)
+
+
+def check_imports(source, output, sourcefile):
+    """Every module this file pulled in, it must still pull in.
+
+    Renaming is safe for the names a module keeps to itself and must not touch
+    the ones it shares. If a specifier went missing, or a new one appeared, then
+    something was bundled or dropped, and the service worker's list of files no
+    longer describes the site. Cheap to check, and it is the one invariant the
+    separate-modules design rests on.
+    """
+    before = specifiers(source, sourcefile)
+    after = specifiers(output, sourcefile + ' (mangled)')
+    if before != after:
+        raise MangleError(
+            f'esbuild changed what {sourcefile} imports.\n'
+            f'    before: {before}\n'
+            f'    after:  {after}\n'
+            '    Every module here keeps its own file; nothing should be bundled.')

--- a/config/site.toml
+++ b/config/site.toml
@@ -22,6 +22,20 @@ contact_email = "hi@abox.tools"
 adsense_client = "ca-pub-5997711677062324"
 analytics_id = "G-SCBN29XZ31"
 
+#
+# The build. `python build.py` needs nothing but Python and produces a readable,
+# working site; that is the default and stays the default. `--mangle` renames
+# identifiers as well, which needs esbuild, and is what CI runs and what gets
+# deployed - so `--check` needs it too.
+#
+# The version is pinned rather than merely requested. Two versions of esbuild do
+# not have to invent the same names, and if the checker and the deploy disagree
+# then --check reports tampering where there was none, which is worse than
+# having no checker at all. The build refuses to run against any other version.
+#
+[build]
+esbuild_version = "0.25.0"
+
 [bmc]
 # Buy Me a Coffee. The build writes their snippet out unchanged; these are the
 # data- attributes it is configured with.


### PR DESCRIPTION
Two additions to what the build does to its output.

CSS, MINIFIED

Comments and whitespace out, 39% off the stylesheets, and nothing else touched: no shorthand collapsed, no colour re-spelled, no rule reordered. Those are the transformations that make a CSS minifier impressive and also the ones that occasionally change a page.

Whitespace collapses rather than vanishing, because a space between two selectors is the descendant combinator and a space between two values is what separates them. The space after a colon only goes inside a declaration - in a selector it is a combinator, and `a :hover` is not `a:hover` - which is what the declaration/selector tracking in cssmin.py is for.

A custom property's value is copied across whole. It is not parsed until it is substituted, so it is an arbitrary run of tokens where every space may be load-bearing: `--op: +` exists to be dropped into a calc(). Writing this the obvious way rewrote those values, which is how the check below earned its keep.

The check is a real CSS parser rather than this repository's own idea of the answer: load the minified sheet and the readable one into a browser and compare what comes back. All five stylesheets return the same rules, and all 129 custom properties across them come back byte for byte identical.

RENAMING, BEHIND A FLAG

`python build.py --mangle` hands each module to esbuild, which has the parser and the scope analysis that renaming safely needs. Exported names are never renamed, so the module graph is untouched; nothing is bundled, so every module keeps its own file and the service worker's asset list still matches.

This is the only step in the repository that needs something installed, and the plain build still exists for exactly that reason:

  * `python build.py` needs nothing but Python and produces a working, readable site. Still the default, and still what anybody can run to check a claim;
  * `--mangle` needs esbuild and is what CI runs and what gets deployed;
  * `--check` implies `--mangle`, because the deployed branch is mangled and comparing against it any other way would report a difference on every file.

The version is pinned in config/site.toml and verified, not merely requested. Two versions of esbuild need not invent the same names, and if the checker and the deploy disagree then --check reports tampering where there was none, which is worse than having no checker. The build refuses to run against any other version and says which one to install.

CI installs the pinned esbuild, builds both ways, and checks the mangled output: every emitted script is parsed by Node as a real ES module, and the two builds are compared by filename so a module that vanished is caught even if what is left parses. There is no Node on the machine this was written on, so that first CI run is where the renaming gets its first real test - the plain build, the CSS minifying and everything else here were verified locally.

Verified locally: two builds byte-identical; all 44 emitted scripts re-tokenise; every stylesheet re-minifies to itself; HTML still pure ASCII; all eight crop-video modules load in a browser with the minified CSS applied and --shadow intact.