### PR TITLE
Make the drop zone a shared part instead of five copies of one

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,9 +296,60 @@ the analytics bootstrap — you get for free and should not reimplement. What a
 tool writes for itself is its interface (`body.html`), its own rules
 (`styles.css`), its own code (`src/`), and its own words (`tool.toml`).
 
-A tool that needs a stylesheet part more than one tool wants, but that no tool
-should own, puts it in `shared/css/` and names it in `css_parts`. The file-list
-widget — drop a file, see a row — works that way.
+### Shared parts
+
+A component more than one tool needs, and that no tool should own, lives under
+`shared/` and is named in the tool's `tool.toml`. Three of them exist:
+
+| Part | Named in | Becomes |
+|---|---|---|
+| `shared/css/file-list.css` | `css_parts = ["file-list"]` | appended to the tool's stylesheet |
+| `shared/js/file-picker.js` | `js_parts = ["file-picker"]` | copied to `<tool>/src/shared/` |
+| `templates/partials/file-picker.html` | `{% include %}` in `body.html` | the drop-zone markup |
+
+The **file picker** is all three at once, and is the reason the arrangement
+exists: the drop zone, the hidden input, the drag highlighting, and the "Reading
+3 files…" label were the same in every tool, written out five times.
+
+```toml
+js_parts = ["file-picker"]
+
+[picker]
+accept = "image/*"
+multiple = true
+title = "Drop images here"
+hint = "or click to browse &mdash; JPEG, PNG, WebP, GIF, AVIF"
+```
+
+```html
+<!-- in body.html -->
+{% include "partials/file-picker.html" %}
+```
+
+```js
+// in src/main.js
+import { wireFilePicker, readingLabel } from './shared/file-picker.js';
+
+const picker = wireFilePicker({
+  input: el.fileInput,
+  dropzone: el.dropzone,
+  onFiles(files) { addFiles(files); },
+});
+```
+
+`picker.busy(readingLabel(files.length))` while reading, `picker.done()` after.
+The resting label is read off the markup, so it is written once, in `tool.toml`,
+rather than there and in the JavaScript as well.
+
+**Shared JavaScript is copied, not linked.** It lands in the tool's own
+`src/shared/`, so every tool folder in `dist/` is still complete on its own,
+cached by its own service worker, and works offline with nothing fetched from a
+neighbour. That is also why a tool's source folder imports a file it does not
+contain — the import path says `./shared/` to make where it came from obvious.
+
+Only *choosing* the files is shared. What a tool does with them afterwards — the
+list, the thumbnails, the reordering, the per-row buttons — differs enough per
+tool that sharing it would cost more than it saved.
 
 Two things to hold the line on, because the whole site rests on them:
 

--- a/build.py
+++ b/build.py
@@ -192,14 +192,24 @@ def build_tool(out, templates, site, tool, footer, emit):
     src_dir = tool['dir'] / 'src'
     if not src_dir.is_dir():
         raise sitelib.ConfigError(f'{tool["slug"]}: no src/ folder')
-    assets = sorted(src_dir.glob('*.js'))
-    if not any(path.name == 'main.js' for path in assets):
+    own = sorted(src_dir.glob('*.js'))
+    if not any(path.name == 'main.js' for path in own):
         raise sitelib.ConfigError(f'{tool["slug"]}: src/main.js is required')
-    (dest / 'src').mkdir(exist_ok=True)
-    for asset in assets:
-        emit.js(dest / 'src' / asset.name,
-                asset.read_text(encoding='utf-8'),
-                where=f'{tool["slug"]}/src/{asset.name}')
+
+    # Shared modules land in src/shared/ rather than beside the tool's own
+    # files, so that an import in main.js says where the thing came from. A tool
+    # folder in dist/ is still complete on its own - nothing is bundled, nothing
+    # is fetched from a neighbour, and the service worker below caches these
+    # exactly like the rest.
+    shared = shared_js(tool)
+    assets = [(f'src/shared/{path.name}', path) for path in shared]
+    assets += [(f'src/{path.name}', path) for path in own]
+
+    for name, path in assets:
+        (dest / name).parent.mkdir(parents=True, exist_ok=True)
+        emit.js(dest / name, path.read_text(encoding='utf-8'),
+                where=f'{tool["slug"]}/{name}')
+
     for extra in sorted(src_dir.iterdir()):
         if extra.is_file() and extra.suffix != '.js':
             shutil.copy2(extra, dest / 'src' / extra.name)
@@ -215,6 +225,13 @@ def build_tool(out, templates, site, tool, footer, emit):
     css = emit.css_text(tool_css(tool))
     css_href = f'styles.css?v={sitelib.text_hash(css)}'
 
