### PR TITLE
Stop the tool pages scrolling sideways on a phone

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -46,6 +46,12 @@
    anyway. This keeps the attribute authoritative. */
 [hidden] { display: none !important; }
 
+/* A fieldset's automatic minimum width is min-content rather than zero, and no
+   author rule short of this one changes it. Every options fieldset on this site
+   holds a <select> whose longest option is a sentence, so the box refused to
+   shrink below that sentence and the whole page scrolled sideways on a phone. */
+fieldset { min-inline-size: 0; }
+
 body {
   margin: 0;
   padding: 0 1rem 3rem;

--- a/shared/css/url-import.css
+++ b/shared/css/url-import.css
@@ -47,6 +47,14 @@
   resize: vertical;
 }
 
+/* Safari zooms the page into any field it is asked to focus whose text is under
+   16px, and then leaves it zoomed - which on the one field here somebody has to
+   type a whole URL into is worth avoiding. Only where there is a finger, so the
+   monospace column this panel is set in is unchanged on a desktop. */
+@media (pointer: coarse) {
+  .url-body textarea { font-size: 16px; }
+}
+
 .url-actions { display: flex; align-items: center; gap: 0.7rem; margin-top: 0.6rem; flex-wrap: wrap; }
 .url-status { font-size: 0.85rem; color: var(--text-dim); }
 .url-note { margin: 0.6rem 0 0; font-size: 0.78rem; color: var(--text-dim); }

--- a/tools/compress-image/styles.css
+++ b/tools/compress-image/styles.css
@@ -115,7 +115,12 @@
 }
 
 .option-row label { font-size: 0.9rem; font-weight: 600; }
