### PR TITLE
Translate the site into French

### DIFF
--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -13,7 +13,7 @@ lang = "fr"
 name = "French"
 endonym = "Français"
 
-complete = false
+complete = true
 
 #
 # ---------------------------------------------------------------------------
@@ -45,6 +45,25 @@ complete = false
 "images-to-video" = "images-en-video"
 "resize-image" = "redimensionner-une-image"
 "trim-video" = "couper-une-video"
+# Named for the job rather than for the format, like the EXIF tool above:
+# hardly anyone types "image en ICO", and a great many people type "créer un
+# favicon".
+"image-to-ico" = "creer-un-favicon"
+# The article drops out where the two format names carry the phrase. "Convertir
+# SVG en PNG" is what gets typed, and "convertir-un-svg-en-une-png" is not
+# French anybody writes - the formats behave like proper nouns here.
+"svg-to-image" = "convertir-svg-en-png"
+"heic-to-jpg" = "convertir-heic-en-jpg"
+# The same shape as "images-en-pdf" and "images-en-video" above: a conversion
+# named by its two ends.
+"video-to-gif" = "video-en-gif"
+"image-to-data-uri" = "image-en-base64"
+# The one tool here named by a noun rather than by a verb, because that is the
+# phrase: "générateur de QR code" is what French speakers type, in a way that
+# "créer un QR code" - which is the GUIDE below - is not. The barcodes are left
+# out of the address and carried by the page title; QR is what the search is
+# about, and a slug naming both would be too long to read in a URL bar.
+"qr-barcode" = "generateur-de-qr-code"
 
 "guides" = "guides"
 "roadmap" = "feuille-de-route"
@@ -60,6 +79,17 @@ complete = false
 "guides/trim-a-video" = "guides/couper-une-video"
 "guides/crop-a-video" = "guides/recadrer-une-video"
 "guides/is-it-safe-to-upload-files" = "guides/est-il-sur-d-envoyer-ses-fichiers"
+# "Son favicon" rather than "un favicon", which is the tool's address just
+# above: the guide is the long way round and the possessive says so, and two
+# addresses one word apart would be a coin toss for whoever pastes one.
+"guides/make-a-favicon" = "guides/creer-son-favicon"
+# The guides keep the article the tool slugs drop, because a question is asked
+# in full sentences even when a search box is not.
+"guides/convert-an-svg-to-png" = "guides/convertir-un-svg-en-png"
+"guides/convert-heic-to-jpg" = "guides/convertir-un-heic-en-jpg"
+"guides/turn-a-video-into-a-gif" = "guides/transformer-une-video-en-gif"
+"guides/embed-an-image-in-css" = "guides/integrer-une-image-dans-le-css"
+"guides/make-a-qr-code" = "guides/creer-un-qr-code"
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/fr/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/fr/pages/guides/combine-images-into-a-pdf.html
@@ -1,0 +1,211 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez <a href="../../images-en-pdf/">Images en PDF</a>, déposez-y les
+      images, faites glisser les tuiles jusqu'à ce que l'ordre soit bon, et créez
+      le document. Les réglages par défaut &mdash; pages A4, petite marge,
+      photographies recopiées sans réencodage &mdash; sont ce que veulent la
+      plupart des gens.
+    </p>
+    <p>
+      Les quatre choses qui méritent réflexion sont l'ordre, le format de page,
+      le réglage de qualité, et ce que le document fini raconte sur vous. Dans
+      cet ordre de fréquence des erreurs.
+    </p>
+  </section>
+
+  <section>
+    <h2>Réglez l'ordre avant tout le reste</h2>
+    <p>
+      L'ordre des pages est de loin ce qu'on rate le plus, parce que les noms de
+      fichiers se trient d'une façon à laquelle personne ne s'attend.
+      <code>IMG_2.jpg</code> vient après <code>IMG_10.jpg</code> dans un tri
+      alphabétique, puisque la comparaison se fait caractère par caractère et que
+      <code>1</code> précède <code>2</code>. Un dossier de scans nommés
+      <code>page1</code> à <code>page12</code> arrivera dans le mauvais ordre
+      dans à peu près n'importe quel outil.
+    </p>
+    <p>
+      Trier par date de prise de vue est en général plus fiable pour des
+      photographies, parce que vous avez photographié les pages dans l'ordre où
+      elles étaient. Dans un cas comme dans l'autre, vérifiez les tuiles avant
+      d'appuyer sur le bouton, plutôt que de vérifier le PDF après.
+    </p>
+  </section>
+
+  <section>
+    <h2>La qualité&nbsp;: ce que la plupart des outils ratent en silence</h2>
+    <p>
+      Un PDF sait transporter des données JPEG directement. C'est une propriété
+      du format&nbsp;: les octets compressés d'un JPEG peuvent être déposés tels
+      quels dans le document, et le lecteur les décode comme le ferait un
+      navigateur.
+    </p>
+    <p>
+      Cela compte, parce que cela veut dire qu'une photographie n'a rien à perdre
+      en entrant dans un PDF. Elle n'est jamais décodée et jamais recompressée
+      &nbsp;; l'image du document est bit pour bit l'image de votre fichier.
+      Beaucoup d'outils réencodent quand même &mdash; il est plus simple de tout
+      rendre sur un canvas et d'encoder uniformément &mdash; et le résultat est
+      une génération de qualité perdue pour rien.
+    </p>
+    <p>
+      Les autres formats ne peuvent pas voyager ainsi. Le PNG, le WebP, le HEIC
+      et le reste n'ont pas de filtre correspondant dans le PDF&nbsp;: ils
+      doivent donc être convertis. Vous avez le choix de la manière&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Réencoder en JPEG</strong> (le réglage par défaut). Fichier le
+        plus léger, petit coût en qualité, et la bonne réponse pour des
+        photographies.
+      </li>
+      <li>
+        <strong>Sans perte.</strong> Stocke les pixels exacts au prix d'un
+        document bien plus lourd. La bonne réponse pour les captures d'écran, les
+        schémas, et tout ce qui contient du texte ou des bords francs, où les
+        artefacts du JPEG sautent aux yeux.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Le format de page, et quand &laquo;&nbsp;ajuster à l'image&nbsp;&raquo; vaut mieux</h2>
+    <p>
+      Un format de page standard &mdash; A4, Letter, Legal, A3, A5, Tabloid
+      &mdash; pose chaque image sur une page de ce format, mise à l'échelle pour
+      tenir dans votre marge. Prenez-en un quand le document sera imprimé, ou
+      quand quelqu'un d'officiel va le classer.
+    </p>
+    <p>
+      &laquo;&nbsp;Exactement à la taille de chaque image&nbsp;&raquo; fait
+      correspondre chaque page à son image&nbsp;: il n'y a alors ni espace blanc
+      ni mise à l'échelle. Prenez-le quand le PDF est un contenant à images
+      plutôt qu'un document&nbsp;: un portfolio, un jeu de captures, une bande
+      dessinée. Cela a l'air faux à l'impression, parce que chaque page a une
+      taille différente.
+    </p>
+    <p>
+      Une marge vaut la peine sur tout ce qui sera imprimé. Les imprimantes
+      domestiques ne savent pas imprimer jusqu'au bord du papier, et une
+      photographie posée bord à bord ressort rognée.
+    </p>
+    <h3>Des pages verticales à partir de photographies horizontales</h3>
+    <p>
+      Si vous avez photographié des feuilles de papier avec un téléphone tenu en
+      travers, chaque image sera horizontale et se posera toute petite au milieu
+      d'une page verticale. Faire pivoter chacune d'un quart de tour avant de
+      construire le document est ce qui corrige cela, et c'est un choix par image
+      plutôt que global, parce qu'en général quelques-unes étaient dans le bon
+      sens.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que le PDF fini raconte sur vous</h2>
+    <p>
+      Un PDF porte un bloc d'informations de document&nbsp;: auteur, producteur,
+      date de création, parfois le titre. Selon ce qui l'a écrit, cela peut
+      comprendre votre nom de compte, le nom de votre machine, et l'heure exacte
+      à laquelle vous l'avez fabriqué.
+    </p>
+    <p>
+      Cela mérite réflexion, parce qu'un PDF est une chose que les gens envoient
+      à d'autres gens &mdash; une candidature, une réclamation, un document pour
+      un propriétaire. Les métadonnées voyagent avec, et n'importe quel lecteur
+      peut les afficher.
+    </p>
+    <p>
+      L'outil d'ici laisse ce bloc vide, à l'exception de son propre nom&nbsp;:
+      pas de noms de fichiers, pas de nom de machine, pas de nom d'utilisateur,
+      et pas de date de création sauf si vous cochez la case qui en demande une.
+      Si vous utilisez un autre outil, cela vaut la peine d'ouvrir une fois les
+      propriétés du résultat pour voir ce qu'il a écrit.
+    </p>
+    <p>
+      À part cela&nbsp;: les images elles-mêmes. Si vos photographies portent des
+      étiquettes EXIF et GPS, leur sort dépend du chemin. Un JPEG recopié sans
+      réencodage garde ce qu'il avait&nbsp;; une image réencodée perd les
+      étiquettes par effet de bord. Si cela compte, nettoyez les photos d'abord
+      avec le <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur
+      EXIF</a> &mdash; <a href="../supprimer-les-donnees-exif-et-gps/">son
+      guide</a> explique ce qu'il y a dedans.
+    </p>
+  </section>
+
+  <section>
+    <h2>Si le PDF ressort trop gros</h2>
+    <p>
+      Les photographies de téléphone sont lourdes, et vingt d'entre elles font un
+      document qu'un courriel refusera. Trois choses à essayer, dans
+      l'ordre&nbsp;:
+    </p>
+    <p>
+      <strong>Réduisez le plus grand côté.</strong> Une photographie de 4000
+      pixels d'une feuille de papier transporte bien plus de détail qu'aucun
+      lecteur ni aucune imprimante n'en utilisera. Ramener le grand côté à
+      quelque chose comme 2000 pixels divise typiquement le fichier par quatre et
+      ne change rien que quiconque puisse voir sur une page.
+    </p>
+    <p>
+      <strong>Prenez le JPEG plutôt que le sans perte</strong> pour tout ce qui
+      est photographique. Le sans perte est la bonne réponse pour les schémas et
+      la mauvaise pour la photo d'une page.
+    </p>
+    <p>
+      <strong>Compressez le document fini.</strong> Le
+      <a href="../../compresser-un-pdf/">compresseur de PDF</a> travaille par
+      rapport à la taille à laquelle chaque image est dessinée sur la page plutôt
+      que par rapport à son nombre de pixels, et c'est la mesure qui
+      compte&nbsp;; <a href="../reduire-la-taille-d-un-pdf/">son guide</a> traite
+      de ce que cela coûte.
+    </p>
+    <p>
+      Aucune limite n'est intégrée à l'outil quant au nombre d'images. Le plafond
+      pratique est la mémoire de votre propre machine, parce que le document fini
+      y est assemblé avant que vous le téléchargiez &mdash; quelques centaines de
+      photos de téléphone en pleine résolution est la première chose à s'en
+      ressentir, et réduire le plus grand côté repousse ce plafond bien plus
+      loin.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que cela ne vous donnera pas</h2>
+    <p>
+      Un PDF fait de photographies est un PDF plein d'images. Les mots qui y
+      figurent ne sont pas du texte&nbsp;: vous ne pouvez ni les chercher, ni les
+      copier, ni les faire lire par un lecteur d'écran. C'est une propriété de ce
+      dont vous êtes parti, pas de la conversion.
+    </p>
+    <p>
+      S'il vous faut du texte cherchable, il vous faut de l'OCR, qui est un autre
+      métier. Et si le document d'origine existe encore quelque part comme
+      document, l'exporter directement en PDF battra toujours le fait de le
+      photographier &mdash; plus léger, plus net, cherchable.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi cela ne demande pas d'envoi</h2>
+    <p>
+      Écrire un PDF, c'est écrire un fichier structuré&nbsp;: un en-tête, un jeu
+      d'objets, une table de références croisées. Il n'y a rien là-dedans qu'un
+      navigateur ne sache faire, et rien dans ce travail qui exige que les images
+      voyagent où que ce soit.
+    </p>
+    <p>
+      Ce qui mérite attention ici, à cause de ce que les gens mettent dans ces
+      documents. Pièces d'identité, relevés bancaires, courriers médicaux,
+      contrats signés &mdash; toute la raison pour laquelle quelqu'un fabrique un
+      PDF est en général qu'il l'envoie à une institution. L'outil d'ici n'a
+      aucune fonction réseau, et la <code>Content-Security-Policy</code> de la
+      page nomme toutes les adresses qu'elle peut contacter, dont aucune
+      n'appartient à ce site.
+    </p>
+    <p>
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose comment le vérifier
+      vous-même, ici comme ailleurs.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/fr/pages/guides/combine-images-into-a-pdf.toml
@@ -1,0 +1,17 @@
+#
+# Guide : reunir des images dans un PDF - French.
+#
+
+nav = "Des images dans un PDF"
+title = "Comment réunir des images dans un seul PDF"
+description = "Transformer des photos ou des scans en un seul PDF : format de page, ordre et rotation, pourquoi un JPEG n'a pas à perdre de qualité en entrant, et ce qu'un PDF raconte à la personne à qui vous l'envoyez."
+heading = "Comment réunir des images dans un seul PDF"
+lede = """
+    On vous a demandé &laquo;&nbsp;un seul PDF&nbsp;&raquo; et vous avez onze
+    photographies de papier. Voici les choix qui changent vraiment le résultat
+    &mdash; format de page, ordre, qualité, et ce que le document dit de vous
+    &mdash; et ceux que vous pouvez ignorer."""
+updated = "20 août 2026"
+og_title = "Comment réunir des images dans un seul PDF"
+og_description = "Format de page, ordre et rotation, pourquoi un JPEG n'a pas à perdre de qualité en entrant, et ce qu'un PDF raconte à la personne à qui vous l'envoyez."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/fr/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,0 +1,259 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../compresser-une-image/">compresseur d'images</a>,
+      déposez-y la photo, tapez le chiffre qu'on vous a donné et appuyez sur le
+      bouton. Il encode l'image plusieurs fois, garde le meilleur résultat qui
+      tienne sous votre cible, et vous dit ce que cela a coûté. Pour la plupart
+      des photographies et la plupart des cibles, le résumé honnête est que vous
+      ne verrez pas la différence.
+    </p>
+    <p>
+      Le reste de cette page est pour les fois où cela ne se passe pas ainsi
+      &nbsp;: quand le résultat paraît mou, quand un PNG bouge à peine, ou quand
+      vous voulez savoir ce que l'outil fait réellement à votre image avant de
+      l'envoyer à quelqu'un.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qu'une limite de taille demande vraiment</h2>
+    <p>
+      Un JPEG ou un WebP ne stocke pas votre photographie. Il en stocke une
+      description, et le réglage de qualité décide du niveau de détail auquel
+      cette description a droit. Baissez-le et le fichier rétrécit parce que la
+      description devient plus vague&nbsp;: les textures fines sont moyennées,
+      les dégradés se mettent en bandes, et les bords se couvrent d'un léger halo
+      de blocs.
+    </p>
+    <p>
+      Une limite de taille est donc un budget de détail. La question utile n'est
+      pas &laquo;&nbsp;puis-je atteindre 500&nbsp;KB&nbsp;&raquo; &mdash; on peut
+      toujours atteindre n'importe quel chiffre &mdash; mais
+      &laquo;&nbsp;quelle part de l'image dois-je abandonner pour y arriver, et
+      est-ce que cela compte pour l'usage que j'en fais&nbsp;?&nbsp;&raquo;
+    </p>
+    <p>
+      Deux règles empiriques. Une photographie d'une scène réelle &mdash;
+      visages, feuillages, tissus &mdash; cache bien la compression, parce que
+      l'œil n'y trouve aucune zone parfaitement plate où remarquer les dégâts.
+      Une capture d'écran, un graphique, un logo ou tout ce qui a de grands
+      aplats et des bords de texte francs la montre immédiatement, et devrait en
+      général être un PNG ou un WebP plutôt qu'un JPEG.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi il n'y a pas de formule, et que faire à la place</h2>
+    <p>
+      Il n'existe aucun moyen de calculer le réglage de qualité qui produit un
+      fichier de 500&nbsp;KB. Le rapport entre les deux dépend entièrement du
+      contenu de l'image&nbsp;: au même réglage, une photographie d'un mur nu
+      peut ressortir dix fois plus légère qu'une photographie de forêt. Tout
+      outil qui vous propose &laquo;&nbsp;qualité&nbsp;: 60&nbsp;&raquo; et croise
+      les doigts devine à votre place.
+    </p>
+    <p>
+      La seule méthode fiable est d'essayer. Encoder l'image, regarder la taille,
+      ajuster, encoder à nouveau. Le faire à la main est fastidieux, et c'est
+      pourquoi les compresseurs demandent un chiffre de qualité à la place
+      &mdash; cela vous refile le fastidieux. Le faire automatiquement, c'est
+      environ huit encodages, et huit encodages d'une photo de téléphone
+      représentent une fraction de seconde sur toute machine construite cette
+      décennie&nbsp;: c'est pourquoi l'outil de ce site demande la taille et fait
+      la recherche lui-même.
+    </p>
+    <p>
+      Chaque taille qu'il rapporte est un vrai fichier encodé, pas une
+      estimation. Cela compte quand un formulaire a une limite dure&nbsp;: une
+      estimation optimiste de 2&nbsp;%, c'est un envoi refusé.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dépensez la qualité avant de dépenser les pixels</h2>
+    <p>
+      Il n'y a que deux façons d'alléger un fichier image. Décrire la même image
+      moins précisément, c'est la qualité. Ou décrire moins de pixels, c'est le
+      redimensionnement. Ce n'est pas équivalent, et l'ordre compte.
+    </p>
+    <p>
+      La qualité passe en premier, parce que les 30&nbsp;% premiers de réduction
+      de qualité sont réellement invisibles sur une photographie &mdash; vous
+      jetez du détail que le format conservait plus soigneusement qu'aucun œil ne
+      peut le vérifier. Les pixels passent en second, parce qu'une fois la
+      qualité descendue assez bas pour que les artefacts se voient, une image
+      plus petite à une qualité correcte est plus belle qu'une image en taille
+      pleine mais abîmée. Moins de bons pixels valent mieux que davantage de
+      mauvais.
+    </p>
+    <p>
+      C'est toute la stratégie, et elle vaut d'être connue même si vous utilisez
+      un autre outil&nbsp;: baissez la qualité jusqu'à ce que cela commence à
+      avoir l'air faux, puis réduisez l'image au lieu de la baisser davantage.
+    </p>
+    <h3>Quand redimensionner exprès</h3>
+    <p>
+      Parfois, les pixels n'ont jamais été nécessaires. Une photo de 4000 pixels
+      de large affichée dans une colonne de 600 pixels sur une page web transporte
+      six fois le détail que quiconque verra. Si vous connaissez la destination
+      finale de l'image, redimensionnez-la d'abord et le problème de taille
+      disparaît souvent sans qu'une once de qualité soit dépensée. Le
+      <a href="../../redimensionner-une-image/">redimensionneur d'images</a> est
+      l'outil pour cela, et <a href="../redimensionner-une-image/">son propre
+      guide</a> traite du choix d'une taille.
+    </p>
+  </section>
+
+  <section>
+    <h2>Choisir un format</h2>
+    <p>
+      Trois formats valent d'être connus, et les navigateurs savent écrire les
+      trois.
+    </p>
+    <ul>
+      <li>
+        <strong>Le JPEG</strong> est fait pour les photographies. Il est avec
+        perte, il est compris par tout ce qui a jamais été fabriqué, et pour une
+        image de scène réelle il reste un excellent choix. Il ne sait pas stocker
+        de transparence.
+      </li>
+      <li>
+        <strong>Le WebP</strong> fait le même travail, en mieux&nbsp;: environ 25
+        à 35&nbsp;% plus léger que le JPEG à une qualité qu'on ne distingue pas,
+        et il garde la transparence. Tous les navigateurs actuels le lisent.
+        Quelques vieilles applications de bureau et certains formulaires d'envoi
+        d'entreprise ne le font toujours pas, ce qui est la seule vraie raison de
+        ne pas s'en servir.
+      </li>
+      <li>
+        <strong>Le PNG</strong> est sans perte, c'est-à-dire exact et lourd.
+        C'est la bonne réponse pour les captures d'écran, les logos, le dessin au
+        trait et tout ce qui a des bords francs ou des aplats, et la mauvaise
+        réponse pour une photographie.
+      </li>
+    </ul>
+    <p>
+      Si celui qui vous a demandé le fichier ne vous impose rien, le WebP vous
+      amènera à la cible avec moins de dégâts visibles que le JPEG. Si le fichier
+      part dans quelque chose d'ancien, ou dans un système que vous ne pouvez pas
+      tester, le JPEG est la réponse sûre.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi votre PNG ne maigrira pas beaucoup</h2>
+    <p>
+      C'est la surprise la plus courante, et ce n'est pas un défaut de l'outil
+      que vous utilisez. Le PNG est un format sans perte&nbsp;: il stocke les
+      pixels exacts, et il n'a aucune molette de qualité à tourner, parce que
+      tourner une telle molette en ferait un autre format. Tout ce qu'un
+      compresseur PNG peut faire, c'est empaqueter les mêmes pixels plus
+      astucieusement, ce qui vaut en général quelques pour cent.
+    </p>
+    <p>
+      Donc, s'il vous faut un fichier bien plus léger et qu'il doit rester un
+      PNG, le seul levier restant est la taille &mdash; moins de pixels, ou moins
+      de couleurs. S'il a le droit de cesser d'être un PNG, la question est ce
+      qu'il y a dedans&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Une photographie enregistrée en PNG.</strong> Très courant, en
+        général par accident, et le gain le plus facile de cette page&nbsp;: la
+        convertir en JPEG ou en WebP la rendra souvent cinq à dix fois plus
+        légère sans changement visible.
+      </li>
+      <li>
+        <strong>Une capture d'écran ou un schéma.</strong> Convertissez en WebP,
+        qui est sans perte lui aussi quand vous le lui demandez, et qui est
+        généralement plus léger que le PNG pour les mêmes pixels. Passer en JPEG
+        rendra les bords du texte flous.
+      </li>
+      <li>
+        <strong>Un logo avec transparence.</strong> Le WebP garde la
+        transparence&nbsp;; le JPEG la remplira d'une couleur unie, ce qui n'est
+        presque jamais ce que vous vouliez.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Comment savoir si le résultat est assez bon</h2>
+    <p>
+      Regarder une vignette ne prouve rien &mdash; tout a l'air correct en
+      vignette. Deux vérifications valent mieux&nbsp;:
+    </p>
+    <p>
+      <strong>Regardez-la en taille réelle, sur la zone la plus plate de
+      l'image.</strong> Le ciel, la peau, un mur peint. Les dégâts de compression
+      apparaissent d'abord dans les dégradés doux, sous forme de blocs ou de
+      bandes légères, bien avant de toucher les zones détaillées.
+    </p>
+    <p>
+      <strong>Lisez la mesure, si l'outil vous en donne une.</strong> Le
+      compresseur d'ici décode son propre résultat et le compare à l'original, et
+      rapporte le SSIM&nbsp;: un chiffre qui compare la luminosité, le contraste
+      et la structure locales plutôt que de compter les pixels modifiés, ce qui
+      est bien plus proche de ce qui gêne un œil. Au-dessus de 0,98 environ, les
+      deux images sont difficiles à séparer côte à côte. En dessous de 0,95
+      environ, regardez avant d'envoyer. Il rapporte aussi le PSNR, le chiffre en
+      décibels traditionnel, pour qui le préfère.
+    </p>
+    <p>
+      Les deux sont calculés sur votre propre machine et vous sont montrés, et
+      c'est tout l'intérêt de les avoir&nbsp;: cela transforme
+      &laquo;&nbsp;perte de qualité minimale&nbsp;&raquo; d'une affirmation en un
+      chiffre vérifiable.
+    </p>
+  </section>
+
+  <section>
+    <h2>Trois choses à savoir avant d'envoyer le fichier</h2>
+    <p>
+      <strong>Compresser efface les métadonnées.</strong> Réencoder, c'est
+      décoder l'image en pixels puis réencoder ces pixels, et un canvas plein de
+      pixels ne porte aucune étiquette &mdash; la position GPS, le modèle
+      d'appareil, les horodatages et le reste ne sont donc simplement pas écrits
+      dans le nouveau fichier. C'est généralement un bonus. Si vous vouliez les
+      étiquettes disparues mais l'image intacte, c'est un autre travail&nbsp;: le
+      <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a>
+      réécrit le conteneur sans rien recompresser, et
+      <a href="../supprimer-les-donnees-exif-et-gps/">son guide</a> explique ce
+      qu'il y a dedans.
+    </p>
+    <p>
+      <strong>Ne compressez jamais deux fois le même fichier.</strong> Chaque
+      encodage avec perte jette du détail définitivement, et encoder une image
+      déjà compressée en jette davantage &mdash; y compris les artefacts de la
+      première passe, qu'il conserve fidèlement au prix du vrai détail. Repartez
+      toujours de l'original et compressez une seule fois.
+    </p>
+    <p>
+      <strong>Gardez l'original.</strong> Il n'y a pas de retour possible après
+      un encodage avec perte. Quoi que vous envoyiez, gardez quelque part le
+      fichier de départ.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rien de tout cela ne demande un envoi</h2>
+    <p>
+      Tous les navigateurs livrent un encodeur JPEG, PNG et WebP depuis des
+      années &mdash; c'est le même code qui enregistre une image depuis un
+      canvas. Compresser une image fait partie des travaux qui n'ont aucune
+      raison technique de faire intervenir un serveur, et c'est pourquoi l'outil
+      d'ici n'en a pas&nbsp;: l'image est décodée, encodée et mesurée sur votre
+      propre machine, et il n'y a dans la
+      <code>Content-Security-Policy</code> de la page aucune adresse appartenant
+      à ce site vers laquelle elle pourrait être envoyée.
+    </p>
+    <p>
+      La façon la plus simple de le confirmer, ici comme ailleurs, est de charger
+      la page, de couper la connexion, et de compresser quelque chose quand même.
+      Si cela fonctionne encore, rien n'était envoyé.
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
+      vérifications du même genre.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/fr/pages/guides/compress-an-image-to-a-target-size.toml
@@ -1,0 +1,17 @@
+#
+# Guide : compresser une image a une taille precise - French.
+#
+
+nav = "Compresser une image"
+title = "Comment compresser une image à une taille de fichier exacte"
+description = "Un formulaire d'envoi veut 500 KB et votre photo en fait 4 MB. Ce qu'une limite de taille coûte vraiment, quel réglage déplacer en premier, et pourquoi un PNG ne maigrit pas comme un JPEG."
+heading = "Comment compresser une image à une taille de fichier exacte"
+lede = """
+    On vous a donné un chiffre &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
+    &mdash; et votre photo en est très loin. Voici ce que ce chiffre coûte, à
+    quoi le dépenser, et comment savoir si le résultat est encore assez bon pour
+    être envoyé."""
+updated = "20 août 2026"
+og_title = "Compresser une image à une taille de fichier exacte"
+og_description = "Ce qu'une limite de taille coûte vraiment, quel réglage déplacer en premier, et pourquoi un PNG ne maigrit pas comme un JPEG."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/convert-an-svg-to-png.html
+++ b/locales/fr/pages/guides/convert-an-svg-to-png.html
@@ -1,0 +1,253 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez <a href="../../convertir-svg-en-png/">SVG en image</a>, déposez-y le
+      fichier, et nommez une taille. Si rien ne vous a dit quelle taille prendre,
+      <strong>1024 pixels sur le plus grand côté</strong> est un bon
+      défaut&nbsp;: assez grand pour presque tout et assez petit pour un
+      courriel. Laissez le format sur PNG, laissez le fond sur transparent, et
+      prenez le fichier.
+    </p>
+    <p>
+      Tout ce qui suit est pour les cas où ce défaut ne suffit pas &mdash; quand
+      un chiffre vous a été imposé, quand cela part à l'impression, ou quand cela
+      revient avec l'air faux.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi la taille est votre décision et non celle du fichier</h2>
+    <p>
+      Un JPEG est une grille de pixels mesurés&nbsp;; demander sa taille a une
+      réponse. Un SVG n'est pas une image du tout, c'est un jeu d'instructions
+      &mdash; dessine un cercle ici, ce tracé dans cette couleur &mdash; et des
+      instructions n'ont pas de taille. Un navigateur peut les exécuter à 16
+      pixels ou à 4000 et le résultat est aussi net dans les deux cas, parce
+      qu'il ne met rien à l'échelle. Il redessine.
+    </p>
+    <p>
+      C'est pourquoi la conversion ne peut pas choisir un chiffre à votre place,
+      et pourquoi en choisir un grand ne vous coûte rien. C'est le seul travail
+      d'image où &laquo;&nbsp;fais-le plus grand&nbsp;&raquo; est gratuit.
+    </p>
+    <p>
+      La plupart des fichiers SVG portent bien un attribut <code>width</code> et
+      <code>height</code>, et un outil vous le montrera &mdash; mais c'est un
+      défaut, pas une limite. Une icône qui dit <code>width="24"</code> dit
+      seulement que la personne qui l'a dessinée avait en tête une barre d'outils
+      de 24&nbsp;pixels.
+    </p>
+  </section>
+
+  <section>
+    <h2>D'où vient réellement le chiffre</h2>
+    <p><strong>Pour un site web.</strong> Prenez la taille que l'image occupe sur
+      la page en pixels CSS et multipliez par la densité des écrans qui vous
+      importent. Un logo dans un emplacement de 200&nbsp;pixels de large a besoin
+      d'un fichier de 400&nbsp;pixels pour un portable Retina et de 600 pour un
+      téléphone récent. C'est tout ce que veulent dire <code>@2x</code> et
+      <code>@3x</code>, et c'est pourquoi un outil qui les écrit vous évite de
+      faire le calcul trois fois.
+    </p>
+    <p><strong>Pour une icône d'application, une fiche de boutique ou un
+      favicon.</strong> Le chiffre est publié et il n'y a rien à calculer&nbsp;:
+      ce que dit la page de la boutique, exactement. Pour un favicon, ne
+      rastérisez pas du tout &mdash;
+      <a href="../creer-son-favicon/">fabriquez un .ico</a>, qui contient
+      plusieurs tailles dans un fichier, parce qu'un onglet de navigateur, un
+      signet et un raccourci Windows en réclament chacun une différente.
+    </p>
+    <p><strong>Pour l'impression.</strong> Multipliez la taille physique en
+      pouces par la résolution de l'imprimante. Un logo qui va sur une carte de
+      visite sur deux pouces de large à 300&nbsp;DPI fait 600 pixels&nbsp;; le
+      même logo en travers d'une page A4, soit 8,3&nbsp;pouces, en fait environ
+      2500. Les imprimeries demandent 300&nbsp;DPI par principe, et pour une
+      bannière grand format regardée du bout d'une pièce, 150 suffit largement.
+    </p>
+    <p><strong>Pour un aperçu social ou une image OG.</strong> La plateforme
+      nomme un cadre &mdash; 1200&nbsp;&times;&nbsp;630 pour la plupart des
+      aperçus de liens &mdash; et le cadre n'a pas la forme de votre logo. C'est
+      à cela que sert le réglage &laquo;&nbsp;compléter&nbsp;&raquo;&nbsp;: le
+      dessin centré à ses propres proportions, avec une couleur de fond qui
+      remplit le reste, plutôt qu'un logo étiré qui annonce à tout le monde que
+      vous n'avez pas vérifié.
+    </p>
+    <p>
+      Quand deux de ces cas s'appliquent, prenez le plus grand. Un PNG plus grand
+      que nécessaire est un téléchargement un peu plus lourd&nbsp;; un PNG trop
+      petit ne se rattrape pas ensuite, pour la raison exposée dans la section
+      suivante.
+    </p>
+  </section>
+
+  <section>
+    <h2>On ne revient pas en arrière</h2>
+    <p>
+      La rastérisation est à sens unique. Une fois le dessin devenu un PNG, ce
+      sont des pixels comme dans n'importe quelle autre image, et l'agrandir
+      ensuite doit inventer un détail qui n'a jamais été mesuré &mdash; le même
+      résultat mou et étalé qu'on obtient en agrandissant une photographie.
+    </p>
+    <p>
+      Gardez donc le SVG. C'est la copie maîtresse, c'est presque toujours le
+      fichier le plus léger, et toutes les tailles futures en sortiront
+      parfaitement. Le PNG est un export pour un usage particulier, et quand il
+      vous faut une autre taille, le bon geste est de réexporter plutôt que de
+      redimensionner ce que vous aviez exporté.
+    </p>
+    <p>
+      Il existe des logiciels qui prétendent reconvertir un PNG en SVG. Ce qu'ils
+      font, c'est du tracé&nbsp;: deviner quelles courbes pourraient expliquer une
+      grille de pixels. Cela marche passablement sur un dessin plat à deux
+      couleurs et produit un galimatias coûteux sur tout le reste, et cela ne
+      retrouve jamais ce que le dessin d'origine contenait.
+    </p>
+  </section>
+
+  <section>
+    <h2>Trois choses changent à l'instant où cela devient des pixels</h2>
+    <p>
+      Un SVG rastérisé qui a l'air faux a presque toujours l'air faux pour l'une
+      de ces trois raisons, et toutes les trois valent d'être connues avant
+      l'export plutôt qu'après.
+    </p>
+    <p>
+      <strong>Le texte est dessiné dans la police que possède la
+      machine.</strong> Un SVG qui contient du texte ne contient pas la police
+      &mdash; il en nomme une et laisse le moteur de rendu la trouver. Si la
+      police n'est pas installée, une police de remplacement est utilisée, et
+      cette remplaçante a d'autres dessins de lettres et d'autres
+      chasses&nbsp;: le texte peut donc se recomposer ou déborder. Un fichier qui
+      tire sa police d'une adresse web s'en tire encore plus mal&nbsp;: un SVG
+      rastérisé à travers un <code>&lt;img&gt;</code> n'a pas le droit de
+      récupérer quoi que ce soit, alors rien n'arrive.
+    </p>
+    <p>
+      Le remède est celui que tout graphiste connaît déjà&nbsp;:
+      <strong>convertissez le texte en contours</strong> avant d'exporter le SVG
+      (Illustrator appelle cela Vectoriser, Figma dit Flatten, Inkscape dit Objet
+      en chemin). Les lettres deviennent de la géométrie, la police cesse
+      d'importer, et l'image a la même allure sur toutes les machines.
+      Faites-le sur une copie &mdash; un texte vectorisé n'est plus modifiable
+      comme texte.
+    </p>
+    <p>
+      <strong>Les filets virent au gris ou disparaissent.</strong> Un trait qui
+      revient à moins d'un pixel à la taille choisie ne peut pas être dessiné
+      comme une ligne pleine&nbsp;: il est donc dessiné faiblement. C'est
+      pourquoi un logo délicat rastérisé à 64&nbsp;pixels a l'air délavé quand le
+      même fichier à 512 est parfait. Si une petite taille est l'exigence, la
+      réponse est un dessin simplifié aux traits plus épais plutôt qu'un autre
+      réglage d'export &mdash; c'est la même raison qui fait qu'un favicon est un
+      symbole et non un mot.
+    </p>
+    <p>
+      <strong>L'animation s'arrête.</strong> Un SVG animé se rastérise en une
+      seule image fixe&nbsp;: la première, quelle qu'elle soit. Aucun réglage
+      d'export n'y change rien. S'il vous faut le mouvement, il vous faut un GIF
+      ou une vidéo, fabriqués autrement.
+    </p>
+  </section>
+
+  <section>
+    <h2>La transparence, et quel format choisir</h2>
+    <p>
+      <strong>PNG</strong>, sauf raison particulière. Il est sans perte, il garde
+      la transparence, et les aplats à bords francs &mdash; qui sont l'essentiel
+      de ce dont un dessin est fait &mdash; s'y compressent bien. Un logo
+      rastérisé est en général un PNG <em>plus léger</em> qu'il ne serait un
+      JPEG, en plus d'être plus propre.
+    </p>
+    <p>
+      <strong>Le JPEG</strong> n'a aucune transparence. Chaque pixel transparent
+      doit devenir une couleur, et si personne n'en choisit une pour vous, il
+      devient noir &mdash; c'est de là que vient le résultat du logo dans un
+      rectangle noir que l'on prend pour un bug. Il est en outre avec perte de la
+      façon qui se voit le plus mal sur exactement ce genre d'image&nbsp;: un
+      liseré de moucheture autour de chaque bord franc. Utilisez-le quand quelque
+      chose l'exige.
+    </p>
+    <p>
+      <strong>Le WebP</strong> fait tout ce que fait le PNG, dans un fichier plus
+      léger, et il est lu par tous les navigateurs actuels. La raison de ne pas
+      s'en servir est ce qui vient après le navigateur&nbsp;: les logiciels plus
+      anciens, certaines imprimeries et un bon nombre de formulaires d'envoi
+      refusent toujours d'en ouvrir un.
+    </p>
+    <p>
+      Choisir une couleur de fond avec du PNG est aussi une chose parfaitement
+      ordinaire à vouloir. La transparence n'est utile que lorsque ce sur quoi
+      l'image atterrit est une couleur que vous ne pouvez pas prévoir&nbsp;;
+      quand vous savez déjà que c'est une page blanche, l'aplatir sur du blanc
+      évite toute une catégorie de surprises.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quand l'export ressort vide ou faux</h2>
+    <p>
+      <strong>Rien que du vide.</strong> En général un attribut
+      <code>xmlns</code> manquant sur l'élément racine. Un fichier sans lui n'est
+      pas du SVG pour une balise image, et il se dessine comme rien. Ouvrir le
+      fichier dans un navigateur est le test rapide&nbsp;: si le navigateur ne
+      montre rien non plus, le problème est le fichier et non le convertisseur.
+    </p>
+    <p>
+      <strong>Le dessin est petit, dans le coin en haut à gauche.</strong> Le
+      fichier a une <code>width</code> et une <code>height</code> mais pas de
+      <code>viewBox</code>&nbsp;: il n'y a donc aucun système de coordonnées à
+      mettre à l'échelle et le dessin garde ses unités d'origine sur un canvas
+      plus grand. Un bon convertisseur ajoute un viewBox pour vous&nbsp;; si le
+      vôtre ne l'a pas fait, ajouter à la main
+      <code>viewBox="0 0 <em>largeur</em> <em>hauteur</em>"</code> sur l'élément
+      racine corrige la chose, et le fichier est du texte brut, donc vous le
+      pouvez.
+    </p>
+    <p>
+      <strong>Une partie de l'image manque.</strong> Quelque chose dans le
+      fichier pointait vers une adresse au lieu de contenir le dessin &mdash; une
+      photographie incorporée stockée comme lien, une feuille de style, une
+      police. Un rastériseur qui refuse d'aller les chercher fait ce qu'il faut,
+      et c'est le même refus qui empêche un SVG téléchargé quelque part de
+      rendre des comptes à celui qui l'a fabriqué. Réexportez depuis le logiciel
+      de dessin avec les images incorporées.
+    </p>
+    <p>
+      <strong>Il refuse une très grande taille.</strong> Les navigateurs
+      plafonnent la taille d'un canvas, et ils ne s'accordent pas sur
+      l'endroit&nbsp;: au-delà d'environ 16 000&nbsp;pixels de côté rien ne
+      revient, et Safari sur un iPhone ou un iPad abandonne bien plus tôt, vers
+      4096&nbsp;&times;&nbsp;4096. Un outil qui vous prévient vous épargne un
+      fichier vide, parce que c'est ce que produit un navigateur à court de
+      ressources plutôt qu'un message d'erreur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rien de tout cela ne demande un envoi</h2>
+    <p>
+      Rastériser un SVG est une chose que tous les navigateurs font des milliers
+      de fois par jour &mdash; c'est la machinerie même qui dessine une icône sur
+      une page web. Il n'y a aucune raison technique pour que votre dessin voyage
+      jusqu'à un serveur et en revienne sous forme de PNG, et l'outil d'ici ne
+      l'envoie nulle part&nbsp;: la <code>Content-Security-Policy</code> de la
+      page nomme toutes les adresses qu'elle peut contacter, et aucune
+      n'appartient à ce site.
+    </p>
+    <p>
+      Cela compte plus que d'habitude avec le SVG, parce qu'un SVG est un
+      document et non une image. Il peut contenir un script et une adresse
+      distante, et un logo qu'une agence vous a envoyé est un fichier que vous
+      n'avez pas écrit. Dessiné à travers une balise image, il est dans ce que la
+      spécification appelle le <em>mode statique sécurisé</em>&nbsp;: le script
+      ne peut pas s'exécuter et l'adresse n'est jamais contactée. C'est le
+      navigateur qui l'applique, pas le site web.
+    </p>
+    <p>
+      Chargez la page, coupez votre connexion, et convertissez quelque chose
+      quand même, si vous préférez vérifier plutôt qu'on vous le dise.
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
+      vérifications applicables à n'importe quel outil.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/fr/pages/guides/convert-an-svg-to-png.toml
@@ -1,0 +1,17 @@
+#
+# Guide : convertir un SVG en PNG - French.
+#
+
+nav = "Convertir un SVG en PNG"
+title = "Comment convertir un SVG en PNG à la bonne taille"
+description = "Un vectoriel n'a pas de taille en pixels à lui : le nombre est à vous de le choisir. D'où vient ce nombre pour un écran, une icône d'application et une imprimante, et ce qui change quand un dessin devient des pixels."
+heading = "Comment convertir un SVG en PNG à la bonne taille"
+lede = """
+    Convertir est la moitié facile. La question qui décide si le résultat sert à
+    quelque chose est celle dont personne ne vous donne la réponse&nbsp;: combien
+    de pixels&nbsp;? Voici d'où vient ce nombre, et ce qu'un dessin perd en
+    chemin."""
+updated = "20 août 2026"
+og_title = "Convertir un SVG en PNG à la bonne taille"
+og_description = "D'où vient vraiment le nombre de pixels, et les trois choses qui changent quand un dessin devient des pixels."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/convert-heic-to-jpg.html
+++ b/locales/fr/pages/guides/convert-heic-to-jpg.html
@@ -1,0 +1,261 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../convertir-heic-en-jpg/">convertisseur HEIC vers
+      JPG</a>, déposez-y les photos, et appuyez sur
+      &laquo;&nbsp;Convertir&nbsp;&raquo;. Laissez le curseur de qualité où il
+      est et laissez cochée la case
+      &laquo;&nbsp;garder la date, l'appareil et les réglages&nbsp;&raquo;, sauf
+      raison contraire. Vous récupérez des JPEG, un bouton de téléchargement
+      chacun, ou un zip s'il y en a plusieurs.
+    </p>
+    <p>
+      Rien n'est envoyé pendant ce temps. C'est inhabituel pour ce travail-là en
+      particulier, et la raison est la moitié intéressante de cette page.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qu'est réellement le HEIC</h2>
+    <p>
+      Le HEIC n'est pas vraiment un format d'image au sens où le JPEG en est un.
+      C'est un conteneur &mdash; la même structure à boîtes dont est fait un MP4
+      &mdash; avec à l'intérieur une image fixe de vidéo <strong>HEVC</strong>.
+      Le HEVC, aussi appelé H.265, est le codec qui a remplacé celui de votre
+      vieux caméscope, et il est très bon&nbsp;: une photo d'iPhone en HEIC pèse
+      à peu près la moitié de la même photo en JPEG à qualité égale.
+    </p>
+    <p>
+      Apple y est passé dans iOS 11, en 2017, et l'a mis par défaut. Ce qui veut
+      dire qu'à moins d'être allé dans les Réglages choisir
+      &laquo;&nbsp;Le plus compatible&nbsp;&raquo;, chaque photo prise par son
+      téléphone depuis près d'une décennie est dans un format que&nbsp;:
+    </p>
+    <ul>
+      <li>Windows ne prévisualise pas sans une extension du Store&nbsp;;</li>
+      <li>la plupart des formulaires d'envoi web rejettent d'emblée&nbsp;;</li>
+      <li>quantité de logiciels de bureau plus anciens n'ont jamais connu&nbsp;;</li>
+      <li>et qu'aucun navigateur web sauf Safari n'affiche.</li>
+    </ul>
+    <p>
+      La photo va très bien. C'est un meilleur fichier que ne l'aurait été le
+      JPEG. Elle est simplement écrite dans une langue que la plus grande partie
+      du monde n'a jamais apprise.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi seul Safari en ouvre un</h2>
+    <p>
+      C'est la partie qui explique tous les convertisseurs que vous avez jamais
+      utilisés&nbsp;: elle vaut donc un paragraphe.
+    </p>
+    <p>
+      Décoder du HEVC demande un décodeur HEVC, et le HEVC est breveté. Les
+      licences sont administrées par plus d'un consortium de brevets, et livrer
+      un décodeur veut dire payer quelqu'un. Les navigateurs s'en tirent en
+      s'appuyant sur le système d'exploitation &mdash; Chrome lit de la
+      <em>vidéo</em> HEVC sur une machine dont le matériel a déjà un décodeur
+      sous licence &mdash; mais ce chemin est câblé pour la lecture vidéo et non
+      pour les images fixes. Un HEIC remis à <code>&lt;img&gt;</code> est donc
+      refusé, dans Chrome, Firefox et Edge pareillement, sur tous les systèmes
+      d'exploitation.
+    </p>
+    <p>
+      Safari sur du matériel Apple est l'exception, parce que macOS et iOS ont le
+      décodeur et que Safari a le droit de le lui demander. Partout ailleurs,
+      l'image est tout simplement indécodable par le navigateur.
+    </p>
+    <p>
+      Ce qui ne laisse à un convertisseur qu'exactement deux possibilités, et le
+      choix entre les deux est toute l'histoire de ce genre d'outil.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi presque tous les convertisseurs HEIC veulent un envoi</h2>
+    <p>
+      Première possibilité&nbsp;: mettre le décodeur sur un serveur. La photo est
+      envoyée, décodée sur une machine que vous n'avez jamais vue, réencodée en
+      JPEG, et renvoyée. C'est ce que fait à peu près tout
+      &laquo;&nbsp;convertisseur HEIC en ligne gratuit&nbsp;&raquo;, et c'est
+      pourquoi ils ont tous besoin de vos fichiers. Ce n'est pas de la paresse
+      &mdash; le navigateur en est réellement incapable tout seul.
+    </p>
+    <p>
+      Ce que cela coûte mérite d'être dit sans détour. Les photos d'un téléphone
+      sont les fichiers les plus personnels que possèdent la plupart des gens, et
+      un HEIC sorti tout droit d'un iPhone porte typiquement les coordonnées du
+      lieu de la prise de vue, précises à quelques mètres, avec la date à la
+      seconde et un identifiant d'appareil. En envoyer un dossier à un service
+      gratuit, c'est remettre les images et cela avec. Ce qui se passe ensuite est
+      régi par une politique de confidentialité que vous n'avez pas lue, sur un
+      serveur que vous ne pouvez pas inspecter, dans une juridiction que vous
+      n'avez pas choisie.
+    </p>
+    <p>
+      Seconde possibilité&nbsp;: mettre le décodeur dans la page. C'est ce que
+      fait <a href="../../convertir-heic-en-jpg/">celui-ci</a>. Il emporte
+      <code>libheif</code>, compilé en WebAssembly, comme un fichier servi depuis
+      ce site &mdash; environ 1,4 MB, téléchargé une fois puis mis en cache.
+      Votre navigateur l'exécute sur votre propre machine, sur votre propre
+      matériel, et la photo ne va nulle part. Chargez la page une fois et vous
+      pouvez couper entièrement votre connexion sans qu'elle cesse de
+      fonctionner, ce qu'aucun convertisseur qui envoie ne sait faire et la preuve
+      la plus simple qui soit.
+    </p>
+    <p>
+      Les 1,4 MB sont le prix entier. Si vous êtes sur une connexion facturée au
+      volume, c'est un coût réel et il vaut la peine de le savoir&nbsp;: c'est
+      pourquoi la page le dit à voix haute au lieu de le télécharger en douce.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que la conversion coûte à l'image</h2>
+    <p>
+      Le HEIC et le JPEG sont des codecs différents&nbsp;: il n'y a donc aucun
+      passage de l'un à l'autre qui n'implique pas de décoder l'image et de la
+      réencoder. Ce second encodage est avec perte. En pratique, cela compte bien
+      moins que cela n'en a l'air&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>À la qualité 92</strong> &mdash; là où le convertisseur commence
+        &mdash; une photographie est très difficile à distinguer de l'original à
+        toute taille de visionnage normale. Vous cherchez des différences dans
+        les dégradés doux, comme un ciel dégagé, et vous n'en trouverez
+        généralement pas.
+      </li>
+      <li>
+        <strong>Le JPEG sera plus gros.</strong> En général entre un tiers de
+        plus et le double, parce que le JPEG est un codec de 1992 et que le HEVC
+        n'en est pas un. C'est le marché&nbsp;: un fichier plus gros que tout
+        ouvre.
+      </li>
+      <li>
+        <strong>Ce qu'il faut éviter, c'est convertir deux fois.</strong> Chaque
+        encodage avec perte coûte un peu. Convertissez depuis le HEIC d'origine,
+        pas depuis un JPEG que quelqu'un a déjà fabriqué pour vous, et faites-le
+        une seule fois.
+      </li>
+    </ul>
+    <p>
+      Si vous ne voulez aucune perte, le PNG est au menu des formats. Préparez-vous
+      pour le fichier&nbsp;: une photographie en PNG pèse couramment cinq à dix
+      fois le JPEG, parce que la compression du PNG a été conçue pour les aplats
+      et le dessin au trait plutôt que pour l'herbe et la peau.
+    </p>
+  </section>
+
+  <section>
+    <h2>La date, l'appareil et les coordonnées</h2>
+    <p>
+      Le reproche habituel fait aux convertisseurs HEIC est que les photos
+      reviennent en ayant perdu leur jour de prise de vue&nbsp;: toute une
+      photothèque de vacances se range alors en bas de la bibliothèque, à la date
+      du jour. Cela arrive parce que convertir à travers un canvas ne donne que
+      des pixels &mdash; un canvas ne contient aucune étiquette &mdash;&nbsp;;
+      donc, à moins qu'un convertisseur n'aille chercher les métadonnées à part,
+      elles ont simplement disparu.
+    </p>
+    <p>
+      L'outil d'ici copie le bloc EXIF depuis le HEIC et l'écrit dans le
+      JPEG&nbsp;: la date survit donc. Il y a une case, et elle est cochée par
+      défaut. Décochez-la et le JPEG ressort avec l'image et rien d'autre.
+    </p>
+    <p>
+      Avant de décider, regardez la liste&nbsp;: la ligne de chaque photo dit si
+      le fichier porte des coordonnées GPS, et elle le dit avant que quoi que ce
+      soit soit converti. Si les photos partent quelque part de public, c'est la
+      ligne à lire. Si elles partent dans votre propre bibliothèque, garder les
+      métadonnées est presque certainement ce que vous voulez.
+    </p>
+    <p>
+      Une étiquette est changée quel que soit votre choix, et il vaut la peine de
+      savoir pourquoi. Un HEIC enregistre sa rotation à deux endroits&nbsp;: dans
+      le conteneur, et dans le bloc EXIF. Le décodeur applique la rotation du
+      conteneur pendant le décodage&nbsp;: les pixels remis sont donc déjà dans
+      le bon sens. Si l'EXIF disait encore
+      &laquo;&nbsp;tournez ceci de 90 degrés&nbsp;&raquo;, un afficheur le ferait
+      une seconde fois et toutes les photos verticales ressortiraient couchées.
+      L'étiquette d'orientation est donc mise à &laquo;&nbsp;droite&nbsp;&raquo;
+      et tout le reste est recopié exactement comme le téléphone l'avait écrit.
+    </p>
+    <p>
+      Si ce que vous voulez, c'est parcourir les étiquettes en détail, ou les
+      retirer de photos qui sont déjà des JPEG, c'est un autre travail et il y a
+      <a href="../supprimer-les-donnees-exif-et-gps/">un guide pour cela</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qui prend les gens au dépourvu</h2>
+    <ul>
+      <li>
+        <strong>Un HEIC nommé &laquo;&nbsp;.jpg&nbsp;&raquo;.</strong> Extrêmement
+        courant&nbsp;: quelque chose l'a renommé en chemin sans le convertir, et
+        c'est pourquoi il refuse toujours de s'ouvrir. Chaque fichier déposé sur
+        le convertisseur est identifié par ses premiers octets plutôt que par son
+        nom&nbsp;: celui-là fonctionne donc très bien. C'est aussi pourquoi un
+        fichier qui est vraiment un JPEG se le fait dire au lieu d'être converti
+        en une copie de lui-même.
+      </li>
+      <li>
+        <strong>Un fichier, plusieurs images.</strong> Une rafale ou une Live
+        Photo peut contenir plus d'une image fixe. Toutes sont converties, et les
+        supplémentaires sont numérotées d'après le nom d'origine. La moitié vidéo
+        d'une Live Photo est un fichier séparé que le téléphone garde à côté du
+        HEIC&nbsp;: elle n'est donc pas là pour être convertie.
+      </li>
+      <li>
+        <strong>L'AVIF n'est pas du HEIC.</strong> Ils se ressemblent &mdash; même
+        conteneur, autre codec dedans &mdash; mais tous les navigateurs actuels
+        ouvrent un AVIF nativement&nbsp;: il n'y a donc rien à convertir et
+        l'outil le dit au lieu de faire semblant de travailler.
+      </li>
+      <li>
+        <strong>Arrêter le problème à la source.</strong> Sur le téléphone&nbsp;:
+        Réglages &rarr; Appareil photo &rarr; Formats &rarr; Le plus compatible.
+        Les nouvelles photos sont des JPEG à partir de là. Cela consomme plus de
+        stockage et cela ne touche pas aux photos que vous avez déjà, mais cela
+        veut dire ne plus jamais recommencer.
+      </li>
+      <li>
+        <strong>Le partage convertit, parfois.</strong> Envoyer une photo par
+        AirDrop ou par courriel vers un appareil non Apple remet souvent un JPEG,
+        parce qu'iOS convertit en sortie. Si une photo est arrivée en HEIC quand
+        même, c'est qu'elle est passée par un chemin qui ne le faisait pas.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Comment savoir si un convertisseur envoie vos fichiers</h2>
+    <p>
+      Cela vaut pour n'importe quel outil, pas seulement celui-ci, et cela prend
+      une quinzaine de secondes.
+    </p>
+    <ol>
+      <li>
+        Ouvrez la page, puis ouvrez les outils de développement de votre
+        navigateur et allez dans l'onglet Réseau.
+      </li>
+      <li>
+        Convertissez une photo, et regardez. Un outil qui décode sur votre
+        machine ne fait aucune requête à cet instant. Un outil qui envoie en fait
+        une de la taille de votre photo, et vous en voyez la taille.
+      </li>
+      <li>
+        Ou, plus simplement&nbsp;: chargez la page, coupez votre connexion, et
+        essayez de convertir quelque chose. Un outil qui expédiait votre photo
+        ailleurs pour la décoder s'arrête. Un outil qui emporte le décodeur non.
+      </li>
+    </ol>
+    <p>
+      Le convertisseur d'ici est construit pour passer les deux vérifications, et
+      il existe une version plus longue de cet argument dans
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">est-il sûr d'envoyer ses
+      fichiers</a>.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/fr/pages/guides/convert-heic-to-jpg.toml
@@ -1,0 +1,18 @@
+#
+# Guide : le format dans lequel un iPhone enregistre, et comment en sortir - French.
+#
+
+nav = "HEIC vers JPG"
+title = "Comment convertir un HEIC en JPG (et ce qu'est vraiment le HEIC)"
+description = "Les iPhone enregistrent les photos en HEIC, et la moitié d'internet n'en ouvre pas une. Ce qu'est ce format, pourquoi seul Safari le décode, ce que la conversion coûte à l'image, et comment le faire sans envoyer les photos à personne."
+heading = "La photo qu'a enregistrée votre téléphone, et le format que rien n'ouvre"
+lede = """
+    Un iPhone enregistre les photos en HEIC, format plus léger et meilleur que le
+    JPEG, et qu'une grande quantité de logiciels refuse toujours d'ouvrir. Voici
+    ce qu'est réellement ce format, ce que la conversion coûte à l'image, et
+    pourquoi presque tous les convertisseurs veulent que vous l'envoyiez
+    d'abord."""
+updated = "20 août 2026"
+og_title = "Comment convertir un HEIC en JPG"
+og_description = "Pourquoi les photos d'iPhone ne s'ouvrent pas, ce que la conversion coûte, et comment le faire sans remettre les photos à qui que ce soit."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/crop-a-video.html
+++ b/locales/fr/pages/guides/crop-a-video.html
@@ -1,0 +1,221 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../recadrer-une-video/">recadreur de vidéos</a>,
+      déposez-y le clip, faites glisser le cadre sur la partie à garder &mdash;
+      ou verrouillez-le sur une forme si on vous en a imposé une &mdash; et
+      exportez. Le clip qui sort dure exactement aussi longtemps que celui qui
+      est entré, avec son rythme et son son intacts.
+    </p>
+    <p>
+      Contrairement à la coupe, celui-ci doit écrire de nouvelles images. Ce
+      n'est pas un défaut d'un outil particulier&nbsp;; c'est ce qu'est le
+      recadrage. Le reste de cette page traite de ce que cela coûte et de la
+      façon de le garder petit.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi le recadrage ne peut pas éviter un réencodage</h2>
+    <p>
+      Une coupe garde des images entières&nbsp;: un bon coupeur les déplace donc
+      intactes et rien n'est décodé. Un recadrage garde une partie de chaque
+      image &mdash; et une partie d'image est une autre image. Il n'y a aucun
+      moyen de stocker une autre image sans réécrire les pixels.
+    </p>
+    <p>
+      Il existe une exception étroite, et il vaut la peine de la connaître pour
+      reconnaître quand on vous en fait argument. La vidéo est encodée par blocs,
+      et si un recadrage tombait exactement sur des frontières de blocs des
+      quatre côtés, une partie des données pourrait en principe être réutilisée.
+      En pratique, les dimensions de l'image, les vecteurs de mouvement et la
+      prédiction doivent de toute façon être réécrits&nbsp;: rien de réel ne se
+      construit ainsi. Considérez qu'un recadrage veut dire un réencodage.
+    </p>
+    <p>
+      Ce qu'un recadreur bien élevé fera, c'est ne pas dépenser
+      <em>davantage</em> que l'original ne dépensait sur la même zone. Encoder
+      une région recadrée à un débit plus élevé que sa source ne fait que grossir
+      le fichier&nbsp;; cela ne peut pas remettre un détail que l'original
+      n'avait pas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les formes qu'on vous réclame réellement</h2>
+    <p>
+      La plupart des recadrages se font parce qu'un endroit impose une
+      proportion. La liste courte&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>9:16 &mdash; vertical.</strong> Stories, reels, shorts, TikTok.
+        Plein écran sur un téléphone tenu normalement. La raison la plus courante
+        pour laquelle quiconque recadre une vidéo.
+      </li>
+      <li>
+        <strong>1:1 &mdash; carré.</strong> Les posts de fil sur plusieurs
+        plateformes. Fonctionne dans les deux sens de tenue du téléphone, et
+        c'est pourquoi cela perdure.
+      </li>
+      <li>
+        <strong>4:5 &mdash; légèrement vertical.</strong> La plus grande forme
+        que certains fils autorisent&nbsp;: elle prend donc plus d'écran qu'un
+        carré sans être une vidéo entièrement verticale.
+      </li>
+      <li>
+        <strong>16:9 &mdash; large.</strong> Le standard de la vidéo en général.
+        Vous ne recadrez en général <em>vers</em> ce format que pour retirer des
+        bandes noires, ou <em>depuis</em> ce format pour obtenir l'un des
+        précédents.
+      </li>
+    </ul>
+    <p>
+      Verrouillez le cadre sur la proportion plutôt que de le tirer à l'œil.
+      Quelques pixels d'écart veulent dire que la plateforme recadrera votre
+      recadrage, et elle ne vous consultera pas sur l'endroit.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rendre vertical un clip horizontal</h2>
+    <p>
+      C'est le cas courant le plus difficile, et il vaut la peine de dire
+      clairement que le recadrage est un compromis plutôt qu'une solution.
+    </p>
+    <p>
+      Une vidéo 16:9 recadrée en 9:16 garde environ 32&nbsp;% de la largeur de
+      l'image. Tout ce qui est sur les côtés a disparu &mdash; et dans un plan
+      horizontal, les côtés sont en général là où se trouve le contexte. Si deux
+      personnes se parlent aux deux bords opposés du cadre, aucun recadrage
+      unique ne garde les deux.
+    </p>
+    <p>
+      Choisissez le recadrage en regardant le clip une fois et en vous demandant
+      où le sujet se trouve réellement la plupart du temps. Si la réponse est
+      &laquo;&nbsp;il bouge&nbsp;&raquo;, un recadrage fixe est le mauvais outil
+      et ce qu'il vous faut est un logiciel de montage capable de faire suivre le
+      cadre dans le temps. Si la réponse est
+      &laquo;&nbsp;au centre, la plupart du temps&nbsp;&raquo;, un recadrage
+      centré convient très bien et prend dix secondes.
+    </p>
+    <p>
+      L'autre solution à garder en tête&nbsp;: beaucoup de plateformes acceptent
+      une vidéo horizontale et ajoutent les bandes elles-mêmes. Le recadrage est
+      pour quand vous voulez le plein écran, pas pour quand vous voulez que la
+      vidéo soit acceptée.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi la largeur et la hauteur avancent par deux</h2>
+    <p>
+      Si vous remarquez que le cadre de recadrage refuse les nombres impairs,
+      c'est le codec qui fait des difficultés, pas l'interface.
+    </p>
+    <p>
+      Le H.264 &mdash; le codec à l'intérieur d'un MP4 &mdash; stocke la couleur
+      à demi-résolution horizontalement et verticalement, parce que l'œil est
+      bien moins sensible au détail de couleur qu'à celui de luminosité. Cela veut
+      dire que l'image est traitée par unités de deux pixels et qu'il n'y a aucun
+      moyen de décrire une image dont un côté ferait un nombre impair de pixels.
+    </p>
+    <p>
+      Les outils s'en accommodent en arrondissant votre recadrage une fois posé,
+      ce qui déplace votre cadre d'un pixel sans vous le dire, ou en ne proposant
+      que des nombres pairs dès le départ. C'est la seconde solution qui est
+      retenue ici.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qu'il advient du son</h2>
+    <p>
+      Rien, sur le chemin MP4. Le recadrage change l'image et n'a aucune raison
+      de toucher à l'audio&nbsp;: l'audio est donc recopié échantillon par
+      échantillon sans être jamais décodé &mdash; octet pour octet ce qu'il y
+      avait dans le fichier.
+    </p>
+    <p>
+      Sur le repli par enregistrement, décrit plus bas, le son est capté à la
+      lecture et réencodé, ce qui coûte un peu de qualité. Dans les deux cas, une
+      case permet de le laisser entièrement de côté, ce qui vaut la peine quand
+      le clip part quelque part qui le lira muet de toute façon et que vous
+      voulez le fichier le plus léger.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les formats, et le temps que cela prend</h2>
+    <p>
+      <strong>Le MP4, le M4V et le MOV</strong> sont lus directement, quel que
+      soit leur contenu &mdash; H.264, HEVC, AV1 ou VP9 &mdash; du moment que
+      votre navigateur sait décoder ce codec. Contrairement à la coupe, le
+      recadrage doit décoder&nbsp;: le codec compte donc ici d'une façon dont il
+      ne compte pas là-bas.
+    </p>
+    <p>
+      <strong>Tout le reste que votre navigateur sait lire</strong>, le WebM au
+      premier chef, est recadré en le jouant et en enregistrant le résultat, ce
+      qui marche et prend le temps que dure le clip.
+    </p>
+    <p>
+      <strong>L'AVI, le WMV, le FLV et la plupart des MKV</strong>, le navigateur
+      ne sait ni les lire ni les jouer, et l'outil les refuse avec un message
+      plutôt que d'échouer à mi-course.
+    </p>
+    <p>
+      Attendez-vous à ce qu'un recadrage prenne un temps réel sur un long clip,
+      parce que chaque image est décodée puis réencodée. Aucune limite n'est
+      intégrée à l'outil, et le fichier est parcouru quelques mégaoctets à la
+      fois plutôt que chargé en entier&nbsp;; le plafond pratique est la vidéo
+      finie, assemblée en mémoire avant que vous la téléchargiez.
+    </p>
+  </section>
+
+  <section>
+    <h2>Recadrez avant toute autre chose</h2>
+    <p>
+      Si un clip demande à la fois une coupe et un recadrage, coupez d'abord
+      &mdash; c'est gratuit, et chaque seconde retirée est une seconde que
+      personne n'a à réencoder. Recadrez ensuite le clip raccourci, une seule
+      fois.
+    </p>
+    <p>
+      Faire l'inverse revient à recadrer des images que vous êtes sur le point de
+      jeter, ce qui coûte du temps et de la qualité pour rien. Le
+      <a href="../../couper-une-video/">coupeur de vidéos</a> est juste à côté, et
+      <a href="../couper-une-video/">son guide</a> explique pourquoi cette étape
+      n'a pas à vous coûter quoi que ce soit.
+    </p>
+    <p>
+      Plus généralement&nbsp;: chaque étape avec perte s'accumule. Un recadrage
+      d'un original, c'est une génération. Un recadrage d'une coupe d'un export
+      d'un téléchargement, c'en est quatre, et cela se voit.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi cela ne demande pas d'envoi</h2>
+    <p>
+      Décoder et réencoder de la vidéo dans un navigateur est récent et c'est
+      réel&nbsp;: WebCodecs expose l'encodeur matériel même que votre téléphone
+      utilise pour enregistrer de la vidéo, et c'est rapide pour la même raison.
+      Le travail se passe sur la machine qui a déjà le fichier, ce qui est aussi,
+      pour une vidéo de plusieurs gigaoctets, la seule disposition qui ait du sens
+      &mdash; l'envoyer et retélécharger le résultat coûte plus de temps que
+      l'encodage.
+    </p>
+    <p>
+      L'outil d'ici n'a aucune fonction réseau, et la
+      <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+      qu'elle peut contacter, dont aucune n'appartient à ce site. Coupez votre
+      connexion et recadrez un clip quand même, si vous préférez vérifier plutôt
+      qu'on vous le dise.
+    </p>
+    <p>
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
+      vérifications applicables à n'importe quel outil.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/crop-a-video.toml
+++ b/locales/fr/pages/guides/crop-a-video.toml
@@ -1,0 +1,17 @@
+#
+# Guide : recadrer une video - French.
+#
+
+nav = "Recadrer une vidéo"
+title = "Comment recadrer une vidéo dans une autre forme"
+description = "Ramener un clip à un carré, à un format 9:16 vertical, ou à un cadre en pixels exact. Quelle proportion réclame chaque plateforme, pourquoi recadrer doit réencoder quand couper ne le fait pas, et ce que cela coûte."
+heading = "Comment recadrer une vidéo dans une autre forme"
+lede = """
+    Recadrer change la forme de l'image, ce qui veut dire écrire de nouvelles
+    images &mdash; il n'y a pas moyen d'y couper, et tout outil qui prétend le
+    contraire fait autre chose. Voici ce que cela coûte, et comment bien le
+    dépenser."""
+updated = "20 août 2026"
+og_title = "Comment recadrer une vidéo dans une autre forme"
+og_description = "Quelle proportion réclame chaque plateforme, pourquoi recadrer doit réencoder quand couper ne le fait pas, et ce que cela coûte."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/embed-an-image-in-css.html
+++ b/locales/fr/pages/guides/embed-an-image-in-css.html
@@ -1,0 +1,329 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez <a href="../../image-en-base64/">Image en data URI</a>, déposez-y
+      l'image, choisissez <em>Une propriété personnalisée CSS</em>, et collez la
+      ligne en tête de votre feuille de style. Servez-vous-en ensuite comme
+      <code>background-image: var(--logo)</code> partout où il vous la faut.
+    </p>
+    <p>
+      Faites-le quand l'image est petite &mdash; une icône, une puce, un chevron,
+      un motif &mdash; et qu'elle est nécessaire sur toutes les pages. Ne le
+      faites pas avec une photographie. Tout ce qui suit explique pourquoi ces
+      deux phrases diffèrent, et comment savoir dans quel cas vous êtes.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qu'est réellement un data URI</h2>
+    <p>
+      Une adresse qui contient la chose au lieu de pointer vers elle. Là où une
+      feuille de style dirait normalement
+    </p>
+    <pre><code>background-image: url("logo.png");</code></pre>
+    <p>
+      et où le navigateur va chercher <code>logo.png</code>, un data URI dit
+    </p>
+    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <p>
+      et il n'y a rien à aller chercher&nbsp;: l'image est déjà là, écrite en
+      caractères. Il y a trois parties. <code>data:</code> est le schéma.
+      <code>image/png</code> est le type de média, et le navigateur le croit sur
+      parole &mdash; on y revient plus bas. Tout ce qui suit la virgule est le
+      fichier.
+    </p>
+    <p>
+      C'est toute l'idée. Ce n'est ni une astuce ni un bricolage&nbsp;; c'est
+      dans les standards depuis 1998 et cela fonctionne dans tous les navigateurs
+      sortis depuis.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que cela vous rapporte&nbsp;: un aller-retour de moins</h2>
+    <p>
+      L'économie n'est pas la bande passante. C'est la requête.
+    </p>
+    <p>
+      Un navigateur ne peut pas demander <code>logo.png</code> avant d'avoir lu
+      la feuille de style qui le mentionne, et il ne peut pas lire cette feuille
+      de style avant de l'avoir récupérée. Une image de fond ordinaire est donc à
+      au moins deux allers-retours de profondeur dans le chargement de la page,
+      et sur un téléphone en réseau lent un aller-retour peut représenter deux
+      cents millisecondes quelle que soit la petitesse du fichier. Un chevron de
+      600 octets ne coûte presque rien à transférer et peut quand même coûter un
+      quart de seconde à arriver.
+    </p>
+    <p>
+      Mis en ligne, il arrive avec la feuille de style. C'est là tout le
+      bénéfice, et pour une petite icône visible d'emblée, il est réel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que cela coûte&nbsp;: un tiers, puis la mise en cache</h2>
+    <p>
+      <strong>Le base64 ajoute environ un tiers.</strong> Trois octets de fichier
+      deviennent quatre caractères, parce que c'est ce qu'il faut pour écrire des
+      octets quelconques avec les seuls caractères qu'une URL autorise. Il
+      n'existe aucun encodeur malin qui l'évite. Un PNG de 9 KB fait 12 KB de
+      feuille de style.
+    </p>
+    <p>
+      <strong>La compression ne le rend pas.</strong> C'est la partie que les
+      gens balaient d'un revers de main. Le gzip et le Brotli travaillent en
+      trouvant de la redondance, et un PNG, un JPEG et un WebP ont déjà été
+      compressés &mdash; il ne leur reste presque aucune redondance, et le base64
+      n'en ajoute pas. En pratique, vous en récupérez quelque chose comme un
+      dixième du tiers, pas la totalité. (Un SVG est le cas inverse, et la
+      section suivante en parle.)
+    </p>
+    <p>
+      <strong>Cela cesse d'être un fichier.</strong> C'est le coût qui
+      n'apparaîtra dans aucune mesure que vous êtes susceptible de prendre, et
+      c'est celui qui compte quand la taille monte&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Cela ne peut plus être mis en cache pour soi-même.</strong> Une
+        image ordinaire est récupérée une fois et réutilisée un an. Une image en
+        ligne fait partie de la feuille de style&nbsp;: elle vit et meurt avec
+        l'entrée de cache de celle-ci.
+      </li>
+      <li>
+        <strong>Changer quoi que ce soit fait tout retélécharger.</strong>
+        Corrigez une marge, livrez une nouvelle feuille de style, et chaque
+        visiteur retélécharge l'image en ligne avec elle &mdash; une image qui
+        n'a pas changé depuis deux ans.
+      </li>
+      <li>
+        <strong>C'est sur le chemin critique.</strong> Une feuille de style
+        bloque le rendu. Une image non. Mettre une image en ligne la fait passer
+        de la seconde catégorie à la première&nbsp;: la page ne peut pas se
+        peindre avant que le tout, image comprise, soit arrivé.
+      </li>
+      <li>
+        <strong>Cela ne peut plus être récupéré en parallèle.</strong> Les
+        navigateurs téléchargent beaucoup de choses à la fois. Une image en ligne
+        n'est plus une chose à part, elle ne bénéficie donc de rien de tout cela.
+      </li>
+    </ul>
+    <p>
+      Des seuils approximatifs, qui marquent l'endroit où le conseil change
+      plutôt que celui où un navigateur fait quoi que ce soit de
+      différent&nbsp;: sous 2 KB environ, c'est un gain net&nbsp;; jusqu'à 10 KB
+      environ, cela vaut encore le coup pour quelque chose présent sur toutes les
+      pages&nbsp;; passé 50 KB, c'est une erreur sans message d'erreur.
+      <a href="../../image-en-base64/">L'outil</a> vous dit dans quelle plage
+      tombe chaque résultat, avec le nombre de caractères à côté.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ne passez jamais un SVG en base64</h2>
+    <p>
+      C'est de loin l'erreur la plus courante en matière d'images en ligne, et
+      elle est commise par les exporteurs et les greffons de compilation aussi
+      souvent que par des humains.
+    </p>
+    <p>
+      Un SVG est du texte. Une URL transporte déjà du texte. Seule une poignée de
+      caractères doit être échappée &mdash; <code>%</code>, <code>#</code>,
+      <code>&lt;</code>, <code>&gt;</code> et le guillemet dans lequel vous
+      l'avez enveloppé &mdash; et tout le reste peut rester exactement tel quel.
+      L'encoder ainsi vous donne un URI typiquement un cinquième plus court que
+      le base64 du même fichier, et qui se compresse ensuite comme du texte
+      plutôt que comme du bruit.
+    </p>
+    <p>
+      Il reste en outre lisible&nbsp;:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <p>
+      Vous voyez le <code>viewBox</code>. Vous pouvez changer la couleur de
+      remplissage dans votre éditeur sans rien décoder. Passez le même fichier en
+      base64 et cela devient un mur de lettres que plus personne ne touchera
+      jamais. <a href="../../image-en-base64/">Image en data URI</a> le fait
+      automatiquement pour tout ce qui s'avère être un SVG, et propose une case
+      pour la rare chaîne d'outils qui exige <code>;base64</code>.
+    </p>
+  </section>
+
+  <section>
+    <h2>L'erreur de guillemets qui ne casse que les SVG</h2>
+    <p>
+      Le CSS permet d'écrire <code>url()</code> sans guillemets, et pour un nom
+      de fichier ordinaire cela va très bien&nbsp;:
+    </p>
+    <pre><code>background-image: url(logo.png);</code></pre>
+    <p>
+      Faites la même chose avec un SVG encodé en pourcents et cela casse. Un
+      jeton <code>url()</code> sans guillemets se termine au premier espace,
+      parenthèse, guillemet ou caractère de contrôle &mdash; et un SVG est plein
+      d'espaces, entre chaque attribut et chaque nombre d'un tracé. La
+      déclaration est alors invalide, le CSS jette les déclarations invalides en
+      silence, et vous n'obtenez ni fond ni erreur.
+    </p>
+    <p>
+      Le remède, ce sont les guillemets, à chaque fois&nbsp;:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
+    <p>
+      C'est aussi pourquoi un encodeur n'a pas besoin d'échapper les espaces
+      &mdash; ils sont parfaitement légaux à l'intérieur d'une URL entre
+      guillemets, et échapper chacun en <code>%20</code> coûterait trois
+      caractères par espace du fichier. Les deux décisions vont ensemble&nbsp;:
+      mettez l'URI entre guillemets, et vous pouvez laisser les espaces
+      tranquilles. Toutes les formes que produit l'outil sont entre guillemets
+      pour exactement cette raison.
+    </p>
+  </section>
+
+  <section>
+    <h2>Le type de média doit être juste</h2>
+    <p>
+      Un data URI déclare son propre type, et le navigateur le prend au mot. Il
+      n'y a pas de repli par reniflage comme pour un fichier récupéré&nbsp;:
+      dites <code>image/png</code> à propos de quelque chose qui est en réalité
+      un JPEG et l'image ne s'affiche pas, sans message nulle part où cela
+      servirait.
+    </p>
+    <p>
+      Ce qui compte, parce que les extensions mentent. Une photo exportée en JPEG
+      et renommée <code>logo.png</code> est une chose ordinaire à trouver sur un
+      disque. Les premiers octets d'un fichier image, en revanche, disent sans
+      ambiguïté ce qu'il est &mdash; chaque format a une signature &mdash;&nbsp;;
+      un outil devrait donc lire le fichier plutôt que son nom. Celui d'ici le
+      fait, et vous prévient quand les deux se contredisent.
+    </p>
+    <p>
+      Deux formats valent d'être connus parce qu'ils échouent de façon déroutante.
+      Le <strong>HEIC</strong>, qui est ce dans quoi photographie un iPhone, et
+      le <strong>TIFF</strong>, qui est ce que produisent les scanners, font tous
+      deux des data URI parfaitement valides qu'aucun navigateur sauf Safari ne
+      dessinera. L'URI n'est pas cassé&nbsp;; le format n'est simplement pas un
+      format que le web prend en charge. Convertissez d'abord.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les métadonnées que vous ne vouliez pas publier</h2>
+    <p>
+      Un data URI est une copie du fichier, octet pour octet. Rien n'est décodé
+      puis réencodé, ce qui est en général tout l'intérêt &mdash; aucune qualité
+      n'est perdue &mdash; mais cela veut dire aussi que tout le reste du fichier
+      suit.
+    </p>
+    <p>
+      Une photographie sortie tout droit d'un téléphone porte de l'EXIF&nbsp;: les
+      coordonnées GPS du lieu de la prise de vue, l'horodatage, le modèle
+      d'appareil et souvent son numéro de série. Cela peut représenter 30 KB du
+      fichier. Mis en ligne, cela devient 40 KB de base64 dans votre feuille de
+      style, sur le chemin critique de chaque page &mdash; et une adresse
+      personnelle versionnée dans un dépôt, sous une forme que personne ne
+      pensera jamais à regarder.
+    </p>
+    <p>
+      Retirez-les d'abord avec le
+      <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a>,
+      qui réécrit le conteneur sans toucher à l'image&nbsp;; il y a aussi
+      <a href="../supprimer-les-donnees-exif-et-gps/">un guide pour cela</a>.
+      Image en data URI lit la quantité de métadonnées présentes dans un JPEG, un
+      PNG ou un WebP et le dit avant que vous ne copiiez quoi que ce soit.
+    </p>
+  </section>
+
+  <section>
+    <h2>Où le mettre, une fois que vous l'avez</h2>
+    <p>
+      Si l'image apparaît dans une seule règle, mettez l'URI dans cette règle. Si
+      elle apparaît dans plusieurs &mdash; et les icônes le font en général, une
+      fois comptés l'état de survol et le thème sombre &mdash; déclarez-la une
+      fois comme propriété personnalisée&nbsp;:
+    </p>
+    <pre><code>:root {
+  --icon-search: url("data:image/svg+xml,%3Csvg ... %3E");
+}
+
+.search-field { background-image: var(--icon-search); }
+.search-button::before { content: var(--icon-search); }</code></pre>
+    <p>
+      Un URI de 3 KB collé dans quatre règles, ce sont 12 KB de feuille de style
+      et quatre endroits à modifier quand l'icône change. La propriété
+      personnalisée, c'est un seul de chaque. C'est aussi la forme qui fait
+      fonctionner les thèmes&nbsp;: redéfinissez <code>--icon-search</code> dans
+      une media query et chacun de ses usages suit.
+    </p>
+    <p>
+      Pour une balise <code>&lt;img&gt;</code> plutôt que du CSS, mettez
+      <code>width</code> et <code>height</code>. Une image en ligne se charge
+      instantanément&nbsp;: une taille manquante est donc un décalage de mise en
+      page trop rapide pour être vu et qui compte quand même contre vous.
+      L'exception est le SVG&nbsp;: celui qui ne porte qu'un <code>viewBox</code>
+      n'a pas de taille en pixels à lui, et écrire le défaut de 300&times;150 du
+      navigateur sur la balise fige une image extensible à une taille que
+      personne n'a choisie.
+    </p>
+    <p>
+      Laissez l'<code>alt</code> vide, sauf si vous avez quelque chose de vrai à
+      y mettre. Vous seul savez si l'image porte du sens ou n'est que décorative,
+      et une description devinée à partir d'un nom de fichier est pire, pour qui
+      utilise un lecteur d'écran, que pas de description du tout.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quand la réponse est &laquo;&nbsp;ne le faites pas&nbsp;&raquo;</h2>
+    <p>
+      Si l'image dépasse les 50 KB une fois encodée, la mise en ligne est le
+      mauvais outil et aucun soin apporté à l'encodage n'y changera rien. Les
+      solutions de rechange, dans l'ordre où il vaut la peine de les
+      essayer&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Alléger l'image.</strong> La plupart des images trop grosses pour
+        être mises en ligne sont trop grosses tout court. Le
+        <a href="../../compresser-une-image/">compresseur d'images</a> amènera
+        une photographie à une taille que vous nommez, et le
+        <a href="../../redimensionner-une-image/">redimensionneur d'images</a>
+        ramènera les dimensions en pixels à ce que la mise en page utilise
+        réellement &mdash; ce qui est très souvent le vrai problème.
+      </li>
+      <li>
+        <strong>La redessiner en SVG.</strong> Une icône exportée en PNG de 40 KB
+        est fréquemment un SVG de 900 octets. Ce n'est pas une différence de
+        compression, c'est une différence de format, et cela règle aussi le
+        problème du Retina.
+      </li>
+      <li>
+        <strong>La laisser en fichier et la précharger.</strong>
+        <code>&lt;link rel="preload" as="image"&gt;</code> lance la récupération
+        immédiatement sans déplacer les octets sur le chemin critique. Cela
+        rapporte l'essentiel du bénéfice de la mise en ligne sans son coût de
+        mise en cache.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Rien de tout cela ne demande un envoi</h2>
+    <p>
+      Encoder un fichier en base64 est de l'arithmétique. Ce sont deux fonctions
+      que le navigateur possède depuis le début &mdash; <code>btoa</code> et
+      <code>encodeURIComponent</code> &mdash; et il n'y a absolument aucune
+      raison technique pour qu'une image voyage jusqu'à un serveur et en revienne
+      pour être écrite autrement. Tout convertisseur qui envoie votre fichier
+      pour faire cela l'envoie pour ses propres raisons, pas pour les vôtres.
+    </p>
+    <p>
+      <a href="../../image-en-base64/">L'outil d'ici</a> ne l'envoie nulle
+      part&nbsp;: la <code>Content-Security-Policy</code> de la page nomme toutes
+      les adresses qu'elle peut contacter, et aucune n'appartient à ce site.
+      Chargez la page, coupez votre connexion, et encodez quelque chose quand
+      même, si vous préférez vérifier plutôt qu'on vous le dise.
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
+      vérifications applicables à n'importe quel outil.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/embed-an-image-in-css.toml
+++ b/locales/fr/pages/guides/embed-an-image-in-css.toml
@@ -1,0 +1,18 @@
+#
+# Guide : integrer une image dans le CSS - French.
+#
+
+nav = "Intégrer une image dans le CSS"
+title = "Les data URI en CSS : quand intégrer une image, et quand s'abstenir"
+description = "Ce que coûte un data URI, pourquoi le base64 ajoute un tiers que le gzip ne rend pas, pourquoi un SVG ne devrait jamais être en base64, et l'erreur de guillemets qui casse les SVG en ligne sans rien dire."
+heading = "Quand mettre une image dans votre CSS, et quand s'abstenir"
+lede = """
+    Une image écrite dans une feuille de style arrive avec elle&nbsp;: pas de
+    seconde requête, pas d'attente. Elle cesse aussi d'être un fichier &mdash;
+    elle ne peut donc plus être mise en cache pour elle-même, et elle est
+    retéléchargée dès que quoi que ce soit autour d'elle change. Voici où ce
+    marché vaut la peine, et où il ne la vaut discrètement pas."""
+updated = "20 août 2026"
+og_title = "Quand mettre une image dans votre CSS"
+og_description = "Ce que coûte un data URI, pourquoi un SVG ne devrait jamais être en base64, et l'erreur de guillemets qui casse les SVG en ligne sans rien dire."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/fr/pages/guides/is-it-safe-to-upload-files.html
@@ -1,0 +1,272 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Pour la plupart des fichiers, la plupart du temps, envoyer ne pose pas de
+      problème. Les convertisseurs sérieux effacent ce que vous leur envoyez au
+      bout de quelques heures et n'ont aucun intérêt pour vos photos de vacances.
+    </p>
+    <p>
+      Le problème n'est pas qu'ils mentent. C'est que
+      <strong>vous n'avez aucun moyen de savoir s'ils mentent</strong>. Une fois
+      qu'un fichier a quitté votre machine, chaque promesse sur ce qui lui arrive
+      ensuite est une promesse que vous croyez sur parole&nbsp;: combien de temps
+      il est gardé, qui peut l'atteindre, s'il est copié dans une sauvegarde qui
+      survivra au minuteur de suppression, ce qu'il en advient si l'entreprise est
+      vendue ou piratée. Rien de tout cela n'est visible de l'extérieur.
+    </p>
+    <p>
+      La question utile n'est donc pas
+      &laquo;&nbsp;est-ce que je fais confiance à ce site&nbsp;?&nbsp;&raquo;
+      C'est <strong>&laquo;&nbsp;est-ce que ce travail exige que mon fichier
+      parte&nbsp;?&nbsp;&raquo;</strong> Pour un nombre important et croissant de
+      travaux, la réponse est non &mdash; et quand la réponse est non, la question
+      de la confiance cesse d'être une question à laquelle vous devez répondre.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que l'envoi fait réellement</h2>
+    <p>
+      Quand un convertisseur vous demande de choisir un fichier puis vous montre
+      une barre de progression, votre navigateur copie tout le fichier, octet pour
+      octet, à travers internet, vers un ordinateur qui appartient à quelqu'un
+      d'autre. Cet ordinateur l'écrit sur un disque, exécute la conversion, écrit
+      le résultat sur le même disque, et vous remet un lien.
+    </p>
+    <p>
+      À cet instant, votre fichier existe dans au moins trois endroits que vous
+      n'avez pas choisis&nbsp;: le disque du serveur, les journaux qui ont
+      enregistré la requête, et souvent un réseau de diffusion de contenu qui a
+      mis le résultat en cache pour que le téléchargement soit rapide. Une
+      politique de suppression doit atteindre les trois. La plupart disent le
+      faire. Vous ne pouvez en vérifier aucun.
+    </p>
+    <p>
+      À savoir également&nbsp;: le fichier n'est pas la seule chose qui arrive. Le
+      nom de fichier part avec lui, et tout ce qui se trouve dans le fichier sans
+      que vous puissiez le voir aussi. Une photo sortie tout droit d'un téléphone
+      porte typiquement les coordonnées GPS exactes du lieu de la prise de vue,
+      l'heure, le numéro de série de l'appareil, et parfois une vignette
+      incorporée de l'image d'origine, d'avant votre recadrage. Les gens qui font
+      attention à l'image ne font souvent pas attention à cela, parce que rien à
+      l'écran ne le leur montre.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi la plupart des outils envoient quand même</h2>
+    <p>
+      Pas parce qu'ils veulent vos fichiers. Parce que, pendant l'essentiel de la
+      vie du web, il n'y avait pas d'alternative. Un navigateur ne savait ni
+      décoder une vidéo, ni réencoder une image à une qualité choisie, ni analyser
+      un format de fichier&nbsp;; un serveur avec FFmpeg et ImageMagick le savait.
+      L'envoi n'était pas un modèle économique, c'était le seul endroit où le
+      travail pouvait avoir lieu.
+    </p>
+    <p>
+      Cela a cessé d'être vrai récemment et discrètement. Les navigateurs livrent
+      désormais WebAssembly, qui exécute les mêmes codecs compilés à une vitesse
+      proche du natif, WebCodecs, qui expose l'encodeur vidéo matériel déjà présent
+      dans votre machine, et une API Canvas capable de décoder et de réencoder des
+      images directement. Le travail pour lequel un serveur était nécessaire tourne
+      maintenant sur l'appareil qui a déjà le fichier.
+    </p>
+    <p>
+      Bien des outils envoient encore, et il y a des raisons honnêtes&nbsp;: une
+      chaîne de traitement existante que personne ne veut réécrire, un format sans
+      décodeur côté navigateur, un travail réellement trop lourd pour un téléphone.
+      Il y a aussi une raison moins honnête, à savoir qu'un serveur est l'endroit
+      où vivent les comptes, les quotas et les offres payantes. Un outil qui tourne
+      entièrement dans votre navigateur est difficile à compter.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quatre vérifications que vous pouvez faire vous-même</h2>
+    <p>
+      Elles fonctionnent sur n'importe quel outil, celui-ci compris. Aucune
+      n'exige de croire qui que ce soit sur parole, et la première prend une
+      dizaine de secondes.
+    </p>
+
+    <h3>1. Débranchez</h3>
+    <p>
+      Chargez la page, puis coupez votre wi-fi ou débranchez le câble, et essayez
+      de vous en servir. Un outil qui fait son travail dans votre navigateur
+      continue exactement comme avant. Un outil qui envoie s'arrête
+      immédiatement, parce que ce qui fait le travail n'est plus joignable.
+    </p>
+    <p>
+      C'est le test le plus fort qui soit, et le plus difficile à truquer, parce
+      qu'on ne peut pas y répondre par des formulations. Ou bien la conversion
+      s'achève sans réseau, ou bien non.
+    </p>
+
+    <h3>2. Surveillez l'onglet Réseau</h3>
+    <p>
+      Ouvrez les outils de développement de votre navigateur, choisissez Réseau,
+      puis servez-vous de l'outil. Chaque requête que fait la page est listée avec
+      sa taille. Si votre photo de 4&nbsp;MB a été envoyée, il y a une requête de
+      4&nbsp;MB dans cette liste. Si la plus grosse chose qui quitte la page fait
+      quelques kilooctets de publicité, elle ne l'a pas été.
+    </p>
+    <p>
+      Triez par taille et regardez le haut. Vous n'avez pas besoin de comprendre
+      les requêtes&nbsp;; vous avez besoin de remarquer si l'une d'elles fait la
+      taille de votre fichier.
+    </p>
+
+    <h3>3. Lisez la Content-Security-Policy</h3>
+    <p>
+      Affichez le source de la page et cherchez
+      <code>Content-Security-Policy</code>, vers le haut. C'est la liste des
+      adresses que cette page a le droit de contacter, et c'est votre navigateur
+      qui l'applique, non les bonnes intentions du site &mdash; une requête vers
+      quoi que ce soit d'absent de la liste est refusée, quoi que le code essaie.
+    </p>
+    <p>
+      La directive qui compte est <code>connect-src</code>, qui régit les endroits
+      où la page peut envoyer des données. Si elle nomme une adresse appartenant
+      au site où vous êtes, la page peut y envoyer votre fichier. Si elle ne nomme
+      rien, ou seulement des tiers comme une régie publicitaire, elle ne le peut
+      pas.
+    </p>
+    <p>
+      Une page sans aucune Content-Security-Policy n'est la preuve de rien de
+      mauvais. Cela veut simplement dire que cette vérification-là n'a rien à vous
+      apprendre.
+    </p>
+
+    <h3>4. Lisez le code</h3>
+    <p>
+      La moins commode, la plus concluante. Si un outil publie son source et le
+      sert sans étape de compilation, les fichiers que votre navigateur a
+      récupérés sont les fichiers que vous pouvez lire. Cherchez-y
+      <code>fetch</code>, <code>XMLHttpRequest</code> et <code>sendBeacon</code>
+      &mdash; les trois façons dont une page peut envoyer quoi que ce soit &mdash;
+      et regardez ce qu'on leur donne.
+    </p>
+    <p>
+      La plupart des gens ne le feront pas. Il n'en reste pas moins important que
+      ce soit possible, parce qu'une affirmation que personne ne peut vérifier
+      n'est pas vraiment une affirmation.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que &laquo;&nbsp;tourne dans votre navigateur&nbsp;&raquo; ne veut pas dire</h2>
+    <p>
+      Il vaut la peine d'être précis, parce que l'expression est employée à la
+      légère et que ce site doit se tenir au standard qu'il propose.
+    </p>
+    <ul>
+      <li>
+        <strong>Cela ne veut pas dire aucune requête du tout.</strong> La page
+        elle-même est arrivée par le réseau, et la plupart des outils gratuits
+        portent de la publicité ou de l'analytique qui parlent à quelqu'un.
+        L'affirmation porte sur votre <em>fichier</em>, pas sur le trafic en
+        général.
+      </li>
+      <li>
+        <strong>Cela ne cache pas votre adresse IP.</strong> Tous les sites que
+        vous visitez la voient, celui-ci compris. Le traitement local porte sur le
+        contenu de vos fichiers, pas sur l'anonymat.
+      </li>
+      <li>
+        <strong>Cela ne survit pas à une fonction qui va chercher quelque
+        chose.</strong> Un outil qui vous laisse coller une adresse web doit
+        contacter cette adresse, et ce serveur apprend votre IP et ce que vous
+        avez demandé. C'est inhérent à la fonction, pas un défaut &mdash; mais
+        c'est une vraie exception, et un outil devrait le dire franchement plutôt
+        que de l'arrondir.
+      </li>
+      <li>
+        <strong>Ce n'est pas la même chose que
+        &laquo;&nbsp;nous supprimons vos fichiers&nbsp;&raquo;.</strong> La
+        seconde phrase parle de ce qu'une entreprise choisit de faire. La première
+        parle de ce qui est techniquement possible. Une seule des deux est
+        vérifiable.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Quand envoyer ne pose vraiment pas de problème</h2>
+    <p>
+      Ce n'est pas un plaidoyer selon lequel tout envoi serait une erreur. Envoyez
+      le fichier quand le contenu n'est pas sensible et que le travail en est
+      facilité&nbsp;; quand le travail est réellement trop lourd pour votre
+      appareil&nbsp;; quand le format n'a pas de décodeur côté navigateur&nbsp;;
+      ou quand vous utilisez un service avec lequel vous avez déjà une relation et
+      dont vous avez réellement lu les conditions.
+    </p>
+    <p>
+      Soyez plus prudent quand le fichier contient quelque chose que vous ne
+      publieriez pas&nbsp;: pièces d'identité, examens médicaux, contrats, tout ce
+      qui porte une adresse ou un visage que vous n'aviez pas l'intention de
+      partager, ou une photo dont vous n'avez pas regardé les données de lieu.
+      Pour ceux-là, un outil que vous pouvez vérifier vaut mieux qu'un outil
+      auquel vous devez faire confiance &mdash; non parce que celui à qui l'on
+      fait confiance risque de vous trahir, mais parce qu'avec celui qui est
+      vérifiable la question ne se pose pas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Comment ce site répond à ces quatre vérifications</h2>
+    <p>
+      Ce serait un drôle de guide que celui qui vous dit de vérifier puis demande
+      une dispense. Donc, dans l'ordre&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Débranchez.</strong> Ouvrez n'importe quel outil d'ici, coupez la
+        connexion, et il continue de fonctionner. Chaque page d'outil a un
+        indicateur en direct qui vous dit si vous êtes actuellement en ligne&nbsp;:
+        vous pouvez donc le regarder changer.
+      </li>
+      <li>
+        <strong>Onglet Réseau.</strong> Convertissez quelque chose et lisez la
+        liste. Rien ne transporte votre fichier, une vignette de celui-ci, son
+        nom, sa taille, ni quoi que ce soit qui en soit lu. Il n'existe sur ce
+        site aucun événement d'analytique maison qui aurait quoi que ce soit de
+        cela à envoyer.
+      </li>
+      <li>
+        <strong>Content-Security-Policy.</strong> Elle est en tête du source de
+        chaque page. <code>connect-src</code> nomme les points de mesure et de
+        publicité de Google et le bouton de don, et rien d'autre.
+        <strong>Aucune adresse de cette liste n'appartient à ce site</strong>,
+        parce que ce site n'a pas de serveur &mdash; ce sont des fichiers
+        statiques. Il n'y a nulle part où envoyer un fichier, même si quelque
+        chose essayait.
+      </li>
+      <li>
+        <strong>Le code.</strong> Chaque ligne est
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">publique</a>.
+        La compilation retire les commentaires et les espaces et rien d'autre, et
+        vous pouvez l'exécuter vous-même et comparer le résultat à ce qui est
+        servi.
+      </li>
+    </ul>
+    <p>
+      Les exceptions, dites plutôt qu'enterrées&nbsp;: ce site porte de la
+      publicité Google et un compteur de visites, qui parlent tous deux à Google
+      et dont aucun ne reçoit quoi que ce soit sur vos fichiers&nbsp;; et l'outil
+      <a href="../../images-en-video/">Images en vidéo</a> peut récupérer une
+      image à une adresse que vous collez, ce qui veut dire que ce serveur voit
+      votre IP. La <a href="../../confidentialite/">page Confidentialité</a> expose
+      les deux en entier.
+    </p>
+    <p>
+      Tous les outils d'ici fonctionnent ainsi&nbsp;: un
+      <a href="../../compresser-une-image/">compresseur d'images</a> qui atteint
+      une taille que vous nommez, un
+      <a href="../../recadrer-une-video/">recadreur de vidéos</a>, un
+      <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a>
+      pour les données cachées décrites plus haut sur cette page,
+      <a href="../../images-en-video/">images en vidéo</a>, et
+      <a href="../../images-en-pdf/">images en PDF</a>. Tous gratuits, sans
+      compte, et aucun n'a où envoyer vos fichiers.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/fr/pages/guides/is-it-safe-to-upload-files.toml
@@ -1,0 +1,17 @@
+#
+# Guide : est-il sur d'envoyer ses fichiers a un convertisseur en ligne - French.
+#
+
+nav = "Est-il sûr d'envoyer ses fichiers ?"
+title = "Est-il sûr d'envoyer ses fichiers à un convertisseur en ligne ?"
+description = "La plupart des convertisseurs en ligne envoient votre fichier à un serveur. Ce que cela veut dire, ce qui lui arrive là-bas, et quatre vérifications qui disent si un outil en a vraiment besoin."
+heading = "Est-il sûr d'envoyer ses fichiers à un convertisseur en ligne ?"
+lede = """
+    La réponse honnête est en général &laquo;&nbsp;probablement, mais vous ne
+    pouvez pas le vérifier&nbsp;&raquo;. Voici ce que l'envoi fait réellement de
+    votre fichier, pourquoi la plupart des outils le font encore, et quatre tests
+    qui disent si celui que vous avez sous les yeux en a besoin."""
+updated = "20 août 2026"
+og_title = "Est-il sûr d'envoyer ses fichiers à un convertisseur en ligne ?"
+og_description = "Ce qu'il advient d'un fichier envoyé à un convertisseur, pourquoi la plupart des outils en réclament un, et quatre vérifications que vous pouvez faire vous-même."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/make-a-favicon.html
+++ b/locales/fr/pages/guides/make-a-favicon.html
@@ -1,0 +1,349 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez <a href="../../creer-un-favicon/">Image en ICO</a>, déposez-y une
+      image carrée d'au moins 256 pixels, laissez le préréglage sur
+      <em>Favicon de site</em>, et téléchargez <code>favicon.ico</code>.
+      Posez-le à la racine de votre site, pour qu'il réponde à
+      <code>https://votresite.com/favicon.ico</code>. Cette adresse est demandée
+      par tous les navigateurs, que votre HTML la mentionne ou non&nbsp;: il n'y
+      a donc rien d'autre que vous soyez strictement obligé de faire.
+    </p>
+    <p>
+      Tout ce qui suit est ce qui fait la différence entre une icône
+      techniquement présente et une icône lisible&nbsp;: quelles tailles entrent
+      dedans, ce que réclament plutôt les iPhone et Android, et quoi faire quand
+      votre logo ne survit pas à ses seize pixels de large.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi c'est un jeu de tailles et non une image</h2>
+    <p>
+      Un fichier <code>.ico</code> est un conteneur. Dedans se trouvent plusieurs
+      images complètes de la même chose à des tailles différentes, et ce qui lit
+      le fichier prend celle qui est la plus proche de la taille dont il a
+      besoin.
+    </p>
+    <p>
+      Cela a l'air redondant et ne l'est pas. Un navigateur qui dessine votre
+      icône à seize pixels a deux possibilités&nbsp;: lire une version de seize
+      pixels que vous avez dessinée, ou en réduire une plus grande sur-le-champ.
+      La seconde est pire, et visiblement &mdash; la réduction automatique d'un
+      logo détaillé produit une bouillie, alors qu'une version de seize pixels
+      que vous avez regardée est une chose que vous avez eu l'occasion de
+      simplifier. Toute la raison pour laquelle le format contient plusieurs
+      tailles est de vous donner cette occasion.
+    </p>
+    <p>
+      Trois tailles sont la convention pour un site web, et chacune a sa
+      raison&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>16&times;16</strong> &mdash; l'onglet du navigateur, la barre
+        d'adresse, le menu des signets. C'est celle que les gens voient. Si vous
+        n'en réussissez qu'une, réussissez celle-là.
+      </li>
+      <li>
+        <strong>32&times;32</strong> &mdash; une barre de signets, un raccourci
+        Windows vers votre site sur le bureau, et la plupart des navigateurs sur
+        un écran haute densité, qui tirent l'icône de l'onglet du 32 et la
+        réduisent.
+      </li>
+      <li>
+        <strong>48&times;48</strong> &mdash; la taille à laquelle Google lit
+        l'icône d'un site pour les résultats de recherche, et la vue à icônes
+        moyennes de Windows.
+      </li>
+    </ul>
+    <p>
+      Tout ce qui est plus grand a sa place dans un PNG à côté du
+      <code>.ico</code>, pas dedans, pour des raisons qui reviennent plus bas au
+      sujet des fichiers mobiles.
+    </p>
+  </section>
+
+  <section>
+    <h2>Le problème des seize pixels</h2>
+    <p>
+      C'est la partie dont personne ne vous prévient. Seize pixels, c'est environ
+      quatre millimètres sur un écran normal&nbsp;: une grille de 256 points en
+      tout, moins que les lettres de cette phrase. Presque rien de ce qui a été
+      conçu pour fonctionner sur une enseigne, une carte de visite ou un en-tête
+      de site ne survit à une telle réduction.
+    </p>
+    <p>
+      Ce qui disparaît, dans l'ordre&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Le texte.</strong> Un mot réduit dans un carré fait environ trois
+        pixels de haut. Il ne devient pas du petit texte, il devient une barre
+        grise. C'est pourquoi presque toutes les entreprises qui ont un symbole
+        en plus d'un nom se servent du symbole seul comme favicon, et pourquoi
+        celles qui n'ont pas de symbole utilisent une seule lettre.
+      </li>
+      <li>
+        <strong>Les traits fins.</strong> Un contour d'un pixel sur un logo de
+        512 pixels fait un trente-deuxième de pixel à seize. Il se rend en une
+        vague brume grise le long du bord, ou disparaît.
+      </li>
+      <li>
+        <strong>Les dégradés et les ombres.</strong> Il n'y a pas la place pour
+        une transition. Une ombre portée douce devient une frange sale.
+      </li>
+      <li>
+        <strong>Le détail dans le détail.</strong> L'icône d'un document couvert
+        d'écriture devient un rectangle avec une tache.
+      </li>
+    </ul>
+    <p>
+      Le remède n'est pas un réglage, c'est un autre dessin&nbsp;: une marque
+      simplifiée à une ou deux formes, à fort contraste, et sans texte au-delà
+      d'un seul caractère. Dessinez cette version à 32 ou 48 pixels
+      délibérément, et servez-vous-en comme source.
+    </p>
+    <p>
+      Ce qu'un outil peut faire, c'est vous montrer le problème avant que vous ne
+      le publiiez. L'aperçu d'<a href="../../creer-un-favicon/">Image en ICO</a>
+      dessine chaque taille à sa taille réelle à l'écran, seule façon d'en juger
+      &mdash; une icône de seize pixels affichée à soixante-quatre a l'air très
+      bien et ne vous apprend rien.
+    </p>
+  </section>
+
+  <section>
+    <h2>Votre logo n'est pas carré. Compléter ou recadrer&nbsp;?</h2>
+    <p>
+      Une icône est toujours carrée, et la plupart des logos ne le sont
+      pas&nbsp;: quelque chose doit donc arriver. Il y a trois réponses et elles
+      ne se valent pas.
+    </p>
+    <p>
+      <strong>Compléter</strong> garde l'image entière et met de l'espace
+      au-dessus et au-dessous. C'est le choix sûr par défaut et le mauvais choix
+      pour un mot large&nbsp;: faire tenir dans un carré quelque chose de trois
+      fois plus large que haut le laisse occuper un tiers de la hauteur, ce qui
+      fait à seize pixels cinq pixels de logo et onze de rien.
+    </p>
+    <p>
+      <strong>Recadrer au milieu</strong> prend le plus grand carré du centre.
+      Pour un ensemble &mdash; un symbole avec le nom de l'entreprise à côté
+      &mdash; cela coupe souvent les deux en plein milieu. Mieux vaut recadrer la
+      source vous-même d'abord, jusqu'au symbole seul, puis convertir cela.
+    </p>
+    <p>
+      <strong>Étirer</strong> écrase l'image pour la faire entrer. Il n'existe
+      pratiquement aucune situation où c'est le bon choix, et il est proposé
+      surtout pour que l'outil ne le fasse pas en silence.
+    </p>
+    <p>
+      La réponse générale pour un logo large&nbsp;: ne convertissez pas le logo.
+      Convertissez la partie du logo qui tient debout toute seule.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparent ou fond uni&nbsp;?</h2>
+    <p>
+      Transparent est en général le bon choix pour un site web. Les onglets de
+      navigateur sont gris, blancs ou presque noirs selon le navigateur et le
+      thème, et une icône transparente se pose sur tous. Une icône avec un fond
+      blanc peint dedans est un rectangle blanc dans une barre d'onglets sombre.
+    </p>
+    <p>
+      Deux exceptions valent d'être connues&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Un logo qui n'est que sombre</strong> disparaît en mode sombre.
+        Si votre marque est noire sur blanc par nature, donnez-lui un fond coloré
+        plutôt que transparent, ou un contour clair.
+      </li>
+      <li>
+        <strong>L'icône Apple touch doit être opaque.</strong> iOS la dessine sur
+        sa propre tuile arrondie et rend la transparence en noir. Tout outil qui
+        produit ce fichier devrait l'aplatir pour vous&nbsp;; celui d'ici le
+        fait, sur du blanc par défaut.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Les fichiers dont un site a besoin en plus du .ico</h2>
+    <p>
+      <code>favicon.ico</code> couvre les navigateurs et Windows. Il ne couvre
+      pas les téléphones, et c'est là que la plupart des jeux d'icônes faits
+      maison s'arrêtent trop tôt. Trois autres plateformes réclament leurs
+      propres fichiers, sous leurs propres noms, et aucune n'ira regarder dans un
+      <code>.ico</code>&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>iOS</strong> lit <code>apple-touch-icon.png</code> en
+        180&times;180 quand quelqu'un ajoute votre site à son écran d'accueil.
+        Sans lui, iOS utilise une capture de la page, ce qui a l'air d'une
+        erreur.
+      </li>
+      <li>
+        <strong>Android et toutes les invites d'installation</strong> lisent un
+        manifeste d'application web &mdash; <code>site.webmanifest</code> &mdash;
+        qui pointe vers des PNG de 192 et 512 pixels. Le 512 est aussi ce qu'une
+        application web montre sur son écran de démarrage.
+      </li>
+      <li>
+        <strong>Une tuile du menu Démarrer de Windows</strong> lit
+        <code>browserconfig.xml</code>, qui pointe vers un PNG de 150&times;150.
+        Le moins important des trois, et quatre lignes de XML.
+      </li>
+    </ul>
+    <p>
+      Il y en a une dernière facile à rater&nbsp;: les lanceurs Android rognent
+      une icône adaptative à la forme que le téléphone préfère &mdash; cercle,
+      carré arrondi, &laquo;&nbsp;squircle&nbsp;&raquo; &mdash; et seuls les
+      80&nbsp;% centraux de l'image sont garantis de survivre. Une icône dessinée
+      bord à bord perd ses coins. C'est cela, une icône
+      <em>masquable</em>&nbsp;: la même image dessinée délibérément petite à
+      l'intérieur du carré, déclarée séparément dans le manifeste.
+    </p>
+    <p>
+      Cocher le jeu pour site web dans
+      <a href="../../creer-un-favicon/">Image en ICO</a> produit tous ces
+      fichiers, le manifeste, et le bloc de HTML qui pointe vers eux. Une chose
+      que ce bloc omet délibérément, c'est un <code>&lt;link&gt;</code> vers
+      <code>favicon.ico</code>&nbsp;: les navigateurs demandent cette adresse
+      d'eux-mêmes, et la nommer en plus fait récupérer le même fichier deux fois.
+    </p>
+  </section>
+
+  <section>
+    <h2>Une icône d'application Windows est un autre jeu</h2>
+    <p>
+      Si l'icône est pour un programme et non pour un site, les tailles changent.
+      Ce que contient l'<code>app.ico</code> livrée par défaut avec Visual Studio,
+      ce sont 16, 32, 48 et 256 &mdash; les trois tailles du shell plus la grande
+      dont se servent le menu Démarrer et la vue très grande de l'Explorateur.
+    </p>
+    <p>
+      Sur un écran haute densité, Windows réclame aussi 20, 24, 40, 64 et 96, et
+      les rééchantillonne depuis la taille la plus proche dont il dispose quand
+      elles manquent. Que cela compte ou non dépend de votre icône&nbsp;: une
+      forme plate survit au rééchantillonnage, une forme détaillée non. Les
+      ajouter double à peu près le fichier, ce qui pour une application ne
+      représente rien du tout &mdash; le calcul est complètement différent de
+      celui d'un favicon, que chaque visiteur récupère.
+    </p>
+    <p>
+      Encore une chose au sujet de la taille&nbsp;: c'est l'entrée 256 qui pèse.
+      Stockée sans compression, elle fait 264&nbsp;KB à elle seule&nbsp;; stockée
+      en PNG dans l'icône, elle est en général sous les 30. Les entrées PNG sont
+      lisibles depuis Windows Vista&nbsp;: la seule raison de les éviter est donc
+      un logiciel réellement plus ancien que cela, ou un installeur ou un outil
+      embarqué qui analyse les icônes lui-même.
+    </p>
+  </section>
+
+  <section>
+    <h2>Un Mac lit un tout autre fichier</h2>
+    <p>
+      Si l'icône est pour une application Mac et non Windows, rien de ce qui
+      précède ne s'applique&nbsp;: macOS ne lit pas du tout le <code>.ico</code>.
+      Il lit le <code>.icns</code>, qui est la même idée dans un autre emballage
+      &mdash; plusieurs tailles dans un conteneur &mdash; avec trois différences
+      à connaître.
+    </p>
+    <ul>
+      <li>
+        <strong>Les tailles sont imposées.</strong> Apple publie dix emplacements
+        et il n'y a rien à choisir&nbsp;: 16, 32, 64, 128, 256, 512 et 1024
+        pixels, les 32, 256 et 512 apparaissant deux fois parce que chacune est à
+        la fois une taille à part entière et la version Retina de la taille
+        inférieure.
+      </li>
+      <li>
+        <strong>Cela monte jusqu'à 1024.</strong> Un <code>.ico</code> s'arrête à
+        256, et c'est pourquoi un fichier d'icône Mac fait plusieurs centaines de
+        kilooctets quand un favicon en fait quinze. Pour une application livrée
+        une fois, ce n'est rien&nbsp;; il n'y a qu'un favicon à être récupéré par
+        chaque visiteur.
+      </li>
+      <li>
+        <strong>1024 pixels, c'est ce à quoi votre dessin doit survivre.</strong>
+        Les deux problèmes sont les deux extrémités de la même image&nbsp;: un
+        favicon doit fonctionner tout petit, et une icône Mac doit tenir debout
+        en très grand. Un logo exporté en 512 et gonflé à 1024 a l'air mou sur un
+        écran Retina, et l'App Store ne le prendra pas.
+      </li>
+    </ul>
+    <p>
+      Pour s'en servir&nbsp;: un bundle d'application le garde dans
+      <code>VotreApp.app/Contents/Resources/</code> et le nomme dans
+      <code>Info.plist</code>. Pour un dossier ou une image disque, sélectionnez
+      le <code>.icns</code> dans le Finder, faites Commande-C, puis Lire les
+      informations sur la chose à changer, cliquez la petite icône en haut à
+      gauche et faites Commande-V.
+    </p>
+    <p>
+      Cocher <em>icône macOS</em> dans
+      <a href="../../creer-un-favicon/">Image en ICO</a> en écrit un, avec ou
+      sans le fichier Windows à côté. Tout ce qui sort sur les deux plateformes
+      veut les deux, et les deux sont tirés de la même image en une seule passe.
+    </p>
+  </section>
+
+  <section>
+    <h2>Vérifier que cela a marché</h2>
+    <p>
+      Les navigateurs mettent les favicons en cache plus durement que presque
+      tout le reste&nbsp;: &laquo;&nbsp;je l'ai mis en ligne et rien n'a
+      changé&nbsp;&raquo; est donc en général un cache plutôt qu'une erreur. Deux
+      choses à essayer avant de vous remettre à modifier des fichiers&nbsp;:
+    </p>
+    <ul>
+      <li>
+        Ouvrez directement <code>https://votresite.com/favicon.ico</code>. Si le
+        fichier se télécharge, il est là et vous regardez un cache. Si vous
+        obtenez une 404, il n'est pas à la racine.
+      </li>
+      <li>
+        Chargez le site dans une fenêtre privée, qui a en général son propre
+        cache d'icônes.
+      </li>
+    </ul>
+    <p>
+      Sous Windows, un <code>.ico</code> se vérifie en le mettant dans un dossier
+      et en faisant défiler les tailles d'affichage de l'Explorateur&nbsp;:
+      petites, moyennes, grandes et très grandes icônes tirent des entrées
+      différentes du même fichier, et vous voyez donc chacune telle que le
+      système la verra.
+    </p>
+    <p>
+      Sur un Mac, un <code>.icns</code> s'ouvre dans Aperçu, qui liste chaque
+      emplacement sur le côté &mdash; et la même astuce marche dans le
+      Finder&nbsp;: déposez-le dans un dossier et faites glisser le curseur de
+      taille des options d'affichage pour le voir basculer d'une image à l'autre.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rien de tout cela ne demande un envoi</h2>
+    <p>
+      Mettre une image à l'échelle est une chose que tous les navigateurs font
+      depuis des années, et un <code>.ico</code>, c'est un en-tête de six octets,
+      seize octets par image, puis les images. Il n'y a dans sa fabrication
+      aucune étape qui exige un serveur, et l'outil d'ici n'en utilise
+      pas&nbsp;: la <code>Content-Security-Policy</code> de la page nomme toutes
+      les adresses qu'elle peut contacter, et aucune n'appartient à ce site.
+    </p>
+    <p>
+      Cela mérite plus d'attention ici qu'ailleurs. Un logo confié à un
+      générateur de favicons gratuit est, assez souvent, une marque non encore
+      dévoilée &mdash; l'icône est l'une des premières choses fabriquées et l'une
+      des dernières annoncées. Chargez la page, coupez votre connexion, et
+      fabriquez-en une quand même, si vous préférez vérifier plutôt qu'on vous le
+      dise. <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer
+      ses fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
+      vérifications applicables à n'importe quel outil.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/make-a-favicon.toml
+++ b/locales/fr/pages/guides/make-a-favicon.toml
@@ -1,0 +1,18 @@
+#
+# Guide : creer un favicon (et une icone d'application Windows) - French.
+#
+
+nav = "Créer un favicon"
+title = "Comment créer un favicon (et une icône d'application Windows)"
+description = "Quelles tailles un favicon.ico réclame vraiment, quels fichiers supplémentaires demandent les iPhone, Android et un Mac, et pourquoi un logo qui marche sur une affiche disparaît à seize pixels."
+heading = "Comment créer un favicon qui se lise encore à seize pixels"
+lede = """
+    Un favicon n'est pas une petite image de votre logo. C'est un jeu d'images à
+    des tailles fixes, dans un conteneur que presque personne n'ouvre, et la plus
+    petite d'entre elles est celle que tout le monde voit réellement. Voici les
+    tailles qu'il vous faut, les fichiers qui les accompagnent, et quoi faire
+    quand votre logo ne survit pas au voyage."""
+updated = "20 août 2026"
+og_title = "Créer un favicon qui se lise encore à seize pixels"
+og_description = "Quelles tailles un favicon.ico réclame, les fichiers supplémentaires que demandent les iPhone et Android, et quoi faire quand votre logo ne survit pas à la réduction."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/make-a-pdf-smaller.html
+++ b/locales/fr/pages/guides/make-a-pdf-smaller.html
@@ -1,0 +1,241 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../compresser-un-pdf/">compresseur de PDF</a>,
+      déposez-y le document, et regardez ce qu'il vous dit avant de changer quoi
+      que ce soit. Il lit le fichier et montre où se trouve vraiment le poids
+      &mdash; images, polices, texte et dessin, et tout ce à quoi plus rien dans
+      le document ne renvoie. Cet écran répond en général à la question.
+    </p>
+    <p>
+      Si l'essentiel du poids est fait d'images, vous pouvez espérer une grosse
+      économie. Si c'est des polices et du texte, non, et aucun outil ne le peut.
+      Lequel des deux vous avez est toute l'histoire, et cela vaut dix secondes
+      de regard.
+    </p>
+  </section>
+
+  <section>
+    <h2>Où se trouve vraiment le poids d'un PDF</h2>
+    <p>
+      Un PDF est un conteneur pour plusieurs sortes de choses, et elles ne se
+      compressent pas pareil.
+    </p>
+    <ul>
+      <li>
+        <strong>Les images.</strong> Photographies et scans. Presque toujours
+        l'essentiel d'un gros PDF, et la seule partie où il y ait vraiment de la
+        marge.
+      </li>
+      <li>
+        <strong>Les polices incorporées.</strong> Une police complète peut faire
+        des centaines de kilooctets&nbsp;; un sous-ensemble des caractères
+        réellement utilisés, bien moins. Dans les deux cas, elles ont été
+        compressées par ce qui a produit le fichier.
+      </li>
+      <li>
+        <strong>Le texte et le dessin vectoriel.</strong> Des instructions
+        plutôt que des pixels&nbsp;: trace cette ligne, pose ce mot ici. Déjà
+        compact, et déjà compressé.
+      </li>
+      <li>
+        <strong>Les objets vers lesquels plus rien ne pointe.</strong> Les PDF en
+        accumulent. Modifier un document ajoute souvent le changement à la suite
+        plutôt que de réécrire le fichier&nbsp;: une ancienne version d'une page
+        peut donc y rester indéfiniment. Réempaqueter le fichier les jette.
+      </li>
+    </ul>
+    <p>
+      Les deux documents que les gens apportent à un compresseur de PDF ont donc
+      des perspectives complètement différentes. Un document numérisé est pour
+      l'essentiel une pile de photographies, et ressort couramment 60 à 90&nbsp;%
+      plus léger. Un contrat, une thèse ou un rapport exporté, c'est du texte, du
+      dessin et des polices &mdash; tous déjà compressés par le logiciel qui les
+      a écrits &mdash; et l'économie y est en général de quelques pour cent,
+      obtenue en réempaquetant et en jetant ce qui n'est plus référencé.
+    </p>
+    <p>
+      Tout outil qui promet &laquo;&nbsp;jusqu'à 90&nbsp;% plus
+      léger&nbsp;&raquo; sans regarder votre fichier cite le meilleur cas du
+      premier type à propos du second.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que le DPI vient faire là-dedans</h2>
+    <p>
+      Un PDF ne contient pas seulement une image&nbsp;; il enregistre la taille à
+      laquelle cette image est dessinée sur la page. Cela vous donne quelque
+      chose de plus utile que le nombre de pixels&nbsp;: la résolution effective.
+    </p>
+    <p>
+      Un scan de 4000 pixels de large étalé sur vingt centimètres de papier
+      transporte 500 pixels par pouce. Un écran en montre environ 100. Une bonne
+      imprimante de bureau travaille à 300 et ne sait guère faire plus. Tout ce
+      qui dépasse est du détail que rien dans l'avenir du document n'affichera
+      jamais &mdash; et c'est en général l'essentiel du fichier.
+    </p>
+    <p>
+      C'est pourquoi un compresseur de PDF sensé demande un DPI plutôt qu'un
+      pourcentage de qualité. Il jette d'abord les pixels au-dessus de votre
+      chiffre, parce qu'ils ne coûtent rien que quiconque puisse voir, et ce
+      n'est qu'ensuite qu'il commence à dépenser de la vraie qualité.
+    </p>
+    <p>
+      Repère approximatif&nbsp;: <strong>150 DPI</strong> pour un document qui
+      sera lu à l'écran, <strong>200 à 300</strong> pour ce qui sera imprimé,
+      <strong>72 à 100</strong> pour un brouillon que personne ne gardera. Mesurer
+      par rapport à la taille à laquelle l'image est dessinée est aussi ce qui
+      fait qu'un logo posé en petit n'est pas traité comme un scan pleine page
+      &mdash; le logo est déjà proche de sa résolution effective et il n'y a rien
+      à y prendre.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que compresser doit et ne doit pas toucher</h2>
+    <p>
+      Les images sont réencodées&nbsp;: elles perdent donc un peu. Rien d'autre
+      ne devrait être touché, et il vaut la peine de vérifier que l'outil que
+      vous utilisez s'y tient&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Le texte reste du texte.</strong> Sélectionnable, cherchable,
+        copiable. Un compresseur qui aplatit les pages en images produira un
+        fichier très léger et détruira le document &mdash; vous ne pouvez plus le
+        chercher, les lecteurs d'écran ne peuvent plus le lire, et cela ne se
+        défait jamais.
+      </li>
+      <li>
+        <strong>Les polices restent entières.</strong> Remplacer des polices
+        change l'aspect du document sur la machine de quelqu'un d'autre, ce qui
+        est la seule chose que le PDF existe pour empêcher.
+      </li>
+      <li>
+        <strong>Le dessin vectoriel est recopié à l'identique.</strong> Il est
+        déjà léger, et le rastériser le rendrait à la fois plus lourd et moins
+        bon.
+      </li>
+      <li>
+        <strong>Les formulaires, les liens, les signets, la structure
+        d'accessibilité et les pièces jointes sont repris.</strong> Ce sont des
+        choses faciles à perdre dans une réécriture et qu'on remarque rarement
+        avant que quelqu'un en ait besoin.
+      </li>
+    </ul>
+    <p>
+      Une règle voisine qu'un compresseur devrait suivre et que beaucoup ne
+      suivent pas&nbsp;: si le réencodage d'une image ne ressort pas réellement
+      plus petit que l'original, il faut remettre les octets d'origine. Abîmer une
+      image sans rien économiser est le cas de perte pure, et cela arrive plus
+      souvent qu'on ne le croirait sur des images déjà bien compressées.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les images qui ne peuvent pas être compressées</h2>
+    <p>
+      Certaines images à l'intérieur d'un PDF sont passées, et un bon outil les
+      nomme plutôt que de les laisser discrètement hors du calcul&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Les images JPEG&nbsp;2000, JBIG2 et codées fax (CCITT).</strong>
+        Aucun navigateur ne livre de décodeur pour l'une d'elles&nbsp;: elles
+        sont donc transmises intactes. Les deux dernières sont bitonales &mdash;
+        noir et blanc seulement &mdash; et sont en général déjà proches de leur
+        plus petite taille.
+      </li>
+      <li>
+        <strong>Les images CMJN.</strong> Laissées tranquilles délibérément. Les
+        réencoder risquerait de déplacer les couleurs qu'une imprimerie
+        produirait, ce qui est une drôle d'initiative à prendre sur un document
+        que quelqu'un va imprimer.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Choses à essayer avant de compresser</h2>
+    <p>
+      Parfois, le fichier est gros pour une raison à laquelle la compression est
+      la mauvaise réponse.
+    </p>
+    <p>
+      <strong>A-t-il été scanné alors que ce n'était pas nécessaire&nbsp;?</strong>
+      Un document imprimé puis scanné est une pile de photographies de texte. Si
+      l'original existe encore quelque part comme document, l'exporter en PDF
+      produira un fichier d'une fraction du poids, et cherchable en prime.
+    </p>
+    <p>
+      <strong>A-t-il été exporté aux réglages d'impression&nbsp;?</strong> Les
+      traitements de texte et les logiciels de mise en page proposent souvent par
+      défaut un export en qualité d'impression. Réexporter pour l'écran depuis le
+      fichier source bat en général la compression de l'export.
+    </p>
+    <p>
+      <strong>Faut-il vraiment que ce soit un seul fichier&nbsp;?</strong> Une
+      limite de courriel est par message. Découper un document de 200 pages en
+      chapitres est parfois le remède honnête.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les fichiers chiffrés, et pourquoi un compresseur devrait les refuser</h2>
+    <p>
+      Un PDF protégé par mot de passe est refusé par l'outil d'ici, et c'est
+      délibéré et non une fonction manquante &mdash; y compris quand le mot de
+      passe est vide, ce qui est la façon dont enregistrent beaucoup de scanners
+      et de photocopieurs.
+    </p>
+    <p>
+      Retirer la protection d'un document est un autre métier que le compresser.
+      Un outil qui le ferait en silence ferait quelque chose que vous n'avez pas
+      demandé, à un fichier que quelqu'un avait délibérément verrouillé, et vous
+      rendrait une copie qui n'aurait plus la propriété qu'on avait voulu lui
+      donner. Retirez la protection vous-même d'abord, délibérément, si c'est ce
+      que vous voulez.
+    </p>
+  </section>
+
+  <section>
+    <h2>Vérifier le résultat</h2>
+    <p>
+      Ouvrez-le. Regardez les images en zoom maximal, vérifiez que le texte est
+      toujours sélectionnable, et confirmez le nombre de pages.
+    </p>
+    <p>
+      L'outil d'ici fait le dernier point pour vous avant de proposer le
+      fichier&nbsp;: il rouvre le document qu'il vient d'écrire et compte les
+      pages, sur votre propre machine. Il écrit en outre du PDF 1.5, que comprend
+      tout lecteur sorti depuis 2003&nbsp;: &laquo;&nbsp;il s'ouvre sur ma
+      machine&nbsp;&raquo; est donc un indice raisonnable de
+      &laquo;&nbsp;il s'ouvre sur la leur&nbsp;&raquo;.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi cela ne demande pas de serveur</h2>
+    <p>
+      Compresser un PDF a l'air d'un travail de serveur, et pendant l'essentiel
+      de la vie du web ç'en a été un. Ce que cela implique réellement, c'est
+      analyser la structure du fichier, trouver les flux d'images, les décoder et
+      les réencoder avec les codecs qu'un navigateur embarque déjà, et réécrire
+      le document. Tout cela tourne dans un navigateur aujourd'hui.
+    </p>
+    <p>
+      Ce qui compte plus pour ce type de fichier que pour la plupart, à cause de
+      ce que les gens compressent&nbsp;: contrats, courriers médicaux, relevés
+      bancaires, pièces d'identité, déclarations d'impôts. L'outil d'ici n'a
+      aucune fonction réseau, et la <code>Content-Security-Policy</code> de la
+      page nomme toutes les adresses qu'elle peut contacter, dont aucune
+      n'appartient à ce site. Chargez-le, débranchez, et compressez quelque chose
+      quand même.
+    </p>
+    <p>
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
+      vérifications du même genre.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/fr/pages/guides/make-a-pdf-smaller.toml
@@ -1,0 +1,17 @@
+#
+# Guide : reduire la taille d'un PDF - French.
+#
+
+nav = "Alléger un PDF"
+title = "Comment alléger un PDF (et pourquoi certains ne maigrissent pas)"
+description = "Où se trouve vraiment le poids d'un PDF, pourquoi un scan perd 80 % et un contrat bouge à peine, ce que veut dire le DPI ici, et ce qu'un compresseur ne devrait jamais faire à votre document."
+heading = "Comment alléger un PDF, et pourquoi certains ne maigrissent pas"
+lede = """
+    Un PDF qui ne passe pas la limite d'un courriel est presque toujours un PDF
+    plein d'images. Voici comment savoir si c'est le cas du vôtre, ce que le
+    compresser coûte, et pourquoi tout outil qui promet un pourcentage fixe n'a
+    pas regardé votre fichier."""
+updated = "20 août 2026"
+og_title = "Comment alléger un PDF"
+og_description = "Où se trouve vraiment le poids d'un PDF, pourquoi un scan maigrit et un contrat non, et ce que le DPI vient faire là-dedans."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/make-a-qr-code.html
+++ b/locales/fr/pages/guides/make-a-qr-code.html
@@ -1,0 +1,276 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../generateur-de-qr-code/">générateur de QR codes et
+      de codes-barres</a>, collez votre lien, laissez le niveau sur
+      <strong>M</strong> et la marge sur <strong>4</strong>, et téléchargez le
+      SVG. Imprimez-le sur au moins deux centimètres de large, sur un support
+      mat, sombre sur clair. Scannez ensuite l'exemplaire imprimé avec un
+      téléphone qui n'est pas le vôtre avant d'en commander mille.
+    </p>
+    <p>
+      Cela couvre à peu près tous les cas. Le reste de cette page est pour les
+      autres&nbsp;: un code qui doit survivre à la manipulation, un code avec un
+      logo dessus, un code destiné à un petit support, et la seule décision
+      facile à rater d'une façon dont vous ne vous apercevrez qu'un an plus tard.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qu'il y a réellement dans un QR code</h2>
+    <p>
+      Une chaîne de caractères. C'est tout. Scanner un QR code remet au téléphone
+      un morceau de texte, et tout le reste &mdash; ouvrir une page, rejoindre un
+      réseau, proposer d'enregistrer un contact &mdash; c'est le téléphone qui
+      reconnaît la forme de ce texte et propose d'agir dessus.
+    </p>
+    <p>
+      Il n'existe donc pas de &laquo;&nbsp;QR code Wi-Fi&nbsp;&raquo; comme genre
+      de code. Il existe un QR code contenant
+      <code>WIFI:T:WPA;S:Mon Réseau;P:le mot de passe;;</code>, que tous les
+      téléphones fabriqués depuis dix ans savent lire. Le générateur vous montre
+      la chaîne finie pour exactement cette raison&nbsp;: quand un code ne fait
+      pas ce que vous attendiez, la chaîne est la seule chose qui vaille d'être
+      regardée.
+    </p>
+    <p>
+      Cela veut dire aussi qu'un QR code ne peut pas être changé une fois
+      imprimé, ne peut pas téléphoner à la maison, et ne peut pas expirer &mdash;
+      sauf si quelqu'un y a mis un lien vers son propre serveur, ce qui est le
+      sujet de la dernière section d'ici.
+    </p>
+  </section>
+
+  <section>
+    <h2>Décision un&nbsp;: le niveau de correction d'erreurs</h2>
+    <p>
+      Un QR code transporte un jeu de mots de contrôle à côté des données,
+      calculés pour qu'un lecteur puisse reconstruire ce qu'il n'a pas pu voir.
+      C'est pourquoi un code auquel il manque un coin se scanne encore. Le nombre
+      de ces mots de contrôle, c'est le niveau, et il y en a quatre&nbsp;:
+    </p>
+    <ul>
+      <li><strong>L</strong> &mdash; environ 7&nbsp;% du code peut être perdu.</li>
+      <li><strong>M</strong> &mdash; environ 15&nbsp;%.</li>
+      <li><strong>Q</strong> &mdash; environ 25&nbsp;%.</li>
+      <li><strong>H</strong> &mdash; environ 30&nbsp;%.</li>
+    </ul>
+    <p>
+      Plus de correction n'est pas gratuit&nbsp;: les données de contrôle vont
+      dans le même carré, si bien que le même texte au niveau H demande un code
+      plus grand et plus dense qu'au niveau L. En gros, passer de L à H double le
+      nombre de modules pour la même chaîne, et des modules plus denses sont plus
+      difficiles à résoudre pour un appareil photo. Il y a là un vrai marché, et
+      la réponse dépend de la destination du code.
+    </p>
+    <p>
+      <strong>L</strong> est pour un écran&nbsp;: un code dans une diapositive,
+      un courriel, une page web. Rien ne va l'abîmer et chaque module
+      supplémentaire le rend plus difficile à lire de loin.
+    </p>
+    <p>
+      <strong>M</strong> est le défaut et la bonne réponse pour la plupart des
+      impressions. Du papier qui sera un peu manipulé, un prospectus, une carte
+      de visite.
+    </p>
+    <p>
+      <strong>Q et H</strong> sont pour les codes qui vont être malmenés&nbsp;:
+      un menu essuyé tous les jours, un autocollant sur une machine d'atelier,
+      une étiquette sur une caisse, un code en vitrine qui prend le soleil
+      direct. Le H est aussi ce qui rend possible un logo au milieu &mdash; voir
+      plus bas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Décision deux&nbsp;: la marge, qui fait partie du code</h2>
+    <p>
+      L'espace blanc autour d'un QR code n'est pas du remplissage, et ce n'est pas
+      un choix graphique. Un lecteur s'en sert pour trouver où le symbole
+      s'arrête. La spécification demande quatre modules de silence de chaque côté,
+      et un code rogné au ras du bord est de loin la première raison pour laquelle
+      un code imprimé échoue.
+    </p>
+    <p>
+      Cela mérite d'être dit sans détour parce que le rognage est une chose si
+      naturelle à faire. Le code a l'air d'avoir trop de blanc autour&nbsp;: il se
+      fait donc recadrer dans la maquette, ou poser sur un aplat de couleur qui
+      vient jusqu'aux carrés, ou posé sur une photographie. Chacune de ces
+      opérations retire la frontière dont le lecteur allait se servir.
+    </p>
+    <p>
+      Si le code paraît trop grand avec sa marge, faites le code plus petit. Ne
+      retirez pas la marge.
+    </p>
+  </section>
+
+  <section>
+    <h2>Décision trois&nbsp;: à quelle taille l'imprimer</h2>
+    <p>
+      La règle empirique qui a survécu au contact du réel est
+      <strong>un pour dix</strong>&nbsp;: un code doit faire environ un dixième
+      de la distance depuis laquelle il sera scanné.
+    </p>
+    <ul>
+      <li>Une carte de visite ou un menu, lus à 30 cm&nbsp;: environ 2 cm de côté.</li>
+      <li>Une affiche lue à deux mètres&nbsp;: environ 20 cm.</li>
+      <li>Un abribus ou une vitrine lus à cinq mètres&nbsp;: environ 50 cm.</li>
+    </ul>
+    <p>
+      Deux centimètres est un plancher plutôt qu'une cible. En dessous d'environ
+      1,5 cm, un téléphone ordinaire commence à peiner quelle que soit la qualité
+      de l'impression, parce que les modules individuels approchent la taille d'un
+      pixel de son capteur.
+    </p>
+    <p>
+      Moins de texte veut dire moins de modules, ce qui veut dire un code qui se
+      lit de loin pour une taille imprimée donnée &mdash; bonne raison de pointer
+      un code vers <code>exemple.com/x</code> plutôt que vers une URL avec cent
+      caractères de paramètres de suivi à la fin.
+    </p>
+    <p>
+      Et imprimez depuis le <strong>SVG</strong>. Un QR code est fait de bords, et
+      un PNG a un nombre fixe de pixels pour les faire&nbsp;; agrandissez-en un et
+      chaque bord s'adoucit, ce qui est précisément ce qui gêne un scanner. Un SVG,
+      ce sont les carrés sous forme d'instructions&nbsp;: il ressort net sur une
+      carte de visite comme sur un panneau publicitaire.
+    </p>
+  </section>
+
+  <section>
+    <h2>Couleur, contraste, et les deux erreurs</h2>
+    <p>
+      Un lecteur mesure la différence entre les modules sombres et les
+      clairs&nbsp;: le contraste, c'est tout. Deux choses tournent mal
+      régulièrement&nbsp;:
+    </p>
+    <p>
+      <strong>Un code clair sur fond sombre.</strong> C'est spectaculaire, et bon
+      nombre de lecteurs le refusent d'emblée&nbsp;: ils cherchent du sombre sur
+      clair et n'essaient pas l'inversion. Certains le font. Vous ne saurez pas
+      lesquels vos clients ont.
+    </p>
+    <p>
+      <strong>Pas assez d'écart.</strong> Un gris moyen sur blanc, ou deux
+      couleurs de marque de poids voisin, peuvent très bien se mesurer à l'écran
+      et échouer sur le papier une fois l'étalement de l'encre et l'exposition
+      automatique d'un téléphone entrés en jeu. Si vous colorez un code, gardez
+      la partie sombre réellement sombre.
+    </p>
+    <p>
+      Le mat bat le brillant pour tout ce qui sera scanné sous une lampe, et les
+      deux battent l'impression sur une photographie. Les fonds transparents sont
+      utiles pour poser un code sur un aplat de couleur &mdash; mais vérifiez ce
+      qui finit derrière, parce qu'un code transparent sur un aplat sombre est la
+      première erreur ci-dessus avec des étapes en plus.
+    </p>
+  </section>
+
+  <section>
+    <h2>Un logo au milieu</h2>
+    <p>
+      Cela fonctionne, et cela fonctionne grâce à la correction d'erreurs plutôt
+      que malgré elle. Au niveau H, environ 30&nbsp;% des modules peuvent être
+      détruits sans que le code cesse d'être lisible&nbsp;: un logo qui en couvre
+      nettement moins &mdash; au centre, là où ne se trouve aucun motif de
+      repérage &mdash; est un dégât que le lecteur répare.
+    </p>
+    <p>
+      Trois règles à tenir. Utilisez le niveau H. Gardez le logo sous environ un
+      cinquième de la surface, bien en deçà de la limite théorique, parce que
+      l'impression n'est pas la seule chose à grignoter votre marge. Et ne
+      couvrez jamais les trois grands carrés des coins ni les plus petits qui les
+      accompagnent&nbsp;: c'est ainsi qu'un lecteur trouve et oriente le symbole
+      en premier lieu, et aucune correction d'erreurs ne les reconstruit.
+    </p>
+    <p>
+      Testez-le ensuite sur de vrais téléphones. Un logo fait passer un code de
+      &laquo;&nbsp;marche toujours&nbsp;&raquo; à
+      &laquo;&nbsp;marche avec cette marge-là&nbsp;&raquo;, et le seul moyen de
+      savoir combien de marge il reste est d'essayer.
+    </p>
+  </section>
+
+  <section>
+    <h2>La décision qu'on regrette&nbsp;: statique ou &laquo;&nbsp;dynamique&nbsp;&raquo;</h2>
+    <p>
+      Cherchez un générateur de QR code et la plupart des résultats voudront que
+      vous créiez un compte, parce qu'ils vendent des codes <em>dynamiques</em>.
+      Un code dynamique ne contient pas votre lien. Il contient un lien court vers
+      le serveur du générateur, qui redirige vers le vôtre.
+    </p>
+    <p>
+      Ce que cela vous rapporte est réel&nbsp;: vous pouvez changer la
+      destination du code après l'impression, et vous obtenez un décompte de
+      chaque scan. Pour une campagne à six chiffres d'exemplaires, cela vaut
+      qu'on paie.
+    </p>
+    <p>
+      Ce que cela coûte est réel aussi, et vaut d'être su avant plutôt
+      qu'après&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Le code cesse de fonctionner quand ils cessent de
+        fonctionner.</strong> Si le service ferme, si le domaine expire, ou si
+        l'offre gratuite se termine, chaque code que vous avez imprimé meurt
+        &mdash; et à ce moment-là ils sont sur dix mille menus.
+      </li>
+      <li>
+        <strong>Chaque scan est la donnée de quelqu'un d'autre.</strong> La
+        redirection voit l'adresse IP, l'heure et l'appareil de chaque personne
+        qui scanne votre code.
+      </li>
+      <li>
+        <strong>Le lien est le leur, pas le vôtre.</strong> Quiconque le scanne
+        voit passer un domaine inconnu, ce dont on dit précisément aux gens de se
+        méfier.
+      </li>
+    </ul>
+    <p>
+      La voie du milieu ne coûte rien&nbsp;: faites un QR code statique autour
+      d'une URL courte <em>sur votre propre domaine</em>, et redirigez-la
+      vous-même. Vous gardez la possibilité de changer la destination, vous
+      gardez les statistiques, et rien du code ne dépend de la survie, l'an
+      prochain, d'une entreprise que vous n'avez jamais rencontrée.
+    </p>
+    <p>
+      Le <a href="../../generateur-de-qr-code/">générateur d'ici</a> ne fait que
+      des codes statiques, et il n'y a aucun compte à créer. Ce que vous tapez est
+      ce que le code contient.
+    </p>
+  </section>
+
+  <section>
+    <h2>Avant d'en imprimer mille</h2>
+    <p>
+      Scannez le code. Pas celui de votre écran &mdash; l'épreuve imprimée, à
+      l'endroit où elle va, avec un téléphone qui n'est pas celui sur lequel vous
+      l'avez fabriqué. Cela prend une minute et attrape toute la catégorie de
+      problèmes dont parle cette page&nbsp;: une marge mangée par la maquette, un
+      lien à qui il manque son <code>https://</code>, une couleur qui s'est
+      mesurée autrement sur le papier, un code imprimé à une taille qui marche sur
+      un bureau et pas sur un mur.
+    </p>
+    <p>
+      Et vérifiez ce qui se passe après le scan. Un code qui ouvre une page
+      illisible sur un téléphone est un code qui a échoué, même s'il s'est scanné.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rien de tout cela n'exige d'envoyer quoi que ce soit</h2>
+    <p>
+      Un QR code est de l'arithmétique sur une chaîne de caractères. Il n'y a
+      aucun fichier à envoyer et rien qu'un serveur puisse faire qu'un navigateur
+      ne puisse pas, et c'est pourquoi
+      <a href="../../generateur-de-qr-code/">l'outil d'ici</a> fait tout sur votre
+      propre machine et fonctionne réseau débranché.
+    </p>
+    <p>
+      Cela compte plus que cela n'en a l'air, à cause de ce que les gens mettent
+      dans les QR codes. L'usage le plus courant du format Wi-Fi, c'est le mot de
+      passe réel d'un réseau, tapé dans une page web. Il vaut la peine de savoir
+      si cette page avait quelque part où l'envoyer.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/make-a-qr-code.toml
+++ b/locales/fr/pages/guides/make-a-qr-code.toml
@@ -1,0 +1,17 @@
+#
+# Guide : creer un QR code qui se scanne vraiment - French.
+#
+
+nav = "Créer un QR code"
+title = "Comment créer un QR code qui se scanne à tous les coups"
+description = "Quel niveau de correction d'erreurs choisir, pourquoi la marge blanche autour d'un QR code fait partie du code, à quelle taille l'imprimer, et ce que le code « dynamique » d'un générateur gratuit vous coûtera plus tard."
+heading = "Comment créer un QR code qui se scanne encore sur le téléphone d'un autre"
+lede = """
+    Créer un QR code prend une seconde. En créer un qui fonctionne sur un menu
+    mouillé, un abribus, ou un téléphone tenu à bout de bras dans une mauvaise
+    lumière demande quatre décisions, et toutes les quatre se prennent avant que
+    vous imprimiez quoi que ce soit. Voici ce que chacune fait."""
+updated = "20 août 2026"
+og_title = "Créer un QR code qui se scanne encore sur le téléphone d'un autre"
+og_description = "Les quatre décisions qui font qu'un QR code imprimé fonctionne : le niveau, la marge, la taille, et l'adresse de qui se trouve réellement dedans."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/fr/pages/guides/remove-exif-and-gps-data.html
@@ -1,0 +1,233 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur
+      EXIF</a>, déposez-y les photos, et appuyez sur
+      &laquo;&nbsp;Tout supprimer&nbsp;&raquo;. Chaque étiquette, les blocs XMP
+      et IPTC, les commentaires et la vignette incorporée partent, sur toutes les
+      photos de la liste d'un coup. L'image elle-même n'est pas touchée &mdash;
+      ni recompressée, ni décodée, ni changée d'un seul pixel.
+    </p>
+    <p>
+      Avant de le faire, cela vaut la peine de regarder ce qu'il y avait dedans.
+      C'est en général plus que ce que les gens imaginent, et cette liste est
+      l'argument même en faveur de l'opération.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qu'il y a réellement dans une photo</h2>
+    <p>
+      Un JPEG n'est pas seulement une image compressée. C'est un conteneur, et à
+      côté de l'image se trouvent plusieurs blocs d'informations que votre
+      appareil, votre téléphone ou votre logiciel de retouche y ont écrits.
+    </p>
+    <ul>
+      <li>
+        <strong>L'EXIF.</strong> Le principal. Marque et modèle de l'appareil,
+        objectif, réglages d'exposition, ISO, date et heure à la seconde,
+        orientation dans laquelle l'image doit être montrée, et &mdash; sur un
+        téléphone dont la localisation est active pour l'appareil photo &mdash;
+        une position GPS précise à quelques mètres. Souvent aussi un numéro de
+        série de boîtier.
+      </li>
+      <li>
+        <strong>Le GPS.</strong> Techniquement une partie de l'EXIF, et qui vaut
+        d'être nommée à part parce que c'est celle qui compte le plus. Elle est
+        écrite en degrés, minutes et secondes, format qui réussit très bien à ne
+        pas ressembler à une adresse.
+      </li>
+      <li>
+        <strong>Le XMP.</strong> Un paquet de XML qu'écrivent les logiciels de
+        retouche. Il peut porter votre nom, votre logiciel, des notes, des
+        mots-clés, un historique de modifications, et une copie de certains
+        champs EXIF &mdash; c'est pourquoi supprimer l'EXIF seul ne suffit pas.
+      </li>
+      <li>
+        <strong>L'IPTC.</strong> Un bloc plus ancien de champs de légende, de
+        signature, de crédit et de copyright, utilisé dans la presse et la photo
+        de stock.
+      </li>
+      <li>
+        <strong>La vignette incorporée.</strong> Une petite deuxième copie de
+        l'image. Elle est produite au moment de l'écriture du fichier, et elle
+        n'est pas toujours refaite quand l'image est modifiée &mdash; c'est ainsi
+        qu'une photo recadrée peut voyager avec une vignette de ce qui a été
+        coupé.
+      </li>
+      <li>
+        <strong>La note de fabricant.</strong> Un bloc de données non documenté.
+        Personne en dehors du fabricant ne sait tout ce qu'il contient.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Qui le voit réellement</h2>
+    <p>
+      C'est la partie où il vaut la peine d'être exact, parce que la version
+      alarmiste et la version dédaigneuse sont fausses toutes les deux.
+    </p>
+    <p>
+      <strong>La plupart des grands réseaux sociaux effacent les métadonnées
+      quand vous publiez.</strong> Facebook, Instagram et X réencodent les images
+      envoyées et jettent les étiquettes au passage. Ce n'est pas une gentillesse
+      &mdash; ils gardent les données de leur côté &mdash; mais cela veut bien
+      dire qu'une photo publiée sur ces services ne remet pas ses coordonnées à
+      chaque personne qui la regarde.
+    </p>
+    <p>
+      <strong>Presque tout le reste les conserve.</strong> Une pièce jointe de
+      courriel. Un fichier envoyé sur la plupart des messageries comme
+      &laquo;&nbsp;document&nbsp;&raquo; plutôt que comme photo. Une image sur un
+      forum, une annonce de petites annonces, un site personnel, un disque
+      partagé, un rapport de bug, un ticket de support. Dans tous ces cas le
+      fichier arrive intact, et quiconque le télécharge peut en lire les
+      étiquettes avec des outils livrés avec son système d'exploitation.
+    </p>
+    <p>
+      Les risques réalistes sont banals plutôt que spectaculaires&nbsp;: une
+      annonce photographiée à la maison, une photo d'enfant prise dans son école,
+      un compte apparemment anonyme qui publie des photos partageant toutes le
+      même numéro de série d'appareil, un
+      &laquo;&nbsp;pris la semaine dernière&nbsp;&raquo; qui a été pris en mars.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi ne pas simplement réenregistrer&nbsp;?</h2>
+    <p>
+      Réenregistrer une photo dans un logiciel de retouche ou un compresseur
+      supprime bien les métadonnées &mdash; l'image est décodée en pixels puis
+      réencodée, et un canvas plein de pixels ne porte aucune étiquette. Cela
+      fonctionne, et cela vous coûte de la qualité, parce que ce réencodage est
+      avec perte.
+    </p>
+    <p>
+      Supprimer les métadonnées proprement ne coûte rien du tout. Les étiquettes
+      se trouvent dans le conteneur <em>autour</em> de l'image compressée, pas
+      dedans&nbsp;: les retirer, c'est effacer des entrées d'une liste et
+      réécrire la liste. Les données d'image compressées sont recopiées octet
+      pour octet et le résultat décode exactement les mêmes pixels. C'est là
+      toute la raison d'utiliser un outil de métadonnées plutôt qu'un
+      convertisseur.
+    </p>
+    <p>
+      L'exception est le cas où vous alliez réencoder de toute façon. Si vous
+      compressez ou redimensionnez déjà la photo, les étiquettes partent par
+      effet de bord et vous n'avez pas besoin d'une seconde étape.
+    </p>
+  </section>
+
+  <section>
+    <h2>La seule chose à garder&nbsp;: l'orientation</h2>
+    <p>
+      Les téléphones ne font pas pivoter l'image quand vous tournez le téléphone.
+      Ils l'enregistrent telle que le capteur l'a vue et ajoutent une étiquette
+      d'orientation qui dit comment la tourner pour l'affichage. Retirez toutes
+      les étiquettes et certains afficheurs montreront votre photo couchée.
+    </p>
+    <p>
+      C'est pourquoi l'outil d'ici a une option
+      &laquo;&nbsp;garder l'étiquette d'orientation&nbsp;&raquo;, active par
+      défaut. Elle réécrit un minuscule bloc EXIF contenant cette seule étiquette
+      et rien d'autre, et seulement pour les photos qui en avaient réellement
+      besoin. Le GPS, les horodatages, le numéro de série et le reste ont toujours
+      disparu.
+    </p>
+    <p>
+      Décochez-la si vous préférez que le fichier ne porte plus le moindre EXIF
+      &mdash; et vérifiez alors le résultat avant de l'envoyer, parce qu'une
+      photo couchée est le dénouement habituel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Modifier au lieu de supprimer</h2>
+    <p>
+      Tout supprimer est la bonne réponse pour la plupart des gens. Parfois non
+      &nbsp;: un photographe peut vouloir garder la ligne de copyright et les
+      réglages de l'appareil et n'effacer que le lieu&nbsp;; un archiviste peut
+      avoir besoin de corriger une date fausse parce que l'horloge de l'appareil
+      l'était.
+    </p>
+    <p>
+      Les deux sont possibles. Le lieu peut être supprimé seul, et les étiquettes
+      de texte, les dates, l'ISO, l'orientation et la résolution peuvent être
+      modifiés sur place.
+    </p>
+    <p>
+      Une réserve qui vaut pour tous les outils qui font cela, pas seulement pour
+      celui-ci&nbsp;: écrire le fichier reconstruit le bloc EXIF, et une note de
+      fabricant contient des décalages vers le bloc <em>d'origine</em>. Une note
+      reconstruite peut donc ne plus être lisible par le logiciel du fabricant.
+      Si cela compte, supprimez la note de fabricant ou laissez le fichier tel
+      quel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les formats, et ceux qui ne se traitent pas ainsi</h2>
+    <p>
+      Le JPEG, le PNG et le WebP peuvent tous être réécrits proprement, et ce
+      sont les trois que prend en charge l'outil d'ici.
+    </p>
+    <p>
+      Le HEIC &mdash; ce qu'un iPhone enregistre par défaut &mdash; et l'AVIF
+      sont des formats à boîtes faits d'atomes imbriqués, et demandent un tout
+      autre analyseur. L'outil les reconnaît et le dit plutôt que de produire un
+      fichier cassé. Si vous avez un HEIC, le convertir en JPEG supprimera les
+      métadonnées par effet de bord de la conversion.
+    </p>
+    <p>
+      Un TIFF nu n'est pas pris en charge non plus, et pour une raison plus
+      intéressante&nbsp;: dans un TIFF, les métadonnées et les données de pixels
+      sont adressées par les mêmes décalages, si bien que retirer des étiquettes
+      revient à réécrire l'adressage de l'image elle-même. C'est faisable, et
+      c'est un autre travail.
+    </p>
+  </section>
+
+  <section>
+    <h2>Une habitude qui vaut la peine</h2>
+    <p>
+      Vérifiez avant de publier plutôt qu'après. Lire les étiquettes prend
+      quelques secondes et la liste des trouvailles nomme ce qui vaut d'être su
+      &mdash; la position, les horodatages, les numéros de série &mdash; avant le
+      tableau complet de toutes les étiquettes&nbsp;: vous n'avez donc pas besoin
+      de savoir quoi chercher.
+    </p>
+    <p>
+      La position est d'abord montrée en degrés décimaux, exprès.
+      &laquo;&nbsp;51 degrés, 30 minutes, 26 secondes&nbsp;&raquo; ne rend pas
+      évident qu'une photo nomme le bâtiment où elle a été prise. Une paire de
+      décimaux que vous pouvez coller dans une carte, si.
+    </p>
+  </section>
+
+  <section>
+    <h2>N'envoyez pas la photo pour savoir ce qu'il y a dedans</h2>
+    <p>
+      Il y a une ironie particulière dans la façon dont ce problème se résout
+      d'habitude&nbsp;: quelqu'un qui s'inquiète de ce que révèle sa photo
+      l'envoie à un site web pour le savoir. Le site a maintenant la photo, les
+      coordonnées, l'horodatage et le numéro de série, plus une copie de l'image
+      sur un disque qui lui appartient.
+    </p>
+    <p>
+      Il n'y a aucune raison à cela. Lire et réécrire le conteneur autour d'un
+      JPEG représente quelques centaines de lignes d'analyse qu'un navigateur
+      exécute parfaitement, et c'est pourquoi l'outil d'ici n'a aucune fonction
+      réseau&nbsp;: pas de <code>fetch</code>, pas de
+      <code>XMLHttpRequest</code>, rien qui puisse envoyer un fichier même si
+      quelque chose essayait. Chargez-le une fois, coupez la connexion, et il
+      continue de fonctionner.
+    </p>
+    <p>
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose comment vérifier
+      cette affirmation, sur ce site comme sur n'importe quel autre &mdash; et
+      c'est le type de fichier pour lequel cela vaut le plus la peine de
+      vérifier.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/fr/pages/guides/remove-exif-and-gps-data.toml
@@ -1,0 +1,18 @@
+#
+# Guide : les donnees EXIF et GPS d'une photo, et comment les retirer - French.
+#
+
+nav = "Données EXIF et GPS"
+title = "Comment supprimer les données EXIF et GPS d'une photo"
+description = "Une photo sortie d'un téléphone porte en général l'endroit exact où elle a été prise, l'heure à la seconde, et le numéro de série de l'appareil. Ce qu'il y a dedans, qui peut le lire, et comment le retirer sans toucher à l'image."
+heading = "Ce qu'une photo raconte sur vous, et comment le retirer"
+lede = """
+    Une image sortie tout droit d'un téléphone porte typiquement les coordonnées
+    du lieu où elle a été prise, l'heure à la seconde, et assez de choses sur
+    l'appareil pour la relier à toutes les autres photos du même téléphone. Rien
+    de tout cela n'est visible à l'écran. Voici ce qu'il y a dedans et comment le
+    supprimer."""
+updated = "20 août 2026"
+og_title = "Ce qu'une photo raconte sur vous, et comment le retirer"
+og_description = "Coordonnées GPS, horodatages et numéros de série voyagent à l'intérieur des photos ordinaires. Ce qu'il y a dedans, qui peut le lire, et comment l'effacer."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/resize-an-image.html
+++ b/locales/fr/pages/guides/resize-an-image.html
@@ -1,0 +1,250 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../redimensionner-une-image/">redimensionneur
+      d'images</a>, déposez-y votre image, tapez un seul chiffre &mdash; la
+      largeur, en général &mdash; et laissez l'autre vide. La hauteur découle de
+      la forme de l'image, ce qui est presque toujours ce qu'on
+      voulait&nbsp;: &laquo;&nbsp;1920 de large&nbsp;&raquo; veut dire
+      &laquo;&nbsp;1920 de large et la hauteur que cela donne&nbsp;&raquo;.
+    </p>
+    <p>
+      Tout ce qui suit est pour les cas où un seul chiffre ne suffit pas&nbsp;:
+      quand on vous a donné un cadre à deux côtés, quand l'image doit grossir, ou
+      quand tout un dossier de fichiers doit ressortir pareil.
+    </p>
+  </section>
+
+  <section>
+    <h2>Réduire est sans danger. Agrandir ne l'est pas.</h2>
+    <p>
+      Ce ne sont pas deux sens d'une même opération, et il vaut la peine de dire
+      clairement pourquoi.
+    </p>
+    <p>
+      <strong>Réduire une image</strong> jette de l'information, et dans le seul
+      sens bénin du terme&nbsp;: il entre plus de pixels qu'il n'en sort, et
+      chaque pixel du résultat est donc une moyenne de détail réellement mesuré.
+      Une copie réduite proprement est en général <em>plus belle</em> que
+      l'original regardé à cette taille, parce que le moyennage supprime le
+      bruit. Rien n'est inventé.
+    </p>
+    <p>
+      <strong>Agrandir une image</strong> doit inventer. Le détail ne manque pas
+      dans le fichier&nbsp;; il n'a jamais été photographié. Tout ce qu'un
+      agrandisseur peut faire, c'est deviner les pixels intermédiaires d'après
+      leurs voisins, et une supposition entre deux valeurs connues est une rampe
+      douce &mdash; c'est pourquoi une photo agrandie paraît molle plutôt que
+      nette. C'est une copie plus grande de la même image, pas une copie plus
+      détaillée.
+    </p>
+    <p>
+      C'est pourquoi &laquo;&nbsp;ne jamais agrandir une image au-delà de sa
+      taille de départ&nbsp;&raquo; est actif par défaut dans l'outil d'ici.
+      Décochez-le si vous avez réellement besoin du nombre de pixels &mdash; une
+      imprimerie qui exige une taille minimale, un gabarit qui refuse tout ce qui
+      est sous une largeur &mdash; mais faites-le en sachant que vous achetez des
+      pixels, pas du détail.
+    </p>
+    <p>
+      Les agrandisseurs par apprentissage automatique qui semblent, eux, ajouter
+      du détail sont une tout autre chose&nbsp;: ils inventent une texture
+      plausible à partir d'un modèle de ce à quoi les images ressemblent
+      d'habitude. Pour un fond d'écran, c'est très bien. Pour la photographie
+      d'une personne, d'un document, ou de tout ce dont quelqu'un tirera une
+      conclusion, comprenez que le détail supplémentaire est une fiction.
+    </p>
+  </section>
+
+  <section>
+    <h2>Trois façons de dire la taille voulue</h2>
+    <p>
+      La plupart des outils, celui-ci compris, acceptent les mêmes trois, et
+      elles conviennent à des travaux différents.
+    </p>
+    <ul>
+      <li>
+        <strong>Des pixels exacts.</strong> À utiliser quand quelqu'un a précisé
+        le nombre&nbsp;: un avatar qui doit faire 400&times;400, une bannière qui
+        doit faire 1500 de large. Remplissez un côté et laissez l'autre suivre,
+        sauf si on vous a donné les deux.
+      </li>
+      <li>
+        <strong>Un pourcentage.</strong> À utiliser quand vous voulez tout
+        proportionnellement plus petit sans vous soucier du chiffre exact &mdash;
+        &laquo;&nbsp;moitié moins&nbsp;&raquo; pour un jeu de photos destinées à
+        un document.
+      </li>
+      <li>
+        <strong>Un plus grand côté.</strong> La plus utile des trois pour un lot
+        mêlé. &laquo;&nbsp;Plus grand côté 1600&nbsp;&raquo; fait tenir chaque
+        image dans un carré de 1600 pixels, qu'elle soit verticale ou
+        horizontale, ce qui est en pratique ce que veut dire
+        &laquo;&nbsp;mets-moi tout ça à une taille raisonnable&nbsp;&raquo;.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Quand le cadre n'a pas la forme de l'image</h2>
+    <p>
+      C'est là que le redimensionnement se décide réellement. Si vous donnez une
+      largeur et une hauteur qui ne correspondent pas aux proportions de votre
+      image, quelque chose doit céder, et il n'y a exactement que quatre choses
+      qui le peuvent&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Tenir dans le cadre.</strong> L'image entière est gardée et
+        ressort plus petite que le cadre sur un axe. Rien n'est perdu et rien
+        n'est déformé&nbsp;; vous n'obtenez simplement pas les dimensions exactes
+        demandées. C'est le bon comportement par défaut pour à peu près tout.
+      </li>
+      <li>
+        <strong>Remplir le cadre et couper ce qui dépasse.</strong> Vous obtenez
+        exactement les dimensions demandées, et les parties de l'image qui
+        débordent ont disparu. Bon pour les vignettes, les avatars et les
+        couvertures, où la forme est imposée et le sujet est au milieu. Mauvais
+        quand ce qui compte est près d'un bord.
+      </li>
+      <li>
+        <strong>Compléter.</strong> L'image entière est gardée, centrée, et
+        l'espace restant est rempli d'une couleur que vous choisissez. Bon quand
+        un système exige des dimensions exactes et que vous ne pouvez rien perdre
+        de l'image &mdash; les fiches produit fonctionnent souvent ainsi.
+      </li>
+      <li>
+        <strong>Étirer.</strong> L'image est écrasée ou tirée pour entrer. Ce
+        n'est jamais ce que vous voulez, sauf à le faire exprès, et c'est celui
+        que tout le monde reconnaît instantanément comme faux.
+      </li>
+    </ul>
+    <p>
+      Si vous vous surprenez à tendre la main vers l'étirement, ce que vous
+      voulez sans doute, c'est recadrer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Recadrer est un autre travail, et souvent le bon</h2>
+    <p>
+      Redimensionner change le nombre de pixels qui décrivent l'image entière.
+      Recadrer change la partie de l'image que vous gardez. Les gens tendent la
+      main vers le premier en pensant au second étonnamment souvent &mdash;
+      &laquo;&nbsp;il faut que ce soit carré&nbsp;&raquo; est un problème de
+      recadrage, pas de redimensionnement.
+    </p>
+    <p>
+      Faites-les dans cet ordre&nbsp;: recadrez d'abord selon le cadrage voulu,
+      puis redimensionnez le résultat à la taille voulue. Faire l'inverse revient
+      à choisir le recadrage dans une image qui a déjà perdu des pixels.
+    </p>
+    <p>
+      L'outil d'ici fait les deux en une passe pour cette raison &mdash; tracez
+      un cadre, verrouillez-le sur une forme s'il vous faut une proportion
+      précise, puis dites la taille de sortie voulue. Le faire en une passe veut
+      aussi dire que l'image n'est encodée qu'une fois, ce qui compte pour la
+      raison exposée dans la section suivante.
+    </p>
+    <h3>Recadrer tout un lot</h3>
+    <p>
+      Un cadre tracé sur une image est appliqué aux autres comme la même zone
+      <em>relative</em>&nbsp;: les mêmes fractions de la largeur et de la hauteur
+      propres à chaque fichier. Pour un dossier de captures ou d'exports tous de
+      la même taille, c'est exactement le même rectangle. Pour un lot mêlé, c'est
+      le même cadrage plutôt que le même rectangle, ce qui est en général ce
+      qu'on voulait, mais vaut d'être su avant de lui confier cinquante fichiers.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que coûte le réencodage, et comment n'en faire qu'un</h2>
+    <p>
+      Redimensionner un JPEG ou un WebP, c'est le décoder, mettre les pixels à
+      l'échelle, et les réencoder &mdash; et cette dernière étape est avec perte.
+      Ce n'est pas la mise à l'échelle elle-même qui vous coûte de la
+      qualité&nbsp;; c'est le réencodage.
+    </p>
+    <p>
+      Deux conséquences. D'abord, le réglage de qualité en sortie compte&nbsp;:
+      quelque part autour de 80 à 85, c'est invisible pour une photographie et
+      considérablement plus léger que 100. Ensuite, ne le faites qu'une fois.
+      Redimensionner une image déjà redimensionnée deux fois, ce sont trois
+      générations d'encodage avec perte, et cela se voit.
+    </p>
+    <p>
+      Un PNG n'a pas ce coût, parce qu'il est sans perte &mdash; un PNG
+      redimensionné, ce sont exactement les pixels mis à l'échelle. Si vous
+      travaillez en plusieurs étapes et que le format final n'est pas encore
+      décidé, passer par du PNG au milieu évite d'empiler les générations.
+    </p>
+    <p>
+      Un détail vaut d'être connu à propos de l'outil d'ici&nbsp;: un fichier que
+      vous ne changez pas réellement vous est rendu octet pour octet plutôt que
+      réencodé. Demandez &laquo;&nbsp;plus grand côté 1600&nbsp;&raquo; sur un
+      lot et ceux qui sont déjà sous 1600 ressortent intacts, étiquettes
+      comprises. Un outil qui les réencoderait discrètement vous coûterait de la
+      qualité sur des fichiers que personne ne lui avait demandé de changer.
+    </p>
+  </section>
+
+  <section>
+    <h2>La transparence, et ce qu'elle devient</h2>
+    <p>
+      Le PNG et le WebP savent stocker la transparence. Le JPEG non &mdash; il
+      n'y a aucun canal alpha dans ce format. Enregistrer une image transparente
+      en JPEG oblige donc à mettre quelque chose derrière, et ce quelque chose
+      est une couleur unie.
+    </p>
+    <p>
+      La plupart des outils prennent du blanc sans le dire, ce qui va très bien
+      jusqu'au jour où votre logo atterrit sur une page sombre avec un rectangle
+      blanc autour. Choisissez la couleur délibérément, ou enregistrez en PNG ou
+      en WebP et gardez la transparence. La même couleur sert derrière un cadre
+      complété, l'autre endroit où l'on rencontre cela par surprise.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quel outil, si on vous a donné un chiffre</h2>
+    <p>
+      Deux chiffres différents circulent, et ils appellent des outils différents.
+    </p>
+    <p>
+      <strong>&laquo;&nbsp;1200 pixels de large&nbsp;&raquo;</strong> est un
+      problème de dimensions. Le
+      <a href="../../redimensionner-une-image/">redimensionneur d'images</a> est
+      le bon&nbsp;: vous dites combien de pixels vous voulez et il vous les
+      donne.
+    </p>
+    <p>
+      <strong>&laquo;&nbsp;Sous 500&nbsp;KB&nbsp;&raquo;</strong> est un problème
+      de taille de fichier, et le redimensionnement n'est qu'une des façons de le
+      résoudre. Le <a href="../../compresser-une-image/">compresseur d'images</a>
+      cherche la meilleure qualité qui tienne dans votre cible et ne
+      redimensionne que si la qualité seule n'y arrive pas&nbsp;;
+      <a href="../compresser-une-image-a-une-taille-precise/">son guide</a>
+      traite de ce que cela coûte.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rien de tout cela ne demande un envoi</h2>
+    <p>
+      Décoder une image, la mettre à l'échelle et la réencoder sont des choses
+      que tous les navigateurs savent faire depuis des années &mdash; c'est la
+      machinerie même dont une page web se sert pour dessiner une image à une
+      autre taille. Il n'y a aucune raison technique pour que votre photo voyage
+      jusqu'à un serveur et en revienne pour ressortir plus petite, et l'outil
+      d'ici ne l'envoie nulle part&nbsp;: la
+      <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+      qu'elle peut contacter, et aucune n'appartient à ce site.
+    </p>
+    <p>
+      Chargez la page, coupez votre connexion, et redimensionnez quelque chose
+      quand même, si vous préférez vérifier plutôt qu'on vous le dise.
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
+      vérifications applicables à n'importe quel outil.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/resize-an-image.toml
+++ b/locales/fr/pages/guides/resize-an-image.toml
@@ -1,0 +1,17 @@
+#
+# Guide : redimensionner une image - French.
+#
+
+nav = "Redimensionner une image"
+title = "Comment redimensionner une image sans l'abîmer"
+description = "Ce qui arrive à une image quand on change ses dimensions en pixels : pourquoi réduire est sans danger et agrandir ne l'est pas, que faire quand le cadre n'a pas la bonne forme, et quand recadrer plutôt."
+heading = "Comment redimensionner une image sans l'abîmer"
+lede = """
+    Le redimensionnement est le seul travail d'image où les dégâts sont décidés
+    avant d'appuyer sur le bouton, par le chiffre que vous tapez et la forme que
+    vous demandez. Voici ce que chaque choix fait à l'image, et lesquels vous
+    pouvez défaire."""
+updated = "20 août 2026"
+og_title = "Redimensionner une image sans l'abîmer"
+og_description = "Pourquoi réduire est sans danger et agrandir ne l'est pas, que faire quand le cadre n'a pas la bonne forme, et quand recadrer plutôt."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/trim-a-video.html
+++ b/locales/fr/pages/guides/trim-a-video.html
@@ -1,0 +1,208 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../couper-une-video/">coupeur de vidéos</a>, déposez-y
+      le clip, appuyez sur <kbd>I</kbd> et <kbd>O</kbd> pour marquer chaque
+      passage voulu &mdash; autant que vous voulez &mdash; et exportez. Sur un
+      MP4, un MOV ou un M4V, les images que vous gardez sont déplacées dans le
+      nouveau fichier exactement telles qu'elles étaient &mdash; mêmes octets,
+      mêmes réglages d'encodeur, même tout &mdash; et le son est recopié
+      échantillon par échantillon sans être décodé.
+    </p>
+    <p>
+      Cela veut dire qu'une coupe ne vous coûte rien en qualité, et qu'elle est
+      rapide&nbsp;: sortir une minute d'un enregistrement de quatre gigaoctets
+      coûte à peu près ce que coûte l'écriture de cette minute sur le disque,
+      parce que les images sont pointées plutôt que chargées. Le seul endroit où
+      cela se voit, c'est là où votre coupe tombe réellement, et c'est le reste
+      de cette page.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi une coupe n'a pas à perdre de qualité</h2>
+    <p>
+      Couper ne change l'aspect d'aucune image. Chaque image que vous gardez est
+      censée ressortir identique à ce qu'elle était en entrant&nbsp;: il n'y a
+      donc aucune raison de la décoder et de la réencoder &mdash; et toutes les
+      raisons de ne pas le faire, puisqu'un réencodage est avec perte et
+      dégraderait légèrement tout le clip dans le seul but de le raccourcir.
+    </p>
+    <p>
+      Un bon coupeur ne réencode donc pas. Il lit l'index du fichier, détermine
+      quelles images encodées tombent dans votre intervalle, et écrit ces octets
+      dans un nouveau conteneur avec un nouvel index devant. Rien n'est décodé du
+      tout sur ce chemin.
+    </p>
+    <p>
+      Bien des outils réencodent quand même, parce que décoder et réencoder est
+      bien plus simple à implémenter que d'analyser le format du conteneur. On
+      reconnaît en général lequel des deux on utilise à la durée&nbsp;: une copie
+      est limitée par la vitesse d'écriture de votre disque, et un réencodage par
+      la vitesse à laquelle votre machine encode de la vidéo, ce qui est cent
+      fois plus lent.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les images clés, et pourquoi votre coupe peut tomber plus tôt</h2>
+    <p>
+      Voici la contrainte dont découle tout ce qui concerne la coupe.
+    </p>
+    <p>
+      La vidéo n'est pas stockée comme une suite d'images complètes. Ce serait
+      énorme. La plupart des images sont stockées comme une description de ce qui
+      les différencie de leurs voisines, ce qui veut dire qu'elles ne peuvent pas
+      être décodées seules &mdash; il vous faut les images autour d'elles. Seule
+      une <strong>image clé</strong> se tient toute seule comme une image
+      complète, et les images clés sont typiquement espacées d'une à dix
+      secondes.
+    </p>
+    <p>
+      Donc, si vous marquez une coupe deux secondes après la dernière image clé,
+      un coupeur qui recopie les images ne peut pas commencer là. Les images à
+      votre marque sont illisibles sans la suite qui y mène. Il doit emporter
+      toute la portion depuis l'image clé qui précède votre marque.
+    </p>
+    <p>
+      Ce qu'il en fait est la partie intéressante. Le format de fichier a une
+      façon standard de dire <em>commencer la lecture à ce point</em> &mdash; les
+      images supplémentaires sont dans le fichier mais le conteneur ordonne au
+      lecteur de les sauter. Tout lecteur grand public le respecte, et le clip
+      commence exactement là où vous l'avez dit. Un lecteur qui l'ignore
+      démarrera plus tôt, de l'écart entre images clés au maximum.
+    </p>
+    <p>
+      L'outil d'ici vous dit dans quel cas vous êtes et de combien avant
+      l'export&nbsp;: c'est donc une décision plutôt qu'une surprise.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quand accepter un réencodage</h2>
+    <p>
+      Il existe une coupe exacte, et elle fonctionne en réencodant la portion
+      d'ouverture &mdash; en décodant depuis l'image clé, et en écrivant une
+      nouvelle suite d'images qui commence réellement là où vous avez marqué.
+      Elle est plus lente, et elle coûte un peu de qualité sur cette portion
+      d'ouverture seulement.
+    </p>
+    <p>
+      Choisissez-la quand le clip part quelque part qui ne respectera pas
+      l'instruction du conteneur, ou quand vous ne maîtrisez pas le
+      lecteur&nbsp;: certains logiciels de montage, certains systèmes de
+      diffusion et de visioconférence, certains lecteurs matériels plus anciens.
+      Choisissez la copie pour tout le reste, c'est-à-dire pour presque tout
+      &mdash; un navigateur, un téléphone, une plateforme sociale, un lecteur
+      multimédia.
+    </p>
+    <p>
+      Une troisième option qui ne coûte rien&nbsp;: déplacez votre marque. Si
+      l'outil vous montre où sont les images clés, pousser la coupe jusqu'à la
+      plus proche vous donne une coupe exacte sans le moindre réencodage. Il est
+      rare qu'une seconde d'écart vaille qu'on renonce à une copie.
+    </p>
+  </section>
+
+  <section>
+    <h2>Retirer un morceau du milieu</h2>
+    <p>
+      Couper un passage est une opération différente d'en garder un, et il vaut
+      la peine de savoir que c'est possible, parce que bien des coupeurs ne font
+      que la seconde. Marquez la partie dont vous ne voulez pas, choisissez de la
+      couper, et ce qui reste de part et d'autre est raccordé en un seul clip,
+      avec le son repris au pas.
+    </p>
+    <p>
+      Le raccord subit la même contrainte d'image clé à l'endroit où la seconde
+      moitié reprend, pour la même raison. Cela fonctionne sur les deux chemins
+      MP4 d'ici. C'est la seule chose que le repli par enregistrement, plus bas,
+      ne sait pas faire, parce qu'un enregistrement se fait en une passe depuis
+      une seule tête de lecture.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les formats, et le repli</h2>
+    <p>
+      <strong>Le MP4, le M4V et le MOV</strong> sont lus directement, quel que
+      soit le codec à l'intérieur &mdash; H.264, HEVC, AV1, VP9. Recopier des
+      images n'implique pas de les décoder&nbsp;: ce chemin fonctionne donc même
+      pour un codec dont votre navigateur n'a aucun décodeur, agréable
+      conséquence du fait de ne pas regarder les images.
+    </p>
+    <p>
+      <strong>Tout le reste que votre navigateur sait lire</strong>, le WebM au
+      premier chef, est coupé en le jouant et en enregistrant le résultat. Cela
+      marche, et cela coûte deux choses&nbsp;: cela prend le temps que dure le
+      passage, et l'image et le son sont réencodés.
+    </p>
+    <p>
+      <strong>L'AVI, le WMV, le FLV et la plupart des MKV</strong>, le navigateur
+      ne sait ni les lire ni les jouer, et l'outil le dit plutôt que d'échouer à
+      mi-course. Convertissez-les d'abord en MP4 avec quelque chose qui les
+      prend en charge.
+    </p>
+  </section>
+
+  <section>
+    <h2>Deux choses qui tournent mal en silence ailleurs</h2>
+    <p>
+      <strong>La rotation.</strong> Un téléphone filme à l'horizontale et écrit
+      une instruction de rotation dans le fichier plutôt que de tourner les
+      pixels. Un coupeur qui recopie les images doit reporter cette instruction,
+      sinon votre clip vertical ressort couché &mdash; c'est la façon classique
+      dont une vidéo coupée est gâchée. Le chemin exact d'ici tourne les images en
+      les réencodant et écrit un fichier qui n'a besoin d'aucune rotation.
+    </p>
+    <p>
+      <strong>La synchronisation du son.</strong> L'audio et la vidéo sont
+      stockés comme des flux séparés avec leur propre rythme, et ils ne sont pas
+      découpés aux mêmes points. Si les deux ne sont pas alignés délibérément à
+      la coupe, le son dérive. Sur le chemin par copie d'ici, l'audio est recopié
+      échantillon par échantillon sans être décodé&nbsp;: il est donc octet pour
+      octet ce qu'il y avait dans le fichier, et une marque de montage le garde
+      au pas de l'image au millième de seconde près.
+    </p>
+  </section>
+
+  <section>
+    <h2>Couper n'est pas recadrer</h2>
+    <p>
+      Deux mots qu'on emploie l'un pour l'autre. Couper change la durée du
+      clip&nbsp;; recadrer change la forme de l'image. Si ce que vous voulez est
+      une version carrée d'une vidéo horizontale, ou les bandes noires enlevées
+      sur les côtés, c'est le
+      <a href="../../recadrer-une-video/">recadreur de vidéos</a> &mdash; et,
+      contrairement à la coupe, lui doit réencoder, pour la raison
+      qu'<a href="../recadrer-une-video/">expose son guide</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi cela ne demande pas d'envoi &mdash; celui-ci surtout</h2>
+    <p>
+      La vidéo est le type de fichier pour lequel les gens s'attendent le plus à
+      devoir faire un envoi, parce que les fichiers sont gros et que le travail a
+      l'air lourd. La coupe est le cas où c'est le moins vrai&nbsp;: sur le
+      chemin par copie, le fichier est à peine lu. L'outil parcourt l'index,
+      détermine quelles plages d'octets garder, et les écrit. Envoyer un fichier
+      de quatre gigaoctets à un serveur pour qu'il fasse cela serait la façon la
+      plus lente possible de s'y prendre.
+    </p>
+    <p>
+      C'est aussi le type de fichier où l'envoi coûte le plus cher si vous
+      préférez l'éviter&nbsp;: la vidéo porte des visages, des voix, des
+      logements et des lieux d'une façon qu'un document ne connaît pas. L'outil
+      d'ici n'a aucune fonction réseau, et la
+      <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+      qu'elle peut contacter, dont aucune n'appartient à ce site.
+    </p>
+    <p>
+      Coupez votre connexion et coupez un clip quand même, si vous préférez
+      vérifier plutôt qu'on vous le dise.
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
+      vérifications du même genre.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/trim-a-video.toml
+++ b/locales/fr/pages/guides/trim-a-video.toml
@@ -1,0 +1,17 @@
+#
+# Guide : couper une video - French.
+#
+
+nav = "Couper une vidéo"
+title = "Comment couper une vidéo sans la réencoder"
+description = "Couper un clip n'a pas à perdre un seul octet de qualité. Pourquoi une coupe tombe parfois plus tôt que là où vous l'avez marquée, ce qu'une image clé vient y faire, et quand accepter un réencodage."
+heading = "Comment couper une vidéo sans la réencoder"
+lede = """
+    Couper ne change l'aspect d'aucune image&nbsp;: un bon coupeur n'y touche
+    donc pas &mdash; il les déplace dans un nouveau fichier exactement telles
+    qu'elles étaient. Voici ce que cela vous rapporte, et le seul endroit où cela
+    se voit."""
+updated = "20 août 2026"
+og_title = "Comment couper une vidéo sans la réencoder"
+og_description = "Pourquoi une coupe tombe parfois plus tôt que là où vous l'avez marquée, ce qu'une image clé vient y faire, et quand accepter un réencodage."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/fr/pages/guides/turn-a-video-into-a-gif.html
@@ -1,0 +1,232 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../video-en-gif/">convertisseur de vidéo en GIF</a>,
+      déposez-y le clip, marquez les secondes voulues, et laissez la largeur à
+      480 et la cadence à 12 images par seconde. C'est le réglage que veulent la
+      plupart des GIF. Si le fichier ressort trop gros, baissez la largeur avant
+      de toucher à quoi que ce soit d'autre &mdash; c'est le réglage qui paie
+      deux fois.
+    </p>
+    <p>
+      Le reste de cette page explique pourquoi, parce que
+      &laquo;&nbsp;mon GIF fait 14 MB&nbsp;&raquo; est le problème que tout le
+      monde a réellement, et que le bouton à tourner n'est pas évident.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi un GIF tiré d'une vidéo est si énorme</h2>
+    <p>
+      Un codec vidéo stocke du <em>mouvement</em>. Il écrit une image complète
+      toutes les deux secondes environ puis, pour chaque image intermédiaire, une
+      description de la façon dont cette image a bougé&nbsp;: ce bloc de pixels a
+      glissé de quatre vers la gauche, cette zone s'est un peu assombrie. Un clip
+      de cinq secondes peut faire quelques centaines de kilooctets parce que
+      l'essentiel est fait d'instructions à propos d'une image que vous avez
+      déjà.
+    </p>
+    <p>
+      Le GIF n'a rien de tout cela. Il a été achevé en 1989, avant que rien de
+      cela n'existe. Chaque image est une image, compressée pour elle-même avec
+      un procédé conçu pour des captures d'écran de tableur. Il n'y a aucune
+      estimation de mouvement nulle part dans le format, et aucun moyen d'en
+      ajouter une.
+    </p>
+    <p>
+      Le chiffre à attendre est donc <strong>dix fois le poids de la
+      vidéo</strong>, et aucun convertisseur ne vous en dissuadera. Ce qu'un bon
+      convertisseur peut faire, c'est ne rien gaspiller par-dessus, et vous donner
+      les trois réglages qui en décident réellement.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les trois réglages, et ce que chacun coûte</h2>
+    <p>
+      Tout ce qui fait le poids d'un GIF se ramène au nombre de pixels qu'il
+      contient, c'est-à-dire la durée multipliée par la cadence multipliée par la
+      surface d'une image.
+    </p>
+    <ul>
+      <li>
+        <strong>Le passage &mdash; linéaire.</strong> Deux fois plus long, c'est
+        deux fois plus d'images et à peu près deux fois le fichier. C'est celui
+        que la plupart des gens comprennent déjà, et il vaut la peine d'être
+        impitoyable&nbsp;: un GIF qui fait son effet en trois secondes est un
+        meilleur GIF en plus d'être un GIF plus léger.
+      </li>
+      <li>
+        <strong>La largeur &mdash; quadratique.</strong> Diviser la largeur par
+        deux divise la hauteur avec elle&nbsp;: c'est donc le <em>quart</em> des
+        pixels. Passer de 640 à 320 n'économise pas un peu moins de la
+        moitié&nbsp;; cela économise environ les trois quarts. C'est le réglage
+        vers lequel personne ne tend la main en premier et celui qui paie le
+        mieux.
+      </li>
+      <li>
+        <strong>La cadence &mdash; linéaire.</strong> Dix images par seconde,
+        c'est les deux tiers du poids de quinze. C'est aussi le réglage où la
+        perte est la plus visible, parce qu'un mouvement trop lent se lit comme
+        cassé plutôt que comme léger.
+      </li>
+    </ul>
+    <p>
+      Un exemple chiffré. Six secondes d'un clip de téléphone à ses
+      1080&times;1920 et 30 images par seconde, ce sont 180 images de deux
+      millions de pixels&nbsp;: environ 350 millions de pixels, ce qui n'est pas
+      un GIF mais une prise d'otages. Les mêmes six secondes à 480 de large et 12
+      images par seconde font 72 images de 400 000 pixels &mdash; 30 millions,
+      soit environ un douzième &mdash; et cela ressemble à ce que les gens
+      appellent un GIF.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quelle cadence choisir</h2>
+    <p>
+      Douze est le défaut ici et la bonne réponse étonnamment souvent. C'est la
+      cadence qu'emploie l'animation dessinée à la main depuis un siècle&nbsp;:
+      assez rapide pour que l'œil la lise comme un mouvement continu, assez lente
+      pour que vous ne payiez pas des images que personne ne voit.
+    </p>
+    <ul>
+      <li><strong>5 à 8</strong> &mdash; un air de diaporama. Convient pour un
+        panoramique lent ou une capture d'écran où rien ne bouge vite.</li>
+      <li><strong>10 à 15</strong> &mdash; normal. Se lit comme du mouvement. À
+        peu près tout GIF qui vaut la peine d'être fait est là-dedans.</li>
+      <li><strong>20 à 25</strong> &mdash; fluide, et à peu près le double du
+        poids de 12 pour une différence que la plupart des spectateurs ne sauront
+        pas nommer. Cela vaut le coup pour du mouvement rapide, un clip sportif,
+        tout ce qui contient un panoramique filé.</li>
+    </ul>
+    <p>
+      Il existe un plafond dur autant le savoir&nbsp;: le GIF stocke la durée
+      d'affichage de chaque image en centièmes de seconde, et tous les
+      navigateurs traitent un délai inférieur à deux centièmes comme s'il en
+      valait dix. Le vrai maximum est donc de 50 images par seconde, et un fichier
+      qui en demande 100 jouera en silence à 10. Un convertisseur qui vous propose
+      du 60 images par seconde soit l'ignore, soit s'apprête à vous surprendre.
+    </p>
+  </section>
+
+  <section>
+    <h2>256 couleurs, et à quoi sert le tramage</h2>
+    <p>
+      L'autre moitié de l'âge du format&nbsp;: un GIF porte une table d'au plus
+      256 couleurs, et chaque pixel est un numéro qui pointe dedans. Une image de
+      vidéo en a jusqu'à seize millions. Presque tout cela est jeté, et la façon
+      dont c'est jeté fait l'essentiel de l'allure d'un GIF.
+    </p>
+    <p>
+      Un bon convertisseur compte les couleurs de <em>votre</em> clip et en
+      choisit 256 qui lui conviennent, plutôt que d'utiliser un jeu figé. Un plan
+      de forêt reçoit 256 verts&nbsp;; un plan de coucher de soleil reçoit 256
+      oranges. C'est ce que fait l'outil d'ici, sur chaque image du passage plutôt
+      que sur la première seulement, si bien qu'une couleur qui n'apparaît qu'à la
+      fin a quand même sa place.
+    </p>
+    <p>
+      <strong>Le tramage</strong> est ce qui se passe là où la couleur dont vous
+      avez besoin manque encore. Au lieu d'arrondir toute une zone à la couleur
+      disponible la plus proche &mdash; ce qui transforme un ciel doux en quatre
+      aplats aux marches visibles &mdash; il alterne les deux couleurs les plus
+      proches selon un motif fin, et à une distance de vue normale votre œil les
+      mélange en celle qui n'est pas là.
+    </p>
+    <ul>
+      <li><strong>Laissez-le activé</strong> pour tout ce qui est
+        photographique&nbsp;: ciels, peau, dégradés, ombres, film.</li>
+      <li><strong>Désactivez-le</strong> pour les aplats&nbsp;: captures d'écran,
+        dessin au trait, logos, dessins animés, tout ce qui a de grandes zones
+        d'une seule teinte. Il n'y a pas de dégradé à protéger, et le fichier est
+        plus léger et plus propre sans lui.</li>
+    </ul>
+    <p>
+      Un détail à connaître si vous comparez des convertisseurs. La façon évidente
+      de tramer &mdash; la diffusion d'erreur, qu'utilisent la plupart des
+      logiciels d'image &mdash; fait dépendre le résultat de chaque pixel des
+      pixels qui l'entourent. Dans une animation, cela veut dire qu'un fond qui ne
+      bouge pas est tramé différemment à chaque image&nbsp;: il grouille
+      visiblement, et chaque image doit être stockée en entier parce que chaque
+      pixel a techniquement changé. L'autre solution, un tramage ordonné, ne
+      dépend que de la position du pixel&nbsp;: un fond immobile reste donc
+      parfaitement immobile. C'est ce qu'utilise cet outil, et c'est pourquoi ses
+      fichiers sont à la fois plus légers et plus calmes.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quand ne pas faire de GIF du tout</h2>
+    <p>
+      La question mérite d'être posée, parce que la réponse honnête est souvent
+      &laquo;&nbsp;ne le faites pas&nbsp;&raquo;. Un MP4 ou un WebM muet en boucle
+      pèse environ un dixième de la même animation en GIF, se lit de la même
+      façon, et c'est de toute manière ce en quoi toutes les plateformes sociales
+      convertissent votre GIF après l'envoi.
+    </p>
+    <p>Gardez le GIF là où la destination en a réellement besoin&nbsp;:</p>
+    <ul>
+      <li>un endroit qui n'accepte qu'une image &mdash; beaucoup de messageries,
+        de forums, de wikis et de logiciels de courriel&nbsp;;</li>
+      <li>un README ou une page de documentation, où un GIF joue dans le fil du
+        texte quand une vidéo réclame un lecteur&nbsp;;</li>
+      <li>une présentation ou un document qui doit continuer de bouger hors
+        ligne&nbsp;;</li>
+      <li>un emoji, un autocollant, une réaction &mdash; assez petits pour que
+        rien de l'arithmétique ci-dessus ne compte.</li>
+    </ul>
+    <p>
+      Là où le son compte, la question se répond d'elle-même&nbsp;: le GIF n'a
+      jamais eu d'audio et n'en aura jamais. Coupez plutôt la vidéo &mdash; le
+      <a href="../../couper-une-video/">coupeur de vidéos</a> en extrait un
+      passage sans réencoder une seule image.
+    </p>
+  </section>
+
+  <section>
+    <h2>Passer sous une limite de taille</h2>
+    <p>
+      La raison principale pour laquelle on règle un GIF est une limite à l'autre
+      bout. Dans l'ordre approximatif de leur dureté&nbsp;:
+    </p>
+    <ul>
+      <li><strong>Le courriel</strong> &mdash; 10 à 25 MB pour tout le message, et
+        une pièce jointe proche de cela se fait retirer ou rejeter par quelque
+        chose en chemin. Visez bien en dessous.</li>
+      <li><strong>Les messageries et les forums</strong> &mdash; couramment 8 à
+        10 MB, parfois bien moins pour un aperçu en ligne plutôt qu'un
+        téléchargement.</li>
+      <li><strong>Un README GitHub</strong> &mdash; 10 MB par fichier, et tout ce
+        qui dépasse deux mégaoctets donne à la page l'air d'être cassée sur un
+        téléphone.</li>
+      <li><strong>Les emplacements d'autocollants et d'emojis</strong> &mdash;
+        souvent quelques centaines de kilooctets, ce qui veut dire une petite
+        largeur et un passage court, pas une cadence plus basse.</li>
+    </ul>
+    <p>
+      L'ordre à essayer quand vous dépassez&nbsp;: raccourcir le passage, puis
+      diviser la largeur par deux, puis baisser la cadence, puis désactiver le
+      tramage. Les deux premiers valent plus que les deux derniers réunis.
+    </p>
+  </section>
+
+  <section>
+    <h2>Rien de tout cela ne demande un envoi</h2>
+    <p>
+      Convertir une vidéo en GIF, c'est décoder, redimensionner, compter des
+      couleurs et compresser &mdash; quatre choses qu'un navigateur sait faire
+      tout seul depuis des années. L'outil lié en haut fait tout cela sur votre
+      machine&nbsp;: le fichier est lu sur votre disque, les images sont décodées
+      par votre navigateur, et le GIF est assemblé en mémoire puis remis à vos
+      téléchargements.
+    </p>
+    <p>
+      Cela mérite plus d'attention ici qu'ailleurs. Les clips que les gens
+      transforment en GIF sont des clips personnels &mdash; un moment d'une vidéo
+      de famille, une capture d'écran de quelque chose au travail, quelques
+      secondes d'un appel. Un convertisseur qui veut qu'on les lui envoie demande
+      une copie de tout cela, et il ne reste plus aucune raison technique de dire
+      oui.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/fr/pages/guides/turn-a-video-into-a-gif.toml
@@ -1,0 +1,17 @@
+#
+# Guide : transformer une video en GIF - French.
+#
+
+nav = "Faire un GIF depuis une vidéo"
+title = "Comment transformer une vidéo en GIF (et le garder léger)"
+description = "Quel passage, quelle largeur et quelle cadence choisir, pourquoi un GIF tiré d'une vidéo pèse dix fois la vidéo, et quand en faire un tout court."
+heading = "Comment transformer une vidéo en GIF"
+lede = """
+    Le GIF est un format de 1987 qui stocke des images entières plutôt que du
+    mouvement&nbsp;: celui qu'on tire d'une vidéo est donc toujours gros. Voici
+    lequel des trois réglages déplacer quand il est trop gros, et ce que chacun
+    vous rapporte."""
+updated = "20 août 2026"
+og_title = "Comment transformer une vidéo en GIF, et le garder léger"
+og_description = "Les trois réglages qui décident du poids d'un GIF, ce que chacun coûte, et quand le GIF est carrément la mauvaise réponse."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/turn-images-into-a-video.html
+++ b/locales/fr/pages/guides/turn-images-into-a-video.html
@@ -1,0 +1,200 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez <a href="../../images-en-video/">Images en vidéo</a>, déposez-y les
+      images, mettez-les en ordre, réglez la durée d'affichage de chacune, et
+      créez la vidéo. Vous obtenez un MP4 avec de la vidéo H.264, qui se lit sur
+      à peu près n'importe quoi.
+    </p>
+    <p>
+      Les deux réglages qui demandent le plus souvent une seconde passe sont la
+      durée et la résolution, et ils valent d'être compris avant le premier rendu
+      plutôt qu'après.
+    </p>
+  </section>
+
+  <section>
+    <h2>La cadence et la durée ne sont pas la même chose</h2>
+    <p>
+      C'est la confusion qui coûte un nouveau rendu.
+    </p>
+    <p>
+      <strong>La durée</strong> est le temps que chaque image reste à l'écran.
+      C'est le réglage qui vous intéresse réellement. Trois secondes est un
+      défaut confortable pour un diaporama que quelqu'un regarde&nbsp;; une à
+      deux secondes donne un rythme alerte&nbsp;; au-delà de cinq, cela traîne à
+      moins qu'une voix ne le commente.
+    </p>
+    <p>
+      <strong>La cadence</strong> est le nombre de fois par seconde où la vidéo
+      répète cette image. Elle ne change rien à l'allure du diaporama &mdash; une
+      image fixe tenue trois secondes est identique à 24 images par seconde et à
+      60 &mdash; et elle change beaucoup le poids du fichier et le temps
+      d'encodage.
+    </p>
+    <p>
+      Pour un simple diaporama, prenez donc une cadence basse. 24 ou 30 suffit
+      largement. La raison de monter est la présence de mouvement dans la
+      vidéo&nbsp;: un panoramique ou un zoom sur chaque photo, ou un fondu
+      enchaîné entre elles, où une cadence basse se voit comme des saccades.
+    </p>
+  </section>
+
+  <section>
+    <h2>La résolution, et les images qui n'ont pas la bonne forme</h2>
+    <p>
+      Une vidéo a une seule taille d'image sur toute sa durée. Vos photographies
+      n'en partagent presque certainement pas une seule&nbsp;: quelque chose doit
+      donc arriver à celles qui n'entrent pas &mdash; et ce quelque chose est le
+      choix qu'il vaut la peine de faire délibérément.
+    </p>
+    <p>
+      Commencez par choisir la résolution en fonction de la destination de la
+      vidéo&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>1920&times;1080</strong> pour tout usage général. Prise en charge
+        universellement, se lit partout, et c'est ce que la plupart des gens
+        appellent la HD.
+      </li>
+      <li>
+        <strong>1080&times;1920</strong> &mdash; les mêmes nombres dans l'autre
+        sens &mdash; pour une destination pensée pour le téléphone&nbsp;:
+        stories, reels, shorts.
+      </li>
+      <li>
+        <strong>3840&times;2160</strong> seulement si les images ont réellement
+        autant de détail et si la destination le montrera. C'est quatre fois les
+        pixels, quatre fois le temps d'encodage, et à peu près quatre fois le
+        fichier.
+      </li>
+    </ul>
+    <p>
+      Décidez ensuite du sort des images qui ne correspondent pas. Les faire
+      tenir dans le cadre garde tout et laisse des bandes sur les côtés &mdash;
+      sûr, et la bonne réponse quand les images comptent plus que la présentation.
+      Remplir le cadre et rogner le débord a plus d'allure et coupera le haut de
+      certaines. Mêler photographies verticales et horizontales dans une même
+      vidéo est le cas où il n'y a pas de bonne réponse&nbsp;; décider à l'avance
+      de quel côté vous préférez avoir tort épargne un nouveau rendu.
+    </p>
+  </section>
+
+  <section>
+    <h2>L'ordre, et le piège des noms de fichiers</h2>
+    <p>
+      Comme pour tout traitement par lots, les noms de fichiers se trient d'une
+      façon qui n'est pas celle dont vous avez compté.
+      <code>photo2.jpg</code> vient après <code>photo10.jpg</code> dans un tri
+      alphabétique, parce que la comparaison se fait caractère par caractère.
+    </p>
+    <p>
+      Trier par date de prise de vue est en général juste pour des photographies
+      d'un événement, puisque vous les avez prises dans l'ordre où il s'est
+      déroulé. Faire glisser les tuiles est juste pour tout ce dont le récit
+      n'est pas chronologique. Vérifiez avant de lancer le rendu&nbsp;: la vidéo
+      est l'objet où corriger l'ordre veut dire refaire tout le travail.
+    </p>
+  </section>
+
+  <section>
+    <h2>Il n'y a pas de bande-son, et ce n'est pas un détail</h2>
+    <p>
+      Le MP4 qu'écrit cet outil a une seule piste vidéo et aucune piste audio. Si
+      votre diaporama a besoin de musique ou d'une voix, il vous faudra un
+      logiciel de montage pour cette étape.
+    </p>
+    <p>
+      Il vaut la peine de savoir pourquoi, et pas seulement que&nbsp;: ajouter de
+      l'audio veut dire décoder un fichier de musique, l'encoder en AAC, et
+      l'entrelacer avec la vidéo dans le conteneur. Les trois sont du vrai
+      travail, et les faire mal produit un fichier qui se désynchronise à la
+      lecture. C'est sur la liste plutôt qu'à moitié fait.
+    </p>
+    <p>
+      Une note pratique si vous ajoutez la musique après&nbsp;: choisissez
+      d'abord le morceau et réglez la durée par image pour que le diaporama
+      ressorte proche de la longueur de la chanson. Rogner la musique pour
+      qu'elle entre dans la vidéo sonne toujours plus mal que d'ajuster la vidéo
+      à la musique.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qui sort, et que faire si cela refuse de se lire</h2>
+    <p>
+      La cible est du MP4 avec du H.264, la combinaison la plus largement lisible
+      qui soit. Dans un navigateur sans WebCodecs, l'outil se rabat sur un
+      enregistrement WebM &mdash; les mêmes images dans un conteneur que moins
+      d'éditeurs et de plateformes sociales acceptent.
+    </p>
+    <p>
+      Si vous vous retrouvez avec un WebM et que quelque chose le refuse, le
+      remède est un navigateur qui prend en charge WebCodecs plutôt qu'une
+      conversion&nbsp;: les versions actuelles de Chrome, Edge et Safari le font
+      toutes. Refaire le rendu vaut mieux que convertir, parce que convertir veut
+      dire une génération de plus d'encodage avec perte.
+    </p>
+    <p>
+      Aucune limite n'est intégrée à l'outil quant au nombre d'images. Le plafond
+      est la mémoire de votre propre machine, parce que la vidéo finie y est
+      assemblée avant que vous la téléchargiez &mdash; un long diaporama en 4K
+      est la première chose à s'en ressentir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Alléger le fichier</h2>
+    <p>
+      Si le résultat est trop lourd pour sa destination, dans l'ordre de ce qui
+      aide réellement&nbsp;:
+    </p>
+    <p>
+      <strong>Baissez la cadence.</strong> Pour un diaporama d'images fixes, cela
+      ne coûte rien de visible et c'est la plus grosse économie disponible d'un
+      seul coup.
+    </p>
+    <p>
+      <strong>Baissez la résolution.</strong> Du 1080p au lieu de la 4K, c'est le
+      quart des pixels, et sur un écran de téléphone personne ne le saura.
+    </p>
+    <p>
+      <strong>Raccourcissez.</strong> Trois secondes par image au lieu de cinq,
+      c'est 40&nbsp;% de durée en moins et 40&nbsp;% de fichier en moins, et en
+      général un meilleur diaporama.
+    </p>
+    <p>
+      Réduire d'abord les photographies source n'aide pas beaucoup. La vidéo est
+      encodée à la résolution que vous avez choisie de toute façon&nbsp;: une
+      photo de 4000 pixels et une de 2000 produisent presque le même nombre
+      d'octets dans une vidéo 1080p. Cela accélère l'encodage, en revanche, et
+      cela repousse ce plafond de mémoire.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi cela ne demande pas de serveur, avec une exception dite</h2>
+    <p>
+      Encoder de la vidéo était naguère le cas le plus clair en faveur de
+      l'envoi&nbsp;: les navigateurs ne savaient pas le faire, et une machine
+      dotée de FFmpeg le savait. WebCodecs a changé cela en exposant l'encodeur
+      matériel qui est déjà dans votre machine, celui-là même que votre téléphone
+      utilise pour enregistrer de la vidéo en temps réel. Composer les images,
+      c'est un canvas. Aucune des deux étapes n'a besoin d'autre chose que de
+      votre propre matériel.
+    </p>
+    <p>
+      Une exception sur cet outil précis, dite plutôt qu'enterrée&nbsp;: la
+      fonction facultative &laquo;&nbsp;ajouter depuis une adresse web&nbsp;&raquo;
+      récupère une image à une adresse que vous collez, et le serveur qui se
+      trouve à cette adresse voit votre IP et ce que vous avez demandé. C'est
+      inhérent à la fonction plutôt qu'un défaut, et c'est la seule étape réseau
+      de tout l'outil. Ne vous en servez pas et rien ne quitte votre machine.
+    </p>
+    <p>
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> expose quatre vérifications
+      qui vous diront la même chose de n'importe quel outil, celui-ci compris.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/turn-images-into-a-video.toml
+++ b/locales/fr/pages/guides/turn-images-into-a-video.toml
@@ -1,0 +1,16 @@
+#
+# Guide : transformer des images en video - French.
+#
+
+nav = "Des images en vidéo"
+title = "Comment transformer un dossier d'images en vidéo"
+description = "Faire un diaporama MP4 à partir de photos : ce que contrôlent vraiment la cadence et la durée, comment traiter les images qui n'ont pas la bonne forme, et pourquoi le résultat n'a pas de bande-son."
+heading = "Comment transformer un dossier d'images en vidéo"
+lede = """
+    Un diaporama est une chose simple à fabriquer et facile à fabriquer deux
+    fois, parce que deux des réglages ne veulent pas dire ce qu'ils ont l'air de
+    vouloir dire. Voici ce que chacun contrôle et lequel choisir."""
+updated = "20 août 2026"
+og_title = "Comment transformer un dossier d'images en vidéo"
+og_description = "Ce que contrôlent vraiment la cadence et la durée, comment traiter les images qui n'ont pas la bonne forme, et pourquoi il n'y a pas de bande-son."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/privacy.html
+++ b/locales/fr/pages/privacy.html
@@ -1,0 +1,196 @@
+  <section>
+    <h2>Vos fichiers</h2>
+    <p>
+      Chaque outil de ce site fait son travail à l'intérieur de votre propre
+      navigateur, sur votre propre matériel. Quand vous choisissez un fichier, il
+      est lu par la page que vous avez déjà ouverte. Il ne nous est pas envoyé,
+      parce qu'il n'existe aucun serveur à nous vers lequel l'envoyer &mdash; ce
+      site est un ensemble de fichiers statiques, sans backend, sans base de
+      données et sans stockage.
+    </p>
+    <p>
+      Cela veut dire que nous ne recevons, ne voyons, ne stockons, ne
+      journalisons et ne traitons jamais&nbsp;:
+    </p>
+    <ul>
+      <li>vos fichiers, en tout ou en partie</li>
+      <li>leurs vignettes ou leurs aperçus</li>
+      <li>leurs noms, tailles, dimensions ou formats</li>
+      <li>combien vous en avez choisi, ni ce que vous en avez fait</li>
+      <li>quoi que ce soit qui en est lu, données EXIF et GPS comprises</li>
+    </ul>
+    <p>
+      Ce n'est pas une promesse sur nos intentions. Chaque page porte une
+      <code>Content-Security-Policy</code> qui nomme toutes les adresses que la
+      page a le droit de contacter, et c'est le navigateur qui l'applique. Aucune
+      de ces adresses ne nous appartient. Vous pouvez lire la politique en tête
+      du source de n'importe quelle page, ou ouvrir l'onglet Réseau de votre
+      navigateur et regarder&nbsp;: aucune requête ne transporte votre fichier.
+    </p>
+    <p>
+      Les fichiers que vous produisez avec un outil sont remis au mécanisme de
+      téléchargement de votre propre navigateur et enregistrés là où vous le lui
+      dites. Nous ne sommes pas non plus impliqués dans cette étape.
+    </p>
+  </section>
+
+  <section>
+    <h2>La seule exception, et où elle s'applique</h2>
+    <p>
+      L'outil <a href="../images-en-video/">Images en vidéo</a> a une fonction
+      &laquo;&nbsp;ajouter depuis une adresse web&nbsp;&raquo;. Si vous y collez
+      une adresse, votre navigateur récupère cette image sur le serveur que vous
+      avez nommé, et <strong>ce serveur voit votre adresse IP</strong> ainsi que
+      le fichier que vous avez demandé. C'est incontournable, et c'est la nature
+      même de la fonction.
+    </p>
+    <p>
+      Cela n'arrive jamais que pour des adresses que vous tapez vous-même, c'est
+      construit de sorte que les images puissent entrer mais que les données ne
+      puissent pas sortir, et la page de cet outil l'explique plus en détail.
+      Aucun autre outil de ce site ne peut émettre une requête sortante avec quoi
+      que ce soit de vous dedans.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qui est collecté, et par qui</h2>
+    <p>
+      Ce site est gratuit et il est payé par la publicité. Cela veut dire que
+      deux produits Google tournent sur ces pages, et qu'un bouton de don tourne
+      sur la plupart d'entre elles. Voici la liste entière.
+    </p>
+
+    <h3>Google AdSense &mdash; les annonces</h3>
+    <p>
+      Google sert les annonces et décide de celles que vous voyez. Pour cela, il
+      peut poser et lire des cookies ou des identifiants similaires dans votre
+      navigateur, et il reçoit votre adresse IP, une localisation approximative
+      qui en découle, votre agent utilisateur, et la page sur laquelle vous
+      étiez. Selon vos réglages et l'endroit où vous vous trouvez, les annonces
+      peuvent être personnalisées à partir d'un profil que Google détient sur
+      vous, bâti pour l'essentiel sur votre activité sur d'autres sites.
+    </p>
+    <p>
+      Nous ne recevons rien de tout cela, nous ne pouvons pas le voir, et nous
+      n'envoyons jamais à Google quoi que ce soit sur vos fichiers. L'exposé de
+      Google sur la façon dont il utilise les données des sites qui affichent ses
+      annonces se trouve sur
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>.
+    </p>
+
+    <h3>Google Analytics &mdash; le compteur de visites</h3>
+    <p>
+      Nous utilisons Google Analytics 4 pour compter les visites de pages, afin
+      de savoir quels outils méritent qu'on y travaille. Il enregistre la page
+      consultée, à peu près quand, un identifiant tiré au hasard et stocké dans
+      votre navigateur, une localisation approximative, le type de votre appareil
+      et de votre navigateur, et le site qui vous a envoyé ici.
+    </p>
+    <p>
+      Il est configuré pour ne rien faire d'autre, et cette configuration est un
+      fichier que vous pouvez lire&nbsp;: <code>analytics.js</code>, à côté de
+      chaque page, met en place un compteur de pages vues et ne contient aucun
+      événement personnalisé. Rien sur ce site ne lui passe un fichier, un nom de
+      fichier, une dimension ou un nombre &mdash; il n'y a ici aucun code qui le
+      pourrait.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; le bouton de don</h3>
+    <p>
+      La page d'accueil et les pages d'outils portent un bouton de don, qui se
+      charge depuis les serveurs de Buy Me a Coffee. Le charger implique que leur
+      CDN voie votre adresse IP et sache que vous étiez sur ce site, et le
+      lettrage du bouton est récupéré sur Google Fonts, qui voit lui aussi votre
+      adresse IP. Rien d'autre n'est transmis, et rien de plus ne se passe tant
+      que vous ne cliquez pas réellement dessus&nbsp;; à ce moment-là, vous êtes
+      sur leur site, sous leurs conditions. Cette page et la
+      <a href="../conditions-d-utilisation/">page des conditions</a> ne dessinent
+      pas le bouton.
+    </p>
+
+    <h3>Hébergement</h3>
+    <p>
+      Le site est servi par GitHub Pages, derrière Cloudflare. Comme tout
+      hébergeur web, ils traitent les requêtes que fait votre navigateur &mdash;
+      ce qui comprend votre adresse IP, la page demandée et votre agent
+      utilisateur &mdash; afin de livrer la page et de garder le service debout
+      et sûr. Nous n'avons accès aux journaux par visiteur d'aucun des deux.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cookies</h2>
+    <p>
+      Nous ne posons aucun cookie à nous. Nous n'avons ni connexion, ni session,
+      ni préférences à retenir, ni aucune raison d'en avoir.
+    </p>
+    <p>
+      Tout cookie ou identifiant similaire que vous pourriez trouver ici
+      appartient à Google et est posé par les scripts publicitaires et
+      d'analytique décrits ci-dessus. Ils servent à mesurer les visites, et à
+      choisir et plafonner les annonces.
+    </p>
+    <h3>Comment tout désactiver</h3>
+    <ul>
+      <li>
+        La personnalisation des annonces peut être désactivée, pour tous les
+        sites d'un coup, dans
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">Mon centre de préférences pour les annonces</a>.
+      </li>
+      <li>
+        Google Analytics peut être bloqué partout avec le
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">module de désactivation pour navigateur</a>
+        de Google.
+      </li>
+      <li>
+        Les réglages de votre propre navigateur peuvent bloquer ou effacer les
+        cookies tiers, et n'importe quel bloqueur de contenu empêchera ces
+        scripts de se charger tout court.
+      </li>
+    </ul>
+    <p>
+      Tout bloquer nous convient très bien. <strong>Chaque outil de ce site
+      fonctionne avec les scripts bloqués, et fonctionne avec le réseau
+      entièrement débranché.</strong> Rien ici n'est retenu derrière une annonce.
+    </p>
+  </section>
+
+  <section>
+    <h2>Vos droits sur les données</h2>
+    <p>
+      Nous ne détenons aucune donnée personnelle sur vous&nbsp;: il n'y a donc
+      rien que nous puissions vous montrer, corriger, exporter ou supprimer
+      &mdash; une demande adressée à nous reviendrait vide, honnêtement.
+    </p>
+    <p>
+      Les données décrites ci-dessus sont détenues par Google, qui en est son
+      propre responsable de traitement. Les demandes à leur sujet doivent lui
+      être adressées, via
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">votre compte Google</a>
+      ou ses contacts en matière de confidentialité.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les enfants</h2>
+    <p>
+      Ce site ne s'adresse pas aux enfants et ne demande son âge à personne,
+      parce qu'il ne demande rien à personne. Nous ne collectons sciemment aucune
+      donnée personnelle, de qui que ce soit, à tout âge.
+    </p>
+  </section>
+
+  <section>
+    <h2>Modifications, et comment nous joindre</h2>
+    <p>
+      Si cette page change, la date en haut change avec elle, et la modification
+      figure dans l'historique public des commits, comme tout le reste.
+    </p>
+    <p>
+      Les questions sur tout cela peuvent aller à
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, ou être posées comme
+      ticket sur <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">le dépôt</a>,
+      où la réponse est visible par tous ceux qui se posent la même question.
+    </p>
+  </section>

--- a/locales/fr/pages/privacy.toml
+++ b/locales/fr/pages/privacy.toml
@@ -1,0 +1,17 @@
+#
+# Confidentialité & cookies - French. Overrides for pages/privacy/page.toml.
+#
+
+nav = "Confidentialité &amp; cookies"
+title = "Confidentialité &amp; cookies &mdash; abox.tools"
+description = "Ce qu'abox.tools collecte et ce qu'il ne collecte pas. Vos fichiers ne sont jamais envoyés ; la publicité, le compteur de visites et le bouton de don sont décrits ici en entier."
+heading = "Confidentialité &amp; cookies"
+lede = """
+    La version courte&nbsp;: vos fichiers ne sont jamais envoyés, parce qu'il n'y
+    a nulle part où les envoyer. Tout le reste de cette page concerne la
+    publicité, le compteur de visites et l'hébergement &mdash; les parties qui,
+    elles, font intervenir d'autres entreprises."""
+updated = "19 août 2026"
+og_title = "Confidentialité &amp; cookies &mdash; abox.tools"
+og_description = "Vos fichiers ne sont jamais envoyés. Ce qui est collecté, par qui, et comment le désactiver."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/terms.html
+++ b/locales/fr/pages/terms.html
@@ -1,0 +1,163 @@
+  <section>
+    <h2>Ce qu'est ce site</h2>
+    <p>
+      abox.tools est un ensemble de petits utilitaires qui tournent à l'intérieur
+      de votre navigateur web. Ils sont libres d'usage, pour tout, y compris pour
+      un travail commercial. Il n'y a rien à acheter, aucun compte à créer,
+      aucune limite d'usage, et aucune fonction retenue.
+    </p>
+    <p>
+      En utilisant le site, vous acceptez les conditions de cette page. Si vous
+      ne les acceptez pas, le remède est simplement de fermer l'onglet &mdash;
+      rien de vous n'est retenu ici.
+    </p>
+  </section>
+
+  <section>
+    <h2>Vos fichiers restent les vôtres</h2>
+    <p>
+      Vous conservez tous les droits que vous aviez déjà sur les fichiers que
+      vous ouvrez avec ces outils, et sur ce que vous produisez avec eux. Nous ne
+      revendiquons ni licence, ni propriété, ni intérêt d'aucune sorte sur les
+      uns comme sur les autres.
+    </p>
+    <p>
+      Ce n'est pas de la générosité, c'est de l'arithmétique&nbsp;: les outils
+      tournent entièrement dans votre navigateur et vos fichiers ne nous sont
+      jamais transmis&nbsp;; il n'y a donc rien sur quoi nous puissions avoir des
+      droits. La <a href="../confidentialite/">page Confidentialité</a> expose
+      comment cela fonctionne et comment le vérifier.
+    </p>
+  </section>
+
+  <section>
+    <h2>Utiliser le site de façon responsable</h2>
+    <p>
+      Vous êtes responsable des fichiers que vous traitez et de ce que vous
+      faites des résultats. En particulier, n'utilisez pas ces outils sur des
+      contenus sur lesquels vous n'avez aucun droit, ni pour produire quoi que ce
+      soit d'illégal.
+    </p>
+    <p>
+      Nous ne pouvons pas faire respecter cela et nous ne prétendons pas le
+      contraire. Nous ne voyons jamais vos fichiers&nbsp;: il n'y a donc ici
+      aucune modération, aucune analyse, et aucun moyen pour nous de savoir ce
+      que fait qui que ce soit. L'obligation est véritablement la vôtre.
+    </p>
+    <p>
+      Merci également de ne pas vous en prendre au site lui-même &mdash; en
+      attaquant l'hébergement, ou en redistribuant des copies modifiées d'une
+      façon qui laisserait croire qu'il s'agit de l'original.
+    </p>
+  </section>
+
+  <section>
+    <h2>Aucune garantie</h2>
+    <p>
+      Le site et ses outils sont fournis <strong>en l'état</strong>, sans
+      garantie d'aucune sorte, expresse ou implicite, y compris toute garantie
+      implicite de qualité marchande, d'adéquation à un usage particulier ou
+      d'absence de contrefaçon.
+    </p>
+    <p>
+      Concrètement&nbsp;: un outil peut produire un résultat que vous ne vouliez
+      pas, peut échouer sur un fichier qu'il ne comprend pas, peut se comporter
+      différemment d'un navigateur à l'autre, et peut perdre le travail en cours
+      si l'onglet est fermé en pleine opération. Rien de ce que vous faites ici
+      n'est enregistré où que ce soit, alors <strong>gardez vos
+      originaux</strong>. N'utilisez pas ces outils sur l'unique copie de quelque
+      chose qui compte pour vous.
+    </p>
+  </section>
+
+  <section>
+    <h2>Limitation de responsabilité</h2>
+    <p>
+      Dans toute la mesure permise par la loi, nous ne sommes pas responsables
+      des pertes ou dommages découlant de votre utilisation de ce site &mdash; y
+      compris les fichiers perdus, corrompus ou inutilisables, le temps perdu, le
+      manque à gagner, ou tout dommage indirect ou consécutif.
+    </p>
+    <p>
+      Rien ici ne limite une responsabilité qui ne peut pas légalement être
+      limitée.
+    </p>
+  </section>
+
+  <section>
+    <h2>Disponibilité</h2>
+    <p>
+      Le site est proposé sans aucune promesse qu'il restera en ligne, qu'il
+      restera gratuit, qu'il conservera tel ou tel outil, ni même qu'il
+      continuera d'exister. Des outils peuvent changer ou disparaître sans
+      préavis.
+    </p>
+    <p>
+      Une conséquence pratique de la façon dont ces outils sont construits vaut
+      d'être connue&nbsp;: une fois la page d'un outil chargée, elle continue de
+      fonctionner hors ligne, et elle ne s'arrête pas parce que le site est
+      tombé. Le code est en outre public&nbsp;: un outil dont vous dépendez peut
+      donc être maintenu en service par vous, quoi qu'il advienne ici.
+    </p>
+  </section>
+
+  <section>
+    <h2>Publicité et autres entreprises</h2>
+    <p>
+      Le site porte de la publicité de Google, compte les visites avec Google
+      Analytics, et montre un bouton de don sur la plupart des pages. Ce que
+      chacun de ces éléments implique est décrit en entier sur la
+      <a href="../confidentialite/">page Confidentialité</a>.
+    </p>
+    <p>
+      Les annonces, et tout site que vous atteignez en cliquant sur l'une
+      d'elles, ne sont pas les nôtres. Nous ne choisissons pas les annonces une à
+      une, nous n'approuvons pas ce qu'elles disent, et nous ne sommes
+      responsables ni des sites vers lesquels elles mènent, ni de vos échanges
+      là-bas. Il en va de même pour tous les autres liens externes de ce site.
+    </p>
+  </section>
+
+  <section>
+    <h2>Le code source</h2>
+    <p>
+      Le code de ce site est publié ouvertement sur
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>,
+      parce que &laquo;&nbsp;lisez-le et vérifiez vous-même&nbsp;&raquo; est la
+      seule vraie réponse à &laquo;&nbsp;pourquoi devrais-je faire
+      confiance&nbsp;?&nbsp;&raquo;. La réutilisation de ce code est régie par les
+      termes de licence indiqués dans le dépôt, et non par cette page. Les
+      présentes conditions couvrent votre utilisation du site web.
+    </p>
+  </section>
+
+  <section>
+    <h2>Droit applicable</h2>
+    <p>
+      Ce site est exploité depuis le Canada. Les présentes conditions, et tout
+      litige né d'elles ou de votre utilisation du site, sont régis par le droit
+      du Canada et de la province depuis laquelle le site est exploité, sans
+      égard aux règles de conflit de lois.
+    </p>
+    <p>
+      Si le droit de la consommation de votre lieu de résidence vous accorde des
+      droits que ces conditions restreindraient autrement, ces droits
+      prévalent.
+    </p>
+  </section>
+
+  <section>
+    <h2>Modifications de ces conditions</h2>
+    <p>
+      Ces conditions peuvent être mises à jour. Quand elles le sont, la date en
+      haut change, et la modification apparaît dans l'historique public des
+      commits comme tout autre changement. Continuer d'utiliser le site après un
+      changement vaut acceptation de la version mise à jour.
+    </p>
+    <p>
+      Les questions peuvent aller à
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, ou être posées comme
+      ticket sur
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">le dépôt</a>.
+    </p>
+  </section>

--- a/locales/fr/pages/terms.toml
+++ b/locales/fr/pages/terms.toml
@@ -1,0 +1,16 @@
+#
+# Conditions d'utilisation - French. Overrides for pages/terms/page.toml.
+#
+
+nav = "Conditions d'utilisation"
+title = "Conditions d'utilisation &mdash; abox.tools"
+description = "Les conditions auxquelles ce site est offert : gratuit, en l'état, sans compte, sans garantie, et vos fichiers restent entièrement les vôtres parce qu'ils ne nous sont jamais transmis."
+heading = "Conditions d'utilisation"
+lede = """
+    Il n'y a aucun compte à ouvrir et aucun contrat à signer&nbsp;: elles sont
+    donc courtes. Elles décrivent ce que vous pouvez attendre de ce site, et ce
+    qu'il ne promet pas."""
+updated = "19 août 2026"
+og_title = "Conditions d'utilisation &mdash; abox.tools"
+og_description = "Gratuit, en l'état, sans compte, sans garantie. Vos fichiers restent entièrement les vôtres."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/planned.toml
+++ b/locales/fr/planned.toml
@@ -1,0 +1,76 @@
+#
+# La liste des outils prévus, sur la feuille de route - French.
+#
+# Overrides for config/planned.toml. Only words: the group `id` stays as it is,
+# because that is what a tool's roadmap_group matches on, and the order of the
+# groups and of the items inside them is decided once, in English.
+#
+# Every group and every item has to be here. They are merged in order, so a
+# missing entry would render in English in the middle of a French list with
+# nothing on the page to say which one it was - the build refuses a list whose
+# length has changed for exactly that reason.
+#
+
+note = "Pas encore construit. Listé pour que vous voyiez où cela va."
+
+[[group]]
+id = "images"
+name = "Images"
+items = [
+  ["Faire pivoter &amp; retourner", "par quarts de tour, ou redressé de quelques degrés"],
+  ["Ajouter du texte", "sur l'image, ou dans un bandeau au-dessus"],
+  ["Filtres", "luminosité, contraste, saturation, flou, niveaux de gris"],
+  ["Image en data URI", "coller le résultat directement dans du CSS ou du HTML"],
+  ["HEIC vers JPG", "les photos que fait un iPhone, dans un format que tout ouvre"],
+  ["AVIF &amp; JPEG XL", "convertir dans les deux sens, quel que soit le navigateur où vous êtes"],
+]
+
+[[group]]
+id = "gif"
+name = "GIF &amp; animation"
+items = [
+  ["GIF en MP4 ou WebM", "la même animation, en général au dixième du poids"],
+  ["Redimensionner, recadrer &amp; faire pivoter des GIF", "image par image, en gardant le rythme"],
+  ["Inverser un GIF", "la dernière image en premier"],
+  ["Changer la vitesse d'un GIF", "le recaler sans refabriquer les images"],
+  ["Analyseur de GIF", "images, délais, palette, et où sont passés les octets"],
+  ["Créateur d'APNG", "de l'animation avec une vraie transparence et toutes les couleurs"],
+  ["WebP animé", "encore la même animation, pour une fraction du poids"],
+]
+
+[[group]]
+id = "video"
+name = "Vidéo"
+items = [
+  ["Redimensionner", "jusqu'à une taille qui passera vraiment"],
+  ["Faire pivoter", "pour le clip filmé de travers"],
+  ["Couper le son, ou l'enregistrer", "retirer le son, ou le garder à part"],
+  ["Convertir en MP4 ou WebM", "celui des deux qu'exige le site où vous publiez"],
+  ["Filtres", "luminosité, contraste, saturation, flou"],
+  ["Incruster des sous-titres", "un fichier SRT dessiné dans l'image"],
+]
+
+[[group]]
+id = "audio"
+name = "Audio"
+items = [
+  ["Fondus d'entrée &amp; de sortie", "pour que cela ne démarre ni ne s'arrête à pic"],
+  ["Image de forme d'onde", "dessiner une piste comme une image"],
+  ["Convertir le format", "MP3, WAV et Opus, dans tous les sens"],
+]
+
+[[group]]
+id = "documents"
+name = "Documents &amp; PDF"
+items = [
+  ["Faire pivoter &amp; recadrer des pages", "redresser un scan couché, ou rogner ses marges"],
+  ["Extraire les images", "ressortir les images d'un document"],
+]
+
+[[group]]
+id = "beyond"
+name = "Au-delà des médias"
+items = [
+  ["Données", "conversion, nettoyage et inspection de CSV et de JSON"],
+  ["Confidentialité &amp; sécurité", "empreintes, sommes de contrôle, suppression de métadonnées"],
+]

--- a/locales/fr/tools/compress-image.html
+++ b/locales/fr/tools/compress-image.html
@@ -1,0 +1,121 @@
+<main>
+  <!-- Étape 1 &mdash; les fichiers -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir les images</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer de la liste</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; le chiffre qui compte -->
+  <section class="card" id="target-card">
+    <h2><span class="step">2</span> Dire quelle taille est permise</h2>
+
+    <p class="card-lede">
+      C'est la partie que les autres compresseurs prennent à l'envers. Ils vous
+      donnent un curseur de qualité et vous laissent deviner quel réglage passe
+      sous la limite qu'on vous a imposée. Donnez plutôt la limite&nbsp;: l'outil
+      cherche la meilleure qualité qui tienne dedans &mdash; puis dépense ce qui
+      reste du budget au lieu de vous rendre un fichier deux fois plus petit que
+      demandé.
+    </p>
+
+    <div class="target-row">
+      <div class="target-field">
+        <label for="target-value">Taille visée, par image</label>
+        <div class="inline-pair">
+          <input type="number" id="target-value" value="500" min="1" step="1" inputmode="decimal">
+          <label for="target-unit" class="visually-hidden">Unité</label>
+          <select id="target-unit">
+            <option value="KB" selected>KB</option>
+            <option value="MB">MB</option>
+          </select>
+        </div>
+      </div>
+
+      <!--
+        The four numbers people are actually given: an upload form that says
+        100 KB, a forum avatar or a job application at 500 KB, an email
+        attachment at 1 MB, and a web page hero at 2 MB.
+      -->
+      <div class="presets" id="presets" role="group" aria-label="Tailles courantes">
+        <button type="button" class="ghost" data-bytes="102400">100 KB</button>
+        <button type="button" class="ghost" data-bytes="512000">500 KB</button>
+        <button type="button" class="ghost" data-bytes="1048576">1 MB</button>
+        <button type="button" class="ghost" data-bytes="2097152">2 MB</button>
+      </div>
+    </div>
+
+    <p id="target-summary" class="field-summary"></p>
+
+    <fieldset class="options">
+      <legend>Par quels moyens il a le droit d'y arriver</legend>
+
+      <div class="option-row">
+        <label for="format-select">Format de sortie</label>
+        <select id="format-select">
+          <option value="auto" selected>Auto &mdash; garder le format, sauf si un autre fait mieux</option>
+          <option value="keep">Toujours garder le format d'origine</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/webp">WebP</option>
+          <option value="image/png">PNG (sans perte : la taille se paie donc sur les dimensions)</option>
+        </select>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="allow-resize" checked>
+        <span>
+          <strong>Peut réduire l'image s'il le faut</strong>
+          <span class="check-note">
+            Utilisé seulement lorsque la qualité seule devrait descendre sous le
+            point où la compression commence à se voir. En dessous, moins de bons
+            pixels valent mieux que davantage de pixels abîmés. Décochez pour
+            garder les dimensions exactes et payer une cible serrée sur la
+            qualité à la place.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Étape 3 &mdash; le clic unique -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Compresser</h2>
+
+    <div class="run-row">
+      <button type="button" id="compress-all" class="primary big" disabled>Compresser à la taille visée</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Compressé</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Tout télécharger en zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/compress-image.toml
+++ b/locales/fr/tools/compress-image.toml
@@ -1,0 +1,257 @@
+#
+# Compresseur d'images - French.
+#
+# Overrides for tools/compress-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# KB and MB are left alone throughout. The figures on screen are written by
+# src/files.js, which is the same file in every language and says "KB", so
+# prose that said "Ko" would disagree with the tool it is describing.
+#
+
+name = "Compresseur d'images"
+# Le complément est l'expression que les gens tapent. Comme en anglais, le nom
+# du produit reste la moitié qui parle fort.
+heading = "Compresseur&nbsp;d'images <span class=\"h1-kw\">&mdash; compresser à une taille exacte</span>"
+tagline = "Vous donnez la taille. Il se charge du reste."
+
+title = "Compresser une image à une taille précise &mdash; gratuit, sans envoi"
+description = "Compressez un JPEG, un PNG ou un WebP à une taille exacte - 100 KB, 2 MB, ce que vous voulez. Tout se passe dans votre navigateur : rien n'est envoyé, aucun compte, fonctionne hors ligne."
+og_title = "Compresser une image à la taille que vous choisissez"
+og_description = "Donnez une taille à atteindre : l'outil cherche la compression la plus légère qui y arrive, puis mesure ce que cela a coûté. Il tourne sur votre machine et n'envoie rien."
+og_image_alt = "Compresseur d'images - donnez une taille, gardez la qualité"
+
+pledge = """
+    La compression se fait dans votre propre navigateur, sur votre propre
+    matériel, avec les encodeurs qu'il embarque déjà. Cet outil n'a aucune
+    fonction réseau &mdash; rien à récupérer, rien à envoyer &mdash; et il n'y a
+    à l'autre bout de cette page aucun serveur auquel envoyer une image, quand
+    bien même il existerait un chemin pour l'atteindre."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et compressez une photo. Pas une seule
+      requête ne transporte d'image, de vignette, de nom de fichier ni un octet
+      de ce que vous avez choisi. Ou coupez votre connexion et compressez-en une
+      quand même."""
+
+read_first = """
+, <code>src/compress.js</code> pour la recherche qui
+      décide de la quantité de qualité à dépenser, et
+      <code>src/measure.js</code> pour la comparaison derrière le chiffre de
+      &laquo;&nbsp;correspondance visuelle&nbsp;&raquo;."""
+
+howto_heading = "Compresser une image à une taille précise"
+
+card = """
+            Dites la taille qu'il vous faut &mdash; 100 KB, 2 MB, ce que vous
+            voulez &mdash; et il trouve la compression la plus légère qui y
+            arrive."""
+
+[words]
+plural = "images"
+choose = "une image"
+analytics_extra = """, ni aucune des
+  tailles ou des valeurs de qualité que cet outil calcule"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans limite de taille"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Vos images n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où vos fichiers pourraient arriver, et rien dans le code qui les
+      y enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Il n'y a ni
+      <code>fetch</code>, ni <code>XMLHttpRequest</code>, ni
+      <code>sendBeacon</code> nulle part dans <code>src/</code>. La compression,
+      c'est <code>canvas.toBlob</code> &mdash; l'encodeur déjà installé dans
+      votre navigateur."""
+
+[[privacy]]
+title = "Les chiffres sont mesurés, pas remontés."
+body = """
+ Les tailles, la
+      valeur de qualité et la comparaison SSIM sont toutes calculées sur cette
+      page et vous sont montrées. Il n'existe dans ce dépôt aucun événement
+      d'analytique maison qui transporte un nom de fichier, une taille, un
+      nombre ou un résultat."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google, et le bouton de don de Buy
+      Me a Coffee. Aucun d'eux ne reçoit quoi que ce soit sur vos images. Chaque
+      ligne qui lit, compresse ou mesure un fichier est servie depuis cette
+      origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et l'outil est
+      inchangé, parce qu'il n'y a jamais eu d'étape réseau dedans. C'est la
+      preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez vos images."
+body = """
+ Déposez-les sur la zone prévue ou
+      sélectionnez-les à la main. Le navigateur les lit directement sur votre
+      disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Tapez la taille qu'on vous a imposée."
+body = """
+ 100 KB pour le
+      formulaire d'envoi qui refuse obstinément votre photo, 500 KB pour le
+      portail de candidature, 2 MB pour une page qui doit charger vite. Les
+      quatre plus courantes sont des boutons."""
+
+[[howto]]
+title = "Appuyez sur &laquo;&nbsp;Compresser à la taille visée&nbsp;&raquo;."
+body = """
+ Chaque image est
+      encodée plusieurs fois pendant que l'outil resserre autour de la meilleure
+      qualité qui tienne. Ce qui est déjà sous la taille visée est laissé
+      exactement tel quel."""
+
+[[howto]]
+title = "Regardez ce que cela a coûté, puis téléchargez."
+body = """
+ Chaque résultat
+      indique dans quel format il a été écrit, à quelle qualité, si les
+      dimensions ont changé, et à quel point il correspond à l'original une fois
+      mesuré. &laquo;&nbsp;Comparer&nbsp;&raquo; met les deux images côte à
+      côte."""
+
+[[faq]]
+q = "Mon image est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. Le fichier est décodé, compressé et mesuré par votre propre navigateur
+        sur votre propre matériel, avec les encodeurs JPEG, PNG et WebP que le
+        navigateur embarque déjà. Cet outil n'a aucune fonction réseau &mdash; il ne
+        récupère jamais rien et n'envoie jamais rien &mdash; et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter, dont aucune n'appartient à ce site."""
+
+[[faq]]
+q = "Comment atteint-il une taille exacte&nbsp;?"
+a = """
+        En essayant. Il n'existe pas de formule qui transforme un réglage de qualité
+        en un nombre d'octets &mdash; cela dépend entièrement de l'image &mdash; alors
+        l'outil encode l'image plusieurs fois et cherche la réponse. Il part du haut
+        de la plage de qualité et resserre par dichotomie, ce qui trouve la meilleure
+        qualité qui tienne en huit encodages environ. Chaque taille affichée sur la
+        page est un vrai fichier encodé, pas une estimation."""
+
+[[faq]]
+q = "Que veut dire &laquo;&nbsp;perte minimale&nbsp;&raquo; exactement, ici&nbsp;?"
+a = """
+        Trois choses précises. D'abord, une image déjà sous votre taille visée est
+        transmise octet pour octet plutôt que réencodée. Ensuite, la qualité est
+        dépensée avant la résolution, et seulement jusqu'à un plancher où les
+        artefacts de compression commencent à se voir &mdash; en dessous, l'outil
+        réduit l'image et remonte la qualité, parce que moins de bons pixels valent
+        mieux que davantage de pixels abîmés. Enfin, une fois trouvé un résultat qui
+        tient, la recherche remonte jusqu'à épuiser le budget&nbsp;: vous n'obtenez
+        donc pas un fichier de 300 KB quand vous en avez demandé 500."""
+
+[[faq]]
+q = "Que sont les valeurs SSIM et PSNR sur chaque résultat&nbsp;?"
+a = """
+        Ce sont des mesures de ce que la compression a coûté, prises en décodant le
+        résultat et en le comparant à l'image d'origine. Le SSIM compare la
+        luminosité, le contraste et la structure locales, ce qui est bien plus proche
+        de ce qui gêne un œil que le comptage des pixels modifiés&nbsp;; au-dessus de
+        0,98 environ, les deux sont difficiles à distinguer côte à côte. Le PSNR est
+        le chiffre en décibels traditionnel. Les deux sont calculés sur votre machine,
+        et les deux sont affichés pour que l'affirmation d'une faible perte soit
+        vérifiable plutôt que simplement énoncée."""
+
+[[faq]]
+q = "Quels formats sait-il lire et écrire&nbsp;?"
+a = """
+        Il lit tout ce que votre navigateur sait décoder, ce qui en pratique veut dire
+        JPEG, PNG, WebP, GIF, BMP et &mdash; sur la plupart des navigateurs actuels
+        &mdash; AVIF. Il écrit du JPEG, du PNG et du WebP, parce que ce sont les
+        encodeurs que les navigateurs embarquent. En mode
+        &laquo;&nbsp;auto&nbsp;&raquo;, il garde le format dans lequel votre fichier
+        est arrivé et ne bascule sur WebP que lorsque le garder aurait imposé un
+        redimensionnement ou une baisse de qualité visible."""
+
+[[faq]]
+q = "Pourquoi ne peut-il pas compresser un PNG bien loin&nbsp;?"
+a = """
+        Parce que le PNG est sans perte&nbsp;: il n'a aucune molette de qualité à
+        tourner. Le seul moyen de réduire un PNG est de lui donner moins de pixels ou
+        moins de couleurs&nbsp;; avec PNG sélectionné, l'outil atteint donc une cible
+        par le redimensionnement seul. Si l'image est une photographie, le JPEG ou le
+        WebP s'approcheront bien davantage de votre cible, à une qualité dont vous
+        verrez qu'elle convient &mdash; et s'il s'agit d'un logo ou d'une capture
+        d'écran avec transparence, le WebP garde la transparence que le JPEG
+        remplirait de blanc."""
+
+[[faq]]
+q = "Compresser une image supprime-t-il ses données EXIF et GPS&nbsp;?"
+a = """
+        Oui, par effet de bord. Compresser, c'est décoder l'image en pixels puis
+        réencoder ces pixels, et un canvas plein de pixels ne porte aucune
+        étiquette&nbsp;: le lieu, le modèle d'appareil, les horodatages et tout le
+        reste ne sont simplement pas écrits dans le nouveau fichier. Si vous voulez
+        que les métadonnées disparaissent mais que l'image reste intacte, prenez
+        plutôt le <a href="../supprimer-les-donnees-exif/">lecteur et effaceur
+        EXIF</a> &mdash; il réécrit le conteneur sans rien recompresser."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Il n'y a pas non plus de limite au nombre ni à la
+        taille des fichiers, parce qu'aucun serveur ne les paie &mdash; le travail se
+        fait sur votre propre machine. Le site porte de la publicité, et c'est elle
+        qui le finance&nbsp;; les annonces ne reçoivent rien sur vos images."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait vos images ailleurs pour les compresser
+        s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Compressez des images JPEG, PNG et WebP à une taille que vous nommez. L'outil cherche la meilleure qualité qui tienne dans la cible, ne redimensionne que lorsque la qualité seule n'y suffit pas, et mesure le résultat par rapport à l'original. Tout se passe dans le navigateur, sans aucun envoi."
+features = [
+  "Compresse vers une taille de fichier que vous choisissez, pas vers un chiffre de qualité à deviner",
+  "Garde la pleine résolution quand il le peut, et ne redimensionne que si la qualité seule n'atteint pas la cible",
+  "Dépense tout le budget : le résultat arrive juste sous la cible plutôt que loin en dessous",
+  "Mesure le résultat par rapport à l'original avec le SSIM et le PSNR",
+  "Laisse totalement intacts les fichiers déjà sous la cible",
+  "JPEG, PNG et WebP, avec un choix de format automatique",
+  "Traitement par lots, tous les résultats dans un seul zip",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]
+
+[picker]
+title = "Déposez vos images ici"
+hint = "ou cliquez pour parcourir &mdash; JPEG, PNG, WebP et tout ce que votre navigateur sait ouvrir"

--- a/locales/fr/tools/compress-pdf.html
+++ b/locales/fr/tools/compress-pdf.html
@@ -1,0 +1,162 @@
+<main>
+  <!-- Étape 1 &mdash; le fichier -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir un PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="file-row" class="file-row" hidden>
+      <div class="file-facts">
+        <strong id="file-name" class="file-name"></strong>
+        <span id="file-facts" class="file-sub"></span>
+      </div>
+      <button type="button" id="clear-file" class="ghost danger">En choisir un autre</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Step 2 &mdash; the screen this tool would keep if it could keep only one -->
+  <section class="card" id="inventory-card" hidden>
+    <h2><span class="step">2</span> Voir où est le poids</h2>
+
+    <p class="card-lede">
+      &laquo;&nbsp;Compresser un PDF&nbsp;&raquo;, ce sont deux métiers
+      différents qui partagent un nom. Un scan est une pile de photographies, et
+      les réencoder vaut l'essentiel du fichier. Un contrat, c'est du texte et
+      des polices, que ce qui l'a produit avait déjà compressés &mdash; il n'y a
+      pas quatre-vingts pour cent cachés dedans, et aucun outil ne peut en
+      trouver. Lequel des deux vous avez n'est pas affaire d'opinion&nbsp;: le
+      voici donc avant qu'on touche à quoi que ce soit.
+    </p>
+
+    <p id="verdict" class="verdict"></p>
+
+    <div class="breakdown">
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <ul id="breakdown-list" class="breakdown-list"></ul>
+    </div>
+
+    <p id="inventory-notes" class="field-summary"></p>
+  </section>
+
+  <!-- Étape 3 &mdash; combien dépenser -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">3</span> Dire jusqu'où serrer</h2>
+
+    <p class="card-lede">
+      Un PDF enregistre la taille à laquelle chaque image est dessinée&nbsp;: cet
+      outil peut donc mesurer ce que la page utilise vraiment, au lieu de le
+      deviner. Un scan de 4000 pixels étalé sur vingt centimètres de papier
+      transporte 500 pixels par pouce&nbsp;; à 150, il s'imprime pareil et se
+      regarde pareil à l'écran. Les pixels que personne ne voit sont dépensés en
+      premier, parce qu'ils ne coûtent rien.
+    </p>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Quelle part de qualité peut être dépensée</legend>
+      <div class="presets" id="presets" role="radiogroup" aria-label="Quelle part de qualité peut être dépensée">
+        <label class="preset">
+          <input type="radio" name="preset" value="smallest">
+          <span class="preset-body">
+            <strong>Le plus léger</strong>
+            <span class="preset-note">96 DPI. Pour ce qui n'a qu'à se lire à l'écran.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="screen" checked>
+          <span class="preset-body">
+            <strong>Bien à l'écran</strong>
+            <span class="preset-note">130 DPI. La réponse habituelle pour un fichier à envoyer par courriel.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="print">
+          <span class="preset-body">
+            <strong>Encore bien sur papier</strong>
+            <span class="preset-note">220 DPI. Plus léger, et il s'imprimera toujours correctement.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="gentle">
+          <span class="preset-body">
+            <strong>Toucher à peine aux images</strong>
+            <span class="preset-note">Aucun redimensionnement. L'essentiel du gain vient du réempaquetage du fichier.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <details class="advanced">
+      <summary>Régler les deux nombres vous-même</summary>
+      <div class="option-row">
+        <label for="dpi-value">Pixels au maximum par pouce d'espace dessiné</label>
+        <div class="inline-pair">
+          <input type="number" id="dpi-value" min="0" max="1200" step="10" value="130" inputmode="numeric">
+          <span class="unit">DPI &mdash; 0 laisse chaque image à sa taille pleine</span>
+        </div>
+      </div>
+      <div class="option-row">
+        <label for="quality-value">Qualité JPEG</label>
+        <div class="inline-pair">
+          <input type="range" id="quality-value" min="30" max="95" step="1" value="68">
+          <output id="quality-out" for="quality-value">68</output>
+        </div>
+      </div>
+    </details>
+
+    <label class="check">
+      <input type="checkbox" id="strip-meta" checked>
+      <span>
+        <strong>Enlever ce que le fichier retient de sa provenance</strong>
+        <span class="check-note">
+          Le nom et la version du programme qui l'a fabriqué, la date de création
+          et de dernière modification, le paquet XMP, et le bloc privé qu'une
+          application de mise en page laisse derrière elle pour pouvoir
+          réimporter son propre travail &mdash; ce qui fait parfois plusieurs
+          mégaoctets. Rien de tout cela n'est nécessaire pour afficher le
+          document.
+        </span>
+      </span>
+    </label>
+
+    <p id="settings-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Étape 4 &mdash; le clic unique -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Compresser</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Compresser ce PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Télécharger</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <details id="per-image" class="advanced" hidden>
+        <summary>Ce qui est arrivé à chaque image</summary>
+        <ul id="image-list" class="image-list"></ul>
+      </details>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/compress-pdf.toml
+++ b/locales/fr/tools/compress-pdf.toml
@@ -1,0 +1,267 @@
+#
+# Compresseur de PDF - French.
+#
+# Overrides for tools/compress-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Compresseur de PDF"
+heading = "Compresser&nbsp;un&nbsp;PDF <span class=\"h1-kw\">&mdash; alléger un document</span>"
+tagline = "Alléger un document sans l'envoyer où que ce soit."
+
+title = "Compresser un PDF &mdash; gratuit, dans votre navigateur, sans envoi"
+description = "Alléger un PDF sans l'envoyer. Le fichier est lu, recompressé et réécrit par votre propre navigateur, et l'outil vous montre où se trouve vraiment son poids avant de toucher à quoi que ce soit."
+og_title = "Compresser un PDF &mdash; gratuit, et rien n'est envoyé"
+og_description = "Allégez un PDF sur votre propre machine. L'outil mesure la taille à laquelle chaque image est réellement dessinée sur la page, et ne jette donc que des pixels que personne ne pouvait voir."
+og_image_alt = "Compresser un PDF - alléger un document sans l'envoyer"
+
+pledge = """
+    Le document est ouvert, démonté et réécrit en mémoire sur cette machine, par
+    du code servi depuis cette adresse. Rien ici ne sait faire un envoi, et il
+    n'y a à l'autre bout de cette page aucun serveur pour en recevoir un."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et compressez un fichier. Pas une seule
+      requête ne transporte de page, d'image ni de nom de fichier. Ou coupez
+      votre connexion et compressez-en un quand même."""
+
+read_first = """
+, ainsi que <code>src/reader.js</code> et <code>src/writer.js</code>
+      pour la totalité de la lecture et de la réécriture, dont aucun des deux ne
+      peut atteindre le réseau."""
+
+howto_heading = "Comment alléger un PDF"
+
+card = """
+            Alléger un document en recompressant les images qu'il contient. Il
+            vous montre d'abord où se trouve vraiment le poids, et dit
+            franchement quand il n'y a rien à gagner."""
+
+[words]
+plural = "documents"
+choose = "un PDF"
+analytics_extra = """"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[facts]]
+text = "Les fichiers restent sur votre appareil"
+
+[[privacy]]
+title = "Votre document n'a nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Cet outil n'ajoute rien à
+      cette liste&nbsp;: il n'a aucune fonction réseau propre, pas même
+      facultative. Il n'y a ici aucun point de collecte où votre fichier
+      pourrait arriver, et rien dans le code qui l'y enverrait s'il en existait
+      un."""
+
+[[privacy]]
+title = "Le format entier est dans ce dépôt."
+body = """
+ Un PDF, c'est une liste
+      d'objets et une table qui dit où chacun commence.
+      <code>src/objects.js</code> lit cette syntaxe, <code>src/reader.js</code>
+      suit la table, <code>src/writer.js</code> en écrit une nouvelle, et aucun
+      des trois n'importe quoi que ce soit capable de faire une requête. Aucune
+      bibliothèque n'est récupérée et rien n'est rendu sur un serveur."""
+
+[[privacy]]
+title = "Les fichiers chiffrés sont refusés plutôt qu'ouverts."
+body = """
+
+      Un PDF protégé par mot de passe est refusé, y compris celui que produisent
+      les scanners avec un mot de passe vide et qui s'ouvrirait techniquement.
+      Retirer la protection d'un document est un autre métier que l'alléger, et
+      le faire en douce serait une drôle d'initiative pour un outil."""
+
+[[privacy]]
+title = "Il enlève des choses plutôt qu'il n'en ajoute."
+body = """
+ Le fichier fini ne porte
+      ni date de création, ni ligne de producteur, ni nom de l'outil qui l'a
+      fabriqué. Avec la case cochée, il perd aussi le paquet XMP et les blocs
+      privés que laissent derrière elles les applications de mise en page
+      &mdash; le même argument que celui de l'outil EXIF, appliqué à un autre
+      conteneur."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google. Ni l'un ni l'autre ne
+      reçoit quoi que ce soit sur votre document&nbsp;: ni un fichier, ni une
+      page, ni un nom, une taille ou un nombre de pages. Chaque ligne qui lit,
+      décode ou écrit un PDF est servie depuis cette origine et figure dans le
+      dépôt."""
+
+[[privacy]]
+title = "Ce que le bouton de don charge, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; dans l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et se compose avec Google
+      Fonts. C'est un lien, rien de plus&nbsp;: il ne signale aucune visite, et
+      on ne lui donne rien sur vous ni sur votre document. Rien ne se passe tant
+      que vous ne cliquez pas, et ce vers quoi vous cliqueriez est le site de
+      quelqu'un d'autre."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et tout sur cette page
+      fonctionne encore. C'est la preuve la plus simple de toutes&nbsp;: un
+      outil qui expédierait votre document ailleurs pour le compresser
+      s'arrêterait."""
+
+[[howto]]
+title = "Choisissez un PDF."
+body = """
+ Déposez-le sur la zone prévue ou
+      sélectionnez-le à la main. Le navigateur le lit directement sur votre
+      disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Regardez où est le poids."
+body = """
+ La répartition est tout
+      l'intérêt de la deuxième étape. Si la barre est surtout faite d'images,
+      cet outil a de quoi travailler. Si elle est surtout faite de polices et de
+      contenu de page, il le dira, et l'économie honnête sera de quelques pour
+      cent &mdash; autant le savoir avant d'y passer une minute."""
+
+[[howto]]
+title = "Dites jusqu'où serrer."
+body = """
+ Les réglages nommés sont des
+      résolutions, pas des mentions vagues&nbsp;: 96 DPI pour lire à l'écran,
+      130 pour envoyer par courriel, 220 pour ce qui doit encore s'imprimer.
+      Chacun est comparé à la taille à laquelle l'image est réellement dessinée
+      sur la page, si bien qu'une photo posée en vignette n'est pas traitée
+      comme un scan pleine page."""
+
+[[howto]]
+title = "Compressez, puis lisez la ligne qui dit que c'est vérifié."
+body = """
+
+      Une fois la réécriture faite, le fichier fini est rouvert par le même
+      lecteur, sur cette page, et ses pages sont comptées. Si le compte ne
+      correspond pas à l'original, l'opération est signalée comme échouée et
+      aucun téléchargement n'est proposé."""
+
+[[faq]]
+q = "Mon PDF est-il envoyé quelque part&nbsp;?"
+a = """
+        Non. Le fichier est lu, recompressé et écrit par votre propre navigateur sur
+        votre propre matériel. Cet outil n'a pas de côté serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter &mdash; aucune n'appartient à ce site. Cet outil n'a
+        aucune fonction réseau, pas même facultative."""
+
+[[faq]]
+q = "De combien mon PDF va-t-il maigrir&nbsp;?"
+a = """
+        Cela dépend entièrement de ce qu'il contient, et c'est pour cela que l'outil
+        mesure et vous montre avant de compresser quoi que ce soit. Un document
+        numérisé n'est presque que des photographies et ressort couramment 60 à 90&nbsp;%
+        plus léger. Un contrat ou une thèse, c'est du texte, du dessin vectoriel et
+        des polices incorporées, tous déjà compressés par ce qui les a produits&nbsp;;
+        là, l'économie est en général de quelques pour cent, obtenue en réempaquetant
+        le fichier et en jetant ce que plus rien ne référence. Tout outil qui promet
+        un pourcentage fixe sans regarder votre fichier devine."""
+
+[[faq]]
+q = "Compresser un PDF fait-il perdre de la qualité&nbsp;?"
+a = """
+        Les images qu'il contient sont réencodées, donc oui, pour elles. Rien d'autre
+        n'est touché&nbsp;: le texte reste du texte, sélectionnable et cherchable, les
+        polices sont gardées entières, et le dessin vectoriel est recopié à
+        l'identique. L'outil refuse aussi d'abîmer une image pour rien &mdash; si un
+        réencodage ne ressort pas plus petit que l'original, ce sont les octets
+        d'origine qui retournent dans le document, intacts."""
+
+[[faq]]
+q = "Qu'est-ce que le DPI ici, et pourquoi le demande-t-il&nbsp;?"
+a = """
+        Un PDF enregistre la taille à laquelle chaque image est dessinée sur la page,
+        ce qui permet à l'outil d'en déduire la résolution effective&nbsp;: un scan de
+        4000 pixels étalé sur vingt centimètres de papier transporte 500 pixels par
+        pouce. Rien à l'écran et très peu de choses sur le papier ne savent en faire
+        quoi que ce soit, alors les pixels au-dessus du réglage que vous choisissez
+        partent en premier &mdash; ils coûtent une qualité que personne ne voit. C'est
+        cette mesure qui fait qu'un logo posé en petit n'est pas traité comme un scan
+        pleine page."""
+
+[[faq]]
+q = "Peut-il ouvrir un PDF protégé par mot de passe&nbsp;?"
+a = """
+        Non, et c'est délibéré. Un document chiffré est refusé avec un message qui le
+        dit, même quand le mot de passe est vide &mdash; ce qui est la façon dont
+        enregistrent beaucoup de scanners et de photocopieurs. Retirer la protection
+        d'un fichier est un autre métier que le compresser, et un outil qui le ferait
+        en silence ferait quelque chose que vous n'avez pas demandé."""
+
+[[faq]]
+q = "Y a-t-il des PDF qu'il ne sait pas compresser&nbsp;?"
+a = """
+        Certaines images à l'intérieur, oui. Les images JPEG 2000, JBIG2 et codées fax
+        (CCITT) n'ont de décodeur dans aucun navigateur&nbsp;: elles sont transmises
+        intactes et signalées comme telles &mdash; les deux dernières sont des codecs
+        bitonaux et sont de toute façon en général déjà au plus petit. Les images CMJN
+        sont laissées tranquilles elles aussi, parce que les réencoder risquerait de
+        déplacer les couleurs qu'une imprimerie produirait. Tout ce que l'outil passe
+        est nommé dans les résultats, avec la raison."""
+
+[[faq]]
+q = "Le fichier compressé s'ouvrira-t-il encore partout&nbsp;?"
+a = """
+        Oui. La sortie est écrite en PDF 1.5, que comprend tout lecteur sorti depuis
+        2003, et l'outil le prouve sur votre propre machine&nbsp;: il rouvre le
+        fichier fini et compte ses pages avant de vous le proposer. Les formulaires,
+        les liens, les signets, la structure d'accessibilité et les pièces jointes
+        incorporées sont repris&nbsp;; ce qui reste en arrière est la matière à
+        laquelle plus rien dans le document ne renvoyait."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas d'autre limite de taille que ce que permet la mémoire de votre
+        propre machine. Le site porte de la publicité, et c'est elle qui le
+        finance&nbsp;; les annonces ne reçoivent rien sur votre document."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait votre document ailleurs pour le
+        compresser s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Compressez un PDF dans votre navigateur. Les images sont recompressées par rapport à la taille à laquelle elles sont réellement dessinées sur la page, et le document est réécrit localement, si bien qu'aucun fichier n'est jamais envoyé."
+features = [
+  "Montre où se trouve vraiment le poids d'un document avant de compresser quoi que ce soit",
+  "Recompresse les images par rapport à leur résolution mesurée sur la page",
+  "Laisse une image tranquille quand la réencoder ne l'allégerait pas",
+  "Jette les objets laissés par une modification précédente, et les métadonnées facultatives",
+  "Rouvre et vérifie le fichier fini avant de le proposer",
+  "Fonctionne hors ligne ; sans envoi, sans compte, sans limite de taille",
+]
+
+[picker]
+title = "Déposez un PDF ici"
+hint = "ou cliquez pour parcourir &mdash; un document à la fois"

--- a/locales/fr/tools/crop-video.html
+++ b/locales/fr/tools/crop-video.html
@@ -1,0 +1,147 @@
+<main>
+  <!-- Étape 1 &mdash; le fichier -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir une vidéo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Fichier</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Taille</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Image</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durée</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Vidéo</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Audio</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; le recadrage -->
+  <section class="card" id="crop-card" hidden>
+    <h2><span class="step">2</span> Poser le recadrage</h2>
+
+    <p class="stage-hint">
+      Faites glisser depuis l'intérieur du cadre pour le déplacer, ou par un coin
+      pour le redimensionner. Le cadre étant sélectionné, les flèches le
+      déplacent d'un pixel à la fois,
+      <kbd>Alt</kbd>&nbsp;+&nbsp;flèches le redimensionnent, et maintenir
+      <kbd>Maj</kbd> fait passer chaque pas à dix.
+    </p>
+
+    <!-- The crop box itself is added here by src/cropper.js. The stage is given
+         the video's own shape, so the box can be positioned in percentages and
+         needs no recalculating when the window is resized. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <div class="crop-controls">
+      <div class="aspect-row" role="group" aria-label="Verrouiller le recadrage sur une forme">
+        <button type="button" data-aspect="free" class="active">Libre</button>
+        <button type="button" data-aspect="source">Original</button>
+        <button type="button" data-aspect="1:1">1:1</button>
+        <button type="button" data-aspect="4:5">4:5</button>
+        <button type="button" data-aspect="9:16">9:16</button>
+        <button type="button" data-aspect="16:9">16:9</button>
+        <button type="button" data-aspect="4:3">4:3</button>
+        <button type="button" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="ghost" title="Basculer la forme verrouillée sur le côté">
+          Basculer
+        </button>
+      </div>
+
+      <div class="numbers">
+        <label>Gauche<input type="number" id="crop-x" min="0" step="1"></label>
+        <label>Haut<input type="number" id="crop-y" min="0" step="1"></label>
+        <label>Largeur<input type="number" id="crop-w" min="16" step="2"></label>
+        <label>Hauteur<input type="number" id="crop-h" min="16" step="2"></label>
+        <div class="number-actions">
+          <button type="button" id="crop-max" class="ghost">Le plus grand</button>
+          <button type="button" id="crop-centre" class="ghost">Centrer</button>
+          <button type="button" id="crop-reset" class="ghost">Image entière</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="even-note">
+      La largeur et la hauteur avancent par deux, parce que le H.264 n'a aucun
+      moyen de stocker une image à côté impair.
+    </p>
+  </section>
+
+  <!-- Étape 3 &mdash; l'export -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Recadrer</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Sortie</label>
+        <select id="format">
+          <option value="mp4" selected>MP4 &mdash; réencodé image par image</option>
+          <option value="webm">WebM &mdash; enregistré pendant la lecture</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Qualité</label>
+        <select id="quality">
+          <option value="low">Fichier plus léger</option>
+          <option value="medium" selected>Équilibré</option>
+          <option value="high">Meilleure qualité</option>
+        </select>
+        <p class="field-note">
+          Jamais plus que ce que l'original dépensait sur la même zone &mdash;
+          réencoder au-dessus ne fait que grossir le fichier.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Garder le son
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Image de sortie</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Gardé</dt><dd id="sum-kept">&mdash;</dd></div>
+      <div><dt>Durée</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Comment</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Recadrer la vidéo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Télécharger la vidéo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/crop-video.toml
+++ b/locales/fr/tools/crop-video.toml
@@ -1,0 +1,247 @@
+#
+# Recadreur de vidéos - French.
+#
+# Overrides for tools/crop-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Recadreur de vidéos"
+heading = "Recadrer&nbsp;une&nbsp;vidéo <span class=\"h1-kw\">&mdash; recadrer une vidéo en ligne</span>"
+tagline = "Ramener un clip à ce qui compte dedans."
+
+title = "Recadrer une vidéo en ligne &mdash; gratuit, sans envoi, hors ligne"
+description = "Recadrez un MP4, un MOV ou un WebM dans n'importe quelle forme - carré, 9:16, ou un cadre en pixels exact. Tout se passe dans votre navigateur : rien n'est envoyé, le son est gardé, fonctionne hors ligne."
+og_title = "Recadreur de vidéos &mdash; recadrer un clip sans l'envoyer"
+og_description = "Tracez un cadre sur votre clip et recadrez-le dans la forme que vous voulez. Les images sont décodées et réencodées sur votre propre machine, et le son d'origine est repris intact."
+og_image_alt = "Recadreur de vidéos - recadrer un clip dans votre navigateur, sans rien envoyer"
+
+pledge = """
+    Chaque image est décodée, recadrée et encodée par votre propre navigateur,
+    sur votre propre matériel. Rien ici ne sait récupérer ni envoyer quoi que ce
+    soit &mdash; cet outil n'a aucune fonction réseau &mdash; et il n'y a à
+    l'autre bout de cette page aucun serveur auquel envoyer une vidéo, quand
+    bien même il y en aurait une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et recadrez un clip. Pas une seule requête
+      ne transporte d'image, de nom de fichier ni un octet de ce que vous avez
+      choisi. Ou coupez votre connexion et recadrez-en un quand même &mdash; un
+      outil qui expédierait votre vidéo ailleurs pour la traiter s'arrêterait
+      tout simplement."""
+
+read_first = """
+, <code>src/demux.js</code> pour le lecteur qui trouve
+      les images dans un MP4, et <code>src/transcode.js</code> pour la boucle qui
+      les décode, les recadre et les encode. Ni l'un ni l'autre n'importe quoi
+      que ce soit capable de faire une requête."""
+
+howto_heading = "Comment recadrer une vidéo"
+
+card = """
+            Tracez un cadre sur un clip et ramenez-le à cette forme &mdash; carré
+            pour un fil, vertical pour un téléphone, ou un cadre en pixels
+            exact."""
+
+[words]
+plural = "vidéos"
+choose = "une vidéo"
+analytics_extra = """, ni
+  image, durée ou taille de recadrage"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans filigrane"
+
+[[facts]]
+text = "Garde le son"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[privacy]]
+title = "Vos vidéos n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où votre fichier pourrait arriver, et rien dans le code qui l'y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Cet outil n'a aucune fonction
+      réseau&nbsp;: pas d'adresse à coller, rien à télécharger, aucun moteur
+      récupéré à la première utilisation. Chaque octet qui touche à votre vidéo
+      vient de cette origine, au chargement de la page."""
+
+[[privacy]]
+title = "Le décodage et l'encodage sont locaux."
+body = """
+ Les images passent par
+      WebCodecs dans votre propre navigateur, ou par le même moteur de lecture
+      qui vous montrerait le clip de toute façon. Le fichier fini est construit
+      en mémoire sur cette machine et remis directement à un
+      téléchargement."""
+
+[[privacy]]
+title = "Le son est copié, pas écouté."
+body = """
+ Sur le chemin MP4, les
+      échantillons audio sont déplacés sans être décodés du tout &mdash; rien
+      ici ne les retransforme jamais en son, et rien ne saurait les faire passer
+      où que ce soit si c'était le cas."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit
+      quoi que ce soit sur votre vidéo&nbsp;: ni un fichier, ni une image, ni un
+      nom, une taille, une durée ou la forme à laquelle vous l'avez recadrée.
+      Chaque ligne qui lit, décode, recadre ou encode est servie depuis cette
+      origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Ce que le bouton de don charge, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; dans l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et se compose avec Google
+      Fonts. C'est un lien, rien de plus&nbsp;: il ne signale aucune visite, et
+      on ne lui donne rien sur vous ni sur votre vidéo."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et tout sur cette
+      page fonctionne encore. C'est la preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez une vidéo."
+body = """
+ Déposez un MP4, un MOV, un M4V ou
+      un WebM sur la zone prévue, ou sélectionnez-en un à la main. Le navigateur
+      le lit directement sur votre disque&nbsp;; rien n'est envoyé nulle part
+      pendant ce temps."""
+
+[[howto]]
+title = "Tracez le cadre sur la partie à garder."
+body = """
+ Faites-le
+      glisser depuis l'intérieur pour le déplacer, et par un coin pour le
+      redimensionner. Verrouillez-le d'abord sur une forme &mdash; 1:1 pour un
+      post carré, 9:16 pour un téléphone, 16:9 pour un cadre large &mdash; ou
+      tapez un cadre en pixels exact dans les quatre champs en dessous."""
+
+[[howto]]
+title = "Choisissez combien de qualité dépenser."
+body = """
+ L'image doit être
+      réencodée, parce qu'une image recadrée est une autre image.
+      &laquo;&nbsp;Équilibré&nbsp;&raquo; reste proche de ce que le fichier
+      dépensait déjà sur cette zone&nbsp;; &laquo;&nbsp;Meilleure
+      qualité&nbsp;&raquo; dépense davantage. Le son est gardé, sauf si vous le
+      coupez."""
+
+[[howto]]
+title = "Recadrez et téléchargez."
+body = """
+ Le travail se fait sur votre
+      propre matériel&nbsp;: la durée dépend donc de votre machine et non d'une
+      file d'attente. La vidéo finie est remise directement aux téléchargements
+      de votre navigateur."""
+
+[[faq]]
+q = "Ma vidéo est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. Elle est lue, décodée, recadrée et encodée par votre propre navigateur
+        sur votre propre matériel. Cet outil n'a pas de côté serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter &mdash; aucune n'appartient à ce site. Coupez votre
+        connexion et recadrez un clip quand même, si vous préférez vérifier plutôt
+        qu'on vous le dise."""
+
+[[faq]]
+q = "Quels formats vidéo puis-je recadrer&nbsp;?"
+a = """
+        Le MP4, le M4V et le MOV sont lus directement, quel que soit leur
+        contenu&nbsp;: H.264, HEVC, AV1 ou VP9, du moment que votre navigateur sait
+        décoder ce codec. Tout le reste que votre navigateur sait lire &mdash; le WebM
+        au premier chef &mdash; est recadré en le jouant et en enregistrant le
+        résultat, ce qui marche mais prend le temps que dure le clip. Un fichier que
+        le navigateur ne sait ni lire ni jouer, ce qui en pratique veut dire l'AVI, le
+        WMV, le FLV et la plupart des MKV, est refusé avec un message qui le dit,
+        plutôt que d'échouer à mi-course."""
+
+[[faq]]
+q = "Y a-t-il une limite de taille ou de durée&nbsp;?"
+a = """
+        Aucune limite n'est intégrée à l'outil, et le fichier n'est pas chargé en
+        mémoire d'un seul coup &mdash; il est parcouru quelques mégaoctets à la fois.
+        Le plafond pratique, c'est la vidéo finie, assemblée en mémoire avant que vous
+        la téléchargiez, et le temps que votre machine met à l'encoder."""
+
+[[faq]]
+q = "Le son survit-il&nbsp;?"
+a = """
+        Sur le chemin MP4, exactement&nbsp;: l'audio est recopié échantillon par
+        échantillon sans jamais être décodé, il est donc octet pour octet ce qu'il y
+        avait dans le fichier. Sur le chemin par enregistrement, il est capté à la
+        lecture et réencodé, ce qui coûte un peu de qualité. Dans les deux cas, une
+        case permet de le laisser entièrement de côté."""
+
+[[faq]]
+q = "Recadrer fait-il perdre de la qualité&nbsp;?"
+a = """
+        L'image est réencodée, parce qu'une image recadrée est une autre image et
+        qu'il n'y a aucun moyen de la stocker sans réécrire les pixels. Ce que l'outil
+        ne fera pas, c'est dépenser plus que l'original ne dépensait sur la même zone,
+        puisque réencoder au-dessus ne fait que grossir le fichier sans l'améliorer."""
+
+[[faq]]
+q = "Puis-je aussi raccourcir la durée&nbsp;?"
+a = """
+        Pas ici, mais juste à côté. Cet outil change la forme de l'image et rien
+        d'autre&nbsp;: le clip qui sort dure exactement aussi longtemps que celui qui
+        est entré, avec son rythme et son son intacts. Couper est un autre métier et
+        c'est un autre outil &mdash; le
+        <a href="../couper-une-video/">coupeur de vidéos</a> marque les passages d'un
+        clip qui valent d'être gardés et les enregistre en un seul fichier, sans
+        réencoder une image."""
+
+[[faq]]
+q = "Pourquoi la largeur et la hauteur avancent-elles par deux&nbsp;?"
+a = """
+        Le H.264, le codec d'un MP4, stocke l'image par blocs et n'a aucun moyen de
+        décrire une image dont un côté ferait un nombre impair de pixels. Plutôt que
+        d'arrondir votre recadrage en silence une fois posé, le cadre ne propose que
+        des nombres pairs dès le départ."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Le site porte de la publicité, et c'est elle qui
+        le finance&nbsp;; les annonces ne reçoivent rien sur votre vidéo."""
+
+[schema]
+browser_requirements = "Nécessite JavaScript. La sortie MP4 demande un navigateur avec WebCodecs ; les autres se rabattent sur un enregistrement WebM."
+description = "Recadrez une vidéo dans n'importe quelle forme ou dans un cadre en pixels exact, depuis le navigateur. Les MP4, MOV et M4V sont décodés et réencodés image par image, avec l'audio d'origine repris intact ; tout ce que le navigateur sait jouer est recadré par enregistrement. Rien n'est envoyé."
+features = [
+  "Recadre des vidéos MP4, MOV, M4V et WebM",
+  "Sources H.264, HEVC, AV1 et VP9, décodées par WebCodecs",
+  "Recadrage libre, proportions verrouillées (1:1, 4:5, 9:16, 16:9, 4:3, 3:2) ou cadre en pixels exact",
+  "Garde l'audio d'origine sans le réencoder",
+  "Fonctionne hors ligne ; sans envoi, sans compte, sans filigrane",
+]
+
+[picker]
+title = "Déposez une vidéo ici"
+hint = "ou cliquez pour parcourir &mdash; MP4, MOV, M4V, WebM, et tout ce que ce navigateur sait jouer"

--- a/locales/fr/tools/edit-audio.html
+++ b/locales/fr/tools/edit-audio.html
@@ -1,0 +1,171 @@
+<main>
+  <!-- Étape 1 &mdash; le fichier -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir un fichier</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Fichier</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Taille</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Durée</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Son</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>Moment le plus fort</dt><dd id="src-peak">&mdash;</dd></div>
+      <div><dt>Lu comme</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <div class="wave-wrap" id="src-wave-wrap" hidden>
+      <canvas id="src-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="preview" controls preload="metadata"></audio>
+    </div>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; les modifications -->
+  <section class="card" id="edit-card" hidden>
+    <h2><span class="step">2</span> Le modifier</h2>
+
+    <div class="edit-block">
+      <label class="check" for="reverse">
+        <input type="checkbox" id="reverse">
+        Le passer à l'envers
+      </label>
+      <p class="field-note">
+        Les échantillons sont écrits du dernier au premier. Rien d'autre ne
+        change en eux&nbsp;: inverser deux fois rend donc exactement le fichier
+        de départ.
+      </p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="speed">Vitesse</label>
+        <input type="text" id="speed-value" class="value-box" inputmode="decimal"
+               spellcheck="false" autocomplete="off" aria-label="Vitesse, en multiple">
+      </div>
+
+      <!-- The slider is in octaves, not multiples: half speed and double speed
+           are then the same distance either side of the middle, which is how
+           they sound. main.js does the conversion. -->
+      <input type="range" id="speed" min="-2" max="2" step="0.01" value="0"
+             aria-describedby="speed-note">
+
+      <div class="presets" role="group" aria-label="Vitesses préréglées">
+        <button type="button" class="ghost" data-speed="0.5">0,5&times;</button>
+        <button type="button" class="ghost" data-speed="0.75">0,75&times;</button>
+        <button type="button" class="ghost" data-speed="1">1&times;</button>
+        <button type="button" class="ghost" data-speed="1.25">1,25&times;</button>
+        <button type="button" class="ghost" data-speed="1.5">1,5&times;</button>
+        <button type="button" class="ghost" data-speed="2">2&times;</button>
+      </div>
+
+      <fieldset class="modes">
+        <legend>Ce qui arrive à la hauteur</legend>
+        <label class="mode">
+          <input type="radio" name="pitch" value="keep" checked>
+          <span>
+            <strong>Garder la hauteur</strong>
+            Une voix reste la même voix, seulement plus rapide ou plus lente.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="pitch" value="move">
+          <span>
+            <strong>La laisser suivre</strong>
+            Plus vite, c'est plus aigu ; plus lent, plus grave, comme une bande.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="speed-note"></p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="volume">Volume</label>
+        <input type="text" id="volume-value" class="value-box" inputmode="decimal"
+               spellcheck="false" aria-label="Écart de volume, en décibels">
+      </div>
+
+      <input type="range" id="volume" min="-24" max="24" step="0.5" value="0"
+             aria-describedby="volume-note">
+
+      <fieldset class="modes">
+        <legend>À quel point le monter</legend>
+        <label class="mode">
+          <input type="radio" name="level" value="gain" checked>
+          <span>
+            <strong>De tant</strong>
+            Chaque échantillon multiplié par le même nombre. Rien d'autre ne change.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="level" value="normalize">
+          <span>
+            <strong>Aussi fort que possible</strong>
+            Remonté jusqu'à ce que le moment le plus fort se pose juste sous le plafond.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="volume-note"></p>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Durée</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Vitesse</dt><dd id="sum-speed">&mdash;</dd></div>
+      <div><dt>Moment le plus fort</dt><dd id="sum-peak">&mdash;</dd></div>
+      <div><dt>Environ</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="clip-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Étape 3 &mdash; le fichier qui sort -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> L'enregistrer</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">Ce qu'il faut écrire</label>
+        <select id="depth">
+          <option value="16" selected>WAV 16 bits &mdash; se lit partout</option>
+          <option value="32">WAV 32 bits flottant &mdash; rien n'est écrêté</option>
+        </select>
+        <p class="field-note" id="depth-note">
+          Un WAV garde les échantillons tels quels&nbsp;: en écrire un ne peut
+          donc pas coûter de qualité. Ce n'est pas un petit fichier&nbsp;: voyez
+          l'estimation ci-dessus.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary">Modifier l'audio</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Télécharger l'audio</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/edit-audio.toml
+++ b/locales/fr/tools/edit-audio.toml
@@ -1,0 +1,289 @@
+#
+# Éditeur audio - French.
+#
+# Overrides for tools/edit-audio/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Éditeur audio"
+heading = "Éditeur&nbsp;audio <span class=\"h1-kw\">&mdash; inverser, accélérer ou amplifier une piste</span>"
+tagline = "La passer à l'envers, changer la vitesse, relever un enregistrement trop faible &mdash; tout cela ici, sur votre machine."
+
+title = "Inverser un audio, changer la vitesse et monter le volume &mdash; gratuit, sans envoi"
+description = "Passez une piste à l'envers, accélérez-la ou ralentissez-la, et rendez plus fort un enregistrement trop faible. Récupère aussi le son d'une vidéo. Tout se passe dans votre navigateur : rien n'est envoyé."
+og_title = "Éditeur audio &mdash; inverser, retimer et amplifier sans rien envoyer"
+og_description = "Inversez une piste, changez sa vitesse avec ou sans déplacer la hauteur, réglez le niveau, puis téléchargez un WAV. Le fichier est lu et écrit par votre propre navigateur."
+og_image_alt = "Éditeur audio - inverser, retimer et amplifier un son dans votre navigateur"
+
+pledge = """
+    Votre fichier est lu, modifié et écrit par votre propre navigateur, sur votre
+    propre matériel. Rien ici ne sait récupérer ni envoyer quoi que ce soit
+    &mdash; cet outil n'a aucune fonction réseau &mdash; et il n'y a à l'autre
+    bout de cette page aucun serveur auquel envoyer un enregistrement, quand bien
+    même il y en aurait une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et inversez quelque chose. Pas une seule
+      requête ne transporte d'échantillon, de nom de fichier ni un octet de ce
+      que vous avez choisi. Ou coupez votre connexion et modifiez une piste quand
+      même &mdash; un outil qui expédierait votre audio ailleurs pour le traiter
+      s'arrêterait tout simplement."""
+
+read_first = """
+, <code>src/decode.js</code> pour les vingt lignes qui
+      remettent votre fichier au décodeur du navigateur,
+      <code>src/stretch.js</code> pour l'étirement temporel,
+      <code>src/speed.js</code> pour le rééchantillonneur, et
+      <code>src/wav.js</code> pour l'en-tête posé devant les échantillons. Aucun
+      d'eux n'importe quoi que ce soit capable de faire une requête."""
+
+howto_heading = "Comment modifier un fichier audio"
+
+card = """
+            Inversez une piste, changez sa vitesse avec ou sans déplacer la
+            hauteur, et remontez un enregistrement trop faible. Récupère aussi le
+            son d'une vidéo."""
+
+[words]
+plural = "enregistrements"
+choose = "un fichier"
+analytics_extra = """, ni
+  forme d'onde, durée ou niveau"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans filigrane"
+
+[[facts]]
+text = "Vidéo en entrée, audio en sortie"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[privacy]]
+title = "Vos enregistrements n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où votre fichier pourrait arriver, et rien dans le code qui l'y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Cet outil n'a aucune fonction
+      réseau&nbsp;: pas d'adresse à coller, rien à télécharger, aucun moteur
+      récupéré à la première utilisation. Chaque octet qui touche à votre audio
+      vient de cette origine, au chargement de la page."""
+
+[[privacy]]
+title = "Le décodeur est celui qui est déjà dans votre navigateur."
+body = """
+
+      Le fichier est remis à <code>decodeAudioData</code>, le code même qui joue
+      une piste dans un élément <code>&lt;audio&gt;</code>. Rien n'est livré ici
+      pour lire votre format, et rien n'est demandé non plus à quoi que ce soit
+      en dehors de cette page pour le lire."""
+
+[[privacy]]
+title = "L'image d'une vidéo n'est jamais décodée."
+body = """
+ Quand vous déposez une
+      vidéo, seule sa piste audio est demandée. Les images ne sont ni lues, ni
+      décodées, ni dessinées, ni regardées &mdash; il n'y a sur cette page aucun
+      code qui le pourrait, et le fichier qui en sort contient du son et rien
+      d'autre."""
+
+[[privacy]]
+title = "Les échantillons sont écrits, pas réencodés."
+body = """
+
+      Un WAV, ce sont les échantillons que cette page a calculés avec un en-tête
+      devant. Il n'y a dans la boucle aucun encodeur qui prendrait des décisions
+      sur votre enregistrement, et rien qu'on puisse décrire comme un envoi pour
+      qu'il s'en produise un."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit
+      quoi que ce soit sur votre enregistrement&nbsp;: ni un fichier, ni un
+      échantillon, ni un nom, une taille, une durée ou son niveau sonore. Chaque
+      ligne qui lit, modifie et écrit est servie depuis cette origine et figure
+      dans le dépôt."""
+
+[[privacy]]
+title = "Ce que le bouton de don charge, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; dans l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et se compose avec Google
+      Fonts. C'est un lien, rien de plus&nbsp;: il ne signale aucune visite, et
+      on ne lui donne rien sur vous ni sur votre fichier."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et tout sur cette
+      page fonctionne encore. C'est la preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez un fichier."
+body = """
+ Déposez un MP3, un WAV, un FLAC, un
+      M4A, un Ogg ou un Opus sur la zone prévue &mdash; ou une vidéo, si ce que
+      vous voulez, c'est le son qui est dedans. Le navigateur le lit directement
+      sur votre disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Retournez-la, si c'est pour cela que vous êtes venu."
+body = """
+ Une seule
+      case. Les échantillons sont écrits du dernier au premier, ce qui est
+      exactement réversible&nbsp;: faites-le deux fois et vous retrouvez le
+      fichier de départ, échantillon pour échantillon."""
+
+[[howto]]
+title = "Réglez la vitesse."
+body = """
+ Faites glisser le curseur, tapez un
+      multiple, ou appuyez sur l'un des préréglages. Choisissez ensuite ce qui
+      arrive à la hauteur&nbsp;: la tenir où elle est, ce que vous voulez pour un
+      cours à 1,5&times;, ou la laisser suivre la vitesse, ce que fait une bande
+      et ce qui fait monter ou descendre une voix."""
+
+[[howto]]
+title = "Réglez le niveau."
+body = """
+ Nommez un écart en décibels, ou demandez
+      que l'enregistrement soit remonté jusqu'à ce que son moment le plus fort se
+      pose juste sous le plafond. La page dit où ce moment atterrira avant que
+      vous appuyiez sur quoi que ce soit, et vous prévient si le réglage choisi
+      le pousserait au-delà de la pleine échelle."""
+
+[[howto]]
+title = "Enregistrez."
+body = """
+ Le travail se fait sur votre propre matériel&nbsp;:
+      la durée dépend donc de votre machine et non d'une file d'attente. Ce qui
+      sort est un WAV &mdash; les échantillons eux-mêmes, avec un en-tête devant
+      &mdash; d'abord rejoué sur la page, puis remis directement aux
+      téléchargements de votre navigateur."""
+
+[[faq]]
+q = "Mon audio est-il envoyé quelque part&nbsp;?"
+a = """
+        Non. Il est lu, modifié et écrit par votre propre navigateur sur votre propre
+        matériel. Cet outil n'a pas de côté serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter &mdash; aucune n'appartient à ce site. Coupez votre
+        connexion et inversez une piste quand même, si vous préférez vérifier plutôt
+        qu'on vous le dise."""
+
+[[faq]]
+q = "Puis-je récupérer le son d'une vidéo&nbsp;?"
+a = """
+        Oui, et c'est ici le même travail qu'ouvrir un MP3. Déposez un MP4, un MOV ou
+        un WebM et seule sa piste audio est décodée&nbsp;: l'image n'est jamais lue,
+        et ce qui sort est un fichier son sans vidéo dedans. C'est aussi la façon
+        d'enregistrer le son d'un clip sans le modifier du tout &mdash; ne touchez à
+        aucun réglage et appuyez sur le bouton."""
+
+[[faq]]
+q = "Changer la vitesse change-t-il la hauteur&nbsp;?"
+a = """
+        Seulement si vous le demandez. &laquo;&nbsp;Garder la hauteur&nbsp;&raquo;
+        découpe l'enregistrement en fenêtres qui se chevauchent, d'une cinquantaine de
+        millisecondes, et les repose plus serrées ou plus espacées, en choisissant
+        chaque position pour que les ondes se rejoignent au croisement &mdash; une
+        voix reste la même voix à 1,5&times;. &laquo;&nbsp;La laisser
+        suivre&nbsp;&raquo; rééchantillonne à la place, ce que fait une bande jouée
+        plus vite&nbsp;: deux fois la vitesse, c'est exactement une octave au-dessus."""
+
+[[faq]]
+q = "Pourquoi enregistre-t-il un WAV plutôt qu'un MP3&nbsp;?"
+a = """
+        Parce qu'aucun navigateur n'embarque d'encodeur MP3, et que cet outil refuse
+        d'envoyer votre enregistrement à un serveur qui en aurait un. Un WAV ne
+        demande aucun encodeur &mdash; ce sont les échantillons avec un en-tête de
+        quarante-quatre octets devant &mdash; c'est donc à la fois l'option honnête et
+        la seule qui ne puisse pas coûter de qualité. Il est plus gros&nbsp;: environ
+        dix mégaoctets la minute en stéréo. Tous les lecteurs, téléphones et éditeurs
+        en ouvrent un, et tout ce qui veut un MP3 peut en fabriquer un à partir de
+        là."""
+
+[[faq]]
+q = "Quels formats puis-je ouvrir&nbsp;?"
+a = """
+        Tout ce que votre navigateur décode, ce qui en pratique veut dire le MP3, le
+        WAV, le FLAC, le M4A et l'AAC, l'Ogg Vorbis et l'Opus, et l'audio contenu dans
+        les vidéos MP4, M4V, MOV et WebM. Ce qui reste dehors, c'est la même courte
+        liste que partout ailleurs&nbsp;: l'AVI, le WMA et la plupart des MKV. Un
+        fichier que ce navigateur refuse de lire est écarté avec un message qui le
+        dit, plutôt que d'échouer à mi-course."""
+
+[[faq]]
+q = "Le monter plus fort va-t-il le distordre&nbsp;?"
+a = """
+        Seulement si vous le poussez au-delà de la pleine échelle, et la page vous le
+        dit avant. L'audio numérique a un plafond dur&nbsp;: un échantillon ne peut
+        pas être plus fort que la pleine échelle, alors tout ce qui dépasse est aplati
+        contre le plafond, et c'est à cela que ressemble la distorsion.
+        &laquo;&nbsp;Aussi fort que possible&nbsp;&raquo; est le réglage qui ne peut
+        pas faire cela &mdash; il calcule la marge qui reste à l'enregistrement et
+        utilise exactement celle-là. En dessous du plafond, tout n'est que
+        multiplication&nbsp;: montez de 6 dB, redescendez de 6 dB, et les échantillons
+        sont là où ils étaient."""
+
+[[faq]]
+q = "Inverser ou retimer fait-il perdre de la qualité&nbsp;?"
+a = """
+        Inverser, non&nbsp;: ce sont les mêmes échantillons qui ressortent dans
+        l'autre ordre, ce qui est exact. Changer la vitesse déplace chaque
+        échantillon, c'est donc de l'arithmétique et non une copie &mdash; le
+        rééchantillonneur filtre correctement en chemin, si bien qu'accélérer ne
+        replie pas les aigus en un sifflement métallique, et les fenêtres de
+        l'étireur sont posées là où les ondes se rejoignent plutôt que là où le calcul
+        les aurait laissées. Aucun des deux chemins ne réencode quoi que ce soit,
+        parce qu'il n'y a ici aucun encodeur avec quoi réencoder."""
+
+[[faq]]
+q = "Y a-t-il une limite à la durée du fichier&nbsp;?"
+a = """
+        Aucune limite n'est intégrée à l'outil. Le plafond pratique, c'est la
+        mémoire&nbsp;: tout l'enregistrement est décodé d'un coup dans cette page, et
+        un WAV est assemblé en mémoire avant que vous le téléchargiez&nbsp;; une heure
+        de stéréo demande donc un peu moins d'un gigaoctet pour travailler. Un WAV de
+        quatre gigaoctets est refusé d'emblée, parce que le champ de taille du format
+        lui-même ne sait pas en décrire un."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Le site porte de la publicité, et c'est elle qui
+        le finance&nbsp;; les annonces ne reçoivent rien sur votre enregistrement."""
+
+[schema]
+browser_requirements = "Nécessite JavaScript et un navigateur doté de Web Audio, ce qui est le cas de tous les navigateurs actuels. Aucune prise en charge de codec au-delà de ce que le navigateur a déjà pour lire le fichier."
+description = "Inversez une piste audio, changez sa vitesse avec ou sans déplacer la hauteur, et réglez son niveau, depuis le navigateur. Fonctionne aussi sur l'audio contenu dans une vidéo. Rien n'est envoyé et le résultat est écrit en WAV, si bien que rien n'est réencodé."
+features = [
+  "Passe une piste à l'envers, exactement",
+  "Change la vitesse d'un quart à quatre fois, en gardant la hauteur ou en la déplaçant",
+  "Monte ou baisse le niveau, ou le normalise juste sous la pleine échelle",
+  "Récupère l'audio d'un MP4, d'un MOV ou d'un WebM sans toucher à l'image",
+  "Écrit du WAV 16 bits ou 32 bits flottant, sans encodeur dans la boucle",
+  "Fonctionne hors ligne ; sans envoi, sans compte, sans filigrane",
+]
+
+[picker]
+title = "Déposez un fichier audio ou une vidéo ici"
+hint = "ou cliquez pour parcourir &mdash; MP3, WAV, FLAC, M4A, Ogg, et le son contenu dans un MP4, un MOV ou un WebM"

--- a/locales/fr/tools/exif-editor.html
+++ b/locales/fr/tools/exif-editor.html
@@ -1,0 +1,150 @@
+<main>
+  <!-- Étape 1 &mdash; les fichiers -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir des photos</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer de la liste</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; le clic unique -->
+  <section class="card" id="strip-card">
+    <h2><span class="step">2</span> Tout supprimer</h2>
+
+    <p class="card-lede">
+      Un bouton, toutes les photos de la liste. L'image n'est ni décodée, ni
+      redessinée, ni recompressée &mdash; les données d'image compressées sont
+      recopiées intactes et seules les métadonnées autour d'elles sont jetées, si
+      bien que le résultat est la même photo, sans rien d'attaché.
+    </p>
+
+    <div class="strip-row">
+      <button type="button" id="strip-all" class="primary big" disabled>Tout supprimer</button>
+      <span id="strip-status" class="strip-status" role="status" aria-live="polite"></span>
+    </div>
+
+    <!--
+      Two things are kept by default, and both are stated on the button's own
+      line rather than buried in a settings panel. "Remove all" that quietly
+      keeps things is a broken promise; "remove all except these two, and here
+      they are" is a choice.
+    -->
+    <fieldset class="keep-options">
+      <legend>Ce qu'il faut garder</legend>
+      <label class="check">
+        <input type="checkbox" id="keep-orientation" checked>
+        <span>
+          <strong>L'étiquette d'orientation</strong>
+          <span class="check-note">
+            Les téléphones stockent une photo telle que le capteur l'a vue et
+            ajoutent une étiquette disant de quel côté elle se tient. Retirez-la et
+            certains afficheurs la montreront couchée. Gardée, un nouveau bloc EXIF
+            est écrit qui ne contient que cette étiquette &mdash; et seulement quand
+            la photo n'était pas déjà dans le bon sens.
+          </span>
+        </span>
+      </label>
+      <label class="check">
+        <input type="checkbox" id="keep-icc" checked>
+        <span>
+          <strong>Le profil colorimétrique</strong>
+          <span class="check-note">
+            Le profil ICC dit ce que les nombres de l'image veulent dire comme
+            couleurs. Il ne dit rien sur vous. Le jeter peut déplacer visiblement les
+            couleurs d'une photo à large gamut, et c'est pourquoi il est gardé sauf
+            avis contraire.
+          </span>
+        </span>
+      </label>
+      <p class="keep-summary" id="keep-summary"></p>
+    </fieldset>
+
+    <div id="clean-results" class="results" hidden>
+      <div class="results-head">
+        <h3>Nettoyées</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Tout télécharger en zip</button>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!-- Étape 3 &mdash; lire et modifier -->
+  <section class="card" id="inspect-card">
+    <h2><span class="step">3</span> Regarder dedans, et changer ce que vous voulez</h2>
+
+    <p id="inspect-empty" class="empty-note">
+      Choisissez une photo ci-dessus et tout ce qu'elle contient apparaît
+      ici&nbsp;: ce qu'elle raconte sur l'endroit où vous étiez, quand, et avec
+      quoi. Rien n'est envoyé nulle part pour l'établir.
+    </p>
+
+    <div id="inspector" hidden>
+      <div class="inspect-head">
+        <div class="inspect-file">
+          <img id="inspect-thumb" class="inspect-thumb" alt="" hidden>
+          <div>
+            <p class="inspect-name" id="inspect-name"></p>
+            <p class="inspect-sub" id="inspect-sub"></p>
+          </div>
+        </div>
+        <div class="inspect-switch">
+          <label for="inspect-select" class="visually-hidden">Quelle photo examiner</label>
+          <select id="inspect-select"></select>
+        </div>
+      </div>
+
+      <!-- The findings: the part of this page that answers the actual question. -->
+      <section class="findings" aria-labelledby="findings-h">
+        <h3 id="findings-h">Ce que ce fichier laisse échapper</h3>
+        <ul id="findings-list" class="findings-list"></ul>
+      </section>
+
+      <!-- Whole blocks, each removable on its own. -->
+      <section class="blocks" aria-labelledby="blocks-h">
+        <h3 id="blocks-h">Les blocs de ce fichier</h3>
+        <ul id="block-list" class="block-list"></ul>
+      </section>
+
+      <!-- Every tag, editable. -->
+      <section class="tags" aria-labelledby="tags-h">
+        <h3 id="tags-h">Toutes les étiquettes</h3>
+        <p class="tags-note" id="tags-note"></p>
+        <div id="tag-groups"></div>
+
+        <details class="add-tag" id="add-tag">
+          <summary>Ajouter une étiquette</summary>
+          <div class="add-tag-body">
+            <label for="add-tag-select">Étiquette</label>
+            <select id="add-tag-select"></select>
+            <label for="add-tag-value">Valeur</label>
+            <input type="text" id="add-tag-value" spellcheck="false">
+            <button type="button" id="add-tag-go" class="ghost">Ajouter</button>
+          </div>
+        </details>
+      </section>
+
+      <div class="save-row">
+        <button type="button" id="save-edits" class="primary" disabled>Enregistrer cette photo</button>
+        <button type="button" id="revert-edits" class="ghost" disabled>Annuler mes changements</button>
+        <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
+      </div>
+      <p id="edit-error" class="error" role="alert" hidden></p>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/exif-editor.toml
+++ b/locales/fr/tools/exif-editor.toml
@@ -1,0 +1,245 @@
+#
+# Lecteur et effaceur EXIF - French.
+#
+# Overrides for tools/exif-editor/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Lecteur et effaceur EXIF"
+heading = "Lecteur&nbsp;et&nbsp;effaceur EXIF <span class=\"h1-kw\">&mdash; supprimer les métadonnées d'une photo</span>"
+tagline = "Voyez ce qu'une photo raconte sur vous. Puis retirez-le."
+
+title = "Lecteur et effaceur EXIF &mdash; éditeur de métadonnées photo gratuit"
+description = "Voyez les données EXIF et GPS cachées dans une photo, modifiez-les, ou retirez tout d'un clic. Dans votre navigateur : rien n'est envoyé, et la photo n'est jamais réencodée."
+og_title = "Lecteur et effaceur EXIF &mdash; les voir, les modifier, ou tout retirer"
+og_description = "Lisez les métadonnées cachées dans une photo et retirez-les toutes d'un clic. Tout tourne sur votre machine ; l'image elle-même n'est jamais réencodée."
+og_image_alt = "Lecteur et effaceur EXIF - lire, modifier ou retirer les métadonnées d'une photo"
+
+pledge = """
+    Le fichier est ouvert, analysé et réécrit par votre propre navigateur. Cet
+    outil n'a aucune fonction réseau &mdash; rien à récupérer, rien à envoyer
+    &mdash; et il n'y a à l'autre bout de cette page aucun serveur auquel envoyer
+    une photo, quand bien même il y en aurait une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et nettoyez une photo. Pas une seule requête
+      ne transporte d'image, de vignette, de nom de fichier ni une étiquette lue
+      dans votre fichier. Ou coupez votre connexion et nettoyez-en une quand
+      même."""
+
+read_first = """
+, <code>src/tiff.js</code> pour l'analyseur EXIF, et
+      <code>src/jpeg.js</code> pour la preuve que l'image elle-même n'est jamais
+      que copiée."""
+
+howto_heading = "Comment supprimer les données EXIF d'une photo"
+
+card = """
+            Voyez le lieu, l'appareil et les numéros de série cachés dans une
+            photo, modifiez ce que vous voulez, ou retirez tout d'un clic."""
+
+[words]
+plural = "photos"
+choose = "une photo"
+analytics_extra = """, ni aucune des étiquettes
+  que cet outil lit dans vos fichiers"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[facts]]
+text = "Ne réencode jamais l'image"
+
+[[privacy]]
+title = "Vos photos n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où vos fichiers pourraient arriver, et rien dans le code qui les y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Contrairement aux autres outils de
+      cette boîte, celui-ci n'a pas de fonction
+      &laquo;&nbsp;charger depuis une adresse web&nbsp;&raquo; ni la moindre
+      étape réseau facultative. Il n'y a ni <code>fetch</code>, ni
+      <code>XMLHttpRequest</code>, ni <code>sendBeacon</code> nulle part dans
+      <code>src/</code>."""
+
+[[privacy]]
+title = "Les métadonnées que nous lisons ne sont jamais relayées."
+body = """
+ Votre position
+      GPS est affichée sur cette page et ne va nulle part ailleurs. Il n'existe
+      dans ce dépôt aucun événement d'analytique maison qui transporte une
+      étiquette, un nom de fichier, une taille ou un nombre."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit
+      quoi que ce soit sur vos photos. Chaque ligne qui lit, analyse ou réécrit
+      un fichier est servie depuis cette origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Ce que le bouton de don charge, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; dans l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et se compose avec Google
+      Fonts. C'est un lien, rien de plus&nbsp;: il ne signale aucune visite, et
+      on ne lui donne rien sur vous ni sur vos fichiers. Rien ne se passe tant
+      que vous ne cliquez pas, et ce vers quoi vous cliqueriez est le site de
+      quelqu'un d'autre."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et l'outil est
+      inchangé, parce qu'il n'y a jamais eu d'étape réseau dedans. C'est la
+      preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez vos photos."
+body = """
+ Déposez-les sur la zone prévue ou
+      sélectionnez-les à la main. Le navigateur les lit directement sur votre
+      disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Lisez ce qu'il y a dedans, si vous voulez."
+body = """
+ La liste des trouvailles
+      nomme ce qui vaut d'être su &mdash; la position GPS, les horodatages, les
+      numéros de série &mdash; avant le tableau complet de toutes les
+      étiquettes."""
+
+[[howto]]
+title = "Appuyez sur &laquo;&nbsp;Tout supprimer&nbsp;&raquo;."
+body = """
+ C'est tout le travail pour la
+      plupart des gens. Chaque étiquette, les blocs XMP et IPTC, les commentaires
+      et la vignette incorporée partent, sur toutes les photos de la liste d'un
+      coup."""
+
+[[howto]]
+title = "Ou modifiez au lieu de supprimer."
+body = """
+ Changez une date, corrigez une
+      ligne de copyright, retirez le lieu et gardez les réglages de l'appareil
+      &mdash; puis enregistrez cette photo seule."""
+
+[[faq]]
+q = "Ma photo est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. Le fichier est lu, analysé et réécrit par votre propre navigateur sur
+        votre propre matériel. Cet outil n'a aucune fonction réseau &mdash; il ne
+        récupère jamais rien et n'envoie jamais rien &mdash; et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter, dont aucune n'appartient à ce site."""
+
+[[faq]]
+q = "Qu'est-ce que l'EXIF, et quoi d'autre se cache dans une photo&nbsp;?"
+a = """
+        L'EXIF est un bloc d'étiquettes qu'un appareil écrit à côté de l'image&nbsp;:
+        la marque et le modèle, les réglages d'exposition, la date et l'heure à la
+        seconde près, souvent une position GPS, et parfois un numéro de série. Les
+        photos portent fréquemment davantage &mdash; un paquet XMP de XML laissé par
+        un logiciel de retouche, un bloc IPTC de légendes et de signatures, un profil
+        colorimétrique, une petite deuxième copie de l'image en vignette, et une note
+        de fabricant de données non documentées. Cet outil liste tout cela."""
+
+[[faq]]
+q = "Supprimer les métadonnées réduit-il la qualité de l'image&nbsp;?"
+a = """
+        Non, et c'est la principale raison d'utiliser un outil comme celui-ci plutôt
+        que de réenregistrer la photo. Les métadonnées se trouvent dans le conteneur
+        autour de l'image compressée, pas dedans. Les supprimer, c'est effacer des
+        entrées d'une liste et réécrire la liste&nbsp;; les données d'image
+        compressées sont recopiées octet pour octet, si bien que le résultat décode
+        exactement les mêmes pixels. Rien n'est décodé et rien n'est recompressé."""
+
+[[faq]]
+q = "Quels formats de fichier prend-il en charge&nbsp;?"
+a = """
+        Le JPEG, le PNG et le WebP. Le HEIC et l'AVIF sont reconnus mais pas
+        réécrits&nbsp;: ce sont des formats à boîtes faits d'atomes imbriqués et ils
+        demandent un autre analyseur, alors l'outil le dit plutôt que de produire un
+        fichier cassé. Un TIFF nu n'est pas pris en charge non plus, parce que dans un
+        TIFF les métadonnées et les pixels sont adressés par les mêmes décalages."""
+
+[[faq]]
+q = "Ma photo apparaîtra-t-elle tournée une fois les métadonnées retirées&nbsp;?"
+a = """
+        C'est possible, et il y a un réglage pour cela. Les téléphones enregistrent
+        d'habitude l'image telle que le capteur l'a vue et ajoutent une étiquette
+        d'orientation qui dit comment la tourner. Retirez cette étiquette et certains
+        afficheurs montreront la photo couchée. L'option &laquo;&nbsp;garder
+        l'étiquette d'orientation&nbsp;&raquo;, active par défaut, réécrit un minuscule
+        bloc EXIF ne contenant que cette seule étiquette &mdash; et seulement quand la
+        photo en avait réellement besoin. Décochez-la si vous préférez que le fichier
+        ne porte plus le moindre EXIF."""
+
+[[faq]]
+q = "Supprime-t-il la position GPS&nbsp;?"
+a = """
+        Oui. Tout supprimer supprime le répertoire GPS entier, et vous pouvez aussi
+        effacer le lieu seul en gardant le reste. La position est d'abord montrée en
+        degrés décimaux, parce que
+        &laquo;&nbsp;51 degrés, 30 minutes, 26 secondes&nbsp;&raquo; ne rend pas
+        évident qu'une photo nomme le bâtiment où elle a été prise."""
+
+[[faq]]
+q = "Puis-je modifier une étiquette au lieu de la supprimer&nbsp;?"
+a = """
+        Oui. Les étiquettes de texte, les dates, l'ISO, l'orientation et la résolution
+        peuvent toutes être modifiées, et quelques étiquettes courantes peuvent être
+        ajoutées à une photo qui n'en a aucune. Une réserve&nbsp;: écrire le fichier
+        reconstruit le bloc EXIF, et une note de fabricant contient des décalages vers
+        le bloc d'origine&nbsp;; une note reconstruite peut donc ne plus être lisible
+        ensuite par le logiciel du fabricant. Supprimez-la, ou laissez le fichier tel
+        quel, si cela compte pour vous."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion et pas de période
+        d'essai. Le site porte de la publicité, et c'est elle qui le finance&nbsp;;
+        les annonces ne reçoivent rien sur vos photos."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait vos photos ailleurs pour les traiter
+        s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Lisez les métadonnées EXIF, GPS, XMP et IPTC contenues dans une photo, modifiez des étiquettes une à une, ou retirez tout d'un clic. JPEG, PNG et WebP, traités dans le navigateur sans réencoder l'image."
+features = [
+  "Montre toutes les étiquettes EXIF, y compris la position GPS, les numéros de série de l'appareil et les notes de fabricant",
+  "Modifie ou supprime des étiquettes une à une et réécrit le fichier",
+  "Retire l'EXIF, le GPS, le XMP, l'IPTC, les commentaires et la vignette incorporée d'un clic",
+  "JPEG, PNG et WebP",
+  "Ne réécrit que le conteneur, si bien que l'image n'est jamais recompressée",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]
+
+[picker]
+title = "Déposez vos photos ici"
+hint = "ou cliquez pour parcourir &mdash; JPEG, PNG et WebP"

--- a/locales/fr/tools/heic-to-jpg.html
+++ b/locales/fr/tools/heic-to-jpg.html
@@ -1,0 +1,113 @@
+<main>
+  <!-- Étape 1 &mdash; les fichiers -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir vos photos HEIC</h2>
+
+    <p class="card-lede">
+      Directement depuis le téléphone, depuis une sauvegarde, ou copiées d'une
+      carte mémoire. Le fichier est lu ici, sur cette machine, et l'image y est
+      décodée aussi &mdash; il n'y a dans cette page aucune étape d'envoi, et
+      aucun serveur derrière.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer de la liste</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; ce qui ressort -->
+  <section class="card" id="options-card">
+    <h2><span class="step">2</span> Dire ce que vous voulez récupérer</h2>
+
+    <fieldset class="options">
+      <legend>Le format</legend>
+
+      <div class="option-row">
+        <label for="format-select">Écrire les images en</label>
+        <select id="format-select">
+          <option value="image/jpeg" selected>JPEG &mdash; s'ouvre partout, y compris sur ce qui a été fait ce siècle-ci par accident</option>
+          <option value="image/png">PNG &mdash; sans perte, et plusieurs fois plus lourd</option>
+          <option value="image/webp">WebP &mdash; plus léger que le JPEG à qualité égale, et navigateurs récents seulement</option>
+        </select>
+      </div>
+
+      <div class="option-row" id="quality-row">
+        <label for="quality">Qualité</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="50" max="100" step="1" value="92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Les détails de la photo</legend>
+
+      <label class="check">
+        <input type="checkbox" id="keep-exif" checked>
+        <span>
+          <strong>Garder la date, l'appareil et les réglages</strong>
+          <span class="check-note">
+            Recopiés exactement comme le téléphone les a écrits, si bien que la
+            photo convertie se range encore au jour de la prise de vue et non au
+            jour de la conversion. Cela inclut les coordonnées GPS quand la photo
+            en a &mdash; la liste ci-dessus dit lesquelles des vôtres en ont.
+            Décochez et le JPEG ressort sans rien d'autre que l'image.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary">
+        Dans un cas comme dans l'autre, rien ici n'est relayé à qui que ce
+        soit&nbsp;: le choix porte sur ce qui entre dans le fichier que vous
+        récupérez, pas sur ce que cette page en fait. Si vous voulez parcourir les
+        étiquettes en détail, ou les retirer de photos qui sont déjà des JPEG, le
+        <a href="../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a> est
+        l'outil pour cela.
+      </p>
+    </fieldset>
+  </section>
+
+  <!-- Étape 3 &mdash; le clic unique -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Convertir</h2>
+
+    <div class="run-row">
+      <button type="button" id="convert-all" class="primary big" disabled>Convertir</button>
+    </div>
+
+    <!--
+      The decoder's own status line. This page is the only one on the site that
+      carries a codec, so it is the only one with anything to report here, and
+      saying where the megabyte came from is the point: it is served from this
+      origin, it is cached with the rest of the page, and it is what makes the
+      offline promise hold on a browser that cannot open a HEIC at all.
+    -->
+    <p id="engine-status" class="engine-status" role="status" aria-live="polite"></p>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Converties</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Tout télécharger en zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/heic-to-jpg.toml
+++ b/locales/fr/tools/heic-to-jpg.toml
@@ -1,0 +1,302 @@
+#
+# HEIC vers JPG - French.
+#
+# Overrides for tools/heic-to-jpg/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "HEIC vers JPG"
+heading = "HEIC&nbsp;vers&nbsp;JPG <span class=\"h1-kw\">&mdash; convertir les photos d'iPhone</span>"
+tagline = "Les photos que fait un iPhone, dans un format que tout ouvre."
+
+title = "Convertisseur HEIC vers JPG &mdash; gratuit, sans envoi"
+description = "Convertissez vos photos HEIC d'iPhone en JPG dans votre navigateur. Le décodeur tourne sur votre propre machine : rien n'est envoyé, aucun compte, fonctionne hors ligne, et la date et les détails de l'appareil peuvent suivre."
+og_title = "Transformer des photos HEIC en JPG sans les envoyer"
+og_description = "Le convertisseur qui ne veut pas de vos photos. Le décodeur HEIC est servi depuis cette page et tourne sur votre propre machine : les images ne la quittent donc jamais."
+og_image_alt = "HEIC vers JPG - les photos d'iPhone dans un format que tout ouvre"
+
+pledge = """
+    Le décodage se fait dans votre propre navigateur, sur votre propre matériel.
+    Le HEIC est le seul format d'image qu'un navigateur n'ouvre pas tout seul,
+    alors cette page emporte le décodeur avec elle &mdash; environ 1,4 MB, servi
+    depuis ce site, mis en cache après la première visite. C'est là toute la
+    raison pour laquelle tous les autres convertisseurs HEIC vous demandent
+    d'envoyer vos fichiers&nbsp;: ils mettent le codec sur un serveur, et vos
+    photos doivent aller jusqu'à lui. Celui-ci met le codec ici à la place. Il
+    n'y a sur cette page aucune fonction réseau, et aucun serveur à l'autre bout
+    auquel envoyer une photo."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et convertissez une photo. Vous verrez les
+      fichiers de cette page se charger, le décodeur parmi eux, et pas une seule
+      requête qui transporte une photo, une vignette, un nom de fichier ou un
+      octet de ce que vous avez choisi. Ou chargez la page une fois, coupez votre
+      connexion, et convertissez un dossier entier quand même."""
+
+read_first = """
+, <code>src/heif.js</code> pour la façon dont le
+      décodeur est chargé et ce qu'il a le droit de faire, <code>src/boxes.js</code>
+      pour l'analyse du conteneur qui trouve les métadonnées de la photo, et
+      <code>src/exif.js</code> pour ce qu'il advient de ces métadonnées en
+      entrant dans un JPEG. Le moteur lui-même est <code>vendor/libheif.js</code>,
+      non modifié, avec sa licence à côté."""
+
+howto_heading = "Comment convertir des photos HEIC en JPG"
+
+card = """
+            Les photos que fait un iPhone, dans un format que tout ouvre &mdash;
+            décodées sur votre propre machine, pas sur le serveur de quelqu'un."""
+
+[words]
+plural = "photos"
+choose = "une photo"
+analytics_extra = """, ni aucune des
+  dates, des modèles d'appareil ou des coordonnées que cet outil y lit"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans limite de taille"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Vos photos n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où vos fichiers pourraient arriver, et rien dans le code qui les y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Le décodeur est venu d'ici, et il ne va nulle part."
+body = """
+ Le HEIC, c'est du
+      HEVC dans un format à boîtes, et aucun navigateur sauf Safari n'en décode
+      un&nbsp;; cette page livre donc <code>libheif</code> compilé en WebAssembly
+      &mdash; environ 1,4 MB, versionné dans ce dépôt, servi depuis cette origine,
+      et mis en cache par le service worker comme tous les autres fichiers d'ici.
+      Il n'est pas récupéré sur un CDN, parce que cela mettrait un tiers sur le
+      chemin de chaque visite et empêcherait l'outil de fonctionner hors ligne. Le
+      binaire est à l'intérieur du script plutôt qu'à côté, précisément pour
+      qu'aucune requête ne soit nécessaire pour le démarrer."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Il n'y a ni
+      <code>fetch</code>, ni <code>XMLHttpRequest</code>, ni
+      <code>sendBeacon</code> dans aucun fichier écrit pour cet outil. Le moteur
+      embarqué, comme toute compilation Emscripten, contient les chemins de
+      chargement qui iraient chercher un <code>.wasm</code> à une URL&nbsp;; ils
+      ne sont pas empruntés, parce que le binaire est déjà en main &mdash; et s'ils
+      l'étaient, <code>connect-src</code> ne nomme que les points de mesure de
+      Google et rien d'autre&nbsp;: le navigateur refuserait. La politique est la
+      preuve, pas la promesse."""
+
+[[privacy]]
+title = "Les métadonnées sont lues ici et vous sont rapportées."
+body = """
+ La liste sur
+      la page dit ce que porte chaque photo &mdash; la date, l'appareil, et s'il y
+      a des coordonnées GPS dedans &mdash; parce que c'est une chose que vous
+      pourriez vouloir savoir avant de remettre le JPEG à quelqu'un. Elle est lue
+      dans le fichier par <code>src/boxes.js</code> dans ce navigateur, montrée sur
+      cette page, et écrite dans votre JPEG ou laissée de côté, entièrement comme
+      vous le décidez. Il n'existe dans ce dépôt aucun événement d'analytique
+      maison qui transporte un nom de fichier, une date, une coordonnée ou un
+      nombre."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google, et le bouton de don de Buy
+      Me a Coffee. Aucun d'eux ne reçoit quoi que ce soit sur vos photos. Chaque
+      ligne qui lit, décode ou écrit un fichier est servie depuis cette origine et
+      figure dans le dépôt."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Chargez la page une fois puis coupez le
+      réseau&nbsp;: l'outil est inchangé &mdash; le décodeur est mis en cache avec
+      lui. C'est la preuve la plus simple de toutes, et elle est ici plus forte
+      que partout ailleurs sur ce site&nbsp;: un convertisseur qui expédierait vos
+      photos ailleurs pour les décoder n'y arriverait tout simplement pas."""
+
+[[howto]]
+title = "Choisissez vos photos HEIC."
+body = """
+ Déposez-les sur la zone prévue ou
+      sélectionnez-les à la main, directement depuis une sauvegarde de téléphone
+      ou un dossier du bureau. Le navigateur les lit sur votre disque&nbsp;; rien
+      n'est envoyé nulle part pendant ce temps. La liste dit ce qu'est chacune et
+      ce qu'elle a dedans."""
+
+[[howto]]
+title = "Regardez ce que portent les photos."
+body = """
+ Chaque ligne nomme la date de
+      prise de vue, l'appareil, et &mdash; en vert, parce que c'est la partie qui
+      mérite l'attention &mdash; si le fichier contient des coordonnées GPS. Cela
+      est lu dans le conteneur sans décoder l'image&nbsp;: cela ne coûte rien et
+      apparaît immédiatement."""
+
+[[howto]]
+title = "Choisissez un format, et tranchez sur les détails."
+body = """
+ JPEG, sauf si vous
+      avez une raison&nbsp;: c'est le format qui s'ouvre partout, ce qui est tout
+      l'intérêt de convertir. Le curseur de qualité est à 92, réglage auquel une
+      photographie est difficile à distinguer de l'original. La case décide si la
+      date, l'appareil et le lieu suivent."""
+
+[[howto]]
+title = "Appuyez sur &laquo;&nbsp;Convertir&nbsp;&raquo;, et téléchargez."
+body = """
+ Le décodeur arrive à la
+      première conversion &mdash; environ 1,4 MB, une seule fois &mdash; et chaque
+      photo ensuite est décodée et écrite sur votre propre machine. Un fichier
+      vous donne un bouton de téléchargement&nbsp;; plusieurs vous donnent aussi
+      un zip."""
+
+[[faq]]
+q = "Ma photo est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. Le fichier est lu, décodé et écrit par votre propre navigateur sur votre
+        propre matériel. Cet outil n'a aucune fonction réseau &mdash; il ne récupère
+        jamais rien et n'envoie jamais rien &mdash; et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter, dont aucune n'appartient à ce site. La seule chose qui
+        se charge, c'est le décodeur lui-même, et il vient de ce site, une fois, avant
+        que votre photo soit impliquée."""
+
+[[faq]]
+q = "Pourquoi cette page télécharge-t-elle 1,4 MB la première fois&nbsp;?"
+a = """
+        Parce que le HEIC est le seul format d'image qu'un navigateur n'ouvre pas.
+        C'est une image HEVC dans un conteneur à boîtes, et seul Safari, sur du
+        matériel Apple, en a un décodeur&nbsp;; Chrome, Firefox et Edge refusent
+        simplement le fichier. Un convertisseur HEIC a donc besoin d'un décodeur, et
+        il ne peut venir que de deux endroits&nbsp;: un serveur, ou la page. Tous les
+        autres convertisseurs ont choisi le serveur, et c'est exactement pour cela
+        qu'ils exigent tous l'envoi de vos photos. Celui-ci emporte
+        <code>libheif</code> compilé en WebAssembly à la place. Il est servi depuis ce
+        site, mis en cache après la première visite, et c'est le prix entier du fait
+        que vos photos n'aillent nulle part."""
+
+[[faq]]
+q = "Le JPEG garde-t-il la date, l'appareil et le lieu&nbsp;?"
+a = """
+        Si vous le voulez, et c'est une case sur la page. Laissée cochée, le bloc EXIF
+        est copié depuis le HEIC et écrit dans le JPEG exactement comme le téléphone
+        l'avait écrit&nbsp;: la photo convertie se range donc encore au jour de la
+        prise de vue et non au jour de la conversion &mdash; ce qui est le reproche
+        habituel fait aux convertisseurs HEIC. Une étiquette est changée, et une
+        seule&nbsp;: l'orientation, mise à &laquo;&nbsp;droite&nbsp;&raquo;, parce que
+        la rotation a déjà été appliquée aux pixels et qu'un afficheur qui
+        l'appliquerait de nouveau coucherait toutes les photos verticales.
+        Décochez la case et le JPEG sort avec l'image et rien d'autre."""
+
+[[faq]]
+q = "Retire-t-il les coordonnées GPS&nbsp;?"
+a = """
+        Il vous dit qu'elles sont là, puis il fait ce que vous demandez. La ligne de
+        chaque photo dit si le fichier porte des coordonnées avant que vous convertissiez
+        quoi que ce soit, ce qui est plus que ne fait le téléphone. Décocher
+        &laquo;&nbsp;garder la date, l'appareil et les réglages&nbsp;&raquo; les laisse
+        hors du JPEG avec tout le reste&nbsp;; laisser coché les fait suivre. Si ce que
+        vous voulez, c'est parcourir les étiquettes en détail, ou les retirer de photos
+        qui sont déjà des JPEG, le
+        <a href="../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a> est
+        l'outil pour cela, et il le fait sans recompresser l'image."""
+
+[[faq]]
+q = "L'image est-elle recompressée&nbsp;?"
+a = """
+        Oui, et il le faut&nbsp;: le HEIC et le JPEG sont des codecs différents, il n'y
+        a donc aucun moyen de passer de l'un à l'autre sans décoder l'image et la
+        réencoder. Ce que vous pouvez maîtriser, c'est ce que cela coûte. Le curseur de
+        qualité est par défaut à 92, réglage auquel une photographie est très difficile
+        à distinguer de l'original, et le PNG est au menu pour le cas où vous ne voulez
+        aucune perte et acceptez un fichier cinq à dix fois plus gros."""
+
+[[faq]]
+q = "Et si le fichier s'appelle .jpg mais est en réalité un HEIC&nbsp;?"
+a = """
+        Cela marche quand même. Chaque fichier déposé ici est identifié par ses premiers
+        octets et non par son nom, parce que le nom est celui que la dernière
+        application à avoir touché le fichier a décidé de lui donner &mdash; et un HEIC
+        arrivé sous le nom &laquo;&nbsp;.jpg&nbsp;&raquo; est l'une des façons les plus
+        courantes de finir par chercher un outil comme celui-ci. Un fichier qui est
+        vraiment un JPEG ou un PNG est refusé avec un message qui le dit, plutôt que
+        converti en une copie de lui-même."""
+
+[[faq]]
+q = "Peut-il convertir une Live Photo, ou une rafale&nbsp;?"
+a = """
+        Les images fixes qui sont dedans, oui. Un HEIC peut contenir plus d'une image,
+        et chacune de celles qu'il contient est convertie et nommée d'après l'original
+        avec un numéro à la fin. La moitié vidéo d'une Live Photo est un fichier séparé
+        que le téléphone garde à côté du HEIC&nbsp;: elle n'est donc pas là pour être
+        convertie. Les cartes de profondeur et les vignettes sont dans le conteneur mais
+        ne sont pas des images que quiconque a demandées, et elles sont laissées
+        tranquilles."""
+
+[[faq]]
+q = "Pourquoi refuse-t-il mon AVIF&nbsp;?"
+a = """
+        Parce qu'il n'y a rien à en faire. L'AVIF est le même conteneur que le HEIC avec
+        de l'AV1 dedans au lieu du HEVC, et tous les navigateurs actuels en décodent un
+        nativement &mdash; un convertisseur livrerait donc un mégaoctet de moteur pour
+        résoudre un problème que vous n'avez pas. S'il vous faut un AVIF en JPEG, le
+        <a href="../compresser-une-image/">compresseur d'images</a> et le
+        <a href="../redimensionner-une-image/">redimensionneur d'images</a> lisent tous
+        deux l'AVIF et écrivent du JPEG avec le décodeur que votre navigateur a déjà."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Il n'y a pas non plus de limite au nombre ni à la
+        taille des fichiers, parce qu'aucun serveur ne les paie &mdash; le travail se
+        fait sur votre propre machine. Le site porte de la publicité, et c'est elle qui
+        le finance&nbsp;; les annonces ne reçoivent rien sur vos photos."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui, décodeur compris. Chargez la page une fois, coupez ensuite votre connexion
+        et elle continue de travailler sur vos photos exactement comme avant. C'est
+        aussi la preuve la plus forte qu'on puisse avoir que rien n'est envoyé&nbsp;: un
+        convertisseur qui expédierait vos HEIC ailleurs pour les décoder s'arrêterait à
+        l'instant où vous débranchez, et celui-ci ne s'arrête pas."""
+
+[schema]
+description = "Convertissez des photos HEIC et HEIF d'iPhone en JPEG, PNG ou WebP. Le décodeur HEIC est du WebAssembly servi par la page elle-même : les images sont donc décodées sur votre propre machine et ne sont jamais envoyées. La date, l'appareil et le lieu peuvent être portés dans le JPEG ou laissés de côté."
+features = [
+  "Convertit le HEIC et le HEIF en JPEG, PNG ou WebP",
+  "Décode dans le navigateur, sur n'importe quel navigateur - pas seulement Safari",
+  "Rien n'est envoyé, et l'outil fonctionne réseau débranché",
+  "Porte la date, l'appareil et le GPS dans le JPEG, ou les laisse de côté",
+  "Dit quelles photos contiennent des coordonnées GPS avant toute conversion",
+  "Corrige l'étiquette d'orientation, pour que les photos verticales ne sortent pas couchées",
+  "Identifie les fichiers par leur contenu, si bien qu'un HEIC nommé .jpg marche quand même",
+  "Convertit chaque image d'une rafale ou d'une Live Photo, pas seulement la première",
+  "Traitement par lots, tous les résultats dans un seul zip",
+]
+
+[picker]
+title = "Déposez vos photos HEIC ici"
+hint = "ou cliquez pour parcourir &mdash; .heic et .heif, quel que soit leur nom"

--- a/locales/fr/tools/image-to-data-uri.html
+++ b/locales/fr/tools/image-to-data-uri.html
@@ -1,0 +1,142 @@
+<main>
+  <!-- Étape 1 &mdash; les fichiers -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir des images</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer de la liste</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; la ligne qui sera vraiment collée -->
+  <section class="card" id="shape-card">
+    <h2><span class="step">2</span> Dire où cela va</h2>
+
+    <p class="card-lede">
+      Un data URI tout seul est rarement ce que l'on veut. Ce que l'on veut,
+      c'est la ligne qui ira dans la feuille de style &mdash; choisissez donc la
+      ligne, et l'image y arrive déjà entre guillemets, ce qui est la partie
+      facile à rater et qui n'échoue que pour les SVG.
+    </p>
+
+    <div class="shapes" id="shapes" role="radiogroup" aria-label="Ce qu'il faut coller">
+      <label class="shape">
+        <input type="radio" name="shape" value="uri" checked>
+        <span class="shape-body">
+          <strong>Le data URI tout seul</strong>
+          <span class="shape-note">
+            Tout ce qui suit la virgule est le fichier. Collez-le partout où va une URL.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-rule">
+        <span class="shape-body">
+          <strong>Une règle CSS</strong>
+          <span class="shape-note">
+            Une règle entière, avec une classe nommée d'après le fichier. Changez
+            le sélecteur pour ce que vous stylez vraiment.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-var">
+        <span class="shape-body">
+          <strong>Une propriété personnalisée CSS</strong>
+          <span class="shape-note">
+            Déclarée une fois en tête de la feuille de style et utilisée en
+            <code>var(--nom)</code> autant de fois que vous voulez. C'est celle à
+            choisir quand l'image apparaît dans plus d'une règle.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="html">
+        <span class="shape-body">
+          <strong>Une balise HTML <code>&lt;img&gt;</code></strong>
+          <span class="shape-note">
+            Avec la taille en pixels remplie, pour que la page ne saute pas
+            pendant que le reste se charge.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="markdown">
+        <span class="shape-body">
+          <strong>Du Markdown</strong>
+          <span class="shape-note">
+            Pour un README ou un ticket&nbsp;: une image qui voyage avec le texte
+            au lieu d'avoir besoin d'un hébergement.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary">
+      Le texte <code>alt</code> est laissé vide exprès. Vous seul savez si
+      l'image porte du sens ou n'est que décorative, et une description devinée à
+      partir d'un nom de fichier est pire, pour qui utilise un lecteur d'écran,
+      que pas de description du tout.
+    </p>
+
+    <fieldset class="options">
+      <legend>SVG</legend>
+
+      <label class="check">
+        <input type="checkbox" id="svg-base64">
+        <span>
+          <strong>Passer aussi les SVG en base64</strong>
+          <span class="check-note">
+            Décoché par défaut, parce qu'un SVG est du texte et que le base64 est
+            fait pour des octets. L'encodage en pourcents laisse le balisage
+            lisible dans la feuille de style et est en général un cinquième plus
+            court. Cochez pour la rare chaîne d'outils qui exige
+            <code>;base64</code>.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Step 3 &mdash; the result. There is no button here on purpose: encoding
+       is instant, so there is nothing for a "convert" press to wait for. -->
+  <section class="card" id="output-card">
+    <h2><span class="step">3</span> Copier</h2>
+
+    <p id="empty-note" class="card-lede">
+      Rien de choisi pour l'instant. Déposez une image ci-dessus et la ligne à
+      coller apparaît ici.
+    </p>
+
+    <div id="results" hidden>
+      <div class="results-head">
+        <p id="results-summary" class="results-summary"></p>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Tout copier</button>
+          <button type="button" id="download-all" class="ghost">Télécharger en un seul fichier</button>
+        </div>
+      </div>
+
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/image-to-data-uri.toml
+++ b/locales/fr/tools/image-to-data-uri.toml
@@ -1,0 +1,329 @@
+#
+# Image en base64 - French.
+#
+# Overrides for tools/image-to-data-uri/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Data URI" is left in English throughout. It is the name of the thing in the
+# specification and in every stylesheet a reader will meet, and a French
+# rendering of it would name something they could not then search for.
+#
+
+name = "Image en data URI"
+heading = "Image&nbsp;en&nbsp;data&nbsp;URI <span class=\"h1-kw\">&mdash; encoder une image en base64 pour le CSS ou le HTML</span>"
+tagline = "L'image entière en une ligne de texte. À coller directement dans du CSS ou du HTML."
+
+title = "Image en data URI &mdash; encodage base64 pour le CSS, gratuit, sans envoi"
+description = "Transformez un PNG, un JPEG, un SVG ou un WebP en data URI à coller dans du CSS ou du HTML. Les SVG sont encodés en pourcents plutôt qu'en base64 : ils restent lisibles et plus courts. Tout se passe dans votre navigateur ; rien n'est envoyé."
+og_title = "Transformer une image en une ligne à coller dans du CSS"
+og_description = "Base64 pour les images, encodage en pourcents pour le SVG, et la règle, la propriété personnalisée ou la balise img déjà faites autour. Tout tourne sur votre machine ; rien n'est envoyé."
+og_image_alt = "Image en data URI - coller l'image dans la feuille de style"
+
+pledge = """
+    L'encodage se fait dans votre propre navigateur, sur votre propre matériel.
+    C'est de l'arithmétique sur des octets que la page a déjà&nbsp;: pas
+    d'encodeur, pas de serveur, et aucune étape réseau à omettre. Cet outil n'a
+    aucune fonction réseau &mdash; rien à récupérer, rien à envoyer &mdash; et il
+    n'y a à l'autre bout de cette page aucun serveur auquel envoyer une image,
+    quand bien même il y en aurait une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et déposez une image. Pas une seule requête
+      ne transporte d'image, de vignette, de nom de fichier ni un octet de ce que
+      vous avez choisi. Ou coupez votre connexion et encodez-en une quand
+      même."""
+
+read_first = """
+, <code>src/encode.js</code> pour les deux encodages
+      et le raisonnement derrière chacun, <code>src/sniff.js</code> pour la façon
+      dont le type de média est lu dans le fichier plutôt que dans son nom, et
+      <code>src/metadata.js</code> pour la vérification qui dit quelle part de ce
+      que vous vous apprêtez à coller n'est pas l'image."""
+
+howto_heading = "Comment transformer une image en data URI"
+
+card = """
+            Base64 pour les images, encodage en pourcents pour le SVG, et la
+            règle CSS ou la balise <code>&lt;img&gt;</code> déjà construite
+            autour."""
+
+[words]
+plural = "images"
+choose = "une image"
+analytics_extra = """, ni aucun des
+  noms de fichiers, des tailles ou des textes encodés que cet outil produit"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans réencodage"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Vos images n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où vos fichiers pourraient arriver, et rien dans le code qui les y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Il n'y a ni
+      <code>fetch</code>, ni <code>XMLHttpRequest</code>, ni
+      <code>sendBeacon</code> nulle part dans <code>src/</code>. L'encodage, ce
+      sont <code>btoa</code> et <code>encodeURIComponent</code> &mdash; deux
+      fonctions que le navigateur a depuis le début, qui prennent toutes deux des
+      octets et rendent du texte sans aller nulle part."""
+
+[[privacy]]
+title = "L'aperçu est la preuve."
+body = """
+ L'image à côté de chaque résultat est
+      dessinée à partir du data URI que cette page vient de construire, pas à
+      partir de votre fichier. Elle s'affiche parce que l'URI est correct, sur
+      votre machine, sans aucun serveur dans l'affaire &mdash; et si elle ne
+      s'affiche pas, la page le dit au lieu de vous remettre quelque chose de
+      cassé."""
+
+[[privacy]]
+title = "L'avertissement sur les métadonnées est de votre côté."
+body = """
+ Un data URI copie
+      le fichier exactement&nbsp;: la position GPS d'une photographie voyage donc
+      avec lui jusque dans votre feuille de style. Cette page lit combien il y en
+      a et vous le dit, parce que l'autre solution, c'est que vous l'appreniez
+      une fois le commit fait."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google, et le bouton de don de Buy
+      Me a Coffee. Aucun d'eux ne reçoit quoi que ce soit sur vos images. Chaque
+      ligne qui lit ou encode un fichier est servie depuis cette origine et
+      figure dans le dépôt."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et l'outil est
+      inchangé, parce qu'il n'y a jamais eu d'étape réseau dedans. C'est la
+      preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez vos images."
+body = """
+ Déposez-les sur la zone prévue ou
+      sélectionnez-les à la main. Le navigateur les lit directement sur votre
+      disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Dites où va le résultat."
+body = """
+ L'URI seul, une règle CSS, une
+      propriété personnalisée, une balise <code>&lt;img&gt;</code> ou du
+      Markdown. Chacun met l'URI entre guillemets, et c'est le détail qui décide
+      si un SVG en ligne fonctionne ou échoue en silence."""
+
+[[howto]]
+title = "Lisez ce que cela a coûté."
+body = """
+ Chaque résultat dit en combien de
+      caractères il s'est transformé, de combien c'est plus lourd que le fichier,
+      et si mettre en ligne quelque chose de cette taille est une bonne idée. Le
+      base64 ajoute un tiers&nbsp;; que ce tiers vaille une requête économisée
+      dépend entièrement de la taille, alors la page dit de quel côté de la ligne
+      vous êtes."""
+
+[[howto]]
+title = "Regardez les avertissements."
+body = """
+ Si l'image porte de l'EXIF, un profil
+      colorimétrique ou du XMP, ils sont nommés avec le nombre d'octets de votre
+      résultat qu'ils représentent. Si l'extension contredit le format réel, la
+      page suit le format et vous le dit. Si votre navigateur ne sait pas
+      dessiner le résultat, elle le dit aussi."""
+
+[[howto]]
+title = "Copiez, ou téléchargez."
+body = """
+ Un bouton par résultat, et un pour
+      tous d'un coup &mdash; les propriétés personnalisées ressortent enveloppées
+      dans un bloc <code>:root</code>, prêtes à coller en tête d'une feuille de
+      style."""
+
+[[faq]]
+q = "Mon image est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. Le fichier est lu et encodé par votre propre navigateur sur votre propre
+        matériel, avec deux fonctions que le navigateur possède déjà. Cet outil n'a
+        aucune fonction réseau &mdash; il ne récupère jamais rien et n'envoie jamais
+        rien &mdash; et la <code>Content-Security-Policy</code> de la page nomme
+        toutes les adresses qu'elle peut contacter, dont aucune n'appartient à ce
+        site."""
+
+[[faq]]
+q = "Qu'est-ce qu'un data URI&nbsp;?"
+a = """
+        Une façon d'écrire un fichier entier là où irait normalement une adresse web.
+        Au lieu de <code>url("logo.png")</code>, qui dit au navigateur d'aller
+        chercher quelque chose, vous écrivez
+        <code>url("data:image/png;base64,iVBORw0...")</code>, qui contient l'image
+        elle-même. Le navigateur la décode sur place. L'effet pratique est une requête
+        de moins&nbsp;: l'image arrive avec la feuille de style ou la page plutôt
+        qu'après elle."""
+
+[[faq]]
+q = "Pourquoi mon SVG n'est-il pas en base64&nbsp;?"
+a = """
+        Parce que le base64 est le mauvais encodage pour lui. Un SVG est du texte, et
+        une URL sait déjà transporter du texte &mdash; seule une poignée de caractères
+        doit être échappée. Les encoder en pourcents et laisser le reste tranquille
+        produit un URI typiquement un cinquième plus court que le base64 du même
+        fichier, et que vous pouvez encore lire dans votre feuille de style&nbsp;: les
+        noms d'éléments, les couleurs et le <code>viewBox</code> sont tous encore là,
+        modifiables. Une case permet de forcer le base64 pour la rare chaîne d'outils
+        qui l'exige."""
+
+[[faq]]
+q = "De combien le base64 alourdit-il mon image&nbsp;?"
+a = """
+        D'environ un tiers. Trois octets de fichier deviennent quatre caractères de
+        base64, soit 33&nbsp;% avant même le <code>data:image/png;base64,</code> de
+        tête. C'est le plancher, et il est incontournable&nbsp;: c'est ce que coûte
+        l'écriture d'octets quelconques avec les seuls caractères qu'une URL autorise.
+        C'est aussi pourquoi la page affiche le nombre de caractères à côté de la
+        taille du fichier, plutôt que de vous laisser le découvrir une fois la feuille
+        de style déployée."""
+
+[[faq]]
+q = "Quand mettre une image en ligne est-il vraiment une bonne idée&nbsp;?"
+a = """
+        Quand elle est petite et qu'elle est nécessaire tout de suite. Une icône de
+        2 KB dans une feuille de style que toutes les pages chargent est un gain
+        clair&nbsp;: un aller-retour de moins, et l'image est là dès que le CSS l'est.
+        Passé une dizaine de kilooctets, le marché s'inverse. Une image en ligne n'est
+        plus un fichier séparé&nbsp;: elle ne peut plus être mise en cache pour
+        elle-même, ni récupérée en parallèle d'autre chose, et elle est retéléchargée
+        en entier à chaque fois que le fichier qui l'entoure change &mdash; une
+        photographie de 200 KB dans une feuille de style, ce sont 200 KB ajoutés au
+        chemin critique de toutes les pages du site. La page vous dit de quel côté de
+        cette ligne tombe chaque résultat."""
+
+[[faq]]
+q = "Le gzip annule-t-il le surcoût du base64&nbsp;?"
+a = """
+        Moins qu'on ne le croit. Le base64 d'un fichier déjà compressé &mdash; ce que
+        sont un PNG, un JPEG et un WebP &mdash; se compresse mal, parce qu'il ne reste
+        presque aucune redondance à trouver pour le compresseur&nbsp;; vous en
+        récupérez typiquement quelque chose comme un dixième du tiers ajouté par le
+        base64, pas la totalité. Un SVG encodé en pourcents est le cas inverse&nbsp;:
+        c'est toujours du texte, il se compresse donc à peu près aussi bien qu'avant,
+        ce qui est une raison de plus de ne pas en passer un en base64."""
+
+[[faq]]
+q = "Cela modifie-t-il mon image&nbsp;?"
+a = """
+        Non, et c'est une différence délibérée avec la plupart des outils d'ici. Rien
+        n'est décodé en pixels puis réencodé&nbsp;: les octets qui sont sortis de votre
+        disque sont les octets qui entrent dans l'URI. Un JPEG reste exactement le JPEG
+        qu'il était, à la même qualité, aux mêmes dimensions. C'est la raison pour
+        laquelle le résultat peut être décrit comme le même fichier plutôt que comme
+        une copie."""
+
+[[faq]]
+q = "Mes données EXIF et GPS partent donc aussi dans la feuille de style&nbsp;?"
+a = """
+        Oui, et c'est la partie qui mérite réflexion avant de coller. Comme rien n'est
+        réencodé, tout ce que l'appareil a écrit voyage avec l'image&nbsp;: le lieu,
+        l'horodatage, le numéro de série de l'appareil. Sur une photographie de
+        téléphone, cela peut représenter 30 KB du fichier, ce qui devient 40 KB de
+        base64 sur le chemin critique de votre page, et une adresse personnelle dans
+        quelque chose qui sera versionné dans un dépôt. La page lit la quantité de
+        métadonnées présentes dans un JPEG, un PNG ou un WebP et le dit. Pour les
+        retirer d'abord, prenez le
+        <a href="../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a>."""
+
+[[faq]]
+q = "Pourquoi a-t-il utilisé un type différent de l'extension de mon fichier&nbsp;?"
+a = """
+        Parce que l'extension peut se tromper et les octets non. Un fichier nommé
+        <code>logo.png</code> qui a en réalité été exporté en JPEG est assez courant
+        pour que tout outil d'image doive s'en accommoder, et un data URI qui déclare
+        le mauvais type ne s'affiche tout simplement pas &mdash; sans repli et sans
+        message d'erreur digne d'être lu. Le type est donc lu dans les premiers octets
+        du fichier, qui disent sans ambiguïté ce qu'il est dans tous les formats
+        d'ici, et la page vous prévient quand les deux se contredisent."""
+
+[[faq]]
+q = "L'aperçu est vide. Qu'est-ce qui a échoué&nbsp;?"
+a = """
+        Sans doute rien du côté de l'URI. Le HEIC et le TIFF font tous deux des data
+        URI parfaitement valides qu'aucun navigateur sauf Safari ne dessinera&nbsp;:
+        l'image manquera donc aussi là où vous la collerez &mdash; convertissez-la
+        d'abord en PNG, JPEG ou WebP avec le
+        <a href="../compresser-une-image/">compresseur d'images</a> ou le
+        <a href="../redimensionner-une-image/">redimensionneur d'images</a>. Si le
+        format est ordinaire, c'est probablement le fichier lui-même qui est
+        endommagé&nbsp;: l'aperçu est dessiné à partir de l'URI construit par cette
+        page, et un aperçu vide veut donc dire que l'image n'a pas décodé."""
+
+[[faq]]
+q = "Y a-t-il une limite de taille à un data URI&nbsp;?"
+a = """
+        Aucune que vous rencontrerez en CSS ou dans une balise
+        <code>&lt;img&gt;</code>&nbsp;; les navigateurs modernes n'y imposent aucun
+        plafond pratique. Ce que les navigateurs limitent, c'est la saisie d'un data
+        URI dans la barre d'adresse, que la plupart refusent désormais dès que ce n'est
+        pas trivial, pour des raisons de sécurité qui n'ont rien à voir avec cet usage.
+        La vraie limite est celle ci-dessus&nbsp;: bien avant que quoi que ce soit de
+        technique ne casse, la page qui le contient est devenue plus lente qu'elle ne
+        l'aurait été avec un fichier image ordinaire."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Il n'y a pas non plus de limite au nombre ni à la
+        taille des fichiers, parce qu'aucun serveur ne les paie &mdash; le travail se
+        fait sur votre propre machine. Le site porte de la publicité, et c'est elle qui
+        le finance&nbsp;; les annonces ne reçoivent rien sur vos images."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait vos images ailleurs pour les encoder
+        s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Convertissez un PNG, un JPEG, un SVG, un WebP, un GIF ou un ICO en data URI prêt à coller dans du CSS ou du HTML. Base64 pour les formats matriciels et encodage en pourcents pour le SVG, enveloppés dans une règle CSS, une propriété personnalisée, une balise img ou du Markdown, avec le coût en taille et les métadonnées incorporées signalés. Tout se passe dans le navigateur, sans aucun envoi."
+features = [
+  "Data URI en base64 pour PNG, JPEG, WebP, GIF, ICO, AVIF et d'autres",
+  "Data URI SVG encodés en pourcents, plus courts que le base64 et qui restent lisibles",
+  "Règle CSS, propriété personnalisée CSS, balise img HTML ou Markdown déjà faites, toujours correctement mises entre guillemets",
+  "Le type de média lu dans les octets du fichier, pas dans son extension",
+  "Dit ce que l'encodage a coûté en caractères, et si la mise en ligne vaut le coup à cette taille",
+  "Prévient quand de l'EXIF, du XMP ou un profil colorimétrique est sur le point d'être copié dans votre feuille de style",
+  "Copie le fichier octet pour octet : aucun réencodage et aucune perte de qualité",
+  "Traitement par lots, tout copié ou téléchargé en un seul fichier",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]
+
+[picker]
+title = "Déposez vos images ici"
+hint = "ou cliquez pour parcourir &mdash; PNG, JPEG, SVG, WebP, GIF, ICO et d'autres"

--- a/locales/fr/tools/image-to-ico.html
+++ b/locales/fr/tools/image-to-ico.html
@@ -1,0 +1,186 @@
+<main>
+  <!-- Étape 1 &mdash; l'image -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir une image</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer de la liste</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="shape-note" class="field-summary" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; quelle norme -->
+  <section class="card" id="preset-card">
+    <h2><span class="step">2</span> Dire à quoi sert l'icône</h2>
+
+    <p class="card-lede">
+      Un fichier d'icône n'est pas une image mais plusieurs&nbsp;: le même logo
+      redessiné à chaque taille que réclame ce qui va le lire. Quelles tailles ce
+      sont n'est pas affaire de goût &mdash; un navigateur en veut trois, une
+      application sur un portable haute densité en veut dix, un Mac veut ses dix
+      à lui, et quelque chose écrit avant Windows Vista les veut stockées tout
+      autrement.
+    </p>
+
+    <!--
+      Which files to write. Windows and macOS read different containers and
+      neither will look at the other's, so this is a set of checkboxes rather
+      than a menu: wanting both is the normal case for anything shipped on both.
+    -->
+    <fieldset class="options outputs">
+      <legend>Ce qu'il faut fabriquer</legend>
+
+      <label class="check">
+        <input type="checkbox" id="want-ico" checked>
+        <span>
+          <strong>Icône Windows &mdash; <code>.ico</code></strong>
+          <span class="check-note">
+            Lue par tous les navigateurs comme favicon, et par Windows pour une
+            application, un raccourci et un dossier. Les tailles sont à vous de
+            les choisir ci-dessous.
+          </span>
+        </span>
+      </label>
+
+      <label class="check">
+        <input type="checkbox" id="want-icns">
+        <span>
+          <strong>Icône macOS &mdash; <code>.icns</code></strong>
+          <span class="check-note">
+            Ce que porte un bundle d'application Mac. Apple nomme exactement dix
+            emplacements, de 16 pixels à 1024&nbsp;: il n'y a donc rien à choisir,
+            les dix y vont, tirés de sept rendus, parce qu'un emplacement Retina
+            et la taille juste au-dessus sont la même image.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="pack-row">
+        <input type="checkbox" id="want-pack">
+        <span>
+          <strong>Le reste du jeu d'icônes d'un site web</strong>
+          <span class="check-note">
+            Un .ico couvre l'onglet du navigateur et Windows. Il ne couvre pas un
+            écran d'accueil d'iPhone, une invite d'installation Android, ni une
+            tuile épinglée au menu Démarrer &mdash; ceux-là lisent un PNG de
+            180 px, un manifeste d'application web et un fichier XML, dont aucun
+            n'ira regarder dans un .ico. Cochez ceci et vous les obtenez tous, le
+            manifeste, et le bloc de HTML à coller dans votre page.
+          </span>
+        </span>
+      </label>
+
+      <p id="output-summary" class="field-summary"></p>
+    </fieldset>
+
+    <div id="ico-settings">
+      <div class="presets" id="preset-list" role="radiogroup" aria-label="À quoi sert l'icône"></div>
+
+      <p id="preset-note" class="field-summary"></p>
+
+      <fieldset class="options" id="size-set">
+        <legend>Les tailles qui entrent dans le .ico</legend>
+        <div class="size-grid" id="size-grid"></div>
+        <p id="size-summary" class="field-summary"></p>
+      </fieldset>
+    </div>
+
+    <fieldset class="options">
+      <legend>Comment elle est dessinée</legend>
+
+      <div class="option-row">
+        <label for="fit-select">Si l'image n'est pas carrée</label>
+        <select id="fit-select">
+          <option value="pad" selected>La compléter en carré &mdash; l'image entière est gardée</option>
+          <option value="crop">Recadrer sur le carré du milieu</option>
+          <option value="stretch">L'étirer en carré</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="background-mode">Fond</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparent</option>
+          <option value="colour">Une couleur</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Couleur de fond" hidden>
+      </div>
+
+      <div class="option-row" id="storage-row">
+        <label for="storage-select">Comment chaque taille est stockée dans le .ico</label>
+        <select id="storage-select">
+          <option value="auto" selected>Automatique &mdash; compatible quand c'est peu cher, PNG sinon</option>
+          <option value="png">PNG pour toutes les tailles &mdash; fichier le plus léger, exige Vista ou plus récent</option>
+          <option value="bmp">Non compressé pour toutes les tailles &mdash; s'ouvre dans n'importe quoi, plusieurs fois plus lourd</option>
+        </select>
+      </div>
+
+      <p id="storage-note" class="field-summary"></p>
+    </fieldset>
+
+  </section>
+
+  <!-- Étape 3 &mdash; la voir petite, puis la prendre -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> La vérifier à la taille où elle sera vue</h2>
+
+    <p class="card-lede">
+      C'est la partie qui mérite un regard avant de télécharger quoi que ce soit.
+      Un logo parfaitement lisible à 512 pixels fait seize pixels de large dans
+      un onglet de navigateur, et ses parties fines &mdash; les traits d'un mot,
+      un filet, un dégradé &mdash; n'y survivent pas. Chaque carré ci-dessous est
+      dessiné à sa taille réelle à partir du fichier que vous avez choisi.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-strip" id="preview-strip"></div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make-icon" class="primary big" disabled>Fabriquer l'icône</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Prêt</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Tout télécharger en zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+
+      <!--
+        The block to paste into a page's <head>, shown rather than only zipped:
+        most people making a favicon are about to paste this into a template,
+        and a copy button is a shorter route than a download and a text editor.
+      -->
+      <div id="snippet" class="snippet" hidden>
+        <div class="snippet-head">
+          <h4>Collez ceci dans votre <code>&lt;head&gt;</code></h4>
+          <button type="button" id="copy-snippet" class="ghost">Copier</button>
+        </div>
+        <pre id="snippet-text"></pre>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/image-to-ico.toml
+++ b/locales/fr/tools/image-to-ico.toml
@@ -1,0 +1,352 @@
+#
+# Image en ICO - French.
+#
+# Overrides for tools/image-to-ico/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Image en ICO"
+heading = "Image&nbsp;en&nbsp;ICO <span class=\"h1-kw\">&mdash; créer un favicon et des icônes Windows et macOS</span>"
+tagline = "Une image en entrée. Toutes les tailles qu'un navigateur, Windows ou un Mac réclame, en sortie."
+
+title = "Image en ICO &mdash; créer un favicon, une icône d'application ou un ICNS, sans envoi"
+description = "Convertissez un PNG, un JPEG ou un SVG en un vrai .ico multi-tailles ou en .icns macOS, dans votre navigateur. Favicon, icône d'application Windows, icône d'application Mac, plus les fichiers Apple et Android dont un site a besoin. Rien n'est envoyé."
+og_title = "Créer un .ico ou un .icns contenant toutes les tailles, sans rien envoyer"
+og_description = "Un favicon.ico pour un site, un app.ico pour un programme Windows, un .icns pour un Mac - avec un aperçu à 16 pixels avant de télécharger. Tout tourne sur votre propre machine."
+og_image_alt = "Image en ICO - créer un favicon et des icônes Windows et macOS, sans envoi"
+
+pledge = """
+    La mise à l'échelle et les fichiers d'icônes eux-mêmes sont faits dans votre
+    propre navigateur. L'image est dessinée par le canvas que votre navigateur
+    embarque déjà, et chaque conteneur &mdash; le <code>.ico</code> de Windows,
+    le <code>.icns</code> de macOS &mdash; est assemblé à partir de ces pixels
+    par quelques centaines de lignes, dans <code>src/ico.js</code> et
+    <code>src/icns.js</code>, que vous pouvez lire. Cet outil n'a aucune fonction
+    réseau &mdash; rien à récupérer, rien à envoyer &mdash; et il n'y a à l'autre
+    bout de cette page aucun serveur auquel envoyer un logo, quand bien même il y
+    en aurait une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et fabriquez une icône. Pas une seule
+      requête ne transporte d'image, de vignette, de nom de fichier ni un octet
+      de ce que vous avez choisi. Ou coupez votre connexion et fabriquez-en une
+      quand même."""
+
+read_first = """
+, <code>src/ico.js</code> et
+      <code>src/icns.js</code> pour les deux formats d'icône &mdash; le
+      répertoire, les entrées et le masque dans l'un, les dix emplacements nommés
+      par Apple dans l'autre &mdash; et <code>src/sizes.js</code> pour l'origine
+      de chaque taille affichée sur la page."""
+
+howto_heading = "Comment créer un fichier .ico sans rien envoyer"
+
+card = """
+            Un favicon, une icône d'application Windows ou un .icns macOS &mdash;
+            toutes les tailles dans un fichier, avec un aperçu à 16 pixels avant
+            de télécharger."""
+
+[words]
+plural = "images"
+choose = "une image"
+analytics_extra = """, ni aucune des
+  tailles, des formats ou des noms de fichiers que cet outil calcule"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans filigrane"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Votre logo n'a nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où vos fichiers pourraient arriver, et rien dans le code qui les y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Il n'y a ni
+      <code>fetch</code>, ni <code>XMLHttpRequest</code>, ni
+      <code>sendBeacon</code> nulle part dans <code>src/</code>. La mise à
+      l'échelle est un <code>drawImage</code> sur un canvas&nbsp;; chaque icône
+      est un en-tête écrit devant ces pixels par <code>src/ico.js</code> ou
+      <code>src/icns.js</code>, dans cette page."""
+
+[[privacy]]
+title = "Le fichier est décrit à partir de ses propres octets."
+body = """
+ La liste des tailles
+      montrée à côté d'une icône finie n'est pas la liste des tailles que vous
+      avez demandées. Elle est relue dans le fichier qui vient d'être écrit, par
+      <code>readIcoDirectory</code> ou <code>readIcnsElements</code>&nbsp;: si un
+      écrivain contredisait un jour les réglages, la page le dirait, plutôt que
+      vous ne l'appreniez en voyant Windows ne rien dessiner et macOS afficher une
+      feuille blanche."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google, et le bouton de don de Buy
+      Me a Coffee. Aucun d'eux ne reçoit quoi que ce soit sur votre image. Chaque
+      ligne qui lit, met à l'échelle ou écrit un fichier est servie depuis cette
+      origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et l'outil est
+      inchangé, parce qu'il n'y a jamais eu d'étape réseau dedans. C'est la
+      preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez l'image."
+body = """
+ Déposez un PNG, un JPEG, un WebP ou un
+      SVG sur la zone prévue, ou prenez-en plusieurs et convertissez-les d'un
+      coup. Le carré est le plus simple, et tout ce qui fait 256 pixels ou plus a
+      assez de détail pour toutes les tailles. Le navigateur la lit directement
+      sur votre disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Choisissez les fichiers qu'il vous faut."
+body = """
+ Windows et un navigateur lisent
+      le <code>.ico</code>&nbsp;; un Mac lit le <code>.icns</code> et ne
+      regardera pas l'autre. Cochez l'un, ou les deux si ce que vous fabriquez
+      sort sur les deux. Un site web veut en plus les images Apple, Android et
+      tuile, et c'est la troisième case."""
+
+[[howto]]
+title = "Dites à quoi sert l'icône."
+body = """
+ Un favicon de site fait 16, 32 et 48
+      pixels&nbsp;; une application Windows veut aussi 256&nbsp;; une application
+      qui doit être correcte sur un portable haute densité veut les tailles
+      intermédiaires que Windows réclame aux échelles 125&nbsp;% et
+      150&nbsp;%. Prenez celle qui correspond au travail, ou cochez les tailles
+      vous-même. Chaque taille de la liste dit qui la réclame. Le
+      <code>.icns</code> n'offre pas ce choix&nbsp;: Apple nomme exactement dix
+      emplacements et les dix y vont."""
+
+[[howto]]
+title = "Réglez la forme et le fond."
+body = """
+ Une icône est carrée et la plupart des
+      logos ne le sont pas. Complétez et l'image entière est gardée, avec de
+      l'espace au-dessus et au-dessous&nbsp;; recadrez et c'est le milieu qui est
+      pris&nbsp;; étirez et elle est écrasée. La transparence est gardée comme
+      transparence, sauf si vous choisissez une couleur à mettre derrière."""
+
+[[howto]]
+title = "Regardez celle de 16 pixels avant de télécharger."
+body = """
+ C'est la taille à
+      laquelle l'icône sera le plus souvent vue, et c'est là que les traits fins
+      et les petites lettres disparaissent. Chaque carré de l'aperçu est dessiné à
+      sa taille réelle depuis votre propre fichier. Si la plus petite est une
+      tache, le remède est un dessin plus simple, pas un autre réglage."""
+
+[[howto]]
+title = "Prenez les fichiers."
+body = """
+ Un .ico avec toutes les tailles dedans,
+      nommé <code>favicon.ico</code> quand c'est ce que vous avez demandé, parce
+      que c'est l'adresse que les navigateurs cherchent. Un .icns à côté si vous
+      avez coché cela, prêt à entrer dans un bundle d'application Mac. Cochez en
+      plus le jeu pour site web et vous obtenez aussi les images Apple, Android et
+      tuile Windows, le manifeste, et le bloc de HTML à coller dans votre page.
+      Tout ce qui dépasse un fichier unique arrive en un seul zip."""
+
+[[faq]]
+q = "Mon image est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. L'image est décodée et mise à l'échelle par votre propre navigateur sur
+        votre propre matériel, et le .ico est assemblé à partir de ces pixels par du
+        code servi depuis cette page. Cet outil n'a aucune fonction réseau &mdash; il
+        ne récupère jamais rien et n'envoie jamais rien &mdash; et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter, dont aucune n'appartient à ce site."""
+
+[[faq]]
+q = "Quelles tailles un favicon.ico doit-il contenir&nbsp;?"
+a = """
+        16, 32 et 48. Ce n'est pas une préférence&nbsp;: 16 est ce qu'un navigateur
+        dessine dans un onglet, 32 ce que Windows utilise pour un raccourci de bureau
+        et ce que plusieurs navigateurs utilisent pour un signet, et 48 la taille à
+        laquelle Google lit l'icône d'un site. Tout ce qui est plus grand a sa place
+        dans un PNG à côté du .ico plutôt que dedans &mdash; et c'est ce que produit
+        ici le jeu pour site web."""
+
+[[faq]]
+q = "De quelles tailles une icône d'application Windows a-t-elle besoin&nbsp;?"
+a = """
+        16, 32, 48 et 256, ce que contient l'app.ico livrée par défaut avec Visual
+        Studio. 16 est la barre de titre et la petite vue de l'Explorateur, 32 le
+        bureau et la barre des tâches, 48 les icônes moyennes de l'Explorateur, et 256
+        le menu Démarrer et la vue très grande. Sur un écran haute densité, Windows
+        réclame aussi 20, 24, 40, 64 et 96, et les rééchantillonne depuis la taille la
+        plus proche s'ils manquent &mdash; le préréglage
+        &laquo;&nbsp;toutes les échelles&nbsp;&raquo; les met dedans."""
+
+[[faq]]
+q = "Pourquoi le fichier est-il plus gros que l'image de départ&nbsp;?"
+a = """
+        Parce qu'un .ico n'est pas une image mais plusieurs, et que les petites y sont
+        stockées sans compression pour que n'importe quoi puisse les lire. Une entrée
+        32x32 fait exactement 4 264 octets quel qu'en soit le contenu, et une entrée
+        256x256 non compressée fait 264 KB &mdash; c'est pourquoi les tailles au-dessus
+        de 64 sont stockées en PNG par défaut. Choisir
+        &laquo;&nbsp;PNG pour toutes les tailles&nbsp;&raquo; donne le plus petit
+        fichier possible&nbsp;; choisir le non compressé partout donne le plus
+        compatible."""
+
+[[faq]]
+q = "Quelle différence entre les entrées PNG et non compressées&nbsp;?"
+a = """
+        Seulement la façon dont les pixels sont stockés dans le .ico. Une entrée non
+        compressée est l'arrangement Windows d'origine &mdash; un en-tête bitmap, les
+        pixels à l'envers, et un masque de transparence d'un bit &mdash; et toutes les
+        versions de Windows jamais sorties savent la lire. Une entrée PNG est un
+        fichier PNG entier glissé dans l'icône, trois à dix fois plus petit aux grandes
+        tailles, mais compris seulement à partir de Windows Vista. Le réglage par
+        défaut utilise chacun là où il gagne&nbsp;: non compressé jusqu'à 64 pixels,
+        PNG au-dessus."""
+
+[[faq]]
+q = "Peut-il faire une icône plus grande que 256 pixels&nbsp;?"
+a = """
+        Non, et rien ne le peut. Le format stocke chaque côté sur un seul octet, et 0
+        est déjà pris &mdash; il veut dire 256. C'est le plafond&nbsp;: un .ico
+        contenant une image de 512 pixels n'est pas une icône plus grande, c'est une
+        icône cassée. S'il vous faut du 512, il vous faut un PNG, ce que le jeu pour
+        site web inclut pour Android et pour l'écran de démarrage d'une application
+        web."""
+
+[[faq]]
+q = "Garde-t-il la transparence&nbsp;?"
+a = """
+        Oui, dans les deux sortes d'entrées, et il écrit aussi l'ancien masque d'un bit
+        à côté du canal alpha, pour qu'un logiciel trop ancien pour lire l'alpha
+        découpe quand même l'icône au lieu de dessiner un carré noir. Le seul fichier
+        rendu opaque délibérément est l'icône Apple touch du jeu pour site web&nbsp;:
+        iOS la compose sur sa propre tuile et transforme la transparence en noir, elle
+        est donc aplatie sur votre couleur de fond, blanche par défaut."""
+
+[[faq]]
+q = "Mon logo est un mot large. Que lui arrive-t-il&nbsp;?"
+a = """
+        Quelque chose, forcément, puisqu'une icône est carrée. Compléter garde le tout
+        et le rend petit &mdash; un mot complété dans un carré de 16 pixels fait
+        environ trois pixels de haut et est illisible. Recadrer au milieu marche
+        généralement mieux&nbsp;: sortez le symbole de l'ensemble et servez-vous-en,
+        comme le font presque toutes les marques pour leur favicon. L'aperçu vous
+        montre lequel survit avant que vous téléchargiez quoi que ce soit."""
+
+[[faq]]
+q = "Que contient le jeu pour site web, et faut-il tout&nbsp;?"
+a = """
+        Sept PNG, un manifeste d'application web, un browserconfig.xml et un bloc de
+        HTML à coller. Il vous les faut parce qu'un .ico couvre les navigateurs et
+        Windows, et rien d'autre&nbsp;: un écran d'accueil d'iPhone lit un PNG de 180
+        pixels portant un nom à lui, Android et toutes les invites d'installation
+        lisent le manifeste, et une tuile épinglée au menu Démarrer lit le XML. Aucun
+        d'eux n'ira regarder dans un .ico. Tout est produit ici, sur votre machine, et
+        le zip contient une note disant à quoi sert chaque fichier."""
+
+[[faq]]
+q = "Peut-il faire aussi une icône macOS&nbsp;?"
+a = """
+        Oui &mdash; cochez <em>icône macOS</em> et vous obtenez un <code>.icns</code> à
+        côté du <code>.ico</code>, ou à sa place. C'est un autre conteneur pour la même
+        idée, et aucun des deux systèmes ne lira celui de l'autre&nbsp;: Windows veut
+        du .ico et un bundle d'application Mac veut du .icns. Les tailles n'y sont pas
+        un choix, parce qu'Apple publie exactement dix emplacements &mdash; 16, 32, 64,
+        128, 256, 512 et 1024 pixels, dont trois apparaissent deux fois comme version
+        Retina de la taille inférieure. Les dix y vont, tirés de sept rendus, et c'est
+        pourquoi un .icns est le fichier le plus gros."""
+
+[[faq]]
+q = "Comment utiliser le fichier .icns&nbsp;?"
+a = """
+        Pour une application, il va dans le bundle, à
+        <code>VotreApp.app/Contents/Resources/</code>, et il est nommé dans
+        <code>Info.plist</code> sous <code>CFBundleIconFile</code>&nbsp;; tous les
+        outils d'empaquetage Mac ont un champ pour cela. Pour le reste, sélectionnez le
+        fichier dans le Finder, faites Commande-C, puis Lire les informations sur le
+        dossier ou l'image disque à changer, cliquez la petite icône en haut à gauche
+        et faites Commande-V."""
+
+[[faq]]
+q = "Le .icns est-il identique à celui que fabrique iconutil&nbsp;?"
+a = """
+        Les mêmes dix emplacements avec les mêmes types de quatre lettres, et du PNG
+        dans chacun, ce que produit <code>iconutil</code> à partir d'un dossier
+        <code>.iconset</code>. Une différence délibérée&nbsp;: l'outil d'Apple écrit
+        aussi un élément <code>TOC&nbsp;</code>, un index des types et des longueurs
+        qui suivent. C'est une optimisation plutôt qu'une partie du format &mdash; un
+        lecteur sans index parcourt les éléments de bout en bout et arrive au même
+        résultat &mdash; et un index faux est pire que pas d'index, alors il est laissé
+        de côté."""
+
+[[faq]]
+q = "Puis-je convertir plusieurs images à la fois&nbsp;?"
+a = """
+        Oui. Chaque image de la liste devient son propre .ico avec les mêmes réglages,
+        et le lot arrive en un zip avec un dossier par image &mdash; sinon deux
+        d'entre eux s'appelleraient favicon.ico et l'un écraserait l'autre. Chaque
+        sortie que vous avez cochée est produite pour chaque image. Cliquez sur une
+        ligne pour mettre cette image dans l'aperçu."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Il n'y a pas non plus de limite au nombre ni à la
+        taille des fichiers, parce qu'aucun serveur ne les paie &mdash; le travail se
+        fait sur votre propre machine. Le site porte de la publicité, et c'est elle qui
+        le finance&nbsp;; les annonces ne reçoivent rien sur vos images."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait votre logo ailleurs pour le convertir
+        s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Convertissez une image en fichier ICO Windows multi-tailles ou en fichier ICNS macOS, depuis le navigateur. Préréglages pour un favicon de site, une icône d'application Windows et une icône d'application haute densité, les dix emplacements icns d'Apple, un aperçu de chaque taille à sa taille réelle en pixels, et un jeu facultatif des fichiers Apple, Android et tuile Windows dont un site a besoin. Rien n'est envoyé."
+features = [
+  "Écrit un vrai .ico multi-tailles, de 16 à 256 pixels",
+  "Écrit un .icns macOS avec les dix emplacements d'Apple, de 16 à 1024 pixels",
+  "Les deux formats à partir d'une seule image, en une passe, chaque taille n'étant dessinée qu'une fois",
+  "Préréglages pour un favicon de site, une icône d'application Windows, Windows haute densité, et compatibilité maximale",
+  "Chaque taille dit qui la réclame, pour que rien n'entre sans raison",
+  "Entrées non compressées pour les petites tailles et PNG pour les grandes, ou tout en l'un ou l'autre",
+  "Garde la transparence, et écrit aussi le masque de transparence d'avant Vista",
+  "Compléter, recadrer ou étirer une image qui n'est pas carrée, sur une couleur ou sur rien",
+  "Montre chaque taille à sa taille réelle en pixels avant le téléchargement",
+  "Jeu facultatif pour site web : icône Apple touch, icônes Android, icône masquable, tuile Windows, manifeste et le HTML à coller",
+  "Traitement par lots, tous les résultats dans un seul zip",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]
+
+[picker]
+title = "Déposez une image ici"
+hint = "ou cliquez pour parcourir &mdash; PNG, SVG, JPEG, WebP et tout ce que votre navigateur sait ouvrir"

--- a/locales/fr/tools/images-to-pdf.html
+++ b/locales/fr/tools/images-to-pdf.html
@@ -1,0 +1,230 @@
+<main>
+  <!-- Étape 1 &mdash; les images -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir des images</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" data-sort="name" class="ghost">Trier par nom</button>
+        <button type="button" data-sort="date" class="ghost">Trier par date</button>
+        <button type="button" data-sort="reverse" class="ghost">Inverser</button>
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Une image par page, dans cet ordre. Faites glisser par la poignée
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> pour déplacer une page,
+      ou servez-vous des flèches qui s'y trouvent.
+    </p>
+
+    <ul id="image-list" class="image-list"></ul>
+  </section>
+
+  <!-- Étape 2 &mdash; les pages -->
+  <section class="card">
+    <h2><span class="step">2</span> Mise en page</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Format de page</label>
+        <select id="page-size">
+          <option value="fit" selected>Ajuster la page à chaque image</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 in</option>
+          <option value="a3">A3 &mdash; 297 &times; 420 mm</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+          <option value="tabloid">Tabloid &mdash; 11 &times; 17 in</option>
+          <option value="custom">Personnalisé&hellip;</option>
+        </select>
+        <div id="custom-size" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="1" max="5000" step="1" value="210"
+                 aria-label="Largeur de page personnalisée">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="1" max="5000" step="1" value="297"
+                 aria-label="Hauteur de page personnalisée">
+          <select id="custom-unit" aria-label="Unité du format de page personnalisé">
+            <option value="mm" selected>mm</option>
+            <option value="in">in</option>
+          </select>
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Résolution d'impression</label>
+        <select id="dpi">
+          <option value="72">72 DPI &mdash; écran</option>
+          <option value="96">96 DPI</option>
+          <option value="150" selected>150 DPI</option>
+          <option value="200">200 DPI</option>
+          <option value="300">300 DPI &mdash; impression</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Décide de la taille d'une page pour un nombre de pixels donné. Cela ne
+          change pas l'image.
+        </p>
+      </div>
+
+      <div class="field" id="orientation-field" hidden>
+        <label for="orientation">Orientation</label>
+        <select id="orientation">
+          <option value="auto" selected>Suivre chaque image</option>
+          <option value="portrait">Portrait</option>
+          <option value="landscape">Paysage</option>
+        </select>
+      </div>
+
+      <div class="field" id="fit-field" hidden>
+        <label for="fit">Comment l'image se pose sur la page</label>
+        <select id="fit">
+          <option value="contain" selected>Tenir dans les marges</option>
+          <option value="cover">Remplir la page (rogne les bords)</option>
+          <option value="stretch">Étirer jusqu'aux marges (déforme)</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="margin">Marge</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="100" step="1" value="0"
+                 aria-label="Marge en millimètres">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="background">Couleur de page</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Apparaît dans les marges, et derrière tout ce qui est transparent.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="mode">Qualité des images</label>
+        <select id="mode">
+          <option value="keep" selected>Garder les JPEG exactement tels quels</option>
+          <option value="jpeg">Tout réencoder en JPEG</option>
+          <option value="lossless">Sans perte &mdash; aucune perte de compression</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualité JPEG</label>
+        <select id="quality">
+          <option value="0.75">Fichier plus léger</option>
+          <option value="0.88" selected>Équilibré</option>
+          <option value="0.95">Meilleure qualité</option>
+        </select>
+        <p class="field-note">Utilisé seulement pour les images que cet outil doit réencoder.</p>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Réduire les grandes images</label>
+        <select id="max-side">
+          <option value="0" selected>Jamais &mdash; garder la taille pleine</option>
+          <option value="4000">Plus grand côté 4000 px</option>
+          <option value="2000">Plus grand côté 2000 px</option>
+          <option value="1200">Plus grand côté 1200 px</option>
+        </select>
+        <p class="field-note" id="shrink-note"></p>
+      </div>
+    </div>
+
+    <details class="meta-panel">
+      <summary>Détails du document &mdash; tous facultatifs, tous vides par défaut</summary>
+      <div class="meta-body">
+        <p class="meta-note">
+          Un PDF porte un petit bloc d'informations sur lui-même, et la plupart
+          des outils le remplissent d'un horodatage et d'un nom de programme, que
+          vous l'ayez demandé ou non. Celui-ci écrit ce que vous tapez ici et rien
+          d'autre&nbsp;: pas de noms de fichiers, pas de nom de machine, et pas de
+          date sauf si vous cochez la case.
+        </p>
+        <div class="settings">
+          <div class="field">
+            <label for="doc-title">Titre</label>
+            <input type="text" id="doc-title" maxlength="200" spellcheck="false"
+                   placeholder="Omis si vide">
+          </div>
+          <div class="field">
+            <label for="doc-author">Auteur</label>
+            <input type="text" id="doc-author" maxlength="200" spellcheck="false"
+                   placeholder="Omis si vide">
+          </div>
+          <div class="field">
+            <label for="file-name">Nom du fichier</label>
+            <div class="inline-pair">
+              <input type="text" id="file-name" maxlength="120" spellcheck="false"
+                     value="images">
+              <span class="unit-label">.pdf</span>
+            </div>
+          </div>
+          <div class="field checkbox-field">
+            <label for="dated">
+              <input type="checkbox" id="dated">
+              Inscrire la date du jour dans le document
+            </label>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="480" height="640" aria-label="Aperçu d'une page"></canvas>
+        <p id="preview-empty" class="preview-empty">Ajoutez des images pour voir les pages</p>
+        <div id="preview-nav" class="preview-nav" hidden>
+          <button type="button" id="preview-prev" class="ghost" aria-label="Page précédente">&lsaquo;</button>
+          <span id="preview-label" class="preview-label"></span>
+          <button type="button" id="preview-next" class="ghost" aria-label="Page suivante">&rsaquo;</button>
+        </div>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Pages</dt><dd id="sum-pages">&mdash;</dd></div>
+        <div><dt>Format de page</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Images choisies</dt><dd id="sum-input">&mdash;</dd></div>
+        <div><dt>Recopiées intactes</dt><dd id="sum-copied">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Étape 3 &mdash; l'export -->
+  <section class="card">
+    <h2><span class="step">3</span> Créer le PDF</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Créer le PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Télécharger le PDF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/images-to-pdf.toml
+++ b/locales/fr/tools/images-to-pdf.toml
@@ -1,0 +1,233 @@
+#
+# Images en PDF - French.
+#
+# Overrides for tools/images-to-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Images en PDF"
+heading = "Images&nbsp;en&nbsp;PDF <span class=\"h1-kw\">&mdash; convertisseur JPG en PDF</span>"
+tagline = "Réunir vos images dans un seul document."
+
+title = "Convertisseur d'images en PDF &mdash; JPG en PDF gratuit, sans envoi"
+description = "Réunissez des images JPG, PNG ou WebP dans un seul PDF, gratuitement et entièrement dans votre navigateur. Les photos entrent sans être réencodées, et rien n'est envoyé."
+og_title = "Images en PDF &mdash; convertisseur JPG en PDF gratuit"
+og_description = "Réunissez des images dans un seul PDF sur votre propre machine. Les photos JPEG y sont recopiées intactes : rien ne perd en qualité et rien n'est envoyé."
+og_image_alt = "Images en PDF - réunir des images dans un document sans les envoyer"
+
+pledge = """
+    Le document est écrit en mémoire sur cette machine, page par page, par du
+    code servi depuis cette adresse. Rien ici ne sait faire un envoi, et il n'y a
+    à l'autre bout de cette page aucun serveur pour en recevoir un."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et fabriquez un PDF. Pas une seule requête ne
+      transporte d'image, de vignette ni de nom de fichier. Ou coupez votre
+      connexion et fabriquez-en un quand même."""
+
+read_first = """
+, ainsi que <code>src/pdf.js</code> et <code>src/document.js</code>
+      pour la totalité de l'écriture du fichier, qui ne touche jamais au
+      réseau."""
+
+howto_heading = "Comment transformer des images en PDF"
+
+card = """
+            Réunissez des images dans un seul PDF, une image par page. Les photos
+            JPEG y sont recopiées telles quelles, si bien que rien ne perd en
+            qualité."""
+
+[words]
+plural = "images"
+choose = "des images"
+analytics_extra = """"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[facts]]
+text = "Les fichiers restent sur votre appareil"
+
+[[privacy]]
+title = "Vos images n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Cet outil n'ajoute rien à
+      cette liste&nbsp;: il n'a aucune fonction réseau propre, pas même
+      facultative. Il n'y a ici aucun point de collecte où vos fichiers
+      pourraient arriver, et rien dans le code qui les y enverrait s'il en
+      existait un."""
+
+[[privacy]]
+title = "Le PDF est écrit ici."
+body = """
+ Un PDF, c'est une liste d'objets et une table
+      qui dit où chacun commence, et <code>src/pdf.js</code> écrit les deux.
+      Aucune bibliothèque n'est récupérée, rien n'est rendu sur un serveur, et le
+      fichier fini est remis directement à un téléchargement depuis la
+      mémoire."""
+
+[[privacy]]
+title = "On ne dit rien au document sur vous."
+body = """
+ La plupart des outils
+      tamponnent un PDF d'un horodatage et du nom du programme qui l'a fabriqué.
+      Celui-ci n'écrit un titre, un auteur et une date que si vous les tapez&nbsp;;
+      les noms de fichiers de vos images n'apparaissent jamais dans le document,
+      et rien sur votre machine non plus."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit
+      quoi que ce soit sur vos images&nbsp;: ni un fichier, ni une vignette, ni un
+      nom, une taille ou un nombre. Chaque ligne qui lit, décode ou écrit une
+      image est servie depuis cette origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Ce que le bouton de don charge, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; dans l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et se compose avec Google
+      Fonts. C'est un lien, rien de plus&nbsp;: il ne signale aucune visite, et
+      on ne lui donne rien sur vous ni sur vos images. Rien ne se passe tant que
+      vous ne cliquez pas, et ce vers quoi vous cliqueriez est le site de
+      quelqu'un d'autre."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et tout sur cette page
+      fonctionne encore. C'est la preuve la plus simple de toutes&nbsp;: un outil
+      qui expédierait vos images ailleurs pour en faire un document
+      s'arrêterait."""
+
+[[howto]]
+title = "Choisissez vos images."
+body = """
+ Déposez un dossier sur la zone prévue, ou
+      sélectionnez les fichiers à la main. Le navigateur les lit directement sur
+      votre disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Mettez les pages dans l'ordre, et tournez celles qui le demandent."
+body = """
+ Une
+      image devient une page, dans l'ordre affiché. Faites glisser une tuile par
+      sa poignée pour la déplacer, ou servez-vous des flèches&nbsp;; les boutons
+      de rotation tournent une page d'un quart de tour à la fois, ce dont un scan
+      couché a généralement besoin."""
+
+[[howto]]
+title = "Choisissez un format de page."
+body = """
+ &laquo;&nbsp;Ajuster la page à chaque
+      image&nbsp;&raquo; fait de chaque page exactement son image, sans rien
+      recadrer et sans bandes blanches. Les formats nommés &mdash; A4, Letter,
+      Legal et les autres &mdash; posent chaque image sur une page fixe à la
+      place, avec une marge si vous en voulez une."""
+
+[[howto]]
+title = "Créez le PDF et téléchargez-le."
+body = """
+ Le document est écrit sur votre
+      propre machine&nbsp;: la durée dépend donc de votre matériel et non d'une
+      file d'attente. Le fichier fini est remis directement aux téléchargements de
+      votre navigateur."""
+
+[[faq]]
+q = "Mes images sont-elles envoyées quelque part&nbsp;?"
+a = """
+        Non. Vos images sont lues et le PDF est écrit par votre propre navigateur sur
+        votre propre matériel. Cet outil n'a pas de côté serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter &mdash; aucune n'appartient à ce site. Contrairement à
+        certains autres outils d'ici, celui-ci n'a aucune fonction réseau facultative."""
+
+[[faq]]
+q = "Convertir en PDF fait-il perdre de la qualité&nbsp;?"
+a = """
+        Pas pour un JPEG, avec le réglage par défaut. Le PDF sait transporter des
+        données JPEG directement&nbsp;: une photographie est donc recopiée dans le
+        document octet pour octet, elle n'est jamais décodée ni recompressée, et
+        l'image dans le PDF est l'image du fichier. Les autres formats doivent être
+        réencodés, parce que le PDF n'a pas de filtre pour eux &mdash; sauf si vous
+        choisissez le réglage sans perte, qui les stocke exactement au prix d'un
+        fichier plus gros."""
+
+[[faq]]
+q = "Quels formats d'image puis-je utiliser&nbsp;?"
+a = """
+        Toute image fixe que votre navigateur sait décoder, ce qui en pratique veut
+        dire le JPG, le PNG, le WebP, le GIF, l'AVIF et, sur les appareils Apple, le
+        HEIC. Il n'y a pas ici de liste séparée à tenir à jour, parce que le décodage
+        est le travail du navigateur et non le nôtre."""
+
+[[faq]]
+q = "Puis-je choisir le format de page et l'ordre des pages&nbsp;?"
+a = """
+        Oui. Les pages peuvent être en A4, Letter, Legal, A3, A5, Tabloid, à un format
+        que vous tapez, ou exactement à la taille de chaque image. Faites glisser les
+        tuiles pour les réordonner, triez-les par nom ou par date, tournez-en une d'un
+        quart de tour, et réglez une marge en millimètres."""
+
+[[faq]]
+q = "Combien d'images puis-je mettre dans un seul PDF&nbsp;?"
+a = """
+        Aucune limite n'est intégrée à l'outil. Le plafond pratique est la mémoire de
+        votre propre machine, parce que le document fini y est assemblé avant que vous
+        le téléchargiez. Quelques centaines de photos de téléphone en pleine résolution
+        est la première chose à s'en ressentir&nbsp;; réduire le plus grand côté, dans
+        les réglages, repousse ce plafond bien plus loin."""
+
+[[faq]]
+q = "Le PDF contient-il mes noms de fichiers ou un horodatage&nbsp;?"
+a = """
+        Non, sauf si vous en demandez un. Le bloc d'informations du document est laissé
+        vide, à l'exception du nom de cet outil&nbsp;: pas de noms de fichiers, pas de
+        nom de machine, pas de nom d'utilisateur, et pas de date de création sauf si
+        vous cochez la case. C'est délibéré &mdash; un PDF est une chose que les gens
+        envoient à d'autres gens."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion et pas de période
+        d'essai. Le site porte de la publicité, et c'est elle qui le finance&nbsp;; les
+        annonces ne reçoivent rien sur vos images."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait vos images ailleurs pour en faire un
+        document s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Réunissez des images JPG, PNG et WebP dans un seul document PDF. Chaque page est écrite dans votre navigateur, si bien qu'aucune image n'est jamais envoyée."
+features = [
+  "Réunit des images JPG, PNG, WebP, GIF et AVIF dans un seul PDF",
+  "Les photos JPEG sont incorporées sans être réencodées",
+  "Formats de page de l'A5 au Tabloid, ou une page ajustée à chaque image",
+  "Réordonner, faire tourner, régler les marges et une couleur de page",
+  "Stockage sans perte facultatif pour les scans et les captures d'écran",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]
+
+[picker]
+title = "Déposez vos images ici"
+hint = "ou cliquez pour parcourir &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/fr/tools/images-to-video.html
+++ b/locales/fr/tools/images-to-video.html
@@ -1,0 +1,166 @@
+<main>
+  <!-- Étape 1 &mdash; les images -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir des images</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    {% include "partials/url-import.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Changer l'affichage de la liste">
+          <button type="button" data-view="large" class="active">Grand</button>
+          <button type="button" data-view="small">Petit</button>
+          <button type="button" data-view="list">Liste</button>
+          <button type="button" data-view="details">Détails</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Trier par nom</button>
+        <button type="button" data-sort="date" class="ghost">Trier par date</button>
+        <button type="button" data-sort="reverse" class="ghost">Inverser</button>
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Faites glisser une image par sa poignée <span class="grip" aria-hidden="true">&#8942;&#8942;</span>
+      pour réordonner, ou servez-vous des flèches sur chacune.
+    </p>
+
+    <ul id="image-list" class="image-list view-large"></ul>
+
+    <div id="bulk-duration" class="bulk" hidden>
+      <label for="bulk-amount">Tenir chaque image pendant</label>
+      <input type="number" id="bulk-amount" min="1" max="3600" step="1" value="1">
+      <select id="duration-unit" aria-label="Unité de la durée d'affichage de chaque image">
+        <option value="frames" selected>images</option>
+        <option value="seconds">secondes</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Appliquer à toutes</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Étape 2 &mdash; les réglages -->
+  <section class="card">
+    <h2><span class="step">2</span> Réglages de la vidéo</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="resolution">Résolution</label>
+        <select id="resolution">
+          <option value="auto" selected>Suivre la plus haute résolution</option>
+          <option value="3840x2160">3840 &times; 2160 &mdash; 4K</option>
+          <option value="1920x1080">1920 &times; 1080 &mdash; 1080p</option>
+          <option value="1280x720">1280 &times; 720 &mdash; 720p</option>
+          <option value="1080x1080">1080 &times; 1080 &mdash; carré</option>
+          <option value="1080x1920">1080 &times; 1920 &mdash; vertical</option>
+          <option value="custom">Personnalisée&hellip;</option>
+        </select>
+        <div id="resolution-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="7680" step="2" value="1920"
+                 aria-label="Largeur de sortie personnalisée, en pixels">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="7680" step="2" value="1080"
+                 aria-label="Hauteur de sortie personnalisée, en pixels">
+        </div>
+        <p class="field-note" id="resolution-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Cadence</label>
+        <select id="fps">
+          <option value="12">12 fps</option>
+          <option value="15">15 fps</option>
+          <option value="24">24 fps &mdash; cinéma</option>
+          <option value="25">25 fps &mdash; PAL</option>
+          <option value="30" selected>30 fps</option>
+          <option value="50">50 fps</option>
+          <option value="60">60 fps</option>
+          <option value="custom">Personnalisée&hellip;</option>
+        </select>
+        <input type="number" id="fps-custom" class="spaced" min="1" max="120" step="1" value="30"
+               aria-label="Cadence personnalisée, en images par seconde" hidden>
+        <p class="field-note" id="fps-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Cadrage des images</label>
+        <select id="fit">
+          <option value="contain" selected>Tenir dedans (bandes noires)</option>
+          <option value="blur">Tenir dedans, fond flouté</option>
+          <option value="cover">Remplir l'image (rogne les bords)</option>
+          <option value="stretch">Étirer pour remplir (déforme)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Couleur de fond</label>
+        <input type="color" id="background" value="#000000">
+      </div>
+
+      <div class="field">
+        <label for="quality">Qualité</label>
+        <select id="quality">
+          <option value="low">Fichier plus léger</option>
+          <option value="medium" selected>Équilibré</option>
+          <option value="high">Meilleure qualité</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format">
+          <option value="auto" selected>MP4 (recommandé)</option>
+          <option value="webm">WebM (repli)</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="640" height="360" aria-label="Aperçu de la première image"></canvas>
+        <p id="preview-empty" class="preview-empty">Ajoutez des images pour voir un aperçu</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Images</dt><dd id="sum-images">&mdash;</dd></div>
+        <div><dt>Durée</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Taille de sortie</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Images au total</dt><dd id="sum-frames">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Étape 3 &mdash; l'export -->
+  <section class="card">
+    <h2><span class="step">3</span> Créer la vidéo</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Créer la vidéo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Télécharger la vidéo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/images-to-video.toml
+++ b/locales/fr/tools/images-to-video.toml
@@ -1,0 +1,258 @@
+#
+# Images en vidéo - French.
+#
+# Overrides for tools/images-to-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# This is the one tool with a [picker.urls] table, so it is also the one whose
+# translation has to supply the noun the importer's warning in [ui.picker] is
+# written around. French needs it in the singular and with the gender the
+# articles in those sentences were written for - feminine, here - which is why
+# the warning is a whole sentence in the locale file rather than two fragments.
+#
+
+name = "Images en vidéo"
+heading = "Images&nbsp;en&nbsp;vidéo <span class=\"h1-kw\">&mdash; faire un diaporama MP4</span>"
+tagline = "Transformer un dossier d'images en vidéo."
+
+title = "Séquence d'images en MP4 &mdash; gratuit, sans envoi, hors ligne"
+description = "Transformez des images JPG, PNG ou WebP en un diaporama vidéo MP4, gratuitement et entièrement dans votre navigateur. Rien n'est envoyé, aucune inscription, et cela fonctionne hors ligne."
+og_title = "Séquence d'images en MP4 &mdash; gratuit, dans votre navigateur"
+og_description = "Transformez une séquence de rendu, un timelapse ou un dossier de photos en MP4. L'encodage tourne sur votre propre machine ; rien n'est envoyé."
+og_image_alt = "Images en vidéo - transformer un dossier d'images en diaporama MP4"
+
+pledge = """
+    Chaque image est encodée par votre propre navigateur et la vidéo est
+    construite en mémoire sur cette machine. L'encodeur ne touche jamais au
+    réseau, et il n'y a à l'autre bout de cette page aucun serveur auquel envoyer
+    une image, même s'il y touchait."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et fabriquez une vidéo. Pas une seule
+      requête ne transporte d'image, de vignette ni de nom de fichier. Ou coupez
+      votre connexion et fabriquez-en une quand même."""
+
+read_first = """
+, ainsi que <code>src/encoder.js</code> pour la boucle
+      d'encodage, qui ne touche jamais au réseau."""
+
+howto_heading = "Comment transformer des images en vidéo"
+
+card = """
+            Transformez un dossier d'images en diaporama MP4. L'encodage tourne
+            sur votre propre machine, avec votre propre matériel."""
+
+[words]
+plural = "images"
+choose = "des images"
+analytics_extra = """"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[facts]]
+text = "Les fichiers restent sur votre appareil"
+
+[[privacy]]
+title = "Vos images n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où vos fichiers pourraient arriver, et rien dans le code qui les y
+      enverrait s'il en existait un. Cette ligne disait autrefois
+      <code>connect-src 'none'</code>, ce qui était absolu&nbsp;; ajouter la
+      publicité a coûté cela, et le dire fait partie du marché."""
+
+[[privacy]]
+title = "L'encodage est local."
+body = """
+ WebCodecs tourne dans votre navigateur et le
+      fichier fini est remis directement à un téléchargement. Cette application
+      n'a pas de côté serveur."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit
+      quoi que ce soit sur vos images&nbsp;: ni un fichier, ni une vignette, ni un
+      nom, une taille ou un nombre. Chaque ligne qui lit, décode, compose ou
+      encode une image est servie depuis cette origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Ce que le bouton de don charge, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; dans l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et se compose avec Google
+      Fonts. C'est un lien, rien de plus&nbsp;: il ne signale aucune visite, et
+      on ne lui donne rien sur vous ni sur vos images. Rien ne se passe tant que
+      vous ne cliquez pas, et ce vers quoi vous cliqueriez est le site de
+      quelqu'un d'autre."""
+
+[[privacy]]
+title = "Une exception délibérée."
+body = """
+ Si vous utilisez
+      &laquo;&nbsp;Ajouter depuis une adresse web&nbsp;&raquo;, le serveur
+      concerné est contacté pour récupérer l'image et verra votre adresse IP.
+      Seules les images que vous collez sont récupérées, et seulement en
+      entrée&nbsp;: <code>img-src</code> est ouvert, <code>connect-src</code> ne
+      l'est pas. Le compteur ci-dessous liste toutes les origines extérieures
+      contactées."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et tout fonctionne
+      encore, sauf le chargement depuis une adresse web. C'est la preuve la plus
+      simple de toutes."""
+
+[[howto]]
+title = "Choisissez vos images."
+body = """
+ Déposez un dossier sur la zone prévue, ou
+      sélectionnez les fichiers à la main. Le navigateur les lit directement sur
+      votre disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Mettez-les en ordre et dites combien de temps chacune est tenue."
+body = """
+ Faites
+      glisser pour réordonner. La durée d'affichage peut être donnée en images ou
+      en secondes, pour toutes les images d'un coup ou une par une."""
+
+[[howto]]
+title = "Choisissez une résolution et une cadence."
+body = """
+ &laquo;&nbsp;Suivre la
+      plus haute résolution&nbsp;&raquo; se règle sur votre plus grande
+      image&nbsp;; les préréglages couvrent la 4K, le 1080p, le 720p, le carré et
+      le vertical, et il y a un format personnalisé si aucun ne convient."""
+
+[[howto]]
+title = "Créez la vidéo et téléchargez-la."
+body = """
+ L'encodage tourne sur votre
+      propre matériel&nbsp;: la durée dépend donc de votre machine et non d'une
+      file d'attente. Le MP4 fini est remis directement aux téléchargements de
+      votre navigateur."""
+
+[[faq]]
+q = "Mes images sont-elles envoyées quelque part&nbsp;?"
+a = """
+        Non. Vos images sont lues, composées et encodées par votre propre navigateur
+        sur votre propre matériel. Cet outil n'a pas de côté serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter &mdash; aucune n'appartient à ce site. La seule
+        exception est la fonction facultative
+        &laquo;&nbsp;ajouter depuis une adresse web&nbsp;&raquo;, qui récupère une
+        image que vous collez, et ce serveur-là voit votre adresse IP."""
+
+[[faq]]
+q = "Quels formats d'image puis-je utiliser&nbsp;?"
+a = """
+        Tout format d'image fixe que votre navigateur sait décoder, ce qui en pratique
+        veut dire le JPG, le PNG, le WebP, le GIF, l'AVIF et, sur les appareils Apple,
+        le HEIC. Il n'y a pas ici de liste séparée à tenir à jour, parce que le
+        décodage est le travail du navigateur et non le nôtre."""
+
+[[faq]]
+q = "Quel format vidéo produit-il&nbsp;?"
+a = """
+        Du MP4 avec de la vidéo H.264, qui se lit sur à peu près n'importe quoi. Dans
+        un navigateur sans WebCodecs, l'outil se rabat sur un enregistrement WebM
+        &mdash; les mêmes images dans un conteneur que moins d'éditeurs acceptent."""
+
+[[faq]]
+q = "Puis-je m'en servir pour une séquence de rendu Blender ou After Effects&nbsp;?"
+a = """
+        Oui &mdash; une séquence de rendu numérotée est exactement ce à quoi cela sert.
+        Ajoutez les images écrites par votre moteur de rendu, laissez la durée
+        d'affichage à une image chacune, et réglez la cadence sur celle du rendu.
+        &laquo;&nbsp;Trier par nom&nbsp;&raquo; compte comme vous vous y attendez, si
+        bien que <code>frame_2</code> se place avant <code>frame_10</code> et non
+        après.
+        <br><br>
+        Une chose à savoir avant de commencer&nbsp;: le H.264 n'a pas de canal alpha,
+        la transparence est donc aplatie sur la couleur de fond plutôt que reportée. Si
+        vous devez garder l'alpha, composez les images dans votre logiciel de montage à
+        la place."""
+
+[[faq]]
+q = "Puis-je faire un timelapse à partir de photos&nbsp;?"
+a = """
+        Oui, et c'est le même travail qu'une séquence de rendu&nbsp;: tenez chaque
+        photo une seule image et choisissez une cadence. À 30 images par seconde,
+        chaque trentaine de photos devient une seconde de vidéo&nbsp;; à 12, ces mêmes
+        photos durent deux secondes et demie.
+        <br><br>
+        &laquo;&nbsp;Trier par date&nbsp;&raquo; remet une pellicule dans l'ordre où
+        elle a été prise, ce qui compte quand les noms de fichiers sont repartis à
+        0001. Des photos de tailles différentes ne posent pas de problème &mdash;
+        &laquo;&nbsp;Suivre la plus haute résolution&nbsp;&raquo; dimensionne la vidéo
+        pour qu'aucune ne soit réduite."""
+
+[[faq]]
+q = "Y a-t-il une limite au nombre d'images ou à la durée de la vidéo&nbsp;?"
+a = """
+        Aucune limite n'est intégrée à l'outil. Le plafond pratique est la mémoire de
+        votre propre machine, parce que la vidéo finie y est assemblée avant que vous
+        la téléchargiez. Les très grands diaporamas en 4K sont la première chose à
+        s'en ressentir."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion et pas de période
+        d'essai. Le site porte de la publicité, et c'est elle qui le finance&nbsp;; les
+        annonces ne reçoivent rien sur vos images."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait vos images ailleurs pour les traiter
+        s'arrêterait à l'instant où vous débranchez."""
+
+[[faq]]
+q = "Puis-je ajouter de la musique ou une bande-son&nbsp;?"
+a = """
+        Pas encore. L'outil ne produit que de la vidéo&nbsp;: le MP4 qu'il écrit a une
+        seule piste vidéo et aucune piste audio. Ajoutez une bande-son ensuite dans un
+        logiciel de montage s'il vous en faut une."""
+
+[schema]
+browser_requirements = "Nécessite JavaScript. La sortie MP4 demande un navigateur avec WebCodecs ; les autres se rabattent sur le WebM."
+description = "Transformez un dossier d'images en un diaporama vidéo MP4. Chaque étape tourne dans votre navigateur, si bien qu'aucune image n'est jamais envoyée."
+features = [
+  "Convertit des images JPG, PNG, WebP, GIF et AVIF en vidéo",
+  "Sortie MP4 (H.264), avec le WebM comme repli",
+  "Résolutions jusqu'à 3840x2160, cadences de 12 à 60 images par seconde",
+  "Durée d'affichage par image, en images ou en secondes",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]
+
+[picker]
+title = "Déposez vos images ici"
+hint = "ou cliquez pour parcourir &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+[picker.urls]
+summary = "Ajouter depuis une adresse web"
+button = "Récupérer les images"
+# Singular, and the gender the sentences in [ui.picker] were written around:
+# feminine, because they say "la ... est copiée" and "quelle ... vous avez
+# demandée".
+noun = "image"

--- a/locales/fr/tools/qr-barcode.html
+++ b/locales/fr/tools/qr-barcode.html
@@ -1,0 +1,187 @@
+<main>
+  <!-- Étape 1 &mdash; quel type de code -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir le type de code</h2>
+
+    <p class="card-lede">
+      Un QR code contient n'importe quoi et c'est ce qu'un appareil photo de
+      téléphone cherche. Un code-barres contient un nombre, et celui qu'il vous
+      faut est en général décidé pour vous &mdash; par le magasin, l'entrepôt ou
+      le transporteur qui le réclame.
+    </p>
+
+    <div class="option-row">
+      <label for="symbology">Type de code</label>
+      <select id="symbology">
+        <optgroup label="Carré">
+          <option value="qr" selected>QR code</option>
+        </optgroup>
+        <optgroup label="À barres">
+          <option value="code128">Code 128</option>
+          <option value="ean13">EAN-13</option>
+          <option value="upca">UPC-A</option>
+          <option value="ean8">EAN-8</option>
+          <option value="itf14">ITF-14</option>
+          <option value="itf">Interleaved 2 of 5</option>
+          <option value="code39">Code 39</option>
+        </optgroup>
+      </select>
+    </div>
+
+    <p class="field-summary" id="symbology-note"></p>
+  </section>
+
+  <!-- Étape 2 &mdash; la chaîne elle-même -->
+  <section class="card">
+    <h2><span class="step">2</span> Dire ce qui va dedans</h2>
+
+    <div class="option-row" id="format-row">
+      <label for="format">Ce qu'il contient</label>
+      <select id="format"></select>
+    </div>
+
+    <p class="card-lede" id="format-note"></p>
+
+    <div id="fields" class="fields"></div>
+
+    <p id="input-error" class="error" role="alert" hidden></p>
+
+    <!--
+      The finished string, shown rather than hidden. A "Wi-Fi QR code" is an
+      ordinary QR code holding a line of text in a format phones recognise, and
+      when a phone does not act on one, this line is the thing to look at.
+    -->
+    <details class="encoded" id="encoded-panel">
+      <summary>La chaîne exacte que ce code contiendra</summary>
+      <pre id="encoded"></pre>
+      <p class="field-summary" id="encoded-note"></p>
+    </details>
+  </section>
+
+  <!-- Étape 3 &mdash; comment il est dessiné -->
+  <section class="card">
+    <h2><span class="step">3</span> Choisir son allure</h2>
+
+    <fieldset class="options" id="qr-options">
+      <legend>Le QR code</legend>
+
+      <div class="option-row">
+        <label for="level">Combien de dégâts il peut encaisser</label>
+        <select id="level">
+          <option value="L">L &mdash; environ 7 % récupérables, le code le plus petit</option>
+          <option value="M" selected>M &mdash; environ 15 %, le choix habituel</option>
+          <option value="Q">Q &mdash; environ 25 %</option>
+          <option value="H">H &mdash; environ 30 %, pour un imprimé qui va s'user</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="quiet">Marge, en modules</label>
+        <input type="number" id="quiet" value="4" min="0" max="16" step="1" inputmode="numeric">
+      </div>
+
+      <p class="field-summary">
+        La marge fait partie du code, ce n'est pas de l'espace autour de lui.
+        Quatre modules, voilà ce que demande la spécification, et un code rogné
+        au ras du bord est un code que bien des scanners ne verront pas du tout.
+      </p>
+    </fieldset>
+
+    <fieldset class="options" id="barcode-options" hidden>
+      <legend>Le code-barres</legend>
+
+      <div class="option-row">
+        <label for="bar-width">Barre la plus fine, en pixels</label>
+        <input type="number" id="bar-width" value="2" min="1" max="10" step="1" inputmode="numeric">
+      </div>
+
+      <div class="option-row">
+        <label for="bar-height">Hauteur des barres, en pixels</label>
+        <input type="number" id="bar-height" value="120" min="20" max="600" step="10" inputmode="numeric">
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="show-text" checked>
+        <span>
+          <strong>Imprimer les caractères en dessous</strong>
+          <span class="check-note">
+            Ce qu'une personne lit quand le scanner refuse. Sur un code du
+            commerce, les chiffres se placent aussi dans les marges, et c'est
+            délibéré&nbsp;: ils balisent l'espace blanc que personne ne devrait
+            rogner.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="code39-check-row" hidden>
+        <input type="checkbox" id="code39-check">
+        <span>
+          <strong>Ajouter un caractère de contrôle</strong>
+          <span class="check-note">
+            Le Code 39 n'en porte normalement pas. Certains systèmes l'exigent&nbsp;;
+            ne l'ajoutez que si le vôtre le fait, parce qu'un lecteur qui ne
+            l'attend pas le lira comme un caractère de plus à la fin.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Couleur et taille</legend>
+
+      <div class="colour-row">
+        <div class="option-row">
+          <label for="foreground">Le code</label>
+          <input type="color" id="foreground" value="#000000">
+        </div>
+        <div class="option-row">
+          <label for="background">Derrière lui</label>
+          <input type="color" id="background" value="#ffffff">
+        </div>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="transparent">
+        <span>
+          <strong>Pas de fond du tout</strong>
+          <span class="check-note">
+            Transparent, pour le poser sur quelque chose qui a déjà une couleur.
+            Le SVG et le PNG le gardent tous deux&nbsp;; ce qui finit derrière
+            doit être clair, sinon un scanner ne trouvera aucun contraste.
+          </span>
+        </span>
+      </label>
+
+      <div class="option-row" id="size-row">
+        <label for="size">Taille de l'image, en pixels</label>
+        <input type="number" id="size" value="512" min="64" max="4096" step="16" inputmode="numeric">
+      </div>
+
+      <p class="field-summary" id="size-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Étape 4 &mdash; le résultat -->
+  <section class="card" id="result-card">
+    <h2><span class="step">4</span> Le prendre</h2>
+
+    <div class="preview" id="preview" role="img" aria-label="Le code que vous avez fabriqué"></div>
+
+    <p class="facts" id="facts"></p>
+
+    <div class="run-row">
+      <button type="button" id="download-svg" class="primary">Télécharger le SVG</button>
+      <button type="button" id="download-png" class="primary">Télécharger le PNG</button>
+      <button type="button" id="copy-png" class="ghost">Copier l'image</button>
+    </div>
+
+    <p class="field-summary" id="download-note" role="status"></p>
+
+    <p class="field-summary">
+      Le SVG est celui à garder. C'est le code sous forme d'instructions plutôt
+      que de pixels&nbsp;: il s'imprime à n'importe quelle taille sans s'adoucir
+      &mdash; ce qui compte ici plus que pour la plupart des images, parce qu'un
+      bord flou est précisément ce qu'un scanner ne sait pas résoudre.
+    </p>
+  </section>
+</main>

--- a/locales/fr/tools/qr-barcode.toml
+++ b/locales/fr/tools/qr-barcode.toml
@@ -1,0 +1,349 @@
+#
+# Générateur de QR codes et de codes-barres - French.
+#
+# Overrides for tools/qr-barcode/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# The format names stay as they are - EAN-13, UPC-A, ITF-14, Code 128, Code 39
+# are the names printed on the specification and on whatever is going to scan
+# the label, and a translated one would name nothing.
+#
+
+name = "Générateur de QR codes et de codes-barres"
+heading = "QR&nbsp;&amp;&nbsp;code-barres <span class=\"h1-kw\">&mdash; créer un QR code ou un code-barres, hors ligne</span>"
+tagline = "Vous le tapez, cela devient un code. Rien n'est envoyé pour en fabriquer un."
+
+title = "Générateur de QR codes et de codes-barres &mdash; gratuit, sans inscription, sans envoi"
+description = "Créez un QR code pour un lien, un réseau Wi-Fi ou une carte de visite, ou un code-barres EAN-13, UPC-A, Code 128 ou Code 39. Téléchargez en SVG ou en PNG. Tout se passe dans votre navigateur."
+og_title = "Créer un QR code ou un code-barres sans rien envoyer à personne"
+og_description = "Liens, mots de passe Wi-Fi, cartes de visite et codes-barres du commerce, dessinés dans votre propre navigateur et téléchargés en SVG ou en PNG. Sans compte, sans filigrane, sans pixel espion au milieu de votre code."
+og_image_alt = "Générateur de QR codes et de codes-barres - créer un QR code ou un code-barres, sans envoi"
+
+pledge = """
+    Un QR code, c'est de l'arithmétique sur une chaîne de caractères&nbsp;: il n'y
+    a pas de fichier à envoyer et pas de service à interroger. Chaque étape
+    &mdash; le choix du mode, celui de la version, la correction d'erreurs de
+    Reed-Solomon, le masque, les barres d'un code-barres et la clé de contrôle en
+    dessous &mdash; se passe dans un millier de lignes de JavaScript, dans cette
+    page, que vous pouvez lire. Cet outil n'a aucune fonction réseau, ce qui
+    compte ici plus que sur la plupart des pages&nbsp;: la chose encodée est
+    souvent un mot de passe Wi-Fi."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et tapez un mot de passe dans le formulaire
+      Wi-Fi. Pas une seule requête n'en transporte un caractère. Ou coupez votre
+      connexion et fabriquez le code quand même."""
+
+read_first = """
+, <code>src/qr-encode.js</code>
+      et <code>src/qr.js</code> pour le QR code lui-même &mdash; les modes, la
+      version et les blocs dans l'un, les motifs, le masque et les bits de format
+      dans l'autre &mdash; <code>src/gf256.js</code> pour la correction
+      d'erreurs, et <code>src/barcode.js</code> pour les codes à barres."""
+
+howto_heading = "Comment créer un QR code sans rien envoyer"
+
+card = """
+            Un QR code pour un lien, un réseau Wi-Fi ou une carte de visite
+            &mdash; ou un code-barres du commerce avec sa clé de contrôle
+            calculée. SVG ou PNG."""
+
+[words]
+plural = "codes et le texte qu'ils contiennent"
+choose = "ce qui va dedans"
+analytics_extra = """, ni un seul
+  caractère de ce que vous tapez"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans expiration"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Ce que vous tapez n'a nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où un mot de passe Wi-Fi pourrait arriver, et rien dans le code
+      qui l'y enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Il n'y a ni
+      <code>fetch</code>, ni <code>XMLHttpRequest</code>, ni
+      <code>sendBeacon</code> nulle part dans <code>src/</code>. Le code est
+      construit à partir de la chaîne par arithmétique et dessiné en SVG, dans
+      cette page, sur votre machine."""
+
+[[privacy]]
+title = "Le code ne pointe pas vers nous."
+body = """
+ Ce que vous tapez est ce que
+      le code contient. Plusieurs générateurs gratuits vous rendent un code
+      contenant un lien vers leur propre site, qui redirige ensuite vers le
+      vôtre &mdash; chaque scan est donc compté par eux, et le code cesse de
+      fonctionner le jour où ils arrêtent de payer le domaine ou décident que
+      l'offre gratuite a expiré. Rien ici ne raccourcit, ne redirige ni ne
+      piste&nbsp;: la chaîne affichée sur la page est la chaîne qui est dans
+      l'image."""
+
+[[privacy]]
+title = "Le PNG est fabriqué à partir du SVG affiché."
+body = """
+ Le téléchargement
+      n'est pas un second rendu qui pourrait contredire l'aperçu. Le même
+      balisage est remis au navigateur et peint sur un canvas, ce qui est aussi
+      pourquoi cela peut se faire sans contacter quoi que ce soit&nbsp;: il n'y a
+      aucune police à récupérer et aucune image à charger dedans."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google, et le bouton de don de Buy
+      Me a Coffee. Aucun d'eux ne reçoit quoi que ce soit de ce que vous tapez.
+      Chaque ligne qui transforme une chaîne en code est servie depuis cette
+      origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et l'outil est
+      inchangé, parce qu'il n'y a jamais eu d'étape réseau dedans. C'est la
+      preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez le type de code."
+body = """
+ Un QR code contient n'importe quoi
+      et c'est ce qu'un appareil photo de téléphone cherche&nbsp;: c'est donc la
+      réponse, sauf si on vous a dit autre chose. Un code-barres contient un
+      nombre, et celui qu'il vous faut est décidé par qui va le scanner &mdash;
+      un magasin veut un EAN-13 ou un UPC-A, un carton d'expédition un ITF-14, et
+      tout ce qui est interne est en général du Code 128."""
+
+[[howto]]
+title = "Dites ce qui va dedans."
+body = """
+ Un lien est le cas courant, et les
+      champs au-dessus construisent les autres formats que les téléphones
+      connaissent&nbsp;: un réseau Wi-Fi qui propose de s'y connecter, une carte
+      de visite qui propose d'être enregistrée, un courriel, un SMS, un numéro de
+      téléphone, un point sur une carte. Quel que soit votre choix, la chaîne
+      finie est affichée sur la page &mdash; c'est tout ce qu'un QR code contient
+      jamais."""
+
+[[howto]]
+title = "Choisissez combien de dégâts il peut encaisser."
+body = """
+ Les quatre niveaux
+      mettent plus ou moins de correction d'erreurs, et plus de correction veut
+      dire un code plus grand et plus dense. Le L suffit pour un écran, le M pour
+      du papier ordinaire, et le H pour ce qui sera manipulé, imprimé petit ou
+      collé sur une vitrine au soleil. Un code sur un menu qu'on essuie tous les
+      jours vaut un Q ou un H."""
+
+[[howto]]
+title = "Réglez la taille, la marge et les couleurs."
+body = """
+ La marge fait partie du code&nbsp;:
+      quatre modules de silence tout autour, voilà ce que demande la
+      spécification, et la rogner est de loin la première raison pour laquelle un
+      code imprimé refuse de se scanner. Sombre sur clair, avec un vrai contraste
+      &mdash; un scanner lit la différence entre les deux, alors un gris pâle sur
+      blanc ne convient pas, et le clair sur sombre échoue carrément sur bon
+      nombre de lecteurs."""
+
+[[howto]]
+title = "Vérifiez-le avec le téléphone que vous avez."
+body = """
+ Avant d'en imprimer mille,
+      scannez celui qui est à l'écran. Cela prend dix secondes et attrape toute
+      la catégorie d'erreurs qu'un aperçu ne peut pas voir&nbsp;: un mot de passe
+      Wi-Fi avec un caractère qui demandait d'être échappé, un lien à qui il
+      manquait son <code>https://</code>, un numéro de code-barres à qui il
+      manque un chiffre."""
+
+[[howto]]
+title = "Prenez le SVG."
+body = """
+ C'est le code sous forme d'instructions
+      plutôt que de pixels&nbsp;: il s'imprime à n'importe quelle taille sans
+      s'adoucir, et un bord adouci est précisément ce qu'un scanner ne sait pas
+      résoudre. Prenez aussi le PNG si ce dans quoi vous collez refuse un SVG&nbsp;;
+      il est dessiné à un nombre entier de pixels par module, il n'a donc pas de
+      bords flous non plus."""
+
+[[faq]]
+q = "Ce que je tape est-il envoyé quelque part&nbsp;?"
+a = """
+        Non. Un QR code est de l'arithmétique sur une chaîne de caractères, et cette
+        arithmétique tourne dans votre propre navigateur sur votre propre machine. Cet
+        outil n'a aucune fonction réseau &mdash; il ne récupère jamais rien et n'envoie
+        jamais rien &mdash; et la <code>Content-Security-Policy</code> de la page nomme
+        toutes les adresses qu'elle peut contacter, dont aucune n'appartient à ce site.
+        Cela vaut plus ici que sur la plupart des pages, parce que la chose que les
+        gens mettent le plus souvent dans un QR code est le mot de passe de leur
+        Wi-Fi."""
+
+[[faq]]
+q = "Ces codes expirent-ils, ou cessent-ils de fonctionner un jour&nbsp;?"
+a = """
+        Non, et ils ne le peuvent pas. Ce que vous tapez est ce que le code contient&nbsp;:
+        le scanner rend donc exactement cette chaîne, pour toujours. Les codes qui
+        expirent sont ceux qui ont l'adresse de quelqu'un d'autre dedans&nbsp;: un QR
+        code &laquo;&nbsp;dynamique&nbsp;&raquo; contient un lien vers le serveur du
+        générateur, qui redirige vers le vôtre, ce qui leur permet de compter chaque
+        scan, de changer la destination, ou de tout éteindre quand une période d'essai
+        se termine. Rien ici ne redirige par quoi que ce soit."""
+
+[[faq]]
+q = "Est-ce gratuit, et puis-je m'en servir commercialement&nbsp;?"
+a = """
+        C'est gratuit, il n'y a pas de compte, pas de filigrane et aucune limite au
+        nombre que vous en faites, et vous pouvez mettre le résultat sur un produit,
+        une affiche ou une devanture. QR Code est une marque déposée de Denso Wave, qui
+        a déclaré ne pas la faire valoir contre les gens qui utilisent les codes
+        &mdash; la spécification est publiée sous le nom ISO/IEC 18004 et est libre
+        d'implémentation, ce que fait cette page. Le site porte de la publicité, et
+        c'est elle qui le finance."""
+
+[[faq]]
+q = "Quel niveau de correction d'erreurs choisir&nbsp;?"
+a = """
+        Le M, sauf raison particulière. Le L fait le code le plus petit et convient sur
+        un écran&nbsp;; le M survit à une manipulation ordinaire&nbsp;; le Q et le H
+        sont pour un code qui sera imprimé petit, plastifié, collé sur une vitre ou
+        partiellement recouvert par un logo. Chaque cran ajoute des données de
+        contrôle, ce qui demande un symbole plus grand pour la même quantité de texte
+        &mdash; passer de L à H double à peu près le nombre de modules pour la même
+        chaîne."""
+
+[[faq]]
+q = "Combien un QR code peut-il contenir&nbsp;?"
+a = """
+        À la plus grande taille, 177 modules de côté, jusqu'à 7 089 chiffres, 4 296
+        majuscules et chiffres, ou 2 953 octets de n'importe quoi d'autre &mdash; et
+        cela à la correction d'erreurs la plus faible&nbsp;; à la plus forte, c'est
+        environ un tiers de cela. En pratique, la limite n'est pas le format mais le
+        scanner&nbsp;: passé quelques centaines de caractères, les modules deviennent
+        si petits qu'un appareil photo de téléphone ordinaire ne les résout plus à bout
+        de bras. Un code long est en général le signe qu'un lien court aurait dû y
+        aller à la place."""
+
+[[faq]]
+q = "Pourquoi mon code est-il plus gros quand j'écris le lien en minuscules&nbsp;?"
+a = """
+        Parce qu'un QR code a un mode pour les majuscules et les chiffres qui tasse
+        deux caractères en onze bits, et aucun mode équivalent pour les minuscules, qui
+        coûtent huit bits chacune. Une URL écrite
+        <code>HTTPS://EXEMPLE.COM/PAGE</code> peut être un tiers plus petite que la
+        même URL en minuscules. Le schéma et l'hôte sont insensibles à la casse&nbsp;:
+        les crier ne change rien d'autre que la taille. Le chemin après l'hôte, lui,
+        n'est pas insensible à la casse, alors n'y touchez pas."""
+
+[[faq]]
+q = "Sait-il lire un QR code aussi bien qu'en fabriquer un&nbsp;?"
+a = """
+        Pas encore. Le lire, c'est décoder une image &mdash; trouver le symbole dans
+        une photographie, corriger l'angle de la prise de vue, et réparer les dégâts
+        &mdash; ce qui est un travail différent et bien plus lourd que d'en dessiner
+        un. Cela pourrait être construit ici aux mêmes conditions que tout le reste, et
+        c'est sur la liste. En attendant, l'appareil photo de votre téléphone le fait
+        déjà, et le fait bien."""
+
+[[faq]]
+q = "À quoi sert la marge, et puis-je la réduire&nbsp;?"
+a = """
+        L'espace blanc autour d'un QR code fait partie du code. Un lecteur s'en sert
+        pour trouver où le symbole s'arrête, et la spécification demande quatre modules
+        de chaque côté&nbsp;; un code-barres en veut une dizaine. Vous pouvez la mettre
+        à zéro ici et l'image aura l'air plus nette, et bon nombre de scanners ne la
+        verront alors plus du tout &mdash; surtout sur un fond chargé. Si c'est la
+        place qui manque, faites le code plus petit plutôt que de rogner sa marge."""
+
+[[faq]]
+q = "De quel code-barres ai-je besoin&nbsp;?"
+a = """
+        De celui que demande la personne qui va le scanner. L'EAN-13 est le code-barres
+        du commerce hors Amérique du Nord et l'UPC-A celui d'Amérique du Nord &mdash;
+        les deux exigent un numéro qui vous est attribué par GS1, parce que le numéro
+        identifie votre entreprise et pas seulement le produit. L'EAN-8 est la version
+        courte pour les petits emballages. L'ITF-14 va sur le carton d'expédition. Le
+        Code 128 et le Code 39 contiennent du texte aussi bien que des chiffres et ne
+        demandent aucun enregistrement, ce qui en fait la bonne réponse pour tout ce
+        qui est interne&nbsp;: parc matériel, rayonnages, fiches de travail."""
+
+[[faq]]
+q = "Qu'est-ce qu'une clé de contrôle, et pourquoi l'outil en a-t-il ajouté une&nbsp;?"
+a = """
+        C'est le dernier chiffre d'un code-barres du commerce, calculé à partir de ceux
+        qui précèdent, pour qu'un scanner puisse distinguer une mauvaise lecture d'une
+        bonne. L'EAN-13 veut douze chiffres et calcule le treizième&nbsp;; l'UPC-A en
+        veut onze et calcule le douzième. Tapez le numéro court et cette page l'ajoute.
+        Tapez le numéro complet et elle vérifie celui que vous avez donné &mdash; et
+        refuse, plutôt que de le corriger en silence, parce qu'un chiffre faux
+        discrètement réparé, c'est une étiquette qui se scanne comme le produit de
+        quelqu'un d'autre."""
+
+[[faq]]
+q = "Puis-je mettre un logo au milieu d'un QR code&nbsp;?"
+a = """
+        Pas ici, mais la raison pour laquelle cela marche ailleurs vaut d'être
+        sue&nbsp;: c'est la correction d'erreurs qui le rend possible. Au niveau H,
+        environ 30&nbsp;% des modules peuvent être détruits sans que le code cesse
+        d'être lisible&nbsp;: un logo qui en couvre nettement moins au centre &mdash;
+        là où ne se trouve aucun motif de repérage &mdash; est un dégât réparable.
+        Passez le code dans votre logiciel d'image au niveau H, gardez le logo sous
+        environ un cinquième de la surface, et testez-le avec un vrai téléphone plutôt
+        que de lui faire confiance."""
+
+[[faq]]
+q = "Pourquoi le SVG vaut-il mieux que le PNG&nbsp;?"
+a = """
+        Parce qu'un code, ce sont des bords, et qu'un PNG a un nombre fixe de pixels
+        pour les faire. Agrandissez-en un et chaque bord s'adoucit&nbsp;; un bord
+        adouci est précisément ce qui gêne un scanner, et une imprimante à 1200 dpi à
+        qui on donne un PNG de 512 pixels se voit demander d'inventer la différence. Un
+        SVG, ce sont les carrés sous forme d'instructions&nbsp;: il s'imprime net sur
+        une carte de visite comme sur un panneau publicitaire. Le PNG proposé ici est
+        dessiné à un nombre entier de pixels par module, ce qui est le mieux qu'un PNG
+        puisse faire."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait votre texte ailleurs pour qu'on y
+        dessine un code s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Produisez un QR code ou un code-barres linéaire à partir d'une chaîne de caractères, dans le navigateur. QR codes pour des liens, des réseaux Wi-Fi, des cartes de visite, des courriels, des SMS, des numéros de téléphone et des coordonnées, avec les quatre niveaux de correction d'erreurs ; codes-barres EAN-13, EAN-8, UPC-A, ITF-14, Interleaved 2 of 5, Code 128 et Code 39 avec leurs clés de contrôle. Téléchargement en SVG ou en PNG. Rien n'est envoyé."
+features = [
+  "QR codes de la version 1 à la version 40, en mode numérique, alphanumérique et octet",
+  "Les quatre niveaux de correction d'erreurs, avec ce que chacun coûte dit à voix haute",
+  "Formats prêts à l'emploi : réseau Wi-Fi, carte de visite, courriel, SMS, numéro de téléphone, point sur une carte",
+  "Montre la chaîne exacte que le code contiendra, au lieu de la cacher",
+  "EAN-13, EAN-8 et UPC-A, avec la clé de contrôle calculée ou vérifiée",
+  "ITF-14 et Interleaved 2 of 5 pour les cartons et la logistique",
+  "Code 128 avec passage automatique en mode numérique, et Code 39 avec caractère de contrôle facultatif",
+  "Chiffres lisibles imprimés sous un code-barres, aux bons endroits",
+  "Sortie SVG, qui s'imprime net à toute taille, et un PNG dessiné à un nombre entier de pixels par module",
+  "Deux couleurs quelconques, ou pas de fond du tout",
+  "Ne redirige jamais : pas de lien court, pas de pistage, rien qui puisse expirer",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]

--- a/locales/fr/tools/resize-image.html
+++ b/locales/fr/tools/resize-image.html
@@ -1,0 +1,282 @@
+<main>
+  <!-- Étape 1 &mdash; les fichiers -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir des images</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer de la liste</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; le recadrage -->
+  <section class="card" id="crop-card">
+    <h2><span class="step">2</span> Recadrer, si vous voulez</h2>
+
+    <p class="card-lede">
+      Le cadre part sur l'image entière&nbsp;: laisser cette étape tranquille ne
+      recadre donc rien. Chaque image garde son propre cadre &mdash; prenez-en
+      une dans la liste ci-dessus pour dessiner dessus. Le recadrage a lieu avant
+      le redimensionnement, seul ordre qui ait du sens&nbsp;: une image coupée
+      après avoir été réduite a déjà jeté les pixels dont elle avait besoin.
+    </p>
+
+    <p id="crop-empty" class="field-summary">Ajoutez une image et le cadre apparaît ici.</p>
+
+    <div id="crop-controls" hidden>
+      <p class="stage-hint">
+        <span id="stage-name" class="stage-name"></span>
+        Faites glisser depuis l'intérieur du cadre pour le déplacer, ou par un
+        coin pour le redimensionner. Le cadre étant sélectionné, les flèches le
+        déplacent d'un pixel à la fois,
+        <kbd>Alt</kbd>&nbsp;+&nbsp;flèches le redimensionnent, et maintenir
+        <kbd>Maj</kbd> fait passer chaque pas à dix.
+      </p>
+
+      <!-- The crop box itself is added here by src/cropper.js. The stage is
+           given the picture's own shape, so the box can be positioned in
+           percentages and needs no recalculating when the window is resized. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <p id="stage-note" class="stage-note" hidden></p>
+
+      <div class="crop-controls">
+        <div class="aspect-row" id="aspect-row" role="group" aria-label="Verrouiller le recadrage sur une forme">
+          <button type="button" data-aspect="free" class="active">Libre</button>
+          <button type="button" data-aspect="source">Original</button>
+          <button type="button" data-aspect="1:1">1:1</button>
+          <button type="button" data-aspect="4:5">4:5</button>
+          <button type="button" data-aspect="9:16">9:16</button>
+          <button type="button" data-aspect="16:9">16:9</button>
+          <button type="button" data-aspect="4:3">4:3</button>
+          <button type="button" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="ghost" title="Basculer la forme verrouillée sur le côté">
+            Basculer
+          </button>
+        </div>
+
+        <div class="numbers">
+          <label>Gauche<input type="number" id="crop-x" min="0" step="1"></label>
+          <label>Haut<input type="number" id="crop-y" min="0" step="1"></label>
+          <label>Largeur<input type="number" id="crop-w" min="8" step="1"></label>
+          <label>Hauteur<input type="number" id="crop-h" min="8" step="1"></label>
+          <div class="number-actions">
+            <button type="button" id="crop-max" class="ghost">Le plus grand</button>
+            <button type="button" id="crop-centre" class="ghost">Centrer</button>
+            <button type="button" id="crop-reset" class="ghost">Image entière</button>
+          </div>
+        </div>
+
+        <!--
+          Every image keeps its own box, which is the point. This is for the
+          case that is still worth one click: a folder of exports that all want
+          the same framing.
+        -->
+        <div class="apply-row" id="apply-row" hidden>
+          <button type="button" id="crop-apply-all" class="ghost">Utiliser ce recadrage sur toutes les images</button>
+          <p class="hint-line" id="apply-note"></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Étape 3 &mdash; la taille -->
+  <section class="card" id="resize-card">
+    <h2><span class="step">3</span> Dire la taille voulue</h2>
+
+    <div class="option-row">
+      <label for="resize-mode">Régler la taille par</label>
+      <select id="resize-mode">
+        <option value="pixels" selected>Largeur et hauteur, en pixels</option>
+        <option value="longest">Le plus grand côté</option>
+        <option value="percent">Un pourcentage de la taille actuelle</option>
+        <option value="none">Rien &mdash; laisser la taille exactement telle quelle</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="pixels-fields">
+      <div class="numbers">
+        <label>Largeur<input type="number" id="size-w" min="1" step="1" placeholder="auto" value="1920"></label>
+        <label>Hauteur<input type="number" id="size-h" min="1" step="1" placeholder="auto"></label>
+        <div class="number-actions">
+          <button type="button" id="swap-size" class="ghost">Basculer</button>
+        </div>
+      </div>
+
+      <!--
+        Leaving one of them blank is the common case and the one worth
+        supporting properly: "1920 wide, whatever tall that makes it" needs no
+        decision about shapes at all.
+      -->
+      <p class="hint-line">
+        Remplissez-en un et laissez l'autre vide pour garder la forme même de l'image.
+      </p>
+
+      <div class="presets" id="size-presets" role="group" aria-label="Tailles courantes">
+        <button type="button" class="ghost" data-w="1920" data-h="1080">1920 &times; 1080</button>
+        <button type="button" class="ghost" data-w="1280" data-h="720">1280 &times; 720</button>
+        <button type="button" class="ghost" data-w="1080" data-h="1080">1080 &times; 1080</button>
+        <button type="button" class="ghost" data-w="600" data-h="">600 de large</button>
+      </div>
+
+      <div class="option-row" id="fit-row">
+        <label for="fit">Si les formes se contredisent</label>
+        <select id="fit">
+          <option value="contain" selected>Tenir dedans &mdash; l'image entière, un côté sort plus court</option>
+          <option value="cover">Remplir &mdash; exactement cette taille, le débord coupé</option>
+          <option value="pad">Compléter &mdash; exactement cette taille, avec un fond autour</option>
+          <option value="stretch">Étirer &mdash; exactement cette taille, et la forme déformée</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Plus grand côté<input type="number" id="size-longest" min="1" step="1" value="1920"></label>
+      </div>
+      <p class="hint-line">
+        Le côté le plus long devient celui-ci, et l'autre suit. Les prises
+        verticales et horizontales d'un même lot ressortent toutes à la même
+        taille sur leur grand côté, ce qu'une galerie veut d'habitude.
+      </p>
+      <div class="presets" id="longest-presets" role="group" aria-label="Grands côtés courants">
+        <button type="button" class="ghost" data-longest="640">640</button>
+        <button type="button" class="ghost" data-longest="1280">1280</button>
+        <button type="button" class="ghost" data-longest="1920">1920</button>
+        <button type="button" class="ghost" data-longest="2560">2560</button>
+      </div>
+    </div>
+
+    <div class="size-fields" id="percent-fields" hidden>
+      <div class="numbers">
+        <label>Pourcentage<input type="number" id="size-percent" min="1" max="1000" step="1" value="50"></label>
+      </div>
+      <div class="presets" id="percent-presets" role="group" aria-label="Pourcentages courants">
+        <button type="button" class="ghost" data-percent="25">25 %</button>
+        <button type="button" class="ghost" data-percent="50">50 %</button>
+        <button type="button" class="ghost" data-percent="75">75 %</button>
+        <button type="button" class="ghost" data-percent="200">200 %</button>
+      </div>
+    </div>
+
+    <label class="check" id="enlarge-row">
+      <input type="checkbox" id="no-enlarge" checked>
+      <span>
+        <strong>Ne jamais agrandir une image au-delà de sa taille de départ</strong>
+        <span class="check-note">
+          Agrandir invente des pixels qui n'ont jamais été photographiés&nbsp;:
+          une petite image à qui l'on demande un grand cadre ressort molle plutôt
+          que détaillée. Avec ceci coché, tout ce qui est déjà plus petit que la
+          taille demandée est laissé à sa propre taille.
+        </span>
+      </span>
+    </label>
+
+    <p id="size-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Étape 4 &mdash; le format, et le clic unique -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> L'enregistrer</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format">
+          <option value="keep" selected>Garder le format d'arrivée de chaque fichier</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/png">PNG</option>
+          <option value="image/webp">WebP</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualité &mdash; <output id="quality-value" for="quality">85</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="85">
+        <p class="field-note">
+          JPEG et WebP seulement&nbsp;; le PNG n'a pas de molette de qualité. 85
+          est le point où la plupart des gens cessent de voir la différence. En
+          dessous de 60 environ, les aplats commencent à faire des bandes.
+        </p>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Fond</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Ce qui apparaît là où l'image n'est pas&nbsp;: derrière un cadre
+          complété, et derrière la transparence quand le format de sortie n'a pas
+          de canal alpha.
+        </p>
+      </div>
+    </div>
+
+    <p id="plan-summary" class="field-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Redimensionner les images</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Terminé</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Tout télécharger en zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The big look at one result. A <dialog> opened with showModal() rather than
+    a div pretending to be one: the browser gives the focus trap, the Escape
+    key and the inert background for nothing, and gets all three right.
+
+    Both pictures in it are object URLs made on this page - the result, and the
+    original that was already decoded for the thumbnail. Opening this fetches
+    nothing and decodes nothing that was not already decoded.
+  -->
+  <dialog id="viewer" class="viewer" aria-labelledby="viewer-name">
+    <div class="viewer-head">
+      <h2 id="viewer-name" class="viewer-name"></h2>
+      <button type="button" id="viewer-close" class="ghost" aria-label="Fermer">Fermer</button>
+    </div>
+
+    <div class="viewer-stage">
+      <img id="viewer-image" alt="">
+    </div>
+
+    <p id="viewer-caption" class="viewer-caption"></p>
+
+    <dl class="viewer-facts" id="viewer-facts"></dl>
+
+    <div class="viewer-actions">
+      <button type="button" id="viewer-compare" class="ghost" aria-pressed="false">Montrer l'original</button>
+      <a id="viewer-download" class="primary as-button" download>Télécharger</a>
+    </div>
+  </dialog>
+</main>

--- a/locales/fr/tools/resize-image.toml
+++ b/locales/fr/tools/resize-image.toml
@@ -1,0 +1,285 @@
+#
+# Redimensionneur d'images - French.
+#
+# Overrides for tools/resize-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Redimensionneur d'images"
+heading = "Redimensionner&nbsp;une&nbsp;image <span class=\"h1-kw\">&mdash; redimensionner, recadrer et convertir</span>"
+tagline = "Vous dites la taille. Vous tracez le cadre. Vous choisissez le format."
+
+title = "Redimensionner une image &mdash; recadrer et convertir aussi, sans envoi"
+description = "Redimensionnez, recadrez et convertissez des images JPEG, PNG et WebP dans votre navigateur. Pixels exacts, pourcentage, ou plus grand côté - une image ou un dossier entier. Rien n'est envoyé."
+og_title = "Redimensionner, recadrer et convertir une image sans l'envoyer"
+og_description = "Réglez la taille en pixels ou en pourcentage, tracez un cadre de recadrage, changez le format - pour une image ou tout un lot. Tout tourne sur votre propre machine."
+og_image_alt = "Redimensionneur d'images - redimensionner, recadrer et convertir sans envoi"
+
+pledge = """
+    Le redimensionnement, le recadrage et le changement de format se font tous
+    dans votre propre navigateur, sur votre propre matériel, avec les encodeurs
+    d'images qu'il embarque déjà. Cet outil n'a aucune fonction réseau &mdash;
+    rien à récupérer, rien à envoyer &mdash; et il n'y a à l'autre bout de cette
+    page aucun serveur auquel envoyer une image, quand bien même il y en aurait
+    une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et redimensionnez une photo. Pas une seule
+      requête ne transporte d'image, de vignette, de nom de fichier ni un octet
+      de ce que vous avez choisi. Ou coupez votre connexion et redimensionnez-en
+      une quand même."""
+
+read_first = """
+, <code>src/geometry.js</code> pour l'arithmétique qui
+      décide de ce qui est gardé et de la taille de sortie, et
+      <code>src/codecs.js</code> pour l'unique appel à <code>drawImage</code> qui
+      fait le recadrage et le redimensionnement ensemble."""
+
+howto_heading = "Comment redimensionner une image sans l'envoyer"
+
+card = """
+            Pixels exacts, pourcentage, ou plus grand côté &mdash; avec un cadre
+            de recadrage et un changement de format au passage. Une image ou un
+            dossier."""
+
+[words]
+plural = "images"
+choose = "une image"
+analytics_extra = """, ni aucune des
+  tailles, des recadrages ou des formats que cet outil calcule"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans filigrane"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Vos images n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où vos fichiers pourraient arriver, et rien dans le code qui les y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Il n'y a ni
+      <code>fetch</code>, ni <code>XMLHttpRequest</code>, ni
+      <code>sendBeacon</code> nulle part dans <code>src/</code>. Le
+      redimensionnement, c'est un <code>drawImage</code> sur un canvas et un
+      <code>canvas.toBlob</code> &mdash; le rééchantillonneur et l'encodeur déjà
+      installés dans votre navigateur."""
+
+[[privacy]]
+title = "Un fichier que personne n'a demandé de changer n'est pas changé."
+body = """
+ Sans recadrage,
+      sans redimensionnement et sans changement de format, le fichier que vous
+      avez choisi vous est rendu octet pour octet plutôt que réenregistré. Ce
+      n'est pas seulement de la politesse&nbsp;: c'est ce qui empêche cet outil
+      de réencoder discrètement une image, ou de jeter discrètement les
+      métadonnées d'une image que vous vouliez seulement regarder."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google, et le bouton de don de Buy
+      Me a Coffee. Aucun d'eux ne reçoit quoi que ce soit sur vos images. Chaque
+      ligne qui lit, recadre, met à l'échelle ou écrit un fichier est servie
+      depuis cette origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et l'outil est
+      inchangé, parce qu'il n'y a jamais eu d'étape réseau dedans. C'est la
+      preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez vos images."
+body = """
+ Déposez-les sur la zone prévue ou
+      sélectionnez-les à la main. Le navigateur les lit directement sur votre
+      disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Recadrez, si vous voulez."
+body = """
+ Le cadre part sur l'image entière&nbsp;:
+      le laisser tranquille ne recadre donc rien. Faites-le glisser, ou
+      verrouillez-le sur une forme &mdash; 1:1 pour une photo de profil, 9:16
+      pour une story, 16:9 pour une vignette &mdash; et appuyez sur
+      &laquo;&nbsp;Le plus grand&nbsp;&raquo; pour le plus grand qui tienne.
+      Chaque image garde son propre cadre&nbsp;: cliquez sur une ligne de la
+      liste pour dessiner sur celle-là. Si elles doivent toutes être cadrées de
+      la même façon, un bouton le fait aussi."""
+
+[[howto]]
+title = "Dites la taille de sortie."
+body = """
+ Une largeur, une hauteur, ou les
+      deux&nbsp;; un plus grand côté, qui met les prises verticales et
+      horizontales à la même taille&nbsp;; ou un simple pourcentage. Laissez
+      l'un des deux champs vide et l'image garde sa propre forme."""
+
+[[howto]]
+title = "Choisissez le format, puis appuyez sur le bouton."
+body = """
+ Gardez le format
+      d'arrivée de chaque fichier, ou écrivez tout en JPEG, en PNG ou en WebP.
+      Chaque résultat dit ce qu'il est devenu et de combien il a maigri&nbsp;;
+      cliquez dessus pour l'ouvrir en grand avec tous les chiffres derrière, et
+      l'original à côté pour comparer. Un lot arrive en un seul zip."""
+
+[[faq]]
+q = "Mon image est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. Le fichier est décodé, recadré, mis à l'échelle et écrit par votre propre
+        navigateur sur votre propre matériel, avec les encodeurs JPEG, PNG et WebP que
+        le navigateur embarque déjà. Cet outil n'a aucune fonction réseau &mdash; il ne
+        récupère jamais rien et n'envoie jamais rien &mdash; et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter, dont aucune n'appartient à ce site."""
+
+[[faq]]
+q = "Que se passe-t-il si je donne une largeur mais pas de hauteur&nbsp;?"
+a = """
+        La hauteur découle de la forme même de l'image, ce qui est presque toujours ce
+        que l'on voulait&nbsp;: &laquo;&nbsp;1920 de large&nbsp;&raquo; veut dire
+        &laquo;&nbsp;1920 de large et la hauteur que cela donne&nbsp;&raquo;.
+        Remplissez les deux et ils peuvent contredire la forme de l'image&nbsp;: c'est
+        le seul moment où apparaît le choix
+        &laquo;&nbsp;si les formes se contredisent&nbsp;&raquo; &mdash; tenir dans le
+        cadre, le remplir et couper ce qui dépasse, compléter avec un fond, ou étirer
+        et accepter la déformation."""
+
+[[faq]]
+q = "Redimensionner une image fait-il perdre de la qualité&nbsp;?"
+a = """
+        Réduire une image, non, d'aucune façon visible&nbsp;: il entre plus de pixels
+        qu'il n'en sort, et le détail conservé est du vrai détail. Agrandir ne peut pas
+        ajouter ce qui n'a jamais été photographié &mdash; le résultat est une copie
+        plus molle de la même image, pas une plus nette &mdash; et c'est pourquoi
+        &laquo;&nbsp;ne jamais agrandir une image au-delà de sa taille de
+        départ&nbsp;&raquo; est actif par défaut. Ce qui coûte un peu, c'est le
+        réencodage qui suit, si le format est du JPEG ou du WebP, et le curseur de
+        qualité est ce que vous y dépensez."""
+
+[[faq]]
+q = "Puis-je recadrer chaque image différemment&nbsp;?"
+a = """
+        Oui &mdash; c'est le comportement par défaut. Chaque image de la liste porte
+        son propre cadre, dans ses propres pixels, et cliquer sur une ligne met cette
+        image dans l'aperçu avec son cadre et sa forme verrouillée à elle. Ce que vous
+        faites à l'une n'affecte pas les autres. Chaque cadre part aussi de l'image
+        entière&nbsp;: une image sur laquelle vous ne dessinez jamais n'est pas
+        recadrée du tout."""
+
+[[faq]]
+q = "Peut-il recadrer tout un lot de la même façon d'un coup&nbsp;?"
+a = """
+        Oui, avec le bouton sous l'aperçu. Il donne à toutes les autres images la même
+        zone relative &mdash; les mêmes fractions de leur propre largeur et de leur
+        propre hauteur &mdash; ce qui, pour un jeu de captures ou d'exports tous de la
+        même taille, est exactement le même cadre, et la page le dit. Avec une forme
+        verrouillée, il donne à chacune le plus grand cadre de cette forme à
+        l'intérieur de cette zone&nbsp;: appuyer sur 1:1 puis sur ce bouton vous sort
+        donc des carrés d'un dossier mêlant portraits et paysages. Chaque cadre reste
+        modifiable ensuite."""
+
+[[faq]]
+q = "Quels formats sait-il lire et écrire&nbsp;?"
+a = """
+        Il lit tout ce que votre navigateur sait décoder, ce qui en pratique veut dire
+        JPEG, PNG, WebP, GIF, BMP et &mdash; sur la plupart des navigateurs actuels
+        &mdash; AVIF. Il écrit du JPEG, du PNG et du WebP, parce que ce sont les
+        encodeurs que les navigateurs embarquent. Avec
+        &laquo;&nbsp;garder le format&nbsp;&raquo;, un JPEG reste un JPEG et un PNG
+        reste un PNG&nbsp;; tout ce que le navigateur ne sait pas écrire, comme un GIF
+        ou un BMP, ressort en PNG, celui qui garde la transparence et les aplats
+        intacts."""
+
+[[faq]]
+q = "Qu'arrive-t-il à la transparence quand j'enregistre en JPEG&nbsp;?"
+a = """
+        Elle est remplie avec la couleur de fond, parce que le JPEG n'a pas de canal
+        alpha où la stocker. La couleur est à vous de la choisir et part du blanc, ce
+        que la plupart des gens veulent et ce que fait presque tout autre outil sans
+        vous le dire. La même couleur est utilisée derrière un cadre complété.
+        Enregistrez en PNG ou en WebP à la place et la transparence passe intacte."""
+
+[[faq]]
+q = "Supprime-t-il les données EXIF et GPS&nbsp;?"
+a = """
+        Pour tout ce qu'il traite réellement, oui, par effet de bord&nbsp;: recadrer ou
+        redimensionner, c'est décoder l'image en pixels puis réencoder ces pixels, et
+        un canvas plein de pixels ne porte aucune étiquette&nbsp;: le lieu, le modèle
+        d'appareil et les horodatages ne sont simplement pas écrits dans le nouveau
+        fichier. Un fichier que vous ne changez pas du tout est un autre cas &mdash; il
+        vous est rendu octet pour octet, étiquettes comprises. Si vous voulez que les
+        métadonnées disparaissent mais que l'image reste intacte, prenez le
+        <a href="../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a>, qui
+        réécrit le conteneur sans rien recompresser."""
+
+[[faq]]
+q = "En quoi est-ce différent du compresseur d'images&nbsp;?"
+a = """
+        Celui-ci parle de dimensions&nbsp;: vous dites combien de pixels vous voulez et
+        il vous les donne. Le <a href="../compresser-une-image/">compresseur
+        d'images</a> parle de taille de fichier&nbsp;: vous dites combien de kilooctets
+        vous avez le droit d'occuper et il cherche la meilleure qualité qui tienne, en
+        ne redimensionnant que si la qualité seule n'y suffit pas. Si on vous a dit
+        &laquo;&nbsp;1200 pixels de large&nbsp;&raquo;, vous êtes au bon endroit. Si on
+        vous a dit &laquo;&nbsp;sous 500 KB&nbsp;&raquo;, l'autre vous en approchera
+        davantage."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Il n'y a pas non plus de limite au nombre ni à la
+        taille des fichiers, parce qu'aucun serveur ne les paie &mdash; le travail se
+        fait sur votre propre machine. Le site porte de la publicité, et c'est elle qui
+        le finance&nbsp;; les annonces ne reçoivent rien sur vos images."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait vos images ailleurs pour les
+        redimensionner s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Redimensionnez, recadrez et convertissez des images JPEG, PNG et WebP dans le navigateur. Réglez une taille exacte en pixels, un pourcentage ou un plus grand côté, tracez un cadre de recadrage ou verrouillez-le sur une forme, et écrivez le résultat en JPEG, PNG ou WebP. Traitement par lots pris en charge, et rien n'est envoyé."
+features = [
+  "Redimensionne en pixels exacts, par le plus grand côté, ou en pourcentage",
+  "Remplissez un côté et l'autre suit la forme même de l'image",
+  "Tenir dedans, remplir et recadrer, compléter jusqu'à un cadre exact, ou étirer",
+  "Un cadre de recadrage déplaçable par image, verrouillable en 1:1, 4:5, 9:16, 16:9, 4:3 ou 3:2",
+  "Recadre chaque image différemment, ou applique un même cadrage à tout le lot en un clic",
+  "Ouvre chaque image finie en grand, avec tous les chiffres derrière et l'original pour comparer",
+  "Convertit entre JPEG, PNG et WebP, avec un réglage de qualité et une couleur de fond",
+  "N'agrandit jamais une image sans qu'on le lui demande",
+  "Rend intact tout fichier qu'on ne lui a pas demandé de changer",
+  "Traitement par lots, tous les résultats dans un seul zip",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]
+
+[picker]
+title = "Déposez vos images ici"
+hint = "ou cliquez pour parcourir &mdash; JPEG, PNG, WebP et tout ce que votre navigateur sait ouvrir"

--- a/locales/fr/tools/svg-to-image.html
+++ b/locales/fr/tools/svg-to-image.html
@@ -1,0 +1,212 @@
+<main>
+  <!-- Étape 1 &mdash; les fichiers -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir les fichiers SVG</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer de la liste</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; la taille -->
+  <section class="card" id="size-card">
+    <h2><span class="step">2</span> Dire quelle taille il doit faire</h2>
+
+    <p class="card-lede">
+      C'est la seule question à laquelle un vectoriel ne peut pas répondre à
+      votre place. Un SVG ne contient pas de pixels &mdash; il contient des
+      instructions de dessin, et il les suivra à la taille que vous nommerez. Le
+      nombre ci-dessous n'est pas une limite contre laquelle vous poussez, comme
+      ce serait le cas avec une photographie&nbsp;; 4000 pixels tirés d'une icône
+      de 24&nbsp;pixels sont exactement aussi nets que l'étaient les 24.
+    </p>
+
+    <div class="option-row">
+      <label for="size-mode">Régler la taille par</label>
+      <select id="size-mode">
+        <option value="scale" selected>Un multiple de la taille que le fichier demande</option>
+        <option value="width">Largeur en pixels</option>
+        <option value="height">Hauteur en pixels</option>
+        <option value="longest">Le plus grand côté</option>
+        <option value="box">Un cadre, les deux côtés donnés</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="scale-fields">
+      <div class="numbers">
+        <label>Multiplier par<input type="number" id="size-scale" min="0.01" max="200" step="0.5" value="4"></label>
+      </div>
+      <div class="presets" id="scale-presets" role="group" aria-label="Multiples courants">
+        <button type="button" class="ghost" data-scale="1">1&times;</button>
+        <button type="button" class="ghost" data-scale="2">2&times;</button>
+        <button type="button" class="ghost" data-scale="4">4&times;</button>
+        <button type="button" class="ghost" data-scale="8">8&times;</button>
+        <button type="button" class="ghost" data-scale="16">16&times;</button>
+      </div>
+      <p class="hint-line">
+        Chaque fichier de la liste est multiplié depuis sa propre taille&nbsp;:
+        un lot d'icônes dessinées à des tailles différentes reste donc en
+        proportion.
+      </p>
+    </div>
+
+    <div class="size-fields" id="width-fields" hidden>
+      <div class="numbers">
+        <label>Largeur<input type="number" id="size-width" min="1" step="1" value="1024"></label>
+      </div>
+      <div class="presets" id="width-presets" role="group" aria-label="Largeurs courantes">
+        <button type="button" class="ghost" data-width="256">256</button>
+        <button type="button" class="ghost" data-width="512">512</button>
+        <button type="button" class="ghost" data-width="1024">1024</button>
+        <button type="button" class="ghost" data-width="2048">2048</button>
+      </div>
+      <p class="hint-line">La hauteur découle de la forme du dessin.</p>
+    </div>
+
+    <div class="size-fields" id="height-fields" hidden>
+      <div class="numbers">
+        <label>Hauteur<input type="number" id="size-height" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">La largeur découle de la forme du dessin.</p>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Plus grand côté<input type="number" id="size-longest" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">
+        Le côté le plus long devient celui-ci et l'autre suit&nbsp;: un logo
+        large et un logo haut ressortent donc à la même taille sur leur grand
+        côté.
+      </p>
+    </div>
+
+    <div class="size-fields" id="box-fields" hidden>
+      <div class="numbers">
+        <label>Largeur<input type="number" id="box-width" min="1" step="1" value="1200"></label>
+        <label>Hauteur<input type="number" id="box-height" min="1" step="1" value="630"></label>
+      </div>
+      <div class="option-row">
+        <label for="box-fit">Si le dessin a une autre forme</label>
+        <select id="box-fit">
+          <option value="fit" selected>Tenir dedans &mdash; le dessin entier, un côté sort plus court</option>
+          <option value="pad">Compléter &mdash; exactement cette taille, avec le fond de part et d'autre</option>
+          <option value="stretch">Étirer &mdash; exactement cette taille, et la forme déformée</option>
+        </select>
+      </div>
+    </div>
+
+    <!--
+      The one thing people rasterise a vector for more than once: the same
+      drawing at 1x, 2x and 3x for a screen with more device pixels than CSS
+      pixels. Multiplied from the plan above rather than planned again, so an
+      @2x is exactly twice its @1x and cannot drift by a rounded pixel.
+    -->
+    <div class="option-row" id="density-row">
+      <label for="density">Écrire aussi les copies haute densité</label>
+      <select id="density">
+        <option value="1" selected>Non &mdash; un fichier par dessin</option>
+        <option value="2">Aussi @2x &mdash; pour un écran Retina</option>
+        <option value="3">@2x et @3x &mdash; le jeu complet qu'un téléphone réclame</option>
+      </select>
+    </div>
+
+    <p id="size-summary" class="field-summary"></p>
+    <p id="size-warning" class="field-summary warn" hidden></p>
+  </section>
+
+  <!-- Étape 3 &mdash; le format -->
+  <section class="card" id="format-card">
+    <h2><span class="step">3</span> Choisir le format</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; garde la transparence, bords exacts</option>
+          <option value="image/jpeg">JPEG &mdash; pas de transparence, photographies plus légères</option>
+          <option value="image/webp">WebP &mdash; transparence et fichier plus léger</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Qualité &mdash; <output id="quality-value" for="quality">90</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="90">
+        <p class="field-note">
+          JPEG et WebP seulement&nbsp;; le PNG n'a pas de molette de qualité
+          parce qu'il est sans perte. Les aplats et les bords francs &mdash; qui
+          sont l'essentiel de ce dont un SVG est fait &mdash; sont précisément ce
+          qu'un encodeur avec perte gère le plus mal, alors ce réglage est ici
+          plus haut qu'il ne le serait pour une photographie.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="background-mode">Fond</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparent</option>
+          <option value="colour">Une couleur</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Couleur de fond" hidden>
+        <p class="field-note" id="background-note"></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Étape 4 &mdash; le regarder, puis le prendre -->
+  <section class="card" id="run-card">
+    <h2><span class="step">4</span> Le regarder, puis l'enregistrer</h2>
+
+    <p class="card-lede">
+      L'aperçu est dessiné par le code même qui écrit le fichier, depuis le
+      fichier que vous avez choisi, sur cette machine. Ce qu'il vaut la peine d'y
+      vérifier, ce sont les deux choses qui changent quand un dessin devient des
+      pixels&nbsp;: un filet large d'un demi-pixel qui a viré au gris, et tout
+      texte, qui est dessiné dans une police que cette machine possède plutôt que
+      dans une police récupérée sur le web.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-stage">
+        <canvas id="preview-canvas"></canvas>
+      </div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <p id="preview-empty" class="field-summary">Ajoutez un SVG et il apparaît ici.</p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Rastériser</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Terminé</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Tout télécharger en zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/svg-to-image.toml
+++ b/locales/fr/tools/svg-to-image.toml
@@ -1,0 +1,324 @@
+#
+# SVG en image - French.
+#
+# Overrides for tools/svg-to-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "SVG en image"
+heading = "SVG&nbsp;en&nbsp;image <span class=\"h1-kw\">&mdash; rastériser un vectoriel en PNG, JPEG ou WebP, à n'importe quelle taille</span>"
+tagline = "Vous donnez la taille. Un vectoriel n'en a aucune à perdre."
+
+title = "SVG en PNG &mdash; rastériser un vectoriel à n'importe quelle taille, sans envoi"
+description = "Convertissez un SVG en PNG, JPEG ou WebP à n'importe quelle taille, dans votre navigateur. Donnez la largeur, un multiple ou un cadre ; récupérez aussi les copies @2x et @3x. Transparence gardée, rien n'est envoyé."
+og_title = "Transformer un SVG en PNG à n'importe quelle taille, sans l'envoyer"
+og_description = "Un vectoriel n'a pas de taille en pixels à lui : le nombre est à vous de le choisir - 32 ou 8000, avec la même netteté dans les deux cas. Tout tourne sur votre propre machine."
+og_image_alt = "SVG en image - rastériser un vectoriel en PNG, JPEG ou WebP à n'importe quelle taille"
+
+pledge = """
+    Le dessin est rastérisé par le moteur même qui vient de le mettre à votre
+    écran. Votre fichier est lu sur votre disque, sa balise racine est réécrite à
+    la taille demandée par une centaine de lignes dans <code>src/svg.js</code>
+    que vous pouvez lire, et il est dessiné sur un canvas que votre navigateur
+    embarque déjà. Cet outil n'a aucune fonction réseau &mdash; rien à récupérer,
+    rien à envoyer &mdash; et il n'y a à l'autre bout de cette page aucun serveur
+    auquel envoyer un logo, quand bien même il y en aurait une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et rastérisez quelque chose. Pas une seule
+      requête ne transporte de fichier, de vignette, de nom de fichier ni un
+      octet de ce que vous avez choisi. Ou coupez votre connexion et
+      convertissez-en un quand même."""
+
+read_first = """
+, <code>src/svg.js</code> pour la façon dont la taille
+      propre d'un fichier est lue et dont sa balise racine est réécrite, et
+      <code>src/render.js</code> pour les huit lignes qui font la rastérisation
+      &mdash; un &lt;img&gt;, un <code>drawImage</code> et un
+      <code>toBlob</code>, sans rien entre les deux."""
+
+howto_heading = "Comment convertir un SVG en PNG sans l'envoyer"
+
+card = """
+            Un SVG n'a pas de taille en pixels à lui&nbsp;: le nombre est à vous
+            de le choisir &mdash; 32 ou 8000, et la même netteté dans les deux
+            cas."""
+
+[words]
+plural = "fichiers SVG"
+choose = "un SVG"
+analytics_extra = """, ni aucune des
+  tailles, des formats ou des noms de fichiers que cet outil calcule"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans filigrane"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Votre dessin n'a nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où vos fichiers pourraient arriver, et rien dans le code qui les y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Il n'y a ni
+      <code>fetch</code>, ni <code>XMLHttpRequest</code>, ni
+      <code>sendBeacon</code> nulle part dans <code>src/</code>. Le rastériseur
+      tout entier, c'est un <code>&lt;img&gt;</code> qui tient un blob de votre
+      propre fichier, un <code>drawImage</code> sur un canvas, et un
+      <code>canvas.toBlob</code>."""
+
+[[privacy]]
+title = "Un SVG est un document, et voici le mode où il ne peut pas agir."
+body = """
+ Un SVG peut porter un
+      <code>&lt;script&gt;</code>, une
+      <code>&lt;image href=&quot;https://&hellip;&quot;&gt;</code> distante, une
+      feuille de style et une police web. Dessiné à travers un
+      <code>&lt;img&gt;</code>, il est dans ce que la spécification appelle le
+      <em>mode statique sécurisé</em>&nbsp;: le script ne s'exécute pas et pas
+      une seule de ces adresses n'est contactée. C'est une garantie du
+      navigateur, pas une promesse de notre part, et c'est la raison pour
+      laquelle cette page peut ouvrir un fichier qu'elle n'a jamais vu sans que
+      ce fichier puisse téléphoner à la maison."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google, et le bouton de don de Buy
+      Me a Coffee. Aucun d'eux ne reçoit quoi que ce soit sur votre dessin.
+      Chaque ligne qui lit, dimensionne ou dessine un fichier est servie depuis
+      cette origine et figure dans le dépôt."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et l'outil est
+      inchangé, parce qu'il n'y a jamais eu d'étape réseau dedans. C'est la
+      preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez le SVG."
+body = """
+ Déposez-en un sur la zone prévue, ou
+      prenez-en un dossier entier et convertissez le tout d'un coup. Le
+      navigateur lit le fichier directement sur votre disque&nbsp;; rien n'est
+      envoyé nulle part pendant ce temps. Chaque ligne dit quelle taille le
+      fichier croit avoir &mdash; et le dit différemment quand cette taille vient
+      de son <code>viewBox</code>, ou a été supposée parce que le fichier n'en
+      déclare aucune."""
+
+[[howto]]
+title = "Dites quelle taille."
+body = """
+ Un multiple de la taille propre du fichier
+      est la réponse la plus rapide et la bonne pour un lot&nbsp;: chaque dessin
+      est mis à l'échelle depuis son propre point de départ, si bien qu'un jeu
+      d'icônes reste en proportion. Sinon, nommez une largeur, une hauteur, le
+      plus grand côté, ou un cadre dont les deux côtés sont donnés. Il n'y a ici
+      aucune pénalité à donner un grand nombre, contrairement à une photographie
+      &mdash; le dessin est redessiné à cette taille, pas étiré jusqu'à elle."""
+
+[[howto]]
+title = "Ajoutez les copies haute densité s'il vous en faut."
+body = """
+ Un téléphone et un portable
+      Retina dessinent deux ou trois pixels physiques pour chaque pixel CSS&nbsp;:
+      un logo de 200 pixels a donc besoin d'un fichier de 400 ou 600 pixels
+      derrière lui. Demandez <code>@2x</code> et <code>@3x</code> et ils
+      ressortent nommés comme Xcode, les outils Android et
+      <code>image-set()</code> en CSS l'attendent tous, et chacun fait exactement
+      le double ou le triple du premier plutôt que d'être arrondi séparément."""
+
+[[howto]]
+title = "Choisissez le format et tranchez sur la transparence."
+body = """
+ PNG, sauf si vous avez
+      une raison&nbsp;: il est sans perte, il garde la transparence, et les
+      aplats s'y compressent bien. Le JPEG n'a aucune transparence, alors une
+      couleur de fond est peinte que vous en choisissiez une ou non &mdash; sans
+      elle, chaque pixel transparent ressort noir. Le WebP fait les deux et donne
+      un fichier plus léger, au prix des logiciels assez anciens pour ne pas le
+      lire."""
+
+[[howto]]
+title = "Regardez l'aperçu avant de télécharger."
+body = """
+ Il est dessiné par le code même qui
+      écrit le fichier, depuis votre fichier, sur votre machine. Deux choses
+      changent quand un dessin devient des pixels, et les deux se voient
+      ici&nbsp;: un filet large d'un demi-pixel vire au gris, et tout texte est
+      dessiné dans une police que cet ordinateur possède, et non dans une police
+      récupérée sur le web."""
+
+[[howto]]
+title = "Prenez les fichiers."
+body = """
+ Un téléchargement par fichier, ou tout le
+      lot en un seul zip. Les noms suivent le SVG dont ils viennent, avec
+      <code>@2x</code> et <code>@3x</code> sur les copies, et deux fichiers qui
+      auraient porté le même nom sont numérotés plutôt que l'un ne remplace
+      discrètement l'autre."""
+
+[[faq]]
+q = "Mon SVG est-il envoyé quelque part&nbsp;?"
+a = """
+        Non. Le fichier est lu par votre propre navigateur sur votre propre matériel,
+        dessiné sur un canvas par le moteur même qui rend toutes les autres images que
+        vous voyez, et rendu sous forme de téléchargement. Cet outil n'a aucune
+        fonction réseau &mdash; il ne récupère jamais rien et n'envoie jamais rien
+        &mdash; et la <code>Content-Security-Policy</code> de la page nomme toutes les
+        adresses qu'elle peut contacter, dont aucune n'appartient à ce site."""
+
+[[faq]]
+q = "À quelle taille faut-il rastériser un SVG&nbsp;?"
+a = """
+        À celle que demande ce qui va le lire, multipliée par le rapport de pixels de
+        l'écran où il sera vu. Un logo qui occupe 200 pixels CSS en demande 400 pour un
+        portable Retina et 600 pour un téléphone récent, ce que sont ici les copies
+        <code>@2x</code> et <code>@3x</code>. Pour une icône d'application ou une fiche
+        de boutique, la boutique nomme un nombre exact et c'est ce nombre-là. Quand rien
+        ne vous a rien dit, 1024 sur le plus grand côté est un défaut utile&nbsp;: assez
+        grand pour presque tout usage et assez petit pour un courriel."""
+
+[[faq]]
+q = "L'agrandir fait-il perdre de la qualité&nbsp;?"
+a = """
+        Non, et c'est le seul endroit où cette réponse est honnêtement non. Un
+        vectoriel, ce sont des instructions et non des pixels&nbsp;: le navigateur
+        redessine donc les courbes à la taille demandée. 4000 pixels tirés d'une icône
+        de 24 pixels sont exactement aussi nets que l'étaient les 24. Ce que vous ne
+        pouvez pas faire, c'est le chemin inverse&nbsp;: une fois que c'est un PNG, ce
+        sont des pixels comme tout le reste, alors rastérisez à la taille dont vous avez
+        besoin plutôt que de redimensionner le résultat ensuite."""
+
+[[faq]]
+q = "Mon SVG n'a ni largeur ni hauteur. Quelle taille vais-je obtenir&nbsp;?"
+a = """
+        Le <code>viewBox</code>, s'il y en a un &mdash; sa largeur et sa hauteur sont
+        des unités utilisateur plutôt que des pixels, mais ce sont les seuls nombres du
+        fichier et un navigateur les traite comme la taille naturelle du dessin. S'il
+        n'y a pas de viewBox non plus, la page affiche <em>supposée</em> à côté de la
+        ligne et utilise 300&nbsp;&times;&nbsp;150, ce à quoi un
+        <code>&lt;img&gt;</code> l'aurait dessiné. Dans les deux cas, vous pouvez nommer
+        la taille voulue et le fichier est dessiné à celle-là."""
+
+[[faq]]
+q = "Pourquoi le texte a-t-il l'air différent dans le PNG&nbsp;?"
+a = """
+        Parce que la police n'est pas dans le SVG. Un SVG qui dessine du texte nomme une
+        police et laisse la machine la trouver, et un fichier qui en tire une de Google
+        Fonts avec un <code>@import</code> n'obtient rien ici&nbsp;: un SVG dessiné à
+        travers un <code>&lt;img&gt;</code> n'a pas le droit de récupérer quoi que ce
+        soit, ce qui est la règle même qui l'empêche de téléphoner à la maison avec
+        votre fichier. Le remède est celui que tout graphiste connaît déjà &mdash;
+        convertissez le texte en tracés dans le logiciel de dessin avant d'exporter.
+        C'est alors de la géométrie, et cela a la même allure partout."""
+
+[[faq]]
+q = "Peut-il convertir plusieurs fichiers à la fois&nbsp;?"
+a = """
+        Oui. Chaque SVG de la liste est rendu avec les mêmes réglages et le lot arrive
+        en un seul zip. Un multiple &mdash;
+        &laquo;&nbsp;4&times; la taille que le fichier demande&nbsp;&raquo; &mdash; est
+        en général le bon réglage pour un lot, parce que chaque dessin est mis à
+        l'échelle depuis sa propre taille au lieu que tous soient forcés au même nombre
+        de pixels. Cliquez sur une ligne pour mettre celle-là dans l'aperçu."""
+
+[[faq]]
+q = "Y a-t-il une limite de taille&nbsp;?"
+a = """
+        Celle du navigateur, pas la nôtre. Un canvas abandonne quelque part au-delà de
+        16 384 pixels de côté, et Safari sur un iPhone ou un iPad s'arrête à environ
+        16,7 mégapixels de surface &mdash; 4096&nbsp;&times;&nbsp;4096. Au-dessus, la
+        page vous prévient plutôt que de vous rendre une image vide, ce que fait un
+        navigateur à court de ressources&nbsp;: <code>toBlob</code> ne rend rien du
+        tout, sans la moindre erreur pour s'expliquer. Passé 100 mégapixels, l'outil
+        refuse, parce que cela fait 400&nbsp;MB de canvas avant qu'un seul octet ait été
+        encodé."""
+
+[[faq]]
+q = "Qu'advient-il de la transparence&nbsp;?"
+a = """
+        Elle est gardée, en PNG et en WebP. Le JPEG n'a aucun canal alpha, alors une
+        couleur est peinte derrière toute l'image que vous en demandiez une ou non
+        &mdash; sans elle, tout ce qui est transparent ressortirait noir, ce qui a l'air
+        d'un bug plutôt que du JPEG. Choisir une couleur de fond avec du PNG est aussi
+        une chose parfaitement ordinaire à vouloir&nbsp;: cela aplatit le dessin sur
+        cette couleur au lieu de laisser un trou."""
+
+[[faq]]
+q = "Peut-il lire un SVG qui contient un script ou une image externe&nbsp;?"
+a = """
+        Il peut en lire un, et il dessinera exactement les parties qu'un navigateur veut
+        bien dessiner. Un SVG chargé à travers un <code>&lt;img&gt;</code> est en
+        <em>mode statique sécurisé</em>&nbsp;: les scripts ne s'exécutent pas, les
+        références externes ne sont pas récupérées, et l'animation ne joue pas &mdash;
+        c'est la première image que vous obtenez. Un fichier avec une
+        <code>&lt;image&gt;</code> distante ressort donc avec cette partie manquante.
+        C'est le navigateur qui refuse pour votre compte, et c'est la raison pour
+        laquelle cette page peut ouvrir sans danger un fichier qu'elle n'a jamais vu."""
+
+[[faq]]
+q = "Quelle différence avec le redimensionneur d'images&nbsp;?"
+a = """
+        La nature de la source. Le redimensionneur d'images part de pixels &mdash; un
+        JPEG, un PNG &mdash; alors l'agrandir doit inventer un détail qui n'a jamais
+        existé. Celui-ci part d'un dessin&nbsp;: il n'y a rien à inventer et aucune
+        limite haute dont il faille se soucier. Si ce que vous avez est un SVG, c'est
+        celui-ci qui vous donne un résultat net&nbsp;; si ce que vous avez est une
+        photographie, c'est l'autre."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Il n'y a pas non plus de limite au nombre ni à la
+        taille des fichiers, parce qu'aucun serveur ne les paie &mdash; le travail se
+        fait sur votre propre machine. Le site porte de la publicité, et c'est elle qui
+        le finance&nbsp;; les annonces ne reçoivent rien sur vos fichiers."""
+
+[[faq]]
+q = "Est-ce que cela fonctionne hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, coupez ensuite votre connexion et elle continue
+        de travailler. C'est aussi la façon la plus simple de prouver que rien n'est
+        envoyé&nbsp;: un outil qui expédierait votre dessin ailleurs pour le faire
+        rendre s'arrêterait à l'instant où vous débranchez."""
+
+[schema]
+description = "Rastérisez un SVG en PNG, JPEG ou WebP à n'importe quelle taille, dans le navigateur. Réglez la taille par un multiple, une largeur, une hauteur, le plus grand côté ou un cadre, ajoutez les copies @2x et @3x, gardez ou aplatissez la transparence, et convertissez tout un lot d'un coup. Rien n'est envoyé."
+features = [
+  "Redessine le vectoriel à chaque taille, si bien que le résultat est net à toutes",
+  "Taille par un multiple, une largeur, une hauteur, le plus grand côté, ou un cadre avec un mode de placement",
+  "Copies @2x et @3x, chacune un multiple exact de la première plutôt qu'arrondie deux fois",
+  "PNG, JPEG et WebP, avec la transparence gardée ou aplatie sur une couleur",
+  "Lit la taille dans width, height ou le viewBox, et dit laquelle il a utilisée",
+  "Prévient avant une taille qu'un canvas de navigateur ne sait pas produire",
+  "Aperçu dessiné par le code même qui écrit le fichier",
+  "Traitement par lots, tous les résultats dans un seul zip",
+  "Les scripts et les références distantes du fichier ne sont jamais exécutés ni récupérés",
+  "Fonctionne hors ligne ; sans envoi, sans compte",
+]
+
+[picker]
+title = "Déposez un SVG ici"
+hint = "ou cliquez pour parcourir &mdash; plusieurs à la fois, c'est très bien"

--- a/locales/fr/tools/trim-video.html
+++ b/locales/fr/tools/trim-video.html
@@ -1,0 +1,225 @@
+<main>
+  <!-- Étape 1 &mdash; la vidéo -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir une vidéo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <!-- One row a video, in the order they will be joined. Hidden until there
+         is more than one, because a list of one is furniture. -->
+    <ol class="clip-list" id="clip-list" hidden></ol>
+
+    <p id="join-note" class="path-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; les marques -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> Marquer les passages voulus
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Lisez-la en entier et appuyez sur <kbd>I</kbd> là où un passage doit
+      commencer et sur <kbd>O</kbd> là où il doit finir. Faites-le autant de fois
+      que vous voulez &mdash; chaque paire devient une ligne en dessous, et la
+      vidéo finie, ce sont ces lignes, l'une après l'autre. <kbd>U</kbd> annule la
+      dernière, <kbd>Espace</kbd> lit et met en pause, et les flèches sautent de
+      cinq secondes.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- Built by src/timeline.js: a band for every segment, the one being
+         marked, a tick for every keyframe, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Lecture</button>
+      <button type="button" id="back-5" class="ghost" title="Reculer de cinq secondes">&minus;5s</button>
+      <button type="button" id="forward-5" class="ghost" title="Avancer de cinq secondes">+5s</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Marquer le début</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Marquer la fin</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Annuler</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Vitesse de lecture">
+      <span class="speed-label">Vitesse</span>
+      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normale</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The segments themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Passages <span class="segment-count" id="segment-count">aucun pour l'instant</span></h3>
+        <p class="segments-total">
+          Total gardé <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">N&deg;</th>
+            <th scope="col">Début</th>
+            <th scope="col">Fin</th>
+            <th scope="col">Durée</th>
+            <th scope="col"><span class="visually-hidden">Actions</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Rien de marqué pour l'instant. Appuyez sur <kbd>I</kbd> puis sur
+        <kbd>O</kbd> pendant la lecture, ou servez-vous des boutons ci-dessus.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Ajouter une ligne à la main</button>
+        <button type="button" id="reset-segments" class="ghost danger">Tout effacer</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">Charger des marques&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Format du fichier d'horodatages">
+          <option value="seconds" selected>secondes</option>
+          <option value="HHMMSSmmm">HH:MM:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">Enregistrer les marques</button>
+      </div>
+
+      <p class="field-note">
+        Les marques s'enregistrent dans un simple fichier texte &mdash; une ligne
+        par passage, au format ci-dessus &mdash; si bien qu'une longue séance de
+        marquage survit à un onglet fermé, et que le même fichier peut être remis
+        à n'importe quel outil qui lit cette disposition.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>Que faire des passages marqués</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Les garder</strong>
+          La vidéo finie, ce sont les passages marqués, mis bout à bout dans l'ordre.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Les couper</strong>
+          Les passages marqués partent, et tout le reste est raccordé.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Étape 3 &mdash; l'export -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Couper</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="method">Comment couper</label>
+        <select id="method">
+          <option value="copy" selected>Garder chaque octet &mdash; rien n'est réencodé</option>
+          <option value="exact">Couper exactement ici &mdash; réencode l'image</option>
+          <option value="record">L'enregistrer pendant la lecture</option>
+        </select>
+        <p class="field-note" id="method-note"></p>
+      </div>
+
+      <div class="field" id="frame-field" hidden>
+        <label for="frame">Taille de l'image</label>
+        <select id="frame">
+          <option value="first" selected>Suivre la première vidéo</option>
+          <option value="largest">Suivre la plus grande</option>
+          <option value="1080p">1920 &times; 1080</option>
+          <option value="720p">1280 &times; 720</option>
+        </select>
+        <p class="field-note">
+          Une seule taille couvre tout le fichier. Une vidéo d'une autre forme y
+          est ajustée avec des bandes, jamais étirée.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualité</label>
+        <select id="quality">
+          <option value="low">Fichier plus léger</option>
+          <option value="medium" selected>Équilibré</option>
+          <option value="high">Meilleure qualité</option>
+        </select>
+        <p class="field-note">
+          Jamais plus que ce que l'original dépensait &mdash; réencoder au-dessus
+          ne fait que grossir le fichier.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Garder le son
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>On garde</dt><dd id="sum-clips">&mdash;</dd></div>
+      <div><dt>Durée finie</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Commence à</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>Environ</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Image</dt><dd id="sum-picture">&mdash;</dd></div>
+      <div><dt>Son</dt><dd id="sum-sound">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Couper la vidéo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Télécharger la vidéo</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/trim-video.toml
+++ b/locales/fr/tools/trim-video.toml
@@ -1,0 +1,332 @@
+#
+# Coupeur de vidéos - French.
+#
+# Overrides for tools/trim-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# The I and O keys are not translated. They are the keys the player listens
+# for - the shortcut is the letter itself, not a word - and renaming them in
+# the prose would name a key that does nothing.
+#
+
+name = "Coupeur de vidéos"
+heading = "Couper&nbsp;une&nbsp;vidéo <span class=\"h1-kw\">&mdash; couper une vidéo en ligne</span>"
+tagline = "Marquez les passages à garder pendant la lecture. Récupérez-les en une seule vidéo."
+
+title = "Couper une vidéo en ligne &mdash; ne garder que ce que vous voulez, sans envoi"
+description = "Regardez une vidéo et marquez chaque passage à garder pendant qu'elle joue, puis enregistrez ces passages en un seul fichier. Tout se passe dans votre navigateur : rien n'est envoyé, rien n'est réencodé, fonctionne hors ligne."
+og_title = "Coupeur de vidéos &mdash; ne garder que ce que vous voulez, sans rien envoyer"
+og_description = "Appuyez sur I et O pendant la lecture pour marquer chaque passage à garder. Les passages marqués sont réécrits en une seule vidéo, image pour image, sans rien envoyer."
+og_image_alt = "Coupeur de vidéos - marquez ce que vous voulez et enregistrez-le en une seule vidéo, dans votre navigateur"
+
+pledge = """
+    Votre vidéo est lue, marquée, coupée et écrite par votre propre navigateur,
+    sur votre propre matériel. Rien ici ne sait récupérer ni envoyer quoi que ce
+    soit &mdash; cet outil n'a aucune fonction réseau &mdash; et il n'y a à
+    l'autre bout de cette page aucun serveur auquel envoyer une vidéo, quand bien
+    même il y en aurait une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et coupez une vidéo. Pas une seule requête
+      ne transporte d'image, de nom de fichier ni un octet de ce que vous avez
+      choisi. Ou coupez votre connexion et coupez-en une quand même &mdash; un
+      outil qui expédierait votre vidéo ailleurs pour la couper s'arrêterait tout
+      simplement."""
+
+read_first = """
+, <code>src/segments.js</code> pour les marques et le
+      fichier où elles s'enregistrent, <code>src/demux.js</code> pour le lecteur
+      qui trouve les images dans un MP4, <code>src/ranges.js</code> pour
+      l'arithmétique qui transforme une marque en une suite d'échantillons, et
+      <code>src/copy.js</code> pour la boucle qui déplace ces échantillons dans
+      le nouveau fichier. Aucun d'eux n'importe quoi que ce soit capable de faire
+      une requête."""
+
+howto_heading = "Comment couper une vidéo"
+
+card = """
+            Marquez chaque passage à garder pendant la lecture, puis
+            enregistrez-les en une seule vidéo. Les images sont recopiées plutôt
+            que réencodées&nbsp;: rien n'est perdu."""
+
+[words]
+plural = "vidéos"
+choose = "une vidéo"
+analytics_extra = """, ni
+  image, durée ou point de coupe"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans filigrane"
+
+[[facts]]
+text = "Autant de passages que vous voulez"
+
+[[facts]]
+text = "Aucune perte de qualité"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[privacy]]
+title = "Vos vidéos n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où votre fichier pourrait arriver, et rien dans le code qui l'y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Cet outil n'a aucune fonction
+      réseau&nbsp;: pas d'adresse à coller, rien à télécharger, aucun moteur
+      récupéré à la première utilisation. Chaque octet qui touche à votre vidéo
+      vient de cette origine, au chargement de la page."""
+
+[[privacy]]
+title = "Sur le chemin normal, rien n'est même décodé."
+body = """
+
+      Couper ne change l'aspect d'aucune image&nbsp;: les images encodées des
+      passages que vous avez marqués sont donc déplacées dans le nouveau fichier
+      exactement telles qu'on les a trouvées. Chacune est retenue comme une
+      tranche du fichier sur votre disque &mdash; une note disant quels octets,
+      pas les octets eux-mêmes &mdash; et votre navigateur les lit pour la
+      première fois au moment d'écrire le téléchargement. Rien ici ne
+      retransforme jamais votre vidéo en image."""
+
+[[privacy]]
+title = "Le fichier de marques est fabriqué dans la page."
+body = """
+ Enregistrer vos marques
+      écrit un fichier texte à partir des nombres déjà à l'écran, directement
+      dans vos téléchargements. En charger un le lit ici. Ni l'un ni l'autre ne
+      s'approche d'un réseau, et ni l'un ni l'autre ne transporte autre chose que
+      des temps."""
+
+[[privacy]]
+title = "Le son est copié, pas écouté."
+body = """
+ Sur les deux chemins MP4, les
+      échantillons audio sont déplacés sans être décodés du tout &mdash; rien ici
+      ne les retransforme jamais en son, et rien ne saurait les faire passer où
+      que ce soit si c'était le cas."""
+
+[[privacy]]
+title = "Là où des images sont décodées, cela se passe ici."
+body = """
+ La coupe exacte, et
+      l'aperçu d'un fichier que ce navigateur refuse de jouer, passent par
+      WebCodecs sur votre propre machine. C'est le décodeur même qui vous
+      montrerait la vidéo de toute façon, tournant au même endroit."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit
+      quoi que ce soit sur votre vidéo&nbsp;: ni un fichier, ni une image, ni un
+      nom, une taille, une durée ou l'endroit où vous avez coupé. Chaque ligne
+      qui lit, coupe et écrit est servie depuis cette origine et figure dans le
+      dépôt."""
+
+[[privacy]]
+title = "Ce que le bouton de don charge, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; dans l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et se compose avec Google
+      Fonts. C'est un lien, rien de plus&nbsp;: il ne signale aucune visite, et
+      on ne lui donne rien sur vous ni sur votre vidéo."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et tout sur cette
+      page fonctionne encore. C'est la preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez une vidéo."
+body = """
+ Déposez un MP4, un MOV, un M4V ou un
+      WebM sur la zone prévue. Le navigateur le lit directement sur votre
+      disque&nbsp;; rien n'est envoyé nulle part pendant ce temps. Déposez-en
+      plusieurs et ils sont mis bout à bout, dans l'ordre où vous les avez
+      posés."""
+
+[[howto]]
+title = "Lancez la lecture et marquez les passages voulus."
+body = """
+ Appuyez sur
+      <kbd>I</kbd> là où un passage doit commencer et sur <kbd>O</kbd> là où il
+      doit finir. Faites-le autant de fois que vous voulez &mdash; chaque paire
+      devient une ligne dans le tableau du dessous, et une bande sur la ligne de
+      temps. <kbd>U</kbd> reprend la dernière, <kbd>Espace</kbd> lit et met en
+      pause, et les flèches sautent de cinq secondes. Ralentissez la lecture si
+      le moment est difficile à attraper."""
+
+[[howto]]
+title = "Retouchez les marques."
+body = """
+ Chaque ligne peut être relue seule,
+      recalée en tapant un temps exact, montée ou descendue dans l'ordre, ou
+      supprimée. Les deux extrémités du passage sélectionné peuvent aussi être
+      tirées le long de la ligne de temps. Le total en haut est la durée que fera
+      la vidéo finie."""
+
+[[howto]]
+title = "Gardez-les, ou coupez-les."
+body = """
+ Garder est le sens habituel&nbsp;:
+      la vidéo finie, ce sont les passages que vous avez marqués, mis bout à bout
+      dans l'ordre. Les couper est l'autre travail que les gens veulent et
+      trouvent rarement &mdash; marquez les publicités, les silences ou les faux
+      départs, et ce qui reste est raccordé sans eux."""
+
+[[howto]]
+title = "Coupez, et téléchargez."
+body = """
+ &laquo;&nbsp;Garder chaque
+      octet&nbsp;&raquo; déplace les images intactes&nbsp;: c'est rapide et cela
+      ne peut pas coûter de qualité, mais chaque passage commence à l'image clé
+      qui précède votre marque. &laquo;&nbsp;Couper exactement ici&nbsp;&raquo;
+      décode et réécrit l'image pour que chaque passage démarre sur l'image que
+      vous avez choisie. La page dit lequel des deux vous êtes sur le point
+      d'obtenir, et ce qu'il coûte, avant que vous appuyiez sur le bouton."""
+
+[[faq]]
+q = "Ma vidéo est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. Elle est lue, marquée, coupée et écrite par votre propre navigateur sur
+        votre propre matériel. Cet outil n'a pas de côté serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter &mdash; aucune n'appartient à ce site. Coupez votre
+        connexion et coupez une vidéo quand même, si vous préférez vérifier plutôt
+        qu'on vous le dise."""
+
+[[faq]]
+q = "Puis-je garder plusieurs passages d'une même vidéo&nbsp;?"
+a = """
+        C'est fait pour cela. Appuyez sur <kbd>I</kbd> et <kbd>O</kbd> autant de fois
+        que vous voulez pendant la lecture&nbsp;; chaque paire devient une ligne, et la
+        vidéo finie est l'ensemble des lignes mises bout à bout, tout le reste ayant
+        disparu. La plupart des coupeurs en ligne vous donnent une seule paire de
+        poignées et vous demandent quel unique passage garder, ce qui convient pour
+        ébarber un clip et ne sert à rien du tout quand il s'agit de regarder une heure
+        de rushes une fois et d'en garder les six moments qui valent la peine."""
+
+[[faq]]
+q = "Couper fait-il perdre de la qualité&nbsp;?"
+a = """
+        Pas sur le chemin normal, et pas de la façon qui compte. Couper ne change
+        l'aspect d'aucune image&nbsp;: les images sont donc déplacées dans le nouveau
+        fichier exactement telles qu'elles étaient &mdash; mêmes octets, mêmes réglages
+        d'encodeur, même tout. Le seul chemin d'ici qui réencode quoi que ce soit est la
+        coupe exacte, et le bouton le dit."""
+
+[[faq]]
+q = "Pourquoi un passage commence-t-il plus tôt que là où je l'ai marqué&nbsp;?"
+a = """
+        À cause de la façon dont la vidéo est stockée, et seulement sur les lecteurs qui
+        ignorent une partie standard du format. La plupart des images sont gardées comme
+        une description de ce qui les différencie de leurs voisines&nbsp;: elles ne
+        peuvent pas être décodées sans elles. Seule une image clé se tient toute seule,
+        et les images clés sont typiquement espacées d'une à dix secondes. Une coupe qui
+        recopie les images doit donc emporter la suite depuis l'image clé qui précède
+        votre marque &mdash; et le fichier dit <em>commencer la lecture à votre
+        marque</em>, ce que tout lecteur grand public respecte. S'il vous la faut exacte
+        dans tous les lecteurs, choisissez
+        &laquo;&nbsp;Couper exactement ici&nbsp;&raquo;, qui réencode. La page vous dit
+        dans quel cas vous êtes, et de combien, avant l'export."""
+
+[[faq]]
+q = "Puis-je plutôt couper les publicités&nbsp;?"
+a = """
+        Oui. Marquez-les, puis choisissez &laquo;&nbsp;Les couper&nbsp;&raquo;&nbsp;:
+        c'est tout ce que vous n'avez <em>pas</em> marqué qui est raccordé, dans
+        l'ordre. La même liste de marques répond aux deux questions&nbsp;: vous pouvez
+        donc passer de l'une à l'autre et voir la durée changer sans rien marquer deux
+        fois."""
+
+[[faq]]
+q = "Puis-je enregistrer mes marques et y revenir&nbsp;?"
+a = """
+        Oui. &laquo;&nbsp;Enregistrer les marques&nbsp;&raquo; écrit un simple fichier
+        texte &mdash; une ligne par passage, un début et une fin séparés par une virgule
+        &mdash; et &laquo;&nbsp;Charger des marques&nbsp;&raquo; en relit un. Deux
+        formats sont proposés, des secondes brutes et
+        <code>HH:MM:SS.mmm</code>, et tous deux respectent la disposition qu'utilisent
+        déjà les autres outils qui travaillent ainsi&nbsp;: un fichier écrit ici peut
+        être donné à l'un d'eux, et un fichier écrit là-bas peut être déposé sur cette
+        page. Marquer est un travail minutieux et personne ne devrait avoir à le faire
+        deux fois."""
+
+[[faq]]
+q = "Quels formats vidéo puis-je couper&nbsp;?"
+a = """
+        Le MP4, le M4V et le MOV sont lus directement, quel que soit leur
+        contenu&nbsp;: H.264, HEVC, AV1 ou VP9. Recopier des images n'implique pas de
+        les décoder&nbsp;: ce chemin fonctionne donc même pour un codec dont votre
+        navigateur n'a aucun décodeur. Tout le reste que votre navigateur sait lire
+        &mdash; le WebM au premier chef &mdash; est coupé en le jouant et en
+        enregistrant le résultat, ce qui marche, prend le temps que dure le résultat, et
+        ne peut garder qu'un seul passage. Un fichier que le navigateur ne sait ni lire
+        ni jouer, ce qui en pratique veut dire l'AVI, le WMV, le FLV et la plupart des
+        MKV, est refusé avec un message qui le dit, plutôt que d'échouer à mi-course."""
+
+[[faq]]
+q = "Y a-t-il une limite de taille ou de durée&nbsp;?"
+a = """
+        Aucune limite n'est intégrée à l'outil, et sur le chemin par copie le fichier
+        est à peine lu&nbsp;: les images que vous gardez sont pointées plutôt que
+        chargées, si bien que garder quatre minutes d'un enregistrement de quatre
+        gigaoctets coûte à peu près ce que coûte l'écriture de ces quatre minutes sur le
+        disque. La coupe exacte parcourt le fichier quelques mégaoctets à la fois. Dans
+        les deux cas, le plafond pratique est le fichier fini, assemblé en mémoire avant
+        que vous le téléchargiez."""
+
+[[faq]]
+q = "Le son survit-il&nbsp;?"
+a = """
+        Sur les deux chemins MP4, il est recopié échantillon par échantillon sans jamais
+        être décodé, il est donc octet pour octet ce qu'il y avait dans le fichier, et
+        une marque de montage garde chaque passage aligné sur son image au millième de
+        seconde près. La seule exception est le raccordement de vidéos distinctes dont
+        le son est décrit différemment &mdash; des fréquences d'échantillonnage
+        différentes, par exemple &mdash; où il n'y a aucun moyen de mettre les deux dans
+        une seule piste sans les décoder, et la page le dit avant de le faire. Sur le
+        chemin par enregistrement, il est capté à la lecture et réencodé. Dans les deux
+        cas, une case permet de le laisser entièrement de côté."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Le site porte de la publicité, et c'est elle qui le
+        finance&nbsp;; les annonces ne reçoivent rien sur votre vidéo."""
+
+[schema]
+browser_requirements = "Nécessite JavaScript. Recopier les images ne demande aucune prise en charge de codec vidéo ; la coupe exacte demande un navigateur avec WebCodecs, et les autres formats se rabattent sur l'enregistrement."
+description = "Marquez autant de passages que vous voulez pendant la lecture d'une vidéo, puis enregistrez ces passages en un seul fichier - ou coupez-les et gardez le reste. Les MP4, MOV et M4V sont coupés en déplaçant les images encodées intactes dans un nouveau fichier, avec l'audio d'origine repris échantillon par échantillon ; rien n'est envoyé et rien n'est réencodé."
+features = [
+  "Marque autant de passages que voulu avec I et O pendant la lecture",
+  "Raccorde les passages marqués en un seul fichier, dans l'ordre que vous choisissez",
+  "Coupe plutôt les passages marqués, en gardant tout le reste",
+  "Coupe sans réencoder, si bien qu'aucune qualité n'est perdue",
+  "Enregistre et recharge les marques dans un fichier texte d'horodatages",
+  "Marques à l'image près, avec les images clés montrées sur la ligne de temps",
+  "Garde l'audio d'origine sans le réencoder",
+  "Fonctionne hors ligne ; sans envoi, sans compte, sans filigrane",
+]
+
+[picker]
+title = "Déposez une vidéo ici"
+hint = "ou cliquez pour parcourir &mdash; MP4, MOV, M4V, WebM. Déposez-en plusieurs pour les raccorder."

--- a/locales/fr/tools/video-to-gif.html
+++ b/locales/fr/tools/video-to-gif.html
@@ -1,0 +1,170 @@
+<main>
+  <!-- Étape 1 &mdash; le fichier -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisir une vidéo</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Fichier</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Taille</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Image</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durée</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Vidéo</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Lue par</dt><dd id="src-path">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Étape 2 &mdash; le passage -->
+  <section class="card" id="section-card" hidden>
+    <h2><span class="step">2</span> Choisir le passage</h2>
+
+    <p class="hint">
+      Lisez le clip et marquez la partie voulue. <kbd>I</kbd> pose le début là où
+      se trouve la tête de lecture, <kbd>O</kbd> pose la fin, et les deux
+      poignées de la barre peuvent être tirées.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- The bar itself is built by src/range.js. -->
+    <div id="rangebar"></div>
+    <div class="rb-scale">
+      <span>0:00.000</span>
+      <span id="scale-end">&mdash;</span>
+    </div>
+
+    <div class="marks">
+      <label>Début
+        <input type="text" id="start-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-in" class="ghost" title="Poser le début là où se trouve la tête de lecture (I)">
+        Poser à la tête de lecture
+      </button>
+
+      <label>Fin
+        <input type="text" id="end-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-out" class="ghost" title="Poser la fin là où se trouve la tête de lecture (O)">
+        Poser à la tête de lecture
+      </button>
+
+      <div class="mark-actions">
+        <button type="button" id="play-section" class="ghost">Lire le passage</button>
+        <button type="button" id="whole-clip" class="ghost">Tout le clip</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Étape 3 &mdash; le GIF -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Taille et cadence</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="width">Largeur</label>
+        <select id="width">
+          <option value="240">240 px</option>
+          <option value="320">320 px</option>
+          <option value="480" selected>480 px</option>
+          <option value="640">640 px</option>
+          <option value="source">Taille d'origine</option>
+          <option value="custom">Exactement&hellip;</option>
+        </select>
+        <p class="field-note">
+          La hauteur suit&nbsp;: la forme ne change donc jamais. C'est la largeur
+          qui fait le prix d'un GIF&nbsp;: la moitié de la largeur, c'est le
+          quart des pixels.
+        </p>
+        <p class="field-note" id="width-note" hidden></p>
+      </div>
+
+      <div class="field" id="custom-width-field" hidden>
+        <label for="custom-width">Largeur exacte</label>
+        <input type="number" id="custom-width" min="16" max="1920" step="1" value="480">
+        <p class="field-note">En pixels, entre 16 et 1920.</p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Images par seconde</label>
+        <select id="fps">
+          <option value="5">5 &mdash; le plus léger</option>
+          <option value="10">10</option>
+          <option value="12" selected>12 &mdash; assez fluide</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+          <option value="25">25 &mdash; le plus fluide</option>
+        </select>
+        <p class="field-note">
+          Pas la cadence propre de la vidéo&nbsp;: les images y sont
+          échantillonnées. Douze se lit comme du mouvement&nbsp;; au-dessus de
+          vingt, le fichier grossit plus vite que la fluidité ne se voit.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Tramage</label>
+        <select id="dither">
+          <option value="on" selected>Activé &mdash; dégradés plus doux</option>
+          <option value="off">Désactivé &mdash; plus plat, plus léger</option>
+        </select>
+        <p class="field-note">
+          Mélange deux couleurs de la palette là où la bonne manque. Ordonné,
+          pour qu'un fond immobile ne scintille pas.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="loop">
+          <input type="checkbox" id="loop" checked>
+          Boucler indéfiniment
+        </label>
+        <p class="field-note">Décoché, il joue une fois et s'arrête.</p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Passage</dt><dd id="sum-section">&mdash;</dd></div>
+      <div><dt>Sortie</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Images</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Taille de fichier approximative</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="memory-note" class="field-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Fabriquer le GIF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <img id="result-image" alt="L'animation finie, en cours de lecture">
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Télécharger le GIF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/fr/tools/video-to-gif.toml
+++ b/locales/fr/tools/video-to-gif.toml
@@ -1,0 +1,256 @@
+#
+# Vidéo en GIF - French.
+#
+# Overrides for tools/video-to-gif/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Vidéo en GIF"
+heading = "Vidéo&nbsp;en&nbsp;GIF <span class=\"h1-kw\">&mdash; convertir une vidéo en GIF</span>"
+tagline = "Choisissez le passage, la taille et la cadence."
+
+title = "Convertisseur de vidéo en GIF &mdash; gratuit, sans envoi, hors ligne"
+description = "Transformez un passage d'un MP4, d'un MOV ou d'un WebM en GIF animé. Choisissez le passage, la largeur et la cadence ; les images sont lues et le GIF est écrit dans votre navigateur. Rien n'est envoyé."
+og_title = "Vidéo en GIF &mdash; faire un GIF sans envoyer le clip"
+og_description = "Marquez les secondes voulues, choisissez une largeur et une cadence, et récupérez un GIF animé. L'échantillonnage des images, la palette, le tramage et le LZW se font tous sur votre propre machine."
+og_image_alt = "Vidéo en GIF - faire un GIF animé dans votre navigateur, sans rien envoyer"
+
+pledge = """
+    Chaque image est lue, redimensionnée, quantifiée et écrite par votre propre
+    navigateur, sur votre propre matériel. Rien ici ne sait récupérer ni envoyer
+    quoi que ce soit &mdash; cet outil n'a aucune fonction réseau &mdash; et il
+    n'y a à l'autre bout de cette page aucun serveur auquel envoyer une vidéo,
+    quand bien même il y en aurait une."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les outils de développement,
+      gardez l'onglet Réseau à l'œil et fabriquez un GIF. Pas une seule requête
+      ne transporte d'image, de nom de fichier ni un octet de ce que vous avez
+      choisi. Ou coupez votre connexion et fabriquez-en un quand même &mdash; un
+      outil qui expédierait votre vidéo ailleurs pour la convertir s'arrêterait
+      tout simplement."""
+
+read_first = """
+, <code>src/frames.js</code> pour les deux façons de
+      lire les images d'une vidéo, <code>src/quantize.js</code> pour la palette,
+      et <code>src/gif.js</code> pour le fichier lui-même, LZW compris. Aucun
+      d'eux n'importe quoi que ce soit capable de faire une requête."""
+
+howto_heading = "Comment transformer une vidéo en GIF"
+
+card = """
+            Marquez les secondes voulues, choisissez une largeur et une cadence,
+            et récupérez un GIF animé &mdash; palette, tramage et tout le
+            reste."""
+
+[words]
+plural = "vidéos"
+choose = "une vidéo"
+analytics_extra = """, ni
+  image, durée ou taille"""
+
+[[facts]]
+text = "Sans envoi"
+
+[[facts]]
+text = "Sans compte"
+
+[[facts]]
+text = "Sans filigrane"
+
+[[facts]]
+text = "N'importe quelle durée"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[privacy]]
+title = "Vos vidéos n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme toutes les adresses que cette page peut
+      contacter, et aucune n'appartient à ce site. Il n'y a ici aucun point de
+      collecte où votre fichier pourrait arriver, et rien dans le code qui l'y
+      enverrait s'il en existait un."""
+
+[[privacy]]
+title = "Rien ici ne va rien chercher."
+body = """
+ Cet outil n'a aucune fonction
+      réseau&nbsp;: pas d'adresse à coller, rien à télécharger, aucun moteur
+      récupéré à la première utilisation. Chaque octet qui touche à votre vidéo
+      vient de cette origine, au chargement de la page."""
+
+[[privacy]]
+title = "Le décodage est local."
+body = """
+ Les images passent par WebCodecs dans
+      votre propre navigateur, ou par le même moteur de lecture qui vous
+      montrerait le clip de toute façon. Lequel des deux a servi est écrit en
+      haut de la page, parce que cela change la façon dont les images sont
+      choisies et que vous devez pouvoir le voir."""
+
+[[privacy]]
+title = "Le GIF est écrit ici, dans du code que vous pouvez lire."
+body = """
+ La palette, le
+      tramage et la compression LZW font environ six cents lignes dans le dossier
+      propre à cet outil. Il n'y a aucun service d'encodage, aucune bibliothèque
+      récupérée à l'exécution, et aucun endroit dans tout cela où une image
+      pourrait être envoyée."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts
+      publicitaires et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit
+      quoi que ce soit sur votre vidéo&nbsp;: ni un fichier, ni une image, ni un
+      nom, une taille, une durée ou le passage que vous avez marqué. Chaque ligne
+      qui lit, échantillonne, quantifie ou encode est servie depuis cette origine
+      et figure dans le dépôt."""
+
+[[privacy]]
+title = "Ce que le bouton de don charge, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; dans l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et se compose avec Google
+      Fonts. C'est un lien, rien de plus&nbsp;: il ne signale aucune visite, et
+      on ne lui donne rien sur vous ni sur votre vidéo."""
+
+[[privacy]]
+title = "Cela fonctionne hors ligne."
+body = """
+ Coupez le réseau et tout sur cette
+      page fonctionne encore. C'est la preuve la plus simple de toutes."""
+
+[[howto]]
+title = "Choisissez une vidéo."
+body = """
+ Déposez un MP4, un MOV, un M4V ou un
+      WebM sur la zone prévue, ou sélectionnez-en un à la main. Le navigateur le
+      lit directement sur votre disque&nbsp;; rien n'est envoyé nulle part
+      pendant ce temps."""
+
+[[howto]]
+title = "Marquez le passage."
+body = """
+ Lisez le clip et appuyez sur
+      <kbd>I</kbd> là où il doit commencer et sur <kbd>O</kbd> là où il doit
+      finir, ou tirez les poignées sur la barre. Un GIF dure quelques secondes
+      &mdash; c'est le réglage qui décide si le fichier sera petit ou énorme,
+      bien plus que les deux autres."""
+
+[[howto]]
+title = "Choisissez la largeur et la cadence."
+body = """
+ 480 pixels de large et 12
+      images par seconde conviennent à la plupart des usages d'un GIF. Diviser la
+      largeur par deux divise les pixels par quatre&nbsp;; douze images par
+      seconde se lisent comme du mouvement sans payer pour celles que personne ne
+      voit."""
+
+[[howto]]
+title = "Fabriquez-le, et téléchargez."
+body = """
+ Les images sont lues, une seule
+      palette de 256 couleurs est choisie pour toute l'animation, et chaque image
+      n'est écrite que sur la partie qui a changé. Il joue sur la page une fois
+      prêt, et c'est le même fichier que celui du téléchargement."""
+
+[[faq]]
+q = "Ma vidéo est-elle envoyée quelque part&nbsp;?"
+a = """
+        Non. Elle est lue, échantillonnée et convertie par votre propre navigateur sur
+        votre propre matériel. Cet outil n'a pas de côté serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+        qu'elle peut contacter &mdash; aucune n'appartient à ce site. Coupez votre
+        connexion et fabriquez un GIF quand même, si vous préférez vérifier plutôt
+        qu'on vous le dise."""
+
+[[faq]]
+q = "Quels formats vidéo puis-je convertir&nbsp;?"
+a = """
+        Le MP4, le M4V et le MOV sont lus directement, quel que soit leur
+        contenu&nbsp;: H.264, HEVC, AV1 ou VP9, du moment que votre navigateur sait
+        décoder ce codec. Tout le reste que votre navigateur sait lire &mdash; le WebM
+        au premier chef &mdash; est lu en déplaçant le lecteur jusqu'à chaque instant,
+        ce qui est plus lent et un peu moins exact sur l'image qui atterrit où. Un
+        fichier que le navigateur ne sait ni lire ni jouer, ce qui en pratique veut dire
+        l'AVI, le WMV, le FLV et la plupart des MKV, est refusé avec un message qui le
+        dit, plutôt que d'échouer à mi-course."""
+
+[[faq]]
+q = "Pourquoi mon GIF est-il si gros&nbsp;?"
+a = """
+        Parce que le GIF est un format de 1987 qui stocke des images entières plutôt
+        que du mouvement. Il n'y a aucun moyen d'en faire un, à partir d'un clip de cinq
+        secondes, qui soit aussi léger que le MP4 de cinq secondes dont il vient &mdash;
+        un GIF tiré d'une vidéo pèse couramment dix fois la vidéo. Les trois réglages
+        qui décident vraiment sont, dans l'ordre&nbsp;: la durée du passage, la largeur
+        de l'image, et le nombre d'images par seconde. Diviser la largeur par deux
+        divise les pixels par quatre, et ce sont les pixels qui coûtent."""
+
+[[faq]]
+q = "Pourquoi seulement 256 couleurs&nbsp;?"
+a = """
+        C'est le format&nbsp;: un GIF porte une table d'au plus 256 couleurs et stocke
+        chaque pixel comme un numéro dans cette table. Cet outil choisit ces 256 en
+        comptant les couleurs de chaque image de votre passage et en les répartissant en
+        256 groupes &mdash; la coupe médiane, la méthode classique &mdash; si bien que
+        la palette colle à votre clip au lieu d'être un jeu de couleurs figé. Là où une
+        couleur manque, le tramage mélange les deux plus proches pour qu'un dégradé
+        reste un dégradé au lieu de devenir des bandes."""
+
+[[faq]]
+q = "Que fait le réglage de tramage&nbsp;?"
+a = """
+        Il échange un peu de bruit contre beaucoup de bandes en moins. Activé, un ciel
+        qui serait sinon devenu quatre aplats reste un dégradé, au prix d'une légère
+        texture et d'un fichier plus gros. Désactivé, l'image est plus plate et le
+        fichier plus léger, ce qui convient aux captures d'écran, au dessin au trait et
+        à tout ce qui est déjà fait d'aplats. Le tramage employé ici est ordonné plutôt
+        que du type à diffusion d'erreur&nbsp;: un fond inchangé reste ainsi
+        parfaitement immobile d'une image à l'autre au lieu de scintiller."""
+
+[[faq]]
+q = "Y a-t-il une limite de durée ou de taille&nbsp;?"
+a = """
+        C'est le passage qui est limité, et par la mémoire plutôt que par une
+        règle&nbsp;: chacune de ses images est retenue en même temps pendant le choix de
+        la palette, alors la page calcule ce que vos réglages coûteraient et le dit
+        avant de commencer. Elle refuse plutôt que de laisser l'onglet manquer de
+        mémoire et disparaître. Un passage plus court, une largeur plus petite ou une
+        cadence plus basse font tous baisser le chiffre."""
+
+[[faq]]
+q = "Garde-t-il le son&nbsp;?"
+a = """
+        Un GIF ne sait pas transporter de son. Il n'existe aucune version du format qui
+        ait de l'audio, ce qui est la principale raison pour laquelle le web a
+        essentiellement remplacé les GIF par de la vidéo muette en boucle. Si le son
+        compte, gardez la vidéo &mdash; le
+        <a href="../couper-une-video/">coupeur de vidéos</a> en découpera un passage
+        sans réencoder une seule image."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a pas de compte, pas de connexion, pas de période
+        d'essai et pas de filigrane. Le site porte de la publicité, et c'est elle qui le
+        finance&nbsp;; les annonces ne reçoivent rien sur votre vidéo."""
+
+[schema]
+browser_requirements = "Nécessite JavaScript. Le MP4 et le MOV demandent un navigateur avec WebCodecs ; tout ce que le navigateur sait jouer fonctionne sans."
+description = "Convertissez un passage d'une vidéo en GIF animé, dans le navigateur. Les images sont échantillonnées à la cadence choisie, une seule palette de 256 couleurs est choisie pour toute l'animation par coupe médiane, et chaque image n'est écrite que sur la région qui a changé. Rien n'est envoyé."
+features = [
+  "Convertit des vidéos MP4, MOV, M4V et WebM en GIF animé",
+  "Sources H.264, HEVC, AV1 et VP9, décodées par WebCodecs",
+  "Marquez le passage sur une ligne de temps, ou tapez des temps exacts",
+  "N'importe quelle largeur, de 5 à 25 images par seconde, tramage ordonné facultatif",
+  "Fonctionne hors ligne ; sans envoi, sans compte, sans filigrane",
+]
+
+[picker]
+title = "Déposez une vidéo ici"
+hint = "ou cliquez pour parcourir &mdash; MP4, MOV, M4V, WebM, et tout ce que ce navigateur sait jouer"


### PR DESCRIPTION
Français, complete: all fifteen tools, all fifteen guides, the roadmap list, the
two legal pages, and the six addresses the frame was missing. `complete = true`,
so French is now in the sitemap, in every hreflang set and in the language
switcher — and the link check is on for it.

**Stacked on #48.** It branches from `claude/website-i18n-translations`, not from
`main`, because that is where the French frame and the locale machinery live.
Merge #48 first; this diff on its own would not apply.

## What is in it

* `locales/fr/tools/` — 15 tools, `.toml` and `.html` each. Headings, pledge,
  live check, privacy panel, how-to, questions, structured data, drop zone.
* `locales/fr/pages/guides/` — 15 guides, `.toml` and `.html` each.
* `locales/fr/pages/` — privacy and terms.
* `locales/fr/planned.toml` — the roadmap list.
* `locales/fr/locale.toml` — six new slug entries, the `codes-and-data`
  category, and the flag.

Nothing outside `locales/fr/` is touched. `python build.py` succeeds with French
absent from the "still in English" list; `python -m unittest discover -s
tests/python -t .` is 305 tests, OK.

## The slug choices

Six were needed. Each is the phrase a French speaker types, not a translation of
the English slug.

| English | French | why |
|---|---|---|
| `image-to-ico` | `creer-un-favicon` | Nobody searches "image en ICO". Named for the job, like the EXIF tool above it. |
| `svg-to-image` | `convertir-svg-en-png` | The two format names carry the phrase; "convertir un SVG en une PNG" is not French anybody writes. |
| `heic-to-jpg` | `convertir-heic-en-jpg` | Same shape, same reason. |
| `video-to-gif` | `video-en-gif` | Matches the existing `images-en-pdf` / `images-en-video`: a conversion named by its two ends. |
| `image-to-data-uri` | `image-en-base64` | "Image en base64" is the query. "Data URI" survives in the page title and the prose, where it is the name of the thing. |
| `qr-barcode` | `generateur-de-qr-code` | The one noun phrase. "Générateur de QR code" is genuinely what gets typed, where "créer un QR code" is the *guide* beside it. |

The guides keep the article the tool slugs drop, because a question is asked in
full sentences even when a search box is not:
`guides/convertir-un-svg-en-png`, `guides/convertir-un-heic-en-jpg`,
`guides/transformer-une-video-en-gif`, `guides/integrer-une-image-dans-le-css`,
`guides/creer-un-qr-code`, and `guides/creer-son-favicon`.

That last one is deliberate rather than careless. The tool is
`creer-un-favicon`; a guide at `guides/creer-un-favicon` would sit one word from
it and be a coin toss for anyone pasting a link, so the possessive marks the
long way round — the same move German makes with `favicon-selbst-erstellen`.

## Calls I would like a second opinion on

1. **KB and MB, left in English throughout.** French prose wants "Ko" and "Mo",
   but the figures on screen come from `src/files.js`, which is one file for
   every language and says "KB". Prose saying "Ko" beside a tool saying "KB"
   seemed worse than the small unidiomatic note. If the JS is ever localised,
   this should follow.
2. **`generateur-de-qr-code`** is the only noun-phrase tool slug, against the
   convention the file's own comment sets out. I think the query justifies it
   and I have written the reasoning into the comment beside it, but it is the
   one slug I would happily change.
3. **`image-en-base64`** names base64 while the tool percent-encodes SVGs rather
   than base64-ing them — which the page then spends a section explaining. The
   slug follows the search rather than the tool's full behaviour.
4. **"image clé" for keyframe**, throughout the trimming guide. French has no
   settled everyday word for it outside broadcast; the guide defines it once and
   uses it consistently.

## One bug fixed on the way

`[ui.picker].note` built a plural by appending an `s` to
`{{ tool.picker.urls.noun }}`. That is an English trick rather than a rule — it
happens to give "images" correctly for the one noun that exists today, and would
not for a noun with an irregular plural. The sentence is now written round the
singular, and the gender the rest of the panel assumes ("la … est copiée",
"quelle … vous avez demandée") is written down beside it so the next tool with a
`[picker.urls]` table does not have to rediscover it.

## Found, not touched

`locales/de/` is `complete = false` on this base and I left it alone, per the
brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
