### PR TITLE
Say the same things in more than one language

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,108 @@ Neither link's text is written twice either. The tool page shows the guide's own
 
 ---
 
+## Languages
+
+The site is written in English and served in as many languages as have been
+translated. English keeps the addresses it has always had - `/compress-image/`
+- and every other language sits under a prefix with slugs of its own:
+`/de/bild-komprimieren/`.
+
+The slug is translated on purpose, and it is the reason this is not simply
+`/de/compress-image/`. A slug is the one part of a page's markup that is also a
+keyword, and a German reader looking for this tool types "bild komprimieren".
+Leaving the English word in the URL throws that away in every market except the
+one the site was written for.
+
+### What a locale is, and what it is not
+
+A locale is **words and slugs**. It is not a copy of the site.
+
+Which tools exist, which category each one joins, which guide is about which
+tool, what the Content-Security-Policy allows - none of that is language, so
+none of it is repeated per language. It stays in `config/site.toml` and in each
+`tool.toml`, in English, once. A locale file that tries to restate any of it
+fails the build rather than becoming a second site to keep in step.
+
+The practical effect is that shipping a tool gives every language a page for it
+the same day - in English until somebody translates it, but present, linked,
+and in the right category, because the category was never a translated string.
+
+    locales/de/locale.toml            the language, its slugs, and every
+                                      translatable string in config/site.toml
+    locales/de/tools/<slug>.toml      overrides for tools/<slug>/tool.toml
+    locales/de/tools/<slug>.html      that tool's translated body.html
+    locales/de/pages/<slug>.toml      overrides for pages/<slug>/page.toml
+    locales/de/pages/<slug>.html      that page's translated body.html
+
+The slug in a locale's filename is always the **English** one. The translated
+slug is a value, in `[slugs]`, and never a filename - so every address a
+language changes can be read in one place, and a translation does not become
+impossible to find because somebody localized the folder it sits in too.
+
+English is not a folder under `locales/`. It is the sources themselves. The
+moment it became `locales/en/` it would be a translation of itself, free to
+drift from the `tool.toml` it was copied out of, and the build would lose the
+one text every other language is measured against.
+
+### Half-translated is allowed, and is never advertised
+
+`buildlib/template.py` refuses to render a name it cannot resolve, and that
+rule is not weakened for locales - it is moved. A locale may leave a key out
+and the English is used; what it may not do is leave a key out and still be
+offered as a translation.
+
+While a `locale.toml` says `complete = false`, the language is built and
+readable at its own address, and is kept out of all three places that would
+claim it exists:
+
+* no `<link rel="alternate" hreflang>` pointing at it, from any page;
+* no entry in `sitemap.xml`;
+* no link in the language switcher.
+
+All three are built from one list - `i18n.published` - so they cannot disagree
+about which languages the site has, which is the failure Google reports as
+"hreflang points to a page that is not indexed".
+
+Setting `complete = true` turns every remaining fallback into a build failure,
+naming the strings. A language therefore gets stricter as it gets more
+finished, which is the direction that helps. Every build says how far the
+unfinished ones have to go:
+
+    de: 738 strings still in English (not advertised until complete = true)
+
+### Adding a language
+
+1. Make `locales/<lang>/locale.toml` with `lang`, `name` (in English, for the
+   build log) and `endonym` (in its own language, which is what the switcher
+   shows - somebody looking for German is scanning for "Deutsch").
+2. Fill in `[slugs]`, keyed by the English slug. The build refuses a slug that
+   names nothing, and refuses two entries that would land on one address.
+3. Translate the rest of `locale.toml`, then the files under `tools/` and
+   `pages/`.
+4. Set `complete = true` when the build stops listing anything.
+
+Set `hreflang` where it differs from `lang` - `pt-BR` is a language and a
+region, and `hreflang` is the only place that distinction is expressed. Set
+`dir = "rtl"` for Arabic or Hebrew; note that the stylesheets have not been
+written for it yet, so that is a layout job as well as a translation one.
+
+### The strings still in the JavaScript
+
+Not done. There are about 380 user-facing strings inline in `tools/*/src/*.js`
+- 213 of them in `exif-editor` alone, most of those EXIF tag names - and they
+are still English in every language. They need extracting to a source of their
+own before a locale can reach them, which is a change to the tools' own code
+rather than to the build, and is the one part of this that cannot be checked by
+reading the output: it has to be exercised in a browser.
+
+Worth deciding when it is done: the long tail of EXIF tag names is probably
+better left in English. They are identifiers people cross-reference against
+ExifTool, Lightroom and Windows' own properties dialog, and localizing the
+obscure ones makes the tool harder to use rather than easier.
+
+---
+
 ## Deploying
 
 The site is one domain, `abox.tools`. It is served by **GitHub Pages** from the

--- a/build.py
+++ b/build.py
@@ -67,6 +67,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from buildlib import cssmin
+from buildlib import i18n
 from buildlib import mangle
 from buildlib import minify
 from buildlib import site as sitelib
@@ -78,6 +79,7 @@ CONFIG = ROOT / 'config'
 TOOLS = ROOT / 'tools'
 PAGES = ROOT / 'pages'
 SHARED = ROOT / 'shared'
+LOCALES = ROOT / 'locales'
 
 
 def main(argv=None):
@@ -135,21 +137,145 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
              for path in sorted(TOOLS.glob('*/tool.toml'))]
     if not tools:
         raise sitelib.ConfigError(f'no tools found under {TOOLS}')
-    by_slug = {tool['slug']: tool for tool in tools}
 
     # ** rather than *, because a guide lives at pages/guides/<slug>/ and a
     # legal page at pages/<slug>/. The slug in each page.toml has to match the
     # folder either way, so a page cannot end up at a URL nobody wrote down.
     prose = [sitelib.load_page(path, site, PAGES)
              for path in sorted(PAGES.glob('**/page.toml'))]
-    guides = [page for page in prose if page['kind'] == 'guide']
-    legal = [page for page in prose if page['kind'] == 'legal']
+
+    # Every language this site is written in, English first. English is the
+    # sources themselves rather than a folder under locales/ - buildlib/i18n.py
+    # says why at length, and the short version is that a translation of English
+    # into English is a copy free to drift from what it was copied out of.
+    locales = i18n.load_locales(LOCALES, site)
+    for locale in locales:
+        i18n.check_slugs(locale, [tool['slug'] for tool in tools],
+                         [page['slug'] for page in prose], site)
+
+    written = []
+    for locale in locales:
+        written += build_locale(out, templates, locale, locales, site, tools,
+                                prose, planned, css_v, site_css, emit)
+
+    # After every locale, because a locale only counts as finished once every
+    # page in it has been rendered and had the chance to fall back. Raising
+    # here rather than at load time is what makes the report a list of
+    # everything still to translate instead of the first thing missing.
+    for locale in locales:
+        i18n.check_complete(locale)
+
+    # How far along each unfinished language is, said out loud on every build.
+    # A translation that is 40 strings from done and a translation that has not
+    # been started look identical in a directory listing, and the difference is
+    # the only thing anybody wants to know about it.
+    for locale in locales:
+        if locale['is_base'] or locale['complete']:
+            continue
+        left = len(set(locale['missing']))
+        print(f'  {locale["lang"]}: {left} strings still in English '
+              f'(not advertised until complete = true)')
+
+    # One 404 for the whole domain, in English, because GitHub Pages serves one
+    # file for every address it cannot find and has no way to know which
+    # language the visitor was looking for. It carries the language switcher
+    # like every other page, so arriving here in the wrong language is still a
+    # click away from the right one.
+    base = locales[0]
+
+    # Everything in the order the site puts it in rather than the order the
+    # folders happen to sort in: tools as the hub groups them, guides as
+    # config/site.toml groups them, then the legal pages. Both orderings are
+    # structural rather than translated, so they are the same in every language
+    # and are worked out once, here, rather than once per locale.
+    by_slug = {tool['slug']: tool for tool in tools}
+    ordered_tools = [by_slug[slug]
+                     for category in site['hub']['categories']
+                     for slug in category['order'] if slug in by_slug]
+
+    groups = guide_groups(site, [page for page in prose if page['kind'] == 'guide'])
+    ordered_prose = [guide for group in groups for guide in group['guides']]
+    ordered_prose += [page for page in prose if page['kind'] == 'legal']
+
+    # tools/README.md, from the English list and only once. It is a file in the
+    # repository rather than a page of the site - the index GitHub shows when
+    # somebody browses to tools/ - so it has no language to be written in and
+    # no locale to be written per.
+    write_tools_index(ordered_tools)
+
+    build_404(out, templates, base, locales, site, ordered_tools, ordered_prose,
+              css_v, emit)
+    written.append('404.html')
+
+    # After the 404 and deliberately not passed it: the 404 has no address of
+    # its own to list, and inviting a crawler to index it would be inviting it
+    # to serve "not found" in place of a real page.
+    build_sitemap(out, templates, site, locales, tools, ordered_prose)
+    written.append('sitemap.xml')
+
+    copy_shared(out)
+    write(out / 'site.css', site_css)
+    return written
+
+
+# ---------------------------------------------------------------------------
+# One language
+#
+# Everything below the top of this function is the site as it was before there
+# were locales: the same tools, the same guides, the same checks, the same
+# order. What changed is that it now happens once per language rather than
+# once, and that every slug it writes to disk is `out_slug` - the localized
+# one - while every slug it looks something up by is `slug`, which stays
+# English in every language.
+#
+# That distinction is the whole trick, and it is worth stating plainly because
+# mixing the two is the one bug this arrangement can still have. `slug` is the
+# name of a thing: which tool this is, which category lists it, which guide is
+# about it. `out_slug` is an address. A German reader never sees the first and
+# a build never matches on the second.
+
+
+def build_locale(out, templates, locale, locales, site, tools, prose, planned,
+                 css_v, site_css, emit):
+    """The whole site, in one language, under out/<lang>/ - or at the root of
+    out/ for English, whose pages keep the addresses they have always had.
+
+    Nothing here re-reads a source file. The tools and the prose pages were
+    loaded once, in English, and are localized into copies, so eleven languages
+    cost eleven renders rather than eleven parses - and, more to the point, a
+    tool cannot exist in one language and not another, because there is only one
+    list of which tools there are.
+    """
+    root = locale['site']
+    dest_root = out / locale['prefix'] if locale['prefix'] else out
+    dest_root.mkdir(parents=True, exist_ok=True)
+
+    # Where this language's own front door, guides index and roadmap are. The
+    # structured data needs all three as absolute URLs, and needs them to be
+    # this language's rather than English's: a German page whose WebSite node
+    # points at the English root is telling a search engine the two are one
+    # document, which is the opposite of what hreflang beside it says.
+    #
+    # `lang` goes the same way. It is what every inLanguage in the graph is
+    # built from, and it is the one value in config/site.toml that is a fact
+    # about the language rather than about the site.
+    root['lang'] = locale['hreflang']
+    root['home'] = i18n.locale_url(locale, '', site)
+    root['guides_url'] = i18n.locale_url(locale, site['guides']['slug'], site)
+    root['roadmap_url'] = i18n.locale_url(locale, site['roadmap']['slug'], site)
+
+    ltools = [i18n.localize_tool(tool, locale, site) for tool in tools]
+    lprose = [i18n.localize_page(page, locale, site) for page in prose]
+    by_slug = {tool['slug']: tool for tool in ltools}
+
+    guides = [page for page in lprose if page['kind'] == 'guide']
+    legal = [page for page in lprose if page['kind'] == 'legal']
 
     # The guides, grouped and in the order config/site.toml puts them in, and
     # every check that says the grouping is complete. Done here rather than
     # inside build_guides because the footer needs the same order, and an order
     # worked out twice is an order that can differ.
-    groups = guide_groups(site, guides)
+    groups = guide_groups(root, guides)
     ordered_guides = [guide for group in groups for guide in group['guides']]
 
     # Which guide belongs to which tool, so that a tool page can link to its
@@ -157,59 +283,116 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     # guide's page.toml - one place, both directions.
     guide_of = tie_guides_to_tools(ordered_guides, by_slug)
 
+    # Tools in the order the hub shows them, not the order the folders happen to
+    # sort in, so the footer and the cards above it agree. A slug named here
+    # that has no tool, or a tool named nowhere, is caught by build_hub below.
+    ordered = [by_slug[slug]
+               for category in root['hub']['categories']
+               for slug in category['order'] if slug in by_slug]
+
     # What the footer on every page is built from. Derived from the folders that
     # exist rather than written down anywhere, so a new tool or a new legal page
     # reaches every footer on the site without a second edit.
-    # Tools in the order the hub shows them, not the order the folders happen to
-    # sort in, so the footer and the cards above it agree. A slug named here that
-    # has no tool, or a tool named nowhere, is caught by build_hub below.
     #
     # No guide list. The footer carries one link to the guides index instead of
     # an entry per guide - a column that grew by a line every time somebody
     # wrote one, in front of a reader who was looking for the privacy page. The
     # index is the link that keeps working however long the list gets, and it is
     # already built from the folders that exist.
-    ordered = [by_slug[slug]
-               for category in site['hub']['categories']
-               for slug in category['order'] if slug in by_slug]
+    #
+    # The slugs in it are localized, because a footer is a set of addresses.
     footer = {
-        'tools': [{'name': tool['name'], 'slug': tool['slug']} for tool in ordered],
-        'pages': [{'nav': page['nav'], 'slug': page['slug']} for page in legal],
+        'tools': [{'name': tool['name'], 'slug': tool['out_slug']} for tool in ordered],
+        'pages': [{'nav': page['nav'], 'slug': page['out_slug']} for page in legal],
     }
 
+    links = locale_links(locale, site, lprose)
+
     written = []
-    for tool in tools:
-        build_tool(out, templates, site, tool, footer,
-                   guide_of.get(tool['slug'], {}), emit)
-        written.append(f'{tool["slug"]}/index.html')
+    for tool in ltools:
+        build_tool(dest_root, templates, locale, locales, site, tool, footer,
+                   links, guide_of.get(tool['slug'], {}), emit)
+        written.append(f'{locale["prefix"]}{tool["out_slug"]}/index.html')
 
-    for page in prose:
-        build_page(out, templates, site, page, footer, css_v, by_slug, emit)
-        written.append(f'{page["slug"]}/index.html')
+    for page in lprose:
+        build_page(dest_root, templates, locale, locales, site, page, footer,
+                   links, css_v, by_slug, emit)
+        written.append(f'{locale["prefix"]}{page["out_slug"]}/index.html')
 
-    build_guides(out, templates, site, groups, ordered_guides, footer, css_v, emit)
-    written.append(f'{site["guides"]["slug"]}/index.html')
+    build_guides(dest_root, templates, locale, locales, site, groups,
+                 ordered_guides, footer, links, css_v, emit)
+    written.append(f'{locale["prefix"]}{links["guides"]}/index.html')
 
-    build_hub(out, templates, site, by_slug, footer, css_v, emit)
-    written.append('index.html')
+    build_hub(dest_root, templates, locale, locales, site, by_slug, footer,
+              links, css_v, emit)
+    written.append(f'{locale["prefix"]}index.html')
 
-    build_roadmap(out, templates, site, planned, ordered, footer, css_v, emit)
-    written.append(f'{site["roadmap"]["slug"]}/index.html')
+    build_roadmap(dest_root, templates, locale, locales, site, planned, ordered,
+                  footer, links, css_v, emit)
+    written.append(f'{locale["prefix"]}{links["roadmap"]}/index.html')
 
-    write_tools_index(ordered)
+    # A copy of the site stylesheet at the root of every language, so that the
+    # relative path from a page to it is the same number of steps up in every
+    # language and `depth` stays the only thing the frame has to know. It is the
+    # same bytes under the same hashed URL, so a reader who crosses from one
+    # language to another is served it from cache either way.
+    if locale['prefix']:
+        write(dest_root / 'site.css', site_css)
 
-    build_404(out, templates, site, ordered, footer, css_v, emit)
-    written.append('404.html')
-
-    # After the sitemap and deliberately not passed to it: the 404 has no
-    # address of its own to list, and inviting a crawler to index it would be
-    # inviting it to serve "not found" in place of a real page.
-    build_sitemap(out, templates, site, tools, ordered_guides, legal)
-    written.append('sitemap.xml')
-
-    copy_shared(out)
-    write(out / 'site.css', site_css)
     return written
+
+
+def locale_links(locale, site, pages):
+    """The handful of pages that are linked to from inside a sentence.
+
+    A link written into prose - "there is a guide for every tool" - cannot be
+    derived from the sentence around it, so the address is passed in beside the
+    words and the translated string points at it. Three of them, and every one
+    is checked here rather than discovered as a 404 later.
+    """
+    def address(slug):
+        return locale['slugs'].get(slug, slug)
+
+    known = {page['slug'] for page in pages}
+    if site['safety_guide'] not in known:
+        raise sitelib.ConfigError(
+            f'config/site.toml: safety_guide is {site["safety_guide"]!r}, but there '
+            f'is no pages/{site["safety_guide"]}/page.toml. The hub links to it in '
+            'the middle of a sentence, so it cannot simply be dropped.')
+
+    return {
+        'guides': address(site['guides']['slug']),
+        'roadmap': address(site['roadmap']['slug']),
+        'safety_guide': address(site['safety_guide']),
+    }
+
+
+def frame(locale, locales, site, slug, base, links, extra=None):
+    """The context every page shares: which language it is in, what the words of
+    the frame around it are, and where its own address is in every other
+    language.
+
+    Built in one place because the three have to agree. A page whose <html lang>
+    says German, whose hreflang set leaves German out, and whose switcher offers
+    German anyway is three different answers to one question, and each of them
+    is a separate afternoon in Search Console.
+    """
+    context = {
+        'site': locale['site'],
+        'locale': {
+            'lang': locale['lang'],
+            'hreflang': locale['hreflang'],
+            'endonym': locale['endonym'],
+            'rtl': locale['dir'] == 'rtl',
+        },
+        'base': base,
+        'links': links,
+        'canonical': i18n.locale_url(locale, slug, site),
+        'alternates': i18n.alternates(locales, slug, site),
+        'languages': i18n.switcher(locales, locale, slug, site),
+    }
+    context.update(extra or {})
+    return context
 
 
 # ---------------------------------------------------------------------------
@@ -287,7 +470,8 @@ def tie_guides_to_tools(guides, by_slug):
     return owned
 
 
-def build_guides(out, templates, site, groups, guides, footer, css_v, emit):
+def build_guides(out, templates, locale, locales, site, groups, guides, footer,
+                 links, css_v, emit):
     """The index of the written half of the site.
 
     Built like the roadmap and for the same reason: it is a frame around a list
@@ -297,33 +481,39 @@ def build_guides(out, templates, site, groups, guides, footer, css_v, emit):
     and its <meta name="description">, so the index cannot promise something the
     guide does not deliver.
     """
