### PR TITLE
Move the planned list off the front page and onto a roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ buildlib/
   site.py                config loading, the CSP, the structured data, the checks
 config/
   site.toml              everything true of every page: the CSP, the ids, the hub
-  planned.toml           the "Planned" list on the hub page
+  planned.toml           the "Planned" list on the roadmap page
 templates/
   hub.html               the hub page
+  roadmap.html           the roadmap: what is built, then what is planned
   tool.html              the frame every tool page wears
   page.html              the frame a prose page wears - the legal ones
   404.html               what GitHub Pages returns for an address that is not here
@@ -658,7 +659,7 @@ worse than no link at all. All five come from `source_url` in
 
 ## What can be built here
 
-The "Planned" list on the front page is not a wishlist. It was drawn up by going
+The "Planned" list on the roadmap is not a wishlist. It was drawn up by going
 through the tool list of the largest online GIF and video site — the closest
 thing there is to a complete catalogue of what people actually want done to a
 media file — and putting every entry through one test:

--- a/build.py
+++ b/build.py
@@ -168,8 +168,11 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
         build_page(out, templates, site, page, footer, css_v, emit)
         written.append(f'{page["slug"]}/index.html')
 
-    build_hub(out, templates, site, planned, by_slug, footer, css_v, emit)
+    build_hub(out, templates, site, by_slug, footer, css_v, emit)
     written.append('index.html')
+
+    build_roadmap(out, templates, site, planned, ordered, footer, css_v, emit)
+    written.append(f'{site["roadmap"]["slug"]}/index.html')
 
     build_404(out, templates, site, ordered, footer, css_v, emit)
     written.append('404.html')
@@ -373,7 +376,7 @@ def build_page(out, templates, site, page, footer, css_v, emit):
 # The hub
 
 
-def build_hub(out, templates, site, planned, by_slug, footer, css_v, emit):
+def build_hub(out, templates, site, by_slug, footer, css_v, emit):
     categories = []
     listed = set()
     for category in site['hub']['categories']:
@@ -399,12 +402,9 @@ def build_hub(out, templates, site, planned, by_slug, footer, css_v, emit):
             f'so nothing would link to them: {", ".join(stray)}')
 
     ordered = [tool for category in categories for tool in category['tools']]
-    for group in planned['group']:
-        group['items'] = [{'name': name, 'desc': desc} for name, desc in group['items']]
 
     emit.html(out / 'index.html', templates.render('hub.html', {
         'site': site,
-        'planned': planned,
         'categories': categories,
         'footer': footer,
         'base': './',
@@ -414,6 +414,48 @@ def build_hub(out, templates, site, planned, by_slug, footer, css_v, emit):
     }))
 
     emit.js(out / 'analytics.js', templates.render('analytics.js', {
+        'site': site,
+        'words': {'plural': 'files', 'analytics_extra': ''},
+    }), where='analytics.js')
+
+
+def build_roadmap(out, templates, site, planned, ordered, footer, css_v, emit):
+    """The roadmap: what is built, then what is planned.
+
+    This was the last section of the hub until the planned list passed about
+    fifty names. A front page that ends on a long list of things the site cannot
+    do reads as an apology, and it pushed the tools that do exist off the bottom
+    of the screen. Moving it here keeps the list - saying out loud where this is
+    going is the same habit as saying out loud what the tools do with your files
+    - without letting it be the last word on the hub.
+
+    Neither half is written here. The built half is `ordered`, the same tool
+    list the hub and the footer are drawn from; the planned half is
+    config/planned.toml. A tool that ships moves from one to the other by
+    appearing in tools/ and leaving that file."""
+    roadmap = site['roadmap']
+
+    # planned.toml stores each entry as a two-item array, which is compact to
+    # write by hand and unusable in a template. Named here rather than in the
+    # file so the file stays a list of names and descriptions.
+    for group in planned['group']:
+        group['items'] = [{'name': name, 'desc': desc} for name, desc in group['items']]
+
+    dest = out / roadmap['slug']
+    dest.mkdir(parents=True, exist_ok=True)
+
+    emit.html(dest / 'index.html', templates.render('roadmap.html', {
+        'site': site,
+        'planned': planned,
+        'tools': ordered,
+        'footer': footer,
+        'base': '../',
+        'css_href': f'../site.css?v={css_v}',
+        'csp': sitelib.render_csp(site['csp']),
+        'jsonld': sitelib.roadmap_jsonld(site),
+    }))
+
+    emit.js(dest / 'analytics.js', templates.render('analytics.js', {
         'site': site,
         'words': {'plural': 'files', 'analytics_extra': ''},
     }), where='analytics.js')
