### PR TITLE
Give the guides one footer link instead of a column

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ something the build does, and cannot forget to do:
 | Four copies of the repository URL per page | `source_url` in `config/site.toml`. |
 | A cache name to bump by hand when minification changed the bytes | The cache name hashes the files **as emitted**, so turning minifying on or off invalidates the cache by itself. |
 | Nothing at all, which is how a stylesheet change reached returning visitors four hours late | Every page asks for its stylesheet by a URL carrying a hash of that stylesheet, so changing the CSS changes the URL and there is no stale copy to serve. |
-| Three different footers, none of which linked to a privacy policy because there was nowhere to put one | One `templates/partials/footer.html`. Its tool list, guide list and legal-page list come from `tools/` and `pages/`, and the only thing that differs per page is whether links start `./` or `../`. |
+| Three different footers, none of which linked to a privacy policy because there was nowhere to put one | One `templates/partials/footer.html`. Its tool list and legal-page list come from `tools/` and `pages/`, and the only thing that differs per page is whether links start `./` or `../`. |
 
 The build refuses to produce a site rather than produce a broken one. A missing
 config key, a tool whose folder and `slug` disagree, a tool listed on the hub
@@ -470,11 +470,14 @@ pages/guides/trim-a-video/          kind = "guide"
   body.html    the same
 ```
 
-`nav` is the label the footer uses. Either kind gets the site frame, the site's
-Content-Security-Policy unchanged, an entry in `sitemap.xml`, and a link in the
-footer of every page on the site. Neither gets a service worker, because there
-is nothing here worth keeping offline, or `blob:` in `img-src`, because neither
+Either kind gets the site frame, the site's Content-Security-Policy unchanged,
+and an entry in `sitemap.xml`. Neither gets a service worker, because there is
+nothing here worth keeping offline, or `blob:` in `img-src`, because neither
 ever makes one.
+
+`nav` is the short label. A legal page uses it for its own link in the footer;
+a guide uses it for the last step of its breadcrumb, because guides are reached
+through their index rather than listed one by one down there.
 
 A **legal** page is Privacy or Terms. It matters for trust rather than for
 search, which is why it sits at the lowest priority the sitemap has and carries
@@ -538,8 +541,10 @@ a legal page does not have:
 | `tool` | optional: the slug of the tool it is about |
 
 Then name the folder in that group's `order` list. Everything else follows: the
-card on the index, the entry in the footer of every page, the line in
-`sitemap.xml`, and both halves of the link between the guide and its tool.
+card on the index, the line in `sitemap.xml`, and both halves of the link
+between the guide and its tool. The footer needs nothing — it carries one link
+to the index, not an entry per guide, so it does not grow by a line every time
+somebody writes one.
 
 ### The three refusals
 

--- a/build.py
+++ b/build.py
@@ -157,18 +157,22 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     guide_of = tie_guides_to_tools(ordered_guides, by_slug)
 
     # What the footer on every page is built from. Derived from the folders that
-    # exist rather than written down anywhere, so a new tool, a new guide or a
-    # new legal page reaches every footer on the site without a second edit.
+    # exist rather than written down anywhere, so a new tool or a new legal page
+    # reaches every footer on the site without a second edit.
     # Tools in the order the hub shows them, not the order the folders happen to
     # sort in, so the footer and the cards above it agree. A slug named here that
     # has no tool, or a tool named nowhere, is caught by build_hub below.
+    #
+    # No guide list. The footer carries one link to the guides index instead of
+    # an entry per guide - a column that grew by a line every time somebody
+    # wrote one, in front of a reader who was looking for the privacy page. The
+    # index is the link that keeps working however long the list gets, and it is
+    # already built from the folders that exist.
     ordered = [by_slug[slug]
                for category in site['hub']['categories']
                for slug in category['order'] if slug in by_slug]
     footer = {
         'tools': [{'name': tool['name'], 'slug': tool['slug']} for tool in ordered],
-        'guides': [{'nav': page['nav'], 'slug': page['slug']}
-                   for page in ordered_guides],
         'pages': [{'nav': page['nav'], 'slug': page['slug']} for page in legal],
     }
 

--- a/config/site.toml
+++ b/config/site.toml
@@ -305,6 +305,11 @@ og_image_alt = "abox.tools - tools that never touch a server"
 
 [guides]
 slug = "guides"
+# The footer label, sitting directly under "All tools" and deliberately matching
+# it: the two are the front door to each half of the site. It is the only guide
+# link in the footer - the guides themselves are reached from the index rather
+# than listed one by one, which is what stops that column growing by a line
+# every time one is written.
 nav = "All guides"
 lastmod = "2026-08-20"
 

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -9,9 +9,10 @@
   `base`: './' at the root, '../' one level down. Every link below is built from
   it, so nothing here has to know which kind of page it landed on.
 
-  The tool list, the guide list and the legal-page list are passed in by
-  build.py from the folders that exist, so a new tool, a new guide or a new page
-  appears here without anybody remembering to add it.
+  The tool list and the legal-page list are passed in by build.py from the
+  folders that exist, so a new tool or a new page appears here without anybody
+  remembering to add it. The guides are reached through their index rather than
+  listed one by one - see the comment above that link.
 -->
 <footer>
   <div class="footer-cols">
@@ -33,28 +34,22 @@
     </div>
 
     <!--
-      The guides, with their own index at the top of the column. The index is
-      the entry that matters - it is the only one of these links that keeps
-      working as the list grows - but the guides themselves are listed under it
-      as well, because a footer link is how a reader who is already on a page
-      finds the next one without going back through an index first.
+      The guides get one link, not a column of their own. Every guide used to be
+      listed here, which made a fourth column that grew by a line every time one
+      was written and put nine near-identical entries in front of somebody who
+      wanted the privacy page. The index is the entry that matters: it is the
+      one link that keeps working however long the list gets, and it is where a
+      reader can see all of them side by side with a sentence each, which a
+      footer column cannot do.
 
-      Like the tool list, this comes from the folders that exist, in the order
-      config/site.toml groups them in, so a new guide reaches every footer on
-      the site without anybody editing this file.
+      It sits directly under "All tools" because the two are the same kind of
+      thing - the front door to each half of the site.
     -->
-    <div class="footer-col">
-      <strong>Guides</strong>
-      <ul>
-        <li><a href="{{ base }}{{ site.guides.slug }}/">{{ site.guides.nav }}</a></li>
-{% for g in footer.guides %}        <li><a href="{{ base }}{{ g.slug }}/">{{ g.nav }}</a></li>
-{% endfor %}      </ul>
-    </div>
-
     <div class="footer-col">
       <strong>This site</strong>
       <ul>
         <li><a href="{{ base }}">All tools</a></li>
+        <li><a href="{{ base }}{{ site.guides.slug }}/">{{ site.guides.nav }}</a></li>
         <li><a href="{{ base }}{{ site.roadmap.slug }}/">{{ site.roadmap.nav }}</a></li>
 {% for p in footer.pages %}        <li><a href="{{ base }}{{ p.slug }}/">{{ p.nav }}</a></li>
 {% endfor %}        <li><a href="/sitemap.xml">Sitemap</a></li>

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -373,6 +373,19 @@ class BuildTheSite(unittest.TestCase):
                 text = (self.out / name).read_text(encoding='utf-8')
                 self.assertRegex(text, r'href="(\.\./|\./|/)*guides/"')
 
+    def test_the_footer_links_the_index_rather_than_every_guide(self):
+        """One link, not a column that grows by a line per guide.
+
+        Checked on the privacy page, because it is the one kind of page whose
+        own prose links no guide at all - so anything matching here could only
+        have come from the footer."""
+        names = sorted(p.parent.name for p in ROOT.glob('pages/guides/*/page.toml'))
+        self.assertTrue(names)
+        legal = (self.out / 'privacy' / 'index.html').read_text(encoding='utf-8')
+        for guide in names:
+            with self.subTest(guide=guide):
+                self.assertNotIn(f'guides/{guide}/', legal)
+
     def test_a_guide_and_its_tool_link_to_each_other(self):
         """One line - `tool` in the guide's page.toml - makes both halves.
 


### PR DESCRIPTION
Follow-up to #31. The footer listed every guide under a heading of its own.
That column grew by a line every time one was written, and it put nine
near-identical entries in front of a reader who had scrolled to the bottom
looking for the privacy page.

**Before**

```
Tools            Guides                      This site
...              All guides                  All tools
                 Compressing an image        Roadmap
                 Resizing an image           Privacy & Cookies
                 EXIF and GPS data           Terms of Use
                 Making a PDF smaller        Sitemap
                 Images into a PDF
                 Images into a video
                 Trimming a video
                 Cropping video
                 Is it safe to upload files?
```

**After**

```
Tools            This site
...              All tools
                 All guides
                 Roadmap
                 Privacy & Cookies
                 Terms of Use
                 Sitemap
```

`All guides` sits directly under `All tools` because the two are the same kind
of thing — the front door to each half of the site. The index is also the only
one of those links that keeps working however long the list gets, and it is
where the guides can be seen side by side with a sentence each, which a footer
column cannot do.

`footer.guides` is dropped from `build.py` with it, since nothing reads it any
more. The guides index, `sitemap.xml`, the breadcrumbs and both halves of the
guide-to-tool link are untouched and still derived from the folders that exist.

## Checks

- `python -m unittest discover -t . -s tests/python` — 267 pass, one new: the
  privacy page is the one kind whose own prose links no guide, so a guide URL
  appearing there could only have come from the footer.
- `node --test "tests/js/*.test.js"` — 639 pass, untouched.
- Footer checked rendered on a hub, tool, guide and legal page.

## Worth knowing

`edit-audio` (#29) landed alongside the guides work and is the one tool
without one — which makes the index's "One guide per tool" lede a slight
overstatement. Not touched here to keep this diff to the footer; say the word
and I will write it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
