### PR TITLE
Make the roadmap read like a guide, and put the planned list first

### DIFF
--- a/build.py
+++ b/build.py
@@ -447,6 +447,8 @@ def build_roadmap(out, templates, site, planned, ordered, footer, css_v, emit):
     emit.html(dest / 'index.html', templates.render('roadmap.html', {
         'site': site,
         'planned': planned,
+        'planned_count': sum(len(group['items']) for group in planned['group']),
+        'built_count': len(ordered),
         'tools': ordered,
         'footer': footer,
         'base': '../',

--- a/config/site.toml
+++ b/config/site.toml
@@ -241,19 +241,43 @@ slug = "roadmap"
 nav = "Roadmap"
 lastmod = "2026-08-20"
 
-title = "Roadmap &mdash; what abox.tools has built, and what is next"
-description = "Every tool on abox.tools that is finished, and the ones planned next. All of them run in your browser, and none of them upload your files."
+title = "Roadmap &mdash; what abox.tools is building next"
+description = "Every tool planned for abox.tools, grouped and in the open, plus the ones already finished. All of them run in your browser and upload nothing."
 
-heading = "What is built, and what is coming"
+heading = "What is coming next"
 lede = """
-    Everything here runs in your browser and uploads nothing, the ones that
-    exist today and the ones that do not yet. This is the whole list, kept in
-    the open so you can see whether the thing you need is coming."""
+    Everything on both lists below does its work inside your browser and
+    uploads nothing &mdash; that is the rule a name has to pass before it goes
+    on here at all. The counts are not written down anywhere; the build reads
+    them off the two lists."""
 
-built_heading = "Built and working"
-built_note = "Finished, and linked from every page on the site."
+intro_heading = "How this list was drawn up"
+intro = """
+    <p>
+      It is not a wishlist. It was drawn up by going through the tool list of
+      the largest online GIF and video site, the closest thing there is to a
+      catalogue of what people actually want done to a file, and keeping every
+      entry that can be built so the work happens on your own machine and keeps
+      happening with the network unplugged.
+    </p>
+    <p>
+      Most of what survived runs on APIs the browser already ships. A few need
+      a codec vendored into the one tool that uses it, which is allowed &mdash;
+      the file still never leaves the machine. Anything that cannot clear that
+      bar was left off rather than promised, so a few of the obvious-looking
+      gaps below are gaps on purpose.
+    </p>
+    <p>
+      Nothing here is a link until it exists. When a tool ships it moves out of
+      this list and into the one at the foot of the page.
+    </p>"""
 
 planned_heading = "Planned"
+
+built_heading = "Already built"
+built_note = """
+      Each one has its own page, and every page on this site links to all of
+      them from the footer."""
 
 og_title = "abox.tools roadmap"
 og_description = "What is built, and what is next. Everything runs in your browser and uploads nothing."

--- a/shared/site.css
+++ b/shared/site.css
@@ -225,47 +225,87 @@ code {
 
 .roadmap-note a { color: var(--accent); }
 
-/* ---- planned ----------------------------------------------------------- */
+/* ---- the roadmap ------------------------------------------------------- */
 
-.planned .category-head h2 { color: var(--text-dim); }
-
-/* The planned list is grouped once it is longer than a handful of lines: a
-   flat run of forty names reads as a wishlist, the same names under Images /
-   Video / Audio read as a shape. The heading is deliberately quieter than a
-   category's <h2> so a shipped tool still outranks a planned one visually. */
-
-.planned-group + .planned-group { margin-top: 1.35rem; }
-
-.planned-group h3 {
-  margin: 0 0 0.5rem;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
+/* The two counts under the lede. Read off the lists by the build, so they are
+   a fact about the page rather than a claim in a sentence. */
+.roadmap-count {
+  margin: 0.9rem 0 0;
+  font-size: 0.85rem;
   color: var(--text-dim);
 }
 
-.planned-list {
+.roadmap-count strong {
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Read as prose, not scanned as a grid, so it wears the same frame the guides
+   do - one narrow column, headings with a rule under them, ordinary lists.
+
+   The planned list is the substance of this page and comes first. It used to
+   sit in a grid of dashed boxes, which made forty-two names look like forty-two
+   things going wrong; as a plain list under its group heading it reads like a
+   plan. Grouping matters for the same reason: a flat run of forty names is a
+   wishlist, the same names under Images / Video / Audio are a shape. */
+
+.plan-group + .plan-group { margin-top: 1.6rem; }
+
+.plan-group h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.plan-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.4rem;
-  font-size: 0.9rem;
+  gap: 0.05rem;
 }
 
-.planned-list li {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.15rem 0.5rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px dashed var(--border);
-  border-radius: var(--radius);
-  color: var(--text-dim);
+.plan-list li {
+  margin: 0;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.92rem;
+  line-height: 1.5;
 }
+
+.plan-list li:last-child { border-bottom: 0; }
 
 .p-name { font-weight: 600; color: var(--text); }
-.p-desc { font-size: 0.85rem; }
+.p-desc { color: var(--text-dim); }
+
+/* The built half, deliberately quiet. Every one of these already has a card on
+   the hub and a link in the footer of every page; repeating them here at that
+   weight made the roadmap look like a second front page and pushed the part
+   somebody came to read below the fold. */
+
+.built-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.05rem;
+}
+
+.built-list li {
+  margin: 0;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.built-list li:last-child { border-bottom: 0; }
+.built-list a { font-weight: 600; text-decoration: none; }
+.built-list a:hover { text-decoration: underline; }
+.b-desc { color: var(--text-dim); }
 
 /* ---- legal pages ------------------------------------------------------- */
 
@@ -300,11 +340,11 @@ code {
   color: var(--text-dim);
 }
 
-.legal { max-width: 68ch; }
+.legal, .prose { max-width: 68ch; }
 
-.legal section { margin: 0 0 2.25rem; }
+.legal section, .prose section { margin: 0 0 2.25rem; }
 
-.legal h2 {
+.legal h2, .prose h2 {
   margin: 0 0 0.7rem;
   padding-bottom: 0.4rem;
   border-bottom: 1px solid var(--border);
@@ -312,15 +352,15 @@ code {
   letter-spacing: -0.01em;
 }
 
-.legal h3 {
+.legal h3, .prose h3 {
   margin: 1.5rem 0 0.45rem;
   font-size: 0.95rem;
 }
 
-.legal p { margin: 0 0 0.85rem; }
-.legal ul { margin: 0 0 0.95rem; padding-left: 1.25rem; }
-.legal li { margin: 0.3rem 0; }
-.legal a { color: var(--accent); }
+.legal p, .prose p { margin: 0 0 0.85rem; }
+.legal ul, .prose ul { margin: 0 0 0.95rem; padding-left: 1.25rem; }
+.legal li, .prose li { margin: 0.3rem 0; }
+.legal a, .prose a { color: var(--accent); }
 
 /* ---- footer ------------------------------------------------------------ */
 

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -85,59 +85,71 @@
   <p class="lede">
 {{ site.roadmap.lede }}
   </p>
+  <!--
+    Counted by the build from the two lists themselves, so they cannot be wrong
+    the way a number typed into a sentence goes wrong the first time a tool
+    ships and nobody remembers this page exists.
+  -->
+  <p class="roadmap-count">
+    <strong>{{ planned_count }}</strong> planned
+    &middot;
+    <strong>{{ built_count }}</strong> built
+  </p>
 </header>
 
-<main>
+<!--
+  One narrow column, the same frame the guides wear. This page is read rather
+  than scanned: somebody is here to find out whether the thing they need is
+  coming, which is a question you answer by reading a list, not by looking at a
+  grid of cards for tools you already saw on the front page.
+-->
+<main class="prose">
 
-  <!--
-    The built half first. A roadmap that opens on what does not exist yet is a
-    wishlist; opening on what does makes the rest of it a promise with a track
-    record behind it. These are real links, so this page also spreads crawl
-    depth across every tool rather than being a dead end.
-  -->
-  <section class="category" id="built" aria-labelledby="built-h">
-    <div class="category-head">
-      <h2 id="built-h">{{ site.roadmap.built_heading }}</h2>
-      <p class="category-note">{{ site.roadmap.built_note }}</p>
-    </div>
-    <ul class="tool-grid">
-{% for tool in tools %}      <li>
-        <a class="tool-card" href="{{ base }}{{ tool.slug }}/">
-          <span class="tool-icon" aria-hidden="true">{{ tool.icon }}</span>
-          <span class="tool-name">{{ tool.name | e }}</span>
-          <span class="tool-desc">
-{{ tool.card }}
-          </span>
-        </a>
-      </li>
-{% endfor %}    </ul>
+  <section>
+    <h2>{{ site.roadmap.intro_heading }}</h2>
+{{ site.roadmap.intro }}
   </section>
 
   <!--
     ==========================================================================
-    THE PLANNED LIST
+    THE PLANNED LIST - the substance of this page, and first for that reason.
 
-    Written as plain text on purpose. A card that links nowhere reads as a
+    Written as plain text on purpose. A name that links nowhere reads as a
     broken page rather than an honest one, so nothing here is a link until it
     ships. Move a name out of config/planned.toml when the tool actually
-    exists, and add its folder to tools/ at the same time - it will appear in
-    the section above, in the hub, in the footer and in the sitemap without
-    anybody editing this template.
+    exists, and add its folder to tools/ at the same time - it will leave this
+    list and join the one below it, and appear on the hub, in every footer and
+    in the sitemap, without anybody editing this template.
     ==========================================================================
   -->
-  <section class="category planned" id="planned" aria-labelledby="planned-h">
-    <div class="category-head">
-      <h2 id="planned-h">{{ site.roadmap.planned_heading }}</h2>
-      <p class="category-note">{{ planned.note }}</p>
-    </div>
+  <section id="planned" aria-labelledby="planned-h">
+    <h2 id="planned-h">{{ site.roadmap.planned_heading }}</h2>
+    <p>{{ planned.note }}</p>
 {% for group in planned.group %}
-    <div class="planned-group">
+    <div class="plan-group">
       <h3>{{ group.name }}</h3>
-      <ul class="planned-list">
-{% for item in group.items %}        <li><span class="p-name">{{ item.name }}</span> <span class="p-desc">{{ item.desc }}</span></li>
+      <ul class="plan-list">
+{% for item in group.items %}        <li><span class="p-name">{{ item.name }}</span> <span class="p-desc">&mdash; {{ item.desc }}</span></li>
 {% endfor %}      </ul>
     </div>
 {% endfor %}  </section>
+
+  <!--
+    The built half, and deliberately quiet. Every one of these already has a
+    card on the hub and a link in the footer of every page; giving them the same
+    weight again here made the roadmap look like a second front page and pushed
+    the list above - the part somebody actually came for - below the fold.
+
+    Still real links, so this page is not a dead end and still spreads crawl
+    depth across every tool.
+  -->
+  <section id="built" aria-labelledby="built-h">
+    <h2 id="built-h">{{ site.roadmap.built_heading }}</h2>
+    <p>{{ site.roadmap.built_note }}</p>
+    <ul class="built-list">
+{% for tool in tools %}      <li><a href="{{ base }}{{ tool.slug }}/">{{ tool.name | e }}</a> <span class="b-desc">&mdash; {{ tool.tagline }}</span></li>
+{% endfor %}    </ul>
+  </section>
 
 </main>
 


### PR DESCRIPTION
The roadmap shipped looking like a second front page. Two things were wrong with that, and both are fixed here.

## The layout

Emoji icons are not all the same height, so cards in a row started their titles at **different baselines** — visible in the first row, where "Images to Video" sits noticeably lower than "Video Trimmer". And seven cards in a three-column grid leaves the seventh alone beside a gap two cards wide.

Both are gone, because the cards are gone.

## The emphasis

Somebody on this page is asking whether the thing they need is coming. That is the planned list — and it was sitting below a screen and a half of tools they had just seen on the hub.

The order is now: **how the list was drawn up → Planned → Already built.**

## Guide/blog styling

It wears the frame the guides wear: one narrow column (68ch), headings with a rule under them, ordinary lists.

That frame was called `.legal`, which was already the wrong name for the guides using it. `.prose` is now an alias for the same rules and this page uses that — no change to any existing page.

**The planned list loses the dashed boxes.** Forty-two names each in its own dashed rectangle looks like forty-two things going wrong; the same names as a plain list under their group heading read as a plan. Group headings move from grey to the accent colour, because they are now the navigation of the page rather than a quiet subdivision of its last section.

**The built half stays, quietly** — name, one line, real link. Each already has a card on the hub and a footer link on every page, so repeating them at card weight was pure duplication. Still real links, so the page is not a dead end for a crawler and still spreads crawl depth across all seven tools.

## One thing I caught in my own draft

I first wrote "Forty-two tools are planned and seven are built" into the lede. That would have been wrong the next time a tool shipped — exactly the class of hand-maintained fact this build exists to abolish. The two counts under the lede are now read off the lists by the build.

## Checks

- `python build.py --out _site --clean` → 14 pages, exit 0
- `python -m unittest discover -t . -s tests/python` → **250 tests, OK**
- Roadmap: 897 words, title 42 chars, description 143 chars, one H1, H2 order `How this list was drawn up / Planned / Already built`
- 42 planned items in 6 groups, 7 built, **0 tool cards remaining**
- `CollectionPage` + `BreadcrumbList` still valid
- Every internal link resolves
- No horizontal overflow at 375px or 1280px; row heights even at 35–36px throughout both lists
- Hub, guide, privacy and tool pages unchanged in shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)
