### PR TITLE
Answer a wrong address with something useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ templates/
   hub.html               the hub page
   tool.html              the frame every tool page wears
   page.html              the frame a prose page wears - the legal ones
+  404.html               what GitHub Pages returns for an address that is not here
   sw.js                  the offline service worker
   analytics.js           the Google Analytics bootstrap
   sitemap.xml
@@ -564,6 +565,36 @@ It matches on the whole request, query string included, so a worker that cached
 `styles.css` while the page asked for `styles.css?v=...` would leave the tool
 styled online and bare offline. `build.py` passes the same string to both, which
 is the only reason they cannot drift.
+
+### The 404 page
+
+`build.py` writes `404.html` to the root of the output, which is where
+[GitHub Pages looks for it](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site).
+For this site that root is the root of the `dist` branch, so the deploy needs no
+extra step. The wording lives in `[not_found]` in `config/site.toml`, and the
+tool cards on it come from the same list the hub is built from.
+
+**Every URL on that page is root-absolute, and has to be.** It is the only page
+here that is served at an address it was not built for: someone who mistypes
+`/compress-imag/` gets this file back while the browser still believes it is
+sitting in a folder of that name. A relative `styles.css` would be fetched from
+that folder, 404 in its turn, and the error page would arrive unstyled — a worse
+first impression than the error. The build passes `base = "/"` for this page
+alone, which is what makes the shared footer's links absolute too.
+
+Two more things it does differently, both on purpose:
+
+- **No advertising.** Google asks that ads not be placed on error pages, and an
+  advert on top of "we could not find that" is a poor way to meet somebody. The
+  measurement tag stays, because knowing which addresses people arrive at and
+  fail to find is the whole operational reason to have a custom 404.
+- **`noindex`, and no canonical.** The page has no address of its own — it is
+  what a thousand wrong addresses return. Giving it a canonical would invite a
+  search engine to serve "not found" in place of a real page. It is left out of
+  `sitemap.xml` for the same reason.
+
+`serve.ps1` serves it for a miss as well, so the mistake it invites shows up
+locally rather than in production.
 
 ### Canonical URLs
 

--- a/build.py
+++ b/build.py
@@ -171,6 +171,12 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     build_hub(out, templates, site, planned, by_slug, footer, css_v, emit)
     written.append('index.html')
 
+    build_404(out, templates, site, ordered, footer, css_v, emit)
+    written.append('404.html')
+
+    # After the sitemap and deliberately not passed to it: the 404 has no
+    # address of its own to list, and inviting a crawler to index it would be
+    # inviting it to serve "not found" in place of a real page.
     build_sitemap(out, templates, site, tools, guides, legal)
     written.append('sitemap.xml')
 
@@ -411,6 +417,31 @@ def build_hub(out, templates, site, planned, by_slug, footer, css_v, emit):
         'site': site,
         'words': {'plural': 'files', 'analytics_extra': ''},
     }), where='analytics.js')
+
+
+def build_404(out, templates, site, tools, footer, css_v, emit):
+    """The page GitHub Pages returns for anything it cannot find.
+
+    One file, at the root of the publishing source, per its documentation:
+    docs.github.com -> Pages -> Creating a custom 404 page. For this site that
+    root is the root of the dist branch, which is what the build writes.
+
+    `base` is '/' rather than './' or '../'. Every other page here knows where
+    it is standing; this one does not, because it is served at whatever address
+    was asked for. A visitor who mistypes /compress-imag/ gets this file while
+    the browser still believes it is in a folder of that name, so a relative
+    link would resolve against a folder that does not exist and the error page
+    would arrive unstyled. Absolute is the only form that works from every
+    depth at once.
+    """
+    emit.html(out / '404.html', templates.render('404.html', {
+        'site': site,
+        'tools': tools,
+        'footer': footer,
+        'base': '/',
+        'css_href': f'/site.css?v={css_v}',
+        'csp': sitelib.render_csp(site['csp']),
+    }))
 
 
 def build_sitemap(out, templates, site, tools, guides, legal):

--- a/config/site.toml
+++ b/config/site.toml
@@ -127,6 +127,32 @@ font = "Cookie"
 # ---------------------------------------------------------------------------
 #
 
