### PR TITLE
Add a guides section, and the guide the whole site is an argument for

### DIFF
--- a/build.py
+++ b/build.py
@@ -136,8 +136,13 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
         raise sitelib.ConfigError(f'no tools found under {TOOLS}')
     by_slug = {tool['slug']: tool for tool in tools}
 
-    prose = [sitelib.load_page(path, site)
-             for path in sorted(PAGES.glob('*/page.toml'))]
+    # ** rather than *, because a guide lives at pages/guides/<slug>/ and a
+    # legal page at pages/<slug>/. The slug in each page.toml has to match the
+    # folder either way, so a page cannot end up at a URL nobody wrote down.
+    prose = [sitelib.load_page(path, site, PAGES)
+             for path in sorted(PAGES.glob('**/page.toml'))]
+    guides = [page for page in prose if page['kind'] == 'guide']
+    legal = [page for page in prose if page['kind'] == 'legal']
 
     # What the footer on every page is built from. Derived from the folders that
     # exist rather than written down anywhere, so a new tool or a new legal page
@@ -150,7 +155,8 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
                for slug in category['order'] if slug in by_slug]
     footer = {
         'tools': [{'name': tool['name'], 'slug': tool['slug']} for tool in ordered],
-        'pages': [{'nav': page['nav'], 'slug': page['slug']} for page in prose],
+        'guides': [{'nav': page['nav'], 'slug': page['slug']} for page in guides],
+        'pages': [{'nav': page['nav'], 'slug': page['slug']} for page in legal],
     }
 
     written = []
@@ -165,7 +171,7 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     build_hub(out, templates, site, planned, by_slug, footer, css_v, emit)
     written.append('index.html')
 
-    build_sitemap(out, templates, site, tools, prose)
+    build_sitemap(out, templates, site, tools, guides, legal)
     written.append('sitemap.xml')
 
     copy_shared(out)
@@ -272,17 +278,20 @@ def tool_css(tool):
 
 
 # ---------------------------------------------------------------------------
-# One prose page (the legal ones)
+# One prose page (a legal page or a guide)
 
 
 def build_page(out, templates, site, page, footer, css_v, emit):
-    """A legal page: the site frame around a body.html, and nothing else.
+    """A prose page: the site frame around a body.html, and nothing else.
 
     No service worker, because there is nothing here worth keeping offline, and
     no CSP of its own - it gets the site policy unchanged, which is the point.
     When these pages were written by hand they carried a hand-narrowed copy that
     left out the donate button's origins; one policy in one file ended that
-    argument by making it impossible to have."""
+    argument by making it impossible to have.
+
+    `up` is how the frame climbs back to the root. A legal page sits one level
+    down and a guide two, and neither template should have to know which."""
     dest = out / page['slug']
     dest.mkdir(parents=True, exist_ok=True)
 
@@ -290,12 +299,15 @@ def build_page(out, templates, site, page, footer, css_v, emit):
     if not body_path.is_file():
         raise sitelib.ConfigError(f'{page["slug"]}: no body.html')
 
+    up = '../' * page['depth']
+
     emit.html(dest / 'index.html', templates.render('page.html', {
         'site': site,
         'page': page,
         'footer': footer,
-        'base': '../',
-        'css_href': f'../site.css?v={css_v}',
+        'base': up,
+        'css_href': f'{up}site.css?v={css_v}',
+        'jsonld': sitelib.page_jsonld(site, page),
         'csp': sitelib.render_csp(site['csp']),
         'body': body_path.read_text(encoding='utf-8').rstrip('\n'),
     }))
@@ -356,14 +368,18 @@ def build_hub(out, templates, site, planned, by_slug, footer, css_v, emit):
     }), where='analytics.js')
 
 
-def build_sitemap(out, templates, site, tools, prose):
+def build_sitemap(out, templates, site, tools, guides, legal):
     pages = [{'url': site['domain'], 'lastmod': site['lastmod'],
               'changefreq': 'weekly', 'priority': '1.0'}]
     pages += [{'url': tool['url'], 'lastmod': tool['lastmod'],
                'changefreq': 'monthly', 'priority': '0.8'} for tool in tools]