@@ -453,6 +495,11 @@ def build_sitemap(out, templates, site, tools, guides, legal):
     # came for; a guide is how they find out this site exists.
     pages += [{'url': page['url'], 'lastmod': page['lastmod'],
                'changefreq': 'monthly', 'priority': '0.6'} for page in guides]
+    # The roadmap: a real page, but not one anybody searches for. Below the
+    # guides, above the legal pages.
+    pages.append({'url': f'{site["domain"]}{site["roadmap"]["slug"]}/',
+                  'lastmod': site['roadmap']['lastmod'],
+                  'changefreq': 'monthly', 'priority': '0.5'})
     # The legal pages last, and low: they matter for trust, not for search.
     pages += [{'url': page['url'], 'lastmod': page['lastmod'],
                'changefreq': 'yearly', 'priority': '0.3'} for page in legal]

--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -152,6 +152,36 @@ def tool_jsonld(site, tool):
     return dumps_ld(graph)
 
 
+def roadmap_jsonld(site):
+    """CollectionPage + BreadcrumbList for the roadmap.
+
+    Not an ItemList: the hub already publishes one naming the tools that exist,
+    and a second list here that mixed shipped tools with names nobody can click
+    would be describing products that are not products yet."""
+    roadmap = site['roadmap']
+    url = f'{site["domain"]}{roadmap["slug"]}/'
+    graph = [
+        {
+            '@type': 'CollectionPage',
+            'url': url,
+            'name': to_text(roadmap['heading']),
+            'description': to_text(roadmap['description']),
+            'inLanguage': site['lang'],
+            'isPartOf': {'@id': site['domain'] + '#website'},
+        },
+        {
+            '@type': 'BreadcrumbList',
+            'itemListElement': [
+                {'@type': 'ListItem', 'position': 1,
+                 'name': site['name'], 'item': site['domain']},
+                {'@type': 'ListItem', 'position': 2,
+                 'name': to_text(roadmap['nav']), 'item': url},
+            ],
+        },
+    ]
+    return dumps_ld(graph)
+
+
 def page_jsonld(site, page):
     """Structured data for a prose page, or nothing for a legal one.
 

--- a/config/site.toml
+++ b/config/site.toml
@@ -219,6 +219,48 @@ order = ["compress-pdf", "images-to-pdf"]
 
 #
 # ---------------------------------------------------------------------------
+# The roadmap page.
+#
+# The planned list used to sit at the foot of the hub, under the shipped tools.
+# It had grown to about fifty names across six groups, which meant the last
+# thing a visitor saw on the front page was a long list of things this site
+# cannot do yet. It reads as an apology, and it pushed the tools that do exist
+# off the bottom of the screen.
+#
+# It is worth keeping - saying out loud where this is going is the same habit as
+# saying out loud what the tools do with your files - so it moved here instead
+# of being deleted. The page lists what is built first and what is planned
+# second, which is the honest order and also the useful one.
+#
+# The content itself is still config/planned.toml. This is only the frame.
+# ---------------------------------------------------------------------------
+#
+
+[roadmap]
+slug = "roadmap"
+nav = "Roadmap"
+lastmod = "2026-08-20"
+
+title = "Roadmap &mdash; what abox.tools has built, and what is next"
+description = "Every tool on abox.tools that is finished, and the ones planned next. All of them run in your browser, and none of them upload your files."
+
+heading = "What is built, and what is coming"
+lede = """
+    Everything here runs in your browser and uploads nothing, the ones that
+    exist today and the ones that do not yet. This is the whole list, kept in
+    the open so you can see whether the thing you need is coming."""
+
+built_heading = "Built and working"
+built_note = "Finished, and linked from every page on the site."
+
+planned_heading = "Planned"
+
+og_title = "abox.tools roadmap"
+og_description = "What is built, and what is next. Everything runs in your browser and uploads nothing."
+og_image_alt = "abox.tools - tools that never touch a server"
+
+#
+# ---------------------------------------------------------------------------
 # The footer, which is now the same on every page - hub, tool and legal alike.
 #
 # The tool list and the legal-page list in it are not written here: build.py

--- a/shared/site.css
+++ b/shared/site.css
@@ -212,6 +212,19 @@ code {
 .tool-name { font-weight: 600; font-size: 1.02rem; }
 .tool-desc { font-size: 0.88rem; color: var(--text-dim); line-height: 1.5; }
 
+/* ---- the line that replaced the planned list on the hub ----------------- */
+
+/* Sits under the last category, where fifty planned names used to be. Quiet on
+   purpose: it is a pointer, and the tools above it are the point. */
+.roadmap-note {
+  margin: 0;
+  padding-top: 0.25rem;
+  font-size: 0.9rem;
+  color: var(--text-dim);
+}
+
+.roadmap-note a { color: var(--accent); }
+
 /* ---- planned ----------------------------------------------------------- */
 
 .planned .category-head h2 { color: var(--text-dim); }

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -5,7 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <!--
   GENERATED FILE - do not edit. Built by build.py from templates/hub.html,
-  config/site.toml, config/planned.toml, and one tool.toml per shipped tool.
+  config/site.toml and one tool.toml per shipped tool. The planned list moved to
+  templates/roadmap.html.
   Edit those and run `python build.py`.
 -->
 <!--
@@ -171,19 +172,19 @@
 {% endfor %}    </ul>
   </section>
 {% endfor %}
-  <section class="category planned" id="planned" aria-labelledby="planned-h">
-    <div class="category-head">
-      <h2 id="planned-h">Planned</h2>
-      <p class="category-note">{{ planned.note }}</p>
-    </div>
-{% for group in planned.group %}
-    <div class="planned-group">
-      <h3>{{ group.name }}</h3>
-      <ul class="planned-list">
-{% for item in group.items %}        <li><span class="p-name">{{ item.name }}</span> <span class="p-desc">{{ item.desc }}</span></li>
-{% endfor %}      </ul>
-    </div>
-{% endfor %}  </section>
+  <!--
+    The planned list used to be spelled out here, and had grown to about fifty
+    names across six groups. That meant the last thing anybody saw on the front
+    page was a long list of things this site cannot do yet, below the fold and
+    below the tools that do exist. It reads as an apology.
+
+    It still exists, in full, on the roadmap - see templates/roadmap.html and
+    config/planned.toml. This is the one line that points at it.
+  -->
+  <p class="roadmap-note">
+    More is coming, and the list is public:
+    <a href="{{ base }}{{ site.roadmap.slug }}/">see what is planned next</a>.
+  </p>
 
 </main>
 

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -36,6 +36,7 @@
       <strong>This site</strong>
       <ul>
         <li><a href="{{ base }}">All tools</a></li>
+        <li><a href="{{ base }}{{ site.roadmap.slug }}/">{{ site.roadmap.nav }}</a></li>
 {% for g in footer.guides %}        <li><a href="{{ base }}{{ g.slug }}/">{{ g.nav }}</a></li>
 {% endfor %}{% for p in footer.pages %}        <li><a href="{{ base }}{{ p.slug }}/">{{ p.nav }}</a></li>
 {% endfor %}        <li><a href="/sitemap.xml">Sitemap</a></li>

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="{{ site.lang }}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!--
+  GENERATED FILE - do not edit. Built by build.py from templates/roadmap.html,
+  config/site.toml, config/planned.toml, and one tool.toml per shipped tool.
+  Edit those and run `python build.py`.
+
+  This page used to be the last section of the hub. It was moved out when the
+  planned list passed about fifty names: the front page ended on a long list of
+  things the site cannot do, which reads as an apology and pushed the tools that
+  do exist off the bottom of the screen.
+
+  Nothing here is written twice. The built half is the same tool list the hub
+  and the footer are drawn from, and the planned half is config/planned.toml, so
+  a tool that ships moves between the two halves by being added to tools/ and
+  taken out of that file - never by editing this page.
+-->
+<!--
+  This page carries advertising, and ad code cannot run under default-src
+  'none'. The allowlist below is generated from config/site.toml, the same one
+  every other page is built from, so the pages cannot drift apart.
+-->
+{{ csp }}
+<title>{{ site.roadmap.title }}</title>
+<meta name="description" content="{{ site.roadmap.description }}">
+
+<link rel="canonical" href="{{ site.domain }}{{ site.roadmap.slug }}/">
+
+<meta name="google-adsense-account" content="{{ site.adsense_client }}">
+
+{% include "partials/head-scripts.html" %}
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="{{ site.name }}">
+<meta property="og:url" content="{{ site.domain }}{{ site.roadmap.slug }}/">
+<meta property="og:title" content="{{ site.roadmap.og_title }}">
+<meta property="og:description" content="{{ site.roadmap.og_description }}">
+<meta property="og:image" content="{{ site.domain }}og.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="{{ site.roadmap.og_image_alt }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ site.roadmap.og_title }}">
+<meta name="twitter:description" content="{{ site.roadmap.og_description }}">
+<meta name="twitter:image" content="{{ site.domain }}og.png">
+
+<!--
+  Structured data. The breadcrumb is here and so is the visible trail below it,
+  because markup is meant to describe what a visitor can actually see.
+
+  Inline is deliberate and does not need 'unsafe-inline': a <script> whose type
+  is not a JavaScript type is a data block the parser never executes.
+-->
+<script type="application/ld+json">
+{{ jsonld }}
+</script>
+
+<!--
+  The stylesheet URL carries a hash of the stylesheet. GitHub Pages serves
+  HTML with max-age=600 and CSS with max-age=14400, so without this a deploy
+  reaches a returning visitor as new markup wearing a four-hour-old sheet.
+-->
+<link rel="stylesheet" href="{{ css_href }}">
+<link rel="icon" href="/logo.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/icon-180.png">
+</head>
+<body>
+
+<nav class="crumbs" aria-label="Breadcrumb">
+  <a href="{{ base }}">All tools</a>
+  <span aria-hidden="true">&rsaquo;</span>
+  <span aria-current="page">{{ site.roadmap.nav }}</span>
+</nav>
+
+<header class="hub-head">
+  <p class="brand">
+    <a class="brand-home" href="{{ base }}">
+      <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
+    </a>
+  </p>
+  <h1>{{ site.roadmap.heading }}</h1>
+  <p class="lede">
+{{ site.roadmap.lede }}
+  </p>
+</header>
+
+<main>
+
+  <!--
+    The built half first. A roadmap that opens on what does not exist yet is a
+    wishlist; opening on what does makes the rest of it a promise with a track
+    record behind it. These are real links, so this page also spreads crawl
+    depth across every tool rather than being a dead end.
+  -->
+  <section class="category" id="built" aria-labelledby="built-h">
+    <div class="category-head">
+      <h2 id="built-h">{{ site.roadmap.built_heading }}</h2>
+      <p class="category-note">{{ site.roadmap.built_note }}</p>
+    </div>
+    <ul class="tool-grid">
+{% for tool in tools %}      <li>
+        <a class="tool-card" href="{{ base }}{{ tool.slug }}/">
+          <span class="tool-icon" aria-hidden="true">{{ tool.icon }}</span>
+          <span class="tool-name">{{ tool.name | e }}</span>
+          <span class="tool-desc">
+{{ tool.card }}
+          </span>
+        </a>
+      </li>
+{% endfor %}    </ul>
+  </section>
+
+  <!--
+    ==========================================================================
+    THE PLANNED LIST
+
+    Written as plain text on purpose. A card that links nowhere reads as a
+    broken page rather than an honest one, so nothing here is a link until it
+    ships. Move a name out of config/planned.toml when the tool actually
+    exists, and add its folder to tools/ at the same time - it will appear in
+    the section above, in the hub, in the footer and in the sitemap without
+    anybody editing this template.
+    ==========================================================================
+  -->
+  <section class="category planned" id="planned" aria-labelledby="planned-h">
+    <div class="category-head">
+      <h2 id="planned-h">{{ site.roadmap.planned_heading }}</h2>
+      <p class="category-note">{{ planned.note }}</p>
+    </div>
+{% for group in planned.group %}
+    <div class="planned-group">
+      <h3>{{ group.name }}</h3>
+      <ul class="planned-list">
+{% for item in group.items %}        <li><span class="p-name">{{ item.name }}</span> <span class="p-desc">{{ item.desc }}</span></li>
+{% endfor %}      </ul>
+    </div>
+{% endfor %}  </section>
+
+</main>
+
+{% include "partials/footer.html" %}
+
+</body>
+</html>


### PR DESCRIPTION
The planned list had grown to **42 names across six groups**, sitting at the foot of the hub under the shipped tools. That made the last thing anybody saw on the front page a long list of things the site cannot do yet — an apology, below a screen and a half of scrolling, burying the seven tools that do exist.

It is worth keeping, so it moved rather than went away. The hub now ends on one line pointing at it, and the front page is roughly **half the height** it was (1,863px, down from a page dominated by the planned list).

## What the roadmap is

`/roadmap/` — **built first, planned second.** A roadmap that opens on what does not exist is a wishlist; opening on what does makes the rest of it a promise with a record behind it.

Neither half is written into the template:

- the **built** half is the same ordered tool list the hub and the footer are drawn from
- the **planned** half is `config/planned.toml`, unchanged

So a tool that ships crosses from one half to the other by appearing in `tools/` and leaving that file. There is still no second place to remember.

## Details worth flagging

**Schema.** `CollectionPage` + `BreadcrumbList`, with a visible trail to match. Deliberately *not* a second `ItemList` — the hub already publishes one naming the tools that exist, and a list here mixing those with names nobody can click would be describing products that are not products yet.

**Sitemap priority 0.5** — below the guide (0.6), above the legal pages (0.3). A real page, but not one anybody searches for.

**Internal linking.** The seven tool cards make this the second page on the site that links to every tool. On a site whose pages mostly only link back to the hub, that is worth something.

**Cleanup.** `build_hub` no longer takes `planned` at all, and the two-item arrays in `planned.toml` are now named where they are used rather than inside the hub's builder.

## Checks

- `python build.py --out _site --clean` → 14 pages, exit 0
- `python -m unittest discover -t . -s tests/python` → **250 tests, OK**
- Roadmap: 789 words, title 53 chars, description 138 chars, one H1, two H2s, 6 groups, 42 planned items, 7 tool cards, breadcrumb present
- JSON-LD parses
- Hub: zero planned items remaining, roadmap note renders, no overlap with the last category or the footer
- Footer link resolves at all three depths (`./roadmap/`, `../roadmap/`, `../../roadmap/`)
- No horizontal overflow at 1280px
- README updated: file map and the "What can be built here" section now say roadmap, not front page

## Note

`.claude/worktrees/` contains other in-progress branches that still reference the old `build_hub(…, planned, …)` signature. They are separate worktrees and not touched here — they will need a rebase onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