+#
+# ---------------------------------------------------------------------------
+# The 404 page.
+#
+# GitHub Pages serves one file, at the root of the publishing source, for every
+# address it cannot find. It is the only page on the site that is read at an
+# address it was not built for, which is why every URL on it is root-absolute -
+# templates/404.html says more about that.
+#
+# It carries no advertising and is not indexed. Both on purpose, both explained
+# in the template.
+# ---------------------------------------------------------------------------
+#
+
+[not_found]
+title = "Page not found &mdash; abox.tools"
+description = "That address does not exist on abox.tools. Here are the tools that do - all of them free, and none of them uploading your files anywhere."
+heading = "That page is not here"
+tools_heading = "Every tool, in one place"
+tools_note = "All free, all running in your browser, none of them uploading anything."
+
+lede = """
+    Either the address has a typo in it, or something that used to be at that
+    address has moved. Nothing is wrong with your file and nothing was lost:
+    this site has never held anything of yours to lose."""
+
 [hub]
 title = "Free Browser Tools &mdash; No Upload, No Sign-In | abox.tools"
 # Kept under 155 characters. Google truncates a description around there, and

--- a/serve.ps1
+++ b/serve.ps1
@@ -126,9 +126,20 @@ try {
       }
 
       if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+        # Serve the built 404 page, the way GitHub Pages will. Doing it here as
+        # well is what makes the page testable at all: it is the one page on the
+        # site that is only ever read at an address it was not built for, and
+        # the mistake it invites - a relative link resolving against a folder
+        # that does not exist - shows up nowhere else.
+        $notFound = Join-Path $root '404.html'
         $response.StatusCode = 404
-        $body = [System.Text.Encoding]::UTF8.GetBytes("404 - $relative not found")
-        $response.ContentType = 'text/plain; charset=utf-8'
+        if (Test-Path -LiteralPath $notFound -PathType Leaf) {
+          $body = [System.IO.File]::ReadAllBytes($notFound)
+          $response.ContentType = 'text/html; charset=utf-8'
+        } else {
+          $body = [System.Text.Encoding]::UTF8.GetBytes("404 - $relative not found")
+          $response.ContentType = 'text/plain; charset=utf-8'
+        }
         $response.ContentLength64 = $body.Length
         $response.OutputStream.Write($body, 0, $body.Length)
         $response.Close()

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="{{ site.lang }}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!--
+  GENERATED FILE - do not edit. Built by build.py from templates/404.html and
+  the [not_found] table in config/site.toml. Edit those and run `python build.py`.
+
+  GitHub Pages serves this for any address it cannot find, from one file at the
+  root of the publishing source - which for this site is the root of the dist
+  branch. See README.md under "The 404 page".
+
+  EVERY URL ON THIS PAGE IS ROOT-ABSOLUTE, AND HAS TO BE
+
+  This is the one page on the site that is served at an address it was not
+  built for. A visitor who mistypes /compress-imag/ gets this file back while
+  the browser still believes it is sitting in a folder called compress-imag, so
+  a relative "styles.css" would be fetched from there and 404 in its turn -
+  leaving an unstyled error page, which is a worse first impression than the
+  error itself. `base` is passed in as "/" for this page alone, so every link
+  the shared footer builds is absolute too.
+-->
+<!--
+  The same Content-Security-Policy as every other page, from config/site.toml.
+  It is wider than this page needs, because this page carries no advertising -
+  see below - but one policy for the whole site is worth more than a bespoke
+  one here: a second list would be a second thing to keep in step.
+-->
+{{ csp }}
+<title>{{ site.not_found.title }}</title>
+<meta name="description" content="{{ site.not_found.description }}">
+
+<!--
+  Not indexed, and no canonical. This page has no address of its own: it is what
+  a thousand different wrong addresses return. Telling a search engine to file it
+  under one of them would be inviting it to serve this in place of a real page.
+-->
+<meta name="robots" content="noindex, follow">
+
+<!--
+  No AdSense on this page, deliberately. Google asks that ads not be placed on
+  error pages and pages without content of their own, and an advert on top of
+  "we could not find that" is a poor way to meet somebody either way.
+
+  The measurement tag stays, because knowing which addresses people arrive at
+  and fail to find is the entire operational reason to have a custom 404 rather
+  than the stock one. It is given the same thing as everywhere else on this
+  site, which is a page view and nothing more.
+
+  Both paths are absolute for the reason in the head comment above.
+-->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics_id }}"></script>
+<script src="/analytics.js" defer></script>
+
+<link rel="stylesheet" href="{{ css_href }}">
+<link rel="icon" href="/logo.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/icon-180.png">
+</head>
+<body>
+
+<header class="hub-head">
+  <p class="brand">
+    <a class="brand-home" href="{{ base }}">
+      <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
+    </a>
+  </p>
+  <h1>{{ site.not_found.heading }}</h1>
+  <p class="lede">
+{{ site.not_found.lede }}
+  </p>
+</header>
+
+<main>
+  <!--
+    The tools, drawn from the same list the hub is built from. Somebody who
+    landed here was looking for one of them, and a list of the things that do
+    exist is more use than an apology and a link back to the front page.
+  -->
+  <section class="category" aria-labelledby="tools-h">
+    <div class="category-head">
+      <h2 id="tools-h">{{ site.not_found.tools_heading }}</h2>
+      <p class="category-note">{{ site.not_found.tools_note }}</p>
+    </div>
+    <ul class="tool-grid">
+{% for tool in tools %}      <li>
+        <a class="tool-card" href="{{ base }}{{ tool.slug }}/">
+          <span class="tool-icon" aria-hidden="true">{{ tool.icon }}</span>
+          <span class="tool-name">{{ tool.name | e }}</span>
+          <span class="tool-desc">
+{{ tool.card }}
+          </span>
+        </a>
+      </li>
+{% endfor %}    </ul>
+  </section>
+</main>
+
+{% include "partials/footer.html" %}
+
+</body>
+</html>