-    dest = out / site['guides']['slug']
+    root = locale['site']
+    dest = out / links['guides']
     dest.mkdir(parents=True, exist_ok=True)
 
-    emit.html(dest / 'index.html', templates.render('guides.html', {
-        'site': site,
+    context = frame(locale, locales, site, root['guides']['slug'], '../', links, {
         'groups': groups,
         'guide_count': len(guides),
-        'guide_noun': 'guide' if len(guides) == 1 else 'guides',
+        'guide_noun': (root['ui']['guide_one'] if len(guides) == 1
+                       else root['ui']['guide_many']),
         'footer': footer,
-        'base': '../',
         'css_href': f'../site.css?v={css_v}',
-        'csp': sitelib.render_csp(site['csp']),
-        'jsonld': sitelib.guides_jsonld(site, guides),
-    }))
+        'csp': sitelib.render_csp(root['csp']),
+        'jsonld': sitelib.guides_jsonld(root, guides),
+    })
+    context['ui'] = i18n.render_ui(templates, root['ui'], context,
+                                   f'ui [{locale["lang"]}]')
+
+    emit.html(dest / 'index.html', templates.render('guides.html', context))
 
     emit.js(dest / 'analytics.js', templates.render('analytics.js', {
-        'site': site,
+        'site': root,
         'words': {'plural': 'files', 'analytics_extra': ''},
-    }), where=f'{site["guides"]["slug"]}/analytics.js')
+    }), where=f'{locale["prefix"]}{links["guides"]}/analytics.js')
 
 
 # ---------------------------------------------------------------------------
 # One tool
 
 
-def build_tool(out, templates, site, tool, footer, guide, emit):
-    dest = out / tool['slug']
+def build_tool(out, templates, locale, locales, site, tool, footer, links,
+               guide, emit):
+    root = locale['site']
+    dest = out / tool['out_slug']
     dest.mkdir(parents=True, exist_ok=True)
 
     # The app code. Every module keeps its own file and its own name; only the
@@ -347,7 +537,7 @@ def build_tool(out, templates, site, tool, footer, guide, emit):
     for name, path in assets:
         (dest / name).parent.mkdir(parents=True, exist_ok=True)
         emit.js(dest / name, path.read_text(encoding='utf-8'),
-                where=f'{tool["slug"]}/{name}')
+                where=f'{locale["prefix"]}{tool["out_slug"]}/{name}')
 
     for extra in sorted(src_dir.iterdir()):
         if extra.is_file() and extra.suffix != '.js':
@@ -374,12 +564,29 @@ def build_tool(out, templates, site, tool, footer, guide, emit):
     css = emit.css_text(tool_css(tool))
     css_href = f'styles.css?v={sitelib.text_hash(css)}'
 
+    # The frame's own words, rendered before the body is, because the body can
+    # {% include %} a partial that uses them - the URL importer's warning being
+    # the one that does.
+    #
+    # [ui.tool] on every tool page and [ui.picker] only where there is a picker
+    # to describe. The second is not a tidiness: those strings name
+    # {{ tool.picker.urls.noun }}, which a tool that does not fetch addresses
+    # has never defined, so rendering them everywhere fails the build on the
+    # first tool that does not.
+    parts = ['tool'] + (['picker'] if sitelib.wants_urls(tool) else [])
+    ui_context = {'site': root, 'tool': tool, 'base': '../', 'links': links}
+    ui = i18n.render_ui(templates, root['ui'], ui_context,
+                        f'ui [{locale["lang"]}]', include=parts)
+
     # body.html goes through the template engine before it is dropped into the
     # page, so a tool can {% include %} a shared partial - the drop zone being
     # the one every tool wants - instead of copying the markup for it.
     body = templates.render_source(
-        body_path.read_text(encoding='utf-8'), f'{tool["slug"]}/body.html',
-        {'site': site, 'tool': tool}).rstrip('\n')
+        i18n.body_for(locale, 'tools', tool['slug'],
+                      body_path.read_text(encoding='utf-8')),
+        f'{tool["slug"]}/body.html [{locale["lang"]}]',
+        {'site': root, 'tool': tool, 'ui': ui, 'base': '../',
+         'links': links}).rstrip('\n')
 
     # Setting [picker.urls] ships the module, the stylesheet and the widened
     # img-src. If the panel itself were then left off the page, the tool would
@@ -391,25 +598,25 @@ def build_tool(out, templates, site, tool, footer, guide, emit):
             'network permission the importer needs, but body.html never includes '
             '{% include "partials/url-import.html" %}. Add it, or drop [picker.urls].')
 
-    emit.html(dest / 'index.html', templates.render('tool.html', {
-        'site': site,
-        'tool': tool,
-        'guide': guide,
-        'footer': footer,
-        'base': '../',
-        'csp': sitelib.render_csp(site['csp'], site.get('tool_csp', {}),
-                                  sitelib.picker_csp(tool), tool['csp']),
-        'css_href': css_href,
-        'jsonld': sitelib.tool_jsonld(site, tool),
-        'body': body,
-    }))
+    emit.html(dest / 'index.html', templates.render(
+        'tool.html', frame(locale, locales, site, tool['slug'], '../', links, {
+            'tool': tool,
+            'guide': guide,
+            'ui': ui,
+            'footer': footer,
+            'csp': sitelib.render_csp(root['csp'], root.get('tool_csp', {}),
+                                      sitelib.picker_csp(tool), tool['csp']),
+            'css_href': css_href,
+            'jsonld': sitelib.tool_jsonld(root, tool),
+            'body': body,
+        })))
 
     write(dest / 'styles.css', css)
 
     emit.js(dest / 'analytics.js', templates.render('analytics.js', {
-        'site': site,
+        'site': root,
         'words': tool['words'],
-    }), where=f'{tool["slug"]}/analytics.js')
+    }), where=f'{locale["prefix"]}{tool["out_slug"]}/analytics.js')
 
     # The service worker caches './', its own src/*.js, and analytics.js. The
     # list is read off the disk rather than written down, so a new module is
@@ -425,7 +632,7 @@ def build_tool(out, templates, site, tool, footer, guide, emit):
         'tool': tool,
         'assets': ['index.html', css_href] + [name for name, _ in assets],
         'cache_hash': sitelib.cache_hash(cached),
-    }), where=f'{tool["slug"]}/sw.js')
+    }), where=f'{locale["prefix"]}{tool["out_slug"]}/sw.js')
 
     og = tool['dir'] / 'og.png'
     if og.is_file():
@@ -476,7 +683,8 @@ def tool_css(tool):
 # One prose page (a legal page or a guide)
 
 
-def build_page(out, templates, site, page, footer, css_v, by_slug, emit):
+def build_page(out, templates, locale, locales, site, page, footer, links,
+               css_v, by_slug, emit):
     """A prose page: the site frame around a body.html, and nothing else.
 
     No service worker, because there is nothing here worth keeping offline, and
@@ -493,51 +701,66 @@ def build_page(out, templates, site, page, footer, css_v, by_slug, emit):
     the visible half of the trail the structured data describes - and, when it
     names a tool, the tool itself, so the page can offer a way to go and use the
     thing it has just spent two thousand words explaining."""
-    dest = out / page['slug']
+    root = locale['site']
+    dest = out / page['out_slug']
     dest.mkdir(parents=True, exist_ok=True)
 
     body_path = page['dir'] / 'body.html'
     if not body_path.is_file():
         raise sitelib.ConfigError(f'{page["slug"]}: no body.html')
 
+    # How far this page sits below the root of its own language, which is one
+    # more step under a locale prefix than it is in English. `depth` was worked
+    # out for this locale when the page was localized, so the frame still does
+    # not have to know which language it is wearing.
     up = '../' * page['depth']
 
     crumbs = []
     if page['kind'] == 'guide':
         crumbs = [
-            {'name': 'All tools', 'href': up},
-            {'name': site['guides']['heading'],
-             'href': f'{up}{site["guides"]["slug"]}/'},
+            {'name': root['ui']['all_tools'], 'href': up},
+            {'name': root['guides']['heading'],
+             'href': f'{up}{links["guides"]}/'},
         ]
 
-    emit.html(dest / 'index.html', templates.render('page.html', {
-        'site': site,
+    context = frame(locale, locales, site, page['slug'], up, links, {
         'page': page,
         'tool': by_slug.get(page['tool'], {}),
         'crumbs': crumbs,
         'main_class': 'prose' if page['kind'] == 'guide' else 'legal',
         'footer': footer,
-        'base': up,
         'css_href': f'{up}site.css?v={css_v}',
-        'jsonld': sitelib.page_jsonld(site, page),
-        'csp': sitelib.render_csp(site['csp']),
-        'body': body_path.read_text(encoding='utf-8').rstrip('\n'),
-    }))
+        'jsonld': sitelib.page_jsonld(root, page),
+        'csp': sitelib.render_csp(root['csp']),
+        'body': i18n.body_for(
+            locale, 'pages', page['slug'],
+            body_path.read_text(encoding='utf-8')).rstrip('\n'),
+    })
+    # [ui.guide] only where the page names a tool. It reaches for {{ tool }},
+    # and a legal page has not got one - nor has a guide about no tool in
+    # particular, which is what "is it safe to upload files" is.
+    context['ui'] = i18n.render_ui(
+        templates, root['ui'], context, f'ui [{locale["lang"]}]',
+        include=['guide'] if context['tool'] else [])
+
+    emit.html(dest / 'index.html', templates.render('page.html', context))
 
     emit.js(dest / 'analytics.js', templates.render('analytics.js', {
-        'site': site,
+        'site': root,
         'words': {'plural': 'files', 'analytics_extra': ''},
-    }), where=f'{page["slug"]}/analytics.js')
+    }), where=f'{locale["prefix"]}{page["out_slug"]}/analytics.js')
 
 
 # ---------------------------------------------------------------------------
 # The hub
 
 
-def build_hub(out, templates, site, by_slug, footer, css_v, emit):
+def build_hub(out, templates, locale, locales, site, by_slug, footer, links,
+              css_v, emit):
+    root = locale['site']
     categories = []
     listed = set()
-    for category in site['hub']['categories']:
+    for category in root['hub']['categories']:
         chosen = []
         for slug in category['order']:
             if slug not in by_slug:
@@ -561,23 +784,26 @@ def build_hub(out, templates, site, by_slug, footer, css_v, emit):
 
     ordered = [tool for category in categories for tool in category['tools']]
 
-    emit.html(out / 'index.html', templates.render('hub.html', {
-        'site': site,
+    context = frame(locale, locales, site, '', './', links, {
         'categories': categories,
         'footer': footer,
-        'base': './',
         'css_href': f'site.css?v={css_v}',
-        'csp': sitelib.render_csp(site['csp']),
-        'jsonld': sitelib.hub_jsonld(site, ordered),
-    }))
+        'csp': sitelib.render_csp(root['csp']),
+        'jsonld': sitelib.hub_jsonld(root, ordered),
+    })
+    context['ui'] = i18n.render_ui(templates, root['ui'], context,
+                                   f'ui [{locale["lang"]}]')
+
+    emit.html(out / 'index.html', templates.render('hub.html', context))
 
     emit.js(out / 'analytics.js', templates.render('analytics.js', {
-        'site': site,
+        'site': root,
         'words': {'plural': 'files', 'analytics_extra': ''},
-    }), where='analytics.js')
+    }), where=f'{locale["prefix"]}analytics.js')
 
 
-def build_roadmap(out, templates, site, planned, ordered, footer, css_v, emit):
+def build_roadmap(out, templates, locale, locales, site, planned, ordered,
+                  footer, links, css_v, emit):
     """The roadmap: what is built, then what is planned.
 
     This was the last section of the hub until the planned list passed about
@@ -591,7 +817,8 @@ def build_roadmap(out, templates, site, planned, ordered, footer, css_v, emit):
     list the hub and the footer are drawn from; the planned half is
     config/planned.toml. A tool that ships moves from one to the other by
     appearing in tools/ and leaving that file."""
-    roadmap = site['roadmap']
+    root = locale['site']
+    roadmap = root['roadmap']
 
     # planned.toml stores each entry as a two-item array, which is compact to
     # write by hand and unusable in a template. Named here rather than in the
@@ -619,29 +846,31 @@ def build_roadmap(out, templates, site, planned, ordered, footer, css_v, emit):
     for group in planned['group']:
         group.setdefault('built', [])
 
-    dest = out / roadmap['slug']
+    dest = out / links['roadmap']
     dest.mkdir(parents=True, exist_ok=True)
 
-    emit.html(dest / 'index.html', templates.render('roadmap.html', {
-        'site': site,
+    context = frame(locale, locales, site, roadmap['slug'], '../', links, {
         'planned': planned,
         'planned_count': sum(len(group['items']) for group in planned['group']),
         'built_count': len(ordered),
         'tools': ordered,
         'footer': footer,
-        'base': '../',
         'css_href': f'../site.css?v={css_v}',
-        'csp': sitelib.render_csp(site['csp']),
-        'jsonld': sitelib.roadmap_jsonld(site),
-    }))
+        'csp': sitelib.render_csp(root['csp']),
+        'jsonld': sitelib.roadmap_jsonld(root),
+    })
+    context['ui'] = i18n.render_ui(templates, root['ui'], context,
+                                   f'ui [{locale["lang"]}]')
+
+    emit.html(dest / 'index.html', templates.render('roadmap.html', context))
 
     emit.js(dest / 'analytics.js', templates.render('analytics.js', {
-        'site': site,
+        'site': root,
         'words': {'plural': 'files', 'analytics_extra': ''},
-    }), where='analytics.js')
+    }), where=f'{locale["prefix"]}{links["roadmap"]}/analytics.js')
 
 
-def build_404(out, templates, site, tools, footer, css_v, emit):
+def build_404(out, templates, locale, locales, site, tools, pages, css_v, emit):
     """The page GitHub Pages returns for anything it cannot find.
 
     One file, at the root of the publishing source, per its documentation:
@@ -656,14 +885,35 @@ def build_404(out, templates, site, tools, footer, css_v, emit):
     would arrive unstyled. Absolute is the only form that works from every
     depth at once.
     """
-    emit.html(out / '404.html', templates.render('404.html', {
-        'site': site,
-        'tools': tools,
+    root = locale['site']
+    links = locale_links(locale, site, pages)
+
+    # Built from the English lists, because this is the English page, and every
+    # link on it is root-absolute for the reason in the docstring above. `base`
+    # is '/', so a slug appended to it is already the English address.
+    footer = {
+        'tools': [{'name': tool['name'], 'slug': tool['slug']} for tool in tools],
+        'pages': [{'nav': page['nav'], 'slug': page['slug']}
+                  for page in pages if page['kind'] == 'legal'],
+    }
+
+    context = frame(locale, locales, site, '', '/', links, {
+        'tools': [dict(tool, out_slug=tool['slug']) for tool in tools],
         'footer': footer,
-        'base': '/',
         'css_href': f'/site.css?v={css_v}',
-        'csp': sitelib.render_csp(site['csp']),
-    }))
+        'csp': sitelib.render_csp(root['csp']),
+        # No hreflang set, deliberately. This file has no address of its own -
+        # it is what a thousand wrong addresses return - so there is no page
+        # for a German one to be the alternate of, and a set claiming otherwise
+        # would be pointing every language at the same error page. The switcher
+        # underneath still works: "take me to the German front door" is a
+        # useful answer even where "this page in German" is not.
+        'alternates': [],
+    })
+    context['ui'] = i18n.render_ui(templates, root['ui'], context,
+                                   f'ui [{locale["lang"]}]')
+
+    emit.html(out / '404.html', templates.render('404.html', context))
 
 
 def write_tools_index(tools):
@@ -712,29 +962,55 @@ def write_tools_index(tools):
         print(f'  wrote {path.relative_to(ROOT).as_posix()}')
 
 
-def build_sitemap(out, templates, site, tools, guides, legal):
-    pages = [{'url': site['domain'], 'lastmod': site['lastmod'],
-              'changefreq': 'weekly', 'priority': '1.0'}]
-    pages += [{'url': tool['url'], 'lastmod': tool['lastmod'],
-               'changefreq': 'monthly', 'priority': '0.8'} for tool in tools]
-    # Guides below the tools and above the legal pages. A tool is what somebody
-    # came for; a guide is how they find out this site exists. The index they
-    # are listed on goes first and slightly higher: it is the page that gains
-    # from being crawled as a set rather than as nine unrelated articles.
-    pages.append({'url': f'{site["domain"]}{site["guides"]["slug"]}/',
-                  'lastmod': site['guides']['lastmod'],
-                  'changefreq': 'monthly', 'priority': '0.7'})
-    pages += [{'url': page['url'], 'lastmod': page['lastmod'],
-               'changefreq': 'monthly', 'priority': '0.6'} for page in guides]
-    # The roadmap: a real page, but not one anybody searches for. Below the
-    # guides, above the legal pages.
-    pages.append({'url': f'{site["domain"]}{site["roadmap"]["slug"]}/',
-                  'lastmod': site['roadmap']['lastmod'],
-                  'changefreq': 'monthly', 'priority': '0.5'})
-    # The legal pages last, and low: they matter for trust, not for search.
-    pages += [{'url': page['url'], 'lastmod': page['lastmod'],
-               'changefreq': 'yearly', 'priority': '0.3'} for page in legal]
-    write(out / 'sitemap.xml', templates.render('sitemap.xml', {'pages': pages}))
+def build_sitemap(out, templates, site, locales, tools, prose):
+    """One sitemap for the whole domain, listing every published language.
+
+    Published, not built. A locale still being translated is deliberately
+    absent: it carries no hreflang tag pointing at it and no link in the
+    switcher either, and a sitemap entry would be the one remaining way a
+    crawler could still be told to go and index a page that is half in English.
+
+    The order within a language is the order it always was - the hub, the
+    tools, the guides, the roadmap, the legal pages - and the languages follow
+    each other in the order locales/ sorts in, English first.
+
+    Priority does not decay down the list. It says what a page is worth against
+    the rest of the site, not against the rest of its own language: the German
+    hub is as much a front door as the English one, and marking it lower would
+    be saying the opposite of what the hreflang tags beside it say.
+    """
+    entries = []
+    for locale in i18n.published(locales):
+        def url(slug, locale=locale):
+            return i18n.locale_url(locale, slug, site)
+
+        entries.append({'url': url(''), 'lastmod': site['lastmod'],
+                        'changefreq': 'weekly', 'priority': '1.0'})
+        entries += [{'url': url(tool['slug']), 'lastmod': tool['lastmod'],
+                     'changefreq': 'monthly', 'priority': '0.8'}
+                    for tool in tools]
+        # Guides below the tools and above the legal pages. A tool is what
+        # somebody came for; a guide is how they find out this site exists. The
+        # index they are listed on goes first and slightly higher: it is the
+        # page that gains from being crawled as a set rather than as nine
+        # unrelated articles.
+        entries.append({'url': url(site['guides']['slug']),
+                        'lastmod': site['guides']['lastmod'],
+                        'changefreq': 'monthly', 'priority': '0.7'})
+        entries += [{'url': url(page['slug']), 'lastmod': page['lastmod'],
+                     'changefreq': 'monthly', 'priority': '0.6'}
+                    for page in prose if page['kind'] == 'guide']
+        # The roadmap: a real page, but not one anybody searches for. Below the
+        # guides, above the legal pages.
+        entries.append({'url': url(site['roadmap']['slug']),
+                        'lastmod': site['roadmap']['lastmod'],
+                        'changefreq': 'monthly', 'priority': '0.5'})
+        # The legal pages last, and low: they matter for trust, not for search.
+        entries += [{'url': url(page['slug']), 'lastmod': page['lastmod'],
+                     'changefreq': 'yearly', 'priority': '0.3'}
+                    for page in prose if page['kind'] == 'legal']
+
+    write(out / 'sitemap.xml', templates.render('sitemap.xml', {'pages': entries}))
 
 
 def copy_shared(out):

