### PR TITLE
Translate the site into Italian

### DIFF
--- a/locales/it/locale.toml
+++ b/locales/it/locale.toml
@@ -10,7 +10,7 @@ lang = "it"
 name = "Italian"
 endonym = "Italiano"
 
-complete = false
+complete = true
 
 #
 # ---------------------------------------------------------------------------
@@ -23,22 +23,41 @@ complete = false
 #
 
 [slugs]
+# Gli strumenti.
 "compress-image" = "comprimere-immagine"
 "compress-pdf" = "comprimere-pdf"
 "crop-video" = "ritagliare-video"
 "edit-audio" = "modificare-audio"
 # Quasi nessuno cerca un "editor EXIF": si cerca come togliere i dati da una foto.
 "exif-editor" = "rimuovere-dati-exif"
+# Le conversioni perdono il verbo, come in "immagini-in-pdf": è il modo in cui
+# si scrive una conversione in italiano quando la si cerca.
+"heic-to-jpg" = "heic-in-jpg"
+# Nessuno cerca "immagine in data URI". Si cerca base64, che è la cosa che
+# finisce nel foglio di stile.
+"image-to-data-uri" = "immagine-in-base64"
+# Anche qui il lavoro, non il formato: quasi nessuno cerca "da immagine a ICO"
+# e moltissimi cercano come si fa una favicon.
+"image-to-ico" = "creare-favicon"
 "images-to-pdf" = "immagini-in-pdf"
 "images-to-video" = "immagini-in-video"
+# "QR code" e non "codice QR": è la forma che in italiano si scrive e si cerca,
+# prestito compreso.
+"qr-barcode" = "creare-qr-code"
 "resize-image" = "ridimensionare-immagine"
+# Lo strumento scrive anche JPEG e WebP, ma la domanda che porta qui è sempre
+# la stessa, e nomina il PNG.
+"svg-to-image" = "svg-in-png"
 "trim-video" = "tagliare-video"
+"video-to-gif" = "video-in-gif"
 
 "guides" = "guide"
 "roadmap" = "roadmap"
 "privacy" = "privacy"
 "terms" = "termini"
 
+# Le guide. Ognuna è la domanda che fa chi la cerca, nelle parole in cui la fa,
+# e non la traduzione del titolo inglese.
 "guides/compress-an-image-to-a-target-size" = "guide/comprimere-un-immagine-a-una-dimensione-esatta"
 "guides/resize-an-image" = "guide/ridimensionare-un-immagine"
 "guides/remove-exif-and-gps-data" = "guide/rimuovere-i-dati-exif-e-gps"
@@ -48,6 +67,12 @@ complete = false
 "guides/trim-a-video" = "guide/tagliare-un-video"
 "guides/crop-a-video" = "guide/ritagliare-un-video"
 "guides/is-it-safe-to-upload-files" = "guide/e-sicuro-caricare-i-propri-file"
+"guides/make-a-favicon" = "guide/creare-una-favicon"
+"guides/convert-an-svg-to-png" = "guide/convertire-un-svg-in-png"
+"guides/convert-heic-to-jpg" = "guide/convertire-heic-in-jpg"
+"guides/embed-an-image-in-css" = "guide/inserire-un-immagine-nel-css"
+"guides/make-a-qr-code" = "guide/creare-un-qr-code"
+"guides/turn-a-video-into-a-gif" = "guide/trasformare-un-video-in-gif"
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/it/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/it/pages/guides/combine-images-into-a-pdf.html
@@ -1,0 +1,208 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri <a href="../../immagini-in-pdf/">Immagini in PDF</a>, trascinaci
+      dentro le foto, sposta le tessere finché l'ordine non è giusto, e crea il
+      documento. Le impostazioni predefinite &mdash; pagine A4, un margine
+      piccolo, le fotografie copiate dentro senza essere ricodificate &mdash;
+      sono quello che vuole quasi tutti.
+    </p>
+    <p>
+      Le quattro cose su cui vale la pena pensarci due volte sono l'ordine, la
+      dimensione della pagina, l'impostazione della qualità, e cosa dice di te
+      il documento finito. In quest'ordine di frequenza con cui vanno storte.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sistema l'ordine prima di ogni altra cosa</h2>
+    <p>
+      L'ordine delle pagine è di gran lunga la cosa che si sbaglia più spesso,
+      perché i nomi dei file si ordinano in modi che nessuno si aspetta.
+      <code>IMG_2.jpg</code> viene dopo <code>IMG_10.jpg</code> in un ordine
+      alfabetico, perché il confronto è carattere per carattere e
+      <code>1</code> viene prima di <code>2</code>. Una cartella di scansioni
+      chiamate da <code>pagina1</code> a <code>pagina12</code> arriverà
+      nell'ordine sbagliato in quasi qualunque strumento.
+    </p>
+    <p>
+      Ordinare per data di scatto è di solito più affidabile per le fotografie,
+      perché hai fotografato le pagine nell'ordine in cui erano. In ogni caso,
+      controlla le tessere prima di premere il pulsante invece di controllare il
+      PDF dopo.
+    </p>
+  </section>
+
+  <section>
+    <h2>La qualità: la parte che quasi tutti gli strumenti sbagliano in silenzio</h2>
+    <p>
+      Un PDF sa portare direttamente i dati JPEG. È una proprietà del formato: i
+      byte compressi di un JPEG si possono lasciar cadere nel documento così
+      come sono, e il lettore li decodifica come farebbe un browser.
+    </p>
+    <p>
+      Conta perché vuol dire che una fotografia non deve perdere niente entrando
+      in un PDF. Non viene mai decodificata e non viene mai ricompressa;
+      l'immagine nel documento è bit per bit l'immagine nel tuo file. Molti
+      strumenti ricodificano lo stesso &mdash; è più semplice disegnare tutto su
+      una tela e codificare in modo uniforme &mdash; e il risultato è una
+      generazione di qualità persa per niente.
+    </p>
+    <p>
+      Gli altri formati non possono viaggiare così. PNG, WebP, HEIC e gli altri
+      non hanno un filtro corrispondente nel PDF, quindi vanno convertiti. Su
+      come, puoi scegliere:
+    </p>
+    <ul>
+      <li>
+        <strong>Ricodifica come JPEG</strong> (il comportamento predefinito).
+        File più leggero, un piccolo costo di qualità, ed è la risposta giusta
+        per le fotografie.
+      </li>
+      <li>
+        <strong>Senza perdita.</strong> Conserva i pixel esatti al prezzo di un
+        documento molto più pesante. È la risposta giusta per screenshot, schemi
+        e qualunque cosa con dentro testo o bordi netti, dove gli artefatti del
+        JPEG si vedono subito.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>La dimensione della pagina, e quando «adatta all'immagine» è meglio</h2>
+    <p>
+      Una dimensione di pagina standard &mdash; A4, Letter, Legal, A3, A5,
+      Tabloid &mdash; mette ogni immagine su una pagina di quella misura,
+      scalata per stare dentro il tuo margine. Usane una quando il documento
+      andrà in stampa, o quando qualcuno di ufficiale lo archivierà.
+    </p>
+    <p>
+      «Esattamente la dimensione di ogni immagine» rende ogni pagina uguale alla
+      sua immagine, quindi non c'è spazio bianco e non c'è alcuna scalatura.
+      Usalo quando il PDF è un contenitore di immagini invece che un documento:
+      un portfolio, una serie di screenshot, un fumetto. Stampato viene male,
+      perché ogni pagina ha una dimensione diversa.
+    </p>
+    <p>
+      Un margine vale la pena averlo su qualunque cosa verrà stampata. Le
+      stampanti di casa non sanno stampare fino al bordo del foglio, e una
+      fotografia messa da bordo a bordo esce tagliata.
+    </p>
+    <h3>Pagine verticali da fotografie orizzontali</h3>
+    <p>
+      Se hai fotografato dei fogli di carta con il telefono tenuto di traverso,
+      ogni immagine sarà orizzontale e starà piccola in mezzo a una pagina
+      verticale. La soluzione è ruotarne ciascuna di un quarto di giro prima di
+      costruire il documento, ed è una scelta per singola immagine e non
+      generale, perché di solito qualcuna è entrata dal verso giusto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa dice di te il PDF finito</h2>
+    <p>
+      Un PDF porta con sé un blocco di informazioni sul documento: autore,
+      produttore, data di creazione, a volte il titolo. A seconda di cosa
+      l'abbia scritto, ci possono finire il nome del tuo account, il nome del
+      tuo dispositivo, e l'ora esatta in cui l'hai fatto.
+    </p>
+    <p>
+      Vale la pena pensarci, perché un PDF è una cosa che le persone mandano ad
+      altre persone &mdash; una candidatura, una richiesta di rimborso, un
+      documento per il padrone di casa. I metadati viaggiano insieme a lui e
+      qualunque lettore può mostrarli.
+    </p>
+    <p>
+      Lo strumento di qui lascia quel blocco vuoto tranne che per il proprio
+      nome: nessun nome di file, nessun nome di dispositivo, nessun nome utente,
+      e nessuna data di creazione se non spunti la casella apposta. Se usi un
+      altro strumento, vale la pena aprire una volta le proprietà del risultato
+      per vedere cosa ci ha scritto.
+    </p>
+    <p>
+      A parte: le immagini stesse. Se le tue fotografie portano con sé tag EXIF
+      e GPS, quello che gli succede dipende dalla via. Un JPEG copiato dentro
+      senza ricodifica tiene quello che aveva; un'immagine che viene
+      ricodificata perde i tag come effetto collaterale. Se la cosa ti
+      interessa, ripulisci prima le foto con il
+      <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>
+      &mdash; <a href="../rimuovere-i-dati-exif-e-gps/">la sua guida</a> spiega
+      cosa c'è là dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Se il PDF esce troppo pesante</h2>
+    <p>
+      Le fotografie da telefono sono pesanti, e venti di loro fanno un documento
+      che la mail rifiuterà. Tre cose da provare, in ordine:
+    </p>
+    <p>
+      <strong>Rimpicciolisci il lato più lungo.</strong> La fotografia da 4000
+      pixel di un foglio di carta porta molto più dettaglio di quanto ne userà
+      qualunque lettore o stampante. Portare il lato lungo a qualcosa come 2000
+      pixel di solito divide il file per quattro e non cambia niente che
+      qualcuno possa vedere su una pagina.
+    </p>
+    <p>
+      <strong>Usa il JPEG invece del senza perdita</strong> per qualunque cosa
+      sia fotografica. Il senza perdita è la risposta giusta per gli schemi e
+      quella sbagliata per la foto di una pagina.
+    </p>
+    <p>
+      <strong>Comprimi il documento finito.</strong> Il
+      <a href="../../comprimere-pdf/">compressore di PDF</a> lavora rispetto a
+      quanto grande viene disegnata ogni immagine sulla pagina invece che
+      rispetto al suo numero di pixel, che è la misura che conta;
+      <a href="../ridurre-le-dimensioni-di-un-pdf/">la sua guida</a> spiega
+      quanto costa.
+    </p>
+    <p>
+      Nello strumento non c'è alcun limite al numero di immagini che puoi usare.
+      Il tetto pratico è la memoria del tuo dispositivo, perché il documento
+      finito viene assemblato lì prima che tu lo scarichi &mdash; qualche
+      centinaio di foto da telefono a piena risoluzione è la prima cosa a
+      sentirlo, e rimpicciolire il lato più lungo sposta quel tetto parecchio
+      più in là.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa questo non ti darà</h2>
+    <p>
+      Un PDF fatto di fotografie è un PDF pieno di immagini. Le parole che ci
+      sono dentro non sono testo: non le puoi cercare, non le puoi copiare, e
+      uno screen reader non le può leggere. È una proprietà di ciò da cui sei
+      partito, non della conversione.
+    </p>
+    <p>
+      Se ti serve testo cercabile ti serve l'OCR, che è un altro lavoro. E se il
+      documento originale esiste ancora come documento da qualche parte,
+      esportarlo direttamente in PDF batterà sempre il fotografarlo &mdash; più
+      leggero, più nitido, cercabile.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché questo non ha bisogno di un caricamento</h2>
+    <p>
+      Scrivere un PDF è scrivere un file strutturato: un'intestazione, un
+      insieme di oggetti, una tabella di riferimenti incrociati. Non c'è niente
+      lì dentro che un browser non sappia fare, e niente in questo lavoro che
+      richieda alle immagini di andare da qualche parte.
+    </p>
+    <p>
+      Ed è una cosa a cui qui vale la pena tenere, per quello che la gente mette
+      in questi documenti. Documenti d'identità, estratti conto, referti medici,
+      contratti firmati &mdash; tutto il motivo per cui una persona sta facendo
+      un PDF è di solito che lo sta mandando a un'istituzione. Lo strumento di
+      qui non ha alcuna funzione di rete, e la
+      <code>Content-Security-Policy</code> della pagina nomina tutti gli
+      indirizzi che può contattare, nessuno dei quali appartiene a questo sito.
+    </p>
+    <p>
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> spiega come verificarlo da solo, qui
+      come altrove.
+    </p>
+  </section>

--- a/locales/it/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/it/pages/guides/combine-images-into-a-pdf.toml
@@ -1,0 +1,17 @@
+#
+# Guida: unire immagini in un PDF - Italian.
+#
+
+nav = "Immagini in un PDF"
+title = "Come unire delle immagini in un unico PDF"
+description = "Trasforma foto o scansioni in un unico PDF: dimensione della pagina, ordine e rotazione, perché un JPEG non deve perdere qualità entrando, e cosa dice un PDF alla persona a cui lo mandi."
+heading = "Come unire delle immagini in un unico PDF"
+lede = """
+    Qualcuno ha chiesto «un PDF solo» e tu hai undici fotografie di fogli di
+    carta. Qui ci sono le scelte che cambiano davvero il risultato &mdash;
+    dimensione della pagina, ordine, qualità e cosa il documento dice di te
+    &mdash; e quali puoi ignorare."""
+updated = "20 agosto 2026"
+og_title = "Come unire delle immagini in un unico PDF"
+og_description = "Dimensione della pagina, ordine e rotazione, perché un JPEG non deve perdere qualità entrando, e cosa dice un PDF alla persona a cui lo mandi."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/it/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,0 +1,248 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../comprimere-immagine/">compressore di immagini</a>,
+      trascinaci dentro la foto, scrivi il numero che ti hanno dato, e premi il
+      pulsante. Codifica l'immagine più volte, tiene il risultato migliore che
+      sta sotto il tuo obiettivo, e ti dice quanto è costato. Per quasi tutte le
+      fotografie e quasi tutti gli obiettivi, il riassunto onesto è che la
+      differenza non riuscirai a vederla.
+    </p>
+    <p>
+      Il resto di questa pagina è per quando non va così: quando il risultato si
+      vede morbido, quando un PNG quasi non si muove, o quando vuoi sapere cosa
+      sta davvero facendo lo strumento alla tua immagine prima di mandarla a
+      qualcuno.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa chiede davvero un limite di peso</h2>
+    <p>
+      Un JPEG o un WebP non conserva la tua fotografia. Conserva una descrizione
+      di essa, e l'impostazione della qualità decide quanto dettagliata quella
+      descrizione può essere. Abbassala e il file si alleggerisce perché la
+      descrizione si fa più vaga: la texture fine viene mediata via, le sfumature
+      fanno bande, e i bordi si prendono un lieve alone di blocchi.
+    </p>
+    <p>
+      Quindi un limite di peso è un budget di dettaglio. La domanda utile non è
+      «riesco a centrare i 500&nbsp;KB» &mdash; qualunque numero lo si centra
+      sempre &mdash; ma «quanta parte dell'immagine devo cedere per arrivarci, e
+      conta per quello che ci devo fare?».
+    </p>
+    <p>
+      Due regole spannometriche. La fotografia di una scena reale &mdash; volti,
+      fogliame, tessuti &mdash; nasconde bene la compressione, perché l'occhio
+      non ha alcuna zona perfettamente piatta in cui notare il danno. Uno
+      screenshot, un grafico, un logo o qualunque cosa con grandi tinte piatte e
+      bordi netti di testo la mostrano subito, e di solito dovrebbero essere un
+      PNG o un WebP invece che un JPEG.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché non esiste una formula, e cosa farci</h2>
+    <p>
+      Non c'è modo di calcolare l'impostazione di qualità che produce un file da
+      500&nbsp;KB. Il rapporto tra le due cose dipende interamente da cosa c'è
+      nell'immagine: alla stessa impostazione, la fotografia di un muro liscio
+      potrebbe uscire un decimo della fotografia di un bosco. Qualunque strumento
+      ti proponga «qualità: 60» e speri sta tirando a indovinare per conto tuo.
+    </p>
+    <p>
+      L'unico metodo affidabile è provare. Codifica l'immagine, guarda il peso,
+      correggi, codifica di nuovo. Farlo a mano è noioso, ed è per questo che i
+      compressori chiedono invece un numero di qualità &mdash; sposta la noia
+      addosso a te. Farlo automaticamente sono all'incirca otto codifiche, e otto
+      codifiche di una foto da telefono sono una frazione di secondo su
+      qualunque dispositivo fatto in questo decennio, che è il motivo per cui lo
+      strumento di questo sito chiede il peso e fa la ricerca da sé.
+    </p>
+    <p>
+      Ogni peso che riporta è un file davvero codificato, non una stima. Conta
+      quando un modulo ha un limite rigido: una stima ottimista del 2% è un
+      caricamento rifiutato.
+    </p>
+  </section>
+
+  <section>
+    <h2>Spendi la qualità prima dei pixel</h2>
+    <p>
+      Ci sono solo due modi di alleggerire il file di un'immagine. Puoi
+      descrivere la stessa immagine in modo meno preciso, ed è la qualità.
+      Oppure puoi descrivere meno pixel, ed è il ridimensionamento. Non sono
+      equivalenti, e l'ordine conta.
+    </p>
+    <p>
+      Prima va la qualità, perché il primo 30% circa di riduzione è davvero
+      invisibile su una fotografia &mdash; stai buttando via dettaglio che il
+      formato conservava con più cura di quanta ne possa verificare un occhio.
+      Poi vanno i pixel, perché una volta che la qualità scende abbastanza da
+      rendere visibili gli artefatti, un'immagine più piccola a una qualità
+      decente si vede meglio di un'immagine a piena dimensione ma rovinata. Meno
+      pixel buoni battono più pixel cattivi.
+    </p>
+    <p>
+      È tutta lì la strategia, e vale la pena conoscerla anche se usi un altro
+      strumento: abbassa la qualità finché non comincia a venire male, poi
+      rimpicciolisci l'immagine invece di abbassarla ancora.
+    </p>
+    <h3>Quando ridimensionare di proposito</h3>
+    <p>
+      A volte i pixel non servivano proprio. Una foto larga 4000 pixel mostrata
+      in una colonna larga 600 pixel dentro una pagina web porta sei volte il
+      dettaglio che qualcuno vedrà. Se sai dove finirà l'immagine,
+      ridimensionala prima a quella misura e il problema del peso spesso sparisce
+      senza spendere alcuna qualità. Lo strumento per quel lavoro è il
+      <a href="../../ridimensionare-immagine/">ridimensionatore di immagini</a>,
+      e <a href="../ridimensionare-un-immagine/">la sua guida</a> spiega come
+      scegliere una dimensione.
+    </p>
+  </section>
+
+  <section>
+    <h2>Scegliere un formato</h2>
+    <p>
+      Vale la pena conoscere tre formati, e i browser sanno scriverli tutti e
+      tre.
+    </p>
+    <ul>
+      <li>
+        <strong>Il JPEG</strong> è per le fotografie. È con perdita, lo capisce
+        qualunque cosa sia mai stata costruita, e per l'immagine di una scena
+        reale resta un'ottima scelta. Non sa conservare la trasparenza.
+      </li>
+      <li>
+        <strong>Il WebP</strong> è per lo stesso lavoro, fatto meglio: dal 25 al
+        35% circa più leggero del JPEG a una qualità che non si distingue, e
+        tiene la trasparenza. Lo legge ogni browser attuale. Qualche vecchia
+        applicazione da scrivania e qualche modulo di caricamento aziendale
+        ancora no, che è l'unico motivo vero per non usarlo.
+      </li>
+      <li>
+        <strong>Il PNG</strong> è senza perdita, il che vuol dire che è esatto ed
+        è pesante. È la risposta giusta per screenshot, loghi, disegni al tratto
+        e qualunque cosa con bordi netti o tinte piatte, ed è la risposta
+        sbagliata per una fotografia.
+      </li>
+    </ul>
+    <p>
+      Se non hai vincoli da parte di chi ti ha chiesto il file, il WebP ti porta
+      all'obiettivo con meno danno visibile del JPEG. Se il file va dentro
+      qualcosa di vecchio, o dentro un sistema che non puoi provare, il JPEG è la
+      risposta sicura.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché il tuo PNG non si alleggerirà granché</h2>
+    <p>
+      È la sorpresa più comune, e non è un difetto dello strumento che stai
+      usando. Il PNG è un formato senza perdita: conserva i pixel esatti, e non
+      ha una manopola della qualità da girare, perché girarne una lo renderebbe
+      un formato diverso. Tutto quello che un compressore PNG può fare è
+      impacchettare gli stessi pixel in modo più furbo, cosa che di solito vale
+      qualche punto percentuale.
+    </p>
+    <p>
+      Quindi se ti serve per forza un file molto più leggero e deve restare un
+      PNG, l'unica leva che resta è la dimensione &mdash; meno pixel, o meno
+      colori. Se può smettere di essere un PNG, la domanda è cosa c'è dentro:
+    </p>
+    <ul>
+      <li>
+        <strong>Una fotografia salvata come PNG.</strong> Comunissimo, di solito
+        per sbaglio, ed è il guadagno più facile di questa pagina: convertirla in
+        JPEG o WebP spesso la rende da cinque a dieci volte più leggera senza
+        alcun cambiamento visibile.
+      </li>
+      <li>
+        <strong>Uno screenshot o uno schema.</strong> Converti in WebP, che è
+        anche senza perdita quando glielo chiedi, ed è in genere più leggero del
+        PNG a parità di pixel. Passare al JPEG rende sfocati i bordi del testo.
+      </li>
+      <li>
+        <strong>Un logo con trasparenza.</strong> Il WebP tiene la trasparenza;
+        il JPEG la riempirà di un colore pieno, che non è quasi mai quello che
+        volevi.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Come capire se il risultato è abbastanza buono</h2>
+    <p>
+      Guardare una miniatura non dimostra niente &mdash; a dimensione miniatura
+      viene bene tutto. Due controlli migliori:
+    </p>
+    <p>
+      <strong>Guardala a dimensione piena, sulla cosa più piatta
+      dell'inquadratura.</strong> Cielo, pelle, un muro dipinto. Il danno da
+      compressione si vede prima nelle sfumature morbide, come blocchi o bande
+      leggere, molto prima di toccare le zone dettagliate.
+    </p>
+    <p>
+      <strong>Leggi la misura, se lo strumento te ne dà una.</strong> Il
+      compressore di qui decodifica il proprio risultato e lo confronta con
+      l'originale, e riporta l'SSIM: un numero che confronta luminosità,
+      contrasto e struttura locali invece di contare i pixel cambiati, il che è
+      molto più vicino a ciò che dà fastidio a un occhio. Sopra lo 0,98 circa le
+      due immagini sono difficili da separare una accanto all'altra. Sotto lo
+      0,95 circa, guarda prima di mandare. Riporta anche il PSNR, il classico
+      valore in decibel, per chi lo preferisce.
+    </p>
+    <p>
+      Entrambi sono calcolati sul tuo dispositivo e mostrati a te, ed è tutto il
+      senso di averli: trasformano «perdita di qualità minima» da affermazione a
+      numero che puoi verificare.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tre cose da sapere prima di mandare il file</h2>
+    <p>
+      <strong>Comprimere toglie i metadati.</strong> Ricodificare vuol dire
+      decodificare l'immagine in pixel e ricodificare quei pixel, e una tela
+      piena di pixel non porta con sé alcun tag &mdash; quindi la posizione GPS,
+      il modello della fotocamera, gli orari e il resto semplicemente non
+      vengono scritti nel file nuovo. Di solito è un vantaggio. Se volevi via i
+      tag ma l'immagine intatta, è un altro lavoro: il
+      <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>
+      riscrive il contenitore senza ricomprimere niente, e
+      <a href="../rimuovere-i-dati-exif-e-gps/">la sua guida</a> spiega cosa c'è
+      là dentro.
+    </p>
+    <p>
+      <strong>Non comprimere mai lo stesso file due volte.</strong> Ogni
+      codifica con perdita butta via dettaglio per sempre, e codificare
+      un'immagine già compressa ne butta via ancora &mdash; compresi gli
+      artefatti del primo passaggio, che conserva fedelmente a spese di
+      dettaglio vero. Torna sempre all'originale e comprimi una volta sola.
+    </p>
+    <p>
+      <strong>Tieni l'originale.</strong> Da una codifica con perdita non si
+      torna indietro. Qualunque cosa tu mandi, tieni da qualche parte il file da
+      cui sei partito.
+    </p>
+  </section>
+
+  <section>
+    <h2>Niente di tutto questo ha bisogno di un caricamento</h2>
+    <p>
+      Ogni browser si porta dietro da anni un encoder JPEG, PNG e WebP &mdash; è
+      lo stesso codice che salva un'immagine da una tela. Comprimere un'immagine
+      è uno dei lavori che non hanno alcun motivo tecnico per coinvolgere un
+      server, ed è per questo che lo strumento di qui non ne ha uno: l'immagine
+      viene decodificata, codificata e misurata sul tuo dispositivo, e nella
+      <code>Content-Security-Policy</code> della pagina non c'è alcun indirizzo
+      appartenente a questo sito a cui spedirla.
+    </p>
+    <p>
+      Il modo più semplice per confermarlo, qui come altrove, è caricare la
+      pagina, staccare la connessione, e comprimere qualcosa lo stesso. Se
+      funziona ancora, non veniva caricato niente.
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone altre tre verifiche come questa.
+    </p>
+  </section>

--- a/locales/it/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/it/pages/guides/compress-an-image-to-a-target-size.toml
@@ -1,0 +1,17 @@
+#
+# Guida: comprimere un'immagine a una dimensione esatta - Italian.
+#
+
+nav = "Comprimere un'immagine"
+title = "Come comprimere un'immagine a un peso esatto"
+description = "Un modulo di caricamento vuole 500 KB e la tua foto pesa 4 MB. Quanto costa davvero un limite di peso, quale impostazione muovere per prima, e perché un PNG non si rimpicciolisce come un JPEG."
+heading = "Come comprimere un'immagine a un peso esatto"
+lede = """
+    Qualcuno ti ha detto un numero &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
+    &mdash; e la tua foto non ci si avvicina nemmeno. Qui c'è quanto costa quel
+    numero, su cosa spenderlo, e come capire se il risultato è ancora abbastanza
+    buono da mandare."""
+updated = "20 agosto 2026"
+og_title = "Comprimere un'immagine a un peso esatto"
+og_description = "Quanto costa davvero un limite di peso, quale impostazione muovere per prima, e perché un PNG non si rimpicciolisce come un JPEG."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/convert-an-svg-to-png.html
+++ b/locales/it/pages/guides/convert-an-svg-to-png.html
@@ -1,0 +1,247 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri <a href="../../svg-in-png/">Da SVG a immagine</a>, trascinaci dentro
+      il file, e indica una dimensione. Se nessuno ti ha detto che dimensione
+      usare, <strong>1024 pixel sul lato più lungo</strong> è un buon valore
+      predefinito: abbastanza grande per quasi tutto e abbastanza piccolo da
+      mandare via mail. Lascia il formato su PNG, lascia lo sfondo su
+      trasparente, e prendi il file.
+    </p>
+    <p>
+      Tutto quello che segue è cosa fare quando quel valore non basta &mdash;
+      quando un numero te l'hanno indicato, quando la cosa va in stampa, o quando
+      torna indietro con un aspetto sbagliato.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché la dimensione è una tua decisione e non del file</h2>
+    <p>
+      Un JPEG è una griglia di pixel misurati; chiedere quanto è grande ha una
+      risposta. Un SVG non è affatto un'immagine, è un insieme di istruzioni
+      &mdash; disegna un cerchio qui, questo tracciato di quel colore &mdash; e
+      le istruzioni non hanno dimensione. Un browser può eseguirle a 16 pixel o a
+      4000 e il risultato è ugualmente nitido nei due casi, perché non sta
+      scalando niente. Sta ridisegnando.
+    </p>
+    <p>
+      È per questo che la conversione non può scegliere un numero al posto tuo, e
+      perché sceglierne uno grande non ti costa niente. È l'unico lavoro sulle
+      immagini in cui «fallo più grande» è gratis.
+    </p>
+    <p>
+      Quasi tutti i file SVG portano con sé un attributo <code>width</code> e
+      <code>height</code>, e uno strumento te lo mostrerà &mdash; ma è un valore
+      di partenza, non un limite. Un'icona che dice <code>width="24"</code> dice
+      soltanto che chi l'ha disegnata aveva in mente una barra degli strumenti da
+      24&nbsp;pixel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Da dove viene davvero il numero</h2>
+    <p><strong>Per un sito web.</strong> Prendi la dimensione che l'immagine
+      occupa sulla pagina in pixel CSS e moltiplicala per la densità di pixel
+      degli schermi che ti interessano. Un logo in uno spazio largo
+      200&nbsp;pixel ha bisogno di un file da 400&nbsp;pixel per un portatile
+      Retina e da 600 per un telefono recente. È tutto lì il senso di
+      <code>@2x</code> e <code>@3x</code>, ed è il motivo per cui uno strumento
+      che le scrive ti risparmia di fare il conto tre volte.
+    </p>
+    <p><strong>Per l'icona di un'app, per una scheda su uno store o per una
+      favicon.</strong> Il numero è pubblicato e non c'è niente da calcolare:
+      quello che dice la pagina dello store, esattamente. Per una favicon non
+      rasterizzare affatto &mdash; <a href="../creare-una-favicon/">fai un
+      .ico</a>, che contiene parecchie dimensioni in un file solo, perché la
+      scheda di un browser, un segnalibro e un collegamento di Windows ne
+      chiedono di diverse.
+    </p>
+    <p><strong>Per la stampa.</strong> Moltiplica la dimensione fisica in pollici
+      per la risoluzione della stampante. Un logo che va su un biglietto da
+      visita largo due pollici a 300&nbsp;DPI sono 600 pixel; lo stesso logo
+      steso su una pagina A4, cioè 8,3&nbsp;pollici, sono circa 2500. Le
+      tipografie chiedono 300&nbsp;DPI per abitudine, e per uno striscione di
+      grande formato guardato dall'altra parte di una stanza 150 abbondano.
+    </p>
+    <p><strong>Per un'anteprima social o un'immagine OG.</strong> La piattaforma
+      indica un riquadro &mdash; 1200&nbsp;&times;&nbsp;630 per quasi tutte le
+      anteprime dei link &mdash; e il riquadro ha una forma diversa dal tuo logo.
+      È a questo che serve l'impostazione «riempi con lo sfondo»: il disegno
+      centrato nelle sue proporzioni, con un colore di sfondo a riempire il
+      resto, invece di un logo stirato che dice a tutti che non hai
+      controllato.
+    </p>
+    <p>
+      Quando ne valgono due, usa la più grande. Un PNG più grande del necessario
+      è uno scaricamento leggermente più pesante; uno troppo piccolo non si può
+      sistemare dopo, per il motivo della sezione successiva.
+    </p>
+  </section>
+
+  <section>
+    <h2>Non si torna indietro</h2>
+    <p>
+      Rasterizzare è a senso unico. Una volta che il disegno è un PNG sono pixel
+      come in qualunque altra immagine, e ingrandirlo dopo deve inventare
+      dettaglio che non è mai stato misurato &mdash; lo stesso risultato morbido
+      e spalmato che ottieni ingrandendo una fotografia.
+    </p>
+    <p>
+      Quindi tieni l'SVG. È la copia madre, è quasi sempre il file più leggero, e
+      ogni dimensione futura ne esce perfetta. Il PNG è un'esportazione per un
+      uso particolare, e quando ti serve un'altra dimensione la mossa giusta è
+      riesportare invece di ridimensionare quello che hai esportato.
+    </p>
+    <p>
+      C'è del software che dice di riconvertire un PNG in un SVG. Quello che fa è
+      ricalcare: indovinare quali curve potrebbero spiegare una griglia di pixel.
+      Funziona passabilmente su disegni piatti a due colori e produce sciocchezze
+      costose su tutto il resto, e non recupera mai quello che aveva il disegno
+      originale.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tre cose cambiano nel momento in cui diventa pixel</h2>
+    <p>
+      Un SVG rasterizzato che viene male viene male quasi sempre per uno di
+      questi tre motivi, e vale la pena conoscerli tutti e tre prima di esportare
+      invece che dopo.
+    </p>
+    <p>
+      <strong>Il testo viene disegnato con il carattere che la macchina
+      ha.</strong> Un SVG che contiene del testo non contiene il carattere
+      &mdash; ne nomina uno e lascia che sia chi disegna a trovarlo. Se il
+      carattere non è installato, ne viene usato un sostituto, e il sostituto ha
+      forme delle lettere e larghezze diverse, quindi il testo può riflusso o
+      traboccare. Un file che si tira il carattere da un indirizzo web se la
+      passa anche peggio: a un SVG che viene rasterizzato attraverso un
+      <code>&lt;img&gt;</code> non è concesso recuperare proprio niente, quindi
+      non arriva nulla.
+    </p>
+    <p>
+      La soluzione la conosce già ogni grafico: <strong>converti il testo in
+      tracciati</strong> prima di esportare l'SVG (Illustrator lo chiama Crea
+      contorni, Figma lo chiama Flatten, Inkscape lo chiama Da oggetto a
+      tracciato). Le lettere diventano geometria, il carattere smette di contare,
+      e l'immagine viene uguale su ogni macchina. Fallo su una copia &mdash; il
+      testo trasformato in tracciati non è più modificabile come testo.
+    </p>
+    <p>
+      <strong>I tratti da un capello diventano grigi o spariscono.</strong> Un
+      tratto che alla dimensione che hai scelto risulta più sottile di un pixel
+      non si può disegnare come una linea piena, quindi viene disegnato come una
+      linea sbiadita. È per questo che un logo delicato rasterizzato a
+      64&nbsp;pixel si vede slavato mentre lo stesso file a 512 viene perfetto.
+      Se una dimensione piccola è un obbligo, la risposta è un disegno
+      semplificato con tratti più spessi e non un'impostazione di esportazione
+      diversa &mdash; che è lo stesso motivo per cui una favicon è un simbolo e
+      non un marchio scritto.
+    </p>
+    <p>
+      <strong>L'animazione si ferma.</strong> Un SVG animato si rasterizza in un
+      unico fermo immagine: qualunque sia il primo fotogramma. Non c'è
+      un'impostazione di esportazione che cambi la cosa. Se ti serve il
+      movimento, ti serve una GIF o un video, fatti in un altro modo.
+    </p>
+  </section>
+
+  <section>
+    <h2>La trasparenza, e quale formato scegliere</h2>
+    <p>
+      <strong>PNG</strong>, a meno che tu non abbia un motivo. È senza perdita,
+      tiene la trasparenza, e le tinte piatte con i bordi netti &mdash; che sono
+      quasi tutto quello di cui è fatto un disegno &mdash; ci si comprimono bene.
+      Un logo rasterizzato di solito è un PNG <em>più leggero</em> di quanto
+      sarebbe un JPEG, oltre che più pulito.
+    </p>
+    <p>
+      Il <strong>JPEG</strong> non ha alcuna trasparenza. Ogni pixel trasparente
+      deve diventare un qualche colore, e se nessuno ne sceglie uno per te
+      diventa nero &mdash; ed è da qui che viene il risultato logo-su-rettangolo-
+      nero che la gente scambia per un difetto. È anche con perdita nel modo che
+      si vede peggio proprio su questo tipo di immagine: un anello di puntini
+      attorno a ogni bordo netto. Usalo quando qualcosa ci insiste.
+    </p>
+    <p>
+      Il <strong>WebP</strong> fa tutto quello che fa il PNG, in un file più
+      leggero, e lo legge ogni browser attuale. Il motivo per non usarlo è quello
+      che succede dopo il browser: il software più vecchio, certe tipografie e un
+      bel po' di moduli di caricamento ancora non ne aprono uno.
+    </p>
+    <p>
+      Anche scegliere un colore di sfondo con il PNG è una cosa perfettamente
+      normale da volere. La trasparenza serve solo quando la cosa su cui
+      l'immagine finisce è di un colore che non puoi prevedere; quando sai già
+      che è una pagina bianca, appiattire sul bianco evita tutta una categoria di
+      sorprese.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando l'esportazione esce vuota o sbagliata</h2>
+    <p>
+      <strong>Solo spazio vuoto.</strong> Di solito manca l'attributo
+      <code>xmlns</code> sull'elemento radice. Un file senza non è SVG per quanto
+      riguarda un tag immagine, e si disegna come niente. La prova rapida è
+      aprire il file in un browser: se anche il browser non mostra niente, il
+      problema è il file e non il convertitore.
+    </p>
+    <p>
+      <strong>Il disegno è piccolo, nell'angolo in alto a sinistra.</strong> Il
+      file ha un <code>width</code> e un <code>height</code> ma nessun
+      <code>viewBox</code>, quindi non c'è un sistema di coordinate da scalare e
+      il disegno tiene le proprie unità originali su una tela più grande. Un buon
+      convertitore ci mette un viewBox al posto tuo; se il tuo non l'ha fatto,
+      aggiungere a mano <code>viewBox="0 0 <em>larghezza</em>
+      <em>altezza</em>"</code> all'elemento radice sistema la cosa, e il file è
+      testo semplice, quindi puoi.
+    </p>
+    <p>
+      <strong>Manca una parte dell'immagine.</strong> Qualcosa nel file puntava a
+      un indirizzo invece di contenere il disegno &mdash; una fotografia
+      incorporata conservata come link, un foglio di stile, un carattere. Un
+      rasterizzatore che si rifiuta di recuperarli sta facendo la cosa giusta, ed
+      è lo stesso rifiuto che impedisce a un SVG che hai scaricato da qualche
+      parte di riferire a chi l'ha fatto. Riesporta dal programma di disegno con
+      le immagini incorporate.
+    </p>
+    <p>
+      <strong>Rifiuta una dimensione molto grande.</strong> I browser mettono un
+      tetto a quanto può essere grande una tela, e non sono d'accordo su dove:
+      oltre i 16.000&nbsp;pixel per lato circa non torna indietro niente, e
+      Safari su iPhone o iPad si arrende molto prima, attorno ai
+      4096&nbsp;&times;&nbsp;4096. Uno strumento che ti avverte ti sta salvando
+      da un file vuoto, perché è quello che un browser produce quando è a corto,
+      invece di un messaggio d'errore.
+    </p>
+  </section>
+
+  <section>
+    <h2>Niente di tutto questo ha bisogno di un caricamento</h2>
+    <p>
+      Rasterizzare un SVG è una cosa che ogni browser fa migliaia di volte al
+      giorno &mdash; è lo stesso meccanismo che disegna un'icona su una pagina
+      web. Non c'è alcun motivo tecnico per cui il tuo disegno debba andare fino
+      a un server e tornare per uscirne come PNG, e lo strumento di qui non lo
+      manda da nessuna parte: la <code>Content-Security-Policy</code> della
+      pagina nomina tutti gli indirizzi che può contattare, e nessuno di questi
+      appartiene a questo sito.
+    </p>
+    <p>
+      Con l'SVG conta più del solito, perché un SVG è un documento e non
+      un'immagine. Può contenere uno script e un indirizzo remoto, e un logo che
+      ti ha mandato un'agenzia è un file che non hai scritto tu. Disegnato
+      attraverso un tag immagine si trova in quella che la specifica chiama
+      <em>secure static mode</em>: lo script non può girare e l'indirizzo non
+      viene mai contattato. A farlo rispettare è il browser, non il sito.
+    </p>
+    <p>
+      Carica la pagina, stacca la connessione, e converti qualcosa lo stesso se
+      preferisci verificare invece che crederci.
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone altre tre verifiche che puoi fare
+      su qualunque strumento.
+    </p>
+  </section>

--- a/locales/it/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/it/pages/guides/convert-an-svg-to-png.toml
@@ -1,0 +1,16 @@
+#
+# Guida: convertire un SVG in PNG - Italian.
+#
+
+nav = "Convertire un SVG in PNG"
+title = "Come convertire un SVG in PNG alla dimensione giusta"
+description = "Un vettoriale non ha una dimensione in pixel sua, quindi il numero lo scegli tu. Da dove viene quel numero per uno schermo, per l'icona di un'app e per una stampante, e cosa cambia quando un disegno diventa pixel."
+heading = "Come convertire un SVG in PNG alla dimensione giusta"
+lede = """
+    Convertire è la metà facile. La domanda che decide se il risultato serve a
+    qualcosa è quella a cui nessuno ti dà una risposta: quanti pixel? Qui c'è da
+    dove viene quel numero, e cosa perde un disegno mentre diventa uno."""
+updated = "20 agosto 2026"
+og_title = "Convertire un SVG in PNG alla dimensione giusta"
+og_description = "Da dove viene davvero il numero di pixel, e le tre cose che cambiano quando un disegno diventa pixel."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/convert-heic-to-jpg.html
+++ b/locales/it/pages/guides/convert-heic-to-jpg.html
@@ -1,0 +1,252 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../heic-in-jpg/">convertitore da HEIC a JPG</a>,
+      trascinaci dentro le foto, e premi «Converti». Lascia il cursore della
+      qualità dov'è e lascia spuntato «tieni la data, la fotocamera e le
+      impostazioni», a meno che tu non abbia un motivo per non farlo. Ti tornano
+      indietro dei JPEG, con un pulsante di download ciascuno, o uno zip se sono
+      parecchi.
+    </p>
+    <p>
+      Mentre lo fai non viene caricato niente. Per questo lavoro in particolare è
+      una cosa insolita, e il perché è la metà interessante di questa pagina.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cos'è davvero l'HEIC</h2>
+    <p>
+      L'HEIC non è propriamente un formato di immagine nel modo in cui lo è il
+      JPEG. È un contenitore &mdash; la stessa struttura a scatole con cui è
+      costruito un MP4 &mdash; con dentro un fotogramma fermo di video
+      <strong>HEVC</strong>. L'HEVC, chiamato anche H.265, è il codec che ha
+      sostituito quello che usava la tua vecchia videocamera, ed è molto buono:
+      una foto dell'iPhone in HEIC pesa all'incirca la metà della stessa foto in
+      JPEG a parità di qualità.
+    </p>
+    <p>
+      Apple è passata a lui in iOS 11, nel 2017, e l'ha messo come predefinito.
+      Il che vuol dire che, a meno che qualcuno non sia entrato in Impostazioni e
+      abbia scelto «Massima compatibilità», ogni foto che il suo telefono ha
+      scattato in quasi un decennio è in un formato che:
+    </p>
+    <ul>
+      <li>Windows non mostra in anteprima senza un'estensione dallo Store;</li>
+      <li>quasi tutti i moduli di caricamento web rifiutano subito;</li>
+      <li>moltissimo software da scrivania più vecchio non ha mai sentito
+        nominare;</li>
+      <li>e che nessun browser tranne Safari mostra.</li>
+    </ul>
+    <p>
+      La foto sta benissimo. È un file migliore di quanto sarebbe stato il JPEG.
+      È semplicemente scritta in una lingua che quasi tutto il mondo non ha mai
+      imparato.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché lo apre solo Safari</h2>
+    <p>
+      È la parte che spiega ogni convertitore che tu abbia mai usato, quindi vale
+      un paragrafo.
+    </p>
+    <p>
+      Decodificare l'HEVC richiede un decodificatore HEVC, e l'HEVC è brevettato.
+      Le licenze sono amministrate da più di un consorzio di brevetti, e spedire
+      un decodificatore vuol dire pagare qualcuno. I browser se la cavano
+      appoggiandosi al sistema operativo &mdash; Chrome riproduce
+      <em>video</em> HEVC su una macchina il cui hardware ha già un
+      decodificatore con licenza &mdash; ma quella strada è cablata per la
+      riproduzione video e non per le immagini ferme. Quindi un HEIC consegnato a
+      un <code>&lt;img&gt;</code> viene rifiutato, in Chrome, in Firefox e in
+      Edge allo stesso modo, su qualunque sistema operativo.
+    </p>
+    <p>
+      Safari su hardware Apple è l'eccezione, perché macOS e iOS hanno il
+      decodificatore e a Safari è concesso chiederlo. Dappertutto altrove
+      l'immagine è semplicemente indecodificabile per il browser.
+    </p>
+    <p>
+      Il che lascia a un convertitore esattamente due possibilità, e la scelta
+      tra le due è tutta la storia di questo tipo di strumento.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché quasi ogni convertitore HEIC vuole un caricamento</h2>
+    <p>
+      Possibilità uno: mettere il decodificatore su un server. La foto viene
+      caricata, decodificata su una macchina che non hai mai visto, ricodificata
+      come JPEG e rispedita indietro. È quello che fa quasi ogni «convertitore
+      HEIC online gratuito», ed è il motivo per cui hanno tutti bisogno dei tuoi
+      file. Non è pigrizia &mdash; il browser davvero non ce la fa da solo.
+    </p>
+    <p>
+      Su quanto costa vale la pena essere schietti. Le foto di un telefono sono i
+      file più personali che quasi tutti possiedano, e un HEIC appena uscito da
+      un iPhone porta con sé di solito le coordinate del posto in cui è stato
+      scattato, precise a pochi metri, insieme alla data al secondo e a un
+      identificatore della fotocamera. Caricare una cartella di quelle su un
+      servizio gratuito vuol dire consegnare sia le immagini sia tutto questo.
+      Cosa succede dopo è regolato da un'informativa che non hai letto, su un
+      server che non puoi ispezionare, in una giurisdizione che non hai scelto.
+    </p>
+    <p>
+      Possibilità due: mettere il decodificatore nella pagina. È quello che fa
+      <a href="../../heic-in-jpg/">questo</a>. Si porta dietro
+      <code>libheif</code>, compilato in WebAssembly, come file servito da questo
+      sito &mdash; circa 1,4 MB, scaricati una volta e poi messi in cache. Il tuo
+      browser lo esegue sul tuo dispositivo, sul tuo hardware, e la foto non va
+      da nessuna parte. Carica la pagina una volta e puoi staccare del tutto la
+      connessione e continua a funzionare, cosa che nessun convertitore che
+      carica può fare e la prova più semplice che ci sia.
+    </p>
+    <p>
+      L'1,4 MB è tutto il prezzo. Se sei su una connessione a consumo è un costo
+      vero e vale la pena saperlo; è per questo che la pagina lo dice a voce alta
+      invece di scaricarlo in silenzio.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quanto costa all'immagine la conversione</h2>
+    <p>
+      HEIC e JPEG sono codec diversi, quindi non c'è una strada che non comporti
+      decodificare l'immagine e ricodificarla. Quella seconda codifica è con
+      perdita. In pratica conta molto meno di quanto sembri:
+    </p>
+    <ul>
+      <li>
+        <strong>Alla qualità 92</strong> &mdash; da cui parte il convertitore
+        &mdash; una fotografia è molto difficile da distinguere dall'originale a
+        qualunque normale dimensione di visione. Le differenze si cercano nelle
+        sfumature morbide, come un cielo terso, e di solito non si trovano.
+      </li>
+      <li>
+        <strong>Il JPEG sarà più pesante.</strong> Di solito tra un terzo in più
+        e il doppio, perché il JPEG è un codec del 1992 e l'HEVC no. È lo
+        scambio: un file più pesante che apre chiunque.
+      </li>
+      <li>
+        <strong>Quello da evitare è convertire due volte.</strong> Ogni codifica
+        con perdita costa un po'. Converti dall'HEIC originale, non da un JPEG
+        che qualcuno ha già fatto per te, e fallo una volta sola.
+      </li>
+    </ul>
+    <p>
+      Se non vuoi alcuna perdita, nel menu dei formati c'è il PNG. Preparati al
+      peso: una fotografia come PNG pesa di solito da cinque a dieci volte il
+      JPEG, perché la compressione del PNG è stata pensata per le tinte piatte e
+      i disegni al tratto, non per l'erba e la pelle.
+    </p>
+  </section>
+
+  <section>
+    <h2>La data, la fotocamera e le coordinate</h2>
+    <p>
+      La lamentela abituale sui convertitori HEIC è che le foto tornano indietro
+      avendo perso il giorno dello scatto, così un'intera vacanza di immagini
+      finisce in fondo alla libreria sotto la data di oggi. Succede perché
+      convertire passando per una tela ti dà pixel e nient'altro &mdash; una tela
+      non contiene tag &mdash; quindi, a meno che un convertitore non vada a
+      prendere i metadati a parte, sono semplicemente spariti.
+    </p>
+    <p>
+      Lo strumento di qui copia il blocco EXIF fuori dall'HEIC e lo scrive nel
+      JPEG, così la data sopravvive. C'è una casella, ed è spuntata di default.
+      Toglila e il JPEG esce con l'immagine e nient'altro.
+    </p>
+    <p>
+      Prima di decidere, guarda l'elenco: la riga di ogni foto dice se il file
+      porta con sé delle coordinate GPS, e lo dice prima che venga convertito
+      qualcosa. Se le foto vanno in un posto pubblico, è quella la riga da
+      leggere. Se vanno nella tua libreria, tenere i metadati è quasi certamente
+      quello che vuoi.
+    </p>
+    <p>
+      Un tag viene cambiato qualunque cosa tu scelga, e vale la pena sapere
+      perché. Un HEIC registra la propria rotazione in due posti: nel contenitore
+      e nel blocco EXIF. Il decodificatore applica la rotazione del contenitore
+      mentre decodifica, quindi i pixel che consegna sono già dritti. Se poi
+      l'EXIF continuasse a dire «ruota questa di 90 gradi», un visualizzatore lo
+      farebbe di nuovo e ogni foto verticale uscirebbe di traverso. Quindi il tag
+      di orientamento viene messo su «dritto» e tutto il resto viene copiato
+      esattamente come l'aveva scritto il telefono.
+    </p>
+    <p>
+      Se quello che vuoi è passare in rassegna i tag nel dettaglio, o toglierli da
+      foto che sono già JPEG, è un altro lavoro e c'è
+      <a href="../rimuovere-i-dati-exif-e-gps/">una guida apposta</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cose su cui la gente inciampa</h2>
+    <ul>
+      <li>
+        <strong>Un HEIC chiamato «.jpg».</strong> Comunissimo: qualcosa lungo la
+        strada l'ha rinominato senza convertirlo, ed è per questo che continua a
+        non aprirsi. Ogni file trascinato sul convertitore viene identificato dai
+        suoi primi byte invece che dal nome, quindi uno di questi funziona
+        benissimo. È anche il motivo per cui a un file che è davvero un JPEG viene
+        detto che lo è, invece di convertirlo in una copia di sé stesso.
+      </li>
+      <li>
+        <strong>Un file, parecchie immagini.</strong> Una raffica o una Live
+        Photo può contenere più di un fermo immagine. Vengono convertite tutte, e
+        quelle in più vengono numerate dopo il nome originale. La metà video di
+        una Live Photo è un file a parte che il telefono tiene accanto all'HEIC,
+        quindi lì dentro non c'è da convertire.
+      </li>
+      <li>
+        <strong>L'AVIF non è l'HEIC.</strong> Si somigliano &mdash; stesso
+        contenitore, codec diverso dentro &mdash; ma ogni browser attuale apre un
+        AVIF nativamente, quindi non c'è niente da convertire e lo strumento lo
+        dice invece di fingere di lavorare.
+      </li>
+      <li>
+        <strong>Fermare il problema alla fonte.</strong> Sul telefono:
+        Impostazioni &rarr; Fotocamera &rarr; Formati &rarr; Massima
+        compatibilità. Da lì in poi le foto nuove sono JPEG. Occupa più spazio e
+        non tocca le foto che hai già, ma vuol dire non doverlo rifare mai più.
+      </li>
+      <li>
+        <strong>A volte la condivisione converte già.</strong> Mandare una foto
+        con AirDrop o per mail a un dispositivo non Apple spesso consegna un
+        JPEG, perché iOS converte in uscita. Se una foto è arrivata comunque come
+        HEIC, è passata da una strada che non lo faceva.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Come capire se un convertitore sta caricando</h2>
+    <p>
+      Vale per qualunque strumento, non solo per questo, e richiede una quindicina
+      di secondi.
+    </p>
+    <ol>
+      <li>
+        Apri la pagina, poi apri gli strumenti di sviluppo del tuo browser e vai
+        alla scheda Rete.
+      </li>
+      <li>
+        Converti una foto, e guarda. Uno strumento che decodifica sul tuo
+        dispositivo in quel momento non fa proprio alcuna richiesta. Uno strumento
+        che carica ne fa una della dimensione della tua foto, e la dimensione la
+        vedi.
+      </li>
+      <li>
+        Oppure, più semplicemente: carica la pagina, stacca la connessione, e
+        prova a convertire qualcosa. Uno strumento che spediva via la tua foto per
+        farla decodificare si ferma. Uno che si porta dietro il decodificatore no.
+      </li>
+    </ol>
+    <p>
+      Il convertitore di qui è costruito per superare entrambe le verifiche, e
+      c'è una versione più lunga di questo ragionamento in
+      <a href="../e-sicuro-caricare-i-propri-file/">è sicuro caricare i propri
+      file</a>.
+    </p>
+  </section>

--- a/locales/it/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/it/pages/guides/convert-heic-to-jpg.toml
@@ -1,0 +1,17 @@
+#
+# Guida: da HEIC a JPG, e cos'è davvero l'HEIC - Italian.
+#
+
+nav = "Da HEIC a JPG"
+title = "Come convertire un HEIC in JPG (e cos'è davvero l'HEIC)"
+description = "Gli iPhone salvano le foto in HEIC, e mezza internet non riesce ad aprirne una. Cos'è il formato, perché solo Safari lo decodifica, quanto costa convertire all'immagine, e come farlo senza caricare le foto da nessuno."
+heading = "La foto che il tuo telefono ha salvato, e il formato che non apre niente"
+lede = """
+    Un iPhone salva le foto in HEIC, che è più leggero e migliore del JPEG e che
+    moltissimo software si rifiuta ancora di aprire. Qui c'è cos'è davvero quel
+    formato, quanto costa convertirlo all'immagine, e perché quasi ogni
+    convertitore vuole prima che tu lo carichi."""
+updated = "20 agosto 2026"
+og_title = "Come convertire un HEIC in JPG"
+og_description = "Perché le foto dell'iPhone non si aprono, quanto costa convertirle, e come farlo senza consegnarle a nessuno."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/crop-a-video.html
+++ b/locales/it/pages/guides/crop-a-video.html
@@ -1,0 +1,217 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../ritagliare-video/">ritagliatore di video</a>,
+      trascinaci dentro la clip, trascina il riquadro sulla parte che vuoi tenere
+      &mdash; oppure bloccalo su una forma, se te ne hanno data una &mdash; ed
+      esporta. La clip che esce è lunga esattamente come quella che è entrata,
+      con i suoi tempi e il suo audio intatti.
+    </p>
+    <p>
+      A differenza del tagliare, questo lavoro deve scrivere fotogrammi nuovi.
+      Non è una mancanza di un particolare strumento; è cos'è il ritaglio. Il
+      resto di questa pagina riguarda quanto costa e come tenerlo basso.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché ritagliare non può evitare una ricodifica</h2>
+    <p>
+      Un taglio tiene fotogrammi interi, quindi un buon tagliavideo li sposta
+      dall'altra parte intatti e non viene decodificato proprio niente. Un
+      ritaglio tiene una parte di ogni fotogramma &mdash; e una parte di
+      fotogramma è un'immagine diversa. Non c'è modo di conservare un'immagine
+      diversa senza riscrivere i pixel da capo.
+    </p>
+    <p>
+      C'è un'eccezione stretta, e vale la pena conoscerla per riconoscere quando
+      qualcuno la sta rivendicando. Il video è codificato a blocchi, e se un
+      ritaglio cadesse esattamente sui confini dei blocchi su tutti e quattro i
+      lati, in linea di principio una parte dei dati si potrebbe riusare. In
+      pratica le dimensioni stesse del fotogramma, i vettori di movimento e la
+      predizione vanno riscritti comunque, quindi non c'è niente di reale
+      costruito così. Dai per scontato che un ritaglio voglia dire una
+      ricodifica.
+    </p>
+    <p>
+      Quello che un ritagliatore ben educato farà è non spendere <em>più</em> di
+      quanto spendesse l'originale sulla stessa zona. Codificare una zona
+      ritagliata a un bitrate più alto della sorgente rende il file solo più
+      pesante; non può rimettere dentro dettaglio che l'originale non aveva.
+    </p>
+  </section>
+
+  <section>
+    <h2>Le forme che ti stanno davvero chiedendo</h2>
+    <p>
+      Quasi tutti i ritagli si fanno perché da qualche parte c'è una proporzione
+      obbligatoria. L'elenco corto:
+    </p>
+    <ul>
+      <li>
+        <strong>9:16 &mdash; verticale.</strong> Storie, reel, short, TikTok. A
+        schermo pieno su un telefono tenuto normalmente. Il motivo più comune per
+        cui qualcuno ritaglia un video.
+      </li>
+      <li>
+        <strong>1:1 &mdash; quadrato.</strong> I post nei feed di parecchie
+        piattaforme. Funziona da qualunque verso chi guarda tenga il telefono,
+        ed è per questo che resiste.
+      </li>
+      <li>
+        <strong>4:5 &mdash; leggermente verticale.</strong> La forma più grande
+        che certi feed consentono, quindi prende più schermo di un quadrato senza
+        essere un video verticale pieno.
+      </li>
+      <li>
+        <strong>16:9 &mdash; orizzontale.</strong> Lo standard del video in
+        generale. Di solito ritagli <em>verso</em> questa forma solo per togliere
+        le bande nere, o <em>da</em> questa forma per ottenere una delle
+        precedenti.
+      </li>
+    </ul>
+    <p>
+      Blocca il riquadro sulla proporzione invece di trascinarlo a occhio.
+      Sbagliare di qualche pixel vuol dire che la piattaforma ritaglia il tuo
+      ritaglio, e non ti consulterà su dove.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rendere verticale una clip orizzontale</h2>
+    <p>
+      È il caso comune più difficile, e vale la pena essere chiari che ritagliare
+      è un compromesso e non una soluzione.
+    </p>
+    <p>
+      Un video 16:9 ritagliato a 9:16 tiene circa il 32% della larghezza
+      dell'immagine. Tutto quello che sta ai lati sparisce &mdash; e in uno
+      scatto orizzontale, ai lati di solito c'è il contesto. Se due persone
+      parlano ai due estremi dell'inquadratura, non c'è un solo ritaglio che le
+      tenga entrambe.
+    </p>
+    <p>
+      Scegli il ritaglio guardando la clip una volta e chiedendoti dove sta
+      davvero il soggetto per la maggior parte del tempo. Se la risposta è «si
+      muove», un ritaglio fisso è lo strumento sbagliato e quello che ti serve è
+      un programma di montaggio che sappia spostare il ritaglio nel tempo. Se la
+      risposta è «al centro, quasi sempre», un ritaglio centrato va benissimo e
+      richiede dieci secondi.
+    </p>
+    <p>
+      L'alternativa da ricordare: molte piattaforme accettano un video
+      orizzontale e ci mettono loro le bande. Il ritaglio serve per quando vuoi
+      lo schermo pieno, non per quando vuoi che il video venga accettato.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché larghezza e altezza si muovono di due in due</h2>
+    <p>
+      Se noti che il riquadro di ritaglio rifiuta i numeri dispari, a fare il
+      difficile è il codec e non l'interfaccia.
+    </p>
+    <p>
+      L'H.264 &mdash; il codec dentro un MP4 &mdash; conserva il colore a metà
+      risoluzione in orizzontale e in verticale, perché l'occhio è molto meno
+      sensibile al dettaglio di colore che a quello di luminosità. Vuol dire che
+      l'immagine viene gestita a unità di due pixel e non c'è modo di descrivere
+      un fotogramma con un numero dispari di pixel su un lato.
+    </p>
+    <p>
+      Gli strumenti se la cavano arrotondando il tuo ritaglio dopo che l'hai
+      impostato, cosa che sposta il riquadro di un pixel senza dirtelo, oppure
+      proponendo fin dall'inizio solo numeri pari. Qui succede la seconda.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa succede al suono</h2>
+    <p>
+      Niente, sulla via dell'MP4. Ritagliare cambia l'immagine e non ha alcun
+      motivo di toccare l'audio, quindi l'audio viene copiato dall'altra parte
+      campione per campione senza essere mai decodificato &mdash; byte per byte
+      quello che c'era nel file.
+    </p>
+    <p>
+      Sul ripiego della registrazione, descritto qui sotto, il suono viene
+      catturato dalla riproduzione e ricodificato, il che costa un po' di
+      qualità. In entrambi i casi c'è una casella per lasciarlo fuori del tutto,
+      che vale la pena usare quando la clip va in un posto che la riproduce muta
+      comunque e vuoi il file più leggero.
+    </p>
+  </section>
+
+  <section>
+    <h2>I formati, e quanto ci mette</h2>
+    <p>
+      <strong>MP4, M4V e MOV</strong> vengono letti direttamente, qualunque cosa
+      ci sia dentro &mdash; H.264, HEVC, AV1 o VP9 &mdash; purché il tuo browser
+      sappia decodificare quel codec. A differenza del tagliare, il ritagliare
+      deve decodificare, quindi qui il codec conta in un modo in cui là non
+      conta.
+    </p>
+    <p>
+      <strong>Tutto il resto che il tuo browser sa riprodurre</strong>, il WebM
+      in primis, viene ritagliato riproducendolo e registrando il risultato, cosa
+      che funziona e richiede tanto tempo quanto è lunga la clip.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV e quasi tutti gli MKV</strong> il browser non li sa
+      né leggere né riprodurre, e lo strumento li rifiuta con un messaggio invece
+      di piantarsi a metà strada.
+    </p>
+    <p>
+      Aspettati che un ritaglio richieda tempo vero su una clip lunga, perché
+      ogni fotogramma viene decodificato e ricodificato. Nello strumento non c'è
+      alcun limite, e il file viene percorso qualche megabyte alla volta invece
+      di essere caricato tutto; il tetto pratico è il video finito, che viene
+      assemblato in memoria prima che tu lo scarichi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ritaglia prima di fare qualunque altra cosa</h2>
+    <p>
+      Se una clip ha bisogno sia di essere accorciata sia di essere ritagliata,
+      accorciala per prima &mdash; è gratis, e ogni secondo che tagli è un
+      secondo che nessuno deve ricodificare. Poi ritaglia una volta sola la clip
+      più corta.
+    </p>
+    <p>
+      Farlo al contrario vuol dire ritagliare riprese che stai per buttare, cosa
+      che costa tempo e qualità per niente. Il
+      <a href="../../tagliare-video/">tagliavideo</a> è qui accanto, e
+      <a href="../tagliare-un-video/">la sua guida</a> spiega perché quel
+      passaggio non deve costarti proprio niente.
+    </p>
+    <p>
+      Più in generale: ogni passaggio con perdita si somma. Un ritaglio di un
+      originale è una generazione. Un ritaglio di un taglio di un'esportazione di
+      uno scaricamento sono quattro, e si vede.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché questo non ha bisogno di un caricamento</h2>
+    <p>
+      Decodificare e ricodificare video in un browser è una cosa recente ed è una
+      cosa vera: WebCodecs espone lo stesso encoder hardware che il tuo telefono
+      usa per registrare video, ed è veloce per lo stesso motivo. Il lavoro
+      avviene sul dispositivo che ha già il file, il che per un video da parecchi
+      gigabyte è anche l'unica disposizione che abbia senso &mdash; caricarlo e
+      riscaricare il risultato costa più tempo della codifica.
+    </p>
+    <p>
+      Lo strumento di qui non ha alcuna funzione di rete, e la
+      <code>Content-Security-Policy</code> della pagina nomina tutti gli
+      indirizzi che può contattare, nessuno dei quali appartiene a questo sito.
+      Stacca la connessione e ritaglia una clip lo stesso, se preferisci
+      verificare invece che crederci.
+    </p>
+    <p>
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone altre tre verifiche che puoi fare
+      su qualunque strumento.
+    </p>
+  </section>

--- a/locales/it/pages/guides/crop-a-video.toml
+++ b/locales/it/pages/guides/crop-a-video.toml
@@ -1,0 +1,17 @@
+#
+# Guida: ritagliare un video - Italian.
+#
+
+nav = "Ritagliare un video"
+title = "Come ritagliare un video in una forma diversa"
+description = "Riduci una clip a un quadrato, a un verticale 9:16 o a un riquadro di pixel esatto. Quale proporzione vuole ogni piattaforma, perché ritagliare deve ricodificare mentre tagliare no, e quanto costa."
+heading = "Come ritagliare un video in una forma diversa"
+lede = """
+    Ritagliare cambia la forma dell'immagine, il che vuol dire scrivere
+    fotogrammi nuovi &mdash; non c'è modo di aggirarlo, e qualunque strumento
+    dica il contrario sta facendo un'altra cosa. Qui c'è quanto costa, e come
+    spenderlo bene."""
+updated = "20 agosto 2026"
+og_title = "Come ritagliare un video in una forma diversa"
+og_description = "Quale proporzione vuole ogni piattaforma, perché ritagliare deve ricodificare mentre tagliare no, e quanto costa."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/embed-an-image-in-css.html
+++ b/locales/it/pages/guides/embed-an-image-in-css.html
@@ -1,0 +1,317 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri <a href="../../immagine-in-base64/">Immagine in data URI</a>,
+      trascinaci dentro l'immagine, scegli <em>una proprietà personalizzata
+      CSS</em>, e incolla la riga in cima al tuo foglio di stile. Poi usala come
+      <code>background-image: var(--logo)</code> dove ti serve.
+    </p>
+    <p>
+      Fallo quando l'immagine è piccola &mdash; un'icona, un punto elenco, una
+      freccetta, un motivo &mdash; e serve su ogni pagina. Non farlo con una
+      fotografia. Tutto quello che segue è perché quelle due frasi sono diverse,
+      e come capire quale delle due hai davanti.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cos'è davvero un data URI</h2>
+    <p>
+      Un indirizzo che contiene la cosa invece di puntarci. Dove un foglio di
+      stile direbbe normalmente
+    </p>
+    <pre><code>background-image: url("logo.png");</code></pre>
+    <p>
+      e il browser va a recuperare <code>logo.png</code>, un data URI dice
+    </p>
+    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <p>
+      e non c'è niente da recuperare: l'immagine è già lì, scritta in caratteri.
+      Le parti sono tre. <code>data:</code> è lo schema. <code>image/png</code> è
+      il tipo di media, e il browser ci crede completamente &mdash; su questo
+      torniamo sotto. Tutto quello che sta dopo la virgola è il file.
+    </p>
+    <p>
+      È tutta lì l'idea. Non è un trucco né un espediente; sta negli standard dal
+      1998 e funziona in ogni browser uscito da allora.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa ci guadagni: un giro in meno</h2>
+    <p>
+      Il risparmio non è di banda. È della richiesta.
+    </p>
+    <p>
+      Un browser non può chiedere <code>logo.png</code> finché non ha letto il
+      foglio di stile che lo nomina, e non può leggere il foglio di stile finché
+      non l'ha recuperato. Quindi una normale immagine di sfondo sta ad almeno
+      due giri di profondità nel caricamento della pagina, e su un telefono con
+      una rete lenta un giro può valere un paio di centinaia di millisecondi a
+      prescindere da quanto sia leggero il file. Una freccetta da 600 byte costa
+      quasi niente da trasferire e può comunque costare un quarto di secondo per
+      arrivare.
+    </p>
+    <p>
+      Incorporata, arriva insieme al foglio di stile. È tutto lì il vantaggio, e
+      per una piccola icona che compare nella prima schermata è un vantaggio
+      vero.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa costa: un terzo, e poi la cache</h2>
+    <p>
+      <strong>Il base64 aggiunge circa un terzo.</strong> Tre byte di file
+      diventano quattro caratteri, perché è quello che ci vuole per scrivere byte
+      arbitrari usando solo i caratteri che un URL consente. Non c'è un encoder
+      furbo che lo eviti. Un PNG da 9 KB sono 12 KB di foglio di stile.
+    </p>
+    <p>
+      <strong>La compressione non te lo restituisce.</strong> È la parte che la
+      gente dà per scontata. Gzip e Brotli funzionano trovando ridondanza, e un
+      PNG, un JPEG e un WebP sono già stati compressi &mdash; di ridondanza ne è
+      rimasta pochissima, e il base64 non ne aggiunge. In pratica ti torna
+      indietro qualcosa come un decimo di quel terzo, non tutto. (Un SVG è il
+      caso opposto, e la sezione successiva parla di quello.)
+    </p>
+    <p>
+      <strong>Smette di essere un file.</strong> È il costo che non compare in
+      nessuna misura che è probabile tu prenda, ed è quello che conta quando le
+      dimensioni crescono:
+    </p>
+    <ul>
+      <li>
+        <strong>Non può stare in cache per conto suo.</strong> Un'immagine
+        normale viene recuperata una volta e riusata per un anno. Una incorporata
+        è parte del foglio di stile, quindi vive e muore con la voce di cache del
+        foglio di stile.
+      </li>
+      <li>
+        <strong>Cambiare qualunque cosa fa riscaricare tutto.</strong> Sistemi un
+        margine, pubblichi un nuovo foglio di stile, e ogni visitatore riscarica
+        insieme a lui l'immagine incorporata &mdash; un'immagine che non cambia
+        da due anni.
+      </li>
+      <li>
+        <strong>Sta sul percorso critico.</strong> Un foglio di stile blocca il
+        disegno della pagina. Un'immagine no. Incorporare un'immagine la sposta
+        dalla seconda categoria alla prima: la pagina non può dipingersi finché
+        non è arrivato tutto, immagine compresa.
+      </li>
+      <li>
+        <strong>Non può essere recuperata in parallelo.</strong> I browser
+        scaricano molte cose insieme. Un'immagine incorporata non è una cosa a
+        sé, quindi di tutto questo non ha niente.
+      </li>
+    </ul>
+    <p>
+      Soglie spannometriche, che sono i punti in cui cambia il consiglio e non
+      quelli in cui un browser fa qualcosa di diverso: sotto i 2 KB circa è un
+      guadagno netto; fino ai 10 KB circa di solito ne vale ancora la pena per
+      qualcosa che sta su ogni pagina; oltre i 50 KB è un errore senza messaggio
+      d'errore. <a href="../../immagine-in-base64/">Lo strumento</a> ti dice in
+      quale fascia cade ogni risultato, con accanto il numero di caratteri.
+    </p>
+  </section>
+
+  <section>
+    <h2>Non mettere mai un SVG in base64</h2>
+    <p>
+      È l'errore di gran lunga più comune nelle immagini incorporate, e lo fanno
+      gli esportatori e i plugin di compilazione tanto quanto le persone.
+    </p>
+    <p>
+      Un SVG è testo. Un URL sa già portare testo. Solo una manciata di caratteri
+      va protetta &mdash; <code>%</code>, <code>#</code>, <code>&lt;</code>,
+      <code>&gt;</code> e la virgoletta con cui l'hai avvolto &mdash; e tutto il
+      resto si può lasciare esattamente com'è. Codificarlo così ti dà un URI che
+      di solito è circa un quinto più corto del base64 dello stesso file, e che
+      poi si comprime come testo invece che come rumore.
+    </p>
+    <p>
+      Ed è anche ancora leggibile:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <p>
+      Il <code>viewBox</code> lo vedi. Il colore di riempimento lo puoi cambiare
+      nel tuo editor senza decodificare niente. Metti in base64 lo stesso file e
+      diventa un muro di lettere che nessuno toccherà mai più.
+      <a href="../../immagine-in-base64/">Immagine in data URI</a> lo fa
+      automaticamente per tutto ciò che risulta essere un SVG, e ha una casella
+      per la rara catena di strumenti che insiste su <code>;base64</code>.
+    </p>
+  </section>
+
+  <section>
+    <h2>L'errore di virgolette che rompe solo gli SVG</h2>
+    <p>
+      Il CSS ti lascia scrivere <code>url()</code> senza virgolette, e per un
+      normale nome di file va bene:
+    </p>
+    <pre><code>background-image: url(logo.png);</code></pre>
+    <p>
+      Fai lo stesso con un SVG codificato in percentuale e si rompe. Un token
+      <code>url()</code> senza virgolette finisce al primo spazio, parentesi,
+      virgoletta o carattere di controllo &mdash; e un SVG è pieno di spazi, tra
+      ogni attributo e ogni numero di un tracciato. La dichiarazione è allora non
+      valida, il CSS scarta in silenzio le dichiarazioni non valide, e tu non
+      ottieni né sfondo né errore.
+    </p>
+    <p>
+      La soluzione sono le virgolette, tutte le volte:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
+    <p>
+      È anche il motivo per cui un encoder non ha bisogno di proteggere gli spazi
+      &mdash; sono perfettamente leciti dentro un URL tra virgolette, e proteggere
+      ognuno come <code>%20</code> costerebbe tre caratteri per ogni spazio del
+      file. Le due decisioni vanno insieme: metti l'URI tra virgolette, e gli
+      spazi li puoi lasciare stare. Ogni forma che lo strumento produce è tra
+      virgolette esattamente per questo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Il tipo di media deve essere giusto</h2>
+    <p>
+      Un data URI dichiara il proprio tipo, e il browser gli crede sulla parola.
+      Non c'è un ripiego che vada a fiutare il contenuto come succede per un file
+      recuperato: di' <code>image/png</code> di qualcosa che in realtà è un JPEG
+      e l'immagine non compare, senza un messaggio in nessun posto utile.
+    </p>
+    <p>
+      E conta perché le estensioni mentono. Una foto esportata come JPEG e
+      rinominata <code>logo.png</code> è una cosa che si trova normalmente su un
+      disco. I primi byte di un file immagine, invece, dicono cos'è senza
+      ambiguità &mdash; ogni formato ha una firma &mdash; quindi uno strumento
+      dovrebbe leggere il file e non il suo nome. Quello di qui lo fa, e ti dice
+      quando i due non concordano.
+    </p>
+    <p>
+      Due formati vale la pena conoscerli perché falliscono in modo confuso.
+      <strong>HEIC</strong>, cioè come fotografa un iPhone, e <strong>TIFF</strong>,
+      cioè quello che producono gli scanner, fanno entrambi data URI
+      perfettamente validi che nessun browser tranne Safari disegna. L'URI non è
+      rotto; è il formato a non essere fra quelli che il web supporta. Converti
+      prima.
+    </p>
+  </section>
+
+  <section>
+    <h2>I metadati che non volevi pubblicare</h2>
+    <p>
+      Un data URI è una copia del file, byte per byte. Niente viene decodificato
+      e ricodificato, che di solito è il senso della cosa &mdash; non si perde
+      qualità &mdash; ma vuol dire anche che tutto il resto che c'è nel file
+      viene dietro.
+    </p>
+    <p>
+      Una fotografia appena uscita da un telefono porta con sé l'EXIF: le
+      coordinate GPS del posto in cui è stata scattata, l'orario, il modello
+      della fotocamera e spesso il suo numero di serie. Possono essere 30 KB del
+      file. Incorporati, diventano 40 KB di base64 nel tuo foglio di stile, sul
+      percorso critico di ogni pagina &mdash; e un indirizzo di casa depositato in
+      un repository, in una forma che a nessuno verrà mai in mente di guardare.
+    </p>
+    <p>
+      Toglilo prima con il
+      <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>,
+      che riscrive il contenitore senza toccare l'immagine; c'è anche
+      <a href="../rimuovere-i-dati-exif-e-gps/">una guida apposta</a>. Immagine
+      in data URI legge quanti metadati ci sono in un JPEG, un PNG o un WebP e lo
+      dice prima che tu copi qualunque cosa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dove metterlo, una volta che ce l'hai</h2>
+    <p>
+      Se l'immagine compare in una sola regola, metti l'URI in quella regola. Se
+      compare in più di una &mdash; e le icone di solito lo fanno, una volta che
+      conti lo stato al passaggio del mouse e il tema scuro &mdash; dichiarala
+      una volta come proprietà personalizzata:
+    </p>
+    <pre><code>:root {
+  --icona-cerca: url("data:image/svg+xml,%3Csvg ... %3E");
+}
+
+.campo-ricerca { background-image: var(--icona-cerca); }
+.pulsante-ricerca::before { content: var(--icona-cerca); }</code></pre>
+    <p>
+      Un URI da 3 KB incollato in quattro regole sono 12 KB di foglio di stile e
+      quattro punti da modificare quando l'icona cambia. La proprietà
+      personalizzata è uno di ciascuno. È anche la forma che fa funzionare i
+      temi: ridefinisci <code>--icona-cerca</code> dentro una media query e ogni
+      suo uso segue.
+    </p>
+    <p>
+      Per un tag <code>&lt;img&gt;</code> invece che per il CSS, metti
+      <code>width</code> e <code>height</code>. Un'immagine incorporata si carica
+      all'istante, quindi una dimensione mancante è uno spostamento di layout che
+      avviene troppo in fretta per essere visto e ti viene contato lo stesso.
+      L'eccezione è l'SVG: uno che porta solo un <code>viewBox</code> non ha una
+      dimensione in pixel sua, e scrivere sul tag il 300&times;150 predefinito del
+      browser inchioda un'immagine scalabile a una dimensione che non ha scelto
+      nessuno.
+    </p>
+    <p>
+      Lascia vuoto l'<code>alt</code> a meno che tu non abbia qualcosa di vero da
+      metterci. Solo tu sai se l'immagine porta un significato o è decorazione, e
+      una descrizione indovinata da un nome di file è peggio, per chi usa uno
+      screen reader, che nessuna descrizione.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando la risposta è «non farlo»</h2>
+    <p>
+      Se l'immagine, una volta codificata, supera i 50 KB circa, incorporare è lo
+      strumento sbagliato e nessuna cura nella codifica lo sistema. Le
+      alternative, nell'ordine in cui vale la pena provarle:
+    </p>
+    <ul>
+      <li>
+        <strong>Rendila più leggera.</strong> Quasi tutte le immagini troppo
+        pesanti da incorporare sono troppo pesanti in generale. Il
+        <a href="../../comprimere-immagine/">compressore di immagini</a> porta
+        una fotografia a un peso che dici tu, e il
+        <a href="../../ridimensionare-immagine/">ridimensionatore di
+        immagini</a> taglia le misure in pixel a quello che il layout usa
+        davvero &mdash; che molto spesso è il problema vero.
+      </li>
+      <li>
+        <strong>Ridisegnala come SVG.</strong> Un'icona esportata come PNG da 40
+        KB è spesso un SVG da 900 byte. Non è una differenza di compressione, è
+        una differenza di formato, e risolve anche il problema del retina.
+      </li>
+      <li>
+        <strong>Lasciala come file e precaricala.</strong>
+        <code>&lt;link rel="preload" as="image"&gt;</code> avvia il recupero
+        subito senza spostare i byte sul percorso critico. Ottiene quasi tutto il
+        vantaggio dell'incorporare e niente del costo di cache.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Niente di tutto questo ha bisogno di un caricamento</h2>
+    <p>
+      Codificare un file in base64 è aritmetica. Sono due funzioni che il browser
+      ha dall'inizio &mdash; <code>btoa</code> ed <code>encodeURIComponent</code>
+      &mdash; e non c'è alcun motivo tecnico, proprio nessuno, per cui
+      un'immagine debba andare fino a un server e tornare per essere scritta in
+      un altro modo. Qualunque convertitore che carichi il tuo file per fare
+      questo lo sta caricando per motivi suoi, non tuoi.
+    </p>
+    <p>
+      <a href="../../immagine-in-base64/">Lo strumento di qui</a> non lo manda da
+      nessuna parte: la <code>Content-Security-Policy</code> della pagina nomina
+      tutti gli indirizzi che può contattare, e nessuno di questi appartiene a
+      questo sito. Carica la pagina, stacca la connessione, e codifica qualcosa
+      lo stesso se preferisci verificare invece che crederci.
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone altre tre verifiche che puoi fare
+      su qualunque strumento.
+    </p>
+  </section>

--- a/locales/it/pages/guides/embed-an-image-in-css.toml
+++ b/locales/it/pages/guides/embed-an-image-in-css.toml
@@ -1,0 +1,18 @@
+#
+# Guida: mettere un'immagine dentro il CSS - Italian.
+#
+
+nav = "Inserire un'immagine nel CSS"
+title = "Data URI nel CSS: quando incorporare un'immagine e quando no"
+description = "Quanto costa un data URI, perché il base64 aggiunge un terzo e il gzip non lo restituisce, perché un SVG non va mai messo in base64, e l'errore di virgolette che rompe in silenzio gli SVG incorporati."
+heading = "Quando mettere un'immagine dentro il tuo CSS, e quando no"
+lede = """
+    Un'immagine scritta dentro un foglio di stile arriva insieme a lui: nessuna
+    seconda richiesta, nessuna attesa. Però smette anche di essere un file
+    &mdash; quindi non può stare in cache per conto suo, e viene riscaricata
+    ogni volta che cambia qualcosa attorno. Qui c'è dove quello scambio conviene,
+    e dove invece, in silenzio, non conviene."""
+updated = "20 agosto 2026"
+og_title = "Quando mettere un'immagine dentro il tuo CSS"
+og_description = "Quanto costa un data URI, perché un SVG non va mai messo in base64, e l'errore di virgolette che rompe in silenzio gli SVG incorporati."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/it/pages/guides/is-it-safe-to-upload-files.html
@@ -1,0 +1,264 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Per quasi tutti i file, quasi sempre, caricare va bene. I convertitori
+      seri cancellano quello che mandi nel giro di qualche ora e non hanno alcun
+      interesse per le tue foto delle vacanze.
+    </p>
+    <p>
+      Il problema non è che stiano mentendo. È che
+      <strong>non hai modo di sapere se lo stanno facendo</strong>. Una volta che
+      un file lascia il tuo dispositivo, ogni promessa su quello che succede dopo
+      è una promessa che prendi sulla fiducia: per quanto viene tenuto, chi ci può
+      arrivare, se viene copiato in un backup che sopravvive al timer di
+      cancellazione, cosa gli succede se l'azienda viene venduta o violata.
+      Niente di tutto questo si vede da fuori.
+    </p>
+    <p>
+      Quindi la domanda utile non è «mi fido di questo sito?». È
+      <strong>«questo lavoro ha davvero bisogno che il mio file se ne
+      vada?»</strong>. Per un numero grande e crescente di lavori la risposta è
+      no, e quando la risposta è no, la domanda sulla fiducia smette di essere
+      una a cui devi rispondere.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa fa davvero un «caricamento»</h2>
+    <p>
+      Quando un convertitore ti chiede di scegliere un file e poi ti mostra una
+      barra di avanzamento, il tuo browser sta copiando tutto il file, byte per
+      byte, attraverso internet, su un computer che è di qualcun altro. Quel
+      computer lo scrive su un disco, esegue la conversione, scrive il risultato
+      sullo stesso disco, e ti passa un link.
+    </p>
+    <p>
+      In quel momento il tuo file esiste in almeno tre posti che non hai scelto
+      tu: il disco del server, i registri che hanno annotato la richiesta, e
+      spesso una rete di distribuzione dei contenuti che ha messo in cache il
+      risultato perché lo scaricamento sia rapido. Una politica di cancellazione
+      deve arrivare a tutti e tre. Quasi tutte dicono di arrivarci. Tu non ne
+      puoi verificare nemmeno una.
+    </p>
+    <p>
+      Vale anche la pena saperlo: il file non è l'unica cosa che arriva. Il nome
+      del file va con lui, e ci va anche tutto quello che c'è dentro il file e
+      che tu non vedi. Una foto appena uscita da un telefono porta di solito le
+      coordinate GPS esatte del posto in cui è stata scattata, l'ora, il numero di
+      serie della fotocamera, e a volte una miniatura incorporata dell'immagine
+      originale, quella di prima che la ritagliassi. Chi sta attento all'immagine
+      spesso non sta attento a quello, perché sullo schermo non c'è niente che
+      glielo mostri.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché quasi tutti gli strumenti caricano lo stesso</h2>
+    <p>
+      Non perché vogliano i tuoi file. Perché per quasi tutta la vita del web non
+      c'era alternativa. Un browser non sapeva decodificare un video,
+      ricodificare un'immagine a una qualità scelta, o analizzare un formato di
+      file; un server con FFmpeg e ImageMagick sì. Caricare non era un modello di
+      business, era l'unico posto in cui il lavoro potesse avvenire.
+    </p>
+    <p>
+      Ha smesso di essere vero di recente e in sordina. I browser ormai si
+      portano dietro WebAssembly, che esegue gli stessi codec compilati a una
+      velocità vicina a quella nativa, WebCodecs, che espone l'encoder video
+      hardware che il tuo dispositivo ha già, e un'API Canvas che sa decodificare
+      e ricodificare immagini direttamente. Il lavoro per cui serviva un server
+      adesso gira sul dispositivo che ha già il file.
+    </p>
+    <p>
+      Parecchi strumenti caricano ancora, e ci sono motivi onesti: una catena
+      esistente che nessuno vuole riscrivere, un formato senza decodificatore lato
+      browser, un lavoro davvero troppo pesante per un telefono. C'è anche un
+      motivo meno onesto, ed è che è sul server che vivono gli account, le quote e
+      i piani a pagamento. Uno strumento che gira interamente nel tuo browser è
+      difficile da contabilizzare.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quattro verifiche che puoi fare da solo</h2>
+    <p>
+      Funzionano su qualunque strumento, questo compreso. Nessuna richiede di
+      credere a nessuno sulla parola, e la prima richiede una decina di secondi.
+    </p>
+
+    <h3>1. Stacca la spina</h3>
+    <p>
+      Carica la pagina, poi spegni il wi-fi o stacca il cavo, e prova a usarla.
+      Uno strumento che fa il lavoro nel tuo browser continua esattamente come
+      prima. Uno strumento che carica si ferma subito, perché la cosa che faceva
+      il lavoro non è più raggiungibile.
+    </p>
+    <p>
+      È la prova più forte che ci sia, e la più difficile da falsificare, perché
+      non si può rispondere con una formulazione. O la conversione si completa
+      senza rete o non si completa.
+    </p>
+
+    <h3>2. Guarda la scheda Rete</h3>
+    <p>
+      Apri gli strumenti di sviluppo del tuo browser, scegli Rete, poi usa lo
+      strumento. Ogni richiesta che la pagina fa è elencata con la sua
+      dimensione. Se la tua foto da 4&nbsp;MB è stata caricata, in quell'elenco
+      c'è una richiesta da 4&nbsp;MB. Se la cosa più grande che esce dalla pagina
+      sono qualche kilobyte di pubblicità, non lo è stata.
+    </p>
+    <p>
+      Ordina per dimensione e guarda in cima. Non ti serve capire le richieste;
+      ti serve accorgerti se una di loro è della dimensione del tuo file.
+    </p>
+
+    <h3>3. Leggi la Content-Security-Policy</h3>
+    <p>
+      Guarda il sorgente della pagina e cerca
+      <code>Content-Security-Policy</code>, vicino alla cima. È l'elenco degli
+      indirizzi che quella pagina può contattare, e a farlo rispettare è il tuo
+      browser e non le buone intenzioni del sito &mdash; una richiesta verso
+      qualcosa che non è nell'elenco viene rifiutata, qualunque cosa provi a fare
+      il codice.
+    </p>
+    <p>
+      La direttiva che conta è <code>connect-src</code>, che regola dove la
+      pagina può mandare dati. Se nomina un indirizzo appartenente al sito su cui
+      ti trovi, la pagina può mandarci il tuo file. Se non nomina niente, o
+      nomina solo terze parti come una rete pubblicitaria, non può.
+    </p>
+    <p>
+      Una pagina senza alcuna Content-Security-Policy non è la prova di niente di
+      brutto. Vuol dire solo che questa particolare verifica non ha niente da
+      dirti.
+    </p>
+
+    <h3>4. Leggi il codice</h3>
+    <p>
+      La meno comoda, la più conclusiva. Se uno strumento pubblica il proprio
+      sorgente e lo serve senza un passaggio di compilazione, i file che il tuo
+      browser ha recuperato sono i file che puoi leggere. Cercaci
+      <code>fetch</code>, <code>XMLHttpRequest</code> e <code>sendBeacon</code>
+      &mdash; i tre modi in cui una pagina può mandare qualcosa &mdash; e guarda
+      cosa gli viene passato.
+    </p>
+    <p>
+      Quasi nessuno lo farà. Conta lo stesso che sia possibile, perché
+      un'affermazione che nessuno è in grado di verificare non è davvero
+      un'affermazione.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa non vuol dire «gira nel tuo browser»</h2>
+    <p>
+      Vale la pena essere precisi, perché l'espressione viene usata alla leggera
+      e questo sito deve tenersi allo stesso standard che sta proponendo.
+    </p>
+    <ul>
+      <li>
+        <strong>Non vuol dire nessuna richiesta.</strong> La pagina stessa è
+        arrivata dalla rete, e quasi tutti gli strumenti gratuiti hanno
+        pubblicità o statistiche che parlano con qualcuno. L'affermazione
+        riguarda il tuo <em>file</em>, non il traffico in generale.
+      </li>
+      <li>
+        <strong>Non nasconde il tuo indirizzo IP.</strong> Lo vede ogni sito che
+        visiti, questo compreso. L'elaborazione locale riguarda il contenuto dei
+        tuoi file, non l'anonimato.
+      </li>
+      <li>
+        <strong>Non sopravvive a una funzione che recupera qualcosa.</strong>
+        Uno strumento che ti lascia incollare un indirizzo web deve contattare
+        quell'indirizzo, e quel server viene a sapere il tuo IP e cosa hai
+        chiesto. È insito nella funzione, non un suo difetto &mdash; ma è
+        un'eccezione vera e uno strumento dovrebbe dirlo chiaramente invece di
+        arrotondarla.
+      </li>
+      <li>
+        <strong>Non è la stessa cosa di «cancelliamo i tuoi file».</strong> La
+        seconda frase riguarda quello che un'azienda sceglie di fare. La prima
+        riguarda quello che è tecnicamente possibile. Solo una delle due è
+        verificabile.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Quando caricare va davvero bene</h2>
+    <p>
+      Questo non è un ragionamento per cui ogni caricamento è un errore. Manda il
+      file quando il contenuto non è delicato e il lavoro è più facile così;
+      quando il lavoro è davvero troppo pesante per il tuo dispositivo; quando il
+      formato non ha un decodificatore lato browser; o quando stai usando un
+      servizio con cui hai già un rapporto e di cui hai davvero letto le
+      condizioni.
+    </p>
+    <p>
+      Stai più attento quando il file contiene qualcosa che non pubblicheresti:
+      documenti d'identità, esami medici, contratti, qualunque cosa con un
+      indirizzo o un volto che non avevi intenzione di condividere, o una foto di
+      cui non hai guardato i dati di posizione. Per quelli, uno strumento che
+      puoi verificare è da preferire a uno di cui ti devi fidare &mdash; non
+      perché quello di cui ti fidi sia probabile che ti tradisca, ma perché con
+      quello verificabile la domanda non si pone.
+    </p>
+  </section>
+
+  <section>
+    <h2>Come risponde questo sito a quelle quattro verifiche</h2>
+    <p>
+      Sarebbe una guida strana quella che ti dice di verificare e poi chiede
+      un'esenzione. Quindi, in ordine:
+    </p>
+    <ul>
+      <li>
+        <strong>Stacca la spina.</strong> Apri uno strumento qualsiasi di qui,
+        stacca la connessione, e continua a funzionare. La pagina di ogni
+        strumento ha un indicatore dal vivo che ti dice se in questo momento sei
+        online, così puoi guardarlo cambiare.
+      </li>
+      <li>
+        <strong>Scheda Rete.</strong> Converti qualcosa e leggi l'elenco. Non c'è
+        niente che porti con sé il tuo file, una sua miniatura, il suo nome, la
+        sua dimensione, o qualunque cosa ci sia stata letta dentro. Su questo
+        sito non esiste alcun evento di analytics personalizzato che abbia
+        qualcosa del genere da mandare.
+      </li>
+      <li>
+        <strong>Content-Security-Policy.</strong> Sta in cima al sorgente di ogni
+        pagina. <code>connect-src</code> nomina gli endpoint pubblicitari e di
+        misurazione di Google e il pulsante delle donazioni, e nient'altro.
+        <strong>Nessun indirizzo di quell'elenco appartiene a questo
+        sito</strong>, perché questo sito non ha un server &mdash; sono file
+        statici. Non c'è nessun posto dove un file potrebbe essere mandato, anche
+        se qualcosa ci provasse.
+      </li>
+      <li>
+        <strong>Codice.</strong> Ogni riga è
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">pubblica</a>.
+        La compilazione toglie i commenti e gli spazi e nient'altro, e la puoi
+        eseguire tu e confrontare il risultato con quello che viene servito.
+      </li>
+    </ul>
+    <p>
+      Le eccezioni, dichiarate invece che sepolte: questo sito ospita pubblicità
+      di Google e un contatore delle visite, che parlano entrambi con Google e a
+      nessuno dei due viene passato niente sui tuoi file; e lo strumento
+      <a href="../../immagini-in-video/">Immagini in video</a> può recuperare
+      un'immagine da un indirizzo che incolli tu, il che vuol dire che quel
+      server vede il tuo IP. La <a href="../../privacy/">pagina sulla
+      privacy</a> le espone entrambe per intero.
+    </p>
+    <p>
+      Ogni strumento di qui funziona così: un
+      <a href="../../comprimere-immagine/">compressore di immagini</a> che
+      centra un peso che dici tu, un
+      <a href="../../ritagliare-video/">ritagliatore di video</a>, un
+      <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>
+      per i dati nascosti descritti più su in questa pagina,
+      <a href="../../immagini-in-video/">immagini in video</a>, e
+      <a href="../../immagini-in-pdf/">immagini in PDF</a>. Tutti gratuiti,
+      nessun account, e nessuno di loro ha un posto dove mandare i tuoi file.
+    </p>
+  </section>

--- a/locales/it/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/it/pages/guides/is-it-safe-to-upload-files.toml
@@ -1,0 +1,17 @@
+#
+# Guida: è sicuro caricare i propri file? - Italian.
+#
+
+nav = "È sicuro caricare i file?"
+title = "È sicuro caricare i propri file sui convertitori online?"
+description = "Quasi tutti i convertitori online mandano il tuo file a un server. Cosa vuol dire, cosa gli succede là, e quattro verifiche che ti dicono se uno strumento ne ha davvero bisogno."
+heading = "È sicuro caricare i propri file sui convertitori online?"
+lede = """
+    Di solito la risposta onesta è «probabilmente sì, ma non lo puoi
+    verificare». Qui c'è cosa fa davvero un caricamento al tuo file, perché
+    quasi tutti gli strumenti lo fanno ancora, e quattro prove che ti dicono se
+    quello che hai davanti ne ha bisogno."""
+updated = "20 agosto 2026"
+og_title = "È sicuro caricare i propri file sui convertitori online?"
+og_description = "Cosa succede a un file che carichi su un convertitore, perché quasi tutti gli strumenti lo chiedono ancora, e quattro verifiche che puoi fare da solo."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/make-a-favicon.html
+++ b/locales/it/pages/guides/make-a-favicon.html
@@ -1,0 +1,343 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri <a href="../../creare-favicon/">Da immagine a ICO</a>, trascinaci
+      dentro un'immagine quadrata di almeno 256 pixel, lascia il valore pronto su
+      <em>favicon per un sito</em>, e scarica <code>favicon.ico</code>. Mettilo
+      alla radice del tuo sito, in modo che risponda a
+      <code>https://iltuosito.it/favicon.ico</code>. Quell'indirizzo lo chiede
+      ogni browser che il tuo HTML lo nomini o no, quindi non c'è nient'altro che
+      tu debba fare per forza.
+    </p>
+    <p>
+      Tutto quello che segue è la parte che fa la differenza tra un'icona
+      tecnicamente presente e una leggibile: quali dimensioni ci entrano, cosa
+      chiedono invece gli iPhone e Android, e cosa fare quando il tuo logo non
+      sopravvive a essere largo sedici pixel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché è una serie di dimensioni e non un'immagine sola</h2>
+    <p>
+      Un file <code>.ico</code> è un contenitore. Dentro ci sono parecchie
+      immagini complete della stessa cosa a dimensioni diverse, e chi legge il
+      file sceglie quella più vicina alla dimensione che gli serve.
+    </p>
+    <p>
+      Sembra ridondanza e non lo è. Un browser che disegna la tua icona a sedici
+      pixel ha due possibilità: leggere una versione da sedici pixel che hai
+      disegnato tu, oppure rimpicciolirne sul momento una più grande. La seconda
+      è peggiore, e in modo visibile &mdash; un rimpicciolimento automatico di un
+      logo dettagliato produce poltiglia, mentre una versione da sedici pixel che
+      hai guardato è qualcosa che hai avuto occasione di semplificare. Tutto il
+      motivo per cui il formato contiene parecchie dimensioni è darti quella
+      occasione.
+    </p>
+    <p>
+      Per un sito la convenzione sono tre dimensioni, e ognuna ha un motivo:
+    </p>
+    <ul>
+      <li>
+        <strong>16&times;16</strong> &mdash; la scheda del browser, la barra
+        degli indirizzi, il menu dei segnalibri. È quella che la gente vede. Se
+        ne azzecchi una sola, azzecca questa.
+      </li>
+      <li>
+        <strong>32&times;32</strong> &mdash; la barra dei segnalibri, un
+        collegamento sul desktop di Windows al tuo sito, e quasi tutti i browser
+        su uno schermo ad alta densità, che disegnano l'icona della scheda a
+        partire da 32 e la rimpiccioliscono.
+      </li>
+      <li>
+        <strong>48&times;48</strong> &mdash; la dimensione a cui Google legge
+        l'icona di un sito per i risultati di ricerca, e la vista a icone medie
+        di Windows.
+      </li>
+    </ul>
+    <p>
+      Tutto quello che è più grande sta in un PNG accanto all'<code>.ico</code> e
+      non dentro, per motivi che tornano qui sotto sui file per il cellulare.
+    </p>
+  </section>
+
+  <section>
+    <h2>Il problema dei sedici pixel</h2>
+    <p>
+      È la parte di cui nessuno ti avverte. Sedici pixel sono circa quattro
+      millimetri su uno schermo normale: una griglia di 256 punti in tutto, meno
+      delle lettere di questa frase. Quasi niente di ciò che è stato progettato
+      per funzionare su un'insegna, un biglietto da visita o l'intestazione di un
+      sito sopravvive a essere ridotto a quello.
+    </p>
+    <p>
+      Quello che sparisce, in ordine:
+    </p>
+    <ul>
+      <li>
+        <strong>Il testo.</strong> Un marchio scritto rimpicciolito dentro un
+        quadrato è alto circa tre pixel. Non diventa testo piccolo, diventa una
+        barra grigia. È per questo che quasi ogni azienda che ha un simbolo oltre
+        al nome usa il solo simbolo come favicon, e perché quelle che non hanno
+        un simbolo usano una sola lettera.
+      </li>
+      <li>
+        <strong>Le linee sottili.</strong> Un bordo da un pixel su un logo da 512
+        pixel è un trentaduesimo di pixel a sedici. Si disegna come una foschia
+        grigia lungo il bordo, oppure sparisce.
+      </li>
+      <li>
+        <strong>Sfumature e ombre.</strong> Non c'è spazio per una transizione.
+        Un'ombra portata morbida diventa una frangia sporca.
+      </li>
+      <li>
+        <strong>Il dettaglio dentro il dettaglio.</strong> L'icona di un documento
+        con sopra della scrittura diventa un rettangolo con una macchia.
+      </li>
+    </ul>
+    <p>
+      La soluzione non è un'impostazione, è un disegno diverso: un marchio
+      semplificato con una o due forme, molto contrasto, e nessun testo oltre a
+      un singolo carattere. Disegna quella versione a 32 o 48 pixel di proposito,
+      e usala come sorgente.
+    </p>
+    <p>
+      Quello che uno strumento può fare è mostrarti il problema prima che tu lo
+      pubblichi. L'anteprima in <a href="../../creare-favicon/">Da immagine a
+      ICO</a> disegna ogni dimensione alla sua dimensione reale sullo schermo,
+      che è l'unico modo di giudicare questa cosa &mdash; un'icona da sedici
+      pixel mostrata a sessantaquattro viene bene e non ti dice niente.
+    </p>
+  </section>
+
+  <section>
+    <h2>Il tuo logo non è quadrato. Riempire o ritagliare?</h2>
+    <p>
+      Un'icona è sempre quadrata, e quasi tutti i loghi non lo sono, quindi
+      qualcosa deve succedere. Le risposte sono tre e non sono ugualmente buone.
+    </p>
+    <p>
+      <strong>Il riempimento</strong> tiene tutta l'immagine e ci mette dello
+      spazio sopra e sotto. È il comportamento prudente predefinito ed è la
+      scelta sbagliata per un marchio scritto largo: far stare in un quadrato una
+      cosa larga tre volte più di quanto sia alta la lascia a occupare un terzo
+      dell'altezza, che a sedici pixel sono cinque pixel di logo e undici di
+      niente.
+    </p>
+    <p>
+      <strong>Il ritaglio al centro</strong> prende il quadrato più grande dal
+      mezzo. Per un blocco &mdash; un simbolo con accanto il nome dell'azienda
+      &mdash; spesso taglia dritto attraverso tutti e due. Meglio ritagliare
+      prima tu la sorgente, fino al solo simbolo, e convertire quello.
+    </p>
+    <p>
+      <strong>Lo stiramento</strong> schiaccia l'immagine per farla entrare. Non
+      c'è quasi nessuna situazione in cui sia giusto, ed è proposto soprattutto
+      perché lo strumento non lo faccia in silenzio.
+    </p>
+    <p>
+      La risposta generale per un logo largo: non convertire il logo. Converti la
+      parte di lui che funziona da sola.
+    </p>
+  </section>
+
+  <section>
+    <h2>Trasparente o sfondo pieno?</h2>
+    <p>
+      Per un sito, trasparente è di solito la scelta giusta. Le schede dei
+      browser sono grigie, bianche o quasi nere a seconda del browser e del tema,
+      e un'icona trasparente sta bene su tutte. Un'icona con lo sfondo bianco
+      dipinto dentro è un rettangolo bianco in una barra delle schede scura.
+    </p>
+    <p>
+      Due eccezioni da conoscere:
+    </p>
+    <ul>
+      <li>
+        <strong>Un logo scuro e nient'altro</strong> sparisce in modalità scura.
+        Se il tuo marchio è per natura nero su bianco, dagli uno sfondo colorato
+        invece che trasparente, oppure un contorno chiaro.
+      </li>
+      <li>
+        <strong>L'icona Apple touch deve essere opaca.</strong> iOS la disegna
+        sulla propria tessera arrotondata e rende la trasparenza come nero.
+        Qualunque strumento produca quel file dovrebbe appiattirlo per te; quello
+        di qui lo fa, sul bianco per impostazione predefinita.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>I file che servono a un sito e che non sono l'.ico</h2>
+    <p>
+      <code>favicon.ico</code> copre i browser e Windows. Non copre i telefoni,
+      ed è qui che quasi tutte le serie di icone fatte in casa si fermano troppo
+      presto. Altre tre piattaforme chiedono i propri file, con nomi propri, e
+      nessuna di loro va a guardare dentro un <code>.ico</code>:
+    </p>
+    <ul>
+      <li>
+        <strong>iOS</strong> legge <code>apple-touch-icon.png</code> a
+        180&times;180 quando qualcuno aggiunge il tuo sito alla schermata Home.
+        Senza, iOS usa uno screenshot della pagina, che sembra un errore.
+      </li>
+      <li>
+        <strong>Android e ogni richiesta di installazione</strong> leggono un
+        manifest per web app &mdash; <code>site.webmanifest</code> &mdash; che
+        punta a PNG da 192 e 512 pixel. Il 512 è anche quello che una web app
+        mostra sulla schermata di avvio.
+      </li>
+      <li>
+        <strong>Una tessera del menu Start di Windows</strong> legge
+        <code>browserconfig.xml</code>, che punta a un PNG da 150&times;150. La
+        meno importante delle tre, e quattro righe di XML.
+      </li>
+    </ul>
+    <p>
+      Ce n'è un'altra facile da sbagliare: i launcher Android ritagliano
+      un'icona adattiva nella forma che piace al telefono &mdash; cerchio,
+      quadrato stondato, rettangolo arrotondato &mdash; e solo l'80% centrale
+      dell'immagine è garantito che sopravviva. Un'icona disegnata da bordo a
+      bordo perde gli angoli. È questo che è un'icona <em>maskable</em>: la
+      stessa immagine disegnata di proposito piccola dentro il quadrato,
+      dichiarata a parte nel manifest.
+    </p>
+    <p>
+      Spuntando il pacchetto per il sito in
+      <a href="../../creare-favicon/">Da immagine a ICO</a> ottieni tutti
+      questi, il manifest, e il blocco di HTML che ci punta. Una cosa che quel
+      blocco lascia fuori di proposito è un <code>&lt;link&gt;</code> per
+      <code>favicon.ico</code>: i browser chiedono quell'indirizzo da soli, e
+      nominarlo anche lì fa recuperare due volte lo stesso file.
+    </p>
+  </section>
+
+  <section>
+    <h2>L'icona di un'applicazione Windows è un'altra serie</h2>
+    <p>
+      Se l'icona è per un programma e non per un sito, le dimensioni cambiano.
+      Quello che contiene l'<code>app.ico</code> predefinito di Visual Studio è
+      16, 32, 48 e 256 &mdash; le tre dimensioni della shell più quella grande da
+      cui il menu Start e la vista extra large di Esplora risorse attingono.
+    </p>
+    <p>
+      Su uno schermo ad alta densità Windows chiede anche 20, 24, 40, 64 e 96, e
+      se mancano le ricava dalla dimensione più vicina che ha. Se la cosa conti
+      dipende dalla tua icona: una forma piatta sopravvive al ricampionamento,
+      una dettagliata no. Aggiungerle raddoppia all'incirca il file, che per
+      un'applicazione non è proprio niente &mdash; il calcolo è del tutto diverso
+      da quello di una favicon, che viene recuperata da ogni visitatore.
+    </p>
+    <p>
+      Un'altra cosa sulla dimensione: è nella voce da 256 che stanno i byte. Non
+      compressa pesa 264&nbsp;KB da sola; conservata come PNG dentro l'icona di
+      solito sta sotto i 30. Le voci PNG sono leggibili da Windows Vista in poi,
+      quindi l'unico motivo per evitarle è del software davvero più vecchio di
+      quello, o un programma di installazione o uno strumento incorporato che
+      analizza le icone per conto suo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Un Mac legge tutt'altro file</h2>
+    <p>
+      Se l'icona è per un'applicazione Mac e non per una Windows, niente di
+      quanto sopra vale: macOS non legge proprio l'<code>.ico</code>. Legge
+      l'<code>.icns</code>, che è la stessa idea in un involucro diverso &mdash;
+      parecchie dimensioni in un contenitore &mdash; con tre differenze da
+      conoscere.
+    </p>
+    <ul>
+      <li>
+        <strong>Le dimensioni sono fisse.</strong> Apple pubblica dieci slot e
+        non c'è niente da scegliere: 16, 32, 64, 128, 256, 512 e 1024 pixel, con
+        32, 256 e 512 che compaiono due volte perché ognuna è insieme una
+        dimensione a sé e la versione Retina della dimensione sotto.
+      </li>
+      <li>
+        <strong>Arriva a 1024.</strong> Un <code>.ico</code> si ferma a 256, ed è
+        per questo che il file icona di un Mac pesa qualche centinaio di kilobyte
+        e una favicon quindici. Per un'applicazione consegnata una volta sola non
+        è niente; è solo una favicon a essere recuperata da ogni visitatore.
+      </li>
+      <li>
+        <strong>A 1024 pixel il tuo disegno deve reggere.</strong> I due problemi
+        sono i due estremi della stessa immagine: una favicon deve funzionare
+        quando è minuscola, e l'icona di un Mac deve reggere quando è enorme. Un
+        logo esportato a 512 e ingrandito a 1024 si vede morbido su uno schermo
+        Retina, e l'App Store non lo accetta.
+      </li>
+    </ul>
+    <p>
+      Per usarne uno: il bundle di un'applicazione lo tiene in
+      <code>TuaApp.app/Contents/Resources/</code> e lo nomina in
+      <code>Info.plist</code>. Per una cartella o un'immagine disco, seleziona
+      l'<code>.icns</code> nel Finder, premi Comando-C, poi apri Ottieni
+      informazioni sulla cosa che vuoi cambiare, clicca la piccola icona in alto
+      a sinistra e premi Comando-V.
+    </p>
+    <p>
+      Spuntando <em>icona macOS</em> in
+      <a href="../../creare-favicon/">Da immagine a ICO</a> ne viene scritto
+      uno, con o senza il file Windows accanto. Qualunque cosa esca su entrambe
+      le piattaforme li vuole entrambi, ed entrambi vengono disegnati dalla
+      stessa immagine nello stesso passaggio.
+    </p>
+  </section>
+
+  <section>
+    <h2>Controllare che abbia funzionato</h2>
+    <p>
+      I browser tengono in cache le favicon più tenacemente di quasi ogni altra
+      cosa, quindi «l'ho caricata e non è cambiato niente» è di solito una cache
+      e non un errore. Due cose da provare prima di rimetterti a modificare
+      file:
+    </p>
+    <ul>
+      <li>
+        Apri direttamente <code>https://iltuosito.it/favicon.ico</code>. Se il
+        file si scarica, c'è, e stai guardando una cache. Se ottieni un 404, non
+        è alla radice.
+      </li>
+      <li>
+        Carica il sito in una finestra privata, che di solito ha una cache delle
+        icone tutta sua.
+      </li>
+    </ul>
+    <p>
+      Su Windows, un <code>.ico</code> si controlla mettendolo in una cartella e
+      facendo passare Esplora risorse per le sue dimensioni di visualizzazione:
+      piccole, medie, grandi ed extra grandi disegnano voci diverse dello stesso
+      file, così vedi ciascuna come la vedrà il sistema.
+    </p>
+    <p>
+      Su un Mac, un <code>.icns</code> si apre in Anteprima, che elenca ogni slot
+      di lato &mdash; e lo stesso trucco funziona nel Finder: mettilo in una
+      cartella e trascina il cursore della dimensione nelle opzioni di
+      visualizzazione per guardarlo passare da un'immagine all'altra di quelle
+      che contiene.
+    </p>
+  </section>
+
+  <section>
+    <h2>Niente di tutto questo ha bisogno di un caricamento</h2>
+    <p>
+      Ridimensionare un'immagine è una cosa che ogni browser fa da anni, e un
+      <code>.ico</code> è un'intestazione da sei byte, sedici byte per immagine, e
+      poi le immagini. Non c'è alcun passaggio nel farne uno che richieda un
+      server, e lo strumento di qui non ne usa uno: la
+      <code>Content-Security-Policy</code> della pagina nomina tutti gli
+      indirizzi che può contattare, e nessuno di questi appartiene a questo sito.
+    </p>
+    <p>
+      Ed è una cosa a cui qui vale la pena tenere più del solito. Un logo
+      consegnato a un generatore di favicon gratuito è, molto spesso, un marchio
+      non ancora annunciato &mdash; l'icona è una delle prime cose che si fanno e
+      una delle ultime che si annunciano. Carica la pagina, stacca la
+      connessione, e fanne una lo stesso se preferisci verificare invece che
+      crederci.
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone altre tre verifiche che puoi fare
+      su qualunque strumento.
+    </p>
+  </section>

--- a/locales/it/pages/guides/make-a-favicon.toml
+++ b/locales/it/pages/guides/make-a-favicon.toml
@@ -1,0 +1,18 @@
+#
+# Guida: creare una favicon (e l'icona di un'app Windows) - Italian.
+#
+
+nav = "Creare una favicon"
+title = "Come creare una favicon (e l'icona di un'app Windows)"
+description = "Di quali dimensioni ha davvero bisogno un favicon.ico, quali file in più chiedono iPhone, Android e un Mac, e perché un logo che funziona su un manifesto sparisce a sedici pixel."
+heading = "Come creare una favicon che si legga ancora a sedici pixel"
+lede = """
+    Una favicon non è una piccola immagine del tuo logo. È una serie di immagini
+    a dimensioni fisse, dentro un contenitore che quasi nessuno apre mai, e la
+    più piccola di loro è quella che vedono davvero tutti. Qui ci sono le
+    dimensioni che ti servono, i file che le stanno accanto, e cosa fare quando
+    il tuo logo non sopravvive alla discesa."""
+updated = "20 agosto 2026"
+og_title = "Creare una favicon che si legga ancora a sedici pixel"
+og_description = "Di quali dimensioni ha bisogno un favicon.ico, i file in più che chiedono iPhone e Android, e cosa fare quando il tuo logo non sopravvive al rimpicciolimento."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/make-a-pdf-smaller.html
+++ b/locales/it/pages/guides/make-a-pdf-smaller.html
@@ -1,0 +1,232 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../comprimere-pdf/">compressore di PDF</a>, trascinaci
+      dentro il documento, e guarda cosa ti dice prima di cambiare qualcosa.
+      Legge il file e mostra dove sta davvero il peso &mdash; immagini,
+      caratteri, testo e disegno, e tutto quello a cui nel documento non fa più
+      riferimento nessuno. Quella schermata di solito risponde alla domanda.
+    </p>
+    <p>
+      Se quasi tutto il peso sono immagini, puoi aspettarti un grande risparmio.
+      Se sono caratteri e testo, no, e non può nessuno strumento. Quale dei due
+      hai in mano è tutta la storia, e vale dieci secondi di sguardo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dove sta davvero il peso di un PDF</h2>
+    <p>
+      Un PDF è un contenitore per parecchi tipi diversi di cosa, e non si
+      comprimono allo stesso modo.
+    </p>
+    <ul>
+      <li>
+        <strong>Immagini.</strong> Fotografie e scansioni. Quasi sempre il grosso
+        di un PDF pesante, e l'unica parte con vero spazio dentro.
+      </li>
+      <li>
+        <strong>Caratteri incorporati.</strong> Un carattere intero può pesare
+        centinaia di kilobyte; un sottoinsieme dei soli segni davvero usati pesa
+        molto meno. In ogni caso, sono stati compressi da ciò che ha prodotto il
+        file.
+      </li>
+      <li>
+        <strong>Testo e disegno vettoriale.</strong> Istruzioni invece di pixel:
+        traccia questa linea, metti questa parola qui. Già compatti, e già
+        compressi.
+      </li>
+      <li>
+        <strong>Oggetti a cui non punta più niente.</strong> I PDF li accumulano.
+        Modificare un documento spesso aggiunge la modifica in coda invece di
+        riscrivere il file, quindi una vecchia versione di una pagina può restare
+        lì dentro all'infinito. Riimpacchettare il file li butta.
+      </li>
+    </ul>
+    <p>
+      Quindi i due documenti che la gente porta a un compressore di PDF hanno
+      prospettive completamente diverse. Un documento scansionato è in sostanza
+      una pila di fotografie, e di solito esce dal 60 al 90% più leggero. Un
+      contratto, una tesi o un rapporto esportato sono testo, disegno e
+      caratteri &mdash; tutti già compressi dal software che li ha scritti
+      &mdash; e lì il risparmio è di solito di qualche punto percentuale, dal
+      riimpacchettamento e dal buttare quello a cui nessuno fa riferimento.
+    </p>
+    <p>
+      Qualunque strumento prometta «fino al 90% più leggero» senza guardare il
+      tuo file sta citando il caso migliore del primo tipo per il secondo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa c'entrano i DPI</h2>
+    <p>
+      Un PDF non contiene solo un'immagine; registra quanto grande viene
+      disegnata quell'immagine sulla pagina. Il che ti dà qualcosa di più utile
+      del numero di pixel: la risoluzione effettiva.
+    </p>
+    <p>
+      Una scansione larga 4000 pixel stesa su venti centimetri di carta porta
+      500 pixel per pollice. Uno schermo ne mostra un centinaio. Una buona
+      stampante da ufficio lavora a 300 e non sa farsene di molto di più. Tutto
+      quello che sta sopra è dettaglio che niente nel futuro del documento
+      mostrerà mai &mdash; ed è di solito la maggior parte del file.
+    </p>
+    <p>
+      È per questo che un compressore di PDF sensato chiede dei DPI invece di
+      una percentuale di qualità. Butta per primi i pixel sopra la tua cifra,
+      perché quelli non costano niente che qualcuno possa vedere, e solo dopo
+      comincia a spendere qualità vera.
+    </p>
+    <p>
+      Regola spannometrica: <strong>150 DPI</strong> per un documento che verrà
+      letto sullo schermo, <strong>200&ndash;300</strong> per qualcosa che verrà
+      stampato, <strong>72&ndash;100</strong> per una bozza che nessuno terrà.
+      Misurare rispetto a quanto grande viene disegnata l'immagine è anche il
+      motivo per cui un logo messo piccolo non viene trattato come una scansione
+      a pagina intera &mdash; il logo è già vicino alla propria risoluzione
+      effettiva e non c'è niente da prendere.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa dovrebbe e cosa non dovrebbe toccare una compressione</h2>
+    <p>
+      Le immagini vengono ricodificate, quindi quelle perdono un po'. Tutto il
+      resto non dovrebbe essere toccato affatto, e vale la pena controllare che
+      lo strumento che usi rispetti la regola:
+    </p>
+    <ul>
+      <li>
+        <strong>Il testo resta testo.</strong> Selezionabile, cercabile,
+        copiabile. Un compressore che appiattisce le pagine in immagini
+        produrrà un file molto leggero e distruggerà il documento &mdash; non lo
+        puoi cercare, gli screen reader non lo possono leggere, e non si può
+        tornare indietro.
+      </li>
+      <li>
+        <strong>I caratteri restano interi.</strong> Sostituire i caratteri
+        cambia come si presenta il documento sul dispositivo di qualcun altro,
+        che è l'unica cosa che il PDF esiste per impedire.
+      </li>
+      <li>
+        <strong>Il disegno vettoriale viene copiato tale e quale.</strong> È già
+        leggero, e rasterizzarlo lo renderebbe insieme più pesante e peggiore.
+      </li>
+      <li>
+        <strong>Moduli, link, segnalibri, struttura di accessibilità e allegati
+        passano dall'altra parte.</strong> Sono cose facili da perdere in una
+        riscrittura e di cui raramente ci si accorge finché a qualcuno non ne
+        serve una.
+      </li>
+    </ul>
+    <p>
+      Una regola collegata che un compressore dovrebbe seguire e che molti non
+      seguono: se ricodificare un'immagine non la fa uscire davvero più leggera
+      dell'originale, rimetti dentro i byte originali. Peggiorare un'immagine
+      senza risparmio è il caso di pura perdita, e succede più spesso di quanto
+      si creda su immagini che erano già compresse bene.
+    </p>
+  </section>
+
+  <section>
+    <h2>Le immagini che non si possono comprimere</h2>
+    <p>
+      Alcune immagini dentro un PDF vengono saltate, e un buon strumento le
+      nomina invece di lasciarle in silenzio fuori dall'aritmetica:
+    </p>
+    <ul>
+      <li>
+        <strong>Immagini JPEG&nbsp;2000, JBIG2 e in codifica fax (CCITT).</strong>
+        Nessun browser si porta dietro un decodificatore per nessuna delle tre,
+        quindi passano intatte. Le ultime due sono in bianco e nero e di solito
+        sono già vicine al minimo.
+      </li>
+      <li>
+        <strong>Immagini CMYK.</strong> Lasciate stare di proposito.
+        Ricodificarle rischia di spostare i colori che produrrebbe una
+        stampante, che è una cosa sorprendente da fare a un documento che
+        qualcuno sta per stampare.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Cose da provare prima di comprimere</h2>
+    <p>
+      A volte il file è pesante per un motivo a cui la compressione è la risposta
+      sbagliata.
+    </p>
+    <p>
+      <strong>È stato scansionato quando non ce n'era bisogno?</strong> Un
+      documento stampato e poi scansionato è una pila di fotografie di testo. Se
+      l'originale esiste ancora da qualche parte come documento, esportarlo in
+      PDF produrrà un file di una frazione del peso che è anche cercabile.
+    </p>
+    <p>
+      <strong>È stato esportato con impostazioni da stampa?</strong> I programmi
+      di videoscrittura e di grafica esportano spesso in qualità di stampa per
+      impostazione predefinita. Riesportare per lo schermo dal file sorgente di
+      solito batte il comprimere l'esportazione.
+    </p>
+    <p>
+      <strong>Deve per forza essere un file solo?</strong> Il limite di una mail
+      vale per messaggio. Dividere un documento da 200 pagine in capitoli a
+      volte è la soluzione onesta.
+    </p>
+  </section>
+
+  <section>
+    <h2>I file cifrati, e perché un compressore dovrebbe rifiutarli</h2>
+    <p>
+      Un PDF protetto da password viene rifiutato dallo strumento di qui, ed è
+      voluto invece che una funzione mancante &mdash; anche quando la password è
+      vuota, che è il modo in cui salvano moltissimi scanner e fotocopiatrici.
+    </p>
+    <p>
+      Togliere la protezione a un documento è un lavoro diverso dal comprimerlo.
+      Uno strumento che lo facesse in silenzio starebbe facendo qualcosa che non
+      hai chiesto, a un file che qualcuno aveva deliberatamente bloccato, e ti
+      restituirebbe una copia che non ha più la proprietà che gli si voleva
+      dare. Se è quello che vuoi, togli prima tu la protezione, di proposito.
+    </p>
+  </section>
+
+  <section>
+    <h2>Controllare il risultato</h2>
+    <p>
+      Aprilo. Guarda le immagini a ingrandimento pieno, controlla che il testo
+      sia ancora selezionabile, e verifica il numero di pagine.
+    </p>
+    <p>
+      Lo strumento di qui fa l'ultima cosa al posto tuo prima di offrirti il
+      file: riapre il documento che ha appena scritto e ne conta le pagine, sul
+      tuo dispositivo. Scrive anche in PDF 1.5, che ogni lettore uscito dal 2003
+      in poi capisce, quindi «si apre sul mio computer» è un ragionevole
+      surrogato di «si apre sul loro».
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché questo non ha bisogno di un server</h2>
+    <p>
+      Comprimere un PDF sembra un lavoro da server, e per quasi tutta la vita
+      del web lo è stato. Quello che comporta davvero è analizzare la struttura
+      del file, trovare i flussi delle immagini, decodificarli e ricodificarli
+      con i codec che un browser si porta già dietro, e riscrivere il documento.
+      Tutto questo ormai gira in un browser.
+    </p>
+    <p>
+      Il che conta per questo tipo di file più che per quasi tutti gli altri,
+      per quello che la gente comprime: contratti, referti medici, estratti
+      conto, documenti d'identità, dichiarazioni dei redditi. Lo strumento di
+      qui non ha proprio alcuna funzione di rete, e la
+      <code>Content-Security-Policy</code> della pagina nomina tutti gli
+      indirizzi che può contattare, nessuno dei quali appartiene a questo sito.
+      Caricala, stacca la spina, e comprimi qualcosa lo stesso.
+    </p>
+    <p>
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone altre tre verifiche come quella.
+    </p>
+  </section>

--- a/locales/it/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/it/pages/guides/make-a-pdf-smaller.toml
@@ -1,0 +1,17 @@
+#
+# Guida: ridurre le dimensioni di un PDF - Italian.
+#
+
+nav = "Alleggerire un PDF"
+title = "Come alleggerire un PDF (e perché alcuni non si rimpiccioliscono)"
+description = "Dove sta davvero il peso di un PDF, perché una scansione si comprime dell'80% e un contratto quasi non si muove, cosa vogliono dire qui i DPI, e cosa un compressore non dovrebbe mai fare al tuo documento."
+heading = "Come alleggerire un PDF, e perché alcuni non si rimpiccioliscono"
+lede = """
+    Un PDF che non entra nel limite di una mail è quasi sempre un PDF pieno di
+    immagini. Qui c'è come capire se il tuo lo è, quanto costa comprimerlo, e
+    perché qualunque strumento prometta una percentuale fissa non ha guardato il
+    tuo file."""
+updated = "20 agosto 2026"
+og_title = "Come alleggerire un PDF"
+og_description = "Dove sta davvero il peso di un PDF, perché una scansione si rimpicciolisce e un contratto no, e cosa c'entrano i DPI."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/make-a-qr-code.html
+++ b/locales/it/pages/guides/make-a-qr-code.html
@@ -1,0 +1,272 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../creare-qr-code/">generatore di QR code e codici a
+      barre</a>, incolla il tuo link, lascia il livello su <strong>M</strong> e
+      il margine su <strong>4</strong>, e scarica l'SVG. Stampalo largo almeno
+      due centimetri, su qualcosa di opaco, scuro su chiaro. Poi scansiona quello
+      stampato con un telefono che non è il tuo, prima di ordinarne mille.
+    </p>
+    <p>
+      Copre quasi ogni caso. Il resto di questa pagina è cosa fare quando non è
+      uno di quelli: un codice che deve sopravvivere a essere maneggiato, un
+      codice con sopra un logo, un codice che va su qualcosa di piccolo, e
+      l'unica decisione facile da sbagliare in un modo di cui ti accorgi solo un
+      anno dopo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa c'è davvero dentro un QR code</h2>
+    <p>
+      Una stringa. È tutto lì. Scansionare un QR code consegna al telefono un
+      pezzo di testo, e tutto il resto &mdash; aprire una pagina, collegarsi a
+      una rete, proporre di salvare un contatto &mdash; è il telefono che
+      riconosce la forma di quel testo e propone di agire di conseguenza.
+    </p>
+    <p>
+      Quindi non esiste il «QR code del Wi-Fi» come tipo di codice. Esiste un QR
+      code che contiene <code>WIFI:T:WPA;S:La mia rete;P:la password;;</code>, che
+      ogni telefono fatto nell'ultimo decennio sa leggere. Il generatore ti mostra
+      la stringa finita esattamente per questo: quando un codice non fa quello
+      che ti aspettavi, la stringa è l'unica cosa che vale la pena guardare.
+    </p>
+    <p>
+      Vuol dire anche che un QR code non si può cambiare dopo essere stato
+      stampato, non può chiamare casa, e non può scadere &mdash; a meno che
+      qualcuno non ci abbia messo dentro un link al proprio server, che è
+      l'argomento dell'ultima sezione di qui.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisione uno: il livello di correzione d'errore</h2>
+    <p>
+      Un QR code porta con sé una serie di parole di controllo accanto ai dati,
+      calcolate in modo che un lettore possa ricostruire quello che non è
+      riuscito a vedere. È per questo che un codice con un angolo strappato si
+      legge lo stesso. Quante siano quelle parole di controllo è il livello, e i
+      livelli sono quattro:
+    </p>
+    <ul>
+      <li><strong>L</strong> &mdash; si può perdere circa il 7% del codice.</li>
+      <li><strong>M</strong> &mdash; circa il 15%.</li>
+      <li><strong>Q</strong> &mdash; circa il 25%.</li>
+      <li><strong>H</strong> &mdash; circa il 30%.</li>
+    </ul>
+    <p>
+      Più correzione non è gratis: i dati di controllo entrano nello stesso
+      quadrato, quindi lo stesso testo a H ha bisogno di un codice più grande e
+      più fitto che a L. All'incirca, passare da L a H raddoppia il numero di
+      moduli per la stessa stringa, e moduli più fitti sono più difficili da
+      risolvere per una fotocamera. Qui c'è uno scambio vero e la risposta dipende
+      da dove va il codice.
+    </p>
+    <p>
+      <strong>L</strong> è per uno schermo: un codice in una diapositiva, in una
+      mail, in una pagina web. Non c'è niente che lo danneggerà e ogni modulo in
+      più lo rende più difficile da leggere a distanza.
+    </p>
+    <p>
+      <strong>M</strong> è il valore predefinito ed è la risposta giusta per
+      quasi tutte le stampe. Carta che verrà maneggiata un po', un volantino, un
+      biglietto da visita.
+    </p>
+    <p>
+      <strong>Q e H</strong> sono per i codici che verranno maltrattati: un menu
+      pulito tutti i giorni, un adesivo su una macchina in officina,
+      un'etichetta su una cassa, un codice in una vetrina che prende il sole
+      diretto. H è anche ciò che rende possibile un logo in mezzo &mdash; vedi
+      sotto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisione due: il margine, che è parte del codice</h2>
+    <p>
+      Lo spazio bianco attorno a un QR code non è imbottitura, e non è una scelta
+      grafica. Un lettore lo usa per capire dove finisce il simbolo. La specifica
+      chiede quattro moduli di spazio libero su ogni lato, e un codice tagliato al
+      bordo è di gran lunga il motivo più comune per cui un codice stampato
+      fallisce.
+    </p>
+    <p>
+      Vale la pena essere schietti, perché tagliare è una cosa così naturale da
+      fare. Il codice sembra avere troppo bianco attorno, quindi viene ritagliato
+      nell'impaginazione, o appoggiato su un pannello colorato che arriva fin
+      contro i quadrati, o messo su una fotografia. Ognuna di queste cose toglie
+      il confine che il lettore stava per usare.
+    </p>
+    <p>
+      Se il codice con il suo margine sembra troppo grande, rimpicciolisci il
+      codice. Non togliere il margine.
+    </p>
+  </section>
+
+  <section>
+    <h2>Decisione tre: quanto grande stamparlo</h2>
+    <p>
+      La regola spannometrica che ha retto al contatto con la realtà è
+      <strong>uno a dieci</strong>: un codice deve essere largo circa un decimo
+      della distanza da cui verrà scansionato.
+    </p>
+    <ul>
+      <li>Un biglietto da visita o un menu, letto a 30 cm: circa 2 cm di
+        lato.</li>
+      <li>Un manifesto letto da due metri: circa 20 cm.</li>
+      <li>Una pensilina o una vetrina letta da cinque metri: circa 50 cm.</li>
+    </ul>
+    <p>
+      Due centimetri sono un pavimento più che un obiettivo. Sotto 1,5 cm circa
+      un telefono comune comincia a faticare a prescindere da quanto sia buona la
+      stampa, perché i singoli moduli si avvicinano alla dimensione di un pixel
+      della sua fotocamera.
+    </p>
+    <p>
+      Meno testo vuol dire meno moduli vuol dire un codice che si legge a distanza
+      per una data dimensione di stampa &mdash; che è un buon motivo per far
+      puntare un codice a <code>esempio.it/x</code> invece che a un URL con in
+      fondo cento caratteri di parametri di tracciamento.
+    </p>
+    <p>
+      E stampa dall'<strong>SVG</strong>. Un QR code è fatto di bordi, e un PNG
+      ha un numero fisso di pixel con cui farli; ingrandiscine uno e ogni bordo
+      si ammorbidisce, che è esattamente quello con cui uno scanner fa fatica. Un
+      SVG sono i quadrati come istruzioni, quindi esce nitido su un biglietto da
+      visita come su un cartellone.
+    </p>
+  </section>
+
+  <section>
+    <h2>Colore, contrasto, e i due errori</h2>
+    <p>
+      Un lettore misura la differenza tra i moduli scuri e quelli chiari, quindi
+      il contrasto è tutto. Due cose vanno storte con regolarità:
+    </p>
+    <p>
+      <strong>Codice chiaro su sfondo scuro.</strong> Fa colpo, e parecchi
+      lettori lo rifiutano subito: cercano scuro su chiaro e non provano
+      l'inversione. Alcuni la provano. Non saprai quali abbiano i tuoi clienti.
+    </p>
+    <p>
+      <strong>Differenza insufficiente.</strong> Grigio medio su bianco, o due
+      colori aziendali di peso simile, possono misurare bene sullo schermo e
+      fallire su carta una volta che entrano in gioco lo spandimento
+      dell'inchiostro e l'esposizione automatica di un telefono. Se stai
+      colorando un codice, tieni la parte scura davvero scura.
+    </p>
+    <p>
+      L'opaco batte il lucido per qualunque cosa verrà scansionata sotto una
+      luce, ed entrambi battono lo stampare sopra una fotografia. Gli sfondi
+      trasparenti sono utili per mettere un codice su un pannello colorato
+      &mdash; ma controlla cosa ci finisce davvero dietro, perché un codice
+      trasparente su un pannello scuro è il primo errore qui sopra con qualche
+      passaggio in più.
+    </p>
+  </section>
+
+  <section>
+    <h2>Un logo in mezzo</h2>
+    <p>
+      Funziona, e funziona grazie alla correzione d'errore e non a suo dispetto.
+      Al livello H si può distruggere all'incirca il 30% dei moduli e il codice
+      si legge lo stesso, quindi un logo che ne copre parecchi di meno &mdash; al
+      centro, dove non c'è alcun disegno di ricerca &mdash; è un danno che il
+      lettore ripara.
+    </p>
+    <p>
+      Tre cose a cui attenersi. Usa il livello H. Tieni il logo sotto un quinto
+      circa dell'area, ben al di sotto del limite teorico, perché la stampa non è
+      l'unica cosa che ti mangia il margine. E non coprire mai i tre quadrati
+      grandi negli angoli né quelli più piccoli lì vicino: sono il modo in cui un
+      lettore trova e orienta il simbolo fin dall'inizio, e nessuna quantità di
+      correzione d'errore li ricostruisce.
+    </p>
+    <p>
+      Poi provalo su telefoni veri. Un logo porta un codice da «funziona sempre»
+      a «funziona con questo margine», e l'unico modo di sapere quanto margine
+      resti è provare.
+    </p>
+  </section>
+
+  <section>
+    <h2>La decisione di cui ci si pente: statico o «dinamico»</h2>
+    <p>
+      Cerca un generatore di QR code e quasi tutti i risultati vogliono che tu
+      faccia un account, perché vendono codici <em>dinamici</em>. Un codice
+      dinamico non contiene il tuo link. Contiene un link corto al server del
+      generatore, che rimanda al tuo.
+    </p>
+    <p>
+      Quello che ci guadagni è reale: puoi cambiare dove punta il codice dopo che
+      è stato stampato, e ottieni un conteggio di ogni scansione. Per una
+      campagna con una tiratura a sei cifre, vale i soldi che costa.
+    </p>
+    <p>
+      Quello che costa è altrettanto reale, e vale la pena saperlo prima e non
+      dopo:
+    </p>
+    <ul>
+      <li>
+        <strong>Il codice smette di funzionare quando smettono loro.</strong> Se
+        il servizio chiude, il dominio scade, o il piano gratuito finisce, ogni
+        codice che hai stampato muore &mdash; e a quel punto sono su diecimila
+        menu.
+      </li>
+      <li>
+        <strong>Ogni scansione è un dato di qualcun altro.</strong> Il rimando
+        vede l'indirizzo IP, l'ora e il dispositivo di ogni persona che scansiona
+        il tuo codice.
+      </li>
+      <li>
+        <strong>Il link è loro, non tuo.</strong> Chiunque lo scansioni vede
+        passare un dominio sconosciuto, che è esattamente quello di cui alla
+        gente viene detto di diffidare.
+      </li>
+    </ul>
+    <p>
+      La via di mezzo non costa niente: metti un QR code statico attorno a un URL
+      corto <em>sul tuo dominio</em>, e reindirizzalo tu. Ti tieni la possibilità
+      di cambiare la destinazione, ti tieni le statistiche, e niente del codice
+      dipende dal fatto che un'azienda che non hai mai incontrato esista ancora
+      l'anno prossimo.
+    </p>
+    <p>
+      Il <a href="../../creare-qr-code/">generatore di qui</a> fa solo codici
+      statici, e non ha alcun account da creare. Quello che scrivi è quello che
+      il codice contiene.
+    </p>
+  </section>
+
+  <section>
+    <h2>Prima di stamparne mille</h2>
+    <p>
+      Scansiona il codice. Non quello sullo schermo &mdash; la prova stampata,
+      nel posto dove andrà, con un telefono che non è quello su cui l'hai fatto.
+      Ci vuole un minuto e prende tutta la categoria di problemi di cui parla
+      questa pagina: un margine che l'impaginazione si è mangiata, un link a cui
+      manca l'<code>https://</code>, un colore che su carta ha misurato in modo
+      diverso, un codice stampato a una dimensione che funziona su una scrivania
+      e non su un muro.
+    </p>
+    <p>
+      E controlla cosa succede dopo la scansione. Un codice che apre una pagina
+      illeggibile su un telefono è un codice fallito, anche se si è letto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Niente di tutto questo richiede di caricare qualcosa</h2>
+    <p>
+      Un QR code è aritmetica su una stringa. Non c'è un file da spedire e non
+      c'è niente che un server sappia fare e un browser no, ed è per questo che
+      lo <a href="../../creare-qr-code/">strumento di qui</a> fa tutto sul tuo
+      dispositivo e funziona con la rete staccata.
+    </p>
+    <p>
+      Conta più di quanto sembri, per quello che la gente mette nei QR code.
+      L'uso più comune del formato Wi-Fi è la password vera di una rete,
+      digitata dentro una pagina web. Vale la pena sapere se quella pagina aveva
+      un posto dove mandarla.
+    </p>
+  </section>

--- a/locales/it/pages/guides/make-a-qr-code.toml
+++ b/locales/it/pages/guides/make-a-qr-code.toml
@@ -1,0 +1,17 @@
+#
+# Guida: fare un QR code che si legga davvero - Italian.
+#
+
+nav = "Creare un QR code"
+title = "Come fare un QR code che si legge tutte le volte"
+description = "Quale livello di correzione d'errore scegliere, perché il margine bianco attorno a un QR code è parte del codice, quanto grande stamparlo, e quanto ti costa dopo il codice «dinamico» di un generatore gratuito."
+heading = "Come fare un QR code che si legga anche sul telefono di qualcun altro"
+lede = """
+    Fare un QR code richiede un secondo. Farne uno che funzioni su un menu
+    bagnato, su una pensilina dell'autobus o su un telefono tenuto a distanza di
+    braccio con poca luce richiede quattro decisioni, e tutte e quattro si
+    prendono prima di stampare qualsiasi cosa. Ecco cosa fa ciascuna."""
+updated = "20 agosto 2026"
+og_title = "Fare un QR code che si legga anche sul telefono di qualcun altro"
+og_description = "Le quattro decisioni che stabiliscono se un QR code stampato funziona: il livello, il margine, la dimensione, e di chi è l'indirizzo che c'è davvero dentro."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/it/pages/guides/remove-exif-and-gps-data.html
@@ -1,0 +1,226 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione
+      EXIF</a>, trascinaci dentro le foto, e premi «Rimuovi tutti i metadati».
+      Ogni tag, i blocchi XMP e IPTC, i commenti e la miniatura incorporata se ne
+      vanno, su tutte le foto dell'elenco in una volta. L'immagine in sé non
+      viene toccata &mdash; non ricompressa, non decodificata, non cambiata di un
+      pixel.
+    </p>
+    <p>
+      Prima di farlo, vale la pena guardare cosa c'era là dentro. Di solito è più
+      di quanto la gente si aspetti, e quell'elenco è la ragione stessa per fare
+      tutto questo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa c'è davvero dentro una foto</h2>
+    <p>
+      Un JPEG non è solo un'immagine compressa. È un contenitore, e accanto
+      all'immagine stanno parecchi blocchi di informazioni che la tua fotocamera,
+      il tuo telefono o il tuo programma di ritocco ci hanno scritto.
+    </p>
+    <ul>
+      <li>
+        <strong>EXIF.</strong> Il principale. Marca e modello della fotocamera,
+        obiettivo, impostazioni di esposizione, ISO, la data e l'ora al secondo,
+        l'orientamento in cui l'immagine va mostrata, e &mdash; su un telefono
+        con i servizi di localizzazione attivi per la fotocamera &mdash; una
+        posizione GPS accurata a pochi metri. Spesso anche il numero di serie del
+        corpo macchina.
+      </li>
+      <li>
+        <strong>GPS.</strong> Tecnicamente parte dell'EXIF, e vale la pena
+        nominarlo a parte perché è quello che conta di più. È scritto in gradi,
+        primi e secondi, un formato che riesce benissimo a non sembrare un
+        indirizzo.
+      </li>
+      <li>
+        <strong>XMP.</strong> Un pacchetto di XML che scrivono i programmi di
+        ritocco. Può portare il tuo nome, il tuo software, valutazioni, parole
+        chiave, cronologia delle modifiche, e una copia di alcuni campi EXIF
+        &mdash; motivo per cui rimuovere solo l'EXIF non basta.
+      </li>
+      <li>
+        <strong>IPTC.</strong> Un blocco più vecchio con campi di didascalia,
+        firma, crediti e copyright, usato nella stampa e nella fotografia
+        d'archivio.
+      </li>
+      <li>
+        <strong>La miniatura incorporata.</strong> Una piccola seconda copia
+        dell'immagine. Viene generata quando il file viene scritto, e non sempre
+        viene rigenerata quando l'immagine viene modificata &mdash; ed è così che
+        una foto ritagliata può viaggiare con una miniatura di quello che è stato
+        ritagliato via.
+      </li>
+      <li>
+        <strong>La maker note.</strong> Un blocco non documentato di dati del
+        produttore. Nessuno fuori dal produttore sa tutto quello che c'è dentro.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Chi lo vede davvero</h2>
+    <p>
+      È la parte su cui vale la pena essere precisi, perché sia la versione
+      allarmata sia quella sbrigativa sono sbagliate.
+    </p>
+    <p>
+      <strong>Quasi tutti i grandi social network tolgono i metadati quando
+      pubblichi.</strong> Facebook, Instagram e X ricodificano le immagini
+      caricate e nel farlo buttano i tag. Non è una gentilezza &mdash; i dati
+      dalla loro parte se li tengono &mdash; ma vuol dire che una foto pubblicata
+      su quei servizi non consegna le proprie coordinate a chiunque la guardi.
+    </p>
+    <p>
+      <strong>Quasi tutto il resto li tiene.</strong> Un allegato di posta. Un
+      file mandato con quasi ogni applicazione di chat come «documento» invece
+      che come foto. Un'immagine su un forum, un annuncio di un mercatino, un
+      sito personale, un'unità condivisa, una segnalazione di bug, un ticket di
+      assistenza. In tutti questi casi il file arriva intatto, e chiunque lo
+      scarichi può leggerne i tag con strumenti che arrivano insieme al suo
+      sistema operativo.
+    </p>
+    <p>
+      I rischi realistici sono banali più che drammatici: un annuncio fotografato
+      in casa, la foto di un bambino scattata a scuola, un account
+      apparentemente anonimo che pubblica foto che condividono tutte lo stesso
+      numero di serie della fotocamera, un «scattata la settimana scorsa» che era
+      di marzo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché non risalvarla e basta?</h2>
+    <p>
+      Risalvare una foto passando da un programma di ritocco o da un compressore
+      rimuove davvero i metadati &mdash; l'immagine viene decodificata in pixel e
+      ricodificata, e una tela piena di pixel non porta con sé alcun tag.
+      Funziona, e ti costa qualità, perché quella ricodifica è con perdita.
+    </p>
+    <p>
+      Rimuovere i metadati come si deve non costa proprio niente. I tag stanno
+      nel contenitore <em>attorno</em> all'immagine compressa, non dentro,
+      quindi toglierli è cancellare voci da un elenco e riscrivere l'elenco. I
+      dati compressi dell'immagine vengono copiati byte per byte e il risultato
+      decodifica esattamente gli stessi pixel. È tutto lì il motivo per usare uno
+      strumento per i metadati invece di un convertitore.
+    </p>
+    <p>
+      L'eccezione è se dovevi ricodificare comunque. Se stai già comprimendo o
+      ridimensionando la foto, i tag se ne vanno come effetto collaterale e non
+      ti serve un secondo passaggio.
+    </p>
+  </section>
+
+  <section>
+    <h2>L'unica cosa da tenere: l'orientamento</h2>
+    <p>
+      I telefoni non ruotano l'immagine quando giri il telefono. La registrano
+      come l'ha vista il sensore e aggiungono un tag Orientation che dice come va
+      girata per mostrarla. Togli tutti i tag e certi visualizzatori mostreranno
+      la tua foto di traverso.
+    </p>
+    <p>
+      È per questo che lo strumento di qui ha un'opzione «tieni il tag di
+      orientamento», attiva di default. Riscrive un minuscolo blocco EXIF che
+      contiene quel solo tag e nient'altro, e solo per le foto che ne avevano
+      davvero bisogno. Il GPS, gli orari, il numero di serie e il resto se ne
+      vanno lo stesso.
+    </p>
+    <p>
+      Toglila se preferisci che il file non porti alcun EXIF, proprio nessuno
+      &mdash; e poi controlla il risultato prima di mandarlo, perché una foto di
+      traverso è l'esito abituale.
+    </p>
+  </section>
+
+  <section>
+    <h2>Modificare invece di rimuovere</h2>
+    <p>
+      Rimuovere tutto è la risposta giusta per quasi tutti. A volte non lo è: un
+      fotografo può volere che la riga di copyright e le impostazioni della
+      fotocamera restino e che se ne vada solo la posizione; un archivista può
+      aver bisogno di correggere una data sbagliata perché lo era l'orologio
+      della fotocamera.
+    </p>
+    <p>
+      Si può fare in entrambi i casi. La posizione si può cancellare per conto
+      suo, e tag di testo, date, ISO, orientamento e risoluzione si possono
+      modificare sul posto.
+    </p>
+    <p>
+      Un avvertimento che vale per ogni strumento che fa questo, non solo per
+      questo: scrivere il file ricostruisce il blocco EXIF, e una maker note
+      contiene offset che puntano dentro il blocco <em>originale</em>. Una maker
+      note ricostruita potrebbe quindi non essere più leggibile dal software del
+      produttore. Se la cosa ti interessa, cancella la maker note o lascia il
+      file non modificato.
+    </p>
+  </section>
+
+  <section>
+    <h2>I formati, e quelli che non si possono fare così</h2>
+    <p>
+      JPEG, PNG e WebP si possono riscrivere tutti in modo pulito, e sono i tre
+      che lo strumento di qui gestisce.
+    </p>
+    <p>
+      L'HEIC &mdash; quello che un iPhone salva di default &mdash; e l'AVIF sono
+      formati a scatole costruiti con atomi annidati, e hanno bisogno di un
+      analizzatore del tutto diverso. Lo strumento li riconosce e lo dice invece
+      di produrre un file rotto. Se hai un HEIC, convertirlo in JPEG ne rimuoverà
+      i metadati come effetto collaterale della conversione.
+    </p>
+    <p>
+      Nemmeno un TIFF nudo viene gestito, e per un motivo più interessante: in un
+      TIFF i metadati e i dati dei pixel sono indirizzati dagli stessi offset,
+      quindi rimuovere dei tag vuol dire riscrivere l'indirizzamento stesso
+      dell'immagine. È fattibile ed è un altro lavoro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Un'abitudine che vale la pena prendere</h2>
+    <p>
+      Controlla prima di pubblicare invece che dopo. Leggere i tag richiede
+      qualche secondo e l'elenco dei riscontri nomina le cose che vale la pena
+      sapere &mdash; la posizione, gli orari, i numeri di serie &mdash; prima
+      della tabella completa di tutti i tag, così non devi sapere cosa cercare.
+    </p>
+    <p>
+      La posizione è mostrata prima in gradi decimali, di proposito. «51 gradi,
+      30 primi, 26 secondi» non rende evidente che una foto nomina l'edificio in
+      cui è stata scattata. Una coppia di decimali che puoi incollare in una
+      mappa sì.
+    </p>
+  </section>
+
+  <section>
+    <h2>Non caricare la foto per scoprire cosa c'è dentro</h2>
+    <p>
+      C'è un'ironia particolare nel modo abituale in cui questo problema viene
+      risolto: una persona preoccupata di cosa riveli la propria foto la carica
+      su un sito per scoprirlo. Adesso il sito ha la foto, le coordinate,
+      l'orario e il numero di serie, e una copia dell'immagine su un disco che è
+      suo.
+    </p>
+    <p>
+      Non ce n'è motivo. Leggere e riscrivere il contenitore attorno a un JPEG
+      sono qualche centinaio di righe di analisi che un browser esegue
+      benissimo, ed è per questo che lo strumento di qui non ha proprio alcuna
+      funzione di rete: nessun <code>fetch</code>, nessun
+      <code>XMLHttpRequest</code>, niente che potrebbe spedire un file anche se
+      qualcosa ci provasse. Caricalo una volta, stacca la connessione, e continua
+      a funzionare.
+    </p>
+    <p>
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> spiega come verificare quell'affermazione
+      su questo sito come su qualunque altro &mdash; e questo è il tipo di file
+      su cui vale più la pena verificare.
+    </p>
+  </section>

--- a/locales/it/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/it/pages/guides/remove-exif-and-gps-data.toml
@@ -1,0 +1,18 @@
+#
+# Guida: i metadati dentro una foto, e come toglierli - Italian.
+#
+
+nav = "Dati EXIF e GPS"
+title = "Come rimuovere i dati EXIF e GPS da una foto"
+description = "Una foto fatta con un telefono di solito porta con sé il punto esatto in cui è stata scattata, l'ora al secondo e il numero di serie della fotocamera. Cosa c'è là dentro, chi può leggerlo, e come toglierlo senza toccare l'immagine."
+heading = "Cosa dice di te una foto, e come toglierlo"
+lede = """
+    Un'immagine appena uscita da un telefono porta di solito le coordinate del
+    posto in cui è stata scattata, l'ora al secondo, e abbastanza sulla
+    fotocamera da legarla a ogni altra foto dello stesso dispositivo. Niente di
+    tutto questo si vede sullo schermo. Qui c'è cosa c'è là dentro e come
+    rimuoverlo."""
+updated = "20 agosto 2026"
+og_title = "Cosa dice di te una foto, e come toglierlo"
+og_description = "Coordinate GPS, orari e numeri di serie viaggiano dentro foto comunissime. Cosa c'è là dentro, chi può leggerlo, e come toglierlo."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/resize-an-image.html
+++ b/locales/it/pages/guides/resize-an-image.html
@@ -1,0 +1,245 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../ridimensionare-immagine/">ridimensionatore di
+      immagini</a>, trascinaci dentro la tua immagine, scrivi un numero solo
+      &mdash; di solito la larghezza &mdash; e lascia vuoto l'altro campo.
+      L'altezza segue dalla forma dell'immagine, che è quasi sempre quello che
+      si voleva: «larga 1920» vuol dire «larga 1920 e alta quanto viene».
+    </p>
+    <p>
+      Tutto quello che segue è cosa fare quando un numero non basta: quando ti
+      hanno dato un riquadro con due lati, quando l'immagine deve diventare più
+      grande, o quando una cartella intera di file deve uscire uguale.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rimpicciolire è sicuro. Ingrandire no.</h2>
+    <p>
+      Non sono due direzioni della stessa operazione, e vale la pena essere
+      chiari sul perché.
+    </p>
+    <p>
+      <strong>Rimpicciolire un'immagine</strong> butta via informazione, e
+      nell'unico senso innocuo: entrano più pixel di quanti ne escano, quindi
+      ogni pixel del risultato è la media di dettaglio davvero misurato. Una
+      copia rimpicciolita bene di solito si vede <em>meglio</em> dell'originale
+      guardato a quella dimensione, perché la media toglie il rumore. Non viene
+      inventato niente.
+    </p>
+    <p>
+      <strong>Ingrandire un'immagine</strong> deve inventare. Il dettaglio non
+      manca dal file; non è mai stato fotografato. Tutto quello che un
+      ingranditore può fare è indovinare i pixel intermedi dai vicini, e
+      un'ipotesi tra due valori noti è una rampa liscia &mdash; ed è per questo
+      che una foto ingrandita si vede morbida invece che nitida. È una copia più
+      grande della stessa immagine, non una più dettagliata.
+    </p>
+    <p>
+      È per questo che «non ingrandire mai un'immagine oltre la sua dimensione
+      di partenza» è attivo di default nello strumento di qui. Toglilo se ti
+      serve davvero il numero di pixel &mdash; una tipografia che chiede una
+      dimensione minima, un modello che rifiuta qualunque cosa sotto una certa
+      larghezza &mdash; ma fallo sapendo che stai comprando pixel, non
+      dettaglio.
+    </p>
+    <p>
+      Gli ingranditori con apprendimento automatico che sembrano davvero
+      aggiungere dettaglio sono tutt'altra cosa: stanno inventando texture
+      plausibile a partire da un modello di come sono fatte di solito le
+      immagini. Per uno sfondo del desktop va benissimo. Per la fotografia di
+      una persona, di un documento, o di qualunque cosa da cui qualcuno trarrà
+      una conclusione, tieni presente che il dettaglio in più è finzione.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tre modi di dire che dimensione vuoi</h2>
+    <p>
+      Quasi tutti gli strumenti, questo compreso, accettano gli stessi tre, e
+      vanno bene per lavori diversi.
+    </p>
+    <ul>
+      <li>
+        <strong>Pixel esatti.</strong> Usalo quando qualcuno ha indicato il
+        numero: un'immagine profilo che deve essere 400&times;400, un'insegna
+        che deve essere larga 1500. Riempi un lato e lascia che l'altro segua,
+        a meno che non ti abbiano dato entrambi.
+      </li>
+      <li>
+        <strong>Una percentuale.</strong> Usala quando vuoi tutto
+        proporzionalmente più piccolo e la cifra esatta non ti interessa
+        &mdash; «metà» per una serie di foto che va dentro un documento.
+      </li>
+      <li>
+        <strong>Il lato lungo.</strong> Il più utile dei tre per un lotto
+        misto. «Lato più lungo 1600» fa stare ogni immagine dentro un quadrato
+        da 1600 pixel, che sia verticale od orizzontale, che è quello che in
+        pratica vuol dire di solito «fammele tutte di una dimensione
+        ragionevole».
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Quando il riquadro ha una forma diversa dall'immagine</h2>
+    <p>
+      È qui che il ridimensionamento si decide davvero. Se dai sia una larghezza
+      sia un'altezza e non corrispondono alle proporzioni della tua immagine,
+      qualcosa deve cedere, e le cose che possono cedere sono esattamente
+      quattro:
+    </p>
+    <ul>
+      <li>
+        <strong>Stare dentro il riquadro.</strong> L'immagine viene tenuta tutta
+        ed esce più piccola del riquadro su un asse. Non si perde niente e non
+        si deforma niente; semplicemente non ottieni le misure esatte che avevi
+        chiesto. È il comportamento giusto per quasi tutto.
+      </li>
+      <li>
+        <strong>Riempire il riquadro e tagliare quello che avanza.</strong>
+        Ottieni esattamente le misure che avevi chiesto, e le parti di immagine
+        che sporgono dai bordi spariscono. Giusto per miniature, immagini
+        profilo e copertine, dove la forma è fissa e il soggetto sta in mezzo.
+        Sbagliato quando la cosa che conta sta vicino a un bordo.
+      </li>
+      <li>
+        <strong>Riempire con lo sfondo.</strong> L'immagine viene tenuta tutta,
+        centrata, con lo spazio che avanza riempito da un colore che scegli tu.
+        Giusto quando un sistema pretende misure esatte e non puoi perdere
+        niente dell'immagine &mdash; le schede prodotto funzionano spesso così.
+      </li>
+      <li>
+        <strong>Stirarla.</strong> L'immagine viene schiacciata o tirata per
+        entrare. Non è mai quello che vuoi, a meno che tu non lo stia facendo
+        apposta, ed è quella che chiunque riconosce all'istante come sbagliata.
+      </li>
+    </ul>
+    <p>
+      Se ti accorgi di star cercando lo stiramento, quello che probabilmente
+      vuoi è il ritaglio.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ritagliare è un altro lavoro, e spesso è quello giusto</h2>
+    <p>
+      Ridimensionare cambia quanti pixel descrivono tutta l'immagine. Ritagliare
+      cambia quale parte dell'immagine tieni. Si va a cercare la prima cosa
+      intendendo la seconda sorprendentemente spesso &mdash; «questa deve essere
+      quadrata» è un problema di ritaglio, non di ridimensionamento.
+    </p>
+    <p>
+      Falli in quell'ordine: prima ritaglia l'inquadratura che vuoi, poi
+      ridimensiona il risultato alla dimensione che ti serve. Farlo al contrario
+      vuol dire scegliere il ritaglio dentro un'immagine che ha già perso pixel.
+    </p>
+    <p>
+      Lo strumento di qui li fa entrambi in un passaggio solo proprio per questo
+      &mdash; trascina un riquadro, bloccalo su una forma se ti serve una
+      proporzione precisa, poi di' che dimensione deve avere il risultato. Farlo
+      in un passaggio solo vuol dire anche che l'immagine viene codificata una
+      volta sola, il che conta per il motivo della sezione successiva.
+    </p>
+    <h3>Ritagliare un lotto intero</h3>
+    <p>
+      Un riquadro disegnato su un'immagine viene applicato alle altre come la
+      stessa area <em>relativa</em>: le stesse frazioni della larghezza e
+      dell'altezza di ciascun file. Per una cartella di screenshot o di
+      esportazioni tutti della stessa dimensione, è esattamente lo stesso
+      rettangolo. Per un lotto misto è la stessa inquadratura invece dello stesso
+      rettangolo, il che di solito è quello che si voleva ma vale la pena saperlo
+      prima di affidargli cinquanta file.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quanto costa la ricodifica, e come tenerla a una sola</h2>
+    <p>
+      Ridimensionare un JPEG o un WebP vuol dire decodificarlo, scalare i pixel
+      e ricodificarli &mdash; e quest'ultimo passaggio è con perdita. Non è la
+      scalatura in sé a costarti qualità; è la ricodifica.
+    </p>
+    <p>
+      Ne seguono due cose. Primo: l'impostazione della qualità in uscita conta,
+      e da qualche parte attorno a 80&ndash;85 è invisibile per una fotografia e
+      parecchio più leggera di 100. Secondo: fallo una volta sola.
+      Ridimensionare un'immagine che è già stata ridimensionata due volte vuol
+      dire tre generazioni di codifica con perdita, e si vede.
+    </p>
+    <p>
+      Un PNG non ha questo costo, perché è senza perdita &mdash; un PNG
+      ridimensionato è esattamente i pixel scalati. Se stai lavorando in più
+      passaggi e il formato finale non è ancora deciso, lavorare in PNG nel
+      frattempo evita di accumulare generazioni.
+    </p>
+    <p>
+      Un dettaglio che vale la pena sapere sullo strumento di qui: un file che
+      non stai cambiando affatto ti viene restituito byte per byte invece che
+      ricodificato. Chiedi «lato più lungo 1600» su un lotto e quelli già sotto
+      i 1600 escono intatti, tag compresi. Uno strumento che li ricodificasse in
+      silenzio ti starebbe costando qualità su file che nessuno gli aveva chiesto
+      di cambiare.
+    </p>
+  </section>
+
+  <section>
+    <h2>La trasparenza, e cosa le succede</h2>
+    <p>
+      PNG e WebP sanno conservare la trasparenza. Il JPEG no &mdash; nel formato
+      non c'è proprio alcun canale alfa. Quindi salvare un'immagine trasparente
+      come JPEG deve metterci qualcosa dietro, e quel qualcosa è un colore
+      pieno.
+    </p>
+    <p>
+      Quasi tutti gli strumenti usano il bianco e non lo dicono, il che va bene
+      finché il tuo logo non finisce su una pagina scura con un rettangolo bianco
+      attorno. Scegli il colore di proposito, oppure salva in PNG o WebP e tieni
+      la trasparenza. Lo stesso colore viene usato dietro una cornice di
+      riempimento, che è l'altro punto in cui la gente ci si imbatte per
+      sorpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quale strumento, se ti hanno dato un numero</h2>
+    <p>
+      Vengono dati due numeri diversi, e servono strumenti diversi.
+    </p>
+    <p>
+      <strong>«Larga 1200 pixel»</strong> è un problema di misure. Quello giusto
+      è il <a href="../../ridimensionare-immagine/">ridimensionatore di
+      immagini</a>: dici quanti pixel vuoi e te li dà.
+    </p>
+    <p>
+      <strong>«Sotto i 500&nbsp;KB»</strong> è un problema di peso del file, e
+      ridimensionare è solo uno dei modi di risolverlo. Il
+      <a href="../../comprimere-immagine/">compressore di immagini</a> cerca la
+      qualità più alta che sta nel tuo obiettivo e ridimensiona solo se la
+      qualità da sola non ci arriva;
+      <a href="../comprimere-un-immagine-a-una-dimensione-esatta/">la sua
+      guida</a> spiega quanto costa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Niente di tutto questo ha bisogno di un caricamento</h2>
+    <p>
+      Decodificare un'immagine, scalarla e ricodificarla sono cose che ogni
+      browser sa fare da anni &mdash; è lo stesso meccanismo che una pagina web
+      usa per disegnare un'immagine a una dimensione diversa. Non c'è alcun
+      motivo tecnico per cui la tua foto debba andare fino a un server e tornare
+      per uscirne più piccola, e lo strumento di qui non la manda da nessuna
+      parte: la <code>Content-Security-Policy</code> della pagina nomina tutti
+      gli indirizzi che può contattare, e nessuno di questi appartiene a questo
+      sito.
+    </p>
+    <p>
+      Carica la pagina, stacca la connessione, e ridimensiona qualcosa lo stesso
+      se preferisci verificare invece che crederci.
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone altre tre verifiche che puoi
+      fare su qualunque strumento.
+    </p>
+  </section>

--- a/locales/it/pages/guides/resize-an-image.toml
+++ b/locales/it/pages/guides/resize-an-image.toml
@@ -1,0 +1,17 @@
+#
+# Guida: ridimensionare un'immagine senza rovinarla - Italian.
+#
+
+nav = "Ridimensionare un'immagine"
+title = "Come ridimensionare un'immagine senza rovinarla"
+description = "Cosa succede a un'immagine quando ne cambi le misure in pixel: perché rimpicciolire è sicuro e ingrandire no, cosa fare quando il riquadro ha la forma sbagliata, e quando conviene invece ritagliare."
+heading = "Come ridimensionare un'immagine senza rovinarla"
+lede = """
+    Ridimensionare è l'unico lavoro sulle immagini in cui il danno è deciso
+    prima di premere il pulsante, da quale numero scrivi e da quale forma
+    chiedi. Qui c'è cosa fa all'immagine ognuna di quelle scelte, e quali di
+    esse si possono disfare."""
+updated = "20 agosto 2026"
+og_title = "Ridimensionare un'immagine senza rovinarla"
+og_description = "Perché rimpicciolire è sicuro e ingrandire no, cosa fare quando il riquadro ha la forma sbagliata, e quando conviene invece ritagliare."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/trim-a-video.html
+++ b/locales/it/pages/guides/trim-a-video.html
@@ -1,0 +1,202 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../tagliare-video/">tagliavideo</a>, trascinaci dentro
+      la clip, premi <kbd>I</kbd> e <kbd>O</kbd> per segnare ogni pezzo che vuoi
+      &mdash; quanti ne vuoi &mdash; ed esporta. Su un MP4, un MOV o un M4V i
+      fotogrammi che tieni vengono spostati nel file nuovo esattamente com'erano
+      &mdash; gli stessi byte, le stesse impostazioni dell'encoder, tutto uguale
+      &mdash; e l'audio viene copiato campione per campione senza essere
+      decodificato.
+    </p>
+    <p>
+      Vuol dire che un taglio non ti costa niente in qualità, ed è veloce:
+      tirare fuori un minuto da una registrazione di quattro gigabyte costa più
+      o meno quanto costa scrivere quel minuto sul disco, perché i fotogrammi
+      vengono puntati invece che caricati. L'unico punto in cui la cosa si vede
+      è dove il tuo taglio cade davvero, ed è il resto di questa pagina.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché un taglio non deve far perdere alcuna qualità</h2>
+    <p>
+      Tagliare non cambia l'aspetto di alcun fotogramma. Ogni fotogramma che
+      tieni deve uscire identico a com'era entrato, quindi non c'è motivo di
+      decodificarlo e ricodificarlo &mdash; e ci sono tutti i motivi per non
+      farlo, visto che una ricodifica è con perdita e renderebbe tutta la clip
+      leggermente peggiore solo per accorciarla.
+    </p>
+    <p>
+      Quindi un buon tagliavideo non ricodifica. Legge l'indice del file, calcola
+      quali fotogrammi codificati cadono nel tuo intervallo, e scrive quei byte
+      dentro un contenitore nuovo con un indice nuovo davanti. Su quella via non
+      viene decodificato proprio niente.
+    </p>
+    <p>
+      Parecchi strumenti ricodificano lo stesso, perché decodificare e
+      ricodificare è molto più semplice da realizzare che analizzare il formato
+      del contenitore. Di solito riconosci quale dei due stai usando dal tempo
+      che ci mette: una copia è limitata da quanto in fretta scrive il tuo disco,
+      una ricodifica da quanto in fretta il tuo dispositivo codifica video, che è
+      cento volte più lento.
+    </p>
+  </section>
+
+  <section>
+    <h2>I fotogrammi chiave, e perché il tuo taglio può cadere prima</h2>
+    <p>
+      Ecco il vincolo da cui discende tutto quello che riguarda il tagliare.
+    </p>
+    <p>
+      Il video non è conservato come una sequenza di immagini complete. Sarebbe
+      enorme. Quasi tutti i fotogrammi sono conservati come una descrizione di
+      come differiscono dai vicini, il che vuol dire che non si possono
+      decodificare da soli &mdash; ti servono i fotogrammi attorno. Solo un
+      <strong>fotogramma chiave</strong> sta in piedi da solo come immagine
+      completa, e i fotogrammi chiave di solito distano da uno a dieci secondi.
+    </p>
+    <p>
+      Quindi se segni un taglio due secondi dopo l'ultimo fotogramma chiave, un
+      tagliavideo che copia i fotogrammi non può cominciare lì. I fotogrammi in
+      corrispondenza del tuo segno sono illeggibili senza la serie che ci porta.
+      Deve portarsi tutto il tratto a partire dal fotogramma chiave davanti al
+      tuo segno.
+    </p>
+    <p>
+      Cosa ne fa è la parte interessante. Il formato del file ha un modo
+      standard per dire <em>comincia a riprodurre da questo punto</em> &mdash; i
+      fotogrammi in più stanno nel file ma il contenitore ordina al lettore di
+      saltarli. Ogni lettore diffuso lo rispetta, e la clip comincia esattamente
+      dove hai detto. Un lettore che lo ignora comincerà prima, fino a un
+      intervallo tra fotogrammi chiave.
+    </p>
+    <p>
+      Lo strumento di qui ti dice in quale dei due casi ti trovi e di quanto,
+      prima che tu esporti, così è una decisione e non una sorpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando accettare una ricodifica</h2>
+    <p>
+      C'è un taglio esatto, e funziona ricodificando il tratto iniziale &mdash;
+      decodificando dal fotogramma chiave, e riscrivendo una nuova serie di
+      fotogrammi che comincia davvero dove avevi segnato. È più lento, e costa un
+      po' di qualità, ma solo su quel tratto iniziale.
+    </p>
+    <p>
+      Scegli quello quando la clip va in un posto che non rispetterà l'ordine del
+      contenitore, o dove non controlli il lettore: certi programmi di montaggio,
+      certi sistemi di trasmissione e videoconferenza, certi lettori hardware
+      vecchi. Scegli la copia per tutto il resto, che è quasi tutto &mdash; un
+      browser, un telefono, una piattaforma social, un lettore multimediale.
+    </p>
+    <p>
+      Una terza possibilità che non costa niente: sposta il tuo segno. Se lo
+      strumento ti mostra dove sono i fotogrammi chiave, portare il taglio sul
+      più vicino ti dà un taglio esatto senza alcuna ricodifica. Raramente vale
+      la pena rinunciare a una copia per un secondo di differenza.
+    </p>
+  </section>
+
+  <section>
+    <h2>Togliere un pezzo in mezzo</h2>
+    <p>
+      Togliere un pezzo è un'operazione diversa dal tenerne uno, e vale la pena
+      sapere che è supportata, perché parecchi tagliavideo fanno solo la seconda.
+      Segna la parte che non vuoi, scegli di toglierla, e quello che resta ai
+      due lati viene unito in una clip sola con l'audio portato dall'altra parte
+      in sincrono.
+    </p>
+    <p>
+      Nel punto in cui riprende la seconda metà, la giunzione ha lo stesso
+      vincolo dei fotogrammi chiave, per lo stesso motivo. Qui funziona su
+      entrambe le vie dell'MP4. È l'unica cosa che il ripiego della registrazione
+      qui sotto non sa fare, perché una registrazione si fa in un passaggio solo
+      da una sola testina.
+    </p>
+  </section>
+
+  <section>
+    <h2>I formati, e il ripiego</h2>
+    <p>
+      <strong>MP4, M4V e MOV</strong> vengono letti direttamente, qualunque
+      codec ci sia dentro &mdash; H.264, HEVC, AV1, VP9. Copiare i fotogrammi non
+      comporta decodificarli, quindi questa via funziona anche per un codec per
+      cui il tuo browser non ha proprio alcun decodificatore, che è una piacevole
+      conseguenza del non guardare le immagini.
+    </p>
+    <p>
+      <strong>Tutto il resto che il tuo browser sa riprodurre</strong>, il WebM
+      in primis, viene tagliato riproducendolo e registrando il risultato.
+      Funziona, e ha due costi: richiede tanto tempo quanto è lungo il pezzo, e
+      l'immagine e il suono vengono ricodificati.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV e quasi tutti gli MKV</strong> il browser non li sa
+      né leggere né riprodurre, e lo strumento lo dice invece di piantarsi a metà
+      strada. Convertili prima in MP4 con qualcosa che li gestisca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Due cose che altrove vanno storte in silenzio</h2>
+    <p>
+      <strong>La rotazione.</strong> Un telefono filma in orizzontale e scrive
+      nel file un'istruzione di rotazione invece di girare i pixel. Un
+      tagliavideo che copia i fotogrammi deve portarsi dietro quell'istruzione, o
+      la tua clip verticale esce di traverso &mdash; che è il modo classico in
+      cui un video tagliato viene rovinato. La via esatta di qui gira i
+      fotogrammi mentre li ricodifica e scrive un file che non ha bisogno di
+      alcuna rotazione.
+    </p>
+    <p>
+      <strong>Il sincrono dell'audio.</strong> Audio e video sono conservati come
+      flussi separati con tempi propri, e non vengono tagliati negli stessi
+      punti. Se i due non vengono allineati di proposito al taglio, il suono
+      slitta. Sulla via della copia di qui l'audio viene copiato campione per
+      campione senza essere decodificato, quindi è byte per byte quello che
+      c'era nel file, e un segno di montaggio lo tiene in sincrono con
+      l'immagine entro un millesimo di secondo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tagliare non è ritagliare</h2>
+    <p>
+      Due parole che vengono usate una per l'altra. Tagliare cambia la durata
+      della clip; ritagliare cambia la forma dell'immagine. Se quello che vuoi è
+      una versione quadrata di un video orizzontale, o le bande nere via dai
+      lati, è il <a href="../../ritagliare-video/">ritagliatore di video</a>
+      &mdash; e a differenza del tagliare, quello deve ricodificare, per il
+      motivo che spiega <a href="../ritagliare-un-video/">la sua guida</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché questo non ha bisogno di un caricamento &mdash; questo in particolare</h2>
+    <p>
+      Il video è il tipo di file per cui più di ogni altro ci si aspetta di dover
+      caricare qualcosa, perché i file sono pesanti e il lavoro suona gravoso.
+      Tagliare è il caso in cui è meno vero: sulla via della copia il file viene
+      letto a malapena. Lo strumento percorre l'indice, calcola quali intervalli
+      di byte tenere, e li riscrive. Caricare un file da quattro gigabyte su un
+      server perché possa fare questo sarebbe il modo più lento possibile di
+      organizzare la cosa.
+    </p>
+    <p>
+      È anche il tipo di file in cui caricare costa di più, se preferiresti non
+      farlo: un video porta con sé volti, voci, case e luoghi in un modo in cui
+      un documento non lo fa. Lo strumento di qui non ha alcuna funzione di
+      rete, e la <code>Content-Security-Policy</code> della pagina nomina tutti
+      gli indirizzi che può contattare, nessuno dei quali appartiene a questo
+      sito.
+    </p>
+    <p>
+      Stacca la connessione e taglia una clip lo stesso, se preferisci verificare
+      invece che crederci.
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone altre tre verifiche come questa.
+    </p>
+  </section>

--- a/locales/it/pages/guides/trim-a-video.toml
+++ b/locales/it/pages/guides/trim-a-video.toml
@@ -1,0 +1,17 @@
+#
+# Guida: tagliare un video senza ricodificarlo - Italian.
+#
+
+nav = "Tagliare un video"
+title = "Come tagliare un video senza ricodificarlo"
+description = "Accorciare una clip non deve costare un solo byte di qualità. Perché a volte un taglio cade prima di dove l'hai segnato, cosa c'entra un fotogramma chiave, e quando accettare una ricodifica."
+heading = "Come tagliare un video senza ricodificarlo"
+lede = """
+    Tagliare non cambia l'aspetto di alcun fotogramma, quindi un buon
+    tagliavideo non li tocca &mdash; li sposta in un file nuovo esattamente
+    com'erano. Qui c'è cosa ti fa guadagnare, e l'unico punto in cui si
+    vede."""
+updated = "20 agosto 2026"
+og_title = "Come tagliare un video senza ricodificarlo"
+og_description = "Perché a volte un taglio cade prima di dove l'hai segnato, cosa c'entra un fotogramma chiave, e quando accettare una ricodifica."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/it/pages/guides/turn-a-video-into-a-gif.html
@@ -1,0 +1,227 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri il <a href="../../video-in-gif/">convertitore da video a GIF</a>,
+      trascinaci dentro la clip, segna i secondi che vuoi, e lascia la larghezza
+      a 480 e la frequenza a 12 fotogrammi al secondo. È l'impostazione che vuole
+      quasi ogni GIF. Se il file esce troppo pesante, abbassa la larghezza prima
+      di toccare qualunque altra cosa &mdash; è l'impostazione che rende doppio.
+    </p>
+    <p>
+      Il resto di questa pagina riguarda il perché, perché «la mia GIF pesa 14
+      MB» è il problema che hanno davvero tutti, e quale manopola girare non è
+      ovvio.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché una GIF fatta da un video è così enorme</h2>
+    <p>
+      Un codec video conserva il <em>movimento</em>. Scrive un'immagine completa
+      ogni due secondi circa e poi, per ogni fotogramma in mezzo, una descrizione
+      di come quell'immagine si è spostata: questo blocco di pixel è scivolato di
+      quattro a sinistra, questa zona si è un po' scurita. Una clip di cinque
+      secondi può pesare qualche centinaio di kilobyte perché quasi tutta è fatta
+      di istruzioni su un'immagine che hai già.
+    </p>
+    <p>
+      La GIF non ha niente di tutto questo. È stata finita nel 1989, prima che
+      esistesse. Ogni fotogramma è un'immagine, compressa per conto suo con uno
+      schema pensato per gli screenshot di un foglio di calcolo. Nel formato non
+      c'è alcuna stima del movimento, e non c'è modo di aggiungerne una.
+    </p>
+    <p>
+      Quindi il numero da aspettarsi è <strong>dieci volte il peso del
+      video</strong>, e nessun convertitore ti può convincere del contrario.
+      Quello che un buon convertitore può fare è non sprecare niente sopra a
+      quel numero, e darti le tre impostazioni che lo decidono davvero.
+    </p>
+  </section>
+
+  <section>
+    <h2>Le tre impostazioni, e quanto costa ciascuna</h2>
+    <p>
+      Tutto quello che riguarda il peso di una GIF si riduce a quanti pixel
+      contiene, che è la durata per la frequenza per l'area di un fotogramma.
+    </p>
+    <ul>
+      <li>
+        <strong>Il pezzo &mdash; lineare.</strong> Il doppio della durata sono il
+        doppio dei fotogrammi e all'incirca il doppio del file. È quello che
+        quasi tutti capiscono già, e vale la pena essere spietati: una GIF che
+        dice quello che deve dire in tre secondi è una GIF migliore oltre che più
+        leggera.
+      </li>
+      <li>
+        <strong>La larghezza &mdash; quadratica.</strong> Dimezzare la larghezza
+        dimezza anche l'altezza, quindi è un <em>quarto</em> dei pixel. Passare
+        da 640 a 320 non risparmia poco meno della metà; risparmia circa tre
+        quarti. È l'impostazione che nessuno va a cercare per prima ed è quella
+        che rende meglio.
+      </li>
+      <li>
+        <strong>La frequenza dei fotogrammi &mdash; lineare.</strong> Dieci
+        fotogrammi al secondo pesano due terzi di quindici. È anche
+        l'impostazione in cui la perdita si vede di più, perché un movimento
+        troppo lento si legge come rotto e non come leggero.
+      </li>
+    </ul>
+    <p>
+      Un esempio fatto. Sei secondi di una clip da telefono alla sua
+      1080&times;1920 e a 30 fps sono 180 fotogrammi da due milioni di pixel:
+      circa 350 milioni di pixel, che non è una GIF, è un sequestro di persona.
+      Gli stessi sei secondi a 480 di larghezza e 12 fps sono 72 fotogrammi da
+      400.000 pixel &mdash; 30 milioni, circa un dodicesimo &mdash; e si
+      presentano come quello che la gente intende per GIF.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quale frequenza scegliere</h2>
+    <p>
+      Dodici è il valore predefinito di qui ed è la risposta giusta
+      sorprendentemente spesso. È la frequenza che l'animazione disegnata a mano
+      usa da un secolo: abbastanza rapida perché l'occhio la legga come movimento
+      continuo, abbastanza lenta da non farti pagare fotogrammi che nessuno può
+      vedere.
+    </p>
+    <ul>
+      <li><strong>5&ndash;8</strong> &mdash; effetto presentazione. Va bene per
+        una panoramica lenta o per una registrazione dello schermo dove non si
+        muove niente in fretta.</li>
+      <li><strong>10&ndash;15</strong> &mdash; normale. Si legge come movimento.
+        Quasi ogni GIF che valga la pena fare sta qui dentro.</li>
+      <li><strong>20&ndash;25</strong> &mdash; fluido, e all'incirca il doppio
+        del peso di 12 per una differenza che quasi nessuno saprebbe nominare.
+        Vale la pena per il movimento veloce, una clip sportiva, qualunque cosa
+        con dentro una panoramica a frusta.</li>
+    </ul>
+    <p>
+      C'è un tetto rigido che tanto vale conoscere: la GIF conserva quanto ogni
+      fotogramma resta sullo schermo in centesimi di secondo, e ogni browser
+      tratta un ritardo sotto i due centesimi come dieci. Quindi 50 fotogrammi al
+      secondo sono il massimo vero, e un file che ne chiede 100 andrà in silenzio
+      a 10. Un convertitore che ti propone 60 fps o sta ignorando la cosa o sta
+      per sorprenderti.
+    </p>
+  </section>
+
+  <section>
+    <h2>256 colori, e a cosa serve il dithering</h2>
+    <p>
+      L'altra metà dell'età del formato: una GIF porta con sé una tabella di al
+      massimo 256 colori, e ogni pixel è un numero che punta lì dentro. Un
+      fotogramma di video ne ha fino a sedici milioni. Quasi tutti vengono
+      buttati, e come vengono buttati è la maggior parte di come si presenta una
+      GIF.
+    </p>
+    <p>
+      Un buon convertitore conta i colori nella <em>tua</em> clip e ne sceglie
+      256 che le si addicono, invece di usare un insieme fisso. Un'inquadratura
+      di un bosco riceve 256 verdi; una di un tramonto riceve 256 arancioni. È
+      quello che fa lo strumento di qui, su ogni fotogramma del pezzo e non solo
+      sul primo, così un colore che compare solo alla fine ottiene comunque un
+      posto.
+    </p>
+    <p>
+      Il <strong>dithering</strong> è quello che succede dove il colore che ti
+      serve manca comunque. Invece di arrotondare tutta una zona al colore
+      disponibile più vicino &mdash; cosa che trasforma un cielo morbido in
+      quattro fasce piatte con gradini visibili in mezzo &mdash; alterna i due
+      colori più vicini secondo uno schema fine, e a una normale distanza di
+      visione il tuo occhio li mescola in quello che non c'è.
+    </p>
+    <ul>
+      <li><strong>Lascialo attivo</strong> per qualunque cosa fotografica: cieli,
+        pelle, sfumature, ombre, pellicola.</li>
+      <li><strong>Spegnilo</strong> per le tinte piatte: registrazioni dello
+        schermo, disegni al tratto, loghi, cartoni animati, qualunque cosa con
+        grandi aree di una sola tinta. Non c'è alcuna sfumatura da proteggere, e
+        senza il file è più leggero e più pulito.</li>
+    </ul>
+    <p>
+      Un dettaglio da sapere se confronti dei convertitori. Il modo ovvio di fare
+      dithering &mdash; la diffusione dell'errore, che usa quasi ogni programma
+      di grafica &mdash; fa dipendere il risultato di ogni pixel dai pixel
+      attorno. In un'animazione vuol dire che uno sfondo che non si muove viene
+      comunque ditherato in modo diverso a ogni fotogramma, quindi brulica
+      visibilmente, e ogni fotogramma va conservato per intero perché
+      tecnicamente ogni pixel è cambiato. L'alternativa, un dithering ordinato,
+      dipende solo da dove sta un pixel, quindi uno sfondo fermo resta
+      perfettamente fermo. È quello che usa questo strumento, ed è il motivo per
+      cui i suoi file sono insieme più leggeri e più tranquilli.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando non fare affatto una GIF</h2>
+    <p>
+      Vale la pena chiederselo, perché la risposta onesta è spesso «non farla».
+      Un MP4 o un WebM muto che si ripete pesa circa un decimo della stessa
+      animazione come GIF, si comporta allo stesso modo, ed è quello in cui ogni
+      piattaforma social converte comunque la tua GIF dopo che l'hai caricata.
+    </p>
+    <p>Tieni la GIF dove la destinazione ne ha davvero bisogno:</p>
+    <ul>
+      <li>un posto che accetta solo un'immagine &mdash; parecchi programmi di
+        chat, forum, wiki e posta;</li>
+      <li>un README o una pagina di documentazione, dove una GIF si riproduce
+        nel testo e un video ha bisogno di un lettore;</li>
+      <li>una presentazione o un documento che deve continuare a muoversi
+        offline;</li>
+      <li>un'emoji, uno sticker, una reazione &mdash; abbastanza piccoli perché
+        tutta l'aritmetica del peso qui sopra non conti.</li>
+    </ul>
+    <p>
+      Dove conta il suono, la domanda si risponde da sola: la GIF non ha mai
+      avuto l'audio e non lo avrà mai. Taglia invece il video &mdash; il
+      <a href="../../tagliare-video/">tagliavideo</a> ne tira fuori un pezzo
+      senza ricodificarne un fotogramma.
+    </p>
+  </section>
+
+  <section>
+    <h2>Stare sotto un limite di peso</h2>
+    <p>
+      Quasi tutto il motivo per cui si mette a punto una GIF è un limite
+      dall'altra parte. Più o meno in ordine di quanto mordono:
+    </p>
+    <ul>
+      <li><strong>Posta</strong> &mdash; da 10 a 25 MB per tutto il messaggio, e
+        un allegato vicino a quella soglia viene tolto o respinto da qualcosa
+        lungo la strada. Punta molto più in basso.</li>
+      <li><strong>Chat e forum</strong> &mdash; di solito da 8 a 10 MB, a volte
+        molto meno per un'anteprima nel testo invece che per un download.</li>
+      <li><strong>Un README su GitHub</strong> &mdash; 10 MB per file, e
+        qualunque cosa oltre un paio di megabyte fa sembrare rotta la pagina su
+        un telefono.</li>
+      <li><strong>Gli spazi per sticker ed emoji</strong> &mdash; spesso qualche
+        centinaio di kilobyte, il che vuol dire una larghezza piccola e un pezzo
+        corto, non una frequenza più bassa.</li>
+    </ul>
+    <p>
+      L'ordine in cui provare, quando sei sopra: accorcia il pezzo, poi dimezza
+      la larghezza, poi abbassa la frequenza, poi spegni il dithering. Le prime
+      due valgono più delle ultime due messe insieme.
+    </p>
+  </section>
+
+  <section>
+    <h2>Niente di tutto questo ha bisogno di un caricamento</h2>
+    <p>
+      Convertire un video in una GIF è decodificare, ridimensionare, contare i
+      colori e comprimere &mdash; quattro cose che un browser sa fare da solo da
+      anni. Lo strumento collegato in cima le fa tutte sul tuo dispositivo: il
+      file viene letto dal tuo disco, i fotogrammi vengono decodificati dal tuo
+      browser, e la GIF viene assemblata in memoria e consegnata ai tuoi
+      download.
+    </p>
+    <p>
+      Ed è una cosa a cui qui vale la pena tenere più del solito. Le clip che la
+      gente trasforma in GIF sono personali &mdash; un momento di un video di
+      famiglia, la registrazione dello schermo di qualcosa al lavoro, qualche
+      secondo di una videochiamata. Un convertitore che vuole che vengano
+      caricate sta chiedendo una copia di quelle cose, e non è rimasto alcun
+      motivo tecnico per dire di sì.
+    </p>
+  </section>

--- a/locales/it/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/it/pages/guides/turn-a-video-into-a-gif.toml
@@ -1,0 +1,17 @@
+#
+# Guida: trasformare un video in una GIF - Italian.
+#
+
+nav = "Fare una GIF da un video"
+title = "Come trasformare un video in una GIF (e tenerla leggera)"
+description = "Quale pezzo, quale larghezza e quale frequenza scegliere, perché una GIF di un video pesa dieci volte il video, e quando usarne una."
+heading = "Come trasformare un video in una GIF"
+lede = """
+    La GIF è un formato del 1987 che conserva immagini intere invece del
+    movimento, quindi una fatta da un video è sempre pesante. Qui c'è quale
+    delle tre impostazioni muovere quando è troppo pesante, e quanto ti fa
+    guadagnare ciascuna."""
+updated = "20 agosto 2026"
+og_title = "Come trasformare un video in una GIF, e tenerla leggera"
+og_description = "Le tre impostazioni che decidono il peso di una GIF, quanto costa ciascuna, e quando una GIF è del tutto la risposta sbagliata."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/turn-images-into-a-video.html
+++ b/locales/it/pages/guides/turn-images-into-a-video.html
@@ -1,0 +1,197 @@
+  <section>
+    <h2>La risposta corta</h2>
+    <p>
+      Apri <a href="../../immagini-in-video/">Immagini in video</a>, trascinaci
+      dentro le foto, mettile in ordine, imposta quanto viene tenuta ciascuna, e
+      crea il video. Ottieni un MP4 con video H.264, che si riproduce
+      praticamente ovunque.
+    </p>
+    <p>
+      Le due impostazioni che più spesso richiedono un secondo giro sono la
+      durata e la risoluzione, e vale la pena capirle prima del primo render e
+      non dopo.
+    </p>
+  </section>
+
+  <section>
+    <h2>La frequenza dei fotogrammi e la durata non sono la stessa cosa</h2>
+    <p>
+      È la confusione che costa alla gente un secondo render.
+    </p>
+    <p>
+      La <strong>durata</strong> è quanto ogni immagine resta sullo schermo. È
+      l'impostazione che ti interessa davvero. Tre secondi sono un buon valore
+      predefinito per una presentazione che qualcuno guarda; uno o due secondi
+      danno un ritmo svelto; oltre i cinque si trascina, a meno che non ci sia
+      una voce sopra.
+    </p>
+    <p>
+      La <strong>frequenza dei fotogrammi</strong> è quante volte al secondo il
+      video ripete quell'immagine. Non cambia niente di come si presenta la
+      presentazione &mdash; un'immagine ferma tenuta per tre secondi si vede
+      identica a 24 fotogrammi al secondo e a 60 &mdash; e cambia parecchio il
+      peso del file e il tempo di codifica.
+    </p>
+    <p>
+      Quindi per una presentazione semplice scegli una frequenza bassa. 24 o 30
+      abbondano. Il motivo per salire è se nel video c'è movimento: una
+      panoramica o uno zoom su ogni foto, o una dissolvenza incrociata tra loro,
+      dove una frequenza bassa si vede come scatti.
+    </p>
+  </section>
+
+  <section>
+    <h2>La risoluzione, e le immagini della forma sbagliata</h2>
+    <p>
+      Un video ha una sola dimensione di fotogramma per tutta la sua durata. Le
+      tue fotografie quasi certamente non ne condividono una, quindi a quelle che
+      non ci stanno deve succedere qualcosa &mdash; e quel qualcosa è la scelta
+      che vale la pena fare di proposito.
+    </p>
+    <p>
+      Comincia scegliendo la risoluzione in base a dove va il video:
+    </p>
+    <ul>
+      <li>
+        <strong>1920&times;1080</strong> per qualunque cosa generica. Supportato
+        universalmente, si riproduce dappertutto, ed è quello che quasi tutti
+        intendono per HD.
+      </li>
+      <li>
+        <strong>1080&times;1920</strong> &mdash; gli stessi numeri al contrario
+        &mdash; per una destinazione pensata per il telefono: storie, reel,
+        short.
+      </li>
+      <li>
+        <strong>3840&times;2160</strong> solo se le immagini hanno davvero tutto
+        quel dettaglio e la destinazione lo mostrerà. Sono quattro volte i pixel,
+        quattro volte il tempo di codifica, e all'incirca quattro volte il file.
+      </li>
+    </ul>
+    <p>
+      Poi decidi cosa succede a quelle che non corrispondono. Far stare ogni
+      immagine dentro il fotogramma la tiene tutta e lascia delle bande ai lati
+      &mdash; scelta prudente, ed è la risposta giusta quando le immagini
+      contano più della presentazione. Riempire il fotogramma e tagliare quello
+      che avanza viene meglio e a qualcuna taglierà la parte alta. Mescolare foto
+      verticali e orizzontali in un solo video è il caso in cui non c'è una
+      risposta buona; decidere in anticipo da che parte preferisci sbagliare ti
+      risparmia un secondo render.
+    </p>
+  </section>
+
+  <section>
+    <h2>L'ordine, e la trappola dei nomi di file</h2>
+    <p>
+      Come in ogni lavoro a lotti, i nomi dei file si ordinano in un modo che non
+      è quello in cui hai contato tu. <code>foto2.jpg</code> viene dopo
+      <code>foto10.jpg</code> in un ordine alfabetico, perché il confronto è
+      carattere per carattere.
+    </p>
+    <p>
+      Ordinare per data di scatto è di solito giusto per le fotografie di un
+      evento, visto che le hai scattate nell'ordine in cui le cose sono
+      successe. Trascinare le tessere è giusto per tutto ciò in cui la storia non
+      è cronologica. Controlla prima di renderizzare: il video è l'unico
+      manufatto in cui sistemare l'ordine vuol dire rifare tutto il lavoro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Non c'è colonna sonora, e non è una cosa da poco</h2>
+    <p>
+      L'MP4 che questo strumento scrive ha una sola traccia video e nessuna
+      traccia audio. Se la tua presentazione ha bisogno di musica o di una voce
+      fuori campo, per quel passaggio ti servirà un programma di montaggio.
+    </p>
+    <p>
+      Vale la pena sapere il perché, invece del solo fatto: aggiungere l'audio
+      vuol dire decodificare un file musicale, codificarlo in AAC, e intrecciarlo
+      con il video dentro il contenitore. Tutte e tre sono lavoro vero, e farle
+      male produce un file che perde il sincrono mentre scorre. È nella lista,
+      invece che fatto a metà.
+    </p>
+    <p>
+      Una nota pratica se poi la musica la aggiungi: scegli prima il brano e
+      imposta la durata per immagine in modo che la presentazione esca vicina
+      alla lunghezza della canzone. Tagliare la musica per farla stare nel video
+      suona sempre peggio che far stare il video nella musica.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa esce, e cosa fare se non si riproduce</h2>
+    <p>
+      L'obiettivo è l'MP4 con H.264, ed è la combinazione più ampiamente
+      riproducibile che ci sia. In un browser senza WebCodecs lo strumento
+      ripiega sulla registrazione in WebM &mdash; le stesse riprese in un
+      contenitore che meno programmi di montaggio e meno piattaforme social
+      accettano.
+    </p>
+    <p>
+      Se ti ritrovi con un WebM e qualcosa lo rifiuta, la soluzione è un browser
+      che supporti WebCodecs, non una conversione: le versioni attuali di Chrome,
+      Edge e Safari lo fanno tutte. Rifare il render è meglio che convertire,
+      perché convertire vuol dire un'altra generazione di codifica con perdita.
+    </p>
+    <p>
+      Nello strumento non c'è alcun limite al numero di immagini che puoi usare.
+      Il tetto è la memoria del tuo dispositivo, perché il video finito viene
+      assemblato lì prima che tu lo scarichi &mdash; una lunga presentazione in
+      4K è la prima cosa a sentirlo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Alleggerire il file</h2>
+    <p>
+      Se il risultato è troppo pesante per il posto dove sta andando, in ordine
+      di cosa aiuta davvero:
+    </p>
+    <p>
+      <strong>Abbassa la frequenza dei fotogrammi.</strong> Per una presentazione
+      di immagini ferme non costa niente di visibile ed è il singolo risparmio
+      più grande a disposizione.
+    </p>
+    <p>
+      <strong>Abbassa la risoluzione.</strong> 1080p invece di 4K è un quarto dei
+      pixel, e sullo schermo di un telefono non se ne accorgerà nessuno.
+    </p>
+    <p>
+      <strong>Accorciala.</strong> Tre secondi a immagine invece di cinque sono
+      il 40% in meno di durata e il 40% in meno di file, e di solito una
+      presentazione migliore.
+    </p>
+    <p>
+      Rimpicciolire prima le fotografie di partenza non aiuta granché. Il video
+      viene comunque codificato alla risoluzione che hai scelto, quindi una foto
+      da 4000 pixel e una da 2000 producono quasi lo stesso numero di byte in un
+      video 1080p. Rende però la codifica più rapida, e sposta quel tetto di
+      memoria.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché questo non ha bisogno di un server, con un'eccezione dichiarata</h2>
+    <p>
+      Codificare video era il caso più chiaro a favore del caricamento: i browser
+      non lo sapevano fare, e una macchina con FFmpeg sì. WebCodecs ha cambiato
+      le cose esponendo l'encoder hardware che il tuo dispositivo ha già, che è
+      lo stesso che il tuo telefono usa per registrare video in tempo reale.
+      Comporre i fotogrammi è una tela. Nessuno dei due passaggi ha bisogno di
+      altro che del tuo hardware.
+    </p>
+    <p>
+      Un'eccezione su questo strumento in particolare, dichiarata invece che
+      sepolta: la funzione facoltativa «aggiungi da un indirizzo web» recupera
+      un'immagine da un indirizzo che incolli tu, e il server a
+      quell'indirizzo vede il tuo IP e cosa hai chiesto. È insita nella funzione
+      e non è un suo difetto, ed è l'unico passaggio di rete di tutto lo
+      strumento. Non usarla e dal tuo dispositivo non esce proprio niente.
+    </p>
+    <p>
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> propone quattro verifiche che ti diranno
+      la stessa cosa su qualunque strumento, questo compreso.
+    </p>
+  </section>

--- a/locales/it/pages/guides/turn-images-into-a-video.toml
+++ b/locales/it/pages/guides/turn-images-into-a-video.toml
@@ -1,0 +1,16 @@
+#
+# Guida: trasformare delle immagini in un video - Italian.
+#
+
+nav = "Immagini in un video"
+title = "Come trasformare una cartella di immagini in un video"
+description = "Fai una presentazione in MP4 con delle foto: cosa controllano davvero la frequenza dei fotogrammi e la durata, come gestire le immagini della forma sbagliata, e perché il risultato non ha colonna sonora."
+heading = "Come trasformare una cartella di immagini in un video"
+lede = """
+    Una presentazione è una cosa semplice da fare e facile da rifare due volte,
+    perché due delle impostazioni non vogliono dire quello che sembra. Qui c'è
+    cosa controlla ciascuna e cosa scegliere."""
+updated = "20 agosto 2026"
+og_title = "Come trasformare una cartella di immagini in un video"
+og_description = "Cosa controllano davvero la frequenza dei fotogrammi e la durata, come gestire le immagini della forma sbagliata, e perché non c'è colonna sonora."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/privacy.html
+++ b/locales/it/pages/privacy.html
@@ -1,0 +1,190 @@
+  <section>
+    <h2>I tuoi file</h2>
+    <p>
+      Ogni strumento di questo sito fa il proprio lavoro dentro il tuo browser,
+      sul tuo hardware. Quando scegli un file, viene letto dalla pagina che hai
+      già aperto. Non ci viene mandato, perché non esiste un nostro server a cui
+      mandarlo &mdash; questo sito è un insieme di file statici, senza backend,
+      senza database e senza archiviazione.
+    </p>
+    <p>
+      Vuol dire che non riceviamo, non vediamo, non conserviamo, non registriamo
+      e non elaboriamo mai:
+    </p>
+    <ul>
+      <li>i tuoi file, interi o in parte</li>
+      <li>miniature o anteprime di essi</li>
+      <li>i loro nomi, dimensioni, misure o formati</li>
+      <li>quanti ne hai scelti, o cosa ci hai fatto</li>
+      <li>niente di quello che ci viene letto dentro, dati EXIF e GPS compresi</li>
+    </ul>
+    <p>
+      Non è una promessa sulle nostre intenzioni. Ogni pagina porta con sé una
+      <code>Content-Security-Policy</code> che nomina tutti gli indirizzi che la
+      pagina può contattare, e il browser la fa rispettare. Nessuno di quegli
+      indirizzi è nostro. Puoi leggere la policy in cima al sorgente di
+      qualunque pagina, oppure aprire la scheda Rete del tuo browser e guardare:
+      nessuna richiesta porta con sé il tuo file.
+    </p>
+    <p>
+      I file che produci con uno strumento vengono consegnati al meccanismo di
+      download del tuo browser e salvati dove gli dici tu. Nemmeno in quel
+      passaggio siamo coinvolti.
+    </p>
+  </section>
+
+  <section>
+    <h2>L'unica eccezione, e dove vale</h2>
+    <p>
+      Lo strumento <a href="../immagini-in-video/">Immagini in video</a> ha una
+      funzione «aggiungi da un indirizzo web». Se ci incolli dentro un
+      indirizzo, il tuo browser recupera quell'immagine dal server che hai
+      nominato, e <strong>quel server vede il tuo indirizzo IP</strong> e quale
+      file hai chiesto. È inevitabile, ed è tutta la natura di quella funzione.
+    </p>
+    <p>
+      Succede solo per gli indirizzi che scrivi tu, è costruita in modo che le
+      immagini possano entrare ma i dati non possano uscire, e la pagina di
+      quello strumento la spiega più nel dettaglio. Nessun altro strumento di
+      questo sito può fare una richiesta in uscita con dentro qualcosa di tuo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cosa viene raccolto, e da chi</h2>
+    <p>
+      Questo sito è gratuito ed è pagato dalla pubblicità. Vuol dire che su
+      queste pagine girano due prodotti di Google, e su quasi tutte un pulsante
+      per le donazioni. Ecco l'elenco completo.
+    </p>
+
+    <h3>Google AdSense &mdash; la pubblicità</h3>
+    <p>
+      Google serve gli annunci e decide quali vedi. Per farlo può impostare e
+      leggere cookie o identificatori simili nel tuo browser, e riceve il tuo
+      indirizzo IP, una posizione approssimativa ricavata da esso, il tuo user
+      agent, e su quale pagina eri. A seconda delle tue impostazioni e di dove
+      ti trovi, gli annunci possono essere personalizzati usando un profilo che
+      Google ha su di te, costruito in gran parte a partire dalla tua attività
+      su altri siti.
+    </p>
+    <p>
+      Noi non riceviamo niente di tutto ciò, non lo possiamo vedere, e non
+      mandiamo mai a Google niente sui tuoi file. Il resoconto di Google su come
+      usa i dati dei siti che ospitano la sua pubblicità sta su
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>.
+    </p>
+
+    <h3>Google Analytics &mdash; il contatore delle visite</h3>
+    <p>
+      Usiamo Google Analytics 4 per contare le visite alle pagine, così sappiamo
+      su quali strumenti vale la pena lavorare. Registra la pagina che hai
+      guardato, all'incirca quando, un identificatore generato a caso e
+      conservato nel tuo browser, una posizione approssimativa, il tipo di
+      dispositivo e di browser, e il sito da cui sei arrivato.
+    </p>
+    <p>
+      È configurato per non fare nient'altro, e la configurazione è un file che
+      puoi leggere: <code>analytics.js</code>, accanto a ogni pagina, imposta un
+      contatore di visualizzazioni e non contiene proprio alcun evento
+      personalizzato. Su questo sito non c'è niente che gli passi un file, un
+      nome di file, una misura o un conteggio &mdash; qui non c'è codice che
+      potrebbe farlo.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; il pulsante delle donazioni</h3>
+    <p>
+      La pagina principale e le pagine degli strumenti hanno un pulsante per le
+      donazioni, che si carica dai server di Buy Me a Coffee. Caricarlo vuol
+      dire che la loro CDN vede il tuo indirizzo IP e che eri su questo sito, e
+      i caratteri del pulsante vengono presi da Google Fonts, che vede
+      anch'essa il tuo indirizzo IP. Non viene mandato nient'altro, e non
+      succede altro finché non ci clicchi davvero, momento in cui sei sul loro
+      sito e sotto le loro condizioni. Questa pagina e la
+      <a href="../termini/">pagina dei termini</a> non disegnano il pulsante.
+    </p>
+
+    <h3>Hosting</h3>
+    <p>
+      Il sito è servito da GitHub Pages, dietro Cloudflare. Come qualunque host
+      web, elaborano le richieste che fa il tuo browser &mdash; il che comprende
+      il tuo indirizzo IP, la pagina richiesta e il tuo user agent &mdash; per
+      consegnare la pagina e per tenere il servizio in piedi e al sicuro. Non
+      abbiamo accesso ai registri per singolo visitatore di nessuno dei due.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cookie</h2>
+    <p>
+      Non impostiamo alcun cookie nostro. Non abbiamo un accesso, non abbiamo
+      una sessione, non abbiamo preferenze da ricordare, e non abbiamo alcun
+      motivo per averne.
+    </p>
+    <p>
+      Ogni cookie o identificatore simile che puoi trovare qui appartiene a
+      Google ed è impostato dagli script pubblicitari e di misurazione descritti
+      sopra. Servono a misurare le visite, e a scegliere e limitare gli annunci.
+    </p>
+    <h3>Come spegnerlo</h3>
+    <ul>
+      <li>
+        La personalizzazione degli annunci si può disattivare, per tutti i siti
+        in una volta, su
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">My Ad Center</a>.
+      </li>
+      <li>
+        Google Analytics si può bloccare dappertutto con il
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">componente aggiuntivo di rinuncia</a>
+        di Google.
+      </li>
+      <li>
+        Le impostazioni del tuo browser possono bloccare o cancellare i cookie di
+        terze parti, e qualunque blocca-contenuti impedisce a questi script di
+        caricarsi fin dall'inizio.
+      </li>
+    </ul>
+    <p>
+      Bloccare tutto ci sta benissimo. <strong>Ogni strumento di questo sito
+      funziona con gli script bloccati, e funziona con la rete staccata del
+      tutto.</strong> Qui non c'è niente trattenuto dietro un annuncio.
+    </p>
+  </section>
+
+  <section>
+    <h2>I tuoi diritti sui dati</h2>
+    <p>
+      Non abbiamo alcun dato personale su di te, quindi non c'è niente che
+      possiamo mostrarti, correggere, esportare o cancellare &mdash; una
+      richiesta a noi tornerebbe indietro vuota, sinceramente.
+    </p>
+    <p>
+      I dati descritti sopra sono in mano a Google, che ne è titolare per conto
+      proprio. Le richieste che li riguardano vanno fatte a loro, tramite
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">il tuo account Google</a>
+      o i loro contatti per la privacy.
+    </p>
+  </section>
+
+  <section>
+    <h2>Minori</h2>
+    <p>
+      Questo sito non si rivolge ai minori e non chiede a nessuno la propria
+      età, perché non chiede niente a nessuno. Non raccogliamo consapevolmente
+      alcun dato personale da chicchessia, di qualunque età.
+    </p>
+  </section>
+
+  <section>
+    <h2>Modifiche, e come raggiungerci</h2>
+    <p>
+      Se questa pagina cambia, la data in cima cambia con lei, e la modifica sta
+      nella cronologia pubblica dei commit insieme a tutto il resto.
+    </p>
+    <p>
+      Le domande su tutto questo possono andare a
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, oppure essere aperte come
+      issue sul <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">repository</a>,
+      dove la risposta è visibile a chiunque altro se lo stia chiedendo.
+    </p>
+  </section>

--- a/locales/it/pages/privacy.toml
+++ b/locales/it/pages/privacy.toml
@@ -1,0 +1,17 @@
+#
+# La pagina Privacy - Italian.
+#
+
+nav = "Privacy e cookie"
+title = "Privacy e cookie &mdash; abox.tools"
+description = "Cosa raccoglie e cosa non raccoglie abox.tools. I tuoi file non vengono mai caricati; la pubblicità, il contatore delle visite e il pulsante delle donazioni sono descritti per intero."
+heading = "Privacy e cookie"
+lede = """
+    La versione corta: i tuoi file non vengono mai caricati, perché non c'è
+    nessun posto dove caricarli. Tutto il resto di questa pagina riguarda la
+    pubblicità, il contatore delle visite e l'hosting &mdash; le parti che
+    coinvolgono davvero altre aziende."""
+updated = "19 agosto 2026"
+og_title = "Privacy e cookie &mdash; abox.tools"
+og_description = "I tuoi file non vengono mai caricati. Cosa viene raccolto, da chi, e come spegnerlo."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/terms.html
+++ b/locales/it/pages/terms.html
@@ -1,0 +1,157 @@
+  <section>
+    <h2>Cos'è questo sito</h2>
+    <p>
+      abox.tools è una raccolta di piccole utilità che girano dentro il tuo
+      browser. Si usano gratis, per qualunque cosa, lavoro commerciale compreso.
+      Non c'è niente da comprare, nessun account da creare, nessun limite d'uso,
+      e nessuna funzione trattenuta.
+    </p>
+    <p>
+      Usando il sito accetti i termini di questa pagina. Se non li accetti, il
+      rimedio è semplicemente chiudere la scheda &mdash; qui non è trattenuto
+      niente di tuo.
+    </p>
+  </section>
+
+  <section>
+    <h2>I tuoi file restano tuoi</h2>
+    <p>
+      Mantieni tutti i diritti che avevi già sui file che apri con questi
+      strumenti, e su qualunque cosa ci produci. Non rivendichiamo alcuna
+      licenza, alcuna proprietà e alcun interesse di alcun tipo né sugli uni né
+      sull'altra.
+    </p>
+    <p>
+      Non è generosità, è aritmetica: gli strumenti girano interamente nel tuo
+      browser e i tuoi file non ci vengono mai trasmessi, quindi non c'è niente
+      su cui potremmo avere diritti. La
+      <a href="../privacy/">pagina sulla privacy</a> spiega come funziona e come
+      verificarlo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Usare il sito con responsabilità</h2>
+    <p>
+      Sei responsabile dei file che elabori e di cosa fai dei risultati. In
+      particolare, non usare questi strumenti su materiale su cui non hai
+      diritti, né per produrre qualcosa di illecito.
+    </p>
+    <p>
+      Non possiamo farlo rispettare e non facciamo finta del contrario. Non
+      vediamo mai i tuoi file, quindi qui non c'è moderazione, non c'è
+      scansione, e non c'è modo per noi di sapere cosa stia facendo chiunque.
+      L'obbligo è davvero tuo.
+    </p>
+    <p>
+      Ti chiediamo inoltre di non interferire con il sito in sé &mdash;
+      attaccare l'hosting, o ridistribuire copie modificate in modo da farle
+      passare per l'originale.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nessuna garanzia</h2>
+    <p>
+      Il sito e i suoi strumenti sono forniti <strong>così come sono</strong>,
+      senza garanzia di alcun tipo, esplicita o implicita, compresa qualunque
+      garanzia implicita di commerciabilità, di idoneità a uno scopo particolare
+      o di non violazione di diritti altrui.
+    </p>
+    <p>
+      In concreto: uno strumento può produrre un risultato che non volevi, può
+      fallire su un file che non capisce, può comportarsi in modo diverso da un
+      browser all'altro, e può far perdere il lavoro se la scheda viene chiusa a
+      metà operazione. Niente di quello che fai qui viene salvato da qualche
+      parte, quindi <strong>tieni i tuoi originali</strong>. Non usare questi
+      strumenti sull'unica copia di qualcosa a cui tieni.
+    </p>
+  </section>
+
+  <section>
+    <h2>Limitazione di responsabilità</h2>
+    <p>
+      Nella misura massima consentita dalla legge, non siamo responsabili di
+      alcuna perdita o danno derivante dal tuo uso di questo sito &mdash;
+      compresi file persi, corrotti o inutilizzabili, tempo perso, mancati
+      guadagni, o qualunque perdita indiretta o consequenziale.
+    </p>
+    <p>
+      Niente di quanto qui scritto limita una responsabilità che per legge non
+      può essere limitata.
+    </p>
+  </section>
+
+  <section>
+    <h2>Disponibilità</h2>
+    <p>
+      Il sito è offerto senza alcuna promessa che resterà in piedi, che resterà
+      gratuito, che terrà un determinato strumento, o che continuerà a esistere.
+      Gli strumenti possono cambiare o essere rimossi senza preavviso.
+    </p>
+    <p>
+      Vale la pena conoscere una conseguenza pratica di come sono costruiti
+      questi strumenti: una volta che la pagina di uno strumento si è caricata,
+      continua a funzionare offline, e non smette di funzionare perché il sito è
+      caduto. Il codice è anche pubblico, quindi uno strumento da cui dipendi lo
+      puoi tenere in funzione tu, a prescindere da cosa succede qui.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pubblicità e altre aziende</h2>
+    <p>
+      Il sito ospita pubblicità di Google, conta le visite con Google Analytics,
+      e mostra un pulsante per le donazioni su quasi tutte le pagine. Cosa
+      comporta ciascuna di queste cose è descritto per intero nella
+      <a href="../privacy/">pagina sulla privacy</a>.
+    </p>
+    <p>
+      Gli annunci, e qualunque sito raggiungi cliccandone uno, non sono nostri.
+      Non scegliamo i singoli annunci, non approviamo quello che dicono, e non
+      siamo responsabili dei siti a cui portano né di eventuali rapporti che ci
+      intrattieni. Lo stesso vale per ogni altro link esterno di questo sito.
+    </p>
+  </section>
+
+  <section>
+    <h2>Il codice sorgente</h2>
+    <p>
+      Il codice di questo sito è pubblicato apertamente su
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>,
+      perché «leggilo e controlla tu» è l'unica risposta vera a «perché dovrei
+      fidarmi». Il riutilizzo di quel codice è regolato dai termini di licenza
+      indicati nel repository, non da questa pagina. Questi termini riguardano
+      il tuo uso del sito.
+    </p>
+  </section>
+
+  <section>
+    <h2>Legge applicabile</h2>
+    <p>
+      Questo sito è gestito dal Canada. Questi termini, e qualunque controversia
+      che ne derivi o che derivi dal tuo uso del sito, sono regolati dalle leggi
+      del Canada e della provincia in cui il sito è gestito, senza riguardo alle
+      norme sui conflitti di legge.
+    </p>
+    <p>
+      Se il diritto dei consumatori del posto in cui vivi ti dà diritti che
+      questi termini altrimenti limiterebbero, quei diritti restano.
+    </p>
+  </section>
+
+  <section>
+    <h2>Modifiche a questi termini</h2>
+    <p>
+      Questi termini possono essere aggiornati. Quando succede, la data in cima
+      cambia, e la modifica compare nella cronologia pubblica dei commit come
+      ogni altro cambiamento. Continuare a usare il sito dopo una modifica vuol
+      dire accettare la versione aggiornata.
+    </p>
+    <p>
+      Le domande possono andare a
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, oppure essere aperte come
+      issue sul
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">repository</a>.
+    </p>
+  </section>

--- a/locales/it/pages/terms.toml
+++ b/locales/it/pages/terms.toml
@@ -1,0 +1,16 @@
+#
+# La pagina dei Termini - Italian.
+#
+
+nav = "Termini d'uso"
+title = "Termini d'uso &mdash; abox.tools"
+description = "I termini a cui questo sito viene offerto: gratuito, così com'è, senza account, senza garanzia, e i tuoi file restano interamente tuoi perché non ci vengono mai mandati."
+heading = "Termini d'uso"
+lede = """
+    Non c'è un account da aprire e non c'è un accordo da firmare, quindi sono
+    corti. Descrivono cosa ti puoi aspettare da questo sito, e cosa questo sito
+    non promette."""
+updated = "19 agosto 2026"
+og_title = "Termini d'uso &mdash; abox.tools"
+og_description = "Gratuito, così com'è, senza account, senza garanzia. I tuoi file restano interamente tuoi."
+og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/planned.toml
+++ b/locales/it/planned.toml
@@ -1,0 +1,76 @@
+#
+# La lista dei previsti sulla roadmap - Italian.
+#
+# Overrides for config/planned.toml. Only words: the group `id` stays as it is,
+# because that is what a tool's roadmap_group matches on, and the order of the
+# groups and of the items inside them is decided once, in English.
+#
+# Every group and every item has to be here. They are merged in order, so a
+# missing entry would render in English in the middle of an Italian list with
+# nothing on the page to say which one it was - the build refuses a list whose
+# length has changed for exactly that reason.
+#
+
+note = "Non ancora costruiti. Sono elencati perché si veda dove sta andando tutto questo."
+
+[[group]]
+id = "images"
+name = "Immagini"
+items = [
+  ["Ruotare e specchiare", "di un quarto di giro, o raddrizzando di qualche grado"],
+  ["Aggiungere testo", "sopra la foto, o in una fascia sopra di essa"],
+  ["Filtri", "luminosità, contrasto, saturazione, sfocatura, scala di grigi"],
+  ["Immagine come data URI", "il risultato si incolla direttamente nel CSS o nell'HTML"],
+  ["Da HEIC a JPG", "le foto che fa un iPhone, in un formato che apre chiunque"],
+  ["AVIF e JPEG XL", "conversione in entrambi i sensi, con qualunque browser tu ti trovi"],
+]
+
+[[group]]
+id = "gif"
+name = "GIF e animazione"
+items = [
+  ["Da GIF a MP4 o WebM", "la stessa animazione, di solito un decimo del peso"],
+  ["Ridimensionare, ritagliare e ruotare le GIF", "fotogramma per fotogramma, con i tempi intatti"],
+  ["GIF al contrario", "l'ultimo fotogramma per primo"],
+  ["Cambiare la velocità di una GIF", "ritempificarla senza ridisegnare i fotogrammi"],
+  ["Analizzare una GIF", "fotogrammi, ritardi, tavolozza, e dove sono finiti i byte"],
+  ["Creare un APNG", "animazione con trasparenza vera e colore pieno"],
+  ["WebP animata", "ancora la stessa animazione, a una frazione del peso"],
+]
+
+[[group]]
+id = "video"
+name = "Video"
+items = [
+  ["Ridimensionare", "fino a una dimensione che si riesce davvero a mandare"],
+  ["Ruotare", "per la clip girata di traverso"],
+  ["Togliere l'audio, o salvarlo", "eliminare il suono, o tenerlo per conto suo"],
+  ["Convertire in MP4 o WebM", "quello dei due su cui insiste il sito dove stai pubblicando"],
+  ["Filtri", "luminosità, contrasto, saturazione, sfocatura"],
+  ["Incidere i sottotitoli", "un file SRT disegnato dentro l'immagine"],
+]
+
+[[group]]
+id = "audio"
+name = "Audio"
+items = [
+  ["Dissolvenza in apertura e in chiusura", "così non comincia e non finisce di netto"],
+  ["Forma d'onda come immagine", "disegnare una traccia come figura"],
+  ["Convertire formato", "MP3, WAV e Opus, in qualunque direzione"],
+]
+
+[[group]]
+id = "documents"
+name = "Documenti e PDF"
+items = [
+  ["Ruotare e ritagliare le pagine", "raddrizzare una scansione storta, o tagliarne i margini"],
+  ["Estrarre le immagini", "tirare fuori le figure da un documento"],
+]
+
+[[group]]
+id = "beyond"
+name = "Oltre i media"
+items = [
+  ["Dati", "conversione, pulizia e ispezione di CSV e JSON"],
+  ["Privacy e sicurezza", "hash, checksum, rimozione dei metadati"],
+]

--- a/locales/it/tools/compress-image.html
+++ b/locales/it/tools/compress-image.html
@@ -1,0 +1,121 @@
+<main>
+  <!-- Passo 1 &mdash; i file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli le immagini</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto dalla lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; il numero che conta -->
+  <section class="card" id="target-card">
+    <h2><span class="step">2</span> Di' quanto può pesare</h2>
+
+    <p class="card-lede">
+      È la parte che gli altri compressori fanno al contrario. Ti danno un
+      cursore della qualità e ti lasciano indovinare quale impostazione finisce
+      sotto il limite che ti hanno dato. Di' invece il limite, e lo strumento
+      cerca la qualità più alta che ci sta dentro &mdash; poi spende quello che
+      resta del budget, invece di restituirti un file grande la metà di quanto
+      avevi chiesto.
+    </p>
+
+    <div class="target-row">
+      <div class="target-field">
+        <label for="target-value">Dimensione obiettivo, per immagine</label>
+        <div class="inline-pair">
+          <input type="number" id="target-value" value="500" min="1" step="1" inputmode="decimal">
+          <label for="target-unit" class="visually-hidden">Unità</label>
+          <select id="target-unit">
+            <option value="KB" selected>KB</option>
+            <option value="MB">MB</option>
+          </select>
+        </div>
+      </div>
+
+      <!--
+        The four numbers people are actually given: an upload form that says
+        100 KB, a forum avatar or a job application at 500 KB, an email
+        attachment at 1 MB, and a web page hero at 2 MB.
+      -->
+      <div class="presets" id="presets" role="group" aria-label="Obiettivi più comuni">
+        <button type="button" class="ghost" data-bytes="102400">100 KB</button>
+        <button type="button" class="ghost" data-bytes="512000">500 KB</button>
+        <button type="button" class="ghost" data-bytes="1048576">1 MB</button>
+        <button type="button" class="ghost" data-bytes="2097152">2 MB</button>
+      </div>
+    </div>
+
+    <p id="target-summary" class="field-summary"></p>
+
+    <fieldset class="options">
+      <legend>Come gli è concesso arrivarci</legend>
+
+      <div class="option-row">
+        <label for="format-select">Formato in uscita</label>
+        <select id="format-select">
+          <option value="auto" selected>Automatico &mdash; tieni il formato, a meno che un altro non renda meglio</option>
+          <option value="keep">Tieni sempre il formato originale</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/webp">WebP</option>
+          <option value="image/png">PNG (senza perdita, quindi il peso si toglie dalle dimensioni)</option>
+        </select>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="allow-resize" checked>
+        <span>
+          <strong>Può rimpicciolire l'immagine se è costretto</strong>
+          <span class="check-note">
+            Serve solo quando la qualità da sola dovrebbe scendere oltre il punto
+            in cui la compressione comincia a vedersi. Sotto quel punto, meno
+            pixel buoni si vedono meglio di più pixel rovinati. Togli la spunta
+            per tenere le dimensioni esatte e pagare un obiettivo stretto con la
+            qualità.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Passo 3 &mdash; il clic unico -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Comprimi</h2>
+
+    <div class="run-row">
+      <button type="button" id="compress-all" class="primary big" disabled>Comprimi alla dimensione obiettivo</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Compresse</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Scarica tutto in uno zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/compress-image.toml
+++ b/locales/it/tools/compress-image.toml
@@ -1,0 +1,252 @@
+#
+# Compressore di immagini - Italian.
+#
+# Overrides for tools/compress-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Compressore di immagini"
+# La coda è l'espressione che si cerca. Come in inglese, il nome del prodotto
+# resta la metà che grida.
+heading = "Comprimere&nbsp;un'immagine <span class=\"h1-kw\">&mdash; a una dimensione esatta</span>"
+tagline = "Dici tu la dimensione. Il resto lo calcola lui."
+
+title = "Comprimere un'immagine a una dimensione esatta &mdash; gratis, senza caricare nulla"
+description = "Comprimi un JPEG, un PNG o un WebP a una dimensione esatta: 100 KB, 2 MB, quello che serve. Gira tutto nel browser: niente da caricare, nessun account, anche offline."
+og_title = "Comprimere un'immagine alla dimensione che scegli tu"
+og_description = "Dici una dimensione e lui trova la compressione minima che ci arriva, poi misura quanto è costata. Gira sul tuo dispositivo; non viene caricato nulla."
+og_image_alt = "Compressore di immagini - dici la dimensione, la qualità resta"
+
+pledge = """
+    La compressione avviene nel tuo browser, sul tuo hardware, con gli encoder
+    che si porta già dietro. Questo strumento non ha alcuna funzione di rete
+    &mdash; niente da recuperare, niente da spedire &mdash; e dall'altra parte
+    di questa pagina non c'è alcun server a cui mandare una foto, anche se ci
+    fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e comprimi una foto. Non una sola richiesta porta con sé
+      un'immagine, una miniatura, un nome di file o un byte di quello che hai
+      scelto. Oppure stacca la connessione e comprimine una lo stesso."""
+
+read_first = """
+, <code>src/compress.js</code> per la ricerca che
+      decide quanta qualità spendere, e <code>src/measure.js</code> per il
+      confronto dietro il valore di «corrispondenza visiva»."""
+
+howto_heading = "Come comprimere un'immagine a una dimensione precisa"
+
+card = """
+            Di' la dimensione che ti serve &mdash; 100 KB, 2 MB, qualunque
+            &mdash; e trova la compressione minima che ci arriva."""
+
+[words]
+plural = "immagini"
+choose = "un'immagine"
+analytics_extra = """, e nemmeno una delle
+  dimensioni o dei valori di qualità che questo strumento calcola"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessun limite di dimensione"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Le tue immagini non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove i tuoi file potrebbero finire, e nel codice non
+      c'è nulla che ce li manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Non c'è né un
+      <code>fetch</code>, né un <code>XMLHttpRequest</code>, né un
+      <code>sendBeacon</code> da nessuna parte in <code>src/</code>. La
+      compressione è <code>canvas.toBlob</code> &mdash; l'encoder che è già
+      installato nel tuo browser."""
+
+[[privacy]]
+title = "I numeri sono misurati, non riferiti."
+body = """
+ Le dimensioni, il
+      valore di qualità e il confronto SSIM vengono calcolati tutti su questa
+      pagina e mostrati a te. In questo repository non esiste alcun evento di
+      analytics che porti con sé un nome di file, una dimensione, un conteggio
+      o un risultato."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google, e il pulsante delle
+      donazioni da Buy Me a Coffee. A nessuno di loro viene passato niente
+      sulle tue immagini. Ogni riga che legge, comprime o misura un file è
+      servita da questa origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento resta
+      identico, perché al suo interno non c'è mai stato un passaggio di rete.
+      È la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli le tue immagini."
+body = """
+ Trascinale sul riquadro o
+      selezionale a mano. Il browser le legge direttamente dal tuo disco;
+      mentre lo fai non viene mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Scrivi la dimensione che ti hanno imposto."
+body = """
+ 100 KB per il modulo
+      di caricamento che continua a rifiutare la tua foto, 500 KB per il
+      portale delle domande, 2 MB per una pagina che deve caricarsi in fretta.
+      Le quattro più comuni sono pulsanti."""
+
+[[howto]]
+title = "Premi «Comprimi alla dimensione obiettivo»."
+body = """
+ Ogni immagine viene
+      codificata più volte mentre lo strumento si avvicina alla qualità più
+      alta che ci sta dentro. Quello che è già sotto l'obiettivo resta
+      esattamente com'è."""
+
+[[howto]]
+title = "Guarda quanto è costato, poi scarica."
+body = """
+ Ogni risultato dice in
+      che formato è stato scritto, a che qualità, se le dimensioni in pixel
+      sono cambiate e quanto somiglia all'originale una volta misurato.
+      «Confronta» mette le due immagini una accanto all'altra."""
+
+[[faq]]
+q = "La mia immagine viene caricata da qualche parte?"
+a = """
+        No. Il file viene decodificato, compresso e misurato dal tuo browser sul
+        tuo hardware, con gli encoder JPEG, PNG e WebP che il browser si porta
+        già dietro. Questo strumento non ha alcuna funzione di rete &mdash; non
+        recupera mai niente e non spedisce mai niente &mdash; e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare, nessuno dei quali appartiene a questo
+        sito."""
+
+[[faq]]
+q = "Come fa a centrare una dimensione esatta?"
+a = """
+        Provando. Non esiste una formula che trasformi un'impostazione di qualità
+        in un numero di byte &mdash; dipende interamente dall'immagine &mdash;
+        quindi lo strumento la codifica più volte e cerca la risposta. Parte
+        dall'estremo alto della scala di qualità e si avvicina dimezzando, il che
+        trova la qualità più alta che ci sta in una decina di codifiche. Ogni
+        dimensione che vedi sulla pagina è un file davvero codificato, non una
+        stima."""
+
+[[faq]]
+q = "Cosa vuol dire qui «perdita minima»?"
+a = """
+        Tre cose precise. Primo: un'immagine già sotto il tuo obiettivo viene
+        passata byte per byte invece di essere ricodificata. Secondo: si spende
+        prima la qualità e poi la risoluzione, e solo fino a una soglia sotto la
+        quale gli artefatti di compressione cominciano a vedersi &mdash; oltre
+        quel punto lo strumento rimpicciolisce l'immagine e rialza la qualità,
+        perché meno pixel buoni si vedono meglio di più pixel rovinati. Terzo:
+        una volta trovato un risultato che ci sta, la ricerca risale finché il
+        budget non è speso, così non ti ritrovi con un file da 300 KB quando ne
+        avevi chiesti 500."""
+
+[[faq]]
+q = "Cosa sono i valori SSIM e PSNR su ogni risultato?"
+a = """
+        Sono la misura di quanto è costata la compressione, presa decodificando
+        il risultato e confrontandolo con l'immagine originale. SSIM confronta
+        luminosità, contrasto e struttura locali, il che è molto più vicino a
+        quello che dà fastidio a un occhio che non contare i pixel cambiati;
+        sopra lo 0,98 circa le due immagini sono difficili da distinguere una
+        accanto all'altra. PSNR è il classico valore in decibel. Entrambi sono
+        calcolati sul tuo dispositivo, ed entrambi sono mostrati perché
+        l'affermazione di perdita minima sia verificabile invece che solo
+        dichiarata."""
+
+[[faq]]
+q = "Quali formati sa leggere e scrivere?"
+a = """
+        Legge tutto quello che il tuo browser sa decodificare, che in pratica
+        vuol dire JPEG, PNG, WebP, GIF, BMP e &mdash; sulla maggior parte dei
+        browser attuali &mdash; AVIF. Scrive JPEG, PNG e WebP, perché quelli
+        sono gli encoder che i browser si portano dietro. Su «automatico»
+        mantiene il formato con cui è arrivato il tuo file, e passa a WebP solo
+        quando mantenerlo avrebbe voluto dire ridimensionare o perdere qualità
+        in modo visibile."""
+
+[[faq]]
+q = "Perché un PNG non si riesce a comprimere granché?"
+a = """
+        Perché il PNG è senza perdita: non ha una manopola della qualità da
+        girare. L'unico modo di rimpicciolire un PNG è dargli meno pixel o meno
+        colori, quindi con il PNG selezionato lo strumento raggiunge l'obiettivo
+        solo ridimensionando. Se l'immagine è una fotografia, JPEG o WebP ci
+        arrivano molto più vicino a una qualità che si vede bene &mdash; e se è
+        un logo o uno screenshot con trasparenza, WebP conserva la trasparenza
+        che il JPEG riempirebbe di bianco."""
+
+[[faq]]
+q = "Comprimere un'immagine ne rimuove i dati EXIF e GPS?"
+a = """
+        Sì, come effetto collaterale. Comprimere vuol dire decodificare
+        l'immagine in pixel e ricodificare quei pixel, e una tela piena di pixel
+        non porta con sé alcun tag: posizione, modello della fotocamera, orari e
+        tutto il resto semplicemente non vengono scritti nel file nuovo. Se
+        vuoi via i metadati ma l'immagine intatta, usa invece il
+        <a href="../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>
+        &mdash; riscrive il contenitore senza ricomprimere niente."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Non c'è nemmeno un limite al numero o alla dimensione
+        dei file, perché non c'è un server che li paga &mdash; il lavoro avviene
+        sul tuo dispositivo. Il sito ha della pubblicità, ed è quella che lo
+        paga; agli annunci non viene dato niente sulle tue immagini."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via le tue immagini per
+        comprimerle si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Comprimi immagini JPEG, PNG e WebP a una dimensione che scegli tu. Lo strumento cerca la qualità più alta che sta nell'obiettivo, ridimensiona solo quando la qualità da sola non basta, e misura il risultato contro l'originale. Gira interamente nel browser, senza caricare nulla."
+features = [
+  "Comprime a una dimensione di file scelta da te, non a un numero di qualità da indovinare",
+  "Mantiene la piena risoluzione dove può, e ridimensiona solo quando la qualità da sola non raggiunge l'obiettivo",
+  "Spende tutto il budget: il risultato finisce appena sotto l'obiettivo invece che molto più in basso",
+  "Misura il risultato contro l'originale con SSIM e PSNR",
+  "Lascia del tutto intatti i file già sotto l'obiettivo",
+  "JPEG, PNG e WebP, con scelta automatica del formato",
+  "Lavora a lotti, con tutti i risultati in un unico zip",
+  "Funziona offline; niente caricamenti, nessun account",
+]
+
+[picker]
+title = "Trascina qui le immagini"
+hint = "oppure clicca per scegliere &mdash; JPEG, PNG, WebP e qualunque altra cosa il tuo browser sappia aprire"

--- a/locales/it/tools/compress-pdf.html
+++ b/locales/it/tools/compress-pdf.html
@@ -1,0 +1,161 @@
+<main>
+  <!-- Passo 1 &mdash; il file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli un PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="file-row" class="file-row" hidden>
+      <div class="file-facts">
+        <strong id="file-name" class="file-name"></strong>
+        <span id="file-facts" class="file-sub"></span>
+      </div>
+      <button type="button" id="clear-file" class="ghost danger">Scegline un altro</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; la schermata che questo strumento terrebbe se potesse tenerne una sola -->
+  <section class="card" id="inventory-card" hidden>
+    <h2><span class="step">2</span> Guarda dove sta il peso</h2>
+
+    <p class="card-lede">
+      «Comprimere un PDF» sono due lavori diversi che condividono un nome. Una
+      scansione è una pila di fotografie, e ricodificarle vale quasi tutto il
+      file. Un contratto è testo e caratteri, che qualunque cosa l'abbia fatto
+      aveva già compresso &mdash; là dentro non si nasconde alcun ottanta per
+      cento, e nessuno strumento può trovarlo. Quale dei due hai in mano non è
+      questione di opinioni, quindi eccolo prima che venga toccato qualsiasi
+      cosa.
+    </p>
+
+    <p id="verdict" class="verdict"></p>
+
+    <div class="breakdown">
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <ul id="breakdown-list" class="breakdown-list"></ul>
+    </div>
+
+    <p id="inventory-notes" class="field-summary"></p>
+  </section>
+
+  <!-- Passo 3 &mdash; quanto spendere -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">3</span> Di' quanto stringere</h2>
+
+    <p class="card-lede">
+      Un PDF registra quanto grande viene disegnata ogni figura, quindi questo
+      strumento può misurare cosa la pagina usa davvero invece di indovinarlo.
+      Una scansione da 4000 pixel stesa su venti centimetri di carta porta 500
+      pixel per pollice; a 150 stampa uguale e si vede uguale sullo schermo. I
+      pixel che nessuno può vedere sono i primi a essere spesi, perché non
+      costano niente.
+    </p>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Quanta qualità è concesso spendere</legend>
+      <div class="presets" id="presets" role="radiogroup" aria-label="Quanta qualità è concesso spendere">
+        <label class="preset">
+          <input type="radio" name="preset" value="smallest">
+          <span class="preset-body">
+            <strong>Il più leggero</strong>
+            <span class="preset-note">96 DPI. Per qualcosa che deve solo essere letto su uno schermo.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="screen" checked>
+          <span class="preset-body">
+            <strong>Buono a schermo</strong>
+            <span class="preset-note">130 DPI. La risposta abituale per un file da mandare via mail.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="print">
+          <span class="preset-body">
+            <strong>Ancora buono su carta</strong>
+            <span class="preset-note">220 DPI. Più leggero, e si stampa ancora come si deve.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="gentle">
+          <span class="preset-body">
+            <strong>Tocca appena le figure</strong>
+            <span class="preset-note">Nessun ridimensionamento. Quasi tutto il risparmio viene dal riimpacchettare il file.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <details class="advanced">
+      <summary>Imposta tu i due numeri</summary>
+      <div class="option-row">
+        <label for="dpi-value">Pixel massimi per pollice di spazio disegnato</label>
+        <div class="inline-pair">
+          <input type="number" id="dpi-value" min="0" max="1200" step="10" value="130" inputmode="numeric">
+          <span class="unit">DPI &mdash; con 0 ogni figura resta a piena dimensione</span>
+        </div>
+      </div>
+      <div class="option-row">
+        <label for="quality-value">Qualità JPEG</label>
+        <div class="inline-pair">
+          <input type="range" id="quality-value" min="30" max="95" step="1" value="68">
+          <output id="quality-out" for="quality-value">68</output>
+        </div>
+      </div>
+    </details>
+
+    <label class="check">
+      <input type="checkbox" id="strip-meta" checked>
+      <span>
+        <strong>Togli quello che il file ricorda di dove è nato</strong>
+        <span class="check-note">
+          Il nome e la versione del programma che l'ha fatto, quando è stato
+          fatto e modificato l'ultima volta, il pacchetto XMP e il blocco privato
+          che un programma di impaginazione si lascia dietro per poter
+          reimportare il proprio lavoro &mdash; che ogni tanto pesa megabyte.
+          Niente di tutto questo serve a mostrare il documento.
+        </span>
+      </span>
+    </label>
+
+    <p id="settings-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Passo 4 &mdash; il clic unico -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Comprimi</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Comprimi questo PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Scarica</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <details id="per-image" class="advanced" hidden>
+        <summary>Cosa è successo a ogni figura</summary>
+        <ul id="image-list" class="image-list"></ul>
+      </details>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/compress-pdf.toml
+++ b/locales/it/tools/compress-pdf.toml
@@ -1,0 +1,272 @@
+#
+# Compressore di PDF - Italian.
+#
+# Overrides for tools/compress-pdf/tool.toml. Only words: the slug, the
+# category, the icon and the list of shared parts stay where they are.
+#
+
+name = "Compressore di PDF"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Comprimere&nbsp;un&nbsp;PDF <span class=\"h1-kw\">&mdash; ridurre il peso di un documento</span>"
+tagline = "Rimpicciolisci un documento senza spedirlo da nessuna parte."
+
+title = "Comprimere un PDF &mdash; gratis, nel browser, senza caricare nulla"
+description = "Riduci il peso di un PDF senza caricarlo. Il file viene letto, ricompresso e riscritto dal tuo browser, e lo strumento ti mostra dove sta davvero il peso prima di toccare qualunque cosa."
+og_title = "Comprimere un PDF &mdash; gratis, e non viene caricato nulla"
+og_description = "Rimpicciolisci un PDF sul tuo dispositivo. Misura quanto grande viene disegnata ogni figura sulla pagina, così butta via solo i pixel che nessuno poteva vedere."
+og_image_alt = "Comprimere un PDF - alleggerire un documento senza caricarlo"
+
+pledge = """
+    Il documento viene aperto, smontato e riscritto in memoria su questo
+    dispositivo, da codice servito da questo indirizzo. Qui dentro non c'è
+    niente in grado di fare un caricamento, e dall'altra parte di questa pagina
+    non c'è alcun server che potrebbe riceverlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e comprimi un file. Non una sola richiesta porta con sé una
+      pagina, una figura o un nome di file. Oppure stacca la connessione e
+      comprimine uno lo stesso."""
+
+read_first = """
+, e <code>src/reader.js</code> e <code>src/writer.js</code>
+      per tutta la lettura e la riscrittura, nessuna delle due in grado di
+      raggiungere la rete."""
+
+howto_heading = "Come ridurre il peso di un PDF"
+
+card = """
+            Alleggerisci un documento ricomprimendo le figure che ha dentro.
+            Prima ti mostra dove sta davvero il peso, e dice chiaramente
+            quando non c'è niente da guadagnare."""
+
+[words]
+plural = "documenti"
+choose = "un PDF"
+analytics_extra = """"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "I file restano sul tuo dispositivo"
+
+[[privacy]]
+title = "Il tuo documento non ha dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Questo strumento
+      non aggiunge niente a quella lista: non ha una funzione di rete propria,
+      nemmeno facoltativa. Qui non esiste un punto di raccolta dove il tuo file
+      potrebbe finire, e nel codice non c'è nulla che ce lo manderebbe se
+      esistesse."""
+
+[[privacy]]
+title = "Il formato sta tutto in questo repository."
+body = """
+ Un PDF è un elenco di
+      oggetti e una tabella che dice dove comincia ciascuno.
+      <code>src/objects.js</code> legge quella sintassi,
+      <code>src/reader.js</code> segue la tabella, <code>src/writer.js</code> ne
+      scrive una nuova, e nessuno dei tre importa qualcosa in grado di fare una
+      richiesta. Non viene scaricata alcuna libreria e non viene disegnato
+      niente su un server."""
+
+[[privacy]]
+title = "I file cifrati vengono respinti invece che aperti."
+body = """
+
+      Un PDF con una password sopra viene rifiutato, compreso quello che gli
+      scanner producono con la password vuota e che tecnicamente si aprirebbe.
+      Togliere la protezione a un documento è un lavoro diverso dal
+      rimpicciolirlo, e farlo in silenzio sarebbe una cosa sorprendente da parte
+      di uno strumento che agisce per conto tuo."""
+
+[[privacy]]
+title = "Toglie roba, non ne mette."
+body = """
+ Il file finito non porta con sé
+      data di creazione, né riga del produttore, né il nome dello strumento che
+      l'ha fatto. Con la casella spuntata perde anche il pacchetto XMP e i
+      blocchi privati che i programmi di impaginazione si lasciano dietro
+      &mdash; lo stesso ragionamento dello strumento EXIF, applicato a un
+      contenitore diverso."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google. A nessuno dei due viene
+      passato niente sul tuo documento: né un file, né una pagina, né un nome,
+      una dimensione o un numero di pagine. Ogni riga che legge, decodifica o
+      scrive un PDF è servita da questa origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Cosa carica il pulsante delle donazioni, e cosa non gli viene dato."
+body = """
+
+      Il pulsante «Buy me a coffee» in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non riferisce alcuna visita, e non gli viene passato niente
+      su di te o sul tuo documento. Non succede nulla finché non ci clicchi, e
+      quello a cui arriveresti è il sito di qualcun altro."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e tutto quello che sta su
+      questa pagina continua a funzionare. È la prova più semplice di tutte:
+      uno strumento che spedisse via il tuo documento per comprimerlo si
+      fermerebbe."""
+
+[[howto]]
+title = "Scegli un PDF."
+body = """
+ Trascinalo sul riquadro o
+      selezionalo a mano. Il browser lo legge direttamente dal tuo disco; mentre
+      lo fai non viene mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Guarda dove sta il peso."
+body = """
+ La ripartizione è il senso
+      del secondo passo. Se la barra è quasi tutta immagini, questo strumento ha
+      qualcosa su cui lavorare. Se è quasi tutta caratteri e contenuto delle
+      pagine, te lo dirà, e il risparmio onesto è di qualche punto percentuale
+      &mdash; meglio saperlo prima di perderci un minuto."""
+
+[[howto]]
+title = "Di' quanto stringere."
+body = """
+ Le impostazioni con un nome sono
+      risoluzioni, non voti vaghi: 96 DPI per leggere su uno schermo, 130 per
+      mandarlo via mail, 220 per qualcosa che deve ancora andare in stampa.
+      Ognuna è misurata contro quanto grande la figura viene davvero disegnata
+      sulla pagina, così una foto messa lì come miniatura non viene trattata
+      come una scansione a pagina intera."""
+
+[[howto]]
+title = "Comprimi, e leggi la riga che dice che è stato verificato."
+body = """
+
+      Quando la riscrittura è finita, il file prodotto viene riaperto dallo
+      stesso lettore su questa pagina e le sue pagine vengono contate. Se il
+      conto non torna con l'originale, l'operazione viene dichiarata fallita e
+      non ti viene offerto alcun download."""
+
+[[faq]]
+q = "Il mio PDF viene caricato da qualche parte?"
+a = """
+        No. Il file viene letto, ricompresso e scritto dal tuo browser sul tuo
+        hardware. Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare &mdash; nessuno di questi appartiene a
+        questo sito. Non ha proprio alcuna funzione di rete facoltativa."""
+
+[[faq]]
+q = "Di quanto si rimpicciolirà il mio PDF?"
+a = """
+        Dipende interamente da cosa c'è dentro, ed è per questo che lo strumento
+        misura e ti mostra prima di comprimere qualunque cosa. Un documento
+        scansionato è quasi tutto fotografie e di solito esce dal 60 al 90% più
+        leggero. Un contratto o una tesi sono testo, disegno vettoriale e
+        caratteri incorporati, tutte cose che erano già compresse da ciò che le
+        ha prodotte; lì il risparmio è di solito di qualche punto percentuale,
+        e viene dal riimpacchettare il file e dal buttare quello che non è più
+        richiamato da nessuno. Qualunque strumento prometta una percentuale
+        fissa senza guardare il tuo file sta tirando a indovinare."""
+
+[[faq]]
+q = "Comprimere un PDF fa perdere qualità?"
+a = """
+        Le figure che ha dentro vengono ricodificate, quindi sì, per quelle. Il
+        resto non viene toccato: il testo resta testo, selezionabile e
+        ricercabile, i caratteri restano interi e il disegno vettoriale viene
+        copiato tale e quale. Lo strumento si rifiuta anche di peggiorare
+        un'immagine per niente &mdash; se una ricodifica non esce più leggera
+        dell'originale, i byte originali tornano nel documento intatti."""
+
+[[faq]]
+q = "Cosa sono qui i DPI, e perché me li chiede?"
+a = """
+        Un PDF registra quanto grande viene disegnata ogni figura sulla pagina,
+        quindi lo strumento può ricavarne la risoluzione effettiva: una
+        scansione da 4000 pixel stesa su venti centimetri di carta porta 500
+        pixel per pollice. Niente su uno schermo e ben poco sulla carta sa
+        farsene, quindi i pixel oltre l'impostazione che scegli sono i primi a
+        essere buttati &mdash; costano qualità che nessuno può vedere. È quella
+        misura a fare in modo che un logo messo piccolo non venga trattato come
+        una scansione a pagina intera."""
+
+[[faq]]
+q = "Può aprire un PDF protetto da password?"
+a = """
+        No, ed è voluto. Un documento cifrato viene rifiutato con un messaggio
+        che lo dice, anche quando la password è vuota &mdash; che è il modo in
+        cui salvano moltissimi scanner e fotocopiatrici. Togliere la protezione
+        a un file è un lavoro diverso dal comprimerlo, e uno strumento che lo
+        facesse in silenzio starebbe facendo qualcosa che non hai chiesto."""
+
+[[faq]]
+q = "Ci sono PDF che non riesce a comprimere?"
+a = """
+        Alcune immagini al loro interno, sì. Le immagini JPEG 2000, JBIG2 e in
+        codifica fax (CCITT) non hanno un decodificatore in nessun browser,
+        quindi passano intatte e vengono segnalate come tali &mdash; le ultime
+        due sono codec in bianco e nero e di solito sono già vicine al minimo.
+        Anche le immagini CMYK vengono lasciate stare, perché ricodificarle
+        rischia di spostare i colori che una stampante produrrebbe. Tutto
+        quello che lo strumento salta viene nominato nei risultati, con il
+        motivo."""
+
+[[faq]]
+q = "Il file compresso si aprirà ancora dappertutto?"
+a = """
+        Sì. L'uscita è scritta in PDF 1.5, che ogni lettore uscito dal 2003 in
+        poi capisce, e lo strumento lo dimostra sul tuo dispositivo: riapre il
+        file finito e ne conta le pagine prima di offrirtelo. Moduli, link,
+        segnalibri, la struttura di accessibilità e gli eventuali allegati
+        incorporati vengono portati dall'altra parte; quello che resta indietro
+        è il materiale a cui niente nel documento faceva più riferimento."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è limite di dimensione oltre a quello che consente la memoria del
+        tuo dispositivo. Il sito ha della pubblicità, ed è quella che lo paga;
+        agli annunci non viene dato niente sul tuo documento."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via il tuo documento per
+        comprimerlo si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Comprimi un PDF nel browser. Le immagini vengono ricompresse rispetto a quanto grandi sono davvero disegnate sulla pagina, e il documento viene riscritto in locale, quindi nessun file viene mai caricato."
+features = [
+  "Mostra dove sta davvero il peso di un documento prima di comprimere qualunque cosa",
+  "Ricomprime le immagini rispetto alla loro risoluzione misurata sulla pagina",
+  "Lascia stare un'immagine quando ricodificarla non la renderebbe più leggera",
+  "Butta gli oggetti che una modifica precedente si è lasciata dietro, e i metadati facoltativi",
+  "Riapre e verifica il file finito prima di offrirlo",
+  "Funziona offline; niente caricamenti, nessun account, nessun limite di dimensione",
+]
+
+[picker]
+title = "Trascina qui un PDF"
+hint = "oppure clicca per scegliere &mdash; un documento alla volta"

--- a/locales/it/tools/crop-video.html
+++ b/locales/it/tools/crop-video.html
@@ -1,0 +1,146 @@
+<main>
+  <!-- Passo 1 &mdash; il file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli un video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Dimensione</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Fotogramma</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durata</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Audio</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; il ritaglio -->
+  <section class="card" id="crop-card" hidden>
+    <h2><span class="step">2</span> Imposta il ritaglio</h2>
+
+    <p class="stage-hint">
+      Trascina dentro il riquadro per spostarlo, o un angolo qualsiasi per
+      ridimensionarlo. Con il riquadro selezionato, le frecce lo spostano di un
+      pixel alla volta, <kbd>Alt</kbd>&nbsp;+&nbsp;frecce lo ridimensionano, e
+      tenendo premuto <kbd>Maiusc</kbd> ogni passo diventa di dieci.
+    </p>
+
+    <!-- The crop box itself is added here by src/cropper.js. The stage is given
+         the video's own shape, so the box can be positioned in percentages and
+         needs no recalculating when the window is resized. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <div class="crop-controls">
+      <div class="aspect-row" role="group" aria-label="Blocca il ritaglio su una forma">
+        <button type="button" data-aspect="free" class="active">Libero</button>
+        <button type="button" data-aspect="source">Originale</button>
+        <button type="button" data-aspect="1:1">1:1</button>
+        <button type="button" data-aspect="4:5">4:5</button>
+        <button type="button" data-aspect="9:16">9:16</button>
+        <button type="button" data-aspect="16:9">16:9</button>
+        <button type="button" data-aspect="4:3">4:3</button>
+        <button type="button" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="ghost" title="Metti di lato la forma bloccata">
+          Ruota
+        </button>
+      </div>
+
+      <div class="numbers">
+        <label>Sinistra<input type="number" id="crop-x" min="0" step="1"></label>
+        <label>Alto<input type="number" id="crop-y" min="0" step="1"></label>
+        <label>Larghezza<input type="number" id="crop-w" min="16" step="2"></label>
+        <label>Altezza<input type="number" id="crop-h" min="16" step="2"></label>
+        <div class="number-actions">
+          <button type="button" id="crop-max" class="ghost">Il più grande</button>
+          <button type="button" id="crop-centre" class="ghost">Centra</button>
+          <button type="button" id="crop-reset" class="ghost">Tutto il fotogramma</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="even-note">
+      Larghezza e altezza si muovono di due in due, perché l'H.264 non ha modo
+      di conservare un fotogramma con un lato dispari.
+    </p>
+  </section>
+
+  <!-- Passo 3 &mdash; l'esportazione -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Ritaglialo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Uscita</label>
+        <select id="format">
+          <option value="mp4" selected>MP4 &mdash; ricodificato fotogramma per fotogramma</option>
+          <option value="webm">WebM &mdash; registrato mentre scorre</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Qualità</label>
+        <select id="quality">
+          <option value="low">File più leggero</option>
+          <option value="medium" selected>Equilibrato</option>
+          <option value="high">Massima qualità</option>
+        </select>
+        <p class="field-note">
+          Mai più di quanto spendesse l'originale sulla stessa zona &mdash;
+          ricodificare al di sopra rende il file solo più pesante.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Tieni l'audio
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Fotogramma in uscita</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Tenuto</dt><dd id="sum-kept">&mdash;</dd></div>
+      <div><dt>Durata</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Come</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Ritaglia il video</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Scarica il video</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/crop-video.toml
+++ b/locales/it/tools/crop-video.toml
@@ -1,0 +1,249 @@
+#
+# Ritagliatore di video - Italian.
+#
+# Overrides for tools/crop-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Ritagliatore di video"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Ritagliare&nbsp;un&nbsp;video <span class=\"h1-kw\">&mdash; cambiare l'inquadratura online</span>"
+tagline = "Riduci una clip alla parte che conta."
+
+title = "Ritagliare un video online &mdash; gratis, senza caricare nulla, anche offline"
+description = "Ritaglia un MP4, un MOV o un WebM in qualunque forma: quadrata, 9:16 o un riquadro di pixel esatto. Gira nel browser: niente caricamenti, l'audio resta, funziona offline."
+og_title = "Ritagliatore di video &mdash; cambia l'inquadratura di una clip senza caricarla"
+og_description = "Trascina un riquadro sulla tua clip e ritagliala in qualunque forma. I fotogrammi vengono decodificati e ricodificati sul tuo dispositivo, e l'audio originale passa dall'altra parte intatto."
+og_image_alt = "Ritagliatore di video - ritaglia una clip nel browser, senza caricare nulla"
+
+pledge = """
+    Ogni fotogramma viene decodificato, ritagliato e codificato dal tuo browser,
+    sul tuo hardware. Qui dentro non c'è niente che possa recuperare o spedire
+    qualcosa &mdash; questo strumento non ha proprio alcuna funzione di rete
+    &mdash; e dall'altra parte di questa pagina non c'è alcun server a cui
+    mandare un video, anche se ci fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e ritaglia una clip. Non una sola richiesta porta con sé un
+      fotogramma, un nome di file o un byte di quello che hai scelto. Oppure
+      stacca la connessione e ritagliane una lo stesso &mdash; uno strumento che
+      spedisse via il tuo video per elaborarlo si fermerebbe e basta."""
+
+read_first = """
+, <code>src/demux.js</code> per il lettore che trova
+      i fotogrammi dentro un MP4, e <code>src/transcode.js</code> per il ciclo
+      che li decodifica, li ritaglia e li codifica. Nessuno dei due importa
+      qualcosa in grado di fare una richiesta."""
+
+howto_heading = "Come ritagliare un video"
+
+card = """
+            Trascina un riquadro su una clip e riducila a quella forma &mdash;
+            quadrata per un feed, verticale per un telefono, o un riquadro di
+            pixel esatto."""
+
+[words]
+plural = "video"
+choose = "un video"
+analytics_extra = """, e nessun
+  fotogramma, durata o dimensione del ritaglio"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Tiene l'audio"
+
+[[facts]]
+text = "Funziona offline"
+
+[[privacy]]
+title = "I tuoi video non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove il tuo file potrebbe finire, e nel codice non
+      c'è nulla che ce lo manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Questo strumento non ha proprio
+      alcuna funzione di rete: nessun indirizzo da incollare, niente da
+      scaricare, nessun motore recuperato al primo utilizzo. Ogni byte che tocca
+      il tuo video è arrivato da questa origine quando la pagina si è
+      caricata."""
+
+[[privacy]]
+title = "La decodifica e la codifica sono locali."
+body = """
+ I fotogrammi passano per
+      WebCodecs dentro il tuo browser, oppure per lo stesso motore di
+      riproduzione che ti mostrerebbe la clip comunque. Il file finito viene
+      costruito in memoria su questo dispositivo e consegnato direttamente a un
+      download."""
+
+[[privacy]]
+title = "L'audio viene copiato, non ascoltato."
+body = """
+ Sulla via dell'MP4 i
+      campioni audio vengono spostati dall'altra parte senza essere decodificati
+      affatto &mdash; qui dentro non c'è niente che li ritrasformi in suono, e
+      niente che potrebbe passarli da qualche parte se lo facesse."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google. A nessuno dei due viene
+      passato niente sul tuo video: né un file, né un fotogramma, né un nome,
+      una dimensione, una durata o la forma in cui l'hai ritagliato. Ogni riga
+      che legge, decodifica, ritaglia o codifica è servita da questa origine ed
+      è elencata nel repository."""
+
+[[privacy]]
+title = "Cosa carica il pulsante delle donazioni, e cosa non gli viene dato."
+body = """
+
+      Il pulsante «Buy me a coffee» in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non riferisce alcuna visita, e non gli viene passato niente
+      su di te o sul tuo video."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e tutto quello che sta su
+      questa pagina continua a funzionare. È la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli un video."
+body = """
+ Trascina un MP4, un MOV, un M4V o un
+      WebM sul riquadro, oppure selezionane uno a mano. Il browser lo legge
+      direttamente dal tuo disco; mentre lo fai non viene mandato niente da
+      nessuna parte."""
+
+[[howto]]
+title = "Trascina il riquadro sulla parte che vuoi tenere."
+body = """
+ Trascina
+      al suo interno per spostarlo e un angolo qualsiasi per ridimensionarlo.
+      Prima bloccalo su una forma &mdash; 1:1 per un post quadrato, 9:16 per un
+      telefono, 16:9 per un'inquadratura larga &mdash; oppure scrivi un riquadro
+      di pixel esatto nei quattro campi qui sotto."""
+
+[[howto]]
+title = "Scegli quanta qualità spendere."
+body = """
+ L'immagine va codificata di
+      nuovo, perché un fotogramma ritagliato è un'immagine diversa.
+      «Equilibrato» la tiene vicina a quello che il file spendeva già su quella
+      zona; «Massima qualità» spende di più. L'audio resta, a meno che tu non lo
+      tolga."""
+
+[[howto]]
+title = "Ritaglia e scarica."
+body = """
+ Il lavoro avviene sul tuo hardware,
+      quindi quanto ci mette dipende dal tuo dispositivo e non da una coda. Il
+      video finito viene consegnato direttamente ai download del tuo browser."""
+
+[[faq]]
+q = "Il mio video viene caricato da qualche parte?"
+a = """
+        No. Viene letto, decodificato, ritagliato e codificato dal tuo browser
+        sul tuo hardware. Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare &mdash; nessuno di questi appartiene a
+        questo sito. Se preferisci verificare invece che crederci, stacca la
+        connessione e ritaglia una clip lo stesso."""
+
+[[faq]]
+q = "Quali formati video posso ritagliare?"
+a = """
+        MP4, M4V e MOV vengono letti direttamente, qualunque cosa ci sia dentro:
+        H.264, HEVC, AV1 o VP9, purché il tuo browser sappia decodificare quel
+        codec. Tutto il resto che il browser sa riprodurre &mdash; il WebM in
+        primis &mdash; viene invece ritagliato riproducendolo e registrando il
+        risultato, il che funziona ma richiede tanto tempo quanto è lunga la
+        clip. Un file che il browser non sa né leggere né riprodurre, il che in
+        pratica vuol dire AVI, WMV, FLV e quasi tutti gli MKV, viene rifiutato
+        con un messaggio che lo dice, invece di piantarsi a metà strada."""
+
+[[faq]]
+q = "C'è un limite alla dimensione o alla durata del video?"
+a = """
+        Nello strumento non c'è alcun limite, e il file non viene letto in
+        memoria tutto insieme &mdash; viene percorso qualche megabyte alla
+        volta. Il tetto pratico è il video finito, che viene assemblato in
+        memoria prima che tu lo scarichi, e il tempo che il tuo dispositivo
+        impiega a codificarlo."""
+
+[[faq]]
+q = "L'audio sopravvive?"
+a = """
+        Sulla via dell'MP4, esattamente: l'audio viene copiato campione per
+        campione senza essere mai decodificato, quindi è byte per byte quello
+        che c'era nel file. Sulla via della registrazione viene catturato dalla
+        riproduzione e ricodificato, il che costa un po' di qualità. In
+        entrambi i casi c'è una casella per lasciarlo fuori del tutto."""
+
+[[faq]]
+q = "Ritagliare fa perdere qualità?"
+a = """
+        L'immagine viene codificata di nuovo, perché un fotogramma ritagliato è
+        un'immagine diversa e non c'è modo di conservarla senza riscrivere i
+        pixel da capo. Quello che lo strumento non fa è spendere più di quanto
+        spendesse l'originale sulla stessa zona, visto che ricodificare al di
+        sopra rende il file solo più pesante senza renderlo più bello."""
+
+[[faq]]
+q = "Posso anche accorciarlo?"
+a = """
+        Non qui, ma qui accanto. Questo strumento cambia la forma dell'immagine
+        e nient'altro: la clip che esce è lunga esattamente come quella che è
+        entrata, con i suoi tempi e il suo audio intatti. Accorciare è un lavoro
+        a parte ed è uno strumento a parte &mdash; il
+        <a href="../tagliare-video/">tagliavideo</a> segna i pezzi di una clip
+        che vale la pena tenere e li salva come un file solo, senza ricodificare
+        un fotogramma."""
+
+[[faq]]
+q = "Perché larghezza e altezza si muovono di due in due?"
+a = """
+        L'H.264, il codec dentro un MP4, conserva l'immagine a blocchi e non ha
+        modo di descrivere un fotogramma con un numero dispari di pixel su un
+        lato. Invece di arrotondare in silenzio il tuo ritaglio dopo che l'hai
+        impostato, il riquadro propone fin dall'inizio solo numeri pari."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Il sito ha della pubblicità, ed è quella che lo paga;
+        agli annunci non viene dato niente sul tuo video."""
+
+[schema]
+browser_requirements = "Richiede JavaScript. L'uscita in MP4 ha bisogno di un browser con WebCodecs; gli altri ripiegano sulla registrazione in WebM."
+description = "Ritaglia un video in qualunque forma o riquadro di pixel esatto, nel browser. MP4, MOV e M4V vengono decodificati e ricodificati fotogramma per fotogramma, con l'audio originale portato dall'altra parte intatto; tutto il resto che il browser sa riprodurre viene ritagliato registrandolo. Non viene caricato nulla."
+features = [
+  "Ritaglia video MP4, MOV, M4V e WebM",
+  "Sorgenti H.264, HEVC, AV1 e VP9, decodificate con WebCodecs",
+  "Ritaglio libero, proporzioni bloccate (1:1, 4:5, 9:16, 16:9, 4:3, 3:2) o riquadro di pixel esatto",
+  "Tiene l'audio originale senza ricodificarlo",
+  "Funziona offline; niente caricamenti, nessun account, nessuna filigrana",
+]
+
+[picker]
+title = "Trascina qui un video"
+hint = "oppure clicca per scegliere &mdash; MP4, MOV, M4V, WebM e qualunque altra cosa questo browser riproduca"

--- a/locales/it/tools/edit-audio.html
+++ b/locales/it/tools/edit-audio.html
@@ -1,0 +1,170 @@
+<main>
+  <!-- Passo 1 &mdash; il file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli un file</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Dimensione</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Durata</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Suono</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>Momento più forte</dt><dd id="src-peak">&mdash;</dd></div>
+      <div><dt>Letto come</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <div class="wave-wrap" id="src-wave-wrap" hidden>
+      <canvas id="src-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="preview" controls preload="metadata"></audio>
+    </div>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; le modifiche -->
+  <section class="card" id="edit-card" hidden>
+    <h2><span class="step">2</span> Modificalo</h2>
+
+    <div class="edit-block">
+      <label class="check" for="reverse">
+        <input type="checkbox" id="reverse">
+        Riproducilo al contrario
+      </label>
+      <p class="field-note">
+        I campioni vengono scritti dall'ultimo al primo. Di loro non cambia
+        nient'altro, quindi invertire due volte restituisce esattamente il file
+        da cui sei partito.
+      </p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="speed">Velocità</label>
+        <input type="text" id="speed-value" class="value-box" inputmode="decimal"
+               spellcheck="false" autocomplete="off" aria-label="Velocità, come moltiplicatore">
+      </div>
+
+      <!-- The slider is in octaves, not multiples: half speed and double speed
+           are then the same distance either side of the middle, which is how
+           they sound. main.js does the conversion. -->
+      <input type="range" id="speed" min="-2" max="2" step="0.01" value="0"
+             aria-describedby="speed-note">
+
+      <div class="presets" role="group" aria-label="Velocità pronte">
+        <button type="button" class="ghost" data-speed="0.5">0,5&times;</button>
+        <button type="button" class="ghost" data-speed="0.75">0,75&times;</button>
+        <button type="button" class="ghost" data-speed="1">1&times;</button>
+        <button type="button" class="ghost" data-speed="1.25">1,25&times;</button>
+        <button type="button" class="ghost" data-speed="1.5">1,5&times;</button>
+        <button type="button" class="ghost" data-speed="2">2&times;</button>
+      </div>
+
+      <fieldset class="modes">
+        <legend>Cosa succede all'intonazione</legend>
+        <label class="mode">
+          <input type="radio" name="pitch" value="keep" checked>
+          <span>
+            <strong>Tieni l'intonazione</strong>
+            Una voce suona ancora come la stessa voce, solo più veloce o più lenta.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="pitch" value="move">
+          <span>
+            <strong>Lasciala muovere</strong>
+            Più veloce è più acuto e più lento è più grave, come fa un nastro.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="speed-note"></p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="volume">Volume</label>
+        <input type="text" id="volume-value" class="value-box" inputmode="decimal"
+               spellcheck="false" aria-label="Variazione di volume, in decibel">
+      </div>
+
+      <input type="range" id="volume" min="-24" max="24" step="0.5" value="0"
+             aria-describedby="volume-note">
+
+      <fieldset class="modes">
+        <legend>Quanto forte farlo</legend>
+        <label class="mode">
+          <input type="radio" name="level" value="gain" checked>
+          <span>
+            <strong>Di questo tanto</strong>
+            Ogni campione moltiplicato per lo stesso numero. Non cambia nient'altro.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="level" value="normalize">
+          <span>
+            <strong>Il più forte possibile</strong>
+            Alzato finché il momento più forte non sta appena sotto il tetto.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="volume-note"></p>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Durata</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Velocità</dt><dd id="sum-speed">&mdash;</dd></div>
+      <div><dt>Momento più forte</dt><dd id="sum-peak">&mdash;</dd></div>
+      <div><dt>All'incirca</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="clip-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 3 &mdash; il file che esce -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Salvalo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">Cosa scrivere</label>
+        <select id="depth">
+          <option value="16" selected>WAV a 16 bit &mdash; si riproduce dappertutto</option>
+          <option value="32">WAV in virgola mobile a 32 bit &mdash; niente viene schiacciato</option>
+        </select>
+        <p class="field-note" id="depth-note">
+          Un WAV contiene i campioni così come sono, quindi scriverne uno non può
+          costare qualità. Non è un file leggero: guarda la stima qui sopra.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary">Modifica l'audio</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Scarica l'audio</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/edit-audio.toml
+++ b/locales/it/tools/edit-audio.toml
@@ -1,0 +1,292 @@
+#
+# Editor audio - Italian.
+#
+# Overrides for tools/edit-audio/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Editor audio"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Modificare&nbsp;l'audio <span class=\"h1-kw\">&mdash; invertire, accelerare o alzare una traccia</span>"
+tagline = "Riproducila al contrario, cambiale velocità, tira su una registrazione bassa &mdash; tutto qui, sul tuo dispositivo."
+
+title = "Invertire l'audio, cambiare velocità e alzare il volume &mdash; gratis, senza caricare nulla"
+description = "Riproduci una traccia al contrario, accelerala o rallentala, e alza una registrazione troppo bassa. Tira fuori anche l'audio da un video. Gira nel browser: niente caricamenti."
+og_title = "Editor audio &mdash; invertire, ritempificare e alzare senza caricare nulla"
+og_description = "Inverti una traccia, cambiale velocità con o senza spostare l'intonazione, e imposta il livello: poi scarichi un WAV. Il file viene letto e scritto dal tuo browser."
+og_image_alt = "Editor audio - invertire, ritempificare e alzare l'audio nel browser"
+
+pledge = """
+    Il tuo file viene letto, modificato e scritto dal tuo browser, sul tuo
+    hardware. Qui dentro non c'è niente che possa recuperare o spedire qualcosa
+    &mdash; questo strumento non ha proprio alcuna funzione di rete &mdash; e
+    dall'altra parte di questa pagina non c'è alcun server a cui mandare una
+    registrazione, anche se ci fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e inverti qualcosa. Non una sola richiesta porta con sé un
+      campione, un nome di file o un byte di quello che hai scelto. Oppure
+      stacca la connessione e modifica una traccia lo stesso &mdash; uno
+      strumento che spedisse via il tuo audio per elaborarlo si fermerebbe e
+      basta."""
+
+read_first = """
+, <code>src/decode.js</code> per le venti righe
+      che consegnano il tuo file al decodificatore del browser,
+      <code>src/stretch.js</code> per lo stiratore temporale,
+      <code>src/speed.js</code> per il ricampionatore, e <code>src/wav.js</code>
+      per l'intestazione che va davanti ai campioni. Nessuno di loro importa
+      qualcosa in grado di fare una richiesta."""
+
+howto_heading = "Come modificare un file audio"
+
+card = """
+            Inverti una traccia, cambiale velocità con o senza spostare
+            l'intonazione, e tira su una registrazione troppo bassa. Tira
+            fuori anche l'audio da un video."""
+
+[words]
+plural = "registrazioni"
+choose = "un file"
+analytics_extra = """, e nessuna
+  forma d'onda, durata o livello"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Video dentro, audio fuori"
+
+[[facts]]
+text = "Funziona offline"
+
+[[privacy]]
+title = "Le tue registrazioni non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove il tuo file potrebbe finire, e nel codice non
+      c'è nulla che ce lo manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Questo strumento non ha proprio
+      alcuna funzione di rete: nessun indirizzo da incollare, niente da
+      scaricare, nessun motore recuperato al primo utilizzo. Ogni byte che tocca
+      il tuo audio è arrivato da questa origine quando la pagina si è
+      caricata."""
+
+[[privacy]]
+title = "Il decodificatore è quello che hai già nel browser."
+body = """
+
+      Il file viene consegnato a <code>decodeAudioData</code>, lo stesso codice
+      che riproduce una traccia dentro un elemento <code>&lt;audio&gt;</code>.
+      Qui non viene spedito niente per leggere il tuo formato, e non viene
+      chiesto niente a nulla fuori da questa pagina per leggerlo."""
+
+[[privacy]]
+title = "L'immagine di un video non viene mai decodificata."
+body = """
+ Quando trascini qui
+      dentro un video, viene chiesta solo la sua traccia audio. I fotogrammi non
+      vengono letti, né decodificati, né disegnati, né guardati &mdash; su questa
+      pagina non c'è codice che potrebbe farlo, e il file che esce contiene suono
+      e nient'altro."""
+
+[[privacy]]
+title = "I campioni vengono scritti, non ricodificati."
+body = """
+
+      Un WAV sono i campioni che questa pagina ha calcolato, con un'intestazione
+      davanti. Nel ciclo non c'è un encoder che prende decisioni sulla tua
+      registrazione, e non c'è niente che si possa chiamare caricamento su cui
+      farne avvenire uno."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google. A nessuno dei due viene
+      passato niente sulla tua registrazione: né un file, né un campione, né un
+      nome, una dimensione, una durata o quanto era forte. Ogni riga che legge,
+      modifica e scrive è servita da questa origine ed è elencata nel
+      repository."""
+
+[[privacy]]
+title = "Cosa carica il pulsante delle donazioni, e cosa non gli viene dato."
+body = """
+
+      Il pulsante «Buy me a coffee» in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non riferisce alcuna visita, e non gli viene passato niente
+      su di te o sul tuo file."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e tutto quello che sta su
+      questa pagina continua a funzionare. È la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli un file."
+body = """
+ Trascina sul riquadro un file MP3,
+      WAV, FLAC, M4A, Ogg o Opus &mdash; oppure un video, se quello che vuoi è
+      il suono che c'è dentro. Il browser lo legge direttamente dal tuo disco;
+      mentre lo fai non viene mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Girala al contrario, se è per questo che sei venuto."
+body = """
+ Una
+      casella sola. I campioni vengono scritti dall'ultimo al primo, il che è
+      esattamente reversibile: fallo due volte e ti ritrovi il file da cui sei
+      partito, campione per campione."""
+
+[[howto]]
+title = "Imposta la velocità."
+body = """
+ Trascina il cursore, scrivi un
+      moltiplicatore, o premi uno dei valori pronti. Poi scegli cosa succede
+      all'intonazione: tenerla dov'è, che è quello che vuoi per una lezione a
+      1,5&times;, oppure lasciarla muovere con la velocità, che è quello che fa
+      un nastro e che fa salire o scendere una voce."""
+
+[[howto]]
+title = "Imposta il livello."
+body = """
+ Puoi indicare una variazione in
+      decibel, oppure chiedere che la registrazione venga tirata su finché il
+      suo momento più forte non sta appena sotto il tetto. La pagina dice dove
+      finirà quel momento prima che tu prema qualcosa, e ti avverte se
+      l'impostazione che hai scelto lo spingerebbe oltre il fondo scala."""
+
+[[howto]]
+title = "Salvala."
+body = """
+ Il lavoro avviene sul tuo hardware, quindi quanto
+      ci mette dipende dal tuo dispositivo e non da una coda. Quello che esce è
+      un WAV &mdash; i campioni stessi, con un'intestazione davanti &mdash;
+      prima riprodotto sulla pagina, e poi consegnato direttamente ai download
+      del tuo browser."""
+
+[[faq]]
+q = "Il mio audio viene caricato da qualche parte?"
+a = """
+        No. Viene letto, modificato e scritto dal tuo browser sul tuo hardware.
+        Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare &mdash; nessuno di questi appartiene a
+        questo sito. Se preferisci verificare invece che crederci, stacca la
+        connessione e inverti una traccia lo stesso."""
+
+[[faq]]
+q = "Posso tirare fuori l'audio da un video?"
+a = """
+        Sì, e qui è lo stesso lavoro che aprire un MP3. Trascina dentro un MP4,
+        un MOV o un WebM e viene decodificata solo la sua traccia audio:
+        l'immagine non viene mai letta, e quello che esce è un file sonoro senza
+        video dentro. È anche il modo di salvare il suono di una clip senza
+        modificarlo per niente &mdash; lascia stare ogni impostazione e premi il
+        pulsante."""
+
+[[faq]]
+q = "Cambiare la velocità cambia l'intonazione?"
+a = """
+        Solo se glielo chiedi. «Tieni l'intonazione» taglia la registrazione in
+        finestre sovrapposte lunghe una cinquantina di millisecondi e le
+        riappoggia più vicine o più lontane, scegliendo ogni posizione in modo
+        che le onde si allineino dove si incrociano &mdash; una voce resta la
+        stessa voce a 1,5&times;. «Lasciala muovere» ricampiona invece, che è
+        quello che succede a riprodurre un nastro più in fretta: al doppio
+        della velocità sale esattamente di un'ottava."""
+
+[[faq]]
+q = "Perché salva un WAV invece di un MP3?"
+a = """
+        Perché nessun browser si porta dietro un encoder MP3, e questo strumento
+        si rifiuta di mandare la tua registrazione a un server che ce l'ha. Un
+        WAV non ha bisogno di alcun encoder &mdash; sono i campioni con
+        un'intestazione di quarantaquattro byte davanti &mdash; quindi è insieme
+        l'opzione onesta e l'unica che non può costare qualità. Pesa di più:
+        una decina di megabyte al minuto in stereo. Lo apre qualunque lettore,
+        telefono ed editor, e qualunque cosa voglia un MP3 può farsene uno."""
+
+[[faq]]
+q = "Quali formati posso aprire?"
+a = """
+        Quelli che il tuo browser decodifica, il che in pratica vuol dire MP3,
+        WAV, FLAC, M4A e AAC, Ogg Vorbis e Opus, e l'audio dentro i video MP4,
+        M4V, MOV e WebM. Quello che resta fuori è il solito elenco corto: AVI,
+        WMA e quasi tutti gli MKV. Un file che questo browser non legge viene
+        rifiutato con un messaggio che lo dice, invece di piantarsi a metà
+        strada."""
+
+[[faq]]
+q = "Alzarla la distorcerà?"
+a = """
+        Solo se la porti oltre il fondo scala, e la pagina te lo dice prima che
+        succeda. L'audio digitale ha un tetto rigido: un campione non può essere
+        più forte del fondo scala, quindi tutto quello che sta sopra viene
+        schiacciato contro il tetto, ed è così che suona la distorsione. «Il più
+        forte possibile» è l'impostazione che non può farlo &mdash; calcola
+        quanto spazio è rimasto alla registrazione e usa esattamente quello.
+        Tutto quello che sta sotto il tetto è una moltiplicazione e nient'altro:
+        alzala di 6 dB e riabbassala di 6 dB e i campioni sono dove erano
+        partiti."""
+
+[[faq]]
+q = "Invertire o ritempificare fa perdere qualità?"
+a = """
+        Invertire no: escono gli stessi campioni nell'altro ordine, il che è
+        esatto. Cambiare la velocità sposta ogni campione, quindi è aritmetica e
+        non una copia &mdash; il ricampionatore filtra come si deve strada
+        facendo, così accelerare non ripiega le note alte verso il basso come un
+        ronzio metallico, e le finestre dello stiratore vengono messe dove le
+        onde si allineano invece che dove è capitato all'aritmetica. Nessuna
+        delle due vie ricodifica niente, perché qui non c'è un encoder con cui
+        ricodificare."""
+
+[[faq]]
+q = "C'è un limite alla durata del file?"
+a = """
+        Nello strumento non c'è alcun limite. Il tetto pratico è la memoria:
+        tutta la registrazione viene decodificata dentro questa pagina in una
+        volta, e un WAV viene assemblato in memoria prima che tu lo scarichi,
+        quindi un'ora di stereo ha bisogno di poco meno di un gigabyte per
+        lavorare. Un WAV da quattro gigabyte viene rifiutato subito, perché il
+        campo delle dimensioni del formato non sa descriverne uno."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Il sito ha della pubblicità, ed è quella che lo paga;
+        agli annunci non viene dato niente sulla tua registrazione."""
+
+[schema]
+browser_requirements = "Richiede JavaScript e un browser con Web Audio, cioè qualunque browser attuale. Non serve alcun supporto ai codec oltre a quello che il browser ha già per riprodurre il file."
+description = "Inverti una traccia audio, cambiale velocità con o senza spostare l'intonazione, e impostane il livello, nel browser. Funziona anche sull'audio dentro un video. Non viene caricato nulla e il risultato è scritto come WAV, quindi non viene ricodificato niente."
+features = [
+  "Riproduce una traccia al contrario, esattamente",
+  "Cambia velocità da un quarto a quattro volte, tenendo o spostando l'intonazione",
+  "Alza o abbassa il livello, o lo normalizza appena sotto il fondo scala",
+  "Tira fuori l'audio da un MP4, un MOV o un WebM senza toccare l'immagine",
+  "Scrive WAV a 16 bit o in virgola mobile a 32 bit, senza encoder nel ciclo",
+  "Funziona offline; niente caricamenti, nessun account, nessuna filigrana",
+]
+
+[picker]
+title = "Trascina qui un file audio o un video"
+hint = "oppure clicca per scegliere &mdash; MP3, WAV, FLAC, M4A, Ogg, e il suono dentro un MP4, un MOV o un WebM"

--- a/locales/it/tools/exif-editor.html
+++ b/locales/it/tools/exif-editor.html
@@ -1,0 +1,151 @@
+<main>
+  <!-- Passo 1 &mdash; i file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli le foto</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto dalla lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; il clic unico -->
+  <section class="card" id="strip-card">
+    <h2><span class="step">2</span> Togli tutto</h2>
+
+    <p class="card-lede">
+      Un pulsante, tutte le foto della lista. L'immagine non viene decodificata,
+      né ridisegnata, né ricompressa &mdash; i dati compressi dell'immagine
+      vengono copiati dall'altra parte intatti e viene buttato solo il metadato
+      che ci sta attorno, quindi il risultato è la stessa foto senza niente
+      attaccato.
+    </p>
+
+    <div class="strip-row">
+      <button type="button" id="strip-all" class="primary big" disabled>Rimuovi tutti i metadati</button>
+      <span id="strip-status" class="strip-status" role="status" aria-live="polite"></span>
+    </div>
+
+    <!--
+      Two things are kept by default, and both are stated on the button's own
+      line rather than buried in a settings panel. "Remove all" that quietly
+      keeps things is a broken promise; "remove all except these two, and here
+      they are" is a choice.
+    -->
+    <fieldset class="keep-options">
+      <legend>Cosa tenere</legend>
+      <label class="check">
+        <input type="checkbox" id="keep-orientation" checked>
+        <span>
+          <strong>Il tag di orientamento</strong>
+          <span class="check-note">
+            I telefoni conservano una foto come l'ha vista il sensore e aggiungono
+            un tag che dice da che parte sta il sopra. Toglilo e alcuni
+            visualizzatori la mostrano di traverso. Se lo tieni, viene scritto un
+            nuovo blocco EXIF che contiene questo tag e nient'altro &mdash; e solo
+            quando la foto non era già dritta.
+          </span>
+        </span>
+      </label>
+      <label class="check">
+        <input type="checkbox" id="keep-icc" checked>
+        <span>
+          <strong>Il profilo colore</strong>
+          <span class="check-note">
+            Il profilo ICC dice cosa vogliono dire come colori i numeri dentro
+            l'immagine. Di te non dice niente. Buttarlo può spostare in modo
+            visibile i colori di una foto a gamma ampia, ed è per questo che
+            viene tenuto se non dici altrimenti.
+          </span>
+        </span>
+      </label>
+      <p class="keep-summary" id="keep-summary"></p>
+    </fieldset>
+
+    <div id="clean-results" class="results" hidden>
+      <div class="results-head">
+        <h3>Ripulite</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Scarica tutto in uno zip</button>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; leggere e modificare -->
+  <section class="card" id="inspect-card">
+    <h2><span class="step">3</span> Guarda dentro, e cambia quello che vuoi</h2>
+
+    <p id="inspect-empty" class="empty-note">
+      Scegli una foto qui sopra e tutto quello che contiene compare qui: cosa dice
+      su dove eri, quando, e con cosa. Per capirlo non viene mandato niente da
+      nessuna parte.
+    </p>
+
+    <div id="inspector" hidden>
+      <div class="inspect-head">
+        <div class="inspect-file">
+          <img id="inspect-thumb" class="inspect-thumb" alt="" hidden>
+          <div>
+            <p class="inspect-name" id="inspect-name"></p>
+            <p class="inspect-sub" id="inspect-sub"></p>
+          </div>
+        </div>
+        <div class="inspect-switch">
+          <label for="inspect-select" class="visually-hidden">Quale foto ispezionare</label>
+          <select id="inspect-select"></select>
+        </div>
+      </div>
+
+      <!-- The findings: the part of this page that answers the actual question. -->
+      <section class="findings" aria-labelledby="findings-h">
+        <h3 id="findings-h">Cosa rivela questo file</h3>
+        <ul id="findings-list" class="findings-list"></ul>
+      </section>
+
+      <!-- Whole blocks, each removable on its own. -->
+      <section class="blocks" aria-labelledby="blocks-h">
+        <h3 id="blocks-h">Blocchi in questo file</h3>
+        <ul id="block-list" class="block-list"></ul>
+      </section>
+
+      <!-- Every tag, editable. -->
+      <section class="tags" aria-labelledby="tags-h">
+        <h3 id="tags-h">Tutti i tag</h3>
+        <p class="tags-note" id="tags-note"></p>
+        <div id="tag-groups"></div>
+
+        <details class="add-tag" id="add-tag">
+          <summary>Aggiungi un tag</summary>
+          <div class="add-tag-body">
+            <label for="add-tag-select">Tag</label>
+            <select id="add-tag-select"></select>
+            <label for="add-tag-value">Valore</label>
+            <input type="text" id="add-tag-value" spellcheck="false">
+            <button type="button" id="add-tag-go" class="ghost">Aggiungi</button>
+          </div>
+        </details>
+      </section>
+
+      <div class="save-row">
+        <button type="button" id="save-edits" class="primary" disabled>Salva questa foto</button>
+        <button type="button" id="revert-edits" class="ghost" disabled>Annulla le mie modifiche</button>
+        <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
+      </div>
+      <p id="edit-error" class="error" role="alert" hidden></p>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/exif-editor.toml
+++ b/locales/it/tools/exif-editor.toml
@@ -1,0 +1,245 @@
+#
+# Visualizzatore e rimozione EXIF - Italian.
+#
+# Overrides for tools/exif-editor/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Visualizzatore e rimozione EXIF"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Dati&nbsp;EXIF <span class=\"h1-kw\">&mdash; rimuovere i metadati da una foto</span>"
+tagline = "Guarda cosa dice di te una foto. Poi toglilo."
+
+title = "Visualizzare e rimuovere i dati EXIF &mdash; editor di metadati gratuito"
+description = "Guarda i dati EXIF e GPS nascosti in una foto, modificali, o togli tutto con un clic. Nel browser: niente caricamenti, e la foto non viene mai ricodificata."
+og_title = "Dati EXIF &mdash; guardali, modificali, o toglili"
+og_description = "Leggi i metadati nascosti in una foto e rimuovili tutti con un clic. Gira sul tuo dispositivo; l'immagine in sé non viene mai ricodificata."
+og_image_alt = "Visualizzatore e rimozione EXIF - leggere, modificare o togliere i metadati di una foto"
+
+pledge = """
+    Il file viene aperto, analizzato e riscritto dal tuo browser. Questo
+    strumento non ha alcuna funzione di rete &mdash; niente da recuperare,
+    niente da spedire &mdash; e dall'altra parte di questa pagina non c'è alcun
+    server a cui mandare una foto, anche se ci fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e ripulisci una foto. Non una sola richiesta porta con sé
+      un'immagine, una miniatura, un nome di file o un tag letto dal tuo file.
+      Oppure stacca la connessione e ripuliscine una lo stesso."""
+
+read_first = """
+, <code>src/tiff.js</code> per l'analizzatore EXIF, e
+      <code>src/jpeg.js</code> per la prova che l'immagine in sé viene sempre e
+      solo copiata."""
+
+howto_heading = "Come rimuovere i dati EXIF da una foto"
+
+card = """
+            Guarda la posizione, la fotocamera e i numeri di serie nascosti in
+            una foto, modifica quello che vuoi, o togli tutto con un clic."""
+
+[words]
+plural = "foto"
+choose = "una foto"
+analytics_extra = """, e nemmeno uno dei tag
+  che questo strumento legge dai tuoi file"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "Non ricodifica mai l'immagine"
+
+[[privacy]]
+title = "Le tue foto non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove i tuoi file potrebbero finire, e nel codice non
+      c'è nulla che ce li manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ A differenza degli altri
+      strumenti di questa scatola, questo non ha la funzione «carica da un
+      indirizzo web» e non ha proprio alcun passaggio di rete facoltativo. Non
+      c'è un <code>fetch</code>, né un <code>XMLHttpRequest</code>, né un
+      <code>sendBeacon</code> da nessuna parte in <code>src/</code>."""
+
+[[privacy]]
+title = "I metadati che leggiamo non vengono mai riferiti."
+body = """
+ La tua posizione GPS
+      viene mostrata su questa pagina e non va da nessun'altra parte. In questo
+      repository non esiste alcun evento di analytics che porti con sé un tag,
+      un nome di file, una dimensione o un conteggio."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google. A nessuno dei due viene
+      passato niente sulle tue foto. Ogni riga che legge, analizza o riscrive un
+      file è servita da questa origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Cosa carica il pulsante delle donazioni, e cosa non gli viene dato."
+body = """
+
+      Il pulsante «Buy me a coffee» in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non riferisce alcuna visita, e non gli viene passato niente
+      su di te o sui tuoi file. Non succede nulla finché non ci clicchi, e
+      quello a cui arriveresti è il sito di qualcun altro."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento resta
+      identico, perché al suo interno non c'è mai stato un passaggio di rete. È
+      la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli le tue foto."
+body = """
+ Trascinale sul riquadro o
+      selezionale a mano. Il browser le legge direttamente dal tuo disco; mentre
+      lo fai non viene mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Leggi cosa contengono, se ti va."
+body = """
+ L'elenco dei riscontri nomina
+      le cose che vale la pena sapere &mdash; la posizione GPS, gli orari, i
+      numeri di serie &mdash; prima della tabella completa di tutti i tag."""
+
+[[howto]]
+title = "Premi «Rimuovi tutti i metadati»."
+body = """
+ Per quasi tutti è tutto qui il
+      lavoro. Ogni tag, i blocchi XMP e IPTC, i commenti e la miniatura
+      incorporata se ne vanno, su tutte le foto dell'elenco in una volta."""
+
+[[howto]]
+title = "Oppure modifica invece di rimuovere."
+body = """
+ Cambia una data, correggi una
+      riga di copyright, butta la posizione e tieni le impostazioni della
+      fotocamera &mdash; poi salva quella foto per conto suo."""
+
+[[faq]]
+q = "La mia foto viene caricata da qualche parte?"
+a = """
+        No. Il file viene letto, analizzato e riscritto dal tuo browser sul tuo
+        hardware. Questo strumento non ha alcuna funzione di rete &mdash; non
+        recupera mai niente e non spedisce mai niente &mdash; e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare, nessuno dei quali appartiene a questo
+        sito."""
+
+[[faq]]
+q = "Cos'è l'EXIF, e cos'altro si nasconde in una foto?"
+a = """
+        L'EXIF è un blocco di tag che una fotocamera scrive accanto all'immagine:
+        la marca e il modello, le impostazioni di esposizione, la data e l'ora al
+        secondo, spesso una posizione GPS e a volte un numero di serie. Le foto
+        portano spesso anche altro &mdash; un pacchetto XMP di XML lasciato da un
+        programma di ritocco, un blocco IPTC con didascalia e firma, un profilo
+        colore, una piccola seconda copia dell'immagine come miniatura, e una
+        maker note di dati non documentati del produttore. Questo strumento li
+        elenca tutti."""
+
+[[faq]]
+q = "Rimuovere i metadati peggiora la qualità dell'immagine?"
+a = """
+        No, ed è il motivo principale per usare uno strumento come questo invece
+        di risalvare la foto. I metadati stanno nel contenitore attorno
+        all'immagine compressa, non dentro di essa. Rimuoverli vuol dire
+        cancellare voci da un elenco e riscrivere l'elenco; i dati compressi
+        dell'immagine vengono copiati byte per byte, quindi il risultato
+        decodifica esattamente gli stessi pixel. Non viene decodificato niente e
+        non viene ricompresso niente."""
+
+[[faq]]
+q = "Quali formati di file gestisce?"
+a = """
+        JPEG, PNG e WebP. HEIC e AVIF vengono riconosciuti ma non riscritti: sono
+        formati a scatole costruiti con atomi annidati e hanno bisogno di un
+        analizzatore diverso, quindi lo strumento lo dice invece di produrre un
+        file rotto. Nemmeno un TIFF nudo viene gestito, perché in un TIFF i
+        metadati e i pixel sono indirizzati dagli stessi offset."""
+
+[[faq]]
+q = "La mia foto risulterà ruotata dopo la rimozione dei metadati?"
+a = """
+        Può succedere, e c'è un'impostazione apposta. I telefoni di solito
+        registrano l'immagine come l'ha vista il sensore e aggiungono un tag
+        Orientation che dice come girarla. Togli quel tag e alcuni
+        visualizzatori mostrano la foto di traverso. L'opzione «tieni il tag di
+        orientamento», attiva di default, riscrive un minuscolo blocco EXIF che
+        contiene soltanto quel tag &mdash; e solo quando la foto ne aveva
+        davvero bisogno. Toglila se preferisci che il file non porti alcun EXIF,
+        proprio nessuno."""
+
+[[faq]]
+q = "Rimuove la posizione GPS?"
+a = """
+        Sì. Rimuovere tutto rimuove l'intera directory GPS, e puoi anche
+        cancellare la sola posizione tenendo il resto. La posizione è mostrata
+        prima in gradi decimali, perché «51 gradi, 30 primi, 26 secondi» non
+        rende evidente che una foto nomina l'edificio in cui è stata
+        scattata."""
+
+[[faq]]
+q = "Posso cambiare un tag invece di cancellarlo?"
+a = """
+        Sì. I tag di testo, le date, l'ISO, l'orientamento e la risoluzione si
+        possono modificare tutti, e qualche tag comune si può aggiungere a una
+        foto che non ne ha. Un avvertimento: scrivere il file ricostruisce il
+        blocco EXIF, e una maker note contiene offset che puntano dentro il
+        blocco originale, quindi una maker note ricostruita potrebbe poi non
+        essere leggibile dal software del produttore. Cancellala, o lascia il
+        file non modificato, se la cosa ti interessa."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso e non c'è periodo di prova.
+        Il sito ha della pubblicità, ed è quella che lo paga; agli annunci non
+        viene dato niente sulle tue foto."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via le tue foto per
+        elaborarle si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Leggi i metadati EXIF, GPS, XMP e IPTC dentro una foto, modifica i singoli tag, o rimuovili tutti con un clic. JPEG, PNG e WebP, elaborati nel browser senza ricodificare l'immagine."
+features = [
+  "Mostra tutti i tag EXIF, compresi posizione GPS, numeri di serie della fotocamera e maker note",
+  "Modifica o cancella i singoli tag e riscrive il file",
+  "Rimuove EXIF, GPS, XMP, IPTC, commenti e miniatura incorporata con un clic",
+  "JPEG, PNG e WebP",
+  "Riscrive solo il contenitore, quindi l'immagine non viene mai ricompressa",
+  "Funziona offline; niente caricamenti, nessun account",
+]
+
+[picker]
+title = "Trascina qui le foto"
+hint = "oppure clicca per scegliere &mdash; JPEG, PNG e WebP"

--- a/locales/it/tools/heic-to-jpg.html
+++ b/locales/it/tools/heic-to-jpg.html
@@ -1,0 +1,113 @@
+<main>
+  <!-- Passo 1 &mdash; i file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli le tue foto HEIC</h2>
+
+    <p class="card-lede">
+      Direttamente dal telefono, da un backup, o copiate da una scheda di
+      memoria. Il file viene letto qui, su questo dispositivo, e anche l'immagine
+      viene decodificata qui &mdash; in questa pagina non c'è un passaggio di
+      caricamento e dietro non c'è un server.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto dalla lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; cosa esce -->
+  <section class="card" id="options-card">
+    <h2><span class="step">2</span> Di' cosa vuoi indietro</h2>
+
+    <fieldset class="options">
+      <legend>Il formato</legend>
+
+      <div class="option-row">
+        <label for="format-select">Scrivi le immagini come</label>
+        <select id="format-select">
+          <option value="image/jpeg" selected>JPEG &mdash; si apre dappertutto, comprese le cose fatte in questo secolo per sbaglio</option>
+          <option value="image/png">PNG &mdash; senza perdita, e parecchie volte più pesante</option>
+          <option value="image/webp">WebP &mdash; più leggero del JPEG a parità di qualità, e solo per browser moderni</option>
+        </select>
+      </div>
+
+      <div class="option-row" id="quality-row">
+        <label for="quality">Qualità</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="50" max="100" step="1" value="92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>I dettagli della foto</legend>
+
+      <label class="check">
+        <input type="checkbox" id="keep-exif" checked>
+        <span>
+          <strong>Tieni la data, la fotocamera e le impostazioni</strong>
+          <span class="check-note">
+            Copiate esattamente come le ha scritte il telefono, così la foto
+            convertita si ordina ancora per il giorno dello scatto e non per il
+            giorno della conversione. Comprese le coordinate GPS, quando la foto
+            ce le ha &mdash; l'elenco qui sopra dice quali delle tue le hanno.
+            Togli la spunta e il JPEG esce senza niente dentro tranne
+            l'immagine.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary">
+        In un caso e nell'altro, qui non viene riferito niente a nessuno: la
+        scelta riguarda cosa finisce nel file che ti torna indietro, non cosa ne
+        fa questa pagina. Se vuoi passare in rassegna i tag nel dettaglio, o
+        toglierli da foto che sono già JPEG, lo strumento giusto è il
+        <a href="../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>.
+      </p>
+    </fieldset>
+  </section>
+
+  <!-- Passo 3 &mdash; il clic unico -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Converti</h2>
+
+    <div class="run-row">
+      <button type="button" id="convert-all" class="primary big" disabled>Converti</button>
+    </div>
+
+    <!--
+      The decoder's own status line. This page is the only one on the site that
+      carries a codec, so it is the only one with anything to report here, and
+      saying where the megabyte came from is the point: it is served from this
+      origin, it is cached with the rest of the page, and it is what makes the
+      offline promise hold on a browser that cannot open a HEIC at all.
+    -->
+    <p id="engine-status" class="engine-status" role="status" aria-live="polite"></p>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Convertite</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Scarica tutto in uno zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/heic-to-jpg.toml
+++ b/locales/it/tools/heic-to-jpg.toml
@@ -1,0 +1,306 @@
+#
+# Da HEIC a JPG - Italian.
+#
+# Overrides for tools/heic-to-jpg/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Da HEIC a JPG"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Da&nbsp;HEIC&nbsp;a&nbsp;JPG <span class=\"h1-kw\">&mdash; convertire le foto dell'iPhone</span>"
+tagline = "Le foto che fa un iPhone, in un formato che apre chiunque."
+
+title = "Convertitore da HEIC a JPG &mdash; gratis, senza caricare nulla"
+description = "Converti in JPG le foto HEIC dell'iPhone, nel browser. Il decodificatore gira sul tuo dispositivo: niente caricamenti, nessun account, funziona offline, e la data e i dati della fotocamera possono venire dietro."
+og_title = "Trasformare le foto HEIC in JPG senza caricarle"
+og_description = "Il convertitore che non vuole le tue foto. Il decodificatore HEIC è servito da questa pagina e gira sul tuo dispositivo, quindi le immagini non lo lasciano mai."
+og_image_alt = "Da HEIC a JPG - le foto dell'iPhone in un formato che apre chiunque"
+
+pledge = """
+    La decodifica avviene nel tuo browser, sul tuo hardware. L'HEIC è l'unico
+    formato di immagine che un browser non apre da solo, quindi questa pagina si
+    porta dietro il decodificatore &mdash; circa 1,4 MB, serviti da questo sito,
+    messi in cache dopo la prima visita. È tutta lì la ragione per cui ogni
+    altro convertitore HEIC ti chiede di caricare: mettono il codec su un server
+    e le tue foto devono andarci. Questo mette il codec qui, invece. Su questa
+    pagina non c'è proprio alcuna funzione di rete, e dall'altra parte non c'è
+    alcun server a cui mandare una foto."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e converti una foto. Vedrai caricarsi i file di questa pagina,
+      decodificatore compreso, e non una sola richiesta che porti con sé una
+      foto, una miniatura, un nome di file o un byte di quello che hai scelto.
+      Oppure carica la pagina una volta, stacca la connessione, e converti lo
+      stesso una cartella intera."""
+
+read_first = """
+, <code>src/heif.js</code> per come viene
+      caricato il decodificatore e cosa gli è concesso fare,
+      <code>src/boxes.js</code> per l'analisi del contenitore che trova i
+      metadati della foto, e <code>src/exif.js</code> per quello che succede a
+      quei metadati mentre entrano in un JPEG. Il motore in sé è
+      <code>vendor/libheif.js</code>, non modificato, con la sua licenza
+      accanto."""
+
+howto_heading = "Come convertire le foto HEIC in JPG"
+
+card = """
+            Le foto che fa un iPhone, in un formato che apre chiunque &mdash;
+            decodificate sul tuo dispositivo, non sul server di qualcuno."""
+
+[words]
+plural = "foto"
+choose = "una foto"
+analytics_extra = """, e nemmeno una delle
+  date, dei modelli di fotocamera o delle coordinate che questo strumento ci legge dentro"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessun limite di dimensione"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Le tue foto non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove i tuoi file potrebbero finire, e nel codice non
+      c'è nulla che ce li manderebbe se esistesse."""
+
+[[privacy]]
+title = "Il decodificatore è arrivato da qui, e non va da nessuna parte."
+body = """
+ L'HEIC è HEVC
+      dentro un formato a scatole, e nessun browser tranne Safari ne decodifica
+      uno, quindi questa pagina si porta dietro <code>libheif</code> compilato in
+      WebAssembly &mdash; circa 1,4 MB, depositati in questo repository, serviti
+      da questa origine, e messi in cache dal service worker come ogni altro file
+      qui. Non viene recuperato da una CDN, perché ciò metterebbe un terzo sulla
+      strada di ogni visita e impedirebbe allo strumento di funzionare offline.
+      Il binario sta dentro lo script invece che accanto proprio perché non serva
+      alcun fetch per avviarlo."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Non c'è un
+      <code>fetch</code>, né un <code>XMLHttpRequest</code>, né un
+      <code>sendBeacon</code> in nessun file scritto per questo strumento. Il
+      motore incorporato, come ogni build Emscripten, contiene i percorsi di
+      caricamento che recupererebbero un <code>.wasm</code> da un indirizzo; non
+      vengono presi, perché il binario è già in mano &mdash; e se lo fossero,
+      <code>connect-src</code> nomina gli endpoint di misurazione di Google e
+      nient'altro, quindi il browser rifiuterebbe. La prova è la policy, non la
+      promessa."""
+
+[[privacy]]
+title = "I metadati vengono letti qui e riferiti a te."
+body = """
+ L'elenco sulla
+      pagina dice cosa porta con sé ogni foto &mdash; la data, la fotocamera, e
+      se ci sono dentro coordinate GPS &mdash; perché è una cosa che potresti
+      voler sapere prima di consegnare il JPEG a qualcuno. Viene letto dal file
+      da <code>src/boxes.js</code> dentro questo browser, mostrato su questa
+      pagina, e scritto nel tuo JPEG o lasciato fuori, interamente come decidi
+      tu. In questo repository non esiste alcun evento di analytics che porti con
+      sé un nome di file, una data, una coordinata o un conteggio."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google, e il pulsante delle
+      donazioni da Buy Me a Coffee. A nessuno di loro viene passato niente sulle
+      tue foto. Ogni riga che legge, decodifica o scrive un file è servita da
+      questa origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Carica la pagina una volta e stacca la
+      connessione, e lo strumento resta identico &mdash; il decodificatore è in
+      cache insieme a lei. È la prova più semplice di tutte, e qui è più forte
+      che in qualunque altro punto di questo sito: un convertitore che spedisse
+      via le tue foto per decodificarle non potrebbe assolutamente riuscirci."""
+
+[[howto]]
+title = "Scegli le tue foto HEIC."
+body = """
+ Trascinale sul riquadro o
+      selezionale a mano, direttamente da un backup del telefono o da una
+      cartella sul computer. Il browser le legge dal tuo disco; mentre lo fai non
+      viene mandato niente da nessuna parte. L'elenco dice cos'è ognuna e cosa ha
+      dentro."""
+
+[[howto]]
+title = "Guarda cosa portano con sé le foto."
+body = """
+ Ogni riga nomina la data
+      dello scatto, la fotocamera, e &mdash; in verde, perché è la parte che vale
+      la pena notare &mdash; se il file contiene coordinate GPS. Viene letto dal
+      contenitore senza decodificare l'immagine, quindi non costa niente e
+      compare subito."""
+
+[[howto]]
+title = "Scegli un formato, e decidi sui dettagli."
+body = """
+ JPEG, a meno che tu non
+      abbia un motivo: è il formato che si apre dappertutto, che è tutto il senso
+      del convertire. Il cursore della qualità è su 92, che è l'impostazione a
+      cui una fotografia è difficile da distinguere dall'originale. La casella
+      decide se la data, la fotocamera e la posizione vengono dietro."""
+
+[[howto]]
+title = "Premi «Converti», e scarica."
+body = """
+ Il decodificatore arriva alla
+      prima conversione &mdash; circa 1,4 MB, una volta sola &mdash; e ogni foto
+      dopo di quella viene decodificata e scritta sul tuo dispositivo. Un file
+      solo ti dà un pulsante di download; più file ti danno anche uno zip."""
+
+[[faq]]
+q = "La mia foto viene caricata da qualche parte?"
+a = """
+        No. Il file viene letto, decodificato e scritto dal tuo browser sul tuo
+        hardware. Questo strumento non ha alcuna funzione di rete &mdash; non
+        recupera mai niente e non spedisce mai niente &mdash; e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare, nessuno dei quali appartiene a questo sito.
+        L'unica cosa che si carica davvero è il decodificatore stesso, e arriva
+        da questo sito, una volta sola, prima ancora che la tua foto sia
+        coinvolta."""
+
+[[faq]]
+q = "Perché questa pagina scarica 1,4 MB la prima volta?"
+a = """
+        Perché l'HEIC è l'unico formato di immagine che un browser non apre. È un
+        fotogramma HEVC dentro un contenitore a scatole, e solo Safari, su
+        hardware Apple, ha un decodificatore per lui; Chrome, Firefox ed Edge
+        rifiutano il file e basta. Quindi un convertitore HEIC ha bisogno di un
+        decodificatore da qualche parte, e i posti da cui può arrivare sono due:
+        un server, oppure la pagina. Ogni altro convertitore ha scelto il server,
+        ed è esattamente per questo che tutti hanno bisogno che le tue foto
+        vengano caricate. Questo si porta dietro <code>libheif</code> compilato
+        in WebAssembly, invece. È servito da questo sito, messo in cache dopo la
+        prima visita, ed è tutto il prezzo del fatto che le tue foto non vadano
+        da nessuna parte."""
+
+[[faq]]
+q = "Il JPEG conserva la data, la fotocamera e la posizione?"
+a = """
+        Se lo vuoi, ed è una casella sulla pagina. Lasciata attiva, il blocco
+        EXIF viene copiato fuori dall'HEIC e scritto nel JPEG esattamente come
+        l'aveva scritto il telefono, così la foto convertita si ordina ancora per
+        il giorno dello scatto e non per il giorno della conversione &mdash; che
+        è la lamentela abituale sui convertitori HEIC. Un tag viene cambiato, e
+        uno solo: l'orientamento, che viene messo su «dritto», perché la
+        rotazione è già stata applicata ai pixel e un visualizzatore che la
+        applicasse di nuovo metterebbe di traverso ogni foto verticale. Togli la
+        spunta e il JPEG esce con l'immagine e nient'altro."""
+
+[[faq]]
+q = "Toglie le coordinate GPS?"
+a = """
+        Ti dice che ci sono, e poi fa quello che chiedi. La riga di ogni foto
+        dice se il file porta con sé delle coordinate prima che tu converta
+        qualunque cosa, il che è più di quanto faccia il telefono. Togliendo la
+        spunta a «tieni la data, la fotocamera e le impostazioni» restano fuori
+        dal JPEG insieme a tutto il resto; lasciandola le porta dall'altra parte.
+        Se quello che vuoi è passare in rassegna i tag nel dettaglio, o toglierli
+        da foto che sono già JPEG, lo strumento giusto è il
+        <a href="../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>, e
+        lo fa senza ricomprimere l'immagine."""
+
+[[faq]]
+q = "L'immagine viene ricompressa?"
+a = """
+        Sì, e non può essere altrimenti: HEIC e JPEG sono codec diversi, quindi
+        non c'è modo di passare dall'uno all'altro senza decodificare l'immagine
+        e ricodificarla. Quello che puoi controllare è quanto costa. Il cursore
+        della qualità parte da 92, a cui una fotografia è molto difficile da
+        distinguere dall'originale, e nel menu c'è il PNG per il caso in cui non
+        vuoi alcuna perdita e non ti dispiace un file da cinque a dieci volte più
+        pesante."""
+
+[[faq]]
+q = "E se il file si chiama .jpg ma in realtà è un HEIC?"
+a = """
+        Funziona lo stesso. Ogni file trascinato qui viene identificato dai suoi
+        primi byte e non dal nome, perché il nome è quello che ha deciso l'ultima
+        applicazione che ha toccato il file &mdash; e un HEIC arrivato chiamandosi
+        «.jpg» è uno dei modi più comuni in cui una persona finisce per cercare
+        uno strumento come questo. Un file che è davvero un JPEG o un PNG viene
+        rifiutato con un messaggio che lo dice, invece di essere convertito in una
+        copia di sé stesso."""
+
+[[faq]]
+q = "Può convertire una Live Photo, o una raffica?"
+a = """
+        Le immagini ferme che contiene, sì. Un HEIC può contenere più di
+        un'immagine, e ognuna di quelle che contiene viene convertita e chiamata
+        come l'originale con un numero in fondo. La metà video di una Live Photo
+        è un file a parte che il telefono tiene accanto all'HEIC, quindi qui
+        dentro non c'è da convertire. Le mappe di profondità e le miniature sono
+        nel contenitore ma non sono immagini che qualcuno abbia chiesto, e
+        vengono lasciate stare."""
+
+[[faq]]
+q = "Perché non mi prende l'AVIF?"
+a = """
+        Perché non c'è niente da farci. L'AVIF è lo stesso contenitore dell'HEIC
+        con dentro AV1 al posto di HEVC, e ogni browser attuale ne decodifica uno
+        nativamente &mdash; quindi un convertitore starebbe spedendo un megabyte
+        di motore per risolvere un problema che non hai. Se ti serve un AVIF come
+        JPEG, il <a href="../comprimere-immagine/">compressore di immagini</a> e
+        il <a href="../ridimensionare-immagine/">ridimensionatore di immagini</a>
+        leggono entrambi l'AVIF e scrivono JPEG usando il decodificatore che il
+        tuo browser ha già."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Non c'è nemmeno un limite al numero o alla dimensione
+        dei file, perché non c'è un server che li paga &mdash; il lavoro avviene
+        sul tuo dispositivo. Il sito ha della pubblicità, ed è quella che lo
+        paga; agli annunci non viene dato niente sulle tue foto."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì, decodificatore compreso. Carica la pagina una volta, poi stacca la
+        connessione e continua a lavorare sulle tue foto esattamente come prima.
+        È anche la prova più forte a disposizione che non viene caricato niente:
+        un convertitore che spedisse via i tuoi HEIC per decodificarli si
+        fermerebbe nel momento in cui stacchi la spina, e questo non si ferma."""
+
+[schema]
+description = "Converti in JPEG, PNG o WebP le foto HEIC e HEIF di un iPhone. Il decodificatore HEIC è WebAssembly servito dalla pagina stessa, quindi le immagini vengono decodificate sul tuo dispositivo e non vengono mai caricate. La data, la fotocamera e la posizione possono essere portate nel JPEG oppure lasciate fuori."
+features = [
+  "Converte HEIC e HEIF in JPEG, PNG o WebP",
+  "Decodifica nel browser, in qualunque browser - non solo Safari",
+  "Non viene caricato nulla, e lo strumento funziona con la rete staccata",
+  "Porta data, fotocamera e GPS dentro il JPEG, oppure li lascia fuori",
+  "Dice quali foto contengono coordinate GPS prima che venga convertito qualcosa",
+  "Corregge il tag di orientamento, così le foto verticali non escono di traverso",
+  "Identifica i file dal loro contenuto, così un HEIC chiamato .jpg funziona lo stesso",
+  "Converte tutte le immagini di una raffica o di una Live Photo, non solo la prima",
+  "Lavora a lotti, con tutti i risultati in un unico zip",
+]
+
+[picker]
+title = "Trascina qui le foto HEIC"
+hint = "oppure clicca per scegliere &mdash; .heic e .heif, comunque si chiamino"

--- a/locales/it/tools/image-to-data-uri.html
+++ b/locales/it/tools/image-to-data-uri.html
@@ -1,0 +1,142 @@
+<main>
+  <!-- Passo 1 &mdash; i file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli le immagini</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto dalla lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; la riga che si incolla davvero -->
+  <section class="card" id="shape-card">
+    <h2><span class="step">2</span> Di' dove va a finire</h2>
+
+    <p class="card-lede">
+      Un data URI da solo è raramente quello che si vuole. Quello che si vuole è
+      la riga che va nel foglio di stile &mdash; quindi scegli la riga, e
+      l'immagine ci arriva dentro già tra virgolette, che è la parte facile da
+      sbagliare e che si rompe solo con gli SVG.
+    </p>
+
+    <div class="shapes" id="shapes" role="radiogroup" aria-label="Cosa incollare">
+      <label class="shape">
+        <input type="radio" name="shape" value="uri" checked>
+        <span class="shape-body">
+          <strong>Il data URI da solo</strong>
+          <span class="shape-note">
+            Tutto quello che sta dopo la virgola è il file. Incollalo ovunque vada un URL.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-rule">
+        <span class="shape-body">
+          <strong>Una regola CSS</strong>
+          <span class="shape-note">
+            Una regola intera, con una classe che prende il nome dal file. Cambia
+            il selettore con quello che stai davvero stilando.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-var">
+        <span class="shape-body">
+          <strong>Una proprietà personalizzata CSS</strong>
+          <span class="shape-note">
+            Dichiarata una volta in cima al foglio di stile e usata come
+            <code>var(--nome)</code> tutte le volte che vuoi. È quella da
+            scegliere quando l'immagine compare in più di una regola.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="html">
+        <span class="shape-body">
+          <strong>Un tag HTML <code>&lt;img&gt;</code></strong>
+          <span class="shape-note">
+            Con la dimensione in pixel già compilata, così la pagina non salta
+            mentre il resto si carica.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="markdown">
+        <span class="shape-body">
+          <strong>Markdown</strong>
+          <span class="shape-note">
+            Per un README o una issue: un'immagine che viaggia insieme al testo
+            invece di aver bisogno di un posto dove stare.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary">
+      Il testo <code>alt</code> è lasciato vuoto di proposito. Solo tu sai se
+      l'immagine porta un significato o è decorazione, e una descrizione
+      indovinata da un nome di file è peggio, per chi usa uno screen reader, che
+      nessuna descrizione.
+    </p>
+
+    <fieldset class="options">
+      <legend>SVG</legend>
+
+      <label class="check">
+        <input type="checkbox" id="svg-base64">
+        <span>
+          <strong>Metti in base64 anche gli SVG</strong>
+          <span class="check-note">
+            Disattivo di default, perché un SVG è testo e il base64 è per i byte.
+            La codifica in percentuale lascia il markup leggibile nel foglio di
+            stile ed è di solito un quinto più corta. Attivalo per la rara catena
+            di strumenti che insiste su <code>;base64</code>.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Passo 3 &mdash; il risultato. Qui non c'è un pulsante di proposito: la
+       codifica è istantanea, quindi non c'è niente che un clic su «converti»
+       debba aspettare. -->
+  <section class="card" id="output-card">
+    <h2><span class="step">3</span> Copialo</h2>
+
+    <p id="empty-note" class="card-lede">
+      Non hai ancora scelto niente. Trascina qui sopra un'immagine e la riga da
+      incollare compare qui.
+    </p>
+
+    <div id="results" hidden>
+      <div class="results-head">
+        <p id="results-summary" class="results-summary"></p>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Copia tutto</button>
+          <button type="button" id="download-all" class="ghost">Scarica in un file solo</button>
+        </div>
+      </div>
+
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/image-to-data-uri.toml
+++ b/locales/it/tools/image-to-data-uri.toml
@@ -1,0 +1,325 @@
+#
+# Immagine in data URI - Italian.
+#
+# Overrides for tools/image-to-data-uri/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Immagine in data URI"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Immagine&nbsp;in&nbsp;data&nbsp;URI <span class=\"h1-kw\">&mdash; codificare in base64 una figura per il CSS o l'HTML</span>"
+tagline = "Tutta l'immagine come una riga di testo. Da incollare dritta nel CSS o nell'HTML."
+
+title = "Immagine in data URI &mdash; codifica base64 per il CSS, gratis, senza caricare nulla"
+description = "Trasforma un PNG, un JPEG, un SVG o un WebP in un data URI da incollare nel CSS o nell'HTML. Gli SVG vengono codificati in percentuale invece che in base64, così restano leggibili e più corti. Gira nel browser; non viene caricato nulla."
+og_title = "Trasformare un'immagine in una riga da incollare nel CSS"
+og_description = "Base64 per le immagini, codifica in percentuale per l'SVG, e la regola, la proprietà personalizzata o il tag img già pronti attorno. Gira sul tuo dispositivo; non viene caricato nulla."
+og_image_alt = "Immagine in data URI - incollare la figura dentro il foglio di stile"
+
+pledge = """
+    La codifica avviene nel tuo browser, sul tuo hardware. È aritmetica su byte
+    che la pagina ha già: nessun encoder, nessun server, e nessun passaggio di
+    rete da lasciare fuori. Questo strumento non ha alcuna funzione di rete
+    &mdash; niente da recuperare, niente da spedire &mdash; e dall'altra parte
+    di questa pagina non c'è alcun server a cui mandare un'immagine, anche se ci
+    fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e trascina dentro un'immagine. Non una sola richiesta porta
+      con sé un'immagine, una miniatura, un nome di file o un byte di quello che
+      hai scelto. Oppure stacca la connessione e codificane una lo stesso."""
+
+read_first = """
+, <code>src/encode.js</code> per le due
+      codifiche e il ragionamento dietro ciascuna, <code>src/sniff.js</code> per
+      come il tipo di media viene letto dal file invece che dal suo nome, e
+      <code>src/metadata.js</code> per il controllo che dice quanta parte di
+      quello che stai per incollare non è l'immagine."""
+
+howto_heading = "Come trasformare un'immagine in un data URI"
+
+card = """
+            Base64 per le immagini, codifica in percentuale per l'SVG, e la
+            regola CSS o il tag <code>&lt;img&gt;</code> già costruiti
+            attorno."""
+
+[words]
+plural = "immagini"
+choose = "un'immagine"
+analytics_extra = """, e nemmeno uno dei
+  nomi di file, delle dimensioni o del testo codificato che questo strumento produce"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna ricodifica"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Le tue immagini non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove i tuoi file potrebbero finire, e nel codice non
+      c'è nulla che ce li manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Non c'è un
+      <code>fetch</code>, né un <code>XMLHttpRequest</code>, né un
+      <code>sendBeacon</code> da nessuna parte in <code>src/</code>. La codifica
+      è <code>btoa</code> ed <code>encodeURIComponent</code> &mdash; due
+      funzioni che il browser ha dall'inizio, entrambe prendono byte e
+      restituiscono testo senza andare da nessuna parte."""
+
+[[privacy]]
+title = "L'anteprima è la prova."
+body = """
+ L'immagine accanto a ogni
+      risultato è disegnata a partire dal data URI che questa pagina ha appena
+      costruito, non dal tuo file. Compare perché l'URI è corretto, sul tuo
+      dispositivo, senza alcun server di mezzo &mdash; e se non compare, la
+      pagina lo dice invece di consegnarti qualcosa di rotto."""
+
+[[privacy]]
+title = "L'avviso sui metadati è dalla tua parte."
+body = """
+ Un data URI copia il
+      file esattamente, quindi la posizione GPS di una fotografia viaggia dentro
+      il tuo foglio di stile insieme a lei. Questa pagina legge quanta ce n'è e
+      te lo dice, perché l'alternativa è che tu lo scopra a commit fatto."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google, e il pulsante delle
+      donazioni da Buy Me a Coffee. A nessuno di loro viene passato niente sulle
+      tue immagini. Ogni riga che legge o codifica un file è servita da questa
+      origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento resta
+      identico, perché al suo interno non c'è mai stato un passaggio di rete. È
+      la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli le tue immagini."
+body = """
+ Trascinale sul riquadro o
+      selezionale a mano. Il browser le legge direttamente dal tuo disco; mentre
+      lo fai non viene mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Di' dove va a finire il risultato."
+body = """
+ L'URI da solo, una regola
+      CSS, una proprietà personalizzata, un tag <code>&lt;img&gt;</code> o del
+      Markdown. Ognuno di questi mette l'URI tra virgolette, che è il dettaglio
+      che decide se un SVG incorporato funziona o in silenzio non funziona."""
+
+[[howto]]
+title = "Leggi quanto è costato."
+body = """
+ Ogni risultato dice in quanti
+      caratteri si è trasformato, quanto è più grande del file, e se incorporare
+      qualcosa di questa dimensione sia una buona idea. Il base64 aggiunge un
+      terzo; se quel terzo valga una richiesta risparmiata dipende interamente
+      dalla dimensione, quindi la pagina dice da che parte della linea ti
+      trovi."""
+
+[[howto]]
+title = "Guarda gli avvisi."
+body = """
+ Se l'immagine porta con sé EXIF, un
+      profilo colore o XMP, viene nominato insieme a quanti byte del tuo
+      risultato sono quello. Se l'estensione non concorda con il formato vero,
+      la pagina usa il formato e te lo dice. Se il tuo browser non riesce a
+      disegnare il risultato, dice anche questo."""
+
+[[howto]]
+title = "Copia, oppure scarica."
+body = """
+ Un pulsante per ogni risultato, e
+      uno per tutti insieme &mdash; le proprietà personalizzate escono avvolte in
+      un blocco <code>:root</code>, pronte da incollare in cima a un foglio di
+      stile."""
+
+[[faq]]
+q = "La mia immagine viene caricata da qualche parte?"
+a = """
+        No. Il file viene letto e codificato dal tuo browser sul tuo hardware,
+        con due funzioni che il browser ha già. Questo strumento non ha alcuna
+        funzione di rete &mdash; non recupera mai niente e non spedisce mai
+        niente &mdash; e la <code>Content-Security-Policy</code> della pagina
+        nomina tutti gli indirizzi che può contattare, nessuno dei quali
+        appartiene a questo sito."""
+
+[[faq]]
+q = "Cos'è un data URI?"
+a = """
+        Un modo di scrivere un intero file dove di solito andrebbe un indirizzo
+        web. Invece di <code>url("logo.png")</code>, che dice al browser di
+        andare a recuperare qualcosa, scrivi
+        <code>url("data:image/png;base64,iVBORw0...")</code>, che contiene
+        l'immagine stessa. Il browser la decodifica sul posto. L'effetto pratico
+        è una richiesta in meno: l'immagine arriva insieme al foglio di stile o
+        alla pagina invece che dopo."""
+
+[[faq]]
+q = "Perché il mio SVG non è in base64?"
+a = """
+        Perché il base64 è la codifica sbagliata per lui. Un SVG è testo, e un
+        URL sa già portare testo &mdash; solo una manciata di caratteri va
+        protetta. Codificare in percentuale quelli e lasciare stare il resto
+        produce un URI che di solito è un quinto più corto del base64 dello
+        stesso file, e che nel foglio di stile riesci ancora a leggere: i nomi
+        degli elementi, i colori e il <code>viewBox</code> sono tutti ancora lì
+        da modificare. C'è una casella per forzare il base64 per la rara catena
+        di strumenti che ci insiste."""
+
+[[faq]]
+q = "Di quanto ingrandisce la mia immagine il base64?"
+a = """
+        Di circa un terzo. Tre byte di file diventano quattro caratteri di
+        base64, cioè il 33% prima ancora del <code>data:image/png;base64,</code>
+        davanti. È il minimo, ed è inevitabile: è quanto costa scrivere byte
+        arbitrari usando solo i caratteri che un URL consente. È anche il motivo
+        per cui la pagina mostra il numero di caratteri accanto alla dimensione
+        del file, invece di lasciartelo scoprire a foglio di stile
+        pubblicato."""
+
+[[faq]]
+q = "Quando conviene davvero incorporare un'immagine?"
+a = """
+        Quando è piccola e serve subito. Un'icona da 2 KB dentro un foglio di
+        stile che ogni pagina carica è un guadagno netto: un giro in meno, e
+        l'immagine c'è nel momento in cui c'è il CSS. Oltre i 10 KB circa lo
+        scambio si rovescia. Un'immagine incorporata non è più un file a sé,
+        quindi non può stare in cache per conto suo, non può essere recuperata in
+        parallelo con altro, e viene riscaricata per intero ogni volta che cambia
+        il file attorno &mdash; una fotografia da 200 KB in un foglio di stile
+        sono 200 KB aggiunti al percorso critico di ogni pagina del sito. La
+        pagina ti dice da che parte di quella linea cade ogni risultato."""
+
+[[faq]]
+q = "Il gzip annulla il sovrappeso del base64?"
+a = """
+        Meno di quanto si creda. Il base64 di un file già compresso &mdash; e un
+        PNG, un JPEG e un WebP lo sono tutti &mdash; si comprime male, perché non
+        è rimasta quasi nessuna ridondanza da trovare per il compressore; di
+        solito ti torna indietro qualcosa come un decimo di quel terzo che il
+        base64 aveva aggiunto, non tutto. Un SVG codificato in percentuale è il
+        caso opposto: è ancora testo, quindi si comprime più o meno come prima,
+        che è un'altra ragione per non metterlo in base64."""
+
+[[faq]]
+q = "Questo cambia in qualche modo la mia immagine?"
+a = """
+        No, ed è una differenza voluta rispetto a quasi tutti gli strumenti qui.
+        Niente viene decodificato in pixel e ricodificato: i byte che sono usciti
+        dal tuo disco sono i byte che entrano nell'URI. Un JPEG resta esattamente
+        il JPEG che era, alla stessa qualità, con le stesse dimensioni. È il
+        motivo per cui il risultato si può descrivere come lo stesso file e non
+        come una copia."""
+
+[[faq]]
+q = "Quindi anche i miei dati EXIF e GPS finiscono nel foglio di stile?"
+a = """
+        Sì, ed è la parte a cui vale la pena pensare prima di incollare. Siccome
+        non viene ricodificato niente, tutto quello che ha scritto la fotocamera
+        viaggia insieme all'immagine: la posizione, l'orario, il numero di serie
+        della fotocamera. Su una foto da telefono possono essere 30 KB del file,
+        che diventano 40 KB di base64 sul percorso critico della tua pagina, e un
+        indirizzo di casa dentro qualcosa che verrà depositato in un repository.
+        La pagina legge quanti metadati ci sono in un JPEG, un PNG o un WebP e lo
+        dice. Per toglierli prima, usa il
+        <a href="../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>."""
+
+[[faq]]
+q = "Perché ha usato un tipo diverso dall'estensione del mio file?"
+a = """
+        Perché l'estensione può sbagliarsi e i byte no. Un file chiamato
+        <code>logo.png</code> che in realtà era stato esportato come JPEG è
+        abbastanza comune da costringere ogni strumento per immagini a farci i
+        conti, e un data URI che dichiara il tipo sbagliato semplicemente non
+        compare &mdash; non c'è un ripiego e non c'è un messaggio d'errore che
+        valga la pena leggere. Quindi il tipo viene letto dai primi byte del
+        file, che dicono cos'è senza ambiguità in tutti i formati di qui, e la
+        pagina ti dice quando i due non concordano."""
+
+[[faq]]
+q = "L'anteprima è vuota. Cosa è andato storto?"
+a = """
+        Probabilmente niente che riguardi l'URI. HEIC e TIFF producono entrambi
+        data URI perfettamente validi che nessun browser tranne Safari disegna,
+        quindi l'immagine manca anche ovunque tu la incolli &mdash; convertila
+        prima in PNG, JPEG o WebP con il
+        <a href="../comprimere-immagine/">compressore di immagini</a> o il
+        <a href="../ridimensionare-immagine/">ridimensionatore di immagini</a>.
+        Se il formato è uno di quelli comuni, è probabile che il file stesso sia
+        danneggiato: l'anteprima è disegnata a partire dall'URI che questa pagina
+        ha costruito, quindi se è vuota vuol dire che l'immagine non si è
+        decodificata."""
+
+[[faq]]
+q = "C'è un limite di dimensione per un data URI?"
+a = """
+        Non uno in cui incapperai nel CSS o in un tag <code>&lt;img&gt;</code>; i
+        browser moderni non impongono lì alcun tetto pratico. Quello che i
+        browser limitano davvero è scrivere un data URI nella barra degli
+        indirizzi, cosa che quasi tutti ormai rifiutano per qualunque contenuto
+        non banale, per ragioni di sicurezza che non hanno niente a che vedere con
+        questo uso. Il limite vero è quello di sopra: molto prima che si rompa
+        qualcosa di tecnico, la pagina che lo contiene è diventata più lenta di
+        quanto sarebbe stata con un normale file immagine."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Non c'è nemmeno un limite al numero o alla dimensione
+        dei file, perché non c'è un server che li paga &mdash; il lavoro avviene
+        sul tuo dispositivo. Il sito ha della pubblicità, ed è quella che lo
+        paga; agli annunci non viene dato niente sulle tue immagini."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via le tue immagini per
+        codificarle si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Converti un PNG, un JPEG, un SVG, un WebP, una GIF o un ICO in un data URI pronto da incollare nel CSS o nell'HTML. Base64 per i formati raster e codifica in percentuale per l'SVG, avvolti in una regola CSS, una proprietà personalizzata, un tag img o del Markdown, con il costo in dimensione e gli eventuali metadati incorporati riportati. Gira interamente nel browser, senza caricare nulla."
+features = [
+  "Data URI in base64 per PNG, JPEG, WebP, GIF, ICO, AVIF e altri",
+  "Data URI SVG codificati in percentuale, più corti del base64 e ancora leggibili",
+  "Regola CSS, proprietà personalizzata CSS, tag img HTML o Markdown già pronti, sempre con le virgolette giuste",
+  "Il tipo di media letto dai byte del file, non dalla sua estensione",
+  "Dice quanto è costata la codifica in caratteri, e se a quella dimensione convenga incorporare",
+  "Avverte quando EXIF, XMP o un profilo colore stanno per finire nel tuo foglio di stile",
+  "Copia il file byte per byte: nessuna ricodifica e nessuna perdita di qualità",
+  "Lavora a lotti, con tutto copiato o scaricato in un file solo",
+  "Funziona offline; niente caricamenti, nessun account",
+]
+
+[picker]
+title = "Trascina qui le immagini"
+hint = "oppure clicca per scegliere &mdash; PNG, JPEG, SVG, WebP, GIF, ICO e altri"

--- a/locales/it/tools/image-to-ico.html
+++ b/locales/it/tools/image-to-ico.html
@@ -1,0 +1,188 @@
+<main>
+  <!-- Passo 1 &mdash; l'immagine -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli un'immagine</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto dalla lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="shape-note" class="field-summary" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; quale standard -->
+  <section class="card" id="preset-card">
+    <h2><span class="step">2</span> Di' a cosa serve l'icona</h2>
+
+    <p class="card-lede">
+      Un file icona non è un'immagine, sono parecchie: lo stesso logo ridisegnato
+      a ogni dimensione che chiede la cosa che lo legge. Quali siano quelle
+      dimensioni non è questione di gusti &mdash; un browser ne vuole tre,
+      un'applicazione su un portatile ad alta densità ne vuole dieci, un Mac ne
+      vuole dieci sue, e qualcosa scritto prima di Windows Vista le vuole
+      conservate in tutt'altro modo.
+    </p>
+
+    <!--
+      Which files to write. Windows and macOS read different containers and
+      neither will look at the other's, so this is a set of checkboxes rather
+      than a menu: wanting both is the normal case for anything shipped on both.
+    -->
+    <fieldset class="options outputs">
+      <legend>Cosa fare</legend>
+
+      <label class="check">
+        <input type="checkbox" id="want-ico" checked>
+        <span>
+          <strong>Icona Windows &mdash; <code>.ico</code></strong>
+          <span class="check-note">
+            La legge ogni browser come favicon, e la legge Windows per
+            un'applicazione, un collegamento e una cartella. Le dimensioni le
+            scegli tu qui sotto.
+          </span>
+        </span>
+      </label>
+
+      <label class="check">
+        <input type="checkbox" id="want-icns">
+        <span>
+          <strong>Icona macOS &mdash; <code>.icns</code></strong>
+          <span class="check-note">
+            Quello che si porta dietro il bundle di un'applicazione Mac. Apple
+            nomina esattamente dieci slot, da 16 pixel a 1024, quindi non c'è
+            niente da scegliere: ci entrano tutti e dieci, disegnati da sette
+            rese, perché uno slot Retina e la dimensione sopra sono la stessa
+            immagine.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="pack-row">
+        <input type="checkbox" id="want-pack">
+        <span>
+          <strong>Il resto del pacchetto di icone di un sito</strong>
+          <span class="check-note">
+            Un .ico copre la scheda del browser e Windows. Non copre la schermata
+            Home di un iPhone, la richiesta di installazione di Android o una
+            tessera appuntata al menu Start &mdash; quelli leggono un PNG da 180
+            px, un manifest per web app e un file XML, e nessuno di loro va a
+            guardare dentro un .ico. Spunta questa e ottieni anche tutti quelli,
+            il manifest, e il blocco di HTML da incollare nella tua pagina.
+          </span>
+        </span>
+      </label>
+
+      <p id="output-summary" class="field-summary"></p>
+    </fieldset>
+
+    <div id="ico-settings">
+      <div class="presets" id="preset-list" role="radiogroup" aria-label="A cosa serve l'icona"></div>
+
+      <p id="preset-note" class="field-summary"></p>
+
+      <fieldset class="options" id="size-set">
+        <legend>Le dimensioni che entrano nell'.ico</legend>
+        <div class="size-grid" id="size-grid"></div>
+        <p id="size-summary" class="field-summary"></p>
+      </fieldset>
+    </div>
+
+    <fieldset class="options">
+      <legend>Come viene disegnata</legend>
+
+      <div class="option-row">
+        <label for="fit-select">Se l'immagine non è quadrata</label>
+        <select id="fit-select">
+          <option value="pad" selected>Riempi fino a farla quadrata &mdash; l'immagine viene tenuta tutta</option>
+          <option value="crop">Ritaglia il quadrato al centro</option>
+          <option value="stretch">Stirala fino a farla quadrata</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="background-mode">Sfondo</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Trasparente</option>
+          <option value="colour">Un colore</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Colore di sfondo" hidden>
+      </div>
+
+      <div class="option-row" id="storage-row">
+        <label for="storage-select">Come viene conservata ogni dimensione nell'.ico</label>
+        <select id="storage-select">
+          <option value="auto" selected>Automatico &mdash; compatibile quando costa poco, PNG quando non è così</option>
+          <option value="png">PNG per tutte le dimensioni &mdash; file più leggero, richiede Vista o più recente</option>
+          <option value="bmp">Non compresso per tutte le dimensioni &mdash; si apre ovunque, parecchie volte più pesante</option>
+        </select>
+      </div>
+
+      <p id="storage-note" class="field-summary"></p>
+    </fieldset>
+
+  </section>
+
+  <!-- Passo 3 &mdash; guardala piccola, poi prendila -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Controllala alla dimensione a cui verrà vista</h2>
+
+    <p class="card-lede">
+      È la parte che vale la pena guardare prima di scaricare qualunque cosa. Un
+      logo che si legge alla perfezione a 512 pixel, nella scheda di un browser è
+      largo sedici pixel, e le sue parti sottili &mdash; i tratti di un marchio
+      scritto, un bordo da un capello, una sfumatura &mdash; non sopravvivono.
+      Ogni quadrato qui sotto è disegnato alla sua dimensione vera a partire dal
+      file che hai scelto.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-strip" id="preview-strip"></div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make-icon" class="primary big" disabled>Fai l'icona</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Pronta</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Scarica tutto in uno zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+
+      <!--
+        The block to paste into a page's <head>, shown rather than only zipped:
+        most people making a favicon are about to paste this into a template,
+        and a copy button is a shorter route than a download and a text editor.
+      -->
+      <div id="snippet" class="snippet" hidden>
+        <div class="snippet-head">
+          <h4>Incolla questo nel tuo <code>&lt;head&gt;</code></h4>
+          <button type="button" id="copy-snippet" class="ghost">Copia</button>
+        </div>
+        <pre id="snippet-text"></pre>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/image-to-ico.toml
+++ b/locales/it/tools/image-to-ico.toml
@@ -1,0 +1,357 @@
+#
+# Creare una favicon (immagine in ICO) - Italian.
+#
+# Overrides for tools/image-to-ico/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Da immagine a ICO"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Creare&nbsp;una&nbsp;favicon <span class=\"h1-kw\">&mdash; icone per il web, per Windows e per macOS</span>"
+tagline = "Un'immagine dentro. Tutte le dimensioni che chiedono un browser, Windows o un Mac, fuori."
+
+title = "Da immagine a ICO &mdash; favicon, icona per app o ICNS, senza caricare nulla"
+description = "Converti un PNG, un JPEG o un SVG in un vero .ico multidimensione o in un .icns per macOS, nel browser. Favicon, icona per app Windows, icona per app Mac, più i file Apple e Android che serve a un sito. Non viene caricato nulla."
+og_title = "Fare un .ico o un .icns con tutte le dimensioni dentro, senza caricare niente"
+og_description = "Un favicon.ico per un sito, un app.ico per un programma Windows, un .icns per un Mac - con l'anteprima a 16 pixel prima di scaricare. Gira tutto sul tuo dispositivo."
+og_image_alt = "Da immagine a ICO - favicon e icone per Windows e macOS, senza caricare nulla"
+
+pledge = """
+    Il ridimensionamento e i file icona stessi vengono fatti entrambi nel tuo
+    browser. L'immagine viene disegnata dalla tela che il tuo browser si porta
+    già dietro, e ogni contenitore &mdash; l'<code>.ico</code> di Windows,
+    l'<code>.icns</code> di macOS &mdash; viene assemblato a partire da quei
+    pixel da un paio di centinaia di righe in <code>src/ico.js</code> e
+    <code>src/icns.js</code> che puoi leggere. Questo strumento non ha alcuna
+    funzione di rete &mdash; niente da recuperare, niente da spedire &mdash; e
+    dall'altra parte di questa pagina non c'è alcun server a cui mandare un
+    logo, anche se ci fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e fai un'icona. Non una sola richiesta porta con sé
+      un'immagine, una miniatura, un nome di file o un byte di quello che hai
+      scelto. Oppure stacca la connessione e fanne una lo stesso."""
+
+read_first = """
+, <code>src/ico.js</code> e
+      <code>src/icns.js</code> per i due formati di icona &mdash; la directory,
+      le voci e la maschera nel primo, i dieci slot con nome di Apple nel
+      secondo &mdash; e <code>src/sizes.js</code> per l'origine di ogni
+      dimensione che vedi sulla pagina."""
+
+howto_heading = "Come fare un file .ico senza caricare nulla"
+
+card = """
+            Una favicon, un'icona per un'app Windows o un .icns per macOS
+            &mdash; tutte le dimensioni in un file solo, con l'anteprima a 16
+            pixel prima di scaricare."""
+
+[words]
+plural = "immagini"
+choose = "un'immagine"
+analytics_extra = """, e nemmeno una delle
+  dimensioni, dei formati o dei nomi di file che questo strumento calcola"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Il tuo logo non ha dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove i tuoi file potrebbero finire, e nel codice non
+      c'è nulla che ce li manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Non c'è un
+      <code>fetch</code>, né un <code>XMLHttpRequest</code>, né un
+      <code>sendBeacon</code> da nessuna parte in <code>src/</code>. Il
+      ridimensionamento è un <code>drawImage</code> su una tela; ogni icona è
+      un'intestazione scritta davanti a quei pixel da <code>src/ico.js</code> o
+      <code>src/icns.js</code>, in questa pagina."""
+
+[[privacy]]
+title = "Il file viene descritto a partire dai suoi byte."
+body = """
+ L'elenco di dimensioni
+      mostrato accanto a un'icona finita non è l'elenco delle dimensioni che hai
+      chiesto. Viene riletto dal file appena scritto, da
+      <code>readIcoDirectory</code> o <code>readIcnsElements</code>, così se uno
+      scrittore non concordasse mai con le impostazioni la pagina lo direbbe,
+      invece di fartelo scoprire quando Windows non disegna niente e macOS
+      disegna un foglio bianco."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google, e il pulsante delle
+      donazioni da Buy Me a Coffee. A nessuno di loro viene passato niente sulla
+      tua immagine. Ogni riga che legge, ridimensiona o scrive un file è servita
+      da questa origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento resta
+      identico, perché al suo interno non c'è mai stato un passaggio di rete. È
+      la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli l'immagine."
+body = """
+ Trascina sul riquadro un PNG, un JPEG,
+      un WebP o un SVG, oppure scegline parecchi e convertili in un colpo solo.
+      Quadrata è la cosa più facile, e qualunque immagine da 256 pixel in su ha
+      abbastanza dettaglio per tutte le dimensioni. Il browser la legge
+      direttamente dal tuo disco; mentre lo fai non viene mandato niente da
+      nessuna parte."""
+
+[[howto]]
+title = "Scegli i file che ti servono."
+body = """
+ Windows e un browser leggono
+      l'<code>.ico</code>; un Mac legge l'<code>.icns</code> e l'altro non lo
+      guarda nemmeno. Spunta uno dei due, o entrambi se la cosa che stai facendo
+      esce su tutti e due. Un sito web vuole anche le immagini in più per Apple,
+      Android e le tessere, ed è la terza casella."""
+
+[[howto]]
+title = "Di' a cosa serve l'icona."
+body = """
+ Una favicon per un sito è 16, 32 e
+      48 pixel; un'applicazione Windows vuole anche 256; un'applicazione che deve
+      venir bene su un portatile ad alta densità vuole le dimensioni intermedie
+      che Windows chiede al 125% e al 150%. Scegli quella che corrisponde al
+      lavoro, oppure spunta tu le dimensioni. Ogni dimensione dell'elenco dice chi
+      la chiede. L'<code>.icns</code> non ha questa scelta: Apple nomina
+      esattamente dieci slot e ci entrano tutti e dieci."""
+
+[[howto]]
+title = "Sistema la forma e lo sfondo."
+body = """
+ Un'icona è quadrata e quasi tutti i
+      loghi non lo sono. Con il riempimento tutta l'immagine viene tenuta, con
+      dello spazio sopra e sotto; con il ritaglio viene preso il centro; con lo
+      stiramento viene schiacciata. La trasparenza resta trasparenza, a meno che
+      tu non scelga un colore da metterci dietro."""
+
+[[howto]]
+title = "Guarda quella da 16 pixel prima di scaricare."
+body = """
+ È la dimensione a cui
+      l'icona verrà vista più spesso, ed è dove i tratti sottili e le scritte
+      piccole spariscono. Ogni quadrato dell'anteprima è disegnato alla sua
+      dimensione vera a partire dal tuo file. Se la più piccola è una macchia, la
+      soluzione è un disegno più semplice, non un'impostazione diversa."""
+
+[[howto]]
+title = "Prendi i file."
+body = """
+ Un .ico con tutte le dimensioni dentro,
+      chiamato <code>favicon.ico</code> quando è quello che hai chiesto, perché
+      è l'indirizzo che i browser vanno a cercare. Un .icns accanto se hai
+      spuntato quello, pronto da mettere nel bundle di un'applicazione Mac.
+      Spunta anche il pacchetto per il sito e ottieni pure le immagini Apple,
+      Android e la tessera di Windows, il manifest e il blocco di HTML da
+      incollare nella tua pagina. Qualunque cosa più di un file singolo scende
+      come un unico zip."""
+
+[[faq]]
+q = "La mia immagine viene caricata da qualche parte?"
+a = """
+        No. L'immagine viene decodificata e ridimensionata dal tuo browser sul
+        tuo hardware, e l'.ico viene assemblato a partire da quei pixel da codice
+        servito da questa pagina. Questo strumento non ha alcuna funzione di rete
+        &mdash; non recupera mai niente e non spedisce mai niente &mdash; e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare, nessuno dei quali appartiene a questo
+        sito."""
+
+[[faq]]
+q = "Quali dimensioni dovrebbe contenere un favicon.ico?"
+a = """
+        16, 32 e 48. Non è una preferenza: 16 è quello che un browser disegna in
+        una scheda, 32 è quello che Windows usa per un collegamento sul desktop e
+        che parecchi browser usano per un segnalibro, e 48 è la dimensione a cui
+        Google legge l'icona di un sito. Tutto quello che è più grande sta in un
+        PNG accanto all'.ico e non dentro &mdash; che è quello che produce qui il
+        pacchetto per il sito."""
+
+[[faq]]
+q = "Di quali dimensioni ha bisogno l'icona di un'applicazione Windows?"
+a = """
+        16, 32, 48 e 256, che è quello che contiene l'app.ico predefinito di
+        Visual Studio. 16 è la barra del titolo e la vista piccola di Esplora
+        risorse, 32 il desktop e la barra delle applicazioni, 48 le icone medie di
+        Esplora risorse, e 256 il menu Start e la vista extra large. Su uno
+        schermo ad alta densità Windows chiede anche 20, 24, 40, 64 e 96, e se non
+        ci sono le ricava dalla dimensione più vicina che ha &mdash; il valore
+        pronto «tutte le scale» le mette dentro."""
+
+[[faq]]
+q = "Perché il file è più pesante dell'immagine da cui sono partito?"
+a = """
+        Perché un .ico non è un'immagine, sono parecchie, e le piccole vengono
+        conservate non compresse perché possa leggerle chiunque. Una voce 32x32
+        pesa esattamente 4.264 byte qualunque cosa contenga, e una voce 256x256
+        non compressa pesa 264 KB &mdash; ed è per questo che le dimensioni sopra
+        i 64 vengono conservate come PNG di default. Scegliere «PNG per tutte le
+        dimensioni» fa il file più leggero possibile; scegliere non compresso per
+        tutte fa quello più compatibile."""
+
+[[faq]]
+q = "Che differenza c'è tra le voci PNG e quelle non compresse?"
+a = """
+        Solo come i pixel vengono conservati dentro l'.ico. Una voce non compressa
+        è la disposizione Windows originale &mdash; un'intestazione bitmap, i
+        pixel a testa in giù, e una maschera di trasparenza a un bit &mdash; e
+        sanno leggerla tutte le versioni di Windows mai uscite. Una voce PNG è un
+        intero file PNG infilato dentro l'icona, che alle dimensioni grandi è da
+        tre a dieci volte più leggero ma è stato capito solo da Windows Vista in
+        poi. Il default usa ciascuna dove vince: non compressa fino a 64 pixel,
+        PNG sopra."""
+
+[[faq]]
+q = "Può fare un'icona più grande di 256 pixel?"
+a = """
+        No, e non può nessuno. Il formato conserva ogni lato in un byte solo, e lo
+        0 è già preso &mdash; vuol dire 256. Quello è il tetto, quindi un .ico che
+        contiene un'immagine da 512 pixel non è un'icona più grande, è un'icona
+        rotta. Se ti servono 512, ti serve un PNG, ed è quello che il pacchetto
+        per il sito include per Android e per la schermata di avvio di una web
+        app."""
+
+[[faq]]
+q = "Conserva la trasparenza?"
+a = """
+        Sì, in entrambi i tipi di voce, e scrive anche la vecchia maschera a un bit
+        accanto al canale alfa, così il software troppo vecchio per leggere l'alfa
+        ritaglia comunque l'icona invece di disegnare un rettangolo nero. L'unico
+        file reso opaco di proposito è l'icona Apple touch del pacchetto per il
+        sito: iOS la sovrappone alla propria tessera e trasforma la trasparenza in
+        nero, quindi viene appiattita sul tuo colore di sfondo, bianco di
+        default."""
+
+[[faq]]
+q = "Il mio logo è un marchio scritto e largo. Cosa gli succede?"
+a = """
+        Qualcosa deve succedergli, perché un'icona è quadrata. Il riempimento
+        tiene tutto e lo rende piccolo &mdash; un marchio scritto riempito dentro
+        un quadrato da 16 pixel è alto tre pixel ed è illeggibile. Ritagliare il
+        centro di solito funziona meglio: prendi il simbolo dal blocco e usa
+        quello, come fa quasi ogni marchio per la propria favicon. L'anteprima ti
+        mostra quale dei due sopravvive prima che tu scarichi qualcosa."""
+
+[[faq]]
+q = "Cosa c'è nel pacchetto per il sito, e mi serve tutto?"
+a = """
+        Sette PNG, un manifest per web app, un browserconfig.xml e un blocco di
+        HTML da incollare. Ti servono perché un .ico copre i browser e Windows e
+        nient'altro: la schermata Home di un iPhone legge un PNG da 180 pixel con
+        un nome tutto suo, Android e ogni richiesta di installazione leggono il
+        manifest, e una tessera appuntata al menu Start legge l'XML. Nessuno di
+        questi va a guardare dentro un .ico. Viene generato tutto qui, sul tuo
+        dispositivo, e nello zip c'è una nota che dice a cosa serve ogni file."""
+
+[[faq]]
+q = "Può fare anche un'icona per macOS?"
+a = """
+        Sì &mdash; spunta <em>icona macOS</em> e ottieni un <code>.icns</code>
+        accanto all'<code>.ico</code>, o al posto suo. È un contenitore diverso
+        per la stessa idea, e nessuno dei due sistemi legge quello dell'altro:
+        Windows vuole .ico e il bundle di un'applicazione Mac vuole .icns. Lì le
+        dimensioni non sono una scelta, perché Apple pubblica esattamente dieci
+        slot &mdash; 16, 32, 64, 128, 256, 512 e 1024 pixel, con tre di questi che
+        compaiono due volte come versione Retina della dimensione sotto. Ci
+        entrano tutti e dieci, disegnati da sette rese, ed è per questo che un
+        .icns è il file più pesante."""
+
+[[faq]]
+q = "Come si usa il file .icns?"
+a = """
+        Per un'applicazione, va nel bundle in
+        <code>TuaApp.app/Contents/Resources/</code> e va nominato in
+        <code>Info.plist</code> sotto <code>CFBundleIconFile</code>; ogni
+        strumento di impacchettamento per Mac ha un campo apposta. Per tutto il
+        resto, seleziona il file nel Finder, premi Comando-C, poi apri Ottieni
+        informazioni sulla cartella o sull'immagine disco che vuoi cambiare,
+        clicca la piccola icona in alto a sinistra e premi Comando-V."""
+
+[[faq]]
+q = "L'.icns è uguale a quello che fa iconutil?"
+a = """
+        Gli stessi dieci slot con gli stessi tipi da quattro lettere, e un PNG in
+        ognuno, che è quello che <code>iconutil</code> produce da una cartella
+        <code>.iconset</code>. Una differenza voluta: lo strumento di Apple scrive
+        anche un elemento <code>TOC&nbsp;</code>, un indice dei tipi e delle
+        lunghezze che seguono. È un'ottimizzazione e non una parte del formato
+        &mdash; un lettore che non ce l'ha percorre gli elementi da un capo
+        all'altro e arriva alla stessa risposta &mdash; e un indice sbagliato è
+        peggio di nessun indice, quindi viene lasciato fuori."""
+
+[[faq]]
+q = "Posso convertire più immagini insieme?"
+a = """
+        Sì. Ogni immagine dell'elenco diventa il proprio .ico con le stesse
+        impostazioni, e il lotto scende come un unico zip con una cartella per
+        immagine &mdash; altrimenti due di loro si chiamerebbero entrambe
+        favicon.ico e una sovrascriverebbe l'altra. Ogni uscita che hai spuntato
+        viene fatta per ogni immagine. Clicca una riga qualsiasi per mettere
+        quell'immagine nell'anteprima."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Non c'è nemmeno un limite al numero o alla dimensione
+        dei file, perché non c'è un server che li paga &mdash; il lavoro avviene
+        sul tuo dispositivo. Il sito ha della pubblicità, ed è quella che lo
+        paga; agli annunci non viene dato niente sulle tue immagini."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via il tuo logo per
+        convertirlo si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Converti un'immagine in un file ICO multidimensione per Windows o in un file ICNS per macOS, nel browser. Valori pronti per la favicon di un sito, per l'icona di un'applicazione Windows e per un'icona ad alta densità, i dieci slot icns di Apple, l'anteprima di ogni dimensione alla sua dimensione reale in pixel, e un pacchetto facoltativo con i file Apple, Android e la tessera Windows che servono a un sito. Non viene caricato nulla."
+features = [
+  "Scrive un vero .ico multidimensione, da 16 a 256 pixel",
+  "Scrive un .icns per macOS con tutti e dieci gli slot di Apple, da 16 a 1024 pixel",
+  "Entrambi i formati da un'immagine sola, in un passaggio solo, con ogni dimensione disegnata una volta sola",
+  "Valori pronti per la favicon di un sito, l'icona di un'app Windows, Windows ad alta densità e la massima compatibilità",
+  "Ogni dimensione dice chi la chiede, così non entra niente senza motivo",
+  "Voci non compresse per le dimensioni piccole e PNG per quelle grandi, o tutte dell'uno o dell'altro tipo",
+  "Conserva la trasparenza, e scrive anche la maschera di trasparenza pre-Vista",
+  "Riempi, ritaglia o stira un'immagine che non è quadrata, su un colore o su niente",
+  "Mostra ogni dimensione alla sua dimensione reale in pixel prima che tu scarichi",
+  "Pacchetto facoltativo per il sito: icona Apple touch, icone Android, icona maskable, tessera Windows, manifest e l'HTML da incollare",
+  "Lavora a lotti, con tutti i risultati in un unico zip",
+  "Funziona offline; niente caricamenti, nessun account",
+]
+
+[picker]
+title = "Trascina qui un'immagine"
+hint = "oppure clicca per scegliere &mdash; PNG, SVG, JPEG, WebP e qualunque altra cosa il tuo browser sappia aprire"

--- a/locales/it/tools/images-to-pdf.html
+++ b/locales/it/tools/images-to-pdf.html
@@ -1,0 +1,230 @@
+<main>
+  <!-- Passo 1 &mdash; le immagini -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli le immagini</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" data-sort="name" class="ghost">Ordina per nome</button>
+        <button type="button" data-sort="date" class="ghost">Ordina per data</button>
+        <button type="button" data-sort="reverse" class="ghost">Inverti</button>
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Un'immagine per pagina, in quest'ordine. Trascina per la maniglia
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> per spostare una pagina,
+      oppure usa le frecce che ci sono sopra.
+    </p>
+
+    <ul id="image-list" class="image-list"></ul>
+  </section>
+
+  <!-- Passo 2 &mdash; le pagine -->
+  <section class="card">
+    <h2><span class="step">2</span> Impostazione della pagina</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Dimensione della pagina</label>
+        <select id="page-size">
+          <option value="fit" selected>Adatta la pagina a ogni immagine</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 in</option>
+          <option value="a3">A3 &mdash; 297 &times; 420 mm</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+          <option value="tabloid">Tabloid &mdash; 11 &times; 17 in</option>
+          <option value="custom">Personalizzata&hellip;</option>
+        </select>
+        <div id="custom-size" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="1" max="5000" step="1" value="210"
+                 aria-label="Larghezza personalizzata della pagina">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="1" max="5000" step="1" value="297"
+                 aria-label="Altezza personalizzata della pagina">
+          <select id="custom-unit" aria-label="Unità per la dimensione personalizzata della pagina">
+            <option value="mm" selected>mm</option>
+            <option value="in">in</option>
+          </select>
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Risoluzione di stampa</label>
+        <select id="dpi">
+          <option value="72">72 DPI &mdash; schermo</option>
+          <option value="96">96 DPI</option>
+          <option value="150" selected>150 DPI</option>
+          <option value="200">200 DPI</option>
+          <option value="300">300 DPI &mdash; stampa</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Decide quanto è grande una pagina per un dato numero di pixel. Non
+          cambia l'immagine.
+        </p>
+      </div>
+
+      <div class="field" id="orientation-field" hidden>
+        <label for="orientation">Orientamento</label>
+        <select id="orientation">
+          <option value="auto" selected>Segui ogni immagine</option>
+          <option value="portrait">Verticale</option>
+          <option value="landscape">Orizzontale</option>
+        </select>
+      </div>
+
+      <div class="field" id="fit-field" hidden>
+        <label for="fit">Come sta l'immagine sulla pagina</label>
+        <select id="fit">
+          <option value="contain" selected>Dentro i margini</option>
+          <option value="cover">Riempi la pagina (ritaglia i bordi)</option>
+          <option value="stretch">Stira fino ai margini (deforma)</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="margin">Margine</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="100" step="1" value="0"
+                 aria-label="Margine in millimetri">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="background">Colore della pagina</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Si vede nei margini, e dietro tutto quello che è trasparente.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="mode">Qualità delle immagini</label>
+        <select id="mode">
+          <option value="keep" selected>Tieni i JPEG esattamente come sono</option>
+          <option value="jpeg">Ricodifica tutto come JPEG</option>
+          <option value="lossless">Senza perdita &mdash; nessuna perdita di compressione</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualità JPEG</label>
+        <select id="quality">
+          <option value="0.75">File più leggero</option>
+          <option value="0.88" selected>Equilibrata</option>
+          <option value="0.95">Massima qualità</option>
+        </select>
+        <p class="field-note">Usata solo per le immagini che questo strumento deve ricodificare.</p>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Rimpicciolisci le immagini grandi</label>
+        <select id="max-side">
+          <option value="0" selected>Mai &mdash; tieni la dimensione piena</option>
+          <option value="4000">Lato più lungo 4000 px</option>
+          <option value="2000">Lato più lungo 2000 px</option>
+          <option value="1200">Lato più lungo 1200 px</option>
+        </select>
+        <p class="field-note" id="shrink-note"></p>
+      </div>
+    </div>
+
+    <details class="meta-panel">
+      <summary>Dettagli del documento &mdash; tutti facoltativi, tutti vuoti di default</summary>
+      <div class="meta-body">
+        <p class="meta-note">
+          Un PDF porta con sé un piccolo blocco di informazioni su sé stesso, e
+          quasi tutti gli strumenti lo riempiono con un orario e il nome di un
+          programma che tu l'abbia chiesto o no. Questo scrive quello che digiti
+          qui e nient'altro: nessun nome di file, nessun nome di dispositivo, e
+          nessuna data se non spunti la casella.
+        </p>
+        <div class="settings">
+          <div class="field">
+            <label for="doc-title">Titolo</label>
+            <input type="text" id="doc-title" maxlength="200" spellcheck="false"
+                   placeholder="Lasciato fuori se vuoto">
+          </div>
+          <div class="field">
+            <label for="doc-author">Autore</label>
+            <input type="text" id="doc-author" maxlength="200" spellcheck="false"
+                   placeholder="Lasciato fuori se vuoto">
+          </div>
+          <div class="field">
+            <label for="file-name">Nome del file</label>
+            <div class="inline-pair">
+              <input type="text" id="file-name" maxlength="120" spellcheck="false"
+                     value="immagini">
+              <span class="unit-label">.pdf</span>
+            </div>
+          </div>
+          <div class="field checkbox-field">
+            <label for="dated">
+              <input type="checkbox" id="dated">
+              Registra la data di oggi nel documento
+            </label>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="480" height="640" aria-label="Anteprima di una pagina"></canvas>
+        <p id="preview-empty" class="preview-empty">Aggiungi delle immagini per vedere le pagine</p>
+        <div id="preview-nav" class="preview-nav" hidden>
+          <button type="button" id="preview-prev" class="ghost" aria-label="Pagina precedente">&lsaquo;</button>
+          <span id="preview-label" class="preview-label"></span>
+          <button type="button" id="preview-next" class="ghost" aria-label="Pagina successiva">&rsaquo;</button>
+        </div>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Pagine</dt><dd id="sum-pages">&mdash;</dd></div>
+        <div><dt>Dimensione della pagina</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Immagini scelte</dt><dd id="sum-input">&mdash;</dd></div>
+        <div><dt>Copiate intatte</dt><dd id="sum-copied">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; l'esportazione -->
+  <section class="card">
+    <h2><span class="step">3</span> Crea il PDF</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Crea il PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Scarica il PDF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/images-to-pdf.toml
+++ b/locales/it/tools/images-to-pdf.toml
@@ -1,0 +1,237 @@
+#
+# Immagini in PDF - Italian.
+#
+# Overrides for tools/images-to-pdf/tool.toml. Only words: the slug, the
+# category, the icon and the list of shared parts stay where they are.
+#
+
+name = "Immagini in PDF"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Immagini&nbsp;in&nbsp;PDF <span class=\"h1-kw\">&mdash; convertitore da JPG a PDF</span>"
+tagline = "Metti le tue foto dentro un documento solo."
+
+title = "Convertitore da immagini a PDF &mdash; da JPG a PDF, gratis, senza caricare nulla"
+description = "Unisci immagini JPG, PNG o WebP in un unico PDF, gratis e interamente nel tuo browser. Le foto entrano senza essere ricodificate, e non viene caricato nulla."
+og_title = "Immagini in PDF &mdash; convertitore gratuito da JPG a PDF"
+og_description = "Unisci immagini in un unico PDF sul tuo dispositivo. Le foto JPEG vengono copiate dentro intatte, quindi non si perde qualità e non viene caricato nulla."
+og_image_alt = "Immagini in PDF - unire immagini in un documento senza caricarle"
+
+pledge = """
+    Il documento viene scritto in memoria su questo dispositivo, una pagina alla
+    volta, da codice servito da questo indirizzo. Qui dentro non c'è niente in
+    grado di fare un caricamento, e dall'altra parte di questa pagina non c'è
+    alcun server che potrebbe riceverlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e fai un PDF. Non una sola richiesta porta con sé un'immagine,
+      una miniatura o un nome di file. Oppure stacca la connessione e fanne uno
+      lo stesso."""
+
+read_first = """
+, e <code>src/pdf.js</code> e <code>src/document.js</code>
+      per tutta la scrittura del file, che non tocca mai la rete."""
+
+howto_heading = "Come trasformare delle immagini in un PDF"
+
+card = """
+            Unisci immagini in un unico PDF, un'immagine per pagina. Le foto
+            JPEG vengono copiate dentro esattamente come sono, quindi non si
+            perde qualità."""
+
+[words]
+plural = "immagini"
+choose = "delle immagini"
+analytics_extra = """"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "I file restano sul tuo dispositivo"
+
+[[privacy]]
+title = "Le tue immagini non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Questo strumento
+      non aggiunge niente a quella lista: non ha una funzione di rete propria,
+      nemmeno facoltativa. Qui non esiste un punto di raccolta dove i tuoi file
+      potrebbero finire, e nel codice non c'è nulla che ce li manderebbe se
+      esistesse."""
+
+[[privacy]]
+title = "Il PDF viene scritto qui."
+body = """
+ Un PDF è un elenco di oggetti e una tabella
+      che dice dove comincia ciascuno, e <code>src/pdf.js</code> scrive
+      entrambi. Non viene scaricata alcuna libreria, non viene disegnato niente
+      su un server, e il file finito viene consegnato direttamente a un download
+      dalla memoria."""
+
+[[privacy]]
+title = "Al documento non viene detto niente su di te."
+body = """
+ Quasi tutti gli
+      strumenti timbrano un PDF con un orario e il nome del programma che l'ha
+      fatto. Questo scrive un titolo, un autore e una data solo se li digiti tu;
+      i nomi dei file delle tue immagini non compaiono mai nel documento, e non
+      ci compare niente sul tuo dispositivo."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google. A nessuno dei due viene
+      passato niente sulle tue immagini: né un file, né una miniatura, né un
+      nome, una dimensione o un conteggio. Ogni riga che legge, decodifica o
+      scrive un'immagine è servita da questa origine ed è elencata nel
+      repository."""
+
+[[privacy]]
+title = "Cosa carica il pulsante delle donazioni, e cosa non gli viene dato."
+body = """
+
+      Il pulsante «Buy me a coffee» in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non riferisce alcuna visita, e non gli viene passato niente
+      su di te o sulle tue immagini. Non succede nulla finché non ci clicchi, e
+      quello a cui arriveresti è il sito di qualcun altro."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e tutto quello che sta su questa
+      pagina continua a funzionare. È la prova più semplice di tutte: uno
+      strumento che spedisse via le tue foto per farne un documento si
+      fermerebbe."""
+
+[[howto]]
+title = "Scegli le tue immagini."
+body = """
+ Trascina una cartella sul riquadro,
+      oppure seleziona i file a mano. Il browser li legge direttamente dal tuo
+      disco; mentre lo fai non viene mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Metti le pagine in ordine, e gira quelle che ne hanno bisogno."
+body = """
+ Un'immagine
+      diventa una pagina, nell'ordine che vedi. Trascina una tessera per la sua
+      maniglia per spostarla, oppure usa le frecce; i pulsanti di rotazione
+      girano una pagina di un quarto alla volta, che è quello che di solito
+      serve a una scansione storta."""
+
+[[howto]]
+title = "Scegli una dimensione di pagina."
+body = """
+ «Adatta la pagina a ogni
+      immagine» rende ogni pagina esattamente la sua immagine, senza niente di
+      ritagliato e senza bande bianche. Le dimensioni con un nome &mdash; A4,
+      Letter, Legal e le altre &mdash; mettono invece ogni immagine su una
+      pagina fissa, con un margine se ne vuoi uno."""
+
+[[howto]]
+title = "Crea il PDF e scaricalo."
+body = """
+ Il documento viene scritto sul tuo
+      dispositivo, quindi quanto ci mette dipende dal tuo hardware e non da una
+      coda. Il file finito viene consegnato direttamente ai download del tuo
+      browser."""
+
+[[faq]]
+q = "Le mie immagini vengono caricate da qualche parte?"
+a = """
+        No. Le tue immagini vengono lette e il PDF viene scritto dal tuo browser
+        sul tuo hardware. Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare &mdash; nessuno di questi appartiene a
+        questo sito. A differenza di qualche altro strumento di qui, questo non
+        ha proprio alcuna funzione di rete facoltativa."""
+
+[[faq]]
+q = "Convertire in PDF fa perdere qualità?"
+a = """
+        Non per un JPEG, con l'impostazione predefinita. Il PDF sa portare
+        direttamente i dati JPEG, quindi una fotografia viene copiata nel
+        documento byte per byte: non viene mai decodificata e non viene mai
+        ricompressa, e l'immagine nel PDF è l'immagine nel file. Gli altri
+        formati vanno ricodificati, perché il PDF non ha un filtro per loro
+        &mdash; a meno che tu non scelga l'impostazione senza perdita, che li
+        conserva esattamente al prezzo di un file più pesante."""
+
+[[faq]]
+q = "Quali formati di immagine posso usare?"
+a = """
+        Qualunque immagine ferma che il tuo browser sappia decodificare, il che
+        in pratica vuol dire JPG, PNG, WebP, GIF, AVIF e, sui dispositivi Apple,
+        HEIC. Qui non c'è un elenco a parte da tenere aggiornato, perché la
+        decodifica è compito del browser e non nostro."""
+
+[[faq]]
+q = "Posso scegliere la dimensione della pagina e l'ordine delle pagine?"
+a = """
+        Sì. Le pagine possono essere A4, Letter, Legal, A3, A5, Tabloid, una
+        dimensione che scrivi tu, o esattamente la dimensione di ogni immagine.
+        Trascina le tessere per riordinarle, ordinale per nome o per data,
+        ruotane una qualsiasi di un quarto di giro, e imposta un margine in
+        millimetri."""
+
+[[faq]]
+q = "Quante immagini posso mettere in un PDF?"
+a = """
+        Nello strumento non c'è alcun limite. Il tetto pratico è la memoria del
+        tuo dispositivo, perché il documento finito viene assemblato lì prima che
+        tu lo scarichi. Qualche centinaio di foto da telefono a piena risoluzione
+        è la prima cosa a sentirlo; rimpicciolire il lato più lungo, nelle
+        impostazioni, sposta quel tetto parecchio più in là."""
+
+[[faq]]
+q = "Il PDF contiene i nomi dei miei file o un orario?"
+a = """
+        No, a meno che tu non lo chieda. Il blocco di informazioni del documento
+        è lasciato vuoto tranne che per il nome di questo strumento: nessun nome
+        di file, nessun nome di dispositivo, nessun nome utente, e nessuna data
+        di creazione se non spunti la casella apposta. È voluto &mdash; un PDF è
+        una cosa che le persone mandano ad altre persone."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso e non c'è periodo di prova.
+        Il sito ha della pubblicità, ed è quella che lo paga; agli annunci non
+        viene dato niente sulle tue immagini."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via le tue immagini per farne
+        un documento si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Unisci immagini JPG, PNG e WebP in un unico documento PDF. Ogni pagina viene scritta nel tuo browser, quindi nessuna immagine viene mai caricata."
+features = [
+  "Unisce immagini JPG, PNG, WebP, GIF e AVIF in un unico PDF",
+  "Le foto JPEG vengono incorporate senza essere ricodificate",
+  "Dimensioni di pagina da A5 a Tabloid, o una pagina adattata a ogni immagine",
+  "Riordina, ruota, imposta i margini e un colore di pagina",
+  "Conservazione senza perdita facoltativa per scansioni e screenshot",
+  "Funziona offline; niente caricamenti, nessun account",
+]
+
+[picker]
+title = "Trascina qui le immagini"
+hint = "oppure clicca per scegliere &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/it/tools/images-to-video.html
+++ b/locales/it/tools/images-to-video.html
@@ -1,0 +1,167 @@
+<main>
+  <!-- Passo 1 &mdash; le immagini -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli le immagini</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    {% include "partials/url-import.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Cambia come viene mostrata la lista">
+          <button type="button" data-view="large" class="active">Grandi</button>
+          <button type="button" data-view="small">Piccole</button>
+          <button type="button" data-view="list">Elenco</button>
+          <button type="button" data-view="details">Dettagli</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Ordina per nome</button>
+        <button type="button" data-sort="date" class="ghost">Ordina per data</button>
+        <button type="button" data-sort="reverse" class="ghost">Inverti</button>
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Trascina un'immagine qualsiasi per la sua maniglia
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> per riordinare, oppure usa
+      le frecce su ciascuna.
+    </p>
+
+    <ul id="image-list" class="image-list view-large"></ul>
+
+    <div id="bulk-duration" class="bulk" hidden>
+      <label for="bulk-amount">Tieni ogni immagine per</label>
+      <input type="number" id="bulk-amount" min="1" max="3600" step="1" value="1">
+      <select id="duration-unit" aria-label="Unità per quanto viene tenuta ogni immagine">
+        <option value="frames" selected>fotogrammi</option>
+        <option value="seconds">secondi</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Applica a tutte</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Passo 2 &mdash; le impostazioni -->
+  <section class="card">
+    <h2><span class="step">2</span> Impostazioni del video</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="resolution">Risoluzione</label>
+        <select id="resolution">
+          <option value="auto" selected>Segui la risoluzione più alta</option>
+          <option value="3840x2160">3840 &times; 2160 &mdash; 4K</option>
+          <option value="1920x1080">1920 &times; 1080 &mdash; 1080p</option>
+          <option value="1280x720">1280 &times; 720 &mdash; 720p</option>
+          <option value="1080x1080">1080 &times; 1080 &mdash; quadrato</option>
+          <option value="1080x1920">1080 &times; 1920 &mdash; verticale</option>
+          <option value="custom">Personalizzata&hellip;</option>
+        </select>
+        <div id="resolution-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="7680" step="2" value="1920"
+                 aria-label="Larghezza personalizzata in uscita, in pixel">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="7680" step="2" value="1080"
+                 aria-label="Altezza personalizzata in uscita, in pixel">
+        </div>
+        <p class="field-note" id="resolution-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Frequenza dei fotogrammi</label>
+        <select id="fps">
+          <option value="12">12 fps</option>
+          <option value="15">15 fps</option>
+          <option value="24">24 fps &mdash; cinema</option>
+          <option value="25">25 fps &mdash; PAL</option>
+          <option value="30" selected>30 fps</option>
+          <option value="50">50 fps</option>
+          <option value="60">60 fps</option>
+          <option value="custom">Personalizzata&hellip;</option>
+        </select>
+        <input type="number" id="fps-custom" class="spaced" min="1" max="120" step="1" value="30"
+               aria-label="Frequenza personalizzata, in fotogrammi al secondo" hidden>
+        <p class="field-note" id="fps-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Adattamento dell'immagine</label>
+        <select id="fit">
+          <option value="contain" selected>Dentro il riquadro (bande nere)</option>
+          <option value="blur">Dentro il riquadro, sfondo sfocato</option>
+          <option value="cover">Riempi il fotogramma (ritaglia i bordi)</option>
+          <option value="stretch">Stira per riempire (deforma)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Colore dello sfondo</label>
+        <input type="color" id="background" value="#000000">
+      </div>
+
+      <div class="field">
+        <label for="quality">Qualità</label>
+        <select id="quality">
+          <option value="low">File più leggero</option>
+          <option value="medium" selected>Equilibrata</option>
+          <option value="high">Massima qualità</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="auto" selected>MP4 (consigliato)</option>
+          <option value="webm">WebM (ripiego)</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="640" height="360" aria-label="Anteprima del primo fotogramma"></canvas>
+        <p id="preview-empty" class="preview-empty">Aggiungi delle immagini per vedere un'anteprima</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Immagini</dt><dd id="sum-images">&mdash;</dd></div>
+        <div><dt>Durata</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Dimensione in uscita</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Fotogrammi totali</dt><dd id="sum-frames">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; l'esportazione -->
+  <section class="card">
+    <h2><span class="step">3</span> Crea il video</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Crea il video</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Scarica il video</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/images-to-video.toml
+++ b/locales/it/tools/images-to-video.toml
@@ -1,0 +1,248 @@
+#
+# Immagini in video - Italian.
+#
+# Overrides for tools/images-to-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Immagini in video"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Immagini&nbsp;in&nbsp;video <span class=\"h1-kw\">&mdash; fare una presentazione in MP4</span>"
+tagline = "Trasforma una cartella di immagini in un video."
+
+title = "Da sequenza di immagini a MP4 &mdash; gratis, senza caricare nulla, anche offline"
+description = "Trasforma immagini JPG, PNG o WebP in un video MP4, gratis e interamente nel tuo browser. Non viene caricato nulla, non serve iscriversi, e funziona offline."
+og_title = "Da sequenza di immagini a MP4 &mdash; gratis, nel tuo browser"
+og_description = "Trasforma una sequenza di render, un timelapse o una cartella di foto in un MP4. La codifica gira sul tuo dispositivo; non viene caricato nulla."
+og_image_alt = "Immagini in video - trasformare una cartella di immagini in una presentazione MP4"
+
+pledge = """
+    Ogni fotogramma viene codificato dal tuo browser e il video viene costruito
+    in memoria su questo dispositivo. L'encoder non tocca mai la rete, e
+    dall'altra parte di questa pagina non c'è alcun server a cui mandare
+    un'immagine, anche se la toccasse."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e fai un video. Non una sola richiesta porta con sé
+      un'immagine, una miniatura o un nome di file. Oppure stacca la connessione
+      e fanne uno lo stesso."""
+
+read_first = """
+, e <code>src/encoder.js</code> per il ciclo di codifica
+      che non tocca mai la rete."""
+
+howto_heading = "Come trasformare delle immagini in un video"
+
+card = """
+            Trasforma una cartella di immagini in una presentazione MP4. La
+            codifica gira sul tuo dispositivo, usando il tuo hardware."""
+
+[words]
+plural = "immagini"
+choose = "delle immagini"
+analytics_extra = """"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "I file restano sul tuo dispositivo"
+
+[[privacy]]
+title = "Le tue immagini non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove i tuoi file potrebbero finire, e nel codice non
+      c'è nulla che ce li manderebbe se esistesse. Prima qui c'era scritto
+      <code>connect-src 'none'</code>, che era assoluto; aggiungere la
+      pubblicità è costato quello, e dirlo fa parte del patto."""
+
+[[privacy]]
+title = "La codifica è locale."
+body = """
+ WebCodecs gira nel tuo browser e il file finito
+      viene consegnato direttamente a un download. Questa applicazione non ha un
+      lato server."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google. A nessuno dei due viene
+      passato niente sulle tue immagini: né un file, né una miniatura, né un
+      nome, una dimensione o un conteggio. Ogni riga che legge, decodifica,
+      compone o codifica un'immagine è servita da questa origine ed è elencata
+      nel repository."""
+
+[[privacy]]
+title = "Cosa carica il pulsante delle donazioni, e cosa non gli viene dato."
+body = """
+
+      Il pulsante «Buy me a coffee» in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non riferisce alcuna visita, e non gli viene passato niente
+      su di te o sulle tue immagini. Non succede nulla finché non ci clicchi, e
+      quello a cui arriveresti è il sito di qualcun altro."""
+
+[[privacy]]
+title = "Un'eccezione voluta."
+body = """
+ Se usi «Aggiungi da un indirizzo web»,
+      quel server viene contattato per recuperare l'immagine e vedrà il tuo
+      indirizzo IP. Vengono recuperate solo le immagini che incolli tu, e solo
+      in entrata: <code>img-src</code> è aperto, <code>connect-src</code> no. Il
+      contatore qui sotto elenca ogni origine esterna contattata."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e tutto quello che sta qui,
+      tranne il caricamento da un indirizzo web, continua a funzionare. È la
+      prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli le tue immagini."
+body = """
+ Trascina una cartella sul riquadro,
+      oppure seleziona i file a mano. Il browser li legge direttamente dal tuo
+      disco; mentre lo fai non viene mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Mettile in ordine e imposta quanto dura ciascuna."
+body = """
+ Trascina
+      per riordinare. La durata si può dare in fotogrammi o in secondi, o per
+      tutte le immagini insieme o una alla volta."""
+
+[[howto]]
+title = "Scegli una risoluzione e una frequenza di fotogrammi."
+body = """
+ «Segui la
+      risoluzione più alta» va dietro alla tua immagine più grande; i valori
+      pronti coprono 4K, 1080p, 720p, quadrato e verticale, e c'è una dimensione
+      personalizzata se nessuno di questi va bene."""
+
+[[howto]]
+title = "Crea il video e scaricalo."
+body = """
+ La codifica gira sul tuo hardware,
+      quindi quanto ci mette dipende dal tuo dispositivo e non da una coda.
+      L'MP4 finito viene consegnato direttamente ai download del tuo
+      browser."""
+
+[[faq]]
+q = "Le mie immagini vengono caricate da qualche parte?"
+a = """
+        No. Le tue immagini vengono lette, composte e codificate dal tuo browser
+        sul tuo hardware. Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare &mdash; nessuno di questi appartiene a
+        questo sito. L'unica eccezione è la funzione facoltativa «aggiungi da un
+        indirizzo web», che recupera un'immagine che hai incollato tu, e quel
+        server vede il tuo indirizzo IP."""
+
+[[faq]]
+q = "Quali formati di immagine posso usare?"
+a = """
+        Qualunque formato di immagine ferma che il tuo browser sappia
+        decodificare, il che in pratica vuol dire JPG, PNG, WebP, GIF, AVIF e,
+        sui dispositivi Apple, HEIC. Qui non c'è un elenco a parte da tenere
+        aggiornato, perché la decodifica è compito del browser e non nostro."""
+
+[[faq]]
+q = "Che formato video produce?"
+a = """
+        MP4 con video H.264, che si riproduce praticamente ovunque. In un browser
+        senza WebCodecs lo strumento ripiega sulla registrazione in WebM &mdash;
+        le stesse riprese in un contenitore che meno programmi di montaggio
+        accettano."""
+
+[[faq]]
+q = "Posso usarlo per una sequenza di render di Blender o After Effects?"
+a = """
+        Sì &mdash; una sequenza di render numerata è esattamente ciò per cui
+        esiste. Aggiungi i fotogrammi che ha scritto il tuo renderer, lascia la
+        durata a un fotogramma ciascuno, e imposta la frequenza in modo che
+        corrisponda al render. «Ordina per nome» conta come ti aspetti, quindi
+        <code>frame_2</code> finisce prima di <code>frame_10</code> e non dopo.
+        <br><br>
+        Una cosa da sapere prima di cominciare: l'H.264 non ha un canale alfa,
+        quindi la trasparenza viene appiattita sul colore di sfondo invece che
+        portata dall'altra parte. Se ti serve tenere l'alfa, componi i fotogrammi
+        nel tuo programma di montaggio."""
+
+[[faq]]
+q = "Posso fare un timelapse con delle foto?"
+a = """
+        Sì, ed è lo stesso lavoro di una sequenza di render: tieni ogni foto per
+        un fotogramma solo e scegli una frequenza. A 30 fps ogni trenta foto
+        diventano un secondo di video; a 12 fps quelle stesse foto durano due
+        secondi e mezzo.
+        <br><br>
+        «Ordina per data» rimette un rullino nell'ordine in cui è stato scattato,
+        cosa che conta quando i nomi dei file sono ripartiti da 0001. Foto di
+        dimensioni diverse non sono un problema &mdash; «segui la risoluzione più
+        alta» dimensiona il video in modo che nessuna venga rimpicciolita."""
+
+[[faq]]
+q = "C'è un limite al numero di immagini o alla durata del video?"
+a = """
+        Nello strumento non c'è alcun limite. Il tetto pratico è la memoria del
+        tuo dispositivo, perché il video finito viene assemblato lì prima che tu
+        lo scarichi. Le presentazioni 4K molto lunghe sono la prima cosa a
+        sentirlo."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso e non c'è periodo di prova.
+        Il sito ha della pubblicità, ed è quella che lo paga; agli annunci non
+        viene dato niente sulle tue immagini."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via le tue immagini per
+        elaborarle si fermerebbe nel momento in cui stacchi la spina."""
+
+[[faq]]
+q = "Posso aggiungere della musica o una colonna sonora?"
+a = """
+        Non ancora. Lo strumento produce solo video: l'MP4 che scrive ha una sola
+        traccia video e nessuna traccia audio. Se ti serve una colonna sonora,
+        aggiungila dopo in un programma di montaggio."""
+
+[schema]
+browser_requirements = "Richiede JavaScript. L'uscita in MP4 ha bisogno di un browser con WebCodecs; gli altri ripiegano sul WebM."
+description = "Trasforma una cartella di immagini in un video MP4 di presentazione. Ogni passaggio gira nel tuo browser, quindi nessuna immagine viene mai caricata."
+features = [
+  "Converte in video immagini JPG, PNG, WebP, GIF e AVIF",
+  "Uscita MP4 (H.264), con il WebM come ripiego",
+  "Risoluzioni fino a 3840x2160, frequenze da 12 a 60 fps",
+  "Durata per singola immagine, in fotogrammi o in secondi",
+  "Funziona offline; niente caricamenti, nessun account",
+]
+
+[picker]
+title = "Trascina qui le immagini"
+hint = "oppure clicca per scegliere &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+[picker.urls]
+summary = "Aggiungi da un indirizzo web"
+button = "Scarica le immagini"
+noun = "immagine"

--- a/locales/it/tools/qr-barcode.html
+++ b/locales/it/tools/qr-barcode.html
@@ -1,0 +1,187 @@
+<main>
+  <!-- Passo 1 &mdash; che tipo di codice -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli il tipo di codice</h2>
+
+    <p class="card-lede">
+      Un QR code contiene qualunque cosa ed è quello che la fotocamera di un
+      telefono cerca. Un codice a barre contiene un numero, e quale ti serve di
+      solito lo decidono per te &mdash; il negozio, il magazzino o il corriere
+      che te lo chiede.
+    </p>
+
+    <div class="option-row">
+      <label for="symbology">Tipo di codice</label>
+      <select id="symbology">
+        <optgroup label="Quadrati">
+          <option value="qr" selected>QR code</option>
+        </optgroup>
+        <optgroup label="A barre">
+          <option value="code128">Code 128</option>
+          <option value="ean13">EAN-13</option>
+          <option value="upca">UPC-A</option>
+          <option value="ean8">EAN-8</option>
+          <option value="itf14">ITF-14</option>
+          <option value="itf">Interleaved 2 of 5</option>
+          <option value="code39">Code 39</option>
+        </optgroup>
+      </select>
+    </div>
+
+    <p class="field-summary" id="symbology-note"></p>
+  </section>
+
+  <!-- Passo 2 &mdash; la stringa in sé -->
+  <section class="card">
+    <h2><span class="step">2</span> Di' cosa ci va dentro</h2>
+
+    <div class="option-row" id="format-row">
+      <label for="format">Cosa contiene</label>
+      <select id="format"></select>
+    </div>
+
+    <p class="card-lede" id="format-note"></p>
+
+    <div id="fields" class="fields"></div>
+
+    <p id="input-error" class="error" role="alert" hidden></p>
+
+    <!--
+      The finished string, shown rather than hidden. A "Wi-Fi QR code" is an
+      ordinary QR code holding a line of text in a format phones recognise, and
+      when a phone does not act on one, this line is the thing to look at.
+    -->
+    <details class="encoded" id="encoded-panel">
+      <summary>La stringa esatta che questo codice conterrà</summary>
+      <pre id="encoded"></pre>
+      <p class="field-summary" id="encoded-note"></p>
+    </details>
+  </section>
+
+  <!-- Passo 3 &mdash; come viene disegnato -->
+  <section class="card">
+    <h2><span class="step">3</span> Scegli come si presenta</h2>
+
+    <fieldset class="options" id="qr-options">
+      <legend>Il QR code</legend>
+
+      <div class="option-row">
+        <label for="level">Quanti danni può sopportare</label>
+        <select id="level">
+          <option value="L">L &mdash; circa il 7% recuperabile, codice più piccolo</option>
+          <option value="M" selected>M &mdash; circa il 15%, la scelta abituale</option>
+          <option value="Q">Q &mdash; circa il 25%</option>
+          <option value="H">H &mdash; circa il 30%, per una stampa destinata a consumarsi</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="quiet">Margine, in moduli</label>
+        <input type="number" id="quiet" value="4" min="0" max="16" step="1" inputmode="numeric">
+      </div>
+
+      <p class="field-summary">
+        Il margine è parte del codice, non spazio attorno. Quattro moduli sono
+        quello che chiede la specifica, e un codice tagliato al bordo è un codice
+        che parecchi scanner non vedranno affatto.
+      </p>
+    </fieldset>
+
+    <fieldset class="options" id="barcode-options" hidden>
+      <legend>Il codice a barre</legend>
+
+      <div class="option-row">
+        <label for="bar-width">Barra più stretta, in pixel</label>
+        <input type="number" id="bar-width" value="2" min="1" max="10" step="1" inputmode="numeric">
+      </div>
+
+      <div class="option-row">
+        <label for="bar-height">Altezza delle barre, in pixel</label>
+        <input type="number" id="bar-height" value="120" min="20" max="600" step="10" inputmode="numeric">
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="show-text" checked>
+        <span>
+          <strong>Stampa i caratteri sotto</strong>
+          <span class="check-note">
+            Quello che legge una persona quando lo scanner non ci riesce. Su un
+            codice da negozio le cifre stanno anche nei margini, ed è voluto:
+            segnano lo spazio bianco che nessuno dovrebbe tagliare.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="code39-check-row" hidden>
+        <input type="checkbox" id="code39-check">
+        <span>
+          <strong>Aggiungi un carattere di controllo</strong>
+          <span class="check-note">
+            Il Code 39 normalmente non ne porta uno. Alcuni sistemi ci insistono;
+            aggiungilo solo se il tuo lo fa, perché un lettore che non se lo
+            aspetta lo leggerà come un carattere in più alla fine.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Colore e dimensione</legend>
+
+      <div class="colour-row">
+        <div class="option-row">
+          <label for="foreground">Il codice</label>
+          <input type="color" id="foreground" value="#000000">
+        </div>
+        <div class="option-row">
+          <label for="background">Dietro</label>
+          <input type="color" id="background" value="#ffffff">
+        </div>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="transparent">
+        <span>
+          <strong>Nessuno sfondo</strong>
+          <span class="check-note">
+            Trasparente, per metterlo su qualcosa che ha già un colore. Lo
+            tengono sia l'SVG che il PNG; quello che finisce dietro deve essere
+            chiaro, o uno scanner non troverà alcun contrasto.
+          </span>
+        </span>
+      </label>
+
+      <div class="option-row" id="size-row">
+        <label for="size">Dimensione della figura, in pixel</label>
+        <input type="number" id="size" value="512" min="64" max="4096" step="16" inputmode="numeric">
+      </div>
+
+      <p class="field-summary" id="size-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Passo 4 &mdash; il risultato -->
+  <section class="card" id="result-card">
+    <h2><span class="step">4</span> Prendilo</h2>
+
+    <div class="preview" id="preview" role="img" aria-label="Il codice che hai fatto"></div>
+
+    <p class="facts" id="facts"></p>
+
+    <div class="run-row">
+      <button type="button" id="download-svg" class="primary">Scarica l'SVG</button>
+      <button type="button" id="download-png" class="primary">Scarica il PNG</button>
+      <button type="button" id="copy-png" class="ghost">Copia l'immagine</button>
+    </div>
+
+    <p class="field-summary" id="download-note" role="status"></p>
+
+    <p class="field-summary">
+      L'SVG è quello da tenere. È il codice come istruzioni invece che come
+      pixel, quindi si stampa a qualunque dimensione senza diventare morbido
+      &mdash; il che qui conta più che nella maggior parte delle figure, perché
+      un bordo sfocato è esattamente quello che uno scanner non riesce a
+      risolvere.
+    </p>
+  </section>
+</main>

--- a/locales/it/tools/qr-barcode.toml
+++ b/locales/it/tools/qr-barcode.toml
@@ -1,0 +1,351 @@
+#
+# Generatore di QR code e codici a barre - Italian.
+#
+# Overrides for tools/qr-barcode/tool.toml. Only words: the slug, the category,
+# the icon and the CSP stay where they are.
+#
+# «QR code» resta com'è: è la forma che in italiano si scrive e si dice, e
+# «codice QR» compare quasi solo nelle traduzioni.
+#
+
+name = "Generatore di QR code e codici a barre"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "QR&nbsp;e&nbsp;codici&nbsp;a&nbsp;barre <span class=\"h1-kw\">&mdash; creare un QR code o un codice a barre, offline</span>"
+tagline = "Lo scrivi, e diventa un codice. Per farne uno non viene spedito niente."
+
+title = "Generatore di QR code e codici a barre &mdash; gratis, senza iscrizione, senza caricare nulla"
+description = "Fai un QR code per un link, una rete Wi-Fi o un biglietto da visita, oppure un codice a barre EAN-13, UPC-A, Code 128 o Code 39. Scaricalo come SVG o PNG. Succede tutto nel tuo browser."
+og_title = "Fare un QR code o un codice a barre senza mandare niente a nessuno"
+og_description = "Link, password del Wi-Fi, biglietti da visita e i codici a barre dei negozi, disegnati nel tuo browser e scaricati come SVG o PNG. Nessun account, nessuna filigrana, nessun pixel di tracciamento in mezzo al tuo codice."
+og_image_alt = "Generatore di QR code e codici a barre - fare un QR code o un codice a barre, senza caricare nulla"
+
+pledge = """
+    Un QR code è aritmetica su una stringa: non c'è un file da spedire e non c'è
+    un servizio da interpellare. Ogni passaggio &mdash; la scelta della
+    modalità, la scelta della versione, la correzione d'errore Reed-Solomon, la
+    maschera, le barre di un codice a barre e la cifra di controllo sotto
+    &mdash; avviene in un migliaio di righe di JavaScript dentro questa pagina,
+    che puoi leggere. Questo strumento non ha alcuna funzione di rete, il che
+    qui conta più che su quasi tutte le altre pagine: la cosa che viene
+    codificata è spesso la password del Wi-Fi."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete, e scrivi una password nel modulo del Wi-Fi. Non una sola
+      richiesta ne porta con sé un carattere. Oppure stacca la connessione e fai
+      il codice lo stesso."""
+
+read_first = """
+, <code>src/qr-encode.js</code>
+      e <code>src/qr.js</code> per il QR code in sé &mdash; le modalità, la
+      versione e i blocchi nel primo, i disegni fissi, la maschera e i bit di
+      formato nel secondo &mdash; <code>src/gf256.js</code> per la correzione
+      d'errore, e <code>src/barcode.js</code> per quelli a righe."""
+
+howto_heading = "Come fare un QR code senza caricare nulla"
+
+card = """
+            Un QR code per un link, una rete Wi-Fi o un biglietto da visita
+            &mdash; oppure un codice a barre da negozio con la sua cifra di
+            controllo già calcolata. SVG o PNG."""
+
+[words]
+plural = "codici e il testo che contengono"
+choose = "cosa ci va dentro"
+analytics_extra = """, e nemmeno un
+  carattere di quello che scrivi"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna scadenza"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Quello che scrivi non ha dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove una password del Wi-Fi potrebbe finire, e nel
+      codice non c'è nulla che ce la manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Non c'è un
+      <code>fetch</code>, né un <code>XMLHttpRequest</code>, né un
+      <code>sendBeacon</code> da nessuna parte in <code>src/</code>. Il codice
+      viene costruito dalla stringa per via aritmetica e disegnato come SVG, in
+      questa pagina, sul tuo dispositivo."""
+
+[[privacy]]
+title = "Il codice non punta a noi."
+body = """
+ Quello che scrivi è quello che il
+      codice contiene. Parecchi generatori gratuiti ti restituiscono un codice
+      che contiene un link al loro sito, che poi rimanda al tuo &mdash; così
+      ogni scansione la contano loro, e il codice smette di funzionare il giorno
+      in cui smettono di pagare il dominio o decidono che il piano gratuito è
+      scaduto. Qui non si accorcia niente, non si rimanda da nessuna parte e non
+      si traccia nulla: la stringa mostrata sulla pagina è la stringa dentro la
+      figura."""
+
+[[privacy]]
+title = "Il PNG è fatto a partire dall'SVG che hai sullo schermo."
+body = """
+ Il
+      download non è una seconda resa che potrebbe non concordare con
+      l'anteprima. Lo stesso markup viene consegnato al browser e dipinto su una
+      tela, che è anche il motivo per cui si può fare senza contattare niente:
+      non c'è un carattere tipografico da recuperare e non c'è un'immagine da
+      caricare lì dentro."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google, e il pulsante delle
+      donazioni da Buy Me a Coffee. A nessuno di loro viene passato niente di
+      quello che scrivi. Ogni riga che trasforma una stringa in un codice è
+      servita da questa origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento resta
+      identico, perché al suo interno non c'è mai stato un passaggio di rete. È
+      la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli il tipo di codice."
+body = """
+ Un QR code contiene qualunque cosa
+      ed è quello che la fotocamera di un telefono cerca, quindi è la risposta a
+      meno che qualcuno non ti abbia detto altrimenti. Un codice a barre
+      contiene un numero, e quale ti serve lo decide chi dovrà scansionarlo
+      &mdash; un negozio vuole un EAN-13 o un UPC-A, un cartone da spedizione un
+      ITF-14, e qualunque cosa a uso interno di solito è Code 128."""
+
+[[howto]]
+title = "Di' cosa ci va dentro."
+body = """
+ Un link è il caso comune, e i campi
+      qui sopra costruiscono gli altri formati che i telefoni conoscono: una
+      rete Wi-Fi che si propone di collegarsi da sola, un biglietto da visita
+      che si propone di essere salvato, una mail, un SMS, un numero di telefono,
+      un punto su una mappa. Qualunque cosa tu scelga, la stringa finita viene
+      mostrata sulla pagina &mdash; è tutto quello che un QR code contiene."""
+
+[[howto]]
+title = "Scegli quanti danni può sopportare."
+body = """
+ I quattro livelli mettono dentro
+      più o meno correzione d'errore, e più correzione vuol dire un codice più
+      grande e più fitto. L basta per uno schermo, M per la carta comune, e H
+      per qualcosa che verrà maneggiato, stampato piccolo, o attaccato a una
+      vetrina al sole. Un codice su un menu che viene pulito tutti i giorni vale
+      un Q o un H."""
+
+[[howto]]
+title = "Imposta la dimensione, il margine e i colori."
+body = """
+ Il margine è parte del codice:
+      quattro moduli di spazio libero attorno sono quello che chiede la
+      specifica, e tagliarlo è di gran lunga il motivo più comune per cui un
+      codice stampato non si legge. Scuro su chiaro, con un contrasto vero
+      &mdash; uno scanner legge la differenza tra i due, quindi il grigino su
+      bianco non va bene, e il chiaro su scuro fallisce del tutto su parecchi
+      lettori."""
+
+[[howto]]
+title = "Provalo con il telefono che hai."
+body = """
+ Prima di stamparne mille,
+      scansiona quello che hai sullo schermo. Ci vogliono dieci secondi e prende
+      tutta la categoria di errori che un'anteprima non può prendere: una
+      password del Wi-Fi con un carattere che andava protetto, un link a cui
+      mancava l'<code>https://</code>, un numero di codice a barre a cui manca
+      una cifra."""
+
+[[howto]]
+title = "Prendi l'SVG."
+body = """
+ È il codice come istruzioni invece che
+      come pixel, quindi si stampa a qualunque dimensione senza diventare
+      morbido, e un bordo morbido è esattamente quello che uno scanner non
+      riesce a risolvere. Prendi anche il PNG se la cosa in cui stai incollando
+      non accetta un SVG; è disegnato a un numero intero di pixel per modulo,
+      quindi nemmeno lui ha bordi sfocati."""
+
+[[faq]]
+q = "Quello che scrivo viene mandato da qualche parte?"
+a = """
+        No. Un QR code è aritmetica su una stringa, e quell'aritmetica gira nel
+        tuo browser sul tuo dispositivo. Questo strumento non ha alcuna funzione
+        di rete &mdash; non recupera mai niente e non spedisce mai niente
+        &mdash; e la <code>Content-Security-Policy</code> della pagina nomina
+        tutti gli indirizzi che può contattare, nessuno dei quali appartiene a
+        questo sito. Qui vale più che su quasi tutte le altre pagine, perché la
+        cosa che si mette più spesso in un QR code è la password del proprio
+        Wi-Fi."""
+
+[[faq]]
+q = "Questi codici scadono, o smettono di funzionare?"
+a = """
+        No, e non possono. Quello che scrivi è quello che il codice contiene,
+        quindi scansionarlo restituisce esattamente quella stringa per sempre. I
+        codici che scadono sono quelli che hanno dentro l'indirizzo di qualcun
+        altro: un QR code «dinamico» contiene un link al server del generatore,
+        che rimanda al tuo, il che vuol dire che loro possono contare ogni
+        scansione, cambiare dove porta, o spegnerlo quando finisce una prova.
+        Qui non si passa attraverso niente."""
+
+[[faq]]
+q = "È gratis, e posso usarlo per lavoro?"
+a = """
+        È gratis, non c'è account, non c'è filigrana e non c'è limite a quanti ne
+        fai, e il risultato lo puoi mettere su un prodotto, un manifesto o una
+        vetrina. QR Code è un marchio registrato di Denso Wave, che ha dichiarato
+        che non lo farà valere contro chi usa i codici &mdash; la specifica è
+        pubblicata come ISO/IEC 18004 ed è libera da implementare, che è quello
+        che fa questa pagina. Il sito ha della pubblicità, ed è quella che lo
+        paga."""
+
+[[faq]]
+q = "Quale livello di correzione d'errore devo scegliere?"
+a = """
+        M, a meno che tu non abbia un motivo. L fa il codice più piccolo e va
+        benissimo su uno schermo; M sopravvive a un uso normale; Q e H sono per
+        un codice che verrà stampato piccolo, plastificato, attaccato a una
+        vetrina o coperto in parte da un logo. Ogni scalino in su mette dentro
+        più dati di controllo, il che richiede un simbolo più grande a parità di
+        testo &mdash; passare da L a H all'incirca raddoppia il numero di moduli
+        per la stessa stringa."""
+
+[[faq]]
+q = "Quanto può contenere un QR code?"
+a = """
+        Alla dimensione massima, 177 moduli per lato, fino a 7.089 cifre, 4.296
+        lettere maiuscole e cifre, o 2.953 byte di qualunque altra cosa &mdash; e
+        questo con la correzione d'errore più debole; con la più forte è circa un
+        terzo. In pratica il limite non è il formato ma lo scanner: oltre qualche
+        centinaio di caratteri i moduli diventano così piccoli che la fotocamera
+        di un telefono comune non li risolve a distanza di braccio. Un codice
+        lungo di solito è il segno che al suo posto ci vorrebbe un link corto."""
+
+[[faq]]
+q = "Perché il mio codice è più grande se scrivo il link in minuscolo?"
+a = """
+        Perché un QR code ha una modalità per maiuscole e cifre che impacchetta
+        due caratteri in undici bit, e non ha una modalità del genere per il
+        minuscolo, che costa otto bit a carattere. Un URL scritto
+        <code>HTTPS://ESEMPIO.IT/PAGINA</code> può essere un terzo più piccolo
+        dello stesso URL in minuscolo. Lo schema e l'host non distinguono
+        maiuscole e minuscole, quindi urlarli non cambia niente tranne la
+        dimensione; il percorso dopo l'host invece le distingue, quindi quello
+        lascialo stare."""
+
+[[faq]]
+q = "Sa anche leggere un QR code, oltre a farlo?"
+a = """
+        Non ancora. Leggerne uno vuol dire decodificare un'immagine &mdash;
+        trovare il simbolo dentro una fotografia, correggere l'angolo da cui è
+        stata scattata, e riparare i danni &mdash; che è un lavoro diverso e
+        parecchio più grosso che disegnarne uno. Si potrebbe costruire qui alle
+        stesse condizioni di tutto il resto, ed è nella lista. Nel frattempo la
+        fotocamera del tuo telefono lo fa già, e lo fa bene."""
+
+[[faq]]
+q = "A cosa serve il margine, e posso ridurlo?"
+a = """
+        Lo spazio bianco attorno a un QR code è parte del codice. Un lettore lo
+        usa per capire dove finisce il simbolo, e la specifica chiede quattro
+        moduli su ogni lato; un codice a barre ne vuole una decina. Qui puoi
+        metterlo a zero e la figura verrà più ordinata, e parecchi scanner poi
+        non la vedranno affatto &mdash; soprattutto su uno sfondo movimentato. Se
+        il problema è lo spazio, rimpicciolisci il codice invece di tagliargli il
+        margine."""
+
+[[faq]]
+q = "Quale codice a barre mi serve?"
+a = """
+        Quello che chiede chi lo scansiona. L'EAN-13 è il codice a barre da
+        negozio fuori dal Nord America e l'UPC-A è quello nordamericano &mdash;
+        entrambi hanno bisogno di un numero assegnato a te da GS1, perché il
+        numero identifica la tua azienda e non solo il prodotto. L'EAN-8 è la
+        versione corta per le confezioni piccole. L'ITF-14 va sul cartone da
+        spedizione. Code 128 e Code 39 contengono testo oltre alle cifre e non
+        hanno bisogno di alcuna registrazione, il che li rende la risposta giusta
+        per qualunque cosa a uso interno: beni, scaffali, schede di lavoro."""
+
+[[faq]]
+q = "Cos'è una cifra di controllo, e perché lo strumento ne ha aggiunta una?"
+a = """
+        È l'ultima cifra di un codice a barre da negozio, calcolata a partire da
+        quelle prima, così che uno scanner possa distinguere una lettura
+        sbagliata da una buona. L'EAN-13 vuole dodici cifre e calcola la
+        tredicesima; l'UPC-A ne vuole undici e calcola la dodicesima. Scrivi il
+        numero corto e questa pagina la aggiunge. Scrivi il numero intero e
+        controlla quella che hai dato &mdash; e rifiuta, invece di correggerla in
+        silenzio, perché una cifra sbagliata sistemata di nascosto è
+        un'etichetta che si legge come il prodotto di qualcun altro."""
+
+[[faq]]
+q = "Posso mettere un logo in mezzo a un QR code?"
+a = """
+        Non qui, ma il motivo per cui altrove funziona vale la pena saperlo: a
+        renderlo possibile è la correzione d'errore. Al livello H si può
+        distruggere all'incirca il 30% dei moduli e il codice si legge lo stesso,
+        quindi un logo che ne copre parecchi di meno al centro &mdash; dove non
+        c'è alcun disegno di ricerca &mdash; è un danno riparabile. Passa il
+        codice nel tuo programma di grafica al livello H, tieni il logo sotto un
+        quinto circa dell'area, e provalo con un telefono vero invece di
+        fidarti."""
+
+[[faq]]
+q = "Perché l'SVG è meglio del PNG?"
+a = """
+        Perché un codice sono bordi, e un PNG ha un numero fisso di pixel con cui
+        farli. Ingrandiscine uno e ogni bordo si ammorbidisce; un bordo morbido è
+        esattamente quello con cui uno scanner fa fatica, e a una stampante da
+        1200 dpi a cui dai un PNG da 512 pixel stai chiedendo di inventarsi la
+        differenza. Un SVG sono i quadrati come istruzioni, quindi stampa nitido
+        su un biglietto da visita come su un cartellone. Il PNG di qui è
+        disegnato a un numero intero di pixel per modulo, che è il meglio che un
+        PNG possa fare."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via il tuo testo per farne
+        disegnare un codice si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Genera un QR code o un codice a barre lineare da una stringa, nel browser. QR code per link, reti Wi-Fi, biglietti da visita, mail, SMS, numeri di telefono e coordinate, con tutti e quattro i livelli di correzione d'errore; codici a barre EAN-13, EAN-8, UPC-A, ITF-14, Interleaved 2 of 5, Code 128 e Code 39 con le loro cifre di controllo. Scaricabile come SVG o PNG. Non viene caricato nulla."
+features = [
+  "QR code a tutte le versioni da 1 a 40, in modalità numerica, alfanumerica e byte",
+  "Tutti e quattro i livelli di correzione d'errore, con quello che ognuno costa detto a voce alta",
+  "Formati già pronti: rete Wi-Fi, biglietto da visita, mail, SMS, numero di telefono, punto su una mappa",
+  "Mostra la stringa esatta che il codice conterrà, invece di nasconderla",
+  "EAN-13, EAN-8 e UPC-A, con la cifra di controllo calcolata o verificata",
+  "ITF-14 e Interleaved 2 of 5 per cartoni e magazzino",
+  "Code 128 con uso automatico della sua modalità numerica, e Code 39 con carattere di controllo facoltativo",
+  "Cifre leggibili stampate sotto un codice a barre, nei punti giusti",
+  "Uscita in SVG, così stampa nitido a qualunque dimensione, e un PNG disegnato a pixel interi per modulo",
+  "Due colori qualsiasi, oppure nessuno sfondo",
+  "Non rimanda mai altrove: nessun link corto, nessun tracciamento, niente che possa scadere",
+  "Funziona offline; niente caricamenti, nessun account",
+]

--- a/locales/it/tools/resize-image.html
+++ b/locales/it/tools/resize-image.html
@@ -1,0 +1,283 @@
+<main>
+  <!-- Passo 1 &mdash; i file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli le immagini</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto dalla lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; il ritaglio -->
+  <section class="card" id="crop-card">
+    <h2><span class="step">2</span> Ritaglia, se ti va</h2>
+
+    <p class="card-lede">
+      Il riquadro parte su tutta l'immagine, quindi lasciare stare questo passo
+      non ritaglia niente. Ogni immagine tiene il proprio riquadro &mdash;
+      scegline una dall'elenco qui sopra per disegnarci sopra. Il ritaglio
+      avviene prima del ridimensionamento, che è l'unico ordine che abbia senso:
+      un'immagine tagliata dopo essere stata rimpicciolita ha già buttato via i
+      pixel che le servivano.
+    </p>
+
+    <p id="crop-empty" class="field-summary">Aggiungi un'immagine e il riquadro compare qui.</p>
+
+    <div id="crop-controls" hidden>
+      <p class="stage-hint">
+        <span id="stage-name" class="stage-name"></span>
+        Trascina dentro il riquadro per spostarlo, o un angolo qualsiasi per
+        ridimensionarlo. Con il riquadro selezionato, le frecce lo spostano di un
+        pixel alla volta, <kbd>Alt</kbd>&nbsp;+&nbsp;frecce lo ridimensionano, e
+        tenendo premuto <kbd>Maiusc</kbd> ogni passo diventa di dieci.
+      </p>
+
+      <!-- The crop box itself is added here by src/cropper.js. The stage is
+           given the picture's own shape, so the box can be positioned in
+           percentages and needs no recalculating when the window is resized. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <p id="stage-note" class="stage-note" hidden></p>
+
+      <div class="crop-controls">
+        <div class="aspect-row" id="aspect-row" role="group" aria-label="Blocca il ritaglio su una forma">
+          <button type="button" data-aspect="free" class="active">Libero</button>
+          <button type="button" data-aspect="source">Originale</button>
+          <button type="button" data-aspect="1:1">1:1</button>
+          <button type="button" data-aspect="4:5">4:5</button>
+          <button type="button" data-aspect="9:16">9:16</button>
+          <button type="button" data-aspect="16:9">16:9</button>
+          <button type="button" data-aspect="4:3">4:3</button>
+          <button type="button" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="ghost" title="Metti di lato la forma bloccata">
+            Ruota
+          </button>
+        </div>
+
+        <div class="numbers">
+          <label>Sinistra<input type="number" id="crop-x" min="0" step="1"></label>
+          <label>Alto<input type="number" id="crop-y" min="0" step="1"></label>
+          <label>Larghezza<input type="number" id="crop-w" min="8" step="1"></label>
+          <label>Altezza<input type="number" id="crop-h" min="8" step="1"></label>
+          <div class="number-actions">
+            <button type="button" id="crop-max" class="ghost">Il più grande</button>
+            <button type="button" id="crop-centre" class="ghost">Centra</button>
+            <button type="button" id="crop-reset" class="ghost">Tutta l'immagine</button>
+          </div>
+        </div>
+
+        <!--
+          Every image keeps its own box, which is the point. This is for the
+          case that is still worth one click: a folder of exports that all want
+          the same framing.
+        -->
+        <div class="apply-row" id="apply-row" hidden>
+          <button type="button" id="crop-apply-all" class="ghost">Usa questo ritaglio su tutte le immagini</button>
+          <p class="hint-line" id="apply-note"></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; la dimensione -->
+  <section class="card" id="resize-card">
+    <h2><span class="step">3</span> Di' che dimensione deve avere</h2>
+
+    <div class="option-row">
+      <label for="resize-mode">Imposta la dimensione con</label>
+      <select id="resize-mode">
+        <option value="pixels" selected>Larghezza e altezza, in pixel</option>
+        <option value="longest">Il lato più lungo</option>
+        <option value="percent">Una percentuale di quello che è adesso</option>
+        <option value="none">Niente &mdash; lascia la dimensione esattamente com'è</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="pixels-fields">
+      <div class="numbers">
+        <label>Larghezza<input type="number" id="size-w" min="1" step="1" placeholder="auto" value="1920"></label>
+        <label>Altezza<input type="number" id="size-h" min="1" step="1" placeholder="auto"></label>
+        <div class="number-actions">
+          <button type="button" id="swap-size" class="ghost">Scambia</button>
+        </div>
+      </div>
+
+      <!--
+        Leaving one of them blank is the common case and the one worth
+        supporting properly: "1920 wide, whatever tall that makes it" needs no
+        decision about shapes at all.
+      -->
+      <p class="hint-line">
+        Riempi un campo e lascia vuoto l'altro per tenere la forma dell'immagine.
+      </p>
+
+      <div class="presets" id="size-presets" role="group" aria-label="Dimensioni comuni">
+        <button type="button" class="ghost" data-w="1920" data-h="1080">1920 &times; 1080</button>
+        <button type="button" class="ghost" data-w="1280" data-h="720">1280 &times; 720</button>
+        <button type="button" class="ghost" data-w="1080" data-h="1080">1080 &times; 1080</button>
+        <button type="button" class="ghost" data-w="600" data-h="">larga 600</button>
+      </div>
+
+      <div class="option-row" id="fit-row">
+        <label for="fit">Se le forme non concordano</label>
+        <select id="fit">
+          <option value="contain" selected>Stai dentro &mdash; tutta l'immagine, un lato viene più corto</option>
+          <option value="cover">Riempi &mdash; esattamente questa dimensione, con quello che avanza tagliato</option>
+          <option value="pad">Riempi con lo sfondo &mdash; esattamente questa dimensione, con uno sfondo attorno</option>
+          <option value="stretch">Stira &mdash; esattamente questa dimensione, e la forma deformata</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Lato più lungo<input type="number" id="size-longest" min="1" step="1" value="1920"></label>
+      </div>
+      <p class="hint-line">
+        Il lato più lungo, qualunque sia, diventa questo, e l'altro segue. Gli
+        scatti verticali e orizzontali dello stesso lotto escono tutti della
+        stessa dimensione sul lato lungo, che è quello che di solito serve a una
+        galleria.
+      </p>
+      <div class="presets" id="longest-presets" role="group" aria-label="Lati lunghi comuni">
+        <button type="button" class="ghost" data-longest="640">640</button>
+        <button type="button" class="ghost" data-longest="1280">1280</button>
+        <button type="button" class="ghost" data-longest="1920">1920</button>
+        <button type="button" class="ghost" data-longest="2560">2560</button>
+      </div>
+    </div>
+
+    <div class="size-fields" id="percent-fields" hidden>
+      <div class="numbers">
+        <label>Percentuale<input type="number" id="size-percent" min="1" max="1000" step="1" value="50"></label>
+      </div>
+      <div class="presets" id="percent-presets" role="group" aria-label="Percentuali comuni">
+        <button type="button" class="ghost" data-percent="25">25%</button>
+        <button type="button" class="ghost" data-percent="50">50%</button>
+        <button type="button" class="ghost" data-percent="75">75%</button>
+        <button type="button" class="ghost" data-percent="200">200%</button>
+      </div>
+    </div>
+
+    <label class="check" id="enlarge-row">
+      <input type="checkbox" id="no-enlarge" checked>
+      <span>
+        <strong>Non ingrandire mai un'immagine oltre la sua dimensione di partenza</strong>
+        <span class="check-note">
+          Ingrandire inventa pixel che non sono mai stati fotografati, quindi
+          un'immagine piccola messa in una cornice grande esce morbida invece che
+          dettagliata. Con questa attiva, tutto quello che è già più piccolo della
+          dimensione che hai chiesto viene lasciato alla propria dimensione.
+        </span>
+      </span>
+    </label>
+
+    <p id="size-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Passo 4 &mdash; il formato, e il clic unico -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Salvala</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="keep" selected>Tieni il formato con cui è arrivato ogni file</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/png">PNG</option>
+          <option value="image/webp">WebP</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualità &mdash; <output id="quality-value" for="quality">85</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="85">
+        <p class="field-note">
+          Solo JPEG e WebP; il PNG non ha una manopola della qualità. 85 è dove
+          quasi tutti smettono di accorgersene. Sotto il 60 circa le zone piatte
+          cominciano a fare bande.
+        </p>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Sfondo</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Quello che si vede dove non c'è l'immagine: dietro una cornice di
+          riempimento, e dietro la trasparenza quando il formato in uscita non ha
+          un canale alfa.
+        </p>
+      </div>
+    </div>
+
+    <p id="plan-summary" class="field-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Ridimensiona le immagini</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Finito</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Scarica tutto in uno zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The big look at one result. A <dialog> opened with showModal() rather than
+    a div pretending to be one: the browser gives the focus trap, the Escape
+    key and the inert background for nothing, and gets all three right.
+
+    Both pictures in it are object URLs made on this page - the result, and the
+    original that was already decoded for the thumbnail. Opening this fetches
+    nothing and decodes nothing that was not already decoded.
+  -->
+  <dialog id="viewer" class="viewer" aria-labelledby="viewer-name">
+    <div class="viewer-head">
+      <h2 id="viewer-name" class="viewer-name"></h2>
+      <button type="button" id="viewer-close" class="ghost" aria-label="Chiudi">Chiudi</button>
+    </div>
+
+    <div class="viewer-stage">
+      <img id="viewer-image" alt="">
+    </div>
+
+    <p id="viewer-caption" class="viewer-caption"></p>
+
+    <dl class="viewer-facts" id="viewer-facts"></dl>
+
+    <div class="viewer-actions">
+      <button type="button" id="viewer-compare" class="ghost" aria-pressed="false">Mostra l'originale</button>
+      <a id="viewer-download" class="primary as-button" download>Scarica</a>
+    </div>
+  </dialog>
+</main>

--- a/locales/it/tools/resize-image.toml
+++ b/locales/it/tools/resize-image.toml
@@ -1,0 +1,285 @@
+#
+# Ridimensionatore di immagini - Italian.
+#
+# Overrides for tools/resize-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Ridimensionatore di immagini"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Ridimensionare&nbsp;un'immagine <span class=\"h1-kw\">&mdash; ritagliare e convertire</span>"
+tagline = "Di' la dimensione. Disegna il riquadro. Scegli il formato."
+
+title = "Ridimensionare un'immagine &mdash; anche ritagliare e convertire, senza caricare nulla"
+description = "Ridimensiona, ritaglia e converti immagini JPEG, PNG e WebP nel tuo browser. Pixel esatti, una percentuale o il lato lungo - un'immagine o una cartella intera. Non viene caricato nulla."
+og_title = "Ridimensionare, ritagliare e convertire un'immagine senza caricarla"
+og_description = "Imposta la dimensione in pixel o in percentuale, trascina un riquadro di ritaglio, cambia formato - per un'immagine o per un lotto intero. Gira tutto sul tuo dispositivo."
+og_image_alt = "Ridimensionatore di immagini - ridimensionare, ritagliare e convertire senza caricare nulla"
+
+pledge = """
+    Il ridimensionamento, il ritaglio e il cambio di formato avvengono tutti nel
+    tuo browser, sul tuo hardware, con gli encoder di immagini che si porta già
+    dietro. Questo strumento non ha alcuna funzione di rete &mdash; niente da
+    recuperare, niente da spedire &mdash; e dall'altra parte di questa pagina
+    non c'è alcun server a cui mandare un'immagine, anche se ci fosse un modo
+    per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e ridimensiona una foto. Non una sola richiesta porta con sé
+      un'immagine, una miniatura, un nome di file o un byte di quello che hai
+      scelto. Oppure stacca la connessione e ridimensionane una lo stesso."""
+
+read_first = """
+, <code>src/geometry.js</code> per l'aritmetica
+      che decide cosa viene tenuto e quanto grande esce, e
+      <code>src/codecs.js</code> per l'unica chiamata a <code>drawImage</code>
+      che fa il ritaglio e il ridimensionamento insieme."""
+
+howto_heading = "Come ridimensionare un'immagine senza caricarla"
+
+card = """
+            Pixel esatti, una percentuale o il lato lungo &mdash; con un
+            riquadro di ritaglio e un cambio di formato lungo la strada.
+            Un'immagine o una cartella."""
+
+[words]
+plural = "immagini"
+choose = "un'immagine"
+analytics_extra = """, e nemmeno una delle
+  dimensioni, dei ritagli o dei formati che questo strumento calcola"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Le tue immagini non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove i tuoi file potrebbero finire, e nel codice non
+      c'è nulla che ce li manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Non c'è un
+      <code>fetch</code>, né un <code>XMLHttpRequest</code>, né un
+      <code>sendBeacon</code> da nessuna parte in <code>src/</code>. Il
+      ridimensionamento è un <code>drawImage</code> su una tela e un
+      <code>canvas.toBlob</code> &mdash; lo scalatore e l'encoder che sono già
+      installati nel tuo browser."""
+
+[[privacy]]
+title = "Un file che nessuno ha chiesto di cambiare non viene cambiato."
+body = """
+ Senza ritaglio, senza
+      ridimensionamento e senza cambio di formato, il file che hai scelto ti
+      viene restituito byte per byte invece che risalvato. Non è solo cortesia:
+      è il motivo per cui questo strumento non può ricodificare in silenzio
+      un'immagine, né buttare in silenzio i metadati di una che volevi solo
+      guardare."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google, e il pulsante delle
+      donazioni da Buy Me a Coffee. A nessuno di loro viene passato niente sulle
+      tue immagini. Ogni riga che legge, ritaglia, scala o scrive un file è
+      servita da questa origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento resta
+      identico, perché al suo interno non c'è mai stato un passaggio di rete. È
+      la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli le tue immagini."
+body = """
+ Trascinale sul riquadro o
+      selezionale a mano. Il browser le legge direttamente dal tuo disco; mentre
+      lo fai non viene mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Ritaglia, se ti va."
+body = """
+ Il riquadro parte su tutta l'immagine,
+      quindi lasciarlo stare non ritaglia niente. Trascinalo, oppure bloccalo su
+      una forma &mdash; 1:1 per una foto profilo, 9:16 per una storia, 16:9 per
+      una miniatura &mdash; e premi «Il più grande» per quello più grande che ci
+      sta. Ogni immagine tiene il proprio riquadro: clicca una riga qualsiasi
+      dell'elenco per disegnare su quella. Se devono essere tutte inquadrate allo
+      stesso modo, c'è un pulsante anche per quello."""
+
+[[howto]]
+title = "Di' che dimensione deve avere in uscita."
+body = """
+ Una larghezza,
+      un'altezza, o entrambe; un lato lungo, che tiene gli scatti verticali e
+      orizzontali della stessa dimensione tra loro; oppure una semplice
+      percentuale. Lascia vuoto uno dei due campi e l'immagine tiene la propria
+      forma."""
+
+[[howto]]
+title = "Scegli il formato, poi premi il pulsante."
+body = """
+ Tieni quello con cui
+      è arrivato ogni file, oppure scrivi tutto come JPEG, PNG o WebP. Ogni
+      risultato dice cosa è diventato e di quanto si è alleggerito; cliccane uno
+      per aprirlo a dimensione piena con tutti i numeri dietro, e l'originale
+      accanto per confrontare. Un lotto scende come un unico zip."""
+
+[[faq]]
+q = "La mia immagine viene caricata da qualche parte?"
+a = """
+        No. Il file viene decodificato, ritagliato, scalato e scritto dal tuo
+        browser sul tuo hardware, con gli encoder JPEG, PNG e WebP che il browser
+        si porta già dietro. Questo strumento non ha alcuna funzione di rete
+        &mdash; non recupera mai niente e non spedisce mai niente &mdash; e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare, nessuno dei quali appartiene a questo
+        sito."""
+
+[[faq]]
+q = "Cosa succede se do una larghezza ma non un'altezza?"
+a = """
+        L'altezza segue dalla forma stessa dell'immagine, che è quasi sempre
+        quello che si voleva: «larga 1920» vuol dire «larga 1920 e alta quanto
+        viene». Riempi entrambi i campi e i due possono non concordare con la
+        forma dell'immagine, che è l'unico caso in cui compare la scelta «se le
+        forme non concordano» &mdash; stare dentro il riquadro, riempirlo e
+        tagliare quello che avanza, riempire con uno sfondo, o stirare e
+        accettare la deformazione."""
+
+[[faq]]
+q = "Ridimensionare un'immagine fa perdere qualità?"
+a = """
+        Rimpicciolire un'immagine no, in nessun modo che si veda: entrano più
+        pixel di quanti ne escano, quindi il dettaglio che resta è dettaglio
+        vero. Ingrandirne una non può aggiungere quello che non è mai stato
+        fotografato &mdash; il risultato è una copia più morbida della stessa
+        immagine, non una più nitida &mdash; ed è per questo che «non ingrandire
+        mai un'immagine oltre la sua dimensione di partenza» è attivo di default.
+        Quello che costa qualcosa è la ricodifica successiva, se il formato è
+        JPEG o WebP, e il cursore della qualità è quello che spendi lì."""
+
+[[faq]]
+q = "Posso ritagliare ogni immagine in modo diverso?"
+a = """
+        Sì &mdash; è il comportamento predefinito. Ogni immagine dell'elenco
+        porta il proprio riquadro, nei propri pixel, e cliccare una riga mette
+        quell'immagine nell'anteprima con il suo riquadro e la sua forma bloccata
+        di nuovo addosso. Niente di quello che fai a una tocca un'altra. Anche
+        ogni riquadro parte su tutta l'immagine, quindi un'immagine su cui non
+        disegni mai non viene ritagliata affatto."""
+
+[[faq]]
+q = "Può ritagliare un lotto intero allo stesso modo in una volta?"
+a = """
+        Sì, con il pulsante sotto l'anteprima. Dà a ogni altra immagine la stessa
+        area relativa &mdash; le stesse frazioni della propria larghezza e
+        altezza &mdash; che per una serie di screenshot o di esportazioni tutti
+        della stessa dimensione è esattamente lo stesso riquadro, e la pagina lo
+        dice. Con una forma bloccata dà invece a ciascuna il riquadro più grande
+        di quella forma dentro quell'area, così premere 1:1 e poi quel pulsante
+        ti tira fuori dei quadrati da una cartella di scatti verticali e
+        orizzontali mescolati. Ogni riquadro resta modificabile dopo."""
+
+[[faq]]
+q = "Quali formati sa leggere e scrivere?"
+a = """
+        Legge tutto quello che il tuo browser sa decodificare, che in pratica
+        vuol dire JPEG, PNG, WebP, GIF, BMP e &mdash; sulla maggior parte dei
+        browser attuali &mdash; AVIF. Scrive JPEG, PNG e WebP, perché quelli sono
+        gli encoder che i browser si portano dietro. Su «tieni il formato» un
+        JPEG resta un JPEG e un PNG resta un PNG; tutto quello che il browser non
+        sa scrivere, come una GIF o un BMP, esce come PNG, che è quello che tiene
+        intatte la trasparenza e le tinte piatte."""
+
+[[faq]]
+q = "Cosa succede alla trasparenza se salvo in JPEG?"
+a = """
+        Viene riempita con il colore di sfondo, perché il JPEG non ha un canale
+        alfa in cui conservarla. Il colore lo scegli tu e parte dal bianco, che è
+        quello che vuole quasi tutti e quello che fa quasi ogni altro strumento
+        senza dirtelo. Lo stesso colore viene usato dietro una cornice di
+        riempimento. Salva invece in PNG o WebP e la trasparenza passa
+        intatta."""
+
+[[faq]]
+q = "Rimuove i dati EXIF e GPS?"
+a = """
+        Da tutto quello che elabora davvero, sì, come effetto collaterale:
+        ritagliare o ridimensionare vuol dire decodificare l'immagine in pixel e
+        ricodificare quei pixel, e una tela piena di pixel non porta con sé alcun
+        tag, quindi la posizione, il modello della fotocamera e gli orari
+        semplicemente non vengono scritti nel file nuovo. Un file che non stai
+        cambiando affatto è un caso diverso &mdash; ti viene restituito byte per
+        byte, tag compresi. Se vuoi via i metadati ma l'immagine intatta, usa il
+        <a href="../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>,
+        che riscrive il contenitore senza ricomprimere niente."""
+
+[[faq]]
+q = "In cosa è diverso dal compressore di immagini?"
+a = """
+        Questo riguarda le dimensioni: dici quanti pixel vuoi e te li dà. Il
+        <a href="../comprimere-immagine/">compressore di immagini</a> riguarda il
+        peso del file: dici quanti kilobyte ti sono concessi e lui cerca la
+        qualità più alta che ci sta, ridimensionando solo se la qualità da sola
+        non ci arriva. Se ti hanno detto «larga 1200 pixel», sei nel posto
+        giusto. Se ti hanno detto «sotto i 500 KB», l'altro ti porterà più
+        vicino."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Non c'è nemmeno un limite al numero o alla dimensione
+        dei file, perché non c'è un server che li paga &mdash; il lavoro avviene
+        sul tuo dispositivo. Il sito ha della pubblicità, ed è quella che lo
+        paga; agli annunci non viene dato niente sulle tue immagini."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via le tue immagini per
+        ridimensionarle si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Ridimensiona, ritaglia e converti immagini JPEG, PNG e WebP nel browser. Imposta una dimensione esatta in pixel, una percentuale o il lato lungo, trascina un riquadro di ritaglio o bloccalo su una forma, e scrivi il risultato come JPEG, PNG o WebP. Supporta i lotti, e non viene caricato nulla."
+features = [
+  "Ridimensiona per pixel esatti, per lato lungo o in percentuale",
+  "Riempi un lato solo e l'altro segue la forma stessa dell'immagine",
+  "Stai dentro, riempi e ritaglia, riempi fino a una cornice esatta, o stira",
+  "Un riquadro di ritaglio trascinabile per ogni immagine, bloccabile su 1:1, 4:5, 9:16, 16:9, 4:3 o 3:2",
+  "Ritaglia ogni immagine in modo diverso, o dà una sola inquadratura a tutto il lotto con un clic",
+  "Apre ogni immagine finita a dimensione piena, con tutti i numeri dietro e l'originale accanto per confrontare",
+  "Converte tra JPEG, PNG e WebP, con un controllo della qualità e un colore di sfondo",
+  "Non ingrandisce mai un'immagine se non glielo chiedi",
+  "Restituisce intatto qualunque file non gli sia stato chiesto di cambiare",
+  "Lavora a lotti, con tutti i risultati in un unico zip",
+  "Funziona offline; niente caricamenti, nessun account",
+]
+
+[picker]
+title = "Trascina qui le immagini"
+hint = "oppure clicca per scegliere &mdash; JPEG, PNG, WebP e qualunque altra cosa il tuo browser sappia aprire"

--- a/locales/it/tools/svg-to-image.html
+++ b/locales/it/tools/svg-to-image.html
@@ -1,0 +1,210 @@
+<main>
+  <!-- Passo 1 &mdash; i file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli i file SVG</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Togli tutto dalla lista</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; la dimensione -->
+  <section class="card" id="size-card">
+    <h2><span class="step">2</span> Di' quanto grande deve venire</h2>
+
+    <p class="card-lede">
+      È l'unica domanda a cui un vettoriale non può rispondere al posto tuo. Un
+      SVG non ha pixel dentro &mdash; ha istruzioni per disegnare, e le seguirà a
+      qualunque dimensione tu dica. Il numero qui sotto non è un limite contro
+      cui stai spingendo, come sarebbe con una fotografia; quattromila pixel da
+      un'icona da 24&nbsp;pixel sono nitidi esattamente come lo erano i 24.
+    </p>
+
+    <div class="option-row">
+      <label for="size-mode">Imposta la dimensione con</label>
+      <select id="size-mode">
+        <option value="scale" selected>Un moltiplicatore della dimensione che il file chiede</option>
+        <option value="width">Larghezza in pixel</option>
+        <option value="height">Altezza in pixel</option>
+        <option value="longest">Il lato più lungo</option>
+        <option value="box">Un riquadro, con entrambi i lati dati</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="scale-fields">
+      <div class="numbers">
+        <label>Moltiplica per<input type="number" id="size-scale" min="0.01" max="200" step="0.5" value="4"></label>
+      </div>
+      <div class="presets" id="scale-presets" role="group" aria-label="Moltiplicatori comuni">
+        <button type="button" class="ghost" data-scale="1">1&times;</button>
+        <button type="button" class="ghost" data-scale="2">2&times;</button>
+        <button type="button" class="ghost" data-scale="4">4&times;</button>
+        <button type="button" class="ghost" data-scale="8">8&times;</button>
+        <button type="button" class="ghost" data-scale="16">16&times;</button>
+      </div>
+      <p class="hint-line">
+        Ogni file dell'elenco viene moltiplicato a partire dalla propria
+        dimensione, così un lotto di icone disegnate a dimensioni diverse resta
+        in proporzione tra sé.
+      </p>
+    </div>
+
+    <div class="size-fields" id="width-fields" hidden>
+      <div class="numbers">
+        <label>Larghezza<input type="number" id="size-width" min="1" step="1" value="1024"></label>
+      </div>
+      <div class="presets" id="width-presets" role="group" aria-label="Larghezze comuni">
+        <button type="button" class="ghost" data-width="256">256</button>
+        <button type="button" class="ghost" data-width="512">512</button>
+        <button type="button" class="ghost" data-width="1024">1024</button>
+        <button type="button" class="ghost" data-width="2048">2048</button>
+      </div>
+      <p class="hint-line">L'altezza segue dalla forma del disegno.</p>
+    </div>
+
+    <div class="size-fields" id="height-fields" hidden>
+      <div class="numbers">
+        <label>Altezza<input type="number" id="size-height" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">La larghezza segue dalla forma del disegno.</p>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Lato più lungo<input type="number" id="size-longest" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">
+        Il lato più lungo, qualunque sia, diventa questo e l'altro segue, così un
+        logo largo e uno alto escono della stessa dimensione sul lato lungo.
+      </p>
+    </div>
+
+    <div class="size-fields" id="box-fields" hidden>
+      <div class="numbers">
+        <label>Larghezza<input type="number" id="box-width" min="1" step="1" value="1200"></label>
+        <label>Altezza<input type="number" id="box-height" min="1" step="1" value="630"></label>
+      </div>
+      <div class="option-row">
+        <label for="box-fit">Se il disegno ha una forma diversa</label>
+        <select id="box-fit">
+          <option value="fit" selected>Stai dentro &mdash; tutto il disegno, un lato viene più corto</option>
+          <option value="pad">Riempi con lo sfondo &mdash; esattamente questa dimensione, con lo sfondo ai due lati</option>
+          <option value="stretch">Stira &mdash; esattamente questa dimensione, e la forma deformata</option>
+        </select>
+      </div>
+    </div>
+
+    <!--
+      The one thing people rasterise a vector for more than once: the same
+      drawing at 1x, 2x and 3x for a screen with more device pixels than CSS
+      pixels. Multiplied from the plan above rather than planned again, so an
+      @2x is exactly twice its @1x and cannot drift by a rounded pixel.
+    -->
+    <div class="option-row" id="density-row">
+      <label for="density">Scrivi anche le copie ad alta densità</label>
+      <select id="density">
+        <option value="1" selected>No &mdash; un file per disegno</option>
+        <option value="2">Anche @2x &mdash; per uno schermo Retina</option>
+        <option value="3">@2x e @3x &mdash; la serie completa che chiede un telefono</option>
+      </select>
+    </div>
+
+    <p id="size-summary" class="field-summary"></p>
+    <p id="size-warning" class="field-summary warn" hidden></p>
+  </section>
+
+  <!-- Passo 3 &mdash; il formato -->
+  <section class="card" id="format-card">
+    <h2><span class="step">3</span> Scegli il formato</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Formato</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; tiene la trasparenza, bordi esatti</option>
+          <option value="image/jpeg">JPEG &mdash; niente trasparenza, fotografie più leggere</option>
+          <option value="image/webp">WebP &mdash; trasparenza e file più leggero</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Qualità &mdash; <output id="quality-value" for="quality">90</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="90">
+        <p class="field-note">
+          Solo JPEG e WebP; il PNG non ha una manopola della qualità perché è
+          senza perdita. Tinte piatte e bordi netti &mdash; che sono quasi tutto
+          quello di cui è fatto un SVG &mdash; sono esattamente ciò che un
+          encoder con perdita gestisce peggio, quindi qui questo cursore sta più
+          in alto di quanto starebbe per una fotografia.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="background-mode">Sfondo</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Trasparente</option>
+          <option value="colour">Un colore</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Colore di sfondo" hidden>
+        <p class="field-note" id="background-note"></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Passo 4 &mdash; guardalo, poi prendilo -->
+  <section class="card" id="run-card">
+    <h2><span class="step">4</span> Guardalo, poi salvalo</h2>
+
+    <p class="card-lede">
+      L'anteprima è disegnata dallo stesso codice che scrive il file, dal file
+      che hai scelto, su questo dispositivo. Quello che vale la pena controllare
+      sono le due cose che cambiano quando un disegno diventa pixel: un tratto da
+      un capello, largo mezzo pixel, che è diventato grigio, e il testo, che
+      viene disegnato con un carattere che questo dispositivo ha e non con uno
+      recuperato dal web.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-stage">
+        <canvas id="preview-canvas"></canvas>
+      </div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <p id="preview-empty" class="field-summary">Aggiungi un SVG e compare qui.</p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Rasterizza</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Finito</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Scarica tutto in uno zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/svg-to-image.toml
+++ b/locales/it/tools/svg-to-image.toml
@@ -1,0 +1,328 @@
+#
+# Da SVG a immagine - Italian.
+#
+# Overrides for tools/svg-to-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Da SVG a immagine"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Da&nbsp;SVG&nbsp;a&nbsp;PNG <span class=\"h1-kw\">&mdash; rasterizzare un vettoriale in PNG, JPEG o WebP a qualunque dimensione</span>"
+tagline = "Di' la dimensione. Un vettoriale non ne ha una sua da perdere."
+
+title = "Da SVG a PNG &mdash; rasterizzare un vettoriale a qualunque dimensione, senza caricare nulla"
+description = "Converti un SVG in PNG, JPEG o WebP a qualunque dimensione, nel tuo browser. Di' la larghezza, un moltiplicatore o un riquadro; ottieni anche le copie @2x e @3x. Trasparenza conservata, niente caricamenti."
+og_title = "Trasformare un SVG in un PNG a qualunque dimensione, senza caricarlo"
+og_description = "Un vettoriale non ha una dimensione in pixel sua, quindi il numero lo scegli tu - 32 o 8000, con la stessa nitidezza in entrambi i casi. Gira tutto sul tuo dispositivo."
+og_image_alt = "Da SVG a immagine - rasterizzare un vettoriale in PNG, JPEG o WebP a qualunque dimensione"
+
+pledge = """
+    Il disegno viene rasterizzato dallo stesso motore che l'ha appena messo sul
+    tuo schermo. Il tuo file viene letto dal tuo disco, il suo tag radice viene
+    riscritto alla dimensione che hai chiesto da un centinaio di righe in
+    <code>src/svg.js</code> che puoi leggere, e viene disegnato su una tela che
+    il tuo browser si porta già dietro. Questo strumento non ha alcuna funzione
+    di rete &mdash; niente da recuperare, niente da spedire &mdash; e dall'altra
+    parte di questa pagina non c'è alcun server a cui mandare un logo, anche se
+    ci fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e rasterizza qualcosa. Non una sola richiesta porta con sé un
+      file, una miniatura, un nome di file o un byte di quello che hai scelto.
+      Oppure stacca la connessione e convertine uno lo stesso."""
+
+read_first = """
+, <code>src/svg.js</code> per come viene letta
+      la dimensione dichiarata da un file e come ne viene riscritto il tag
+      radice, e <code>src/render.js</code> per le otto righe che rasterizzano
+      &mdash; un &lt;img&gt;, un <code>drawImage</code> e un
+      <code>toBlob</code>, senza niente in mezzo."""
+
+howto_heading = "Come convertire un SVG in PNG senza caricarlo"
+
+card = """
+            Un SVG non ha una dimensione in pixel sua, quindi il numero lo
+            scegli tu &mdash; 32 o 8000, e la nitidezza è la stessa."""
+
+[words]
+plural = "file SVG"
+choose = "un SVG"
+analytics_extra = """, e nemmeno una delle
+  dimensioni, dei formati o dei nomi di file che questo strumento calcola"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Il tuo disegno non ha dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove i tuoi file potrebbero finire, e nel codice non
+      c'è nulla che ce li manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Non c'è un
+      <code>fetch</code>, né un <code>XMLHttpRequest</code>, né un
+      <code>sendBeacon</code> da nessuna parte in <code>src/</code>. Tutto il
+      rasterizzatore è un <code>&lt;img&gt;</code> che contiene un blob del tuo
+      file, un <code>drawImage</code> su una tela, e un
+      <code>canvas.toBlob</code>."""
+
+[[privacy]]
+title = "Un SVG è un documento, e questa è la modalità in cui non può agire."
+body = """
+ Un SVG può portare con sé
+      uno <code>&lt;script&gt;</code>, un
+      <code>&lt;image href=&quot;https://&hellip;&quot;&gt;</code> remoto, un
+      foglio di stile e un carattere web. Disegnato attraverso un
+      <code>&lt;img&gt;</code> si trova in quella che la specifica chiama
+      <em>secure static mode</em>: lo script non gira e non viene recuperato
+      nemmeno uno di quegli indirizzi. È una garanzia del browser, non una
+      nostra promessa, ed è il motivo per cui questa pagina può aprire un file
+      che non ha mai visto senza che il file possa chiamare casa."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google, e il pulsante delle
+      donazioni da Buy Me a Coffee. A nessuno di loro viene passato niente sul
+      tuo disegno. Ogni riga che legge, dimensiona o disegna un file è servita
+      da questa origine ed è elencata nel repository."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento resta
+      identico, perché al suo interno non c'è mai stato un passaggio di rete. È
+      la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli l'SVG."
+body = """
+ Trascinane uno sul riquadro, oppure
+      prendi una cartella intera e convertili tutti in un colpo solo. Il browser
+      legge il file direttamente dal tuo disco; mentre lo fai non viene mandato
+      niente da nessuna parte. Ogni riga dice che dimensione crede di avere il
+      file &mdash; e lo dice in modo diverso quando quella dimensione viene dal
+      suo <code>viewBox</code>, o è stata data per scontata perché il file non ne
+      dichiara nessuna."""
+
+[[howto]]
+title = "Di' quanto grande."
+body = """
+ Un moltiplicatore della dimensione del
+      file è la risposta più rapida e quella giusta per un lotto: ogni disegno
+      viene scalato dal proprio punto di partenza, così una serie di icone resta
+      in proporzione. Altrimenti indica una larghezza, un'altezza, il lato più
+      lungo, o un riquadro con entrambi i lati dati. Qui non c'è alcuna penale
+      per un numero grande come ce n'è con una fotografia &mdash; il disegno
+      viene ridisegnato a quella dimensione, non stirato fino a lì."""
+
+[[howto]]
+title = "Aggiungi le copie ad alta densità, se ti servono."
+body = """
+ Un telefono e un portatile
+      Retina disegnano due o tre pixel fisici per ogni pixel CSS, quindi un logo
+      da 200 pixel ha bisogno di un file da 400 o 600 pixel dietro. Chiedi
+      <code>@2x</code> e <code>@3x</code> ed escono nominate come si aspettano
+      Xcode, gli strumenti di Android e l'<code>image-set()</code> del CSS, e
+      ognuna è esattamente il doppio o il triplo della prima invece che
+      arrotondata a parte."""
+
+[[howto]]
+title = "Scegli il formato e decidi sulla trasparenza."
+body = """
+ PNG, a meno che tu non abbia
+      un motivo: è senza perdita, tiene la trasparenza, e le tinte piatte ci si
+      comprimono bene. Il JPEG non ha alcuna trasparenza, quindi un colore di
+      sfondo viene dipinto che tu ne scelga uno o no &mdash; senza, ogni pixel
+      trasparente esce nero. Il WebP fa entrambe le cose e produce un file più
+      leggero, al prezzo del software abbastanza vecchio da non saperlo
+      leggere."""
+
+[[howto]]
+title = "Guarda l'anteprima prima di scaricare."
+body = """
+ È disegnata dallo stesso codice che
+      scrive il file, dal tuo file, sul tuo dispositivo. Due cose cambiano quando
+      un disegno diventa pixel, ed entrambe si vedono qui: un tratto da un
+      capello, che era largo mezzo pixel, diventa grigio, e il testo viene
+      disegnato con un carattere che questo computer ha, non con uno recuperato
+      dal web."""
+
+[[howto]]
+title = "Prendi i file."
+body = """
+ Un download per file, oppure tutto il
+      lotto in un unico zip. I nomi seguono l'SVG da cui vengono, con
+      <code>@2x</code> e <code>@3x</code> sulle copie, e due file che avrebbero
+      avuto lo stesso nome vengono numerati invece che uno sostituire l'altro in
+      silenzio."""
+
+[[faq]]
+q = "Il mio SVG viene caricato da qualche parte?"
+a = """
+        No. Il file viene letto dal tuo browser sul tuo hardware, disegnato su
+        una tela dallo stesso motore che rende ogni altra immagine che vedi, e
+        restituito come download. Questo strumento non ha alcuna funzione di rete
+        &mdash; non recupera mai niente e non spedisce mai niente &mdash; e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare, nessuno dei quali appartiene a questo
+        sito."""
+
+[[faq]]
+q = "A che dimensione dovrei rasterizzare un SVG?"
+a = """
+        A quella che chiede la cosa che lo legge, moltiplicata per il rapporto di
+        pixel del dispositivo dello schermo su cui verrà visto. Un logo che
+        occupa 200 pixel CSS ha bisogno di 400 per un portatile Retina e di 600
+        per un telefono recente, che è quello che sono qui le copie
+        <code>@2x</code> e <code>@3x</code>. Per l'icona di un'app o per una
+        scheda su uno store, lo store nomina un numero esatto ed è quello il
+        numero. Quando nessuno ti ha detto niente, 1024 sul lato più lungo è un
+        default utile: abbastanza grande per quasi ogni uso e abbastanza piccolo
+        da mandare via mail."""
+
+[[faq]]
+q = "Ingrandirlo fa perdere qualità?"
+a = """
+        No, e questo è l'unico posto in cui quella risposta è onestamente no. Un
+        vettoriale è istruzioni invece che pixel, quindi il browser ridisegna le
+        curve a qualunque dimensione gli si chieda. Quattromila pixel da
+        un'icona da 24 pixel sono nitidi esattamente come lo erano i 24. Quello
+        che non puoi fare è il percorso inverso: una volta che è un PNG sono
+        pixel come qualunque altra cosa, quindi rasterizza alla dimensione che ti
+        serve invece di ridimensionare il risultato dopo."""
+
+[[faq]]
+q = "Il mio SVG non ha larghezza né altezza. Che dimensione ottengo?"
+a = """
+        Il <code>viewBox</code>, se ce n'è uno &mdash; la sua larghezza e la sua
+        altezza sono unità utente e non pixel, ma sono gli unici numeri nel file
+        e un browser li tratta come la dimensione naturale del disegno. Se non
+        c'è nemmeno un viewBox, la pagina scrive <em>presunta</em> accanto alla
+        riga e usa 300&nbsp;&times;&nbsp;150, che è la dimensione a cui l'avrebbe
+        disegnato un <code>&lt;img&gt;</code>. In un caso e nell'altro puoi
+        indicare la dimensione che vuoi e il file viene disegnato a quella."""
+
+[[faq]]
+q = "Perché il testo nel PNG viene diverso?"
+a = """
+        Perché il carattere non è dentro l'SVG. Un SVG che disegna del testo
+        nomina un carattere e lascia che sia la macchina a trovarlo, e un file
+        che se lo tira da Google Fonts con un <code>@import</code> qui non
+        ottiene niente: a un SVG disegnato attraverso un <code>&lt;img&gt;</code>
+        non è concesso recuperare niente, che è la stessa regola che gli impedisce
+        di chiamare casa con il tuo file. La soluzione la conosce già ogni
+        grafico &mdash; converti il testo in tracciati nel programma di disegno
+        prima di esportare. Allora è geometria, e viene uguale dappertutto."""
+
+[[faq]]
+q = "Può convertire più file insieme?"
+a = """
+        Sì. Ogni SVG dell'elenco viene reso con le stesse impostazioni e il lotto
+        scende come un unico zip. Un moltiplicatore &mdash; «4&times; la
+        dimensione che il file chiede» &mdash; di solito è l'impostazione giusta
+        per un lotto, perché ogni disegno viene scalato dalla propria dimensione
+        invece che essere forzato tutto allo stesso numero di pixel. Clicca una
+        riga qualsiasi per mettere quella nell'anteprima."""
+
+[[faq]]
+q = "C'è un limite di dimensione?"
+a = """
+        Quello del browser, non il nostro. Una tela si arrende da qualche parte
+        oltre i 16.384 pixel per lato, e Safari su iPhone o iPad si ferma attorno
+        ai 16,7 megapixel di area &mdash; 4096&nbsp;&times;&nbsp;4096. Sopra
+        quella soglia la pagina ti avverte invece di restituirti un'immagine
+        vuota, che è quello che fa un browser quando è a corto:
+        <code>toBlob</code> non restituisce proprio niente, senza un errore che
+        si spieghi. Oltre i 100 megapixel lo strumento si rifiuta, perché sono
+        400&nbsp;MB di tela prima ancora che sia stato codificato un byte."""
+
+[[faq]]
+q = "Cosa succede alla trasparenza?"
+a = """
+        Viene conservata, in PNG e in WebP. Il JPEG non ha alcun canale alfa,
+        quindi un colore viene dipinto dietro tutta l'immagine che tu ne chieda
+        uno o no &mdash; senza, tutto quello che è trasparente uscirebbe nero,
+        cosa che sembra un difetto e non il JPEG. Anche scegliere un colore di
+        sfondo con il PNG è una cosa perfettamente normale da volere: appiattisce
+        il disegno su quel colore invece di lasciare un buco."""
+
+[[faq]]
+q = "Può leggere un SVG che contiene uno script o un'immagine esterna?"
+a = """
+        Può leggerlo, e disegnerà esattamente le parti che un browser è disposto
+        a disegnare. Un SVG caricato attraverso un <code>&lt;img&gt;</code> si
+        trova in <em>secure static mode</em>: gli script non girano, i
+        riferimenti esterni non vengono recuperati, e l'animazione non parte
+        &mdash; quello che ottieni è il primo fotogramma. Quindi un file che ha
+        dentro un <code>&lt;image&gt;</code> remoto esce con quella parte
+        mancante. È il browser che si rifiuta per conto tuo, ed è il motivo per
+        cui questa pagina può aprire senza rischi un file che non ha mai
+        visto."""
+
+[[faq]]
+q = "Che differenza c'è tra questo e il ridimensionatore di immagini?"
+a = """
+        Da cosa partono. Il ridimensionatore di immagini parte da pixel &mdash;
+        un JPEG, un PNG &mdash; quindi ingrandirlo deve inventare dettaglio che
+        non c'è mai stato. Questo parte da un disegno, quindi non c'è niente da
+        inventare e nessun limite superiore di cui preoccuparsi. Se quello che
+        hai è un SVG, questo è quello che ti dà un risultato nitido; se quello
+        che hai è una fotografia, è l'altro."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Non c'è nemmeno un limite al numero o alla dimensione
+        dei file, perché non c'è un server che li paga &mdash; il lavoro avviene
+        sul tuo dispositivo. Il sito ha della pubblicità, ed è quella che lo
+        paga; agli annunci non viene dato niente sui tuoi file."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la connessione e continua a
+        funzionare. È anche il modo più semplice per dimostrare che non viene
+        caricato niente: uno strumento che spedisse via il tuo disegno per farlo
+        rendere si fermerebbe nel momento in cui stacchi la spina."""
+
+[schema]
+description = "Rasterizza un SVG in PNG, JPEG o WebP a qualunque dimensione, nel browser. Imposta la dimensione con un moltiplicatore, una larghezza, un'altezza, il lato più lungo o un riquadro, aggiungi le copie @2x e @3x, conserva o appiattisci la trasparenza, e converti un lotto in una volta. Non viene caricato nulla."
+features = [
+  "Ridisegna il vettoriale a ogni dimensione, quindi il risultato è nitido a tutte",
+  "Dimensione con un moltiplicatore, una larghezza, un'altezza, il lato più lungo o un riquadro con un adattamento",
+  "Copie @2x e @3x, ognuna un multiplo esatto della prima invece che arrotondata due volte",
+  "PNG, JPEG e WebP, con la trasparenza conservata o appiattita su un colore",
+  "Legge la dimensione da width, height o dal viewBox, e dice quale ha usato",
+  "Avverte prima di una dimensione che la tela di un browser non riesce davvero a produrre",
+  "Anteprima disegnata dallo stesso codice che scrive il file",
+  "Lavora a lotti, con tutti i risultati in un unico zip",
+  "Gli script e i riferimenti remoti dentro il file non vengono mai eseguiti né recuperati",
+  "Funziona offline; niente caricamenti, nessun account",
+]
+
+[picker]
+title = "Trascina qui un SVG"
+hint = "oppure clicca per scegliere &mdash; anche più d'uno alla volta"

--- a/locales/it/tools/trim-video.html
+++ b/locales/it/tools/trim-video.html
@@ -1,0 +1,224 @@
+<main>
+  <!-- Passo 1 &mdash; il video -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli un video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <!-- One row a video, in the order they will be joined. Hidden until there
+         is more than one, because a list of one is furniture. -->
+    <ol class="clip-list" id="clip-list" hidden></ol>
+
+    <p id="join-note" class="path-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; i segni -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> Segna i pezzi che vuoi
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Fallo scorrere e premi <kbd>I</kbd> dove un pezzo deve cominciare e
+      <kbd>O</kbd> dove deve finire. Fallo tutte le volte che vuoi &mdash; ogni
+      coppia diventa una riga qui sotto, e il video finito sono quelle righe, una
+      dopo l'altra. <kbd>U</kbd> annulla l'ultima, <kbd>Spazio</kbd> avvia e mette
+      in pausa, e le frecce saltano di cinque secondi.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- Built by src/timeline.js: a band for every segment, the one being
+         marked, a tick for every keyframe, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Riproduci</button>
+      <button type="button" id="back-5" class="ghost" title="Indietro di cinque secondi">&minus;5s</button>
+      <button type="button" id="forward-5" class="ghost" title="Avanti di cinque secondi">+5s</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Segna l'inizio</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Segna la fine</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Annulla</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Velocità di riproduzione">
+      <span class="speed-label">Velocità</span>
+      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normale</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The segments themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Segmenti <span class="segment-count" id="segment-count">ancora nessuno</span></h3>
+        <p class="segments-total">
+          Totale tenuto <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">#</th>
+            <th scope="col">Inizio</th>
+            <th scope="col">Fine</th>
+            <th scope="col">Durata</th>
+            <th scope="col"><span class="visually-hidden">Azioni</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Non hai ancora segnato niente. Premi <kbd>I</kbd> e poi <kbd>O</kbd>
+        mentre scorre, oppure usa i pulsanti qui sopra.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Aggiungi una riga a mano</button>
+        <button type="button" id="reset-segments" class="ghost danger">Cancellale tutte</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">Carica i segni&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Formato del file dei marcatori temporali">
+          <option value="seconds" selected>secondi</option>
+          <option value="HHMMSSmmm">HH:MM:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">Salva i segni</button>
+      </div>
+
+      <p class="field-note">
+        I segni si salvano come file di testo semplice &mdash; una riga per
+        segmento, nel formato qui sopra &mdash; così una lunga sessione di
+        marcatura sopravvive a una scheda chiusa, e lo stesso file si può
+        consegnare a qualunque strumento che legga quella disposizione.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>Cosa fare con i pezzi segnati</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Tienili</strong>
+          Il video finito sono i pezzi segnati, uniti in ordine.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Toglili</strong>
+          I pezzi segnati se ne vanno, e tutto il resto viene unito.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Passo 3 &mdash; l'esportazione -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Taglialo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="method">Come tagliarlo</label>
+        <select id="method">
+          <option value="copy" selected>Tieni ogni byte &mdash; niente viene ricodificato</option>
+          <option value="exact">Taglia esattamente qui &mdash; ricodifica l'immagine</option>
+          <option value="record">Registralo mentre scorre</option>
+        </select>
+        <p class="field-note" id="method-note"></p>
+      </div>
+
+      <div class="field" id="frame-field" hidden>
+        <label for="frame">Dimensione del fotogramma</label>
+        <select id="frame">
+          <option value="first" selected>Segui il primo video</option>
+          <option value="largest">Segui il più grande</option>
+          <option value="1080p">1920 &times; 1080</option>
+          <option value="720p">1280 &times; 720</option>
+        </select>
+        <p class="field-note">
+          Una dimensione sola copre tutto il file. Un video di un'altra forma
+          viene messo dentro con delle bande, mai stirato.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualità</label>
+        <select id="quality">
+          <option value="low">File più leggero</option>
+          <option value="medium" selected>Equilibrata</option>
+          <option value="high">Massima qualità</option>
+        </select>
+        <p class="field-note">
+          Mai più di quanto spendesse l'originale &mdash; ricodificare al di
+          sopra rende il file solo più pesante.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Tieni l'audio
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Tieni</dt><dd id="sum-clips">&mdash;</dd></div>
+      <div><dt>Durata finita</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Comincia a</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>All'incirca</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Immagine</dt><dd id="sum-picture">&mdash;</dd></div>
+      <div><dt>Suono</dt><dd id="sum-sound">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Taglia il video</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Scarica il video</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/trim-video.toml
+++ b/locales/it/tools/trim-video.toml
@@ -1,0 +1,328 @@
+#
+# Tagliavideo - Italian.
+#
+# Overrides for tools/trim-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Tagliavideo"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Tagliare&nbsp;un&nbsp;video <span class=\"h1-kw\">&mdash; accorciarlo online</span>"
+tagline = "Segna i pezzi che vale la pena tenere mentre scorre. Te li ritrovi come un video solo."
+
+title = "Tagliare un video online &mdash; tieni solo i pezzi che vuoi, senza caricare nulla"
+description = "Guarda un video e segna ogni pezzo che vale la pena tenere mentre scorre, poi salva quei pezzi come un file solo. Gira nel browser: niente caricamenti, niente ricodifiche, funziona offline."
+og_title = "Tagliavideo &mdash; tieni solo i pezzi che vuoi, senza caricare niente"
+og_description = "Premi I e O mentre scorre per segnare ogni pezzo che vale la pena tenere. I pezzi segnati vengono riscritti come un video solo, fotogramma per fotogramma, senza caricare nulla."
+og_image_alt = "Tagliavideo - segna i pezzi che vuoi e salvali come un video solo, nel browser"
+
+pledge = """
+    Il tuo video viene letto, segnato, tagliato e scritto dal tuo browser, sul
+    tuo hardware. Qui dentro non c'è niente che possa recuperare o spedire
+    qualcosa &mdash; questo strumento non ha proprio alcuna funzione di rete
+    &mdash; e dall'altra parte di questa pagina non c'è alcun server a cui
+    mandare un video, anche se ci fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e taglia un video. Non una sola richiesta porta con sé un
+      fotogramma, un nome di file o un byte di quello che hai scelto. Oppure
+      stacca la connessione e tagliane uno lo stesso &mdash; uno strumento che
+      spedisse via il tuo video per tagliarlo si fermerebbe e basta."""
+
+read_first = """
+, <code>src/segments.js</code> per i segni e il file
+      in cui vengono salvati, <code>src/demux.js</code> per il lettore che trova
+      i fotogrammi dentro un MP4, <code>src/ranges.js</code> per l'aritmetica
+      che trasforma un segno in una serie di campioni, e
+      <code>src/copy.js</code> per il ciclo che sposta quei campioni nel file
+      nuovo. Nessuno di loro importa qualcosa in grado di fare una richiesta."""
+
+howto_heading = "Come tagliare un video"
+
+card = """
+            Segna ogni pezzo che vale la pena tenere mentre scorre, poi salvali
+            come un video solo. I fotogrammi vengono copiati invece che
+            ricodificati, quindi non si perde niente."""
+
+[words]
+plural = "video"
+choose = "un video"
+analytics_extra = """, e nessun
+  fotogramma, durata o punto di taglio"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Quanti pezzi vuoi"
+
+[[facts]]
+text = "Nessuna qualità persa"
+
+[[facts]]
+text = "Funziona offline"
+
+[[privacy]]
+title = "I tuoi video non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove il tuo file potrebbe finire, e nel codice non
+      c'è nulla che ce lo manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Questo strumento non ha proprio
+      alcuna funzione di rete: nessun indirizzo da incollare, niente da
+      scaricare, nessun motore recuperato al primo utilizzo. Ogni byte che tocca
+      il tuo video è arrivato da questa origine quando la pagina si è
+      caricata."""
+
+[[privacy]]
+title = "Sulla via normale non viene nemmeno decodificato niente."
+body = """
+
+      Tagliare non cambia l'aspetto di alcun fotogramma, quindi i fotogrammi
+      codificati dei pezzi che hai segnato vengono spostati nel file nuovo
+      esattamente come sono stati trovati. Ognuno viene conservato come una
+      fetta del file sul tuo disco &mdash; un appunto che dice quali byte, non i
+      byte stessi &mdash; e il tuo browser li legge per la prima volta mentre
+      scrive il download. Qui dentro non c'è niente che ritrasformi mai il tuo
+      video in un'immagine."""
+
+[[privacy]]
+title = "Il file dei segni viene fatto nella pagina."
+body = """
+ Salvare i tuoi segni
+      scrive un file di testo a partire dai numeri già sullo schermo,
+      direttamente nei tuoi download. Caricarne uno lo legge qui. Nessuno dei
+      due si avvicina a una rete, e nessuno dei due porta con sé altro che
+      tempi."""
+
+[[privacy]]
+title = "L'audio viene copiato, non ascoltato."
+body = """
+ Su entrambe le vie
+      dell'MP4 i campioni audio vengono spostati dall'altra parte senza essere
+      decodificati affatto &mdash; qui dentro non c'è niente che li ritrasformi
+      in suono, e niente che potrebbe passarli da qualche parte se lo
+      facesse."""
+
+[[privacy]]
+title = "Dove i fotogrammi vengono decodificati, avviene qui."
+body = """
+ Il taglio
+      esatto, e l'anteprima per un file che questo browser non riproduce,
+      passano per WebCodecs sul tuo dispositivo. È lo stesso decodificatore che
+      ti mostrerebbe il video comunque, che gira nello stesso posto."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google. A nessuno dei due viene
+      passato niente sul tuo video: né un file, né un fotogramma, né un nome,
+      una dimensione, una durata o dove l'hai tagliato. Ogni riga che legge,
+      taglia e scrive è servita da questa origine ed è elencata nel
+      repository."""
+
+[[privacy]]
+title = "Cosa carica il pulsante delle donazioni, e cosa non gli viene dato."
+body = """
+
+      Il pulsante «Buy me a coffee» in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non riferisce alcuna visita, e non gli viene passato niente
+      su di te o sul tuo video."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e tutto quello che sta su
+      questa pagina continua a funzionare. È la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli un video."
+body = """
+ Trascina un MP4, un MOV, un M4V o un
+      WebM sul riquadro. Il browser lo legge direttamente dal tuo disco; mentre
+      lo fai non viene mandato niente da nessuna parte. Trascinane parecchi e
+      vengono uniti, nell'ordine in cui li hai messi."""
+
+[[howto]]
+title = "Fallo scorrere, e segna i pezzi che vuoi."
+body = """
+ Premi
+      <kbd>I</kbd> dove un pezzo deve cominciare e <kbd>O</kbd> dove deve finire.
+      Fallo tutte le volte che vuoi &mdash; ogni coppia diventa una riga nella
+      tabella qui sotto, e una fascia sulla linea del tempo. <kbd>U</kbd> toglie
+      l'ultima, <kbd>Spazio</kbd> avvia e mette in pausa, e le frecce saltano di
+      cinque secondi alla volta. Rallenta la riproduzione se il momento è
+      difficile da prendere."""
+
+[[howto]]
+title = "Sistema i segni."
+body = """
+ Ogni riga si può riprodurre per conto
+      suo, ritempificare scrivendoci dentro un tempo esatto, spostare su o giù
+      nell'ordine, o cancellare. I due estremi del pezzo selezionato si possono
+      anche trascinare lungo la linea del tempo. Il totale in cima è quanto
+      durerà il video finito."""
+
+[[howto]]
+title = "Tienili, oppure toglili."
+body = """
+ Tenere è il verso abituale: il
+      video finito sono i pezzi che hai segnato, uniti in ordine. Toglierli è
+      l'altro lavoro che si vuole e che raramente si trova &mdash; segna le
+      pubblicità, i silenzi o le false partenze, e quello che resta viene unito
+      senza di loro."""
+
+[[howto]]
+title = "Taglia, e scarica."
+body = """
+ «Tieni ogni byte» sposta i
+      fotogrammi dall'altra parte intatti: è rapido e non può costare qualità,
+      ma ogni pezzo comincia dal fotogramma chiave prima del tuo segno.
+      «Taglia esattamente qui» decodifica e riscrive l'immagine, così ogni pezzo
+      parte dal fotogramma che hai scelto. La pagina dice quale dei due stai per
+      ottenere, e quanto costa, prima che tu prema il pulsante."""
+
+[[faq]]
+q = "Il mio video viene caricato da qualche parte?"
+a = """
+        No. Viene letto, segnato, tagliato e scritto dal tuo browser sul tuo
+        hardware. Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare &mdash; nessuno di questi appartiene a
+        questo sito. Se preferisci verificare invece che crederci, stacca la
+        connessione e taglia un video lo stesso."""
+
+[[faq]]
+q = "Posso tenere più pezzi dello stesso video?"
+a = """
+        È esattamente per questo che esiste. Premi <kbd>I</kbd> e <kbd>O</kbd>
+        tutte le volte che vuoi mentre scorre; ogni coppia diventa una riga, e il
+        video finito è ogni riga unita in ordine con tutto il resto sparito.
+        Quasi tutti i tagliavideo online ti danno una coppia di maniglie e ti
+        chiedono quale unico tratto tenere, il che va bene per rifilare l'inizio
+        e la fine di una clip e non serve a niente per guardare un'ora di riprese
+        una volta sola e tenere i sei momenti che valgono."""
+
+[[faq]]
+q = "Tagliare fa perdere qualità?"
+a = """
+        Non sulla via normale, e non nel modo che conta. Tagliare non cambia
+        l'aspetto di alcun fotogramma, quindi i fotogrammi vengono spostati nel
+        file nuovo esattamente com'erano: gli stessi byte, le stesse
+        impostazioni dell'encoder, tutto uguale. L'unica via di qui che
+        ricodifica qualcosa è il taglio esatto, e lo dice sul pulsante."""
+
+[[faq]]
+q = "Perché un pezzo comincia prima di dove l'ho segnato?"
+a = """
+        Per come è conservato il video, e solo sui lettori che ignorano una parte
+        standard del formato. Quasi tutti i fotogrammi sono conservati come una
+        descrizione di come differiscono dai vicini, quindi non si possono
+        decodificare senza di loro; solo un fotogramma chiave sta in piedi da
+        solo, e i fotogrammi chiave di solito distano da uno a dieci secondi. Un
+        taglio che copia i fotogrammi deve quindi portarsi la serie a partire dal
+        fotogramma chiave davanti al tuo segno &mdash; e il file dice <em>comincia
+        a riprodurre dal tuo segno</em>, cosa che ogni lettore diffuso rispetta.
+        Se ti serve esatto su qualunque lettore, scegli «Taglia esattamente qui»,
+        che ricodifica. La pagina ti dice in quale dei due casi ti trovi, e di
+        quanto, prima che tu esporti."""
+
+[[faq]]
+q = "Posso invece togliere le pubblicità?"
+a = """
+        Sì. Segnale, poi scegli «Toglili»: viene unito invece tutto quello che
+        <em>non</em> hai segnato, in ordine. Lo stesso elenco di segni risponde a
+        entrambe le domande, quindi puoi passare dall'una all'altra e vedere la
+        durata cambiare senza segnare niente due volte."""
+
+[[faq]]
+q = "Posso salvare i miei segni e riprenderli dopo?"
+a = """
+        Sì. «Salva i segni» scrive un file di testo semplice &mdash; una riga per
+        pezzo, un inizio e una fine separati da una virgola &mdash; e «Carica i
+        segni» ne rilegge uno. Vengono offerti due formati, secondi semplici e
+        <code>HH:MM:SS.mmm</code>, ed entrambi rispettano la disposizione che
+        altri strumenti fatti così usano già, quindi un file scritto qui si può
+        consegnare a uno di quelli e un file scritto là si può trascinare su
+        questa pagina. Segnare è un lavoro paziente e nessuno dovrebbe doverlo
+        fare due volte."""
+
+[[faq]]
+q = "Quali formati video posso tagliare?"
+a = """
+        MP4, M4V e MOV vengono letti direttamente, qualunque cosa ci sia dentro:
+        H.264, HEVC, AV1 o VP9. Copiare i fotogrammi non comporta decodificarli,
+        quindi questa via funziona anche per un codec per cui il tuo browser non
+        ha proprio alcun decodificatore. Tutto il resto che il browser sa
+        riprodurre &mdash; il WebM in primis &mdash; viene invece tagliato
+        riproducendolo e registrando il risultato, il che funziona, richiede
+        tanto tempo quanto è lungo il risultato, e può tenere un pezzo solo. Un
+        file che il browser non sa né leggere né riprodurre, il che in pratica
+        vuol dire AVI, WMV, FLV e quasi tutti gli MKV, viene rifiutato con un
+        messaggio che lo dice, invece di piantarsi a metà strada."""
+
+[[faq]]
+q = "C'è un limite alla dimensione o alla durata del video?"
+a = """
+        Nello strumento non c'è alcun limite, e sulla via della copia il file
+        viene letto a malapena: i fotogrammi che tieni vengono puntati invece che
+        caricati, quindi tenere quattro minuti da una registrazione di quattro
+        gigabyte costa più o meno quanto costa scrivere quei quattro minuti sul
+        disco. Il taglio esatto percorre il file qualche megabyte alla volta. In
+        entrambi i casi il tetto pratico è il file finito, che viene assemblato
+        in memoria prima che tu lo scarichi."""
+
+[[faq]]
+q = "L'audio sopravvive?"
+a = """
+        Su entrambe le vie dell'MP4 viene copiato campione per campione senza
+        essere mai decodificato, quindi è byte per byte quello che c'era nel
+        file, e un segno di montaggio tiene ogni pezzo allineato con la sua
+        immagine entro un millesimo di secondo. L'unica eccezione è unire video
+        separati il cui audio è descritto in modo diverso &mdash; frequenze di
+        campionamento diverse, per esempio &mdash; dove non c'è modo di mettere
+        entrambi in una traccia sola senza decodificarli, e la pagina lo dice
+        prima di farlo. Sulla via della registrazione viene catturato dalla
+        riproduzione e ricodificato. In entrambi i casi c'è una casella per
+        lasciarlo fuori del tutto."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Il sito ha della pubblicità, ed è quella che lo paga;
+        agli annunci non viene dato niente sul tuo video."""
+
+[schema]
+browser_requirements = "Richiede JavaScript. Copiare i fotogrammi non richiede alcun supporto ai codec video; il taglio esatto richiede un browser con WebCodecs, e gli altri formati ripiegano sulla registrazione."
+description = "Segna quanti pezzi vuoi di un video mentre scorre, poi salva quei pezzi come un file solo - oppure toglili e tieni il resto. MP4, MOV e M4V vengono tagliati spostando i fotogrammi codificati in un file nuovo intatti, con l'audio originale portato dall'altra parte campione per campione; non viene caricato nulla e non viene ricodificato niente."
+features = [
+  "Segna quanti pezzi vuoi con I e O mentre il video scorre",
+  "Unisce i pezzi segnati in un file solo, nell'ordine che scegli tu",
+  "Oppure toglie i pezzi segnati, tenendo tutto il resto",
+  "Taglia senza ricodificare, quindi non si perde qualità",
+  "Salva e ricarica i segni come un file di testo di marcatori temporali",
+  "Segni al fotogramma, con i fotogrammi chiave mostrati sulla linea del tempo",
+  "Tiene l'audio originale senza ricodificarlo",
+  "Funziona offline; niente caricamenti, nessun account, nessuna filigrana",
+]
+
+[picker]
+title = "Trascina qui un video"
+hint = "oppure clicca per scegliere &mdash; MP4, MOV, M4V, WebM. Trascinane parecchi per unirli."

--- a/locales/it/tools/video-to-gif.html
+++ b/locales/it/tools/video-to-gif.html
@@ -1,0 +1,169 @@
+<main>
+  <!-- Passo 1 &mdash; il file -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli un video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Dimensione</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Fotogramma</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durata</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Letto da</dt><dd id="src-path">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 2 &mdash; il pezzo -->
+  <section class="card" id="section-card" hidden>
+    <h2><span class="step">2</span> Scegli il pezzo</h2>
+
+    <p class="hint">
+      Fai scorrere la clip e segna la parte che vuoi. <kbd>I</kbd> mette
+      l'inizio dov'è la testina, <kbd>O</kbd> mette la fine, ed entrambe le
+      maniglie sulla barra si possono trascinare.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- The bar itself is built by src/range.js. -->
+    <div id="rangebar"></div>
+    <div class="rb-scale">
+      <span>0:00.000</span>
+      <span id="scale-end">&mdash;</span>
+    </div>
+
+    <div class="marks">
+      <label>Inizio
+        <input type="text" id="start-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-in" class="ghost" title="Metti l'inizio dov'è la testina (I)">
+        Metti sulla testina
+      </button>
+
+      <label>Fine
+        <input type="text" id="end-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-out" class="ghost" title="Metti la fine dov'è la testina (O)">
+        Metti sulla testina
+      </button>
+
+      <div class="mark-actions">
+        <button type="button" id="play-section" class="ghost">Riproduci il pezzo</button>
+        <button type="button" id="whole-clip" class="ghost">Tutta la clip</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; la GIF -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Dimensione e frequenza</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="width">Larghezza</label>
+        <select id="width">
+          <option value="240">240 px</option>
+          <option value="320">320 px</option>
+          <option value="480" selected>480 px</option>
+          <option value="640">640 px</option>
+          <option value="source">Dimensione originale</option>
+          <option value="custom">Esattamente&hellip;</option>
+        </select>
+        <p class="field-note">
+          L'altezza segue, quindi la forma non cambia mai. È la larghezza a
+          costare in una GIF: metà larghezza è un quarto dei pixel.
+        </p>
+        <p class="field-note" id="width-note" hidden></p>
+      </div>
+
+      <div class="field" id="custom-width-field" hidden>
+        <label for="custom-width">Larghezza esatta</label>
+        <input type="number" id="custom-width" min="16" max="1920" step="1" value="480">
+        <p class="field-note">In pixel, tra 16 e 1920.</p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Fotogrammi al secondo</label>
+        <select id="fps">
+          <option value="5">5 &mdash; il più leggero</option>
+          <option value="10">10</option>
+          <option value="12" selected>12 &mdash; abbastanza fluido</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+          <option value="25">25 &mdash; il più fluido</option>
+        </select>
+        <p class="field-note">
+          Non è la frequenza del video: i fotogrammi vengono campionati da lui.
+          Dodici si leggono come movimento; sopra i venti il file cresce più in
+          fretta di quanto si veda la fluidità.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Dithering</label>
+        <select id="dither">
+          <option value="on" selected>Attivo &mdash; sfumature più morbide</option>
+          <option value="off">Spento &mdash; più piatto, più leggero</option>
+        </select>
+        <p class="field-note">
+          Mescola due colori della tavolozza dove quello giusto manca. È
+          ordinato, così uno sfondo fermo non tremola.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="loop">
+          <input type="checkbox" id="loop" checked>
+          Ripeti all'infinito
+        </label>
+        <p class="field-note">Se lo togli, scorre una volta e si ferma.</p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Pezzo</dt><dd id="sum-section">&mdash;</dd></div>
+      <div><dt>Uscita</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Fotogrammi</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Peso approssimativo</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="memory-note" class="field-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Fai la GIF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <img id="result-image" alt="L'animazione finita, in riproduzione">
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Scarica la GIF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/it/tools/video-to-gif.toml
+++ b/locales/it/tools/video-to-gif.toml
@@ -1,0 +1,261 @@
+#
+# Da video a GIF - Italian.
+#
+# Overrides for tools/video-to-gif/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Da video a GIF"
+# La coda è l'espressione che si cerca; il nome del prodotto resta la metà che
+# grida.
+heading = "Da&nbsp;video&nbsp;a&nbsp;GIF <span class=\"h1-kw\">&mdash; convertire un video in una GIF</span>"
+tagline = "Scegli il pezzo, la dimensione e la frequenza dei fotogrammi."
+
+title = "Convertitore da video a GIF &mdash; gratis, senza caricare nulla, anche offline"
+description = "Trasforma un pezzo di un MP4, un MOV o un WebM in una GIF animata. Scegli il pezzo, la larghezza e la frequenza dei fotogrammi; i fotogrammi vengono letti e la GIF viene scritta nel tuo browser. Niente caricamenti."
+og_title = "Da video a GIF &mdash; fare una GIF senza caricare la clip"
+og_description = "Segna i secondi che vuoi, scegli una larghezza e una frequenza, e ottieni una GIF animata. Il campionamento dei fotogrammi, la tavolozza, il dithering e l'LZW avvengono tutti sul tuo dispositivo."
+og_image_alt = "Da video a GIF - fare una GIF animata nel browser, senza caricare nulla"
+
+pledge = """
+    Ogni fotogramma viene letto, ridimensionato, quantizzato e scritto dal tuo
+    browser, sul tuo hardware. Qui dentro non c'è niente che possa recuperare o
+    spedire qualcosa &mdash; questo strumento non ha proprio alcuna funzione di
+    rete &mdash; e dall'altra parte di questa pagina non c'è alcun server a cui
+    mandare un video, anche se ci fosse un modo per farlo."""
+
+live_hint = """
+      Non crederci sulla parola: apri gli strumenti di sviluppo, guarda la
+      scheda Rete e fai una GIF. Non una sola richiesta porta con sé un
+      fotogramma, un nome di file o un byte di quello che hai scelto. Oppure
+      stacca la connessione e fanne una lo stesso &mdash; uno strumento che
+      spedisse via il tuo video per convertirlo si fermerebbe e basta."""
+
+read_first = """
+, <code>src/frames.js</code> per i due modi in cui
+      i fotogrammi vengono letti da un video, <code>src/quantize.js</code> per
+      la tavolozza, e <code>src/gif.js</code> per il file in sé, LZW compreso.
+      Nessuno di loro importa qualcosa in grado di fare una richiesta."""
+
+howto_heading = "Come trasformare un video in una GIF"
+
+card = """
+            Segna i secondi che vuoi, scegli una larghezza e una frequenza, e
+            ottieni una GIF animata &mdash; tavolozza, dithering e tutto il
+            resto."""
+
+[words]
+plural = "video"
+choose = "un video"
+analytics_extra = """, e nessun
+  fotogramma, durata o dimensione"""
+
+[[facts]]
+text = "Niente caricamenti"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Qualunque durata"
+
+[[facts]]
+text = "Funziona offline"
+
+[[privacy]]
+title = "I tuoi video non hanno dove andare."
+body = """
+ La
+      Content-Security-Policy nomina tutti gli indirizzi che questa pagina può
+      contattare, e nessuno di questi appartiene a questo sito. Qui non esiste
+      un punto di raccolta dove il tuo file potrebbe finire, e nel codice non
+      c'è nulla che ce lo manderebbe se esistesse."""
+
+[[privacy]]
+title = "Qui dentro niente recupera niente."
+body = """
+ Questo strumento non ha proprio
+      alcuna funzione di rete: nessun indirizzo da incollare, niente da
+      scaricare, nessun motore recuperato al primo utilizzo. Ogni byte che tocca
+      il tuo video è arrivato da questa origine quando la pagina si è
+      caricata."""
+
+[[privacy]]
+title = "La decodifica è locale."
+body = """
+ I fotogrammi passano per WebCodecs
+      dentro il tuo browser, oppure per lo stesso motore di riproduzione che ti
+      mostrerebbe la clip comunque. Quale dei due sia stato usato è scritto in
+      cima alla pagina, perché cambia il modo in cui i fotogrammi vengono
+      scelti e devi poterlo vedere."""
+
+[[privacy]]
+title = "La GIF viene scritta qui, in codice che puoi leggere."
+body = """
+ La
+      tavolozza, il dithering e la compressione LZW sono un seicento righe nella
+      cartella di questo strumento. Non c'è un servizio di codifica, non c'è una
+      libreria recuperata all'avvio, e in nessun punto di tutto questo
+      un'immagine potrebbe essere spedita."""
+
+[[privacy]]
+title = "Cosa carica Google, e cosa non gli viene dato."
+body = """
+ Gli script
+      pubblicitari e di misurazione arrivano da Google. A nessuno dei due viene
+      passato niente sul tuo video: né un file, né un fotogramma, né un nome,
+      una dimensione, una durata o il pezzo che hai segnato. Ogni riga che
+      legge, campiona, quantizza o codifica è servita da questa origine ed è
+      elencata nel repository."""
+
+[[privacy]]
+title = "Cosa carica il pulsante delle donazioni, e cosa non gli viene dato."
+body = """
+
+      Il pulsante «Buy me a coffee» in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non riferisce alcuna visita, e non gli viene passato niente
+      su di te o sul tuo video."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e tutto quello che sta su
+      questa pagina continua a funzionare. È la prova più semplice di tutte."""
+
+[[howto]]
+title = "Scegli un video."
+body = """
+ Trascina un MP4, un MOV, un M4V o un
+      WebM sul riquadro, oppure selezionane uno a mano. Il browser lo legge
+      direttamente dal tuo disco; mentre lo fai non viene mandato niente da
+      nessuna parte."""
+
+[[howto]]
+title = "Segna il pezzo."
+body = """
+ Fai scorrere la clip e premi
+      <kbd>I</kbd> dove deve cominciare e <kbd>O</kbd> dove deve finire, oppure
+      trascina le maniglie sulla barra. Una GIF dura qualche secondo &mdash; è
+      questa l'impostazione che decide se il file sarà leggero o enorme, molto
+      più delle altre due."""
+
+[[howto]]
+title = "Scegli la larghezza e la frequenza dei fotogrammi."
+body = """
+ 480 pixel di
+      larghezza e 12 fotogrammi al secondo vanno bene per quasi tutto ciò a cui
+      serve una GIF. Dimezzare la larghezza divide i pixel per quattro; dodici
+      fotogrammi al secondo si leggono come movimento senza pagare per quelli
+      che nessuno vede."""
+
+[[howto]]
+title = "Falla, e scarica."
+body = """
+ I fotogrammi vengono letti, viene
+      scelta una sola tavolozza di 256 colori per tutta l'animazione, e ogni
+      fotogramma viene scritto come la sola parte dell'immagine che è cambiata.
+      Quando è finita si riproduce sulla pagina, ed è lo stesso file che ti dà
+      il download."""
+
+[[faq]]
+q = "Il mio video viene caricato da qualche parte?"
+a = """
+        No. Viene letto, campionato e convertito dal tuo browser sul tuo
+        hardware. Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina nomina tutti gli
+        indirizzi che può contattare &mdash; nessuno di questi appartiene a
+        questo sito. Se preferisci verificare invece che crederci, stacca la
+        connessione e fai una GIF lo stesso."""
+
+[[faq]]
+q = "Quali formati video posso convertire?"
+a = """
+        MP4, M4V e MOV vengono letti direttamente, qualunque cosa ci sia dentro:
+        H.264, HEVC, AV1 o VP9, purché il tuo browser sappia decodificare quel
+        codec. Tutto il resto che il browser sa riprodurre &mdash; il WebM in
+        primis &mdash; viene invece letto portando il lettore su ogni istante,
+        cosa più lenta e leggermente meno esatta su quale fotogramma finisca
+        dove. Un file che il browser non sa né leggere né riprodurre, il che in
+        pratica vuol dire AVI, WMV, FLV e quasi tutti gli MKV, viene rifiutato
+        con un messaggio che lo dice, invece di piantarsi a metà strada."""
+
+[[faq]]
+q = "Perché la mia GIF è così pesante?"
+a = """
+        Perché la GIF è un formato del 1987 che conserva immagini intere invece
+        del movimento. Non c'è modo di farne una da una clip di cinque secondi
+        che sia leggera come l'MP4 di cinque secondi da cui viene &mdash; una GIF
+        di un video pesa abitualmente dieci volte il video. Le tre impostazioni
+        che la decidono davvero sono, in quest'ordine: quanto è lungo il pezzo,
+        quanto è larga l'immagine, e quanti fotogrammi al secondo. Dimezzare la
+        larghezza divide i pixel per quattro, e sono i pixel a costare."""
+
+[[faq]]
+q = "Perché solo 256 colori?"
+a = """
+        È il formato: una GIF porta con sé una tabella di al massimo 256 colori e
+        conserva ogni pixel come un numero che punta lì dentro. Questo strumento
+        sceglie quei 256 contando i colori di ogni fotogramma del tuo pezzo e
+        dividendoli in 256 gruppi &mdash; median cut, il metodo classico &mdash;
+        così la tavolozza si adatta alla tua clip invece di essere un insieme
+        fisso di colori. Dove un colore manca, il dithering mescola i due più
+        vicini, così una sfumatura resta una sfumatura invece di diventare a
+        strisce."""
+
+[[faq]]
+q = "Cosa fa l'impostazione del dithering?"
+a = """
+        Scambia un po' di rumore per molte meno bande. Con il dithering attivo,
+        un cielo che altrimenti diventerebbe quattro fasce piatte resta una
+        sfumatura, al prezzo di una texture leggera e di un file più pesante.
+        Senza, l'immagine è più piatta e il file più leggero, il che va bene per
+        le registrazioni dello schermo, i disegni al tratto e qualunque cosa sia
+        già fatta di tinte piatte. Il dithering usato qui è ordinato e non del
+        tipo a diffusione dell'errore, così uno sfondo che non cambia resta
+        perfettamente fermo tra un fotogramma e l'altro invece di tremolare."""
+
+[[faq]]
+q = "C'è un limite alla durata o alla dimensione?"
+a = """
+        Il limite riguarda il pezzo, ed è dettato dalla memoria e non da una
+        regola: ogni suo fotogramma viene tenuto insieme agli altri mentre viene
+        scelta la tavolozza, quindi la pagina calcola quanto costerebbero le tue
+        impostazioni e lo dice prima che tu cominci. Si rifiuta invece di
+        lasciare che la scheda finisca la memoria e sparisca. Un pezzo più corto,
+        una larghezza minore o una frequenza più bassa lo fanno scendere
+        tutti."""
+
+[[faq]]
+q = "Tiene l'audio?"
+a = """
+        Una GIF non può portare suono. Non esiste una versione del formato che
+        abbia l'audio, che è il motivo principale per cui il web ha sostituito
+        quasi ovunque le GIF con video muti che si ripetono. Se il suono conta,
+        tieni il video &mdash; il <a href="../tagliare-video/">tagliavideo</a> ne
+        ritaglia un pezzo senza ricodificare un fotogramma."""
+
+[[faq]]
+q = "È gratis, e mi serve un account?"
+a = """
+        È gratis, e non c'è account, non c'è accesso, non c'è periodo di prova e
+        non c'è filigrana. Il sito ha della pubblicità, ed è quella che lo paga;
+        agli annunci non viene dato niente sul tuo video."""
+
+[schema]
+browser_requirements = "Richiede JavaScript. MP4 e MOV hanno bisogno di un browser con WebCodecs; tutto quello che il browser sa riprodurre funziona anche senza."
+description = "Converti un pezzo di video in una GIF animata, nel browser. I fotogrammi vengono campionati alla frequenza scelta, viene scelta con il median cut una sola tavolozza da 256 colori per tutta l'animazione, e ogni fotogramma viene scritto come la sola zona che è cambiata. Non viene caricato nulla."
+features = [
+  "Converte video MP4, MOV, M4V e WebM in GIF animata",
+  "Sorgenti H.264, HEVC, AV1 e VP9, decodificate con WebCodecs",
+  "Segna il pezzo su una linea del tempo, oppure scrivi i tempi esatti",
+  "Qualunque larghezza, da 5 a 25 fotogrammi al secondo, dithering ordinato facoltativo",
+  "Funziona offline; niente caricamenti, nessun account, nessuna filigrana",
+]
+
+[picker]
+title = "Trascina qui un video"
+hint = "oppure clicca per scegliere &mdash; MP4, MOV, M4V, WebM e qualunque altra cosa questo browser riproduca"


### PR DESCRIPTION
Italian is finished: `complete = true`, 0 strings falling back to English, and the
link check switched on for it.

## What is covered

All 66 files under `locales/it/`:

* **The frame** — `locale.toml`: the hub, the guides index, the roadmap, the 404,
  the footer, and the words the templates use. Extended with the twelve slugs that
  were missing and the fourth hub category.
* **The roadmap list** — `planned.toml`, all six groups and every item, against the
  current English (which lost the two entries that shipped as tools).
* **All fifteen tools** — `tool.toml` and `body.html` each.
* **All fifteen guides** — `page.toml` and `body.html` each.
* **The two legal pages** — privacy and terms.

Nothing structural is restated: no tool list, no category ids, no ordering, no CSP,
no `lastmod`. Every `[[faq]]`, `[[howto]]`, `[[privacy]]`, `[[facts]]`, `features`
and `planned` list matches the English count, which is what the build refuses
otherwise.

## The slugs

The twelve that were missing, chosen as the words an Italian speaker types into a
search box rather than as translations of the English slug — the same rule the
existing twenty-two follow.

| English | Italian | why |
|---|---|---|
| `image-to-ico` | `creare-favicon` | The job, not the format. Almost nobody searches "da immagine a ICO"; a great many people search how to make a favicon. |
| `svg-to-image` | `svg-in-png` | Conversions drop the verb in Italian search, as `immagini-in-pdf` already does here. PNG is what the question names, even though the tool also writes JPEG and WebP. |
| `heic-to-jpg` | `heic-in-jpg` | Same pattern. |
| `image-to-data-uri` | `immagine-in-base64` | Nobody searches "data URI". They search base64, which is the thing that ends up in the stylesheet. |
| `qr-barcode` | `creare-qr-code` | "QR code" and not "codice QR": the loan is what Italian writes and searches. |
| `video-to-gif` | `video-in-gif` | Same pattern. |
| `guides/make-a-favicon` | `guide/creare-una-favicon` | Guides keep the full verb phrase, as the existing nine do. |
| `guides/convert-an-svg-to-png` | `guide/convertire-un-svg-in-png` | |
| `guides/convert-heic-to-jpg` | `guide/convertire-heic-in-jpg` | |
| `guides/embed-an-image-in-css` | `guide/inserire-un-immagine-nel-css` | |
| `guides/make-a-qr-code` | `guide/creare-un-qr-code` | |
| `guides/turn-a-video-into-a-gif` | `guide/trasformare-un-video-in-gif` | |

Cross-links inside every translated body point at those Italian slugs. That is what
the link check on a complete locale exists to catch, and it passes.

## Two frame strings I rewrote rather than translated

Both because Italian agreement made the English sentence shape impossible to fill
safely, and both are in `locale.toml` with the reason written beside them.

* **`[ui] pledge_line`.** The English is "Your {plural} are **never uploaded**." A
  passive participle in Italian agrees in gender with its subject, and
  `{{ tool.words.plural }}` is feminine for some tools (`immagini`, `foto`) and
  masculine for others (`documenti`, `video`). Any single wording was wrong for
  half the site. It is now active — "Questa pagina non carica **mai** X" — which
  has nothing to agree with and reads correctly for every noun.
* **`[ui.picker]`.** Two of its three sentences put an article in front of
  `{{ tool.picker.urls.noun }}` and one treated the noun as plural, so the
  Italian frame as it stood rendered "La immagine" and "delle sue immagine".
  Rewritten so no sentence needs the article, and the noun is a singular
  everywhere.

## Calls worth a second opinion

* **`creare-favicon`** names the job most people arrive for, but the tool also
  writes a macOS `.icns` and a Windows application icon. The slug is narrower than
  the tool.
* **`immagine-in-base64`** likewise: the tool percent-encodes SVGs rather than
  base64-ing them, and says so on the page, so the slug names the common half.
* **`svg-in-png`** for a tool that also writes JPEG and WebP, for the same reason.
* **Register.** Informal *tu* throughout, which is what the existing Italian frame
  already used. The German locale uses *Sie*; Italian web copy of this kind
  normally does not.
* **Elided articles in slugs.** `comprimere-un-immagine-a-una-dimensione-esatta`
  keeps the pre-existing convention of dropping the apostrophe from *un'immagine*
  rather than spelling it *una-immagine*. The new guide slugs follow it.
* **Quotation marks.** Italian guillemets « … » in prose, since nothing had been
  established. HTML entities, tags and `{{ }}` expressions are byte-identical to
  the English throughout.

## Stacking

**This is stacked on #48** and must be merged after it. It is branched from
`claude/website-i18n-translations` at `a52e05f`; the only files it touches are under
`locales/it/`.

One thing found and deliberately not touched: `main` has gained two more tools and
two more guides since `a52e05f`, which are not on this branch. Whenever main is
merged in again, Italian will need those four files and its flag will fail the
build until it has them — the same thing that just happened to German.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
