### PR TITLE
Give the image resizer the roadmap group the build now requires

### DIFF
--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -16,6 +16,9 @@ tagline = "Say the size. Draw the box. Pick the format."
 icon = "&#128208;"          # the mark beside the page heading
 favicon = "&#128208;"       # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that


### PR DESCRIPTION
`main` is red. This fixes it.

## What happened

[#25](https://github.com/A-Box-of-Tools/website/pull/25) made `roadmap_group` required of every tool, so a built tool appears at the top of the roadmap group it belongs to and the build refuses rather than quietly leaving one off. [#24](https://github.com/A-Box-of-Tools/website/pull/24) was written before that landed and merged after it.

The two touched no common line, so git merged them cleanly — and the result does not build:

```
resize-image: no roadmap_group, so it would appear nowhere on the roadmap.
Name one of: images, gif, video, audio, documents, beyond
```

Which is #25's own error message doing its job. The failure is in `tests/python/test_build.py`, in the two whole-build cases — the pair that exists to notice a page that stopped being written at all.

## The fix

`roadmap_group = "images"`, beside the compressor and the EXIF tool. Three lines, comment included, matching the other seven tools.

The roadmap's Images group now opens with the three built tools in hub order:

> **EXIF Viewer & Remover** — See what a photo says about you. Then take it out. `Built`
> **Image Resizer** — Say the size. Draw the box. Pick the format. `Built`
> **Image Compressor** — Name the size. It works out the rest. `Built`
> Rotate & flip — quarter turns, or straightening by a few degrees
> …

## Checks

- `python build.py` clean, 15 pages; `--mangle` clean at the pinned esbuild 0.25.0.
- 250 Python tests pass (was 232 run / 2 errors).
- 534 JS tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)