--- a/buildlib/i18n.py
+++ b/buildlib/i18n.py
@@ -1,0 +1,622 @@
+"""
+Locales: the same site, said in another language.
+
+WHAT A LOCALE IS HERE
+
+A locale is not a copy of the site. It is a set of overrides read on top of the
+English sources, which stay the single description of what the site *is* - which
+tools exist, which category each one joins, which guide is about which tool,
+what the Content-Security-Policy allows. None of that is language. A locale
+supplies only the words, plus the one structural thing that genuinely differs
+between languages: the slug in the URL.
+
+That split is the whole design, and it is what stops eleven languages from
+becoming eleven sites to keep in step. Ship a new tool and every locale gains a
+page for it the same day - in English until somebody translates it, but present,
+linked, and in the right category, because the category was never a translated
+string in the first place.
+
+WHERE IT LIVES
+
+    locales/<lang>/locale.toml            the language itself: its name, its
+                                          slugs, and every string in
+                                          config/site.toml worth translating
+    locales/<lang>/tools/<slug>.toml      overrides for tools/<slug>/tool.toml
+    locales/<lang>/tools/<slug>.html      that tool's translated body.html
+    locales/<lang>/pages/<slug>.toml      overrides for pages/<slug>/page.toml
+    locales/<lang>/pages/<slug>.html      that page's translated body.html
+
+The slug in a locale's filename is always the ENGLISH slug. The localized slug
+is a value, in [slugs], and never a filename - so renaming a German URL is one
+line in one file, and the German translation of a tool does not become
+impossible to find because somebody localized the folder it sits in too.
+
+FALLING BACK, AND WHY IT IS ALLOWED HERE
+
+buildlib/template.py refuses to render a missing name: "a page that silently
+loses its description because a key was renamed is exactly the failure this
+build is meant to make impossible". That rule is not weakened below - it is
+moved. A locale may leave a key out, and the English text is used; what a locale
+may NOT do is leave a key out and still be advertised as a translation.
+
+An incomplete locale is built, so it can be read and reviewed at a real URL, and
+is then held back from every place that would claim it exists:
+
+  * no <link rel="alternate" hreflang> pointing at it, from any page;
+  * no entry in sitemap.xml;
+  * no link in the language switcher.
+
+So a half-translated German site is a thing the author can open, and a thing
+Google is never invited to index. Setting `complete = true` turns the fallback
+back into an error: from then on a missing key fails the build, exactly as a
+missing name does in a template. A locale therefore gets more strict as it gets
+more finished, which is the direction that helps.
+"""
+
+from buildlib.site import ConfigError, load_toml
+
+
+# ---------------------------------------------------------------------------
+# What is a word, and what is a fact about the site
+#
+# Listed rather than inferred, for the same reason REQUIRED_TOOL_KEYS is listed:
+# a rule you can read beats a rule you have to work out. Everything named here
+# is prose a translator is expected to rewrite. Everything not named is either
+# structure (a slug, a category id, an order), a fact that does not change with
+# the language (a date, an origin, an analytics id), or a mark rather than a
+# word (an emoji, an SVG path).
+#
+# Getting this list wrong is visible rather than silent: a key left off cannot
+# be translated and shows in English on a "complete" locale, and a key added by
+# mistake makes the build ask for a translation of something that has none.
+
+TRANSLATABLE_TOOL_KEYS = (
+    'name', 'heading', 'tagline',
+    'title', 'description', 'og_title', 'og_description', 'og_image_alt',
+    'pledge', 'live_hint', 'read_first', 'howto_heading', 'card',
+    'words', 'facts', 'privacy', 'howto', 'faq', 'schema',
+    # The drop zone, and the importer panel on the tools that have one. Its
+    # `accept` and `multiple` are structural and stay put; what a locale
+    # supplies is the two lines a visitor actually reads off it, and the noun
+    # the importer's warning is written around.
+    'picker',
+)
+
+TRANSLATABLE_PAGE_KEYS = (
+    'nav', 'title', 'description', 'heading', 'lede',
+    'og_title', 'og_description', 'og_image_alt',
+    # The date as it is written on the page - "19 August 2026" - and not
+    # `lastmod`, which is the machine-readable copy of it that goes in the
+    # sitemap. A month has a name in every language and that name is a word;
+    # 2026-08-19 is the same string everywhere and is not.
+    'updated',
+)
+
+# Top-level tables of config/site.toml a locale may rewrite. Naming a table
+# means every string under it, however deep - [hub] carries its own lede, its
+# guarantees and its categories, and all of them are words.
+TRANSLATABLE_SITE_PATHS = (
+    'hub', 'guides', 'roadmap', 'not_found', 'footer', 'ui',
+)
+
+# Inside those tables, the keys that are still structure and must survive
+# translation untouched. `slug` above all: a locale changes a URL through
+# [slugs], where every URL it changes can be read in one place, and never by
+# quietly redefining one in the middle of a wall of prose.
+STRUCTURAL_KEYS = frozenset({
+    'slug', 'id', 'order', 'lastmod', 'published', 'category', 'group',
+    'mark', 'icon', 'favicon', 'brand_mark', 'kind', 'tool',
+    'css_parts', 'js_parts', 'roadmap_group', 'analytics_extra',
+    # The file input's own attributes. A MIME type and a boolean are the same
+    # in every language, and a locale that translated "image/*" would produce a
+    # picker that accepts nothing.
+    'accept', 'multiple',
+})
+
+# ...except under [ui], where the list does not apply at all, because [ui] is
+# nothing but words - that is what it is for.
+#
+# The list above is matched on the key name at any depth, which is what makes it
+# short enough to read. The cost is that a name meaning something structural in
+# one table means it everywhere, and [ui.tool] - the frame's words for a tool
+# page - collides with `tool` in a guide's page.toml, which names the tool the
+# guide is about. Left alone, that one collision quietly served the English
+# pledge and the English button labels on every translated tool page, while the
+# rest of the page around them came out correctly in German.
+#
+# Exempting the subtree is the fix rather than renaming the table, because the
+# next such collision would otherwise be found the same way: by reading a
+# finished page and noticing a sentence in the wrong language.
+WORDS_ONLY = 'ui'
+
+
+class LocaleError(ConfigError):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Loading
+
+
+REQUIRED_LOCALE_KEYS = ('lang', 'name', 'endonym')
+
+RESERVED_LOCALE_KEYS = frozenset({
+    'lang', 'name', 'endonym', 'hreflang', 'dir', 'complete', 'slugs',
+})
+
+
+def load_locales(root, site):
+    """Every locale under locales/, English first.
+
+    English is not a folder. It is the sources themselves, wrapped in the same
+    shape a locale has so that the build can loop over one list and not care
+    which member of it is the original. That is deliberate: the moment English
+    becomes locales/en/ it becomes a translation of itself, free to drift from
+    the tool.toml it was copied out of, and the build loses the one copy of the
+    text every other language is measured against.
+    """
+    locales = [base_locale(site)]
+    if not root.is_dir():
+        return locales
+
+    for path in sorted(root.iterdir()):
+        if path.is_dir():
+            locales.append(load_locale(path, site))
+
+    seen = set()
+    for locale in locales:
+        if locale['lang'] in seen:
+            raise LocaleError(f'two locales both call themselves {locale["lang"]!r}')
+        seen.add(locale['lang'])
+    return locales
+
+
+def base_locale(site):
+    """English, as a locale. Complete by definition - it is what the others are
+    measured against, so it cannot be missing a key it defines."""
+    return {
+        'lang': site['lang'],
+        'name': 'English',
+        'endonym': 'English',
+        'hreflang': site['lang'],
+        'dir': 'ltr',
+        'complete': True,
+        'is_base': True,
+        'prefix': '',
+        'slugs': {},
+        'site': site,
+        'tools': {},
+        'pages': {},
+        'bodies': {},
+        'missing': [],
+    }
+
+
+def load_locale(path, site):
+    """Read one locales/<lang>/ folder."""
+    config = load_toml(path / 'locale.toml')
+    missing = [key for key in REQUIRED_LOCALE_KEYS if key not in config]
+    if missing:
+        raise LocaleError(f'{path}/locale.toml: missing {", ".join(missing)}')
+
+    if config['lang'] != path.name:
+        raise LocaleError(
+            f'{path}/locale.toml: lang is {config["lang"]!r} but the folder is '
+            f'{path.name!r}')
+    if config['lang'] == site['lang']:
+        raise LocaleError(
+            f'{path}: {config["lang"]!r} is the language the sources are already '
+            'written in. English is not a locale folder - see buildlib/i18n.py.')
+
+    locale = {
+        'lang': config['lang'],
+        # `name` is the language in English, for a build log and an error
+        # message. `endonym` is the language in its own language, which is what
+        # the switcher shows: a reader looking for their own language scans for
+        # the word they would use for it, not for the word English uses.
+        'name': config['name'],
+        'endonym': config['endonym'],
+        # Usually the same as `lang`, and not always: pt-BR is a language and a
+        # region, and hreflang is the one place that distinction is expressed.
+        'hreflang': config.get('hreflang', config['lang']),
+        'dir': config.get('dir', 'ltr'),
+        'complete': bool(config.get('complete', False)),
+        'is_base': False,
+        'prefix': f'{config["lang"]}/',
+        'slugs': dict(config.get('slugs', {})),
+        'tools': {},
+        'pages': {},
+        'bodies': {},
+        'missing': [],
+    }
+
+    stray = sorted(set(config) - RESERVED_LOCALE_KEYS - set(TRANSLATABLE_SITE_PATHS))
+    if stray:
+        raise LocaleError(
+            f'{path}/locale.toml: {", ".join(stray)} is not a translatable part of '
+            'config/site.toml. A locale supplies words and slugs; everything else '
+            'about the site is decided once, in English, for every language.')
+
+    overrides = {key: value for key, value in config.items()
+                 if key in TRANSLATABLE_SITE_PATHS}
+    locale['site'] = merge(site, overrides, f'{path.name}/locale.toml',
+                           locale['missing'], 'site')
+
+    for kind_name, keys in (('tools', TRANSLATABLE_TOOL_KEYS),
+                            ('pages', TRANSLATABLE_PAGE_KEYS)):
+        folder = path / kind_name
+        if not folder.is_dir():
+            continue
+
+        for entry in sorted(folder.glob('**/*.toml')):
+            slug = entry.relative_to(folder).with_suffix('').as_posix()
+            table = load_toml(entry)
+            unknown = sorted(set(table) - set(keys))
+            if unknown:
+                raise LocaleError(
+                    f'{entry}: {", ".join(unknown)} is not translatable. A '
+                    f'{kind_name[:-1]} locale file carries only: {", ".join(keys)}')
+            locale[kind_name][slug] = table
+
+        for entry in sorted(folder.glob('**/*.html')):
+            slug = entry.relative_to(folder).with_suffix('').as_posix()
+            locale['bodies'][f'{kind_name}/{slug}'] = entry.read_text(encoding='utf-8')
+
+    return locale
+
+
+# ---------------------------------------------------------------------------
+# Merging
+
+
+def merge(base, over, where, missing, path, words_only=False):
+    """English underneath, the translation on top, recursively.
+
+    Records what was not translated in `missing` rather than raising, because
+    whether an untranslated key is fatal is a question about the locale as a
+    whole - see `check_complete` - and not one this function can answer while it
+    is halfway down a table.
+
+    Two shapes are refused outright, because neither is a translation:
+
+      * a list whose length changed. [[faq]] and [[hub.guarantees]] are merged
+        entry by entry, in order, so five questions in English and four in
+        German is not a shorter translation, it is a question that will render
+        in English inside a German page with nothing to say which one it was.
+      * a value whose type changed. A table where the English has a string is a
+        translator having restructured the page, which the templates cannot
+        follow.
+    """
+    if isinstance(base, dict):
+        if not isinstance(over, dict):
+            raise LocaleError(f'{where}: {path} should be a table, not a {kind(over)}')
+
+        unknown = sorted(set(over) - set(base))
+        if unknown:
+            raise LocaleError(
+                f'{where}: {path} has {", ".join(unknown)}, which the English does '
+                'not. A locale translates what is there; it cannot add a key the '
+                'templates never ask for.')
+
+        merged = {}
+        for key, value in base.items():
+            # Once inside [ui] the whole subtree is words, however deep it
+            # goes, so STRUCTURAL_KEYS stops applying from here down.
+            inner = words_only or (path == 'site' and key == WORDS_ONLY)
+            if key in STRUCTURAL_KEYS and not words_only:
+                merged[key] = value
+            elif key in over:
+                merged[key] = merge(value, over[key], where, missing,
+                                    f'{path}.{key}', inner)
+            else:
+                merged[key] = value
+                note_missing(value, missing, f'{path}.{key}', inner)
+        return merged
+
+    if isinstance(base, list):
+        if not isinstance(over, list):
+            raise LocaleError(f'{where}: {path} should be a list, not a {kind(over)}')
+        if len(base) != len(over):
+            raise LocaleError(
+                f'{where}: {path} has {len(over)} entries and the English has '
+                f'{len(base)}. They are merged in order, so the counts have to '
+                'match - a missing entry would render in English with nothing to '
+                'say which one it was.')
+        return [merge(a, b, where, missing, f'{path}[{index}]', words_only)
+                for index, (a, b) in enumerate(zip(base, over))]
+
+    if isinstance(over, (dict, list)):
+        raise LocaleError(
+            f'{where}: {path} should be a {kind(base)}, not a {kind(over)}')
+    return over
+
+
+def note_missing(value, missing, path, words_only=False):
+    """Record an untranslated string, and walk into a table or a list to record
+    the strings inside it.
+
+    Only strings are counted. Numbers, booleans and dates are the same in every
+    language, and counting them would leave a locale permanently short of
+    complete over keys no translator will ever touch.
+    """
+    if isinstance(value, str):
+        if value.strip():
+            missing.append(path)
+    elif isinstance(value, dict):
+        for key, inner in value.items():
+            if words_only or key not in STRUCTURAL_KEYS:
+                note_missing(inner, missing, f'{path}.{key}', words_only)
+    elif isinstance(value, list):
+        for index, inner in enumerate(value):
+            note_missing(inner, missing, f'{path}[{index}]', words_only)
+
+
+def kind(value):
+    return {dict: 'table', list: 'list', str: 'string',
+            bool: 'boolean', int: 'number', float: 'number'}.get(type(value), 'value')
+
+
+# ---------------------------------------------------------------------------
+# Applying a locale to one tool or one page
+
+
+def translate(source, over, keys, where, missing, path):
+    """Merge a translation over just the keys that are words.
+
+    Merging over the whole table instead was the first version, and it counted
+    things nobody will ever translate as untranslated: the `url` the build had
+    already worked out, the `dir` it was read from, and - because a
+    Content-Security-Policy is a table of lists of strings and looks exactly
+    like prose from the inside - every origin in the policy. A locale reported
+    hundreds of missing strings it could not have supplied, which made the one
+    report that says what is left to do useless for saying it.
+
+    Naming the keys fixes that at the source. The lists are the same ones a
+    locale file is checked against when it is read, so what may be translated
+    and what is counted as untranslated cannot drift apart.
+    """
+    return merge({key: source[key] for key in keys if key in source},
+                 over, where, missing, path)
+
+
+def localize_tool(tool, locale, site):
+    """One tool, said in one language, at its own URL.
+
+    The returned tool is a copy. `dir` still points at the English source folder
+    - the JavaScript, the stylesheet and the share card are the same files in
+    every language, and building eleven copies of a tool out of eleven folders
+    is the drift this whole arrangement exists to avoid.
+    """
+    slug = tool['slug']
+    merged = dict(tool)
+    merged.update(translate(tool, locale['tools'].get(slug, {}),
+                            TRANSLATABLE_TOOL_KEYS,
+                            f'locales/{locale["lang"]}/tools/{slug}.toml',
+                            locale['missing'], f'tools.{slug}'))
+    merged['out_slug'] = locale['slugs'].get(slug, slug)
+    merged['url'] = f'{site["domain"]}{locale["prefix"]}{merged["out_slug"]}/'
+    return merged
+
+
+def localize_page(page, locale, site):
+    """One prose page, said in one language.
+
+    `depth` is recomputed rather than carried over: a guide sits two levels down
+    in English and three under a locale prefix, and the frame around it works
+    out where the stylesheet and the hub are from that number alone.
+    """
+    slug = page['slug']
+    merged = dict(page)
+    merged.update(translate(page, locale['pages'].get(slug, {}),
+                            TRANSLATABLE_PAGE_KEYS,
+                            f'locales/{locale["lang"]}/pages/{slug}.toml',
+                            locale['missing'], f'pages.{slug}'))
+    merged['out_slug'] = locale['slugs'].get(slug, slug)
+    merged['url'] = f'{site["domain"]}{locale["prefix"]}{merged["out_slug"]}/'
+    merged['depth'] = (merged['out_slug'].count('/') + 1
+                       + (0 if locale['is_base'] else 1))
+    return merged
+
+
+def body_for(locale, kind_name, slug, fallback):
+    """The translated body.html for a tool or a page, or the English one.
+
+    Prose bodies are whole files rather than keys in a table, so they fall back
+    as whole files too: a guide is either translated or it is not, and there is
+    no useful halfway state where three of its paragraphs are in German.
+    """
+    key = f'{kind_name}/{slug}'
+    if key in locale['bodies']:
+        return locale['bodies'][key]
+    if not locale['is_base']:
+        locale['missing'].append(f'{kind_name}.{slug}.body')
+    return fallback
+
+
+# ---------------------------------------------------------------------------
+# The frame's own words
+
+
+def render_ui(templates, ui, context, where, include=()):
+    """Render the [ui] strings from config/site.toml as small templates.
+
+    They are not plain strings, and that is the point. "Your files are never
+    uploaded" is subject-verb-object; the German for it is not, and a string cut
+    into a before-half and an after-half around the noun could only ever be one
+    word order or the other. Written whole, with {{ tool.words.plural }} sitting
+    wherever the language puts it, it can be either.
+
+    Using the site's own template syntax rather than inventing a placeholder
+    syntax for translations buys the checking for free: buildlib/template.py
+    refuses to render a name it cannot resolve, so a translator who mistypes
+    {{ tool.words.plural }} gets a failed build naming the string, rather than a
+    published sentence with a hole in the middle of it.
+
+    `include` names the nested tables to render as well - [ui.tool] and
+    [ui.picker] - and every one not named is left out rather than rendered.
+    They reach for names only some pages have: [ui.tool] needs {{ tool }}, which
+    a hub page has not got, and [ui.picker] needs {{ tool.picker.urls }}, which
+    only the tools that offer to fetch an address define. Rendering one where
+    its names are missing is a build failure; carrying it unrendered would put
+    template syntax on screen. Asking for it by name where it belongs is
+    neither.
+    """
+    include = set(include)
+    out = {}
+    for key, value in ui.items():
+        if isinstance(value, dict):
+            if key in include:
+                out[key] = render_ui(templates, value, context, f'{where}.{key}')
+            continue
+        out[key] = templates.render_source(value, f'{where}.{key}', context)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Slugs
+
+
+def check_slugs(locale, tool_slugs, page_slugs, site):
+    """Every slug a locale renames has to name something, and no two things may
+    end up at one address.
+
+    Neither failure is visible in the output, which is why both are checked
+    here: a typo in [slugs] silently leaves that one page at its English URL
+    inside a German site, and two entries colliding silently means one page is
+    written over the other while the sitemap goes on advertising an address that
+    now serves somebody else's content.
+    """
+    known = set(tool_slugs) | set(page_slugs) | {
+        site['guides']['slug'], site['roadmap']['slug']}
+    where = f'locales/{locale["lang"]}/locale.toml'
+
+    for english in sorted(locale['slugs']):
+        if english not in known:
+            raise LocaleError(
+                f'{where}: [slugs] renames {english!r}, which is not a tool, a page, '
+                'the guides index or the roadmap. Slugs are keyed by the ENGLISH '
+                f'slug. Known: {", ".join(sorted(known))}')
+
+    taken = {}
+    for english in sorted(known):
+        localized = locale['slugs'].get(english, english)
+        if localized in taken:
+            raise LocaleError(
+                f'{where}: {english!r} and {taken[localized]!r} both become '
+                f'{localized!r} in {locale["lang"]}, so one page would be written '
+                'over the other.')
+        taken[localized] = english
+
+
+# ---------------------------------------------------------------------------
+# Completeness, and what it gates
+
+
+def check_complete(locale):
+    """A locale that claims to be finished has to be finished.
+
+    Called after every page has been localized, so `missing` holds everything
+    that fell back across the whole site rather than whatever happened to have
+    been reached by the time some earlier check ran.
+    """
+    if locale['is_base'] or not locale['complete']:
+        return
+    if not locale['missing']:
+        return
+
+    shown = sorted(set(locale['missing']))
+    more = len(shown) - 12
+    tail = f'\n    ... and {more} more' if more > 0 else ''
+    raise LocaleError(
+        f'locales/{locale["lang"]}/ says complete = true, but {len(shown)} strings '
+        'still fall back to English:\n    '
+        + '\n    '.join(shown[:12]) + tail
+        + '\n  Translate them, or set complete = false: the locale is then still '
+          'built and still readable at its own URL, and is kept out of the '
+          'sitemap, the hreflang tags and the language switcher until it is ready.')
+
+
+def published(locales):
+    """The locales fit to be advertised: English, and every locale that says it
+    is finished.
+
+    The sitemap, the hreflang tags and the switcher are all built from this one
+    list, so the three cannot disagree about which languages the site claims to
+    be available in - which is the failure Google reports as "hreflang tags
+    point to a page that is not indexed".
+    """
+    return [locale for locale in locales if locale['is_base'] or locale['complete']]
+
+
+def alternates(locales, slug, site):
+    """The <link rel="alternate" hreflang> set for one page, in every language
+    it is published in.
+
+    Google's rule is that the set is reciprocal and self-inclusive: every page
+    lists every version of itself, its own included, and each of those pages
+    lists the same set back. Built from one list here, so reciprocity is a
+    property of the code rather than something to be audited afterwards.
+
+    x-default points at English, which is what a reader whose language is not
+    one of these is meant to be given.
+    """
+    ready = published(locales)
+    # One language is not a set of alternates, it is a page. A lone
+    # hreflang="en" beside an x-default pointing at the same URL says nothing
+    # that the canonical above it has not already said, so until there is a
+    # second language to point at, nothing is written at all.
+    if len(ready) < 2:
+        return []
+
+    entries = [{'hreflang': locale['hreflang'], 'href': locale_url(locale, slug, site)}
+               for locale in ready]
+    entries.append({'hreflang': 'x-default', 'href': entries[0]['href']})
+    return entries
+
+
+def switcher(locales, current, slug, site):
+    """What the language switcher on one page offers.
+
+    Every published language, linked to this same page in that language rather
+    than to its front door. A reader who wants this page in German wants this
+    page; dropping them on the hub to find it again is the commonest way a
+    switcher gets built wrong.
+
+    Plain links, with no JavaScript, no cookie and no redirect anywhere near
+    them. A crawler has to be able to walk from one language into the next, and
+    a site whose whole claim is that it does not track you cannot be storing a
+    preference in order to do it.
+    """
+    ready = published(locales)
+    # Nothing to switch to. A control offering only the language you are already
+    # reading is furniture, so it is not rendered until a second language is
+    # finished enough to be offered.
+    if len(ready) < 2:
+        return []
+
+    return [
+        {
+            'lang': locale['lang'],
+            'hreflang': locale['hreflang'],
+            'endonym': locale['endonym'],
+            'dir': locale['dir'],
+            # Root-absolute, unlike every other link on the page. The switcher
+            # is the one set of links that leaves the language it is written
+            # in, so it cannot be resolved against a folder whose name is
+            # itself localized.
+            'href': locale_path(locale, slug),
+            'current': locale['lang'] == current['lang'],
+        }
+        for locale in ready
+    ]
+
+
+def locale_path(locale, slug):
+    """Where one page lives in one language, as a root-absolute path."""
+    localized = locale['slugs'].get(slug, slug)
+    return f'/{locale["prefix"]}' + (f'{localized}/' if localized else '')
+
+
+def locale_url(locale, slug, site):
+    """The same, as the absolute URL a canonical or an hreflang needs."""
+    return site['domain'].rstrip('/') + locale_path(locale, slug)

