### PR TITLE
Test the hand-written code, and make CI wait for the result

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@
 # On a pull request this builds but does not publish, so a change that breaks
 # the build is caught before it reaches main.
 #
+# The unit tests run first, in their own job, and the build waits on them. They
+# cover the hand-written code on both sides: the generator in Python and the
+# parsers and writers the browser runs. See tests/README.md.
+#
 
 name: Build
 
@@ -33,7 +37,38 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # The unit tests, for the code in this repository that was written by hand:
+  # the site generator in Python, and the parsers and writers the browser runs.
+  # Neither suite needs anything installed - unittest and node:test are both
+  # standard library - so this job installs nothing at all. See tests/README.md.
+  #
+  # It runs before the build rather than beside it, and the build needs it, so
+  # a failing test cannot deploy.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Newer than the build job's Node, and deliberately: `node --test` only
+      # learned to take a glob in 21, and on 20 the same argument is read as a
+      # path that does not exist. Nothing is installed with it, so the version
+      # here is free to differ from the one esbuild is pinned against below.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: The build (Python)
+        run: python -m unittest discover -t . -s tests/python -v
+
+      - name: The tools (JavaScript)
+        run: node --test "tests/js/*.test.js"
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 /.dist-check/
 __pycache__/
 
+# Nothing here has a dependency to install, and package.json declares no
+# packages - but `npm install` is a reflex, and its output does not belong here.
+node_modules/
+package-lock.json
+
 # OS metadata
 Thumbs.db
 desktop.ini

