### PR TITLE
Translate the site into Portuguese

### DIFF
--- a/locales/pt/locale.toml
+++ b/locales/pt/locale.toml
@@ -16,7 +16,11 @@ name = "Portuguese (Brazil)"
 endonym = "Português"
 hreflang = "pt-BR"
 
-complete = false
+# Finished: every tool, every guide, the roadmap list and the two legal
+# pages. From here a missing key is a build failure rather than a silent
+# fallback to English, and the link check runs over the Portuguese slugs -
+# see check_complete in buildlib/i18n.py.
+complete = true
 
 #
 # ---------------------------------------------------------------------------
@@ -32,10 +36,25 @@ complete = false
 "edit-audio" = "editar-audio"
 # Quase ninguém procura um "editor EXIF"; procura-se como tirar os dados de uma foto.
 "exif-editor" = "remover-dados-exif"
+# Quem quer isto quase nunca digita "HEIC": digita o que quer no fim, que é um
+# JPG que todo mundo abre. O nome do formato fica, porque é ele que está no
+# arquivo que a pessoa acabou de tirar do iPhone.
+"heic-to-jpg" = "heic-para-jpg"
+# "Data URI" é jargão; "base64" é o que se digita na busca e o que aparece na
+# linha do CSS que a pessoa quer colar.
+"image-to-data-uri" = "imagem-para-base64"
+# Pelo trabalho, não pelo formato: ninguém procura "imagem para ICO", e muita
+# gente procura como fazer um favicon.
+"image-to-ico" = "criar-favicon"
 "images-to-pdf" = "imagens-para-pdf"
 "images-to-video" = "imagens-para-video"
+# No Brasil se fala "gerar um QR Code", não "criar" nem "fazer". O código de
+# barras fica de fora do endereço: é a metade menos procurada das duas.
+"qr-barcode" = "gerar-qr-code"
 "resize-image" = "redimensionar-imagem"
+"svg-to-image" = "svg-para-png"
 "trim-video" = "aparar-video"
+"video-to-gif" = "video-para-gif"
 
 "guides" = "guias"
 "roadmap" = "roteiro"
@@ -51,6 +70,12 @@ complete = false
 "guides/trim-a-video" = "guias/aparar-um-video"
 "guides/crop-a-video" = "guias/cortar-um-video"
 "guides/is-it-safe-to-upload-files" = "guias/e-seguro-enviar-arquivos"
+"guides/make-a-favicon" = "guias/criar-um-favicon"
+"guides/convert-an-svg-to-png" = "guias/converter-svg-para-png"
+"guides/convert-heic-to-jpg" = "guias/converter-heic-para-jpg"
+"guides/embed-an-image-in-css" = "guias/colocar-uma-imagem-no-css"
+"guides/make-a-qr-code" = "guias/gerar-um-qr-code"
+"guides/turn-a-video-into-a-gif" = "guias/transformar-um-video-em-gif"
 
 #
 # ---------------------------------------------------------------------------
@@ -122,7 +147,7 @@ note = "Crie e reorganize documentos sem mandá-los para serem processados fora.
 
 [[hub.categories]]
 name = "Códigos e dados"
-note = "Transformar o que você digitou em algo que uma máquina consegue ler, sem que saia da página."
+note = "Transforme o que você digitou em algo que uma máquina consegue ler, sem que isso saia da página."
 
 [[hub.categories]]
 name = "Texto e código"
@@ -147,7 +172,6 @@ lede = """
 og_title = "Guias do abox.tools"
 og_description = "Como comprimir, redimensionar, cortar, aparar e converter seus arquivos, e o que cada ajuste custa. Sem envio nenhum."
 og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"
-
 
 [[guides.groups]]
 name = "Fazendo o trabalho"
@@ -290,8 +314,13 @@ questions_heading = "Perguntas"
 guide_heading = "A versão longa"
 privacy_heading = "Como a promessa de privacidade se verifica"
 
+# O inglês escreve "Your {{ plural }} are never uploaded", e o particípio
+# concorda em gênero: "enviadas" para imagens e fotos, "enviados" para vídeos
+# e documentos. Como o substantivo vem de cada ferramenta, nenhuma das duas
+# formas serve para todas - então a frase foi reescrita em volta de um verbo
+# que não concorda com nada.
 pledge_line = """
-    Suas {{ tool.words.plural }} <strong>nunca são enviadas</strong>. Não existe servidor."""
+    <strong>Nada sai daqui</strong> &mdash; nem {{ tool.words.plural }}. Não existe servidor."""
 
 boot_title = "O código desta página não iniciou."
 boot_body = """
@@ -317,14 +346,20 @@ read_first_lead = """
 [ui.guide]
 open_tool = "Abrir {{ tool.name | e }}"
 
+# O inglês faz o plural aqui grudando um "s" no substantivo - "its
+# {{ noun }}s" - e isso só funciona em inglês: o plural de "imagem" é
+# "imagens". As duas frases abaixo usam o substantivo apenas onde ele não
+# obriga concordância nenhuma: depois de "qual" e depois de "cada", que são
+# invariáveis em gênero e em número. Assim o próximo tool que ganhar um
+# [picker.urls] pode nomear o que quiser sem quebrar a gramática.
 [ui.picker]
 warning = """
       <strong>Esta é a única função que encosta na rede.</strong>
       Buscar um endereço informa àquele servidor o seu IP e qual {{ tool.picker.urls.noun }} você
-      pediu. A {{ tool.picker.urls.noun }} é copiada para a memória local ao chegar e nunca mais é
-      pedida de novo. Nada seu jamais sai &mdash; esta página continua incapaz
+      pediu. O que chega é copiado para a memória local na hora e nunca mais é
+      pedido de novo. Nada seu jamais sai &mdash; esta página continua incapaz
       de fazer qualquer envio."""
 label = "Um endereço por linha"
 note = """
-      O servidor precisa permitir o uso entre origens das suas {{ tool.picker.urls.noun }}s. Muitos sites não
+      O servidor precisa permitir o uso entre origens de cada {{ tool.picker.urls.noun }}. Muitos sites não
       permitem, e esses vão falhar com uma mensagem em vez de quebrar em silêncio mais tarde."""

--- a/locales/pt/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/pt/pages/guides/combine-images-into-a-pdf.html
@@ -1,0 +1,205 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../imagens-para-pdf/">Imagens para PDF</a>, jogue as
+      imagens dentro, arraste os quadradinhos até a ordem ficar certa e crie o
+      documento. Os padrões &mdash; páginas A4, uma margem pequena, fotografias
+      copiadas sem recodificação &mdash; são o que a maioria das pessoas quer.
+    </p>
+    <p>
+      As quatro coisas que merecem uma segunda olhada são a ordem, o tamanho da
+      página, o ajuste de qualidade e o que o documento pronto conta sobre você.
+      Nessa ordem de frequência com que dão errado.
+    </p>
+  </section>
+
+  <section>
+    <h2>Acerte a ordem antes de qualquer outra coisa</h2>
+    <p>
+      A ordem das páginas é de longe o que mais sai errado, porque nomes de
+      arquivo se ordenam de um jeito que ninguém espera. <code>IMG_2.jpg</code>
+      vem depois de <code>IMG_10.jpg</code> numa ordenação alfabética, já que a
+      comparação é caractere por caractere e <code>1</code> vem antes de
+      <code>2</code>. Uma pasta de escaneamentos chamados <code>page1</code> a
+      <code>page12</code> vai chegar na ordem errada em quase qualquer
+      ferramenta.
+    </p>
+    <p>
+      Ordenar pela data em que a foto foi tirada costuma ser mais confiável para
+      fotografias, porque você fotografou as páginas na ordem em que elas
+      estavam. De todo jeito, confira os quadradinhos antes de apertar o botão,
+      em vez de conferir o PDF depois.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qualidade: a parte que a maioria das ferramentas erra em silêncio</h2>
+    <p>
+      Um PDF consegue carregar dados JPEG diretamente. Isso é uma propriedade do
+      formato: os bytes comprimidos de um JPEG podem ser jogados dentro do
+      documento como estão, e o leitor os decodifica do mesmo jeito que um
+      navegador faria.
+    </p>
+    <p>
+      Isso importa porque significa que uma fotografia não precisa perder nada
+      no caminho para dentro de um PDF. Ela nunca é decodificada e nunca é
+      comprimida de novo; a imagem no documento é bit a bit a imagem do seu
+      arquivo. Muitas ferramentas recodificam mesmo assim &mdash; é mais simples
+      desenhar tudo num canvas e codificar de forma uniforme &mdash; e o
+      resultado é uma geração de qualidade perdida sem motivo.
+    </p>
+    <p>
+      Outros formatos não conseguem pegar essa carona. PNG, WebP, HEIC e os
+      demais não têm filtro correspondente no PDF, então precisam ser
+      convertidos. Você escolhe como:
+    </p>
+    <ul>
+      <li>
+        <strong>Recodificar como JPEG</strong> (o padrão). Arquivo menor, um
+        pequeno custo de qualidade, e a resposta certa para fotografias.
+      </li>
+      <li>
+        <strong>Sem perdas.</strong> Guarda os pixels exatos ao custo de um
+        documento bem maior. É a resposta certa para capturas de tela, diagramas
+        e qualquer coisa com texto ou bordas nítidas, onde os artefatos de JPEG
+        são evidentes.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Tamanho da página, e quando &ldquo;caber na imagem&rdquo; é melhor</h2>
+    <p>
+      Um tamanho de página padrão &mdash; A4, Carta, Ofício, A3, A5, Tabloide
+      &mdash; coloca cada imagem numa página daquele tamanho, escalada para
+      caber dentro da sua margem. Use um deles quando o documento for impresso,
+      ou quando alguém oficial for arquivá-lo.
+    </p>
+    <p>
+      &ldquo;Exatamente do tamanho de cada imagem&rdquo; faz cada página bater
+      com a imagem dela, então não sobra espaço branco e não há escala nenhuma.
+      Use quando o PDF for um contêiner de imagens em vez de um documento: um
+      portfólio, um conjunto de capturas de tela, uma história em quadrinhos.
+      Fica errado impresso, porque cada página tem um tamanho.
+    </p>
+    <p>
+      Vale ter margem em qualquer coisa que vá ser impressa. Impressoras
+      domésticas não conseguem imprimir até a borda do papel, e uma fotografia
+      colocada de ponta a ponta sai cortada.
+    </p>
+    <h3>Páginas em pé a partir de fotos deitadas</h3>
+    <p>
+      Se você fotografou folhas de papel com o celular deitado, toda imagem vai
+      estar deitada e vai ficar pequenininha no meio de uma página em pé. Girar
+      cada uma um quarto de volta antes de montar o documento é o que conserta,
+      e é uma escolha por imagem, e não geral, porque em geral algumas delas
+      entraram no sentido certo.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que o PDF pronto conta sobre você</h2>
+    <p>
+      Um PDF carrega um bloco de informações do documento: autor, produtor, data
+      de criação, às vezes o título. Dependendo do que o escreveu, isso pode
+      incluir o nome da sua conta, o nome da sua máquina e a hora exata em que
+      você o fez.
+    </p>
+    <p>
+      Vale pensar nisso, porque um PDF é uma coisa que as pessoas mandam para
+      outras pessoas &mdash; uma candidatura a vaga, um pedido de indenização,
+      um documento para o dono do imóvel. Os metadados viajam junto e qualquer
+      leitor consegue exibi-los.
+    </p>
+    <p>
+      A ferramenta daqui deixa esse bloco vazio, exceto pelo próprio nome dela:
+      nenhum nome de arquivo, nenhum nome de máquina, nenhum nome de usuário e
+      nenhuma data de criação, a não ser que você marque a caixa pedindo uma. Se
+      você usa outra ferramenta, vale abrir as propriedades do resultado uma vez
+      para ver o que ela escreveu.
+    </p>
+    <p>
+      À parte disso: as imagens em si. Se as suas fotografias carregam etiquetas
+      EXIF e de GPS, o que acontece com elas depende do caminho. Um JPEG copiado
+      sem recodificação mantém o que tinha dentro; uma imagem que é recodificada
+      perde as etiquetas como efeito colateral. Se isso importa, limpe as fotos
+      antes com o
+      <a href="../../remover-dados-exif/">Visualizador e removedor de EXIF</a>
+      &mdash; <a href="../remover-dados-exif-e-gps/">o guia dele</a> explica o
+      que tem lá dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Se o PDF sair grande demais</h2>
+    <p>
+      Fotos de celular são grandes, e vinte delas fazem um documento que o
+      e-mail vai recusar. Três coisas para tentar, nesta ordem:
+    </p>
+    <p>
+      <strong>Diminua o lado maior.</strong> Uma fotografia de 4000 pixels de
+      uma folha de papel carrega muito mais detalhe do que qualquer leitor ou
+      impressora vai usar. Baixar o lado maior para algo como 2000 pixels
+      normalmente reduz o arquivo a um quarto e não muda nada que alguém consiga
+      ver numa página.
+    </p>
+    <p>
+      <strong>Use JPEG em vez de sem perdas</strong> para qualquer coisa
+      fotográfica. Sem perdas é a resposta certa para diagramas e a errada para a
+      foto de uma página.
+    </p>
+    <p>
+      <strong>Comprima o documento pronto.</strong> O
+      <a href="../../comprimir-pdf/">Compressor de PDF</a> trabalha em cima do
+      tamanho em que cada imagem é desenhada na página, e não da contagem de
+      pixels dela, que é a medida que importa;
+      <a href="../deixar-um-pdf-menor/">o guia dele</a> trata do que isso custa.
+    </p>
+    <p>
+      Não há limite embutido na ferramenta para quantas imagens você pode usar.
+      O teto prático é a memória da sua própria máquina, porque o documento
+      pronto é montado ali antes de você baixá-lo &mdash; algumas centenas de
+      fotos de celular em resolução cheia são a primeira coisa a sentir isso, e
+      diminuir o lado maior empurra esse teto para bem longe.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que isto não vai lhe dar</h2>
+    <p>
+      Um PDF feito de fotografias é um PDF cheio de imagens. As palavras dentro
+      dele não são texto: você não consegue pesquisar, copiar nem fazer um
+      leitor de tela ler. Isso é uma propriedade daquilo de onde você partiu, e
+      não da conversão.
+    </p>
+    <p>
+      Se você precisa de texto pesquisável, precisa de OCR, que é outro
+      trabalho. E se o documento original ainda existe como documento em algum
+      lugar, exportar aquilo direto para PDF sempre vai ganhar de fotografá-lo
+      &mdash; menor, mais nítido, pesquisável.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que isso não precisa de envio</h2>
+    <p>
+      Escrever um PDF é escrever um arquivo estruturado: um cabeçalho, um
+      conjunto de objetos, uma tabela de referências cruzadas. Não há nada nisso
+      que um navegador não consiga fazer, e nada no trabalho que exija que as
+      imagens viajem para lugar nenhum.
+    </p>
+    <p>
+      O que vale se importar aqui, por causa do que as pessoas colocam nesses
+      documentos. Documentos de identidade, extratos bancários, laudos médicos,
+      contratos assinados &mdash; o motivo inteiro de alguém estar fazendo um
+      PDF costuma ser que vai mandá-lo a uma instituição. A ferramenta daqui não
+      tem função de rede de espécie alguma, e a
+      <code>Content-Security-Policy</code> da página nomeia todos os endereços
+      que ela pode contatar, nenhum dos quais é deste site.
+    </p>
+    <p>
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> mostra como conferir isso você mesmo, aqui ou em
+      qualquer outro lugar.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/pt/pages/guides/combine-images-into-a-pdf.toml
@@ -1,0 +1,17 @@
+#
+# Guia: juntar imagens em um PDF - português do Brasil.
+#
+
+nav = "Imagens em um PDF"
+title = "Como juntar imagens em um único PDF"
+description = "Transforme fotos ou escaneamentos num só PDF: tamanho de página, ordem e rotação, por que um JPEG não precisa perder qualidade na entrada e o que um PDF conta para quem o recebe."
+heading = "Como juntar imagens em um único PDF"
+lede = """
+    Alguém pediu &ldquo;um PDF só&rdquo; e você tem onze fotografias de papel.
+    Isto cobre as escolhas que de fato mudam o resultado &mdash; tamanho de
+    página, ordem, qualidade e o que o documento conta sobre você &mdash; e
+    quais delas dá para ignorar."""
+updated = "20 de agosto de 2026"
+og_title = "Como juntar imagens em um único PDF"
+og_description = "Tamanho de página, ordem e rotação, por que um JPEG não precisa perder qualidade na entrada e o que um PDF conta para quem o recebe."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/pt/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,0 +1,247 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../comprimir-imagem/">Compressor de imagens</a>, jogue
+      a foto dentro, digite o número que lhe deram e aperte o botão. Ele
+      codifica a imagem várias vezes, fica com o melhor resultado que cabe
+      abaixo do seu alvo e diz quanto isso custou. Para a maioria das
+      fotografias e a maioria dos alvos, o resumo honesto é que você não vai
+      conseguir ver diferença.
+    </p>
+    <p>
+      O resto desta página é para quando não é isso que acontece: quando o
+      resultado sai borrado, quando um PNG quase não se mexe, ou quando você
+      quer saber o que a ferramenta está de fato fazendo com a sua imagem antes
+      de mandá-la para alguém.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que um limite de tamanho está realmente pedindo</h2>
+    <p>
+      Um JPEG ou um WebP não guarda a sua fotografia. Guarda uma descrição dela,
+      e o ajuste de qualidade decide o quanto essa descrição pode ser detalhada.
+      Abaixe o ajuste e o arquivo diminui porque a descrição fica mais vaga:
+      texturas finas viram média, gradientes ganham faixas e as bordas pegam uma
+      leve auréola de blocos.
+    </p>
+    <p>
+      Ou seja, um limite de tamanho é um orçamento de detalhe. A pergunta útil
+      não é &ldquo;consigo chegar a 500&nbsp;KB?&rdquo; &mdash; você sempre
+      consegue chegar a qualquer número &mdash; e sim &ldquo;quanto da imagem
+      preciso entregar para chegar lá, e isso importa para o que vou fazer com
+      ela?&rdquo;
+    </p>
+    <p>
+      Duas regras de bolso. Uma fotografia de uma cena real &mdash; rostos,
+      folhagem, tecido &mdash; esconde bem a compressão, porque o olho não tem
+      nenhuma área perfeitamente lisa onde perceber o estrago. Uma captura de
+      tela, um gráfico, uma logomarca ou qualquer coisa com grandes áreas de cor
+      chapada e bordas duras de texto mostra o estrago na hora, e em geral
+      deveria ser um PNG ou um WebP, e não um JPEG.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que não existe fórmula, e o que fazer a respeito</h2>
+    <p>
+      Não há como calcular o ajuste de qualidade que produz um arquivo de
+      500&nbsp;KB. A relação entre os dois depende inteiramente do que está na
+      imagem: no mesmo ajuste, a foto de uma parede lisa pode sair com um décimo
+      do tamanho da foto de uma floresta. Toda ferramenta que lhe oferece
+      &ldquo;qualidade: 60&rdquo; e torce está chutando no seu lugar.
+    </p>
+    <p>
+      O único método confiável é tentar. Codificar a imagem, olhar o tamanho,
+      ajustar, codificar de novo. Fazer isso na mão é chato, e é por isso que os
+      compressores pedem um número de qualidade &mdash; assim a chatice passa a
+      ser sua. Fazer automaticamente dá umas oito codificações, e oito
+      codificações de uma foto de celular são uma fração de segundo em qualquer
+      máquina feita nesta década. Por isso a ferramenta deste site pede o
+      tamanho e faz a busca sozinha.
+    </p>
+    <p>
+      Todo tamanho que ela informa é um arquivo codificado de verdade, não uma
+      estimativa. Isso importa quando o formulário tem um limite rígido: uma
+      estimativa 2% otimista é um envio recusado.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gaste qualidade antes de gastar pixels</h2>
+    <p>
+      Só existem dois jeitos de deixar um arquivo de imagem menor. Você pode
+      descrever a mesma imagem com menos precisão, que é qualidade. Ou pode
+      descrever menos pixels, que é redimensionar. Não são equivalentes, e a
+      ordem importa.
+    </p>
+    <p>
+      Qualidade vem primeiro, porque os primeiros 30% mais ou menos de redução
+      de qualidade são genuinamente invisíveis numa fotografia &mdash; você está
+      jogando fora detalhe que o formato guardava com mais cuidado do que
+      qualquer olho consegue conferir. Pixels vêm depois, porque assim que a
+      qualidade cai o bastante para os artefatos aparecerem, uma imagem menor com
+      qualidade decente fica melhor do que uma imagem em tamanho cheio que foi
+      arruinada. Menos pixels bons ganham de mais pixels ruins.
+    </p>
+    <p>
+      Essa é a estratégia inteira, e vale saber mesmo que você use outra
+      ferramenta: baixe a qualidade até começar a ficar errado e então diminua a
+      imagem, em vez de baixar mais ainda.
+    </p>
+    <h3>Quando redimensionar de propósito</h3>
+    <p>
+      Às vezes os pixels nunca foram necessários. Uma foto de 4000 pixels de
+      largura exibida numa coluna de 600 pixels numa página web carrega seis
+      vezes o detalhe que alguém vai ver. Se você sabe onde a imagem vai morar,
+      redimensione para lá primeiro e o problema de tamanho muitas vezes some
+      sem gastar qualidade nenhuma. O
+      <a href="../../redimensionar-imagem/">Redimensionador de imagens</a> é a
+      ferramenta para esse trabalho, e
+      <a href="../redimensionar-uma-imagem/">o guia dele</a> trata de escolher
+      um tamanho.
+    </p>
+  </section>
+
+  <section>
+    <h2>Escolhendo um formato</h2>
+    <p>
+      Três formatos valem a pena conhecer, e o navegador sabe escrever os três.
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG</strong> é para fotografias. É com perdas, é entendido por
+        tudo o que já foi fabricado, e para uma imagem de cena real continua
+        sendo uma excelente escolha. Não guarda transparência.
+      </li>
+      <li>
+        <strong>WebP</strong> é para o mesmo trabalho, feito melhor: uns
+        25&ndash;35% menor que o JPEG numa qualidade que você não distingue, e
+        mantém a transparência. Todo navegador atual lê. Alguns programas de
+        computador mais antigos e alguns formulários de envio corporativos ainda
+        não leem, e esse é o único motivo real para não usar.
+      </li>
+      <li>
+        <strong>PNG</strong> é sem perdas, o que significa que é exato e é
+        grande. É a resposta certa para capturas de tela, logomarcas, desenho de
+        traço e qualquer coisa com bordas nítidas ou cor chapada, e a resposta
+        errada para uma fotografia.
+      </li>
+    </ul>
+    <p>
+      Se quem pediu o arquivo não lhe impôs restrição, o WebP leva você até o
+      alvo com menos estrago visível que o JPEG. Se o arquivo vai entrar em algo
+      antigo, ou num sistema que você não tem como testar, o JPEG é a resposta
+      segura.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que o seu PNG não vai ficar muito menor</h2>
+    <p>
+      Esta é a surpresa mais comum, e não é um defeito da ferramenta que você
+      está usando. PNG é um formato sem perdas: ele guarda os pixels exatos e
+      não tem botão de qualidade para girar, porque girar um faria dele outro
+      formato. Tudo o que um compressor de PNG pode fazer é empacotar os mesmos
+      pixels de forma mais esperta, o que costuma render alguns por cento.
+    </p>
+    <p>
+      Então, se você precisa de um arquivo bem menor e ele tem que continuar
+      PNG, a única alavanca que sobra é o tamanho &mdash; menos pixels, ou menos
+      cores. Se ele pode deixar de ser PNG, a pergunta é o que tem dentro:
+    </p>
+    <ul>
+      <li>
+        <strong>Uma fotografia salva como PNG.</strong> Muito comum, quase
+        sempre por acidente, e a vitória mais fácil desta página: converter para
+        JPEG ou WebP costuma deixar o arquivo de cinco a dez vezes menor sem
+        mudança visível.
+      </li>
+      <li>
+        <strong>Uma captura de tela ou um diagrama.</strong> Converta para WebP,
+        que também é sem perdas quando você pede, e em geral é menor que o PNG
+        para os mesmos pixels. Ir para JPEG deixa as bordas do texto borradas.
+      </li>
+      <li>
+        <strong>Uma logomarca com transparência.</strong> O WebP mantém a
+        transparência; o JPEG vai preenchê-la com uma cor sólida, o que quase
+        nunca é o que você queria.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Como saber se o resultado está bom o bastante</h2>
+    <p>
+      Olhar a miniatura não prova nada &mdash; em tamanho de miniatura tudo
+      parece ótimo. Duas verificações melhores:
+    </p>
+    <p>
+      <strong>Olhe em tamanho cheio, na coisa mais lisa do quadro.</strong> Céu,
+      pele, uma parede pintada. O estrago da compressão aparece primeiro em
+      gradientes suaves, como blocos ou faixas de leve, muito antes de encostar
+      nas áreas detalhadas.
+    </p>
+    <p>
+      <strong>Leia a medição, se a ferramenta lhe der uma.</strong> O compressor
+      daqui decodifica o próprio resultado, compara com o original e informa o
+      SSIM: um número que compara brilho, contraste e estrutura locais em vez de
+      contar pixels alterados, o que é bem mais próximo daquilo que incomoda um
+      olho. Acima de mais ou menos 0,98 as duas imagens são difíceis de separar
+      lado a lado. Abaixo de uns 0,95, olhe antes de mandar. Ele também informa
+      o PSNR, a tradicional medida em decibéis, para quem preferir.
+    </p>
+    <p>
+      Os dois são calculados na sua própria máquina e mostrados a você, e é esse
+      o motivo de existirem: transformam &ldquo;perda mínima de qualidade&rdquo;
+      de uma afirmação num número que você pode conferir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Três coisas que vale saber antes de mandar o arquivo</h2>
+    <p>
+      <strong>Comprimir apaga os metadados.</strong> Recodificar significa
+      decodificar a imagem em pixels e codificar esses pixels de novo, e um
+      canvas cheio de pixels não carrega etiqueta nenhuma &mdash; então a
+      posição de GPS, o modelo da câmera, os horários e o resto simplesmente não
+      são escritos no arquivo novo. Em geral isso é um bônus. Se você queria as
+      etiquetas fora mas a imagem intacta, esse é outro trabalho: o
+      <a href="../../remover-dados-exif/">Visualizador e removedor de EXIF</a>
+      reescreve o contêiner sem recomprimir nada, e
+      <a href="../remover-dados-exif-e-gps/">o guia dele</a> explica o que tem
+      lá dentro.
+    </p>
+    <p>
+      <strong>Nunca comprima o mesmo arquivo duas vezes.</strong> Cada
+      codificação com perdas joga detalhe fora em definitivo, e codificar uma
+      imagem já comprimida joga fora mais ainda &mdash; inclusive preservando
+      fielmente os artefatos da primeira passada, às custas de detalhe de
+      verdade. Volte sempre ao original e comprima uma vez só.
+    </p>
+    <p>
+      <strong>Guarde o original.</strong> Não existe volta de uma codificação
+      com perdas. Seja lá o que você mandar, guarde em algum lugar o arquivo de
+      onde partiu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada disso precisa de envio</h2>
+    <p>
+      Todo navegador já vem há anos com um codificador de JPEG, PNG e WebP
+      &mdash; é o mesmo código que salva uma imagem a partir de um canvas.
+      Comprimir uma imagem é um dos trabalhos que não tem motivo técnico nenhum
+      para envolver um servidor, e é por isso que a ferramenta daqui não tem
+      um: a imagem é decodificada, codificada e medida na sua própria máquina, e
+      não existe na <code>Content-Security-Policy</code> da página nenhum
+      endereço deste site para onde ela pudesse ser mandada.
+    </p>
+    <p>
+      O jeito mais simples de confirmar isso, aqui ou em qualquer outro lugar, é
+      carregar a página, desconectar da internet e comprimir alguma coisa mesmo
+      assim. Se continuar funcionando, nada estava sendo enviado.
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta mais três verificações do mesmo tipo.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/pt/pages/guides/compress-an-image-to-a-target-size.toml
@@ -1,0 +1,17 @@
+#
+# Guia: comprimir uma imagem para um tamanho exato - português do Brasil.
+#
+
+nav = "Comprimir uma imagem"
+title = "Como comprimir uma imagem para um tamanho de arquivo exato"
+description = "O formulário quer 500 KB e sua foto tem 4 MB. O que um limite de tamanho custa de verdade, qual ajuste mexer primeiro e por que um PNG não encolhe como um JPEG."
+heading = "Como comprimir uma imagem para um tamanho de arquivo exato"
+lede = """
+    Alguém lhe deu um número &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
+    &mdash; e sua foto está longe dele. Aqui está o que esse número custa, em
+    que gastá-lo e como saber se o resultado ainda está bom o bastante para
+    mandar."""
+updated = "20 de agosto de 2026"
+og_title = "Comprimir uma imagem para um tamanho de arquivo exato"
+og_description = "O que um limite de tamanho custa de verdade, qual ajuste mexer primeiro e por que um PNG não encolhe como um JPEG."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/convert-an-svg-to-png.html
+++ b/locales/pt/pages/guides/convert-an-svg-to-png.html
@@ -1,0 +1,239 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../svg-para-png/">SVG para imagem</a>, jogue o arquivo
+      dentro e diga um tamanho. Se ninguém lhe disse que tamanho usar,
+      <strong>1024 pixels no lado maior</strong> é um bom padrão: grande o
+      bastante para quase tudo e pequeno o bastante para mandar por e-mail.
+      Deixe o formato em PNG, deixe o fundo em transparente e leve o arquivo.
+    </p>
+    <p>
+      Tudo o que vem abaixo é o que fazer quando esse padrão não basta &mdash;
+      quando um número foi especificado para você, quando a coisa vai para
+      impressão, ou quando ela volta com cara de errada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que o tamanho é decisão sua e não do arquivo</h2>
+    <p>
+      Um JPEG é uma grade de pixels medidos; perguntar de que tamanho ele é tem
+      resposta. Um SVG não é uma imagem, é um conjunto de instruções &mdash;
+      desenhe um círculo aqui, este traçado naquela cor &mdash; e instruções não
+      têm tamanho. Um navegador pode executá-las a 16 pixels ou a 4000 e o
+      resultado é igualmente nítido dos dois jeitos, porque ele não está escalando
+      nada. Está desenhando de novo.
+    </p>
+    <p>
+      É por isso que a conversão não pode escolher um número por você, e por isso
+      que não lhe custa nada escolher um grande. Este é o único trabalho de
+      imagem em que &ldquo;faça maior&rdquo; é de graça.
+    </p>
+    <p>
+      A maioria dos arquivos SVG carrega mesmo um atributo <code>width</code> e
+      um <code>height</code>, e a ferramenta vai mostrar &mdash; mas é um padrão,
+      não um limite. Um ícone que diz <code>width="24"</code> só está dizendo que
+      quem o desenhou tinha em mente uma barra de ferramentas de
+      24&nbsp;pixels.
+    </p>
+  </section>
+
+  <section>
+    <h2>De onde o número realmente vem</h2>
+    <p><strong>Para um site.</strong> Pegue o tamanho que a imagem ocupa na
+      página em pixels de CSS e multiplique pela densidade de pixels das telas
+      com que você se importa. Uma logomarca num espaço de 200&nbsp;pixels de
+      largura precisa de um arquivo de 400&nbsp;pixels para um notebook Retina e
+      de 600 para um celular recente. É isso o que <code>@2x</code> e
+      <code>@3x</code> significam, e é por isso que uma ferramenta que os escreve
+      poupa você de fazer a conta três vezes.
+    </p>
+    <p><strong>Para um ícone de aplicativo, uma ficha de loja ou um
+      favicon.</strong> O número é publicado e não há o que descobrir: o que a
+      página da loja disser, exatamente. Para um favicon, não rasterize de jeito
+      nenhum &mdash; <a href="../criar-um-favicon/">faça um .ico</a>, que guarda
+      vários tamanhos num arquivo só, porque uma aba de navegador, um favorito e
+      um atalho do Windows pedem tamanhos diferentes.
+    </p>
+    <p><strong>Para impressão.</strong> Multiplique o tamanho físico em polegadas
+      pela resolução da impressora. Uma logomarca indo para um cartão de visita
+      com cinco centímetros de largura a 300&nbsp;DPI dá 600 pixels; a mesma
+      logomarca atravessando uma página A4, com 21&nbsp;centímetros, dá cerca de
+      2500. As gráficas pedem 300&nbsp;DPI por hábito, e para um banner de grande
+      formato visto do outro lado de uma sala 150 dá e sobra.
+    </p>
+    <p><strong>Para uma prévia em rede social ou uma imagem OG.</strong> A
+      plataforma nomeia uma caixa &mdash; 1200&nbsp;&times;&nbsp;630 na maioria
+      das prévias de link &mdash; e a caixa tem formato diferente da sua
+      logomarca. É para isso que serve o ajuste de &ldquo;completar com
+      margem&rdquo;: o desenho centralizado nas proporções dele, com uma cor de
+      fundo preenchendo o resto, em vez de uma logomarca esticada que conta a
+      todo mundo que você não conferiu.
+    </p>
+    <p>
+      Quando dois desses casos se aplicam, use o maior. Um PNG maior do que
+      precisa é um download um pouco maior; um pequeno demais não tem conserto
+      depois, pelo motivo da próxima seção.
+    </p>
+  </section>
+
+  <section>
+    <h2>Não dá para voltar</h2>
+    <p>
+      Rasterizar é caminho de mão única. Assim que o desenho vira um PNG ele é
+      pixel como qualquer outra imagem, e ampliá-lo depois obriga a inventar
+      detalhe que nunca foi medido &mdash; o mesmo resultado macio e borrado que
+      se obtém ao ampliar uma fotografia.
+    </p>
+    <p>
+      Então guarde o SVG. Ele é a cópia mestra, é quase sempre o arquivo menor, e
+      todo tamanho futuro sai dele perfeito. O PNG é uma exportação para um uso
+      específico, e quando você precisar de outro tamanho a jogada certa é
+      exportar de novo, e não redimensionar o que você exportou.
+    </p>
+    <p>
+      Existe software que afirma converter um PNG de volta em SVG. O que ele faz
+      é traçar: chutar quais curvas poderiam explicar uma grade de pixels.
+      Funciona razoavelmente numa arte chapada de duas cores e produz besteira
+      cara em qualquer outra coisa, e nunca recupera o que o desenho original
+      tinha.
+    </p>
+  </section>
+
+  <section>
+    <h2>Três coisas mudam no instante em que vira pixel</h2>
+    <p>
+      Um SVG rasterizado que sai com cara de errado quase sempre sai errado por
+      um destes três motivos, e vale conhecer os três antes de exportar, não
+      depois.
+    </p>
+    <p>
+      <strong>Texto é desenhado com a fonte que a máquina tiver.</strong> Um SVG
+      que contém texto não contém a fonte &mdash; ele nomeia uma e deixa que o
+      renderizador a encontre. Se a fonte não estiver instalada, uma substituta é
+      usada, e a substituta tem outro desenho de letra e outras larguras, então o
+      texto pode reorganizar ou transbordar. Um arquivo que puxa a fonte de um
+      endereço da web se sai ainda pior: um SVG rasterizado por meio de uma
+      <code>&lt;img&gt;</code> não tem permissão de buscar coisa alguma, então
+      nada chega.
+    </p>
+    <p>
+      O conserto é o que todo designer já sabe: <strong>converta o texto em
+      contornos</strong> antes de exportar o SVG (o Illustrator chama de Criar
+      Contornos, o Figma chama de Flatten, o Inkscape chama de Objeto para
+      Caminho). As letras viram geometria, a fonte deixa de importar e a imagem
+      fica igual em qualquer máquina. Faça numa cópia &mdash; texto contornado
+      deixa de ser editável como texto.
+    </p>
+    <p>
+      <strong>Fios de cabelo ficam cinza ou somem.</strong> Um traço que dá menos
+      de um pixel no tamanho que você escolheu não pode ser desenhado como linha
+      sólida, então é desenhado tênue. É por isso que uma logomarca delicada
+      rasterizada a 64&nbsp;pixels fica desbotada enquanto o mesmo arquivo a 512
+      fica perfeito. Se o tamanho pequeno é a exigência, a resposta é um desenho
+      simplificado com traços mais pesados, e não outro ajuste de exportação
+      &mdash; que é o mesmo motivo de um favicon ser um símbolo e não uma
+      logomarca escrita.
+    </p>
+    <p>
+      <strong>A animação para.</strong> Um SVG animado rasteriza para uma única
+      imagem parada: o que quer que seja o primeiro quadro. Não existe ajuste de
+      exportação que mude isso. Se você precisa do movimento, precisa de um GIF
+      ou de um vídeo, feito de outro jeito.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparência, e qual formato escolher</h2>
+    <p>
+      <strong>PNG</strong>, a menos que você tenha um motivo. É sem perdas,
+      mantém a transparência, e cor chapada com bordas duras &mdash; que é a
+      maior parte do que um desenho tem &mdash; comprime bem nele. Uma logomarca
+      rasterizada normalmente é um PNG <em>menor</em> do que seria um JPEG, além
+      de mais limpo.
+    </p>
+    <p>
+      <strong>JPEG</strong> não tem transparência nenhuma. Cada pixel
+      transparente tem que virar alguma cor, e se nada escolher uma por você ele
+      vira preto &mdash; que é de onde vem aquele resultado de logomarca sobre
+      caixa preta que as pessoas acham que é bug. Ele também é com perdas do jeito
+      que pior aparece exatamente nesse tipo de imagem: um anel de sujeirinha em
+      volta de cada borda dura. Use quando alguma coisa insistir nele.
+    </p>
+    <p>
+      <strong>WebP</strong> faz tudo o que o PNG faz, num arquivo menor, e é lido
+      por todo navegador atual. O motivo para não usar é o que acontece depois do
+      navegador: software mais antigo, algumas gráficas e um bom número de
+      formulários de envio ainda não abrem um.
+    </p>
+    <p>
+      Escolher uma cor de fundo com PNG também é uma coisa perfeitamente comum de
+      se querer. Transparência só é útil quando aquilo em que a imagem vai cair é
+      de uma cor que você não consegue prever; quando você já sabe que é uma
+      página branca, achatar sobre branco evita uma categoria inteira de
+      surpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando a exportação sai em branco ou errada</h2>
+    <p>
+      <strong>Nada além de espaço vazio.</strong> Normalmente um atributo
+      <code>xmlns</code> faltando no elemento raiz. Um arquivo sem ele não é SVG
+      do ponto de vista de uma tag de imagem, e é desenhado como nada. Abrir o
+      arquivo num navegador é o teste rápido: se o navegador também não mostrar
+      nada, o problema é o arquivo, e não o conversor.
+    </p>
+    <p>
+      <strong>O desenho está pequeno, no canto superior esquerdo.</strong> O
+      arquivo tem <code>width</code> e <code>height</code> mas não tem
+      <code>viewBox</code>, então não há sistema de coordenadas a escalar e a
+      arte mantém as unidades originais num canvas maior. Um bom conversor coloca
+      um viewBox para você; se o seu não colocou, acrescentar
+      <code>viewBox="0 0 <em>largura</em> <em>altura</em>"</code> no elemento raiz
+      à mão resolve, e o arquivo é texto puro, então dá para fazer.
+    </p>
+    <p>
+      <strong>Falta parte da imagem.</strong> Alguma coisa no arquivo apontava
+      para um endereço em vez de conter a arte &mdash; uma fotografia embutida
+      guardada como link, uma folha de estilo, uma fonte. Um rasterizador que se
+      recusa a buscar essas coisas está fazendo o certo, e é a mesma recusa que
+      impede um SVG que você baixou de algum lugar de dar notícia a quem o fez.
+      Reexporte do programa de desenho com as imagens embutidas.
+    </p>
+    <p>
+      <strong>Ele recusa um tamanho muito grande.</strong> Os navegadores limitam
+      o tamanho de um canvas, e não concordam sobre onde: passando de mais ou
+      menos 16.000&nbsp;pixels de lado nada volta, e o Safari num iPhone ou iPad
+      desiste bem antes, por volta de 4096&nbsp;&times;&nbsp;4096. Uma ferramenta
+      que avisa está lhe poupando de um arquivo em branco, porque é isso que um
+      navegador produz quando não dá conta, em vez de uma mensagem de erro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada disso precisa de envio</h2>
+    <p>
+      Rasterizar um SVG é coisa que todo navegador faz milhares de vezes por dia
+      &mdash; é o mesmo maquinário que desenha um ícone numa página web. Não há
+      motivo técnico para a sua arte viajar até um servidor e voltar para sair
+      como PNG, e a ferramenta daqui não manda ela para lugar nenhum: a
+      <code>Content-Security-Policy</code> da página nomeia todos os endereços
+      que ela pode contatar, e nenhum deles é deste site.
+    </p>
+    <p>
+      Isso importa mais que de costume com SVG, porque um SVG é um documento e
+      não uma imagem. Ele pode conter um script e um endereço remoto, e uma
+      logomarca que uma agência lhe mandou é um arquivo que você não escreveu.
+      Desenhado por meio de uma tag de imagem, ele está no que a especificação
+      chama de <em>modo estático seguro</em>: o script não pode rodar e o endereço
+      nunca é contatado. Quem faz isso valer é o navegador, e não o site.
+    </p>
+    <p>
+      Carregue a página, desconecte da internet e converta alguma coisa mesmo
+      assim, se preferir conferir a acreditar.
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta mais três verificações que você pode
+      fazer em qualquer ferramenta.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/pt/pages/guides/convert-an-svg-to-png.toml
@@ -1,0 +1,17 @@
+#
+# Guia: converter um SVG em PNG - português do Brasil.
+#
+
+nav = "Converter um SVG em PNG"
+title = "Como converter um SVG em PNG no tamanho certo"
+description = "Um vetor não tem tamanho em pixels próprio, então o número é escolha sua. De onde vem esse número para uma tela, um ícone de aplicativo e uma impressora, e o que muda quando um desenho vira pixels."
+heading = "Como converter um SVG em PNG no tamanho certo"
+lede = """
+    Converter é a metade fácil. A pergunta que decide se o resultado serve para
+    alguma coisa é aquela para a qual ninguém lhe dá resposta: quantos pixels?
+    Aqui está de onde vem esse número, e o que um desenho perde no caminho até
+    virar um."""
+updated = "20 de agosto de 2026"
+og_title = "Converter um SVG em PNG no tamanho certo"
+og_description = "De onde vem de verdade o número de pixels, e as três coisas que mudam quando um desenho vira pixels."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/convert-heic-to-jpg.html
+++ b/locales/pt/pages/guides/convert-heic-to-jpg.html
@@ -1,0 +1,251 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../heic-para-jpg/">conversor de HEIC para JPG</a>, jogue
+      as fotos dentro e aperte &ldquo;Converter&rdquo;. Deixe o controle de
+      qualidade onde está e deixe marcado &ldquo;manter a data, a câmera e os
+      ajustes&rdquo;, a menos que você tenha um motivo para não deixar. Você
+      recebe JPEGs de volta, um botão de download para cada, ou um zip se forem
+      vários.
+    </p>
+    <p>
+      Nada é enviado enquanto você faz isso. Isso é incomum neste trabalho
+      específico, e o motivo é a metade interessante desta página.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que HEIC é de verdade</h2>
+    <p>
+      HEIC não é bem um formato de imagem do jeito que o JPEG é. É um contêiner
+      &mdash; a mesma estrutura de caixas com que um MP4 é montado &mdash; com um
+      quadro parado de vídeo <strong>HEVC</strong> lá dentro. O HEVC, também
+      chamado de H.265, é o codec que substituiu o que a sua filmadora antiga
+      usava, e é muito bom: uma foto de iPhone em HEIC tem mais ou menos metade
+      do tamanho da mesma foto como JPEG na mesma qualidade.
+    </p>
+    <p>
+      A Apple mudou para ele no iOS 11, em 2017, e o deixou como padrão. O que
+      significa que, a menos que alguém tenha entrado em Ajustes e escolhido
+      &ldquo;Mais compatível&rdquo;, toda foto que o celular daquela pessoa tirou
+      em quase uma década está num formato que:
+    </p>
+    <ul>
+      <li>o Windows não pré-visualiza sem uma extensão da Store;</li>
+      <li>a maioria dos formulários de envio na web recusa de cara;</li>
+      <li>um monte de software de computador mais antigo nunca ouviu falar;</li>
+      <li>e navegador nenhum, exceto o Safari, exibe.</li>
+    </ul>
+    <p>
+      A foto está ótima. É um arquivo melhor do que o JPEG teria sido. Ela apenas
+      está escrita numa língua que a maior parte do mundo nunca aprendeu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que só o Safari abre um</h2>
+    <p>
+      Esta é a parte que explica todo conversor que você já usou, então merece um
+      parágrafo.
+    </p>
+    <p>
+      Decodificar HEVC precisa de um decodificador de HEVC, e HEVC é patenteado.
+      O licenciamento é administrado por mais de um consórcio de patentes, e
+      distribuir um decodificador significa pagar alguém. Os navegadores lidam
+      com isso apoiando-se no sistema operacional &mdash; o Chrome toca
+      <em>vídeo</em> HEVC numa máquina cujo hardware já tem um decodificador
+      licenciado &mdash; mas esse caminho está ligado à reprodução de vídeo, e
+      não a imagens paradas. Então um HEIC entregue a uma
+      <code>&lt;img&gt;</code> é recusado, no Chrome, no Firefox e no Edge
+      igualmente, em qualquer sistema operacional.
+    </p>
+    <p>
+      O Safari em hardware da Apple é a exceção, porque o macOS e o iOS têm o
+      decodificador e o Safari tem permissão de pedir a ele. Em todo o resto, a
+      imagem simplesmente não é decodificável pelo navegador.
+    </p>
+    <p>
+      O que deixa um conversor com exatamente duas opções, e a escolha entre elas
+      é a história inteira desse tipo de ferramenta.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que quase todo conversor de HEIC quer um envio</h2>
+    <p>
+      Opção um: colocar o decodificador num servidor. A foto é enviada,
+      decodificada numa máquina que você nunca viu, recodificada como JPEG e
+      mandada de volta. É isso que quase todo &ldquo;conversor de HEIC online
+      gratuito&rdquo; faz, e é por isso que todos precisam dos seus arquivos. Não
+      é preguiça &mdash; o navegador genuinamente não dá conta sozinho.
+    </p>
+    <p>
+      Vale ser direto sobre o que isso custa. Fotos de celular são os arquivos
+      mais pessoais que a maioria das pessoas tem, e um HEIC recém-saído de um
+      iPhone normalmente carrega as coordenadas de onde foi tirado, com precisão
+      de poucos metros, junto com a data até o segundo e um identificador de
+      câmera. Enviar uma pasta cheia deles a um serviço gratuito significa
+      entregar as imagens e isso tudo junto. O que acontece depois é regido por
+      uma política de privacidade que você não leu, num servidor que você não
+      pode inspecionar, numa jurisdição que você não escolheu.
+    </p>
+    <p>
+      Opção dois: colocar o decodificador na página. É isso que
+      <a href="../../heic-para-jpg/">este aqui</a> faz. Ele carrega a
+      <code>libheif</code>, compilada para WebAssembly, como um arquivo servido
+      deste site &mdash; cerca de 1,4 MB, baixado uma vez e depois guardado em
+      cache. O seu navegador roda isso na sua própria máquina, no seu próprio
+      hardware, e a foto não vai a lugar nenhum. Carregue a página uma vez e você
+      pode desconectar completamente da internet que ela continua funcionando, o
+      que é uma coisa que conversor nenhum que envia consegue fazer, e a prova
+      mais simples que existe.
+    </p>
+    <p>
+      Os 1,4 MB são o preço inteiro. Se você está numa conexão tarifada é um
+      custo real e vale saber; é por isso que a página diz isso em voz alta em
+      vez de baixar em silêncio.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que a conversão custa à imagem</h2>
+    <p>
+      HEIC e JPEG são codecs diferentes, então não há caminho entre os dois que
+      não envolva decodificar a imagem e codificá-la de novo. Essa segunda
+      codificação é com perdas. Na prática isso importa bem menos do que soa:
+    </p>
+    <ul>
+      <li>
+        <strong>Na qualidade 92</strong> &mdash; onde o conversor começa &mdash;
+        uma fotografia é muito difícil de distinguir do original em qualquer
+        tamanho normal de visualização. Você estaria procurando diferenças em
+        gradientes suaves, como um céu limpo, e em geral não vai achar.
+      </li>
+      <li>
+        <strong>O JPEG vai ser maior.</strong> Normalmente entre um terço maior e
+        o dobro do tamanho, porque JPEG é um codec de 1992 e HEVC não é. Essa é a
+        troca: um arquivo maior que tudo abre.
+      </li>
+      <li>
+        <strong>Converter duas vezes é o que se deve evitar.</strong> Toda
+        codificação com perdas custa um pouco. Converta a partir do HEIC
+        original, e não de um JPEG que alguém já fez para você, e faça uma vez
+        só.
+      </li>
+    </ul>
+    <p>
+      Se você não quer perda nenhuma, o PNG está no menu de formatos. Prepare-se
+      para o arquivo: uma fotografia como PNG costuma ter de cinco a dez vezes o
+      tamanho do JPEG, porque a compressão do PNG foi desenhada para cor chapada
+      e desenho de traço, não para grama e pele.
+    </p>
+  </section>
+
+  <section>
+    <h2>A data, a câmera e as coordenadas</h2>
+    <p>
+      A reclamação de sempre sobre conversores de HEIC é que as fotos voltam sem
+      o dia em que foram tiradas, então uma viagem inteira de fotos vai parar no
+      fim da biblioteca com a data de hoje. Isso acontece porque converter por um
+      canvas lhe dá pixels e mais nada &mdash; um canvas não guarda etiquetas
+      &mdash; então, a não ser que o conversor vá buscar os metadados à parte,
+      eles simplesmente somem.
+    </p>
+    <p>
+      A ferramenta daqui copia o bloco EXIF do HEIC e o escreve dentro do JPEG,
+      então a data sobrevive. Existe uma caixinha, e ela vem marcada. Desmarque e
+      o JPEG sai com a imagem e nada mais.
+    </p>
+    <p>
+      Antes de decidir, olhe a lista: a linha de cada foto diz se o arquivo
+      carrega coordenadas de GPS, e diz isso antes de qualquer coisa ser
+      convertida. Se as fotos vão para algum lugar público, é essa a linha para
+      ler. Se vão para a sua própria biblioteca, manter os metadados quase
+      certamente é o que você quer.
+    </p>
+    <p>
+      Uma etiqueta muda de qualquer jeito, e vale saber por quê. Um HEIC registra
+      a rotação dele em dois lugares: no contêiner e no bloco EXIF. O
+      decodificador aplica a rotação do contêiner enquanto decodifica, então os
+      pixels entregues já estão no sentido certo. Se o EXIF ainda dissesse
+      &ldquo;gire isto 90 graus&rdquo;, um visualizador faria de novo e toda foto
+      em pé sairia deitada. Então a etiqueta de orientação é ajustada para
+      &ldquo;em pé&rdquo; e todo o resto é copiado exatamente como o celular
+      escreveu.
+    </p>
+    <p>
+      Se o que você quer é percorrer as etiquetas em detalhe, ou apagá-las de
+      fotos que já são JPEG, isso é outro trabalho e existe
+      <a href="../remover-dados-exif-e-gps/">um guia para ele</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Coisas que pegam as pessoas de surpresa</h2>
+    <ul>
+      <li>
+        <strong>Um HEIC chamado &ldquo;.jpg&rdquo;.</strong> Muitíssimo comum:
+        alguma coisa no caminho renomeou o arquivo sem convertê-lo, e é por isso
+        que ele continua não abrindo. Todo arquivo jogado no conversor é
+        identificado pelos primeiros bytes e não pelo nome, então um desses
+        funciona sem problema. É também por isso que um arquivo que é
+        genuinamente um JPEG recebe esse aviso, em vez de ser convertido numa
+        cópia de si mesmo.
+      </li>
+      <li>
+        <strong>Um arquivo, várias imagens.</strong> Uma rajada ou uma Live Photo
+        pode guardar mais de uma imagem parada. Todas são convertidas, e as
+        extras são numeradas depois do nome original. A metade em vídeo de uma
+        Live Photo é um arquivo separado que o celular guarda ao lado do HEIC,
+        então não está ali dentro para ser convertida.
+      </li>
+      <li>
+        <strong>AVIF não é HEIC.</strong> Eles se parecem &mdash; mesmo
+        contêiner, codec diferente lá dentro &mdash; mas todo navegador atual
+        abre um AVIF nativamente, então não há o que converter e a ferramenta diz
+        isso em vez de fingir que trabalhou.
+      </li>
+      <li>
+        <strong>Cortar o problema na origem.</strong> No celular: Ajustes &rarr;
+        Câmera &rarr; Formatos &rarr; Mais compatível. Dali em diante as fotos
+        novas são JPEGs. Isso usa mais armazenamento e não encosta nas fotos que
+        você já tem, mas significa nunca mais fazer isso.
+      </li>
+      <li>
+        <strong>Compartilhar às vezes já converte.</strong> Mandar uma foto por
+        AirDrop ou por e-mail a um aparelho que não é da Apple muitas vezes
+        entrega um JPEG, porque o iOS converte na saída. Se uma foto chegou como
+        HEIC mesmo assim, ela veio por um caminho que não converteu.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Como saber se um conversor está enviando</h2>
+    <p>
+      Isso vale para qualquer ferramenta, não só para esta, e leva uns quinze
+      segundos.
+    </p>
+    <ol>
+      <li>
+        Abra a página, então abra as ferramentas de desenvolvedor do seu
+        navegador e vá para a aba Rede.
+      </li>
+      <li>
+        Converta uma foto e observe. Uma ferramenta que decodifica na sua máquina
+        não faz requisição nenhuma naquele momento. Uma ferramenta que envia faz
+        uma do tamanho da sua foto, e você consegue ver o tamanho.
+      </li>
+      <li>
+        Ou, mais simples ainda: carregue a página, desconecte da internet e tente
+        converter alguma coisa. Uma ferramenta que mandou a sua foto para ser
+        decodificada em outro lugar para de funcionar. Uma que carrega o
+        decodificador não para.
+      </li>
+    </ol>
+    <p>
+      O conversor daqui foi feito para passar nas duas verificações, e há uma
+      versão mais longa desse argumento em
+      <a href="../e-seguro-enviar-arquivos/">é seguro enviar arquivos</a>.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/pt/pages/guides/convert-heic-to-jpg.toml
@@ -1,0 +1,17 @@
+#
+# Guia: converter HEIC em JPG - português do Brasil.
+#
+
+nav = "HEIC para JPG"
+title = "Como converter HEIC em JPG (e o que HEIC é de verdade)"
+description = "iPhones salvam fotos em HEIC, e metade da internet não consegue abrir uma. O que é o formato, por que só o Safari decodifica, o que a conversão custa à imagem e como fazer isso sem entregar as fotos a ninguém."
+heading = "A foto que seu celular salvou, e o formato que nada abre"
+lede = """
+    O iPhone salva fotos em HEIC, um formato menor e melhor que o JPEG e que
+    um monte de programa ainda se recusa a abrir. Aqui está o que o formato é
+    de fato, o que a conversão custa à imagem e por que quase todo conversor
+    quer que você mande a foto para ele primeiro."""
+updated = "20 de agosto de 2026"
+og_title = "Como converter HEIC em JPG"
+og_description = "Por que fotos de iPhone não abrem, o que a conversão custa e como fazer sem entregar as fotos a ninguém."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/crop-a-video.html
+++ b/locales/pt/pages/guides/crop-a-video.html
@@ -1,0 +1,210 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../cortar-video/">Cortador de vídeo</a>, jogue o clipe
+      dentro, arraste a caixa sobre a parte que quer manter &mdash; ou trave numa
+      proporção, se lhe deram uma &mdash; e exporte. O clipe que sai tem
+      exatamente a mesma duração do que entrou, com a temporização e o som
+      intactos.
+    </p>
+    <p>
+      Ao contrário de aparar, este trabalho precisa escrever quadros novos. Isso
+      não é uma deficiência de uma ferramenta específica; é o que cortar é. O
+      resto desta página trata do que isso custa e de como manter o custo baixo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que cortar não consegue evitar uma recodificação</h2>
+    <p>
+      Aparar mantém quadros inteiros, então um bom aparador move os quadros
+      intocados e nada é decodificado. Cortar mantém parte de cada quadro
+      &mdash; e parte de um quadro é outra imagem. Não há como guardar outra
+      imagem sem escrever os pixels de novo.
+    </p>
+    <p>
+      Existe uma exceção estreita, e vale conhecê-la para você reconhecer quando
+      alguém a invoca. Vídeo é codificado em blocos, e se um corte caísse
+      exatamente nas fronteiras de bloco nos quatro lados, parte dos dados
+      poderia em princípio ser reaproveitada. Na prática, as dimensões do próprio
+      quadro, os vetores de movimento e a predição precisam ser reescritos de
+      qualquer jeito, então nada de verdade é construído assim. Presuma que um
+      corte significa uma recodificação.
+    </p>
+    <p>
+      O que um cortador bem-comportado faz é não gastar <em>mais</em> do que o
+      original gastava naquela mesma área. Codificar uma região cortada com uma
+      taxa de bits maior que a da origem só deixa o arquivo maior; não devolve
+      detalhe que o original não tinha.
+    </p>
+  </section>
+
+  <section>
+    <h2>Os formatos que estão realmente lhe pedindo</h2>
+    <p>
+      A maior parte dos cortes é feita porque algum lugar exige uma proporção de
+      tela. A lista curta:
+    </p>
+    <ul>
+      <li>
+        <strong>9:16 &mdash; em pé.</strong> Stories, reels, shorts, TikTok.
+        Tela cheia num celular segurado normalmente. O motivo mais comum para
+        alguém cortar um vídeo.
+      </li>
+      <li>
+        <strong>1:1 &mdash; quadrado.</strong> Publicações de feed em várias
+        plataformas. Funciona de qualquer jeito que a pessoa esteja segurando o
+        celular, e é por isso que persiste.
+      </li>
+      <li>
+        <strong>4:5 &mdash; levemente em pé.</strong> O maior formato que alguns
+        feeds permitem, então ocupa mais tela que um quadrado sem ser um vídeo
+        vertical inteiro.
+      </li>
+      <li>
+        <strong>16:9 &mdash; deitado.</strong> O padrão de vídeo em geral. Em
+        geral você corta <em>para</em> ele só para tirar tarjas pretas, ou
+        <em>a partir</em> dele para chegar a um dos formatos acima.
+      </li>
+    </ul>
+    <p>
+      Trave a caixa na proporção em vez de arrastar no olho. Errar por alguns
+      pixels significa que a plataforma vai cortar o seu corte, e ela não vai
+      consultar você sobre onde.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transformando um clipe deitado em vertical</h2>
+    <p>
+      Este é o caso comum mais difícil, e vale deixar claro que cortar é um
+      arranjo, não uma solução.
+    </p>
+    <p>
+      Um vídeo 16:9 cortado para 9:16 mantém cerca de 32% da largura da imagem. O
+      que estiver nas laterais some &mdash; e numa tomada deitada as laterais
+      costumam ser onde está o contexto. Se duas pessoas conversam em lados
+      opostos do quadro, corte nenhum mantém as duas.
+    </p>
+    <p>
+      Escolha o corte assistindo ao clipe uma vez e perguntando onde o assunto de
+      fato está na maior parte do tempo. Se a resposta for &ldquo;ele se
+      mexe&rdquo;, um corte estático é a ferramenta errada e o que você quer é um
+      editor que consiga movimentar o corte ao longo do tempo. Se a resposta for
+      &ldquo;no centro, na maior parte&rdquo;, um corte centralizado resolve e
+      leva dez segundos.
+    </p>
+    <p>
+      A alternativa que vale lembrar: muitas plataformas aceitam um vídeo deitado
+      e colocam as tarjas por conta própria. Cortar é para quando você quer a
+      tela cheia, não para quando você quer que o vídeo seja aceito.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que a largura e a altura andam de dois em dois</h2>
+    <p>
+      Se você notar que a caixa de corte recusa números ímpares, é o codec sendo
+      difícil, não a interface.
+    </p>
+    <p>
+      O H.264 &mdash; o codec dentro de um MP4 &mdash; guarda a cor em metade da
+      resolução na horizontal e na vertical, porque o olho é muito menos sensível
+      a detalhe de cor do que a detalhe de brilho. Isso significa que a imagem é
+      tratada em unidades de dois pixels e não há como descrever um quadro com um
+      número ímpar de pixels num lado.
+    </p>
+    <p>
+      As ferramentas lidam com isso arredondando o seu corte depois que você o
+      define, o que move a sua caixa em um pixel sem lhe avisar, ou oferecendo
+      apenas números pares desde o começo. É a segunda coisa que acontece aqui.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que acontece com o som</h2>
+    <p>
+      Nada, no caminho do MP4. Cortar muda a imagem e não tem motivo para
+      encostar no áudio, então o áudio é copiado amostra por amostra sem nunca
+      ser decodificado &mdash; byte a byte o que estava no arquivo.
+    </p>
+    <p>
+      No recuo por gravação, descrito abaixo, o som é capturado da reprodução e
+      codificado de novo, o que custa um pouco de qualidade. De todo jeito existe
+      uma caixinha para deixá-lo de fora por completo, que vale usar quando o
+      clipe vai para um lugar que toca sem som mesmo e você quer o menor arquivo
+      possível.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formatos, e quanto tempo leva</h2>
+    <p>
+      <strong>MP4, M4V e MOV</strong> são lidos diretamente, seja lá o que houver
+      dentro deles &mdash; H.264, HEVC, AV1 ou VP9 &mdash; desde que o seu
+      navegador saiba decodificar aquele codec. Ao contrário de aparar, cortar
+      precisa decodificar, então aqui o codec importa de um jeito que lá não
+      importa.
+    </p>
+    <p>
+      <strong>Qualquer outra coisa que o seu navegador consiga tocar</strong>,
+      WebM mais obviamente, é cortada tocando o arquivo e gravando o resultado, o
+      que funciona e leva o mesmo tempo que o clipe dura.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV e a maioria dos MKVs</strong> o navegador não
+      consegue nem ler nem tocar, e a ferramenta os recusa com uma mensagem em
+      vez de falhar no meio do caminho.
+    </p>
+    <p>
+      Espere que um corte leve tempo de verdade num clipe longo, porque cada
+      quadro está sendo decodificado e recodificado. Não há limite embutido na
+      ferramenta, e o arquivo é percorrido em fatias de alguns megabytes em vez
+      de ser carregado inteiro; o teto prático é o vídeo pronto, que é montado na
+      memória antes de você baixá-lo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Corte depois de tudo o mais</h2>
+    <p>
+      Se um clipe precisa ser aparado e cortado, apare primeiro &mdash; isso é de
+      graça, e cada segundo que você tira é um segundo que ninguém precisa
+      recodificar. Depois corte o clipe mais curto uma vez.
+    </p>
+    <p>
+      Ao contrário, significa cortar imagens que você está prestes a jogar fora, o
+      que custa tempo e qualidade à toa. O
+      <a href="../../aparar-video/">Aparador de vídeo</a> fica ao lado, e
+      <a href="../aparar-um-video/">o guia dele</a> explica por que aquela etapa
+      não precisa lhe custar nada.
+    </p>
+    <p>
+      De forma mais geral: toda etapa com perdas se acumula. Um corte de um
+      original é uma geração. Um corte de uma aparada de uma exportação de um
+      download são quatro, e dá para ver.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que isso não precisa de envio</h2>
+    <p>
+      Decodificar e recodificar vídeo num navegador é coisa recente e é coisa de
+      verdade: o WebCodecs expõe o mesmo codificador de hardware que o seu celular
+      usa para gravar vídeo, e é rápido pelo mesmo motivo. O trabalho acontece na
+      máquina que já tem o arquivo, o que, para um vídeo de vários gigabytes,
+      também é o único arranjo que faz sentido &mdash; enviá-lo e baixar o
+      resultado custa mais tempo do que a codificação.
+    </p>
+    <p>
+      A ferramenta daqui não tem função de rede de espécie alguma, e a
+      <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+      ela pode contatar, nenhum dos quais é deste site. Desconecte da internet e
+      corte um clipe mesmo assim, se preferir conferir a acreditar.
+    </p>
+    <p>
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta mais três verificações que você pode
+      fazer em qualquer ferramenta.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/crop-a-video.toml
+++ b/locales/pt/pages/guides/crop-a-video.toml
@@ -1,0 +1,21 @@
+#
+# Guia: cortar um vídeo (mudar o enquadramento) - português do Brasil.
+#
+# "Cortar" aqui é recortar a moldura, e não encurtar a duração - esse é o guia
+# de aparar. O texto diz "o formato da imagem" nas primeiras linhas justamente
+# para que ninguém confunda os dois.
+#
+
+nav = "Cortar um vídeo"
+title = "Como cortar um vídeo para outro formato de tela"
+description = "Reduza um clipe a um quadrado, a um retrato 9:16 ou a uma caixa exata em pixels. Qual proporção cada plataforma quer, por que cortar obriga a recodificar e aparar não, e o que isso custa."
+heading = "Como cortar um vídeo para outro formato de tela"
+lede = """
+    Cortar muda o formato da imagem, o que significa escrever quadros novos
+    &mdash; não há como escapar disso, e qualquer ferramenta que afirme o
+    contrário está fazendo outra coisa. Aqui está o que isso custa e como
+    gastar bem."""
+updated = "20 de agosto de 2026"
+og_title = "Como cortar um vídeo para outro formato de tela"
+og_description = "Qual proporção cada plataforma quer, por que cortar obriga a recodificar e aparar não, e o que isso custa."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/embed-an-image-in-css.html
+++ b/locales/pt/pages/guides/embed-an-image-in-css.html
@@ -1,0 +1,315 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../imagem-para-base64/">Imagem para data URI</a>, jogue
+      a imagem dentro, escolha <em>Uma propriedade personalizada de CSS</em> e
+      cole a linha no alto da sua folha de estilo. Depois use como
+      <code>background-image: var(--logo)</code> onde precisar.
+    </p>
+    <p>
+      Faça isso quando a imagem for pequena &mdash; um ícone, um marcador de
+      lista, uma setinha, um padrão &mdash; e for necessária em toda página. Não
+      faça com uma fotografia. Tudo o que vem abaixo é o porquê de essas duas
+      frases diferirem, e como saber com qual dos dois casos você está lidando.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que uma data URI é de fato</h2>
+    <p>
+      Um endereço que contém a coisa em vez de apontar para ela. Onde uma folha
+      de estilo normalmente diria
+    </p>
+    <pre><code>background-image: url("logo.png");</code></pre>
+    <p>
+      e o navegador vai buscar o <code>logo.png</code>, uma data URI diz
+    </p>
+    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <p>
+      e não há o que buscar: a imagem já está ali, escrita em caracteres. São
+      três partes. <code>data:</code> é o esquema. <code>image/png</code> é o tipo
+      de mídia, e o navegador acredita nele por completo &mdash; mais sobre isso
+      abaixo. Tudo depois da vírgula é o arquivo.
+    </p>
+    <p>
+      É essa a ideia inteira. Não é truque nem gambiarra; está nos padrões desde
+      1998 e funciona em todo navegador lançado desde então.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que isso lhe rende: uma ida e volta a menos</h2>
+    <p>
+      A economia não é de banda. É da requisição.
+    </p>
+    <p>
+      Um navegador não consegue pedir o <code>logo.png</code> antes de ter lido a
+      folha de estilo que o menciona, e não consegue ler a folha de estilo antes
+      de tê-la buscado. Então uma imagem de fundo comum está pelo menos duas idas
+      e voltas fundo no carregamento da página, e num celular numa rede lenta uma
+      ida e volta pode ser algumas centenas de milissegundos por menor que seja o
+      arquivo. Uma setinha de 600 bytes quase não custa nada para transferir e
+      ainda assim pode custar um quarto de segundo para chegar.
+    </p>
+    <p>
+      Embutida, ela chega junto com a folha de estilo. Esse é o benefício inteiro,
+      e para um ícone pequeno que aparece na primeira dobra ele é real.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que isso custa: um terço, e depois o cache</h2>
+    <p>
+      <strong>O base64 acrescenta cerca de um terço.</strong> Três bytes de
+      arquivo viram quatro caracteres, porque é isso que se leva para escrever
+      bytes arbitrários usando só os caracteres que uma URL permite. Não existe
+      codificador esperto que fuja disso. Um PNG de 9 KB são 12 KB de folha de
+      estilo.
+    </p>
+    <p>
+      <strong>A compressão não devolve.</strong> Esta é a parte que as pessoas
+      dispensam por suposição. Gzip e Brotli funcionam encontrando redundância, e
+      um PNG, um JPEG e um WebP já foram comprimidos &mdash; sobra pouquíssima
+      redundância neles, e o base64 não acrescenta nenhuma. Na prática você
+      recupera algo como um décimo daquele terço, e não o terço inteiro. (Um SVG
+      é o caso oposto, e a próxima seção é sobre isso.)
+    </p>
+    <p>
+      <strong>Ela deixa de ser um arquivo.</strong> Este é o custo que não
+      aparece em nenhuma medição que você provavelmente vá fazer, e é o que
+      importa em escala:
+    </p>
+    <ul>
+      <li>
+        <strong>Não pode ser guardada em cache sozinha.</strong> Uma imagem comum
+        é buscada uma vez e reaproveitada por um ano. Uma embutida faz parte da
+        folha de estilo, então vive e morre com a entrada de cache dela.
+      </li>
+      <li>
+        <strong>Mudar qualquer coisa rebaixa tudo.</strong> Conserte uma margem,
+        publique uma folha de estilo nova, e todo visitante baixa a imagem
+        embutida de novo junto com ela &mdash; uma imagem que não muda há dois
+        anos.
+      </li>
+      <li>
+        <strong>Ela está no caminho crítico.</strong> Uma folha de estilo bloqueia
+        a renderização. Uma imagem não. Embutir uma imagem a move da segunda
+        categoria para a primeira: a página não pode pintar até que a coisa
+        inteira, imagem incluída, tenha chegado.
+      </li>
+      <li>
+        <strong>Não pode ser buscada em paralelo.</strong> Os navegadores baixam
+        várias coisas ao mesmo tempo. Uma imagem embutida não é uma coisa
+        separada, então não pega nada disso.
+      </li>
+    </ul>
+    <p>
+      Limiares grosseiros, que são onde o conselho muda e não onde algum navegador
+      faz algo diferente: abaixo de uns 2 KB é vitória clara; até uns 10 KB
+      normalmente ainda vale para algo que está em toda página; passando de 50 KB
+      é um erro sem mensagem de erro.
+      <a href="../../imagem-para-base64/">A ferramenta</a> lhe diz em qual faixa
+      cada resultado cai, com a contagem de caracteres ao lado.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nunca ponha um SVG em base64</h2>
+    <p>
+      Este é de longe o erro mais comum em imagens embutidas, e é cometido por
+      exportadores e plugins de compilação com a mesma frequência que por
+      pessoas.
+    </p>
+    <p>
+      Um SVG é texto. Uma URL já carrega texto. Só um punhado de caracteres
+      precisa ser escapado &mdash; <code>%</code>, <code>#</code>,
+      <code>&lt;</code>, <code>&gt;</code> e a aspa em que você o envolveu
+      &mdash; e todo o resto pode ficar exatamente como está. Codificar assim lhe
+      dá uma URI tipicamente uns 20% mais curta que o base64 do mesmo arquivo, e
+      que depois comprime como texto em vez de comprimir como ruído.
+    </p>
+    <p>
+      E continua legível:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <p>
+      Você consegue ver o <code>viewBox</code>. Você consegue mudar a cor de
+      preenchimento no seu editor sem decodificar nada. Ponha o mesmo arquivo em
+      base64 e ele vira uma parede de letras em que ninguém nunca mais vai
+      encostar. O <a href="../../imagem-para-base64/">Imagem para data URI</a>
+      faz isso automaticamente com qualquer coisa que se revele um SVG, e tem uma
+      caixinha para a rara cadeia de ferramentas que insiste no
+      <code>;base64</code>.
+    </p>
+  </section>
+
+  <section>
+    <h2>O erro de aspas que só quebra SVGs</h2>
+    <p>
+      O CSS permite escrever <code>url()</code> sem aspas, e para um nome de
+      arquivo comum tudo bem:
+    </p>
+    <pre><code>background-image: url(logo.png);</code></pre>
+    <p>
+      Faça o mesmo com um SVG codificado em porcentagem e quebra. Um token
+      <code>url()</code> sem aspas termina no primeiro espaço, parêntese, aspa ou
+      caractere de controle &mdash; e um SVG é cheio de espaços, entre cada
+      atributo e cada número de um traçado. A declaração fica inválida, o CSS
+      descarta declarações inválidas em silêncio, e você fica sem fundo e sem
+      erro.
+    </p>
+    <p>
+      O conserto é aspas, sempre:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
+    <p>
+      É também por isso que um codificador não precisa escapar espaços &mdash;
+      eles são perfeitamente legais dentro de uma URL com aspas, e escapar cada um
+      como <code>%20</code> custaria três caracteres por espaço do arquivo. As
+      duas decisões andam juntas: ponha a URI entre aspas e você pode deixar os
+      espaços em paz. Todo formato que a ferramenta produz vem com aspas
+      exatamente por isso.
+    </p>
+  </section>
+
+  <section>
+    <h2>O tipo de mídia precisa estar certo</h2>
+    <p>
+      Uma data URI declara o próprio tipo, e o navegador acredita na palavra
+      dela. Não existe farejamento de recuo como existe para um arquivo buscado:
+      diga <code>image/png</code> sobre algo que na verdade é um JPEG e a imagem
+      não é desenhada, sem mensagem em lugar nenhum útil.
+    </p>
+    <p>
+      O que importa porque extensões de arquivo mentem. Uma foto exportada como
+      JPEG e renomeada para <code>logo.png</code> é uma coisa comum de se achar
+      num disco. Os primeiros bytes de um arquivo de imagem, por outro lado, dizem
+      o que ele é sem ambiguidade &mdash; todo formato tem uma assinatura &mdash;
+      então uma ferramenta deveria ler o arquivo em vez do nome dele. A daqui lê,
+      e avisa quando os dois discordam.
+    </p>
+    <p>
+      Dois formatos valem menção porque falham de um jeito confuso.
+      <strong>HEIC</strong>, que é como um iPhone fotografa, e
+      <strong>TIFF</strong>, que é o que os escâneres produzem, geram data URIs
+      perfeitamente válidas que navegador nenhum, exceto o Safari, vai desenhar. A
+      URI não está quebrada; o formato simplesmente não é um que a web suporte.
+      Converta antes.
+    </p>
+  </section>
+
+  <section>
+    <h2>Os metadados que você não pretendia publicar</h2>
+    <p>
+      Uma data URI é uma cópia do arquivo, byte por byte. Nada é decodificado e
+      recodificado, o que normalmente é a graça &mdash; nenhuma qualidade se
+      perde &mdash; mas também significa que todo o resto do arquivo vem junto.
+    </p>
+    <p>
+      Uma fotografia recém-saída de um celular carrega EXIF: as coordenadas de
+      GPS de onde foi tirada, a hora, o modelo da câmera e muitas vezes o número
+      de série dela. Isso pode ser 30 KB do arquivo. Embutido, vira 40 KB de
+      base64 na sua folha de estilo, no caminho crítico de toda página &mdash; e
+      um endereço residencial comprometido num repositório, numa forma em que
+      ninguém jamais vai pensar em olhar.
+    </p>
+    <p>
+      Limpe antes com o
+      <a href="../../remover-dados-exif/">Visualizador e removedor de EXIF</a>,
+      que reescreve o contêiner sem encostar na imagem; há
+      <a href="../remover-dados-exif-e-gps/">um guia sobre isso</a> também. O
+      Imagem para data URI lê quanto metadado existe num JPEG, PNG ou WebP e diz
+      isso antes de você copiar qualquer coisa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Onde colocar, depois de ter a linha</h2>
+    <p>
+      Se a imagem aparece numa regra, ponha a URI naquela regra. Se aparece em
+      mais de uma &mdash; e ícones em geral aparecem, quando você conta o estado
+      de hover e o tema escuro &mdash; declare uma vez como propriedade
+      personalizada:
+    </p>
+    <pre><code>:root {
+  --icon-search: url("data:image/svg+xml,%3Csvg ... %3E");
+}
+
+.search-field { background-image: var(--icon-search); }
+.search-button::before { content: var(--icon-search); }</code></pre>
+    <p>
+      Uma URI de 3 KB colada em quatro regras são 12 KB de folha de estilo e
+      quatro lugares para editar quando o ícone mudar. A propriedade
+      personalizada é um de cada. É também o formato que faz a troca de tema
+      funcionar: redefina <code>--icon-search</code> dentro de uma media query e
+      todo uso dela acompanha.
+    </p>
+    <p>
+      Para uma tag <code>&lt;img&gt;</code> em vez de CSS, inclua
+      <code>width</code> e <code>height</code>. Uma imagem embutida carrega
+      instantaneamente, então um tamanho faltando é um deslocamento de layout que
+      acontece rápido demais para ser visto e continua contando contra você. A
+      exceção é o SVG: um que carrega só um <code>viewBox</code> não tem tamanho
+      em pixels próprio, e escrever na tag o padrão de 300&times;150 do navegador
+      prende uma imagem escalável num tamanho que ninguém escolheu.
+    </p>
+    <p>
+      Deixe o <code>alt</code> vazio a menos que você tenha algo verdadeiro para
+      pôr nele. Só você sabe se a imagem carrega significado ou é decoração, e uma
+      descrição chutada a partir de um nome de arquivo é pior para quem usa leitor
+      de tela do que descrição nenhuma.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando a resposta é &ldquo;não faça&rdquo;</h2>
+    <p>
+      Se a imagem passa de uns 50 KB codificada, embutir é a ferramenta errada e
+      nenhum cuidado com a codificação conserta. As alternativas, na ordem em que
+      vale tentar:
+    </p>
+    <ul>
+      <li>
+        <strong>Deixe menor.</strong> A maioria das imagens grandes demais para
+        embutir é grande demais em geral. O
+        <a href="../../comprimir-imagem/">Compressor de imagens</a> leva uma
+        fotografia a um tamanho que você diz, e o
+        <a href="../../redimensionar-imagem/">Redimensionador de imagens</a> corta
+        as dimensões em pixels até o que o layout de fato usa &mdash; o que
+        muitíssimas vezes é o problema real.
+      </li>
+      <li>
+        <strong>Redesenhe como SVG.</strong> Um ícone exportado como PNG de 40 KB
+        frequentemente é um SVG de 900 bytes. Isso não é diferença de compressão,
+        é diferença de formato, e também resolve o problema das telas retina.
+      </li>
+      <li>
+        <strong>Deixe como arquivo e faça preload.</strong>
+        <code>&lt;link rel="preload" as="image"&gt;</code> começa a busca na hora
+        sem mover os bytes para o caminho crítico. Rende quase todo o benefício de
+        embutir e nenhum dos custos de cache.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Nada disso precisa de envio</h2>
+    <p>
+      Codificar um arquivo em base64 é aritmética. São duas funções que o
+      navegador tem desde o começo &mdash; <code>btoa</code> e
+      <code>encodeURIComponent</code> &mdash; e não existe motivo técnico nenhum
+      para uma imagem viajar até um servidor e voltar só para ser escrita de outro
+      jeito. Qualquer conversor que envia o seu arquivo para fazer isso está
+      enviando pelos motivos dele, não pelos seus.
+    </p>
+    <p>
+      <a href="../../imagem-para-base64/">A ferramenta daqui</a> não manda a
+      imagem para lugar nenhum: a <code>Content-Security-Policy</code> da página
+      nomeia todos os endereços que ela pode contatar, e nenhum deles é deste
+      site. Carregue a página, desconecte da internet e codifique alguma coisa
+      mesmo assim, se preferir conferir a acreditar.
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta mais três verificações que você pode fazer
+      em qualquer ferramenta.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/embed-an-image-in-css.toml
+++ b/locales/pt/pages/guides/embed-an-image-in-css.toml
@@ -1,0 +1,18 @@
+#
+# Guia: colocar uma imagem dentro do CSS - português do Brasil.
+#
+
+nav = "Colocar uma imagem no CSS"
+title = "Data URIs no CSS: quando embutir uma imagem e quando não"
+description = "O que uma data URI custa, por que o base64 acrescenta um terço e o gzip não devolve, por que um SVG nunca deveria ir em base64, e o erro de aspas que quebra SVGs embutidos em silêncio."
+heading = "Quando colocar uma imagem dentro do seu CSS, e quando não"
+lede = """
+    Uma imagem escrita dentro de uma folha de estilo chega junto com ela: sem
+    segunda requisição, sem espera. Ela também deixa de ser um arquivo &mdash;
+    então não pode ser guardada em cache sozinha, e é baixada de novo toda vez
+    que qualquer coisa ao redor muda. Aqui está onde essa troca compensa, e
+    onde ela discretamente não compensa."""
+updated = "20 de agosto de 2026"
+og_title = "Quando colocar uma imagem dentro do seu CSS"
+og_description = "O que uma data URI custa, por que um SVG nunca deveria ir em base64, e o erro de aspas que quebra SVGs embutidos em silêncio."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/pt/pages/guides/is-it-safe-to-upload-files.html
@@ -1,0 +1,264 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Para a maioria dos arquivos, na maior parte das vezes, enviar está tudo
+      bem. Conversores sérios apagam o que você manda em algumas horas e não têm
+      interesse nenhum nas suas fotos de viagem.
+    </p>
+    <p>
+      O problema não é que eles estejam mentindo. É que
+      <strong>você não tem como saber se estão</strong>. Assim que um arquivo
+      sai da sua máquina, toda promessa sobre o que acontece depois é uma
+      promessa que você aceita na confiança: por quanto tempo ele fica, quem
+      consegue alcançá-lo, se ele foi copiado para um backup que sobrevive ao
+      cronômetro de exclusão, o que acontece com ele se a empresa for vendida ou
+      invadida. Nada disso é visível de fora.
+    </p>
+    <p>
+      Então a pergunta útil não é &ldquo;eu confio neste site?&rdquo;. É
+      <strong>&ldquo;este trabalho precisa mesmo que o meu arquivo saia
+      daqui?&rdquo;</strong> Para um número grande e crescente de trabalhos a
+      resposta é não, e quando a resposta é não, a pergunta sobre confiança deixa
+      de ser uma que você precisa responder.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que &ldquo;enviar&rdquo; de fato faz</h2>
+    <p>
+      Quando um conversor pede que você escolha um arquivo e então lhe mostra uma
+      barra de progresso, o seu navegador está copiando o arquivo inteiro, byte
+      por byte, pela internet, até um computador que pertence a outra pessoa.
+      Esse computador escreve o arquivo num disco, roda a conversão, escreve o
+      resultado no mesmo disco e lhe entrega um link.
+    </p>
+    <p>
+      Nesse momento o seu arquivo existe em pelo menos três lugares que você não
+      escolheu: o disco do servidor, os registros que anotaram a requisição e,
+      muitas vezes, uma rede de distribuição de conteúdo que guardou o resultado
+      em cache para o download ser rápido. Uma política de exclusão precisa
+      alcançar os três. A maioria diz que alcança. Você não consegue conferir
+      nenhum deles.
+    </p>
+    <p>
+      Vale saber também: o arquivo não é a única coisa que chega. O nome do
+      arquivo vai junto, e junto vai tudo aquilo que está dentro do arquivo e que
+      você não consegue ver. Uma foto recém-saída de um celular normalmente
+      carrega as coordenadas de GPS exatas de onde foi tirada, a hora, o número
+      de série da câmera e às vezes uma miniatura embutida da imagem original,
+      de antes de você cortá-la. Quem tem cuidado com a imagem muitas vezes não
+      tem cuidado com isso, porque nada na tela mostra essas coisas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que a maioria das ferramentas envia mesmo assim</h2>
+    <p>
+      Não é porque queiram os seus arquivos. É porque, durante a maior parte da
+      vida da web, não havia alternativa. Um navegador não conseguia decodificar
+      um vídeo, recodificar uma imagem numa qualidade escolhida ou interpretar um
+      formato de arquivo; um servidor com FFmpeg e ImageMagick conseguia. Enviar
+      não era um modelo de negócio, era o único lugar onde o trabalho podia
+      acontecer.
+    </p>
+    <p>
+      Isso deixou de ser verdade há pouco tempo e sem alarde. Os navegadores hoje
+      trazem WebAssembly, que roda os mesmos codecs compilados perto da
+      velocidade nativa, WebCodecs, que expõe o codificador de vídeo por hardware
+      que já está na sua máquina, e uma API de Canvas que decodifica e recodifica
+      imagens diretamente. O trabalho para o qual um servidor era necessário
+      agora roda no aparelho que já tem o arquivo.
+    </p>
+    <p>
+      Muitas ferramentas ainda enviam, e há motivos honestos: um encanamento
+      existente que ninguém quer reescrever, um formato sem decodificador do lado
+      do navegador, um trabalho genuinamente pesado demais para um celular.
+      Existe também um motivo menos honesto, que é o servidor ser o lugar onde
+      moram as contas, as cotas e os planos pagos. Uma ferramenta que roda
+      inteiramente no seu navegador é difícil de tarifar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quatro verificações que você mesmo pode fazer</h2>
+    <p>
+      Elas funcionam em qualquer ferramenta, esta inclusive. Nenhuma exige
+      acreditar na palavra de ninguém, e a primeira leva uns dez segundos.
+    </p>
+
+    <h3>1. Tire da tomada</h3>
+    <p>
+      Carregue a página, então desligue o wi-fi ou tire o cabo, e tente usar. Uma
+      ferramenta que faz o trabalho no seu navegador continua exatamente como
+      antes. Uma ferramenta que envia para na hora, porque aquilo que faz o
+      trabalho deixou de estar ao alcance.
+    </p>
+    <p>
+      Este é o teste mais forte que existe, e o mais difícil de fingir, porque
+      não pode ser respondido com escolha de palavras. Ou a conversão termina sem
+      rede, ou não termina.
+    </p>
+
+    <h3>2. Olhe a aba Rede</h3>
+    <p>
+      Abra as ferramentas de desenvolvedor do seu navegador, escolha Rede e então
+      use a ferramenta. Toda requisição que a página faz aparece na lista com o
+      tamanho. Se a sua foto de 4&nbsp;MB foi enviada, existe uma requisição de
+      4&nbsp;MB naquela lista. Se a maior coisa saindo da página são alguns
+      kilobytes de publicidade, não foi.
+    </p>
+    <p>
+      Ordene por tamanho e olhe o topo. Você não precisa entender as
+      requisições; precisa notar se alguma delas tem o tamanho do seu arquivo.
+    </p>
+
+    <h3>3. Leia a Content-Security-Policy</h3>
+    <p>
+      Veja o código-fonte da página e procure por
+      <code>Content-Security-Policy</code>, lá no alto. É uma lista dos endereços
+      que aquela página tem permissão de contatar, e quem a faz valer é o seu
+      navegador, e não as boas intenções do site &mdash; uma requisição a
+      qualquer coisa fora da lista é recusada, tente o código o que tentar.
+    </p>
+    <p>
+      A diretiva que importa é <code>connect-src</code>, que rege para onde a
+      página pode mandar dados. Se ela nomeia um endereço pertencente ao site em
+      que você está, a página pode mandar o seu arquivo para lá. Se não nomeia
+      nada, ou nomeia só terceiros como uma rede de anúncios, não pode.
+    </p>
+    <p>
+      Uma página sem Content-Security-Policy nenhuma não é evidência de nada
+      ruim. Só quer dizer que esta verificação em particular não tem nada a lhe
+      dizer.
+    </p>
+
+    <h3>4. Leia o código</h3>
+    <p>
+      A menos conveniente, a mais conclusiva. Se uma ferramenta publica o código
+      dela e o serve sem etapa de compilação, os arquivos que o seu navegador
+      buscou são os arquivos que você pode ler. Procure neles por
+      <code>fetch</code>, <code>XMLHttpRequest</code> e <code>sendBeacon</code>
+      &mdash; os três jeitos que uma página tem de mandar qualquer coisa &mdash;
+      e veja o que é passado para eles.
+    </p>
+    <p>
+      A maioria das pessoas não vai fazer isso. Continua importando que seja
+      possível, porque uma afirmação que ninguém consegue conferir não é bem uma
+      afirmação.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que &ldquo;roda no seu navegador&rdquo; não quer dizer</h2>
+    <p>
+      Vale ser preciso, porque a expressão é usada de forma frouxa e este site
+      tem que se sujeitar ao mesmo critério que está propondo.
+    </p>
+    <ul>
+      <li>
+        <strong>Não quer dizer requisição nenhuma.</strong> A própria página
+        chegou pela rede, e a maioria das ferramentas gratuitas carrega
+        publicidade ou análise que conversa com alguém. A afirmação é sobre o seu
+        <em>arquivo</em>, não sobre tráfego em geral.
+      </li>
+      <li>
+        <strong>Não esconde o seu endereço IP.</strong> Todo site que você visita
+        enxerga o IP, este inclusive. Processamento local é sobre o conteúdo dos
+        seus arquivos, não sobre anonimato.
+      </li>
+      <li>
+        <strong>Não sobrevive a uma função que busca alguma coisa.</strong> Uma
+        ferramenta que deixa você colar um endereço da web precisa contatar
+        aquele endereço, e aquele servidor fica sabendo o seu IP e o que você
+        pediu. Isso é inerente à função, não um defeito dela &mdash; mas é uma
+        exceção real, e uma ferramenta deve dizer isso com todas as letras em vez
+        de arredondar.
+      </li>
+      <li>
+        <strong>Não é a mesma coisa que &ldquo;nós apagamos seus
+        arquivos&rdquo;.</strong> A segunda frase é sobre o que uma empresa
+        escolhe fazer. A primeira é sobre o que é tecnicamente possível. Só uma
+        das duas é verificável.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Quando enviar está genuinamente tudo bem</h2>
+    <p>
+      Isto não é um argumento de que todo envio é um erro. Mande o arquivo quando
+      o conteúdo não for sensível e o trabalho ficar mais fácil assim; quando o
+      trabalho for de fato pesado demais para o seu aparelho; quando o formato
+      não tiver decodificador do lado do navegador; ou quando você estiver usando
+      um serviço com o qual já tem relação e cujos termos você leu de verdade.
+    </p>
+    <p>
+      Tenha mais cuidado quando o arquivo contém algo que você não postaria
+      publicamente: documentos de identidade, exames de imagem, contratos,
+      qualquer coisa com um endereço ou um rosto que você não pretendia
+      compartilhar, ou uma foto cujos dados de localização você não olhou. Para
+      esses, uma ferramenta que você consegue conferir merece preferência sobre
+      uma ferramenta em que você precisa confiar &mdash; não porque a confiável
+      provavelmente vá traí-lo, mas porque com a verificável a pergunta nem
+      chega a surgir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Como este site responde a essas quatro verificações</h2>
+    <p>
+      Seria um guia estranho o que mandasse você conferir e depois pedisse
+      isenção. Então, na ordem:
+    </p>
+    <ul>
+      <li>
+        <strong>Tire da tomada.</strong> Abra qualquer ferramenta daqui,
+        desconecte, e ela continua funcionando. Cada página de ferramenta tem um
+        indicador ao vivo que diz se você está online neste momento, para você
+        ver a mudança acontecer.
+      </li>
+      <li>
+        <strong>Aba Rede.</strong> Converta alguma coisa e leia a lista. Nada
+        leva o seu arquivo, uma miniatura dele, o nome, o tamanho ou qualquer
+        coisa lida de dentro dele. Não existe neste site nenhum evento de análise
+        personalizado que tivesse algo disso para mandar.
+      </li>
+      <li>
+        <strong>Content-Security-Policy.</strong> Está no alto do código-fonte de
+        toda página. O <code>connect-src</code> nomeia os endereços de
+        publicidade e de medição do Google e o botão de doação, e nada mais.
+        <strong>Nenhum endereço daquela lista pertence a este site</strong>,
+        porque este site não tem servidor &mdash; são arquivos estáticos. Não há
+        para onde um arquivo pudesse ser mandado, mesmo que alguma coisa
+        tentasse.
+      </li>
+      <li>
+        <strong>Código.</strong> Cada linha é
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">pública</a>.
+        A compilação remove comentários e espaços em branco e nada mais, e você
+        pode rodá-la você mesmo e comparar o resultado com o que está sendo
+        servido.
+      </li>
+    </ul>
+    <p>
+      As exceções, declaradas em vez de escondidas: este site carrega publicidade
+      do Google e um contador de visitas, os dois conversam com o Google e
+      nenhum dos dois recebe qualquer coisa sobre os seus arquivos; e a
+      ferramenta <a href="../../imagens-para-video/">Imagens para vídeo</a>
+      consegue buscar uma imagem num endereço que você cola, o que significa que
+      aquele servidor enxerga o seu IP. A
+      <a href="../../privacidade/">página de privacidade</a> apresenta as duas
+      por inteiro.
+    </p>
+    <p>
+      Toda ferramenta daqui funciona assim: um
+      <a href="../../comprimir-imagem/">compressor de imagens</a> que acerta um
+      tamanho que você diz, um
+      <a href="../../cortar-video/">cortador de vídeo</a>, um
+      <a href="../../remover-dados-exif/">visualizador e removedor de EXIF</a>
+      para os dados escondidos descritos mais acima nesta página,
+      <a href="../../imagens-para-video/">imagens para vídeo</a> e
+      <a href="../../imagens-para-pdf/">imagens para PDF</a>. Todas gratuitas,
+      sem conta, e nenhuma delas tem para onde mandar os seus arquivos.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/pt/pages/guides/is-it-safe-to-upload-files.toml
@@ -1,0 +1,17 @@
+#
+# Guia: é seguro enviar arquivos? - português do Brasil.
+#
+
+nav = "É seguro enviar arquivos?"
+title = "É seguro enviar arquivos para conversores online?"
+description = "A maioria dos conversores online manda o seu arquivo para um servidor. O que isso significa, o que acontece com ele lá e quatro verificações que dizem se a ferramenta precisa mesmo fazer isso."
+heading = "É seguro enviar arquivos para conversores online?"
+lede = """
+    Normalmente a resposta honesta é &ldquo;provavelmente, mas você não tem
+    como conferir&rdquo;. Aqui está o que enviar realmente faz com o seu
+    arquivo, por que a maioria das ferramentas ainda faz isso e quatro testes
+    que dizem se a que está na sua frente precisa fazer."""
+updated = "20 de agosto de 2026"
+og_title = "É seguro enviar arquivos para conversores online?"
+og_description = "O que acontece com um arquivo enviado a um conversor, por que a maioria das ferramentas ainda pede um e quatro verificações que você mesmo pode fazer."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/make-a-favicon.html
+++ b/locales/pt/pages/guides/make-a-favicon.html
@@ -1,0 +1,340 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../criar-favicon/">Imagem para ICO</a>, jogue dentro uma
+      imagem quadrada de pelo menos 256 pixels, deixe a predefinição em
+      <em>Favicon de site</em> e baixe o <code>favicon.ico</code>. Coloque na
+      raiz do seu site, de modo que ele responda em
+      <code>https://seusite.com/favicon.ico</code>. Esse endereço é pedido por
+      todo navegador, mencione o seu HTML ou não, então a rigor não há mais nada
+      que você precise fazer.
+    </p>
+    <p>
+      Tudo o que vem abaixo é a parte que faz a diferença entre um ícone que está
+      tecnicamente presente e um que é legível: quais tamanhos entram, o que o
+      iPhone e o Android pedem no lugar disso, e o que fazer quando a sua
+      logomarca não sobrevive a ter dezesseis pixels de largura.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que é um conjunto de tamanhos e não uma imagem só</h2>
+    <p>
+      Um arquivo <code>.ico</code> é um contêiner. Dentro dele há várias imagens
+      completas da mesma coisa em tamanhos diferentes, e quem estiver lendo o
+      arquivo escolhe a mais próxima do tamanho de que precisa.
+    </p>
+    <p>
+      Isso soa como redundância e não é. Um navegador desenhando o seu ícone a
+      dezesseis pixels tem duas opções: ler uma versão de dezesseis pixels que
+      você desenhou, ou diminuir uma maior na hora. A segunda é pior, e
+      visivelmente &mdash; uma redução automática de uma logomarca detalhada
+      vira mingau, ao passo que uma versão de dezesseis pixels que você olhou é
+      algo que você teve chance de simplificar. O motivo inteiro de o formato
+      guardar vários tamanhos é lhe dar essa chance.
+    </p>
+    <p>
+      Três tamanhos é a convenção para um site, e cada um tem seu motivo:
+    </p>
+    <ul>
+      <li>
+        <strong>16&times;16</strong> &mdash; a aba do navegador, a barra de
+        endereços, o menu de favoritos. É este que as pessoas veem. Se você só
+        acertar um, acerte este.
+      </li>
+      <li>
+        <strong>32&times;32</strong> &mdash; a barra de favoritos, um atalho de
+        área de trabalho do Windows para o seu site, e a maioria dos navegadores
+        numa tela de alta densidade, que desenham o ícone da aba a partir do 32 e
+        o reduzem.
+      </li>
+      <li>
+        <strong>48&times;48</strong> &mdash; o tamanho em que o Google lê o ícone
+        de um site para os resultados de busca, e a visualização de ícones médios
+        do Windows.
+      </li>
+    </ul>
+    <p>
+      Qualquer coisa maior pertence a um PNG ao lado do <code>.ico</code>, e não
+      dentro dele, por motivos que aparecem abaixo, nos arquivos para celular.
+    </p>
+  </section>
+
+  <section>
+    <h2>O problema dos dezesseis pixels</h2>
+    <p>
+      Esta é a parte sobre a qual ninguém lhe avisa. Dezesseis pixels são cerca
+      de quatro milímetros numa tela normal: uma grade de 256 pontos ao todo,
+      menos que as letras desta frase. Quase nada que foi desenhado para
+      funcionar numa placa, num cartão de visita ou no cabeçalho de um site
+      sobrevive a ser reduzido a isso.
+    </p>
+    <p>
+      O que some, na ordem:
+    </p>
+    <ul>
+      <li>
+        <strong>Texto.</strong> Uma logomarca escrita, encolhida dentro de um
+        quadrado, fica com uns três pixels de altura. Ela não vira texto pequeno,
+        vira uma barra cinza. É por isso que quase toda empresa que tem um
+        símbolo além do nome usa só o símbolo como favicon, e por isso que as que
+        não têm símbolo usam uma letra só.
+      </li>
+      <li>
+        <strong>Linhas finas.</strong> Uma borda de um pixel numa logomarca de
+        512 pixels é um trinta e dois avos de pixel a dezesseis. Ela sai como uma
+        névoa cinza tênue ao longo da borda, ou some.
+      </li>
+      <li>
+        <strong>Gradientes e sombras.</strong> Não há espaço para uma transição.
+        Uma sombra suave vira uma franja suja.
+      </li>
+      <li>
+        <strong>Detalhe dentro de detalhe.</strong> Um ícone de um documento com
+        escrita nele vira um retângulo com um borrão.
+      </li>
+    </ul>
+    <p>
+      O conserto não é um ajuste, é outro desenho: uma marca simplificada com uma
+      ou duas formas, contraste alto e nada de texto além de um único caractere.
+      Desenhe essa versão a 32 ou 48 pixels de propósito, e use como origem.
+    </p>
+    <p>
+      O que uma ferramenta pode fazer é mostrar o problema antes de você
+      publicar. A pré-visualização do
+      <a href="../../criar-favicon/">Imagem para ICO</a> desenha cada tamanho no
+      tamanho real na tela, que é o único jeito de julgar isso &mdash; um ícone
+      de dezesseis pixels exibido a sessenta e quatro fica ótimo e não lhe diz
+      nada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sua logomarca não é quadrada. Completar ou cortar?</h2>
+    <p>
+      Um ícone é sempre quadrado, e a maioria das logomarcas não é, então alguma
+      coisa tem que acontecer. Há três respostas, e elas não são igualmente boas.
+    </p>
+    <p>
+      <strong>Completar com margem</strong> mantém a imagem inteira e põe espaço
+      acima e abaixo dela. É o padrão seguro e a escolha errada para uma
+      logomarca escrita e larga: encaixar num quadrado algo três vezes mais largo
+      que alto deixa a marca ocupando um terço da altura, o que a dezesseis
+      pixels são cinco pixels de logomarca e onze de nada.
+    </p>
+    <p>
+      <strong>Cortar pelo meio</strong> pega o maior quadrado do centro. Numa
+      composição &mdash; um símbolo com o nome da empresa ao lado &mdash; isso
+      muitas vezes corta os dois ao meio. Melhor cortar a origem você mesmo
+      antes, até ficar só o símbolo, e então converter aquilo.
+    </p>
+    <p>
+      <strong>Esticar</strong> achata a imagem para caber. Quase não existe
+      situação em que isso esteja certo, e a opção é oferecida principalmente
+      para que a ferramenta não esteja fazendo isso em silêncio.
+    </p>
+    <p>
+      A resposta geral para uma logomarca larga: não converta a logomarca.
+      Converta a parte dela que funciona sozinha.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparente ou fundo sólido?</h2>
+    <p>
+      Transparente costuma ser o certo para um site. Abas de navegador são
+      cinzas, brancas ou quase pretas, dependendo do navegador e do tema, e um
+      ícone transparente assenta em todas. Um ícone com um fundo branco pintado é
+      um retângulo branco numa barra de abas escura.
+    </p>
+    <p>
+      Duas exceções que vale conhecer:
+    </p>
+    <ul>
+      <li>
+        <strong>Uma logomarca que é escura e mais nada</strong> some no modo
+        escuro. Se a sua marca é preta sobre branco por natureza, dê a ela um
+        fundo colorido em vez de transparente, ou um contorno claro.
+      </li>
+      <li>
+        <strong>O ícone de toque da Apple tem que ser opaco.</strong> O iOS
+        desenha ele sobre o próprio ladrilho arredondado e renderiza
+        transparência como preto. Toda ferramenta que produz aquele arquivo
+        deveria estar achatando para você; a daqui achata, sobre branco por
+        padrão.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Os arquivos de que um site precisa e que não são o .ico</h2>
+    <p>
+      O <code>favicon.ico</code> cobre navegadores e Windows. Ele não cobre
+      celulares, e é aqui que a maioria dos conjuntos de ícones caseiros para
+      cedo demais. Outras três plataformas pedem os arquivos delas, com os nomes
+      delas, e nenhuma vai olhar dentro de um <code>.ico</code>:
+    </p>
+    <ul>
+      <li>
+        <strong>O iOS</strong> lê <code>apple-touch-icon.png</code> a
+        180&times;180 quando alguém adiciona o seu site à tela inicial. Sem ele, o
+        iOS usa uma captura de tela da página, que parece um erro.
+      </li>
+      <li>
+        <strong>O Android e todo aviso de instalação</strong> leem um manifesto
+        de aplicativo web &mdash; <code>site.webmanifest</code> &mdash; que
+        aponta para PNGs de 192 e 512 pixels. O de 512 também é o que um
+        aplicativo web mostra na tela de abertura.
+      </li>
+      <li>
+        <strong>Um ladrilho do menu Iniciar do Windows</strong> lê
+        <code>browserconfig.xml</code>, que aponta para um PNG de 150&times;150.
+        O menos importante dos três, e quatro linhas de XML.
+      </li>
+    </ul>
+    <p>
+      Há mais um que é fácil errar: os lançadores do Android cortam um ícone
+      adaptativo no formato que o celular preferir &mdash; círculo, quadrado
+      arredondado, aquele quase quadrado &mdash; e só os 80% centrais da imagem
+      têm sobrevivência garantida. Um ícone desenhado de borda a borda perde os
+      cantos. É isso que um ícone <em>maskable</em> é: a mesma imagem desenhada
+      de propósito pequena dentro do quadrado, declarada à parte no manifesto.
+    </p>
+    <p>
+      Marcar o conjunto de site no
+      <a href="../../criar-favicon/">Imagem para ICO</a> produz todos esses, o
+      manifesto e o bloco de HTML que aponta para eles. Uma coisa que aquele
+      bloco deixa de fora de propósito é um <code>&lt;link&gt;</code> para o
+      <code>favicon.ico</code>: os navegadores pedem aquele endereço por conta
+      própria, e nomeá-lo também faz o mesmo arquivo ser buscado duas vezes.
+    </p>
+  </section>
+
+  <section>
+    <h2>Um ícone de aplicativo do Windows é outro conjunto</h2>
+    <p>
+      Se o ícone é para um programa e não para um site, os tamanhos mudam. O que
+      o próprio <code>app.ico</code> padrão do Visual Studio contém é 16, 32, 48
+      e 256 &mdash; os três tamanhos do shell mais o grande, de onde o menu
+      Iniciar e a visualização de ícones extragrandes do Explorer desenham.
+    </p>
+    <p>
+      Numa tela de alta densidade o Windows também pede 20, 24, 40, 64 e 96, e os
+      reamostra a partir do tamanho mais próximo que tiver quando estiverem
+      faltando. Se isso importa depende do seu ícone: uma forma chapada sobrevive
+      à reamostragem, uma detalhada não. Acrescentá-los mais ou menos dobra o
+      arquivo, o que para um aplicativo não é nada &mdash; a conta é
+      completamente diferente da de um favicon, onde o arquivo é buscado por cada
+      visitante.
+    </p>
+    <p>
+      Mais uma coisa sobre tamanho: a entrada de 256 é onde estão os bytes.
+      Guardada sem compressão ela sozinha tem 264&nbsp;KB; guardada como PNG
+      dentro do ícone costuma ficar abaixo de 30. Entradas em PNG são legíveis
+      desde o Windows Vista, então o único motivo para evitá-las é software
+      genuinamente mais velho que isso, ou um instalador ou ferramenta embarcada
+      que interpreta ícones por conta própria.
+    </p>
+  </section>
+
+  <section>
+    <h2>Um Mac lê um arquivo completamente diferente</h2>
+    <p>
+      Se o ícone é para um aplicativo de Mac e não para um de Windows, nada do
+      que está acima se aplica: o macOS não lê <code>.ico</code> de jeito nenhum.
+      Ele lê <code>.icns</code>, que é a mesma ideia noutra embalagem &mdash;
+      vários tamanhos num contêiner &mdash; com três diferenças que vale
+      conhecer.
+    </p>
+    <ul>
+      <li>
+        <strong>Os tamanhos são fixos.</strong> A Apple publica dez vagas e não
+        há o que escolher: 16, 32, 64, 128, 256, 512 e 1024 pixels, com 32, 256 e
+        512 aparecendo duas vezes porque cada um é ao mesmo tempo um tamanho
+        próprio e a versão Retina do tamanho de baixo.
+      </li>
+      <li>
+        <strong>Vai até 1024.</strong> Um <code>.ico</code> para em 256, e é por
+        isso que um arquivo de ícone de Mac tem várias centenas de kilobytes e um
+        favicon tem quinze. Para um aplicativo entregue uma vez isso não é nada;
+        só um favicon é buscado por cada visitante.
+      </li>
+      <li>
+        <strong>1024 pixels é o que a sua arte tem que aguentar.</strong> Os dois
+        problemas são pontas opostas da mesma imagem: um favicon tem que
+        funcionar quando é minúsculo, e um ícone de Mac tem que se sustentar
+        quando é enorme. Uma logomarca exportada a 512 e ampliada para 1024 fica
+        macia numa tela Retina, e a App Store não aceita.
+      </li>
+    </ul>
+    <p>
+      Para usar um: um pacote de aplicativo guarda o arquivo em
+      <code>SeuApp.app/Contents/Resources/</code> e o nomeia no
+      <code>Info.plist</code>. Para uma pasta ou uma imagem de disco, selecione o
+      <code>.icns</code> no Finder, aperte Command-C, então Obter Informações na
+      coisa que você quer mudar, clique no ícone pequeno no canto superior
+      esquerdo e aperte Command-V.
+    </p>
+    <p>
+      Marcar <em>ícone do macOS</em> no
+      <a href="../../criar-favicon/">Imagem para ICO</a> escreve um, com ou sem o
+      arquivo do Windows ao lado. Qualquer coisa entregue nas duas plataformas
+      quer os dois, e os dois são desenhados a partir da mesma imagem na mesma
+      passada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Conferindo que deu certo</h2>
+    <p>
+      Os navegadores guardam favicons em cache com mais teimosia do que quase
+      qualquer outra coisa, então &ldquo;subi e não mudou nada&rdquo; costuma ser
+      cache, e não erro. Duas coisas para tentar antes de voltar a editar
+      arquivos:
+    </p>
+    <ul>
+      <li>
+        Abra <code>https://seusite.com/favicon.ico</code> diretamente. Se o
+        arquivo baixar, ele está lá e você está olhando para um cache. Se der
+        404, ele não está na raiz.
+      </li>
+      <li>
+        Carregue o site numa janela anônima, que em geral tem o próprio cache de
+        ícones.
+      </li>
+    </ul>
+    <p>
+      No Windows, um <code>.ico</code> pode ser conferido colocando-o numa pasta
+      e alternando o Explorer entre os tamanhos de visualização: pequeno, médio,
+      grande e extragrande desenham entradas diferentes do mesmo arquivo, então
+      você consegue ver cada uma como o sistema vai ver.
+    </p>
+    <p>
+      Num Mac, um <code>.icns</code> abre no Preview, que lista cada vaga na
+      lateral &mdash; e o mesmo truque funciona no Finder: jogue o arquivo numa
+      pasta e arraste o controle de tamanho nas opções de visualização para ver a
+      troca entre as imagens de dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada disso precisa de envio</h2>
+    <p>
+      Escalar uma imagem é coisa que todo navegador faz há anos, e um
+      <code>.ico</code> é um cabeçalho de seis bytes, dezesseis bytes por imagem,
+      e então as imagens. Não há etapa nenhuma na criação de um que exija um
+      servidor, e a ferramenta daqui não usa um: a
+      <code>Content-Security-Policy</code> da página nomeia todos os endereços
+      que ela pode contatar, e nenhum deles é deste site.
+    </p>
+    <p>
+      Isso vale mais aqui do que de costume. Uma logomarca entregue a um gerador
+      gratuito de favicon é, com bastante frequência, uma marca ainda não
+      lançada &mdash; o ícone é uma das primeiras coisas feitas e uma das últimas
+      anunciadas. Carregue a página, desconecte da internet e faça um mesmo
+      assim, se preferir conferir a acreditar.
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta mais três verificações que você pode
+      fazer em qualquer ferramenta.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/make-a-favicon.toml
+++ b/locales/pt/pages/guides/make-a-favicon.toml
@@ -1,0 +1,21 @@
+#
+# Guia: criar um favicon - português do Brasil.
+#
+# "Favicon" fica como está: é o nome do arquivo e do elemento no HTML, e é
+# assim que a palavra é usada no Brasil - não existe tradução em circulação.
+#
+
+nav = "Criar um favicon"
+title = "Como criar um favicon (e um ícone de aplicativo do Windows)"
+description = "De quais tamanhos um favicon.ico realmente precisa, quais arquivos extras o iPhone, o Android e o Mac pedem, e por que uma logomarca que funciona num cartaz desaparece a dezesseis pixels."
+heading = "Como criar um favicon que ainda se lê a dezesseis pixels"
+lede = """
+    Um favicon não é uma foto pequena da sua logomarca. É um conjunto de
+    imagens em tamanhos fixos, dentro de um contêiner que quase ninguém abre, e
+    a menor delas é a que todo mundo de fato vê. Aqui estão os tamanhos de que
+    você precisa, os arquivos que vão ao lado deles e o que fazer quando sua
+    logomarca não sobrevive à descida."""
+updated = "20 de agosto de 2026"
+og_title = "Criar um favicon que ainda se lê a dezesseis pixels"
+og_description = "De quais tamanhos um favicon.ico precisa, os arquivos extras que o iPhone e o Android pedem, e o que fazer quando sua logomarca não sobrevive à redução."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/make-a-pdf-smaller.html
+++ b/locales/pt/pages/guides/make-a-pdf-smaller.html
@@ -1,0 +1,233 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../comprimir-pdf/">Compressor de PDF</a>, jogue o
+      documento dentro e olhe o que ele lhe diz antes de mudar qualquer coisa.
+      Ele lê o arquivo e mostra onde o tamanho realmente está &mdash; imagens,
+      fontes, texto e desenho, e tudo aquilo a que nada no documento se refere
+      mais. Essa tela sozinha costuma responder à pergunta.
+    </p>
+    <p>
+      Se a maior parte do tamanho é imagem, espere uma economia grande. Se são
+      fontes e texto, não espere, e ferramenta nenhuma vai conseguir. Qual dos
+      dois você tem é a história inteira, e vale dez segundos de olhada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Onde o tamanho de um PDF realmente está</h2>
+    <p>
+      Um PDF é um contêiner para várias coisas diferentes, e elas não comprimem
+      igual.
+    </p>
+    <ul>
+      <li>
+        <strong>Imagens.</strong> Fotografias e escaneamentos. Quase sempre o
+        grosso de um PDF grande, e a única parte com folga de verdade.
+      </li>
+      <li>
+        <strong>Fontes embutidas.</strong> Uma fonte inteira pode ter centenas
+        de kilobytes; um subconjunto só com os caracteres de fato usados é bem
+        menos. De um jeito ou de outro, elas já foram comprimidas por quem
+        produziu o arquivo.
+      </li>
+      <li>
+        <strong>Texto e desenho vetorial.</strong> Instruções em vez de pixels:
+        desenhe esta linha, ponha esta palavra aqui. Já é compacto, e já vem
+        comprimido.
+      </li>
+      <li>
+        <strong>Objetos que nada mais aponta.</strong> PDFs acumulam isso.
+        Editar um documento muitas vezes acrescenta a mudança em vez de
+        reescrever o arquivo, então uma versão antiga de uma página pode ficar
+        lá dentro por tempo indeterminado. Reempacotar o arquivo descarta esses
+        objetos.
+      </li>
+    </ul>
+    <p>
+      Ou seja, os dois documentos que as pessoas levam a um compressor de PDF
+      têm perspectivas completamente diferentes. Um documento escaneado é
+      essencialmente uma pilha de fotografias, e costuma sair 60&ndash;90%
+      menor. Um contrato, uma tese ou um relatório exportado são texto, desenho
+      e fontes &mdash; tudo já comprimido pelo programa que escreveu o arquivo
+      &mdash; e ali a economia costuma ser de alguns por cento, vinda do
+      reempacotamento e do descarte do que não é referenciado.
+    </p>
+    <p>
+      Qualquer ferramenta que promete &ldquo;até 90% menor&rdquo; sem olhar o
+      seu arquivo está citando o melhor caso do primeiro tipo para o segundo.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que o DPI tem a ver com isso</h2>
+    <p>
+      Um PDF não guarda apenas uma imagem; ele registra de que tamanho essa
+      imagem é desenhada na página. Isso lhe dá algo mais útil que a contagem de
+      pixels: a resolução efetiva.
+    </p>
+    <p>
+      Um escaneamento de 4000 pixels de largura colocado ao longo de vinte
+      centímetros de papel está carregando 500 pixels por polegada. Uma tela
+      mostra cerca de 100. Uma boa impressora de escritório trabalha a 300 e não
+      consegue usar muito mais. Tudo acima disso é detalhe que nada no futuro do
+      documento jamais vai exibir &mdash; e costuma ser a maior parte do
+      arquivo.
+    </p>
+    <p>
+      É por isso que um compressor de PDF sensato pede um DPI em vez de uma
+      porcentagem de qualidade. Ele joga fora primeiro os pixels acima do seu
+      número, porque esses não custam nada que alguém possa ver, e só então
+      começa a gastar qualidade de verdade.
+    </p>
+    <p>
+      Guia grosseiro: <strong>150 DPI</strong> para um documento que será lido na
+      tela, <strong>200&ndash;300</strong> para algo que será impresso,
+      <strong>72&ndash;100</strong> para um rascunho que ninguém vai guardar.
+      Medir contra o tamanho em que a imagem é desenhada também é o motivo de
+      uma logomarca colocada pequena não ser tratada igual a um escaneamento de
+      página inteira &mdash; a logomarca já está perto da resolução efetiva dela
+      e não há nada a tirar.
+    </p>
+  </section>
+
+  <section>
+    <h2>No que comprimir deve e no que não deve encostar</h2>
+    <p>
+      As imagens são recodificadas, então essas perdem um pouco. Nada mais
+      deveria ser tocado, e vale conferir se a ferramenta que você usa respeita
+      isso:
+    </p>
+    <ul>
+      <li>
+        <strong>Texto continua texto.</strong> Selecionável, pesquisável,
+        copiável. Um compressor que achata as páginas em imagens vai produzir um
+        arquivo bem pequeno e destruir o documento &mdash; você não consegue
+        pesquisar, leitores de tela não conseguem ler, e não há como desfazer.
+      </li>
+      <li>
+        <strong>As fontes continuam inteiras.</strong> Substituir fontes muda
+        como o documento aparece na máquina de outra pessoa, que é exatamente a
+        coisa que o PDF existe para evitar.
+      </li>
+      <li>
+        <strong>Desenho vetorial é copiado exatamente.</strong> Já é pequeno, e
+        rasterizá-lo o deixaria maior e pior ao mesmo tempo.
+      </li>
+      <li>
+        <strong>Formulários, links, marcadores, estrutura de acessibilidade e
+        anexos passam adiante.</strong> Essas são coisas fáceis de perder numa
+        reescrita e raramente notadas até alguém precisar de uma.
+      </li>
+    </ul>
+    <p>
+      Uma regra relacionada que um compressor deveria seguir e muitos não seguem:
+      se recodificar uma imagem não sai de fato menor que o original, devolva os
+      bytes originais. Piorar uma imagem sem economia nenhuma é o caso de perda
+      pura, e acontece mais do que se imagina em imagens que já estavam bem
+      comprimidas.
+    </p>
+  </section>
+
+  <section>
+    <h2>As imagens que não dá para comprimir</h2>
+    <p>
+      Algumas imagens dentro de um PDF são puladas, e uma boa ferramenta nomeia
+      quais em vez de silenciosamente deixá-las fora da conta:
+    </p>
+    <ul>
+      <li>
+        <strong>Imagens JPEG&nbsp;2000, JBIG2 e codificadas em fax
+        (CCITT).</strong> Navegador nenhum traz decodificador para nenhuma
+        delas, então passam intocadas. As duas últimas são de dois níveis
+        &mdash; só preto e branco &mdash; e em geral já estão perto do menor
+        tamanho possível.
+      </li>
+      <li>
+        <strong>Imagens CMYK.</strong> Deixadas de lado de propósito.
+        Recodificá-las corre o risco de deslocar as cores que uma impressora
+        produziria, o que é uma coisa surpreendente de se fazer com um documento
+        que alguém vai imprimir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Coisas para tentar antes de comprimir</h2>
+    <p>
+      Às vezes o arquivo é grande por um motivo para o qual comprimir é a
+      resposta errada.
+    </p>
+    <p>
+      <strong>Ele foi escaneado sem precisar?</strong> Um documento impresso e
+      depois escaneado é uma pilha de fotografias de texto. Se o original ainda
+      existe em algum lugar como documento, exportar aquilo para PDF vai produzir
+      um arquivo com uma fração do tamanho, e ainda pesquisável.
+    </p>
+    <p>
+      <strong>Ele foi exportado em ajustes de impressão?</strong> Editores de
+      texto e programas de design costumam ter como padrão uma exportação em
+      qualidade de impressão. Reexportar para tela a partir do arquivo de origem
+      normalmente ganha de comprimir a exportação.
+    </p>
+    <p>
+      <strong>Ele precisa ser um arquivo só?</strong> O limite do e-mail é por
+      mensagem. Separar um documento de 200 páginas em capítulos às vezes é o
+      conserto honesto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Arquivos criptografados, e por que um compressor deve recusá-los</h2>
+    <p>
+      Um PDF protegido por senha é recusado pela ferramenta daqui, e isso é
+      deliberado, não uma função faltando &mdash; inclusive quando a senha é
+      vazia, que é como muitos escâneres e copiadoras salvam.
+    </p>
+    <p>
+      Tirar a proteção de um documento é um trabalho diferente de comprimi-lo.
+      Uma ferramenta que fizesse isso em silêncio estaria fazendo algo que você
+      não pediu, num arquivo que alguém trancou de propósito, e lhe devolvendo
+      uma cópia que já não tem a propriedade que aquela pessoa quis lhe dar.
+      Tire a proteção você mesmo primeiro, de propósito, se é isso que você
+      quer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Conferindo o resultado</h2>
+    <p>
+      Abra o arquivo. Olhe as imagens no zoom cheio, confira se o texto continua
+      selecionável e confirme a contagem de páginas.
+    </p>
+    <p>
+      A ferramenta daqui faz a última dessas coisas por você antes de oferecer o
+      arquivo: ela reabre o documento que acabou de escrever e conta as páginas,
+      na sua própria máquina. Ela também escreve PDF 1.5, que todo leitor lançado
+      desde 2003 entende, então &ldquo;abre na minha máquina&rdquo; é uma
+      aproximação razoável de &ldquo;abre na deles&rdquo;.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que isso não precisa de servidor</h2>
+    <p>
+      Comprimir um PDF soa como trabalho de servidor, e durante a maior parte da
+      vida da web foi mesmo. O que a coisa envolve de fato é interpretar a
+      estrutura do arquivo, achar os fluxos de imagem, decodificá-los e
+      recodificá-los com os codecs que o navegador já traz, e escrever o
+      documento de volta. Tudo isso roda num navegador hoje.
+    </p>
+    <p>
+      O que importa mais neste tipo de arquivo do que na maioria, por causa do
+      que as pessoas comprimem: contratos, laudos médicos, extratos bancários,
+      documentos de identidade, declarações de imposto. A ferramenta daqui não
+      tem função de rede nenhuma, e a <code>Content-Security-Policy</code> da
+      página nomeia todos os endereços que ela pode contatar, nenhum dos quais é
+      deste site. Carregue, desconecte e comprima alguma coisa mesmo assim.
+    </p>
+    <p>
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta mais três verificações como essa.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/pt/pages/guides/make-a-pdf-smaller.toml
@@ -1,0 +1,17 @@
+#
+# Guia: deixar um PDF menor - português do Brasil.
+#
+
+nav = "Deixar um PDF menor"
+title = "Como deixar um PDF menor (e por que alguns não encolhem)"
+description = "Onde o tamanho de um PDF realmente está, por que um escaneamento comprime 80% e um contrato quase não se mexe, o que DPI significa aqui e o que um compressor jamais deveria fazer com o seu documento."
+heading = "Como deixar um PDF menor, e por que alguns não encolhem"
+lede = """
+    Um PDF que não cabe no limite do e-mail é quase sempre um PDF cheio de
+    imagens. Aqui está como descobrir se o seu é assim, o que comprimi-lo
+    custa e por que qualquer ferramenta que promete uma porcentagem fixa não
+    olhou para o seu arquivo."""
+updated = "20 de agosto de 2026"
+og_title = "Como deixar um PDF menor"
+og_description = "Onde o tamanho de um PDF realmente está, por que um escaneamento encolhe e um contrato não, e o que o DPI tem a ver com isso."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/make-a-qr-code.html
+++ b/locales/pt/pages/guides/make-a-qr-code.html
@@ -1,0 +1,263 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../gerar-qr-code/">Gerador de QR Code e código de
+      barras</a>, cole o seu link, deixe o nível em <strong>M</strong> e a margem
+      em <strong>4</strong>, e baixe o SVG. Imprima com pelo menos dois
+      centímetros de largura, em algo fosco, escuro sobre claro. Depois escaneie
+      o impresso com um celular que não é o seu, antes de mandar imprimir mil.
+    </p>
+    <p>
+      Isso cobre quase todos os casos. O resto desta página é o que fazer quando
+      não é um deles: um código que precisa aguentar ser manuseado, um código com
+      uma logomarca em cima, um código indo para algo pequeno, e a única decisão
+      que é fácil de errar de um jeito que você só descobre um ano depois.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que existe de fato dentro de um QR Code</h2>
+    <p>
+      Uma cadeia de texto. É isso tudo. Escanear um QR Code entrega ao celular um
+      pedaço de texto, e todo o resto &mdash; abrir uma página, entrar numa rede,
+      oferecer para salvar um contato &mdash; é o celular reconhecendo o formato
+      daquele texto e se oferecendo para agir.
+    </p>
+    <p>
+      Então não existe &ldquo;QR Code de Wi-Fi&rdquo; como categoria de código.
+      Existe um QR Code guardando <code>WIFI:T:WPA;S:Minha Rede;P:a senha;;</code>,
+      que todo celular feito na última década sabe ler. O gerador mostra a cadeia
+      final exatamente por isso: quando um código não faz o que você esperava, a
+      cadeia é a única coisa que vale olhar.
+    </p>
+    <p>
+      Também significa que um QR Code não pode ser mudado depois de impresso, não
+      pode dar notícia a ninguém e não pode expirar &mdash; a não ser que alguém
+      tenha colocado dentro dele um link para o próprio servidor, que é o assunto
+      da última seção daqui.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisão um: o nível de correção de erros</h2>
+    <p>
+      Um QR Code carrega um conjunto de palavras de verificação junto com os
+      dados, calculadas de modo que um leitor consiga reconstruir o que não
+      conseguiu enxergar. É por isso que um código com um canto rasgado ainda
+      escaneia. Quantas dessas palavras existem é o nível, e há quatro:
+    </p>
+    <ul>
+      <li><strong>L</strong> &mdash; cerca de 7% do código pode se perder.</li>
+      <li><strong>M</strong> &mdash; cerca de 15%.</li>
+      <li><strong>Q</strong> &mdash; cerca de 25%.</li>
+      <li><strong>H</strong> &mdash; cerca de 30%.</li>
+    </ul>
+    <p>
+      Mais correção não é de graça: os dados de verificação entram no mesmo
+      quadrado, então o mesmo texto no nível H precisa de um código maior e mais
+      denso que no L. Grosso modo, ir de L para H dobra o número de módulos para a
+      mesma cadeia, e módulos mais densos são mais difíceis de uma câmera
+      resolver. Há uma troca real aqui, e a resposta depende de para onde o código
+      vai.
+    </p>
+    <p>
+      <strong>L</strong> é para tela: um código num slide, num e-mail, numa página
+      web. Nada vai danificá-lo, e cada módulo a mais o torna mais difícil de ler
+      de longe.
+    </p>
+    <p>
+      <strong>M</strong> é o padrão e a resposta certa para a maior parte da
+      impressão. Papel que vai ser manuseado um pouco, um panfleto, um cartão de
+      visita.
+    </p>
+    <p>
+      <strong>Q e H</strong> são para códigos que vão apanhar: um cardápio limpado
+      todo dia, um adesivo numa máquina de oficina, uma etiqueta num engradado, um
+      código numa vitrine que pega sol direto. O H é também o que torna possível
+      uma logomarca no meio &mdash; veja abaixo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisão dois: a margem, que faz parte do código</h2>
+    <p>
+      O espaço branco em volta de um QR Code não é enchimento, e não é escolha de
+      design. Um leitor usa esse espaço para achar onde o símbolo termina. A
+      especificação pede quatro módulos de espaço em silêncio de cada lado, e um
+      código aparado até a borda é o motivo isolado mais comum de um código
+      impresso falhar.
+    </p>
+    <p>
+      Vale ser direto sobre isso porque aparar é uma coisa tão natural de fazer. O
+      código parece ter branco demais em volta, então é cortado no layout, ou
+      jogado sobre um painel colorido que encosta nos quadradinhos, ou colocado
+      sobre uma fotografia. Cada uma dessas coisas remove a fronteira que o leitor
+      ia usar.
+    </p>
+    <p>
+      Se o código parece grande demais com a margem, deixe o código menor. Não
+      tire a margem.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisão três: de que tamanho imprimir</h2>
+    <p>
+      A regra de bolso que sobreviveu ao contato com a realidade é
+      <strong>um para dez</strong>: um código precisa ter cerca de um décimo da
+      distância de onde vai ser escaneado.
+    </p>
+    <ul>
+      <li>Um cartão de visita ou um cardápio, lido a 30 cm: uns 2 cm de largura.</li>
+      <li>Um cartaz lido a dois metros: uns 20 cm.</li>
+      <li>Um ponto de ônibus ou uma vitrine lidos a cinco metros: uns 50 cm.</li>
+    </ul>
+    <p>
+      Dois centímetros é um piso, não um alvo. Abaixo de uns 1,5 cm um celular
+      comum começa a penar, por melhor que seja a impressão, porque os módulos
+      individuais chegam perto do tamanho de um pixel na câmera dele.
+    </p>
+    <p>
+      Menos texto significa menos módulos, o que significa um código que se lê de
+      longe para um dado tamanho impresso &mdash; um bom motivo para apontar um
+      código para <code>exemplo.com.br/x</code> em vez de para uma URL com cem
+      caracteres de parâmetros de rastreamento no fim.
+    </p>
+    <p>
+      E imprima a partir do <strong>SVG</strong>. Um QR Code é feito de bordas, e
+      um PNG tem um número fixo de pixels com que formá-las; amplie um e toda
+      borda amolece, que é exatamente o que dá trabalho a um leitor. Um SVG são os
+      quadradinhos como instruções, então sai nítido num cartão de visita ou num
+      outdoor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cor, contraste e os dois erros</h2>
+    <p>
+      Um leitor mede a diferença entre os módulos escuros e os claros, então o
+      contraste é tudo. Duas coisas dão errado com regularidade:
+    </p>
+    <p>
+      <strong>Código claro sobre fundo escuro.</strong> Fica bonito, e um bom
+      número de leitores recusa de cara: eles procuram escuro sobre claro e não
+      tentam a inversão. Alguns tentam. Você não vai saber quais os seus clientes
+      têm.
+    </p>
+    <p>
+      <strong>Diferença insuficiente.</strong> Cinza médio sobre branco, ou duas
+      cores de marca com peso parecido, podem medir bem na tela e falhar no papel
+      quando entram o espalhamento da tinta e a exposição automática de um
+      celular. Se você está colorindo um código, mantenha a parte escura
+      genuinamente escura.
+    </p>
+    <p>
+      Fosco ganha de brilhante para qualquer coisa que vá ser escaneada sob uma
+      luz, e os dois ganham de imprimir sobre uma fotografia. Fundos transparentes
+      são úteis para colocar um código num painel colorido &mdash; mas confira o
+      que de fato acaba atrás dele, porque um código transparente num painel
+      escuro é o primeiro erro acima com etapas a mais.
+    </p>
+  </section>
+
+  <section>
+    <h2>Uma logomarca no meio</h2>
+    <p>
+      Isso funciona, e funciona por causa da correção de erros, e não apesar dela.
+      No nível H, cerca de 30% dos módulos podem ser destruídos e o código ainda é
+      lido, então uma logomarca cobrindo bem menos que isso &mdash; no centro,
+      onde não fica nenhum padrão de localização &mdash; é dano que o leitor
+      conserta.
+    </p>
+    <p>
+      Três coisas a respeitar. Use o nível H. Mantenha a logomarca abaixo de uns
+      20% da área, bem longe do limite teórico, porque a impressão não é a única
+      coisa comendo a sua margem. E nunca cubra os três quadrados grandes dos
+      cantos nem os menores perto deles: é assim que um leitor encontra e orienta
+      o símbolo em primeiro lugar, e correção de erros nenhuma reconstrói isso.
+    </p>
+    <p>
+      Depois teste em celulares de verdade. Uma logomarca leva um código de
+      &ldquo;sempre funciona&rdquo; para &ldquo;funciona com esta margem&rdquo;, e
+      o único jeito de saber quanta margem sobrou é tentar.
+    </p>
+  </section>
+
+  <section>
+    <h2>A decisão de que as pessoas se arrependem: estático ou &ldquo;dinâmico&rdquo;</h2>
+    <p>
+      Procure por um gerador de QR Code e a maioria dos resultados vai querer que
+      você crie uma conta, porque eles estão vendendo códigos
+      <em>dinâmicos</em>. Um código dinâmico não contém o seu link. Contém um link
+      curto para o servidor do próprio gerador, que redireciona para o seu.
+    </p>
+    <p>
+      O que isso lhe rende é real: você pode mudar para onde o código aponta
+      depois de impresso, e recebe uma contagem de cada escaneamento. Para uma
+      campanha com uma tiragem de seis dígitos, isso vale pagar.
+    </p>
+    <p>
+      O que isso custa também é real, e vale saber antes em vez de depois:
+    </p>
+    <ul>
+      <li>
+        <strong>O código para de funcionar quando eles pararem.</strong> Se o
+        serviço fechar, o domínio expirar ou o plano gratuito acabar, todo código
+        que você imprimiu morre &mdash; e a essa altura eles estão em dez mil
+        cardápios.
+      </li>
+      <li>
+        <strong>Cada escaneamento é dado de outra pessoa.</strong> O
+        redirecionamento enxerga o endereço IP, a hora e o aparelho de cada pessoa
+        que escaneia o seu código.
+      </li>
+      <li>
+        <strong>O link é deles, não seu.</strong> Quem escaneia vê um domínio
+        desconhecido piscar na tela, que é exatamente aquilo de que as pessoas
+        estão sendo orientadas a desconfiar.
+      </li>
+    </ul>
+    <p>
+      O caminho do meio não custa nada: faça um QR Code estático em volta de uma
+      URL curta <em>no seu próprio domínio</em>, e redirecione você mesmo. Você
+      mantém a capacidade de trocar o destino, mantém as estatísticas, e nada
+      sobre o código depende de uma empresa que você nunca viu continuar existindo
+      no ano que vem.
+    </p>
+    <p>
+      O <a href="../../gerar-qr-code/">gerador daqui</a> só faz códigos estáticos,
+      e não tem conta para criar. O que você digita é o que o código guarda.
+    </p>
+  </section>
+
+  <section>
+    <h2>Antes de imprimir mil deles</h2>
+    <p>
+      Escaneie o código. Não o que está na sua tela &mdash; a prova impressa, no
+      lugar em que ele vai ficar, com um celular que não é aquele em que você o
+      fez. Isso leva um minuto e pega a categoria inteira de problemas de que esta
+      página trata: uma margem que o layout comeu, um link sem o
+      <code>https://</code>, uma cor que mediu diferente no papel, um código
+      impresso num tamanho que funciona numa mesa e não numa parede.
+    </p>
+    <p>
+      E confira o que acontece depois do escaneamento. Um código que abre uma
+      página ilegível no celular é um código que falhou, mesmo tendo escaneado.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada disso exige enviar coisa alguma</h2>
+    <p>
+      Um QR Code é aritmética sobre uma cadeia de texto. Não há arquivo para
+      mandar e não há nada que um servidor consiga fazer que um navegador não
+      consiga, e é por isso que a <a href="../../gerar-qr-code/">ferramenta
+      daqui</a> faz tudo na sua própria máquina e funciona com a rede desligada.
+    </p>
+    <p>
+      Isso importa mais do que soa, por causa do que as pessoas colocam em QR
+      Codes. O uso mais comum do formato de Wi-Fi é a senha real de uma rede,
+      digitada numa página web. Vale saber se aquela página tinha para onde
+      mandá-la.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/make-a-qr-code.toml
+++ b/locales/pt/pages/guides/make-a-qr-code.toml
@@ -1,0 +1,20 @@
+#
+# Guia: gerar um QR Code - português do Brasil.
+#
+# "QR Code" fica em inglês porque é assim que se fala no Brasil, inclusive em
+# placa de restaurante. "Código de barras", esse sim, é português corrente.
+#
+
+nav = "Gerar um QR Code"
+title = "Como gerar um QR Code que escaneia sempre"
+description = "Qual nível de correção de erros escolher, por que a margem branca em volta do QR Code faz parte do código, de que tamanho imprimir, e o que o código \"dinâmico\" de um gerador gratuito lhe custa depois."
+heading = "Como gerar um QR Code que ainda escaneia no celular dos outros"
+lede = """
+    Gerar um QR Code leva um segundo. Gerar um que funcione num cardápio
+    molhado, num ponto de ônibus ou num celular esticado no braço com pouca luz
+    leva quatro decisões, e as quatro são tomadas antes de imprimir qualquer
+    coisa. Aqui está o que cada uma faz."""
+updated = "20 de agosto de 2026"
+og_title = "Gerar um QR Code que ainda escaneia no celular dos outros"
+og_description = "As quatro decisões que definem se um QR Code impresso funciona: o nível, a margem, o tamanho e de quem é o endereço que está lá dentro."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/pt/pages/guides/remove-exif-and-gps-data.html
@@ -1,0 +1,220 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../remover-dados-exif/">Visualizador e removedor de
+      EXIF</a>, jogue as fotos dentro e aperte &ldquo;Remover todos os
+      metadados&rdquo;. Todas as etiquetas, os blocos XMP e IPTC, os comentários
+      e a miniatura embutida vão embora, em todas as fotos da lista de uma vez.
+      A imagem em si não é tocada &mdash; não é recomprimida, não é decodificada,
+      não muda um pixel sequer.
+    </p>
+    <p>
+      Antes de fazer isso, vale olhar o que tinha lá dentro. Costuma ser mais do
+      que as pessoas esperam, e essa lista é o argumento para fazer isso.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que existe de fato dentro de uma foto</h2>
+    <p>
+      Um JPEG não é só uma imagem comprimida. É um contêiner, e ao lado da
+      imagem ficam vários blocos de informação que a sua câmera, o seu celular
+      ou o seu editor escreveram ali.
+    </p>
+    <ul>
+      <li>
+        <strong>EXIF.</strong> O principal. Marca e modelo da câmera, lente,
+        ajustes de exposição, ISO, a data e a hora com precisão de segundo, a
+        orientação em que a imagem deve ser exibida e &mdash; num celular com a
+        localização ligada para a câmera &mdash; uma posição de GPS com precisão
+        de poucos metros. Muitas vezes, também o número de série do corpo da
+        câmera.
+      </li>
+      <li>
+        <strong>GPS.</strong> Tecnicamente parte do EXIF, e vale nomear à parte
+        porque é o que mais importa. Vem escrito em graus, minutos e segundos,
+        um formato que faz um ótimo trabalho de não parecer um endereço.
+      </li>
+      <li>
+        <strong>XMP.</strong> Um pacote de XML que os editores escrevem. Pode
+        carregar o seu nome, o seu software, avaliações, palavras-chave,
+        histórico de edição e uma cópia de alguns campos do EXIF &mdash; e é por
+        isso que remover só o EXIF não basta.
+      </li>
+      <li>
+        <strong>IPTC.</strong> Um bloco mais antigo com campos de legenda,
+        assinatura, crédito e direitos autorais, usado na imprensa e em bancos
+        de imagens.
+      </li>
+      <li>
+        <strong>A miniatura embutida.</strong> Uma segunda cópia pequena da
+        imagem. Ela é gerada quando o arquivo é escrito, e nem sempre é gerada
+        de novo quando a imagem é editada &mdash; e é assim que uma foto cortada
+        pode viajar com uma miniatura do que foi cortado fora.
+      </li>
+      <li>
+        <strong>A maker note.</strong> Um bloco não documentado com dados do
+        fabricante. Ninguém fora do fabricante sabe tudo o que tem lá dentro.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Quem de fato vê isso</h2>
+    <p>
+      Esta é a parte em que vale ser preciso, porque tanto a versão alarmada
+      quanto a versão debochada estão erradas.
+    </p>
+    <p>
+      <strong>A maioria das grandes redes sociais apaga os metadados quando você
+      posta.</strong> Facebook, Instagram e X recodificam as imagens enviadas e
+      descartam as etiquetas no processo. Isso não é gentileza &mdash; eles ficam
+      com os dados do lado deles &mdash; mas significa que uma foto postada
+      nesses serviços não entrega as coordenadas dela a cada pessoa que a vê.
+    </p>
+    <p>
+      <strong>Quase todo o resto mantém.</strong> Um anexo de e-mail. Um arquivo
+      mandado pela maioria dos aplicativos de mensagem como
+      &ldquo;documento&rdquo; em vez de foto. Uma imagem num fórum, num anúncio
+      de classificados, num site pessoal, num drive compartilhado, num relato de
+      bug, num chamado de suporte. Em todos esses o arquivo chega inteiro, e
+      qualquer um que o baixe consegue ler as etiquetas com ferramentas que já
+      vêm no sistema operacional.
+    </p>
+    <p>
+      Os riscos realistas são banais em vez de dramáticos: um anúncio de
+      classificados fotografado dentro de casa, uma foto de criança tirada na
+      escola dela, uma conta aparentemente anônima postando fotos que
+      compartilham todas um mesmo número de série de câmera, um &ldquo;tirada
+      semana passada&rdquo; que foi tirada em março.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que não simplesmente salvar de novo?</h2>
+    <p>
+      Salvar de novo uma foto por um editor ou um compressor realmente remove os
+      metadados &mdash; a imagem é decodificada em pixels e codificada outra vez,
+      e um canvas cheio de pixels não carrega etiqueta nenhuma. Funciona, e lhe
+      custa qualidade, porque essa recodificação é com perdas.
+    </p>
+    <p>
+      Remover os metadados direito não custa nada. As etiquetas ficam no
+      contêiner <em>em volta</em> da imagem comprimida, e não dentro dela, então
+      apagá-las é excluir entradas de uma lista e escrever a lista de volta. Os
+      dados de imagem comprimida são copiados byte por byte e o resultado
+      decodifica exatamente para os mesmos pixels. Esse é o motivo inteiro para
+      usar uma ferramenta de metadados em vez de um conversor.
+    </p>
+    <p>
+      A exceção é se você fosse recodificar de qualquer jeito. Se já está
+      comprimindo ou redimensionando a foto, as etiquetas vão embora como efeito
+      colateral e você não precisa de uma segunda etapa.
+    </p>
+  </section>
+
+  <section>
+    <h2>A única coisa que vale manter: a orientação</h2>
+    <p>
+      Celulares não giram a imagem quando você vira o aparelho. Eles gravam do
+      jeito que o sensor viu e acrescentam uma etiqueta de Orientação dizendo
+      como aquilo deve ser virado para exibição. Apague todas as etiquetas e
+      alguns visualizadores vão mostrar a sua foto deitada.
+    </p>
+    <p>
+      É por isso que a ferramenta daqui tem uma opção de &ldquo;manter a etiqueta
+      de orientação&rdquo;, ligada por padrão. Ela escreve de volta um
+      pequeníssimo bloco EXIF contendo só essa etiqueta e nada mais, e só nas
+      fotos que realmente precisavam. O GPS, os horários, o número de série e o
+      resto continuam fora.
+    </p>
+    <p>
+      Desligue se você preferir que o arquivo não carregue EXIF nenhum &mdash; e
+      então confira o resultado antes de mandar, porque uma foto deitada é o
+      desfecho de sempre.
+    </p>
+  </section>
+
+  <section>
+    <h2>Editar em vez de remover</h2>
+    <p>
+      Remover tudo é a resposta certa para a maioria das pessoas. Às vezes não
+      é: um fotógrafo pode querer manter a linha de direitos autorais e os
+      ajustes da câmera e tirar só a localização; um arquivista pode precisar
+      corrigir uma data que estava errada porque o relógio da câmera estava.
+    </p>
+    <p>
+      Os dois são possíveis. A localização pode ser apagada sozinha, e etiquetas
+      de texto, datas, ISO, orientação e resolução podem ser editadas ali mesmo.
+    </p>
+    <p>
+      Uma ressalva que vale para toda ferramenta que faz isso, não só para esta:
+      escrever o arquivo reconstrói o bloco EXIF, e uma maker note contém
+      deslocamentos que apontam para dentro do bloco <em>original</em>. Uma maker
+      note reconstruída pode, portanto, deixar de ser legível pelo próprio
+      software do fabricante. Se isso importa, apague a maker note ou deixe o
+      arquivo sem editar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formatos, e os que não dão para fazer assim</h2>
+    <p>
+      JPEG, PNG e WebP podem todos ser reescritos de forma limpa, e são esses os
+      três que a ferramenta daqui trata.
+    </p>
+    <p>
+      HEIC &mdash; o que um iPhone salva por padrão &mdash; e AVIF são formatos
+      de caixas montados a partir de átomos aninhados, e precisam de um
+      interpretador completamente diferente. A ferramenta reconhece os dois e diz
+      isso, em vez de produzir um arquivo quebrado. Se você tem um HEIC,
+      convertê-lo para JPEG vai remover os metadados como efeito colateral da
+      conversão.
+    </p>
+    <p>
+      Um TIFF puro também não é tratado, e por um motivo mais interessante: num
+      TIFF os metadados e os dados de pixel são endereçados pelos mesmos
+      deslocamentos, então remover etiquetas significa reescrever o
+      endereçamento da própria imagem. Dá para fazer, e é outro trabalho.
+    </p>
+  </section>
+
+  <section>
+    <h2>Um hábito que vale ter</h2>
+    <p>
+      Confira antes de postar, não depois. Ler as etiquetas leva alguns segundos,
+      e a lista de achados nomeia as coisas que vale saber &mdash; a posição, os
+      horários, os números de série &mdash; antes da tabela completa com todas as
+      etiquetas, para você não precisar saber o que procurar.
+    </p>
+    <p>
+      A posição é mostrada primeiro em graus decimais, de propósito. &ldquo;51
+      graus, 30 minutos, 26 segundos&rdquo; não deixa evidente que a foto nomeia
+      o prédio em que foi tirada. Um par de decimais que você cola num mapa
+      deixa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Não mande a foto para descobrir o que tem nela</h2>
+    <p>
+      Há uma ironia específica no jeito como esse problema costuma ser resolvido:
+      alguém preocupado com o que a foto revela envia essa foto a um site para
+      descobrir. O site agora tem a foto, as coordenadas, o horário e o número de
+      série, e uma cópia da imagem num disco que é dele.
+    </p>
+    <p>
+      Não há motivo para isso. Ler e reescrever o contêiner em volta de um JPEG
+      são algumas centenas de linhas de interpretação que um navegador roda
+      perfeitamente bem, e é por isso que a ferramenta daqui não tem função de
+      rede nenhuma: nenhum <code>fetch</code>, nenhum <code>XMLHttpRequest</code>,
+      nada que pudesse mandar um arquivo mesmo que alguma coisa tentasse.
+      Carregue uma vez, desconecte, e ela continua funcionando.
+    </p>
+    <p>
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> mostra como conferir essa afirmação neste site ou
+      em qualquer outro &mdash; e este é o tipo de arquivo em que mais vale a
+      pena conferir.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/pt/pages/guides/remove-exif-and-gps-data.toml
@@ -1,0 +1,17 @@
+#
+# Guia: remover dados EXIF e de GPS - português do Brasil.
+#
+
+nav = "Dados EXIF e de GPS"
+title = "Como remover dados EXIF e de GPS de uma foto"
+description = "Uma foto tirada no celular normalmente carrega o ponto exato onde foi feita, a hora com precisão de segundo e o número de série da câmera. O que tem lá dentro, quem consegue ler e como tirar sem encostar na imagem."
+heading = "O que uma foto conta sobre você, e como tirar isso"
+lede = """
+    Uma foto recém-saída de um celular costuma carregar as coordenadas do lugar
+    onde foi tirada, a hora com precisão de segundo e informação suficiente
+    sobre a câmera para ligá-la a todas as outras fotos do mesmo aparelho. Nada
+    disso aparece na tela. Aqui está o que tem lá dentro e como remover."""
+updated = "20 de agosto de 2026"
+og_title = "O que uma foto conta sobre você, e como tirar isso"
+og_description = "Coordenadas de GPS, horários e números de série viajam dentro de fotos comuns. O que tem lá dentro, quem consegue ler e como apagar."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/resize-an-image.html
+++ b/locales/pt/pages/guides/resize-an-image.html
@@ -1,0 +1,243 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../redimensionar-imagem/">Redimensionador de
+      imagens</a>, jogue a sua imagem dentro, digite um número &mdash; a
+      largura, normalmente &mdash; e deixe o outro em branco. A altura sai do
+      formato da imagem, que é quase sempre o que se queria: &ldquo;1920 de
+      largura&rdquo; quer dizer &ldquo;1920 de largura e a altura que isso
+      der&rdquo;.
+    </p>
+    <p>
+      Tudo o que vem abaixo é o que fazer quando um número não basta: quando lhe
+      deram uma caixa com dois lados, quando a imagem precisa ficar maior, ou
+      quando uma pasta inteira de arquivos tem que sair igual.
+    </p>
+  </section>
+
+  <section>
+    <h2>Diminuir é seguro. Aumentar não é.</h2>
+    <p>
+      Não são duas direções da mesma operação, e vale deixar claro por quê.
+    </p>
+    <p>
+      <strong>Diminuir uma imagem</strong> joga informação fora, e no único
+      sentido benigno: entram mais pixels do que saem, então cada pixel do
+      resultado é a média de detalhe medido de verdade. Uma cópia menor bem
+      redimensionada costuma ficar <em>melhor</em> do que o original visto
+      naquele tamanho, porque a média remove ruído. Nada é inventado.
+    </p>
+    <p>
+      <strong>Aumentar uma imagem</strong> obriga a inventar. O detalhe não está
+      faltando no arquivo; ele nunca foi fotografado. Tudo o que qualquer
+      ampliador pode fazer é chutar os pixels intermediários a partir dos
+      vizinhos, e um chute entre dois valores conhecidos é uma rampa suave
+      &mdash; e é por isso que uma foto ampliada fica macia em vez de nítida. É
+      uma cópia maior da mesma imagem, não uma cópia mais detalhada.
+    </p>
+    <p>
+      É por isso que &ldquo;nunca deixar uma imagem maior do que ela
+      começou&rdquo; vem ligado por padrão na ferramenta daqui. Desligue se você
+      realmente precisar da contagem de pixels &mdash; uma gráfica pedindo um
+      tamanho mínimo, um modelo que recusa qualquer coisa abaixo de certa
+      largura &mdash; mas faça sabendo que está comprando pixels, e não detalhe.
+    </p>
+    <p>
+      Os ampliadores com aprendizado de máquina que parecem mesmo acrescentar
+      detalhe são outra coisa completamente diferente: eles inventam textura
+      plausível a partir de um modelo de como as imagens costumam ser. Para um
+      papel de parede, tudo bem. Para a fotografia de uma pessoa, de um
+      documento, ou de qualquer coisa da qual alguém vá tirar conclusões,
+      entenda que o detalhe extra é ficção.
+    </p>
+  </section>
+
+  <section>
+    <h2>Três maneiras de dizer o tamanho que você quer</h2>
+    <p>
+      A maioria das ferramentas, esta inclusive, aceita as mesmas três, e cada
+      uma serve a um trabalho.
+    </p>
+    <ul>
+      <li>
+        <strong>Pixels exatos.</strong> Use quando alguém especificou o número:
+        um avatar que tem que ter 400&times;400, um banner que tem que ter 1500
+        de largura. Preencha um lado e deixe o outro seguir, a menos que tenham
+        lhe dado os dois.
+      </li>
+      <li>
+        <strong>Uma porcentagem.</strong> Use quando você quer tudo
+        proporcionalmente menor e não se importa com o número exato &mdash;
+        &ldquo;metade do tamanho&rdquo; para um conjunto de fotos que vai entrar
+        num documento.
+      </li>
+      <li>
+        <strong>O lado maior.</strong> A mais útil das três para um lote
+        misturado. &ldquo;Lado maior 1600&rdquo; faz cada imagem caber dentro de
+        um quadrado de 1600 pixels, seja ela em pé ou deitada, que é o que
+        &ldquo;deixa todas num tamanho razoável&rdquo; costuma significar na
+        prática.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Quando a caixa tem formato diferente do da imagem</h2>
+    <p>
+      É aqui que o redimensionamento de fato se decide. Se você der uma largura
+      e uma altura que não batem com as proporções da sua imagem, alguma coisa
+      tem que ceder, e existem exatamente quatro coisas que podem:
+    </p>
+    <ul>
+      <li>
+        <strong>Caber dentro da caixa.</strong> A imagem inteira é mantida e sai
+        menor que a caixa num dos eixos. Nada se perde e nada se deforma; você
+        só não fica com as dimensões exatas que pediu. É o padrão certo para
+        quase tudo.
+      </li>
+      <li>
+        <strong>Preencher a caixa e cortar o que sobra.</strong> Você fica com
+        exatamente as dimensões que pediu, e as partes da imagem que passam das
+        bordas somem. Certo para miniaturas, avatares e capas, onde o formato é
+        fixo e o assunto está no meio. Errado quando o que importa está perto de
+        uma borda.
+      </li>
+      <li>
+        <strong>Completar com margem.</strong> A imagem inteira é mantida,
+        centralizada, com o espaço que sobra preenchido por uma cor que você
+        escolhe. Certo quando um sistema exige dimensões exatas e você não pode
+        perder nada da imagem &mdash; anúncios de produto costumam funcionar
+        assim.
+      </li>
+      <li>
+        <strong>Esticar.</strong> A imagem é achatada ou puxada para caber. Isso
+        nunca é o que você quer, a não ser que esteja fazendo de propósito, e é
+        a opção que todo mundo reconhece na hora como errada.
+      </li>
+    </ul>
+    <p>
+      Se você se pegar indo atrás do esticar, o que provavelmente quer é cortar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cortar é outro trabalho, e muitas vezes é o certo</h2>
+    <p>
+      Redimensionar muda quantos pixels descrevem a imagem inteira. Cortar muda
+      qual parte da imagem você fica. As pessoas vão atrás do primeiro querendo
+      o segundo com uma frequência surpreendente &mdash; &ldquo;isto precisa ser
+      quadrado&rdquo; é um problema de corte, não de redimensionamento.
+    </p>
+    <p>
+      Faça nessa ordem: corte primeiro para o enquadramento que quer, depois
+      redimensione o resultado para o tamanho de que precisa. Ao contrário,
+      significa escolher o corte dentro de uma imagem que já perdeu pixels.
+    </p>
+    <p>
+      A ferramenta daqui faz os dois numa passada só justamente por isso
+      &mdash; arraste uma caixa, trave numa proporção se precisar de uma
+      específica, e então diga em que tamanho o resultado deve sair. Fazer numa
+      passada só também significa que a imagem é codificada uma vez só, o que
+      importa pelo motivo da próxima seção.
+    </p>
+    <h3>Cortando um lote inteiro</h3>
+    <p>
+      Uma caixa desenhada numa imagem é aplicada às demais como a mesma área
+      <em>relativa</em>: as mesmas frações da largura e da altura de cada
+      arquivo. Numa pasta de capturas de tela ou de exportações que têm todas o
+      mesmo tamanho, isso é exatamente o mesmo retângulo. Num lote misturado é o
+      mesmo enquadramento em vez do mesmo retângulo, o que em geral é o que se
+      queria, mas vale saber antes de confiar cinquenta arquivos a ele.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que a recodificação custa, e como manter em uma só</h2>
+    <p>
+      Redimensionar um JPEG ou um WebP significa decodificá-lo, escalar os
+      pixels e codificá-los de novo &mdash; e essa última etapa é com perdas. A
+      escala em si não é o que lhe custa qualidade; a recodificação é.
+    </p>
+    <p>
+      Daí decorrem duas coisas. Primeira, o ajuste de qualidade na saída importa:
+      algo em torno de 80&ndash;85 é invisível numa fotografia e
+      consideravelmente menor que 100. Segunda, faça uma vez só. Redimensionar
+      uma imagem que já foi redimensionada duas vezes dá três gerações de
+      codificação com perdas, e isso aparece.
+    </p>
+    <p>
+      Um PNG não tem esse custo, porque é sem perdas &mdash; um PNG
+      redimensionado é exatamente os pixels escalados. Se você está trabalhando
+      em várias etapas e o formato final ainda não foi decidido, trabalhar em
+      PNG no meio do caminho evita empilhar gerações.
+    </p>
+    <p>
+      Um detalhe que vale saber sobre a ferramenta daqui: um arquivo que você
+      não está de fato alterando é devolvido byte por byte em vez de
+      recodificado. Peça &ldquo;lado maior 1600&rdquo; num lote e os que já
+      estão abaixo de 1600 saem intocados, com etiquetas e tudo. Uma ferramenta
+      que recodificasse esses em silêncio estaria lhe custando qualidade em
+      arquivos que ninguém pediu para mudar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparência, e o que acontece com ela</h2>
+    <p>
+      PNG e WebP conseguem guardar transparência. JPEG não &mdash; não existe
+      canal alfa nenhum no formato. Então salvar uma imagem transparente como
+      JPEG obriga a pôr alguma coisa atrás dela, e essa alguma coisa é uma cor
+      chapada.
+    </p>
+    <p>
+      A maioria das ferramentas usa branco e não avisa, o que está tudo bem até
+      a sua logomarca cair numa página escura com uma caixa branca em volta.
+      Escolha a cor de propósito, ou salve como PNG ou WebP e mantenha a
+      transparência. A mesma cor é usada atrás de um quadro com margem
+      preenchida, que é o outro lugar onde as pessoas encontram isso de
+      surpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qual ferramenta, se lhe deram um número</h2>
+    <p>
+      Dois números diferentes costumam ser entregues, e cada um pede uma
+      ferramenta diferente.
+    </p>
+    <p>
+      <strong>&ldquo;1200 pixels de largura&rdquo;</strong> é um problema de
+      dimensões. O
+      <a href="../../redimensionar-imagem/">Redimensionador de imagens</a> é o
+      caminho: você diz quantos pixels quer e ele lhe dá isso.
+    </p>
+    <p>
+      <strong>&ldquo;Abaixo de 500&nbsp;KB&rdquo;</strong> é um problema de
+      tamanho de arquivo, e redimensionar é só uma das formas de resolver. O
+      <a href="../../comprimir-imagem/">Compressor de imagens</a> procura a
+      maior qualidade que cabe no seu alvo e só redimensiona se a qualidade
+      sozinha não chegar lá;
+      <a href="../comprimir-uma-imagem-para-um-tamanho-exato/">o guia dele</a>
+      trata do que isso custa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada disso precisa de envio</h2>
+    <p>
+      Decodificar uma imagem, escalá-la e codificá-la de novo são coisas que
+      todo navegador sabe fazer há anos &mdash; é o mesmo maquinário que uma
+      página web usa para desenhar uma imagem em outro tamanho. Não existe
+      motivo técnico para a sua foto viajar até um servidor e voltar para sair
+      menor, e a ferramenta daqui não manda ela para lugar nenhum: a
+      <code>Content-Security-Policy</code> da página nomeia todos os endereços
+      que ela pode contatar, e nenhum deles é deste site.
+    </p>
+    <p>
+      Carregue a página, desconecte da internet e redimensione alguma coisa
+      mesmo assim, se você preferir conferir a acreditar.
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta mais três verificações que você pode
+      fazer em qualquer ferramenta.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/resize-an-image.toml
+++ b/locales/pt/pages/guides/resize-an-image.toml
@@ -1,0 +1,17 @@
+#
+# Guia: redimensionar uma imagem - português do Brasil.
+#
+
+nav = "Redimensionar uma imagem"
+title = "Como redimensionar uma imagem sem estragá-la"
+description = "O que acontece com uma foto quando você muda as dimensões em pixels: por que diminuir é seguro e aumentar não é, o que fazer quando a caixa tem outro formato e quando é melhor cortar."
+heading = "Como redimensionar uma imagem sem estragá-la"
+lede = """
+    Redimensionar é o único trabalho de imagem em que o estrago fica decidido
+    antes de você apertar o botão, pelo número que digita e pelo formato que
+    pede. Aqui está o que cada escolha faz com a foto e quais delas dá para
+    desfazer."""
+updated = "20 de agosto de 2026"
+og_title = "Redimensionar uma imagem sem estragá-la"
+og_description = "Por que diminuir é seguro e aumentar não é, o que fazer quando a caixa tem outro formato e quando é melhor cortar."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/trim-a-video.html
+++ b/locales/pt/pages/guides/trim-a-video.html
@@ -1,0 +1,198 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../aparar-video/">Aparador de vídeo</a>, jogue o clipe
+      dentro, aperte <kbd>I</kbd> e <kbd>O</kbd> para marcar cada trecho que
+      você quer &mdash; quantos quiser &mdash; e exporte. Num MP4, MOV ou M4V os
+      quadros que você mantém são movidos para o arquivo novo exatamente como
+      estavam &mdash; os mesmos bytes, os mesmos ajustes de codificador, tudo
+      igual &mdash; e o som é copiado amostra por amostra sem ser decodificado.
+    </p>
+    <p>
+      Isso significa que aparar não lhe custa qualidade nenhuma, e é rápido:
+      tirar um minuto de uma gravação de quatro gigabytes custa mais ou menos o
+      que custa escrever esse minuto no disco, porque os quadros são apontados
+      em vez de carregados. O único lugar onde isso aparece é onde o seu corte de
+      fato cai, que é o resto desta página.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que aparar não precisa perder qualidade nenhuma</h2>
+    <p>
+      Aparar não muda a aparência de quadro nenhum. Cada quadro que você mantém
+      deve sair idêntico a como entrou, então não há motivo para decodificá-lo e
+      codificá-lo de novo &mdash; e há todo motivo para não fazer isso, já que
+      uma recodificação é com perdas e deixaria o clipe inteiro um pouco pior só
+      para encurtá-lo.
+    </p>
+    <p>
+      Então um bom aparador não recodifica. Ele lê o índice do arquivo, descobre
+      quais quadros codificados caem na sua faixa e escreve aqueles bytes num
+      contêiner novo com um índice novo na frente deles. Nada é decodificado
+      nesse caminho.
+    </p>
+    <p>
+      Muitas ferramentas recodificam mesmo assim, porque decodificar e recodificar
+      é bem mais simples de implementar do que interpretar o formato do
+      contêiner. Você normalmente descobre com qual das duas está lidando pelo
+      tempo que leva: uma cópia é limitada pela velocidade de escrita do seu
+      disco, e uma recodificação é limitada pela velocidade com que a sua máquina
+      codifica vídeo, que é cem vezes mais lenta.
+    </p>
+  </section>
+
+  <section>
+    <h2>Keyframes, e por que o seu corte pode cair antes</h2>
+    <p>
+      Aqui está a restrição da qual decorre tudo o que se refere a aparar.
+    </p>
+    <p>
+      Vídeo não é guardado como uma sequência de imagens completas. Isso seria
+      enorme. A maioria dos quadros é guardada como uma descrição de como eles
+      diferem dos vizinhos, o que significa que não podem ser decodificados
+      sozinhos &mdash; você precisa dos quadros em volta. Só um
+      <strong>keyframe</strong> se sustenta sozinho como imagem completa, e os
+      keyframes ficam tipicamente de um a dez segundos de distância um do outro.
+    </p>
+    <p>
+      Então, se você marca um corte dois segundos depois do último keyframe, um
+      aparador que copia quadros não consegue começar ali. Os quadros no seu
+      marcador são ilegíveis sem a sequência que leva até eles. Ele tem que
+      carregar o trecho inteiro a partir do keyframe anterior ao seu marcador.
+    </p>
+    <p>
+      O que ele faz a respeito disso é a parte interessante. O formato do arquivo
+      tem uma forma padrão de dizer <em>comece a tocar neste ponto</em> &mdash;
+      os quadros extras estão no arquivo, mas o contêiner instrui o reprodutor a
+      pulá-los. Todo reprodutor mais usado respeita isso, e o clipe começa
+      exatamente onde você disse. Um reprodutor que ignore vai começar antes, no
+      máximo pelo intervalo entre keyframes.
+    </p>
+    <p>
+      A ferramenta daqui diz em qual dos casos você está e por quanto, antes de
+      exportar, para que seja uma decisão em vez de uma surpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando aceitar uma recodificação</h2>
+    <p>
+      Existe o corte exato, e ele funciona recodificando o trecho de abertura
+      &mdash; decodificando a partir do keyframe e escrevendo uma nova sequência
+      de quadros que começa genuinamente onde você marcou. É mais lento, e custa
+      um pouco de qualidade só naquele trecho de abertura.
+    </p>
+    <p>
+      Escolha esse caminho quando o clipe for para algum lugar que não respeite a
+      instrução do contêiner, ou onde você não controla o reprodutor: alguns
+      editores de vídeo, alguns sistemas de transmissão e de videoconferência,
+      alguns reprodutores de hardware mais antigos. Escolha a cópia para todo o
+      resto, que é quase tudo &mdash; um navegador, um celular, uma plataforma
+      social, um reprodutor de mídia.
+    </p>
+    <p>
+      Uma terceira opção que não custa nada: mova o seu marcador. Se a ferramenta
+      mostra onde estão os keyframes, empurrar o corte para o mais próximo lhe dá
+      um corte exato sem recodificação nenhuma. Raramente vale a pena abrir mão
+      de uma cópia por um segundo de diferença.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tirando um pedaço do meio</h2>
+    <p>
+      Cortar um trecho fora é uma operação diferente de manter um trecho, e vale
+      saber que é suportada, porque muitos aparadores só fazem a segunda. Marque
+      a parte que você não quer, escolha tirá-la, e o que sobra dos dois lados é
+      unido num só clipe com o som carregado junto e em sincronia.
+    </p>
+    <p>
+      A emenda tem a mesma restrição de keyframe no ponto em que a segunda metade
+      recomeça, pelo mesmo motivo. Funciona nos dois caminhos de MP4 daqui. É a
+      única coisa que a gravação de recuo descrita abaixo não consegue fazer,
+      porque uma gravação é feita numa passada só, a partir de um único cursor de
+      reprodução.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formatos, e o recuo</h2>
+    <p>
+      <strong>MP4, M4V e MOV</strong> são lidos diretamente, seja qual for o
+      codec lá dentro &mdash; H.264, HEVC, AV1, VP9. Copiar quadros não envolve
+      decodificá-los, então esse caminho funciona até para um codec para o qual o
+      seu navegador não tem decodificador nenhum, o que é uma consequência
+      agradável de não olhar as imagens.
+    </p>
+    <p>
+      <strong>Qualquer outra coisa que o seu navegador consiga tocar</strong>,
+      WebM mais obviamente, é aparada tocando o arquivo e gravando o resultado.
+      Funciona, e tem dois custos: leva o mesmo tempo que o trecho dura, e a
+      imagem e o som são codificados de novo.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV e a maioria dos MKVs</strong> o navegador não
+      consegue nem ler nem tocar, e a ferramenta diz isso em vez de falhar no
+      meio do caminho. Converta esses para MP4 antes, com algo que dê conta
+      deles.
+    </p>
+  </section>
+
+  <section>
+    <h2>Duas coisas que dão errado em silêncio por aí</h2>
+    <p>
+      <strong>Rotação.</strong> Um celular filma deitado e escreve uma instrução
+      de rotação no arquivo em vez de girar os pixels. Um aparador que copia
+      quadros tem que carregar essa instrução adiante, ou o seu clipe em pé sai
+      deitado &mdash; que é o jeito clássico de arruinar um vídeo aparado. O
+      caminho exato daqui gira os quadros enquanto os recodifica e escreve um
+      arquivo que não precisa de rotação nenhuma.
+    </p>
+    <p>
+      <strong>Sincronia do áudio.</strong> Áudio e vídeo são guardados como
+      fluxos separados com temporização própria, e não são picotados nos mesmos
+      pontos. Se os dois não forem alinhados de propósito no corte, o som vai
+      derivando. No caminho de cópia daqui o áudio é copiado amostra por amostra
+      sem ser decodificado, então é byte a byte o que estava no arquivo, e um
+      marcador de edição o mantém em sincronia com a imagem dentro de um
+      milésimo de segundo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Aparar não é cortar o enquadramento</h2>
+    <p>
+      Duas palavras que as pessoas usam uma pela outra. Aparar muda a duração do
+      clipe; cortar muda o formato da imagem. Se o que você quer é uma versão
+      quadrada de um vídeo deitado, ou as tarjas pretas fora das laterais, isso é
+      o <a href="../../cortar-video/">Cortador de vídeo</a> &mdash; e, ao
+      contrário de aparar, ele precisa recodificar, pelo motivo que
+      <a href="../cortar-um-video/">o guia dele</a> explica.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que isso não precisa de envio &mdash; especialmente isto</h2>
+    <p>
+      Vídeo é o tipo de arquivo que as pessoas mais esperam ter que enviar,
+      porque os arquivos são grandes e o trabalho soa pesado. Aparar é o caso em
+      que isso é menos verdade: no caminho de cópia o arquivo mal é lido. A
+      ferramenta percorre o índice, descobre quais faixas de bytes manter e as
+      escreve. Enviar um arquivo de quatro gigabytes a um servidor para que ele
+      faça isso seria a forma mais lenta possível de organizar a coisa.
+    </p>
+    <p>
+      É também o tipo de arquivo em que enviar custa mais caro para quem preferia
+      não enviar: vídeo carrega rostos, vozes, casas e localizações de um jeito
+      que um documento não carrega. A ferramenta daqui não tem função de rede de
+      espécie alguma, e a <code>Content-Security-Policy</code> da página nomeia
+      todos os endereços que ela pode contatar, nenhum dos quais é deste site.
+    </p>
+    <p>
+      Desconecte da internet e apare um clipe mesmo assim, se preferir conferir a
+      acreditar.
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta mais três verificações do mesmo tipo.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/trim-a-video.toml
+++ b/locales/pt/pages/guides/trim-a-video.toml
@@ -1,0 +1,16 @@
+#
+# Guia: aparar um vídeo - português do Brasil.
+#
+
+nav = "Aparar um vídeo"
+title = "Como aparar um vídeo sem recodificá-lo"
+description = "Cortar um clipe não precisa perder um único byte de qualidade. Por que um corte às vezes cai antes de onde você marcou, o que um keyframe tem a ver com isso e quando aceitar uma recodificação."
+heading = "Como aparar um vídeo sem recodificá-lo"
+lede = """
+    Aparar não muda a aparência de quadro nenhum, então um bom aparador não
+    encosta neles &mdash; ele os move para um arquivo novo exatamente como
+    estavam. Aqui está o que isso lhe garante, e o único lugar onde aparece."""
+updated = "20 de agosto de 2026"
+og_title = "Como aparar um vídeo sem recodificá-lo"
+og_description = "Por que um corte às vezes cai antes de onde você marcou, o que um keyframe tem a ver com isso e quando aceitar uma recodificação."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/pt/pages/guides/turn-a-video-into-a-gif.html
@@ -1,0 +1,220 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../video-para-gif/">conversor de vídeo para GIF</a>,
+      jogue o clipe dentro, marque os segundos que quer e deixe a largura em 480
+      e a taxa em 12 quadros por segundo. Esse é o ajuste que a maioria dos GIFs
+      quer. Se o arquivo sair grande demais, baixe a largura antes de encostar em
+      qualquer outra coisa &mdash; é o ajuste que rende em dobro.
+    </p>
+    <p>
+      O resto desta página é o porquê, porque &ldquo;meu GIF está com 14 MB&rdquo;
+      é o problema que todo mundo de fato tem, e qual botão girar não é óbvio.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que um GIF de um vídeo é tão enorme</h2>
+    <p>
+      Um codec de vídeo guarda <em>movimento</em>. Ele escreve uma imagem inteira
+      a cada par de segundos e então, para cada quadro no meio, uma descrição de
+      como aquela imagem se mexeu: este bloco de pixels deslizou quatro para a
+      esquerda, esta área ficou um pouco mais escura. Um clipe de cinco segundos
+      pode ter algumas centenas de kilobytes porque a maior parte dele são
+      instruções sobre uma imagem que você já tem.
+    </p>
+    <p>
+      O GIF não tem nada disso. Ele foi finalizado em 1989, antes de qualquer uma
+      dessas coisas existir. Todo quadro é uma imagem, comprimida sozinha com um
+      esquema desenhado para capturas de tela de uma planilha. Não existe
+      estimativa de movimento em lugar nenhum do formato e não há como
+      acrescentar uma.
+    </p>
+    <p>
+      Então o número a esperar é <strong>dez vezes o tamanho do vídeo</strong>, e
+      conversor nenhum vai lhe convencer do contrário. O que um bom conversor pode
+      fazer é não desperdiçar nada além disso, e lhe dar os três ajustes que de
+      fato decidem a coisa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Os três ajustes, e o que cada um custa</h2>
+    <p>
+      Tudo sobre o tamanho de um GIF se resume a quantos pixels ele contém, que é
+      a duração vezes a taxa vezes a área de um quadro.
+    </p>
+    <ul>
+      <li>
+        <strong>O trecho &mdash; linear.</strong> O dobro da duração é o dobro de
+        quadros e mais ou menos o dobro do arquivo. Este é o que a maioria já
+        entende, e vale ser implacável: um GIF que faz o ponto dele em três
+        segundos é um GIF melhor além de menor.
+      </li>
+      <li>
+        <strong>A largura &mdash; quadrática.</strong> Cortar a largura pela
+        metade corta a altura junto, então é um <em>quarto</em> dos pixels. Ir de
+        640 para 320 não economiza pouco menos da metade; economiza uns três
+        quartos. Este é o ajuste que ninguém procura primeiro e o que mais rende.
+      </li>
+      <li>
+        <strong>A taxa de quadros &mdash; linear.</strong> Dez quadros por segundo
+        dão dois terços do tamanho de quinze. É também o ajuste em que a perda
+        mais aparece, porque movimento lento demais se lê como quebrado em vez de
+        como pequeno.
+      </li>
+    </ul>
+    <p>
+      Um exemplo feito. Seis segundos de um clipe de celular na resolução própria
+      dele, 1080&times;1920, a 30 fps são 180 quadros de dois milhões de pixels:
+      cerca de 350 milhões de pixels, o que não é um GIF, é um sequestro com
+      reféns. Os mesmos seis segundos a 480 de largura e 12 fps são 72 quadros de
+      400.000 pixels &mdash; 30 milhões, cerca de um doze avos &mdash; e ficam
+      parecidos com aquilo que as pessoas querem dizer com GIF.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qual taxa de quadros escolher</h2>
+    <p>
+      Doze é o padrão daqui e a resposta certa com uma frequência surpreendente. É
+      a taxa que a animação desenhada à mão usa há um século: rápida o bastante
+      para o olho ler como movimento contínuo, lenta o bastante para você não
+      estar pagando por quadros que ninguém consegue ver.
+    </p>
+    <ul>
+      <li><strong>5&ndash;8</strong> &mdash; jeitão de apresentação de slides.
+        Serve para um travelling lento ou uma gravação de tela em que nada se mexe
+        depressa.</li>
+      <li><strong>10&ndash;15</strong> &mdash; normal. Lê-se como movimento. Quase
+        todo GIF que vale a pena fazer está aqui.</li>
+      <li><strong>20&ndash;25</strong> &mdash; suave, e mais ou menos o dobro do
+        tamanho de 12 por uma diferença que a maioria de quem assiste não vai
+        saber nomear. Vale para movimento rápido, um clipe de esporte, qualquer
+        coisa com uma panorâmica veloz.</li>
+    </ul>
+    <p>
+      Há um teto rígido que vale conhecer: o GIF guarda quanto tempo cada quadro
+      fica na tela em centésimos de segundo, e todo navegador trata um atraso
+      abaixo de dois centésimos como dez. Então 50 quadros por segundo é o máximo
+      real, e um arquivo pedindo 100 vai tocar em silêncio a 10. Um conversor que
+      lhe oferece 60 fps ou está ignorando isso ou está prestes a lhe
+      surpreender.
+    </p>
+  </section>
+
+  <section>
+    <h2>256 cores, e para que serve o dithering</h2>
+    <p>
+      A outra metade da idade do formato: um GIF carrega uma tabela de no máximo
+      256 cores, e cada pixel é um número que aponta para dentro dela. Um quadro
+      de vídeo tem até dezesseis milhões. Quase tudo isso é jogado fora, e o jeito
+      como é jogado fora é a maior parte da aparência de um GIF.
+    </p>
+    <p>
+      Um bom conversor conta as cores do <em>seu</em> clipe e escolhe 256 que lhe
+      caiam bem, em vez de usar um conjunto fixo. Uma tomada de floresta ganha 256
+      verdes; uma tomada de pôr do sol ganha 256 laranjas. É isso que a ferramenta
+      daqui faz, olhando todos os quadros do trecho em vez de só o primeiro, para
+      que uma cor que só aparece no fim ainda ganhe uma vaga.
+    </p>
+    <p>
+      <strong>Dithering</strong> é o que acontece onde a cor de que você precisa
+      continua faltando. Em vez de arredondar uma área inteira para a cor
+      disponível mais próxima &mdash; o que transforma um céu suave em quatro
+      faixas chapadas com degraus visíveis entre elas &mdash; ele alterna as duas
+      cores mais próximas num padrão fino, e de uma distância normal de
+      visualização o seu olho as mistura naquela que não existe.
+    </p>
+    <ul>
+      <li><strong>Deixe ligado</strong> para qualquer coisa fotográfica: céus,
+        pele, gradientes, sombras, cinema.</li>
+      <li><strong>Desligue</strong> para cor chapada: gravações de tela, desenho
+        de traço, logomarcas, desenhos animados, qualquer coisa com grandes áreas
+        de um tom só. Não há gradiente a proteger, e o arquivo fica menor e mais
+        limpo sem ele.</li>
+    </ul>
+    <p>
+      Um detalhe que vale conhecer se você comparar conversores. O jeito óbvio de
+      fazer dithering &mdash; difusão de erro, que a maioria dos editores de
+      imagem usa &mdash; faz o resultado de cada pixel depender dos pixels em
+      volta. Numa animação isso significa que um fundo que não está se mexendo
+      ainda assim recebe dithering diferente em cada quadro, então ele fervilha
+      visivelmente, e todo quadro tem que ser guardado por inteiro porque
+      tecnicamente todo pixel mudou. A alternativa, um dithering ordenado, depende
+      só de onde o pixel está, então um fundo parado fica perfeitamente parado. É
+      isso que esta ferramenta usa, e é por isso que os arquivos dela são menores
+      além de mais calmos.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando não fazer um GIF</h2>
+    <p>
+      Vale perguntar, porque a resposta honesta muitas vezes é &ldquo;não
+      faça&rdquo;. Um MP4 ou WebM mudo e em laço tem cerca de um décimo do tamanho
+      da mesma animação como GIF, toca do mesmo jeito, e é no que toda plataforma
+      social converte o seu GIF depois que você o envia, de qualquer forma.
+    </p>
+    <p>Fique com o GIF onde o destino genuinamente precisa de um:</p>
+    <ul>
+      <li>algum lugar que só aceita imagem &mdash; muitos softwares de chat, de
+        fórum, de wiki e de e-mail;</li>
+      <li>um README ou uma página de documentação, onde um GIF toca embutido e um
+        vídeo precisa de um reprodutor;</li>
+      <li>uma apresentação de slides ou um documento que tem que continuar se
+        mexendo offline;</li>
+      <li>um emoji, uma figurinha, uma reação &mdash; pequenos o bastante para
+        nenhuma daquelas contas de tamanho importar.</li>
+    </ul>
+    <p>
+      Onde o som importa, a pergunta se responde sozinha: o GIF nunca teve áudio e
+      nunca vai ter. Corte o vídeo em vez disso &mdash; o
+      <a href="../../aparar-video/">Aparador de vídeo</a> tira um trecho sem
+      recodificar um quadro sequer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ficando abaixo de um limite de tamanho</h2>
+    <p>
+      A maior parte do motivo de alguém ajustar um GIF é um limite na outra ponta.
+      Em ordem grosseira de quanto eles mordem:
+    </p>
+    <ul>
+      <li><strong>E-mail</strong> &mdash; de 10 a 25 MB para a mensagem inteira, e
+        um anexo perto disso é retirado ou devolvido por alguma coisa no meio do
+        caminho. Mire bem abaixo.</li>
+      <li><strong>Chat e fóruns</strong> &mdash; comumente de 8 a 10 MB, às vezes
+        muito menos para uma prévia embutida em vez de um download.</li>
+      <li><strong>Um README do GitHub</strong> &mdash; 10 MB por arquivo, e
+        qualquer coisa acima de uns dois megabytes faz a página parecer quebrada
+        num celular.</li>
+      <li><strong>Vagas de figurinha e de emoji</strong> &mdash; muitas vezes
+        algumas centenas de kilobytes, o que significa largura pequena e trecho
+        curto, e não taxa de quadros menor.</li>
+    </ul>
+    <p>
+      A ordem para tentar, quando você estiver acima: encurte o trecho, depois
+      corte a largura pela metade, depois baixe a taxa, depois desligue o
+      dithering. As duas primeiras valem mais que as duas últimas juntas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nada disso precisa de envio</h2>
+    <p>
+      Converter um vídeo em GIF é decodificar, redimensionar, contar cores e
+      comprimir &mdash; quatro coisas que um navegador sabe fazer sozinho há anos.
+      A ferramenta ligada lá em cima faz tudo isso na sua máquina: o arquivo é
+      lido do seu disco, os quadros são decodificados pelo seu navegador, e o GIF
+      é montado na memória e entregue aos seus downloads.
+    </p>
+    <p>
+      Isso vale mais aqui do que de costume. Os clipes que as pessoas transformam
+      em GIF são pessoais &mdash; um momento de um vídeo de família, uma gravação
+      de tela de algo do trabalho, alguns segundos de uma chamada. Um conversor
+      que quer isso enviado está pedindo uma cópia daquilo, e não sobrou motivo
+      técnico para dizer sim.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/pt/pages/guides/turn-a-video-into-a-gif.toml
@@ -1,0 +1,16 @@
+#
+# Guia: transformar um vídeo em GIF - português do Brasil.
+#
+
+nav = "Fazer um GIF de um vídeo"
+title = "Como transformar um vídeo em GIF (e manter ele pequeno)"
+description = "Qual trecho, qual largura e qual taxa de quadros escolher, por que um GIF de um vídeo tem dez vezes o tamanho do vídeo, e quando vale usar um."
+heading = "Como transformar um vídeo em GIF"
+lede = """
+    GIF é um formato de 1987 que guarda imagens inteiras em vez de movimento,
+    então um GIF feito de vídeo é sempre grande. Aqui está qual dos três
+    ajustes mexer quando ele ficar grande demais, e quanto cada um rende."""
+updated = "20 de agosto de 2026"
+og_title = "Como transformar um vídeo em GIF, e manter ele pequeno"
+og_description = "Os três ajustes que decidem o tamanho de um GIF, o que cada um custa e quando o GIF é a resposta errada de saída."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/guides/turn-images-into-a-video.html
+++ b/locales/pt/pages/guides/turn-images-into-a-video.html
@@ -1,0 +1,194 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../imagens-para-video/">Imagens para vídeo</a>, jogue
+      as imagens dentro, coloque em ordem, defina quanto tempo cada uma fica na
+      tela e crie o vídeo. Você recebe um MP4 com vídeo H.264, que toca em
+      basicamente qualquer coisa.
+    </p>
+    <p>
+      Os dois ajustes que mais costumam obrigar a uma segunda passada são a
+      duração e a resolução, e vale entendê-los antes da primeira renderização,
+      não depois.
+    </p>
+  </section>
+
+  <section>
+    <h2>Taxa de quadros e duração não são a mesma coisa</h2>
+    <p>
+      Essa é a confusão que custa às pessoas uma nova renderização.
+    </p>
+    <p>
+      <strong>Duração</strong> é quanto tempo cada imagem fica na tela. É o
+      ajuste com que você de fato se importa. Três segundos é um padrão
+      confortável para uma apresentação que alguém está assistindo; um a dois
+      segundos parece ágil; qualquer coisa acima de cinco arrasta, a menos que
+      haja narração por cima.
+    </p>
+    <p>
+      <strong>Taxa de quadros</strong> é quantas vezes por segundo o vídeo repete
+      aquela imagem. Ela não muda nada na aparência da apresentação &mdash; uma
+      imagem parada mantida por três segundos fica idêntica a 24 quadros por
+      segundo e a 60 &mdash; e muda bastante o tamanho do arquivo e o tempo de
+      codificação.
+    </p>
+    <p>
+      Então, para uma apresentação simples, escolha uma taxa de quadros baixa. 24
+      ou 30 dá e sobra. O motivo para subir é se houver movimento no vídeo: um
+      travelling ou zoom sobre cada foto, ou uma transição entre elas, onde uma
+      taxa baixa aparece como serrilhado no movimento.
+    </p>
+  </section>
+
+  <section>
+    <h2>Resolução, e imagens de formato errado</h2>
+    <p>
+      Um vídeo tem um único tamanho de quadro do começo ao fim. As suas
+      fotografias quase certamente não têm todas o mesmo, então alguma coisa
+      precisa acontecer com as que não couberem &mdash; e essa alguma coisa é a
+      escolha que vale fazer de propósito.
+    </p>
+    <p>
+      Comece escolhendo a resolução a partir do destino do vídeo:
+    </p>
+    <ul>
+      <li>
+        <strong>1920&times;1080</strong> para qualquer coisa geral. Suportado
+        universalmente, toca em todo lugar, e é o que a maioria das pessoas
+        chama de HD.
+      </li>
+      <li>
+        <strong>1080&times;1920</strong> &mdash; os mesmos números ao contrário
+        &mdash; para um destino pensado no celular: stories, reels, shorts.
+      </li>
+      <li>
+        <strong>3840&times;2160</strong> só se as imagens realmente tiverem todo
+        esse detalhe e o destino for exibi-lo. São quatro vezes os pixels, quatro
+        vezes o tempo de codificação e mais ou menos quatro vezes o arquivo.
+      </li>
+    </ul>
+    <p>
+      Depois decida o que acontece com as que não batem. Caber cada imagem dentro
+      do quadro mantém tudo e deixa tarjas nas laterais &mdash; seguro, e a
+      resposta certa quando as imagens importam mais do que a apresentação.
+      Preencher o quadro e cortar o que sobra fica mais bonito e vai cortar o
+      topo de algumas delas. Misturar fotos em pé e deitadas num vídeo só é o
+      caso em que não existe boa resposta; decidir antes de qual jeito você
+      prefere errar poupa uma nova renderização.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ordem, e a armadilha do nome de arquivo</h2>
+    <p>
+      Como em qualquer trabalho em lote, os nomes de arquivo se ordenam de um
+      jeito que não é o jeito como você contou. <code>photo2.jpg</code> vem
+      depois de <code>photo10.jpg</code> numa ordenação alfabética, porque a
+      comparação é caractere por caractere.
+    </p>
+    <p>
+      Ordenar pela data em que a foto foi tirada costuma estar certo para
+      fotografias de um evento, já que você as tirou na ordem em que as coisas
+      aconteceram. Arrastar os quadradinhos está certo para qualquer coisa em
+      que a história não seja cronológica. Confira antes de renderizar: o vídeo é
+      o único produto em que consertar a ordem significa refazer o trabalho
+      inteiro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Não há trilha sonora, e isso não é pouca coisa</h2>
+    <p>
+      O MP4 que esta ferramenta escreve tem uma única trilha de vídeo e nenhuma
+      trilha de áudio. Se a sua apresentação precisa de música ou narração, você
+      vai precisar de um editor de vídeo para essa etapa.
+    </p>
+    <p>
+      Vale saber por quê, e não apenas que é assim: acrescentar áudio significa
+      decodificar um arquivo de música, codificá-lo em AAC e intercalá-lo com o
+      vídeo dentro do contêiner. As três coisas são trabalho de verdade, e
+      fazê-las mal produz um arquivo que vai perdendo o sincronismo enquanto
+      toca. Está na lista em vez de estar pela metade.
+    </p>
+    <p>
+      Uma nota prática, se você for acrescentar música depois: escolha a faixa
+      primeiro e ajuste a duração por imagem para que a apresentação saia perto
+      da duração da música. Aparar a música para caber no vídeo sempre soa pior
+      que ajustar o vídeo à música.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que sai, e o que fazer se não tocar</h2>
+    <p>
+      MP4 com H.264 é o alvo, e é a combinação mais amplamente reproduzível que
+      existe. Num navegador sem WebCodecs a ferramenta recua para gravar WebM
+      &mdash; as mesmas imagens num contêiner que menos editores e menos
+      plataformas sociais aceitam.
+    </p>
+    <p>
+      Se você acabar com um WebM e alguma coisa recusar, o conserto é um
+      navegador com suporte a WebCodecs, e não uma conversão: as versões atuais
+      do Chrome, do Edge e do Safari têm. Renderizar de novo é melhor do que
+      converter, porque converter significa mais uma geração de codificação com
+      perdas.
+    </p>
+    <p>
+      Não há limite embutido na ferramenta para quantas imagens você pode usar. O
+      teto é a memória da sua própria máquina, porque o vídeo pronto é montado
+      ali antes de você baixá-lo &mdash; uma apresentação longa em 4K é a
+      primeira coisa a sentir isso.
+    </p>
+  </section>
+
+  <section>
+    <h2>Deixando o arquivo menor</h2>
+    <p>
+      Se o resultado ficar grande demais para onde ele vai, na ordem do que de
+      fato ajuda:
+    </p>
+    <p>
+      <strong>Baixe a taxa de quadros.</strong> Numa apresentação de imagens
+      paradas isso não custa nada visível e é a maior economia isolada
+      disponível.
+    </p>
+    <p>
+      <strong>Baixe a resolução.</strong> 1080p em vez de 4K é um quarto dos
+      pixels, e numa tela de celular ninguém vai perceber.
+    </p>
+    <p>
+      <strong>Encurte.</strong> Três segundos por imagem em vez de cinco tira 40%
+      da duração e 40% do arquivo, e em geral dá uma apresentação melhor.
+    </p>
+    <p>
+      Diminuir as fotografias de origem não ajuda muito. O vídeo é codificado na
+      resolução que você escolheu de todo jeito, então uma foto de 4000 pixels e
+      uma de 2000 produzem quase o mesmo número de bytes num vídeo 1080p. O que
+      isso faz é acelerar a codificação, e empurrar aquele teto de memória.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que isso não precisa de servidor, com uma exceção declarada</h2>
+    <p>
+      Codificar vídeo já foi o caso mais evidente a favor do envio: navegadores
+      não davam conta, e uma máquina com FFmpeg dava. O WebCodecs mudou isso ao
+      expor o codificador de hardware que já está na sua máquina, que é o mesmo
+      que o seu celular usa para gravar vídeo em tempo real. Compor os quadros é
+      um canvas. Nenhuma das duas etapas precisa de nada além do seu próprio
+      hardware.
+    </p>
+    <p>
+      Uma exceção nesta ferramenta específica, declarada em vez de escondida: a
+      função opcional de &ldquo;adicionar a partir de um endereço da web&rdquo;
+      busca uma imagem num endereço que você cola, e o servidor daquele endereço
+      enxerga o seu IP e o que você pediu. Isso é inerente à função, e não um
+      defeito dela, e é a única etapa de rede em toda a ferramenta. Não use essa
+      função e nada sai da sua máquina.
+    </p>
+    <p>
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> apresenta quatro verificações que lhe dizem a mesma
+      coisa sobre qualquer ferramenta, esta inclusive.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/turn-images-into-a-video.toml
+++ b/locales/pt/pages/guides/turn-images-into-a-video.toml
@@ -1,0 +1,16 @@
+#
+# Guia: transformar imagens em vídeo - português do Brasil.
+#
+
+nav = "Imagens em vídeo"
+title = "Como transformar uma pasta de imagens em um vídeo"
+description = "Faça uma apresentação em MP4 a partir de fotos: o que a taxa de quadros e a duração de fato controlam, o que fazer com imagens de formato diferente e por que o resultado sai sem trilha sonora."
+heading = "Como transformar uma pasta de imagens em um vídeo"
+lede = """
+    Uma apresentação de slides é simples de fazer e fácil de ter que renderizar
+    duas vezes, porque dois dos ajustes não significam o que parecem
+    significar. Aqui está o que cada um controla e o que escolher."""
+updated = "20 de agosto de 2026"
+og_title = "Como transformar uma pasta de imagens em um vídeo"
+og_description = "O que a taxa de quadros e a duração de fato controlam, o que fazer com imagens de formato diferente e por que não há trilha sonora."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/privacy.html
+++ b/locales/pt/pages/privacy.html
@@ -1,0 +1,192 @@
+  <section>
+    <h2>Seus arquivos</h2>
+    <p>
+      Toda ferramenta deste site faz seu trabalho dentro do seu próprio
+      navegador, no seu próprio hardware. Quando você escolhe um arquivo, ele é
+      lido pela página que você já tem aberta. Ele não é enviado para nós,
+      porque não existe servidor nosso para onde ele pudesse ir &mdash; este
+      site é um conjunto de arquivos estáticos, sem backend, sem banco de dados
+      e sem armazenamento.
+    </p>
+    <p>
+      Isso quer dizer que nunca recebemos, vemos, guardamos, registramos nem
+      processamos:
+    </p>
+    <ul>
+      <li>seus arquivos, inteiros ou em partes</li>
+      <li>miniaturas ou pré-visualizações deles</li>
+      <li>os nomes, os tamanhos, as dimensões ou os formatos</li>
+      <li>quantos você escolheu, ou o que você fez com eles</li>
+      <li>nada lido de dentro deles, inclusive dados EXIF e de GPS</li>
+    </ul>
+    <p>
+      Isto não é uma promessa sobre as nossas intenções. Cada página carrega uma
+      <code>Content-Security-Policy</code> que nomeia todos os endereços que a
+      página tem permissão de contatar, e quem faz valer a regra é o navegador.
+      Nenhum desses endereços é nosso. Você pode ler a política no alto do
+      código-fonte de qualquer página, ou abrir a aba Rede do seu navegador e
+      observar: nenhuma requisição leva o seu arquivo.
+    </p>
+    <p>
+      Os arquivos que você produz com uma ferramenta são entregues ao mecanismo
+      de download do próprio navegador e salvos onde você mandar. Nessa etapa
+      também não entramos.
+    </p>
+  </section>
+
+  <section>
+    <h2>A única exceção, e onde ela vale</h2>
+    <p>
+      A ferramenta <a href="../imagens-para-video/">Imagens para vídeo</a> tem
+      uma função de &ldquo;adicionar a partir de um endereço da web&rdquo;. Se
+      você colar um endereço nela, o seu navegador vai buscar aquela imagem no
+      servidor que você indicou, e <strong>esse servidor enxerga o seu endereço
+      IP</strong> e qual arquivo você pediu. Isso é inevitável, e é a natureza
+      inteira da função.
+    </p>
+    <p>
+      Só acontece com endereços que você mesmo digita, foi construída de modo
+      que imagens possam entrar mas nenhum dado possa sair, e a página daquela
+      ferramenta explica isso com mais detalhes. Nenhuma outra ferramenta deste
+      site consegue fazer uma requisição para fora levando algo seu dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que é coletado, e por quem</h2>
+    <p>
+      Este site é gratuito e se paga com publicidade. Isso significa que dois
+      produtos do Google rodam nestas páginas, e um botão de doação roda na
+      maioria delas. A lista completa é esta.
+    </p>
+
+    <h3>Google AdSense &mdash; os anúncios</h3>
+    <p>
+      O Google exibe os anúncios e decide quais você vê. Para isso ele pode
+      gravar e ler cookies ou identificadores parecidos no seu navegador, e
+      recebe o seu endereço IP, uma localização aproximada derivada dele, o seu
+      agente de usuário e em qual página você estava. Dependendo das suas
+      configurações e de onde você está, os anúncios podem ser personalizados
+      usando um perfil que o Google mantém sobre você, montado em boa parte a
+      partir da sua atividade em outros sites.
+    </p>
+    <p>
+      Nada disso chega até nós, não conseguimos ver, e nunca mandamos ao Google
+      coisa alguma sobre os seus arquivos. A explicação do próprio Google sobre
+      como ele usa dados de sites que exibem seus anúncios está em
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>.
+    </p>
+
+    <h3>Google Analytics &mdash; o contador de visitas</h3>
+    <p>
+      Usamos o Google Analytics 4 para contar visitas às páginas, para saber em
+      quais ferramentas vale a pena trabalhar. Ele registra a página que você
+      viu, mais ou menos quando, um identificador gerado aleatoriamente e
+      guardado no seu navegador, uma localização aproximada, o tipo do seu
+      aparelho e do seu navegador, e o site que trouxe você até aqui.
+    </p>
+    <p>
+      Ele está configurado para não fazer mais nada, e a configuração é um
+      arquivo que você pode ler: o <code>analytics.js</code> ao lado de cada
+      página monta um contador de visualizações e não contém evento
+      personalizado nenhum. Nada neste site passa a ele um arquivo, um nome de
+      arquivo, uma dimensão ou uma contagem &mdash; não existe aqui código que
+      pudesse fazer isso.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; o botão de doação</h3>
+    <p>
+      A página inicial e as páginas das ferramentas trazem um botão de doação,
+      que é carregado dos servidores do Buy Me a Coffee. Carregá-lo faz com que
+      a CDN deles veja o seu endereço IP e saiba que você estava neste site, e
+      as letras do botão vêm do Google Fonts, que também vê o seu endereço IP.
+      Nada mais é enviado, e nada além disso acontece a menos que você
+      efetivamente clique, e aí você já está no site deles, sob as políticas
+      deles. Esta página e a <a href="../termos/">página de termos</a> não
+      desenham o botão.
+    </p>
+
+    <h3>Hospedagem</h3>
+    <p>
+      O site é servido pelo GitHub Pages, atrás da Cloudflare. Como qualquer
+      hospedagem, eles processam as requisições que o seu navegador faz &mdash;
+      o que inclui o seu endereço IP, a página pedida e o seu agente de usuário
+      &mdash; para entregar a página e manter o serviço no ar e seguro. Não
+      temos acesso aos registros por visitante de nenhum dos dois.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cookies</h2>
+    <p>
+      Não gravamos nenhum cookie nosso. Não temos login, não temos sessão, não
+      temos preferências para lembrar e não temos motivo para isso.
+    </p>
+    <p>
+      Todo cookie ou identificador parecido que você encontrar aqui é do Google
+      e foi gravado pelos scripts de publicidade e de análise descritos acima.
+      Servem para medir visitas e para escolher e limitar a repetição dos
+      anúncios.
+    </p>
+    <h3>Como desligar</h3>
+    <ul>
+      <li>
+        A personalização de anúncios pode ser desligada, para todos os sites de
+        uma vez, na
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">Central de Anúncios</a>.
+      </li>
+      <li>
+        O Google Analytics pode ser bloqueado em todo lugar com a
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">extensão de desativação</a>
+        do próprio Google.
+      </li>
+      <li>
+        As configurações do seu navegador podem bloquear ou apagar cookies de
+        terceiros, e qualquer bloqueador de conteúdo impede que esses scripts
+        cheguem a carregar.
+      </li>
+    </ul>
+    <p>
+      Bloquear tudo isso está ótimo para nós. <strong>Toda ferramenta deste site
+      funciona com os scripts bloqueados, e funciona com a rede completamente
+      desconectada.</strong> Nada aqui fica preso atrás de um anúncio.
+    </p>
+  </section>
+
+  <section>
+    <h2>Seus direitos sobre os dados</h2>
+    <p>
+      Não guardamos nenhum dado pessoal sobre você, então não há nada que
+      possamos lhe mostrar, corrigir, exportar ou apagar &mdash; um pedido feito
+      a nós voltaria vazio, sinceramente.
+    </p>
+    <p>
+      Os dados descritos acima ficam com o Google, que é o próprio controlador
+      deles. Pedidos a respeito têm que ir para eles, pela
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">sua conta Google</a>
+      ou pelos canais de privacidade deles.
+    </p>
+  </section>
+
+  <section>
+    <h2>Crianças</h2>
+    <p>
+      Este site não é dirigido a crianças e não pergunta a idade de ninguém,
+      porque não pergunta nada a ninguém. Não coletamos conscientemente nenhum
+      dado pessoal de ninguém, de idade nenhuma.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mudanças, e como falar com a gente</h2>
+    <p>
+      Se esta página mudar, a data no alto muda junto, e a edição fica no
+      histórico público de commits junto com todo o resto.
+    </p>
+    <p>
+      Dúvidas sobre qualquer coisa daqui podem ir para
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, ou virar uma issue
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">no repositório</a>,
+      onde a resposta fica visível para todo mundo que estiver na mesma dúvida.
+    </p>
+  </section>

--- a/locales/pt/pages/privacy.toml
+++ b/locales/pt/pages/privacy.toml
@@ -1,0 +1,17 @@
+#
+# Privacidade e cookies - português do Brasil. Overrides for pages/privacy/page.toml.
+#
+
+nav = "Privacidade e cookies"
+title = "Privacidade e cookies &mdash; abox.tools"
+description = "O que o abox.tools coleta e o que não coleta. Seus arquivos nunca são enviados; a publicidade, o contador de visitas e o botão de doação estão descritos por inteiro."
+heading = "Privacidade e cookies"
+lede = """
+    A versão curta: seus arquivos nunca são enviados, porque não existe lugar
+    nenhum para enviá-los. Todo o resto desta página trata da publicidade, do
+    contador de visitas e da hospedagem &mdash; as partes em que outras
+    empresas realmente entram."""
+updated = "19 de agosto de 2026"
+og_title = "Privacidade e cookies &mdash; abox.tools"
+og_description = "Seus arquivos nunca são enviados. O que é coletado, por quem e como desligar."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/pages/terms.html
+++ b/locales/pt/pages/terms.html
@@ -1,0 +1,155 @@
+  <section>
+    <h2>O que é este site</h2>
+    <p>
+      O abox.tools é um conjunto de pequenos utilitários que rodam dentro do seu
+      navegador. São de uso gratuito, para qualquer coisa, inclusive trabalho
+      comercial. Não há nada para comprar, nenhuma conta para criar, nenhum
+      limite de uso e nenhuma função guardada.
+    </p>
+    <p>
+      Ao usar o site você aceita os termos desta página. Se não aceitar, a
+      solução é simplesmente fechar a aba &mdash; não há nada de seu guardado
+      aqui.
+    </p>
+  </section>
+
+  <section>
+    <h2>Seus arquivos continuam seus</h2>
+    <p>
+      Você mantém todos os direitos que já tinha sobre os arquivos que abrir com
+      estas ferramentas e sobre o que quer que produza com elas. Não reivindicamos
+      licença, propriedade nem interesse de espécie alguma sobre nenhum dos dois.
+    </p>
+    <p>
+      Isso não é generosidade, é aritmética: as ferramentas rodam inteiramente no
+      seu navegador e seus arquivos nunca são transmitidos para nós, então não
+      existe nada sobre o que pudéssemos ter direitos. A
+      <a href="../privacidade/">página de privacidade</a> explica como isso
+      funciona e como conferir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Usar o site com responsabilidade</h2>
+    <p>
+      Você é responsável pelos arquivos que processar e pelo que fizer com os
+      resultados. Em especial, não use estas ferramentas em material sobre o qual
+      você não tem direito, nem para produzir qualquer coisa ilegal.
+    </p>
+    <p>
+      Não temos como fazer valer isso e não estamos fingindo o contrário. Nunca
+      vemos seus arquivos, então aqui não existe moderação, não existe varredura
+      e não existe maneira de sabermos o que alguém está fazendo. A obrigação é
+      genuinamente sua.
+    </p>
+    <p>
+      Também pedimos que não interfira no site em si &mdash; atacando a
+      hospedagem, ou redistribuindo cópias modificadas de um jeito que sugira que
+      são o original.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sem garantia</h2>
+    <p>
+      O site e suas ferramentas são fornecidos <strong>como estão</strong>, sem
+      garantia de espécie alguma, expressa ou implícita, incluindo qualquer
+      garantia implícita de comerciabilidade, adequação a uma finalidade
+      específica ou não violação de direitos.
+    </p>
+    <p>
+      Concretamente: uma ferramenta pode produzir um resultado que você não
+      queria, pode falhar num arquivo que não entende, pode se comportar de forma
+      diferente em navegadores diferentes e pode perder o trabalho se a aba for
+      fechada no meio da operação. Nada do que você faz aqui é salvo em lugar
+      nenhum, então <strong>guarde os seus originais</strong>. Não use estas
+      ferramentas na única cópia de algo que importe para você.
+    </p>
+  </section>
+
+  <section>
+    <h2>Limitação de responsabilidade</h2>
+    <p>
+      Na maior extensão que a lei permitir, não somos responsáveis por qualquer
+      perda ou dano decorrente do seu uso deste site &mdash; incluindo arquivos
+      perdidos, corrompidos ou inutilizáveis, tempo perdido, lucros cessantes ou
+      qualquer perda indireta ou consequencial.
+    </p>
+    <p>
+      Nada aqui limita responsabilidade que a lei não permita limitar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Disponibilidade</h2>
+    <p>
+      O site é oferecido sem promessa de que vai continuar no ar, continuar
+      gratuito, manter qualquer ferramenta específica ou sequer continuar
+      existindo. Ferramentas podem mudar ou ser retiradas sem aviso.
+    </p>
+    <p>
+      Vale conhecer uma consequência prática do jeito como estas ferramentas são
+      feitas: depois que a página de uma ferramenta carregou, ela continua
+      funcionando offline, e não para de funcionar porque o site caiu. O código
+      também é público, então uma ferramenta da qual você depende pode ser
+      mantida no ar por você, aconteça o que acontecer por aqui.
+    </p>
+  </section>
+
+  <section>
+    <h2>Publicidade e outras empresas</h2>
+    <p>
+      O site exibe publicidade do Google, conta visitas com o Google Analytics e
+      mostra um botão de doação na maioria das páginas. O que cada uma dessas
+      coisas envolve está descrito por inteiro na
+      <a href="../privacidade/">página de privacidade</a>.
+    </p>
+    <p>
+      Os anúncios, e qualquer site a que você chegue clicando num deles, não são
+      nossos. Não escolhemos anúncios individuais, não endossamos o que eles
+      dizem e não somos responsáveis pelos sites para onde levam nem por
+      negócios que você venha a fazer lá. O mesmo vale para todos os outros links
+      externos deste site.
+    </p>
+  </section>
+
+  <section>
+    <h2>O código-fonte</h2>
+    <p>
+      O código deste site é publicado abertamente em
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>,
+      porque &ldquo;leia e confira você mesmo&rdquo; é a única resposta de
+      verdade para &ldquo;por que eu deveria confiar nisso&rdquo;. O reúso desse
+      código é regido pelos termos de licença declarados no repositório, e não
+      por esta página. Estes termos tratam do seu uso do site.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lei aplicável</h2>
+    <p>
+      Este site é operado a partir do Canadá. Estes termos, e qualquer disputa
+      que surja deles ou do seu uso do site, são regidos pelas leis do Canadá e
+      da província em que o site é operado, sem consideração às regras de
+      conflito de leis.
+    </p>
+    <p>
+      Se a lei de defesa do consumidor do lugar onde você mora lhe dá direitos
+      que estes termos restringiriam, esses direitos prevalecem.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mudanças nestes termos</h2>
+    <p>
+      Estes termos podem ser atualizados. Quando forem, a data no alto muda, e a
+      edição aparece no histórico público de commits como qualquer outra
+      alteração. Continuar usando o site depois de uma mudança significa aceitar
+      a versão atualizada.
+    </p>
+    <p>
+      Dúvidas podem ir para <a href="mailto:hi@abox.tools">hi@abox.tools</a>, ou
+      virar uma issue
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">no repositório</a>.
+    </p>
+  </section>

--- a/locales/pt/pages/terms.toml
+++ b/locales/pt/pages/terms.toml
@@ -1,0 +1,15 @@
+#
+# Termos de uso - português do Brasil. Overrides for pages/terms/page.toml.
+#
+
+nav = "Termos de uso"
+title = "Termos de uso &mdash; abox.tools"
+description = "As condições em que este site é oferecido: gratuito, como está, sem conta, sem garantia &mdash; e seus arquivos continuam inteiramente seus, porque nunca chegam até nós."
+heading = "Termos de uso"
+lede = """
+    Não há conta para abrir nem contrato para assinar, então isto aqui é curto.
+    Descreve o que você pode esperar deste site e o que ele não promete."""
+updated = "19 de agosto de 2026"
+og_title = "Termos de uso &mdash; abox.tools"
+og_description = "Gratuito, como está, sem conta, sem garantia. Seus arquivos continuam inteiramente seus."
+og_image_alt = "abox.tools - ferramentas que não encostam em servidor nenhum"

--- a/locales/pt/planned.toml
+++ b/locales/pt/planned.toml
@@ -1,0 +1,77 @@
+#
+# A lista planejada da página de roteiro - português do Brasil.
+#
+# Overrides for config/planned.toml. Only words: the group `id` stays as it is,
+# because that is what a tool's roadmap_group matches on, and the order of the
+# groups and of the items inside them is decided once, in English.
+#
+# Every group and every item has to be here. They are merged in order, so a
+# missing entry would render in English in the middle of a Portuguese list with
+# nothing on the page to say which one it was - the build refuses a list whose
+# length has changed for exactly that reason.
+#
+# Os nomes de formato ficam como estão: JPG, HEIC, AVIF, MP4, SRT e CSV são a
+# mesma coisa em qualquer idioma, e traduzi-los só tornaria a lista mais difícil
+# de reconhecer para quem já sabe o que está procurando.
+#
+
+note = "Ainda não construídas. Listadas para você ver aonde isto vai dar."
+
+[[group]]
+name = "Imagens"
+items = [
+  ["Girar e espelhar", "em quartos de volta, ou endireitando por alguns graus"],
+  ["Escrever na imagem", "por cima da foto, ou numa tarja de legenda acima dela"],
+  ["Filtros", "brilho, contraste, saturação, desfoque, preto e branco"],
+  ["Imagem para data URI", "cole o resultado direto no CSS ou no HTML"],
+  ["HEIC para JPG", "as fotos que o iPhone tira, num formato que tudo abre"],
+  ["AVIF e JPEG XL", "converta nos dois sentidos, no navegador que você estiver usando"],
+]
+
+[[group]]
+name = "GIF e animação"
+items = [
+  ["GIF para MP4 ou WebM", "a mesma animação, em geral com um décimo do tamanho"],
+  ["Separar um GIF", "cada quadro sai como um PNG"],
+  ["Redimensionar, cortar e girar GIFs", "quadro a quadro, mantendo o tempo de cada um"],
+  ["Inverter um GIF", "o último quadro primeiro"],
+  ["Mudar a velocidade do GIF", "retemporizar sem renderizar os quadros de novo"],
+  ["Analisador de GIF", "quadros, atrasos, paleta e para onde foram os bytes"],
+  ["Criar APNG", "animação com transparência de verdade e cor completa"],
+  ["WebP animado", "de novo a mesma animação, por uma fração do tamanho"],
+]
+
+[[group]]
+name = "Vídeo"
+items = [
+  ["Redimensionar", "até um tamanho que realmente vá conseguir ser enviado"],
+  ["Girar", "para aquele clipe que foi filmado deitado"],
+  ["Tirar o som, ou salvar o áudio", "descarte o som, ou guarde ele sozinho"],
+  ["Converter para MP4 ou WebM", "seja qual for o que o site onde você vai postar exige"],
+  ["Filtros", "brilho, contraste, saturação, desfoque"],
+  ["Gravar legendas na imagem", "um arquivo SRT desenhado dentro do quadro"],
+]
+
+[[group]]
+name = "Áudio"
+items = [
+  ["Aparar", "fique com o trecho que você queria"],
+  ["Abrir e fechar em fade", "para não começar e terminar num corte seco"],
+  ["Forma de onda em imagem", "desenhar uma faixa como figura"],
+  ["Converter formato", "MP3, WAV e Opus, em qualquer direção"],
+]
+
+[[group]]
+name = "Documentos e PDF"
+items = [
+  ["Juntar, separar e reordenar", "páginas trocadas de lugar sem ida e volta a um servidor"],
+  ["Girar e cortar páginas", "endireitar um escaneamento que veio deitado, ou aparar as margens"],
+  ["Extrair imagens", "tirar as figuras de volta de dentro de um documento"],
+]
+
+[[group]]
+name = "Além de mídia"
+items = [
+  ["Dados", "conversão, limpeza e inspeção de CSV e JSON"],
+  ["Privacidade e segurança", "hashes, somas de verificação, remoção de metadados"],
+]

--- a/locales/pt/tools/compress-image.html
+++ b/locales/pt/tools/compress-image.html
@@ -1,0 +1,120 @@
+<main>
+  <!-- Passo 1 &mdash; os arquivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha as imagens</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tirar tudo da lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; o número que importa -->
+  <section class="card" id="target-card">
+    <h2><span class="step">2</span> Diga que tamanho ela pode ter</h2>
+
+    <p class="card-lede">
+      Esta é a parte que os outros compressores fazem ao contrário. Eles lhe dão
+      um controle de qualidade e deixam que você adivinhe qual ajuste cai abaixo
+      do limite que lhe deram. Diga o limite em vez disso, e a ferramenta procura
+      a maior qualidade que cabe nele &mdash; e então gasta o que sobrou do
+      orçamento, em vez de lhe devolver um arquivo com metade do tamanho que você
+      pediu.
+    </p>
+
+    <div class="target-row">
+      <div class="target-field">
+        <label for="target-value">Tamanho alvo, por imagem</label>
+        <div class="inline-pair">
+          <input type="number" id="target-value" value="500" min="1" step="1" inputmode="decimal">
+          <label for="target-unit" class="visually-hidden">Unidade</label>
+          <select id="target-unit">
+            <option value="KB" selected>KB</option>
+            <option value="MB">MB</option>
+          </select>
+        </div>
+      </div>
+
+      <!--
+        The four numbers people are actually given: an upload form that says
+        100 KB, a forum avatar or a job application at 500 KB, an email
+        attachment at 1 MB, and a web page hero at 2 MB.
+      -->
+      <div class="presets" id="presets" role="group" aria-label="Alvos comuns">
+        <button type="button" class="ghost" data-bytes="102400">100 KB</button>
+        <button type="button" class="ghost" data-bytes="512000">500 KB</button>
+        <button type="button" class="ghost" data-bytes="1048576">1 MB</button>
+        <button type="button" class="ghost" data-bytes="2097152">2 MB</button>
+      </div>
+    </div>
+
+    <p id="target-summary" class="field-summary"></p>
+
+    <fieldset class="options">
+      <legend>Como ela pode chegar lá</legend>
+
+      <div class="option-row">
+        <label for="format-select">Formato de saída</label>
+        <select id="format-select">
+          <option value="auto" selected>Automático &mdash; mantém o formato, a menos que outro fique melhor</option>
+          <option value="keep">Sempre manter o formato original</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/webp">WebP</option>
+          <option value="image/png">PNG (sem perdas, então o tamanho sai das dimensões)</option>
+        </select>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="allow-resize" checked>
+        <span>
+          <strong>Pode diminuir a imagem se precisar</strong>
+          <span class="check-note">
+            Só é usado quando a qualidade sozinha teria que cair além do ponto em
+            que a compressão começa a aparecer. Abaixo disso, menos pixels bons
+            ficam melhores que mais pixels arruinados. Desligue para manter as
+            dimensões exatas e pagar por um alvo apertado com qualidade.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Passo 3 &mdash; o único clique -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Comprimir</h2>
+
+    <div class="run-row">
+      <button type="button" id="compress-all" class="primary big" disabled>Comprimir até o alvo</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Comprimidas</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Baixar tudo num zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/compress-image.toml
+++ b/locales/pt/tools/compress-image.toml
@@ -1,0 +1,249 @@
+#
+# Compressor de imagens - português do Brasil.
+#
+# Overrides for tools/compress-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Compressor de imagens"
+# O trecho final é a expressão que as pessoas procuram. O nome do produto
+# continua sendo a metade barulhenta, como no inglês.
+heading = "Comprimir&nbsp;imagem <span class=\"h1-kw\">&mdash; para um tamanho exato</span>"
+tagline = "Diga o tamanho. Ele resolve o resto."
+
+title = "Comprimir imagem para um tamanho exato &mdash; grátis, sem envio"
+description = "Comprima um JPEG, PNG ou WebP para um tamanho exato - 100 KB, 2 MB, o que for. Roda inteiro no navegador: nada é enviado, sem conta, funciona offline."
+og_title = "Comprima uma imagem para um tamanho que você escolhe"
+og_description = "Diga um tamanho alvo e isto encontra a menor compressão que chega lá, e depois mede o que aquilo custou. Roda na sua própria máquina; nada é enviado."
+og_image_alt = "Compressor de imagens - diga um tamanho, mantenha a qualidade"
+
+pledge = """
+    A compressão roda no seu próprio navegador, no seu próprio hardware, com os
+    codificadores que ele já traz. Esta ferramenta não tem função de rede de
+    espécie alguma &mdash; nada a buscar, nada a enviar &mdash; e não existe do
+    outro lado desta página servidor nenhum para onde mandar uma imagem, mesmo
+    que houvesse caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e comprima uma foto. Nenhuma requisição leva uma imagem, uma
+      miniatura, um nome de arquivo ou um byte do que você escolheu. Ou
+      desconecte da internet e comprima uma mesmo assim."""
+
+read_first = """
+, <code>src/compress.js</code> para a busca que decide
+      quanta qualidade gastar, e <code>src/measure.js</code> para a comparação
+      por trás do número de &ldquo;semelhança visual&rdquo;."""
+
+howto_heading = "Como comprimir uma imagem para um tamanho específico"
+
+card = """
+            Diga o tamanho de que você precisa &mdash; 100 KB, 2 MB, o que for
+            &mdash; e ele encontra a menor compressão que chega lá."""
+
+[words]
+plural = "imagens"
+choose = "uma imagem"
+analytics_extra = """, nem nenhum dos
+  tamanhos ou números de qualidade que esta ferramenta calcula"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem limite de tamanho"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "Suas imagens não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      seus arquivos pudessem ser coletados, e não existe no código nada que os
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Não existe
+      <code>fetch</code>, nem <code>XMLHttpRequest</code>, nem
+      <code>sendBeacon</code> em lugar nenhum de <code>src/</code>. A compressão é
+      <code>canvas.toBlob</code> &mdash; o codificador que já está instalado no
+      seu navegador."""
+
+[[privacy]]
+title = "Os números são medidos, não reportados."
+body = """
+ Os tamanhos, o
+      número de qualidade e a comparação SSIM são todos calculados nesta página e
+      mostrados a você. Não existe neste repositório nenhum evento de análise
+      personalizado que carregue um nome de arquivo, um tamanho, uma contagem ou
+      um resultado."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google, e o botão de doação vem do Buy Me a
+      Coffee. Nenhum deles recebe coisa alguma sobre as suas imagens. Toda linha
+      que lê, comprime ou mede um arquivo é servida desta origem e está listada no
+      repositório."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua
+      igual, porque nunca houve uma etapa de rede nela. Essa é a prova mais
+      simples de todas."""
+
+[[howto]]
+title = "Escolha suas imagens."
+body = """
+ Arraste até o seletor ou escolha na mão.
+      Elas são lidas direto do seu disco pelo navegador; nada é mandado para lugar
+      nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Digite o tamanho que mandaram você cumprir."
+body = """
+ 100 KB para o
+      formulário que insiste em recusar a sua foto, 500 KB para o sistema de
+      inscrição, 2 MB para uma página que precisa carregar rápido. Os quatro mais
+      comuns são botões."""
+
+[[howto]]
+title = "Aperte &ldquo;Comprimir até o alvo&rdquo;."
+body = """
+ Cada imagem é
+      codificada várias vezes enquanto a ferramenta se aproxima da maior qualidade
+      que cabe. Qualquer coisa que já esteja abaixo do alvo é deixada exatamente
+      como está."""
+
+[[howto]]
+title = "Confira o que custou e baixe."
+body = """
+ Cada resultado diz em que formato
+      foi escrito, com qual qualidade, se as dimensões mudaram e o quanto ele bate
+      com o original quando medido. &ldquo;Comparar&rdquo; põe as duas imagens
+      lado a lado."""
+
+[[faq]]
+q = "Minha imagem é enviada para algum lugar?"
+a = """
+        Não. O arquivo é decodificado, comprimido e medido pelo seu próprio
+        navegador no seu próprio hardware, com os codificadores de JPEG, PNG e WebP
+        que o navegador já traz. Esta ferramenta não tem função de rede de espécie
+        alguma &mdash; nunca busca nada e nunca manda nada &mdash; e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar, nenhum dos quais é deste site."""
+
+[[faq]]
+q = "Como ele acerta um tamanho exato?"
+a = """
+        Tentando. Não existe fórmula que transforme um ajuste de qualidade numa
+        contagem de bytes &mdash; isso depende inteiramente da imagem &mdash; então
+        a ferramenta codifica a imagem várias vezes e procura a resposta. Ela começa
+        no topo da faixa de qualidade e vai fechando o cerco pela metade, o que
+        encontra a maior qualidade que cabe em umas oito codificações. Todo tamanho
+        que você vê na página é um arquivo codificado de verdade, não uma
+        estimativa."""
+
+[[faq]]
+q = "O que &ldquo;perda mínima&rdquo; quer dizer aqui, exatamente?"
+a = """
+        Três coisas específicas. Primeira, uma imagem que já está abaixo do seu alvo
+        é repassada byte por byte em vez de recodificada. Segunda, a qualidade é
+        gasta antes da resolução, e só até um piso em que os artefatos de compressão
+        começam a aparecer &mdash; passando desse ponto a ferramenta diminui a
+        imagem e devolve a qualidade para cima, porque menos pixels bons ficam
+        melhores que mais pixels arruinados. Terceira, assim que um resultado que
+        cabe é encontrado, a busca volta a subir até o orçamento ser usado, então
+        você não recebe um arquivo de 300 KB tendo pedido 500 KB."""
+
+[[faq]]
+q = "O que são os números de SSIM e PSNR em cada resultado?"
+a = """
+        São uma medição do que a compressão custou, feita decodificando o resultado
+        e comparando com a imagem original. O SSIM compara brilho, contraste e
+        estrutura locais, o que é bem mais próximo daquilo que incomoda um olho do
+        que contar pixels alterados; acima de mais ou menos 0,98 os dois são
+        difíceis de distinguir lado a lado. O PSNR é a tradicional medida em
+        decibéis. Os dois são calculados na sua máquina, e os dois são mostrados
+        para que a afirmação de perda baixa seja verificável em vez de apenas
+        alegada."""
+
+[[faq]]
+q = "Quais formatos ele consegue ler e escrever?"
+a = """
+        Ele lê tudo o que o seu navegador consegue decodificar, o que na prática
+        significa JPEG, PNG, WebP, GIF, BMP e &mdash; na maioria dos navegadores
+        atuais &mdash; AVIF. Ele escreve JPEG, PNG e WebP, porque são esses os
+        codificadores que os navegadores trazem. Em &ldquo;automático&rdquo; ele
+        mantém o formato em que o seu arquivo chegou, e só troca para WebP quando
+        manter teria significado um redimensionamento ou uma queda visível de
+        qualidade."""
+
+[[faq]]
+q = "Por que ele não consegue comprimir muito um PNG?"
+a = """
+        Porque o PNG é sem perdas: ele não tem botão de qualidade para girar. O
+        único jeito de deixar um PNG menor é dar a ele menos pixels ou menos cores,
+        então, com PNG selecionado, a ferramenta chega a um alvo só redimensionando.
+        Se a imagem é uma fotografia, JPEG ou WebP chegam muito mais perto do seu
+        alvo num tamanho em que dá para ver que está tudo bem &mdash; e se for uma
+        logomarca ou uma captura de tela com transparência, o WebP mantém a
+        transparência que o JPEG preencheria com branco."""
+
+[[faq]]
+q = "Comprimir uma imagem remove os dados EXIF e de GPS dela?"
+a = """
+        Sim, como efeito colateral. Comprimir significa decodificar a imagem em
+        pixels e codificar esses pixels de novo, e um canvas cheio de pixels não
+        carrega etiquetas, então a localização, o modelo da câmera, os horários e
+        todo o resto simplesmente não são escritos no arquivo novo. Se você quer os
+        metadados fora mas a imagem intocada, use o
+        <a href="../remover-dados-exif/">Visualizador e removedor de EXIF</a> em vez
+        disso &mdash; ele reescreve o contêiner sem recomprimir nada."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. Também não há limite para o número ou o tamanho dos arquivos,
+        porque não há servidor pagando por eles &mdash; o trabalho acontece na sua
+        própria máquina. O site exibe publicidade, e é ela que paga a conta; os
+        anúncios não recebem nada sobre as suas imagens."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse as suas imagens embora para
+        serem comprimidas pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Comprima imagens JPEG, PNG e WebP até um tamanho que você diz. A ferramenta procura a maior qualidade que cabe no alvo, redimensionando só quando a qualidade sozinha não chega lá, e mede o resultado contra o original. Roda inteiramente no navegador, sem envio."
+features = [
+  "Comprime até um tamanho de arquivo alvo que você escolhe, e não um número de qualidade que você teria que adivinhar",
+  "Mantém a resolução cheia quando dá, e só redimensiona quando a qualidade sozinha não alcança o alvo",
+  "Gasta o orçamento inteiro: o resultado cai logo abaixo do alvo, e não bem longe dele",
+  "Mede o resultado contra o original com SSIM e PSNR",
+  "Deixa completamente intocados os arquivos que já estão abaixo do alvo",
+  "JPEG, PNG e WebP, com escolha automática de formato",
+  "Trabalha em lote, com todos os resultados num zip",
+  "Roda offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste imagens para cá"
+hint = "ou clique para escolher &mdash; JPEG, PNG, WebP e tudo o mais que o seu navegador conseguir abrir"

--- a/locales/pt/tools/compress-pdf.html
+++ b/locales/pt/tools/compress-pdf.html
@@ -1,0 +1,160 @@
+<main>
+  <!-- Passo 1 &mdash; o arquivo -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha um PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="file-row" class="file-row" hidden>
+      <div class="file-facts">
+        <strong id="file-name" class="file-name"></strong>
+        <span id="file-facts" class="file-sub"></span>
+      </div>
+      <button type="button" id="clear-file" class="ghost danger">Escolher outro</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; a tela que esta ferramenta manteria se pudesse manter só uma -->
+  <section class="card" id="inventory-card" hidden>
+    <h2><span class="step">2</span> Veja onde está o tamanho</h2>
+
+    <p class="card-lede">
+      &ldquo;Comprimir um PDF&rdquo; são dois trabalhos diferentes dividindo um
+      nome. Um escaneamento é uma pilha de fotografias, e recodificá-las vale a
+      maior parte do arquivo. Um contrato é texto e fontes, que o que quer que o
+      tenha feito já comprimiu &mdash; não existe oitenta por cento escondido lá
+      dentro, e ferramenta nenhuma vai achar um. Qual dos dois você tem não é
+      questão de opinião, então aqui está, antes de qualquer coisa ser tocada.
+    </p>
+
+    <p id="verdict" class="verdict"></p>
+
+    <div class="breakdown">
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <ul id="breakdown-list" class="breakdown-list"></ul>
+    </div>
+
+    <p id="inventory-notes" class="field-summary"></p>
+  </section>
+
+  <!-- Passo 3 &mdash; quanto gastar -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">3</span> Diga com que força apertar</h2>
+
+    <p class="card-lede">
+      Um PDF registra de que tamanho cada imagem é desenhada, então esta
+      ferramenta consegue medir o que a página de fato usa em vez de adivinhar. Um
+      escaneamento de 4000 pixels colocado ao longo de vinte centímetros de papel
+      está carregando 500 pixels por polegada; a 150 ele imprime igual e fica
+      igual na tela. Os pixels que ninguém consegue ver são gastos primeiro,
+      porque não custam nada.
+    </p>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Quanta qualidade pode ser gasta</legend>
+      <div class="presets" id="presets" role="radiogroup" aria-label="Quanta qualidade pode ser gasta">
+        <label class="preset">
+          <input type="radio" name="preset" value="smallest">
+          <span class="preset-body">
+            <strong>O menor possível</strong>
+            <span class="preset-note">96 DPI. Para algo que só precisa ser lido numa tela.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="screen" checked>
+          <span class="preset-body">
+            <strong>Bom na tela</strong>
+            <span class="preset-note">130 DPI. A resposta de sempre para um arquivo que você precisa mandar por e-mail.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="print">
+          <span class="preset-body">
+            <strong>Ainda bom no papel</strong>
+            <span class="preset-note">220 DPI. Menor, e ainda vai imprimir direito.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="gentle">
+          <span class="preset-body">
+            <strong>Quase não encostar nas imagens</strong>
+            <span class="preset-note">Sem redimensionamento nenhum. A maior parte da economia vem de reempacotar o arquivo.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <details class="advanced">
+      <summary>Defina os dois números você mesmo</summary>
+      <div class="option-row">
+        <label for="dpi-value">Máximo de pixels por polegada de espaço desenhado</label>
+        <div class="inline-pair">
+          <input type="number" id="dpi-value" min="0" max="1200" step="10" value="130" inputmode="numeric">
+          <span class="unit">DPI &mdash; 0 deixa cada imagem no tamanho cheio dela</span>
+        </div>
+      </div>
+      <div class="option-row">
+        <label for="quality-value">Qualidade do JPEG</label>
+        <div class="inline-pair">
+          <input type="range" id="quality-value" min="30" max="95" step="1" value="68">
+          <output id="quality-out" for="quality-value">68</output>
+        </div>
+      </div>
+    </details>
+
+    <label class="check">
+      <input type="checkbox" id="strip-meta" checked>
+      <span>
+        <strong>Tirar o que o arquivo lembra sobre de onde ele veio</strong>
+        <span class="check-note">
+          O nome e a versão do programa que o fez, quando foi feito e editado pela
+          última vez, o pacote XMP, e aquele blob privado que um programa de
+          diagramação deixa para trás para conseguir reimportar o próprio trabalho
+          &mdash; o que às vezes são megabytes. Nada disso é necessário para exibir
+          o documento.
+        </span>
+      </span>
+    </label>
+
+    <p id="settings-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Passo 4 &mdash; o único clique -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Comprimir</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Comprimir este PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Baixar</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <details id="per-image" class="advanced" hidden>
+        <summary>O que aconteceu com cada imagem</summary>
+        <ul id="image-list" class="image-list"></ul>
+      </details>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/compress-pdf.toml
+++ b/locales/pt/tools/compress-pdf.toml
@@ -1,0 +1,262 @@
+#
+# Compressor de PDF - português do Brasil.
+#
+# Overrides for tools/compress-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Compressor de PDF"
+heading = "Comprimir&nbsp;PDF <span class=\"h1-kw\">&mdash; deixar um PDF menor</span>"
+tagline = "Encolha um documento sem mandá-lo para lugar nenhum."
+
+title = "Comprimir PDF &mdash; grátis, no seu navegador, sem envio"
+description = "Deixe um PDF menor sem enviá-lo. O arquivo é lido, recomprimido e reescrito pelo seu próprio navegador, e a ferramenta mostra onde o tamanho dele realmente está antes de encostar em qualquer coisa."
+og_title = "Comprimir PDF &mdash; grátis, e nada é enviado"
+og_description = "Encolha um PDF na sua própria máquina. Ele mede de que tamanho cada imagem é desenhada na página, então só joga fora pixels que ninguém conseguiria ver."
+og_image_alt = "Comprimir PDF - deixe um documento menor sem enviá-lo"
+
+pledge = """
+    O documento é aberto, desmontado e escrito de volta na memória desta máquina,
+    por código servido deste endereço. Nada aqui consegue fazer um envio, e não
+    existe do outro lado desta página servidor nenhum para receber um."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e comprima um arquivo. Nenhuma requisição leva uma página, uma
+      imagem ou um nome de arquivo. Ou desconecte da internet e comprima um mesmo
+      assim."""
+
+read_first = """
+, e <code>src/reader.js</code> e <code>src/writer.js</code>
+      para a leitura e a reescrita inteiras, e nenhum dos dois consegue alcançar a
+      rede."""
+
+howto_heading = "Como deixar um PDF menor"
+
+card = """
+            Deixe um documento menor recomprimindo as imagens de dentro dele. Ele
+            mostra antes onde o tamanho realmente está, e diz com todas as letras
+            quando não há nada a ganhar."""
+
+[words]
+plural = "documentos"
+choose = "um PDF"
+analytics_extra = """"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[facts]]
+text = "Os arquivos ficam no seu aparelho"
+
+[[privacy]]
+title = "Seu documento não tem para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Esta ferramenta não acrescenta nada
+      àquela lista: ela não tem função de rede própria, nem sequer uma opcional.
+      Não existe aqui um ponto final onde o seu arquivo pudesse ser coletado, e
+      não existe no código nada que o mandaria se existisse."""
+
+[[privacy]]
+title = "O formato inteiro está neste repositório."
+body = """
+ Um PDF é uma lista de
+      objetos e uma tabela de onde cada um começa. O <code>src/objects.js</code>
+      lê essa sintaxe, o <code>src/reader.js</code> segue a tabela, o
+      <code>src/writer.js</code> escreve uma nova, e nenhum dos três importa nada
+      que consiga fazer uma requisição. Nenhuma biblioteca é buscada e nada é
+      renderizado num servidor."""
+
+[[privacy]]
+title = "Arquivos criptografados são recusados em vez de abertos."
+body = """
+
+      Um PDF com senha é recusado, inclusive daquele tipo que os escâneres
+      produzem com senha vazia e que tecnicamente abriria. Tirar a proteção de um
+      documento é um trabalho diferente de deixá-lo menor, e fazer isso em
+      silêncio seria uma coisa surpreendente para uma ferramenta fazer em seu
+      nome."""
+
+[[privacy]]
+title = "Ela tira coisas em vez de pôr."
+body = """
+ O arquivo pronto não carrega data de
+      criação, nem linha de produtor, nem nome da ferramenta que o fez. Com a
+      caixinha marcada ele também perde o pacote XMP e os blocos privados que os
+      programas de diagramação deixam para trás &mdash; o mesmo argumento que a
+      ferramenta de EXIF faz, aplicado a outro contêiner."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google. Nenhum dos dois recebe coisa alguma
+      sobre o seu documento: nem um arquivo, nem uma página, nem um nome, um
+      tamanho ou uma contagem de páginas. Toda linha que lê, decodifica ou escreve
+      um PDF é servida desta origem e está listada no repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não é entregue a ele."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; do cabeçalho é desenhado por um
+      script vindo de cdnjs.buymeacoffee.com e busca as letras dele no Google
+      Fonts. É um link e nada mais: ele não reporta visita nenhuma, e não recebe
+      nada sobre você nem sobre o seu documento. Nada acontece a menos que você
+      clique, e aquilo para onde você iria clicando é o site de outra gente."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e tudo nesta página
+      continua funcionando. Essa é a prova mais simples de todas: uma ferramenta
+      que mandasse o seu documento embora para ser comprimido pararia."""
+
+[[howto]]
+title = "Escolha um PDF."
+body = """
+ Arraste até o seletor ou escolha na mão. Ele
+      é lido direto do seu disco pelo navegador; nada é mandado para lugar nenhum
+      enquanto você faz isso."""
+
+[[howto]]
+title = "Olhe onde está o tamanho."
+body = """
+ O detalhamento é a razão de ser do
+      segundo passo. Se a barra for quase toda de imagens, esta ferramenta tem com
+      o que trabalhar. Se for quase toda de fontes e conteúdo de página, ela vai
+      dizer isso, e a economia honesta é de alguns por cento &mdash; melhor saber
+      antes de gastar um minuto nisso."""
+
+[[howto]]
+title = "Diga com que força apertar."
+body = """
+ Os ajustes nomeados são
+      resoluções, e não notas vagas: 96 DPI para ler na tela, 130 para mandar por
+      e-mail, 220 para algo que ainda precisa ser impresso. Cada um é medido
+      contra o tamanho em que a imagem é de fato desenhada na página, então uma
+      foto colocada como miniatura não é tratada como um escaneamento de página
+      inteira."""
+
+[[howto]]
+title = "Comprima, e leia a linha que diz que foi conferido."
+body = """
+
+      Quando a reescrita termina, o arquivo pronto é aberto de novo pelo mesmo
+      leitor desta página e as páginas dele são contadas. Se aquilo discordar do
+      original, a execução é reportada como falha e nenhum download é
+      oferecido."""
+
+[[faq]]
+q = "Meu PDF é enviado para algum lugar?"
+a = """
+        Não. O arquivo é lido, recomprimido e escrito pelo seu próprio navegador no
+        seu próprio hardware. Não existe lado de servidor nesta ferramenta, e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar &mdash; nenhum deles é deste site. Esta ferramenta não tem
+        função de rede opcional nenhuma."""
+
+[[faq]]
+q = "Quanto menor o meu PDF vai ficar?"
+a = """
+        Depende inteiramente do que tem nele, e é por isso que a ferramenta mede e
+        mostra a você antes de comprimir qualquer coisa. Um documento escaneado é
+        quase todo fotografia e costuma sair 60&ndash;90% menor. Um contrato ou uma
+        tese são texto, desenho vetorial e fontes embutidas, tudo isso já comprimido
+        pelo que quer que os tenha produzido; ali a economia costuma ser de alguns
+        por cento, vinda do reempacotamento do arquivo e do descarte do que não é
+        mais referenciado. Qualquer ferramenta que promete uma porcentagem fixa sem
+        olhar o seu arquivo está chutando."""
+
+[[faq]]
+q = "Comprimir um PDF perde qualidade?"
+a = """
+        As imagens dentro dele são recodificadas, então sim, para elas. Nada mais é
+        tocado: o texto continua texto, selecionável e pesquisável, as fontes ficam
+        inteiras, e o desenho vetorial é copiado exatamente. A ferramenta também se
+        recusa a piorar uma imagem à toa &mdash; se uma recodificação não sai menor
+        que o original, os bytes originais voltam para o documento intocados."""
+
+[[faq]]
+q = "O que é DPI aqui, e por que ele pergunta?"
+a = """
+        Um PDF registra de que tamanho cada imagem é desenhada na página, então a
+        ferramenta consegue calcular a resolução efetiva dela: um escaneamento de
+        4000 pixels colocado ao longo de vinte centímetros de papel está carregando
+        500 pixels por polegada. Nada numa tela e muito pouco no papel consegue usar
+        isso, então os pixels acima do ajuste que você escolher são jogados fora
+        primeiro &mdash; eles custam qualidade que ninguém consegue ver. É essa
+        medição que faz uma logomarca colocada pequena não ser tratada como um
+        escaneamento de página inteira."""
+
+[[faq]]
+q = "Ele consegue abrir um PDF protegido por senha?"
+a = """
+        Não, e isso é deliberado. Um documento criptografado é recusado com uma
+        mensagem dizendo isso, mesmo quando a senha é vazia &mdash; que é como muitos
+        escâneres e copiadoras salvam. Tirar a proteção de um arquivo é um trabalho
+        diferente de comprimi-lo, e uma ferramenta que fizesse isso em silêncio
+        estaria fazendo algo que você não pediu."""
+
+[[faq]]
+q = "Existem PDFs que ele não consegue comprimir?"
+a = """
+        Algumas imagens dentro deles, sim. Imagens JPEG 2000, JBIG2 e codificadas em
+        fax (CCITT) não têm decodificador em navegador nenhum, então passam
+        intocadas e são reportadas assim &mdash; as duas últimas são codecs de dois
+        níveis e em geral já estão perto do menor tamanho possível. Imagens CMYK
+        também são deixadas em paz, porque recodificá-las corre o risco de deslocar
+        as cores que uma impressora produziria. Tudo o que a ferramenta pula é
+        nomeado nos resultados, com o motivo."""
+
+[[faq]]
+q = "O arquivo comprimido vai continuar abrindo em todo lugar?"
+a = """
+        Sim. A saída é escrita como PDF 1.5, que todo leitor lançado desde 2003
+        entende, e a ferramenta prova isso na sua própria máquina: ela abre o arquivo
+        pronto de novo e conta as páginas antes de oferecê-lo a você. Formulários,
+        links, marcadores, a estrutura de acessibilidade e quaisquer anexos
+        embutidos são levados adiante; o que fica para trás é o material a que nada
+        no documento se referia mais."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem limite de
+        tamanho de arquivo além do que a memória da sua própria máquina permitir. O
+        site exibe publicidade, e é ela que paga a conta; os anúncios não recebem
+        nada sobre o seu documento."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse o seu documento embora para ser
+        comprimido pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Comprima um PDF no seu navegador. As imagens são recomprimidas em relação ao tamanho em que são de fato desenhadas na página, e o documento é reescrito localmente, então arquivo nenhum é enviado."
+features = [
+  "Mostra onde o tamanho de um documento realmente está antes de comprimir qualquer coisa",
+  "Recomprime imagens em relação à resolução medida delas na página",
+  "Deixa uma imagem em paz quando recodificar não a deixaria menor",
+  "Descarta objetos que uma edição anterior deixou para trás, e metadados opcionais",
+  "Reabre e confere o arquivo pronto antes de oferecê-lo",
+  "Roda offline; sem envio, sem conta, sem limite de tamanho de arquivo",
+]
+
+[picker]
+title = "Arraste um PDF para cá"
+hint = "ou clique para escolher &mdash; um documento por vez"

--- a/locales/pt/tools/crop-video.html
+++ b/locales/pt/tools/crop-video.html
@@ -1,0 +1,146 @@
+<main>
+  <!-- Passo 1 &mdash; o arquivo -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha um vídeo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Arquivo</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Tamanho</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Quadro</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Duração</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Vídeo</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Áudio</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; o corte -->
+  <section class="card" id="crop-card" hidden>
+    <h2><span class="step">2</span> Defina o corte</h2>
+
+    <p class="stage-hint">
+      Arraste dentro da caixa para movê-la, ou qualquer canto para
+      redimensioná-la. Com a caixa em foco, as setas a empurram um pixel de cada
+      vez, <kbd>Alt</kbd>&nbsp;+&nbsp;setas a redimensionam, e segurar
+      <kbd>Shift</kbd> faz cada passo valer dez.
+    </p>
+
+    <!-- The crop box itself is added here by src/cropper.js. The stage is given
+         the video's own shape, so the box can be positioned in percentages and
+         needs no recalculating when the window is resized. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <div class="crop-controls">
+      <div class="aspect-row" role="group" aria-label="Travar o corte numa proporção">
+        <button type="button" data-aspect="free" class="active">Livre</button>
+        <button type="button" data-aspect="source">Original</button>
+        <button type="button" data-aspect="1:1">1:1</button>
+        <button type="button" data-aspect="4:5">4:5</button>
+        <button type="button" data-aspect="9:16">9:16</button>
+        <button type="button" data-aspect="16:9">16:9</button>
+        <button type="button" data-aspect="4:3">4:3</button>
+        <button type="button" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="ghost" title="Virar a proporção travada de lado">
+          Inverter
+        </button>
+      </div>
+
+      <div class="numbers">
+        <label>Esquerda<input type="number" id="crop-x" min="0" step="1"></label>
+        <label>Topo<input type="number" id="crop-y" min="0" step="1"></label>
+        <label>Largura<input type="number" id="crop-w" min="16" step="2"></label>
+        <label>Altura<input type="number" id="crop-h" min="16" step="2"></label>
+        <div class="number-actions">
+          <button type="button" id="crop-max" class="ghost">Maior</button>
+          <button type="button" id="crop-centre" class="ghost">Centralizar</button>
+          <button type="button" id="crop-reset" class="ghost">Quadro inteiro</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="even-note">
+      A largura e a altura andam de dois em dois, porque o H.264 não tem como
+      guardar um quadro com lado ímpar.
+    </p>
+  </section>
+
+  <!-- Passo 3 &mdash; a exportação -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Corte</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Saída</label>
+        <select id="format">
+          <option value="mp4" selected>MP4 &mdash; recodificado quadro a quadro</option>
+          <option value="webm">WebM &mdash; gravado enquanto toca</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Qualidade</label>
+        <select id="quality">
+          <option value="low">Arquivo menor</option>
+          <option value="medium" selected>Equilibrada</option>
+          <option value="high">Melhor qualidade</option>
+        </select>
+        <p class="field-note">
+          Nunca mais do que o original gastava na mesma área &mdash; recodificar
+          acima disso só deixa o arquivo maior.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Manter o som
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Quadro de saída</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Mantido</dt><dd id="sum-kept">&mdash;</dd></div>
+      <div><dt>Duração</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Como</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Cortar o vídeo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Baixar o vídeo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/crop-video.toml
+++ b/locales/pt/tools/crop-video.toml
@@ -1,0 +1,246 @@
+#
+# Cortador de vídeo - português do Brasil.
+#
+# Overrides for tools/crop-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Cortar" aqui é recortar a moldura, e "aparar" é encurtar a duração - a mesma
+# distinção que o inglês faz entre crop e trim. As duas ferramentas se citam uma
+# à outra, então os dois verbos precisam ficar separados em toda a tradução.
+#
+
+name = "Cortador de vídeo"
+heading = "Cortar&nbsp;vídeo <span class=\"h1-kw\">&mdash; mudar o enquadramento online</span>"
+tagline = "Reduza um clipe à parte que importa."
+
+title = "Cortar um vídeo online &mdash; grátis, sem envio, funciona offline"
+description = "Corte um MP4, MOV ou WebM para qualquer formato - quadrado, 9:16, ou uma caixa exata em pixels. Roda no navegador: nada é enviado, o som é mantido, funciona offline."
+og_title = "Cortador de vídeo &mdash; corte um clipe sem enviá-lo"
+og_description = "Arraste uma caixa sobre o seu clipe e corte para qualquer formato. Os quadros são decodificados e recodificados na sua própria máquina, e o som original é levado adiante intocado."
+og_image_alt = "Cortador de vídeo - corte um clipe no navegador, sem nada ser enviado"
+
+pledge = """
+    Cada quadro é decodificado, cortado e codificado pelo seu próprio navegador,
+    no seu próprio hardware. Nada aqui consegue buscar ou mandar coisa alguma
+    &mdash; não existe função de rede nenhuma nesta ferramenta &mdash; e não
+    existe do outro lado desta página servidor nenhum para onde mandar um vídeo,
+    mesmo que houvesse caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e corte um clipe. Nenhuma requisição leva um quadro, um nome de
+      arquivo ou um byte do que você escolheu. Ou desconecte da internet e corte
+      um mesmo assim &mdash; uma ferramenta que mandasse o seu vídeo embora para
+      ser processado simplesmente pararia."""
+
+read_first = """
+, <code>src/demux.js</code> para o leitor que acha os
+      quadros num MP4, e <code>src/transcode.js</code> para o laço que
+      decodifica, corta e codifica. Nenhum dos dois importa qualquer coisa que
+      consiga fazer uma requisição."""
+
+howto_heading = "Como cortar um vídeo"
+
+card = """
+            Arraste uma caixa sobre um clipe e reduza ele àquele formato &mdash;
+            quadrado para um feed, em pé para o celular, ou uma caixa exata em
+            pixels."""
+
+[words]
+plural = "vídeos"
+choose = "um vídeo"
+analytics_extra = """, nem nenhum
+  quadro, duração ou tamanho de corte"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca d'água"
+
+[[facts]]
+text = "Mantém o som"
+
+[[facts]]
+text = "Funciona offline"
+
+[[privacy]]
+title = "Seus vídeos não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      o seu arquivo pudesse ser coletado, e não existe no código nada que o
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Esta ferramenta não tem função de
+      rede nenhuma: nenhum endereço para colar, nada para baixar, nenhum motor
+      buscado no primeiro uso. Cada byte que encosta no seu vídeo veio desta
+      origem quando a página carregou."""
+
+[[privacy]]
+title = "A decodificação e a codificação são locais."
+body = """
+ Os quadros passam pelo
+      WebCodecs no seu próprio navegador, ou pelo mesmo motor de reprodução que
+      lhe mostraria o clipe de qualquer jeito. O arquivo pronto é montado na
+      memória desta máquina e entregue direto a um download."""
+
+[[privacy]]
+title = "O som é copiado, não escutado."
+body = """
+ No caminho do MP4 as amostras
+      de áudio são movidas sem serem decodificadas &mdash; nada aqui jamais as
+      transforma de volta em som, e nada conseguiria passá-las a lugar nenhum se
+      transformasse."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google. Nenhum dos dois recebe coisa alguma
+      sobre o seu vídeo: nem um arquivo, nem um quadro, nem um nome, um tamanho,
+      uma duração ou o formato para o qual você cortou. Toda linha que lê,
+      decodifica, corta ou codifica é servida desta origem e está listada no
+      repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não é entregue a ele."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; do cabeçalho é desenhado por um
+      script vindo de cdnjs.buymeacoffee.com e busca as letras dele no Google
+      Fonts. É um link e nada mais: ele não reporta visita nenhuma, e não recebe
+      nada sobre você nem sobre o seu vídeo."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e tudo nesta página continua
+      funcionando. Essa é a prova mais simples de todas."""
+
+[[howto]]
+title = "Escolha um vídeo."
+body = """
+ Arraste um MP4, MOV, M4V ou WebM até o
+      seletor, ou escolha um na mão. Ele é lido direto do seu disco pelo
+      navegador; nada é mandado para lugar nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Arraste a caixa sobre a parte que você quer manter."
+body = """
+ Arraste
+      dentro dela para movê-la e qualquer canto para redimensionar. Trave numa
+      proporção antes &mdash; 1:1 para um post quadrado, 9:16 para celular, 16:9
+      para um quadro deitado &mdash; ou digite uma caixa exata em pixels nos
+      quatro campos abaixo."""
+
+[[howto]]
+title = "Escolha quanta qualidade gastar."
+body = """
+ A imagem precisa ser
+      codificada de novo, porque um quadro cortado é outra imagem.
+      &ldquo;Equilibrada&rdquo; a mantém perto do que o arquivo já gastava naquela
+      área; &ldquo;Melhor qualidade&rdquo; gasta mais. O som é mantido, a menos
+      que você desligue."""
+
+[[howto]]
+title = "Corte e baixe."
+body = """
+ O trabalho acontece no seu próprio hardware,
+      então o tempo que leva depende da sua máquina e não de uma fila. O vídeo
+      pronto é entregue direto aos downloads do seu navegador."""
+
+[[faq]]
+q = "Meu vídeo é enviado para algum lugar?"
+a = """
+        Não. Ele é lido, decodificado, cortado e codificado pelo seu próprio
+        navegador no seu próprio hardware. Não existe lado de servidor nesta
+        ferramenta, e a <code>Content-Security-Policy</code> da página nomeia todos
+        os endereços que ela pode contatar &mdash; nenhum deles é deste site.
+        Desconecte da internet e corte um clipe mesmo assim, se preferir conferir a
+        acreditar."""
+
+[[faq]]
+q = "Quais formatos de vídeo posso cortar?"
+a = """
+        MP4, M4V e MOV são lidos diretamente, seja lá o que houver dentro deles:
+        H.264, HEVC, AV1 ou VP9, desde que o seu navegador saiba decodificar aquele
+        codec. Qualquer outra coisa que o seu navegador consiga tocar &mdash; WebM
+        mais obviamente &mdash; é cortada tocando o arquivo e gravando o resultado,
+        o que funciona mas leva o mesmo tempo que o clipe dura. Um arquivo que o
+        navegador não consegue nem ler nem tocar, o que na prática significa AVI,
+        WMV, FLV e a maioria dos MKVs, é recusado com uma mensagem dizendo isso, em
+        vez de falhar no meio do caminho."""
+
+[[faq]]
+q = "Existe limite de tamanho ou de duração do vídeo?"
+a = """
+        Não há limite embutido na ferramenta, e o arquivo não é lido para a memória
+        de uma vez só &mdash; ele é percorrido em fatias de alguns megabytes. O teto
+        prático é o vídeo pronto, que é montado na memória antes de você baixá-lo, e
+        o tempo que a sua máquina leva para codificá-lo."""
+
+[[faq]]
+q = "O som sobrevive?"
+a = """
+        No caminho do MP4, exatamente: o áudio é copiado amostra por amostra sem
+        nunca ser decodificado, então é byte a byte o que estava no arquivo. No
+        caminho da gravação, ele é capturado da reprodução e codificado de novo, o
+        que custa um pouco de qualidade. De qualquer jeito, existe uma caixinha para
+        deixá-lo de fora por completo."""
+
+[[faq]]
+q = "Cortar perde qualidade?"
+a = """
+        A imagem é codificada de novo, porque um quadro cortado é outra imagem e não
+        há como guardá-la sem escrever os pixels de novo. O que a ferramenta não faz
+        é gastar mais do que o original gastava naquela mesma área, já que
+        recodificar acima disso só deixa o arquivo maior sem deixá-lo mais
+        bonito."""
+
+[[faq]]
+q = "Posso encurtar a duração também?"
+a = """
+        Aqui não, mas na ferramenta ao lado. Esta muda o formato da imagem e mais
+        nada: o clipe que sai tem exatamente a mesma duração do que entrou, com a
+        temporização e o som intactos. Aparar é outro trabalho e é outra ferramenta
+        &mdash; o <a href="../aparar-video/">Aparador de vídeo</a> marca os trechos
+        de um clipe que valem a pena e os salva como um arquivo só, sem recodificar
+        um quadro."""
+
+[[faq]]
+q = "Por que a largura e a altura andam de dois em dois?"
+a = """
+        O H.264, o codec dentro de um MP4, guarda a imagem em blocos e não tem como
+        descrever um quadro com um número ímpar de pixels num lado. Em vez de
+        arredondar o seu corte em silêncio depois que você o define, a caixa só
+        oferece números pares desde o começo."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. O site exibe publicidade, e é ela que paga a conta; os anúncios não
+        recebem nada sobre o seu vídeo."""
+
+[schema]
+browser_requirements = "Requer JavaScript. A saída em MP4 precisa de um navegador com WebCodecs; os demais recuam para gravar WebM."
+description = "Corte um vídeo para qualquer formato ou caixa exata em pixels dentro do navegador. MP4, MOV e M4V são decodificados e recodificados quadro a quadro, com o áudio original levado adiante intocado; qualquer outra coisa que o navegador consiga tocar é cortada por gravação. Nada é enviado."
+features = [
+  "Corta vídeo em MP4, MOV, M4V e WebM",
+  "Origens em H.264, HEVC, AV1 e VP9, decodificadas pelo WebCodecs",
+  "Corte livre, proporções travadas (1:1, 4:5, 9:16, 16:9, 4:3, 3:2) ou uma caixa exata em pixels",
+  "Mantém o áudio original sem recodificá-lo",
+  "Roda offline; sem envio, sem conta, sem marca d'água",
+]
+
+[picker]
+title = "Arraste um vídeo para cá"
+hint = "ou clique para escolher &mdash; MP4, MOV, M4V, WebM, e tudo o mais que este navegador tocar"

--- a/locales/pt/tools/edit-audio.html
+++ b/locales/pt/tools/edit-audio.html
@@ -1,0 +1,170 @@
+<main>
+  <!-- Passo 1 &mdash; o arquivo -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha um arquivo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Arquivo</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Tamanho</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Duração</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Som</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>Momento mais alto</dt><dd id="src-peak">&mdash;</dd></div>
+      <div><dt>Lido como</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <div class="wave-wrap" id="src-wave-wrap" hidden>
+      <canvas id="src-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="preview" controls preload="metadata"></audio>
+    </div>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; as edições -->
+  <section class="card" id="edit-card" hidden>
+    <h2><span class="step">2</span> Mude</h2>
+
+    <div class="edit-block">
+      <label class="check" for="reverse">
+        <input type="checkbox" id="reverse">
+        Tocar de trás para a frente
+      </label>
+      <p class="field-note">
+        As amostras são escritas da última para a primeira. Nada mais nelas
+        muda, então inverter duas vezes devolve exatamente o arquivo de onde você
+        partiu.
+      </p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="speed">Velocidade</label>
+        <input type="text" id="speed-value" class="value-box" inputmode="decimal"
+               spellcheck="false" autocomplete="off" aria-label="Velocidade, como multiplicador">
+      </div>
+
+      <!-- The slider is in octaves, not multiples: half speed and double speed
+           are then the same distance either side of the middle, which is how
+           they sound. main.js does the conversion. -->
+      <input type="range" id="speed" min="-2" max="2" step="0.01" value="0"
+             aria-describedby="speed-note">
+
+      <div class="presets" role="group" aria-label="Predefinições de velocidade">
+        <button type="button" class="ghost" data-speed="0.5">0,5&times;</button>
+        <button type="button" class="ghost" data-speed="0.75">0,75&times;</button>
+        <button type="button" class="ghost" data-speed="1">1&times;</button>
+        <button type="button" class="ghost" data-speed="1.25">1,25&times;</button>
+        <button type="button" class="ghost" data-speed="1.5">1,5&times;</button>
+        <button type="button" class="ghost" data-speed="2">2&times;</button>
+      </div>
+
+      <fieldset class="modes">
+        <legend>O que acontece com o tom</legend>
+        <label class="mode">
+          <input type="radio" name="pitch" value="keep" checked>
+          <span>
+            <strong>Manter o tom</strong>
+            Uma voz continua soando como a mesma voz, só que mais rápida ou mais lenta.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="pitch" value="move">
+          <span>
+            <strong>Deixar mover</strong>
+            Mais rápido é mais agudo e mais lento é mais grave, do jeito que uma fita faz.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="speed-note"></p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="volume">Volume</label>
+        <input type="text" id="volume-value" class="value-box" inputmode="decimal"
+               spellcheck="false" aria-label="Mudança de volume, em decibéis">
+      </div>
+
+      <input type="range" id="volume" min="-24" max="24" step="0.5" value="0"
+             aria-describedby="volume-note">
+
+      <fieldset class="modes">
+        <legend>Quão alto deixar</legend>
+        <label class="mode">
+          <input type="radio" name="level" value="gain" checked>
+          <span>
+            <strong>Por esta quantidade</strong>
+            Cada amostra multiplicada pelo mesmo número. Nada mais muda.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="level" value="normalize">
+          <span>
+            <strong>O mais alto que der</strong>
+            Levantado até o momento mais alto ficar logo abaixo do teto.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="volume-note"></p>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Duração</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Velocidade</dt><dd id="sum-speed">&mdash;</dd></div>
+      <div><dt>Momento mais alto</dt><dd id="sum-peak">&mdash;</dd></div>
+      <div><dt>Aproximadamente</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="clip-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 3 &mdash; o arquivo que sai -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Salve</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">O que escrever</label>
+        <select id="depth">
+          <option value="16" selected>WAV de 16 bits &mdash; toca em todo lugar</option>
+          <option value="32">WAV float de 32 bits &mdash; nada é ceifado</option>
+        </select>
+        <p class="field-note" id="depth-note">
+          Um WAV guarda as amostras como elas são, então escrever um não tem como
+          custar qualidade. Não é um arquivo pequeno: veja a estimativa acima.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary">Editar o áudio</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Baixar o áudio</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/edit-audio.toml
+++ b/locales/pt/tools/edit-audio.toml
@@ -1,0 +1,279 @@
+#
+# Editor de áudio - português do Brasil.
+#
+# Overrides for tools/edit-audio/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Editor de áudio"
+heading = "Editor&nbsp;de&nbsp;áudio <span class=\"h1-kw\">&mdash; inverter, mudar a velocidade ou aumentar o volume</span>"
+tagline = "Toque de trás para a frente, mude a velocidade, levante uma gravação baixa &mdash; tudo aqui, na sua máquina."
+
+title = "Inverter áudio, mudar a velocidade e aumentar o volume &mdash; grátis, sem envio"
+description = "Toque uma faixa de trás para a frente, acelere ou desacelere, e deixe uma gravação baixa mais alta. Também tira o som de dentro de um vídeo. Roda no navegador: nada é enviado."
+og_title = "Editor de áudio &mdash; inverta, retemporize e amplifique sem enviar nada"
+og_description = "Inverta uma faixa, mude a velocidade com ou sem mexer no tom, e ajuste o nível - depois baixe um WAV. O arquivo é lido e escrito pelo seu próprio navegador."
+og_image_alt = "Editor de áudio - inverta, retemporize e amplifique áudio no seu navegador"
+
+pledge = """
+    Seu arquivo é lido, editado e escrito pelo seu próprio navegador, no seu
+    próprio hardware. Nada aqui consegue buscar ou mandar coisa alguma &mdash;
+    não existe função de rede nenhuma nesta ferramenta &mdash; e não existe do
+    outro lado desta página servidor nenhum para onde mandar uma gravação, mesmo
+    que houvesse caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e inverta alguma coisa. Nenhuma requisição leva uma amostra, um
+      nome de arquivo ou um byte do que você escolheu. Ou desconecte da internet e
+      edite uma faixa mesmo assim &mdash; uma ferramenta que mandasse o seu áudio
+      embora para ser processado simplesmente pararia."""
+
+read_first = """
+, <code>src/decode.js</code> para as vinte linhas que
+      entregam o seu arquivo ao decodificador do próprio navegador,
+      <code>src/stretch.js</code> para o esticador de tempo,
+      <code>src/speed.js</code> para o reamostrador, e <code>src/wav.js</code>
+      para o cabeçalho que vai na frente das amostras. Nenhum deles importa
+      qualquer coisa que consiga fazer uma requisição."""
+
+howto_heading = "Como editar um arquivo de áudio"
+
+card = """
+            Inverta uma faixa, mude a velocidade com ou sem mexer no tom, e
+            levante uma gravação baixa. Também tira o som de dentro de um
+            vídeo."""
+
+[words]
+plural = "gravações"
+choose = "um arquivo"
+analytics_extra = """, nem nenhuma
+  forma de onda, duração ou nível"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca d'água"
+
+[[facts]]
+text = "Vídeo entra, áudio sai"
+
+[[facts]]
+text = "Funciona offline"
+
+[[privacy]]
+title = "Suas gravações não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      o seu arquivo pudesse ser coletado, e não existe no código nada que o
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Esta ferramenta não tem função de
+      rede nenhuma: nenhum endereço para colar, nada para baixar, nenhum motor
+      buscado no primeiro uso. Cada byte que encosta no seu áudio veio desta
+      origem quando a página carregou."""
+
+[[privacy]]
+title = "O decodificador é o que já está no seu navegador."
+body = """
+
+      O arquivo é entregue ao <code>decodeAudioData</code>, o mesmo código que
+      toca uma faixa num elemento <code>&lt;audio&gt;</code>. Nada é embarcado
+      aqui para ler o seu formato, e nada é pedido a coisa alguma fora desta
+      página para lê-lo tampouco."""
+
+[[privacy]]
+title = "A imagem de um vídeo nunca chega a ser decodificada."
+body = """
+ Quando você joga um
+      vídeo aqui, só a trilha de áudio dele é pedida. Os quadros não são lidos,
+      não são decodificados, não são desenhados e não são olhados &mdash; não
+      existe nesta página código que pudesse, e o arquivo que sai carrega som e
+      nada mais."""
+
+[[privacy]]
+title = "As amostras são anotadas, não codificadas de novo."
+body = """
+
+      Um WAV são as amostras que esta página calculou com um cabeçalho na frente
+      delas. Não há um codificador no meio tomando decisões sobre a sua gravação,
+      e não há nada que pudesse ser chamado de envio para isso acontecer."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google. Nenhum dos dois recebe coisa alguma
+      sobre a sua gravação: nem um arquivo, nem uma amostra, nem um nome, um
+      tamanho, uma duração ou o quão alta ela estava. Toda linha que lê, edita e
+      escreve é servida desta origem e está listada no repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não é entregue a ele."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; do cabeçalho é desenhado por um
+      script vindo de cdnjs.buymeacoffee.com e busca as letras dele no Google
+      Fonts. É um link e nada mais: ele não reporta visita nenhuma, e não recebe
+      nada sobre você nem sobre o seu arquivo."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e tudo nesta página continua
+      funcionando. Essa é a prova mais simples de todas."""
+
+[[howto]]
+title = "Escolha um arquivo."
+body = """
+ Arraste um MP3, WAV, FLAC, M4A, Ogg ou
+      Opus até o seletor &mdash; ou um vídeo, se o que você quer é o som de
+      dentro dele. Ele é lido direto do seu disco pelo navegador; nada é mandado
+      para lugar nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Vire de trás para a frente, se foi para isso que você veio."
+body = """
+ Uma
+      caixinha. As amostras são escritas da última para a primeira, o que é
+      exatamente reversível: faça duas vezes e você tem o arquivo de onde partiu,
+      amostra por amostra."""
+
+[[howto]]
+title = "Ajuste a velocidade."
+body = """
+ Arraste o controle, digite um multiplicador,
+      ou aperte uma das predefinições. Depois escolha o que acontece com o tom:
+      segurá-lo onde está, que é o que você quer numa aula a 1,5&times;, ou
+      deixá-lo mover junto com a velocidade, que é o que uma fita faz e o que faz
+      uma voz subir ou descer."""
+
+[[howto]]
+title = "Ajuste o nível."
+body = """
+ Ou diga uma mudança em decibéis, ou peça que a
+      gravação seja levantada até o momento mais alto dela ficar logo abaixo do
+      teto. A página diz onde aquele momento vai cair antes de você apertar
+      qualquer coisa, e avisa se o ajuste escolhido o empurraria além da escala
+      cheia."""
+
+[[howto]]
+title = "Salve."
+body = """
+ O trabalho acontece no seu próprio hardware, então o
+      tempo que leva depende da sua máquina e não de uma fila. O que sai é um WAV
+      &mdash; as próprias amostras, com um cabeçalho na frente &mdash; tocado na
+      página primeiro, e depois entregue direto aos downloads do seu
+      navegador."""
+
+[[faq]]
+q = "Meu áudio é enviado para algum lugar?"
+a = """
+        Não. Ele é lido, editado e escrito pelo seu próprio navegador no seu próprio
+        hardware. Não existe lado de servidor nesta ferramenta, e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar &mdash; nenhum deles é deste site. Desconecte da internet e
+        inverta uma faixa mesmo assim, se preferir conferir a acreditar."""
+
+[[faq]]
+q = "Consigo tirar o áudio de dentro de um vídeo?"
+a = """
+        Sim, e aqui é o mesmo trabalho que abrir um MP3. Jogue um MP4, MOV ou WebM
+        aqui e só a trilha de áudio dele é decodificada: a imagem nunca é lida, e o
+        que sai é um arquivo de som sem vídeo nenhum. É também o jeito de salvar o
+        som de um clipe sem editá-lo &mdash; deixe todos os ajustes em paz e aperte
+        o botão."""
+
+[[faq]]
+q = "Mudar a velocidade muda o tom?"
+a = """
+        Só se você pedir. &ldquo;Manter o tom&rdquo; corta a gravação em janelas
+        sobrepostas de uns cinquenta milissegundos e as reassenta mais perto ou mais
+        longe umas das outras, escolhendo cada posição de modo que as ondas se
+        alinhem onde se cruzam &mdash; uma voz continua a mesma voz a 1,5&times;.
+        &ldquo;Deixar mover&rdquo; reamostra em vez disso, que é o que tocar uma
+        fita mais rápido faz: o dobro da velocidade é exatamente uma oitava
+        acima."""
+
+[[faq]]
+q = "Por que ele salva um WAV em vez de um MP3?"
+a = """
+        Porque navegador nenhum traz um codificador de MP3, e esta ferramenta se
+        recusa a mandar a sua gravação para um servidor que tenha um. Um WAV não
+        precisa de codificador nenhum &mdash; são as amostras com um cabeçalho de
+        quarenta e quatro bytes na frente &mdash; então é ao mesmo tempo a opção
+        honesta e a única que não tem como custar qualidade. Ele é maior: cerca de
+        dez megabytes por minuto em estéreo. Todo reprodutor, celular e editor abre
+        um, e qualquer coisa que queira um MP3 consegue fazer um a partir dele."""
+
+[[faq]]
+q = "Quais formatos posso abrir?"
+a = """
+        O que o seu navegador decodificar, o que na prática significa MP3, WAV,
+        FLAC, M4A e AAC, Ogg Vorbis e Opus, e o áudio dentro de vídeos MP4, M4V, MOV
+        e WebM. O que fica de fora é a mesma lista curta de sempre: AVI, WMA e a
+        maioria dos MKVs. Um arquivo que este navegador não lê é recusado com uma
+        mensagem dizendo isso, em vez de falhar no meio do caminho."""
+
+[[faq]]
+q = "Deixar mais alto vai distorcer?"
+a = """
+        Só se você passar da escala cheia, e a página avisa antes de você passar. O
+        áudio digital tem um teto rígido: uma amostra não pode ser mais alta que a
+        escala cheia, então qualquer coisa acima disso é achatada contra o teto, e é
+        assim que a distorção soa. &ldquo;O mais alto que der&rdquo; é o ajuste que
+        não consegue fazer isso &mdash; ele calcula quanto espaço sobrou na gravação
+        e usa exatamente aquilo. Tudo abaixo do teto é multiplicação e mais nada:
+        suba 6 dB e desça 6 dB e as amostras estão onde começaram."""
+
+[[faq]]
+q = "Inverter ou retemporizar perde qualidade?"
+a = """
+        Inverter não perde: as mesmas amostras saem na outra ordem, o que é exato.
+        Mudar a velocidade move cada amostra, então é aritmética e não cópia &mdash;
+        o reamostrador filtra direito no caminho, então acelerar não dobra as notas
+        altas de volta para baixo como um zumbido metálico, e as janelas do
+        esticador são colocadas onde as ondas se alinham, e não onde a conta calhou
+        de cair. Nenhum dos dois caminhos recodifica nada, porque não há aqui
+        codificador com que recodificar."""
+
+[[faq]]
+q = "Existe limite de duração do arquivo?"
+a = """
+        Não há limite embutido na ferramenta. O teto prático é a memória: a gravação
+        inteira é decodificada nesta página de uma vez, e um WAV é montado na memória
+        antes de você baixá-lo, então uma hora de estéreo precisa de algo abaixo de
+        um gigabyte para trabalhar. Um WAV de quatro gigabytes é recusado de cara,
+        porque o próprio campo de tamanho do formato não consegue descrever um."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. O site exibe publicidade, e é ela que paga a conta; os anúncios não
+        recebem nada sobre a sua gravação."""
+
+[schema]
+browser_requirements = "Requer JavaScript e um navegador com Web Audio, o que é todo navegador atual. Nenhum suporte a codec além do que o navegador já tem para tocar o arquivo."
+description = "Inverta uma faixa de áudio, mude a velocidade dela com ou sem mexer no tom, e ajuste o nível, dentro do navegador. Funciona também com o áudio de dentro de um vídeo. Nada é enviado e o resultado é escrito como WAV, então nada é recodificado."
+features = [
+  "Toca uma faixa de trás para a frente, exatamente",
+  "Muda a velocidade de um quarto a quatro vezes, mantendo o tom ou movendo-o",
+  "Sobe ou desce o nível, ou normaliza para logo abaixo da escala cheia",
+  "Tira o áudio de um MP4, MOV ou WebM sem encostar na imagem",
+  "Escreve WAV de 16 bits ou float de 32 bits, sem codificador no meio",
+  "Roda offline; sem envio, sem conta, sem marca d'água",
+]
+
+[picker]
+title = "Arraste um arquivo de áudio ou um vídeo para cá"
+hint = "ou clique para escolher &mdash; MP3, WAV, FLAC, M4A, Ogg, e o som dentro de MP4, MOV ou WebM"

--- a/locales/pt/tools/exif-editor.html
+++ b/locales/pt/tools/exif-editor.html
@@ -1,0 +1,150 @@
+<main>
+  <!-- Passo 1 &mdash; os arquivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha as fotos</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tirar tudo da lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; o único clique -->
+  <section class="card" id="strip-card">
+    <h2><span class="step">2</span> Remova tudo</h2>
+
+    <p class="card-lede">
+      Um botão, todas as fotos da lista. A imagem não é decodificada, redesenhada
+      nem recomprimida &mdash; os dados de imagem comprimida são copiados
+      intocados e só os metadados em volta são descartados, então o resultado é a
+      mesma foto sem nada anexado.
+    </p>
+
+    <div class="strip-row">
+      <button type="button" id="strip-all" class="primary big" disabled>Remover todos os metadados</button>
+      <span id="strip-status" class="strip-status" role="status" aria-live="polite"></span>
+    </div>
+
+    <!--
+      Two things are kept by default, and both are stated on the button's own
+      line rather than buried in a settings panel. "Remove all" that quietly
+      keeps things is a broken promise; "remove all except these two, and here
+      they are" is a choice.
+    -->
+    <fieldset class="keep-options">
+      <legend>O que manter</legend>
+      <label class="check">
+        <input type="checkbox" id="keep-orientation" checked>
+        <span>
+          <strong>A etiqueta de orientação</strong>
+          <span class="check-note">
+            Os celulares guardam a foto do jeito que o sensor viu e acrescentam uma
+            etiqueta dizendo para que lado é o de cima. Remova isso e alguns
+            visualizadores mostram a foto deitada. Mantida, um novo bloco EXIF é
+            escrito com essa etiqueta e nada mais &mdash; e só quando a foto já não
+            estava no sentido certo.
+          </span>
+        </span>
+      </label>
+      <label class="check">
+        <input type="checkbox" id="keep-icc" checked>
+        <span>
+          <strong>O perfil de cor</strong>
+          <span class="check-note">
+            O perfil ICC diz o que os números da imagem significam como cores. Ele
+            não diz nada sobre você. Descartá-lo pode deslocar visivelmente as cores
+            de uma foto de gama ampla, e é por isso que ele fica, a menos que você
+            diga o contrário.
+          </span>
+        </span>
+      </label>
+      <p class="keep-summary" id="keep-summary"></p>
+    </fieldset>
+
+    <div id="clean-results" class="results" hidden>
+      <div class="results-head">
+        <h3>Limpas</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Baixar tudo num zip</button>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; ler e editar -->
+  <section class="card" id="inspect-card">
+    <h2><span class="step">3</span> Olhe por dentro e mude o que quiser</h2>
+
+    <p id="inspect-empty" class="empty-note">
+      Escolha uma foto acima e tudo o que há nela aparece aqui: o que ela conta
+      sobre onde você estava, quando e em qual aparelho. Nada é mandado para lugar
+      nenhum para descobrir isso.
+    </p>
+
+    <div id="inspector" hidden>
+      <div class="inspect-head">
+        <div class="inspect-file">
+          <img id="inspect-thumb" class="inspect-thumb" alt="" hidden>
+          <div>
+            <p class="inspect-name" id="inspect-name"></p>
+            <p class="inspect-sub" id="inspect-sub"></p>
+          </div>
+        </div>
+        <div class="inspect-switch">
+          <label for="inspect-select" class="visually-hidden">Qual foto inspecionar</label>
+          <select id="inspect-select"></select>
+        </div>
+      </div>
+
+      <!-- The findings: the part of this page that answers the actual question. -->
+      <section class="findings" aria-labelledby="findings-h">
+        <h3 id="findings-h">O que este arquivo entrega</h3>
+        <ul id="findings-list" class="findings-list"></ul>
+      </section>
+
+      <!-- Whole blocks, each removable on its own. -->
+      <section class="blocks" aria-labelledby="blocks-h">
+        <h3 id="blocks-h">Blocos neste arquivo</h3>
+        <ul id="block-list" class="block-list"></ul>
+      </section>
+
+      <!-- Every tag, editable. -->
+      <section class="tags" aria-labelledby="tags-h">
+        <h3 id="tags-h">Todas as etiquetas</h3>
+        <p class="tags-note" id="tags-note"></p>
+        <div id="tag-groups"></div>
+
+        <details class="add-tag" id="add-tag">
+          <summary>Adicionar uma etiqueta</summary>
+          <div class="add-tag-body">
+            <label for="add-tag-select">Etiqueta</label>
+            <select id="add-tag-select"></select>
+            <label for="add-tag-value">Valor</label>
+            <input type="text" id="add-tag-value" spellcheck="false">
+            <button type="button" id="add-tag-go" class="ghost">Adicionar</button>
+          </div>
+        </details>
+      </section>
+
+      <div class="save-row">
+        <button type="button" id="save-edits" class="primary" disabled>Salvar esta foto</button>
+        <button type="button" id="revert-edits" class="ghost" disabled>Desfazer minhas mudanças</button>
+        <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
+      </div>
+      <p id="edit-error" class="error" role="alert" hidden></p>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/exif-editor.toml
+++ b/locales/pt/tools/exif-editor.toml
@@ -1,0 +1,243 @@
+#
+# Visualizador e removedor de EXIF - português do Brasil.
+#
+# Overrides for tools/exif-editor/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "EXIF" fica como está em toda parte: é o nome do bloco dentro do arquivo, e é
+# assim que ele aparece em qualquer programa que o leia.
+#
+
+name = "Visualizador e removedor de EXIF"
+heading = "Remover&nbsp;dados&nbsp;EXIF <span class=\"h1-kw\">&mdash; ver e apagar metadados de fotos</span>"
+tagline = "Veja o que uma foto conta sobre você. Depois tire isso."
+
+title = "Ver e remover dados EXIF &mdash; editor de metadados de fotos grátis"
+description = "Veja os dados EXIF e de GPS escondidos numa foto, edite, ou apague tudo num clique. No seu navegador: nada é enviado, e a foto nunca é recodificada."
+og_title = "Visualizador e removedor de EXIF &mdash; veja, edite ou apague"
+og_description = "Leia os metadados escondidos numa foto e remova todos num clique. Roda na sua própria máquina; a imagem em si nunca é recodificada."
+og_image_alt = "Visualizador e removedor de EXIF - leia, edite ou apague os metadados de uma foto"
+
+pledge = """
+    O arquivo é aberto, interpretado e reescrito pelo seu próprio navegador. Esta
+    ferramenta não tem função de rede de espécie alguma &mdash; nada a buscar,
+    nada a enviar &mdash; e não existe do outro lado desta página servidor nenhum
+    para onde mandar uma foto, mesmo que houvesse caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e limpe uma foto. Nenhuma requisição leva uma imagem, uma
+      miniatura, um nome de arquivo ou uma etiqueta que lemos do seu arquivo. Ou
+      desconecte da internet e limpe uma mesmo assim."""
+
+read_first = """
+, <code>src/tiff.js</code> para o interpretador de
+      EXIF, e <code>src/jpeg.js</code> para a prova de que a imagem em si nunca é
+      mais que copiada."""
+
+howto_heading = "Como remover os dados EXIF de uma foto"
+
+card = """
+            Veja a localização, a câmera e os números de série escondidos numa
+            foto, edite o que quiser, ou apague tudo num clique."""
+
+[words]
+plural = "fotos"
+choose = "uma foto"
+analytics_extra = """, nem nenhuma das
+  etiquetas que esta ferramenta lê dos seus arquivos"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[facts]]
+text = "Nunca recodifica a imagem"
+
+[[privacy]]
+title = "Suas fotos não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      seus arquivos pudessem ser coletados, e não existe no código nada que os
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Ao contrário das outras
+      ferramentas desta caixa, esta não tem função de &ldquo;carregar de um
+      endereço da web&rdquo; e não tem etapa de rede opcional nenhuma. Não existe
+      <code>fetch</code>, nem <code>XMLHttpRequest</code>, nem
+      <code>sendBeacon</code> em lugar nenhum de <code>src/</code>."""
+
+[[privacy]]
+title = "Os metadados que lemos nunca são relatados."
+body = """
+ Sua posição de GPS
+      é exibida nesta página e não vai a mais lugar nenhum. Não existe neste
+      repositório nenhum evento de análise personalizado que carregue uma
+      etiqueta, um nome de arquivo, um tamanho ou uma contagem."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google. Nenhum dos dois recebe coisa alguma
+      sobre as suas fotos. Toda linha que lê, interpreta ou reescreve um arquivo é
+      servida desta origem e está listada no repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não é entregue a ele."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; do cabeçalho é desenhado por um
+      script vindo de cdnjs.buymeacoffee.com e busca as letras dele no Google
+      Fonts. É um link e nada mais: ele não reporta visita nenhuma, e não recebe
+      nada sobre você nem sobre os seus arquivos. Nada acontece a menos que você
+      clique, e aquilo para onde você iria clicando é o site de outra gente."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua
+      igual, porque nunca houve uma etapa de rede nela. Essa é a prova mais
+      simples de todas."""
+
+[[howto]]
+title = "Escolha suas fotos."
+body = """
+ Arraste até o seletor ou escolha na mão.
+      Elas são lidas direto do seu disco pelo navegador; nada é mandado para lugar
+      nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Leia o que tem nelas, se quiser."
+body = """
+ A lista de achados nomeia as
+      coisas que vale saber &mdash; a posição de GPS, os horários, os números de
+      série &mdash; antes da tabela completa com todas as etiquetas."""
+
+[[howto]]
+title = "Aperte &ldquo;Remover todos os metadados&rdquo;."
+body = """
+ Esse é o trabalho inteiro
+      para a maioria das pessoas. Todas as etiquetas, os blocos XMP e IPTC, os
+      comentários e a miniatura embutida vão embora, em todas as fotos da lista de
+      uma vez."""
+
+[[howto]]
+title = "Ou edite em vez de remover."
+body = """
+ Mude uma data, corrija uma linha de
+      direitos autorais, descarte a localização e mantenha os ajustes da câmera
+      &mdash; e então salve aquela foto sozinha."""
+
+[[faq]]
+q = "Minha foto é enviada para algum lugar?"
+a = """
+        Não. O arquivo é lido, interpretado e reescrito pelo seu próprio navegador
+        no seu próprio hardware. Esta ferramenta não tem função de rede de espécie
+        alguma &mdash; nunca busca nada e nunca manda nada &mdash; e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar, nenhum dos quais é deste site."""
+
+[[faq]]
+q = "O que é EXIF, e o que mais está escondido numa foto?"
+a = """
+        EXIF é um bloco de etiquetas que a câmera escreve ao lado da imagem: a marca
+        e o modelo, os ajustes de exposição, a data e a hora com precisão de segundo,
+        muitas vezes uma posição de GPS e às vezes um número de série. As fotos
+        costumam carregar mais coisas além disso &mdash; um pacote XMP de XML vindo
+        de um editor, um bloco IPTC com campos de legenda e assinatura, um perfil de
+        cor, uma segunda cópia pequena da imagem como miniatura, e uma maker note
+        com dados não documentados do fabricante. Esta ferramenta lista tudo
+        isso."""
+
+[[faq]]
+q = "Remover os metadados reduz a qualidade da imagem?"
+a = """
+        Não, e esse é o motivo principal para usar uma ferramenta assim em vez de
+        salvar a foto de novo. Os metadados ficam no contêiner em volta da imagem
+        comprimida, e não dentro dela. Removê-los é apagar itens de uma lista e
+        escrever a lista de volta; os dados de imagem comprimida são copiados byte
+        por byte, então o resultado decodifica exatamente para os mesmos pixels.
+        Nada é decodificado e nada é recomprimido."""
+
+[[faq]]
+q = "Quais formatos de arquivo ele trata?"
+a = """
+        JPEG, PNG e WebP. HEIC e AVIF são reconhecidos, mas não reescritos: são
+        formatos de caixas montados a partir de átomos aninhados e precisam de outro
+        interpretador, então a ferramenta diz isso em vez de produzir um arquivo
+        quebrado. Um TIFF puro também não é tratado, porque num TIFF os metadados e
+        os pixels são endereçados pelos mesmos deslocamentos."""
+
+[[faq]]
+q = "Minha foto vai aparecer girada depois que os metadados forem removidos?"
+a = """
+        Pode acontecer, e há um ajuste para isso. Os celulares normalmente gravam a
+        imagem do jeito que o sensor viu e acrescentam uma etiqueta de Orientação
+        dizendo como virar. Remova essa etiqueta e alguns visualizadores mostram a
+        foto deitada. A opção de &ldquo;manter a etiqueta de orientação&rdquo;, que
+        vem ligada, escreve de volta um pequeníssimo bloco EXIF contendo só essa
+        etiqueta &mdash; e só quando a foto realmente precisava. Desligue se você
+        preferir que o arquivo não carregue EXIF nenhum."""
+
+[[faq]]
+q = "Ele remove a localização de GPS?"
+a = """
+        Sim. Remover tudo remove o diretório de GPS inteiro, e você também pode
+        apagar a localização sozinha e manter o resto. A posição é mostrada primeiro
+        em graus decimais, porque &ldquo;51 graus, 30 minutos, 26 segundos&rdquo; não
+        deixa evidente que a foto nomeia o prédio em que foi tirada."""
+
+[[faq]]
+q = "Posso mudar uma etiqueta em vez de apagá-la?"
+a = """
+        Sim. Etiquetas de texto, datas, o ISO, a orientação e a resolução podem
+        todas ser editadas, e algumas etiquetas comuns podem ser acrescentadas a uma
+        foto que não tem nenhuma. Uma ressalva: escrever o arquivo reconstrói o
+        bloco EXIF, e uma maker note contém deslocamentos que apontam para dentro do
+        bloco original, então uma maker note reconstruída pode deixar de ser legível
+        pelo próprio software do fabricante. Apague a maker note ou deixe o arquivo
+        sem editar, se isso lhe importa."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste. O site exibe
+        publicidade, e é ela que paga a conta; os anúncios não recebem nada sobre as
+        suas fotos."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse as suas fotos embora para serem
+        processadas pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Leia os metadados EXIF, GPS, XMP e IPTC de dentro de uma foto, edite etiquetas individuais, ou remova tudo num clique. JPEG, PNG e WebP, processados no navegador sem recodificar a imagem."
+features = [
+  "Mostra todas as etiquetas EXIF, inclusive posição de GPS, números de série da câmera e maker notes",
+  "Edita ou apaga etiquetas individuais e escreve o arquivo de volta",
+  "Remove EXIF, GPS, XMP, IPTC, comentários e a miniatura embutida num clique",
+  "JPEG, PNG e WebP",
+  "Reescreve só o contêiner, então a imagem nunca é recomprimida",
+  "Roda offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste fotos para cá"
+hint = "ou clique para escolher &mdash; JPEG, PNG e WebP"

--- a/locales/pt/tools/heic-to-jpg.html
+++ b/locales/pt/tools/heic-to-jpg.html
@@ -1,0 +1,113 @@
+<main>
+  <!-- Passo 1 &mdash; os arquivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha suas fotos HEIC</h2>
+
+    <p class="card-lede">
+      Direto do celular, de dentro de um backup, ou copiadas de um cartão de
+      memória. O arquivo é lido aqui, nesta máquina, e a imagem é decodificada
+      aqui também &mdash; não existe etapa de envio nesta página e não existe
+      servidor atrás dela.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tirar tudo da lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; o que sai -->
+  <section class="card" id="options-card">
+    <h2><span class="step">2</span> Diga o que você quer de volta</h2>
+
+    <fieldset class="options">
+      <legend>O formato</legend>
+
+      <div class="option-row">
+        <label for="format-select">Escrever as imagens como</label>
+        <select id="format-select">
+          <option value="image/jpeg" selected>JPEG &mdash; abre em todo lugar, inclusive em coisas feitas neste século por engano</option>
+          <option value="image/png">PNG &mdash; sem perdas, e várias vezes maior</option>
+          <option value="image/webp">WebP &mdash; menor que o JPEG na mesma qualidade, e só em navegadores modernos</option>
+        </select>
+      </div>
+
+      <div class="option-row" id="quality-row">
+        <label for="quality">Qualidade</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="50" max="100" step="1" value="92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Os detalhes da foto</legend>
+
+      <label class="check">
+        <input type="checkbox" id="keep-exif" checked>
+        <span>
+          <strong>Manter a data, a câmera e os ajustes</strong>
+          <span class="check-note">
+            Copiados exatamente como o celular escreveu, então a foto convertida
+            continua se ordenando pelo dia em que foi tirada, e não pelo dia em
+            que foi convertida. Isso inclui as coordenadas de GPS quando a foto as
+            tem &mdash; a lista acima diz quais das suas têm. Desligue e o JPEG
+            sai sem nada dentro além da imagem.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary">
+        De um jeito ou de outro, nada daqui é relatado a ninguém: a escolha é
+        sobre o que entra no arquivo que você recebe de volta, e não sobre o que
+        esta página faz com isso. Se você quer percorrer as etiquetas em detalhe,
+        ou apagá-las de fotos que já são JPEG, o
+        <a href="../remover-dados-exif/">Visualizador e removedor de EXIF</a> é a
+        ferramenta para isso.
+      </p>
+    </fieldset>
+  </section>
+
+  <!-- Passo 3 &mdash; o único clique -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Converter</h2>
+
+    <div class="run-row">
+      <button type="button" id="convert-all" class="primary big" disabled>Converter</button>
+    </div>
+
+    <!--
+      The decoder's own status line. This page is the only one on the site that
+      carries a codec, so it is the only one with anything to report here, and
+      saying where the megabyte came from is the point: it is served from this
+      origin, it is cached with the rest of the page, and it is what makes the
+      offline promise hold on a browser that cannot open a HEIC at all.
+    -->
+    <p id="engine-status" class="engine-status" role="status" aria-live="polite"></p>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Convertidas</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Baixar tudo num zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/heic-to-jpg.toml
+++ b/locales/pt/tools/heic-to-jpg.toml
@@ -1,0 +1,299 @@
+#
+# HEIC para JPG - português do Brasil.
+#
+# Overrides for tools/heic-to-jpg/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Os nomes de formato e de biblioteca ficam como estão: HEIC, HEIF, HEVC, JPEG,
+# libheif, WebAssembly. São nomes próprios, e traduzir qualquer um deles só
+# tornaria a página mais difícil de conferir contra o repositório.
+#
+
+name = "HEIC para JPG"
+heading = "HEIC&nbsp;para&nbsp;JPG <span class=\"h1-kw\">&mdash; converter fotos de iPhone</span>"
+tagline = "As fotos que o iPhone tira, num formato que tudo abre."
+
+title = "Conversor de HEIC para JPG &mdash; grátis, sem envio"
+description = "Converta fotos HEIC de iPhone em JPG no seu navegador. O decodificador roda na sua própria máquina: nada é enviado, sem conta, funciona offline, e a data e os detalhes da câmera podem vir junto."
+og_title = "Transforme fotos HEIC em JPGs sem enviá-las"
+og_description = "O conversor que não quer as suas fotos. O decodificador de HEIC é servido por esta página e roda na sua própria máquina, então as imagens nunca saem dela."
+og_image_alt = "HEIC para JPG - fotos de iPhone num formato que tudo abre"
+
+pledge = """
+    A decodificação roda no seu próprio navegador, no seu próprio hardware. O
+    HEIC é o único formato de imagem que um navegador não abre sozinho, então
+    esta página carrega o decodificador junto &mdash; cerca de 1,4 MB, servido
+    deste site, guardado em cache depois da primeira visita. É esse o motivo
+    inteiro de todo outro conversor de HEIC lhe pedir um envio: eles põem o codec
+    num servidor e as suas fotos têm que ir até lá. Este põe o codec aqui. Não
+    existe função de rede nenhuma nesta página, e nem servidor do outro lado dela
+    para onde mandar uma foto."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e converta uma foto. Você vai ver os arquivos desta própria página
+      carregarem, o decodificador entre eles, e nenhuma requisição levando uma
+      foto, uma miniatura, um nome de arquivo ou um byte do que você escolheu. Ou
+      carregue a página uma vez, desconecte da internet e converta uma pasta
+      inteira mesmo assim."""
+
+read_first = """
+, <code>src/heif.js</code> para como o
+      decodificador é carregado e o que ele tem permissão de fazer,
+      <code>src/boxes.js</code> para a interpretação do contêiner que acha os
+      metadados da foto, e <code>src/exif.js</code> para o que acontece com esses
+      metadados no caminho para dentro de um JPEG. O motor em si é o
+      <code>vendor/libheif.js</code>, sem modificações, com a licença dele ao
+      lado."""
+
+howto_heading = "Como converter fotos HEIC em JPG"
+
+card = """
+            As fotos que o iPhone tira, num formato que tudo abre &mdash;
+            decodificadas na sua própria máquina, e não no servidor de
+            alguém."""
+
+[words]
+plural = "fotos"
+choose = "uma foto"
+analytics_extra = """, nem nenhuma das
+  datas, modelos de câmera ou coordenadas que esta ferramenta lê delas"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem limite de tamanho"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "Suas fotos não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      seus arquivos pudessem ser coletados, e não existe no código nada que os
+      mandaria se existisse."""
+
+[[privacy]]
+title = "O decodificador veio daqui, e não vai a lugar nenhum."
+body = """
+ HEIC é HEVC
+      dentro de um formato de caixas, e navegador nenhum além do Safari decodifica
+      um, então esta página traz a <code>libheif</code> compilada para
+      WebAssembly &mdash; cerca de 1,4 MB, commitados neste repositório, servidos
+      desta origem, e guardados em cache pelo service worker como qualquer outro
+      arquivo daqui. Ela não é buscada de uma CDN, porque isso colocaria um
+      terceiro no caminho de cada visita e faria a ferramenta parar de funcionar
+      offline. O binário está dentro do script em vez de ao lado dele justamente
+      para que nenhuma busca seja necessária para iniciá-lo."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Não existe
+      <code>fetch</code>, nem <code>XMLHttpRequest</code>, nem
+      <code>sendBeacon</code> em nenhum arquivo escrito para esta ferramenta. O
+      motor de terceiros, como toda compilação do Emscripten, contém os caminhos
+      de carregamento que buscariam um <code>.wasm</code> numa URL; eles não são
+      tomados, porque o binário já está em mãos &mdash; e se fossem, o
+      <code>connect-src</code> nomeia os pontos de medição do Google e nada mais,
+      então o navegador recusaria. A prova é a política, não a promessa."""
+
+[[privacy]]
+title = "Os metadados são lidos aqui e relatados a você."
+body = """
+ A lista na
+      página diz o que cada foto carrega &mdash; a data, a câmera, e se há
+      coordenadas de GPS lá dentro &mdash; porque essa é uma coisa que você pode
+      querer saber antes de entregar o JPEG a alguém. É lido do arquivo pelo
+      <code>src/boxes.js</code> neste navegador, mostrado nesta página, e escrito
+      no seu JPEG ou deixado de fora, inteiramente conforme você escolher. Não
+      existe neste repositório nenhum evento de análise personalizado que carregue
+      um nome de arquivo, uma data, uma coordenada ou uma contagem."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google, e o botão de doação vem do Buy Me a
+      Coffee. Nenhum deles recebe coisa alguma sobre as suas fotos. Toda linha que
+      lê, decodifica ou escreve um arquivo é servida desta origem e está listada
+      no repositório."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Carregue a página uma vez e desconecte da rede, e
+      a ferramenta continua igual &mdash; o decodificador é guardado em cache
+      junto. Essa é a prova mais simples de todas, e aqui ela é mais forte que em
+      qualquer outro lugar deste site: um conversor que mandasse as suas fotos
+      embora para serem decodificadas não teria como dar conta."""
+
+[[howto]]
+title = "Escolha suas fotos HEIC."
+body = """
+ Arraste até o seletor ou escolha na mão,
+      direto de um backup do celular ou de uma pasta na área de trabalho. Elas são
+      lidas do seu disco pelo navegador; nada é mandado para lugar nenhum enquanto
+      você faz isso. A lista diz o que cada uma é e o que ela tem dentro."""
+
+[[howto]]
+title = "Confira o que as fotos carregam."
+body = """
+ Cada linha nomeia a data em que foi
+      tirada, a câmera, e &mdash; em verde, porque é a parte que vale notar
+      &mdash; se o arquivo guarda coordenadas de GPS. Isso é lido do contêiner sem
+      decodificar a imagem, então não custa nada e aparece na hora."""
+
+[[howto]]
+title = "Escolha um formato e decida sobre os detalhes."
+body = """
+ JPEG, a menos que você
+      tenha um motivo: é o formato que abre em todo lugar, que é o ponto inteiro
+      de converter. O controle de qualidade está em 92, que é o ajuste em que uma
+      fotografia é difícil de distinguir do original. A caixinha decide se a data,
+      a câmera e a localização vêm junto."""
+
+[[howto]]
+title = "Aperte &ldquo;Converter&rdquo;, e baixe."
+body = """
+ O decodificador chega na
+      primeira conversão &mdash; cerca de 1,4 MB, uma vez &mdash; e toda foto
+      depois disso é decodificada e escrita na sua própria máquina. Um arquivo lhe
+      dá um botão de download; vários lhe dão um zip também."""
+
+[[faq]]
+q = "Minha foto é enviada para algum lugar?"
+a = """
+        Não. O arquivo é lido, decodificado e escrito pelo seu próprio navegador no
+        seu próprio hardware. Esta ferramenta não tem função de rede de espécie
+        alguma &mdash; nunca busca nada e nunca manda nada &mdash; e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar, nenhum dos quais é deste site. A única coisa que carrega
+        é o próprio decodificador, e ele vem deste site, uma vez, antes de a sua
+        foto sequer entrar na história."""
+
+[[faq]]
+q = "Por que esta página baixa 1,4 MB na primeira vez?"
+a = """
+        Porque o HEIC é o único formato de imagem que um navegador não abre. É um
+        quadro HEVC num contêiner de caixas, e só o Safari, em hardware da Apple,
+        tem um decodificador para ele; Chrome, Firefox e Edge simplesmente recusam o
+        arquivo. Então um conversor de HEIC precisa de um decodificador vindo de
+        algum lugar, e há dois lugares de onde ele pode vir: um servidor, ou a
+        página. Todo outro conversor escolheu o servidor, que é exatamente por que
+        todos eles precisam que você envie as suas fotos. Este carrega a
+        <code>libheif</code> compilada para WebAssembly em vez disso. Ela é servida
+        deste site, guardada em cache depois da primeira visita, e é o preço inteiro
+        de as suas fotos não irem a lugar nenhum."""
+
+[[faq]]
+q = "O JPEG mantém a data, a câmera e a localização?"
+a = """
+        Se você quiser, e isso é uma caixinha na página. Deixada ligada, o bloco
+        EXIF é copiado do HEIC e escrito no JPEG exatamente como o celular escreveu,
+        então a foto convertida continua se ordenando pelo dia em que foi tirada, e
+        não pelo dia em que foi convertida &mdash; que é a reclamação de sempre
+        sobre conversores de HEIC. Uma etiqueta é mudada, e só uma: a orientação,
+        que é ajustada para &ldquo;em pé&rdquo;, porque a rotação já foi aplicada aos
+        pixels e um visualizador que a aplicasse de novo viraria toda foto em pé de
+        lado. Desligue a caixinha e o JPEG sai com a imagem e nada mais."""
+
+[[faq]]
+q = "Ele apaga as coordenadas de GPS?"
+a = """
+        Ele lhe diz que elas estão lá, e então faz o que você mandar. A linha de
+        cada foto diz se o arquivo carrega coordenadas antes de qualquer coisa ser
+        convertida, o que é mais do que o celular faz. Desmarcar &ldquo;manter a
+        data, a câmera e os ajustes&rdquo; deixa as coordenadas fora do JPEG junto
+        com todo o resto; deixar marcado as leva adiante. Se o que você quer é
+        percorrer as etiquetas em detalhe, ou apagá-las de fotos que já são JPEG, o
+        <a href="../remover-dados-exif/">Visualizador e removedor de EXIF</a> é a
+        ferramenta para isso, e ele faz sem recomprimir a imagem."""
+
+[[faq]]
+q = "A imagem é recomprimida?"
+a = """
+        Sim, e tem que ser: HEIC e JPEG são codecs diferentes, então não há como ir
+        de um ao outro sem decodificar a imagem e codificá-la de novo. O que você
+        controla é quanto isso custa. O controle de qualidade vem em 92, em que uma
+        fotografia é muito difícil de distinguir do original, e o PNG está no menu
+        para o caso em que você não quer perda nenhuma e não se importa com o
+        arquivo ficar de cinco a dez vezes maior."""
+
+[[faq]]
+q = "E se o arquivo se chama .jpg mas na verdade é um HEIC?"
+a = """
+        Funciona do mesmo jeito. Todo arquivo jogado aqui é identificado pelos
+        primeiros bytes e não pelo nome, porque o nome é o que o último aplicativo a
+        encostar no arquivo resolveu chamá-lo &mdash; e um HEIC que chegou chamado
+        de &ldquo;.jpg&rdquo; é um dos jeitos mais comuns de alguém acabar
+        procurando uma ferramenta como esta. Um arquivo que é genuinamente um JPEG
+        ou um PNG é recusado com uma mensagem dizendo isso, em vez de ser convertido
+        numa cópia de si mesmo."""
+
+[[faq]]
+q = "Ele converte uma Live Photo, ou uma rajada?"
+a = """
+        As imagens paradas de dentro, sim. Um HEIC pode guardar mais de uma imagem,
+        e cada uma que ele guarda é convertida e nomeada a partir do original com um
+        número no fim. A metade em vídeo de uma Live Photo é um arquivo separado que
+        o celular guarda ao lado do HEIC, então ela não está aqui dentro para ser
+        convertida. Mapas de profundidade e miniaturas estão no contêiner mas não
+        são imagens que alguém pediu, e são deixados em paz."""
+
+[[faq]]
+q = "Por que ele não aceita o meu AVIF?"
+a = """
+        Porque não há o que fazer com ele. AVIF é o mesmo contêiner do HEIC com AV1
+        dentro no lugar do HEVC, e todo navegador atual decodifica um nativamente
+        &mdash; então um conversor estaria entregando um megabyte de motor para
+        resolver um problema que você não tem. Se você precisa de um AVIF como JPEG,
+        o <a href="../comprimir-imagem/">Compressor de imagens</a> e o
+        <a href="../redimensionar-imagem/">Redimensionador de imagens</a> leem AVIF
+        e escrevem JPEG usando o decodificador que o seu navegador já tem."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. Também não há limite para o número ou o tamanho dos arquivos,
+        porque não há servidor pagando por eles &mdash; o trabalho acontece na sua
+        própria máquina. O site exibe publicidade, e é ela que paga a conta; os
+        anúncios não recebem nada sobre as suas fotos."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim, decodificador incluído. Carregue a página uma vez, então desconecte da
+        internet e ela continua trabalhando nas suas fotos exatamente como antes.
+        Essa é também a prova mais forte disponível de que nada está sendo enviado:
+        um conversor que mandasse os seus HEICs embora para serem decodificados
+        pararia no instante em que você tirasse da tomada, e este não para."""
+
+[schema]
+description = "Converta fotos HEIC e HEIF de um iPhone em JPEG, PNG ou WebP. O decodificador de HEIC é WebAssembly servido pela própria página, então as imagens são decodificadas na sua própria máquina e nunca enviadas. A data, a câmera e a localização podem ser levadas para dentro do JPEG ou deixadas de fora."
+features = [
+  "Converte HEIC e HEIF em JPEG, PNG ou WebP",
+  "Decodifica no navegador, em qualquer navegador - não só no Safari",
+  "Nada é enviado, e a ferramenta funciona com a rede desligada",
+  "Leva a data, a câmera e o GPS para dentro do JPEG, ou os deixa de fora",
+  "Diz quais fotos guardam coordenadas de GPS antes de qualquer conversão",
+  "Corrige a etiqueta de orientação, para as fotos em pé não saírem deitadas",
+  "Identifica arquivos pelo conteúdo, então um HEIC chamado .jpg funciona igual",
+  "Converte todas as imagens de uma rajada ou Live Photo, e não só a primeira",
+  "Trabalha em lote, com todos os resultados num zip",
+]
+
+[picker]
+title = "Arraste fotos HEIC para cá"
+hint = "ou clique para escolher &mdash; .heic e .heif, seja qual for o nome que estiverem usando"

--- a/locales/pt/tools/image-to-data-uri.html
+++ b/locales/pt/tools/image-to-data-uri.html
@@ -1,0 +1,141 @@
+<main>
+  <!-- Passo 1 &mdash; os arquivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha as imagens</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tirar tudo da lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; a linha que de fato vai ser colada -->
+  <section class="card" id="shape-card">
+    <h2><span class="step">2</span> Diga para onde ela vai</h2>
+
+    <p class="card-lede">
+      Uma data URI sozinha raramente é o que alguém quer. O que se quer é a linha
+      que vai na folha de estilo &mdash; então escolha a linha, e a imagem chega
+      dentro dela já entre aspas, que é a parte fácil de errar e que só falha com
+      SVGs.
+    </p>
+
+    <div class="shapes" id="shapes" role="radiogroup" aria-label="O que colar">
+      <label class="shape">
+        <input type="radio" name="shape" value="uri" checked>
+        <span class="shape-body">
+          <strong>A data URI sozinha</strong>
+          <span class="shape-note">
+            Tudo depois da vírgula é o arquivo. Cole em qualquer lugar onde caiba uma URL.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-rule">
+        <span class="shape-body">
+          <strong>Uma regra de CSS</strong>
+          <span class="shape-note">
+            Uma regra inteira, com uma classe nomeada a partir do arquivo. Troque
+            o seletor pelo que você está de fato estilizando.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-var">
+        <span class="shape-body">
+          <strong>Uma propriedade personalizada de CSS</strong>
+          <span class="shape-note">
+            Declarada uma vez no alto da folha de estilo e usada como
+            <code>var(--nome)</code> quantas vezes você quiser. É esta a escolha
+            quando a imagem aparece em mais de uma regra.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="html">
+        <span class="shape-body">
+          <strong>Uma tag <code>&lt;img&gt;</code> de HTML</strong>
+          <span class="shape-note">
+            Com o tamanho em pixels preenchido, para a página não pular enquanto o
+            resto dela carrega.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="markdown">
+        <span class="shape-body">
+          <strong>Markdown</strong>
+          <span class="shape-note">
+            Para um README ou uma issue: uma imagem que viaja junto com o texto em
+            vez de precisar de algum lugar para ser hospedada.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary">
+      O texto <code>alt</code> é deixado vazio de propósito. Só você sabe se a
+      imagem carrega significado ou é decoração, e uma descrição chutada a partir
+      de um nome de arquivo é pior para quem usa leitor de tela do que descrição
+      nenhuma.
+    </p>
+
+    <fieldset class="options">
+      <legend>SVG</legend>
+
+      <label class="check">
+        <input type="checkbox" id="svg-base64">
+        <span>
+          <strong>Pôr os SVGs em base64 também</strong>
+          <span class="check-note">
+            Desligado por padrão, porque um SVG é texto e base64 é para bytes. A
+            codificação em porcentagem deixa a marcação legível na folha de estilo
+            e costuma ser uns 20% mais curta. Ligue para a rara cadeia de
+            ferramentas que insiste em <code>;base64</code>.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Passo 3 &mdash; o resultado. Não há botão aqui de propósito: codificar é
+       instantâneo, então não há nada que um "converter" tivesse que esperar. -->
+  <section class="card" id="output-card">
+    <h2><span class="step">3</span> Copie</h2>
+
+    <p id="empty-note" class="card-lede">
+      Nada escolhido ainda. Jogue uma imagem aí em cima e a linha para colar
+      aparece aqui.
+    </p>
+
+    <div id="results" hidden>
+      <div class="results-head">
+        <p id="results-summary" class="results-summary"></p>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Copiar tudo</button>
+          <button type="button" id="download-all" class="ghost">Baixar como um arquivo só</button>
+        </div>
+      </div>
+
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/image-to-data-uri.toml
+++ b/locales/pt/tools/image-to-data-uri.toml
@@ -1,0 +1,315 @@
+#
+# Imagem para data URI - português do Brasil.
+#
+# Overrides for tools/image-to-data-uri/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Data URI" fica em inglês porque é o nome da coisa na especificação e o que
+# se digita numa busca; o slug, esse sim, é "imagem-para-base64", que é como se
+# procura no Brasil.
+#
+
+name = "Imagem para data URI"
+heading = "Imagem&nbsp;para&nbsp;data&nbsp;URI <span class=\"h1-kw\">&mdash; codificar uma imagem em base64 para CSS ou HTML</span>"
+tagline = "A imagem inteira como uma linha de texto. Cole direto no CSS ou no HTML."
+
+title = "Imagem para data URI &mdash; base64 para CSS, grátis, sem envio"
+description = "Transforme um PNG, JPEG, SVG ou WebP numa data URI que você cola no CSS ou no HTML. SVGs são codificados em porcentagem em vez de base64, então ficam legíveis e mais curtos. Roda no seu navegador; nada é enviado."
+og_title = "Transforme uma imagem numa linha que você cola no CSS"
+og_description = "Base64 para imagens, codificação em porcentagem para SVG, e a regra, a propriedade personalizada ou a tag img já montadas em volta. Roda na sua própria máquina; nada é enviado."
+og_image_alt = "Imagem para data URI - cole a imagem dentro da folha de estilo"
+
+pledge = """
+    A codificação roda no seu próprio navegador, no seu próprio hardware. É
+    aritmética sobre bytes que a página já tem: sem codificador, sem servidor, e
+    sem etapa de rede para deixar de fora. Esta ferramenta não tem função de rede
+    de espécie alguma &mdash; nada a buscar, nada a enviar &mdash; e não existe do
+    outro lado desta página servidor nenhum para onde mandar uma imagem, mesmo
+    que houvesse caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e jogue uma imagem aqui. Nenhuma requisição leva uma imagem, uma
+      miniatura, um nome de arquivo ou um byte do que você escolheu. Ou desconecte
+      da internet e codifique uma mesmo assim."""
+
+read_first = """
+, <code>src/encode.js</code> para as duas
+      codificações e o raciocínio por trás de cada uma, <code>src/sniff.js</code>
+      para como o tipo de mídia é lido do arquivo em vez do nome dele, e
+      <code>src/metadata.js</code> para a verificação que diz quanto daquilo que
+      você está prestes a colar não é a imagem."""
+
+howto_heading = "Como transformar uma imagem em uma data URI"
+
+card = """
+            Base64 para imagens, codificação em porcentagem para SVG, e a regra
+            de CSS ou a tag <code>&lt;img&gt;</code> já montada em volta."""
+
+[words]
+plural = "imagens"
+choose = "uma imagem"
+analytics_extra = """, nem nenhum dos
+  nomes de arquivo, tamanhos ou textos codificados que esta ferramenta produz"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem recodificação"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "Suas imagens não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      seus arquivos pudessem ser coletados, e não existe no código nada que os
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Não existe
+      <code>fetch</code>, nem <code>XMLHttpRequest</code>, nem
+      <code>sendBeacon</code> em lugar nenhum de <code>src/</code>. A codificação
+      é <code>btoa</code> e <code>encodeURIComponent</code> &mdash; duas funções
+      que o navegador tem desde o começo, e as duas pegam bytes e devolvem texto
+      sem ir a lugar nenhum."""
+
+[[privacy]]
+title = "A pré-visualização é a prova."
+body = """
+ A imagem ao lado de cada
+      resultado é desenhada a partir da data URI que esta página acabou de montar,
+      e não do seu arquivo. Ela aparece porque a URI está correta, na sua máquina,
+      sem servidor nenhum envolvido &mdash; e se não aparecer, a página diz isso em
+      vez de lhe entregar algo quebrado."""
+
+[[privacy]]
+title = "O aviso de metadados está do seu lado."
+body = """
+ Uma data URI copia o
+      arquivo exatamente, então a posição de GPS de uma fotografia viaja junto para
+      dentro da sua folha de estilo. Esta página lê quanto disso existe e lhe diz,
+      porque a alternativa é você descobrir depois de já ter feito o commit."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google, e o botão de doação vem do Buy Me a
+      Coffee. Nenhum deles recebe coisa alguma sobre as suas imagens. Toda linha
+      que lê ou codifica um arquivo é servida desta origem e está listada no
+      repositório."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua
+      igual, porque nunca houve uma etapa de rede nela. Essa é a prova mais
+      simples de todas."""
+
+[[howto]]
+title = "Escolha suas imagens."
+body = """
+ Arraste até o seletor ou escolha na mão.
+      Elas são lidas direto do seu disco pelo navegador; nada é mandado para lugar
+      nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Diga para onde o resultado vai."
+body = """
+ A URI sozinha, uma regra de
+      CSS, uma propriedade personalizada, uma tag <code>&lt;img&gt;</code> ou
+      Markdown. Todas elas põem a URI entre aspas, que é o detalhe que decide se um
+      SVG embutido funciona ou silenciosamente não funciona."""
+
+[[howto]]
+title = "Leia o que custou."
+body = """
+ Cada resultado diz em quantos caracteres ele
+      virou, quanto isso é maior que o arquivo, e se embutir algo desse tamanho é
+      boa ideia. O base64 acrescenta um terço; se esse terço vale uma requisição
+      poupada depende inteiramente do tamanho, então a página diz de que lado da
+      linha você está."""
+
+[[howto]]
+title = "Confira os avisos."
+body = """
+ Se a imagem carrega EXIF, um perfil de cor ou
+      XMP, isso é nomeado junto com quantos bytes do seu resultado são aquilo. Se a
+      extensão discorda do formato real, a página usa o formato e lhe avisa. Se o
+      seu navegador não conseguir desenhar o resultado, ela diz isso também."""
+
+[[howto]]
+title = "Copie, ou baixe."
+body = """
+ Um botão por resultado, e um para todos de uma
+      vez &mdash; as propriedades personalizadas saem embrulhadas num bloco
+      <code>:root</code>, prontas para colar no alto de uma folha de estilo."""
+
+[[faq]]
+q = "Minha imagem é enviada para algum lugar?"
+a = """
+        Não. O arquivo é lido e codificado pelo seu próprio navegador no seu próprio
+        hardware, com duas funções que o navegador já tem. Esta ferramenta não tem
+        função de rede de espécie alguma &mdash; nunca busca nada e nunca manda nada
+        &mdash; e a <code>Content-Security-Policy</code> da página nomeia todos os
+        endereços que ela pode contatar, nenhum dos quais é deste site."""
+
+[[faq]]
+q = "O que é uma data URI?"
+a = """
+        Um jeito de escrever um arquivo inteiro onde normalmente iria um endereço da
+        web. Em vez de <code>url("logo.png")</code>, que manda o navegador ir buscar
+        alguma coisa, você escreve
+        <code>url("data:image/png;base64,iVBORw0...")</code>, que contém a própria
+        imagem. O navegador a decodifica ali mesmo. O efeito prático é uma
+        requisição a menos: a imagem chega junto com a folha de estilo ou com a
+        página, em vez de chegar depois."""
+
+[[faq]]
+q = "Por que o meu SVG não está em base64?"
+a = """
+        Porque base64 é a codificação errada para ele. Um SVG é texto, e uma URL já
+        carrega texto &mdash; só um punhado de caracteres precisa ser escapado.
+        Codificar esses em porcentagem e deixar o resto em paz produz uma URI que
+        costuma ser uns 20% mais curta que o base64 do mesmo arquivo, e que você
+        ainda consegue ler na sua folha de estilo: os nomes dos elementos, as cores e
+        o <code>viewBox</code> continuam todos lá para editar. Existe uma caixinha
+        para forçar base64, para a rara cadeia de ferramentas que insiste nisso."""
+
+[[faq]]
+q = "Quanto o base64 deixa a minha imagem maior?"
+a = """
+        Cerca de um terço. Três bytes de arquivo viram quatro caracteres de base64,
+        o que dá 33% antes do <code>data:image/png;base64,</code> na frente. Esse é
+        o piso, e é inevitável: é o que custa escrever bytes arbitrários usando só
+        os caracteres que uma URL permite. É também por isso que a página mostra a
+        contagem de caracteres ao lado do tamanho do arquivo, em vez de deixar você
+        descobrir quando a folha de estilo já estiver no ar."""
+
+[[faq]]
+q = "Quando embutir uma imagem é realmente boa ideia?"
+a = """
+        Quando ela é pequena e é necessária de imediato. Um ícone de 2 KB numa folha
+        de estilo que toda página carrega é vitória clara: uma ida e volta a menos, e
+        a imagem já está lá no momento em que o CSS está. Passando de uns 10 KB a
+        troca vira. Uma imagem embutida deixa de ser um arquivo separado, então não
+        pode ser guardada em cache sozinha, não pode ser buscada em paralelo com
+        outra coisa, e é baixada de novo por inteiro toda vez que o arquivo em volta
+        dela muda &mdash; uma fotografia de 200 KB numa folha de estilo são 200 KB
+        acrescentados ao caminho crítico de toda página do site. A página lhe diz de
+        que lado dessa linha cada resultado cai."""
+
+[[faq]]
+q = "O gzip desfaz o custo do base64?"
+a = """
+        Menos do que as pessoas esperam. O base64 de um arquivo já comprimido
+        &mdash; que é o que um PNG, um JPEG e um WebP são &mdash; comprime mal,
+        porque quase não sobrou redundância para o compressor achar; você
+        normalmente recupera algo como um décimo daquele terço que o base64
+        acrescentou, e não o terço inteiro. Um SVG codificado em porcentagem é o
+        caso oposto: ele continua sendo texto, então comprime mais ou menos tão bem
+        quanto antes, o que é mais um motivo para não pôr um em base64."""
+
+[[faq]]
+q = "Isto muda a minha imagem em alguma coisa?"
+a = """
+        Não, e essa é uma diferença deliberada em relação à maioria das ferramentas
+        daqui. Nada é decodificado em pixels e codificado de novo: os bytes que
+        saíram do seu disco são os bytes que entram na URI. Um JPEG continua
+        exatamente o JPEG que era, na mesma qualidade, com as mesmas dimensões. É
+        por isso que o resultado pode ser descrito como o mesmo arquivo, e não como
+        uma cópia dele."""
+
+[[faq]]
+q = "Então os meus dados EXIF e de GPS vão para dentro da folha de estilo também?"
+a = """
+        Vão, e essa é a parte que vale pensar antes de colar. Como nada é
+        recodificado, tudo o que a câmera escreveu viaja junto com a imagem: a
+        localização, o horário, o número de série da câmera. Numa foto de celular
+        isso pode ser 30 KB do arquivo, que viram 40 KB de base64 no caminho crítico
+        da sua página, e um endereço residencial dentro de algo que vai para um
+        repositório. A página lê quanto metadado existe num JPEG, PNG ou WebP e diz
+        isso. Para tirar antes, use o
+        <a href="../remover-dados-exif/">Visualizador e removedor de EXIF</a>."""
+
+[[faq]]
+q = "Por que ele usou um tipo diferente da extensão do meu arquivo?"
+a = """
+        Porque a extensão pode estar errada e os bytes não podem. Um arquivo chamado
+        <code>logo.png</code> que na verdade foi exportado como JPEG é comum o
+        bastante para toda ferramenta de imagem ter que lidar com isso, e uma data
+        URI que declara o tipo errado simplesmente não é desenhada &mdash; não há
+        recuo e não há mensagem de erro que valha a leitura. Então o tipo é lido dos
+        primeiros bytes do arquivo, que dizem o que ele é sem ambiguidade em todos
+        os formatos daqui, e a página lhe avisa quando os dois discordam."""
+
+[[faq]]
+q = "A pré-visualização está em branco. O que deu errado?"
+a = """
+        Provavelmente nada na URI. HEIC e TIFF geram data URIs perfeitamente válidas
+        que navegador nenhum, exceto o Safari, vai desenhar, então a imagem também
+        vai faltar onde quer que você a cole &mdash; converta para PNG, JPEG ou WebP
+        antes, com o <a href="../comprimir-imagem/">Compressor de imagens</a> ou o
+        <a href="../redimensionar-imagem/">Redimensionador de imagens</a>. Se o
+        formato for um comum, é provável que o arquivo em si esteja danificado: a
+        pré-visualização é desenhada a partir da URI que esta página montou, então
+        uma em branco significa que a imagem não decodificou."""
+
+[[faq]]
+q = "Existe limite de tamanho para uma data URI?"
+a = """
+        Nenhum que você vá encontrar em CSS ou numa tag <code>&lt;img&gt;</code>; os
+        navegadores modernos não impõem teto prático ali. O que os navegadores
+        limitam é digitar uma data URI na barra de endereços, o que a maioria deles
+        hoje recusa para qualquer coisa não trivial, por motivos de segurança que
+        nada têm a ver com este uso. O limite real é o de cima: muito antes de algo
+        técnico quebrar, a página em que ela está já ficou mais lenta do que ficaria
+        com um arquivo de imagem comum."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. Também não há limite para o número ou o tamanho dos arquivos,
+        porque não há servidor pagando por eles &mdash; o trabalho acontece na sua
+        própria máquina. O site exibe publicidade, e é ela que paga a conta; os
+        anúncios não recebem nada sobre as suas imagens."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse as suas imagens embora para serem
+        codificadas pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Converta um PNG, JPEG, SVG, WebP, GIF ou ICO numa data URI pronta para colar no CSS ou no HTML. Base64 para formatos de pixel e codificação em porcentagem para SVG, embrulhados numa regra de CSS, numa propriedade personalizada, numa tag img ou em Markdown, com o custo em tamanho e qualquer metadado embutido informados. Roda inteiramente no navegador, sem envio."
+features = [
+  "Data URIs em base64 para PNG, JPEG, WebP, GIF, ICO, AVIF e mais",
+  "Data URIs de SVG codificadas em porcentagem, que são mais curtas que base64 e continuam legíveis",
+  "Regra de CSS, propriedade personalizada de CSS, tag img de HTML ou Markdown já prontas, sempre com aspas corretas",
+  "O tipo de mídia lido dos próprios bytes do arquivo, e não da extensão",
+  "Diz o que a codificação custou em caracteres, e se embutir naquele tamanho compensa",
+  "Avisa quando EXIF, XMP ou um perfil de cor está prestes a ser copiado para a sua folha de estilo",
+  "Copia o arquivo byte por byte: sem recodificação e sem perda de qualidade",
+  "Trabalha em lote, com tudo copiado ou baixado como um arquivo só",
+  "Roda offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste imagens para cá"
+hint = "ou clique para escolher &mdash; PNG, JPEG, SVG, WebP, GIF, ICO e mais"

--- a/locales/pt/tools/image-to-ico.html
+++ b/locales/pt/tools/image-to-ico.html
@@ -1,0 +1,187 @@
+<main>
+  <!-- Passo 1 &mdash; a imagem -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha uma imagem</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tirar tudo da lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="shape-note" class="field-summary" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; qual padrão -->
+  <section class="card" id="preset-card">
+    <h2><span class="step">2</span> Diga para que serve o ícone</h2>
+
+    <p class="card-lede">
+      Um arquivo de ícone não é uma imagem, são várias: a mesma logomarca
+      desenhada de novo em cada tamanho que a coisa que vai lê-la pede. Quais
+      tamanhos são esses não é questão de gosto &mdash; um navegador quer três
+      deles, um aplicativo num notebook de alta densidade quer dez, um Mac quer
+      os dez dele, e algo escrito antes do Windows Vista quer os tamanhos
+      guardados de um jeito completamente diferente.
+    </p>
+
+    <!--
+      Which files to write. Windows and macOS read different containers and
+      neither will look at the other's, so this is a set of checkboxes rather
+      than a menu: wanting both is the normal case for anything shipped on both.
+    -->
+    <fieldset class="options outputs">
+      <legend>O que fazer</legend>
+
+      <label class="check">
+        <input type="checkbox" id="want-ico" checked>
+        <span>
+          <strong>Ícone do Windows &mdash; <code>.ico</code></strong>
+          <span class="check-note">
+            Lido por todo navegador como favicon, e pelo Windows para um
+            aplicativo, um atalho e uma pasta. Os tamanhos são escolha sua, aí
+            embaixo.
+          </span>
+        </span>
+      </label>
+
+      <label class="check">
+        <input type="checkbox" id="want-icns">
+        <span>
+          <strong>Ícone do macOS &mdash; <code>.icns</code></strong>
+          <span class="check-note">
+            O que um pacote de aplicativo de Mac carrega. A Apple nomeia
+            exatamente dez vagas, de 16 pixels a 1024, então não há o que
+            escolher: as dez entram, desenhadas a partir de sete renderizações,
+            porque uma vaga Retina e o tamanho de cima são a mesma imagem.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="pack-row">
+        <input type="checkbox" id="want-pack">
+        <span>
+          <strong>O resto do conjunto de ícones de um site</strong>
+          <span class="check-note">
+            Um .ico cobre a aba do navegador e o Windows. Ele não cobre uma tela
+            inicial de iPhone, um aviso de instalação do Android, nem um ladrilho
+            fixado no menu Iniciar &mdash; esses leem um PNG de 180px, um
+            manifesto de aplicativo web e um arquivo XML, e nenhum deles vai olhar
+            dentro de um .ico. Marque esta caixa e você leva todos eles também, o
+            manifesto, e o bloco de HTML para colar na sua página.
+          </span>
+        </span>
+      </label>
+
+      <p id="output-summary" class="field-summary"></p>
+    </fieldset>
+
+    <div id="ico-settings">
+      <div class="presets" id="preset-list" role="radiogroup" aria-label="Para que serve o ícone"></div>
+
+      <p id="preset-note" class="field-summary"></p>
+
+      <fieldset class="options" id="size-set">
+        <legend>Os tamanhos que entram no .ico</legend>
+        <div class="size-grid" id="size-grid"></div>
+        <p id="size-summary" class="field-summary"></p>
+      </fieldset>
+    </div>
+
+    <fieldset class="options">
+      <legend>Como ele é desenhado</legend>
+
+      <div class="option-row">
+        <label for="fit-select">Se a imagem não for quadrada</label>
+        <select id="fit-select">
+          <option value="pad" selected>Completar até virar um quadrado &mdash; a imagem inteira é mantida</option>
+          <option value="crop">Cortar no quadrado do meio</option>
+          <option value="stretch">Esticar até virar um quadrado</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="background-mode">Fundo</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparente</option>
+          <option value="colour">Uma cor</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Cor de fundo" hidden>
+      </div>
+
+      <div class="option-row" id="storage-row">
+        <label for="storage-select">Como cada tamanho é guardado no .ico</label>
+        <select id="storage-select">
+          <option value="auto" selected>Automático &mdash; compatível quando é barato, PNG quando não é</option>
+          <option value="png">PNG em todos os tamanhos &mdash; menor arquivo, precisa do Vista ou mais novo</option>
+          <option value="bmp">Sem compressão em todos os tamanhos &mdash; abre em qualquer coisa, várias vezes maior</option>
+        </select>
+      </div>
+
+      <p id="storage-note" class="field-summary"></p>
+    </fieldset>
+
+  </section>
+
+  <!-- Passo 3 &mdash; veja pequeno, e então leve -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Confira no tamanho em que ele vai ser visto</h2>
+
+    <p class="card-lede">
+      Esta é a parte que vale olhar antes de baixar qualquer coisa. Uma
+      logomarca que se lê perfeitamente a 512 pixels tem dezesseis pixels de
+      largura numa aba de navegador, e as partes finas dela &mdash; os traços de
+      uma logomarca escrita, uma borda de fio de cabelo, um gradiente &mdash; não
+      sobrevivem a isso. Cada quadrado abaixo é desenhado no tamanho real a partir
+      do arquivo que você escolheu.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-strip" id="preview-strip"></div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make-icon" class="primary big" disabled>Criar o ícone</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Pronto</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Baixar tudo num zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+
+      <!--
+        The block to paste into a page's <head>, shown rather than only zipped:
+        most people making a favicon are about to paste this into a template,
+        and a copy button is a shorter route than a download and a text editor.
+      -->
+      <div id="snippet" class="snippet" hidden>
+        <div class="snippet-head">
+          <h4>Cole isto no seu <code>&lt;head&gt;</code></h4>
+          <button type="button" id="copy-snippet" class="ghost">Copiar</button>
+        </div>
+        <pre id="snippet-text"></pre>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/image-to-ico.toml
+++ b/locales/pt/tools/image-to-ico.toml
@@ -1,0 +1,354 @@
+#
+# Imagem para ICO - português do Brasil.
+#
+# Overrides for tools/image-to-ico/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# O slug é "criar-favicon" e não "imagem-para-ico": ninguém procura pelo
+# formato, procura-se pelo trabalho. O nome da ferramenta continua nomeando o
+# formato, porque é o que o arquivo que sai é.
+#
+
+name = "Imagem para ICO"
+heading = "Imagem&nbsp;para&nbsp;ICO <span class=\"h1-kw\">&mdash; criador de favicon e de ícone do Windows e do macOS</span>"
+tagline = "Uma imagem entra. Sai todo tamanho que um navegador, o Windows ou um Mac pede."
+
+title = "Imagem para ICO &mdash; crie um favicon, ícone de app ou ICNS, sem envio"
+description = "Converta um PNG, JPEG ou SVG num .ico de verdade, com vários tamanhos, ou num .icns do macOS, no seu navegador. Favicon, ícone de aplicativo do Windows, ícone de app do Mac, mais os arquivos da Apple e do Android que um site precisa. Nada é enviado."
+og_title = "Crie um .ico ou um .icns com todos os tamanhos dentro, sem enviar nada"
+og_description = "Um favicon.ico para um site, um app.ico para um programa do Windows, um .icns para um Mac - com uma pré-visualização a 16 pixels antes de você baixar. Tudo roda na sua própria máquina."
+og_image_alt = "Imagem para ICO - criador de favicon e de ícone do Windows e do macOS, sem envio"
+
+pledge = """
+    A escala e os próprios arquivos de ícone são feitos no seu próprio
+    navegador. A imagem é desenhada pelo canvas que o seu navegador já traz, e
+    cada contêiner &mdash; o <code>.ico</code> do Windows, o <code>.icns</code>
+    do macOS &mdash; é montado a partir daqueles pixels por umas duas centenas de
+    linhas em <code>src/ico.js</code> e <code>src/icns.js</code> que você pode
+    ler. Esta ferramenta não tem função de rede de espécie alguma &mdash; nada a
+    buscar, nada a enviar &mdash; e não existe do outro lado desta página
+    servidor nenhum para onde mandar uma logomarca, mesmo que houvesse
+    caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e crie um ícone. Nenhuma requisição leva uma imagem, uma
+      miniatura, um nome de arquivo ou um byte do que você escolheu. Ou desconecte
+      da internet e crie um mesmo assim."""
+
+read_first = """
+, <code>src/ico.js</code> e
+      <code>src/icns.js</code> para os dois formatos de ícone &mdash; o
+      diretório, as entradas e a máscara num, as dez vagas nomeadas pela Apple no
+      outro &mdash; e <code>src/sizes.js</code> para de onde vem cada tamanho da
+      página."""
+
+howto_heading = "Como criar um arquivo .ico sem enviar nada"
+
+card = """
+            Um favicon, um ícone de aplicativo do Windows ou um .icns do macOS
+            &mdash; todos os tamanhos num arquivo só, com uma pré-visualização a
+            16 pixels antes de você baixar."""
+
+[words]
+plural = "imagens"
+choose = "uma imagem"
+analytics_extra = """, nem nenhum dos
+  tamanhos, formatos ou nomes de arquivo que esta ferramenta calcula"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca d'água"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "Sua logomarca não tem para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      seus arquivos pudessem ser coletados, e não existe no código nada que os
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Não existe
+      <code>fetch</code>, nem <code>XMLHttpRequest</code>, nem
+      <code>sendBeacon</code> em lugar nenhum de <code>src/</code>. A escala é um
+      <code>drawImage</code> num canvas; cada ícone é um cabeçalho escrito na
+      frente daqueles pixels pelo <code>src/ico.js</code> ou pelo
+      <code>src/icns.js</code>, nesta página."""
+
+[[privacy]]
+title = "O arquivo é descrito a partir dos próprios bytes dele."
+body = """
+ A lista de tamanhos mostrada
+      ao lado de um ícone pronto não é a lista de tamanhos que você pediu. Ela é
+      lida de volta do arquivo que acabou de ser escrito, pelo
+      <code>readIcoDirectory</code> ou pelo <code>readIcnsElements</code>, então,
+      se um escritor algum dia discordasse dos ajustes, a página diria isso em vez
+      de você descobrir quando o Windows não desenhasse nada e o macOS desenhasse
+      uma folha de papel em branco."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google, e o botão de doação vem do Buy Me a
+      Coffee. Nenhum deles recebe coisa alguma sobre a sua imagem. Toda linha que
+      lê, escala ou escreve um arquivo é servida desta origem e está listada no
+      repositório."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua
+      igual, porque nunca houve uma etapa de rede nela. Essa é a prova mais
+      simples de todas."""
+
+[[howto]]
+title = "Escolha a imagem."
+body = """
+ Arraste um PNG, JPEG, WebP ou SVG até o
+      seletor, ou escolha várias e converta todas de uma vez. Quadrada é o mais
+      fácil, e qualquer coisa a partir de 256 pixels tem detalhe suficiente para
+      todos os tamanhos. Ela é lida direto do seu disco pelo navegador; nada é
+      mandado para lugar nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Escolha os arquivos de que você precisa."
+body = """
+ O Windows e um navegador leem
+      <code>.ico</code>; um Mac lê <code>.icns</code> e nem olha para o outro.
+      Marque um, ou os dois, se a coisa que você está fazendo sai nas duas
+      plataformas. Um site quer também as imagens extras da Apple, do Android e do
+      ladrilho, e essa é a terceira caixinha."""
+
+[[howto]]
+title = "Diga para que serve o ícone."
+body = """
+ Um favicon de site tem 16, 32 e 48
+      pixels; um aplicativo do Windows quer 256 também; um aplicativo que precisa
+      ficar bom num notebook de alta densidade quer os tamanhos intermediários que
+      o Windows pede a 125% e 150% de escala. Escolha o que corresponde ao
+      trabalho, ou marque os tamanhos você mesmo. Cada tamanho da lista diz quem
+      pede por ele. O <code>.icns</code> não tem essa escolha: a Apple nomeia
+      exatamente dez vagas e as dez entram."""
+
+[[howto]]
+title = "Resolva o formato e o fundo."
+body = """
+ Um ícone é quadrado e a maioria das
+      logomarcas não é. Completar com margem mantém a imagem inteira com espaço
+      acima e abaixo; cortar pega o meio; esticar achata. A transparência é
+      mantida como transparência, a menos que você escolha uma cor para ficar
+      atrás dela."""
+
+[[howto]]
+title = "Olhe o de 16 pixels antes de baixar."
+body = """
+ É nesse tamanho que o ícone vai
+      ser visto na maior parte das vezes, e é ali que traços finos e letras
+      pequenas somem. Cada quadrado da pré-visualização é desenhado no tamanho
+      real a partir do seu próprio arquivo. Se o menor deles for um borrão, o
+      conserto é um desenho mais simples, e não outro ajuste."""
+
+[[howto]]
+title = "Leve os arquivos."
+body = """
+ Um .ico com todos os tamanhos dentro,
+      chamado <code>favicon.ico</code> quando foi isso que você pediu, porque é
+      esse o endereço que os navegadores procuram. Um .icns ao lado, se você
+      marcou aquilo, pronto para entrar num pacote de aplicativo de Mac. Marque
+      também o conjunto de site e você leva ainda as imagens da Apple, do Android
+      e do ladrilho do Windows, o manifesto, e o bloco de HTML para colar na sua
+      página. Qualquer coisa além de um arquivo só desce como um zip."""
+
+[[faq]]
+q = "Minha imagem é enviada para algum lugar?"
+a = """
+        Não. A imagem é decodificada e escalada pelo seu próprio navegador no seu
+        próprio hardware, e o .ico é montado a partir daqueles pixels por código
+        servido por esta página. Esta ferramenta não tem função de rede de espécie
+        alguma &mdash; nunca busca nada e nunca manda nada &mdash; e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar, nenhum dos quais é deste site."""
+
+[[faq]]
+q = "Quais tamanhos um favicon.ico deve conter?"
+a = """
+        16, 32 e 48. Isso não é preferência: 16 é o que um navegador desenha numa
+        aba, 32 é o que o Windows usa para um atalho de área de trabalho e o que
+        vários navegadores usam para um favorito, e 48 é o tamanho em que o Google
+        lê o ícone de um site. Qualquer coisa maior pertence a um PNG ao lado do
+        .ico em vez de dentro dele &mdash; que é o que o conjunto de site daqui
+        produz."""
+
+[[faq]]
+q = "De quais tamanhos precisa um ícone de aplicativo do Windows?"
+a = """
+        16, 32, 48 e 256, que é o que o próprio app.ico padrão do Visual Studio
+        guarda. 16 é a barra de título e a visualização pequena do Explorer, 32 é a
+        área de trabalho e a barra de tarefas, 48 são os ícones médios do Explorer,
+        e 256 é o menu Iniciar e a visualização extragrande. Numa tela de alta
+        densidade o Windows também pede 20, 24, 40, 64 e 96, e os reamostra a partir
+        do tamanho mais próximo que tiver se não estiverem lá &mdash; a predefinição
+        de &ldquo;todas as escalas&rdquo; coloca esses."""
+
+[[faq]]
+q = "Por que o arquivo ficou maior que a imagem de onde eu parti?"
+a = """
+        Porque um .ico não é uma imagem, são várias, e as pequenas são guardadas sem
+        compressão para que qualquer coisa consiga lê-las. Uma entrada de 32x32 tem
+        exatamente 4.264 bytes, seja lá o que houver nela, e uma entrada de 256x256
+        sem compressão tem 264 KB &mdash; e é por isso que tamanhos acima de 64 são
+        guardados como PNG por padrão. Escolher &ldquo;PNG em todos os
+        tamanhos&rdquo; gera o menor arquivo possível; escolher sem compressão em
+        todos os tamanhos gera o mais compatível."""
+
+[[faq]]
+q = "Qual a diferença entre as entradas em PNG e as sem compressão?"
+a = """
+        Só como os pixels são guardados dentro do .ico. Uma entrada sem compressão é
+        o arranjo original do Windows &mdash; um cabeçalho de bitmap, os pixels de
+        cabeça para baixo, e uma máscara de transparência de um bit &mdash; e toda
+        versão do Windows já lançada consegue ler. Uma entrada em PNG é um arquivo
+        PNG inteiro enfiado dentro do ícone, o que é de três a dez vezes menor nos
+        tamanhos grandes, mas só passou a ser entendido a partir do Windows Vista. O
+        padrão usa cada um onde ele ganha: sem compressão até 64 pixels, PNG
+        acima."""
+
+[[faq]]
+q = "Ele consegue fazer um ícone maior que 256 pixels?"
+a = """
+        Não, e nada consegue. O formato guarda cada lado num único byte, e o 0 já
+        está tomado &mdash; ele significa 256. Esse é o teto, então um .ico contendo
+        uma imagem de 512 pixels não é um ícone maior, é um ícone quebrado. Se você
+        precisa de 512, precisa de um PNG, que é o que o conjunto de site inclui
+        para o Android e para a tela de abertura de um aplicativo web."""
+
+[[faq]]
+q = "Ele mantém a transparência?"
+a = """
+        Sim, nos dois tipos de entrada, e também escreve a antiga máscara de um bit
+        ao lado do canal alfa, para que software velho demais para ler o alfa ainda
+        recorte o ícone em vez de desenhar uma caixa preta. O único arquivo que é
+        deliberadamente deixado opaco é o ícone de toque da Apple no conjunto de
+        site: o iOS o compõe sobre o próprio ladrilho e transforma transparência em
+        preto, então ele é achatado sobre a sua cor de fundo, branca por padrão."""
+
+[[faq]]
+q = "Minha logomarca é escrita e larga. O que acontece com ela?"
+a = """
+        Alguma coisa tem que acontecer, porque um ícone é quadrado. Completar com
+        margem mantém tudo e deixa pequeno &mdash; uma logomarca escrita completada
+        dentro de um quadrado de 16 pixels fica com uns três pixels de altura e
+        ilegível. Cortar pelo meio costuma funcionar melhor: tire o símbolo da
+        composição e use aquilo, como quase toda marca faz no favicon dela. A
+        pré-visualização mostra qual dos dois sobrevive antes de você baixar
+        qualquer coisa."""
+
+[[faq]]
+q = "O que tem no conjunto de site, e eu preciso de tudo aquilo?"
+a = """
+        Sete PNGs, um manifesto de aplicativo web, um browserconfig.xml e um bloco
+        de HTML para colar. Você precisa deles porque um .ico cobre navegadores e
+        Windows e nada mais: uma tela inicial de iPhone lê um PNG de 180 pixels com
+        um nome próprio, o Android e todo aviso de instalação leem o manifesto, e um
+        ladrilho fixado no menu Iniciar lê o XML. Nenhum deles vai olhar dentro de
+        um .ico. Tudo é gerado aqui, na sua máquina, e o zip vem com uma nota
+        dizendo para que serve cada arquivo."""
+
+[[faq]]
+q = "Ele também faz um ícone de macOS?"
+a = """
+        Faz &mdash; marque <em>ícone do macOS</em> e você recebe um
+        <code>.icns</code> ao lado do <code>.ico</code>, ou no lugar dele. É outro
+        contêiner para a mesma ideia, e nenhum dos dois sistemas lê o do outro: o
+        Windows quer .ico e um pacote de aplicativo de Mac quer .icns. Ali os
+        tamanhos não são escolha, porque a Apple publica exatamente dez vagas
+        &mdash; 16, 32, 64, 128, 256, 512 e 1024 pixels, com três delas aparecendo
+        duas vezes como a versão Retina do tamanho de baixo. As dez entram,
+        desenhadas a partir de sete renderizações, e é por isso que um .icns é o
+        arquivo maior."""
+
+[[faq]]
+q = "Como eu uso o arquivo .icns?"
+a = """
+        Para um aplicativo, ele vai no pacote em
+        <code>SeuApp.app/Contents/Resources/</code> e é nomeado no
+        <code>Info.plist</code> sob <code>CFBundleIconFile</code>; toda ferramenta
+        de empacotamento de Mac tem um campo para isso. Para qualquer outra coisa,
+        selecione o arquivo no Finder, aperte Command-C, então Obter Informações na
+        pasta ou imagem de disco que você quer mudar, clique no ícone pequeno no
+        canto superior esquerdo e aperte Command-V."""
+
+[[faq]]
+q = "O .icns é igual ao que o iconutil faz?"
+a = """
+        As mesmas dez vagas com os mesmos tipos de quatro letras, e PNG em cada uma,
+        que é o que o <code>iconutil</code> produz a partir de uma pasta
+        <code>.iconset</code>. Uma diferença deliberada: a ferramenta da Apple
+        também escreve um elemento <code>TOC&nbsp;</code>, um índice dos tipos e
+        tamanhos que vêm depois. É uma otimização e não parte do formato &mdash; um
+        leitor sem ele percorre os elementos de ponta a ponta e chega à mesma
+        resposta &mdash; e um índice errado é pior que índice nenhum, então ele fica
+        de fora."""
+
+[[faq]]
+q = "Posso converter várias imagens de uma vez?"
+a = """
+        Pode. Toda imagem da lista vira o próprio .ico com os mesmos ajustes, e o
+        lote desce como um zip só, com uma pasta por imagem &mdash; senão duas delas
+        se chamariam favicon.ico e uma sobrescreveria a outra. Toda saída que você
+        marcou é feita para toda imagem. Clique em qualquer linha para pôr aquela
+        imagem na pré-visualização."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. Também não há limite para o número ou o tamanho dos arquivos,
+        porque não há servidor pagando por eles &mdash; o trabalho acontece na sua
+        própria máquina. O site exibe publicidade, e é ela que paga a conta; os
+        anúncios não recebem nada sobre as suas imagens."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse a sua logomarca embora para ser
+        convertida pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Converta uma imagem num arquivo ICO do Windows com vários tamanhos ou num arquivo ICNS do macOS, dentro do navegador. Predefinições para favicon de site, ícone de aplicativo do Windows e ícone de aplicativo em alta densidade, as dez vagas de icns da Apple, uma pré-visualização de cada tamanho no tamanho real em pixels, e um conjunto opcional dos arquivos da Apple, do Android e do ladrilho do Windows que um site precisa. Nada é enviado."
+features = [
+  "Escreve um .ico de verdade com vários tamanhos, de 16 a 256 pixels",
+  "Escreve um .icns do macOS com as dez vagas da Apple, de 16 a 1024 pixels",
+  "Os dois formatos a partir de uma imagem, numa passada só, com cada tamanho desenhado uma vez",
+  "Predefinições para favicon de site, ícone de app do Windows, Windows em alta densidade e compatibilidade máxima",
+  "Cada tamanho diz quem pede por ele, então nada entra à toa",
+  "Entradas sem compressão nos tamanhos pequenos e PNG nos grandes, ou tudo de um jeito só",
+  "Mantém a transparência, e escreve também a máscara de transparência anterior ao Vista",
+  "Completa, corta ou estica uma imagem que não é quadrada, sobre uma cor ou sobre nada",
+  "Mostra cada tamanho no tamanho real em pixels antes de você baixar",
+  "Conjunto de site opcional: ícone de toque da Apple, ícones do Android, ícone maskable, ladrilho do Windows, manifesto e o HTML para colar",
+  "Trabalha em lote, com todos os resultados num zip",
+  "Roda offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste uma imagem para cá"
+hint = "ou clique para escolher &mdash; PNG, SVG, JPEG, WebP e tudo o mais que o seu navegador conseguir abrir"

--- a/locales/pt/tools/images-to-pdf.html
+++ b/locales/pt/tools/images-to-pdf.html
@@ -1,0 +1,230 @@
+<main>
+  <!-- Passo 1 &mdash; as imagens -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha as imagens</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" data-sort="name" class="ghost">Ordenar por nome</button>
+        <button type="button" data-sort="date" class="ghost">Ordenar por data</button>
+        <button type="button" data-sort="reverse" class="ghost">Inverter</button>
+        <button type="button" id="clear-all" class="ghost danger">Remover todas</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Uma imagem por página, nesta ordem. Arraste pela alça
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> para mover uma página,
+      ou use as setas nela.
+    </p>
+
+    <ul id="image-list" class="image-list"></ul>
+  </section>
+
+  <!-- Passo 2 &mdash; as páginas -->
+  <section class="card">
+    <h2><span class="step">2</span> Configuração da página</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Tamanho da página</label>
+        <select id="page-size">
+          <option value="fit" selected>Ajustar a página a cada imagem</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Carta &mdash; 8,5 &times; 11 pol</option>
+          <option value="legal">Ofício &mdash; 8,5 &times; 14 pol</option>
+          <option value="a3">A3 &mdash; 297 &times; 420 mm</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+          <option value="tabloid">Tabloide &mdash; 11 &times; 17 pol</option>
+          <option value="custom">Personalizado&hellip;</option>
+        </select>
+        <div id="custom-size" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="1" max="5000" step="1" value="210"
+                 aria-label="Largura de página personalizada">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="1" max="5000" step="1" value="297"
+                 aria-label="Altura de página personalizada">
+          <select id="custom-unit" aria-label="Unidade do tamanho de página personalizado">
+            <option value="mm" selected>mm</option>
+            <option value="in">pol</option>
+          </select>
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Resolução de impressão</label>
+        <select id="dpi">
+          <option value="72">72 DPI &mdash; tela</option>
+          <option value="96">96 DPI</option>
+          <option value="150" selected>150 DPI</option>
+          <option value="200">200 DPI</option>
+          <option value="300">300 DPI &mdash; impressão</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Decide de que tamanho fica uma página para um dado número de pixels. Não
+          muda a imagem.
+        </p>
+      </div>
+
+      <div class="field" id="orientation-field" hidden>
+        <label for="orientation">Orientação</label>
+        <select id="orientation">
+          <option value="auto" selected>Acompanhar cada imagem</option>
+          <option value="portrait">Em pé</option>
+          <option value="landscape">Deitada</option>
+        </select>
+      </div>
+
+      <div class="field" id="fit-field" hidden>
+        <label for="fit">Como a imagem se assenta na página</label>
+        <select id="fit">
+          <option value="contain" selected>Caber dentro das margens</option>
+          <option value="cover">Preencher a página (corta as bordas)</option>
+          <option value="stretch">Esticar até as margens (deforma)</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="margin">Margem</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="100" step="1" value="0"
+                 aria-label="Margem em milímetros">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="background">Cor da página</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Aparece nas margens, e atrás de qualquer coisa transparente.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="mode">Qualidade da imagem</label>
+        <select id="mode">
+          <option value="keep" selected>Manter os JPEGs exatamente como estão</option>
+          <option value="jpeg">Recodificar tudo como JPEG</option>
+          <option value="lossless">Sem perdas &mdash; nenhuma perda de compressão</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualidade do JPEG</label>
+        <select id="quality">
+          <option value="0.75">Arquivo menor</option>
+          <option value="0.88" selected>Equilibrado</option>
+          <option value="0.95">Melhor qualidade</option>
+        </select>
+        <p class="field-note">Usada só nas imagens que esta ferramenta precisa recodificar.</p>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Encolher imagens grandes</label>
+        <select id="max-side">
+          <option value="0" selected>Nunca &mdash; manter o tamanho cheio</option>
+          <option value="4000">Lado maior 4000 px</option>
+          <option value="2000">Lado maior 2000 px</option>
+          <option value="1200">Lado maior 1200 px</option>
+        </select>
+        <p class="field-note" id="shrink-note"></p>
+      </div>
+    </div>
+
+    <details class="meta-panel">
+      <summary>Detalhes do documento &mdash; todos opcionais, todos em branco por padrão</summary>
+      <div class="meta-body">
+        <p class="meta-note">
+          Um PDF carrega um pequeno bloco de informações sobre si mesmo, e a
+          maioria das ferramentas o preenche com um horário e um nome de programa,
+          você tendo pedido ou não. Esta escreve o que você digitar aqui e nada
+          mais: nenhum nome de arquivo, nenhum nome de máquina, e nenhuma data a
+          não ser que você marque a caixa.
+        </p>
+        <div class="settings">
+          <div class="field">
+            <label for="doc-title">Título</label>
+            <input type="text" id="doc-title" maxlength="200" spellcheck="false"
+                   placeholder="Deixado de fora se em branco">
+          </div>
+          <div class="field">
+            <label for="doc-author">Autor</label>
+            <input type="text" id="doc-author" maxlength="200" spellcheck="false"
+                   placeholder="Deixado de fora se em branco">
+          </div>
+          <div class="field">
+            <label for="file-name">Nome do arquivo</label>
+            <div class="inline-pair">
+              <input type="text" id="file-name" maxlength="120" spellcheck="false"
+                     value="imagens">
+              <span class="unit-label">.pdf</span>
+            </div>
+          </div>
+          <div class="field checkbox-field">
+            <label for="dated">
+              <input type="checkbox" id="dated">
+              Registrar a data de hoje no documento
+            </label>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="480" height="640" aria-label="Pré-visualização de uma página"></canvas>
+        <p id="preview-empty" class="preview-empty">Adicione imagens para ver as páginas</p>
+        <div id="preview-nav" class="preview-nav" hidden>
+          <button type="button" id="preview-prev" class="ghost" aria-label="Página anterior">&lsaquo;</button>
+          <span id="preview-label" class="preview-label"></span>
+          <button type="button" id="preview-next" class="ghost" aria-label="Próxima página">&rsaquo;</button>
+        </div>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Páginas</dt><dd id="sum-pages">&mdash;</dd></div>
+        <div><dt>Tamanho da página</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Imagens escolhidas</dt><dd id="sum-input">&mdash;</dd></div>
+        <div><dt>Copiadas intocadas</dt><dd id="sum-copied">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; exportar -->
+  <section class="card">
+    <h2><span class="step">3</span> Crie o PDF</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Criar PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Baixar PDF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/images-to-pdf.toml
+++ b/locales/pt/tools/images-to-pdf.toml
@@ -1,0 +1,225 @@
+#
+# Imagens para PDF - português do Brasil.
+#
+# Overrides for tools/images-to-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Imagens para PDF"
+heading = "Imagens&nbsp;para&nbsp;PDF <span class=\"h1-kw\">&mdash; conversor de JPG para PDF</span>"
+tagline = "Coloque suas imagens num documento só."
+
+title = "Conversor de imagens para PDF &mdash; JPG para PDF grátis, sem envio"
+description = "Junte imagens JPG, PNG ou WebP num só PDF, de graça e inteiramente no seu navegador. As fotos entram sem serem recodificadas, e nada é enviado."
+og_title = "Imagens para PDF &mdash; conversor grátis de JPG para PDF"
+og_description = "Junte imagens num só PDF na sua própria máquina. Fotos JPEG são copiadas intocadas, então nada perde qualidade e nada é enviado."
+og_image_alt = "Imagens para PDF - junte imagens num documento sem enviá-las"
+
+pledge = """
+    O documento é escrito na memória desta máquina, uma página por vez, por
+    código servido deste endereço. Nada aqui consegue fazer um envio, e não existe
+    do outro lado desta página servidor nenhum para receber um."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e faça um PDF. Nenhuma requisição leva uma imagem, uma miniatura ou
+      um nome de arquivo. Ou desconecte da internet e faça um mesmo assim."""
+
+read_first = """
+, e <code>src/pdf.js</code> e <code>src/document.js</code>
+      para a escrita inteira do arquivo, que nunca encosta na rede."""
+
+howto_heading = "Como transformar imagens em um PDF"
+
+card = """
+            Junte imagens num só PDF, uma imagem por página. Fotos JPEG são
+            copiadas exatamente como estão, então nada perde qualidade."""
+
+[words]
+plural = "imagens"
+choose = "imagens"
+analytics_extra = """"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[facts]]
+text = "Os arquivos ficam no seu aparelho"
+
+[[privacy]]
+title = "Suas imagens não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Esta ferramenta não acrescenta nada
+      àquela lista: ela não tem função de rede própria, nem sequer uma opcional.
+      Não existe aqui um ponto final onde seus arquivos pudessem ser coletados, e
+      não existe no código nada que os mandaria se existisse."""
+
+[[privacy]]
+title = "O PDF é escrito aqui."
+body = """
+ Um PDF é uma lista de objetos e uma tabela de
+      onde cada um começa, e o <code>src/pdf.js</code> escreve as duas coisas.
+      Nenhuma biblioteca é buscada, nada é renderizado num servidor, e o arquivo
+      pronto é entregue direto a um download a partir da memória."""
+
+[[privacy]]
+title = "Não é dito ao documento nada sobre você."
+body = """
+ A maioria das ferramentas
+      carimba num PDF um horário e o nome do programa que o fez. Esta escreve um
+      título, um autor e uma data só se você digitar; os nomes de arquivo das suas
+      imagens nunca aparecem no documento, e nada sobre a sua máquina
+      aparece."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google. Nenhum dos dois recebe coisa alguma
+      sobre as suas imagens: nem um arquivo, nem uma miniatura, nem um nome, um
+      tamanho ou uma contagem. Toda linha que lê, decodifica ou escreve uma imagem
+      é servida desta origem e está listada no repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não é entregue a ele."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; do cabeçalho é desenhado por um
+      script vindo de cdnjs.buymeacoffee.com e busca as letras dele no Google
+      Fonts. É um link e nada mais: ele não reporta visita nenhuma, e não recebe
+      nada sobre você nem sobre as suas imagens. Nada acontece a menos que você
+      clique, e aquilo para onde você iria clicando é o site de outra gente."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e tudo nesta página continua
+      funcionando. Essa é a prova mais simples de todas: uma ferramenta que
+      mandasse as suas imagens embora para virarem um documento pararia."""
+
+[[howto]]
+title = "Escolha suas imagens."
+body = """
+ Arraste uma pasta até o seletor, ou escolha
+      os arquivos na mão. Eles são lidos direto do seu disco pelo navegador; nada
+      é mandado para lugar nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Ponha as páginas em ordem e gire as que precisarem."
+body = """
+ Uma
+      imagem vira uma página, na ordem mostrada. Arraste um quadradinho pela alça
+      para movê-lo, ou use as setas; os botões de girar viram uma página um quarto
+      de volta por vez, que é o que um escaneamento deitado normalmente pede."""
+
+[[howto]]
+title = "Escolha um tamanho de página."
+body = """
+ &ldquo;Ajustar a página a cada
+      imagem&rdquo; faz cada página ser exatamente a imagem dela, sem nada cortado
+      e sem faixas brancas. Os tamanhos nomeados &mdash; A4, Carta, Ofício e os
+      demais &mdash; colocam cada imagem numa página fixa, com margem se você
+      quiser uma."""
+
+[[howto]]
+title = "Crie o PDF e baixe."
+body = """
+ O documento é escrito na sua própria máquina,
+      então o tempo que leva depende do seu hardware e não de uma fila. O arquivo
+      pronto é entregue direto aos downloads do seu navegador."""
+
+[[faq]]
+q = "Minhas imagens são enviadas para algum lugar?"
+a = """
+        Não. Suas imagens são lidas e o PDF é escrito pelo seu próprio navegador no
+        seu próprio hardware. Não existe lado de servidor nesta ferramenta, e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar &mdash; nenhum deles é deste site. Ao contrário de algumas
+        das outras ferramentas daqui, esta não tem função de rede opcional
+        nenhuma."""
+
+[[faq]]
+q = "Converter para PDF perde qualidade?"
+a = """
+        Não, no caso de um JPEG e no ajuste padrão. O PDF consegue carregar dados
+        JPEG diretamente, então uma fotografia é copiada para dentro do documento
+        byte por byte: ela nunca é decodificada e nunca é comprimida de novo, e a
+        imagem no PDF é a imagem do arquivo. Outros formatos precisam ser
+        recodificados, porque o PDF não tem filtro para eles &mdash; a não ser que
+        você escolha o ajuste sem perdas, que os guarda exatamente ao custo de um
+        arquivo maior."""
+
+[[faq]]
+q = "Quais formatos de imagem posso usar?"
+a = """
+        Qualquer imagem parada que o seu navegador consiga decodificar, o que na
+        prática significa JPG, PNG, WebP, GIF, AVIF e, em aparelhos da Apple, HEIC.
+        Não existe aqui uma lista separada para manter atualizada, porque
+        decodificar é trabalho do navegador, e não nosso."""
+
+[[faq]]
+q = "Posso escolher o tamanho da página e a ordem das páginas?"
+a = """
+        Sim. As páginas podem ser A4, Carta, Ofício, A3, A5, Tabloide, um tamanho
+        que você digita, ou exatamente o tamanho de cada imagem. Arraste os
+        quadradinhos para reordenar, ordene por nome ou por data, gire qualquer um
+        deles um quarto de volta, e defina uma margem em milímetros."""
+
+[[faq]]
+q = "Quantas imagens posso pôr num PDF?"
+a = """
+        Não há limite embutido na ferramenta. O teto prático é a memória da sua
+        própria máquina, porque o documento pronto é montado ali antes de você
+        baixá-lo. Algumas centenas de fotos de celular em resolução cheia são a
+        primeira coisa a sentir isso; diminuir o lado maior, nos ajustes, empurra
+        esse teto para bem longe."""
+
+[[faq]]
+q = "O PDF contém os nomes dos meus arquivos ou um horário?"
+a = """
+        Não, a menos que você peça. O bloco de informações do documento é deixado
+        vazio, exceto pelo nome desta ferramenta: nenhum nome de arquivo, nenhum
+        nome de máquina, nenhum nome de usuário, e nenhuma data de criação a não ser
+        que você marque a caixa. Isso é deliberado &mdash; um PDF é uma coisa que as
+        pessoas mandam para outras pessoas."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste. O site exibe
+        publicidade, e é ela que paga a conta; os anúncios não recebem nada sobre as
+        suas imagens."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse as suas imagens embora para
+        virarem um documento pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Junte imagens JPG, PNG e WebP num único documento PDF. Cada página é escrita no seu navegador, então imagem nenhuma é enviada."
+features = [
+  "Junta imagens JPG, PNG, WebP, GIF e AVIF num só PDF",
+  "Fotos JPEG são embutidas sem serem recodificadas",
+  "Tamanhos de página de A5 a Tabloide, ou uma página ajustada a cada imagem",
+  "Reordene, gire, defina margens e uma cor de página",
+  "Armazenamento sem perdas opcional para escaneamentos e capturas de tela",
+  "Roda offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste imagens para cá"
+hint = "ou clique para escolher &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/pt/tools/images-to-video.html
+++ b/locales/pt/tools/images-to-video.html
@@ -1,0 +1,166 @@
+<main>
+  <!-- Passo 1 &mdash; as imagens -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha as imagens</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    {% include "partials/url-import.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Mudar como a lista é mostrada">
+          <button type="button" data-view="large" class="active">Grande</button>
+          <button type="button" data-view="small">Pequena</button>
+          <button type="button" data-view="list">Lista</button>
+          <button type="button" data-view="details">Detalhes</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Ordenar por nome</button>
+        <button type="button" data-sort="date" class="ghost">Ordenar por data</button>
+        <button type="button" data-sort="reverse" class="ghost">Inverter</button>
+        <button type="button" id="clear-all" class="ghost danger">Remover todas</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Arraste qualquer imagem pela alça <span class="grip" aria-hidden="true">&#8942;&#8942;</span> para
+      reordenar, ou use as setas de cada uma.
+    </p>
+
+    <ul id="image-list" class="image-list view-large"></ul>
+
+    <div id="bulk-duration" class="bulk" hidden>
+      <label for="bulk-amount">Manter cada imagem por</label>
+      <input type="number" id="bulk-amount" min="1" max="3600" step="1" value="1">
+      <select id="duration-unit" aria-label="Unidade do tempo que cada imagem fica na tela">
+        <option value="frames" selected>quadros</option>
+        <option value="seconds">segundos</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Aplicar a todas</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Passo 2 &mdash; os ajustes -->
+  <section class="card">
+    <h2><span class="step">2</span> Ajustes do vídeo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="resolution">Resolução</label>
+        <select id="resolution">
+          <option value="auto" selected>Acompanhar a maior resolução</option>
+          <option value="3840x2160">3840 &times; 2160 &mdash; 4K</option>
+          <option value="1920x1080">1920 &times; 1080 &mdash; 1080p</option>
+          <option value="1280x720">1280 &times; 720 &mdash; 720p</option>
+          <option value="1080x1080">1080 &times; 1080 &mdash; quadrado</option>
+          <option value="1080x1920">1080 &times; 1920 &mdash; vertical</option>
+          <option value="custom">Personalizada&hellip;</option>
+        </select>
+        <div id="resolution-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="7680" step="2" value="1920"
+                 aria-label="Largura de saída personalizada em pixels">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="7680" step="2" value="1080"
+                 aria-label="Altura de saída personalizada em pixels">
+        </div>
+        <p class="field-note" id="resolution-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Taxa de quadros</label>
+        <select id="fps">
+          <option value="12">12 fps</option>
+          <option value="15">15 fps</option>
+          <option value="24">24 fps &mdash; cinema</option>
+          <option value="25">25 fps &mdash; PAL</option>
+          <option value="30" selected>30 fps</option>
+          <option value="50">50 fps</option>
+          <option value="60">60 fps</option>
+          <option value="custom">Personalizada&hellip;</option>
+        </select>
+        <input type="number" id="fps-custom" class="spaced" min="1" max="120" step="1" value="30"
+               aria-label="Taxa de quadros personalizada, em quadros por segundo" hidden>
+        <p class="field-note" id="fps-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Encaixe da imagem</label>
+        <select id="fit">
+          <option value="contain" selected>Caber dentro (com tarjas)</option>
+          <option value="blur">Caber dentro, com fundo desfocado</option>
+          <option value="cover">Preencher o quadro (corta as bordas)</option>
+          <option value="stretch">Esticar até preencher (deforma)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Cor de fundo</label>
+        <input type="color" id="background" value="#000000">
+      </div>
+
+      <div class="field">
+        <label for="quality">Qualidade</label>
+        <select id="quality">
+          <option value="low">Arquivo menor</option>
+          <option value="medium" selected>Equilibrada</option>
+          <option value="high">Melhor qualidade</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="auto" selected>MP4 (recomendado)</option>
+          <option value="webm">WebM (recuo)</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="640" height="360" aria-label="Pré-visualização do primeiro quadro"></canvas>
+        <p id="preview-empty" class="preview-empty">Adicione imagens para ver uma pré-visualização</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Imagens</dt><dd id="sum-images">&mdash;</dd></div>
+        <div><dt>Duração</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Tamanho de saída</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Total de quadros</dt><dd id="sum-frames">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; exportar -->
+  <section class="card">
+    <h2><span class="step">3</span> Crie o vídeo</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Criar vídeo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Baixar o vídeo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/images-to-video.toml
+++ b/locales/pt/tools/images-to-video.toml
@@ -1,0 +1,251 @@
+#
+# Imagens para vídeo - português do Brasil.
+#
+# Overrides for tools/images-to-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# This is the one tool with a [picker.urls] table, so it is also the one whose
+# translation has to supply the noun the importer's warning in [ui.picker] is
+# written around. The Portuguese sentences there were rewritten to use it only
+# after "qual" and "cada", which inflect for neither gender nor number, so the
+# noun can simply be the right word - see the comment above [ui.picker].
+#
+
+name = "Imagens para vídeo"
+heading = "Imagens&nbsp;para&nbsp;vídeo <span class=\"h1-kw\">&mdash; fazer uma apresentação em MP4</span>"
+tagline = "Transforme uma pasta de imagens em um vídeo."
+
+title = "Sequência de imagens para MP4 &mdash; grátis, sem envio, funciona offline"
+description = "Transforme imagens JPG, PNG ou WebP num vídeo MP4 de apresentação, de graça e inteiramente no seu navegador. Nada é enviado, sem cadastro, e funciona offline."
+og_title = "Sequência de imagens para MP4 &mdash; grátis, no seu navegador"
+og_description = "Transforme uma sequência renderizada, um timelapse ou uma pasta de fotos num MP4. A codificação roda na sua própria máquina; nada é enviado."
+og_image_alt = "Imagens para vídeo - transforme uma pasta de imagens numa apresentação em MP4"
+
+pledge = """
+    Cada quadro é codificado pelo seu próprio navegador e o vídeo é montado na
+    memória desta máquina. O codificador nunca encosta na rede, e não existe do
+    outro lado desta página servidor nenhum para onde mandar uma imagem, mesmo se
+    ele encostasse."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e faça um vídeo. Nenhuma requisição leva uma imagem, uma miniatura
+      ou um nome de arquivo. Ou desconecte da internet e faça um mesmo assim."""
+
+read_first = """
+, e <code>src/encoder.js</code> para o laço de
+      codificação, que nunca encosta na rede."""
+
+howto_heading = "Como transformar imagens em um vídeo"
+
+card = """
+            Transforme uma pasta de imagens numa apresentação em MP4. A
+            codificação roda na sua própria máquina, com o seu próprio
+            hardware."""
+
+[words]
+plural = "imagens"
+choose = "imagens"
+analytics_extra = """"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[facts]]
+text = "Os arquivos ficam no seu aparelho"
+
+[[privacy]]
+title = "Suas imagens não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      seus arquivos pudessem ser coletados, e não existe no código nada que os
+      mandaria se existisse. Isto já foi <code>connect-src 'none'</code>, que era
+      absoluto; acrescentar publicidade custou isso, e dizer isso faz parte do
+      acordo."""
+
+[[privacy]]
+title = "A codificação é local."
+body = """
+ O WebCodecs roda no seu navegador e o arquivo
+      pronto é entregue direto a um download. Não existe lado de servidor neste
+      aplicativo."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google. Nenhum dos dois recebe coisa alguma
+      sobre as suas imagens: nem um arquivo, nem uma miniatura, nem um nome, um
+      tamanho ou uma contagem. Toda linha que lê, decodifica, compõe ou codifica
+      uma imagem é servida desta origem e está listada no repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não é entregue a ele."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; do cabeçalho é desenhado por um
+      script vindo de cdnjs.buymeacoffee.com e busca as letras dele no Google
+      Fonts. É um link e nada mais: ele não reporta visita nenhuma, e não recebe
+      nada sobre você nem sobre as suas imagens. Nada acontece a menos que você
+      clique, e aquilo para onde você iria clicando é o site de outra gente."""
+
+[[privacy]]
+title = "Uma exceção deliberada."
+body = """
+ Se você usar &ldquo;Adicionar a partir de um
+      endereço da web&rdquo;, aquele servidor é contatado para buscar a imagem e
+      vai enxergar o seu endereço IP. Só imagens que você cola são buscadas, e só
+      para dentro: o <code>img-src</code> é aberto, o <code>connect-src</code>
+      não. O contador abaixo lista todas as origens externas contatadas."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e tudo, menos o carregamento
+      por endereço da web, continua funcionando. Essa é a prova mais simples de
+      todas."""
+
+[[howto]]
+title = "Escolha suas imagens."
+body = """
+ Arraste uma pasta até o seletor, ou escolha
+      os arquivos na mão. Eles são lidos direto do seu disco pelo navegador; nada
+      é mandado para lugar nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Ponha em ordem e defina quanto tempo cada uma fica."
+body = """
+ Arraste
+      para reordenar. O tempo de permanência pode ser dado em quadros ou em
+      segundos, para todas as imagens de uma vez ou uma imagem por vez."""
+
+[[howto]]
+title = "Escolha uma resolução e uma taxa de quadros."
+body = """
+ &ldquo;Acompanhar a
+      maior resolução&rdquo; segue a sua maior imagem; as predefinições cobrem 4K,
+      1080p, 720p, quadrado e vertical, e há um tamanho personalizado se nenhum
+      deles servir."""
+
+[[howto]]
+title = "Crie o vídeo e baixe."
+body = """
+ A codificação roda no seu próprio
+      hardware, então o tempo que leva depende da sua máquina e não de uma fila. O
+      MP4 pronto é entregue direto aos downloads do seu navegador."""
+
+[[faq]]
+q = "Minhas imagens são enviadas para algum lugar?"
+a = """
+        Não. Suas imagens são lidas, compostas e codificadas pelo seu próprio
+        navegador no seu próprio hardware. Não existe lado de servidor nesta
+        ferramenta, e a <code>Content-Security-Policy</code> da página nomeia todos
+        os endereços que ela pode contatar &mdash; nenhum deles é deste site. A
+        única exceção é a função opcional de &ldquo;adicionar a partir de um
+        endereço da web&rdquo;, que busca uma imagem que você cola, e aquele
+        servidor enxerga o seu endereço IP."""
+
+[[faq]]
+q = "Quais formatos de imagem posso usar?"
+a = """
+        Qualquer formato de imagem parada que o seu navegador consiga decodificar, o
+        que na prática significa JPG, PNG, WebP, GIF, AVIF e, em aparelhos da Apple,
+        HEIC. Não existe aqui uma lista separada para manter atualizada, porque
+        decodificar é trabalho do navegador, e não nosso."""
+
+[[faq]]
+q = "Que formato de vídeo ele produz?"
+a = """
+        MP4 com vídeo H.264, que toca em basicamente qualquer coisa. Num navegador
+        sem WebCodecs a ferramenta recua para gravar WebM &mdash; as mesmas imagens
+        num contêiner que menos editores aceitam."""
+
+[[faq]]
+q = "Posso usar isto para uma sequência renderizada do Blender ou do After Effects?"
+a = """
+        Sim &mdash; uma sequência renderizada numerada é exatamente para isso que
+        isto serve. Acrescente os quadros que o seu renderizador escreveu, deixe o
+        tempo de permanência em um quadro cada, e ajuste a taxa de quadros para
+        bater com a renderização. O &ldquo;Ordenar por nome&rdquo; conta do jeito
+        que você espera, então <code>frame_2</code> cai antes de
+        <code>frame_10</code>, e não depois.
+        <br><br>
+        Uma coisa que vale saber antes de começar: o H.264 não tem canal alfa,
+        então a transparência é achatada sobre a cor de fundo em vez de ser levada
+        adiante. Se você precisa manter o alfa, componha os quadros no seu editor
+        em vez disso."""
+
+[[faq]]
+q = "Posso fazer um timelapse com fotos?"
+a = """
+        Sim, e é o mesmo trabalho de uma sequência renderizada: mantenha cada foto
+        por um único quadro e escolha uma taxa de quadros. A 30 fps, cada trinta
+        fotos viram um segundo de vídeo; a 12 fps, essas mesmas fotos duram dois
+        segundos e meio.
+        <br><br>
+        O &ldquo;Ordenar por data&rdquo; devolve um rolo de câmera à ordem em que
+        foi fotografado, o que importa quando os nomes de arquivo recomeçaram em
+        0001. Fotos de tamanhos diferentes não são problema &mdash; &ldquo;Acompanhar
+        a maior resolução&rdquo; dimensiona o vídeo de modo que nenhuma delas seja
+        reduzida."""
+
+[[faq]]
+q = "Existe limite de quantas imagens, ou de quanto o vídeo pode durar?"
+a = """
+        Não há limite embutido na ferramenta. O teto prático é a memória da sua
+        própria máquina, porque o vídeo pronto é montado ali antes de você
+        baixá-lo. Apresentações muito grandes em 4K são a primeira coisa a sentir
+        isso."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste. O site exibe
+        publicidade, e é ela que paga a conta; os anúncios não recebem nada sobre as
+        suas imagens."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse as suas imagens embora para
+        serem processadas pararia no instante em que você tirasse da tomada."""
+
+[[faq]]
+q = "Posso acrescentar música ou uma trilha sonora?"
+a = """
+        Ainda não. A ferramenta produz só vídeo: o MP4 que ela escreve tem uma única
+        trilha de vídeo e nenhuma trilha de áudio. Acrescente a trilha sonora depois,
+        num editor de vídeo, se precisar de uma."""
+
+[schema]
+browser_requirements = "Requer JavaScript. A saída em MP4 precisa de um navegador com WebCodecs; os demais recuam para WebM."
+description = "Transforme uma pasta de imagens numa apresentação em vídeo MP4. Cada etapa roda no seu navegador, então imagem nenhuma é enviada."
+features = [
+  "Converte imagens JPG, PNG, WebP, GIF e AVIF em vídeo",
+  "Saída em MP4 (H.264), com WebM como recuo",
+  "Resoluções até 3840x2160, taxas de quadros de 12 a 60 fps",
+  "Tempo de permanência por imagem, em quadros ou em segundos",
+  "Roda offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste imagens para cá"
+hint = "ou clique para escolher &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+[picker.urls]
+summary = "Adicionar a partir de um endereço da web"
+button = "Baixar as imagens"
+noun = "imagem"

--- a/locales/pt/tools/qr-barcode.html
+++ b/locales/pt/tools/qr-barcode.html
@@ -1,0 +1,186 @@
+<main>
+  <!-- Passo 1 &mdash; que tipo de código -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha o tipo de código</h2>
+
+    <p class="card-lede">
+      Um QR Code guarda qualquer coisa e é o que a câmera de um celular procura.
+      Um código de barras guarda um número, e qual deles você precisa costuma já
+      estar decidido &mdash; pela loja, pelo depósito ou pela transportadora que
+      está pedindo.
+    </p>
+
+    <div class="option-row">
+      <label for="symbology">Tipo de código</label>
+      <select id="symbology">
+        <optgroup label="Quadrado">
+          <option value="qr" selected>QR Code</option>
+        </optgroup>
+        <optgroup label="Barras">
+          <option value="code128">Code 128</option>
+          <option value="ean13">EAN-13</option>
+          <option value="upca">UPC-A</option>
+          <option value="ean8">EAN-8</option>
+          <option value="itf14">ITF-14</option>
+          <option value="itf">Intercalado 2 de 5</option>
+          <option value="code39">Code 39</option>
+        </optgroup>
+      </select>
+    </div>
+
+    <p class="field-summary" id="symbology-note"></p>
+  </section>
+
+  <!-- Passo 2 &mdash; a cadeia de texto em si -->
+  <section class="card">
+    <h2><span class="step">2</span> Diga o que vai dentro</h2>
+
+    <div class="option-row" id="format-row">
+      <label for="format">O que ele guarda</label>
+      <select id="format"></select>
+    </div>
+
+    <p class="card-lede" id="format-note"></p>
+
+    <div id="fields" class="fields"></div>
+
+    <p id="input-error" class="error" role="alert" hidden></p>
+
+    <!--
+      The finished string, shown rather than hidden. A "Wi-Fi QR code" is an
+      ordinary QR code holding a line of text in a format phones recognise, and
+      when a phone does not act on one, this line is the thing to look at.
+    -->
+    <details class="encoded" id="encoded-panel">
+      <summary>A cadeia de texto exata que este código vai guardar</summary>
+      <pre id="encoded"></pre>
+      <p class="field-summary" id="encoded-note"></p>
+    </details>
+  </section>
+
+  <!-- Passo 3 &mdash; como ele é desenhado -->
+  <section class="card">
+    <h2><span class="step">3</span> Escolha a aparência</h2>
+
+    <fieldset class="options" id="qr-options">
+      <legend>O QR Code</legend>
+
+      <div class="option-row">
+        <label for="level">Quanto dano ele pode aguentar</label>
+        <select id="level">
+          <option value="L">L &mdash; cerca de 7% recuperável, código menor</option>
+          <option value="M" selected>M &mdash; cerca de 15%, a escolha de sempre</option>
+          <option value="Q">Q &mdash; cerca de 25%</option>
+          <option value="H">H &mdash; cerca de 30%, para uma impressão que vai se desgastar</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="quiet">Margem, em módulos</label>
+        <input type="number" id="quiet" value="4" min="0" max="16" step="1" inputmode="numeric">
+      </div>
+
+      <p class="field-summary">
+        A margem faz parte do código, e não é espaço em volta dele. Quatro
+        módulos é o que a especificação pede, e um código aparado até a borda é um
+        que muitos leitores não vão enxergar.
+      </p>
+    </fieldset>
+
+    <fieldset class="options" id="barcode-options" hidden>
+      <legend>O código de barras</legend>
+
+      <div class="option-row">
+        <label for="bar-width">Barra mais estreita, em pixels</label>
+        <input type="number" id="bar-width" value="2" min="1" max="10" step="1" inputmode="numeric">
+      </div>
+
+      <div class="option-row">
+        <label for="bar-height">Altura das barras, em pixels</label>
+        <input type="number" id="bar-height" value="120" min="20" max="600" step="10" inputmode="numeric">
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="show-text" checked>
+        <span>
+          <strong>Imprimir os caracteres embaixo</strong>
+          <span class="check-note">
+            O que uma pessoa lê quando o leitor não lê. Num código de varejo os
+            dígitos ficam também nas margens, e isso é de propósito: eles marcam
+            o espaço em branco que ninguém deveria aparar.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="code39-check-row" hidden>
+        <input type="checkbox" id="code39-check">
+        <span>
+          <strong>Acrescentar um caractere de verificação</strong>
+          <span class="check-note">
+            O Code 39 normalmente não carrega um. Alguns sistemas insistem nele;
+            só acrescente se o seu insistir, porque um leitor que não estiver
+            esperando um vai lê-lo como um caractere a mais no fim.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Cor e tamanho</legend>
+
+      <div class="colour-row">
+        <div class="option-row">
+          <label for="foreground">O código</label>
+          <input type="color" id="foreground" value="#000000">
+        </div>
+        <div class="option-row">
+          <label for="background">Atrás dele</label>
+          <input type="color" id="background" value="#ffffff">
+        </div>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="transparent">
+        <span>
+          <strong>Sem fundo nenhum</strong>
+          <span class="check-note">
+            Transparente, para pôr sobre algo que já tem cor. O SVG e o PNG
+            mantêm isso; seja lá o que acabar atrás dele tem que ser claro, ou um
+            leitor não vai achar contraste.
+          </span>
+        </span>
+      </label>
+
+      <div class="option-row" id="size-row">
+        <label for="size">Tamanho da imagem, em pixels</label>
+        <input type="number" id="size" value="512" min="64" max="4096" step="16" inputmode="numeric">
+      </div>
+
+      <p class="field-summary" id="size-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Passo 4 &mdash; o resultado -->
+  <section class="card" id="result-card">
+    <h2><span class="step">4</span> Leve</h2>
+
+    <div class="preview" id="preview" role="img" aria-label="O código que você gerou"></div>
+
+    <p class="facts" id="facts"></p>
+
+    <div class="run-row">
+      <button type="button" id="download-svg" class="primary">Baixar o SVG</button>
+      <button type="button" id="download-png" class="primary">Baixar o PNG</button>
+      <button type="button" id="copy-png" class="ghost">Copiar a imagem</button>
+    </div>
+
+    <p class="field-summary" id="download-note" role="status"></p>
+
+    <p class="field-summary">
+      O SVG é o que vale guardar. Ele é o código como instruções em vez de
+      pixels, então imprime em qualquer tamanho sem amolecer &mdash; o que importa
+      mais aqui do que na maioria das imagens, porque uma borda borrada é
+      exatamente o que um leitor não consegue resolver.
+    </p>
+  </section>
+</main>

--- a/locales/pt/tools/qr-barcode.toml
+++ b/locales/pt/tools/qr-barcode.toml
@@ -1,0 +1,339 @@
+#
+# Gerador de QR Code e código de barras - português do Brasil.
+#
+# Overrides for tools/qr-barcode/tool.toml. Only words: the slug, the
+# category, the icon and the CSP stay where they are. This tool has no
+# [picker] table, because what goes in is typed rather than dropped.
+#
+# "QR Code" fica em inglês porque é assim que se fala no Brasil, inclusive em
+# placa de restaurante; "código de barras", esse sim, é português corrente. Os
+# nomes dos simbolismos - EAN-13, UPC-A, ITF-14, Code 128, Code 39 - são nomes
+# de norma e ficam como estão.
+#
+
+name = "Gerador de QR Code e código de barras"
+heading = "QR&nbsp;Code&nbsp;e&nbsp;barras <span class=\"h1-kw\">&mdash; gerar um QR Code ou um código de barras, offline</span>"
+tagline = "Digite, e vira um código. Nada é enviado para fazer um."
+
+title = "Gerador de QR Code e código de barras &mdash; grátis, sem cadastro, nada enviado"
+description = "Gere um QR Code para um link, uma rede Wi-Fi ou um cartão de contato, ou um código de barras EAN-13, UPC-A, Code 128 ou Code 39. Baixe em SVG ou PNG. Tudo acontece no seu navegador."
+og_title = "Gere um QR Code ou um código de barras sem mandar nada para ninguém"
+og_description = "Links, senhas de Wi-Fi, cartões de contato e os códigos de barras do varejo, desenhados no seu próprio navegador e baixados em SVG ou PNG. Sem conta, sem marca d'água, sem pixel de rastreamento no meio do seu código."
+og_image_alt = "Gerador de QR Code e código de barras - gere um código, nada é enviado"
+
+pledge = """
+    Um QR Code é aritmética sobre uma cadeia de texto: não há arquivo para
+    mandar e não há serviço a quem pedir. Cada etapa &mdash; escolher o modo,
+    escolher a versão, a correção de erros Reed-Solomon, a máscara, as barras de
+    um código de barras e o dígito verificador embaixo &mdash; acontece em cerca
+    de mil linhas de JavaScript nesta página, que você pode ler. Esta ferramenta
+    não tem função de rede de espécie alguma, o que importa mais aqui do que na
+    maioria das páginas: o que está sendo codificado é muitas vezes uma senha de
+    Wi-Fi."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e digite uma senha no formulário de Wi-Fi. Nenhuma requisição leva
+      um caractere dela. Ou desconecte da internet e gere o código mesmo
+      assim."""
+
+read_first = """
+, <code>src/qr-encode.js</code>
+      e <code>src/qr.js</code> para o QR Code em si &mdash; os modos, a versão e
+      os blocos num, e os padrões, a máscara e os bits de formato no outro
+      &mdash; <code>src/gf256.js</code> para a correção de erros, e
+      <code>src/barcode.js</code> para os listrados."""
+
+howto_heading = "Como gerar um QR Code sem enviar nada"
+
+card = """
+            Um QR Code para um link, uma rede Wi-Fi ou um cartão de contato
+            &mdash; ou um código de barras de varejo com o dígito verificador já
+            calculado. SVG ou PNG."""
+
+[words]
+plural = "códigos e o texto dentro deles"
+choose = "o que vai dentro dele"
+analytics_extra = """, nem um
+  caractere do que você digitar"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem validade"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "Não existe para onde o que você digita possa ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      uma senha de Wi-Fi pudesse ser coletada, e não existe no código nada que a
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Não existe
+      <code>fetch</code>, nem <code>XMLHttpRequest</code>, nem
+      <code>sendBeacon</code> em lugar nenhum de <code>src/</code>. O código é
+      montado a partir da cadeia de texto por aritmética e desenhado como um SVG,
+      nesta página, na sua máquina."""
+
+[[privacy]]
+title = "O código não aponta para a gente."
+body = """
+ O que você digita é o que o
+      código guarda. Vários geradores gratuitos lhe devolvem um código contendo
+      um link para o site deles, que então redireciona para o seu &mdash; então
+      cada escaneamento é contado por eles, e o código para de funcionar no dia
+      em que eles pararem de pagar o domínio ou decidirem que o plano gratuito
+      acabou. Nada aqui encurta, redireciona ou rastreia: a cadeia de texto
+      mostrada na página é a cadeia de texto que está na imagem."""
+
+[[privacy]]
+title = "O PNG é feito a partir do SVG que está na tela."
+body = """
+ O
+      download não é uma segunda renderização que pudesse discordar da
+      pré-visualização. A mesma marcação é entregue ao navegador e pintada num
+      canvas, o que também é por que isso pode ser feito sem contatar nada: não
+      há fonte para buscar nem imagem para carregar lá dentro."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google, e o botão de doação vem do Buy Me a
+      Coffee. Nenhum deles recebe nada do que você digita. Toda linha que
+      transforma uma cadeia de texto num código é servida desta origem e está
+      listada no repositório."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua
+      igual, porque nunca houve uma etapa de rede nela. Essa é a prova mais
+      simples de todas."""
+
+[[howto]]
+title = "Escolha o tipo de código."
+body = """
+ Um QR Code guarda qualquer coisa e é
+      o que a câmera de um celular procura, então é a resposta a menos que
+      alguém lhe tenha dito outra coisa. Um código de barras guarda um número, e
+      qual deles você precisa é decidido por quem vai escaneá-lo &mdash; uma loja
+      quer um EAN-13 ou um UPC-A, uma caixa de transporte quer um ITF-14, e
+      qualquer coisa interna costuma ser Code 128."""
+
+[[howto]]
+title = "Diga o que vai dentro."
+body = """
+ Um link é o caso comum, e as caixas
+      acima dele montam os outros formatos que os celulares conhecem: uma rede
+      Wi-Fi que se oferece para conectar, um cartão de contato que se oferece
+      para ser salvo, um e-mail, uma mensagem de texto, um telefone, um lugar num
+      mapa. Qualquer que seja a sua escolha, a cadeia de texto final aparece na
+      página &mdash; é só isso que um QR Code guarda."""
+
+[[howto]]
+title = "Escolha quanto dano ele pode aguentar."
+body = """
+ Os quatro níveis põem mais ou
+      menos correção de erros, e mais correção significa um código maior e mais
+      denso. L basta para uma tela, M para papel comum, e H para algo que vai ser
+      manuseado, impresso pequeno, ou colado numa vitrine ao sol. Um código num
+      cardápio que é limpado todo dia merece Q ou H."""
+
+[[howto]]
+title = "Defina o tamanho, a margem e as cores."
+body = """
+ A margem faz parte do código:
+      quatro módulos de espaço em silêncio em volta é o que a especificação pede,
+      e aparar isso é o motivo isolado mais comum de um código impresso não
+      escanear. Escuro sobre claro, com contraste de verdade &mdash; um leitor lê
+      a diferença entre os dois, então cinza pálido sobre branco não serve, e
+      claro sobre escuro falha de cara num bom número de leitores."""
+
+[[howto]]
+title = "Confira com o celular que você tem."
+body = """
+ Antes de imprimir mil deles,
+      escaneie o que está na sua tela. Isso leva dez segundos e pega a categoria
+      inteira de erros que uma pré-visualização não pega: uma senha de Wi-Fi com
+      um caractere que precisava ser escapado, um link sem o
+      <code>https://</code>, um número de código de barras com um dígito a
+      menos."""
+
+[[howto]]
+title = "Leve o SVG."
+body = """
+ Ele é o código como instruções em vez de
+      pixels, então imprime em qualquer tamanho sem amolecer, e uma borda mole é
+      exatamente o que um leitor não consegue resolver. Leve o PNG também se
+      aquilo em que você vai colar não aceitar um SVG; ele é desenhado num número
+      inteiro de pixels por módulo, então também não tem bordas borradas."""
+
+[[faq]]
+q = "Alguma coisa que eu digito é mandada para algum lugar?"
+a = """
+        Não. Um QR Code é aritmética sobre uma cadeia de texto, e essa aritmética
+        roda no seu próprio navegador, na sua própria máquina. Esta ferramenta não
+        tem função de rede de espécie alguma &mdash; nunca busca nada e nunca manda
+        nada &mdash; e a <code>Content-Security-Policy</code> da página nomeia todos
+        os endereços que ela pode contatar, nenhum dos quais é deste site. Isso vale
+        mais aqui do que na maioria das páginas, porque a coisa que as pessoas mais
+        põem num QR Code é a senha do Wi-Fi delas."""
+
+[[faq]]
+q = "Estes códigos expiram, ou param de funcionar depois?"
+a = """
+        Não, e não teriam como. O que você digita é o que o código guarda, então
+        escaneá-lo devolve exatamente aquela cadeia de texto para sempre. Os códigos
+        que expiram são os que têm o endereço de outra gente lá dentro: um QR Code
+        &ldquo;dinâmico&rdquo; guarda um link para o servidor do gerador, que
+        redireciona para o seu, o que significa que eles podem contar cada
+        escaneamento, mudar para onde ele leva, ou desligá-lo quando um teste
+        acabar. Nada aqui redireciona por lugar nenhum."""
+
+[[faq]]
+q = "É grátis, e posso usar comercialmente?"
+a = """
+        É grátis, não há conta, não há marca d'água e não há limite de quantos você
+        gera, e você pode pôr o resultado num produto, num cartaz ou numa fachada.
+        QR Code é marca registrada da Denso Wave, que declarou que não vai exercê-la
+        contra quem usa os códigos &mdash; a especificação é publicada como ISO/IEC
+        18004 e é livre para implementar, que é o que esta página faz. O site exibe
+        publicidade, e é ela que paga a conta."""
+
+[[faq]]
+q = "Qual nível de correção de erros eu devo escolher?"
+a = """
+        M, a menos que você tenha um motivo. L gera o código menor e serve numa
+        tela; M sobrevive ao manuseio comum; Q e H são para um código que vai ser
+        impresso pequeno, plastificado, colado numa vitrine, ou parcialmente coberto
+        por uma logomarca. Cada degrau a mais põe mais dados de verificação, o que
+        exige um símbolo maior para a mesma quantidade de texto &mdash; ir de L para
+        H mais ou menos dobra o número de módulos para a mesma cadeia."""
+
+[[faq]]
+q = "Quanto cabe num QR Code?"
+a = """
+        No tamanho maior, 177 módulos de lado, até 7.089 dígitos, 4.296 letras
+        maiúsculas e dígitos, ou 2.953 bytes de qualquer outra coisa &mdash; e isso
+        na correção de erros mais fraca; na mais forte é cerca de um terço disso. Na
+        prática, o limite não é o formato e sim o leitor: passando de algumas
+        centenas de caracteres, os módulos ficam tão pequenos que a câmera de um
+        celular comum não consegue resolvê-los a um braço de distância. Um código
+        longo costuma ser sinal de que ali cabia um link curto."""
+
+[[faq]]
+q = "Por que o meu código fica maior quando escrevo o link em minúsculas?"
+a = """
+        Porque um QR Code tem um modo para maiúsculas e dígitos que empacota dois
+        caracteres em onze bits, e não tem modo equivalente para minúsculas, que
+        custam oito bits cada. Uma URL escrita
+        <code>HTTPS://EXEMPLO.COM.BR/PAGINA</code> pode ficar um terço menor que a
+        mesma URL em minúsculas. O esquema e o host não diferenciam maiúsculas, então
+        gritá-los não muda nada além do tamanho; o caminho depois do host diferencia,
+        então deixe esse em paz."""
+
+[[faq]]
+q = "Ele também lê um QR Code, além de gerar?"
+a = """
+        Ainda não. Ler um significa decodificar uma imagem &mdash; achar o símbolo
+        numa fotografia, corrigir o ângulo em que ela foi tirada e reparar o dano
+        &mdash; o que é um trabalho diferente e bem maior do que desenhar um. Dava
+        para construir aqui nos mesmos termos que todo o resto, e está na lista.
+        Enquanto isso, a câmera do seu celular já faz, e faz bem."""
+
+[[faq]]
+q = "Para que serve a margem, e posso deixá-la menor?"
+a = """
+        O espaço branco em volta de um QR Code faz parte do código. Um leitor o usa
+        para achar onde o símbolo termina, e a especificação pede quatro módulos de
+        cada lado; um código de barras quer uns dez. Você pode zerar isso aqui e a
+        imagem vai ficar mais arrumada, e um bom número de leitores então vai deixar
+        de enxergá-la &mdash; especialmente sobre um fundo carregado. Se o problema é
+        espaço, deixe o código menor em vez de aparar a margem dele."""
+
+[[faq]]
+q = "De qual código de barras eu preciso?"
+a = """
+        Do que a pessoa que vai escanear pedir. EAN-13 é o código de barras do
+        varejo fora da América do Norte e UPC-A é o norte-americano &mdash; os dois
+        precisam de um número emitido para você pela GS1, porque o número identifica
+        a sua empresa, e não só o produto. EAN-8 é a versão curta para embalagens
+        pequenas. ITF-14 vai na caixa de transporte. Code 128 e Code 39 guardam
+        texto além de dígitos e não precisam de registro nenhum, o que faz deles a
+        resposta certa para qualquer coisa interna: patrimônio, prateleiras, ordens
+        de serviço."""
+
+[[faq]]
+q = "O que é um dígito verificador, e por que a ferramenta acrescentou um?"
+a = """
+        É o último dígito de um código de barras de varejo, calculado a partir dos
+        anteriores, para que um leitor consiga distinguir uma leitura errada de uma
+        certa. O EAN-13 quer doze dígitos e calcula o décimo terceiro; o UPC-A quer
+        onze e calcula o décimo segundo. Digite o número curto e esta página
+        acrescenta o dígito. Digite o número completo e ela confere o que você deu
+        &mdash; e recusa, em vez de corrigir em silêncio, porque um dígito errado
+        consertado caladinho é uma etiqueta que escaneia como produto de outra
+        pessoa."""
+
+[[faq]]
+q = "Posso pôr uma logomarca no meio de um QR Code?"
+a = """
+        Aqui não, mas vale saber por que funciona em outros lugares: é a correção de
+        erros que torna isso possível. No nível H, cerca de 30% dos módulos podem
+        ser destruídos e o código ainda é lido, então uma logomarca cobrindo bem
+        menos que isso no centro &mdash; onde não fica nenhum padrão de localização
+        &mdash; é dano reparável. Passe o código pelo seu editor de imagem no nível
+        H, mantenha a logomarca abaixo de uns 20% da área, e teste com um celular de
+        verdade em vez de confiar."""
+
+[[faq]]
+q = "Por que o SVG é melhor que o PNG?"
+a = """
+        Porque um código é feito de bordas, e um PNG tem um número fixo de pixels com
+        que formá-las. Amplie um e toda borda amolece; uma borda mole é precisamente
+        o que dá trabalho a um leitor, e uma impressora a 1200 dpi recebendo um PNG
+        de 512 pixels está sendo convidada a inventar a diferença. Um SVG são os
+        quadradinhos como instruções, então imprime nítido num cartão de visita ou
+        num outdoor. O PNG daqui é desenhado num número inteiro de pixels por módulo,
+        que é o melhor que um PNG consegue fazer."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse o seu texto embora para ter um
+        código desenhado pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Gere um QR Code ou um código de barras linear a partir de uma cadeia de texto, dentro do navegador. QR Codes para links, redes Wi-Fi, cartões de contato, e-mail, SMS, telefones e coordenadas, com os quatro níveis de correção de erros; códigos de barras EAN-13, EAN-8, UPC-A, ITF-14, Intercalado 2 de 5, Code 128 e Code 39 com os dígitos verificadores deles. Baixe em SVG ou PNG. Nada é enviado."
+features = [
+  "QR Codes em todas as versões, de 1 a 40, nos modos numérico, alfanumérico e de bytes",
+  "Os quatro níveis de correção de erros, com o custo de cada um dito em voz alta",
+  "Formatos prontos: rede Wi-Fi, cartão de contato, e-mail, mensagem de texto, telefone, local no mapa",
+  "Mostra a cadeia de texto exata que o código vai guardar, em vez de escondê-la",
+  "EAN-13, EAN-8 e UPC-A, com o dígito verificador calculado ou conferido",
+  "ITF-14 e Intercalado 2 de 5 para caixas e armazenagem",
+  "Code 128 com uso automático do modo numérico dele, e Code 39 com caractere de verificação opcional",
+  "Dígitos legíveis impressos embaixo de um código de barras, nos lugares certos",
+  "Saída em SVG, que imprime nítida em qualquer tamanho, e um PNG desenhado em pixels inteiros por módulo",
+  "Quaisquer duas cores, ou fundo nenhum",
+  "Nunca redireciona: sem link curto, sem rastreamento, sem nada que possa expirar",
+  "Roda offline; sem envio, sem conta",
+]

--- a/locales/pt/tools/resize-image.html
+++ b/locales/pt/tools/resize-image.html
@@ -1,0 +1,281 @@
+<main>
+  <!-- Passo 1 &mdash; os arquivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha as imagens</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tirar tudo da lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; o corte -->
+  <section class="card" id="crop-card">
+    <h2><span class="step">2</span> Corte, se quiser</h2>
+
+    <p class="card-lede">
+      A caixa começa na imagem inteira, então deixar este passo em paz não corta
+      nada. Cada imagem guarda a caixa dela &mdash; escolha uma da lista acima
+      para desenhar nela. O corte acontece antes do redimensionamento, que é a
+      única ordem que faz sentido: uma imagem cortada depois de encolhida já
+      jogou fora os pixels de que precisava.
+    </p>
+
+    <p id="crop-empty" class="field-summary">Adicione uma imagem e a caixa aparece aqui.</p>
+
+    <div id="crop-controls" hidden>
+      <p class="stage-hint">
+        <span id="stage-name" class="stage-name"></span>
+        Arraste dentro da caixa para movê-la, ou qualquer canto para
+        redimensioná-la. Com a caixa em foco, as setas a empurram um pixel de
+        cada vez, <kbd>Alt</kbd>&nbsp;+&nbsp;setas a redimensionam, e segurar
+        <kbd>Shift</kbd> faz cada passo valer dez.
+      </p>
+
+      <!-- The crop box itself is added here by src/cropper.js. The stage is
+           given the picture's own shape, so the box can be positioned in
+           percentages and needs no recalculating when the window is resized. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <p id="stage-note" class="stage-note" hidden></p>
+
+      <div class="crop-controls">
+        <div class="aspect-row" id="aspect-row" role="group" aria-label="Travar o corte numa proporção">
+          <button type="button" data-aspect="free" class="active">Livre</button>
+          <button type="button" data-aspect="source">Original</button>
+          <button type="button" data-aspect="1:1">1:1</button>
+          <button type="button" data-aspect="4:5">4:5</button>
+          <button type="button" data-aspect="9:16">9:16</button>
+          <button type="button" data-aspect="16:9">16:9</button>
+          <button type="button" data-aspect="4:3">4:3</button>
+          <button type="button" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="ghost" title="Virar a proporção travada de lado">
+            Inverter
+          </button>
+        </div>
+
+        <div class="numbers">
+          <label>Esquerda<input type="number" id="crop-x" min="0" step="1"></label>
+          <label>Topo<input type="number" id="crop-y" min="0" step="1"></label>
+          <label>Largura<input type="number" id="crop-w" min="8" step="1"></label>
+          <label>Altura<input type="number" id="crop-h" min="8" step="1"></label>
+          <div class="number-actions">
+            <button type="button" id="crop-max" class="ghost">Maior</button>
+            <button type="button" id="crop-centre" class="ghost">Centralizar</button>
+            <button type="button" id="crop-reset" class="ghost">Imagem inteira</button>
+          </div>
+        </div>
+
+        <!--
+          Every image keeps its own box, which is the point. This is for the
+          case that is still worth one click: a folder of exports that all want
+          the same framing.
+        -->
+        <div class="apply-row" id="apply-row" hidden>
+          <button type="button" id="crop-apply-all" class="ghost">Usar este corte em todas as imagens</button>
+          <p class="hint-line" id="apply-note"></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; o tamanho -->
+  <section class="card" id="resize-card">
+    <h2><span class="step">3</span> Diga que tamanho ela deve ter</h2>
+
+    <div class="option-row">
+      <label for="resize-mode">Definir o tamanho por</label>
+      <select id="resize-mode">
+        <option value="pixels" selected>Largura e altura, em pixels</option>
+        <option value="longest">O lado maior</option>
+        <option value="percent">Uma porcentagem do que ela é agora</option>
+        <option value="none">Nada &mdash; deixar o tamanho exatamente como está</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="pixels-fields">
+      <div class="numbers">
+        <label>Largura<input type="number" id="size-w" min="1" step="1" placeholder="auto" value="1920"></label>
+        <label>Altura<input type="number" id="size-h" min="1" step="1" placeholder="auto"></label>
+        <div class="number-actions">
+          <button type="button" id="swap-size" class="ghost">Inverter</button>
+        </div>
+      </div>
+
+      <!--
+        Leaving one of them blank is the common case and the one worth
+        supporting properly: "1920 wide, whatever tall that makes it" needs no
+        decision about shapes at all.
+      -->
+      <p class="hint-line">
+        Preencha um e deixe o outro em branco para manter o formato da própria imagem.
+      </p>
+
+      <div class="presets" id="size-presets" role="group" aria-label="Tamanhos comuns">
+        <button type="button" class="ghost" data-w="1920" data-h="1080">1920 &times; 1080</button>
+        <button type="button" class="ghost" data-w="1280" data-h="720">1280 &times; 720</button>
+        <button type="button" class="ghost" data-w="1080" data-h="1080">1080 &times; 1080</button>
+        <button type="button" class="ghost" data-w="600" data-h="">600 de largura</button>
+      </div>
+
+      <div class="option-row" id="fit-row">
+        <label for="fit">Se os formatos discordarem</label>
+        <select id="fit">
+          <option value="contain" selected>Caber dentro &mdash; a imagem inteira, com um lado sobrando</option>
+          <option value="cover">Preencher &mdash; exatamente este tamanho, com o excesso cortado</option>
+          <option value="pad">Completar &mdash; exatamente este tamanho, com um fundo em volta</option>
+          <option value="stretch">Esticar &mdash; exatamente este tamanho, e o formato deformado</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Lado maior<input type="number" id="size-longest" min="1" step="1" value="1920"></label>
+      </div>
+      <p class="hint-line">
+        O lado que for maior vira isto, e o outro acompanha. Fotos em pé e
+        deitadas no mesmo lote saem todas do mesmo tamanho no lado maior, que é o
+        que uma galeria normalmente quer.
+      </p>
+      <div class="presets" id="longest-presets" role="group" aria-label="Lados maiores comuns">
+        <button type="button" class="ghost" data-longest="640">640</button>
+        <button type="button" class="ghost" data-longest="1280">1280</button>
+        <button type="button" class="ghost" data-longest="1920">1920</button>
+        <button type="button" class="ghost" data-longest="2560">2560</button>
+      </div>
+    </div>
+
+    <div class="size-fields" id="percent-fields" hidden>
+      <div class="numbers">
+        <label>Porcentagem<input type="number" id="size-percent" min="1" max="1000" step="1" value="50"></label>
+      </div>
+      <div class="presets" id="percent-presets" role="group" aria-label="Porcentagens comuns">
+        <button type="button" class="ghost" data-percent="25">25%</button>
+        <button type="button" class="ghost" data-percent="50">50%</button>
+        <button type="button" class="ghost" data-percent="75">75%</button>
+        <button type="button" class="ghost" data-percent="200">200%</button>
+      </div>
+    </div>
+
+    <label class="check" id="enlarge-row">
+      <input type="checkbox" id="no-enlarge" checked>
+      <span>
+        <strong>Nunca deixar uma imagem maior do que ela começou</strong>
+        <span class="check-note">
+          Ampliar inventa pixels que nunca foram fotografados, então uma imagem
+          pequena a quem se pede um quadro grande sai macia em vez de detalhada.
+          Com isto ligado, qualquer coisa que já seja menor que o tamanho pedido
+          fica no próprio tamanho.
+        </span>
+      </span>
+    </label>
+
+    <p id="size-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Passo 4 &mdash; o formato, e o único clique -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Salve</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="keep" selected>Manter o formato em que cada arquivo chegou</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/png">PNG</option>
+          <option value="image/webp">WebP</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualidade &mdash; <output id="quality-value" for="quality">85</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="85">
+        <p class="field-note">
+          Só JPEG e WebP; o PNG não tem botão de qualidade. 85 é onde a maioria
+          das pessoas para de conseguir perceber. Abaixo de uns 60 as áreas
+          chapadas começam a criar faixas.
+        </p>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Fundo</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          O que aparece onde a imagem não está: atrás de um quadro completado com
+          margem, e atrás da transparência quando o formato de saída não tem
+          canal alfa.
+        </p>
+      </div>
+    </div>
+
+    <p id="plan-summary" class="field-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Redimensionar as imagens</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Prontas</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Baixar tudo num zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The big look at one result. A <dialog> opened with showModal() rather than
+    a div pretending to be one: the browser gives the focus trap, the Escape
+    key and the inert background for nothing, and gets all three right.
+
+    Both pictures in it are object URLs made on this page - the result, and the
+    original that was already decoded for the thumbnail. Opening this fetches
+    nothing and decodes nothing that was not already decoded.
+  -->
+  <dialog id="viewer" class="viewer" aria-labelledby="viewer-name">
+    <div class="viewer-head">
+      <h2 id="viewer-name" class="viewer-name"></h2>
+      <button type="button" id="viewer-close" class="ghost" aria-label="Fechar">Fechar</button>
+    </div>
+
+    <div class="viewer-stage">
+      <img id="viewer-image" alt="">
+    </div>
+
+    <p id="viewer-caption" class="viewer-caption"></p>
+
+    <dl class="viewer-facts" id="viewer-facts"></dl>
+
+    <div class="viewer-actions">
+      <button type="button" id="viewer-compare" class="ghost" aria-pressed="false">Mostrar o original</button>
+      <a id="viewer-download" class="primary as-button" download>Baixar</a>
+    </div>
+  </dialog>
+</main>

--- a/locales/pt/tools/resize-image.toml
+++ b/locales/pt/tools/resize-image.toml
@@ -1,0 +1,279 @@
+#
+# Redimensionador de imagens - português do Brasil.
+#
+# Overrides for tools/resize-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Redimensionador de imagens"
+heading = "Redimensionar&nbsp;imagem <span class=\"h1-kw\">&mdash; cortar e converter também</span>"
+tagline = "Diga o tamanho. Desenhe a caixa. Escolha o formato."
+
+title = "Redimensionar uma imagem &mdash; cortar e converter, sem envio"
+description = "Redimensione, corte e converta imagens JPEG, PNG e WebP no seu navegador. Pixels exatos, uma porcentagem ou o lado maior - uma imagem ou uma pasta inteira. Nada é enviado."
+og_title = "Redimensione, corte e converta uma imagem sem enviá-la"
+og_description = "Defina o tamanho em pixels ou em porcentagem, arraste uma caixa de corte, mude o formato - para uma imagem ou um lote inteiro. Tudo roda na sua própria máquina."
+og_image_alt = "Redimensionador de imagens - redimensione, corte e converta sem enviar"
+
+pledge = """
+    O redimensionamento, o corte e a mudança de formato rodam todos no seu
+    próprio navegador, no seu próprio hardware, com os codificadores de imagem
+    que ele já traz. Esta ferramenta não tem função de rede de espécie alguma
+    &mdash; nada a buscar, nada a enviar &mdash; e não existe do outro lado desta
+    página servidor nenhum para onde mandar uma imagem, mesmo que houvesse
+    caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e redimensione uma foto. Nenhuma requisição leva uma imagem, uma
+      miniatura, um nome de arquivo ou um byte do que você escolheu. Ou
+      desconecte da internet e redimensione uma mesmo assim."""
+
+read_first = """
+, <code>src/geometry.js</code> para a aritmética que
+      decide o que é mantido e de que tamanho sai, e
+      <code>src/codecs.js</code> para a única chamada de <code>drawImage</code>
+      que faz o corte e o redimensionamento de uma vez."""
+
+howto_heading = "Como redimensionar uma imagem sem enviá-la"
+
+card = """
+            Pixels exatos, uma porcentagem ou o lado maior &mdash; com uma caixa
+            de corte e uma troca de formato no caminho. Uma imagem ou uma
+            pasta."""
+
+[words]
+plural = "imagens"
+choose = "uma imagem"
+analytics_extra = """, nem nenhum dos
+  tamanhos, cortes ou formatos que esta ferramenta calcula"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca d'água"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "Suas imagens não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      seus arquivos pudessem ser coletados, e não existe no código nada que os
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Não existe
+      <code>fetch</code>, nem <code>XMLHttpRequest</code>, nem
+      <code>sendBeacon</code> em lugar nenhum de <code>src/</code>. O
+      redimensionamento é um <code>drawImage</code> num canvas e um
+      <code>canvas.toBlob</code> &mdash; o escalador e o codificador que já estão
+      instalados no seu navegador."""
+
+[[privacy]]
+title = "Um arquivo que ninguém pediu para mudar não é mudado."
+body = """
+ Sem corte, sem
+      redimensionamento e sem troca de formato, o arquivo que você escolheu é
+      devolvido a você byte por byte em vez de ser salvo de novo. Isso não é só
+      educação: é por isso que esta ferramenta não consegue recodificar uma imagem
+      em silêncio, nem descartar em silêncio os metadados de uma que você só
+      queria olhar."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google, e o botão de doação vem do Buy Me a
+      Coffee. Nenhum deles recebe coisa alguma sobre as suas imagens. Toda linha
+      que lê, corta, escala ou escreve um arquivo é servida desta origem e está
+      listada no repositório."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua
+      igual, porque nunca houve uma etapa de rede nela. Essa é a prova mais
+      simples de todas."""
+
+[[howto]]
+title = "Escolha suas imagens."
+body = """
+ Arraste até o seletor ou escolha na mão.
+      Elas são lidas direto do seu disco pelo navegador; nada é mandado para lugar
+      nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Corte, se quiser."
+body = """
+ A caixa começa na imagem inteira, então
+      deixá-la em paz não corta nada. Arraste, ou trave numa proporção &mdash; 1:1
+      para foto de perfil, 9:16 para um story, 16:9 para uma miniatura &mdash; e
+      aperte &ldquo;Maior&rdquo; para a maior caixa que couber. Cada imagem guarda
+      a caixa dela: clique em qualquer linha da lista para desenhar naquela. Se
+      todas tiverem que ficar com o mesmo enquadramento, um botão faz isso
+      também."""
+
+[[howto]]
+title = "Diga de que tamanho ela deve sair."
+body = """
+ Uma largura, uma altura
+      ou as duas; um lado maior, que deixa as fotos em pé e as deitadas do mesmo
+      tamanho entre si; ou uma porcentagem simples. Deixe uma das duas caixas em
+      branco e a imagem mantém o próprio formato."""
+
+[[howto]]
+title = "Escolha o formato e aperte o botão."
+body = """
+ Mantenha o formato em que
+      cada arquivo chegou, ou escreva tudo como JPEG, PNG ou WebP. Cada resultado
+      diz no que virou e quanto diminuiu; clique num deles para abrir em tamanho
+      cheio com todos os números por trás, e o original ao lado para comparar. Um
+      lote desce como um zip só."""
+
+[[faq]]
+q = "Minha imagem é enviada para algum lugar?"
+a = """
+        Não. O arquivo é decodificado, cortado, escalado e escrito pelo seu próprio
+        navegador no seu próprio hardware, com os codificadores de JPEG, PNG e WebP
+        que o navegador já traz. Esta ferramenta não tem função de rede de espécie
+        alguma &mdash; nunca busca nada e nunca manda nada &mdash; e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar, nenhum dos quais é deste site."""
+
+[[faq]]
+q = "O que acontece se eu der uma largura e não uma altura?"
+a = """
+        A altura sai do formato da própria imagem, que é quase sempre o que se
+        queria: &ldquo;1920 de largura&rdquo; quer dizer &ldquo;1920 de largura e a
+        altura que isso der&rdquo;. Preencha as duas e elas podem discordar do
+        formato da imagem, que é a única hora em que a escolha de &ldquo;se os
+        formatos discordarem&rdquo; aparece &mdash; caber dentro da caixa,
+        preenchê-la e cortar o que sobra, completar com um fundo, ou esticar e
+        aceitar a deformação."""
+
+[[faq]]
+q = "Redimensionar uma imagem perde qualidade?"
+a = """
+        Diminuir uma imagem não perde, de nenhum jeito que você consiga ver: entram
+        mais pixels do que saem, então o detalhe que fica é detalhe de verdade.
+        Aumentar não consegue acrescentar o que nunca foi fotografado &mdash; o
+        resultado é uma cópia mais macia da mesma imagem, não uma mais nítida
+        &mdash; e é por isso que &ldquo;nunca deixar uma imagem maior do que ela
+        começou&rdquo; vem ligado por padrão. O que custa um pouco é a recodificação
+        depois, se o formato for JPEG ou WebP, e o controle de qualidade é onde você
+        gasta ali."""
+
+[[faq]]
+q = "Posso cortar cada imagem de um jeito diferente?"
+a = """
+        Sim &mdash; esse é o padrão. Toda imagem da lista carrega a caixa dela, nos
+        pixels dela, e clicar numa linha põe aquela imagem na pré-visualização com a
+        caixa dela e a proporção travada dela de volta. Nada do que você faz numa
+        afeta outra. Toda caixa também começa na imagem inteira, então uma imagem em
+        que você nunca desenhou não é cortada."""
+
+[[faq]]
+q = "Ele consegue cortar um lote inteiro do mesmo jeito de uma vez?"
+a = """
+        Sim, com o botão embaixo da pré-visualização. Ele dá a cada outra imagem a
+        mesma área relativa &mdash; as mesmas frações da largura e da altura dela
+        &mdash; o que, num conjunto de capturas de tela ou exportações todas do
+        mesmo tamanho, é exatamente a mesma caixa, e a página diz isso. Com uma
+        proporção travada, ele dá a cada uma a maior caixa daquela proporção dentro
+        daquela área, então apertar 1:1 e depois aquele botão lhe rende quadrados a
+        partir de uma pasta com fotos em pé e deitadas misturadas. Toda caixa
+        continua editável depois."""
+
+[[faq]]
+q = "Quais formatos ele consegue ler e escrever?"
+a = """
+        Ele lê tudo o que o seu navegador consegue decodificar, o que na prática
+        significa JPEG, PNG, WebP, GIF, BMP e &mdash; na maioria dos navegadores
+        atuais &mdash; AVIF. Ele escreve JPEG, PNG e WebP, porque são esses os
+        codificadores que os navegadores trazem. Em &ldquo;manter o formato&rdquo;,
+        um JPEG continua JPEG e um PNG continua PNG; qualquer coisa que o navegador
+        não saiba escrever, como um GIF ou um BMP, sai como PNG, que é o formato que
+        mantém intactas a transparência e a cor chapada."""
+
+[[faq]]
+q = "O que acontece com a transparência quando eu salvo como JPEG?"
+a = """
+        Ela é preenchida com a cor de fundo, porque o JPEG não tem canal alfa onde
+        guardá-la. A cor é sua para escolher e começa em branco, que é o que a
+        maioria das pessoas quer e o que quase toda outra ferramenta faz sem lhe
+        avisar. A mesma cor é usada atrás de um quadro completado com margem. Salve
+        como PNG ou WebP e a transparência passa intocada."""
+
+[[faq]]
+q = "Ele remove os dados EXIF e de GPS?"
+a = """
+        De qualquer coisa que ele de fato processe, sim, como efeito colateral:
+        cortar ou redimensionar significa decodificar a imagem em pixels e codificar
+        esses pixels de novo, e um canvas cheio de pixels não carrega etiquetas,
+        então a localização, o modelo da câmera e os horários simplesmente não são
+        escritos no arquivo novo. Um arquivo que você não está alterando é outro
+        caso &mdash; ele é devolvido byte por byte, com etiquetas e tudo. Se você
+        quer os metadados fora mas a imagem intocada, use o
+        <a href="../remover-dados-exif/">Visualizador e removedor de EXIF</a>, que
+        reescreve o contêiner sem recomprimir nada."""
+
+[[faq]]
+q = "Qual a diferença entre isto e o compressor de imagens?"
+a = """
+        Este aqui é sobre dimensões: você diz quantos pixels quer e ele lhe dá isso.
+        O <a href="../comprimir-imagem/">Compressor de imagens</a> é sobre tamanho
+        de arquivo: você diz quantos kilobytes lhe permitiram e ele procura a maior
+        qualidade que cabe, redimensionando só se a qualidade sozinha não chegar lá.
+        Se mandaram você fazer &ldquo;1200 pixels de largura&rdquo;, você está no
+        lugar certo. Se mandaram &ldquo;abaixo de 500 KB&rdquo;, o outro chega mais
+        perto."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. Também não há limite para o número ou o tamanho dos arquivos,
+        porque não há servidor pagando por eles &mdash; o trabalho acontece na sua
+        própria máquina. O site exibe publicidade, e é ela que paga a conta; os
+        anúncios não recebem nada sobre as suas imagens."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse as suas imagens embora para
+        serem redimensionadas pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Redimensione, corte e converta imagens JPEG, PNG e WebP no navegador. Defina um tamanho exato em pixels, uma porcentagem ou um lado maior, arraste uma caixa de corte ou trave numa proporção, e escreva o resultado como JPEG, PNG ou WebP. Aceita lotes, e nada é enviado."
+features = [
+  "Redimensiona por pixels exatos, pelo lado maior ou por porcentagem",
+  "Preencha um lado e o outro acompanha o formato da própria imagem",
+  "Caber dentro, preencher e cortar, completar com margem até um quadro exato, ou esticar",
+  "Uma caixa de corte arrastável por imagem, travável em 1:1, 4:5, 9:16, 16:9, 4:3 ou 3:2",
+  "Corta cada imagem de um jeito, ou aplica um enquadramento ao lote inteiro num clique",
+  "Abre cada imagem pronta em tamanho cheio, com todos os números por trás e o original para comparar",
+  "Converte entre JPEG, PNG e WebP, com controle de qualidade e cor de fundo",
+  "Nunca amplia uma imagem a menos que você peça",
+  "Devolve intocado qualquer arquivo que não foi pedido para mudar",
+  "Trabalha em lote, com todos os resultados num zip",
+  "Roda offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste imagens para cá"
+hint = "ou clique para escolher &mdash; JPEG, PNG, WebP e tudo o mais que o seu navegador conseguir abrir"

--- a/locales/pt/tools/svg-to-image.html
+++ b/locales/pt/tools/svg-to-image.html
@@ -1,0 +1,209 @@
+<main>
+  <!-- Passo 1 &mdash; os arquivos -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha os arquivos SVG</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tirar tudo da lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; o tamanho -->
+  <section class="card" id="size-card">
+    <h2><span class="step">2</span> Diga de que tamanho ele deve ser</h2>
+
+    <p class="card-lede">
+      Esta é a única pergunta que um vetor não consegue responder por você. Um
+      SVG não tem pixels dentro &mdash; tem instruções de desenho, e vai
+      segui-las em qualquer tamanho que você disser. O número abaixo não é um
+      limite contra o qual você está empurrando, como seria com uma fotografia;
+      4000 pixels a partir de um ícone de 24&nbsp;pixels é exatamente tão nítido
+      quanto 24 era.
+    </p>
+
+    <div class="option-row">
+      <label for="size-mode">Definir o tamanho por</label>
+      <select id="size-mode">
+        <option value="scale" selected>Um multiplicador do tamanho que o arquivo pede</option>
+        <option value="width">Largura em pixels</option>
+        <option value="height">Altura em pixels</option>
+        <option value="longest">O lado maior</option>
+        <option value="box">Uma caixa, com os dois lados</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="scale-fields">
+      <div class="numbers">
+        <label>Multiplicar por<input type="number" id="size-scale" min="0.01" max="200" step="0.5" value="4"></label>
+      </div>
+      <div class="presets" id="scale-presets" role="group" aria-label="Multiplicadores comuns">
+        <button type="button" class="ghost" data-scale="1">1&times;</button>
+        <button type="button" class="ghost" data-scale="2">2&times;</button>
+        <button type="button" class="ghost" data-scale="4">4&times;</button>
+        <button type="button" class="ghost" data-scale="8">8&times;</button>
+        <button type="button" class="ghost" data-scale="16">16&times;</button>
+      </div>
+      <p class="hint-line">
+        Todo arquivo da lista é multiplicado a partir do próprio tamanho, então um
+        lote de ícones desenhados em tamanhos diferentes continua em proporção
+        entre si.
+      </p>
+    </div>
+
+    <div class="size-fields" id="width-fields" hidden>
+      <div class="numbers">
+        <label>Largura<input type="number" id="size-width" min="1" step="1" value="1024"></label>
+      </div>
+      <div class="presets" id="width-presets" role="group" aria-label="Larguras comuns">
+        <button type="button" class="ghost" data-width="256">256</button>
+        <button type="button" class="ghost" data-width="512">512</button>
+        <button type="button" class="ghost" data-width="1024">1024</button>
+        <button type="button" class="ghost" data-width="2048">2048</button>
+      </div>
+      <p class="hint-line">A altura sai do formato do desenho.</p>
+    </div>
+
+    <div class="size-fields" id="height-fields" hidden>
+      <div class="numbers">
+        <label>Altura<input type="number" id="size-height" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">A largura sai do formato do desenho.</p>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Lado maior<input type="number" id="size-longest" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">
+        O lado que for maior vira isto e o outro acompanha, então uma logomarca
+        larga e uma alta saem do mesmo tamanho no lado maior.
+      </p>
+    </div>
+
+    <div class="size-fields" id="box-fields" hidden>
+      <div class="numbers">
+        <label>Largura<input type="number" id="box-width" min="1" step="1" value="1200"></label>
+        <label>Altura<input type="number" id="box-height" min="1" step="1" value="630"></label>
+      </div>
+      <div class="option-row">
+        <label for="box-fit">Se o desenho tiver outro formato</label>
+        <select id="box-fit">
+          <option value="fit" selected>Caber dentro &mdash; o desenho inteiro, com um lado sobrando</option>
+          <option value="pad">Completar &mdash; exatamente este tamanho, com o fundo dos dois lados</option>
+          <option value="stretch">Esticar &mdash; exatamente este tamanho, e o formato deformado</option>
+        </select>
+      </div>
+    </div>
+
+    <!--
+      The one thing people rasterise a vector for more than once: the same
+      drawing at 1x, 2x and 3x for a screen with more device pixels than CSS
+      pixels. Multiplied from the plan above rather than planned again, so an
+      @2x is exactly twice its @1x and cannot drift by a rounded pixel.
+    -->
+    <div class="option-row" id="density-row">
+      <label for="density">Escrever também as cópias de alta densidade</label>
+      <select id="density">
+        <option value="1" selected>Não &mdash; um arquivo por desenho</option>
+        <option value="2">@2x também &mdash; para uma tela Retina</option>
+        <option value="3">@2x e @3x &mdash; o conjunto completo que um celular pede</option>
+      </select>
+    </div>
+
+    <p id="size-summary" class="field-summary"></p>
+    <p id="size-warning" class="field-summary warn" hidden></p>
+  </section>
+
+  <!-- Passo 3 &mdash; o formato -->
+  <section class="card" id="format-card">
+    <h2><span class="step">3</span> Escolha o formato</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; mantém a transparência, bordas exatas</option>
+          <option value="image/jpeg">JPEG &mdash; sem transparência, fotografias menores</option>
+          <option value="image/webp">WebP &mdash; transparência e um arquivo menor</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Qualidade &mdash; <output id="quality-value" for="quality">90</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="90">
+        <p class="field-note">
+          Só JPEG e WebP; o PNG não tem botão de qualidade porque é sem perdas.
+          Cor chapada e bordas duras &mdash; que é a maior parte do que um SVG
+          tem &mdash; são exatamente o que um codificador com perdas trata pior,
+          então isto fica mais alto aqui do que ficaria numa fotografia.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="background-mode">Fundo</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparente</option>
+          <option value="colour">Uma cor</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Cor de fundo" hidden>
+        <p class="field-note" id="background-note"></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Passo 4 &mdash; olhe, e então leve -->
+  <section class="card" id="run-card">
+    <h2><span class="step">4</span> Olhe, e então salve</h2>
+
+    <p class="card-lede">
+      A pré-visualização é desenhada pelo mesmo código que escreve o arquivo, a
+      partir do arquivo que você escolheu, nesta máquina. O que vale conferir são
+      as duas coisas que mudam quando um desenho vira pixels: um fio de cabelo
+      que tinha meio pixel de largura e ficou cinza, e qualquer texto, que é
+      desenhado com uma fonte que esta máquina tem, e não com uma buscada na web.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-stage">
+        <canvas id="preview-canvas"></canvas>
+      </div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <p id="preview-empty" class="field-summary">Adicione um SVG e ele aparece aqui.</p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Rasterizar</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Prontos</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Baixar tudo num zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/svg-to-image.toml
+++ b/locales/pt/tools/svg-to-image.toml
@@ -1,0 +1,317 @@
+#
+# SVG para imagem - português do Brasil.
+#
+# Overrides for tools/svg-to-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "SVG para imagem"
+heading = "SVG&nbsp;para&nbsp;imagem <span class=\"h1-kw\">&mdash; rasterizar um vetor em PNG, JPEG ou WebP em qualquer tamanho</span>"
+tagline = "Diga o tamanho. Um vetor não tem tamanho próprio a perder."
+
+title = "SVG para PNG &mdash; rasterize um vetor em qualquer tamanho, sem envio"
+description = "Converta um SVG em PNG, JPEG ou WebP em qualquer tamanho, no seu navegador. Diga a largura, um multiplicador ou uma caixa; leve também as cópias @2x e @3x. Transparência mantida, nada enviado."
+og_title = "Transforme um SVG em PNG em qualquer tamanho, sem enviá-lo"
+og_description = "Um vetor não tem tamanho em pixels próprio, então o número é escolha sua - 32 ou 8000, com a mesma nitidez nos dois casos. Tudo roda na sua própria máquina."
+og_image_alt = "SVG para imagem - rasterize um vetor em PNG, JPEG ou WebP em qualquer tamanho"
+
+pledge = """
+    O desenho é rasterizado pelo mesmo motor que acabou de colocá-lo na sua
+    tela. O seu arquivo é lido do seu disco, a tag raiz dele é reescrita para o
+    tamanho que você pediu por cem linhas em <code>src/svg.js</code> que você
+    pode ler, e ele é desenhado num canvas que o seu navegador já traz. Esta
+    ferramenta não tem função de rede de espécie alguma &mdash; nada a buscar,
+    nada a enviar &mdash; e não existe do outro lado desta página servidor nenhum
+    para onde mandar uma logomarca, mesmo que houvesse caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e rasterize alguma coisa. Nenhuma requisição leva um arquivo, uma
+      miniatura, um nome de arquivo ou um byte do que você escolheu. Ou desconecte
+      da internet e converta um mesmo assim."""
+
+read_first = """
+, <code>src/svg.js</code> para como o tamanho
+      próprio de um arquivo é lido e como a tag raiz dele é reescrita, e
+      <code>src/render.js</code> para as oito linhas que fazem a rasterização
+      &mdash; um &lt;img&gt;, um <code>drawImage</code> e um
+      <code>toBlob</code>, sem nada no meio."""
+
+howto_heading = "Como converter um SVG em PNG sem enviá-lo"
+
+card = """
+            Um SVG não tem tamanho em pixels próprio, então o número é escolha
+            sua &mdash; 32 ou 8000, e a mesma nitidez nos dois casos."""
+
+[words]
+plural = "arquivos SVG"
+choose = "um SVG"
+analytics_extra = """, nem nenhum dos
+  tamanhos, formatos ou nomes de arquivo que esta ferramenta calcula"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca d'água"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "Sua arte não tem para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      seus arquivos pudessem ser coletados, e não existe no código nada que os
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Não existe
+      <code>fetch</code>, nem <code>XMLHttpRequest</code>, nem
+      <code>sendBeacon</code> em lugar nenhum de <code>src/</code>. O
+      rasterizador inteiro é um <code>&lt;img&gt;</code> segurando um blob do seu
+      próprio arquivo, um <code>drawImage</code> num canvas e um
+      <code>canvas.toBlob</code>."""
+
+[[privacy]]
+title = "Um SVG é um documento, e este é o modo em que ele não consegue agir."
+body = """
+ Um SVG pode carregar um
+      <code>&lt;script&gt;</code>, um
+      <code>&lt;image href=&quot;https://&hellip;&quot;&gt;</code> remoto, uma
+      folha de estilo e uma fonte da web. Desenhado por meio de um
+      <code>&lt;img&gt;</code> ele está no que a especificação chama de
+      <em>modo estático seguro</em>: o script não roda e nenhum daqueles
+      endereços é buscado. Essa é uma garantia do navegador, não uma promessa
+      nossa, e é o motivo de esta página conseguir abrir um arquivo que nunca viu
+      sem que o arquivo consiga dar notícia a ninguém."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google, e o botão de doação vem do Buy Me a
+      Coffee. Nenhum deles recebe coisa alguma sobre o seu desenho. Toda linha que
+      lê, dimensiona ou desenha um arquivo é servida desta origem e está listada
+      no repositório."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua
+      igual, porque nunca houve uma etapa de rede nela. Essa é a prova mais
+      simples de todas."""
+
+[[howto]]
+title = "Escolha o SVG."
+body = """
+ Arraste um até o seletor, ou escolha uma pasta
+      cheia deles e converta o lote de uma vez. O arquivo é lido direto do seu
+      disco pelo navegador; nada é mandado para lugar nenhum enquanto você faz
+      isso. Cada linha diz que tamanho o arquivo acha que tem &mdash; e diz de
+      outro jeito quando aquele tamanho veio do <code>viewBox</code>, ou foi
+      presumido porque o arquivo não declara nenhum."""
+
+[[howto]]
+title = "Diga de que tamanho."
+body = """
+ Um multiplicador do tamanho próprio do
+      arquivo é a resposta mais rápida e a certa para um lote: cada desenho é
+      escalado a partir do próprio ponto de partida, então um conjunto de ícones
+      continua em proporção. Fora isso, diga uma largura, uma altura, o lado maior,
+      ou uma caixa com os dois lados. Aqui não há penalidade por um número grande,
+      como haveria com uma fotografia &mdash; o desenho é redesenhado naquele
+      tamanho, não esticado até ele."""
+
+[[howto]]
+title = "Acrescente as cópias de alta densidade, se precisar delas."
+body = """
+ Um celular e um notebook Retina desenham
+      dois ou três pixels de aparelho para cada pixel de CSS, então uma logomarca
+      de 200 pixels precisa de um arquivo de 400 ou 600 pixels por trás. Peça
+      <code>@2x</code> e <code>@3x</code> e elas saem nomeadas do jeito que o
+      Xcode, as ferramentas do Android e o <code>image-set()</code> do CSS
+      esperam, e cada uma é exatamente o dobro ou o triplo da primeira, em vez de
+      arredondada à parte."""
+
+[[howto]]
+title = "Escolha o formato e decida sobre a transparência."
+body = """
+ PNG, a menos que você tenha um
+      motivo: é sem perdas, mantém a transparência, e cor chapada comprime bem
+      nele. O JPEG não tem transparência nenhuma, então uma cor de fundo é
+      pintada quer você escolha uma ou não &mdash; sem ela, cada pixel
+      transparente sai preto. O WebP faz as duas coisas e gera um arquivo menor,
+      ao custo de software velho o bastante para não lê-lo."""
+
+[[howto]]
+title = "Olhe a pré-visualização antes de baixar."
+body = """
+ Ela é desenhada pelo mesmo código que
+      escreve o arquivo, a partir do seu arquivo, na sua máquina. Duas coisas
+      mudam quando um desenho vira pixels, e as duas aparecem aqui: um fio de
+      cabelo que tinha meio pixel de largura fica cinza, e qualquer texto é
+      desenhado com uma fonte que este computador tem, e não com uma buscada na
+      web."""
+
+[[howto]]
+title = "Leve os arquivos."
+body = """
+ Um download por arquivo, ou o lote inteiro como
+      um zip só. Os nomes seguem o SVG de onde vieram, com <code>@2x</code> e
+      <code>@3x</code> nas cópias, e dois arquivos que teriam o mesmo nome são
+      numerados em vez de um substituir o outro em silêncio."""
+
+[[faq]]
+q = "Meu SVG é enviado para algum lugar?"
+a = """
+        Não. O arquivo é lido pelo seu próprio navegador no seu próprio hardware,
+        desenhado num canvas pelo mesmo motor que renderiza qualquer outra imagem
+        que você vê, e devolvido como download. Esta ferramenta não tem função de
+        rede de espécie alguma &mdash; nunca busca nada e nunca manda nada &mdash;
+        e a <code>Content-Security-Policy</code> da página nomeia todos os
+        endereços que ela pode contatar, nenhum dos quais é deste site."""
+
+[[faq]]
+q = "Em que tamanho eu deveria rasterizar um SVG?"
+a = """
+        No que a coisa que vai lê-lo pedir, multiplicado pela densidade de pixels
+        da tela em que ele vai ser visto. Uma logomarca que ocupa 200 pixels de CSS
+        precisa de 400 num notebook Retina e de 600 num celular recente, que é o
+        que as cópias <code>@2x</code> e <code>@3x</code> daqui são. Para um ícone
+        de aplicativo ou uma ficha de loja, a loja nomeia um número exato e é esse
+        o número. Quando ninguém lhe disse nada, 1024 no lado maior é um padrão
+        útil: grande o bastante para quase qualquer uso e pequeno o bastante para
+        mandar por e-mail."""
+
+[[faq]]
+q = "Deixar maior perde qualidade?"
+a = """
+        Não, e este é o único lugar onde essa resposta é honestamente não. Um vetor
+        é instrução em vez de pixel, então o navegador desenha as curvas de novo no
+        tamanho que for pedido. 4000 pixels a partir de um ícone de 24 pixels é
+        exatamente tão nítido quanto 24 era. O que você não pode é ir no sentido
+        contrário: assim que virou PNG é pixel como qualquer outra coisa, então
+        rasterize no tamanho de que você precisa em vez de redimensionar o
+        resultado depois."""
+
+[[faq]]
+q = "Meu SVG não tem width nem height. Que tamanho eu recebo?"
+a = """
+        O do <code>viewBox</code>, se houver um &mdash; a largura e a altura dele
+        são unidades de usuário e não pixels, mas são os únicos números do arquivo
+        e um navegador os trata como o tamanho natural do desenho. Se também não
+        houver viewBox, a página diz <em>presumido</em> ao lado da linha e usa
+        300&nbsp;&times;&nbsp;150, que é o tamanho em que um
+        <code>&lt;img&gt;</code> o teria desenhado. De todo jeito, você pode dizer
+        o tamanho que quer e o arquivo é desenhado naquele."""
+
+[[faq]]
+q = "Por que o texto ficou diferente no PNG?"
+a = """
+        Porque a fonte não está no SVG. Um SVG que desenha texto nomeia uma fonte e
+        deixa a máquina encontrá-la, e um arquivo que puxa uma do Google Fonts com
+        um <code>@import</code> não recebe nada aqui: um SVG desenhado por meio de
+        um <code>&lt;img&gt;</code> não tem permissão de buscar coisa alguma, que é
+        a mesma regra que o impede de dar notícia a alguém com o seu arquivo. O
+        conserto é o que todo designer já sabe &mdash; converta o texto em traçados
+        no programa de desenho antes de exportar. Aí vira geometria, e fica igual em
+        todo lugar."""
+
+[[faq]]
+q = "Ele consegue converter vários arquivos de uma vez?"
+a = """
+        Sim. Todo SVG da lista é renderizado com os mesmos ajustes e o lote desce
+        como um zip só. Um multiplicador &mdash; &ldquo;4&times; o tamanho que o
+        arquivo pede&rdquo; &mdash; costuma ser o ajuste certo para um lote, porque
+        cada desenho é escalado a partir do próprio tamanho em vez de todos serem
+        forçados ao mesmo número de pixels. Clique em qualquer linha para pôr aquele
+        na pré-visualização."""
+
+[[faq]]
+q = "Existe limite de tamanho?"
+a = """
+        O do navegador, não o nosso. Um canvas desiste em algum ponto acima de
+        16.384 pixels de lado, e o Safari num iPhone ou iPad para em cerca de 16,7
+        megapixels de área &mdash; 4096&nbsp;&times;&nbsp;4096. Acima disso a página
+        avisa você em vez de devolver uma imagem em branco, que é o que um navegador
+        faz quando não dá conta: o <code>toBlob</code> não devolve nada, sem erro
+        nenhum para se explicar. Passando de 100 megapixels a ferramenta recusa,
+        porque isso são 400&nbsp;MB de canvas antes de um byte ser codificado."""
+
+[[faq]]
+q = "O que acontece com a transparência?"
+a = """
+        Ela é mantida, em PNG e em WebP. O JPEG não tem canal alfa nenhum, então uma
+        cor é pintada atrás da imagem inteira, você pedindo uma ou não &mdash; sem
+        ela, tudo o que é transparente sairia preto, o que parece um defeito em vez
+        de parecer JPEG. Escolher uma cor de fundo com PNG também é uma coisa
+        perfeitamente comum de se querer: isso achata o desenho sobre aquela cor em
+        vez de deixar um buraco."""
+
+[[faq]]
+q = "Ele consegue ler um SVG que contém um script ou uma imagem externa?"
+a = """
+        Consegue ler um, e vai desenhar exatamente as partes que um navegador se
+        dispõe a desenhar. Um SVG carregado por meio de um <code>&lt;img&gt;</code>
+        está em <em>modo estático seguro</em>: scripts não rodam, referências
+        externas não são buscadas, e animação não toca &mdash; o primeiro quadro é o
+        que você recebe. Então um arquivo com um <code>&lt;image&gt;</code> remoto
+        sai com aquela parte faltando. É o navegador recusando em seu nome, e é o
+        motivo de esta página conseguir abrir com segurança um arquivo que nunca
+        viu."""
+
+[[faq]]
+q = "Qual a diferença entre isto e o Redimensionador de imagens?"
+a = """
+        A origem. O Redimensionador de imagens parte de pixels &mdash; um JPEG, um
+        PNG &mdash; então deixar maior obriga a inventar detalhe que nunca esteve
+        lá. Este parte de um desenho, então não há o que inventar e não há limite
+        superior que valha a preocupação. Se o que você tem é um SVG, é este que lhe
+        dá um resultado nítido; se o que você tem é uma fotografia, é aquele."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. Também não há limite para o número ou o tamanho dos arquivos,
+        porque não há servidor pagando por eles &mdash; o trabalho acontece na sua
+        própria máquina. O site exibe publicidade, e é ela que paga a conta; os
+        anúncios não recebem nada sobre os seus arquivos."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, então desconecte da internet e ela continua
+        funcionando. Esse é também o jeito mais simples de provar que nada está
+        sendo enviado: uma ferramenta que mandasse a sua arte embora para ser
+        renderizada pararia no instante em que você tirasse da tomada."""
+
+[schema]
+description = "Rasterize um SVG em PNG, JPEG ou WebP em qualquer tamanho, dentro do navegador. Defina o tamanho por um multiplicador, uma largura, uma altura, o lado maior ou uma caixa, acrescente cópias @2x e @3x, mantenha ou achate a transparência, e converta um lote de uma vez. Nada é enviado."
+features = [
+  "Renderiza o vetor de novo em cada tamanho, então o resultado é nítido em todos eles",
+  "Tamanho por multiplicador, largura, altura, lado maior, ou uma caixa com um encaixe",
+  "Cópias @2x e @3x, cada uma um múltiplo exato da primeira em vez de arredondada duas vezes",
+  "PNG, JPEG e WebP, com a transparência mantida ou achatada sobre uma cor",
+  "Lê o tamanho de width, height ou do viewBox, e diz qual deles usou",
+  "Avisa antes de um tamanho que o canvas de um navegador não consegue produzir",
+  "Pré-visualização desenhada pelo mesmo código que escreve o arquivo",
+  "Trabalha em lote, com todos os resultados num zip",
+  "Scripts e referências remotas dentro do arquivo nunca são executados nem buscados",
+  "Roda offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste um SVG para cá"
+hint = "ou clique para escolher &mdash; vários de uma vez também serve"

--- a/locales/pt/tools/trim-video.html
+++ b/locales/pt/tools/trim-video.html
@@ -1,0 +1,224 @@
+<main>
+  <!-- Passo 1 &mdash; o vídeo -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha um vídeo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <!-- One row a video, in the order they will be joined. Hidden until there
+         is more than one, because a list of one is furniture. -->
+    <ol class="clip-list" id="clip-list" hidden></ol>
+
+    <p id="join-note" class="path-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; as marcações -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> Marque os trechos que você quer
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Toque o vídeo inteiro e aperte <kbd>I</kbd> onde um trecho deve começar e
+      <kbd>O</kbd> onde ele deve terminar. Faça isso quantas vezes quiser &mdash;
+      cada par vira uma linha abaixo, e o vídeo pronto são essas linhas, uma
+      depois da outra. <kbd>U</kbd> desfaz a última, <kbd>Espaço</kbd> toca e
+      pausa, e as setas pulam cinco segundos.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- Built by src/timeline.js: a band for every segment, the one being
+         marked, a tick for every keyframe, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Tocar</button>
+      <button type="button" id="back-5" class="ghost" title="Voltar cinco segundos">&minus;5s</button>
+      <button type="button" id="forward-5" class="ghost" title="Avançar cinco segundos">+5s</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Marcar início</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Marcar fim</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Desfazer</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Velocidade de reprodução">
+      <span class="speed-label">Velocidade</span>
+      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normal</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The segments themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Trechos <span class="segment-count" id="segment-count">nenhum ainda</span></h3>
+        <p class="segments-total">
+          Total mantido <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">#</th>
+            <th scope="col">Início</th>
+            <th scope="col">Fim</th>
+            <th scope="col">Duração</th>
+            <th scope="col"><span class="visually-hidden">Ações</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Nada marcado ainda. Aperte <kbd>I</kbd> e depois <kbd>O</kbd> enquanto
+        toca, ou use os botões acima.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Adicionar uma linha na mão</button>
+        <button type="button" id="reset-segments" class="ghost danger">Limpar todas</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">Carregar marcações&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Formato do arquivo de tempos">
+          <option value="seconds" selected>segundos</option>
+          <option value="HHMMSSmmm">HH:MM:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">Salvar marcações</button>
+      </div>
+
+      <p class="field-note">
+        As marcações são salvas como um arquivo de texto puro &mdash; uma linha
+        por trecho, no formato acima &mdash; então uma sessão longa de marcação
+        sobrevive a uma aba fechada, e o mesmo arquivo pode ser entregue a
+        qualquer ferramenta que leia aquele desenho.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>O que fazer com os trechos marcados</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Ficar com eles</strong>
+          O vídeo pronto são os trechos marcados, emendados em ordem.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Tirar fora</strong>
+          Os trechos marcados vão embora, e todo o resto é emendado.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Passo 3 &mdash; a exportação -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Apare</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="method">Como aparar</label>
+        <select id="method">
+          <option value="copy" selected>Manter cada byte &mdash; nada recodificado</option>
+          <option value="exact">Cortar exatamente aqui &mdash; recodifica a imagem</option>
+          <option value="record">Gravar enquanto toca</option>
+        </select>
+        <p class="field-note" id="method-note"></p>
+      </div>
+
+      <div class="field" id="frame-field" hidden>
+        <label for="frame">Tamanho do quadro</label>
+        <select id="frame">
+          <option value="first" selected>Acompanhar o primeiro vídeo</option>
+          <option value="largest">Acompanhar o maior</option>
+          <option value="1080p">1920 &times; 1080</option>
+          <option value="720p">1280 &times; 720</option>
+        </select>
+        <p class="field-note">
+          Um tamanho vale para o arquivo inteiro. Um vídeo de outro formato é
+          encaixado dentro dele com tarjas, nunca esticado.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualidade</label>
+        <select id="quality">
+          <option value="low">Arquivo menor</option>
+          <option value="medium" selected>Equilibrada</option>
+          <option value="high">Melhor qualidade</option>
+        </select>
+        <p class="field-note">
+          Nunca mais do que o original gastou &mdash; recodificar acima disso só
+          deixa o arquivo maior.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Manter o som
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Mantendo</dt><dd id="sum-clips">&mdash;</dd></div>
+      <div><dt>Duração final</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Começa em</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>Aproximadamente</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Imagem</dt><dd id="sum-picture">&mdash;</dd></div>
+      <div><dt>Som</dt><dd id="sum-sound">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Aparar o vídeo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Baixar o vídeo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/trim-video.toml
+++ b/locales/pt/tools/trim-video.toml
@@ -1,0 +1,325 @@
+#
+# Aparador de vídeo - português do Brasil.
+#
+# Overrides for tools/trim-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Aparar" e não "cortar": em português os dois trabalhos de vídeo deste site
+# ficariam com o mesmo verbo, e o outro - mudar o formato da imagem - é o que
+# fica com "cortar". A distinção é a mesma que o inglês faz entre trim e crop,
+# e vale mantê-la porque as duas ferramentas se citam uma à outra.
+#
+
+name = "Aparador de vídeo"
+heading = "Aparar&nbsp;vídeo <span class=\"h1-kw\">&mdash; cortar trechos de um vídeo online</span>"
+tagline = "Marque os trechos que valem a pena enquanto ele toca. Receba tudo como um vídeo só."
+
+title = "Aparar um vídeo online &mdash; fique só com os trechos que quer, sem envio"
+description = "Assista a um vídeo e marque cada trecho que vale a pena enquanto ele toca, depois salve esses trechos como um arquivo só. Roda no navegador: nada é enviado, nada é recodificado, funciona offline."
+og_title = "Aparador de vídeo &mdash; fique só com os trechos que quer, sem enviar nada"
+og_description = "Aperte I e O enquanto toca para marcar cada trecho que vale a pena. Os trechos marcados são escritos de volta como um vídeo só, quadro a quadro, sem nada ser enviado."
+og_image_alt = "Aparador de vídeo - marque os trechos que você quer e salve como um vídeo só, no navegador"
+
+pledge = """
+    Seu vídeo é lido, marcado, cortado e escrito pelo seu próprio navegador, no
+    seu próprio hardware. Nada aqui consegue buscar ou mandar coisa alguma
+    &mdash; não existe função de rede nenhuma nesta ferramenta &mdash; e não
+    existe do outro lado desta página servidor nenhum para onde mandar um vídeo,
+    mesmo que houvesse caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e apare um vídeo. Nenhuma requisição leva um quadro, um nome de
+      arquivo ou um byte do que você escolheu. Ou desconecte da internet e apare
+      um mesmo assim &mdash; uma ferramenta que mandasse o seu vídeo embora para
+      ser aparado simplesmente pararia."""
+
+read_first = """
+, <code>src/segments.js</code> para as marcações e o
+      arquivo em que elas são salvas, <code>src/demux.js</code> para o leitor que
+      acha os quadros num MP4, <code>src/ranges.js</code> para a aritmética que
+      transforma uma marcação numa sequência de amostras, e
+      <code>src/copy.js</code> para o laço que move essas amostras para o arquivo
+      novo. Nenhum deles importa qualquer coisa que consiga fazer uma
+      requisição."""
+
+howto_heading = "Como aparar um vídeo"
+
+card = """
+            Marque cada trecho que vale a pena enquanto ele toca, e salve tudo
+            como um vídeo só. Os quadros são copiados em vez de recodificados,
+            então nada se perde."""
+
+[words]
+plural = "vídeos"
+choose = "um vídeo"
+analytics_extra = """, nem nenhum
+  quadro, duração ou ponto de corte"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca d'água"
+
+[[facts]]
+text = "Quantos trechos você quiser"
+
+[[facts]]
+text = "Sem perda de qualidade"
+
+[[facts]]
+text = "Funciona offline"
+
+[[privacy]]
+title = "Seus vídeos não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      o seu arquivo pudesse ser coletado, e não existe no código nada que o
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Esta ferramenta não tem função de
+      rede nenhuma: nenhum endereço para colar, nada para baixar, nenhum motor
+      buscado no primeiro uso. Cada byte que encosta no seu vídeo veio desta
+      origem quando a página carregou."""
+
+[[privacy]]
+title = "No caminho normal, nada chega sequer a ser decodificado."
+body = """
+
+      Aparar não muda a aparência de quadro nenhum, então os quadros codificados
+      dos trechos que você marcou são movidos para o arquivo novo exatamente como
+      foram encontrados. Cada um é guardado como uma fatia do arquivo no seu disco
+      &mdash; uma anotação dizendo quais bytes, e não os bytes em si &mdash; e o
+      seu navegador os lê pela primeira vez enquanto escreve o download. Nada aqui
+      jamais transforma o seu vídeo de volta em imagem."""
+
+[[privacy]]
+title = "O arquivo de marcações é feito na página."
+body = """
+ Salvar as suas
+      marcações escreve um arquivo de texto a partir dos números que já estão na
+      tela, direto para os seus downloads. Carregar um lê o arquivo aqui. Nenhum
+      dos dois chega perto de uma rede, e nenhum dos dois carrega nada além de
+      tempos."""
+
+[[privacy]]
+title = "O som é copiado, não escutado."
+body = """
+ Nos dois caminhos de MP4, as
+      amostras de áudio são movidas sem serem decodificadas &mdash; nada aqui
+      jamais as transforma de volta em som, e nada conseguiria passá-las a lugar
+      nenhum se transformasse."""
+
+[[privacy]]
+title = "Onde quadros são decodificados, isso acontece aqui."
+body = """
+ O corte
+      exato, e a pré-visualização de um arquivo que este navegador não toca, passam
+      pelo WebCodecs na sua própria máquina. É o mesmo decodificador que lhe
+      mostraria o vídeo de qualquer jeito, rodando no mesmo lugar."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google. Nenhum dos dois recebe coisa alguma
+      sobre o seu vídeo: nem um arquivo, nem um quadro, nem um nome, um tamanho,
+      uma duração ou onde você cortou. Toda linha que lê, corta e escreve é
+      servida desta origem e está listada no repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não é entregue a ele."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; do cabeçalho é desenhado por um
+      script vindo de cdnjs.buymeacoffee.com e busca as letras dele no Google
+      Fonts. É um link e nada mais: ele não reporta visita nenhuma, e não recebe
+      nada sobre você nem sobre o seu vídeo."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e tudo nesta página continua
+      funcionando. Essa é a prova mais simples de todas."""
+
+[[howto]]
+title = "Escolha um vídeo."
+body = """
+ Arraste um MP4, MOV, M4V ou WebM até o
+      seletor. Ele é lido direto do seu disco pelo navegador; nada é mandado para
+      lugar nenhum enquanto você faz isso. Arraste vários e eles são emendados, na
+      ordem em que você os colocou."""
+
+[[howto]]
+title = "Toque, e marque os trechos que você quer."
+body = """
+ Aperte
+      <kbd>I</kbd> onde um trecho deve começar e <kbd>O</kbd> onde ele deve
+      terminar. Faça isso quantas vezes quiser &mdash; cada par vira uma linha na
+      tabela de baixo, e uma faixa na linha do tempo. <kbd>U</kbd> desfaz o
+      último, <kbd>Espaço</kbd> toca e pausa, e as setas pulam cinco segundos por
+      vez. Diminua a velocidade de reprodução se o momento for difícil de
+      pegar."""
+
+[[howto]]
+title = "Acerte as marcações."
+body = """
+ Cada linha pode ser reproduzida sozinha,
+      retemporizada digitando um tempo exato nela, movida para cima ou para baixo
+      na ordem, ou apagada. As duas pontas do trecho selecionado também podem ser
+      arrastadas ao longo da linha do tempo. O total lá em cima é o que o vídeo
+      pronto vai durar."""
+
+[[howto]]
+title = "Fique com eles, ou tire-os fora."
+body = """
+ Ficar é o sentido de
+      sempre: o vídeo pronto são os trechos que você marcou, emendados em ordem.
+      Tirá-los fora é o outro trabalho que as pessoas querem e raramente acham
+      &mdash; marque os comerciais, os silêncios ou as tentativas falhas, e o que
+      sobra é emendado sem eles."""
+
+[[howto]]
+title = "Apare, e baixe."
+body = """
+ &ldquo;Manter cada byte&rdquo; move os
+      quadros intocados: rápido, e não tem como custar qualidade, mas cada trecho
+      começa no keyframe anterior à sua marcação. &ldquo;Cortar exatamente
+      aqui&rdquo; decodifica e escreve a imagem de novo, para que cada trecho
+      comece no quadro que você escolheu. A página diz qual dos dois você está
+      prestes a receber, e o que isso custa, antes de você apertar o botão."""
+
+[[faq]]
+q = "Meu vídeo é enviado para algum lugar?"
+a = """
+        Não. Ele é lido, marcado, cortado e escrito pelo seu próprio navegador no
+        seu próprio hardware. Não existe lado de servidor nesta ferramenta, e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar &mdash; nenhum deles é deste site. Desconecte da internet e
+        apare um vídeo mesmo assim, se preferir conferir a acreditar."""
+
+[[faq]]
+q = "Posso ficar com vários trechos do mesmo vídeo?"
+a = """
+        É para isso que isto serve. Aperte <kbd>I</kbd> e <kbd>O</kbd> quantas vezes
+        quiser enquanto ele toca; cada par vira uma linha, e o vídeo pronto é cada
+        linha emendada em ordem, com todo o resto fora. A maioria dos aparadores
+        online lhe dá um par de alças e pergunta qual trecho único manter, o que
+        serve para aparar a ponta de um clipe e não serve de nada para assistir a
+        uma hora de gravação uma vez e ficar com os seis momentos que prestam."""
+
+[[faq]]
+q = "Aparar perde qualidade?"
+a = """
+        Não no caminho normal, e não do jeito que importa. Aparar não muda a
+        aparência de quadro nenhum, então os quadros são movidos para o arquivo novo
+        exatamente como estavam: os mesmos bytes, os mesmos ajustes de codificador,
+        tudo igual. O único caminho daqui que recodifica alguma coisa é o corte
+        exato, e ele diz isso no botão."""
+
+[[faq]]
+q = "Por que um trecho começa antes de onde eu marquei?"
+a = """
+        Por causa de como o vídeo é guardado, e só em reprodutores que ignoram uma
+        parte padronizada do formato. A maioria dos quadros é guardada como uma
+        descrição de como eles diferem dos vizinhos, então não podem ser
+        decodificados sem eles; só um keyframe se sustenta sozinho, e os keyframes
+        ficam tipicamente de um a dez segundos de distância. Um corte que copia
+        quadros precisa, portanto, carregar a sequência a partir do keyframe
+        anterior à sua marcação &mdash; e o arquivo diz <em>comece a tocar na sua
+        marcação</em>, o que todo reprodutor mais usado respeita. Se você precisa
+        que seja exato em todo reprodutor, escolha &ldquo;Cortar exatamente
+        aqui&rdquo;, que recodifica. A página lhe diz em qual caso você está, e por
+        quanto, antes de exportar."""
+
+[[faq]]
+q = "Posso tirar os comerciais em vez disso?"
+a = """
+        Pode. Marque-os e escolha &ldquo;Tirar fora&rdquo;: tudo o que você
+        <em>não</em> marcou é emendado, em ordem. A mesma lista de marcações
+        responde às duas perguntas, então você pode alternar entre elas e ver a
+        duração mudar sem marcar nada duas vezes."""
+
+[[faq]]
+q = "Posso salvar minhas marcações e voltar a elas depois?"
+a = """
+        Pode. &ldquo;Salvar marcações&rdquo; escreve um arquivo de texto puro
+        &mdash; uma linha por trecho, um início e um fim separados por vírgula
+        &mdash; e &ldquo;Carregar marcações&rdquo; lê um de volta. Dois formatos são
+        oferecidos, segundos simples e <code>HH:MM:SS.mmm</code>, e os dois seguem o
+        mesmo desenho que outras ferramentas do gênero já usam, então um arquivo
+        escrito aqui pode ser entregue a uma delas e um arquivo escrito lá pode ser
+        jogado nesta página. Marcar é trabalho cuidadoso e ninguém deveria ter que
+        fazer duas vezes."""
+
+[[faq]]
+q = "Quais formatos de vídeo posso aparar?"
+a = """
+        MP4, M4V e MOV são lidos diretamente, seja lá o que houver dentro deles:
+        H.264, HEVC, AV1 ou VP9. Copiar quadros não envolve decodificá-los, então
+        esse caminho funciona até para um codec para o qual o seu navegador não tem
+        decodificador nenhum. Qualquer outra coisa que o seu navegador consiga tocar
+        &mdash; WebM mais obviamente &mdash; é aparada tocando o arquivo e gravando
+        o resultado, o que funciona, leva o mesmo tempo que o resultado dura, e só
+        consegue manter um trecho. Um arquivo que o navegador não consegue nem ler
+        nem tocar, o que na prática significa AVI, WMV, FLV e a maioria dos MKVs, é
+        recusado com uma mensagem dizendo isso, em vez de falhar no meio do
+        caminho."""
+
+[[faq]]
+q = "Existe limite de tamanho ou de duração do vídeo?"
+a = """
+        Não há limite embutido na ferramenta, e no caminho de cópia o arquivo mal é
+        lido: os quadros que você mantém são apontados em vez de carregados, então
+        ficar com quatro minutos de uma gravação de quatro gigabytes custa mais ou
+        menos o que custa escrever esses quatro minutos no disco. O corte exato
+        percorre o arquivo em fatias de alguns megabytes. De todo jeito o teto
+        prático é o arquivo pronto, que é montado na memória antes de você
+        baixá-lo."""
+
+[[faq]]
+q = "O som sobrevive?"
+a = """
+        Nos dois caminhos de MP4 ele é copiado amostra por amostra sem nunca ser
+        decodificado, então é byte a byte o que estava no arquivo, e um marcador de
+        edição mantém cada trecho alinhado com a imagem dele dentro de um milésimo
+        de segundo. A única exceção é emendar vídeos separados cujo som é descrito
+        de formas diferentes &mdash; taxas de amostragem diferentes, por exemplo
+        &mdash; onde não há como pôr os dois numa trilha só sem decodificá-los, e a
+        página diz isso antes de fazer. No caminho da gravação, ele é capturado da
+        reprodução e codificado de novo. De qualquer jeito, existe uma caixinha para
+        deixá-lo de fora por completo."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. O site exibe publicidade, e é ela que paga a conta; os anúncios não
+        recebem nada sobre o seu vídeo."""
+
+[schema]
+browser_requirements = "Requer JavaScript. Copiar quadros não precisa de suporte a codec de vídeo nenhum; o corte exato precisa de um navegador com WebCodecs, e outros formatos recuam para gravação."
+description = "Marque quantos trechos quiser de um vídeo enquanto ele toca, e salve esses trechos como um arquivo só - ou tire-os fora e fique com o resto. MP4, MOV e M4V são aparados movendo os quadros codificados para um arquivo novo, intocados, com o áudio original levado adiante amostra por amostra; nada é enviado e nada é recodificado."
+features = [
+  "Marca quantos trechos você quiser, com I e O, enquanto o vídeo toca",
+  "Emenda os trechos marcados num arquivo só, na ordem que você escolher",
+  "Ou tira os trechos marcados fora, mantendo todo o resto",
+  "Apara sem recodificar, então nenhuma qualidade se perde",
+  "Salva e recarrega as marcações como um arquivo de texto com os tempos",
+  "Marcações com precisão de quadro, com os keyframes mostrados na linha do tempo",
+  "Mantém o áudio original sem recodificá-lo",
+  "Roda offline; sem envio, sem conta, sem marca d'água",
+]
+
+[picker]
+title = "Arraste um vídeo para cá"
+hint = "ou clique para escolher &mdash; MP4, MOV, M4V, WebM. Arraste vários para emendá-los."

--- a/locales/pt/tools/video-to-gif.html
+++ b/locales/pt/tools/video-to-gif.html
@@ -1,0 +1,169 @@
+<main>
+  <!-- Passo 1 &mdash; o arquivo -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha um vídeo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Arquivo</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Tamanho</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Quadro</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Duração</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Vídeo</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Lido por</dt><dd id="src-path">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; o trecho -->
+  <section class="card" id="section-card" hidden>
+    <h2><span class="step">2</span> Escolha o trecho</h2>
+
+    <p class="hint">
+      Toque o clipe e marque a parte que você quer. <kbd>I</kbd> põe o início
+      onde o cursor de reprodução está, <kbd>O</kbd> põe o fim, e as duas alças
+      da barra podem ser arrastadas.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- The bar itself is built by src/range.js. -->
+    <div id="rangebar"></div>
+    <div class="rb-scale">
+      <span>0:00.000</span>
+      <span id="scale-end">&mdash;</span>
+    </div>
+
+    <div class="marks">
+      <label>Início
+        <input type="text" id="start-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-in" class="ghost" title="Pôr o início onde o cursor de reprodução está (I)">
+        Marcar no cursor
+      </button>
+
+      <label>Fim
+        <input type="text" id="end-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-out" class="ghost" title="Pôr o fim onde o cursor de reprodução está (O)">
+        Marcar no cursor
+      </button>
+
+      <div class="mark-actions">
+        <button type="button" id="play-section" class="ghost">Tocar o trecho</button>
+        <button type="button" id="whole-clip" class="ghost">Clipe inteiro</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; o GIF -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Tamanho e taxa de quadros</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="width">Largura</label>
+        <select id="width">
+          <option value="240">240 px</option>
+          <option value="320">320 px</option>
+          <option value="480" selected>480 px</option>
+          <option value="640">640 px</option>
+          <option value="source">Tamanho original</option>
+          <option value="custom">Exatamente&hellip;</option>
+        </select>
+        <p class="field-note">
+          A altura acompanha, então o formato nunca muda. A largura é o que um
+          GIF custa: metade da largura é um quarto dos pixels.
+        </p>
+        <p class="field-note" id="width-note" hidden></p>
+      </div>
+
+      <div class="field" id="custom-width-field" hidden>
+        <label for="custom-width">Largura exata</label>
+        <input type="number" id="custom-width" min="16" max="1920" step="1" value="480">
+        <p class="field-note">Em pixels, entre 16 e 1920.</p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Quadros por segundo</label>
+        <select id="fps">
+          <option value="5">5 &mdash; o menor</option>
+          <option value="10">10</option>
+          <option value="12" selected>12 &mdash; suave o bastante</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+          <option value="25">25 &mdash; o mais suave</option>
+        </select>
+        <p class="field-note">
+          Não é a taxa do próprio vídeo: os quadros são amostrados dele. Doze se
+          lê como movimento; acima de vinte o arquivo cresce mais rápido do que a
+          suavidade aparece.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Dithering</label>
+        <select id="dither">
+          <option value="on" selected>Ligado &mdash; gradientes mais suaves</option>
+          <option value="off">Desligado &mdash; mais chapado, menor</option>
+        </select>
+        <p class="field-note">
+          Mistura duas cores da paleta onde a certa está faltando. Ordenado, para
+          um fundo parado não fervilhar.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="loop">
+          <input type="checkbox" id="loop" checked>
+          Repetir para sempre
+        </label>
+        <p class="field-note">Desligado toca uma vez e para.</p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Trecho</dt><dd id="sum-section">&mdash;</dd></div>
+      <div><dt>Saída</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Quadros</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Tamanho aproximado</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="memory-note" class="field-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Fazer o GIF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <img id="result-image" alt="A animação pronta, tocando">
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Baixar o GIF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/pt/tools/video-to-gif.toml
+++ b/locales/pt/tools/video-to-gif.toml
@@ -1,0 +1,255 @@
+#
+# Vídeo para GIF - português do Brasil.
+#
+# Overrides for tools/video-to-gif/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Dithering" e "LZW" ficam em inglês: são os nomes das técnicas em qualquer
+# documentação que o leitor vá encontrar depois, e "pontilhamento" mandaria
+# alguém procurar por uma palavra que ninguém usa.
+#
+
+name = "Vídeo para GIF"
+heading = "Vídeo&nbsp;para&nbsp;GIF <span class=\"h1-kw\">&mdash; converter um vídeo em GIF</span>"
+tagline = "Escolha o trecho, o tamanho e a taxa de quadros."
+
+title = "Conversor de vídeo para GIF &mdash; grátis, sem envio, funciona offline"
+description = "Transforme um trecho de um MP4, MOV ou WebM num GIF animado. Escolha o trecho, a largura e a taxa de quadros; os quadros são lidos e o GIF é escrito no seu navegador. Nada é enviado."
+og_title = "Vídeo para GIF &mdash; faça um GIF sem enviar o clipe"
+og_description = "Marque os segundos que você quer, escolha uma largura e uma taxa de quadros, e receba um GIF animado. A amostragem dos quadros, a paleta, o dithering e o LZW são todos feitos na sua própria máquina."
+og_image_alt = "Vídeo para GIF - faça um GIF animado no navegador, sem nada ser enviado"
+
+pledge = """
+    Cada quadro é lido, redimensionado, quantizado e escrito pelo seu próprio
+    navegador, no seu próprio hardware. Nada aqui consegue buscar ou mandar coisa
+    alguma &mdash; não existe função de rede nenhuma nesta ferramenta &mdash; e
+    não existe do outro lado desta página servidor nenhum para onde mandar um
+    vídeo, mesmo que houvesse caminho."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas de desenvolvedor, olhe a
+      aba Rede e faça um GIF. Nenhuma requisição leva um quadro, um nome de
+      arquivo ou um byte do que você escolheu. Ou desconecte da internet e faça um
+      mesmo assim &mdash; uma ferramenta que mandasse o seu vídeo embora para ser
+      convertido simplesmente pararia."""
+
+read_first = """
+, <code>src/frames.js</code> para as duas maneiras
+      pelas quais os quadros são lidos de um vídeo, <code>src/quantize.js</code>
+      para a paleta, e <code>src/gif.js</code> para o arquivo em si, LZW e tudo.
+      Nenhum deles importa qualquer coisa que consiga fazer uma requisição."""
+
+howto_heading = "Como transformar um vídeo em GIF"
+
+card = """
+            Marque os segundos que você quer, escolha uma largura e uma taxa de
+            quadros, e receba um GIF animado &mdash; com paleta, dithering e
+            tudo."""
+
+[words]
+plural = "vídeos"
+choose = "um vídeo"
+analytics_extra = """, nem nenhum
+  quadro, duração ou tamanho"""
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca d'água"
+
+[[facts]]
+text = "Qualquer duração"
+
+[[facts]]
+text = "Funciona offline"
+
+[[privacy]]
+title = "Seus vídeos não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy nomeia todos os endereços que esta página pode
+      contatar, e nenhum deles é deste site. Não existe aqui um ponto final onde
+      o seu arquivo pudesse ser coletado, e não existe no código nada que o
+      mandaria se existisse."""
+
+[[privacy]]
+title = "Nada aqui busca coisa alguma."
+body = """
+ Esta ferramenta não tem função de
+      rede nenhuma: nenhum endereço para colar, nada para baixar, nenhum motor
+      buscado no primeiro uso. Cada byte que encosta no seu vídeo veio desta
+      origem quando a página carregou."""
+
+[[privacy]]
+title = "A decodificação é local."
+body = """
+ Os quadros passam pelo WebCodecs no seu
+      próprio navegador, ou pelo mesmo motor de reprodução que lhe mostraria o
+      clipe de qualquer jeito. Qual dos dois foi usado fica escrito no alto da
+      página, porque isso muda como os quadros são escolhidos e você deveria poder
+      ver."""
+
+[[privacy]]
+title = "O GIF é escrito aqui, em código que você pode ler."
+body = """
+ A
+      paleta, o dithering e a compressão LZW são umas seiscentas linhas na pasta
+      desta própria ferramenta. Não existe serviço de codificação, nem biblioteca
+      buscada em tempo de execução, nem lugar nenhum em nada disso para onde uma
+      imagem pudesse ser mandada."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não é entregue a ele."
+body = """
+ Os scripts de
+      publicidade e de medição vêm do Google. Nenhum dos dois recebe coisa alguma
+      sobre o seu vídeo: nem um arquivo, nem um quadro, nem um nome, um tamanho,
+      uma duração ou o trecho que você marcou. Toda linha que lê, amostra,
+      quantiza ou codifica é servida desta origem e está listada no
+      repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não é entregue a ele."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; do cabeçalho é desenhado por um
+      script vindo de cdnjs.buymeacoffee.com e busca as letras dele no Google
+      Fonts. É um link e nada mais: ele não reporta visita nenhuma, e não recebe
+      nada sobre você nem sobre o seu vídeo."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e tudo nesta página continua
+      funcionando. Essa é a prova mais simples de todas."""
+
+[[howto]]
+title = "Escolha um vídeo."
+body = """
+ Arraste um MP4, MOV, M4V ou WebM até o
+      seletor, ou escolha um na mão. Ele é lido direto do seu disco pelo
+      navegador; nada é mandado para lugar nenhum enquanto você faz isso."""
+
+[[howto]]
+title = "Marque o trecho."
+body = """
+ Toque o clipe e aperte <kbd>I</kbd> onde ele
+      deve começar e <kbd>O</kbd> onde ele deve terminar, ou arraste as alças na
+      barra. Um GIF tem poucos segundos &mdash; este é o ajuste que decide se o
+      arquivo é pequeno ou enorme, muito mais que os outros dois."""
+
+[[howto]]
+title = "Escolha a largura e a taxa de quadros."
+body = """
+ 480 pixels de
+      largura e 12 quadros por segundo servem para a maior parte do que um GIF
+      serve. Cortar a largura pela metade deixa os pixels em um quarto; doze
+      quadros por segundo se leem como movimento sem pagar pelos quadros que
+      ninguém vê."""
+
+[[howto]]
+title = "Faça, e baixe."
+body = """
+ Os quadros são lidos, uma paleta de 256 cores é
+      escolhida para a animação inteira, e cada quadro é escrito como só a parte
+      da imagem que mudou. Ele toca na página quando fica pronto, e é o mesmo
+      arquivo que o download lhe dá."""
+
+[[faq]]
+q = "Meu vídeo é enviado para algum lugar?"
+a = """
+        Não. Ele é lido, amostrado e convertido pelo seu próprio navegador no seu
+        próprio hardware. Não existe lado de servidor nesta ferramenta, e a
+        <code>Content-Security-Policy</code> da página nomeia todos os endereços que
+        ela pode contatar &mdash; nenhum deles é deste site. Desconecte da internet
+        e faça um GIF mesmo assim, se preferir conferir a acreditar."""
+
+[[faq]]
+q = "Quais formatos de vídeo posso converter?"
+a = """
+        MP4, M4V e MOV são lidos diretamente, seja lá o que houver dentro deles:
+        H.264, HEVC, AV1 ou VP9, desde que o seu navegador saiba decodificar aquele
+        codec. Qualquer outra coisa que o seu navegador consiga tocar &mdash; WebM
+        mais obviamente &mdash; é lida movendo o reprodutor até cada instante, o que
+        é mais lento e um pouco menos exato sobre qual quadro cai onde. Um arquivo
+        que o navegador não consegue nem ler nem tocar, o que na prática significa
+        AVI, WMV, FLV e a maioria dos MKVs, é recusado com uma mensagem dizendo
+        isso, em vez de falhar no meio do caminho."""
+
+[[faq]]
+q = "Por que o meu GIF está tão grande?"
+a = """
+        Porque GIF é um formato de 1987 que guarda imagens inteiras em vez de
+        movimento. Não há como fazer um de um clipe de cinco segundos que seja tão
+        pequeno quanto o MP4 de cinco segundos de onde ele veio &mdash; um GIF de um
+        vídeo tem rotineiramente dez vezes o tamanho do vídeo. Os três ajustes que
+        de fato decidem isso são, nesta ordem: quanto dura o trecho, quão larga é a
+        imagem, e quantos quadros por segundo. Cortar a largura pela metade deixa os
+        pixels em um quarto, e são os pixels que custam."""
+
+[[faq]]
+q = "Por que só 256 cores?"
+a = """
+        É o formato: um GIF carrega uma tabela de no máximo 256 cores e guarda cada
+        pixel como um número apontando para ela. Esta ferramenta escolhe essas 256
+        contando as cores de todos os quadros do seu trecho e dividindo-as em 256
+        grupos &mdash; corte pela mediana, o método padrão &mdash; então a paleta
+        cai bem no seu clipe em vez de ser um conjunto fixo de cores. Onde uma cor
+        está faltando, o dithering mistura as duas mais próximas para um gradiente
+        continuar sendo um gradiente em vez de virar faixas."""
+
+[[faq]]
+q = "O que o ajuste de dithering faz?"
+a = """
+        Ele troca um pouco de ruído por muito menos faixamento. Ligado, um céu que
+        de outro modo viraria quatro faixas chapadas continua um gradiente, ao custo
+        de uma textura tênue e de um arquivo maior. Desligado, a imagem fica mais
+        chapada e o arquivo menor, o que serve para gravações de tela, desenho de
+        traço e qualquer coisa já feita de cor chapada. O dithering usado aqui é
+        ordenado em vez de ser do tipo por difusão de erro, então um fundo que não
+        muda fica perfeitamente parado entre os quadros em vez de fervilhar."""
+
+[[faq]]
+q = "Existe limite de duração ou de tamanho?"
+a = """
+        O trecho é o que fica limitado, e por memória e não por regra: todo quadro
+        dele é mantido de uma vez enquanto a paleta é escolhida, então a página
+        calcula o que os seus ajustes custariam e diz isso antes de você começar.
+        Ela recusa em vez de deixar a aba ficar sem memória e sumir. Um trecho mais
+        curto, uma largura menor ou uma taxa de quadros mais baixa baixam essa
+        conta."""
+
+[[faq]]
+q = "Ele mantém o som?"
+a = """
+        Um GIF não consegue carregar som. Não existe versão do formato que tenha
+        áudio, e é o motivo principal de a web ter, na maior parte, substituído os
+        GIFs por vídeo mudo em laço. Se o som importa, fique com o vídeo &mdash; o
+        <a href="../aparar-video/">Aparador de vídeo</a> tira um trecho dele sem
+        recodificar um quadro."""
+
+[[faq]]
+q = "É grátis, e preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem período de teste, nem marca
+        d'água. O site exibe publicidade, e é ela que paga a conta; os anúncios não
+        recebem nada sobre o seu vídeo."""
+
+[schema]
+browser_requirements = "Requer JavaScript. MP4 e MOV precisam de um navegador com WebCodecs; qualquer coisa que o navegador consiga tocar funciona sem ele."
+description = "Converta um trecho de um vídeo num GIF animado dentro do navegador. Os quadros são amostrados na taxa escolhida, uma paleta de 256 cores é escolhida para a animação inteira por corte pela mediana, e cada quadro é escrito como só a região que mudou. Nada é enviado."
+features = [
+  "Converte vídeo em MP4, MOV, M4V e WebM para GIF animado",
+  "Origens em H.264, HEVC, AV1 e VP9, decodificadas pelo WebCodecs",
+  "Marque o trecho numa linha do tempo, ou digite tempos exatos",
+  "Qualquer largura, de 5 a 25 quadros por segundo, com dithering ordenado opcional",
+  "Roda offline; sem envio, sem conta, sem marca d'água",
+]
+
+[picker]
+title = "Arraste um vídeo para cá"
+hint = "ou clique para escolher &mdash; MP4, MOV, M4V, WebM, e tudo o mais que este navegador tocar"


### PR DESCRIPTION
**Stacked on #48 and must be merged after it.** The base commit here is
`a52e05f` on `claude/website-i18n-translations`; everything below that in the
diff belongs to #48. Only `locales/pt/` is mine.

## What is covered

All 1360 strings. `python build.py` no longer lists `pt`, and
`complete = true` is set, which turns every remaining fallback into a build
failure and switches on the link check for the Portuguese slugs.

- `locale.toml` — the frame, plus the 12 new slugs below
- `planned.toml` — the roadmap list
- 15 tools — `tool.toml` and `body.html` each
- 15 guides — `page.toml` and `body.html` each
- privacy and terms

66 files. Brazilian throughout: *arquivo* not *ficheiro*, *tela* not *ecrã*,
*você*, *baixar*, *celular*, *aparelho*.

## Slugs

The 22 that were already in the frame are unchanged. Twelve more, written as
the words a Brazilian would type rather than as translations of the English
slug:

| English | Portuguese | why |
|---|---|---|
| `image-to-ico` | `criar-favicon` | nobody searches for a format, they search for the job |
| `svg-to-image` | `svg-para-png` | PNG is what people actually want out |
| `heic-to-jpg` | `heic-para-jpg` | the format name is what is on the file off the iPhone |
| `image-to-data-uri` | `imagem-para-base64` | "data URI" is jargon; base64 is what gets typed |
| `qr-barcode` | `gerar-qr-code` | "gerar", not "criar" or "fazer"; the barcode half is the less-searched one |
| `video-to-gif` | `video-para-gif` | |
| `guides/make-a-favicon` | `guias/criar-um-favicon` | |
| `guides/convert-an-svg-to-png` | `guias/converter-svg-para-png` | |
| `guides/convert-heic-to-jpg` | `guias/converter-heic-para-jpg` | |
| `guides/embed-an-image-in-css` | `guias/colocar-uma-imagem-no-css` | |
| `guides/make-a-qr-code` | `guias/gerar-um-qr-code` | |
| `guides/turn-a-video-into-a-gif` | `guias/transformar-um-video-em-gif` | |

No collisions: the tool slugs sit at the root and the guides under `guias/`,
so `svg-para-png` and `guias/converter-svg-para-png` are different addresses.
Every cross-link inside a body was rewritten to the Portuguese slug, which is
what the link check now verifies.

## Two changes to the frame, both grammatical

The brief said to touch only `[slugs]` in `locale.toml`. Two sentences there
could not survive contact with a real set of tool nouns, so they were
rewritten. Both are worth a look.

**`[ui.tool].pledge_line`.** It read *"Suas {{ tool.words.plural }} nunca são
enviadas"*, and the participle agrees in gender with a noun that comes from
each tool: *enviadas* for `imagens` and `fotos`, *enviados* for `vídeos` and
`documentos`. Neither form is right for all fifteen. It is now built around a
verb that agrees with nothing:

> **Nada sai daqui** — nem {{ tool.words.plural }}. Não existe servidor.

**`[ui.picker]`.** The English `note` makes a plural by sticking a bare `s`
on the interpolated noun — `its {{ noun }}s` — which is a plural only English
makes. Portuguese pluralises *imagem* as *imagens*, so it rendered *imagems*;
and the `warning` above it put a feminine article in front of the same noun,
which would be wrong the moment a tool named a masculine one. Both sentences
now use the noun only after *qual* and *cada*, neither of which inflects for
gender or number, so the next tool to gain a `[picker.urls]` table can name
whatever it likes:

> …o seu IP e qual **{{ noun }}** você pediu. O que chega é copiado para a
> memória local na hora…
>
> O servidor precisa permitir o uso entre origens de cada **{{ noun }}**.

That frees the noun to be the accurate word: `imagem`, rather than the `foto`
I had picked purely to survive the bare `s`.

Also removed a duplicated `[[hub.categories]]` block for *Códigos e dados*:
`a52e05f` added one and this branch already had one. The surviving copy is the
one in the register of the rest of the file — "Códigos e dados" with a plain
*e*, imperative *Transforme* — matching the other three category notes.

## Calls I would like a second opinion on

- **`aparar` vs `cortar` for video.** English has trim and crop; Portuguese
  reaches for *cortar* for both. The frame had already fixed
  `trim-video` → `aparar-video` and `crop-video` → `cortar-video`, so I kept
  that and leaned on it: `crop-a-video`'s lede says "muda o formato da
  imagem" in the first line so nobody reads it as shortening. A Brazilian
  might well expect "cortar vídeo" to mean trimming.
- **"QR Code" left in English.** That is how it is said in Brazil, including
  on restaurant signage. "Código de barras" is translated, because that one
  is ordinary Portuguese.
- **`dithering` left in English** in the video-to-GIF pages, with a note in
  the file saying why: it is the word in any documentation the reader will
  meet next.
- **`favicon` left in English** — no translation is in circulation, and it is
  also the file name.
- **`guias/colocar-uma-imagem-no-css`** rather than *embutir*. *Embutir* is
  the precise word; *colocar* is what someone would type.

## Things found but not touched

- `.gitignore` ignores `/.dist-check/` but not `/dist-check/`, which is the
  path the README-ish workflow and the brief both use for a throwaway build.
  The checkpoint commit on this branch swept 530 generated files into git as
  a result; they are removed again in `b5d4e87`. Adding `/dist-check/` to
  `.gitignore` would stop it happening to the next locale, but that is
  outside `locales/pt/`.
- `templates/analytics.js` and `templates/sw.js` interpolate
  `{{ words.plural }}` into English comments, so a Portuguese build gets
  English sentences with a Portuguese noun in them. Harmless — they are
  comments in generated JS — but they are the only place the locale system
  produces mixed-language output.

## Checks

- `python build.py --clean` succeeds with `complete = true`; `pt` is absent
  from the still-in-English report, and 35 Portuguese URLs are in
  `sitemap.xml` with `hreflang="pt-BR"` on every page.
- `python -m unittest discover -s tests/python -t .` — 305 tests, OK.
- `git status` clean apart from `locales/pt/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
