### PR TITLE
Retitle images-to-video around the sequence it is usually given

### DIFF
--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -28,10 +28,10 @@ lastmod = "2026-08-19"
 
 # --- what search engines and chat apps are told ------------------------------
 
-title = "Images to Video Converter &mdash; Free MP4 Slideshow Maker"
+title = "Image Sequence to MP4 &mdash; Free, No Upload, Works Offline"
 description = "Turn JPG, PNG or WebP images into an MP4 slideshow video, free and entirely in your browser. Nothing is uploaded, no sign-up, and it works offline."
-og_title = "Images to Video &mdash; free MP4 slideshow maker"
-og_description = "Turn a folder of images into an MP4 slideshow. Encoding runs on your own machine; nothing is uploaded."
+og_title = "Image Sequence to MP4 &mdash; free, in your browser"
+og_description = "Turn a render sequence, a timelapse or a folder of photos into an MP4. Encoding runs on your own machine; nothing is uploaded."
 og_image_alt = "Images to Video - turn a folder of images into an MP4 slideshow"
 
 # Appended to the Content-Security-Policy comment in the generated page, for
@@ -205,6 +205,33 @@ a = """
         MP4 with H.264 video, which plays on essentially anything. In a browser
         without WebCodecs the tool falls back to recording WebM instead &mdash;
         the same footage in a container that fewer editors accept."""
+
+[[faq]]
+q = "Can I use this for a Blender or After Effects render sequence?"
+a = """
+        Yes &mdash; a numbered render sequence is exactly what this is for. Add
+        the frames your renderer wrote, leave the hold time at one frame each,
+        and set the frame rate to match the render. "Sort by name" counts the
+        way you would expect, so <code>frame_2</code> lands before
+        <code>frame_10</code> rather than after it.
+        <br><br>
+        One thing worth knowing before you start: H.264 has no alpha channel,
+        so transparency is flattened onto the backdrop colour rather than
+        carried through. If you need to keep the alpha, composite the frames in
+        your editor instead."""
+
+[[faq]]
+q = "Can I make a timelapse from photos?"
+a = """
+        Yes, and it is the same job as a render sequence: hold each photo for a
+        single frame and pick a frame rate. At 30 fps every thirty photos
+        becomes one second of video; at 12 fps those same photos run for two
+        and a half seconds.
+        <br><br>
+        "Sort by date" puts a camera roll back into the order it was shot,
+        which matters when the filenames have restarted at 0001. Photos of
+        different sizes are fine &mdash; "Match highest resolution" sizes the
+        video so that none of them is scaled down."""
 
 [[faq]]
 q = "Is there a limit on how many images, or how long the video can be?"


### PR DESCRIPTION
The page was titled *"Images to Video Converter — Free MP4 Slideshow Maker"*, which describes a holiday photo slideshow. A good share of the people who want this tool arrive with a numbered render sequence out of Blender or After Effects, or a folder of timelapse frames — and none of them are searching for a slideshow maker.

Everything here is one file: `tools/images-to-video/tool.toml`.

## Title

```
Image Sequence to MP4 — Free, No Upload, Works Offline
```

54 characters, so it survives Google’s truncation intact, and the two differentiators that are actually rare among the alternatives are in it. `og_title` and `og_description` follow the same framing, and the description now names the three things people arrive with rather than only the slideshow.

## Two new FAQs

**"Can I use this for a Blender or After Effects render sequence?"** and **"Can I make a timelapse from photos?"** — both were already true, neither was written down anywhere a search engine could see it. They render twice: as the `<details>` blocks at the foot of the page and as `FAQPage` structured data, from the same source.

Each claim was checked against the code rather than written from memory:

| Claim | Where it comes from |
|---|---|
| `frame_2` sorts before `frame_10` | `Intl.Collator(…, { numeric: true })` in `src/images.js` |
| One frame per image by default | `durationUnit = frames` in `src/main.js` |
| Transparency is flattened | `alpha: discard` in `src/encoder.js`, canvas is `{ alpha: false }` |
| Mixed sizes are not downscaled | widest-width × tallest-height rule in `src/compose.js` |
| 30 photos at 30 fps = 1s, at 12 fps = 2.5s | measured end-to-end against a real decoder |

The render-sequence answer carries the alpha warning deliberately: H.264 has no alpha channel, and that is worth knowing before a long export rather than after one.

## Deliberately unchanged

The tool’s `name`, `heading` and OG image still read "Images to Video". The name is the product, and `og-image.ps1` draws those exact words into the card — so `og_image_alt` still describes what a reader would actually see. Regenerating the image to match the new framing is a separate call.

`description` (the search snippet) also still says "slideshow". Happy to realign it too if you want the whole set moved.

## Checks

- Build clean, 14 pages
- FAQ JSON-LD parses; the `<br><br>` paragraph breaks collapse to single spaces in the schema text rather than running sentences together
- 250 Python tests pass
- JS tests need Node, which is not installed locally — those run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)