--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ python build.py
 ```
 
 Python 3.11 or newer, and nothing to install: the build uses only the standard
-library. There is no `package.json` and no lockfile. The one exception is
-`--mangle`, which renames identifiers and needs esbuild; it is what CI runs and
-what gets deployed, and it is described under
+library. There is no lockfile and no dependency to fetch. The `package.json` at
+the root declares one thing — that the `.js` files here are ES modules, which
+is what they already were — so that `node --test` can import them; nothing
+installs it and the build never reads it. The one exception is `--mangle`,
+which renames identifiers and needs esbuild; it is what CI runs and what gets
+deployed, and it is described under
 [What the build does to the output](#what-the-build-does-to-the-output). The
 command above is not that, and never needs it.
 
@@ -98,6 +101,32 @@ python build.py --no-minify
 > file picker still opens — that part is plain HTML — but choosing images does nothing.
 > The app detects this and shows a red banner explaining it, but the failure is easy
 > to hit, so it is worth knowing about.
+
+### The tests
+
+Both suites need nothing installed, for the same reason the build does not:
+
+```bash
+python -m unittest discover -t . -s tests/python
+```
+
+```bash
+node --test "tests/js/*.test.js"
+```
+
+The first covers `build.py` and `buildlib/` — the template engine, the two
+minifiers and their refusals, the config loading, and a whole build into a
+temporary directory, including the 404 page and the root-absolute URLs it has
+to carry. The second covers what the browser actually runs: the EXIF and TIFF
+parsers, the three container formats, the PDF object grammar, reader and
+rewriter, the three MP4 writers, the trimmer's keyframe arithmetic, the PDF
+writer, the layout maths and the ZIP writer. Mostly round trips — read a file,
+write it back, and check the picture came through byte for byte with only the
+metadata gone.
+
+Both run in CI on every push and every pull request, and nothing is published
+if either fails. `tests/README.md` says what is covered and what deliberately
+is not.
 
 ---
 
@@ -151,6 +180,12 @@ pages/
     page.toml            title, description, dates - the frame, not the prose
     body.html            the <main> of the page
   terms/                 the same two things
+tests/
+  python/                the generator: unittest, standard library only
+  js/                    the tools: node --test, built in since Node 18
+    helpers.js           image fixtures, built rather than checked in as binary
+    pdf-fixtures.js      the same for PDFs, with real byte offsets
+package.json             says the .js files are ES modules; no dependencies
 og-image.ps1             draws the share cards and the icon from shared/logo.svg
 serve.ps1                builds, then serves dist/ locally
 cloudflare/              the edge config that adds the security headers

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "abox-tools",
+  "private": true,
+  "type": "module",
+  "description": "Declares what the .js files in this repository already are: ES modules. There are no dependencies and there is no lockfile - this exists so that `node --test` can import tools/*/src/*.js directly, rather than reading a bare .js as CommonJS and failing on the first `import`. Nothing installs it, and the build does not read it.",
+  "scripts": {
+    "test": "node --test \"tests/js/*.test.js\""
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,92 @@
+# Tests
+
+Everything in this repository is written by hand, and these are the tests for
+it. Two suites, because there are two languages, and neither needs anything
+installed:
+
+| Suite | Covers | Runner |
+|---|---|---|
+| `tests/python/` | `build.py` and `buildlib/` — the site generator | `unittest`, standard library |
+| `tests/js/` | `tools/*/src/` and `shared/js/` — what the browser runs | `node --test`, built in since Node 18 |
+
+There is no test framework to install and no lockfile, which is the same
+bargain the rest of the repository makes: if you have to fetch a tree of
+dependencies before you can check what a claim means, the claim is not really
+checkable.
+
+## Running them
+
+```bash
+python -m unittest discover -t . -s tests/python
+```
+
+```bash
+node --test "tests/js/*.test.js"
+```
+
+`npm test` runs the second one, and is the only thing `package.json` is for —
+see the note in that file. Both run in CI on every push and every pull request,
+and the build will not publish if either fails.
+
+To run one file, or one test:
+
+```bash
+python -m unittest tests.python.test_cssmin -v
+```
+
+```bash
+node --test --test-name-pattern="stco" "tests/js/*.test.js"
+```
+
+## What is tested, and what is not
+
+The line is drawn at the browser. A function that computes something — a CRC, a
+page layout, a set of MP4 boxes, the bytes of a stripped JPEG — is tested here.
+A function that needs a `<canvas>`, a `VideoEncoder` or a `DecompressionStream`
+attached to a real document is not, because faking those well enough to be
+worth the trouble means testing the fake.
+
+That leaves the parsers and the writers, which is where this project's risk
+actually is: they are hand-written, they are the reason the tools can promise
+that nothing is uploaded, and a mistake in one of them silently corrupts
+somebody's file rather than throwing an error. So `tests/js/` is mostly round
+trips — read a file, write it back, and check that what came out is what went
+in, byte for byte, with only the metadata gone.
+
+The one thing that is neither a round trip nor a refusal is the video
+trimmer's `ranges.js`, and it is the most carefully tested file here. It turns
+seconds into ticks on two different clocks, and its answers decide where a
+lossless cut actually begins — which is at the keyframe in front of the mark,
+not at the mark. Getting that wrong does not throw; it desynchronises the
+sound.
+
+On the Python side the same reasoning points at the minifiers. `buildlib/`
+already refuses to write output whose tokens moved; `tests/python/` checks the
+refusals fire, and checks every stylesheet and every module in the repository
+still minifies to a fixed point.
+
+`tests/python/test_build.py` ends with a whole build into a temporary
+directory. That is not a unit test and it earns its place anyway: it is the
+only thing that would notice a page that stopped being written at all.
+
+## Fixtures
+
+`tests/js/helpers.js` builds the smallest JPEG, PNG, WebP and TIFF blocks the
+parsers will accept. They are built rather than checked in as binary files, so
+a reader can see exactly what is in each one — and the two TIFF blocks are
+written out byte by byte with a comment on every field, because a fixture whose
+contents you have to take on trust cannot pin down a parser.
+
+`tests/js/pdf-fixtures.js` does the same for PDFs, and has one extra job. The
+compress-pdf tool opens files other programs made, and its reader has three
+ways in: a classic cross-reference table, a cross-reference stream, and — when
+neither survives checking — scanning the whole file for `N 0 obj`. A fixture
+with a wrong xref table would silently exercise the third path and never touch
+the first, so `buildPdf` computes real byte offsets, and the damaged variants
+each break exactly one thing.
+
+## Adding a tool
+
+Nothing needs registering. The Python build test globs `tools/*/tool.toml`, so
+a new tool is built and checked the moment it exists. Its JavaScript is a new
+`tests/js/<tool>-*.test.js`; the glob picks that up too.

--- a/tests/js/compress-pdf-objects.test.js
+++ b/tests/js/compress-pdf-objects.test.js
@@ -1,0 +1,385 @@
+/**
+ * tools/compress-pdf/src/objects.js - the PDF object grammar.
+ *
+ * This is the half of the format images-to-pdf never needed. That tool only
+ * ever wrote documents it had just built; this one opens files somebody else
+ * made, which means the whole grammar and, more to the point, everything real
+ * files do to it.
+ *
+ * The module's own comments name the concessions it makes to broken files - a
+ * dictionary key that is not a name, a "1.0-2" number from a scanner, a
+ * /Length that lies. Each of those is a test, because each is a place where a
+ * silent guess would write out a document that is subtly not the one it read.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  Name, Parser, PdfStream, PdfString, PdfSyntaxError, Ref,
+  ascii as asciiOf, indexOfAscii, isName, lastIndexOfAscii, name,
+  parseIndirectObject,
+} from '../../tools/compress-pdf/src/objects.js';
+import { ascii, concat } from './pdf-fixtures.js';
+
+/** Parse one value out of a source string. */
+const parse = (source, resolve) => new Parser(ascii(source), 0, resolve).parseValue();
+
+/** Parse one value and say where the cursor stopped. */
+function parseWithPos(source) {
+  const parser = new Parser(ascii(source));
+  return { value: parser.parseValue(), pos: parser.pos };
+}
+
+const stringOf = (value) => new TextDecoder('latin1').decode(value.bytes);
+
+/* ================================================================== atoms */
+
+test('numbers', () => {
+  assert.equal(parse('42'), 42);
+  assert.equal(parse('-17'), -17);
+  assert.equal(parse('+3'), 3);
+  assert.equal(parse('3.14'), 3.14);
+  assert.equal(parse('.5'), 0.5);
+  assert.equal(parse('-.5'), -0.5);
+  assert.equal(parse('0'), 0);
+});
+
+test('a number with a minus in the middle stops at the minus', () => {
+  // "1.0-2" is a real thing scanners emit; readers take the number up to that
+  // point, and so does this.
+  assert.equal(parseWithPos('1.0-2').value, 1);
+});
+
+test('booleans and null', () => {
+  assert.equal(parse('true'), true);
+  assert.equal(parse('false'), false);
+  assert.equal(parse('null'), null);
+});
+
+test('names', () => {
+  assert.ok(parse('/Type') instanceof Name);
+  assert.equal(parse('/Type').value, 'Type');
+  assert.equal(parse('/').value, '', 'the empty name is legal');
+});
+
+test('a name may carry escaped bytes', () => {
+  // #41 is how a name carries a byte that would otherwise end it.
+  assert.equal(parse('/A#20Name').value, 'A Name');
+  assert.equal(parse('/Sl#2Fash').value, 'Sl/ash');
+  assert.equal(parse('/Hash#23').value, 'Hash#');
+});
+
+test('an incomplete escape is left as a literal hash', () => {
+  assert.equal(parse('/Bad#ZZ').value, 'Bad#ZZ');
+  assert.equal(parse('/Trailing#').value, 'Trailing#');
+});
+
+test('names are interned, so comparison is cheap', () => {
+  assert.equal(name('Type'), name('Type'));
+  assert.equal(parse('/Type'), parse('/Type'));
+});
+
+test('isName answers for anything, including nothing', () => {
+  assert.equal(isName(name('Page'), 'Page'), true);
+  assert.equal(isName(name('Page'), 'Pages'), false);
+  assert.equal(isName(undefined, 'Page'), false);
+  assert.equal(isName(null, 'Page'), false);
+  assert.equal(isName('Page', 'Page'), false, 'a JS string is not a name');
+});
+
+/* ================================================================ strings */
+
+test('a literal string', () => {
+  assert.ok(parse('(Hello)') instanceof PdfString);
+  assert.equal(stringOf(parse('(Hello)')), 'Hello');
+  assert.equal(stringOf(parse('()')), '');
+});
+
+test('a literal string may nest balanced brackets', () => {
+  assert.equal(stringOf(parse('(a (b) c)')), 'a (b) c');
+  assert.equal(stringOf(parse('(((deep)))')), '((deep))');
+});
+
+test('backslash escapes', () => {
+  assert.equal(stringOf(parse('(a\\nb)')), 'a\nb');
+  assert.equal(stringOf(parse('(a\\rb)')), 'a\rb');
+  assert.equal(stringOf(parse('(a\\tb)')), 'a\tb');
+  assert.equal(stringOf(parse('(a\\bb)')), 'a\bb');
+  assert.equal(stringOf(parse('(a\\fb)')), 'a\fb');
+  assert.equal(stringOf(parse('(a\\(b)')), 'a(b');
+  assert.equal(stringOf(parse('(a\\)b)')), 'a)b');
+  assert.equal(stringOf(parse('(a\\\\b)')), 'a\\b');
+});
+
+test('an octal escape', () => {
+  assert.equal(stringOf(parse('(\\101\\102)')), 'AB');
+  assert.equal(stringOf(parse('(\\5)')), '', 'fewer than three digits');
+  assert.equal(parse('(\\400)').bytes[0], 0x00, 'wrapped to a byte');
+});
+
+test('a backslash before a line break continues the line', () => {
+  assert.equal(stringOf(parse('(one\\\ntwo)')), 'onetwo');
+  assert.equal(stringOf(parse('(one\\\r\ntwo)')), 'onetwo');
+});
+
+test('a hex string', () => {
+  assert.equal(stringOf(parse('<48656C6C6F>')), 'Hello');
+  assert.equal(stringOf(parse('<>')), '');
+});
+
+test('a hex string ignores whitespace and takes an odd digit as a high nibble', () => {
+  assert.equal(stringOf(parse('<48 65 6C 6C 6F>')), 'Hello');
+  assert.deepEqual(parse('<4>').bytes, new Uint8Array([0x40]));
+  assert.deepEqual(parse('<414>').bytes, new Uint8Array([0x41, 0x40]));
+});
+
+test('a string is kept as bytes, not decoded', () => {
+  // The bytes may be PDFDocEncoding, UTF-16, or not text at all; decoding on
+  // the way in and re-encoding on the way out would change files this tool is
+  // only meant to be passing through.
+  assert.deepEqual(parse('<FEFF0041>').bytes, new Uint8Array([0xfe, 0xff, 0x00, 0x41]));
+});
+
+/* ================================================================= arrays */
+
+test('an array', () => {
+  assert.deepEqual(parse('[1 2 3]'), [1, 2, 3]);
+  assert.deepEqual(parse('[]'), []);
+});
+
+test('an array may hold anything, including other arrays', () => {
+  const value = parse('[1 /Name (str) [2 3] true null]');
+  assert.equal(value.length, 6);
+  assert.equal(value[0], 1);
+  assert.equal(value[1].value, 'Name');
+  assert.deepEqual(value[3], [2, 3]);
+  assert.equal(value[4], true);
+  assert.equal(value[5], null);
+});
+
+test('an unclosed array is reported', () => {
+  assert.throws(() => parse('[1 2 3'), PdfSyntaxError);
+});
+
+/* =========================================================== dictionaries */
+
+test('a dictionary is a Map keyed without the slash', () => {
+  const dict = parse('<< /Type /Page /Count 3 >>');
+  assert.ok(dict instanceof Map);
+  assert.equal(dict.get('Type').value, 'Page');
+  assert.equal(dict.get('Count'), 3);
+});
+
+test('a dictionary is a Map so that odd keys cannot reach a prototype', () => {
+  // "/constructor" and "/__proto__" are legal PDF names.
+  const dict = parse('<< /__proto__ 1 /constructor 2 >>');
+  assert.equal(dict.get('__proto__'), 1);
+  assert.equal(dict.get('constructor'), 2);
+  assert.equal(Object.getPrototypeOf(dict), Map.prototype);
+});
+
+test('an empty dictionary', () => {
+  assert.equal(parse('<< >>').size, 0);
+});
+
+test('dictionaries nest', () => {
+  const dict = parse('<< /Resources << /Font << /F1 5 0 R >> >> >>');
+  assert.equal(dict.get('Resources').get('Font').get('F1').num, 5);
+});
+
+test('a key that is not a name is skipped rather than abandoning the rest', () => {
+  // The file is damaged; a dictionary that is almost entirely readable is
+  // worth more than nothing.
+  const dict = parse('<< /Good 1 42 /Also 2 >>');
+  assert.equal(dict.get('Good'), 1);
+  assert.equal(dict.get('Also'), 2);
+});
+
+test('an unclosed dictionary is reported', () => {
+  assert.throws(() => parse('<< /Type /Page'), PdfSyntaxError);
+});
+
+test('nesting past the guard is refused rather than exhausting the stack', () => {
+  // This runs on bytes a stranger sent.
+  assert.throws(() => parse('['.repeat(400) + ']'.repeat(400)), /nested too deeply/);
+});
+
+/* ============================================================= references */
+
+test('an indirect reference', () => {
+  const ref = parse('12 0 R');
+  assert.ok(ref instanceof Ref);
+  assert.equal(ref.num, 12);
+  assert.equal(ref.gen, 0);
+  assert.equal(ref.key, '12,0');
+});
+
+test('two numbers that are not a reference stay two numbers', () => {
+  assert.deepEqual(parse('[12 0]'), [12, 0]);
+  assert.deepEqual(parse('[1 2 3]'), [1, 2, 3]);
+});
+
+test('the lookahead puts the cursor back when the guess is wrong', () => {
+  const parser = new Parser(ascii('12 0 /Next'));
+  assert.equal(parser.parseValue(), 12);
+  assert.equal(parser.parseValue(), 0);
+  assert.equal(parser.parseValue().value, 'Next');
+});
+
+test('R must stand alone to end a reference', () => {
+  // "12 0 Rx" is not a reference: the two numbers come back as numbers, and
+  // the leftover keyword is reported rather than guessed at.
+  const parser = new Parser(ascii('12 0 Rx'));
+  assert.equal(parser.parseValue(), 12);
+  assert.equal(parser.parseValue(), 0);
+  assert.throws(() => parser.parseValue(), PdfSyntaxError);
+});
+
+test('a reference may be followed immediately by a delimiter', () => {
+  assert.equal(parse('[12 0 R]')[0].num, 12);
+  assert.equal(parse('<< /A 12 0 R>>').get('A').num, 12);
+});
+
+test('a negative object number is not a reference', () => {
+  assert.equal(parse('-1 0 R'), -1);
+});
+
+/* ============================================================== comments */
+
+test('a comment runs to the end of the line and is skipped', () => {
+  assert.equal(parse('% a note\n42'), 42);
+  const dict = parse('<< /A 1 % why\n/B 2 >>');
+  assert.equal(dict.get('B'), 2);
+});
+
+/* ================================================================ streams */
+
+test('a stream keeps its bytes exactly as they appeared', () => {
+  const source = '<< /Length 5 >>\nstream\nHELLO\nendstream';
+  const value = parse(source);
+  assert.ok(value instanceof PdfStream);
+  assert.equal(new TextDecoder().decode(value.raw), 'HELLO');
+});
+
+test('a stream with a CRLF after the keyword', () => {
+  const value = parse('<< /Length 5 >>\nstream\r\nHELLO\r\nendstream');
+  assert.equal(new TextDecoder().decode(value.raw), 'HELLO');
+});
+
+test('a /Length that lies is not believed', () => {
+  // Getting this wrong does not produce a small error: every byte after it is
+  // misread.
+  const value = parse('<< /Length 2 >>\nstream\nHELLO WORLD\nendstream');
+  assert.equal(new TextDecoder().decode(value.raw), 'HELLO WORLD');
+  assert.equal(value.dict.get('Length'), 11, 'the dictionary is corrected');
+});
+
+test('a missing /Length falls back to finding endstream', () => {
+  const value = parse('<< /Filter /FlateDecode >>\nstream\nDATA HERE\nendstream');
+  assert.equal(new TextDecoder().decode(value.raw), 'DATA HERE');
+});
+
+test('the end-of-line before endstream is punctuation, not data', () => {
+  const value = parse('<< >>\nstream\nDATA\r\nendstream');
+  assert.equal(new TextDecoder().decode(value.raw), 'DATA');
+});
+
+test('an indirect /Length is resolved when it can be', () => {
+  const resolve = (ref) => (ref instanceof Ref && ref.num === 9 ? 5 : null);
+  const value = parse('<< /Length 9 0 R >>\nstream\nHELLO\nendstream', resolve);
+  assert.equal(new TextDecoder().decode(value.raw), 'HELLO');
+});
+
+test('an indirect /Length that cannot be resolved falls back', () => {
+  const resolve = () => { throw new Error('no such object'); };
+  const value = parse('<< /Length 9 0 R >>\nstream\nHELLO\nendstream', resolve);
+  assert.equal(new TextDecoder().decode(value.raw), 'HELLO');
+});
+
+test('a stream with no endstream is reported', () => {
+  assert.throws(() => parse('<< >>\nstream\nDATA'), /no endstream/);
+});
+
+test('a stream may hold bytes that look like syntax', () => {
+  const data = '<< >> obj endobj [ ] ( )';
+  const value = parse(`<< /Length ${data.length} >>\nstream\n${data}\nendstream`);
+  assert.equal(new TextDecoder().decode(value.raw), data);
+});
+
+test('the cursor lands past endstream', () => {
+  const parser = new Parser(ascii('<< /Length 5 >>\nstream\nHELLO\nendstream /After'));
+  parser.parseValue();
+  assert.equal(parser.parseValue().value, 'After');
+});
+
+/* ======================================================= indirect objects */
+
+test('parseIndirectObject reads the whole envelope', () => {
+  const bytes = ascii('12 0 obj\n<< /Type /Page >>\nendobj\n');
+  const found = parseIndirectObject(bytes, 0);
+  assert.equal(found.num, 12);
+  assert.equal(found.gen, 0);
+  assert.equal(found.value.get('Type').value, 'Page');
+});
+
+test('parseIndirectObject reads from an offset', () => {
+  const bytes = ascii('%PDF-1.7\n7 0 obj\n42\nendobj\n');
+  const found = parseIndirectObject(bytes, 9);
+  assert.equal(found.num, 7);
+  assert.equal(found.value, 42);
+});
+
+test('parseIndirectObject refuses something that is not one', () => {
+  assert.throws(() => parseIndirectObject(ascii('12 0 << >>'), 0), /no obj keyword/);
+});
+
+/* ============================================================ byte search */
+
+test('ascii reads a run of bytes as text', () => {
+  const bytes = ascii('hello world');
+  assert.equal(asciiOf(bytes, 0, 5), 'hello');
+  assert.equal(asciiOf(bytes, 6, 11), 'world');
+  assert.equal(asciiOf(bytes, 6, 999), 'world', 'clamped to the end');
+});
+
+test('indexOfAscii finds the first occurrence', () => {
+  const bytes = ascii('one two one two');
+  assert.equal(indexOfAscii(bytes, 'one'), 0);
+  assert.equal(indexOfAscii(bytes, 'one', 1), 8);
+  assert.equal(indexOfAscii(bytes, 'two'), 4);
+  assert.equal(indexOfAscii(bytes, 'three'), -1);
+});
+
+test('lastIndexOfAscii searches backwards, which is how startxref is found', () => {
+  const bytes = ascii('startxref 1 startxref 2');
+  assert.equal(lastIndexOfAscii(bytes, 'startxref'), 12);
+  assert.equal(lastIndexOfAscii(bytes, 'startxref', 11), 0);
+  assert.equal(lastIndexOfAscii(bytes, 'nope'), -1);
+});
+
+test('the searches do not run off either end', () => {
+  const bytes = ascii('abc');
+  assert.equal(indexOfAscii(bytes, 'abcd'), -1);
+  assert.equal(lastIndexOfAscii(bytes, 'abcd'), -1);
+  assert.equal(indexOfAscii(bytes, 'a', -5), 0);
+  assert.equal(indexOfAscii(bytes, 'c', 99), -1);
+});
+
+/* ================================================================ refusals */
+
+test('an empty input, and a value that is not one', () => {
+  assert.throws(() => parse(''), /ran off the end/);
+  assert.throws(() => parse('>>'), PdfSyntaxError);
+  assert.throws(() => parse(']'), PdfSyntaxError);
+});
+
+test('a syntax error names where it happened', () => {
+  try {
+    new Parser(concat('   ', ']')).parseValue();
+    assert.fail('should have thrown');
+  } catch (err) {
+    assert.ok(err instanceof PdfSyntaxError);
+    assert.match(err.message, /at 3/);
+  }
+});

--- a/tests/js/compress-pdf-reader.test.js
+++ b/tests/js/compress-pdf-reader.test.js
@@ -1,0 +1,303 @@
+/**
+ * tools/compress-pdf/src/{reader,filters}.js.
+ *
+ * The reader's job is to survive files it did not write. There are three ways
+ * in - a classic cross-reference table, a cross-reference stream, and, when
+ * neither survives checking, scanning the whole file for "N 0 obj" - and the
+ * third one is the one that matters, because it is what stands between a
+ * damaged file and an error message.
+ *
+ * The two refusals are tested too. An encrypted PDF is turned away rather than
+ * quietly decrypted, and something that is not a PDF is told so.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EncryptedPdfError, NotAPdfError, PdfDocument, scanObjectHeaders,
+} from '../../tools/compress-pdf/src/reader.js';
+import { decodeStream, filterNames } from '../../tools/compress-pdf/src/filters.js';
+import { PdfStream, name } from '../../tools/compress-pdf/src/objects.js';
+import {
+  MINIMAL_OBJECTS, ascii, buildPdf, concat, deflate, minimalPdf, pdfWithMetadata,
+  streamObject, text,
+} from './pdf-fixtures.js';
+
+/* ================================================================= opening */
+
+test('a minimal document opens through the real xref table', async () => {
+  const doc = await PdfDocument.open(minimalPdf());
+  assert.equal(doc.repaired, false, 'the table was believed');
+  assert.equal(doc.entries.size, 3);
+  assert.equal(doc.version, '1.7');
+  assert.equal(doc.countPages(), 1);
+});
+
+test('the catalogue is found through the trailer', async () => {
+  const doc = await PdfDocument.open(minimalPdf());
+  assert.ok(doc.catalog instanceof Map);
+  assert.equal(doc.catalog.get('Type').value, 'Catalog');
+});
+
+test('the version comes off the header', async () => {
+  assert.equal((await PdfDocument.open(minimalPdf({ header: '%PDF-1.4\n' }))).version, '1.4');
+  assert.equal((await PdfDocument.open(minimalPdf({ header: '%PDF-2.0\n' }))).version, '2.0');
+});
+
+test('junk in front of the header is allowed', async () => {
+  // A shell script or a mail part may precede it; readers are told to look in
+  // the first kilobyte.
+  const bytes = concat('#!/bin/sh\n# a wrapper\n', minimalPdf());
+  const doc = await PdfDocument.open(bytes);
+  assert.equal(doc.countPages(), 1);
+});
+
+test('objects resolve through references', async () => {
+  const doc = await PdfDocument.open(minimalPdf());
+  const pages = doc.resolve(doc.catalog.get('Pages'));
+  assert.equal(pages.get('Type').value, 'Pages');
+  assert.equal(pages.get('Count'), 1);
+});
+
+test('a page tree with several pages is counted', async () => {
+  const doc = await PdfDocument.open(buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 >>',
+    '<< /Type /Page /Parent 2 0 R >>',
+    '<< /Type /Page /Parent 2 0 R >>',
+    '<< /Type /Page /Parent 2 0 R >>',
+  ]));
+  assert.equal(doc.countPages(), 3);
+});
+
+/* ================================================================ refusals */
+
+test('something that is not a PDF is told so', async () => {
+  await assert.rejects(
+    () => PdfDocument.open(ascii('This is a plain text file, not a PDF at all.')),
+    NotAPdfError,
+  );
+});
+
+test('the refusal names what was missing', async () => {
+  await assert.rejects(() => PdfDocument.open(ascii('nope')), /no %PDF- header/);
+});
+
+test('an encrypted PDF is turned away rather than quietly decrypted', async () => {
+  // Even when the password is blank, removing that protection is a different
+  // job from making the file smaller.
+  const bytes = buildPdf(MINIMAL_OBJECTS);
+  const withEncrypt = concat(
+    text(bytes).replace('/Root 1 0 R >>', '/Root 1 0 R /Encrypt 4 0 R >>'),
+  );
+  await assert.rejects(() => PdfDocument.open(withEncrypt), EncryptedPdfError);
+});
+
+test('the encryption refusal explains itself', async () => {
+  const bytes = buildPdf(MINIMAL_OBJECTS);
+  const withEncrypt = concat(
+    text(bytes).replace('/Root 1 0 R >>', '/Root 1 0 R /Encrypt 4 0 R >>'),
+  );
+  await assert.rejects(() => PdfDocument.open(withEncrypt),
+    /will not do it behind your back/);
+});
+
+test('a PDF header with no catalogue behind it is refused', async () => {
+  await assert.rejects(
+    () => PdfDocument.open(ascii('%PDF-1.7\nnothing else at all\n%%EOF\n')),
+    NotAPdfError,
+  );
+});
+
+/* ================================================================= repair */
+
+test('a broken startxref falls back to scanning, and still opens', async () => {
+  const bytes = concat(text(minimalPdf()).replace(/startxref\n\d+/, 'startxref\n999999'));
+  const doc = await PdfDocument.open(bytes);
+  assert.equal(doc.repaired, true);
+  assert.equal(doc.countPages(), 1, 'the document still reads');
+});
+
+test('an xref table full of wrong offsets is repaired', async () => {
+  const bytes = concat(text(minimalPdf()).replace(/^0000000(\d\d\d) 00000 n $/gm,
+    '0000000999 00000 n '));
+  const doc = await PdfDocument.open(bytes);
+  assert.equal(doc.countPages(), 1);
+});
+
+test('scanObjectHeaders finds every object in the file', () => {
+  const found = scanObjectHeaders(minimalPdf());
+  const numbers = found.map((entry) => entry.num);
+  for (const num of [1, 2, 3]) assert.ok(numbers.includes(num), `object ${num}`);
+});
+
+test('scanObjectHeaders reports the offset the object number starts at', () => {
+  const bytes = minimalPdf();
+  for (const entry of scanObjectHeaders(bytes)) {
+    const head = text(bytes.subarray(entry.offset, entry.offset + 12));
+    assert.match(head, new RegExp(`^${entry.num} \\d+ obj`), head);
+  }
+});
+
+test('scanObjectHeaders lists a rewritten object twice, in file order', () => {
+  // An incremental update rewrites an object further down the file. The
+  // scanner reports both and the caller takes the later one.
+  const bytes = concat(
+    '%PDF-1.7\n',
+    '1 0 obj\n<< /Version 1 >>\nendobj\n',
+    '1 0 obj\n<< /Version 2 >>\nendobj\n',
+  );
+  const found = scanObjectHeaders(bytes).filter((entry) => entry.num === 1);
+  assert.equal(found.length, 2);
+  assert.ok(found[0].offset < found[1].offset);
+});
+
+test('scanObjectHeaders does not take the tail of a longer number', () => {
+  // "1234 0 obj" is object 1234, not object 234.
+  const bytes = concat('%PDF-1.7\n', '1234 0 obj\n42\nendobj\n');
+  assert.deepEqual(scanObjectHeaders(bytes).map((e) => e.num), [1234]);
+});
+
+/* ================================================================ filters */
+
+test('filterNames reads both spellings', () => {
+  assert.deepEqual(filterNames(new Map([['Filter', name('FlateDecode')]])), ['FlateDecode']);
+  assert.deepEqual(
+    filterNames(new Map([['Filter', [name('ASCII85Decode'), name('FlateDecode')]]])),
+    ['ASCII85Decode', 'FlateDecode'],
+  );
+});
+
+test('filterNames on a stream with no filter', () => {
+  assert.deepEqual(filterNames(new Map()), []);
+  assert.deepEqual(filterNames(new Map([['Filter', null]])), []);
+});
+
+test('decodeStream leaves an unfiltered stream alone', async () => {
+  const stream = new PdfStream(new Map(), ascii('plain bytes'));
+  const { bytes, remaining } = await decodeStream(stream);
+  assert.equal(new TextDecoder().decode(bytes), 'plain bytes');
+  assert.deepEqual(remaining, []);
+});
+
+test('decodeStream inflates FlateDecode', async () => {
+  const raw = await deflate(ascii('the quick brown fox'.repeat(20)));
+  const stream = new PdfStream(new Map([['Filter', name('FlateDecode')]]), raw);
+  const { bytes, remaining } = await decodeStream(stream);
+  assert.equal(new TextDecoder().decode(bytes), 'the quick brown fox'.repeat(20));
+  assert.deepEqual(remaining, []);
+});
+
+test('decodeStream understands ASCIIHexDecode', async () => {
+  const stream = new PdfStream(new Map([['Filter', name('ASCIIHexDecode')]]),
+    ascii('48656C6C6F>'));
+  const { bytes } = await decodeStream(stream);
+  assert.equal(new TextDecoder().decode(bytes), 'Hello');
+});
+
+test('decodeStream understands RunLengthDecode', async () => {
+  // A length byte under 128 means "the next n+1 bytes are literal"; over 128
+  // means "repeat the next byte 257-n times"; 128 ends the data.
+  const raw = new Uint8Array([4, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 254, 0x21, 128]);
+  const stream = new PdfStream(new Map([['Filter', name('RunLengthDecode')]]), raw);
+  const { bytes } = await decodeStream(stream);
+  assert.equal(new TextDecoder().decode(bytes), 'Hello!!!');
+});
+
+test('decodeStream understands ASCII85Decode', async () => {
+  const stream = new PdfStream(new Map([['Filter', name('ASCII85Decode')]]),
+    ascii('87cURD]j7BEbo7~>'));
+  const { bytes } = await decodeStream(stream);
+  assert.equal(new TextDecoder().decode(bytes), 'Hello world');
+});
+
+test('ASCII85 handles a partial final group and the z shorthand', async () => {
+  const decode = async (source) => {
+    const stream = new PdfStream(new Map([['Filter', name('ASCII85Decode')]]), ascii(source));
+    return new TextDecoder().decode((await decodeStream(stream)).bytes);
+  };
+  assert.equal(await decode('9jqo^~>'), 'Man ', 'a full group');
+  assert.equal(await decode('87cURD]j7BEbo7~>'), 'Hello world', 'a partial one');
+  // 'z' stands for four zero bytes.
+  const zeros = new PdfStream(new Map([['Filter', name('ASCII85Decode')]]), ascii('z~>'));
+  assert.deepEqual(Array.from((await decodeStream(zeros)).bytes), [0, 0, 0, 0]);
+});
+
+test('ASCII85 accepts the optional opener and ignores whitespace', async () => {
+  const stream = new PdfStream(new Map([['Filter', name('ASCII85Decode')]]),
+    ascii('<~87cURD]j7\n BEbo7~>'));
+  assert.equal(new TextDecoder().decode((await decodeStream(stream)).bytes), 'Hello world');
+});
+
+test('decodeStream applies a chain of filters in order', async () => {
+  const inner = await deflate(ascii('twice wrapped'));
+  let hex = '';
+  for (const byte of inner) hex += byte.toString(16).padStart(2, '0');
+  const stream = new PdfStream(
+    new Map([['Filter', [name('ASCIIHexDecode'), name('FlateDecode')]]]),
+    ascii(`${hex}>`),
+  );
+  const { bytes } = await decodeStream(stream);
+  assert.equal(new TextDecoder().decode(bytes), 'twice wrapped');
+});
+
+test('decodeStream stops in front of an image filter and says which', async () => {
+  // ['DCTDecode'] means the bytes are a JPEG, and the caller wants them that
+  // way rather than decoded.
+  const stream = new PdfStream(new Map([['Filter', name('DCTDecode')]]),
+    ascii('JPEG BYTES'));
+  const { bytes, remaining } = await decodeStream(stream);
+  assert.deepEqual(remaining, ['DCTDecode']);
+  assert.equal(new TextDecoder().decode(bytes), 'JPEG BYTES');
+});
+
+test('decodeStream unwraps a flate layer in front of an image filter', async () => {
+  const raw = await deflate(ascii('JPEG BYTES'));
+  const stream = new PdfStream(
+    new Map([['Filter', [name('FlateDecode'), name('DCTDecode')]]]), raw,
+  );
+  const { bytes, remaining } = await decodeStream(stream);
+  assert.deepEqual(remaining, ['DCTDecode']);
+  assert.equal(new TextDecoder().decode(bytes), 'JPEG BYTES');
+});
+
+test('decodeStream refuses a filter it does not know', async () => {
+  const stream = new PdfStream(new Map([['Filter', name('MadeUpDecode')]]), ascii('x'));
+  await assert.rejects(() => decodeStream(stream), /unknown filter \/MadeUpDecode/);
+});
+
+test('decodeStream undoes a PNG predictor', async () => {
+  // Predictor 12 is PNG "up": each row is stored as the difference from the
+  // row above, with a filter-type byte in front.
+  const rows = [
+    [2, 10, 20, 30],  // filter type 2 (up), first row: nothing above, so as-is
+    [2, 1, 1, 1],     // each byte one more than the row above
+  ];
+  const raw = await deflate(Uint8Array.from(rows.flat()));
+  const stream = new PdfStream(new Map([
+    ['Filter', name('FlateDecode')],
+    ['DecodeParms', new Map([['Predictor', 12], ['Colors', 1], ['Columns', 3]])],
+  ]), raw);
+  const { bytes } = await decodeStream(stream);
+  assert.deepEqual(Array.from(bytes), [10, 20, 30, 11, 21, 31]);
+});
+
+/* =============================================== streams inside a document */
+
+test('a document holding a compressed stream reads it back', async () => {
+  const raw = await deflate(ascii('BT /F1 12 Tf (Hello) Tj ET'));
+  const doc = await PdfDocument.open(buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /Contents 4 0 R >>',
+    streamObject('/Filter /FlateDecode', raw),
+  ]));
+
+  const contents = doc.resolve(doc.resolve(doc.catalog.get('Pages')));
+  assert.ok(contents);
+  const stream = doc.getObject(4);
+  assert.ok(stream instanceof PdfStream);
+  const { bytes } = await decodeStream(stream, (v) => doc.resolve(v));
+  assert.equal(new TextDecoder().decode(bytes), 'BT /F1 12 Tf (Hello) Tj ET');
+});

--- a/tests/js/compress-pdf-writer.test.js
+++ b/tests/js/compress-pdf-writer.test.js
@@ -1,0 +1,350 @@
+/**
+ * tools/compress-pdf/src/{writer,inventory,placements,format,compress}.js.
+ *
+ * The writer is where a mistake is expensive: it rebuilds the file from the
+ * objects that are still reachable, so an object wrongly judged unreachable
+ * disappears from a document somebody is about to send to somebody else. The
+ * round trip below is the real check - rewrite the document, open the result,
+ * and confirm the pages and the content are still there.
+ *
+ * stripMetadata gets the same argument the EXIF tool makes, applied to a
+ * different container: a PDF routinely carries the name of the program that
+ * made it and a private blob a layout application left behind, and none of it
+ * is needed to display the document.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PdfDocument } from '../../tools/compress-pdf/src/reader.js';
+import { reachable, stripMetadata, writeDocument } from '../../tools/compress-pdf/src/writer.js';
+import { Ref, PdfStream } from '../../tools/compress-pdf/src/objects.js';
+import { decodeStream } from '../../tools/compress-pdf/src/filters.js';
+import { verdict } from '../../tools/compress-pdf/src/inventory.js';
+import { effectiveDpi } from '../../tools/compress-pdf/src/placements.js';
+import {
+  PRESETS, describeSettings,
+} from '../../tools/compress-pdf/src/compress.js';
+import {
+  bytes as sizeText, change, count, dimensions, dpi, outName, share,
+} from '../../tools/compress-pdf/src/format.js';
+import {
+  ascii, blobBytes, buildPdf, deflate, minimalPdf, pdfWithMetadata, streamObject, text,
+} from './pdf-fixtures.js';
+
+/* =============================================================== reachable */
+
+test('reachable walks out from the trailer', async () => {
+  const doc = await PdfDocument.open(minimalPdf());
+  const live = reachable(doc, [doc.trailer.get('Root')]);
+  assert.deepEqual([...live].sort(), [1, 2, 3]);
+});
+
+test('an object nothing points at is not reachable', async () => {
+  const doc = await PdfDocument.open(buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R >>',
+    '<< /Orphan (nothing points here) >>',
+  ]));
+  const live = reachable(doc, [doc.trailer.get('Root')]);
+  assert.ok(!live.has(4), 'the orphan is left out');
+  assert.equal(live.size, 3);
+});
+
+test('reachable follows arrays and nested dictionaries', async () => {
+  const doc = await PdfDocument.open(buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Resources << /XObject << /Im0 4 0 R >> >> /Annots [5 0 R] >>',
+    '<< /Type /XObject >>',
+    '<< /Type /Annot >>',
+  ]));
+  const live = reachable(doc, [doc.trailer.get('Root')]);
+  assert.ok(live.has(4), 'reached through two dictionaries');
+  assert.ok(live.has(5), 'reached through an array');
+});
+
+test('reachable survives a reference cycle', async () => {
+  // A page pointing back at its parent is the normal case, not a broken one.
+  const doc = await PdfDocument.open(minimalPdf());
+  const live = reachable(doc, [doc.trailer.get('Root')]);
+  assert.equal(live.size, 3);
+});
+
+test('reachable follows a stream dictionary as well as a plain one', async () => {
+  const doc = await PdfDocument.open(buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Contents 4 0 R >>',
+    streamObject('/Extra 5 0 R', ascii('content')),
+    '<< /Reached (through a stream dict) >>',
+  ]));
+  const live = reachable(doc, [doc.trailer.get('Root')]);
+  assert.ok(live.has(5));
+});
+
+/* =========================================================== stripMetadata */
+
+test('stripMetadata takes out what the file remembers about its origin', async () => {
+  const doc = await PdfDocument.open(pdfWithMetadata());
+  assert.ok(doc.trailer.has('Info'), 'there was something to remove');
+
+  const removed = stripMetadata(doc);
+  assert.ok(removed > 0);
+  assert.equal(doc.trailer.has('Info'), false);
+  assert.equal(doc.catalog.has('Metadata'), false);
+
+  const page = doc.getObject(3);
+  assert.equal(page.has('LastModified'), false);
+  assert.equal(page.has('PieceInfo'), false);
+});
+
+test('stripMetadata leaves the document itself alone', async () => {
+  const doc = await PdfDocument.open(pdfWithMetadata());
+  stripMetadata(doc);
+  assert.equal(doc.countPages(), 1);
+  assert.equal(doc.getObject(3).get('MediaBox').length, 4);
+});
+
+test('stripMetadata on a file with none removes nothing', async () => {
+  const doc = await PdfDocument.open(minimalPdf());
+  assert.equal(stripMetadata(doc), 0);
+});
+
+/* ============================================================ writeDocument */
+
+test('the rewritten file is a PDF that opens again', async () => {
+  const doc = await PdfDocument.open(minimalPdf());
+  const out = await blobBytes(await writeDocument(doc, { recompress: false }));
+
+  assert.equal(text(out.subarray(0, 5)), '%PDF-');
+  assert.ok(text(out.subarray(out.length - 20)).includes('%%EOF'));
+
+  const again = await PdfDocument.open(out);
+  assert.equal(again.countPages(), 1);
+  assert.equal(again.repaired, false, 'the xref it wrote is believed');
+});
+
+test('the page content survives the rewrite', async () => {
+  const content = 'BT /F1 12 Tf 72 720 Td (Hello) Tj ET';
+  const doc = await PdfDocument.open(buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /Contents 4 0 R >>',
+    streamObject('', ascii(content)),
+  ]));
+  const out = await blobBytes(await writeDocument(doc, { recompress: false }));
+
+  const again = await PdfDocument.open(out);
+  const page = again.resolve(again.resolve(again.catalog.get('Pages')).get('Kids')[0]);
+  const stream = again.resolve(page.get('Contents'));
+  assert.ok(stream instanceof PdfStream);
+  const decoded = await decodeStream(stream, (v) => again.resolve(v));
+  assert.equal(new TextDecoder().decode(decoded.bytes), content);
+});
+
+/** Catalogue -> page tree -> first page -> its content stream. */
+async function firstPageContent(doc) {
+  const pages = doc.resolve(doc.catalog.get('Pages'));
+  const page = doc.resolve(doc.resolve(pages.get('Kids'))[0]);
+  const stream = doc.resolve(page.get('Contents'));
+  assert.ok(stream instanceof PdfStream, 'the page has a content stream');
+  const decoded = await decodeStream(stream, (v) => doc.resolve(v));
+  return new TextDecoder().decode(decoded.bytes);
+}
+
+test('a compressed stream still decodes after the rewrite', async () => {
+  const content = 'q 1 0 0 1 0 0 cm Q'.repeat(40);
+  const doc = await PdfDocument.open(buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /Contents 4 0 R >>',
+    streamObject('/Filter /FlateDecode', await deflate(ascii(content))),
+  ]));
+  const out = await blobBytes(await writeDocument(doc, { recompress: false }));
+
+  const again = await PdfDocument.open(out);
+  assert.equal(again.countPages(), 1);
+  assert.equal(await firstPageContent(again), content);
+});
+
+test('the rewrite packs the small objects into an object stream', async () => {
+  // Which is most of where the repack saving comes from, and the reason a
+  // rewritten file cannot be compared to the original object by object.
+  const doc = await PdfDocument.open(minimalPdf());
+  const out = await blobBytes(await writeDocument(doc, { recompress: false }));
+  assert.ok(text(out).includes('/ObjStm'), 'objects were packed');
+
+  const again = await PdfDocument.open(out);
+  assert.equal(again.catalog.get('Type').value, 'Catalog',
+    'and they are still readable through the xref stream');
+});
+
+test('an unreferenced object is dropped from the rewrite', async () => {
+  const doc = await PdfDocument.open(buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R >>',
+    streamObject('', ascii('THIS ORPHAN SHOULD NOT SURVIVE THE REWRITE')),
+  ]));
+  const out = await blobBytes(await writeDocument(doc, { recompress: false }));
+  assert.equal(text(out).includes('THIS ORPHAN SHOULD NOT SURVIVE'), false);
+});
+
+test('the blob is typed as a pdf', async () => {
+  const doc = await PdfDocument.open(minimalPdf());
+  assert.equal((await writeDocument(doc, { recompress: false })).type, 'application/pdf');
+});
+
+test('progress is reported and ends at the total', async () => {
+  const doc = await PdfDocument.open(minimalPdf());
+  const seen = [];
+  await writeDocument(doc, { recompress: false, onProgress: (d, t) => seen.push([d, t]) });
+  assert.ok(seen.length > 0);
+  const [done, total] = seen.at(-1);
+  assert.equal(done, total);
+});
+
+test('a stripped document round-trips with its metadata gone', async () => {
+  const doc = await PdfDocument.open(pdfWithMetadata());
+  stripMetadata(doc);
+  const out = await blobBytes(await writeDocument(doc, { recompress: false }));
+
+  assert.equal(text(out).includes('Some Layout App'), false);
+  assert.equal(text(out).includes('xmpmeta'), false);
+  const again = await PdfDocument.open(out);
+  assert.equal(again.countPages(), 1);
+});
+
+/* ================================================================ verdict */
+
+test('verdict: a file that is mostly images promises a large saving', () => {
+  const found = verdict({ images: 900, total: 1000 });
+  assert.equal(found.tone, 'good');
+  assert.match(found.text, /90% of this file is images/);
+});
+
+test('verdict: a middling file says where the floor comes from', () => {
+  assert.equal(verdict({ images: 500, total: 1000 }).tone, 'ok');
+});
+
+test('verdict: a text document is told so in the same breath', () => {
+  // Somebody whose contract cannot be made smaller should be told why.
+  const thin = verdict({ images: 100, total: 1000 });
+  assert.equal(thin.tone, 'thin');
+  assert.match(thin.text, /not much for an image compressor/);
+
+  const none = verdict({ images: 0, total: 1000 });
+  assert.equal(none.tone, 'thin');
+  assert.match(none.text, /no images in this file/);
+});
+
+test('verdict: an empty file does not divide by zero', () => {
+  assert.equal(verdict({ images: 0, total: 0 }).tone, 'thin');
+});
+
+/* =========================================================== effectiveDpi */
+
+test('effectiveDpi is pixels per inch of the space drawn into', () => {
+  // 72 points is an inch, so 300 pixels across 72 points is 300 DPI.
+  assert.equal(effectiveDpi(300, 72), 300);
+  assert.equal(effectiveDpi(150, 72), 150);
+  assert.equal(effectiveDpi(1224, 612), 144);
+});
+
+test('effectiveDpi: an image that is never drawn answers zero', () => {
+  assert.equal(effectiveDpi(300, 0), 0);
+  assert.equal(effectiveDpi(0, 72), 0);
+  assert.equal(effectiveDpi(300, 0.001), 0);
+  assert.equal(effectiveDpi(NaN, 72), 0);
+});
+
+/* ================================================================ wording */
+
+test('bytes: the units a person would use', () => {
+  assert.equal(sizeText(0), '0 bytes');
+  assert.equal(sizeText(999), '999 bytes');
+  assert.equal(sizeText(1024), '1.0 KB');
+  assert.equal(sizeText(10240), '10 KB');
+  assert.equal(sizeText(1024 * 1024), '1.00 MB');
+  assert.equal(sizeText(5.5 * 1024 * 1024), '5.50 MB');
+});
+
+test('bytes: nonsense in, zero out', () => {
+  assert.equal(sizeText(-1), '0 bytes');
+  assert.equal(sizeText(NaN), '0 bytes');
+  assert.equal(sizeText(Infinity), '0 bytes');
+});
+
+test('change: the honest answer when a run went the wrong way', () => {
+  assert.equal(change(1000, 320), '68% smaller');
+  assert.equal(change(1000, 1050), '5% larger');
+  assert.equal(change(1000, 1000), 'about the same size');
+  assert.equal(change(0, 100), '');
+});
+
+test('share: never rounded up to 100 unless it really is all of it', () => {
+  assert.equal(share(1000, 1000), '100%');
+  assert.equal(share(999, 1000), '99%');
+  assert.equal(share(9999, 10000), '99%', 'not 100 while a byte is left');
+  assert.equal(share(1, 1000), '<1%');
+  assert.equal(share(0, 1000), '0%');
+  assert.equal(share(5, 0), '0%');
+});
+
+test('dpi: rounded, and empty when there is nothing to say', () => {
+  assert.equal(dpi(300), '300 DPI');
+  assert.equal(dpi(149.6), '150 DPI');
+  assert.equal(dpi(0), '');
+  assert.equal(dpi(-1), '');
+});
+
+test('dimensions: a real multiplication sign', () => {
+  assert.equal(dimensions(2480, 3508), '2480 × 3508');
+});
+
+test('outName: the extension is kept, because it is still a PDF', () => {
+  assert.equal(outName('contract.pdf'), 'contract-compressed.pdf');
+  assert.equal(outName('CONTRACT.PDF'), 'CONTRACT-compressed.pdf');
+  assert.equal(outName('report'), 'report-compressed.pdf');
+  assert.equal(outName('.pdf'), 'document-compressed.pdf');
+});
+
+test('outName: only the trailing extension goes', () => {
+  assert.equal(outName('v1.pdf.pdf'), 'v1.pdf-compressed.pdf');
+});
+
+test('count: one image, fourteen images', () => {
+  assert.equal(count(1, 'image'), '1 image');
+  assert.equal(count(14, 'image'), '14 images');
+  assert.equal(count(0, 'image'), '0 images');
+  assert.equal(count(1, 'entry', 'entries'), '1 entry');
+  assert.equal(count(3, 'entry', 'entries'), '3 entries');
+});
+
+/* =============================================================== presets */
+
+test('the presets are ordered the way the trade uses them', () => {
+  assert.ok(PRESETS.smallest.dpi < PRESETS.screen.dpi);
+  assert.ok(PRESETS.screen.dpi < PRESETS.print.dpi);
+  assert.ok(PRESETS.smallest.quality < PRESETS.screen.quality);
+  assert.ok(PRESETS.screen.quality < PRESETS.print.quality);
+  assert.ok(PRESETS.print.quality < PRESETS.gentle.quality);
+  assert.equal(PRESETS.gentle.dpi, 0, 'gentle does not resize at all');
+});
+
+test('every preset has a label to show', () => {
+  for (const [key, preset] of Object.entries(PRESETS)) {
+    assert.equal(typeof preset.label, 'string', key);
+    assert.ok(preset.label.length > 0, key);
+  }
+});
+
+test('describeSettings says what the controls add up to', () => {
+  assert.match(describeSettings({ dpi: 150, quality: 0.7 }),
+    /at most 150 pixels per inch.*JPEG quality 70/s);
+  assert.match(describeSettings({ dpi: 0, quality: 0.9 }),
+    /kept at their full size/);
+  assert.match(describeSettings({ dpi: 0, quality: 0.9 }), /JPEG quality 90/);
+});

--- a/tests/js/compress.test.js
+++ b/tests/js/compress.test.js
@@ -1,0 +1,251 @@
+/**
+ * tools/compress-image/src/{files,compress,codecs}.js and shared/js/*.js.
+ *
+ * The wording functions look like the least important thing in the tool and
+ * are not: sizes on this page are read against a target, so a 511.6 KB result
+ * shown as "512 KB" beside a 512 KB target reads as a miss when it was a hit.
+ * That rounding rule is a test.
+ *
+ * The format choices are the other half. Keeping the format is the default
+ * because a .jpg that leaves as a .webp is a support question for whoever it
+ * gets sent to, and there is exactly one case where "auto" changes the
+ * extension anyway.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  UNITS, bytes, change, dimensions, matchText, outName, psnrText, targetBytes,
+} from '../../tools/compress-image/src/files.js';
+import {
+  MIN_SCALE, QUALITY_CEILING, QUALITY_FLOOR, QUALITY_HARD_MIN, SEARCH_QUALITY,
+  alternativeFormat, keepFormat,
+} from '../../tools/compress-image/src/compress.js';
+import { FORMATS, JPEG, PNG, READABLE, WEBP } from '../../tools/compress-image/src/codecs.js';
+import { readingLabel } from '../../shared/js/file-picker.js';
+import { parseImageUrl } from '../../shared/js/url-import.js';
+
+/* ================================================================= sizes */
+
+test('bytes: under a kilobyte is counted exactly', () => {
+  assert.equal(bytes(0), '0 bytes');
+  assert.equal(bytes(1), '1 bytes');
+  assert.equal(bytes(1023), '1023 bytes');
+});
+
+test('bytes: kilobytes carry a decimal until ten of them', () => {
+  assert.equal(bytes(1024), '1.0 KB');
+  assert.equal(bytes(10239), '10.0 KB');
+  assert.equal(bytes(10240), '10 KB');
+  assert.equal(bytes(512 * 1024), '512 KB');
+});
+
+test('bytes: megabytes carry two decimals', () => {
+  assert.equal(bytes(1024 * 1024), '1.00 MB');
+  assert.equal(bytes(1536 * 1024), '1.50 MB');
+});
+
+test('bytes: a near miss is never rounded up past its target', () => {
+  // 511.6 KB shown as "512 KB" beside a 512 KB target reads as a miss.
+  assert.equal(bytes(511 * 1024 + 600), '512 KB');
+  assert.equal(bytes(1024 * 1024 - 1), '1024 KB');
+});
+
+test('targetBytes: a number and a unit', () => {
+  assert.equal(targetBytes('500', 'KB'), 500 * 1024);
+  assert.equal(targetBytes('1.5', 'MB'), Math.round(1.5 * 1024 * 1024));
+  assert.equal(targetBytes('2', 'MB'), 2 * 1024 * 1024);
+});
+
+test('targetBytes: KB and MB mean 1024, which is what people mean', () => {
+  assert.equal(UNITS.KB, 1024);
+  assert.equal(UNITS.MB, 1024 * 1024);
+});
+
+test('targetBytes: an unknown unit is read as KB', () => {
+  assert.equal(targetBytes('500', 'gigglebytes'), 500 * 1024);
+  assert.equal(targetBytes('500', undefined), 500 * 1024);
+});
+
+test('targetBytes: a field with nothing usable in it', () => {
+  assert.equal(targetBytes('', 'KB'), null);
+  assert.equal(targetBytes('abc', 'KB'), null);
+  assert.equal(targetBytes('0', 'KB'), null);
+  assert.equal(targetBytes('-5', 'KB'), null);
+  assert.equal(targetBytes('Infinity', 'KB'), null);
+});
+
+test('targetBytes: a trailing unit in the field is ignored', () => {
+  assert.equal(targetBytes('500kb', 'KB'), 500 * 1024);
+});
+
+test('dimensions: a real multiplication sign', () => {
+  assert.equal(dimensions(4032, 3024), '4032 × 3024');
+});
+
+/* ================================================================= names */
+
+test('outName: the original extension is dropped, not kept alongside', () => {
+  // "holiday.jpg-compressed.webp" is how a file ends up unopenable on a phone.
+  assert.equal(outName('holiday.jpg', WEBP), 'holiday-compressed.webp');
+  assert.equal(outName('holiday.jpeg', JPEG), 'holiday-compressed.jpg');
+  assert.equal(outName('shot.PNG', PNG), 'shot-compressed.png');
+});
+
+test('outName: only the last extension goes', () => {
+  assert.equal(outName('my.holiday.photo.jpg', JPEG), 'my.holiday.photo-compressed.jpg');
+});
+
+test('outName: a name with no extension', () => {
+  assert.equal(outName('holiday', JPEG), 'holiday-compressed.jpg');
+});
+
+test('outName: a name that is nothing but an extension', () => {
+  assert.equal(outName('.jpg', JPEG), 'image-compressed.jpg');
+  assert.equal(outName('', JPEG), 'image-compressed.jpg');
+});
+
+test('outName: an unknown type falls back to jpg', () => {
+  assert.equal(outName('a.gif', 'image/gif'), 'a-compressed.jpg');
+});
+
+/* =============================================================== wording */
+
+test('change: smaller, larger, or about the same', () => {
+  assert.equal(change(1000, 270), '73% smaller');
+  assert.equal(change(1000, 1030), '3% larger');
+  assert.equal(change(1000, 1000), 'about the same size');
+  assert.equal(change(1000, 998), 'about the same size');
+});
+
+test('change: nothing to say about a file that was empty', () => {
+  assert.equal(change(0, 100), '');
+});
+
+test('matchText: the number, and wording that stops it being over-read', () => {
+  // 0.97 is a good result, not "97% of the picture survived".
+  assert.equal(matchText(1), '100.0% - indistinguishable');
+  assert.equal(matchText(0.995), '99.5% - indistinguishable');
+  assert.equal(matchText(0.99), '99.0% - no visible difference');
+  assert.equal(matchText(0.97), '97.0% - very close');
+  assert.equal(matchText(0.93), '93.0% - slight softening');
+  assert.equal(matchText(0.8), '80.0% - visibly compressed');
+});
+
+test('matchText: the boundaries land on the wording above them', () => {
+  assert.match(matchText(0.985), /no visible difference/);
+  assert.match(matchText(0.96), /very close/);
+  assert.match(matchText(0.92), /slight softening/);
+  assert.match(matchText(0.9199), /visibly compressed/);
+});
+
+test('psnrText: identical pictures have no finite ratio to report', () => {
+  assert.equal(psnrText(Infinity), 'identical');
+  assert.equal(psnrText(NaN), 'identical');
+  assert.equal(psnrText(42.35), '42.4 dB');
+});
+
+test('readingLabel: one file, or several', () => {
+  assert.equal(readingLabel(1), 'Reading 1 file...');
+  assert.equal(readingLabel(0), 'Reading 0 files...');
+  assert.equal(readingLabel(12), 'Reading 12 files...');
+});
+
+/* ================================================================ formats */
+
+test('the search constants are in the order the search spends them', () => {
+  assert.ok(QUALITY_CEILING > SEARCH_QUALITY);
+  assert.ok(SEARCH_QUALITY > QUALITY_FLOOR);
+  assert.ok(QUALITY_FLOOR > QUALITY_HARD_MIN);
+  assert.ok(MIN_SCALE > 0 && MIN_SCALE < 1);
+});
+
+test('FORMATS names every writable type, and READABLE covers more', () => {
+  assert.deepEqual(Object.keys(FORMATS).sort(), [JPEG, PNG, WEBP].sort());
+  assert.equal(FORMATS[PNG].lossy, false);
+  assert.equal(FORMATS[JPEG].lossy, true);
+  for (const mime of Object.keys(FORMATS)) assert.ok(READABLE.includes(mime));
+  assert.ok(READABLE.includes('image/avif'), 'read but not written');
+});
+
+test('keepFormat: keeping the format is the default answer', () => {
+  const all = new Set([JPEG, PNG, WEBP]);
+  assert.equal(keepFormat(JPEG, all), JPEG);
+  assert.equal(keepFormat(PNG, all), PNG);
+  assert.equal(keepFormat(WEBP, all), WEBP);
+});
+
+test('keepFormat: a type this browser cannot write becomes one it can', () => {
+  const noWebp = new Set([JPEG, PNG]);
+  assert.equal(keepFormat(WEBP, noWebp), JPEG);
+});
+
+test('keepFormat: a GIF keeps its transparency by becoming a PNG', () => {
+  assert.equal(keepFormat('image/gif', new Set([JPEG, PNG])), PNG);
+});
+
+test('keepFormat: everything else this browser will not write becomes a JPEG', () => {
+  const writable = new Set([JPEG, PNG]);
+  assert.equal(keepFormat('image/bmp', writable), JPEG);
+  assert.equal(keepFormat('image/avif', writable), JPEG);
+  assert.equal(keepFormat('image/heic', writable), JPEG);
+});
+
+test('alternativeFormat: WebP is the one thing worth trying', () => {
+  const all = new Set([JPEG, PNG, WEBP]);
+  assert.equal(alternativeFormat(JPEG, all, false), WEBP);
+  assert.equal(alternativeFormat(PNG, all, true), WEBP);
+});
+
+test('alternativeFormat: a PNG with no transparency can become a JPEG', () => {
+  assert.equal(alternativeFormat(PNG, new Set([JPEG, PNG]), false), JPEG);
+});
+
+test('alternativeFormat: a PNG carrying transparency has nowhere to go', () => {
+  assert.equal(alternativeFormat(PNG, new Set([JPEG, PNG]), true), null);
+});
+
+test('alternativeFormat: nothing better than WebP', () => {
+  assert.equal(alternativeFormat(WEBP, new Set([JPEG, PNG, WEBP]), false), null);
+});
+
+test('alternativeFormat: a JPEG in a browser with no WebP has nowhere to go', () => {
+  assert.equal(alternativeFormat(JPEG, new Set([JPEG, PNG]), false), null);
+});
+
+/* ============================================================ url import */
+
+test('parseImageUrl: http and https are the only schemes', () => {
+  assert.equal(parseImageUrl('https://example.test/a.jpg').href,
+    'https://example.test/a.jpg');
+  assert.equal(parseImageUrl('http://example.test/a.jpg').protocol, 'http:');
+});
+
+test('parseImageUrl: surrounding whitespace is forgiven', () => {
+  assert.equal(parseImageUrl('  https://example.test/a.jpg \n ').hostname,
+    'example.test');
+});
+
+test('parseImageUrl: anything that is not a web address is refused', () => {
+  assert.throws(() => parseImageUrl('not a url'), /Not a valid web address/);
+  assert.throws(() => parseImageUrl(''), /Not a valid web address/);
+  assert.throws(() => parseImageUrl('example.test/a.jpg'), /Not a valid web address/);
+});
+
+test('parseImageUrl: other schemes are named in the refusal', () => {
+  // file:, data: and javascript: all have to be turned away by scheme rather
+  // than by guesswork.
+  for (const raw of ['file:///etc/passwd', 'data:image/png;base64,AAA', 'ftp://x.test/a.jpg']) {
+    assert.throws(() => parseImageUrl(raw), /Only http and https/, raw);
+  }
+});
+
+test('parseImageUrl: the refusal message is short enough to show', () => {
+  try {
+    parseImageUrl('x'.repeat(500));
+    assert.fail('should have thrown');
+  } catch (err) {
+    assert.ok(err.message.length < 100);
+  }
+});

--- a/tests/js/crc32.test.js
+++ b/tests/js/crc32.test.js
@@ -1,0 +1,68 @@
+/**
+ * tools/*\/src/crc32.js - the CRC-32 from the PNG and ZIP specifications.
+ *
+ * Both tools carry a copy, so both copies are checked, and checked against
+ * values from outside this repository rather than against each other.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { crc32 as compressCrc } from '../../tools/compress-image/src/crc32.js';
+import { crc32 as exifCrc } from '../../tools/exif-editor/src/crc32.js';
+import { ascii } from './helpers.js';
+
+const copies = [['compress-image', compressCrc], ['exif-editor', exifCrc]];
+
+for (const [tool, crc32] of copies) {
+  test(`${tool}: the check value from the specification`, () => {
+    // "123456789" is the standard CRC-32 check vector.
+    assert.equal(crc32([ascii('123456789')]), 0xcbf43926);
+  });
+
+  test(`${tool}: an empty input`, () => {
+    assert.equal(crc32([]), 0);
+    assert.equal(crc32([new Uint8Array(0)]), 0);
+  });
+
+  test(`${tool}: known short inputs`, () => {
+    assert.equal(crc32([ascii('a')]), 0xe8b7be43);
+    assert.equal(crc32([ascii('abc')]), 0x352441c2);
+    assert.equal(crc32([new Uint8Array([0])]), 0xd202ef8d);
+  });
+
+  test(`${tool}: parts are checksummed as one run of bytes`, () => {
+    // The signature takes a list because a PNG chunk's CRC covers its type and
+    // its data, which are two arrays and one checksum.
+    assert.equal(crc32([ascii('abc'), ascii('def')]), crc32([ascii('abcdef')]));
+    assert.equal(crc32([ascii('a'), ascii('b'), ascii('c')]), crc32([ascii('abc')]));
+  });
+
+  test(`${tool}: the result is unsigned`, () => {
+    // 0xffffffff read as a signed 32-bit integer would be -1, and a PNG with a
+    // negative CRC written into it is a corrupt PNG.
+    for (const input of ['', 'a', '123456789', '\0\0\0\0', 'the quick brown fox']) {
+      const value = crc32([ascii(input)]);
+      assert.ok(value >= 0 && value <= 0xffffffff, `${input}: ${value}`);
+      assert.ok(Number.isInteger(value));
+    }
+  });
+
+  test(`${tool}: the table survives being built once`, () => {
+    // The table is built lazily on first use; a second call must not rebuild
+    // it into something different.
+    assert.equal(crc32([ascii('123456789')]), crc32([ascii('123456789')]));
+  });
+
+  test(`${tool}: a long input`, () => {
+    const long = new Uint8Array(10000);
+    for (let i = 0; i < long.length; i += 1) long[i] = i & 0xff;
+    assert.equal(crc32([long]), crc32([long.subarray(0, 5000), long.subarray(5000)]));
+  });
+}
+
+test('the two copies agree', () => {
+  const sample = new Uint8Array(512);
+  for (let i = 0; i < sample.length; i += 1) sample[i] = (i * 7) & 0xff;
+  assert.equal(compressCrc([sample]), exifCrc([sample]));
+});

--- a/tests/js/crop-video-mp4.test.js
+++ b/tests/js/crop-video-mp4.test.js
@@ -1,0 +1,251 @@
+/**
+ * tools/crop-video/src/mp4.js - the second hand-written MP4 writer.
+ *
+ * This one has to carry the sound that arrived with the file, so it interleaves
+ * two tracks into chunks and writes a chunk offset table for each. Two things
+ * are worth pinning down:
+ *
+ *   - Frame durations are worked out from the gap to the next frame rather than
+ *     at capture time, which is what keeps a variable frame rate intact: a
+ *     phone that dropped from 30 to 24 fps halfway through is written back with
+ *     exactly the frame times it had.
+ *   - Audio samples and the sample entry describing them are copied verbatim.
+ *     Nothing decodes them, which is why "keep the sound" costs no quality, and
+ *     the test for it is that the bytes come out the other end unchanged.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Mp4Writer, VIDEO_TIMESCALE } from '../../tools/crop-video/src/mp4.js';
+import { ascii, blobBytes } from './helpers.js';
+
+const AVCC = new Uint8Array([1, 0x64, 0, 0x1f, 0xff, 0xe1, 0, 4, 0x67, 1, 2, 3, 1, 0, 4, 0x68, 1, 2, 3]);
+const AUDIO_ENTRY = ascii('mp4a-sample-entry-copied-verbatim');
+
+function boxes(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const found = [];
+  let at = 0;
+  while (at + 8 <= bytes.length) {
+    const size = view.getUint32(at);
+    found.push({ type: new TextDecoder('latin1').decode(bytes.subarray(at + 4, at + 8)), at, size });
+    if (size < 8) break;
+    at += size;
+  }
+  return found;
+}
+
+function countBoxes(bytes, type) {
+  const name = ascii(type);
+  let seen = 0;
+  outer: for (let i = 0; i + 4 <= bytes.length; i += 1) {
+    for (let j = 0; j < 4; j += 1) if (bytes[i + j] !== name[j]) continue outer;
+    seen += 1;
+  }
+  return seen;
+}
+
+function indexOfBytes(haystack, needle, from = 0) {
+  outer: for (let i = from; i + needle.length <= haystack.length; i += 1) {
+    for (let j = 0; j < needle.length; j += 1) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+/** A writer with `frames` video samples, one every 1/30 second. */
+function videoOnly(frames = 4, step = VIDEO_TIMESCALE / 30) {
+  const writer = new Mp4Writer({ width: 320, height: 240 });
+  writer.setDecoderConfig(AVCC);
+  for (let i = 0; i < frames; i += 1) {
+    writer.addVideoSample(ascii(`v${i}`), i === 0, i * step);
+  }
+  return writer;
+}
+
+test('the top-level boxes, in faststart order', async () => {
+  const bytes = await blobBytes(videoOnly().finalize());
+  assert.deepEqual(boxes(bytes).map((b) => b.type), ['ftyp', 'moov', 'mdat']);
+});
+
+test('the box sizes cover the whole file', async () => {
+  const bytes = await blobBytes(videoOnly().finalize());
+  assert.equal(boxes(bytes).reduce((n, b) => n + b.size, 0), bytes.length);
+});
+
+test('video only writes one track', async () => {
+  const bytes = await blobBytes(videoOnly().finalize());
+  assert.equal(countBoxes(bytes, 'trak'), 1);
+});
+
+test('durations come from the gaps between frames', () => {
+  const writer = videoOnly(4);
+  writer.finalize();
+  const step = Math.round(VIDEO_TIMESCALE / 30);
+  assert.deepEqual(writer.video.samples.map((s) => s.duration),
+    [step, step, step, step]);
+});
+
+test('a variable frame rate is written back as it arrived', () => {
+  // 30 fps, then 24 fps halfway through.
+  const fast = Math.round(VIDEO_TIMESCALE / 30);
+  const slow = Math.round(VIDEO_TIMESCALE / 24);
+  const writer = new Mp4Writer({ width: 16, height: 16 });
+  writer.setDecoderConfig(AVCC);
+  let at = 0;
+  for (const gap of [fast, fast, slow, slow]) {
+    writer.addVideoSample(ascii('f'), at === 0, at);
+    at += gap;
+  }
+  writer.addVideoSample(ascii('f'), false, at);
+  writer.finalize();
+
+  const durations = writer.video.samples.map((s) => s.duration);
+  assert.deepEqual(durations.slice(0, 4), [fast, fast, slow, slow]);
+  // The last frame is held for as long as the one before it.
+  assert.equal(durations[4], slow);
+});
+
+test('a single frame is held for a thirtieth of a second', () => {
+  const writer = videoOnly(1);
+  writer.finalize();
+  assert.equal(writer.video.samples[0].duration, Math.round(VIDEO_TIMESCALE / 30));
+});
+
+test('samples arriving out of order are sorted by time', () => {
+  const writer = new Mp4Writer({ width: 16, height: 16 });
+  writer.setDecoderConfig(AVCC);
+  const step = VIDEO_TIMESCALE / 30;
+  writer.addVideoSample(ascii('b'), false, step * 2);
+  writer.addVideoSample(ascii('a'), true, 0);
+  writer.addVideoSample(ascii('c'), false, step * 4);
+  writer.finalize();
+  assert.deepEqual(writer.video.samples.map((s) => new TextDecoder().decode(s.data)),
+    ['a', 'b', 'c']);
+});
+
+test('the frame data reaches mdat in order', async () => {
+  const bytes = await blobBytes(videoOnly(4).finalize());
+  const mdat = boxes(bytes).find((b) => b.type === 'mdat');
+  const body = new TextDecoder('latin1').decode(bytes.subarray(mdat.at + 8));
+  assert.equal(body, 'v0v1v2v3');
+});
+
+test('mdat declares the size of what follows it', async () => {
+  const bytes = await blobBytes(videoOnly(4).finalize());
+  const mdat = boxes(bytes).find((b) => b.type === 'mdat');
+  assert.equal(mdat.size, 8 + 'v0v1v2v3'.length);
+  assert.equal(mdat.at + mdat.size, bytes.length);
+});
+
+test('sound is carried across untouched', async () => {
+  const writer = videoOnly(4);
+  writer.openAudioTrack({ sampleEntry: AUDIO_ENTRY, timescale: 48000 });
+  for (let i = 0; i < 3; i += 1) {
+    writer.addAudioSample(ascii(`a${i}`), i * 1024, 1024);
+  }
+  const bytes = await blobBytes(writer.finalize());
+
+  assert.equal(countBoxes(bytes, 'trak'), 2, 'video and audio');
+  // The sample entry is copied verbatim: nothing here parses it.
+  assert.ok(indexOfBytes(bytes, AUDIO_ENTRY) > 0);
+  for (let i = 0; i < 3; i += 1) {
+    assert.ok(indexOfBytes(bytes, ascii(`a${i}`)) > 0, `audio sample ${i}`);
+  }
+});
+
+test('an audio track with no samples in it is not written', async () => {
+  const writer = videoOnly(2);
+  writer.openAudioTrack({ sampleEntry: AUDIO_ENTRY, timescale: 48000 });
+  const bytes = await blobBytes(writer.finalize());
+  assert.equal(countBoxes(bytes, 'trak'), 1);
+});
+
+test('every chunk offset lands inside mdat', async () => {
+  // stco holds absolute file offsets that depend on how large moov is, which
+  // is only known once moov has been built. Two passes have to converge.
+  const writer = videoOnly(60);
+  writer.openAudioTrack({ sampleEntry: AUDIO_ENTRY, timescale: 48000 });
+  for (let i = 0; i < 90; i += 1) writer.addAudioSample(ascii(`aud${i}`), i * 1024, 1024);
+  const bytes = await blobBytes(writer.finalize());
+
+  const mdat = boxes(bytes).find((b) => b.type === 'mdat');
+  const view = new DataView(bytes.buffer);
+  const name = ascii('stco');
+
+  let tables = 0;
+  outer: for (let i = 0; i + 4 <= bytes.length; i += 1) {
+    for (let j = 0; j < 4; j += 1) if (bytes[i + j] !== name[j]) continue outer;
+    const box = i - 4;
+    const count = view.getUint32(box + 12);
+    assert.ok(count > 0, 'a chunk offset table with nothing in it');
+    for (let n = 0; n < count; n += 1) {
+      const offset = view.getUint32(box + 16 + n * 4);
+      assert.ok(offset >= mdat.at + 8, `offset ${offset} before mdat`);
+      assert.ok(offset < bytes.length, `offset ${offset} past the end`);
+    }
+    tables += 1;
+  }
+  assert.equal(tables, 2, 'one chunk offset table per track');
+});
+
+test('the two tracks are interleaved rather than written end to end', async () => {
+  // A player should not have to hold the whole video to reach the first of the
+  // sound.
+  const writer = new Mp4Writer({ width: 16, height: 16 });
+  writer.setDecoderConfig(AVCC);
+  writer.openAudioTrack({ sampleEntry: AUDIO_ENTRY, timescale: 48000 });
+  for (let i = 0; i < 120; i += 1) {
+    writer.addVideoSample(ascii(`V${String(i).padStart(3, '0')}`), i === 0, (i * VIDEO_TIMESCALE) / 30);
+    writer.addAudioSample(ascii(`A${String(i).padStart(3, '0')}`), (i * 48000) / 30, 48000 / 30);
+  }
+  const bytes = await blobBytes(writer.finalize());
+  const mdat = boxes(bytes).find((b) => b.type === 'mdat');
+
+  const firstAudio = indexOfBytes(bytes, ascii('A000'), mdat.at);
+  const lastVideo = indexOfBytes(bytes, ascii('V119'), mdat.at);
+  assert.ok(firstAudio > 0 && lastVideo > 0);
+  assert.ok(firstAudio < lastVideo, 'sound arrives before the last frame');
+});
+
+test('the decoder configuration is accepted in every shape', () => {
+  const asView = new Mp4Writer({ width: 16, height: 16 });
+  asView.setDecoderConfig(AVCC);
+  assert.deepEqual(asView.avcC, AVCC);
+
+  const asBuffer = new Mp4Writer({ width: 16, height: 16 });
+  asBuffer.setDecoderConfig(AVCC.buffer.slice(0));
+  assert.deepEqual(asBuffer.avcC, AVCC);
+
+  const backing = new Uint8Array([9, 9, ...AVCC, 9]);
+  const asSlice = new Mp4Writer({ width: 16, height: 16 });
+  asSlice.setDecoderConfig(backing.subarray(2, 2 + AVCC.length));
+  assert.deepEqual(asSlice.avcC, AVCC);
+});
+
+test('the first decoder configuration wins', () => {
+  const writer = new Mp4Writer({ width: 16, height: 16 });
+  writer.setDecoderConfig(AVCC);
+  writer.setDecoderConfig(new Uint8Array([9, 9, 9]));
+  assert.deepEqual(writer.avcC, AVCC);
+});
+
+test('refusals rather than a broken file', () => {
+  assert.throws(() => new Mp4Writer({ width: 16, height: 16 }).setDecoderConfig(null),
+    /no decoder configuration/);
+
+  const noFrames = new Mp4Writer({ width: 16, height: 16 });
+  noFrames.setDecoderConfig(AVCC);
+  assert.throws(() => noFrames.finalize(), /No frames were encoded/);
+
+  const noConfig = new Mp4Writer({ width: 16, height: 16 });
+  noConfig.addVideoSample(ascii('v'), true, 0);
+  assert.throws(() => noConfig.finalize(), /never reported a decoder configuration/);
+});
+
+test('the blob is typed as an mp4', () => {
+  assert.equal(videoOnly().finalize().type, 'video/mp4');
+});

--- a/tests/js/exif-container-door.test.js
+++ b/tests/js/exif-container-door.test.js
@@ -1,0 +1,358 @@
+/**
+ * tools/exif-editor/src/container.js and src/report.js.
+ *
+ * container.js is the one door in front of the three formats: it identifies a
+ * file by its first bytes rather than by its name (a ".jpg" that is really a
+ * PNG is common, and acting on the extension would mean writing a JPEG segment
+ * into a PNG), and it turns all three into one shape.
+ *
+ * report.js turns that shape into sentences. The findings list is the part of
+ * the page that matters - it is the answer to "is there anything in this photo
+ * I would not want to post" - so what is asserted here is which findings appear
+ * and how severe each is said to be.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  KIND_NAMES, exifBytes, outputType, readBytes, serialize, sniff,
+} from '../../tools/exif-editor/src/container.js';
+import {
+  badges, bytes as sizeText, buildFindings, countTags, hasMetadata, metadataSize,
+  readPosition, tagGroups,
+} from '../../tools/exif-editor/src/report.js';
+import { TYPE, createEntry } from '../../tools/exif-editor/src/tiff.js';
+import {
+  EXIF_ID, TIFF_LE, VP8_CHUNK, ascii, chunk, concat, indexOfBytes,
+  jpeg as makeJpeg, png as makePng, segment, textChunk, vp8xChunk,
+  webp as makeWebp, webpChunk,
+} from './helpers.js';
+
+const exifSegment = (block) => segment(0xe1, concat(EXIF_ID, block));
+
+/* ================================================================ sniff */
+
+test('sniff: the three formats this tool can rewrite', () => {
+  assert.equal(sniff(makeJpeg([])), 'jpeg');
+  assert.equal(sniff(makePng([])), 'png');
+  assert.equal(sniff(makeWebp([VP8_CHUNK])), 'webp');
+});
+
+test('sniff: the formats it can name but not rewrite', () => {
+  const ftyp = (brand) => concat(new Uint8Array(4), ascii('ftyp'), ascii(brand));
+  assert.equal(sniff(ftyp('heic')), 'heic');
+  assert.equal(sniff(ftyp('mif1')), 'heic');
+  assert.equal(sniff(ftyp('avif')), 'avif');
+  assert.equal(sniff(ascii('GIF89a')), 'gif');
+  assert.equal(sniff(new Uint8Array([0x49, 0x49, 0x2a, 0x00])), 'tiff');
+  assert.equal(sniff(new Uint8Array([0x4d, 0x4d, 0x00, 0x2a])), 'tiff');
+});
+
+test('sniff: anything else', () => {
+  assert.equal(sniff(ascii('hello there')), 'unknown');
+  assert.equal(sniff(new Uint8Array(0)), 'unknown');
+  assert.equal(sniff(new Uint8Array([0xff])), 'unknown');
+});
+
+test('sniff: the name is never consulted', async () => {
+  // A PNG that arrived called ".jpg" must be read as a PNG.
+  const item = await readBytes(makePng([]));
+  assert.equal(item.kind, 'png');
+  assert.equal(KIND_NAMES[item.kind], 'PNG');
+});
+
+/* ============================================================= readBytes */
+
+test('readBytes: a JPEG with EXIF in it', async () => {
+  const item = await readBytes(makeJpeg([exifSegment(TIFF_LE)]));
+  assert.equal(item.ok, true);
+  assert.equal(item.kind, 'jpeg');
+  assert.equal(item.exif.ok, true);
+  assert.equal(item.size, makeJpeg([exifSegment(TIFF_LE)]).length);
+  assert.equal(countTags(item), 2);
+});
+
+test('readBytes: EXIF that will not parse comes back as a failure, not a crash', async () => {
+  const item = await readBytes(makeJpeg([exifSegment(ascii('XXnot a tiff block'))]));
+  assert.equal(item.ok, true, 'the file itself still read');
+  assert.equal(item.exif.ok, false);
+  assert.ok(item.exif.error);
+});
+
+test('readBytes: a file with no EXIF has no model', async () => {
+  const item = await readBytes(makeJpeg([]));
+  assert.equal(item.exif, null);
+  assert.equal(countTags(item), 0);
+});
+
+test('readBytes: a format that cannot be rewritten explains itself', async () => {
+  const heic = concat(new Uint8Array(4), ascii('ftyp'), ascii('heic'), new Uint8Array(8));
+  const item = await readBytes(heic);
+  assert.equal(item.ok, false);
+  assert.equal(item.kind, 'heic');
+  assert.match(item.error, /Convert it to JPEG/);
+});
+
+test('readBytes: an unknown format is refused plainly', async () => {
+  const item = await readBytes(ascii('this is a text file'));
+  assert.equal(item.ok, false);
+  assert.match(item.error, /JPEG, PNG or WebP/);
+});
+
+test('readBytes: a damaged file of a known format reports the format error', async () => {
+  const item = await readBytes(concat([0xff, 0xd8, 0xff], ascii('broken')));
+  assert.equal(item.ok, false);
+  assert.equal(item.kind, 'jpeg');
+});
+
+test('readBytes: the original bytes are kept', async () => {
+  // "Undo my changes" is this function run again on them.
+  const original = makeJpeg([exifSegment(TIFF_LE)]);
+  const item = await readBytes(original);
+  assert.deepEqual(item.bytes, original);
+});
+
+/* ============================================================= serialize */
+
+test('serialize: stripping a JPEG keeps the scan', async () => {
+  const scan = ascii('PICTURE DATA');
+  const item = await readBytes(makeJpeg([exifSegment(TIFF_LE)], scan));
+  const out = serialize(item, { exif: null, xmp: null, comments: null, extras: null });
+  assert.ok(indexOfBytes(out, scan) > 0);
+  assert.equal((await readBytes(out)).exif, null);
+});
+
+test('serialize: the in-memory document is not changed', async () => {
+  // A failed or cancelled save must not leave the copy half-rewritten.
+  const item = await readBytes(makeJpeg([exifSegment(TIFF_LE)]));
+  const before = item.doc.segments.length;
+  serialize(item, { exif: null });
+  assert.equal(item.doc.segments.length, before);
+  assert.equal(countTags(item), 2);
+});
+
+test('serialize: a PNG and a WebP go through the same door', async () => {
+  const pngItem = await readBytes(makePng([chunk('eXIf', TIFF_LE)]));
+  assert.equal((await readBytes(serialize(pngItem, { exif: null }))).exif, null);
+
+  const webpItem = await readBytes(
+    makeWebp([vp8xChunk(0x08), VP8_CHUNK, webpChunk('EXIF', TIFF_LE)]));
+  assert.equal((await readBytes(serialize(webpItem, { exif: null }))).exif, null);
+});
+
+test('exifBytes: an edited model comes back as a block', async () => {
+  const item = await readBytes(makeJpeg([exifSegment(TIFF_LE)]));
+  const block = exifBytes(item.exif);
+  assert.ok(block instanceof Uint8Array);
+  assert.equal((await readBytes(serialize(item, { exif: block }))).exif.ok, true);
+});
+
+test('exifBytes: nothing left means nothing written', () => {
+  assert.equal(exifBytes(null), null);
+  assert.equal(exifBytes({ ok: false }), null);
+  assert.equal(exifBytes({ ok: true, groups: {} }), null);
+});
+
+test('outputType: the extension and type each format is saved as', () => {
+  assert.deepEqual(outputType('png'), { mime: 'image/png', ext: 'png' });
+  assert.deepEqual(outputType('webp'), { mime: 'image/webp', ext: 'webp' });
+  assert.deepEqual(outputType('jpeg'), { mime: 'image/jpeg', ext: 'jpg' });
+  assert.deepEqual(outputType('anything else'), { mime: 'image/jpeg', ext: 'jpg' });
+});
+
+/* ================================================================ report */
+
+test('bytes: sizes in the units a person would say them in', () => {
+  assert.equal(sizeText(0), '0 bytes');
+  assert.equal(sizeText(1023), '1023 bytes');
+  assert.equal(sizeText(1024), '1.0 KB');
+  assert.equal(sizeText(10240), '10 KB');
+  assert.equal(sizeText(1024 * 1024), '1.0 MB');
+});
+
+test('readPosition: degrees, minutes and seconds become a decimal', () => {
+  const gps = [
+    { tag: 0x0001, value: 'N' },
+    { tag: 0x0002, value: [51, 30, 26] },
+    { tag: 0x0003, value: 'W' },
+    { tag: 0x0004, value: [0, 7, 39] },
+  ];
+  const position = readPosition(gps);
+  assert.ok(Math.abs(position.lat - 51.507222) < 1e-5);
+  assert.ok(Math.abs(position.lon - -0.1275) < 1e-5);
+  assert.match(position.text, /51\.507222. N, 0\.127500. W/);
+});
+
+test('readPosition: the hemisphere tag decides the sign', () => {
+  const at = (ref) => readPosition([
+    { tag: 0x0001, value: ref }, { tag: 0x0002, value: [10, 0, 0] },
+    { tag: 0x0003, value: 'E' }, { tag: 0x0004, value: [10, 0, 0] },
+  ]).lat;
+  assert.equal(at('N'), 10);
+  assert.equal(at('S'), -10);
+});
+
+test('readPosition: altitude is read and said in words', () => {
+  const gps = [
+    { tag: 0x0001, value: 'N' }, { tag: 0x0002, value: [1, 0, 0] },
+    { tag: 0x0003, value: 'E' }, { tag: 0x0004, value: [1, 0, 0] },
+    { tag: 0x0005, value: 1 }, { tag: 0x0006, value: 12.4 },
+  ];
+  assert.equal(readPosition(gps).altitude, '12 m below sea level');
+});
+
+test('readPosition: an incomplete coordinate is no coordinate', () => {
+  assert.equal(readPosition([]), null);
+  assert.equal(readPosition(null), null);
+  assert.equal(readPosition([{ tag: 0x0002, value: [51, 30, 26] }]), null,
+    'a latitude with no longitude');
+  assert.equal(readPosition([
+    { tag: 0x0002, value: [51, 30] }, { tag: 0x0004, value: [0, 7, 39] },
+  ]), null, 'fewer than three parts');
+});
+
+/** An item shaped the way readBytes returns one, for the report functions. */
+function itemWith({ groups = {}, meta = {}, ...rest } = {}) {
+  return {
+    ok: true,
+    kind: 'jpeg',
+    exif: { ok: true, groups: { ifd0: [], exif: [], gps: [], interop: [], ifd1: [], ...groups } },
+    meta: {
+      exif: null, xmp: null, iptc: null, icc: null,
+      comments: [], text: [], extras: [], notes: [], ...meta,
+    },
+    ...rest,
+  };
+}
+
+test('findings: a location is the headline finding', () => {
+  const item = itemWith({
+    meta: { exif: ascii('block') },
+    groups: {
+      gps: [
+        { tag: 0x0001, value: 'N' }, { tag: 0x0002, value: [51, 30, 26] },
+        { tag: 0x0003, value: 'W' }, { tag: 0x0004, value: [0, 7, 39] },
+      ],
+    },
+  });
+  const found = buildFindings(item);
+  assert.equal(found[0].level, 'high');
+  assert.match(found[0].title, /Where the photo was taken/);
+});
+
+test('findings: EXIF that will not parse is a reason to remove it', () => {
+  const item = itemWith({
+    exifUnreadable: true,
+    exifError: 'The TIFF magic number is wrong.',
+    meta: { exif: ascii('block') },
+  });
+  const found = buildFindings(item);
+  assert.ok(found.some((f) => f.level === 'high' && /nobody can read/.test(f.title)));
+});
+
+test('findings: an EXIF block that parses to nothing is only worth a note', () => {
+  const item = itemWith({ meta: { exif: ascii('block') } });
+  const found = buildFindings(item);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].level, 'low');
+  assert.match(found[0].title, /nothing in it/);
+});
+
+test('findings: a clean file has none', () => {
+  assert.deepEqual(buildFindings(itemWith()), []);
+});
+
+test('countTags: across every directory', () => {
+  const item = itemWith({
+    groups: {
+      ifd0: [{ tag: 1 }, { tag: 2 }],
+      exif: [{ tag: 3 }],
+      gps: [{ tag: 4 }],
+    },
+  });
+  assert.equal(countTags(item), 4);
+  assert.equal(countTags({ exif: null }), 0);
+  assert.equal(countTags({ exif: { ok: false } }), 0);
+});
+
+test('metadataSize: the blocks are added up', () => {
+  const item = itemWith({
+    meta: {
+      exif: new Uint8Array(100),
+      xmp: 'x'.repeat(50),
+      icc: new Uint8Array(20),
+      comments: ['abc'],
+      text: [{ keyword: 'ab', value: 'cd' }],
+      extras: [{ label: 'x', size: 7 }],
+    },
+  });
+  assert.equal(metadataSize(item), 100 + 50 + 20 + 3 + 4 + 7);
+});
+
+test('badges: an unreadable file says only that', () => {
+  assert.deepEqual(badges({ ok: false }), [{ label: 'Cannot read', level: 'high' }]);
+});
+
+test('badges: a clean file says so rather than saying nothing', () => {
+  assert.deepEqual(badges(itemWith()), [{ label: 'Nothing found', level: 'clean' }]);
+});
+
+test('badges: GPS outranks everything else', () => {
+  const item = itemWith({
+    meta: { exif: ascii('x'), xmp: 'x', icc: new Uint8Array(1) },
+    groups: { gps: [{ tag: 1 }], ifd0: [{ tag: 2 }] },
+  });
+  const labels = badges(item).map((b) => b.label);
+  assert.equal(labels[0], 'GPS');
+  assert.ok(labels.includes('EXIF 2'));
+  assert.ok(labels.includes('XMP'));
+  assert.ok(labels.includes('ICC'));
+});
+
+test('badges: an empty EXIF block is distinguished from an unreadable one', () => {
+  assert.ok(badges(itemWith({ meta: { exif: ascii('x') } }))
+    .some((b) => b.label === 'EXIF empty'));
+  assert.ok(badges(itemWith({ exifUnreadable: true, meta: { exif: ascii('x') } }))
+    .some((b) => b.label === 'EXIF unreadable'));
+});
+
+test('hasMetadata: a block that parsed to nothing is still bytes to remove', () => {
+  assert.equal(hasMetadata(itemWith()), false);
+  assert.equal(hasMetadata(itemWith({ meta: { exif: ascii('x') } })), true);
+  assert.equal(hasMetadata(itemWith({ meta: { comments: ['hi'] } })), true);
+  assert.equal(hasMetadata(itemWith({ groups: { ifd0: [{ tag: 1 }] } })), true);
+  assert.equal(hasMetadata({ ok: false }), false);
+});
+
+test('tagGroups: empty directories are left out and tags are sorted', () => {
+  const item = itemWith({
+    groups: {
+      ifd0: [{ tag: 0x0112 }, { tag: 0x010f }],
+      exif: [{ tag: 0x829a }],
+    },
+  });
+  const shown = tagGroups(item);
+  assert.deepEqual(shown.map((g) => g.id), ['ifd0', 'exif']);
+  assert.deepEqual(shown[0].entries.map((e) => e.tag), [0x010f, 0x0112]);
+  assert.equal(tagGroups({ exif: null }).length, 0);
+});
+
+test('a real edit survives the whole door: read, edit, write, read again', async () => {
+  const item = await readBytes(makeJpeg([exifSegment(TIFF_LE)]));
+  item.exif.groups.ifd0.push(createEntry(0x010e, TYPE.ASCII, 'A description', true));
+
+  const out = serialize(item, { exif: exifBytes(item.exif) });
+  const back = await readBytes(out);
+
+  assert.equal(back.exif.ok, true);
+  assert.equal(countTags(back), 3);
+  assert.equal(back.exif.groups.ifd0.find((e) => e.tag === 0x010e).value,
+    'A description');
+});
+
+test('text chunks in a PNG reach the report', async () => {
+  const item = await readBytes(makePng([textChunk('Author', 'Jane')]));
+  assert.equal(hasMetadata(item), true);
+  assert.ok(badges(item).some((b) => b.label === 'Text 1'));
+});

--- a/tests/js/exif-containers.test.js
+++ b/tests/js/exif-containers.test.js
@@ -1,0 +1,458 @@
+/**
+ * tools/exif-editor/src/{jpeg,png,webp}.js.
+ *
+ * All three do the same job three ways: split a file into a list, report what
+ * metadata is in it, rewrite the list from a plan, and put it back together.
+ *
+ * The claim that matters is the one on every page of the tool: removing
+ * metadata does not touch the picture. For JPEG that means the entropy-coded
+ * scan is copied byte for byte; for PNG it means IDAT is; for WebP it means
+ * the VP8 chunk is. Each of those is asserted below on a file that had its
+ * metadata taken out.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import * as jpeg from '../../tools/exif-editor/src/jpeg.js';
+import * as png from '../../tools/exif-editor/src/png.js';
+import * as webp from '../../tools/exif-editor/src/webp.js';
+import {
+  EXIF_ID, IDAT, IHDR, JFIF_SEGMENT, PNG_SIGNATURE, VP8_CHUNK, XMP_ID,
+  ascii, chunk, concat, deflate, indexOfBytes, jpeg as makeJpeg, png as makePng,
+  segment, textChunk, vp8xChunk, webp as makeWebp, webpChunk,
+} from './helpers.js';
+
+const STRIP_ALL = { exif: null, xmp: null, iptc: null, icc: null, comments: null, extras: null, text: null };
+
+/* ================================================================== JPEG */
+
+test('jpeg: a file that does not start like one', () => {
+  assert.equal(jpeg.read(ascii('nope')).ok, false);
+  assert.match(jpeg.read(ascii('nope')).error, /does not start like a JPEG/);
+});
+
+test('jpeg: a file with no scan in it', () => {
+  const parsed = jpeg.read(new Uint8Array([0xff, 0xd8, 0xff, 0xd9]));
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /ended before the image data/);
+});
+
+test('jpeg: a segment claiming a length past the end of the file', () => {
+  const bytes = concat([0xff, 0xd8], [0xff, 0xe1], [0xff, 0xff], ascii('short'));
+  const parsed = jpeg.read(bytes);
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /runs off the end/);
+});
+
+test('jpeg: lost segment structure is reported', () => {
+  const bytes = concat([0xff, 0xd8], ascii('not a marker'));
+  assert.match(jpeg.read(bytes).error, /segment structure/);
+});
+
+test('jpeg: read then write is byte-for-byte', () => {
+  const bytes = makeJpeg([JFIF_SEGMENT, segment(0xe1, concat(EXIF_ID, ascii('block')))]);
+  const doc = jpeg.read(bytes);
+  assert.equal(doc.ok, true);
+  assert.deepEqual(jpeg.write(doc), bytes);
+});
+
+test('jpeg: padding 0xff bytes before a marker are tolerated', () => {
+  const bytes = concat([0xff, 0xd8], [0xff, 0xff, 0xff], JFIF_SEGMENT,
+    [0xff, 0xda], [0x00, 0x04], ascii('ab'));
+  const doc = jpeg.read(bytes);
+  assert.equal(doc.ok, true);
+  assert.equal(doc.segments.length, 1);
+});
+
+test('jpeg: standalone markers carry no payload', () => {
+  const bytes = concat([0xff, 0xd8], [0xff, 0x01], [0xff, 0xd0], JFIF_SEGMENT,
+    [0xff, 0xda], [0x00, 0x04], ascii('ab'));
+  assert.equal(jpeg.read(bytes).segments.length, 1);
+});
+
+test('jpeg: the exif block is collected without its wrapper', () => {
+  const bytes = makeJpeg([segment(0xe1, concat(EXIF_ID, ascii('TIFFBLOCK')))]);
+  const meta = jpeg.collect(jpeg.read(bytes));
+  assert.deepEqual(meta.exif, ascii('TIFFBLOCK'));
+});
+
+test('jpeg: xmp is collected as text', () => {
+  const bytes = makeJpeg([segment(0xe1, concat(XMP_ID, ascii('<x:xmpmeta/>')))]);
+  assert.equal(jpeg.collect(jpeg.read(bytes)).xmp, '<x:xmpmeta/>');
+});
+
+test('jpeg: a comment is collected', () => {
+  const bytes = makeJpeg([segment(0xfe, ascii('taken on holiday'))]);
+  assert.deepEqual(jpeg.collect(jpeg.read(bytes)).comments, ['taken on holiday']);
+});
+
+test('jpeg: an ICC profile split over segments is rejoined in order', () => {
+  const part = (seq, total, body) =>
+    segment(0xe2, concat(ascii('ICC_PROFILE\0'), [seq, total], ascii(body)));
+  // Deliberately out of order in the file.
+  const bytes = makeJpeg([part(2, 2, 'second'), part(1, 2, 'first')]);
+  assert.equal(new TextDecoder().decode(jpeg.collect(jpeg.read(bytes)).icc),
+    'firstsecond');
+});
+
+test('jpeg: jfif and the adobe marker are reported as deliberately kept', () => {
+  const adobe = segment(0xee, ascii('Adobe\0something'));
+  const meta = jpeg.collect(jpeg.read(makeJpeg([JFIF_SEGMENT, adobe])));
+  assert.deepEqual(meta.notes.map((n) => n.label),
+    ['JFIF header', 'Adobe colour marker']);
+  assert.equal(meta.extras.length, 0);
+});
+
+test('jpeg: an unidentified APPn segment is labelled by its signature', () => {
+  const bytes = makeJpeg([segment(0xe5, ascii('SomeTool\0payload'))]);
+  const extras = jpeg.collect(jpeg.read(bytes)).extras;
+  assert.equal(extras.length, 1);
+  assert.equal(extras[0].label, 'APP5 (SomeTool)');
+});
+
+test('jpeg: an APPn with no readable signature is named by its number', () => {
+  const bytes = makeJpeg([segment(0xe5, new Uint8Array([1, 2, 3, 0, 9]))]);
+  assert.equal(jpeg.collect(jpeg.read(bytes)).extras[0].label, 'APP5');
+});
+
+test('jpeg: stripping everything leaves the scan untouched', () => {
+  const scan = ascii('ENTROPY CODED PICTURE DATA');
+  const bytes = makeJpeg([
+    JFIF_SEGMENT,
+    segment(0xe1, concat(EXIF_ID, ascii('exif'))),
+    segment(0xe1, concat(XMP_ID, ascii('xmp'))),
+    segment(0xfe, ascii('a comment')),
+    segment(0xe5, ascii('Other\0junk')),
+    segment(0xdb, ascii('quantisation table')), // image data, must survive
+  ], scan);
+
+  const doc = jpeg.read(bytes);
+  jpeg.apply(doc, STRIP_ALL);
+  const out = jpeg.write(doc);
+
+  const meta = jpeg.collect(doc);
+  assert.equal(meta.exif, null);
+  assert.equal(meta.xmp, null);
+  assert.deepEqual(meta.comments, []);
+  assert.deepEqual(meta.extras, []);
+  assert.ok(indexOfBytes(out, scan) > 0, 'the scan is still in the file');
+  assert.ok(indexOfBytes(out, ascii('quantisation table')) > 0, 'image data kept');
+  assert.equal(indexOfBytes(out, ascii('a comment')), -1);
+  assert.ok(out.length < bytes.length);
+});
+
+test('jpeg: jfif goes first and the adobe marker survives stripping', () => {
+  const doc = jpeg.read(makeJpeg([
+    segment(0xfe, ascii('comment')),
+    segment(0xee, ascii('Adobe\0x')),
+    JFIF_SEGMENT,
+  ]));
+  jpeg.apply(doc, STRIP_ALL);
+  // Removing the Adobe marker turns some files inside out colour-wise.
+  assert.equal(new TextDecoder('latin1').decode(doc.segments[0].payload).slice(0, 5), 'JFIF\0');
+  assert.equal(doc.segments.length, 2);
+});
+
+test('jpeg: a key left out of the plan means leave it alone', () => {
+  const doc = jpeg.read(makeJpeg([segment(0xfe, ascii('keep me'))]));
+  jpeg.apply(doc, { exif: null });
+  assert.deepEqual(jpeg.collect(doc).comments, ['keep me']);
+});
+
+test('jpeg: a new exif block is written into an APP1 segment', () => {
+  const doc = jpeg.read(makeJpeg([]));
+  jpeg.apply(doc, { exif: ascii('NEWBLOCK') });
+  assert.deepEqual(jpeg.collect(doc).exif, ascii('NEWBLOCK'));
+  assert.deepEqual(jpeg.write(doc).subarray(0, 2), new Uint8Array([0xff, 0xd8]));
+});
+
+test('jpeg: metadata too large for one segment is refused with advice', () => {
+  const doc = jpeg.read(makeJpeg([]));
+  assert.throws(
+    () => jpeg.apply(doc, { exif: new Uint8Array(70000) }),
+    /thumbnail|maker note/,
+  );
+});
+
+/* =================================================================== PNG */
+
+test('png: a file that does not start like one', async () => {
+  const parsed = await png.read(ascii('not a png at all'));
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /does not start like a PNG/);
+});
+
+test('png: a chunk claiming a length past the end of the file', async () => {
+  const bad = concat(PNG_SIGNATURE, [0xff, 0xff, 0xff, 0xff], ascii('IHDR'), ascii('xx'));
+  assert.match((await png.read(bad)).error, /runs off the end/);
+});
+
+test('png: a file whose first chunk is not IHDR', async () => {
+  const bad = concat(PNG_SIGNATURE, textChunk('a', 'b'));
+  assert.match((await png.read(bad)).error, /header chunk is missing/);
+});
+
+test('png: read then write recomputes every CRC and matches', async () => {
+  const bytes = makePng([textChunk('Author', 'Jane')]);
+  const doc = await png.read(bytes);
+  assert.equal(doc.ok, true);
+  assert.deepEqual(png.write(doc), bytes);
+});
+
+test('png: chunks after IEND are not read', async () => {
+  const bytes = concat(makePng([]), textChunk('Trailing', 'junk'));
+  const doc = await png.read(bytes);
+  assert.equal(doc.chunks.at(-1).type, 'IEND');
+});
+
+test('png: a tEXt chunk is unpacked', async () => {
+  const doc = await png.read(makePng([textChunk('Author', 'Jane Doe')]));
+  const meta = png.collect(doc);
+  assert.equal(meta.text.length, 1);
+  assert.equal(meta.text[0].keyword, 'Author');
+  assert.equal(meta.text[0].value, 'Jane Doe');
+  assert.equal(meta.text[0].encoding, 'tEXt');
+});
+
+test('png: a zTXt chunk is decompressed', async () => {
+  const body = await deflate(ascii('a compressed comment'));
+  const zTXt = chunk('zTXt', concat(ascii('Comment'), [0, 0], body));
+  const meta = png.collect(await png.read(makePng([zTXt])));
+  assert.equal(meta.text[0].value, 'a compressed comment');
+});
+
+test('png: an unreadable compressed chunk is still reported', async () => {
+  // Unreadable is not the same as empty: it is still there and still
+  // removable.
+  const zTXt = chunk('zTXt', concat(ascii('Comment'), [0, 0], ascii('not deflate')));
+  const meta = png.collect(await png.read(makePng([zTXt])));
+  assert.equal(meta.text[0].unreadable, true);
+  assert.equal(meta.text[0].value, null);
+});
+
+test('png: an eXIf chunk is collected', async () => {
+  const doc = await png.read(makePng([chunk('eXIf', ascii('TIFFBLOCK'))]));
+  assert.deepEqual(png.collect(doc).exif, ascii('TIFFBLOCK'));
+});
+
+test('png: a JPEG-style Exif marker in front is tolerated', async () => {
+  const doc = await png.read(makePng([chunk('eXIf', concat(EXIF_ID, ascii('TIFF')))]));
+  assert.deepEqual(png.collect(doc).exif, ascii('TIFF'));
+});
+
+test('png: an XMP packet is recognised by its keyword', async () => {
+  const iTXt = chunk('iTXt', concat(
+    ascii('XML:com.adobe.xmp'), [0, 0, 0, 0, 0], ascii('<x:xmpmeta/>'),
+  ));
+  const meta = png.collect(await png.read(makePng([iTXt])));
+  assert.equal(meta.xmp, '<x:xmpmeta/>');
+  assert.equal(meta.text.length, 0, 'XMP is not listed twice');
+});
+
+test('png: an ICC profile is collected with its name', async () => {
+  const iCCP = chunk('iCCP', concat(ascii('Display P3'), [0, 0], ascii('profile')));
+  const meta = png.collect(await png.read(makePng([iCCP])));
+  assert.equal(meta.iccName, 'Display P3');
+  assert.deepEqual(meta.icc, ascii('profile'));
+});
+
+test('png: tIME and dSIG are listed as removable extras', async () => {
+  const doc = await png.read(makePng([chunk('tIME', new Uint8Array(7)), chunk('dSIG', ascii('sig'))]));
+  assert.deepEqual(png.collect(doc).extras.map((e) => e.label), [
+    'Last-modified time (tIME)', 'Embedded digital signature (dSIG)',
+  ]);
+});
+
+test('png: stripping everything leaves IDAT untouched', async () => {
+  const bytes = makePng([
+    textChunk('Author', 'Jane'),
+    chunk('eXIf', ascii('TIFFBLOCK')),
+    chunk('iCCP', concat(ascii('P3'), [0, 0], ascii('profile'))),
+    chunk('tIME', new Uint8Array(7)),
+  ]);
+  const doc = await png.read(bytes);
+  png.apply(doc, STRIP_ALL);
+  const out = png.write(doc);
+
+  assert.deepEqual(doc.chunks.map((c) => c.type), ['IHDR', 'IDAT', 'IEND']);
+  assert.ok(indexOfBytes(out, IDAT) > 0, 'IDAT survives byte for byte');
+  assert.equal(indexOfBytes(out, ascii('Jane')), -1);
+  assert.ok(out.length < bytes.length);
+});
+
+test('png: new metadata goes in after IHDR and nothing else moves', async () => {
+  // An animated PNG carries fcTL and fdAT chunks after IDAT; shuffling chunks
+  // into tidy groups would quietly turn the animation into a still.
+  const fcTL = chunk('fcTL', new Uint8Array(26));
+  const fdAT = chunk('fdAT', ascii('frame'));
+  const bytes = concat(PNG_SIGNATURE, IHDR, IDAT, fcTL, fdAT, chunk('IEND'));
+  const doc = await png.read(bytes);
+  png.apply(doc, { exif: ascii('NEW') });
+  assert.deepEqual(doc.chunks.map((c) => c.type),
+    ['IHDR', 'eXIf', 'IDAT', 'fcTL', 'fdAT', 'IEND']);
+});
+
+test('png: plain text is written as tEXt and other text as iTXt', async () => {
+  const doc = await png.read(makePng([]));
+  png.apply(doc, { text: [{ keyword: 'A', value: 'plain' }, { keyword: 'B', value: 'café — x' }] });
+  assert.deepEqual(doc.chunks.map((c) => c.type), ['IHDR', 'tEXt', 'iTXt', 'IDAT', 'IEND']);
+
+  const back = png.collect(await png.read(png.write(doc)));
+  assert.deepEqual(back.text.map((t) => t.value), ['plain', 'café — x']);
+});
+
+test('png: a keyword longer than the format allows is truncated', async () => {
+  const doc = await png.read(makePng([]));
+  png.apply(doc, { text: [{ keyword: 'k'.repeat(120), value: 'v' }] });
+  assert.equal(png.collect(doc).text[0].keyword.length, 79);
+});
+
+/* ================================================================== WebP */
+
+test('webp: a file that does not start like one', () => {
+  assert.match(webp.read(ascii('RIFFxxxxNOPExxxx')).error, /does not start like a WebP/);
+  assert.match(webp.read(ascii('short')).error, /does not start like a WebP/);
+});
+
+test('webp: a chunk claiming a size past the end of the file', () => {
+  const bytes = concat(ascii('RIFF'), new Uint8Array([20, 0, 0, 0]), ascii('WEBP'),
+    ascii('VP8 '), new Uint8Array([0xff, 0xff, 0, 0]), ascii('xx'));
+  assert.match(webp.read(bytes).error, /runs off the end/);
+});
+
+test('webp: read then write is byte-for-byte', () => {
+  const bytes = makeWebp([vp8xChunk(0x08), VP8_CHUNK, webpChunk('EXIF', ascii('TIFF'))]);
+  const doc = webp.read(bytes);
+  assert.equal(doc.ok, true);
+  assert.deepEqual(webp.write(doc), bytes);
+});
+
+test('webp: an odd-length chunk is padded and the pad is not data', () => {
+  const bytes = makeWebp([webpChunk('EXIF', ascii('odd')), VP8_CHUNK]);
+  const doc = webp.read(bytes);
+  assert.deepEqual(doc.chunks[0].data, ascii('odd'));
+  assert.deepEqual(webp.write(doc), bytes);
+});
+
+test('webp: metadata chunks are collected', () => {
+  const doc = webp.read(makeWebp([
+    vp8xChunk(0x2c), VP8_CHUNK,
+    webpChunk('EXIF', ascii('TIFFBLOCK')),
+    webpChunk('XMP ', ascii('<x:xmpmeta/>')),
+    webpChunk('ICCP', ascii('profile')),
+  ]));
+  const meta = webp.collect(doc);
+  assert.deepEqual(meta.exif, ascii('TIFFBLOCK'));
+  assert.equal(meta.xmp, '<x:xmpmeta/>');
+  assert.deepEqual(meta.icc, ascii('profile'));
+});
+
+test('webp: a JPEG-style Exif marker in front is tolerated', () => {
+  const doc = webp.read(makeWebp([VP8_CHUNK, webpChunk('EXIF', concat(EXIF_ID, ascii('TIFF')))]));
+  assert.deepEqual(webp.collect(doc).exif, ascii('TIFF'));
+});
+
+test('webp: a chunk this tool cannot read is reported as an extra', () => {
+  // "Remove everything" promises that any block this tool could not identify
+  // goes. JPEG and PNG always kept that promise; WebP once quietly did not.
+  const doc = webp.read(makeWebp([VP8_CHUNK, webpChunk('ZZZZ', ascii('who knows'))]));
+  const extras = webp.collect(doc).extras;
+  assert.equal(extras.length, 1);
+  assert.equal(extras[0].label, '"ZZZZ" chunk');
+  assert.equal(extras[0].size, 'who knows'.length);
+});
+
+test('webp: the chunks it does understand are not reported as extras', () => {
+  const doc = webp.read(makeWebp([
+    vp8xChunk(0x2c), VP8_CHUNK,
+    webpChunk('EXIF', ascii('x')), webpChunk('XMP ', ascii('y')),
+    webpChunk('ICCP', ascii('z')), webpChunk('ALPH', ascii('a')),
+  ]));
+  assert.deepEqual(webp.collect(doc).extras, []);
+});
+
+test('webp: an unreadable chunk is removed with the rest', () => {
+  const doc = webp.read(makeWebp([
+    vp8xChunk(0x08), VP8_CHUNK,
+    webpChunk('EXIF', ascii('TIFF')), webpChunk('ZZZZ', ascii('who knows')),
+  ]));
+  webp.apply(doc, STRIP_ALL);
+  assert.deepEqual(doc.chunks.map((c) => c.fourcc), ['VP8X', 'VP8 ']);
+  assert.equal(indexOfBytes(webp.write(doc), ascii('who knows')), -1);
+});
+
+test('webp: an unprintable fourcc is shown safely', () => {
+  const doc = webp.read(makeWebp([VP8_CHUNK, webpChunk('ab', ascii('x'))]));
+  assert.equal(webp.collect(doc).extras[0].label, '"??ab" chunk');
+});
+
+test('webp: stripping everything clears the VP8X flags to match', () => {
+  // A file that says it has metadata and does not is what some readers treat
+  // as corruption.
+  const doc = webp.read(makeWebp([
+    vp8xChunk(0x08 | 0x04 | 0x20), VP8_CHUNK,
+    webpChunk('EXIF', ascii('TIFF')),
+    webpChunk('XMP ', ascii('xmp')),
+    webpChunk('ICCP', ascii('profile')),
+  ]));
+  webp.apply(doc, STRIP_ALL);
+
+  const vp8x = doc.chunks.find((c) => c.fourcc === 'VP8X');
+  assert.equal(vp8x.data[0], 0, 'every optional-chunk flag is cleared');
+  assert.deepEqual(doc.chunks.map((c) => c.fourcc), ['VP8X', 'VP8 ']);
+});
+
+test('webp: the alpha flag is carried over rather than derived', () => {
+  // A lossless bitstream can set it with no ALPH chunk of its own.
+  const doc = webp.read(makeWebp([vp8xChunk(0x10 | 0x08), VP8_CHUNK, webpChunk('EXIF', ascii('x'))]));
+  webp.apply(doc, { exif: null });
+  assert.equal(doc.chunks.find((c) => c.fourcc === 'VP8X').data[0], 0x10);
+});
+
+test('webp: adding metadata sets the flag for it', () => {
+  const doc = webp.read(makeWebp([vp8xChunk(0), VP8_CHUNK]));
+  webp.apply(doc, { exif: ascii('TIFF') });
+  assert.equal(doc.chunks.find((c) => c.fourcc === 'VP8X').data[0] & 0x08, 0x08);
+});
+
+test('webp: a plain file gains a VP8X header when metadata is added', () => {
+  const doc = webp.read(makeWebp([VP8_CHUNK]));
+  doc.canvas = { width: 16, height: 16 };
+  webp.apply(doc, { exif: ascii('TIFF') });
+
+  const vp8x = doc.chunks.find((c) => c.fourcc === 'VP8X');
+  assert.ok(vp8x, 'a VP8X header was built');
+  assert.equal(vp8x.data[4], 15, 'width - 1, little-endian');
+  assert.equal(vp8x.data[7], 15, 'height - 1');
+  assert.equal(vp8x.data[0] & 0x08, 0x08);
+});
+
+test('webp: adding metadata without a known size is refused', () => {
+  const doc = webp.read(makeWebp([VP8_CHUNK]));
+  assert.throws(() => webp.apply(doc, { exif: ascii('TIFF') }), /size could not be read/);
+});
+
+test('webp: chunks come out in the order the specification asks for', () => {
+  const doc = webp.read(makeWebp([VP8_CHUNK, vp8xChunk(0)]));
+  doc.canvas = { width: 16, height: 16 };
+  webp.apply(doc, { exif: ascii('TIFF'), xmp: 'xmp' });
+  assert.deepEqual(doc.chunks.map((c) => c.fourcc), ['VP8X', 'VP8 ', 'EXIF', 'XMP ']);
+});
+
+test('webp: the picture chunk is copied untouched', () => {
+  const bytes = makeWebp([vp8xChunk(0x08), VP8_CHUNK, webpChunk('EXIF', ascii('TIFF'))]);
+  const doc = webp.read(bytes);
+  webp.apply(doc, STRIP_ALL);
+  const out = webp.write(doc);
+  assert.ok(indexOfBytes(out, ascii('bitstream')) > 0);
+  assert.equal(indexOfBytes(out, ascii('TIFF')), -1);
+});
+
+test('webp: the RIFF size field describes what follows it', () => {
+  const doc = webp.read(makeWebp([vp8xChunk(0x08), VP8_CHUNK, webpChunk('EXIF', ascii('TIFF'))]));
+  webp.apply(doc, STRIP_ALL);
+  const out = webp.write(doc);
+  const view = new DataView(out.buffer);
+  assert.equal(view.getUint32(4, true), out.length - 8);
+});

--- a/tests/js/exif-tiff.test.js
+++ b/tests/js/exif-tiff.test.js
@@ -1,0 +1,396 @@
+/**
+ * tools/exif-editor/src/tiff.js.
+ *
+ * The rule the file is built on is "a tag nobody edited is written back byte
+ * for byte from the bytes it was read as", so most of these tests are round
+ * trips: parse, serialise, parse again, and check that what came back is what
+ * went in. That is the property that keeps values this tool does not
+ * understand exactly as the camera wrote them.
+ *
+ * The rest are the things a malformed file could do: an IFD pointing at
+ * itself, a count that runs off the end of the block, a type nobody has heard
+ * of. None of them may hang the page or read past the buffer.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GROUP_ORDER, TYPE, createEntry, isEdited, parseExif, serializeExif, setEntryValue,
+} from '../../tools/exif-editor/src/tiff.js';
+import { TIFF_BE, TIFF_LE, concat, u32le } from './helpers.js';
+
+const MAKE = 0x010f;
+const ORIENTATION = 0x0112;
+const X_RESOLUTION = 0x011a;
+const USER_COMMENT = 0x9286;
+const XP_TITLE = 0x9c9b;
+
+const tag = (group, id) => group.find((e) => e.tag === id);
+const values = (group) => Object.fromEntries(group.map((e) => [e.tag, e.value]));
+
+/** Parse a model, serialise it, and parse the result. */
+function roundTrip(model) {
+  const bytes = serializeExif(model);
+  assert.ok(bytes, 'serialising produced nothing');
+  const back = parseExif(bytes);
+  assert.equal(back.ok, true, back.error);
+  return back;
+}
+
+/* -------------------------------------------------------------- reading */
+
+test('a hand-written little-endian block', () => {
+  const parsed = parseExif(TIFF_LE);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.littleEndian, true);
+  assert.deepEqual(values(parsed.groups.ifd0), { [MAKE]: 'Acme', [ORIENTATION]: 6 });
+});
+
+test('a hand-written big-endian block reads the same', () => {
+  const parsed = parseExif(TIFF_BE);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.littleEndian, false);
+  assert.deepEqual(values(parsed.groups.ifd0), { [MAKE]: 'Acme', [ORIENTATION]: 6 });
+});
+
+test('every group exists even when empty', () => {
+  const parsed = parseExif(TIFF_LE);
+  for (const group of GROUP_ORDER) {
+    assert.ok(Array.isArray(parsed.groups[group]), group);
+  }
+  assert.equal(parsed.thumbnail, null);
+});
+
+test('an entry keeps the bytes it was read as', () => {
+  const entry = tag(parseExif(TIFF_LE).groups.ifd0, MAKE);
+  assert.deepEqual(entry.raw, new Uint8Array([0x41, 0x63, 0x6d, 0x65, 0x00]));
+  assert.equal(entry.type, TYPE.ASCII);
+  assert.equal(entry.count, 5);
+  assert.equal(entry.edited, undefined);
+});
+
+test('a short value read from inside its own entry', () => {
+  const entry = tag(parseExif(TIFF_LE).groups.ifd0, ORIENTATION);
+  assert.equal(entry.type, TYPE.SHORT);
+  assert.equal(entry.raw.length, 2, 'four bytes or fewer sit in the entry');
+});
+
+/* ------------------------------------------------------- reading badly */
+
+test('a block that is too short', () => {
+  const parsed = parseExif(new Uint8Array(4));
+  assert.equal(parsed.ok, false);
+  assert.match(parsed.error, /too short/);
+});
+
+test('nothing at all', () => {
+  assert.equal(parseExif(null).ok, false);
+  assert.equal(parseExif(new Uint8Array(0)).ok, false);
+});
+
+test('no byte-order mark', () => {
+  const bytes = TIFF_LE.slice();
+  bytes[0] = 0x58;
+  bytes[1] = 0x58;
+  assert.match(parseExif(bytes).error, /byte-order mark/);
+});
+
+test('the wrong magic number', () => {
+  const bytes = TIFF_LE.slice();
+  bytes[2] = 43;
+  assert.match(parseExif(bytes).error, /magic number/);
+});
+
+test('a first directory offset pointing outside the block', () => {
+  const bytes = TIFF_LE.slice();
+  bytes.set(u32le(9999), 4);
+  const parsed = parseExif(bytes);
+  assert.equal(parsed.ok, false);
+  // "unreadable" and "no tags" are different claims, and the caller needs the
+  // first one.
+  assert.match(parsed.error, /points outside/);
+});
+
+test('an entry whose count runs off the end is skipped, not read', () => {
+  const bytes = TIFF_LE.slice();
+  bytes.set(u32le(0xffff), 0x0a + 4); // Make's count
+  const parsed = parseExif(bytes);
+  assert.equal(parsed.ok, true);
+  assert.equal(tag(parsed.groups.ifd0, MAKE), undefined);
+  assert.equal(tag(parsed.groups.ifd0, ORIENTATION).value, 6, 'the rest still reads');
+});
+
+test('an unknown type is skipped', () => {
+  const bytes = TIFF_LE.slice();
+  bytes[0x0a + 2] = 99; // Make's type
+  const parsed = parseExif(bytes);
+  assert.equal(parsed.ok, true);
+  assert.equal(tag(parsed.groups.ifd0, MAKE), undefined);
+});
+
+test('an IFD pointing at itself does not hang', () => {
+  // A malformed file can point one directory at another in a loop; visited
+  // offsets are remembered so a corrupt photo cannot hang the page.
+  const bytes = TIFF_LE.slice();
+  bytes.set(u32le(8), 0x22); // "next IFD" points back at IFD0
+  const parsed = parseExif(bytes);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.groups.ifd1.length, 0);
+});
+
+/* ------------------------------------------------- pointers and thumbnails */
+
+test('a sub-directory is followed and its pointer tag is not shown', () => {
+  const model = {
+    littleEndian: true,
+    groups: {
+      ifd0: [createEntry(MAKE, TYPE.ASCII, 'Acme', true)],
+      exif: [createEntry(0x829a, TYPE.RATIONAL, '0.005', true)],
+      gps: [], interop: [], ifd1: [],
+    },
+  };
+  const back = roundTrip(model);
+  assert.equal(back.groups.exif.length, 1);
+  // 0x8769 and 0x8825 are bookkeeping this file rewrites, never content.
+  assert.equal(tag(back.groups.ifd0, 0x8769), undefined);
+  assert.equal(tag(back.groups.ifd0, 0x8825), undefined);
+});
+
+test('an interop directory is reached through the exif one', () => {
+  const model = {
+    littleEndian: true,
+    groups: {
+      ifd0: [], exif: [], gps: [], ifd1: [],
+      interop: [createEntry(0x0001, TYPE.ASCII, 'R98', true)],
+    },
+  };
+  const back = roundTrip(model);
+  assert.equal(back.groups.interop.length, 1);
+  assert.equal(tag(back.groups.interop, 0x0001).value, 'R98');
+});
+
+test('a gps directory survives a round trip', () => {
+  const model = {
+    littleEndian: true,
+    groups: {
+      ifd0: [], exif: [], interop: [], ifd1: [],
+      gps: [
+        createEntry(0x0001, TYPE.ASCII, 'N', true),
+        createEntry(0x0002, TYPE.RATIONAL, '51 30 26', true),
+      ],
+    },
+  };
+  const back = roundTrip(model);
+  assert.equal(tag(back.groups.gps, 0x0001).value, 'N');
+  assert.deepEqual(tag(back.groups.gps, 0x0002).value, [51, 30, 26]);
+});
+
+test('a thumbnail is lifted out and put back', () => {
+  const thumbnail = new Uint8Array([0xff, 0xd8, 1, 2, 3, 4, 0xff, 0xd9]);
+  const model = {
+    littleEndian: true,
+    thumbnail,
+    groups: { ifd0: [], exif: [], gps: [], interop: [], ifd1: [] },
+  };
+  const back = roundTrip(model);
+  assert.deepEqual(back.thumbnail, thumbnail);
+  // The two tags that say where it lives are rewritten, never copied.
+  assert.equal(tag(back.groups.ifd1, 0x0201), undefined);
+  assert.equal(tag(back.groups.ifd1, 0x0202), undefined);
+});
+
+/* -------------------------------------------------------------- writing */
+
+test('an empty model serialises to nothing', () => {
+  // Which is what "remove everything" produces, and the caller's signal to
+  // drop the wrapper rather than write an empty one.
+  const empty = { groups: { ifd0: [], exif: [], gps: [], interop: [], ifd1: [] } };
+  assert.equal(serializeExif(empty), null);
+  assert.equal(serializeExif({ groups: {} }), null);
+});
+
+test('the round trip preserves untouched entries byte for byte', () => {
+  const parsed = parseExif(TIFF_LE);
+  const before = tag(parsed.groups.ifd0, MAKE).raw;
+  const back = roundTrip(parsed);
+  assert.deepEqual(tag(back.groups.ifd0, MAKE).raw, before);
+});
+
+test('the round trip is stable', () => {
+  const once = serializeExif(parseExif(TIFF_LE));
+  const twice = serializeExif(parseExif(once));
+  assert.deepEqual(twice, once);
+});
+
+test('byte order is carried through', () => {
+  const fromBig = serializeExif(parseExif(TIFF_BE));
+  assert.equal(parseExif(fromBig).littleEndian, false);
+  const fromLittle = serializeExif(parseExif(TIFF_LE));
+  assert.equal(parseExif(fromLittle).littleEndian, true);
+});
+
+test('little-endian is the default when the model does not say', () => {
+  const model = {
+    groups: { ifd0: [createEntry(MAKE, TYPE.ASCII, 'X', true)], exif: [], gps: [], interop: [], ifd1: [] },
+  };
+  assert.equal(parseExif(serializeExif(model)).littleEndian, true);
+});
+
+test('entries are written in ascending tag order', () => {
+  // Some readers do a binary search and quietly miss tags that are out of
+  // order.
+  const model = {
+    littleEndian: true,
+    groups: {
+      ifd0: [
+        createEntry(ORIENTATION, TYPE.SHORT, '1', true),
+        createEntry(MAKE, TYPE.ASCII, 'Acme', true),
+        createEntry(0x0100, TYPE.LONG, '640', true),
+      ],
+      exif: [], gps: [], interop: [], ifd1: [],
+    },
+  };
+  const written = roundTrip(model).groups.ifd0.map((e) => e.tag);
+  assert.deepEqual(written, [...written].sort((a, b) => a - b));
+});
+
+test('a value longer than four bytes lands outside its entry and comes back', () => {
+  const long = 'a name far too long to sit inside a twelve byte entry';
+  const model = {
+    littleEndian: true,
+    groups: {
+      ifd0: [createEntry(MAKE, TYPE.ASCII, long, true)],
+      exif: [], gps: [], interop: [], ifd1: [],
+    },
+  };
+  assert.equal(tag(roundTrip(model).groups.ifd0, MAKE).value, long);
+});
+
+test('directory offsets are even', () => {
+  // TIFF offsets are word-aligned and readers that assume it are common.
+  const model = {
+    littleEndian: true,
+    groups: {
+      // An odd-length value forces the padding path.
+      ifd0: [createEntry(MAKE, TYPE.ASCII, 'odd', true)],
+      exif: [createEntry(0x9000, TYPE.UNDEFINED, '0231', true)],
+      gps: [], interop: [], ifd1: [],
+    },
+  };
+  const bytes = serializeExif(model);
+  const view = new DataView(bytes.buffer);
+  assert.equal(view.getUint32(4, true) % 2, 0, 'IFD0 offset');
+});
+
+/* -------------------------------------------------------------- editing */
+
+test('setEntryValue re-encodes and marks the entry', () => {
+  const parsed = parseExif(TIFF_LE);
+  const entry = tag(parsed.groups.ifd0, MAKE);
+  assert.equal(isEdited(parsed), false);
+
+  assert.equal(setEntryValue(entry, 'Other', true), true);
+  assert.equal(entry.value, 'Other');
+  assert.equal(entry.edited, true);
+  assert.equal(isEdited(parsed), true);
+  assert.equal(tag(roundTrip(parsed).groups.ifd0, MAKE).value, 'Other');
+});
+
+test('an ASCII value is NUL-terminated', () => {
+  const entry = createEntry(MAKE, TYPE.ASCII, 'Acme', true);
+  assert.equal(entry.raw.length, 5);
+  assert.equal(entry.raw[4], 0);
+});
+
+test('a number that does not fit the tag type is refused', () => {
+  const entry = tag(parseExif(TIFF_LE).groups.ifd0, ORIENTATION);
+  assert.equal(setEntryValue(entry, 'not a number', true), false);
+  assert.equal(entry.value, 6, 'the old value is left alone');
+  assert.equal(entry.edited, undefined);
+});
+
+test('createEntry returns null rather than writing something else', () => {
+  assert.equal(createEntry(ORIENTATION, TYPE.SHORT, 'sideways', true), null);
+});
+
+test('a list of numbers can be typed with spaces or commas', () => {
+  assert.deepEqual(createEntry(0x0100, TYPE.SHORT, '1 2 3', true).value, [1, 2, 3]);
+  assert.deepEqual(createEntry(0x0100, TYPE.SHORT, '1,2,3', true).value, [1, 2, 3]);
+  assert.deepEqual(createEntry(0x0100, TYPE.SHORT, ' 1 , 2 ', true).value, [1, 2]);
+});
+
+test('numbers are clamped to what the type can hold', () => {
+  assert.equal(createEntry(0x0100, TYPE.SHORT, '99999', true).value, 65535);
+  assert.equal(createEntry(0x0100, TYPE.BYTE, '300', true).value, 255);
+  assert.equal(createEntry(0x0100, TYPE.SHORT, '-5', true).value, 0);
+});
+
+test('a rational is written as a decimal fraction', () => {
+  const entry = createEntry(X_RESOLUTION, TYPE.RATIONAL, '72.5', true);
+  assert.deepEqual(entry.pairs, [725, 10]);
+  assert.equal(entry.value, 72.5);
+});
+
+test('a whole-number rational keeps a denominator of one', () => {
+  const entry = createEntry(X_RESOLUTION, TYPE.RATIONAL, '300', true);
+  assert.deepEqual(entry.pairs, [300, 1]);
+});
+
+test('a signed rational can go negative', () => {
+  const entry = createEntry(0x9203, TYPE.SRATIONAL, '-1.5', true);
+  assert.deepEqual(entry.pairs, [-15, 10]);
+  assert.equal(entry.value, -1.5);
+});
+
+test('a UserComment gets the ASCII header the format requires', () => {
+  const entry = createEntry(USER_COMMENT, TYPE.UNDEFINED, 'hello', true);
+  assert.equal(new TextDecoder().decode(entry.raw.subarray(0, 8)), 'ASCII\0\0\0');
+  // ... and reading it back does not print the header, which is where the
+  // stray "ASCII" in so many comments comes from.
+  assert.equal(entry.value, 'hello');
+});
+
+test('a UserComment with non-ASCII text is written as UNICODE', () => {
+  const entry = createEntry(USER_COMMENT, TYPE.UNDEFINED, 'café', true);
+  assert.equal(new TextDecoder().decode(entry.raw.subarray(0, 8)), 'UNICODE\0');
+  assert.equal(entry.value, 'café');
+});
+
+test('an XP tag is stored as UTF-16 and read back whole', () => {
+  // Trimming NULs a byte at a time here would eat half of the last Latin
+  // letter: "Jane P" would come back as "Jane " and a broken fragment.
+  const entry = createEntry(XP_TITLE, TYPE.BYTE, 'Jane P', true);
+  assert.equal(entry.type, TYPE.BYTE);
+  assert.equal(entry.value, 'Jane P');
+});
+
+test('an XP tag survives a round trip', () => {
+  const model = {
+    littleEndian: true,
+    groups: {
+      ifd0: [createEntry(XP_TITLE, TYPE.BYTE, 'A title', true)],
+      exif: [], gps: [], interop: [], ifd1: [],
+    },
+  };
+  assert.equal(tag(roundTrip(model).groups.ifd0, XP_TITLE).value, 'A title');
+});
+
+test('an edited entry loses the rational pair it used to have', () => {
+  const entry = createEntry(X_RESOLUTION, TYPE.RATIONAL, '72.5', true);
+  assert.ok(entry.pairs);
+  setEntryValue(entry, '300', true);
+  assert.deepEqual(entry.pairs, [300, 1]);
+});
+
+test('isEdited is false for a model read straight off disk', () => {
+  assert.equal(isEdited(parseExif(TIFF_LE)), false);
+  assert.equal(isEdited({ groups: {} }), false);
+  assert.equal(isEdited({}), false);
+});
+
+test('a value with an embedded NUL is shown as a space', () => {
+  const bytes = concat(TIFF_LE.subarray(0, 38), new Uint8Array([0x41, 0x00, 0x42, 0x00, 0x00]));
+  const parsed = parseExif(bytes);
+  assert.equal(tag(parsed.groups.ifd0, MAKE).value, 'A B');
+});

--- a/tests/js/helpers.js
+++ b/tests/js/helpers.js
@@ -1,0 +1,168 @@
+/**
+ * Fixtures: the smallest real JPEG, PNG, WebP and TIFF blocks that the parsers
+ * under test will accept.
+ *
+ * Built here rather than checked in as binary files, so that a reader can see
+ * exactly what is in each one and why. Where a fixture is meant to pin a
+ * parser's behaviour rather than exercise a round trip, the bytes are written
+ * out by hand and commented field by field - see TIFF_LE below.
+ */
+
+import { crc32 } from '../../tools/exif-editor/src/crc32.js';
+
+/**
+ * Join byte runs. A part may be a Uint8Array, a plain array of byte values, or
+ * an array of parts - so a fixture can be written as a list of chunks without
+ * every call site having to say which of the three it meant.
+ */
+export const concat = (...parts) => {
+  const runs = parts.map(asBytes);
+  const out = new Uint8Array(runs.reduce((n, p) => n + p.length, 0));
+  let at = 0;
+  for (const run of runs) {
+    out.set(run, at);
+    at += run.length;
+  }
+  return out;
+};
+
+function asBytes(part) {
+  if (part instanceof Uint8Array) return part;
+  if (!Array.isArray(part)) throw new TypeError(`not a byte run: ${part}`);
+  return part.every((v) => typeof v === 'number')
+    ? new Uint8Array(part)
+    : concat(...part);
+}
+
+export const ascii = (text) => {
+  const out = new Uint8Array(text.length);
+  for (let i = 0; i < text.length; i += 1) out[i] = text.charCodeAt(i) & 0xff;
+  return out;
+};
+
+export const u16be = (n) => new Uint8Array([(n >> 8) & 0xff, n & 0xff]);
+export const u32be = (n) => new Uint8Array([(n >>> 24) & 0xff, (n >>> 16) & 0xff, (n >>> 8) & 0xff, n & 0xff]);
+export const u32le = (n) => new Uint8Array([n & 0xff, (n >>> 8) & 0xff, (n >>> 16) & 0xff, (n >>> 24) & 0xff]);
+
+/* ------------------------------------------------------------------- JPEG */
+
+/** One JPEG segment: 0xFF, the marker, a two-byte length, the payload. */
+export const segment = (marker, payload) =>
+  concat([0xff, marker], u16be(payload.length + 2), payload);
+
+/**
+ * A JPEG that `jpeg.read` will accept: SOI, the segments given, then a scan.
+ *
+ * The scan is never parsed and never rewritten, only copied, which is the
+ * property that lets this tool strip metadata without touching a pixel - so
+ * the fixture's scan is arbitrary bytes and the tests check they come back.
+ */
+export const jpeg = (segments = [], scan = ascii('SCANDATA')) =>
+  concat([0xff, 0xd8], segments, [0xff, 0xda], u16be(scan.length + 2), scan);
+
+export const EXIF_ID = ascii('Exif\0\0');
+export const XMP_ID = ascii('http://ns.adobe.com/xap/1.0/\0');
+export const JFIF_SEGMENT = segment(0xe0, concat(ascii('JFIF\0'), [1, 2, 0, 0, 1, 0, 1, 0, 0]));
+
+/* -------------------------------------------------------------------- PNG */
+
+export const PNG_SIGNATURE = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** One PNG chunk: length, type, data, and a CRC over the last two. */
+export const chunk = (type, data = new Uint8Array(0)) => {
+  const name = ascii(type);
+  return concat(u32be(data.length), name, data, u32be(crc32([name, data])));
+};
+
+/** IHDR for a 1x1 8-bit truecolour image. */
+export const IHDR = chunk('IHDR', concat(u32be(1), u32be(1), [8, 2, 0, 0, 0]));
+export const IDAT = chunk('IDAT', ascii('not really deflate'));
+export const IEND = chunk('IEND');
+
+export const png = (middle = []) => concat(PNG_SIGNATURE, IHDR, middle, IDAT, IEND);
+
+/** A tEXt chunk: keyword, NUL, Latin-1 text. */
+export const textChunk = (keyword, value) =>
+  chunk('tEXt', concat(ascii(keyword), [0], ascii(value)));
+
+/** Deflate, so a zTXt fixture is genuinely compressed rather than pretending. */
+export async function deflate(bytes) {
+  const stream = new Blob([bytes]).stream().pipeThrough(new CompressionStream('deflate'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/* ------------------------------------------------------------------- WebP */
+
+export const webpChunk = (fourcc, data) => {
+  const body = concat(ascii(fourcc.padEnd(4, ' ')), u32le(data.length), data);
+  return data.length % 2 ? concat(body, [0]) : body;
+};
+
+export const webp = (chunks) => {
+  const body = concat(ascii('WEBP'), chunks);
+  return concat(ascii('RIFF'), u32le(body.length), body);
+};
+
+/** A VP8 bitstream chunk. Its contents are never parsed by this tool. */
+export const VP8_CHUNK = webpChunk('VP8 ', ascii('bitstream'));
+
+/** A VP8X header for a 16x16 canvas, with the flag byte given. */
+export const vp8xChunk = (flags = 0) => {
+  const data = new Uint8Array(10);
+  data[0] = flags;
+  data[4] = 15; // width - 1, 24-bit little-endian
+  data[7] = 15; // height - 1
+  return webpChunk('VP8X', data);
+};
+
+/* ------------------------------------------------------------------- TIFF */
+
+/**
+ * A little-endian EXIF block, written out by hand.
+ *
+ * Two tags in IFD0 and nothing else. One value is short enough to sit inside
+ * its own entry and one is not, which is the only awkward part of the format
+ * and the reason writing has to be a rebuild rather than a patch.
+ *
+ *   00  49 49 2a 00        "II", then 42: little-endian TIFF
+ *   04  08 00 00 00        IFD0 begins at byte 8
+ *   08  02 00              two entries
+ *   0a  0f 01 02 00 ...    tag 0x010f (Make), ASCII, 5 bytes, at offset 38
+ *   16  12 01 03 00 ...    tag 0x0112 (Orientation), SHORT, 1, value 6 inline
+ *   22  00 00 00 00        no IFD1
+ *   26  41 63 6d 65 00     "Acme\0"
+ */
+export const TIFF_LE = new Uint8Array([
+  0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00,
+  0x02, 0x00,
+  0x0f, 0x01, 0x02, 0x00, 0x05, 0x00, 0x00, 0x00, 0x26, 0x00, 0x00, 0x00,
+  0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00,
+  0x41, 0x63, 0x6d, 0x65, 0x00,
+]);
+
+/** The same two tags, big-endian. Cameras write both. */
+export const TIFF_BE = new Uint8Array([
+  0x4d, 0x4d, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08,
+  0x00, 0x02,
+  0x01, 0x0f, 0x00, 0x02, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x26,
+  0x01, 0x12, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x06, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00,
+  0x41, 0x63, 0x6d, 0x65, 0x00,
+]);
+
+/** Read a Blob back as bytes, which is how every writer here hands over. */
+export async function blobBytes(blob) {
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+/** Find the offset of a byte pattern, or -1. */
+export function indexOfBytes(haystack, needle) {
+  outer: for (let i = 0; i + needle.length <= haystack.length; i += 1) {
+    for (let j = 0; j < needle.length; j += 1) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}

--- a/tests/js/pdf-fixtures.js
+++ b/tests/js/pdf-fixtures.js
@@ -1,0 +1,99 @@
+/**
+ * Building real PDFs to read back.
+ *
+ * The compress-pdf tool opens files somebody else made, so its tests need
+ * files somebody else made - or the nearest honest substitute, which is one
+ * assembled here with the byte offsets worked out rather than asserted. A
+ * fixture whose xref table is wrong would test the repair path by accident
+ * and never touch the one that matters.
+ *
+ * `buildPdf` therefore writes a correct classic cross-reference table, and the
+ * damaged variants below each break exactly one thing.
+ */
+
+export const ascii = (text) => {
+  const out = new Uint8Array(text.length);
+  for (let i = 0; i < text.length; i += 1) out[i] = text.charCodeAt(i) & 0xff;
+  return out;
+};
+
+export const concat = (...parts) => {
+  const runs = parts.map((p) => (typeof p === 'string' ? ascii(p) : p));
+  const out = new Uint8Array(runs.reduce((n, p) => n + p.length, 0));
+  let at = 0;
+  for (const run of runs) {
+    out.set(run, at);
+    at += run.length;
+  }
+  return out;
+};
+
+export const text = (bytes) => new TextDecoder('latin1').decode(bytes);
+
+/**
+ * Assemble a PDF from a list of object bodies.
+ *
+ * @param {(string|Uint8Array)[]} objects  body of object 1, 2, 3... in order
+ * @param {{root?: number, info?: number, header?: string, extra?: string}} options
+ */
+export function buildPdf(objects, { root = 1, info = null, header = '%PDF-1.7\n' } = {}) {
+  const parts = [ascii(header)];
+  let at = parts[0].length;
+  const offsets = [];
+
+  objects.forEach((body, index) => {
+    offsets.push(at);
+    const chunk = concat(`${index + 1} 0 obj\n`, body, '\nendobj\n');
+    parts.push(chunk);
+    at += chunk.length;
+  });
+
+  const startxref = at;
+  let table = `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets) {
+    table += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  }
+  const trailer = info === null
+    ? `trailer\n<< /Size ${objects.length + 1} /Root ${root} 0 R >>\n`
+    : `trailer\n<< /Size ${objects.length + 1} /Root ${root} 0 R /Info ${info} 0 R >>\n`;
+
+  parts.push(ascii(table + trailer + `startxref\n${startxref}\n%%EOF\n`));
+  return concat(...parts);
+}
+
+/** A stream object: a dictionary, the `stream` keyword, the bytes, `endstream`. */
+export const streamObject = (dict, data) =>
+  concat(`<< ${dict} /Length ${data.length} >>\nstream\n`, data, '\nendstream');
+
+/**
+ * The smallest document this tool will open: a catalogue, a page tree and one
+ * page. Object 1 is the catalogue, so `root` defaults to it everywhere.
+ */
+export const MINIMAL_OBJECTS = [
+  '<< /Type /Catalog /Pages 2 0 R >>',
+  '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>',
+];
+
+export const minimalPdf = (options) => buildPdf(MINIMAL_OBJECTS, options);
+
+/** The same, plus an /Info dictionary and an XMP packet to strip. */
+export function pdfWithMetadata() {
+  return buildPdf([
+    '<< /Type /Catalog /Pages 2 0 R /Metadata 5 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] '
+      + '/LastModified (D:20260101000000Z) /PieceInfo << /App << /Private (blob) >> >> >>',
+    '<< /Producer (Some Layout App 9.1) /Creator (A Person) >>',
+    streamObject('/Type /Metadata /Subtype /XML', ascii('<x:xmpmeta>a packet</x:xmpmeta>')),
+  ], { info: 4 });
+}
+
+/** Deflate, so a FlateDecode fixture is genuinely compressed. */
+export async function deflate(bytes) {
+  const stream = new Blob([bytes]).stream().pipeThrough(new CompressionStream('deflate'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/** Read a Blob back as bytes. */
+export const blobBytes = async (blob) => new Uint8Array(await blob.arrayBuffer());

--- a/tests/js/pdf.test.js
+++ b/tests/js/pdf.test.js
@@ -1,0 +1,543 @@
+/**
+ * tools/images-to-pdf/src/{pdf,layout,jpeg}.js.
+ *
+ * pdf.js writes the three things a PDF is as far as this tool is concerned: a
+ * list of numbered objects, a cross-reference table saying what byte each one
+ * starts at, and a trailer. The byte offsets are the part worth testing,
+ * because getting one wrong produces a file that opens in one reader and not
+ * another.
+ *
+ * layout.js is arithmetic, and jpeg.js decides whether a photograph can be
+ * copied into the document untouched - the interesting part of the tool, and
+ * the reason a JPEG that goes in comes out with its pixels bit for bit.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PT_PER_INCH, PT_PER_MM, PdfWriter, num, textString,
+} from '../../tools/images-to-pdf/src/pdf.js';
+import {
+  PAGE_SIZES, displaySize, fitRect, layoutPage, pageSizePt, placement, seenSize,
+  swapsAxes,
+} from '../../tools/images-to-pdf/src/layout.js';
+import { inspectJpeg } from '../../tools/images-to-pdf/src/jpeg.js';
+import { ascii, blobBytes, concat, segment, u16be } from './helpers.js';
+
+/* ============================================================== pdf.js */
+
+test('num: small numbers do not come out in exponent notation', () => {
+  // String(1e-7) would write "1e-7" and the file would be corrupt at exactly
+  // the point it looked fine.
+  assert.equal(num(1e-7), '0');
+  assert.equal(num(0.00001), '0');
+  // A tiny negative rounds to "-0", which is a real number PDF accepts.
+  assert.equal(num(-1e-9), '-0');
+});
+
+test('num: nothing this tool can produce comes out in exponent notation', () => {
+  // toFixed switches to exponent notation at 1e21, so that is the ceiling of
+  // the guarantee. Page boxes are points, image sizes are pixels, and the
+  // matrix entries are products of the two, so everything here is many orders
+  // of magnitude below it.
+  const values = [0, 1, 72, 595.2756, 841.8898, 1e6, 1e12, 1e20, -1e20];
+  for (const value of values) {
+    assert.ok(!num(value).includes('e'), `${value} -> ${num(value)}`);
+  }
+});
+
+test('num: trailing zeros are trimmed', () => {
+  assert.equal(num(595.2756), '595.2756');
+  assert.equal(num(10), '10');
+  assert.equal(num(10.5), '10.5');
+  assert.equal(num(0), '0');
+  assert.equal(num(-3.25), '-3.25');
+});
+
+test('num: anything that is not a number becomes zero', () => {
+  assert.equal(num(NaN), '0');
+  assert.equal(num(Infinity), '0');
+  assert.equal(num(-Infinity), '0');
+});
+
+test('num: four decimal places, which is finer than a printer resolves', () => {
+  assert.equal(num(1 / 3), '0.3333');
+});
+
+test('textString: UTF-16BE hex with a byte-order mark', () => {
+  assert.equal(textString('AB'), '<FEFF00410042>');
+  assert.equal(textString(''), '<FEFF>');
+});
+
+test('textString: brackets and backslashes need no escaping', () => {
+  // Which is the whole reason hex is used rather than a literal (string).
+  const out = textString('a (b) \\ c');
+  assert.match(out, /^<FEFF[0-9A-F]+>$/);
+});
+
+test('textString: characters outside Latin-1 survive', () => {
+  assert.equal(textString('—'), '<FEFF2014>');
+  assert.equal(textString('😀'), '<FEFFD83DDE00>', 'a surrogate pair');
+});
+
+test('pdf: the file starts with the version and the binary comment', async () => {
+  const writer = new PdfWriter();
+  const id = writer.reserve();
+  writer.object(id, '<< /Type /Catalog >>');
+  const bytes = await blobBytes(writer.finish({ root: id }));
+
+  assert.equal(new TextDecoder('latin1').decode(bytes.subarray(0, 9)), '%PDF-1.7\n');
+  // Four bytes above 127, so nothing "helpfully" translates the line endings.
+  assert.deepEqual(bytes.subarray(9, 15), new Uint8Array([0x25, 0xe2, 0xe3, 0xcf, 0xd3, 0x0a]));
+});
+
+test('pdf: the blob is typed as a pdf and ends with the marker', async () => {
+  const writer = new PdfWriter();
+  const id = writer.reserve();
+  writer.object(id, '<< /Type /Catalog >>');
+  const blob = writer.finish({ root: id });
+  assert.equal(blob.type, 'application/pdf');
+  const text = new TextDecoder('latin1').decode(await blobBytes(blob));
+  assert.ok(text.endsWith('%%EOF\n'));
+});
+
+test('pdf: every xref entry points at its own object', async () => {
+  const writer = new PdfWriter();
+  const catalog = writer.reserve();
+  const pages = writer.reserve();
+  writer.object(catalog, '<< /Type /Catalog /Pages 2 0 R >>');
+  writer.object(pages, '<< /Type /Pages /Count 0 >>');
+  const bytes = await blobBytes(writer.finish({ root: catalog }));
+  const text = new TextDecoder('latin1').decode(bytes);
+
+  const start = Number(text.slice(text.lastIndexOf('startxref')).split('\n')[1]);
+  assert.equal(text.slice(start, start + 4), 'xref');
+
+  // Entries are exactly twenty bytes, so a reader may seek to first + 20 * n.
+  const first = start + `xref\n0 3\n`.length;
+  for (const id of [catalog, pages]) {
+    const entry = text.slice(first + 20 * id, first + 20 * (id + 1));
+    assert.equal(entry.length, 20);
+    assert.equal(text.slice(Number(entry.slice(0, 10))).startsWith(`${id} 0 obj`), true);
+  }
+});
+
+test('pdf: the free entry is the one the format requires', async () => {
+  const writer = new PdfWriter();
+  const id = writer.reserve();
+  writer.object(id, '<< >>');
+  const text = new TextDecoder('latin1').decode(await blobBytes(writer.finish({ root: id })));
+  assert.ok(text.includes('xref\n0 2\n0000000000 65535 f\r\n'));
+});
+
+test('pdf: a stream carries its own length', async () => {
+  const writer = new PdfWriter();
+  const id = writer.reserve();
+  const data = ascii('some image bytes');
+  writer.stream(id, ' /Type /XObject', data);
+  const text = new TextDecoder('latin1').decode(await blobBytes(writer.finish({ root: id })));
+  assert.ok(text.includes(`/Length ${data.length}>>`));
+  assert.ok(text.includes('stream\nsome image bytes\nendstream'));
+});
+
+test('pdf: stream data is copied through unchanged', async () => {
+  const writer = new PdfWriter();
+  const id = writer.reserve();
+  const data = new Uint8Array([0, 1, 255, 254, 10, 13, 37]);
+  writer.stream(id, ' /Type /XObject', data);
+  const bytes = await blobBytes(writer.finish({ root: id }));
+  const text = new TextDecoder('latin1').decode(bytes);
+  const at = text.indexOf('stream\n') + 'stream\n'.length;
+  assert.deepEqual(bytes.subarray(at, at + data.length), data);
+});
+
+test('pdf: the trailer names the catalogue, and /Info only when there is one', async () => {
+  const withInfo = new PdfWriter();
+  const root = withInfo.reserve();
+  const info = withInfo.reserve();
+  withInfo.object(root, '<< >>');
+  withInfo.object(info, '<< >>');
+  const a = new TextDecoder('latin1').decode(await blobBytes(withInfo.finish({ root, info })));
+  assert.ok(a.includes(`/Root ${root} 0 R /Info ${info} 0 R`));
+
+  const without = new PdfWriter();
+  const only = without.reserve();
+  without.object(only, '<< >>');
+  const b = new TextDecoder('latin1').decode(await blobBytes(without.finish({ root: only })));
+  assert.ok(b.includes(`/Root ${only} 0 R >>`));
+  assert.ok(!b.includes('/Info'));
+});
+
+test('pdf: no /ID is written', async () => {
+  // The usual way to fill it is a hash of the time and the file name, which
+  // would put something in the document this tool spends its existence
+  // keeping out.
+  const writer = new PdfWriter();
+  const id = writer.reserve();
+  writer.object(id, '<< >>');
+  const text = new TextDecoder('latin1').decode(await blobBytes(writer.finish({ root: id })));
+  assert.ok(!text.includes('/ID'));
+});
+
+test('pdf: reserve hands out numbers in order', () => {
+  const writer = new PdfWriter();
+  assert.equal(writer.reserve(), 1);
+  assert.equal(writer.reserve(), 2);
+  assert.equal(writer.reserve(), 3);
+});
+
+/* =========================================================== layout.js */
+
+test('units', () => {
+  assert.equal(PT_PER_INCH, 72);
+  assert.ok(Math.abs(PT_PER_MM - 2.8346) < 1e-3);
+});
+
+test('swapsAxes: a quarter turn from either source', () => {
+  assert.equal(swapsAxes(1, 0), false);
+  assert.equal(swapsAxes(6, 0), true, 'the EXIF tag alone');
+  assert.equal(swapsAxes(1, 90), true, 'the buttons alone');
+  assert.equal(swapsAxes(6, 90), false, 'both, which cancel out');
+  assert.equal(swapsAxes(6, 270), false);
+  assert.equal(swapsAxes(3, 180), false);
+  assert.equal(swapsAxes(), false);
+});
+
+test('swapsAxes: tags 5 to 8 are the ones that turn, and only those', () => {
+  // 8 is the far end of the range and the easiest to lose off it.
+  for (const tag of [1, 2, 3, 4]) {
+    assert.equal(swapsAxes(tag, 0), false, `tag ${tag}`);
+  }
+  for (const tag of [5, 6, 7, 8]) {
+    assert.equal(swapsAxes(tag, 0), true, `tag ${tag}`);
+  }
+});
+
+test('swapsAxes: only 90 and 270 count as a turn from the buttons', () => {
+  assert.equal(swapsAxes(1, 0), false);
+  assert.equal(swapsAxes(1, 90), true);
+  assert.equal(swapsAxes(1, 180), false);
+  assert.equal(swapsAxes(1, 270), true);
+});
+
+test('displaySize: every quarter-turn tag swaps the sides', () => {
+  for (const tag of [5, 6, 7, 8]) {
+    assert.deepEqual(displaySize(400, 300, tag), { width: 300, height: 400 }, `tag ${tag}`);
+  }
+  for (const tag of [1, 2, 3, 4]) {
+    assert.deepEqual(displaySize(400, 300, tag), { width: 400, height: 300 }, `tag ${tag}`);
+  }
+});
+
+test('displaySize: width and height trade places on a quarter turn', () => {
+  assert.deepEqual(displaySize(400, 300), { width: 400, height: 300 });
+  assert.deepEqual(displaySize(400, 300, 6), { width: 300, height: 400 });
+  assert.deepEqual(displaySize(400, 300, 1, 90), { width: 300, height: 400 });
+  assert.deepEqual(displaySize(400, 300, 6, 90), { width: 400, height: 300 });
+});
+
+test('seenSize: reads the item', () => {
+  assert.deepEqual(seenSize({ width: 400, height: 300, orientation: 6, rotate: 0 }),
+    { width: 300, height: 400 });
+});
+
+test('placement: an untagged, unturned image maps straight onto its box', () => {
+  const rect = { x: 10, y: 20, width: 100, height: 50 };
+  assert.deepEqual(placement(rect), [100, 0, 0, 50, 10, 20]);
+});
+
+test('placement: a quarter turn clockwise', () => {
+  const rect = { x: 0, y: 0, width: 100, height: 50 };
+  // Tag 6 is [0 -1 1 0 0 1]: scaled by the box and moved to it.
+  assert.deepEqual(placement(rect, 6), [0, -50, 100, 0, 0, 50]);
+});
+
+test('placement: a half turn puts the image back in the same place', () => {
+  const rect = { x: 5, y: 7, width: 100, height: 50 };
+  assert.deepEqual(placement(rect, 3), [-100, 0, 0, -50, 105, 57]);
+});
+
+test('placement: the tag and the buttons compose', () => {
+  const rect = { x: 0, y: 0, width: 100, height: 50 };
+  // A quarter turn each way is no turn at all.
+  assert.deepEqual(placement(rect, 6, 270), placement(rect, 1, 0));
+});
+
+test('placement: an unknown orientation falls back to "as stored"', () => {
+  const rect = { x: 0, y: 0, width: 10, height: 10 };
+  assert.deepEqual(placement(rect, 99, 45), placement(rect, 1, 0));
+});
+
+test('pageSizePt: the named sizes are the millimetre ones in points', () => {
+  const [width, height] = pageSizePt({ pageSize: 'a4' });
+  assert.ok(Math.abs(width - 210 * PT_PER_MM) < 1e-9);
+  assert.ok(Math.abs(height - 297 * PT_PER_MM) < 1e-9);
+  assert.ok(Math.abs(pageSizePt({ pageSize: 'letter' })[0] - 215.9 * PT_PER_MM) < 1e-9);
+});
+
+test('pageSizePt: every named size is portrait', () => {
+  for (const [name, [width, height]] of Object.entries(PAGE_SIZES)) {
+    assert.ok(width < height, `${name} is taller than it is wide`);
+  }
+});
+
+test('pageSizePt: an unknown name falls back to A4', () => {
+  assert.deepEqual(pageSizePt({ pageSize: 'nope' }), pageSizePt({ pageSize: 'a4' }));
+});
+
+test('pageSizePt: a custom size, in either unit', () => {
+  assert.deepEqual(
+    pageSizePt({ pageSize: 'custom', customUnit: 'in', customWidth: 8.5, customHeight: 11 }),
+    [8.5 * 72, 11 * 72],
+  );
+  assert.deepEqual(
+    pageSizePt({ pageSize: 'custom', customUnit: 'mm', customWidth: 100, customHeight: 200 }),
+    [100 * PT_PER_MM, 200 * PT_PER_MM],
+  );
+});
+
+test('pageSizePt: a custom size is never zero', () => {
+  const [width, height] = pageSizePt({
+    pageSize: 'custom', customUnit: 'mm', customWidth: 0, customHeight: -5,
+  });
+  assert.equal(width, PT_PER_MM);
+  assert.equal(height, PT_PER_MM);
+});
+
+test('fitRect: contain fits inside and centres', () => {
+  const box = { x: 0, y: 0, width: 100, height: 100 };
+  const rect = fitRect(200, 100, box, 'contain');
+  assert.deepEqual(rect, { x: 0, y: 25, width: 100, height: 50 });
+});
+
+test('fitRect: cover fills and overflows', () => {
+  const box = { x: 0, y: 0, width: 100, height: 100 };
+  const rect = fitRect(200, 100, box, 'cover');
+  assert.deepEqual(rect, { x: -50, y: 0, width: 200, height: 100 });
+});
+
+test('fitRect: stretch takes the box exactly', () => {
+  const box = { x: 3, y: 4, width: 100, height: 50 };
+  assert.deepEqual(fitRect(200, 100, box, 'stretch'), box);
+});
+
+test('fitRect: the box offset is carried through', () => {
+  const box = { x: 10, y: 20, width: 100, height: 100 };
+  assert.deepEqual(fitRect(100, 100, box, 'contain'),
+    { x: 10, y: 20, width: 100, height: 100 });
+});
+
+test('layoutPage: "fit" makes the page the picture plus the margin', () => {
+  const page = layoutPage(
+    { width: 300, height: 150, orientation: 1, rotate: 0 },
+    { pageSize: 'fit', dpi: 150, margin: 0, fit: 'contain' },
+  );
+  assert.equal(page.width, (300 * 72) / 150);
+  assert.equal(page.height, (150 * 72) / 150);
+  assert.equal(page.clip, null, 'nothing is cropped when there is no page to fit');
+});
+
+test('layoutPage: "fit" adds the margin on all four sides', () => {
+  const page = layoutPage(
+    { width: 300, height: 150, orientation: 1, rotate: 0 },
+    { pageSize: 'fit', dpi: 150, margin: 10, fit: 'contain' },
+  );
+  const margin = 10 * PT_PER_MM;
+  assert.ok(Math.abs(page.width - ((300 * 72) / 150 + margin * 2)) < 1e-9);
+  assert.equal(page.rect.x, margin);
+  assert.equal(page.rect.y, margin);
+});
+
+test('layoutPage: the dpi is clamped to something printable', () => {
+  const at = (dpi) => layoutPage({ width: 300, height: 150, orientation: 1, rotate: 0 },
+    { pageSize: 'fit', dpi, margin: 0, fit: 'contain' }).width;
+  assert.equal(at(99999), (300 * 72) / 1200);
+  assert.equal(at(1), (300 * 72) / 18);
+  assert.equal(at('nonsense'), (300 * 72) / 150, 'the default');
+});
+
+test('layoutPage: auto orientation follows the picture', () => {
+  const settings = { pageSize: 'a4', orientation: 'auto', margin: 0, fit: 'contain' };
+  const wide = layoutPage({ width: 400, height: 300, orientation: 1, rotate: 0 }, settings);
+  assert.ok(wide.width > wide.height);
+  const tall = layoutPage({ width: 300, height: 400, orientation: 1, rotate: 0 }, settings);
+  assert.ok(tall.height > tall.width);
+});
+
+test('layoutPage: auto orientation follows the EXIF tag, not the stored size', () => {
+  // A sideways phone photo is stored landscape and seen portrait.
+  const page = layoutPage(
+    { width: 400, height: 300, orientation: 6, rotate: 0 },
+    { pageSize: 'a4', orientation: 'auto', margin: 0, fit: 'contain' },
+  );
+  assert.ok(page.height > page.width);
+});
+
+test('layoutPage: an explicit orientation overrides the picture', () => {
+  const page = layoutPage(
+    { width: 300, height: 400, orientation: 1, rotate: 0 },
+    { pageSize: 'a4', orientation: 'landscape', margin: 0, fit: 'contain' },
+  );
+  assert.ok(page.width > page.height);
+});
+
+test('layoutPage: only "fill the page" clips', () => {
+  const settings = { pageSize: 'a4', orientation: 'portrait', margin: 10 };
+  const image = { width: 400, height: 300, orientation: 1, rotate: 0 };
+  assert.equal(layoutPage(image, { ...settings, fit: 'contain' }).clip, null);
+  assert.equal(layoutPage(image, { ...settings, fit: 'stretch' }).clip, null);
+  assert.ok(layoutPage(image, { ...settings, fit: 'cover' }).clip);
+});
+
+test('layoutPage: the picture stays inside the margins when contained', () => {
+  const margin = 10 * PT_PER_MM;
+  const page = layoutPage(
+    { width: 400, height: 300, orientation: 1, rotate: 0 },
+    { pageSize: 'a4', orientation: 'portrait', margin: 10, fit: 'contain' },
+  );
+  assert.ok(page.rect.x >= margin - 1e-9);
+  assert.ok(page.rect.y >= margin - 1e-9);
+  assert.ok(page.rect.x + page.rect.width <= page.width - margin + 1e-9);
+  assert.ok(page.rect.y + page.rect.height <= page.height - margin + 1e-9);
+});
+
+test('layoutPage: a margin larger than the page still leaves a box', () => {
+  const page = layoutPage(
+    { width: 400, height: 300, orientation: 1, rotate: 0 },
+    { pageSize: 'a5', orientation: 'portrait', margin: 500, fit: 'contain' },
+  );
+  assert.ok(page.rect.width > 0);
+  assert.ok(page.rect.height > 0);
+});
+
+/* ============================================================= jpeg.js */
+
+/** A baseline JPEG frame header: precision, height, width, components. */
+const frame = (marker, width, height, components) =>
+  segment(marker, concat([8], u16be(height), u16be(width), [components]));
+
+const jpegFile = (parts) => concat([0xff, 0xd8], parts, [0xff, 0xda], u16be(2));
+
+test('inspectJpeg: a baseline colour photo', () => {
+  const info = inspectJpeg(jpegFile([frame(0xc0, 640, 480, 3)]));
+  assert.deepEqual(info, {
+    sequential: true, width: 640, height: 480, components: 3,
+    orientation: 1, icc: null,
+  });
+});
+
+test('inspectJpeg: extended sequential also qualifies', () => {
+  assert.equal(inspectJpeg(jpegFile([frame(0xc1, 10, 10, 3)])).sequential, true);
+});
+
+test('inspectJpeg: a progressive JPEG is flagged for re-encoding', () => {
+  // PDF's DCTDecode is defined over baseline and extended sequential. Many
+  // readers cope with progressive; "many" is not good enough for a file
+  // somebody sends to a printer.
+  assert.equal(inspectJpeg(jpegFile([frame(0xc2, 10, 10, 3)])).sequential, false);
+});
+
+test('inspectJpeg: component count is reported', () => {
+  assert.equal(inspectJpeg(jpegFile([frame(0xc0, 10, 10, 1)])).components, 1);
+  assert.equal(inspectJpeg(jpegFile([frame(0xc0, 10, 10, 4)])).components, 4);
+});
+
+test('inspectJpeg: fill bytes before a marker are stepped over', () => {
+  // A JPEG may pad the gap before a marker with 0xff. Reading a fill byte as
+  // the marker, and the two after it as a length, sent a perfectly valid photo
+  // down the re-encode path this whole file exists to avoid.
+  const padded = concat([0xff, 0xd8], [0xff, 0xff, 0xff], frame(0xc0, 640, 480, 3),
+    [0xff, 0xda], u16be(2));
+  const info = inspectJpeg(padded);
+  assert.ok(info, 'the file was readable');
+  assert.equal(info.width, 640);
+  assert.equal(info.height, 480);
+  assert.equal(info.sequential, true);
+});
+
+test('inspectJpeg: fill bytes before the EXIF segment do not lose the orientation', () => {
+  const tiff = new Uint8Array([
+    0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x01, 0x00,
+    0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+  ]);
+  const exif = segment(0xe1, concat(ascii('Exif\0\0'), tiff));
+  const padded = concat([0xff, 0xd8], [0xff], exif, [0xff, 0xff], frame(0xc0, 10, 10, 3),
+    [0xff, 0xda], u16be(2));
+  assert.equal(inspectJpeg(padded).orientation, 6);
+});
+
+test('inspectJpeg: anything that is not a JPEG', () => {
+  assert.equal(inspectJpeg(ascii('nope')), null);
+  assert.equal(inspectJpeg(new Uint8Array(2)), null);
+});
+
+test('inspectJpeg: a file with no frame header', () => {
+  assert.equal(inspectJpeg(jpegFile([])), null);
+});
+
+test('inspectJpeg: a zero-sized frame is refused', () => {
+  assert.equal(inspectJpeg(jpegFile([frame(0xc0, 0, 480, 3)])), null);
+});
+
+test('inspectJpeg: a segment length running past the end is refused', () => {
+  const bad = concat([0xff, 0xd8], [0xff, 0xc0], [0xff, 0xff], ascii('x'));
+  assert.equal(inspectJpeg(bad), null);
+});
+
+test('inspectJpeg: the EXIF orientation is read', () => {
+  // A PDF reader has no equivalent tag, so this is the only place a sideways
+  // phone photo gets put right.
+  const tiff = new Uint8Array([
+    0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x01, 0x00,
+    0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+  ]);
+  const exif = segment(0xe1, concat(ascii('Exif\0\0'), tiff));
+  assert.equal(inspectJpeg(jpegFile([exif, frame(0xc0, 10, 10, 3)])).orientation, 6);
+});
+
+test('inspectJpeg: an unreadable orientation leaves the default', () => {
+  // A photo shown the right way up by luck beats one thrown away over a
+  // malformed tag.
+  const exif = segment(0xe1, concat(ascii('Exif\0\0'), ascii('not a tiff block')));
+  assert.equal(inspectJpeg(jpegFile([exif, frame(0xc0, 10, 10, 3)])).orientation, 1);
+});
+
+test('inspectJpeg: an out-of-range orientation is ignored', () => {
+  const tiff = new Uint8Array([
+    0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x01, 0x00,
+    0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x63, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+  ]);
+  const exif = segment(0xe1, concat(ascii('Exif\0\0'), tiff));
+  assert.equal(inspectJpeg(jpegFile([exif, frame(0xc0, 10, 10, 3)])).orientation, 1);
+});
+
+test('inspectJpeg: an ICC profile is pulled out', () => {
+  // Without it a Display P3 photo is shown as though its numbers were sRGB.
+  const icc = segment(0xe2, concat(ascii('ICC_PROFILE\0'), [1, 1], ascii('profile')));
+  const info = inspectJpeg(jpegFile([icc, frame(0xc0, 10, 10, 3)]));
+  assert.equal(new TextDecoder().decode(info.icc), 'profile');
+});
+
+test('inspectJpeg: a profile split over segments is rejoined by sequence number', () => {
+  const part = (index, body) =>
+    segment(0xe2, concat(ascii('ICC_PROFILE\0'), [index, 2], ascii(body)));
+  const info = inspectJpeg(jpegFile([part(2, 'second'), part(1, 'first'), frame(0xc0, 10, 10, 3)]));
+  assert.equal(new TextDecoder().decode(info.icc), 'firstsecond');
+});
+
+test('inspectJpeg: no profile means null, not an empty array', () => {
+  assert.equal(inspectJpeg(jpegFile([frame(0xc0, 10, 10, 3)])).icc, null);
+});
+
+test('inspectJpeg: only the first frame header counts', () => {
+  const info = inspectJpeg(jpegFile([frame(0xc0, 640, 480, 3), frame(0xc2, 1, 1, 1)]));
+  assert.equal(info.width, 640);
+  assert.equal(info.sequential, true);
+});

--- a/tests/js/trim-video.test.js
+++ b/tests/js/trim-video.test.js
@@ -1,0 +1,547 @@
+/**
+ * tools/trim-video/src/{ranges,timeline,copy,mp4}.js.
+ *
+ * `ranges.js` is where seconds become ticks, once, so that the two export
+ * paths and the summary on the page cannot disagree about where a cut lands.
+ * The part worth testing is why a lossless cut starts earlier than you asked:
+ * a frame that is not a keyframe cannot be decoded without the frames around
+ * it, so a copy has to begin at a keyframe and play in from partway through.
+ *
+ * That pre-roll is stated on the page, so it is not a secret - but it is
+ * arithmetic over two different clocks, and getting it wrong desynchronises
+ * the sound rather than throwing anything.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  keyframeBefore, keyframeTimes, planRange, planRanges, rangesFor,
+  sampleDurations, totalSeconds,
+} from '../../tools/trim-video/src/ranges.js';
+import { formatTime, parseTime } from '../../tools/trim-video/src/timeline.js';
+import { estimateCopy } from '../../tools/trim-video/src/copy.js';
+import { MOVIE_TIMESCALE, Mp4Writer, avcSampleEntry } from '../../tools/trim-video/src/mp4.js';
+import { ascii, blobBytes } from './helpers.js';
+
+/* ------------------------------------------------------------- fixtures */
+
+/**
+ * A video track at 30 fps on a 90000-tick clock, with a keyframe every
+ * `gap` frames. No B-frames, so pts and dts agree.
+ */
+function videoTrack({ frames = 60, fps = 30, gap = 15, timescale = 90000 } = {}) {
+  const step = timescale / fps;
+  const samples = [];
+  for (let i = 0; i < frames; i += 1) {
+    samples.push({ dts: i * step, pts: i * step, isKey: i % gap === 0, size: 1000 + i });
+  }
+  return { timescale, samples, duration: frames * step };
+}
+
+/** An audio track on its own, different clock: 48 kHz, 1024 samples a packet. */
+function audioTrack({ packets = 90, timescale = 48000, span = 1024 } = {}) {
+  const samples = [];
+  for (let i = 0; i < packets; i += 1) {
+    samples.push({ dts: i * span, pts: i * span, isKey: true, size: 400 });
+  }
+  return { timescale, samples, duration: packets * span };
+}
+
+const plan = (args) => {
+  const video = args.video ?? videoTrack();
+  const audio = args.audio ?? null;
+  return planRange({
+    video,
+    audio,
+    videoDurations: sampleDurations(video),
+    audioDurations: audio ? sampleDurations(audio) : null,
+    start: args.start,
+    end: args.end,
+    anchor: args.anchor ?? 'keyframe',
+  });
+};
+
+/* ------------------------------------------------------ sampleDurations */
+
+test('a sample lasts until the next one decodes', () => {
+  const track = videoTrack({ frames: 4, fps: 30 });
+  const durations = sampleDurations(track);
+  assert.equal(durations[0], 3000);
+  assert.equal(durations[1], 3000);
+  assert.equal(durations[2], 3000);
+});
+
+test('the last sample takes the track duration that is left', () => {
+  // Decode times are stored; durations are not.
+  const track = videoTrack({ frames: 4, fps: 30 });
+  assert.equal(sampleDurations(track)[3], track.duration - track.samples[3].dts);
+});
+
+test('an absurd declared duration falls back to the sample before it', () => {
+  // A fragmented file whose header was written before its fragments existed.
+  const track = videoTrack({ frames: 4, fps: 30 });
+  track.duration = 9_000_000;
+  const durations = sampleDurations(track);
+  assert.equal(durations[3], durations[2], 'not the absurd remainder');
+});
+
+test('a missing declared duration falls back too', () => {
+  const track = videoTrack({ frames: 4, fps: 30 });
+  track.duration = 0;
+  assert.equal(sampleDurations(track)[3], 3000);
+});
+
+test('a single-sample track still gets a duration', () => {
+  const track = { timescale: 90000, duration: 0, samples: [{ dts: 0, pts: 0, isKey: true, size: 1 }] };
+  assert.equal(sampleDurations(track)[0], 1);
+});
+
+test('an empty track produces an empty list', () => {
+  assert.equal(sampleDurations({ timescale: 90000, duration: 0, samples: [] }).length, 0);
+});
+
+test('decode times that go backwards never produce a negative duration', () => {
+  const track = {
+    timescale: 90000,
+    duration: 6000,
+    samples: [{ dts: 3000, pts: 3000, isKey: true, size: 1 },
+      { dts: 0, pts: 0, isKey: false, size: 1 }],
+  };
+  for (const value of sampleDurations(track)) assert.ok(value >= 0, `${value}`);
+});
+
+/* ---------------------------------------------------------- keyframes */
+
+test('keyframeTimes lists every keyframe in seconds', () => {
+  const times = keyframeTimes(videoTrack({ frames: 60, fps: 30, gap: 15 }));
+  assert.deepEqual(times, [0, 0.5, 1, 1.5]);
+});
+
+test('keyframeTimes comes back sorted', () => {
+  const track = videoTrack({ frames: 30, gap: 10 });
+  track.samples.reverse();
+  assert.deepEqual(keyframeTimes(track), [0, 1 / 3, 2 / 3]);
+});
+
+test('keyframeBefore finds where a lossless cut would really begin', () => {
+  const video = videoTrack({ frames: 60, fps: 30, gap: 15 }); // keys at 0, .5, 1, 1.5
+  assert.equal(keyframeBefore(video, 0.7), 0.5);
+  assert.equal(keyframeBefore(video, 1.5), 1.5, 'landing exactly on one');
+  assert.equal(keyframeBefore(video, 0), 0);
+});
+
+test('keyframeBefore answers zero when there is nothing in front of the cut', () => {
+  const video = videoTrack({ frames: 30, gap: 15 });
+  video.samples[0].isKey = false;
+  assert.equal(keyframeBefore(video, 0.1), 0);
+});
+
+/* ---------------------------------------------------------- planRange */
+
+test('a cut on a keyframe has no pre-roll', () => {
+  const found = plan({ start: 0.5, end: 1.0 });
+  assert.equal(found.keyframeSeconds, 0.5);
+  assert.equal(found.preRoll, 0);
+  assert.equal(found.video.editStart, 0, 'nothing to skip on the way in');
+});
+
+test('a cut between keyframes starts earlier, and says by how much', () => {
+  // Keys every half second; asking for 0.7 gets the one at 0.5.
+  const found = plan({ start: 0.7, end: 1.2 });
+  assert.equal(found.keyframeSeconds, 0.5);
+  assert.ok(Math.abs(found.preRoll - 0.2) < 1e-9);
+  assert.equal(found.start, 0.7, 'what was asked for is remembered');
+});
+
+test('the edit list skips exactly the pre-roll', () => {
+  const found = plan({ start: 0.7, end: 1.2 });
+  const video = videoTrack();
+  // editStart is in the video track's own ticks, measured from the keyframe.
+  assert.ok(Math.abs(found.video.editStart / video.timescale - 0.2) < 1e-9);
+});
+
+test('the sample run begins at the keyframe, not at the cut', () => {
+  const found = plan({ start: 0.7, end: 1.2 });
+  const video = videoTrack();
+  assert.equal(video.samples[found.video.from].isKey, true);
+  assert.ok(video.samples[found.video.from].pts / video.timescale <= 0.7);
+});
+
+test('the run covers every frame shown before the end', () => {
+  const video = videoTrack({ frames: 60, fps: 30, gap: 15 });
+  const found = plan({ video, start: 0.5, end: 1.0 });
+  assert.ok(video.samples[found.video.to].pts / video.timescale < 1.0);
+  const next = video.samples[found.video.to + 1];
+  assert.ok(next.pts / video.timescale >= 1.0, 'and stops there');
+});
+
+test('editStart is never negative', () => {
+  // For the one file in a thousand that stores a frame shown before it decodes.
+  const video = videoTrack({ frames: 30, gap: 15 });
+  video.samples[0].pts = 5000;
+  const found = plan({ video, start: 0, end: 0.5 });
+  assert.ok(found.video.editStart >= 0);
+});
+
+test('a cut in front of the first keyframe still starts somewhere', () => {
+  const video = videoTrack({ frames: 30, gap: 15 });
+  video.samples[0].isKey = false;
+  const found = plan({ video, start: 0.05, end: 0.4 });
+  assert.ok(found.video.from >= 0);
+  assert.ok(found.video.to >= found.video.from);
+});
+
+test('a range with nothing in it still returns a usable plan', () => {
+  const found = plan({ start: 0.5, end: 0.5 });
+  assert.ok(found.video.to >= found.video.from);
+});
+
+/* --------------------------------------------------- planRange, with sound */
+
+test('both tracks are cut from the same instant', () => {
+  // Or they drift apart in any player that ignores the edit list.
+  const video = videoTrack();
+  const audio = audioTrack();
+  const found = plan({ video, audio, start: 0.7, end: 1.2, anchor: 'keyframe' });
+
+  const audioStart = audio.samples[found.audio.from].dts / audio.timescale;
+  assert.ok(audioStart <= found.keyframeSeconds + 1e-9,
+    `sound starts at ${audioStart}, picture at ${found.keyframeSeconds}`);
+});
+
+test('the copy path anchors the sound to the keyframe', () => {
+  const video = videoTrack();
+  const audio = audioTrack();
+  const copy = plan({ video, audio, start: 0.7, end: 1.2, anchor: 'keyframe' });
+  const encode = plan({ video, audio, start: 0.7, end: 1.2, anchor: 'start' });
+  // The re-encode path's picture really does begin at the cut, so its sound
+  // starts later than the copy path's.
+  assert.ok(encode.audio.from >= copy.audio.from);
+});
+
+test('a file with no sound plans no audio', () => {
+  assert.equal(plan({ start: 0.5, end: 1 }).audio, null);
+  assert.equal(plan({ audio: { timescale: 48000, duration: 0, samples: [] }, start: 0.5, end: 1 }).audio,
+    null);
+});
+
+test('the audio edit start is measured on the audio clock', () => {
+  const video = videoTrack();
+  const audio = audioTrack();
+  const found = plan({ video, audio, start: 0.7, end: 1.2 });
+  const skipped = found.audio.editStart / audio.timescale;
+  const audioStart = found.audio.base / audio.timescale;
+  assert.ok(Math.abs((audioStart + skipped) - 0.7) < 0.05, `${audioStart} + ${skipped}`);
+});
+
+/* --------------------------------------------------------- planRanges */
+
+test('several sections are laid end to end', () => {
+  const video = videoTrack({ frames: 120, fps: 30, gap: 15 });
+  const { plans } = planRanges({
+    video, audio: null, anchor: 'keyframe',
+    ranges: [{ start: 0, end: 0.5 }, { start: 1.0, end: 1.5 }],
+  });
+
+  assert.equal(plans.length, 2);
+  assert.equal(plans[0].video.offset, 0);
+  assert.equal(plans[1].video.offset, plans[0].video.spanTs,
+    'the second begins where the first ended');
+});
+
+test('the running offsets are cumulative across three sections', () => {
+  const video = videoTrack({ frames: 180, fps: 30, gap: 15 });
+  const { plans } = planRanges({
+    video, audio: null, anchor: 'keyframe',
+    ranges: [{ start: 0, end: 0.5 }, { start: 1.0, end: 1.5 }, { start: 2.0, end: 2.5 }],
+  });
+  let running = 0;
+  for (const found of plans) {
+    assert.equal(found.video.offset, running);
+    running += found.video.spanTs;
+  }
+});
+
+test('the sound gets its own running offset on its own clock', () => {
+  const video = videoTrack({ frames: 120 });
+  const audio = audioTrack({ packets: 200 });
+  const { plans } = planRanges({
+    video, audio, anchor: 'keyframe',
+    ranges: [{ start: 0, end: 0.5 }, { start: 1.0, end: 1.5 }],
+  });
+  assert.equal(plans[0].audio.offset, 0);
+  assert.equal(plans[1].audio.offset, plans[0].audio.spanTs);
+});
+
+test('planRanges hands back the durations it computed', () => {
+  const video = videoTrack();
+  const { videoDurations, audioDurations } = planRanges({
+    video, audio: null, ranges: [{ start: 0, end: 1 }], anchor: 'keyframe',
+  });
+  assert.equal(videoDurations.length, video.samples.length);
+  assert.equal(audioDurations, null);
+});
+
+/* ---------------------------------------------------------- rangesFor */
+
+test('keeping a section is that section', () => {
+  assert.deepEqual(rangesFor({ mode: 'keep', start: 1, end: 3, duration: 10 }),
+    [{ start: 1, end: 3 }]);
+});
+
+test('cutting a section out leaves the two either side', () => {
+  assert.deepEqual(rangesFor({ mode: 'cut', start: 1, end: 3, duration: 10 }),
+    [{ start: 0, end: 1 }, { start: 3, end: 10 }]);
+});
+
+test('cutting from an end leaves one section, not an empty one', () => {
+  assert.deepEqual(rangesFor({ mode: 'cut', start: 0, end: 3, duration: 10 }),
+    [{ start: 3, end: 10 }]);
+  assert.deepEqual(rangesFor({ mode: 'cut', start: 7, end: 10, duration: 10 }),
+    [{ start: 0, end: 7 }]);
+});
+
+test('a section shorter than a frame is not a section', () => {
+  assert.deepEqual(rangesFor({ mode: 'keep', start: 1, end: 1.01, duration: 10 }), []);
+  assert.deepEqual(rangesFor({ mode: 'keep', start: 1, end: 1, duration: 10 }), []);
+});
+
+test('cutting the whole clip leaves nothing', () => {
+  assert.deepEqual(rangesFor({ mode: 'cut', start: 0, end: 10, duration: 10 }), []);
+});
+
+test('totalSeconds adds the sections up', () => {
+  assert.equal(totalSeconds([{ start: 0, end: 1 }, { start: 5, end: 7 }]), 3);
+  assert.equal(totalSeconds([]), 0);
+});
+
+/* ------------------------------------------------------------- timeline */
+
+test('formatTime is short enough to read and exact enough to type back', () => {
+  assert.equal(formatTime(0), '0:00.000');
+  assert.equal(formatTime(1.5), '0:01.500');
+  assert.equal(formatTime(83.25), '1:23.250');
+  assert.equal(formatTime(3600), '1:00:00.000');
+  assert.equal(formatTime(3723.5), '1:02:03.500');
+});
+
+test('formatTime never shows a negative time', () => {
+  assert.equal(formatTime(-5), '0:00.000');
+  assert.equal(formatTime(undefined), '0:00.000');
+  assert.equal(formatTime(NaN), '0:00.000');
+});
+
+test('parseTime accepts the spellings a person would type', () => {
+  assert.equal(parseTime('1:23.5'), 83.5);
+  assert.equal(parseTime('83.5'), 83.5);
+  assert.equal(parseTime('0:01:23.500'), 83.5);
+  assert.equal(parseTime('  1:23.5  '), 83.5);
+  assert.equal(parseTime('0'), 0);
+});
+
+test('parseTime refuses what is not a time', () => {
+  assert.equal(parseTime(''), null);
+  assert.equal(parseTime('abc'), null);
+  assert.equal(parseTime('1:2:3:4'), null);
+  assert.equal(parseTime('1::2'), null);
+  assert.equal(parseTime('1:.'), null);
+  assert.equal(parseTime(null), null);
+  assert.equal(parseTime(undefined), null);
+});
+
+test('formatTime and parseTime round-trip', () => {
+  for (const seconds of [0, 0.001, 1.5, 59.999, 83.25, 3600, 3723.5, 7199.999]) {
+    const back = parseTime(formatTime(seconds));
+    assert.ok(Math.abs(back - seconds) < 0.001, `${seconds} -> ${formatTime(seconds)} -> ${back}`);
+  }
+});
+
+/* --------------------------------------------------------- estimateCopy */
+
+test('estimateCopy adds up the samples a copy would write', () => {
+  const video = videoTrack({ frames: 60, fps: 30, gap: 15 });
+  const found = estimateCopy({ media: { video, audio: null }, ranges: [{ start: 0, end: 0.5 }] });
+  assert.equal(found.frames, 15);
+  assert.ok(found.bytes > 0);
+  assert.equal(found.preRoll, 0);
+});
+
+test('estimateCopy reports the pre-roll a cut between keyframes costs', () => {
+  const video = videoTrack({ frames: 60, fps: 30, gap: 15 });
+  const found = estimateCopy({ media: { video, audio: null }, ranges: [{ start: 0.7, end: 1.2 }] });
+  assert.ok(Math.abs(found.preRoll - 0.2) < 1e-9);
+  assert.ok(found.frames > 15, 'the hidden frames are in the file');
+});
+
+test('estimateCopy on nothing is zero, not a crash', () => {
+  const video = videoTrack();
+  assert.deepEqual(estimateCopy({ media: { video, audio: null }, ranges: [] }),
+    { bytes: 0, preRoll: 0, frames: 0 });
+});
+
+test('estimateCopy counts the sound only when it is being kept', () => {
+  const media = { video: videoTrack({ frames: 60 }), audio: audioTrack() };
+  const ranges = [{ start: 0, end: 0.5 }];
+  const withSound = estimateCopy({ media, ranges, keepAudio: true });
+  const without = estimateCopy({ media, ranges, keepAudio: false });
+  assert.ok(withSound.bytes > without.bytes);
+  assert.equal(withSound.frames, without.frames, 'the picture is the same either way');
+});
+
+test('estimateCopy takes the largest pre-roll across sections', () => {
+  // The largest deliberately comes first, so that taking the maximum is
+  // distinguishable from simply keeping the last one.
+  const video = videoTrack({ frames: 120, fps: 30, gap: 15 }); // keys every 0.5s
+  const found = estimateCopy({
+    media: { video, audio: null },
+    ranges: [{ start: 0.7, end: 0.9 }, { start: 1.5, end: 1.9 }],
+  });
+  assert.ok(Math.abs(found.preRoll - 0.2) < 1e-9, `got ${found.preRoll}`);
+});
+
+test('estimateCopy reports no pre-roll when every section is on a keyframe', () => {
+  const video = videoTrack({ frames: 120, fps: 30, gap: 15 });
+  const found = estimateCopy({
+    media: { video, audio: null },
+    ranges: [{ start: 0.5, end: 0.9 }, { start: 1.5, end: 1.9 }],
+  });
+  assert.equal(found.preRoll, 0);
+});
+
+/* -------------------------------------------------------------- mp4.js */
+
+const AVCC = new Uint8Array([1, 0x64, 0, 0x1f, 0xff, 0xe1, 0, 4, 0x67, 1, 2, 3, 1, 0, 4, 0x68, 1, 2, 3]);
+
+function topBoxes(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const found = [];
+  let at = 0;
+  while (at + 8 <= bytes.length) {
+    const size = view.getUint32(at);
+    found.push({ type: new TextDecoder('latin1').decode(bytes.subarray(at + 4, at + 8)), at, size });
+    if (size < 8) break;
+    at += size;
+  }
+  return found;
+}
+
+const has = (bytes, type) => {
+  const name = ascii(type);
+  outer: for (let i = 0; i + 4 <= bytes.length; i += 1) {
+    for (let j = 0; j < 4; j += 1) if (bytes[i + j] !== name[j]) continue outer;
+    return true;
+  }
+  return false;
+};
+
+test('avcSampleEntry carries the size and the decoder configuration', () => {
+  const entry = avcSampleEntry(1920, 1080, AVCC);
+  const view = new DataView(entry.buffer, entry.byteOffset, entry.byteLength);
+  assert.equal(new TextDecoder('latin1').decode(entry.subarray(4, 8)), 'avc1');
+  assert.equal(view.getUint16(8 + 24), 1920);
+  assert.equal(view.getUint16(8 + 26), 1080);
+  assert.ok(has(entry, 'avcC'));
+});
+
+test('a written file has the three top-level boxes in faststart order', async () => {
+  const writer = new Mp4Writer();
+  const track = writer.addTrack({
+    kind: 'vide', timescale: 90000, sampleEntry: avcSampleEntry(320, 240, AVCC),
+  });
+  for (let i = 0; i < 4; i += 1) {
+    track.addSample({ data: ascii(`f${i}`), isKey: i === 0, dts: i * 3000, pts: i * 3000, duration: 3000 });
+  }
+  const bytes = await blobBytes(writer.finalize());
+  assert.deepEqual(topBoxes(bytes).map((b) => b.type), ['ftyp', 'moov', 'mdat']);
+  assert.equal(topBoxes(bytes).reduce((n, b) => n + b.size, 0), bytes.length);
+});
+
+test('the sample data reaches mdat in order', async () => {
+  const writer = new Mp4Writer();
+  const track = writer.addTrack({
+    kind: 'vide', timescale: 90000, sampleEntry: avcSampleEntry(320, 240, AVCC),
+  });
+  for (let i = 0; i < 4; i += 1) {
+    track.addSample({ data: ascii(`f${i}`), isKey: i === 0, dts: i * 3000, pts: i * 3000, duration: 3000 });
+  }
+  const bytes = await blobBytes(writer.finalize());
+  const mdat = topBoxes(bytes).find((b) => b.type === 'mdat');
+  assert.equal(new TextDecoder('latin1').decode(bytes.subarray(mdat.at + 8)), 'f0f1f2f3');
+});
+
+test('a composition offset table appears only when the frames need one', async () => {
+  const build = async (withOffsets) => {
+    const writer = new Mp4Writer();
+    const track = writer.addTrack({
+      kind: 'vide', timescale: 90000, sampleEntry: avcSampleEntry(16, 16, AVCC),
+    });
+    for (let i = 0; i < 3; i += 1) {
+      track.addSample({
+        data: ascii('x'), isKey: i === 0, dts: i * 3000,
+        pts: i * 3000 + (withOffsets ? 1500 : 0), duration: 3000,
+      });
+    }
+    return blobBytes(await writer.finalize());
+  };
+  assert.equal(has(await build(false), 'ctts'), false, 'no B-frames, no ctts');
+  assert.equal(has(await build(true), 'ctts'), true);
+});
+
+test('a sync sample table appears only when some frames are not keyframes', async () => {
+  const build = async (allKey) => {
+    const writer = new Mp4Writer();
+    const track = writer.addTrack({
+      kind: 'vide', timescale: 90000, sampleEntry: avcSampleEntry(16, 16, AVCC),
+    });
+    for (let i = 0; i < 3; i += 1) {
+      track.addSample({ data: ascii('x'), isKey: allKey || i === 0, dts: i * 3000, pts: i * 3000, duration: 3000 });
+    }
+    return blobBytes(await writer.finalize());
+  };
+  assert.equal(has(await build(true), 'stss'), false);
+  assert.equal(has(await build(false), 'stss'), true);
+});
+
+test('a track with no sample entry is refused', () => {
+  const writer = new Mp4Writer();
+  assert.throws(() => writer.addTrack({ kind: 'vide', timescale: 90000, sampleEntry: null }),
+    /no sample entry/);
+  assert.throws(() => writer.addTrack({ kind: 'soun', timescale: 48000, sampleEntry: new Uint8Array(0) }),
+    /audio track has no sample entry/);
+});
+
+test('a file with no video frames is refused rather than written', () => {
+  const writer = new Mp4Writer();
+  writer.addTrack({ kind: 'vide', timescale: 90000, sampleEntry: avcSampleEntry(16, 16, AVCC) });
+  assert.throws(() => writer.finalize(), /holds no video frames/);
+});
+
+test('sound is interleaved with the picture rather than written after it', async () => {
+  const writer = new Mp4Writer();
+  const video = writer.addTrack({
+    kind: 'vide', timescale: 90000, sampleEntry: avcSampleEntry(16, 16, AVCC),
+  });
+  const audio = writer.addTrack({
+    kind: 'soun', timescale: 48000, sampleEntry: ascii('mp4a-entry'),
+  });
+  for (let i = 0; i < 120; i += 1) {
+    video.addSample({
+      data: ascii(`V${String(i).padStart(3, '0')}`), isKey: i % 30 === 0,
+      dts: i * 3000, pts: i * 3000, duration: 3000,
+    });
+    audio.addSample({
+      data: ascii(`A${String(i).padStart(3, '0')}`), isKey: true,
+      dts: i * 1600, pts: i * 1600, duration: 1600,
+    });
+  }
+  const bytes = await blobBytes(writer.finalize());
+  const mdat = topBoxes(bytes).find((b) => b.type === 'mdat');
+  const body = new TextDecoder('latin1').decode(bytes.subarray(mdat.at + 8));
+  assert.ok(body.indexOf('A000') < body.lastIndexOf('V119'),
+    'the sound does not all sit behind the picture');
+});
+
+test('the movie timescale is the one the edit lists are written in', () => {
+  assert.equal(MOVIE_TIMESCALE, 1000);
+});

--- a/tests/js/video.test.js
+++ b/tests/js/video.test.js
@@ -1,0 +1,261 @@
+/**
+ * tools/images-to-video/src/{mp4,compose}.js.
+ *
+ * mp4.js is an ISO-BMFF writer built by hand, so nothing has to be fetched to
+ * make a video. The part that can go quietly wrong is `stco`: it holds an
+ * absolute file offset, and that offset depends on how large `moov` is, which
+ * is only known once `moov` has been built. The file builds it twice and
+ * asserts the two passes agree - so the test below reads the offset back out
+ * of the finished file and checks it really does land on the sample data.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Mp4Muxer } from '../../tools/images-to-video/src/mp4.js';
+import {
+  resolveOutputSize, toEvenSize,
+} from '../../tools/images-to-video/src/compose.js';
+import { ascii, blobBytes } from './helpers.js';
+
+const TIMESCALE = 90000;
+
+/** Walk the top-level boxes of an MP4: size, then a four-letter type. */
+function boxes(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const found = [];
+  let at = 0;
+  while (at + 8 <= bytes.length) {
+    const size = view.getUint32(at);
+    const type = new TextDecoder('latin1').decode(bytes.subarray(at + 4, at + 8));
+    found.push({ type, at, size });
+    if (size < 8) break;
+    at += size;
+  }
+  return found;
+}
+
+/**
+ * Find a nested box by type, from `from` onwards.
+ *
+ * `from` matters: ftyp lists "avc1" among its compatible brands, so a search
+ * from the start of the file would find the brand rather than the sample entry.
+ */
+function findBox(bytes, type, from = 4) {
+  const name = ascii(type);
+  outer: for (let i = from; i + 4 <= bytes.length; i += 1) {
+    for (let j = 0; j < 4; j += 1) if (bytes[i + j] !== name[j]) continue outer;
+    return i - 4; // the start of the box, four bytes before its type
+  }
+  return -1;
+}
+
+/** Where a full box's payload begins: size, type, then version and flags. */
+const PAYLOAD = 12;
+
+/** Read the nth 32-bit field of a full box's payload. */
+const field = (bytes, box, n) =>
+  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+    .getUint32(box + PAYLOAD + n * 4);
+
+/** The start of the moov box, which is where the sample tables live. */
+const afterFtyp = (bytes) => boxes(bytes)[0].size;
+
+const AVCC = new Uint8Array([1, 0x64, 0, 0x1f, 0xff, 0xe1, 0, 4, 0x67, 1, 2, 3, 1, 0, 4, 0x68, 1, 2, 3]);
+
+function muxed({ frames = 3, width = 320, height = 240, allKey = false } = {}) {
+  const muxer = new Mp4Muxer({ width, height });
+  muxer.setDecoderConfig(AVCC.buffer.slice(0));
+  for (let i = 0; i < frames; i += 1) {
+    muxer.addSample(ascii(`frame-${i}-data`), allKey || i === 0, 1 / 30);
+  }
+  return muxer;
+}
+
+test('mp4: the top-level boxes, in faststart order', async () => {
+  const bytes = await blobBytes(muxed().finalize());
+  assert.deepEqual(boxes(bytes).map((b) => b.type), ['ftyp', 'moov', 'mdat']);
+});
+
+test('mp4: the box sizes cover the whole file exactly', async () => {
+  const bytes = await blobBytes(muxed().finalize());
+  const total = boxes(bytes).reduce((n, b) => n + b.size, 0);
+  assert.equal(total, bytes.length);
+});
+
+test('mp4: the blob is typed as an mp4', () => {
+  assert.equal(muxed().finalize().type, 'video/mp4');
+});
+
+test('mp4: mdat holds the samples, in order, untouched', async () => {
+  const bytes = await blobBytes(muxed({ frames: 3 }).finalize());
+  const mdat = boxes(bytes).find((b) => b.type === 'mdat');
+  const body = new TextDecoder('latin1').decode(bytes.subarray(mdat.at + 8));
+  assert.equal(body, 'frame-0-dataframe-1-dataframe-2-data');
+});
+
+test('mp4: stco points at the first byte of the sample data', async () => {
+  // The two-pass offset. If it were wrong the file would still parse and no
+  // frame would decode.
+  const bytes = await blobBytes(muxed().finalize());
+  const stco = findBox(bytes, 'stco');
+  const offset = field(bytes, stco, 1); // entry_count, then the offset
+  const mdat = boxes(bytes).find((b) => b.type === 'mdat');
+  assert.equal(offset, mdat.at + 8);
+  assert.equal(new TextDecoder('latin1').decode(bytes.subarray(offset, offset + 7)), 'frame-0');
+});
+
+test('mp4: stsz lists every sample size', async () => {
+  const bytes = await blobBytes(muxed({ frames: 3 }).finalize());
+  const stsz = findBox(bytes, 'stsz');
+  assert.equal(field(bytes, stsz, 0), 0, 'sample_size 0: the sizes vary');
+  assert.equal(field(bytes, stsz, 1), 3, 'sample count');
+  for (let i = 0; i < 3; i += 1) {
+    assert.equal(field(bytes, stsz, 2 + i), `frame-${i}-data`.length);
+  }
+});
+
+test('mp4: the durations are in the declared timescale', async () => {
+  const bytes = await blobBytes(muxed({ frames: 3 }).finalize());
+  const stts = findBox(bytes, 'stts');
+  // Equal durations are run-length encoded into one entry.
+  assert.equal(field(bytes, stts, 0), 1, 'one run');
+  assert.equal(field(bytes, stts, 1), 3, 'covering three samples');
+  assert.equal(field(bytes, stts, 2), Math.round(TIMESCALE / 30));
+});
+
+test('mp4: a sync sample table appears only when some frames are not keyframes', async () => {
+  const mixed = await blobBytes(muxed({ frames: 3, allKey: false }).finalize());
+  assert.notEqual(findBox(mixed, 'stss'), -1);
+
+  const all = await blobBytes(muxed({ frames: 3, allKey: true }).finalize());
+  assert.equal(findBox(all, 'stss'), -1, 'every frame is a sync sample');
+});
+
+test('mp4: stss lists keyframes one-based', async () => {
+  const bytes = await blobBytes(muxed({ frames: 3 }).finalize());
+  const stss = findBox(bytes, 'stss');
+  assert.equal(field(bytes, stss, 0), 1, 'one keyframe');
+  assert.equal(field(bytes, stss, 1), 1, 'sample number 1, not index 0');
+});
+
+test('mp4: the decoder configuration is written into avcC', async () => {
+  const bytes = await blobBytes(muxed().finalize());
+  const avcC = findBox(bytes, 'avcC');
+  assert.notEqual(avcC, -1);
+  assert.deepEqual(bytes.subarray(avcC + 8, avcC + 8 + AVCC.length), AVCC);
+});
+
+test('mp4: the frame size reaches the sample entry', async () => {
+  const bytes = await blobBytes(muxed({ width: 1920, height: 1080 }).finalize());
+  const view = new DataView(bytes.buffer);
+  // Searched from past ftyp, which lists "avc1" among its compatible brands.
+  const avc1 = findBox(bytes, 'avc1', afterFtyp(bytes));
+  // 6 reserved, data_reference_index, 2 pre_defined/reserved, 12 pre_defined.
+  assert.equal(view.getUint16(avc1 + 8 + 24), 1920);
+  assert.equal(view.getUint16(avc1 + 8 + 26), 1080);
+});
+
+test('mp4: the first decoder configuration wins', () => {
+  // VideoEncoder supplies it on the first chunk and occasionally repeats it.
+  const muxer = new Mp4Muxer({ width: 16, height: 16 });
+  muxer.setDecoderConfig(AVCC.buffer.slice(0));
+  muxer.setDecoderConfig(new Uint8Array([9, 9, 9]).buffer);
+  assert.deepEqual(muxer.avcC, AVCC);
+});
+
+test('mp4: a decoder configuration given as a view is copied out of it', () => {
+  const backing = new Uint8Array([0, 0, ...AVCC, 0, 0]);
+  const muxer = new Mp4Muxer({ width: 16, height: 16 });
+  muxer.setDecoderConfig(backing.subarray(2, 2 + AVCC.length));
+  assert.deepEqual(muxer.avcC, AVCC);
+});
+
+test('mp4: refusals rather than a broken file', () => {
+  assert.throws(() => new Mp4Muxer({ width: 16, height: 16 }).setDecoderConfig(null),
+    /no decoder configuration/);
+
+  const noFrames = new Mp4Muxer({ width: 16, height: 16 });
+  noFrames.setDecoderConfig(AVCC.buffer.slice(0));
+  assert.throws(() => noFrames.finalize(), /No frames were encoded/);
+
+  const noConfig = new Mp4Muxer({ width: 16, height: 16 });
+  noConfig.addSample(ascii('x'), true, 1 / 30);
+  assert.throws(() => noConfig.finalize(), /never reported a decoder configuration/);
+});
+
+test('mp4: a duration of zero still advances the clock by one tick', () => {
+  const muxer = new Mp4Muxer({ width: 16, height: 16 });
+  muxer.addSample(ascii('x'), true, 0);
+  assert.equal(muxer.samples[0].durationTs, 1);
+});
+
+test('mp4: totalBytes tracks what was added', () => {
+  const muxer = muxed({ frames: 3 });
+  assert.equal(muxer.totalBytes, 'frame-0-data'.length * 3);
+});
+
+/* ============================================================== compose */
+
+test('toEvenSize: H.264 needs even dimensions in both axes', () => {
+  assert.deepEqual(toEvenSize(1920, 1080), { width: 1920, height: 1080 });
+  assert.deepEqual(toEvenSize(1921, 1081), { width: 1920, height: 1080 });
+  assert.deepEqual(toEvenSize(1919.9, 1079.9), { width: 1918, height: 1078 });
+});
+
+test('toEvenSize: never smaller than two', () => {
+  assert.deepEqual(toEvenSize(1, 1), { width: 2, height: 2 });
+  assert.deepEqual(toEvenSize(0, 0), { width: 2, height: 2 });
+  assert.deepEqual(toEvenSize(-10, -10), { width: 2, height: 2 });
+});
+
+test('resolveOutputSize: a WIDTHxHEIGHT preset is taken as written', () => {
+  assert.deepEqual(resolveOutputSize('1280x720', []), { width: 1280, height: 720 });
+  assert.deepEqual(resolveOutputSize('1281x721', []), { width: 1280, height: 720 });
+});
+
+test('resolveOutputSize: "auto" takes each axis independently', () => {
+  // A set holding both a landscape and a portrait photo resolves to a box
+  // large enough for both, so neither is scaled down.
+  const items = [{ width: 4000, height: 3000 }, { width: 3000, height: 4000 }];
+  assert.deepEqual(resolveOutputSize('auto', items), { width: 4000, height: 4000 });
+});
+
+test('resolveOutputSize: "auto" with nothing to go on', () => {
+  assert.deepEqual(resolveOutputSize('auto', []), { width: 1920, height: 1080 });
+});
+
+test('resolveOutputSize: "auto" is capped and stays proportional', () => {
+  const size = resolveOutputSize('auto', [{ width: 16000, height: 8000 }]);
+  assert.equal(size.width, 7680);
+  assert.equal(size.height, 3840);
+});
+
+test('resolveOutputSize: "custom" is used, and capped', () => {
+  assert.deepEqual(resolveOutputSize('custom', [], { width: 800, height: 600 }),
+    { width: 800, height: 600 });
+  assert.deepEqual(resolveOutputSize('custom', [], { width: 16000, height: 16000 }),
+    { width: 7680, height: 7680 });
+});
+
+test('resolveOutputSize: "custom" with nothing usable falls back', () => {
+  assert.deepEqual(resolveOutputSize('custom', []), { width: 1920, height: 1080 });
+  assert.deepEqual(resolveOutputSize('custom', [], { width: 0, height: -1 }),
+    { width: 1920, height: 1080 });
+  assert.deepEqual(resolveOutputSize('custom', [], { width: 'x', height: 'y' }),
+    { width: 1920, height: 1080 });
+});
+
+test('resolveOutputSize: every answer is even', () => {
+  const cases = [
+    ['auto', [{ width: 1921, height: 1081 }], undefined],
+    ['auto', [{ width: 15999, height: 8001 }], undefined],
+    ['custom', [], { width: 801, height: 601 }],
+    ['1281x721', [], undefined],
+  ];
+  for (const [preset, items, custom] of cases) {
+    const { width, height } = resolveOutputSize(preset, items, custom);
+    assert.equal(width % 2, 0, `${preset}: width ${width}`);
+    assert.equal(height % 2, 0, `${preset}: height ${height}`);
+  }
+});

--- a/tests/js/zip.test.js
+++ b/tests/js/zip.test.js
@@ -1,0 +1,155 @@
+/**
+ * tools/*\/src/zip.js - the stored-only ZIP writer.
+ *
+ * Nothing here compresses, so the interesting part is the bookkeeping: the
+ * three signatures, the CRC of each entry, the offset in each central
+ * directory record pointing at that entry's local header, and the flag that
+ * says the names are UTF-8. Get the offsets wrong and the archive opens in one
+ * reader and not another, which is the kind of failure nobody notices until
+ * somebody else cannot open the file.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { makeZip as compressZip } from '../../tools/compress-image/src/zip.js';
+import { makeZip as exifZip } from '../../tools/exif-editor/src/zip.js';
+import { crc32 } from '../../tools/exif-editor/src/crc32.js';
+import { ascii, blobBytes } from './helpers.js';
+
+const LOCAL_SIG = 0x04034b50;
+const CENTRAL_SIG = 0x02014b50;
+const END_SIG = 0x06054b50;
+
+const files = [
+  { name: 'one.jpg', data: ascii('the first file') },
+  { name: 'two.png', data: ascii('and the second') },
+];
+
+/** Read the end-of-central-directory record, which is the last 22 bytes. */
+function endRecord(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const at = bytes.length - 22;
+  return {
+    signature: view.getUint32(at, true),
+    entries: view.getUint16(at + 8, true),
+    total: view.getUint16(at + 10, true),
+    centralSize: view.getUint32(at + 12, true),
+    centralAt: view.getUint32(at + 16, true),
+  };
+}
+
+const copies = [['compress-image', compressZip], ['exif-editor', exifZip]];
+
+for (const [tool, makeZip] of copies) {
+  const built = async (input = files) => blobBytes(makeZip(input));
+
+  test(`${tool}: the blob is typed as a zip`, () => {
+    assert.equal(makeZip(files).type, 'application/zip');
+  });
+
+  test(`${tool}: it starts with a local file header`, async () => {
+    const bytes = await built();
+    const view = new DataView(bytes.buffer);
+    assert.equal(view.getUint32(0, true), LOCAL_SIG);
+  });
+
+  test(`${tool}: the end record counts the files`, async () => {
+    const end = endRecord(await built());
+    assert.equal(end.signature, END_SIG);
+    assert.equal(end.entries, files.length);
+    assert.equal(end.total, files.length);
+  });
+
+  test(`${tool}: the central directory is where the end record says`, async () => {
+    const bytes = await built();
+    const end = endRecord(bytes);
+    const view = new DataView(bytes.buffer);
+    assert.equal(view.getUint32(end.centralAt, true), CENTRAL_SIG);
+    assert.equal(end.centralAt + end.centralSize + 22, bytes.length);
+  });
+
+  test(`${tool}: each central record points at its own local header`, async () => {
+    // This is the field that decides whether the archive opens at all.
+    const bytes = await built();
+    const end = endRecord(bytes);
+    const view = new DataView(bytes.buffer);
+
+    let at = end.centralAt;
+    for (const file of files) {
+      assert.equal(view.getUint32(at, true), CENTRAL_SIG);
+      const nameLength = view.getUint16(at + 28, true);
+      const localAt = view.getUint32(at + 42, true);
+      assert.equal(view.getUint32(localAt, true), LOCAL_SIG, `${file.name}: local header`);
+      assert.equal(
+        new TextDecoder().decode(bytes.subarray(localAt + 30, localAt + 30 + nameLength)),
+        file.name,
+      );
+      at += 46 + nameLength;
+    }
+    assert.equal(at, end.centralAt + end.centralSize);
+  });
+
+  test(`${tool}: the file data follows its header, uncompressed`, async () => {
+    const bytes = await built();
+    const view = new DataView(bytes.buffer);
+    const nameLength = view.getUint16(26, true);
+    const start = 30 + nameLength;
+    assert.equal(view.getUint16(8, true), 0, 'method 0: stored');
+    assert.deepEqual(bytes.subarray(start, start + files[0].data.length), files[0].data);
+  });
+
+  test(`${tool}: the sizes are the real ones and are equal`, async () => {
+    const bytes = await built();
+    const view = new DataView(bytes.buffer);
+    assert.equal(view.getUint32(18, true), files[0].data.length, 'compressed size');
+    assert.equal(view.getUint32(22, true), files[0].data.length, 'uncompressed size');
+  });
+
+  test(`${tool}: each entry carries the CRC of its own data`, async () => {
+    const bytes = await built();
+    const view = new DataView(bytes.buffer);
+    assert.equal(view.getUint32(14, true), crc32([files[0].data]));
+  });
+
+  test(`${tool}: names are flagged as UTF-8`, async () => {
+    // Bit 11, or a name outside code page 437 comes out as mojibake.
+    const bytes = await built();
+    const view = new DataView(bytes.buffer);
+    assert.equal(view.getUint16(6, true) & 0x0800, 0x0800);
+  });
+
+  test(`${tool}: a non-ASCII name survives`, async () => {
+    const name = 'café — photo.jpg';
+    const bytes = await built([{ name, data: ascii('x') }]);
+    const view = new DataView(bytes.buffer);
+    const nameLength = view.getUint16(26, true);
+    assert.equal(new TextDecoder().decode(bytes.subarray(30, 30 + nameLength)), name);
+    assert.ok(nameLength > name.length, 'a multi-byte name is longer in bytes');
+  });
+
+  test(`${tool}: an empty archive is just an end record`, async () => {
+    const bytes = await built([]);
+    assert.equal(bytes.length, 22);
+    const end = endRecord(bytes);
+    assert.equal(end.entries, 0);
+    assert.equal(end.centralSize, 0);
+    assert.equal(end.centralAt, 0);
+  });
+
+  test(`${tool}: an empty file is allowed`, async () => {
+    const bytes = await built([{ name: 'empty.txt', data: new Uint8Array(0) }]);
+    const view = new DataView(bytes.buffer);
+    assert.equal(view.getUint32(18, true), 0);
+    assert.equal(view.getUint32(14, true), 0, 'CRC of nothing is zero');
+  });
+
+  test(`${tool}: total length is the sum of its parts`, async () => {
+    const bytes = await built();
+    const names = files.reduce((n, f) => n + f.name.length, 0);
+    const data = files.reduce((n, f) => n + f.data.length, 0);
+    // Two local headers (30 + name), the data, two central records
+    // (46 + name), and one 22-byte end record.
+    assert.equal(bytes.length, 30 * 2 + names + data + 46 * 2 + names + 22);
+  });
+}

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -1,0 +1,331 @@
+"""
+build.py.
+
+Three things are checked here.
+
+The small pieces first: `write`, which exists because a build that produced
+CRLF on Windows and LF in CI would show every line of every file as changed on
+alternate deploys; `blob_id`, which has to agree with Git exactly or `--check`
+compares nothing; and `Emitter`, which decides what gets minified.
+
+Then the build itself, run into a temporary directory. That is more than a unit
+test, and it earns its place: it is the only thing that catches a template that
+stopped rendering, a tool.toml that lost a key, or a page that quietly stopped
+being written. It needs nothing installed - the plain build is pure Python.
+"""
+
+import hashlib
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import build as buildmod
+from buildlib import mangle
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class Write(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_a_trailing_newline_is_added_when_missing(self):
+        path = self.dir / 'a.txt'
+        buildmod.write(path, 'x')
+        self.assertEqual(path.read_bytes(), b'x\n')
+
+    def test_a_trailing_newline_is_not_doubled(self):
+        path = self.dir / 'a.txt'
+        buildmod.write(path, 'x\n')
+        self.assertEqual(path.read_bytes(), b'x\n')
+
+    def test_line_endings_are_always_lf(self):
+        # Even on Windows, and even when the text already holds CRLF.
+        path = self.dir / 'a.txt'
+        buildmod.write(path, 'a\nb\n')
+        self.assertEqual(path.read_bytes(), b'a\nb\n')
+
+    def test_the_text_is_utf8(self):
+        path = self.dir / 'a.txt'
+        buildmod.write(path, 'café\n')
+        self.assertEqual(path.read_bytes(), 'café\n'.encode('utf-8'))
+
+
+class BlobId(unittest.TestCase):
+    """The id Git would give a file, computed without shelling out per file."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_it_matches_the_documented_rule(self):
+        path = self.dir / 'a.txt'
+        path.write_bytes(b'hello\n')
+        expected = hashlib.sha1(b'blob 6\x00hello\n').hexdigest()
+        self.assertEqual(buildmod.blob_id(path), expected)
+
+    def test_an_empty_file_is_the_well_known_empty_blob(self):
+        path = self.dir / 'empty'
+        path.write_bytes(b'')
+        self.assertEqual(buildmod.blob_id(path),
+                         'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391')
+
+    def test_it_agrees_with_git_itself(self):
+        path = self.dir / 'a.bin'
+        path.write_bytes(bytes(range(256)) + b'\r\n mixed \n endings \r\n')
+        found = subprocess.run(['git', 'hash-object', str(path)],
+                               capture_output=True, text=True, check=True)
+        self.assertEqual(buildmod.blob_id(path), found.stdout.strip())
+
+
+class EmitterSetup(unittest.TestCase):
+    SITE = {'source_url': 'https://example.test/repo',
+            'build': {'esbuild_version': '0.25.0'}}
+
+    def test_the_banner_names_the_source_and_the_check_command(self):
+        emitter = buildmod.Emitter(True, self.SITE)
+        self.assertIn('https://example.test/repo', emitter.js_banner)
+        self.assertIn('build.py --check', emitter.js_banner)
+
+    def test_the_mangled_banner_says_so(self):
+        emitter = buildmod.Emitter(True, self.SITE)
+        self.assertIn('mangled', emitter.js_mangled_banner)
+
+    def test_mangling_without_minifying_is_refused(self):
+        # Mangling is minifying, and more of it.
+        with self.assertRaises(mangle.MangleError) as caught:
+            buildmod.Emitter(False, self.SITE, mangle_names=True)
+        self.assertIn('contradict', str(caught.exception))
+
+    def test_mangling_needs_a_pinned_version(self):
+        site = {'source_url': 'https://example.test/repo'}
+        with self.assertRaises(mangle.MangleError) as caught:
+            buildmod.Emitter(True, site, mangle_names=True)
+        self.assertIn('esbuild_version', str(caught.exception))
+
+    def test_not_mangling_never_looks_for_esbuild(self):
+        self.assertIsNone(buildmod.Emitter(True, self.SITE).esbuild)
+
+
+class EmitterOutput(unittest.TestCase):
+    SITE = {'source_url': 'https://example.test/repo'}
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_minifying_off_writes_the_source_through(self):
+        emitter = buildmod.Emitter(False, self.SITE)
+        source = '// a note\nlet x = 1\n'
+        emitter.js(self.dir / 'a.js', source, where='a.js')
+        self.assertEqual((self.dir / 'a.js').read_text(encoding='utf-8'), source)
+
+    def test_minifying_on_strips_comments_and_keeps_the_banner(self):
+        emitter = buildmod.Emitter(True, self.SITE)
+        emitter.js(self.dir / 'a.js', '// a note\nlet x = 1\n', where='a.js')
+        out = (self.dir / 'a.js').read_text(encoding='utf-8')
+        self.assertNotIn('a note', out)
+        self.assertIn('let x=1', out)
+        self.assertIn('build.py --check', out)
+
+    def test_html_carries_the_banner_as_a_comment(self):
+        emitter = buildmod.Emitter(True, self.SITE)
+        emitter.html(self.dir / 'a.html', '<p>\n  a\n</p>\n')
+        out = (self.dir / 'a.html').read_text(encoding='utf-8')
+        self.assertTrue(out.startswith('<!--'))
+        self.assertIn('<p> a </p>', out)
+
+    def test_css_text_returns_rather_than_writes(self):
+        # The stylesheet has to be hashed after minifying and before being
+        # written, because the hash goes in the URL the page asks for it by.
+        emitter = buildmod.Emitter(True, self.SITE)
+        out = emitter.css_text('a {\n  color: red;\n}\n')
+        self.assertIn('a{color:red}', out)
+        self.assertEqual(list(self.dir.iterdir()), [])
+
+    def test_css_text_is_untouched_when_minifying_is_off(self):
+        source = 'a {\n  color: red;\n}\n'
+        self.assertEqual(buildmod.Emitter(False, self.SITE).css_text(source),
+                         source)
+
+
+class BuildTheSite(unittest.TestCase):
+    """A whole plain build, into a temporary directory.
+
+    Slower than the rest of this file and worth it: everything above tests one
+    piece, and this is the only thing that would notice a page that stopped
+    being written at all.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.out = Path(cls.tmp.name) / 'dist'
+        cls.written = buildmod.build(cls.out, clean=True, minify_output=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def test_it_reports_what_it_wrote(self):
+        self.assertIn('index.html', self.written)
+        self.assertIn('sitemap.xml', self.written)
+
+    def test_every_reported_page_is_on_disk(self):
+        for name in self.written:
+            with self.subTest(page=name):
+                self.assertTrue((self.out / name).is_file(), name)
+
+    def test_every_tool_in_the_repository_got_a_page(self):
+        slugs = sorted(p.parent.name for p in ROOT.glob('tools/*/tool.toml'))
+        self.assertTrue(slugs)
+        for slug in slugs:
+            with self.subTest(tool=slug):
+                self.assertIn(f'{slug}/index.html', self.written)
+
+    def test_a_tool_page_is_complete(self):
+        slug = sorted(p.parent.name for p in ROOT.glob('tools/*/tool.toml'))[0]
+        for name in ('index.html', 'styles.css', 'analytics.js', 'sw.js',
+                     'src/main.js'):
+            with self.subTest(file=name):
+                self.assertTrue((self.out / slug / name).is_file(), name)
+
+    def test_a_tool_page_carries_a_policy_and_its_structured_data(self):
+        slug = sorted(p.parent.name for p in ROOT.glob('tools/*/tool.toml'))[0]
+        page = (self.out / slug / 'index.html').read_text(encoding='utf-8')
+        self.assertIn('Content-Security-Policy', page)
+        self.assertIn('application/ld+json', page)
+        self.assertIn('SoftwareApplication', page)
+
+    def test_the_stylesheet_is_asked_for_by_a_versioned_url(self):
+        slug = sorted(p.parent.name for p in ROOT.glob('tools/*/tool.toml'))[0]
+        page = (self.out / slug / 'index.html').read_text(encoding='utf-8')
+        self.assertIn('styles.css?v=', page)
+
+    def test_the_service_worker_precaches_that_same_url(self):
+        # A mismatch would leave the tool styled online and bare offline.
+        slug = sorted(p.parent.name for p in ROOT.glob('tools/*/tool.toml'))[0]
+        page = (self.out / slug / 'index.html').read_text(encoding='utf-8')
+        worker = (self.out / slug / 'sw.js').read_text(encoding='utf-8')
+        version = page.split('styles.css?v=')[1].split('"')[0].split("'")[0]
+        self.assertIn(f'styles.css?v={version}', worker)
+
+    def test_no_template_tag_survives_into_the_output(self):
+        for name in self.written:
+            if not name.endswith('.html'):
+                continue
+            with self.subTest(page=name):
+                text = (self.out / name).read_text(encoding='utf-8')
+                self.assertNotIn('{{', text)
+                self.assertNotIn('{%', text)
+
+    def test_the_sitemap_lists_every_page(self):
+        sitemap = (self.out / 'sitemap.xml').read_text(encoding='utf-8')
+        site = buildmod.sitelib.load_toml(ROOT / 'config' / 'site.toml')
+        for name in self.written:
+            if not name.endswith('index.html'):
+                continue
+            slug = name[:-len('index.html')]
+            with self.subTest(page=slug or '/'):
+                self.assertIn(f'{site["domain"]}{slug}', sitemap)
+
+    def test_the_404_page_is_written(self):
+        self.assertIn('404.html', self.written)
+        self.assertTrue((self.out / '404.html').is_file())
+
+    def test_the_404_page_is_not_in_the_sitemap(self):
+        """It has no address of its own to list.
+
+        Inviting a crawler to index it would be inviting it to serve "not
+        found" in place of a real page."""
+        sitemap = (self.out / 'sitemap.xml').read_text(encoding='utf-8')
+        self.assertNotIn('404', sitemap)
+
+    def test_the_404_page_asks_not_to_be_indexed(self):
+        page = (self.out / '404.html').read_text(encoding='utf-8')
+        self.assertIn('noindex', page)
+        self.assertNotIn('rel="canonical"', page)
+
+    def test_the_404_page_carries_no_advertising(self):
+        # Google asks that ads not be placed on error pages, and an advert on
+        # top of "we could not find that" is a poor way to meet somebody.
+        page = (self.out / '404.html').read_text(encoding='utf-8')
+        self.assertNotIn('adsbygoogle', page)
+        self.assertNotIn('pagead2.googlesyndication.com/pagead/js', page)
+
+    def test_every_url_on_the_404_page_is_root_absolute(self):
+        """It is served at whatever address was asked for.
+
+        A visitor who mistypes /compress-imag/ gets this file while the browser
+        still believes it is in a folder of that name, so a relative link would
+        resolve against a folder that does not exist and the page would arrive
+        unstyled."""
+        page = (self.out / '404.html').read_text(encoding='utf-8')
+        for attribute in ('href', 'src'):
+            for match in re.finditer(attribute + r'="([^"]+)"', page):
+                url = match.group(1)
+                if url.startswith(('http://', 'https://', 'data:', '#', 'mailto:')):
+                    continue
+                with self.subTest(url=url):
+                    self.assertTrue(url.startswith('/'), f'{attribute}="{url}" is relative')
+
+    def test_the_404_page_links_every_tool(self):
+        page = (self.out / '404.html').read_text(encoding='utf-8')
+        for path in ROOT.glob('tools/*/tool.toml'):
+            with self.subTest(tool=path.parent.name):
+                self.assertIn(f'/{path.parent.name}/', page)
+
+    def test_shared_files_are_copied_but_the_css_sources_are_not(self):
+        self.assertTrue((self.out / 'robots.txt').is_file())
+        self.assertTrue((self.out / 'site.css').is_file())
+        # shared/css is an input to the assembled stylesheets, not a file
+        # anyone fetches.
+        self.assertFalse((self.out / 'css').exists())
+
+    def test_every_file_written_uses_lf(self):
+        for path in self.out.rglob('*'):
+            if not path.is_file() or path.suffix not in ('.html', '.css', '.js', '.xml'):
+                continue
+            with self.subTest(file=path.name):
+                self.assertNotIn(b'\r\n', path.read_bytes())
+
+    def test_building_twice_gives_the_same_bytes(self):
+        """Nothing here depends on the machine, the clock, or directory order.
+
+        That is what makes `python build.py --check` mean anything.
+        """
+        with tempfile.TemporaryDirectory() as second:
+            other = Path(second) / 'dist'
+            buildmod.build(other, clean=True, minify_output=False)
+            for path in sorted(self.out.rglob('*')):
+                if not path.is_file():
+                    continue
+                name = path.relative_to(self.out)
+                with self.subTest(file=name.as_posix()):
+                    self.assertEqual(path.read_bytes(),
+                                     (other / name).read_bytes())
+
+
+class BuildMinified(unittest.TestCase):
+    def test_a_minified_build_produces_the_same_file_list(self):
+        """The readable build is the reference the minified one is judged
+        against - the same check CI runs against the mangled output."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plain = Path(tmp) / 'plain'
+            small = Path(tmp) / 'small'
+            buildmod.build(plain, clean=True, minify_output=False)
+            buildmod.build(small, clean=True, minify_output=True)
+            self.assertEqual(
+                sorted(p.relative_to(plain).as_posix() for p in plain.rglob('*')),
+                sorted(p.relative_to(small).as_posix() for p in small.rglob('*')))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/test_cssmin.py
+++ b/tests/python/test_cssmin.py
@@ -1,0 +1,202 @@
+"""
+buildlib/cssmin.py.
+
+That module's docstring is a list of promises about what it will and will not
+touch. These are those promises written as assertions, and most of them are the
+same shape: a space that looks removable and is not. Those are the ones where a
+minifier changes a page rather than shrinking it.
+"""
+
+import unittest
+
+from buildlib import cssmin
+
+
+def mini(source):
+    """Minify, without the trailing newline every result carries."""
+    return cssmin.css(source).rstrip('\n')
+
+
+class Basics(unittest.TestCase):
+    def test_a_rule_loses_its_layout(self):
+        self.assertEqual(mini('a {\n  color: red;\n}\n'), 'a{color:red}')
+
+    def test_result_always_ends_in_one_newline(self):
+        self.assertEqual(cssmin.css('a{color:red}'), 'a{color:red}\n')
+
+    def test_empty_input_is_just_the_newline(self):
+        self.assertEqual(cssmin.css(''), '\n')
+
+    def test_banner_is_wrapped_in_a_comment(self):
+        self.assertEqual(cssmin.css('a{color:red}', ' built '),
+                         '/* built */a{color:red}\n')
+
+    def test_comments_go(self):
+        self.assertEqual(mini('/* why */ a { /* also why */ color: red }'),
+                         'a{color:red}')
+
+    def test_the_last_semicolon_in_a_block_goes(self):
+        self.assertEqual(mini('a{color:red;background:blue;}'),
+                         'a{color:red;background:blue}')
+
+    def test_repeated_semicolons_collapse(self):
+        self.assertEqual(mini('a{color:red;;;background:blue}'),
+                         'a{color:red;background:blue}')
+
+    def test_a_semicolon_straight_after_a_brace_goes(self):
+        self.assertEqual(mini('a{;color:red}'), 'a{color:red}')
+
+
+class SpacesThatMatter(unittest.TestCase):
+    def test_the_descendant_combinator_survives(self):
+        self.assertEqual(mini('.a .b { color: red }'), '.a .b{color:red}')
+
+    def test_a_compound_selector_gains_nothing(self):
+        self.assertEqual(mini('.a.b { color: red }'), '.a.b{color:red}')
+
+    def test_space_between_values_survives(self):
+        self.assertEqual(mini('a { margin: 1px 2px }'), 'a{margin:1px 2px}')
+
+    def test_a_font_shorthand_survives(self):
+        self.assertEqual(mini('a { font: bold 12px/1.4 serif }'),
+                         'a{font:bold 12px/1.4 serif}')
+
+    def test_calc_keeps_its_arithmetic_spaces(self):
+        self.assertEqual(mini('a { width: calc(100% - 2rem) }'),
+                         'a{width:calc(100% - 2rem)}')
+
+    def test_a_combinator_in_a_selector_loses_its_spaces(self):
+        self.assertEqual(mini('a > b + c ~ d { color: red }'), 'a>b+c~d{color:red}')
+
+    def test_the_same_characters_in_a_value_keep_theirs(self):
+        # In a selector `+` is a combinator; in a value it is arithmetic, and
+        # `calc(1px+2px)` is invalid.
+        self.assertEqual(mini('a { width: calc(1px + 2px) }'),
+                         'a{width:calc(1px + 2px)}')
+        self.assertEqual(mini('a { width: calc(100% - 2rem + 1px) }'),
+                         'a{width:calc(100% - 2rem + 1px)}')
+
+    def test_a_combinator_inside_a_media_block_still_binds_selectors(self):
+        self.assertEqual(mini('@media screen { a > b { width: calc(1px + 2px) } }'),
+                         '@media screen{a>b{width:calc(1px + 2px)}}')
+
+    def test_colon_in_a_selector_is_left_alone(self):
+        # `a :hover` is a hovered descendant of `a`; `a:hover` is a hovered `a`.
+        self.assertEqual(mini('a :hover { color: red }'), 'a :hover{color:red}')
+
+    def test_colon_in_a_declaration_loses_its_space(self):
+        self.assertEqual(mini('a{ color : red }'), 'a{color:red}')
+
+    def test_important_keeps_the_space_before_it(self):
+        self.assertEqual(mini('a { color: red !important }'),
+                         'a{color:red !important}')
+
+    def test_space_before_a_closing_paren_goes(self):
+        self.assertEqual(mini('a { color: rgb(1, 2, 3 ) }'), 'a{color:rgb(1,2,3)}')
+
+    def test_commas_lose_their_spaces_between_selectors(self):
+        self.assertEqual(mini('a , b { color: red }'), 'a,b{color:red}')
+
+
+class Context(unittest.TestCase):
+    def test_a_media_block_is_still_selector_context(self):
+        # The `:` in `:hover` inside @media must not be read as a declaration
+        # colon, and `a :hover` inside it is still a descendant selector. The
+        # space in the media feature survives for the same reason - the prelude
+        # is not a declaration - which costs a byte and is always legal.
+        self.assertEqual(
+            mini('@media (min-width: 30em) { a :hover { color: red } }'),
+            '@media (min-width: 30em){a :hover{color:red}}')
+
+    def test_keyframe_steps_hold_declarations(self):
+        self.assertEqual(mini('@keyframes spin { to { transform: rotate(1turn) } }'),
+                         '@keyframes spin{to{transform:rotate(1turn)}}')
+
+    def test_supports_is_a_rule_body(self):
+        self.assertEqual(mini('@supports (display: grid) { .a .b { color: red } }'),
+                         '@supports (display: grid){.a .b{color:red}}')
+
+    def test_font_face_holds_declarations(self):
+        self.assertEqual(mini('@font-face { font-family: "X"; src: url( a.woff ) }'),
+                         '@font-face{font-family:"X";src:url(a.woff)}')
+
+    def test_declaration_context_is_restored_after_a_nested_block(self):
+        self.assertEqual(
+            mini('@media screen { a { color: red } } b :hover { color: blue }'),
+            '@media screen{a{color:red}}b :hover{color:blue}')
+
+
+class LiteralRuns(unittest.TestCase):
+    def test_a_string_is_copied_whole(self):
+        self.assertEqual(mini('a { content: "  {  ;  }  " }'),
+                         'a{content:"  {  ;  }  "}')
+
+    def test_an_escaped_quote_does_not_end_a_string(self):
+        self.assertEqual(mini(r'a { content: "he said \" then  left" }'),
+                         r'a{content:"he said \" then  left"}')
+
+    def test_unquoted_url_is_trimmed_but_not_reformatted(self):
+        self.assertEqual(mini('a { background: url(  pic;{}.png  ) }'),
+                         'a{background:url(pic;{}.png)}')
+
+    def test_url_only_counts_at_the_start_of_a_token(self):
+        # `blurl(` is not a url() and must not be rewritten as one.
+        self.assertEqual(mini('a { x: blurl( 1 ) }'), 'a{x:blurl(1)}')
+
+    def test_a_custom_property_value_is_untouched(self):
+        self.assertEqual(mini('a { --op:  +  ; color: red }'), 'a{--op:+;color:red}')
+
+    def test_a_custom_property_keeps_its_inner_spaces(self):
+        self.assertEqual(mini('a { --gap:  1px   2px  ; color: red }'),
+                         'a{--gap:1px   2px;color:red}')
+
+
+class Failures(unittest.TestCase):
+    def test_unterminated_comment(self):
+        with self.assertRaises(cssmin.CssError):
+            cssmin.css('a { /* forever')
+
+    def test_unterminated_string(self):
+        with self.assertRaises(cssmin.CssError):
+            cssmin.css('a { content: "forever }')
+
+    def test_unterminated_url(self):
+        with self.assertRaises(cssmin.CssError):
+            cssmin.css('a { background: url(forever')
+
+    def test_custom_property_with_no_value(self):
+        with self.assertRaises(cssmin.CssError):
+            cssmin.css('a { --x }')
+
+
+SAMPLE = """
+    /* a sheet with most of the awkward shapes in it */
+    :root { --pad: 1rem; --op:  +  ; }
+    .card > .title, .card .lede { margin: 0 auto; width: calc(100% - var(--pad)) }
+    @media (min-width: 40em) { .card :hover { color: red !important } }
+"""
+
+
+class Determinism(unittest.TestCase):
+    def test_minifying_twice_gives_the_same_bytes(self):
+        once = cssmin.css(SAMPLE)
+        self.assertEqual(once, cssmin.css(SAMPLE))
+
+    def test_minifying_the_output_again_changes_nothing(self):
+        once = cssmin.css(SAMPLE)
+        self.assertEqual(once, cssmin.css(once))
+
+    def test_the_real_stylesheets_survive_a_round_trip(self):
+        """Every sheet in the repository minifies, and minifies to a fixed point."""
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        sheets = sorted(root.glob('shared/**/*.css')) + sorted(root.glob('tools/*/styles.css'))
+        self.assertTrue(sheets, 'no stylesheets found to check')
+        for path in sheets:
+            with self.subTest(sheet=path.name):
+                once = cssmin.css(path.read_text(encoding='utf-8'))
+                self.assertEqual(once, cssmin.css(once))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/test_mangle.py
+++ b/tests/python/test_mangle.py
@@ -1,0 +1,204 @@
+"""
+buildlib/mangle.py, without running esbuild.
+
+The parts worth testing here are the ones that do not need it: the import
+checker, which is the single invariant the separate-modules design rests on,
+and the version pinning, which is what keeps `--check` meaningful.
+
+`specifiers` is the interesting one. It reads imports off the token stream
+rather than out of the raw text, because `from` is not a reserved word and the
+word turns up inside strings all over this repository - so a regular expression
+finds imports that are not there, and finds different ones before and after the
+comments have been taken out.
+"""
+
+import unittest
+from unittest import mock
+
+from buildlib import mangle
+
+
+class Specifiers(unittest.TestCase):
+    def find(self, source):
+        return mangle.specifiers(source, 'x.js')
+
+    def test_a_named_import(self):
+        self.assertEqual(self.find('import { a } from "./b.js";'), ['./b.js'])
+
+    def test_a_default_import(self):
+        self.assertEqual(self.find("import a from './b.js';"), ['./b.js'])
+
+    def test_a_namespace_import(self):
+        self.assertEqual(self.find('import * as png from "./png.js";'), ['./png.js'])
+
+    def test_a_bare_side_effect_import(self):
+        self.assertEqual(self.find('import "./setup.js";'), ['./setup.js'])
+
+    def test_a_dynamic_import(self):
+        self.assertEqual(self.find('const m = await import("./slow.js");'),
+                         ['./slow.js'])
+
+    def test_a_re_export(self):
+        self.assertEqual(self.find('export { a } from "./b.js";'), ['./b.js'])
+
+    def test_several_come_back_sorted(self):
+        source = 'import "./z.js";\nimport "./a.js";\nimport "./m.js";\n'
+        self.assertEqual(self.find(source), ['./a.js', './m.js', './z.js'])
+
+    def test_a_file_with_no_imports(self):
+        self.assertEqual(self.find('export function f() { return 1 }'), [])
+
+    def test_the_word_from_inside_a_string_is_not_an_import(self):
+        # A real line from the EXIF parser is "...data from 'this block is
+        # unreadable'". A regular expression would call that an import.
+        source = 'const msg = "read the data from \'this block\'";'
+        self.assertEqual(self.find(source), [])
+
+    def test_the_word_from_inside_a_comment_is_not_an_import(self):
+        source = '// copied from "./elsewhere.js"\nexport const a = 1;\n'
+        self.assertEqual(self.find(source), [])
+
+    def test_the_word_from_inside_a_template_literal_is_not_an_import(self):
+        source = 'const msg = `taken from "./nowhere.js"`;'
+        self.assertEqual(self.find(source), [])
+
+    def test_from_used_as_an_identifier_is_not_an_import(self):
+        # `from` is not a reserved word.
+        self.assertEqual(self.find('const from = 1; use(from);'), [])
+
+    def test_a_comment_does_not_change_the_answer(self):
+        # The same file with and without its comments must report the same
+        # imports, or the check after mangling would compare two different
+        # things.
+        with_comments = ('// from "./ghost.js"\n'
+                         'import { a } from "./real.js";\n'
+                         '/* also from "./ghost.js" */\n')
+        without = 'import { a } from "./real.js";\n'
+        self.assertEqual(self.find(with_comments), self.find(without))
+
+
+class CheckImports(unittest.TestCase):
+    def test_matching_imports_pass(self):
+        source = 'import { a } from "./b.js";\nexport const c = a;\n'
+        output = 'import{a}from"./b.js";export const c=a;\n'
+        mangle.check_imports(source, output, 'x.js')
+
+    def test_a_dropped_import_fails(self):
+        source = 'import { a } from "./b.js";\nexport const c = 1;\n'
+        with self.assertRaises(mangle.MangleError) as caught:
+            mangle.check_imports(source, 'export const c=1;\n', 'x.js')
+        self.assertIn('changed what x.js imports', str(caught.exception))
+        self.assertIn('./b.js', str(caught.exception))
+
+    def test_a_bundled_in_module_fails(self):
+        # Something that inlined a dependency would show up as a specifier that
+        # went missing, which is what would break the service worker's list.
+        source = 'import { a } from "./b.js";\nimport { c } from "./d.js";\n'
+        output = 'import{a}from"./b.js";\n'
+        with self.assertRaises(mangle.MangleError):
+            mangle.check_imports(source, output, 'x.js')
+
+    def test_an_invented_import_fails(self):
+        with self.assertRaises(mangle.MangleError):
+            mangle.check_imports('export const a = 1;\n',
+                                 'import"./chunk.js";export const a=1;\n', 'x.js')
+
+    def test_order_does_not_matter(self):
+        source = 'import "./a.js";\nimport "./b.js";\n'
+        output = 'import"./b.js";import"./a.js";\n'
+        mangle.check_imports(source, output, 'x.js')
+
+
+class Resolve(unittest.TestCase):
+    def test_a_missing_esbuild_says_what_to_install(self):
+        with mock.patch('shutil.which', return_value=None):
+            with self.assertRaises(mangle.MangleError) as caught:
+                mangle.resolve('0.25.0')
+        message = str(caught.exception)
+        self.assertIn('esbuild@0.25.0', message)
+        # ... and that leaving it out is still a working build.
+        self.assertIn('python build.py', message)
+
+    def test_a_found_esbuild_comes_back(self):
+        with mock.patch('shutil.which', return_value='/usr/bin/esbuild') as which:
+            self.assertEqual(mangle.resolve('0.25.0'), '/usr/bin/esbuild')
+        which.assert_called_once_with('esbuild')
+
+
+def completed(code=0, out='', err=''):
+    return mock.Mock(returncode=code, stdout=out, stderr=err)
+
+
+class RequireVersion(unittest.TestCase):
+    def test_the_pinned_version_is_accepted(self):
+        with mock.patch('subprocess.run', return_value=completed(out='0.25.0\n')):
+            self.assertEqual(mangle.require_version('esbuild', '0.25.0'), '0.25.0')
+
+    def test_any_other_version_is_refused(self):
+        # Two versions of esbuild need not invent the same names, and --check
+        # would then report tampering where there was none.
+        with mock.patch('subprocess.run', return_value=completed(out='0.24.2\n')):
+            with self.assertRaises(mangle.MangleError) as caught:
+                mangle.require_version('esbuild', '0.25.0')
+        message = str(caught.exception)
+        self.assertIn('0.24.2', message)
+        self.assertIn('0.25.0', message)
+        self.assertIn('config/site.toml', message)
+
+    def test_a_failing_version_call_is_reported(self):
+        with mock.patch('subprocess.run', return_value=completed(1, err='boom')):
+            with self.assertRaises(mangle.MangleError) as caught:
+                mangle.version('esbuild')
+        self.assertIn('boom', str(caught.exception))
+
+    def test_an_unrunnable_esbuild_is_reported(self):
+        with mock.patch('subprocess.run', side_effect=OSError('no such file')):
+            with self.assertRaises(mangle.MangleError) as caught:
+                mangle.version('esbuild')
+        self.assertIn('could not run', str(caught.exception))
+
+
+class Js(unittest.TestCase):
+    """`js` shells out, so esbuild is stubbed and the wiring is what is checked."""
+
+    def run_with(self, result, source='import { a } from "./b.js";\n', **kwargs):
+        with mock.patch('subprocess.run', return_value=result) as run:
+            out = mangle.js(source, 'esbuild', **kwargs)
+        return out, run.call_args
+
+    def test_the_pinned_flags_are_passed(self):
+        _, call = self.run_with(completed(out='import{a}from"./b.js";\n'))
+        argv = call.args[0]
+        for flag in ('--minify', '--format=esm', '--target=esnext',
+                     '--legal-comments=none'):
+            self.assertIn(flag, argv)
+
+    def test_the_source_file_name_reaches_esbuild(self):
+        _, call = self.run_with(completed(out='import"./b.js";\n'),
+                                sourcefile='widget/src/main.js')
+        self.assertIn('--sourcefile=widget/src/main.js', call.args[0])
+
+    def test_a_banner_is_prepended_rather_than_asked_of_esbuild(self):
+        out, call = self.run_with(completed(out='import{a}from"./b.js";\n'),
+                                  banner='/* built */')
+        self.assertTrue(out.startswith('/* built */\n'))
+        self.assertFalse(any(a.startswith('--banner') for a in call.args[0]))
+
+    def test_a_failing_esbuild_stops_the_build(self):
+        with self.assertRaises(mangle.MangleError) as caught:
+            self.run_with(completed(1, err='syntax error'))
+        self.assertIn('syntax error', str(caught.exception))
+
+    def test_empty_output_stops_the_build(self):
+        with self.assertRaises(mangle.MangleError) as caught:
+            self.run_with(completed(out='   \n'))
+        self.assertIn('produced nothing', str(caught.exception))
+
+    def test_output_that_lost_an_import_stops_the_build(self):
+        with self.assertRaises(mangle.MangleError) as caught:
+            self.run_with(completed(out='const a=1;\n'))
+        self.assertIn('imports', str(caught.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/test_minify.py
+++ b/tests/python/test_minify.py
@@ -1,0 +1,289 @@
+"""
+buildlib/minify.py.
+
+Two invariants carry the whole module, and both are here:
+
+  1. Line terminators never move, because automatic semicolon insertion depends
+     on them.
+  2. Re-tokenising the output gives back the input's tokens.
+
+`check` enforces both on every file the build emits, so most of the damage a
+minifier can do shows up as a MinifyError rather than as a wrong page. The
+tests below are in two halves: the tokeniser has to be right about the awkward
+corners of JavaScript (regex versus division, nested template substitutions),
+and `check` has to reject output that has drifted even when it is handed
+something plausible.
+"""
+
+import unittest
+
+from buildlib import minify
+
+
+def texts(source):
+    return [text for _, text in minify.tokenize_js(source)]
+
+
+def lines(source):
+    return [line for line, _ in minify.tokenize_js(source)]
+
+
+class Tokeniser(unittest.TestCase):
+    def test_a_simple_statement(self):
+        self.assertEqual(texts('let x = 1;'), ['let', 'x', '=', '1', ';'])
+
+    def test_line_comments_go_and_the_line_still_counts(self):
+        self.assertEqual(minify.tokenize_js('// hello\nlet x = 1'),
+                         [(2, 'let'), (2, 'x'), (2, '='), (2, '1')])
+
+    def test_a_block_comment_spanning_lines_still_advances_the_counter(self):
+        # A line terminator inside a block comment counts for semicolon
+        # insertion exactly as a bare newline does.
+        self.assertEqual(lines('a\n/* one\ntwo */ b'), [1, 3])
+
+    def test_longest_punctuator_wins(self):
+        self.assertEqual(texts('a >>>= b'), ['a', '>>>=', 'b'])
+        self.assertEqual(texts('a ?? b'), ['a', '??', 'b'])
+        self.assertEqual(texts('a?.b'), ['a', '?.', 'b'])
+
+    def test_numbers(self):
+        for source in ('0x1f', '0b1010', '0o17', '1_000', '1e-7', '.5', '1.', '9n'):
+            with self.subTest(number=source):
+                self.assertEqual(texts(f'x = {source}'), ['x', '=', source])
+
+    def test_a_string_is_one_token(self):
+        self.assertEqual(texts('x = "a b // c /* d */"'),
+                         ['x', '=', '"a b // c /* d */"'])
+
+    def test_an_escaped_quote_does_not_end_a_string(self):
+        self.assertEqual(texts(r'x = "he said \" then left"'),
+                         ['x', '=', r'"he said \" then left"'])
+
+    def test_a_regex_after_a_keyword_is_a_regex(self):
+        self.assertEqual(texts('return /a\\/b/g'), ['return', '/a\\/b/g'])
+
+    def test_a_slash_after_a_value_is_division(self):
+        self.assertEqual(texts('a / b / c'), ['a', '/', 'b', '/', 'c'])
+        self.assertEqual(texts('x[0] / 2'), ['x', '[', '0', ']', '/', '2'])
+
+    def test_a_slash_in_a_character_class_does_not_end_the_regex(self):
+        self.assertEqual(texts('x = /[/]/'), ['x', '=', '/[/]/'])
+
+    def test_a_template_literal_is_one_token(self):
+        self.assertEqual(texts('x = `a ${b} c`'), ['x', '=', '`a ${b} c`'])
+
+    def test_nested_templates(self):
+        self.assertEqual(texts('x = `a${`b${c}`}d`'), ['x', '=', '`a${`b${c}`}d`'])
+
+    def test_a_brace_inside_a_string_inside_a_substitution(self):
+        self.assertEqual(texts('x = `${ y("}") }`'), ['x', '=', '`${ y("}") }`'])
+
+    def test_a_regex_inside_a_substitution(self):
+        # The comment in _scan_template names this as the case that once broke
+        # the build: a quote inside a regular expression opening a string.
+        source = 'x = `${x.replace(/["]/g, \'\')}`'
+        self.assertEqual(texts(source), ['x', '=', '`${x.replace(/["]/g, \'\')}`'])
+
+    def test_division_inside_a_substitution(self):
+        self.assertEqual(texts('x = `${ a / b }`'), ['x', '=', '`${ a / b }`'])
+
+    def test_a_no_break_space_is_whitespace(self):
+        # Legal between tokens, arrives in text pasted out of an editor,
+        # and must not reach the output.
+        self.assertEqual(texts('let x = 1'), ['let', 'x', '=', '1'])
+        self.assertEqual(minify.js('let x = 1\n'), 'let x=1\n')
+
+    def test_a_byte_order_mark_between_tokens_is_whitespace(self):
+        self.assertEqual(texts('let﻿x = 1'), ['let', 'x', '=', '1'])
+        self.assertEqual(minify.js('let﻿x = 1\n'), 'let x=1\n')
+
+
+class TokeniserFailures(unittest.TestCase):
+    def test_unterminated_block_comment(self):
+        with self.assertRaises(minify.MinifyError):
+            minify.tokenize_js('/* forever')
+
+    def test_unterminated_string(self):
+        with self.assertRaises(minify.MinifyError):
+            minify.tokenize_js('x = "forever')
+
+    def test_a_newline_inside_a_string(self):
+        with self.assertRaises(minify.MinifyError):
+            minify.tokenize_js('x = "one\ntwo"')
+
+    def test_unterminated_template(self):
+        with self.assertRaises(minify.MinifyError):
+            minify.tokenize_js('x = `forever')
+
+    def test_unterminated_regex(self):
+        with self.assertRaises(minify.MinifyError):
+            minify.tokenize_js('x = /forever')
+
+    def test_the_message_names_the_file_and_the_line(self):
+        with self.assertRaises(minify.MinifyError) as caught:
+            minify.tokenize_js('a\nb\nx = "oops', where='src/main.js')
+        self.assertIn('src/main.js:3', str(caught.exception))
+
+
+class MinifyJs(unittest.TestCase):
+    def test_comments_and_indentation_go(self):
+        self.assertEqual(minify.js('// note\nlet x = 1; // trailing\n'),
+                         'let x=1;\n')
+
+    def test_every_newline_stays_where_it_was(self):
+        source = 'let a = 1\nlet b = 2\nlet c = 3\n'
+        self.assertEqual(minify.js(source), 'let a=1\nlet b=2\nlet c=3\n')
+
+    def test_a_blank_line_does_not_survive_as_a_line(self):
+        # Numbers shift; what must not change is whether there is a break
+        # between one token and the next, which `check` verifies.
+        self.assertEqual(minify.js('let a = 1\n\n\nlet b = 2\n'),
+                         'let a=1\nlet b=2\n')
+
+    def test_a_space_that_holds_two_words_apart_survives(self):
+        self.assertEqual(minify.js('if (a in b) c()\n'), 'if(a in b)c()\n')
+        self.assertEqual(minify.js('let x = typeof y\n'), 'let x=typeof y\n')
+
+    def test_plus_plus_is_not_invented(self):
+        self.assertEqual(minify.js('let x = a + +b\n'), 'let x=a+ +b\n')
+        self.assertEqual(minify.js('let x = a - -b\n'), 'let x=a- -b\n')
+
+    def test_a_sign_after_an_operator_keeps_its_space(self):
+        # `+-` is not a token, so joining these would not trip `check` - the
+        # space is kept because two operators running together is unreadable
+        # and one character from being wrong.
+        self.assertEqual(minify.js('let x = a + -b\n'), 'let x=a+ -b\n')
+        self.assertEqual(minify.js('let x = a - +b\n'), 'let x=a- +b\n')
+
+    def test_a_comment_is_not_invented(self):
+        self.assertEqual(minify.js('let x = a / /b/.source\n'),
+                         'let x=a/ /b/.source\n')
+
+    def test_a_number_keeps_the_space_before_a_method_call(self):
+        self.assertEqual(minify.js('1 .toString()\n'), '1 .toString()\n')
+
+    def test_a_banner_goes_on_its_own_first_line(self):
+        out = minify.js('let x = 1\n', banner='/* built */')
+        self.assertEqual(out, '/* built */\nlet x=1\n')
+
+    def test_empty_input_produces_nothing_at_all(self):
+        self.assertEqual(minify.js(''), '')
+        self.assertEqual(minify.js('// only a comment\n'), '')
+
+    def test_result_ends_in_a_newline(self):
+        self.assertTrue(minify.js('let x = 1').endswith('\n'))
+
+    def test_minifying_the_output_again_changes_nothing(self):
+        source = 'export function f(a) {\n  return a in b ? /x/g : a + +1\n}\n'
+        once = minify.js(source)
+        self.assertEqual(once, minify.js(once))
+
+    def test_the_real_modules_survive_a_round_trip(self):
+        """Every module in the repository minifies to a fixed point.
+
+        This is the whole build's safety net exercised directly: minify.js
+        already calls `check` on its own output, so a failure here is a file
+        the build would have refused to write.
+        """
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        modules = sorted(root.glob('shared/js/*.js')) + sorted(root.glob('tools/*/src/*.js'))
+        self.assertTrue(modules, 'no modules found to check')
+        for path in modules:
+            with self.subTest(module=path.name):
+                once = minify.js(path.read_text(encoding='utf-8'),
+                                 where=path.name)
+                self.assertEqual(once, minify.js(once, where=path.name))
+
+
+class Check(unittest.TestCase):
+    """`check` is what stands between a bad minify and a deployed site."""
+
+    def test_identical_streams_pass(self):
+        minify.check('let x = 1\n', 'let x=1\n', 'x.js')
+
+    def test_a_lost_token_is_caught(self):
+        with self.assertRaises(minify.MinifyError) as caught:
+            minify.check('let x = 1\n', 'let x\n', 'x.js')
+        self.assertIn('token count', str(caught.exception))
+
+    def test_a_changed_token_is_caught(self):
+        with self.assertRaises(minify.MinifyError) as caught:
+            minify.check('let x = 1\n', 'let x = 2\n', 'x.js')
+        self.assertIn('changed a token', str(caught.exception))
+
+    def test_a_lost_line_break_is_caught(self):
+        # Joining two lines is exactly the transformation that changes where a
+        # semicolon gets inserted.
+        with self.assertRaises(minify.MinifyError) as caught:
+            minify.check('let a = 1\nlet b = 2\n', 'let a=1 let b=2\n', 'x.js')
+        self.assertIn('lost a line break', str(caught.exception))
+
+    def test_a_gained_line_break_is_caught(self):
+        with self.assertRaises(minify.MinifyError) as caught:
+            minify.check('let a = 1 + 2\n', 'let a = 1 +\n2\n', 'x.js')
+        self.assertIn('gained a line break', str(caught.exception))
+
+
+class MinifyHtml(unittest.TestCase):
+    def test_comments_go(self):
+        self.assertEqual(minify.html('<p>a</p><!-- why --><p>b</p>'),
+                         '<p>a</p><p>b</p>\n')
+
+    def test_indentation_collapses_to_one_space(self):
+        # Not to nothing: between two inline elements it is the space between
+        # two words.
+        self.assertEqual(minify.html('<p>\n  <b>a</b>\n  <i>b</i>\n</p>\n'),
+                         '<p> <b>a</b> <i>b</i> </p>\n')
+
+    def test_leading_and_trailing_whitespace_goes(self):
+        self.assertEqual(minify.html('\n\n  <p>a</p>  \n\n'), '<p>a</p>\n')
+
+    def test_attribute_whitespace_collapses(self):
+        self.assertEqual(minify.html('<a   href="/x"\n   rel="me"  >a</a>'),
+                         '<a href="/x" rel="me">a</a>\n')
+
+    def test_no_space_is_left_before_a_self_closing_slash(self):
+        self.assertEqual(minify.html('<img src="/x"  />'), '<img src="/x"/>\n')
+
+    def test_an_attribute_value_is_never_touched(self):
+        # The favicon on every page is a data: URI with a whole SVG, angle
+        # brackets and double spaces and all, inside one attribute.
+        tag = '<link rel="icon" href="data:image/svg+xml,<svg  a=\'1\'>  </svg>">'
+        self.assertEqual(minify.html(tag), tag + '\n')
+
+    def test_pre_is_copied_through(self):
+        self.assertEqual(minify.html('<pre>  a\n   b  </pre>'),
+                         '<pre>  a\n   b  </pre>\n')
+
+    def test_script_contents_are_copied_through(self):
+        self.assertEqual(minify.html('<script>\n  let x = 1\n</script>'),
+                         '<script>\n  let x = 1\n</script>\n')
+
+    def test_a_bare_less_than_in_text_is_legal_and_kept(self):
+        self.assertEqual(minify.html('<p>a < b</p>'), '<p>a < b</p>\n')
+
+    def test_structured_data_is_re_serialised_compactly(self):
+        source = ('<script type="application/ld+json">\n'
+                  '{\n  "@context": "https://schema.org",\n  "a": 1\n}\n'
+                  '</script>')
+        self.assertEqual(
+            minify.html(source),
+            '<script type="application/ld+json">'
+            '{"@context":"https://schema.org","a":1}</script>\n')
+
+    def test_structured_data_is_escaped_to_ascii(self):
+        source = '<script type="application/ld+json">{"a": "—"}</script>'
+        self.assertIn('\\u2014', minify.html(source))
+
+    def test_invalid_structured_data_fails_the_build(self):
+        with self.assertRaises(minify.MinifyError):
+            minify.html('<script type="application/ld+json">{ nope }</script>')
+
+    def test_a_banner_is_wrapped_in_a_comment(self):
+        self.assertEqual(minify.html('<p>a</p>', ' built '),
+                         '<!-- built --><p>a</p>\n')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/test_site.py
+++ b/tests/python/test_site.py
@@ -1,0 +1,419 @@
+"""
+buildlib/site.py.
+
+Two groups of claims are worth pinning down here.
+
+The first is the Content-Security-Policy. `render_csp` exists so that no tool
+can quietly widen or narrow the site policy, and "never narrower" is a property
+a test can check directly rather than a comment anyone has to trust.
+
+The second is the config loading, which is a pile of refusals: a tool whose
+slug does not match its folder, a guide with no publication date, a page that
+would end up at a URL nobody wrote down. Each of those is a build that should
+stop, and each is one test.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from buildlib import site as sitelib
+
+SITE = {'domain': 'https://example.test/', 'name': 'Site', 'lang': 'en'}
+
+TOOL_TOML = '''
+slug = "widget"
+name = "Widget"
+heading = "Widget"
+tagline = "Does a thing"
+icon = "W"
+favicon = "W"
+category = "images"
+lastmod = "2026-01-01"
+title = "Widget"
+description = "d"
+og_title = "t"
+og_description = "d"
+og_image_alt = "a"
+pledge = "p"
+live_hint = "h"
+read_first = "r"
+howto_heading = "How"
+card = "c"
+facts = []
+privacy = []
+howto = []
+faq = []
+
+[words]
+plural = "files"
+choose = "Choose files"
+
+[schema]
+category = "UtilitiesApplication"
+description = "d"
+features = []
+'''
+
+PAGE_TOML = '''
+slug = "privacy"
+nav = "Privacy"
+title = "Privacy"
+description = "d"
+heading = "Privacy"
+lede = "l"
+updated = "January 2026"
+lastmod = "2026-01-01"
+og_title = "t"
+og_description = "d"
+og_image_alt = "a"
+'''
+
+
+class TempTree(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def write(self, relative, text):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding='utf-8')
+        return path
+
+
+class LoadToml(TempTree):
+    def test_a_missing_file_is_a_config_error(self):
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_toml(self.root / 'nope.toml')
+        self.assertIn('missing config file', str(caught.exception))
+
+    def test_a_syntax_error_names_the_file(self):
+        path = self.write('bad.toml', 'a = = 1\n')
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_toml(path)
+        self.assertIn('bad.toml', str(caught.exception))
+
+    def test_a_good_file_loads(self):
+        path = self.write('ok.toml', 'a = 1\n')
+        self.assertEqual(sitelib.load_toml(path), {'a': 1})
+
+
+class RenderCsp(unittest.TestCase):
+    def test_the_base_policy_is_rendered(self):
+        out = sitelib.render_csp({'default-src': ["'none'"]})
+        self.assertIn('<meta http-equiv="Content-Security-Policy" content="', out)
+        self.assertIn("default-src 'none';", out)
+        self.assertTrue(out.endswith('">'))
+
+    def test_an_addition_widens_an_existing_directive(self):
+        out = sitelib.render_csp({'img-src': ["'self'"]}, {'img-src': ['http:']})
+        self.assertIn("img-src 'self' http:;", out)
+
+    def test_an_addition_may_introduce_a_new_directive(self):
+        out = sitelib.render_csp({'default-src': ["'none'"]},
+                                 {'worker-src': ["'self'"]})
+        self.assertIn("worker-src 'self';", out)
+
+    def test_nothing_can_be_removed(self):
+        # The result is always at least as wide as the site policy. Handing a
+        # directive a shorter list must not shorten it.
+        base = {'script-src': ["'self'", 'https://a.test']}
+        out = sitelib.render_csp(base, {'script-src': ["'self'"]})
+        self.assertIn("script-src 'self' https://a.test;", out)
+
+    def test_a_repeated_value_is_not_written_twice(self):
+        out = sitelib.render_csp({'img-src': ["'self'"]},
+                                 {'img-src': ["'self'", 'http:']},
+                                 {'img-src': ['http:']})
+        self.assertIn("img-src 'self' http:;", out)
+        self.assertEqual(out.count('http:'), 1)
+
+    def test_empty_additions_are_ignored(self):
+        base = {'default-src': ["'none'"]}
+        self.assertEqual(sitelib.render_csp(base, {}, None),
+                         sitelib.render_csp(base))
+
+    def test_a_long_directive_is_broken_over_lines(self):
+        hosts = [f'https://origin-number-{n}.example.test' for n in range(4)]
+        out = sitelib.render_csp({'script-src': ["'self'"] + hosts})
+        lines = out.split('\n')
+        # Keyword sources stay up on the directive line, hosts go underneath.
+        self.assertIn("  script-src 'self'", lines)
+        for host in hosts[:-1]:
+            self.assertIn(f'    {host}', lines)
+        self.assertIn(f'    {hosts[-1]};', lines)
+
+    def test_every_directive_ends_in_a_semicolon(self):
+        out = sitelib.render_csp({
+            'default-src': ["'none'"],
+            'script-src': [f'https://origin-number-{n}.example.test' for n in range(5)],
+        })
+        body = [l for l in out.split('\n')[1:-1]]
+        self.assertEqual(sum(1 for l in body if l.rstrip().endswith(';')), 2)
+
+    def test_the_real_site_policy_renders(self):
+        """Every directive in config/site.toml reaches the rendered tag."""
+        root = Path(__file__).resolve().parents[2]
+        config = sitelib.load_toml(root / 'config' / 'site.toml')
+        out = sitelib.render_csp(config['csp'], config.get('tool_csp', {}))
+
+        # A directive with only hosts in it has nothing after its name on the
+        # opening line, so match the name at the start of a line rather than
+        # assuming a space follows it.
+        heads = {line.strip().split(' ')[0].rstrip(';')
+                 for line in out.split('\n') if line.startswith('  ')}
+        for directive in config['csp']:
+            self.assertIn(directive, heads)
+
+    def test_the_real_site_policy_carries_every_origin(self):
+        root = Path(__file__).resolve().parents[2]
+        config = sitelib.load_toml(root / 'config' / 'site.toml')
+        out = sitelib.render_csp(config['csp'])
+        for values in config['csp'].values():
+            for value in values:
+                self.assertIn(value, out)
+
+
+class ToText(unittest.TestCase):
+    def test_tags_are_removed(self):
+        self.assertEqual(sitelib.to_text('<p>Hello <code>x</code></p>'), 'Hello x')
+
+    def test_entities_are_unescaped(self):
+        self.assertEqual(sitelib.to_text('a &amp; b &mdash; c'), 'a & b - c')
+
+    def test_typographic_punctuation_is_flattened(self):
+        self.assertEqual(sitelib.to_text('it’s “x” – y'),
+                         'it\'s "x" - y')
+
+    def test_whitespace_is_collapsed(self):
+        self.assertEqual(sitelib.to_text('a\n\n   b\t c '), 'a b c')
+
+    def test_a_non_breaking_space_becomes_a_plain_one(self):
+        self.assertEqual(sitelib.to_text('a b'), 'a b')
+
+    def test_the_result_is_ascii(self):
+        text = sitelib.to_text('<b>café</b> — “work”')
+        self.assertEqual(text, 'café - "work"')  # accents stay, punctuation flattens
+
+
+class StructuredData(unittest.TestCase):
+    def test_dumps_ld_is_pure_ascii(self):
+        out = sitelib.dumps_ld([{'name': 'café — x'}])
+        out.encode('ascii')  # raises if it is not
+        self.assertIn('\\u00e9', out)
+
+    def test_dumps_ld_carries_the_context(self):
+        data = json.loads(sitelib.dumps_ld([{'@type': 'Thing'}]))
+        self.assertEqual(data['@context'], 'https://schema.org')
+        self.assertEqual(data['@graph'], [{'@type': 'Thing'}])
+
+    def test_a_tool_graph_has_the_three_types(self):
+        tool = {
+            'name': 'Widget', 'url': 'https://example.test/widget/',
+            'schema': {'category': 'UtilitiesApplication', 'description': 'd',
+                       'features': ['a']},
+            'faq': [{'q': '<b>Why?</b>', 'a': 'Because &amp; so.'}],
+        }
+        graph = json.loads(sitelib.tool_jsonld(SITE, tool))['@graph']
+        self.assertEqual([item['@type'] for item in graph],
+                         ['SoftwareApplication', 'BreadcrumbList', 'FAQPage'])
+
+    def test_faq_answers_are_derived_from_the_page_html(self):
+        # Authored once as the HTML that renders, so the two cannot contradict
+        # each other.
+        tool = {
+            'name': 'Widget', 'url': 'https://example.test/widget/',
+            'schema': {'category': 'C', 'description': 'd', 'features': []},
+            'faq': [{'q': '<b>Why?</b>', 'a': 'Because &amp; <i>so</i>.'}],
+        }
+        faq = json.loads(sitelib.tool_jsonld(SITE, tool))['@graph'][2]
+        self.assertEqual(faq['mainEntity'][0]['name'], 'Why?')
+        self.assertEqual(faq['mainEntity'][0]['acceptedAnswer']['text'],
+                         'Because & so.')
+
+    def test_a_guide_is_an_article(self):
+        page = {'kind': 'guide', 'heading': 'H', 'description': 'd', 'nav': 'N',
+                'url': 'https://example.test/guides/x/',
+                'published': '2026-01-01', 'lastmod': '2026-02-01'}
+        graph = json.loads(sitelib.page_jsonld(SITE, page))['@graph']
+        self.assertEqual(graph[0]['@type'], 'Article')
+        self.assertEqual(graph[0]['datePublished'], '2026-01-01')
+        self.assertEqual(graph[0]['dateModified'], '2026-02-01')
+
+    def test_a_legal_page_gets_no_structured_data(self):
+        # Inventing schema for a privacy policy would describe the page as
+        # something it is not.
+        page = {'kind': 'legal', 'heading': 'H', 'description': 'd', 'nav': 'N',
+                'url': 'https://example.test/privacy/', 'lastmod': '2026-01-01'}
+        self.assertEqual(sitelib.page_jsonld(SITE, page), '')
+
+    def test_the_hub_lists_the_tools_in_order(self):
+        tools = [{'name': 'A', 'url': 'https://example.test/a/'},
+                 {'name': 'B', 'url': 'https://example.test/b/'}]
+        site = dict(SITE, hub={'schema_description': 'd', 'schema_about': ['x']})
+        graph = json.loads(sitelib.hub_jsonld(site, tools))['@graph']
+        items = graph[2]['mainEntity']['itemListElement']
+        self.assertEqual([i['position'] for i in items], [1, 2])
+        self.assertEqual([i['name'] for i in items], ['A', 'B'])
+
+
+class LoadTool(TempTree):
+    def tool_at(self, folder, body=TOOL_TOML):
+        return self.write(f'tools/{folder}/tool.toml', body)
+
+    def test_a_complete_tool_loads(self):
+        tool = sitelib.load_tool(self.tool_at('widget'), SITE)
+        self.assertEqual(tool['url'], 'https://example.test/widget/')
+        self.assertEqual(tool['dir'].name, 'widget')
+
+    def test_optional_keys_are_filled_in(self):
+        tool = sitelib.load_tool(self.tool_at('widget'), SITE)
+        self.assertEqual(tool['words']['analytics_extra'], '')
+        self.assertEqual(tool['csp_note'], '')
+        self.assertEqual(tool['csp'], {})
+
+    def test_a_missing_key_is_named(self):
+        body = TOOL_TOML.replace('tagline = "Does a thing"\n', '')
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_tool(self.tool_at('widget', body), SITE)
+        self.assertIn('tagline', str(caught.exception))
+
+    def test_the_slug_must_match_the_folder(self):
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_tool(self.tool_at('gadget'), SITE)
+        self.assertIn('gadget', str(caught.exception))
+
+    def test_words_needs_plural_and_choose(self):
+        body = TOOL_TOML.replace('choose = "Choose files"\n', '')
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_tool(self.tool_at('widget', body), SITE)
+        self.assertIn('choose', str(caught.exception))
+
+
+class LoadPage(TempTree):
+    def page_at(self, folder, body=PAGE_TOML):
+        return self.write(f'pages/{folder}/page.toml', body)
+
+    def test_a_legal_page_loads(self):
+        page = sitelib.load_page(self.page_at('privacy'), SITE, self.root / 'pages')
+        self.assertEqual(page['kind'], 'legal')
+        self.assertEqual(page['url'], 'https://example.test/privacy/')
+        self.assertEqual(page['depth'], 1)
+
+    def test_a_guide_sits_one_level_deeper(self):
+        body = (PAGE_TOML.replace('slug = "privacy"', 'slug = "guides/why"')
+                + 'kind = "guide"\npublished = "2026-01-01"\n')
+        page = sitelib.load_page(self.page_at('guides/why', body), SITE,
+                                 self.root / 'pages')
+        self.assertEqual(page['depth'], 2)
+        self.assertEqual(page['url'], 'https://example.test/guides/why/')
+
+    def test_the_slug_is_measured_from_the_pages_root(self):
+        body = PAGE_TOML.replace('slug = "privacy"', 'slug = "why"')
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_page(self.page_at('guides/why', body), SITE,
+                              self.root / 'pages')
+        self.assertIn('guides/why', str(caught.exception))
+
+    def test_an_unknown_kind_is_refused(self):
+        body = PAGE_TOML + 'kind = "essay"\n'
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_page(self.page_at('privacy', body), SITE,
+                              self.root / 'pages')
+        self.assertIn('essay', str(caught.exception))
+
+    def test_a_guide_must_say_when_it_was_published(self):
+        # Defaulting to lastmod would quietly claim a correction was the
+        # original.
+        body = (PAGE_TOML.replace('slug = "privacy"', 'slug = "guides/why"')
+                + 'kind = "guide"\n')
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_page(self.page_at('guides/why', body), SITE,
+                              self.root / 'pages')
+        self.assertIn('published', str(caught.exception))
+
+    def test_a_missing_key_is_named(self):
+        body = PAGE_TOML.replace('lede = "l"\n', '')
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_page(self.page_at('privacy', body), SITE,
+                              self.root / 'pages')
+        self.assertIn('lede', str(caught.exception))
+
+
+class SharedParts(unittest.TestCase):
+    """Setting [picker.urls] has to imply the module, the sheet and the CSP."""
+
+    def test_a_tool_without_urls_wants_nothing(self):
+        tool = {'picker': {}}
+        self.assertFalse(sitelib.wants_urls(tool))
+        self.assertEqual(sitelib.js_parts(tool), [])
+        self.assertEqual(sitelib.css_parts(tool), [])
+        self.assertEqual(sitelib.picker_csp(tool), {})
+
+    def test_urls_pull_in_the_module_and_the_sheet(self):
+        tool = {'picker': {'urls': True}}
+        self.assertIn('url-import', sitelib.js_parts(tool))
+        self.assertIn('url-import', sitelib.css_parts(tool))
+
+    def test_urls_widen_img_src_and_nothing_else(self):
+        # img-src rather than connect-src is the whole design: pictures come
+        # in, nothing goes out.
+        self.assertEqual(sitelib.picker_csp({'picker': {'urls': True}}),
+                         {'img-src': ['http:']})
+
+    def test_the_part_is_not_added_twice(self):
+        tool = {'picker': {'urls': True}, 'js_parts': ['url-import', 'file-picker']}
+        self.assertEqual(sitelib.js_parts(tool), ['url-import', 'file-picker'])
+
+    def test_explicit_parts_are_kept_in_order(self):
+        tool = {'picker': {'urls': True}, 'js_parts': ['file-picker']}
+        self.assertEqual(sitelib.js_parts(tool), ['file-picker', 'url-import'])
+
+    def test_the_returned_list_is_a_copy(self):
+        parts = ['file-picker']
+        sitelib.js_parts({'picker': {'urls': True}, 'js_parts': parts})
+        self.assertEqual(parts, ['file-picker'])
+
+
+class Hashes(TempTree):
+    def test_text_hash_is_ten_hex_characters(self):
+        digest = sitelib.text_hash('a')
+        self.assertEqual(len(digest), 10)
+        int(digest, 16)
+
+    def test_text_hash_is_stable(self):
+        self.assertEqual(sitelib.text_hash('a{color:red}'),
+                         sitelib.text_hash('a{color:red}'))
+
+    def test_text_hash_changes_with_the_text(self):
+        self.assertNotEqual(sitelib.text_hash('a'), sitelib.text_hash('b'))
+
+    def test_cache_hash_ignores_the_order_it_is_given(self):
+        a = self.write('a.js', 'one')
+        b = self.write('b.js', 'two')
+        self.assertEqual(sitelib.cache_hash([a, b]), sitelib.cache_hash([b, a]))
+
+    def test_cache_hash_changes_when_a_file_changes(self):
+        a = self.write('a.js', 'one')
+        before = sitelib.cache_hash([a])
+        a.write_text('two', encoding='utf-8')
+        self.assertNotEqual(before, sitelib.cache_hash([a]))
+
+    def test_cache_hash_changes_when_a_file_is_renamed(self):
+        # The name is hashed as well as the bytes, so a module that moved
+        # invalidates the cache even if its contents did not change.
+        a = self.write('a.js', 'one')
+        b = self.write('b.js', 'one')
+        self.assertNotEqual(sitelib.cache_hash([a]), sitelib.cache_hash([b]))
+
+    def test_cache_hash_changes_when_a_file_is_added(self):
+        a = self.write('a.js', 'one')
+        b = self.write('b.js', 'two')
+        self.assertNotEqual(sitelib.cache_hash([a]), sitelib.cache_hash([a, b]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/test_template.py
+++ b/tests/python/test_template.py
@@ -1,0 +1,227 @@
+"""
+buildlib/template.py.
+
+The engine supports five things and nothing else, so these tests are mostly
+about the fifth: what happens when a template asks for something that is not
+there. "Missing names are an error, not an empty string" is the design claim,
+and a page that silently loses its description because a key was renamed is
+the failure the whole build exists to make impossible.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from buildlib.template import Loader, Template, TemplateError, escape, resolve
+
+
+def render(source, context, loader=None):
+    return Template(source, loader=loader).render(context)
+
+
+class Escape(unittest.TestCase):
+    def test_the_four_characters(self):
+        self.assertEqual(escape('<a href="x">&</a>'),
+                         '&lt;a href=&quot;x&quot;&gt;&amp;&lt;/a&gt;')
+
+    def test_ampersand_is_escaped_first(self):
+        # Escaping `<` first would turn `<` into `&lt;` and then into `&amp;lt;`.
+        self.assertEqual(escape('<'), '&lt;')
+
+    def test_text_with_nothing_to_escape_is_unchanged(self):
+        self.assertEqual(escape('plain text'), 'plain text')
+
+
+class Resolve(unittest.TestCase):
+    def test_a_plain_key(self):
+        self.assertEqual(resolve({'a': 1}, 'a'), 1)
+
+    def test_a_dotted_path(self):
+        self.assertEqual(resolve({'a': {'b': {'c': 2}}}, 'a.b.c'), 2)
+
+    def test_an_attribute_on_an_object(self):
+        self.assertEqual(resolve({'p': Path('/x/y.html')}, 'p.name'), 'y.html')
+
+    def test_a_missing_key_names_the_path_and_the_part(self):
+        with self.assertRaises(TemplateError) as caught:
+            resolve({'a': {'b': 1}}, 'a.nope')
+        self.assertIn('a.nope', str(caught.exception))
+        self.assertIn('nope', str(caught.exception))
+
+    def test_a_missing_attribute_is_the_same_error(self):
+        with self.assertRaises(TemplateError):
+            resolve({'p': Path('/x')}, 'p.nope')
+
+
+class Values(unittest.TestCase):
+    def test_a_value_is_inserted_raw(self):
+        # Raw is deliberate: values come from config files in this repository
+        # and most of them are HTML fragments written on purpose.
+        self.assertEqual(render('{{ a }}', {'a': '<b>hi</b>'}), '<b>hi</b>')
+
+    def test_the_e_filter_escapes(self):
+        self.assertEqual(render('{{ a | e }}', {'a': '<b>'}), '&lt;b&gt;')
+
+    def test_whitespace_inside_the_braces_is_ignored(self):
+        self.assertEqual(render('{{a}}|{{   a   }}|{{ a|e }}',
+                                {'a': '&'}), '&|&|&amp;')
+
+    def test_a_number_becomes_text(self):
+        self.assertEqual(render('{{ n }}', {'n': 180}), '180')
+
+    def test_a_missing_name_is_an_error(self):
+        with self.assertRaises(TemplateError):
+            render('{{ nope }}', {})
+
+    def test_a_none_value_is_an_error(self):
+        # An empty description should stop the build, not render as "None".
+        with self.assertRaises(TemplateError) as caught:
+            render('{{ a }}', {'a': None})
+        self.assertIn('is empty', str(caught.exception))
+
+    def test_an_unknown_filter_is_an_error(self):
+        with self.assertRaises(TemplateError) as caught:
+            render('{{ a | upper }}', {'a': 'x'})
+        self.assertIn('no such filter', str(caught.exception))
+
+    def test_text_around_the_tags_survives_exactly(self):
+        self.assertEqual(render('a {{ x }} b\n', {'x': '-'}), 'a - b\n')
+
+
+class Conditionals(unittest.TestCase):
+    def test_true_takes_the_body(self):
+        self.assertEqual(render('{% if a %}yes{% endif %}', {'a': 1}), 'yes')
+
+    def test_false_takes_nothing(self):
+        self.assertEqual(render('{% if a %}yes{% endif %}', {'a': ''}), '')
+
+    def test_else(self):
+        source = '{% if a %}yes{% else %}no{% endif %}'
+        self.assertEqual(render(source, {'a': True}), 'yes')
+        self.assertEqual(render(source, {'a': False}), 'no')
+
+    def test_an_empty_list_is_false(self):
+        self.assertEqual(render('{% if a %}yes{% else %}no{% endif %}',
+                                {'a': []}), 'no')
+
+    def test_nesting(self):
+        source = '{% if a %}[{% if b %}b{% else %}!b{% endif %}]{% endif %}'
+        self.assertEqual(render(source, {'a': 1, 'b': 0}), '[!b]')
+        self.assertEqual(render(source, {'a': 1, 'b': 1}), '[b]')
+
+    def test_an_else_only_binds_to_its_own_if(self):
+        source = '{% if a %}{% if b %}B{% endif %}A{% else %}X{% endif %}'
+        self.assertEqual(render(source, {'a': 1, 'b': 0}), 'A')
+        self.assertEqual(render(source, {'a': 0, 'b': 1}), 'X')
+
+    def test_a_dotted_condition(self):
+        self.assertEqual(render('{% if a.b %}yes{% endif %}', {'a': {'b': 1}}), 'yes')
+
+    def test_an_unclosed_if_is_an_error(self):
+        with self.assertRaises(TemplateError) as caught:
+            render('{% if a %}yes', {'a': 1})
+        self.assertIn('never closed', str(caught.exception))
+
+    def test_a_missing_condition_name_is_an_error(self):
+        with self.assertRaises(TemplateError):
+            render('{% if nope %}yes{% endif %}', {})
+
+
+class Loops(unittest.TestCase):
+    def test_a_simple_loop(self):
+        self.assertEqual(render('{% for x in xs %}[{{ x }}]{% endfor %}',
+                                {'xs': [1, 2, 3]}), '[1][2][3]')
+
+    def test_an_empty_list_renders_nothing(self):
+        self.assertEqual(render('{% for x in xs %}[{{ x }}]{% endfor %}',
+                                {'xs': []}), '')
+
+    def test_the_loop_variable_does_not_escape_the_body(self):
+        with self.assertRaises(TemplateError):
+            render('{% for x in xs %}{% endfor %}{{ x }}', {'xs': [1]})
+
+    def test_the_outer_context_is_visible_inside(self):
+        self.assertEqual(
+            render('{% for x in xs %}{{ sep }}{{ x }}{% endfor %}',
+                   {'xs': [1, 2], 'sep': '-'}), '-1-2')
+
+    def test_loops_nest(self):
+        source = '{% for a in as %}{% for b in bs %}{{ a }}{{ b }} {% endfor %}{% endfor %}'
+        self.assertEqual(render(source, {'as': [1, 2], 'bs': ['x', 'y']}),
+                         '1x 1y 2x 2y ')
+
+    def test_a_loop_over_dicts(self):
+        self.assertEqual(
+            render('{% for t in tools %}{{ t.name }};{% endfor %}',
+                   {'tools': [{'name': 'a'}, {'name': 'b'}]}), 'a;b;')
+
+    def test_an_if_inside_a_loop(self):
+        self.assertEqual(
+            render('{% for x in xs %}{% if x %}{{ x }}{% endif %}{% endfor %}',
+                   {'xs': [0, 1, 0, 2]}), '12')
+
+    def test_a_bad_for_tag_is_an_error(self):
+        with self.assertRaises(TemplateError) as caught:
+            render('{% for x of xs %}{% endfor %}', {'xs': []})
+        self.assertIn('bad for tag', str(caught.exception))
+
+
+class Includes(unittest.TestCase):
+    def test_a_partial_is_rendered_in_the_same_context(self):
+        parts = {'p.html': '<b>{{ a }}</b>'}
+        self.assertEqual(render('[{% include "p.html" %}]', {'a': 'x'},
+                                loader=parts.__getitem__), '[<b>x</b>]')
+
+    def test_a_partial_may_include_another(self):
+        parts = {'one.html': '1{% include "two.html" %}', 'two.html': '2'}
+        self.assertEqual(render('{% include "one.html" %}', {},
+                                loader=parts.__getitem__), '12')
+
+    def test_an_unquoted_include_is_an_error(self):
+        with self.assertRaises(TemplateError) as caught:
+            render('{% include p.html %}', {}, loader=lambda n: '')
+        self.assertIn('quoted name', str(caught.exception))
+
+
+class LoaderTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+        (self.root / 'partials').mkdir()
+        (self.root / 'page.html').write_text(
+            'A{% include "partials/b.html" %}C', encoding='utf-8')
+        (self.root / 'partials' / 'b.html').write_text('{{ b }}', encoding='utf-8')
+
+    def test_render_reads_from_disk(self):
+        self.assertEqual(Loader(self.root).render('page.html', {'b': 'B'}), 'ABC')
+
+    def test_a_missing_template_names_where_it_looked(self):
+        with self.assertRaises(TemplateError) as caught:
+            Loader(self.root).render('nope.html', {})
+        self.assertIn('no such template', str(caught.exception))
+        self.assertIn(str(self.root), str(caught.exception))
+
+    def test_a_template_is_only_read_once(self):
+        # The source is cached, not the rendering: a second render sees the new
+        # context but the old file.
+        loader = Loader(self.root)
+        self.assertEqual(loader.render('page.html', {'b': '1'}), 'A1C')
+        (self.root / 'page.html').write_text('changed', encoding='utf-8')
+        self.assertEqual(loader.render('page.html', {'b': '2'}), 'A2C')
+
+    def test_render_source_can_reach_a_shared_partial(self):
+        # This is how a tool's body.html includes the drop zone without living
+        # in templates/ itself.
+        out = Loader(self.root).render_source(
+            'own {% include "partials/b.html" %}', 'tool/body.html', {'b': 'B'})
+        self.assertEqual(out, 'own B')
+
+    def test_an_error_in_a_partial_names_the_partial(self):
+        with self.assertRaises(TemplateError) as caught:
+            Loader(self.root).render('page.html', {})
+        self.assertIn('partials/b.html', str(caught.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Everything in this repository is written by hand: a site generator in Python, and, in each tool, the parsers and writers that let the page promise nothing is uploaded. None of it had a test.

That matters more here than it usually would. A mistake in a container parser does not throw — it silently hands somebody back a corrupted file — so the failure this codebase most needs catching is exactly the one nothing was watching for.

## What this adds

**736 tests in two suites, neither needing anything installed.** Same bargain the build makes: if you have to fetch a tree of dependencies before you can check what a claim means, the claim is not really checkable.

| Suite | Covers | Runner |
|---|---|---|
| `tests/python/` (250) | `build.py` and `buildlib/` | `unittest`, standard library |
| `tests/js/` (486) | `tools/*/src/` and `shared/js/` | `node --test`, built in |

**Python** — the template engine, both minifiers and the refusals that keep them honest, the config loading, the CSP assembly, and a whole build into a temporary directory. That last one is not a unit test and earns its place: it is the only thing that would notice a page that stopped being written at all. It also pins the 404 page from #19, including the root-absolute URLs it has to carry and the fact that it stays out of the sitemap.

**JavaScript** — the EXIF and TIFF parsers, the three container formats, the PDF object grammar and rewriter from #18, the three MP4 writers, the trimmer's keyframe arithmetic from #20, the PDF writer, the layout maths, ZIP and CRC-32.

Mostly round trips, because that is the shape of the promise being kept: read a file, write it back, and check the picture came through byte for byte with only the metadata gone. The rest are the refusals — an encrypted PDF turned away rather than quietly decrypted, an IFD pointing at itself, a `/Length` that lies, a segment claiming a length past the end of the file.

The most carefully tested file is `trim-video/src/ranges.js`. It turns seconds into ticks on two different clocks, and its answers decide where a lossless cut actually begins — at the keyframe in front of the mark, not at the mark. Getting that wrong does not throw; it desynchronises the sound.

## CI

A `test` job that the `build` job now `needs`, so a failing test cannot deploy. It runs on **every push and every pull request**, and installs nothing.

It pins Node 24 rather than the build job's 20, because `node --test` only learned to take a glob in 21 — on 20 the same argument is read as a path that does not exist. Nothing is installed with it, so the version is free to differ from the one esbuild is pinned against.

## Is the suite actually load-bearing?

Checked against **28 deliberate mutations** of the sources — a dropped keyframe search, a believed `/Length`, a cleared VP8X flag, an inverted combinator rule, a `Math.max` turned into an assignment. Every one fails a test. Three gaps turned up that way and were closed; one mutation turned out to be behaviourally equivalent and is documented as such rather than papered over.

## Fixtures

Built rather than checked in as binaries, so a reader can see what is in each one. The two TIFF blocks and the PDFs are written with real byte offsets and a comment on every field — a fixture with a wrong xref table would silently exercise the compress-pdf repair path and never touch the one that matters.

## The one judgement call

**A new `package.json` at the root.** It declares `"type": "module"` and nothing else. Without it Node reads `tools/*/src/*.js` as CommonJS and fails on the first `import`, so no JS test can run at all.

No dependencies, no lockfile, nothing installs it, and the build never reads it. It declares what these files already are. The README previously said "There is no `package.json` and no lockfile"; that sentence now says what there is and why.

## Notes

- Two regression tests cover parser bugs fixed in #17 (JPEG fill bytes read as a marker; unknown WebP chunks neither reported nor removed).
- Adding a tool needs no registration: the Python build test globs `tools/*/tool.toml` and the JS runner globs `tests/js/*.test.js`.
- One latent issue found and **not** fixed here, to keep this PR to one thing: `num()` in `images-to-pdf/src/pdf.js` guards against exponent notation below 1e21 but not above, and `pageSizePt()` puts no upper bound on a custom page size. The test documents the current ceiling in a comment rather than asserting a broken guarantee.

`tests/README.md` says what is covered and what deliberately is not — the line is drawn at the browser, because faking a `VideoEncoder` well enough to be worth the trouble means testing the fake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