-.option-row select { max-width: 100%; }
+
+/* `max-width` alone loses: a flex item's automatic minimum is min-content, and
+   for a <select> that is its longest option - a whole sentence here. Without the
+   `min-width`, the row stayed as wide as that sentence on a narrow screen. */
+.option-row { min-width: 0; }
+.option-row select { min-width: 0; max-width: 100%; }
 
 .check {
   display: flex;

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -222,6 +222,14 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* The label is 0.8rem and the input inherits it, which is right on a desktop
+   and wrong on an iPhone: Safari zooms the page into any field it is asked to
+   focus whose text is under 16px, and then leaves it zoomed. Sixteen only where
+   there is a finger, so the desktop reading of these fields is unchanged. */
+@media (pointer: coarse) {
+  .numbers input { font-size: 16px; }
+}
+
 .number-actions {
   display: flex;
   gap: 0.4rem;

--- a/tools/exif-editor/styles.css
+++ b/tools/exif-editor/styles.css
@@ -229,6 +229,13 @@
 .inspect-name { margin: 0; font-weight: 600; word-break: break-all; }
 .inspect-sub { margin: 0.15rem 0 0; font-size: 0.83rem; color: var(--text-dim); }
 
+/* Every option in this select is a filename, so the control's own idea of how
+   wide it wants to be is the longest one - which on a phone is wider than the
+   screen. Both rules are needed: a flex item's automatic minimum is min-content,
+   and until that is nought the max-width has nothing to clamp. */
+.inspect-switch { min-width: 0; }
+.inspect-switch select { min-width: 0; max-width: 100%; }
+
 .inspector h3 {
   margin: 1.5rem 0 0.2rem;
   font-size: 0.98rem;
@@ -440,6 +447,14 @@
 }
 
 .tag-input.bad { border-color: var(--danger); }
+
+/* Safari zooms the page into any field it is asked to focus whose text is under
+   16px, and then leaves it zoomed - and this table already scrolls sideways
+   inside its own panel, so being zoomed into it is a poor place to be. Sixteen
+   only where there is a finger; the desktop table is unchanged. */
+@media (pointer: coarse) {
+  .tag-input { font-size: 16px; }
+}
 
 .tag-readonly {
   color: var(--text-dim);

--- a/tools/images-to-video/styles.css
+++ b/tools/images-to-video/styles.css
@@ -49,8 +49,14 @@
 .image-list.view-list,
 .image-list.view-details { grid-template-columns: 1fr; gap: 0.4rem; }
 
+/* `min-width` because this is a grid item, and a grid item's automatic minimum
+   is min-content. In the one-column views that is the whole filename, which
+   .image-name means to cut short with an ellipsis - so without this the column
+   grew to fit a name the ellipsis was there to hide, and the page went with
+   it. */
 .image-item {
   position: relative;
+  min-width: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--surface-2);
@@ -241,18 +247,26 @@
   border-radius: 5px;
 }
 
+/* Wraps because a thumbnail, a name and a duration control do not fit across a
+   320px screen. The controls drop under the name rather than off the side of
+   it; on anything wider the row is unchanged, because wrapping only happens
+   when there is nothing left to give. */
 .view-list .image-meta,
 .view-details .image-meta {
   flex: 1;
   padding: 0;
   display: flex;
   align-items: center;
-  gap: 0.8rem;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.8rem;
   min-width: 0;
 }
 
+/* `flex: 1` is `1 1 0%`, but the automatic minimum still holds the name at its
+   full width - and the name does not wrap. `min-width: 0` is what lets it
+   shrink and the ellipsis do its job. */
 .view-list .image-name,
-.view-details .image-name { margin: 0; flex: 1; font-size: 0.85rem; }
+.view-details .image-name { margin: 0; flex: 1; min-width: 0; font-size: 0.85rem; }
 
 .view-list .image-controls,
 .view-details .image-controls { flex: none; }
@@ -285,6 +299,16 @@
 }
 
 .image-controls .unit { font-size: 0.78rem; color: var(--text-dim); flex: 1; }
+
+/* Safari zooms the page into any field it is asked to focus whose text is under
+   16px, and then leaves it zoomed. Sixteen only where there is a finger, so the
+   desktop reading of these fields is unchanged. .bulk inherits its 0.9rem to
+   the two controls inside it, which is why they are named here too. */
+@media (pointer: coarse) {
+  .image-controls input[type="number"],
+  .bulk input,
+  .bulk select { font-size: 16px; }
+}
 
 .move-btn {
   border: 1px solid var(--border);

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -123,10 +123,17 @@ button.file-main-wrap:focus-visible {
 }
 
 /* Which file is under the box, said where the box is rather than only in the
-   list above it. Empty, and so invisible, when there is only one image. */
+   list above it. Empty, and so invisible, when there is only one image.
+
+   It wraps anywhere because a phone's filenames have no spaces in them -
+   Screenshot_2026-08-20-12-13-14-123_com.instagram.android.jpg is one
+   unbreakable word - and dropped into a sentence like this one it pushed the
+   whole page sideways. Breaking a name mid-word is ugly; a page that scrolls
+   sideways on a phone is worse. */
 .stage-name {
   color: var(--text);
   font-weight: 600;
+  overflow-wrap: anywhere;
 }
 
 .stage-hint kbd {
@@ -321,6 +328,14 @@ button.file-main-wrap:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
+/* The label is 0.8rem and the input inherits it, which is right on a desktop
+   and wrong on an iPhone: Safari zooms the page into any field it is asked to
+   focus whose text is under 16px, and then leaves it zoomed. Sixteen only where
+   there is a finger, so the desktop reading of these fields is unchanged. */
+@media (pointer: coarse) {
+  .numbers input { font-size: 16px; }
+}
+
 .number-actions {
   display: flex;
   gap: 0.4rem;
@@ -348,7 +363,12 @@ button.file-main-wrap:focus-visible {
 }
 
 .option-row label { font-size: 0.9rem; font-weight: 600; }
-.option-row select { max-width: 100%; }
+
+/* `max-width` alone loses: a flex item's automatic minimum is min-content, and
+   for a <select> that is its longest option - a whole sentence here. Without the
+   `min-width`, the row stayed as wide as that sentence on a narrow screen. */
+.option-row { min-width: 0; }
+.option-row select { min-width: 0; max-width: 100%; }
 
 /* ------------------------------------------------------------- the sizing */
 
@@ -385,7 +405,10 @@ button.file-main-wrap:focus-visible {
 
 /* The sentence under a group of controls, restating what they are about to do.
    Every step on this page has one, because "contain, 1920, no enlarge" means
-   nothing to somebody who came here to make a photograph fit an upload form. */
+   nothing to somebody who came here to make a photograph fit an upload form.
+
+   They name the file as well, so they wrap anywhere for the same reason
+   .stage-name does. */
 .field-summary {
   margin: 1.1rem 0 0;
   padding-top: 0.8rem;
@@ -394,6 +417,7 @@ button.file-main-wrap:focus-visible {
   line-height: 1.6;
   color: var(--text-dim);
   max-width: 74ch;
+  overflow-wrap: anywhere;
 }
 
 /* ---------------------------------------------------------------- settings */

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -51,10 +51,16 @@
   gap: 0.5rem;
 }
 
+/* `min-width` because this is a grid item, and a grid item's automatic minimum
+   is min-content - here the clip's whole filename, which .clip-name is already
+   set up to cut short with an ellipsis but never got the chance to. Without it
+   the single column grew wider than the phone it is being read on. The file
+   rows on the other tools get this free from their `overflow: hidden`. */
 .clip {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  min-width: 0;
   padding: 0.5rem 0.6rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);


### PR DESCRIPTION
Six tool pages were wider than the phone screen they were being read on. The cause was the same shape every time: an element whose **automatic minimum width is `min-content`**, holding something long that was never meant to be measured — a filename, or a `<select>` whose longest option is a whole sentence.

Numbers below are document scroll width on a 375px viewport.

| Tool | Was | Cause |
|---|---|---|
| compress-image | **511px** on load, before any file | A `<fieldset>`'s minimum is `min-content`, and nothing but `min-inline-size` changes it |
| images-to-video | **731px** in List/Details | `.image-name` is `flex: 1` and `nowrap`; its automatic minimum held it at the full filename the ellipsis existed to hide |
| exif-editor | **542px** once a file loads | `.inspect-switch` had no rules at all, and every option in its `<select>` is a filename |
| trim-video | **431px** with a clip loaded | `.clip` is a grid item with `overflow: visible` — the file rows on the other tools get a zero minimum free from their `overflow: hidden` |
| resize-image | **474px** | `select#fit` — `max-width: 100%` was already there and had nothing to clamp while `min-width` was `auto` |
| resize-image | **426px** | `.stage-name` / `.field-summary` drop the filename into a sentence, and phone filenames have no spaces to break at |
| images-to-video | **325px** at 320px wide | A thumbnail, a name and a duration control do not fit across one row |

Also **fifteen form controls under 16px** — the size below which Safari zooms the page into a field it focuses, and then leaves it zoomed. The crop and size fields on crop-video and resize-image inherit `0.8rem` from their labels; exif-editor's tag inputs and images-to-video's URL textarea and per-image controls set their own.

## Approach

`fieldset { min-inline-size: 0 }` went into `shared/css/tool-frame.css` rather than into one tool, because it protects all six fieldsets across five tools. Everything else is a targeted `min-width: 0`, `overflow-wrap: anywhere`, or `flex-wrap: wrap`.

The font-size fixes are scoped to `@media (pointer: coarse)`, matching the idiom already in `tools/resize-image/styles.css`, so **no desktop rendering changes**. Verified: at 1265px the fields still measure 12.8px and nothing reflowed.

CSS only — no markup, no scripts, no behaviour.

## How this was checked

Every page driven in a real browser at **375px** and **320px**, in three states each: idle, with real files loaded, and with every `[hidden]` panel forced open. Files were generated in-page — JPEGs, a WAV, MP4s via `MediaRecorder`, and a hand-built PDF with embedded DCTDecode images — with filenames in the shape phones actually produce, e.g. `Screenshot_2026-08-20-12-13-14-123_com.instagram.android.jpg`, which is one unbreakable word.

Every page now measures **exactly the viewport width** in every state. 639 JS tests and 266 Python tests pass.

## Left alone, deliberately

- **exif-editor's tag table** scrolls sideways inside its own panel. That is the documented choice in the file and the right one — a wide table in a scroller beats a page that scrolls.
- **Range sliders** are 16px tall, thinner than a comfortable touch target. Each has a paired number box for precise entry, so there is a working alternative; enlarging them would change the drawn design.
- **crop-video's crop handles** grow via `@media (max-width: 620px)` where resize-image uses `@media (pointer: coarse)` for the identical rule. Same effect on a phone; a touch laptop at 800px gets the small handles. Worth aligning, but a preference rather than a defect.

One note: `python build.py --check` needs `esbuild` on PATH and could not be run here, so verification was against plain `python build.py` output throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