+    # body.html goes through the template engine before it is dropped into the
+    # page, so a tool can {% include %} a shared partial - the drop zone being
+    # the one every tool wants - instead of copying the markup for it.
+    body = templates.render_source(
+        body_path.read_text(encoding='utf-8'), f'{tool["slug"]}/body.html',
+        {'site': site, 'tool': tool}).rstrip('\n')
+
     emit.html(dest / 'index.html', templates.render('tool.html', {
         'site': site,
         'tool': tool,
@@ -223,7 +240,7 @@ def build_tool(out, templates, site, tool, footer, emit):
         'csp': sitelib.render_csp(site['csp'], site.get('tool_csp', {}), tool['csp']),
         'css_href': css_href,
         'jsonld': sitelib.tool_jsonld(site, tool),
-        'body': body_path.read_text(encoding='utf-8').rstrip('\n'),
+        'body': body,
     }))
 
     write(dest / 'styles.css', css)
@@ -242,16 +259,33 @@ def build_tool(out, templates, site, tool, footer, emit):
     # cache. Hashing the sources instead would leave a visitor holding the old
     # copy of a file that had genuinely changed.
     cached = ([dest / 'index.html', dest / 'styles.css', dest / 'analytics.js']
-              + [dest / 'src' / asset.name for asset in assets])
+              + [dest / name for name, _ in assets])
     emit.js(dest / 'sw.js', templates.render('sw.js', {
         'tool': tool,
-        'assets': ['index.html', css_href] + [f'src/{p.name}' for p in assets],
+        'assets': ['index.html', css_href] + [name for name, _ in assets],
         'cache_hash': sitelib.cache_hash(cached),
     }), where=f'{tool["slug"]}/sw.js')
 
     og = tool['dir'] / 'og.png'
     if og.is_file():
         shutil.copy2(og, dest / 'og.png')
+
+
+def shared_js(tool):
+    """The shared modules this tool asked for, in `js_parts`.
+
+    The same arrangement as `css_parts` and for the same reason: a component
+    more than one tool needs, and no tool should own. Opt-in rather than given
+    to everybody, so a tool that has no use for a drop zone does not ship one.
+    """
+    chosen = []
+    for name in tool.get('js_parts', []):
+        path = SHARED / 'js' / f'{name}.js'
+        if not path.is_file():
+            raise sitelib.ConfigError(
+                f'{tool["slug"]}: no such js part: {name} (looked in shared/js)')
+        chosen.append(path)
+    return chosen
 
 
 def tool_css(tool):

--- a/buildlib/template.py
+++ b/buildlib/template.py
@@ -188,3 +188,13 @@ class Loader:
 
     def render(self, name, context):
         return self.get(name).render(context)
+
+    def render_source(self, source, name, context):
+        """Render text that did not come from the template directory, but which
+        may still {% include %} something that did.
+
+        A tool's body.html goes through here: it lives beside the tool rather
+        than in templates/, because it is the one part of the page that is only
+        about that tool - but it should still be able to reach for a shared
+        partial like the drop zone instead of copying the markup for it."""
+        return Template(source, loader=self.source, name=name).render(context)