--- a/buildlib/site.py
+++ b/buildlib/site.py
@@ -119,6 +119,7 @@ def tool_jsonld(site, tool):
             'browserRequirements': tool['schema'].get(
                 'browser_requirements', 'Requires JavaScript.'),
             'description': tool['schema']['description'],
+            'inLanguage': site['lang'],
             'isAccessibleForFree': True,
             'offers': {'@type': 'Offer', 'price': '0', 'priceCurrency': 'USD'},
             'featureList': tool['schema']['features'],
@@ -132,7 +133,7 @@ def tool_jsonld(site, tool):
             '@type': 'BreadcrumbList',
             'itemListElement': [
                 {'@type': 'ListItem', 'position': 1,
-                 'name': site['name'], 'item': site['domain']},
+                 'name': site['name'], 'item': site['home']},
                 {'@type': 'ListItem', 'position': 2,
                  'name': tool['name'], 'item': tool['url']},
             ],
@@ -167,11 +168,11 @@ def roadmap_jsonld(site):
     graph = [
         {
             '@type': 'CollectionPage',
-            'url': f'{site["domain"]}{roadmap["slug"]}/',
+            'url': site['roadmap_url'],
             'name': to_text(roadmap['heading']),
             'description': to_text(roadmap['description']),
             'inLanguage': site['lang'],
-            'isPartOf': {'@id': site['domain'] + '#website'},
+            'isPartOf': {'@id': site['home'] + '#website'},
         },
     ]
     return dumps_ld(graph)
@@ -217,10 +218,10 @@ def page_jsonld(site, page):
             # asks for - markup describes what a visitor can see.
             'itemListElement': [
                 {'@type': 'ListItem', 'position': 1,
-                 'name': site['name'], 'item': site['domain']},
+                 'name': site['name'], 'item': site['home']},
                 {'@type': 'ListItem', 'position': 2,
                  'name': to_text(site['guides']['heading']),
-                 'item': f'{site["domain"]}{site["guides"]["slug"]}/'},
+                 'item': site['guides_url']},
                 {'@type': 'ListItem', 'position': 3,
                  'name': to_text(page['nav']), 'item': page['url']},
             ],
