### PR TITLE
Add a guides index, and a guide for every tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ tools/
     src/*.js             the app itself; minified into dist/, renamed only by --mangle
     og.png               its share card
   crop-video/            the same five things
+  trim-video/            and again
   exif-editor/           and again
+  resize-image/          and again
   images-to-video/       and again
   images-to-pdf/         and again
   compress-pdf/          and again
@@ -182,6 +184,7 @@ pages/
     page.toml            title, description, dates - the frame, not the prose
     body.html            the <main> of the page
   terms/                 the same two things
+  guides/<slug>/         the same two things, plus a group and usually a tool
 tests/
   python/                the generator: unittest, standard library only
   js/                    the tools: node --test, built in since Node 18
@@ -296,12 +299,15 @@ something the build does, and cannot forget to do:
 | Four copies of the repository URL per page | `source_url` in `config/site.toml`. |
 | A cache name to bump by hand when minification changed the bytes | The cache name hashes the files **as emitted**, so turning minifying on or off invalidates the cache by itself. |
 | Nothing at all, which is how a stylesheet change reached returning visitors four hours late | Every page asks for its stylesheet by a URL carrying a hash of that stylesheet, so changing the CSS changes the URL and there is no stale copy to serve. |
-| Three different footers, none of which linked to a privacy policy because there was nowhere to put one | One `templates/partials/footer.html`. Its tool list and legal-page list come from `tools/` and `pages/`, and the only thing that differs per page is whether links start `./` or `../`. |
+| Three different footers, none of which linked to a privacy policy because there was nowhere to put one | One `templates/partials/footer.html`. Its tool list, guide list and legal-page list come from `tools/` and `pages/`, and the only thing that differs per page is whether links start `./` or `../`. |
 
 The build refuses to produce a site rather than produce a broken one. A missing
 config key, a tool whose folder and `slug` disagree, a tool listed on the hub
 that does not exist, and a tool that exists but is on no category list — so
-nothing would link to it — are all errors, not warnings.
+nothing would link to it — are all errors, not warnings. The guides index makes
+the same three checks about guides and groups, and one more: a guide naming a
+tool that does not exist, or a second guide claiming a tool that already has
+one.
 
 ---
 
@@ -321,6 +327,11 @@ nothing would link to it — are all errors, not warnings.
    and writes nothing.
 4. If it belongs to a category that does not exist yet, add a
    `[[hub.categories]]` table and move that name out of `config/planned.toml`.
+5. Set `roadmap_group` to one of the groups in `config/planned.toml`, so the
+   tool crosses from the planned half of that group to the built half. A tool
+   without one fails the build rather than quietly going missing.
+6. Write it a guide. See [The guides](#the-guides) — one folder under
+   `pages/guides/`, and the link between the two pages is a single `tool` key.
 
    You do **not** have to touch the footer, the sitemap, or the other pages. The
    footer's tool list is derived from `tools/` in the order the hub shows them,
@@ -444,23 +455,35 @@ Two things to hold the line on, because the whole site rests on them:
 
 ---
 
-## The legal pages
+## The prose pages
 
-`pages/` holds the prose pages that are neither the hub nor a tool: Privacy and
-Terms. One is built exactly like a tool page, minus everything a tool needs and
-a page does not.
+`pages/` holds everything that is neither the hub nor a tool. There are two
+kinds, and they differ only in where they are meant to be read.
 
 ```
-pages/privacy/
+pages/privacy/                      kind = "legal"
   page.toml    slug, nav label, title, description, dates, share-card text
   body.html    the <main> - sections of prose and nothing else
+pages/guides/trim-a-video/          kind = "guide"
+  page.toml    the same, plus `published`, `group`, and usually `tool`
+  body.html    the same
 ```
 
-`nav` is the label the footer uses. The page gets the site frame, the site's
-Content-Security-Policy unchanged, an entry in `sitemap.xml` at a low priority,
-and a link in the footer of every page on the site. It gets no service worker,
-because there is nothing here worth keeping offline, and no `blob:` in
-`img-src`, because it never makes one.
+`nav` is the label the footer uses. Either kind gets the site frame, the site's
+Content-Security-Policy unchanged, an entry in `sitemap.xml`, and a link in the
+footer of every page on the site. Neither gets a service worker, because there
+is nothing here worth keeping offline, or `blob:` in `img-src`, because neither
+ever makes one.
+
+A **legal** page is Privacy or Terms. It matters for trust rather than for
+search, which is why it sits at the lowest priority the sitemap has and carries
+no structured data at all — inventing an `Article` for a privacy policy would be
+describing the page as something it is not.
+
+A **guide** is written to be found. Same frame, same policy, and three things a
+legal page does not get: `Article` structured data, a breadcrumb through the
+guides index (visible as well as in the markup, which is the rule Google asks
+for), and — when it names a tool — a link to that tool under the heading.
 
 **These pages get the same CSP as everywhere else, and that is the point.**
 Written by hand, they carried a narrowed copy that left out the donate button's
@@ -491,6 +514,59 @@ Two things it does **not** claim, deliberately:
   laws of Canada and of the province in which the site is operated". Naming the
   province outright is one line in `pages/terms/body.html` and makes the clause
   easier to rely on; it was left open rather than guessed at.
+
+---
+
+## The guides
+
+Every tool has one, and there is an index of them at `/guides/`. A tool page
+answers "which button do I press"; a guide answers "what does the setting I am
+about to move actually do, and what does it cost me". They are also the half of
+the site that can be found by somebody who does not yet know it exists.
+
+### Adding one
+
+Make a folder under `pages/guides/`, and set four things in its `page.toml` that
+a legal page does not have:
+
+| key | what it does |
+|---|---|
+| `kind = "guide"` | `Article` structured data, a breadcrumb, `prose` styling |
+| `published` | the date the guide first appeared, for the `Article` |
+| `group` | which `[[guides.groups]]` in `config/site.toml` it appears under |
+| `tool` | optional: the slug of the tool it is about |
+
+Then name the folder in that group's `order` list. Everything else follows: the
+card on the index, the entry in the footer of every page, the line in
+`sitemap.xml`, and both halves of the link between the guide and its tool.
+
+### The three refusals
+
+The build stops rather than quietly producing a page nothing links to. A guide
+that names no `group`, a group that lists a guide that does not exist, and a
+guide that exists and that no group lists are each an error with a message
+naming the file. They are the same three checks `build_hub` already makes about
+tools and categories, and they matter slightly more here: a tool missing from
+the hub would be noticed the first time anybody looked at the front page, while
+a guide that fell out of the index is only ever missed by the reader who never
+found it.
+
+`tool` is checked too — it has to name a tool that exists, and two guides cannot
+claim the same one, because a tool page has room for exactly one link.
+
+### Why the link between a guide and its tool is one setting
+
+`tool` in the guide's `page.toml` produces both directions: the "Open the …"
+button under the guide's lede, and "The longer version" under the tool's
+questions. Written the other way round — a `guide` key in each `tool.toml` —
+it would be two settings that could disagree about which page is about which,
+and the way that shows up in public is a tool linking to a guide that never
+mentions it. `tests/python/test_build.py` checks both halves land in the built
+HTML.
+
+Neither link's text is written twice either. The tool page shows the guide's own
+`heading` and `description`; the guide shows the tool's own `name` and
+`tagline`. So neither page can promise something the other does not deliver.
 
 ---
 

--- a/build.py
+++ b/build.py
@@ -144,9 +144,21 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     guides = [page for page in prose if page['kind'] == 'guide']
     legal = [page for page in prose if page['kind'] == 'legal']
 
+    # The guides, grouped and in the order config/site.toml puts them in, and
+    # every check that says the grouping is complete. Done here rather than
+    # inside build_guides because the footer needs the same order, and an order
+    # worked out twice is an order that can differ.
+    groups = guide_groups(site, guides)
+    ordered_guides = [guide for group in groups for guide in group['guides']]
+
+    # Which guide belongs to which tool, so that a tool page can link to its
+    # guide and the guide back to the tool. The owning line is `tool` in the
+    # guide's page.toml - one place, both directions.
+    guide_of = tie_guides_to_tools(ordered_guides, by_slug)
+
     # What the footer on every page is built from. Derived from the folders that
-    # exist rather than written down anywhere, so a new tool or a new legal page
-    # reaches every footer on the site without a second edit.
+    # exist rather than written down anywhere, so a new tool, a new guide or a
+    # new legal page reaches every footer on the site without a second edit.
     # Tools in the order the hub shows them, not the order the folders happen to
     # sort in, so the footer and the cards above it agree. A slug named here that
     # has no tool, or a tool named nowhere, is caught by build_hub below.
@@ -155,18 +167,23 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
                for slug in category['order'] if slug in by_slug]
     footer = {
         'tools': [{'name': tool['name'], 'slug': tool['slug']} for tool in ordered],
-        'guides': [{'nav': page['nav'], 'slug': page['slug']} for page in guides],
+        'guides': [{'nav': page['nav'], 'slug': page['slug']}
+                   for page in ordered_guides],
         'pages': [{'nav': page['nav'], 'slug': page['slug']} for page in legal],
     }
 
     written = []
     for tool in tools:
-        build_tool(out, templates, site, tool, footer, emit)
+        build_tool(out, templates, site, tool, footer,
+                   guide_of.get(tool['slug'], {}), emit)
         written.append(f'{tool["slug"]}/index.html')
 
     for page in prose:
-        build_page(out, templates, site, page, footer, css_v, emit)
+        build_page(out, templates, site, page, footer, css_v, by_slug, emit)
         written.append(f'{page["slug"]}/index.html')
+
+    build_guides(out, templates, site, groups, ordered_guides, footer, css_v, emit)
+    written.append(f'{site["guides"]["slug"]}/index.html')
 
     build_hub(out, templates, site, by_slug, footer, css_v, emit)
     written.append('index.html')
@@ -180,7 +197,7 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     # After the sitemap and deliberately not passed to it: the 404 has no
     # address of its own to list, and inviting a crawler to index it would be
     # inviting it to serve "not found" in place of a real page.
-    build_sitemap(out, templates, site, tools, guides, legal)
+    build_sitemap(out, templates, site, tools, ordered_guides, legal)
     written.append('sitemap.xml')
 
     copy_shared(out)
@@ -189,10 +206,116 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
 
 
 # ---------------------------------------------------------------------------
+# The guides, and how they are tied to the tools
+
+
+def guide_groups(site, guides):
+    """The guides, in the groups and the order config/site.toml gives them.
+
+    Three things are checked, and each of them is a way a guide could end up
+    written and then linked to from nowhere:
+
+      * a guide naming a group that does not exist;
+      * a group listing a guide that does not exist;
+      * a guide that exists and that no group lists.
+
+    The same three the hub already makes about tools and categories. A page
+    nothing links to is a page that might as well not have been written, and
+    the point of checking here is that the build says so rather than the
+    silence of a missing card.
+    """
+    by_name = {guide['slug'].rsplit('/', 1)[-1]: guide for guide in guides}
+    groups, listed = [], set()
+    for group in site['guides']['groups']:
+        chosen = []
+        for name in group['order']:
+            if name not in by_name:
+                raise sitelib.ConfigError(
+                    f'config/site.toml lists {name!r} in guide group '
+                    f'{group["id"]!r}, but there is no '
+                    f'pages/{site["guides"]["slug"]}/{name}/page.toml')
+            guide = by_name[name]
+            if guide['group'] != group['id']:
+                raise sitelib.ConfigError(
+                    f'{guide["slug"]} says group = {guide["group"]!r} but is listed '
+                    f'under {group["id"]!r} in config/site.toml')
+            chosen.append(guide)
+            listed.add(name)
+        groups.append({**group, 'guides': chosen})
+
+    stray = sorted(set(by_name) - listed)
+    if stray:
+        raise sitelib.ConfigError(
+            'these guides exist but are not listed in any [[guides.groups]] order, '
+            f'so nothing would link to them: {", ".join(stray)}')
+    return groups
+
+
+def tie_guides_to_tools(guides, by_slug):
+    """Map a tool's slug to the guide about it, from the guides' own `tool`.
+
+    One line in one file makes both links: the guide gets a link to the tool
+    under its heading, and the tool gets a link to the guide under its
+    questions. Written the other way round - a `guide` key in each tool.toml -
+    it would be two lines that could disagree about which page is about which.
+
+    A slug that names no tool is an error, because it is a link to a page that
+    is not there. Two guides claiming one tool is an error as well: the tool
+    page has room for one, so the second would be written and never linked.
+    """
+    owned = {}
+    for guide in guides:
+        slug = guide['tool']
+        if not slug:
+            continue
+        if slug not in by_slug:
+            raise sitelib.ConfigError(
+                f'{guide["slug"]}: tool is {slug!r}, but there is no '
+                f'tools/{slug}/tool.toml')
+        if slug in owned:
+            raise sitelib.ConfigError(
+                f'{guide["slug"]} and {owned[slug]["slug"]} both say they are the '
+                f'guide for {slug}, and a tool page links to one guide')
+        owned[slug] = guide
+    return owned
+
+
+def build_guides(out, templates, site, groups, guides, footer, css_v, emit):
+    """The index of the written half of the site.
+
+    Built like the roadmap and for the same reason: it is a frame around a list
+    that lives somewhere else. Nothing on the page is written in the template or
+    in config/site.toml except the grouping - every card is a guide's own
+    heading and description, the two strings that also draw that guide's <h1>
+    and its <meta name="description">, so the index cannot promise something the
+    guide does not deliver.
+    """
+    dest = out / site['guides']['slug']
+    dest.mkdir(parents=True, exist_ok=True)
+
+    emit.html(dest / 'index.html', templates.render('guides.html', {
+        'site': site,
+        'groups': groups,
+        'guide_count': len(guides),
+        'guide_noun': 'guide' if len(guides) == 1 else 'guides',
+        'footer': footer,
+        'base': '../',
+        'css_href': f'../site.css?v={css_v}',
+        'csp': sitelib.render_csp(site['csp']),
+        'jsonld': sitelib.guides_jsonld(site, guides),
+    }))
+
+    emit.js(dest / 'analytics.js', templates.render('analytics.js', {
+        'site': site,
+        'words': {'plural': 'files', 'analytics_extra': ''},
+    }), where=f'{site["guides"]["slug"]}/analytics.js')
+
+
+# ---------------------------------------------------------------------------
 # One tool
 
 
-def build_tool(out, templates, site, tool, footer, emit):
+def build_tool(out, templates, site, tool, footer, guide, emit):
     dest = out / tool['slug']
     dest.mkdir(parents=True, exist_ok=True)
 
@@ -254,6 +377,7 @@ def build_tool(out, templates, site, tool, footer, emit):
     emit.html(dest / 'index.html', templates.render('tool.html', {
         'site': site,
         'tool': tool,
+        'guide': guide,
         'footer': footer,
         'base': '../',
         'csp': sitelib.render_csp(site['csp'], site.get('tool_csp', {}),
@@ -335,7 +459,7 @@ def tool_css(tool):
 # One prose page (a legal page or a guide)
 
 
-def build_page(out, templates, site, page, footer, css_v, emit):
+def build_page(out, templates, site, page, footer, css_v, by_slug, emit):
     """A prose page: the site frame around a body.html, and nothing else.
 
     No service worker, because there is nothing here worth keeping offline, and
@@ -345,7 +469,13 @@ def build_page(out, templates, site, page, footer, css_v, emit):
     argument by making it impossible to have.
 
     `up` is how the frame climbs back to the root. A legal page sits one level
-    down and a guide two, and neither template should have to know which."""
+    down and a guide two, and neither template should have to know which.
+
+    A guide gets two things a legal page does not, and both are worked out here
+    rather than tested for in markup: a breadcrumb through the guides index -
+    the visible half of the trail the structured data describes - and, when it
+    names a tool, the tool itself, so the page can offer a way to go and use the
+    thing it has just spent two thousand words explaining."""
     dest = out / page['slug']
     dest.mkdir(parents=True, exist_ok=True)
 
@@ -355,9 +485,20 @@ def build_page(out, templates, site, page, footer, css_v, emit):
 
     up = '../' * page['depth']
 
+    crumbs = []
+    if page['kind'] == 'guide':
+        crumbs = [
+            {'name': 'All tools', 'href': up},
+            {'name': site['guides']['heading'],
+             'href': f'{up}{site["guides"]["slug"]}/'},
+        ]
+
     emit.html(dest / 'index.html', templates.render('page.html', {
         'site': site,
         'page': page,
+        'tool': by_slug.get(page['tool'], {}),
+        'crumbs': crumbs,
+        'main_class': 'prose' if page['kind'] == 'guide' else 'legal',
         'footer': footer,
         'base': up,
         'css_href': f'{up}site.css?v={css_v}',
@@ -514,7 +655,12 @@ def build_sitemap(out, templates, site, tools, guides, legal):
     pages += [{'url': tool['url'], 'lastmod': tool['lastmod'],
                'changefreq': 'monthly', 'priority': '0.8'} for tool in tools]
     # Guides below the tools and above the legal pages. A tool is what somebody
-    # came for; a guide is how they find out this site exists.
+    # came for; a guide is how they find out this site exists. The index they
+    # are listed on goes first and slightly higher: it is the page that gains
+    # from being crawled as a set rather than as nine unrelated articles.
+    pages.append({'url': f'{site["domain"]}{site["guides"]["slug"]}/',
+                  'lastmod': site['guides']['lastmod'],
+                  'changefreq': 'monthly', 'priority': '0.7'})
     pages += [{'url': page['url'], 'lastmod': page['lastmod'],
                'changefreq': 'monthly', 'priority': '0.6'} for page in guides]
     # The roadmap: a real page, but not one anybody searches for. Below the

--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -211,11 +211,61 @@ def page_jsonld(site, page):
         },
         {
             '@type': 'BreadcrumbList',
+            # Three steps rather than two, because there are now three: the hub,
+            # the guides index, and this guide. The visible trail at the top of
+            # the page is built from the same list, which is the rule Google
+            # asks for - markup describes what a visitor can see.
             'itemListElement': [
                 {'@type': 'ListItem', 'position': 1,
                  'name': site['name'], 'item': site['domain']},
                 {'@type': 'ListItem', 'position': 2,
+                 'name': to_text(site['guides']['heading']),
+                 'item': f'{site["domain"]}{site["guides"]["slug"]}/'},
+                {'@type': 'ListItem', 'position': 3,
                  'name': to_text(page['nav']), 'item': page['url']},
+            ],
+        },
+    ]
+    return dumps_ld(graph)
+
+
+def guides_jsonld(site, guides):
+    """CollectionPage + ItemList for the guides index.
+
+    An ItemList here and not on the roadmap, and the difference is whether the
+    names can be clicked: every entry below is a page that exists, so listing
+    them is describing the page rather than advertising something that is not
+    built yet.
+    """
+    index_url = f'{site["domain"]}{site["guides"]["slug"]}/'
+    graph = [
+        {
+            '@type': 'CollectionPage',
+            'url': index_url,
+            'name': to_text(site['guides']['heading']),
+            'description': to_text(site['guides']['description']),
+            'inLanguage': site['lang'],
+            'isPartOf': {'@id': site['domain'] + '#website'},
+            'mainEntity': {
+                '@type': 'ItemList',
+                'itemListElement': [
+                    {
+                        '@type': 'ListItem',
+                        'position': position,
+                        'url': guide['url'],
+                        'name': to_text(guide['heading']),
+                    }
+                    for position, guide in enumerate(guides, start=1)
+                ],
+            },
+        },
+        {
+            '@type': 'BreadcrumbList',
+            'itemListElement': [
+                {'@type': 'ListItem', 'position': 1,
+                 'name': site['name'], 'item': site['domain']},
+                {'@type': 'ListItem', 'position': 2,
+                 'name': to_text(site['guides']['heading']), 'item': index_url},
             ],
         },
     ]
@@ -351,6 +401,23 @@ def load_page(path, site, root):
     # silent default would quietly claim the correction was the original.
     if page['kind'] == 'guide' and 'published' not in page:
         raise ConfigError(f'{path}: a guide needs `published`')
+
+    # Which group on the guides index it joins. Required for the same reason a
+    # tool's `roadmap_group` is: a guide that named no group would be built,
+    # sit at a URL, and be linked to from nowhere at all. The group has to
+    # exist, and has to list this guide back; build.py checks both, because it
+    # is the only place that can see every guide at once.
+    if page['kind'] == 'guide' and 'group' not in page:
+        raise ConfigError(
+            f'{path}: a guide needs `group`, naming one of the [[guides.groups]] '
+            'in config/site.toml, or nothing would link to it')
+
+    # Optional, and in practice only a guide sets it: the slug of the tool this
+    # guide is about. It puts a link to the tool on the guide and to the guide on
+    # the tool, from one line rather than two edits that can disagree. A guide
+    # about no tool in particular - "is it safe to upload files" - leaves it
+    # out. build.py checks the slug names a tool that exists.
+    page.setdefault('tool', '')
 
     page['url'] = f'{site["domain"]}{page["slug"]}/'
     page['dir'] = path.parent

--- a/config/site.toml
+++ b/config/site.toml
@@ -281,6 +281,63 @@ og_image_alt = "abox.tools - tools that never touch a server"
 
 #
 # ---------------------------------------------------------------------------
+# The guides index at /guides/.
+#
+# Guides themselves live under pages/guides/<slug>/, one folder each, and the
+# build finds them there - this is only the frame around the list, in exactly
+# the way [roadmap] above is only the frame around config/planned.toml.
+#
+# The one thing written here rather than derived is the grouping and the order
+# within each group, in [[guides.groups]] below. A guide names the group it
+# joins in its own page.toml, and the build refuses to finish if a guide names
+# a group that does not exist, if a group lists a guide that does not exist, or
+# if a guide exists that no group lists - the same three checks the hub makes
+# about tools, and for the same reason: a page nothing links to is a page that
+# might as well not have been written.
+# ---------------------------------------------------------------------------
+#
+
+[guides]
+slug = "guides"
+nav = "All guides"
+lastmod = "2026-08-20"
+
+title = "Guides &mdash; how to do the job, and what each choice costs"
+description = "Plain guides to compressing, resizing, cropping, trimming and converting your own files - what the settings mean, what they cost, and why none of it needs an upload."
+
+heading = "Guides"
+lede = """
+    One guide per tool, written for the person who has been told to hit a size
+    or a shape and would like to know what the setting they are about to move
+    actually does. Everything described here happens on your own machine."""
+
+og_title = "abox.tools guides"
+og_description = "How to compress, resize, crop, trim and convert your own files - and what each setting costs. No uploads involved."
+og_image_alt = "abox.tools - tools that never touch a server"
+
+[[guides.groups]]
+id = "doing-the-job"
+name = "Doing the job"
+note = "One per tool: what the job involves, which setting matters, and what it costs you."
+order = [
+  "compress-an-image-to-a-target-size",
+  "resize-an-image",
+  "remove-exif-and-gps-data",
+  "make-a-pdf-smaller",
+  "combine-images-into-a-pdf",
+  "turn-images-into-a-video",
+  "trim-a-video",
+  "crop-a-video",
+]
+
+[[guides.groups]]
+id = "before-you-upload"
+name = "Before you upload anything"
+note = "What handing a file to a website actually does, and how to tell whether it had to happen."
+order = ["is-it-safe-to-upload-files"]
+
+#
+# ---------------------------------------------------------------------------
 # The footer, which is now the same on every page - hub, tool and legal alike.
 #
 # The tool list and the legal-page list in it are not written here: build.py

--- a/pages/guides/combine-images-into-a-pdf/body.html
+++ b/pages/guides/combine-images-into-a-pdf/body.html
@@ -1,0 +1,196 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      Open <a href="../../images-to-pdf/">Images to PDF</a>, drop the pictures
+      in, drag the tiles until the order is right, and create the document. The
+      defaults &mdash; A4 pages, a small margin, photographs copied in without
+      being re-encoded &mdash; are what most people want.
+    </p>
+    <p>
+      The four things worth a second thought are the order, the page size, the
+      quality setting, and what the finished document says about you. In that
+      order of how often they go wrong.
+    </p>
+  </section>
+
+  <section>
+    <h2>Get the order right before anything else</h2>
+    <p>
+      Page order is the single most common thing to get wrong, because file
+      names sort in ways nobody expects. <code>IMG_2.jpg</code> comes after
+      <code>IMG_10.jpg</code> in an alphabetical sort, since the comparison is
+      character by character and <code>1</code> is before <code>2</code>. A
+      folder of scans named <code>page1</code> to <code>page12</code> will
+      arrive in the wrong order in almost any tool.
+    </p>
+    <p>
+      Sorting by date taken is usually more reliable for photographs, because
+      you photographed the pages in the order they were in. Either way, check
+      the tiles before you press the button rather than checking the PDF
+      afterwards.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quality: the part most tools get wrong quietly</h2>
+    <p>
+      A PDF can carry JPEG data directly. That is a property of the format: the
+      compressed bytes of a JPEG can be dropped into the document as they are,
+      and the reader decodes them the same way a browser would.
+    </p>
+    <p>
+      This matters because it means a photograph does not have to lose anything
+      on the way into a PDF. It is never decoded and never compressed again; the
+      picture in the document is bit for bit the picture in your file. Many
+      tools re-encode anyway &mdash; it is simpler to render everything to a
+      canvas and encode uniformly &mdash; and the result is a generation of
+      quality lost for no reason.
+    </p>
+    <p>
+      Other formats cannot ride along like that. PNG, WebP, HEIC and the rest
+      have no matching filter in PDF, so they have to be converted. You get a
+      choice about how:
+    </p>
+    <ul>
+      <li>
+        <strong>Re-encode as JPEG</strong> (the default). Smallest file, a small
+        quality cost, and the right answer for photographs.
+      </li>
+      <li>
+        <strong>Lossless.</strong> Stores the exact pixels at the cost of a much
+        larger document. The right answer for screenshots, diagrams, and
+        anything with text or sharp edges in it, where JPEG artefacts are
+        obvious.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Page size, and when &ldquo;fit the picture&rdquo; is better</h2>
+    <p>
+      A standard page size &mdash; A4, Letter, Legal, A3, A5, Tabloid &mdash;
+      places each image on a page of that size, scaled to fit inside your
+      margin. Use one when the document is going to be printed, or when somebody
+      official is going to file it.
+    </p>
+    <p>
+      &ldquo;Exactly the size of each picture&rdquo; makes every page match its
+      image, so there is no white space and no scaling at all. Use it when the
+      PDF is a container for pictures rather than a document: a portfolio, a set
+      of screenshots, a comic. It looks wrong when printed, because every page
+      is a different size.
+    </p>
+    <p>
+      A margin is worth having on anything that will be printed. Home printers
+      cannot print to the edge of the paper, and a photograph placed edge to
+      edge comes out clipped.
+    </p>
+    <h3>Portrait pages from landscape photographs</h3>
+    <p>
+      If you photographed pages of paper with a phone held sideways, every image
+      will be landscape and will sit small in the middle of a portrait page.
+      Rotating each one a quarter turn before you build the document is what
+      fixes it, and it is a per-image choice rather than a global one, because
+      usually a few of them went in the right way round.
+    </p>
+  </section>
+
+  <section>
+    <h2>What the finished PDF says about you</h2>
+    <p>
+      A PDF carries a document information block: author, producer, creation
+      date, sometimes the title. Depending on what wrote it, that can include
+      your account name, your machine name, and the exact time you made it.
+    </p>
+    <p>
+      That is worth thinking about, because a PDF is a thing people send to
+      other people &mdash; a job application, a claim, a document for a
+      landlord. The metadata travels with it and any reader can display it.
+    </p>
+    <p>
+      The tool here leaves that block empty except for its own name: no file
+      names, no machine name, no user name, and no creation date unless you tick
+      the box asking for one. If you use a different tool, it is worth opening
+      the result's properties once to see what it wrote.
+    </p>
+    <p>
+      Separately: the images themselves. If your photographs carry EXIF and GPS
+      tags, what happens to them depends on the path. A JPEG copied in without
+      re-encoding keeps whatever was in it; an image that gets re-encoded loses
+      the tags as a side effect. If it matters, strip the photos first with the
+      <a href="../../exif-editor/">EXIF Viewer &amp; Remover</a> &mdash;
+      <a href="../remove-exif-and-gps-data/">its guide</a> explains what is in
+      there.
+    </p>
+  </section>
+
+  <section>
+    <h2>If the PDF comes out too large</h2>
+    <p>
+      Phone photographs are large, and twenty of them make a document that email
+      will refuse. Three things to try, in order:
+    </p>
+    <p>
+      <strong>Shrink the longest side.</strong> A 4000-pixel photograph of a
+      sheet of paper is carrying far more detail than any reader or printer will
+      use. Bringing the long edge down to something like 2000 pixels typically
+      quarters the file and changes nothing anyone can see on a page.
+    </p>
+    <p>
+      <strong>Use JPEG rather than lossless</strong> for anything photographic.
+      Lossless is the right answer for diagrams and the wrong one for a photo of
+      a page.
+    </p>
+    <p>
+      <strong>Compress the finished document.</strong> The
+      <a href="../../compress-pdf/">PDF Compressor</a> works against how large
+      each image is drawn on the page rather than against its pixel count, which
+      is the measurement that matters;
+      <a href="../make-a-pdf-smaller/">its guide</a> covers what that costs.
+    </p>
+    <p>
+      There is no limit built into the tool on how many images you can use. The
+      practical ceiling is your own machine's memory, because the finished
+      document is assembled there before you download it &mdash; a few hundred
+      phone photos at full resolution is the first thing to feel it, and
+      shrinking the longest side moves that ceiling a long way.
+    </p>
+  </section>
+
+  <section>
+    <h2>What this will not give you</h2>
+    <p>
+      A PDF made from photographs is a PDF full of pictures. The words in it are
+      not text: you cannot search them, copy them, or have a screen reader read
+      them. That is a property of what you started with, not of the conversion.
+    </p>
+    <p>
+      If you need searchable text you need OCR, which is a different job. And if
+      the original document still exists as a document somewhere, exporting that
+      directly to PDF will always beat photographing it &mdash; smaller,
+      sharper, searchable.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why this does not need an upload</h2>
+    <p>
+      Writing a PDF is writing a structured file: a header, a set of objects, a
+      cross-reference table. There is nothing in it a browser cannot do, and
+      nothing about the job that requires the pictures to travel anywhere.
+    </p>
+    <p>
+      Which is worth caring about here, because of what people put in these
+      documents. Identity papers, bank statements, medical letters, signed
+      contracts &mdash; the whole reason somebody is making a PDF at all is
+      usually that they are sending it to an institution. The tool here has no
+      network feature of any kind, and the page's
+      <code>Content-Security-Policy</code> names every address it may contact,
+      none of which belongs to this site.
+    </p>
+    <p>
+      <a href="../is-it-safe-to-upload-files/">Is it safe to upload files to
+      online converters?</a> sets out how to check that for yourself, here or
+      anywhere else.
+    </p>
+  </section>

--- a/pages/guides/combine-images-into-a-pdf/page.toml
+++ b/pages/guides/combine-images-into-a-pdf/page.toml
@@ -1,0 +1,34 @@
+#
+# Guide: combining images into a PDF.
+#
+# Usually somebody has been asked to "send it as a PDF" and has photographs of
+# paper. The interesting parts are the ones nobody warns them about: that a
+# JPEG can go in without being re-encoded at all, and that a PDF carries author
+# and timestamp fields to whoever they send it to.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/combine-images-into-a-pdf"
+kind = "guide"
+nav = "Images into a PDF"
+group = "doing-the-job"
+tool = "images-to-pdf"
+
+title = "How to Combine Images Into One PDF"
+description = "Turn photos or scans into a single PDF: page size, order and rotation, why a JPEG need not lose any quality on the way in, and what a PDF tells the person you send it to."
+
+heading = "How to combine images into one PDF"
+lede = """
+    Somebody has asked for &ldquo;one PDF&rdquo; and you have eleven photographs
+    of paper. This covers the choices that actually change the result &mdash;
+    page size, order, quality and what the document says about you &mdash; and
+    which of them you can ignore."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "How to combine images into one PDF"
+og_description = "Page size, order and rotation, why a JPEG need not lose quality on the way in, and what a PDF tells the person you send it to."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/pages/guides/compress-an-image-to-a-target-size/body.html
+++ b/pages/guides/compress-an-image-to-a-target-size/body.html
@@ -1,0 +1,242 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      Open the <a href="../../compress-image/">Image Compressor</a>, drop the
+      photo in, type the number you were given, and press the button. It encodes
+      the picture several times, keeps the best result that fits under your
+      target, and tells you what that cost. For most photographs and most
+      targets, the honest summary is that you will not be able to see the
+      difference.
+    </p>
+    <p>
+      The rest of this page is for when that does not happen: when the result
+      looks soft, when a PNG barely moves, or when you want to know what the
+      tool is actually doing to your picture before you send it to somebody.
+    </p>
+  </section>
+
+  <section>
+    <h2>What a file size limit is really asking for</h2>
+    <p>
+      A JPEG or a WebP does not store your photograph. It stores a description
+      of it, and the quality setting decides how detailed that description is
+      allowed to be. Turn it down and the file gets smaller because the
+      description gets vaguer: fine texture is averaged away, gradients get
+      banded, and edges pick up a faint halo of blocks.
+    </p>
+    <p>
+      So a size limit is a budget for detail. The useful question is not
+      &ldquo;can I hit 500&nbsp;KB&rdquo; &mdash; you can always hit any number
+      &mdash; but &ldquo;how much of the picture do I have to give up to get
+      there, and does it matter for what I am doing with it?&rdquo;
+    </p>
+    <p>
+      Two rules of thumb. A photograph of a real scene &mdash; faces, foliage,
+      fabric &mdash; hides compression well, because the eye has no perfectly
+      flat area to notice damage in. A screenshot, a chart, a logo or anything
+      with large flat colours and hard text edges shows it immediately, and
+      should usually be a PNG or a WebP rather than a JPEG at all.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why there is no formula, and what to do about it</h2>
+    <p>
+      There is no way to calculate the quality setting that produces a
+      500&nbsp;KB file. The relationship between the two depends entirely on
+      what is in the picture: at the same setting, a photograph of a plain wall
+      might come out at a tenth the size of a photograph of a forest. Any tool
+      that offers you &ldquo;quality: 60&rdquo; and hopes is guessing on your
+      behalf.
+    </p>
+    <p>
+      The only reliable method is to try. Encode the image, look at the size,
+      adjust, encode again. Doing that by hand is tedious, which is why
+      compressors ask for a quality number instead &mdash; it moves the tedium
+      to you. Doing it automatically is roughly eight encodes, and eight encodes
+      of a phone photo is a fraction of a second on any machine made this
+      decade, which is why this site's tool asks for the size and does the
+      searching itself.
+    </p>
+    <p>
+      Every size it reports is a real encoded file, not an estimate. That
+      matters when a form has a hard limit: an estimate that is 2% optimistic is
+      a rejected upload.
+    </p>
+  </section>
+
+  <section>
+    <h2>Spend quality before you spend pixels</h2>
+    <p>
+      There are only two ways to make an image file smaller. You can describe
+      the same picture less precisely, which is quality. Or you can describe
+      fewer pixels, which is resizing. They are not equivalent, and the order
+      matters.
+    </p>
+    <p>
+      Quality goes first, because the first 30% or so of quality reduction is
+      genuinely invisible on a photograph &mdash; you are throwing away detail
+      that the format was storing more carefully than any eye can check. Pixels
+      go second, because once quality drops far enough that artefacts are
+      visible, a smaller picture at a decent quality looks better than a
+      full-size picture that has been ruined. Fewer good pixels beat more bad
+      ones.
+    </p>
+    <p>
+      That is the whole strategy, and it is worth knowing even if you use a
+      different tool: turn the quality down until it starts to look wrong, then
+      make the picture smaller instead of turning it down further.
+    </p>
+    <h3>When to resize on purpose</h3>
+    <p>
+      Sometimes the pixels were never needed. A 4000-pixel-wide photo displayed
+      in a 600-pixel-wide column on a web page is carrying six times the detail
+      anyone will see. If you know the picture's final home, resize to it first
+      and the size problem often disappears without any quality being spent at
+      all. The
+      <a href="../../resize-image/">Image Resizer</a> is the tool for that job,
+      and <a href="../resize-an-image/">its own guide</a> covers picking a size.
+    </p>
+  </section>
+
+  <section>
+    <h2>Choosing a format</h2>
+    <p>
+      Three formats are worth knowing about, and browsers can write all three.
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG</strong> is for photographs. It is lossy, it is understood
+        by everything ever made, and for a picture of a real scene it is still
+        an excellent choice. It cannot store transparency.
+      </li>
+      <li>
+        <strong>WebP</strong> is for the same job, done better: roughly 25&ndash;35%
+        smaller than JPEG at a quality you cannot tell apart, and it keeps
+        transparency. Every current browser reads it. A few older desktop
+        applications and some corporate upload forms still do not, which is the
+        only real reason not to use it.
+      </li>
+      <li>
+        <strong>PNG</strong> is lossless, which means it is exact and it is
+        large. It is the right answer for screenshots, logos, line art, and
+        anything with sharp edges or flat colour, and the wrong answer for a
+        photograph.
+      </li>
+    </ul>
+    <p>
+      If you have no constraint from whoever asked for the file, WebP will get
+      you to a target with less visible damage than JPEG. If the file is going
+      into something old, or into a system you cannot test, JPEG is the safe
+      answer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why your PNG will not get much smaller</h2>
+    <p>
+      This is the most common surprise, and it is not a bug in whatever tool you
+      are using. PNG is a lossless format: it stores the exact pixels, and it has
+      no quality dial to turn, because turning one would make it a different
+      format. All a PNG compressor can do is pack the same pixels more cleverly,
+      which is usually worth a few per cent.
+    </p>
+    <p>
+      So if you must have a much smaller file and it must stay a PNG, the only
+      lever left is size &mdash; fewer pixels, or fewer colours. If it may stop
+      being a PNG, the question is what is in it:
+    </p>
+    <ul>
+      <li>
+        <strong>A photograph saved as a PNG.</strong> Very common, usually by
+        accident, and the easiest win on this page: converting it to JPEG or
+        WebP will often make it five to ten times smaller with no visible
+        change.
+      </li>
+      <li>
+        <strong>A screenshot or a diagram.</strong> Convert to WebP, which is
+        lossless as well when you ask it to be, and is generally smaller than
+        PNG for the same pixels. Going to JPEG will make text edges fuzzy.
+      </li>
+      <li>
+        <strong>A logo with transparency.</strong> WebP keeps the transparency;
+        JPEG will fill it in with a solid colour, which is almost never what you
+        wanted.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>How to tell whether the result is good enough</h2>
+    <p>
+      Looking at a thumbnail proves nothing &mdash; everything looks fine at
+      thumbnail size. Two better checks:
+    </p>
+    <p>
+      <strong>Look at it at full size, at the flattest thing in the frame.</strong>
+      Sky, skin, a painted wall. Compression damage shows up first in smooth
+      gradients, as faint blocks or bands, long before it touches detailed
+      areas.
+    </p>
+    <p>
+      <strong>Read the measurement, if the tool gives you one.</strong> The
+      compressor here decodes its own result and compares it with the original,
+      and reports SSIM: a number that compares local brightness, contrast and
+      structure rather than counting changed pixels, which is much closer to
+      what an eye objects to. Above roughly 0.98 the two pictures are hard to
+      separate side by side. Below about 0.95, look before you send. It also
+      reports PSNR, the traditional decibel figure, for anyone who prefers it.
+    </p>
+    <p>
+      Both are computed on your own machine and shown to you, which is the point
+      of having them: it turns &ldquo;minimal quality loss&rdquo; from a claim
+      into a number you can check.
+    </p>
+  </section>
+
+  <section>
+    <h2>Three things worth knowing before you send the file</h2>
+    <p>
+      <strong>Compressing strips the metadata.</strong> Re-encoding means
+      decoding the picture to pixels and encoding those pixels again, and a
+      canvas full of pixels carries no tags &mdash; so the GPS position, the
+      camera model, the timestamps and the rest are simply not written to the
+      new file. Usually that is a bonus. If you wanted the tags gone but the
+      picture untouched, that is a different job: the
+      <a href="../../exif-editor/">EXIF Viewer &amp; Remover</a> rewrites the
+      container without re-compressing anything, and
+      <a href="../remove-exif-and-gps-data/">its guide</a> explains what is in
+      there.
+    </p>
+    <p>
+      <strong>Never compress the same file twice.</strong> Each lossy encode
+      throws away detail permanently, and encoding an already-compressed picture
+      throws away more &mdash; including the artefacts from the first pass,
+      which it faithfully preserves at the cost of real detail. Always go back
+      to the original and compress once.
+    </p>
+    <p>
+      <strong>Keep the original.</strong> There is no way back from a lossy
+      encode. Whatever you send, keep the file you started with somewhere.
+    </p>
+  </section>
+
+  <section>
+    <h2>None of this needs an upload</h2>
+    <p>
+      Every browser has shipped a JPEG, PNG and WebP encoder for years &mdash;
+      it is the same code that saves a picture out of a canvas. Compressing an
+      image is one of the jobs that has no technical reason to involve a server
+      at all, which is why the tool here does not have one: the picture is
+      decoded, encoded and measured on your own machine, and there is no address
+      in the page's <code>Content-Security-Policy</code> that belongs to this
+      site for it to be sent to.
+    </p>
+    <p>
+      The simplest way to confirm that, here or anywhere else, is to load the
+      page, disconnect from the internet, and compress something anyway. If it
+      still works, nothing was being uploaded.
+      <a href="../is-it-safe-to-upload-files/">Is it safe to upload files to
+      online converters?</a> sets out three more checks like it.
+    </p>
+  </section>

--- a/pages/guides/compress-an-image-to-a-target-size/page.toml
+++ b/pages/guides/compress-an-image-to-a-target-size/page.toml
@@ -1,0 +1,34 @@
+#
+# Guide: compressing an image to a target size.
+#
+# The question behind almost every visit to an image compressor is not "how do
+# I compress this" but "the form said 500 KB and mine is 4 MB". This is written
+# for that person: what a target size actually costs, which of the three dials
+# to turn first, and why a PNG will not do what is being asked of it.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/compress-an-image-to-a-target-size"
+kind = "guide"
+nav = "Compressing an image"
+group = "doing-the-job"
+tool = "compress-image"
+
+title = "How to Compress an Image to an Exact File Size"
+description = "An upload form wants 500 KB and your photo is 4 MB. What a size limit really costs, which setting to move first, and why a PNG will not shrink the way a JPEG does."
+
+heading = "How to compress an image to an exact file size"
+lede = """
+    Someone has told you a number &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
+    &mdash; and your photo is nowhere near it. This is what that number costs,
+    what to spend it on, and how to tell whether the result is still good
+    enough to send."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "Compressing an image to an exact file size"
+og_description = "What a size limit really costs, which setting to move first, and why a PNG will not shrink the way a JPEG does."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/pages/guides/crop-a-video/body.html
+++ b/pages/guides/crop-a-video/body.html
@@ -1,0 +1,205 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      Open the <a href="../../crop-video/">Video Cropper</a>, drop the clip in,
+      drag the box over the part you want to keep &mdash; or lock it to a shape
+      if you have been given one &mdash; and export. The clip that comes out is
+      exactly as long as the one that went in, with its timing and its sound
+      intact.
+    </p>
+    <p>
+      Unlike trimming, this one has to write new frames. That is not a
+      shortcoming of any particular tool; it is what cropping is. The rest of
+      this page is about what that costs and how to keep it small.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why cropping cannot avoid a re-encode</h2>
+    <p>
+      A trim keeps whole frames, so a good trimmer moves them across untouched
+      and nothing is decoded at all. A crop keeps part of each frame &mdash; and
+      part of a frame is a different picture. There is no way to store a
+      different picture without writing the pixels out afresh.
+    </p>
+    <p>
+      There is a narrow exception, and it is worth knowing so you can recognise
+      when somebody is claiming it. Video is encoded in blocks, and if a crop
+      landed exactly on block boundaries on all four sides, some of the data
+      could in principle be reused. In practice the frame's own dimensions,
+      motion vectors and prediction all have to be rewritten anyway, so nothing
+      real is built this way. Assume a crop means a re-encode.
+    </p>
+    <p>
+      What a well-behaved cropper will do is not spend <em>more</em> than the
+      original did on the same area. Encoding a cropped region at a higher
+      bitrate than its source only makes the file bigger; it cannot put back
+      detail the original did not have.
+    </p>
+  </section>
+
+  <section>
+    <h2>The shapes you are actually being asked for</h2>
+    <p>
+      Most cropping is done because somewhere has a required aspect ratio. The
+      short list:
+    </p>
+    <ul>
+      <li>
+        <strong>9:16 &mdash; tall.</strong> Stories, reels, shorts, TikTok. Full
+        screen on a phone held normally. The most common reason anybody crops a
+        video at all.
+      </li>
+      <li>
+        <strong>1:1 &mdash; square.</strong> Feed posts on several platforms.
+        Works whichever way the viewer is holding their phone, which is why it
+        persists.
+      </li>
+      <li>
+        <strong>4:5 &mdash; slightly tall.</strong> The largest shape some feeds
+        allow, so it takes more of the screen than a square without being a full
+        vertical video.
+      </li>
+      <li>
+        <strong>16:9 &mdash; wide.</strong> The standard for video generally.
+        You are usually cropping <em>to</em> this only to remove black bars, or
+        <em>from</em> it to get one of the above.
+      </li>
+    </ul>
+    <p>
+      Lock the box to the ratio rather than dragging by eye. Being a few pixels
+      out means the platform crops your crop, and it will not consult you about
+      where.
+    </p>
+  </section>
+
+  <section>
+    <h2>Turning a landscape clip vertical</h2>
+    <p>
+      This is the hardest common case, and it is worth being clear that
+      cropping is a compromise rather than a solution.
+    </p>
+    <p>
+      A 16:9 video cropped to 9:16 keeps about 32% of the picture width. Whatever
+      is at the sides is gone &mdash; and in a landscape shot, the sides are
+      usually where the context is. If two people are talking on opposite sides
+      of the frame, no single crop keeps both.
+    </p>
+    <p>
+      Choose the crop by watching the clip once and asking where the subject
+      actually is for most of it. If the answer is &ldquo;it moves&rdquo;, a
+      static crop is the wrong tool and what you want is an editor that can pan
+      the crop over time. If the answer is &ldquo;centre, mostly&rdquo;, a
+      centred crop is fine and takes ten seconds.
+    </p>
+    <p>
+      The alternative worth remembering: many platforms accept a landscape video
+      and letterbox it themselves. Cropping is for when you want the full screen,
+      not for when you want the video to be accepted.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why the width and height move in steps of two</h2>
+    <p>
+      If you notice the crop box refusing odd numbers, that is the codec rather
+      than the interface being difficult.
+    </p>
+    <p>
+      H.264 &mdash; the codec inside an MP4 &mdash; stores colour at half
+      resolution horizontally and vertically, because the eye is much less
+      sensitive to colour detail than to brightness. That means the picture is
+      handled in two-pixel units and there is no way to describe a frame with an
+      odd number of pixels on a side.
+    </p>
+    <p>
+      Tools deal with this by rounding your crop after you set it, which moves
+      your box by a pixel without telling you, or by only ever offering even
+      numbers in the first place. The second is what happens here.
+    </p>
+  </section>
+
+  <section>
+    <h2>What happens to the sound</h2>
+    <p>
+      Nothing, on the MP4 path. Cropping changes the picture and has no reason to
+      touch the audio, so the audio is copied across sample by sample without
+      ever being decoded &mdash; byte for byte what was in the file.
+    </p>
+    <p>
+      On the recording fallback, described below, the sound is captured from
+      playback and encoded again, which costs a little quality. Either way there
+      is a checkbox to leave it out entirely, which is worth using when the clip
+      is going somewhere that plays muted anyway and you want the smallest file.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formats, and how long it takes</h2>
+    <p>
+      <strong>MP4, M4V and MOV</strong> are read directly, whatever is inside
+      them &mdash; H.264, HEVC, AV1 or VP9 &mdash; as long as your browser can
+      decode that codec. Unlike trimming, cropping does have to decode, so the
+      codec matters here in a way it does not there.
+    </p>
+    <p>
+      <strong>Anything else your browser can play</strong>, WebM most obviously,
+      is cropped by playing it and recording the result, which works and takes
+      as long as the clip is long.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV and most MKVs</strong> the browser can neither read
+      nor play, and the tool refuses them with a message rather than failing
+      halfway through.
+    </p>
+    <p>
+      Expect a crop to take real time on a long clip, because every frame is
+      being decoded and re-encoded. There is no limit built into the tool, and
+      the file is walked through a few megabytes at a time rather than loaded
+      whole; the practical ceiling is the finished video, which is assembled in
+      memory before you download it.
+    </p>
+  </section>
+
+  <section>
+    <h2>Crop before you do anything else</h2>
+    <p>
+      If a clip needs both trimming and cropping, trim first &mdash; it is free,
+      and every second you cut is a second nobody has to re-encode. Then crop
+      the shorter clip once.
+    </p>
+    <p>
+      Doing it the other way round means cropping footage you are about to throw
+      away, which costs time and quality for nothing. The
+      <a href="../../trim-video/">Video Trimmer</a> is next door, and
+      <a href="../trim-a-video/">its guide</a> explains why that step need not
+      cost you anything at all.
+    </p>
+    <p>
+      More generally: every lossy step compounds. One crop of an original is one
+      generation. A crop of a trim of an export of a download is four, and it
+      looks like it.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why this does not need an upload</h2>
+    <p>
+      Decoding and re-encoding video in a browser is recent and it is real:
+      WebCodecs exposes the same hardware encoder your phone uses to record
+      video, and it is fast for the same reason. The work happens on the machine
+      that already has the file, which for a multi-gigabyte video is also the
+      only arrangement that makes sense &mdash; uploading it and downloading the
+      result costs more time than the encoding does.
+    </p>
+    <p>
+      The tool here has no network feature of any kind, and the page's
+      <code>Content-Security-Policy</code> names every address it may contact,
+      none of which belongs to this site. Unplug from the internet and crop a
+      clip anyway if you would rather check than be told.
+    </p>
+    <p>
+      <a href="../is-it-safe-to-upload-files/">Is it safe to upload files to
+      online converters?</a> sets out three more checks you can run on any tool.
+    </p>
+  </section>

--- a/pages/guides/crop-a-video/page.toml
+++ b/pages/guides/crop-a-video/page.toml
@@ -1,0 +1,33 @@
+#
+# Guide: cropping a video.
+#
+# The counterpart to the trimming guide, and deliberately honest about the
+# difference: cropping cannot avoid a re-encode, and a guide that implied
+# otherwise would be selling the tool rather than explaining it. The useful
+# content is the aspect ratios people are actually being asked for.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/crop-a-video"
+kind = "guide"
+nav = "Cropping a video"
+group = "doing-the-job"
+tool = "crop-video"
+
+title = "How to Crop a Video to a Different Shape"
+description = "Cut a clip down to a square, a 9:16 portrait, or an exact pixel box. Which ratio each platform wants, why cropping has to re-encode when trimming does not, and what that costs."
+
+heading = "How to crop a video to a different shape"
+lede = """
+    Cropping changes the shape of the picture, which means writing new frames
+    &mdash; there is no way round that, and any tool claiming otherwise is
+    doing something else. This is what it costs, and how to spend it well."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "How to crop a video to a different shape"
+og_description = "Which aspect ratio each platform wants, why cropping has to re-encode when trimming does not, and what that costs."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/pages/guides/is-it-safe-to-upload-files/page.toml
+++ b/pages/guides/is-it-safe-to-upload-files/page.toml
@@ -13,6 +13,10 @@
 slug = "guides/is-it-safe-to-upload-files"
 kind = "guide"
 nav = "Is it safe to upload files?"
+# Which group on the guides index this joins, by the id in
+# config/site.toml. A guide that named no group would be built, sit at a
+# URL, and be linked to from nowhere.
+group = "before-you-upload"
 
 title = "Is It Safe to Upload Files to Online Converters?"
 description = "Most online converters send your file to a server. What that means, what happens to it there, and four checks that tell you whether a tool needs to."

--- a/pages/guides/make-a-pdf-smaller/body.html
+++ b/pages/guides/make-a-pdf-smaller/body.html
@@ -1,0 +1,225 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      Open the <a href="../../compress-pdf/">PDF Compressor</a>, drop the
+      document in, and look at what it tells you before you change anything. It
+      reads the file and shows where the size actually is &mdash; images, fonts,
+      text and drawing, and anything nothing in the document refers to any more.
+      That one screen usually answers the question.
+    </p>
+    <p>
+      If most of the size is images, you can expect a large saving. If it is
+      fonts and text, you cannot, and no tool can. Which of those you have is
+      the whole story, and it is worth ten seconds of looking.
+    </p>
+  </section>
+
+  <section>
+    <h2>Where a PDF's size actually is</h2>
+    <p>
+      A PDF is a container for several different kinds of thing, and they do not
+      compress alike.
+    </p>
+    <ul>
+      <li>
+        <strong>Images.</strong> Photographs and scans. Almost always the bulk
+        of a large PDF, and the only part with real room in it.
+      </li>
+      <li>
+        <strong>Embedded fonts.</strong> A full font can be hundreds of
+        kilobytes; a subset of the characters actually used is far less. Either
+        way, they were compressed by whatever produced the file.
+      </li>
+      <li>
+        <strong>Text and vector drawing.</strong> Instructions rather than
+        pixels: draw this line, set this word here. Compact already, and
+        compressed already.
+      </li>
+      <li>
+        <strong>Objects nothing points at any more.</strong> PDFs accumulate
+        these. Editing a document often appends the change rather than rewriting
+        the file, so an old version of a page can sit in there indefinitely.
+        Repacking the file drops them.
+      </li>
+    </ul>
+    <p>
+      So the two documents people bring to a PDF compressor have completely
+      different prospects. A scanned document is essentially a stack of
+      photographs, and commonly comes out 60&ndash;90% smaller. A contract, a
+      thesis or an exported report is text, drawing and fonts &mdash; all
+      already compressed by the software that wrote it &mdash; and the saving
+      there is usually a few per cent, from repacking and dropping what is
+      unreferenced.
+    </p>
+    <p>
+      Any tool that promises &ldquo;up to 90% smaller&rdquo; without looking at
+      your file is quoting the best case of the first kind at the second.
+    </p>
+  </section>
+
+  <section>
+    <h2>What DPI has to do with it</h2>
+    <p>
+      A PDF does not just hold a picture; it records how large that picture is
+      drawn on the page. That gives you something more useful than the pixel
+      count: the effective resolution.
+    </p>
+    <p>
+      A 4000-pixel-wide scan placed across eight inches of paper is carrying 500
+      pixels to the inch. A screen shows about 100. A good office printer works
+      at 300 and cannot use much more. Everything above that is detail that
+      nothing in the document's future will ever display &mdash; and it is
+      usually most of the file.
+    </p>
+    <p>
+      That is why a sensible PDF compressor asks for a DPI rather than a quality
+      percentage. It throws away the pixels above your figure first, because
+      those cost nothing that anyone can see, and only then starts spending
+      actual quality.
+    </p>
+    <p>
+      Rough guide: <strong>150 DPI</strong> for a document that will be read on
+      screen, <strong>200&ndash;300</strong> for something that will be printed,
+      <strong>72&ndash;100</strong> for a draft nobody will keep. Measuring
+      against how large the image is drawn is also why a logo placed small is not
+      treated the same as a full-page scan &mdash; the logo is already near its
+      effective resolution and there is nothing to take.
+    </p>
+  </section>
+
+  <section>
+    <h2>What compressing should and should not touch</h2>
+    <p>
+      The pictures get re-encoded, so those lose a little. Nothing else should
+      be touched at all, and it is worth checking that whatever tool you use
+      holds to that:
+    </p>
+    <ul>
+      <li>
+        <strong>Text stays text.</strong> Selectable, searchable, copyable. A
+        compressor that flattens pages to images will produce a very small file
+        and destroy the document &mdash; you cannot search it, screen readers
+        cannot read it, and it can never be undone.
+      </li>
+      <li>
+        <strong>Fonts stay whole.</strong> Substituting fonts changes how the
+        document looks on someone else's machine, which is the one thing PDF
+        exists to prevent.
+      </li>
+      <li>
+        <strong>Vector drawing is copied exactly.</strong> It is already small,
+        and rasterising it would make it both larger and worse.
+      </li>
+      <li>
+        <strong>Forms, links, bookmarks, accessibility structure and
+        attachments carry across.</strong> These are easy to lose in a rewrite
+        and rarely noticed until somebody needs one.
+      </li>
+    </ul>
+    <p>
+      A related rule that a compressor should follow and many do not: if
+      re-encoding an image does not actually come out smaller than the original,
+      put the original bytes back. Making a picture worse for no saving is the
+      pure-loss case, and it happens more often than you would think on images
+      that were already well compressed.
+    </p>
+  </section>
+
+  <section>
+    <h2>The pictures that cannot be compressed</h2>
+    <p>
+      Some images inside a PDF get skipped, and a good tool names them rather
+      than quietly leaving them out of the arithmetic:
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG&nbsp;2000, JBIG2 and fax-coded (CCITT) images.</strong> No
+        browser ships a decoder for any of them, so they are passed through
+        untouched. The last two are bilevel &mdash; black and white only &mdash;
+        and are usually near their smallest already.
+      </li>
+      <li>
+        <strong>CMYK images.</strong> Left alone deliberately. Re-encoding them
+        risks shifting the colours a printer would produce, which is a
+        surprising thing to do to a document somebody is going to print.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Things to try before compressing</h2>
+    <p>
+      Sometimes the file is large for a reason that compression is the wrong
+      answer to.
+    </p>
+    <p>
+      <strong>Was it scanned when it did not need to be?</strong> A document
+      printed and then scanned is a stack of photographs of text. If the original
+      still exists somewhere as a document, exporting that to PDF will produce a
+      file a fraction of the size that is also searchable.
+    </p>
+    <p>
+      <strong>Was it exported at print settings?</strong> Word processors and
+      design software often default to a print-quality export. Re-exporting for
+      screen from the source file usually beats compressing the export.
+    </p>
+    <p>
+      <strong>Does it need to be one file?</strong> An email limit is per
+      message. Splitting a 200-page document into chapters is sometimes the
+      honest fix.
+    </p>
+  </section>
+
+  <section>
+    <h2>Encrypted files, and why a compressor should refuse them</h2>
+    <p>
+      A password-protected PDF is refused by the tool here, and that is
+      deliberate rather than a missing feature &mdash; including when the
+      password is blank, which is how a lot of scanners and copiers save.
+    </p>
+    <p>
+      Taking the protection off a document is a different job from compressing
+      it. A tool that did it silently would be doing something you did not ask
+      for, to a file somebody had deliberately locked, and handing you back a
+      copy that no longer had the property they intended it to have. Remove the
+      protection yourself first, deliberately, if that is what you want.
+    </p>
+  </section>
+
+  <section>
+    <h2>Checking the result</h2>
+    <p>
+      Open it. Look at the pictures at full zoom, check that the text is still
+      selectable, and confirm the page count.
+    </p>
+    <p>
+      The tool here does the last of those for you before it offers the file:
+      it re-opens the document it just wrote and counts the pages, on your own
+      machine. It also writes PDF 1.5, which every reader shipped since 2003
+      understands, so &ldquo;it opens on my machine&rdquo; is a reasonable proxy
+      for &ldquo;it opens on theirs&rdquo;.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why this does not need a server</h2>
+    <p>
+      Compressing a PDF sounds like server work, and for most of the web's life
+      it was. What it actually involves is parsing the file structure, finding
+      the image streams, decoding and re-encoding those with the codecs a
+      browser already ships, and writing the document back out. All of that runs
+      in a browser now.
+    </p>
+    <p>
+      Which matters more for this file type than most, because of what people
+      compress: contracts, medical letters, bank statements, identity documents,
+      tax returns. The tool here has no network feature at all, and the page's
+      <code>Content-Security-Policy</code> names every address it may contact,
+      none of which belongs to this site. Load it, unplug, and compress
+      something anyway.
+    </p>
+    <p>
+      <a href="../is-it-safe-to-upload-files/">Is it safe to upload files to
+      online converters?</a> sets out three more checks like that one.
+    </p>
+  </section>

--- a/pages/guides/make-a-pdf-smaller/page.toml
+++ b/pages/guides/make-a-pdf-smaller/page.toml
@@ -1,0 +1,34 @@
+#
+# Guide: making a PDF smaller.
+#
+# The one guide whose main job is to manage an expectation. "Compress PDF" is
+# searched for by two different people - one with a scan, one with a contract -
+# and only the first of them can be helped much. Saying so early is more useful
+# than a percentage nobody can keep.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/make-a-pdf-smaller"
+kind = "guide"
+nav = "Making a PDF smaller"
+group = "doing-the-job"
+tool = "compress-pdf"
+
+title = "How to Make a PDF Smaller (and Why Some Will Not Shrink)"
+description = "Where a PDF's size actually is, why a scan compresses 80% and a contract barely moves, what DPI means here, and what a compressor should never do to your document."
+
+heading = "How to make a PDF smaller, and why some will not shrink"
+lede = """
+    A PDF that will not fit an email limit is nearly always a PDF full of
+    pictures. This explains how to tell whether yours is, what compressing it
+    costs, and why any tool promising a fixed percentage has not looked at your
+    file."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "How to make a PDF smaller"
+og_description = "Where a PDF's size actually is, why a scan shrinks and a contract does not, and what DPI has to do with it."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/pages/guides/remove-exif-and-gps-data/body.html
+++ b/pages/guides/remove-exif-and-gps-data/body.html
@@ -1,0 +1,213 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      Open the <a href="../../exif-editor/">EXIF Viewer &amp; Remover</a>, drop
+      the photos in, and press &ldquo;Remove all metadata&rdquo;. Every tag, the
+      XMP and IPTC blocks, the comments and the embedded thumbnail go, on every
+      photo on the list at once. The picture itself is not touched &mdash; not
+      re-compressed, not decoded, not changed by a single pixel.
+    </p>
+    <p>
+      Before you do that, it is worth looking at what was in there. It is
+      usually more than people expect, and the list is the argument for doing
+      this at all.
+    </p>
+  </section>
+
+  <section>
+    <h2>What is actually inside a photo</h2>
+    <p>
+      A JPEG is not just a compressed picture. It is a container, and beside the
+      picture sit several blocks of information that your camera, phone or
+      editor wrote there.
+    </p>
+    <ul>
+      <li>
+        <strong>EXIF.</strong> The main one. Camera make and model, lens,
+        exposure settings, ISO, the date and time to the second, the orientation
+        the picture should be shown in, and &mdash; on a phone with location
+        services on for the camera &mdash; a GPS position accurate to a few
+        metres. Frequently a camera body serial number as well.
+      </li>
+      <li>
+        <strong>GPS.</strong> Technically part of EXIF, and worth naming
+        separately because it is the one that matters most. It is written in
+        degrees, minutes and seconds, which is a format that does a very good
+        job of not looking like an address.
+      </li>
+      <li>
+        <strong>XMP.</strong> A packet of XML that editors write. It can carry
+        your name, your software, ratings, keywords, edit history, and a copy of
+        some of the EXIF fields &mdash; which is why removing EXIF alone is not
+        enough.
+      </li>
+      <li>
+        <strong>IPTC.</strong> An older block of caption, byline, credit and
+        copyright fields, used across the press and stock photography.
+      </li>
+      <li>
+        <strong>The embedded thumbnail.</strong> A small second copy of the
+        image. It is generated when the file is written, and it is not always
+        regenerated when the picture is edited &mdash; which is how a cropped
+        photo can travel with a thumbnail of what was cropped out.
+      </li>
+      <li>
+        <strong>The maker note.</strong> An undocumented block of manufacturer
+        data. Nobody outside the manufacturer knows everything that is in it.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Who actually sees it</h2>
+    <p>
+      This is the part worth being accurate about, because both the alarmed and
+      the dismissive versions are wrong.
+    </p>
+    <p>
+      <strong>Most large social networks strip metadata when you post.</strong>
+      Facebook, Instagram and X re-encode uploaded images and drop the tags in
+      the process. This is not a kindness &mdash; they keep the data on their
+      side &mdash; but it does mean a photo posted to those services does not
+      hand its coordinates to every viewer.
+    </p>
+    <p>
+      <strong>Almost everything else keeps it.</strong> An email attachment. A
+      file sent over most chat apps as a &ldquo;document&rdquo; rather than a
+      photo. A picture on a forum, a marketplace listing, a personal site, a
+      shared drive, a bug report, a support ticket. In all of those the file
+      arrives intact, and anyone who downloads it can read the tags with tools
+      that ship with their operating system.
+    </p>
+    <p>
+      The realistic risks are mundane rather than dramatic: a marketplace listing
+      photographed at home, a picture of a child taken at their school, an
+      apparently anonymous account posting photos that all share one camera
+      serial number, a &ldquo;taken last week&rdquo; that was taken in March.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why not just re-save it?</h2>
+    <p>
+      Re-saving a photo through an editor or a compressor does remove the
+      metadata &mdash; the picture is decoded to pixels and encoded again, and a
+      canvas full of pixels carries no tags. It works, and it costs you quality,
+      because that re-encode is lossy.
+    </p>
+    <p>
+      Removing the metadata properly costs nothing at all. The tags sit in the
+      container <em>around</em> the compressed picture, not inside it, so
+      stripping them is deleting entries from a list and writing the list back
+      out. The compressed image data is copied across byte for byte and the
+      result decodes to exactly the same pixels. That is the whole reason to use
+      a metadata tool rather than a converter.
+    </p>
+    <p>
+      The exception is if you were going to re-encode anyway. If you are already
+      compressing or resizing the photo, the tags go as a side effect and you do
+      not need a second step.
+    </p>
+  </section>
+
+  <section>
+    <h2>The one thing to keep: orientation</h2>
+    <p>
+      Phones do not rotate the picture when you turn the phone. They record it
+      the way the sensor saw it and add an Orientation tag saying how it should
+      be turned for display. Strip every tag and some viewers will show your
+      photo on its side.
+    </p>
+    <p>
+      This is why the tool here has a &ldquo;keep the orientation tag&rdquo;
+      option, on by default. It writes back a tiny EXIF block containing that
+      one tag and nothing else, and only for photos that actually needed it. The
+      GPS, the timestamps, the serial number and the rest are still gone.
+    </p>
+    <p>
+      Turn it off if you would rather the file carry no EXIF whatsoever &mdash;
+      and then check the result before you send it, because a sideways photo is
+      the usual outcome.
+    </p>
+  </section>
+
+  <section>
+    <h2>Editing instead of removing</h2>
+    <p>
+      Removing everything is the right answer for most people. Sometimes it is
+      not: a photographer may want the copyright line and the camera settings
+      kept and only the location gone; an archivist may need to correct a date
+      that was wrong because the camera clock was.
+    </p>
+    <p>
+      Both are possible. The location can be deleted on its own, and text tags,
+      dates, ISO, orientation and resolution can be edited in place.
+    </p>
+    <p>
+      One caveat that applies to every tool that does this, not just this one:
+      writing the file rebuilds the EXIF block, and a maker note contains offsets
+      into the <em>original</em> block. A rebuilt maker note may therefore no
+      longer be readable by the manufacturer's own software. If that matters,
+      delete the maker note or leave the file unedited.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formats, and the ones that cannot be done this way</h2>
+    <p>
+      JPEG, PNG and WebP can all be rewritten cleanly, and those are the three
+      the tool here handles.
+    </p>
+    <p>
+      HEIC &mdash; what an iPhone saves by default &mdash; and AVIF are box
+      formats built from nested atoms, and need a different parser entirely. The
+      tool recognises them and says so rather than producing a broken file. If
+      you have a HEIC, converting it to JPEG will remove the metadata as a side
+      effect of the conversion.
+    </p>
+    <p>
+      A bare TIFF is not handled either, and for a more interesting reason: in a
+      TIFF the metadata and the pixel data are addressed by the same offsets, so
+      removing tags means rewriting the picture's own addressing. It is doable
+      and it is a different job.
+    </p>
+  </section>
+
+  <section>
+    <h2>A habit worth having</h2>
+    <p>
+      Check before you post rather than after. Reading the tags takes a few
+      seconds and the finding list names the things worth knowing about &mdash;
+      the position, the timestamps, the serial numbers &mdash; before the full
+      table of every tag, so you do not have to know what to look for.
+    </p>
+    <p>
+      The position is shown in decimal degrees first, on purpose. &ldquo;51
+      degrees, 30 minutes, 26 seconds&rdquo; does not make it obvious that a
+      photo names the building it was taken in. A pair of decimals you can paste
+      into a map does.
+    </p>
+  </section>
+
+  <section>
+    <h2>Do not upload the photo to find out what is in it</h2>
+    <p>
+      There is a particular irony in the usual way this problem gets solved:
+      somebody worried about what their photo reveals uploads it to a website to
+      find out. The site now has the photo, the coordinates, the timestamp and
+      the serial number, and a copy of the picture on a disk they own.
+    </p>
+    <p>
+      There is no reason for it. Reading and rewriting the container around a
+      JPEG is a few hundred lines of parsing that a browser runs perfectly well,
+      which is why the tool here has no network feature at all: no
+      <code>fetch</code>, no <code>XMLHttpRequest</code>, nothing that could send
+      a file even if something tried. Load it once, disconnect, and it keeps
+      working.
+    </p>
+    <p>
+      <a href="../is-it-safe-to-upload-files/">Is it safe to upload files to
+      online converters?</a> sets out how to check that claim on this site or any
+      other &mdash; and this is the file type where it is most worth checking.
+    </p>
+  </section>

--- a/pages/guides/remove-exif-and-gps-data/page.toml
+++ b/pages/guides/remove-exif-and-gps-data/page.toml
@@ -1,0 +1,34 @@
+#
+# Guide: the metadata inside a photo, and how to remove it.
+#
+# The one guide here where the reader may not know they have a problem. Most
+# people who post a photo have no idea it names the building it was taken in,
+# and nothing on screen shows it to them - so this page leads with what is in
+# there rather than with which button to press.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/remove-exif-and-gps-data"
+kind = "guide"
+nav = "EXIF and GPS data"
+group = "doing-the-job"
+tool = "exif-editor"
+
+title = "How to Remove EXIF and GPS Data From a Photo"
+description = "A photo off a phone usually carries the exact spot it was taken, the time to the second, and the camera's serial number. What is in there, who can read it, and how to take it out without touching the picture."
+
+heading = "What a photo says about you, and how to take it out"
+lede = """
+    A picture straight off a phone typically carries the coordinates of the
+    place it was taken, the time to the second, and enough about the camera to
+    tie it to every other photo from the same device. None of it is visible on
+    screen. This is what is in there and how to remove it."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "What a photo says about you, and how to take it out"
+og_description = "GPS coordinates, timestamps and serial numbers travel inside ordinary photos. What is in there, who can read it, and how to strip it."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/pages/guides/resize-an-image/body.html
+++ b/pages/guides/resize-an-image/body.html
@@ -1,0 +1,235 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      Open the <a href="../../resize-image/">Image Resizer</a>, drop your picture
+      in, type one number &mdash; the width, usually &mdash; and leave the other
+      blank. The height follows from the shape of the picture, which is almost
+      always what was wanted: &ldquo;1920 wide&rdquo; means &ldquo;1920 wide and
+      whatever tall that makes it&rdquo;.
+    </p>
+    <p>
+      Everything below is what to do when one number is not enough: when you have
+      been given a box with two sides, when the picture needs to get bigger, or
+      when a whole folder of files has to come out the same.
+    </p>
+  </section>
+
+  <section>
+    <h2>Shrinking is safe. Enlarging is not.</h2>
+    <p>
+      These are not two directions of the same operation, and it is worth being
+      clear about why.
+    </p>
+    <p>
+      <strong>Making a picture smaller</strong> throws information away, and in
+      the only benign sense: there are more pixels going in than coming out, so
+      every pixel of the result is averaged from real measured detail. A
+      well-resized smaller copy usually looks <em>better</em> than the original
+      viewed at that size, because the averaging removes noise. Nothing is
+      invented.
+    </p>
+    <p>
+      <strong>Making a picture bigger</strong> has to invent. The detail is not
+      missing from the file; it was never photographed. All any enlarger can do
+      is guess intermediate pixels from their neighbours, and a guess between
+      two known values is a smooth ramp &mdash; which is why an enlarged photo
+      looks soft rather than sharp. It is a bigger copy of the same picture, not
+      a more detailed one.
+    </p>
+    <p>
+      That is why &ldquo;never make a picture bigger than it started&rdquo; is
+      on by default in the tool here. Turn it off if you genuinely need the
+      pixel count &mdash; a print shop asking for a minimum size, a template
+      that refuses anything under a width &mdash; but do it knowing that you are
+      buying pixels, not detail.
+    </p>
+    <p>
+      The machine-learning upscalers that do appear to add detail are a
+      different thing entirely: they are inventing plausible texture from a model
+      of what pictures usually look like. For a wallpaper that is fine. For a
+      photograph of a person, a document, or anything anybody will draw a
+      conclusion from, understand that the extra detail is fiction.
+    </p>
+  </section>
+
+  <section>
+    <h2>Three ways to say what size you want</h2>
+    <p>
+      Most tools, including this one, accept the same three, and they suit
+      different jobs.
+    </p>
+    <ul>
+      <li>
+        <strong>Exact pixels.</strong> Use this when somebody has specified the
+        number: an avatar that must be 400&times;400, a banner that must be
+        1500 wide. Fill in one side and let the other follow unless you have
+        been given both.
+      </li>
+      <li>
+        <strong>A percentage.</strong> Use this when you want everything
+        proportionally smaller and do not care about the exact figure &mdash;
+        &ldquo;half size&rdquo; for a set of photos going into a document.
+      </li>
+      <li>
+        <strong>A long edge.</strong> The most useful of the three for a mixed
+        batch. &ldquo;Longest side 1600&rdquo; makes every picture fit inside a
+        1600-pixel square whether it is portrait or landscape, which is what
+        &ldquo;make these all a reasonable size&rdquo; usually means in
+        practice.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>When the box is a different shape from the picture</h2>
+    <p>
+      This is where resizing actually gets decided. If you give both a width and
+      a height and they do not match your picture's proportions, something has
+      to give, and there are exactly four things that can:
+    </p>
+    <ul>
+      <li>
+        <strong>Fit inside the box.</strong> The whole picture is kept and comes
+        out smaller than the box on one axis. Nothing is lost and nothing is
+        distorted; you just do not get the exact dimensions you asked for. This
+        is the right default for almost everything.
+      </li>
+      <li>
+        <strong>Fill the box and cut the overflow off.</strong> You get exactly
+        the dimensions you asked for, and the parts of the picture that hang
+        over the edges are gone. Right for thumbnails, avatars and covers, where
+        the shape is fixed and the subject is in the middle. Wrong when the
+        thing that matters is near an edge.
+      </li>
+      <li>
+        <strong>Pad it out.</strong> The whole picture is kept, centred, with
+        the leftover space filled with a colour you pick. Right when a system
+        demands exact dimensions and you cannot lose any of the image &mdash;
+        product listings often work this way.
+      </li>
+      <li>
+        <strong>Stretch it.</strong> The picture is squashed or pulled to fit.
+        This is never what you want unless you are doing it deliberately, and it
+        is the one that everyone recognises instantly as wrong.
+      </li>
+    </ul>
+    <p>
+      If you find yourself reaching for stretch, what you probably want is crop.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cropping is a different job, and often the right one</h2>
+    <p>
+      Resizing changes how many pixels describe the whole picture. Cropping
+      changes which part of the picture you keep. People reach for the first when
+      they mean the second surprisingly often &mdash; &ldquo;this needs to be
+      square&rdquo; is a cropping problem, not a resizing one.
+    </p>
+    <p>
+      Do them in that order: crop to the framing you want first, then resize the
+      result to the size you need. Doing it the other way round means choosing
+      the crop out of a picture that has already lost pixels.
+    </p>
+    <p>
+      The tool here does both in one pass for that reason &mdash; drag a box,
+      lock it to a shape if you need a specific ratio, then say what size the
+      result should come out. Doing it in one pass also means the picture is only
+      encoded once, which matters for the reason in the next section.
+    </p>
+    <h3>Cropping a whole batch</h3>
+    <p>
+      A box drawn on one picture is applied to the rest as the same
+      <em>relative</em> area: the same fractions of each file's own width and
+      height. For a folder of screenshots or exports that are all the same size,
+      that is the same rectangle exactly. For a mixed batch it is the same
+      framing rather than the same rectangle, which is usually what was wanted
+      but is worth knowing before you trust it with fifty files.
+    </p>
+  </section>
+
+  <section>
+    <h2>What the re-encode costs, and how to keep it to one</h2>
+    <p>
+      Resizing a JPEG or a WebP means decoding it, scaling the pixels, and
+      encoding them again &mdash; and that last step is lossy. The scaling
+      itself is not what costs you quality; the re-encode is.
+    </p>
+    <p>
+      Two things follow. First, the quality setting on the way out matters:
+      somewhere around 80&ndash;85 is invisible for a photograph and considerably
+      smaller than 100. Second, do it once. Resizing a picture that has been
+      resized twice already means three generations of lossy encoding, and it
+      shows.
+    </p>
+    <p>
+      A PNG has no such cost, because it is lossless &mdash; a resized PNG is
+      exactly the scaled pixels. If you are working through several steps and
+      the final format has not been decided, working in PNG in the middle avoids
+      stacking up generations.
+    </p>
+    <p>
+      One detail worth knowing about the tool here: a file you are not actually
+      changing at all is handed back byte for byte rather than re-encoded. Ask
+      for &ldquo;longest side 1600&rdquo; on a batch and the ones that are
+      already under 1600 come out untouched, tags and all. A tool that quietly
+      re-encoded them would be costing you quality on files nobody asked it to
+      change.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparency, and what happens to it</h2>
+    <p>
+      PNG and WebP can store transparency. JPEG cannot &mdash; there is no alpha
+      channel in the format at all. So saving a transparent image as JPEG has to
+      put something behind it, and that something is a flat colour.
+    </p>
+    <p>
+      Most tools use white and do not mention it, which is fine until your logo
+      lands on a dark page with a white box around it. Pick the colour
+      deliberately, or save as PNG or WebP and keep the transparency. The same
+      colour is used behind a padded frame, which is the other place people meet
+      this by surprise.
+    </p>
+  </section>
+
+  <section>
+    <h2>Which tool, if you were given a number</h2>
+    <p>
+      Two different numbers get handed out, and they need different tools.
+    </p>
+    <p>
+      <strong>&ldquo;1200 pixels wide&rdquo;</strong> is a dimensions problem.
+      The <a href="../../resize-image/">Image Resizer</a> is the one: you say how
+      many pixels you want and it gives you that.
+    </p>
+    <p>
+      <strong>&ldquo;Under 500&nbsp;KB&rdquo;</strong> is a file size problem, and
+      resizing is only one of the ways to solve it. The
+      <a href="../../compress-image/">Image Compressor</a> searches for the
+      highest quality that fits your target and resizes only if quality alone
+      cannot get there;
+      <a href="../compress-an-image-to-a-target-size/">its guide</a> covers what
+      that costs.
+    </p>
+  </section>
+
+  <section>
+    <h2>None of this needs an upload</h2>
+    <p>
+      Decoding an image, scaling it and encoding it again are things every
+      browser has been able to do for years &mdash; it is the same machinery a
+      web page uses to draw a picture at a different size. There is no technical
+      reason for your photo to travel to a server and back to come out smaller,
+      and the tool here does not send it anywhere: the page's
+      <code>Content-Security-Policy</code> names every address it may contact,
+      and none of them belongs to this site.
+    </p>
+    <p>
+      Load the page, unplug from the internet, and resize something anyway if you
+      would rather check than be told.
+      <a href="../is-it-safe-to-upload-files/">Is it safe to upload files to
+      online converters?</a> sets out three more checks you can run on any tool.
+    </p>
+  </section>

--- a/pages/guides/resize-an-image/page.toml
+++ b/pages/guides/resize-an-image/page.toml
@@ -1,0 +1,33 @@
+#
+# Guide: resizing an image.
+#
+# Written for the person who has been handed a number of pixels and does not
+# know what happens to their picture when they type it in: what "1200 wide"
+# does to the height, why enlarging cannot work, and what the four answers to
+# "the box is a different shape from my photo" actually do.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/resize-an-image"
+kind = "guide"
+nav = "Resizing an image"
+group = "doing-the-job"
+tool = "resize-image"
+
+title = "How to Resize an Image Without Wrecking It"
+description = "What happens to a picture when you change its pixel dimensions: why shrinking is safe and enlarging is not, what to do when the box is the wrong shape, and when to crop instead."
+
+heading = "How to resize an image without wrecking it"
+lede = """
+    Resizing is the one image job where the damage is decided before you press
+    the button, by which number you type and which shape you ask for. This is
+    what each choice does to the picture, and which of them you can undo."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "Resizing an image without wrecking it"
+og_description = "Why shrinking is safe and enlarging is not, what to do when the box is the wrong shape, and when to crop instead."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/pages/guides/trim-a-video/body.html
+++ b/pages/guides/trim-a-video/body.html
@@ -1,0 +1,192 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      Open the <a href="../../trim-video/">Video Trimmer</a>, drop the clip in,
+      mark the start and the end, and export. On an MP4, MOV or M4V the frames
+      you keep are moved into the new file exactly as they were &mdash; the same
+      bytes, the same encoder settings, the same everything &mdash; and the
+      sound is copied across sample by sample without being decoded.
+    </p>
+    <p>
+      That means a trim costs you nothing in quality, and it is fast: cutting a
+      minute out of a four-gigabyte recording costs about what writing that
+      minute to disk costs, because the frames are pointed at rather than loaded.
+      The one place this shows is where your cut actually lands, which is the
+      rest of this page.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why a trim need not lose quality at all</h2>
+    <p>
+      Trimming does not change what any frame looks like. Every frame you keep
+      is meant to come out identical to how it went in, so there is no reason to
+      decode it and encode it again &mdash; and every reason not to, since a
+      re-encode is lossy and would make the whole clip slightly worse in order
+      to shorten it.
+    </p>
+    <p>
+      So a good trimmer does not re-encode. It reads the file's index, works out
+      which encoded frames fall in your range, and writes those bytes into a new
+      container with a new index in front of them. Nothing is decoded at all on
+      that path.
+    </p>
+    <p>
+      Plenty of tools re-encode anyway, because decoding and re-encoding is much
+      simpler to implement than parsing the container format. You can usually
+      tell which kind you are using by how long it takes: a copy is limited by
+      how fast your disk writes, and a re-encode is limited by how fast your
+      machine encodes video, which is a hundred times slower.
+    </p>
+  </section>
+
+  <section>
+    <h2>Keyframes, and why your cut may land early</h2>
+    <p>
+      Here is the constraint that everything about trimming follows from.
+    </p>
+    <p>
+      Video is not stored as a sequence of complete pictures. That would be
+      enormous. Most frames are stored as a description of how they differ from
+      their neighbours, which means they cannot be decoded on their own &mdash;
+      you need the frames around them. Only a <strong>keyframe</strong> stands
+      alone as a complete picture, and keyframes are typically one to ten
+      seconds apart.
+    </p>
+    <p>
+      So if you mark a cut two seconds after the last keyframe, a trimmer that
+      copies frames cannot start there. The frames at your mark are unreadable
+      without the run that leads up to them. It has to carry the whole stretch
+      from the keyframe in front of your mark.
+    </p>
+    <p>
+      What it does about that is the interesting part. The file format has a
+      standard way to say <em>start playing at this point</em> &mdash; the extra
+      frames are in the file but the container instructs the player to skip
+      them. Every mainstream player honours it, and the clip begins exactly
+      where you said. A player that ignores it will start early, by up to the
+      keyframe gap.
+    </p>
+    <p>
+      The tool here tells you which case you are in and by how much before you
+      export, so it is a decision rather than a surprise.
+    </p>
+  </section>
+
+  <section>
+    <h2>When to accept a re-encode</h2>
+    <p>
+      There is an exact cut, and it works by re-encoding the opening stretch
+      &mdash; decoding from the keyframe, and writing out a new run of frames
+      that genuinely begins where you marked. It is slower, and it costs a
+      little quality on that opening stretch only.
+    </p>
+    <p>
+      Choose it when the clip is going somewhere that will not honour the
+      container's instruction, or where you cannot control the player: some
+      video editors, some broadcast and conferencing systems, some older
+      hardware players. Choose the copy for everything else, which is nearly
+      everything &mdash; a browser, a phone, a social platform, a media player.
+    </p>
+    <p>
+      A third option that costs nothing: move your mark. If the tool shows you
+      where the keyframes are, nudging the cut to the nearest one gives you an
+      exact cut with no re-encoding at all. It is rarely worth a second of
+      difference to give up on a copy.
+    </p>
+  </section>
+
+  <section>
+    <h2>Taking a piece out of the middle</h2>
+    <p>
+      Cutting a section out is a different operation from keeping one, and worth
+      knowing is supported, because a lot of trimmers only do the second. Mark
+      the part you do not want, choose to cut it out, and what is left on either
+      side is joined into one clip with the sound carried across in step.
+    </p>
+    <p>
+      The join has the same keyframe constraint at the point where the second
+      half resumes, for the same reason. It works on both MP4 paths here. It is
+      the one thing the recording fallback below cannot do, because a recording
+      is made in one pass from one playhead.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formats, and the fallback</h2>
+    <p>
+      <strong>MP4, M4V and MOV</strong> are read directly, whatever codec is
+      inside them &mdash; H.264, HEVC, AV1, VP9. Copying frames does not involve
+      decoding them, so this path works even for a codec your browser has no
+      decoder for at all, which is a pleasant consequence of not looking at the
+      pictures.
+    </p>
+    <p>
+      <strong>Anything else your browser can play</strong>, WebM most obviously,
+      is trimmed by playing it and recording the result. That works, and it has
+      two costs: it takes as long as the section is long, and the picture and
+      sound are encoded again.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV and most MKVs</strong> the browser can neither read
+      nor play, and the tool says so rather than failing halfway through. Convert
+      those to MP4 first with something that handles them.
+    </p>
+  </section>
+
+  <section>
+    <h2>Two things that quietly go wrong elsewhere</h2>
+    <p>
+      <strong>Rotation.</strong> A phone films in landscape and writes a
+      rotation instruction into the file rather than turning the pixels. A
+      trimmer that copies frames has to carry that instruction across, or your
+      portrait clip comes out on its side &mdash; which is the classic way a
+      trimmed video is ruined. The exact path here turns the frames as it
+      re-encodes them and writes a file that needs no rotation at all.
+    </p>
+    <p>
+      <strong>Audio sync.</strong> Audio and video are stored as separate
+      streams with their own timing, and they are not chopped at the same
+      points. If the two are not lined up deliberately at the cut, the sound
+      drifts. On the copy path here the audio is copied sample by sample without
+      being decoded, so it is byte for byte what was in the file, and an edit
+      mark keeps it in step with the picture to within a thousandth of a second.
+    </p>
+  </section>
+
+  <section>
+    <h2>Trimming is not cropping</h2>
+    <p>
+      Two words that get used for each other. Trimming changes the length of the
+      clip; cropping changes the shape of the picture. If what you want is a
+      square version of a landscape video, or the black bars gone from the
+      sides, that is the <a href="../../crop-video/">Video Cropper</a> &mdash;
+      and unlike trimming it does have to re-encode, for the reason
+      <a href="../crop-a-video/">its guide</a> explains.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why this does not need an upload &mdash; especially this</h2>
+    <p>
+      Video is the file type people most expect to have to upload, because the
+      files are large and the work sounds heavy. Trimming is the case where that
+      is least true: on the copy path the file is barely read at all. The tool
+      walks the index, works out which byte ranges to keep, and writes them out.
+      Uploading a four-gigabyte file to a server so it can do that would be the
+      slowest possible way to arrange it.
+    </p>
+    <p>
+      It is also the file type where uploading costs the most if you would
+      rather not: video carries faces, voices, homes and locations in a way a
+      document does not. The tool here has no network feature of any kind, and
+      the page's <code>Content-Security-Policy</code> names every address it may
+      contact, none of which belongs to this site.
+    </p>
+    <p>
+      Unplug from the internet and trim a clip anyway if you would rather check
+      than be told.
+      <a href="../is-it-safe-to-upload-files/">Is it safe to upload files to
+      online converters?</a> sets out three more checks like it.
+    </p>
+  </section>

--- a/pages/guides/trim-a-video/page.toml
+++ b/pages/guides/trim-a-video/page.toml
@@ -1,0 +1,33 @@
+#
+# Guide: trimming a video.
+#
+# The one job on this site where the interesting thing is a genuine technical
+# constraint rather than a preference: keyframes, why a cut lands early, and
+# the two honest ways round it. Somebody who reads this understands the "why
+# did it not cut where I told it" question that every trimmer gets asked.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/trim-a-video"
+kind = "guide"
+nav = "Trimming a video"
+group = "doing-the-job"
+tool = "trim-video"
+
+title = "How to Trim a Video Without Re-Encoding It"
+description = "Cutting a clip need not lose a single byte of quality. Why a cut sometimes lands earlier than you marked it, what a keyframe has to do with it, and when to accept a re-encode."
+
+heading = "How to trim a video without re-encoding it"
+lede = """
+    Trimming does not change what any frame looks like, so a good trimmer does
+    not touch them &mdash; it moves them into a new file exactly as they were.
+    This explains what that buys you, and the one place it shows."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "How to trim a video without re-encoding it"
+og_description = "Why a cut sometimes lands earlier than you marked it, what a keyframe has to do with it, and when to accept a re-encode."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/pages/guides/turn-images-into-a-video/body.html
+++ b/pages/guides/turn-images-into-a-video/body.html
@@ -1,0 +1,187 @@
+  <section>
+    <h2>The short answer</h2>
+    <p>
+      Open <a href="../../images-to-video/">Images to Video</a>, drop the
+      pictures in, put them in order, set how long each one is held, and create
+      the video. You get an MP4 with H.264 video, which plays on essentially
+      anything.
+    </p>
+    <p>
+      The two settings that most often need a second pass are the duration and
+      the resolution, and they are worth understanding before the first render
+      rather than after it.
+    </p>
+  </section>
+
+  <section>
+    <h2>Frame rate and duration are not the same thing</h2>
+    <p>
+      This is the confusion that costs people a re-render.
+    </p>
+    <p>
+      <strong>Duration</strong> is how long each picture stays on screen. It is
+      the setting you actually care about. Three seconds is a comfortable default
+      for a slideshow somebody is watching; one to two seconds feels brisk;
+      anything over five drags unless there is narration over it.
+    </p>
+    <p>
+      <strong>Frame rate</strong> is how many times a second the video repeats
+      that picture. It changes nothing about what the slideshow looks like
+      &mdash; a still image held for three seconds looks identical at 24 frames
+      per second and at 60 &mdash; and it changes the file size and the encoding
+      time quite a lot.
+    </p>
+    <p>
+      So for a plain slideshow, pick a low frame rate. 24 or 30 is plenty. The
+      reason to go higher is if there is motion in the video: a pan or zoom
+      across each photo, or a cross-fade between them, where a low frame rate
+      shows as visible stepping.
+    </p>
+  </section>
+
+  <section>
+    <h2>Resolution, and pictures of the wrong shape</h2>
+    <p>
+      A video has one frame size for its whole length. Your photographs almost
+      certainly do not all share one, so something has to happen to the ones
+      that do not fit &mdash; and that something is the choice worth making
+      deliberately.
+    </p>
+    <p>
+      Start by picking the resolution from where the video is going:
+    </p>
+    <ul>
+      <li>
+        <strong>1920&times;1080</strong> for anything general. Universally
+        supported, plays everywhere, and is what most people mean by HD.
+      </li>
+      <li>
+        <strong>1080&times;1920</strong> &mdash; the same numbers the other way
+        round &mdash; for a phone-first destination: stories, reels, shorts.
+      </li>
+      <li>
+        <strong>3840&times;2160</strong> only if the pictures genuinely have that
+        much detail and the destination will show it. It is four times the
+        pixels, four times the encoding time, and roughly four times the file.
+      </li>
+    </ul>
+    <p>
+      Then decide what happens to the mismatches. Fitting each picture inside
+      the frame keeps all of it and leaves bars at the sides &mdash; safe, and
+      the right answer when the pictures matter more than the presentation.
+      Filling the frame and cropping the overflow looks better and will cut the
+      top off some of them. Mixing portrait and landscape photographs in one
+      video is the case where there is no good answer; deciding in advance which
+      way you would rather be wrong saves a re-render.
+    </p>
+  </section>
+
+  <section>
+    <h2>Order, and the file-name trap</h2>
+    <p>
+      As with any batch job, file names sort in a way that is not the way you
+      counted. <code>photo2.jpg</code> comes after <code>photo10.jpg</code> in an
+      alphabetical sort, because the comparison is character by character.
+    </p>
+    <p>
+      Sorting by date taken is usually right for photographs of an event, since
+      you took them in the order they happened. Dragging the tiles is right for
+      anything where the story is not chronological. Check before you render:
+      the video is the one artefact where fixing the order means doing the whole
+      job again.
+    </p>
+  </section>
+
+  <section>
+    <h2>There is no soundtrack, and that is not a small thing</h2>
+    <p>
+      The MP4 this tool writes has a single video track and no audio track at
+      all. If your slideshow needs music or narration, you will need a video
+      editor for that step.
+    </p>
+    <p>
+      It is worth knowing why, rather than just that: adding audio means
+      decoding a music file, encoding it to AAC, and interleaving it with the
+      video in the container. All three are real work, and doing them badly
+      produces a file that drifts out of sync as it plays. It is on the list
+      rather than half-done.
+    </p>
+    <p>
+      A practical note if you do add music afterwards: pick the track first and
+      set the per-picture duration so the slideshow comes out close to the length
+      of the song. Trimming the music to fit the video always sounds worse than
+      fitting the video to the music.
+    </p>
+  </section>
+
+  <section>
+    <h2>What comes out, and what to do if it will not play</h2>
+    <p>
+      MP4 with H.264 is the target, and it is the most widely playable
+      combination there is. In a browser without WebCodecs the tool falls back to
+      recording WebM instead &mdash; the same footage in a container that fewer
+      editors and social platforms accept.
+    </p>
+    <p>
+      If you end up with a WebM and something refuses it, the fix is a browser
+      that supports WebCodecs rather than a conversion: current versions of
+      Chrome, Edge and Safari all do. Re-rendering is better than converting,
+      because converting means another generation of lossy encoding.
+    </p>
+    <p>
+      There is no limit built into the tool on how many pictures you can use.
+      The ceiling is your own machine's memory, because the finished video is
+      assembled there before you download it &mdash; a long 4K slideshow is the
+      first thing to feel it.
+    </p>
+  </section>
+
+  <section>
+    <h2>Making the file smaller</h2>
+    <p>
+      If the result is too large for wherever it is going, in order of what
+      actually helps:
+    </p>
+    <p>
+      <strong>Drop the frame rate.</strong> For a still slideshow this costs
+      nothing visible and is the largest single saving available.
+    </p>
+    <p>
+      <strong>Drop the resolution.</strong> 1080p instead of 4K is a quarter of
+      the pixels, and on a phone screen nobody will know.
+    </p>
+    <p>
+      <strong>Shorten it.</strong> Three seconds a picture instead of five is
+      40% off the length and 40% off the file, and usually a better slideshow.
+    </p>
+    <p>
+      Shrinking the source photographs first does not help much. The video is
+      encoded at the resolution you chose regardless, so a 4000-pixel photo and
+      a 2000-pixel one produce almost the same number of bytes in a 1080p video.
+      It does make the encoding quicker, and it moves that memory ceiling.
+    </p>
+  </section>
+
+  <section>
+    <h2>Why this does not need a server, with one exception stated</h2>
+    <p>
+      Encoding video used to be the clearest case for uploading: browsers could
+      not do it, and a machine with FFmpeg could. WebCodecs changed that by
+      exposing the hardware encoder that is already in your machine, which is
+      the same one your phone uses to record video in real time. Compositing the
+      frames is a canvas. Neither step needs anything but your own hardware.
+    </p>
+    <p>
+      One exception on this particular tool, stated rather than buried: the
+      optional &ldquo;add from a web address&rdquo; feature fetches an image
+      from an address you paste in, and the server at that address sees your IP
+      and what you asked for. That is inherent to the feature rather than a flaw
+      in it, and it is the only network step anywhere in the tool. Do not use it
+      and nothing leaves your machine at all.
+    </p>
+    <p>
+      <a href="../is-it-safe-to-upload-files/">Is it safe to upload files to
+      online converters?</a> sets out four checks that will tell you the same
+      thing about any tool, including this one.
+    </p>
+  </section>

--- a/pages/guides/turn-images-into-a-video/page.toml
+++ b/pages/guides/turn-images-into-a-video/page.toml
@@ -1,0 +1,33 @@
+#
+# Guide: turning images into a video.
+#
+# The job is easy and the settings are where it goes wrong: a frame rate people
+# confuse with how long each picture is held, a resolution that decides what
+# happens to photos of the wrong shape, and the fact that the result has no
+# sound track at all. Said plainly, before somebody renders a slideshow twice.
+#
+# Prose lives next door in body.html.
+#
+
+slug = "guides/turn-images-into-a-video"
+kind = "guide"
+nav = "Images into a video"
+group = "doing-the-job"
+tool = "images-to-video"
+
+title = "How to Turn a Folder of Images Into a Video"
+description = "Make an MP4 slideshow from photos: what frame rate and duration actually control, how to handle pictures that are the wrong shape, and why the result has no soundtrack."
+
+heading = "How to turn a folder of images into a video"
+lede = """
+    A slideshow is a simple thing to make and an easy one to render twice,
+    because two of the settings do not mean what they sound like. This is what
+    each of them controls and what to choose."""
+
+updated = "20 August 2026"
+published = "2026-08-20"
+lastmod = "2026-08-20"
+
+og_title = "How to turn a folder of images into a video"
+og_description = "What frame rate and duration actually control, how to handle pictures that are the wrong shape, and why there is no soundtrack."
+og_image_alt = "abox.tools - tools that never touch a server"

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -509,6 +509,7 @@ button, .as-button {
 }
 
 .faq h2 + .faq-list,
+.faq-list + h2,
 .how-to + h2 { margin-top: 1.6rem; }
 
 .how-to {
@@ -561,6 +562,22 @@ button, .as-button {
   border-radius: 4px;
   font-size: 0.88em;
 }
+
+/* The link to this tool's guide, under the questions. One line, because that
+   is what it is: the steps above say which button to press, and the guide is
+   for the reader who wants to know what the setting they are about to move
+   actually does. A card here would compete with the tool. */
+
+.tool-guide {
+  display: grid;
+  gap: 0.2rem;
+  margin: 0;
+  max-width: 68ch;
+  font-size: 0.93rem;
+}
+
+.tool-guide a { color: var(--accent); font-weight: 600; }
+.tool-guide-note { font-size: 0.88rem; color: var(--text-dim); }
 
 /* ---- footer ------------------------------------------------------------ */
 