--- a/shared/js/file-picker.js
+++ b/shared/js/file-picker.js
@@ -1,0 +1,101 @@
+/**
+ * The drop zone and the file picker, which every tool here needs and none of
+ * them should own.
+ *
+ * GENERATED INTO EACH TOOL. This file lives at shared/js/file-picker.js and the
+ * build copies it to <tool>/src/shared/file-picker.js, which is why a tool's
+ * source folder imports a file it does not contain. Nothing is bundled: each
+ * tool still gets its own copy, cached by its own service worker, and a tool
+ * folder on the deployed site is still complete on its own. Edit it here.
+ *
+ * WHAT IS SHARED AND WHAT IS NOT
+ *
+ * Only choosing the files. What a tool does with them afterwards - the list, the
+ * thumbnails, the reordering, the per-row buttons - is the tool's own business
+ * and stays in the tool. The markup this drives comes from the same place:
+ * templates/partials/file-picker.html, filled in from the [picker] table in each
+ * tool.toml.
+ *
+ * WHY THERE IS NO CLICK HANDLER
+ *
+ * The drop zone is a <label for="file-input">, so the browser opens the picker
+ * itself. Calling .click() on a display:none input is refused outright by Safari
+ * and by some Chrome configurations, which is the bug this shape avoids. The
+ * input stays in the layout - visually hidden, still focusable, still reachable
+ * by keyboard - and there is no JavaScript in that path at all.
+ */
+
+/**
+ * @typedef {object} Picker
+ * @property {(text: string) => void} busy   drop zone shows it is reading
+ * @property {() => void} done               back to its resting label
+ */
+
+/**
+ * @param {object} options
+ * @param {HTMLInputElement} options.input      the file input
+ * @param {HTMLElement} options.dropzone        the <label> around it
+ * @param {(files: File[]) => void} options.onFiles  called with what was chosen
+ * @param {string} [options.idleTitle]  resting label; taken from the markup if
+ *   left out, so the wording lives in one place rather than two
+ * @returns {Picker}
+ */
+export function wireFilePicker({ input, dropzone, onFiles, idleTitle }) {
+  const titleEl = dropzone.querySelector('.dropzone-title');
+  const idle = idleTitle ?? titleEl?.textContent ?? '';
+
+  const hand = (files) => {
+    const picked = Array.from(files ?? []);
+    if (picked.length) onFiles(picked);
+  };
+
+  input.addEventListener('change', () => {
+    // `input.files` is a live list and resetting `value` empties it, so take a
+    // real array first. Clearing the input is what lets somebody pick the same
+    // file twice in a row.
+    const picked = Array.from(input.files);
+    input.value = '';
+    hand(picked);
+  });
+
+  for (const type of ['dragenter', 'dragover']) {
+    dropzone.addEventListener(type, (event) => {
+      event.preventDefault();
+      dropzone.classList.add('dragover');
+    });
+  }
+
+  for (const type of ['dragleave', 'drop']) {
+    dropzone.addEventListener(type, () => dropzone.classList.remove('dragover'));
+  }
+
+  dropzone.addEventListener('drop', (event) => {
+    event.preventDefault();
+    hand(event.dataTransfer?.files);
+  });
+
+  // A file dropped anywhere else on the page would otherwise be opened by the
+  // browser, navigating away from the app and throwing away everything chosen
+  // so far. Both of these are needed: without the dragover handler the drop
+  // never fires at all.
+  window.addEventListener('dragover', (event) => event.preventDefault());
+  window.addEventListener('drop', (event) => event.preventDefault());
+
+  return {
+    busy(text) {
+      dropzone.classList.add('busy');
+      if (titleEl && text) titleEl.textContent = text;
+    },
+    done() {
+      dropzone.classList.remove('busy');
+      if (titleEl) titleEl.textContent = idle;
+    },
+  };
+}
+
+/**
+ * "Reading 1 file..." / "Reading 4 files...", said the same way everywhere.
+ */
+export function readingLabel(count) {
+  return `Reading ${count} file${count === 1 ? '' : 's'}...`;
+}

--- a/templates/partials/file-picker.html
+++ b/templates/partials/file-picker.html
@@ -1,0 +1,16 @@
+<!--
+  The drop zone. Filled in from the [picker] table in this tool's tool.toml, and
+  driven by src/shared/file-picker.js, which the build copies in from
+  shared/js/.
+
+  A real <label> opens the file picker natively. Calling .click() on a
+  display:none input is refused by Safari and by some Chrome configurations, so
+  the input stays in the layout: visually hidden, still focusable, and reachable
+  by keyboard. There is no JavaScript in that path at all.
+-->
+<input type="file" id="file-input" class="visually-hidden"
+       accept="{{ tool.picker.accept }}"{% if tool.picker.multiple %} multiple{% endif %}>
+<label id="dropzone" class="dropzone" for="file-input">
+  <span class="dropzone-title">{{ tool.picker.title }}</span>
+  <span class="dropzone-hint">{{ tool.picker.hint }}</span>
+</label>

--- a/tools/compress-image/body.html
+++ b/tools/compress-image/body.html
@@ -9,12 +9,7 @@
       so the input stays in the layout: visually hidden, still focusable, and
       reachable by keyboard. There is no JavaScript in this path at all.
     -->
-    <input type="file" id="file-input" class="visually-hidden"
-           accept="image/*,.jpg,.jpeg,.png,.webp,.gif,.bmp,.avif" multiple>
-    <label id="dropzone" class="dropzone" for="file-input">
-      <span class="dropzone-title">Drop images here</span>
-      <span class="dropzone-hint">or click to browse &mdash; JPEG, PNG, WebP and anything else your browser can open</span>
-    </label>
+    {% include "partials/file-picker.html" %}
 
     <div id="list-toolbar" class="toolbar" hidden>
       <span id="count-label" class="count"></span>

