### PR TITLE
Put the built tools into the roadmap list they belong in

### DIFF
--- a/build.py
+++ b/build.py
@@ -441,6 +441,26 @@ def build_roadmap(out, templates, site, planned, ordered, footer, css_v, emit):
     for group in planned['group']:
         group['items'] = [{'name': name, 'desc': desc} for name, desc in group['items']]
 
+    # The shipped tools go into the group each one names, at the top of it, as
+    # links. A group is then the whole story for that kind of file - what exists
+    # and what is still to come - rather than two lists in different places that
+    # a reader has to hold together in their head.
+    by_group = {group['id']: group for group in planned['group']}
+    for tool in ordered:
+        gid = tool.get('roadmap_group')
+        if gid is None:
+            raise sitelib.ConfigError(
+                f'{tool["slug"]}: no roadmap_group, so it would appear nowhere on '
+                f'the roadmap. Name one of: {", ".join(by_group)}')
+        if gid not in by_group:
+            raise sitelib.ConfigError(
+                f'{tool["slug"]}: roadmap_group is {gid!r}, which is not a group in '
+                f'config/planned.toml. Name one of: {", ".join(by_group)}')
+        by_group[gid].setdefault('built', []).append(tool)
+
+    for group in planned['group']:
+        group.setdefault('built', [])
+
     dest = out / roadmap['slug']
     dest.mkdir(parents=True, exist_ok=True)
 

--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -153,30 +153,25 @@ def tool_jsonld(site, tool):
 
 
 def roadmap_jsonld(site):
-    """CollectionPage + BreadcrumbList for the roadmap.
+    """CollectionPage for the roadmap, and nothing else.
 
-    Not an ItemList: the hub already publishes one naming the tools that exist,
-    and a second list here that mixed shipped tools with names nobody can click
-    would be describing products that are not products yet."""
+    No ItemList: the hub already publishes one naming the tools that exist, and
+    a list here mixing those with names nobody can click would be describing
+    products that are not products yet.
+
+    No BreadcrumbList either. There was one, until the visible trail above the
+    heading went - it repeated a journey the header's own brand link already
+    offers. Markup is meant to describe what a visitor can see, so the two left
+    together."""
     roadmap = site['roadmap']
-    url = f'{site["domain"]}{roadmap["slug"]}/'
     graph = [
         {
             '@type': 'CollectionPage',
-            'url': url,
+            'url': f'{site["domain"]}{roadmap["slug"]}/',
             'name': to_text(roadmap['heading']),
             'description': to_text(roadmap['description']),
             'inLanguage': site['lang'],
             'isPartOf': {'@id': site['domain'] + '#website'},
-        },
-        {
-            '@type': 'BreadcrumbList',
-            'itemListElement': [
-                {'@type': 'ListItem', 'position': 1,
-                 'name': site['name'], 'item': site['domain']},
-                {'@type': 'ListItem', 'position': 2,
-                 'name': to_text(roadmap['nav']), 'item': url},
-            ],
         },
     ]
     return dumps_ld(graph)

--- a/config/planned.toml
+++ b/config/planned.toml
@@ -20,6 +20,7 @@
 note = "Not built yet. Listed so you can see where this is going."
 
 [[group]]