--- a/shared/site.css
+++ b/shared/site.css
@@ -12,6 +12,11 @@
   --accent: #2b6cb0;
   --accent-deep: #1d4f83;
   --accent-pale: #d7e7f7;
+  /* What is legible on top of --accent. Not white in both themes: the dark
+     accent is a pale blue, and white on it is the kind of contrast that passes
+     a glance and fails a measurement. Same values as shared/css/tool-frame.css,
+     which defines it for the tool pages. */
+  --accent-text: #ffffff;
   /* Green means "this is true" across the site: the pledge ticks on a tool page
      use it, and so does the Built tag on the roadmap. Same values as
      shared/css/tool-frame.css, which defines it for the tool pages. */
@@ -31,6 +36,7 @@
     --accent: #5b9bd8;
     --accent-deep: #3772ab;
     --accent-pale: #cfe3f8;
+    --accent-text: #0d1117;
     --ok: #6cc79b;
     --shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 4px 12px rgb(0 0 0 / 20%);
   }
@@ -217,30 +223,36 @@ code {
 .tool-name { font-weight: 600; font-size: 1.02rem; }
 .tool-desc { font-size: 0.88rem; color: var(--text-dim); line-height: 1.5; }
 
-/* ---- the line that replaced the planned list on the hub ----------------- */
+/* ---- the quiet pointer line, and the count under a heading -------------- */
 
-/* Sits under the last category, where fifty planned names used to be. Quiet on
-   purpose: it is a pointer, and the tools above it are the point. */
-.roadmap-note {
+/* Both of these began on the roadmap and are now used by the guides index as
+   well, which is why neither is named after the roadmap any more. A class that
+   says `roadmap` on a page of guides is a class nobody can search for.
+
+   The pointer sits under the last section of a page, where the planned list
+   used to be on the hub. Quiet on purpose: it is a pointer, and what is above
+   it is the point. Two in a row - the hub has the guides and the roadmap -
+   need a little air between them. */
+.page-note {
   margin: 0;
   padding-top: 0.25rem;
   font-size: 0.9rem;
   color: var(--text-dim);
 }
 
-.roadmap-note a { color: var(--accent); }
+.page-note a { color: var(--accent); }
+.page-note + .page-note { padding-top: 0.55rem; }
 
-/* ---- the roadmap ------------------------------------------------------- */
-
-/* The two counts under the lede. Read off the lists by the build, so they are
-   a fact about the page rather than a claim in a sentence. */
-.roadmap-count {
+/* The count under a lede: how many planned, how many built, how many guides.
+   Read off the lists by the build, so it is a fact about the page rather than
+   a claim in a sentence. */
+.page-count {
   margin: 0.9rem 0 0;
   font-size: 0.85rem;
   color: var(--text-dim);
 }
 
-.roadmap-count strong {
+.page-count strong {
   color: var(--text);
   font-variant-numeric: tabular-nums;
 }
@@ -336,11 +348,98 @@ code {
 .logo-band { fill: var(--accent); }
 .logo-latch { fill: var(--accent-pale); }
 
+/* The trail above a guide's heading. A tool page gets the same three rules from
+   shared/css/tool-frame.css; they are repeated here for the same reason the
+   site mark above is, which is that site.css is a whole stylesheet rather than
+   one of the parts the build assembles. If one changes, change the other.
+
+   Legal pages are passed an empty trail and never render the element, so these
+   rules apply to guides and to nothing else. */
+
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-top: 0.9rem;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+.crumbs a { color: var(--text-dim); text-decoration: none; }
+.crumbs a:hover { color: var(--accent); text-decoration: underline; }
+.crumbs [aria-current="page"] { color: var(--text); }
+
+/* A guide with a crumb above it does not also need the header's usual gap. */
+.crumbs + .hub-head { padding-top: 1.5rem; }
+
 .legal-date {
   margin: 1rem 0 0;
   font-size: 0.82rem;
   color: var(--text-dim);
 }
+
+/* ---- the guides index --------------------------------------------------- */
+
+/* One column rather than the hub's grid of cards. A tool card is a name and an
+   icon and can sit beside three others; a guide card is a sentence, and a row
+   of sentences is a wall. Reading down a list is also how somebody decides
+   which of nine guides is the one they came for. */
+
+.guide-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.guide-card {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.95rem 1.1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.12s ease, transform 0.12s ease;
+}
+
+.guide-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.guide-name { font-weight: 600; font-size: 1rem; color: var(--accent); }
+.guide-desc { font-size: 0.88rem; color: var(--text-dim); line-height: 1.5; }
+
+/* The link from a guide to the tool it is about, under the lede. Loud enough
+   to be the way out for somebody who already knows what they want, quiet
+   enough not to be the first thing read on a page of prose. */
+
+.guide-cta {
+  margin: 1.25rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.2rem 0.6rem;
+}
+
+.guide-cta-link {
+  display: inline-block;
+  padding: 0.45rem 0.85rem;
+  background: var(--accent);
+  border-radius: var(--radius);
+  color: var(--accent-text);
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.guide-cta-link:hover { filter: brightness(1.08); }
+
+.guide-cta-note { font-size: 0.85rem; color: var(--text-dim); }
 
 .legal, .prose { max-width: 68ch; }
 

--- a/templates/guides.html
+++ b/templates/guides.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="{{ site.lang }}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<!--
+  GENERATED FILE - do not edit. Built by build.py from templates/guides.html,
+  config/site.toml, and one page.toml per guide under pages/guides/.
+  Edit those and run `python build.py`.
+
+  The index of the written half of this site. Nothing on it is written here:
+  every card below is a guide's own `heading` and `description`, the same two
+  strings that draw its <h1> and its <meta name="description">, so the promise
+  this page makes about a guide is the promise that guide keeps. Adding a guide
+  is adding a folder under pages/guides/ and naming it in a [[guides.groups]]
+  `order`; this file does not change.
+-->
+<!--
+  This page carries advertising, and ad code cannot run under default-src
+  'none'. The allowlist below is generated from config/site.toml, the same one
+  every other page is built from, so the pages cannot drift apart.
+-->
+{{ csp }}
+<title>{{ site.guides.title }}</title>
+<meta name="description" content="{{ site.guides.description }}">
+
+<link rel="canonical" href="{{ site.domain }}{{ site.guides.slug }}/">
+
+<meta name="google-adsense-account" content="{{ site.adsense_client }}">
+
+{% include "partials/head-scripts.html" %}
+
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="{{ site.name }}">
+<meta property="og:url" content="{{ site.domain }}{{ site.guides.slug }}/">
+<meta property="og:title" content="{{ site.guides.og_title }}">
+<meta property="og:description" content="{{ site.guides.og_description }}">
+<meta property="og:image" content="{{ site.domain }}og.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="{{ site.guides.og_image_alt }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ site.guides.og_title }}">
+<meta name="twitter:description" content="{{ site.guides.og_description }}">
+<meta name="twitter:image" content="{{ site.domain }}og.png">
+
+<!--
+  Structured data. The ItemList is built from the same guides that draw the
+  cards below, so a guide cannot appear in one and not the other.
+
+  Inline is deliberate and does not need 'unsafe-inline': a <script> whose type
+  is not a JavaScript type is a data block the parser never executes.
+-->
+<script type="application/ld+json">
+{{ jsonld }}
+</script>
+
+<!--
+  The stylesheet URL carries a hash of the stylesheet. GitHub Pages serves
+  HTML with max-age=600 and CSS with max-age=14400, so without this a deploy
+  reaches a returning visitor as new markup wearing a four-hour-old sheet.
+-->
+<link rel="stylesheet" href="{{ css_href }}">
+<link rel="icon" href="/logo.svg" type="image/svg+xml">
+<link rel="apple-touch-icon" href="/icon-180.png">
+</head>
+<body>
+
+<header class="hub-head">
+  <p class="brand">
+    <a class="brand-home" href="{{ base }}">
+      <span class="brand-mark" aria-hidden="true">{{ site.brand_mark }}</span> abox.tools
+    </a>
+  </p>
+  <h1>{{ site.guides.heading }}</h1>
+  <p class="lede">
+{{ site.guides.lede }}
+  </p>
+  <!-- Counted by the build off the list itself, so it cannot be the kind of
+       number that is right on the day it is typed and wrong ever after. The
+       noun comes with it rather than being written here, because a count
+       rendered into a fixed plural reads "1 guides" on the day it matters. -->
+  <p class="page-count">
+    <strong>{{ guide_count }}</strong> {{ guide_noun }}
+  </p>
+</header>
+
+<main>
+
+{% for group in groups %}
+  <section class="category" id="{{ group.id }}" aria-labelledby="{{ group.id }}-h">
+    <div class="category-head">
+      <h2 id="{{ group.id }}-h">{{ group.name }}</h2>
+      <p class="category-note">{{ group.note }}</p>
+    </div>
+    <ul class="guide-list">
+{% for guide in group.guides %}      <li>
+        <a class="guide-card" href="{{ base }}{{ guide.slug }}/">
+          <span class="guide-name">{{ guide.heading }}</span>
+          <span class="guide-desc">{{ guide.description }}</span>
+        </a>
+      </li>
+{% endfor %}    </ul>
+  </section>
+{% endfor %}
+  <p class="page-note">
+    Every guide here describes a tool that runs on your own machine:
+    <a href="{{ base }}">see all of them</a>.
+  </p>
+
+</main>
+
+{% include "partials/footer.html" %}
+
+</body>
+</html>

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -173,6 +173,17 @@
   </section>
 {% endfor %}
   <!--
+    The guides: the written half of the site, one per tool, explaining what a
+    setting costs rather than which button it is. Reachable from the footer of
+    every page as well; this is the line that offers it to somebody who has
+    just read the cards above and is not sure which of them they want.
+  -->
+  <p class="page-note">
+    Not sure which setting to move, or what it costs?
+    <a href="{{ base }}{{ site.guides.slug }}/">There is a guide for every tool</a>.
+  </p>
+
+  <!--
     The planned list used to be spelled out here, and had grown to about fifty
     names across six groups. That meant the last thing anybody saw on the front
     page was a long list of things this site cannot do yet, below the fold and
@@ -181,7 +192,7 @@
     It still exists, in full, on the roadmap - see templates/roadmap.html and
     config/planned.toml. This is the one line that points at it.
   -->
-  <p class="roadmap-note">
+  <p class="page-note">
     More is coming, and the list is public:
     <a href="{{ base }}{{ site.roadmap.slug }}/">see what is planned next</a>.
   </p>

--- a/templates/page.html
+++ b/templates/page.html
@@ -8,11 +8,17 @@
   config/site.toml, and pages/{{ page.slug }}/{page.toml,body.html}.
   Edit those and run `python build.py`.
 
-  A "page" here is a prose page that is not a tool and not the hub: the legal
-  pages. It gets the site frame, the same Content-Security-Policy as everywhere
-  else, and the same footer, and nothing else - no service worker, because there
-  is nothing to keep working offline, and no blob: in img-src, because it never
-  makes one.
+  A "page" here is a prose page that is not a tool and not the hub: a legal page
+  or a guide. It gets the site frame, the same Content-Security-Policy as
+  everywhere else, and the same footer, and nothing else - no service worker,
+  because there is nothing to keep working offline, and no blob: in img-src,
+  because it never makes one.
+
+  The two differ in three places below, all of them driven by values build.py
+  passes in rather than by a test written here: a guide gets a visible
+  breadcrumb, Article structured data, and - when it is about one particular
+  tool - a link to that tool under the heading. A legal page gets none of the
+  three, and the blocks simply do not appear.
 -->
 <!--
   This page carries advertising, and ad code cannot run under default-src
@@ -68,6 +74,19 @@
 </head>
 <body>
 
+<!--
+  The visible half of the BreadcrumbList in the head, and only where there is
+  one: a guide sits two levels down, under an index, and saying so is worth the
+  line. A legal page is passed an empty trail and this block does not render -
+  markup is meant to describe what a visitor can see, so a page with nothing to
+  show describes nothing.
+-->
+{% if crumbs %}<nav class="crumbs" aria-label="Breadcrumb">
+{% for crumb in crumbs %}  <a href="{{ crumb.href }}">{{ crumb.name }}</a>
+  <span aria-hidden="true">&rsaquo;</span>
+{% endfor %}  <span aria-current="page">{{ page.nav }}</span>
+</nav>
+{% endif %}
 <header class="hub-head">
   <p class="brand">
     <a class="brand-home" href="{{ base }}">
@@ -78,10 +97,26 @@
   <p class="lede">
 {{ page.lede }}
   </p>
-  <p class="legal-date">Last updated {{ page.updated }}</p>
+  <!--
+    The tool this guide is about, named once at the top where somebody who
+    already knows what they want can leave immediately. `tool` is empty on a
+    legal page and on a guide about no tool in particular, and then this is not
+    written at all.
+  -->
+{% if tool %}  <p class="guide-cta">
+    <a class="guide-cta-link" href="{{ base }}{{ tool.slug }}/">Open the {{ tool.name | e }}</a>
+    <span class="guide-cta-note">{{ tool.tagline }}</span>
+  </p>
+{% endif %}  <p class="legal-date">Last updated {{ page.updated }}</p>
 </header>
 
-<main class="legal">
+<!--
+  `prose` on a guide and `legal` on a legal page. The two rule sets are the same
+  narrow column - they are written as one selector list in shared/site.css - and
+  the class is still worth getting right, because a stylesheet that calls a
+  guide a legal page is a stylesheet nobody can search.
+-->
+<main class="{{ main_class }}">
 {{ body }}
 </main>
 

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -9,9 +9,9 @@
   `base`: './' at the root, '../' one level down. Every link below is built from
   it, so nothing here has to know which kind of page it landed on.
 
-  The tool list and the legal-page list are passed in by build.py from the
-  folders that exist, so a new tool or a new page appears here without anybody
-  remembering to add it.
+  The tool list, the guide list and the legal-page list are passed in by
+  build.py from the folders that exist, so a new tool, a new guide or a new page
+  appears here without anybody remembering to add it.
 -->
 <footer>
   <div class="footer-cols">
@@ -32,13 +32,31 @@
 {% endfor %}      </ul>
     </div>
 
+    <!--
+      The guides, with their own index at the top of the column. The index is
+      the entry that matters - it is the only one of these links that keeps
+      working as the list grows - but the guides themselves are listed under it
+      as well, because a footer link is how a reader who is already on a page
+      finds the next one without going back through an index first.
+
+      Like the tool list, this comes from the folders that exist, in the order
+      config/site.toml groups them in, so a new guide reaches every footer on
+      the site without anybody editing this file.
+    -->
+    <div class="footer-col">
+      <strong>Guides</strong>
+      <ul>
+        <li><a href="{{ base }}{{ site.guides.slug }}/">{{ site.guides.nav }}</a></li>
+{% for g in footer.guides %}        <li><a href="{{ base }}{{ g.slug }}/">{{ g.nav }}</a></li>
+{% endfor %}      </ul>
+    </div>
+
     <div class="footer-col">
       <strong>This site</strong>
       <ul>
         <li><a href="{{ base }}">All tools</a></li>
         <li><a href="{{ base }}{{ site.roadmap.slug }}/">{{ site.roadmap.nav }}</a></li>
-{% for g in footer.guides %}        <li><a href="{{ base }}{{ g.slug }}/">{{ g.nav }}</a></li>
-{% endfor %}{% for p in footer.pages %}        <li><a href="{{ base }}{{ p.slug }}/">{{ p.nav }}</a></li>
+{% for p in footer.pages %}        <li><a href="{{ base }}{{ p.slug }}/">{{ p.nav }}</a></li>
 {% endfor %}        <li><a href="/sitemap.xml">Sitemap</a></li>
       </ul>
     </div>

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -91,7 +91,7 @@
     the way a number typed into a sentence goes wrong the first time a tool
     ships and nobody remembers this page exists.
   -->
-  <p class="roadmap-count">
+  <p class="page-count">
     <strong>{{ planned_count }}</strong> planned
     &middot;
     <strong>{{ built_count }}</strong> built

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -258,7 +258,25 @@
       </p>
     </details>
 {% endfor %}  </div>
-</section>
+
+  <!--
+    The guide for this tool, if one has been written. The steps above say which
+    button to press; the guide is for the reader who wants to know what the
+    setting they are about to move actually does, and why the answer is what it
+    is. It is not written twice: the link's text is the guide's own heading and
+    the line under it is the guide's own description, so it cannot promise
+    something the guide does not go on to say.
+
+    Which guide belongs to which tool is one line - `tool` in that guide's
+    page.toml - and the build turns it into both halves of the link, this one
+    and the one back. A tool with no guide yet renders nothing here.
+  -->
+{% if guide %}  <h2 id="guide-h">The longer version</h2>
+  <p class="tool-guide">
+    <a href="{{ base }}{{ guide.slug }}/">{{ guide.heading }}</a>
+    <span class="tool-guide-note">{{ guide.description }}</span>
+  </p>
+{% endif %}</section>
 
 {% include "partials/footer.html" %}
 

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -156,6 +156,74 @@ class EmitterOutput(unittest.TestCase):
                          source)
 
 
+class GuideGroups(unittest.TestCase):
+    """Every way a guide could be written and then linked to from nowhere.
+
+    The same three refusals the hub already makes about tools and categories,
+    and they matter more here: a tool that vanished from the hub would be
+    noticed the first time somebody looked at the front page, whereas a guide
+    that fell out of the index is only ever missed by the reader who never
+    found it.
+    """
+
+    SITE = {'guides': {'slug': 'guides', 'groups': [
+        {'id': 'g', 'name': 'G', 'note': 'n', 'order': ['a', 'b']}]}}
+
+    def guide(self, name, group='g'):
+        return {'slug': f'guides/{name}', 'group': group, 'tool': ''}
+
+    def test_the_order_in_the_config_is_the_order_on_the_page(self):
+        guides = [self.guide('b'), self.guide('a')]
+        groups = buildmod.guide_groups(self.SITE, guides)
+        self.assertEqual([g['slug'] for g in groups[0]['guides']],
+                         ['guides/a', 'guides/b'])
+
+    def test_a_guide_no_group_lists_is_refused(self):
+        guides = [self.guide('a'), self.guide('b'), self.guide('c')]
+        with self.assertRaises(buildmod.sitelib.ConfigError) as caught:
+            buildmod.guide_groups(self.SITE, guides)
+        self.assertIn('c', str(caught.exception))
+
+    def test_a_group_naming_a_guide_that_does_not_exist_is_refused(self):
+        with self.assertRaises(buildmod.sitelib.ConfigError) as caught:
+            buildmod.guide_groups(self.SITE, [self.guide('a')])
+        self.assertIn('b', str(caught.exception))
+
+    def test_the_two_halves_have_to_agree_on_the_group(self):
+        guides = [self.guide('a'), self.guide('b', group='elsewhere')]
+        with self.assertRaises(buildmod.sitelib.ConfigError) as caught:
+            buildmod.guide_groups(self.SITE, guides)
+        self.assertIn('elsewhere', str(caught.exception))
+
+
+class GuidesAndTools(unittest.TestCase):
+    """One line in a guide's page.toml makes both halves of the link."""
+
+    def test_a_guide_is_found_by_the_slug_of_its_tool(self):
+        guide = {'slug': 'guides/a', 'tool': 'widget'}
+        owned = buildmod.tie_guides_to_tools([guide], {'widget': {}})
+        self.assertIs(owned['widget'], guide)
+
+    def test_a_guide_about_no_tool_claims_none(self):
+        guide = {'slug': 'guides/a', 'tool': ''}
+        self.assertEqual(buildmod.tie_guides_to_tools([guide], {'widget': {}}), {})
+
+    def test_a_tool_that_does_not_exist_is_refused(self):
+        guide = {'slug': 'guides/a', 'tool': 'gadget'}
+        with self.assertRaises(buildmod.sitelib.ConfigError) as caught:
+            buildmod.tie_guides_to_tools([guide], {'widget': {}})
+        self.assertIn('gadget', str(caught.exception))
+
+    def test_two_guides_cannot_claim_one_tool(self):
+        # A tool page links to one guide, so the second would be written and
+        # never linked.
+        guides = [{'slug': 'guides/a', 'tool': 'widget'},
+                  {'slug': 'guides/b', 'tool': 'widget'}]
+        with self.assertRaises(buildmod.sitelib.ConfigError) as caught:
+            buildmod.tie_guides_to_tools(guides, {'widget': {}})
+        self.assertIn('guides/b', str(caught.exception))
+
+
 class BuildTheSite(unittest.TestCase):
     """A whole plain build, into a temporary directory.
 
@@ -281,6 +349,48 @@ class BuildTheSite(unittest.TestCase):
         for path in ROOT.glob('tools/*/tool.toml'):
             with self.subTest(tool=path.parent.name):
                 self.assertIn(f'/{path.parent.name}/', page)
+
+    def test_every_guide_in_the_repository_got_a_page(self):
+        slugs = sorted(p.parent.name for p in ROOT.glob('pages/guides/*/page.toml'))
+        self.assertTrue(slugs)
+        for slug in slugs:
+            with self.subTest(guide=slug):
+                self.assertIn(f'guides/{slug}/index.html', self.written)
+
+    def test_the_guides_index_links_every_guide(self):
+        index = (self.out / 'guides' / 'index.html').read_text(encoding='utf-8')
+        for path in ROOT.glob('pages/guides/*/page.toml'):
+            with self.subTest(guide=path.parent.name):
+                self.assertIn(f'guides/{path.parent.name}/', index)
+
+    def test_every_page_footer_reaches_the_guides_index(self):
+        # The footer is the second navigation, and the index is the one link in
+        # it that keeps working however long the list of guides grows.
+        for name in self.written:
+            if not name.endswith('.html'):
+                continue
+            with self.subTest(page=name):
+                text = (self.out / name).read_text(encoding='utf-8')
+                self.assertRegex(text, r'href="(\.\./|\./|/)*guides/"')
+
+    def test_a_guide_and_its_tool_link_to_each_other(self):
+        """One line - `tool` in the guide's page.toml - makes both halves.
+
+        Checking both directions is the point: written as two settings they
+        could disagree about which page is about which, and the way that shows
+        up is a tool page pointing at a guide that never mentions it."""
+        pages = ROOT.glob('pages/guides/*/page.toml')
+        pairs = [(p.parent.name, buildmod.sitelib.load_toml(p).get('tool'))
+                 for p in pages]
+        pairs = [(guide, tool) for guide, tool in pairs if tool]
+        self.assertTrue(pairs)
+        for guide, tool in pairs:
+            with self.subTest(guide=guide):
+                tool_page = (self.out / tool / 'index.html').read_text(encoding='utf-8')
+                self.assertIn(f'../guides/{guide}/', tool_page)
+                guide_page = (self.out / 'guides' / guide / 'index.html'
+                              ).read_text(encoding='utf-8')
+                self.assertIn(f'../../{tool}/', guide_page)
 
     def test_shared_files_are_copied_but_the_css_sources_are_not(self):
         self.assertTrue((self.out / 'robots.txt').is_file())

--- a/tests/python/test_site.py
+++ b/tests/python/test_site.py
@@ -20,7 +20,9 @@ from pathlib import Path
 
 from buildlib import site as sitelib
 
-SITE = {'domain': 'https://example.test/', 'name': 'Site', 'lang': 'en'}
+SITE = {'domain': 'https://example.test/', 'name': 'Site', 'lang': 'en',
+        'guides': {'slug': 'guides', 'heading': 'Guides',
+                   'description': 'every guide'}}
 
 TOOL_TOML = '''
 slug = "widget"
@@ -243,6 +245,28 @@ class StructuredData(unittest.TestCase):
         self.assertEqual(graph[0]['datePublished'], '2026-01-01')
         self.assertEqual(graph[0]['dateModified'], '2026-02-01')
 
+    def test_a_guides_breadcrumb_goes_through_the_index(self):
+        # Three steps, because the visible trail on the page has three. Markup
+        # is meant to describe what a visitor can see.
+        page = {'kind': 'guide', 'heading': 'H', 'description': 'd', 'nav': 'N',
+                'url': 'https://example.test/guides/x/',
+                'published': '2026-01-01', 'lastmod': '2026-02-01'}
+        graph = json.loads(sitelib.page_jsonld(SITE, page))['@graph']
+        trail = graph[1]['itemListElement']
+        self.assertEqual([step['position'] for step in trail], [1, 2, 3])
+        self.assertEqual([step['item'] for step in trail],
+                         ['https://example.test/',
+                          'https://example.test/guides/',
+                          'https://example.test/guides/x/'])
+
+    def test_the_guides_index_lists_the_guides_in_order(self):
+        guides = [{'heading': 'First', 'url': 'https://example.test/guides/a/'},
+                  {'heading': 'Second', 'url': 'https://example.test/guides/b/'}]
+        graph = json.loads(sitelib.guides_jsonld(SITE, guides))['@graph']
+        items = graph[0]['mainEntity']['itemListElement']
+        self.assertEqual([item['position'] for item in items], [1, 2])
+        self.assertEqual([item['name'] for item in items], ['First', 'Second'])
+
     def test_a_legal_page_gets_no_structured_data(self):
         # Inventing schema for a privacy policy would describe the page as
         # something it is not.
@@ -305,7 +329,7 @@ class LoadPage(TempTree):
 
     def test_a_guide_sits_one_level_deeper(self):
         body = (PAGE_TOML.replace('slug = "privacy"', 'slug = "guides/why"')
-                + 'kind = "guide"\npublished = "2026-01-01"\n')
+                + 'kind = "guide"\npublished = "2026-01-01"\ngroup = "g"\n')
         page = sitelib.load_page(self.page_at('guides/why', body), SITE,
                                  self.root / 'pages')
         self.assertEqual(page['depth'], 2)
@@ -329,11 +353,27 @@ class LoadPage(TempTree):
         # Defaulting to lastmod would quietly claim a correction was the
         # original.
         body = (PAGE_TOML.replace('slug = "privacy"', 'slug = "guides/why"')
-                + 'kind = "guide"\n')
+                + 'kind = "guide"\ngroup = "g"\n')
         with self.assertRaises(sitelib.ConfigError) as caught:
             sitelib.load_page(self.page_at('guides/why', body), SITE,
                               self.root / 'pages')
         self.assertIn('published', str(caught.exception))
+
+    def test_a_guide_must_name_the_group_it_appears_under(self):
+        # A guide with no group would be built, sit at a URL, and be linked to
+        # from nowhere at all.
+        body = (PAGE_TOML.replace('slug = "privacy"', 'slug = "guides/why"')
+                + 'kind = "guide"\npublished = "2026-01-01"\n')
+        with self.assertRaises(sitelib.ConfigError) as caught:
+            sitelib.load_page(self.page_at('guides/why', body), SITE,
+                              self.root / 'pages')
+        self.assertIn('group', str(caught.exception))
+
+    def test_a_page_that_names_no_tool_gets_an_empty_one(self):
+        # Falsy rather than missing, so the template can ask without a page
+        # having to declare that it is about nothing.
+        page = sitelib.load_page(self.page_at('privacy'), SITE, self.root / 'pages')
+        self.assertEqual(page['tool'], '')
 
     def test_a_missing_key_is_named(self):
         body = PAGE_TOML.replace('lede = "l"\n', '')

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -16,6 +16,9 @@ tagline = "Say the size. Draw the box. Pick the format."
 icon = "&#128208;"          # the mark beside the page heading
 favicon = "&#128208;"       # the tab icon, drawn into an inline SVG
 category = "images-and-video"
+# Which group on the roadmap this tool joins, by the id in config/planned.toml.
+# It sits at the top of that group as a link, above the names still to be built.
+roadmap_group = "images"
 
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that


### PR DESCRIPTION
The site had one guide, and no way to find it except a line in the footer. It
now has nine, an index at **`/guides/`**, and a link in both directions between
every tool and the guide about it.

## The guides

Eight new ones, one per tool. A tool page answers *which button do I press*;
these answer *what does the setting I am about to move actually do, and what
does it cost me*.

| Guide | Tool |
|---|---|
| How to compress an image to an exact file size | Image Compressor |
| How to resize an image without wrecking it | Image Resizer |
| What a photo says about you, and how to take it out | EXIF Viewer & Remover |
| How to make a PDF smaller, and why some will not shrink | PDF Compressor |
| How to combine images into one PDF | Images to PDF |
| How to turn a folder of images into a video | Images to Video |
| How to trim a video without re-encoding it | Video Trimmer |
| How to crop a video to a different shape | Video Cropper |

They are written to be useful rather than to be filler: keyframes and why a
trimmed clip starts earlier than you marked it; why a PNG will not compress the
way a JPEG does; what DPI means inside a PDF and why a logo placed small is not
treated like a full-page scan; the four things that can happen when a resize box
is a different shape from the picture. Each one ends where the site's existing
guide does - with how to check the no-upload claim rather than be asked to
believe it.

## How it is wired

The same arrangement the hub and the roadmap already use, so there is no second
place to remember:

- `[guides]` in `config/site.toml` is the frame around the list. The only thing
  written there rather than derived is `[[guides.groups]]`: the grouping, and
  the order within each group.
- A guide names its group in its own `page.toml`, and optionally the tool it is
  about. That one `tool` key produces **both** halves of the link - the
  "Open the ..." button under the guide's lede and "The longer version" under
  the tool's questions - so the two cannot disagree about which page is about
  which. Neither link's text is written twice either: the tool page shows the
  guide's own heading and description, and the guide shows the tool's own name
  and tagline.
- The footer, `sitemap.xml` and the index itself all come from the folders that
  exist, so a tenth guide needs no edit to any of them.

### Five refusals

The build stops rather than quietly producing a page nothing links to: a guide
with no `group`; a group naming a guide that does not exist; a guide that exists
and that no group lists; a `tool` naming a tool that does not exist; two guides
claiming the same tool. The first three are the checks `build_hub` already makes
about tools and categories.

## Also in here

- **`resize-image` had no `roadmap_group`**, so `python build.py` has failed on
  `main` since #24 landed after #25. One line, and the build passes again.
- A guide now carries a **visible breadcrumb** through the index as well as the
  `BreadcrumbList` that describes it, and wears `prose` rather than `legal`.
- The hub gets one line pointing at the index, above the roadmap line.
- `.roadmap-note` / `.roadmap-count` are now `.page-note` / `.page-count`. The
  guides index uses both, and a class that says `roadmap` on a page of guides is
  a class nobody can search for.
- `--accent-text` is added to `site.css`, mirroring `tool-frame.css`, so the one
  filled button on these pages is legible in dark mode as well as light.

## Checks

- `python -m unittest discover -t . -s tests/python` - 266 pass (12 new, covering
  the grouping refusals, the guide/tool tie-in in both directions, and that every
  page's footer reaches the index).
- `node --test "tests/js/*.test.js"` - 534 pass, untouched.
- Every internal link in `dist/` resolves; all new files are ASCII and LF.
- Checked in a browser at desktop and mobile widths, in light and dark.

README updated: "The legal pages" is now "The prose pages", plus a section on
adding a guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