### PR DESCRIPTION
Replaces the GitHub Pages stock 404 with a page in the site's own frame, listing every tool. One file at the root of the publishing source — [as the docs require](https://docs.github.com/en/pages/getting-started-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site) — which for this site is the root of the `dist` branch, so the deploy needs no extra step.

## Every URL on it is root-absolute, and has to be

This is the only page here that is read at an address it was not built for. Someone who mistypes `/compress-imag/` is handed this file while the browser still believes it is in a folder of that name — so a relative `styles.css` would be fetched from *there*, 404 in its turn, and the error page would arrive unstyled. A worse first impression than the error itself.

The footer already builds every link from `base`, so passing `"/"` for this page alone makes the whole thing work from any depth.

## What it does differently, and why

- **No advertising.** Google asks that ads not be placed on error pages, and an advert on top of "we could not find that" is a poor way to meet somebody either way. The measurement tag stays — knowing which addresses people arrive at and fail to find is the entire operational reason to have a custom 404 rather than the stock one.
- **`noindex`, no canonical, not in `sitemap.xml`.** The page has no address of its own; it is what a thousand wrong addresses return. Giving it one would invite a crawler to serve "not found" in place of a real page.
- **The site CSP unchanged**, not a narrower bespoke one. Wider than this page needs since it loads no ads, but one policy for the whole site beats a second list to keep in step.

The wording lives in `[not_found]` in `config/site.toml`; the tool cards come from the same list the hub is built from, so a new tool appears here without anyone remembering.

## `serve.ps1` serves it too

Previously a line of plain text. That change is what makes any of this testable — the mistake this page invites shows up on no other page, so without it the first real proof would have been in production.

## Verified

Served `dist/` with a 404 fallback and opened a three-deep wrong address, `/compress-imag/typo/deep/`:

| | |
|---|---|
| Page returned | ✅ correct title and heading |
| Stylesheet applied from 3 folders deep | ✅ 72 rules, cards styled |
| All 26 URLs resolve | ✅ tool links and footer links alike |
| Layout vs the hub as control | identical numbers |

Plus: two builds byte-identical, HTML still pure ASCII, all 72 emitted scripts re-tokenise, and `404.html` lands at the output root.