--- a/tools/compress-image/src/main.js
+++ b/tools/compress-image/src/main.js
@@ -6,6 +6,7 @@ import {
 import {
   fitToTarget, keepFormat, alternativeFormat, QUALITY_FLOOR,
 } from './compress.js';
+import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { compare, hasTransparency } from './measure.js';
 import {
   bytes as humanBytes, targetBytes, dimensions, outName, change, matchText, psnrText,
@@ -72,13 +73,22 @@ let writable = new Set([JPEG, PNG]);
 
 /* ------------------------------------------------------------------ adding */
 
-const dropzoneTitle = el.dropzone.querySelector('.dropzone-title');
+// The drop zone and the picker: shared, because every tool here needs the
+// same one. src/shared/file-picker.js, copied in from shared/js/ by the
+// build. The resting label comes off the markup, so it is written once,
+// in this tool.toml, rather than here as well.
+const picker = wireFilePicker({
+  input: el.fileInput,
+  dropzone: el.dropzone,
+  onFiles(files) {
+    addFiles(files);
+  },
+});
 
 async function addFiles(files) {
   if (!files?.length || busy) return;
 
-  el.dropzone.classList.add('busy');
-  dropzoneTitle.textContent = `Reading ${files.length} file${files.length === 1 ? '' : 's'}...`;
+  picker.busy(readingLabel(files.length));
 
   const failures = [];
 
@@ -109,8 +119,7 @@ async function addFiles(files) {
       items.push(item);
     }
   } finally {
-    el.dropzone.classList.remove('busy');
-    dropzoneTitle.textContent = 'Drop images here';
+    picker.done();
   }
 
   if (failures.length) showLoadError(failures.join('\n'));
@@ -137,30 +146,6 @@ function measure(url) {
   });
 }
 