+    # Guides below the tools and above the legal pages. A tool is what somebody
+    # came for; a guide is how they find out this site exists.
+    pages += [{'url': page['url'], 'lastmod': page['lastmod'],
+               'changefreq': 'monthly', 'priority': '0.6'} for page in guides]
     # The legal pages last, and low: they matter for trust, not for search.
     pages += [{'url': page['url'], 'lastmod': page['lastmod'],
-               'changefreq': 'yearly', 'priority': '0.3'} for page in prose]
+               'changefreq': 'yearly', 'priority': '0.3'} for page in legal]
     write(out / 'sitemap.xml', templates.render('sitemap.xml', {'pages': pages}))
 
 

--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -152,6 +152,51 @@ def tool_jsonld(site, tool):
     return dumps_ld(graph)
 
 
+def page_jsonld(site, page):
+    """Structured data for a prose page, or nothing for a legal one.
+
+    A guide is an Article and says so; a privacy policy is not, and inventing
+    schema for it would be describing the page as something it is not. The
+    template asks for this unconditionally and writes nothing when it is empty,
+    which keeps the "is this page an Article?" decision here rather than in
+    markup."""
+    if page['kind'] != 'guide':
+        return ''
+
+    graph = [
+        {
+            '@type': 'Article',
+            'headline': to_text(page['heading']),
+            'description': to_text(page['description']),
+            'url': page['url'],
+            'datePublished': page['published'],
+            'dateModified': page['lastmod'],
+            'inLanguage': site['lang'],
+            'mainEntityOfPage': {'@type': 'WebPage', '@id': page['url']},
+            'author': {
+                '@type': 'Organization',
+                'name': site['name'],
+                'url': site['domain'],
+            },
+            'publisher': {
+                '@type': 'Organization',
+                'name': site['name'],
+                'url': site['domain'],
+            },
+        },
+        {
+            '@type': 'BreadcrumbList',
+            'itemListElement': [
+                {'@type': 'ListItem', 'position': 1,
+                 'name': site['name'], 'item': site['domain']},
+                {'@type': 'ListItem', 'position': 2,
+                 'name': to_text(page['nav']), 'item': page['url']},
+            ],
+        },
+    ]
+    return dumps_ld(graph)
+
+
 def hub_jsonld(site, tools):
     graph = [
         {
@@ -237,24 +282,56 @@ def load_tool(path, site):
     return tool
 
 
-def load_page(path, site):
+PAGE_KINDS = ('legal', 'guide')
+
+
+def load_page(path, site, root):
     """Read one pages/<slug>/page.toml.
 
-    A page is a prose page that is neither a tool nor the hub - the legal ones.
-    It needs far less than a tool does: no words, no FAQ, no schema, no service
+    A page is a prose page that is neither a tool nor the hub. There are two
+    kinds and they differ only in where they are meant to be read:
+
+      legal - privacy and terms. They matter for trust, not for search, which
+              is why the sitemap gives them the lowest priority it has.
+      guide - written to be found. Same frame, same policy, but it carries
+              Article structured data and sits above the legal pages in the
+              sitemap and the footer.
+
+    Either way it needs far less than a tool does: no words, no FAQ, no service
     worker, and no CSP of its own, because it does nothing the site policy does
-    not already allow."""
+    not already allow.
+
+    The slug is a path, not a name, so a page can live at a depth: `guides/x`
+    is a folder pages/guides/x/ and a URL /guides/x/. It has to match the folder
+    it was found in, the same rule as before, only measured from pages/ rather
+    than from the immediate parent."""
     page = load_toml(path)
     missing = [key for key in REQUIRED_PAGE_KEYS if key not in page]
     if missing:
         raise ConfigError(f'{path}: missing {", ".join(missing)}')
 
-    if page['slug'] != path.parent.name:
+    where = path.parent.relative_to(root).as_posix()
+    if page['slug'] != where:
         raise ConfigError(
-            f'{path}: slug is {page["slug"]!r} but the folder is {path.parent.name!r}')
+            f'{path}: slug is {page["slug"]!r} but the folder is {where!r}')
+
+    page.setdefault('kind', 'legal')
+    if page['kind'] not in PAGE_KINDS:
+        raise ConfigError(
+            f'{path}: kind is {page["kind"]!r}, expected one of {", ".join(PAGE_KINDS)}')
+
+    # A guide is an Article, and an Article has a date it was published as well
+    # as a date it last changed. Required rather than defaulted to `lastmod`,
+    # because the two drift apart the first time a guide is corrected and a
+    # silent default would quietly claim the correction was the original.
+    if page['kind'] == 'guide' and 'published' not in page:
+        raise ConfigError(f'{path}: a guide needs `published`')
 
     page['url'] = f'{site["domain"]}{page["slug"]}/'
     page['dir'] = path.parent
+    # How far this page sits below the root, so the frame around it can point at
+    # the stylesheet and the hub without knowing where it was put.
+    page['depth'] = page['slug'].count('/') + 1
     return page
 
 

--- a/pages/guides/is-it-safe-to-upload-files/body.html
+++ b/pages/guides/is-it-safe-to-upload-files/body.html
@@ -1,0 +1,246 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      For most files, most of the time, uploading is fine. Reputable converters
+      delete what you send within a few hours and have no interest in your
+      holiday photos.
+    </p>
+    <p>
+      The problem is not that they are lying. It is that
+      <strong>you have no way to tell whether they are</strong>. Once a file
+      leaves your machine, every promise about what happens next is a promise you
+      are taking on trust: how long it is kept, who can reach it, whether it is
+      copied to a backup that outlives the deletion timer, what happens to it if
+      the company is sold or breached. None of that is visible from outside.
+    </p>
+    <p>
+      So the useful question is not &ldquo;do I trust this site?&rdquo; It is
+      <strong>&ldquo;does this job need my file to leave at all?&rdquo;</strong>
+      For a large and growing number of jobs the answer is no, and when the
+      answer is no, the trust question stops being one you have to answer.
+    </p>
+  </section>
+
+  <section>
+    <h2>What &ldquo;upload&rdquo; actually does</h2>
+    <p>
+      When a converter asks you to choose a file and then shows you a progress
+      bar, your browser is copying the whole file, byte for byte, across the
+      internet to a computer somebody else owns. That computer writes it to a
+      disk, runs the conversion, writes the result to the same disk, and hands
+      you a link.
+    </p>
+    <p>
+      At that moment your file exists in at least three places you did not
+      choose: the server's disk, whatever logs recorded the request, and often a
+      content delivery network that cached the result so the download is fast.
+      A deletion policy has to reach all three. Most say they do. You cannot
+      check any of them.
+    </p>
+    <p>
+      Worth knowing as well: the file is not the only thing that arrives. The
+      filename goes with it, and so does everything inside the file that you
+      cannot see. A photo straight off a phone typically carries the exact GPS
+      coordinates where it was taken, the time, the camera's serial number, and
+      sometimes an embedded thumbnail of the original image from before you
+      cropped it. People who are careful about the picture are often not careful
+      about that, because nothing on screen shows it to them.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why most tools upload anyway</h2>
+    <p>
+      Not because they want your files. Because for most of the web's life there
+      was no alternative. A browser could not decode a video, re-encode an image
+      at a chosen quality, or parse a file format; a server with FFmpeg and
+      ImageMagick could. Uploading was not a business model, it was the only
+      place the work could happen.
+    </p>
+    <p>
+      That stopped being true recently and quietly. Browsers now ship
+      WebAssembly, which runs the same compiled codecs at close to native speed,
+      WebCodecs, which exposes the hardware video encoder already in your
+      machine, and a Canvas API that can decode and re-encode images directly.
+      The work a server used to be needed for now runs on the device that already
+      has the file.
+    </p>
+    <p>
+      Plenty of tools still upload, and there are honest reasons: an existing
+      pipeline nobody wants to rewrite, a format with no browser-side decoder, a
+      job genuinely too heavy for a phone. There is also a less honest reason,
+      which is that a server is where accounts, quotas and paid tiers live. A
+      tool that runs entirely in your browser is difficult to meter.
+    </p>
+  </section>
+
+  <section>
+    <h2>Four checks you can run yourself</h2>
+    <p>
+      These work on any tool, including this one. None of them requires taking
+      anybody's word for anything, and the first takes about ten seconds.
+    </p>
+
+    <h3>1. Pull the plug</h3>
+    <p>
+      Load the page, then turn off your wi-fi or unplug the cable, and try to use
+      it. A tool that does its work in your browser carries on exactly as before.
+      A tool that uploads stops immediately, because the thing doing the work is
+      no longer reachable.
+    </p>
+    <p>
+      This is the strongest test there is, and the hardest to fake, because it
+      cannot be answered with wording. Either the conversion completes with no
+      network or it does not.
+    </p>
+
+    <h3>2. Watch the Network tab</h3>
+    <p>
+      Open your browser's developer tools, select Network, then use the tool.
+      Every request the page makes is listed with its size. If your 4&nbsp;MB
+      photo was uploaded, there is a 4&nbsp;MB request in that list. If the
+      largest thing leaving the page is a few kilobytes of advertising, it was
+      not.
+    </p>
+    <p>
+      Sort by size and look at the top. You do not need to understand the
+      requests; you need to notice whether one of them is the size of your file.
+    </p>
+
+    <h3>3. Read the Content-Security-Policy</h3>
+    <p>
+      View the page source and look for
+      <code>Content-Security-Policy</code>, near the top. It is a list of the
+      addresses that page is permitted to contact, and it is enforced by your
+      browser rather than by the site's good intentions &mdash; a request to
+      anything not on the list is refused, whatever the code tries.
+    </p>
+    <p>
+      The directive that matters is <code>connect-src</code>, which governs where
+      the page may send data. If it names an address belonging to the site you
+      are on, the page can send your file there. If it names nothing, or only
+      third parties like an ad network, it cannot.
+    </p>
+    <p>
+      A page with no Content-Security-Policy at all is not evidence of anything
+      bad. It just means this particular check has nothing to tell you.
+    </p>
+
+    <h3>4. Read the code</h3>
+    <p>
+      Least convenient, most conclusive. If a tool publishes its source and
+      serves it without a build step, the files your browser fetched are the
+      files you can read. Search them for <code>fetch</code>,
+      <code>XMLHttpRequest</code> and <code>sendBeacon</code> &mdash; the three
+      ways a page can send anything &mdash; and see what they are given.
+    </p>
+    <p>
+      Most people will not do this. It still matters that it is possible,
+      because a claim nobody is able to check is not really a claim.
+    </p>
+  </section>
+
+  <section>
+    <h2>What &ldquo;runs in your browser&rdquo; does not mean</h2>
+    <p>
+      It is worth being precise, because the phrase gets used loosely and this
+      site has to hold itself to the same standard it is proposing.
+    </p>
+    <ul>
+      <li>
+        <strong>It does not mean no requests at all.</strong> The page itself
+        arrived over the network, and most free tools carry advertising or
+        analytics that talk to somebody. The claim is about your
+        <em>file</em>, not about traffic in general.
+      </li>
+      <li>
+        <strong>It does not hide your IP address.</strong> Every site you visit
+        sees it, this one included. Local processing is about the contents of
+        your files, not about anonymity.
+      </li>
+      <li>
+        <strong>It does not survive a feature that fetches something.</strong> A
+        tool that lets you paste a web address has to contact that address, and
+        that server learns your IP and what you asked for. That is inherent to
+        the feature, not a flaw in it &mdash; but it is a real exception and a
+        tool should say so plainly rather than round it off.
+      </li>
+      <li>
+        <strong>It is not the same as &ldquo;we delete your files.&rdquo;</strong>
+        The second sentence is about what a company chooses to do. The first is
+        about what is technically possible. Only one of them is checkable.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>When uploading is genuinely fine</h2>
+    <p>
+      This is not an argument that every upload is a mistake. Send the file when
+      the content is not sensitive and the job is easier that way; when the work
+      really is too heavy for your device; when the format has no browser-side
+      decoder; or when you are using a service you already have a relationship
+      with and whose terms you have actually read.
+    </p>
+    <p>
+      Be more careful when the file contains something you would not post
+      publicly: identity documents, medical scans, contracts, anything with an
+      address or a face you did not intend to share, or a photo whose location
+      data you have not looked at. For those, a tool you can check is worth
+      preferring over a tool you have to trust &mdash; not because the trusted
+      one is likely to betray you, but because with the checkable one the
+      question does not arise.
+    </p>
+  </section>
+
+  <section>
+    <h2>How this site answers those four checks</h2>
+    <p>
+      It would be a strange guide that told you to check and then asked to be
+      exempt. So, in order:
+    </p>
+    <ul>
+      <li>
+        <strong>Pull the plug.</strong> Open any tool here, disconnect, and it
+        keeps working. Each tool page has a live indicator that tells you whether
+        you are currently online, so you can watch it change.
+      </li>
+      <li>
+        <strong>Network tab.</strong> Convert something and read the list.
+        Nothing carries your file, a thumbnail of it, its name, its size, or
+        anything read out of it. There is no custom analytics event on this site
+        that has any of that to send.
+      </li>
+      <li>
+        <strong>Content-Security-Policy.</strong> It is at the top of every
+        page's source. <code>connect-src</code> names Google's advertising and
+        measurement endpoints and the donate button, and nothing else.
+        <strong>No address on that list belongs to this site</strong>, because
+        this site has no server &mdash; it is static files. There is nowhere for
+        a file to be sent even if something tried.
+      </li>
+      <li>
+        <strong>Code.</strong> Every line is
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">public</a>.
+        The build strips comments and whitespace and nothing else, and you can
+        run it yourself and compare the result against what is being served.
+      </li>
+    </ul>
+    <p>
+      The exceptions, stated rather than buried: this site carries Google
+      advertising and a visit counter, both of which talk to Google and neither
+      of which is handed anything about your files; and the
+      <a href="../../images-to-video/">Images to Video</a> tool can fetch an
+      image from an address you paste in, which means that server sees your IP.
+      The <a href="../../privacy/">privacy page</a> sets both out in full.
+    </p>
+    <p>
+      Every tool here works this way: an
+      <a href="../../compress-image/">image compressor</a> that hits a size you
+      name, a <a href="../../crop-video/">video cropper</a>, an
+      <a href="../../exif-editor/">EXIF viewer and remover</a> for the hidden
+      data described further up this page, and
+      <a href="../../images-to-video/">images to video</a>. All free, no account,
+      and none of them has anywhere to send your files.
+    </p>
+  </section>

--- a/pages/guides/is-it-safe-to-upload-files/page.toml
+++ b/pages/guides/is-it-safe-to-upload-files/page.toml
@@ -1,0 +1,33 @@
+#
+# Guide: is it safe to upload files to online converters?
+#
+# The first page on this site written to be found rather than to be used. It
+# answers the question somebody asks just before they hand a photo to a website
+# they have never heard of, and it is the one subject where this site can show
+# its working instead of asserting it: every check in it can be run against this
+# site, or against any other.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/is-it-safe-to-upload-files"
+kind = "guide"
+nav = "Is it safe to upload files?"
+
+title = "Is It Safe to Upload Files to Online Converters?"
+description = "Most online converters send your file to a server. What that means, what happens to it there, and four checks that tell you whether a tool needs to."
+
+heading = "Is it safe to upload files to online converters?"
+lede = """
+    Usually the honest answer is &ldquo;probably, but you cannot check.&rdquo;
+    This explains what uploading actually does with your file, why most tools
+    still do it, and four tests that tell you whether the one in front of you
+    has to."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "Is it safe to upload files to online converters?"
+og_description = "What happens to a file you upload to a converter, why most tools still ask for one, and four checks you can run yourself."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/shared/site.css
+++ b/shared/site.css
@@ -132,6 +132,17 @@ body {
 .g-title { font-weight: 600; font-size: 0.92rem; }
 .g-body { font-size: 0.85rem; line-height: 1.5; color: var(--text-dim); }
 
+/* The line under the three guarantees, pointing at the guide that says how to
+   check them. Quiet: it is a footnote to the claims, not a fourth claim. */
+.guarantees-note {
+  margin: -1.75rem 0 2.75rem;
+  font-size: 0.88rem;
+  color: var(--text-dim);
+  max-width: 68ch;
+}
+
+.guarantees-note a { color: var(--accent); }
+
 code {
   font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Consolas, monospace;
   font-size: 0.92em;

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -121,6 +121,19 @@
 {% endfor %}  </ul>
 
   <!--
+    The three claims above are worth nothing if a reader has no way to test
+    them, and "read our privacy policy" is not a way to test anything. This
+    points at the guide that sets out how to check a tool like this one -
+    including the checks that can be run against this site.
+  -->
+  <p class="guarantees-note">
+    None of that has to be taken on trust.
+    <a href="{{ base }}guides/is-it-safe-to-upload-files/">
+      How to tell whether a tool really needs your files</a>
+    sets out four checks you can run yourself, on this site or any other.
+  </p>
+
+  <!--
     ==========================================================================
     ADDING A TOOL
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -49,6 +49,19 @@
   HTML with max-age=600 and CSS with max-age=14400, so without this a deploy
   reaches a returning visitor as new markup wearing a four-hour-old sheet.
 -->
+<!--
+  Structured data, and only for a guide. A guide is an Article and says so; a
+  privacy policy is not one, and describing it as an Article would be claiming
+  the page is something it is not. buildlib/site.py decides which, and returns
+  nothing for a legal page, so this block simply does not appear on one.
+
+  Inline is deliberate and does not need 'unsafe-inline': a <script> whose type
+  is not a JavaScript type is a data block the parser never executes.
+-->
+{% if jsonld %}<script type="application/ld+json">
+{{ jsonld }}
+</script>
+{% endif %}
 <link rel="stylesheet" href="{{ css_href }}">
 <link rel="icon" href="/logo.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/icon-180.png">
@@ -57,7 +70,7 @@
 
 <header class="hub-head">
   <p class="brand">
-    <a class="brand-home" href="../">
+    <a class="brand-home" href="{{ base }}">
       <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
     </a>
   </p>

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -36,7 +36,8 @@
       <strong>This site</strong>
       <ul>
         <li><a href="{{ base }}">All tools</a></li>
-{% for p in footer.pages %}        <li><a href="{{ base }}{{ p.slug }}/">{{ p.nav }}</a></li>
+{% for g in footer.guides %}        <li><a href="{{ base }}{{ g.slug }}/">{{ g.nav }}</a></li>
+{% endfor %}{% for p in footer.pages %}        <li><a href="{{ base }}{{ p.slug }}/">{{ p.nav }}</a></li>
 {% endfor %}        <li><a href="/sitemap.xml">Sitemap</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Acts on the top item from the second SEO audit: **"is it safe to upload files to online converters"** was the highest-opportunity keyword in the table, and it is the one subject where this site can show its working rather than assert it.

Every competitor answers that question with a promise. This answers it with four tests the reader runs themselves — three of which work on any tool, including ours.

## The guide

`/guides/is-it-safe-to-upload-files/` — 1,745 words. Deliberately **not** about this site until the last section:

- what uploading actually does with a file (three copies you did not choose: server disk, logs, CDN cache — and the filename, GPS coordinates and embedded original thumbnail that travel with a phone photo)
- why most tools still upload — browsers could not decode video or re-encode images until recently; also, a server is where accounts, quotas and paid tiers live
- **four checks**: pull the plug, watch the Network tab, read the `Content-Security-Policy`, read the code
- what "runs in your browser" does *not* mean — not no requests, not anonymity, not a deletion promise
- when uploading is genuinely fine
- only then: how this site answers its own four checks, including both exceptions (ads/analytics, and the images-to-video URL fetch)

## The section around it

`pages/` grew a `kind`, because a guide and a privacy policy want opposite things from a sitemap. The legal pages sit at priority 0.3 under the comment *"they matter for trust, not for search"*; a guide is the reverse, so it gets 0.6/monthly, between the tools and the legal pages.

**Slugs are paths now, not names.** `pages/guides/x/` builds to `/guides/x/`. The frame works out how far down it is rather than assuming one level — `base` and the stylesheet href had that hardcoded, so a nested page would have pointed at a stylesheet that was not there. The rule that a slug must match the folder it was found in still holds, measured from `pages/` instead of the immediate parent.

**Structured data by kind.** A guide gets `Article` + `BreadcrumbList`; a legal page gets none, because inventing schema for a privacy policy would describe it as something it is not. `published` is required for guides rather than defaulted from `lastmod` — the two separate the first time a guide is corrected, and a silent default would claim the correction was the original.

**Linked** from the footer of every page, and from directly under the three guarantees on the hub — where a reader who has just been asked to believe three claims is most likely to want a way to check them.

## Checks

- `python build.py --out _site --clean` → 9 pages, exit 0
- JSON-LD parses on all six pages that carry it; legal pages correctly carry none
- Guide: 1,745 words, title 48 chars, description 148 chars, one H1, 7 H2s, 4 H3s
- Every internal link on the guide resolves; footer link resolves from hub, tool, legal and guide depths
- No horizontal overflow at 375px or 1280px; measure holds at 68ch
- Built HTML/CSS/XML all pure ASCII

## Note

`tools/images-to-pdf/` is untracked in the working tree and is **not** in this PR — it has no `tool.toml` yet so the build ignores it, and it is not mine to commit.

## Not in this PR

The audit's blocking item is still Search Console verification, which this repository cannot do. The site remains unindexed, so this guide will not be found until that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
