### PR TITLE
Translate the site into Spanish

### DIFF
--- a/locales/es/locale.toml
+++ b/locales/es/locale.toml
@@ -16,7 +16,10 @@ lang = "es"
 name = "Spanish"
 endonym = "Español"
 
-complete = false
+# Every tool, every guide, both legal pages and the roadmap list are
+# translated, so the fallback is now an error rather than a silence, and
+# Spanish is advertised in the sitemap, the hreflang tags and the switcher.
+complete = true
 
 #
 # ---------------------------------------------------------------------------
@@ -45,6 +48,15 @@ complete = false
 "images-to-video" = "imagenes-a-video"
 "resize-image" = "redimensionar-imagen"
 "trim-video" = "cortar-video"
+# Nombradas por la tarea, no por el formato: casi nadie busca "imagen a ICO",
+# y muchísima gente busca cómo hacerse un favicon.
+"image-to-ico" = "crear-favicon"
+"svg-to-image" = "convertir-svg-a-png"
+"heic-to-jpg" = "convertir-heic-a-jpg"
+# "Base64" es la palabra que se teclea; "data URI" es la que sale después.
+"image-to-data-uri" = "imagen-a-base64"
+"qr-barcode" = "generar-codigo-qr"
+"video-to-gif" = "convertir-video-a-gif"
 
 "guides" = "guias"
 "roadmap" = "hoja-de-ruta"
@@ -60,6 +72,12 @@ complete = false
 "guides/trim-a-video" = "guias/cortar-un-video"
 "guides/crop-a-video" = "guias/recortar-un-video"
 "guides/is-it-safe-to-upload-files" = "guias/es-seguro-subir-archivos"
+"guides/make-a-favicon" = "guias/como-hacer-un-favicon"
+"guides/convert-an-svg-to-png" = "guias/convertir-un-svg-a-png"
+"guides/convert-heic-to-jpg" = "guias/convertir-heic-a-jpg"
+"guides/embed-an-image-in-css" = "guias/incrustar-una-imagen-en-css"
+"guides/make-a-qr-code" = "guias/como-hacer-un-codigo-qr"
+"guides/turn-a-video-into-a-gif" = "guias/convertir-un-video-en-gif"
 
 #
 # ---------------------------------------------------------------------------
@@ -130,7 +148,7 @@ note = "Crea y reordena documentos sin mandarlos a procesar a ninguna parte."
 
 [[hub.categories]]
 name = "Códigos y datos"
-note = "Convertir lo que ha escrito en algo que una máquina puede leer, sin que salga de la página."
+note = "Convierte lo que escribes en algo que una máquina puede leer, sin que salga de la página."
 
 [[hub.categories]]
 name = "Texto y código"
@@ -334,6 +352,8 @@ warning = """
       pedir. De ti no sale nunca nada &mdash; esta página sigue sin poder hacer
       ninguna subida."""
 label = "Una dirección por línea"
+# El inglés forma el plural añadiendo una "s" al nombre; en español eso daría
+# «imagens», así que la frase se escribe alrededor del singular.
 note = """
-      El servidor debe permitir el uso entre orígenes de sus {{ tool.picker.urls.noun }}s. Muchos sitios no lo
+      El servidor debe permitir el uso entre orígenes de sus archivos de {{ tool.picker.urls.noun }}. Muchos sitios no lo
       hacen, y esos fallarán con un mensaje en vez de romperse en silencio más tarde."""

--- a/locales/es/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/es/pages/guides/combine-images-into-a-pdf.html
@@ -1,0 +1,205 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre <a href="../../imagenes-a-pdf/">Imágenes a PDF</a>, suelta las fotos
+      dentro, arrastra las fichas hasta que el orden esté bien, y crea el
+      documento. Los valores por defecto &mdash; páginas A4, un margen pequeño,
+      las fotografías copiadas sin recodificar &mdash; son lo que quiere casi
+      todo el mundo.
+    </p>
+    <p>
+      Las cuatro cosas que merecen un segundo pensamiento son el orden, el tamaño
+      de página, el ajuste de calidad y qué dice el documento terminado sobre ti.
+      En ese orden de frecuencia con que salen mal.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pon bien el orden antes que nada</h2>
+    <p>
+      El orden de las páginas es lo que más veces sale mal, porque los nombres de
+      archivo se ordenan de formas que nadie espera. <code>IMG_2.jpg</code> va
+      después de <code>IMG_10.jpg</code> en una ordenación alfabética, ya que la
+      comparación es carácter a carácter y el <code>1</code> va antes que el
+      <code>2</code>. Una carpeta de escaneos llamados <code>pagina1</code> a
+      <code>pagina12</code> llegará en el orden equivocado en casi cualquier
+      herramienta.
+    </p>
+    <p>
+      Ordenar por fecha de captura suele ser más fiable con fotografías, porque
+      fotografiaste las páginas en el orden en que estaban. En cualquier caso,
+      comprueba las fichas antes de pulsar el botón en vez de comprobar el PDF
+      después.
+    </p>
+  </section>
+
+  <section>
+    <h2>La calidad: la parte que casi todas las herramientas hacen mal en silencio</h2>
+    <p>
+      Un PDF puede llevar datos JPEG directamente. Es una propiedad del formato:
+      los bytes comprimidos de un JPEG se pueden meter en el documento tal cual, y
+      el lector los descodifica igual que lo haría un navegador.
+    </p>
+    <p>
+      Esto importa porque significa que una fotografía no tiene por qué perder
+      nada al entrar en un PDF. Nunca se descodifica y nunca se vuelve a comprimir;
+      la imagen del documento es bit a bit la imagen de tu archivo. Muchas
+      herramientas la recodifican igualmente &mdash; es más simple renderizarlo
+      todo a un lienzo y codificar de forma uniforme &mdash; y el resultado es una
+      generación de calidad perdida sin motivo.
+    </p>
+    <p>
+      Los demás formatos no pueden colarse así. PNG, WebP, HEIC y los demás no
+      tienen ningún filtro equivalente en PDF, así que hay que convertirlos. Tú
+      eliges cómo:
+    </p>
+    <ul>
+      <li>
+        <strong>Recodificar como JPEG</strong> (lo predeterminado). El archivo más
+        pequeño, un pequeño coste de calidad, y la respuesta correcta para
+        fotografías.
+      </li>
+      <li>
+        <strong>Sin pérdidas.</strong> Guarda los píxeles exactos a costa de un
+        documento mucho más grande. La respuesta correcta para capturas de
+        pantalla, diagramas y cualquier cosa con texto o bordes nítidos, donde los
+        artefactos del JPEG se ven a la legua.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>El tamaño de página, y cuándo es mejor «ajustar a la imagen»</h2>
+    <p>
+      Un tamaño de página estándar &mdash; A4, Carta, Oficio, A3, A5, Tabloide
+      &mdash; coloca cada imagen en una página de ese tamaño, escalada para que
+      quepa dentro de tu margen. Usa uno cuando el documento se vaya a imprimir, o
+      cuando alguien oficial lo vaya a archivar.
+    </p>
+    <p>
+      «Exactamente el tamaño de cada imagen» hace que cada página coincida con su
+      imagen, así que no hay espacio en blanco ni escalado ninguno. Úsalo cuando el
+      PDF sea un contenedor de imágenes más que un documento: un porfolio, un
+      conjunto de capturas, un cómic. Queda mal impreso, porque cada página tiene
+      un tamaño distinto.
+    </p>
+    <p>
+      Un margen merece la pena en cualquier cosa que se vaya a imprimir. Las
+      impresoras domésticas no pueden imprimir hasta el borde del papel, y una
+      fotografía colocada de borde a borde sale cortada.
+    </p>
+    <h3>Páginas verticales a partir de fotografías horizontales</h3>
+    <p>
+      Si fotografiaste hojas de papel con el móvil puesto de lado, todas las
+      imágenes serán horizontales y quedarán pequeñas en medio de una página
+      vertical. Girar cada una un cuarto de vuelta antes de construir el documento
+      es lo que lo arregla, y es una decisión por imagen y no global, porque casi
+      siempre unas cuantas entraron bien orientadas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué dice el PDF terminado sobre ti</h2>
+    <p>
+      Un PDF lleva un bloque de información del documento: autor, productor, fecha
+      de creación y a veces el título. Según lo que lo haya escrito, eso puede
+      incluir el nombre de tu cuenta, el nombre de tu equipo y la hora exacta a la
+      que lo hiciste.
+    </p>
+    <p>
+      Merece la pena pensarlo, porque un PDF es algo que la gente le manda a otra
+      gente &mdash; una candidatura, una reclamación, un documento para un
+      casero. Los metadatos viajan con él y cualquier lector puede mostrarlos.
+    </p>
+    <p>
+      La herramienta de aquí deja ese bloque vacío salvo por su propio nombre: ni
+      nombres de archivo, ni nombre de equipo, ni nombre de usuario, ni fecha de
+      creación a menos que marques la casilla que la pide. Si usas otra
+      herramienta, merece la pena abrir una vez las propiedades del resultado para
+      ver qué ha escrito.
+    </p>
+    <p>
+      Aparte: las propias imágenes. Si tus fotografías llevan etiquetas EXIF y
+      GPS, lo que les pase depende de la vía. Un JPEG copiado sin recodificar
+      conserva lo que llevara dentro; una imagen que se recodifica pierde las
+      etiquetas como efecto secundario. Si te importa, límpialas antes con el
+      <a href="../../eliminar-datos-exif/">visor y eliminador de EXIF</a> &mdash;
+      <a href="../eliminar-datos-exif-y-gps/">su guía</a> explica qué hay ahí
+      dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Si el PDF sale demasiado grande</h2>
+    <p>
+      Las fotografías de móvil son grandes, y veinte de ellas hacen un documento
+      que el correo va a rechazar. Tres cosas que probar, por orden:
+    </p>
+    <p>
+      <strong>Reduce el lado más largo.</strong> Una fotografía de 4000 píxeles de
+      una hoja de papel lleva mucho más detalle del que va a usar ningún lector ni
+      ninguna impresora. Bajar el lado largo a algo así como 2000 píxeles suele
+      dejar el archivo en la cuarta parte y no cambia nada que nadie pueda ver en
+      una página.
+    </p>
+    <p>
+      <strong>Usa JPEG en vez de sin pérdidas</strong> para cualquier cosa
+      fotográfica. Sin pérdidas es la respuesta correcta para diagramas y la
+      equivocada para la foto de una página.
+    </p>
+    <p>
+      <strong>Comprime el documento terminado.</strong> El
+      <a href="../../comprimir-pdf/">compresor de PDF</a> trabaja contra el tamaño
+      al que se dibuja cada imagen en la página y no contra su número de píxeles,
+      que es la medición que importa;
+      <a href="../reducir-el-tamano-de-un-pdf/">su guía</a> explica lo que cuesta
+      eso.
+    </p>
+    <p>
+      La herramienta no lleva ningún límite dentro sobre cuántas imágenes puedes
+      usar. El techo práctico es la memoria de tu propio equipo, porque el
+      documento terminado se monta ahí antes de que lo descargues &mdash; unos
+      cientos de fotos de móvil a resolución completa es lo primero que lo nota, y
+      reducir el lado más largo mueve ese techo bastante lejos.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lo que esto no te va a dar</h2>
+    <p>
+      Un PDF hecho a partir de fotografías es un PDF lleno de imágenes. Las
+      palabras que hay dentro no son texto: no puedes buscarlas, ni copiarlas, ni
+      hacer que un lector de pantalla las lea. Eso es una propiedad de aquello de
+      lo que partiste, no de la conversión.
+    </p>
+    <p>
+      Si necesitas texto buscable necesitas OCR, que es otro trabajo. Y si el
+      documento original todavía existe en alguna parte como documento, exportarlo
+      directamente a PDF siempre le ganará a fotografiarlo &mdash; más pequeño,
+      más nítido, buscable.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué esto no necesita una subida</h2>
+    <p>
+      Escribir un PDF es escribir un archivo estructurado: una cabecera, un
+      conjunto de objetos, una tabla de referencias cruzadas. No hay nada ahí que
+      un navegador no sepa hacer, ni nada en el trabajo que exija que las imágenes
+      viajen a ninguna parte.
+    </p>
+    <p>
+      Cosa que aquí merece preocupación, por lo que la gente mete en estos
+      documentos. Documentos de identidad, extractos bancarios, informes médicos,
+      contratos firmados &mdash; la razón entera de que alguien esté haciendo un
+      PDF suele ser que se lo va a mandar a una institución. La herramienta de
+      aquí no tiene ninguna función de red, y la
+      <code>Content-Security-Policy</code> de la página nombra todas las
+      direcciones que puede contactar, ninguna de las cuales es de este sitio.
+    </p>
+    <p>
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> explica cómo comprobarlo tú mismo, aquí o en
+      cualquier otra parte.
+    </p>
+  </section>

--- a/locales/es/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/es/pages/guides/combine-images-into-a-pdf.toml
@@ -1,0 +1,25 @@
+#
+# Guía: unir imágenes en un PDF - Spanish.
+#
+# Overrides for pages/guides/combine-images-into-a-pdf/page.toml. Only words:
+# the slug, the kind, the group and the tool this guide is about stay where
+# they are.
+#
+
+nav = "Imágenes en un PDF"
+
+title = "Cómo unir imágenes en un solo PDF"
+description = "Convierte fotos o escaneos en un único PDF: tamaño de página, orden y giro, por qué un JPEG no tiene por qué perder calidad al entrar, y qué le cuenta un PDF a la persona a la que se lo mandas."
+
+heading = "Cómo unir imágenes en un solo PDF"
+lede = """
+    Alguien ha pedido «un PDF» y tú tienes once fotografías de papeles. Esto
+    cubre las decisiones que de verdad cambian el resultado &mdash; tamaño de
+    página, orden, calidad y qué dice el documento sobre ti &mdash; y cuáles
+    puedes ignorar."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Cómo unir imágenes en un solo PDF"
+og_description = "Tamaño de página, orden y giro, por qué un JPEG no tiene por qué perder calidad al entrar, y qué le cuenta un PDF a la persona a la que se lo mandas."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/es/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,0 +1,251 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../comprimir-imagen/">compresor de imágenes</a>, suelta
+      la foto dentro, escribe el número que te han dado y pulsa el botón.
+      Codifica la imagen varias veces, se queda con el mejor resultado que cabe
+      por debajo de tu objetivo, y te dice lo que ha costado. Para la mayoría de
+      las fotografías y la mayoría de los objetivos, el resumen honesto es que no
+      vas a ser capaz de ver la diferencia.
+    </p>
+    <p>
+      El resto de esta página es para cuando eso no pasa: cuando el resultado se
+      ve blando, cuando un PNG apenas se mueve, o cuando quieres saber qué le
+      está haciendo la herramienta a tu foto antes de mandársela a alguien.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué está pidiendo de verdad un límite de tamaño</h2>
+    <p>
+      Un JPEG o un WebP no guarda tu fotografía. Guarda una descripción de ella,
+      y el ajuste de calidad decide hasta qué punto se le permite ser detallada.
+      Bájalo y el archivo se hace más pequeño porque la descripción se vuelve más
+      vaga: la textura fina se promedia, los degradados hacen bandas, y los
+      bordes cogen un halo tenue de bloques.
+    </p>
+    <p>
+      Así que un límite de tamaño es un presupuesto de detalle. La pregunta útil
+      no es «¿puedo llegar a 500&nbsp;KB?» &mdash; siempre puedes llegar a
+      cualquier número &mdash;, sino «¿cuánto de la imagen tengo que entregar
+      para llegar hasta ahí, y me importa para lo que voy a hacer con ella?».
+    </p>
+    <p>
+      Dos reglas prácticas. Una fotografía de una escena real &mdash; caras,
+      follaje, tela &mdash; esconde bien la compresión, porque el ojo no tiene
+      ninguna zona perfectamente plana en la que notar el daño. Una captura de
+      pantalla, un gráfico, un logotipo o cualquier cosa con colores planos
+      grandes y bordes duros de texto la enseña de inmediato, y normalmente
+      debería ser un PNG o un WebP en vez de un JPEG.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué no hay ninguna fórmula, y qué hacer al respecto</h2>
+    <p>
+      No hay forma de calcular el ajuste de calidad que produce un archivo de
+      500&nbsp;KB. La relación entre los dos depende por completo de lo que haya
+      en la foto: con el mismo ajuste, una fotografía de una pared lisa puede
+      salir a la décima parte del tamaño de una fotografía de un bosque.
+      Cualquier herramienta que te ofrezca «calidad: 60» y cruce los dedos está
+      adivinando por ti.
+    </p>
+    <p>
+      El único método fiable es probar. Codificar la imagen, mirar el tamaño,
+      ajustar, volver a codificar. Hacerlo a mano es pesado, y por eso los
+      compresores piden un número de calidad &mdash; te trasladan la pesadez a
+      ti. Hacerlo automáticamente son unas ocho codificaciones, y ocho
+      codificaciones de una foto de móvil son una fracción de segundo en
+      cualquier equipo hecho esta década, que es por lo que la herramienta de
+      este sitio pide el tamaño y hace la búsqueda ella misma.
+    </p>
+    <p>
+      Cada tamaño que informa es un archivo codificado de verdad, no una
+      estimación. Eso importa cuando un formulario tiene un límite duro: una
+      estimación optimista por un 2&nbsp;% es una subida rechazada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gasta calidad antes que píxeles</h2>
+    <p>
+      Solo hay dos formas de hacer más pequeño un archivo de imagen. Puedes
+      describir la misma foto con menos precisión, que es la calidad. O puedes
+      describir menos píxeles, que es redimensionar. No son equivalentes, y el
+      orden importa.
+    </p>
+    <p>
+      La calidad va primero, porque el primer 30&nbsp;% de reducción de calidad
+      más o menos es genuinamente invisible en una fotografía &mdash; estás
+      tirando detalle que el formato guardaba con más cuidado del que ningún ojo
+      puede comprobar. Los píxeles van después, porque una vez que la calidad
+      baja lo bastante como para que se vean artefactos, una foto más pequeña con
+      una calidad decente se ve mejor que una foto a tamaño completo que ha
+      quedado arruinada. Menos píxeles buenos ganan a más píxeles malos.
+    </p>
+    <p>
+      Esa es la estrategia entera, y merece la pena saberla aunque uses otra
+      herramienta: baja la calidad hasta que empiece a verse mal, y entonces haz
+      la foto más pequeña en lugar de seguir bajándola.
+    </p>
+    <h3>Cuándo redimensionar a propósito</h3>
+    <p>
+      A veces los píxeles nunca hicieron falta. Una foto de 4000 píxeles de ancho
+      mostrada en una columna de 600 píxeles de ancho de una página web lleva seis
+      veces el detalle que nadie va a ver. Si sabes dónde va a acabar la foto,
+      redimensiónala a eso primero y el problema de tamaño desaparece muchas veces
+      sin gastar nada de calidad. El
+      <a href="../../redimensionar-imagen/">redimensionador de imágenes</a> es la
+      herramienta para ese trabajo, y
+      <a href="../redimensionar-una-imagen/">su propia guía</a> explica cómo
+      elegir un tamaño.
+    </p>
+  </section>
+
+  <section>
+    <h2>Elegir un formato</h2>
+    <p>
+      Merece la pena conocer tres formatos, y los navegadores saben escribir los
+      tres.
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG</strong> es para fotografías. Tiene pérdidas, lo entiende
+        todo lo que se ha fabricado jamás, y para una imagen de una escena real
+        sigue siendo una elección excelente. No puede guardar transparencia.
+      </li>
+      <li>
+        <strong>WebP</strong> es para el mismo trabajo, hecho mejor: alrededor de
+        un 25&ndash;35&nbsp;% más pequeño que JPEG a una calidad que no puedes
+        distinguir, y conserva la transparencia. Lo lee cualquier navegador
+        actual. Unas pocas aplicaciones de escritorio antiguas y algunos
+        formularios de subida corporativos siguen sin leerlo, y esa es la única
+        razón de verdad para no usarlo.
+      </li>
+      <li>
+        <strong>PNG</strong> no tiene pérdidas, lo que significa que es exacto y
+        es grande. Es la respuesta correcta para capturas de pantalla, logotipos,
+        dibujo de línea y cualquier cosa con bordes nítidos o color plano, y la
+        respuesta equivocada para una fotografía.
+      </li>
+    </ul>
+    <p>
+      Si no tienes ninguna restricción de quien te ha pedido el archivo, WebP te
+      llevará hasta el objetivo con menos daño visible que JPEG. Si el archivo va
+      a algo antiguo, o a un sistema que no puedes probar, JPEG es la respuesta
+      segura.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué tu PNG no se va a hacer mucho más pequeño</h2>
+    <p>
+      Esta es la sorpresa más habitual, y no es un fallo de la herramienta que
+      estés usando. PNG es un formato sin pérdidas: guarda los píxeles exactos, y
+      no tiene ningún mando de calidad que girar, porque girar uno lo convertiría
+      en otro formato. Todo lo que puede hacer un compresor de PNG es empaquetar
+      los mismos píxeles con más maña, que suele valer un pequeño porcentaje.
+    </p>
+    <p>
+      Así que si necesitas por narices un archivo mucho más pequeño y tiene que
+      seguir siendo un PNG, la única palanca que queda es el tamaño &mdash; menos
+      píxeles, o menos colores. Si puede dejar de ser un PNG, la pregunta es qué
+      lleva dentro:
+    </p>
+    <ul>
+      <li>
+        <strong>Una fotografía guardada como PNG.</strong> Muy común, casi
+        siempre por accidente, y la victoria más fácil de esta página:
+        convertirla a JPEG o WebP la dejará muchas veces de cinco a diez veces
+        más pequeña sin ningún cambio visible.
+      </li>
+      <li>
+        <strong>Una captura de pantalla o un diagrama.</strong> Conviértelo a
+        WebP, que también es sin pérdidas cuando se lo pides, y suele ser más
+        pequeño que PNG para los mismos píxeles. Pasarlo a JPEG dejará borrosos
+        los bordes del texto.
+      </li>
+      <li>
+        <strong>Un logotipo con transparencia.</strong> WebP conserva la
+        transparencia; JPEG la rellenará con un color sólido, que casi nunca es
+        lo que querías.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Cómo saber si el resultado es lo bastante bueno</h2>
+    <p>
+      Mirar una miniatura no demuestra nada &mdash; a tamaño de miniatura todo se
+      ve bien. Dos comprobaciones mejores:
+    </p>
+    <p>
+      <strong>Míralo a tamaño completo, en lo más plano del encuadre.</strong>
+      Cielo, piel, una pared pintada. El daño de la compresión aparece primero en
+      los degradados suaves, como bloques o bandas tenues, mucho antes de tocar
+      las zonas detalladas.
+    </p>
+    <p>
+      <strong>Lee la medición, si la herramienta te da una.</strong> El compresor
+      de aquí descodifica su propio resultado y lo compara con el original, e
+      informa del SSIM: un número que compara brillo, contraste y estructura
+      locales en vez de contar píxeles cambiados, que se parece mucho más a lo
+      que molesta a un ojo. Por encima de 0,98 más o menos, las dos fotos cuesta
+      separarlas una al lado de la otra. Por debajo de 0,95 más o menos, míralo
+      antes de enviarlo. También informa del PSNR, la cifra clásica en
+      decibelios, para quien la prefiera.
+    </p>
+    <p>
+      Las dos se calculan en tu propio equipo y se te muestran, que es el sentido
+      de tenerlas: convierten la «pérdida mínima de calidad» de una afirmación en
+      un número que puedes comprobar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tres cosas que conviene saber antes de mandar el archivo</h2>
+    <p>
+      <strong>Comprimir quita los metadatos.</strong> Recodificar significa
+      descodificar la foto a píxeles y volver a codificar esos píxeles, y un
+      lienzo lleno de píxeles no lleva etiquetas &mdash; así que la posición GPS,
+      el modelo de cámara, las marcas de tiempo y todo lo demás sencillamente no
+      se escriben en el archivo nuevo. Normalmente eso es una ventaja. Si lo que
+      querías era quitar las etiquetas sin tocar la foto, eso es otro trabajo: el
+      <a href="../../eliminar-datos-exif/">visor y eliminador de EXIF</a>
+      reescribe el contenedor sin volver a comprimir nada, y
+      <a href="../eliminar-datos-exif-y-gps/">su guía</a> explica qué hay ahí
+      dentro.
+    </p>
+    <p>
+      <strong>No comprimas nunca dos veces el mismo archivo.</strong> Cada
+      codificación con pérdidas tira detalle para siempre, y codificar una foto ya
+      comprimida tira más &mdash; incluidos los artefactos de la primera pasada,
+      que conserva fielmente a costa de detalle real. Vuelve siempre al original y
+      comprime una sola vez.
+    </p>
+    <p>
+      <strong>Conserva el original.</strong> De una codificación con pérdidas no
+      hay vuelta atrás. Mandes lo que mandes, guarda en alguna parte el archivo
+      del que partiste.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada de esto necesita una subida</h2>
+    <p>
+      Todos los navegadores llevan años trayendo un codificador de JPEG, PNG y
+      WebP &mdash; es el mismo código que guarda una imagen desde un lienzo.
+      Comprimir una imagen es uno de los trabajos que no tiene ninguna razón
+      técnica para implicar a un servidor, y por eso la herramienta de aquí no
+      tiene ninguno: la imagen se descodifica, se codifica y se mide en tu propio
+      equipo, y en la <code>Content-Security-Policy</code> de la página no hay
+      ninguna dirección de este sitio a la que pudiera enviarse.
+    </p>
+    <p>
+      La forma más sencilla de confirmarlo, aquí o en cualquier otra parte, es
+      cargar la página, desconectarse de internet y comprimir algo de todos modos.
+      Si sigue funcionando, no se estaba subiendo nada.
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea otras tres comprobaciones parecidas.
+    </p>
+  </section>

--- a/locales/es/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/es/pages/guides/compress-an-image-to-a-target-size.toml
@@ -1,0 +1,25 @@
+#
+# Guía: comprimir una imagen a un tamaño exacto - Spanish.
+#
+# Overrides for pages/guides/compress-an-image-to-a-target-size/page.toml.
+# Only words: the slug, the kind, the group and the tool this guide is about
+# stay where they are.
+#
+
+nav = "Comprimir una imagen"
+
+title = "Cómo comprimir una imagen a un tamaño de archivo exacto"
+description = "Un formulario pide 500 KB y tu foto ocupa 4 MB. Lo que cuesta de verdad un límite de tamaño, qué ajuste mover primero, y por qué un PNG no va a encoger como lo hace un JPEG."
+
+heading = "Cómo comprimir una imagen a un tamaño de archivo exacto"
+lede = """
+    Alguien te ha dado un número &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
+    &mdash; y tu foto no se acerca ni de lejos. Esto es lo que cuesta ese
+    número, en qué gastarlo, y cómo saber si el resultado sigue siendo lo
+    bastante bueno para enviarlo."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Comprimir una imagen a un tamaño de archivo exacto"
+og_description = "Lo que cuesta de verdad un límite de tamaño, qué ajuste mover primero, y por qué un PNG no va a encoger como lo hace un JPEG."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/convert-an-svg-to-png.html
+++ b/locales/es/pages/guides/convert-an-svg-to-png.html
@@ -1,0 +1,239 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre <a href="../../convertir-svg-a-png/">SVG a imagen</a>, suelta el
+      archivo dentro y di un tamaño. Si nadie te ha dicho qué tamaño usar,
+      <strong>1024 píxeles en el lado más largo</strong> es un buen valor por
+      defecto: lo bastante grande para casi todo y lo bastante pequeño para
+      mandarlo por correo. Deja el formato en PNG, deja el fondo en transparente y
+      llévate el archivo.
+    </p>
+    <p>
+      Todo lo de abajo es qué hacer cuando ese valor por defecto no basta &mdash;
+      cuando te han especificado un número, cuando va a una imprenta, o cuando
+      vuelve con mal aspecto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué el tamaño lo decides tú y no el archivo</h2>
+    <p>
+      Un JPEG es una rejilla de píxeles medidos; preguntar cuánto mide tiene
+      respuesta. Un SVG no es una imagen en absoluto, es un conjunto de
+      instrucciones &mdash; dibuja un círculo aquí, este trazado de este color
+      &mdash; y las instrucciones no tienen tamaño. Un navegador puede ejecutarlas
+      a 16 píxeles o a 4000 y el resultado es igual de nítido en ambos casos,
+      porque no está escalando nada. Está dibujando otra vez.
+    </p>
+    <p>
+      Por eso la conversión no puede elegir un número por ti, y por eso no te
+      cuesta nada elegir uno grande. Este es el único trabajo de imagen en el que
+      «hazlo más grande» es gratis.
+    </p>
+    <p>
+      Casi todos los archivos SVG sí llevan un atributo <code>width</code> y
+      <code>height</code>, y una herramienta te lo enseñará &mdash; pero es un
+      valor por defecto, no un límite. Un icono que dice <code>width="24"</code>
+      solo dice que quien lo dibujó tenía en mente una barra de herramientas de
+      24&nbsp;píxeles.
+    </p>
+  </section>
+
+  <section>
+    <h2>De dónde sale de verdad el número</h2>
+    <p><strong>Para una web.</strong> Coge el tamaño que ocupa la imagen en la
+      página en píxeles CSS y multiplícalo por la densidad de píxeles de las
+      pantallas que te importen. Un logotipo en un hueco de 200&nbsp;píxeles de
+      ancho necesita un archivo de 400&nbsp;píxeles para un portátil Retina y de
+      600 para un móvil reciente. Eso es todo lo que significan <code>@2x</code> y
+      <code>@3x</code>, y es por lo que una herramienta que los escriba te ahorra
+      hacer la cuenta tres veces.
+    </p>
+    <p><strong>Para el icono de una aplicación, una ficha de tienda o un
+      favicon.</strong> El número está publicado y no hay nada que calcular: lo
+      que diga la página de la tienda, exactamente. Para un favicon, no
+      rasterices en absoluto &mdash; <a href="../como-hacer-un-favicon/">haz un
+      .ico</a>, que guarda varios tamaños en un archivo, porque la pestaña de un
+      navegador, un marcador y un acceso directo de Windows piden todos tamaños
+      distintos.
+    </p>
+    <p><strong>Para imprenta.</strong> Multiplica el tamaño físico en pulgadas
+      por la resolución de la impresora. Un logotipo que va en una tarjeta de
+      visita con dos pulgadas de ancho a 300&nbsp;PPP son 600 píxeles; el mismo
+      logotipo a lo ancho de una página A4, con 8,3&nbsp;pulgadas, son unos 2500.
+      Las imprentas piden 300&nbsp;PPP por costumbre, y para una lona de gran
+      formato que se ve desde el otro lado de una sala 150 sobran.
+    </p>
+    <p><strong>Para una vista previa social o una imagen OG.</strong> La
+      plataforma dice una caja &mdash; 1200&nbsp;&times;&nbsp;630 para casi todas
+      las vistas previas de enlaces &mdash; y la caja tiene otra forma que tu
+      logotipo. Para eso está el ajuste de «rellenar»: el dibujo centrado con sus
+      propias proporciones, con un color de fondo llenando el resto, en lugar de
+      un logotipo estirado que le cuenta a todo el mundo que no lo comprobaste.
+    </p>
+    <p>
+      Cuando se apliquen dos de estos, usa el mayor. Un PNG más grande de lo
+      necesario es una descarga algo mayor; uno demasiado pequeño no se puede
+      arreglar después, por la razón del apartado siguiente.
+    </p>
+  </section>
+
+  <section>
+    <h2>No se puede volver atrás</h2>
+    <p>
+      Rasterizar es de ida. Una vez que el dibujo es un PNG son píxeles como los de
+      cualquier otra imagen, y ampliarlo después tiene que inventar detalle que
+      nunca se midió &mdash; el mismo resultado blando y emborronado que da ampliar
+      una fotografía.
+    </p>
+    <p>
+      Así que conserva el SVG. Es la copia maestra, casi siempre es el archivo más
+      pequeño, y todos los tamaños futuros salen de él perfectamente. El PNG es una
+      exportación para un uso concreto, y cuando necesites otro tamaño lo correcto
+      es volver a exportar y no redimensionar lo que exportaste.
+    </p>
+    <p>
+      Hay software que dice convertir un PNG de vuelta en un SVG. Lo que hace es
+      calcar: adivinar qué curvas podrían explicar una rejilla de píxeles. Funciona
+      pasablemente con dibujo plano de dos colores y produce disparates caros con
+      cualquier otra cosa, y nunca recupera lo que tenía el dibujo original.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tres cosas cambian en cuanto se convierte en píxeles</h2>
+    <p>
+      Un SVG rasterizado que se ve mal casi siempre se ve mal por una de estas tres
+      razones, y las tres conviene conocerlas antes de exportar y no después.
+    </p>
+    <p>
+      <strong>El texto se dibuja con la tipografía que tenga la máquina.</strong>
+      Un SVG que contiene texto no contiene la tipografía &mdash; nombra una y deja
+      que el renderizador la encuentre. Si la tipografía no está instalada, se usa
+      una sustituta, y la sustituta tiene otras formas de letra y otras anchuras,
+      así que el texto puede recolocarse o desbordarse. A un archivo que se trae su
+      tipografía de una dirección web le va todavía peor: a un SVG que se rasteriza
+      a través de un <code>&lt;img&gt;</code> no se le permite descargar
+      absolutamente nada, así que no llega nada.
+    </p>
+    <p>
+      La solución es la que cualquier diseñador ya conoce: <strong>convertir el
+      texto en contornos</strong> antes de exportar el SVG (Illustrator lo llama
+      Crear contornos, Figma lo llama Flatten, Inkscape lo llama Objeto a trazado).
+      Las letras se convierten en geometría, la tipografía deja de importar y la
+      imagen se ve igual en todas las máquinas. Hazlo sobre una copia &mdash; el
+      texto convertido en contornos ya no se puede editar como texto.
+    </p>
+    <p>
+      <strong>Las líneas de un pelo se vuelven grises o desaparecen.</strong> Un
+      trazo que sale a menos de un píxel al tamaño que has elegido no se puede
+      dibujar como una línea sólida, así que se dibuja como una tenue. Por eso un
+      logotipo delicado rasterizado a 64&nbsp;píxeles se ve deslavado mientras que
+      el mismo archivo a 512 se ve perfecto. Si el requisito es un tamaño pequeño,
+      la respuesta es un dibujo simplificado con trazos más gruesos y no otro
+      ajuste de exportación &mdash; que es la misma razón por la que un favicon es
+      un símbolo y no un logotipo de palabra.
+    </p>
+    <p>
+      <strong>La animación se para.</strong> Un SVG animado rasteriza a una sola
+      imagen fija: el primer fotograma, sea cual sea. No hay ningún ajuste de
+      exportación que cambie eso. Si necesitas el movimiento, necesitas un GIF o un
+      vídeo, hechos de otra manera.
+    </p>
+  </section>
+
+  <section>
+    <h2>La transparencia, y qué formato elegir</h2>
+    <p>
+      <strong>PNG</strong> salvo que tengas un motivo. No tiene pérdidas, conserva
+      la transparencia, y el color plano con bordes duros &mdash; que es de lo que
+      está hecho casi todo dibujo &mdash; se comprime bien en él. Un logotipo
+      rasterizado suele ser un PNG <em>más pequeño</em> de lo que sería un JPEG,
+      además de más limpio.
+    </p>
+    <p>
+      <strong>JPEG</strong> no tiene transparencia en absoluto. Cada píxel
+      transparente tiene que convertirse en algún color, y si nadie elige uno por ti
+      se convierte en negro &mdash; de ahí viene ese resultado de logotipo sobre
+      caja negra que la gente da por hecho que es un error. Además tiene pérdidas de
+      la forma que peor se nota justo en este tipo de imagen: un anillo de
+      salpicaduras alrededor de cada borde duro. Úsalo cuando algo insista.
+    </p>
+    <p>
+      <strong>WebP</strong> hace todo lo que hace PNG, en un archivo más pequeño, y
+      lo lee cualquier navegador actual. La razón para no usarlo es lo que pasa
+      después del navegador: el software antiguo, algunas imprentas y bastantes
+      formularios de subida siguen sin abrir uno.
+    </p>
+    <p>
+      Elegir un color de fondo con PNG es también algo perfectamente normal de
+      querer. La transparencia solo es útil cuando aquello sobre lo que aterriza la
+      imagen es de un color que no puedes predecir; cuando ya sabes que es una
+      página blanca, aplanar sobre blanco evita toda una categoría de sorpresas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cuando la exportación sale en blanco o mal</h2>
+    <p>
+      <strong>Nada más que espacio vacío.</strong> Normalmente falta el atributo
+      <code>xmlns</code> en el elemento raíz. Un archivo sin él no es SVG a efectos
+      de una etiqueta de imagen, y se dibuja como nada. Abrir el archivo en un
+      navegador es la prueba rápida: si el navegador tampoco enseña nada, el
+      problema es el archivo y no el conversor.
+    </p>
+    <p>
+      <strong>El dibujo sale pequeño, en la esquina superior izquierda.</strong> El
+      archivo tiene <code>width</code> y <code>height</code> pero no
+      <code>viewBox</code>, así que no hay ningún sistema de coordenadas que
+      escalar y el dibujo conserva sus unidades originales sobre un lienzo más
+      grande. Un buen conversor te pone un viewBox; si el tuyo no lo ha hecho,
+      añadir <code>viewBox="0 0 <em>ancho</em> <em>alto</em>"</code> al elemento
+      raíz a mano lo arregla, y el archivo es texto plano, así que puedes.
+    </p>
+    <p>
+      <strong>Falta parte de la imagen.</strong> Algo del archivo apuntaba a una
+      dirección en vez de contener el dibujo &mdash; una fotografía incrustada
+      guardada como enlace, una hoja de estilos, una tipografía. Un rasterizador
+      que se niegue a descargar eso está haciendo lo correcto, y es la misma
+      negativa que impide que un SVG que te has bajado de algún sitio informe a
+      quien lo hizo. Vuelve a exportar desde el programa de dibujo con las imágenes
+      incrustadas.
+    </p>
+    <p>
+      <strong>Rechaza un tamaño muy grande.</strong> Los navegadores ponen un tope
+      a lo grande que puede ser un lienzo, y no se ponen de acuerdo en dónde:
+      pasados unos 16&nbsp;000&nbsp;píxeles de lado no vuelve nada, y Safari en un
+      iPhone o un iPad se rinde mucho antes, alrededor de
+      4096&nbsp;&times;&nbsp;4096. Una herramienta que te avisa te está salvando de
+      un archivo en blanco, porque eso es lo que produce un navegador cuando se
+      queda sin recursos, en vez de un mensaje de error.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada de esto necesita una subida</h2>
+    <p>
+      Rasterizar un SVG es algo que cualquier navegador hace miles de veces al día
+      &mdash; es la misma maquinaria que dibuja un icono en una página web. No hay
+      ninguna razón técnica para que tu dibujo viaje a un servidor y vuelva
+      convertido en PNG, y la herramienta de aquí no lo manda a ninguna parte: la
+      <code>Content-Security-Policy</code> de la página nombra todas las
+      direcciones que puede contactar, y ninguna es de este sitio.
+    </p>
+    <p>
+      Y con SVG eso importa más de lo habitual, porque un SVG es un documento y no
+      una imagen. Puede contener un script y una dirección remota, y un logotipo
+      que te ha mandado una agencia es un archivo que no escribiste tú. Dibujado a
+      través de una etiqueta de imagen está en lo que la especificación llama
+      <em>modo estático seguro</em>: el script no se puede ejecutar y con la
+      dirección no se contacta nunca. Eso lo hace cumplir el navegador, no la web.
+    </p>
+    <p>
+      Carga la página, desenchúfate de internet y convierte algo de todos modos si
+      prefieres comprobarlo a que te lo cuenten.
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      hacerle a cualquier herramienta.
+    </p>
+  </section>

--- a/locales/es/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/es/pages/guides/convert-an-svg-to-png.toml
@@ -1,0 +1,24 @@
+#
+# Guía: convertir un SVG en un PNG - Spanish.
+#
+# Overrides for pages/guides/convert-an-svg-to-png/page.toml. Only words: the
+# slug, the kind, the group and the tool this guide is about stay where they
+# are.
+#
+
+nav = "Convertir un SVG a PNG"
+
+title = "Cómo convertir un SVG en un PNG al tamaño correcto"
+description = "Un vector no tiene tamaño propio en píxeles, así que el número lo eliges tú. De dónde sale ese número para una pantalla, para el icono de una aplicación y para una imprenta, y qué cambia cuando un dibujo se convierte en píxeles."
+
+heading = "Cómo convertir un SVG en un PNG al tamaño correcto"
+lede = """
+    Convertir es la mitad fácil. La pregunta que decide si el resultado sirve de
+    algo es la que nadie te responde: ¿cuántos píxeles? Esto es de dónde sale ese
+    número, y qué pierde un dibujo camino de convertirse en uno."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Convertir un SVG en un PNG al tamaño correcto"
+og_description = "De dónde sale de verdad el número de píxeles, y las tres cosas que cambian cuando un dibujo se convierte en píxeles."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/convert-heic-to-jpg.html
+++ b/locales/es/pages/guides/convert-heic-to-jpg.html
@@ -1,0 +1,247 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../convertir-heic-a-jpg/">convertidor de HEIC a JPG</a>,
+      suelta las fotos dentro y pulsa «Convertir». Deja el control de calidad
+      donde está y deja marcado «conservar la fecha, la cámara y los ajustes»
+      salvo que tengas un motivo para no hacerlo. Te llevas JPEG de vuelta, un
+      botón de descarga por cada uno, o un zip si son varios.
+    </p>
+    <p>
+      Mientras lo haces no se sube nada. Eso es raro en este trabajo en concreto,
+      y la razón es la mitad interesante de esta página.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué es HEIC en realidad</h2>
+    <p>
+      HEIC no es realmente un formato de imagen como lo es JPEG. Es un contenedor
+      &mdash; la misma estructura de cajas con la que está construido un MP4
+      &mdash; con un fotograma fijo de vídeo <strong>HEVC</strong> dentro. HEVC,
+      también llamado H.265, es el códec que sustituyó al que usaba tu vieja
+      videocámara, y es muy bueno: una foto de iPhone en HEIC ocupa más o menos la
+      mitad que la misma foto en JPEG a la misma calidad.
+    </p>
+    <p>
+      Apple se pasó a él en iOS 11, en 2017, y lo puso por defecto. Lo que
+      significa que, a menos que alguien haya entrado en los ajustes y haya
+      elegido «Más compatible», todas las fotos que ha hecho su móvil durante casi
+      una década están en un formato que:
+    </p>
+    <ul>
+      <li>Windows no previsualiza sin una extensión de la Store;</li>
+      <li>casi todos los formularios de subida de la web rechazan de plano;</li>
+      <li>muchísimo software de escritorio antiguo no ha oído nombrar en su vida;</li>
+      <li>y ningún navegador salvo Safari va a mostrar.</li>
+    </ul>
+    <p>
+      La foto está perfectamente. Es un archivo mejor de lo que habría sido el
+      JPEG. Sencillamente está escrito en un idioma que casi todo el mundo no
+      aprendió nunca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué solo Safari abre una</h2>
+    <p>
+      Esta es la parte que explica todos los conversores que has usado en tu vida,
+      así que merece un párrafo.
+    </p>
+    <p>
+      Descodificar HEVC necesita un descodificador de HEVC, y HEVC está patentado.
+      Las licencias las administra más de un consorcio de patentes, y distribuir un
+      descodificador significa pagarle a alguien. Los navegadores se apañan con
+      esto apoyándose en el sistema operativo &mdash; Chrome reproduce
+      <em>vídeo</em> HEVC en un equipo cuyo hardware ya tiene un descodificador con
+      licencia &mdash;, pero esa vía está cableada para la reproducción de vídeo y
+      no para imágenes fijas. Así que un HEIC entregado a un
+      <code>&lt;img&gt;</code> se rechaza, en Chrome, en Firefox y en Edge por
+      igual, en todos los sistemas operativos.
+    </p>
+    <p>
+      Safari sobre hardware de Apple es la excepción, porque macOS e iOS tienen el
+      descodificador y a Safari se le permite pedírselo. En todo lo demás, la
+      imagen es sencillamente indescodificable para el navegador.
+    </p>
+    <p>
+      Lo que le deja a un conversor exactamente dos opciones, y la elección entre
+      ellas es la historia entera de este tipo de herramienta.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué casi todos los conversores de HEIC quieren una subida</h2>
+    <p>
+      Opción uno: poner el descodificador en un servidor. La foto se sube, se
+      descodifica en una máquina que no has visto nunca, se recodifica como JPEG y
+      se te devuelve. Esto es lo que hace prácticamente cualquier «conversor de
+      HEIC gratuito en línea», y es por lo que todos necesitan tus archivos. No es
+      pereza &mdash; el navegador de verdad no puede hacerlo por su cuenta.
+    </p>
+    <p>
+      Lo que eso cuesta merece decirse sin rodeos. Las fotos de un móvil son los
+      archivos más personales que tiene casi todo el mundo, y un HEIC recién salido
+      de un iPhone suele llevar las coordenadas del sitio donde se tomó, con una
+      precisión de unos pocos metros, junto con la fecha al segundo y un
+      identificador de la cámara. Subir una carpeta entera a un servicio gratuito
+      significa entregar las dos cosas: las imágenes y eso. Lo que pase después lo
+      rige una política de privacidad que no leíste, en un servidor que no puedes
+      inspeccionar, en una jurisdicción que no elegiste.
+    </p>
+    <p>
+      Opción dos: poner el descodificador en la página. Eso es lo que hace
+      <a href="../../convertir-heic-a-jpg/">este</a>. Lleva <code>libheif</code>,
+      compilado a WebAssembly, como un archivo servido desde este sitio &mdash;
+      unos 1,4 MB, descargados una vez y después guardados en caché. Tu navegador
+      lo ejecuta en tu propio equipo, en tu propio hardware, y la foto no va a
+      ninguna parte. Carga la página una vez y puedes desenchufarte de internet del
+      todo y sigue funcionando, cosa que ningún conversor que suba archivos puede
+      hacer y la prueba más sencilla que hay.
+    </p>
+    <p>
+      Los 1,4 MB son el precio entero. Si estás con una conexión con límite de
+      datos es un coste real y conviene saberlo; por eso la página lo dice en voz
+      alta en vez de descargarlo en silencio.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué le cuesta a la imagen convertirla</h2>
+    <p>
+      HEIC y JPEG son códecs distintos, así que no hay forma de pasar de uno a otro
+      sin descodificar la imagen y volver a codificarla. Esa segunda codificación
+      tiene pérdidas. En la práctica esto importa mucho menos de lo que suena:
+    </p>
+    <ul>
+      <li>
+        <strong>Con calidad 92</strong> &mdash; que es donde arranca el conversor
+        &mdash; una fotografía es muy difícil de distinguir del original a
+        cualquier tamaño normal de visionado. Estarías buscando diferencias en
+        degradados suaves, como un cielo despejado, y por lo general no las vas a
+        encontrar.
+      </li>
+      <li>
+        <strong>El JPEG será más grande.</strong> Normalmente entre un tercio más
+        grande y el doble, porque JPEG es un códec de 1992 y HEVC no. Ese es el
+        trato: un archivo más grande que abre todo.
+      </li>
+      <li>
+        <strong>Convertir dos veces es lo que hay que evitar.</strong> Cada
+        codificación con pérdidas cuesta un poco. Convierte desde el HEIC
+        original, no desde un JPEG que ya te hizo alguien, y hazlo una sola vez.
+      </li>
+    </ul>
+    <p>
+      Si no quieres ninguna pérdida, PNG está en el menú de formatos. Prepárate
+      para el archivo: una fotografía en PNG suele ser de cinco a diez veces el
+      tamaño del JPEG, porque la compresión de PNG se diseñó para el color plano y
+      el dibujo de línea, no para la hierba y la piel.
+    </p>
+  </section>
+
+  <section>
+    <h2>La fecha, la cámara y las coordenadas</h2>
+    <p>
+      La queja habitual con los conversores de HEIC es que las fotos vuelven
+      habiendo perdido el día en que se tomaron, así que las imágenes de unas
+      vacaciones enteras se ordenan al final de la fototeca con la fecha de hoy.
+      Eso pasa porque convertir a través de un lienzo te da píxeles y nada más
+      &mdash; un lienzo no guarda etiquetas &mdash;, así que a menos que un
+      conversor vaya a buscar los metadatos por separado, sencillamente
+      desaparecen.
+    </p>
+    <p>
+      La herramienta de aquí copia el bloque EXIF del HEIC y lo escribe en el JPEG,
+      así que la fecha sobrevive. Hay una casilla, y viene marcada. Desmárcala y el
+      JPEG sale con la imagen y nada más.
+    </p>
+    <p>
+      Antes de decidir, mira la lista: la fila de cada foto dice si el archivo
+      lleva coordenadas GPS, y lo dice antes de que se convierta nada. Si las fotos
+      van a algún sitio público, esa es la línea que hay que leer. Si van a tu
+      propia fototeca, conservar los metadatos es casi seguro lo que quieres.
+    </p>
+    <p>
+      Una etiqueta se cambia elijas lo que elijas, y conviene saber por qué. Un
+      HEIC anota su rotación en dos sitios: en el contenedor y en el bloque EXIF.
+      El descodificador aplica la rotación del contenedor mientras descodifica, así
+      que los píxeles que entrega ya están derechos. Si el EXIF siguiera diciendo
+      «gira esto 90 grados», un visor lo haría otra vez y todas las fotos
+      verticales saldrían de lado. Así que la etiqueta de orientación se pone en
+      «derecha» y todo lo demás se copia exactamente como lo escribió el móvil.
+    </p>
+    <p>
+      Si lo que quieres es repasar las etiquetas en detalle, o quitarlas de fotos
+      que ya son JPEG, eso es otro trabajo y hay una
+      <a href="../eliminar-datos-exif-y-gps/">guía para ello</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosas con las que la gente se topa</h2>
+    <ul>
+      <li>
+        <strong>Un HEIC llamado «.jpg».</strong> Extremadamente común: algo por el
+        camino lo renombró sin convertirlo, que es por lo que sigue sin abrirse.
+        Todo archivo que se suelte en el conversor se identifica por sus primeros
+        bytes y no por su nombre, así que uno de estos funciona sin problema. Es
+        además la razón de que a un archivo que sea de verdad un JPEG se le diga
+        que lo es, en lugar de convertirlo en una copia de sí mismo.
+      </li>
+      <li>
+        <strong>Un archivo, varias imágenes.</strong> Una ráfaga o una Live Photo
+        pueden llevar más de una imagen fija. Se convierten todas, y las de más se
+        numeran a partir del nombre original. La mitad de vídeo de una Live Photo
+        es un archivo aparte que el móvil guarda junto al HEIC, así que no está ahí
+        para convertirlo.
+      </li>
+      <li>
+        <strong>AVIF no es HEIC.</strong> Se parecen &mdash; el mismo contenedor,
+        otro códec dentro &mdash;, pero cualquier navegador actual abre un AVIF de
+        forma nativa, así que no hay nada que convertir y la herramienta lo dice en
+        vez de fingir que trabaja.
+      </li>
+      <li>
+        <strong>Cortar el problema de raíz.</strong> En el móvil: Ajustes &rarr;
+        Cámara &rarr; Formatos &rarr; Más compatible. A partir de ahí las fotos
+        nuevas son JPEG. Ocupa más almacenamiento y no toca las fotos que ya
+        tienes, pero significa no volver a hacer esto nunca.
+      </li>
+      <li>
+        <strong>Compartir a veces ya convierte.</strong> Pasar una foto por AirDrop
+        o por correo a un dispositivo que no sea de Apple muchas veces entrega un
+        JPEG, porque iOS convierte a la salida. Si una foto ha llegado como HEIC de
+        todas formas, vino por una vía que no lo hizo.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Cómo saber si un conversor está subiendo tus fotos</h2>
+    <p>
+      Esto vale para cualquier herramienta, no solo para esta, y lleva unos quince
+      segundos.
+    </p>
+    <ol>
+      <li>
+        Abre la página, después abre las herramientas de desarrollo de tu navegador
+        y ve a la pestaña Red.
+      </li>
+      <li>
+        Convierte una foto y mira. Una herramienta que descodifica en tu equipo no
+        hace ninguna petición en ese momento. Una herramienta que sube hace una del
+        tamaño de tu foto, y el tamaño se ve.
+      </li>
+      <li>
+        O, más sencillo todavía: carga la página, desconéctate de internet e
+        intenta convertir algo. Una herramienta que mandara tu foto fuera a
+        descodificar deja de funcionar. Una que lleva el descodificador dentro, no.
+      </li>
+    </ol>
+    <p>
+      El conversor de aquí está construido para pasar las dos comprobaciones, y hay
+      una versión más larga de este argumento en
+      <a href="../es-seguro-subir-archivos/">¿es seguro subir archivos?</a>.
+    </p>
+  </section>

--- a/locales/es/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/es/pages/guides/convert-heic-to-jpg.toml
@@ -1,0 +1,25 @@
+#
+# Guía: el formato en que guarda un iPhone, y cómo salir de él - Spanish.
+#
+# Overrides for pages/guides/convert-heic-to-jpg/page.toml. Only words: the
+# slug, the kind, the group and the tool this guide is about stay where they
+# are.
+#
+
+nav = "HEIC a JPG"
+
+title = "Cómo convertir HEIC a JPG (y qué es HEIC en realidad)"
+description = "Los iPhone guardan las fotos como HEIC, y media internet no sabe abrir una. Qué es el formato, por qué solo Safari lo descodifica, qué le cuesta a la imagen convertirla, y cómo hacerlo sin subirle las fotos a nadie."
+
+heading = "La foto que guardó tu móvil, y el formato que no abre nada"
+lede = """
+    Un iPhone guarda las fotos como HEIC, que es más pequeño y mejor que JPEG y
+    que muchísimo software se sigue negando a abrir. Esto es qué es el formato en
+    realidad, qué le cuesta a la imagen convertirla, y por qué casi todos los
+    conversores quieren que la subas primero."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Cómo convertir HEIC a JPG"
+og_description = "Por qué las fotos de iPhone no se abren, qué cuesta convertirlas, y cómo hacerlo sin entregarle las fotos a nadie."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/crop-a-video.html
+++ b/locales/es/pages/guides/crop-a-video.html
@@ -1,0 +1,210 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../recortar-video/">recortador de vídeo</a>, suelta el
+      clip dentro, arrastra la caja sobre la parte que quieras conservar &mdash;
+      o fíjala a una forma si te han dado una &mdash; y exporta. El clip que sale
+      dura exactamente lo mismo que el que entró, con su sincronía y su sonido
+      intactos.
+    </p>
+    <p>
+      A diferencia de cortar, esto sí tiene que escribir fotogramas nuevos. No es
+      una carencia de ninguna herramienta en concreto; es lo que es recortar. El
+      resto de esta página va de lo que cuesta eso y de cómo mantenerlo bajo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué recortar no puede evitar una recodificación</h2>
+    <p>
+      Un corte conserva fotogramas enteros, así que un buen cortador los traslada
+      intactos y no se descodifica nada. Un recorte conserva parte de cada
+      fotograma &mdash; y parte de un fotograma es otra imagen distinta. No hay
+      forma de guardar otra imagen sin escribir los píxeles de nuevo.
+    </p>
+    <p>
+      Hay una excepción muy estrecha, y conviene conocerla para reconocer cuándo
+      alguien la invoca. El vídeo se codifica en bloques, y si un recorte cayera
+      exactamente sobre los límites de bloque por los cuatro lados, parte de los
+      datos podría en principio reutilizarse. En la práctica, las propias
+      dimensiones del fotograma, los vectores de movimiento y la predicción hay
+      que reescribirlos igualmente, así que no se construye nada real de esa
+      manera. Da por hecho que un recorte significa una recodificación.
+    </p>
+    <p>
+      Lo que sí hará un recortador que se porte bien es no gastar <em>más</em> de
+      lo que gastaba el original en esa misma zona. Codificar una región recortada
+      a más bitrate que su origen solo hace el archivo más grande; no puede
+      devolver detalle que el original no tenía.
+    </p>
+  </section>
+
+  <section>
+    <h2>Las formas que te están pidiendo de verdad</h2>
+    <p>
+      Casi todos los recortes se hacen porque en algún sitio exigen una proporción
+      concreta. La lista corta:
+    </p>
+    <ul>
+      <li>
+        <strong>9:16 &mdash; vertical.</strong> Historias, reels, shorts, TikTok.
+        Pantalla completa en un móvil sostenido normalmente. La razón más común
+        por la que alguien recorta un vídeo.
+      </li>
+      <li>
+        <strong>1:1 &mdash; cuadrado.</strong> Publicaciones de feed en varias
+        plataformas. Funciona sostengas el móvil como lo sostengas, que es por lo
+        que sigue vivo.
+      </li>
+      <li>
+        <strong>4:5 &mdash; ligeramente vertical.</strong> La forma más grande que
+        permiten algunos feeds, así que ocupa más pantalla que un cuadrado sin ser
+        un vídeo vertical completo.
+      </li>
+      <li>
+        <strong>16:9 &mdash; horizontal.</strong> El estándar del vídeo en
+        general. Normalmente recortas <em>hacia</em> esto solo para quitar bandas
+        negras, o <em>desde</em> esto para llegar a alguna de las anteriores.
+      </li>
+    </ul>
+    <p>
+      Fija la caja a la proporción en vez de arrastrar a ojo. Quedarte a unos
+      pocos píxeles significa que la plataforma recorta tu recorte, y no te va a
+      consultar por dónde.
+    </p>
+  </section>
+
+  <section>
+    <h2>Convertir un clip horizontal en vertical</h2>
+    <p>
+      Este es el caso común más difícil, y conviene tener claro que recortar es un
+      apaño más que una solución.
+    </p>
+    <p>
+      Un vídeo 16:9 recortado a 9:16 conserva alrededor del 32&nbsp;% del ancho de
+      la imagen. Lo que haya a los lados desaparece &mdash; y en un plano
+      horizontal, los lados suelen ser donde está el contexto. Si hay dos personas
+      hablando en lados opuestos del encuadre, ningún recorte único conserva a las
+      dos.
+    </p>
+    <p>
+      Elige el recorte viendo el clip una vez y preguntándote dónde está de verdad
+      el sujeto la mayor parte del tiempo. Si la respuesta es «se mueve», un
+      recorte estático es la herramienta equivocada y lo que quieres es un editor
+      que pueda desplazar el recorte con el tiempo. Si la respuesta es «en el
+      centro, casi siempre», un recorte centrado sirve y lleva diez segundos.
+    </p>
+    <p>
+      La alternativa que conviene recordar: muchas plataformas aceptan un vídeo
+      horizontal y le ponen ellas las bandas. Recortar es para cuando quieres la
+      pantalla completa, no para cuando quieres que te acepten el vídeo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué el ancho y el alto se mueven de dos en dos</h2>
+    <p>
+      Si notas que la caja de recorte rechaza los números impares, es el códec y no
+      la interfaz lo que se está poniendo difícil.
+    </p>
+    <p>
+      H.264 &mdash; el códec que hay dentro de un MP4 &mdash; guarda el color a la
+      mitad de resolución en horizontal y en vertical, porque el ojo es mucho menos
+      sensible al detalle de color que al de brillo. Eso significa que la imagen se
+      maneja en unidades de dos píxeles y no hay forma de describir un fotograma
+      con un número impar de píxeles de lado.
+    </p>
+    <p>
+      Las herramientas se apañan con esto redondeando tu recorte después de que lo
+      fijes, lo que mueve tu caja un píxel sin decírtelo, o no ofreciendo nunca más
+      que números pares desde el principio. Lo segundo es lo que pasa aquí.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué le pasa al sonido</h2>
+    <p>
+      Nada, por la vía de MP4. Recortar cambia la imagen y no tiene ninguna razón
+      para tocar el audio, así que el audio se copia muestra a muestra sin
+      descodificarlo nunca &mdash; byte por byte lo que había en el archivo.
+    </p>
+    <p>
+      Por la alternativa de grabación, descrita más abajo, el sonido se captura de
+      la reproducción y se vuelve a codificar, lo que cuesta algo de calidad. En
+      cualquiera de los dos casos hay una casilla para dejarlo fuera del todo, que
+      merece la pena usar cuando el clip va a un sitio donde se reproduce sin
+      sonido igualmente y quieres el archivo más pequeño posible.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formatos, y cuánto tarda</h2>
+    <p>
+      <strong>MP4, M4V y MOV</strong> se leen directamente, lleven lo que lleven
+      dentro &mdash; H.264, HEVC, AV1 o VP9 &mdash;, siempre que tu navegador sepa
+      descodificar ese códec. A diferencia de cortar, recortar sí tiene que
+      descodificar, así que aquí el códec importa de una manera en que allí no.
+    </p>
+    <p>
+      <strong>Cualquier otra cosa que tu navegador sepa reproducir</strong>, WebM
+      la más evidente, se recorta reproduciéndola y grabando el resultado, lo que
+      funciona y tarda lo que dure el clip.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV y casi todos los MKV</strong> el navegador no los sabe
+      ni leer ni reproducir, y la herramienta los rechaza con un mensaje en vez de
+      fallar a mitad de camino.
+    </p>
+    <p>
+      Cuenta con que un recorte lleve su tiempo en un clip largo, porque cada
+      fotograma se está descodificando y recodificando. La herramienta no lleva
+      ningún límite dentro, y el archivo se recorre de unos pocos megabytes en unos
+      pocos megabytes en vez de cargarlo entero; el techo práctico es el vídeo
+      terminado, que se monta en memoria antes de que lo descargues.
+    </p>
+  </section>
+
+  <section>
+    <h2>Recorta antes de hacer cualquier otra cosa</h2>
+    <p>
+      Si un clip necesita corte y recorte, corta primero &mdash; es gratis, y cada
+      segundo que quitas es un segundo que nadie tiene que recodificar. Después
+      recorta el clip más corto una sola vez.
+    </p>
+    <p>
+      Hacerlo al revés significa recortar material que estás a punto de tirar, lo
+      que cuesta tiempo y calidad para nada. El
+      <a href="../../cortar-video/">cortador de vídeo</a> está al lado, y
+      <a href="../cortar-un-video/">su guía</a> explica por qué ese paso no tiene
+      por qué costarte nada en absoluto.
+    </p>
+    <p>
+      Y en general: cada paso con pérdidas se acumula. Un recorte de un original es
+      una generación. Un recorte de un corte de una exportación de una descarga son
+      cuatro, y se nota.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué esto no necesita una subida</h2>
+    <p>
+      Descodificar y recodificar vídeo en un navegador es reciente y es real:
+      WebCodecs expone el mismo codificador por hardware que usa tu móvil para
+      grabar vídeo, y es rápido por la misma razón. El trabajo ocurre en el equipo
+      que ya tiene el archivo, que para un vídeo de varios gigabytes es además la
+      única disposición con sentido &mdash; subirlo y descargar el resultado cuesta
+      más tiempo que la propia codificación.
+    </p>
+    <p>
+      La herramienta de aquí no tiene ninguna función de red, y la
+      <code>Content-Security-Policy</code> de la página nombra todas las
+      direcciones que puede contactar, ninguna de las cuales es de este sitio.
+      Desenchúfate de internet y recorta un clip de todos modos si prefieres
+      comprobarlo a que te lo cuenten.
+    </p>
+    <p>
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      hacerle a cualquier herramienta.
+    </p>
+  </section>

--- a/locales/es/pages/guides/crop-a-video.toml
+++ b/locales/es/pages/guides/crop-a-video.toml
@@ -1,0 +1,24 @@
+#
+# Guía: recortar un vídeo - Spanish.
+#
+# Overrides for pages/guides/crop-a-video/page.toml. Only words: the slug, the
+# kind, the group and the tool this guide is about stay where they are.
+#
+
+nav = "Recortar un vídeo"
+
+title = "Cómo recortar un vídeo a otra forma"
+description = "Deja un clip reducido a un cuadrado, a un vertical 9:16 o a una caja de píxeles exacta. Qué proporción quiere cada plataforma, por qué recortar tiene que recodificar cuando cortar no, y lo que eso cuesta."
+
+heading = "Cómo recortar un vídeo a otra forma"
+lede = """
+    Recortar cambia la forma de la imagen, lo que significa escribir fotogramas
+    nuevos &mdash; no hay manera de evitarlo, y cualquier herramienta que diga lo
+    contrario está haciendo otra cosa. Esto es lo que cuesta, y cómo gastarlo
+    bien."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Cómo recortar un vídeo a otra forma"
+og_description = "Qué proporción quiere cada plataforma, por qué recortar tiene que recodificar cuando cortar no, y lo que eso cuesta."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/embed-an-image-in-css.html
+++ b/locales/es/pages/guides/embed-an-image-in-css.html
@@ -1,0 +1,318 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre <a href="../../imagen-a-base64/">Imagen a data URI</a>, suelta la
+      imagen dentro, elige <em>una propiedad personalizada de CSS</em> y pega la
+      línea al principio de tu hoja de estilos. Después úsala como
+      <code>background-image: var(--logo)</code> donde te haga falta.
+    </p>
+    <p>
+      Hazlo cuando la imagen sea pequeña &mdash; un icono, una viñeta, una flecha,
+      un patrón &mdash; y haga falta en todas las páginas. No lo hagas con una
+      fotografía. Todo lo de abajo es por qué esas dos frases se contradicen, y
+      cómo saber cuál de los dos casos tienes delante.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué es en realidad un data URI</h2>
+    <p>
+      Una dirección que contiene la cosa en vez de apuntar a ella. Donde una hoja
+      de estilos diría normalmente
+    </p>
+    <pre><code>background-image: url("logo.png");</code></pre>
+    <p>
+      y el navegador va a buscar <code>logo.png</code>, un data URI dice
+    </p>
+    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <p>
+      y no hay nada que buscar: la imagen ya está ahí, escrita en caracteres. Tiene
+      tres partes. <code>data:</code> es el esquema. <code>image/png</code> es el
+      tipo de medio, y el navegador se lo cree por completo &mdash; más sobre eso
+      abajo. Todo lo que va después de la coma es el archivo.
+    </p>
+    <p>
+      Esa es la idea entera. No es ningún truco ni ningún apaño; está en los
+      estándares desde 1998 y funciona en todos los navegadores publicados desde
+      entonces.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lo que te compra: un viaje de ida y vuelta menos</h2>
+    <p>
+      El ahorro no es de ancho de banda. Es de la petición.
+    </p>
+    <p>
+      Un navegador no puede pedir <code>logo.png</code> hasta que ha leído la hoja
+      de estilos que lo menciona, y no puede leer la hoja de estilos hasta que se
+      la ha descargado. Así que una imagen de fondo corriente está al menos a dos
+      viajes de ida y vuelta de profundidad dentro de la carga de la página, y en
+      un móvil con red lenta un viaje de ida y vuelta pueden ser un par de cientos
+      de milisegundos por pequeño que sea el archivo. Una flecha de 600 bytes no
+      cuesta casi nada de transferir y puede costar igualmente un cuarto de segundo
+      en llegar.
+    </p>
+    <p>
+      Incrustada, llega con la hoja de estilos. Ese es el beneficio entero, y para
+      un icono pequeño que aparece en la primera pantalla es un beneficio de
+      verdad.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lo que cuesta: un tercio, y después la caché</h2>
+    <p>
+      <strong>Base64 añade alrededor de un tercio.</strong> Tres bytes de archivo
+      se convierten en cuatro caracteres, porque eso es lo que hace falta para
+      escribir bytes arbitrarios usando solo los caracteres que permite una URL. No
+      hay ningún codificador ingenioso que lo evite. Un PNG de 9 KB son 12 KB de
+      hoja de estilos.
+    </p>
+    <p>
+      <strong>La compresión no lo devuelve.</strong> Esta es la parte que la gente
+      da por supuesta. Gzip y Brotli funcionan encontrando redundancia, y un PNG,
+      un JPEG y un WebP ya vienen comprimidos &mdash; les queda muy poca
+      redundancia, y base64 no añade ninguna. En la práctica recuperas algo así
+      como una décima parte de ese tercio, no el tercio entero. (Un SVG es el caso
+      contrario, y el apartado siguiente va de eso.)
+    </p>
+    <p>
+      <strong>Deja de ser un archivo.</strong> Este es el coste que no aparece en
+      ninguna medición que sea probable que hagas, y es el que importa cuando la
+      cosa crece:
+    </p>
+    <ul>
+      <li>
+        <strong>No se puede cachear por su cuenta.</strong> Una imagen corriente
+        se descarga una vez y se reutiliza durante un año. Una incrustada es parte
+        de la hoja de estilos, así que vive y muere con la entrada de caché de la
+        hoja de estilos.
+      </li>
+      <li>
+        <strong>Cambiar cualquier cosa lo vuelve a descargar todo.</strong>
+        Arregla un margen, publica una hoja de estilos nueva, y todos los
+        visitantes se vuelven a descargar con ella la imagen incrustada &mdash; una
+        imagen que no ha cambiado en dos años.
+      </li>
+      <li>
+        <strong>Está en el camino crítico.</strong> Una hoja de estilos bloquea el
+        renderizado. Una imagen no. Incrustar una imagen la mueve de la segunda
+        categoría a la primera: la página no puede pintar hasta que ha llegado
+        todo, imagen incluida.
+      </li>
+      <li>
+        <strong>No se puede descargar en paralelo.</strong> Los navegadores bajan
+        muchas cosas a la vez. Una imagen incrustada no es una cosa aparte, así que
+        no se lleva nada de eso.
+      </li>
+    </ul>
+    <p>
+      Umbrales aproximados, que son donde cambia el consejo y no donde un navegador
+      haga nada distinto: por debajo de unos 2 KB es una victoria clara; hasta unos
+      10 KB suele seguir mereciendo la pena para algo que está en todas las
+      páginas; pasados los 50 KB es un error sin mensaje de error.
+      <a href="../../imagen-a-base64/">La herramienta</a> te dice en qué franja cae
+      cada resultado, con el número de caracteres al lado.
+    </p>
+  </section>
+
+  <section>
+    <h2>No pases nunca un SVG a base64</h2>
+    <p>
+      Este es el error más común de las imágenes incrustadas, y lo cometen los
+      exportadores y los complementos de compilación tanto como las personas.
+    </p>
+    <p>
+      Un SVG es texto. Una URL ya lleva texto. Solo hay que escapar un puñado de
+      caracteres &mdash; <code>%</code>, <code>#</code>, <code>&lt;</code>,
+      <code>&gt;</code> y la comilla con la que lo hayas envuelto &mdash; y todo lo
+      demás se puede dejar exactamente como está. Codificarlo así da un URI que
+      suele ser una quinta parte más corto que el base64 del mismo archivo, y que
+      después se comprime como texto en vez de como ruido.
+    </p>
+    <p>
+      Y además sigue siendo legible:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <p>
+      Ves el <code>viewBox</code>. Puedes cambiar el color de relleno en tu editor
+      sin descodificar nada. Pasa el mismo archivo a base64 y se convierte en un
+      muro de letras que nadie va a volver a tocar jamás.
+      <a href="../../imagen-a-base64/">Imagen a data URI</a> hace esto
+      automáticamente con todo lo que resulte ser un SVG, y tiene una casilla para
+      esa rara cadena de herramientas que insiste en <code>;base64</code>.
+    </p>
+  </section>
+
+  <section>
+    <h2>El error de comillas que solo rompe los SVG</h2>
+    <p>
+      CSS te deja escribir <code>url()</code> sin comillas, y para un nombre de
+      archivo corriente eso está bien:
+    </p>
+    <pre><code>background-image: url(logo.png);</code></pre>
+    <p>
+      Haz lo mismo con un SVG codificado con porcentajes y se rompe. Un token
+      <code>url()</code> sin comillas termina en el primer espacio, paréntesis,
+      comilla o carácter de control &mdash; y un SVG está lleno de espacios, entre
+      cada atributo y cada número de un trazado. La declaración queda entonces
+      inválida, CSS descarta las declaraciones inválidas en silencio, y te quedas
+      sin fondo y sin error.
+    </p>
+    <p>
+      La solución son comillas, siempre:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
+    <p>
+      Es además la razón de que un codificador no necesite escapar los espacios
+      &mdash; son perfectamente legales dentro de una URL entrecomillada, y escapar
+      cada uno como <code>%20</code> costaría tres caracteres por cada espacio del
+      archivo. Las dos decisiones van juntas: entrecomilla el URI y podrás dejar
+      los espacios en paz. Todas las formas que produce la herramienta van
+      entrecomilladas exactamente por esto.
+    </p>
+  </section>
+
+  <section>
+    <h2>El tipo de medio tiene que estar bien</h2>
+    <p>
+      Un data URI declara su propio tipo, y el navegador se lo cree. No hay ninguna
+      detección de reserva como la hay para un archivo descargado: di
+      <code>image/png</code> de algo que en realidad es un JPEG y la imagen no se
+      dibuja, sin ningún mensaje en ningún sitio útil.
+    </p>
+    <p>
+      Cosa que importa porque las extensiones de archivo mienten. Una foto
+      exportada como JPEG y renombrada <code>logo.png</code> es algo corriente de
+      encontrarse en un disco. Los primeros bytes de un archivo de imagen, en
+      cambio, dicen sin ambigüedad qué es &mdash; todos los formatos tienen una
+      firma &mdash;, así que una herramienta debería leer el archivo y no su
+      nombre. La de aquí lo hace, y te avisa cuando los dos no coinciden.
+    </p>
+    <p>
+      Hay dos formatos que conviene conocer porque fallan de forma confusa.
+      <strong>HEIC</strong>, que es en lo que fotografía un iPhone, y
+      <strong>TIFF</strong>, que es lo que producen los escáneres, hacen los dos
+      data URI perfectamente válidos que ningún navegador salvo Safari va a
+      dibujar. El URI no está roto; sencillamente el formato no es de los que la
+      web soporta. Conviértelos antes.
+    </p>
+  </section>
+
+  <section>
+    <h2>Los metadatos que no querías publicar</h2>
+    <p>
+      Un data URI es una copia del archivo, byte por byte. No se descodifica ni se
+      recodifica nada, que suele ser el sentido de todo esto &mdash; no se pierde
+      calidad &mdash;, pero también significa que todo lo demás del archivo se
+      viene contigo.
+    </p>
+    <p>
+      Una fotografía recién salida de un móvil lleva EXIF: las coordenadas GPS del
+      sitio donde se tomó, la marca de tiempo, el modelo de cámara y muchas veces
+      su número de serie. Eso pueden ser 30 KB del archivo. Incrustado, se
+      convierte en 40 KB de base64 dentro de tu hoja de estilos, en el camino
+      crítico de todas las páginas &mdash; y en una dirección de casa metida en un
+      repositorio, en una forma en la que nadie va a pensar en mirar.
+    </p>
+    <p>
+      Quítalo antes con el <a href="../../eliminar-datos-exif/">visor y eliminador
+      de EXIF</a>, que reescribe el contenedor sin tocar la imagen; también hay una
+      <a href="../eliminar-datos-exif-y-gps/">guía sobre eso</a>. Imagen a data URI
+      lee cuántos metadatos hay en un JPEG, un PNG o un WebP y lo dice antes de que
+      copies nada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dónde ponerlo, una vez que lo tienes</h2>
+    <p>
+      Si la imagen aparece en una regla, pon el URI en esa regla. Si aparece en más
+      de una &mdash; y los iconos suelen hacerlo, en cuanto cuentas el estado de
+      hover y el tema oscuro &mdash;, decláralo una vez como propiedad
+      personalizada:
+    </p>
+    <pre><code>:root {
+  --icono-buscar: url("data:image/svg+xml,%3Csvg ... %3E");
+}
+
+.campo-busqueda { background-image: var(--icono-buscar); }
+.boton-busqueda::before { content: var(--icono-buscar); }</code></pre>
+    <p>
+      Un URI de 3 KB pegado en cuatro reglas son 12 KB de hoja de estilos y cuatro
+      sitios que editar cuando cambie el icono. La propiedad personalizada es uno
+      de cada. Es además la forma que hace que los temas funcionen: redefine
+      <code>--icono-buscar</code> dentro de una media query y todos sus usos van
+      detrás.
+    </p>
+    <p>
+      Para una etiqueta <code>&lt;img&gt;</code> en vez de CSS, incluye
+      <code>width</code> y <code>height</code>. Una imagen incrustada carga al
+      instante, así que un tamaño ausente es un salto de maquetación que ocurre
+      demasiado rápido para verlo y que te sigue contando en contra. La excepción
+      es el SVG: uno que solo lleva un <code>viewBox</code> no tiene tamaño propio
+      en píxeles, y escribir en la etiqueta los 300&times;150 por defecto del
+      navegador clava una imagen escalable a un tamaño que no eligió nadie.
+    </p>
+    <p>
+      Deja el <code>alt</code> vacío salvo que tengas algo cierto que poner ahí.
+      Solo tú sabes si la imagen lleva significado o es decoración, y una
+      descripción adivinada a partir de un nombre de archivo es peor para alguien
+      que use un lector de pantalla que no tener ninguna descripción.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cuando la respuesta es «no lo hagas»</h2>
+    <p>
+      Si la imagen pasa de unos 50 KB codificada, incrustarla es la herramienta
+      equivocada y no hay cuidado con la codificación que lo arregle. Las
+      alternativas, en el orden en que merece la pena probarlas:
+    </p>
+    <ul>
+      <li>
+        <strong>Hazla más pequeña.</strong> Casi todas las imágenes que son
+        demasiado grandes para incrustarlas son demasiado grandes en general. El
+        <a href="../../comprimir-imagen/">compresor de imágenes</a> te dejará una
+        fotografía en un tamaño que tú digas, y el
+        <a href="../../redimensionar-imagen/">redimensionador de imágenes</a>
+        recortará las dimensiones en píxeles hasta lo que usa de verdad la
+        maquetación &mdash; que muy a menudo es el problema real.
+      </li>
+      <li>
+        <strong>Redibújala como SVG.</strong> Un icono exportado como PNG de 40 KB
+        es con frecuencia un SVG de 900 bytes. Eso no es una diferencia de
+        compresión, es una diferencia de formato, y además resuelve el problema de
+        las pantallas retina.
+      </li>
+      <li>
+        <strong>Déjala como archivo y precárgala.</strong>
+        <code>&lt;link rel="preload" as="image"&gt;</code> arranca la descarga de
+        inmediato sin mover los bytes al camino crítico. Se lleva casi todo el
+        beneficio de incrustar y ninguno del coste de caché.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Nada de esto necesita una subida</h2>
+    <p>
+      Codificar un archivo en base64 es aritmética. Son dos funciones que el
+      navegador tiene desde el principio &mdash; <code>btoa</code> y
+      <code>encodeURIComponent</code> &mdash; y no hay absolutamente ninguna razón
+      técnica para que una imagen viaje a un servidor y vuelva para acabar escrita
+      de otra manera. Cualquier conversor que suba tu archivo para hacer esto lo
+      está subiendo por sus propios motivos, no por los tuyos.
+    </p>
+    <p>
+      <a href="../../imagen-a-base64/">La herramienta de aquí</a> no lo manda a
+      ninguna parte: la <code>Content-Security-Policy</code> de la página nombra
+      todas las direcciones que puede contactar, y ninguna es de este sitio. Carga
+      la página, desenchúfate de internet y codifica algo de todos modos si
+      prefieres comprobarlo a que te lo cuenten.
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      hacerle a cualquier herramienta.
+    </p>
+  </section>

--- a/locales/es/pages/guides/embed-an-image-in-css.toml
+++ b/locales/es/pages/guides/embed-an-image-in-css.toml
@@ -1,0 +1,26 @@
+#
+# Guía: meter una imagen dentro de una hoja de estilos - Spanish.
+#
+# Overrides for pages/guides/embed-an-image-in-css/page.toml. Only words: the
+# slug, the kind, the group and the tool this guide is about stay where they
+# are.
+#
+
+nav = "Incrustar una imagen en CSS"
+
+title = "Data URI en CSS: cuándo incrustar una imagen y cuándo no"
+description = "Lo que cuesta un data URI, por qué base64 añade un tercio y gzip no lo devuelve, por qué un SVG nunca debería ir en base64, y el error de comillas que rompe los SVG incrustados en silencio."
+
+heading = "Cuándo meter una imagen dentro de tu CSS y cuándo no"
+lede = """
+    Una imagen escrita dentro de una hoja de estilos llega con ella: sin una
+    segunda petición y sin esperas. También deja de ser un archivo &mdash; así
+    que no se puede cachear por su cuenta, y se vuelve a descargar cada vez que
+    cambia algo a su alrededor. Esto es dónde merece la pena hacer ese trato, y
+    dónde en silencio no."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Cuándo meter una imagen dentro de tu CSS"
+og_description = "Lo que cuesta un data URI, por qué un SVG nunca debería ir en base64, y el error de comillas que rompe los SVG incrustados en silencio."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/es/pages/guides/is-it-safe-to-upload-files.html
@@ -1,0 +1,255 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Para casi todos los archivos, y casi siempre, subirlos no pasa nada. Los
+      conversores serios borran lo que les mandas en unas pocas horas y no tienen
+      ningún interés en tus fotos de vacaciones.
+    </p>
+    <p>
+      El problema no es que estén mintiendo. Es que
+      <strong>no tienes forma de saber si lo hacen</strong>. Una vez que un
+      archivo sale de tu equipo, cada promesa sobre lo que pasa después es una
+      promesa que te estás creyendo: cuánto tiempo se guarda, quién puede
+      alcanzarlo, si se copia a una copia de seguridad que sobreviva al
+      temporizador de borrado, qué le pasa si la empresa se vende o sufre una
+      brecha. Nada de eso se ve desde fuera.
+    </p>
+    <p>
+      Así que la pregunta útil no es «¿me fío de este sitio?». Es
+      <strong>«¿necesita este trabajo que mi archivo salga de aquí?»</strong>.
+      Para un número grande y creciente de trabajos la respuesta es que no, y
+      cuando la respuesta es que no, la pregunta de la confianza deja de ser una
+      pregunta que tengas que responder.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué hace de verdad una «subida»</h2>
+    <p>
+      Cuando un conversor te pide que elijas un archivo y después te enseña una
+      barra de progreso, tu navegador está copiando el archivo entero, byte por
+      byte, a través de internet hasta un ordenador que es de otra persona. Ese
+      ordenador lo escribe en un disco, ejecuta la conversión, escribe el
+      resultado en el mismo disco y te da un enlace.
+    </p>
+    <p>
+      En ese momento tu archivo existe en al menos tres sitios que no elegiste: el
+      disco del servidor, los registros que hayan anotado la petición, y muchas
+      veces una red de distribución de contenidos que ha cacheado el resultado para
+      que la descarga sea rápida. Una política de borrado tiene que alcanzar los
+      tres. Casi todas dicen que lo hacen. Tú no puedes comprobar ninguno.
+    </p>
+    <p>
+      Conviene saber además que el archivo no es lo único que llega. El nombre del
+      archivo va con él, y también todo lo que hay dentro del archivo y que tú no
+      ves. Una foto recién salida de un móvil suele llevar las coordenadas GPS
+      exactas del sitio donde se tomó, la hora, el número de serie de la cámara y a
+      veces una miniatura incrustada de la imagen original de antes de que la
+      recortaras. La gente que tiene cuidado con la imagen muchas veces no lo tiene
+      con eso, porque nada en pantalla se lo enseña.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué casi todas las herramientas suben de todas formas</h2>
+    <p>
+      No porque quieran tus archivos. Porque durante casi toda la vida de la web no
+      había alternativa. Un navegador no podía descodificar un vídeo, recodificar
+      una imagen a una calidad elegida ni analizar un formato de archivo; un
+      servidor con FFmpeg e ImageMagick sí. Subir cosas no era un modelo de
+      negocio, era el único sitio donde podía ocurrir el trabajo.
+    </p>
+    <p>
+      Eso dejó de ser cierto hace poco y sin ruido. Los navegadores traen hoy
+      WebAssembly, que ejecuta los mismos códecs compilados a una velocidad cercana
+      a la nativa; WebCodecs, que expone el codificador de vídeo por hardware que
+      ya está en tu equipo; y una API de lienzo que puede descodificar y
+      recodificar imágenes directamente. El trabajo para el que hacía falta un
+      servidor ocurre ahora en el dispositivo que ya tiene el archivo.
+    </p>
+    <p>
+      Muchas herramientas siguen subiendo, y hay razones honestas: una cadena de
+      procesos que nadie quiere reescribir, un formato sin descodificador del lado
+      del navegador, un trabajo genuinamente demasiado pesado para un móvil. Hay
+      también una razón menos honesta, y es que un servidor es donde viven las
+      cuentas, las cuotas y los planes de pago. Una herramienta que funciona por
+      completo en tu navegador es difícil de medir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cuatro comprobaciones que puedes hacer tú</h2>
+    <p>
+      Funcionan con cualquier herramienta, esta incluida. Ninguna exige creerse la
+      palabra de nadie, y la primera lleva unos diez segundos.
+    </p>
+
+    <h3>1. Desenchufa</h3>
+    <p>
+      Carga la página, apaga el wifi o desenchufa el cable, e intenta usarla. Una
+      herramienta que hace su trabajo en tu navegador sigue exactamente igual que
+      antes. Una herramienta que sube se detiene de inmediato, porque lo que hacía
+      el trabajo ya no está a su alcance.
+    </p>
+    <p>
+      Esta es la prueba más fuerte que hay, y la más difícil de fingir, porque no
+      se puede responder con palabras. O la conversión termina sin red o no
+      termina.
+    </p>
+
+    <h3>2. Mira la pestaña Red</h3>
+    <p>
+      Abre las herramientas de desarrollo de tu navegador, elige Red y usa después
+      la herramienta. Todas las peticiones que hace la página aparecen listadas con
+      su tamaño. Si tu foto de 4&nbsp;MB se ha subido, hay una petición de
+      4&nbsp;MB en esa lista. Si lo más grande que sale de la página son unos pocos
+      kilobytes de publicidad, no se ha subido.
+    </p>
+    <p>
+      Ordena por tamaño y mira lo de arriba. No necesitas entender las peticiones;
+      necesitas fijarte en si alguna tiene el tamaño de tu archivo.
+    </p>
+
+    <h3>3. Lee la Content-Security-Policy</h3>
+    <p>
+      Mira el código fuente de la página y busca
+      <code>Content-Security-Policy</code>, cerca del principio. Es una lista de
+      las direcciones que esa página tiene permitido contactar, y la hace cumplir
+      tu navegador en vez de las buenas intenciones del sitio &mdash; una petición
+      a algo que no esté en la lista se rechaza, intente lo que intente el código.
+    </p>
+    <p>
+      La directiva que importa es <code>connect-src</code>, que rige adónde puede
+      enviar datos la página. Si nombra una dirección que pertenece al sitio en el
+      que estás, la página puede mandar tu archivo ahí. Si no nombra nada, o solo
+      terceros como una red publicitaria, no puede.
+    </p>
+    <p>
+      Una página sin ninguna Content-Security-Policy no es prueba de nada malo.
+      Solo significa que esta comprobación en concreto no tiene nada que decirte.
+    </p>
+
+    <h3>4. Lee el código</h3>
+    <p>
+      La menos cómoda y la más concluyente. Si una herramienta publica su código
+      fuente y lo sirve sin ningún paso de compilación, los archivos que se ha
+      bajado tu navegador son los archivos que puedes leer. Búscales
+      <code>fetch</code>, <code>XMLHttpRequest</code> y <code>sendBeacon</code>
+      &mdash; las tres formas que tiene una página de enviar algo &mdash; y mira
+      qué se les entrega.
+    </p>
+    <p>
+      Casi nadie va a hacer esto. Sigue importando que sea posible, porque una
+      afirmación que nadie puede comprobar no es realmente una afirmación.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lo que «funciona en tu navegador» no significa</h2>
+    <p>
+      Conviene ser preciso, porque la frase se usa a la ligera y este sitio tiene
+      que exigirse el mismo listón que está proponiendo.
+    </p>
+    <ul>
+      <li>
+        <strong>No significa ninguna petición en absoluto.</strong> La propia
+        página llegó por la red, y casi todas las herramientas gratuitas llevan
+        publicidad o analítica que hablan con alguien. La afirmación va de tu
+        <em>archivo</em>, no del tráfico en general.
+      </li>
+      <li>
+        <strong>No esconde tu dirección IP.</strong> Todos los sitios que visitas
+        la ven, este incluido. El procesamiento local va del contenido de tus
+        archivos, no del anonimato.
+      </li>
+      <li>
+        <strong>No sobrevive a una función que descarga algo.</strong> Una
+        herramienta que te deja pegar una dirección web tiene que contactar con esa
+        dirección, y ese servidor se entera de tu IP y de qué has pedido. Eso es
+        inherente a la función y no un defecto suyo &mdash; pero es una excepción
+        real y una herramienta debería decirlo con claridad en vez de
+        redondearla.
+      </li>
+      <li>
+        <strong>No es lo mismo que «borramos tus archivos».</strong> La segunda
+        frase va de lo que una empresa decide hacer. La primera va de lo que es
+        técnicamente posible. Solo una de las dos se puede comprobar.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Cuándo subir está genuinamente bien</h2>
+    <p>
+      Esto no es un argumento de que toda subida sea un error. Manda el archivo
+      cuando el contenido no sea sensible y el trabajo sea más fácil así; cuando el
+      trabajo sea de verdad demasiado pesado para tu dispositivo; cuando el formato
+      no tenga descodificador del lado del navegador; o cuando estés usando un
+      servicio con el que ya tienes una relación y cuyas condiciones te has leído de
+      verdad.
+    </p>
+    <p>
+      Ten más cuidado cuando el archivo contenga algo que no publicarías:
+      documentos de identidad, pruebas médicas, contratos, cualquier cosa con una
+      dirección o una cara que no pretendías compartir, o una foto cuyos datos de
+      ubicación no has mirado. Para esos, una herramienta que puedes comprobar
+      merece preferirse a una herramienta en la que tienes que confiar &mdash; no
+      porque sea probable que la de confianza te traicione, sino porque con la
+      comprobable la pregunta ni se plantea.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cómo responde este sitio a esas cuatro comprobaciones</h2>
+    <p>
+      Sería una guía muy rara la que te dijera que compruebes y después pidiera
+      quedar exenta. Así que, por orden:
+    </p>
+    <ul>
+      <li>
+        <strong>Desenchufa.</strong> Abre cualquier herramienta de aquí,
+        desconéctate, y sigue funcionando. Cada página de herramienta tiene un
+        indicador en directo que dice si estás conectado ahora mismo, así que
+        puedes verlo cambiar.
+      </li>
+      <li>
+        <strong>Pestaña Red.</strong> Convierte algo y lee la lista. Nada lleva tu
+        archivo, ni una miniatura suya, ni su nombre, ni su tamaño, ni nada leído
+        de dentro de él. En este sitio no hay ningún evento de analítica propio que
+        tenga nada de eso que enviar.
+      </li>
+      <li>
+        <strong>Content-Security-Policy.</strong> Está al principio del código
+        fuente de todas las páginas. <code>connect-src</code> nombra los puntos
+        finales de publicidad y medición de Google y el botón de donación, y nada
+        más. <strong>Ninguna dirección de esa lista pertenece a este sitio</strong>,
+        porque este sitio no tiene servidor &mdash; son archivos estáticos. No hay
+        ningún sitio al que enviar un archivo aunque algo lo intentara.
+      </li>
+      <li>
+        <strong>Código.</strong> Todas las líneas son
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">públicas</a>.
+        La compilación quita comentarios y espacios en blanco y nada más, y puedes
+        ejecutarla tú mismo y comparar el resultado con lo que se está sirviendo.
+      </li>
+    </ul>
+    <p>
+      Las excepciones, declaradas en vez de escondidas: este sitio lleva publicidad
+      de Google y un contador de visitas, que hablan los dos con Google y a ninguno
+      de los cuales se le entrega nada sobre tus archivos; y la herramienta
+      <a href="../../imagenes-a-video/">Imágenes a vídeo</a> puede descargar una
+      imagen desde una dirección que pegues tú, lo que significa que ese servidor ve
+      tu IP. La <a href="../../privacidad/">página de privacidad</a> explica las dos
+      por completo.
+    </p>
+    <p>
+      Todas las herramientas de aquí funcionan así: un
+      <a href="../../comprimir-imagen/">compresor de imágenes</a> que acierta un
+      tamaño que tú digas, un <a href="../../recortar-video/">recortador de
+      vídeo</a>, un <a href="../../eliminar-datos-exif/">visor y eliminador de
+      EXIF</a> para los datos ocultos descritos más arriba en esta página,
+      <a href="../../imagenes-a-video/">imágenes a vídeo</a> e
+      <a href="../../imagenes-a-pdf/">imágenes a PDF</a>. Todas gratuitas, sin
+      cuenta, y ninguna tiene adónde mandar tus archivos.
+    </p>
+  </section>

--- a/locales/es/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/es/pages/guides/is-it-safe-to-upload-files.toml
@@ -1,0 +1,24 @@
+#
+# Guía: ¿es seguro subir archivos a los conversores en línea? - Spanish.
+#
+# Overrides for pages/guides/is-it-safe-to-upload-files/page.toml. Only words:
+# the slug, the kind and the guides group this page joins stay where they are.
+#
+
+nav = "¿Es seguro subir archivos?"
+
+title = "¿Es seguro subir archivos a los conversores en línea?"
+description = "Casi todos los conversores en línea mandan tu archivo a un servidor. Qué significa eso, qué le pasa ahí, y cuatro comprobaciones que te dicen si una herramienta lo necesita de verdad."
+
+heading = "¿Es seguro subir archivos a los conversores en línea?"
+lede = """
+    Normalmente la respuesta honesta es «probablemente, pero no puedes
+    comprobarlo». Esto explica qué le hace de verdad una subida a tu archivo, por
+    qué casi todas las herramientas siguen haciéndola, y cuatro pruebas que te
+    dicen si la que tienes delante la necesita."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "¿Es seguro subir archivos a los conversores en línea?"
+og_description = "Qué le pasa a un archivo que subes a un conversor, por qué casi todas las herramientas siguen pidiéndotelo, y cuatro comprobaciones que puedes hacer tú."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/make-a-favicon.html
+++ b/locales/es/pages/guides/make-a-favicon.html
@@ -1,0 +1,335 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre <a href="../../crear-favicon/">Imagen a ICO</a>, suelta dentro una
+      imagen cuadrada de al menos 256 píxeles, deja el preajuste en <em>favicon
+      de una web</em> y descarga <code>favicon.ico</code>. Ponlo en la raíz de tu
+      sitio, de modo que responda en
+      <code>https://tusitio.com/favicon.ico</code>. Esa dirección la pide
+      cualquier navegador mencione o no tu HTML, así que estrictamente no hay nada
+      más que tengas que hacer.
+    </p>
+    <p>
+      Todo lo de abajo es la parte que marca la diferencia entre un icono que está
+      técnicamente presente y uno que se lee: qué tamaños entran, qué piden en su
+      lugar los iPhone y Android, y qué hacer cuando tu logotipo no sobrevive a
+      medir dieciséis píxeles de ancho.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué es un conjunto de tamaños y no una imagen</h2>
+    <p>
+      Un archivo <code>.ico</code> es un contenedor. Dentro hay varias imágenes
+      completas de la misma cosa a tamaños distintos, y quien esté leyendo el
+      archivo escoge la más cercana al tamaño que necesita.
+    </p>
+    <p>
+      Eso suena a redundancia y no lo es. Un navegador que dibuja tu icono a
+      dieciséis píxeles tiene dos opciones: leer una versión de dieciséis píxeles
+      que hayas dibujado tú, o encoger una más grande sobre la marcha. Lo segundo
+      es peor, y de forma visible &mdash; un encogido automático de un logotipo
+      detallado produce papilla, mientras que una versión de dieciséis píxeles que
+      has mirado es algo que has tenido la oportunidad de simplificar. La razón
+      entera de que el formato guarde varios tamaños es darte esa oportunidad.
+    </p>
+    <p>
+      Tres tamaños es la convención para una web, y cada uno tiene su razón:
+    </p>
+    <ul>
+      <li>
+        <strong>16&times;16</strong> &mdash; la pestaña del navegador, la barra de
+        direcciones, el menú de marcadores. Este es el que ve la gente. Si solo
+        vas a acertar con uno, acierta con este.
+      </li>
+      <li>
+        <strong>32&times;32</strong> &mdash; una barra de marcadores, un acceso
+        directo de escritorio de Windows a tu sitio, y casi todos los navegadores
+        en una pantalla de alta densidad, que dibujan el icono de la pestaña a
+        partir de 32 y lo reducen.
+      </li>
+      <li>
+        <strong>48&times;48</strong> &mdash; el tamaño al que Google lee el icono
+        de un sitio para los resultados de búsqueda, y la vista de iconos medianos
+        de Windows.
+      </li>
+    </ul>
+    <p>
+      Cualquier cosa más grande va en un PNG al lado del <code>.ico</code>, no
+      dentro, por razones que aparecen más abajo con los archivos para móvil.
+    </p>
+  </section>
+
+  <section>
+    <h2>El problema de los dieciséis píxeles</h2>
+    <p>
+      Esta es la parte de la que nadie te avisa. Dieciséis píxeles son unos cuatro
+      milímetros en una pantalla normal: una rejilla de 256 puntos en total, menos
+      que las letras de esta frase. Casi nada diseñado para funcionar en un cartel,
+      en una tarjeta de visita o en la cabecera de una web sobrevive a reducirse a
+      eso.
+    </p>
+    <p>
+      Lo que desaparece, por orden:
+    </p>
+    <ul>
+      <li>
+        <strong>El texto.</strong> Un logotipo de palabra encogido dentro de un
+        cuadrado tiene unos tres píxeles de alto. No se convierte en texto
+        pequeño, se convierte en una barra gris. Por eso casi todas las empresas
+        que tienen un símbolo además de un nombre usan solo el símbolo como
+        favicon, y las que no tienen símbolo usan una sola letra.
+      </li>
+      <li>
+        <strong>Las líneas finas.</strong> Un borde de un píxel en un logotipo de
+        512 píxeles es una treintaidosava parte de un píxel a dieciséis. Se dibuja
+        como una neblina gris tenue a lo largo del borde, o desaparece.
+      </li>
+      <li>
+        <strong>Los degradados y las sombras.</strong> No hay sitio para una
+        transición. Una sombra suave se convierte en un fleco sucio.
+      </li>
+      <li>
+        <strong>El detalle dentro del detalle.</strong> Un icono de un documento
+        con algo escrito encima se convierte en un rectángulo con un borrón.
+      </li>
+    </ul>
+    <p>
+      La solución no es un ajuste, es otro dibujo: una marca simplificada con una o
+      dos formas, mucho contraste y nada de texto más allá de un solo carácter.
+      Dibuja esa versión a 32 o 48 píxeles a propósito, y úsala como origen.
+    </p>
+    <p>
+      Lo que una herramienta sí puede hacer es enseñarte el problema antes de que
+      lo publiques. La vista previa de <a href="../../crear-favicon/">Imagen a
+      ICO</a> dibuja cada tamaño a su tamaño real en pantalla, que es la única
+      forma de juzgar esto &mdash; un icono de dieciséis píxeles mostrado a sesenta
+      y cuatro se ve bien y no te dice nada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tu logotipo no es cuadrado. ¿Rellenar o recortar?</h2>
+    <p>
+      Un icono siempre es cuadrado, y casi ningún logotipo lo es, así que algo
+      tiene que pasar. Hay tres respuestas y no son igual de buenas.
+    </p>
+    <p>
+      <strong>Rellenar</strong> conserva la imagen entera y le pone espacio arriba
+      y abajo. Es el valor por defecto seguro y la elección equivocada para un
+      logotipo de palabra ancho: meter algo tres veces más ancho que alto dentro
+      de un cuadrado lo deja ocupando un tercio del alto, que a dieciséis píxeles
+      son cinco píxeles de logotipo y once de nada.
+    </p>
+    <p>
+      <strong>Recortar al centro</strong> saca el mayor cuadrado del medio. Para un
+      conjunto &mdash; un símbolo con el nombre de la empresa al lado &mdash; esto
+      muchas veces corta por la mitad los dos. Mejor recorta el original tú
+      primero, dejando solo el símbolo, y convierte eso.
+    </p>
+    <p>
+      <strong>Estirar</strong> aplasta la imagen para que quepa. Casi no hay
+      ninguna situación en la que esto sea lo correcto, y se ofrece sobre todo para
+      que la herramienta no lo esté haciendo en silencio.
+    </p>
+    <p>
+      La respuesta general para un logotipo ancho: no conviertas el logotipo.
+      Convierte la parte de él que funciona sola.
+    </p>
+  </section>
+
+  <section>
+    <h2>¿Transparente o con fondo sólido?</h2>
+    <p>
+      Transparente suele ser lo correcto para una web. Las pestañas del navegador
+      son grises, blancas o casi negras según el navegador y el tema, y un icono
+      transparente se apoya en todas. Un icono con un fondo blanco pintado es un
+      rectángulo blanco en una barra de pestañas oscura.
+    </p>
+    <p>
+      Dos excepciones que conviene conocer:
+    </p>
+    <ul>
+      <li>
+        <strong>Un logotipo que es oscuro y nada más</strong> desaparece en modo
+        oscuro. Si tu marca es negra sobre blanco por naturaleza, dale un fondo de
+        color en vez de uno transparente, o un contorno claro.
+      </li>
+      <li>
+        <strong>El icono táctil de Apple tiene que ser opaco.</strong> iOS lo
+        dibuja sobre su propio mosaico redondeado y convierte la transparencia en
+        negro. Cualquier herramienta que produzca ese archivo debería aplanarlo por
+        ti; la de aquí lo hace, sobre blanco por defecto.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Los archivos que necesita una web y que no son el .ico</h2>
+    <p>
+      <code>favicon.ico</code> cubre los navegadores y Windows. No cubre los
+      móviles, y aquí es donde casi todos los conjuntos de iconos caseros se paran
+      demasiado pronto. Otras tres plataformas piden sus propios archivos, con sus
+      propios nombres, y ninguna va a mirar dentro de un <code>.ico</code>:
+    </p>
+    <ul>
+      <li>
+        <strong>iOS</strong> lee <code>apple-touch-icon.png</code> a
+        180&times;180 cuando alguien añade tu sitio a su pantalla de inicio. Sin
+        él, iOS usa una captura de la página, que parece un error.
+      </li>
+      <li>
+        <strong>Android y cualquier aviso de instalación</strong> leen un
+        manifiesto de aplicación web &mdash; <code>site.webmanifest</code>
+        &mdash;, que apunta a PNG de 192 y de 512 píxeles. El de 512 es además lo
+        que enseña una aplicación web en su pantalla de arranque.
+      </li>
+      <li>
+        <strong>Un mosaico del menú Inicio de Windows</strong> lee
+        <code>browserconfig.xml</code>, que apunta a un PNG de 150&times;150. El
+        menos importante de los tres, y cuatro líneas de XML.
+      </li>
+    </ul>
+    <p>
+      Hay uno más que es fácil de hacer mal: los lanzadores de Android recortan un
+      icono adaptativo a la forma que le guste al móvil &mdash; círculo, cuadrado
+      redondeado, «squircle» &mdash; y solo se garantiza que sobreviva el 80&nbsp;%
+      central de la imagen. Un icono dibujado de borde a borde pierde las esquinas.
+      Eso es lo que es un icono <em>enmascarable</em>: la misma imagen dibujada
+      deliberadamente pequeña dentro del cuadrado, declarada aparte en el
+      manifiesto.
+    </p>
+    <p>
+      Marcar el conjunto para web en <a href="../../crear-favicon/">Imagen a
+      ICO</a> produce todos ellos, el manifiesto y el bloque de HTML que apunta a
+      ellos. Una cosa que ese bloque deja fuera a propósito es un
+      <code>&lt;link&gt;</code> para <code>favicon.ico</code>: los navegadores
+      piden esa dirección por su cuenta, y nombrarla además hace que el mismo
+      archivo se descargue dos veces.
+    </p>
+  </section>
+
+  <section>
+    <h2>El icono de una aplicación de Windows es otro conjunto</h2>
+    <p>
+      Si el icono es para un programa y no para un sitio, los tamaños cambian. Lo
+      que contiene el <code>app.ico</code> que trae por defecto el propio Visual
+      Studio es 16, 32, 48 y 256 &mdash; los tres tamaños del shell más el grande
+      del que dibujan el menú Inicio y la vista extragrande del Explorador.
+    </p>
+    <p>
+      En una pantalla de alta densidad Windows pide además 20, 24, 40, 64 y 96, y
+      los remuestrea del tamaño más cercano que tenga cuando faltan. Que eso importe
+      o no depende de tu icono: una forma plana sobrevive al remuestreo, una
+      detallada no. Añadirlos más o menos duplica el archivo, que para una
+      aplicación no es nada &mdash; la cuenta es completamente distinta de la de un
+      favicon, donde el archivo se lo descarga cada visitante.
+    </p>
+    <p>
+      Una cosa más sobre el tamaño: la entrada de 256 es donde están los bytes.
+      Guardada sin comprimir son 264&nbsp;KB ella sola; guardada como PNG dentro
+      del icono suele quedarse por debajo de 30. Las entradas PNG se leen desde
+      Windows Vista, así que la única razón para evitarlas es software genuinamente
+      más antiguo que eso, o un instalador o una herramienta incrustada que analice
+      los iconos por su cuenta.
+    </p>
+  </section>
+
+  <section>
+    <h2>Un Mac lee un archivo completamente distinto</h2>
+    <p>
+      Si el icono es para una aplicación de Mac y no de Windows, nada de lo
+      anterior sirve: macOS no lee <code>.ico</code> en absoluto. Lee
+      <code>.icns</code>, que es la misma idea en otro envoltorio &mdash; varios
+      tamaños en un contenedor &mdash; con tres diferencias que conviene conocer.
+    </p>
+    <ul>
+      <li>
+        <strong>Los tamaños son fijos.</strong> Apple publica diez ranuras y no hay
+        nada que elegir: 16, 32, 64, 128, 256, 512 y 1024 píxeles, con 32, 256 y
+        512 apareciendo dos veces porque cada uno es a la vez un tamaño propio y la
+        versión Retina del tamaño de debajo.
+      </li>
+      <li>
+        <strong>Llega hasta 1024.</strong> Un <code>.ico</code> se para en 256, y
+        por eso un archivo de icono de Mac son varios cientos de kilobytes y un
+        favicon son quince. Para una aplicación que se distribuye una vez eso no es
+        nada; solo un favicon se lo descarga cada visitante.
+      </li>
+      <li>
+        <strong>1024 píxeles es lo que tiene que aguantar tu dibujo.</strong> Los
+        dos problemas son los extremos opuestos de la misma imagen: un favicon
+        tiene que funcionar cuando es diminuto, y un icono de Mac tiene que
+        aguantar cuando es enorme. Un logotipo exportado a 512 y ampliado a 1024 se
+        ve blando en una pantalla Retina, y la App Store no lo va a aceptar.
+      </li>
+    </ul>
+    <p>
+      Para usar uno: un paquete de aplicación lo guarda en
+      <code>TuApp.app/Contents/Resources/</code> y lo nombra en
+      <code>Info.plist</code>. Para una carpeta o una imagen de disco, selecciona el
+      <code>.icns</code> en el Finder, pulsa Comando-C, después haz Obtener
+      información sobre la cosa que quieras cambiar, haz clic en el icono pequeño de
+      arriba a la izquierda y pulsa Comando-V.
+    </p>
+    <p>
+      Marcar <em>icono de macOS</em> en <a href="../../crear-favicon/">Imagen a
+      ICO</a> escribe uno, con o sin el archivo de Windows al lado. Cualquier cosa
+      que se distribuya en las dos plataformas quiere los dos, y los dos se dibujan
+      a partir de la misma imagen en la misma pasada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Comprobar que ha funcionado</h2>
+    <p>
+      Los navegadores cachean los favicons con más ganas que casi cualquier otra
+      cosa, así que «lo he subido y no ha cambiado nada» suele ser una caché y no un
+      error. Dos cosas que probar antes de ponerte a editar archivos otra vez:
+    </p>
+    <ul>
+      <li>
+        Abre <code>https://tusitio.com/favicon.ico</code> directamente. Si el
+        archivo se descarga, está ahí y lo que estás viendo es una caché. Si te sale
+        un 404, no está en la raíz.
+      </li>
+      <li>
+        Carga el sitio en una ventana privada, que normalmente tiene su propia caché
+        de iconos.
+      </li>
+    </ul>
+    <p>
+      En Windows, un <code>.ico</code> se puede comprobar poniéndolo en una carpeta
+      y cambiando el Explorador entre sus tamaños de vista: pequeño, mediano, grande
+      y extragrande dibujan entradas distintas del mismo archivo, así que puedes ver
+      cada una tal como la verá el sistema.
+    </p>
+    <p>
+      En un Mac, un <code>.icns</code> se abre en Vista Previa, que lista todas las
+      ranuras en el lateral &mdash; y el mismo truco funciona en el Finder: déjalo
+      en una carpeta y mueve el control de tamaño de las opciones de vista para
+      verlo cambiar entre las imágenes de dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada de esto necesita una subida</h2>
+    <p>
+      Escalar una imagen es algo que cualquier navegador lleva años haciendo, y un
+      <code>.ico</code> es una cabecera de seis bytes, dieciséis bytes por imagen y
+      después las imágenes. No hay ningún paso en hacer uno que exija un servidor, y
+      la herramienta de aquí no usa ninguno: la
+      <code>Content-Security-Policy</code> de la página nombra todas las direcciones
+      que puede contactar, y ninguna es de este sitio.
+    </p>
+    <p>
+      Y aquí eso merece más preocupación de lo habitual. Un logotipo entregado a un
+      generador gratuito de favicons es, muy a menudo, una marca sin lanzar &mdash;
+      el icono es de las primeras cosas que se hacen y de las últimas que se
+      anuncian. Carga la página, desenchúfate de internet y haz uno de todos modos
+      si prefieres comprobarlo a que te lo cuenten.
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      hacerle a cualquier herramienta.
+    </p>
+  </section>

--- a/locales/es/pages/guides/make-a-favicon.toml
+++ b/locales/es/pages/guides/make-a-favicon.toml
@@ -1,0 +1,25 @@
+#
+# Guía: hacer un favicon y un icono de aplicación - Spanish.
+#
+# Overrides for pages/guides/make-a-favicon/page.toml. Only words: the slug,
+# the kind, the group and the tool this guide is about stay where they are.
+#
+
+nav = "Hacer un favicon"
+
+title = "Cómo hacer un favicon (y un icono de aplicación de Windows)"
+description = "Qué tamaños necesita de verdad un favicon.ico, qué archivos extra piden los iPhone, Android y un Mac, y por qué un logotipo que funciona en un cartel desaparece a dieciséis píxeles."
+
+heading = "Cómo hacer un favicon que todavía se lea a dieciséis píxeles"
+lede = """
+    Un favicon no es una imagen pequeña de tu logotipo. Es un conjunto de
+    imágenes a tamaños fijos, dentro de un contenedor que casi nadie abre, y la
+    más pequeña de todas es la que ve la gente. Esto es qué tamaños necesitas,
+    qué archivos van al lado, y qué hacer cuando tu logotipo no sobrevive al
+    viaje hacia abajo."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Hacer un favicon que todavía se lea a dieciséis píxeles"
+og_description = "Qué tamaños necesita un favicon.ico, los archivos extra que piden los iPhone y Android, y qué hacer cuando tu logotipo no sobrevive a encogerse."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/make-a-pdf-smaller.html
+++ b/locales/es/pages/guides/make-a-pdf-smaller.html
@@ -1,0 +1,234 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../comprimir-pdf/">compresor de PDF</a>, suelta el
+      documento dentro y mira lo que te dice antes de cambiar nada. Lee el
+      archivo y enseña dónde está de verdad el tamaño &mdash; imágenes,
+      tipografías, texto y dibujo, y todo aquello a lo que ya no apunta nada del
+      documento. Esa sola pantalla suele responder la pregunta.
+    </p>
+    <p>
+      Si casi todo el tamaño son imágenes, puedes esperar un ahorro grande. Si
+      son tipografías y texto, no puedes, y ninguna herramienta puede. Cuál de
+      los dos tienes es la historia entera, y merece diez segundos de mirada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dónde está de verdad el tamaño de un PDF</h2>
+    <p>
+      Un PDF es un contenedor de varias clases de cosas distintas, y no se
+      comprimen igual.
+    </p>
+    <ul>
+      <li>
+        <strong>Imágenes.</strong> Fotografías y escaneos. Casi siempre el grueso
+        de un PDF grande, y la única parte con margen de verdad.
+      </li>
+      <li>
+        <strong>Tipografías incrustadas.</strong> Una tipografía completa puede
+        ser de cientos de kilobytes; un subconjunto con solo los caracteres usados
+        es mucho menos. En cualquier caso, las comprimió el programa que produjo
+        el archivo.
+      </li>
+      <li>
+        <strong>Texto y dibujo vectorial.</strong> Instrucciones en vez de
+        píxeles: dibuja esta línea, pon esta palabra aquí. Compacto ya, y
+        comprimido ya.
+      </li>
+      <li>
+        <strong>Objetos a los que ya no apunta nada.</strong> Los PDF los
+        acumulan. Editar un documento muchas veces añade el cambio en vez de
+        reescribir el archivo, así que una versión antigua de una página puede
+        quedarse ahí dentro indefinidamente. Reempaquetar el archivo los tira.
+      </li>
+    </ul>
+    <p>
+      Así que los dos documentos que la gente le lleva a un compresor de PDF
+      tienen perspectivas completamente distintas. Un documento escaneado es en
+      esencia un montón de fotografías, y suele salir un 60&ndash;90&nbsp;% más
+      pequeño. Un contrato, una tesis o un informe exportado son texto, dibujo y
+      tipografías &mdash; todo ello comprimido ya por el programa que lo escribió
+      &mdash; y ahí el ahorro suele ser de un pequeño porcentaje, de reempaquetar
+      y tirar lo que no se referencia.
+    </p>
+    <p>
+      Cualquier herramienta que prometa «hasta un 90&nbsp;% más pequeño» sin
+      mirar tu archivo te está citando el mejor caso del primer tipo aplicado al
+      segundo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué tienen que ver los PPP con esto</h2>
+    <p>
+      Un PDF no guarda solo una imagen; anota de qué tamaño se dibuja esa imagen
+      en la página. Eso te da algo más útil que el número de píxeles: la
+      resolución efectiva.
+    </p>
+    <p>
+      Un escaneo de 4000 píxeles de ancho colocado a lo ancho de veinte
+      centímetros de papel lleva unos 500 píxeles por pulgada. Una pantalla
+      enseña unos 100. Una buena impresora de oficina trabaja a 300 y no puede
+      aprovechar mucho más. Todo lo que hay por encima es detalle que nada en el
+      futuro del documento va a mostrar jamás &mdash; y suele ser casi todo el
+      archivo.
+    </p>
+    <p>
+      Por eso un compresor de PDF sensato pide unos PPP en vez de un porcentaje de
+      calidad. Tira primero los píxeles que están por encima de tu cifra, porque
+      esos no cuestan nada que nadie pueda ver, y solo entonces empieza a gastar
+      calidad de verdad.
+    </p>
+    <p>
+      Guía aproximada: <strong>150 PPP</strong> para un documento que se va a leer
+      en pantalla, <strong>200&ndash;300</strong> para algo que se va a imprimir,
+      <strong>72&ndash;100</strong> para un borrador que nadie va a guardar. Medir
+      contra el tamaño al que se dibuja la imagen es además la razón de que un
+      logotipo colocado pequeño no se trate igual que un escaneo a página completa
+      &mdash; el logotipo ya está cerca de su resolución efectiva y no hay nada que
+      quitarle.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué debería y qué no debería tocar la compresión</h2>
+    <p>
+      Las imágenes se recodifican, así que esas pierden un poco. Nada más debería
+      tocarse en absoluto, y merece la pena comprobar que la herramienta que uses
+      lo respeta:
+    </p>
+    <ul>
+      <li>
+        <strong>El texto sigue siendo texto.</strong> Seleccionable, buscable,
+        copiable. Un compresor que aplane las páginas a imágenes producirá un
+        archivo muy pequeño y destruirá el documento &mdash; no puedes buscar en
+        él, los lectores de pantalla no pueden leerlo, y no hay vuelta atrás.
+      </li>
+      <li>
+        <strong>Las tipografías siguen enteras.</strong> Sustituir tipografías
+        cambia el aspecto del documento en el equipo de otra persona, que es
+        justamente lo que el PDF existe para evitar.
+      </li>
+      <li>
+        <strong>El dibujo vectorial se copia tal cual.</strong> Ya es pequeño, y
+        rasterizarlo lo haría a la vez más grande y peor.
+      </li>
+      <li>
+        <strong>Los formularios, los enlaces, los marcadores, la estructura de
+        accesibilidad y los adjuntos se llevan al archivo nuevo.</strong> Son
+        fáciles de perder en una reescritura y casi nunca se nota hasta que
+        alguien necesita uno.
+      </li>
+    </ul>
+    <p>
+      Una regla relacionada que un compresor debería seguir y muchos no siguen: si
+      recodificar una imagen no sale de verdad más pequeño que el original, hay
+      que devolver los bytes originales. Empeorar una imagen sin ningún ahorro es
+      el caso de pérdida pura, y pasa más a menudo de lo que uno pensaría con
+      imágenes que ya estaban bien comprimidas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Las imágenes que no se pueden comprimir</h2>
+    <p>
+      Algunas imágenes de dentro de un PDF se saltan, y una buena herramienta las
+      nombra en vez de dejarlas fuera de la cuenta en silencio:
+    </p>
+    <ul>
+      <li>
+        <strong>Imágenes JPEG&nbsp;2000, JBIG2 y codificadas para fax
+        (CCITT).</strong> Ningún navegador trae un descodificador para ninguna de
+        ellas, así que pasan intactas. Las dos últimas son de dos niveles &mdash;
+        solo blanco y negro &mdash; y suelen estar ya cerca de su tamaño mínimo.
+      </li>
+      <li>
+        <strong>Imágenes CMYK.</strong> Se dejan en paz a propósito.
+        Recodificarlas arriesga a desplazar los colores que sacaría una imprenta,
+        que es algo sorprendente que hacerle a un documento que alguien va a
+        imprimir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Cosas que probar antes de comprimir</h2>
+    <p>
+      A veces el archivo es grande por una razón para la que la compresión es la
+      respuesta equivocada.
+    </p>
+    <p>
+      <strong>¿Se escaneó cuando no hacía falta?</strong> Un documento impreso y
+      después escaneado es un montón de fotografías de texto. Si el original
+      todavía existe en alguna parte como documento, exportarlo a PDF producirá un
+      archivo de una fracción del tamaño y además buscable.
+    </p>
+    <p>
+      <strong>¿Se exportó con ajustes de imprenta?</strong> Los procesadores de
+      texto y los programas de diseño suelen exportar por defecto con calidad de
+      imprenta. Volver a exportar para pantalla desde el archivo original suele
+      ganarle a comprimir la exportación.
+    </p>
+    <p>
+      <strong>¿Tiene que ser un solo archivo?</strong> El límite de un correo es
+      por mensaje. Dividir un documento de 200 páginas en capítulos es a veces la
+      solución honesta.
+    </p>
+  </section>
+
+  <section>
+    <h2>Los archivos cifrados, y por qué un compresor debería rechazarlos</h2>
+    <p>
+      Un PDF protegido con contraseña lo rechaza la herramienta de aquí, y eso es
+      deliberado y no una función que falte &mdash; incluso cuando la contraseña
+      está en blanco, que es como guardan muchos escáneres y fotocopiadoras.
+    </p>
+    <p>
+      Quitarle la protección a un documento es un trabajo distinto de
+      comprimirlo. Una herramienta que lo hiciera en silencio estaría haciendo
+      algo que no le pediste, sobre un archivo que alguien había bloqueado a
+      propósito, y devolviéndote una copia que ya no tendría la propiedad que esa
+      persona quiso que tuviera. Quítale la protección tú primero, a propósito, si
+      es lo que quieres.
+    </p>
+  </section>
+
+  <section>
+    <h2>Comprobar el resultado</h2>
+    <p>
+      Ábrelo. Mira las imágenes con el zoom al máximo, comprueba que el texto
+      sigue siendo seleccionable y confirma el número de páginas.
+    </p>
+    <p>
+      La herramienta de aquí hace lo último por ti antes de ofrecerte el archivo:
+      vuelve a abrir el documento que acaba de escribir y le cuenta las páginas, en
+      tu propio equipo. Escribe además PDF 1.5, que entiende cualquier lector
+      publicado desde 2003, así que «se abre en mi equipo» es una aproximación
+      razonable a «se abre en el suyo».
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué esto no necesita un servidor</h2>
+    <p>
+      Comprimir un PDF suena a trabajo de servidor, y durante casi toda la vida de
+      la web lo fue. Lo que implica en realidad es analizar la estructura del
+      archivo, encontrar los flujos de imagen, descodificarlos y recodificarlos
+      con los códecs que un navegador ya trae, y volver a escribir el documento.
+      Todo eso funciona hoy dentro de un navegador.
+    </p>
+    <p>
+      Cosa que importa más con este tipo de archivo que con casi cualquier otro,
+      por lo que la gente comprime: contratos, informes médicos, extractos
+      bancarios, documentos de identidad, declaraciones de la renta. La
+      herramienta de aquí no tiene ninguna función de red, y la
+      <code>Content-Security-Policy</code> de la página nombra todas las
+      direcciones que puede contactar, ninguna de las cuales es de este sitio.
+      Cárgala, desenchúfate y comprime algo de todos modos.
+    </p>
+    <p>
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea otras tres comprobaciones como esa.
+    </p>
+  </section>

--- a/locales/es/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/es/pages/guides/make-a-pdf-smaller.toml
@@ -1,0 +1,25 @@
+#
+# Guía: reducir el tamaño de un PDF - Spanish.
+#
+# Overrides for pages/guides/make-a-pdf-smaller/page.toml. Only words: the
+# slug, the kind, the group and the tool this guide is about stay where they
+# are.
+#
+
+nav = "Reducir un PDF"
+
+title = "Cómo reducir el tamaño de un PDF (y por qué algunos no encogen)"
+description = "Dónde está de verdad el tamaño de un PDF, por qué un escaneo se comprime un 80&nbsp;% y un contrato apenas se mueve, qué significan aquí los PPP, y qué no debería hacerle nunca un compresor a tu documento."
+
+heading = "Cómo reducir el tamaño de un PDF, y por qué algunos no encogen"
+lede = """
+    Un PDF que no cabe en el límite de un correo es casi siempre un PDF lleno de
+    imágenes. Esto explica cómo saber si el tuyo lo es, qué cuesta comprimirlo, y
+    por qué cualquier herramienta que prometa un porcentaje fijo no ha mirado tu
+    archivo."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Cómo reducir el tamaño de un PDF"
+og_description = "Dónde está de verdad el tamaño de un PDF, por qué un escaneo encoge y un contrato no, y qué tienen que ver los PPP con esto."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/make-a-qr-code.html
+++ b/locales/es/pages/guides/make-a-qr-code.html
@@ -1,0 +1,263 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../generar-codigo-qr/">generador de QR y códigos de
+      barras</a>, pega tu enlace, deja el nivel en <strong>M</strong> y el margen
+      en <strong>4</strong>, y descarga el SVG. Imprímelo con al menos dos
+      centímetros de ancho, sobre algo mate, oscuro sobre claro. Y después escanea
+      el impreso con un móvil que no sea el tuyo antes de encargar mil.
+    </p>
+    <p>
+      Eso cubre casi todos los casos. El resto de esta página es qué hacer cuando
+      no es uno de ellos: un código que tiene que aguantar que lo manoseen, un
+      código con un logotipo encima, un código que va en algo pequeño, y la única
+      decisión que es fácil de equivocar de una forma de la que no te enteras hasta
+      un año después.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué hay de verdad dentro de un código QR</h2>
+    <p>
+      Una cadena de texto. Eso es todo. Escanear un código QR le entrega al móvil
+      un trozo de texto, y todo lo demás &mdash; abrir una página, conectarse a una
+      red, ofrecerse a guardar un contacto &mdash; es el móvil reconociendo la
+      forma de ese texto y ofreciéndose a actuar.
+    </p>
+    <p>
+      Así que no existe eso de un «código QR de wifi» como tipo de código. Existe
+      un código QR que lleva <code>WIFI:T:WPA;S:Mi Red;P:la contraseña;;</code>,
+      que sabe leer cualquier móvil hecho en la última década. El generador te
+      enseña la cadena terminada exactamente por esto: cuando un código no hace lo
+      que esperabas, la cadena es lo único que merece la pena mirar.
+    </p>
+    <p>
+      Significa además que un código QR no se puede cambiar una vez impreso, no
+      puede llamar a casa y no puede caducar &mdash; salvo que alguien le haya
+      metido dentro un enlace a su propio servidor, que es el tema del último
+      apartado de aquí.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisión uno: el nivel de corrección de errores</h2>
+    <p>
+      Un código QR lleva junto a los datos un conjunto de palabras de
+      comprobación, calculadas para que un lector pueda reconstruir lo que no ha
+      podido ver. Por eso un código con una esquina arrancada sigue escaneando.
+      Cuántas de esas palabras hay es el nivel, y hay cuatro:
+    </p>
+    <ul>
+      <li><strong>L</strong> &mdash; se puede perder alrededor del 7&nbsp;% del código.</li>
+      <li><strong>M</strong> &mdash; alrededor del 15&nbsp;%.</li>
+      <li><strong>Q</strong> &mdash; alrededor del 25&nbsp;%.</li>
+      <li><strong>H</strong> &mdash; alrededor del 30&nbsp;%.</li>
+    </ul>
+    <p>
+      Más corrección no es gratis: los datos de comprobación van en el mismo
+      cuadrado, así que el mismo texto en H necesita un código más grande y más
+      denso que en L. A grandes rasgos, pasar de L a H duplica el número de módulos
+      para la misma cadena, y unos módulos más densos son más difíciles de resolver
+      para una cámara. Aquí hay un trato de verdad y la respuesta depende de adónde
+      vaya el código.
+    </p>
+    <p>
+      <strong>L</strong> es para una pantalla: un código en una diapositiva, en un
+      correo, en una página web. Nada lo va a dañar y cada módulo de más lo hace
+      más difícil de leer a distancia.
+    </p>
+    <p>
+      <strong>M</strong> es el valor por defecto y la respuesta correcta para casi
+      cualquier impresión. Papel que se va a manosear un poco, un folleto, una
+      tarjeta de visita.
+    </p>
+    <p>
+      <strong>Q y H</strong> son para códigos que van a sufrir: una carta que se
+      limpia a diario, una pegatina en una máquina de un taller, una etiqueta en
+      una caja, un código en un escaparate que le da el sol directo. H es además lo
+      que hace posible un logotipo en el centro &mdash; ver más abajo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisión dos: el margen, que forma parte del código</h2>
+    <p>
+      El espacio en blanco de alrededor de un código QR no es relleno, y no es una
+      decisión de diseño. Un lector lo usa para saber dónde termina el símbolo. La
+      especificación pide cuatro módulos de espacio en calma por cada lado, y un
+      código recortado hasta su borde es la razón número uno de que un código
+      impreso falle.
+    </p>
+    <p>
+      Merece la pena decirlo sin rodeos porque recortar es una cosa muy natural de
+      hacer. El código parece que tiene demasiado blanco alrededor, así que se
+      recorta en la maquetación, o se suelta sobre un panel de color que llega
+      hasta los cuadrados, o se pone encima de una fotografía. Cada una de esas
+      cosas le quita el límite que iba a usar el lector.
+    </p>
+    <p>
+      Si el código parece demasiado grande con su margen, haz el código más
+      pequeño. No le quites el margen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisión tres: de qué tamaño imprimirlo</h2>
+    <p>
+      La regla práctica que ha sobrevivido al contacto con la realidad es
+      <strong>uno a diez</strong>: un código tiene que medir de ancho más o menos
+      una décima parte de la distancia desde la que se va a escanear.
+    </p>
+    <ul>
+      <li>Una tarjeta de visita o una carta, leída a 30 cm: unos 2 cm de ancho.</li>
+      <li>Un cartel leído a dos metros: unos 20 cm.</li>
+      <li>Una marquesina o un escaparate leídos a cinco metros: unos 50 cm.</li>
+    </ul>
+    <p>
+      Dos centímetros es un suelo, no un objetivo. Por debajo de 1,5 cm más o menos
+      un móvil corriente empieza a sufrir por buena que sea la impresión, porque los
+      módulos sueltos se acercan al tamaño de un píxel de su cámara.
+    </p>
+    <p>
+      Menos texto significa menos módulos, y eso significa un código que se lee a
+      distancia para un tamaño impreso dado &mdash; que es un buen motivo para
+      apuntar un código a <code>ejemplo.com/x</code> y no a una URL con cien
+      caracteres de parámetros de seguimiento al final.
+    </p>
+    <p>
+      Y imprime desde el <strong>SVG</strong>. Un código QR está hecho de bordes, y
+      un PNG tiene un número fijo de píxeles con los que hacerlos; amplía uno y
+      todos los bordes se ablandan, que es justo lo que le cuesta a un escáner. Un
+      SVG son los cuadrados como instrucciones, así que sale nítido tanto en una
+      tarjeta de visita como en una valla.
+    </p>
+  </section>
+
+  <section>
+    <h2>Color, contraste y los dos errores</h2>
+    <p>
+      Un lector mide la diferencia entre los módulos oscuros y los claros, así que
+      el contraste lo es todo. Hay dos cosas que salen mal a menudo:
+    </p>
+    <p>
+      <strong>Código claro sobre fondo oscuro.</strong> Queda llamativo, y bastantes
+      lectores lo rechazan de plano: buscan oscuro sobre claro y no prueban la
+      inversión. Algunos sí. No vas a saber cuáles tienen tus clientes.
+    </p>
+    <p>
+      <strong>Poca diferencia.</strong> Un gris medio sobre blanco, o dos colores de
+      marca de peso parecido, pueden medir bien en pantalla y fallar en papel en
+      cuanto entran en juego la ganancia de tinta y la exposición automática de un
+      móvil. Si vas a colorear un código, mantén la parte oscura genuinamente
+      oscura.
+    </p>
+    <p>
+      El mate le gana al brillo en cualquier cosa que se vaya a escanear bajo una
+      luz, y los dos le ganan a imprimir sobre una fotografía. Los fondos
+      transparentes son útiles para poner un código sobre un panel de color &mdash;
+      pero comprueba qué acaba de verdad detrás, porque un código transparente sobre
+      un panel oscuro es el primer error de arriba con pasos de más.
+    </p>
+  </section>
+
+  <section>
+    <h2>Un logotipo en el centro</h2>
+    <p>
+      Esto funciona, y funciona gracias a la corrección de errores y no a pesar de
+      ella. En el nivel H se puede destruir alrededor del 30&nbsp;% de los módulos
+      y el código sigue leyéndose, así que un logotipo que cubra bastante menos que
+      eso &mdash; en el centro, donde no hay ningún patrón de localización &mdash;
+      es un daño que el lector repara.
+    </p>
+    <p>
+      Tres cosas que respetar. Usa el nivel H. Mantén el logotipo por debajo de una
+      quinta parte del área más o menos, bien lejos del límite teórico, porque la
+      impresión no es lo único que se está comiendo tu margen. Y no tapes nunca los
+      tres cuadrados grandes de las esquinas ni los pequeños que hay cerca: así es
+      como un lector encuentra y orienta el símbolo, para empezar, y no hay
+      corrección de errores que los reconstruya.
+    </p>
+    <p>
+      Y después pruébalo en móviles de verdad. Un logotipo lleva un código de
+      «siempre funciona» a «funciona con este margen», y la única forma de saber
+      cuánto margen queda es probarlo.
+    </p>
+  </section>
+
+  <section>
+    <h2>La decisión de la que la gente se arrepiente: estático o «dinámico»</h2>
+    <p>
+      Busca un generador de QR y casi todos los resultados quieren que te hagas una
+      cuenta, porque están vendiendo códigos <em>dinámicos</em>. Un código dinámico
+      no contiene tu enlace. Contiene un enlace corto al propio servidor del
+      generador, que redirige al tuyo.
+    </p>
+    <p>
+      Lo que eso te compra es real: puedes cambiar adónde apunta el código después
+      de imprimirlo, y te llevas un recuento de cada escaneo. Para una campaña con
+      una tirada de seis cifras, eso merece pagarse.
+    </p>
+    <p>
+      Lo que cuesta también es real, y merece saberse antes y no después:
+    </p>
+    <ul>
+      <li>
+        <strong>El código deja de funcionar cuando ellos dejan de funcionar.</strong>
+        Si el servicio cierra, el dominio caduca o el plan gratuito expira, todos
+        los códigos que imprimiste se quedan muertos &mdash; y para entonces están
+        en diez mil cartas.
+      </li>
+      <li>
+        <strong>Cada escaneo son datos de otra persona.</strong> La redirección ve
+        la dirección IP, la hora y el dispositivo de todo el que escanee tu código.
+      </li>
+      <li>
+        <strong>El enlace es suyo, no tuyo.</strong> Cualquiera que lo escanee ve
+        pasar un dominio desconocido, que es justo de lo que a la gente le están
+        diciendo que desconfíe.
+      </li>
+    </ul>
+    <p>
+      El término medio no cuesta nada: pon un código QR estático alrededor de una
+      URL corta <em>de tu propio dominio</em>, y redirígela tú. Conservas la
+      capacidad de cambiar el destino, conservas la analítica, y nada del código
+      depende de que una empresa que no conoces siga existiendo el año que viene.
+    </p>
+    <p>
+      El <a href="../../generar-codigo-qr/">generador de aquí</a> solo hace códigos
+      estáticos, y no tiene ninguna cuenta que crear. Lo que escribes es lo que
+      lleva el código.
+    </p>
+  </section>
+
+  <section>
+    <h2>Antes de imprimir mil</h2>
+    <p>
+      Escanea el código. No el de tu pantalla &mdash; la prueba impresa, en el
+      sitio al que va, con un móvil que no sea aquel con el que lo hiciste. Eso
+      lleva un minuto y pilla la categoría entera de problemas de la que va esta
+      página: un margen que se comió la maquetación, un enlace al que le faltaba el
+      <code>https://</code>, un color que midió distinto en papel, un código impreso
+      a un tamaño que funciona en un escritorio y no en una pared.
+    </p>
+    <p>
+      Y comprueba qué pasa después del escaneo. Un código que abre una página
+      ilegible en un móvil es un código que ha fallado, aunque haya escaneado.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada de esto exige subir nada</h2>
+    <p>
+      Un código QR es aritmética sobre una cadena de texto. No hay ningún archivo
+      que enviar ni nada que un servidor pueda hacer y un navegador no, y por eso
+      la <a href="../../generar-codigo-qr/">herramienta de aquí</a> lo hace todo en
+      tu propio equipo y funciona con la red desenchufada.
+    </p>
+    <p>
+      Y eso importa más de lo que suena, por lo que la gente mete en los códigos QR.
+      El uso más común del formato de wifi es la contraseña real de una red,
+      tecleada en una página web. Merece la pena saber si esa página tenía adónde
+      mandarla.
+    </p>
+  </section>

--- a/locales/es/pages/guides/make-a-qr-code.toml
+++ b/locales/es/pages/guides/make-a-qr-code.toml
@@ -1,0 +1,24 @@
+#
+# Guía: hacer un código QR que escanee de verdad - Spanish.
+#
+# Overrides for pages/guides/make-a-qr-code/page.toml. Only words: the slug,
+# the kind, the group and the tool this guide is about stay where they are.
+#
+
+nav = "Hacer un código QR"
+
+title = "Cómo hacer un código QR que escanee siempre"
+description = "Qué nivel de corrección de errores elegir, por qué el margen blanco de alrededor forma parte del código, de qué tamaño imprimirlo, y lo que te cuesta después el código «dinámico» de un generador gratuito."
+
+heading = "Cómo hacer un código QR que también escanee en el móvil de otro"
+lede = """
+    Hacer un código QR lleva un segundo. Hacer uno que funcione en una carta
+    mojada, en una marquesina o en un móvil sostenido con el brazo estirado y con
+    mala luz lleva cuatro decisiones, y las cuatro se toman antes de imprimir
+    nada. Esto es lo que hace cada una."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Hacer un código QR que también escanee en el móvil de otro"
+og_description = "Las cuatro decisiones que deciden si un código QR impreso funciona: el nivel, el margen, el tamaño y de quién es la dirección que lleva dentro."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/es/pages/guides/remove-exif-and-gps-data.html
@@ -1,0 +1,224 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../eliminar-datos-exif/">visor y eliminador de EXIF</a>,
+      suelta las fotos dentro y pulsa «Quitar todos los metadatos». Todas las
+      etiquetas, los bloques XMP e IPTC, los comentarios y la miniatura
+      incrustada se van, de todas las fotos de la lista a la vez. La imagen en sí
+      no se toca &mdash; no se vuelve a comprimir, no se descodifica y no cambia
+      ni un píxel.
+    </p>
+    <p>
+      Antes de hacerlo, merece la pena mirar qué había ahí dentro. Suele ser más
+      de lo que la gente espera, y esa lista es el argumento para hacer esto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué hay de verdad dentro de una foto</h2>
+    <p>
+      Un JPEG no es solo una imagen comprimida. Es un contenedor, y junto a la
+      imagen hay varios bloques de información que escribieron ahí tu cámara, tu
+      móvil o tu editor.
+    </p>
+    <ul>
+      <li>
+        <strong>EXIF.</strong> El principal. Marca y modelo de cámara, objetivo,
+        ajustes de exposición, ISO, la fecha y la hora al segundo, la orientación
+        en que hay que mostrar la imagen y &mdash; en un móvil con la ubicación
+        activada para la cámara &mdash; una posición GPS con una precisión de unos
+        pocos metros. Muchas veces también el número de serie del cuerpo de la
+        cámara.
+      </li>
+      <li>
+        <strong>GPS.</strong> Técnicamente forma parte del EXIF, y merece
+        nombrarse aparte porque es el que más importa. Se escribe en grados,
+        minutos y segundos, que es un formato que hace un trabajo excelente
+        pareciendo cualquier cosa menos una dirección.
+      </li>
+      <li>
+        <strong>XMP.</strong> Un paquete de XML que escriben los editores. Puede
+        llevar tu nombre, tu software, valoraciones, palabras clave, historial de
+        ediciones y una copia de algunos de los campos EXIF &mdash; y por eso
+        quitar solo el EXIF no basta.
+      </li>
+      <li>
+        <strong>IPTC.</strong> Un bloque más antiguo con campos de pie de foto,
+        autoría, crédito y derechos, usado en la prensa y en la fotografía de
+        archivo.
+      </li>
+      <li>
+        <strong>La miniatura incrustada.</strong> Una segunda copia pequeña de la
+        imagen. Se genera cuando se escribe el archivo, y no siempre se vuelve a
+        generar cuando se edita la imagen &mdash; que es como una foto recortada
+        puede viajar con una miniatura de lo que se recortó.
+      </li>
+      <li>
+        <strong>La nota del fabricante.</strong> Un bloque sin documentar de datos
+        del fabricante. Nadie fuera del fabricante sabe todo lo que lleva dentro.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Quién lo ve de verdad</h2>
+    <p>
+      Esta es la parte en la que conviene ser preciso, porque tanto la versión
+      alarmada como la despreocupada están equivocadas.
+    </p>
+    <p>
+      <strong>Casi todas las redes sociales grandes quitan los metadatos cuando
+      publicas.</strong> Facebook, Instagram y X recodifican las imágenes subidas
+      y tiran las etiquetas por el camino. Eso no es un favor &mdash; se quedan
+      los datos de su lado &mdash;, pero sí significa que una foto publicada en
+      esos servicios no le entrega sus coordenadas a todo el que la vea.
+    </p>
+    <p>
+      <strong>Casi todo lo demás las conserva.</strong> Un adjunto de correo. Un
+      archivo enviado por casi cualquier aplicación de mensajería como
+      «documento» en vez de como foto. Una imagen en un foro, un anuncio de
+      compraventa, una web personal, una unidad compartida, un informe de error,
+      un ticket de soporte. En todos esos casos el archivo llega intacto, y
+      cualquiera que lo descargue puede leer las etiquetas con herramientas que
+      trae su propio sistema operativo.
+    </p>
+    <p>
+      Los riesgos realistas son mundanos más que dramáticos: un anuncio de
+      compraventa fotografiado en casa, una foto de un niño tomada en su colegio,
+      una cuenta aparentemente anónima que publica fotos que comparten todas el
+      mismo número de serie de cámara, un «tomada la semana pasada» que se tomó en
+      marzo.
+    </p>
+  </section>
+
+  <section>
+    <h2>¿Por qué no volver a guardarla y ya?</h2>
+    <p>
+      Volver a guardar una foto con un editor o un compresor sí quita los
+      metadatos &mdash; la imagen se descodifica a píxeles y se vuelve a
+      codificar, y un lienzo lleno de píxeles no lleva etiquetas. Funciona, y te
+      cuesta calidad, porque esa recodificación tiene pérdidas.
+    </p>
+    <p>
+      Quitar los metadatos como es debido no cuesta absolutamente nada. Las
+      etiquetas están en el contenedor <em>alrededor</em> de la imagen comprimida,
+      no dentro de ella, así que eliminarlas consiste en borrar entradas de una
+      lista y volver a escribir la lista. Los datos de imagen comprimidos se
+      copian byte por byte y el resultado descodifica exactamente los mismos
+      píxeles. Esa es la razón entera para usar una herramienta de metadatos en
+      vez de un conversor.
+    </p>
+    <p>
+      La excepción es si ibas a recodificar de todas formas. Si ya estás
+      comprimiendo o redimensionando la foto, las etiquetas se van como efecto
+      secundario y no necesitas un segundo paso.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lo único que hay que conservar: la orientación</h2>
+    <p>
+      Los móviles no giran la imagen cuando giras el móvil. La graban tal como la
+      vio el sensor y añaden una etiqueta de orientación que dice cómo hay que
+      girarla para mostrarla. Quita todas las etiquetas y algunos visores enseñarán
+      tu foto de lado.
+    </p>
+    <p>
+      Por eso la herramienta de aquí tiene una opción de «conservar la etiqueta de
+      orientación», activada por defecto. Vuelve a escribir un bloque EXIF diminuto
+      que contiene esa única etiqueta y nada más, y solo para las fotos que la
+      necesitaban de verdad. El GPS, las marcas de tiempo, el número de serie y
+      todo lo demás siguen fuera.
+    </p>
+    <p>
+      Desactívala si prefieres que el archivo no lleve EXIF en absoluto &mdash; y
+      después comprueba el resultado antes de enviarlo, porque lo normal es que la
+      foto salga de lado.
+    </p>
+  </section>
+
+  <section>
+    <h2>Editar en lugar de quitar</h2>
+    <p>
+      Quitarlo todo es la respuesta correcta para casi todo el mundo. A veces no
+      lo es: un fotógrafo puede querer conservar la línea de derechos y los
+      ajustes de la cámara y que solo desaparezca la ubicación; alguien que
+      archiva puede necesitar corregir una fecha que estaba mal porque lo estaba
+      el reloj de la cámara.
+    </p>
+    <p>
+      Las dos cosas se pueden hacer. La ubicación se puede borrar por su cuenta, y
+      las etiquetas de texto, las fechas, el ISO, la orientación y la resolución
+      se pueden editar en el sitio.
+    </p>
+    <p>
+      Una advertencia que vale para cualquier herramienta que haga esto, no solo
+      para esta: escribir el archivo reconstruye el bloque EXIF, y una nota del
+      fabricante contiene desplazamientos hacia el bloque <em>original</em>. Una
+      nota reconstruida puede dejar de ser legible, por tanto, para el propio
+      programa del fabricante. Si eso importa, borra la nota del fabricante o deja
+      el archivo sin editar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formatos, y los que no se pueden hacer así</h2>
+    <p>
+      JPEG, PNG y WebP se pueden reescribir los tres limpiamente, y esos son los
+      tres con los que trabaja la herramienta de aquí.
+    </p>
+    <p>
+      HEIC &mdash; lo que guarda un iPhone por defecto &mdash; y AVIF son formatos
+      de cajas construidos con átomos anidados, y necesitan un analizador
+      completamente distinto. La herramienta los reconoce y lo dice, en vez de
+      producir un archivo roto. Si tienes un HEIC, convertirlo a JPEG quitará los
+      metadatos como efecto secundario de la conversión.
+    </p>
+    <p>
+      Un TIFF suelto tampoco se maneja, y por una razón más interesante: en un
+      TIFF los metadatos y los datos de píxeles se direccionan con los mismos
+      desplazamientos, así que quitar etiquetas significa reescribir el
+      direccionamiento de la propia imagen. Se puede hacer, y es otro trabajo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Una costumbre que merece la pena</h2>
+    <p>
+      Comprueba antes de publicar, no después. Leer las etiquetas lleva unos pocos
+      segundos y la lista de hallazgos nombra las cosas que conviene saber &mdash;
+      la posición, las marcas de tiempo, los números de serie &mdash; antes de la
+      tabla completa con todas las etiquetas, así que no tienes que saber qué
+      buscar.
+    </p>
+    <p>
+      La posición se muestra primero en grados decimales, a propósito. «51 grados,
+      30 minutos, 26 segundos» no deja claro que una foto esté nombrando el
+      edificio en el que se tomó. Un par de decimales que puedes pegar en un mapa
+      sí.
+    </p>
+  </section>
+
+  <section>
+    <h2>No subas la foto para averiguar qué lleva dentro</h2>
+    <p>
+      Hay una ironía particular en la forma habitual de resolver este problema:
+      alguien preocupado por lo que revela su foto la sube a una web para
+      averiguarlo. Ahora esa web tiene la foto, las coordenadas, la marca de
+      tiempo y el número de serie, y una copia de la imagen en un disco suyo.
+    </p>
+    <p>
+      No hay ningún motivo para eso. Leer y reescribir el contenedor que rodea a
+      un JPEG son unos cientos de líneas de análisis que un navegador ejecuta
+      perfectamente, y por eso la herramienta de aquí no tiene ninguna función de
+      red: ningún <code>fetch</code>, ningún <code>XMLHttpRequest</code>, nada que
+      pudiera enviar un archivo aunque algo lo intentara. Cárgala una vez,
+      desconéctate, y sigue funcionando.
+    </p>
+    <p>
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> explica cómo comprobar esa afirmación en este
+      sitio o en cualquier otro &mdash; y este es el tipo de archivo en el que más
+      merece la pena comprobarla.
+    </p>
+  </section>

--- a/locales/es/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/es/pages/guides/remove-exif-and-gps-data.toml
@@ -1,0 +1,25 @@
+#
+# Guía: los metadatos de una foto y cómo quitarlos - Spanish.
+#
+# Overrides for pages/guides/remove-exif-and-gps-data/page.toml. Only words:
+# the slug, the kind, the group and the tool this guide is about stay where
+# they are.
+#
+
+nav = "Datos EXIF y GPS"
+
+title = "Cómo quitar los datos EXIF y GPS de una foto"
+description = "Una foto salida de un móvil suele llevar el punto exacto en que se tomó, la hora al segundo y el número de serie de la cámara. Qué hay ahí dentro, quién puede leerlo, y cómo quitarlo sin tocar la imagen."
+
+heading = "Lo que una foto cuenta de ti, y cómo quitarlo"
+lede = """
+    Una imagen recién salida de un móvil suele llevar las coordenadas del sitio
+    en que se tomó, la hora al segundo, y datos suficientes de la cámara como
+    para atarla a todas las demás fotos del mismo dispositivo. Nada de eso se ve
+    en pantalla. Esto es lo que hay ahí dentro y cómo quitarlo."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Lo que una foto cuenta de ti, y cómo quitarlo"
+og_description = "Las coordenadas GPS, las marcas de tiempo y los números de serie viajan dentro de fotos corrientes. Qué hay ahí dentro, quién puede leerlo, y cómo eliminarlo."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/resize-an-image.html
+++ b/locales/es/pages/guides/resize-an-image.html
@@ -1,0 +1,238 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../redimensionar-imagen/">redimensionador de
+      imágenes</a>, suelta tu foto dentro, escribe un número &mdash; el ancho,
+      normalmente &mdash; y deja el otro en blanco. El alto sale de la forma de
+      la foto, que es casi siempre lo que se quería: «1920 de ancho» significa
+      «1920 de ancho y el alto que eso dé».
+    </p>
+    <p>
+      Todo lo de abajo es qué hacer cuando un número no basta: cuando te han dado
+      una caja con dos lados, cuando la foto tiene que hacerse más grande, o
+      cuando una carpeta entera de archivos tiene que salir igual.
+    </p>
+  </section>
+
+  <section>
+    <h2>Encoger es seguro. Agrandar no.</h2>
+    <p>
+      No son dos direcciones de la misma operación, y merece la pena tener claro
+      por qué.
+    </p>
+    <p>
+      <strong>Hacer una foto más pequeña</strong> tira información, y en el único
+      sentido benigno: entran más píxeles de los que salen, así que cada píxel
+      del resultado es el promedio de detalle real medido. Una copia pequeña bien
+      redimensionada suele verse <em>mejor</em> que el original visto a ese
+      tamaño, porque el promediado quita ruido. No se inventa nada.
+    </p>
+    <p>
+      <strong>Hacer una foto más grande</strong> tiene que inventar. El detalle
+      no falta del archivo; es que nunca se fotografió. Todo lo que puede hacer
+      cualquier ampliador es adivinar píxeles intermedios a partir de sus vecinos,
+      y una suposición entre dos valores conocidos es una rampa suave &mdash; por
+      eso una foto ampliada se ve blanda en vez de nítida. Es una copia más grande
+      de la misma foto, no una copia con más detalle.
+    </p>
+    <p>
+      Por eso «no agrandar nunca una foto más de lo que empezó» viene activado en
+      la herramienta de aquí. Desactívalo si de verdad necesitas el número de
+      píxeles &mdash; una imprenta que pide un tamaño mínimo, una plantilla que
+      rechaza cualquier cosa por debajo de un ancho &mdash;, pero hazlo sabiendo
+      que estás comprando píxeles, no detalle.
+    </p>
+    <p>
+      Los ampliadores de aprendizaje automático que sí parecen añadir detalle son
+      una cosa completamente distinta: se están inventando textura plausible a
+      partir de un modelo de cómo suelen ser las imágenes. Para un fondo de
+      pantalla eso está bien. Para la fotografía de una persona, de un documento o
+      de cualquier cosa de la que alguien vaya a sacar una conclusión, entiende
+      que el detalle de más es ficción.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tres formas de decir qué tamaño quieres</h2>
+    <p>
+      Casi todas las herramientas, esta incluida, aceptan las mismas tres, y le
+      van bien a trabajos distintos.
+    </p>
+    <ul>
+      <li>
+        <strong>Píxeles exactos.</strong> Úsalo cuando alguien te ha dado el
+        número: un avatar que tiene que ser de 400&times;400, un banner que tiene
+        que medir 1500 de ancho. Rellena un lado y deja que el otro lo siga, salvo
+        que te hayan dado los dos.
+      </li>
+      <li>
+        <strong>Un porcentaje.</strong> Úsalo cuando quieres que todo salga
+        proporcionalmente más pequeño y te da igual la cifra exacta &mdash; «a la
+        mitad» para un conjunto de fotos que van dentro de un documento.
+      </li>
+      <li>
+        <strong>Un lado largo.</strong> El más útil de los tres para un lote
+        mezclado. «Lado más largo 1600» hace que todas las fotos quepan dentro de
+        un cuadrado de 1600 píxeles, sean verticales u horizontales, que es lo que
+        suele significar en la práctica «déjame todas estas a un tamaño
+        razonable».
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Cuando la caja tiene otra forma que la foto</h2>
+    <p>
+      Aquí es donde se decide de verdad el redimensionado. Si das un ancho y un
+      alto y no encajan con las proporciones de tu foto, algo tiene que ceder, y
+      hay exactamente cuatro cosas que pueden hacerlo:
+    </p>
+    <ul>
+      <li>
+        <strong>Encajar dentro de la caja.</strong> Se conserva la foto entera y
+        sale más pequeña que la caja en uno de los ejes. No se pierde nada y no se
+        deforma nada; simplemente no obtienes las dimensiones exactas que pediste.
+        Es la opción por defecto correcta para casi todo.
+      </li>
+      <li>
+        <strong>Llenar la caja y cortar lo que sobra.</strong> Obtienes
+        exactamente las dimensiones que pediste, y las partes de la foto que
+        cuelgan por fuera de los bordes desaparecen. Correcto para miniaturas,
+        avatares y portadas, donde la forma es fija y el sujeto está en el medio.
+        Incorrecto cuando lo que importa está cerca de un borde.
+      </li>
+      <li>
+        <strong>Rellenar.</strong> Se conserva la foto entera, centrada, con el
+        espacio sobrante relleno de un color que elijas tú. Correcto cuando un
+        sistema exige dimensiones exactas y no puedes perder nada de la imagen
+        &mdash; las fichas de producto suelen funcionar así.
+      </li>
+      <li>
+        <strong>Estirar.</strong> La foto se aplasta o se tira para que encaje.
+        Esto nunca es lo que quieres, salvo que lo estés haciendo a propósito, y
+        es lo que todo el mundo reconoce al instante como mal hecho.
+      </li>
+    </ul>
+    <p>
+      Si te sorprendes buscando el estirado, lo que probablemente quieres es
+      recortar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Recortar es otro trabajo, y muchas veces el correcto</h2>
+    <p>
+      Redimensionar cambia cuántos píxeles describen la foto entera. Recortar
+      cambia qué parte de la foto conservas. La gente busca lo primero cuando
+      quiere decir lo segundo sorprendentemente a menudo &mdash; «esto tiene que
+      ser cuadrado» es un problema de recorte, no de redimensionado.
+    </p>
+    <p>
+      Hazlos en ese orden: recorta primero al encuadre que quieras, y después
+      redimensiona el resultado al tamaño que necesites. Hacerlo al revés
+      significa elegir el recorte sobre una foto que ya ha perdido píxeles.
+    </p>
+    <p>
+      La herramienta de aquí hace las dos cosas de una pasada precisamente por eso
+      &mdash; arrastra una caja, fíjala a una forma si necesitas una proporción
+      concreta, y después di de qué tamaño tiene que salir el resultado. Hacerlo
+      de una pasada significa además que la foto solo se codifica una vez, que
+      importa por lo que dice el apartado siguiente.
+    </p>
+    <h3>Recortar un lote entero</h3>
+    <p>
+      Una caja dibujada sobre una foto se aplica a las demás como la misma zona
+      <em>relativa</em>: las mismas fracciones del ancho y el alto de cada
+      archivo. Para una carpeta de capturas o exportaciones que son todas del
+      mismo tamaño, eso es exactamente el mismo rectángulo. Para un lote mezclado
+      es el mismo encuadre y no el mismo rectángulo, que suele ser lo que se
+      quería pero conviene saberlo antes de confiarle cincuenta archivos.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué cuesta la recodificación, y cómo dejarla en una</h2>
+    <p>
+      Redimensionar un JPEG o un WebP significa descodificarlo, escalar los
+      píxeles y volver a codificarlos &mdash; y ese último paso tiene pérdidas.
+      El escalado en sí no es lo que te cuesta calidad; la recodificación sí.
+    </p>
+    <p>
+      De ahí salen dos cosas. Primera: el ajuste de calidad de la salida importa;
+      algo en torno a 80&ndash;85 es invisible en una fotografía y bastante más
+      pequeño que 100. Segunda: hazlo una vez. Redimensionar una foto que ya se ha
+      redimensionado dos veces significa tres generaciones de codificación con
+      pérdidas, y se nota.
+    </p>
+    <p>
+      Un PNG no tiene ese coste, porque no tiene pérdidas &mdash; un PNG
+      redimensionado son exactamente los píxeles escalados. Si estás pasando por
+      varios pasos y todavía no se ha decidido el formato final, trabajar en PNG
+      por el medio evita ir acumulando generaciones.
+    </p>
+    <p>
+      Un detalle que conviene saber sobre la herramienta de aquí: un archivo que
+      no estás cambiando en nada se devuelve byte por byte en vez de
+      recodificarse. Pide «lado más largo 1600» en un lote y los que ya están por
+      debajo de 1600 salen intactos, con etiquetas y todo. Una herramienta que los
+      recodificara en silencio te estaría costando calidad en archivos que nadie
+      le ha pedido cambiar.
+    </p>
+  </section>
+
+  <section>
+    <h2>La transparencia y qué le pasa</h2>
+    <p>
+      PNG y WebP pueden guardar transparencia. JPEG no &mdash; el formato no tiene
+      ningún canal alfa. Así que guardar una imagen transparente como JPEG obliga a
+      poner algo detrás, y ese algo es un color plano.
+    </p>
+    <p>
+      Casi todas las herramientas usan blanco y no lo mencionan, lo que está bien
+      hasta que tu logotipo aterriza en una página oscura con una caja blanca
+      alrededor. Elige el color a propósito, o guarda como PNG o WebP y conserva
+      la transparencia. El mismo color se usa detrás de un marco rellenado, que es
+      el otro sitio donde la gente se topa con esto por sorpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué herramienta, si te han dado un número</h2>
+    <p>
+      Se reparten dos números distintos, y necesitan herramientas distintas.
+    </p>
+    <p>
+      <strong>«1200 píxeles de ancho»</strong> es un problema de dimensiones. El
+      <a href="../../redimensionar-imagen/">redimensionador de imágenes</a> es el
+      indicado: dices cuántos píxeles quieres y te los da.
+    </p>
+    <p>
+      <strong>«Por debajo de 500&nbsp;KB»</strong> es un problema de tamaño de
+      archivo, y redimensionar es solo una de las formas de resolverlo. El
+      <a href="../../comprimir-imagen/">compresor de imágenes</a> busca la calidad
+      más alta que cabe en tu objetivo y redimensiona solo si la calidad por sí
+      sola no llega;
+      <a href="../comprimir-una-imagen-a-un-tamano-exacto/">su guía</a> explica lo
+      que cuesta eso.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada de esto necesita una subida</h2>
+    <p>
+      Descodificar una imagen, escalarla y volver a codificarla son cosas que
+      cualquier navegador lleva años sabiendo hacer &mdash; es la misma maquinaria
+      que usa una página web para dibujar una imagen a otro tamaño. No hay ninguna
+      razón técnica para que tu foto viaje a un servidor y vuelva para salir más
+      pequeña, y la herramienta de aquí no la manda a ninguna parte: la
+      <code>Content-Security-Policy</code> de la página nombra todas las
+      direcciones que puede contactar, y ninguna es de este sitio.
+    </p>
+    <p>
+      Carga la página, desenchúfate de internet y redimensiona algo de todos modos
+      si prefieres comprobarlo a que te lo cuenten.
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      hacerle a cualquier herramienta.
+    </p>
+  </section>

--- a/locales/es/pages/guides/resize-an-image.toml
+++ b/locales/es/pages/guides/resize-an-image.toml
@@ -1,0 +1,23 @@
+#
+# Guía: redimensionar una imagen - Spanish.
+#
+# Overrides for pages/guides/resize-an-image/page.toml. Only words: the slug,
+# the kind, the group and the tool this guide is about stay where they are.
+#
+
+nav = "Redimensionar una imagen"
+
+title = "Cómo redimensionar una imagen sin destrozarla"
+description = "Qué le pasa a una foto cuando cambias sus dimensiones en píxeles: por qué encogerla es seguro y agrandarla no, qué hacer cuando la caja tiene otra forma, y cuándo conviene recortar en su lugar."
+
+heading = "Cómo redimensionar una imagen sin destrozarla"
+lede = """
+    Redimensionar es el único trabajo de imagen en el que el daño se decide
+    antes de pulsar el botón, según qué número escribas y qué forma pidas. Esto
+    es lo que le hace cada elección a la foto, y cuáles se pueden deshacer."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Redimensionar una imagen sin destrozarla"
+og_description = "Por qué encogerla es seguro y agrandarla no, qué hacer cuando la caja tiene otra forma, y cuándo conviene recortar en su lugar."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/trim-a-video.html
+++ b/locales/es/pages/guides/trim-a-video.html
@@ -1,0 +1,198 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../cortar-video/">cortador de vídeo</a>, suelta el clip
+      dentro, pulsa <kbd>I</kbd> y <kbd>O</kbd> para marcar cada trozo que
+      quieras &mdash; tantos como te apetezca &mdash; y exporta. En un MP4, un MOV
+      o un M4V, los fotogramas que conservas se trasladan al archivo nuevo tal y
+      como estaban &mdash; los mismos bytes, los mismos ajustes de codificación,
+      lo mismo en todo &mdash; y el sonido se copia muestra a muestra sin
+      descodificarlo.
+    </p>
+    <p>
+      Eso significa que un corte no te cuesta nada de calidad, y es rápido: sacar
+      un minuto de una grabación de cuatro gigabytes cuesta más o menos lo que
+      cuesta escribir ese minuto en disco, porque a los fotogramas se les apunta en
+      vez de cargarlos. El único sitio donde esto se nota es dónde cae de verdad tu
+      corte, que es el resto de esta página.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué un corte no tiene por qué perder nada de calidad</h2>
+    <p>
+      Cortar no cambia el aspecto de ningún fotograma. Cada fotograma que
+      conservas debe salir idéntico a como entró, así que no hay ninguna razón
+      para descodificarlo y volver a codificarlo &mdash; y todas las razones para
+      no hacerlo, ya que una recodificación tiene pérdidas y empeoraría
+      ligeramente el clip entero solo para acortarlo.
+    </p>
+    <p>
+      Así que un buen cortador no recodifica. Lee el índice del archivo, calcula
+      qué fotogramas codificados caen dentro de tu rango, y escribe esos bytes en
+      un contenedor nuevo con un índice nuevo delante. Por esa vía no se
+      descodifica absolutamente nada.
+    </p>
+    <p>
+      Muchas herramientas recodifican igualmente, porque descodificar y volver a
+      codificar es mucho más sencillo de implementar que analizar el formato del
+      contenedor. Normalmente puedes saber cuál estás usando por lo que tarda: una
+      copia está limitada por lo rápido que escriba tu disco, y una recodificación
+      está limitada por lo rápido que codifique vídeo tu equipo, que es cien veces
+      más lento.
+    </p>
+  </section>
+
+  <section>
+    <h2>Los fotogramas clave, y por qué tu corte puede caer antes</h2>
+    <p>
+      Aquí está la restricción de la que se deriva todo lo demás sobre cortar.
+    </p>
+    <p>
+      El vídeo no se guarda como una secuencia de imágenes completas. Eso sería
+      enorme. Casi todos los fotogramas se guardan como una descripción de en qué
+      se diferencian de sus vecinos, lo que significa que no se pueden
+      descodificar por su cuenta &mdash; hacen falta los fotogramas de alrededor.
+      Solo un <strong>fotograma clave</strong> se sostiene solo como imagen
+      completa, y los fotogramas clave suelen estar separados entre uno y diez
+      segundos.
+    </p>
+    <p>
+      Así que si marcas un corte dos segundos después del último fotograma clave,
+      un cortador que copia fotogramas no puede empezar ahí. Los fotogramas de tu
+      marca son ilegibles sin la tirada que lleva hasta ellos. Tiene que arrastrar
+      todo el tramo desde el fotograma clave anterior a tu marca.
+    </p>
+    <p>
+      Lo que hace al respecto es la parte interesante. El formato de archivo tiene
+      una manera estándar de decir <em>empieza a reproducir en este punto</em>
+      &mdash; los fotogramas de más están en el archivo pero el contenedor le
+      indica al reproductor que se los salte. Cualquier reproductor corriente lo
+      respeta, y el clip empieza exactamente donde dijiste. Un reproductor que lo
+      ignore empezará antes, hasta el hueco de un fotograma clave.
+    </p>
+    <p>
+      La herramienta de aquí te dice en qué caso estás y por cuánto antes de
+      exportar, así que es una decisión y no una sorpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cuándo aceptar una recodificación</h2>
+    <p>
+      Existe un corte exacto, y funciona recodificando el tramo inicial &mdash;
+      descodificando desde el fotograma clave y escribiendo una tirada nueva de
+      fotogramas que sí empieza donde lo marcaste. Es más lento, y cuesta un poco
+      de calidad solo en ese tramo inicial.
+    </p>
+    <p>
+      Elígelo cuando el clip vaya a un sitio que no vaya a respetar la instrucción
+      del contenedor, o donde no puedas controlar el reproductor: algunos editores
+      de vídeo, algunos sistemas de emisión y videoconferencia, algunos
+      reproductores por hardware antiguos. Elige la copia para todo lo demás, que
+      es casi todo &mdash; un navegador, un móvil, una plataforma social, un
+      reproductor multimedia.
+    </p>
+    <p>
+      Una tercera opción que no cuesta nada: mueve tu marca. Si la herramienta te
+      enseña dónde están los fotogramas clave, desplazar el corte al más cercano te
+      da un corte exacto sin ninguna recodificación. Rara vez merece la pena
+      renunciar a una copia por un segundo de diferencia.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sacar un trozo del medio</h2>
+    <p>
+      Quitar un tramo es una operación distinta de conservar uno, y conviene saber
+      que está soportada, porque muchos cortadores solo hacen lo segundo. Marca la
+      parte que no quieres, elige quitarla, y lo que queda a cada lado se une en un
+      solo clip con el sonido trasladado en sincronía.
+    </p>
+    <p>
+      La unión tiene la misma restricción de fotograma clave en el punto en que se
+      reanuda la segunda mitad, por el mismo motivo. Funciona por las dos vías de
+      MP4 de aquí. Es lo único que no puede hacer la alternativa por grabación de
+      más abajo, porque una grabación se hace de una pasada desde un solo cabezal.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formatos, y la alternativa</h2>
+    <p>
+      <strong>MP4, M4V y MOV</strong> se leen directamente, lleven el códec que
+      lleven dentro &mdash; H.264, HEVC, AV1, VP9. Copiar fotogramas no implica
+      descodificarlos, así que esta vía funciona incluso con un códec para el que
+      tu navegador no tenga ningún descodificador, que es una consecuencia
+      agradable de no mirar las imágenes.
+    </p>
+    <p>
+      <strong>Cualquier otra cosa que tu navegador sepa reproducir</strong>, WebM
+      la más evidente, se corta reproduciéndola y grabando el resultado. Eso
+      funciona, y tiene dos costes: tarda lo que dure el trozo, y la imagen y el
+      sonido se vuelven a codificar.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV y casi todos los MKV</strong> el navegador no los sabe
+      ni leer ni reproducir, y la herramienta lo dice en vez de fallar a mitad de
+      camino. Convierte esos primero a MP4 con algo que sí los maneje.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dos cosas que salen mal en silencio en otras herramientas</h2>
+    <p>
+      <strong>La rotación.</strong> Un móvil graba en horizontal y escribe una
+      instrucción de rotación dentro del archivo en vez de girar los píxeles. Un
+      cortador que copia fotogramas tiene que trasladar esa instrucción, o tu clip
+      vertical sale de lado &mdash; que es la forma clásica de arruinar un vídeo
+      cortado. La vía exacta de aquí gira los fotogramas mientras los recodifica y
+      escribe un archivo que no necesita ninguna rotación.
+    </p>
+    <p>
+      <strong>La sincronía del audio.</strong> El audio y el vídeo se guardan como
+      flujos separados con sus propios tiempos, y no se cortan en los mismos
+      puntos. Si los dos no se alinean a propósito en el corte, el sonido se va
+      desplazando. Por la vía de copia de aquí el audio se copia muestra a muestra
+      sin descodificarlo, así que es byte por byte lo que había en el archivo, y
+      una marca de edición lo mantiene sincronizado con la imagen con una precisión
+      de una milésima de segundo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cortar no es recortar</h2>
+    <p>
+      Dos palabras que se usan una por otra. Cortar cambia la duración del clip;
+      recortar cambia la forma de la imagen. Si lo que quieres es una versión
+      cuadrada de un vídeo horizontal, o quitar las bandas negras de los lados, eso
+      es el <a href="../../recortar-video/">recortador de vídeo</a> &mdash; y, a
+      diferencia de cortar, sí tiene que recodificar, por la razón que explica
+      <a href="../recortar-un-video/">su guía</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué esto no necesita una subida &mdash; y menos esto</h2>
+    <p>
+      El vídeo es el tipo de archivo que la gente más espera tener que subir,
+      porque los archivos son grandes y el trabajo suena pesado. Cortar es el caso
+      en el que eso es menos cierto: por la vía de copia el archivo apenas se lee.
+      La herramienta recorre el índice, calcula qué rangos de bytes conservar y los
+      escribe. Subir un archivo de cuatro gigabytes a un servidor para que haga eso
+      sería la forma más lenta posible de organizarlo.
+    </p>
+    <p>
+      Es además el tipo de archivo en el que subir cuesta más si prefieres no
+      hacerlo: el vídeo lleva caras, voces, casas y ubicaciones de una forma en que
+      un documento no. La herramienta de aquí no tiene ninguna función de red, y la
+      <code>Content-Security-Policy</code> de la página nombra todas las
+      direcciones que puede contactar, ninguna de las cuales es de este sitio.
+    </p>
+    <p>
+      Desenchúfate de internet y corta un clip de todos modos si prefieres
+      comprobarlo a que te lo cuenten.
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea otras tres comprobaciones parecidas.
+    </p>
+  </section>

--- a/locales/es/pages/guides/trim-a-video.toml
+++ b/locales/es/pages/guides/trim-a-video.toml
@@ -1,0 +1,23 @@
+#
+# Guía: cortar un vídeo - Spanish.
+#
+# Overrides for pages/guides/trim-a-video/page.toml. Only words: the slug, the
+# kind, the group and the tool this guide is about stay where they are.
+#
+
+nav = "Cortar un vídeo"
+
+title = "Cómo cortar un vídeo sin recodificarlo"
+description = "Cortar un clip no tiene por qué perder ni un byte de calidad. Por qué a veces el corte cae antes de donde lo marcaste, qué tiene que ver un fotograma clave con eso, y cuándo conviene aceptar una recodificación."
+
+heading = "Cómo cortar un vídeo sin recodificarlo"
+lede = """
+    Cortar no cambia el aspecto de ningún fotograma, así que un buen cortador no
+    los toca &mdash; los traslada a un archivo nuevo tal y como estaban. Esto
+    explica qué te compra eso, y el único sitio donde se nota."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Cómo cortar un vídeo sin recodificarlo"
+og_description = "Por qué a veces el corte cae antes de donde lo marcaste, qué tiene que ver un fotograma clave con eso, y cuándo conviene aceptar una recodificación."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/es/pages/guides/turn-a-video-into-a-gif.html
@@ -1,0 +1,225 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../convertir-video-a-gif/">convertidor de vídeo a
+      GIF</a>, suelta el clip dentro, marca los segundos que quieras, y deja el
+      ancho en 480 y la cadencia en 12 fotogramas por segundo. Ese es el ajuste
+      que quiere casi cualquier GIF. Si el archivo sale demasiado grande, baja el
+      ancho antes de tocar nada más &mdash; es el ajuste que paga dos veces.
+    </p>
+    <p>
+      El resto de esta página va de por qué, porque «mi GIF ocupa 14 MB» es el
+      problema que tiene todo el mundo de verdad, y cuál es el mando que hay que
+      girar no es evidente.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué un GIF de un vídeo es tan enorme</h2>
+    <p>
+      Un códec de vídeo guarda <em>movimiento</em>. Escribe una imagen completa
+      cada par de segundos y después, para cada fotograma intermedio, una
+      descripción de cómo se movió esa imagen: este bloque de píxeles se deslizó
+      cuatro a la izquierda, esta zona se oscureció un poco. Un clip de cinco
+      segundos puede ser de unos cientos de kilobytes porque casi todo él son
+      instrucciones sobre una imagen que ya tienes.
+    </p>
+    <p>
+      GIF no tiene nada de eso. Se terminó en 1989, antes de que existiera nada de
+      aquello. Cada fotograma es una imagen, comprimida por su cuenta con un
+      esquema diseñado para capturas de pantalla de una hoja de cálculo. En el
+      formato no hay ninguna estimación de movimiento por ninguna parte, y no hay
+      forma de añadirla.
+    </p>
+    <p>
+      Así que el número que hay que esperar es <strong>diez veces el tamaño del
+      vídeo</strong>, y ningún conversor te va a librar de eso. Lo que sí puede
+      hacer uno bueno es no desperdiciar nada por encima, y darte los tres ajustes
+      que de verdad lo deciden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Los tres ajustes, y lo que cuesta cada uno</h2>
+    <p>
+      Todo lo relativo al tamaño de un GIF se reduce a cuántos píxeles contiene,
+      que es la duración por la cadencia por el área de un fotograma.
+    </p>
+    <ul>
+      <li>
+        <strong>El trozo &mdash; lineal.</strong> El doble de largo son el doble
+        de fotogramas y más o menos el doble de archivo. Este es el que casi todo
+        el mundo ya entiende, y merece la pena ser implacable: un GIF que dice lo
+        que tiene que decir en tres segundos es además de más pequeño, un GIF
+        mejor.
+      </li>
+      <li>
+        <strong>El ancho &mdash; cuadrático.</strong> Reducir el ancho a la mitad
+        reduce el alto con él, así que son <em>la cuarta parte</em> de los
+        píxeles. Pasar de 640 a 320 no ahorra un poco menos de la mitad; ahorra
+        alrededor de tres cuartas partes. Este es el ajuste que nadie toca primero
+        y el que mejor paga.
+      </li>
+      <li>
+        <strong>La cadencia &mdash; lineal.</strong> Diez fotogramas por segundo
+        son dos tercios del tamaño de quince. Es además el ajuste en el que la
+        pérdida se ve más, porque un movimiento demasiado lento se lee como roto y
+        no como pequeño.
+      </li>
+    </ul>
+    <p>
+      Un ejemplo hecho. Seis segundos de un clip de móvil a sus propios
+      1080&times;1920 y 30 fps son 180 fotogramas de dos millones de píxeles: unos
+      350 millones de píxeles, que no es un GIF, es un secuestro. Los mismos seis
+      segundos a 480 de ancho y 12 fps son 72 fotogramas de 400 000 píxeles
+      &mdash; 30 millones, más o menos la doceava parte &mdash; y se parece a lo
+      que la gente entiende por un GIF.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué cadencia elegir</h2>
+    <p>
+      Doce es el valor por defecto de aquí y la respuesta correcta
+      sorprendentemente a menudo. Es la cadencia que lleva usando un siglo la
+      animación dibujada a mano: lo bastante rápida como para que el ojo la lea
+      como movimiento continuo, lo bastante lenta como para no estar pagando por
+      fotogramas que nadie ve.
+    </p>
+    <ul>
+      <li><strong>5&ndash;8</strong> &mdash; sensación de pase de diapositivas.
+        Vale para una panorámica lenta o para una grabación de pantalla donde no
+        se mueve nada rápido.</li>
+      <li><strong>10&ndash;15</strong> &mdash; normal. Se lee como movimiento.
+        Casi todos los GIF que merece la pena hacer están aquí.</li>
+      <li><strong>20&ndash;25</strong> &mdash; fluido, y más o menos el doble de
+        tamaño que 12 por una diferencia que casi ningún espectador va a saber
+        nombrar. Merece la pena para movimiento rápido, un clip deportivo o
+        cualquier cosa con una panorámica de latigazo.</li>
+    </ul>
+    <p>
+      Hay un techo duro que más vale conocer: GIF guarda cuánto se queda cada
+      fotograma en pantalla en centésimas de segundo, y todos los navegadores
+      tratan un retardo por debajo de dos centésimas como si fueran diez. Así que
+      50 fotogramas por segundo es el máximo real, y un archivo que pida 100 se
+      reproducirá a 10 sin decir nada. Un conversor que te ofrezca 60 fps o está
+      ignorando eso o está a punto de darte una sorpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>256 colores, y para qué sirve el tramado</h2>
+    <p>
+      La otra mitad de la edad del formato: un GIF lleva una tabla de 256 colores
+      como mucho, y cada píxel es un número que apunta dentro de ella. Un
+      fotograma de vídeo tiene hasta dieciséis millones. Casi todo eso se tira, y
+      cómo se tira es casi todo el aspecto que tiene un GIF.
+    </p>
+    <p>
+      Un buen conversor cuenta los colores de <em>tu</em> clip y elige 256 que le
+      vayan bien, en vez de usar un conjunto fijo. Un plano de un bosque se lleva
+      256 verdes; un plano de un atardecer se lleva 256 naranjas. Eso es lo que
+      hace la herramienta de aquí, a lo largo de todos los fotogramas del trozo y
+      no solo del primero, así que un color que solo aparece al final también tiene
+      su sitio.
+    </p>
+    <p>
+      El <strong>tramado</strong> es lo que pasa donde el color que necesitas sigue
+      sin estar. En vez de redondear una zona entera al color más cercano
+      disponible &mdash; que convierte un cielo suave en cuatro franjas planas con
+      escalones visibles entre ellas &mdash;, alterna los dos colores más cercanos
+      en un patrón fino, y desde una distancia normal de visionado tu ojo los
+      mezcla y ve el que no está.
+    </p>
+    <ul>
+      <li><strong>Déjalo activado</strong> para cualquier cosa fotográfica:
+        cielos, piel, degradados, sombras, cine.</li>
+      <li><strong>Desactívalo</strong> para el color plano: grabaciones de
+        pantalla, dibujo de línea, logotipos, dibujos animados, cualquier cosa con
+        grandes zonas de un solo tono. No hay ningún degradado que proteger, y el
+        archivo queda más pequeño y más limpio sin él.</li>
+    </ul>
+    <p>
+      Un detalle que conviene conocer si comparas conversores. La forma evidente de
+      tramar &mdash; la difusión de error, que es la que usan casi todos los
+      editores de imagen &mdash; hace que el resultado de cada píxel dependa de los
+      píxeles de alrededor. En una animación eso significa que un fondo que no se
+      mueve trama distinto en cada fotograma, así que hormiguea a la vista, y hay
+      que guardar cada fotograma entero porque técnicamente ha cambiado cada píxel.
+      La alternativa, un tramado ordenado, depende solo de dónde está un píxel, así
+      que un fondo quieto se queda perfectamente quieto. Eso es lo que usa esta
+      herramienta, y es por lo que sus archivos son además de más tranquilos, más
+      pequeños.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cuándo no hacer un GIF en absoluto</h2>
+    <p>
+      Merece la pena preguntárselo, porque la respuesta honesta muchas veces es «no
+      lo hagas». Un MP4 o un WebM mudo en bucle ocupa alrededor de la décima parte
+      que la misma animación en GIF, se reproduce igual, y es en lo que cualquier
+      plataforma social convierte tu GIF después de que lo subas de todas formas.
+    </p>
+    <p>Quédate con el GIF cuando el destino necesite uno de verdad:</p>
+    <ul>
+      <li>un sitio que solo acepta una imagen &mdash; mucho software de chat, de
+        foros, de wikis y de correo;</li>
+      <li>un README o una página de documentación, donde un GIF se reproduce en
+        línea y un vídeo necesita un reproductor;</li>
+      <li>una presentación o un documento que tiene que seguir moviéndose sin
+        conexión;</li>
+      <li>un emoji, una pegatina, una reacción &mdash; lo bastante pequeños como
+        para que nada de la aritmética de arriba importe.</li>
+    </ul>
+    <p>
+      Cuando el sonido importa, la pregunta se responde sola: GIF nunca ha tenido
+      audio y nunca lo tendrá. Corta el vídeo en su lugar &mdash; el
+      <a href="../../cortar-video/">cortador de vídeo</a> te saca un trozo sin
+      recodificar ni un fotograma.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bajar de un límite de tamaño</h2>
+    <p>
+      Casi todo el motivo por el que alguien afina un GIF es un límite al otro
+      lado. Por orden aproximado de cuánto aprietan:
+    </p>
+    <ul>
+      <li><strong>Correo</strong> &mdash; de 10 a 25 MB para el mensaje entero, y
+        un adjunto cerca de eso se lo quita o lo rebota algo por el camino.
+        Apunta bastante por debajo.</li>
+      <li><strong>Chat y foros</strong> &mdash; normalmente de 8 a 10 MB, a veces
+        mucho menos para una vista previa en línea en lugar de una descarga.</li>
+      <li><strong>Un README de GitHub</strong> &mdash; 10 MB por archivo, y
+        cualquier cosa por encima de un par de megabytes hace que la página
+        parezca rota en un móvil.</li>
+      <li><strong>Los huecos de pegatinas y emojis</strong> &mdash; muchas veces
+        unos cientos de kilobytes, lo que significa un ancho pequeño y un trozo
+        corto, no una cadencia más baja.</li>
+    </ul>
+    <p>
+      El orden en que hay que probar, cuando te pasas: acorta el trozo, después
+      reduce el ancho a la mitad, después baja la cadencia, después desactiva el
+      tramado. Los dos primeros valen más que los dos últimos juntos.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada de esto necesita una subida</h2>
+    <p>
+      Convertir un vídeo en un GIF es descodificar, redimensionar, contar colores y
+      comprimir &mdash; cuatro cosas que un navegador lleva años sabiendo hacer por
+      su cuenta. La herramienta enlazada arriba lo hace todo en tu equipo: el
+      archivo se lee de tu disco, los fotogramas los descodifica tu navegador, y el
+      GIF se monta en memoria y se entrega a tus descargas.
+    </p>
+    <p>
+      Y aquí eso merece más preocupación de lo habitual. Los clips que la gente
+      convierte en GIF son personales &mdash; un momento de un vídeo familiar, una
+      grabación de pantalla de algo del trabajo, unos segundos de una llamada. Un
+      conversor que quiere que se los subas está pidiendo una copia de ellos, y ya
+      no queda ninguna razón técnica para decir que sí.
+    </p>
+  </section>

--- a/locales/es/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/es/pages/guides/turn-a-video-into-a-gif.toml
@@ -1,0 +1,25 @@
+#
+# Guía: convertir un vídeo en un GIF - Spanish.
+#
+# Overrides for pages/guides/turn-a-video-into-a-gif/page.toml. Only words: the
+# slug, the kind, the group and the tool this guide is about stay where they
+# are.
+#
+
+nav = "Hacer un GIF a partir de un vídeo"
+
+title = "Cómo convertir un vídeo en un GIF (y que salga pequeño)"
+description = "Qué trozo, qué ancho y qué cadencia elegir, por qué un GIF de un vídeo ocupa diez veces lo que el vídeo, y cuándo conviene usar uno."
+
+heading = "Cómo convertir un vídeo en un GIF"
+lede = """
+    GIF es un formato de 1987 que guarda imágenes enteras en vez de movimiento,
+    así que uno hecho a partir de un vídeo siempre es grande. Esto es cuál de los
+    tres ajustes mover cuando sale demasiado grande, y cuánto te compra cada
+    uno."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Cómo convertir un vídeo en un GIF y que salga pequeño"
+og_description = "Los tres ajustes que deciden el tamaño de un GIF, lo que cuesta cada uno, y cuándo un GIF es directamente la respuesta equivocada."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/turn-images-into-a-video.html
+++ b/locales/es/pages/guides/turn-images-into-a-video.html
@@ -1,0 +1,193 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre <a href="../../imagenes-a-video/">Imágenes a vídeo</a>, suelta las
+      fotos dentro, ponlas en orden, decide cuánto se mantiene cada una y crea el
+      vídeo. Te llevas un MP4 con vídeo H.264, que se reproduce prácticamente en
+      cualquier cosa.
+    </p>
+    <p>
+      Los dos ajustes que más veces obligan a una segunda pasada son la duración
+      y la resolución, y merece la pena entenderlos antes del primer renderizado
+      y no después.
+    </p>
+  </section>
+
+  <section>
+    <h2>La cadencia y la duración no son lo mismo</h2>
+    <p>
+      Esta es la confusión que le cuesta a la gente un renderizado de más.
+    </p>
+    <p>
+      <strong>La duración</strong> es cuánto tiempo se queda cada imagen en
+      pantalla. Es el ajuste que de verdad te importa. Tres segundos es un valor
+      por defecto cómodo para un pase que alguien está mirando; uno o dos segundos
+      resulta ágil; cualquier cosa por encima de cinco se hace pesada, salvo que
+      haya una voz por encima.
+    </p>
+    <p>
+      <strong>La cadencia</strong> es cuántas veces por segundo el vídeo repite
+      esa imagen. No cambia nada del aspecto del pase &mdash; una imagen fija
+      mantenida tres segundos se ve idéntica a 24 fotogramas por segundo y a 60
+      &mdash; y cambia bastante el tamaño del archivo y el tiempo de codificación.
+    </p>
+    <p>
+      Así que para un pase de diapositivas normal, elige una cadencia baja. 24 o
+      30 sobran. La razón para subir es que haya movimiento en el vídeo: una
+      panorámica o un zoom sobre cada foto, o un fundido entre ellas, donde una
+      cadencia baja se ve como saltos.
+    </p>
+  </section>
+
+  <section>
+    <h2>La resolución, y las imágenes de otra forma</h2>
+    <p>
+      Un vídeo tiene un solo tamaño de fotograma para toda su duración. Tus
+      fotografías casi seguro que no comparten uno, así que algo tiene que
+      pasarles a las que no encajan &mdash; y ese algo es la decisión que merece
+      la pena tomar a propósito.
+    </p>
+    <p>
+      Empieza eligiendo la resolución según adónde va el vídeo:
+    </p>
+    <ul>
+      <li>
+        <strong>1920&times;1080</strong> para cualquier cosa general. Compatible
+        con todo, se reproduce en todas partes, y es lo que casi todo el mundo
+        entiende por HD.
+      </li>
+      <li>
+        <strong>1080&times;1920</strong> &mdash; los mismos números al revés
+        &mdash; para un destino pensado para el móvil: historias, reels, shorts.
+      </li>
+      <li>
+        <strong>3840&times;2160</strong> solo si las imágenes tienen de verdad
+        tanto detalle y el destino lo va a mostrar. Son cuatro veces los píxeles,
+        cuatro veces el tiempo de codificación y más o menos cuatro veces el
+        archivo.
+      </li>
+    </ul>
+    <p>
+      Después decide qué pasa con las que no encajan. Encajar cada imagen dentro
+      del fotograma la conserva entera y deja bandas a los lados &mdash; seguro, y
+      la respuesta correcta cuando las imágenes importan más que la presentación.
+      Llenar el fotograma y recortar lo que sobra queda mejor y le cortará la parte
+      de arriba a algunas. Mezclar fotografías verticales y horizontales en un
+      mismo vídeo es el caso en el que no hay ninguna buena respuesta; decidir de
+      antemano por qué lado prefieres equivocarte ahorra un renderizado.
+    </p>
+  </section>
+
+  <section>
+    <h2>El orden y la trampa de los nombres de archivo</h2>
+    <p>
+      Como en cualquier trabajo por lotes, los nombres de archivo se ordenan de
+      una forma que no es la forma en que contaste. <code>foto2.jpg</code> va
+      después de <code>foto10.jpg</code> en una ordenación alfabética, porque la
+      comparación es carácter a carácter.
+    </p>
+    <p>
+      Ordenar por fecha de captura suele ser lo correcto para fotografías de un
+      evento, ya que las hiciste en el orden en que pasaron las cosas. Arrastrar
+      las fichas es lo correcto para cualquier cosa cuya historia no sea
+      cronológica. Compruébalo antes de renderizar: el vídeo es el único resultado
+      en el que arreglar el orden significa volver a hacer el trabajo entero.
+    </p>
+  </section>
+
+  <section>
+    <h2>No hay banda sonora, y no es poca cosa</h2>
+    <p>
+      El MP4 que escribe esta herramienta tiene una única pista de vídeo y ninguna
+      pista de audio. Si tu pase necesita música o narración, harás falta un editor
+      de vídeo para ese paso.
+    </p>
+    <p>
+      Merece la pena saber por qué, y no solo que es así: añadir audio significa
+      descodificar un archivo de música, codificarlo a AAC e intercalarlo con el
+      vídeo dentro del contenedor. Las tres cosas son trabajo de verdad, y hacerlas
+      mal produce un archivo que se va desincronizando mientras se reproduce. Está
+      en la lista en vez de estar a medio hacer.
+    </p>
+    <p>
+      Una nota práctica si vas a añadir música después: elige primero la pista y
+      ajusta la duración por imagen para que el pase salga cerca de la duración de
+      la canción. Recortar la música para que quepa en el vídeo siempre suena peor
+      que ajustar el vídeo a la música.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué sale, y qué hacer si no se reproduce</h2>
+    <p>
+      El objetivo es MP4 con H.264, y es la combinación más ampliamente
+      reproducible que hay. En un navegador sin WebCodecs la herramienta recurre a
+      grabar WebM &mdash; el mismo material en un contenedor que aceptan menos
+      editores y menos plataformas sociales.
+    </p>
+    <p>
+      Si acabas con un WebM y algo lo rechaza, la solución es un navegador
+      compatible con WebCodecs y no una conversión: las versiones actuales de
+      Chrome, Edge y Safari lo son todas. Volver a renderizar es mejor que
+      convertir, porque convertir significa otra generación de codificación con
+      pérdidas.
+    </p>
+    <p>
+      La herramienta no lleva ningún límite dentro sobre cuántas imágenes puedes
+      usar. El techo es la memoria de tu propio equipo, porque el vídeo terminado
+      se monta ahí antes de que lo descargues &mdash; un pase largo en 4K es lo
+      primero que lo nota.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hacer el archivo más pequeño</h2>
+    <p>
+      Si el resultado es demasiado grande para donde vaya, por orden de lo que
+      ayuda de verdad:
+    </p>
+    <p>
+      <strong>Baja la cadencia.</strong> En un pase de imágenes fijas esto no
+      cuesta nada visible y es el mayor ahorro que hay de una sola tacada.
+    </p>
+    <p>
+      <strong>Baja la resolución.</strong> 1080p en vez de 4K es la cuarta parte
+      de los píxeles, y en la pantalla de un móvil nadie lo va a saber.
+    </p>
+    <p>
+      <strong>Acórtalo.</strong> Tres segundos por imagen en vez de cinco es un
+      40&nbsp;% menos de duración y un 40&nbsp;% menos de archivo, y normalmente un
+      pase mejor.
+    </p>
+    <p>
+      Reducir antes las fotografías de origen no ayuda mucho. El vídeo se codifica
+      a la resolución que elegiste, pase lo que pase, así que una foto de 4000
+      píxeles y una de 2000 producen casi el mismo número de bytes en un vídeo de
+      1080p. Sí hace la codificación más rápida, y mueve ese techo de memoria.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué esto no necesita un servidor, con una excepción declarada</h2>
+    <p>
+      Codificar vídeo solía ser el caso más claro a favor de subir cosas: los
+      navegadores no podían y una máquina con FFmpeg sí. WebCodecs cambió eso al
+      exponer el codificador por hardware que ya está en tu equipo, que es el mismo
+      que usa tu móvil para grabar vídeo en tiempo real. Componer los fotogramas es
+      un lienzo. Ninguno de los dos pasos necesita nada que no sea tu propio
+      hardware.
+    </p>
+    <p>
+      Una excepción en esta herramienta en concreto, declarada en vez de escondida:
+      la función opcional de «añadir desde una dirección web» descarga una imagen
+      desde una dirección que pegas tú, y el servidor de esa dirección ve tu IP y
+      qué has pedido. Eso es inherente a la función y no un defecto suyo, y es el
+      único paso de red que hay en toda la herramienta. No la uses y no sale nada
+      de tu equipo en absoluto.
+    </p>
+    <p>
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores en línea?</a> plantea cuatro comprobaciones que te dirán lo mismo
+      sobre cualquier herramienta, esta incluida.
+    </p>
+  </section>

--- a/locales/es/pages/guides/turn-images-into-a-video.toml
+++ b/locales/es/pages/guides/turn-images-into-a-video.toml
@@ -1,0 +1,24 @@
+#
+# Guía: convertir imágenes en un vídeo - Spanish.
+#
+# Overrides for pages/guides/turn-images-into-a-video/page.toml. Only words:
+# the slug, the kind, the group and the tool this guide is about stay where
+# they are.
+#
+
+nav = "Imágenes en un vídeo"
+
+title = "Cómo convertir una carpeta de imágenes en un vídeo"
+description = "Haz un pase de diapositivas en MP4 con tus fotos: qué controlan de verdad la cadencia y la duración, qué hacer con las imágenes que tienen otra forma, y por qué el resultado no lleva banda sonora."
+
+heading = "Cómo convertir una carpeta de imágenes en un vídeo"
+lede = """
+    Un pase de diapositivas es fácil de hacer y fácil de renderizar dos veces,
+    porque dos de los ajustes no significan lo que parece. Esto es lo que
+    controla cada uno y qué elegir."""
+
+updated = "20 de agosto de 2026"
+
+og_title = "Cómo convertir una carpeta de imágenes en un vídeo"
+og_description = "Qué controlan de verdad la cadencia y la duración, qué hacer con las imágenes que tienen otra forma, y por qué no hay banda sonora."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/privacy.html
+++ b/locales/es/pages/privacy.html
@@ -1,0 +1,188 @@
+  <section>
+    <h2>Tus archivos</h2>
+    <p>
+      Todas las herramientas de este sitio hacen su trabajo dentro de tu propio
+      navegador, en tu propio hardware. Cuando eliges un archivo, lo lee la
+      página que ya tienes abierta. No se nos envía, porque no hay ningún
+      servidor nuestro al que enviarlo &mdash; este sitio es un conjunto de
+      archivos estáticos, sin backend, sin base de datos y sin almacenamiento.
+    </p>
+    <p>
+      Eso significa que nunca recibimos, vemos, guardamos, registramos ni
+      procesamos:
+    </p>
+    <ul>
+      <li>tus archivos, ni enteros ni en parte</li>
+      <li>miniaturas o vistas previas de ellos</li>
+      <li>sus nombres, tamaños, dimensiones o formatos</li>
+      <li>cuántos elegiste, ni qué hiciste con ellos</li>
+      <li>nada leído de dentro de ellos, incluidos los datos EXIF y GPS</li>
+    </ul>
+    <p>
+      Esto no es una promesa sobre nuestras intenciones. Cada página lleva una
+      <code>Content-Security-Policy</code> que nombra todas las direcciones que
+      la página tiene permitido contactar, y el navegador la hace cumplir.
+      Ninguna de esas direcciones es nuestra. Puedes leer la política al
+      principio del código fuente de cualquier página, o abrir la pestaña Red de
+      tu navegador y mirar: ninguna petición lleva tu archivo.
+    </p>
+    <p>
+      Los archivos que produces con una herramienta se le entregan al mecanismo
+      de descargas de tu propio navegador y se guardan donde tú le digas. En ese
+      paso tampoco intervenimos.
+    </p>
+  </section>
+
+  <section>
+    <h2>La única excepción, y dónde se aplica</h2>
+    <p>
+      La herramienta <a href="../imagenes-a-video/">Imágenes a vídeo</a> tiene una
+      función de «añadir desde una dirección web». Si pegas una dirección en
+      ella, tu navegador descarga esa imagen del servidor que hayas nombrado, y
+      <strong>ese servidor ve tu dirección IP</strong> y qué archivo has pedido.
+      Eso es inevitable, y es la naturaleza entera de la función.
+    </p>
+    <p>
+      Solo ocurre con las direcciones que tecleas tú, está construida de modo que
+      las imágenes puedan entrar pero los datos no puedan salir, y la página de
+      esa herramienta lo explica con más detalle. Ninguna otra herramienta de este
+      sitio puede hacer una petición hacia fuera con nada tuyo dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué se recoge y quién lo recoge</h2>
+    <p>
+      Este sitio es gratuito y lo paga la publicidad. Eso significa que en estas
+      páginas funcionan dos productos de Google, y en casi todas ellas un botón
+      de donación. Esta es la lista entera.
+    </p>
+
+    <h3>Google AdSense &mdash; los anuncios</h3>
+    <p>
+      Google sirve los anuncios y decide cuáles ves. Para eso puede poner y leer
+      cookies o identificadores similares en tu navegador, y recibe tu dirección
+      IP, una ubicación aproximada derivada de ella, tu agente de usuario y en
+      qué página estabas. Según cuáles sean tus ajustes y dónde estés, los
+      anuncios pueden personalizarse usando un perfil que Google tiene sobre ti,
+      construido en gran medida a partir de tu actividad en otros sitios.
+    </p>
+    <p>
+      Nosotros no recibimos nada de eso, no podemos verlo, y nunca le enviamos a
+      Google nada sobre tus archivos. La explicación del propio Google sobre cómo
+      usa los datos de los sitios que llevan su publicidad está en
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>.
+    </p>
+
+    <h3>Google Analytics &mdash; el contador de visitas</h3>
+    <p>
+      Usamos Google Analytics 4 para contar visitas a las páginas, y así saber en
+      qué herramientas merece la pena trabajar. Registra la página que viste,
+      más o menos cuándo, un identificador generado al azar y guardado en tu
+      navegador, una ubicación aproximada, tu tipo de dispositivo y navegador, y
+      el sitio que te trajo hasta aquí.
+    </p>
+    <p>
+      Está configurado para no hacer nada más, y la configuración es un archivo
+      que puedes leer: el <code>analytics.js</code> que hay junto a cada página
+      monta un contador de páginas vistas y no contiene ningún evento propio. En
+      este sitio nada le pasa un archivo, un nombre de archivo, una dimensión o
+      un recuento &mdash; aquí no hay código que pudiera hacerlo.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; el botón de donación</h3>
+    <p>
+      La página principal y las páginas de las herramientas llevan un botón de
+      donación, que se carga desde los servidores de Buy Me a Coffee. Cargarlo
+      significa que su CDN ve tu dirección IP y que estabas en este sitio, y las
+      letras del botón se traen de Google Fonts, que también ve tu dirección IP.
+      No se envía nada más, y no pasa nada más a menos que lo pulses de verdad,
+      momento en el cual estás en su sitio y bajo sus políticas. Esta página y la
+      <a href="../terminos/">página de condiciones</a> no dibujan el botón.
+    </p>
+
+    <h3>Alojamiento</h3>
+    <p>
+      El sitio lo sirve GitHub Pages, detrás de Cloudflare. Como cualquier
+      alojamiento web, procesan las peticiones que hace tu navegador &mdash; lo
+      que incluye tu dirección IP, la página pedida y tu agente de usuario
+      &mdash; para entregar la página y para mantener el servicio en pie y
+      seguro. No tenemos acceso a registros por visitante de ninguno de los dos.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cookies</h2>
+    <p>
+      No ponemos ninguna cookie propia. No tenemos inicio de sesión, ni sesión,
+      ni preferencias que recordar, ni motivo para tenerlas.
+    </p>
+    <p>
+      Cualquier cookie o identificador similar que encuentres aquí es de Google y
+      lo ponen los scripts de publicidad y analítica descritos arriba. Se usan
+      para medir visitas y para seleccionar y limitar anuncios.
+    </p>
+    <h3>Cómo desactivarlo</h3>
+    <ul>
+      <li>
+        La personalización de anuncios se puede desactivar, para todos los sitios
+        a la vez, en
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">Mi centro de anuncios</a>.
+      </li>
+      <li>
+        Google Analytics se puede bloquear en todas partes con el
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">complemento de inhabilitación</a>
+        del propio Google.
+      </li>
+      <li>
+        Los ajustes de tu propio navegador pueden bloquear o borrar las cookies
+        de terceros, y cualquier bloqueador de contenido impedirá que estos
+        scripts lleguen a cargarse.
+      </li>
+    </ul>
+    <p>
+      Que lo bloquees todo nos parece bien. <strong>Todas las herramientas de
+      este sitio funcionan con los scripts bloqueados, y funcionan con la red
+      desconectada del todo.</strong> Aquí no hay nada retenido detrás de un
+      anuncio.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tus derechos sobre los datos</h2>
+    <p>
+      No tenemos ningún dato personal tuyo, así que no hay nada que podamos
+      enseñarte, corregir, exportar ni borrar &mdash; una solicitud dirigida a
+      nosotros volvería vacía, honestamente.
+    </p>
+    <p>
+      Los datos descritos arriba los tiene Google, que actúa como responsable de
+      ellos por su cuenta. Las solicitudes sobre ellos hay que dirigirlas a
+      Google, a través de
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">tu cuenta de Google</a>
+      o de sus contactos de privacidad.
+    </p>
+  </section>
+
+  <section>
+    <h2>Menores</h2>
+    <p>
+      Este sitio no está dirigido a menores y no le pregunta a nadie su edad,
+      porque no le pide nada a nadie. No recogemos a sabiendas ningún dato
+      personal de nadie, tenga la edad que tenga.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cambios y cómo contactar</h2>
+    <p>
+      Si esta página cambia, la fecha de arriba cambia con ella, y la edición
+      queda en el historial público de commits junto con todo lo demás.
+    </p>
+    <p>
+      Las preguntas sobre cualquiera de estas cosas pueden ir a
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, o plantearse como una
+      incidencia en <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">el repositorio</a>,
+      donde la respuesta la ve todo el que se estuviera preguntando lo mismo.
+    </p>
+  </section>

--- a/locales/es/pages/privacy.toml
+++ b/locales/es/pages/privacy.toml
@@ -1,0 +1,24 @@
+#
+# Privacidad y cookies - Spanish.
+#
+# Overrides for pages/privacy/page.toml. Only words: the slug, and the
+# machine-readable `lastmod` that goes in the sitemap, stay where they are.
+#
+
+nav = "Privacidad y cookies"
+
+title = "Privacidad y cookies &mdash; abox.tools"
+description = "Qué recoge y qué no recoge abox.tools. Tus archivos no se suben nunca; la publicidad, el contador de visitas y el botón de donación se describen aquí por completo."
+
+heading = "Privacidad y cookies"
+lede = """
+    La versión corta: tus archivos no se suben nunca, porque no hay ningún sitio
+    al que subirlos. Todo lo demás de esta página va de la publicidad, del
+    contador de visitas y del alojamiento &mdash; las partes en las que sí
+    intervienen otras empresas."""
+
+updated = "19 de agosto de 2026"
+
+og_title = "Privacidad y cookies &mdash; abox.tools"
+og_description = "Tus archivos no se suben nunca. Qué se recoge, quién lo recoge y cómo desactivarlo."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/terms.html
+++ b/locales/es/pages/terms.html
@@ -1,0 +1,157 @@
+  <section>
+    <h2>Qué es este sitio</h2>
+    <p>
+      abox.tools es una colección de utilidades pequeñas que funcionan dentro de
+      tu navegador. Son gratuitas y se pueden usar para cualquier cosa, incluido
+      el trabajo comercial. No hay nada que comprar, ninguna cuenta que crear,
+      ningún límite de uso y ninguna función retenida.
+    </p>
+    <p>
+      Al usar el sitio aceptas las condiciones de esta página. Si no las aceptas,
+      el remedio es sencillamente cerrar la pestaña &mdash; aquí no se guarda nada
+      tuyo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tus archivos siguen siendo tuyos</h2>
+    <p>
+      Conservas todos los derechos que ya tenías sobre los archivos que abras con
+      estas herramientas y sobre lo que produzcas con ellas. No reclamamos
+      ninguna licencia, ninguna propiedad ni ningún interés de ningún tipo sobre
+      ninguna de las dos cosas.
+    </p>
+    <p>
+      Y no es generosidad, es aritmética: las herramientas funcionan por completo
+      en tu navegador y tus archivos no se nos transmiten nunca, así que no hay
+      nada sobre lo que podamos tener derechos. La
+      <a href="../privacidad/">página de privacidad</a> explica cómo funciona eso
+      y cómo comprobarlo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Usar el sitio con responsabilidad</h2>
+    <p>
+      Eres responsable de los archivos que proceses y de lo que hagas con los
+      resultados. En particular, no uses estas herramientas sobre material sobre
+      el que no tengas derechos, ni para producir nada ilegal.
+    </p>
+    <p>
+      No podemos hacer cumplir esto y no vamos a fingir lo contrario. Nunca vemos
+      tus archivos, así que aquí no hay moderación, ni escaneo, ni forma alguna de
+      que sepamos qué está haciendo nadie. La obligación es genuinamente tuya.
+    </p>
+    <p>
+      Tampoco interfieras, por favor, con el propio sitio &mdash; atacando el
+      alojamiento, o redistribuyendo copias modificadas de una forma que sugiera
+      que son el original.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sin garantía</h2>
+    <p>
+      El sitio y sus herramientas se ofrecen <strong>tal cual</strong>, sin
+      garantía de ningún tipo, expresa o implícita, incluida cualquier garantía
+      implícita de comerciabilidad, de idoneidad para un fin concreto o de no
+      infracción.
+    </p>
+    <p>
+      En concreto: una herramienta puede producir un resultado que no querías,
+      puede fallar con un archivo que no entienda, puede comportarse de otra
+      manera en otro navegador, y puede perder el trabajo si se cierra la pestaña
+      a mitad de una operación. Nada de lo que haces aquí se guarda en ninguna
+      parte, así que <strong>conserva tus originales</strong>. No uses estas
+      herramientas sobre la única copia de algo que te importe.
+    </p>
+  </section>
+
+  <section>
+    <h2>Limitación de responsabilidad</h2>
+    <p>
+      En la máxima medida que permita la ley, no somos responsables de ninguna
+      pérdida ni daño derivados de tu uso de este sitio &mdash; incluidos
+      archivos perdidos, corrompidos o inutilizables, tiempo perdido, beneficios
+      perdidos, o cualquier pérdida indirecta o consecuente.
+    </p>
+    <p>
+      Nada de lo dicho aquí limita una responsabilidad que no pueda limitarse
+      legalmente.
+    </p>
+  </section>
+
+  <section>
+    <h2>Disponibilidad</h2>
+    <p>
+      El sitio se ofrece sin ninguna promesa de que vaya a seguir en pie, de que
+      vaya a seguir siendo gratuito, de que vaya a conservar una herramienta
+      concreta ni de que vaya a seguir existiendo. Las herramientas pueden
+      cambiar o retirarse sin aviso.
+    </p>
+    <p>
+      Hay una consecuencia práctica de cómo están construidas estas herramientas
+      que conviene saber: una vez que la página de una herramienta se ha cargado,
+      sigue funcionando sin conexión, y no deja de funcionar porque el sitio se
+      haya caído. El código es además público, así que una herramienta de la que
+      dependas puedes mantenerla en marcha tú, pase lo que pase aquí.
+    </p>
+  </section>
+
+  <section>
+    <h2>Publicidad y otras empresas</h2>
+    <p>
+      El sitio lleva publicidad de Google, cuenta las visitas con Google Analytics
+      y muestra un botón de donación en casi todas las páginas. Lo que implica
+      cada una de esas cosas se describe por completo en la
+      <a href="../privacidad/">página de privacidad</a>.
+    </p>
+    <p>
+      Los anuncios, y cualquier sitio al que llegues pulsando uno, no son
+      nuestros. No seleccionamos anuncios concretos, no respaldamos lo que dicen y
+      no somos responsables de los sitios a los que llevan ni de los tratos que
+      tengas allí. Lo mismo vale para todos los demás enlaces externos de este
+      sitio.
+    </p>
+  </section>
+
+  <section>
+    <h2>El código fuente</h2>
+    <p>
+      El código de este sitio está publicado abiertamente en
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>,
+      porque «léelo y compruébalo tú mismo» es la única respuesta de verdad a «por
+      qué debería fiarme de esto». La reutilización de ese código se rige por los
+      términos de licencia indicados en el repositorio, no por esta página. Estas
+      condiciones cubren tu uso del sitio web.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ley aplicable</h2>
+    <p>
+      Este sitio se opera desde Canadá. Estas condiciones, y cualquier disputa
+      que surja de ellas o de tu uso del sitio, se rigen por las leyes de Canadá
+      y de la provincia desde la que se opera el sitio, sin atender a las normas
+      de conflicto de leyes.
+    </p>
+    <p>
+      Si la legislación de consumo del lugar donde vives te da derechos que estas
+      condiciones restringirían, esos derechos prevalecen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cambios en estas condiciones</h2>
+    <p>
+      Estas condiciones pueden actualizarse. Cuando lo hagan, la fecha de arriba
+      cambia, y la edición aparece en el historial público de commits como
+      cualquier otro cambio. Seguir usando el sitio después de un cambio significa
+      aceptar la versión actualizada.
+    </p>
+    <p>
+      Las preguntas pueden ir a <a href="mailto:hi@abox.tools">hi@abox.tools</a>,
+      o plantearse como una incidencia en
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">el repositorio</a>.
+    </p>
+  </section>

--- a/locales/es/pages/terms.toml
+++ b/locales/es/pages/terms.toml
@@ -1,0 +1,23 @@
+#
+# Condiciones de uso - Spanish.
+#
+# Overrides for pages/terms/page.toml. Only words: the slug, and the
+# machine-readable `lastmod` that goes in the sitemap, stay where they are.
+#
+
+nav = "Condiciones de uso"
+
+title = "Condiciones de uso &mdash; abox.tools"
+description = "Las condiciones bajo las que se ofrece este sitio: gratis, tal cual, sin cuenta, sin garantía, y tus archivos siguen siendo enteramente tuyos porque nunca se nos envían."
+
+heading = "Condiciones de uso"
+lede = """
+    No hay ninguna cuenta que abrir ni ningún acuerdo que firmar, así que estas
+    son cortas. Describen lo que puedes esperar de este sitio y lo que no
+    promete."""
+
+updated = "19 de agosto de 2026"
+
+og_title = "Condiciones de uso &mdash; abox.tools"
+og_description = "Gratis, tal cual, sin cuenta y sin garantía. Tus archivos siguen siendo enteramente tuyos."
+og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/planned.toml
+++ b/locales/es/planned.toml
@@ -1,0 +1,73 @@
+#
+# La lista de lo previsto en la hoja de ruta - Spanish.
+#
+# Overrides for config/planned.toml. Only words: the group `id` stays as it is,
+# because that is what a tool's roadmap_group matches on, and the order of the
+# groups and of the items inside them is decided once, in English.
+#
+# Every group and every item has to be here. They are merged in order, so a
+# missing entry would render in English in the middle of a Spanish list with
+# nothing on the page to say which one it was - the build refuses a list whose
+# length has changed for exactly that reason.
+#
+
+note = "Todavía sin construir. Está aquí para que veas hacia dónde va esto."
+
+[[group]]
+name = "Imágenes"
+items = [
+  ["Girar y voltear", "en cuartos de vuelta, o enderezar unos pocos grados"],
+  ["Añadir texto", "sobre la imagen, o en una caja de texto encima"],
+  ["Filtros", "brillo, contraste, saturación, desenfoque, escala de grises"],
+  ["Imagen a data URI", "el resultado se pega directamente en CSS o HTML"],
+  ["HEIC a JPG", "las fotos que hace un iPhone, en un formato que abre todo"],
+  ["AVIF y JPEG XL", "convertir en ambas direcciones, sea cual sea el navegador que uses"],
+]
+
+[[group]]
+name = "GIF y animación"
+items = [
+  ["GIF a MP4 o WebM", "la misma animación, normalmente a una décima parte del tamaño"],
+  ["Descomponer un GIF", "cada fotograma como su propio PNG"],
+  ["Redimensionar, recortar y girar GIF", "fotograma a fotograma, conservando los tiempos"],
+  ["Invertir un GIF", "el último fotograma primero"],
+  ["Cambiar la velocidad de un GIF", "retimarlo sin volver a renderizar los fotogramas"],
+  ["Analizador de GIF", "fotogramas, retardos, paleta y adónde se han ido los bytes"],
+  ["Creador de APNG", "animación con transparencia de verdad y color completo"],
+  ["WebP animado", "otra vez la misma animación, por una fracción del tamaño"],
+]
+
+[[group]]
+name = "Vídeo"
+items = [
+  ["Redimensionar", "hasta un tamaño que de verdad se pueda enviar"],
+  ["Girar", "para ese clip que se grabó de lado"],
+  ["Silenciar, o guardar el audio", "quitar el sonido, o conservarlo por su cuenta"],
+  ["Convertir a MP4 o WebM", "el que insista en pedirte el sitio donde vas a publicar"],
+  ["Filtros", "brillo, contraste, saturación, desenfoque"],
+  ["Incrustar subtítulos", "un archivo SRT dibujado dentro de la imagen"],
+]
+
+[[group]]
+name = "Audio"
+items = [
+  ["Cortar", "quedarte con la parte que querías"],
+  ["Fundido de entrada y de salida", "para que no empiece y acabe de golpe"],
+  ["Imagen de la forma de onda", "dibujar una pista como si fuera una imagen"],
+  ["Convertir de formato", "MP3, WAV y Opus, en cualquier dirección"],
+]
+
+[[group]]
+name = "Documentos y PDF"
+items = [
+  ["Unir, dividir y reordenar", "páginas movidas de sitio sin pasar por un servidor"],
+  ["Girar y recortar páginas", "enderezar un escaneo que entró de lado, o recortarle los márgenes"],
+  ["Extraer imágenes", "sacar las fotos de vuelta de un documento"],
+]
+
+[[group]]
+name = "Más allá de los medios"
+items = [
+  ["Datos", "convertir, limpiar e inspeccionar CSV y JSON"],
+  ["Privacidad y seguridad", "hashes, sumas de verificación, eliminación de metadatos"],
+]

--- a/locales/es/tools/compress-image.html
+++ b/locales/es/tools/compress-image.html
@@ -1,0 +1,120 @@
+<main>
+  <!-- Paso 1 &mdash; los archivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige las imágenes</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo de la lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; la cifra que importa -->
+  <section class="card" id="target-card">
+    <h2><span class="step">2</span> Di cuánto puede ocupar</h2>
+
+    <p class="card-lede">
+      Esta es la parte que los demás compresores hacen al revés. Te dan un
+      control de calidad y te dejan adivinar qué ajuste queda por debajo del
+      límite que te han puesto. Di el límite en su lugar, y la herramienta busca
+      la calidad más alta que cabe &mdash; y después gasta lo que quede del
+      presupuesto en vez de devolverte un archivo de la mitad de lo que pediste.
+    </p>
+
+    <div class="target-row">
+      <div class="target-field">
+        <label for="target-value">Tamaño objetivo, por imagen</label>
+        <div class="inline-pair">
+          <input type="number" id="target-value" value="500" min="1" step="1" inputmode="decimal">
+          <label for="target-unit" class="visually-hidden">Unidad</label>
+          <select id="target-unit">
+            <option value="KB" selected>KB</option>
+            <option value="MB">MB</option>
+          </select>
+        </div>
+      </div>
+
+      <!--
+        The four numbers people are actually given: an upload form that says
+        100 KB, a forum avatar or a job application at 500 KB, an email
+        attachment at 1 MB, and a web page hero at 2 MB.
+      -->
+      <div class="presets" id="presets" role="group" aria-label="Objetivos habituales">
+        <button type="button" class="ghost" data-bytes="102400">100 KB</button>
+        <button type="button" class="ghost" data-bytes="512000">500 KB</button>
+        <button type="button" class="ghost" data-bytes="1048576">1 MB</button>
+        <button type="button" class="ghost" data-bytes="2097152">2 MB</button>
+      </div>
+    </div>
+
+    <p id="target-summary" class="field-summary"></p>
+
+    <fieldset class="options">
+      <legend>Cómo se le permite llegar hasta ahí</legend>
+
+      <div class="option-row">
+        <label for="format-select">Formato de salida</label>
+        <select id="format-select">
+          <option value="auto" selected>Automático &mdash; conservar el formato salvo que otro quede mejor</option>
+          <option value="keep">Conservar siempre el formato original</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/webp">WebP</option>
+          <option value="image/png">PNG (sin pérdidas, así que el tamaño sale de las dimensiones)</option>
+        </select>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="allow-resize" checked>
+        <span>
+          <strong>Puede hacer la foto más pequeña si no queda otra</strong>
+          <span class="check-note">
+            Solo se usa cuando la calidad por sí sola tendría que caer por debajo
+            del punto en que la compresión empieza a notarse. Por debajo de ahí,
+            menos píxeles buenos se ven mejor que más píxeles arruinados.
+            Desactívalo para conservar las dimensiones exactas y pagar un
+            objetivo ajustado con calidad.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Paso 3 &mdash; el único clic -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Comprimir</h2>
+
+    <div class="run-row">
+      <button type="button" id="compress-all" class="primary big" disabled>Comprimir al objetivo</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Comprimidas</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Descargar todo en un zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/compress-image.toml
+++ b/locales/es/tools/compress-image.toml
@@ -1,0 +1,251 @@
+#
+# Compresor de imágenes - Spanish.
+#
+# Overrides for tools/compress-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Compresor de imágenes"
+# El añadido es la frase que la gente busca. Como en inglés, el nombre del
+# producto se queda con la mitad ruidosa.
+heading = "Comprimir&nbsp;imagen <span class=\"h1-kw\">&mdash; a un tamaño exacto</span>"
+tagline = "Dices el tamaño. Lo demás lo calcula él."
+
+title = "Comprimir una imagen a un tamaño exacto &mdash; gratis, sin subir nada"
+description = "Comprime un JPEG, un PNG o un WebP a un tamaño exacto: 100 KB, 2 MB, el que sea. Funciona entero en tu navegador: sin subidas, sin cuenta y también sin conexión."
+og_title = "Comprimir una imagen al tamaño que tú elijas"
+og_description = "Dices un tamaño objetivo y esto busca la menor compresión que llega a él; después mide lo que ha costado. Funciona en tu propio equipo y no sube nada."
+og_image_alt = "Compresor de imágenes - di un tamaño y conserva la calidad"
+
+pledge = """
+    La compresión ocurre en tu propio navegador, en tu propio hardware, con los
+    codificadores que ya trae de serie. Esta herramienta no tiene ninguna
+    función de red &mdash; nada que descargar, nada que enviar &mdash; y al otro
+    lado de esta página no hay ningún servidor al que mandar una foto aunque lo
+    hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y comprime una foto. Ni una sola petición lleva una imagen,
+      una miniatura, un nombre de archivo ni un byte de lo que has elegido. O
+      desconéctate de internet y comprime una de todos modos."""
+
+read_first = """
+, <code>src/compress.js</code> para la búsqueda que
+      decide cuánta calidad se gasta, y <code>src/measure.js</code> para la
+      comparación que hay detrás de la cifra de «coincidencia visual»."""
+
+howto_heading = "Cómo comprimir una imagen a un tamaño concreto"
+
+card = """
+            Di el tamaño que necesitas &mdash; 100 KB, 2 MB, el que sea
+            &mdash; y encuentra la menor compresión que llega hasta ahí."""
+
+[words]
+plural = "imágenes"
+choose = "una imagen"
+analytics_extra = """, ni ninguno de los
+  tamaños o valores de calidad que esta herramienta calcula"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin límite de tamaño"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Tus imágenes no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final
+      donde pudieran recogerse tus archivos, ni nada en el código que los
+      enviara si lo hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ No hay ningún
+      <code>fetch</code>, ningún <code>XMLHttpRequest</code> ni ningún
+      <code>sendBeacon</code> en todo <code>src/</code>. La compresión es
+      <code>canvas.toBlob</code> &mdash; el codificador que ya está instalado en
+      tu navegador."""
+
+[[privacy]]
+title = "Las cifras se miden, no se informan."
+body = """
+ Los tamaños, el
+      valor de calidad y la comparación SSIM se calculan todos en esta página y
+      se te muestran. En este repositorio no hay ningún evento de analítica
+      propio que lleve un nombre de archivo, un tamaño, un recuento o un
+      resultado."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google, y el botón de donación de Buy Me a
+      Coffee. A ninguno se le entrega nada sobre tus fotos. Cada línea que lee,
+      comprime o mide un archivo se sirve desde este origen y está listada en el
+      repositorio."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta
+      sigue igual, porque nunca hubo un paso de red dentro de ella. Es la prueba
+      más sencilla de todas."""
+
+[[howto]]
+title = "Elige tus imágenes."
+body = """
+ Suéltalas sobre el selector o
+      escógelas a mano. Tu navegador las lee directamente del disco; mientras lo
+      haces no se envía nada a ninguna parte."""
+
+[[howto]]
+title = "Escribe el tamaño que te han exigido."
+body = """
+ 100 KB para ese
+      formulario que no para de rechazar tu foto, 500 KB para el portal de
+      solicitudes, 2 MB para una página que tiene que cargar rápido. Los cuatro
+      más habituales son botones."""
+
+[[howto]]
+title = "Pulsa «Comprimir al objetivo»."
+body = """
+ Cada imagen se codifica
+      varias veces mientras la herramienta se acerca a la calidad más alta que
+      cabe. Lo que ya está por debajo del objetivo se deja exactamente como
+      está."""
+
+[[howto]]
+title = "Mira lo que ha costado y descarga."
+body = """
+ Cada resultado dice en qué
+      se ha escrito, con qué calidad, si han cambiado las dimensiones y cuánto
+      se parece al original al medirlo. «Comparar» pone las dos fotos una al
+      lado de la otra."""
+
+[[faq]]
+q = "¿Se sube mi imagen a alguna parte?"
+a = """
+        No. Tu propio navegador descodifica, comprime y mide el archivo en tu
+        propio hardware, con los codificadores JPEG, PNG y WebP que ya trae de
+        serie. Esta herramienta no tiene ninguna función de red &mdash; nunca
+        descarga nada y nunca envía nada &mdash; y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es de este
+        sitio."""
+
+[[faq]]
+q = "¿Cómo acierta un tamaño exacto?"
+a = """
+        Probando. No existe ninguna fórmula que convierta un ajuste de calidad en
+        un número de bytes &mdash; depende por completo de la foto &mdash;, así
+        que la herramienta codifica la imagen varias veces y busca la respuesta.
+        Empieza por lo alto del rango de calidad y se acerca dividiendo por la
+        mitad, lo que encuentra la calidad más alta que cabe en unas ocho
+        codificaciones. Cada tamaño que ves en la página es un archivo codificado
+        de verdad, no una estimación."""
+
+[[faq]]
+q = "¿Qué significa aquí exactamente «pérdida mínima»?"
+a = """
+        Tres cosas concretas. Primera: una imagen que ya está por debajo de tu
+        objetivo pasa byte a byte en vez de volver a codificarse. Segunda: se
+        gasta calidad antes que resolución, y solo hasta un suelo a partir del
+        cual los artefactos de compresión empiezan a notarse &mdash; por debajo
+        de ese punto la herramienta hace la foto más pequeña y vuelve a subir la
+        calidad, porque menos píxeles buenos se ven mejor que más píxeles
+        arruinados. Tercera: en cuanto encuentra un resultado que cabe, la
+        búsqueda vuelve a subir hasta agotar el presupuesto, así que no te
+        llevas un archivo de 300 KB cuando pediste 500 KB."""
+
+[[faq]]
+q = "¿Qué son las cifras SSIM y PSNR de cada resultado?"
+a = """
+        Son una medición de lo que ha costado la compresión, tomada
+        descodificando el resultado y comparándolo con la foto original. SSIM
+        compara brillo, contraste y estructura locales, que se parece mucho más a
+        lo que molesta a un ojo que contar píxeles cambiados; por encima de 0,98
+        más o menos cuesta distinguirlas una al lado de la otra. PSNR es la cifra
+        clásica en decibelios. Ambas se calculan en tu equipo y ambas se muestran
+        para que la afirmación de pérdida baja se pueda comprobar en vez de solo
+        creerse."""
+
+[[faq]]
+q = "¿Qué formatos puede leer y escribir?"
+a = """
+        Lee todo lo que tu navegador sepa descodificar, que en la práctica
+        significa JPEG, PNG, WebP, GIF, BMP y &mdash; en casi todos los
+        navegadores actuales &mdash; AVIF. Escribe JPEG, PNG y WebP, porque esos
+        son los codificadores que traen los navegadores. En «automático» conserva
+        el formato con el que llegó tu archivo, y cambia a WebP solo cuando
+        conservarlo habría obligado a redimensionar o a una caída visible de
+        calidad."""
+
+[[faq]]
+q = "¿Por qué no puede comprimir mucho un PNG?"
+a = """
+        Porque PNG no tiene pérdidas: no hay ningún mando de calidad que girar.
+        La única forma de hacer un PNG más pequeño es darle menos píxeles o menos
+        colores, así que con PNG seleccionado la herramienta llega al objetivo
+        solo redimensionando. Si la imagen es una fotografía, JPEG o WebP se
+        acercarán mucho más a tu objetivo con una calidad que se ve perfectamente
+        bien &mdash; y si es un logotipo o una captura con transparencia, WebP
+        conserva la transparencia que JPEG rellenaría de blanco."""
+
+[[faq]]
+q = "¿Comprimir una imagen le quita los datos EXIF y GPS?"
+a = """
+        Sí, como efecto secundario. Comprimir significa descodificar la foto a
+        píxeles y volver a codificar esos píxeles, y un lienzo lleno de píxeles
+        no lleva etiquetas, así que la ubicación, el modelo de cámara, las marcas
+        de tiempo y todo lo demás sencillamente no se escriben en el archivo
+        nuevo. Si lo que quieres es quitar los metadatos sin tocar la foto, usa
+        mejor el <a href="../eliminar-datos-exif/">visor y eliminador de
+        EXIF</a> &mdash; reescribe el contenedor sin volver a comprimir nada."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. Tampoco hay límite en el número ni en el tamaño de los archivos,
+        porque no hay ningún servidor pagándolos &mdash; el trabajo ocurre en tu
+        propio equipo. El sitio lleva publicidad, que es lo que lo paga; a los
+        anuncios no se les da nada sobre tus imágenes."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tus imágenes fuera para
+        comprimirlas se detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Comprime imágenes JPEG, PNG y WebP al tamaño que tú digas. La herramienta busca la calidad más alta que cabe en el objetivo, redimensiona solo cuando la calidad por sí sola no llega, y mide el resultado frente al original. Funciona por completo en el navegador y no sube nada."
+features = [
+  "Comprime a un tamaño de archivo objetivo que tú eliges, no a un número de calidad que tienes que adivinar",
+  "Conserva la resolución completa siempre que puede, y redimensiona solo cuando la calidad por sí sola no alcanza el objetivo",
+  "Gasta todo el presupuesto: el resultado queda justo por debajo del objetivo en vez de muy por debajo",
+  "Mide el resultado frente al original con SSIM y PSNR",
+  "Deja los archivos que ya están por debajo del objetivo completamente intactos",
+  "JPEG, PNG y WebP, con elección automática de formato",
+  "Por lotes, con todos los resultados en un zip",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí las imágenes"
+hint = "o haz clic para buscarlas &mdash; JPEG, PNG, WebP y cualquier otra cosa que tu navegador sepa abrir"

--- a/locales/es/tools/compress-pdf.html
+++ b/locales/es/tools/compress-pdf.html
@@ -1,0 +1,161 @@
+<main>
+  <!-- Paso 1 &mdash; el archivo -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige un PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="file-row" class="file-row" hidden>
+      <div class="file-facts">
+        <strong id="file-name" class="file-name"></strong>
+        <span id="file-facts" class="file-sub"></span>
+      </div>
+      <button type="button" id="clear-file" class="ghost danger">Elegir otro</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; la pantalla que esta herramienta conservaría si solo pudiera conservar una -->
+  <section class="card" id="inventory-card" hidden>
+    <h2><span class="step">2</span> Mira dónde está el tamaño</h2>
+
+    <p class="card-lede">
+      «Comprimir un PDF» son dos trabajos distintos que comparten un nombre. Un
+      escaneo es un montón de fotografías, y volver a codificarlas vale la mayor
+      parte del archivo. Un contrato es texto y tipografías, que ya vinieron
+      comprimidos por el programa que los hizo &mdash; ahí no hay ningún ochenta
+      por ciento escondido, y ninguna herramienta puede encontrarlo. Cuál de los
+      dos tienes no es cuestión de opinión, así que aquí lo tienes antes de que
+      se toque nada.
+    </p>
+
+    <p id="verdict" class="verdict"></p>
+
+    <div class="breakdown">
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <ul id="breakdown-list" class="breakdown-list"></ul>
+    </div>
+
+    <p id="inventory-notes" class="field-summary"></p>
+  </section>
+
+  <!-- Paso 3 &mdash; cuánto gastar -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">3</span> Di cuánto hay que apretar</h2>
+
+    <p class="card-lede">
+      Un PDF anota de qué tamaño se dibuja cada imagen, así que esta herramienta
+      puede medir lo que la página usa de verdad en vez de adivinarlo. Un escaneo
+      de 4000 píxeles colocado a lo ancho de veinte centímetros de papel lleva
+      unos 500 píxeles por pulgada; a 150 se imprime igual y se ve igual en
+      pantalla. Los píxeles que nadie puede ver se gastan primero, porque no
+      cuestan nada.
+    </p>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Cuánta calidad se puede gastar</legend>
+      <div class="presets" id="presets" role="radiogroup" aria-label="Cuánta calidad se puede gastar">
+        <label class="preset">
+          <input type="radio" name="preset" value="smallest">
+          <span class="preset-body">
+            <strong>Lo más pequeño</strong>
+            <span class="preset-note">96 PPP. Para algo que solo hay que leer en pantalla.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="screen" checked>
+          <span class="preset-body">
+            <strong>Bien en pantalla</strong>
+            <span class="preset-note">130 PPP. La respuesta habitual para un archivo que tienes que enviar por correo.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="print">
+          <span class="preset-body">
+            <strong>Todavía bien en papel</strong>
+            <span class="preset-note">220 PPP. Más pequeño, y se seguirá imprimiendo como es debido.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="gentle">
+          <span class="preset-body">
+            <strong>Casi sin tocar las imágenes</strong>
+            <span class="preset-note">Sin ningún redimensionado. Casi todo el ahorro viene de reempaquetar el archivo.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <details class="advanced">
+      <summary>Poner los dos números a mano</summary>
+      <div class="option-row">
+        <label for="dpi-value">Máximo de píxeles por pulgada de espacio dibujado</label>
+        <div class="inline-pair">
+          <input type="number" id="dpi-value" min="0" max="1200" step="10" value="130" inputmode="numeric">
+          <span class="unit">PPP &mdash; con 0 cada imagen se queda a su tamaño completo</span>
+        </div>
+      </div>
+      <div class="option-row">
+        <label for="quality-value">Calidad JPEG</label>
+        <div class="inline-pair">
+          <input type="range" id="quality-value" min="30" max="95" step="1" value="68">
+          <output id="quality-out" for="quality-value">68</output>
+        </div>
+      </div>
+    </details>
+
+    <label class="check">
+      <input type="checkbox" id="strip-meta" checked>
+      <span>
+        <strong>Quitar lo que el archivo recuerda sobre su procedencia</strong>
+        <span class="check-note">
+          El nombre y la versión del programa que lo hizo, cuándo se creó y se
+          editó por última vez, el paquete XMP y el bloque privado que deja atrás
+          un programa de maquetación para poder reimportar su propio trabajo
+          &mdash; que a veces son megabytes. Nada de eso hace falta para mostrar
+          el documento.
+        </span>
+      </span>
+    </label>
+
+    <p id="settings-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Paso 4 &mdash; el único clic -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Comprimir</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Comprimir este PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Descargar</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <details id="per-image" class="advanced" hidden>
+        <summary>Qué le ha pasado a cada imagen</summary>
+        <ul id="image-list" class="image-list"></ul>
+      </details>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/compress-pdf.toml
+++ b/locales/es/tools/compress-pdf.toml
@@ -1,0 +1,267 @@
+#
+# Compresor de PDF - Spanish.
+#
+# Overrides for tools/compress-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Compresor de PDF"
+heading = "Comprimir&nbsp;PDF <span class=\"h1-kw\">&mdash; reducir el tamaño de un PDF</span>"
+tagline = "Encoge un documento sin mandarlo a ninguna parte."
+
+title = "Comprimir PDF &mdash; gratis, en tu navegador y sin subir nada"
+description = "Reduce el tamaño de un PDF sin subirlo. Tu propio navegador lee el archivo, lo vuelve a comprimir y lo reescribe, y la herramienta te enseña dónde está de verdad su tamaño antes de tocar nada."
+og_title = "Comprimir PDF &mdash; gratis, y no se sube nada"
+og_description = "Encoge un PDF en tu propio equipo. Mide de qué tamaño se dibuja cada imagen en la página, así que solo tira los píxeles que nadie podría ver."
+og_image_alt = "Comprimir PDF - reducir un documento sin subirlo"
+
+pledge = """
+    El documento se abre, se despieza y se vuelve a escribir en la memoria de
+    este equipo, con código servido desde esta dirección. Aquí nada puede hacer
+    una subida, y al otro lado de esta página no hay ningún servidor que la
+    recibiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y comprime un archivo. Ni una sola petición lleva una
+      página, una imagen ni un nombre de archivo. O desconéctate de internet y
+      comprime uno de todos modos."""
+
+read_first = """
+, y <code>src/reader.js</code> y <code>src/writer.js</code>
+      para toda la lectura y la reescritura, ninguna de las cuales puede llegar
+      a la red."""
+
+howto_heading = "Cómo reducir el tamaño de un PDF"
+
+card = """
+            Reduce un documento volviendo a comprimir las imágenes que lleva
+            dentro. Primero te enseña dónde está de verdad el tamaño, y dice sin
+            rodeos cuando no hay nada que rascar."""
+
+[words]
+plural = "documentos"
+choose = "un PDF"
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[facts]]
+text = "Los archivos se quedan en tu dispositivo"
+
+[[privacy]]
+title = "Tu documento no tiene adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Esta herramienta no añade nada a esa
+      lista: no tiene ninguna función de red propia, ni siquiera opcional. Aquí
+      no hay ningún punto final donde pudiera recogerse tu archivo, ni nada en el
+      código que lo enviara si lo hubiera."""
+
+[[privacy]]
+title = "El formato entero está en este repositorio."
+body = """
+ Un PDF es una lista de
+      objetos y una tabla que dice dónde empieza cada uno.
+      <code>src/objects.js</code> lee esa sintaxis, <code>src/reader.js</code>
+      sigue la tabla, <code>src/writer.js</code> escribe una nueva, y ninguno de
+      los tres importa nada capaz de hacer una petición. No se descarga ninguna
+      biblioteca y no se renderiza nada en un servidor."""
+
+[[privacy]]
+title = "Los archivos cifrados se rechazan en vez de abrirse."
+body = """
+
+      Un PDF con contraseña se rechaza, incluidos los que producen los escáneres
+      con una contraseña vacía y que técnicamente se abrirían. Quitarle la
+      protección a un documento es un trabajo distinto de hacerlo más pequeño, y
+      hacerlo en silencio sería una cosa sorprendente para una herramienta que
+      actúa en tu nombre."""
+
+[[privacy]]
+title = "Quita cosas en lugar de meterlas."
+body = """
+ El archivo terminado no lleva fecha
+      de creación, ni línea de productor, ni el nombre de la herramienta que lo
+      hizo. Con la casilla marcada pierde además el paquete XMP y los bloques
+      privados que dejan atrás los programas de maquetación &mdash; el mismo
+      argumento que hace la herramienta de EXIF, aplicado a otro contenedor."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google. A ninguno se le entrega nada sobre
+      tu documento: ni un archivo, ni una página, ni un nombre, un tamaño o un
+      número de páginas. Cada línea que lee, descodifica o escribe un PDF se
+      sirve desde este origen y está listada en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le da."
+body = """
+
+      El botón «Buy me a coffee» de la cabecera lo dibuja un script de
+      cdnjs.buymeacoffee.com y se compone con Google Fonts. Es un enlace y nada
+      más: no informa de ninguna visita, y no se le entrega nada sobre ti ni
+      sobre tu documento. No pasa nada a menos que lo pulses, y lo que hay al
+      otro lado es el sitio de otra gente."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo lo de esta
+      página sigue funcionando. Es la prueba más sencilla de todas: una
+      herramienta que mandara tu documento fuera para comprimirlo se
+      detendría."""
+
+[[howto]]
+title = "Elige un PDF."
+body = """
+ Suéltalo sobre el selector o escógelo a
+      mano. Tu navegador lo lee directamente del disco; mientras lo haces no se
+      envía nada a ninguna parte."""
+
+[[howto]]
+title = "Mira dónde está el tamaño."
+body = """
+ El desglose es la razón de
+      ser del segundo paso. Si la barra es casi toda imágenes, esta herramienta
+      tiene con qué trabajar. Si es casi toda tipografías y contenido de página,
+      lo dirá, y el ahorro honesto es de un pequeño porcentaje &mdash; mejor
+      saberlo antes de dedicarle un minuto."""
+
+[[howto]]
+title = "Di cuánto hay que apretar."
+body = """
+ Los ajustes con nombre son
+      resoluciones, no notas vagas: 96 PPP para leer en pantalla, 130 para
+      enviar por correo, 220 para algo que todavía tiene que imprimirse. Cada
+      uno se mide contra el tamaño al que se dibuja realmente la imagen en la
+      página, así que una foto colocada como miniatura no se trata como un
+      escaneo a página completa."""
+
+[[howto]]
+title = "Comprímelo y lee la línea que dice que se ha comprobado."
+body = """
+
+      Cuando termina la reescritura, el mismo lector de esta página vuelve a
+      abrir el archivo terminado y le cuenta las páginas. Si eso no coincide con
+      el original, la ejecución se declara fallida y no se ofrece ninguna
+      descarga."""
+
+[[faq]]
+q = "¿Se sube mi PDF a alguna parte?"
+a = """
+        No. Tu propio navegador lee, vuelve a comprimir y escribe el archivo en
+        tu propio hardware. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar &mdash; ninguna es de este sitio. Esta
+        herramienta no tiene ninguna función de red, ni siquiera opcional."""
+
+[[faq]]
+q = "¿Cuánto se va a reducir mi PDF?"
+a = """
+        Depende por completo de lo que lleve dentro, y por eso la herramienta lo
+        mide y te lo enseña antes de comprimir nada. Un documento escaneado es
+        casi todo fotografías y suele quedarse un 60&ndash;90&nbsp;% más
+        pequeño. Un contrato o una tesis son texto, dibujo vectorial y
+        tipografías incrustadas, y todo eso ya venía comprimido por el programa
+        que lo generó; ahí el ahorro suele ser de un pequeño porcentaje, de
+        reempaquetar el archivo y tirar lo que ya no se referencia. Cualquier
+        herramienta que prometa un porcentaje fijo sin mirar tu archivo está
+        adivinando."""
+
+[[faq]]
+q = "¿Comprimir un PDF le hace perder calidad?"
+a = """
+        Las imágenes que lleva se vuelven a codificar, así que sí, para esas. No
+        se toca nada más: el texto sigue siendo texto, seleccionable y
+        buscable, las tipografías se conservan enteras y el dibujo vectorial se
+        copia tal cual. La herramienta también se niega a empeorar una imagen
+        para nada &mdash; si la recodificación no sale más pequeña que el
+        original, los bytes originales vuelven al documento sin tocar."""
+
+[[faq]]
+q = "¿Qué son aquí los PPP y por qué los pregunta?"
+a = """
+        Un PDF anota de qué tamaño se dibuja cada imagen en la página, así que la
+        herramienta puede calcular su resolución efectiva: un escaneo de 4000
+        píxeles colocado a lo ancho de veinte centímetros de papel lleva unos 500
+        píxeles por pulgada. Nada en una pantalla y muy poco en papel puede
+        aprovechar eso, así que los píxeles por encima del ajuste que elijas son
+        los primeros en tirarse &mdash; cuestan una calidad que nadie ve. Esa
+        medición es la razón de que un logotipo colocado pequeño no se trate
+        igual que un escaneo a página completa."""
+
+[[faq]]
+q = "¿Puede abrir un PDF protegido con contraseña?"
+a = """
+        No, y es a propósito. Un documento cifrado se rechaza con un mensaje que
+        lo dice, incluso cuando la contraseña está en blanco &mdash; que es como
+        guardan muchos escáneres y fotocopiadoras. Quitarle la protección a un
+        archivo es un trabajo distinto de comprimirlo, y una herramienta que lo
+        hiciera en silencio estaría haciendo algo que no le pediste."""
+
+[[faq]]
+q = "¿Hay PDF que no pueda comprimir?"
+a = """
+        Algunas imágenes de dentro, sí. Las imágenes JPEG 2000, JBIG2 y
+        codificadas para fax (CCITT) no tienen descodificador en ningún
+        navegador, así que pasan intactas y se informa de ello &mdash; las dos
+        últimas son códecs de dos niveles y suelen estar ya cerca de su tamaño
+        mínimo. Las imágenes CMYK también se dejan en paz, porque recodificarlas
+        arriesga a desplazar los colores que sacaría una imprenta. Todo lo que
+        la herramienta se salta aparece nombrado en los resultados, con el
+        motivo."""
+
+[[faq]]
+q = "¿El archivo comprimido se seguirá abriendo en todas partes?"
+a = """
+        Sí. La salida se escribe como PDF 1.5, que entiende cualquier lector
+        publicado desde 2003, y la herramienta lo demuestra en tu propio equipo:
+        vuelve a abrir el archivo terminado y le cuenta las páginas antes de
+        ofrecértelo. Los formularios, los enlaces, los marcadores, la estructura
+        de accesibilidad y los adjuntos incrustados se llevan al archivo nuevo;
+        lo que se queda atrás es el material al que ya no apuntaba nada del
+        documento."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni más límite
+        de tamaño de archivo que el que permita la memoria de tu propio equipo.
+        El sitio lleva publicidad, que es lo que lo paga; a los anuncios no se
+        les da nada sobre tu documento."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tu documento fuera para
+        comprimirlo se detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Comprime un PDF en tu navegador. Las imágenes se vuelven a comprimir contra el tamaño al que se dibujan realmente en la página, y el documento se reescribe localmente, así que no se sube ningún archivo."
+features = [
+  "Enseña dónde está de verdad el tamaño de un documento antes de comprimir nada",
+  "Vuelve a comprimir las imágenes contra su resolución medida en la página",
+  "Deja una imagen en paz cuando recodificarla no la haría más pequeña",
+  "Tira los objetos que dejó atrás una edición anterior, y los metadatos opcionales",
+  "Vuelve a abrir y comprobar el archivo terminado antes de ofrecerlo",
+  "Funciona sin conexión; sin subidas, sin cuenta y sin límite de tamaño",
+]
+
+[picker]
+title = "Suelta aquí un PDF"
+hint = "o haz clic para buscarlo &mdash; un documento cada vez"

--- a/locales/es/tools/crop-video.html
+++ b/locales/es/tools/crop-video.html
@@ -1,0 +1,146 @@
+<main>
+  <!-- Paso 1 &mdash; el archivo -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige un vídeo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Archivo</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Tamaño</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Fotograma</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Duración</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Vídeo</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Audio</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; el recorte -->
+  <section class="card" id="crop-card" hidden>
+    <h2><span class="step">2</span> Define el recorte</h2>
+
+    <p class="stage-hint">
+      Arrastra dentro de la caja para moverla, o desde cualquier esquina para
+      cambiarle el tamaño. Con la caja enfocada, las flechas la desplazan un
+      píxel cada vez, <kbd>Alt</kbd>&nbsp;+&nbsp;flechas la redimensionan, y
+      mantener <kbd>Mayús</kbd> hace que cada paso sean diez.
+    </p>
+
+    <!-- The crop box itself is added here by src/cropper.js. The stage is given
+         the video's own shape, so the box can be positioned in percentages and
+         needs no recalculating when the window is resized. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <div class="crop-controls">
+      <div class="aspect-row" role="group" aria-label="Fijar el recorte a una forma">
+        <button type="button" data-aspect="free" class="active">Libre</button>
+        <button type="button" data-aspect="source">Original</button>
+        <button type="button" data-aspect="1:1">1:1</button>
+        <button type="button" data-aspect="4:5">4:5</button>
+        <button type="button" data-aspect="9:16">9:16</button>
+        <button type="button" data-aspect="16:9">16:9</button>
+        <button type="button" data-aspect="4:3">4:3</button>
+        <button type="button" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="ghost" title="Poner de lado la forma fijada">
+          Girar
+        </button>
+      </div>
+
+      <div class="numbers">
+        <label>Izquierda<input type="number" id="crop-x" min="0" step="1"></label>
+        <label>Arriba<input type="number" id="crop-y" min="0" step="1"></label>
+        <label>Ancho<input type="number" id="crop-w" min="16" step="2"></label>
+        <label>Alto<input type="number" id="crop-h" min="16" step="2"></label>
+        <div class="number-actions">
+          <button type="button" id="crop-max" class="ghost">Lo más grande</button>
+          <button type="button" id="crop-centre" class="ghost">Centrar</button>
+          <button type="button" id="crop-reset" class="ghost">Fotograma entero</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="even-note">
+      El ancho y el alto se mueven de dos en dos, porque H.264 no tiene forma de
+      guardar un fotograma con un lado impar.
+    </p>
+  </section>
+
+  <!-- Paso 3 &mdash; la exportación -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Recórtalo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Salida</label>
+        <select id="format">
+          <option value="mp4" selected>MP4 &mdash; recodificado fotograma a fotograma</option>
+          <option value="webm">WebM &mdash; grabado mientras se reproduce</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Calidad</label>
+        <select id="quality">
+          <option value="low">Archivo más pequeño</option>
+          <option value="medium" selected>Equilibrado</option>
+          <option value="high">Mejor calidad</option>
+        </select>
+        <p class="field-note">
+          Nunca más de lo que gastaba el original en esa misma zona &mdash;
+          recodificar por encima de eso solo hace el archivo más grande.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Conservar el sonido
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Fotograma de salida</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Conservado</dt><dd id="sum-kept">&mdash;</dd></div>
+      <div><dt>Duración</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Cómo</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Recortar vídeo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Descargar vídeo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/crop-video.toml
+++ b/locales/es/tools/crop-video.toml
@@ -1,0 +1,241 @@
+#
+# Recortador de vídeo - Spanish.
+#
+# Overrides for tools/crop-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Recortador de vídeo"
+heading = "Recortar&nbsp;vídeo <span class=\"h1-kw\">&mdash; recortar un vídeo en línea</span>"
+tagline = "Deja un clip reducido a la parte que importa."
+
+title = "Recortar un vídeo en línea &mdash; gratis, sin subidas y sin conexión"
+description = "Recorta un MP4, un MOV o un WebM a cualquier forma: cuadrado, 9:16 o una caja de píxeles exacta. Funciona en tu navegador: no se sube nada, se conserva el sonido y funciona sin conexión."
+og_title = "Recortador de vídeo &mdash; recorta un clip sin subirlo"
+og_description = "Arrastra una caja sobre tu clip y recórtalo a cualquier forma. Los fotogramas se descodifican y se vuelven a codificar en tu propio equipo, y el sonido original pasa intacto."
+og_image_alt = "Recortador de vídeo - recorta un clip en tu navegador sin subir nada"
+
+pledge = """
+    Tu propio navegador descodifica, recorta y codifica cada fotograma, en tu
+    propio hardware. Aquí nada puede descargar ni enviar nada &mdash; esta
+    herramienta no tiene ninguna función de red &mdash; y al otro lado de esta
+    página no hay ningún servidor al que mandar un vídeo aunque lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y recorta un clip. Ni una sola petición lleva un fotograma,
+      un nombre de archivo ni un byte de lo que has elegido. O desconéctate de
+      internet y recorta uno de todos modos &mdash; una herramienta que mandara
+      tu vídeo fuera a procesar sencillamente se detendría."""
+
+read_first = """
+, <code>src/demux.js</code> para el lector que
+      encuentra los fotogramas dentro de un MP4, y <code>src/transcode.js</code>
+      para el bucle que los descodifica, los recorta y los codifica. Ninguno
+      importa nada capaz de hacer una petición."""
+
+howto_heading = "Cómo recortar un vídeo"
+
+card = """
+            Arrastra una caja sobre un clip y déjalo con esa forma &mdash;
+            cuadrado para un feed, vertical para el móvil, o una caja de píxeles
+            exacta."""
+
+[words]
+plural = "vídeos"
+choose = "un vídeo"
+analytics_extra = """, ni ningún
+  fotograma, duración o tamaño de recorte"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Conserva el sonido"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[privacy]]
+title = "Tus vídeos no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudiera recogerse tu archivo, ni nada en el código que lo enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ Esta herramienta no tiene ninguna
+      función de red: ninguna dirección que pegar, nada que descargar, ningún
+      motor que se baje en el primer uso. Cada byte que toca tu vídeo vino de
+      este origen cuando se cargó la página."""
+
+[[privacy]]
+title = "La descodificación y la codificación son locales."
+body = """
+ Los fotogramas pasan
+      por WebCodecs en tu propio navegador, o por el mismo motor de reproducción
+      que te enseñaría el clip de todas formas. El archivo terminado se construye
+      en la memoria de este equipo y se entrega directamente a una descarga."""
+
+[[privacy]]
+title = "El sonido se copia, no se escucha."
+body = """
+ Por la vía de MP4 las
+      muestras de audio se trasladan sin descodificarlas siquiera &mdash; aquí
+      nada las vuelve a convertir en sonido, y nada podría pasarlas a ninguna
+      parte si lo hiciera."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google. A ninguno se le entrega nada sobre
+      tu vídeo: ni un archivo, ni un fotograma, ni un nombre, un tamaño, una
+      duración o la forma a la que lo recortaste. Cada línea que lee,
+      descodifica, recorta o codifica se sirve desde este origen y está listada
+      en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le da."
+body = """
+
+      El botón «Buy me a coffee» de la cabecera lo dibuja un script de
+      cdnjs.buymeacoffee.com y se compone con Google Fonts. Es un enlace y nada
+      más: no informa de ninguna visita, y no se le entrega nada sobre ti ni
+      sobre tu vídeo."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo lo de esta
+      página sigue funcionando. Es la prueba más sencilla de todas."""
+
+[[howto]]
+title = "Elige un vídeo."
+body = """
+ Suelta un MP4, MOV, M4V o WebM sobre
+      el selector, o escoge uno a mano. Tu navegador lo lee directamente del
+      disco; mientras lo haces no se envía nada a ninguna parte."""
+
+[[howto]]
+title = "Arrastra la caja sobre la parte que quieres conservar."
+body = """
+ Arrastra
+      dentro para moverla y desde cualquier esquina para cambiarle el tamaño.
+      Fíjala antes a una forma &mdash; 1:1 para una publicación cuadrada, 9:16
+      para el móvil, 16:9 para un encuadre panorámico &mdash; o escribe una caja
+      de píxeles exacta en los cuatro campos de debajo."""
+
+[[howto]]
+title = "Elige cuánta calidad gastar."
+body = """
+ La imagen tiene que volver
+      a codificarse, porque un fotograma recortado es otra imagen distinta.
+      «Equilibrado» la deja cerca de lo que el archivo ya gastaba en esa zona;
+      «Mejor calidad» gasta más. El sonido se conserva salvo que lo desactives."""
+
+[[howto]]
+title = "Recórtalo y descárgalo."
+body = """
+ El trabajo ocurre en tu propio
+      hardware, así que lo que tarde depende de tu equipo y no de una cola. El
+      vídeo terminado se entrega directamente a las descargas de tu navegador."""
+
+[[faq]]
+q = "¿Se sube mi vídeo a alguna parte?"
+a = """
+        No. Tu propio navegador lo lee, lo descodifica, lo recorta y lo codifica
+        en tu propio hardware. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar &mdash; ninguna es de este sitio.
+        Desenchúfate de internet y recorta un clip de todos modos si prefieres
+        comprobarlo a que te lo cuenten."""
+
+[[faq]]
+q = "¿Qué formatos de vídeo puedo recortar?"
+a = """
+        MP4, M4V y MOV se leen directamente, lleven lo que lleven dentro: H.264,
+        HEVC, AV1 o VP9, siempre que tu navegador sepa descodificar ese códec.
+        Cualquier otra cosa que tu navegador sepa reproducir &mdash; WebM la más
+        evidente &mdash; se recorta reproduciéndola y grabando el resultado, lo
+        que funciona pero tarda lo que dure el clip. Un archivo que el navegador
+        no sabe ni leer ni reproducir, que en la práctica significa AVI, WMV, FLV
+        y casi todos los MKV, se rechaza con un mensaje que lo dice, en vez de
+        fallar a mitad de camino."""
+
+[[faq]]
+q = "¿Hay algún límite de tamaño o duración del vídeo?"
+a = """
+        La herramienta no lleva ningún límite dentro, y el archivo no se carga
+        entero en memoria de golpe &mdash; se recorre de unos pocos megabytes en
+        unos pocos megabytes. El techo práctico es el vídeo terminado, que se
+        monta en memoria antes de que lo descargues, y el tiempo que tarde tu
+        equipo en codificarlo."""
+
+[[faq]]
+q = "¿Sobrevive el sonido?"
+a = """
+        Por la vía de MP4, exactamente: el audio se copia muestra a muestra sin
+        descodificarlo nunca, así que es byte por byte lo que había en el
+        archivo. Por la vía de la grabación se captura de la reproducción y se
+        vuelve a codificar, lo que cuesta algo de calidad. En cualquiera de los
+        dos casos hay una casilla para dejarlo fuera del todo."""
+
+[[faq]]
+q = "¿Recortar hace perder calidad?"
+a = """
+        La imagen se vuelve a codificar, porque un fotograma recortado es otra
+        imagen distinta y no hay forma de guardarla sin escribir los píxeles de
+        nuevo. Lo que la herramienta no hará es gastar más de lo que gastaba el
+        original en esa misma zona, ya que recodificar por encima de eso solo
+        hace el archivo más grande sin hacer que se vea mejor."""
+
+[[faq]]
+q = "¿Puedo cortar también la duración?"
+a = """
+        Aquí no, pero al lado sí. Esta herramienta cambia la forma de la imagen y
+        nada más: el clip que sale dura exactamente lo mismo que el que entró,
+        con su sincronía y su sonido intactos. Cortar es un trabajo aparte y es
+        una herramienta aparte &mdash; el <a href="../cortar-video/">cortador de
+        vídeo</a> marca los trozos de un clip que merece la pena conservar y los
+        guarda como un solo archivo, sin recodificar ni un fotograma."""
+
+[[faq]]
+q = "¿Por qué el ancho y el alto se mueven de dos en dos?"
+a = """
+        H.264, el códec que hay dentro de un MP4, guarda la imagen en bloques y
+        no tiene forma de describir un fotograma con un número impar de píxeles
+        de lado. En vez de redondear tu recorte en silencio después de fijarlo,
+        la caja solo ofrece números pares desde el principio."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. El sitio lleva publicidad, que es lo que lo paga; a los anuncios no
+        se les da nada sobre tu vídeo."""
+
+[schema]
+browser_requirements = "Necesita JavaScript. La salida en MP4 requiere un navegador con WebCodecs; los demás recurren a grabar en WebM."
+description = "Recorta un vídeo a cualquier forma o a una caja de píxeles exacta en el navegador. MP4, MOV y M4V se descodifican y se vuelven a codificar fotograma a fotograma, con el audio original trasladado intacto; cualquier otra cosa que el navegador sepa reproducir se recorta grabándola. No se sube nada."
+features = [
+  "Recorta vídeo MP4, MOV, M4V y WebM",
+  "Fuentes H.264, HEVC, AV1 y VP9, descodificadas mediante WebCodecs",
+  "Recorte libre, proporciones fijas (1:1, 4:5, 9:16, 16:9, 4:3, 3:2) o una caja de píxeles exacta",
+  "Conserva el audio original sin volver a codificarlo",
+  "Funciona sin conexión; sin subidas, sin cuenta y sin marca de agua",
+]
+
+[picker]
+title = "Suelta aquí un vídeo"
+hint = "o haz clic para buscarlo &mdash; MP4, MOV, M4V, WebM y cualquier otra cosa que este navegador reproduzca"

--- a/locales/es/tools/edit-audio.html
+++ b/locales/es/tools/edit-audio.html
@@ -1,0 +1,170 @@
+<main>
+  <!-- Paso 1 &mdash; el archivo -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige un archivo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Archivo</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Tamaño</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Duración</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Sonido</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>Momento más alto</dt><dd id="src-peak">&mdash;</dd></div>
+      <div><dt>Leído como</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <div class="wave-wrap" id="src-wave-wrap" hidden>
+      <canvas id="src-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="preview" controls preload="metadata"></audio>
+    </div>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; las ediciones -->
+  <section class="card" id="edit-card" hidden>
+    <h2><span class="step">2</span> Cámbialo</h2>
+
+    <div class="edit-block">
+      <label class="check" for="reverse">
+        <input type="checkbox" id="reverse">
+        Reproducirlo al revés
+      </label>
+      <p class="field-note">
+        Las muestras se escriben empezando por la última. No cambia nada más de
+        ellas, así que invertir dos veces devuelve exactamente el archivo del
+        principio.
+      </p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="speed">Velocidad</label>
+        <input type="text" id="speed-value" class="value-box" inputmode="decimal"
+               spellcheck="false" autocomplete="off" aria-label="Velocidad, como múltiplo">
+      </div>
+
+      <!-- The slider is in octaves, not multiples: half speed and double speed
+           are then the same distance either side of the middle, which is how
+           they sound. main.js does the conversion. -->
+      <input type="range" id="speed" min="-2" max="2" step="0.01" value="0"
+             aria-describedby="speed-note">
+
+      <div class="presets" role="group" aria-label="Preajustes de velocidad">
+        <button type="button" class="ghost" data-speed="0.5">0,5&times;</button>
+        <button type="button" class="ghost" data-speed="0.75">0,75&times;</button>
+        <button type="button" class="ghost" data-speed="1">1&times;</button>
+        <button type="button" class="ghost" data-speed="1.25">1,25&times;</button>
+        <button type="button" class="ghost" data-speed="1.5">1,5&times;</button>
+        <button type="button" class="ghost" data-speed="2">2&times;</button>
+      </div>
+
+      <fieldset class="modes">
+        <legend>Qué le pasa al tono</legend>
+        <label class="mode">
+          <input type="radio" name="pitch" value="keep" checked>
+          <span>
+            <strong>Conservar el tono</strong>
+            Una voz sigue sonando a la misma voz, solo que más rápida o más lenta.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="pitch" value="move">
+          <span>
+            <strong>Dejar que se mueva</strong>
+            Más rápido es más agudo y más lento es más grave, como hace una cinta.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="speed-note"></p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="volume">Volumen</label>
+        <input type="text" id="volume-value" class="value-box" inputmode="decimal"
+               spellcheck="false" aria-label="Cambio de volumen, en decibelios">
+      </div>
+
+      <input type="range" id="volume" min="-24" max="24" step="0.5" value="0"
+             aria-describedby="volume-note">
+
+      <fieldset class="modes">
+        <legend>Cuánto hay que subirlo</legend>
+        <label class="mode">
+          <input type="radio" name="level" value="gain" checked>
+          <span>
+            <strong>Esta cantidad</strong>
+            Todas las muestras multiplicadas por el mismo número. No cambia nada más.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="level" value="normalize">
+          <span>
+            <strong>Lo más alto que dé</strong>
+            Subido hasta que el momento más alto queda justo por debajo del techo.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="volume-note"></p>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Duración</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Velocidad</dt><dd id="sum-speed">&mdash;</dd></div>
+      <div><dt>Momento más alto</dt><dd id="sum-peak">&mdash;</dd></div>
+      <div><dt>Aproximadamente</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="clip-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Paso 3 &mdash; el archivo que sale -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Guárdalo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">Qué escribir</label>
+        <select id="depth">
+          <option value="16" selected>WAV de 16 bits &mdash; se reproduce en todas partes</option>
+          <option value="32">WAV de coma flotante de 32 bits &mdash; nada recortado</option>
+        </select>
+        <p class="field-note" id="depth-note">
+          Un WAV guarda las muestras tal cual, así que escribir uno no puede
+          costar calidad. No es un archivo pequeño: mira la estimación de arriba.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary">Editar el audio</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Descargar audio</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/edit-audio.toml
+++ b/locales/es/tools/edit-audio.toml
@@ -1,0 +1,283 @@
+#
+# Editor de audio - Spanish.
+#
+# Overrides for tools/edit-audio/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Editor de audio"
+heading = "Editor&nbsp;de&nbsp;audio <span class=\"h1-kw\">&mdash; invertir, acelerar o amplificar una pista</span>"
+tagline = "Ponla del revés, cámbiale la velocidad, levanta una grabación floja &mdash; todo aquí, en tu equipo."
+
+title = "Invertir audio, cambiar la velocidad y subir el volumen &mdash; gratis, sin subir nada"
+description = "Reproduce una pista al revés, acelérala o ralentízala, y sube una grabación que quedó floja. También saca el sonido de un vídeo. Funciona en tu navegador: no se sube nada."
+og_title = "Editor de audio &mdash; invierte, retima y amplifica sin subir nada"
+og_description = "Invierte una pista, cámbiale la velocidad con o sin mover el tono, y ajusta el nivel; después descarga un WAV. Tu propio navegador lee y escribe el archivo."
+og_image_alt = "Editor de audio - invierte, retima y amplifica audio en tu navegador"
+
+pledge = """
+    Tu propio navegador lee, edita y escribe tu archivo, en tu propio hardware.
+    Aquí nada puede descargar ni enviar nada &mdash; esta herramienta no tiene
+    ninguna función de red &mdash; y al otro lado de esta página no hay ningún
+    servidor al que mandar una grabación aunque lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» e invierte algo. Ni una sola petición lleva una muestra, un
+      nombre de archivo ni un byte de lo que has elegido. O desconéctate de
+      internet y edita una pista de todos modos &mdash; una herramienta que
+      mandara tu audio fuera a procesar sencillamente se detendría."""
+
+read_first = """
+, <code>src/decode.js</code> para las veinte líneas
+      que le pasan tu archivo al descodificador del propio navegador,
+      <code>src/stretch.js</code> para el estirador de tiempo,
+      <code>src/speed.js</code> para el remuestreador y <code>src/wav.js</code>
+      para la cabecera que va delante de las muestras. Ninguno importa nada
+      capaz de hacer una petición."""
+
+howto_heading = "Cómo editar un archivo de audio"
+
+card = """
+            Invierte una pista, cámbiale la velocidad con o sin mover el tono, y
+            levanta una grabación que quedó floja. También saca el sonido de un
+            vídeo."""
+
+[words]
+plural = "grabaciones"
+choose = "un archivo"
+analytics_extra = """, ni ninguna
+  forma de onda, duración o nivel"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Entra vídeo, sale audio"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[privacy]]
+title = "Tus grabaciones no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudiera recogerse tu archivo, ni nada en el código que lo enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ Esta herramienta no tiene ninguna
+      función de red: ninguna dirección que pegar, nada que descargar, ningún
+      motor que se baje en el primer uso. Cada byte que toca tu audio vino de
+      este origen cuando se cargó la página."""
+
+[[privacy]]
+title = "El descodificador es el que ya trae tu navegador."
+body = """
+
+      El archivo se le pasa a <code>decodeAudioData</code>, el mismo código que
+      reproduce una pista en un elemento <code>&lt;audio&gt;</code>. Aquí no se
+      envía nada para leer tu formato, y tampoco se le pide nada a nada de fuera
+      de esta página para leerlo."""
+
+[[privacy]]
+title = "La imagen de un vídeo no se descodifica jamás."
+body = """
+ Cuando sueltas un
+      vídeo, solo se pide su pista de audio. Los fotogramas no se leen, no se
+      descodifican, no se dibujan y no se miran &mdash; no hay en esta página
+      código que pudiera hacerlo, y el archivo que sale lleva sonido y nada
+      más."""
+
+[[privacy]]
+title = "Las muestras se anotan, no se vuelven a codificar."
+body = """
+
+      Un WAV son las muestras que ha calculado esta página con una cabecera
+      delante. En el bucle no hay ningún codificador tomando decisiones sobre tu
+      grabación, ni nada que pudiera describirse como una subida sobre la que
+      ocurriera algo."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google. A ninguno se le entrega nada sobre
+      tu grabación: ni un archivo, ni una muestra, ni un nombre, un tamaño, una
+      duración o lo alta que estaba. Cada línea que lee, edita y escribe se sirve
+      desde este origen y está listada en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le da."
+body = """
+
+      El botón «Buy me a coffee» de la cabecera lo dibuja un script de
+      cdnjs.buymeacoffee.com y se compone con Google Fonts. Es un enlace y nada
+      más: no informa de ninguna visita, y no se le entrega nada sobre ti ni
+      sobre tu archivo."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo lo de esta
+      página sigue funcionando. Es la prueba más sencilla de todas."""
+
+[[howto]]
+title = "Elige un archivo."
+body = """
+ Suelta sobre el selector un MP3, WAV,
+      FLAC, M4A, Ogg u Opus &mdash; o un vídeo, si lo que quieres es sacarle el
+      sonido. Tu navegador lo lee directamente del disco; mientras lo haces no se
+      envía nada a ninguna parte."""
+
+[[howto]]
+title = "Dale la vuelta, si es a lo que venías."
+body = """
+ Una sola
+      casilla. Las muestras se escriben empezando por la última, lo cual es
+      exactamente reversible: hazlo dos veces y tienes el archivo del principio,
+      muestra por muestra."""
+
+[[howto]]
+title = "Ajusta la velocidad."
+body = """
+ Arrastra el control, escribe un
+      múltiplo o pulsa uno de los preajustes. Después elige qué le pasa al tono:
+      dejarlo donde está, que es lo que quieres para una clase a 1,5&times;, o
+      dejar que se mueva con la velocidad, que es lo que hace una cinta y lo que
+      sube o baja una voz."""
+
+[[howto]]
+title = "Ajusta el nivel."
+body = """
+ O dices un cambio en decibelios, o pides
+      que la grabación suba hasta que su momento más alto quede justo por debajo
+      del techo. La página dice dónde va a caer ese momento antes de que pulses
+      nada, y te avisa si el ajuste que has elegido lo empujaría más allá de la
+      escala completa."""
+
+[[howto]]
+title = "Guárdalo."
+body = """
+ El trabajo ocurre en tu propio hardware, así que
+      lo que tarde depende de tu equipo y no de una cola. Lo que sale es un WAV
+      &mdash; las propias muestras, con una cabecera delante &mdash; que primero
+      se reproduce en la página y después se entrega directamente a las descargas
+      de tu navegador."""
+
+[[faq]]
+q = "¿Se sube mi audio a alguna parte?"
+a = """
+        No. Tu propio navegador lo lee, lo edita y lo escribe en tu propio
+        hardware. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar &mdash; ninguna es de este sitio.
+        Desenchúfate de internet e invierte una pista de todos modos si prefieres
+        comprobarlo a que te lo cuenten."""
+
+[[faq]]
+q = "¿Puedo sacar el audio de un vídeo?"
+a = """
+        Sí, y aquí es el mismo trabajo que abrir un MP3. Suelta un MP4, un MOV o
+        un WebM y solo se descodifica su pista de audio: la imagen no se lee
+        nunca, y lo que sale es un archivo de sonido sin vídeo dentro. Es además
+        la forma de guardar el sonido de un clip sin editarlo en absoluto
+        &mdash; no toques ningún ajuste y pulsa el botón."""
+
+[[faq]]
+q = "¿Cambiar la velocidad cambia el tono?"
+a = """
+        Solo si se lo pides. «Conservar el tono» corta la grabación en ventanas
+        solapadas de unos cincuenta milisegundos y las vuelve a colocar más
+        juntas o más separadas, eligiendo cada posición para que las ondas
+        encajen donde se cruzan &mdash; una voz sigue siendo la misma voz a
+        1,5&times;. «Dejar que se mueva» remuestrea, que es lo que hace poner una
+        cinta más rápido: el doble de velocidad es exactamente una octava más
+        arriba."""
+
+[[faq]]
+q = "¿Por qué guarda un WAV y no un MP3?"
+a = """
+        Porque ningún navegador trae un codificador de MP3, y esta herramienta se
+        niega a mandar tu grabación a un servidor que tenga uno. Un WAV no
+        necesita ningún codificador &mdash; son las muestras con una cabecera de
+        cuarenta y cuatro bytes delante &mdash;, así que es a la vez la opción
+        honesta y la única que no puede costar calidad. Es más grande: unos diez
+        megabytes por minuto en estéreo. Lo abre cualquier reproductor, cualquier
+        móvil y cualquier editor, y lo que quiera un MP3 puede sacarlo de ahí."""
+
+[[faq]]
+q = "¿Qué formatos puedo abrir?"
+a = """
+        Los que tu navegador descodifique, que en la práctica significa MP3, WAV,
+        FLAC, M4A y AAC, Ogg Vorbis y Opus, y el audio dentro de vídeo MP4, M4V,
+        MOV y WebM. Lo que queda fuera es la misma lista corta de siempre: AVI,
+        WMA y casi todos los MKV. Un archivo que este navegador no lea se rechaza
+        con un mensaje que lo dice, en vez de fallar a mitad de camino."""
+
+[[faq]]
+q = "¿Subirle el volumen lo va a distorsionar?"
+a = """
+        Solo si lo pasas de la escala completa, y la página te lo dice antes de
+        que lo hagas. El audio digital tiene un techo duro: una muestra no puede
+        ser más alta que la escala completa, así que todo lo que quede por encima
+        se aplasta contra el techo, y eso es lo que suena a distorsión. «Lo más
+        alto que dé» es el ajuste que no puede hacer eso &mdash; calcula cuánto
+        margen le queda a la grabación y usa exactamente ese. Todo lo que hay por
+        debajo del techo es una multiplicación y nada más: súbelo 6 dB, bájalo
+        6 dB y las muestras están donde empezaron."""
+
+[[faq]]
+q = "¿Invertir o cambiar la velocidad hace perder calidad?"
+a = """
+        Invertir no: salen las mismas muestras en el otro orden, lo cual es
+        exacto. Cambiar la velocidad mueve todas las muestras, así que es
+        aritmética y no una copia &mdash; el remuestreador filtra como es debido
+        por el camino, de modo que acelerar no dobla las notas altas hacia abajo
+        con un timbre metálico, y las ventanas del estirador se colocan donde las
+        ondas encajan y no donde cayera la cuenta. Ninguna de las dos vías vuelve
+        a codificar nada, porque aquí no hay ningún codificador con el que
+        recodificar."""
+
+[[faq]]
+q = "¿Hay algún límite de duración del archivo?"
+a = """
+        La herramienta no lleva ningún límite dentro. El techo práctico es la
+        memoria: la grabación entera se descodifica de golpe en esta página, y un
+        WAV se monta en memoria antes de que lo descargues, así que una hora de
+        estéreo necesita algo menos de un gigabyte para trabajar. Un WAV de
+        cuatro gigabytes se rechaza sin más, porque el propio campo de tamaño del
+        formato no puede describirlo."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. El sitio lleva publicidad, que es lo que lo paga; a los anuncios no
+        se les da nada sobre tu grabación."""
+
+[schema]
+browser_requirements = "Necesita JavaScript y un navegador con Web Audio, que son todos los actuales. No hace falta más soporte de códecs que el que el navegador ya tiene para reproducir el archivo."
+description = "Invierte una pista de audio, cámbiale la velocidad con o sin mover el tono y ajusta su nivel, en el navegador. También funciona sobre el audio de dentro de un vídeo. No se sube nada y el resultado se escribe como WAV, así que no se recodifica nada."
+features = [
+  "Reproduce una pista al revés, exactamente",
+  "Cambia la velocidad de un cuarto a cuatro veces, conservando el tono o moviéndolo",
+  "Sube o baja el nivel, o lo normaliza a justo por debajo de la escala completa",
+  "Saca el audio de un MP4, MOV o WebM sin tocar la imagen",
+  "Escribe WAV de 16 bits o de coma flotante de 32 bits, sin ningún codificador en el bucle",
+  "Funciona sin conexión; sin subidas, sin cuenta y sin marca de agua",
+]
+
+[picker]
+title = "Suelta aquí un archivo de audio o un vídeo"
+hint = "o haz clic para buscarlo &mdash; MP3, WAV, FLAC, M4A, Ogg y el sonido dentro de MP4, MOV o WebM"

--- a/locales/es/tools/exif-editor.html
+++ b/locales/es/tools/exif-editor.html
@@ -1,0 +1,150 @@
+<main>
+  <!-- Paso 1 &mdash; los archivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige las fotos</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo de la lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; el único clic -->
+  <section class="card" id="strip-card">
+    <h2><span class="step">2</span> Quítalo todo</h2>
+
+    <p class="card-lede">
+      Un botón, todas las fotos de la lista. La imagen no se descodifica, no se
+      vuelve a dibujar ni se vuelve a comprimir &mdash; los datos de imagen
+      comprimidos se copian intactos y solo se tiran los metadatos que hay
+      alrededor, así que el resultado es la misma foto sin nada pegado.
+    </p>
+
+    <div class="strip-row">
+      <button type="button" id="strip-all" class="primary big" disabled>Quitar todos los metadatos</button>
+      <span id="strip-status" class="strip-status" role="status" aria-live="polite"></span>
+    </div>
+
+    <!--
+      Two things are kept by default, and both are stated on the button's own
+      line rather than buried in a settings panel. "Remove all" that quietly
+      keeps things is a broken promise; "remove all except these two, and here
+      they are" is a choice.
+    -->
+    <fieldset class="keep-options">
+      <legend>Qué conservar</legend>
+      <label class="check">
+        <input type="checkbox" id="keep-orientation" checked>
+        <span>
+          <strong>La etiqueta de orientación</strong>
+          <span class="check-note">
+            Los móviles guardan la foto tal como la vio el sensor y añaden una
+            etiqueta que dice para qué lado va. Quítala y algunos visores la
+            enseñan de lado. Si se conserva, se escribe un bloque EXIF nuevo que
+            lleva esta etiqueta y nada más &mdash; y solo cuando la foto no
+            estaba ya derecha.
+          </span>
+        </span>
+      </label>
+      <label class="check">
+        <input type="checkbox" id="keep-icc" checked>
+        <span>
+          <strong>El perfil de color</strong>
+          <span class="check-note">
+            El perfil ICC dice qué colores significan los números de la imagen.
+            No dice nada sobre ti. Tirarlo puede desplazar visiblemente los
+            colores de una foto de gama amplia, y por eso se conserva salvo que
+            digas lo contrario.
+          </span>
+        </span>
+      </label>
+      <p class="keep-summary" id="keep-summary"></p>
+    </fieldset>
+
+    <div id="clean-results" class="results" hidden>
+      <div class="results-head">
+        <h3>Limpias</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Descargar todo en un zip</button>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!-- Paso 3 &mdash; leer y editar -->
+  <section class="card" id="inspect-card">
+    <h2><span class="step">3</span> Mira dentro y cambia lo que quieras</h2>
+
+    <p id="inspect-empty" class="empty-note">
+      Elige una foto arriba y aquí aparece todo lo que lleva: lo que dice sobre
+      dónde estabas, cuándo y con qué. No se envía nada a ninguna parte para
+      averiguarlo.
+    </p>
+
+    <div id="inspector" hidden>
+      <div class="inspect-head">
+        <div class="inspect-file">
+          <img id="inspect-thumb" class="inspect-thumb" alt="" hidden>
+          <div>
+            <p class="inspect-name" id="inspect-name"></p>
+            <p class="inspect-sub" id="inspect-sub"></p>
+          </div>
+        </div>
+        <div class="inspect-switch">
+          <label for="inspect-select" class="visually-hidden">Qué foto inspeccionar</label>
+          <select id="inspect-select"></select>
+        </div>
+      </div>
+
+      <!-- The findings: the part of this page that answers the actual question. -->
+      <section class="findings" aria-labelledby="findings-h">
+        <h3 id="findings-h">Lo que este archivo delata</h3>
+        <ul id="findings-list" class="findings-list"></ul>
+      </section>
+
+      <!-- Whole blocks, each removable on its own. -->
+      <section class="blocks" aria-labelledby="blocks-h">
+        <h3 id="blocks-h">Bloques de este archivo</h3>
+        <ul id="block-list" class="block-list"></ul>
+      </section>
+
+      <!-- Every tag, editable. -->
+      <section class="tags" aria-labelledby="tags-h">
+        <h3 id="tags-h">Todas las etiquetas</h3>
+        <p class="tags-note" id="tags-note"></p>
+        <div id="tag-groups"></div>
+
+        <details class="add-tag" id="add-tag">
+          <summary>Añadir una etiqueta</summary>
+          <div class="add-tag-body">
+            <label for="add-tag-select">Etiqueta</label>
+            <select id="add-tag-select"></select>
+            <label for="add-tag-value">Valor</label>
+            <input type="text" id="add-tag-value" spellcheck="false">
+            <button type="button" id="add-tag-go" class="ghost">Añadir</button>
+          </div>
+        </details>
+      </section>
+
+      <div class="save-row">
+        <button type="button" id="save-edits" class="primary" disabled>Guardar esta foto</button>
+        <button type="button" id="revert-edits" class="ghost" disabled>Deshacer mis cambios</button>
+        <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
+      </div>
+      <p id="edit-error" class="error" role="alert" hidden></p>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/exif-editor.toml
+++ b/locales/es/tools/exif-editor.toml
@@ -1,0 +1,245 @@
+#
+# Visor y eliminador de EXIF - Spanish.
+#
+# Overrides for tools/exif-editor/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Visor y eliminador de EXIF"
+heading = "Visor&nbsp;y&nbsp;eliminador de EXIF <span class=\"h1-kw\">&mdash; quitar los metadatos de una foto</span>"
+tagline = "Mira lo que una foto cuenta de ti. Después quítalo."
+
+title = "Visor y eliminador de EXIF &mdash; editor gratuito de metadatos de fotos"
+description = "Mira los datos EXIF y GPS escondidos en una foto, edítalos o quítalos todos de un clic. En tu navegador: no se sube nada, y la foto nunca se vuelve a codificar."
+og_title = "Visor y eliminador de EXIF &mdash; míralos, edítalos o quítalos"
+og_description = "Lee los metadatos escondidos en una foto y quítalos todos de un clic. Funciona en tu propio equipo; la imagen en sí nunca se vuelve a codificar."
+og_image_alt = "Visor y eliminador de EXIF - lee, edita o quita los metadatos de una foto"
+
+pledge = """
+    Tu propio navegador abre, analiza y reescribe el archivo. Esta herramienta no
+    tiene ninguna función de red &mdash; nada que descargar, nada que enviar
+    &mdash; y al otro lado de esta página no hay ningún servidor al que mandar
+    una foto aunque lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y limpia una foto. Ni una sola petición lleva una imagen, una
+      miniatura, un nombre de archivo ni una etiqueta leída de tu archivo. O
+      desconéctate de internet y limpia una de todos modos."""
+
+read_first = """
+, <code>src/tiff.js</code> para el analizador de
+      EXIF, y <code>src/jpeg.js</code> para la prueba de que la imagen en sí solo
+      se copia."""
+
+howto_heading = "Cómo quitar los datos EXIF de una foto"
+
+card = """
+            Mira la ubicación, la cámara y los números de serie escondidos en una
+            foto, edita lo que quieras o quítalo todo de un clic."""
+
+[words]
+plural = "fotos"
+choose = "una foto"
+analytics_extra = """, ni ninguna de las
+  etiquetas que esta herramienta lee de tus archivos"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[facts]]
+text = "Nunca recodifica la imagen"
+
+[[privacy]]
+title = "Tus fotos no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudieran recogerse tus archivos, ni nada en el código que los enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ A diferencia de las demás
+      herramientas de esta caja, esta no tiene ninguna función de «cargar desde
+      una dirección web» ni ningún paso de red opcional. No hay ningún
+      <code>fetch</code>, ningún <code>XMLHttpRequest</code> ni ningún
+      <code>sendBeacon</code> en todo <code>src/</code>."""
+
+[[privacy]]
+title = "Los metadatos que leemos no se cuentan a nadie."
+body = """
+ Tu posición GPS
+      se muestra en esta página y no va a ningún otro sitio. En este repositorio
+      no hay ningún evento de analítica propio que lleve una etiqueta, un nombre
+      de archivo, un tamaño o un recuento."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google. A ninguno se le entrega nada sobre
+      tus fotos. Cada línea que lee, analiza o reescribe un archivo se sirve desde
+      este origen y está listada en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le da."
+body = """
+
+      El botón «Buy me a coffee» de la cabecera lo dibuja un script de
+      cdnjs.buymeacoffee.com y se compone con Google Fonts. Es un enlace y nada
+      más: no informa de ninguna visita, y no se le entrega nada sobre ti ni
+      sobre tus archivos. No pasa nada a menos que lo pulses, y lo que hay al
+      otro lado es el sitio de otra gente."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta
+      sigue igual, porque nunca hubo un paso de red dentro de ella. Es la prueba
+      más sencilla de todas."""
+
+[[howto]]
+title = "Elige tus fotos."
+body = """
+ Suéltalas sobre el selector o escógelas
+      a mano. Tu navegador las lee directamente del disco; mientras lo haces no se
+      envía nada a ninguna parte."""
+
+[[howto]]
+title = "Lee lo que llevan dentro, si te apetece."
+body = """
+ La lista de hallazgos
+      nombra las cosas que conviene saber &mdash; la posición GPS, las marcas de
+      tiempo, los números de serie &mdash; antes de la tabla completa con todas
+      las etiquetas."""
+
+[[howto]]
+title = "Pulsa «Quitar todos los metadatos»."
+body = """
+ Ese es el trabajo entero
+      para casi todo el mundo. Todas las etiquetas, los bloques XMP e IPTC, los
+      comentarios y la miniatura incrustada se van, de todas las fotos de la
+      lista a la vez."""
+
+[[howto]]
+title = "O edita en lugar de quitar."
+body = """
+ Cambia una fecha, corrige una
+      línea de derechos, tira la ubicación y conserva los ajustes de la cámara
+      &mdash; y guarda después esa foto por su cuenta."""
+
+[[faq]]
+q = "¿Se sube mi foto a alguna parte?"
+a = """
+        No. Tu propio navegador lee, analiza y reescribe el archivo en tu propio
+        hardware. Esta herramienta no tiene ninguna función de red &mdash; nunca
+        descarga nada y nunca envía nada &mdash; y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es de este
+        sitio."""
+
+[[faq]]
+q = "¿Qué es EXIF y qué más se esconde en una foto?"
+a = """
+        EXIF es un bloque de etiquetas que una cámara escribe junto a la imagen:
+        la marca y el modelo, los ajustes de exposición, la fecha y la hora al
+        segundo, muchas veces una posición GPS y a veces un número de serie. Las
+        fotos suelen llevar más cosas además &mdash; un paquete XMP de XML puesto
+        por un editor, un bloque IPTC con campos de pie de foto y autoría, un
+        perfil de color, una segunda copia pequeña de la imagen como miniatura, y
+        una nota del fabricante con datos sin documentar. Esta herramienta lo
+        lista todo."""
+
+[[faq]]
+q = "¿Quitar los metadatos reduce la calidad de la imagen?"
+a = """
+        No, y esa es la razón principal para usar una herramienta así en vez de
+        volver a guardar la foto. Los metadatos están en el contenedor que rodea
+        a la imagen comprimida, no dentro de ella. Quitarlos consiste en borrar
+        elementos de una lista y volver a escribir la lista; los datos de imagen
+        comprimidos se copian byte por byte, así que el resultado descodifica
+        exactamente los mismos píxeles. No se descodifica nada y no se vuelve a
+        comprimir nada."""
+
+[[faq]]
+q = "¿Con qué formatos de archivo trabaja?"
+a = """
+        JPEG, PNG y WebP. HEIC y AVIF se reconocen pero no se reescriben: son
+        formatos de cajas construidos con átomos anidados y necesitan otro
+        analizador, así que la herramienta lo dice en vez de producir un archivo
+        roto. Un TIFF suelto tampoco se maneja, porque en un TIFF los metadatos y
+        los píxeles se direccionan con los mismos desplazamientos."""
+
+[[faq]]
+q = "¿Mi foto va a salir girada después de quitarle los metadatos?"
+a = """
+        Puede pasar, y hay un ajuste para eso. Los móviles suelen guardar la foto
+        tal como la vio el sensor y añaden una etiqueta de orientación que dice
+        cómo hay que girarla. Quita esa etiqueta y algunos visores la enseñan de
+        lado. La opción «conservar la etiqueta de orientación», activada por
+        defecto, vuelve a escribir un bloque EXIF diminuto que no contiene más
+        que esa única etiqueta &mdash; y solo cuando la foto la necesitaba de
+        verdad. Desactívala si prefieres que el archivo no lleve EXIF en
+        absoluto."""
+
+[[faq]]
+q = "¿Quita la ubicación GPS?"
+a = """
+        Sí. Quitarlo todo elimina el directorio GPS entero, y también puedes
+        borrar la ubicación por su cuenta y conservar el resto. La posición se
+        muestra primero en grados decimales, porque «51 grados, 30 minutos, 26
+        segundos» no deja claro que una foto esté nombrando el edificio en el que
+        se tomó."""
+
+[[faq]]
+q = "¿Puedo cambiar una etiqueta en vez de borrarla?"
+a = """
+        Sí. Las etiquetas de texto, las fechas, el ISO, la orientación y la
+        resolución se pueden editar, y unas cuantas etiquetas habituales se pueden
+        añadir a una foto que no tenga ninguna. Una advertencia: escribir el
+        archivo reconstruye el bloque EXIF, y una nota del fabricante contiene
+        desplazamientos hacia el bloque original, así que una nota reconstruida
+        puede dejar de ser legible para el propio programa del fabricante.
+        Bórrala, o deja el archivo sin editar, si eso te importa."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba. El sitio lleva
+        publicidad, que es lo que lo paga; a los anuncios no se les da nada sobre
+        tus fotos."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tus fotos fuera a procesar se
+        detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Lee los metadatos EXIF, GPS, XMP e IPTC de dentro de una foto, edita etiquetas sueltas o quítalo todo de un clic. JPEG, PNG y WebP, procesados en el navegador sin volver a codificar la imagen."
+features = [
+  "Muestra todas las etiquetas EXIF, incluidas la posición GPS, los números de serie de la cámara y las notas del fabricante",
+  "Edita o borra etiquetas sueltas y vuelve a escribir el archivo",
+  "Quita EXIF, GPS, XMP, IPTC, comentarios y la miniatura incrustada de un clic",
+  "JPEG, PNG y WebP",
+  "Reescribe solo el contenedor, así que la imagen nunca se vuelve a comprimir",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí las fotos"
+hint = "o haz clic para buscarlas &mdash; JPEG, PNG y WebP"

--- a/locales/es/tools/heic-to-jpg.html
+++ b/locales/es/tools/heic-to-jpg.html
@@ -1,0 +1,113 @@
+<main>
+  <!-- Paso 1 &mdash; los archivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige tus fotos HEIC</h2>
+
+    <p class="card-lede">
+      Directamente del móvil, de una copia de seguridad o copiadas de una tarjeta
+      de memoria. El archivo se lee aquí, en este equipo, y la imagen se
+      descodifica aquí también &mdash; esta página no tiene ningún paso de subida
+      y no tiene ningún servidor detrás.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo de la lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; qué sale -->
+  <section class="card" id="options-card">
+    <h2><span class="step">2</span> Di qué quieres de vuelta</h2>
+
+    <fieldset class="options">
+      <legend>El formato</legend>
+
+      <div class="option-row">
+        <label for="format-select">Escribir las imágenes como</label>
+        <select id="format-select">
+          <option value="image/jpeg" selected>JPEG &mdash; se abre en todas partes, incluidas las hechas este siglo por error</option>
+          <option value="image/png">PNG &mdash; sin pérdidas, y varias veces más grande</option>
+          <option value="image/webp">WebP &mdash; más pequeño que JPEG a la misma calidad, y solo en navegadores modernos</option>
+        </select>
+      </div>
+
+      <div class="option-row" id="quality-row">
+        <label for="quality">Calidad</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="50" max="100" step="1" value="92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Los datos de la foto</legend>
+
+      <label class="check">
+        <input type="checkbox" id="keep-exif" checked>
+        <span>
+          <strong>Conservar la fecha, la cámara y los ajustes</strong>
+          <span class="check-note">
+            Copiados exactamente como los escribió el móvil, así que la foto
+            convertida sigue ordenándose por el día en que se tomó y no por el día
+            en que se convirtió. Esto incluye las coordenadas GPS cuando la foto
+            las tiene &mdash; la lista de arriba dice cuáles de las tuyas las
+            tienen. Desactívalo y el JPEG sale sin nada dentro salvo la imagen.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary">
+        En cualquiera de los dos casos, aquí no se le cuenta nada a nadie: la
+        elección va de qué entra en el archivo que te llevas, no de qué hace esta
+        página con ello. Si quieres repasar las etiquetas en detalle, o quitarlas
+        de fotos que ya son JPEG, el
+        <a href="../eliminar-datos-exif/">visor y eliminador de EXIF</a> es la
+        herramienta para eso.
+      </p>
+    </fieldset>
+  </section>
+
+  <!-- Paso 3 &mdash; el único clic -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Convertir</h2>
+
+    <div class="run-row">
+      <button type="button" id="convert-all" class="primary big" disabled>Convertir</button>
+    </div>
+
+    <!--
+      The decoder's own status line. This page is the only one on the site that
+      carries a codec, so it is the only one with anything to report here, and
+      saying where the megabyte came from is the point: it is served from this
+      origin, it is cached with the rest of the page, and it is what makes the
+      offline promise hold on a browser that cannot open a HEIC at all.
+    -->
+    <p id="engine-status" class="engine-status" role="status" aria-live="polite"></p>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Convertidas</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Descargar todo en un zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/heic-to-jpg.toml
+++ b/locales/es/tools/heic-to-jpg.toml
@@ -1,0 +1,299 @@
+#
+# HEIC a JPG - Spanish.
+#
+# Overrides for tools/heic-to-jpg/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "HEIC a JPG"
+heading = "HEIC&nbsp;a&nbsp;JPG <span class=\"h1-kw\">&mdash; convertir fotos de iPhone</span>"
+tagline = "Las fotos que hace un iPhone, en un formato que abre todo."
+
+title = "Convertidor de HEIC a JPG &mdash; gratis y sin subir nada"
+description = "Convierte las fotos HEIC de un iPhone en JPG desde tu navegador. El descodificador funciona en tu propio equipo: no se sube nada, no hay cuenta, funciona sin conexión, y la fecha y los datos de la cámara pueden venirse contigo."
+og_title = "Convierte fotos HEIC en JPG sin subirlas"
+og_description = "El convertidor que no quiere tus fotos. El descodificador de HEIC se sirve desde esta página y funciona en tu propio equipo, así que las fotos no salen de él."
+og_image_alt = "HEIC a JPG - las fotos de iPhone en un formato que abre todo"
+
+pledge = """
+    La descodificación ocurre en tu propio navegador, en tu propio hardware. HEIC
+    es el único formato de imagen que un navegador no abre por su cuenta, así que
+    esta página lleva el descodificador consigo &mdash; unos 1,4 MB, servidos
+    desde este sitio y guardados en caché tras la primera visita. Esa es la razón
+    entera de que todos los demás convertidores de HEIC te pidan que subas algo:
+    ponen el códec en un servidor y tus fotos tienen que ir hasta él. Este pone el
+    códec aquí. En esta página no hay ninguna función de red, ni ningún servidor
+    al otro lado al que mandar una foto."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y convierte una foto. Verás cargarse los archivos propios de
+      esta página, el descodificador entre ellos, y ni una sola petición que lleve
+      una foto, una miniatura, un nombre de archivo o un byte de lo que has
+      elegido. O carga la página una vez, desconéctate de internet y convierte una
+      carpeta entera de todos modos."""
+
+read_first = """
+, <code>src/heif.js</code> para ver cómo se carga
+      el descodificador y qué se le permite hacer, <code>src/boxes.js</code> para
+      el análisis del contenedor que encuentra los metadatos de la foto, y
+      <code>src/exif.js</code> para lo que le pasa a esos metadatos camino de un
+      JPEG. El motor en sí es <code>vendor/libheif.js</code>, sin modificar y con
+      su licencia al lado."""
+
+howto_heading = "Cómo convertir fotos HEIC a JPG"
+
+card = """
+            Las fotos que hace un iPhone, en un formato que abre todo &mdash;
+            descodificadas en tu propio equipo, no en el servidor de nadie."""
+
+[words]
+plural = "fotos"
+choose = "una foto"
+analytics_extra = """, ni ninguna de las
+  fechas, modelos de cámara o coordenadas que esta herramienta lee de ellas"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin límite de tamaño"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Tus fotos no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudieran recogerse tus archivos, ni nada en el código que los enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "El descodificador vino de aquí, y no va a ninguna parte."
+body = """
+ HEIC es HEVC
+      dentro de un formato de cajas, y ningún navegador salvo Safari sabe
+      descodificar uno, así que esta página distribuye <code>libheif</code>
+      compilado a WebAssembly &mdash; unos 1,4 MB, guardados en este repositorio,
+      servidos desde este origen y cacheados por el service worker como cualquier
+      otro archivo de aquí. No se descarga de una CDN, porque eso pondría a un
+      tercero en el camino de cada visita y dejaría a la herramienta sin
+      funcionar sin conexión. El binario está dentro del script y no al lado
+      precisamente para que no haga falta ninguna descarga para arrancarlo."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ No hay ningún
+      <code>fetch</code>, ningún <code>XMLHttpRequest</code> ni ningún
+      <code>sendBeacon</code> en ningún archivo escrito para esta herramienta. El
+      motor incorporado, como cualquier compilación de Emscripten, contiene las
+      rutas de carga que descargarían un <code>.wasm</code> desde una URL; no se
+      toman, porque el binario ya está en la mano &mdash; y si se tomara,
+      <code>connect-src</code> nombra los puntos finales de medición de Google y
+      nada más, así que el navegador lo rechazaría. La prueba es la política, no
+      la promesa."""
+
+[[privacy]]
+title = "Los metadatos se leen aquí y se te cuentan a ti."
+body = """
+ La lista de
+      la página dice qué lleva cada foto &mdash; la fecha, la cámara y si hay
+      coordenadas GPS dentro &mdash; porque es algo que quizá quieras saber antes
+      de darle el JPEG a alguien. Los lee del archivo <code>src/boxes.js</code> en
+      este navegador, se muestran en esta página, y se escriben en tu JPEG o se
+      dejan fuera, exactamente como tú elijas. En este repositorio no hay ningún
+      evento de analítica propio que lleve un nombre de archivo, una fecha, una
+      coordenada o un recuento."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google, y el botón de donación de Buy Me a
+      Coffee. A ninguno se le entrega nada sobre tus fotos. Cada línea que lee,
+      descodifica o escribe un archivo se sirve desde este origen y está listada
+      en el repositorio."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Carga la página una vez y desconéctate de
+      la red, y la herramienta sigue igual &mdash; el descodificador se guarda en
+      caché con ella. Es la prueba más sencilla de todas, y aquí es más fuerte que
+      en ninguna otra parte de este sitio: un convertidor que mandara tus fotos
+      fuera a descodificar no podría apañárselas de ninguna manera."""
+
+[[howto]]
+title = "Elige tus fotos HEIC."
+body = """
+ Suéltalas sobre el selector o
+      escógelas a mano, directamente de una copia de seguridad del móvil o de una
+      carpeta del escritorio. Tu navegador las lee del disco; mientras lo haces no
+      se envía nada a ninguna parte. La lista dice qué es cada una y qué lleva
+      dentro."""
+
+[[howto]]
+title = "Comprueba qué llevan las fotos."
+body = """
+ Cada fila nombra la fecha en
+      que se tomó, la cámara y &mdash; en verde, porque es la parte que merece la
+      pena notar &mdash; si el archivo lleva coordenadas GPS. Eso se lee del
+      contenedor sin descodificar la imagen, así que no cuesta nada y aparece de
+      inmediato."""
+
+[[howto]]
+title = "Elige un formato y decide sobre los datos."
+body = """
+ JPEG salvo que tengas un
+      motivo: es el formato que se abre en todas partes, que es el sentido entero
+      de convertir. El control de calidad está en 92, que es el ajuste en el que
+      una fotografía cuesta distinguirla del original. La casilla decide si la
+      fecha, la cámara y la ubicación se vienen contigo."""
+
+[[howto]]
+title = "Pulsa «Convertir» y descarga."
+body = """
+ El descodificador llega en la
+      primera conversión &mdash; unos 1,4 MB, una vez &mdash; y cada foto a partir
+      de ahí se descodifica y se escribe en tu propio equipo. Un archivo te da un
+      botón de descarga; varios te dan además un zip."""
+
+[[faq]]
+q = "¿Se sube mi foto a alguna parte?"
+a = """
+        No. Tu propio navegador lee, descodifica y escribe el archivo en tu propio
+        hardware. Esta herramienta no tiene ninguna función de red &mdash; nunca
+        descarga nada y nunca envía nada &mdash; y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es de este sitio. Lo
+        único que sí se carga es el propio descodificador, y viene de este sitio,
+        una vez, antes de que tu foto entre siquiera en la ecuación."""
+
+[[faq]]
+q = "¿Por qué esta página descarga 1,4 MB la primera vez?"
+a = """
+        Porque HEIC es el único formato de imagen que un navegador no abre. Es un
+        fotograma HEVC dentro de un contenedor de cajas, y solo Safari, sobre
+        hardware de Apple, tiene un descodificador para él; Chrome, Firefox y Edge
+        sencillamente rechazan el archivo. Así que un convertidor de HEIC necesita
+        un descodificador de alguna parte, y hay dos sitios de los que puede venir:
+        un servidor o la página. Todos los demás convertidores eligieron el
+        servidor, que es justamente por lo que todos necesitan que subas tus fotos.
+        Este lleva <code>libheif</code> compilado a WebAssembly en su lugar. Se
+        sirve desde este sitio, se guarda en caché tras la primera visita, y es el
+        precio entero de que tus fotos no vayan a ninguna parte."""
+
+[[faq]]
+q = "¿El JPEG conserva la fecha, la cámara y la ubicación?"
+a = """
+        Si tú quieres, y es una casilla de la página. Si la dejas activada, el
+        bloque EXIF se copia del HEIC y se escribe en el JPEG exactamente como lo
+        escribió el móvil, así que la foto convertida sigue ordenándose por el día
+        en que se tomó y no por el día en que se convirtió &mdash; que es la queja
+        habitual con los convertidores de HEIC. Se cambia una etiqueta y solo una:
+        la orientación, que se pone en «derecha», porque la rotación ya se ha
+        aplicado a los píxeles y un visor que volviera a aplicarla pondría de lado
+        todas las fotos verticales. Desactiva la casilla y el JPEG sale con la
+        imagen y nada más."""
+
+[[faq]]
+q = "¿Quita las coordenadas GPS?"
+a = """
+        Te dice que están ahí, y después hace lo que le pidas. La fila de cada foto
+        dice si el archivo lleva coordenadas antes de que conviertas nada, que es
+        más de lo que hace el móvil. Desmarcar «conservar la fecha, la cámara y los
+        ajustes» las deja fuera del JPEG junto con todo lo demás; dejarla marcada
+        las traslada. Si lo que quieres es repasar las etiquetas en detalle, o
+        quitarlas de fotos que ya son JPEG, el
+        <a href="../eliminar-datos-exif/">visor y eliminador de EXIF</a> es la
+        herramienta para eso, y lo hace sin volver a comprimir la imagen."""
+
+[[faq]]
+q = "¿Se vuelve a comprimir la imagen?"
+a = """
+        Sí, y tiene que hacerlo: HEIC y JPEG son códecs distintos, así que no hay
+        forma de pasar de uno a otro sin descodificar la imagen y volver a
+        codificarla. Lo que sí puedes controlar es cuánto cuesta eso. El control de
+        calidad viene en 92, donde una fotografía es muy difícil de distinguir del
+        original, y PNG está en el menú para el caso en que no quieras ninguna
+        pérdida y no te importe que el archivo sea de cinco a diez veces más
+        grande."""
+
+[[faq]]
+q = "¿Y si el archivo se llama .jpg pero en realidad es un HEIC?"
+a = """
+        Funciona igual. Todo archivo que se suelte aquí se identifica por sus
+        primeros bytes y no por su nombre, porque el nombre es lo que decidiera
+        llamarlo la última aplicación que tocó el archivo &mdash; y un HEIC que
+        llegó llamándose «.jpg» es una de las formas más comunes de acabar buscando
+        una herramienta como esta. Un archivo que sea de verdad un JPEG o un PNG se
+        rechaza con un mensaje que lo dice, en vez de convertirse en una copia de
+        sí mismo."""
+
+[[faq]]
+q = "¿Puede convertir una Live Photo o una ráfaga?"
+a = """
+        Las imágenes fijas que lleve dentro, sí. Un HEIC puede contener más de una
+        imagen, y todas las que contenga se convierten y se nombran a partir del
+        original con un número al final. La mitad de vídeo de una Live Photo es un
+        archivo aparte que el móvil guarda junto al HEIC, así que no está aquí para
+        convertirlo. Los mapas de profundidad y las miniaturas están en el
+        contenedor pero no son imágenes que nadie haya pedido, y se dejan en
+        paz."""
+
+[[faq]]
+q = "¿Por qué no me acepta un AVIF?"
+a = """
+        Porque no hay nada que hacerle. AVIF es el mismo contenedor que HEIC con AV1
+        dentro en lugar de HEVC, y cualquier navegador actual descodifica uno de
+        forma nativa &mdash; así que un convertidor estaría enviando un megabyte de
+        motor para resolver un problema que no tienes. Si necesitas un AVIF como
+        JPEG, el <a href="../comprimir-imagen/">compresor de imágenes</a> y el
+        <a href="../redimensionar-imagen/">redimensionador de imágenes</a> leen
+        AVIF y escriben JPEG usando el descodificador que tu navegador ya tiene."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. Tampoco hay límite en el número ni en el tamaño de los archivos,
+        porque no hay ningún servidor pagándolos &mdash; el trabajo ocurre en tu
+        propio equipo. El sitio lleva publicidad, que es lo que lo paga; a los
+        anuncios no se les da nada sobre tus fotos."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí, descodificador incluido. Carga la página una vez, desconéctate de
+        internet y sigue trabajando con tus fotos exactamente igual que antes. Esa
+        es además la prueba más fuerte que hay de que no se sube nada: un
+        convertidor que mandara tus HEIC fuera a descodificar se detendría en el
+        momento en que desenchufaras, y este no."""
+
+[schema]
+description = "Convierte fotos HEIC y HEIF de un iPhone en JPEG, PNG o WebP. El descodificador de HEIC es WebAssembly servido desde la propia página, así que las imágenes se descodifican en tu propio equipo y nunca se suben. La fecha, la cámara y la ubicación pueden trasladarse al JPEG o dejarse fuera."
+features = [
+  "Convierte HEIC y HEIF a JPEG, PNG o WebP",
+  "Descodifica en el navegador, en cualquier navegador y no solo en Safari",
+  "No se sube nada, y la herramienta funciona con la red desenchufada",
+  "Traslada al JPEG la fecha, la cámara y el GPS, o los deja fuera",
+  "Dice qué fotos llevan coordenadas GPS antes de convertir nada",
+  "Corrige la etiqueta de orientación, para que las fotos verticales no salgan de lado",
+  "Identifica los archivos por su contenido, así que un HEIC llamado .jpg funciona igual",
+  "Convierte todas las imágenes de una ráfaga o de una Live Photo, no solo la primera",
+  "Por lotes, con todos los resultados en un zip",
+]
+
+[picker]
+title = "Suelta aquí las fotos HEIC"
+hint = "o haz clic para buscarlas &mdash; .heic y .heif, se llamen como se llamen"

--- a/locales/es/tools/image-to-data-uri.html
+++ b/locales/es/tools/image-to-data-uri.html
@@ -1,0 +1,141 @@
+<main>
+  <!-- Paso 1 &mdash; los archivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige las imágenes</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo de la lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; la línea que se pega de verdad -->
+  <section class="card" id="shape-card">
+    <h2><span class="step">2</span> Di adónde va</h2>
+
+    <p class="card-lede">
+      Un data URI a secas casi nunca es lo que alguien quiere. Lo que quiere es la
+      línea que va en la hoja de estilos &mdash; así que elige la línea, y la
+      imagen llega dentro de ella ya entrecomillada, que es la parte fácil de
+      equivocar y que solo falla con los SVG.
+    </p>
+
+    <div class="shapes" id="shapes" role="radiogroup" aria-label="Qué pegar">
+      <label class="shape">
+        <input type="radio" name="shape" value="uri" checked>
+        <span class="shape-body">
+          <strong>El data URI a secas</strong>
+          <span class="shape-note">
+            Todo lo que va después de la coma es el archivo. Pégalo donde vaya una URL.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-rule">
+        <span class="shape-body">
+          <strong>Una regla CSS</strong>
+          <span class="shape-note">
+            Una regla entera, con una clase nombrada a partir del archivo. Cambia
+            el selector por lo que estés dando estilo de verdad.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-var">
+        <span class="shape-body">
+          <strong>Una propiedad personalizada de CSS</strong>
+          <span class="shape-note">
+            Declarada una vez al principio de la hoja de estilos y usada como
+            <code>var(--nombre)</code> tantas veces como quieras. Esta es la que
+            hay que elegir cuando la imagen aparece en más de una regla.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="html">
+        <span class="shape-body">
+          <strong>Una etiqueta <code>&lt;img&gt;</code> de HTML</strong>
+          <span class="shape-note">
+            Con el tamaño en píxeles ya puesto, para que la página no dé saltos
+            mientras carga el resto.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="markdown">
+        <span class="shape-body">
+          <strong>Markdown</strong>
+          <span class="shape-note">
+            Para un README o una incidencia: una imagen que viaja con el texto en
+            vez de necesitar que la alojen en alguna parte.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary">
+      El texto <code>alt</code> se deja vacío a propósito. Solo tú sabes si la
+      imagen lleva significado o es decoración, y una descripción adivinada a
+      partir de un nombre de archivo es peor para alguien que use un lector de
+      pantalla que no tener ninguna descripción.
+    </p>
+
+    <fieldset class="options">
+      <legend>SVG</legend>
+
+      <label class="check">
+        <input type="checkbox" id="svg-base64">
+        <span>
+          <strong>Pasar también los SVG a base64</strong>
+          <span class="check-note">
+            Desactivado por defecto, porque un SVG es texto y base64 es para
+            bytes. La codificación por porcentajes deja el marcado legible en la
+            hoja de estilos y suele ser una quinta parte más corta. Actívalo para
+            esa rara cadena de herramientas que insiste en <code>;base64</code>.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Paso 3 &mdash; el resultado. Aquí no hay botón a propósito: la codificación
+       es instantánea, así que no hay nada que un botón de «convertir» pudiera esperar. -->
+  <section class="card" id="output-card">
+    <h2><span class="step">3</span> Cópialo</h2>
+
+    <p id="empty-note" class="card-lede">
+      Todavía no has elegido nada. Suelta una imagen arriba y aquí aparece la
+      línea para pegar.
+    </p>
+
+    <div id="results" hidden>
+      <div class="results-head">
+        <p id="results-summary" class="results-summary"></p>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Copiar todo</button>
+          <button type="button" id="download-all" class="ghost">Descargar en un solo archivo</button>
+        </div>
+      </div>
+
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/image-to-data-uri.toml
+++ b/locales/es/tools/image-to-data-uri.toml
@@ -1,0 +1,320 @@
+#
+# Imagen a data URI - Spanish.
+#
+# Overrides for tools/image-to-data-uri/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Imagen a data URI"
+heading = "Imagen&nbsp;a&nbsp;data&nbsp;URI <span class=\"h1-kw\">&mdash; codificar una imagen en base64 para CSS o HTML</span>"
+tagline = "La imagen entera como una línea de texto. Pégala directamente en tu CSS o tu HTML."
+
+title = "Imagen a data URI &mdash; codificar en base64 para CSS, gratis y sin subir nada"
+description = "Convierte un PNG, un JPEG, un SVG o un WebP en un data URI que puedes pegar en tu CSS o tu HTML. Los SVG se codifican con porcentajes en vez de base64, así que quedan legibles y más cortos. Funciona en tu navegador; no se sube nada."
+og_title = "Convierte una imagen en una línea que puedes pegar en tu CSS"
+og_description = "Base64 para las imágenes, codificación por porcentajes para SVG, y la regla, la propiedad personalizada o la etiqueta img ya montadas alrededor. Funciona en tu propio equipo; no se sube nada."
+og_image_alt = "Imagen a data URI - mete la imagen dentro de la hoja de estilos"
+
+pledge = """
+    La codificación ocurre en tu propio navegador, en tu propio hardware. Es
+    aritmética sobre unos bytes que la página ya tiene: sin codificador, sin
+    servidor y sin ningún paso de red que dejar fuera. Esta herramienta no tiene
+    ninguna función de red &mdash; nada que descargar, nada que enviar &mdash; y
+    al otro lado de esta página no hay ningún servidor al que mandar una imagen
+    aunque lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y suelta una imagen. Ni una sola petición lleva una imagen,
+      una miniatura, un nombre de archivo ni un byte de lo que has elegido. O
+      desconéctate de internet y codifica una de todos modos."""
+
+read_first = """
+, <code>src/encode.js</code> para las dos
+      codificaciones y el razonamiento detrás de cada una,
+      <code>src/sniff.js</code> para ver cómo se lee el tipo de medio del archivo
+      y no de su nombre, y <code>src/metadata.js</code> para la comprobación que
+      dice cuánto de lo que estás a punto de pegar no es la imagen."""
+
+howto_heading = "Cómo convertir una imagen en un data URI"
+
+card = """
+            Base64 para las imágenes, codificación por porcentajes para SVG, y la
+            regla CSS o la etiqueta <code>&lt;img&gt;</code> ya montada
+            alrededor."""
+
+[words]
+plural = "imágenes"
+choose = "una imagen"
+analytics_extra = """, ni ninguno de los
+  nombres de archivo, tamaños o textos codificados que esta herramienta produce"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin recodificar"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Tus imágenes no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudieran recogerse tus archivos, ni nada en el código que los enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ No hay ningún
+      <code>fetch</code>, ningún <code>XMLHttpRequest</code> ni ningún
+      <code>sendBeacon</code> en todo <code>src/</code>. La codificación es
+      <code>btoa</code> y <code>encodeURIComponent</code> &mdash; dos funciones
+      que el navegador tiene desde el principio, y las dos cogen bytes y
+      devuelven texto sin ir a ninguna parte."""
+
+[[privacy]]
+title = "La vista previa es la prueba."
+body = """
+ La imagen que hay junto a cada
+      resultado se dibuja a partir del data URI que esta página acaba de construir,
+      no a partir de tu archivo. Se ve porque el URI es correcto, en tu equipo, sin
+      ningún servidor de por medio &mdash; y si no se ve, la página lo dice en vez
+      de darte algo roto."""
+
+[[privacy]]
+title = "El aviso de metadatos está de tu lado."
+body = """
+ Un data URI copia el
+      archivo exactamente, así que la posición GPS de una fotografía viaja hasta
+      tu hoja de estilos con ella. Esta página lee cuánto hay de eso y te lo dice,
+      porque la alternativa es que te enteres cuando ya esté en el repositorio."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google, y el botón de donación de Buy Me a
+      Coffee. A ninguno se le entrega nada sobre tus imágenes. Cada línea que lee
+      o codifica un archivo se sirve desde este origen y está listada en el
+      repositorio."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta
+      sigue igual, porque nunca hubo un paso de red dentro de ella. Es la prueba
+      más sencilla de todas."""
+
+[[howto]]
+title = "Elige tus imágenes."
+body = """
+ Suéltalas sobre el selector o escógelas
+      a mano. Tu navegador las lee directamente del disco; mientras lo haces no se
+      envía nada a ninguna parte."""
+
+[[howto]]
+title = "Di adónde va el resultado."
+body = """
+ El URI a secas, una regla CSS,
+      una propiedad personalizada, una etiqueta <code>&lt;img&gt;</code> o
+      Markdown. Todas ellas entrecomillan el URI, que es el detalle que decide si
+      un SVG incrustado funciona o falla en silencio."""
+
+[[howto]]
+title = "Lee lo que ha costado."
+body = """
+ Cada resultado dice en cuántos
+      caracteres se ha convertido, cuánto más grande es eso que el archivo, y si
+      incrustar algo de ese tamaño es buena idea. Base64 añade un tercio; si ese
+      tercio compensa una petición ahorrada depende por completo del tamaño, así
+      que la página dice de qué lado de la raya estás."""
+
+[[howto]]
+title = "Mira los avisos."
+body = """
+ Si la imagen lleva EXIF, un perfil de
+      color o XMP, se nombra junto con cuántos bytes de tu resultado son eso. Si
+      la extensión no coincide con el formato real, la página usa el formato y te
+      lo dice. Y si tu navegador no sabe dibujar el resultado, también lo dice."""
+
+[[howto]]
+title = "Copia, o descarga."
+body = """
+ Un botón por resultado, y uno para todos
+      a la vez &mdash; las propiedades personalizadas salen envueltas en un bloque
+      <code>:root</code>, listas para pegarlas al principio de una hoja de
+      estilos."""
+
+[[faq]]
+q = "¿Se sube mi imagen a alguna parte?"
+a = """
+        No. Tu propio navegador lee y codifica el archivo en tu propio hardware,
+        con dos funciones que el navegador ya tiene. Esta herramienta no tiene
+        ninguna función de red &mdash; nunca descarga nada y nunca envía nada
+        &mdash; y la <code>Content-Security-Policy</code> de la página nombra
+        todas las direcciones que puede contactar, ninguna de las cuales es de
+        este sitio."""
+
+[[faq]]
+q = "¿Qué es un data URI?"
+a = """
+        Una forma de escribir un archivo entero donde normalmente iría una
+        dirección web. En vez de <code>url("logo.png")</code>, que le dice al
+        navegador que vaya a buscar algo, escribes
+        <code>url("data:image/png;base64,iVBORw0...")</code>, que contiene la
+        propia imagen. El navegador la descodifica ahí mismo. El efecto práctico
+        es una petición menos: la imagen llega con la hoja de estilos o con la
+        página en vez de después de ellas."""
+
+[[faq]]
+q = "¿Por qué mi SVG no sale en base64?"
+a = """
+        Porque base64 es la codificación equivocada para él. Un SVG es texto, y una
+        URL ya puede llevar texto &mdash; solo hay que escapar un puñado de
+        caracteres. Codificar esos con porcentajes y dejar el resto en paz produce
+        un URI que suele ser una quinta parte más corto que el base64 del mismo
+        archivo, y que además puedes seguir leyendo en tu hoja de estilos: los
+        nombres de elemento, los colores y el <code>viewBox</code> siguen ahí para
+        editarlos. Hay una casilla para forzar base64 para esa rara cadena de
+        herramientas que insiste en ello."""
+
+[[faq]]
+q = "¿Cuánto agranda base64 mi imagen?"
+a = """
+        Alrededor de un tercio. Tres bytes de archivo se convierten en cuatro
+        caracteres de base64, que es un 33&nbsp;% antes del
+        <code>data:image/png;base64,</code> de delante. Ese es el suelo, y es
+        inevitable: es lo que cuesta escribir bytes arbitrarios usando solo los
+        caracteres que permite una URL. Es también por lo que la página enseña el
+        número de caracteres junto al tamaño del archivo, en vez de dejar que te
+        enteres cuando la hoja de estilos esté desplegada."""
+
+[[faq]]
+q = "¿Cuándo es buena idea incrustar una imagen de verdad?"
+a = """
+        Cuando es pequeña y hace falta de inmediato. Un icono de 2 KB dentro de una
+        hoja de estilos que cargan todas las páginas es una victoria clara: un viaje
+        de ida y vuelta menos, y la imagen está ahí en el momento en que está el
+        CSS. Pasados unos 10 KB el trato se da la vuelta. Una imagen incrustada ya
+        no es un archivo aparte, así que no se puede cachear por su cuenta, no se
+        puede descargar en paralelo con nada más y se vuelve a bajar entera cada vez
+        que cambia el archivo que la rodea &mdash; una fotografía de 200 KB en una
+        hoja de estilos son 200 KB añadidos al camino crítico de todas las páginas
+        del sitio. La página te dice de qué lado de esa raya cae cada resultado."""
+
+[[faq]]
+q = "¿Gzip deshace el coste añadido de base64?"
+a = """
+        Menos de lo que la gente espera. El base64 de un archivo ya comprimido
+        &mdash; que es lo que son un PNG, un JPEG y un WebP &mdash; se comprime mal,
+        porque apenas queda redundancia que el compresor pueda encontrar; lo normal
+        es recuperar algo así como una décima parte del tercio que añadió base64, no
+        el tercio entero. Un SVG codificado con porcentajes es el caso contrario:
+        sigue siendo texto, así que se comprime más o menos igual de bien que antes,
+        que es otra razón para no pasarlo a base64."""
+
+[[faq]]
+q = "¿Esto cambia mi imagen en algo?"
+a = """
+        No, y esa es una diferencia deliberada respecto a casi todas las
+        herramientas de aquí. No se descodifica nada a píxeles ni se vuelve a
+        codificar: los bytes que salieron de tu disco son los bytes que entran en el
+        URI. Un JPEG sigue siendo exactamente el JPEG que era, con la misma calidad
+        y las mismas dimensiones. Es la razón por la que el resultado se puede
+        describir como el mismo archivo y no como una copia."""
+
+[[faq]]
+q = "Entonces, ¿mis datos EXIF y GPS también entran en la hoja de estilos?"
+a = """
+        Sí, y esta es la parte que merece la pena pensar antes de pegar nada. Como
+        no se recodifica nada, todo lo que escribió la cámara viaja con la imagen:
+        la ubicación, la marca de tiempo, el número de serie de la cámara. En una
+        foto de móvil eso pueden ser 30 KB del archivo, que se convierten en 40 KB
+        de base64 en el camino crítico de tu página, y en una dirección de casa
+        dentro de algo que va a acabar en un repositorio. La página lee cuántos
+        metadatos hay en un JPEG, un PNG o un WebP y lo dice. Para quitarlos antes,
+        usa el <a href="../eliminar-datos-exif/">visor y eliminador de EXIF</a>."""
+
+[[faq]]
+q = "¿Por qué ha usado un tipo distinto del de la extensión de mi archivo?"
+a = """
+        Porque la extensión puede estar equivocada y los bytes no. Un archivo
+        llamado <code>logo.png</code> que en realidad se exportó como JPEG es lo
+        bastante común como para que cualquier herramienta de imagen tenga que
+        apañárselas con ello, y un data URI que declara el tipo equivocado
+        sencillamente no se ve &mdash; no hay alternativa ni mensaje de error que
+        merezca la pena leer. Así que el tipo se lee de los primeros bytes del
+        archivo, que dicen sin ambigüedad qué es en todos los formatos de aquí, y la
+        página te avisa cuando los dos no coinciden."""
+
+[[faq]]
+q = "La vista previa sale en blanco. ¿Qué ha fallado?"
+a = """
+        Probablemente nada del URI. HEIC y TIFF hacen los dos data URI
+        perfectamente válidos que ningún navegador salvo Safari va a dibujar, así
+        que la imagen también faltará allá donde lo pegues &mdash; conviértela
+        antes a PNG, JPEG o WebP con el
+        <a href="../comprimir-imagen/">compresor de imágenes</a> o el
+        <a href="../redimensionar-imagen/">redimensionador de imágenes</a>. Si el
+        formato es de los corrientes, lo más probable es que el archivo esté
+        dañado: la vista previa se dibuja a partir del URI que ha construido esta
+        página, así que una en blanco significa que la imagen no ha
+        descodificado."""
+
+[[faq]]
+q = "¿Hay algún límite de tamaño en un data URI?"
+a = """
+        Ninguno con el que te vayas a topar en CSS ni en una etiqueta
+        <code>&lt;img&gt;</code>; los navegadores modernos no imponen ahí ningún
+        tope práctico. Lo que los navegadores sí limitan es teclear un data URI en
+        la barra de direcciones, cosa que casi todos rechazan ya para cualquier cosa
+        no trivial, por motivos de seguridad que no tienen nada que ver con este
+        uso. El límite de verdad es el de más arriba: mucho antes de que se rompa
+        nada técnico, la página en la que está se ha vuelto más lenta de lo que
+        habría sido con un archivo de imagen normal."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. Tampoco hay límite en el número ni en el tamaño de los archivos,
+        porque no hay ningún servidor pagándolos &mdash; el trabajo ocurre en tu
+        propio equipo. El sitio lleva publicidad, que es lo que lo paga; a los
+        anuncios no se les da nada sobre tus imágenes."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tus imágenes fuera a codificar se
+        detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Convierte un PNG, JPEG, SVG, WebP, GIF o ICO en un data URI listo para pegar en CSS o HTML. Base64 para los formatos de mapa de bits y codificación por porcentajes para SVG, envuelto en una regla CSS, una propiedad personalizada, una etiqueta img o Markdown, con el coste en tamaño y los metadatos incrustados a la vista. Funciona por completo en el navegador y no sube nada."
+features = [
+  "Data URI en base64 para PNG, JPEG, WebP, GIF, ICO, AVIF y más",
+  "Data URI de SVG codificados con porcentajes, más cortos que base64 y legibles",
+  "Regla CSS, propiedad personalizada, etiqueta img de HTML o Markdown ya montados, siempre bien entrecomillados",
+  "El tipo de medio leído de los propios bytes del archivo, no de su extensión",
+  "Dice lo que ha costado la codificación en caracteres, y si incrustar a ese tamaño compensa",
+  "Avisa cuando EXIF, XMP o un perfil de color está a punto de copiarse en tu hoja de estilos",
+  "Copia el archivo byte por byte: sin recodificar y sin pérdida de calidad",
+  "Por lotes, con todo copiado o descargado en un solo archivo",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí las imágenes"
+hint = "o haz clic para buscarlas &mdash; PNG, JPEG, SVG, WebP, GIF, ICO y más"

--- a/locales/es/tools/image-to-ico.html
+++ b/locales/es/tools/image-to-ico.html
@@ -1,0 +1,187 @@
+<main>
+  <!-- Paso 1 &mdash; la imagen -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige una imagen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo de la lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="shape-note" class="field-summary" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; qué norma -->
+  <section class="card" id="preset-card">
+    <h2><span class="step">2</span> Di para qué es el icono</h2>
+
+    <p class="card-lede">
+      Un archivo de icono no es una imagen, son varias: el mismo logotipo
+      dibujado otra vez a cada tamaño que pide quien lo lee. Cuáles son esos
+      tamaños no es cuestión de gustos &mdash; un navegador quiere tres, una
+      aplicación en un portátil de alta densidad quiere diez, un Mac quiere los
+      diez suyos, y algo escrito antes de Windows Vista los quiere guardados de
+      una forma completamente distinta.
+    </p>
+
+    <!--
+      Which files to write. Windows and macOS read different containers and
+      neither will look at the other's, so this is a set of checkboxes rather
+      than a menu: wanting both is the normal case for anything shipped on both.
+    -->
+    <fieldset class="options outputs">
+      <legend>Qué hacer</legend>
+
+      <label class="check">
+        <input type="checkbox" id="want-ico" checked>
+        <span>
+          <strong>Icono de Windows &mdash; <code>.ico</code></strong>
+          <span class="check-note">
+            Lo lee cualquier navegador como favicon, y Windows para una
+            aplicación, un acceso directo y una carpeta. Los tamaños los eliges
+            tú abajo.
+          </span>
+        </span>
+      </label>
+
+      <label class="check">
+        <input type="checkbox" id="want-icns">
+        <span>
+          <strong>Icono de macOS &mdash; <code>.icns</code></strong>
+          <span class="check-note">
+            Lo que lleva un paquete de aplicación de Mac. Apple nombra
+            exactamente diez ranuras, de 16 píxeles a 1024, así que no hay nada
+            que elegir: entran las diez, dibujadas a partir de siete renders
+            porque una ranura Retina y el tamaño siguiente son la misma imagen.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="pack-row">
+        <input type="checkbox" id="want-pack">
+        <span>
+          <strong>El resto del conjunto de iconos de una web</strong>
+          <span class="check-note">
+            Un .ico cubre la pestaña del navegador y Windows. No cubre la
+            pantalla de inicio de un iPhone, un aviso de instalación de Android
+            ni un mosaico anclado al menú Inicio &mdash; esos leen un PNG de
+            180 px, un manifiesto de aplicación web y un archivo XML, y ninguno
+            va a mirar dentro de un .ico. Marca esto y te llevas también todos
+            ellos, el manifiesto y el bloque de HTML para pegar en tu página.
+          </span>
+        </span>
+      </label>
+
+      <p id="output-summary" class="field-summary"></p>
+    </fieldset>
+
+    <div id="ico-settings">
+      <div class="presets" id="preset-list" role="radiogroup" aria-label="Para qué es el icono"></div>
+
+      <p id="preset-note" class="field-summary"></p>
+
+      <fieldset class="options" id="size-set">
+        <legend>Los tamaños que entran en el .ico</legend>
+        <div class="size-grid" id="size-grid"></div>
+        <p id="size-summary" class="field-summary"></p>
+      </fieldset>
+    </div>
+
+    <fieldset class="options">
+      <legend>Cómo se dibuja</legend>
+
+      <div class="option-row">
+        <label for="fit-select">Si la imagen no es cuadrada</label>
+        <select id="fit-select">
+          <option value="pad" selected>Rellenar hasta un cuadrado &mdash; se conserva la imagen entera</option>
+          <option value="crop">Recortar al cuadrado del centro</option>
+          <option value="stretch">Estirarla hasta un cuadrado</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="background-mode">Fondo</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparente</option>
+          <option value="colour">Un color</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Color de fondo" hidden>
+      </div>
+
+      <div class="option-row" id="storage-row">
+        <label for="storage-select">Cómo se guarda cada tamaño en el .ico</label>
+        <select id="storage-select">
+          <option value="auto" selected>Automático &mdash; compatible cuando sale barato, PNG cuando no</option>
+          <option value="png">PNG para todos los tamaños &mdash; el archivo más pequeño, necesita Vista o posterior</option>
+          <option value="bmp">Sin comprimir para todos los tamaños &mdash; se abre en cualquier cosa, varias veces más grande</option>
+        </select>
+      </div>
+
+      <p id="storage-note" class="field-summary"></p>
+    </fieldset>
+
+  </section>
+
+  <!-- Paso 3 &mdash; míralo pequeño y llévatelo -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Compruébalo al tamaño al que se verá</h2>
+
+    <p class="card-lede">
+      Esta es la parte que merece la pena mirar antes de descargar nada. Un
+      logotipo que se lee perfectamente a 512 píxeles mide dieciséis píxeles de
+      ancho en una pestaña del navegador, y sus partes finas &mdash; los trazos
+      de un texto, un borde de un pelo, un degradado &mdash; no sobreviven a eso.
+      Cada cuadrado de abajo está dibujado a su tamaño real a partir del archivo
+      que has elegido.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-strip" id="preview-strip"></div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make-icon" class="primary big" disabled>Hacer el icono</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Listo</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Descargar todo en un zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+
+      <!--
+        The block to paste into a page's <head>, shown rather than only zipped:
+        most people making a favicon are about to paste this into a template,
+        and a copy button is a shorter route than a download and a text editor.
+      -->
+      <div id="snippet" class="snippet" hidden>
+        <div class="snippet-head">
+          <h4>Pega esto en tu <code>&lt;head&gt;</code></h4>
+          <button type="button" id="copy-snippet" class="ghost">Copiar</button>
+        </div>
+        <pre id="snippet-text"></pre>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/image-to-ico.toml
+++ b/locales/es/tools/image-to-ico.toml
@@ -1,0 +1,353 @@
+#
+# Imagen a ICO - Spanish.
+#
+# Overrides for tools/image-to-ico/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Imagen a ICO"
+heading = "Imagen&nbsp;a&nbsp;ICO <span class=\"h1-kw\">&mdash; crear un favicon y los iconos de Windows y macOS</span>"
+tagline = "Entra una imagen. Salen todos los tamaños que pide un navegador, Windows o un Mac."
+
+title = "Imagen a ICO &mdash; crea un favicon, un icono de aplicación o un ICNS, sin subir nada"
+description = "Convierte un PNG, un JPEG o un SVG en un .ico real con varios tamaños o en un .icns de macOS, en tu navegador. Favicon, icono de aplicación de Windows, icono de aplicación de Mac, más los archivos de Apple y Android que necesita una web. No se sube nada."
+og_title = "Haz un .ico o un .icns con todos los tamaños dentro, sin subir nada"
+og_description = "Un favicon.ico para una web, un app.ico para un programa de Windows, un .icns para un Mac, con una vista previa a 16 píxeles antes de descargar. Todo ocurre en tu propio equipo."
+og_image_alt = "Imagen a ICO - crea favicons e iconos de Windows y macOS, sin subir nada"
+
+pledge = """
+    El escalado y los propios archivos de icono se hacen los dos en tu propio
+    navegador. La imagen la dibuja el lienzo que tu navegador ya trae de serie, y
+    cada contenedor &mdash; el <code>.ico</code> de Windows, el
+    <code>.icns</code> de macOS &mdash; se monta a partir de esos píxeles con un
+    par de cientos de líneas en <code>src/ico.js</code> y
+    <code>src/icns.js</code> que puedes leer. Esta herramienta no tiene ninguna
+    función de red &mdash; nada que descargar, nada que enviar &mdash; y al otro
+    lado de esta página no hay ningún servidor al que mandar un logotipo aunque
+    lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y haz un icono. Ni una sola petición lleva una imagen, una
+      miniatura, un nombre de archivo ni un byte de lo que has elegido. O
+      desconéctate de internet y haz uno de todos modos."""
+
+read_first = """
+, <code>src/ico.js</code> y
+      <code>src/icns.js</code> para los dos formatos de icono &mdash; el
+      directorio, las entradas y la máscara en uno, las diez ranuras que nombra
+      Apple en el otro &mdash;, y <code>src/sizes.js</code> para saber de dónde
+      sale cada tamaño de la página."""
+
+howto_heading = "Cómo hacer un archivo .ico sin subir nada"
+
+card = """
+            Un favicon, un icono de aplicación de Windows o un .icns de macOS
+            &mdash; todos los tamaños en un archivo, con una vista previa a 16
+            píxeles antes de descargar."""
+
+[words]
+plural = "imágenes"
+choose = "una imagen"
+analytics_extra = """, ni ninguno de los
+  tamaños, formatos o nombres de archivo que esta herramienta calcula"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Tu logotipo no tiene adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudieran recogerse tus archivos, ni nada en el código que los enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ No hay ningún
+      <code>fetch</code>, ningún <code>XMLHttpRequest</code> ni ningún
+      <code>sendBeacon</code> en todo <code>src/</code>. El escalado es un
+      <code>drawImage</code> sobre un lienzo; cada icono es una cabecera escrita
+      delante de esos píxeles por <code>src/ico.js</code> o
+      <code>src/icns.js</code>, en esta página."""
+
+[[privacy]]
+title = "El archivo se describe a partir de sus propios bytes."
+body = """
+ La lista de tamaños que
+      se ve junto a un icono terminado no es la lista de tamaños que pediste. Se
+      vuelve a leer del archivo que se acaba de escribir, con
+      <code>readIcoDirectory</code> o <code>readIcnsElements</code>, así que si
+      alguna vez un escritor discrepara de los ajustes, la página lo diría en vez
+      de enterarte tú cuando Windows no dibujara nada y macOS dibujara una hoja de
+      papel en blanco."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google, y el botón de donación de Buy Me a
+      Coffee. A ninguno se le entrega nada sobre tu imagen. Cada línea que lee,
+      escala o escribe un archivo se sirve desde este origen y está listada en el
+      repositorio."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta
+      sigue igual, porque nunca hubo un paso de red dentro de ella. Es la prueba
+      más sencilla de todas."""
+
+[[howto]]
+title = "Elige la imagen."
+body = """
+ Suelta un PNG, JPEG, WebP o SVG sobre el
+      selector, o escoge varias y conviértelas de una vez. Lo más fácil es que
+      sea cuadrada, y cualquier cosa de 256 píxeles para arriba tiene detalle de
+      sobra para todos los tamaños. Tu navegador la lee directamente del disco;
+      mientras lo haces no se envía nada a ninguna parte."""
+
+[[howto]]
+title = "Elige los archivos que necesitas."
+body = """
+ Windows y un navegador leen
+      <code>.ico</code>; un Mac lee <code>.icns</code> y no mirará el otro. Marca
+      uno, o los dos si lo que estás haciendo se distribuye en ambos. Una web
+      quiere además las imágenes extra de Apple, de Android y de mosaico, y esa es
+      la tercera casilla."""
+
+[[howto]]
+title = "Di para qué es el icono."
+body = """
+ El favicon de una web son 16, 32 y
+      48 píxeles; una aplicación de Windows quiere también 256; una aplicación que
+      tiene que verse bien en un portátil de alta densidad quiere los tamaños
+      intermedios que pide Windows al 125&nbsp;% y al 150&nbsp;%. Elige el que
+      encaje con el trabajo, o marca los tamaños tú mismo. Cada tamaño de la lista
+      dice quién lo pide. El <code>.icns</code> no ofrece esa elección: Apple
+      nombra exactamente diez ranuras y entran las diez."""
+
+[[howto]]
+title = "Resuelve la forma y el fondo."
+body = """
+ Un icono es cuadrado y casi
+      ningún logotipo lo es. Rellena y se conserva la imagen entera con espacio
+      arriba y abajo; recorta y se toma el centro; estira y queda aplastada. La
+      transparencia se conserva como transparencia salvo que elijas un color para
+      ponerlo detrás."""
+
+[[howto]]
+title = "Mira el de 16 píxeles antes de descargar."
+body = """
+ Ese es el tamaño al
+      que más veces se verá el icono, y es donde desaparecen los trazos finos y
+      las letras pequeñas. Cada cuadrado de la vista previa está dibujado a su
+      tamaño real a partir de tu propio archivo. Si el más pequeño es un borrón,
+      la solución es un dibujo más simple, no otro ajuste."""
+
+[[howto]]
+title = "Llévate los archivos."
+body = """
+ Un .ico con todos los tamaños dentro,
+      llamado <code>favicon.ico</code> cuando es eso lo que has pedido, porque esa
+      es la dirección que los navegadores buscan. Un .icns al lado si marcaste
+      eso, listo para entrar en un paquete de aplicación de Mac. Marca también el
+      conjunto para web y te llevas además las imágenes de Apple, de Android y de
+      mosaico de Windows, el manifiesto y el bloque de HTML para pegar en tu
+      página. Cualquier cosa que sea más de un archivo baja como un solo zip."""
+
+[[faq]]
+q = "¿Se sube mi imagen a alguna parte?"
+a = """
+        No. Tu propio navegador descodifica y escala la imagen en tu propio
+        hardware, y el .ico se monta a partir de esos píxeles con código servido
+        desde esta página. Esta herramienta no tiene ninguna función de red
+        &mdash; nunca descarga nada y nunca envía nada &mdash; y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es de este
+        sitio."""
+
+[[faq]]
+q = "¿Qué tamaños debe contener un favicon.ico?"
+a = """
+        16, 32 y 48. Y no es cuestión de gustos: 16 es lo que dibuja un navegador
+        en una pestaña, 32 es lo que usa Windows para un acceso directo del
+        escritorio y lo que usan varios navegadores para un marcador, y 48 es el
+        tamaño al que Google lee el icono de un sitio. Cualquier cosa más grande
+        va en un PNG al lado del .ico y no dentro &mdash; que es lo que produce el
+        conjunto para web de aquí."""
+
+[[faq]]
+q = "¿Qué tamaños necesita el icono de una aplicación de Windows?"
+a = """
+        16, 32, 48 y 256, que es lo que lleva el app.ico que trae por defecto el
+        propio Visual Studio. 16 es la barra de título y la vista pequeña del
+        Explorador, 32 el escritorio y la barra de tareas, 48 los iconos medianos
+        del Explorador, y 256 el menú Inicio y la vista extragrande. En una
+        pantalla de alta densidad Windows pide además 20, 24, 40, 64 y 96, y los
+        remuestrea del tamaño más cercano que tenga si no están &mdash; el
+        preajuste «todas las escalas» los mete."""
+
+[[faq]]
+q = "¿Por qué el archivo es más grande que la imagen de la que partí?"
+a = """
+        Porque un .ico no es una imagen, son varias, y las pequeñas se guardan sin
+        comprimir para que cualquier cosa pueda leerlas. Una entrada de 32x32 son
+        exactamente 4264 bytes lleve lo que lleve, y una entrada de 256x256 sin
+        comprimir son 264 KB &mdash; y por eso los tamaños por encima de 64 se
+        guardan como PNG por defecto. Elegir «PNG para todos los tamaños» hace el
+        archivo más pequeño posible; elegir sin comprimir para todos los tamaños
+        hace el más compatible."""
+
+[[faq]]
+q = "¿Qué diferencia hay entre las entradas PNG y las sin comprimir?"
+a = """
+        Solo cómo se guardan los píxeles dentro del .ico. Una entrada sin comprimir
+        es la disposición original de Windows &mdash; una cabecera de mapa de bits,
+        los píxeles del revés y una máscara de transparencia de un bit &mdash;, y
+        la sabe leer cualquier versión de Windows publicada jamás. Una entrada PNG
+        es un archivo PNG entero metido dentro del icono, que en los tamaños
+        grandes es de tres a diez veces más pequeño pero solo se entiende desde
+        Windows Vista en adelante. El ajuste por defecto usa cada uno donde gana:
+        sin comprimir hasta 64 píxeles, PNG por encima."""
+
+[[faq]]
+q = "¿Puede hacer un icono más grande que 256 píxeles?"
+a = """
+        No, y nada puede. El formato guarda cada lado en un solo byte, y el 0 está
+        cogido &mdash; significa 256. Ese es el techo, así que un .ico que
+        contenga una imagen de 512 píxeles no es un icono más grande, es un icono
+        roto. Si necesitas 512, necesitas un PNG, que es lo que incluye el conjunto
+        para web para Android y para la pantalla de arranque de una aplicación
+        web."""
+
+[[faq]]
+q = "¿Conserva la transparencia?"
+a = """
+        Sí, en los dos tipos de entrada, y además escribe la vieja máscara de un
+        bit junto al canal alfa para que el software demasiado antiguo para leer el
+        alfa siga recortando el icono en lugar de dibujar una caja negra. El único
+        archivo que se hace opaco a propósito es el icono táctil de Apple del
+        conjunto para web: iOS lo compone sobre su propio mosaico y convierte la
+        transparencia en negro, así que se aplana sobre tu color de fondo, blanco
+        por defecto."""
+
+[[faq]]
+q = "Mi logotipo es un texto ancho. ¿Qué le pasa?"
+a = """
+        Algo tiene que pasarle, porque un icono es cuadrado. Rellenar lo conserva
+        entero y lo deja pequeño &mdash; un texto rellenado dentro de un cuadrado
+        de 16 píxeles tiene unos tres píxeles de alto y no se lee. Recortar al
+        centro suele funcionar mejor: saca el símbolo del conjunto y usa eso, como
+        hace casi cualquier marca con su favicon. La vista previa te enseña cuál de
+        los dos sobrevive antes de que descargues nada."""
+
+[[faq]]
+q = "¿Qué hay en el conjunto para web y necesito todo?"
+a = """
+        Siete PNG, un manifiesto de aplicación web, un browserconfig.xml y un
+        bloque de HTML para pegar. Los necesitas porque un .ico cubre los
+        navegadores y Windows y nada más: la pantalla de inicio de un iPhone lee un
+        PNG de 180 píxeles con un nombre propio, Android y cualquier aviso de
+        instalación leen el manifiesto, y un mosaico anclado al menú Inicio lee el
+        XML. Ninguno de ellos va a mirar dentro de un .ico. Todo se genera aquí, en
+        tu equipo, y el zip lleva dentro una nota que dice para qué es cada
+        archivo."""
+
+[[faq]]
+q = "¿Puede hacer también un icono de macOS?"
+a = """
+        Sí &mdash; marca <em>icono de macOS</em> y te llevas un <code>.icns</code>
+        junto al <code>.ico</code>, o en su lugar. Es otro contenedor para la misma
+        idea, y ninguno de los dos sistemas leerá el del otro: Windows quiere .ico y
+        un paquete de aplicación de Mac quiere .icns. Ahí los tamaños no se eligen,
+        porque Apple publica exactamente diez ranuras &mdash; 16, 32, 64, 128, 256,
+        512 y 1024 píxeles, con tres de ellos apareciendo dos veces como la versión
+        Retina del tamaño de debajo. Entran las diez, dibujadas a partir de siete
+        renders, y por eso un .icns es el archivo más grande."""
+
+[[faq]]
+q = "¿Cómo uso el archivo .icns?"
+a = """
+        Para una aplicación, va en el paquete, en
+        <code>TuApp.app/Contents/Resources/</code>, y se nombra en
+        <code>Info.plist</code> bajo <code>CFBundleIconFile</code>; cualquier
+        herramienta de empaquetado de Mac tiene un campo para eso. Para cualquier
+        otra cosa, selecciona el archivo en el Finder, pulsa Comando-C, después
+        haz Obtener información sobre la carpeta o la imagen de disco que quieras
+        cambiar, haz clic en el icono pequeño de arriba a la izquierda y pulsa
+        Comando-V."""
+
+[[faq]]
+q = "¿El .icns es igual que el que hace iconutil?"
+a = """
+        Las mismas diez ranuras con los mismos tipos de cuatro letras, y PNG en
+        cada una, que es lo que produce <code>iconutil</code> a partir de una
+        carpeta <code>.iconset</code>. Una diferencia deliberada: la herramienta de
+        Apple escribe además un elemento <code>TOC&nbsp;</code>, un índice de los
+        tipos y las longitudes que vienen después. Es una optimización más que
+        parte del formato &mdash; un lector sin él recorre los elementos de punta a
+        punta y llega a la misma respuesta &mdash;, y un índice equivocado es peor
+        que ningún índice, así que se deja fuera."""
+
+[[faq]]
+q = "¿Puedo convertir varias imágenes a la vez?"
+a = """
+        Sí. Cada imagen de la lista se convierte en su propio .ico con los mismos
+        ajustes, y el lote baja como un solo zip con una carpeta por imagen
+        &mdash; si no, dos de ellos se llamarían favicon.ico y uno sobrescribiría
+        al otro. Cada salida que hayas marcado se hace para cada imagen. Haz clic
+        en cualquier fila para poner esa imagen en la vista previa."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. Tampoco hay límite en el número ni en el tamaño de los archivos,
+        porque no hay ningún servidor pagándolos &mdash; el trabajo ocurre en tu
+        propio equipo. El sitio lleva publicidad, que es lo que lo paga; a los
+        anuncios no se les da nada sobre tus imágenes."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tu logotipo fuera a convertir se
+        detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Convierte una imagen en un archivo ICO de Windows con varios tamaños o en un archivo ICNS de macOS, en el navegador. Preajustes para el favicon de una web, para el icono de una aplicación de Windows y para una aplicación de alta densidad, las diez ranuras icns de Apple, una vista previa de cada tamaño a su tamaño real en píxeles, y un conjunto opcional con los archivos de Apple, Android y mosaico de Windows que necesita una web. No se sube nada."
+features = [
+  "Escribe un .ico real con varios tamaños, de 16 a 256 píxeles",
+  "Escribe un .icns de macOS con las diez ranuras de Apple, de 16 a 1024 píxeles",
+  "Los dos formatos a partir de una imagen, de una pasada, dibujando cada tamaño una sola vez",
+  "Preajustes para el favicon de una web, el icono de una aplicación de Windows, Windows de alta densidad y máxima compatibilidad",
+  "Cada tamaño dice quién lo pide, así que nada entra porque sí",
+  "Entradas sin comprimir para los tamaños pequeños y PNG para los grandes, o todo de una de las dos formas",
+  "Conserva la transparencia, y escribe también la máscara de transparencia anterior a Vista",
+  "Rellena, recorta o estira una imagen que no sea cuadrada, sobre un color o sobre nada",
+  "Enseña cada tamaño a su tamaño real en píxeles antes de descargar",
+  "Conjunto para web opcional: icono táctil de Apple, iconos de Android, icono enmascarable, mosaico de Windows, manifiesto y el HTML para pegar",
+  "Por lotes, con todos los resultados en un zip",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí una imagen"
+hint = "o haz clic para buscarla &mdash; PNG, SVG, JPEG, WebP y cualquier otra cosa que tu navegador sepa abrir"

--- a/locales/es/tools/images-to-pdf.html
+++ b/locales/es/tools/images-to-pdf.html
@@ -1,0 +1,230 @@
+<main>
+  <!-- Paso 1 &mdash; las imágenes -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige las imágenes</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" data-sort="name" class="ghost">Ordenar por nombre</button>
+        <button type="button" data-sort="date" class="ghost">Ordenar por fecha</button>
+        <button type="button" data-sort="reverse" class="ghost">Invertir</button>
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Una imagen por página, en este orden. Arrastra por el asa
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> para mover una página,
+      o usa sus flechas.
+    </p>
+
+    <ul id="image-list" class="image-list"></ul>
+  </section>
+
+  <!-- Paso 2 &mdash; las páginas -->
+  <section class="card">
+    <h2><span class="step">2</span> Configura la página</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Tamaño de página</label>
+        <select id="page-size">
+          <option value="fit" selected>Ajustar la página a cada imagen</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Carta &mdash; 8,5 &times; 11 pulg.</option>
+          <option value="legal">Oficio &mdash; 8,5 &times; 14 pulg.</option>
+          <option value="a3">A3 &mdash; 297 &times; 420 mm</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+          <option value="tabloid">Tabloide &mdash; 11 &times; 17 pulg.</option>
+          <option value="custom">Personalizado&hellip;</option>
+        </select>
+        <div id="custom-size" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="1" max="5000" step="1" value="210"
+                 aria-label="Ancho de página personalizado">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="1" max="5000" step="1" value="297"
+                 aria-label="Alto de página personalizado">
+          <select id="custom-unit" aria-label="Unidad del tamaño de página personalizado">
+            <option value="mm" selected>mm</option>
+            <option value="in">pulg.</option>
+          </select>
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Resolución de impresión</label>
+        <select id="dpi">
+          <option value="72">72 PPP &mdash; pantalla</option>
+          <option value="96">96 PPP</option>
+          <option value="150" selected>150 PPP</option>
+          <option value="200">200 PPP</option>
+          <option value="300">300 PPP &mdash; imprenta</option>
+          <option value="600">600 PPP</option>
+        </select>
+        <p class="field-note">
+          Decide de qué tamaño es una página para un número dado de píxeles. No
+          cambia la imagen.
+        </p>
+      </div>
+
+      <div class="field" id="orientation-field" hidden>
+        <label for="orientation">Orientación</label>
+        <select id="orientation">
+          <option value="auto" selected>Igual que cada imagen</option>
+          <option value="portrait">Vertical</option>
+          <option value="landscape">Horizontal</option>
+        </select>
+      </div>
+
+      <div class="field" id="fit-field" hidden>
+        <label for="fit">Cómo se coloca la imagen en la página</label>
+        <select id="fit">
+          <option value="contain" selected>Encajar dentro de los márgenes</option>
+          <option value="cover">Llenar la página (recorta los bordes)</option>
+          <option value="stretch">Estirar hasta los márgenes (deforma)</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="margin">Margen</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="100" step="1" value="0"
+                 aria-label="Margen en milímetros">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="background">Color de página</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Se ve en los márgenes, y detrás de lo que sea transparente.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="mode">Calidad de imagen</label>
+        <select id="mode">
+          <option value="keep" selected>Dejar los JPEG exactamente como están</option>
+          <option value="jpeg">Recodificarlo todo como JPEG</option>
+          <option value="lossless">Sin pérdidas &mdash; ninguna pérdida por compresión</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Calidad JPEG</label>
+        <select id="quality">
+          <option value="0.75">Archivo más pequeño</option>
+          <option value="0.88" selected>Equilibrado</option>
+          <option value="0.95">Mejor calidad</option>
+        </select>
+        <p class="field-note">Solo se usa con las fotos que esta herramienta tiene que recodificar.</p>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Reducir las imágenes grandes</label>
+        <select id="max-side">
+          <option value="0" selected>Nunca &mdash; a tamaño completo</option>
+          <option value="4000">Lado más largo 4000 px</option>
+          <option value="2000">Lado más largo 2000 px</option>
+          <option value="1200">Lado más largo 1200 px</option>
+        </select>
+        <p class="field-note" id="shrink-note"></p>
+      </div>
+    </div>
+
+    <details class="meta-panel">
+      <summary>Datos del documento &mdash; todos opcionales y en blanco por defecto</summary>
+      <div class="meta-body">
+        <p class="meta-note">
+          Un PDF lleva un pequeño bloque de información sobre sí mismo, y casi
+          todas las herramientas lo rellenan con una marca de tiempo y el nombre
+          de un programa, se lo pidas o no. Esta escribe lo que teclees aquí y
+          nada más: ni nombres de archivo, ni nombre de equipo, ni fecha a menos
+          que marques la casilla.
+        </p>
+        <div class="settings">
+          <div class="field">
+            <label for="doc-title">Título</label>
+            <input type="text" id="doc-title" maxlength="200" spellcheck="false"
+                   placeholder="Se omite si está en blanco">
+          </div>
+          <div class="field">
+            <label for="doc-author">Autor</label>
+            <input type="text" id="doc-author" maxlength="200" spellcheck="false"
+                   placeholder="Se omite si está en blanco">
+          </div>
+          <div class="field">
+            <label for="file-name">Nombre del archivo</label>
+            <div class="inline-pair">
+              <input type="text" id="file-name" maxlength="120" spellcheck="false"
+                     value="imagenes">
+              <span class="unit-label">.pdf</span>
+            </div>
+          </div>
+          <div class="field checkbox-field">
+            <label for="dated">
+              <input type="checkbox" id="dated">
+              Anotar la fecha de hoy en el documento
+            </label>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="480" height="640" aria-label="Vista previa de una página"></canvas>
+        <p id="preview-empty" class="preview-empty">Añade imágenes para ver las páginas</p>
+        <div id="preview-nav" class="preview-nav" hidden>
+          <button type="button" id="preview-prev" class="ghost" aria-label="Página anterior">&lsaquo;</button>
+          <span id="preview-label" class="preview-label"></span>
+          <button type="button" id="preview-next" class="ghost" aria-label="Página siguiente">&rsaquo;</button>
+        </div>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Páginas</dt><dd id="sum-pages">&mdash;</dd></div>
+        <div><dt>Tamaño de página</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Imágenes elegidas</dt><dd id="sum-input">&mdash;</dd></div>
+        <div><dt>Copiadas intactas</dt><dd id="sum-copied">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Paso 3 &mdash; la exportación -->
+  <section class="card">
+    <h2><span class="step">3</span> Crea el PDF</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Crear PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Descargar PDF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/images-to-pdf.toml
+++ b/locales/es/tools/images-to-pdf.toml
@@ -1,0 +1,228 @@
+#
+# Imágenes a PDF - Spanish.
+#
+# Overrides for tools/images-to-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Imágenes a PDF"
+heading = "Imágenes&nbsp;a&nbsp;PDF <span class=\"h1-kw\">&mdash; convertir JPG a PDF</span>"
+tagline = "Mete tus fotos en un solo documento."
+
+title = "Convertidor de imágenes a PDF &mdash; JPG a PDF gratis y sin subir nada"
+description = "Une imágenes JPG, PNG o WebP en un solo PDF, gratis y por completo en tu navegador. Las fotos entran sin volver a codificarse, y no se sube nada."
+og_title = "Imágenes a PDF &mdash; convertidor gratuito de JPG a PDF"
+og_description = "Une imágenes en un solo PDF en tu propio equipo. Las fotos JPEG se copian intactas, así que no se pierde calidad y no se sube nada."
+og_image_alt = "Imágenes a PDF - une fotos en un documento sin subirlas"
+
+pledge = """
+    El documento se escribe en la memoria de este equipo, página a página, con
+    código servido desde esta dirección. Aquí nada puede hacer una subida, y al
+    otro lado de esta página no hay ningún servidor que la recibiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y haz un PDF. Ni una sola petición lleva una imagen, una
+      miniatura ni un nombre de archivo. O desconéctate de internet y haz uno de
+      todos modos."""
+
+read_first = """
+, y <code>src/pdf.js</code> y <code>src/document.js</code>
+      para toda la escritura del archivo, que nunca toca la red."""
+
+howto_heading = "Cómo convertir imágenes en un PDF"
+
+card = """
+            Une imágenes en un solo PDF, una foto por página. Las fotos JPEG se
+            copian exactamente tal cual, así que no se pierde calidad."""
+
+[words]
+plural = "imágenes"
+choose = "imágenes"
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[facts]]
+text = "Los archivos se quedan en tu dispositivo"
+
+[[privacy]]
+title = "Tus imágenes no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Esta herramienta no añade nada a esa
+      lista: no tiene ninguna función de red propia, ni siquiera opcional. Aquí no
+      hay ningún punto final donde pudieran recogerse tus archivos, ni nada en el
+      código que los enviara si lo hubiera."""
+
+[[privacy]]
+title = "El PDF se escribe aquí."
+body = """
+ Un PDF es una lista de objetos y una tabla
+      que dice dónde empieza cada uno, y <code>src/pdf.js</code> escribe las dos.
+      No se descarga ninguna biblioteca, no se renderiza nada en un servidor, y el
+      archivo terminado se entrega directamente a una descarga desde la
+      memoria."""
+
+[[privacy]]
+title = "Al documento no se le cuenta nada de ti."
+body = """
+ Casi todas las
+      herramientas le estampan a un PDF una marca de tiempo y el nombre del
+      programa que lo hizo. Esta escribe un título, un autor y una fecha solo si
+      los tecleas tú; los nombres de archivo de tus fotos no aparecen nunca en el
+      documento, y nada sobre tu equipo tampoco."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google. A ninguno se le entrega nada sobre
+      tus imágenes: ni un archivo, ni una miniatura, ni un nombre, un tamaño o un
+      recuento. Cada línea que lee, descodifica o escribe una imagen se sirve
+      desde este origen y está listada en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le da."
+body = """
+
+      El botón «Buy me a coffee» de la cabecera lo dibuja un script de
+      cdnjs.buymeacoffee.com y se compone con Google Fonts. Es un enlace y nada
+      más: no informa de ninguna visita, y no se le entrega nada sobre ti ni
+      sobre tus imágenes. No pasa nada a menos que lo pulses, y lo que hay al
+      otro lado es el sitio de otra gente."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo lo de esta
+      página sigue funcionando. Es la prueba más sencilla de todas: una
+      herramienta que mandara tus fotos fuera para convertirlas en un documento se
+      detendría."""
+
+[[howto]]
+title = "Elige tus imágenes."
+body = """
+ Suelta una carpeta sobre el selector,
+      o escoge los archivos a mano. Tu navegador los lee directamente del disco;
+      mientras lo haces no se envía nada a ninguna parte."""
+
+[[howto]]
+title = "Ordena las páginas y gira las que lo necesiten."
+body = """
+ Una
+      imagen es una página, en el orden que se ve. Arrastra una ficha por su asa
+      para moverla, o usa las flechas; los botones de giro voltean una página un
+      cuarto cada vez, que es lo que suele necesitar un escaneo de lado."""
+
+[[howto]]
+title = "Elige un tamaño de página."
+body = """
+ «Ajustar la página a cada
+      imagen» hace que cada página sea exactamente su foto, sin recortes y sin
+      bandas blancas. Los tamaños con nombre &mdash; A4, Carta, Oficio y los
+      demás &mdash; colocan cada foto en una página fija, con un margen si lo
+      quieres."""
+
+[[howto]]
+title = "Crea el PDF y descárgalo."
+body = """
+ El documento se escribe en tu
+      propio equipo, así que lo que tarde depende de tu hardware y no de una cola.
+      El archivo terminado se entrega directamente a las descargas de tu
+      navegador."""
+
+[[faq]]
+q = "¿Se suben mis imágenes a alguna parte?"
+a = """
+        No. Tu propio navegador lee tus imágenes y escribe el PDF en tu propio
+        hardware. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar &mdash; ninguna es de este sitio. A
+        diferencia de algunas de las otras herramientas de aquí, esta no tiene
+        ninguna función de red opcional."""
+
+[[faq]]
+q = "¿Convertir a PDF hace perder calidad?"
+a = """
+        Con un JPEG y el ajuste por defecto, no. Un PDF puede llevar datos JPEG
+        directamente, así que una fotografía se copia al documento byte por byte:
+        nunca se descodifica y nunca se vuelve a comprimir, y la imagen del PDF es
+        la imagen del archivo. Los demás formatos hay que recodificarlos, porque
+        el PDF no tiene ningún filtro para ellos &mdash; salvo que elijas el
+        ajuste sin pérdidas, que los guarda exactamente a costa de un archivo más
+        grande."""
+
+[[faq]]
+q = "¿Qué formatos de imagen puedo usar?"
+a = """
+        Cualquier imagen fija que tu navegador sepa descodificar, que en la
+        práctica significa JPG, PNG, WebP, GIF, AVIF y, en dispositivos Apple,
+        HEIC. Aquí no hay otra lista que mantener al día, porque descodificar es
+        trabajo del navegador y no nuestro."""
+
+[[faq]]
+q = "¿Puedo elegir el tamaño de página y el orden de las páginas?"
+a = """
+        Sí. Las páginas pueden ser A4, Carta, Oficio, A3, A5, Tabloide, un tamaño
+        que teclees tú o exactamente el tamaño de cada foto. Arrastra las fichas
+        para reordenarlas, ordénalas por nombre o por fecha, gira cualquiera un
+        cuarto de vuelta y pon un margen en milímetros."""
+
+[[faq]]
+q = "¿Cuántas imágenes puedo meter en un PDF?"
+a = """
+        La herramienta no lleva ningún límite dentro. El techo práctico es la
+        memoria de tu propio equipo, porque el documento terminado se monta ahí
+        antes de que lo descargues. Unos cientos de fotos de móvil a resolución
+        completa es lo primero que lo nota; reducir el lado más largo, en los
+        ajustes, mueve ese techo bastante lejos."""
+
+[[faq]]
+q = "¿El PDF contiene los nombres de mis archivos o una marca de tiempo?"
+a = """
+        No, salvo que lo pidas. El bloque de información del documento se deja
+        vacío salvo por el nombre de esta herramienta: ni nombres de archivo, ni
+        nombre de equipo, ni nombre de usuario, ni fecha de creación a menos que
+        marques la casilla. Es a propósito &mdash; un PDF es algo que la gente
+        manda a otra gente."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba. El sitio lleva
+        publicidad, que es lo que lo paga; a los anuncios no se les da nada sobre
+        tus imágenes."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tus imágenes fuera para convertirlas
+        en un documento se detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Une imágenes JPG, PNG y WebP en un único documento PDF. Cada página se escribe en tu navegador, así que no se sube ninguna imagen."
+features = [
+  "Une imágenes JPG, PNG, WebP, GIF y AVIF en un solo PDF",
+  "Las fotos JPEG se incrustan sin volver a codificarse",
+  "Tamaños de página de A5 a Tabloide, o una página ajustada a cada imagen",
+  "Reordena, gira, pon márgenes y un color de página",
+  "Almacenamiento sin pérdidas opcional para escaneos y capturas",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí las imágenes"
+hint = "o haz clic para buscarlas &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/es/tools/images-to-video.html
+++ b/locales/es/tools/images-to-video.html
@@ -1,0 +1,166 @@
+<main>
+  <!-- Paso 1 &mdash; las imágenes -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige las imágenes</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    {% include "partials/url-import.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Cambiar cómo se muestra la lista">
+          <button type="button" data-view="large" class="active">Grande</button>
+          <button type="button" data-view="small">Pequeño</button>
+          <button type="button" data-view="list">Lista</button>
+          <button type="button" data-view="details">Detalles</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Ordenar por nombre</button>
+        <button type="button" data-sort="date" class="ghost">Ordenar por fecha</button>
+        <button type="button" data-sort="reverse" class="ghost">Invertir</button>
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Arrastra cualquier imagen por su asa <span class="grip" aria-hidden="true">&#8942;&#8942;</span> para
+      reordenar, o usa las flechas de cada una.
+    </p>
+
+    <ul id="image-list" class="image-list view-large"></ul>
+
+    <div id="bulk-duration" class="bulk" hidden>
+      <label for="bulk-amount">Mantener cada imagen</label>
+      <input type="number" id="bulk-amount" min="1" max="3600" step="1" value="1">
+      <select id="duration-unit" aria-label="Unidad de cuánto se mantiene cada imagen">
+        <option value="frames" selected>fotogramas</option>
+        <option value="seconds">segundos</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Aplicar a todas</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Paso 2 &mdash; los ajustes -->
+  <section class="card">
+    <h2><span class="step">2</span> Ajustes del vídeo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="resolution">Resolución</label>
+        <select id="resolution">
+          <option value="auto" selected>Igualar la resolución más alta</option>
+          <option value="3840x2160">3840 &times; 2160 &mdash; 4K</option>
+          <option value="1920x1080">1920 &times; 1080 &mdash; 1080p</option>
+          <option value="1280x720">1280 &times; 720 &mdash; 720p</option>
+          <option value="1080x1080">1080 &times; 1080 &mdash; cuadrado</option>
+          <option value="1080x1920">1080 &times; 1920 &mdash; vertical</option>
+          <option value="custom">Personalizada&hellip;</option>
+        </select>
+        <div id="resolution-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="7680" step="2" value="1920"
+                 aria-label="Ancho de salida personalizado en píxeles">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="7680" step="2" value="1080"
+                 aria-label="Alto de salida personalizado en píxeles">
+        </div>
+        <p class="field-note" id="resolution-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Cadencia</label>
+        <select id="fps">
+          <option value="12">12 fps</option>
+          <option value="15">15 fps</option>
+          <option value="24">24 fps &mdash; cine</option>
+          <option value="25">25 fps &mdash; PAL</option>
+          <option value="30" selected>30 fps</option>
+          <option value="50">50 fps</option>
+          <option value="60">60 fps</option>
+          <option value="custom">Personalizada&hellip;</option>
+        </select>
+        <input type="number" id="fps-custom" class="spaced" min="1" max="120" step="1" value="30"
+               aria-label="Cadencia personalizada en fotogramas por segundo" hidden>
+        <p class="field-note" id="fps-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Encaje de la imagen</label>
+        <select id="fit">
+          <option value="contain" selected>Encajar dentro (bandas negras)</option>
+          <option value="blur">Encajar dentro, con fondo desenfocado</option>
+          <option value="cover">Llenar el fotograma (recorta los bordes)</option>
+          <option value="stretch">Estirar hasta llenar (deforma)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Color de fondo</label>
+        <input type="color" id="background" value="#000000">
+      </div>
+
+      <div class="field">
+        <label for="quality">Calidad</label>
+        <select id="quality">
+          <option value="low">Archivo más pequeño</option>
+          <option value="medium" selected>Equilibrado</option>
+          <option value="high">Mejor calidad</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="auto" selected>MP4 (recomendado)</option>
+          <option value="webm">WebM (alternativa)</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="640" height="360" aria-label="Vista previa del primer fotograma"></canvas>
+        <p id="preview-empty" class="preview-empty">Añade imágenes para ver una vista previa</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Imágenes</dt><dd id="sum-images">&mdash;</dd></div>
+        <div><dt>Duración</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Tamaño de salida</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Fotogramas totales</dt><dd id="sum-frames">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Paso 3 &mdash; la exportación -->
+  <section class="card">
+    <h2><span class="step">3</span> Crea el vídeo</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Crear vídeo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Descargar vídeo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/images-to-video.toml
+++ b/locales/es/tools/images-to-video.toml
@@ -1,0 +1,244 @@
+#
+# Imágenes a vídeo - Spanish.
+#
+# Overrides for tools/images-to-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Imágenes a vídeo"
+heading = "Imágenes&nbsp;a&nbsp;vídeo <span class=\"h1-kw\">&mdash; hacer un pase de diapositivas en MP4</span>"
+tagline = "Convierte una carpeta de imágenes en un vídeo."
+
+title = "Secuencia de imágenes a MP4 &mdash; gratis, sin subidas y sin conexión"
+description = "Convierte imágenes JPG, PNG o WebP en un vídeo MP4 de pase de diapositivas, gratis y por completo en tu navegador. No se sube nada, no hay que registrarse y funciona sin conexión."
+og_title = "Secuencia de imágenes a MP4 &mdash; gratis, en tu navegador"
+og_description = "Convierte una secuencia de render, un timelapse o una carpeta de fotos en un MP4. La codificación ocurre en tu propio equipo; no se sube nada."
+og_image_alt = "Imágenes a vídeo - convierte una carpeta de imágenes en un pase de diapositivas MP4"
+
+pledge = """
+    Tu propio navegador codifica cada fotograma y el vídeo se construye en la
+    memoria de este equipo. El codificador no toca nunca la red, y al otro lado
+    de esta página no hay ningún servidor al que mandar una imagen aunque la
+    tocara."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y haz un vídeo. Ni una sola petición lleva una imagen, una
+      miniatura ni un nombre de archivo. O desconéctate de internet y haz uno de
+      todos modos."""
+
+read_first = """
+, y <code>src/encoder.js</code> para el bucle de
+      codificación, que nunca toca la red."""
+
+howto_heading = "Cómo convertir imágenes en un vídeo"
+
+card = """
+            Convierte una carpeta de imágenes en un pase de diapositivas en MP4.
+            La codificación ocurre en tu propio equipo, con tu propio
+            hardware."""
+
+[words]
+plural = "imágenes"
+choose = "imágenes"
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[facts]]
+text = "Los archivos se quedan en tu dispositivo"
+
+[[privacy]]
+title = "Tus imágenes no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudieran recogerse tus archivos, ni nada en el código que los enviara si lo
+      hubiera. Esto antes decía <code>connect-src 'none'</code>, que era absoluto;
+      poner publicidad costó eso, y decirlo forma parte del trato."""
+
+[[privacy]]
+title = "La codificación es local."
+body = """
+ WebCodecs funciona dentro de tu navegador y el
+      archivo terminado se entrega directamente a una descarga. Esta aplicación no
+      tiene lado servidor."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google. A ninguno se le entrega nada sobre
+      tus imágenes: ni un archivo, ni una miniatura, ni un nombre, un tamaño o un
+      recuento. Cada línea que lee, descodifica, compone o codifica una imagen se
+      sirve desde este origen y está listada en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le da."
+body = """
+
+      El botón «Buy me a coffee» de la cabecera lo dibuja un script de
+      cdnjs.buymeacoffee.com y se compone con Google Fonts. Es un enlace y nada
+      más: no informa de ninguna visita, y no se le entrega nada sobre ti ni
+      sobre tus imágenes. No pasa nada a menos que lo pulses, y lo que hay al
+      otro lado es el sitio de otra gente."""
+
+[[privacy]]
+title = "Una excepción deliberada."
+body = """
+ Si usas «Añadir desde una dirección web»,
+      se contacta con ese servidor para traer la imagen y verá tu dirección IP.
+      Solo se descargan las imágenes que pegues tú, y solo hacia dentro:
+      <code>img-src</code> se abre, <code>connect-src</code> no. El contador de
+      abajo lista todos los orígenes externos contactados."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo salvo la carga
+      desde una dirección web sigue funcionando. Es la prueba más sencilla de
+      todas."""
+
+[[howto]]
+title = "Elige tus imágenes."
+body = """
+ Suelta una carpeta sobre el selector,
+      o escoge los archivos a mano. Tu navegador los lee directamente del disco;
+      mientras lo haces no se envía nada a ninguna parte."""
+
+[[howto]]
+title = "Ponlas en orden y decide cuánto dura cada una."
+body = """
+ Arrastra
+      para reordenar. La duración se puede dar en fotogramas o en segundos, para
+      todas las imágenes a la vez o de una en una."""
+
+[[howto]]
+title = "Elige una resolución y una cadencia."
+body = """
+ «Igualar la
+      resolución más alta» sigue a tu imagen más grande; los preajustes cubren 4K,
+      1080p, 720p, cuadrado y vertical, y hay un tamaño a medida si ninguno
+      encaja."""
+
+[[howto]]
+title = "Crea el vídeo y descárgalo."
+body = """
+ La codificación ocurre en tu
+      propio hardware, así que lo que tarde depende de tu equipo y no de una cola.
+      El MP4 terminado se entrega directamente a las descargas de tu
+      navegador."""
+
+[[faq]]
+q = "¿Se suben mis imágenes a alguna parte?"
+a = """
+        No. Tu propio navegador lee, compone y codifica tus imágenes en tu propio
+        hardware. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar &mdash; ninguna es de este sitio. La única
+        excepción es la función opcional de «añadir desde una dirección web», que
+        descarga una imagen que pegues tú, y ese servidor ve tu dirección IP."""
+
+[[faq]]
+q = "¿Qué formatos de imagen puedo usar?"
+a = """
+        Cualquier formato de imagen fija que tu navegador sepa descodificar, que
+        en la práctica significa JPG, PNG, WebP, GIF, AVIF y, en dispositivos
+        Apple, HEIC. Aquí no hay otra lista que mantener al día, porque
+        descodificar es trabajo del navegador y no nuestro."""
+
+[[faq]]
+q = "¿Qué formato de vídeo produce?"
+a = """
+        MP4 con vídeo H.264, que se reproduce prácticamente en cualquier cosa. En
+        un navegador sin WebCodecs la herramienta recurre a grabar WebM &mdash; el
+        mismo material en un contenedor que aceptan menos editores."""
+
+[[faq]]
+q = "¿Puedo usar esto para una secuencia de render de Blender o After Effects?"
+a = """
+        Sí &mdash; una secuencia de render numerada es exactamente para lo que
+        está esto. Añade los fotogramas que escribió tu motor de render, deja la
+        duración en un fotograma cada uno y pon la cadencia igual que la del
+        render. «Ordenar por nombre» cuenta como esperarías, así que
+        <code>frame_2</code> cae antes de <code>frame_10</code> y no después.
+        <br><br>
+        Algo que conviene saber antes de empezar: H.264 no tiene canal alfa, así
+        que la transparencia se aplana sobre el color de fondo en vez de
+        conservarse. Si necesitas mantener el alfa, compón los fotogramas en tu
+        editor."""
+
+[[faq]]
+q = "¿Puedo hacer un timelapse con fotos?"
+a = """
+        Sí, y es el mismo trabajo que una secuencia de render: deja cada foto un
+        solo fotograma y elige una cadencia. A 30 fps, cada treinta fotos son un
+        segundo de vídeo; a 12 fps, esas mismas fotos duran dos segundos y
+        medio.
+        <br><br>
+        «Ordenar por fecha» devuelve un carrete al orden en que se disparó, lo
+        cual importa cuando los nombres de archivo han vuelto a empezar en 0001.
+        Que las fotos tengan tamaños distintos no es problema &mdash; «Igualar la
+        resolución más alta» dimensiona el vídeo de modo que ninguna se reduzca."""
+
+[[faq]]
+q = "¿Hay algún límite de cuántas imágenes o de cuánto puede durar el vídeo?"
+a = """
+        La herramienta no lleva ningún límite dentro. El techo práctico es la
+        memoria de tu propio equipo, porque el vídeo terminado se monta ahí antes
+        de que lo descargues. Los pases de diapositivas en 4K muy grandes son lo
+        primero que lo nota."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba. El sitio lleva
+        publicidad, que es lo que lo paga; a los anuncios no se les da nada sobre
+        tus imágenes."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tus imágenes fuera a procesar se
+        detendría en el momento en que desenchufaras."""
+
+[[faq]]
+q = "¿Puedo añadir música o una banda sonora?"
+a = """
+        Todavía no. La herramienta produce solo vídeo: el MP4 que escribe tiene
+        una única pista de vídeo y ninguna de audio. Añade la banda sonora
+        después, en un editor de vídeo, si te hace falta."""
+
+[schema]
+browser_requirements = "Necesita JavaScript. La salida en MP4 requiere un navegador con WebCodecs; los demás recurren a WebM."
+description = "Convierte una carpeta de imágenes en un vídeo MP4 de pase de diapositivas. Cada paso ocurre en tu navegador, así que no se sube ninguna imagen."
+features = [
+  "Convierte imágenes JPG, PNG, WebP, GIF y AVIF en vídeo",
+  "Salida en MP4 (H.264), con WebM como alternativa",
+  "Resoluciones de hasta 3840x2160 y cadencias de 12 a 60 fps",
+  "Duración por imagen en fotogramas o en segundos",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí las imágenes"
+hint = "o haz clic para buscarlas &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+[picker.urls]
+summary = "Añadir desde una dirección web"
+button = "Descargar imágenes"
+# Singular, and the gender the sentences in [ui.picker] were written around:
+# "imagen" is feminine, and so is "La {{ noun }} se copia a la memoria local".
+noun = "imagen"

--- a/locales/es/tools/qr-barcode.html
+++ b/locales/es/tools/qr-barcode.html
@@ -1,0 +1,185 @@
+<main>
+  <!-- Paso 1 &mdash; qué tipo de código -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige el tipo de código</h2>
+
+    <p class="card-lede">
+      Un código QR lleva cualquier cosa y es lo que busca la cámara de un móvil.
+      Un código de barras lleva un número, y cuál necesitas suele decidirlo otro
+      &mdash; la tienda, el almacén o la empresa de transporte que te lo pide.
+    </p>
+
+    <div class="option-row">
+      <label for="symbology">Tipo de código</label>
+      <select id="symbology">
+        <optgroup label="Cuadrado">
+          <option value="qr" selected>Código QR</option>
+        </optgroup>
+        <optgroup label="De barras">
+          <option value="code128">Code 128</option>
+          <option value="ean13">EAN-13</option>
+          <option value="upca">UPC-A</option>
+          <option value="ean8">EAN-8</option>
+          <option value="itf14">ITF-14</option>
+          <option value="itf">2 de 5 intercalado</option>
+          <option value="code39">Code 39</option>
+        </optgroup>
+      </select>
+    </div>
+
+    <p class="field-summary" id="symbology-note"></p>
+  </section>
+
+  <!-- Paso 2 &mdash; la propia cadena -->
+  <section class="card">
+    <h2><span class="step">2</span> Di qué va dentro</h2>
+
+    <div class="option-row" id="format-row">
+      <label for="format">Qué lleva</label>
+      <select id="format"></select>
+    </div>
+
+    <p class="card-lede" id="format-note"></p>
+
+    <div id="fields" class="fields"></div>
+
+    <p id="input-error" class="error" role="alert" hidden></p>
+
+    <!--
+      The finished string, shown rather than hidden. A "Wi-Fi QR code" is an
+      ordinary QR code holding a line of text in a format phones recognise, and
+      when a phone does not act on one, this line is the thing to look at.
+    -->
+    <details class="encoded" id="encoded-panel">
+      <summary>La cadena exacta que va a llevar este código</summary>
+      <pre id="encoded"></pre>
+      <p class="field-summary" id="encoded-note"></p>
+    </details>
+  </section>
+
+  <!-- Paso 3 &mdash; cómo se dibuja -->
+  <section class="card">
+    <h2><span class="step">3</span> Elige cómo se ve</h2>
+
+    <fieldset class="options" id="qr-options">
+      <legend>El código QR</legend>
+
+      <div class="option-row">
+        <label for="level">Cuánto daño puede aguantar</label>
+        <select id="level">
+          <option value="L">L &mdash; alrededor del 7&nbsp;% recuperable, el código más pequeño</option>
+          <option value="M" selected>M &mdash; alrededor del 15&nbsp;%, la elección habitual</option>
+          <option value="Q">Q &mdash; alrededor del 25&nbsp;%</option>
+          <option value="H">H &mdash; alrededor del 30&nbsp;%, para una impresión que se va a desgastar</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="quiet">Margen, en módulos</label>
+        <input type="number" id="quiet" value="4" min="0" max="16" step="1" inputmode="numeric">
+      </div>
+
+      <p class="field-summary">
+        El margen forma parte del código, no es espacio alrededor. Cuatro módulos
+        es lo que pide la especificación, y un código recortado hasta el borde es
+        un código que muchos escáneres no verán en absoluto.
+      </p>
+    </fieldset>
+
+    <fieldset class="options" id="barcode-options" hidden>
+      <legend>El código de barras</legend>
+
+      <div class="option-row">
+        <label for="bar-width">Barra más estrecha, en píxeles</label>
+        <input type="number" id="bar-width" value="2" min="1" max="10" step="1" inputmode="numeric">
+      </div>
+
+      <div class="option-row">
+        <label for="bar-height">Altura de las barras, en píxeles</label>
+        <input type="number" id="bar-height" value="120" min="20" max="600" step="10" inputmode="numeric">
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="show-text" checked>
+        <span>
+          <strong>Imprimir los caracteres debajo</strong>
+          <span class="check-note">
+            Lo que lee una persona cuando el escáner no quiere. En un código de
+            comercio los dígitos van también en los márgenes, y es a propósito:
+            marcan el espacio en blanco que nadie debería recortar.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="code39-check-row" hidden>
+        <input type="checkbox" id="code39-check">
+        <span>
+          <strong>Añadir un carácter de control</strong>
+          <span class="check-note">
+            Code 39 no suele llevar ninguno. Algunos sistemas insisten en él;
+            añádelo solo si el tuyo lo hace, porque un lector que no lo espere lo
+            leerá como un carácter de más al final.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Color y tamaño</legend>
+
+      <div class="colour-row">
+        <div class="option-row">
+          <label for="foreground">El código</label>
+          <input type="color" id="foreground" value="#000000">
+        </div>
+        <div class="option-row">
+          <label for="background">Lo de detrás</label>
+          <input type="color" id="background" value="#ffffff">
+        </div>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="transparent">
+        <span>
+          <strong>Sin ningún fondo</strong>
+          <span class="check-note">
+            Transparente, para ponerlo sobre algo que ya tiene color. El SVG y el
+            PNG lo conservan los dos; lo que acabe detrás tiene que ser pálido, o
+            un escáner no encontrará ningún contraste.
+          </span>
+        </span>
+      </label>
+
+      <div class="option-row" id="size-row">
+        <label for="size">Tamaño de la imagen, en píxeles</label>
+        <input type="number" id="size" value="512" min="64" max="4096" step="16" inputmode="numeric">
+      </div>
+
+      <p class="field-summary" id="size-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Paso 4 &mdash; el resultado -->
+  <section class="card" id="result-card">
+    <h2><span class="step">4</span> Llévatelo</h2>
+
+    <div class="preview" id="preview" role="img" aria-label="El código que has hecho"></div>
+
+    <p class="facts" id="facts"></p>
+
+    <div class="run-row">
+      <button type="button" id="download-svg" class="primary">Descargar el SVG</button>
+      <button type="button" id="download-png" class="primary">Descargar el PNG</button>
+      <button type="button" id="copy-png" class="ghost">Copiar la imagen</button>
+    </div>
+
+    <p class="field-summary" id="download-note" role="status"></p>
+
+    <p class="field-summary">
+      El SVG es el que hay que guardar. Es el código como instrucciones y no como
+      píxeles, así que se imprime a cualquier tamaño sin quedarse blando &mdash;
+      cosa que aquí importa más que en casi cualquier otra imagen, porque un borde
+      borroso es justo lo que un escáner no puede resolver.
+    </p>
+  </section>
+</main>

--- a/locales/es/tools/qr-barcode.toml
+++ b/locales/es/tools/qr-barcode.toml
@@ -1,0 +1,341 @@
+#
+# Generador de códigos QR y de barras - Spanish.
+#
+# Overrides for tools/qr-barcode/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Generador de QR y códigos de barras"
+heading = "QR&nbsp;y&nbsp;código&nbsp;de&nbsp;barras <span class=\"h1-kw\">&mdash; crea un código QR o un código de barras, sin conexión</span>"
+tagline = "Escríbelo y se convierte en un código. No se envía nada para hacerlo."
+
+title = "Generador de códigos QR y de barras &mdash; gratis, sin registro y sin subir nada"
+description = "Haz un código QR para un enlace, una red wifi o una tarjeta de contacto, o un código de barras EAN-13, UPC-A, Code 128 o Code 39. Descárgalo en SVG o PNG. Todo ocurre en tu navegador."
+og_title = "Haz un código QR o un código de barras sin enviarle nada a nadie"
+og_description = "Enlaces, contraseñas de wifi, tarjetas de contacto y los códigos de barras del comercio, dibujados en tu propio navegador y descargados en SVG o PNG. Sin cuenta, sin marca de agua y sin ningún píxel de seguimiento en medio de tu código."
+og_image_alt = "Generador de QR y códigos de barras - haz un código QR o de barras sin subir nada"
+
+pledge = """
+    Un código QR es aritmética sobre una cadena de texto: no hay ningún archivo
+    que enviar ni ningún servicio al que preguntar. Cada paso &mdash; elegir el
+    modo, elegir la versión, la corrección de errores de Reed-Solomon, la
+    máscara, las barras de un código de barras y el dígito de control de debajo
+    &mdash; ocurre en unas mil líneas de JavaScript de esta página que puedes
+    leer. Esta herramienta no tiene ninguna función de red, y aquí eso importa
+    más que en casi cualquier otra página: lo que se está codificando es muchas
+    veces la contraseña del wifi."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y escribe una contraseña en el formulario de wifi. Ni una
+      sola petición lleva un carácter de ella. O desconéctate de internet y haz
+      el código de todos modos."""
+
+read_first = """
+, <code>src/qr-encode.js</code>
+      y <code>src/qr.js</code> para el propio código QR &mdash; los modos, la
+      versión y los bloques en uno, y los patrones, la máscara y los bits de
+      formato en el otro &mdash;, <code>src/gf256.js</code> para la corrección de
+      errores, y <code>src/barcode.js</code> para los de rayas."""
+
+howto_heading = "Cómo hacer un código QR sin subir nada"
+
+card = """
+            Un código QR para un enlace, una red wifi o una tarjeta de contacto
+            &mdash; o un código de barras de comercio con su dígito de control
+            calculado. SVG o PNG."""
+
+[words]
+plural = "códigos y el texto que llevan dentro"
+choose = "lo que va dentro"
+analytics_extra = """, ni un solo
+  carácter de lo que escribes"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin caducidad"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Lo que escribes no tiene adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudiera recogerse una contraseña de wifi, ni nada en el código que la
+      enviara si lo hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ No hay ningún
+      <code>fetch</code>, ningún <code>XMLHttpRequest</code> ni ningún
+      <code>sendBeacon</code> en todo <code>src/</code>. El código se construye a
+      partir de la cadena de texto con aritmética y se dibuja como un SVG, en
+      esta página, en tu equipo."""
+
+[[privacy]]
+title = "El código no apunta hacia nosotros."
+body = """
+ Lo que escribes es lo que
+      lleva el código. Varios generadores gratuitos te devuelven un código que
+      contiene un enlace a su propio sitio, que después redirige al tuyo &mdash;
+      así que ellos cuentan cada escaneo, y el código deja de funcionar el día en
+      que dejan de pagar el dominio o deciden que el plan gratuito ha caducado.
+      Aquí nada acorta, redirige ni rastrea: la cadena que se ve en la página es
+      la cadena que hay en la imagen."""
+
+[[privacy]]
+title = "El PNG se hace a partir del SVG que hay en pantalla."
+body = """
+ La
+      descarga no es un segundo dibujado que pudiera discrepar de la vista previa.
+      Se le entrega el mismo marcado al navegador y se pinta sobre un lienzo, que
+      es además la razón de que pueda hacerse sin contactar con nada: no hay
+      ninguna tipografía que descargar ni ninguna imagen que cargar dentro."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google, y el botón de donación de Buy Me a
+      Coffee. A ninguno se le entrega nada de lo que escribes. Cada línea que
+      convierte una cadena en un código se sirve desde este origen y está listada
+      en el repositorio."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta
+      sigue igual, porque nunca hubo un paso de red dentro de ella. Es la prueba
+      más sencilla de todas."""
+
+[[howto]]
+title = "Elige el tipo de código."
+body = """
+ Un código QR lleva cualquier cosa
+      y es lo que busca la cámara de un móvil, así que es la respuesta salvo que
+      alguien te haya dicho otra cosa. Un código de barras lleva un número, y cuál
+      necesitas lo decide quien vaya a escanearlo &mdash; una tienda quiere un
+      EAN-13 o un UPC-A, una caja de envío un ITF-14, y cualquier cosa interna
+      suele ser Code 128."""
+
+[[howto]]
+title = "Di qué va dentro."
+body = """
+ Un enlace es el caso habitual, y las
+      casillas de encima construyen los otros formatos que los móviles conocen:
+      una red wifi que se ofrece a conectarse sola, una tarjeta de contacto que se
+      ofrece a guardarse, un correo, un mensaje de texto, un número de teléfono,
+      un punto en un mapa. Elijas el que elijas, la cadena terminada se muestra en
+      la página &mdash; eso es todo lo que lleva un código QR."""
+
+[[howto]]
+title = "Elige cuánto daño puede aguantar."
+body = """
+ Los cuatro niveles meten más o
+      menos corrección de errores, y más corrección significa un código más grande
+      y más denso. L basta para una pantalla, M para papel corriente, y H para
+      algo que se va a manosear, a imprimir pequeño o a pegar en un escaparate al
+      sol. Un código en una carta que se limpia todos los días merece Q o H."""
+
+[[howto]]
+title = "Ajusta el tamaño, el margen y los colores."
+body = """
+ El margen forma parte del código:
+      cuatro módulos de espacio en calma alrededor es lo que pide la
+      especificación, y recortarlo es la razón número uno de que un código impreso
+      no escanee. Oscuro sobre claro, con contraste de verdad &mdash; un escáner
+      lee la diferencia entre los dos, así que un gris pálido sobre blanco no
+      vale, y claro sobre oscuro falla de plano en bastantes lectores."""
+
+[[howto]]
+title = "Compruébalo con el móvil que tengas."
+body = """
+ Antes de imprimir mil, escanea
+      el que tienes en pantalla. Eso son diez segundos y pilla toda la categoría
+      de errores que una vista previa no puede: una contraseña de wifi con un
+      carácter que había que escapar, un enlace al que le faltaba el
+      <code>https://</code>, un número de código de barras al que le falta un
+      dígito."""
+
+[[howto]]
+title = "Llévate el SVG."
+body = """
+ Es el código como instrucciones y no como
+      píxeles, así que se imprime a cualquier tamaño sin quedarse blando, y un
+      borde blando es justo lo que un escáner no puede resolver. Llévate también
+      el PNG si aquello donde vayas a pegarlo no acepta un SVG; está dibujado con
+      un número entero de píxeles por módulo, así que tampoco tiene los bordes
+      borrosos."""
+
+[[faq]]
+q = "¿Se envía a alguna parte lo que escribo?"
+a = """
+        No. Un código QR es aritmética sobre una cadena de texto, y esa aritmética
+        ocurre en tu propio navegador y en tu propio equipo. Esta herramienta no
+        tiene ninguna función de red &mdash; nunca descarga nada y nunca envía
+        nada &mdash; y la <code>Content-Security-Policy</code> de la página nombra
+        todas las direcciones que puede contactar, ninguna de las cuales es de
+        este sitio. Aquí eso vale más que en casi cualquier otra página, porque lo
+        que la gente mete con más frecuencia en un código QR es la contraseña de
+        su wifi."""
+
+[[faq]]
+q = "¿Estos códigos caducan o dejan de funcionar más adelante?"
+a = """
+        No, y no pueden. Lo que escribes es lo que lleva el código, así que
+        escanearlo devuelve exactamente esa cadena para siempre. Los códigos que
+        caducan son los que llevan dentro la dirección de otro: un código QR
+        «dinámico» lleva un enlace al servidor del generador, que redirige al tuyo,
+        lo que significa que ellos pueden contar cada escaneo, cambiar adónde va o
+        apagarlo cuando termine una prueba. Aquí nada redirige a través de
+        nada."""
+
+[[faq]]
+q = "¿Es gratis? ¿Puedo usarlo comercialmente?"
+a = """
+        Es gratis, no hay cuenta, ni marca de agua, ni límite de cuántos hagas, y
+        puedes poner el resultado en un producto, un cartel o un escaparate. QR
+        Code es una marca registrada de Denso Wave, que ha declarado que no la
+        ejercerá contra quien use los códigos &mdash; la especificación está
+        publicada como ISO/IEC 18004 y es libre de implementar, que es lo que hace
+        esta página. El sitio lleva publicidad, que es lo que lo paga."""
+
+[[faq]]
+q = "¿Qué nivel de corrección de errores debería elegir?"
+a = """
+        M salvo que tengas un motivo. L hace el código más pequeño y va bien en
+        pantalla; M sobrevive a un manejo corriente; Q y H son para un código que
+        se va a imprimir pequeño, plastificar, pegar en un escaparate o tapar en
+        parte con un logotipo. Cada escalón mete más datos de comprobación, lo que
+        exige un símbolo más grande para la misma cantidad de texto &mdash; pasar
+        de L a H más o menos duplica el número de módulos para la misma cadena."""
+
+[[faq]]
+q = "¿Cuánto puede llevar un código QR?"
+a = """
+        En el tamaño más grande, 177 módulos de lado, hasta 7089 dígitos, 4296
+        letras mayúsculas y dígitos, o 2953 bytes de cualquier otra cosa &mdash; y
+        eso con la corrección de errores más débil; con la más fuerte es alrededor
+        de un tercio de eso. En la práctica, el límite no es el formato sino el
+        escáner: pasados unos cientos de caracteres, los módulos se quedan tan
+        pequeños que la cámara de un móvil corriente no los resuelve con el brazo
+        estirado. Un código largo suele ser señal de que lo que debería ir dentro
+        es un enlace corto."""
+
+[[faq]]
+q = "¿Por qué mi código es más grande si escribo el enlace en minúsculas?"
+a = """
+        Porque un código QR tiene un modo para mayúsculas y dígitos que empaqueta
+        dos caracteres en once bits, y no tiene ninguno así para las minúsculas,
+        que cuestan ocho bits cada una. Una URL escrita
+        <code>HTTPS://EJEMPLO.COM/PAGINA</code> puede ser un tercio más pequeña
+        que la misma URL en minúsculas. El esquema y el host no distinguen
+        mayúsculas de minúsculas, así que gritarlos no cambia nada salvo el
+        tamaño; la ruta que va después del host sí las distingue, así que a esa no
+        la toques."""
+
+[[faq]]
+q = "¿Puede leer un código QR además de hacerlo?"
+a = """
+        Todavía no. Leer uno significa descodificar una imagen &mdash; encontrar
+        el símbolo dentro de una fotografía, corregir el ángulo desde el que se
+        tomó y reparar el daño &mdash;, que es un trabajo distinto y bastante más
+        grande que dibujar uno. Podría construirse aquí en los mismos términos que
+        todo lo demás, y está en la lista. Mientras tanto, la cámara de tu móvil ya
+        lo hace, y lo hace bien."""
+
+[[faq]]
+q = "¿Para qué es el margen? ¿Puedo hacerlo más pequeño?"
+a = """
+        El espacio en blanco alrededor de un código QR forma parte del código. Un
+        lector lo usa para saber dónde termina el símbolo, y la especificación pide
+        cuatro módulos por cada lado; un código de barras quiere unos diez. Aquí
+        puedes ponerlo a cero y la imagen quedará más limpia, y bastantes escáneres
+        no lo verán entonces en absoluto &mdash; sobre todo contra un fondo
+        recargado. Si el problema es el espacio, haz el código más pequeño en vez
+        de recortarle el margen."""
+
+[[faq]]
+q = "¿Qué código de barras necesito?"
+a = """
+        El que te pida quien vaya a escanearlo. EAN-13 es el código de barras del
+        comercio fuera de Norteamérica y UPC-A es el norteamericano &mdash; los dos
+        necesitan un número que te asigne GS1, porque el número identifica a tu
+        empresa y no solo al producto. EAN-8 es la versión corta para envases
+        pequeños. ITF-14 va en la caja de envío. Code 128 y Code 39 llevan texto
+        además de dígitos y no necesitan ningún registro, lo que los convierte en
+        la respuesta correcta para cualquier cosa interna: activos, estanterías,
+        partes de trabajo."""
+
+[[faq]]
+q = "¿Qué es un dígito de control y por qué lo ha añadido la herramienta?"
+a = """
+        Es el último dígito de un código de barras de comercio, calculado a partir
+        de los anteriores, para que un escáner pueda distinguir una lectura
+        errónea de una buena. EAN-13 quiere doce dígitos y calcula el
+        decimotercero; UPC-A quiere once y calcula el duodécimo. Escribe el número
+        corto y esta página lo añade. Escribe el número completo y comprueba el que
+        le has dado &mdash; y se niega, en vez de corregirlo en silencio, porque un
+        dígito equivocado arreglado sin decir nada es una etiqueta que escanea como
+        el producto de otra persona."""
+
+[[faq]]
+q = "¿Puedo poner un logotipo en el centro de un código QR?"
+a = """
+        Aquí no, pero merece la pena saber por qué funciona en otros sitios: lo que
+        lo hace posible es la corrección de errores. En el nivel H se puede
+        destruir alrededor del 30&nbsp;% de los módulos y el código sigue
+        leyéndose, así que un logotipo que cubra bastante menos que eso en el
+        centro &mdash; donde no hay ningún patrón de localización &mdash; es daño
+        reparable. Pasa el código por tu editor de imágenes en el nivel H, mantén
+        el logotipo por debajo de una quinta parte del área más o menos, y
+        pruébalo con un móvil de verdad en lugar de fiarte."""
+
+[[faq]]
+q = "¿Por qué el SVG es mejor que el PNG?"
+a = """
+        Porque un código son bordes, y un PNG tiene un número fijo de píxeles con
+        los que hacerlos. Amplía uno y todos los bordes se ablandan; un borde
+        blando es exactamente lo que le cuesta a un escáner, y a una impresora de
+        1200 ppp a la que le das un PNG de 512 píxeles se le está pidiendo que
+        invente la diferencia. Un SVG son los cuadrados como instrucciones, así que
+        se imprime nítido tanto en una tarjeta de visita como en una valla. El PNG
+        de aquí está dibujado con un número entero de píxeles por módulo, que es lo
+        mejor que puede hacer un PNG."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tu texto fuera para que le
+        dibujaran un código se detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Genera un código QR o un código de barras lineal a partir de una cadena de texto, en el navegador. Códigos QR para enlaces, redes wifi, tarjetas de contacto, correo, SMS, números de teléfono y coordenadas, con los cuatro niveles de corrección de errores; códigos de barras EAN-13, EAN-8, UPC-A, ITF-14, 2 de 5 intercalado, Code 128 y Code 39 con sus dígitos de control. Descarga en SVG o PNG. No se sube nada."
+features = [
+  "Códigos QR en todas las versiones de la 1 a la 40, en modo numérico, alfanumérico y de bytes",
+  "Los cuatro niveles de corrección de errores, diciendo en voz alta lo que cuesta cada uno",
+  "Formatos ya montados: red wifi, tarjeta de contacto, correo, mensaje de texto, número de teléfono, punto en un mapa",
+  "Enseña la cadena exacta que va a llevar el código, en vez de esconderla",
+  "EAN-13, EAN-8 y UPC-A, con el dígito de control calculado o verificado",
+  "ITF-14 y 2 de 5 intercalado para cajas y almacén",
+  "Code 128 con uso automático de su modo numérico, y Code 39 con un carácter de control opcional",
+  "Los dígitos legibles impresos debajo del código de barras, en los sitios correctos",
+  "Salida en SVG, para que se imprima nítido a cualquier tamaño, y un PNG dibujado con píxeles enteros por módulo",
+  "Dos colores cualesquiera, o ningún fondo",
+  "Nunca redirige: sin enlace corto, sin seguimiento y sin nada que pueda caducar",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]

--- a/locales/es/tools/resize-image.html
+++ b/locales/es/tools/resize-image.html
@@ -1,0 +1,281 @@
+<main>
+  <!-- Paso 1 &mdash; los archivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige las imágenes</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo de la lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; el recorte -->
+  <section class="card" id="crop-card">
+    <h2><span class="step">2</span> Recorta, si te apetece</h2>
+
+    <p class="card-lede">
+      La caja empieza sobre la foto entera, así que dejar este paso en paz no
+      recorta nada. Cada imagen conserva su propia caja &mdash; elige una de la
+      lista de arriba para dibujar sobre ella. El recorte ocurre antes del
+      redimensionado, que es el único orden con sentido: una foto cortada después
+      de encogerla ya ha tirado los píxeles que le hacían falta.
+    </p>
+
+    <p id="crop-empty" class="field-summary">Añade una imagen y la caja aparece aquí.</p>
+
+    <div id="crop-controls" hidden>
+      <p class="stage-hint">
+        <span id="stage-name" class="stage-name"></span>
+        Arrastra dentro de la caja para moverla, o desde cualquier esquina para
+        cambiarle el tamaño. Con la caja enfocada, las flechas la desplazan un
+        píxel cada vez, <kbd>Alt</kbd>&nbsp;+&nbsp;flechas la redimensionan, y
+        mantener <kbd>Mayús</kbd> hace que cada paso sean diez.
+      </p>
+
+      <!-- The crop box itself is added here by src/cropper.js. The stage is
+           given the picture's own shape, so the box can be positioned in
+           percentages and needs no recalculating when the window is resized. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <p id="stage-note" class="stage-note" hidden></p>
+
+      <div class="crop-controls">
+        <div class="aspect-row" id="aspect-row" role="group" aria-label="Fijar el recorte a una forma">
+          <button type="button" data-aspect="free" class="active">Libre</button>
+          <button type="button" data-aspect="source">Original</button>
+          <button type="button" data-aspect="1:1">1:1</button>
+          <button type="button" data-aspect="4:5">4:5</button>
+          <button type="button" data-aspect="9:16">9:16</button>
+          <button type="button" data-aspect="16:9">16:9</button>
+          <button type="button" data-aspect="4:3">4:3</button>
+          <button type="button" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="ghost" title="Poner de lado la forma fijada">
+            Girar
+          </button>
+        </div>
+
+        <div class="numbers">
+          <label>Izquierda<input type="number" id="crop-x" min="0" step="1"></label>
+          <label>Arriba<input type="number" id="crop-y" min="0" step="1"></label>
+          <label>Ancho<input type="number" id="crop-w" min="8" step="1"></label>
+          <label>Alto<input type="number" id="crop-h" min="8" step="1"></label>
+          <div class="number-actions">
+            <button type="button" id="crop-max" class="ghost">Lo más grande</button>
+            <button type="button" id="crop-centre" class="ghost">Centrar</button>
+            <button type="button" id="crop-reset" class="ghost">Foto entera</button>
+          </div>
+        </div>
+
+        <!--
+          Every image keeps its own box, which is the point. This is for the
+          case that is still worth one click: a folder of exports that all want
+          the same framing.
+        -->
+        <div class="apply-row" id="apply-row" hidden>
+          <button type="button" id="crop-apply-all" class="ghost">Usar este recorte en todas las imágenes</button>
+          <p class="hint-line" id="apply-note"></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Paso 3 &mdash; el tamaño -->
+  <section class="card" id="resize-card">
+    <h2><span class="step">3</span> Di de qué tamaño tiene que ser</h2>
+
+    <div class="option-row">
+      <label for="resize-mode">Fijar el tamaño por</label>
+      <select id="resize-mode">
+        <option value="pixels" selected>Ancho y alto, en píxeles</option>
+        <option value="longest">El lado más largo</option>
+        <option value="percent">Un porcentaje de lo que mide ahora</option>
+        <option value="none">Nada &mdash; dejar el tamaño exactamente como está</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="pixels-fields">
+      <div class="numbers">
+        <label>Ancho<input type="number" id="size-w" min="1" step="1" placeholder="auto" value="1920"></label>
+        <label>Alto<input type="number" id="size-h" min="1" step="1" placeholder="auto"></label>
+        <div class="number-actions">
+          <button type="button" id="swap-size" class="ghost">Girar</button>
+        </div>
+      </div>
+
+      <!--
+        Leaving one of them blank is the common case and the one worth
+        supporting properly: "1920 wide, whatever tall that makes it" needs no
+        decision about shapes at all.
+      -->
+      <p class="hint-line">
+        Rellena uno y deja el otro en blanco para conservar la forma de la foto.
+      </p>
+
+      <div class="presets" id="size-presets" role="group" aria-label="Tamaños habituales">
+        <button type="button" class="ghost" data-w="1920" data-h="1080">1920 &times; 1080</button>
+        <button type="button" class="ghost" data-w="1280" data-h="720">1280 &times; 720</button>
+        <button type="button" class="ghost" data-w="1080" data-h="1080">1080 &times; 1080</button>
+        <button type="button" class="ghost" data-w="600" data-h="">600 de ancho</button>
+      </div>
+
+      <div class="option-row" id="fit-row">
+        <label for="fit">Si las formas no coinciden</label>
+        <select id="fit">
+          <option value="contain" selected>Encajar dentro &mdash; la foto entera, con un lado más corto</option>
+          <option value="cover">Llenarla &mdash; exactamente este tamaño, cortando lo que sobre</option>
+          <option value="pad">Rellenarla &mdash; exactamente este tamaño, con un fondo alrededor</option>
+          <option value="stretch">Estirarla &mdash; exactamente este tamaño, y la forma deformada</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Lado más largo<input type="number" id="size-longest" min="1" step="1" value="1920"></label>
+      </div>
+      <p class="hint-line">
+        El lado que sea más largo pasa a medir esto, y el otro lo sigue. Las
+        fotos verticales y las horizontales de un mismo lote salen todas del
+        mismo tamaño en su lado largo, que es lo que suele querer una galería.
+      </p>
+      <div class="presets" id="longest-presets" role="group" aria-label="Lados largos habituales">
+        <button type="button" class="ghost" data-longest="640">640</button>
+        <button type="button" class="ghost" data-longest="1280">1280</button>
+        <button type="button" class="ghost" data-longest="1920">1920</button>
+        <button type="button" class="ghost" data-longest="2560">2560</button>
+      </div>
+    </div>
+
+    <div class="size-fields" id="percent-fields" hidden>
+      <div class="numbers">
+        <label>Porcentaje<input type="number" id="size-percent" min="1" max="1000" step="1" value="50"></label>
+      </div>
+      <div class="presets" id="percent-presets" role="group" aria-label="Porcentajes habituales">
+        <button type="button" class="ghost" data-percent="25">25&nbsp;%</button>
+        <button type="button" class="ghost" data-percent="50">50&nbsp;%</button>
+        <button type="button" class="ghost" data-percent="75">75&nbsp;%</button>
+        <button type="button" class="ghost" data-percent="200">200&nbsp;%</button>
+      </div>
+    </div>
+
+    <label class="check" id="enlarge-row">
+      <input type="checkbox" id="no-enlarge" checked>
+      <span>
+        <strong>No agrandar nunca una foto más de lo que empezó</strong>
+        <span class="check-note">
+          Agrandar inventa píxeles que nunca se fotografiaron, así que una foto
+          pequeña a la que se le pide un marco grande sale blanda en lugar de
+          detallada. Con esto activado, lo que ya sea más pequeño que el tamaño
+          que has pedido se queda a su propio tamaño.
+        </span>
+      </span>
+    </label>
+
+    <p id="size-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Paso 4 &mdash; el formato, y el único clic -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Guárdalo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="keep" selected>Conservar el formato con que llegó cada archivo</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/png">PNG</option>
+          <option value="image/webp">WebP</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Calidad &mdash; <output id="quality-value" for="quality">85</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="85">
+        <p class="field-note">
+          Solo para JPEG y WebP; PNG no tiene mando de calidad. En 85 es donde
+          casi todo el mundo deja de notar la diferencia. Por debajo de 60 más o
+          menos, las zonas planas empiezan a hacer bandas.
+        </p>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Fondo</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Lo que se ve donde no llega la foto: detrás de un marco rellenado, y
+          detrás de la transparencia cuando el formato de salida no tiene canal
+          alfa.
+        </p>
+      </div>
+    </div>
+
+    <p id="plan-summary" class="field-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Redimensionar las imágenes</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Terminadas</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Descargar todo en un zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The big look at one result. A <dialog> opened with showModal() rather than
+    a div pretending to be one: the browser gives the focus trap, the Escape
+    key and the inert background for nothing, and gets all three right.
+
+    Both pictures in it are object URLs made on this page - the result, and the
+    original that was already decoded for the thumbnail. Opening this fetches
+    nothing and decodes nothing that was not already decoded.
+  -->
+  <dialog id="viewer" class="viewer" aria-labelledby="viewer-name">
+    <div class="viewer-head">
+      <h2 id="viewer-name" class="viewer-name"></h2>
+      <button type="button" id="viewer-close" class="ghost" aria-label="Cerrar">Cerrar</button>
+    </div>
+
+    <div class="viewer-stage">
+      <img id="viewer-image" alt="">
+    </div>
+
+    <p id="viewer-caption" class="viewer-caption"></p>
+
+    <dl class="viewer-facts" id="viewer-facts"></dl>
+
+    <div class="viewer-actions">
+      <button type="button" id="viewer-compare" class="ghost" aria-pressed="false">Ver el original</button>
+      <a id="viewer-download" class="primary as-button" download>Descargar</a>
+    </div>
+  </dialog>
+</main>

--- a/locales/es/tools/resize-image.toml
+++ b/locales/es/tools/resize-image.toml
@@ -1,0 +1,278 @@
+#
+# Redimensionador de imágenes - Spanish.
+#
+# Overrides for tools/resize-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Redimensionador de imágenes"
+heading = "Redimensionar&nbsp;imagen <span class=\"h1-kw\">&mdash; redimensionar, recortar y convertir</span>"
+tagline = "Di el tamaño. Dibuja la caja. Elige el formato."
+
+title = "Redimensionar una imagen &mdash; también recortar y convertir, sin subir nada"
+description = "Redimensiona, recorta y convierte imágenes JPEG, PNG y WebP en tu navegador. Píxeles exactos, un porcentaje o un lado largo: una imagen o una carpeta entera. No se sube nada."
+og_title = "Redimensiona, recorta y convierte una imagen sin subirla"
+og_description = "Pon el tamaño en píxeles o en porcentaje, arrastra una caja de recorte, cambia el formato: para una foto o para un lote entero. Todo ocurre en tu propio equipo."
+og_image_alt = "Redimensionador de imágenes - redimensiona, recorta y convierte sin subir nada"
+
+pledge = """
+    El redimensionado, el recorte y el cambio de formato ocurren todos en tu
+    propio navegador, en tu propio hardware, con los codificadores de imagen que
+    ya trae de serie. Esta herramienta no tiene ninguna función de red &mdash;
+    nada que descargar, nada que enviar &mdash; y al otro lado de esta página no
+    hay ningún servidor al que mandar una foto aunque lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y redimensiona una foto. Ni una sola petición lleva una
+      imagen, una miniatura, un nombre de archivo ni un byte de lo que has
+      elegido. O desconéctate de internet y redimensiona una de todos modos."""
+
+read_first = """
+, <code>src/geometry.js</code> para la aritmética
+      que decide qué se conserva y de qué tamaño sale, y
+      <code>src/codecs.js</code> para la única llamada a <code>drawImage</code>
+      que hace el recorte y el redimensionado a la vez."""
+
+howto_heading = "Cómo redimensionar una imagen sin subirla"
+
+card = """
+            Píxeles exactos, un porcentaje o un lado largo &mdash; con caja de
+            recorte y cambio de formato por el camino. Una foto o una
+            carpeta."""
+
+[words]
+plural = "imágenes"
+choose = "una imagen"
+analytics_extra = """, ni ninguno de los
+  tamaños, recortes o formatos que esta herramienta calcula"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Tus imágenes no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudieran recogerse tus archivos, ni nada en el código que los enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ No hay ningún
+      <code>fetch</code>, ningún <code>XMLHttpRequest</code> ni ningún
+      <code>sendBeacon</code> en todo <code>src/</code>. El redimensionado es un
+      <code>drawImage</code> sobre un lienzo y un <code>canvas.toBlob</code>
+      &mdash; el escalador y el codificador que ya están instalados en tu
+      navegador."""
+
+[[privacy]]
+title = "Un archivo que nadie ha pedido cambiar no se cambia."
+body = """
+ Sin recorte, sin
+      redimensionado y sin cambio de formato, el archivo que elegiste se te
+      devuelve byte por byte en vez de volver a guardarse. Y no es solo cortesía:
+      es la razón de que esta herramienta no pueda recodificar una foto en
+      silencio, ni tirar en silencio los metadatos de una que solo querías
+      mirar."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google, y el botón de donación de Buy Me a
+      Coffee. A ninguno se le entrega nada sobre tus fotos. Cada línea que lee,
+      recorta, escala o escribe un archivo se sirve desde este origen y está
+      listada en el repositorio."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta
+      sigue igual, porque nunca hubo un paso de red dentro de ella. Es la prueba
+      más sencilla de todas."""
+
+[[howto]]
+title = "Elige tus imágenes."
+body = """
+ Suéltalas sobre el selector o escógelas
+      a mano. Tu navegador las lee directamente del disco; mientras lo haces no se
+      envía nada a ninguna parte."""
+
+[[howto]]
+title = "Recorta, si te apetece."
+body = """
+ La caja empieza sobre la foto entera,
+      así que dejarla en paz no recorta nada. Arrástrala, o fíjala a una forma
+      &mdash; 1:1 para una foto de perfil, 9:16 para una historia, 16:9 para una
+      miniatura &mdash; y pulsa «Lo más grande» para la mayor que quepa. Cada
+      imagen conserva su propia caja: haz clic en cualquier fila de la lista para
+      dibujar sobre esa. Si todas deben quedar encuadradas igual, hay también un
+      botón para eso."""
+
+[[howto]]
+title = "Di de qué tamaño tiene que salir."
+body = """
+ Un ancho, un alto o
+      los dos; un lado largo, que deja las fotos verticales y las horizontales del
+      mismo tamaño entre sí; o un porcentaje pelado. Deja una de las dos casillas
+      en blanco y la foto conserva su propia forma."""
+
+[[howto]]
+title = "Elige el formato y pulsa el botón."
+body = """
+ Conserva el formato con
+      que llegó cada archivo, o escríbelo todo como JPEG, PNG o WebP. Cada
+      resultado dice en qué se ha convertido y cuánto ha encogido; haz clic en uno
+      para abrirlo a tamaño completo con todas sus cifras detrás, y el original al
+      lado para comparar. Un lote baja como un solo zip."""
+
+[[faq]]
+q = "¿Se sube mi imagen a alguna parte?"
+a = """
+        No. Tu propio navegador descodifica, recorta, escala y escribe el archivo
+        en tu propio hardware, con los codificadores JPEG, PNG y WebP que ya trae
+        de serie. Esta herramienta no tiene ninguna función de red &mdash; nunca
+        descarga nada y nunca envía nada &mdash; y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es de este
+        sitio."""
+
+[[faq]]
+q = "¿Qué pasa si le doy un ancho pero no un alto?"
+a = """
+        El alto sale de la propia forma de la foto, que es casi siempre lo que se
+        quería: «1920 de ancho» significa «1920 de ancho y el alto que eso dé».
+        Rellena los dos y ambos pueden discrepar de la forma de la foto, que es la
+        única vez que aparece la opción «si las formas no coinciden» &mdash;
+        encajar dentro de la caja, llenarla y cortar lo que sobre, rellenar con un
+        fondo, o estirar y aceptar la deformación."""
+
+[[faq]]
+q = "¿Redimensionar una imagen hace perder calidad?"
+a = """
+        Hacer una foto más pequeña no, de ninguna forma que puedas ver: entran más
+        píxeles de los que salen, así que el detalle que se conserva es detalle de
+        verdad. Hacer una más grande no puede añadir lo que nunca se fotografió
+        &mdash; el resultado es una copia más blanda de la misma foto, no una más
+        nítida &mdash;, y por eso «no agrandar nunca una foto más de lo que
+        empezó» viene activado. Lo que sí cuesta un poco es la recodificación
+        posterior, si el formato es JPEG o WebP, y el control de calidad es lo que
+        gastas ahí."""
+
+[[faq]]
+q = "¿Puedo recortar cada imagen de forma distinta?"
+a = """
+        Sí &mdash; es lo que hace por defecto. Cada imagen de la lista lleva su
+        propia caja, en sus propios píxeles, y hacer clic en una fila pone esa
+        imagen en la vista previa con su caja y su forma fijada de vuelta. Nada de
+        lo que le hagas a una afecta a otra. Todas las cajas empiezan además sobre
+        la foto entera, así que una imagen sobre la que nunca dibujes no se recorta
+        en absoluto."""
+
+[[faq]]
+q = "¿Puede recortar un lote entero igual de una vez?"
+a = """
+        Sí, con el botón que hay debajo de la vista previa. Le da a cada una de las
+        demás imágenes la misma zona relativa &mdash; las mismas fracciones de su
+        propio ancho y alto &mdash;, lo que para un conjunto de capturas o
+        exportaciones del mismo tamaño es exactamente la misma caja, y la página lo
+        dice. Con una forma fijada, le da a cada una la mayor caja de esa forma
+        dentro de esa zona, así que pulsar 1:1 y luego ese botón te saca cuadrados
+        de una carpeta con fotos verticales y horizontales mezcladas. Después,
+        todas las cajas siguen siendo editables."""
+
+[[faq]]
+q = "¿Qué formatos puede leer y escribir?"
+a = """
+        Lee todo lo que tu navegador sepa descodificar, que en la práctica
+        significa JPEG, PNG, WebP, GIF, BMP y &mdash; en casi todos los
+        navegadores actuales &mdash; AVIF. Escribe JPEG, PNG y WebP, porque esos
+        son los codificadores que traen los navegadores. Con «conservar el
+        formato», un JPEG sigue siendo un JPEG y un PNG sigue siendo un PNG; lo
+        que el navegador no sabe escribir, como un GIF o un BMP, sale como PNG,
+        que es el que conserva intactos la transparencia y el color plano."""
+
+[[faq]]
+q = "¿Qué pasa con la transparencia si guardo como JPEG?"
+a = """
+        Se rellena con el color de fondo, porque JPEG no tiene canal alfa donde
+        guardarla. El color lo eliges tú y empieza en blanco, que es lo que quiere
+        casi todo el mundo y lo que hace casi cualquier otra herramienta sin
+        decírtelo. El mismo color se usa detrás de un marco rellenado. Guarda como
+        PNG o WebP y la transparencia pasa intacta."""
+
+[[faq]]
+q = "¿Quita los datos EXIF y GPS?"
+a = """
+        De todo lo que procesa de verdad, sí, como efecto secundario: recortar o
+        redimensionar significa descodificar la foto a píxeles y volver a
+        codificar esos píxeles, y un lienzo lleno de píxeles no lleva etiquetas,
+        así que la ubicación, el modelo de cámara y las marcas de tiempo
+        sencillamente no se escriben en el archivo nuevo. Un archivo que no estás
+        cambiando en nada es otro caso &mdash; se devuelve byte por byte, con
+        etiquetas y todo. Si lo que quieres es quitar los metadatos sin tocar la
+        foto, usa el <a href="../eliminar-datos-exif/">visor y eliminador de
+        EXIF</a>, que reescribe el contenedor sin volver a comprimir nada."""
+
+[[faq]]
+q = "¿En qué se diferencia esto del compresor de imágenes?"
+a = """
+        Esta va de dimensiones: dices cuántos píxeles quieres y te los da. El
+        <a href="../comprimir-imagen/">compresor de imágenes</a> va de tamaño de
+        archivo: dices cuántos kilobytes tienes permitidos y busca la calidad más
+        alta que cabe, redimensionando solo si la calidad por sí sola no llega. Si
+        te dijeron «1200 píxeles de ancho», estás en el sitio correcto. Si te
+        dijeron «por debajo de 500 KB», la otra te dejará más cerca."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. Tampoco hay límite en el número ni en el tamaño de los archivos,
+        porque no hay ningún servidor pagándolos &mdash; el trabajo ocurre en tu
+        propio equipo. El sitio lleva publicidad, que es lo que lo paga; a los
+        anuncios no se les da nada sobre tus imágenes."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tus imágenes fuera para
+        redimensionarlas se detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Redimensiona, recorta y convierte imágenes JPEG, PNG y WebP en el navegador. Fija un tamaño exacto en píxeles, un porcentaje o un lado largo, arrastra una caja de recorte o fíjala a una forma, y escribe el resultado como JPEG, PNG o WebP. Admite lotes, y no sube nada."
+features = [
+  "Redimensiona por píxeles exactos, por un lado largo o por un porcentaje",
+  "Rellena un lado y el otro sigue la propia forma de la foto",
+  "Encaja dentro, llena y recorta, rellena hasta un marco exacto, o estira",
+  "Una caja de recorte arrastrable por imagen, fijable a 1:1, 4:5, 9:16, 16:9, 4:3 o 3:2",
+  "Recorta cada imagen de forma distinta, o aplica un mismo encuadre a todo el lote de un clic",
+  "Abre cada foto terminada a tamaño completo, con todas sus cifras detrás y el original para comparar",
+  "Convierte entre JPEG, PNG y WebP, con control de calidad y color de fondo",
+  "Nunca agranda una foto salvo que se lo pidas",
+  "Devuelve intacto cualquier archivo que no se le haya pedido cambiar",
+  "Por lotes, con todos los resultados en un zip",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí las imágenes"
+hint = "o haz clic para buscarlas &mdash; JPEG, PNG, WebP y cualquier otra cosa que tu navegador sepa abrir"

--- a/locales/es/tools/svg-to-image.html
+++ b/locales/es/tools/svg-to-image.html
@@ -1,0 +1,210 @@
+<main>
+  <!-- Paso 1 &mdash; los archivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige los archivos SVG</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Quitar todo de la lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; el tamaño -->
+  <section class="card" id="size-card">
+    <h2><span class="step">2</span> Di de qué tamaño tiene que ser</h2>
+
+    <p class="card-lede">
+      Esta es la única pregunta que un vector no puede responderte. Un SVG no
+      tiene píxeles dentro &mdash; tiene instrucciones para dibujar, y las
+      seguirá al tamaño que le digas. El número de abajo no es un límite contra el
+      que empujas, como lo sería con una fotografía; 4000 píxeles a partir de un
+      icono de 24&nbsp;píxeles son exactamente igual de nítidos que los 24.
+    </p>
+
+    <div class="option-row">
+      <label for="size-mode">Fijar el tamaño por</label>
+      <select id="size-mode">
+        <option value="scale" selected>Un múltiplo del tamaño que pide el archivo</option>
+        <option value="width">Ancho en píxeles</option>
+        <option value="height">Alto en píxeles</option>
+        <option value="longest">El lado más largo</option>
+        <option value="box">Una caja, con los dos lados dados</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="scale-fields">
+      <div class="numbers">
+        <label>Multiplicar por<input type="number" id="size-scale" min="0.01" max="200" step="0.5" value="4"></label>
+      </div>
+      <div class="presets" id="scale-presets" role="group" aria-label="Múltiplos habituales">
+        <button type="button" class="ghost" data-scale="1">1&times;</button>
+        <button type="button" class="ghost" data-scale="2">2&times;</button>
+        <button type="button" class="ghost" data-scale="4">4&times;</button>
+        <button type="button" class="ghost" data-scale="8">8&times;</button>
+        <button type="button" class="ghost" data-scale="16">16&times;</button>
+      </div>
+      <p class="hint-line">
+        Cada archivo de la lista se multiplica desde su propio tamaño, así que un
+        lote de iconos dibujados a tamaños distintos mantiene la proporción entre
+        ellos.
+      </p>
+    </div>
+
+    <div class="size-fields" id="width-fields" hidden>
+      <div class="numbers">
+        <label>Ancho<input type="number" id="size-width" min="1" step="1" value="1024"></label>
+      </div>
+      <div class="presets" id="width-presets" role="group" aria-label="Anchos habituales">
+        <button type="button" class="ghost" data-width="256">256</button>
+        <button type="button" class="ghost" data-width="512">512</button>
+        <button type="button" class="ghost" data-width="1024">1024</button>
+        <button type="button" class="ghost" data-width="2048">2048</button>
+      </div>
+      <p class="hint-line">El alto sale de la forma del dibujo.</p>
+    </div>
+
+    <div class="size-fields" id="height-fields" hidden>
+      <div class="numbers">
+        <label>Alto<input type="number" id="size-height" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">El ancho sale de la forma del dibujo.</p>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Lado más largo<input type="number" id="size-longest" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">
+        El lado que sea más largo pasa a medir esto y el otro lo sigue, así que un
+        logotipo ancho y uno alto salen del mismo tamaño en su lado largo.
+      </p>
+    </div>
+
+    <div class="size-fields" id="box-fields" hidden>
+      <div class="numbers">
+        <label>Ancho<input type="number" id="box-width" min="1" step="1" value="1200"></label>
+        <label>Alto<input type="number" id="box-height" min="1" step="1" value="630"></label>
+      </div>
+      <div class="option-row">
+        <label for="box-fit">Si el dibujo tiene otra forma</label>
+        <select id="box-fit">
+          <option value="fit" selected>Encajar dentro &mdash; el dibujo entero, con un lado más corto</option>
+          <option value="pad">Rellenar &mdash; exactamente este tamaño, con el fondo a los lados</option>
+          <option value="stretch">Estirar &mdash; exactamente este tamaño, y la forma deformada</option>
+        </select>
+      </div>
+    </div>
+
+    <!--
+      The one thing people rasterise a vector for more than once: the same
+      drawing at 1x, 2x and 3x for a screen with more device pixels than CSS
+      pixels. Multiplied from the plan above rather than planned again, so an
+      @2x is exactly twice its @1x and cannot drift by a rounded pixel.
+    -->
+    <div class="option-row" id="density-row">
+      <label for="density">Escribir también las copias de alta densidad</label>
+      <select id="density">
+        <option value="1" selected>No &mdash; un archivo por dibujo</option>
+        <option value="2">También @2x &mdash; para una pantalla Retina</option>
+        <option value="3">@2x y @3x &mdash; el conjunto completo que pide un móvil</option>
+      </select>
+    </div>
+
+    <p id="size-summary" class="field-summary"></p>
+    <p id="size-warning" class="field-summary warn" hidden></p>
+  </section>
+
+  <!-- Paso 3 &mdash; el formato -->
+  <section class="card" id="format-card">
+    <h2><span class="step">3</span> Elige el formato</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; conserva la transparencia, bordes exactos</option>
+          <option value="image/jpeg">JPEG &mdash; sin transparencia, mejor con fotografías</option>
+          <option value="image/webp">WebP &mdash; transparencia y un archivo más pequeño</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Calidad &mdash; <output id="quality-value" for="quality">90</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="90">
+        <p class="field-note">
+          Solo para JPEG y WebP; PNG no tiene mando de calidad porque no tiene
+          pérdidas. El color plano y los bordes duros &mdash; que es de lo que
+          está hecho casi todo SVG &mdash; son justo lo que peor lleva un
+          codificador con pérdidas, así que aquí esto queda más alto de lo que
+          quedaría para una fotografía.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="background-mode">Fondo</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparente</option>
+          <option value="colour">Un color</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Color de fondo" hidden>
+        <p class="field-note" id="background-note"></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Paso 4 &mdash; míralo y llévatelo -->
+  <section class="card" id="run-card">
+    <h2><span class="step">4</span> Míralo y guárdalo</h2>
+
+    <p class="card-lede">
+      La vista previa la dibuja el mismo código que escribe el archivo, a partir
+      del archivo que has elegido, en este equipo. Lo que merece la pena
+      comprobar son las dos cosas que cambian cuando un dibujo se convierte en
+      píxeles: una línea de un pelo que medía medio píxel y se ha vuelto gris, y
+      el texto, que se dibuja con una tipografía que este equipo tenga y no con
+      una traída de la web.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-stage">
+        <canvas id="preview-canvas"></canvas>
+      </div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <p id="preview-empty" class="field-summary">Añade un SVG y aparece aquí.</p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Rasterizar</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Terminado</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Descargar todo en un zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/svg-to-image.toml
+++ b/locales/es/tools/svg-to-image.toml
@@ -1,0 +1,322 @@
+#
+# SVG a imagen - Spanish.
+#
+# Overrides for tools/svg-to-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "SVG a imagen"
+heading = "SVG&nbsp;a&nbsp;imagen <span class=\"h1-kw\">&mdash; rasteriza un vector a PNG, JPEG o WebP a cualquier tamaño</span>"
+tagline = "Di el tamaño. Un vector no tiene ninguno propio que perder."
+
+title = "SVG a PNG &mdash; rasteriza un vector a cualquier tamaño, sin subir nada"
+description = "Convierte un SVG en un PNG, un JPEG o un WebP a cualquier tamaño, en tu navegador. Di el ancho, un múltiplo o una caja; llévate también las copias @2x y @3x. Se conserva la transparencia y no se sube nada."
+og_title = "Convierte un SVG en un PNG a cualquier tamaño, sin subirlo"
+og_description = "Un vector no tiene tamaño propio en píxeles, así que el número lo eliges tú: 32 u 8000, con la misma nitidez en ambos casos. Todo ocurre en tu propio equipo."
+og_image_alt = "SVG a imagen - rasteriza un vector a PNG, JPEG o WebP a cualquier tamaño"
+
+pledge = """
+    El dibujo lo rasteriza el mismo motor que acaba de ponerlo en tu pantalla.
+    Tu archivo se lee de tu disco, su etiqueta raíz se reescribe al tamaño que
+    has pedido con cien líneas en <code>src/svg.js</code> que puedes leer, y se
+    dibuja sobre un lienzo que tu navegador ya trae de serie. Esta herramienta no
+    tiene ninguna función de red &mdash; nada que descargar, nada que enviar
+    &mdash; y al otro lado de esta página no hay ningún servidor al que mandar un
+    logotipo aunque lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y rasteriza algo. Ni una sola petición lleva un archivo, una
+      miniatura, un nombre de archivo ni un byte de lo que has elegido. O
+      desconéctate de internet y convierte uno de todos modos."""
+
+read_first = """
+, <code>src/svg.js</code> para ver cómo se lee el
+      tamaño propio de un archivo y cómo se reescribe su etiqueta raíz, y
+      <code>src/render.js</code> para las ocho líneas que hacen el rasterizado
+      &mdash; un &lt;img&gt;, un <code>drawImage</code> y un
+      <code>toBlob</code>, sin nada en medio."""
+
+howto_heading = "Cómo convertir un SVG en un PNG sin subirlo"
+
+card = """
+            Un SVG no tiene tamaño propio en píxeles, así que el número lo eliges
+            tú &mdash; 32 u 8000, y la misma nitidez en ambos casos."""
+
+[words]
+plural = "archivos SVG"
+choose = "un SVG"
+analytics_extra = """, ni ninguno de los
+  tamaños, formatos o nombres de archivo que esta herramienta calcula"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Tus dibujos no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudieran recogerse tus archivos, ni nada en el código que los enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ No hay ningún
+      <code>fetch</code>, ningún <code>XMLHttpRequest</code> ni ningún
+      <code>sendBeacon</code> en todo <code>src/</code>. El rasterizador entero
+      es un <code>&lt;img&gt;</code> que sostiene un blob de tu propio archivo, un
+      <code>drawImage</code> sobre un lienzo y un
+      <code>canvas.toBlob</code>."""
+
+[[privacy]]
+title = "Un SVG es un documento, y este es el modo en el que no puede actuar."
+body = """
+ Un SVG puede llevar un
+      <code>&lt;script&gt;</code>, un
+      <code>&lt;image href=&quot;https://&hellip;&quot;&gt;</code> remoto, una
+      hoja de estilos y una tipografía web. Dibujado a través de un
+      <code>&lt;img&gt;</code> está en lo que la especificación llama <em>modo
+      estático seguro</em>: el script no se ejecuta y no se descarga ninguna de
+      esas direcciones. Esa es una garantía del navegador, no una promesa
+      nuestra, y es la razón de que esta página pueda abrir un archivo que no ha
+      visto nunca sin que el archivo pueda llamar a casa."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google, y el botón de donación de Buy Me a
+      Coffee. A ninguno se le entrega nada sobre tu dibujo. Cada línea que lee,
+      dimensiona o dibuja un archivo se sirve desde este origen y está listada en
+      el repositorio."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta
+      sigue igual, porque nunca hubo un paso de red dentro de ella. Es la prueba
+      más sencilla de todas."""
+
+[[howto]]
+title = "Elige el SVG."
+body = """
+ Suelta uno sobre el selector, o escoge una
+      carpeta entera y conviértelos todos de una vez. Tu navegador lee el archivo
+      directamente del disco; mientras lo haces no se envía nada a ninguna parte.
+      Cada fila dice de qué tamaño se cree el archivo &mdash; y lo dice de otra
+      manera cuando ese tamaño salió de su <code>viewBox</code>, o se dio por
+      supuesto porque el archivo no declara ninguno."""
+
+[[howto]]
+title = "Di de qué tamaño."
+body = """
+ Un múltiplo del tamaño propio del archivo
+      es la respuesta más rápida y la correcta para un lote: cada dibujo se
+      escala desde su propio punto de partida, así que un conjunto de iconos
+      mantiene sus proporciones. Si no, di un ancho, un alto, el lado más largo o
+      una caja con los dos lados. Aquí no hay ninguna penalización por un número
+      grande, como sí la habría con una fotografía &mdash; el dibujo se vuelve a
+      dibujar a ese tamaño, no se estira hasta él."""
+
+[[howto]]
+title = "Añade las copias de alta densidad si las necesitas."
+body = """
+ Un móvil y un portátil Retina
+      dibujan dos o tres píxeles de dispositivo por cada píxel CSS, así que un
+      logotipo de 200 píxeles necesita detrás un archivo de 400 o de 600. Pide
+      <code>@2x</code> y <code>@3x</code> y salen con los nombres que esperan
+      Xcode, las herramientas de Android y el <code>image-set()</code> de CSS, y
+      cada uno es exactamente el doble o el triple del primero en vez de
+      redondearse por separado."""
+
+[[howto]]
+title = "Elige el formato y decide sobre la transparencia."
+body = """
+ PNG salvo que tengas un
+      motivo: no tiene pérdidas, conserva la transparencia y el color plano se
+      comprime bien en él. JPEG no tiene transparencia ninguna, así que se pinta
+      un color de fondo elijas uno o no &mdash; sin él, cada píxel transparente
+      sale negro. WebP hace las dos cosas y da un archivo más pequeño, a costa
+      del software lo bastante viejo como para no leerlo."""
+
+[[howto]]
+title = "Mira la vista previa antes de descargar."
+body = """
+ La dibuja el mismo código que
+      escribe el archivo, a partir de tu archivo, en tu equipo. Dos cosas cambian
+      cuando un dibujo se convierte en píxeles, y las dos se ven aquí: una línea
+      de un pelo que medía medio píxel se vuelve gris, y el texto se dibuja con
+      una tipografía que este ordenador tenga y no con una traída de la web."""
+
+[[howto]]
+title = "Llévate los archivos."
+body = """
+ Una descarga por archivo, o el lote
+      entero como un solo zip. Los nombres siguen al SVG del que salieron, con
+      <code>@2x</code> y <code>@3x</code> en las copias, y dos archivos que
+      habrían tenido el mismo nombre se numeran en vez de que uno reemplace en
+      silencio al otro."""
+
+[[faq]]
+q = "¿Se sube mi SVG a alguna parte?"
+a = """
+        No. Tu propio navegador lee el archivo en tu propio hardware, lo dibuja
+        sobre un lienzo con el mismo motor que renderiza cualquier otra imagen que
+        veas, y te lo devuelve como una descarga. Esta herramienta no tiene
+        ninguna función de red &mdash; nunca descarga nada y nunca envía nada
+        &mdash; y la <code>Content-Security-Policy</code> de la página nombra
+        todas las direcciones que puede contactar, ninguna de las cuales es de
+        este sitio."""
+
+[[faq]]
+q = "¿A qué tamaño debería rasterizar un SVG?"
+a = """
+        Al que pida quien vaya a leerlo, multiplicado por la densidad de píxeles
+        de la pantalla en la que se verá. Un logotipo que ocupa 200 píxeles CSS
+        necesita 400 para un portátil Retina y 600 para un móvil reciente, que es
+        lo que son aquí las copias <code>@2x</code> y <code>@3x</code>. Para el
+        icono de una aplicación o una ficha de tienda, la tienda dice un número
+        exacto y ese es el número. Cuando nadie te ha dicho nada, 1024 en el lado
+        más largo es un valor por defecto útil: lo bastante grande para casi
+        cualquier uso y lo bastante pequeño para mandarlo por correo."""
+
+[[faq]]
+q = "¿Hacerlo más grande hace perder calidad?"
+a = """
+        No, y este es el único sitio donde esa respuesta es honestamente que no.
+        Un vector son instrucciones y no píxeles, así que el navegador vuelve a
+        dibujar las curvas al tamaño que se le pida. 4000 píxeles a partir de un
+        icono de 24 píxeles son exactamente igual de nítidos que los 24. Lo que no
+        se puede es ir al revés: una vez que es un PNG son píxeles como cualquier
+        otra cosa, así que rasteriza al tamaño que necesites en vez de
+        redimensionar el resultado después."""
+
+[[faq]]
+q = "Mi SVG no tiene ancho ni alto. ¿Qué tamaño me sale?"
+a = """
+        El del <code>viewBox</code>, si lo hay &mdash; su ancho y su alto son
+        unidades de usuario y no píxeles, pero son los únicos números del archivo y
+        un navegador los trata como el tamaño natural del dibujo. Si tampoco hay
+        viewBox, la página pone <em>supuesto</em> junto a la fila y usa
+        300&nbsp;&times;&nbsp;150, que es a lo que lo habría dibujado un
+        <code>&lt;img&gt;</code>. En cualquier caso puedes decir el tamaño que
+        quieras y el archivo se dibuja a ese."""
+
+[[faq]]
+q = "¿Por qué el texto se ve distinto en el PNG?"
+a = """
+        Porque la tipografía no está en el SVG. Un SVG que dibuja texto nombra una
+        tipografía y deja que la máquina la encuentre, y un archivo que se trae
+        una de Google Fonts con un <code>@import</code> no consigue nada aquí: a
+        un SVG dibujado a través de un <code>&lt;img&gt;</code> no se le permite
+        descargar nada, que es la misma regla que le impide llamar a casa con tu
+        archivo. La solución es la que cualquier diseñador ya conoce &mdash;
+        convierte el texto en trazados en el programa de dibujo antes de exportar.
+        Entonces es geometría, y se ve igual en todas partes."""
+
+[[faq]]
+q = "¿Puede convertir varios archivos a la vez?"
+a = """
+        Sí. Todos los SVG de la lista se renderizan con los mismos ajustes y el
+        lote baja como un solo zip. Un múltiplo &mdash; «4&times; el tamaño que
+        pide el archivo» &mdash; suele ser el ajuste correcto para un lote, porque
+        cada dibujo se escala desde su propio tamaño en vez de forzarlos todos al
+        mismo número de píxeles. Haz clic en cualquier fila para poner ese en la
+        vista previa."""
+
+[[faq]]
+q = "¿Hay algún límite de tamaño?"
+a = """
+        El del navegador, no el nuestro. Un lienzo se rinde en algún punto pasados
+        los 16&nbsp;384 píxeles de lado, y Safari en un iPhone o un iPad se planta
+        alrededor de los 16,7 megapíxeles de superficie
+        &mdash; 4096&nbsp;&times;&nbsp;4096. Por encima de eso la página te avisa
+        en vez de devolverte una imagen en blanco, que es lo que hace un navegador
+        cuando se ha quedado sin recursos: <code>toBlob</code> no devuelve nada en
+        absoluto, y sin ningún error que lo explique. Pasados los 100 megapíxeles
+        la herramienta se niega, porque eso son 400&nbsp;MB de lienzo antes de
+        haber codificado un solo byte."""
+
+[[faq]]
+q = "¿Qué pasa con la transparencia?"
+a = """
+        Se conserva, en PNG y en WebP. JPEG no tiene canal alfa en absoluto, así
+        que se pinta un color detrás de toda la imagen pidas uno o no &mdash; sin
+        él, todo lo transparente saldría negro, lo que parece un error en lugar de
+        parecer JPEG. Elegir un color de fondo con PNG es también algo
+        perfectamente normal de querer: aplana el dibujo sobre ese color en vez de
+        dejar un hueco."""
+
+[[faq]]
+q = "¿Puede leer un SVG que contenga un script o una imagen externa?"
+a = """
+        Leerlo puede, y dibujará exactamente las partes que un navegador esté
+        dispuesto a dibujar. Un SVG cargado a través de un
+        <code>&lt;img&gt;</code> está en <em>modo estático seguro</em>: los
+        scripts no se ejecutan, las referencias externas no se descargan y la
+        animación no se reproduce &mdash; lo que te llevas es el primer fotograma.
+        Así que un archivo con un <code>&lt;image&gt;</code> remoto dentro sale con
+        esa parte ausente. Eso es el navegador negándose en tu nombre, y es la
+        razón de que esta página pueda abrir con seguridad un archivo que no ha
+        visto nunca."""
+
+[[faq]]
+q = "¿En qué se diferencia esto del redimensionador de imágenes?"
+a = """
+        En cuál es el origen. El redimensionador de imágenes parte de píxeles
+        &mdash; un JPEG, un PNG &mdash;, así que hacerlo más grande tiene que
+        inventarse detalle que nunca estuvo ahí. Esto parte de un dibujo, así que
+        no hay nada que inventar ni ningún límite superior del que preocuparse. Si
+        lo que tienes es un SVG, esta es la que te da un resultado nítido; si lo
+        que tienes es una fotografía, es la otra."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. Tampoco hay límite en el número ni en el tamaño de los archivos,
+        porque no hay ningún servidor pagándolos &mdash; el trabajo ocurre en tu
+        propio equipo. El sitio lleva publicidad, que es lo que lo paga; a los
+        anuncios no se les da nada sobre tus archivos."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Esa es además la forma más sencilla de demostrar que no se
+        sube nada: una herramienta que mandara tus dibujos fuera a renderizar se
+        detendría en el momento en que desenchufaras."""
+
+[schema]
+description = "Rasteriza un SVG a PNG, JPEG o WebP a cualquier tamaño, en el navegador. Fija el tamaño con un múltiplo, un ancho, un alto, el lado más largo o una caja, añade las copias @2x y @3x, conserva o aplana la transparencia, y convierte un lote de una vez. No se sube nada."
+features = [
+  "Vuelve a renderizar el vector a cada tamaño, así que el resultado es nítido en todos",
+  "Tamaño por un múltiplo, un ancho, un alto, el lado más largo o una caja con su encaje",
+  "Copias @2x y @3x, cada una un múltiplo exacto de la primera en vez de redondeada dos veces",
+  "PNG, JPEG y WebP, con la transparencia conservada o aplanada sobre un color",
+  "Lee el tamaño de width, height o el viewBox, y dice cuál ha usado",
+  "Avisa antes de un tamaño que el lienzo de un navegador no puede producir de verdad",
+  "Vista previa dibujada por el mismo código que escribe el archivo",
+  "Por lotes, con todos los resultados en un zip",
+  "Los scripts y las referencias remotas del archivo no se ejecutan ni se descargan nunca",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí un SVG"
+hint = "o haz clic para buscarlo &mdash; varios a la vez también vale"

--- a/locales/es/tools/trim-video.html
+++ b/locales/es/tools/trim-video.html
@@ -1,0 +1,224 @@
+<main>
+  <!-- Paso 1 &mdash; el vídeo -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige un vídeo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <!-- One row a video, in the order they will be joined. Hidden until there
+         is more than one, because a list of one is furniture. -->
+    <ol class="clip-list" id="clip-list" hidden></ol>
+
+    <p id="join-note" class="path-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; las marcas -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> Marca los trozos que quieras
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Reprodúcelo entero y pulsa <kbd>I</kbd> donde debe empezar un trozo y
+      <kbd>O</kbd> donde debe terminar. Hazlo tantas veces como quieras &mdash;
+      cada pareja se convierte en una fila de abajo, y el vídeo terminado son esas
+      filas, una detrás de otra. <kbd>U</kbd> deshace la última,
+      <kbd>Espacio</kbd> reproduce y pausa, y las flechas saltan cinco segundos.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- Built by src/timeline.js: a band for every segment, the one being
+         marked, a tick for every keyframe, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Reproducir</button>
+      <button type="button" id="back-5" class="ghost" title="Cinco segundos atrás">&minus;5s</button>
+      <button type="button" id="forward-5" class="ghost" title="Cinco segundos adelante">+5s</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Marcar inicio</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Marcar final</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Deshacer</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Velocidad de reproducción">
+      <span class="speed-label">Velocidad</span>
+      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normal</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The segments themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Trozos <span class="segment-count" id="segment-count">ninguno todavía</span></h3>
+        <p class="segments-total">
+          Total conservado <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">N.º</th>
+            <th scope="col">Inicio</th>
+            <th scope="col">Final</th>
+            <th scope="col">Duración</th>
+            <th scope="col"><span class="visually-hidden">Acciones</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Todavía no hay nada marcado. Pulsa <kbd>I</kbd> y luego <kbd>O</kbd>
+        mientras se reproduce, o usa los botones de arriba.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Añadir una fila a mano</button>
+        <button type="button" id="reset-segments" class="ghost danger">Borrarlas todas</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">Cargar marcas&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Formato del archivo de tiempos">
+          <option value="seconds" selected>segundos</option>
+          <option value="HHMMSSmmm">HH:MM:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">Guardar marcas</button>
+      </div>
+
+      <p class="field-note">
+        Las marcas se guardan como un archivo de texto plano &mdash; una línea
+        por trozo, en el formato de arriba &mdash;, así que una sesión larga de
+        marcado sobrevive a una pestaña cerrada, y el mismo archivo se le puede
+        pasar a cualquier herramienta que lea esa disposición.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>Qué hacer con los trozos marcados</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Conservarlos</strong>
+          El vídeo terminado son los trozos marcados, unidos en orden.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Quitarlos</strong>
+          Los trozos marcados se van, y todo lo demás se une.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Paso 3 &mdash; la exportación -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Córtalo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="method">Cómo cortarlo</label>
+        <select id="method">
+          <option value="copy" selected>Conservar cada byte &mdash; sin recodificar nada</option>
+          <option value="exact">Cortar exactamente aquí &mdash; recodifica la imagen</option>
+          <option value="record">Grabarlo mientras se reproduce</option>
+        </select>
+        <p class="field-note" id="method-note"></p>
+      </div>
+
+      <div class="field" id="frame-field" hidden>
+        <label for="frame">Tamaño de fotograma</label>
+        <select id="frame">
+          <option value="first" selected>Igual que el primer vídeo</option>
+          <option value="largest">Igual que el más grande</option>
+          <option value="1080p">1920 &times; 1080</option>
+          <option value="720p">1280 &times; 720</option>
+        </select>
+        <p class="field-note">
+          Un solo tamaño cubre el archivo entero. Un vídeo de otra forma se
+          encaja dentro con bandas, nunca estirado.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Calidad</label>
+        <select id="quality">
+          <option value="low">Archivo más pequeño</option>
+          <option value="medium" selected>Equilibrado</option>
+          <option value="high">Mejor calidad</option>
+        </select>
+        <p class="field-note">
+          Nunca más de lo que gastaba el original &mdash; recodificar por encima
+          de eso solo hace el archivo más grande.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Conservar el sonido
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Se conserva</dt><dd id="sum-clips">&mdash;</dd></div>
+      <div><dt>Duración final</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Empieza en</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>Aproximadamente</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Imagen</dt><dd id="sum-picture">&mdash;</dd></div>
+      <div><dt>Sonido</dt><dd id="sum-sound">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Cortar vídeo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Descargar vídeo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/trim-video.toml
+++ b/locales/es/tools/trim-video.toml
@@ -1,0 +1,322 @@
+#
+# Cortador de vídeo - Spanish.
+#
+# Overrides for tools/trim-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Cortador de vídeo"
+heading = "Cortar&nbsp;vídeo <span class=\"h1-kw\">&mdash; cortar un vídeo en línea</span>"
+tagline = "Marca lo que merece la pena mientras se reproduce. Te lo devuelve como un solo vídeo."
+
+title = "Cortar un vídeo en línea &mdash; quédate solo con lo que quieras, sin subir nada"
+description = "Mira un vídeo y marca cada trozo que merezca la pena mientras se reproduce; después guarda esos trozos como un solo archivo. Funciona en tu navegador: no se sube nada, no se recodifica nada y funciona sin conexión."
+og_title = "Cortador de vídeo &mdash; quédate solo con lo que quieras, sin subir nada"
+og_description = "Pulsa I y O mientras se reproduce para marcar cada trozo que quieras conservar. Los trozos marcados se vuelven a escribir como un solo vídeo, fotograma a fotograma, sin subir nada."
+og_image_alt = "Cortador de vídeo - marca lo que quieras y guárdalo como un solo vídeo, en tu navegador"
+
+pledge = """
+    Tu propio navegador lee, marca, corta y escribe tu vídeo, en tu propio
+    hardware. Aquí nada puede descargar ni enviar nada &mdash; esta herramienta
+    no tiene ninguna función de red &mdash; y al otro lado de esta página no hay
+    ningún servidor al que mandar un vídeo aunque lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y corta un vídeo. Ni una sola petición lleva un fotograma, un
+      nombre de archivo ni un byte de lo que has elegido. O desconéctate de
+      internet y corta uno de todos modos &mdash; una herramienta que mandara tu
+      vídeo fuera a cortar sencillamente se detendría."""
+
+read_first = """
+, <code>src/segments.js</code> para las marcas y el
+      archivo en que se guardan, <code>src/demux.js</code> para el lector que
+      encuentra los fotogramas dentro de un MP4, <code>src/ranges.js</code> para
+      la aritmética que convierte una marca en una tirada de muestras, y
+      <code>src/copy.js</code> para el bucle que mueve esas muestras al archivo
+      nuevo. Ninguno importa nada capaz de hacer una petición."""
+
+howto_heading = "Cómo cortar un vídeo"
+
+card = """
+            Marca cada trozo que merezca la pena mientras se reproduce y
+            guárdalos como un solo vídeo. Los fotogramas se copian en vez de
+            recodificarse, así que no se pierde nada."""
+
+[words]
+plural = "vídeos"
+choose = "un vídeo"
+analytics_extra = """, ni ningún
+  fotograma, duración o punto de corte"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Tantos trozos como quieras"
+
+[[facts]]
+text = "Sin pérdida de calidad"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[privacy]]
+title = "Tus vídeos no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudiera recogerse tu archivo, ni nada en el código que lo enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ Esta herramienta no tiene ninguna
+      función de red: ninguna dirección que pegar, nada que descargar, ningún
+      motor que se baje en el primer uso. Cada byte que toca tu vídeo vino de
+      este origen cuando se cargó la página."""
+
+[[privacy]]
+title = "Por la vía normal ni siquiera se descodifica nada."
+body = """
+
+      Cortar no cambia el aspecto de ningún fotograma, así que los fotogramas
+      codificados de los trozos que has marcado se mueven al archivo nuevo tal y
+      como se encontraron. Cada uno se guarda como un trozo del archivo de tu
+      disco &mdash; una nota que dice qué bytes, no los bytes en sí &mdash; y tu
+      navegador los lee por primera vez mientras escribe la descarga. Aquí nada
+      convierte nunca tu vídeo de vuelta en una imagen."""
+
+[[privacy]]
+title = "El archivo de marcas se hace en la página."
+body = """
+ Guardar tus marcas
+      escribe un archivo de texto a partir de los números que ya están en
+      pantalla, directamente a tus descargas. Cargar uno lo lee aquí. Ninguno de
+      los dos se acerca a una red, y ninguno lleva más que tiempos."""
+
+[[privacy]]
+title = "El sonido se copia, no se escucha."
+body = """
+ Por las dos vías de MP4,
+      las muestras de audio se trasladan sin descodificarlas siquiera &mdash;
+      aquí nada las vuelve a convertir en sonido, y nada podría pasarlas a
+      ninguna parte si lo hiciera."""
+
+[[privacy]]
+title = "Donde sí se descodifican fotogramas, ocurre aquí."
+body = """
+ El corte
+      exacto, y la vista previa de un archivo que este navegador no reproduce,
+      pasan por WebCodecs en tu propio equipo. Es el mismo descodificador que te
+      enseñaría el vídeo de todas formas, funcionando en el mismo sitio."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google. A ninguno se le entrega nada sobre
+      tu vídeo: ni un archivo, ni un fotograma, ni un nombre, un tamaño, una
+      duración o dónde lo cortaste. Cada línea que lee, corta y escribe se sirve
+      desde este origen y está listada en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le da."
+body = """
+
+      El botón «Buy me a coffee» de la cabecera lo dibuja un script de
+      cdnjs.buymeacoffee.com y se compone con Google Fonts. Es un enlace y nada
+      más: no informa de ninguna visita, y no se le entrega nada sobre ti ni
+      sobre tu vídeo."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo lo de esta
+      página sigue funcionando. Es la prueba más sencilla de todas."""
+
+[[howto]]
+title = "Elige un vídeo."
+body = """
+ Suelta un MP4, MOV, M4V o WebM sobre
+      el selector. Tu navegador lo lee directamente del disco; mientras lo haces
+      no se envía nada a ninguna parte. Suelta varios y se unen, en el orden en
+      que los pusiste."""
+
+[[howto]]
+title = "Reprodúcelo y marca los trozos que quieras."
+body = """
+ Pulsa
+      <kbd>I</kbd> donde debe empezar un trozo y <kbd>O</kbd> donde debe
+      terminar. Hazlo tantas veces como quieras &mdash; cada pareja se convierte
+      en una fila de la tabla de abajo y en una banda de la línea de tiempo.
+      <kbd>U</kbd> deshace la última, <kbd>Espacio</kbd> reproduce y pausa, y las
+      flechas saltan cinco segundos cada vez. Baja la velocidad de reproducción
+      si el momento es difícil de pillar."""
+
+[[howto]]
+title = "Retoca las marcas."
+body = """
+ Cada fila se puede reproducir por su
+      cuenta, retimar escribiendo dentro un tiempo exacto, subir o bajar de orden,
+      o borrar. Los dos extremos del trozo seleccionado también se pueden
+      arrastrar por la línea de tiempo. El total de arriba es lo que va a durar el
+      vídeo terminado."""
+
+[[howto]]
+title = "Consérvalos, o quítalos."
+body = """
+ Conservar es lo habitual: el
+      vídeo terminado son los trozos que has marcado, unidos en orden. Quitarlos
+      es el otro trabajo que la gente quiere y casi nunca encuentra &mdash; marca
+      los anuncios, los silencios o los arranques en falso, y lo que queda se une
+      sin ellos."""
+
+[[howto]]
+title = "Córtalo y descárgalo."
+body = """
+ «Conservar cada byte» traslada los
+      fotogramas intactos: es rápido y no puede costar calidad, pero cada trozo
+      empieza en el fotograma clave anterior a tu marca. «Cortar exactamente
+      aquí» descodifica y vuelve a escribir la imagen para que cada trozo empiece
+      en el fotograma que elegiste. La página dice cuál de los dos vas a obtener,
+      y lo que cuesta, antes de que pulses el botón."""
+
+[[faq]]
+q = "¿Se sube mi vídeo a alguna parte?"
+a = """
+        No. Tu propio navegador lo lee, lo marca, lo corta y lo escribe en tu
+        propio hardware. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar &mdash; ninguna es de este sitio.
+        Desenchúfate de internet y corta un vídeo de todos modos si prefieres
+        comprobarlo a que te lo cuenten."""
+
+[[faq]]
+q = "¿Puedo conservar varios trozos del mismo vídeo?"
+a = """
+        Para eso está esto. Pulsa <kbd>I</kbd> y <kbd>O</kbd> tantas veces como
+        quieras mientras se reproduce; cada pareja se convierte en una fila, y el
+        vídeo terminado son todas las filas unidas en orden con todo lo demás
+        fuera. Casi todos los cortadores en línea te dan una sola pareja de
+        tiradores y preguntan qué tramo único quieres conservar, lo cual está bien
+        para recortar la entrada y la salida de un clip y no sirve de nada para
+        ver una hora de material una vez y quedarse con los seis momentos que
+        valen."""
+
+[[faq]]
+q = "¿Cortar hace perder calidad?"
+a = """
+        Por la vía normal no, y no en lo que importa. Cortar no cambia el aspecto
+        de ningún fotograma, así que los fotogramas se mueven al archivo nuevo tal
+        y como estaban: los mismos bytes, los mismos ajustes de codificación, lo
+        mismo en todo. La única vía de aquí que recodifica algo es el corte
+        exacto, y lo dice en el botón."""
+
+[[faq]]
+q = "¿Por qué un trozo empieza antes de donde lo marqué?"
+a = """
+        Por cómo se guarda el vídeo, y solo en reproductores que ignoran una parte
+        estándar del formato. Casi todos los fotogramas se guardan como una
+        descripción de en qué se diferencian de sus vecinos, así que no se pueden
+        descodificar sin ellos; solo un fotograma clave se sostiene solo, y los
+        fotogramas clave suelen estar separados entre uno y diez segundos. Un
+        corte que copia fotogramas tiene que arrastrar por tanto la tirada desde
+        el fotograma clave anterior a tu marca &mdash; y el archivo dice
+        <em>empieza a reproducir en tu marca</em>, cosa que respeta cualquier
+        reproductor corriente. Si lo necesitas exacto en todos los reproductores,
+        elige «Cortar exactamente aquí», que recodifica. La página te dice en qué
+        caso estás, y por cuánto, antes de exportar."""
+
+[[faq]]
+q = "¿Puedo quitar los anuncios en vez de conservarlos?"
+a = """
+        Sí. Márcalos y elige «Quitarlos»: se une todo lo que <em>no</em> marcaste,
+        en orden. La misma lista de marcas responde a las dos preguntas, así que
+        puedes cambiar de una a otra y ver cómo cambia la duración sin marcar nada
+        dos veces."""
+
+[[faq]]
+q = "¿Puedo guardar mis marcas y volver a ellas?"
+a = """
+        Sí. «Guardar marcas» escribe un archivo de texto plano &mdash; una línea
+        por trozo, un inicio y un final separados por una coma &mdash; y «Cargar
+        marcas» lee uno de vuelta. Se ofrecen dos formatos, segundos pelados y
+        <code>HH:MM:SS.mmm</code>, y los dos respetan la disposición que ya usan
+        otras herramientas que trabajan así, de modo que un archivo escrito aquí
+        se le puede pasar a una de ellas y un archivo escrito allí se puede soltar
+        en esta página. Marcar es un trabajo cuidadoso y nadie debería tener que
+        hacerlo dos veces."""
+
+[[faq]]
+q = "¿Qué formatos de vídeo puedo cortar?"
+a = """
+        MP4, M4V y MOV se leen directamente, lleven lo que lleven dentro: H.264,
+        HEVC, AV1 o VP9. Copiar fotogramas no implica descodificarlos, así que
+        esta vía funciona incluso con un códec para el que tu navegador no tenga
+        ningún descodificador. Cualquier otra cosa que tu navegador sepa
+        reproducir &mdash; WebM la más evidente &mdash; se corta reproduciéndola y
+        grabando el resultado, lo que funciona, tarda lo que dure el resultado y
+        solo puede conservar un trozo. Un archivo que el navegador no sabe ni leer
+        ni reproducir, que en la práctica significa AVI, WMV, FLV y casi todos los
+        MKV, se rechaza con un mensaje que lo dice, en vez de fallar a mitad de
+        camino."""
+
+[[faq]]
+q = "¿Hay algún límite de tamaño o duración del vídeo?"
+a = """
+        La herramienta no lleva ningún límite dentro, y por la vía de copia el
+        archivo apenas se lee: a los fotogramas que conservas se les apunta en vez
+        de cargarlos, así que quedarse con cuatro minutos de una grabación de
+        cuatro gigabytes cuesta más o menos lo que cuesta escribir esos cuatro
+        minutos en disco. El corte exacto recorre el archivo de unos pocos
+        megabytes en unos pocos megabytes. En cualquiera de los dos casos el techo
+        práctico es el archivo terminado, que se monta en memoria antes de que lo
+        descargues."""
+
+[[faq]]
+q = "¿Sobrevive el sonido?"
+a = """
+        Por las dos vías de MP4 se copia muestra a muestra sin descodificarlo
+        nunca, así que es byte por byte lo que había en el archivo, y una marca de
+        edición mantiene cada trozo alineado con su imagen con una precisión de
+        una milésima de segundo. La única excepción es unir vídeos distintos cuyo
+        sonido esté descrito de otra forma &mdash; frecuencias de muestreo
+        distintas, por ejemplo &mdash;, donde no hay manera de meter los dos en
+        una sola pista sin descodificarlos, y la página lo dice antes de hacerlo.
+        Por la vía de la grabación se captura de la reproducción y se vuelve a
+        codificar. En cualquiera de los dos casos hay una casilla para dejarlo
+        fuera del todo."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. El sitio lleva publicidad, que es lo que lo paga; a los anuncios no
+        se les da nada sobre tu vídeo."""
+
+[schema]
+browser_requirements = "Necesita JavaScript. Copiar fotogramas no requiere ningún soporte de códec de vídeo; el corte exacto necesita un navegador con WebCodecs, y los demás formatos recurren a la grabación."
+description = "Marca cuantos trozos quieras de un vídeo mientras se reproduce y guarda esos trozos como un único archivo, o quítalos y quédate con el resto. MP4, MOV y M4V se cortan trasladando los fotogramas codificados a un archivo nuevo sin tocarlos, con el audio original copiado muestra a muestra; no se sube nada y no se recodifica nada."
+features = [
+  "Marca cuantos trozos quieras con I y O mientras el vídeo se reproduce",
+  "Une los trozos marcados en un solo archivo, en el orden que elijas",
+  "O quita los trozos marcados y conserva todo lo demás",
+  "Corta sin recodificar, así que no se pierde calidad",
+  "Guarda y vuelve a cargar las marcas como un archivo de tiempos en texto plano",
+  "Marcas exactas al fotograma, con los fotogramas clave visibles en la línea de tiempo",
+  "Conserva el audio original sin volver a codificarlo",
+  "Funciona sin conexión; sin subidas, sin cuenta y sin marca de agua",
+]
+
+[picker]
+title = "Suelta aquí un vídeo"
+hint = "o haz clic para buscarlo &mdash; MP4, MOV, M4V, WebM. Suelta varios para unirlos."

--- a/locales/es/tools/video-to-gif.html
+++ b/locales/es/tools/video-to-gif.html
@@ -1,0 +1,169 @@
+<main>
+  <!-- Paso 1 &mdash; el archivo -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige un vídeo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Archivo</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Tamaño</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Fotograma</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Duración</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Vídeo</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Leído por</dt><dd id="src-path">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Paso 2 &mdash; el trozo -->
+  <section class="card" id="section-card" hidden>
+    <h2><span class="step">2</span> Elige el trozo</h2>
+
+    <p class="hint">
+      Reproduce el clip y marca la parte que quieras. <kbd>I</kbd> pone el inicio
+      donde esté el cabezal, <kbd>O</kbd> pone el final, y los dos tiradores de la
+      barra se pueden arrastrar.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- The bar itself is built by src/range.js. -->
+    <div id="rangebar"></div>
+    <div class="rb-scale">
+      <span>0:00.000</span>
+      <span id="scale-end">&mdash;</span>
+    </div>
+
+    <div class="marks">
+      <label>Inicio
+        <input type="text" id="start-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-in" class="ghost" title="Poner el inicio donde está el cabezal (I)">
+        Poner en el cabezal
+      </button>
+
+      <label>Final
+        <input type="text" id="end-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-out" class="ghost" title="Poner el final donde está el cabezal (O)">
+        Poner en el cabezal
+      </button>
+
+      <div class="mark-actions">
+        <button type="button" id="play-section" class="ghost">Reproducir el trozo</button>
+        <button type="button" id="whole-clip" class="ghost">Clip entero</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Paso 3 &mdash; el GIF -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Tamaño y cadencia</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="width">Ancho</label>
+        <select id="width">
+          <option value="240">240 px</option>
+          <option value="320">320 px</option>
+          <option value="480" selected>480 px</option>
+          <option value="640">640 px</option>
+          <option value="source">Tamaño original</option>
+          <option value="custom">Exactamente&hellip;</option>
+        </select>
+        <p class="field-note">
+          El alto va detrás, así que la forma no cambia nunca. El ancho es lo que
+          cuesta un GIF: la mitad de ancho es la cuarta parte de los píxeles.
+        </p>
+        <p class="field-note" id="width-note" hidden></p>
+      </div>
+
+      <div class="field" id="custom-width-field" hidden>
+        <label for="custom-width">Ancho exacto</label>
+        <input type="number" id="custom-width" min="16" max="1920" step="1" value="480">
+        <p class="field-note">En píxeles, entre 16 y 1920.</p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Fotogramas por segundo</label>
+        <select id="fps">
+          <option value="5">5 &mdash; el más pequeño</option>
+          <option value="10">10</option>
+          <option value="12" selected>12 &mdash; suficientemente fluido</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+          <option value="25">25 &mdash; el más fluido</option>
+        </select>
+        <p class="field-note">
+          No es la cadencia propia del vídeo: los fotogramas se muestrean de él.
+          Doce se leen como movimiento; por encima de veinte, el archivo crece más
+          rápido de lo que se nota la fluidez.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Tramado</label>
+        <select id="dither">
+          <option value="on" selected>Activado &mdash; degradados más suaves</option>
+          <option value="off">Desactivado &mdash; más plano y más pequeño</option>
+        </select>
+        <p class="field-note">
+          Mezcla dos colores de la paleta donde falta el correcto. Ordenado, para
+          que un fondo quieto no tiemble.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="loop">
+          <input type="checkbox" id="loop" checked>
+          Repetir para siempre
+        </label>
+        <p class="field-note">Desactivado, se reproduce una vez y para.</p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Trozo</dt><dd id="sum-section">&mdash;</dd></div>
+      <div><dt>Salida</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Fotogramas</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Tamaño aproximado</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="memory-note" class="field-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Hacer el GIF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <img id="result-image" alt="La animación terminada, en reproducción">
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Descargar GIF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/es/tools/video-to-gif.toml
+++ b/locales/es/tools/video-to-gif.toml
@@ -1,0 +1,253 @@
+#
+# Vídeo a GIF - Spanish.
+#
+# Overrides for tools/video-to-gif/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Vídeo a GIF"
+heading = "Vídeo&nbsp;a&nbsp;GIF <span class=\"h1-kw\">&mdash; convertir un vídeo en un GIF</span>"
+tagline = "Elige el trozo, el tamaño y la cadencia."
+
+title = "Convertidor de vídeo a GIF &mdash; gratis, sin subidas y sin conexión"
+description = "Convierte un trozo de un MP4, un MOV o un WebM en un GIF animado. Elige el trozo, el ancho y la cadencia; los fotogramas se leen y el GIF se escribe en tu navegador. No se sube nada."
+og_title = "Vídeo a GIF &mdash; haz un GIF sin subir el clip"
+og_description = "Marca los segundos que quieras, elige un ancho y una cadencia, y llévate un GIF animado. El muestreo de fotogramas, la paleta, el tramado y el LZW ocurren todos en tu propio equipo."
+og_image_alt = "Vídeo a GIF - haz un GIF animado en tu navegador sin subir nada"
+
+pledge = """
+    Tu propio navegador lee, redimensiona, cuantiza y escribe cada fotograma, en
+    tu propio hardware. Aquí nada puede descargar ni enviar nada &mdash; esta
+    herramienta no tiene ninguna función de red &mdash; y al otro lado de esta
+    página no hay ningún servidor al que mandar un vídeo aunque lo hubiera."""
+
+live_hint = """
+      No hace falta que nos creas: abre las herramientas de desarrollo, mira la
+      pestaña «Red» y haz un GIF. Ni una sola petición lleva un fotograma, un
+      nombre de archivo ni un byte de lo que has elegido. O desconéctate de
+      internet y haz uno de todos modos &mdash; una herramienta que mandara tu
+      vídeo fuera a convertir sencillamente se detendría."""
+
+read_first = """
+, <code>src/frames.js</code> para las dos formas
+      en que se leen los fotogramas de un vídeo, <code>src/quantize.js</code>
+      para la paleta, y <code>src/gif.js</code> para el propio archivo, LZW
+      incluido. Ninguno importa nada capaz de hacer una petición."""
+
+howto_heading = "Cómo convertir un vídeo en un GIF"
+
+card = """
+            Marca los segundos que quieras, elige un ancho y una cadencia, y
+            llévate un GIF animado &mdash; con paleta, tramado y todo."""
+
+[words]
+plural = "vídeos"
+choose = "un vídeo"
+analytics_extra = """, ni ningún
+  fotograma, duración o tamaño"""
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Cualquier duración"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[privacy]]
+title = "Tus vídeos no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es de este sitio. Aquí no hay ningún punto final donde
+      pudiera recogerse tu archivo, ni nada en el código que lo enviara si lo
+      hubiera."""
+
+[[privacy]]
+title = "Aquí nada descarga nada."
+body = """
+ Esta herramienta no tiene ninguna
+      función de red: ninguna dirección que pegar, nada que descargar, ningún
+      motor que se baje en el primer uso. Cada byte que toca tu vídeo vino de
+      este origen cuando se cargó la página."""
+
+[[privacy]]
+title = "La descodificación es local."
+body = """
+ Los fotogramas pasan por
+      WebCodecs en tu propio navegador, o por el mismo motor de reproducción que
+      te enseñaría el clip de todas formas. Cuál de los dos se ha usado está
+      escrito arriba de la página, porque cambia cómo se eligen los fotogramas y
+      deberías poder verlo."""
+
+[[privacy]]
+title = "El GIF se escribe aquí, con código que puedes leer."
+body = """
+ La
+      paleta, el tramado y la compresión LZW son unas seiscientas líneas en la
+      carpeta propia de esta herramienta. No hay ningún servicio de codificación,
+      ninguna biblioteca descargada en tiempo de ejecución, ni ningún sitio en
+      todo ello al que pudiera enviarse una imagen."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le da."
+body = """
+ Los scripts de
+      publicidad y medición vienen de Google. A ninguno se le entrega nada sobre
+      tu vídeo: ni un archivo, ni un fotograma, ni un nombre, un tamaño, una
+      duración o el trozo que marcaste. Cada línea que lee, muestrea, cuantiza o
+      codifica se sirve desde este origen y está listada en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le da."
+body = """
+
+      El botón «Buy me a coffee» de la cabecera lo dibuja un script de
+      cdnjs.buymeacoffee.com y se compone con Google Fonts. Es un enlace y nada
+      más: no informa de ninguna visita, y no se le entrega nada sobre ti ni
+      sobre tu vídeo."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo lo de esta
+      página sigue funcionando. Es la prueba más sencilla de todas."""
+
+[[howto]]
+title = "Elige un vídeo."
+body = """
+ Suelta un MP4, MOV, M4V o WebM sobre
+      el selector, o escoge uno a mano. Tu navegador lo lee directamente del
+      disco; mientras lo haces no se envía nada a ninguna parte."""
+
+[[howto]]
+title = "Marca el trozo."
+body = """
+ Reproduce el clip y pulsa
+      <kbd>I</kbd> donde debe empezar y <kbd>O</kbd> donde debe terminar, o
+      arrastra los tiradores de la barra. Un GIF dura unos pocos segundos
+      &mdash; este es el ajuste que decide si el archivo es pequeño o enorme,
+      mucho más que los otros dos."""
+
+[[howto]]
+title = "Elige el ancho y la cadencia."
+body = """
+ 480 píxeles de ancho y 12
+      fotogramas por segundo le van bien a casi todo aquello para lo que sirve un
+      GIF. Reducir el ancho a la mitad deja los píxeles en la cuarta parte; doce
+      fotogramas por segundo se leen como movimiento sin pagar por los que nadie
+      ve."""
+
+[[howto]]
+title = "Hazlo y descárgalo."
+body = """
+ Se leen los fotogramas, se elige una
+      sola paleta de 256 colores para toda la animación, y de cada fotograma se
+      escribe solo la parte de la imagen que ha cambiado. Cuando termina, se
+      reproduce en la página, y ese es el mismo archivo que te da la descarga."""
+
+[[faq]]
+q = "¿Se sube mi vídeo a alguna parte?"
+a = """
+        No. Tu propio navegador lo lee, lo muestrea y lo convierte en tu propio
+        hardware. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar &mdash; ninguna es de este sitio.
+        Desenchúfate de internet y haz un GIF de todos modos si prefieres
+        comprobarlo a que te lo cuenten."""
+
+[[faq]]
+q = "¿Qué formatos de vídeo puedo convertir?"
+a = """
+        MP4, M4V y MOV se leen directamente, lleven lo que lleven dentro: H.264,
+        HEVC, AV1 o VP9, siempre que tu navegador sepa descodificar ese códec.
+        Cualquier otra cosa que tu navegador sepa reproducir &mdash; WebM la más
+        evidente &mdash; se lee llevando el reproductor a cada instante, que es
+        más lento y algo menos exacto sobre qué fotograma cae dónde. Un archivo
+        que el navegador no sabe ni leer ni reproducir, que en la práctica
+        significa AVI, WMV, FLV y casi todos los MKV, se rechaza con un mensaje
+        que lo dice, en vez de fallar a mitad de camino."""
+
+[[faq]]
+q = "¿Por qué mi GIF es tan grande?"
+a = """
+        Porque GIF es un formato de 1987 que guarda imágenes enteras y no
+        movimiento. No hay forma de hacer uno de un clip de cinco segundos que sea
+        tan pequeño como el MP4 de cinco segundos del que salió &mdash; un GIF de
+        un vídeo suele ser diez veces el tamaño del vídeo. Los tres ajustes que lo
+        deciden de verdad son, por orden: cuánto dura el trozo, cuánto mide de
+        ancho la imagen y cuántos fotogramas por segundo. Reducir el ancho a la
+        mitad deja los píxeles en la cuarta parte, y lo que cuesta son los
+        píxeles."""
+
+[[faq]]
+q = "¿Por qué solo 256 colores?"
+a = """
+        Porque es el formato: un GIF lleva una tabla de 256 colores como mucho y
+        guarda cada píxel como un número dentro de ella. Esta herramienta elige
+        esos 256 contando los colores de todos los fotogramas de tu trozo y
+        repartiéndolos en 256 grupos &mdash; corte por la mediana, el método
+        estándar &mdash;, así que la paleta se ajusta a tu clip en vez de ser un
+        conjunto fijo de colores. Donde falta un color, el tramado mezcla los dos
+        más cercanos para que un degradado siga siendo un degradado en lugar de
+        convertirse en franjas."""
+
+[[faq]]
+q = "¿Qué hace el ajuste de tramado?"
+a = """
+        Cambia un poco de ruido por mucho menos bandeado. Con él activado, un
+        cielo que si no se convertiría en cuatro franjas planas sigue siendo un
+        degradado, a costa de una textura tenue y de un archivo más grande.
+        Desactivado, la imagen queda más plana y el archivo más pequeño, lo que le
+        va bien a las grabaciones de pantalla, al dibujo de línea y a cualquier
+        cosa hecha ya de color plano. El tramado que se usa aquí es ordenado y no
+        del tipo de difusión de error, así que un fondo que no cambia se queda
+        perfectamente quieto entre fotogramas en vez de temblar."""
+
+[[faq]]
+q = "¿Hay algún límite de duración o de tamaño?"
+a = """
+        Lo que está limitado es el trozo, y por la memoria más que por una regla:
+        todos sus fotogramas se sostienen a la vez mientras se elige la paleta, así
+        que la página calcula lo que costarían tus ajustes y lo dice antes de que
+        empieces. Se niega en vez de dejar que la pestaña se quede sin memoria y
+        desaparezca. Un trozo más corto, un ancho menor o una cadencia más baja lo
+        bajan todos."""
+
+[[faq]]
+q = "¿Conserva el sonido?"
+a = """
+        Un GIF no puede llevar sonido. No existe ninguna versión del formato que
+        tenga audio, que es la razón principal por la que la web sustituyó casi
+        del todo los GIF por vídeo mudo en bucle. Si el sonido importa, quédate
+        con el vídeo &mdash; el <a href="../cortar-video/">cortador de vídeo</a>
+        te saca un trozo sin recodificar ni un fotograma."""
+
+[[faq]]
+q = "¿Es gratis? ¿Necesito una cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni inicio de sesión, ni prueba, ni marca de
+        agua. El sitio lleva publicidad, que es lo que lo paga; a los anuncios no
+        se les da nada sobre tu vídeo."""
+
+[schema]
+browser_requirements = "Necesita JavaScript. MP4 y MOV requieren un navegador con WebCodecs; cualquier cosa que el navegador sepa reproducir funciona sin ello."
+description = "Convierte un trozo de vídeo en un GIF animado, en el navegador. Los fotogramas se muestrean a la cadencia elegida, se escoge una única paleta de 256 colores para toda la animación por corte de la mediana, y de cada fotograma se escribe solo la zona que ha cambiado. No se sube nada."
+features = [
+  "Convierte vídeo MP4, MOV, M4V y WebM en GIF animado",
+  "Fuentes H.264, HEVC, AV1 y VP9, descodificadas mediante WebCodecs",
+  "Marca el trozo en una línea de tiempo, o escribe tiempos exactos",
+  "Cualquier ancho, de 5 a 25 fotogramas por segundo, tramado ordenado opcional",
+  "Funciona sin conexión; sin subidas, sin cuenta y sin marca de agua",
+]
+
+[picker]
+title = "Suelta aquí un vídeo"
+hint = "o haz clic para buscarlo &mdash; MP4, MOV, M4V, WebM y cualquier otra cosa que este navegador reproduzca"


### PR DESCRIPTION
**Stacked on #48. Merge that first.** This branch is cut from `claude/website-i18n-translations` and its base is `a52e05f`; the diff against `main` will look much larger than it is until #48 lands.

`locales/es/` was a frame with nine slugs and the site's own words in it. It is now a finished locale: `python build.py` no longer lists Spanish among the languages with strings falling back, and `complete = true`, so from here a missing key fails the build and Spanish is advertised in the sitemap, the hreflang tags and the switcher.

## What is covered

* **All fifteen tools** — `tool.toml` and `body.html` each.
* **All thirteen guides**, plus **privacy** and **terms**.
* **`planned.toml`**, the roadmap list, merged entry for entry against the English.
* **`locale.toml`** — eight new slugs, and two fixes described below.

66 files under `locales/es/`, and nothing outside it.

## Register

`locale.toml` had already settled this and the rest follows it: **tú**, not usted, and neutral pan-regional vocabulary — `dispositivo` rather than picking a side between *ordenador* and *computadora*, `vídeo` with the accent, `PPP` for DPI, decimal commas in prose. English `&ldquo;…&rdquo;` becomes `«…»` throughout, matching what the frame already did.

The developer comments inside each `body.html` — the one about `display:none` file inputs, the one about the crop stage — are left in English, as they are in `locales/de/`. They explain a decision to whoever edits the markup and are not words a reader ever sees.

## The slugs, and why these words

Slugs are the one structural thing a locale gets to change, so they are chosen as the phrase a Spanish speaker would type into a search box rather than as a translation of the English name.

| English | Spanish | why |
|---|---|---|
| `image-to-ico` | `crear-favicon` | Named for the job. Almost nobody searches for "imagen a ICO"; a great many people search for how to make a favicon. Same reasoning German used for `favicon-erstellen`. |
| `svg-to-image` | `convertir-svg-a-png` | PNG is the output people actually want and the word they type. |
| `heic-to-jpg` | `convertir-heic-a-jpg` | "convertir heic a jpg" is the search almost verbatim. |
| `image-to-data-uri` | `imagen-a-base64` | *base64* is the word people reach for; *data URI* is the term they learn afterwards. |
| `qr-barcode` | `generar-codigo-qr` | The QR half is what carries the search volume; the barcode half is discoverable from the page. |
| `video-to-gif` | `convertir-video-a-gif` | Ditto, near-verbatim. |
| `guides/make-a-favicon` | `guias/como-hacer-un-favicon` | The guide is the question, so it keeps the "cómo". Kept distinct from the tool's `crear-favicon`. |
| `guides/convert-an-svg-to-png` | `guias/convertir-un-svg-a-png` | The article keeps it apart from the tool slug. |
| `guides/convert-heic-to-jpg` | `guias/convertir-heic-a-jpg` | |
| `guides/embed-an-image-in-css` | `guias/incrustar-una-imagen-en-css` | |
| `guides/make-a-qr-code` | `guias/como-hacer-un-codigo-qr` | |
| `guides/turn-a-video-into-a-gif` | `guias/convertir-un-video-en-gif` | |

No accents and no eñe, per the note already in the file. Every cross-link inside a Spanish body points at the Spanish address, which is what the link check that `complete = true` turns on is there to catch.

## Two fixes the completeness check caught

**The fourth hub category was in `locale.toml` twice** — once from the frame catch-up in `a52e05f` and once from this branch, which had added it before that landed. One copy stays, in the tú register the rest of the file uses: `Códigos y datos` / "Convierte lo que escribes en algo que una máquina puede leer, sin que salga de la página."

**`[ui.picker].note` formed its plural the English way.** The English is `its {{ tool.picker.urls.noun }}s` — append an `s`. With the Spanish noun `imagen` that renders **"imagens"**. The sentence is written around the singular now: "el uso entre orígenes de sus archivos de {{ … }}". The noun itself is `imagen`, feminine singular, which is what the `warning` string beside it was already written around ("La {{ noun }} se copia a la memoria local").

## Verification

* `python build.py --clean --out dist-check` — exit 0, Spanish absent from the "still in English" list.
* `python -m unittest discover -s tests/python -t .` — **305 passed** (304 in the brief; the base gained one).
* Tag-for-tag structural diff of all 32 translated `body.html` files against their English sources: **0 mismatches**. Same check over `id`, `class`, `data-*`, `for`, `type`, `min`/`max`/`step`: one intentional difference, the default PDF filename `images` → `imagenes`, which is what `locales/de/` does too (`bilder`).
* Zero cross-links left pointing at an English slug.
* `git status` clean apart from `locales/es/`; `dist-check` removed.

## Calls I would like a second opinion on

* **`crear-favicon` for the tool and `guias/como-hacer-un-favicon` for its guide.** Both are good Spanish and they are distinct addresses, but they compete for the same query. The alternative was `imagen-a-ico` for the tool, which is honest about what it does and is not what anybody searches for.
* **`generar-codigo-qr`** hides the barcode half of the tool in the URL. I think that is the right trade — the QR side is overwhelmingly the search — but it is a trade.
* **`vídeo` with the accent in prose, `video` unaccented in slugs.** Correct on both counts, and it does mean `cortar-video` sits under a page headed "Cortar vídeo". German has the same shape with its umlauts (`bildgroesse-aendern`), so I kept it.
* **"tramado" for dithering** and **"módulos"** for QR modules are the standard terms, but they are technical enough that a native reviewer may prefer a gloss on first use.
* **`«Buy me a coffee»`** is left in English throughout, because that is the name printed on the button.

## Things I found but did not touch

* **`locales/de/planned.toml` is stale.** It still carries "Video zu GIF" and "QR- &amp; Barcodes" as planned items; both shipped, and the English list no longer has them. German is `complete = false` right now so it does not fail the build, but it will the moment that flag is turned back. `locales/de/` also has no translations for the four tools and four guides that landed after it was finished. Out of scope here, and I understand it is being handled.
* The eight other framed locales are in the same position: frames only, `complete = false`, 1360 strings each.