@@ -237,7 +238,7 @@ def guides_jsonld(site, guides):
     them is describing the page rather than advertising something that is not
     built yet.
     """
-    index_url = f'{site["domain"]}{site["guides"]["slug"]}/'
+    index_url = site['guides_url']
     graph = [
         {
             '@type': 'CollectionPage',
@@ -245,7 +246,7 @@ def guides_jsonld(site, guides):
             'name': to_text(site['guides']['heading']),
             'description': to_text(site['guides']['description']),
             'inLanguage': site['lang'],
-            'isPartOf': {'@id': site['domain'] + '#website'},
+            'isPartOf': {'@id': site['home'] + '#website'},
             'mainEntity': {
                 '@type': 'ItemList',
                 'itemListElement': [
@@ -263,7 +264,7 @@ def guides_jsonld(site, guides):
             '@type': 'BreadcrumbList',
             'itemListElement': [
                 {'@type': 'ListItem', 'position': 1,
-                 'name': site['name'], 'item': site['domain']},
+                 'name': site['name'], 'item': site['home']},
                 {'@type': 'ListItem', 'position': 2,
                  'name': to_text(site['guides']['heading']), 'item': index_url},
             ],
@@ -276,8 +277,8 @@ def hub_jsonld(site, tools):
     graph = [
         {
             '@type': 'WebSite',
-            '@id': site['domain'] + '#website',
-            'url': site['domain'],
+            '@id': site['home'] + '#website',
+            'url': site['home'],
             'name': site['name'],
             'description': site['hub']['schema_description'],
             'inLanguage': site['lang'],
@@ -297,10 +298,10 @@ def hub_jsonld(site, tools):
         },
         {
             '@type': 'CollectionPage',
-            '@id': site['domain'] + '#collection',
-            'url': site['domain'],
+            '@id': site['home'] + '#collection',
+            'url': site['home'],
             'name': site['name'],
-            'isPartOf': {'@id': site['domain'] + '#website'},
+            'isPartOf': {'@id': site['home'] + '#website'},
             'about': site['hub']['schema_about'],
             'mainEntity': {
                 '@type': 'ItemList',

--- a/config/site.toml
+++ b/config/site.toml
@@ -19,6 +19,14 @@ source_url = "https://github.com/A-Box-of-Tools/website"
 source_label = "github.com/A-Box-of-Tools/website"
 contact_email = "hi@abox.tools"
 
+# The one guide that is linked to from inside a sentence rather than from a
+# list. The hub's three guarantees end by pointing at it, so it cannot be moved
+# or renamed without the build noticing - which is the whole reason its slug is
+# written here and not in the middle of the markup. Not translatable: a locale
+# changes the address this resolves to through [slugs], and never which guide
+# the sentence is about.
+safety_guide = "guides/is-it-safe-to-upload-files"
+
 adsense_client = "ca-pub-5997711677062324"
 analytics_id = "G-SCBN29XZ31"
 
@@ -346,6 +354,152 @@ id = "before-you-upload"
 name = "Before you upload anything"
 note = "What handing a file to a website actually does, and how to tell whether it had to happen."
 order = ["is-it-safe-to-upload-files"]
+
+#
+# ---------------------------------------------------------------------------
+# The frame's own words.
+#
+# Everything below used to be typed into templates/. That was fine while the
+# site was written in one language and stopped being fine the moment it was not:
+# a string sitting in markup is a string no locale file can reach, so it renders
+# in English inside a German page with nothing to say why.
+#
+# These are read as small templates rather than as plain strings, using the same
+# {{ }} the rest of the build uses, so a translator can put the moving part
+# wherever their language puts it. "Your files are never uploaded" is
+# subject-verb-object; the German is not, and a string split into a before-half
+# and an after-half around {{ tool.words.plural }} could only ever be one or the
+# other. Written whole, it can be either.
+#
+# The names inside the braces are checked. buildlib/template.py refuses to
+# render a name it cannot resolve, so a translation that mistypes
+# {{ tool.words.plural }} fails the build rather than shipping a sentence with a
+# hole in it - which is the same bargain every other value here is on.
+#
+# [ui.tool] and [ui.picker] are separate because they are the ones that reach
+# for {{ tool }}, and only a tool page has one. A hub page rendering them would
+# be asking for a name that is not there.
+# ---------------------------------------------------------------------------
+#
+
+[ui]
+# The language switcher. `languages` labels it for a screen reader; the
+# languages themselves are never translated - each is written in its own
+# language, in locales/<lang>/locale.toml, because somebody looking for German
+# is looking for the word "Deutsch".
+languages = "Language"
+
+breadcrumb = "Breadcrumb"
+all_tools = "All tools"
+last_updated = "Last updated"
+built_tag = "Built"
+planned_count = "planned"
+built_count = "built"
+
+# The guides index counts itself. Two forms, because "1 guides" is the kind of
+# thing that is only ever noticed by the reader. Languages with more plural
+# forms than two would need more than this, and none of the ten this site is
+# translated into does for a count that starts at nine.
+guide_one = "guide"
+guide_many = "guides"
+
+footer_tools = "Tools"
+footer_site = "This site"
+footer_contact = "Get in touch"
+footer_sitemap = "Sitemap"
+footer_source = "Read the code on GitHub"
+
+# The three lines that carry a link inside a sentence. The <a> is part of the
+# translated string on purpose: which words are the link, and where in the
+# sentence they fall, is a decision only the translator can make.
+guarantees_note = """
+    None of that has to be taken on trust.
+    <a href="{{ base }}{{ links.safety_guide }}/">
+      How to tell whether a tool really needs your files</a>
+    sets out four checks you can run yourself, on this site or any other."""
+
+hub_guides_note = """
+    Not sure which setting to move, or what it costs?
+    <a href="{{ base }}{{ links.guides }}/">There is a guide for every tool</a>."""
+
+hub_roadmap_note = """
+    More is coming, and the list is public:
+    <a href="{{ base }}{{ links.roadmap }}/">see what is planned next</a>."""
+
+guides_all_note = """
+    Every guide here describes a tool that runs on your own machine:
+    <a href="{{ base }}">see all of them</a>."""
+
+#
+# The tool page. Everything here may use {{ tool }}, and nothing outside a tool
+# page may use any of it.
+#
+
+[ui.tool]
+view_source = "View source"
+how_verified = "How this is verified"
+live_check = "Live check:"
+offline = "Offline:"
+checking = "checking&hellip;"
+questions_heading = "Questions"
+guide_heading = "The longer version"
+privacy_heading = "How the privacy claim is verifiable"
+
+# The headline claim. The noun in the middle is this tool's own - "files",
+# "pictures", "clips" - and the sentence is written round it rather than in two
+# pieces either side of it, so a language that puts the verb last can.
+pledge_line = """
+    Your {{ tool.words.plural }} are <strong>never uploaded</strong>. There is no server."""
+
+boot_title = "This page's code did not start."
+boot_body = """
+    Opening <code>index.html</code> directly from a folder blocks JavaScript modules,
+    so nothing will happen when you choose {{ tool.words.choose }}. Serve the folder over http instead:"""
+boot_then = "Then open <code>http://localhost:8080/</code>."
+
+noscript_title = "JavaScript is disabled."
+noscript_body = "This app does all of its work in your browser, so it cannot run without it."
+
+check_yourself = """
+      <strong>Check it yourself.</strong> None of the above has to be taken on trust.
+      This page is generated from the templates and config in the repository by a
+      build script you can read and run yourself, and the result is committed to
+      the <code>dist</code> branch &mdash; so you can diff what is served against
+      what a build of the sources produces:"""
+
+read_first_lead = """
+      The files worth reading first are <code>config/site.toml</code> for the
+      Content-Security-Policy"""
+
+#
+# The one line a guide carries that a legal page does not: the link to the
+# tool the guide is about. Its own table because it needs {{ tool }}, and a
+# guide about no tool in particular - "is it safe to upload files" - has not
+# got one.
+#
+
+[ui.guide]
+# The name goes inside the string rather than after it. English puts the verb
+# first and German puts it last, and a label built as "Open the" plus a name
+# can only ever be the first of those.
+open_tool = "Open the {{ tool.name | e }}"
+
+#
+# The "add from a web address" panel, on the tools that have one. It may use
+# {{ tool.picker.urls }}, which only those tools define.
+#
+
+[ui.picker]
+warning = """
+      <strong>This is the one feature that touches the network.</strong>
+      Fetching an address tells that server your IP address and which {{ tool.picker.urls.noun }} you
+      asked for. The {{ tool.picker.urls.noun }} is copied to local memory on arrival and never
+      requested again. Nothing of yours is ever sent out &mdash; this page still
+      cannot make an upload of any kind."""
+label = "One address per line"
+note = """
+      The server must permit cross-origin use of its {{ tool.picker.urls.noun }}s. Many sites do not,
+      and those will fail with a message rather than silently breaking later."""
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -1,0 +1,361 @@
+#
+# Deutsch.
+#
+# The first locale, and therefore the one that had to prove the arrangement
+# works. What is here is the frame: the hub, the guides index, the roadmap, the
+# 404, the footer, and the words the templates themselves use. The tools and the
+# guides are translated in tools/ and pages/ beside this file.
+#
+# Nothing structural is repeated here. There is no list of which tools exist, no
+# category ids, no ordering, no Content-Security-Policy - all of that is decided
+# once, in English, in config/site.toml, and a locale that tried to restate any
+# of it would be told so by the build. See buildlib/i18n.py.
+#
+
+lang = "de"
+name = "German"
+endonym = "Deutsch"
+
+# Not finished: the guides are still English prose, and so is the planned list
+# on the roadmap, which lives in config/planned.toml and has no locale file yet.
+# While this is false the German pages are built and readable, and are kept out
+# of the sitemap, out of every hreflang set, and out of the language switcher.
+# Turning it true makes every remaining fallback a build failure, which is the
+# point - see check_complete in buildlib/i18n.py.
+complete = false
+
+#
+# ---------------------------------------------------------------------------
+# The addresses.
+#
+# Keyed by the ENGLISH slug on the left, which is the name of the thing, and
+# never by the German one. The German is an address and appears only on the
+# right.
+#
+# These are the words a German speaker actually types into a search box, not
+# translations of the English slugs - "bild-komprimieren", not
+# "komprimieren-bild". That is the entire reason this site is not simply served
+# at /de/compress-image/: the slug is the one part of a page's markup that is
+# also a keyword, and leaving it in English throws that away in every market
+# except this one.
+#
+# No umlauts and no eszett. Both survive a modern URL bar and neither survives
+# being pasted into a forum, a chat client, or an older analytics pipeline
+# intact, so they are transliterated the way German URLs conventionally are:
+# oe, ue, ae, ss.
+# ---------------------------------------------------------------------------
+#
+
+[slugs]
+# The tools.
+"compress-image" = "bild-komprimieren"
+"compress-pdf" = "pdf-verkleinern"
+"crop-video" = "video-zuschneiden"
+"edit-audio" = "audio-bearbeiten"
+# Named for the job rather than for the format. Almost nobody searches for an
+# "EXIF editor" in German; they search for how to get the data out of a photo.
+"exif-editor" = "exif-daten-entfernen"
+"images-to-pdf" = "bilder-in-pdf-umwandeln"
+"images-to-video" = "bilder-in-video-umwandeln"
+"resize-image" = "bildgroesse-aendern"
+"trim-video" = "video-schneiden"
+
+# The indexes and the legal pages. "Ratgeber" rather than a literal "Anleitungen":
+# it is the word German publishers use for exactly this kind of writing, the
+# explanatory piece that sits beside a product.
+"guides" = "ratgeber"
+"roadmap" = "roadmap"
+"privacy" = "datenschutz"
+"terms" = "nutzungsbedingungen"
+
+# The guides. Each one is the question its readers ask, in the words they ask it
+# in, rather than a translation of the English title.
+"guides/compress-an-image-to-a-target-size" = "ratgeber/bild-auf-groesse-komprimieren"
+"guides/resize-an-image" = "ratgeber/bild-skalieren"
+"guides/remove-exif-and-gps-data" = "ratgeber/exif-und-gps-daten-entfernen"
+"guides/make-a-pdf-smaller" = "ratgeber/pdf-kleiner-machen"
+"guides/combine-images-into-a-pdf" = "ratgeber/bilder-zu-pdf-zusammenfuegen"
+"guides/turn-images-into-a-video" = "ratgeber/aus-bildern-ein-video-machen"
+"guides/trim-a-video" = "ratgeber/video-kuerzen"
+"guides/crop-a-video" = "ratgeber/video-bildausschnitt-aendern"
+"guides/is-it-safe-to-upload-files" = "ratgeber/ist-das-hochladen-von-dateien-sicher"
+
+#
+# ---------------------------------------------------------------------------
+# The hub.
+# ---------------------------------------------------------------------------
+#
+
+[hub]
+title = "Kostenlose Browser-Tools &mdash; ohne Upload, ohne Anmeldung | abox.tools"
+# Unter 155 Zeichen, wie im Englischen: Google schneidet eine Beschreibung dort
+# ab, und der Schluss ist hier der Teil, der die Seite verkauft.
+description = "Kostenlose Browser-Tools, die Ihre Dateien nie hochladen. Bilder zu PDF oder MP4 verbinden, Bilder exakt komprimieren, Videos zuschneiden, EXIF entfernen."
+heading = "Werkzeuge, die keinen Server anfassen"
+og_title = "A Box of Tools &mdash; Werkzeuge, die keinen Server anfassen"
+og_description = "Kleine Werkzeuge fuer je eine Aufgabe, die vollstaendig in Ihrem Browser laufen. Ihre Dateien verlassen Ihr Geraet nicht."
+og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"
+schema_description = "Kleine Werkzeuge fuer je eine Aufgabe, die ihre gesamte Arbeit im Browser erledigen. Nichts wird hochgeladen, ein Konto ist nicht noetig."
+schema_about = "Browser-basierte Datei-Werkzeuge, die Dateien lokal verarbeiten, ohne sie hochzuladen"
+
+lede = """
+    Kleine Werkzeuge fuer je eine Aufgabe, die ihre gesamte Arbeit in Ihrem
+    Browser erledigen. Ihre Dateien bleiben auf Ihrem Geraet: Es gibt nichts
+    hochzuladen, kein Konto anzulegen und nichts zu verfolgen."""
+
+support_note = """
+      Diese Werkzeuge sind kostenlos und bleiben es. Wenn Ihnen eines Arbeit
+      erspart hat, ist das hier das Einzige auf der Seite, das Sie um etwas
+      bittet."""
+
+# Drei nachpruefbare Tatsachen, kein Versprechen - genau wie im Englischen.
+[[hub.guarantees]]
+title = "Ihre Dateien verlassen Ihr Geraet nie"
+body = """
+        Sie werden von Ihrem eigenen Browser geoeffnet, gelesen und verarbeitet,
+        auf Ihrer eigenen Hardware. Die <code>Content-Security-Policy</code> jedes
+        Werkzeugs nennt jede Adresse, die es kontaktieren darf, und keine davon
+        gehoert uns."""
+
+[[hub.guarantees]]
+title = "Ueber Ihre Dateien wird nichts uebermittelt"
+body = """
+        Weder die Datei noch ein Vorschaubild, noch der Name, die Groesse oder
+        wie viele Sie ausgewaehlt haben. Kein Werkzeug hier liest davon etwas
+        aus. Es gibt am anderen Ende keinen Server, der es lesen koennte."""
+
+[[hub.guarantees]]
+title = "Es funktioniert offline"
+body = """
+        Oeffnen Sie ein Werkzeug einmal, trennen Sie die Internetverbindung, und
+        es arbeitet unveraendert weiter an Ihren Dateien. Das laesst sich schwer
+        vortaeuschen: Ein Werkzeug, das Ihre Dateien zum Verarbeiten wegschickt,
+        wuerde schlicht stehen bleiben."""
+
+[[hub.categories]]
+name = "Bilder &amp; Video"
+note = "Mit Fotos und Aufnahmen arbeiten, ohne sie aus der Hand zu geben."
+
+[[hub.categories]]
+name = "Audio"
+note = "An einer Aufnahme arbeiten, ohne sie aus der Hand zu geben - auch am Ton in einem Video."
+
+[[hub.categories]]
+name = "Dokumente &amp; PDF"
+note = "Dokumente erstellen und umsortieren, ohne sie zum Verarbeiten wegzuschicken."
+
+#
+# ---------------------------------------------------------------------------
+# The guides index.
+# ---------------------------------------------------------------------------
+#
+
+[guides]
+nav = "Alle Ratgeber"
+title = "Ratgeber &mdash; wie die Arbeit geht und was jede Einstellung kostet"
+description = "Verstaendliche Ratgeber zum Komprimieren, Skalieren, Zuschneiden, Kuerzen und Umwandeln eigener Dateien - was die Einstellungen bedeuten und warum kein Upload noetig ist."
+heading = "Ratgeber"
+lede = """
+    Ein Ratgeber je Werkzeug, geschrieben fuer alle, denen eine Groesse oder ein
+    Format vorgegeben wurde und die wissen moechten, was der Regler, den sie
+    gleich bewegen, eigentlich tut. Alles hier Beschriebene passiert auf Ihrem
+    eigenen Geraet."""
+og_title = "abox.tools Ratgeber"
+og_description = "Bilder komprimieren, skalieren, zuschneiden, kuerzen und umwandeln - und was jede Einstellung kostet. Ganz ohne Upload."
+og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"
+
+[[guides.groups]]
+name = "Die Arbeit erledigen"
+note = "Einer je Werkzeug: worum es geht, welche Einstellung zaehlt und was sie Sie kostet."
+
+[[guides.groups]]
+name = "Bevor Sie etwas hochladen"
+note = "Was das Uebergeben einer Datei an eine Website wirklich bedeutet - und woran Sie erkennen, ob es noetig war."
+
+#
+# ---------------------------------------------------------------------------
+# The roadmap.
+#
+# Only the frame. The list itself is config/planned.toml, which has no locale
+# file yet and is therefore still English on this page - one of the two reasons
+# `complete` is false at the top of this file.
+# ---------------------------------------------------------------------------
+#
+
+[roadmap]
+nav = "Roadmap"
+title = "Roadmap &mdash; was abox.tools als Naechstes baut"
+description = "Jedes fuer abox.tools geplante Werkzeug, offen und gruppiert, dazu die bereits fertigen. Alle laufen im Browser und laden nichts hoch."
+heading = "Was als Naechstes kommt"
+lede = """
+    Alles auf beiden Listen erledigt seine Arbeit in Ihrem Browser und laedt
+    nichts hoch &mdash; das ist die Regel, die ein Name bestehen muss, bevor er
+    ueberhaupt hier landet. Die Zahlen sind nirgends eingetragen; der Build
+    zaehlt sie an den beiden Listen ab."""
+
+intro_heading = "Wie diese Liste entstanden ist"
+intro = """
+    <p>
+      Sie ist keine Wunschliste. Sie entstand, indem die Werkzeugliste der
+      groessten Online-GIF- und -Videoseite durchgegangen wurde &mdash; das
+      Naechste, was es zu einem Katalog dessen gibt, was Menschen tatsaechlich
+      mit einer Datei gemacht haben wollen &mdash; und jeder Eintrag behalten
+      wurde, der sich so bauen laesst, dass die Arbeit auf Ihrem eigenen Geraet
+      stattfindet und auch ohne Netzverbindung weiterlaeuft.
+    </p>
+    <p>
+      Das meiste davon laeuft mit Schnittstellen, die der Browser ohnehin
+      mitbringt. Einige wenige brauchen einen Codec, der in genau das Werkzeug
+      eingebettet wird, das ihn benutzt &mdash; das ist erlaubt, die Datei
+      verlaesst das Geraet trotzdem nicht. Was diese Huerde nicht nimmt, wurde
+      weggelassen statt versprochen; einige der offensichtlich wirkenden
+      Luecken unten sind also Absicht.
+    </p>
+    <p>
+      Die bereits vorhandenen Werkzeuge stehen oben in ihrer Gruppe, als
+      <em>Fertig</em> markiert und mit ihrer eigenen Seite verlinkt. Alles
+      darunter steht noch aus, und nichts wird zu einem Link, bevor es das ist.
+    </p>"""
+
+planned_heading = "Jede Art von Datei, und was sich damit machen laesst"
+
+og_title = "abox.tools Roadmap"
+og_description = "Was fertig ist und was als Naechstes kommt. Alles laeuft im Browser und laedt nichts hoch."
+og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"
+
+#
+# ---------------------------------------------------------------------------
+# The 404.
+#
+# Built in English only - GitHub Pages serves one file for the whole domain and
+# cannot know which language was being looked for - so nothing here is used
+# today. It is translated anyway, because the day that changes should not also
+# be the day somebody has to find this file.
+# ---------------------------------------------------------------------------
+#
+
+[not_found]
+title = "Seite nicht gefunden &mdash; abox.tools"
+description = "Diese Adresse gibt es auf abox.tools nicht. Hier sind die Werkzeuge, die es gibt - alle kostenlos, und keines laedt Ihre Dateien irgendwohin."
+heading = "Diese Seite ist nicht hier"
+tools_heading = "Alle Werkzeuge auf einen Blick"
+tools_note = "Alle kostenlos, alle im Browser, keines laedt irgendetwas hoch."
+
+lede = """
+    Entweder hat die Adresse einen Tippfehler, oder was dort einmal lag, ist
+    umgezogen. Mit Ihrer Datei ist nichts passiert und nichts ist verloren:
+    Diese Seite hatte noch nie etwas von Ihnen, das sie verlieren koennte."""
+
+#
+# ---------------------------------------------------------------------------
+# The footer.
+# ---------------------------------------------------------------------------
+#
+
+[footer]
+blurb = """
+        Werkzeuge, die keinen Server anfassen. Ihre Dateien bleiben auf Ihrem
+        Geraet &mdash; nichts hochzuladen, kein Konto anzulegen."""
+base = "Jede Behauptung auf dieser Seite ist zum Nachpruefen gedacht, nicht zum Glauben."
+
+#
+# ---------------------------------------------------------------------------
+# The frame's own words.
+#
+# Everything with {{ }} in it is a name the build resolves, and the build
+# refuses to render a name it cannot find - so these may be moved anywhere in
+# the sentence, and may not be renamed. German puts the verb at the end far more
+# often than English does, which is exactly why they are whole sentences here
+# rather than fragments glued either side of a value.
+# ---------------------------------------------------------------------------
+#
+
+[ui]
+languages = "Sprache"
+breadcrumb = "Brotkrumennavigation"
+all_tools = "Alle Werkzeuge"
+last_updated = "Zuletzt aktualisiert"
+built_tag = "Fertig"
+planned_count = "geplant"
+built_count = "fertig"
+
+guide_one = "Ratgeber"
+guide_many = "Ratgeber"
+
+footer_tools = "Werkzeuge"
+footer_site = "Diese Seite"
+footer_contact = "Kontakt"
+footer_sitemap = "Sitemap"
+footer_source = "Den Quellcode auf GitHub lesen"
+
+guarantees_note = """
+    Nichts davon muessen Sie uns glauben.
+    <a href="{{ base }}{{ links.safety_guide }}/">
+      Woran Sie erkennen, ob ein Werkzeug Ihre Dateien wirklich braucht</a>
+    nennt vier Pruefungen, die Sie selbst durchfuehren koennen &mdash; auf
+    dieser Seite oder auf jeder anderen."""
+
+hub_guides_note = """
+    Unsicher, welche Einstellung Sie bewegen sollen oder was sie kostet?
+    <a href="{{ base }}{{ links.guides }}/">Zu jedem Werkzeug gibt es einen
+    Ratgeber</a>."""
+
+hub_roadmap_note = """
+    Es kommt noch mehr, und die Liste ist oeffentlich:
+    <a href="{{ base }}{{ links.roadmap }}/">ansehen, was geplant ist</a>."""
+
+guides_all_note = """
+    Jeder Ratgeber hier beschreibt ein Werkzeug, das auf Ihrem eigenen Geraet
+    laeuft: <a href="{{ base }}">alle ansehen</a>."""
+
+[ui.tool]
+view_source = "Quellcode ansehen"
+how_verified = "Wie das nachpruefbar ist"
+live_check = "Live-Pruefung:"
+offline = "Offline:"
+checking = "wird geprueft&hellip;"
+questions_heading = "Fragen"
+guide_heading = "Die ausfuehrliche Fassung"
+privacy_heading = "Wie sich der Datenschutz nachpruefen laesst"
+
+# Das Substantiv steht mitten im Satz, und das Verb am Ende - genau der Grund,
+# warum dieser Satz als Ganzes uebersetzt wird und nicht in zwei Haelften.
+pledge_line = """
+    Ihre {{ tool.words.plural }} werden <strong>nie hochgeladen</strong>. Es gibt keinen Server."""
+
+boot_title = "Der Code dieser Seite ist nicht gestartet."
+boot_body = """
+    Wird <code>index.html</code> direkt aus einem Ordner geoeffnet, blockiert der Browser
+    JavaScript-Module, und beim Auswaehlen von {{ tool.words.choose }} passiert nichts. Geben Sie den Ordner
+    stattdessen ueber http aus:"""
+boot_then = "Oeffnen Sie dann <code>http://localhost:8080/</code>."
+
+noscript_title = "JavaScript ist deaktiviert."
+noscript_body = "Diese Anwendung erledigt ihre gesamte Arbeit in Ihrem Browser und kann ohne JavaScript nicht laufen."
+
+check_yourself = """
+      <strong>Pruefen Sie es selbst.</strong> Nichts davon muessen Sie uns glauben.
+      Diese Seite wird aus den Vorlagen und der Konfiguration im Repository von einem
+      Build-Skript erzeugt, das Sie lesen und selbst ausfuehren koennen, und das
+      Ergebnis liegt im Branch <code>dist</code> &mdash; Sie koennen also
+      vergleichen, was ausgeliefert wird, mit dem, was ein Build der Quellen
+      hervorbringt:"""
+
+read_first_lead = """
+      Zuerst lesenswert sind <code>config/site.toml</code> fuer die
+      Content-Security-Policy"""
+
+[ui.guide]
+open_tool = "{{ tool.name | e }} oeffnen"
+
+[ui.picker]
+warning = """
+      <strong>Dies ist die einzige Funktion, die das Netz beruehrt.</strong>
+      Beim Abrufen einer Adresse erfaehrt der dortige Server Ihre IP-Adresse und welches {{ tool.picker.urls.noun }} Sie
+      angefordert haben. Das {{ tool.picker.urls.noun }} wird beim Eintreffen in den lokalen Speicher kopiert und nie
+      erneut angefordert. Von Ihnen geht nie etwas hinaus &mdash; diese Seite kann
+      nach wie vor keinerlei Upload durchfuehren."""
+label = "Eine Adresse pro Zeile"
+note = """
+      Der Server muss die herkunftsuebergreifende Nutzung seiner {{ tool.picker.urls.noun }} erlauben. Viele Seiten tun
+      das nicht, und die scheitern dann mit einer Meldung, statt spaeter still zu versagen."""

--- a/locales/de/tools/compress-image.toml
+++ b/locales/de/tools/compress-image.toml
@@ -1,0 +1,254 @@
+#
+# Bildkompressor - German.
+#
+# Overrides for tools/compress-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Bildkompressor"
+# Der Zusatz ist der Ausdruck, nach dem gesucht wird. Wie im Englischen bleibt
+# der Produktname die laute Haelfte.
+heading = "Bild&nbsp;komprimieren <span class=\"h1-kw\">&mdash; auf eine exakte Groesse</span>"
+tagline = "Sie nennen die Groesse. Den Rest rechnet es aus."
+
+title = "Bild auf exakte Groesse komprimieren &mdash; kostenlos, ohne Upload"
+description = "JPEG, PNG oder WebP auf eine exakte Groesse komprimieren - 100 KB, 2 MB, beliebig. Laeuft komplett im Browser: kein Upload, kein Konto, auch offline."
+og_title = "Ein Bild auf eine Groesse Ihrer Wahl komprimieren"
+og_description = "Nennen Sie eine Zielgroesse; dieses Werkzeug findet die geringste Kompression, die sie erreicht, und misst, was das gekostet hat. Laeuft auf Ihrem Geraet, nichts wird hochgeladen."
+og_image_alt = "Bildkompressor - Groesse nennen, Qualitaet behalten"
+
+pledge = """
+    Die Kompression laeuft in Ihrem eigenen Browser, auf Ihrer eigenen Hardware,
+    mit den Encodern, die er ohnehin mitbringt. Dieses Werkzeug hat keinerlei
+    Netzfunktion &mdash; nichts abzurufen, nichts zu senden &mdash; und es gibt
+    am anderen Ende dieser Seite keinen Server, an den ein Bild ginge, selbst
+    wenn es einen Weg dorthin gaebe."""
+
+live_hint = """
+      Glauben Sie es uns nicht: Oeffnen Sie die DevTools, beobachten Sie den
+      Tab &bdquo;Netzwerk&ldquo; und komprimieren Sie ein Foto. Keine einzige
+      Anfrage traegt ein Bild, ein Vorschaubild, einen Dateinamen oder ein Byte
+      Ihrer Auswahl. Oder trennen Sie die Internetverbindung und komprimieren
+      Sie trotzdem eines."""
+
+read_first = """
+, <code>src/compress.js</code> fuer die Suche, die
+      entscheidet, wie viel Qualitaet ausgegeben wird, und
+      <code>src/measure.js</code> fuer den Vergleich hinter dem Wert
+      &bdquo;visuelle Uebereinstimmung&ldquo;."""
+
+howto_heading = "Ein Bild auf eine bestimmte Groesse komprimieren"
+
+card = """
+            Nennen Sie die Groesse, die Sie brauchen &mdash; 100 KB, 2 MB,
+            beliebig &mdash; und es findet die geringste Kompression, die
+            dorthin kommt."""
+
+[words]
+plural = "Bilder"
+choose = "ein Bild"
+analytics_extra = """, und auch keine der
+  Groessen oder Qualitaetswerte, die dieses Werkzeug ermittelt"""
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Kein Groessenlimit"
+
+[[facts]]
+text = "Funktioniert offline"
+
+[[facts]]
+text = "Quelloffen"
+
+[[privacy]]
+title = "Ihre Bilder haben keinen Weg nach draussen."
+body = """
+ Die
+      Content-Security-Policy nennt jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehoert zu dieser Seite. Es gibt hier keinen
+      Endpunkt, an dem Ihre Dateien gesammelt werden koennten, und nichts im
+      Code, das sie senden wuerde, gaebe es einen."""
+
+[[privacy]]
+title = "Nichts hier ruft etwas ab."
+body = """
+ Es gibt weder
+      <code>fetch</code> noch <code>XMLHttpRequest</code> noch
+      <code>sendBeacon</code> irgendwo in <code>src/</code>. Die Kompression ist
+      <code>canvas.toBlob</code> &mdash; der Encoder, der in Ihrem Browser
+      bereits installiert ist."""
+
+[[privacy]]
+title = "Die Zahlen werden gemessen, nicht gemeldet."
+body = """
+ Die Groessen, der
+      Qualitaetswert und der SSIM-Vergleich werden alle auf dieser Seite
+      berechnet und Ihnen angezeigt. Es gibt in diesem Repository kein eigenes
+      Analytics-Ereignis, das einen Dateinamen, eine Groesse, eine Anzahl oder
+      ein Ergebnis mitfuehrt."""
+
+[[privacy]]
+title = "Was Google laedt - und was es nicht bekommt."
+body = """
+ Die Werbe- und
+      Messskripte kommen von Google, der Spenden-Button von Buy Me a Coffee.
+      Keinem davon wird irgendetwas ueber Ihre Bilder uebergeben. Jede Zeile,
+      die eine Datei liest, komprimiert oder misst, wird von dieser Herkunft
+      ausgeliefert und ist im Repository aufgefuehrt."""
+
+[[privacy]]
+title = "Es funktioniert offline."
+body = """
+ Trennen Sie die Netzverbindung, und das
+      Werkzeug bleibt unveraendert, weil es nie einen Netzschritt darin gab. Das
+      ist der einfachste Beweis von allen."""
+
+[[howto]]
+title = "Waehlen Sie Ihre Bilder."
+body = """
+ Ziehen Sie sie auf das Auswahlfeld
+      oder waehlen Sie sie von Hand. Der Browser liest sie direkt von Ihrer
+      Festplatte; dabei wird nichts irgendwohin gesendet."""
+
+[[howto]]
+title = "Tippen Sie die geforderte Groesse ein."
+body = """
+ 100 KB fuer das
+      Upload-Formular, das Ihr Foto immer wieder ablehnt, 500 KB fuer das
+      Bewerbungsportal, 2 MB fuer eine Seite, die schnell laden muss. Die vier
+      haeufigsten sind Schaltflaechen."""
+
+[[howto]]
+title = "Klicken Sie auf &bdquo;Auf Zielgroesse komprimieren&ldquo;."
+body = """
+ Jedes Bild wird
+      mehrfach kodiert, waehrend das Werkzeug sich an die hoechste Qualitaet
+      herantastet, die noch hineinpasst. Was bereits unter der Zielgroesse
+      liegt, bleibt genau so, wie es ist."""
+
+[[howto]]
+title = "Pruefen Sie, was es gekostet hat, und laden Sie herunter."
+body = """
+ Jedes Ergebnis
+      nennt das Format, in dem es geschrieben wurde, die Qualitaet, ob sich die
+      Abmessungen geaendert haben und wie genau es dem Original entspricht.
+      &bdquo;Vergleichen&ldquo; stellt beide Bilder nebeneinander."""
+
+[[faq]]
+q = "Wird mein Bild irgendwohin hochgeladen?"
+a = """
+        Nein. Die Datei wird von Ihrem eigenen Browser auf Ihrer eigenen Hardware
+        dekodiert, komprimiert und gemessen &mdash; mit den JPEG-, PNG- und
+        WebP-Encodern, die der Browser bereits mitbringt. Dieses Werkzeug hat
+        keinerlei Netzfunktion &mdash; es ruft nie etwas ab und sendet nie etwas
+        &mdash; und die <code>Content-Security-Policy</code> der Seite nennt jede
+        Adresse, die sie kontaktieren darf; keine davon gehoert zu dieser Seite."""
+
+[[faq]]
+q = "Wie trifft es eine exakte Groesse?"
+a = """
+        Durch Ausprobieren. Es gibt keine Formel, die eine Qualitaetseinstellung in
+        eine Byte-Zahl umrechnet &mdash; das haengt vollstaendig vom Bild ab &mdash;
+        also kodiert das Werkzeug das Bild mehrfach und sucht die Antwort. Es
+        beginnt am oberen Ende des Qualitaetsbereichs und halbiert sich heran, was
+        die hoechste passende Qualitaet in etwa acht Durchgaengen findet. Jede
+        Groesse, die Sie auf der Seite sehen, ist eine echte kodierte Datei, keine
+        Schaetzung."""
+
+[[faq]]
+q = "Was heisst hier eigentlich &bdquo;minimaler Verlust&ldquo;?"
+a = """
+        Drei konkrete Dinge. Erstens wird ein Bild, das bereits unter Ihrer
+        Zielgroesse liegt, Byte fuer Byte durchgereicht statt neu kodiert. Zweitens
+        wird Qualitaet vor Aufloesung ausgegeben, und nur bis zu einer Untergrenze,
+        ab der Kompressionsartefakte sichtbar werden &mdash; darunter verkleinert
+        das Werkzeug das Bild und dreht die Qualitaet wieder hoch, denn weniger gute
+        Pixel sehen besser aus als mehr ruinierte. Drittens tastet sich die Suche,
+        sobald ein passendes Ergebnis gefunden ist, wieder nach oben, bis das Budget
+        aufgebraucht ist &mdash; Sie bekommen also keine 300-KB-Datei, wenn Sie
+        500 KB verlangt haben."""
+
+[[faq]]
+q = "Was sind die SSIM- und PSNR-Werte an jedem Ergebnis?"
+a = """
+        Sie messen, was die Kompression gekostet hat: Das Ergebnis wird dekodiert
+        und mit dem Originalbild verglichen. SSIM vergleicht lokale Helligkeit,
+        Kontrast und Struktur, was dem, woran sich ein Auge stoert, deutlich naeher
+        kommt als das Zaehlen veraenderter Pixel; ab etwa 0,98 sind beide
+        nebeneinander kaum zu unterscheiden. PSNR ist der klassische Dezibelwert.
+        Beide werden auf Ihrem Geraet berechnet, und beide werden angezeigt, damit
+        die Behauptung geringen Verlusts nachpruefbar ist statt nur behauptet."""
+
+[[faq]]
+q = "Welche Formate kann es lesen und schreiben?"
+a = """
+        Es liest alles, was Ihr Browser dekodieren kann, in der Praxis also JPEG,
+        PNG, WebP, GIF, BMP und &mdash; in den meisten aktuellen Browsern &mdash;
+        AVIF. Es schreibt JPEG, PNG und WebP, weil das die Encoder sind, die
+        Browser mitbringen. Auf &bdquo;automatisch&ldquo; behaelt es das Format
+        bei, in dem Ihre Datei ankam, und wechselt nur dann zu WebP, wenn das
+        Beibehalten eine Verkleinerung oder einen sichtbaren Qualitaetsverlust
+        bedeutet haette."""
+
+[[faq]]
+q = "Warum laesst sich ein PNG nicht weit komprimieren?"
+a = """
+        Weil PNG verlustfrei ist: Es hat keinen Qualitaetsregler zum Drehen. Ein
+        PNG kleiner zu machen geht nur ueber weniger Pixel oder weniger Farben, und
+        mit ausgewaehltem PNG erreicht das Werkzeug eine Zielgroesse deshalb allein
+        ueber die Groessenaenderung. Ist das Bild eine Fotografie, kommt JPEG oder
+        WebP Ihrer Zielgroesse in einer sichtbar unbedenklichen Qualitaet weit
+        naeher &mdash; und ist es ein Logo oder ein Screenshot mit Transparenz,
+        behaelt WebP die Transparenz, die JPEG mit Weiss auffuellen wuerde."""
+
+[[faq]]
+q = "Entfernt das Komprimieren die EXIF- und GPS-Daten eines Bildes?"
+a = """
+        Ja, als Nebenwirkung. Komprimieren heisst, das Bild zu Pixeln zu dekodieren
+        und diese Pixel erneut zu kodieren, und eine Leinwand voller Pixel traegt
+        keine Tags &mdash; Ort, Kameramodell, Zeitstempel und alles Weitere werden
+        also schlicht nicht in die neue Datei geschrieben. Sollen die Metadaten weg,
+        das Bild aber unangetastet bleiben, nehmen Sie stattdessen den
+        <a href="../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>
+        &mdash; er schreibt den Container neu, ohne irgendetwas neu zu
+        komprimieren."""
+
+[[faq]]
+q = "Ist es kostenlos, und brauche ich ein Konto?"
+a = """
+        Es ist kostenlos, und es gibt kein Konto, keine Anmeldung, keine Testphase
+        und kein Wasserzeichen. Es gibt auch keine Grenze fuer Anzahl oder Groesse
+        der Dateien, weil es keinen Server gibt, der dafuer zahlt &mdash; die
+        Arbeit passiert auf Ihrem eigenen Geraet. Die Seite traegt Werbung, und die
+        bezahlt sie; den Anzeigen wird nichts ueber Ihre Bilder uebergeben."""
+
+[[faq]]
+q = "Funktioniert es offline?"
+a = """
+        Ja. Laden Sie die Seite einmal, trennen Sie dann die Internetverbindung, und
+        sie arbeitet weiter. Das ist zugleich der einfachste Beweis dafuer, dass
+        nichts hochgeladen wird: Ein Werkzeug, das Ihre Bilder zum Komprimieren
+        wegschickt, wuerde in dem Moment stehen bleiben, in dem Sie den Stecker
+        ziehen."""
+
+[schema]
+description = "JPEG-, PNG- und WebP-Bilder auf eine von Ihnen genannte Groesse komprimieren. Das Werkzeug sucht die hoechste Qualitaet, die in die Zielgroesse passt, verkleinert nur dann, wenn Qualitaet allein nicht reicht, und misst das Ergebnis gegen das Original. Laeuft vollstaendig im Browser, ohne Upload."
+features = [
+  "Komprimiert auf eine Zieldateigroesse Ihrer Wahl statt auf eine zu erratende Qualitaetszahl",
+  "Behaelt die volle Aufloesung, wo es geht, und verkleinert nur, wenn Qualitaet allein die Zielgroesse nicht erreicht",
+  "Nutzt das Budget aus: Das Ergebnis landet knapp unter der Zielgroesse statt weit darunter",
+  "Misst das Ergebnis mit SSIM und PSNR gegen das Original",
+  "Laesst Dateien, die bereits unter der Zielgroesse liegen, vollstaendig unangetastet",
+  "JPEG, PNG und WebP, mit automatischer Formatwahl",
+  "Stapelverarbeitung, alle Ergebnisse in einem ZIP",
+  "Laeuft offline; kein Upload, kein Konto",
+]
+
+[picker]
+title = "Bilder hierher ziehen"
+hint = "oder klicken zum Auswaehlen &mdash; JPEG, PNG, WebP und alles andere, was Ihr Browser oeffnen kann"

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -640,6 +640,42 @@ footer a:hover { text-decoration: underline; }
   text-align: center;
 }
 
+/* The language switcher, across the foot of the page above the closing line.
+
+   A row of plain links and nothing else: no JavaScript, no cookie, no
+   redirect. A site whose whole claim is that it does not track you cannot be
+   storing a preference in order to do it, and a crawler has to be able to walk
+   from one language into the next on foot.
+
+   It sits below the columns rather than inside one because it is not a fifth
+   category of link - it is the same page again, in another language, and a
+   reader scanning for their own is scanning a single line rather than hunting
+   a column. It renders at all only once a second language is finished; see
+   templates/partials/languages.html. */
+.lang-switch {
+  margin: 1.5rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.lang-switch ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  justify-content: center;
+  font-size: 0.8rem;
+}
+
+/* The language being read is not a link. Marked by weight and colour rather
+   than by being removed, so the row does not reflow as you move through it. */
+.lang-current {
+  font-weight: 600;
+  color: var(--text);
+}
+
 /* The way back to the hub, with the site mark on it. It heads the brand column
    now rather than sitting inline in a sentence, so it is a flex row and carries
    its own weight and colour. */

--- a/shared/site.css
+++ b/shared/site.css
@@ -524,6 +524,42 @@ footer a:hover { text-decoration: underline; }
   text-align: center;
 }
 
+/* The language switcher, across the foot of the page above the closing line.
+
+   A row of plain links and nothing else: no JavaScript, no cookie, no
+   redirect. A site whose whole claim is that it does not track you cannot be
+   storing a preference in order to do it, and a crawler has to be able to walk
+   from one language into the next on foot.
+
+   It sits below the columns rather than inside one because it is not a fifth
+   category of link - it is the same page again, in another language, and a
+   reader scanning for their own is scanning a single line rather than hunting
+   a column. It renders at all only once a second language is finished; see
+   templates/partials/languages.html. */
+.lang-switch {
+  margin: 1.5rem 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.lang-switch ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  justify-content: center;
+  font-size: 0.8rem;
+}
+
+/* The language being read is not a link. Marked by weight and colour rather
+   than by being removed, so the row does not reflow as you move through it. */
+.lang-current {
+  font-weight: 600;
+  color: var(--text);
+}
+
 /* The way back to the hub, with the site mark on it. It heads the brand column
    now rather than sitting inline in a sentence, so it is a flex row and carries
    its own weight and colour. */

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ site.lang }}">
+<html lang="{{ locale.hreflang }}"{% if locale.rtl %} dir="rtl"{% endif %}>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -84,7 +84,7 @@
     </div>
     <ul class="tool-grid">
 {% for tool in tools %}      <li>
-        <a class="tool-card" href="{{ base }}{{ tool.slug }}/">
+        <a class="tool-card" href="{{ base }}{{ tool.out_slug }}/">
           <span class="tool-icon" aria-hidden="true">{{ tool.icon }}</span>
           <span class="tool-name">{{ tool.name | e }}</span>
           <span class="tool-desc">

--- a/templates/guides.html
+++ b/templates/guides.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ site.lang }}">
+<html lang="{{ locale.hreflang }}"{% if locale.rtl %} dir="rtl"{% endif %}>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -24,7 +24,8 @@
 <title>{{ site.guides.title }}</title>
 <meta name="description" content="{{ site.guides.description }}">
 
-<link rel="canonical" href="{{ site.domain }}{{ site.guides.slug }}/">
+<link rel="canonical" href="{{ canonical }}">
+{% include "partials/alternates.html" %}
 
 <meta name="google-adsense-account" content="{{ site.adsense_client }}">
 
@@ -95,7 +96,7 @@
     </div>
     <ul class="guide-list">
 {% for guide in group.guides %}      <li>
-        <a class="guide-card" href="{{ base }}{{ guide.slug }}/">
+        <a class="guide-card" href="{{ base }}{{ guide.out_slug }}/">
           <span class="guide-name">{{ guide.heading }}</span>
           <span class="guide-desc">{{ guide.description }}</span>
         </a>
@@ -104,8 +105,7 @@
   </section>
 {% endfor %}
   <p class="page-note">
-    Every guide here describes a tool that runs on your own machine:
-    <a href="{{ base }}">see all of them</a>.
+{{ ui.guides_all_note }}
   </p>
 
 </main>

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ site.lang }}">
+<html lang="{{ locale.hreflang }}"{% if locale.rtl %} dir="rtl"{% endif %}>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -27,7 +27,8 @@
 <title>{{ site.hub.title }}</title>
 <meta name="description" content="{{ site.hub.description }}">
 
-<link rel="canonical" href="{{ site.domain }}">
+<link rel="canonical" href="{{ canonical }}">
+{% include "partials/alternates.html" %}
 
 <!--
   AdSense site verification. This is an inert tag - it loads nothing and runs
@@ -128,10 +129,7 @@
     including the checks that can be run against this site.
   -->
   <p class="guarantees-note">
-    None of that has to be taken on trust.
-    <a href="{{ base }}guides/is-it-safe-to-upload-files/">
-      How to tell whether a tool really needs your files</a>
-    sets out four checks you can run yourself, on this site or any other.
+{{ ui.guarantees_note }}
   </p>
 
   <!--
@@ -159,7 +157,7 @@
     </div>
     <ul class="tool-grid">
 {% for tool in category.tools %}      <li>
-        <a class="tool-card" href="{{ tool.slug }}/">
+        <a class="tool-card" href="{{ tool.out_slug }}/">
           <span class="tool-icon" aria-hidden="true">{{ tool.icon }}</span>
           <!-- `name` is the tool's plain-text name, the one that also goes into
                the structured data above, so it is escaped on the way in here. -->
@@ -179,8 +177,7 @@
     just read the cards above and is not sure which of them they want.
   -->
   <p class="page-note">
-    Not sure which setting to move, or what it costs?
-    <a href="{{ base }}{{ site.guides.slug }}/">There is a guide for every tool</a>.
+{{ ui.hub_guides_note }}
   </p>
 
   <!--
@@ -193,8 +190,7 @@
     config/planned.toml. This is the one line that points at it.
   -->
   <p class="page-note">
-    More is coming, and the list is public:
-    <a href="{{ base }}{{ site.roadmap.slug }}/">see what is planned next</a>.
+{{ ui.hub_roadmap_note }}
   </p>
 
 </main>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ site.lang }}">
+<html lang="{{ locale.hreflang }}"{% if locale.rtl %} dir="rtl"{% endif %}>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -31,6 +31,7 @@
 <meta name="description" content="{{ page.description }}">
 
 <link rel="canonical" href="{{ page.url }}">
+{% include "partials/alternates.html" %}
 
 <meta name="google-adsense-account" content="{{ site.adsense_client }}">
 
@@ -81,7 +82,7 @@
   markup is meant to describe what a visitor can see, so a page with nothing to
   show describes nothing.
 -->
-{% if crumbs %}<nav class="crumbs" aria-label="Breadcrumb">
+{% if crumbs %}<nav class="crumbs" aria-label="{{ ui.breadcrumb }}">
 {% for crumb in crumbs %}  <a href="{{ crumb.href }}">{{ crumb.name }}</a>
   <span aria-hidden="true">&rsaquo;</span>
 {% endfor %}  <span aria-current="page">{{ page.nav }}</span>
@@ -104,10 +105,10 @@
     written at all.
   -->
 {% if tool %}  <p class="guide-cta">
-    <a class="guide-cta-link" href="{{ base }}{{ tool.slug }}/">Open the {{ tool.name | e }}</a>
+    <a class="guide-cta-link" href="{{ base }}{{ tool.out_slug }}/">{{ ui.guide.open_tool }}</a>
     <span class="guide-cta-note">{{ tool.tagline }}</span>
   </p>
-{% endif %}  <p class="legal-date">Last updated {{ page.updated }}</p>
+{% endif %}  <p class="legal-date">{{ ui.last_updated }} {{ page.updated }}</p>
 </header>
 
 <!--

--- a/templates/partials/alternates.html
+++ b/templates/partials/alternates.html
@@ -1,0 +1,21 @@
+<!--
+  Every language this page is published in, this one included.
+
+  Google's rule for hreflang is that the set is reciprocal and self-inclusive:
+  a page lists every version of itself, its own among them, and each of those
+  pages lists the same set back. The list is built once, in buildlib/i18n.py,
+  and handed to every page from there - so reciprocity holds because there is
+  only one list, not because somebody checked.
+
+  x-default is English. It is what a reader whose language is none of these is
+  meant to be given, and it is the last entry rather than the first because it
+  is a fallback rather than a language.
+
+  A locale that is still being translated appears here in no form at all. It is
+  built, and readable at its own URL, and until its locale.toml says
+  complete = true it is not advertised to anybody - inviting a crawler to index
+  a half-translated page is how a site ends up with the untranslated half
+  ranking for the wrong language.
+-->
+{% for alt in alternates %}<link rel="alternate" hreflang="{{ alt.hreflang }}" href="{{ alt.href }}">
+{% endfor %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -27,7 +27,7 @@
     </div>
 
     <div class="footer-col">
-      <strong>Tools</strong>
+      <strong>{{ ui.footer_tools }}</strong>
       <ul>
 {% for t in footer.tools %}        <li><a href="{{ base }}{{ t.slug }}/">{{ t.name | e }}</a></li>
 {% endfor %}      </ul>
@@ -46,28 +46,30 @@
       thing - the front door to each half of the site.
     -->
     <div class="footer-col">
-      <strong>This site</strong>
+      <strong>{{ ui.footer_site }}</strong>
       <ul>
-        <li><a href="{{ base }}">All tools</a></li>
-        <li><a href="{{ base }}{{ site.guides.slug }}/">{{ site.guides.nav }}</a></li>
-        <li><a href="{{ base }}{{ site.roadmap.slug }}/">{{ site.roadmap.nav }}</a></li>
+        <li><a href="{{ base }}">{{ ui.all_tools }}</a></li>
+        <li><a href="{{ base }}{{ links.guides }}/">{{ site.guides.nav }}</a></li>
+        <li><a href="{{ base }}{{ links.roadmap }}/">{{ site.roadmap.nav }}</a></li>
 {% for p in footer.pages %}        <li><a href="{{ base }}{{ p.slug }}/">{{ p.nav }}</a></li>
-{% endfor %}        <li><a href="/sitemap.xml">Sitemap</a></li>
+{% endfor %}        <li><a href="/sitemap.xml">{{ ui.footer_sitemap }}</a></li>
       </ul>
     </div>
 
     <div class="footer-col">
-      <strong>Get in touch</strong>
+      <strong>{{ ui.footer_contact }}</strong>
       <ul>
         <li>
           <a href="{{ site.source_url }}" target="_blank" rel="noopener noreferrer">
-            Read the code on GitHub
+            {{ ui.footer_source }}
           </a>
         </li>
         <li><a href="mailto:{{ site.contact_email }}">{{ site.contact_email }}</a></li>
       </ul>
     </div>
   </div>
+
+{% include "partials/languages.html" %}
 
   <p class="footer-base">
 {{ site.footer.base }}

--- a/templates/partials/languages.html
+++ b/templates/partials/languages.html
@@ -1,0 +1,32 @@
+<!--
+  The language switcher.
+
+  Plain links, and that is the whole design. No JavaScript, no cookie, no
+  redirect and no guess made from Accept-Language: a site whose entire claim is
+  that it does not track you cannot be storing a preference in order to do it,
+  and a crawler has to be able to walk from one language into the next on foot.
+
+  Every link points at THIS page in that language, not at that language's front
+  door. Somebody reading about compressing an image who wants it in German wants
+  that page in German; dropping them on the hub to find it again is the
+  commonest way a switcher gets built wrong.
+
+  Each language is written in its own language - Deutsch, not German - because
+  that is the word a reader looking for it will be scanning for. `lang` and
+  `hreflang` are on every link so that a screen reader announces the name in the
+  language it belongs to rather than in the language of the page around it.
+
+  Root-absolute hrefs, unlike everything else in this footer. The slug in each
+  URL is itself localized, so there is no relative path from
+  /de/bild-komprimieren/ to /es/comprimir-imagen/ that could be worked out from
+  `base`.
+-->
+{% if languages %}<nav class="lang-switch" aria-label="{{ ui.languages }}">
+  <ul>
+{% for lang in languages %}    <li>
+{% if lang.current %}      <span class="lang-current" lang="{{ lang.hreflang }}" aria-current="true">{{ lang.endonym }}</span>
+{% else %}      <a href="{{ lang.href }}" lang="{{ lang.hreflang }}" hreflang="{{ lang.hreflang }}">{{ lang.endonym }}</a>
+{% endif %}    </li>
+{% endfor %}  </ul>
+</nav>
+{% endif %}

--- a/templates/partials/url-import.html
+++ b/templates/partials/url-import.html
@@ -12,13 +12,9 @@
   <summary>{{ tool.picker.urls.summary }}</summary>
   <div class="url-body">
     <p class="url-warning">
-      <strong>This is the one feature that touches the network.</strong>
-      Fetching an address tells that server your IP address and which {{ tool.picker.urls.noun }} you
-      asked for. The {{ tool.picker.urls.noun }} is copied to local memory on arrival and never
-      requested again. Nothing of yours is ever sent out &mdash; this page still
-      cannot make an upload of any kind.
+{{ ui.picker.warning }}
     </p>
-    <label for="url-input">One address per line</label>
+    <label for="url-input">{{ ui.picker.label }}</label>
     <textarea id="url-input" rows="3" spellcheck="false"
               placeholder="https://example.com/photo1.jpg&#10;https://example.com/photo2.jpg"></textarea>
     <div class="url-actions">
@@ -26,8 +22,7 @@
       <span id="url-status" class="url-status" role="status" aria-live="polite"></span>
     </div>
     <p class="url-note">
-      The server must permit cross-origin use of its {{ tool.picker.urls.noun }}s. Many sites do not,
-      and those will fail with a message rather than silently breaking later.
+{{ ui.picker.note }}
     </p>
   </div>
 </details>

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ site.lang }}">
+<html lang="{{ locale.hreflang }}"{% if locale.rtl %} dir="rtl"{% endif %}>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -27,7 +27,8 @@
 <title>{{ site.roadmap.title }}</title>
 <meta name="description" content="{{ site.roadmap.description }}">
 
-<link rel="canonical" href="{{ site.domain }}{{ site.roadmap.slug }}/">
+<link rel="canonical" href="{{ canonical }}">
+{% include "partials/alternates.html" %}
 
 <meta name="google-adsense-account" content="{{ site.adsense_client }}">
 
@@ -92,9 +93,9 @@
     ships and nobody remembers this page exists.
   -->
   <p class="page-count">
-    <strong>{{ planned_count }}</strong> planned
+    <strong>{{ planned_count }}</strong> {{ ui.planned_count }}
     &middot;
-    <strong>{{ built_count }}</strong> built
+    <strong>{{ built_count }}</strong> {{ ui.built_count }}
   </p>
 </header>
 
@@ -136,7 +137,7 @@
     <div class="plan-group">
       <h3>{{ group.name }}</h3>
       <ul class="plan-list">
-{% for tool in group.built %}        <li class="is-built"><a href="{{ base }}{{ tool.slug }}/">{{ tool.name | e }}</a> <span class="p-desc">&mdash; {{ tool.tagline }}</span> <span class="built-tag">Built</span></li>
+{% for tool in group.built %}        <li class="is-built"><a href="{{ base }}{{ tool.out_slug }}/">{{ tool.name | e }}</a> <span class="p-desc">&mdash; {{ tool.tagline }}</span> <span class="built-tag">{{ ui.built_tag }}</span></li>
 {% endfor %}{% for item in group.items %}        <li><span class="p-name">{{ item.name }}</span> <span class="p-desc">&mdash; {{ item.desc }}</span></li>
 {% endfor %}      </ul>
     </div>

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{{ site.lang }}">
+<html lang="{{ locale.hreflang }}"{% if locale.rtl %} dir="rtl"{% endif %}>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -41,6 +41,7 @@
 <meta name="description" content="{{ tool.description }}">
 
 <link rel="canonical" href="{{ tool.url }}">
+{% include "partials/alternates.html" %}
 
 <!--
   Share card. og-image.ps1 draws these, and the URLs have to be absolute -
@@ -95,19 +96,18 @@
   nothing at all happens when you choose {{ tool.words.choose }}.
 -->
 <div id="boot-warning" class="boot-warning">
-  <strong>This page's code did not start.</strong>
+  <strong>{{ ui.tool.boot_title }}</strong>
   <p>
-    Opening <code>index.html</code> directly from a folder blocks JavaScript modules,
-    so nothing will happen when you choose {{ tool.words.choose }}. Serve the folder over http instead:
+{{ ui.tool.boot_body }}
   </p>
   <pre>powershell -ExecutionPolicy Bypass -File serve.ps1</pre>
-  <p>Then open <code>http://localhost:8080/</code>.</p>
+  <p>{{ ui.tool.boot_then }}</p>
 </div>
 
 <noscript>
   <div class="boot-warning">
-    <strong>JavaScript is disabled.</strong>
-    <p>This app does all of its work in your browser, so it cannot run without it.</p>
+    <strong>{{ ui.tool.noscript_title }}</strong>
+    <p>{{ ui.tool.noscript_body }}</p>
   </div>
 </noscript>
 
@@ -128,8 +128,8 @@
   "EXIF Viewer & Remover" carries a bare ampersand - unlike `tool.heading`,
   which is written as markup in tool.toml.
 -->
-<nav class="crumbs" aria-label="Breadcrumb">
-  <a href="../">All tools</a>
+<nav class="crumbs" aria-label="{{ ui.breadcrumb }}">
+  <a href="../">{{ ui.all_tools }}</a>
   <span aria-hidden="true">&rsaquo;</span>
   <span aria-current="page">{{ tool.name | e }}</span>
 </nav>
@@ -153,10 +153,10 @@
           .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65
           3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
       </svg>
-      View source
+      {{ ui.tool.view_source }}
     </a>
     <button type="button" id="privacy-toggle" class="ghost" aria-expanded="false" aria-controls="privacy-panel">
-      How this is verified
+      {{ ui.tool.how_verified }}
     </button>
     <div class="support-cta">
       {% include "partials/bmc.html" %}
@@ -173,7 +173,7 @@
 <section class="pledge">
   <p class="pledge-line">
     <span class="pledge-mark" aria-hidden="true">&#9679;</span>
-    Your {{ tool.words.plural }} are <strong>never uploaded</strong>. There is no server.
+{{ ui.tool.pledge_line }}
   </p>
   <p class="pledge-sub">
 {{ tool.pledge }}
@@ -188,11 +188,11 @@
   <div class="pledge-live">
     <p class="live-row">
       <span id="network-dot" class="live-dot" aria-hidden="true"></span>
-      <span><strong>Live check:</strong> <span id="network-count">checking&hellip;</span></span>
+      <span><strong>{{ ui.tool.live_check }}</strong> <span id="network-count">{{ ui.tool.checking }}</span></span>
     </p>
     <p class="live-row">
       <span id="offline-dot" class="live-dot" aria-hidden="true"></span>
-      <span><strong>Offline:</strong> <span id="offline-status">checking&hellip;</span></span>
+      <span><strong>{{ ui.tool.offline }}</strong> <span id="offline-status">{{ ui.tool.checking }}</span></span>
     </p>
     <p class="live-hint">
 {{ tool.live_hint }}
@@ -201,17 +201,13 @@
 </section>
 
 <section id="privacy-panel" class="privacy" hidden>
-  <h2>How the privacy claim is verifiable</h2>
+  <h2>{{ ui.tool.privacy_heading }}</h2>
   <ul>
 {% for point in tool.privacy %}    <li><strong>{{ point.title }}</strong>{{ point.body }}</li>
 {% endfor %}  </ul>
   <div class="privacy-status">
     <p>
-      <strong>Check it yourself.</strong> None of the above has to be taken on trust.
-      This page is generated from the templates and config in the repository by a
-      build script you can read and run yourself, and the result is committed to
-      the <code>dist</code> branch &mdash; so you can diff what is served against
-      what a build of the sources produces:
+{{ ui.tool.check_yourself }}
     </p>
     <p>
       <a href="{{ site.source_url }}" target="_blank" rel="noopener noreferrer">
@@ -219,8 +215,7 @@
       </a>
     </p>
     <p>
-      The files worth reading first are <code>config/site.toml</code> for the
-      Content-Security-Policy{{ tool.read_first }}
+{{ ui.tool.read_first_lead }}{{ tool.read_first }}
     </p>
   </div>
 </section>
@@ -249,7 +244,7 @@
     </li>
 {% endfor %}  </ol>
 
-  <h2 id="faq-h">Questions</h2>
+  <h2 id="faq-h">{{ ui.tool.questions_heading }}</h2>
   <div class="faq-list">
 {% for entry in tool.faq %}    <details>
       <summary>{{ entry.q }}</summary>
@@ -271,7 +266,7 @@
     page.toml - and the build turns it into both halves of the link, this one
     and the one back. A tool with no guide yet renders nothing here.
   -->
-{% if guide %}  <h2 id="guide-h">The longer version</h2>
+{% if guide %}  <h2 id="guide-h">{{ ui.tool.guide_heading }}</h2>
   <p class="tool-guide">
     <a href="{{ base }}{{ guide.slug }}/">{{ guide.heading }}</a>
     <span class="tool-guide-note">{{ guide.description }}</span>

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -238,9 +238,21 @@ class BuildTheSite(unittest.TestCase):
         cls.out = Path(cls.tmp.name) / 'dist'
         cls.written = buildmod.build(cls.out, clean=True, minify_output=False)
 
+        # Which languages are built but not yet advertised. Read off the locale
+        # files rather than written down here, so adding a language - or
+        # finishing one - does not also mean remembering to edit a test.
+        site = buildmod.sitelib.load_toml(ROOT / 'config' / 'site.toml')
+        cls.locales = buildmod.i18n.load_locales(ROOT / 'locales', site)
+        cls.unfinished = [locale['lang'] for locale in cls.locales
+                          if not locale['is_base'] and not locale['complete']]
+
     @classmethod
     def tearDownClass(cls):
         cls.tmp.cleanup()
+
+    def unpublished(self, name):
+        """Whether a written page belongs to a language that is not finished."""
+        return any(name.startswith(f'{lang}/') for lang in self.unfinished)
 
     def test_it_reports_what_it_wrote(self):
         self.assertIn('index.html', self.written)
@@ -294,15 +306,56 @@ class BuildTheSite(unittest.TestCase):
                 self.assertNotIn('{{', text)
                 self.assertNotIn('{%', text)
 
-    def test_the_sitemap_lists_every_page(self):
+    def test_the_sitemap_lists_every_page_of_a_published_language(self):
+        """Every page that is offered to a reader is offered to a crawler.
+
+        Published, not built. A locale whose locale.toml says complete = false
+        is built - so it can be read and reviewed at a real address - and is
+        kept out of the sitemap until it is finished. The companion test below
+        checks the other half of that, which is the half that matters: nothing
+        half-translated is ever advertised.
+        """
         sitemap = (self.out / 'sitemap.xml').read_text(encoding='utf-8')
         site = buildmod.sitelib.load_toml(ROOT / 'config' / 'site.toml')
         for name in self.written:
-            if not name.endswith('index.html'):
+            if not name.endswith('index.html') or self.unpublished(name):
                 continue
             slug = name[:-len('index.html')]
             with self.subTest(page=slug or '/'):
                 self.assertIn(f'{site["domain"]}{slug}', sitemap)
+
+    def test_an_unfinished_language_is_not_in_the_sitemap(self):
+        """The point of `complete = false`.
+
+        A half-translated page invited into an index is how a site ends up
+        ranking its untranslated half for the wrong language, and the damage
+        outlasts the fix. So the sitemap, the hreflang tags and the language
+        switcher are all built from one list of finished languages - see
+        i18n.published - and this checks the first of the three.
+        """
+        sitemap = (self.out / 'sitemap.xml').read_text(encoding='utf-8')
+        hidden = [name for name in self.written if self.unpublished(name)]
+        self.assertTrue(hidden, 'no unfinished locale in the tree to check')
+        for name in hidden:
+            with self.subTest(page=name):
+                self.assertNotIn(name[:-len('index.html')], sitemap)
+
+    def test_an_unfinished_language_is_never_offered(self):
+        """The other two of the three: no page anywhere points at it.
+
+        Checked over every page of every language, English included, because
+        reciprocity is the property that matters - one page still advertising a
+        language the rest of the site has withdrawn is exactly the state Search
+        Console reports and nobody can reproduce by looking at one file.
+        """
+        for locale in self.unfinished:
+            for name in self.written:
+                if not name.endswith('.html'):
+                    continue
+                with self.subTest(page=name, lang=locale):
+                    text = (self.out / name).read_text(encoding='utf-8')
+                    self.assertNotIn(f'hreflang="{locale}"', text)
+                    self.assertNotIn(f'href="/{locale}/"', text)
 
     def test_the_404_page_is_written(self):
         self.assertIn('404.html', self.written)
@@ -366,12 +419,34 @@ class BuildTheSite(unittest.TestCase):
     def test_every_page_footer_reaches_the_guides_index(self):
         # The footer is the second navigation, and the index is the one link in
         # it that keeps working however long the list of guides grows.
-        for name in self.written:
-            if not name.endswith('.html'):
-                continue
-            with self.subTest(page=name):
-                text = (self.out / name).read_text(encoding='utf-8')
-                self.assertRegex(text, r'href="(\.\./|\./|/)*guides/"')
+        #
+        # In its OWN language. The index a German page links to is
+        # /de/ratgeber/, not /guides/, and a footer that reached across into
+        # English would be the one link on the page that changed the language
+        # without saying so.
+        for locale in self.locales:
+            index = locale['slugs'].get('guides', 'guides')
+            wanted = re.compile(r'href="(\.\./|\./|/)*' + re.escape(index) + '/"')
+            for name in self.written:
+                if not name.endswith('.html') or not self.belongs(name, locale):
+                    continue
+                with self.subTest(page=name):
+                    self.assertRegex(
+                        (self.out / name).read_text(encoding='utf-8'), wanted)
+
+    def belongs(self, name, locale):
+        """Whether a written page is a page of this language.
+
+        The 404 is nobody's: it is served for the whole domain and is built in
+        English, so it is left out rather than counted against every language
+        in turn.
+        """
+        if name == '404.html':
+            return False
+        if locale['is_base']:
+            return not any(name.startswith(f'{other["lang"]}/')
+                           for other in self.locales if not other['is_base'])
+        return name.startswith(f'{locale["lang"]}/')
 
     def test_the_footer_links_the_index_rather_than_every_guide(self):
         """One link, not a column that grows by a line per guide.

