### PR TITLE
Translate the site into Dutch

### DIFF
--- a/locales/nl/locale.toml
+++ b/locales/nl/locale.toml
@@ -14,7 +14,12 @@ lang = "nl"
 name = "Dutch"
 endonym = "Nederlands"
 
-complete = false
+# Finished: every tool, every guide, the roadmap list and both legal pages are
+# translated. While this is true a missing key is a build failure rather than a
+# silent fall back to English, and every link on every Dutch page has to lead to
+# a page that was actually built - which is what catches an English slug left
+# behind in a translated body.
+complete = true
 
 #
 # ---------------------------------------------------------------------------
@@ -37,6 +42,18 @@ complete = false
 "images-to-video" = "afbeeldingen-naar-video"
 "resize-image" = "afbeelding-formaat-wijzigen"
 "trim-video" = "video-knippen"
+"video-to-gif" = "video-naar-gif"
+"heic-to-jpg" = "heic-naar-jpg"
+# Naar de klus genoemd, niet naar het formaat. Niemand zoekt op "afbeelding naar
+# ICO"; men zoekt hoe je een favicon maakt.
+"image-to-ico" = "favicon-maken"
+# Ook hier de klus: "svg naar png" is wat er getypt wordt, en png is het formaat
+# dat er in vrijwel alle gevallen uit moet komen.
+"svg-to-image" = "svg-naar-png"
+# "Data-URI" is het vakwoord; "base64" is wat er gezocht wordt, en het is de
+# regel die je uiteindelijk in je CSS plakt.
+"image-to-data-uri" = "afbeelding-naar-base64"
+"qr-barcode" = "qr-code-maken"
 
 "guides" = "gidsen"
 "roadmap" = "roadmap"
@@ -52,6 +69,12 @@ complete = false
 "guides/trim-a-video" = "gidsen/een-video-inkorten"
 "guides/crop-a-video" = "gidsen/een-video-bijsnijden"
 "guides/is-it-safe-to-upload-files" = "gidsen/is-bestanden-uploaden-veilig"
+"guides/make-a-favicon" = "gidsen/zelf-een-favicon-maken"
+"guides/convert-an-svg-to-png" = "gidsen/een-svg-naar-png-omzetten"
+"guides/turn-a-video-into-a-gif" = "gidsen/van-een-video-een-gif-maken"
+"guides/convert-heic-to-jpg" = "gidsen/heic-naar-jpg-omzetten"
+"guides/embed-an-image-in-css" = "gidsen/een-afbeelding-in-css-zetten"
+"guides/make-a-qr-code" = "gidsen/zelf-een-qr-code-maken"
 
 #
 # ---------------------------------------------------------------------------
@@ -121,7 +144,7 @@ note = "Maak en herschik documenten zonder ze ergens heen te sturen om verwerkt 
 
 [[hub.categories]]
 name = "Codes &amp; gegevens"
-note = "Maak van wat u typt iets dat een machine kan lezen, zonder dat het de pagina verlaat."
+note = "Maak van iets wat je typt iets wat een machine kan lezen, zonder dat het de pagina verlaat."
 
 [[hub.categories]]
 name = "Tekst &amp; code"
@@ -147,7 +170,6 @@ og_title = "De gidsen van abox.tools"
 og_description = "Hoe je je eigen bestanden comprimeert, verkleint, bijsnijdt, inkort en converteert, en wat elke instelling kost. Zonder uploaden."
 og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"
 
-
 [[guides.groups]]
 name = "De klus klaren"
 note = "Eén per tool: waar de klus uit bestaat, welke instelling telt, en wat die je kost."
@@ -158,8 +180,8 @@ note = "Wat een bestand aan een website geven werkelijk betekent, en hoe je ziet
 
 #
 # ---------------------------------------------------------------------------
-# The roadmap. Only the frame - the list itself is config/planned.toml, which
-# has no locale file yet and is therefore still English on this page.
+# The roadmap. Only the frame - the list itself is config/planned.toml, and is
+# translated in planned.toml beside this file.
 # ---------------------------------------------------------------------------
 #
 
@@ -327,6 +349,8 @@ warning = """
       gekopieerd en nooit opnieuw opgevraagd. Er gaat nooit iets van jou naar
       buiten &mdash; deze pagina kan nog steeds geen enkele upload doen."""
 label = "Eén adres per regel"
+# Enkelvoud, want het Nederlands maakt geen meervoud met een losse s: de zin is
+# zo geschreven dat {{ tool.picker.urls.noun }} er onvervoegd in past.
 note = """
-      De server moet cross-origin gebruik van zijn {{ tool.picker.urls.noun }}s toestaan. Veel sites doen dat
-      niet, en die mislukken met een melding in plaats van later stil kapot te gaan."""
+      De server moet cross-origin gebruik toestaan van de {{ tool.picker.urls.noun }} die je opvraagt.
+      Veel sites doen dat niet, en die mislukken met een melding in plaats van later stil kapot te gaan."""

--- a/locales/nl/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/nl/pages/guides/combine-images-into-a-pdf.html
@@ -1,0 +1,205 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open <a href="../../afbeeldingen-naar-pdf/">Afbeeldingen naar pdf</a>,
+      sleep de plaatjes erin, sleep de tegels tot de volgorde klopt, en maak het
+      document. De standaardinstellingen &mdash; A4-pagina's, een kleine marge,
+      foto's die erin gekopieerd worden zonder opnieuw gecodeerd te worden
+      &mdash; zijn wat de meeste mensen willen.
+    </p>
+    <p>
+      De vier dingen die een tweede gedachte waard zijn, zijn de volgorde, het
+      paginaformaat, de kwaliteitsinstelling, en wat het gereedgekomen document
+      over je zegt. In die volgorde van hoe vaak ze misgaan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Zorg eerst dat de volgorde klopt</h2>
+    <p>
+      Paginavolgorde is veruit het meest voorkomende wat misgaat, omdat
+      bestandsnamen sorteren op manieren die niemand verwacht.
+      <code>IMG_2.jpg</code> komt in een alfabetische sortering ná
+      <code>IMG_10.jpg</code>, omdat er teken voor teken vergeleken wordt en
+      <code>1</code> vóór <code>2</code> komt. Een map met scans die
+      <code>pagina1</code> tot <code>pagina12</code> heten, komt in vrijwel elke
+      tool in de verkeerde volgorde binnen.
+    </p>
+    <p>
+      Sorteren op opnamedatum is bij foto's meestal betrouwbaarder, omdat je de
+      pagina's gefotografeerd hebt in de volgorde waarin ze lagen. Hoe dan ook:
+      controleer de tegels voordat je op de knop drukt, in plaats van de pdf
+      achteraf.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kwaliteit: het stuk dat de meeste tools stilletjes verkeerd doen</h2>
+    <p>
+      Een pdf kan JPEG-gegevens rechtstreeks meedragen. Dat is een eigenschap van
+      het formaat: de gecomprimeerde bytes van een jpeg kunnen er zo in gezet
+      worden, en de lezer decodeert ze net zoals een browser dat zou doen.
+    </p>
+    <p>
+      Dat telt, want het betekent dat een foto onderweg naar een pdf niets hoeft
+      te verliezen. Hij wordt nooit gedecodeerd en nooit opnieuw gecomprimeerd;
+      het plaatje in het document is bit voor bit het plaatje in je bestand. Veel
+      tools coderen toch opnieuw &mdash; het is eenvoudiger om alles op een
+      canvas te renderen en uniform te coderen &mdash; en het resultaat is een
+      generatie kwaliteit die voor niets verloren gaat.
+    </p>
+    <p>
+      Andere formaten kunnen niet zo meeliften. Png, WebP, HEIC en de rest hebben
+      geen bijpassend filter in pdf, dus die moeten omgezet worden. Je hebt daar
+      een keuze in:
+    </p>
+    <ul>
+      <li>
+        <strong>Opnieuw coderen als jpeg</strong> (de standaard). Kleinste
+        bestand, een klein kwaliteitsverlies, en het juiste antwoord voor foto's.
+      </li>
+      <li>
+        <strong>Verliesloos.</strong> Bewaart de exacte pixels ten koste van een
+        veel groter document. Het juiste antwoord voor schermafbeeldingen,
+        diagrammen en alles met tekst of scherpe randen erin, waar
+        JPEG-artefacten meteen opvallen.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Paginaformaat, en wanneer &ldquo;pas op het plaatje&rdquo; beter is</h2>
+    <p>
+      Een standaardpaginaformaat &mdash; A4, Letter, Legal, A3, A5, Tabloid
+      &mdash; zet elke afbeelding op een pagina van dat formaat, geschaald om
+      binnen je marge te passen. Gebruik er een wanneer het document geprint gaat
+      worden, of wanneer iemand van een instantie het gaat archiveren.
+    </p>
+    <p>
+      &ldquo;Precies de grootte van elk plaatje&rdquo; laat elke pagina zijn
+      afbeelding volgen, dus er is geen witruimte en helemaal geen schaling.
+      Gebruik het wanneer de pdf een houder voor plaatjes is in plaats van een
+      document: een portfolio, een set schermafbeeldingen, een strip. Geprint
+      ziet het er verkeerd uit, want elke pagina heeft een ander formaat.
+    </p>
+    <p>
+      Een marge is het waard bij alles wat geprint gaat worden. Printers voor
+      thuis kunnen niet tot aan de rand van het papier printen, en een foto die
+      van rand tot rand staat komt er afgeknipt uit.
+    </p>
+    <h3>Staande pagina's van liggende foto's</h3>
+    <p>
+      Heb je pagina's papier gefotografeerd met een telefoon op zijn kant, dan is
+      elke afbeelding liggend en staat hij klein midden op een staande pagina.
+      Ze elk een kwartslag draaien voordat je het document bouwt is wat dat
+      oplost, en het is een keuze per afbeelding in plaats van een keuze voor
+      alles, want meestal zijn er een paar wel goed om gegaan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat de gereedgekomen pdf over je zegt</h2>
+    <p>
+      Een pdf draagt een informatieblok over het document mee: auteur, producent,
+      aanmaakdatum, soms de titel. Afhankelijk van wat hem schreef kan daar je
+      accountnaam in staan, je apparaatnaam, en het exacte tijdstip waarop je hem
+      maakte.
+    </p>
+    <p>
+      Daar mag je over nadenken, want een pdf is iets wat mensen naar andere
+      mensen sturen &mdash; een sollicitatie, een claim, een document voor een
+      verhuurder. De metagegevens reizen mee en elke lezer kan ze tonen.
+    </p>
+    <p>
+      De tool hier laat dat blok leeg op zijn eigen naam na: geen bestandsnamen,
+      geen apparaatnaam, geen gebruikersnaam, en geen aanmaakdatum tenzij je het
+      vinkje aanzet dat erom vraagt. Gebruik je een andere tool, dan is het de
+      moeite waard om de eigenschappen van het resultaat één keer te openen om te
+      zien wat hij geschreven heeft.
+    </p>
+    <p>
+      Los daarvan: de afbeeldingen zelf. Dragen je foto's EXIF- en gps-tags mee,
+      dan hangt het van de route af wat ermee gebeurt. Een jpeg die zonder
+      hercodering meegekopieerd wordt, houdt wat erin zat; een afbeelding die wel
+      opnieuw gecodeerd wordt, verliest de tags als bijwerking. Maakt het uit,
+      wis de foto's dan eerst met de
+      <a href="../../exif-gegevens-verwijderen/">EXIF-lezer &amp; -wisser</a>
+      &mdash; <a href="../exif-en-gps-gegevens-verwijderen/">de bijbehorende
+      gids</a> legt uit wat erin zit.
+    </p>
+  </section>
+
+  <section>
+    <h2>Als de pdf te groot uitvalt</h2>
+    <p>
+      Telefoonfoto's zijn groot, en twintig ervan maken een document dat e-mail
+      weigert. Drie dingen om te proberen, op volgorde:
+    </p>
+    <p>
+      <strong>Verklein de langste zijde.</strong> Een foto van 4000 pixels van
+      een vel papier draagt veel meer detail dan welke lezer of printer ook gaat
+      gebruiken. De lange zijde terugbrengen naar zoiets als 2000 pixels viert
+      meestal het bestand en verandert niets wat iemand op een pagina kan zien.
+    </p>
+    <p>
+      <strong>Gebruik jpeg in plaats van verliesloos</strong> voor alles wat
+      fotografisch is. Verliesloos is het juiste antwoord voor diagrammen en het
+      verkeerde voor een foto van een pagina.
+    </p>
+    <p>
+      <strong>Comprimeer het gereedgekomen document.</strong> De
+      <a href="../../pdf-verkleinen/">Pdf-compressor</a> werkt op basis van hoe
+      groot elke afbeelding op de pagina getekend wordt in plaats van op basis
+      van zijn aantal pixels, en dat is de meting die ertoe doet;
+      <a href="../een-pdf-kleiner-maken/">de bijbehorende gids</a> gaat over wat
+      dat kost.
+    </p>
+    <p>
+      In de tool zit geen limiet op hoeveel afbeeldingen je kunt gebruiken. Het
+      praktische plafond is het geheugen van je eigen apparaat, want het
+      gereedgekomen document wordt daar opgebouwd voordat je het downloadt
+      &mdash; een paar honderd telefoonfoto's op volle resolutie is het eerste
+      wat dat merkt, en de langste zijde verkleinen schuift dat plafond een heel
+      eind op.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat dit je niet gaat opleveren</h2>
+    <p>
+      Een pdf die van foto's gemaakt is, is een pdf vol plaatjes. De woorden erin
+      zijn geen tekst: je kunt er niet in zoeken, ze niet kopiëren, en een
+      schermlezer kan ze niet voorlezen. Dat is een eigenschap van waarmee je
+      begon, niet van de omzetting.
+    </p>
+    <p>
+      Heb je doorzoekbare tekst nodig, dan heb je ocr nodig, en dat is een andere
+      klus. En bestaat het originele document ergens nog als document, dan wint
+      dat rechtstreeks naar pdf exporteren het altijd van het fotograferen
+      &mdash; kleiner, scherper, doorzoekbaar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom hier niets voor geüpload hoeft te worden</h2>
+    <p>
+      Een pdf schrijven is een gestructureerd bestand schrijven: een kop, een set
+      objecten, een kruisverwijzingstabel. Er zit niets in wat een browser niet
+      kan, en er is niets aan de klus dat vereist dat de plaatjes ergens heen
+      reizen.
+    </p>
+    <p>
+      En dat is hier het waard om om te geven, vanwege wat mensen in deze
+      documenten stoppen. Identiteitspapieren, bankafschriften, brieven van de
+      dokter, getekende contracten &mdash; de hele reden dat iemand überhaupt een
+      pdf maakt, is meestal dat hij hem naar een instantie stuurt. De tool hier
+      heeft geen enkele netwerkfunctie, en de
+      <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+      mag benaderen; geen ervan hoort bij deze site.
+    </p>
+    <p>
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet uiteen hoe je dat zelf controleert,
+      hier of ergens anders.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/nl/pages/guides/combine-images-into-a-pdf.toml
@@ -1,0 +1,17 @@
+#
+# Gids: afbeeldingen samenvoegen tot een pdf - Dutch.
+#
+
+nav = "Afbeeldingen naar een pdf"
+title = "Afbeeldingen samenvoegen tot één pdf"
+description = "Maak van foto's of scans één pdf: paginaformaat, volgorde en draaiing, waarom een jpeg onderweg geen kwaliteit hoeft te verliezen, en wat een pdf vertelt aan degene naar wie je hem stuurt."
+heading = "Hoe je afbeeldingen samenvoegt tot één pdf"
+lede = """
+    Iemand heeft om &ldquo;één pdf&rdquo; gevraagd en jij hebt elf foto's van
+    papier. Dit gaat over de keuzes die het resultaat werkelijk veranderen
+    &mdash; paginaformaat, volgorde, kwaliteit en wat het document over je zegt
+    &mdash; en over welke je kunt negeren."""
+updated = "20 augustus 2026"
+og_title = "Hoe je afbeeldingen samenvoegt tot één pdf"
+og_description = "Paginaformaat, volgorde en draaiing, waarom een jpeg onderweg geen kwaliteit hoeft te verliezen, en wat een pdf vertelt aan degene naar wie je hem stuurt."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/nl/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,0 +1,253 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../afbeelding-comprimeren/">Afbeeldingscompressor</a>,
+      sleep de foto erin, tik het getal in dat je gekregen hebt, en druk op de
+      knop. Hij codeert het plaatje een paar keer, houdt het beste resultaat dat
+      onder je doel past, en zegt wat dat gekost heeft. Voor de meeste foto's en
+      de meeste doelen is de eerlijke samenvatting dat je het verschil niet zult
+      zien.
+    </p>
+    <p>
+      De rest van deze pagina is voor wanneer dat niet gebeurt: als het resultaat
+      zacht oogt, als een png nauwelijks beweegt, of als je wilt weten wat de
+      tool werkelijk met je plaatje doet voordat je het naar iemand stuurt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waar een groottelimiet eigenlijk om vraagt</h2>
+    <p>
+      Een jpeg of een WebP slaat je foto niet op. Hij slaat er een beschrijving
+      van op, en de kwaliteitsinstelling bepaalt hoe gedetailleerd die
+      beschrijving mag zijn. Draai hem omlaag en het bestand wordt kleiner omdat
+      de beschrijving vager wordt: fijne textuur wordt uitgemiddeld, verlopen
+      krijgen banden, en randen krijgen een vage halo van blokjes.
+    </p>
+    <p>
+      Een groottelimiet is dus een budget voor detail. De nuttige vraag is niet
+      &ldquo;haal ik 500&nbsp;kB&rdquo; &mdash; elk getal is altijd haalbaar
+      &mdash; maar &ldquo;hoeveel van het plaatje moet ik opgeven om daar te
+      komen, en maakt dat uit voor waar ik het voor gebruik?&rdquo;
+    </p>
+    <p>
+      Twee vuistregels. Een foto van een echt tafereel &mdash; gezichten, blad,
+      stof &mdash; verbergt compressie goed, omdat het oog geen volkomen vlak
+      gebied heeft om schade in op te merken. Een schermafbeelding, een grafiek,
+      een logo of wat dan ook met grote vlakke kleuren en harde tekstranden laat
+      het meteen zien, en zou meestal een png of een WebP moeten zijn in plaats
+      van een jpeg.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom er geen formule is, en wat je daaraan doet</h2>
+    <p>
+      Er is geen manier om de kwaliteitsinstelling uit te rekenen die een bestand
+      van 500&nbsp;kB oplevert. De verhouding tussen die twee hangt volledig af
+      van wat er in het plaatje zit: op dezelfde stand kan een foto van een kale
+      muur er een tiende zo groot uit komen als een foto van een bos. Elke tool
+      die je &ldquo;kwaliteit: 60&rdquo; aanbiedt en er het beste van hoopt, gokt
+      namens jou.
+    </p>
+    <p>
+      De enige betrouwbare methode is proberen. Codeer de afbeelding, kijk naar
+      de grootte, stel bij, codeer opnieuw. Dat met de hand doen is vervelend, en
+      daarom vragen compressors om een kwaliteitsgetal &mdash; dat verschuift het
+      vervelende werk naar jou. Het automatisch doen kost ongeveer acht
+      coderingen, en acht coderingen van een telefoonfoto is een fractie van een
+      seconde op elk apparaat van dit decennium; en daarom vraagt de tool op deze
+      site om de grootte en zoekt hij het zelf uit.
+    </p>
+    <p>
+      Elke grootte die hij meldt, is een echt gecodeerd bestand en geen
+      schatting. Dat telt wanneer een formulier een harde grens heeft: een
+      schatting die 2% optimistisch is, is een geweigerde upload.
+    </p>
+  </section>
+
+  <section>
+    <h2>Geef eerst kwaliteit uit, en pas daarna pixels</h2>
+    <p>
+      Er zijn maar twee manieren om een afbeeldingsbestand kleiner te maken. Je
+      kunt hetzelfde plaatje minder nauwkeurig beschrijven, en dat is kwaliteit.
+      Of je kunt minder pixels beschrijven, en dat is schalen. Ze zijn niet
+      gelijkwaardig, en de volgorde telt.
+    </p>
+    <p>
+      Kwaliteit gaat eerst, want de eerste 30% of zo van de kwaliteitsverlaging
+      is bij een foto werkelijk onzichtbaar &mdash; je gooit detail weg dat het
+      formaat zorgvuldiger bewaarde dan enig oog kan nagaan. Pixels gaan als
+      tweede, want zodra de kwaliteit ver genoeg zakt dat artefacten zichtbaar
+      worden, ziet een kleiner plaatje op fatsoenlijke kwaliteit er beter uit dan
+      een plaatje op volle grootte dat verpest is. Minder goede pixels winnen het
+      van meer slechte.
+    </p>
+    <p>
+      Dat is de hele strategie, en die is het weten waard, ook als je een andere
+      tool gebruikt: draai de kwaliteit omlaag tot het er verkeerd begint uit te
+      zien, en maak het plaatje dan kleiner in plaats van hem verder omlaag te
+      draaien.
+    </p>
+    <h3>Wanneer je met opzet schaalt</h3>
+    <p>
+      Soms waren de pixels nooit nodig. Een foto van 4000 pixels breed die in een
+      kolom van 600 pixels op een webpagina staat, draagt zes keer het detail dat
+      iemand gaat zien. Weet je waar het plaatje uiteindelijk terechtkomt, schaal
+      er dan eerst naartoe en het groottevraagstuk verdwijnt vaak zonder dat er
+      ook maar kwaliteit aan uitgegeven is.
+      <a href="../../afbeelding-formaat-wijzigen/">Afbeeldingsformaat
+      wijzigen</a> is de tool voor die klus, en
+      <a href="../formaat-van-een-afbeelding-wijzigen/">de bijbehorende gids</a>
+      gaat over het kiezen van een formaat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Een formaat kiezen</h2>
+    <p>
+      Drie formaten zijn het kennen waard, en browsers kunnen ze alle drie
+      schrijven.
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG</strong> is voor foto's. Het is verliesgevend, het wordt
+        begrepen door alles wat ooit gemaakt is, en voor een plaatje van een echt
+        tafereel is het nog altijd een uitstekende keuze. Transparantie kan het
+        niet opslaan.
+      </li>
+      <li>
+        <strong>WebP</strong> is voor dezelfde klus, beter gedaan: ruwweg 25 tot
+        35% kleiner dan jpeg op een kwaliteit waarvan je het verschil niet ziet,
+        en het houdt transparantie. Elke huidige browser leest het. Een paar
+        oudere desktopprogramma's en sommige zakelijke uploadformulieren nog niet,
+        en dat is de enige echte reden om het niet te gebruiken.
+      </li>
+      <li>
+        <strong>PNG</strong> is verliesloos, wat betekent dat het exact is en dat
+        het groot is. Het is het juiste antwoord voor schermafbeeldingen, logo's,
+        lijntekeningen en alles met scherpe randen of vlakke kleur, en het
+        verkeerde antwoord voor een foto.
+      </li>
+    </ul>
+    <p>
+      Legt degene die om het bestand vroeg je niets op, dan brengt WebP je met
+      minder zichtbare schade naar een doel dan jpeg. Gaat het bestand ergens in
+      dat oud is, of in een systeem dat je niet kunt testen, dan is jpeg het
+      veilige antwoord.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom je png niet veel kleiner wordt</h2>
+    <p>
+      Dit is de meest voorkomende verrassing, en het is geen fout in de tool die
+      je gebruikt. Png is een verliesloos formaat: het slaat de exacte pixels op
+      en het heeft geen kwaliteitsknop om aan te draaien, want zo'n knop zou er
+      een ander formaat van maken. Het enige wat een png-compressor kan doen, is
+      dezelfde pixels slimmer inpakken, en dat levert meestal een paar procent
+      op.
+    </p>
+    <p>
+      Moet je dus een veel kleiner bestand hebben en moet het een png blijven,
+      dan is de enige hendel die overblijft de grootte &mdash; minder pixels, of
+      minder kleuren. Mag het ophouden een png te zijn, dan is de vraag wat erin
+      zit:
+    </p>
+    <ul>
+      <li>
+        <strong>Een foto die als png opgeslagen is.</strong> Heel gebruikelijk,
+        meestal per ongeluk, en de makkelijkste winst op deze pagina: hem naar
+        jpeg of WebP omzetten maakt hem vaak vijf tot tien keer kleiner zonder
+        zichtbaar verschil.
+      </li>
+      <li>
+        <strong>Een schermafbeelding of een diagram.</strong> Zet om naar WebP,
+        dat ook verliesloos is als je erom vraagt, en dat voor dezelfde pixels
+        meestal kleiner is dan png. Naar jpeg gaan maakt tekstranden vaag.
+      </li>
+      <li>
+        <strong>Een logo met transparantie.</strong> WebP houdt de transparantie;
+        jpeg vult hem op met een vaste kleur, en dat is vrijwel nooit wat je
+        wilde.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Hoe je ziet of het resultaat goed genoeg is</h2>
+    <p>
+      Naar een miniatuur kijken bewijst niets &mdash; op miniatuurformaat ziet
+      alles er prima uit. Twee betere controles:
+    </p>
+    <p>
+      <strong>Kijk ernaar op volle grootte, naar het vlakste stuk in
+      beeld.</strong> Lucht, huid, een geverfde muur. Compressieschade duikt het
+      eerst op in vloeiende verlopen, als vage blokjes of banden, lang voordat ze
+      gedetailleerde gebieden raakt.
+    </p>
+    <p>
+      <strong>Lees de meting, als de tool je er een geeft.</strong> De compressor
+      hier decodeert zijn eigen resultaat, vergelijkt het met het origineel en
+      meldt SSIM: een getal dat plaatselijke helderheid, contrast en structuur
+      vergelijkt in plaats van veranderde pixels te tellen, wat veel dichter ligt
+      bij waar een oog zich aan stoort. Boven ruwweg 0,98 zijn de twee plaatjes
+      naast elkaar moeilijk uit elkaar te houden. Onder ongeveer 0,95: kijk
+      voordat je verstuurt. Hij meldt ook PSNR, het klassieke decibelgetal, voor
+      wie dat liever heeft.
+    </p>
+    <p>
+      Beide worden op je eigen apparaat berekend en aan jou getoond, en daar zijn
+      ze voor: ze maken van &ldquo;minimaal kwaliteitsverlies&rdquo; een getal
+      dat je kunt controleren in plaats van een bewering.
+    </p>
+  </section>
+
+  <section>
+    <h2>Drie dingen om te weten voordat je het bestand verstuurt</h2>
+    <p>
+      <strong>Comprimeren wist de metagegevens.</strong> Hercoderen betekent het
+      plaatje decoderen tot pixels en die pixels opnieuw coderen, en een canvas
+      vol pixels draagt geen tags &mdash; dus de gps-positie, het cameramodel, de
+      tijdstempels en de rest worden domweg niet in het nieuwe bestand
+      geschreven. Meestal is dat mooi meegenomen. Wilde je de tags weg maar het
+      plaatje onaangeroerd, dan is dat een andere klus: de
+      <a href="../../exif-gegevens-verwijderen/">EXIF-lezer &amp; -wisser</a>
+      herschrijft de container zonder ook maar iets opnieuw te comprimeren, en
+      <a href="../exif-en-gps-gegevens-verwijderen/">de bijbehorende gids</a>
+      legt uit wat erin zit.
+    </p>
+    <p>
+      <strong>Comprimeer hetzelfde bestand nooit twee keer.</strong> Elke
+      verliesgevende codering gooit blijvend detail weg, en een al gecomprimeerd
+      plaatje coderen gooit er meer weg &mdash; inclusief de artefacten uit de
+      eerste ronde, die trouw bewaard blijven ten koste van echt detail. Ga
+      altijd terug naar het origineel en comprimeer één keer.
+    </p>
+    <p>
+      <strong>Bewaar het origineel.</strong> Van een verliesgevende codering is
+      geen weg terug. Wat je ook verstuurt, bewaar het bestand waarmee je begon
+      ergens.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hier hoeft niets voor geüpload te worden</h2>
+    <p>
+      Elke browser levert al jaren een jpeg-, png- en WebP-encoder mee &mdash;
+      het is dezelfde code die een plaatje uit een canvas opslaat. Een afbeelding
+      comprimeren is een van de klussen waarvoor er geen technische reden is om
+      er überhaupt een server bij te betrekken, en daarom heeft de tool hier er
+      geen: het plaatje wordt op je eigen apparaat gedecodeerd, gecodeerd en
+      gemeten, en er staat in de <code>Content-Security-Policy</code> van de
+      pagina geen adres van deze site om het heen te sturen.
+    </p>
+    <p>
+      De eenvoudigste manier om dat te bevestigen, hier of ergens anders, is de
+      pagina laden, de verbinding verbreken, en toch iets comprimeren. Werkt het
+      nog, dan werd er niets geüpload.
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet er nog drie zulke controles op een
+      rij.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/nl/pages/guides/compress-an-image-to-a-target-size.toml
@@ -1,0 +1,17 @@
+#
+# Gids: een afbeelding naar een exacte bestandsgrootte comprimeren - Dutch.
+#
+
+nav = "Een afbeelding comprimeren"
+title = "Een afbeelding naar een exacte bestandsgrootte comprimeren"
+description = "Een uploadformulier wil 500 kB en je foto is 4 MB. Wat een groottelimiet werkelijk kost, welke instelling je als eerste verzet, en waarom een png niet krimpt zoals een jpeg."
+heading = "Hoe je een afbeelding naar een exacte bestandsgrootte comprimeert"
+lede = """
+    Iemand heeft je een getal genoemd &mdash; 100&nbsp;kB, 500&nbsp;kB,
+    2&nbsp;MB &mdash; en je foto zit er nergens bij in de buurt. Hier staat wat
+    dat getal kost, waar je het aan uitgeeft, en hoe je ziet of het resultaat nog
+    goed genoeg is om te versturen."""
+updated = "20 augustus 2026"
+og_title = "Een afbeelding naar een exacte bestandsgrootte comprimeren"
+og_description = "Wat een groottelimiet werkelijk kost, welke instelling je als eerste verzet, en waarom een png niet krimpt zoals een jpeg."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/convert-an-svg-to-png.html
+++ b/locales/nl/pages/guides/convert-an-svg-to-png.html
@@ -1,0 +1,244 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open <a href="../../svg-naar-png/">SVG naar afbeelding</a>, sleep het
+      bestand erin, en noem een formaat. Heeft niets je verteld welk formaat je
+      moet gebruiken, dan is <strong>1024 pixels op de langste zijde</strong> een
+      goede standaard: groot genoeg voor vrijwel alles en klein genoeg om te
+      mailen. Laat het bestandstype op png staan, laat de achtergrond op
+      transparant staan, en neem het bestand mee.
+    </p>
+    <p>
+      Alles hieronder gaat over wat je doet wanneer die standaard niet volstaat
+      &mdash; wanneer er een getal voor je vastgelegd is, wanneer het naar de
+      drukker gaat, of wanneer het er verkeerd uit komt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom het formaat jouw beslissing is en niet die van het bestand</h2>
+    <p>
+      Een jpeg is een raster van gemeten pixels; de vraag hoe groot hij is heeft
+      een antwoord. Een svg is helemaal geen plaatje, het is een set instructies
+      &mdash; teken hier een cirkel, dit pad in die kleur &mdash; en instructies
+      hebben geen formaat. Een browser kan ze op 16 pixels of op 4000 uitvoeren
+      en het resultaat is even scherp, want hij schaalt niets. Hij tekent
+      opnieuw.
+    </p>
+    <p>
+      Daarom kan de omzetting geen getal voor je kiezen, en daarom kost het je
+      niets om een groot getal te kiezen. Dit is de ene beeldklus waarbij
+      &ldquo;maak het groter&rdquo; gratis is.
+    </p>
+    <p>
+      De meeste svg-bestanden dragen wel een <code>width</code>- en
+      <code>height</code>-attribuut mee, en een tool laat dat zien &mdash; maar
+      het is een standaard, geen grens. Een icoon dat <code>width="24"</code>
+      zegt, zegt alleen dat degene die het tekende een werkbalk van 24&nbsp;pixels
+      voor ogen had.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waar het getal werkelijk vandaan komt</h2>
+    <p><strong>Voor een website.</strong> Neem de ruimte die de afbeelding op de
+      pagina inneemt in CSS-pixels en vermenigvuldig met de pixeldichtheid van de
+      schermen waar het je om gaat. Een logo in een vak van 200&nbsp;pixels breed
+      heeft een bestand van 400&nbsp;pixels nodig voor een Retina-laptop en 600
+      voor een recente telefoon. Dat is alles wat <code>@2x</code> en
+      <code>@3x</code> betekenen, en daarom bespaart een tool die ze schrijft je
+      het sommetje drie keer te maken.
+    </p>
+    <p><strong>Voor een app-icoon, een winkelvermelding of een favicon.</strong>
+      Het getal is gepubliceerd en er valt niets uit te rekenen: precies wat de
+      pagina van de winkel zegt. Voor een favicon: raster helemaal niet &mdash;
+      <a href="../zelf-een-favicon-maken/">maak een .ico</a>, die meerdere
+      formaten in één bestand bevat, omdat een browsertabblad, een bladwijzer en
+      een Windows-snelkoppeling alle drie om een ander vragen.
+    </p>
+    <p><strong>Voor drukwerk.</strong> Vermenigvuldig de fysieke maat in inches
+      met de resolutie van de printer. Een logo dat op een visitekaartje twee
+      inch breed komt op 300&nbsp;dpi is 600 pixels; hetzelfde logo over een
+      A4-pagina, op 8,3&nbsp;inch, is zo'n 2500. Drukkers vragen standaard om
+      300&nbsp;dpi, en voor een grootformaatbanner die je van de overkant van een
+      zaal ziet is 150 ruim voldoende.
+    </p>
+    <p><strong>Voor een sociale voorvertoning of een OG-afbeelding.</strong> Het
+      platform noemt een kader &mdash; 1200&nbsp;&times;&nbsp;630 voor de meeste
+      linkvoorvertoningen &mdash; en dat kader heeft een andere vorm dan je logo.
+      Daar is de instelling &ldquo;opvullen&rdquo; voor: de tekening gecentreerd
+      op zijn eigen verhoudingen, met een achtergrondkleur die de rest vult, in
+      plaats van een uitgerekt logo dat iedereen vertelt dat je niet gekeken
+      hebt.
+    </p>
+    <p>
+      Gelden er twee van deze, neem dan de grootste. Een png die groter is dan
+      nodig is een iets grotere download; een die te klein is valt later niet meer
+      te herstellen, om de reden in het volgende deel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Je kunt niet terug</h2>
+    <p>
+      Rasteren is eenrichtingsverkeer. Zodra de tekening een png is, is het pixels
+      als elk ander plaatje, en hem daarna vergroten moet detail verzinnen dat
+      nooit gemeten is &mdash; hetzelfde zachte, uitgesmeerde resultaat dat je
+      krijgt van een foto vergroten.
+    </p>
+    <p>
+      Bewaar dus de svg. Dat is het origineel, het is vrijwel altijd het kleinere
+      bestand, en elk toekomstig formaat komt er perfect uit. De png is een
+      export voor één bepaald gebruik, en heb je een ander formaat nodig, dan is
+      opnieuw exporteren de juiste zet en niet je export schalen.
+    </p>
+    <p>
+      Er bestaat software die beweert een png terug naar een svg om te zetten.
+      Wat die doet is traceren: gokken welke krommen een raster van pixels zouden
+      kunnen verklaren. Het werkt redelijk op vlak tweekleurig tekenwerk en levert
+      dure onzin op bij al het andere, en het haalt nooit terug wat de originele
+      tekening had.
+    </p>
+  </section>
+
+  <section>
+    <h2>Drie dingen veranderen zodra het pixels wordt</h2>
+    <p>
+      Een gerasterde svg die er verkeerd uitziet, ziet er vrijwel altijd verkeerd
+      uit om een van deze drie redenen, en alle drie zijn het weten waard vóór je
+      exporteert in plaats van erna.
+    </p>
+    <p>
+      <strong>Tekst wordt getekend in het lettertype dat het apparaat heeft.</strong>
+      Een svg met tekst erin bevat het lettertype niet &mdash; hij noemt er een
+      en laat het aan de renderer over om het te vinden. Is het lettertype niet
+      geïnstalleerd, dan wordt er een vervanger gebruikt, en die vervanger heeft
+      andere letterbeelden en andere breedtes, dus de tekst kan verschuiven of
+      overlopen. Een bestand dat zijn lettertype van een webadres haalt, is er
+      nog slechter aan toe: een svg die via een <code>&lt;img&gt;</code> gerasterd
+      wordt, mag helemaal niets ophalen, dus er komt niets aan.
+    </p>
+    <p>
+      De oplossing is die elke ontwerper al kent: <strong>zet tekst om naar
+      contouren</strong> voordat je de svg exporteert (Illustrator noemt het
+      Create Outlines, Figma noemt het Flatten, Inkscape noemt het Object to
+      Path). De letters worden meetkunde, het lettertype doet er niet meer toe, en
+      het plaatje ziet er op elk apparaat hetzelfde uit. Doe het op een kopie
+      &mdash; tekst die naar contouren omgezet is, is niet meer als tekst te
+      bewerken.
+    </p>
+    <p>
+      <strong>Haarlijnen worden grijs of verdwijnen.</strong> Een lijn die op jouw
+      gekozen formaat op minder dan één pixel uitkomt, kan niet als een volle lijn
+      getekend worden, dus wordt hij vaag getekend. Daarom ziet een fijn logo dat
+      op 64&nbsp;pixels gerasterd is er verwassen uit terwijl hetzelfde bestand op
+      512 er perfect uitziet. Is een klein formaat de eis, dan is het antwoord een
+      vereenvoudigde tekening met zwaardere lijnen en niet een andere
+      exportinstelling &mdash; dezelfde reden waarom een favicon een symbool is en
+      geen woordmerk.
+    </p>
+    <p>
+      <strong>Animatie stopt.</strong> Een bewegende svg rastert naar één
+      stilstaand beeld: wat het eerste frame ook is. Er is geen exportinstelling
+      die dat verandert. Heb je de beweging nodig, dan heb je een gif of een video
+      nodig, op een andere manier gemaakt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparantie, en welk bestandstype je kiest</h2>
+    <p>
+      <strong>Png</strong>, tenzij je een reden hebt. Het is verliesloos, het
+      houdt transparantie, en vlakke kleur met harde randen &mdash; en daar
+      bestaat een tekening vooral uit &mdash; comprimeert er goed in. Een
+      gerasterd logo is meestal een <em>kleinere</em> png dan het een jpeg zou
+      zijn, en bovendien een schonere.
+    </p>
+    <p>
+      <strong>Jpeg</strong> heeft helemaal geen transparantie. Elke transparante
+      pixel moet een kleur worden, en kiest er niets een voor je, dan wordt hij
+      zwart &mdash; en daar komt het resultaat logo-op-een-zwart-vlak vandaan dat
+      mensen voor een fout aanzien. Het is bovendien verliesgevend op de manier
+      die juist bij dit soort plaatjes het meest opvalt: een krans van spikkels om
+      elke harde rand. Gebruik het wanneer iets erop staat.
+    </p>
+    <p>
+      <strong>WebP</strong> doet alles wat png doet, in een kleiner bestand, en
+      wordt door elke huidige browser gelezen. De reden om het niet te gebruiken
+      is wat er ná de browser gebeurt: oudere software, sommige drukkers en een
+      flink aantal uploadformulieren openen er nog steeds geen.
+    </p>
+    <p>
+      Een achtergrondkleur kiezen bij png is ook een volstrekt gewone wens.
+      Transparantie is alleen nuttig wanneer datgene waar de afbeelding op landt
+      een kleur is die je niet kunt voorspellen; weet je al dat het een witte
+      pagina is, dan voorkomt platslaan op wit een hele soort verrassingen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Als de export leeg of verkeerd uit komt</h2>
+    <p>
+      <strong>Niets dan lege ruimte.</strong> Meestal een ontbrekend
+      <code>xmlns</code>-attribuut op het wortelelement. Een bestand zonder dat
+      attribuut is voor een afbeeldingstag geen svg, en het tekent als niets. Het
+      bestand in een browser openen is de snelle test: laat de browser ook niets
+      zien, dan is het bestand het probleem en niet de omzetter.
+    </p>
+    <p>
+      <strong>De tekening is klein, linksboven in de hoek.</strong> Het bestand
+      heeft een <code>width</code> en <code>height</code> maar geen
+      <code>viewBox</code>, dus er is geen coördinatenstelsel om te schalen en het
+      tekenwerk houdt zijn oorspronkelijke eenheden op een groter canvas. Een
+      goede omzetter zet er een viewBox in voor je; heeft die van jou dat niet
+      gedaan, dan lost
+      <code>viewBox="0 0 <em>breedte</em> <em>hoogte</em>"</code> met de hand aan
+      het wortelelement toevoegen het op, en het bestand is platte tekst dus dat
+      kan.
+    </p>
+    <p>
+      <strong>Een deel van het plaatje ontbreekt.</strong> Iets in het bestand
+      wees naar een adres in plaats van het tekenwerk te bevatten &mdash; een
+      ingesloten foto die als link opgeslagen is, een stylesheet, een lettertype.
+      Een rasteraar die weigert die op te halen doet het juiste, en het is
+      dezelfde weigering die belet dat een svg die je ergens gedownload hebt
+      terugrapporteert aan wie hem gemaakt heeft. Exporteer opnieuw uit het
+      tekenprogramma met de afbeeldingen ingesloten.
+    </p>
+    <p>
+      <strong>Hij weigert een heel groot formaat.</strong> Browsers begrenzen hoe
+      groot een canvas mag zijn, en ze zijn het niet eens over waar: voorbij
+      ruwweg 16.000&nbsp;pixels op een zijde komt er niets terug, en Safari op een
+      iPhone of iPad geeft het veel eerder op, bij zo'n
+      4096&nbsp;&times;&nbsp;4096. Een tool die je waarschuwt behoedt je voor een
+      leeg bestand, want dat is wat een browser oplevert wanneer hij op is, in
+      plaats van een foutmelding.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hier hoeft niets voor geüpload te worden</h2>
+    <p>
+      Een svg rasteren is iets wat elke browser duizenden keren per dag doet
+      &mdash; het is dezelfde machinerie die een icoon op een webpagina tekent. Er
+      is geen technische reden voor je tekenwerk om naar een server en terug te
+      reizen om er als png uit te komen, en de tool hier stuurt het nergens heen:
+      de <code>Content-Security-Policy</code> van de pagina noemt elk adres dat
+      hij mag benaderen, en geen ervan hoort bij deze site.
+    </p>
+    <p>
+      Dat telt bij svg zwaarder dan gewoonlijk, want een svg is een document en
+      geen plaatje. Er kan een script en een extern adres in zitten, en een logo
+      dat je van een bureau kreeg is een bestand dat je niet zelf geschreven hebt.
+      Via een afbeeldingstag getekend zit het in wat de specificatie <em>secure
+      static mode</em> noemt: het script kan niet draaien en het adres wordt nooit
+      benaderd. De browser dwingt dat af, niet de website.
+    </p>
+    <p>
+      Laad de pagina, trek de stekker uit het internet, en zet er toch iets om,
+      als je liever controleert dan het aanneemt.
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet nog drie controles op een rij die je
+      op elke tool kunt loslaten.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/nl/pages/guides/convert-an-svg-to-png.toml
@@ -1,0 +1,17 @@
+#
+# Gids: een svg naar een png omzetten - Dutch.
+#
+
+nav = "Een svg naar png omzetten"
+title = "Een svg naar een png omzetten op het juiste formaat"
+description = "Een vector heeft zelf geen pixelformaat, dus het getal kies jij. Waar dat getal vandaan komt voor een scherm, een app-icoon en een printer, en wat er verandert wanneer een tekening pixels wordt."
+heading = "Hoe je een svg naar een png omzet op het juiste formaat"
+lede = """
+    Het omzetten is de makkelijke helft. De vraag die bepaalt of het resultaat
+    ergens goed voor is, is degene waarop niemand je een antwoord aanreikt:
+    hoeveel pixels? Hier staat waar dat getal vandaan komt, en wat een tekening
+    onderweg naar pixels verliest."""
+updated = "20 augustus 2026"
+og_title = "Een svg naar een png omzetten op het juiste formaat"
+og_description = "Waar het aantal pixels werkelijk vandaan komt, en de drie dingen die veranderen wanneer een tekening pixels wordt."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/convert-heic-to-jpg.html
+++ b/locales/nl/pages/guides/convert-heic-to-jpg.html
@@ -1,0 +1,256 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../heic-naar-jpg/">HEIC-naar-JPG-omzetter</a>, sleep de
+      foto's erin, en druk op &ldquo;Omzetten&rdquo;. Laat de kwaliteitsschuif
+      staan waar hij staat en laat &ldquo;hou de datum, de camera en de
+      instellingen&rdquo; aangevinkt, tenzij je een reden hebt om dat niet te
+      doen. Je krijgt jpeg's terug, elk met een downloadknop, of een zip als het
+      er meerdere zijn.
+    </p>
+    <p>
+      Er wordt daarbij niets geüpload. Dat is ongebruikelijk voor juist deze
+      klus, en waarom dat zo is, is de interessante helft van deze pagina.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat HEIC eigenlijk is</h2>
+    <p>
+      HEIC is niet echt een beeldformaat op de manier waarop jpeg dat is. Het is
+      een container &mdash; dezelfde doosstructuur waaruit een mp4 opgebouwd is
+      &mdash; met daarin een stilstaand frame <strong>HEVC</strong>-video. HEVC,
+      ook H.265 genoemd, is de codec die die van je oude camcorder verving, en
+      hij is heel goed: een iPhone-foto in HEIC is ruwweg de helft van de grootte
+      van dezelfde foto als jpeg op dezelfde kwaliteit.
+    </p>
+    <p>
+      Apple stapte er in iOS 11 op over, in 2017, en zette het als standaard. Wat
+      betekent dat, tenzij iemand naar Instellingen gegaan is en &ldquo;Meest
+      compatibel&rdquo; gekozen heeft, elke foto die zijn telefoon het grootste
+      deel van een decennium gemaakt heeft in een formaat staat dat:
+    </p>
+    <ul>
+      <li>Windows niet voorvertoont zonder een uitbreiding uit de Store;</li>
+      <li>de meeste uploadformulieren op het web ronduit weigeren;</li>
+      <li>waar een hoop oudere desktopsoftware nooit van gehoord heeft;</li>
+      <li>en dat geen enkele webbrowser behalve Safari wil tonen.</li>
+    </ul>
+    <p>
+      Met de foto is niets mis. Het is een beter bestand dan de jpeg geweest zou
+      zijn. Hij is alleen geschreven in een taal die het grootste deel van de
+      wereld nooit geleerd heeft.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom alleen Safari er een opent</h2>
+    <p>
+      Dit is het stuk dat elke omzetter verklaart die je ooit gebruikt hebt, dus
+      het is een alinea waard.
+    </p>
+    <p>
+      HEVC decoderen vraagt om een HEVC-decoder, en HEVC is gepatenteerd. De
+      licentieverlening wordt door meer dan één patentpool geregeld, en een
+      decoder meeleveren betekent iemand betalen. Browsers gaan daarmee om door
+      op het besturingssysteem te leunen &mdash; Chrome speelt HEVC-<em>video</em>
+      af op een machine waarvan de hardware al een gelicentieerde decoder heeft
+      &mdash; maar die route is aangesloten op videoweergave en niet op
+      stilstaand beeld. Een HEIC die aan <code>&lt;img&gt;</code> gegeven wordt,
+      wordt dus geweigerd, in Chrome, Firefox en Edge, op elk
+      besturingssysteem.
+    </p>
+    <p>
+      Safari op Apple-hardware is de uitzondering, omdat macOS en iOS de decoder
+      hebben en Safari hem mag aanroepen. Overal elders is het plaatje voor de
+      browser domweg niet te decoderen.
+    </p>
+    <p>
+      Wat een omzetter precies twee mogelijkheden laat, en de keuze daartussen is
+      het hele verhaal van dit soort tools.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom vrijwel elke HEIC-omzetter een upload wil</h2>
+    <p>
+      Mogelijkheid één: zet de decoder op een server. De foto wordt geüpload,
+      gedecodeerd op een machine die je nooit gezien hebt, opnieuw gecodeerd als
+      jpeg, en teruggestuurd. Dat is wat vrijwel elke &ldquo;gratis online
+      HEIC-omzetter&rdquo; doet, en daarom hebben ze allemaal je bestanden nodig.
+      Het is geen luiheid &mdash; de browser kan het werkelijk niet op eigen
+      kracht.
+    </p>
+    <p>
+      Wat het kost is het waard om ronduit te zeggen. Foto's van een telefoon
+      zijn de meest persoonlijke bestanden die de meeste mensen hebben, en een
+      HEIC die zo van een iPhone komt, draagt doorgaans de coördinaten van waar
+      hij genomen is mee, tot op een paar meter nauwkeurig, samen met de datum op
+      de seconde en een camera-aanduiding. Een map ervan naar een gratis dienst
+      uploaden betekent zowel de plaatjes als dat weggeven. Wat er daarna gebeurt
+      wordt bepaald door een privacybeleid dat je niet gelezen hebt, op een
+      server die je niet kunt inspecteren, in een rechtsgebied dat je niet gekozen
+      hebt.
+    </p>
+    <p>
+      Mogelijkheid twee: zet de decoder op de pagina. Dat is wat
+      <a href="../../heic-naar-jpg/">deze</a> doet. Hij draagt
+      <code>libheif</code> mee, gecompileerd naar WebAssembly, als een bestand
+      dat vanaf deze site geserveerd wordt &mdash; zo'n 1,4 MB, één keer
+      gedownload en daarna in de cache. Je browser draait het op je eigen
+      apparaat, op je eigen hardware, en de foto gaat nergens heen. Laad de
+      pagina één keer en je kunt de stekker helemaal uit het internet trekken en
+      hij werkt door, en dat is iets wat geen enkele uploadende omzetter kan en
+      het eenvoudigste bewijs dat er is.
+    </p>
+    <p>
+      Die 1,4 MB is de hele prijs. Zit je op een verbinding met een datalimiet,
+      dan is het een echte kostenpost en het weten waard; daarom zegt de pagina
+      het hardop in plaats van het stilletjes te downloaden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat omzetten het plaatje kost</h2>
+    <p>
+      HEIC en jpeg zijn verschillende codecs, dus er is geen weg ertussen die
+      niet inhoudt dat het plaatje gedecodeerd en opnieuw gecodeerd wordt. Die
+      tweede codering is verliesgevend. In de praktijk telt dat veel minder dan
+      het klinkt:
+    </p>
+    <ul>
+      <li>
+        <strong>Op kwaliteit 92</strong> &mdash; waar de omzetter begint &mdash;
+        is een foto op elk normaal kijkformaat heel moeilijk van het origineel te
+        onderscheiden. Je zoekt naar verschillen in vloeiende verlopen, zoals een
+        strakke lucht, en die vind je meestal niet.
+      </li>
+      <li>
+        <strong>De jpeg wordt groter.</strong> Meestal ergens tussen een derde
+        groter en twee keer zo groot, want jpeg is een codec uit 1992 en HEVC
+        niet. Dat is de ruil: een groter bestand dat alles opent.
+      </li>
+      <li>
+        <strong>Twee keer omzetten is wat je moet vermijden.</strong> Elke
+        verliesgevende codering kost een beetje. Zet om vanaf de originele HEIC,
+        niet vanaf een jpeg die iemand al voor je gemaakt heeft, en doe het één
+        keer.
+      </li>
+    </ul>
+    <p>
+      Wil je helemaal geen verlies, dan staat png op het formaatmenu. Wees
+      voorbereid op het bestand: een foto als png is meestal vijf tot tien keer
+      zo groot als de jpeg, omdat de compressie van png ontworpen is voor vlakke
+      kleur en lijntekeningen en niet voor gras en huid.
+    </p>
+  </section>
+
+  <section>
+    <h2>De datum, de camera en de coördinaten</h2>
+    <p>
+      De gebruikelijke klacht over HEIC-omzetters is dat de foto's terugkomen
+      zonder de dag waarop ze genomen zijn, zodat een vakantie aan foto's
+      onderaan de bibliotheek sorteert onder de datum van vandaag. Dat gebeurt
+      omdat omzetten via een canvas je pixels geeft en verder niets &mdash; een
+      canvas bevat geen tags &mdash; dus tenzij een omzetter de metagegevens
+      apart gaat ophalen, zijn ze domweg weg.
+    </p>
+    <p>
+      De tool hier kopieert het EXIF-blok uit de HEIC en schrijft het in de jpeg,
+      dus de datum overleeft het. Er is een vinkje, en dat staat standaard aan.
+      Zet het uit en de jpeg komt eruit met het plaatje en verder niets.
+    </p>
+    <p>
+      Kijk voordat je beslist naar de lijst: bij elke foto staat op de regel of
+      het bestand gps-coördinaten meedraagt, en het staat er voordat er iets
+      omgezet wordt. Gaan de foto's ergens openbaar heen, dan is dat de regel om
+      te lezen. Gaan ze je eigen bibliotheek in, dan is de metagegevens houden
+      vrijwel zeker wat je wilt.
+    </p>
+    <p>
+      Eén tag verandert er hoe je ook kiest, en het is het weten waard waarom.
+      Een HEIC legt zijn draaiing op twee plekken vast: in de container, en in
+      het EXIF-blok. De decoder past de draaiing van de container toe tijdens het
+      decoderen, dus de pixels die overhandigd worden staan al rechtop. Zou het
+      EXIF dan nog zeggen &ldquo;draai dit 90 graden&rdquo;, dan zou een kijker
+      het nog eens doen en zou elke staande foto er op zijn kant uit komen. De
+      oriëntatietag wordt daarom op rechtop gezet en al het andere wordt precies
+      gekopieerd zoals de telefoon het schreef.
+    </p>
+    <p>
+      Wil je de tags in detail doorlopen, of ze weghalen bij foto's die al jpeg
+      zijn, dan is dat een andere klus en is er
+      <a href="../exif-en-gps-gegevens-verwijderen/">een gids voor</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dingen waar mensen op stuklopen</h2>
+    <ul>
+      <li>
+        <strong>Een HEIC die &ldquo;.jpg&rdquo; heet.</strong> Komt heel vaak
+        voor: iets heeft hem onderweg hernoemd zonder hem om te zetten, en daarom
+        gaat hij nog steeds niet open. Elk bestand dat op de omzetter gesleept
+        wordt, wordt aan zijn eerste bytes herkend en niet aan zijn naam, dus zo
+        een werkt gewoon. Het is ook waarom een bestand dat werkelijk een jpeg is
+        dat te horen krijgt in plaats van omgezet te worden in een kopie van
+        zichzelf.
+      </li>
+      <li>
+        <strong>Eén bestand, meerdere plaatjes.</strong> Een burst of een Live
+        Photo kan meer dan één stilstaand beeld bevatten. Ze worden allemaal
+        omgezet, en de extra worden genummerd achter de originele naam. De
+        videohelft van een Live Photo is een apart bestand dat de telefoon naast
+        de HEIC bewaart, dus dat zit er niet in om om te zetten.
+      </li>
+      <li>
+        <strong>AVIF is geen HEIC.</strong> Ze lijken op elkaar &mdash; dezelfde
+        container, een andere codec erin &mdash; maar elke huidige browser opent
+        een AVIF vanzelf, dus er valt niets om te zetten en de tool zegt dat in
+        plaats van te doen alsof hij werkt.
+      </li>
+      <li>
+        <strong>Het probleem bij de bron stoppen.</strong> Op de telefoon:
+        Instellingen &rarr; Camera &rarr; Structuren &rarr; Meest compatibel.
+        Nieuwe foto's zijn vanaf dan jpeg's. Het gebruikt meer opslag en het
+        raakt de foto's die je al hebt niet aan, maar het betekent dat je dit
+        nooit meer hoeft te doen.
+      </li>
+      <li>
+        <strong>Delen zet soms al om.</strong> Een foto via AirDrop of e-mail
+        naar een niet-Apple-apparaat sturen levert vaak een jpeg op, omdat iOS op
+        de uitgang omzet. Is een foto toch als HEIC aangekomen, dan is hij
+        binnengekomen via een route die dat niet deed.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Hoe je ziet of een omzetter uploadt</h2>
+    <p>
+      Dit geldt voor elke tool, niet alleen voor deze, en het kost een seconde of
+      vijftien.
+    </p>
+    <ol>
+      <li>
+        Open de pagina, open daarna de ontwikkelaarsgereedschappen van je browser
+        en ga naar het tabblad Netwerk.
+      </li>
+      <li>
+        Zet een foto om, en kijk mee. Een tool die op je eigen apparaat
+        decodeert, doet op dat moment helemaal geen verzoek. Een tool die uploadt
+        doet er een ter grootte van je foto, en die grootte kun je zien.
+      </li>
+      <li>
+        Of, eenvoudiger: laad de pagina, verbreek de internetverbinding, en
+        probeer iets om te zetten. Een tool die je foto wegstuurde om hem te
+        laten decoderen, houdt op met werken. Een die de decoder meedraagt niet.
+      </li>
+    </ol>
+    <p>
+      De omzetter hier is gebouwd om allebei de controles te doorstaan, en er
+      staat een langere versie van dit betoog in
+      <a href="../is-bestanden-uploaden-veilig/">is het veilig om bestanden te
+      uploaden</a>.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/nl/pages/guides/convert-heic-to-jpg.toml
@@ -1,0 +1,17 @@
+#
+# Gids: het formaat waarin een iPhone opslaat, en hoe je eruit komt - Dutch.
+#
+
+nav = "HEIC naar JPG"
+title = "HEIC naar JPG omzetten (en wat HEIC eigenlijk is)"
+description = "iPhones slaan foto's op als HEIC, en het halve internet kan er geen openen. Wat het formaat is, waarom alleen Safari het decodeert, wat omzetten het plaatje kost, en hoe je het doet zonder de foto's aan iemand te uploaden."
+heading = "De foto die je telefoon opsloeg, en het formaat dat niets wil openen"
+lede = """
+    Een iPhone slaat foto's op als HEIC, wat kleiner en beter is dan jpeg en wat
+    een hoop software nog steeds weigert te openen. Dit gaat over wat het
+    formaat werkelijk is, wat omzetten het plaatje kost, en waarom vrijwel elke
+    omzetter wil dat je het eerst uploadt."""
+updated = "20 augustus 2026"
+og_title = "HEIC naar JPG omzetten"
+og_description = "Waarom iPhone-foto's niet opengaan, wat omzetten kost, en hoe je het doet zonder de foto's aan iemand te geven."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/crop-a-video.html
+++ b/locales/nl/pages/guides/crop-a-video.html
@@ -1,0 +1,214 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../video-bijsnijden/">Videobijsnijder</a>, sleep het
+      filmpje erin, sleep het kader over het stuk dat je wilt houden &mdash; of
+      zet het vast op een vorm als je er een gekregen hebt &mdash; en exporteer.
+      Het filmpje dat eruit komt is precies zo lang als dat wat erin ging, met
+      zijn timing en zijn geluid intact.
+    </p>
+    <p>
+      Anders dan inkorten moet dit nieuwe frames schrijven. Dat is geen gebrek
+      van een bepaalde tool; dat is wat bijsnijden is. De rest van deze pagina
+      gaat over wat dat kost en hoe je het klein houdt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom bijsnijden niet om een hercodering heen kan</h2>
+    <p>
+      Een inkorting houdt hele frames, dus een goede knipper zet ze onaangeroerd
+      over en wordt er helemaal niets gedecodeerd. Een bijsnijding houdt een deel
+      van elk frame &mdash; en een deel van een frame is een ander beeld. Er is
+      geen manier om een ander beeld op te slaan zonder de pixels opnieuw weg te
+      schrijven.
+    </p>
+    <p>
+      Er is een smalle uitzondering, en die is het kennen waard zodat je hem
+      herkent wanneer iemand er een beroep op doet. Video wordt in blokken
+      gecodeerd, en als een bijsnijding aan alle vier de kanten precies op
+      blokgrenzen landde, zou een deel van de gegevens in principe hergebruikt
+      kunnen worden. In de praktijk moeten de afmetingen van het frame zelf, de
+      bewegingsvectoren en de voorspelling toch herschreven worden, dus er wordt
+      niets echts zo gebouwd. Ga ervan uit dat een bijsnijding een hercodering
+      betekent.
+    </p>
+    <p>
+      Wat een fatsoenlijke bijsnijder wél doet, is niet <em>meer</em> uitgeven
+      dan het origineel aan datzelfde gebied uitgaf. Een bijgesneden gebied op
+      een hogere bitsnelheid coderen dan zijn bron maakt het bestand alleen
+      groter; het kan geen detail terugzetten dat het origineel niet had.
+    </p>
+  </section>
+
+  <section>
+    <h2>De vormen waar je werkelijk om gevraagd wordt</h2>
+    <p>
+      Het meeste bijsnijden gebeurt omdat ergens een beeldverhouding vereist is.
+      Het korte lijstje:
+    </p>
+    <ul>
+      <li>
+        <strong>9:16 &mdash; staand.</strong> Verhalen, reels, shorts, TikTok.
+        Schermvullend op een telefoon die normaal vastgehouden wordt. Veruit de
+        meest voorkomende reden dat iemand überhaupt een video bijsnijdt.
+      </li>
+      <li>
+        <strong>1:1 &mdash; vierkant.</strong> Berichten in de tijdlijn op
+        verschillende platforms. Werkt hoe de kijker zijn telefoon ook
+        vasthoudt, en daarom blijft het bestaan.
+      </li>
+      <li>
+        <strong>4:5 &mdash; licht staand.</strong> De grootste vorm die sommige
+        tijdlijnen toelaten, dus hij pakt meer van het scherm dan een vierkant
+        zonder een volledig verticale video te zijn.
+      </li>
+      <li>
+        <strong>16:9 &mdash; breed.</strong> De standaard voor video in het
+        algemeen. Je snijdt hier meestal alleen <em>naartoe</em> om zwarte balken
+        weg te halen, of <em>vanaf</em> om een van de bovenstaande te krijgen.
+      </li>
+    </ul>
+    <p>
+      Zet het kader op de verhouding vast in plaats van op het oog te slepen. Een
+      paar pixels ernaast betekent dat het platform jouw bijsnijding bijsnijdt,
+      en het overlegt niet met je over waar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Een liggend filmpje staand maken</h2>
+    <p>
+      Dit is het lastigste veelvoorkomende geval, en het is de moeite waard om
+      helder te zijn dat bijsnijden een compromis is in plaats van een oplossing.
+    </p>
+    <p>
+      Een 16:9-video die naar 9:16 bijgesneden wordt, houdt ongeveer 32% van de
+      beeldbreedte. Wat aan de zijkanten zit is weg &mdash; en in een liggende
+      opname zit de context meestal juist aan de zijkanten. Praten er twee mensen
+      aan weerszijden van het beeld, dan houdt geen enkele uitsnede ze allebei.
+    </p>
+    <p>
+      Kies de uitsnede door het filmpje één keer te bekijken en je af te vragen
+      waar het onderwerp het grootste deel van de tijd werkelijk zit. Is het
+      antwoord &ldquo;het beweegt&rdquo;, dan is een vaste uitsnede het verkeerde
+      gereedschap en wil je een editor die de uitsnede in de tijd kan
+      meebewegen. Is het antwoord &ldquo;grotendeels in het midden&rdquo;, dan is
+      een gecentreerde uitsnede prima en kost het tien seconden.
+    </p>
+    <p>
+      Het alternatief dat het onthouden waard is: veel platforms accepteren een
+      liggende video en zetten er zelf balken omheen. Bijsnijden is voor wanneer
+      je het volle scherm wilt, niet voor wanneer je wilt dat de video
+      geaccepteerd wordt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom de breedte en hoogte met stappen van twee gaan</h2>
+    <p>
+      Merk je dat het bijsnijdkader oneven getallen weigert, dan is dat de codec
+      die moeilijk doet en niet de bediening.
+    </p>
+    <p>
+      H.264 &mdash; de codec in een mp4 &mdash; slaat kleur horizontaal en
+      verticaal op halve resolutie op, omdat het oog veel minder gevoelig is voor
+      kleurdetail dan voor helderheid. Dat betekent dat het beeld in eenheden van
+      twee pixels behandeld wordt en dat er geen manier is om een frame met een
+      oneven aantal pixels op een zijde te beschrijven.
+    </p>
+    <p>
+      Tools gaan daarmee om door je uitsnede af te ronden nadat je hem ingesteld
+      hebt, wat je kader zonder mededeling een pixel verschuift, of door van meet
+      af aan alleen even getallen aan te bieden. Het tweede is wat hier gebeurt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat er met het geluid gebeurt</h2>
+    <p>
+      Op de mp4-route niets. Bijsnijden verandert het beeld en heeft geen reden
+      om de audio aan te raken, dus de audio wordt monster voor monster
+      overgezet zonder ooit gedecodeerd te worden &mdash; byte voor byte wat er
+      in het bestand zat.
+    </p>
+    <p>
+      Op de opnameterugval, hieronder beschreven, wordt het geluid van de weergave
+      opgevangen en opnieuw gecodeerd, wat een beetje kwaliteit kost. Hoe dan ook
+      is er een vinkje om het er helemaal uit te laten, en dat is het gebruiken
+      waard wanneer het filmpje ergens heen gaat waar het toch gedempt speelt en
+      je het kleinste bestand wilt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formaten, en hoe lang het duurt</h2>
+    <p>
+      <strong>Mp4, m4v en mov</strong> worden rechtstreeks gelezen, wat er ook in
+      zit &mdash; H.264, HEVC, AV1 of VP9 &mdash; zolang je browser die codec kan
+      decoderen. Anders dan bij inkorten moet er bij bijsnijden wél gedecodeerd
+      worden, dus doet de codec hier ertoe op een manier die daar niet gold.
+    </p>
+    <p>
+      <strong>Al het andere dat je browser kan afspelen</strong>, WebM het meest
+      voor de hand liggend, wordt bijgesneden door het af te spelen en het
+      resultaat op te nemen, wat werkt en zo lang duurt als het filmpje is.
+    </p>
+    <p>
+      <strong>Avi, wmv, flv en de meeste mkv's</strong> kan de browser niet lezen
+      en niet afspelen, en de tool weigert ze met een melding in plaats van
+      halverwege te stranden.
+    </p>
+    <p>
+      Reken erop dat een bijsnijding bij een lang filmpje echte tijd kost, want
+      elk frame wordt gedecodeerd en opnieuw gecodeerd. In de tool zit geen
+      limiet, en het bestand wordt een paar megabyte tegelijk doorlopen in plaats
+      van in zijn geheel geladen; het praktische plafond is de gereedgekomen
+      video, die in het geheugen wordt opgebouwd voordat je hem downloadt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Snijd bij vóór je iets anders doet</h2>
+    <p>
+      Moet een filmpje zowel ingekort als bijgesneden worden, kort dan eerst in
+      &mdash; dat is gratis, en elke seconde die je eraf haalt is een seconde die
+      niemand hoeft te hercoderen. Snijd daarna het kortere filmpje één keer bij.
+    </p>
+    <p>
+      Andersom betekent beeldmateriaal bijsnijden dat je op het punt staat weg te
+      gooien, en dat kost tijd en kwaliteit voor niets. De
+      <a href="../../video-knippen/">Videoknipper</a> staat ernaast, en
+      <a href="../een-video-inkorten/">de bijbehorende gids</a> legt uit waarom
+      die stap je helemaal niets hoeft te kosten.
+    </p>
+    <p>
+      Algemener: elke verliesgevende stap stapelt op. Eén bijsnijding van een
+      origineel is één generatie. Een bijsnijding van een inkorting van een export
+      van een download is er vier, en dat zie je.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom hier niets voor geüpload hoeft te worden</h2>
+    <p>
+      Video decoderen en hercoderen in een browser is recent en het is echt:
+      WebCodecs legt dezelfde hardware-encoder bloot die je telefoon gebruikt om
+      video op te nemen, en het is om diezelfde reden snel. Het werk gebeurt op
+      het apparaat dat het bestand al heeft, en bij een video van meerdere
+      gigabytes is dat ook de enige opstelling die hout snijdt &mdash; hem
+      uploaden en het resultaat downloaden kost meer tijd dan het coderen zelf.
+    </p>
+    <p>
+      De tool hier heeft geen enkele netwerkfunctie, en de
+      <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+      mag benaderen; geen ervan hoort bij deze site. Trek de stekker uit het
+      internet en snijd er toch een bij, als je liever controleert dan het
+      aanneemt.
+    </p>
+    <p>
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet nog drie controles op een rij die je
+      op elke tool kunt loslaten.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/crop-a-video.toml
+++ b/locales/nl/pages/guides/crop-a-video.toml
@@ -1,0 +1,17 @@
+#
+# Gids: een video bijsnijden - Dutch.
+#
+
+nav = "Een video bijsnijden"
+title = "Een video naar een andere vorm bijsnijden"
+description = "Snijd een filmpje terug naar een vierkant, een staande 9:16, of een exact pixelkader. Welke verhouding elk platform wil, waarom bijsnijden wel moet hercoderen en inkorten niet, en wat dat kost."
+heading = "Hoe je een video naar een andere vorm bijsnijdt"
+lede = """
+    Bijsnijden verandert de vorm van het beeld, en dat betekent nieuwe frames
+    schrijven &mdash; daar is geen weg omheen, en elke tool die iets anders
+    beweert doet iets anders. Hier staat wat het kost, en hoe je het goed
+    uitgeeft."""
+updated = "20 augustus 2026"
+og_title = "Hoe je een video naar een andere vorm bijsnijdt"
+og_description = "Welke beeldverhouding elk platform wil, waarom bijsnijden wel moet hercoderen en inkorten niet, en wat dat kost."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/embed-an-image-in-css.html
+++ b/locales/nl/pages/guides/embed-an-image-in-css.html
@@ -1,0 +1,316 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open <a href="../../afbeelding-naar-base64/">Afbeelding naar data-URI</a>,
+      sleep het plaatje erin, kies <em>Een CSS custom property</em>, en plak de
+      regel boven aan je stylesheet. Gebruik hem daarna als
+      <code>background-image: var(--logo)</code> waar je hem nodig hebt.
+    </p>
+    <p>
+      Doe dat wanneer het plaatje klein is &mdash; een icoontje, een opsommingsteken,
+      een pijltje, een patroon &mdash; en op elke pagina nodig is. Doe het niet
+      met een foto. Alles hieronder gaat over waarom die twee zinnen verschillen,
+      en hoe je ziet naar welke van de twee je kijkt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat een data-URI eigenlijk is</h2>
+    <p>
+      Een adres dat het ding bevat in plaats van ernaar te wijzen. Waar een
+      stylesheet normaal zou zeggen
+    </p>
+    <pre><code>background-image: url("logo.png");</code></pre>
+    <p>
+      en de browser <code>logo.png</code> gaat ophalen, zegt een data-URI
+    </p>
+    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <p>
+      en valt er niets op te halen: het plaatje is er al, uitgeschreven in
+      tekens. Er zijn drie delen. <code>data:</code> is het schema.
+      <code>image/png</code> is het mediatype, en de browser gelooft dat
+      volledig &mdash; daarover hieronder meer. Alles na de komma is het bestand.
+    </p>
+    <p>
+      Dat is het hele idee. Het is geen truc of een hack; het staat sinds 1998 in
+      de standaarden en werkt in elke browser die sindsdien uitgekomen is.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat het je oplevert: één heen-en-weer minder</h2>
+    <p>
+      De besparing is geen bandbreedte. Het is het verzoek.
+    </p>
+    <p>
+      Een browser kan pas om <code>logo.png</code> vragen als hij de stylesheet
+      gelezen heeft die het noemt, en die stylesheet kan hij pas lezen als hij
+      hem opgehaald heeft. Een gewone achtergrondafbeelding zit dus minstens twee
+      heen-en-weren diep in het laden van de pagina, en op een telefoon op een
+      traag netwerk kan een heen-en-weer een paar honderd milliseconde zijn, hoe
+      klein het bestand ook is. Een pijltje van 600 bytes kost bijna niets om te
+      versturen en kan toch een kwart seconde kosten om aan te komen.
+    </p>
+    <p>
+      Ingesloten komt hij met de stylesheet mee. Dat is het hele voordeel, en
+      voor een klein icoontje boven de vouw is het een echt voordeel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat het kost: een derde, en dan de caching</h2>
+    <p>
+      <strong>Base64 doet er ongeveer een derde bij.</strong> Drie bytes bestand
+      worden vier tekens, want dat is wat het kost om willekeurige bytes op te
+      schrijven met alleen de tekens die een URL toestaat. Er bestaat geen slimme
+      encoder die eromheen komt. Een png van 9 kB is 12 kB stylesheet.
+    </p>
+    <p>
+      <strong>Compressie geeft het niet terug.</strong> Dit is het stuk dat
+      mensen wegredeneren. Gzip en Brotli werken door herhaling te vinden, en een
+      png, een jpeg en een WebP zijn al gecomprimeerd &mdash; er zit heel weinig
+      herhaling meer in, en base64 voegt er geen toe. In de praktijk krijg je
+      zoiets als een tiende van die derde terug, niet het geheel. (Een svg is het
+      omgekeerde geval, en daar gaat het volgende deel over.)
+    </p>
+    <p>
+      <strong>Het houdt op een bestand te zijn.</strong> Dat is de kostenpost die
+      niet opduikt in enige meting die je waarschijnlijk doet, en het is degene
+      die op omvang telt:
+    </p>
+    <ul>
+      <li>
+        <strong>Hij kan niet los in de cache.</strong> Een gewone afbeelding
+        wordt één keer opgehaald en een jaar lang hergebruikt. Een ingesloten is
+        onderdeel van de stylesheet, dus hij leeft en sterft met het
+        cache-item van die stylesheet.
+      </li>
+      <li>
+        <strong>Iets veranderen downloadt alles opnieuw.</strong> Herstel een
+        marge, lever een nieuwe stylesheet uit, en elke bezoeker downloadt het
+        ingesloten plaatje er weer bij &mdash; een plaatje dat in twee jaar niet
+        veranderd is.
+      </li>
+      <li>
+        <strong>Hij staat op het kritieke pad.</strong> Een stylesheet blokkeert
+        het renderen. Een afbeelding niet. Een plaatje insluiten verplaatst het
+        van de tweede categorie naar de eerste: de pagina kan niet tekenen tot
+        het geheel, plaatje inbegrepen, is aangekomen.
+      </li>
+      <li>
+        <strong>Hij kan niet parallel opgehaald worden.</strong> Browsers
+        downloaden veel dingen tegelijk. Een ingesloten plaatje is geen apart
+        ding, dus daar krijgt het niets van mee.
+      </li>
+    </ul>
+    <p>
+      Ruwe drempels, die aangeven waar het advies verandert en niet waar een
+      browser iets anders doet: onder ongeveer 2 kB is het een duidelijke winst;
+      tot zo'n 10 kB is het meestal nog de moeite waard voor iets dat op elke
+      pagina staat; voorbij 50 kB is het een vergissing zonder foutmelding.
+      <a href="../../afbeelding-naar-base64/">De tool</a> zegt in welke band elk
+      resultaat valt, met het aantal tekens ernaast.
+    </p>
+  </section>
+
+  <section>
+    <h2>Maak nooit base64 van een svg</h2>
+    <p>
+      Dit is veruit de meest voorkomende fout bij ingesloten afbeeldingen, en hij
+      wordt door exporteurs en bouwplug-ins net zo vaak gemaakt als door mensen.
+    </p>
+    <p>
+      Een svg is tekst. Een URL draagt tekst al. Er hoeft maar een handvol tekens
+      ontsnapt te worden &mdash; <code>%</code>, <code>#</code>,
+      <code>&lt;</code>, <code>&gt;</code> en het aanhalingsteken waar je hem in
+      gezet hebt &mdash; en al het andere kan precies blijven zoals het is. Zo
+      coderen levert een URI op die meestal zo'n vijfde korter is dan de base64
+      van hetzelfde bestand, en die daarna comprimeert als tekst in plaats van
+      als ruis.
+    </p>
+    <p>
+      Hij is bovendien nog leesbaar:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <p>
+      Je ziet de <code>viewBox</code>. Je kunt de vulkleur in je editor wijzigen
+      zonder iets te decoderen. Maak van hetzelfde bestand base64 en het wordt een
+      muur van letters die niemand ooit nog aanraakt.
+      <a href="../../afbeelding-naar-base64/">Afbeelding naar data-URI</a> doet
+      dit automatisch voor alles wat een svg blijkt te zijn, en heeft een vinkje
+      voor de zeldzame toolchain die op <code>;base64</code> staat.
+    </p>
+  </section>
+
+  <section>
+    <h2>De aanhalingsfout die alleen svg's breekt</h2>
+    <p>
+      CSS laat je <code>url()</code> zonder aanhalingstekens schrijven, en voor
+      een gewone bestandsnaam is dat prima:
+    </p>
+    <pre><code>background-image: url(logo.png);</code></pre>
+    <p>
+      Doe hetzelfde met een procentgecodeerde svg en het breekt. Een
+      <code>url()</code>-token zonder aanhalingstekens eindigt bij de eerste
+      spatie, haakje, aanhalingsteken of stuurteken &mdash; en een svg zit vol
+      spaties, tussen elk attribuut en elk getal in een pad. De declaratie is dan
+      ongeldig, CSS gooit ongeldige declaraties stilletjes weg, en je krijgt geen
+      achtergrond en geen foutmelding.
+    </p>
+    <p>
+      De oplossing is aanhalingstekens, elke keer:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
+    <p>
+      Dat is ook waarom een encoder spaties niet hoeft te ontsnappen &mdash; die
+      zijn volstrekt legaal binnen een URL tussen aanhalingstekens, en elke spatie
+      als <code>%20</code> ontsnappen zou drie tekens kosten per spatie in het
+      bestand. De twee beslissingen horen bij elkaar: zet de URI tussen
+      aanhalingstekens en je kunt de spaties met rust laten. Elke vorm die de tool
+      oplevert staat precies daarom tussen aanhalingstekens.
+    </p>
+  </section>
+
+  <section>
+    <h2>Het mediatype moet kloppen</h2>
+    <p>
+      Een data-URI geeft zijn eigen type op, en de browser gelooft hem op zijn
+      woord. Er is geen terugval op snuffelen zoals bij een opgehaald bestand:
+      zeg <code>image/png</code> over iets dat in werkelijkheid een jpeg is en
+      het plaatje verschijnt niet, zonder een melding op enige nuttige plek.
+    </p>
+    <p>
+      En dat telt, want bestandsextensies liegen. Een foto die als jpeg
+      geëxporteerd is en <code>logo.png</code> hernoemd, is een gewoon ding om op
+      een schijf tegen te komen. De eerste paar bytes van een afbeeldingsbestand
+      zeggen daarentegen ondubbelzinnig wat het is &mdash; elk formaat heeft een
+      handtekening &mdash; dus een tool hoort het bestand te lezen en niet zijn
+      naam. Die hier doet dat, en zegt het je wanneer de twee het oneens zijn.
+    </p>
+    <p>
+      Twee formaten zijn het weten waard omdat ze op een verwarrende manier
+      falen. <strong>HEIC</strong>, waarin een iPhone fotografeert, en
+      <strong>TIFF</strong>, wat scanners opleveren, maken allebei volkomen
+      geldige data-URI's die geen enkele browser behalve Safari wil tekenen. De
+      URI is niet kapot; het formaat is domweg niet een dat het web ondersteunt.
+      Zet eerst om.
+    </p>
+  </section>
+
+  <section>
+    <h2>De metagegevens die je niet wilde publiceren</h2>
+    <p>
+      Een data-URI is een kopie van het bestand, byte voor byte. Er wordt niets
+      gedecodeerd en hercodeerd, wat meestal juist de bedoeling is &mdash; er gaat
+      geen kwaliteit verloren &mdash; maar het betekent ook dat al het andere in
+      het bestand meekomt.
+    </p>
+    <p>
+      Een foto die zo van een telefoon komt draagt EXIF mee: de gps-coördinaten
+      van waar hij genomen is, de tijdstempel, het cameramodel en vaak het
+      serienummer. Dat kan 30 kB van het bestand zijn. Ingesloten wordt het 40 kB
+      base64 in je stylesheet, op het kritieke pad van elke pagina &mdash; en een
+      woonadres dat naar een repository gecommit wordt, in een vorm waar niemand
+      ooit aan denkt te kijken.
+    </p>
+    <p>
+      Haal het er eerst uit met de
+      <a href="../../exif-gegevens-verwijderen/">EXIF-lezer &amp; -wisser</a>,
+      die de container herschrijft zonder het plaatje aan te raken; daar is ook
+      <a href="../exif-en-gps-gegevens-verwijderen/">een gids voor</a>.
+      Afbeelding naar data-URI leest hoeveel metagegevens er in een jpeg, png of
+      WebP zitten en zegt het voordat je iets kopieert.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waar je hem zet, als je hem eenmaal hebt</h2>
+    <p>
+      Komt het plaatje in één regel voor, zet de URI dan in die regel. Komt het in
+      meer dan één voor &mdash; en bij icoontjes is dat meestal zo, zodra je de
+      hover-toestand en het donkere thema meetelt &mdash; declareer hem dan één
+      keer als custom property:
+    </p>
+    <pre><code>:root {
+  --icon-search: url("data:image/svg+xml,%3Csvg ... %3E");
+}
+
+.search-field { background-image: var(--icon-search); }
+.search-button::before { content: var(--icon-search); }</code></pre>
+    <p>
+      Een URI van 3 kB die in vier regels geplakt is, is 12 kB stylesheet en vier
+      plekken om te bewerken wanneer het icoon verandert. De custom property is
+      één van elk. Het is ook de vorm die themawisseling laat werken: herdefinieer
+      <code>--icon-search</code> binnen een mediaquery en elk gebruik ervan
+      volgt.
+    </p>
+    <p>
+      Voor een <code>&lt;img&gt;</code>-tag in plaats van CSS: zet er
+      <code>width</code> en <code>height</code> bij. Een ingesloten afbeelding
+      laadt ogenblikkelijk, dus een ontbrekend formaat is een layoutverschuiving
+      die te snel gaat om te zien en die toch tegen je telt. De uitzondering is
+      svg: een die alleen een <code>viewBox</code> meedraagt heeft zelf geen
+      pixelformaat, en de standaard 300&times;150 van de browser op de tag zetten
+      pint een schaalbaar plaatje vast op een formaat dat niemand gekozen heeft.
+    </p>
+    <p>
+      Laat de <code>alt</code> leeg tenzij je er iets waars in te zetten hebt.
+      Alleen jij weet of het plaatje betekenis draagt of versiering is, en een
+      beschrijving die uit een bestandsnaam geraden is, is voor iemand met een
+      schermlezer erger dan helemaal geen beschrijving.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wanneer het antwoord &ldquo;niet doen&rdquo; is</h2>
+    <p>
+      Is het plaatje gecodeerd groter dan ongeveer 50 kB, dan is insluiten het
+      verkeerde gereedschap en lost geen enkele zorgvuldigheid bij het coderen dat
+      op. De alternatieven, op volgorde van proberen:
+    </p>
+    <ul>
+      <li>
+        <strong>Maak het kleiner.</strong> De meeste afbeeldingen die te groot
+        zijn om in te sluiten, zijn sowieso te groot. De
+        <a href="../../afbeelding-comprimeren/">Afbeeldingscompressor</a> brengt
+        een foto naar een grootte die jij noemt, en
+        <a href="../../afbeelding-formaat-wijzigen/">Afbeeldingsformaat
+        wijzigen</a> brengt de pixelafmetingen terug tot wat de opmaak werkelijk
+        gebruikt &mdash; en dat is heel vaak het echte probleem.
+      </li>
+      <li>
+        <strong>Teken het opnieuw als svg.</strong> Een icoontje dat als png van
+        40 kB geëxporteerd is, is vaak een svg van 900 bytes. Dat is geen
+        compressieverschil maar een formaatverschil, en het lost meteen het
+        retinaprobleem op.
+      </li>
+      <li>
+        <strong>Laat het een bestand en laad het vooruit.</strong>
+        <code>&lt;link rel="preload" as="image"&gt;</code> start het ophalen
+        meteen zonder de bytes op het kritieke pad te zetten. Het levert het
+        meeste voordeel van insluiten op en niets van de cachekosten.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Hier hoeft niets voor geüpload te worden</h2>
+    <p>
+      Een bestand als base64 coderen is rekenen. Het zijn twee functies die de
+      browser al sinds het begin heeft &mdash; <code>btoa</code> en
+      <code>encodeURIComponent</code> &mdash; en er is werkelijk geen technische
+      reden voor een plaatje om naar een server en terug te reizen om anders
+      opgeschreven te worden. Elke omzetter die je bestand daarvoor uploadt,
+      uploadt het om zijn eigen redenen en niet om die van jou.
+    </p>
+    <p>
+      <a href="../../afbeelding-naar-base64/">De tool hier</a> stuurt het nergens
+      heen: de <code>Content-Security-Policy</code> van de pagina noemt elk adres
+      dat hij mag benaderen, en geen ervan hoort bij deze site. Laad de pagina,
+      trek de stekker uit het internet, en codeer er toch iets, als je liever
+      controleert dan het aanneemt.
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet nog drie controles op een rij die je
+      op elke tool kunt loslaten.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/embed-an-image-in-css.toml
+++ b/locales/nl/pages/guides/embed-an-image-in-css.toml
@@ -1,0 +1,18 @@
+#
+# Gids: een plaatje in een stylesheet zetten - Dutch.
+#
+
+nav = "Een afbeelding in CSS zetten"
+title = "Data-URI's in CSS: wanneer je een afbeelding insluit, en wanneer niet"
+description = "Wat een data-URI kost, waarom base64 er een derde bij doet en gzip dat niet teruggeeft, waarom een svg nooit base64 hoort te zijn, en de aanhalingsfout die ingesloten svg's stilletjes breekt."
+heading = "Wanneer je een plaatje in je CSS zet, en wanneer niet"
+lede = """
+    Een afbeelding die in een stylesheet geschreven staat, komt ermee mee: geen
+    tweede verzoek, geen wachten. Hij houdt ook op een bestand te zijn &mdash;
+    dus hij kan niet los in de cache, en hij wordt opnieuw gedownload elke keer
+    dat er iets eromheen verandert. Dit gaat over waar die ruil het waard is, en
+    waar hij dat stilletjes niet is."""
+updated = "20 augustus 2026"
+og_title = "Wanneer je een plaatje in je CSS zet"
+og_description = "Wat een data-URI kost, waarom een svg nooit base64 hoort te zijn, en de aanhalingsfout die ingesloten svg's stilletjes breekt."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/nl/pages/guides/is-it-safe-to-upload-files.html
@@ -1,0 +1,261 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Voor de meeste bestanden, de meeste tijd, is uploaden prima. Fatsoenlijke
+      omzetters verwijderen binnen een paar uur wat je stuurt en hebben geen
+      belangstelling voor je vakantiefoto's.
+    </p>
+    <p>
+      Het probleem is niet dat ze liegen. Het is dat
+      <strong>je geen manier hebt om na te gaan of ze dat doen</strong>. Zodra
+      een bestand je apparaat verlaat, is elke belofte over wat er daarna gebeurt
+      een belofte die je op vertrouwen aanneemt: hoe lang het bewaard blijft, wie
+      erbij kan, of het gekopieerd wordt naar een back-up die de
+      verwijdertimer overleeft, wat ermee gebeurt als het bedrijf verkocht of
+      gekraakt wordt. Niets daarvan is van buitenaf te zien.
+    </p>
+    <p>
+      De nuttige vraag is dus niet &ldquo;vertrouw ik deze site?&rdquo; Het is
+      <strong>&ldquo;moet mijn bestand voor deze klus überhaupt weg?&rdquo;</strong>
+      Voor een groot en groeiend aantal klussen is het antwoord nee, en wanneer
+      het antwoord nee is, houdt de vertrouwensvraag op er een te zijn die je
+      moet beantwoorden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat &ldquo;uploaden&rdquo; werkelijk doet</h2>
+    <p>
+      Wanneer een omzetter je vraagt een bestand te kiezen en je daarna een
+      voortgangsbalk laat zien, kopieert je browser het hele bestand, byte voor
+      byte, over het internet naar een computer die van iemand anders is. Die
+      computer schrijft het naar een schijf, draait de omzetting, schrijft het
+      resultaat naar diezelfde schijf, en geeft je een link.
+    </p>
+    <p>
+      Op dat moment bestaat je bestand op minstens drie plekken die jij niet
+      gekozen hebt: de schijf van de server, de logboeken die het verzoek
+      vastlegden, en vaak een contentdistributienetwerk dat het resultaat in de
+      cache zette zodat de download snel is. Een verwijderbeleid moet alle drie
+      bereiken. De meeste zeggen dat ze dat doen. Je kunt er geen van controleren.
+    </p>
+    <p>
+      Ook het weten waard: het bestand is niet het enige dat aankomt. De
+      bestandsnaam gaat mee, en alles in het bestand dat je niet kunt zien
+      eveneens. Een foto die zo van een telefoon komt, draagt doorgaans de exacte
+      gps-coördinaten van waar hij genomen is, het tijdstip, het serienummer van
+      de camera, en soms een ingesloten miniatuur van het originele beeld van
+      vóór je bijsnijding. Mensen die voorzichtig zijn met het plaatje zijn dat
+      vaak niet met dat, omdat niets op het scherm het ze laat zien.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom de meeste tools toch uploaden</h2>
+    <p>
+      Niet omdat ze je bestanden willen hebben. Omdat er het grootste deel van
+      het bestaan van het web geen alternatief was. Een browser kon geen video
+      decoderen, geen afbeelding op een gekozen kwaliteit hercoderen, en geen
+      bestandsformaat ontleden; een server met FFmpeg en ImageMagick wel.
+      Uploaden was geen verdienmodel, het was de enige plek waar het werk kon
+      gebeuren.
+    </p>
+    <p>
+      Dat is recent en stilletjes opgehouden waar te zijn. Browsers leveren
+      tegenwoordig WebAssembly mee, dat dezelfde gecompileerde codecs op bijna
+      volle snelheid draait, WebCodecs, dat de hardware-video-encoder blootlegt
+      die al in je apparaat zit, en een Canvas-API die afbeeldingen rechtstreeks
+      kan decoderen en hercoderen. Het werk waar vroeger een server voor nodig
+      was, draait nu op het apparaat dat het bestand al heeft.
+    </p>
+    <p>
+      Genoeg tools uploaden nog steeds, en daar zijn eerlijke redenen voor: een
+      bestaande verwerkingsketen die niemand wil herschrijven, een formaat zonder
+      decoder aan de browserkant, een klus die werkelijk te zwaar is voor een
+      telefoon. Er is ook een minder eerlijke reden, en dat is dat een server de
+      plek is waar accounts, quota's en betaalde lagen wonen. Een tool die
+      volledig in je browser draait, is moeilijk af te rekenen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Vier controles die je zelf kunt doen</h2>
+    <p>
+      Deze werken op elke tool, ook op deze. Voor geen ervan hoef je iemand op
+      zijn woord te geloven, en de eerste kost een seconde of tien.
+    </p>
+
+    <h3>1. Trek de stekker eruit</h3>
+    <p>
+      Laad de pagina, zet daarna je wifi uit of trek de kabel eruit, en probeer
+      hem te gebruiken. Een tool die zijn werk in je browser doet, gaat precies
+      zo door. Een tool die uploadt stopt onmiddellijk, want het ding dat het
+      werk doet is niet meer bereikbaar.
+    </p>
+    <p>
+      Dit is de sterkste test die er is, en de moeilijkste om te veinzen, omdat
+      hij niet met een formulering te beantwoorden valt. Óf de omzetting komt
+      zonder netwerk klaar, óf niet.
+    </p>
+
+    <h3>2. Hou het tabblad Netwerk in de gaten</h3>
+    <p>
+      Open de ontwikkelaarsgereedschappen van je browser, kies Netwerk, en
+      gebruik daarna de tool. Elk verzoek dat de pagina doet, staat er met zijn
+      grootte bij. Is je foto van 4&nbsp;MB geüpload, dan staat er een verzoek
+      van 4&nbsp;MB in die lijst. Is het grootste dat de pagina verlaat een paar
+      kilobyte advertentie, dan is dat niet gebeurd.
+    </p>
+    <p>
+      Sorteer op grootte en kijk bovenaan. Je hoeft de verzoeken niet te
+      begrijpen; je hoeft alleen op te merken of er een de grootte van je bestand
+      heeft.
+    </p>
+
+    <h3>3. Lees de Content-Security-Policy</h3>
+    <p>
+      Bekijk de broncode van de pagina en zoek bovenin naar
+      <code>Content-Security-Policy</code>. Het is een lijst van de adressen die
+      die pagina mag benaderen, en hij wordt afgedwongen door je browser in
+      plaats van door de goede bedoelingen van de site &mdash; een verzoek aan
+      iets dat niet op de lijst staat wordt geweigerd, wat de code ook probeert.
+    </p>
+    <p>
+      De richtlijn die ertoe doet is <code>connect-src</code>, die bepaalt waar
+      de pagina gegevens heen mag sturen. Noemt hij een adres dat bij de site
+      hoort waar je bent, dan kan de pagina je bestand daarheen sturen. Noemt hij
+      niets, of alleen derden zoals een advertentienetwerk, dan kan hij dat niet.
+    </p>
+    <p>
+      Een pagina zonder Content-Security-Policy is geen bewijs van iets slechts.
+      Het betekent alleen dat juist deze controle je niets te vertellen heeft.
+    </p>
+
+    <h3>4. Lees de code</h3>
+    <p>
+      Het minst handig, het meest sluitend. Publiceert een tool zijn broncode en
+      serveert hij die zonder bouwstap, dan zijn de bestanden die je browser
+      ophaalde de bestanden die je kunt lezen. Zoek erin op <code>fetch</code>,
+      <code>XMLHttpRequest</code> en <code>sendBeacon</code> &mdash; de drie
+      manieren waarop een pagina iets kan versturen &mdash; en kijk wat ze
+      meekrijgen.
+    </p>
+    <p>
+      De meeste mensen zullen dit niet doen. Het doet er nog steeds toe dat het
+      kán, want een bewering die niemand kan nagaan is eigenlijk geen bewering.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat &ldquo;draait in je browser&rdquo; niet betekent</h2>
+    <p>
+      Het is de moeite waard hier nauwkeurig te zijn, want de uitdrukking wordt
+      losjes gebruikt en deze site moet zich aan dezelfde lat houden die ze
+      voorstelt.
+    </p>
+    <ul>
+      <li>
+        <strong>Het betekent niet helemaal geen verzoeken.</strong> De pagina
+        zelf kwam over het netwerk binnen, en de meeste gratis tools dragen
+        advertenties of analytics die met iemand praten. De bewering gaat over je
+        <em>bestand</em>, niet over verkeer in het algemeen.
+      </li>
+      <li>
+        <strong>Het verbergt je IP-adres niet.</strong> Elke site die je bezoekt
+        ziet het, deze inbegrepen. Lokaal verwerken gaat over de inhoud van je
+        bestanden, niet over anonimiteit.
+      </li>
+      <li>
+        <strong>Het overleeft geen functie die iets ophaalt.</strong> Een tool
+        waarin je een webadres kunt plakken, moet dat adres benaderen, en die
+        server komt je IP te weten en wat je opvroeg. Dat hoort bij de functie en
+        is er geen gebrek in &mdash; maar het is een echte uitzondering en een
+        tool hoort dat gewoon te zeggen in plaats van het af te ronden.
+      </li>
+      <li>
+        <strong>Het is niet hetzelfde als &ldquo;wij verwijderen je
+        bestanden&rdquo;.</strong> De tweede zin gaat over wat een bedrijf
+        besluit te doen. De eerste gaat over wat technisch mogelijk is. Maar één
+        van de twee is te controleren.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Wanneer uploaden werkelijk prima is</h2>
+    <p>
+      Dit is geen betoog dat elke upload een vergissing is. Stuur het bestand
+      wanneer de inhoud niet gevoelig is en de klus zo makkelijker gaat; wanneer
+      het werk werkelijk te zwaar is voor je apparaat; wanneer het formaat geen
+      decoder aan de browserkant heeft; of wanneer je een dienst gebruikt waar je
+      al een relatie mee hebt en waarvan je de voorwaarden echt gelezen hebt.
+    </p>
+    <p>
+      Wees voorzichtiger wanneer het bestand iets bevat dat je niet openbaar zou
+      posten: identiteitsdocumenten, medische scans, contracten, alles met een
+      adres of een gezicht dat je niet wilde delen, of een foto waarvan je de
+      locatiegegevens niet bekeken hebt. Voor die is een tool die je kunt
+      controleren te verkiezen boven een tool die je moet vertrouwen &mdash; niet
+      omdat de vertrouwde je waarschijnlijk verraadt, maar omdat de vraag bij de
+      controleerbare niet eens opkomt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hoe deze site op die vier controles scoort</h2>
+    <p>
+      Het zou een rare gids zijn die je vertelde te controleren en zichzelf dan om
+      vrijstelling vroeg. Dus, op volgorde:
+    </p>
+    <ul>
+      <li>
+        <strong>Trek de stekker eruit.</strong> Open hier een tool, verbreek de
+        verbinding, en hij werkt door. Elke toolpagina heeft een live-indicator
+        die zegt of je op dit moment online bent, zodat je hem kunt zien
+        veranderen.
+      </li>
+      <li>
+        <strong>Tabblad Netwerk.</strong> Zet iets om en lees de lijst. Niets
+        draagt je bestand, een miniatuur ervan, zijn naam, zijn grootte, of iets
+        wat eruit gelezen is. Er staat op deze site geen eigen
+        analytics-gebeurtenis die daar iets van te versturen heeft.
+      </li>
+      <li>
+        <strong>Content-Security-Policy.</strong> Die staat boven aan de
+        broncode van elke pagina. <code>connect-src</code> noemt de
+        advertentie- en meeteindpunten van Google en de doneerknop, en verder
+        niets. <strong>Geen adres op die lijst hoort bij deze site</strong>, want
+        deze site heeft geen server &mdash; het zijn statische bestanden. Er is
+        nergens waar een bestand heen gestuurd zou kunnen worden, ook al
+        probeerde er iets.
+      </li>
+      <li>
+        <strong>Code.</strong> Elke regel is
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">openbaar</a>.
+        De build haalt opmerkingen en witruimte weg en verder niets, en je kunt
+        hem zelf draaien en het resultaat vergelijken met wat er geserveerd
+        wordt.
+      </li>
+    </ul>
+    <p>
+      De uitzonderingen, hardop gezegd in plaats van weggemoffeld: deze site
+      draagt advertenties van Google en een bezoekersteller, die allebei met
+      Google praten en waarvan geen van beide iets over je bestanden meekrijgt;
+      en de tool <a href="../../afbeeldingen-naar-video/">Afbeeldingen naar
+      video</a> kan een afbeelding ophalen bij een adres dat jij erin plakt, wat
+      betekent dat die server je IP ziet. De
+      <a href="../../privacy/">privacypagina</a> zet ze allebei volledig uiteen.
+    </p>
+    <p>
+      Elke tool hier werkt zo: een
+      <a href="../../afbeelding-comprimeren/">afbeeldingscompressor</a> die een
+      grootte haalt die jij noemt, een
+      <a href="../../video-bijsnijden/">videobijsnijder</a>, een
+      <a href="../../exif-gegevens-verwijderen/">EXIF-lezer en -wisser</a> voor
+      de verborgen gegevens die hoger op deze pagina beschreven staan,
+      <a href="../../afbeeldingen-naar-video/">afbeeldingen naar video</a>, en
+      <a href="../../afbeeldingen-naar-pdf/">afbeeldingen naar pdf</a>. Allemaal
+      gratis, geen account, en geen ervan heeft ergens om je bestanden heen te
+      sturen.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/nl/pages/guides/is-it-safe-to-upload-files.toml
@@ -1,0 +1,17 @@
+#
+# Gids: is het veilig om bestanden naar online omzetters te uploaden? - Dutch.
+#
+
+nav = "Is uploaden veilig?"
+title = "Is het veilig om bestanden naar online omzetters te uploaden?"
+description = "De meeste online omzetters sturen je bestand naar een server. Wat dat betekent, wat er daar mee gebeurt, en vier controles die je vertellen of een tool dat nodig heeft."
+heading = "Is het veilig om bestanden naar online omzetters te uploaden?"
+lede = """
+    Meestal is het eerlijke antwoord &ldquo;waarschijnlijk wel, maar je kunt het
+    niet nagaan&rdquo;. Hier staat wat uploaden werkelijk met je bestand doet,
+    waarom de meeste tools het nog steeds doen, en vier tests die je vertellen of
+    degene vóór je het nodig heeft."""
+updated = "20 augustus 2026"
+og_title = "Is het veilig om bestanden naar online omzetters te uploaden?"
+og_description = "Wat er gebeurt met een bestand dat je naar een omzetter uploadt, waarom de meeste tools er nog steeds om vragen, en vier controles die je zelf kunt doen."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/make-a-favicon.html
+++ b/locales/nl/pages/guides/make-a-favicon.html
@@ -1,0 +1,345 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open <a href="../../favicon-maken/">Afbeelding naar ICO</a>, sleep er een
+      vierkant plaatje van minstens 256 pixels in, laat de voorkeuze op
+      <em>Website-favicon</em> staan, en download <code>favicon.ico</code>. Zet
+      hem in de wortel van je site, zodat hij antwoordt op
+      <code>https://jouwsite.nl/favicon.ico</code>. Dat adres wordt door elke
+      browser opgevraagd, of je HTML het nu noemt of niet, dus meer hoef je
+      strikt genomen niet te doen.
+    </p>
+    <p>
+      Alles hieronder is het deel dat het verschil maakt tussen een icoon dat er
+      technisch is en een dat leesbaar is: welke formaten erin gaan, wat iPhones
+      en Android in plaats daarvan vragen, en wat je doet wanneer je logo het
+      niet overleeft om zestien pixels breed te zijn.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom het een set formaten is en geen enkel plaatje</h2>
+    <p>
+      Een <code>.ico</code>-bestand is een houder. Erin zitten meerdere complete
+      plaatjes van hetzelfde ding op verschillende formaten, en wat het bestand
+      leest kiest degene die het dichtst bij het benodigde formaat zit.
+    </p>
+    <p>
+      Dat klinkt als overbodigheid en dat is het niet. Een browser die je icoon
+      op zestien pixels tekent heeft twee mogelijkheden: een versie van zestien
+      pixels lezen die jij getekend hebt, of ter plekke een grotere verkleinen.
+      Het tweede is slechter, en zichtbaar ook &mdash; een automatische
+      verkleining van een gedetailleerd logo levert pap op, terwijl een versie
+      van zestien pixels waar jij naar gekeken hebt iets is dat je hebt kunnen
+      vereenvoudigen. De hele reden dat het formaat meerdere maten bevat, is om
+      je die kans te geven.
+    </p>
+    <p>
+      Drie formaten is de conventie voor een website, en elk heeft een reden:
+    </p>
+    <ul>
+      <li>
+        <strong>16&times;16</strong> &mdash; het browsertabblad, de adresbalk,
+        het bladwijzermenu. Dit is degene die mensen zien. Krijg je er maar één
+        goed, krijg dan deze goed.
+      </li>
+      <li>
+        <strong>32&times;32</strong> &mdash; een bladwijzerbalk, een
+        Windows-bureaubladsnelkoppeling naar je site, en de meeste browsers op
+        een hi-dpi-scherm, die het tabbladicoon uit 32 halen en verkleinen.
+      </li>
+      <li>
+        <strong>48&times;48</strong> &mdash; het formaat waarop Google een
+        site-icoon voor zoekresultaten leest, en de middelgrote
+        pictogramweergave van Windows.
+      </li>
+    </ul>
+    <p>
+      Alles wat groter is hoort in een png naast de <code>.ico</code>, niet erin,
+      om redenen die bij de mobiele bestanden hieronder aan bod komen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Het zestienpixelprobleem</h2>
+    <p>
+      Dit is het deel waar niemand je voor waarschuwt. Zestien pixels is zo'n
+      vier millimeter op een gewoon scherm: een raster van 256 puntjes in totaal,
+      minder dan het aantal letters in deze zin. Vrijwel niets dat ontworpen is
+      om op een bord, een visitekaartje of een websitekop te werken, overleeft
+      het om daartoe teruggebracht te worden.
+    </p>
+    <p>
+      Wat er verdwijnt, op volgorde:
+    </p>
+    <ul>
+      <li>
+        <strong>Tekst.</strong> Een woordmerk dat in een vierkant gekrompen
+        wordt, is zo'n drie pixels hoog. Het wordt geen kleine tekst, het wordt
+        een grijze balk. Daarom gebruikt vrijwel elk bedrijf dat naast een naam
+        ook een symbool heeft alleen het symbool als favicon, en gebruiken de
+        bedrijven zonder symbool één letter.
+      </li>
+      <li>
+        <strong>Dunne lijnen.</strong> Een rand van één pixel op een logo van 512
+        pixels is bij zestien een tweeëndertigste pixel. Hij verschijnt als een
+        vage grijze waas langs de rand, of hij verdwijnt.
+      </li>
+      <li>
+        <strong>Verlopen en schaduwen.</strong> Er is geen ruimte voor een
+        overgang. Een zachte slagschaduw wordt een vuile rafel.
+      </li>
+      <li>
+        <strong>Detail binnen detail.</strong> Een icoon van een document met
+        schrift erop wordt een rechthoek met een vlek.
+      </li>
+    </ul>
+    <p>
+      De oplossing is geen instelling maar een andere tekening: een vereenvoudigd
+      merk met één of twee vormen, hoog contrast, en geen tekst behalve één
+      teken. Teken die versie met opzet op 32 of 48 pixels en gebruik hem als
+      bron.
+    </p>
+    <p>
+      Wat een tool wel kan, is je het probleem laten zien voordat je het
+      publiceert. De voorvertoning in
+      <a href="../../favicon-maken/">Afbeelding naar ICO</a> tekent elk formaat
+      op zijn echte formaat op het scherm, en dat is de enige manier om dit te
+      beoordelen &mdash; een icoon van zestien pixels dat op vierenzestig getoond
+      wordt, ziet er prima uit en zegt je niets.
+    </p>
+  </section>
+
+  <section>
+    <h2>Je logo is niet vierkant. Opvullen of bijsnijden?</h2>
+    <p>
+      Een icoon is altijd vierkant en de meeste logo's niet, dus er moet iets
+      gebeuren. Er zijn drie antwoorden en ze zijn niet even goed.
+    </p>
+    <p>
+      <strong>Opvullen</strong> houdt het hele plaatje en zet er ruimte boven en
+      onder. Het is de veilige standaard en de verkeerde keuze voor een breed
+      woordmerk: iets dat drie keer breder is dan hoog in een vierkant passen,
+      laat het een derde van de hoogte innemen, en dat is bij zestien pixels vijf
+      pixels logo en elf pixels niets.
+    </p>
+    <p>
+      <strong>Bijsnijden naar het midden</strong> neemt het grootste vierkant uit
+      het midden. Bij een combinatie van symbool en bedrijfsnaam ernaast snijdt
+      dat vaak dwars door allebei. Beter is het om de bron eerst zelf bij te
+      snijden tot alleen het symbool, en dat om te zetten.
+    </p>
+    <p>
+      <strong>Uitrekken</strong> drukt het plaatje plat om te passen. Er is
+      vrijwel geen situatie waarin dit juist is, en het wordt vooral aangeboden
+      zodat de tool het niet stilletjes doet.
+    </p>
+    <p>
+      Het algemene antwoord voor een breed logo: zet het logo niet om. Zet het
+      deel ervan om dat op zichzelf werkt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparant of een vaste achtergrond?</h2>
+    <p>
+      Transparant is voor een website meestal juist. Browsertabbladen zijn grijs,
+      wit of bijna zwart, afhankelijk van de browser en het thema, en een
+      transparant icoon staat op alle drie. Een icoon met een wit vlak erin
+      geschilderd is een witte rechthoek in een donkere tabbalk.
+    </p>
+    <p>
+      Twee uitzonderingen die het weten waard zijn:
+    </p>
+    <ul>
+      <li>
+        <strong>Een logo dat donker is en verder niets</strong> verdwijnt in de
+        donkere modus. Is je merk van nature zwart op wit, geef het dan een
+        gekleurde achtergrond in plaats van een transparante, of een lichte
+        omlijning.
+      </li>
+      <li>
+        <strong>Het Apple-touch-icoon moet ondoorzichtig zijn.</strong> iOS
+        tekent het op zijn eigen afgeronde tegel en maakt transparantie zwart.
+        Elke tool die dat bestand maakt hoort het voor je plat te slaan; die hier
+        doet dat, standaard op wit.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>De bestanden die een website nodig heeft en die de .ico niet zijn</h2>
+    <p>
+      <code>favicon.ico</code> dekt browsers en Windows. Het dekt geen telefoons,
+      en hier houden de meeste zelfgemaakte icoonsets te vroeg op. Drie andere
+      platforms vragen om hun eigen bestanden, onder hun eigen namen, en geen
+      ervan kijkt in een <code>.ico</code>:
+    </p>
+    <ul>
+      <li>
+        <strong>iOS</strong> leest <code>apple-touch-icon.png</code> op
+        180&times;180 wanneer iemand je site aan zijn beginscherm toevoegt.
+        Zonder dat bestand gebruikt iOS een schermafbeelding van de pagina, en
+        dat ziet eruit als een vergissing.
+      </li>
+      <li>
+        <strong>Android en elke installatievraag</strong> lezen een
+        webapp-manifest &mdash; <code>site.webmanifest</code> &mdash; dat naar
+        png's van 192 en 512 pixels wijst. Die 512 is ook wat een webapp op zijn
+        startscherm toont.
+      </li>
+      <li>
+        <strong>Een tegel in het Windows-startmenu</strong> leest
+        <code>browserconfig.xml</code>, dat naar een png van 150&times;150 wijst.
+        Van de drie de minst belangrijke, en het is vier regels XML.
+      </li>
+    </ul>
+    <p>
+      Er is er nog een die makkelijk misgaat: Android-launchers snijden een
+      adaptief icoon bij naar de vorm die de telefoon leuk vindt &mdash; cirkel,
+      squircle, afgerond vierkant &mdash; en alleen de middelste 80% van het
+      beeld overleeft gegarandeerd. Een icoon dat van rand tot rand getekend is,
+      raakt zijn hoeken kwijt. Dat is wat een <em>maskeerbaar</em> icoon is:
+      hetzelfde plaatje met opzet klein binnen het vierkant getekend, apart
+      opgegeven in het manifest.
+    </p>
+    <p>
+      De websiteset aanvinken in
+      <a href="../../favicon-maken/">Afbeelding naar ICO</a> levert al deze
+      bestanden op, plus het manifest en het blok HTML dat ernaar wijst. Eén ding
+      dat dat blok met opzet weglaat, is een <code>&lt;link&gt;</code> voor
+      <code>favicon.ico</code>: browsers vragen dat adres uit zichzelf op, en het
+      er ook nog bij noemen zorgt dat hetzelfde bestand twee keer opgehaald
+      wordt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Een Windows-app-icoon is een andere set</h2>
+    <p>
+      Is het icoon voor een programma in plaats van een site, dan veranderen de
+      formaten. Wat de standaard-<code>app.ico</code> van Visual Studio zelf
+      bevat, is 16, 32, 48 en 256 &mdash; de drie shellformaten plus de grote
+      waar het startmenu en de extra grote weergave van Verkenner uit tekenen.
+    </p>
+    <p>
+      Op een hi-dpi-scherm vraagt Windows ook om 20, 24, 40, 64 en 96, en
+      herbemonstert die vanaf het dichtstbijzijnde formaat dat het heeft wanneer
+      ze ontbreken. Of dat uitmaakt hangt van je icoon af: een vlakke vorm
+      overleeft de herbemonstering, een gedetailleerde niet. Ze toevoegen
+      verdubbelt ruwweg het bestand, en dat is voor een programma helemaal niets
+      &mdash; het rekensommetje is volstrekt anders dan bij een favicon, die door
+      elke bezoeker opgehaald wordt.
+    </p>
+    <p>
+      Nog iets over grootte: bij het item van 256 zitten de bytes.
+      Ongecomprimeerd opgeslagen is het in zijn eentje 264&nbsp;kB; als png in
+      het icoon opgeslagen meestal onder de 30. PNG-items zijn sinds Windows
+      Vista leesbaar, dus de enige reden om ze te mijden is software die
+      werkelijk ouder is dan dat, of een installatieprogramma of ingebedde tool
+      die iconen zelf ontleedt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Een Mac leest een heel ander bestand</h2>
+    <p>
+      Is het icoon voor een Mac-programma in plaats van een Windows-programma,
+      dan geldt niets van het bovenstaande: macOS leest helemaal geen
+      <code>.ico</code>. Het leest <code>.icns</code>, hetzelfde idee in een
+      andere verpakking &mdash; meerdere formaten in één houder &mdash; met drie
+      verschillen die het weten waard zijn.
+    </p>
+    <ul>
+      <li>
+        <strong>De formaten liggen vast.</strong> Apple publiceert tien plekken
+        en er valt niets te kiezen: 16, 32, 64, 128, 256, 512 en 1024 pixels,
+        waarbij 32, 256 en 512 twee keer voorkomen omdat elk zowel een eigen
+        formaat is als de Retina-versie van het formaat eronder.
+      </li>
+      <li>
+        <strong>Het gaat tot 1024.</strong> Een <code>.ico</code> stopt bij 256,
+        en daarom is een Mac-icoonbestand een paar honderd kilobyte en een
+        favicon vijftien. Voor een programma dat één keer uitgeleverd wordt is
+        dat niets; alleen een favicon wordt door elke bezoeker opgehaald.
+      </li>
+      <li>
+        <strong>1024 pixels is wat je tekenwerk moet overleven.</strong> De twee
+        problemen zijn tegenovergestelde uiteinden van hetzelfde plaatje: een
+        favicon moet werken wanneer hij piepklein is, en een Mac-icoon moet
+        standhouden wanneer hij enorm is. Een logo dat op 512 geëxporteerd is en
+        naar 1024 opgeblazen wordt, oogt zacht op een Retina-scherm, en de App
+        Store neemt het niet aan.
+      </li>
+    </ul>
+    <p>
+      Om er een te gebruiken: een applicatiebundel bewaart hem in
+      <code>JouwApp.app/Contents/Resources/</code> en noemt hem in
+      <code>Info.plist</code>. Voor een map of een schijfkopie: selecteer de
+      <code>.icns</code> in de Finder, druk op Command-C, kies daarna Toon info
+      op het ding dat je wilt wijzigen, klik op het kleine icoon linksboven en
+      druk op Command-V.
+    </p>
+    <p>
+      <em>macOS-icoon</em> aanvinken in
+      <a href="../../favicon-maken/">Afbeelding naar ICO</a> schrijft er een, met
+      of zonder het Windows-bestand ernaast. Alles wat op beide platforms
+      uitkomt wil ze allebei, en ze worden allebei in dezelfde ronde uit
+      hetzelfde plaatje getekend.
+    </p>
+  </section>
+
+  <section>
+    <h2>Controleren of het gelukt is</h2>
+    <p>
+      Browsers houden favicons hardnekkiger in de cache dan vrijwel iets anders,
+      dus &ldquo;ik heb hem geüpload en er verandert niets&rdquo; is meestal een
+      cache in plaats van een fout. Twee dingen om te proberen voordat je weer
+      bestanden gaat bewerken:
+    </p>
+    <ul>
+      <li>
+        Open <code>https://jouwsite.nl/favicon.ico</code> rechtstreeks. Wordt het
+        bestand gedownload, dan staat het er en kijk je naar een cache. Krijg je
+        een 404, dan staat het niet in de wortel.
+      </li>
+      <li>
+        Laad de site in een privévenster, dat meestal een eigen icooncache heeft.
+      </li>
+    </ul>
+    <p>
+      Op Windows kun je een <code>.ico</code> controleren door hem in een map te
+      zetten en Verkenner door zijn weergaveformaten te laten lopen: klein,
+      middelgroot, groot en extra groot tekenen verschillende items uit hetzelfde
+      bestand, dus je kunt ze zien zoals het systeem ze ziet.
+    </p>
+    <p>
+      Op een Mac gaat een <code>.icns</code> open in Voorvertoning, dat elke plek
+      langs de zijkant opsomt &mdash; en dezelfde truc werkt in de Finder: zet
+      hem in een map en sleep de formaatschuif in de weergaveopties om hem tussen
+      de plaatjes erin te zien wisselen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hier hoeft niets voor geüpload te worden</h2>
+    <p>
+      Een plaatje schalen is iets wat elke browser al jaren doet, en een
+      <code>.ico</code> is een kop van zes bytes, zestien bytes per afbeelding,
+      en dan de afbeeldingen. Er zit geen stap in het maken ervan die een server
+      vereist, en de tool hier gebruikt er geen: de
+      <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+      mag benaderen, en geen ervan hoort bij deze site.
+    </p>
+    <p>
+      Dat is hier meer dan gewoonlijk het waard om om te geven. Een logo dat aan
+      een gratis favicongenerator gegeven wordt, is nogal eens een merk dat nog
+      niet uit is &mdash; het icoon is een van de eerste dingen die gemaakt
+      worden en een van de laatste die aangekondigd worden. Laad de pagina, trek
+      de stekker uit het internet, en maak er toch een, als je liever controleert
+      dan het aanneemt.
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet nog drie controles op een rij die je
+      op elke tool kunt loslaten.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/make-a-favicon.toml
+++ b/locales/nl/pages/guides/make-a-favicon.toml
@@ -1,0 +1,18 @@
+#
+# Gids: een favicon en een app-icoon maken - Dutch.
+#
+
+nav = "Een favicon maken"
+title = "Een favicon maken (en een Windows-app-icoon)"
+description = "Welke formaten een favicon.ico werkelijk nodig heeft, welke extra bestanden iPhones, Android en een Mac vragen, en waarom een logo dat op een poster werkt bij zestien pixels verdwijnt."
+heading = "Hoe je een favicon maakt die op zestien pixels nog leesbaar is"
+lede = """
+    Een favicon is geen klein plaatje van je logo. Het is een set plaatjes op
+    vaste formaten, in een houder die de meeste mensen nooit openen, en de
+    kleinste ervan is degene die iedereen werkelijk ziet. Dit gaat over welke
+    formaten je nodig hebt, welke bestanden ernaast horen, en wat je doet
+    wanneer je logo de reis omlaag niet overleeft."""
+updated = "20 augustus 2026"
+og_title = "Een favicon maken die op zestien pixels nog leesbaar is"
+og_description = "Welke formaten een favicon.ico nodig heeft, de extra bestanden die iPhones en Android vragen, en wat je doet wanneer je logo het verkleinen niet overleeft."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/make-a-pdf-smaller.html
+++ b/locales/nl/pages/guides/make-a-pdf-smaller.html
@@ -1,0 +1,238 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../pdf-verkleinen/">Pdf-compressor</a>, sleep het
+      document erin, en kijk naar wat hij je vertelt voordat je iets verandert.
+      Hij leest het bestand en laat zien waar de grootte werkelijk zit &mdash;
+      afbeeldingen, lettertypen, tekst en tekenwerk, en alles waar niets in het
+      document nog naar verwijst. Dat ene scherm beantwoordt de vraag meestal.
+    </p>
+    <p>
+      Zit het grootste deel van de grootte in afbeeldingen, dan kun je een flinke
+      besparing verwachten. Zit het in lettertypen en tekst, dan niet, en dan kan
+      geen enkele tool dat. Welke van de twee je hebt, is het hele verhaal, en
+      dat is tien seconden kijken waard.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waar de grootte van een pdf werkelijk zit</h2>
+    <p>
+      Een pdf is een container voor verschillende soorten dingen, en die
+      comprimeren niet gelijk.
+    </p>
+    <ul>
+      <li>
+        <strong>Afbeeldingen.</strong> Foto's en scans. Vrijwel altijd het gros
+        van een grote pdf, en het enige deel met echte ruimte erin.
+      </li>
+      <li>
+        <strong>Ingesloten lettertypen.</strong> Een volledig lettertype kan
+        honderden kilobytes zijn; een subset van de tekens die werkelijk gebruikt
+        worden is veel minder. Hoe dan ook waren ze al gecomprimeerd door wat het
+        bestand maakte.
+      </li>
+      <li>
+        <strong>Tekst en vectortekening.</strong> Instructies in plaats van
+        pixels: teken deze lijn, zet dit woord hier. Al compact, en al
+        gecomprimeerd.
+      </li>
+      <li>
+        <strong>Objecten waar niets meer naar wijst.</strong> Pdf's stapelen die
+        op. Een document bewerken voegt de wijziging vaak achteraan toe in plaats
+        van het bestand te herschrijven, dus een oude versie van een pagina kan
+        er onbeperkt in blijven zitten. Het bestand opnieuw inpakken laat ze
+        vallen.
+      </li>
+    </ul>
+    <p>
+      De twee documenten die mensen naar een pdf-compressor brengen, hebben dus
+      volstrekt verschillende vooruitzichten. Een gescand document is in wezen
+      een stapel foto's, en komt er meestal 60 tot 90% kleiner uit. Een contract,
+      een scriptie of een geëxporteerd rapport is tekst, tekenwerk en
+      lettertypen &mdash; alle drie al gecomprimeerd door de software die het
+      schreef &mdash; en de besparing is daar meestal een paar procent, uit het
+      opnieuw inpakken en het weglaten van wat nergens meer naar verwijst.
+    </p>
+    <p>
+      Elke tool die &ldquo;tot 90% kleiner&rdquo; belooft zonder naar je bestand
+      te kijken, citeert het beste geval van het eerste soort tegen het tweede.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat dpi ermee te maken heeft</h2>
+    <p>
+      Een pdf bevat niet alleen een plaatje; hij legt ook vast hoe groot dat
+      plaatje op de pagina getekend wordt. Dat geeft je iets nuttigers dan het
+      aantal pixels: de effectieve resolutie.
+    </p>
+    <p>
+      Een scan van 4000 pixels breed die over twintig centimeter papier gelegd
+      wordt, draagt zo'n 500 pixels per inch. Een scherm toont er ongeveer 100.
+      Een goede kantoorprinter werkt op 300 en kan met veel meer niets. Alles
+      daarboven is detail dat niets in de toekomst van dat document ooit gaat
+      tonen &mdash; en het is meestal het grootste deel van het bestand.
+    </p>
+    <p>
+      Daarom vraagt een verstandige pdf-compressor om een dpi in plaats van om
+      een kwaliteitspercentage. Hij gooit de pixels boven jouw getal er als
+      eerste af, want die kosten niets wat iemand kan zien, en pas daarna begint
+      hij echte kwaliteit uit te geven.
+    </p>
+    <p>
+      Ruwe leidraad: <strong>150 dpi</strong> voor een document dat op een scherm
+      gelezen wordt, <strong>200 tot 300</strong> voor iets dat geprint gaat
+      worden, <strong>72 tot 100</strong> voor een concept dat niemand bewaart.
+      Afmeten aan hoe groot de afbeelding getekend wordt, is ook waarom een klein
+      geplaatst logo niet hetzelfde behandeld wordt als een paginagrote scan
+      &mdash; het logo zit al dicht bij zijn effectieve resolutie en er valt
+      niets te halen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat comprimeren wel en niet hoort aan te raken</h2>
+    <p>
+      De plaatjes worden opnieuw gecodeerd, dus die verliezen een beetje. Verder
+      hoort er niets aangeraakt te worden, en het is de moeite waard om na te
+      gaan of de tool die je gebruikt zich daaraan houdt:
+    </p>
+    <ul>
+      <li>
+        <strong>Tekst blijft tekst.</strong> Selecteerbaar, doorzoekbaar, te
+        kopiëren. Een compressor die pagina's tot afbeeldingen platslaat, levert
+        een heel klein bestand en vernielt het document &mdash; je kunt er niet
+        in zoeken, schermlezers kunnen het niet lezen, en het is nooit meer
+        terug te draaien.
+      </li>
+      <li>
+        <strong>Lettertypen blijven heel.</strong> Lettertypen vervangen
+        verandert hoe het document er op andermans apparaat uitziet, en dat is
+        precies het ene ding dat pdf bestaat om te voorkomen.
+      </li>
+      <li>
+        <strong>Vectortekening wordt exact gekopieerd.</strong> Die is al klein,
+        en er pixels van maken zou hem zowel groter als slechter maken.
+      </li>
+      <li>
+        <strong>Formulieren, links, bladwijzers, toegankelijkheidsstructuur en
+        bijlagen gaan mee.</strong> Die raak je bij een herschrijving makkelijk
+        kwijt en dat merkt zelden iemand tot hij er een nodig heeft.
+      </li>
+    </ul>
+    <p>
+      Een verwante regel die een compressor hoort te volgen en die veel niet
+      volgen: komt het hercoderen van een afbeelding niet echt kleiner uit dan
+      het origineel, zet de originele bytes dan terug. Een plaatje slechter maken
+      zonder besparing is het geval van puur verlies, en dat gebeurt vaker dan je
+      zou denken bij afbeeldingen die al goed gecomprimeerd waren.
+    </p>
+  </section>
+
+  <section>
+    <h2>De plaatjes die niet gecomprimeerd kunnen worden</h2>
+    <p>
+      Sommige afbeeldingen in een pdf worden overgeslagen, en een goede tool
+      noemt ze in plaats van ze stilletjes buiten het rekenwerk te laten:
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG&nbsp;2000-, JBIG2- en faxgecodeerde (CCITT)
+        afbeeldingen.</strong> Geen enkele browser levert er een decoder voor
+        mee, dus die worden onaangeroerd doorgegeven. De laatste twee zijn
+        tweekleurig &mdash; alleen zwart en wit &mdash; en zitten meestal al
+        bijna op hun kleinst.
+      </li>
+      <li>
+        <strong>CMYK-afbeeldingen.</strong> Met opzet met rust gelaten.
+        Hercoderen kan de kleuren verschuiven die een drukker zou produceren, en
+        dat is een verrassende daad tegenover een document dat iemand gaat
+        printen.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Dingen om te proberen vóór je comprimeert</h2>
+    <p>
+      Soms is het bestand groot om een reden waarvoor comprimeren het verkeerde
+      antwoord is.
+    </p>
+    <p>
+      <strong>Is het gescand terwijl dat niet hoefde?</strong> Een document dat
+      geprint en daarna gescand is, is een stapel foto's van tekst. Bestaat het
+      origineel ergens nog als document, dan levert dat naar pdf exporteren een
+      bestand op van een fractie van de grootte dat bovendien doorzoekbaar is.
+    </p>
+    <p>
+      <strong>Is het op drukinstellingen geëxporteerd?</strong>
+      Tekstverwerkers en ontwerpsoftware kiezen vaak standaard voor een export op
+      drukkwaliteit. Vanuit het bronbestand opnieuw exporteren voor scherm wint
+      het meestal van de export comprimeren.
+    </p>
+    <p>
+      <strong>Moet het één bestand zijn?</strong> Een e-maillimiet geldt per
+      bericht. Een document van 200 pagina's in hoofdstukken splitsen is soms de
+      eerlijke oplossing.
+    </p>
+  </section>
+
+  <section>
+    <h2>Versleutelde bestanden, en waarom een compressor ze hoort te weigeren</h2>
+    <p>
+      Een met een wachtwoord beveiligde pdf wordt door de tool hier geweigerd, en
+      dat is met opzet in plaats van een ontbrekende functie &mdash; ook wanneer
+      het wachtwoord leeg is, wat de manier is waarop veel scanners en
+      kopieerapparaten opslaan.
+    </p>
+    <p>
+      De beveiliging van een document afhalen is een andere klus dan het
+      comprimeren. Een tool die dat stilletjes deed, zou iets doen waar je niet
+      om gevraagd hebt, met een bestand dat iemand met opzet op slot gezet had,
+      en zou je een kopie teruggeven die de eigenschap niet meer had die zij
+      bedoeld hadden. Haal de beveiliging er eerst zelf af, met opzet, als je dat
+      wilt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Het resultaat controleren</h2>
+    <p>
+      Open het. Bekijk de plaatjes op volle zoom, kijk of de tekst nog
+      selecteerbaar is, en bevestig het aantal pagina's.
+    </p>
+    <p>
+      De tool hier doet dat laatste voor je voordat hij het bestand aanbiedt: hij
+      opent het document dat hij zojuist geschreven heeft opnieuw en telt de
+      pagina's, op je eigen apparaat. Hij schrijft ook pdf 1.5, wat elke lezer
+      die sinds 2003 is uitgekomen begrijpt, dus &ldquo;hij gaat open op mijn
+      apparaat&rdquo; is een redelijke plaatsvervanger voor &ldquo;hij gaat open
+      op dat van hen&rdquo;.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom hier geen server voor nodig is</h2>
+    <p>
+      Een pdf comprimeren klinkt als serverwerk, en dat was het het grootste deel
+      van het bestaan van het web ook. Wat het werkelijk inhoudt, is de
+      bestandsstructuur ontleden, de afbeeldingsstromen vinden, die decoderen en
+      opnieuw coderen met de codecs die een browser toch al meelevert, en het
+      document weer wegschrijven. Dat draait tegenwoordig allemaal in een
+      browser.
+    </p>
+    <p>
+      En dat telt bij dit bestandstype zwaarder dan bij de meeste, vanwege wat
+      mensen comprimeren: contracten, brieven van de dokter, bankafschriften,
+      identiteitsdocumenten, belastingaangiftes. De tool hier heeft helemaal geen
+      netwerkfunctie, en de <code>Content-Security-Policy</code> van de pagina
+      noemt elk adres dat hij mag benaderen; geen ervan hoort bij deze site. Laad
+      hem, trek de stekker eruit, en comprimeer toch iets.
+    </p>
+    <p>
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet er nog drie zulke controles op een
+      rij.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/nl/pages/guides/make-a-pdf-smaller.toml
@@ -1,0 +1,17 @@
+#
+# Gids: een pdf kleiner maken - Dutch.
+#
+
+nav = "Een pdf kleiner maken"
+title = "Een pdf kleiner maken (en waarom sommige niet krimpen)"
+description = "Waar de grootte van een pdf werkelijk zit, waarom een scan 80% krimpt en een contract nauwelijks beweegt, wat dpi hier betekent, en wat een compressor nooit met je document hoort te doen."
+heading = "Hoe je een pdf kleiner maakt, en waarom sommige niet krimpen"
+lede = """
+    Een pdf die niet binnen een e-maillimiet past, is bijna altijd een pdf vol
+    plaatjes. Hier staat hoe je ziet of dat bij jou zo is, wat comprimeren kost,
+    en waarom elke tool die een vast percentage belooft niet naar je bestand
+    gekeken heeft."""
+updated = "20 augustus 2026"
+og_title = "Hoe je een pdf kleiner maakt"
+og_description = "Waar de grootte van een pdf werkelijk zit, waarom een scan krimpt en een contract niet, en wat dpi ermee te maken heeft."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/make-a-qr-code.html
+++ b/locales/nl/pages/guides/make-a-qr-code.html
@@ -1,0 +1,265 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../qr-code-maken/">QR- &amp; barcodegenerator</a>, plak
+      je link, laat het niveau op <strong>M</strong> en de marge op
+      <strong>4</strong> staan, en download de svg. Druk hem minstens twee
+      centimeter breed af, op iets mats, donker op licht. Scan daarna de gedrukte
+      versie met een telefoon die niet de jouwe is, voordat je er duizend
+      bestelt.
+    </p>
+    <p>
+      Daarmee is vrijwel elk geval gedekt. De rest van deze pagina gaat over wat
+      je doet wanneer het er geen van is: een code die betast wordt, een code met
+      een logo erop, een code die op iets kleins komt, en de ene beslissing die
+      makkelijk misgaat op een manier die je pas een jaar later merkt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat er werkelijk in een qr-code zit</h2>
+    <p>
+      Een tekenreeks. Meer is het niet. Een qr-code scannen geeft de telefoon een
+      stuk tekst, en al het andere &mdash; een pagina openen, verbinding maken met
+      een netwerk, aanbieden een contact te bewaren &mdash; is de telefoon die de
+      vorm van die tekst herkent en aanbiedt ernaar te handelen.
+    </p>
+    <p>
+      Er bestaat dus niet zoiets als een &ldquo;wifi-qr-code&rdquo; als soort
+      code. Er bestaat een qr-code met
+      <code>WIFI:T:WPA;S:Mijn Netwerk;P:het wachtwoord;;</code> erin, en elke
+      telefoon van het afgelopen decennium weet hoe hij dat leest. De generator
+      laat je precies daarom de uiteindelijke tekenreeks zien: doet een code niet
+      wat je verwachtte, dan is die tekenreeks het enige dat het bekijken waard
+      is.
+    </p>
+    <p>
+      Het betekent ook dat een qr-code na het afdrukken niet meer te wijzigen is,
+      niet naar huis kan bellen, en niet kan verlopen &mdash; tenzij iemand er een
+      link naar zijn eigen server in gezet heeft, en daar gaat het laatste deel
+      hier over.
+    </p>
+  </section>
+
+  <section>
+    <h2>Beslissing één: het foutcorrectieniveau</h2>
+    <p>
+      Een qr-code draagt naast de gegevens een set controlewoorden mee, zo
+      uitgerekend dat een lezer kan herbouwen wat hij niet kon zien. Daarom scant
+      een code met een afgescheurde hoek nog steeds. Hoeveel van die
+      controlewoorden erin zitten is het niveau, en er zijn er vier:
+    </p>
+    <ul>
+      <li><strong>L</strong> &mdash; ongeveer 7% van de code mag verloren gaan.</li>
+      <li><strong>M</strong> &mdash; ongeveer 15%.</li>
+      <li><strong>Q</strong> &mdash; ongeveer 25%.</li>
+      <li><strong>H</strong> &mdash; ongeveer 30%.</li>
+    </ul>
+    <p>
+      Meer correctie is niet gratis: de controlegegevens gaan in hetzelfde
+      vierkant, dus dezelfde tekst op H heeft een groter en dichter code nodig dan
+      op L. Ruwweg verdubbelt de stap van L naar H het aantal modules voor
+      dezelfde tekenreeks, en dichtere modules zijn moeilijker voor een camera om
+      te onderscheiden. Er zit hier een echte afweging in en het antwoord hangt af
+      van waar de code heen gaat.
+    </p>
+    <p>
+      <strong>L</strong> is voor een scherm: een code in een dia, een e-mail, een
+      webpagina. Er gaat niets aan beschadigen en elke extra module maakt hem
+      moeilijker te lezen op afstand.
+    </p>
+    <p>
+      <strong>M</strong> is de standaard en het juiste antwoord voor het meeste
+      drukwerk. Papier dat een beetje betast wordt, een flyer, een visitekaartje.
+    </p>
+    <p>
+      <strong>Q en H</strong> zijn voor codes die het zwaar krijgen: een menukaart
+      die dagelijks afgenomen wordt, een sticker op een machine in een werkplaats,
+      een etiket op een krat, een code in een raam met volle zon. H is ook wat een
+      logo in het midden mogelijk maakt &mdash; zie hieronder.
+    </p>
+  </section>
+
+  <section>
+    <h2>Beslissing twee: de marge, die bij de code hoort</h2>
+    <p>
+      De witruimte om een qr-code heen is geen opvulling, en het is geen
+      ontwerpkeuze. Een lezer gebruikt hem om te vinden waar het symbool ophoudt.
+      De specificatie vraagt om vier modules stille ruimte aan elke kant, en een
+      code die tot de rand teruggeknipt is, is veruit de meest voorkomende reden
+      dat een gedrukte code faalt.
+    </p>
+    <p>
+      Dat is het waard om ronduit te zeggen, want terugknippen is zo'n natuurlijke
+      handeling. De code lijkt te veel wit om zich heen te hebben, dus wordt hij in
+      de opmaak bijgesneden, of op een gekleurd vlak gezet dat tot tegen de
+      vierkantjes loopt, of op een foto geplaatst. Elk daarvan haalt de grens weg
+      die de lezer ging gebruiken.
+    </p>
+    <p>
+      Ziet de code er met zijn marge te groot uit, maak de code dan kleiner. Haal
+      de marge er niet af.
+    </p>
+  </section>
+
+  <section>
+    <h2>Beslissing drie: hoe groot je hem afdrukt</h2>
+    <p>
+      De vuistregel die het contact met de werkelijkheid overleefd heeft is
+      <strong>één op tien</strong>: een code moet ongeveer een tiende zo breed
+      zijn als de afstand waarvandaan hij gescand wordt.
+    </p>
+    <ul>
+      <li>Een visitekaartje of een menukaart, op 30 cm gelezen: zo'n 2 cm breed.</li>
+      <li>Een poster die je van twee meter leest: zo'n 20 cm.</li>
+      <li>Een bushokje of een etalage die je van vijf meter leest: zo'n 50 cm.</li>
+    </ul>
+    <p>
+      Twee centimeter is een ondergrens en geen doel. Onder ongeveer 1,5 cm gaat
+      een gewone telefoon worstelen, hoe goed het drukwerk ook is, omdat de losse
+      modules de grootte van een pixel in zijn camera naderen.
+    </p>
+    <p>
+      Minder tekst betekent minder modules betekent een code die bij een gegeven
+      afdrukformaat op afstand leesbaar is &mdash; en dat is een goede reden om
+      een code naar <code>example.com/x</code> te laten wijzen in plaats van naar
+      een url met honderd tekens aan volgparameters erachter.
+    </p>
+    <p>
+      En druk af vanaf de <strong>svg</strong>. Een qr-code bestaat uit randen, en
+      een png heeft een vast aantal pixels om ze van te maken; vergroot er een en
+      elke rand wordt zacht, en dat is precies waar een scanner moeite mee heeft.
+      Een svg is de vierkantjes als instructies, dus die komt scherp uit op een
+      visitekaartje of een billboard.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kleur, contrast, en de twee fouten</h2>
+    <p>
+      Een lezer meet het verschil tussen de donkere modules en de lichte, dus
+      contrast is het hele verhaal. Er gaan geregeld twee dingen mis:
+    </p>
+    <p>
+      <strong>Lichte code op een donkere achtergrond.</strong> Het ziet er
+      opvallend uit, en een flink aantal lezers weigert het ronduit: die zoeken
+      naar donker-op-licht en proberen de omkering niet. Sommige wel. Je weet niet
+      welke jouw klanten hebben.
+    </p>
+    <p>
+      <strong>Te weinig verschil.</strong> Middengrijs op wit, of twee
+      merkkleuren van vergelijkbaar gewicht, kunnen op het scherm prima meten en
+      op papier falen zodra inktuitvloeiing en de automatische belichting van een
+      telefoon meedoen. Kleur je een code, hou het donkere deel dan werkelijk
+      donker.
+    </p>
+    <p>
+      Mat wint het van glans voor alles dat onder een lamp gescand wordt, en
+      allebei winnen ze het van op een foto afdrukken. Transparante achtergronden
+      zijn nuttig om een code op een gekleurd vlak te zetten &mdash; maar kijk wat
+      er werkelijk achter komt, want een transparante code op een donker vlak is
+      de eerste fout hierboven met extra stappen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Een logo in het midden</h2>
+    <p>
+      Dit werkt, en het werkt dankzij de foutcorrectie in plaats van ondanks. Op
+      niveau H mag ruwweg 30% van de modules vernield zijn en is de code nog
+      leesbaar, dus een logo dat wat minder dan dat bedekt &mdash; in het midden,
+      waar geen zoekpatroon zit &mdash; is schade die de lezer herstelt.
+    </p>
+    <p>
+      Drie dingen om je aan te houden. Gebruik niveau H. Hou het logo onder
+      ongeveer een vijfde van de oppervlakte, ruim onder de theoretische grens,
+      want drukwerk is niet het enige dat aan je marge knabbelt. En bedek nooit de
+      drie grote vierkanten in de hoeken of de kleinere daarbij in de buurt: dat is
+      hoe een lezer het symbool überhaupt vindt en richt, en geen enkele
+      hoeveelheid foutcorrectie herbouwt ze.
+    </p>
+    <p>
+      Test hem daarna op echte telefoons. Een logo brengt een code van
+      &ldquo;werkt altijd&rdquo; naar &ldquo;werkt met zoveel marge&rdquo;, en de
+      enige manier om te weten hoeveel marge er over is, is het te proberen.
+    </p>
+  </section>
+
+  <section>
+    <h2>De beslissing waar mensen spijt van krijgen: statisch of &ldquo;dynamisch&rdquo;</h2>
+    <p>
+      Zoek naar een qr-generator en de meeste resultaten willen dat je een account
+      maakt, omdat ze <em>dynamische</em> codes verkopen. Een dynamische code
+      bevat jouw link niet. Hij bevat een korte link naar de eigen server van de
+      generator, die naar de jouwe doorstuurt.
+    </p>
+    <p>
+      Wat je daarvoor terugkrijgt is echt: je kunt na het afdrukken wijzigen waar
+      de code heen wijst, en je krijgt een telling van elke scan. Voor een
+      campagne met een oplage van zes cijfers is dat betalen waard.
+    </p>
+    <p>
+      Wat het kost is ook echt, en dat is het weten waard vooraf in plaats van
+      achteraf:
+    </p>
+    <ul>
+      <li>
+        <strong>De code stopt met werken wanneer zij stoppen met werken.</strong>
+        Sluit de dienst, loopt het domein af, of verloopt de gratis laag, dan is
+        elke code die je gedrukt hebt dood &mdash; en tegen die tijd hangen ze op
+        tienduizend menukaarten.
+      </li>
+      <li>
+        <strong>Elke scan is andermans data.</strong> De doorverwijzing ziet het
+        IP-adres, het tijdstip en het apparaat van iedereen die je code scant.
+      </li>
+      <li>
+        <strong>De link is van hen, niet van jou.</strong> Wie hem scant ziet een
+        onbekend domein voorbijflitsen, en dat is precies waar mensen wordt
+        verteld argwanend over te zijn.
+      </li>
+    </ul>
+    <p>
+      De middenweg kost niets: zet een statische qr-code om een korte url
+      <em>op je eigen domein</em>, en stuur die zelf door. Je houdt de
+      mogelijkheid om de bestemming te wijzigen, je houdt de statistieken, en
+      niets aan de code hangt af van het voortbestaan van een bedrijf dat je nooit
+      ontmoet hebt.
+    </p>
+    <p>
+      De <a href="../../qr-code-maken/">generator hier</a> maakt alleen statische
+      codes, en er is geen account aan te maken. Wat je typt is wat de code bevat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Voordat je er duizend afdrukt</h2>
+    <p>
+      Scan de code. Niet die op je scherm &mdash; de gedrukte proef, op de plek
+      waar hij komt, met een telefoon die niet degene is waarop je hem gemaakt
+      hebt. Dat kost een minuut en vangt de hele soort problemen waar deze pagina
+      over gaat: een marge die de opmaak opgegeten heeft, een link die zijn
+      <code>https://</code> mist, een kleur die op papier anders meet, een code die
+      op een formaat gedrukt is dat op een bureau werkt en niet op een muur.
+    </p>
+    <p>
+      En kijk wat er ná de scan gebeurt. Een code die een pagina opent die op een
+      telefoon onleesbaar is, is een code die gefaald heeft, ook al scande hij.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hier hoeft niets voor geüpload te worden</h2>
+    <p>
+      Een qr-code is rekenwerk op een tekenreeks. Er is geen bestand te versturen
+      en er is niets wat een server kan en een browser niet, en daarom doet de
+      <a href="../../qr-code-maken/">tool hier</a> het allemaal op je eigen
+      apparaat en werkt hij met de stekker eruit.
+    </p>
+    <p>
+      Dat telt zwaarder dan het klinkt, vanwege wat mensen in qr-codes stoppen.
+      Het meest voorkomende gebruik van het wififormaat is het werkelijke
+      wachtwoord van een netwerk, ingetikt op een webpagina. Het is het weten
+      waard of die pagina ergens had om het heen te sturen.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/make-a-qr-code.toml
+++ b/locales/nl/pages/guides/make-a-qr-code.toml
@@ -1,0 +1,17 @@
+#
+# Gids: een qr-code maken die werkelijk scant - Dutch.
+#
+
+nav = "Een qr-code maken"
+title = "Een qr-code maken die elke keer scant"
+description = "Welk foutcorrectieniveau je kiest, waarom de witte marge om een qr-code heen bij de code hoort, hoe groot je hem afdrukt, en wat de 'dynamische' code van een gratis generator je later kost."
+heading = "Hoe je een qr-code maakt die ook op andermans telefoon scant"
+lede = """
+    Een qr-code maken kost een seconde. Er een maken die werkt op een natte
+    menukaart, in een bushokje, of op een telefoon op armlengte in slecht licht
+    kost vier beslissingen, en alle vier neem je voordat je iets afdrukt. Hier
+    staat wat elk ervan doet."""
+updated = "20 augustus 2026"
+og_title = "Een qr-code maken die ook op andermans telefoon scant"
+og_description = "De vier beslissingen die bepalen of een gedrukte qr-code werkt: het niveau, de marge, het formaat, en wiens adres er eigenlijk in zit."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/nl/pages/guides/remove-exif-and-gps-data.html
@@ -1,0 +1,223 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../exif-gegevens-verwijderen/">EXIF-lezer &amp;
+      -wisser</a>, sleep de foto's erin, en druk op &ldquo;Alle metagegevens
+      verwijderen&rdquo;. Elke tag, de XMP- en IPTC-blokken, de opmerkingen en de
+      ingesloten miniatuur gaan er in één keer af, bij elke foto op de lijst. Het
+      plaatje zelf wordt niet aangeraakt &mdash; niet opnieuw gecomprimeerd, niet
+      gedecodeerd, geen pixel veranderd.
+    </p>
+    <p>
+      Voordat je dat doet, is het de moeite waard om te kijken wat erin zat. Het
+      is meestal meer dan mensen verwachten, en die lijst is het argument om dit
+      überhaupt te doen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat er werkelijk in een foto zit</h2>
+    <p>
+      Een jpeg is niet alleen een gecomprimeerd plaatje. Het is een container, en
+      naast het plaatje zitten een paar blokken informatie die je camera,
+      telefoon of fotobewerker daar geschreven heeft.
+    </p>
+    <ul>
+      <li>
+        <strong>EXIF.</strong> De belangrijkste. Merk en model van de camera, de
+        lens, de belichtingsinstellingen, de ISO, de datum en tijd op de seconde
+        nauwkeurig, de oriëntatie waarin het plaatje getoond hoort te worden, en
+        &mdash; op een telefoon met locatievoorzieningen aan voor de camera
+        &mdash; een gps-positie tot op een paar meter nauwkeurig. Vaak ook nog
+        een serienummer van de camerabody.
+      </li>
+      <li>
+        <strong>Gps.</strong> Technisch een onderdeel van EXIF, en het apart
+        noemen waard omdat het degene is die het zwaarst weegt. Hij staat er in
+        graden, minuten en seconden, en dat is een notatie die er bijzonder goed
+        in slaagt niet op een adres te lijken.
+      </li>
+      <li>
+        <strong>XMP.</strong> Een pakketje XML dat fotobewerkers schrijven. Het
+        kan je naam meedragen, je software, waarderingen, trefwoorden, een
+        bewerkingsgeschiedenis, en een kopie van een deel van de EXIF-velden
+        &mdash; en daarom is alleen EXIF verwijderen niet genoeg.
+      </li>
+      <li>
+        <strong>IPTC.</strong> Een ouder blok met bijschrift-, naamsvermeldings-,
+        credit- en auteursrechtvelden, in gebruik bij pers en stockfotografie.
+      </li>
+      <li>
+        <strong>De ingesloten miniatuur.</strong> Een kleine tweede kopie van het
+        beeld. Hij wordt gemaakt wanneer het bestand geschreven wordt, en hij
+        wordt niet altijd opnieuw gemaakt wanneer het plaatje bewerkt wordt
+        &mdash; zo kan een bijgesneden foto reizen met een miniatuur van wat
+        eraf gesneden is.
+      </li>
+      <li>
+        <strong>De makernotitie.</strong> Een ongedocumenteerd blok
+        fabrikantgegevens. Niemand buiten de fabrikant weet alles wat erin zit.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Wie het werkelijk ziet</h2>
+    <p>
+      Dit is het stuk waarover je nauwkeurig moet zijn, want zowel de
+      alarmerende als de wegwuivende versie klopt niet.
+    </p>
+    <p>
+      <strong>De meeste grote sociale netwerken wissen metagegevens wanneer je
+      post.</strong> Facebook, Instagram en X coderen geüploade afbeeldingen
+      opnieuw en laten de tags daarbij vallen. Dat is geen vriendelijkheid
+      &mdash; zij houden de gegevens aan hun kant &mdash; maar het betekent wel
+      dat een foto die daar gepost wordt, niet aan elke kijker zijn coördinaten
+      geeft.
+    </p>
+    <p>
+      <strong>Vrijwel al het andere houdt ze.</strong> Een e-mailbijlage. Een
+      bestand dat via de meeste chat-apps als &ldquo;document&rdquo; verstuurd
+      wordt in plaats van als foto. Een plaatje op een forum, een
+      marktplaatsadvertentie, een persoonlijke site, een gedeelde schijf, een
+      bugmelding, een supportticket. In al die gevallen komt het bestand intact
+      aan, en iedereen die het downloadt kan de tags lezen met gereedschap dat
+      met zijn besturingssysteem meekomt.
+    </p>
+    <p>
+      De realistische risico's zijn alledaags in plaats van dramatisch: een
+      advertentie met foto's die thuis genomen zijn, een foto van een kind die op
+      hun school gemaakt is, een schijnbaar anoniem account dat foto's post die
+      allemaal hetzelfde cameraserienummer delen, een &ldquo;vorige week
+      genomen&rdquo; dat in maart genomen is.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom niet gewoon opnieuw opslaan?</h2>
+    <p>
+      Een foto opnieuw opslaan via een fotobewerker of een compressor haalt de
+      metagegevens er wel degelijk uit &mdash; het plaatje wordt gedecodeerd tot
+      pixels en opnieuw gecodeerd, en een canvas vol pixels draagt geen tags. Het
+      werkt, en het kost je kwaliteit, want die hercodering is verliesgevend.
+    </p>
+    <p>
+      De metagegevens fatsoenlijk verwijderen kost helemaal niets. De tags zitten
+      in de container <em>om</em> het gecomprimeerde plaatje heen, niet erin, dus
+      ze wissen is items uit een lijst schrappen en de lijst weer wegschrijven.
+      De gecomprimeerde beeldgegevens gaan byte voor byte mee en het resultaat
+      decodeert naar precies dezelfde pixels. Dat is de hele reden om een
+      metagegevenstool te gebruiken in plaats van een omzetter.
+    </p>
+    <p>
+      De uitzondering is wanneer je toch al ging hercoderen. Ben je de foto al
+      aan het comprimeren of schalen, dan gaan de tags als bijwerking mee en heb
+      je geen tweede stap nodig.
+    </p>
+  </section>
+
+  <section>
+    <h2>Het ene ding om te houden: de oriëntatie</h2>
+    <p>
+      Telefoons draaien het plaatje niet wanneer jij de telefoon draait. Ze leggen
+      het vast zoals de sensor het zag en voegen een Orientation-tag toe die zegt
+      hoe het gedraaid moet worden om te tonen. Wis elke tag en sommige kijkers
+      tonen je foto op zijn kant.
+    </p>
+    <p>
+      Daarom heeft de tool hier een optie &ldquo;hou de oriëntatietag&rdquo;, die
+      standaard aanstaat. Die schrijft een piepklein EXIF-blok terug met die ene
+      tag en verder niets, en alleen voor foto's die hem echt nodig hadden. De
+      gps, de tijdstempels, het serienummer en de rest zijn nog steeds weg.
+    </p>
+    <p>
+      Zet hem uit als je liever hebt dat het bestand helemaal geen EXIF draagt
+      &mdash; en controleer het resultaat dan voordat je het verstuurt, want een
+      foto op zijn kant is de gebruikelijke uitkomst.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bewerken in plaats van verwijderen</h2>
+    <p>
+      Alles verwijderen is voor de meeste mensen het juiste antwoord. Soms niet:
+      een fotograaf wil misschien de auteursrechtregel en de camera-instellingen
+      houden en alleen de locatie kwijt; een archivaris moet misschien een datum
+      corrigeren die fout was omdat de cameraklok dat was.
+    </p>
+    <p>
+      Allebei kan. De locatie kan los verwijderd worden, en teksttags, datums,
+      ISO, oriëntatie en resolutie kunnen ter plekke bewerkt worden.
+    </p>
+    <p>
+      Eén kanttekening die voor elke tool geldt die dit doet, niet alleen voor
+      deze: het bestand schrijven bouwt het EXIF-blok opnieuw op, en een
+      makernotitie bevat offsets naar het <em>originele</em> blok. Een herbouwde
+      makernotitie is daarom misschien niet meer leesbaar voor de eigen software
+      van de fabrikant. Maakt dat uit, verwijder dan de makernotitie of laat het
+      bestand onbewerkt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formaten, en die het zo niet kunnen</h2>
+    <p>
+      Jpeg, png en WebP zijn alle drie netjes te herschrijven, en dat zijn de
+      drie die de tool hier aankan.
+    </p>
+    <p>
+      HEIC &mdash; wat een iPhone standaard opslaat &mdash; en AVIF zijn
+      doosformaten die uit geneste atomen zijn opgebouwd en die een heel andere
+      parser nodig hebben. De tool herkent ze en zegt dat, in plaats van een
+      kapot bestand te maken. Heb je een HEIC, dan haalt hem naar jpeg omzetten
+      de metagegevens er als bijwerking van de omzetting uit.
+    </p>
+    <p>
+      Een kale TIFF gaat ook niet, en om een interessantere reden: in een TIFF
+      worden de metagegevens en de pixelgegevens door dezelfde offsets
+      aangewezen, dus tags verwijderen betekent de adressering van het plaatje
+      zelf herschrijven. Dat kan, en het is een andere klus.
+    </p>
+  </section>
+
+  <section>
+    <h2>Een gewoonte die het waard is</h2>
+    <p>
+      Controleer vóór je post in plaats van erna. De tags lezen kost een paar
+      seconden en de bevindingenlijst noemt de dingen die het weten waard zijn
+      &mdash; de positie, de tijdstempels, de serienummers &mdash; vóór de
+      volledige tabel met elke tag, dus je hoeft niet te weten waar je op moet
+      letten.
+    </p>
+    <p>
+      De positie wordt eerst in decimale graden getoond, met opzet. &ldquo;51
+      graden, 30 minuten, 26 seconden&rdquo; maakt niet duidelijk dat een foto
+      het gebouw noemt waarin hij genomen is. Een paar decimalen die je in een
+      kaart kunt plakken wel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Upload de foto niet om erachter te komen wat erin zit</h2>
+    <p>
+      Er zit een bijzondere ironie in de gebruikelijke manier waarop dit probleem
+      opgelost wordt: iemand die zich zorgen maakt over wat zijn foto prijsgeeft,
+      uploadt hem naar een website om erachter te komen. Die site heeft nu de
+      foto, de coördinaten, de tijdstempel en het serienummer, en een kopie van
+      het plaatje op een schijf die van hen is.
+    </p>
+    <p>
+      Er is geen reden voor. De container om een jpeg heen lezen en herschrijven
+      is een paar honderd regels ontleedwerk die een browser prima draait, en
+      daarom heeft de tool hier helemaal geen netwerkfunctie: geen
+      <code>fetch</code>, geen <code>XMLHttpRequest</code>, niets dat een bestand
+      zou kunnen versturen ook al probeerde er iets. Laad hem één keer, verbreek
+      de verbinding, en hij werkt door.
+    </p>
+    <p>
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet uiteen hoe je die bewering
+      controleert, op deze site of op elke andere &mdash; en dit is het
+      bestandstype waarbij dat het meest de moeite waard is.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/nl/pages/guides/remove-exif-and-gps-data.toml
@@ -1,0 +1,18 @@
+#
+# Gids: de metagegevens in een foto, en hoe je ze eruit haalt - Dutch.
+#
+
+nav = "EXIF- en gps-gegevens"
+title = "EXIF- en gps-gegevens uit een foto verwijderen"
+description = "Een foto van een telefoon draagt meestal de exacte plek waar hij genomen is, de tijd op de seconde, en het serienummer van de camera. Wat erin zit, wie het kan lezen, en hoe je het eruit haalt zonder het plaatje aan te raken."
+heading = "Wat een foto over je zegt, en hoe je het eruit haalt"
+lede = """
+    Een plaatje dat zo van een telefoon komt, draagt doorgaans de coördinaten
+    van de plek waar het genomen is, de tijd op de seconde, en genoeg over de
+    camera om het aan elke andere foto van hetzelfde apparaat te knopen. Niets
+    daarvan is op het scherm te zien. Dit is wat erin zit en hoe je het
+    verwijdert."""
+updated = "20 augustus 2026"
+og_title = "Wat een foto over je zegt, en hoe je het eruit haalt"
+og_description = "Gps-coördinaten, tijdstempels en serienummers reizen mee in gewone foto's. Wat erin zit, wie het kan lezen, en hoe je het wist."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/resize-an-image.html
+++ b/locales/nl/pages/guides/resize-an-image.html
@@ -1,0 +1,245 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open <a href="../../afbeelding-formaat-wijzigen/">Afbeeldingsformaat
+      wijzigen</a>, sleep je plaatje erin, tik één getal in &mdash; meestal de
+      breedte &mdash; en laat het andere leeg. De hoogte volgt uit de vorm van
+      het plaatje, en dat is vrijwel altijd wat bedoeld werd: &ldquo;1920
+      breed&rdquo; betekent &ldquo;1920 breed en zo hoog als dat uitkomt&rdquo;.
+    </p>
+    <p>
+      Alles hieronder gaat over wat je doet wanneer één getal niet genoeg is:
+      wanneer je een kader met twee zijden gekregen hebt, wanneer het plaatje
+      groter moet worden, of wanneer een hele map bestanden er hetzelfde uit moet
+      komen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Krimpen is veilig. Vergroten niet.</h2>
+    <p>
+      Dat zijn geen twee richtingen van dezelfde handeling, en het is de moeite
+      waard om helder te hebben waarom.
+    </p>
+    <p>
+      <strong>Een plaatje kleiner maken</strong> gooit informatie weg, en wel in
+      de enige goedaardige zin: er gaan meer pixels in dan eruit komen, dus elke
+      pixel van het resultaat is uitgemiddeld uit echt gemeten detail. Een goed
+      geschaalde kleinere kopie ziet er meestal <em>beter</em> uit dan het
+      origineel op dat formaat bekeken, omdat het middelen ruis wegneemt. Er
+      wordt niets verzonnen.
+    </p>
+    <p>
+      <strong>Een plaatje groter maken</strong> moet verzinnen. Het detail
+      ontbreekt niet in het bestand; het is nooit gefotografeerd. Het enige wat
+      een vergroter kan doen, is tussenliggende pixels raden uit hun buren, en
+      een gok tussen twee bekende waarden is een vloeiende helling &mdash; en
+      daarom ziet een vergrote foto er zacht uit in plaats van scherp. Het is een
+      grotere kopie van hetzelfde plaatje, geen gedetailleerdere.
+    </p>
+    <p>
+      Daarom staat &ldquo;maak een plaatje nooit groter dan het begon&rdquo;
+      standaard aan in de tool hier. Zet hem uit als je het aantal pixels
+      werkelijk nodig hebt &mdash; een drukkerij die om een minimumformaat
+      vraagt, een sjabloon dat alles onder een bepaalde breedte weigert &mdash;
+      maar doe het in de wetenschap dat je pixels koopt, geen detail.
+    </p>
+    <p>
+      De opschalers met machine learning die wél detail lijken toe te voegen,
+      zijn iets heel anders: die verzinnen aannemelijke textuur uit een model van
+      hoe plaatjes er meestal uitzien. Voor een bureaubladachtergrond is dat
+      prima. Voor een foto van een persoon, een document, of iets waar iemand een
+      conclusie uit gaat trekken, moet je begrijpen dat het extra detail fictie
+      is.
+    </p>
+  </section>
+
+  <section>
+    <h2>Drie manieren om te zeggen welk formaat je wilt</h2>
+    <p>
+      De meeste tools, deze inbegrepen, accepteren dezelfde drie, en ze passen
+      bij verschillende klussen.
+    </p>
+    <ul>
+      <li>
+        <strong>Exacte pixels.</strong> Gebruik dit wanneer iemand het getal
+        opgegeven heeft: een profielfoto die 400&times;400 moet zijn, een banner
+        die 1500 breed moet zijn. Vul één zijde in en laat de andere volgen,
+        tenzij je allebei gekregen hebt.
+      </li>
+      <li>
+        <strong>Een percentage.</strong> Gebruik dit wanneer je alles evenredig
+        kleiner wilt en het exacte getal je niet uitmaakt &mdash; &ldquo;halve
+        grootte&rdquo; voor een set foto's die in een document gaat.
+      </li>
+      <li>
+        <strong>Een lange zijde.</strong> De nuttigste van de drie voor een
+        gemengde stapel. &ldquo;Langste zijde 1600&rdquo; laat elk plaatje binnen
+        een vierkant van 1600 pixels passen, of het nu staand of liggend is, en
+        dat is in de praktijk meestal wat &ldquo;maak deze allemaal een
+        redelijke grootte&rdquo; betekent.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Als het kader een andere vorm heeft dan het plaatje</h2>
+    <p>
+      Hier wordt schalen pas echt beslist. Geef je zowel een breedte als een
+      hoogte op en kloppen die niet met de verhoudingen van je plaatje, dan moet
+      er iets wijken, en er zijn precies vier dingen die dat kunnen:
+    </p>
+    <ul>
+      <li>
+        <strong>Binnen het kader passen.</strong> Het hele plaatje blijft en komt
+        er op één as kleiner dan het kader uit. Er gaat niets verloren en er
+        wordt niets vervormd; je krijgt alleen niet de exacte afmetingen waar je
+        om vroeg. Dit is de juiste standaard voor vrijwel alles.
+      </li>
+      <li>
+        <strong>Het kader vullen en de overloop afsnijden.</strong> Je krijgt
+        precies de afmetingen waar je om vroeg, en de delen van het plaatje die
+        over de randen hangen zijn weg. Juist voor miniaturen, profielfoto's en
+        omslagen, waar de vorm vastligt en het onderwerp in het midden zit. Fout
+        wanneer het ding dat ertoe doet dicht bij een rand zit.
+      </li>
+      <li>
+        <strong>Opvullen.</strong> Het hele plaatje blijft, gecentreerd, met de
+        overgebleven ruimte gevuld met een kleur die jij kiest. Juist wanneer een
+        systeem exacte afmetingen eist en je niets van het beeld mag verliezen
+        &mdash; productvermeldingen werken vaak zo.
+      </li>
+      <li>
+        <strong>Uitrekken.</strong> Het plaatje wordt platgedrukt of uitgetrokken
+        om te passen. Dit wil je nooit, tenzij je het met opzet doet, en het is
+        degene die iedereen onmiddellijk als fout herkent.
+      </li>
+    </ul>
+    <p>
+      Betrap je jezelf erop dat je naar uitrekken grijpt, dan wil je
+      waarschijnlijk bijsnijden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bijsnijden is een andere klus, en vaak de juiste</h2>
+    <p>
+      Schalen verandert met hoeveel pixels het hele plaatje beschreven wordt.
+      Bijsnijden verandert welk deel van het plaatje je houdt. Mensen grijpen
+      verrassend vaak naar het eerste terwijl ze het tweede bedoelen &mdash;
+      &ldquo;dit moet vierkant worden&rdquo; is een bijsnijdvraagstuk, geen
+      schaalvraagstuk.
+    </p>
+    <p>
+      Doe ze in die volgorde: snijd eerst bij tot de inkadering die je wilt, en
+      schaal het resultaat daarna naar het formaat dat je nodig hebt. Andersom
+      betekent dat je de uitsnede kiest uit een plaatje dat al pixels
+      kwijtgeraakt is.
+    </p>
+    <p>
+      De tool hier doet daarom allebei in één ronde &mdash; sleep een kader, zet
+      het vast op een vorm als je een specifieke verhouding nodig hebt, en zeg
+      dan welk formaat het resultaat moet krijgen. Het in één ronde doen betekent
+      ook dat het plaatje maar één keer gecodeerd wordt, en dat telt om de reden
+      in het volgende deel.
+    </p>
+    <h3>Een hele stapel bijsnijden</h3>
+    <p>
+      Een kader dat je op één plaatje tekent, wordt op de rest toegepast als
+      hetzelfde <em>relatieve</em> gebied: dezelfde breuken van de eigen breedte
+      en hoogte van elk bestand. Voor een map schermafbeeldingen of exports die
+      allemaal even groot zijn, is dat precies dezelfde rechthoek. Voor een
+      gemengde stapel is het dezelfde inkadering in plaats van dezelfde
+      rechthoek, wat meestal is wat bedoeld werd maar het weten waard is voordat
+      je er vijftig bestanden aan toevertrouwt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat het hercoderen kost, en hoe je het bij één houdt</h2>
+    <p>
+      Een jpeg of een WebP schalen betekent hem decoderen, de pixels schalen, en
+      ze opnieuw coderen &mdash; en die laatste stap is verliesgevend. Het schalen
+      zelf kost je geen kwaliteit; het hercoderen wel.
+    </p>
+    <p>
+      Daar volgen twee dingen uit. Ten eerste doet de kwaliteitsinstelling op de
+      uitgang ertoe: ergens rond 80 tot 85 is bij een foto onzichtbaar en
+      aanzienlijk kleiner dan 100. Ten tweede: doe het één keer. Een plaatje
+      schalen dat al twee keer geschaald is, betekent drie generaties
+      verliesgevende codering, en dat zie je.
+    </p>
+    <p>
+      Een png kent die kosten niet, want die is verliesloos &mdash; een geschaalde
+      png is precies de geschaalde pixels. Werk je via meerdere stappen en ligt
+      het eindformaat nog niet vast, dan voorkomt tussendoor in png werken dat de
+      generaties zich opstapelen.
+    </p>
+    <p>
+      Eén detail over de tool hier is het weten waard: een bestand dat je
+      helemaal niet wijzigt, krijg je byte voor byte terug in plaats van opnieuw
+      gecodeerd. Vraag om &ldquo;langste zijde 1600&rdquo; op een stapel en de
+      bestanden die al onder de 1600 zitten, komen er onaangeroerd uit, tags en
+      al. Een tool die ze stilletjes hercodeerde, zou je kwaliteit kosten op
+      bestanden die niemand hem gevraagd had te wijzigen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparantie, en wat ermee gebeurt</h2>
+    <p>
+      Png en WebP kunnen transparantie opslaan. Jpeg niet &mdash; er zit helemaal
+      geen alfakanaal in het formaat. Een transparante afbeelding als jpeg
+      opslaan moet er dus iets achter zetten, en dat iets is een vlakke kleur.
+    </p>
+    <p>
+      De meeste tools gebruiken wit en zeggen dat er niet bij, wat prima is
+      totdat je logo op een donkere pagina landt met een wit vlak eromheen. Kies
+      de kleur met opzet, of sla op als png of WebP en hou de transparantie.
+      Dezelfde kleur wordt gebruikt achter een opgevuld kader, en dat is de
+      andere plek waar mensen dit bij verrassing tegenkomen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Welke tool, als je een getal gekregen hebt</h2>
+    <p>
+      Er worden twee soorten getallen uitgedeeld, en die vragen om verschillende
+      tools.
+    </p>
+    <p>
+      <strong>&ldquo;1200 pixels breed&rdquo;</strong> is een
+      afmetingenvraagstuk. <a href="../../afbeelding-formaat-wijzigen/">Afbeeldingsformaat
+      wijzigen</a> is degene: je zegt hoeveel pixels je wilt en je krijgt die.
+    </p>
+    <p>
+      <strong>&ldquo;Onder 500&nbsp;kB&rdquo;</strong> is een
+      bestandsgroottevraagstuk, en schalen is maar een van de manieren om het op
+      te lossen. De
+      <a href="../../afbeelding-comprimeren/">Afbeeldingscompressor</a> zoekt de
+      hoogste kwaliteit die binnen je doel past en schaalt alleen wanneer
+      kwaliteit alleen er niet komt;
+      <a href="../afbeelding-naar-exact-formaat-comprimeren/">de bijbehorende
+      gids</a> gaat over wat dat kost.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hier hoeft niets voor geüpload te worden</h2>
+    <p>
+      Een afbeelding decoderen, hem schalen en hem opnieuw coderen zijn dingen
+      die elke browser al jaren kan &mdash; het is dezelfde machinerie waarmee
+      een webpagina een plaatje op een ander formaat tekent. Er is geen
+      technische reden voor je foto om naar een server en terug te reizen om er
+      kleiner uit te komen, en de tool hier stuurt hem nergens heen: de
+      <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+      mag benaderen, en geen ervan hoort bij deze site.
+    </p>
+    <p>
+      Laad de pagina, trek de stekker uit het internet, en schaal er toch iets,
+      als je liever controleert dan het aanneemt.
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet nog drie controles op een rij die je
+      op elke tool kunt loslaten.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/resize-an-image.toml
+++ b/locales/nl/pages/guides/resize-an-image.toml
@@ -1,0 +1,17 @@
+#
+# Gids: het formaat van een afbeelding wijzigen - Dutch.
+#
+
+nav = "Formaat van een afbeelding wijzigen"
+title = "Het formaat van een afbeelding wijzigen zonder hem te verpesten"
+description = "Wat er met een plaatje gebeurt als je zijn pixelafmetingen verandert: waarom krimpen veilig is en vergroten niet, wat je doet als het kader de verkeerde vorm heeft, en wanneer je beter bijsnijdt."
+heading = "Het formaat van een afbeelding wijzigen zonder hem te verpesten"
+lede = """
+    Schalen is de ene beeldklus waarbij de schade al beslist is voordat je op de
+    knop drukt, door het getal dat je intikt en de vorm waar je om vraagt. Hier
+    staat wat elke keuze met het plaatje doet, en welke ervan je terug kunt
+    draaien."""
+updated = "20 augustus 2026"
+og_title = "Het formaat van een afbeelding wijzigen zonder hem te verpesten"
+og_description = "Waarom krimpen veilig is en vergroten niet, wat je doet als het kader de verkeerde vorm heeft, en wanneer je beter bijsnijdt."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/trim-a-video.html
+++ b/locales/nl/pages/guides/trim-a-video.html
@@ -1,0 +1,201 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../video-knippen/">Videoknipper</a>, sleep het filmpje
+      erin, druk op <kbd>I</kbd> en <kbd>O</kbd> om elk stuk te markeren dat je
+      wilt &mdash; zoveel als je wilt &mdash; en exporteer. Bij een mp4, mov of
+      m4v worden de frames die je houdt precies zoals ze waren naar het nieuwe
+      bestand verplaatst &mdash; dezelfde bytes, dezelfde encoderinstellingen,
+      alles hetzelfde &mdash; en het geluid gaat monster voor monster mee zonder
+      gedecodeerd te worden.
+    </p>
+    <p>
+      Dat betekent dat een knip je geen kwaliteit kost, en het is snel: een
+      minuut uit een opname van vier gigabyte halen kost ongeveer wat het kost om
+      die minuut naar schijf te schrijven, omdat naar de frames gewezen wordt in
+      plaats van dat ze geladen worden. De ene plek waar dit zichtbaar wordt, is
+      waar je knip werkelijk landt, en daar gaat de rest van deze pagina over.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom een knip helemaal geen kwaliteit hoeft te kosten</h2>
+    <p>
+      Inkorten verandert niets aan hoe een frame eruitziet. Elk frame dat je
+      houdt hoort er precies zo uit te komen als het erin ging, dus is er geen
+      reden om het te decoderen en opnieuw te coderen &mdash; en alle reden om
+      dat niet te doen, want een hercodering is verliesgevend en zou het hele
+      filmpje een beetje slechter maken om het korter te maken.
+    </p>
+    <p>
+      Een goede knipper hercodeert dus niet. Hij leest de index van het bestand,
+      rekent uit welke gecodeerde frames binnen jouw bereik vallen, en schrijft
+      die bytes naar een nieuwe container met een nieuwe index ervoor. Op die
+      route wordt er helemaal niets gedecodeerd.
+    </p>
+    <p>
+      Genoeg tools hercoderen toch, want decoderen en opnieuw coderen is veel
+      eenvoudiger te bouwen dan het containerformaat ontleden. Je kunt meestal
+      zien welke soort je gebruikt aan hoe lang het duurt: een kopie wordt
+      begrensd door hoe snel je schijf schrijft, en een hercodering door hoe snel
+      je apparaat video codeert, en dat is honderd keer trager.
+    </p>
+  </section>
+
+  <section>
+    <h2>Keyframes, en waarom je knip eerder kan landen</h2>
+    <p>
+      Dit is de beperking waar alles rond inkorten uit volgt.
+    </p>
+    <p>
+      Video wordt niet opgeslagen als een reeks complete plaatjes. Dat zou enorm
+      zijn. De meeste frames worden opgeslagen als een beschrijving van hoe ze
+      van hun buren verschillen, wat betekent dat ze niet op zichzelf te
+      decoderen zijn &mdash; je hebt de frames eromheen nodig. Alleen een
+      <strong>keyframe</strong> staat als compleet plaatje op zichzelf, en
+      keyframes liggen meestal een tot tien seconden uit elkaar.
+    </p>
+    <p>
+      Markeer je dus een knip twee seconden na het laatste keyframe, dan kan een
+      knipper die frames kopieert daar niet beginnen. De frames op je markering
+      zijn onleesbaar zonder de reeks die ernaartoe leidt. Hij moet het hele stuk
+      vanaf het keyframe vóór je markering meenemen.
+    </p>
+    <p>
+      Wat hij daaraan doet, is het interessante deel. Het bestandsformaat heeft
+      een standaardmanier om te zeggen <em>begin hier met afspelen</em> &mdash;
+      de extra frames zitten in het bestand, maar de container draagt de speler
+      op ze over te slaan. Elke gangbare speler respecteert dat, en het filmpje
+      begint precies waar jij zei. Een speler die het negeert begint eerder, tot
+      aan het keyframegat.
+    </p>
+    <p>
+      De tool hier zegt je vóór het exporteren in welk geval je zit en met
+      hoeveel, dus het is een beslissing in plaats van een verrassing.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wanneer je een hercodering accepteert</h2>
+    <p>
+      Er is een exacte knip, en die werkt door het openingsstuk opnieuw te
+      coderen &mdash; decoderen vanaf het keyframe, en een nieuwe reeks frames
+      wegschrijven die werkelijk begint waar jij markeerde. Hij is trager, en hij
+      kost een beetje kwaliteit, alleen op dat openingsstuk.
+    </p>
+    <p>
+      Kies hem wanneer het filmpje ergens heen gaat waar de instructie van de
+      container niet gerespecteerd wordt, of waar je de speler niet in de hand
+      hebt: sommige video-editors, sommige omroep- en vergadersystemen, sommige
+      oudere hardwarespelers. Kies de kopie voor al het andere, en dat is vrijwel
+      alles &mdash; een browser, een telefoon, een sociaal platform, een
+      mediaspeler.
+    </p>
+    <p>
+      Een derde optie die niets kost: verplaats je markering. Laat de tool je
+      zien waar de keyframes zitten, dan levert de knip naar het dichtstbijzijnde
+      schuiven je een exacte knip zonder ook maar te hercoderen. Het is zelden
+      een seconde verschil waard om een kopie op te geven.
+    </p>
+  </section>
+
+  <section>
+    <h2>Een stuk uit het midden halen</h2>
+    <p>
+      Een stuk eruit knippen is een andere handeling dan er een houden, en het is
+      het weten waard dat het ondersteund wordt, want veel knippers doen alleen
+      het tweede. Markeer het stuk dat je niet wilt, kies ervoor het eruit te
+      knippen, en wat aan weerszijden overblijft wordt tot één filmpje aan elkaar
+      gezet met het geluid gelijk mee.
+    </p>
+    <p>
+      De naad heeft dezelfde keyframebeperking op het punt waar de tweede helft
+      weer begint, om dezelfde reden. Het werkt hier op beide mp4-routes. Het is
+      het ene ding dat de opnameterugval hieronder niet kan, want een opname
+      wordt in één ronde vanaf één afspeelkop gemaakt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Formaten, en de terugval</h2>
+    <p>
+      <strong>Mp4, m4v en mov</strong> worden rechtstreeks gelezen, welke codec
+      er ook in zit &mdash; H.264, HEVC, AV1, VP9. Frames kopiëren houdt niet in
+      dat ze gedecodeerd worden, dus deze route werkt zelfs voor een codec
+      waarvoor je browser helemaal geen decoder heeft, en dat is een prettig
+      gevolg van niet naar de plaatjes kijken.
+    </p>
+    <p>
+      <strong>Al het andere dat je browser kan afspelen</strong>, WebM het meest
+      voor de hand liggend, wordt ingekort door het af te spelen en het resultaat
+      op te nemen. Dat werkt, en het heeft twee kosten: het duurt zo lang als het
+      stuk is, en beeld en geluid worden opnieuw gecodeerd.
+    </p>
+    <p>
+      <strong>Avi, wmv, flv en de meeste mkv's</strong> kan de browser niet lezen
+      en niet afspelen, en de tool zegt dat in plaats van halverwege te stranden.
+      Zet die eerst om naar mp4 met iets dat ze wel aankan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Twee dingen die elders stilletjes misgaan</h2>
+    <p>
+      <strong>Draaiing.</strong> Een telefoon filmt liggend en schrijft een
+      draai-instructie in het bestand in plaats van de pixels te draaien. Een
+      knipper die frames kopieert moet die instructie meenemen, of je staande
+      filmpje komt er op zijn kant uit &mdash; en dat is de klassieke manier
+      waarop een ingekorte video verpest wordt. De exacte route hier draait de
+      frames terwijl hij ze hercodeert en schrijft een bestand dat helemaal geen
+      draaiing nodig heeft.
+    </p>
+    <p>
+      <strong>Geluidssynchronisatie.</strong> Audio en video worden als aparte
+      stromen met hun eigen timing opgeslagen, en ze worden niet op dezelfde
+      punten afgehakt. Worden de twee bij de knip niet met opzet uitgelijnd, dan
+      loopt het geluid weg. Op de kopieerroute hier wordt de audio monster voor
+      monster gekopieerd zonder gedecodeerd te worden, dus het is byte voor byte
+      wat er in het bestand zat, en een bewerkingsmarkering houdt hem tot op een
+      duizendste seconde gelijk met het beeld.
+    </p>
+  </section>
+
+  <section>
+    <h2>Inkorten is niet bijsnijden</h2>
+    <p>
+      Twee woorden die door elkaar gebruikt worden. Inkorten verandert de lengte
+      van het filmpje; bijsnijden verandert de vorm van het beeld. Wil je een
+      vierkante versie van een liggende video, of moeten de zwarte balken van de
+      zijkanten af, dan is dat de
+      <a href="../../video-bijsnijden/">Videobijsnijder</a> &mdash; en anders dan
+      inkorten moet die wel hercoderen, om de reden die
+      <a href="../een-video-bijsnijden/">de bijbehorende gids</a> uitlegt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom hier niets voor geüpload hoeft te worden &mdash; en juist hier niet</h2>
+    <p>
+      Video is het bestandstype waarvan mensen het meest verwachten dat het
+      geüpload moet worden, omdat de bestanden groot zijn en het werk zwaar
+      klinkt. Inkorten is het geval waarin dat het minst waar is: op de
+      kopieerroute wordt het bestand nauwelijks gelezen. De tool loopt de index
+      door, rekent uit welke bytebereiken hij houdt, en schrijft die weg. Een
+      bestand van vier gigabyte naar een server uploaden zodat die dat kan doen,
+      zou de traagst denkbare manier zijn om het te regelen.
+    </p>
+    <p>
+      Het is ook het bestandstype waarbij uploaden het meest kost als je dat
+      liever niet doet: video draagt gezichten, stemmen, huizen en locaties mee
+      op een manier die een document niet doet. De tool hier heeft geen enkele
+      netwerkfunctie, en de <code>Content-Security-Policy</code> van de pagina
+      noemt elk adres dat hij mag benaderen; geen ervan hoort bij deze site.
+    </p>
+    <p>
+      Trek de stekker uit het internet en kort er toch een in, als je liever
+      controleert dan het aanneemt.
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet er nog drie zulke controles op een
+      rij.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/trim-a-video.toml
+++ b/locales/nl/pages/guides/trim-a-video.toml
@@ -1,0 +1,17 @@
+#
+# Gids: een video inkorten - Dutch.
+#
+
+nav = "Een video inkorten"
+title = "Een video inkorten zonder hem opnieuw te coderen"
+description = "Een filmpje knippen hoeft geen enkele byte kwaliteit te kosten. Waarom een knip soms eerder landt dan waar je hem markeerde, wat een keyframe daarmee te maken heeft, en wanneer je een hercodering accepteert."
+heading = "Hoe je een video inkort zonder hem opnieuw te coderen"
+lede = """
+    Inkorten verandert niets aan hoe een frame eruitziet, dus een goede knipper
+    raakt ze niet aan &mdash; hij verplaatst ze precies zoals ze waren naar een
+    nieuw bestand. Hier staat wat je dat oplevert, en de ene plek waar het
+    zichtbaar wordt."""
+updated = "20 augustus 2026"
+og_title = "Hoe je een video inkort zonder hem opnieuw te coderen"
+og_description = "Waarom een knip soms eerder landt dan waar je hem markeerde, wat een keyframe daarmee te maken heeft, en wanneer je een hercodering accepteert."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/nl/pages/guides/turn-a-video-into-a-gif.html
@@ -1,0 +1,224 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../video-naar-gif/">Video-naar-gif-omzetter</a>, sleep
+      het filmpje erin, markeer de seconden die je wilt, en laat de breedte op
+      480 en de snelheid op 12 beelden per seconde staan. Dat is de instelling
+      die de meeste gifs willen. Komt het bestand te groot uit, breng dan de
+      breedte omlaag voordat je iets anders aanraakt &mdash; dat is de instelling
+      die dubbel betaalt.
+    </p>
+    <p>
+      De rest van deze pagina gaat over waarom, want &ldquo;mijn gif is 14
+      MB&rdquo; is het probleem dat iedereen werkelijk heeft, en welke knop je
+      moet draaien is niet vanzelfsprekend.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom een gif van een video zo enorm is</h2>
+    <p>
+      Een videocodec slaat <em>beweging</em> op. Hij schrijft om de paar seconden
+      één volledig plaatje en daarna, voor elk frame ertussen, een beschrijving
+      van hoe dat plaatje bewoog: dit blok pixels schoof vier naar links, dit
+      gebied werd iets donkerder. Een filmpje van vijf seconden kan een paar
+      honderd kilobyte zijn omdat het grotendeels instructies zijn over een
+      plaatje dat je al hebt.
+    </p>
+    <p>
+      Gif heeft daar niets van. Het was in 1989 af, voordat dat allemaal bestond.
+      Elk frame is een plaatje, op zichzelf gecomprimeerd met een schema dat voor
+      schermafbeeldingen van een spreadsheet ontworpen is. Er zit nergens in het
+      formaat bewegingsschatting, en er is geen manier om er een toe te voegen.
+    </p>
+    <p>
+      Het getal om te verwachten is dus <strong>tien keer de grootte van de
+      video</strong>, en geen enkele omzetter praat je daaruit. Wat een goede wel
+      kan, is daar bovenop niets verspillen, en je de drie instellingen geven die
+      het werkelijk bepalen.
+    </p>
+  </section>
+
+  <section>
+    <h2>De drie instellingen, en wat elk ervan kost</h2>
+    <p>
+      Alles aan de grootte van een gif komt neer op hoeveel pixels erin zitten, en
+      dat is de lengte maal de snelheid maal de oppervlakte van één frame.
+    </p>
+    <ul>
+      <li>
+        <strong>Het stuk &mdash; lineair.</strong> Twee keer zo lang is twee keer
+        zoveel frames en ongeveer twee keer het bestand. Dit is degene die de
+        meeste mensen al begrijpen, en het is het waard om er meedogenloos in te
+        zijn: een gif die in drie seconden zijn punt maakt, is ook een betere gif
+        dan een kleinere.
+      </li>
+      <li>
+        <strong>De breedte &mdash; kwadratisch.</strong> De breedte halveren
+        halveert de hoogte mee, dus het is een <em>kwart</em> van de pixels. Van
+        640 naar 320 gaan bespaart niet iets minder dan de helft; het bespaart
+        zo'n driekwart. Dit is de instelling waar niemand als eerste naar grijpt
+        en degene die het beste betaalt.
+      </li>
+      <li>
+        <strong>De beeldsnelheid &mdash; lineair.</strong> Tien beelden per
+        seconde is tweederde van de grootte van vijftien. Het is ook de
+        instelling waarbij het verlies het zichtbaarst is, want beweging die te
+        traag is, leest als kapot in plaats van als klein.
+      </li>
+    </ul>
+    <p>
+      Een uitgewerkt voorbeeld. Zes seconden telefoonfilmpje op zijn eigen
+      1080&times;1920 en 30 fps is 180 frames van twee miljoen pixels: zo'n 350
+      miljoen pixels, en dat is geen gif maar een gijzeling. Diezelfde zes
+      seconden op 480 breed en 12 fps is 72 frames van 400.000 pixels &mdash; 30
+      miljoen, ongeveer een twaalfde &mdash; en dat ziet eruit als wat mensen met
+      een gif bedoelen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Welke beeldsnelheid je kiest</h2>
+    <p>
+      Twaalf is hier de standaard en verrassend vaak het juiste antwoord. Het is
+      de snelheid die handgetekende animatie al een eeuw gebruikt: snel genoeg dat
+      het oog het als doorlopende beweging leest, traag genoeg dat je niet betaalt
+      voor beelden die niemand kan zien.
+    </p>
+    <ul>
+      <li><strong>5 tot 8</strong> &mdash; een diavoorstellinggevoel. Prima voor
+        een trage pan of een schermopname waarin niets snel beweegt.</li>
+      <li><strong>10 tot 15</strong> &mdash; normaal. Leest als beweging.
+        Vrijwel elke gif die het maken waard is, zit hierin.</li>
+      <li><strong>20 tot 25</strong> &mdash; vloeiend, en ruwweg twee keer de
+        grootte van 12 voor een verschil dat de meeste kijkers niet kunnen
+        benoemen. Het waard bij snelle beweging, een sportfragment, alles met een
+        zweeppan erin.</li>
+    </ul>
+    <p>
+      Er is een hard plafond dat je net zo goed kunt kennen: gif slaat op hoe lang
+      elk frame in beeld blijft in honderdsten van een seconde, en elke browser
+      behandelt een vertraging onder twee honderdsten als tien. Vijftig beelden
+      per seconde is dus het echte maximum, en een bestand dat om 100 vraagt speelt
+      stilletjes op 10. Een omzetter die je 60 fps aanbiedt, negeert dat of staat
+      op het punt je te verrassen.
+    </p>
+  </section>
+
+  <section>
+    <h2>256 kleuren, en waar rasteren voor is</h2>
+    <p>
+      De andere helft van de ouderdom van het formaat: een gif draagt één tabel
+      van hoogstens 256 kleuren mee, en elke pixel is een nummer dat daarin wijst.
+      Een videoframe heeft er tot zestien miljoen. Vrijwel dat alles wordt
+      weggegooid, en hóe het weggegooid wordt is grotendeels hoe een gif eruitziet.
+    </p>
+    <p>
+      Een goede omzetter telt de kleuren in <em>jouw</em> filmpje en kiest er 256
+      die daarbij passen, in plaats van een vaste set te gebruiken. Een opname van
+      een bos krijgt 256 groenen; een opname van een zonsondergang krijgt 256
+      oranjes. Dat is wat de tool hier doet, over elk frame van het stuk in plaats
+      van alleen het eerste, zodat een kleur die pas aan het eind voorkomt toch een
+      plek krijgt.
+    </p>
+    <p>
+      <strong>Rasteren</strong> is wat er gebeurt waar de kleur die je nodig hebt
+      toch ontbreekt. In plaats van een heel gebied naar de dichtstbijzijnde
+      beschikbare kleur af te ronden &mdash; wat een vloeiende lucht in vier
+      vlakke banden met zichtbare stappen ertussen verandert &mdash; wisselt het
+      de twee dichtstbijzijnde kleuren in een fijn patroon af, en op normale
+      kijkafstand mengt je oog ze tot de kleur die er niet is.
+    </p>
+    <ul>
+      <li><strong>Laat het aan</strong> bij alles wat fotografisch is: luchten,
+        huid, verlopen, schaduwen, film.</li>
+      <li><strong>Zet het uit</strong> bij vlakke kleur: schermopnames,
+        lijntekeningen, logo's, tekenfilms, alles met grote gebieden van één
+        tint. Er is geen verloop om te beschermen, en het bestand is er kleiner
+        en schoner zonder.</li>
+    </ul>
+    <p>
+      Eén detail dat het weten waard is als je omzetters vergelijkt. De voor de
+      hand liggende manier om te rasteren &mdash; foutdiffusie, die de meeste
+      beeldbewerkers gebruiken &mdash; laat het resultaat van elke pixel afhangen
+      van de pixels eromheen. In een animatie betekent dat dat een achtergrond die
+      niet beweegt in elk frame toch anders rastert, dus hij kruipt zichtbaar, en
+      elk frame moet volledig opgeslagen worden omdat elke pixel technisch
+      veranderd is. Het alternatief, een geordend raster, hangt alleen af van waar
+      een pixel zit, dus een stilstaande achtergrond blijft volkomen stil. Dat is
+      wat deze tool gebruikt, en het is waarom zijn bestanden zowel kleiner als
+      rustiger zijn.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wanneer je helemaal geen gif moet maken</h2>
+    <p>
+      De vraag waard, want het eerlijke antwoord is vaak &ldquo;niet doen&rdquo;.
+      Een stille, herhalende mp4 of WebM is ongeveer een tiende van de grootte van
+      dezelfde animatie als gif, speelt hetzelfde af, en is waar elk sociaal
+      platform je gif toch al in omzet nadat je hem geüpload hebt.
+    </p>
+    <p>Hou de gif waar de bestemming er werkelijk een nodig heeft:</p>
+    <ul>
+      <li>ergens waar alleen een afbeelding geaccepteerd wordt &mdash; een hoop
+        chat-, forum-, wiki- en e-mailsoftware;</li>
+      <li>een README of documentatiepagina, waar een gif inline speelt en een
+        video een speler nodig heeft;</li>
+      <li>een presentatie of een document dat offline moet blijven bewegen;</li>
+      <li>een emoji, een sticker, een reactie &mdash; klein genoeg dat het hele
+        rekenwerk hierboven niet uitmaakt.</li>
+    </ul>
+    <p>
+      Waar het geluid ertoe doet, beantwoordt de vraag zichzelf: gif heeft nooit
+      audio gehad en zal die nooit hebben. Knip in plaats daarvan de video &mdash;
+      de <a href="../../video-knippen/">Videoknipper</a> haalt er een stuk uit
+      zonder er één frame van te hercoderen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Onder een groottelimiet komen</h2>
+    <p>
+      De reden dat iemand een gif afstelt is meestal een limiet aan de andere
+      kant. Ruwweg op volgorde van hoe hard ze bijten:
+    </p>
+    <ul>
+      <li><strong>E-mail</strong> &mdash; 10 tot 25 MB voor het hele bericht, en
+        een bijlage in de buurt daarvan wordt onderweg door iets weggehaald of
+        teruggestuurd. Mik er ruim onder.</li>
+      <li><strong>Chat en forums</strong> &mdash; vaak 8 tot 10 MB, soms veel
+        minder voor een inline voorvertoning in plaats van een download.</li>
+      <li><strong>Een GitHub-README</strong> &mdash; 10 MB per bestand, en alles
+        boven een paar megabyte laat de pagina op een telefoon kapot
+        aanvoelen.</li>
+      <li><strong>Sticker- en emojiplekken</strong> &mdash; vaak een paar honderd
+        kilobyte, wat een kleine breedte en een kort stuk betekent, en niet een
+        lagere beeldsnelheid.</li>
+    </ul>
+    <p>
+      De volgorde om te proberen wanneer je eroverheen zit: maak het stuk korter,
+      halveer daarna de breedte, verlaag daarna de snelheid, en zet daarna het
+      rasteren uit. De eerste twee zijn samen meer waard dan de laatste twee bij
+      elkaar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hier hoeft niets voor geüpload te worden</h2>
+    <p>
+      Een video naar een gif omzetten is decoderen, schalen, kleuren tellen en
+      comprimeren &mdash; vier dingen die een browser al jaren op eigen kracht
+      kan. De tool die bovenaan gelinkt staat doet het allemaal op je eigen
+      apparaat: het bestand wordt van je schijf gelezen, de frames worden door je
+      browser gedecodeerd, en de gif wordt in het geheugen opgebouwd en aan je
+      downloads gegeven.
+    </p>
+    <p>
+      Dat is hier meer dan gewoonlijk het waard om om te geven. De filmpjes die
+      mensen in gifs veranderen zijn persoonlijk &mdash; een moment uit een
+      familievideo, een schermopname van iets op het werk, een paar seconden van
+      een gesprek. Een omzetter die die geüpload wil hebben, vraagt om een kopie
+      ervan, en er is geen technische reden meer om ja te zeggen.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/nl/pages/guides/turn-a-video-into-a-gif.toml
@@ -1,0 +1,17 @@
+#
+# Gids: van een video een gif maken - Dutch.
+#
+
+nav = "Een gif maken van een video"
+title = "Van een video een gif maken (en hem klein houden)"
+description = "Welk stuk, welke breedte en welke beeldsnelheid je kiest, waarom een gif van een video tien keer zo groot is als de video, en wanneer je er überhaupt een gebruikt."
+heading = "Hoe je van een video een gif maakt"
+lede = """
+    Gif is een formaat uit 1987 dat hele plaatjes opslaat in plaats van
+    beweging, dus een gif die van een video gemaakt is, is altijd groot. Dit
+    gaat over welke van de drie instellingen je verzet wanneer hij te groot is,
+    en hoeveel elk ervan je oplevert."""
+updated = "20 augustus 2026"
+og_title = "Van een video een gif maken, en hem klein houden"
+og_description = "De drie instellingen die de grootte van een gif bepalen, wat elk ervan kost, en wanneer een gif juist het verkeerde antwoord is."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/guides/turn-images-into-a-video.html
+++ b/locales/nl/pages/guides/turn-images-into-a-video.html
@@ -1,0 +1,193 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open <a href="../../afbeeldingen-naar-video/">Afbeeldingen naar video</a>,
+      sleep de plaatjes erin, zet ze op volgorde, stel in hoe lang elk wordt
+      vastgehouden, en maak de video. Je krijgt een mp4 met H.264-video, die
+      vrijwel overal afspeelt.
+    </p>
+    <p>
+      De twee instellingen die het vaakst een tweede ronde nodig hebben zijn de
+      duur en de resolutie, en die zijn het begrijpen waard vóór de eerste render
+      in plaats van erna.
+    </p>
+  </section>
+
+  <section>
+    <h2>Beeldsnelheid en duur zijn niet hetzelfde</h2>
+    <p>
+      Dit is de verwarring die mensen een nieuwe render kost.
+    </p>
+    <p>
+      <strong>Duur</strong> is hoe lang elk plaatje in beeld blijft. Dat is de
+      instelling waar het je werkelijk om gaat. Drie seconden is een prettige
+      standaard voor een diavoorstelling waar iemand naar kijkt; één tot twee
+      seconden voelt kwiek; alles boven de vijf sleept, tenzij er commentaar
+      overheen ligt.
+    </p>
+    <p>
+      <strong>Beeldsnelheid</strong> is hoe vaak per seconde de video dat plaatje
+      herhaalt. Het verandert niets aan hoe de diavoorstelling eruitziet &mdash;
+      een stilstaand beeld dat drie seconden blijft, ziet er op 24 beelden per
+      seconde precies zo uit als op 60 &mdash; en het verandert de
+      bestandsgrootte en de codeertijd behoorlijk.
+    </p>
+    <p>
+      Kies voor een gewone diavoorstelling dus een lage beeldsnelheid. 24 of 30
+      is ruim voldoende. De reden om hoger te gaan is beweging in de video: een
+      pan of zoom over elke foto, of een overvloeier ertussen, waar een lage
+      beeldsnelheid als zichtbaar stappen te zien is.
+    </p>
+  </section>
+
+  <section>
+    <h2>Resolutie, en plaatjes van de verkeerde vorm</h2>
+    <p>
+      Een video heeft één beeldformaat voor zijn hele lengte. Je foto's delen dat
+      vrijwel zeker niet allemaal, dus er moet iets gebeuren met degene die niet
+      passen &mdash; en dat iets is de keuze die je met opzet hoort te maken.
+    </p>
+    <p>
+      Begin met de resolutie kiezen op basis van waar de video heen gaat:
+    </p>
+    <ul>
+      <li>
+        <strong>1920&times;1080</strong> voor alles wat algemeen is. Overal
+        ondersteund, speelt overal, en het is wat de meeste mensen met hd
+        bedoelen.
+      </li>
+      <li>
+        <strong>1080&times;1920</strong> &mdash; dezelfde getallen andersom
+        &mdash; voor een bestemming waar de telefoon voorop staat: verhalen,
+        reels, shorts.
+      </li>
+      <li>
+        <strong>3840&times;2160</strong> alleen als de plaatjes werkelijk zoveel
+        detail hebben en de bestemming het gaat tonen. Het is vier keer zoveel
+        pixels, vier keer de codeertijd, en ruwweg vier keer het bestand.
+      </li>
+    </ul>
+    <p>
+      Beslis daarna wat er met de afwijkers gebeurt. Elk plaatje binnen het beeld
+      passen houdt het geheel en laat balken aan de zijkanten &mdash; veilig, en
+      het juiste antwoord wanneer de plaatjes zwaarder wegen dan de presentatie.
+      Het beeld vullen en de overloop afsnijden ziet er beter uit en snijdt bij
+      een paar de bovenkant eraf. Staande en liggende foto's in één video mengen
+      is het geval waar geen goed antwoord bestaat; van tevoren beslissen welke
+      kant je liever fout zit, scheelt een nieuwe render.
+    </p>
+  </section>
+
+  <section>
+    <h2>Volgorde, en de bestandsnaamval</h2>
+    <p>
+      Zoals bij elke stapelklus sorteren bestandsnamen op een manier die niet de
+      manier is waarop jij telde. <code>foto2.jpg</code> komt in een alfabetische
+      sortering ná <code>foto10.jpg</code>, omdat er teken voor teken vergeleken
+      wordt.
+    </p>
+    <p>
+      Sorteren op opnamedatum klopt meestal voor foto's van een gebeurtenis,
+      omdat je ze genomen hebt in de volgorde waarin ze gebeurden. De tegels
+      slepen klopt voor alles waar het verhaal niet chronologisch is. Controleer
+      het vóór je rendert: de video is het ene product waarbij de volgorde
+      herstellen betekent dat je de hele klus opnieuw doet.
+    </p>
+  </section>
+
+  <section>
+    <h2>Er zit geen geluidsspoor in, en dat is niet niks</h2>
+    <p>
+      De mp4 die deze tool schrijft heeft één videospoor en helemaal geen
+      audiospoor. Heeft je diavoorstelling muziek of commentaar nodig, dan heb je
+      voor die stap een video-editor nodig.
+    </p>
+    <p>
+      Het is het weten waard waarom, en niet alleen dát: audio toevoegen betekent
+      een muziekbestand decoderen, het naar AAC coderen, en het in de container
+      met de video verweven. Alle drie zijn echt werk, en ze slecht doen levert
+      een bestand op dat tijdens het afspelen uit de pas gaat lopen. Het staat op
+      de lijst in plaats van half af te zijn.
+    </p>
+    <p>
+      Een praktische opmerking als je er achteraf muziek onder zet: kies eerst
+      het nummer en stel de duur per plaatje zo in dat de diavoorstelling dicht
+      bij de lengte van het liedje uitkomt. De muziek inkorten om bij de video te
+      passen klinkt altijd slechter dan de video op de muziek passen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat eruit komt, en wat je doet als het niet afspeelt</h2>
+    <p>
+      Mp4 met H.264 is het doel, en dat is de breedst afspeelbare combinatie die
+      er is. In een browser zonder WebCodecs valt de tool terug op het opnemen
+      van WebM &mdash; hetzelfde beeld in een container die minder editors en
+      sociale platforms accepteren.
+    </p>
+    <p>
+      Kom je met een WebM te zitten en weigert iets hem, dan is de oplossing een
+      browser met WebCodecs in plaats van een omzetting: huidige versies van
+      Chrome, Edge en Safari hebben het alle drie. Opnieuw renderen is beter dan
+      omzetten, want omzetten betekent nog een generatie verliesgevende codering.
+    </p>
+    <p>
+      In de tool zit geen limiet op hoeveel plaatjes je kunt gebruiken. Het
+      plafond is het geheugen van je eigen apparaat, want de gereedgekomen video
+      wordt daar opgebouwd voordat je hem downloadt &mdash; een lange
+      4K-diavoorstelling is het eerste wat dat merkt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Het bestand kleiner maken</h2>
+    <p>
+      Is het resultaat te groot voor waar het heen gaat, dan op volgorde van wat
+      werkelijk helpt:
+    </p>
+    <p>
+      <strong>Verlaag de beeldsnelheid.</strong> Bij een stilstaande
+      diavoorstelling kost dit niets zichtbaars en is het de grootste enkele
+      besparing die er te halen valt.
+    </p>
+    <p>
+      <strong>Verlaag de resolutie.</strong> 1080p in plaats van 4K is een kwart
+      van de pixels, en op een telefoonscherm merkt niemand het.
+    </p>
+    <p>
+      <strong>Maak hem korter.</strong> Drie seconden per plaatje in plaats van
+      vijf is 40% van de lengte eraf en 40% van het bestand eraf, en meestal een
+      betere diavoorstelling.
+    </p>
+    <p>
+      De bronfoto's eerst verkleinen helpt niet veel. De video wordt hoe dan ook
+      op de resolutie gecodeerd die jij koos, dus een foto van 4000 pixels en een
+      van 2000 leveren in een 1080p-video vrijwel hetzelfde aantal bytes op. Het
+      maakt het coderen wel sneller, en het schuift dat geheugenplafond op.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom hier geen server voor nodig is, met één uitzondering erbij gezegd</h2>
+    <p>
+      Video coderen was ooit het duidelijkste geval voor uploaden: browsers
+      konden het niet en een machine met FFmpeg wel. WebCodecs heeft dat
+      veranderd door de hardware-encoder bloot te leggen die al in je apparaat
+      zit, en dat is dezelfde die je telefoon gebruikt om live video op te nemen.
+      De frames samenstellen is een canvas. Geen van beide stappen heeft iets
+      anders nodig dan je eigen hardware.
+    </p>
+    <p>
+      Eén uitzondering bij deze tool, hardop gezegd in plaats van weggemoffeld:
+      de optionele functie &ldquo;toevoegen vanaf een webadres&rdquo; haalt een
+      afbeelding op bij een adres dat jij erin plakt, en de server op dat adres
+      ziet je IP en wat je opvroeg. Dat hoort bij de functie in plaats van dat
+      het een gebrek is, en het is de enige netwerkstap in de hele tool. Gebruik
+      je hem niet, dan verlaat er helemaal niets je apparaat.
+    </p>
+    <p>
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet vier controles op een rij die je
+      hetzelfde vertellen over elke tool, deze inbegrepen.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/turn-images-into-a-video.toml
+++ b/locales/nl/pages/guides/turn-images-into-a-video.toml
@@ -1,0 +1,16 @@
+#
+# Gids: van afbeeldingen een video maken - Dutch.
+#
+
+nav = "Afbeeldingen naar een video"
+title = "Van een map vol afbeeldingen een video maken"
+description = "Maak een mp4-diavoorstelling van foto's: wat beeldsnelheid en duur werkelijk regelen, wat je doet met plaatjes van de verkeerde vorm, en waarom er geen geluidsspoor in zit."
+heading = "Hoe je van een map vol afbeeldingen een video maakt"
+lede = """
+    Een diavoorstelling is eenvoudig te maken en makkelijk twee keer te
+    renderen, want twee van de instellingen betekenen niet wat ze lijken te
+    betekenen. Hier staat wat ze allebei regelen en wat je kiest."""
+updated = "20 augustus 2026"
+og_title = "Hoe je van een map vol afbeeldingen een video maakt"
+og_description = "Wat beeldsnelheid en duur werkelijk regelen, wat je doet met plaatjes van de verkeerde vorm, en waarom er geen geluidsspoor in zit."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/privacy.html
+++ b/locales/nl/pages/privacy.html
@@ -1,0 +1,187 @@
+  <section>
+    <h2>Je bestanden</h2>
+    <p>
+      Elke tool op deze site doet zijn werk binnen je eigen browser, op je eigen
+      hardware. Kies je een bestand, dan wordt het gelezen door de pagina die je
+      al open hebt staan. Het wordt niet naar ons gestuurd, want er is geen
+      server van ons om het heen te sturen &mdash; deze site is een verzameling
+      statische bestanden, zonder backend, zonder database en zonder opslag.
+    </p>
+    <p>
+      Dat betekent dat wij nooit het volgende ontvangen, zien, opslaan, loggen of
+      verwerken:
+    </p>
+    <ul>
+      <li>je bestanden, geheel of gedeeltelijk</li>
+      <li>miniaturen of voorvertoningen daarvan</li>
+      <li>hun namen, groottes, afmetingen of formaten</li>
+      <li>hoeveel je er koos, of wat je ermee deed</li>
+      <li>wat er ook maar uit gelezen wordt, EXIF- en gps-gegevens inbegrepen</li>
+    </ul>
+    <p>
+      Dit is geen belofte over onze bedoelingen. Elke pagina draagt een
+      <code>Content-Security-Policy</code> die elk adres noemt dat de pagina mag
+      benaderen, en de browser dwingt hem af. Geen van die adressen is van ons.
+      Je kunt de policy boven aan de broncode van elke pagina lezen, of het
+      tabblad Netwerk van je browser openen en meekijken: geen enkel verzoek
+      draagt je bestand.
+    </p>
+    <p>
+      Bestanden die je met een tool maakt, worden aan het eigen
+      downloadmechanisme van je browser gegeven en opgeslagen waar jij dat zegt.
+      Ook bij die stap zijn wij niet betrokken.
+    </p>
+  </section>
+
+  <section>
+    <h2>De ene uitzondering, en waar die geldt</h2>
+    <p>
+      De tool <a href="../afbeeldingen-naar-video/">Afbeeldingen naar video</a>
+      heeft een functie &ldquo;toevoegen vanaf een webadres&rdquo;. Plak je daar
+      een adres in, dan haalt je browser die afbeelding op bij de server die je
+      noemde, en <strong>die server ziet je IP-adres</strong> en welk bestand je
+      opvroeg. Dat is onvermijdelijk, en het is de hele aard van de functie.
+    </p>
+    <p>
+      Het gebeurt alleen ooit voor adressen die je zelf intikt, het is zo gebouwd
+      dat afbeeldingen naar binnen kunnen maar gegevens niet naar buiten, en de
+      eigen pagina van die tool legt het uitgebreider uit. Geen enkele andere
+      tool op deze site kan een uitgaand verzoek doen met iets van jou erin.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat er verzameld wordt, en door wie</h2>
+    <p>
+      Deze site is gratis en wordt betaald met advertenties. Dat betekent dat er
+      twee Google-producten op deze pagina's draaien, en op de meeste ervan een
+      doneerknop. Dit is de hele lijst.
+    </p>
+
+    <h3>Google AdSense &mdash; de advertenties</h3>
+    <p>
+      Google serveert de advertenties en bepaalt welke je te zien krijgt. Om dat
+      te doen mag het cookies of vergelijkbare identificatoren in je browser
+      zetten en lezen, en het ontvangt je IP-adres, een globale locatie die
+      daaruit afgeleid wordt, je user agent, en op welke pagina je was.
+      Afhankelijk van je instellingen en waar je bent, kunnen de advertenties
+      gepersonaliseerd worden aan de hand van een profiel dat Google over je
+      heeft, grotendeels opgebouwd uit je gedrag op andere sites.
+    </p>
+    <p>
+      Wij ontvangen daar niets van, we kunnen het niet zien, en we sturen Google
+      nooit iets over je bestanden. Googles eigen uitleg over hoe het gegevens
+      gebruikt van sites die zijn advertenties draaien, staat op
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>.
+    </p>
+
+    <h3>Google Analytics &mdash; de bezoekersteller</h3>
+    <p>
+      We gebruiken Google Analytics 4 om paginabezoeken te tellen, zodat we weten
+      aan welke tools het werken waard is. Het legt vast welke pagina je bekeek,
+      ongeveer wanneer, een willekeurig gegenereerde identificator die in je
+      browser bewaard wordt, een globale locatie, je apparaat- en browsertype, en
+      de site die je doorstuurde.
+    </p>
+    <p>
+      Het is zo ingesteld dat het verder niets doet, en die instelling is een
+      bestand dat je kunt lezen: <code>analytics.js</code> naast elke pagina zet
+      een paginaweergaveteller op en bevat helemaal geen eigen gebeurtenissen.
+      Niets op deze site geeft het een bestand, een bestandsnaam, een afmeting of
+      een aantal door &mdash; er is hier geen code die dat zou kunnen.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; de doneerknop</h3>
+    <p>
+      De hubpagina en de toolpagina's dragen een doneerknop, die van de servers
+      van Buy Me a Coffee geladen wordt. Hem laden betekent dat hun CDN je
+      IP-adres ziet en dat je op deze site was, en de letters van de knop worden
+      bij Google Fonts opgehaald, dat eveneens je IP-adres ziet. Er wordt verder
+      niets verstuurd, en er gebeurt niets meer tenzij je er echt op klikt, en op
+      dat moment zit je op hun site onder hun voorwaarden. Deze pagina en de
+      <a href="../voorwaarden/">pagina Voorwaarden</a> tekenen de knop niet.
+    </p>
+
+    <h3>Hosting</h3>
+    <p>
+      De site wordt geserveerd door GitHub Pages, achter Cloudflare. Zoals elke
+      webhost verwerken zij de verzoeken die je browser doet &mdash; waaronder je
+      IP-adres, de opgevraagde pagina en je user agent &mdash; om de pagina te
+      leveren en de dienst draaiend en veilig te houden. Wij hebben van geen van
+      beide toegang tot logboeken per bezoeker.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cookies</h2>
+    <p>
+      We zetten geen eigen cookies. We hebben geen login, geen sessie, geen
+      voorkeuren om te onthouden, en geen reden ertoe.
+    </p>
+    <p>
+      Elk cookie of vergelijkbare identificator die je hier tegenkomt, is van
+      Google en wordt gezet door de advertentie- en analytics-scripts die
+      hierboven beschreven zijn. Ze worden gebruikt om bezoeken te meten en om
+      advertenties te kiezen en te begrenzen.
+    </p>
+    <h3>Hoe je het uitzet</h3>
+    <ul>
+      <li>
+        Advertentiepersonalisatie kun je voor alle sites tegelijk uitzetten in
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">My Ad Center</a>.
+      </li>
+      <li>
+        Google Analytics kun je overal blokkeren met Googles
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">opt-out-browserextensie</a>.
+      </li>
+      <li>
+        De eigen instellingen van je browser kunnen cookies van derden blokkeren
+        of wissen, en elke contentblokkeerder voorkomt dat deze scripts überhaupt
+        laden.
+      </li>
+    </ul>
+    <p>
+      Alles blokkeren vinden wij prima. <strong>Elke tool op deze site werkt met
+      de scripts geblokkeerd, en werkt met het netwerk volledig
+      losgekoppeld.</strong> Er wordt hier niets achter een advertentie
+      gehouden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Je rechten op de gegevens</h2>
+    <p>
+      Wij hebben geen persoonsgegevens over je, dus er is niets wat we je kunnen
+      tonen, corrigeren, exporteren of verwijderen &mdash; een verzoek aan ons
+      zou eerlijk gezegd leeg terugkomen.
+    </p>
+    <p>
+      De hierboven beschreven gegevens liggen bij Google, dat daarvoor zijn eigen
+      verwerkingsverantwoordelijke is. Verzoeken daarover moeten naar hen, via
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">je Google-account</a>
+      of hun privacycontacten.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kinderen</h2>
+    <p>
+      Deze site is niet op kinderen gericht en vraagt niemand naar zijn leeftijd,
+      want ze vraagt niemand om wat dan ook. Wij verzamelen bewust van niemand
+      persoonsgegevens, van welke leeftijd ook.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wijzigingen, en hoe je ons bereikt</h2>
+    <p>
+      Verandert deze pagina, dan verandert de datum bovenaan mee, en de bewerking
+      staat samen met al het andere in de openbare commitgeschiedenis.
+    </p>
+    <p>
+      Vragen hierover kunnen naar
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, of als issue opgeworpen
+      worden op <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">de repository</a>,
+      waar het antwoord zichtbaar is voor iedereen die zich hetzelfde afvraagt.
+    </p>
+  </section>

--- a/locales/nl/pages/privacy.toml
+++ b/locales/nl/pages/privacy.toml
@@ -1,0 +1,17 @@
+#
+# Privacy & cookies - Dutch. Overrides for pages/privacy/page.toml.
+#
+
+nav = "Privacy &amp; cookies"
+title = "Privacy &amp; cookies &mdash; abox.tools"
+description = "Wat abox.tools wel en niet verzamelt. Je bestanden worden nooit geüpload; de advertenties, de bezoekersteller en de doneerknop staan hier volledig beschreven."
+heading = "Privacy &amp; cookies"
+lede = """
+    De korte versie: je bestanden worden nooit geüpload, want er is nergens om
+    ze naartoe te uploaden. Al het andere op deze pagina gaat over de
+    advertenties, de bezoekersteller en de hosting &mdash; de onderdelen waar wel
+    andere bedrijven bij betrokken zijn."""
+updated = "19 augustus 2026"
+og_title = "Privacy &amp; cookies &mdash; abox.tools"
+og_description = "Je bestanden worden nooit geüpload. Wat er verzameld wordt, door wie, en hoe je het uitzet."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/pages/terms.html
+++ b/locales/nl/pages/terms.html
@@ -1,0 +1,155 @@
+  <section>
+    <h2>Wat deze site is</h2>
+    <p>
+      abox.tools is een verzameling kleine hulpmiddelen die binnen je webbrowser
+      draaien. Ze zijn gratis te gebruiken, voor alles, ook voor commercieel
+      werk. Er valt niets te kopen, er is geen account aan te maken, geen
+      gebruikslimiet, en er wordt geen functie achtergehouden.
+    </p>
+    <p>
+      Door de site te gebruiken aanvaard je de voorwaarden op deze pagina.
+      Aanvaard je ze niet, dan is het middel simpelweg het tabblad te sluiten
+      &mdash; er wordt hier niets van jou vastgehouden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Je bestanden blijven van jou</h2>
+    <p>
+      Je houdt elk recht dat je al had op de bestanden die je met deze tools
+      opent, en op wat je ermee maakt. Wij claimen geen licentie, geen eigendom
+      en geen enkel belang in het een of het ander.
+    </p>
+    <p>
+      Dat is geen vrijgevigheid, het is rekenwerk: de tools draaien volledig in
+      je browser en je bestanden worden nooit naar ons verzonden, dus er is niets
+      waar wij rechten op zouden kunnen hebben. De
+      <a href="../privacy/">pagina Privacy</a> zet uiteen hoe dat werkt en hoe je
+      het controleert.
+    </p>
+  </section>
+
+  <section>
+    <h2>De site verantwoordelijk gebruiken</h2>
+    <p>
+      Je bent zelf verantwoordelijk voor de bestanden die je verwerkt en voor wat
+      je met de resultaten doet. In het bijzonder: gebruik deze tools niet op
+      materiaal waar je geen recht op hebt, en niet om iets onrechtmatigs te
+      maken.
+    </p>
+    <p>
+      Wij kunnen dit niet afdwingen en doen ook niet alsof. We zien je bestanden
+      nooit, dus er is hier geen moderatie, geen scanning, en geen manier voor
+      ons om te weten wat wie dan ook doet. De verplichting is werkelijk de
+      jouwe.
+    </p>
+    <p>
+      Val ook de site zelf niet lastig &mdash; door de hosting aan te vallen, of
+      door gewijzigde kopieën te verspreiden op een manier die suggereert dat ze
+      het origineel zijn.
+    </p>
+  </section>
+
+  <section>
+    <h2>Geen garantie</h2>
+    <p>
+      De site en zijn tools worden geleverd <strong>zoals ze zijn</strong>,
+      zonder enige garantie, uitdrukkelijk of stilzwijgend, met inbegrip van
+      elke stilzwijgende garantie van verkoopbaarheid, geschiktheid voor een
+      bepaald doel, of het niet inbreuk maken op rechten van derden.
+    </p>
+    <p>
+      Concreet: een tool kan een resultaat opleveren dat je niet wilde, kan
+      stranden op een bestand dat hij niet begrijpt, kan zich per browser anders
+      gedragen, en kan werk kwijtraken als het tabblad halverwege gesloten wordt.
+      Niets van wat je hier doet wordt ergens opgeslagen, dus
+      <strong>bewaar je originelen</strong>. Gebruik deze tools niet op de enige
+      kopie van iets waar je aan hecht.
+    </p>
+  </section>
+
+  <section>
+    <h2>Beperking van aansprakelijkheid</h2>
+    <p>
+      Voor zover de wet dat toelaat, zijn wij niet aansprakelijk voor verlies of
+      schade die voortvloeit uit je gebruik van deze site &mdash; met inbegrip
+      van verloren, beschadigde of onbruikbare bestanden, verloren tijd, gederfde
+      winst, of enige indirecte of gevolgschade.
+    </p>
+    <p>
+      Niets hier beperkt aansprakelijkheid die wettelijk niet beperkt mag worden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Beschikbaarheid</h2>
+    <p>
+      De site wordt aangeboden zonder belofte dat hij in de lucht blijft, gratis
+      blijft, een bepaalde tool houdt, of überhaupt blijft bestaan. Tools kunnen
+      zonder aankondiging veranderen of verdwijnen.
+    </p>
+    <p>
+      Eén praktisch gevolg van hoe deze tools gebouwd zijn, is het weten waard:
+      zodra een toolpagina geladen is, blijft hij offline werken, en hij stopt
+      niet met werken omdat de site eruit lag. De code is bovendien openbaar, dus
+      een tool waar je van afhankelijk bent, kun je zelf draaiend houden, wat er
+      hier ook gebeurt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Advertenties en andere bedrijven</h2>
+    <p>
+      De site draagt advertenties van Google, telt bezoeken met Google Analytics,
+      en toont op de meeste pagina's een doneerknop. Wat elk daarvan inhoudt,
+      staat volledig beschreven op de
+      <a href="../privacy/">pagina Privacy</a>.
+    </p>
+    <p>
+      Advertenties, en elke site waar je via een klik terechtkomt, zijn niet van
+      ons. Wij kiezen geen losse advertenties, staan niet achter wat ze zeggen,
+      en zijn niet verantwoordelijk voor de sites waar ze heen leiden of voor wat
+      je daar doet. Hetzelfde geldt voor elke andere externe link op deze site.
+    </p>
+  </section>
+
+  <section>
+    <h2>De broncode</h2>
+    <p>
+      De code van deze site staat openbaar op
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>,
+      omdat &ldquo;lees hem en controleer het zelf&rdquo; het enige echte
+      antwoord is op &ldquo;waarom zou ik dit vertrouwen&rdquo;. Hergebruik van
+      die code valt onder de licentievoorwaarden die in de repository staan, niet
+      onder deze pagina. Deze voorwaarden gaan over je gebruik van de website.
+    </p>
+  </section>
+
+  <section>
+    <h2>Toepasselijk recht</h2>
+    <p>
+      Deze site wordt geëxploiteerd vanuit Canada. Deze voorwaarden, en elk
+      geschil dat eruit voortvloeit of uit je gebruik van de site, worden beheerst
+      door het recht van Canada en van de provincie waarin de site geëxploiteerd
+      wordt, zonder inachtneming van regels van conflictenrecht.
+    </p>
+    <p>
+      Geeft het consumentenrecht waar jij woont je rechten die deze voorwaarden
+      anders zouden beperken, dan gaan die rechten voor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wijzigingen in deze voorwaarden</h2>
+    <p>
+      Deze voorwaarden kunnen bijgewerkt worden. Gebeurt dat, dan verandert de
+      datum bovenaan, en de bewerking verschijnt in de openbare
+      commitgeschiedenis, net als elke andere wijziging. De site na een wijziging
+      blijven gebruiken betekent de bijgewerkte versie aanvaarden.
+    </p>
+    <p>
+      Vragen kunnen naar <a href="mailto:hi@abox.tools">hi@abox.tools</a>, of als
+      issue opgeworpen worden op
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">de repository</a>.
+    </p>
+  </section>

--- a/locales/nl/pages/terms.toml
+++ b/locales/nl/pages/terms.toml
@@ -1,0 +1,16 @@
+#
+# Gebruiksvoorwaarden - Dutch. Overrides for pages/terms/page.toml.
+#
+
+nav = "Gebruiksvoorwaarden"
+title = "Gebruiksvoorwaarden &mdash; abox.tools"
+description = "De voorwaarden waaronder deze site wordt aangeboden: gratis, zoals hij is, geen account, geen garantie, en je bestanden blijven volledig van jou omdat ze nooit naar ons gestuurd worden."
+heading = "Gebruiksvoorwaarden"
+lede = """
+    Er is geen account te openen en geen overeenkomst te tekenen, dus deze zijn
+    kort. Ze beschrijven wat je van deze site mag verwachten, en wat hij niet
+    belooft."""
+updated = "19 augustus 2026"
+og_title = "Gebruiksvoorwaarden &mdash; abox.tools"
+og_description = "Gratis, zoals hij is, geen account, geen garantie. Je bestanden blijven volledig van jou."
+og_image_alt = "abox.tools - gereedschap dat geen server aanraakt"

--- a/locales/nl/planned.toml
+++ b/locales/nl/planned.toml
@@ -1,0 +1,73 @@
+#
+# De gepland-lijst op de roadmap - Dutch.
+#
+# Overrides for config/planned.toml. Only words: the group `id` stays as it is,
+# because that is what a tool's roadmap_group matches on, and the order of the
+# groups and of the items inside them is decided once, in English.
+#
+# Every group and every item has to be here. They are merged in order, so a
+# missing entry would render in English in the middle of a Dutch list with
+# nothing on the page to say which one it was - the build refuses a list whose
+# length has changed for exactly that reason.
+#
+
+note = "Nog niet gebouwd. Hier vermeld zodat je ziet waar dit heen gaat."
+
+[[group]]
+name = "Afbeeldingen"
+items = [
+  ["Draaien &amp; spiegelen", "kwartslagen, of een paar graden rechtzetten"],
+  ["Tekst toevoegen", "over de foto heen, of in een bijschrift erboven"],
+  ["Filters", "helderheid, contrast, verzadiging, vervaging, grijstinten"],
+  ["Afbeelding als data-URI", "het resultaat zo in je CSS of HTML plakken"],
+  ["HEIC naar JPG", "de foto's die een iPhone maakt, in een formaat dat alles opent"],
+  ["AVIF &amp; JPEG XL", "beide kanten op omzetten, in welke browser je ook zit"],
+]
+
+[[group]]
+name = "Gif &amp; animatie"
+items = [
+  ["Gif naar mp4 of WebM", "dezelfde animatie, meestal een tiende van de grootte"],
+  ["Een gif uit elkaar halen", "elk frame als eigen png"],
+  ["Gifs schalen, bijsnijden &amp; draaien", "frame voor frame, met de timing intact"],
+  ["Een gif omkeren", "het laatste frame eerst"],
+  ["Gif-snelheid wijzigen", "opnieuw timen zonder de frames opnieuw te renderen"],
+  ["Gif-analyse", "frames, vertragingen, palet, en waar de bytes heen zijn"],
+  ["APNG maken", "animatie met echte transparantie en volledige kleur"],
+  ["Bewegende WebP", "opnieuw dezelfde animatie, voor een fractie van de grootte"],
+]
+
+[[group]]
+name = "Video"
+items = [
+  ["Formaat wijzigen", "omlaag naar een grootte die er echt doorheen komt"],
+  ["Draaien", "voor het filmpje dat op z'n kant is opgenomen"],
+  ["Dempen, of het geluid bewaren", "het geluid weglaten, of het apart houden"],
+  ["Omzetten naar mp4 of WebM", "welke van de twee de site waarop je post ook eist"],
+  ["Filters", "helderheid, contrast, verzadiging, vervaging"],
+  ["Ondertiteling inbranden", "een srt-bestand vast in beeld getekend"],
+]
+
+[[group]]
+name = "Audio"
+items = [
+  ["Inkorten", "het stuk overhouden waar het je om ging"],
+  ["In- &amp; uitfaden", "zodat het niet tegen een muur begint en eindigt"],
+  ["Golfvorm als afbeelding", "een opname als plaatje tekenen"],
+  ["Formaat omzetten", "mp3, wav en Opus, alle kanten op"],
+]
+
+[[group]]
+name = "Documenten &amp; pdf"
+items = [
+  ["Samenvoegen, splitsen &amp; herordenen", "pagina's verschuiven zonder de omweg langs een server"],
+  ["Pagina's draaien &amp; bijsnijden", "een scan rechtzetten die scheef binnenkwam, of de marges eraf halen"],
+  ["Afbeeldingen eruit halen", "de plaatjes weer uit een document trekken"],
+]
+
+[[group]]
+name = "Verder dan media"
+items = [
+  ["Gegevens", "csv en json omzetten, opschonen, inspecteren"],
+  ["Privacy &amp; beveiliging", "hashes, controlegetallen, metagegevens wissen"],
+]

--- a/locales/nl/tools/compress-image.html
+++ b/locales/nl/tools/compress-image.html
@@ -1,0 +1,121 @@
+<main>
+  <!-- Stap 1 &mdash; de bestanden -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies afbeeldingen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alles van de lijst halen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; het getal waar het om draait -->
+  <section class="card" id="target-card">
+    <h2><span class="step">2</span> Zeg hoe groot het mag zijn</h2>
+
+    <p class="card-lede">
+      Dit is het deel dat andere compressors omgekeerd doen. Ze geven je een
+      kwaliteitsschuif en laten jou raden welke stand onder de opgelegde grens
+      landt. Noem in plaats daarvan de grens, en de tool zoekt de hoogste
+      kwaliteit die erin past &mdash; en geeft daarna uit wat er van het budget
+      over is, in plaats van je een bestand van de halve gevraagde grootte terug
+      te geven.
+    </p>
+
+    <div class="target-row">
+      <div class="target-field">
+        <label for="target-value">Doelgrootte, per afbeelding</label>
+        <div class="inline-pair">
+          <input type="number" id="target-value" value="500" min="1" step="1" inputmode="decimal">
+          <label for="target-unit" class="visually-hidden">Eenheid</label>
+          <select id="target-unit">
+            <option value="KB" selected>KB</option>
+            <option value="MB">MB</option>
+          </select>
+        </div>
+      </div>
+
+      <!--
+        The four numbers people are actually given: an upload form that says
+        100 KB, a forum avatar or a job application at 500 KB, an email
+        attachment at 1 MB, and a web page hero at 2 MB.
+      -->
+      <div class="presets" id="presets" role="group" aria-label="Veelvoorkomende doelgroottes">
+        <button type="button" class="ghost" data-bytes="102400">100 KB</button>
+        <button type="button" class="ghost" data-bytes="512000">500 KB</button>
+        <button type="button" class="ghost" data-bytes="1048576">1 MB</button>
+        <button type="button" class="ghost" data-bytes="2097152">2 MB</button>
+      </div>
+    </div>
+
+    <p id="target-summary" class="field-summary"></p>
+
+    <fieldset class="options">
+      <legend>Waarmee het daar mag komen</legend>
+
+      <div class="option-row">
+        <label for="format-select">Uitvoerformaat</label>
+        <select id="format-select">
+          <option value="auto" selected>Automatisch &mdash; formaat houden, tenzij een ander er beter uitziet</option>
+          <option value="keep">Altijd het originele formaat houden</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/webp">WebP</option>
+          <option value="image/png">PNG (verliesloos, dus de grootte gaat van de afmetingen af)</option>
+        </select>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="allow-resize" checked>
+        <span>
+          <strong>Mag het plaatje kleiner maken als het moet</strong>
+          <span class="check-note">
+            Wordt pas gebruikt zodra kwaliteit alleen onder het punt zou moeten
+            zakken waarop compressie zichtbaar wordt. Daaronder zien minder goede
+            pixels er beter uit dan meer verpeste. Zet dit uit om de exacte
+            afmetingen te houden en een krap doel in plaats daarvan uit de
+            kwaliteit te betalen.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Stap 3 &mdash; de ene klik -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Comprimeren</h2>
+
+    <div class="run-row">
+      <button type="button" id="compress-all" class="primary big" disabled>Comprimeren naar het doel</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Gecomprimeerd</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Alles als zip downloaden</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/compress-image.toml
+++ b/locales/nl/tools/compress-image.toml
@@ -1,0 +1,250 @@
+#
+# Afbeeldingscompressor - Dutch.
+#
+# Overrides for tools/compress-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Afbeeldingscompressor"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Afbeelding&nbsp;comprimeren <span class=\"h1-kw\">&mdash; naar een exacte grootte</span>"
+tagline = "Jij noemt de grootte. De rest rekent het uit."
+
+title = "Afbeelding naar exacte grootte comprimeren &mdash; gratis, zonder uploaden"
+description = "Comprimeer een JPEG, PNG of WebP naar een exacte grootte - 100 kB, 2 MB, wat je wilt. Draait volledig in je browser: niets geüpload, geen account, werkt offline."
+og_title = "Een afbeelding comprimeren naar een grootte die je zelf kiest"
+og_description = "Noem een doelgrootte; deze tool zoekt de minste compressie die daar komt en meet daarna wat dat heeft gekost. Draait op je eigen apparaat; er wordt niets geüpload."
+og_image_alt = "Afbeeldingscompressor - noem een grootte, hou de kwaliteit"
+
+pledge = """
+    Het comprimeren gebeurt in je eigen browser, op je eigen hardware, met de
+    encoders die hij toch al meelevert. Deze tool heeft geen enkele
+    netwerkfunctie &mdash; niets op te halen, niets te versturen &mdash; en er
+    staat aan de andere kant van deze pagina geen server om een foto heen te
+    sturen, ook al was er een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en comprimeer een foto. Geen enkel verzoek draagt een afbeelding, een
+      miniatuur, een bestandsnaam of één byte van wat je koos. Of trek de stekker
+      uit het internet en comprimeer er toch een."""
+
+read_first = """
+, <code>src/compress.js</code> voor de zoektocht die
+      bepaalt hoeveel kwaliteit eraan wordt uitgegeven, en
+      <code>src/measure.js</code> voor de vergelijking achter het cijfer
+      &ldquo;visuele overeenkomst&rdquo;."""
+
+howto_heading = "Een afbeelding naar een bepaalde grootte comprimeren"
+
+card = """
+            Noem de grootte die je nodig hebt &mdash; 100 kB, 2 MB, wat dan
+            ook &mdash; en het zoekt de minste compressie die daar komt."""
+
+[words]
+plural = "afbeeldingen"
+choose = "een afbeelding"
+analytics_extra = """, en ook geen van de
+  groottes of kwaliteitscijfers die deze tool uitrekent"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen groottelimiet"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Je afbeeldingen kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestanden
+      verzameld zouden kunnen worden, en niets in de code dat ze zou versturen
+      als dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Er staat nergens in
+      <code>src/</code> een <code>fetch</code>, een
+      <code>XMLHttpRequest</code> of een <code>sendBeacon</code>. Het
+      comprimeren is <code>canvas.toBlob</code> &mdash; de encoder die al in je
+      browser zit."""
+
+[[privacy]]
+title = "De getallen worden gemeten, niet gemeld."
+body = """
+ De groottes, het
+      kwaliteitscijfer en de SSIM-vergelijking worden allemaal op deze pagina
+      berekend en aan jou getoond. Er zit in deze repository geen eigen
+      analytics-gebeurtenis die een bestandsnaam, een grootte, een aantal of een
+      resultaat meedraagt."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google, de doneerknop van Buy Me a Coffee. Geen
+      ervan krijgt iets over je foto's mee. Elke regel die een bestand leest,
+      comprimeert of meet, wordt vanaf deze herkomst geserveerd en staat in de
+      repository."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en de tool is
+      onveranderd, want er zat nooit een netwerkstap in. Dat is het eenvoudigste
+      bewijs van allemaal."""
+
+[[howto]]
+title = "Kies je afbeeldingen."
+body = """
+ Sleep ze op het keuzevak of kies ze met
+      de hand. De browser leest ze rechtstreeks van je schijf; er wordt daarbij
+      niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Tik de grootte in die je is opgelegd."
+body = """
+ 100 kB voor het
+      uploadformulier dat je foto steeds weigert, 500 kB voor het sollicitatieportaal,
+      2 MB voor een pagina die snel moet laden. De vier meest voorkomende zijn
+      knoppen."""
+
+[[howto]]
+title = "Klik op &ldquo;Comprimeren naar het doel&rdquo;."
+body = """
+ Elke afbeelding wordt
+      een paar keer gecodeerd terwijl de tool inzoomt op de hoogste kwaliteit die
+      er nog in past. Wat al onder het doel zit, blijft precies zoals het is."""
+
+[[howto]]
+title = "Kijk wat het gekost heeft en download."
+body = """
+ Elk resultaat vertelt
+      in welk formaat het geschreven is, op welke kwaliteit, of de afmetingen
+      veranderd zijn en hoe dicht het gemeten bij het origineel blijft.
+      &ldquo;Vergelijken&rdquo; zet de twee plaatjes naast elkaar."""
+
+[[faq]]
+q = "Wordt mijn afbeelding ergens heen geüpload?"
+a = """
+        Nee. Het bestand wordt gedecodeerd, gecomprimeerd en gemeten door je eigen
+        browser op je eigen hardware, met de JPEG-, PNG- en WebP-encoders die de
+        browser al meelevert. Deze tool heeft geen enkele netwerkfunctie &mdash; hij
+        haalt nooit iets op en verstuurt nooit iets &mdash; en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen; geen ervan hoort bij deze site."""
+
+[[faq]]
+q = "Hoe raakt het een exacte grootte?"
+a = """
+        Door te proberen. Er bestaat geen formule die een kwaliteitsinstelling in
+        een aantal bytes omrekent &mdash; dat hangt volledig van het plaatje af
+        &mdash; dus codeert de tool de afbeelding een aantal keer en zoekt hij het
+        antwoord. Hij begint bovenaan het kwaliteitsbereik en halveert zich naar
+        beneden, wat de hoogste passende kwaliteit in een stuk of acht rondes
+        vindt. Elke grootte die je op de pagina ziet, is een echt gecodeerd bestand
+        en geen schatting."""
+
+[[faq]]
+q = "Wat betekent &ldquo;minimaal verlies&rdquo; hier eigenlijk?"
+a = """
+        Drie concrete dingen. Ten eerste: een afbeelding die al onder je doel zit,
+        wordt byte voor byte doorgegeven in plaats van opnieuw gecodeerd. Ten
+        tweede wordt er eerst kwaliteit uitgegeven en pas daarna resolutie, en
+        alleen tot een ondergrens waaronder compressie zichtbaar wordt &mdash;
+        voorbij dat punt maakt de tool het plaatje kleiner en draait hij de
+        kwaliteit weer omhoog, want minder goede pixels zien er beter uit dan meer
+        verpeste. Ten derde kruipt de zoektocht, zodra er een passend resultaat is,
+        weer omhoog tot het budget op is &mdash; je krijgt dus geen bestand van
+        300 kB als je om 500 kB vroeg."""
+
+[[faq]]
+q = "Wat zijn die SSIM- en PSNR-cijfers bij elk resultaat?"
+a = """
+        Een meting van wat de compressie gekost heeft, gedaan door het resultaat te
+        decoderen en met het originele plaatje te vergelijken. SSIM vergelijkt
+        plaatselijke helderheid, contrast en structuur, wat veel dichter ligt bij
+        waar een oog zich aan stoort dan het tellen van veranderde pixels; boven
+        ongeveer 0,98 zijn de twee naast elkaar nauwelijks uit elkaar te houden.
+        PSNR is het klassieke decibelgetal. Beide worden op je eigen apparaat
+        berekend, en beide worden getoond zodat de bewering van weinig verlies te
+        controleren valt in plaats van alleen geponeerd."""
+
+[[faq]]
+q = "Welke formaten kan het lezen en schrijven?"
+a = """
+        Het leest alles wat je browser kan decoderen, in de praktijk dus JPEG, PNG,
+        WebP, GIF, BMP en &mdash; in de meeste huidige browsers &mdash; AVIF. Het
+        schrijft JPEG, PNG en WebP, want dat zijn de encoders die browsers
+        meeleveren. Op &ldquo;automatisch&rdquo; houdt het het formaat waarin je
+        bestand binnenkwam, en stapt het alleen over op WebP wanneer vasthouden een
+        verkleining of een zichtbaar kwaliteitsverlies had betekend."""
+
+[[faq]]
+q = "Waarom valt een PNG niet ver te comprimeren?"
+a = """
+        Omdat PNG verliesloos is: er zit geen kwaliteitsknop aan om aan te draaien.
+        Een PNG kleiner maken kan alleen met minder pixels of minder kleuren, dus
+        met PNG geselecteerd haalt de tool een doel puur via het formaat. Is het
+        plaatje een foto, dan komen JPEG of WebP veel dichter bij je doel op een
+        kwaliteit waarvan je kunt zien dat hij prima is &mdash; en is het een logo
+        of een schermafbeelding met transparantie, dan houdt WebP de transparantie
+        die JPEG met wit zou opvullen."""
+
+[[faq]]
+q = "Haalt comprimeren de EXIF- en gps-gegevens uit een afbeelding?"
+a = """
+        Ja, als bijwerking. Comprimeren betekent het plaatje decoderen tot pixels en
+        die pixels opnieuw coderen, en een canvas vol pixels draagt geen tags, dus
+        de locatie, het cameramodel, de tijdstempels en al het andere worden domweg
+        niet in het nieuwe bestand geschreven. Wil je de metagegevens weg maar het
+        plaatje onaangeroerd, gebruik dan de
+        <a href="../exif-gegevens-verwijderen/">EXIF-lezer &amp; -wisser</a>
+        &mdash; die schrijft de container opnieuw zonder ook maar iets opnieuw te
+        comprimeren."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. Er is ook geen limiet op het aantal of de grootte van de
+        bestanden, want er is geen server die ervoor betaalt &mdash; het werk
+        gebeurt op je eigen apparaat. De site draagt advertenties, en die betalen
+        hem; de advertenties krijgen niets over je afbeeldingen mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je afbeeldingen wegstuurde om ze te
+        comprimeren, zou stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Comprimeer JPEG-, PNG- en WebP-afbeeldingen naar een grootte die je zelf noemt. De tool zoekt de hoogste kwaliteit die binnen het doel past, verkleint alleen wanneer kwaliteit alleen er niet komt, en meet het resultaat tegen het origineel. Draait volledig in de browser, zonder uploaden."
+features = [
+  "Comprimeert naar een doelbestandsgrootte die jij kiest, niet naar een kwaliteitsgetal dat je moet raden",
+  "Houdt de volle resolutie waar het kan, en verkleint alleen wanneer kwaliteit alleen het doel niet haalt",
+  "Maakt het budget op: het resultaat landt net onder het doel in plaats van ver eronder",
+  "Meet het resultaat tegen het origineel met SSIM en PSNR",
+  "Laat bestanden die al onder het doel zitten volledig met rust",
+  "JPEG, PNG en WebP, met een automatische formaatkeuze",
+  "Verwerkt hele stapels, met alle resultaten in één zip",
+  "Draait offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep afbeeldingen hierheen"
+hint = "of klik om te bladeren &mdash; JPEG, PNG, WebP en al het andere dat je browser kan openen"

--- a/locales/nl/tools/compress-pdf.html
+++ b/locales/nl/tools/compress-pdf.html
@@ -1,0 +1,161 @@
+<main>
+  <!-- Stap 1 &mdash; het bestand -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies een pdf</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="file-row" class="file-row" hidden>
+      <div class="file-facts">
+        <strong id="file-name" class="file-name"></strong>
+        <span id="file-facts" class="file-sub"></span>
+      </div>
+      <button type="button" id="clear-file" class="ghost danger">Een andere kiezen</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; het scherm dat deze tool zou houden als hij er maar één mocht houden -->
+  <section class="card" id="inventory-card" hidden>
+    <h2><span class="step">2</span> Zie waar de grootte zit</h2>
+
+    <p class="card-lede">
+      &ldquo;Een pdf comprimeren&rdquo; zijn twee verschillende klussen die één
+      naam delen. Een scan is een stapel foto's, en die opnieuw coderen is het
+      grootste deel van het bestand waard. Een contract is tekst en lettertypen,
+      die door wat het maakte al gecomprimeerd zijn &mdash; daar zit geen tachtig
+      procent in verstopt, en geen enkele tool kan er een vinden. Welke van de
+      twee je hebt, is geen kwestie van mening, dus hier staat het voordat er
+      iets aangeraakt wordt.
+    </p>
+
+    <p id="verdict" class="verdict"></p>
+
+    <div class="breakdown">
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <ul id="breakdown-list" class="breakdown-list"></ul>
+    </div>
+
+    <p id="inventory-notes" class="field-summary"></p>
+  </section>
+
+  <!-- Stap 3 &mdash; hoeveel eraan uitgegeven mag worden -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">3</span> Zeg hoe hard er geknepen mag worden</h2>
+
+    <p class="card-lede">
+      Een pdf legt vast hoe groot elk plaatje getekend wordt, dus kan deze tool
+      meten wat de pagina werkelijk gebruikt in plaats van te gokken. Een scan
+      van 4000 pixels die over twintig centimeter papier gelegd wordt, draagt
+      zo'n 500 pixels per inch; op 150 print hij hetzelfde en ziet hij er op het
+      scherm hetzelfde uit. Pixels die niemand kan zien, gaan er als eerste af,
+      want ze kosten niets.
+    </p>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Hoeveel kwaliteit uitgegeven mag worden</legend>
+      <div class="presets" id="presets" role="radiogroup" aria-label="Hoeveel kwaliteit uitgegeven mag worden">
+        <label class="preset">
+          <input type="radio" name="preset" value="smallest">
+          <span class="preset-body">
+            <strong>Kleinst</strong>
+            <span class="preset-note">96 dpi. Voor iets dat alleen op een scherm gelezen hoeft te worden.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="screen" checked>
+          <span class="preset-body">
+            <strong>Goed op het scherm</strong>
+            <span class="preset-note">130 dpi. Het gebruikelijke antwoord voor een bestand dat je moet mailen.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="print">
+          <span class="preset-body">
+            <strong>Nog goed op papier</strong>
+            <span class="preset-note">220 dpi. Kleiner, en het print nog gewoon netjes.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="gentle">
+          <span class="preset-body">
+            <strong>De plaatjes nauwelijks aanraken</strong>
+            <span class="preset-note">Helemaal geen verkleining. De besparing komt vooral uit het opnieuw inpakken van het bestand.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <details class="advanced">
+      <summary>Zet de twee getallen zelf</summary>
+      <div class="option-row">
+        <label for="dpi-value">Hoogstens zoveel pixels per inch getekende ruimte</label>
+        <div class="inline-pair">
+          <input type="number" id="dpi-value" min="0" max="1200" step="10" value="130" inputmode="numeric">
+          <span class="unit">dpi &mdash; 0 laat elk plaatje op volle grootte staan</span>
+        </div>
+      </div>
+      <div class="option-row">
+        <label for="quality-value">JPEG-kwaliteit</label>
+        <div class="inline-pair">
+          <input type="range" id="quality-value" min="30" max="95" step="1" value="68">
+          <output id="quality-out" for="quality-value">68</output>
+        </div>
+      </div>
+    </details>
+
+    <label class="check">
+      <input type="checkbox" id="strip-meta" checked>
+      <span>
+        <strong>Haal eruit wat het bestand onthoudt over waar het vandaan komt</strong>
+        <span class="check-note">
+          De naam en versie van het programma dat het maakte, wanneer het gemaakt
+          en voor het laatst bewerkt is, het XMP-pakket, en de privéklomp die een
+          opmaakprogramma achterlaat om zijn eigen werk weer te kunnen inlezen
+          &mdash; wat af en toe megabytes is. Niets daarvan is nodig om het
+          document te tonen.
+        </span>
+      </span>
+    </label>
+
+    <p id="settings-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Stap 4 &mdash; de ene klik -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Comprimeren</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Deze pdf comprimeren</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Downloaden</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <details id="per-image" class="advanced" hidden>
+        <summary>Wat er met elk plaatje gebeurd is</summary>
+        <ul id="image-list" class="image-list"></ul>
+      </details>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/compress-pdf.toml
+++ b/locales/nl/tools/compress-pdf.toml
@@ -1,0 +1,266 @@
+#
+# Pdf verkleinen - Dutch.
+#
+# Overrides for tools/compress-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Pdf-compressor"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Pdf&nbsp;comprimeren <span class=\"h1-kw\">&mdash; een pdf kleiner maken</span>"
+tagline = "Een document krimpen zonder het ergens heen te sturen."
+
+title = "Pdf comprimeren &mdash; gratis, in je browser, zonder uploaden"
+description = "Maak een pdf kleiner zonder hem te uploaden. Het bestand wordt door je eigen browser gelezen, opnieuw gecomprimeerd en herschreven, en de tool laat je eerst zien waar de grootte werkelijk zit."
+og_title = "Pdf comprimeren &mdash; gratis, en er wordt niets geüpload"
+og_description = "Krimp een pdf op je eigen apparaat. Het meet hoe groot elke afbeelding op de pagina getekend wordt, dus het gooit alleen pixels weg die niemand kon zien."
+og_image_alt = "Pdf comprimeren - een document kleiner maken zonder het te uploaden"
+
+pledge = """
+    Het document wordt op dit apparaat in het geheugen geopend, uit elkaar
+    gehaald en weer weggeschreven, door code die vanaf dit adres geserveerd
+    wordt. Niets hier kan een upload doen, en er staat aan de andere kant van
+    deze pagina geen server om er een te ontvangen."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en comprimeer een bestand. Geen enkel verzoek draagt een pagina, een
+      plaatje of een bestandsnaam. Of trek de stekker uit het internet en
+      comprimeer er toch een."""
+
+read_first = """
+, en <code>src/reader.js</code> en <code>src/writer.js</code>
+      voor het hele lees- en herschrijfwerk; geen van beide kan bij het netwerk."""
+
+howto_heading = "Een pdf kleiner maken"
+
+card = """
+            Maak een document kleiner door de plaatjes erin opnieuw te
+            comprimeren. Het laat je eerst zien waar de grootte werkelijk zit, en
+            zegt gewoon wanneer er niets te halen valt."""
+
+[words]
+plural = "documenten"
+choose = "een pdf"
+analytics_extra = """"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "Bestanden blijven op je apparaat"
+
+[[privacy]]
+title = "Je document kan nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Deze tool voegt niets aan die lijst toe:
+      hij heeft geen eigen netwerkfunctie, ook geen optionele. Er is hier geen
+      eindpunt waar je bestand verzameld zou kunnen worden, en niets in de code
+      dat het zou versturen als dat er wel was."""
+
+[[privacy]]
+title = "Het hele formaat staat in deze repository."
+body = """
+ Een pdf is een lijst
+      objecten en een tabel van waar elk object begint. <code>src/objects.js</code>
+      leest die syntaxis, <code>src/reader.js</code> volgt de tabel,
+      <code>src/writer.js</code> schrijft een nieuwe, en geen van de drie
+      importeert iets dat een verzoek kan doen. Er wordt geen bibliotheek
+      opgehaald en er wordt niets op een server gerenderd."""
+
+[[privacy]]
+title = "Versleutelde bestanden worden geweigerd in plaats van geopend."
+body = """
+
+      Een pdf met een wachtwoord erop wordt geweigerd, ook het soort dat scanners
+      maken met een leeg wachtwoord en dat technisch gezien gewoon zou opengaan.
+      De beveiliging van een document afhalen is een andere klus dan het kleiner
+      maken, en het stilletjes doen zou een verrassende daad zijn voor een tool
+      die namens jou werkt."""
+
+[[privacy]]
+title = "Het haalt er dingen uit in plaats van erin te stoppen."
+body = """
+ Het klaargekomen bestand draagt geen
+      aanmaakdatum, geen producentregel en geen naam van de tool die het maakte.
+      Met het vinkje aan verliest het ook het XMP-pakket en de privéblokken die
+      opmaakprogramma's achterlaten &mdash; hetzelfde argument dat de EXIF-tool
+      maakt, toegepast op een andere container."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google. Geen van beide krijgt iets over je document
+      mee: geen bestand, geen pagina, geen naam, geen grootte, geen aantal
+      pagina's. Elke regel die een pdf leest, decodeert of schrijft, wordt vanaf
+      deze herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de doneerknop laadt, en wat hij niet krijgt."
+body = """
+
+      De knop &ldquo;Buy me a coffee&rdquo; in de kop wordt getekend door een
+      script van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts.
+      Het is een link en verder niets: hij meldt geen bezoek, en hij krijgt niets
+      over jou of je document mee. Er gebeurt niets tenzij je erop klikt, en waar
+      je dan naartoe klikt is de site van iemand anders."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en alles op deze
+      pagina doet het nog. Dat is het eenvoudigste bewijs van allemaal: een tool
+      die je document wegstuurde om het te comprimeren, zou stoppen."""
+
+[[howto]]
+title = "Kies een pdf."
+body = """
+ Sleep hem op het keuzevak of kies hem met
+      de hand. De browser leest hem rechtstreeks van je schijf; er wordt daarbij
+      niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Kijk waar de grootte zit."
+body = """
+ De uitsplitsing is waar de
+      tweede stap om draait. Bestaat de balk vooral uit afbeeldingen, dan heeft
+      deze tool iets om mee te werken. Bestaat hij vooral uit lettertypen en
+      pagina-inhoud, dan zegt hij dat, en is de eerlijke besparing een paar
+      procent &mdash; dat weet je liever voordat je er een minuut in steekt."""
+
+[[howto]]
+title = "Zeg hoe hard er geknepen mag worden."
+body = """
+ De benoemde
+      instellingen zijn resoluties, geen vage rapportcijfers: 96 dpi om op een
+      scherm te lezen, 130 om te mailen, 220 voor iets dat nog geprint moet
+      worden. Elk daarvan wordt afgemeten aan hoe groot het plaatje werkelijk op
+      de pagina getekend wordt, dus een foto die als miniatuur staat, wordt niet
+      als een paginagrote scan behandeld."""
+
+[[howto]]
+title = "Comprimeer, en lees de regel die zegt dat het gecontroleerd is."
+body = """
+
+      Is het herschrijven klaar, dan wordt het gereedgekomen bestand door
+      dezelfde lezer op deze pagina opnieuw geopend en worden de pagina's geteld.
+      Klopt dat niet met het origineel, dan wordt de ronde als mislukt gemeld en
+      wordt er geen download aangeboden."""
+
+[[faq]]
+q = "Wordt mijn pdf ergens heen geüpload?"
+a = """
+        Nee. Het bestand wordt gelezen, opnieuw gecomprimeerd en geschreven door
+        je eigen browser op je eigen hardware. Deze tool heeft geen serverkant, en
+        de <code>Content-Security-Policy</code> van de pagina noemt elk adres dat
+        hij mag benaderen &mdash; geen ervan hoort bij deze site. Deze tool heeft
+        geen enkele optionele netwerkfunctie."""
+
+[[faq]]
+q = "Hoeveel kleiner wordt mijn pdf?"
+a = """
+        Dat hangt volledig af van wat erin zit, en daarom meet de tool het en
+        laat hij het je zien voordat hij iets comprimeert. Een gescand document
+        bestaat vrijwel geheel uit foto's en komt er meestal 60 tot 90% kleiner
+        uit. Een contract of een scriptie is tekst, vectortekening en ingebedde
+        lettertypen, die allemaal al gecomprimeerd waren door wat ze maakte; daar
+        is de besparing meestal een paar procent, uit het opnieuw inpakken van
+        het bestand en het weglaten van wat nergens meer naar verwijst. Elke tool
+        die een vast percentage belooft zonder naar je bestand te kijken, gokt."""
+
+[[faq]]
+q = "Kost een pdf comprimeren kwaliteit?"
+a = """
+        De plaatjes erin worden opnieuw gecodeerd, dus voor die: ja. Verder wordt
+        er niets aangeraakt: de tekst blijft tekst, selecteerbaar en doorzoekbaar,
+        de lettertypen blijven heel, en de vectortekening wordt exact
+        overgenomen. De tool weigert ook een plaatje voor niets slechter te maken
+        &mdash; komt een hercodering niet kleiner uit dan het origineel, dan gaan
+        de originele bytes onaangeroerd terug het document in."""
+
+[[faq]]
+q = "Wat is dpi hier, en waarom vraagt het ernaar?"
+a = """
+        Een pdf legt vast hoe groot elk plaatje op de pagina getekend wordt, dus
+        kan de tool de effectieve resolutie uitrekenen: een scan van 4000 pixels
+        die over twintig centimeter papier gelegd wordt, draagt zo'n 500 pixels
+        per inch. Niets op een scherm en heel weinig op papier kan daar iets mee,
+        dus de pixels boven de instelling die je kiest, gaan er als eerste af
+        &mdash; ze kosten kwaliteit die niemand kan zien. Door die meting wordt
+        een klein geplaatst logo niet hetzelfde behandeld als een paginagrote
+        scan."""
+
+[[faq]]
+q = "Kan het een met een wachtwoord beveiligde pdf openen?"
+a = """
+        Nee, en dat is met opzet. Een versleuteld document wordt geweigerd met een
+        melding die dat zegt, ook wanneer het wachtwoord leeg is &mdash; wat de
+        manier is waarop veel scanners en kopieerapparaten opslaan. De beveiliging
+        van een bestand halen is een andere klus dan het comprimeren, en een tool
+        die dat stilletjes deed, zou iets doen waar je niet om gevraagd hebt."""
+
+[[faq]]
+q = "Zijn er pdf's die het niet kan comprimeren?"
+a = """
+        Sommige afbeeldingen erin, ja. Voor JPEG 2000, JBIG2 en faxgecodeerde
+        (CCITT) afbeeldingen heeft geen enkele browser een decoder, dus die worden
+        onaangeroerd doorgegeven en als zodanig gemeld &mdash; de laatste twee
+        zijn tweekleurencodecs en zitten meestal toch al bijna op hun kleinst.
+        CMYK-afbeeldingen worden ook met rust gelaten, omdat hercoderen de kleuren
+        kan verschuiven die een drukker zou produceren. Alles wat de tool
+        overslaat, wordt bij de resultaten genoemd, met de reden erbij."""
+
+[[faq]]
+q = "Gaat het gecomprimeerde bestand overal nog open?"
+a = """
+        Ja. De uitvoer wordt geschreven als pdf 1.5, wat elke lezer die sinds 2003
+        is uitgekomen begrijpt, en de tool bewijst dat op je eigen apparaat: hij
+        opent het gereedgekomen bestand opnieuw en telt de pagina's voordat hij
+        het je aanbiedt. Formulieren, links, bladwijzers, de
+        toegankelijkheidsstructuur en eventuele ingesloten bijlagen gaan mee; wat
+        achterblijft is het materiaal waar niets in het document nog naar
+        verwees."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen limiet op de bestandsgrootte behalve wat het geheugen van je eigen
+        apparaat toelaat. De site draagt advertenties, en die betalen hem; de
+        advertenties krijgen niets over je document mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je document wegstuurde om het te
+        comprimeren, zou stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Comprimeer een pdf in je browser. Afbeeldingen worden opnieuw gecomprimeerd op basis van hoe groot ze werkelijk op de pagina getekend worden, en het document wordt lokaal herschreven, dus er wordt nooit een bestand geüpload."
+features = [
+  "Laat zien waar de grootte van een document werkelijk zit voordat er iets gecomprimeerd wordt",
+  "Comprimeert afbeeldingen opnieuw op basis van hun gemeten resolutie op de pagina",
+  "Laat een afbeelding met rust wanneer hercoderen hem niet kleiner zou maken",
+  "Laat objecten vallen die een eerdere bewerking achterliet, plus optionele metagegevens",
+  "Opent het gereedgekomen bestand opnieuw en controleert het voordat het wordt aangeboden",
+  "Draait offline; geen upload, geen account, geen limiet op de bestandsgrootte",
+]
+
+[picker]
+title = "Sleep een pdf hierheen"
+hint = "of klik om te bladeren &mdash; één document tegelijk"

--- a/locales/nl/tools/crop-video.html
+++ b/locales/nl/tools/crop-video.html
@@ -1,0 +1,146 @@
+<main>
+  <!-- Stap 1 &mdash; het bestand -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies een video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Bestand</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Grootte</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Beeld</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Lengte</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Audio</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; de bijsnijding -->
+  <section class="card" id="crop-card" hidden>
+    <h2><span class="step">2</span> Stel de bijsnijding in</h2>
+
+    <p class="stage-hint">
+      Sleep binnen het kader om het te verplaatsen, of aan een hoek om het
+      formaat te wijzigen. Met het kader geselecteerd verschuiven de pijltjes het
+      een pixel tegelijk, wijzigt <kbd>Alt</kbd>&nbsp;+&nbsp;pijltjes het
+      formaat, en maakt <kbd>Shift</kbd> ingedrukt houden elke stap tien.
+    </p>
+
+    <!-- The crop box itself is added here by src/cropper.js. The stage is given
+         the video's own shape, so the box can be positioned in percentages and
+         needs no recalculating when the window is resized. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <div class="crop-controls">
+      <div class="aspect-row" role="group" aria-label="Het kader op een vorm vastzetten">
+        <button type="button" data-aspect="free" class="active">Vrij</button>
+        <button type="button" data-aspect="source">Origineel</button>
+        <button type="button" data-aspect="1:1">1:1</button>
+        <button type="button" data-aspect="4:5">4:5</button>
+        <button type="button" data-aspect="9:16">9:16</button>
+        <button type="button" data-aspect="16:9">16:9</button>
+        <button type="button" data-aspect="4:3">4:3</button>
+        <button type="button" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="ghost" title="Zet de vaste vorm op zijn kant">
+          Omdraaien
+        </button>
+      </div>
+
+      <div class="numbers">
+        <label>Links<input type="number" id="crop-x" min="0" step="1"></label>
+        <label>Boven<input type="number" id="crop-y" min="0" step="1"></label>
+        <label>Breedte<input type="number" id="crop-w" min="16" step="2"></label>
+        <label>Hoogte<input type="number" id="crop-h" min="16" step="2"></label>
+        <div class="number-actions">
+          <button type="button" id="crop-max" class="ghost">Grootst</button>
+          <button type="button" id="crop-centre" class="ghost">Midden</button>
+          <button type="button" id="crop-reset" class="ghost">Hele beeld</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="even-note">
+      Breedte en hoogte gaan met stappen van twee, omdat H.264 geen manier heeft
+      om een frame met een oneven zijde op te slaan.
+    </p>
+  </section>
+
+  <!-- Stap 3 &mdash; de export -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Snijd het bij</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Uitvoer</label>
+        <select id="format">
+          <option value="mp4" selected>MP4 &mdash; frame voor frame opnieuw gecodeerd</option>
+          <option value="webm">WebM &mdash; opgenomen terwijl het speelt</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Kwaliteit</label>
+        <select id="quality">
+          <option value="low">Kleiner bestand</option>
+          <option value="medium" selected>In balans</option>
+          <option value="high">Beste kwaliteit</option>
+        </select>
+        <p class="field-note">
+          Nooit meer dan het origineel aan datzelfde gebied uitgaf &mdash;
+          daarboven hercoderen maakt het bestand alleen groter.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Hou het geluid
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Uitvoerbeeld</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Gehouden</dt><dd id="sum-kept">&mdash;</dd></div>
+      <div><dt>Lengte</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Hoe</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Video bijsnijden</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Video downloaden</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/crop-video.toml
+++ b/locales/nl/tools/crop-video.toml
@@ -1,0 +1,247 @@
+#
+# Videobijsnijder - Dutch.
+#
+# Overrides for tools/crop-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Videobijsnijder"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Video&nbsp;bijsnijden <span class=\"h1-kw\">&mdash; online een video bijsnijden</span>"
+tagline = "Snijd een filmpje terug tot het stuk waar het om gaat."
+
+title = "Online een video bijsnijden &mdash; gratis, zonder uploaden, werkt offline"
+description = "Snijd een mp4, mov of WebM bij naar elke vorm - vierkant, 9:16, of een exact pixelkader. Draait in je browser: niets geüpload, het geluid blijft, werkt offline."
+og_title = "Videobijsnijder &mdash; een filmpje bijsnijden zonder het te uploaden"
+og_description = "Sleep een kader over je filmpje en snijd het bij naar elke vorm. De frames worden op je eigen apparaat gedecodeerd en opnieuw gecodeerd, en het originele geluid gaat onaangeroerd mee."
+og_image_alt = "Videobijsnijder - een filmpje bijsnijden in je browser, zonder iets te uploaden"
+
+pledge = """
+    Elk frame wordt gedecodeerd, bijgesneden en gecodeerd door je eigen browser,
+    op je eigen hardware. Niets hier kan iets ophalen of versturen &mdash; er zit
+    helemaal geen netwerkfunctie in deze tool &mdash; en er staat aan de andere
+    kant van deze pagina geen server om een video heen te sturen, ook al was er
+    een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en snijd een filmpje bij. Geen enkel verzoek draagt een frame, een
+      bestandsnaam of één byte van wat je koos. Of trek de stekker uit het
+      internet en snijd er toch een bij &mdash; een tool die je video wegstuurde
+      om hem te verwerken, zou domweg stoppen."""
+
+read_first = """
+, <code>src/demux.js</code> voor de lezer die de
+      frames in een mp4 vindt, en <code>src/transcode.js</code> voor de lus die
+      ze decodeert, bijsnijdt en codeert. Geen van beide importeert iets dat een
+      verzoek kan doen."""
+
+howto_heading = "Een video bijsnijden"
+
+card = """
+            Sleep een kader over een filmpje en snijd het terug naar die vorm
+            &mdash; vierkant voor een tijdlijn, staand voor een telefoon, of een
+            exact pixelkader."""
+
+[words]
+plural = "video's"
+choose = "een video"
+analytics_extra = """, en geen
+  frame, lengte of bijsnijdformaat"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Houdt het geluid"
+
+[[facts]]
+text = "Werkt offline"
+
+[[privacy]]
+title = "Je video's kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestand
+      verzameld zou kunnen worden, en niets in de code dat het zou versturen als
+      dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Deze tool heeft helemaal geen
+      netwerkfunctie: geen adres om te plakken, niets om te downloaden, geen
+      engine die bij het eerste gebruik opgehaald wordt. Elke byte die je video
+      aanraakt, kwam bij het laden van de pagina van deze herkomst."""
+
+[[privacy]]
+title = "Het decoderen en coderen gebeuren lokaal."
+body = """
+ De frames gaan door
+      WebCodecs in je eigen browser, of door dezelfde afspeelmotor die je het
+      filmpje toch al zou tonen. Het gereedgekomen bestand wordt op dit apparaat
+      in het geheugen opgebouwd en meteen aan een download doorgegeven."""
+
+[[privacy]]
+title = "Het geluid wordt gekopieerd, niet beluisterd."
+body = """
+ Op de mp4-route worden de
+      audiomonsters overgezet zonder ook maar gedecodeerd te worden &mdash; niets
+      hier maakt er ooit weer geluid van, en niets zou ze ergens heen kunnen
+      doorgeven als dat wel zo was."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google. Geen van beide krijgt iets over je video mee:
+      geen bestand, geen frame, geen naam, geen grootte, geen lengte, en niet de
+      vorm waarnaar je bijsneed. Elke regel die leest, decodeert, bijsnijdt of
+      codeert, wordt vanaf deze herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de doneerknop laadt, en wat hij niet krijgt."
+body = """
+
+      De knop &ldquo;Buy me a coffee&rdquo; in de kop wordt getekend door een
+      script van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts.
+      Het is een link en verder niets: hij meldt geen bezoek, en hij krijgt niets
+      over jou of je video mee."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en alles op deze
+      pagina doet het nog. Dat is het eenvoudigste bewijs van allemaal."""
+
+[[howto]]
+title = "Kies een video."
+body = """
+ Sleep een mp4, mov, m4v of WebM op het
+      keuzevak, of kies er een met de hand. De browser leest hem rechtstreeks van
+      je schijf; er wordt daarbij niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Sleep het kader over het stuk dat je wilt houden."
+body = """
+ Sleep
+      binnen het kader om het te verplaatsen en aan een hoek om het formaat te
+      wijzigen. Zet het eerst vast op een vorm &mdash; 1:1 voor een vierkante
+      post, 9:16 voor een telefoon, 16:9 voor een breed beeld &mdash; of tik een
+      exact pixelkader in de vier velden eronder."""
+
+[[howto]]
+title = "Kies hoeveel kwaliteit je eraan uitgeeft."
+body = """
+ Het beeld moet
+      opnieuw gecodeerd worden, want een bijgesneden frame is een ander beeld.
+      &ldquo;In balans&rdquo; houdt het dicht bij wat het bestand al aan dat
+      gebied uitgaf; &ldquo;Beste kwaliteit&rdquo; geeft er meer aan uit. Het
+      geluid blijft, tenzij je het uitzet."""
+
+[[howto]]
+title = "Snijd het bij en download."
+body = """
+ Het werk gebeurt op je eigen
+      hardware, dus hoe lang het duurt hangt af van je apparaat en niet van een
+      wachtrij. De gereedgekomen video gaat rechtstreeks naar de downloads van je
+      browser."""
+
+[[faq]]
+q = "Wordt mijn video ergens heen geüpload?"
+a = """
+        Nee. Hij wordt gelezen, gedecodeerd, bijgesneden en gecodeerd door je
+        eigen browser op je eigen hardware. Deze tool heeft geen serverkant, en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen &mdash; geen ervan hoort bij deze site. Trek de stekker uit
+        het internet en snijd er toch een bij, als je liever controleert dan het
+        aanneemt."""
+
+[[faq]]
+q = "Welke videoformaten kan ik bijsnijden?"
+a = """
+        Mp4, m4v en mov worden rechtstreeks gelezen, wat er ook in zit: H.264,
+        HEVC, AV1 of VP9, zolang je browser die codec kan decoderen. Al het andere
+        dat je browser kan afspelen &mdash; WebM het meest voor de hand liggend
+        &mdash; wordt in plaats daarvan bijgesneden door het af te spelen en het
+        resultaat op te nemen, wat werkt maar zo lang duurt als het filmpje is.
+        Een bestand dat de browser niet kan lezen en ook niet kan afspelen, in de
+        praktijk avi, wmv, flv en de meeste mkv's, wordt geweigerd met een melding
+        die dat zegt, in plaats van halverwege te stranden."""
+
+[[faq]]
+q = "Zit er een limiet op de grootte of lengte van de video?"
+a = """
+        In de tool zit geen limiet ingebouwd, en het bestand wordt niet in één
+        keer in het geheugen gelezen &mdash; er wordt een paar megabyte tegelijk
+        doorheen gelopen. Het praktische plafond is de gereedgekomen video, die in
+        het geheugen wordt opgebouwd voordat je hem downloadt, en de tijd die je
+        apparaat nodig heeft om hem te coderen."""
+
+[[faq]]
+q = "Blijft het geluid intact?"
+a = """
+        Op de mp4-route precies: de audio wordt monster voor monster overgezet
+        zonder ooit gedecodeerd te worden, dus het is byte voor byte wat er in het
+        bestand zat. Op de opnameroute wordt hij van de weergave opgevangen en
+        opnieuw gecodeerd, wat een beetje kwaliteit kost. Hoe dan ook is er een
+        vinkje om hem er helemaal uit te laten."""
+
+[[faq]]
+q = "Kost bijsnijden kwaliteit?"
+a = """
+        Het beeld wordt opnieuw gecodeerd, want een bijgesneden frame is een ander
+        beeld en er is geen manier om het op te slaan zonder de pixels opnieuw weg
+        te schrijven. Wat de tool niet doet, is meer uitgeven dan het origineel
+        aan datzelfde gebied uitgaf, want daarboven hercoderen maakt het bestand
+        alleen groter zonder het er beter uit te laten zien."""
+
+[[faq]]
+q = "Kan ik hem ook korter maken?"
+a = """
+        Hier niet, maar hiernaast wel. Deze tool verandert de vorm van het beeld
+        en verder niets: het filmpje dat eruit komt is precies zo lang als dat wat
+        erin ging, met zijn timing en zijn geluid intact. Inkorten is een aparte
+        klus en een aparte tool &mdash; de
+        <a href="../video-knippen/">Videoknipper</a> markeert de stukken van een
+        filmpje die het bewaren waard zijn en slaat ze op als één bestand, zonder
+        één frame opnieuw te coderen."""
+
+[[faq]]
+q = "Waarom gaan de breedte en hoogte met stappen van twee?"
+a = """
+        H.264, de codec in een mp4, slaat het beeld in blokken op en heeft geen
+        manier om een frame met een oneven aantal pixels op een zijde te
+        beschrijven. In plaats van je bijsnijding stilletjes af te ronden nadat je
+        hem hebt ingesteld, biedt het kader van meet af aan alleen even getallen
+        aan."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. De site draagt advertenties, en die betalen hem; de
+        advertenties krijgen niets over je video mee."""
+
+[schema]
+browser_requirements = "Vereist JavaScript. Voor mp4-uitvoer is een browser met WebCodecs nodig; andere vallen terug op het opnemen van WebM."
+description = "Snijd een video in de browser bij naar elke vorm of een exact pixelkader. Mp4, mov en m4v worden frame voor frame gedecodeerd en opnieuw gecodeerd, met de originele audio onaangeroerd meegenomen; al het andere dat de browser kan afspelen wordt bijgesneden door het op te nemen. Er wordt niets geüpload."
+features = [
+  "Snijdt mp4-, mov-, m4v- en WebM-video bij",
+  "H.264-, HEVC-, AV1- en VP9-bronnen, gedecodeerd via WebCodecs",
+  "Vrij bijsnijden, vaste verhoudingen (1:1, 4:5, 9:16, 16:9, 4:3, 3:2) of een exact pixelkader",
+  "Houdt de originele audio zonder hem opnieuw te coderen",
+  "Draait offline; geen upload, geen account, geen watermerk",
+]
+
+[picker]
+title = "Sleep een video hierheen"
+hint = "of klik om te bladeren &mdash; mp4, mov, m4v, WebM, en al het andere dat deze browser afspeelt"

--- a/locales/nl/tools/edit-audio.html
+++ b/locales/nl/tools/edit-audio.html
@@ -1,0 +1,170 @@
+<main>
+  <!-- Stap 1 &mdash; het bestand -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies een bestand</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Bestand</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Grootte</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Lengte</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Geluid</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>Luidste moment</dt><dd id="src-peak">&mdash;</dd></div>
+      <div><dt>Gelezen als</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <div class="wave-wrap" id="src-wave-wrap" hidden>
+      <canvas id="src-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="preview" controls preload="metadata"></audio>
+    </div>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; de bewerkingen -->
+  <section class="card" id="edit-card" hidden>
+    <h2><span class="step">2</span> Verander hem</h2>
+
+    <div class="edit-block">
+      <label class="check" for="reverse">
+        <input type="checkbox" id="reverse">
+        Achterstevoren afspelen
+      </label>
+      <p class="field-note">
+        De samples worden achterstevoren weggeschreven. Verder verandert er niets
+        aan ze, dus twee keer omkeren geeft precies het bestand terug waarmee je
+        begon.
+      </p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="speed">Snelheid</label>
+        <input type="text" id="speed-value" class="value-box" inputmode="decimal"
+               spellcheck="false" autocomplete="off" aria-label="Snelheid, als factor">
+      </div>
+
+      <!-- The slider is in octaves, not multiples: half speed and double speed
+           are then the same distance either side of the middle, which is how
+           they sound. main.js does the conversion. -->
+      <input type="range" id="speed" min="-2" max="2" step="0.01" value="0"
+             aria-describedby="speed-note">
+
+      <div class="presets" role="group" aria-label="Snelheidsvoorkeuzes">
+        <button type="button" class="ghost" data-speed="0.5">0,5&times;</button>
+        <button type="button" class="ghost" data-speed="0.75">0,75&times;</button>
+        <button type="button" class="ghost" data-speed="1">1&times;</button>
+        <button type="button" class="ghost" data-speed="1.25">1,25&times;</button>
+        <button type="button" class="ghost" data-speed="1.5">1,5&times;</button>
+        <button type="button" class="ghost" data-speed="2">2&times;</button>
+      </div>
+
+      <fieldset class="modes">
+        <legend>Wat er met de toonhoogte gebeurt</legend>
+        <label class="mode">
+          <input type="radio" name="pitch" value="keep" checked>
+          <span>
+            <strong>Hou de toonhoogte</strong>
+            Een stem klinkt nog als dezelfde stem, alleen sneller of langzamer.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="pitch" value="move">
+          <span>
+            <strong>Laat hem meebewegen</strong>
+            Sneller is hoger en langzamer is lager, zoals een bandje het doet.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="speed-note"></p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="volume">Volume</label>
+        <input type="text" id="volume-value" class="value-box" inputmode="decimal"
+               spellcheck="false" aria-label="Volumeverandering, in decibel">
+      </div>
+
+      <input type="range" id="volume" min="-24" max="24" step="0.5" value="0"
+             aria-describedby="volume-note">
+
+      <fieldset class="modes">
+        <legend>Hoe hard het moet worden</legend>
+        <label class="mode">
+          <input type="radio" name="level" value="gain" checked>
+          <span>
+            <strong>Met zoveel</strong>
+            Elke sample met hetzelfde getal vermenigvuldigd. Verder verandert er niets.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="level" value="normalize">
+          <span>
+            <strong>Zo hard als het gaat</strong>
+            Opgetild tot het luidste moment net onder het plafond zit.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="volume-note"></p>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Lengte</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Snelheid</dt><dd id="sum-speed">&mdash;</dd></div>
+      <div><dt>Luidste moment</dt><dd id="sum-peak">&mdash;</dd></div>
+      <div><dt>Ruwweg</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="clip-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Stap 3 &mdash; het bestand dat eruit komt -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Sla hem op</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">Wat er geschreven wordt</label>
+        <select id="depth">
+          <option value="16" selected>16-bits wav &mdash; speelt overal</option>
+          <option value="32">32-bits float wav &mdash; niets afgekapt</option>
+        </select>
+        <p class="field-note" id="depth-note">
+          Een wav bevat de samples zoals ze zijn, dus er een schrijven kan geen
+          kwaliteit kosten. Klein is het niet: zie de schatting hierboven.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary">De audio bewerken</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Audio downloaden</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/edit-audio.toml
+++ b/locales/nl/tools/edit-audio.toml
@@ -1,0 +1,286 @@
+#
+# Audiobewerker - Dutch.
+#
+# Overrides for tools/edit-audio/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Audiobewerker"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Audio&nbsp;bewerken <span class=\"h1-kw\">&mdash; omkeren, versnellen of versterken</span>"
+tagline = "Achterstevoren afspelen, de snelheid wijzigen, een zachte opname optillen &mdash; allemaal hier, op je eigen apparaat."
+
+title = "Audio omkeren, snelheid wijzigen &amp; volume optillen &mdash; gratis, zonder uploaden"
+description = "Speel een opname achterstevoren af, maak hem sneller of langzamer, en maak een zachte opname harder. Haalt ook het geluid uit een video. Draait in je browser: niets geüpload."
+og_title = "Audiobewerker &mdash; omkeren, hertimen en versterken zonder iets te uploaden"
+og_description = "Keer een opname om, wijzig de snelheid met of zonder de toonhoogte mee te nemen, en zet het niveau &mdash; download daarna een wav. Het bestand wordt door je eigen browser gelezen en geschreven."
+og_image_alt = "Audiobewerker - audio omkeren, hertimen en versterken in je browser"
+
+pledge = """
+    Je bestand wordt gelezen, bewerkt en geschreven door je eigen browser, op je
+    eigen hardware. Niets hier kan iets ophalen of versturen &mdash; er zit
+    helemaal geen netwerkfunctie in deze tool &mdash; en er staat aan de andere
+    kant van deze pagina geen server om een opname heen te sturen, ook al was er
+    een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en keer iets om. Geen enkel verzoek draagt een sample, een
+      bestandsnaam of één byte van wat je koos. Of trek de stekker uit het
+      internet en bewerk toch een opname &mdash; een tool die je audio wegstuurde
+      om hem te verwerken, zou domweg stoppen."""
+
+read_first = """
+, <code>src/decode.js</code> voor de twintig regels
+      die je bestand aan de eigen decoder van de browser geven,
+      <code>src/stretch.js</code> voor het uitrekken in de tijd,
+      <code>src/speed.js</code> voor de resampler, en <code>src/wav.js</code>
+      voor de kop die vóór de samples komt. Geen ervan importeert iets dat een
+      verzoek kan doen."""
+
+howto_heading = "Een audiobestand bewerken"
+
+card = """
+            Keer een opname om, wijzig de snelheid met of zonder de toonhoogte
+            mee te nemen, en til een zachte opname op. Haalt ook het geluid uit
+            een video."""
+
+[words]
+plural = "opnames"
+choose = "een bestand"
+analytics_extra = """, en geen
+  golfvorm, lengte of niveau"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Video erin, audio eruit"
+
+[[facts]]
+text = "Werkt offline"
+
+[[privacy]]
+title = "Je opnames kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestand
+      verzameld zou kunnen worden, en niets in de code dat het zou versturen als
+      dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Deze tool heeft helemaal geen
+      netwerkfunctie: geen adres om te plakken, niets om te downloaden, geen
+      engine die bij het eerste gebruik opgehaald wordt. Elke byte die je audio
+      aanraakt, kwam bij het laden van de pagina van deze herkomst."""
+
+[[privacy]]
+title = "De decoder is die je al in je browser hebt."
+body = """
+
+      Het bestand wordt aan <code>decodeAudioData</code> gegeven, dezelfde code
+      die een nummer afspeelt in een <code>&lt;audio&gt;</code>-element. Er wordt
+      hier niets meegeleverd om jouw formaat te lezen, en er wordt ook niets
+      buiten deze pagina om gevraagd om het te lezen."""
+
+[[privacy]]
+title = "Het beeld van een video wordt helemaal nooit gedecodeerd."
+body = """
+ Sleep je een video naar
+      binnen, dan wordt alleen om de audiospoor gevraagd. De frames worden niet
+      gelezen, niet gedecodeerd, niet getekend en niet bekeken &mdash; er staat
+      geen code op deze pagina die dat zou kunnen, en het bestand dat eruit komt
+      bevat geluid en verder niets."""
+
+[[privacy]]
+title = "De samples worden opgeschreven, niet opnieuw gecodeerd."
+body = """
+
+      Een wav is de samples die deze pagina uitrekende, met een kop ervoor. Er
+      zit geen encoder in de lus die beslissingen over je opname neemt, en er is
+      niets wat een upload genoemd zou kunnen worden waarop dat zou moeten
+      gebeuren."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google. Geen van beide krijgt iets over je opname
+      mee: geen bestand, geen sample, geen naam, geen grootte, geen lengte, en
+      niet hoe hard hij was. Elke regel die leest, bewerkt en schrijft, wordt
+      vanaf deze herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de doneerknop laadt, en wat hij niet krijgt."
+body = """
+
+      De knop &ldquo;Buy me a coffee&rdquo; in de kop wordt getekend door een
+      script van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts.
+      Het is een link en verder niets: hij meldt geen bezoek, en hij krijgt niets
+      over jou of je bestand mee."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en alles op deze
+      pagina doet het nog. Dat is het eenvoudigste bewijs van allemaal."""
+
+[[howto]]
+title = "Kies een bestand."
+body = """
+ Sleep een mp3-, wav-, flac-, m4a-,
+      Ogg- of Opus-bestand op het keuzevak &mdash; of een video, als het je om
+      het geluid daaruit te doen is. De browser leest het rechtstreeks van je
+      schijf; er wordt daarbij niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Draai hem om, als je daarvoor kwam."
+body = """
+ Eén vinkje.
+      De samples worden achterstevoren weggeschreven, wat precies omkeerbaar is:
+      doe het twee keer en je hebt het bestand terug waarmee je begon, sample
+      voor sample."""
+
+[[howto]]
+title = "Zet de snelheid."
+body = """
+ Sleep de schuif, tik een factor in, of druk
+      op een van de voorkeuzes. Kies daarna wat er met de toonhoogte gebeurt: hou
+      hem waar hij is, wat je wilt bij een college op 1,5&times;, of laat hem
+      meebewegen met de snelheid, wat een bandje doet en wat een stem hoger of
+      lager maakt."""
+
+[[howto]]
+title = "Zet het niveau."
+body = """
+ Noem een verandering in decibel, of vraag of
+      de opname opgetild mag worden tot het luidste moment net onder het plafond
+      zit. De pagina vertelt waar dat moment gaat landen voordat je op iets
+      drukt, en waarschuwt je als de gekozen instelling het voorbij volle schaal
+      zou duwen."""
+
+[[howto]]
+title = "Sla hem op."
+body = """
+ Het werk gebeurt op je eigen hardware, dus hoe
+      lang het duurt hangt af van je apparaat en niet van een wachtrij. Wat eruit
+      komt is een wav &mdash; de samples zelf, met een kop ervoor &mdash; die
+      eerst op de pagina wordt afgespeeld en daarna rechtstreeks naar de
+      downloads van je browser gaat."""
+
+[[faq]]
+q = "Wordt mijn audio ergens heen geüpload?"
+a = """
+        Nee. Hij wordt gelezen, bewerkt en geschreven door je eigen browser op je
+        eigen hardware. Deze tool heeft geen serverkant, en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen &mdash; geen ervan hoort bij deze site. Trek de stekker uit
+        het internet en keer er toch een om, als je liever controleert dan het
+        aanneemt."""
+
+[[faq]]
+q = "Kan ik het geluid uit een video halen?"
+a = """
+        Ja, en dat is hier dezelfde klus als een mp3 openen. Sleep een mp4, mov of
+        WebM naar binnen en alleen de audiospoor wordt gedecodeerd: het beeld
+        wordt nooit gelezen, en wat eruit komt is een geluidsbestand zonder video
+        erin. Het is ook de manier om het geluid uit een filmpje te bewaren zonder
+        het te bewerken &mdash; laat elke instelling met rust en druk op de
+        knop."""
+
+[[faq]]
+q = "Verandert de toonhoogte als ik de snelheid wijzig?"
+a = """
+        Alleen als je erom vraagt. &ldquo;Hou de toonhoogte&rdquo; knipt de opname
+        in overlappende vensters van zo'n vijftig milliseconde en legt ze dichter
+        bij elkaar of verder uit elkaar terug, waarbij elke plek zo gekozen wordt
+        dat de golven op hun kruising uitlijnen &mdash; een stem blijft dezelfde
+        stem op 1,5&times;. &ldquo;Laat hem meebewegen&rdquo; resampelt in plaats
+        daarvan, wat een bandje sneller afspelen doet: twee keer zo snel is
+        precies een octaaf hoger."""
+
+[[faq]]
+q = "Waarom slaat het een wav op en geen mp3?"
+a = """
+        Omdat geen enkele browser een mp3-encoder meelevert, en deze tool weigert
+        je opname naar een server te sturen die er wel een heeft. Een wav heeft
+        helemaal geen encoder nodig &mdash; het zijn de samples met een kop van
+        vierenveertig bytes ervoor &mdash; dus is het zowel de eerlijke keuze als
+        de enige die geen kwaliteit kan kosten. Hij is wel groter: ongeveer tien
+        megabyte per minuut in stereo. Elke speler, telefoon en editor opent er
+        een, en alles wat een mp3 wil, kan er een van maken."""
+
+[[faq]]
+q = "Welke formaten kan ik openen?"
+a = """
+        Wat je browser decodeert, in de praktijk dus mp3, wav, flac, m4a en AAC,
+        Ogg Vorbis en Opus, en de audio in mp4-, m4v-, mov- en WebM-video. Wat
+        wegvalt is hetzelfde korte lijstje als overal elders: avi, wma en de
+        meeste mkv's. Een bestand dat deze browser niet wil lezen, wordt geweigerd
+        met een melding die dat zegt, in plaats van halverwege te stranden."""
+
+[[faq]]
+q = "Gaat het vervormen als ik het harder maak?"
+a = """
+        Alleen als je het voorbij volle schaal duwt, en de pagina zegt het je
+        voordat je dat doet. Digitale audio heeft een hard plafond: een sample kan
+        niet harder dan volle schaal, dus alles daarboven wordt tegen het plafond
+        platgeslagen, en dat is hoe vervorming klinkt. &ldquo;Zo hard als het
+        gaat&rdquo; is de instelling die dat niet kán doen &mdash; die rekent uit
+        hoeveel ruimte de opname nog heeft en gebruikt precies zoveel. Alles onder
+        het plafond is vermenigvuldigen en verder niets: zet hem 6 dB omhoog en
+        weer 6 dB omlaag en de samples staan waar ze begonnen."""
+
+[[faq]]
+q = "Kost omkeren of hertimen kwaliteit?"
+a = """
+        Omkeren niet: dezelfde samples komen er in de andere volgorde uit, en dat
+        is exact. De snelheid wijzigen verschuift elke sample, dus dat is rekenen
+        in plaats van kopiëren &mdash; de resampler filtert onderweg netjes, zodat
+        versnellen hoge tonen niet terugvouwt als een metalige rinkel, en de
+        vensters van de uitrekker worden gelegd waar de golven uitlijnen in plaats
+        van waar het rekenwerk toevallig uitkwam. Geen van beide routes codeert
+        iets opnieuw, want er is hier geen encoder om mee te hercoderen."""
+
+[[faq]]
+q = "Zit er een limiet op de lengte van het bestand?"
+a = """
+        In de tool zit geen limiet ingebouwd. Het praktische plafond is geheugen:
+        de hele opname wordt in één keer in deze pagina gedecodeerd, en een wav
+        wordt in het geheugen opgebouwd voordat je hem downloadt, dus een uur
+        stereo heeft iets minder dan een gigabyte werkruimte nodig. Een wav van
+        vier gigabyte wordt ronduit geweigerd, omdat het groottiveld van het
+        formaat er geen kan beschrijven."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. De site draagt advertenties, en die betalen hem; de
+        advertenties krijgen niets over je opname mee."""
+
+[schema]
+browser_requirements = "Vereist JavaScript en een browser met Web Audio, wat elke huidige browser is. Geen codecondersteuning nodig buiten wat de browser al heeft om het bestand af te spelen."
+description = "Keer een audio-opname om, wijzig de snelheid met of zonder de toonhoogte mee te nemen, en zet het niveau, in de browser. Werkt ook op de audio in een video. Er wordt niets geüpload en het resultaat wordt als wav geschreven, dus er wordt niets opnieuw gecodeerd."
+features = [
+  "Speelt een opname exact achterstevoren af",
+  "Wijzigt de snelheid van een kwart tot vier keer, met de toonhoogte vast of mee",
+  "Tilt het niveau op of laat het zakken, of normaliseert het tot net onder volle schaal",
+  "Haalt de audio uit een mp4, mov of WebM zonder het beeld aan te raken",
+  "Schrijft 16-bits of 32-bits float wav, zonder encoder in de lus",
+  "Draait offline; geen upload, geen account, geen watermerk",
+]
+
+[picker]
+title = "Sleep een audiobestand of een video hierheen"
+hint = "of klik om te bladeren &mdash; mp3, wav, flac, m4a, Ogg, en het geluid in mp4, mov of WebM"

--- a/locales/nl/tools/exif-editor.html
+++ b/locales/nl/tools/exif-editor.html
@@ -1,0 +1,150 @@
+<main>
+  <!-- Stap 1 &mdash; de bestanden -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies foto's</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alles van de lijst halen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; de ene klik -->
+  <section class="card" id="strip-card">
+    <h2><span class="step">2</span> Haal alles eruit</h2>
+
+    <p class="card-lede">
+      Eén knop, elke foto op de lijst. Het plaatje wordt niet gedecodeerd, niet
+      opnieuw getekend en niet opnieuw gecomprimeerd &mdash; de gecomprimeerde
+      beeldgegevens gaan onaangeroerd mee en alleen de metagegevens eromheen
+      vallen weg, dus het resultaat is dezelfde foto met niets eraan vast.
+    </p>
+
+    <div class="strip-row">
+      <button type="button" id="strip-all" class="primary big" disabled>Alle metagegevens verwijderen</button>
+      <span id="strip-status" class="strip-status" role="status" aria-live="polite"></span>
+    </div>
+
+    <!--
+      Two things are kept by default, and both are stated on the button's own
+      line rather than buried in a settings panel. "Remove all" that quietly
+      keeps things is a broken promise; "remove all except these two, and here
+      they are" is a choice.
+    -->
+    <fieldset class="keep-options">
+      <legend>Wat er blijft</legend>
+      <label class="check">
+        <input type="checkbox" id="keep-orientation" checked>
+        <span>
+          <strong>De oriëntatietag</strong>
+          <span class="check-note">
+            Telefoons bewaren een foto zoals de sensor hem zag en voegen één tag toe
+            die zegt welke kant boven is. Haal die eruit en sommige kijkers tonen hem
+            op zijn kant. Blijft hij, dan wordt er een nieuw EXIF-blok geschreven met
+            deze tag en verder niets &mdash; en alleen wanneer de foto niet al
+            rechtop stond.
+          </span>
+        </span>
+      </label>
+      <label class="check">
+        <input type="checkbox" id="keep-icc" checked>
+        <span>
+          <strong>Het kleurprofiel</strong>
+          <span class="check-note">
+            Het ICC-profiel zegt wat de getallen in het plaatje als kleur betekenen.
+            Over jou zegt het niets. Het weglaten kan de kleuren van een foto met een
+            breed gamma zichtbaar verschuiven, en daarom blijft het staan tenzij je
+            anders zegt.
+          </span>
+        </span>
+      </label>
+      <p class="keep-summary" id="keep-summary"></p>
+    </fieldset>
+
+    <div id="clean-results" class="results" hidden>
+      <div class="results-head">
+        <h3>Schoongemaakt</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Alles als zip downloaden</button>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!-- Stap 3 &mdash; lezen en bewerken -->
+  <section class="card" id="inspect-card">
+    <h2><span class="step">3</span> Kijk erin, en verander wat je wilt</h2>
+
+    <p id="inspect-empty" class="empty-note">
+      Kies hierboven een foto en alles wat erin zit verschijnt hier: wat hij zegt
+      over waar je was, wanneer, en waarmee. Er wordt niets ergens heen gestuurd
+      om dat uit te zoeken.
+    </p>
+
+    <div id="inspector" hidden>
+      <div class="inspect-head">
+        <div class="inspect-file">
+          <img id="inspect-thumb" class="inspect-thumb" alt="" hidden>
+          <div>
+            <p class="inspect-name" id="inspect-name"></p>
+            <p class="inspect-sub" id="inspect-sub"></p>
+          </div>
+        </div>
+        <div class="inspect-switch">
+          <label for="inspect-select" class="visually-hidden">Welke foto je bekijkt</label>
+          <select id="inspect-select"></select>
+        </div>
+      </div>
+
+      <!-- The findings: the part of this page that answers the actual question. -->
+      <section class="findings" aria-labelledby="findings-h">
+        <h3 id="findings-h">Wat dit bestand prijsgeeft</h3>
+        <ul id="findings-list" class="findings-list"></ul>
+      </section>
+
+      <!-- Whole blocks, each removable on its own. -->
+      <section class="blocks" aria-labelledby="blocks-h">
+        <h3 id="blocks-h">Blokken in dit bestand</h3>
+        <ul id="block-list" class="block-list"></ul>
+      </section>
+
+      <!-- Every tag, editable. -->
+      <section class="tags" aria-labelledby="tags-h">
+        <h3 id="tags-h">Elke tag</h3>
+        <p class="tags-note" id="tags-note"></p>
+        <div id="tag-groups"></div>
+
+        <details class="add-tag" id="add-tag">
+          <summary>Een tag toevoegen</summary>
+          <div class="add-tag-body">
+            <label for="add-tag-select">Tag</label>
+            <select id="add-tag-select"></select>
+            <label for="add-tag-value">Waarde</label>
+            <input type="text" id="add-tag-value" spellcheck="false">
+            <button type="button" id="add-tag-go" class="ghost">Toevoegen</button>
+          </div>
+        </details>
+      </section>
+
+      <div class="save-row">
+        <button type="button" id="save-edits" class="primary" disabled>Deze foto opslaan</button>
+        <button type="button" id="revert-edits" class="ghost" disabled>Mijn wijzigingen ongedaan maken</button>
+        <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
+      </div>
+      <p id="edit-error" class="error" role="alert" hidden></p>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/exif-editor.toml
+++ b/locales/nl/tools/exif-editor.toml
@@ -1,0 +1,246 @@
+#
+# EXIF-lezer & -wisser - Dutch.
+#
+# Overrides for tools/exif-editor/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "EXIF-lezer & -wisser"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "EXIF-lezer&nbsp;&amp; -wisser <span class=\"h1-kw\">&mdash; metagegevens uit een foto halen</span>"
+tagline = "Zie wat een foto over je zegt. Haal het er dan uit."
+
+title = "EXIF-lezer &amp; -wisser &mdash; gratis metagegevens uit foto's halen"
+description = "Bekijk de EXIF- en gps-gegevens die in een foto verstopt zitten, bewerk ze, of wis alles in één klik. In je browser: niets geüpload, en de foto wordt nooit opnieuw gecodeerd."
+og_title = "EXIF-lezer &amp; -wisser &mdash; bekijk het, bewerk het, of wis het"
+og_description = "Lees de metagegevens die in een foto verstopt zitten en haal ze er in één klik allemaal uit. Draait op je eigen apparaat; het plaatje zelf wordt nooit opnieuw gecodeerd."
+og_image_alt = "EXIF-lezer en -wisser - metagegevens in een foto lezen, bewerken of wissen"
+
+pledge = """
+    Het bestand wordt geopend, ontleed en herschreven door je eigen browser. Deze
+    tool heeft geen enkele netwerkfunctie &mdash; niets op te halen, niets te
+    versturen &mdash; en er staat aan de andere kant van deze pagina geen server
+    om een foto heen te sturen, ook al was er een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en maak een foto schoon. Geen enkel verzoek draagt een afbeelding, een
+      miniatuur, een bestandsnaam of een tag die we uit je bestand lazen. Of trek
+      de stekker uit het internet en maak er toch een schoon."""
+
+read_first = """
+, <code>src/tiff.js</code> voor de EXIF-parser, en
+      <code>src/jpeg.js</code> voor het bewijs dat het plaatje zelf alleen maar
+      gekopieerd wordt."""
+
+howto_heading = "EXIF-gegevens uit een foto verwijderen"
+
+card = """
+            Zie de locatie, de camera en de serienummers die in een foto verstopt
+            zitten, bewerk wat je wilt, of wis alles in één klik."""
+
+[words]
+plural = "foto's"
+choose = "een foto"
+analytics_extra = """, en ook geen van de tags
+  die deze tool uit je bestanden leest"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "Codeert het plaatje nooit opnieuw"
+
+[[privacy]]
+title = "Je foto's kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestanden
+      verzameld zouden kunnen worden, en niets in de code dat ze zou versturen
+      als dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Anders dan de andere tools in
+      deze doos heeft deze geen &ldquo;laden vanaf een webadres&rdquo;-functie en
+      helemaal geen optionele netwerkstap. Er staat nergens in <code>src/</code>
+      een <code>fetch</code>, een <code>XMLHttpRequest</code> of een
+      <code>sendBeacon</code>."""
+
+[[privacy]]
+title = "De metagegevens die we lezen, worden nooit doorgegeven."
+body = """
+ Je gps-positie
+      wordt op deze pagina getoond en gaat nergens anders heen. Er zit in deze
+      repository geen eigen analytics-gebeurtenis die een tag, een bestandsnaam,
+      een grootte of een aantal meedraagt."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google. Geen van beide krijgt iets over je foto's
+      mee. Elke regel die een bestand leest, ontleedt of herschrijft, wordt vanaf
+      deze herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de doneerknop laadt, en wat hij niet krijgt."
+body = """
+
+      De knop &ldquo;Buy me a coffee&rdquo; in de kop wordt getekend door een
+      script van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts.
+      Het is een link en verder niets: hij meldt geen bezoek, en hij krijgt niets
+      over jou of je bestanden mee. Er gebeurt niets tenzij je erop klikt, en
+      waar je dan naartoe klikt is de site van iemand anders."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en de tool is
+      onveranderd, want er zat nooit een netwerkstap in. Dat is het eenvoudigste
+      bewijs van allemaal."""
+
+[[howto]]
+title = "Kies je foto's."
+body = """
+ Sleep ze op het keuzevak of kies ze met
+      de hand. De browser leest ze rechtstreeks van je schijf; er wordt daarbij
+      niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Lees wat erin zit, als je dat wilt."
+body = """
+ De bevindingenlijst
+      noemt de dingen die het weten waard zijn &mdash; de gps-positie, de
+      tijdstempels, de serienummers &mdash; vóór de volledige tabel met elke
+      tag."""
+
+[[howto]]
+title = "Druk op &ldquo;Alle metagegevens verwijderen&rdquo;."
+body = """
+ Dat is voor de meeste
+      mensen de hele klus. Elke tag, de XMP- en IPTC-blokken, de opmerkingen en
+      de ingesloten miniatuur gaan er in één keer af, bij elke foto op de
+      lijst."""
+
+[[howto]]
+title = "Of bewerk in plaats van te wissen."
+body = """
+ Wijzig een datum,
+      corrigeer een auteursrechtregel, laat de locatie vallen en hou de
+      camera-instellingen &mdash; en sla die foto dan apart op."""
+
+[[faq]]
+q = "Wordt mijn foto ergens heen geüpload?"
+a = """
+        Nee. Het bestand wordt gelezen, ontleed en herschreven door je eigen
+        browser op je eigen hardware. Deze tool heeft geen enkele netwerkfunctie
+        &mdash; hij haalt nooit iets op en verstuurt nooit iets &mdash; en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen; geen ervan hoort bij deze site."""
+
+[[faq]]
+q = "Wat is EXIF, en wat zit er nog meer in een foto verstopt?"
+a = """
+        EXIF is een blok tags dat een camera naast het plaatje schrijft: het merk
+        en model, de belichtingsinstellingen, de datum en tijd op de seconde
+        nauwkeurig, vaak een gps-positie, en soms een serienummer. Foto's dragen
+        vaak nog meer mee &mdash; een XMP-pakket met XML uit een fotobewerker, een
+        IPTC-blok met bijschrift- en naamsvermeldingsvelden, een kleurprofiel, een
+        kleine tweede kopie van het beeld als miniatuur, en een makernotitie met
+        ongedocumenteerde fabrikantgegevens. Deze tool zet het allemaal op een
+        rij."""
+
+[[faq]]
+q = "Gaat er beeldkwaliteit verloren als de metagegevens eruit gaan?"
+a = """
+        Nee, en dat is de belangrijkste reden om zo'n tool te gebruiken in plaats
+        van de foto opnieuw op te slaan. Metagegevens zitten in de container om
+        het gecomprimeerde plaatje heen, niet erin. Ze verwijderen betekent items
+        uit een lijst schrappen en de lijst weer wegschrijven; de gecomprimeerde
+        beeldgegevens gaan byte voor byte mee, dus het resultaat decodeert naar
+        precies dezelfde pixels. Er wordt niets gedecodeerd en niets opnieuw
+        gecomprimeerd."""
+
+[[faq]]
+q = "Welke bestandsformaten kan het aan?"
+a = """
+        JPEG, PNG en WebP. HEIC en AVIF worden herkend maar niet herschreven: het
+        zijn doosformaten die uit geneste atomen zijn opgebouwd en die een andere
+        parser nodig hebben, dus zegt de tool dat in plaats van een kapot bestand
+        te maken. Een kale TIFF gaat ook niet, want in een TIFF worden de
+        metagegevens en de pixels door dezelfde offsets aangewezen."""
+
+[[faq]]
+q = "Staat mijn foto gedraaid nadat de metagegevens eruit zijn?"
+a = """
+        Dat kan, en daar is een instelling voor. Telefoons leggen een foto meestal
+        vast zoals de sensor hem zag en voegen een Orientation-tag toe die zegt
+        hoe hij gedraaid moet worden. Haal die tag eruit en sommige kijkers tonen
+        de foto op zijn kant. De optie &ldquo;hou de oriëntatietag&rdquo;, die
+        standaard aanstaat, schrijft een piepklein EXIF-blok terug met niets
+        anders dan die ene tag &mdash; en alleen wanneer de foto hem echt nodig
+        had. Zet hem uit als je liever hebt dat het bestand helemaal geen EXIF
+        draagt."""
+
+[[faq]]
+q = "Haalt het de gps-locatie eruit?"
+a = """
+        Ja. Alles verwijderen verwijdert de hele gps-directory, en je kunt de
+        locatie ook los weghalen en de rest houden. De positie wordt eerst in
+        decimale graden getoond, omdat &ldquo;51 graden, 30 minuten, 26
+        seconden&rdquo; niet duidelijk maakt dat een foto het gebouw noemt waarin
+        hij genomen is."""
+
+[[faq]]
+q = "Kan ik een tag wijzigen in plaats van hem te verwijderen?"
+a = """
+        Ja. Teksttags, datums, de ISO, de oriëntatie en de resolutie zijn allemaal
+        te bewerken, en een paar veelvoorkomende tags kunnen worden toegevoegd aan
+        een foto die er geen heeft. Eén kanttekening: het bestand schrijven bouwt
+        het EXIF-blok opnieuw op, en een makernotitie bevat offsets naar het
+        originele blok, dus een herbouwde makernotitie is daarna misschien niet
+        meer leesbaar voor de eigen software van de fabrikant. Verwijder hem, of
+        laat het bestand onbewerkt, als dat voor jou uitmaakt."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen en geen proefperiode.
+        De site draagt advertenties, en die betalen hem; de advertenties krijgen
+        niets over je foto's mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je foto's wegstuurde om ze te verwerken, zou
+        stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Lees de EXIF-, gps-, XMP- en IPTC-metagegevens in een foto, bewerk losse tags, of haal alles er in één klik uit. JPEG, PNG en WebP, verwerkt in de browser zonder het beeld opnieuw te coderen."
+features = [
+  "Toont elke EXIF-tag, inclusief gps-positie, serienummers van camera's en makernotities",
+  "Bewerkt of verwijdert losse tags en schrijft het bestand terug",
+  "Verwijdert EXIF, gps, XMP, IPTC, opmerkingen en de ingesloten miniatuur in één klik",
+  "JPEG, PNG en WebP",
+  "Herschrijft alleen de container, dus het beeld wordt nooit opnieuw gecomprimeerd",
+  "Draait offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep foto's hierheen"
+hint = "of klik om te bladeren &mdash; JPEG, PNG en WebP"

--- a/locales/nl/tools/heic-to-jpg.html
+++ b/locales/nl/tools/heic-to-jpg.html
@@ -1,0 +1,113 @@
+<main>
+  <!-- Stap 1 &mdash; de bestanden -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies je HEIC-foto's</h2>
+
+    <p class="card-lede">
+      Zo van de telefoon, uit een back-up, of gekopieerd van een geheugenkaart.
+      Het bestand wordt hier gelezen, op dit apparaat, en het plaatje wordt hier
+      ook gedecodeerd &mdash; er zit geen uploadstap in deze pagina en er staat
+      geen server achter.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alles van de lijst halen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; wat eruit komt -->
+  <section class="card" id="options-card">
+    <h2><span class="step">2</span> Zeg wat je terug wilt</h2>
+
+    <fieldset class="options">
+      <legend>Het formaat</legend>
+
+      <div class="option-row">
+        <label for="format-select">Schrijf de plaatjes als</label>
+        <select id="format-select">
+          <option value="image/jpeg" selected>JPEG &mdash; gaat overal open, ook in dingen die per ongeluk deze eeuw gemaakt zijn</option>
+          <option value="image/png">PNG &mdash; verliesloos, en een paar keer zo groot</option>
+          <option value="image/webp">WebP &mdash; kleiner dan JPEG bij dezelfde kwaliteit, en alleen moderne browsers</option>
+        </select>
+      </div>
+
+      <div class="option-row" id="quality-row">
+        <label for="quality">Kwaliteit</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="50" max="100" step="1" value="92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>De fotogegevens</legend>
+
+      <label class="check">
+        <input type="checkbox" id="keep-exif" checked>
+        <span>
+          <strong>Hou de datum, de camera en de instellingen</strong>
+          <span class="check-note">
+            Precies overgenomen zoals de telefoon ze schreef, zodat de omgezette
+            foto nog sorteert op de dag waarop hij gemaakt is in plaats van de dag
+            waarop hij omgezet is. Daar horen de gps-coördinaten bij wanneer de foto
+            ze heeft &mdash; de lijst hierboven zegt welke van jou dat zijn. Zet dit
+            uit en de JPEG komt eruit met niets erin dan het plaatje.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary">
+        Hoe dan ook wordt hier niets aan iemand doorgegeven: de keuze gaat over
+        wat er in het bestand komt dat je terugkrijgt, niet over wat deze pagina
+        ermee doet. Wil je de tags in detail doorlopen, of ze weghalen bij foto's
+        die al JPEG zijn, dan is de
+        <a href="../exif-gegevens-verwijderen/">EXIF-lezer &amp; -wisser</a> de
+        tool daarvoor.
+      </p>
+    </fieldset>
+  </section>
+
+  <!-- Stap 3 &mdash; de ene klik -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Omzetten</h2>
+
+    <div class="run-row">
+      <button type="button" id="convert-all" class="primary big" disabled>Omzetten</button>
+    </div>
+
+    <!--
+      The decoder's own status line. This page is the only one on the site that
+      carries a codec, so it is the only one with anything to report here, and
+      saying where the megabyte came from is the point: it is served from this
+      origin, it is cached with the rest of the page, and it is what makes the
+      offline promise hold on a browser that cannot open a HEIC at all.
+    -->
+    <p id="engine-status" class="engine-status" role="status" aria-live="polite"></p>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Omgezet</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Alles als zip downloaden</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/heic-to-jpg.toml
+++ b/locales/nl/tools/heic-to-jpg.toml
@@ -1,0 +1,302 @@
+#
+# HEIC naar JPG - Dutch.
+#
+# Overrides for tools/heic-to-jpg/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "HEIC naar JPG"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "HEIC&nbsp;naar&nbsp;JPG <span class=\"h1-kw\">&mdash; iPhone-foto's omzetten</span>"
+tagline = "De foto's die een iPhone maakt, in een formaat dat alles opent."
+
+title = "HEIC-naar-JPG-omzetter &mdash; gratis, zonder uploaden"
+description = "Zet HEIC-foto's van een iPhone om naar JPG in je browser. De decoder draait op je eigen apparaat: niets geüpload, geen account, werkt offline, en de datum en cameragegevens mogen mee."
+og_title = "HEIC-foto's naar JPG omzetten zonder ze te uploaden"
+og_description = "De omzetter die je foto's niet wil hebben. De HEIC-decoder wordt vanaf deze pagina geserveerd en draait op je eigen apparaat, dus de foto's verlaten het nooit."
+og_image_alt = "HEIC naar JPG - iPhone-foto's in een formaat dat alles opent"
+
+pledge = """
+    Het decoderen gebeurt in je eigen browser, op je eigen hardware. HEIC is het
+    ene beeldformaat dat een browser niet uit zichzelf opent, dus draagt deze
+    pagina de decoder mee &mdash; zo'n 1,4 MB, geserveerd vanaf deze site, na het
+    eerste bezoek in de cache. Dat is precies de reden dat elke andere
+    HEIC-omzetter je om een upload vraagt: die zetten de codec op een server en
+    dan moeten je foto's daarheen. Deze zet de codec hier neer. Er zit op deze
+    pagina helemaal geen netwerkfunctie, en er staat aan de andere kant geen
+    server om een foto heen te sturen."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en zet een foto om. Je ziet de eigen bestanden van deze pagina laden,
+      de decoder daaronder, en geen enkel verzoek dat een foto, een miniatuur, een
+      bestandsnaam of één byte van wat je koos meedraagt. Of laad de pagina één
+      keer, trek de stekker uit het internet, en zet er toch een hele map van
+      om."""
+
+read_first = """
+, <code>src/heif.js</code> voor hoe de decoder
+      geladen wordt en wat hij mag, <code>src/boxes.js</code> voor het ontleden
+      van de container die de metagegevens van de foto vindt, en
+      <code>src/exif.js</code> voor wat er met die metagegevens gebeurt op weg
+      naar een JPEG. De engine zelf is <code>vendor/libheif.js</code>,
+      ongewijzigd, met zijn licentie ernaast."""
+
+howto_heading = "HEIC-foto's naar JPG omzetten"
+
+card = """
+            De foto's die een iPhone maakt, in een formaat dat alles opent
+            &mdash; gedecodeerd op je eigen apparaat, niet op iemands server."""
+
+[words]
+plural = "foto's"
+choose = "een foto"
+analytics_extra = """, en ook geen van de
+  datums, cameramodellen of coördinaten die deze tool eruit leest"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen groottelimiet"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Je foto's kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestanden
+      verzameld zouden kunnen worden, en niets in de code dat ze zou versturen
+      als dat er wel was."""
+
+[[privacy]]
+title = "De decoder kwam hiervandaan, en hij gaat nergens heen."
+body = """
+ HEIC is HEVC
+      in een doosformaat, en geen enkele browser behalve Safari decodeert er een,
+      dus levert deze pagina <code>libheif</code> mee, gecompileerd naar
+      WebAssembly &mdash; zo'n 1,4 MB, vastgelegd in deze repository, geserveerd
+      vanaf deze herkomst, en door de service worker in de cache gezet als elk
+      ander bestand hier. Hij wordt niet van een CDN gehaald, want dat zou bij
+      elk bezoek een derde partij in het pad zetten en de tool offline laten
+      stoppen. Het binaire deel zit in het script in plaats van ernaast, juist
+      opdat er geen fetch nodig is om het te starten."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Er staat in geen enkel
+      bestand dat voor deze tool geschreven is een <code>fetch</code>, een
+      <code>XMLHttpRequest</code> of een <code>sendBeacon</code>. De meegeleverde
+      engine bevat, zoals elke Emscripten-build, de laadpaden die een
+      <code>.wasm</code> van een URL zouden halen; die worden niet genomen, omdat
+      het binaire deel al in huis is &mdash; en als dat wel gebeurde, noemt
+      <code>connect-src</code> de meeteindpunten van Google en verder niets, dus
+      zou de browser het weigeren. Het bewijs is de policy, niet de belofte."""
+
+[[privacy]]
+title = "De metagegevens worden hier gelezen en aan jou gemeld."
+body = """
+ De lijst op de
+      pagina zegt wat elke foto meedraagt &mdash; de datum, de camera, en of er
+      gps-coördinaten in zitten &mdash; want dat wil je misschien weten voordat
+      je de JPEG aan iemand geeft. Het wordt door <code>src/boxes.js</code> in
+      deze browser uit het bestand gelezen, op deze pagina getoond, en in je JPEG
+      geschreven of weggelaten, geheel zoals jij kiest. Er zit in deze repository
+      geen eigen analytics-gebeurtenis die een bestandsnaam, een datum, een
+      coördinaat of een aantal meedraagt."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google, de doneerknop van Buy Me a Coffee. Geen ervan
+      krijgt iets over je foto's mee. Elke regel die een bestand leest, decodeert
+      of schrijft, wordt vanaf deze herkomst geserveerd en staat in de
+      repository."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Laad de pagina één keer en verbreek de
+      verbinding, en de tool is onveranderd &mdash; de decoder zit mee in de
+      cache. Dat is het eenvoudigste bewijs van allemaal, en hier is het sterker
+      dan waar dan ook op deze site: een omzetter die je foto's wegstuurde om ze
+      te decoderen, zou dat onmogelijk voor elkaar krijgen."""
+
+[[howto]]
+title = "Kies je HEIC-foto's."
+body = """
+ Sleep ze op het keuzevak of kies ze
+      met de hand, zo uit een telefoonback-up of een map op je bureaublad. De
+      browser leest ze van je schijf; er wordt daarbij niets ergens heen
+      gestuurd. De lijst zegt wat elk bestand is en wat erin zit."""
+
+[[howto]]
+title = "Kijk wat de foto's meedragen."
+body = """
+ Elke regel noemt de datum
+      waarop hij gemaakt is, de camera, en &mdash; in het groen, want dat is het
+      stuk dat opvalt &mdash; of het bestand gps-coördinaten bevat. Dat wordt uit
+      de container gelezen zonder het plaatje te decoderen, dus het kost niets en
+      staat er meteen."""
+
+[[howto]]
+title = "Kies een formaat, en beslis over de details."
+body = """
+ JPEG, tenzij je een
+      reden hebt: dat is het formaat dat overal opengaat, en daar is het omzetten
+      om begonnen. De kwaliteitsschuif staat op 92, de stand waarop een foto
+      nauwelijks van het origineel te onderscheiden is. Het vinkje bepaalt of de
+      datum, camera en locatie meegaan."""
+
+[[howto]]
+title = "Druk op &ldquo;Omzetten&rdquo; en download."
+body = """
+ De decoder komt binnen bij
+      de eerste omzetting &mdash; zo'n 1,4 MB, één keer &mdash; en elke foto
+      daarna wordt op je eigen apparaat gedecodeerd en geschreven. Bij één
+      bestand krijg je een downloadknop; bij meerdere krijg je er een zip bij."""
+
+[[faq]]
+q = "Wordt mijn foto ergens heen geüpload?"
+a = """
+        Nee. Het bestand wordt gelezen, gedecodeerd en geschreven door je eigen
+        browser op je eigen hardware. Deze tool heeft geen enkele netwerkfunctie
+        &mdash; hij haalt nooit iets op en verstuurt nooit iets &mdash; en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen; geen ervan hoort bij deze site. Het enige wat wel laadt is
+        de decoder zelf, en die komt van deze site, één keer, voordat je foto er
+        ooit bij betrokken is."""
+
+[[faq]]
+q = "Waarom downloadt deze pagina de eerste keer 1,4 MB?"
+a = """
+        Omdat HEIC het ene beeldformaat is dat een browser niet opent. Het is een
+        HEVC-frame in een doosformaat, en alleen Safari, op Apple-hardware, heeft
+        er een decoder voor; Chrome, Firefox en Edge weigeren het bestand domweg.
+        Een HEIC-omzetter heeft dus ergens een decoder nodig, en er zijn twee
+        plekken waar die vandaan kan komen: een server, of de pagina. Elke andere
+        omzetter koos de server, en dat is precies waarom ze allemaal je foto's
+        geüpload willen hebben. Deze draagt in plaats daarvan <code>libheif</code>
+        mee, gecompileerd naar WebAssembly. Hij wordt vanaf deze site geserveerd,
+        na het eerste bezoek in de cache gezet, en dat is de volledige prijs van
+        je foto's die nergens heen gaan."""
+
+[[faq]]
+q = "Houdt de JPEG de datum, de camera en de locatie?"
+a = """
+        Als je dat wilt, en het is een vinkje op de pagina. Blijft het aan, dan
+        wordt het EXIF-blok uit de HEIC gekopieerd en precies zo in de JPEG
+        geschreven als de telefoon het schreef, zodat de omgezette foto nog
+        sorteert op de dag waarop hij gemaakt is in plaats van de dag waarop hij
+        omgezet is &mdash; en dat is de gebruikelijke klacht over HEIC-omzetters.
+        Eén tag verandert er, en maar één: de oriëntatie, die op
+        &ldquo;rechtop&rdquo; wordt gezet, omdat de draaiing al op de pixels is
+        toegepast en een kijker die hem nog eens toepaste elke staande foto op
+        zijn kant zou leggen. Zet het vinkje uit en de JPEG komt eruit met het
+        plaatje en verder niets."""
+
+[[faq]]
+q = "Haalt het gps-coördinaten eruit?"
+a = """
+        Het vertelt je dat ze er zijn, en doet daarna wat je vraagt. De regel bij
+        elke foto zegt of het bestand coördinaten meedraagt voordat je iets omzet,
+        en dat is meer dan de telefoon doet. Het vinkje &ldquo;hou de datum, de
+        camera en de instellingen&rdquo; uitzetten laat ze samen met al het andere
+        uit de JPEG; aan laten neemt ze mee. Wil je de tags in detail doorlopen,
+        of ze weghalen bij foto's die al JPEG zijn, dan is de
+        <a href="../exif-gegevens-verwijderen/">EXIF-lezer &amp; -wisser</a> de
+        tool daarvoor, en die doet het zonder het plaatje opnieuw te
+        comprimeren."""
+
+[[faq]]
+q = "Wordt het plaatje opnieuw gecomprimeerd?"
+a = """
+        Ja, en dat moet ook: HEIC en JPEG zijn verschillende codecs, dus er is geen
+        manier om van de ene naar de andere te gaan zonder het plaatje te
+        decoderen en opnieuw te coderen. Wat je wel in de hand hebt, is wat dat
+        kost. De kwaliteitsschuif staat standaard op 92, waarop een foto heel
+        moeilijk van het origineel te onderscheiden is, en PNG staat op het menu
+        voor het geval je helemaal geen verlies wilt en het niet erg vindt dat het
+        bestand vijf tot tien keer zo groot wordt."""
+
+[[faq]]
+q = "En als het bestand .jpg heet maar eigenlijk een HEIC is?"
+a = """
+        Dan werkt het nog steeds. Elk bestand dat hier naar binnen gaat, wordt aan
+        zijn eerste bytes herkend en niet aan zijn naam, want de naam is wat de
+        laatste app die het bestand aanraakte ervan gemaakt heeft &mdash; en een
+        HEIC die binnenkwam met de naam &ldquo;.jpg&rdquo; is een van de
+        gebruikelijkste redenen dat mensen zo'n tool gaan zoeken. Een bestand dat
+        werkelijk een JPEG of een PNG is, wordt geweigerd met een melding die dat
+        zegt, in plaats van omgezet te worden in een kopie van zichzelf."""
+
+[[faq]]
+q = "Kan het een Live Photo of een burst omzetten?"
+a = """
+        De stilstaande beelden erin, ja. Een HEIC kan meer dan één plaatje
+        bevatten, en elk plaatje dat erin zit wordt omgezet en naar het origineel
+        genoemd met een nummer erachter. De videohelft van een Live Photo is een
+        apart bestand dat de telefoon naast de HEIC bewaart, dus dat zit hier niet
+        in om om te zetten. Dieptekaarten en miniaturen zitten wel in de container
+        maar zijn geen plaatjes waar iemand om vroeg, en die worden met rust
+        gelaten."""
+
+[[faq]]
+q = "Waarom neemt het mijn AVIF niet aan?"
+a = """
+        Omdat er niets aan te doen valt. AVIF is dezelfde container als HEIC met
+        AV1 erin in plaats van HEVC, en elke huidige browser decodeert er een
+        vanzelf &mdash; een omzetter zou dus een megabyte engine meesturen om een
+        probleem op te lossen dat je niet hebt. Heb je een AVIF nodig als JPEG,
+        dan lezen de <a href="../afbeelding-comprimeren/">Afbeeldingscompressor</a>
+        en <a href="../afbeelding-formaat-wijzigen/">Afbeeldingsformaat
+        wijzigen</a> allebei AVIF en schrijven ze JPEG met de decoder die je
+        browser al heeft."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. Er is ook geen limiet op het aantal of de grootte van de
+        bestanden, want er is geen server die ervoor betaalt &mdash; het werk
+        gebeurt op je eigen apparaat. De site draagt advertenties, en die betalen
+        hem; de advertenties krijgen niets over je foto's mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja, decoder inbegrepen. Laad de pagina één keer, verbreek dan je
+        internetverbinding, en hij werkt precies zo door aan je foto's. Dat is ook
+        het sterkste bewijs dat er niets geüpload wordt: een omzetter die je
+        HEIC's wegstuurde om ze te decoderen, zou stoppen op het moment dat je de
+        stekker eruit trok, en deze niet."""
+
+[schema]
+description = "Zet HEIC- en HEIF-foto's van een iPhone om naar JPEG, PNG of WebP. De HEIC-decoder is WebAssembly die vanaf de pagina zelf geserveerd wordt, dus de foto's worden op je eigen apparaat gedecodeerd en nooit geüpload. De datum, camera en locatie kunnen mee de JPEG in of weggelaten worden."
+features = [
+  "Zet HEIC en HEIF om naar JPEG, PNG of WebP",
+  "Decodeert in de browser, in elke browser - niet alleen in Safari",
+  "Er wordt niets geüpload, en de tool werkt met de stekker eruit",
+  "Neemt de datum, camera en gps mee de JPEG in, of laat ze weg",
+  "Zegt welke foto's gps-coördinaten bevatten voordat er iets omgezet wordt",
+  "Corrigeert de oriëntatietag, zodat staande foto's er niet op hun kant uit komen",
+  "Herkent bestanden aan hun inhoud, dus een HEIC die .jpg heet werkt gewoon",
+  "Zet elk plaatje in een burst of Live Photo om, niet alleen het eerste",
+  "Verwerkt hele stapels, met alle resultaten in één zip",
+]
+
+[picker]
+title = "Sleep HEIC-foto's hierheen"
+hint = "of klik om te bladeren &mdash; .heic en .heif, hoe ze ook toevallig heten"

--- a/locales/nl/tools/image-to-data-uri.html
+++ b/locales/nl/tools/image-to-data-uri.html
@@ -1,0 +1,141 @@
+<main>
+  <!-- Stap 1 &mdash; de bestanden -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies afbeeldingen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alles van de lijst halen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; de regel die daadwerkelijk geplakt wordt -->
+  <section class="card" id="shape-card">
+    <h2><span class="step">2</span> Zeg waar het heen gaat</h2>
+
+    <p class="card-lede">
+      Een data-URI op zichzelf is zelden wat iemand wil hebben. Wat men wil is de
+      regel die in de stylesheet komt &mdash; kies dus de regel, en het plaatje
+      komt er al netjes tussen aanhalingstekens in aan, en dat is het stuk dat
+      makkelijk fout gaat en dat alleen bij SVG's misgaat.
+    </p>
+
+    <div class="shapes" id="shapes" role="radiogroup" aria-label="Wat je wilt plakken">
+      <label class="shape">
+        <input type="radio" name="shape" value="uri" checked>
+        <span class="shape-body">
+          <strong>De data-URI op zichzelf</strong>
+          <span class="shape-note">
+            Alles na de komma is het bestand. Plak hem overal waar een URL komt.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-rule">
+        <span class="shape-body">
+          <strong>Een CSS-regel</strong>
+          <span class="shape-note">
+            Een hele regel, met een class die naar het bestand genoemd is. Zet de
+            selector op wat je werkelijk aan het stylen bent.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-var">
+        <span class="shape-body">
+          <strong>Een CSS custom property</strong>
+          <span class="shape-note">
+            Eén keer boven aan de stylesheet gedeclareerd en zo vaak als je wilt
+            gebruikt als <code>var(--naam)</code>. Dit is de keuze wanneer het
+            plaatje in meer dan één regel voorkomt.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="html">
+        <span class="shape-body">
+          <strong>Een HTML-<code>&lt;img&gt;</code>-tag</strong>
+          <span class="shape-note">
+            Met de pixelmaten ingevuld, zodat de pagina niet verspringt terwijl de
+            rest laadt.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="markdown">
+        <span class="shape-body">
+          <strong>Markdown</strong>
+          <span class="shape-note">
+            Voor een README of een issue: een plaatje dat met de tekst meereist in
+            plaats van ergens gehost te moeten worden.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary">
+      De <code>alt</code>-tekst blijft met opzet leeg. Alleen jij weet of het
+      plaatje betekenis draagt of versiering is, en een beschrijving die uit een
+      bestandsnaam geraden is, is voor iemand met een schermlezer erger dan
+      helemaal geen beschrijving.
+    </p>
+
+    <fieldset class="options">
+      <legend>SVG</legend>
+
+      <label class="check">
+        <input type="checkbox" id="svg-base64">
+        <span>
+          <strong>Maak ook van de SVG's base64</strong>
+          <span class="check-note">
+            Standaard uit, want een SVG is tekst en base64 is voor bytes.
+            Procentcodering laat de opmaak leesbaar in de stylesheet staan en is
+            meestal een vijfde korter. Zet dit aan voor de zeldzame toolchain die
+            op <code>;base64</code> staat.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Stap 3 &mdash; het resultaat. Hier staat met opzet geen knop: coderen is
+       ogenblikkelijk, dus er is niets waar een "omzetten"-druk op zou wachten. -->
+  <section class="card" id="output-card">
+    <h2><span class="step">3</span> Kopieer hem</h2>
+
+    <p id="empty-note" class="card-lede">
+      Nog niets gekozen. Sleep hierboven een plaatje naar binnen en de regel om
+      te plakken verschijnt hier.
+    </p>
+
+    <div id="results" hidden>
+      <div class="results-head">
+        <p id="results-summary" class="results-summary"></p>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Alles kopiëren</button>
+          <button type="button" id="download-all" class="ghost">Als één bestand downloaden</button>
+        </div>
+      </div>
+
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/image-to-data-uri.toml
+++ b/locales/nl/tools/image-to-data-uri.toml
@@ -1,0 +1,317 @@
+#
+# Afbeelding naar data-URI - Dutch.
+#
+# Overrides for tools/image-to-data-uri/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Afbeelding naar data-URI"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Afbeelding&nbsp;naar&nbsp;data-URI <span class=\"h1-kw\">&mdash; een plaatje base64-coderen voor CSS of HTML</span>"
+tagline = "Het hele plaatje als één regel tekst. Plak hem zo in je CSS of HTML."
+
+title = "Afbeelding naar data-URI &mdash; base64 voor CSS, gratis, zonder uploaden"
+description = "Maak van een PNG, JPEG, SVG of WebP een data-URI die je in CSS of HTML kunt plakken. SVG's worden procentgecodeerd in plaats van base64, dus ze blijven leesbaar en korter. Draait in je browser; er wordt niets geüpload."
+og_title = "Van een afbeelding een regel maken die je in CSS plakt"
+og_description = "Base64 voor plaatjes, procentcodering voor SVG, en de kant-en-klare regel, custom property of img-tag eromheen. Draait op je eigen apparaat; er wordt niets geüpload."
+og_image_alt = "Afbeelding naar data-URI - het plaatje in de stylesheet plakken"
+
+pledge = """
+    Het coderen gebeurt in je eigen browser, op je eigen hardware. Het is rekenen
+    op bytes die de pagina al heeft: geen encoder, geen server, en geen
+    netwerkstap om weg te laten. Deze tool heeft geen enkele netwerkfunctie
+    &mdash; niets op te halen, niets te versturen &mdash; en er staat aan de
+    andere kant van deze pagina geen server om een plaatje heen te sturen, ook al
+    was er een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en sleep er een plaatje in. Geen enkel verzoek draagt een afbeelding,
+      een miniatuur, een bestandsnaam of één byte van wat je koos. Of trek de
+      stekker uit het internet en codeer er toch een."""
+
+read_first = """
+, <code>src/encode.js</code> voor de twee
+      coderingen en de redenering achter elk, <code>src/sniff.js</code> voor hoe
+      het mediatype uit het bestand gelezen wordt en niet uit zijn naam, en
+      <code>src/metadata.js</code> voor de controle die zegt hoeveel van wat je
+      op het punt staat te plakken niet het plaatje is."""
+
+howto_heading = "Van een afbeelding een data-URI maken"
+
+card = """
+            Base64 voor plaatjes, procentcodering voor SVG, en de CSS-regel of
+            <code>&lt;img&gt;</code>-tag er al omheen gebouwd."""
+
+[words]
+plural = "afbeeldingen"
+choose = "een afbeelding"
+analytics_extra = """, en ook geen van de
+  bestandsnamen, groottes of gecodeerde tekst die deze tool oplevert"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen hercodering"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Je afbeeldingen kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestanden
+      verzameld zouden kunnen worden, en niets in de code dat ze zou versturen
+      als dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Er staat nergens in
+      <code>src/</code> een <code>fetch</code>, een <code>XMLHttpRequest</code>
+      of een <code>sendBeacon</code>. Het coderen is <code>btoa</code> en
+      <code>encodeURIComponent</code> &mdash; twee functies die de browser al
+      sinds het begin heeft, en die allebei bytes aannemen en tekst teruggeven
+      zonder ergens heen te gaan."""
+
+[[privacy]]
+title = "De voorvertoning is het bewijs."
+body = """
+ Het plaatje naast elk
+      resultaat wordt getekend uit de data-URI die deze pagina zojuist bouwde,
+      niet uit je bestand. Het verschijnt omdat de URI klopt, op jouw apparaat,
+      zonder server erbij &mdash; en verschijnt het niet, dan zegt de pagina dat
+      in plaats van je iets kapots aan te reiken."""
+
+[[privacy]]
+title = "De metagegevenswaarschuwing staat aan jouw kant."
+body = """
+ Een data-URI kopieert het
+      bestand exact, dus reist de gps-positie van een foto er mee je stylesheet
+      in. Deze pagina leest hoeveel daarvan er is en zegt het je, want het
+      alternatief is dat je erachter komt nadat het gecommit is."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google, de doneerknop van Buy Me a Coffee. Geen ervan
+      krijgt iets over je plaatjes mee. Elke regel die een bestand leest of
+      codeert, wordt vanaf deze herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en de tool is
+      onveranderd, want er zat nooit een netwerkstap in. Dat is het eenvoudigste
+      bewijs van allemaal."""
+
+[[howto]]
+title = "Kies je afbeeldingen."
+body = """
+ Sleep ze op het keuzevak of kies ze
+      met de hand. De browser leest ze rechtstreeks van je schijf; er wordt
+      daarbij niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Zeg waar het resultaat heen gaat."
+body = """
+ De URI op zichzelf, een
+      CSS-regel, een custom property, een <code>&lt;img&gt;</code>-tag of
+      Markdown. Ze zetten de URI allemaal tussen aanhalingstekens, en dat is het
+      detail dat bepaalt of een ingesloten SVG werkt of stilletjes niet."""
+
+[[howto]]
+title = "Lees wat het gekost heeft."
+body = """
+ Elk resultaat zegt hoeveel tekens
+      het geworden is, hoeveel groter dat is dan het bestand, en of iets van dit
+      formaat inline zetten een goed idee is. Base64 doet er een derde bij; of
+      die derde een uitgespaard verzoek waard is, hangt volledig van de grootte
+      af, dus zegt de pagina aan welke kant van de streep je zit."""
+
+[[howto]]
+title = "Lees de waarschuwingen."
+body = """
+ Draagt het plaatje EXIF, een
+      kleurprofiel of XMP mee, dan wordt dat genoemd met erbij hoeveel bytes van
+      je resultaat dat is. Klopt de extensie niet met het werkelijke formaat, dan
+      gebruikt de pagina het formaat en zegt het je. Kan je browser het resultaat
+      niet tekenen, dan zegt hij dat ook."""
+
+[[howto]]
+title = "Kopieer, of download."
+body = """
+ Eén knop per resultaat, en één voor
+      alles tegelijk &mdash; de custom properties komen eruit verpakt in een
+      <code>:root</code>-blok, klaar om boven aan een stylesheet te plakken."""
+
+[[faq]]
+q = "Wordt mijn afbeelding ergens heen geüpload?"
+a = """
+        Nee. Het bestand wordt gelezen en gecodeerd door je eigen browser op je
+        eigen hardware, met twee functies die de browser al heeft. Deze tool heeft
+        geen enkele netwerkfunctie &mdash; hij haalt nooit iets op en verstuurt
+        nooit iets &mdash; en de <code>Content-Security-Policy</code> van de
+        pagina noemt elk adres dat hij mag benaderen; geen ervan hoort bij deze
+        site."""
+
+[[faq]]
+q = "Wat is een data-URI?"
+a = """
+        Een manier om een heel bestand op te schrijven waar normaal een webadres
+        staat. In plaats van <code>url("logo.png")</code>, wat de browser zegt dat
+        hij iets moet gaan halen, schrijf je
+        <code>url("data:image/png;base64,iVBORw0...")</code>, waar het plaatje
+        zelf in zit. De browser decodeert het ter plekke. Het praktische effect is
+        één verzoek minder: het plaatje komt mee met de stylesheet of de pagina in
+        plaats van erna."""
+
+[[faq]]
+q = "Waarom is mijn SVG geen base64?"
+a = """
+        Omdat base64 er de verkeerde codering voor is. Een SVG is tekst, en een URL
+        kan tekst al meedragen &mdash; er hoeft maar een handvol tekens ontsnapt te
+        worden. Die procentcoderen en de rest met rust laten levert een URI op die
+        meestal een vijfde korter is dan de base64 van hetzelfde bestand, en die je
+        in je stylesheet nog gewoon kunt lezen: de elementnamen, de kleuren en de
+        <code>viewBox</code> staan er allemaal nog om te bewerken. Er is een vinkje
+        om base64 af te dwingen voor de zeldzame toolchain die erop staat."""
+
+[[faq]]
+q = "Hoeveel groter maakt base64 mijn afbeelding?"
+a = """
+        Ongeveer een derde. Drie bytes bestand worden vier tekens base64, wat 33%
+        is nog vóór de <code>data:image/png;base64,</code> ervoor. Dat is de
+        ondergrens, en die is onvermijdelijk: het is wat het kost om willekeurige
+        bytes op te schrijven met alleen de tekens die een URL toestaat. Het is ook
+        waarom de pagina het aantal tekens naast de bestandsgrootte zet, in plaats
+        van je het te laten ontdekken wanneer de stylesheet live staat."""
+
+[[faq]]
+q = "Wanneer is een afbeelding inline zetten eigenlijk een goed idee?"
+a = """
+        Wanneer hij klein is en meteen nodig. Een icoontje van 2 kB in een
+        stylesheet die elke pagina laadt is een duidelijke winst: één heen-en-weer
+        minder, en het plaatje is er op het moment dat de CSS er is. Voorbij zo'n
+        10 kB kantelt de ruil. Een inline plaatje is geen apart bestand meer, dus
+        het kan niet los in de cache, het kan niet parallel met iets anders
+        opgehaald worden, en het wordt bij elke wijziging van het bestand eromheen
+        volledig opnieuw gedownload &mdash; een foto van 200 kB in een stylesheet
+        is 200 kB bij het kritieke pad van elke pagina op de site. De pagina zegt
+        aan welke kant van die streep elk resultaat valt."""
+
+[[faq]]
+q = "Maakt gzip de base64-overhead weer ongedaan?"
+a = """
+        Minder dan mensen verwachten. Base64 van een al gecomprimeerd bestand
+        &mdash; en een PNG, een JPEG en een WebP zijn dat alle drie &mdash;
+        comprimeert slecht, want er is bijna geen herhaling meer over die de
+        compressor kan vinden; je krijgt meestal zoiets als een tiende terug van de
+        derde die base64 erbij deed, niet het geheel. Een procentgecodeerde SVG is
+        het omgekeerde geval: dat is nog steeds tekst, dus die comprimeert ongeveer
+        net zo goed als daarvoor, wat nog een reden is om er geen base64 van te
+        maken."""
+
+[[faq]]
+q = "Verandert dit mijn afbeelding op enige manier?"
+a = """
+        Nee, en dat is een bewust verschil met de meeste tools hier. Er wordt niets
+        naar pixels gedecodeerd en opnieuw gecodeerd: de bytes die van je schijf
+        kwamen zijn de bytes die de URI in gaan. Een JPEG blijft precies de JPEG
+        die hij was, op dezelfde kwaliteit, met dezelfde afmetingen. Daarom mag het
+        resultaat hetzelfde bestand genoemd worden in plaats van een kopie ervan."""
+
+[[faq]]
+q = "Dus mijn EXIF- en gps-gegevens gaan ook de stylesheet in?"
+a = """
+        Ja, en dat is het stuk waar je over na wilt denken voordat je plakt. Omdat
+        er niets opnieuw gecodeerd wordt, reist alles wat de camera schreef met het
+        plaatje mee: de locatie, de tijdstempel, het serienummer van de camera. Bij
+        een telefoonfoto kan dat 30 kB van het bestand zijn, wat 40 kB base64 wordt
+        op het kritieke pad van je pagina, en een woonadres in iets dat naar een
+        repository gecommit gaat worden. De pagina leest hoeveel metagegevens er in
+        een JPEG, PNG of WebP zitten en zegt het. Om ze er eerst uit te halen:
+        gebruik de <a href="../exif-gegevens-verwijderen/">EXIF-lezer &amp;
+        -wisser</a>."""
+
+[[faq]]
+q = "Waarom gebruikte het een ander type dan de extensie van mijn bestand?"
+a = """
+        Omdat de extensie fout kan zijn en de bytes niet. Een bestand dat
+        <code>logo.png</code> heet maar in werkelijkheid als JPEG geëxporteerd is,
+        komt vaak genoeg voor dat elke beeldtool ermee om moet kunnen, en een
+        data-URI die het verkeerde type opgeeft, verschijnt domweg niet &mdash; er
+        is geen terugval en geen foutmelding die het lezen waard is. Dus wordt het
+        type uit de eerste paar bytes van het bestand gelezen, die in elk formaat
+        hier ondubbelzinnig zeggen wat het is, en zegt de pagina het je wanneer de
+        twee het oneens zijn."""
+
+[[faq]]
+q = "De voorvertoning is leeg. Wat ging er mis?"
+a = """
+        Waarschijnlijk niets aan de URI. HEIC en TIFF maken allebei volkomen geldige
+        data-URI's die geen enkele browser behalve Safari zal tekenen, dus het
+        plaatje ontbreekt overal waar je het plakt &mdash; zet het eerst om naar
+        PNG, JPEG of WebP met de
+        <a href="../afbeelding-comprimeren/">Afbeeldingscompressor</a> of
+        <a href="../afbeelding-formaat-wijzigen/">Afbeeldingsformaat wijzigen</a>.
+        Is het formaat een gewoon formaat, dan is het bestand zelf waarschijnlijk
+        beschadigd: de voorvertoning wordt getekend uit de URI die deze pagina
+        bouwde, dus een lege betekent dat het plaatje niet decodeerde."""
+
+[[faq]]
+q = "Zit er een groottelimiet op een data-URI?"
+a = """
+        Geen die je in CSS of in een <code>&lt;img&gt;</code>-tag tegenkomt; moderne
+        browsers leggen daar geen praktisch plafond op. Wat browsers wel beperken is
+        een data-URI in de adresbalk tikken, wat de meeste inmiddels weigeren voor
+        alles wat niet triviaal is, om veiligheidsredenen die niets met dit gebruik
+        te maken hebben. De echte grens is die hierboven: lang voordat er technisch
+        iets breekt, is de pagina waar hij in zit trager geworden dan hij met een
+        gewoon afbeeldingsbestand geweest zou zijn."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. Er is ook geen limiet op het aantal of de grootte van de
+        bestanden, want er is geen server die ervoor betaalt &mdash; het werk
+        gebeurt op je eigen apparaat. De site draagt advertenties, en die betalen
+        hem; de advertenties krijgen niets over je afbeeldingen mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je afbeeldingen wegstuurde om ze te coderen,
+        zou stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Zet een PNG, JPEG, SVG, WebP, GIF of ICO om in een data-URI die klaar is om in CSS of HTML te plakken. Base64 voor rasterformaten en procentcodering voor SVG, verpakt in een CSS-regel, een custom property, een img-tag of Markdown, met de groottekosten en eventuele ingesloten metagegevens erbij gemeld. Draait volledig in de browser, zonder uploaden."
+features = [
+  "Base64-data-URI's voor PNG, JPEG, WebP, GIF, ICO, AVIF en meer",
+  "Procentgecodeerde SVG-data-URI's, die korter zijn dan base64 en leesbaar blijven",
+  "Kant-en-klare CSS-regel, CSS custom property, HTML-img-tag of Markdown, altijd netjes tussen aanhalingstekens",
+  "Het mediatype gelezen uit de eigen bytes van het bestand, niet uit de extensie",
+  "Zegt wat het coderen aan tekens kostte, en of inline zetten op die grootte de moeite waard is",
+  "Waarschuwt wanneer EXIF, XMP of een kleurprofiel je stylesheet in gekopieerd gaat worden",
+  "Kopieert het bestand byte voor byte: geen hercodering en geen kwaliteitsverlies",
+  "Verwerkt hele stapels, met alles gekopieerd of gedownload als één bestand",
+  "Draait offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep afbeeldingen hierheen"
+hint = "of klik om te bladeren &mdash; PNG, JPEG, SVG, WebP, GIF, ICO en meer"

--- a/locales/nl/tools/image-to-ico.html
+++ b/locales/nl/tools/image-to-ico.html
@@ -1,0 +1,186 @@
+<main>
+  <!-- Stap 1 &mdash; het plaatje -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies een plaatje</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alles van de lijst halen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="shape-note" class="field-summary" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; welke standaard -->
+  <section class="card" id="preset-card">
+    <h2><span class="step">2</span> Zeg waar het icoon voor is</h2>
+
+    <p class="card-lede">
+      Een icoonbestand is niet één plaatje maar meerdere: hetzelfde logo opnieuw
+      getekend op elk formaat waar het ding dat het leest om vraagt. Welke
+      formaten dat zijn, is geen kwestie van smaak &mdash; een browser wil er
+      drie, een programma op een hi-dpi-laptop wil er tien, een Mac wil zijn
+      eigen tien, en iets dat vóór Windows Vista geschreven is, wil ze op een
+      heel andere manier opgeslagen hebben.
+    </p>
+
+    <!--
+      Which files to write. Windows and macOS read different containers and
+      neither will look at the other's, so this is a set of checkboxes rather
+      than a menu: wanting both is the normal case for anything shipped on both.
+    -->
+    <fieldset class="options outputs">
+      <legend>Wat er gemaakt wordt</legend>
+
+      <label class="check">
+        <input type="checkbox" id="want-ico" checked>
+        <span>
+          <strong>Windows-icoon &mdash; <code>.ico</code></strong>
+          <span class="check-note">
+            Wordt door elke browser als favicon gelezen, en door Windows voor een
+            programma, een snelkoppeling en een map. De formaten kies je hieronder
+            zelf.
+          </span>
+        </span>
+      </label>
+
+      <label class="check">
+        <input type="checkbox" id="want-icns">
+        <span>
+          <strong>macOS-icoon &mdash; <code>.icns</code></strong>
+          <span class="check-note">
+            Wat een Mac-applicatiebundel meedraagt. Apple noemt precies tien
+            plekken, van 16 pixels tot 1024, dus valt er niets te kiezen: alle tien
+            gaan erin, getekend uit zeven renders omdat een Retina-plek en het
+            formaat erboven hetzelfde plaatje zijn.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="pack-row">
+        <input type="checkbox" id="want-pack">
+        <span>
+          <strong>De rest van de icoonset van een website</strong>
+          <span class="check-note">
+            Een .ico dekt het browsertabblad en Windows. Het dekt niet een
+            iPhone-beginscherm, een Android-installatievraag of een tegel die aan
+            het startmenu is vastgezet &mdash; die lezen een PNG van 180px, een
+            webapp-manifest en een XML-bestand, en geen daarvan kijkt in een .ico.
+            Vink dit aan en je krijgt ze er allemaal bij, plus het manifest en het
+            blok HTML om in je pagina te plakken.
+          </span>
+        </span>
+      </label>
+
+      <p id="output-summary" class="field-summary"></p>
+    </fieldset>
+
+    <div id="ico-settings">
+      <div class="presets" id="preset-list" role="radiogroup" aria-label="Waar het icoon voor is"></div>
+
+      <p id="preset-note" class="field-summary"></p>
+
+      <fieldset class="options" id="size-set">
+        <legend>De formaten die in de .ico gaan</legend>
+        <div class="size-grid" id="size-grid"></div>
+        <p id="size-summary" class="field-summary"></p>
+      </fieldset>
+    </div>
+
+    <fieldset class="options">
+      <legend>Hoe het getekend wordt</legend>
+
+      <div class="option-row">
+        <label for="fit-select">Als het plaatje niet vierkant is</label>
+        <select id="fit-select">
+          <option value="pad" selected>Vul het op tot een vierkant &mdash; het hele plaatje blijft</option>
+          <option value="crop">Snijd bij tot het vierkant in het midden</option>
+          <option value="stretch">Rek het uit tot een vierkant</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="background-mode">Achtergrond</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparant</option>
+          <option value="colour">Een kleur</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Achtergrondkleur" hidden>
+      </div>
+
+      <div class="option-row" id="storage-row">
+        <label for="storage-select">Hoe elk formaat in de .ico opgeslagen wordt</label>
+        <select id="storage-select">
+          <option value="auto" selected>Automatisch &mdash; breed leesbaar waar dat goedkoop is, PNG waar dat niet zo is</option>
+          <option value="png">PNG voor elk formaat &mdash; kleinste bestand, vereist Vista of nieuwer</option>
+          <option value="bmp">Ongecomprimeerd voor elk formaat &mdash; gaat overal open, een paar keer zo groot</option>
+        </select>
+      </div>
+
+      <p id="storage-note" class="field-summary"></p>
+    </fieldset>
+
+  </section>
+
+  <!-- Stap 3 &mdash; klein bekijken, dan meenemen -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Bekijk het op het formaat waarop het gezien wordt</h2>
+
+    <p class="card-lede">
+      Dit is het stuk dat het bekijken waard is voordat je iets downloadt. Een
+      logo dat op 512 pixels perfect leest, is zestien pixels breed in een
+      browsertabblad, en de dunne delen ervan &mdash; de lijnen in een woordmerk,
+      een haarlijnrand, een verloop &mdash; overleven dat niet. Elk vierkantje
+      hieronder wordt op zijn echte formaat uit het bestand dat je koos getekend.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-strip" id="preview-strip"></div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make-icon" class="primary big" disabled>Maak het icoon</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Klaar</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Alles als zip downloaden</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+
+      <!--
+        The block to paste into a page's <head>, shown rather than only zipped:
+        most people making a favicon are about to paste this into a template,
+        and a copy button is a shorter route than a download and a text editor.
+      -->
+      <div id="snippet" class="snippet" hidden>
+        <div class="snippet-head">
+          <h4>Plak dit in je <code>&lt;head&gt;</code></h4>
+          <button type="button" id="copy-snippet" class="ghost">Kopiëren</button>
+        </div>
+        <pre id="snippet-text"></pre>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/image-to-ico.toml
+++ b/locales/nl/tools/image-to-ico.toml
@@ -1,0 +1,351 @@
+#
+# Afbeelding naar ICO - Dutch.
+#
+# Overrides for tools/image-to-ico/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Afbeelding naar ICO"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Afbeelding&nbsp;naar&nbsp;ICO <span class=\"h1-kw\">&mdash; favicon-, Windows- en macOS-icoonmaker</span>"
+tagline = "Eén plaatje erin. Elk formaat dat een browser, Windows of een Mac vraagt eruit."
+
+title = "Afbeelding naar ICO &mdash; favicon, app-icoon of icns maken, zonder uploaden"
+description = "Zet een PNG, JPEG of SVG om in een echte .ico met meerdere formaten, of in een macOS-.icns, in je browser. Favicon, Windows-app-icoon, Mac-app-icoon, plus de Apple- en Android-bestanden die een site nodig heeft. Er wordt niets geüpload."
+og_title = "Een .ico of .icns maken met elk formaat erin, zonder iets te uploaden"
+og_description = "Een favicon.ico voor een website, een app.ico voor een Windows-programma, een .icns voor een Mac - met een voorvertoning op 16 pixels vóór je downloadt. Het draait allemaal op je eigen apparaat."
+og_image_alt = "Afbeelding naar ICO - favicon-, Windows- en macOS-icoonmaker, zonder upload"
+
+pledge = """
+    Het schalen en de icoonbestanden zelf worden allebei in je eigen browser
+    gemaakt. Het plaatje wordt getekend door het canvas dat je browser toch al
+    meelevert, en elke container &mdash; de Windows-<code>.ico</code>, de
+    macOS-<code>.icns</code> &mdash; wordt uit die pixels opgebouwd door een paar
+    honderd regels in <code>src/ico.js</code> en <code>src/icns.js</code> die je
+    kunt lezen. Deze tool heeft geen enkele netwerkfunctie &mdash; niets op te
+    halen, niets te versturen &mdash; en er staat aan de andere kant van deze
+    pagina geen server om een logo heen te sturen, ook al was er een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en maak een icoon. Geen enkel verzoek draagt een afbeelding, een
+      miniatuur, een bestandsnaam of één byte van wat je koos. Of trek de stekker
+      uit het internet en maak er toch een."""
+
+read_first = """
+, <code>src/ico.js</code> en
+      <code>src/icns.js</code> voor de twee icoonformaten &mdash; de directory,
+      de items en het masker in het ene, de tien benoemde plekken van Apple in
+      het andere &mdash; en <code>src/sizes.js</code> voor waar elk formaat op de
+      pagina vandaan komt."""
+
+howto_heading = "Een .ico-bestand maken zonder iets te uploaden"
+
+card = """
+            Een favicon, een Windows-app-icoon of een macOS-.icns &mdash; elk
+            formaat in één bestand, met een voorvertoning op 16 pixels vóór je
+            downloadt."""
+
+[words]
+plural = "afbeeldingen"
+choose = "een plaatje"
+analytics_extra = """, en ook geen van de
+  formaten, bestandstypen of bestandsnamen die deze tool uitrekent"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Je logo kan nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestanden
+      verzameld zouden kunnen worden, en niets in de code dat ze zou versturen
+      als dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Er staat nergens in
+      <code>src/</code> een <code>fetch</code>, een <code>XMLHttpRequest</code>
+      of een <code>sendBeacon</code>. Het schalen is een <code>drawImage</code>
+      op een canvas; elk icoon is een kop die door <code>src/ico.js</code> of
+      <code>src/icns.js</code> vóór die pixels geschreven wordt, in deze
+      pagina."""
+
+[[privacy]]
+title = "Het bestand wordt beschreven vanuit zijn eigen bytes."
+body = """
+ De lijst formaten die naast
+      een klaar icoon staat, is niet de lijst formaten waar je om vroeg. Hij wordt
+      teruggelezen uit het bestand dat zojuist geschreven is, door
+      <code>readIcoDirectory</code> of <code>readIcnsElements</code>, dus als een
+      schrijver het ooit met de instellingen oneens was, zou de pagina dat zeggen
+      in plaats van dat jij erachter kwam toen Windows niets tekende en macOS een
+      leeg vel papier."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google, de doneerknop van Buy Me a Coffee. Geen ervan
+      krijgt iets over je plaatje mee. Elke regel die een bestand leest, schaalt
+      of schrijft, wordt vanaf deze herkomst geserveerd en staat in de
+      repository."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en de tool is
+      onveranderd, want er zat nooit een netwerkstap in. Dat is het eenvoudigste
+      bewijs van allemaal."""
+
+[[howto]]
+title = "Kies het plaatje."
+body = """
+ Sleep een PNG, JPEG, WebP of SVG op het
+      keuzevak, of kies er meerdere en zet ze in één keer om. Vierkant is het
+      makkelijkst, en alles vanaf 256 pixels heeft genoeg detail voor elk
+      formaat. De browser leest het rechtstreeks van je schijf; er wordt daarbij
+      niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Kies de bestanden die je nodig hebt."
+body = """
+ Windows en een browser lezen
+      <code>.ico</code>; een Mac leest <code>.icns</code> en kijkt niet naar het
+      andere. Vink er een aan, of allebei als het ding dat je maakt op allebei
+      uitkomt. Een website wil ook de extra Apple-, Android- en tegelplaatjes, en
+      dat is het derde vakje."""
+
+[[howto]]
+title = "Zeg waar het icoon voor is."
+body = """
+ Een website-favicon is 16, 32 en 48
+      pixels; een Windows-programma wil 256 er ook bij; een programma dat op een
+      hi-dpi-laptop goed moet staan, wil de tussenformaten die Windows op 125% en
+      150% schaling vraagt. Kies degene die bij de klus past, of vink de formaten
+      zelf aan. Bij elk formaat op de lijst staat wat erom vraagt. De
+      <code>.icns</code> heeft die keuze niet: Apple noemt precies tien plekken en
+      alle tien gaan erin."""
+
+[[howto]]
+title = "Regel de vorm en de achtergrond."
+body = """
+ Een icoon is vierkant en de
+      meeste logo's zijn dat niet. Vul het op en het hele plaatje blijft, met
+      ruimte erboven en eronder; snijd bij en het midden wordt genomen; rek uit en
+      het wordt platgedrukt. Transparantie blijft transparantie, tenzij je een
+      kleur kiest om erachter te zetten."""
+
+[[howto]]
+title = "Kijk naar die van 16 pixels vóór je downloadt."
+body = """
+ Dat is het formaat waarop
+      het icoon het vaakst gezien wordt, en daar verdwijnen dunne lijnen en kleine
+      letters. Elk vierkantje in de voorvertoning wordt op zijn echte formaat uit
+      je eigen bestand getekend. Is de kleinste een vlek, dan is de oplossing een
+      eenvoudiger tekening, niet een andere instelling."""
+
+[[howto]]
+title = "Neem de bestanden mee."
+body = """
+ Eén .ico met elk formaat erin,
+      <code>favicon.ico</code> genoemd wanneer je daarom vroeg, want dat is het
+      adres waar browsers naar kijken. Eén .icns ernaast als je die aanvinkte,
+      klaar om in een Mac-applicatiebundel te gaan. Vink je ook de websiteset aan,
+      dan krijg je er de Apple-, Android- en Windows-tegelplaatjes, het manifest
+      en het blok HTML bij om in je pagina te plakken. Alles wat meer is dan één
+      bestand komt binnen als één zip."""
+
+[[faq]]
+q = "Wordt mijn afbeelding ergens heen geüpload?"
+a = """
+        Nee. Het plaatje wordt gedecodeerd en geschaald door je eigen browser op je
+        eigen hardware, en de .ico wordt uit die pixels opgebouwd door code die
+        vanaf deze pagina geserveerd wordt. Deze tool heeft geen enkele
+        netwerkfunctie &mdash; hij haalt nooit iets op en verstuurt nooit iets
+        &mdash; en de <code>Content-Security-Policy</code> van de pagina noemt elk
+        adres dat hij mag benaderen; geen ervan hoort bij deze site."""
+
+[[faq]]
+q = "Welke formaten horen er in een favicon.ico?"
+a = """
+        16, 32 en 48. Dat is geen voorkeur: 16 is wat een browser in een tabblad
+        tekent, 32 is wat Windows voor een bureaubladsnelkoppeling gebruikt en wat
+        verschillende browsers voor een bladwijzer gebruiken, en 48 is het formaat
+        waarop Google een site-icoon leest. Alles wat groter is hoort in een PNG
+        naast de .ico in plaats van erin &mdash; en dat is wat de websiteset hier
+        oplevert."""
+
+[[faq]]
+q = "Welke formaten heeft een Windows-app-icoon nodig?"
+a = """
+        16, 32, 48 en 256, en dat is wat de standaard-app.ico van Visual Studio
+        zelf bevat. 16 is de titelbalk en de kleine Verkennerweergave, 32 het
+        bureaublad en de taakbalk, 48 de middelgrote pictogrammen van Verkenner, en
+        256 het startmenu en de extra grote weergave. Op een hi-dpi-scherm vraagt
+        Windows ook om 20, 24, 40, 64 en 96, en herbemonstert die vanaf het
+        dichtstbijzijnde formaat dat het heeft als ze er niet zijn &mdash; de
+        voorkeuze &ldquo;elke schaal&rdquo; zet ze erin."""
+
+[[faq]]
+q = "Waarom is het bestand groter dan het plaatje waarmee ik begon?"
+a = """
+        Omdat een .ico niet één plaatje is maar meerdere, en de kleine
+        ongecomprimeerd worden opgeslagen zodat alles ze kan lezen. Een item van
+        32x32 is precies 4.264 bytes, wat er ook in zit, en een ongecomprimeerd
+        item van 256x256 is 264 kB &mdash; en daarom worden formaten boven 64
+        standaard als PNG opgeslagen. &ldquo;PNG voor elk formaat&rdquo; kiezen
+        levert het kleinste bestand op; ongecomprimeerd voor elk formaat kiezen
+        levert het best leesbare op."""
+
+[[faq]]
+q = "Wat is het verschil tussen de PNG- en de ongecomprimeerde items?"
+a = """
+        Alleen hoe de pixels binnen de .ico opgeslagen worden. Een ongecomprimeerd
+        item is de oorspronkelijke Windows-indeling &mdash; een bitmapkop, de
+        pixels ondersteboven, en een transparantiemasker van één bit &mdash; en
+        elke Windows-versie die ooit is uitgekomen kan het lezen. Een PNG-item is
+        een heel PNG-bestand dat in het icoon gestopt is, wat op de grote formaten
+        drie tot tien keer zo klein is maar pas vanaf Windows Vista begrepen werd.
+        De standaard gebruikt elk waar het wint: ongecomprimeerd tot 64 pixels, PNG
+        daarboven."""
+
+[[faq]]
+q = "Kan het een icoon groter dan 256 pixels maken?"
+a = """
+        Nee, en niets kan dat. Het formaat slaat elke zijde in één byte op, en 0 is
+        vergeven &mdash; dat betekent 256. Dat is het plafond, dus een .ico met een
+        plaatje van 512 pixels erin is geen groter icoon, het is een kapot icoon.
+        Heb je 512 nodig, dan heb je een PNG nodig, en die zit in de websiteset
+        voor Android en voor het startscherm van een webapp."""
+
+[[faq]]
+q = "Blijft de transparantie behouden?"
+a = """
+        Ja, in beide soorten items, en het schrijft daarnaast het oude masker van
+        één bit naast het alfakanaal, zodat software die te oud is om het alfa te
+        lezen het icoon toch uitknipt in plaats van een zwart blok te tekenen. Het
+        ene bestand dat met opzet ondoorzichtig gemaakt wordt, is het
+        Apple-touch-icoon in de websiteset: iOS zet dat op zijn eigen tegel en
+        maakt transparantie zwart, dus wordt het op je achtergrondkleur
+        platgeslagen, standaard wit."""
+
+[[faq]]
+q = "Mijn logo is een breed woordmerk. Wat gebeurt daarmee?"
+a = """
+        Er moet iets gebeuren, want een icoon is vierkant. Opvullen houdt het geheel
+        en maakt het klein &mdash; een woordmerk dat in een vierkant van 16 pixels
+        gepast wordt, is zo'n drie pixels hoog en onleesbaar. Bijsnijden naar het
+        midden werkt meestal beter: haal het symbool uit het geheel en gebruik dat,
+        zoals vrijwel elk merk voor zijn favicon doet. De voorvertoning laat je zien
+        welke van de twee het overleeft voordat je iets downloadt."""
+
+[[faq]]
+q = "Wat zit er in de websiteset, en heb ik het allemaal nodig?"
+a = """
+        Zeven PNG's, een webapp-manifest, een browserconfig.xml en een blok HTML om
+        te plakken. Je hebt ze nodig omdat een .ico browsers en Windows dekt en
+        verder niets: een iPhone-beginscherm leest een PNG van 180 pixels onder een
+        eigen naam, Android en elke installatievraag lezen het manifest, en een
+        tegel die aan het startmenu is vastgezet leest de XML. Geen daarvan kijkt in
+        een .ico. Alles wordt hier gemaakt, op jouw apparaat, en in de zip zit een
+        briefje waarin staat waar elk bestand voor is."""
+
+[[faq]]
+q = "Kan het ook een macOS-icoon maken?"
+a = """
+        Ja &mdash; vink <em>macOS-icoon</em> aan en je krijgt een
+        <code>.icns</code> naast de <code>.ico</code>, of in plaats daarvan. Het is
+        een andere container voor hetzelfde idee, en geen van beide systemen leest
+        die van de ander: Windows wil .ico en een Mac-applicatiebundel wil .icns.
+        De formaten zijn daar geen keuze, want Apple publiceert precies tien
+        plekken &mdash; 16, 32, 64, 128, 256, 512 en 1024 pixels, waarvan er drie
+        twee keer voorkomen als de Retina-versie van het formaat eronder. Alle tien
+        gaan erin, getekend uit zeven renders, en daarom is een .icns het grotere
+        bestand."""
+
+[[faq]]
+q = "Hoe gebruik ik het .icns-bestand?"
+a = """
+        Voor een programma gaat het in de bundel in
+        <code>JouwApp.app/Contents/Resources/</code> en wordt het in
+        <code>Info.plist</code> genoemd onder <code>CFBundleIconFile</code>; elke
+        Mac-inpaktool heeft er een veld voor. Voor al het andere: selecteer het
+        bestand in de Finder, druk op Command-C, kies daarna Toon info op de map of
+        schijfkopie die je wilt wijzigen, klik op het kleine icoon linksboven en
+        druk op Command-V."""
+
+[[faq]]
+q = "Is de .icns hetzelfde als wat iconutil maakt?"
+a = """
+        Dezelfde tien plekken met dezelfde vierlettertypen, en PNG in elk ervan, en
+        dat is wat <code>iconutil</code> uit een <code>.iconset</code>-map maakt.
+        Eén bewust verschil: de tool van Apple schrijft ook een
+        <code>TOC&nbsp;</code>-element, een index van de types en lengtes die
+        volgen. Dat is een optimalisatie in plaats van een deel van het formaat
+        &mdash; een lezer zonder index loopt de elementen van begin tot eind door
+        en komt op hetzelfde antwoord uit &mdash; en een verkeerde index is erger
+        dan geen index, dus hij blijft weg."""
+
+[[faq]]
+q = "Kan ik meerdere plaatjes tegelijk omzetten?"
+a = """
+        Ja. Elk plaatje op de lijst wordt zijn eigen .ico met dezelfde
+        instellingen, en de stapel komt binnen als één zip met een map per plaatje
+        &mdash; anders zouden er twee favicon.ico heten en zou de een de ander
+        overschrijven. Elke uitvoer die je aanvinkte wordt voor elk plaatje
+        gemaakt. Klik op een regel om dat plaatje in de voorvertoning te zetten."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. Er is ook geen limiet op het aantal of de grootte van de
+        bestanden, want er is geen server die ervoor betaalt &mdash; het werk
+        gebeurt op je eigen apparaat. De site draagt advertenties, en die betalen
+        hem; de advertenties krijgen niets over je afbeeldingen mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je logo wegstuurde om het om te zetten, zou
+        stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Zet een afbeelding om in een Windows-ICO-bestand met meerdere formaten of een macOS-ICNS-bestand, in de browser. Voorkeuzes voor een website-favicon, een Windows-app-icoon en een hi-dpi-app-icoon, de tien icns-plekken van Apple, een voorvertoning van elk formaat op zijn echte pixelgrootte, en een optionele set met de Apple-, Android- en Windows-tegelbestanden die een website nodig heeft. Er wordt niets geüpload."
+features = [
+  "Schrijft een echte .ico met meerdere formaten, van 16 tot 256 pixels",
+  "Schrijft een macOS-.icns met alle tien plekken van Apple, van 16 tot 1024 pixels",
+  "Beide formaten uit één plaatje, in één ronde, met elk formaat maar één keer getekend",
+  "Voorkeuzes voor een website-favicon, een Windows-app-icoon, hi-dpi-Windows, en maximale leesbaarheid",
+  "Bij elk formaat staat wat erom vraagt, dus er gaat niets voor niets in",
+  "Ongecomprimeerde items voor de kleine formaten en PNG voor de grote, of overal een van beide",
+  "Houdt transparantie, en schrijft daarnaast het transparantiemasker van vóór Vista",
+  "Opvullen, bijsnijden of uitrekken van een plaatje dat niet vierkant is, op een kleur of op niets",
+  "Toont elk formaat op zijn echte pixelgrootte vóór je downloadt",
+  "Optionele websiteset: Apple-touch-icoon, Android-iconen, maskeerbaar icoon, Windows-tegel, manifest en de HTML om te plakken",
+  "Verwerkt hele stapels, met alle resultaten in één zip",
+  "Draait offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep een plaatje hierheen"
+hint = "of klik om te bladeren &mdash; PNG, SVG, JPEG, WebP en al het andere dat je browser kan openen"

--- a/locales/nl/tools/images-to-pdf.html
+++ b/locales/nl/tools/images-to-pdf.html
@@ -1,0 +1,230 @@
+<main>
+  <!-- Stap 1 &mdash; afbeeldingen -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies afbeeldingen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" data-sort="name" class="ghost">Sorteer op naam</button>
+        <button type="button" data-sort="date" class="ghost">Sorteer op datum</button>
+        <button type="button" data-sort="reverse" class="ghost">Omkeren</button>
+        <button type="button" id="clear-all" class="ghost danger">Alles verwijderen</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Eén afbeelding per pagina, in deze volgorde. Sleep aan het
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span>-handvat om een pagina te
+      verplaatsen, of gebruik de pijltjes erop.
+    </p>
+
+    <ul id="image-list" class="image-list"></ul>
+  </section>
+
+  <!-- Stap 2 &mdash; de pagina's -->
+  <section class="card">
+    <h2><span class="step">2</span> Pagina-instellingen</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Paginaformaat</label>
+        <select id="page-size">
+          <option value="fit" selected>Pas de pagina op elke afbeelding aan</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 in</option>
+          <option value="a3">A3 &mdash; 297 &times; 420 mm</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+          <option value="tabloid">Tabloid &mdash; 11 &times; 17 in</option>
+          <option value="custom">Zelf instellen&hellip;</option>
+        </select>
+        <div id="custom-size" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="1" max="5000" step="1" value="210"
+                 aria-label="Eigen paginabreedte">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="1" max="5000" step="1" value="297"
+                 aria-label="Eigen paginahoogte">
+          <select id="custom-unit" aria-label="Eenheid voor het eigen paginaformaat">
+            <option value="mm" selected>mm</option>
+            <option value="in">in</option>
+          </select>
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Printresolutie</label>
+        <select id="dpi">
+          <option value="72">72 dpi &mdash; scherm</option>
+          <option value="96">96 dpi</option>
+          <option value="150" selected>150 dpi</option>
+          <option value="200">200 dpi</option>
+          <option value="300">300 dpi &mdash; druk</option>
+          <option value="600">600 dpi</option>
+        </select>
+        <p class="field-note">
+          Bepaalt hoe groot een pagina is bij een gegeven aantal pixels. Het
+          verandert niets aan het plaatje.
+        </p>
+      </div>
+
+      <div class="field" id="orientation-field" hidden>
+        <label for="orientation">Richting</label>
+        <select id="orientation">
+          <option value="auto" selected>Volg elke afbeelding</option>
+          <option value="portrait">Staand</option>
+          <option value="landscape">Liggend</option>
+        </select>
+      </div>
+
+      <div class="field" id="fit-field" hidden>
+        <label for="fit">Hoe de afbeelding op de pagina staat</label>
+        <select id="fit">
+          <option value="contain" selected>Binnen de marges passen</option>
+          <option value="cover">De pagina vullen (snijdt de randen af)</option>
+          <option value="stretch">Uitrekken tot de marges (vervormt)</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="margin">Marge</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="100" step="1" value="0"
+                 aria-label="Marge in millimeters">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="background">Paginakleur</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Zichtbaar in de marges, en achter alles wat doorzichtig is.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="mode">Beeldkwaliteit</label>
+        <select id="mode">
+          <option value="keep" selected>Hou JPEG's precies zoals ze zijn</option>
+          <option value="jpeg">Codeer alles opnieuw als JPEG</option>
+          <option value="lossless">Verliesloos &mdash; helemaal geen compressieverlies</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">JPEG-kwaliteit</label>
+        <select id="quality">
+          <option value="0.75">Kleiner bestand</option>
+          <option value="0.88" selected>In balans</option>
+          <option value="0.95">Beste kwaliteit</option>
+        </select>
+        <p class="field-note">Alleen gebruikt voor plaatjes die deze tool opnieuw moet coderen.</p>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Grote afbeeldingen verkleinen</label>
+        <select id="max-side">
+          <option value="0" selected>Nooit &mdash; hou de volle grootte</option>
+          <option value="4000">Langste zijde 4000 px</option>
+          <option value="2000">Langste zijde 2000 px</option>
+          <option value="1200">Langste zijde 1200 px</option>
+        </select>
+        <p class="field-note" id="shrink-note"></p>
+      </div>
+    </div>
+
+    <details class="meta-panel">
+      <summary>Documentgegevens &mdash; allemaal optioneel, allemaal standaard leeg</summary>
+      <div class="meta-body">
+        <p class="meta-note">
+          Een pdf draagt een klein blok informatie over zichzelf mee, en de meeste
+          tools vullen dat met een tijdstempel en een programmanaam, of je erom
+          vroeg of niet. Deze schrijft wat je hier intikt en verder niets: geen
+          bestandsnamen, geen apparaatnaam, en geen datum tenzij je het vinkje
+          aanzet.
+        </p>
+        <div class="settings">
+          <div class="field">
+            <label for="doc-title">Titel</label>
+            <input type="text" id="doc-title" maxlength="200" spellcheck="false"
+                   placeholder="Blijft weg als het leeg is">
+          </div>
+          <div class="field">
+            <label for="doc-author">Auteur</label>
+            <input type="text" id="doc-author" maxlength="200" spellcheck="false"
+                   placeholder="Blijft weg als het leeg is">
+          </div>
+          <div class="field">
+            <label for="file-name">Bestandsnaam</label>
+            <div class="inline-pair">
+              <input type="text" id="file-name" maxlength="120" spellcheck="false"
+                     value="afbeeldingen">
+              <span class="unit-label">.pdf</span>
+            </div>
+          </div>
+          <div class="field checkbox-field">
+            <label for="dated">
+              <input type="checkbox" id="dated">
+              Leg de datum van vandaag in het document vast
+            </label>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="480" height="640" aria-label="Voorvertoning van één pagina"></canvas>
+        <p id="preview-empty" class="preview-empty">Voeg afbeeldingen toe om de pagina's te zien</p>
+        <div id="preview-nav" class="preview-nav" hidden>
+          <button type="button" id="preview-prev" class="ghost" aria-label="Vorige pagina">&lsaquo;</button>
+          <span id="preview-label" class="preview-label"></span>
+          <button type="button" id="preview-next" class="ghost" aria-label="Volgende pagina">&rsaquo;</button>
+        </div>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Pagina's</dt><dd id="sum-pages">&mdash;</dd></div>
+        <div><dt>Paginaformaat</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Afbeeldingen gekozen</dt><dd id="sum-input">&mdash;</dd></div>
+        <div><dt>Onaangeroerd overgenomen</dt><dd id="sum-copied">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Stap 3 &mdash; export -->
+  <section class="card">
+    <h2><span class="step">3</span> Maak de pdf</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Pdf maken</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Pdf downloaden</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/images-to-pdf.toml
+++ b/locales/nl/tools/images-to-pdf.toml
@@ -1,0 +1,233 @@
+#
+# Afbeeldingen naar pdf - Dutch.
+#
+# Overrides for tools/images-to-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Afbeeldingen naar pdf"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Afbeeldingen&nbsp;naar&nbsp;pdf <span class=\"h1-kw\">&mdash; jpg-naar-pdf-omzetter</span>"
+tagline = "Zet je plaatjes in één document."
+
+title = "Afbeeldingen-naar-pdf-omzetter &mdash; gratis jpg naar pdf, zonder uploaden"
+description = "Voeg jpg-, png- of WebP-afbeeldingen samen tot één pdf, gratis en volledig in je browser. Foto's gaan erin zonder opnieuw gecodeerd te worden, en er wordt niets geüpload."
+og_title = "Afbeeldingen naar pdf &mdash; gratis jpg-naar-pdf-omzetter"
+og_description = "Voeg afbeeldingen samen tot één pdf op je eigen apparaat. JPEG-foto's worden onaangeroerd overgenomen, dus er gaat geen kwaliteit verloren en er wordt niets geüpload."
+og_image_alt = "Afbeeldingen naar pdf - plaatjes samenvoegen tot één document zonder ze te uploaden"
+
+pledge = """
+    Het document wordt op dit apparaat in het geheugen geschreven, pagina voor
+    pagina, door code die vanaf dit adres geserveerd wordt. Niets hier kan een
+    upload doen, en er staat aan de andere kant van deze pagina geen server om er
+    een te ontvangen."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en maak een pdf. Geen enkel verzoek draagt een afbeelding, een
+      miniatuur of een bestandsnaam. Of trek de stekker uit het internet en maak
+      er toch een."""
+
+read_first = """
+, en <code>src/pdf.js</code> en <code>src/document.js</code>
+      voor het hele schrijfwerk aan het bestand, dat het netwerk nooit
+      aanraakt."""
+
+howto_heading = "Van afbeeldingen een pdf maken"
+
+card = """
+            Voeg afbeeldingen samen tot één pdf, één plaatje per pagina.
+            JPEG-foto's worden er precies zo in gekopieerd als ze zijn, dus er
+            gaat geen kwaliteit verloren."""
+
+[words]
+plural = "afbeeldingen"
+choose = "afbeeldingen"
+analytics_extra = """"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "Bestanden blijven op je apparaat"
+
+[[privacy]]
+title = "Je afbeeldingen kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Deze tool voegt niets aan die lijst toe: hij
+      heeft geen eigen netwerkfunctie, ook geen optionele. Er is hier geen
+      eindpunt waar je bestanden verzameld zouden kunnen worden, en niets in de
+      code dat ze zou versturen als dat er wel was."""
+
+[[privacy]]
+title = "De pdf wordt hier geschreven."
+body = """
+ Een pdf is een lijst objecten en een
+      tabel van waar elk object begint, en <code>src/pdf.js</code> schrijft ze
+      allebei. Er wordt geen bibliotheek opgehaald, er wordt niets op een server
+      gerenderd, en het gereedgekomen bestand gaat rechtstreeks vanuit het
+      geheugen naar een download."""
+
+[[privacy]]
+title = "Het document krijgt niets over jou te horen."
+body = """
+ De meeste tools stempelen een
+      pdf met een tijdstempel en de naam van het programma dat hem maakte. Deze
+      schrijft alleen een titel, een auteur en een datum als je die intikt; de
+      bestandsnamen van je plaatjes komen nooit in het document voor, en iets over
+      je apparaat evenmin."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google. Geen van beide krijgt iets over je
+      afbeeldingen mee: geen bestand, geen miniatuur, geen naam, geen grootte,
+      geen aantal. Elke regel die een plaatje leest, decodeert of schrijft, wordt
+      vanaf deze herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de doneerknop laadt, en wat hij niet krijgt."
+body = """
+
+      De knop &ldquo;Buy me a coffee&rdquo; in de kop wordt getekend door een
+      script van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts.
+      Het is een link en verder niets: hij meldt geen bezoek, en hij krijgt niets
+      over jou of je afbeeldingen mee. Er gebeurt niets tenzij je erop klikt, en
+      waar je dan naartoe klikt is de site van iemand anders."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en alles op deze
+      pagina doet het nog. Dat is het eenvoudigste bewijs van allemaal: een tool
+      die je plaatjes wegstuurde om er een document van te maken, zou stoppen."""
+
+[[howto]]
+title = "Kies je afbeeldingen."
+body = """
+ Sleep een map op het keuzevak, of kies
+      de bestanden met de hand. De browser leest ze rechtstreeks van je schijf; er
+      wordt daarbij niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Zet de pagina's op volgorde, en draai wat gedraaid moet."
+body = """
+ Eén
+      afbeelding wordt één pagina, in de getoonde volgorde. Sleep een tegel aan
+      zijn handvat om hem te verplaatsen, of gebruik de pijltjes; de draaiknoppen
+      draaien een pagina een kwartslag tegelijk, en dat is wat een scheve scan
+      meestal nodig heeft."""
+
+[[howto]]
+title = "Kies een paginaformaat."
+body = """
+ &ldquo;Pas de pagina op elke
+      afbeelding aan&rdquo; maakt elke pagina precies zijn plaatje, zonder dat er
+      iets bijgesneden wordt en zonder witte banen. De benoemde formaten &mdash;
+      A4, Letter, Legal en de rest &mdash; zetten elk plaatje in plaats daarvan op
+      een vaste pagina, met een marge als je die wilt."""
+
+[[howto]]
+title = "Maak de pdf en download hem."
+body = """
+ Het document wordt op je eigen
+      apparaat geschreven, dus hoe lang het duurt hangt af van je hardware en niet
+      van een wachtrij. Het gereedgekomen bestand gaat rechtstreeks naar de
+      downloads van je browser."""
+
+[[faq]]
+q = "Worden mijn afbeeldingen ergens heen geüpload?"
+a = """
+        Nee. Je afbeeldingen worden gelezen en de pdf wordt geschreven door je
+        eigen browser op je eigen hardware. Deze tool heeft geen serverkant, en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen &mdash; geen ervan hoort bij deze site. Anders dan sommige
+        andere tools hier heeft deze helemaal geen optionele netwerkfunctie."""
+
+[[faq]]
+q = "Kost omzetten naar pdf kwaliteit?"
+a = """
+        Voor een JPEG niet, op de standaardinstelling. Pdf kan JPEG-gegevens
+        rechtstreeks meedragen, dus een foto wordt byte voor byte het document in
+        gekopieerd: hij wordt nooit gedecodeerd en nooit opnieuw gecomprimeerd, en
+        het plaatje in de pdf is het plaatje in het bestand. Andere formaten moeten
+        wel opnieuw gecodeerd worden, want pdf heeft er geen filter voor &mdash;
+        tenzij je de verliesloze instelling kiest, die ze exact bewaart ten koste
+        van een groter bestand."""
+
+[[faq]]
+q = "Welke afbeeldingsformaten kan ik gebruiken?"
+a = """
+        Elk stilstaand beeld dat je browser kan decoderen, in de praktijk dus jpg,
+        png, WebP, gif, AVIF en, op Apple-apparaten, HEIC. Er is hier geen aparte
+        lijst om bij te houden, omdat het decoderen het werk van de browser is en
+        niet het onze."""
+
+[[faq]]
+q = "Kan ik het paginaformaat en de volgorde van de pagina's kiezen?"
+a = """
+        Ja. Pagina's kunnen A4, Letter, Legal, A3, A5 of Tabloid zijn, een formaat
+        dat je zelf intikt, of precies de grootte van elk plaatje. Sleep de tegels
+        om ze te herordenen, sorteer ze op naam of datum, draai er een een
+        kwartslag, en stel een marge in millimeters in."""
+
+[[faq]]
+q = "Hoeveel afbeeldingen kan ik in één pdf zetten?"
+a = """
+        In de tool zit geen limiet ingebouwd. Het praktische plafond is het
+        geheugen van je eigen apparaat, want het gereedgekomen document wordt daar
+        opgebouwd voordat je het downloadt. Een paar honderd telefoonfoto's op
+        volle resolutie is het eerste wat dat merkt; de langste zijde verkleinen,
+        in de instellingen, schuift dat plafond een heel eind op."""
+
+[[faq]]
+q = "Staan mijn bestandsnamen of een tijdstempel in de pdf?"
+a = """
+        Nee, tenzij je erom vraagt. Het informatieblok van het document blijft leeg
+        op de naam van deze tool na: geen bestandsnamen, geen apparaatnaam, geen
+        gebruikersnaam, en geen aanmaakdatum tenzij je het vinkje daarvoor aanzet.
+        Dat is met opzet &mdash; een pdf is iets wat mensen naar andere mensen
+        sturen."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen en geen proefperiode.
+        De site draagt advertenties, en die betalen hem; de advertenties krijgen
+        niets over je afbeeldingen mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je afbeeldingen wegstuurde om er een document
+        van te maken, zou stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Voeg jpg-, png- en WebP-afbeeldingen samen tot één pdf-document. Elke pagina wordt in je browser geschreven, dus er wordt nooit een afbeelding geüpload."
+features = [
+  "Voegt jpg-, png-, WebP-, gif- en AVIF-afbeeldingen samen tot één pdf",
+  "JPEG-foto's worden ingesloten zonder opnieuw gecodeerd te worden",
+  "Paginaformaten van A5 tot Tabloid, of een pagina die op elke afbeelding past",
+  "Herordenen, draaien, marges en een paginakleur instellen",
+  "Optionele verliesloze opslag voor scans en schermafbeeldingen",
+  "Draait offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep afbeeldingen hierheen"
+hint = "of klik om te bladeren &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/nl/tools/images-to-video.html
+++ b/locales/nl/tools/images-to-video.html
@@ -1,0 +1,166 @@
+<main>
+  <!-- Stap 1 &mdash; afbeeldingen -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies afbeeldingen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    {% include "partials/url-import.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Verander hoe de lijst getoond wordt">
+          <button type="button" data-view="large" class="active">Groot</button>
+          <button type="button" data-view="small">Klein</button>
+          <button type="button" data-view="list">Lijst</button>
+          <button type="button" data-view="details">Details</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Sorteer op naam</button>
+        <button type="button" data-sort="date" class="ghost">Sorteer op datum</button>
+        <button type="button" data-sort="reverse" class="ghost">Omkeren</button>
+        <button type="button" id="clear-all" class="ghost danger">Alles verwijderen</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Sleep een afbeelding aan zijn <span class="grip" aria-hidden="true">&#8942;&#8942;</span>-handvat om
+      te herordenen, of gebruik de pijltjes erop.
+    </p>
+
+    <ul id="image-list" class="image-list view-large"></ul>
+
+    <div id="bulk-duration" class="bulk" hidden>
+      <label for="bulk-amount">Hou elke afbeelding vast</label>
+      <input type="number" id="bulk-amount" min="1" max="3600" step="1" value="1">
+      <select id="duration-unit" aria-label="Eenheid voor hoe lang elke afbeelding wordt vastgehouden">
+        <option value="frames" selected>frames</option>
+        <option value="seconds">seconden</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Op alles toepassen</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Stap 2 &mdash; instellingen -->
+  <section class="card">
+    <h2><span class="step">2</span> Video-instellingen</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="resolution">Resolutie</label>
+        <select id="resolution">
+          <option value="auto" selected>Volg de hoogste resolutie</option>
+          <option value="3840x2160">3840 &times; 2160 &mdash; 4K</option>
+          <option value="1920x1080">1920 &times; 1080 &mdash; 1080p</option>
+          <option value="1280x720">1280 &times; 720 &mdash; 720p</option>
+          <option value="1080x1080">1080 &times; 1080 &mdash; vierkant</option>
+          <option value="1080x1920">1080 &times; 1920 &mdash; staand</option>
+          <option value="custom">Zelf instellen&hellip;</option>
+        </select>
+        <div id="resolution-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="7680" step="2" value="1920"
+                 aria-label="Eigen uitvoerbreedte in pixels">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="7680" step="2" value="1080"
+                 aria-label="Eigen uitvoerhoogte in pixels">
+        </div>
+        <p class="field-note" id="resolution-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Beeldsnelheid</label>
+        <select id="fps">
+          <option value="12">12 fps</option>
+          <option value="15">15 fps</option>
+          <option value="24">24 fps &mdash; film</option>
+          <option value="25">25 fps &mdash; PAL</option>
+          <option value="30" selected>30 fps</option>
+          <option value="50">50 fps</option>
+          <option value="60">60 fps</option>
+          <option value="custom">Zelf instellen&hellip;</option>
+        </select>
+        <input type="number" id="fps-custom" class="spaced" min="1" max="120" step="1" value="30"
+               aria-label="Eigen beeldsnelheid in frames per seconde" hidden>
+        <p class="field-note" id="fps-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Passing van de afbeelding</label>
+        <select id="fit">
+          <option value="contain" selected>Binnen passen (met balken)</option>
+          <option value="blur">Binnen passen, met vervaagde achtergrond</option>
+          <option value="cover">Beeld vullen (snijdt de randen af)</option>
+          <option value="stretch">Uitrekken tot het vult (vervormt)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Achtergrondkleur</label>
+        <input type="color" id="background" value="#000000">
+      </div>
+
+      <div class="field">
+        <label for="quality">Kwaliteit</label>
+        <select id="quality">
+          <option value="low">Kleiner bestand</option>
+          <option value="medium" selected>In balans</option>
+          <option value="high">Beste kwaliteit</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="format">Formaat</label>
+        <select id="format">
+          <option value="auto" selected>MP4 (aanbevolen)</option>
+          <option value="webm">WebM (terugval)</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="640" height="360" aria-label="Voorvertoning van het eerste frame"></canvas>
+        <p id="preview-empty" class="preview-empty">Voeg afbeeldingen toe om een voorvertoning te zien</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Afbeeldingen</dt><dd id="sum-images">&mdash;</dd></div>
+        <div><dt>Duur</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Uitvoerformaat</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Frames in totaal</dt><dd id="sum-frames">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Stap 3 &mdash; export -->
+  <section class="card">
+    <h2><span class="step">3</span> Maak de video</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Video maken</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Video downloaden</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/images-to-video.toml
+++ b/locales/nl/tools/images-to-video.toml
@@ -1,0 +1,251 @@
+#
+# Afbeeldingen naar video - Dutch.
+#
+# Overrides for tools/images-to-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# This is the one tool with a [picker.urls] table, so it is also the one whose
+# translation has to supply the noun the importer's warning in [ui.picker] is
+# written around. Dutch needs it in the singular, and the sentences there were
+# written so the bare noun fits without an ending - Dutch does not make a plural
+# with a lone "s".
+#
+
+name = "Afbeeldingen naar video"
+heading = "Afbeeldingen&nbsp;naar&nbsp;video <span class=\"h1-kw\">&mdash; een mp4-diavoorstelling maken</span>"
+tagline = "Maak van een map vol afbeeldingen een video."
+
+title = "Beeldreeks naar mp4 &mdash; gratis, zonder uploaden, werkt offline"
+description = "Maak van jpg-, png- of WebP-afbeeldingen een mp4-diavoorstelling, gratis en volledig in je browser. Er wordt niets geüpload, je hoeft je niet aan te melden, en het werkt offline."
+og_title = "Beeldreeks naar mp4 &mdash; gratis, in je browser"
+og_description = "Maak van een renderreeks, een timelapse of een map vol foto's een mp4. Het coderen gebeurt op je eigen apparaat; er wordt niets geüpload."
+og_image_alt = "Afbeeldingen naar video - van een map vol afbeeldingen een mp4-diavoorstelling maken"
+
+pledge = """
+    Elk frame wordt door je eigen browser gecodeerd en de video wordt op dit
+    apparaat in het geheugen opgebouwd. De encoder raakt het netwerk nooit aan,
+    en er staat aan de andere kant van deze pagina geen server om een afbeelding
+    heen te sturen, ook al deed hij dat wel."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en maak een video. Geen enkel verzoek draagt een afbeelding, een
+      miniatuur of een bestandsnaam. Of trek de stekker uit het internet en maak
+      er toch een."""
+
+read_first = """
+, en <code>src/encoder.js</code> voor de codeerlus die
+      het netwerk nooit aanraakt."""
+
+howto_heading = "Van afbeeldingen een video maken"
+
+card = """
+            Maak van een map vol afbeeldingen een mp4-diavoorstelling. Het
+            coderen gebeurt op je eigen apparaat, met je eigen hardware."""
+
+[words]
+plural = "afbeeldingen"
+choose = "afbeeldingen"
+analytics_extra = """"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "Bestanden blijven op je apparaat"
+
+[[privacy]]
+title = "Je afbeeldingen kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestanden
+      verzameld zouden kunnen worden, en niets in de code dat ze zou versturen
+      als dat er wel was. Hier stond ooit <code>connect-src 'none'</code>, en dat
+      was absoluut; advertenties toevoegen heeft dat gekost, en dat hardop zeggen
+      hoort bij de afspraak."""
+
+[[privacy]]
+title = "Het coderen gebeurt lokaal."
+body = """
+ WebCodecs draait in je browser en het
+      gereedgekomen bestand gaat rechtstreeks naar een download. Deze app heeft
+      geen serverkant."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google. Geen van beide krijgt iets over je
+      afbeeldingen mee: geen bestand, geen miniatuur, geen naam, geen grootte,
+      geen aantal. Elke regel die een afbeelding leest, decodeert, samenstelt of
+      codeert, wordt vanaf deze herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de doneerknop laadt, en wat hij niet krijgt."
+body = """
+
+      De knop &ldquo;Buy me a coffee&rdquo; in de kop wordt getekend door een
+      script van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts.
+      Het is een link en verder niets: hij meldt geen bezoek, en hij krijgt niets
+      over jou of je afbeeldingen mee. Er gebeurt niets tenzij je erop klikt, en
+      waar je dan naartoe klikt is de site van iemand anders."""
+
+[[privacy]]
+title = "Eén bewuste uitzondering."
+body = """
+ Gebruik je &ldquo;Toevoegen vanaf een
+      webadres&rdquo;, dan wordt die server benaderd om de afbeelding op te halen
+      en ziet hij je IP-adres. Alleen afbeeldingen die jij erin plakt worden ooit
+      opgehaald, en alleen naar binnen: <code>img-src</code> is opengezet,
+      <code>connect-src</code> niet. De teller hieronder noemt elke herkomst van
+      buiten die benaderd is."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en alles behalve het
+      laden vanaf een webadres doet het nog. Dat is het eenvoudigste bewijs van
+      allemaal."""
+
+[[howto]]
+title = "Kies je afbeeldingen."
+body = """
+ Sleep een map op het keuzevak, of kies
+      de bestanden met de hand. De browser leest ze rechtstreeks van je schijf; er
+      wordt daarbij niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Zet ze op volgorde en bepaal hoe lang elke wordt vastgehouden."
+body = """
+ Sleep
+      om te herordenen. De vasthoudtijd kan in frames of in seconden, voor alle
+      afbeeldingen tegelijk of per afbeelding."""
+
+[[howto]]
+title = "Kies een resolutie en beeldsnelheid."
+body = """
+ &ldquo;Volg de hoogste
+      resolutie&rdquo; houdt je grootste afbeelding aan; de voorkeuzes dekken 4K,
+      1080p, 720p, vierkant en staand, en er is een eigen formaat als geen ervan
+      past."""
+
+[[howto]]
+title = "Maak de video en download hem."
+body = """
+ Het coderen gebeurt op je eigen
+      hardware, dus hoe lang het duurt hangt af van je apparaat en niet van een
+      wachtrij. De gereedgekomen mp4 gaat rechtstreeks naar de downloads van je
+      browser."""
+
+[[faq]]
+q = "Worden mijn afbeeldingen ergens heen geüpload?"
+a = """
+        Nee. Je afbeeldingen worden gelezen, samengesteld en gecodeerd door je
+        eigen browser op je eigen hardware. Deze tool heeft geen serverkant, en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen &mdash; geen ervan hoort bij deze site. De ene uitzondering
+        is de optionele functie &ldquo;toevoegen vanaf een webadres&rdquo;, die een
+        afbeelding ophaalt die jij erin plakt, en die server ziet je IP-adres."""
+
+[[faq]]
+q = "Welke afbeeldingsformaten kan ik gebruiken?"
+a = """
+        Elk formaat voor stilstaand beeld dat je browser kan decoderen, in de
+        praktijk dus jpg, png, WebP, gif, AVIF en, op Apple-apparaten, HEIC. Er is
+        hier geen aparte lijst om bij te houden, omdat het decoderen het werk van
+        de browser is en niet het onze."""
+
+[[faq]]
+q = "Welk videoformaat levert het op?"
+a = """
+        Mp4 met H.264-video, wat vrijwel overal afspeelt. In een browser zonder
+        WebCodecs valt de tool terug op het opnemen van WebM &mdash; hetzelfde
+        beeld in een container die minder editors accepteren."""
+
+[[faq]]
+q = "Kan ik dit gebruiken voor een renderreeks uit Blender of After Effects?"
+a = """
+        Ja &mdash; een genummerde renderreeks is precies waar dit voor is. Voeg de
+        frames toe die je renderer schreef, laat de vasthoudtijd op één frame per
+        stuk staan, en zet de beeldsnelheid gelijk aan die van de render.
+        &ldquo;Sorteer op naam&rdquo; telt zoals je zou verwachten, dus
+        <code>frame_2</code> landt vóór <code>frame_10</code> in plaats van erna.
+        <br><br>
+        Eén ding is het weten waard voordat je begint: H.264 heeft geen alfakanaal,
+        dus transparantie wordt op de achtergrondkleur platgeslagen in plaats van
+        doorgegeven. Moet het alfa blijven, stel de frames dan in je editor
+        samen."""
+
+[[faq]]
+q = "Kan ik een timelapse van foto's maken?"
+a = """
+        Ja, en dat is dezelfde klus als een renderreeks: hou elke foto één frame
+        vast en kies een beeldsnelheid. Op 30 fps wordt elke dertig foto's één
+        seconde video; op 12 fps lopen diezelfde foto's tweeënhalve seconde.
+        <br><br>
+        &ldquo;Sorteer op datum&rdquo; zet een camerarol terug in de volgorde
+        waarin hij geschoten is, en dat telt wanneer de bestandsnamen weer bij
+        0001 begonnen zijn. Foto's van verschillende formaten zijn geen probleem
+        &mdash; &ldquo;Volg de hoogste resolutie&rdquo; kiest de videogrootte zo
+        dat er geen van verkleind wordt."""
+
+[[faq]]
+q = "Zit er een limiet op het aantal afbeeldingen of de lengte van de video?"
+a = """
+        In de tool zit geen limiet ingebouwd. Het praktische plafond is het
+        geheugen van je eigen apparaat, want de gereedgekomen video wordt daar
+        opgebouwd voordat je hem downloadt. Heel grote 4K-diavoorstellingen merken
+        dat het eerst."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen en geen proefperiode.
+        De site draagt advertenties, en die betalen hem; de advertenties krijgen
+        niets over je afbeeldingen mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je afbeeldingen wegstuurde om ze te
+        verwerken, zou stoppen op het moment dat je de stekker eruit trok."""
+
+[[faq]]
+q = "Kan ik muziek of een soundtrack toevoegen?"
+a = """
+        Nog niet. De tool levert alleen beeld: de mp4 die hij schrijft heeft één
+        videospoor en geen audiospoor. Voeg achteraf een soundtrack toe in een
+        video-editor als je er een nodig hebt."""
+
+[schema]
+browser_requirements = "Vereist JavaScript. Voor mp4-uitvoer is een browser met WebCodecs nodig; andere vallen terug op WebM."
+description = "Maak van een map vol afbeeldingen een mp4-diavoorstelling. Elke stap draait in je browser, dus er wordt nooit een afbeelding geüpload."
+features = [
+  "Zet jpg-, png-, WebP-, gif- en AVIF-afbeeldingen om naar video",
+  "Mp4-uitvoer (H.264), met WebM als terugval",
+  "Resoluties tot 3840x2160, beeldsnelheden van 12 tot 60 fps",
+  "Vasthoudtijd per afbeelding in frames of seconden",
+  "Draait offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep afbeeldingen hierheen"
+hint = "of klik om te bladeren &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+[picker.urls]
+summary = "Toevoegen vanaf een webadres"
+button = "Afbeeldingen downloaden"
+# Enkelvoud, en onvervoegd: de zinnen in [ui.picker] zijn eromheen geschreven.
+noun = "afbeelding"

--- a/locales/nl/tools/qr-barcode.html
+++ b/locales/nl/tools/qr-barcode.html
@@ -1,0 +1,186 @@
+<main>
+  <!-- Stap 1 &mdash; welk soort code -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies het soort code</h2>
+
+    <p class="card-lede">
+      Een qr-code bevat van alles en is waar een telefooncamera naar zoekt. Een
+      barcode bevat een nummer, en welke je nodig hebt wordt meestal voor je
+      bepaald &mdash; door de winkel, het magazijn of de vervoerder die erom
+      vraagt.
+    </p>
+
+    <div class="option-row">
+      <label for="symbology">Soort code</label>
+      <select id="symbology">
+        <optgroup label="Vierkant">
+          <option value="qr" selected>Qr-code</option>
+        </optgroup>
+        <optgroup label="Strepen">
+          <option value="code128">Code 128</option>
+          <option value="ean13">EAN-13</option>
+          <option value="upca">UPC-A</option>
+          <option value="ean8">EAN-8</option>
+          <option value="itf14">ITF-14</option>
+          <option value="itf">Interleaved 2 of 5</option>
+          <option value="code39">Code 39</option>
+        </optgroup>
+      </select>
+    </div>
+
+    <p class="field-summary" id="symbology-note"></p>
+  </section>
+
+  <!-- Stap 2 &mdash; de tekenreeks zelf -->
+  <section class="card">
+    <h2><span class="step">2</span> Zeg wat erin gaat</h2>
+
+    <div class="option-row" id="format-row">
+      <label for="format">Wat het bevat</label>
+      <select id="format"></select>
+    </div>
+
+    <p class="card-lede" id="format-note"></p>
+
+    <div id="fields" class="fields"></div>
+
+    <p id="input-error" class="error" role="alert" hidden></p>
+
+    <!--
+      The finished string, shown rather than hidden. A "Wi-Fi QR code" is an
+      ordinary QR code holding a line of text in a format phones recognise, and
+      when a phone does not act on one, this line is the thing to look at.
+    -->
+    <details class="encoded" id="encoded-panel">
+      <summary>De exacte tekenreeks die deze code gaat bevatten</summary>
+      <pre id="encoded"></pre>
+      <p class="field-summary" id="encoded-note"></p>
+    </details>
+  </section>
+
+  <!-- Stap 3 &mdash; hoe hij getekend wordt -->
+  <section class="card">
+    <h2><span class="step">3</span> Kies hoe hij eruitziet</h2>
+
+    <fieldset class="options" id="qr-options">
+      <legend>De qr-code</legend>
+
+      <div class="option-row">
+        <label for="level">Hoeveel schade hij mag oplopen</label>
+        <select id="level">
+          <option value="L">L &mdash; zo'n 7% herstelbaar, kleinste code</option>
+          <option value="M" selected>M &mdash; zo'n 15%, de gebruikelijke keuze</option>
+          <option value="Q">Q &mdash; zo'n 25%</option>
+          <option value="H">H &mdash; zo'n 30%, voor een druk die te lijden krijgt</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="quiet">Marge, in modules</label>
+        <input type="number" id="quiet" value="4" min="0" max="16" step="1" inputmode="numeric">
+      </div>
+
+      <p class="field-summary">
+        De marge hoort bij de code, het is geen ruimte eromheen. Vier modules is
+        wat de specificatie vraagt, en een code die tot de rand teruggeknipt is,
+        is er een die veel scanners helemaal niet zien.
+      </p>
+    </fieldset>
+
+    <fieldset class="options" id="barcode-options" hidden>
+      <legend>De barcode</legend>
+
+      <div class="option-row">
+        <label for="bar-width">Smalste streep, in pixels</label>
+        <input type="number" id="bar-width" value="2" min="1" max="10" step="1" inputmode="numeric">
+      </div>
+
+      <div class="option-row">
+        <label for="bar-height">Hoogte van de strepen, in pixels</label>
+        <input type="number" id="bar-height" value="120" min="20" max="600" step="10" inputmode="numeric">
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="show-text" checked>
+        <span>
+          <strong>Druk de tekens eronder af</strong>
+          <span class="check-note">
+            Wat een mens leest wanneer de scanner het niet doet. Op een winkelcode
+            staan de cijfers ook in de marges, en dat is met opzet: ze bakenen de
+            witruimte af die niemand eraf hoort te knippen.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="code39-check-row" hidden>
+        <input type="checkbox" id="code39-check">
+        <span>
+          <strong>Voeg een controleteken toe</strong>
+          <span class="check-note">
+            Code 39 draagt er normaal geen. Sommige systemen staan erop; voeg het
+            alleen toe als het jouwe dat doet, want een lezer die er geen verwacht,
+            leest het als een extra teken op het eind.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Kleur en formaat</legend>
+
+      <div class="colour-row">
+        <div class="option-row">
+          <label for="foreground">De code</label>
+          <input type="color" id="foreground" value="#000000">
+        </div>
+        <div class="option-row">
+          <label for="background">Erachter</label>
+          <input type="color" id="background" value="#ffffff">
+        </div>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="transparent">
+        <span>
+          <strong>Helemaal geen achtergrond</strong>
+          <span class="check-note">
+            Transparant, om op iets te zetten dat al een kleur heeft. De svg en de
+            png houden het allebei; wat er uiteindelijk achter komt moet bleek
+            zijn, anders vindt een scanner geen contrast.
+          </span>
+        </span>
+      </label>
+
+      <div class="option-row" id="size-row">
+        <label for="size">Grootte van het plaatje, in pixels</label>
+        <input type="number" id="size" value="512" min="64" max="4096" step="16" inputmode="numeric">
+      </div>
+
+      <p class="field-summary" id="size-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Stap 4 &mdash; het resultaat -->
+  <section class="card" id="result-card">
+    <h2><span class="step">4</span> Neem hem mee</h2>
+
+    <div class="preview" id="preview" role="img" aria-label="De code die je gemaakt hebt"></div>
+
+    <p class="facts" id="facts"></p>
+
+    <div class="run-row">
+      <button type="button" id="download-svg" class="primary">De svg downloaden</button>
+      <button type="button" id="download-png" class="primary">De png downloaden</button>
+      <button type="button" id="copy-png" class="ghost">De afbeelding kopiëren</button>
+    </div>
+
+    <p class="field-summary" id="download-note" role="status"></p>
+
+    <p class="field-summary">
+      De svg is degene om te bewaren. Dat is de code als instructies in plaats
+      van als pixels, dus hij drukt op elk formaat af zonder zacht te worden
+      &mdash; en dat telt hier zwaarder dan bij de meeste plaatjes, want een
+      vervaagde rand is precies wat een scanner niet kan onderscheiden.
+    </p>
+  </section>
+</main>

--- a/locales/nl/tools/qr-barcode.toml
+++ b/locales/nl/tools/qr-barcode.toml
@@ -1,0 +1,344 @@
+#
+# QR- & barcodegenerator - Dutch.
+#
+# Overrides for tools/qr-barcode/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# The one tool here whose input is typed rather than dropped, so there is no
+# [picker] table to translate - and [words].choose has to fit "wanneer je ...
+# kiest" in the boot warning, which is why it is a noun phrase rather than the
+# English clause.
+#
+
+name = "QR- & barcodegenerator"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "QR&nbsp;&amp;&nbsp;barcode <span class=\"h1-kw\">&mdash; een qr-code of barcode maken, offline</span>"
+tagline = "Tik het in, en het wordt een code. Er wordt niets verstuurd om er een te maken."
+
+title = "Qr-code- &amp; barcodegenerator &mdash; gratis, zonder aanmelden, niets geüpload"
+description = "Maak een qr-code voor een link, een wifinetwerk of een visitekaartje, of een EAN-13-, UPC-A-, Code 128- of Code 39-barcode. Download als svg of png. Het gebeurt allemaal in je browser."
+og_title = "Een qr-code of barcode maken zonder iets naar iemand te sturen"
+og_description = "Links, wifiwachtwoorden, visitekaartjes en de winkelbarcodes, in je eigen browser getekend en als svg of png gedownload. Geen account, geen watermerk, geen trackingpixel midden in je code."
+og_image_alt = "QR- & barcodegenerator - een qr-code of barcode maken, niets geüpload"
+
+pledge = """
+    Een qr-code is rekenwerk op een tekenreeks: er is geen bestand te versturen
+    en geen dienst om iets aan te vragen. Elke stap &mdash; de modus kiezen, de
+    versie bepalen, de Reed-Solomon-foutcorrectie, het masker, de strepen van
+    een barcode en het controlecijfer eronder &mdash; gebeurt in zo'n duizend
+    regels JavaScript in deze pagina die je kunt lezen. Deze tool heeft geen
+    enkele netwerkfunctie, en dat telt hier zwaarder dan op de meeste pagina's:
+    wat er gecodeerd wordt is vaak een wifiwachtwoord."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en tik een wachtwoord in het wififormulier. Geen enkel verzoek draagt
+      er één teken van. Of trek de stekker uit het internet en maak de code
+      toch."""
+
+read_first = """
+, <code>src/qr-encode.js</code>
+      en <code>src/qr.js</code> voor de qr-code zelf &mdash; de modi, de versie
+      en de blokken in het ene, de patronen, het masker en de formaatbits in het
+      andere &mdash; <code>src/gf256.js</code> voor de foutcorrectie, en
+      <code>src/barcode.js</code> voor de gestreepte."""
+
+howto_heading = "Een qr-code maken zonder iets te uploaden"
+
+card = """
+            Een qr-code voor een link, een wifinetwerk of een visitekaartje
+            &mdash; of een winkelbarcode met zijn controlecijfer erbij
+            uitgerekend. Svg of png."""
+
+[words]
+plural = "codes en de tekst erin"
+# Zelfstandig naamwoord, want de zin in de opstartwaarschuwing luidt "wanneer je
+# ... kiest".
+choose = "de inhoud"
+analytics_extra = """, en geen
+  enkel teken van wat je typt"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Verloopt niet"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Wat je typt kan nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar een
+      wifiwachtwoord verzameld zou kunnen worden, en niets in de code dat het zou
+      versturen als dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Er staat nergens in
+      <code>src/</code> een <code>fetch</code>, een <code>XMLHttpRequest</code>
+      of een <code>sendBeacon</code>. De code wordt met rekenwerk uit de
+      tekenreeks opgebouwd en als svg getekend, in deze pagina, op jouw
+      apparaat."""
+
+[[privacy]]
+title = "De code wijst niet naar ons."
+body = """
+ Wat je typt is wat de code
+      bevat. Verschillende gratis generatoren geven je een code terug met daarin
+      een link naar hun eigen site, die daarna naar de jouwe doorstuurt &mdash;
+      zodat elke scan door hen geteld wordt, en de code stopt met werken op de
+      dag dat zij het domein niet meer betalen of besluiten dat de gratis laag
+      verlopen is. Hier wordt niets ingekort, doorgestuurd of gevolgd: de
+      tekenreeks die op de pagina staat, is de tekenreeks in het plaatje."""
+
+[[privacy]]
+title = "De png wordt gemaakt uit de svg die op het scherm staat."
+body = """
+ De download
+      is geen tweede rendering die het met de voorvertoning oneens zou kunnen
+      zijn. Dezelfde opmaak wordt aan de browser gegeven en op een canvas
+      geschilderd, en dat is ook waarom het kan zonder ergens contact mee te
+      leggen: er is geen lettertype op te halen en geen plaatje in te laden."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google, de doneerknop van Buy Me a Coffee. Geen ervan
+      krijgt iets van wat je typt mee. Elke regel die een tekenreeks in een code
+      verandert, wordt vanaf deze herkomst geserveerd en staat in de
+      repository."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en de tool is
+      onveranderd, want er zat nooit een netwerkstap in. Dat is het eenvoudigste
+      bewijs van allemaal."""
+
+[[howto]]
+title = "Kies het soort code."
+body = """
+ Een qr-code bevat van alles en is
+      waar een telefooncamera naar zoekt, dus dat is het antwoord tenzij iemand
+      je iets anders verteld heeft. Een barcode bevat een nummer, en welke je
+      nodig hebt bepaalt degene die hem gaat scannen &mdash; een winkel wil een
+      EAN-13 of een UPC-A, een verzenddoos een ITF-14, en alles wat intern is, is
+      meestal Code 128."""
+
+[[howto]]
+title = "Zeg wat erin gaat."
+body = """
+ Een link is het gebruikelijke geval, en
+      de vakjes erboven bouwen de andere formaten die telefoons kennen: een
+      wifinetwerk dat aanbiedt zichzelf te verbinden, een visitekaartje dat
+      aanbiedt bewaard te worden, een e-mail, een sms, een telefoonnummer, een
+      plek op de kaart. Wat je ook kiest, de uiteindelijke tekenreeks staat op de
+      pagina &mdash; en dat is alles wat een qr-code ooit bevat."""
+
+[[howto]]
+title = "Kies hoeveel schade hij mag oplopen."
+body = """
+ De vier niveaus stoppen er
+      meer of minder foutcorrectie in, en meer correctie betekent een grotere,
+      dichtere code. L is genoeg voor een scherm, M voor gewoon papier, en H voor
+      iets dat betast, klein gedrukt of in de zon voor een raam geplakt wordt.
+      Een code op een menukaart die elke dag afgenomen wordt, is Q of H waard."""
+
+[[howto]]
+title = "Zet de grootte, de marge en de kleuren."
+body = """
+ De marge hoort bij de code:
+      vier modules stille ruimte eromheen is wat de specificatie vraagt, en die
+      wegknippen is veruit de meest voorkomende reden dat een gedrukte code niet
+      scant. Donker op licht, met echt contrast &mdash; een scanner leest het
+      verschil tussen de twee, dus lichtgrijs op wit gaat niet werken, en licht
+      op donker faalt ronduit bij een flink aantal lezers."""
+
+[[howto]]
+title = "Controleer hem met de telefoon die je hebt."
+body = """
+ Voordat je er duizend
+      afdrukt: scan die op je scherm. Dat kost tien seconden en vangt de hele
+      soort fouten die een voorvertoning niet kan vangen: een wifiwachtwoord met
+      een teken dat ontsnapt moest worden, een link die zijn
+      <code>https://</code> miste, een barcodenummer dat een cijfer tekortkomt."""
+
+[[howto]]
+title = "Neem de svg."
+body = """
+ Dat is de code als instructies in plaats van
+      als pixels, dus hij drukt op elk formaat af zonder zacht te worden, en een
+      zachte rand is precies wat een scanner niet kan onderscheiden. Neem de png
+      er ook bij als datgene waar je in plakt geen svg accepteert; die wordt
+      getekend op een heel aantal pixels per module, dus die heeft ook geen
+      vervaagde randen."""
+
+[[faq]]
+q = "Wordt er iets van wat ik typ ergens heen gestuurd?"
+a = """
+        Nee. Een qr-code is rekenwerk op een tekenreeks, en dat rekenwerk draait
+        in je eigen browser op je eigen apparaat. Deze tool heeft geen enkele
+        netwerkfunctie &mdash; hij haalt nooit iets op en verstuurt nooit iets
+        &mdash; en de <code>Content-Security-Policy</code> van de pagina noemt elk
+        adres dat hij mag benaderen; geen ervan hoort bij deze site. Dat is hier
+        meer waard dan op de meeste pagina's, want wat mensen het vaakst in een
+        qr-code zetten, is het wachtwoord van hun wifi."""
+
+[[faq]]
+q = "Verlopen deze codes, of stoppen ze later met werken?"
+a = """
+        Nee, en dat kan ook niet. Wat je typt is wat de code bevat, dus hem scannen
+        geeft precies die tekenreeks terug, voor altijd. De codes die verlopen zijn
+        die met het adres van iemand anders erin: een &ldquo;dynamische&rdquo;
+        qr-code bevat een link naar de server van de generator, die naar de jouwe
+        doorstuurt, wat betekent dat zij elke scan kunnen tellen, kunnen veranderen
+        waar hij heen gaat, of hem uit kunnen zetten wanneer een proefperiode
+        eindigt. Hier wordt nergens doorheen doorgestuurd."""
+
+[[faq]]
+q = "Is het gratis, en mag ik het commercieel gebruiken?"
+a = """
+        Het is gratis, er is geen account, geen watermerk en geen limiet op hoeveel
+        je er maakt, en je mag het resultaat op een product, een poster of een
+        winkelpui zetten. QR Code is een geregistreerd handelsmerk van Denso Wave,
+        dat verklaard heeft het niet te zullen inzetten tegen mensen die de codes
+        gebruiken &mdash; de specificatie is gepubliceerd als ISO/IEC 18004 en is
+        vrij te implementeren, en dat is wat deze pagina doet. De site draagt
+        advertenties, en die betalen hem."""
+
+[[faq]]
+q = "Welk foutcorrectieniveau moet ik kiezen?"
+a = """
+        M, tenzij je een reden hebt. L maakt de kleinste code en is prima op een
+        scherm; M overleeft gewoon gebruik; Q en H zijn voor een code die klein
+        gedrukt, gelamineerd, op een raam geplakt of deels door een logo bedekt
+        wordt. Elke stap omhoog stopt er meer controlegegevens in, en dat vraagt
+        bij dezelfde hoeveelheid tekst om een groter symbool &mdash; van L naar H
+        gaan verdubbelt ruwweg het aantal modules voor dezelfde tekenreeks."""
+
+[[faq]]
+q = "Hoeveel kan er in een qr-code?"
+a = """
+        Op het grootste formaat, 177 modules in het vierkant, tot 7.089 cijfers,
+        4.296 hoofdletters en cijfers, of 2.953 bytes van al het andere &mdash; en
+        dat is bij de zwakste foutcorrectie; bij de sterkste is het ongeveer een
+        derde daarvan. In de praktijk is de grens niet het formaat maar de scanner:
+        voorbij een paar honderd tekens worden de modules zo klein dat een gewone
+        telefooncamera ze op armlengte niet meer kan onderscheiden. Een lange code
+        is meestal een teken dat er een korte link in hoort."""
+
+[[faq]]
+q = "Waarom is mijn code groter als ik de link in kleine letters schrijf?"
+a = """
+        Omdat een qr-code een modus heeft voor hoofdletters en cijfers die twee
+        tekens in elf bits propt, en zo'n modus niet heeft voor kleine letters, die
+        elk acht bits kosten. Een url geschreven als
+        <code>HTTPS://EXAMPLE.COM/PAGE</code> kan een derde kleiner zijn dan
+        dezelfde url in kleine letters. Het schema en de host zijn
+        hoofdletterongevoelig, dus ze schreeuwen verandert niets behalve de
+        grootte; het pad achter de host is dat niet, dus laat dat met rust."""
+
+[[faq]]
+q = "Kan het een qr-code ook lezen, en niet alleen maken?"
+a = """
+        Nog niet. Er een lezen betekent een afbeelding decoderen &mdash; het
+        symbool in een foto vinden, corrigeren voor de hoek waaronder hij genomen
+        is, en de schade repareren &mdash; en dat is een andere en aanzienlijk
+        grotere klus dan er een tekenen. Het zou hier op dezelfde voorwaarden als
+        al het andere gebouwd kunnen worden, en het staat op de lijst. Ondertussen
+        doet de camera van je telefoon het al, en goed ook."""
+
+[[faq]]
+q = "Waar is de marge voor, en kan ik hem kleiner maken?"
+a = """
+        De witruimte om een qr-code heen hoort bij de code. Een lezer gebruikt hem
+        om te vinden waar het symbool ophoudt, en de specificatie vraagt om vier
+        modules aan elke kant; een barcode wil er zo'n tien. Je kunt hem hier op
+        nul zetten en het plaatje ziet er dan netter uit, en een flink aantal
+        scanners ziet hem dan helemaal niet meer &mdash; zeker tegen een drukke
+        achtergrond. Is ruimte het probleem, maak de code dan kleiner in plaats van
+        zijn marge weg te knippen."""
+
+[[faq]]
+q = "Welke barcode heb ik nodig?"
+a = """
+        Die waar degene die hem scant om vraagt. EAN-13 is de winkelbarcode buiten
+        Noord-Amerika en UPC-A de Noord-Amerikaanse &mdash; voor allebei heb je een
+        nummer nodig dat GS1 aan jou uitgeeft, want het nummer identificeert je
+        bedrijf en niet alleen het product. EAN-8 is de korte versie voor kleine
+        verpakkingen. ITF-14 gaat op de verzenddoos. Code 128 en Code 39 bevatten
+        naast cijfers ook tekst en hebben helemaal geen registratie nodig, wat ze
+        het juiste antwoord maakt voor alles wat intern is: bedrijfsmiddelen,
+        schappen, werkbonnen."""
+
+[[faq]]
+q = "Wat is een controlecijfer, en waarom voegde de tool er een toe?"
+a = """
+        Het is het laatste cijfer van een winkelbarcode, uitgerekend uit de cijfers
+        ervoor, zodat een scanner een misleze van een leze kan onderscheiden.
+        EAN-13 wil twaalf cijfers en rekent het dertiende uit; UPC-A wil er elf en
+        rekent het twaalfde uit. Tik het korte nummer en deze pagina zet het
+        erbij. Tik het volledige nummer en hij controleert het cijfer dat je gaf
+        &mdash; en weigert, in plaats van het stilletjes te corrigeren, want een
+        fout cijfer dat stil hersteld wordt, is een etiket dat scant als het
+        product van iemand anders."""
+
+[[faq]]
+q = "Kan ik een logo midden in een qr-code zetten?"
+a = """
+        Hier niet, maar waarom het elders werkt is het weten waard: de foutcorrectie
+        maakt het mogelijk. Op niveau H mag ruwweg 30% van de modules vernield zijn
+        en is de code nog steeds leesbaar, dus een logo dat wat minder dan dat in
+        het midden bedekt &mdash; waar geen zoekpatroon zit &mdash; is
+        herstelbare schade. Haal de code op niveau H door je beeldbewerker, hou het
+        logo onder ongeveer een vijfde van de oppervlakte, en test het met een
+        echte telefoon in plaats van erop te vertrouwen."""
+
+[[faq]]
+q = "Waarom is de svg beter dan de png?"
+a = """
+        Omdat een code uit randen bestaat, en een png een vast aantal pixels heeft
+        om ze van te maken. Vergroot er een en elke rand wordt zacht; een zachte
+        rand is precies waar een scanner moeite mee heeft, en een printer op 1200
+        dpi die een png van 512 pixels krijgt, wordt gevraagd het verschil te
+        verzinnen. Een svg is de vierkantjes als instructies, dus die drukt scherp
+        af op een visitekaartje of een billboard. De png hier wordt getekend op een
+        heel aantal pixels per module, en dat is het beste wat een png kan doen."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je tekst wegstuurde om er een code van te
+        laten tekenen, zou stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Genereer een qr-code of een streepjescode uit een tekenreeks in de browser. Qr-codes voor links, wifinetwerken, visitekaartjes, e-mail, sms, telefoonnummers en coördinaten, met alle vier de foutcorrectieniveaus; EAN-13-, EAN-8-, UPC-A-, ITF-14-, Interleaved 2 of 5-, Code 128- en Code 39-barcodes met hun controlecijfers. Download als svg of png. Er wordt niets geüpload."
+features = [
+  "Qr-codes in elke versie van 1 tot 40, in numerieke, alfanumerieke en bytemodus",
+  "Alle vier de foutcorrectieniveaus, met hardop gezegd wat elk ervan kost",
+  "Kant-en-klare formaten: wifinetwerk, visitekaartje, e-mail, sms, telefoonnummer, plek op de kaart",
+  "Toont de exacte tekenreeks die de code gaat bevatten, in plaats van hem te verbergen",
+  "EAN-13, EAN-8 en UPC-A, met het controlecijfer uitgerekend of gecontroleerd",
+  "ITF-14 en Interleaved 2 of 5 voor dozen en magazijnwerk",
+  "Code 128 met automatisch gebruik van zijn numerieke modus, en Code 39 met een optioneel controleteken",
+  "Leesbare cijfers onder een barcode gedrukt, op de juiste plekken",
+  "Svg eruit, dus het drukt scherp af op elk formaat, en een png getekend op hele pixels per module",
+  "Twee kleuren naar keuze, of helemaal geen achtergrond",
+  "Stuurt nooit door: geen korte link, geen tracking, niets dat kan verlopen",
+  "Draait offline; geen upload, geen account",
+]

--- a/locales/nl/tools/resize-image.html
+++ b/locales/nl/tools/resize-image.html
@@ -1,0 +1,282 @@
+<main>
+  <!-- Stap 1 &mdash; de bestanden -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies afbeeldingen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alles van de lijst halen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; de bijsnijding -->
+  <section class="card" id="crop-card">
+    <h2><span class="step">2</span> Snijd bij, als je dat wilt</h2>
+
+    <p class="card-lede">
+      Het kader begint op het hele plaatje, dus deze stap met rust laten snijdt
+      niets bij. Elke afbeelding houdt zijn eigen kader &mdash; kies er een uit
+      de lijst hierboven om erop te tekenen. Bijsnijden gebeurt vóór schalen, en
+      dat is de enige volgorde die hout snijdt: een plaatje dat pas na het
+      krimpen wordt teruggesneden, heeft de pixels die het nodig had al
+      weggegooid.
+    </p>
+
+    <p id="crop-empty" class="field-summary">Voeg een afbeelding toe en het kader verschijnt hier.</p>
+
+    <div id="crop-controls" hidden>
+      <p class="stage-hint">
+        <span id="stage-name" class="stage-name"></span>
+        Sleep binnen het kader om het te verplaatsen, of aan een hoek om het
+        formaat te wijzigen. Met het kader geselecteerd verschuiven de pijltjes
+        het een pixel tegelijk, wijzigt <kbd>Alt</kbd>&nbsp;+&nbsp;pijltjes het
+        formaat, en maakt <kbd>Shift</kbd> ingedrukt houden elke stap tien.
+      </p>
+
+      <!-- The crop box itself is added here by src/cropper.js. The stage is
+           given the picture's own shape, so the box can be positioned in
+           percentages and needs no recalculating when the window is resized. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <p id="stage-note" class="stage-note" hidden></p>
+
+      <div class="crop-controls">
+        <div class="aspect-row" id="aspect-row" role="group" aria-label="Het kader op een vorm vastzetten">
+          <button type="button" data-aspect="free" class="active">Vrij</button>
+          <button type="button" data-aspect="source">Origineel</button>
+          <button type="button" data-aspect="1:1">1:1</button>
+          <button type="button" data-aspect="4:5">4:5</button>
+          <button type="button" data-aspect="9:16">9:16</button>
+          <button type="button" data-aspect="16:9">16:9</button>
+          <button type="button" data-aspect="4:3">4:3</button>
+          <button type="button" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="ghost" title="Zet de vaste vorm op zijn kant">
+            Omdraaien
+          </button>
+        </div>
+
+        <div class="numbers">
+          <label>Links<input type="number" id="crop-x" min="0" step="1"></label>
+          <label>Boven<input type="number" id="crop-y" min="0" step="1"></label>
+          <label>Breedte<input type="number" id="crop-w" min="8" step="1"></label>
+          <label>Hoogte<input type="number" id="crop-h" min="8" step="1"></label>
+          <div class="number-actions">
+            <button type="button" id="crop-max" class="ghost">Grootst</button>
+            <button type="button" id="crop-centre" class="ghost">Midden</button>
+            <button type="button" id="crop-reset" class="ghost">Hele plaatje</button>
+          </div>
+        </div>
+
+        <!--
+          Every image keeps its own box, which is the point. This is for the
+          case that is still worth one click: a folder of exports that all want
+          the same framing.
+        -->
+        <div class="apply-row" id="apply-row" hidden>
+          <button type="button" id="crop-apply-all" class="ghost">Deze uitsnede op elke afbeelding gebruiken</button>
+          <p class="hint-line" id="apply-note"></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Stap 3 &mdash; het formaat -->
+  <section class="card" id="resize-card">
+    <h2><span class="step">3</span> Zeg hoe groot het moet worden</h2>
+
+    <div class="option-row">
+      <label for="resize-mode">Stel het formaat in met</label>
+      <select id="resize-mode">
+        <option value="pixels" selected>Breedte en hoogte, in pixels</option>
+        <option value="longest">De langste zijde</option>
+        <option value="percent">Een percentage van wat het nu is</option>
+        <option value="none">Niets &mdash; laat het formaat precies zoals het is</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="pixels-fields">
+      <div class="numbers">
+        <label>Breedte<input type="number" id="size-w" min="1" step="1" placeholder="auto" value="1920"></label>
+        <label>Hoogte<input type="number" id="size-h" min="1" step="1" placeholder="auto"></label>
+        <div class="number-actions">
+          <button type="button" id="swap-size" class="ghost">Omdraaien</button>
+        </div>
+      </div>
+
+      <!--
+        Leaving one of them blank is the common case and the one worth
+        supporting properly: "1920 wide, whatever tall that makes it" needs no
+        decision about shapes at all.
+      -->
+      <p class="hint-line">
+        Vul er één in en laat de andere leeg om de eigen verhouding van het plaatje te houden.
+      </p>
+
+      <div class="presets" id="size-presets" role="group" aria-label="Veelvoorkomende formaten">
+        <button type="button" class="ghost" data-w="1920" data-h="1080">1920 &times; 1080</button>
+        <button type="button" class="ghost" data-w="1280" data-h="720">1280 &times; 720</button>
+        <button type="button" class="ghost" data-w="1080" data-h="1080">1080 &times; 1080</button>
+        <button type="button" class="ghost" data-w="600" data-h="">600 breed</button>
+      </div>
+
+      <div class="option-row" id="fit-row">
+        <label for="fit">Als de verhoudingen niet kloppen</label>
+        <select id="fit">
+          <option value="contain" selected>Binnen passen &mdash; het hele plaatje, één zijde komt korter uit</option>
+          <option value="cover">Vullen &mdash; precies dit formaat, met de overloop eraf</option>
+          <option value="pad">Opvullen &mdash; precies dit formaat, met een achtergrond eromheen</option>
+          <option value="stretch">Uitrekken &mdash; precies dit formaat, en de verhouding vervormd</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Langste zijde<input type="number" id="size-longest" min="1" step="1" value="1920"></label>
+      </div>
+      <p class="hint-line">
+        Welke zijde de langste is wordt dit, en de andere volgt. Staande en
+        liggende foto's in dezelfde stapel komen er allemaal even groot op hun
+        lange zijde uit, en dat is wat een galerij meestal wil.
+      </p>
+      <div class="presets" id="longest-presets" role="group" aria-label="Veelvoorkomende lange zijden">
+        <button type="button" class="ghost" data-longest="640">640</button>
+        <button type="button" class="ghost" data-longest="1280">1280</button>
+        <button type="button" class="ghost" data-longest="1920">1920</button>
+        <button type="button" class="ghost" data-longest="2560">2560</button>
+      </div>
+    </div>
+
+    <div class="size-fields" id="percent-fields" hidden>
+      <div class="numbers">
+        <label>Procent<input type="number" id="size-percent" min="1" max="1000" step="1" value="50"></label>
+      </div>
+      <div class="presets" id="percent-presets" role="group" aria-label="Veelvoorkomende percentages">
+        <button type="button" class="ghost" data-percent="25">25%</button>
+        <button type="button" class="ghost" data-percent="50">50%</button>
+        <button type="button" class="ghost" data-percent="75">75%</button>
+        <button type="button" class="ghost" data-percent="200">200%</button>
+      </div>
+    </div>
+
+    <label class="check" id="enlarge-row">
+      <input type="checkbox" id="no-enlarge" checked>
+      <span>
+        <strong>Maak een plaatje nooit groter dan het begon</strong>
+        <span class="check-note">
+          Vergroten verzint pixels die nooit gefotografeerd zijn, dus een klein
+          plaatje in een groot kader komt er zacht uit in plaats van gedetailleerd.
+          Met dit aan blijft alles wat al kleiner is dan het gevraagde formaat op
+          zijn eigen formaat staan.
+        </span>
+      </span>
+    </label>
+
+    <p id="size-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Stap 4 &mdash; het bestandstype, en de ene klik -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Sla het op</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Bestandstype</label>
+        <select id="format">
+          <option value="keep" selected>Hou het formaat waarin elk bestand binnenkwam</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/png">PNG</option>
+          <option value="image/webp">WebP</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kwaliteit &mdash; <output id="quality-value" for="quality">85</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="85">
+        <p class="field-note">
+          Alleen JPEG en WebP; PNG heeft geen kwaliteitsknop. Bij 85 houdt het
+          voor de meeste mensen op zichtbaar te zijn. Onder ongeveer 60 gaan de
+          vlakke gebieden banden vertonen.
+        </p>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Achtergrond</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Wat er doorheen komt waar het plaatje niet is: achter een opgevuld
+          kader, en achter transparantie wanneer het uitvoerformaat geen
+          alfakanaal heeft.
+        </p>
+      </div>
+    </div>
+
+    <p id="plan-summary" class="field-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>De afbeeldingen schalen</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Klaar</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Alles als zip downloaden</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The big look at one result. A <dialog> opened with showModal() rather than
+    a div pretending to be one: the browser gives the focus trap, the Escape
+    key and the inert background for nothing, and gets all three right.
+
+    Both pictures in it are object URLs made on this page - the result, and the
+    original that was already decoded for the thumbnail. Opening this fetches
+    nothing and decodes nothing that was not already decoded.
+  -->
+  <dialog id="viewer" class="viewer" aria-labelledby="viewer-name">
+    <div class="viewer-head">
+      <h2 id="viewer-name" class="viewer-name"></h2>
+      <button type="button" id="viewer-close" class="ghost" aria-label="Sluiten">Sluiten</button>
+    </div>
+
+    <div class="viewer-stage">
+      <img id="viewer-image" alt="">
+    </div>
+
+    <p id="viewer-caption" class="viewer-caption"></p>
+
+    <dl class="viewer-facts" id="viewer-facts"></dl>
+
+    <div class="viewer-actions">
+      <button type="button" id="viewer-compare" class="ghost" aria-pressed="false">Toon het origineel</button>
+      <a id="viewer-download" class="primary as-button" download>Downloaden</a>
+    </div>
+  </dialog>
+</main>

--- a/locales/nl/tools/resize-image.toml
+++ b/locales/nl/tools/resize-image.toml
@@ -1,0 +1,282 @@
+#
+# Afbeeldingsformaat wijzigen - Dutch.
+#
+# Overrides for tools/resize-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Afbeeldingsformaat wijzigen"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Afbeeldingsformaat&nbsp;wijzigen <span class=\"h1-kw\">&mdash; schalen, bijsnijden, omzetten</span>"
+tagline = "Noem het formaat. Sleep het kader. Kies het bestandstype."
+
+title = "Een afbeelding schalen &mdash; ook bijsnijden en omzetten, zonder uploaden"
+description = "Schaal, snijd bij en zet JPEG-, PNG- en WebP-afbeeldingen om in je browser. Exacte pixels, een percentage of een lange zijde - één afbeelding of een hele map. Er wordt niets geüpload."
+og_title = "Een afbeelding schalen, bijsnijden en omzetten zonder hem te uploaden"
+og_description = "Zet het formaat in pixels of als percentage, sleep een bijsnijdkader, wijzig het bestandstype - voor één plaatje of een hele stapel. Het draait allemaal op je eigen apparaat."
+og_image_alt = "Afbeeldingsformaat wijzigen - schalen, bijsnijden en omzetten zonder uploaden"
+
+pledge = """
+    Het schalen, het bijsnijden en het wijzigen van het bestandstype gebeuren
+    alle drie in je eigen browser, op je eigen hardware, met de
+    beeldencoders die hij toch al meelevert. Deze tool heeft geen enkele
+    netwerkfunctie &mdash; niets op te halen, niets te versturen &mdash; en er
+    staat aan de andere kant van deze pagina geen server om een plaatje heen te
+    sturen, ook al was er een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en schaal een foto. Geen enkel verzoek draagt een afbeelding, een
+      miniatuur, een bestandsnaam of één byte van wat je koos. Of trek de stekker
+      uit het internet en schaal er toch een."""
+
+read_first = """
+, <code>src/geometry.js</code> voor het rekenwerk dat
+      bepaalt wat er blijft en hoe groot het eruit komt, en
+      <code>src/codecs.js</code> voor de ene <code>drawImage</code>-aanroep die
+      het bijsnijden en het schalen tegelijk doet."""
+
+howto_heading = "Een afbeelding schalen zonder hem te uploaden"
+
+card = """
+            Exacte pixels, een percentage of een lange zijde &mdash; met onderweg
+            een bijsnijdkader en een wijziging van het bestandstype. Eén plaatje
+            of een hele map."""
+
+[words]
+plural = "afbeeldingen"
+choose = "een afbeelding"
+analytics_extra = """, en ook geen van de
+  formaten, uitsnedes of bestandstypen die deze tool uitrekent"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Je afbeeldingen kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestanden
+      verzameld zouden kunnen worden, en niets in de code dat ze zou versturen
+      als dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Er staat nergens in
+      <code>src/</code> een <code>fetch</code>, een <code>XMLHttpRequest</code>
+      of een <code>sendBeacon</code>. Het schalen is één
+      <code>drawImage</code> op een canvas en één <code>canvas.toBlob</code>
+      &mdash; de schaler en de encoder die al in je browser zitten."""
+
+[[privacy]]
+title = "Een bestand waar niemand om wijziging vroeg, wordt niet gewijzigd."
+body = """
+ Zonder bijsnijden, zonder
+      schalen en zonder wijziging van het bestandstype krijg je het bestand dat je
+      koos byte voor byte terug in plaats van opnieuw opgeslagen. Dat is niet
+      alleen beleefdheid: het is waarom deze tool niet stilletjes een plaatje kan
+      hercoderen, of stilletjes de metagegevens kan weglaten van iets waar je
+      alleen naar wilde kijken."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google, de doneerknop van Buy Me a Coffee. Geen ervan
+      krijgt iets over je plaatjes mee. Elke regel die een bestand leest,
+      bijsnijdt, schaalt of schrijft, wordt vanaf deze herkomst geserveerd en
+      staat in de repository."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en de tool is
+      onveranderd, want er zat nooit een netwerkstap in. Dat is het eenvoudigste
+      bewijs van allemaal."""
+
+[[howto]]
+title = "Kies je afbeeldingen."
+body = """
+ Sleep ze op het keuzevak of kies ze
+      met de hand. De browser leest ze rechtstreeks van je schijf; er wordt
+      daarbij niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Snijd bij, als je dat wilt."
+body = """
+ Het kader begint op het hele
+      plaatje, dus het met rust laten snijdt niets bij. Sleep het, of zet het vast
+      op een vorm &mdash; 1:1 voor een profielfoto, 9:16 voor een verhaal, 16:9
+      voor een miniatuur &mdash; en druk op &ldquo;Grootst&rdquo; voor het grootste
+      dat erin past. Elke afbeelding houdt zijn eigen kader: klik op een regel in
+      de lijst om op die te tekenen. Moeten ze allemaal hetzelfde ingekaderd
+      worden, dan doet één knop dat ook."""
+
+[[howto]]
+title = "Zeg welk formaat eruit moet komen."
+body = """
+ Een breedte, een hoogte,
+      of allebei; een lange zijde, waardoor staande en liggende foto's even groot
+      worden; of gewoon een percentage. Laat een van de twee vakjes leeg en het
+      plaatje houdt zijn eigen verhouding."""
+
+[[howto]]
+title = "Kies het bestandstype en druk op de knop."
+body = """
+ Hou waar elk bestand
+      mee binnenkwam, of schrijf alles als JPEG, PNG of WebP. Elk resultaat zegt
+      wat het geworden is en hoeveel kleiner het werd; klik erop om het op volle
+      grootte te openen met alle cijfers erachter, en het origineel ernaast om
+      tegen af te zetten. Een stapel komt binnen als één zip."""
+
+[[faq]]
+q = "Wordt mijn afbeelding ergens heen geüpload?"
+a = """
+        Nee. Het bestand wordt gedecodeerd, bijgesneden, geschaald en geschreven
+        door je eigen browser op je eigen hardware, met de JPEG-, PNG- en
+        WebP-encoders die de browser al meelevert. Deze tool heeft geen enkele
+        netwerkfunctie &mdash; hij haalt nooit iets op en verstuurt nooit iets
+        &mdash; en de <code>Content-Security-Policy</code> van de pagina noemt elk
+        adres dat hij mag benaderen; geen ervan hoort bij deze site."""
+
+[[faq]]
+q = "Wat gebeurt er als ik wel een breedte maar geen hoogte opgeef?"
+a = """
+        De hoogte volgt uit de eigen verhouding van het plaatje, en dat is vrijwel
+        altijd wat bedoeld werd: &ldquo;1920 breed&rdquo; betekent &ldquo;1920 breed
+        en zo hoog als dat uitkomt&rdquo;. Vul je allebei in, dan kunnen de twee het
+        oneens zijn met de verhouding van het plaatje, en dat is het enige moment
+        waarop de keuze &ldquo;als de verhoudingen niet kloppen&rdquo; verschijnt
+        &mdash; binnen passen, vullen en de overloop afsnijden, opvullen met een
+        achtergrond, of uitrekken en de vervorming accepteren."""
+
+[[faq]]
+q = "Kost schalen kwaliteit?"
+a = """
+        Een plaatje kleiner maken niet, op geen enkele zichtbare manier: er gaan
+        meer pixels in dan eruit komen, dus het detail dat blijft is echt detail.
+        Er een groter maken kan niet toevoegen wat nooit gefotografeerd is &mdash;
+        het resultaat is een zachtere kopie van hetzelfde plaatje, geen scherpere
+        &mdash; en daarom staat &ldquo;maak een plaatje nooit groter dan het
+        begon&rdquo; standaard aan. Wat wel een beetje kost, is het hercoderen
+        daarna, als het formaat JPEG of WebP is, en de kwaliteitsschuif is wat je
+        daar uitgeeft."""
+
+[[faq]]
+q = "Kan ik elke afbeelding anders bijsnijden?"
+a = """
+        Ja &mdash; dat is de standaard. Elke afbeelding op de lijst draagt zijn
+        eigen kader, in zijn eigen pixels, en op een regel klikken zet die
+        afbeelding in de voorvertoning met zijn eigen kader en zijn eigen vaste vorm
+        er weer op. Wat je met de een doet, raakt de ander niet. Elk kader begint
+        ook op het hele plaatje, dus een afbeelding waarop je nooit tekent, wordt
+        helemaal niet bijgesneden."""
+
+[[faq]]
+q = "Kan het een hele stapel in één keer hetzelfde bijsnijden?"
+a = """
+        Ja, met de knop onder de voorvertoning. Die geeft elke andere afbeelding
+        hetzelfde relatieve gebied &mdash; dezelfde breuken van zijn eigen breedte
+        en hoogte &mdash; wat voor een set schermafbeeldingen of exports die
+        allemaal even groot zijn precies hetzelfde kader is, en de pagina zegt dat
+        ook. Met een vaste vorm geeft hij elk het grootste kader van die vorm binnen
+        dat gebied, dus 1:1 indrukken en dan die knop levert je vierkanten uit een
+        map met gemengd staande en liggende foto's. Elk kader blijft daarna
+        bewerkbaar."""
+
+[[faq]]
+q = "Welke formaten kan het lezen en schrijven?"
+a = """
+        Het leest alles wat je browser kan decoderen, in de praktijk dus JPEG, PNG,
+        WebP, GIF, BMP en &mdash; in de meeste huidige browsers &mdash; AVIF. Het
+        schrijft JPEG, PNG en WebP, want dat zijn de encoders die browsers
+        meeleveren. Op &ldquo;hou het formaat&rdquo; blijft een JPEG een JPEG en een
+        PNG een PNG; alles wat de browser niet kan schrijven, zoals een GIF of een
+        BMP, komt eruit als PNG, en dat is degene die transparantie en vlakke kleur
+        intact houdt."""
+
+[[faq]]
+q = "Wat gebeurt er met transparantie als ik als JPEG opsla?"
+a = """
+        Die wordt met de achtergrondkleur opgevuld, want JPEG heeft geen alfakanaal
+        om hem in op te slaan. De kleur kies je zelf en begint op wit, wat de
+        meeste mensen willen en wat vrijwel elke andere tool doet zonder het je te
+        vertellen. Dezelfde kleur wordt gebruikt achter een opgevuld kader. Sla in
+        plaats daarvan op als PNG of WebP en de transparantie komt onaangeroerd
+        door."""
+
+[[faq]]
+q = "Haalt het EXIF- en gps-gegevens eruit?"
+a = """
+        Bij alles wat het werkelijk verwerkt wel, als bijwerking: bijsnijden of
+        schalen betekent het plaatje decoderen tot pixels en die pixels opnieuw
+        coderen, en een canvas vol pixels draagt geen tags, dus de locatie, het
+        cameramodel en de tijdstempels worden domweg niet in het nieuwe bestand
+        geschreven. Een bestand dat je helemaal niet wijzigt, is een ander geval
+        &mdash; dat krijg je byte voor byte terug, tags en al. Wil je de
+        metagegevens weg maar het plaatje onaangeroerd, gebruik dan de
+        <a href="../exif-gegevens-verwijderen/">EXIF-lezer &amp; -wisser</a>, die
+        de container herschrijft zonder ook maar iets opnieuw te comprimeren."""
+
+[[faq]]
+q = "Hoe verschilt dit van de afbeeldingscompressor?"
+a = """
+        Deze gaat over afmetingen: je zegt hoeveel pixels je wilt en je krijgt die.
+        De <a href="../afbeelding-comprimeren/">Afbeeldingscompressor</a> gaat over
+        bestandsgrootte: je zegt hoeveel kilobytes je mag hebben en hij zoekt de
+        hoogste kwaliteit die daarin past, en schaalt alleen wanneer kwaliteit
+        alleen er niet komt. Is je gezegd &ldquo;1200 pixels breed&rdquo;, dan zit
+        je hier goed. Is je gezegd &ldquo;onder 500 kB&rdquo;, dan brengt de andere
+        je dichterbij."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. Er is ook geen limiet op het aantal of de grootte van de
+        bestanden, want er is geen server die ervoor betaalt &mdash; het werk
+        gebeurt op je eigen apparaat. De site draagt advertenties, en die betalen
+        hem; de advertenties krijgen niets over je afbeeldingen mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je afbeeldingen wegstuurde om ze te schalen,
+        zou stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Schaal, snijd bij en zet JPEG-, PNG- en WebP-afbeeldingen om in de browser. Zet een exact pixelformaat, een percentage of een lange zijde, sleep een bijsnijdkader of zet het vast op een vorm, en schrijf het resultaat als JPEG, PNG of WebP. Hele stapels kunnen, en er wordt niets geüpload."
+features = [
+  "Schalen op exacte pixels, op een lange zijde, of op een percentage",
+  "Vul één zijde in en de andere volgt de eigen verhouding van het plaatje",
+  "Binnen passen, vullen en bijsnijden, opvullen tot een exact kader, of uitrekken",
+  "Een sleepbaar bijsnijdkader per afbeelding, vast te zetten op 1:1, 4:5, 9:16, 16:9, 4:3 of 3:2",
+  "Snijdt elke afbeelding anders bij, of legt met één klik één inkadering over de hele stapel",
+  "Opent elk klaargekomen plaatje op volle grootte, met alle cijfers erachter en het origineel om tegen af te zetten",
+  "Zet om tussen JPEG, PNG en WebP, met een kwaliteitsregelaar en een achtergrondkleur",
+  "Vergroot een plaatje nooit tenzij je erom vraagt",
+  "Geeft elk bestand dat het niet hoefde te wijzigen onaangeroerd terug",
+  "Verwerkt hele stapels, met alle resultaten in één zip",
+  "Draait offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep afbeeldingen hierheen"
+hint = "of klik om te bladeren &mdash; JPEG, PNG, WebP en al het andere dat je browser kan openen"

--- a/locales/nl/tools/svg-to-image.html
+++ b/locales/nl/tools/svg-to-image.html
@@ -1,0 +1,209 @@
+<main>
+  <!-- Stap 1 &mdash; de bestanden -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies de svg-bestanden</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alles van de lijst halen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; het formaat -->
+  <section class="card" id="size-card">
+    <h2><span class="step">2</span> Zeg hoe groot het moet worden</h2>
+
+    <p class="card-lede">
+      Dit is de ene vraag die een vector niet voor je kan beantwoorden. In een
+      svg zitten geen pixels &mdash; er zitten tekeninstructies in, en die volgt
+      hij op elk formaat dat je noemt. Het getal hieronder is geen grens waar je
+      tegenaan duwt, zoals dat bij een foto zou zijn; 4000 pixels uit een icoon
+      van 24&nbsp;pixels is precies zo scherp als die 24 was.
+    </p>
+
+    <div class="option-row">
+      <label for="size-mode">Stel het formaat in met</label>
+      <select id="size-mode">
+        <option value="scale" selected>Een factor van het formaat dat het bestand vraagt</option>
+        <option value="width">Breedte in pixels</option>
+        <option value="height">Hoogte in pixels</option>
+        <option value="longest">De langste zijde</option>
+        <option value="box">Een kader, met beide zijden erbij</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="scale-fields">
+      <div class="numbers">
+        <label>Vermenigvuldig met<input type="number" id="size-scale" min="0.01" max="200" step="0.5" value="4"></label>
+      </div>
+      <div class="presets" id="scale-presets" role="group" aria-label="Veelvoorkomende factoren">
+        <button type="button" class="ghost" data-scale="1">1&times;</button>
+        <button type="button" class="ghost" data-scale="2">2&times;</button>
+        <button type="button" class="ghost" data-scale="4">4&times;</button>
+        <button type="button" class="ghost" data-scale="8">8&times;</button>
+        <button type="button" class="ghost" data-scale="16">16&times;</button>
+      </div>
+      <p class="hint-line">
+        Elk bestand op de lijst wordt vanaf zijn eigen formaat vermenigvuldigd,
+        dus een stapel iconen die op verschillende formaten getekend zijn, blijft
+        onderling in verhouding.
+      </p>
+    </div>
+
+    <div class="size-fields" id="width-fields" hidden>
+      <div class="numbers">
+        <label>Breedte<input type="number" id="size-width" min="1" step="1" value="1024"></label>
+      </div>
+      <div class="presets" id="width-presets" role="group" aria-label="Veelvoorkomende breedtes">
+        <button type="button" class="ghost" data-width="256">256</button>
+        <button type="button" class="ghost" data-width="512">512</button>
+        <button type="button" class="ghost" data-width="1024">1024</button>
+        <button type="button" class="ghost" data-width="2048">2048</button>
+      </div>
+      <p class="hint-line">De hoogte volgt uit de vorm van de tekening.</p>
+    </div>
+
+    <div class="size-fields" id="height-fields" hidden>
+      <div class="numbers">
+        <label>Hoogte<input type="number" id="size-height" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">De breedte volgt uit de vorm van de tekening.</p>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Langste zijde<input type="number" id="size-longest" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">
+        Welke zijde de langste is wordt dit en de andere volgt, dus een breed
+        logo en een hoog logo komen er even groot op hun lange zijde uit.
+      </p>
+    </div>
+
+    <div class="size-fields" id="box-fields" hidden>
+      <div class="numbers">
+        <label>Breedte<input type="number" id="box-width" min="1" step="1" value="1200"></label>
+        <label>Hoogte<input type="number" id="box-height" min="1" step="1" value="630"></label>
+      </div>
+      <div class="option-row">
+        <label for="box-fit">Als de tekening een andere vorm heeft</label>
+        <select id="box-fit">
+          <option value="fit" selected>Binnen passen &mdash; de hele tekening, één zijde komt korter uit</option>
+          <option value="pad">Opvullen &mdash; precies dit formaat, met de achtergrond aan weerszijden</option>
+          <option value="stretch">Uitrekken &mdash; precies dit formaat, en de vorm vervormd</option>
+        </select>
+      </div>
+    </div>
+
+    <!--
+      The one thing people rasterise a vector for more than once: the same
+      drawing at 1x, 2x and 3x for a screen with more device pixels than CSS
+      pixels. Multiplied from the plan above rather than planned again, so an
+      @2x is exactly twice its @1x and cannot drift by a rounded pixel.
+    -->
+    <div class="option-row" id="density-row">
+      <label for="density">Schrijf ook de hi-dpi-kopieën</label>
+      <select id="density">
+        <option value="1" selected>Nee &mdash; één bestand per tekening</option>
+        <option value="2">Ook @2x &mdash; voor een Retina-scherm</option>
+        <option value="3">@2x en @3x &mdash; de volledige set die een telefoon vraagt</option>
+      </select>
+    </div>
+
+    <p id="size-summary" class="field-summary"></p>
+    <p id="size-warning" class="field-summary warn" hidden></p>
+  </section>
+
+  <!-- Stap 3 &mdash; het bestandstype -->
+  <section class="card" id="format-card">
+    <h2><span class="step">3</span> Kies het bestandstype</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Bestandstype</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; houdt transparantie, exacte randen</option>
+          <option value="image/jpeg">JPEG &mdash; geen transparantie, kleinere foto's</option>
+          <option value="image/webp">WebP &mdash; transparantie én een kleiner bestand</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Kwaliteit &mdash; <output id="quality-value" for="quality">90</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="90">
+        <p class="field-note">
+          Alleen JPEG en WebP; PNG heeft geen kwaliteitsknop omdat het verliesloos
+          is. Vlakke kleur en harde randen &mdash; en daar bestaat een svg vooral
+          uit &mdash; zijn precies waar een verliesgevende encoder het slechtst
+          mee omgaat, dus staat deze hier hoger dan bij een foto.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="background-mode">Achtergrond</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparant</option>
+          <option value="colour">Een kleur</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Achtergrondkleur" hidden>
+        <p class="field-note" id="background-note"></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Stap 4 &mdash; bekijken, dan meenemen -->
+  <section class="card" id="run-card">
+    <h2><span class="step">4</span> Bekijk het, en sla het dan op</h2>
+
+    <p class="card-lede">
+      De voorvertoning wordt getekend door dezelfde code die het bestand
+      schrijft, uit het bestand dat je koos, op dit apparaat. Waar het de moeite
+      waard is op te letten, zijn de twee dingen die veranderen wanneer een
+      tekening pixels wordt: een haarlijn die een halve pixel breed was en grijs
+      geworden is, en tekst, die getekend wordt in een lettertype dat dit
+      apparaat heeft in plaats van een dat van het web gehaald wordt.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-stage">
+        <canvas id="preview-canvas"></canvas>
+      </div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <p id="preview-empty" class="field-summary">Voeg een svg toe en hij verschijnt hier.</p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Rasteren</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Klaar</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Alles als zip downloaden</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/svg-to-image.toml
+++ b/locales/nl/tools/svg-to-image.toml
@@ -1,0 +1,325 @@
+#
+# SVG naar afbeelding - Dutch.
+#
+# Overrides for tools/svg-to-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "SVG naar afbeelding"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "SVG&nbsp;naar&nbsp;afbeelding <span class=\"h1-kw\">&mdash; een vector op elk formaat naar png, jpeg of WebP</span>"
+tagline = "Noem het formaat. Een vector heeft er zelf geen om te verliezen."
+
+title = "SVG naar PNG &mdash; een vector op elk formaat rasteren, zonder uploaden"
+description = "Zet een svg om naar png, jpeg of WebP op elk formaat, in je browser. Noem de breedte, een factor of een kader; krijg er @2x- en @3x-kopieën bij. Transparantie blijft, er wordt niets geüpload."
+og_title = "Van een svg een png maken op elk formaat, zonder hem te uploaden"
+og_description = "Een vector heeft zelf geen pixelformaat, dus het getal kies jij - 32 of 8000, en even scherp hoe dan ook. Het draait allemaal op je eigen apparaat."
+og_image_alt = "SVG naar afbeelding - een vector op elk formaat naar png, jpeg of WebP rasteren"
+
+pledge = """
+    Het tekenwerk wordt gerasterd door dezelfde motor die het zojuist op je
+    scherm zette. Je bestand wordt van je schijf gelezen, zijn worteltag wordt
+    naar het gevraagde formaat herschreven door honderd regels in
+    <code>src/svg.js</code> die je kunt lezen, en het wordt op een canvas
+    getekend dat je browser toch al meelevert. Deze tool heeft geen enkele
+    netwerkfunctie &mdash; niets op te halen, niets te versturen &mdash; en er
+    staat aan de andere kant van deze pagina geen server om een logo heen te
+    sturen, ook al was er een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en raster iets. Geen enkel verzoek draagt een bestand, een miniatuur,
+      een bestandsnaam of één byte van wat je koos. Of trek de stekker uit het
+      internet en zet er toch een om."""
+
+read_first = """
+, <code>src/svg.js</code> voor hoe het eigen
+      formaat van een bestand gelezen wordt en hoe zijn worteltag herschreven
+      wordt, en <code>src/render.js</code> voor de acht regels die het rasteren
+      doen &mdash; een &lt;img&gt;, een <code>drawImage</code> en een
+      <code>toBlob</code>, met niets ertussen."""
+
+howto_heading = "Een svg naar een png omzetten zonder hem te uploaden"
+
+card = """
+            Een svg heeft zelf geen pixelformaat, dus het getal kies jij &mdash;
+            32 of 8000, en even scherp hoe dan ook."""
+
+[words]
+plural = "svg-bestanden"
+choose = "een svg"
+analytics_extra = """, en ook geen van de
+  formaten, bestandstypen of bestandsnamen die deze tool uitrekent"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Je tekenwerk kan nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestanden
+      verzameld zouden kunnen worden, en niets in de code dat ze zou versturen
+      als dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Er staat nergens in
+      <code>src/</code> een <code>fetch</code>, een <code>XMLHttpRequest</code>
+      of een <code>sendBeacon</code>. De hele rasteraar is een
+      <code>&lt;img&gt;</code> met een blob van je eigen bestand erin, één
+      <code>drawImage</code> op een canvas, en één
+      <code>canvas.toBlob</code>."""
+
+[[privacy]]
+title = "Een svg is een document, en dit is de modus waarin het niets kan doen."
+body = """
+ Een svg kan een
+      <code>&lt;script&gt;</code>, een externe
+      <code>&lt;image href=&quot;https://&hellip;&quot;&gt;</code>, een
+      stylesheet en een weblettertype meedragen. Getekend via een
+      <code>&lt;img&gt;</code> zit hij in wat de specificatie <em>secure static
+      mode</em> noemt: het script draait niet en geen van die adressen wordt
+      opgehaald. Dat is een garantie van de browser, geen belofte van ons, en het
+      is de reden dat deze pagina een bestand kan openen dat ze nooit gezien
+      heeft zonder dat het bestand naar huis kan bellen."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google, de doneerknop van Buy Me a Coffee. Geen ervan
+      krijgt iets over je tekening mee. Elke regel die een bestand leest, op
+      formaat zet of tekent, wordt vanaf deze herkomst geserveerd en staat in de
+      repository."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en de tool is
+      onveranderd, want er zat nooit een netwerkstap in. Dat is het eenvoudigste
+      bewijs van allemaal."""
+
+[[howto]]
+title = "Kies de svg."
+body = """
+ Sleep er een op het keuzevak, of kies een
+      map vol en zet ze in één keer om. De browser leest het bestand
+      rechtstreeks van je schijf; er wordt daarbij niets ergens heen gestuurd.
+      Elke regel zegt welk formaat het bestand denkt te hebben &mdash; en zegt
+      dat anders wanneer dat formaat uit zijn <code>viewBox</code> kwam, of
+      aangenomen is omdat het bestand er geen opgeeft."""
+
+[[howto]]
+title = "Zeg hoe groot."
+body = """
+ Een factor van het eigen formaat van het
+      bestand is het snelste antwoord en het juiste voor een stapel: elke
+      tekening wordt vanaf zijn eigen beginpunt geschaald, dus een set iconen
+      blijft onderling in verhouding. Noem anders een breedte, een hoogte, de
+      langste zijde, of een kader met beide zijden erbij. Een groot getal kost
+      hier niets, anders dan bij een foto &mdash; de tekening wordt op dat
+      formaat opnieuw getekend, niet ernaartoe uitgerekt."""
+
+[[howto]]
+title = "Voeg de hi-dpi-kopieën toe als je ze nodig hebt."
+body = """
+ Een telefoon en een
+      Retina-laptop tekenen twee of drie apparaatpixels per CSS-pixel, dus een
+      logo van 200 pixels heeft een bestand van 400 of 600 pixels achter zich
+      nodig. Vraag om <code>@2x</code> en <code>@3x</code> en ze komen eruit met
+      de namen die Xcode, het gereedschap van Android en CSS
+      <code>image-set()</code> alle drie verwachten, en elk is precies twee of
+      drie keer de eerste in plaats van apart afgerond."""
+
+[[howto]]
+title = "Kies het bestandstype en beslis over transparantie."
+body = """
+ Png, tenzij je een reden
+      hebt: het is verliesloos, het houdt transparantie, en vlakke kleur
+      comprimeert er goed in. Jpeg heeft helemaal geen transparantie, dus er
+      wordt een achtergrondkleur in geschilderd, of je er nu een kiest of niet
+      &mdash; zonder komt elke transparante pixel er zwart uit. WebP doet allebei
+      en maakt een kleiner bestand, ten koste van software die oud genoeg is om
+      het niet te lezen."""
+
+[[howto]]
+title = "Kijk naar de voorvertoning voordat je downloadt."
+body = """
+ Die wordt getekend door dezelfde
+      code die het bestand schrijft, uit jouw bestand, op jouw apparaat. Er
+      veranderen twee dingen wanneer een tekening pixels wordt, en allebei zie je
+      hier: een haarlijn die een halve pixel breed was wordt grijs, en tekst
+      wordt getekend in een lettertype dat deze computer heeft in plaats van een
+      dat van het web gehaald wordt."""
+
+[[howto]]
+title = "Neem de bestanden mee."
+body = """
+ Eén download per bestand, of de hele
+      stapel als één zip. De namen volgen de svg waar ze uit kwamen, met
+      <code>@2x</code> en <code>@3x</code> op de kopieën, en twee bestanden die
+      dezelfde naam gekregen zouden hebben, worden genummerd in plaats van dat de
+      een de ander stilletjes vervangt."""
+
+[[faq]]
+q = "Wordt mijn svg ergens heen geüpload?"
+a = """
+        Nee. Het bestand wordt gelezen door je eigen browser op je eigen hardware,
+        op een canvas getekend door dezelfde motor die elk ander plaatje rendert
+        dat je ziet, en als download teruggegeven. Deze tool heeft geen enkele
+        netwerkfunctie &mdash; hij haalt nooit iets op en verstuurt nooit iets
+        &mdash; en de <code>Content-Security-Policy</code> van de pagina noemt elk
+        adres dat hij mag benaderen; geen ervan hoort bij deze site."""
+
+[[faq]]
+q = "Op welk formaat moet ik een svg rasteren?"
+a = """
+        Op wat het ding dat hem leest vraagt, vermenigvuldigd met de
+        pixelverhouding van het scherm waarop hij gezien wordt. Een logo dat 200
+        CSS-pixels beslaat, heeft er 400 nodig voor een Retina-laptop en 600 voor
+        een recente telefoon, en dat zijn hier de <code>@2x</code>- en
+        <code>@3x</code>-kopieën. Voor een app-icoon of een winkelvermelding noemt
+        de winkel een exact getal, en dat is het getal. Heeft niets je iets
+        verteld, dan is 1024 op de langste zijde een bruikbare standaard: groot
+        genoeg voor vrijwel elk gebruik en klein genoeg om te mailen."""
+
+[[faq]]
+q = "Kost het groter maken kwaliteit?"
+a = """
+        Nee, en dit is de ene plek waar dat antwoord eerlijk nee is. Een vector is
+        instructies in plaats van pixels, dus de browser tekent de krommen opnieuw
+        op welk formaat er ook gevraagd wordt. 4000 pixels uit een icoon van 24
+        pixels is precies zo scherp als die 24 was. Wat je niet kunt, is de andere
+        kant op: zodra het een png is, is het pixels als al het andere, dus raster
+        op het formaat dat je nodig hebt in plaats van het resultaat later te
+        schalen."""
+
+[[faq]]
+q = "Mijn svg heeft geen breedte of hoogte. Welk formaat krijg ik?"
+a = """
+        De <code>viewBox</code>, als die er is &mdash; de breedte en hoogte
+        daarvan zijn gebruikerseenheden en geen pixels, maar ze zijn de enige
+        getallen in het bestand en een browser behandelt ze als het natuurlijke
+        formaat van de tekening. Is er ook geen viewBox, dan zegt de pagina
+        <em>aangenomen</em> naast de regel en gebruikt ze
+        300&nbsp;&times;&nbsp;150, en dat is waarop een <code>&lt;img&gt;</code>
+        hem getekend zou hebben. Hoe dan ook kun je zelf het gewenste formaat
+        noemen en wordt het bestand op dat formaat getekend."""
+
+[[faq]]
+q = "Waarom ziet de tekst er in de png anders uit?"
+a = """
+        Omdat het lettertype niet in de svg zit. Een svg die tekst tekent noemt een
+        lettertype en laat het aan de machine over om het te vinden, en een bestand
+        dat er een met een <code>@import</code> van Google Fonts haalt, krijgt hier
+        niets: een svg die via een <code>&lt;img&gt;</code> getekend wordt, mag
+        niets ophalen, en dat is dezelfde regel die hem belet met jouw bestand naar
+        huis te bellen. De oplossing is die elke ontwerper al kent &mdash; zet de
+        tekst in het tekenprogramma om naar paden voordat je exporteert. Dan is het
+        meetkunde, en dan ziet het er overal hetzelfde uit."""
+
+[[faq]]
+q = "Kan het meerdere bestanden tegelijk omzetten?"
+a = """
+        Ja. Elke svg op de lijst wordt met dezelfde instellingen gerenderd en de
+        stapel komt binnen als één zip. Een factor &mdash; &ldquo;4&times; het
+        formaat dat het bestand vraagt&rdquo; &mdash; is meestal de juiste
+        instelling voor een stapel, omdat elke tekening vanaf zijn eigen formaat
+        geschaald wordt in plaats van dat ze allemaal naar hetzelfde aantal pixels
+        gedwongen worden. Klik op een regel om die in de voorvertoning te zetten."""
+
+[[faq]]
+q = "Zit er een groottelimiet op?"
+a = """
+        Die van de browser, niet de onze. Een canvas geeft het ergens voorbij
+        16.384 pixels op een zijde op, en Safari op een iPhone of iPad stopt bij
+        zo'n 16,7 megapixel oppervlak &mdash; 4096&nbsp;&times;&nbsp;4096.
+        Daarboven waarschuwt de pagina je in plaats van je een leeg plaatje te
+        geven, want dat is wat een browser doet wanneer hij op is:
+        <code>toBlob</code> geeft helemaal niets terug, zonder een foutmelding die
+        zichzelf uitlegt. Voorbij 100 megapixel weigert de tool, want dat is
+        400&nbsp;MB canvas nog voordat er één byte gecodeerd is."""
+
+[[faq]]
+q = "Wat gebeurt er met transparantie?"
+a = """
+        Die blijft, in png en in WebP. Jpeg heeft helemaal geen alfakanaal, dus er
+        wordt een kleur achter het hele plaatje geschilderd of je er nu om vraagt
+        of niet &mdash; zonder zou alles wat transparant is er zwart uit komen, en
+        dat ziet eruit als een fout in plaats van als jpeg. Een achtergrondkleur
+        kiezen bij png is ook een volstrekt gewone wens: dat slaat de tekening op
+        die kleur plat in plaats van er een gat te laten."""
+
+[[faq]]
+q = "Kan het een svg lezen met een script of een externe afbeelding erin?"
+a = """
+        Lezen kan het, en het tekent precies de delen die een browser bereid is te
+        tekenen. Een svg die via een <code>&lt;img&gt;</code> geladen wordt, zit in
+        <em>secure static mode</em>: scripts draaien niet, externe verwijzingen
+        worden niet opgehaald, en animatie speelt niet &mdash; je krijgt het eerste
+        frame. Een bestand met een externe <code>&lt;image&gt;</code> erin komt er
+        dus uit met dat deel eruit. Dat is de browser die namens jou weigert, en
+        het is de reden dat deze pagina veilig een bestand kan openen dat ze nooit
+        gezien heeft."""
+
+[[faq]]
+q = "Wat is het verschil tussen dit en Afbeeldingsformaat wijzigen?"
+a = """
+        De bron. <a href="../afbeelding-formaat-wijzigen/">Afbeeldingsformaat
+        wijzigen</a> begint bij pixels &mdash; een jpeg, een png &mdash; dus daar
+        moet groter maken detail verzinnen dat er nooit was. Dit begint bij een
+        tekening, dus valt er niets te verzinnen en is er geen bovengrens om je
+        druk over te maken. Heb je een svg, dan levert deze je een scherp
+        resultaat; heb je een foto, dan is die de juiste."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. Er is ook geen limiet op het aantal of de grootte van de
+        bestanden, want er is geen server die ervoor betaalt &mdash; het werk
+        gebeurt op je eigen apparaat. De site draagt advertenties, en die betalen
+        hem; de advertenties krijgen niets over je bestanden mee."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina één keer, verbreek dan je internetverbinding, en hij
+        werkt door. Dat is ook de eenvoudigste manier om te bewijzen dat er niets
+        geüpload wordt: een tool die je tekenwerk wegstuurde om het te laten
+        renderen, zou stoppen op het moment dat je de stekker eruit trok."""
+
+[schema]
+description = "Raster een svg naar een png, jpeg of WebP op elk formaat, in de browser. Stel het formaat in met een factor, een breedte, een hoogte, de langste zijde of een kader, voeg @2x- en @3x-kopieën toe, hou transparantie of sla hem plat, en zet een hele stapel in één keer om. Er wordt niets geüpload."
+features = [
+  "Tekent de vector op elk formaat opnieuw, dus het resultaat is op elk daarvan scherp",
+  "Formaat via een factor, een breedte, een hoogte, de langste zijde, of een kader met een passing",
+  "@2x- en @3x-kopieën, elk een exact veelvoud van de eerste in plaats van twee keer afgerond",
+  "Png, jpeg en WebP, met transparantie behouden of platgeslagen op een kleur",
+  "Leest het formaat uit width, height of de viewBox, en zegt welke het gebruikte",
+  "Waarschuwt vóór een formaat dat het canvas van een browser niet echt kan maken",
+  "Voorvertoning getekend door dezelfde code die het bestand schrijft",
+  "Verwerkt hele stapels, met alle resultaten in één zip",
+  "Scripts en externe verwijzingen in het bestand worden nooit uitgevoerd of opgehaald",
+  "Draait offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep een svg hierheen"
+hint = "of klik om te bladeren &mdash; meerdere tegelijk mag ook"

--- a/locales/nl/tools/trim-video.html
+++ b/locales/nl/tools/trim-video.html
@@ -1,0 +1,225 @@
+<main>
+  <!-- Stap 1 &mdash; de video -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies een video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <!-- One row a video, in the order they will be joined. Hidden until there
+         is more than one, because a list of one is furniture. -->
+    <ol class="clip-list" id="clip-list" hidden></ol>
+
+    <p id="join-note" class="path-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; de markeringen -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> Markeer de stukken die je wilt
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Speel hem door en druk op <kbd>I</kbd> waar een stuk moet beginnen en op
+      <kbd>O</kbd> waar het moet eindigen. Doe dat zo vaak je wilt &mdash; elk
+      paar wordt een regel hieronder, en de gereedgekomen video bestaat uit die
+      regels, de een na de ander. <kbd>U</kbd> maakt de laatste ongedaan, de
+      <kbd>spatiebalk</kbd> speelt af en pauzeert, en de pijltjes springen vijf
+      seconden.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- Built by src/timeline.js: a band for every segment, the one being
+         marked, a tick for every keyframe, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Afspelen</button>
+      <button type="button" id="back-5" class="ghost" title="Vijf seconden terug">&minus;5s</button>
+      <button type="button" id="forward-5" class="ghost" title="Vijf seconden vooruit">+5s</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Begin zetten</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Eind zetten</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Ongedaan maken</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Afspeelsnelheid">
+      <span class="speed-label">Snelheid</span>
+      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normaal</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The segments themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Segmenten <span class="segment-count" id="segment-count">nog geen</span></h3>
+        <p class="segments-total">
+          Totaal gehouden <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">#</th>
+            <th scope="col">Begin</th>
+            <th scope="col">Eind</th>
+            <th scope="col">Lengte</th>
+            <th scope="col"><span class="visually-hidden">Acties</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Nog niets gemarkeerd. Druk op <kbd>I</kbd> en dan <kbd>O</kbd> terwijl
+        hij speelt, of gebruik de knoppen hierboven.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Met de hand een regel toevoegen</button>
+        <button type="button" id="reset-segments" class="ghost danger">Alles wissen</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">Markeringen laden&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Formaat van het tijdstempelbestand">
+          <option value="seconds" selected>seconden</option>
+          <option value="HHMMSSmmm">HH:MM:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">Markeringen opslaan</button>
+      </div>
+
+      <p class="field-note">
+        De markeringen worden opgeslagen als gewoon tekstbestand &mdash; één
+        regel per segment, in het formaat hierboven &mdash; zodat een lange
+        markeersessie een gesloten tabblad overleeft, en hetzelfde bestand aan
+        elke tool gegeven kan worden die die indeling leest.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>Wat er met de gemarkeerde stukken gebeurt</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Hou ze</strong>
+          De gereedgekomen video is de gemarkeerde stukken, op volgorde aan elkaar gezet.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Knip ze eruit</strong>
+          De gemarkeerde stukken gaan weg, en al het andere wordt aan elkaar gezet.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Stap 3 &mdash; de export -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Knip hem</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="method">Hoe er geknipt wordt</label>
+        <select id="method">
+          <option value="copy" selected>Hou elke byte &mdash; niets opnieuw gecodeerd</option>
+          <option value="exact">Knip precies hier &mdash; codeert het beeld opnieuw</option>
+          <option value="record">Neem het op terwijl het speelt</option>
+        </select>
+        <p class="field-note" id="method-note"></p>
+      </div>
+
+      <div class="field" id="frame-field" hidden>
+        <label for="frame">Beeldformaat</label>
+        <select id="frame">
+          <option value="first" selected>Volg de eerste video</option>
+          <option value="largest">Volg de grootste</option>
+          <option value="1080p">1920 &times; 1080</option>
+          <option value="720p">1280 &times; 720</option>
+        </select>
+        <p class="field-note">
+          Eén formaat geldt voor het hele bestand. Een video met een andere vorm
+          wordt er met balken in gepast, nooit uitgerekt.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kwaliteit</label>
+        <select id="quality">
+          <option value="low">Kleiner bestand</option>
+          <option value="medium" selected>In balans</option>
+          <option value="high">Beste kwaliteit</option>
+        </select>
+        <p class="field-note">
+          Nooit meer dan het origineel uitgaf &mdash; daarboven hercoderen maakt
+          het bestand alleen groter.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Hou het geluid
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Gehouden</dt><dd id="sum-clips">&mdash;</dd></div>
+      <div><dt>Uiteindelijke lengte</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Begint op</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>Ruwweg</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Beeld</dt><dd id="sum-picture">&mdash;</dd></div>
+      <div><dt>Geluid</dt><dd id="sum-sound">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Video knippen</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Video downloaden</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/trim-video.toml
+++ b/locales/nl/tools/trim-video.toml
@@ -1,0 +1,328 @@
+#
+# Videoknipper - Dutch.
+#
+# Overrides for tools/trim-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Videoknipper"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Video&nbsp;knippen <span class=\"h1-kw\">&mdash; online een video inkorten</span>"
+tagline = "Markeer tijdens het afspelen wat het bewaren waard is. Krijg het terug als één video."
+
+title = "Online een video knippen &mdash; hou alleen wat je wilt, zonder uploaden"
+description = "Bekijk een video en markeer tijdens het afspelen elk stuk dat het bewaren waard is, en sla die stukken op als één bestand. Draait in je browser: niets geüpload, niets opnieuw gecodeerd, werkt offline."
+og_title = "Videoknipper &mdash; hou alleen de stukken die je wilt, zonder iets te uploaden"
+og_description = "Druk tijdens het afspelen op I en O om elk stuk te markeren dat het bewaren waard is. De gemarkeerde stukken worden frame voor frame als één video weggeschreven, zonder dat er iets geüpload wordt."
+og_image_alt = "Videoknipper - markeer de stukken die je wilt en sla ze op als één video, in je browser"
+
+pledge = """
+    Je video wordt gelezen, gemarkeerd, geknipt en geschreven door je eigen
+    browser, op je eigen hardware. Niets hier kan iets ophalen of versturen
+    &mdash; er zit helemaal geen netwerkfunctie in deze tool &mdash; en er staat
+    aan de andere kant van deze pagina geen server om een video heen te sturen,
+    ook al was er een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en knip een video. Geen enkel verzoek draagt een frame, een
+      bestandsnaam of één byte van wat je koos. Of trek de stekker uit het
+      internet en knip er toch een &mdash; een tool die je video wegstuurde om
+      hem te knippen, zou domweg stoppen."""
+
+read_first = """
+, <code>src/segments.js</code> voor de markeringen en
+      het bestand waarin ze opgeslagen worden, <code>src/demux.js</code> voor de
+      lezer die de frames in een mp4 vindt, <code>src/ranges.js</code> voor het
+      rekenwerk dat een markering in een reeks samples verandert, en
+      <code>src/copy.js</code> voor de lus die die samples naar het nieuwe
+      bestand verplaatst. Geen ervan importeert iets dat een verzoek kan doen."""
+
+howto_heading = "Een video knippen"
+
+card = """
+            Markeer tijdens het afspelen elk stuk dat het bewaren waard is, en
+            sla ze op als één video. De frames worden gekopieerd in plaats van
+            opnieuw gecodeerd, dus er gaat niets verloren."""
+
+[words]
+plural = "video's"
+choose = "een video"
+analytics_extra = """, en geen
+  frame, lengte of knippunt"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Zoveel stukken als je wilt"
+
+[[facts]]
+text = "Geen kwaliteitsverlies"
+
+[[facts]]
+text = "Werkt offline"
+
+[[privacy]]
+title = "Je video's kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestand
+      verzameld zou kunnen worden, en niets in de code dat het zou versturen als
+      dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Deze tool heeft helemaal geen
+      netwerkfunctie: geen adres om te plakken, niets om te downloaden, geen
+      engine die bij het eerste gebruik opgehaald wordt. Elke byte die je video
+      aanraakt, kwam bij het laden van de pagina van deze herkomst."""
+
+[[privacy]]
+title = "Op de gewone route wordt er niet eens iets gedecodeerd."
+body = """
+
+      Knippen verandert niets aan hoe een frame eruitziet, dus de gecodeerde
+      frames van de stukken die je markeerde, worden precies zoals ze gevonden
+      werden naar het nieuwe bestand verplaatst. Elk frame wordt opgeslagen als
+      een plakje van het bestand op je schijf &mdash; een aantekening welke
+      bytes, niet de bytes zelf &mdash; en je browser leest ze voor het eerst
+      terwijl hij de download schrijft. Niets hier maakt ooit weer een beeld van
+      je video."""
+
+[[privacy]]
+title = "Het markeringenbestand wordt in de pagina gemaakt."
+body = """
+ Je markeringen opslaan
+      schrijft een tekstbestand uit de getallen die al op het scherm staan,
+      rechtstreeks naar je downloads. Er een laden leest het hier in. Geen van
+      beide komt bij een netwerk in de buurt, en geen van beide draagt iets
+      anders dan tijden."""
+
+[[privacy]]
+title = "Het geluid wordt gekopieerd, niet beluisterd."
+body = """
+ Op beide mp4-routes worden de
+      audiomonsters overgezet zonder ook maar gedecodeerd te worden &mdash; niets
+      hier maakt er ooit weer geluid van, en niets zou ze ergens heen kunnen
+      doorgeven als dat wel zo was."""
+
+[[privacy]]
+title = "Waar frames wel gedecodeerd worden, gebeurt dat hier."
+body = """
+ Het exacte
+      knippen, en de voorvertoning van een bestand dat deze browser niet
+      afspeelt, gaan door WebCodecs op je eigen apparaat. Dat is dezelfde decoder
+      die je de video toch al zou tonen, draaiend op dezelfde plek."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google. Geen van beide krijgt iets over je video mee:
+      geen bestand, geen frame, geen naam, geen grootte, geen lengte, en niet
+      waar je knipte. Elke regel die leest, knipt en schrijft, wordt vanaf deze
+      herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de doneerknop laadt, en wat hij niet krijgt."
+body = """
+
+      De knop &ldquo;Buy me a coffee&rdquo; in de kop wordt getekend door een
+      script van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts.
+      Het is een link en verder niets: hij meldt geen bezoek, en hij krijgt niets
+      over jou of je video mee."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en alles op deze
+      pagina doet het nog. Dat is het eenvoudigste bewijs van allemaal."""
+
+[[howto]]
+title = "Kies een video."
+body = """
+ Sleep een mp4, mov, m4v of WebM op het
+      keuzevak. De browser leest hem rechtstreeks van je schijf; er wordt daarbij
+      niets ergens heen gestuurd. Sleep er meerdere en ze worden aan elkaar
+      gezet, in de volgorde waarin je ze erin zette."""
+
+[[howto]]
+title = "Speel hem af en markeer de stukken die je wilt."
+body = """
+ Druk op
+      <kbd>I</kbd> waar een stuk moet beginnen en op <kbd>O</kbd> waar het moet
+      eindigen. Doe dat zo vaak je wilt &mdash; elk paar wordt een regel in de
+      tabel eronder, en een band op de tijdlijn. <kbd>U</kbd> neemt de laatste
+      terug, de <kbd>spatiebalk</kbd> speelt af en pauzeert, en de pijltjes
+      springen vijf seconden tegelijk. Zet het afspelen langzamer als het moment
+      moeilijk te pakken is."""
+
+[[howto]]
+title = "Werk de markeringen bij."
+body = """
+ Elke regel kan apart afgespeeld
+      worden, opnieuw getimed door er een exacte tijd in te tikken, in de
+      volgorde omhoog of omlaag geschoven, of verwijderd. De twee uiteinden van
+      het geselecteerde stuk kunnen ook over de tijdlijn gesleept worden. Het
+      totaal bovenaan is wat de gereedgekomen video gaat duren."""
+
+[[howto]]
+title = "Hou ze, of knip ze eruit."
+body = """
+ Houden is de gebruikelijke kant
+      op: de gereedgekomen video is de stukken die je markeerde, op volgorde aan
+      elkaar gezet. Ze eruit knippen is de andere klus die mensen willen en
+      zelden vinden &mdash; markeer de reclames, de stiltes of de valse starts,
+      en wat overblijft wordt zonder die aan elkaar gezet."""
+
+[[howto]]
+title = "Knip hem, en download."
+body = """
+ &ldquo;Hou elke byte&rdquo; zet de
+      frames onaangeroerd over: snel, en het kan geen kwaliteit kosten, maar elk
+      stuk begint bij het keyframe vóór je markering. &ldquo;Knip precies
+      hier&rdquo; decodeert het beeld en schrijft het opnieuw, zodat elk stuk
+      begint op het frame dat je koos. De pagina zegt welke van de twee je gaat
+      krijgen, en wat het kost, voordat je op de knop drukt."""
+
+[[faq]]
+q = "Wordt mijn video ergens heen geüpload?"
+a = """
+        Nee. Hij wordt gelezen, gemarkeerd, geknipt en geschreven door je eigen
+        browser op je eigen hardware. Deze tool heeft geen serverkant, en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen &mdash; geen ervan hoort bij deze site. Trek de stekker uit
+        het internet en knip er toch een, als je liever controleert dan het
+        aanneemt."""
+
+[[faq]]
+q = "Kan ik meerdere stukken uit dezelfde video houden?"
+a = """
+        Daar is dit voor. Druk zo vaak je wilt op <kbd>I</kbd> en <kbd>O</kbd>
+        terwijl hij speelt; elk paar wordt een regel, en de gereedgekomen video is
+        elke regel op volgorde aan elkaar gezet, met al het andere weg. De meeste
+        online knippers geven je één paar grepen en vragen welk enkel stuk je wilt
+        houden, wat prima is om een filmpje aan de voor- en achterkant bij te
+        snijden en helemaal niets waard om een uur beeldmateriaal één keer te
+        bekijken en de zes momenten te houden die de moeite waard zijn."""
+
+[[faq]]
+q = "Kost knippen kwaliteit?"
+a = """
+        Op de gewone route niet, en niet op de manier die ertoe doet. Knippen
+        verandert niets aan hoe een frame eruitziet, dus de frames worden precies
+        zoals ze waren naar het nieuwe bestand verplaatst: dezelfde bytes,
+        dezelfde encoderinstellingen, alles hetzelfde. De enige route hier die
+        iets opnieuw codeert is het exacte knippen, en dat staat op de knop."""
+
+[[faq]]
+q = "Waarom begint een stuk eerder dan waar ik het markeerde?"
+a = """
+        Door de manier waarop video opgeslagen wordt, en alleen bij spelers die
+        een standaardonderdeel van het formaat negeren. De meeste frames worden
+        bewaard als een beschrijving van hoe ze van hun buren verschillen, dus ze
+        zijn zonder die buren niet te decoderen; alleen een keyframe staat op
+        zichzelf, en keyframes liggen meestal een tot tien seconden uit elkaar.
+        Een knip die frames kopieert moet dus de reeks vanaf het keyframe vóór je
+        markering meenemen &mdash; en het bestand zegt <em>begin met afspelen bij
+        jouw markering</em>, wat elke gangbare speler respecteert. Moet het in elke
+        speler exact zijn, kies dan &ldquo;Knip precies hier&rdquo;, die opnieuw
+        codeert. De pagina zegt in welk geval je zit, en met hoeveel, voordat je
+        exporteert."""
+
+[[faq]]
+q = "Kan ik in plaats daarvan de reclames eruit knippen?"
+a = """
+        Ja. Markeer ze en kies dan &ldquo;Knip ze eruit&rdquo;: alles wat je
+        <em>niet</em> gemarkeerd hebt wordt in plaats daarvan aan elkaar gezet, op
+        volgorde. Dezelfde lijst markeringen beantwoordt beide vragen, dus je kunt
+        ertussen wisselen en de lengte zien veranderen zonder iets twee keer te
+        markeren."""
+
+[[faq]]
+q = "Kan ik mijn markeringen opslaan en er later op terugkomen?"
+a = """
+        Ja. &ldquo;Markeringen opslaan&rdquo; schrijft een gewoon tekstbestand
+        &mdash; één regel per stuk, een begin en een eind gescheiden door een
+        komma &mdash; en &ldquo;Markeringen laden&rdquo; leest er een terug. Er
+        worden twee formaten aangeboden, gewone seconden en
+        <code>HH:MM:SS.mmm</code>, en allebei houden zich aan de indeling die
+        andere tools die zo werken al gebruiken, dus een bestand dat hier
+        geschreven is kun je aan zo'n tool geven en een bestand dat daar
+        geschreven is kun je op deze pagina slepen. Markeren is nauwkeurig werk en
+        niemand hoort het twee keer te doen."""
+
+[[faq]]
+q = "Welke videoformaten kan ik knippen?"
+a = """
+        Mp4, m4v en mov worden rechtstreeks gelezen, wat er ook in zit: H.264,
+        HEVC, AV1 of VP9. Frames kopiëren houdt niet in dat ze gedecodeerd worden,
+        dus deze route werkt zelfs voor een codec waarvoor je browser helemaal
+        geen decoder heeft. Al het andere dat je browser kan afspelen &mdash; WebM
+        het meest voor de hand liggend &mdash; wordt in plaats daarvan geknipt
+        door het af te spelen en het resultaat op te nemen, wat werkt, zo lang
+        duurt als het resultaat is, en maar één stuk kan houden. Een bestand dat
+        de browser niet kan lezen en ook niet kan afspelen, in de praktijk avi,
+        wmv, flv en de meeste mkv's, wordt geweigerd met een melding die dat zegt,
+        in plaats van halverwege te stranden."""
+
+[[faq]]
+q = "Zit er een limiet op de grootte of lengte van de video?"
+a = """
+        In de tool zit geen limiet ingebouwd, en op de kopieerroute wordt het
+        bestand nauwelijks gelezen: naar de frames die je houdt wordt gewezen in
+        plaats van dat ze geladen worden, dus vier minuten overhouden uit een
+        opname van vier gigabyte kost ongeveer wat het kost om die vier minuten
+        naar schijf te schrijven. Het exacte knippen loopt een paar megabyte
+        tegelijk door het bestand. Hoe dan ook is het praktische plafond het
+        gereedgekomen bestand, dat in het geheugen wordt opgebouwd voordat je het
+        downloadt."""
+
+[[faq]]
+q = "Blijft het geluid intact?"
+a = """
+        Op beide mp4-routes wordt het monster voor monster overgezet zonder ooit
+        gedecodeerd te worden, dus het is byte voor byte wat er in het bestand
+        zat, en een bewerkingsmarkering houdt elk stuk tot op een duizendste
+        seconde gelijk met zijn beeld. De ene uitzondering is het aan elkaar
+        zetten van losse video's waarvan het geluid anders beschreven is &mdash;
+        verschillende bemonsteringsfrequenties bijvoorbeeld &mdash; waar er geen
+        manier is om beide in één spoor te krijgen zonder ze te decoderen, en de
+        pagina zegt dat voordat ze het doet. Op de opnameroute wordt het van de
+        weergave opgevangen en opnieuw gecodeerd. Hoe dan ook is er een vinkje om
+        het er helemaal uit te laten."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. De site draagt advertenties, en die betalen hem; de
+        advertenties krijgen niets over je video mee."""
+
+[schema]
+browser_requirements = "Vereist JavaScript. Frames kopiëren vraagt helemaal geen codecondersteuning; voor het exacte knippen is een browser met WebCodecs nodig, en andere formaten vallen terug op opnemen."
+description = "Markeer tijdens het afspelen zoveel stukken van een video als je wilt en sla die stukken op als één bestand - of knip ze eruit en hou de rest. Mp4, mov en m4v worden geknipt door de gecodeerde frames onaangeroerd naar een nieuw bestand te verplaatsen, met de originele audio monster voor monster meegenomen; er wordt niets geüpload en niets opnieuw gecodeerd."
+features = [
+  "Markeert zoveel stukken als je wilt met I en O terwijl de video speelt",
+  "Zet de gemarkeerde stukken aan elkaar tot één bestand, in de volgorde die jij kiest",
+  "Knipt de gemarkeerde stukken er juist uit en houdt al het andere",
+  "Knipt zonder opnieuw te coderen, dus er gaat geen kwaliteit verloren",
+  "Slaat de markeringen op als gewoon tekstbestand met tijdstempels en laadt ze terug",
+  "Framenauwkeurige markeringen, met de keyframes op de tijdlijn",
+  "Houdt de originele audio zonder hem opnieuw te coderen",
+  "Draait offline; geen upload, geen account, geen watermerk",
+]
+
+[picker]
+title = "Sleep een video hierheen"
+hint = "of klik om te bladeren &mdash; mp4, mov, m4v, WebM. Sleep er meerdere om ze aan elkaar te zetten."

--- a/locales/nl/tools/video-to-gif.html
+++ b/locales/nl/tools/video-to-gif.html
@@ -1,0 +1,169 @@
+<main>
+  <!-- Stap 1 &mdash; het bestand -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies een video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Bestand</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Grootte</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Beeld</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Lengte</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Gelezen door</dt><dd id="src-path">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Stap 2 &mdash; het stuk -->
+  <section class="card" id="section-card" hidden>
+    <h2><span class="step">2</span> Kies het stuk</h2>
+
+    <p class="hint">
+      Speel het filmpje af en markeer het stuk dat je wilt. <kbd>I</kbd> zet het
+      begin waar de afspeelkop staat, <kbd>O</kbd> zet het eind, en beide grepen
+      op de balk kun je slepen.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- The bar itself is built by src/range.js. -->
+    <div id="rangebar"></div>
+    <div class="rb-scale">
+      <span>0:00.000</span>
+      <span id="scale-end">&mdash;</span>
+    </div>
+
+    <div class="marks">
+      <label>Begin
+        <input type="text" id="start-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-in" class="ghost" title="Zet het begin waar de afspeelkop staat (I)">
+        Zet op afspeelkop
+      </button>
+
+      <label>Eind
+        <input type="text" id="end-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-out" class="ghost" title="Zet het eind waar de afspeelkop staat (O)">
+        Zet op afspeelkop
+      </button>
+
+      <div class="mark-actions">
+        <button type="button" id="play-section" class="ghost">Speel het stuk af</button>
+        <button type="button" id="whole-clip" class="ghost">Hele filmpje</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Stap 3 &mdash; de gif -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Formaat en beeldsnelheid</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="width">Breedte</label>
+        <select id="width">
+          <option value="240">240 px</option>
+          <option value="320">320 px</option>
+          <option value="480" selected>480 px</option>
+          <option value="640">640 px</option>
+          <option value="source">Originele grootte</option>
+          <option value="custom">Precies&hellip;</option>
+        </select>
+        <p class="field-note">
+          De hoogte volgt, dus de verhouding verandert nooit. Breedte is wat een
+          gif kost: de halve breedte is een kwart van de pixels.
+        </p>
+        <p class="field-note" id="width-note" hidden></p>
+      </div>
+
+      <div class="field" id="custom-width-field" hidden>
+        <label for="custom-width">Exacte breedte</label>
+        <input type="number" id="custom-width" min="16" max="1920" step="1" value="480">
+        <p class="field-note">In pixels, tussen 16 en 1920.</p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Beelden per seconde</label>
+        <select id="fps">
+          <option value="5">5 &mdash; kleinst</option>
+          <option value="10">10</option>
+          <option value="12" selected>12 &mdash; vloeiend genoeg</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+          <option value="25">25 &mdash; het vloeiendst</option>
+        </select>
+        <p class="field-note">
+          Niet de eigen snelheid van de video: de frames worden eruit
+          bemonsterd. Twaalf leest als beweging; boven de twintig groeit het
+          bestand sneller dan de vloeiendheid zichtbaar wordt.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Rasteren</label>
+        <select id="dither">
+          <option value="on" selected>Aan &mdash; vloeiendere verlopen</option>
+          <option value="off">Uit &mdash; vlakker, kleiner</option>
+        </select>
+        <p class="field-note">
+          Mengt twee paletkleuren waar de juiste ontbreekt. Geordend, zodat een
+          stilstaande achtergrond niet flikkert.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="loop">
+          <input type="checkbox" id="loop" checked>
+          Eeuwig herhalen
+        </label>
+        <p class="field-note">Uit speelt hem één keer door en stopt dan.</p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Stuk</dt><dd id="sum-section">&mdash;</dd></div>
+      <div><dt>Uitvoer</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Frames</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Ruwe bestandsgrootte</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="memory-note" class="field-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Maak de gif</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <img id="result-image" alt="De gereedgekomen animatie, spelend">
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Gif downloaden</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/nl/tools/video-to-gif.toml
+++ b/locales/nl/tools/video-to-gif.toml
@@ -1,0 +1,256 @@
+#
+# Video naar gif - Dutch.
+#
+# Overrides for tools/video-to-gif/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Video naar gif"
+# Het staartje is de zoekterm. Net als in het Engels blijft de productnaam de
+# luide helft.
+heading = "Video&nbsp;naar&nbsp;gif <span class=\"h1-kw\">&mdash; een video omzetten naar een gif</span>"
+tagline = "Kies het stuk, het formaat en de beeldsnelheid."
+
+title = "Video-naar-gif-omzetter &mdash; gratis, zonder uploaden, werkt offline"
+description = "Maak van een stuk mp4, mov of WebM een bewegende gif. Kies het stuk, de breedte en de beeldsnelheid; de frames worden gelezen en de gif wordt geschreven in je browser. Niets geüpload."
+og_title = "Video naar gif &mdash; een gif maken zonder het filmpje te uploaden"
+og_description = "Markeer de seconden die je wilt, kies een breedte en een beeldsnelheid, en krijg een bewegende gif. Het bemonsteren, het palet, het rasteren en de LZW gebeuren allemaal op je eigen apparaat."
+og_image_alt = "Video naar gif - een bewegende gif maken in je browser, zonder iets te uploaden"
+
+pledge = """
+    Elk frame wordt gelezen, geschaald, gekwantiseerd en geschreven door je eigen
+    browser, op je eigen hardware. Niets hier kan iets ophalen of versturen
+    &mdash; er zit helemaal geen netwerkfunctie in deze tool &mdash; en er staat
+    aan de andere kant van deze pagina geen server om een video heen te sturen,
+    ook al was er een weg."""
+
+live_hint = """
+      Neem het niet van ons aan: open de DevTools, hou het tabblad Netwerk in de
+      gaten en maak een gif. Geen enkel verzoek draagt een frame, een
+      bestandsnaam of één byte van wat je koos. Of trek de stekker uit het
+      internet en maak er toch een &mdash; een tool die je video wegstuurde om
+      hem om te zetten, zou domweg stoppen."""
+
+read_first = """
+, <code>src/frames.js</code> voor de twee manieren
+      waarop de frames uit een video gelezen worden, <code>src/quantize.js</code>
+      voor het palet, en <code>src/gif.js</code> voor het bestand zelf, LZW en
+      al. Geen ervan importeert iets dat een verzoek kan doen."""
+
+howto_heading = "Van een video een gif maken"
+
+card = """
+            Markeer de seconden die je wilt, kies een breedte en een
+            beeldsnelheid, en krijg een bewegende gif &mdash; palet, rastering en
+            al."""
+
+[words]
+plural = "video's"
+choose = "een video"
+analytics_extra = """, en geen
+  frame, lengte of formaat"""
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Elke lengte"
+
+[[facts]]
+text = "Werkt offline"
+
+[[privacy]]
+title = "Je video's kunnen nergens heen."
+body = """
+ De
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen ervan hoort bij deze site. Er is hier geen eindpunt waar je bestand
+      verzameld zou kunnen worden, en niets in de code dat het zou versturen als
+      dat er wel was."""
+
+[[privacy]]
+title = "Niets hier haalt iets op."
+body = """
+ Deze tool heeft helemaal geen
+      netwerkfunctie: geen adres om te plakken, niets om te downloaden, geen
+      engine die bij het eerste gebruik opgehaald wordt. Elke byte die je video
+      aanraakt, kwam bij het laden van de pagina van deze herkomst."""
+
+[[privacy]]
+title = "Het decoderen gebeurt lokaal."
+body = """
+ De frames gaan door WebCodecs
+      in je eigen browser, of door dezelfde afspeelmotor die je het filmpje toch
+      al zou tonen. Welke van de twee gebruikt is, staat boven aan de pagina,
+      want het verandert hoe de frames gekozen worden en dat hoor je te kunnen
+      zien."""
+
+[[privacy]]
+title = "De gif wordt hier geschreven, in code die je kunt lezen."
+body = """
+ Het
+      palet, het rasteren en de LZW-compressie zijn zo'n zeshonderd regels in de
+      eigen map van deze tool. Er is geen encoderdienst, geen bibliotheek die
+      tijdens het draaien opgehaald wordt, en nergens erin een plek waar een
+      plaatje heen gestuurd zou kunnen worden."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De advertentie- en
+      meetscripts komen van Google. Geen van beide krijgt iets over je video mee:
+      geen bestand, geen frame, geen naam, geen grootte, geen lengte, en niet het
+      stuk dat je markeerde. Elke regel die leest, bemonstert, kwantiseert of
+      codeert, wordt vanaf deze herkomst geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de doneerknop laadt, en wat hij niet krijgt."
+body = """
+
+      De knop &ldquo;Buy me a coffee&rdquo; in de kop wordt getekend door een
+      script van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts.
+      Het is een link en verder niets: hij meldt geen bezoek, en hij krijgt niets
+      over jou of je video mee."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en alles op deze
+      pagina doet het nog. Dat is het eenvoudigste bewijs van allemaal."""
+
+[[howto]]
+title = "Kies een video."
+body = """
+ Sleep een mp4, mov, m4v of WebM op het
+      keuzevak, of kies er een met de hand. De browser leest hem rechtstreeks van
+      je schijf; er wordt daarbij niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Markeer het stuk."
+body = """
+ Speel het filmpje af en druk op
+      <kbd>I</kbd> waar het moet beginnen en op <kbd>O</kbd> waar het moet
+      eindigen, of sleep de grepen op de balk. Een gif duurt een paar seconden
+      &mdash; dit is de instelling die bepaalt of het bestand klein of enorm
+      wordt, veel meer dan de andere twee."""
+
+[[howto]]
+title = "Kies de breedte en de beeldsnelheid."
+body = """
+ 480 pixels
+      breed en 12 beelden per seconde past bij de meeste dingen waar een gif voor
+      is. De breedte halveren viert de pixels; twaalf beelden per seconde leest
+      als beweging zonder te betalen voor de beelden die niemand ziet."""
+
+[[howto]]
+title = "Maak hem, en download."
+body = """
+ De frames worden gelezen, er wordt
+      één palet van 256 kleuren gekozen voor de hele animatie, en elk frame wordt
+      geschreven als alleen het deel van het beeld dat veranderde. Hij speelt op
+      de pagina zodra hij klaar is, en dat is hetzelfde bestand dat de download
+      je geeft."""
+
+[[faq]]
+q = "Wordt mijn video ergens heen geüpload?"
+a = """
+        Nee. Hij wordt gelezen, bemonsterd en omgezet door je eigen browser op je
+        eigen hardware. Deze tool heeft geen serverkant, en de
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen &mdash; geen ervan hoort bij deze site. Trek de stekker uit
+        het internet en maak er toch een gif van, als je liever controleert dan
+        het aanneemt."""
+
+[[faq]]
+q = "Welke videoformaten kan ik omzetten?"
+a = """
+        Mp4, m4v en mov worden rechtstreeks gelezen, wat er ook in zit: H.264,
+        HEVC, AV1 of VP9, zolang je browser die codec kan decoderen. Al het andere
+        dat je browser kan afspelen &mdash; WebM het meest voor de hand liggend
+        &mdash; wordt in plaats daarvan gelezen door de speler naar elk moment te
+        laten springen, wat trager is en iets minder precies over welk frame waar
+        landt. Een bestand dat de browser niet kan lezen en ook niet kan afspelen,
+        in de praktijk avi, wmv, flv en de meeste mkv's, wordt geweigerd met een
+        melding die dat zegt, in plaats van halverwege te stranden."""
+
+[[faq]]
+q = "Waarom is mijn gif zo groot?"
+a = """
+        Omdat gif een formaat uit 1987 is dat hele plaatjes opslaat in plaats van
+        beweging. Er is geen manier om er een van een filmpje van vijf seconden te
+        maken die net zo klein is als de mp4 van vijf seconden waar hij uit kwam
+        &mdash; een gif van een video is routineus tien keer zo groot als de
+        video. De drie instellingen die het werkelijk bepalen zijn, op volgorde:
+        hoe lang het stuk is, hoe breed het beeld is, en hoeveel beelden per
+        seconde. De breedte halveren viert de pixels, en het zijn de pixels die
+        kosten."""
+
+[[faq]]
+q = "Waarom maar 256 kleuren?"
+a = """
+        Dat is het formaat: een gif draagt één tabel van hoogstens 256 kleuren mee
+        en slaat elke pixel op als een nummer daarin. Deze tool kiest die 256 door
+        de kleuren in elk frame van je stuk te tellen en ze in 256 groepen te
+        splitsen &mdash; mediaansnede, de standaardmethode &mdash; zodat het palet
+        bij jouw filmpje past in plaats van een vaste set kleuren te zijn. Waar
+        een kleur ontbreekt, mengt het rasteren de twee dichtstbijzijnde, zodat
+        een verloop een verloop blijft in plaats van strepen te worden."""
+
+[[faq]]
+q = "Wat doet de rasterinstelling?"
+a = """
+        Die ruilt een beetje ruis in voor een hoop bandvorming. Met hem aan blijft
+        een lucht die anders vier vlakke banden zou worden een verloop, ten koste
+        van een vage textuur en een groter bestand. Met hem uit is het beeld
+        vlakker en het bestand kleiner, wat past bij schermopnames, lijntekeningen
+        en alles wat al uit vlakke kleur bestaat. Het raster dat hier gebruikt
+        wordt is geordend en niet van het foutdiffusietype, zodat een onveranderde
+        achtergrond tussen frames volkomen stil blijft in plaats van te
+        flikkeren."""
+
+[[faq]]
+q = "Zit er een limiet op de lengte of de grootte?"
+a = """
+        Het stuk is wat begrensd is, en door geheugen in plaats van door een
+        regel: elk frame ervan wordt tegelijk vastgehouden terwijl het palet
+        gekozen wordt, dus rekent de pagina uit wat jouw instellingen zouden
+        kosten en zegt dat voordat je begint. Hij weigert liever dan het tabblad
+        zonder geheugen te laten vallen. Een korter stuk, een kleinere breedte of
+        een lagere beeldsnelheid brengen het allemaal omlaag."""
+
+[[faq]]
+q = "Blijft het geluid behouden?"
+a = """
+        Een gif kan geen geluid meedragen. Er is geen versie van het formaat met
+        audio, en dat is de belangrijkste reden dat het web gifs grotendeels
+        vervangen heeft door stille loopende video. Doet het geluid ertoe, hou de
+        video dan &mdash; de <a href="../video-knippen/">Videoknipper</a> knipt er
+        een stuk uit zonder één frame opnieuw te coderen."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en
+        geen watermerk. De site draagt advertenties, en die betalen hem; de
+        advertenties krijgen niets over je video mee."""
+
+[schema]
+browser_requirements = "Vereist JavaScript. Voor mp4 en mov is een browser met WebCodecs nodig; alles wat de browser kan afspelen werkt ook zonder."
+description = "Zet een stuk van een video om in een bewegende gif, in de browser. De frames worden op de gekozen snelheid bemonsterd, er wordt met mediaansnede één palet van 256 kleuren voor de hele animatie gekozen, en elk frame wordt geschreven als alleen het gebied dat veranderde. Er wordt niets geüpload."
+features = [
+  "Zet mp4-, mov-, m4v- en WebM-video om naar een bewegende gif",
+  "H.264-, HEVC-, AV1- en VP9-bronnen, gedecodeerd via WebCodecs",
+  "Markeer het stuk op een tijdlijn, of tik exacte tijden in",
+  "Elke breedte, 5 tot 25 beelden per seconde, optioneel geordend rasteren",
+  "Draait offline; geen upload, geen account, geen watermerk",
+]
+
+[picker]
+title = "Sleep een video hierheen"
+hint = "of klik om te bladeren &mdash; mp4, mov, m4v, WebM, en al het andere dat deze browser afspeelt"


### PR DESCRIPTION
**Stacked on #48.** This branches from `claude/website-i18n-translations`, so the diff shown against `main` includes that branch until #48 lands. Merge #48 first.

GitHub reports this PR as conflicting with `main`. The conflict is one file, the generated `tools/README.md`, and it is inherited: `origin/claude/website-i18n-translations` conflicts with `main` on exactly the same file without my commit. Nothing in this change touches it.

Dutch is now `complete = true` — the second language to get there. The build reports `nl: 0 strings still in English`, which turns every remaining fallback into a build failure and turns on the link check for Dutch.

## What is covered

66 files under `locales/nl/`, and nothing outside it.

* `locale.toml` — the frame was already translated; this adds fourteen slugs and drops a duplicated `[[hub.categories]]` entry (mine and the one added in a52e05f both landed; I kept the one in the `je` register the rest of the file uses).
* `planned.toml` — the roadmap list, all six groups.
* `tools/` — all fifteen tools, `.toml` and `.html`.
* `pages/` — privacy, terms, and all fifteen guides.

## The slugs

Named for the job rather than the format, which is the reason the site translates slugs at all:

| English | Dutch | why |
|---|---|---|
| `image-to-ico` | `favicon-maken` | nobody searches "afbeelding naar ICO"; a great many people search how to make a favicon |
| `svg-to-image` | `svg-naar-png` | PNG is what comes out in almost every case, and it is what gets typed |
| `image-to-data-uri` | `afbeelding-naar-base64` | "data-URI" is the term of art, "base64" is the search — and it is the word in the line you paste into CSS |
| `qr-barcode` | `qr-code-maken` | |
| `heic-to-jpg` | `heic-naar-jpg` | format names stay as themselves |
| `video-to-gif` | `video-naar-gif` | |
| `guides/make-a-favicon` | `gidsen/zelf-een-favicon-maken` | `zelf-` keeps it distinct from the tool slug |
| `guides/convert-an-svg-to-png` | `gidsen/een-svg-naar-png-omzetten` | |
| `guides/make-a-qr-code` | `gidsen/zelf-een-qr-code-maken` | |
| `guides/convert-heic-to-jpg` | `gidsen/heic-naar-jpg-omzetten` | |
| `guides/embed-an-image-in-css` | `gidsen/een-afbeelding-in-css-zetten` | |
| `guides/turn-a-video-into-a-gif` | `gidsen/van-een-video-een-gif-maken` | |

Every cross-link in a translated body uses the Dutch slug; the link check passes.

## Two places Dutch could not follow the English

**`[ui.picker].note`** made a plural by putting a bare `s` after `{{ tool.picker.urls.noun }}`. Dutch has no such ending — `afbeelding` pluralises to `afbeeldingen` — so the sentence is rewritten around the singular noun: *"van de {{ noun }} die je opvraagt"*. Same fix the Spanish translation took, and it renders as "van de afbeelding die je opvraagt".

**`qr-barcode`'s `words.choose`** is the clause "what goes in it", which the boot warning wraps in "when you choose …". Dutch sends the verb to the end of that clause, so a clause there produces "wanneer je wat erin gaat kiest". It is a noun phrase in Dutch — `de inhoud` — which renders as "wanneer je de inhoud kiest".

## Register

`je` throughout, which the frame had already established. The English is plain and direct and the formal Dutch would make it read like a letter from a bank. Checked: no `u`/`uw` forms anywhere in `locales/nl/`.

## Things worth a second opinion

* **`resize-image` is `name = "Afbeeldingsformaat wijzigen"`** — a verb phrase where every other tool is a noun. Dutch has no neat equivalent of "resizer"; "Formaatwijziger" is compact but says nothing about images. It reads a little awkwardly inside a sentence ("de tool Afbeeldingsformaat wijzigen"), which happens in three FAQ cross-links.
* **`image-to-data-uri` slug is `afbeelding-naar-base64`** while the tool's own name is "Afbeelding naar data-URI". Deliberate — the slug chases the search and the name chases the tool — but it is the one place a slug and a name disagree.
* **`gidsen/zelf-een-favicon-maken`** — the `zelf-` prefix exists only to avoid colliding with `favicon-maken`. It reads fine ("een favicon zelf maken") but it is a compromise forced by the tool slug.
* **`heic-to-jpg` pledge** keeps "1,4 MB" with a Dutch decimal comma. Consistent with the rest of the file, which uses commas in `0,5×`, `0,98` and so on.

## Verified

* `python build.py --clean --out dist-check` — 387 pages, exit 0, `nl` absent from the "still in English" list.
* `python -m unittest discover -s tests/python -t .` — Ran 305 tests, OK.
* `git status` clean; the diff touches `locales/nl/` and nothing else.

## Not touched, and worth knowing

`de` is `complete = false` on the base with 346 strings outstanding, and the other eight locales are at 1360. That is expected and is being handled elsewhere — this PR does not go near them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
