### PR TITLE
Give resize-image the roadmap group the build now requires

### DIFF
--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -16,6 +16,9 @@ tagline = "Say the size. Draw the box. Pick the format."
 icon = "&#128208;"          # the mark beside the page heading
 favicon = "&#128208;"       # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that


### PR DESCRIPTION
`main` does not currently build.

```
ConfigError: resize-image: no roadmap_group, so it would appear nowhere on the
roadmap. Name one of: images, gif, video, audio, documents, beyond
```

Every tool has to name a `roadmap_group` since #25. `resize-image` arrived in #24 without one, so `build.py` raises before it writes a page — which fails the build, the test suite, and the CI of every open PR, since they are all tested against the merge result.

## Neither PR was wrong on its own

#24 was branched **before** #25 introduced the requirement, so the field did not exist to add. Its own CI passed for the same reason. Merging it after #25 is what broke `main` — a merge-order collision rather than a mistake in either change. Nothing on #24 could have caught it.

## The fix

One field, matching how its siblings are configured:

```toml
roadmap_group = "images"
```

`compress-image` and `exif-editor` are both `category = "images-and-video"` and both sit in `images`. The Images group in `config/planned.toml` lists no resizer among the names still to be built, so this adds the link without the tool appearing as planned and built at the same time.

## Verified

- `python build.py` completes — 15 pages
- `python -m unittest discover -t . -s tests/python` — **250 passed**. CI last reported 232 run with 2 errors, because the errors aborted two whole test classes at `setUpClass`
- The roadmap lists **Image Resizer** exactly once, in **Images**, next to EXIF Viewer & Remover and Image Compressor

Worth merging before #26, which is only red because it inherits this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)