+id = "images"
 name = "Images"
 items = [
   ["Resize", "one image or a whole folder, by pixels or by percent"],
@@ -36,6 +37,7 @@ items = [
 ]
 
 [[group]]
+id = "gif"
 name = "GIF &amp; animation"
 items = [
   ["GIF maker", "images into an animated GIF"],
@@ -51,6 +53,7 @@ items = [
 ]
 
 [[group]]
+id = "video"
 name = "Video"
 items = [
   ["Resize", "down to a size that will actually send"],
@@ -64,6 +67,7 @@ items = [
 ]
 
 [[group]]
+id = "audio"
 name = "Audio"
 items = [
   ["Trim", "keep the part you wanted"],
@@ -75,6 +79,7 @@ items = [
 ]
 
 [[group]]
+id = "documents"
 name = "Documents &amp; PDF"
 items = [
   ["Merge, split &amp; reorder", "pages moved around without a round trip to a server"],
@@ -83,6 +88,7 @@ items = [
 ]
 
 [[group]]
+id = "beyond"
 name = "Beyond media"
 items = [
   ["Text &amp; code", "format, diff, encode, convert between formats"],

--- a/config/site.toml
+++ b/config/site.toml
@@ -268,16 +268,12 @@ intro = """
       gaps below are gaps on purpose.
     </p>
     <p>
-      Nothing here is a link until it exists. When a tool ships it moves out of
-      this list and into the one at the foot of the page.
+      The tools that already exist sit at the top of their group, marked
+      <em>Built</em> and linked to their own page. Everything under them is
+      still to come, and nothing is a link until it is.
     </p>"""
 
-planned_heading = "Planned"
-
-built_heading = "Already built"
-built_note = """
-      Each one has its own page, and every page on this site links to all of
-      them from the footer."""
+planned_heading = "Every kind of file, and what can be done to it"
 
 og_title = "abox.tools roadmap"
 og_description = "What is built, and what is next. Everything runs in your browser and uploads nothing."

--- a/shared/site.css
+++ b/shared/site.css
@@ -12,6 +12,10 @@
   --accent: #2b6cb0;
   --accent-deep: #1d4f83;
   --accent-pale: #d7e7f7;
+  /* Green means "this is true" across the site: the pledge ticks on a tool page
+     use it, and so does the Built tag on the roadmap. Same values as
+     shared/css/tool-frame.css, which defines it for the tool pages. */
+  --ok: #1f7a4d;
   --radius: 10px;
   --shadow: 0 1px 2px rgb(16 24 40 / 6%), 0 4px 12px rgb(16 24 40 / 4%);
 }
@@ -27,6 +31,7 @@
     --accent: #5b9bd8;
     --accent-deep: #3772ab;
     --accent-pale: #cfe3f8;
+    --ok: #6cc79b;
     --shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 4px 12px rgb(0 0 0 / 20%);
   }
 }
@@ -281,31 +286,28 @@ code {
 .p-name { font-weight: 600; color: var(--text); }
 .p-desc { color: var(--text-dim); }
 
-/* The built half, deliberately quiet. Every one of these already has a card on
-   the hub and a link in the footer of every page; repeating them here at that
-   weight made the roadmap look like a second front page and pushed the part
-   somebody came to read below the fold. */
+/* A tool that exists, at the top of its group. It is the same row as the ones
+   below it - same size, same rhythm - because the point of putting the two in
+   one list is that a group reads as one story. What separates them is that this
+   one is a link and carries a tag; that is enough, and a heavier treatment
+   would just rebuild the two-lists-in-two-places problem inside one list. */
 
-.built-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.05rem;
+.plan-list li.is-built { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0 0.4rem; }
+.plan-list li.is-built a { font-weight: 600; text-decoration: none; }
+.plan-list li.is-built a:hover { text-decoration: underline; }
+
+.built-tag {
+  flex: none;
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.1rem 0.4rem;
+  border-radius: 99px;
+  color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ok) 35%, transparent);
 }
-
-.built-list li {
-  margin: 0;
-  padding: 0.45rem 0;
-  border-bottom: 1px solid var(--border);
-  font-size: 0.92rem;
-  line-height: 1.5;
-}
-
-.built-list li:last-child { border-bottom: 0; }
-.built-list a { font-weight: 600; text-decoration: none; }
-.built-list a:hover { text-decoration: underline; }
-.b-desc { color: var(--text-dim); }
 
 /* ---- legal pages ------------------------------------------------------- */
 

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -69,12 +69,13 @@
 </head>
 <body>
 
-<nav class="crumbs" aria-label="Breadcrumb">
-  <a href="{{ base }}">All tools</a>
-  <span aria-hidden="true">&rsaquo;</span>
-  <span aria-current="page">{{ site.roadmap.nav }}</span>
-</nav>
-
+<!--
+  No breadcrumb here, deliberately. The header underneath already carries the
+  brand as a link back to the hub, so a trail above it was the same journey
+  written twice - and the BreadcrumbList that used to describe it has gone from
+  the structured data with it, because markup is meant to describe what a
+  visitor can actually see.
+-->
 <header class="hub-head">
   <p class="brand">
     <a class="brand-home" href="{{ base }}">
@@ -112,14 +113,20 @@
 
   <!--
     ==========================================================================
-    THE PLANNED LIST - the substance of this page, and first for that reason.
+    THE LIST - every kind of file this site works on, in one place.
 
-    Written as plain text on purpose. A name that links nowhere reads as a
-    broken page rather than an honest one, so nothing here is a link until it
-    ships. Move a name out of config/planned.toml when the tool actually
-    exists, and add its folder to tools/ at the same time - it will leave this
-    list and join the one below it, and appear on the hub, in every footer and
-    in the sitemap, without anybody editing this template.
+    Each group holds the tools that exist for that kind of file, as links and
+    marked Built, and under them the ones still to come as plain text. A name
+    that links nowhere reads as a broken page rather than an honest one, so
+    nothing is a link until it ships.
+
+    When a tool ships: add its folder to tools/, give it a `roadmap_group`
+    naming the group it belongs to, and take its name out of
+    config/planned.toml. It crosses from the bottom half of that group to the
+    top of it, and appears on the hub, in every footer and in the sitemap,
+    without anybody editing this template. A tool with no roadmap_group, or one
+    naming a group that does not exist, fails the build rather than quietly
+    going missing from this page.
     ==========================================================================
   -->
   <section id="planned" aria-labelledby="planned-h">
@@ -129,27 +136,11 @@
     <div class="plan-group">
       <h3>{{ group.name }}</h3>
       <ul class="plan-list">
-{% for item in group.items %}        <li><span class="p-name">{{ item.name }}</span> <span class="p-desc">&mdash; {{ item.desc }}</span></li>
+{% for tool in group.built %}        <li class="is-built"><a href="{{ base }}{{ tool.slug }}/">{{ tool.name | e }}</a> <span class="p-desc">&mdash; {{ tool.tagline }}</span> <span class="built-tag">Built</span></li>
+{% endfor %}{% for item in group.items %}        <li><span class="p-name">{{ item.name }}</span> <span class="p-desc">&mdash; {{ item.desc }}</span></li>
 {% endfor %}      </ul>
     </div>
 {% endfor %}  </section>
-
-  <!--
-    The built half, and deliberately quiet. Every one of these already has a
-    card on the hub and a link in the footer of every page; giving them the same
-    weight again here made the roadmap look like a second front page and pushed
-    the list above - the part somebody actually came for - below the fold.
-
-    Still real links, so this page is not a dead end and still spreads crawl
-    depth across every tool.
-  -->
-  <section id="built" aria-labelledby="built-h">
-    <h2 id="built-h">{{ site.roadmap.built_heading }}</h2>
-    <p>{{ site.roadmap.built_note }}</p>
-    <ul class="built-list">
-{% for tool in tools %}      <li><a href="{{ base }}{{ tool.slug }}/">{{ tool.name | e }}</a> <span class="b-desc">&mdash; {{ tool.tagline }}</span></li>
-{% endfor %}    </ul>
-  </section>
 
 </main>
 

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -16,6 +16,9 @@ tagline = "Name the size. It works out the rest."
 icon = "&#128476;&#65039;"          # the mark beside the page heading
 favicon = "&#128476;"      # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that

--- a/tools/compress-pdf/tool.toml
+++ b/tools/compress-pdf/tool.toml
@@ -16,6 +16,9 @@ tagline = "Shrink a document without sending it anywhere."
 icon = "&#128200;"                  # the page mark beside the heading
 favicon = "&#128200;"      # the tab icon, drawn into an inline SVG
 category = "documents-and-pdf"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "documents"
 
 js_parts = ["file-picker"]
 lastmod = "2026-08-20"

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -16,6 +16,9 @@ tagline = "Cut a clip down to the part that matters."
 icon = "&#9986;&#65039;"          # the mark beside the page heading
 favicon = "&#9986;"      # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "video"
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/exif-editor/tool.toml
+++ b/tools/exif-editor/tool.toml
@@ -16,6 +16,9 @@ tagline = "See what a photo says about you. Then take it out."
 icon = "&#127991;&#65039;"          # the mark beside the page heading
 favicon = "&#127991;"      # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that

--- a/tools/images-to-pdf/tool.toml
+++ b/tools/images-to-pdf/tool.toml
@@ -16,6 +16,9 @@ tagline = "Put your pictures into one document."
 icon = "&#128196;"                  # the page mark beside the heading
 favicon = "&#128196;"      # the tab icon, drawn into an inline SVG
 category = "documents-and-pdf"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "documents"
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -16,6 +16,9 @@ tagline = "Turn a folder of images into a video."
 icon = "&#127902;&#65039;"          # the mark beside the page heading
 favicon = "&#127902;"      # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "video"
 
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -16,6 +16,9 @@ tagline = "Keep the part that matters, without losing a single byte of it."
 icon = "&#127902;&#65039;"        # the mark beside the page heading
 favicon = "&#127902;"     # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "video"
 
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.


### PR DESCRIPTION
Both changes from the screenshot.

## The breadcrumb is gone

`All tools › Roadmap` was the first thing on the page, above the heading somebody came to read — and the header directly under it already carries the brand as a link back to the hub. The same journey, written twice.

The `BreadcrumbList` in the structured data went with it. Markup is meant to describe what a visitor can see, and leaving the schema behind would have recreated exactly the mismatch this site fixed on the tool pages.

## Built tools now live in the planned list

Two lists meant a reader had to hold them together in their head: the plan up here, the seven that exist down there, and the work of matching "Video Cropper" to "Crop" left to them.

Now each group holds the whole story for its kind of file — tools that exist at the top as links, marked **Built**, and the ones still to come underneath:

| Group | Built | Planned |
|---|---|---|
| Images | EXIF Viewer & Remover, Image Compressor | 11 |
| GIF & animation | — | 10 |
| Video | Images to Video, Video Trimmer, Video Cropper | 8 |
| Audio | — | 6 |
| Documents & PDF | PDF Compressor, Images to PDF | 3 |
| Beyond media | — | 4 |

**Where each tool goes is a judgement call, and an easy one to change** — it is one line in each `tool.toml`. Say the word if any of them belongs somewhere else.

## How it holds together

A tool declares its group in `roadmap_group`, against ids now on the groups in `config/planned.toml`. Same bargain the hub already makes with `category`: the tool declares, the build places, nothing written down twice.

A tool with no `roadmap_group`, or one naming a group that does not exist, **fails the build** with the list of valid ids rather than quietly going missing from the page:

```
build failed: compress-image: roadmap_group is 'nonsense', which is not a group
in config/planned.toml. Name one of: images, gif, video, audio, documents, beyond
```

(Verified by breaking it on purpose, then putting it back.)

A built row is the same row as the ones under it — same size, same rhythm — because the point of one list is that the group reads as one story. It is a link and it carries a tag; that is enough. Anything heavier would rebuild the two-lists problem inside one list.

`site.css` gains `--ok`, the green already used for the pledge ticks on tool pages, so "this is true" is one colour across the site rather than two.

## Checks

- `python build.py --out _site --clean` → 14 pages, exit 0
- `python -m unittest discover -t . -s tests/python` → **250 tests, OK**
- All 7 tools land in a group, built-first in each; 42 planned unchanged; 7 `Built` tags
- No `nav.crumbs`, no `BreadcrumbList`; JSON-LD is `CollectionPage` only, still valid
- Row heights even at 35–36px whether built or planned
- Every internal link resolves
- No horizontal overflow at 375px or 1280px, light and dark; the tag resolves green in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)