--- a/tests/python/test_i18n.py
+++ b/tests/python/test_i18n.py
@@ -1,0 +1,292 @@
+"""
+What a locale may do, and what it may not.
+
+The rules being checked here are the ones that fail quietly if they are wrong.
+A locale that silently drops a key ships an English sentence inside a German
+page; a locale that renames a slug onto another page's address ships a sitemap
+advertising a URL that serves somebody else's content. Neither shows up in a
+build log, and both show up in Search Console a fortnight later.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from buildlib import i18n
+from buildlib.site import ConfigError
+
+SITE = {
+    'lang': 'en',
+    'domain': 'https://example.test/',
+    'guides': {'slug': 'guides', 'heading': 'Guides'},
+    'roadmap': {'slug': 'roadmap', 'nav': 'Roadmap'},
+    'ui': {
+        'all_tools': 'All tools',
+        # Named `tool` on purpose - see the regression test below.
+        'tool': {'questions': 'Questions'},
+    },
+}
+
+
+def locale(**over):
+    base = {
+        'lang': 'de', 'name': 'German', 'endonym': 'Deutsch', 'hreflang': 'de',
+        'dir': 'ltr', 'complete': False, 'is_base': False, 'prefix': 'de/',
+        'slugs': {}, 'site': SITE, 'tools': {}, 'pages': {}, 'bodies': {},
+        'missing': [],
+    }
+    base.update(over)
+    return base
+
+
+class Merging(unittest.TestCase):
+    def merge(self, base, over, missing=None):
+        return i18n.merge(base, over, 'test', missing if missing is not None else [],
+                          'x')
+
+    def test_a_translated_value_wins(self):
+        self.assertEqual(self.merge({'a': 'one'}, {'a': 'eins'}), {'a': 'eins'})
+
+    def test_an_untranslated_value_falls_back_and_is_recorded(self):
+        missing = []
+        merged = self.merge({'a': 'one', 'b': 'two'}, {'a': 'eins'}, missing)
+        self.assertEqual(merged, {'a': 'eins', 'b': 'two'})
+        self.assertEqual(missing, ['x.b'])
+
+    def test_an_empty_string_is_not_counted_as_missing(self):
+        """A key that is blank in English is blank in every language.
+
+        Counting it would leave a locale permanently short of complete over a
+        string no translator will ever be given anything to translate."""
+        missing = []
+        self.merge({'a': ''}, {}, missing)
+        self.assertEqual(missing, [])
+
+    def test_a_key_the_english_does_not_have_is_refused(self):
+        # A locale translates what is there. Inventing a key means inventing a
+        # value no template asks for, which is a typo far more often than it is
+        # a feature.
+        with self.assertRaises(ConfigError) as caught:
+            self.merge({'a': 'one'}, {'a': 'eins', 'b': 'zwei'})
+        self.assertIn('b', str(caught.exception))
+
+    def test_a_list_of_a_different_length_is_refused(self):
+        # Merged in order, so five questions against four is not a shorter
+        # translation - it is one question that will render in English with
+        # nothing on the page to say which.
+        with self.assertRaises(ConfigError) as caught:
+            self.merge({'faq': ['a', 'b', 'c']}, {'faq': ['a', 'b']})
+        self.assertIn('3', str(caught.exception))
+
+    def test_a_changed_type_is_refused(self):
+        with self.assertRaises(ConfigError):
+            self.merge({'a': 'one'}, {'a': {'nested': 'x'}})
+
+    def test_structure_survives_translation(self):
+        """A slug, an id and an order are what a thing IS, not what it is called.
+
+        A locale that could redefine them could move a page to an address
+        nothing links to, and would be doing it in the middle of a wall of
+        prose rather than in [slugs] where every address it changes can be read
+        at once."""
+        merged = self.merge(
+            {'slug': 'widget', 'id': 'images', 'order': ['a'], 'name': 'Widget'},
+            {'slug': 'dings', 'id': 'bilder', 'order': ['b'], 'name': 'Dings'})
+        self.assertEqual(merged['slug'], 'widget')
+        self.assertEqual(merged['id'], 'images')
+        self.assertEqual(merged['order'], ['a'])
+        self.assertEqual(merged['name'], 'Dings')
+
+    def test_the_ui_table_is_all_words_however_it_is_named(self):
+        """Regression: [ui.tool] was served in English on every translated page.
+
+        STRUCTURAL_KEYS is matched on the key name at any depth, and `tool` is
+        on it - it names the tool a guide is about in that guide's page.toml.
+        That made [ui.tool], which is the frame's words for a tool page, look
+        structural, so the pledge and the button labels stayed English while
+        the page around them came out in German.
+
+        Nothing under [ui] is ever structure. That is what [ui] is for.
+        """
+        merged = i18n.merge(SITE, {'ui': {'tool': {'questions': 'Fragen'}}},
+                            'test', [], 'site')
+        self.assertEqual(merged['ui']['tool']['questions'], 'Fragen')
+
+
+class Slugs(unittest.TestCase):
+    def test_renaming_something_that_does_not_exist_is_refused(self):
+        with self.assertRaises(ConfigError) as caught:
+            i18n.check_slugs(locale(slugs={'widgit': 'dings'}),
+                             ['widget'], [], SITE)
+        self.assertIn('widgit', str(caught.exception))
+
+    def test_two_pages_may_not_land_on_one_address(self):
+        # Silent otherwise: one page is written over the other, and the sitemap
+        # goes on advertising an address that now serves the wrong content.
+        with self.assertRaises(ConfigError) as caught:
+            i18n.check_slugs(
+                locale(slugs={'widget': 'dings', 'gadget': 'dings'}),
+                ['widget', 'gadget'], [], SITE)
+        self.assertIn('dings', str(caught.exception))
+
+    def test_a_localized_slug_may_collide_with_nothing_and_pass(self):
+        i18n.check_slugs(locale(slugs={'widget': 'dings'}), ['widget'], [], SITE)
+
+    def test_english_slugs_are_the_keys(self):
+        # Keyed by what the thing IS. Keyed the other way, a locale could not
+        # be read without already knowing its own answer.
+        i18n.check_slugs(locale(slugs={'guides': 'ratgeber'}), [], [], SITE)
+
+
+class Completeness(unittest.TestCase):
+    def test_an_unfinished_locale_may_fall_back(self):
+        i18n.check_complete(locale(complete=False, missing=['x.y']))
+
+    def test_a_finished_locale_may_not(self):
+        with self.assertRaises(ConfigError) as caught:
+            i18n.check_complete(locale(complete=True, missing=['hub.lede']))
+        message = str(caught.exception)
+        self.assertIn('hub.lede', message)
+        # The error has to say what to do about it, because the right answer is
+        # often "not yet" rather than "translate this now".
+        self.assertIn('complete = false', message)
+
+    def test_english_is_complete_by_definition(self):
+        i18n.check_complete({'is_base': True, 'complete': True, 'missing': ['x']})
+
+
+class Advertising(unittest.TestCase):
+    """What the sitemap, the hreflang tags and the switcher are built from.
+
+    All three come from i18n.published, so they cannot disagree about which
+    languages the site claims to have - which is the failure Google reports as
+    "hreflang points to a page that is not indexed"."""
+
+    def setUp(self):
+        self.english = i18n.base_locale(SITE)
+        self.german = locale(complete=True, slugs={'widget': 'dings'})
+        self.draft = locale(lang='fr', hreflang='fr', prefix='fr/', complete=False)
+
+    def test_one_language_advertises_nothing(self):
+        # A lone hreflang="en" beside an x-default pointing at the same URL
+        # says nothing the canonical above it has not already said.
+        self.assertEqual(i18n.alternates([self.english], 'widget', SITE), [])
+        self.assertEqual(
+            i18n.switcher([self.english], self.english, 'widget', SITE), [])
+
+    def test_two_languages_point_at_each_other_and_at_themselves(self):
+        found = i18n.alternates([self.english, self.german], 'widget', SITE)
+        self.assertEqual(
+            [(entry['hreflang'], entry['href']) for entry in found],
+            [('en', 'https://example.test/widget/'),
+             ('de', 'https://example.test/de/dings/'),
+             ('x-default', 'https://example.test/widget/')])
+
+    def test_an_unfinished_language_is_never_advertised(self):
+        locales = [self.english, self.german, self.draft]
+        langs = [entry['hreflang']
+                 for entry in i18n.alternates(locales, 'widget', SITE)]
+        self.assertNotIn('fr', langs)
+        self.assertNotIn('fr', [entry['lang'] for entry in
+                                i18n.switcher(locales, self.english, 'widget', SITE)])
+
+    def test_the_switcher_stays_on_the_same_page(self):
+        """Not on the front door of the other language.
+
+        Somebody reading about a widget who wants it in German wants that page
+        in German. Dropping them on the hub to find it again is the commonest
+        way a switcher gets built wrong."""
+        found = i18n.switcher([self.english, self.german], self.english,
+                              'widget', SITE)
+        self.assertEqual([entry['href'] for entry in found],
+                         ['/widget/', '/de/dings/'])
+        self.assertEqual([entry['current'] for entry in found], [True, False])
+
+
+class Addresses(unittest.TestCase):
+    def test_a_page_sits_one_step_deeper_under_a_prefix(self):
+        """The frame works out where the stylesheet and the hub are from
+        `depth` alone, so it has to count the language as a level."""
+        page = {'slug': 'guides/resize', 'kind': 'guide', 'nav': 'Resize'}
+        english = i18n.localize_page(page, i18n.base_locale(SITE), SITE)
+        german = i18n.localize_page(
+            page, locale(slugs={'guides/resize': 'ratgeber/skalieren'}), SITE)
+        self.assertEqual(english['depth'], 2)
+        self.assertEqual(german['depth'], 3)
+        self.assertEqual(german['url'],
+                         'https://example.test/de/ratgeber/skalieren/')
+
+    def test_the_english_slug_is_kept_alongside_the_translated_one(self):
+        """`slug` names the thing and `out_slug` is where it is served.
+
+        Mixing the two is the one bug this arrangement can still have: every
+        lookup - which category lists this tool, which guide is about it -
+        matches on the first, and only the address uses the second."""
+        page = {'slug': 'privacy', 'kind': 'legal', 'nav': 'Privacy'}
+        german = i18n.localize_page(page, locale(slugs={'privacy': 'datenschutz'}),
+                                    SITE)
+        self.assertEqual(german['slug'], 'privacy')
+        self.assertEqual(german['out_slug'], 'datenschutz')
+
+
+class LoadingALocale(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write(self, lang, text):
+        folder = self.root / lang
+        folder.mkdir(parents=True, exist_ok=True)
+        (folder / 'locale.toml').write_text(text, encoding='utf-8', newline='\n')
+
+    def test_english_is_first_and_is_not_a_folder(self):
+        """English is the sources, not a translation of itself.
+
+        The moment it becomes locales/en/ it is a copy free to drift from the
+        tool.toml it was made from, and the build loses the one text every
+        other language is measured against."""
+        found = i18n.load_locales(self.root, SITE)
+        self.assertEqual([entry['lang'] for entry in found], ['en'])
+        self.assertTrue(found[0]['is_base'])
+
+    def test_a_locale_folder_for_english_is_refused(self):
+        self.write('en', 'lang = "en"\nname = "English"\nendonym = "English"\n')
+        with self.assertRaises(ConfigError):
+            i18n.load_locales(self.root, SITE)
+
+    def test_the_folder_has_to_match_the_language(self):
+        self.write('de', 'lang = "fr"\nname = "French"\nendonym = "Francais"\n')
+        with self.assertRaises(ConfigError) as caught:
+            i18n.load_locales(self.root, SITE)
+        self.assertIn('folder', str(caught.exception))
+
+    def test_a_locale_may_not_restate_the_site(self):
+        # Words and slugs. Everything else about the site is decided once, in
+        # English, for every language - a locale that could set its own
+        # Content-Security-Policy would be a second site to keep in step.
+        self.write('de', 'lang = "de"\nname = "German"\nendonym = "Deutsch"\n'
+                         'domain = "https://evil.test/"\n')
+        with self.assertRaises(ConfigError) as caught:
+            i18n.load_locales(self.root, SITE)
+        self.assertIn('domain', str(caught.exception))
+
+    def test_hreflang_defaults_to_the_language_and_can_be_set(self):
+        # pt-BR is a language and a region, and hreflang is where that is said.
+        self.write('de', 'lang = "de"\nname = "German"\nendonym = "Deutsch"\n')
+        self.write('pt', 'lang = "pt"\nname = "Portuguese"\n'
+                         'endonym = "Portugues"\nhreflang = "pt-BR"\n')
+        found = {entry['lang']: entry['hreflang']
+                 for entry in i18n.load_locales(self.root, SITE)}
+        self.assertEqual(found['de'], 'de')
+        self.assertEqual(found['pt'], 'pt-BR')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python/test_site.py
+++ b/tests/python/test_site.py
@@ -20,7 +20,17 @@ from pathlib import Path
 
 from buildlib import site as sitelib
 
+# `home`, `guides_url` and `roadmap_url` are the absolute addresses the
+# structured data on a page is hung from. They are separate from `domain`
+# because they are the front door of one LANGUAGE rather than of the site:
+# under a locale they carry its prefix and its translated slugs, and a German
+# page whose WebSite node pointed at the English root would be telling a
+# crawler the two are one document. build.py fills them in per locale; a
+# fixture standing in for a site has to carry them too.
 SITE = {'domain': 'https://example.test/', 'name': 'Site', 'lang': 'en',
+        'home': 'https://example.test/',
+        'guides_url': 'https://example.test/guides/',
+        'roadmap_url': 'https://example.test/roadmap/',
         'guides': {'slug': 'guides', 'heading': 'Guides',
                    'description': 'every guide'}}
 


### PR DESCRIPTION
Adds the machinery to serve the site in more than one language, and German as the locale that proves it works.

## What a locale is

**Words and slugs, and nothing else.** Which tools exist, which category each one joins, which guide is about which tool, what the Content-Security-Policy allows — none of that is language, so none of it is repeated per language. It stays in `config/site.toml` and each `tool.toml`, in English, once, and a locale file that tries to restate any of it fails the build rather than becoming a second site to keep in step.

The effect is that shipping a tool gives every language a page for it the same day: in English until somebody translates it, but present, linked, and in the right category, because the category was never a translated string.

## URLs

English keeps every address it has. Other languages sit under a prefix with slugs of their own — `/de/bild-komprimieren/`, not `/de/compress-image/`. A slug is the one part of a page's markup that is also a keyword, and a German reader types "bild komprimieren"; leaving the English word in the URL throws that away in every market except the one the site was written for.

Slug maps are keyed by the **English** slug and live in one `[slugs]` table, so every address a language changes can be read in one place. The build refuses a slug that names nothing, and refuses two entries that would land on one address.

## Half-translated is allowed, and is never advertised

`buildlib/template.py` refuses to render a name it cannot resolve. That rule is not weakened for locales — it is moved. A locale may leave a key out and the English is used; what it may not do is leave a key out and still be offered as a translation.

While `complete = false`, the language is built and readable at its own address, and is kept out of all three places that would claim it exists: no `hreflang`, no sitemap entry, no link in the switcher. All three are built from one list, so they cannot disagree — which is the failure Google reports as "hreflang points to a page that is not indexed".

`complete = true` turns every remaining fallback into a build failure naming the strings. A language gets stricter as it gets more finished. Every build says how far the unfinished ones have to go:

```
de: 737 strings still in English (not advertised until complete = true)
```

## The frame's own words

The strings that were typed into `templates/` move to a `[ui]` table and are read as small templates rather than as plain strings. "Your files are never uploaded" is subject-verb-object and the German is not, so a string cut in half around `{{ tool.words.plural }}` could only ever be one word order or the other. Written whole it can be either — and because it uses the site's own template syntax, a translator who mistypes the name gets a failed build rather than a published sentence with a hole in it.

## Four bugs found on the way

1. **`[ui.tool]` was served in English on every translated page.** `STRUCTURAL_KEYS` is matched on the key name at any depth and `tool` is on it — it names the tool a guide is about. That made the frame's words for a tool page look structural, so the pledge and the button labels stayed English while the page around them came out in German. Nothing under `[ui]` is ever structure; there is a regression test.
2. The drop-zone labels (`[picker]`) were user-visible but not translatable.
3. The 404 lost its configured tool ordering in the restructure.
4. Derived keys and the CSP origins were counted as untranslated strings, inflating the "still to do" report and making it useless for its one job.

## Checking it

`python build.py` output for English is **unchanged** but for two intended things: `inLanguage` added to the `SoftwareApplication` node, and the stylesheet hash moving because the switcher has styles. Verified by diffing a build of this branch against a build of `main`.

295 tests pass, including 26 new ones covering the merge rules, the fallback, completeness, slug collisions, hreflang reciprocity, and that an unfinished language is advertised nowhere.

## Not done, and written down in the README

- The ~380 user-facing strings inline in `tools/*/src/*.js` — 213 of them in `exif-editor`, most of those EXIF tag names. They need extracting before a locale can reach them, which is a change to the tools' own code rather than to the build, and is the one part that cannot be checked by reading the output: it has to be exercised in a browser. Worth deciding when it is done that the long tail of tag names is better left in English, since people cross-reference those against ExifTool and Windows' own properties dialog.
- `config/planned.toml`, so the roadmap's planned list is still English everywhere.
- German itself is about a tenth translated: the whole frame, plus `compress-image`. The other eight tools and the guides are the 737 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