-// No click handler here on purpose: the drop zone is a <label for="file-input">,
-// so the browser opens the picker itself.
-
-el.fileInput.addEventListener('change', () => {
-  const picked = Array.from(el.fileInput.files);
-  el.fileInput.value = ''; // lets the same file be picked twice in a row
-  addFiles(picked);
-});
-
-for (const type of ['dragenter', 'dragover']) {
-  el.dropzone.addEventListener(type, (event) => {
-    event.preventDefault();
-    el.dropzone.classList.add('dragover');
-  });
-}
-
-for (const type of ['dragleave', 'drop']) {
-  el.dropzone.addEventListener(type, () => el.dropzone.classList.remove('dragover'));
-}
-
-el.dropzone.addEventListener('drop', (event) => {
-  event.preventDefault();
-  addFiles(event.dataTransfer?.files);
-});
 
 function removeItem(id) {
   const at = items.findIndex((i) => i.id === id);

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -21,6 +21,11 @@ category = "images-and-video"
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
 css_parts = ["file-list"]
+
+# Shared modules this tool asks for. The same arrangement as css_parts,
+# and for the same reason: a component more than one tool needs and no
+# tool should own. file-picker brings in the drop zone.
+js_parts = ["file-picker"]
 lastmod = "2026-08-19"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -276,3 +281,11 @@ features = [
   "Batches, with all results in one zip",
   "Runs offline; no upload, no account",
 ]
+
+# The drop zone. Rendered by templates/partials/file-picker.html, which
+# body.html includes, and driven by src/shared/file-picker.js.
+[picker]
+accept = "image/*,.jpg,.jpeg,.png,.webp,.gif,.bmp,.avif"
+multiple = true
+title = "Drop images here"
+hint = "or click to browse &mdash; JPEG, PNG, WebP and anything else your browser can open"

--- a/tools/crop-video/body.html
+++ b/tools/crop-video/body.html
@@ -9,13 +9,7 @@
       so the input stays in the layout: visually hidden, still focusable, and
       reachable by keyboard. There is no JavaScript in this path at all.
     -->
-    <input type="file" id="file-input" class="visually-hidden" accept="video/*">
-    <label id="dropzone" class="dropzone" for="file-input">
-      <span class="dropzone-title">Drop a video here</span>
-      <span class="dropzone-hint">
-        or click to browse &mdash; MP4, MOV, M4V, WebM, and anything else this browser plays
-      </span>
-    </label>
+    {% include "partials/file-picker.html" %}
 
     <dl class="source" id="source" hidden>
       <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>

--- a/tools/crop-video/src/main.js
+++ b/tools/crop-video/src/main.js
@@ -1,5 +1,6 @@
 /** UI wiring and application state. */
 
+import { wireFilePicker } from './shared/file-picker.js';
 import { demux, UnsupportedFile } from './demux.js';
 import { cropExact, grabFrame, decoderConfig, averageFps } from './transcode.js';
 import { cropByRecording } from './record.js';
@@ -81,36 +82,19 @@ const cropper = new Cropper(el.stage, { onChange: onCropChanged });
 
 /* ------------------------------------------------------------------ adding */
 
-const dropzoneTitle = el.dropzone.querySelector('.dropzone-title');
-
-// No click handler on the drop zone on purpose: it is a <label for="file-input">,
-// so the browser opens the picker itself.
-el.fileInput.addEventListener('change', () => {
-  const [picked] = el.fileInput.files;
-  el.fileInput.value = '';
-  if (picked) loadFile(picked);
+// The drop zone and the picker: shared, because every tool here needs the
+// same one. src/shared/file-picker.js, copied in from shared/js/ by the
+// build. The resting label comes off the markup, so it is written once,
+// in this tool.toml, rather than here as well.
+const picker = wireFilePicker({
+  input: el.fileInput,
+  dropzone: el.dropzone,
+  onFiles(files) {
+    const [file] = files;
+    if (file) loadFile(file);
+  },
 });
 
-for (const type of ['dragenter', 'dragover']) {
-  el.dropzone.addEventListener(type, (event) => {
-    event.preventDefault();
-    el.dropzone.classList.add('dragover');
-  });
-}
-
-for (const type of ['dragleave', 'drop']) {
-  el.dropzone.addEventListener(type, () => el.dropzone.classList.remove('dragover'));
-}
-
-el.dropzone.addEventListener('drop', (event) => {
-  event.preventDefault();
-  const [picked] = event.dataTransfer?.files ?? [];
-  if (picked) loadFile(picked);
-});
-
-// Dropping anywhere else on the page should not navigate away from the app.
-window.addEventListener('dragover', (event) => event.preventDefault());
-window.addEventListener('drop', (event) => event.preventDefault());
 
 /* ------------------------------------------------------------------ loading */
 
@@ -150,8 +134,7 @@ async function loadFile(picked) {
   releaseFile();
 
   file = picked;
-  el.dropzone.classList.add('busy');
-  dropzoneTitle.textContent = 'Reading the file...';
+  picker.busy('Reading the file...');
 
   try {
     objectUrl = URL.createObjectURL(picked);
@@ -220,8 +203,7 @@ async function loadFile(picked) {
     showError(error?.message || 'That file could not be opened.');
     resetView();
   } finally {
-    el.dropzone.classList.remove('busy');
-    dropzoneTitle.textContent = 'Drop a video here';
+    picker.done();
   }
 }
 

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -16,6 +16,11 @@ tagline = "Cut a clip down to the part that matters."
 icon = "&#9986;&#65039;"          # the mark beside the page heading
 favicon = "&#9986;"      # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+
+# Shared modules this tool asks for. The same arrangement as css_parts,
+# and for the same reason: a component more than one tool needs and no
+# tool should own. file-picker brings in the drop zone.
+js_parts = ["file-picker"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -276,3 +281,11 @@ features = [
 # other tool's.
 [csp]
 "media-src" = ["'self'", "blob:"]
+
+# The drop zone. Rendered by templates/partials/file-picker.html, which
+# body.html includes, and driven by src/shared/file-picker.js.
+[picker]
+accept = "video/*"
+multiple = false
+title = "Drop a video here"
+hint = "or click to browse &mdash; MP4, MOV, M4V, WebM, and anything else this browser plays"

--- a/tools/exif-editor/body.html
+++ b/tools/exif-editor/body.html
@@ -9,12 +9,7 @@
       so the input stays in the layout: visually hidden, still focusable, and
       reachable by keyboard. There is no JavaScript in this path at all.
     -->
-    <input type="file" id="file-input" class="visually-hidden"
-           accept="image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp" multiple>
-    <label id="dropzone" class="dropzone" for="file-input">
-      <span class="dropzone-title">Drop photos here</span>
-      <span class="dropzone-hint">or click to browse &mdash; JPEG, PNG and WebP</span>
-    </label>
+    {% include "partials/file-picker.html" %}
 
     <div id="list-toolbar" class="toolbar" hidden>
       <span id="count-label" class="count"></span>

--- a/tools/exif-editor/src/main.js
+++ b/tools/exif-editor/src/main.js
@@ -1,5 +1,6 @@
 /** UI wiring and application state. */
 
+import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { readImage, readBytes, serialize, exifBytes, outputType, KIND_NAMES } from './container.js';
 import { serializeExif, setEntryValue, createEntry, TYPE } from './tiff.js';
 import { describeTag } from './tags.js';
@@ -75,13 +76,22 @@ let resultUrls = [];
 
 /* ------------------------------------------------------------------ adding */
 
-const dropzoneTitle = el.dropzone.querySelector('.dropzone-title');
+// The drop zone and the picker: shared, because every tool here needs the
+// same one. src/shared/file-picker.js, copied in from shared/js/ by the
+// build. The resting label comes off the markup, so it is written once,
+// in this tool.toml, rather than here as well.
+const picker = wireFilePicker({
+  input: el.fileInput,
+  dropzone: el.dropzone,
+  onFiles(files) {
+    addFiles(files);
+  },
+});
 
 async function addFiles(files) {
   if (!files?.length) return;
 
-  el.dropzone.classList.add('busy');
-  dropzoneTitle.textContent = `Reading ${files.length} file${files.length === 1 ? '' : 's'}...`;
+  picker.busy(readingLabel(files.length));
 
   const failures = [];
 
@@ -139,8 +149,7 @@ async function addFiles(files) {
       if (!item.ok) failures.push(`${file.name}: ${item.error}`);
     }
   } finally {
-    el.dropzone.classList.remove('busy');
-    dropzoneTitle.textContent = 'Drop photos here';
+    picker.done();
   }
 
   if (failures.length) showLoadError(failures.join('\n'));
@@ -183,30 +192,6 @@ function measure(url) {
   });
 }
 
-// No click handler here on purpose: the drop zone is a <label for="file-input">,
-// so the browser opens the picker itself.
-
-el.fileInput.addEventListener('change', () => {
-  const picked = Array.from(el.fileInput.files);
-  el.fileInput.value = ''; // lets the same file be picked twice in a row
-  addFiles(picked);
-});
-
-for (const type of ['dragenter', 'dragover']) {
-  el.dropzone.addEventListener(type, (event) => {
-    event.preventDefault();
-    el.dropzone.classList.add('dragover');
-  });
-}
-
-for (const type of ['dragleave', 'drop']) {
-  el.dropzone.addEventListener(type, () => el.dropzone.classList.remove('dragover'));
-}
-
-el.dropzone.addEventListener('drop', (event) => {
-  event.preventDefault();
-  addFiles(event.dataTransfer?.files);
-});
 
 function removeItem(id) {
   const at = items.findIndex((i) => i.id === id);

--- a/tools/exif-editor/tool.toml
+++ b/tools/exif-editor/tool.toml
@@ -21,6 +21,11 @@ category = "images-and-video"
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
 css_parts = ["file-list"]
+
+# Shared modules this tool asks for. The same arrangement as css_parts,
+# and for the same reason: a component more than one tool needs and no
+# tool should own. file-picker brings in the drop zone.
+js_parts = ["file-picker"]
 lastmod = "2026-08-19"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -272,3 +277,11 @@ features = [
   "Rewrites the container only, so the image is never re-compressed",
   "Runs offline; no upload, no account",
 ]
+
+# The drop zone. Rendered by templates/partials/file-picker.html, which
+# body.html includes, and driven by src/shared/file-picker.js.
+[picker]
+accept = "image/jpeg,image/png,image/webp,.jpg,.jpeg,.png,.webp"
+multiple = true
+title = "Drop photos here"
+hint = "or click to browse &mdash; JPEG, PNG and WebP"

--- a/tools/images-to-pdf/body.html
+++ b/tools/images-to-pdf/body.html
@@ -9,11 +9,7 @@
       so the input stays in the layout: visually hidden, still focusable, and
       reachable by keyboard. There is no JavaScript in this path at all.
     -->
-    <input type="file" id="file-input" class="visually-hidden" accept="image/*" multiple>
-    <label id="dropzone" class="dropzone" for="file-input">
-      <span class="dropzone-title">Drop images here</span>
-      <span class="dropzone-hint">or click to browse &mdash; JPEG, PNG, WebP, GIF, AVIF</span>
-    </label>
+    {% include "partials/file-picker.html" %}
 
     <p id="load-error" class="error" role="alert" hidden></p>
 

--- a/tools/images-to-pdf/src/main.js
+++ b/tools/images-to-pdf/src/main.js
@@ -1,5 +1,6 @@
 /** UI wiring and application state. */
 
+import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { loadImages, releaseItem, rotateItem, sortItems, moveItem } from './images.js';
 import { layoutPage, seenSize, PAGE_SIZES } from './layout.js';
 import { buildDocument } from './document.js';
@@ -83,13 +84,22 @@ let previewAt = 0;
 
 /* ------------------------------------------------------------------ adding */
 
-const dropzoneTitle = el.dropzone.querySelector('.dropzone-title');
+// The drop zone and the picker: shared, because every tool here needs the
+// same one. src/shared/file-picker.js, copied in from shared/js/ by the
+// build. The resting label comes off the markup, so it is written once,
+// in this tool.toml, rather than here as well.
+const picker = wireFilePicker({
+  input: el.fileInput,
+  dropzone: el.dropzone,
+  onFiles(files) {
+    addFiles(files);
+  },
+});
 
 async function addFiles(files) {
   if (!files?.length || exporting) return;
 
-  el.dropzone.classList.add('busy');
-  dropzoneTitle.textContent = `Reading ${files.length} file${files.length === 1 ? '' : 's'}...`;
+  picker.busy(readingLabel(files.length));
 
   try {
     const { items: added, skipped } = await loadImages(files);
@@ -97,41 +107,12 @@ async function addFiles(files) {
     if (skipped.length) showLoadError(skipped.join('\n'));
     else clearLoadError();
   } finally {
-    el.dropzone.classList.remove('busy');
-    dropzoneTitle.textContent = 'Drop images here';
+    picker.done();
   }
 
   render();
 }
 
-// No click handler here on purpose: the drop zone is a <label for="file-input">,
-// so the browser opens the picker itself.
-el.fileInput.addEventListener('change', () => {
-  const picked = Array.from(el.fileInput.files);
-  el.fileInput.value = ''; // lets the same file be picked twice in a row
-  addFiles(picked);
-});
-
-for (const type of ['dragenter', 'dragover']) {
-  el.dropzone.addEventListener(type, (event) => {
-    event.preventDefault();
-    el.dropzone.classList.add('dragover');
-  });
-}
-
-for (const type of ['dragleave', 'drop']) {
-  el.dropzone.addEventListener(type, () => el.dropzone.classList.remove('dragover'));
-}
-
-el.dropzone.addEventListener('drop', (event) => {
-  event.preventDefault();
-  addFiles(event.dataTransfer?.files);
-});
-
-// A file dropped anywhere else would otherwise be opened by the browser,
-// throwing away everything chosen so far.
-window.addEventListener('dragover', (event) => event.preventDefault());
-window.addEventListener('drop', (event) => event.preventDefault());
 
 /* --------------------------------------------------------------- the pages */
 

--- a/tools/images-to-pdf/tool.toml
+++ b/tools/images-to-pdf/tool.toml
@@ -16,6 +16,11 @@ tagline = "Put your pictures into one document."
 icon = "&#128196;"                  # the page mark beside the heading
 favicon = "&#128196;"      # the tab icon, drawn into an inline SVG
 category = "documents-and-pdf"
+
+# Shared modules this tool asks for. The same arrangement as css_parts,
+# and for the same reason: a component more than one tool needs and no
+# tool should own. file-picker brings in the drop zone.
+js_parts = ["file-picker"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -249,3 +254,11 @@ features = [
   "Optional lossless storage for scans and screenshots",
   "Runs offline; no upload, no account",
 ]
+
+# The drop zone. Rendered by templates/partials/file-picker.html, which
+# body.html includes, and driven by src/shared/file-picker.js.
+[picker]
+accept = "image/*"
+multiple = true
+title = "Drop images here"
+hint = "or click to browse &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/tools/images-to-video/body.html
+++ b/tools/images-to-video/body.html
@@ -9,11 +9,7 @@
       so the input stays in the layout: visually hidden, still focusable, and
       reachable by keyboard. There is no JavaScript in this path at all.
     -->
-    <input type="file" id="file-input" class="visually-hidden" accept="image/*" multiple>
-    <label id="dropzone" class="dropzone" for="file-input">
-      <span class="dropzone-title">Drop images here</span>
-      <span class="dropzone-hint">or click to browse &mdash; JPEG, PNG, WebP, GIF, AVIF</span>
-    </label>
+    {% include "partials/file-picker.html" %}
 
     <details id="url-panel" class="url-panel">
       <summary>Add from a web address</summary>

--- a/tools/images-to-video/src/main.js
+++ b/tools/images-to-video/src/main.js
@@ -1,5 +1,6 @@
 /** UI wiring and application state. */
 
+import { wireFilePicker, readingLabel } from './shared/file-picker.js';
 import { loadImages, decodeFull, releaseItem, sortItems, moveItem } from './images.js';
 import { drawFrame, resolveOutputSize } from './compose.js';
 import { encodeToMp4, countFrames } from './encoder.js';
@@ -80,15 +81,24 @@ let previewToken = 0;
 
 /* ------------------------------------------------------------------ adding */
 
-const dropzoneTitle = el.dropzone.querySelector('.dropzone-title');
+// The drop zone and the picker: shared, because every tool here needs the
+// same one. src/shared/file-picker.js, copied in from shared/js/ by the
+// build. The resting label comes off the markup, so it is written once,
+// in this tool.toml, rather than here as well.
+const picker = wireFilePicker({
+  input: el.fileInput,
+  dropzone: el.dropzone,
+  onFiles(files) {
+    addFiles(files);
+  },
+});
 
 async function addFiles(files) {
   if (!files?.length) return;
 
   // Decoding a batch of large photos takes a few seconds, so say so rather
   // than leaving the drop zone looking inert.
-  el.dropzone.classList.add('busy');
-  dropzoneTitle.textContent = `Reading ${files.length} file${files.length === 1 ? '' : 's'}…`;
+  picker.busy(readingLabel(files.length));
 
   try {
     const typed = Number(el.bulkAmount.value);
@@ -104,45 +114,12 @@ async function addFiles(files) {
       clearError();
     }
   } finally {
-    el.dropzone.classList.remove('busy');
-    dropzoneTitle.textContent = 'Drop images here';
+    picker.done();
   }
 
   render();
 }
 
-// No click handler here on purpose: the drop zone is a <label for="file-input">,
-// so the browser opens the picker itself. Driving it from JS via input.click()
-// on a display:none input is what broke this before.
-
-el.fileInput.addEventListener('change', () => {
-  // `input.files` is a live list and resetting `value` empties it, so take a
-  // real array first. Clearing the input is what lets the same file be picked
-  // twice in a row.
-  const picked = Array.from(el.fileInput.files);
-  el.fileInput.value = '';
-  addFiles(picked);
-});
-
-for (const type of ['dragenter', 'dragover']) {
-  el.dropzone.addEventListener(type, (event) => {
-    event.preventDefault();
-    el.dropzone.classList.add('dragover');
-  });
-}
-
-for (const type of ['dragleave', 'drop']) {
-  el.dropzone.addEventListener(type, () => el.dropzone.classList.remove('dragover'));
-}
-
-el.dropzone.addEventListener('drop', (event) => {
-  event.preventDefault();
-  addFiles(event.dataTransfer?.files);
-});
-
-// Dropping anywhere else on the page should not navigate away from the app.
-window.addEventListener('dragover', (event) => event.preventDefault());
-window.addEventListener('drop', (event) => event.preventDefault());
 
 /* ------------------------------------------------------------ web addresses */
 

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -16,6 +16,11 @@ tagline = "Turn a folder of images into a video."
 icon = "&#127902;&#65039;"          # the mark beside the page heading
 favicon = "&#127902;"      # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+
+# Shared modules this tool asks for. The same arrangement as css_parts,
+# and for the same reason: a component more than one tool needs and no
+# tool should own. file-picker brings in the drop zone.
+js_parts = ["file-picker"]
 lastmod = "2026-08-19"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -252,3 +257,11 @@ features = [
 "img-src" = ["http:"]
 "media-src" = ["'self'", "blob:"]
 "worker-src" = ["'self'", "blob:"]
+
+# The drop zone. Rendered by templates/partials/file-picker.html, which
+# body.html includes, and driven by src/shared/file-picker.js.
+[picker]
+accept = "image/*"
+multiple = true
+title = "Drop images here"
+hint = "or click to browse &mdash; JPEG, PNG, WebP, GIF, AVIF"


### PR DESCRIPTION
Every tool here starts the same way: a hidden file input, a <label> drop zone over it, drag highlighting, and a "Reading 3 files..." label while the files are read. That was written out five times. Four of the five were character for character identical; the fifth, the video cropper, differed only in taking one file rather than a list.

It is shared in three pieces, because it was duplicated in three:

  * shared/js/file-picker.js   - the wiring
  * templates/partials/file-picker.html - the markup
  * the [picker] table in each tool.toml - the three strings that differ,
    which are the accept list, the resting label and the hint under it

The CSS half was already shared, in shared/css/file-list.css and the .dropzone rules in the frame, which is what suggested the rest could be.

COPIED, NOT LINKED

A shared module lands in the tool's own src/shared/, named in `js_parts` the same way `css_parts` already names a stylesheet part. Nothing is bundled and nothing is fetched from a neighbour: every tool folder in dist/ is still complete on its own, cached by its own service worker, and still works with the network unplugged. That property is the reason this site can say what it says, and sharing code was not worth giving it up for.

The cost is that a tool's source folder now imports a file it does not contain. The import reads `./shared/file-picker.js` so that the path itself says where to look, the module's own header says it, and the README says it.

WHAT IS NOT SHARED

Only choosing the files. What a tool does with them afterwards - the list, the thumbnails, the reordering, the per-row buttons - differs enough between the five that sharing it would cost more than it saved.

TWO SMALL CHANGES ALONG THE WAY

body.html now goes through the template engine before it is dropped into the page, so it can {% include %} a partial. Nothing else in any body.html uses template syntax, so this changes no output.

The compressor and the EXIF editor gain the window-level dragover and drop guards the other three already had. Without them, a file dropped just outside the drop zone is opened by the browser, which navigates away and throws out everything chosen so far.

Verified in a browser, all five tools, both paths into the picker: change events on the input and real drop events on the zone. Files land, the input is cleared so the same file can be picked twice, the label goes to "Reading N files..." and back, the dragover highlight comes and goes, and the cropper still takes exactly one file from a picker handed two. Two builds are byte-identical, all 60 emitted scripts re-tokenise, every tool caches the shared module, and an unknown js_parts entry stops the build.