### PR TITLE
Publish a translation a page at a time, and restore the German that was dropped

### DIFF
--- a/build.py
+++ b/build.py
@@ -154,6 +154,14 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
         i18n.check_slugs(locale, [tool['slug'] for tool in tools],
                          [page['slug'] for page in prose], site)
 
+    # Before anything is written, because rendering one page needs to know which
+    # OTHER languages have finished that same page - the hreflang set on the
+    # English tool page is the set of languages it exists in. English is
+    # rendered first, so if the answer were worked out as each language went by,
+    # English would be asking the question before any language had answered it,
+    # and would advertise a German page that is still English.
+    i18n.survey(locales, tools, prose, planned, site)
+
     written = []
     for locale in locales:
         written += build_locale(out, templates, locale, locales, site, tools,
@@ -166,16 +174,31 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     for locale in locales:
         i18n.check_complete(locale)
 
-    # How far along each unfinished language is, said out loud on every build.
-    # A translation that is 40 strings from done and a translation that has not
-    # been started look identical in a directory listing, and the difference is
-    # the only thing anybody wants to know about it.
+    # How far along each language is, said out loud on every build. A
+    # translation that is 40 strings from done and one that has not been started
+    # look identical in a directory listing, and the difference is the only
+    # thing anybody wants to know about it.
+    #
+    # Two different states are worth two different sentences. A locale that has
+    # not finished its frame is not published at all. A locale that has is
+    # published, and owes a number of PAGES - which is the unit that decides
+    # anything now, since a page with one string left is as held back as a page
+    # with four hundred.
     for locale in locales:
-        if locale['is_base'] or locale['complete']:
+        if locale['is_base']:
             continue
-        left = len(set(locale['missing']))
-        print(f'  {locale["lang"]}: {left} strings still in English '
-              f'(not advertised until complete = true)')
+        if not locale['complete']:
+            left = len(set(i18n.all_debt(locale)))
+            print(f'  {locale["lang"]}: {left} strings still in English '
+                  f'(not advertised until complete = true)')
+            continue
+        behind = i18n.debt_report(locale, tools, prose)
+        if behind:
+            print(f'  {locale["lang"]}: published, {len(behind)} of '
+                  f'{len(tools) + len(prose)} pages still in English '
+                  f'(built and readable, kept out of the sitemap): '
+                  + ', '.join(sorted(behind)[:4])
+                  + (' ...' if len(behind) > 4 else ''))
 
     # One 404 for the whole domain, in English, because GitHub Pages serves one
     # file for every address it cannot find and has no way to know which
@@ -333,7 +356,7 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
     written.append(f'{locale["prefix"]}index.html')
 
     build_roadmap(dest_root, templates, locale, locales, site,
-                  i18n.localize_planned(planned, locale), ordered,
+                  i18n.localize_planned(planned, locale, site['roadmap']['slug']), ordered,
                   footer, links, css_v, emit)
     written.append(f'{locale["prefix"]}{links["roadmap"]}/index.html')
 
@@ -1042,31 +1065,44 @@ def build_sitemap(out, templates, site, locales, tools, prose):
         def url(slug, locale=locale):
             return i18n.locale_url(locale, slug, site)
 
-        entries.append({'url': url(''), 'lastmod': site['lastmod'],
-                        'changefreq': 'weekly', 'priority': '1.0'})
+        # A page this language has not translated yet is built and readable,
+        # but it is not listed here. Inviting a crawler to index an English
+        # page sitting at a German URL is how a site ends up ranking its own
+        # untranslated half for the wrong language, and it is the single
+        # failure this whole arrangement exists to avoid.
+        def ready(slug, locale=locale):
+            return i18n.translated(locale, slug)
+
+        if ready(''):
+            entries.append({'url': url(''), 'lastmod': site['lastmod'],
+                            'changefreq': 'weekly', 'priority': '1.0'})
         entries += [{'url': url(tool['slug']), 'lastmod': tool['lastmod'],
                      'changefreq': 'monthly', 'priority': '0.8'}
-                    for tool in tools]
+                    for tool in tools if ready(tool['slug'])]
         # Guides below the tools and above the legal pages. A tool is what
         # somebody came for; a guide is how they find out this site exists. The
         # index they are listed on goes first and slightly higher: it is the
         # page that gains from being crawled as a set rather than as nine
         # unrelated articles.
-        entries.append({'url': url(site['guides']['slug']),
-                        'lastmod': site['guides']['lastmod'],
-                        'changefreq': 'monthly', 'priority': '0.7'})
+        if ready(site['guides']['slug']):
+            entries.append({'url': url(site['guides']['slug']),
+                            'lastmod': site['guides']['lastmod'],
+                            'changefreq': 'monthly', 'priority': '0.7'})
         entries += [{'url': url(page['slug']), 'lastmod': page['lastmod'],
                      'changefreq': 'monthly', 'priority': '0.6'}
-                    for page in prose if page['kind'] == 'guide']
+                    for page in prose
+                    if page['kind'] == 'guide' and ready(page['slug'])]
         # The roadmap: a real page, but not one anybody searches for. Below the
         # guides, above the legal pages.
-        entries.append({'url': url(site['roadmap']['slug']),
-                        'lastmod': site['roadmap']['lastmod'],
-                        'changefreq': 'monthly', 'priority': '0.5'})
+        if ready(site['roadmap']['slug']):
+            entries.append({'url': url(site['roadmap']['slug']),
+                            'lastmod': site['roadmap']['lastmod'],
+                            'changefreq': 'monthly', 'priority': '0.5'})
         # The legal pages last, and low: they matter for trust, not for search.
         entries += [{'url': url(page['slug']), 'lastmod': page['lastmod'],
                      'changefreq': 'yearly', 'priority': '0.3'}
-                    for page in prose if page['kind'] == 'legal']
+                    for page in prose
+                    if page['kind'] == 'legal' and ready(page['slug'])]
 
     write(out / 'sitemap.xml', templates.render('sitemap.xml', {'pages': entries}))
 

--- a/buildlib/i18n.py
+++ b/buildlib/i18n.py
@@ -39,19 +39,54 @@ build is meant to make impossible". That rule is not weakened below - it is
 moved. A locale may leave a key out, and the English text is used; what a locale
 may NOT do is leave a key out and still be advertised as a translation.
 
-An incomplete locale is built, so it can be read and reviewed at a real URL, and
-is then held back from every place that would claim it exists:
+Anything not translated is built, so it can be read and reviewed at a real URL,
+and is then held back from every place that would claim it exists:
 
   * no <link rel="alternate" hreflang> pointing at it, from any page;
   * no entry in sitemap.xml;
   * no link in the language switcher.
 
-So a half-translated German site is a thing the author can open, and a thing
-Google is never invited to index. Setting `complete = true` turns the fallback
-back into an error: from then on a missing key fails the build, exactly as a
-missing name does in a template. A locale therefore gets more strict as it gets
-more finished, which is the direction that helps.
+So a half-translated German page is a thing the author can open, and a thing
+Google is never invited to index.
+
+WHAT "FINISHED" IS MEASURED IN, AND WHY IT IS NOT THE LANGUAGE
+
+It is measured a PAGE at a time. That is the second version of this rule, and
+the first one was wrong in a way worth recording, because the failure was not
+in the code.
+
+`complete = true` used to mean "every string in this language is translated",
+enforced by failing the build on any fallback at all. It reads like the strict
+option, and it is - but English is not finished either. This site ships a tool
+most weeks, and each one arrives untranslated in every language at once, so the
+rule failed the build for ten languages every time English grew. German hit it
+three times while it was being written; the third time it was also holding up
+nine other languages that had nothing to do with it. A rule that turns a normal
+Tuesday into a broken build is not strictness, it is a rule measuring the wrong
+thing.
+
+So the unit is the page:
+
+  * a PAGE that still falls back is built, and kept out of the sitemap, the
+    hreflang sets and the switcher until it is translated - the treatment an
+    unfinished language used to get, given to the part that is unfinished;
+  * the FRAME - the nav, the footer, the hub, the [ui] words - is still judged
+    whole, because it is drawn around every page and there is no per-page way to
+    hold it back. That is what `complete = true` now claims, and it is a set
+    that does not grow when a tool ships;
+  * a list SHORTER than the English one falls back entry by entry instead of
+    raising, which is the same rule again: a locale is allowed to be behind
+    English, and is never allowed to be ahead of it.
+
+Two things follow that are easy to get wrong, and both have their own tests.
+Every language's debt is worked out by `survey` BEFORE any page is rendered,
+because the hreflang set on the English page is a fact about German. And an
+English body falling back inside German has its links rewritten by `relocate`,
+because it was written for a tree whose addresses are English.
 """
+
+import posixpath
+import re
 
 from buildlib.site import ConfigError, load_toml
 
@@ -206,7 +241,8 @@ def base_locale(site):
         'pages': {},
         'bodies': {},
         'planned': {},
-        'missing': [],
+        'frame': [],
+        'debt': {},
     }
 
 
@@ -245,7 +281,15 @@ def load_locale(path, site):
         'tools': {},
         'pages': {},
         'bodies': {},
-        'missing': [],
+        # What the frame still owes, settled once when this file is read. The
+        # nav, the footer, the hub and the [ui] words are drawn around every
+        # page, so there is no per-page way to hold them back.
+        'frame': [],
+        # What fell back, bucketed by the slug of the page it fell back on, so
+        # one untranslated guide costs that guide its place in the sitemap
+        # rather than costing the whole language its place. `missing` stays as
+        # the flat list, because the end-of-build report counts strings.
+        'debt': {},
     }
 
     stray = sorted(set(config) - RESERVED_LOCALE_KEYS - set(TRANSLATABLE_SITE_PATHS))
@@ -270,7 +314,7 @@ def load_locale(path, site):
     locale['site'] = dict(site)
     locale['site'].update(translate(site, overrides, TRANSLATABLE_SITE_PATHS,
                                     f'{path.name}/locale.toml',
-                                    locale['missing'], 'site'))
+                                    locale['frame'], 'site'))
 
     for kind_name, keys in (('tools', TRANSLATABLE_TOOL_KEYS),
                             ('pages', TRANSLATABLE_PAGE_KEYS)):
@@ -302,7 +346,8 @@ def load_locale(path, site):
 # Merging
 
 
-def merge(base, over, where, missing, path, structural=STRUCTURAL_KEYS):
+def merge(base, over, where, missing, path, structural=STRUCTURAL_KEYS,
+          transform=None):
     """English underneath, the translation on top, recursively.
 
     Records what was not translated in `missing` rather than raising, because
@@ -312,10 +357,12 @@ def merge(base, over, where, missing, path, structural=STRUCTURAL_KEYS):
 
     Two shapes are refused outright, because neither is a translation:
 
-      * a list whose length changed. [[faq]] and [[hub.guarantees]] are merged
-        entry by entry, in order, so five questions in English and four in
-        German is not a shorter translation, it is a question that will render
-        in English inside a German page with nothing to say which one it was.
+      * a list LONGER than the English. [[faq]] and [[hub.guarantees]] are
+        merged entry by entry, in order, so six questions in German against
+        five in English is not a fuller translation, it is an entry with
+        nothing to translate. A SHORTER list is fine, and is the ordinary state
+        of a locale that was finished before English grew another entry: the
+        tail falls back and is counted with everything else.
       * a value whose type changed. A table where the English has a string is a
         translator having restructured the page, which the templates cannot
         follow.
@@ -339,28 +386,57 @@ def merge(base, over, where, missing, path, structural=STRUCTURAL_KEYS):
                 merged[key] = value
             elif key in over:
                 merged[key] = merge(value, over[key], where, missing,
-                                    f'{path}.{key}', inner)
+                                    f'{path}.{key}', inner, transform)
             else:
-                merged[key] = value
+                merged[key] = fell_back(value, transform, inner)
                 note_missing(value, missing, f'{path}.{key}', inner)
         return merged
 
     if isinstance(base, list):
         if not isinstance(over, list):
             raise LocaleError(f'{where}: {path} should be a list, not a {kind(over)}')
-        if len(base) != len(over):
+        if len(over) > len(base):
             raise LocaleError(
-                f'{where}: {path} has {len(over)} entries and the English has '
-                f'{len(base)}. They are merged in order, so the counts have to '
-                'match - a missing entry would render in English with nothing to '
-                'say which one it was.')
-        return [merge(a, b, where, missing, f'{path}[{index}]', structural)
-                for index, (a, b) in enumerate(zip(base, over))]
+                f'{where}: {path} has {len(over)} entries and the English has only '
+                f'{len(base)}. They are merged in order, so a locale can be behind '
+                'the English but it cannot be ahead of it - there is nothing for '
+                'the extra entries to translate.')
+        # Short is allowed, and is the ordinary state of a locale that was
+        # finished before English grew another entry. The tail falls back and is
+        # counted, exactly like any other untranslated string, which is what
+        # keeps a new [[hub.categories]] from breaking ten builds at once.
+        merged = [merge(a, b, where, missing, f'{path}[{index}]', structural,
+                        transform)
+                  for index, (a, b) in enumerate(zip(base, over))]
+        for index in range(len(over), len(base)):
+            merged.append(fell_back(base[index], transform, structural))
+            note_missing(base[index], missing, f'{path}[{index}]', structural)
+        return merged
 
     if isinstance(over, (dict, list)):
         raise LocaleError(
             f'{where}: {path} should be a {kind(base)}, not a {kind(over)}')
     return over
+
+
+def fell_back(value, transform, structural=STRUCTURAL_KEYS):
+    """A copy of some English, with `transform` applied to every string in it.
+
+    Walks the same shapes note_missing walks, and skips the same structural
+    keys - a slug or a category id is not prose and must come through a
+    fallback untouched.
+    """
+    if transform is None:
+        return value
+    if isinstance(value, str):
+        return transform(value)
+    if isinstance(value, dict):
+        return {key: (inner if key in structural
+                      else fell_back(inner, transform, structural))
+                for key, inner in value.items()}
+    if isinstance(value, list):
+        return [fell_back(inner, transform, structural) for inner in value]
+    return value
 
 
 def note_missing(value, missing, path, structural=STRUCTURAL_KEYS):
@@ -392,7 +468,43 @@ def kind(value):
 # Applying a locale to one tool or one page
 
 
-def translate(source, over, keys, where, missing, path):
+def charge(locale, slug):
+    """Start this page's tally again, and hand back the list to fill.
+
+    Assigned rather than appended to, because the tally is worked out twice:
+    once by `survey` before any page is rendered, and again as each page is
+    rendered. Appending would count everything in a published language twice.
+    """
+    debt = locale['debt'][slug] = []
+    return debt
+
+
+def all_debt(locale):
+    """Every string this language still owes, frame and pages together."""
+    return locale['frame'] + [entry for debt in locale['debt'].values()
+                              for entry in debt]
+
+
+def survey(locales, tools, prose, planned, site):
+    """Work out what every language owes, before a single page is written.
+
+    Rendering a page needs to know which OTHER languages have finished it, so
+    no page can be the thing that works it out. Cheap: it is the same merge the
+    render does, over tables already in memory, and it runs once per language.
+    """
+    for locale in locales:
+        if locale['is_base']:
+            continue
+        for tool in tools:
+            localize_tool(tool, locale, site)
+            body_for(locale, 'tools', tool['slug'], '')
+        for page in prose:
+            localize_page(page, locale, site)
+            body_for(locale, 'pages', page['slug'], '')
+        localize_planned(planned, locale, site['roadmap']['slug'])
+
+
+def translate(source, over, keys, where, missing, path, transform=None):
     """Merge a translation over just the keys that are words.
 
     Merging over the whole table instead was the first version, and it counted
@@ -408,7 +520,7 @@ def translate(source, over, keys, where, missing, path):
     and what is counted as untranslated cannot drift apart.
     """
     return merge({key: source[key] for key in keys if key in source},
-                 over, where, missing, path)
+                 over, where, missing, path, STRUCTURAL_KEYS, transform)
 
 
 def localize_tool(tool, locale, site):
@@ -421,10 +533,12 @@ def localize_tool(tool, locale, site):
     """
     slug = tool['slug']
     merged = dict(tool)
+    debt = charge(locale, slug)
     merged.update(translate(tool, locale['tools'].get(slug, {}),
                             TRANSLATABLE_TOOL_KEYS,
                             f'locales/{locale["lang"]}/tools/{slug}.toml',
-                            locale['missing'], f'tools.{slug}'))
+                            debt, f'tools.{slug}',
+                            lambda text: relocate(text, locale, slug)))
     merged['out_slug'] = locale['slugs'].get(slug, slug)
     merged['url'] = f'{site["domain"]}{locale["prefix"]}{merged["out_slug"]}/'
     return merged
@@ -450,17 +564,19 @@ def localize_page(page, locale, site):
     """
     slug = page['slug']
     merged = dict(page)
+    debt = charge(locale, slug)
     merged.update(translate(page, locale['pages'].get(slug, {}),
                             TRANSLATABLE_PAGE_KEYS,
                             f'locales/{locale["lang"]}/pages/{slug}.toml',
-                            locale['missing'], f'pages.{slug}'))
+                            debt, f'pages.{slug}',
+                            lambda text: relocate(text, locale, slug)))
     merged['out_slug'] = locale['slugs'].get(slug, slug)
     merged['url'] = f'{site["domain"]}{locale["prefix"]}{merged["out_slug"]}/'
     merged['depth'] = merged['out_slug'].count('/') + 1
     return merged
 
 
-def localize_planned(planned, locale):
+def localize_planned(planned, locale, slug):
     """config/planned.toml, said in one language.
 
     The roadmap is a real page in the sitemap, so a locale that called itself
@@ -470,9 +586,67 @@ def localize_planned(planned, locale):
     """
     if locale['is_base']:
         return planned
-    return merge(planned, locale['planned'],
-                 f'locales/{locale["lang"]}/{PLANNED}',
-                 locale['missing'], 'planned', PLANNED_STRUCTURE)
+    debt = charge(locale, slug)
+    merged = merge(planned, locale['planned'],
+                   f'locales/{locale["lang"]}/{PLANNED}',
+                   debt, 'planned', PLANNED_STRUCTURE)
+    return merged
+
+
+BODY_LINK = re.compile(r'\b(href|src)="([^"]+)"')
+
+# Hrefs that are already pointing somewhere absolute, or at nothing on the
+# filesystem at all. None of them is written relative to the page.
+ABSOLUTE_LINK = ('http://', 'https://', '//', '/', '#', 'mailto:', 'tel:', 'data:')
+
+
+def relocate(html, locale, slug):
+    """Point an English body's links at the language it is falling back into.
+
+    A body that falls back is English prose sitting at a German URL, and the
+    links inside it were written relative to the ENGLISH page - `../trim-video/`
+    from `/guides/reverse-a-video/`. Dropped into `/de/` unchanged they lead to
+    pages that do not exist, because German addresses are German: the tool is at
+    `/de/video-schneiden/`.
+
+    This is a problem the old arrangement never had, and only because it never
+    published a language that had a fallback left in it. Holding pages back one
+    at a time means English bodies now appear inside a published language, so
+    their links have to be made to work there.
+
+    Each one is resolved against the English page's own folder, turned back into
+    the slug it names, and re-emitted as a root-absolute address in this locale -
+    root-absolute because the English tree and the German tree are not the same
+    shape, and a relative path counted from the wrong one is how this broke in
+    the first place. Anything that is not a page keeps its resolved path, which
+    is what assets want anyway.
+    """
+    here = '/' + (f'{slug}/' if slug else '')
+
+    def fix(match):
+        attr, href = match.group(1), match.group(2)
+        if href.startswith(ABSOLUTE_LINK) or not href:
+            return match.group(0)
+        # Keep a fragment or a query on the end of whatever the path becomes.
+        cut = min((i for i in (href.find('#'), href.find('?')) if i >= 0),
+                  default=len(href))
+        path, tail = href[:cut], href[cut:]
+        if not path:
+            return match.group(0)
+        resolved = posixpath.normpath(posixpath.join(here, path))
+        if path.endswith('/') and not resolved.endswith('/'):
+            resolved += '/'
+        # A page of this site is a folder and ends in a slash; an asset is a
+        # file and has an extension. Only the first kind has an address that
+        # differs between languages.
+        if resolved.endswith('/'):
+            # A slug with no translation maps to itself, which is right rather
+            # than a gap: that page is falling back too, and in this language it
+            # lives at its English address under this language's prefix.
+            return f'{attr}="{locale_path(locale, resolved.strip("/"))}{tail}"'
+        return f'{attr}="{resolved}{tail}"'
+
+    return BODY_LINK.sub(fix, html)
 
 
 def body_for(locale, kind_name, slug, fallback):
@@ -486,7 +660,8 @@ def body_for(locale, kind_name, slug, fallback):
     if key in locale['bodies']:
         return locale['bodies'][key]
     if not locale['is_base']:
-        locale['missing'].append(f'{kind_name}.{slug}.body')
+        locale['debt'].setdefault(slug, []).append(f'{kind_name}.{slug}.body')
+        return relocate(fallback, locale, slug)
     return fallback
 
 
@@ -570,39 +745,88 @@ def check_slugs(locale, tool_slugs, page_slugs, site):
 
 
 def check_complete(locale):
-    """A locale that claims to be finished has to be finished.
+    """A locale that claims to be finished has to have finished the FRAME.
 
-    Called after every page has been localized, so `missing` holds everything
-    that fell back across the whole site rather than whatever happened to have
-    been reached by the time some earlier check ran.
+    This used to be judged over the whole language, and the whole language is
+    the wrong unit. English is not finished either - it grows a tool most
+    weeks - and a rule that fails the build the moment it does makes every new
+    English tool wait for ten translations before the site will build at all.
+    That happened three times to German while it was being written, and the
+    third time it was holding up nine other languages that had nothing to do
+    with it.
+
+    So an untranslated PAGE is no longer an error. It falls back, it is built
+    and readable at its own URL, and it is kept out of the sitemap, out of
+    every hreflang set and out of the switcher until it is translated - the
+    same treatment an unfinished locale used to get, applied to the page that
+    is actually unfinished. See `translated`.
+
+    What is still an error is claiming a language and not having said the words
+    around every page in it. That set is small, it is stable, and it does not
+    grow when a new tool ships.
     """
     if locale['is_base'] or not locale['complete']:
         return
-    if not locale['missing']:
+    debt = locale['frame']
+    if not debt:
         return
 
-    shown = sorted(set(locale['missing']))
+    shown = sorted(set(debt))
     more = len(shown) - 12
     tail = f'\n    ... and {more} more' if more > 0 else ''
     raise LocaleError(
         f'locales/{locale["lang"]}/ says complete = true, but {len(shown)} strings '
-        'still fall back to English:\n    '
+        'in the frame around every page still fall back to English:\n    '
         + '\n    '.join(shown[:12]) + tail
-        + '\n  Translate them, or set complete = false: the locale is then still '
-          'built and still readable at its own URL, and is kept out of the '
-          'sitemap, the hreflang tags and the language switcher until it is ready.')
+        + '\n  The frame is the nav, the footer, the hub and the [ui] words, and it '
+          'is drawn around every page in the language, so there is no per-page way '
+          'to hold it back. Translate these, or set complete = false: the locale is '
+          'then still built and still readable at its own URL, and is kept out of '
+          'the sitemap, the hreflang tags and the switcher until it is ready.')
 
 
-def published(locales):
-    """The locales fit to be advertised: English, and every locale that says it
-    is finished.
+def translated(locale, slug):
+    """Is this one page finished in this one language?
+
+    English is finished by definition. A locale that has not finished its frame
+    publishes nothing at all, however many of its pages are done, because every
+    one of them would be wearing an English nav.
+    """
+    if locale['is_base']:
+        return True
+    if not locale['complete']:
+        return False
+    return not locale['debt'].get(slug)
+
+
+def published(locales, slug=None):
+    """The locales fit to be advertised - for the whole site, or for one page.
 
     The sitemap, the hreflang tags and the switcher are all built from this one
-    list, so the three cannot disagree about which languages the site claims to
-    be available in - which is the failure Google reports as "hreflang tags
-    point to a page that is not indexed".
+    function, so the three cannot disagree about which languages the site
+    claims a page to be available in - which is the failure Google reports as
+    "hreflang tags point to a page that is not indexed".
+
+    Without a slug this is the set of locales that have finished their frame,
+    which is what the language switcher on the 404 has to work from. With one,
+    it is the narrower set that has also finished that page.
     """
-    return [locale for locale in locales if locale['is_base'] or locale['complete']]
+    ready = [locale for locale in locales if locale['is_base'] or locale['complete']]
+    if slug is None:
+        return ready
+    return [locale for locale in ready if translated(locale, slug)]
+
+
+def debt_report(locale, tools, prose):
+    """One line per language about what is left, for the end of a build.
+
+    Counted in pages rather than strings, because pages are the unit that now
+    decides anything: a page with one string left is as unpublished as a page
+    with four hundred.
+    """
+    slugs = [tool['slug'] for tool in tools] + [page['slug'] for page in prose]
+    behind = [slug for slug in slugs if locale['debt'].get(slug)]
+    return behind
 
 
 def alternates(locales, slug, site):
@@ -616,8 +840,13 @@ def alternates(locales, slug, site):
 
     x-default points at English, which is what a reader whose language is not
     one of these is meant to be given.
+
+    Judged for THIS page, not for the site. A language that has translated the
+    hub but not this guide does not appear in this guide's set, and the guide it
+    has not translated does not appear in anyone else's - which is the
+    reciprocity rule holding at the level the translation actually happens at.
     """
-    ready = published(locales)
+    ready = published(locales, slug)
     # One language is not a set of alternates, it is a page. A lone
     # hreflang="en" beside an x-default pointing at the same URL says nothing
     # that the canonical above it has not already said, so until there is a
@@ -643,8 +872,12 @@ def switcher(locales, current, slug, site):
     them. A crawler has to be able to walk from one language into the next, and
     a site whose whole claim is that it does not track you cannot be storing a
     preference in order to do it.
+
+    Offers only the languages this page exists in. A switcher that lists German
+    on a page with no German behind it is a promise the next click breaks, and
+    it is worse than not offering German at all.
     """
-    ready = published(locales)
+    ready = published(locales, slug)
     # Nothing to switch to. A control offering only the language you are already
     # reading is furniture, so it is not rendered until a second language is
     # finished enough to be offered.

--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -33,7 +33,7 @@ endonym = "Deutsch"
 # finished, and a finished language cannot silently fall behind the
 # English it was finished against. Flipped back the moment those eight
 # files are translated.
-complete = false
+complete = true
 
 #
 # ---------------------------------------------------------------------------
@@ -74,6 +74,12 @@ complete = false
 # and a great many people search for how to make a favicon.
 "image-to-ico" = "favicon-erstellen"
 "svg-to-image" = "svg-in-png-umwandeln"
+# Named for the job once more. "base64" rather than "data-uri" is what
+# gets typed, even by the people who know it is a data URI.
+"heic-to-jpg" = "heic-in-jpg-umwandeln"
+"image-to-data-uri" = "bild-als-base64"
+"qr-barcode" = "qr-code-erstellen"
+"video-to-gif" = "video-in-gif-umwandeln"
 
 # The indexes and the legal pages. "Ratgeber" rather than a literal
 # "Anleitungen": it is the word German publishers use for exactly this kind of
@@ -96,6 +102,10 @@ complete = false
 "guides/is-it-safe-to-upload-files" = "ratgeber/ist-das-hochladen-von-dateien-sicher"
 "guides/make-a-favicon" = "ratgeber/favicon-selbst-erstellen"
 "guides/convert-an-svg-to-png" = "ratgeber/svg-in-png-umwandeln"
+"guides/convert-heic-to-jpg" = "ratgeber/heic-in-jpg-umwandeln"
+"guides/embed-an-image-in-css" = "ratgeber/bild-in-css-einbetten"
+"guides/make-a-qr-code" = "ratgeber/qr-code-selbst-erstellen"
+"guides/turn-a-video-into-a-gif" = "ratgeber/aus-einem-video-ein-gif-machen"
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/de/pages/guides/convert-heic-to-jpg.html
+++ b/locales/de/pages/guides/convert-heic-to-jpg.html
@@ -1,0 +1,266 @@
+  <section>
+    <h2>Die kurze Antwort</h2>
+    <p>
+      Öffnen Sie den
+      <a href="../../heic-in-jpg-umwandeln/">HEIC-zu-JPG-Umwandler</a>, ziehen
+      Sie die Fotos hinein und klicken Sie auf &bdquo;Umwandeln&ldquo;. Lassen
+      Sie den Qualitätsregler, wo er ist, und lassen Sie &bdquo;Datum, Kamera und
+      Einstellungen behalten&ldquo; gesetzt, sofern Sie keinen Grund dagegen
+      haben. Sie bekommen JPEGs zurück, je eine Download-Schaltfläche &mdash;
+      oder ein ZIP, wenn es mehrere sind.
+    </p>
+    <p>
+      Dabei wird nichts hochgeladen. Das ist für genau diese Aufgabe
+      ungewöhnlich, und der Grund dafür ist die interessante Hälfte dieser Seite.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was HEIC eigentlich ist</h2>
+    <p>
+      HEIC ist nicht wirklich ein Bildformat in dem Sinne, in dem JPEG eines ist.
+      Es ist ein Container &mdash; dieselbe Box-Struktur, aus der ein MP4 gebaut
+      ist &mdash; mit einem Standbild aus <strong>HEVC</strong>-Video darin. HEVC,
+      auch H.265 genannt, ist der Codec, der den Ihres alten Camcorders abgelöst
+      hat, und er ist sehr gut: Ein iPhone-Foto als HEIC ist ungefähr halb so
+      groß wie dasselbe Foto als JPEG bei gleicher Qualität.
+    </p>
+    <p>
+      Apple ist mit iOS 11 im Jahr 2017 darauf umgestiegen und hat es zur
+      Voreinstellung gemacht. Das heißt: Sofern niemand in die Einstellungen
+      gegangen ist und &bdquo;Maximale Kompatibilität&ldquo; gewählt hat, ist
+      jedes Foto, das dieses Telefon seit gut einem Jahrzehnt aufgenommen hat, in
+      einem Format, das
+    </p>
+    <ul>
+      <li>Windows ohne eine Erweiterung aus dem Store nicht in der Vorschau
+        zeigt;</li>
+      <li>die meisten Upload-Formulare im Web rundweg ablehnen;</li>
+      <li>von dem eine ganze Menge älterer Desktop-Software nie gehört hat;</li>
+      <li>und das kein Webbrowser außer Safari anzeigt.</li>
+    </ul>
+    <p>
+      Mit dem Foto ist alles in Ordnung. Es ist eine bessere Datei, als das JPEG
+      gewesen wäre. Es ist nur in einer Sprache geschrieben, die der größte Teil
+      der Welt nie gelernt hat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum nur Safari eines öffnet</h2>
+    <p>
+      Das ist der Teil, der jeden Umwandler erklärt, den Sie je benutzt haben, und
+      deshalb einen Absatz wert.
+    </p>
+    <p>
+      HEVC zu dekodieren braucht einen HEVC-Decoder, und HEVC ist patentiert. Die
+      Lizenzierung wird von mehr als einem Patentpool verwaltet, und einen
+      Decoder auszuliefern heißt, jemanden zu bezahlen. Browser gehen damit um,
+      indem sie sich auf das Betriebssystem stützen &mdash; Chrome spielt
+      HEVC-<em>Video</em> auf einem Gerät ab, dessen Hardware bereits einen
+      lizenzierten Decoder hat &mdash;, aber dieser Weg ist für die
+      Videowiedergabe verdrahtet und nicht für Standbilder. Ein an
+      <code>&lt;img&gt;</code> übergebenes HEIC wird also abgewiesen, in Chrome,
+      Firefox und Edge gleichermaßen, auf jedem Betriebssystem.
+    </p>
+    <p>
+      Safari auf Apple-Hardware ist die Ausnahme, weil macOS und iOS den Decoder
+      haben und Safari ihn fragen darf. Überall sonst ist das Bild für den
+      Browser schlicht nicht dekodierbar.
+    </p>
+    <p>
+      Womit einem Umwandler genau zwei Möglichkeiten bleiben &mdash; und die Wahl
+      zwischen ihnen ist die ganze Geschichte dieser Art von Werkzeug.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum fast jeder HEIC-Umwandler einen Upload will</h2>
+    <p>
+      Möglichkeit eins: den Decoder auf einen Server legen. Das Foto wird
+      hochgeladen, auf einer Maschine dekodiert, die Sie nie gesehen haben, als
+      JPEG neu kodiert und zurückgeschickt. Das ist es, was nahezu jeder
+      &bdquo;kostenlose Online-HEIC-Umwandler&ldquo; tut, und es ist der Grund,
+      warum sie alle Ihre Dateien brauchen. Es ist keine Faulheit &mdash; der
+      Browser kann es ohne Hilfe wirklich nicht.
+    </p>
+    <p>
+      Was das kostet, ist es wert, unverblümt gesagt zu werden. Fotos von einem
+      Telefon sind die persönlichsten Dateien, die die meisten Menschen besitzen,
+      und ein HEIC direkt vom iPhone trägt typischerweise die Koordinaten des
+      Aufnahmeortes auf wenige Meter genau, dazu das Datum auf die Sekunde und
+      eine Kamerakennung. Einen Ordner davon zu einem kostenlosen Dienst
+      hochzuladen heißt, beides zu übergeben: die Bilder und das. Was danach
+      passiert, regelt eine Datenschutzerklärung, die Sie nicht gelesen haben,
+      auf einem Server, den Sie nicht einsehen können, in einer Rechtsordnung,
+      die Sie nicht gewählt haben.
+    </p>
+    <p>
+      Möglichkeit zwei: den Decoder auf die Seite legen. Genau das tut
+      <a href="../../heic-in-jpg-umwandeln/">dieser hier</a>. Er trägt
+      <code>libheif</code>, nach WebAssembly kompiliert, als Datei, die von dieser
+      Seite ausgeliefert wird &mdash; rund 1,4 MB, einmal heruntergeladen und
+      danach zwischengespeichert. Ihr Browser führt sie auf Ihrem eigenen Gerät,
+      auf Ihrer eigenen Hardware aus, und das Foto geht nirgendwohin. Laden Sie
+      die Seite einmal, und Sie können die Internetverbindung völlig trennen, und
+      sie arbeitet weiter &mdash; etwas, das kein hochladender Umwandler kann,
+      und der einfachste Beweis, den es gibt.
+    </p>
+    <p>
+      Die 1,4 MB sind der ganze Preis. Sitzen Sie an einer volumenbegrenzten
+      Verbindung, sind sie ein echter Kostenpunkt und wissenswert; deshalb sagt
+      die Seite es laut, statt sie still herunterzuladen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was das Umwandeln das Bild kostet</h2>
+    <p>
+      HEIC und JPEG sind verschiedene Codecs, es gibt also keinen Weg hinüber,
+      der nicht das Dekodieren des Bildes und ein erneutes Kodieren umfasst.
+      Dieses zweite Kodieren ist verlustbehaftet. In der Praxis zählt das viel
+      weniger, als es klingt:
+    </p>
+    <ul>
+      <li>
+        <strong>Bei Qualität 92</strong> &mdash; wo der Umwandler beginnt &mdash;
+        ist eine Fotografie in jeder normalen Betrachtungsgröße sehr schwer vom
+        Original zu unterscheiden. Sie suchen nach Unterschieden in weichen
+        Verläufen, etwa einem klaren Himmel, und werden sie im Allgemeinen nicht
+        finden.
+      </li>
+      <li>
+        <strong>Das JPEG wird größer sein.</strong> Meist zwischen einem Drittel
+        größer und doppelt so groß, weil JPEG ein Codec von 1992 ist und HEVC
+        nicht. Das ist der Handel: eine größere Datei, die alles öffnet.
+      </li>
+      <li>
+        <strong>Zweimal umzuwandeln ist das, was Sie vermeiden sollten.</strong>
+        Jede verlustbehaftete Kodierung kostet ein wenig. Wandeln Sie vom
+        ursprünglichen HEIC um und nicht von einem JPEG, das jemand schon für Sie
+        gemacht hat, und tun Sie es einmal.
+      </li>
+    </ul>
+    <p>
+      Wollen Sie überhaupt keinen Verlust, steht PNG im Formatmenü. Stellen Sie
+      sich auf die Datei ein: Eine Fotografie als PNG ist üblicherweise fünf- bis
+      zehnmal so groß wie das JPEG, weil die Kompression von PNG für flache
+      Farbflächen und Strichzeichnungen entworfen wurde und nicht für Gras und
+      Haut.
+    </p>
+  </section>
+
+  <section>
+    <h2>Das Datum, die Kamera und die Koordinaten</h2>
+    <p>
+      Die übliche Klage über HEIC-Umwandler ist, dass die Fotos ohne den Tag
+      zurückkommen, an dem sie aufgenommen wurden &mdash; ein ganzer Urlaub
+      sortiert sich dann unter dem heutigen Datum ans Ende der Mediathek. Das
+      passiert, weil das Umwandeln über eine Leinwand Ihnen Pixel gibt und sonst
+      nichts &mdash; eine Leinwand hält keine Tags &mdash;, also ist alles
+      schlicht weg, sofern ein Umwandler die Metadaten nicht eigens holt.
+    </p>
+    <p>
+      Das Werkzeug hier kopiert den EXIF-Block aus dem HEIC heraus und schreibt
+      ihn ins JPEG, das Datum überlebt also. Es gibt ein Häkchen, und es ist
+      standardmäßig gesetzt. Nehmen Sie es heraus, und das JPEG kommt mit dem
+      Bild und sonst nichts heraus.
+    </p>
+    <p>
+      Bevor Sie entscheiden, sehen Sie sich die Liste an: Die Zeile jedes Fotos
+      sagt, ob die Datei GPS-Koordinaten trägt, und sie sagt es, bevor
+      irgendetwas umgewandelt wird. Gehen die Fotos irgendwohin, wo sie
+      öffentlich sind, ist das die Zeile zum Lesen. Gehen sie in Ihre eigene
+      Mediathek, ist die Metadaten zu behalten mit ziemlicher Sicherheit das, was
+      Sie wollen.
+    </p>
+    <p>
+      Ein Tag wird geändert, was Sie auch wählen, und es lohnt sich zu wissen,
+      warum. Ein HEIC hält seine Drehung an zwei Stellen fest: im Container und
+      im EXIF-Block. Der Decoder wendet die Drehung des Containers beim
+      Dekodieren an, die übergebenen Pixel liegen also schon richtig herum. Stünde
+      im EXIF dann immer noch &bdquo;dreh das um 90 Grad&ldquo;, täte ein
+      Betrachter es noch einmal, und jedes Hochformatfoto käme quer heraus. Das
+      Orientierungs-Tag wird also auf aufrecht gesetzt, und alles andere wird
+      exakt so kopiert, wie das Telefon es geschrieben hat.
+    </p>
+    <p>
+      Wollen Sie die Tags im Detail durchgehen oder sie aus Fotos entfernen, die
+      schon JPEGs sind, ist das eine andere Aufgabe, und dafür gibt es einen
+      <a href="../exif-und-gps-daten-entfernen/">eigenen Ratgeber</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was Menschen überrascht</h2>
+    <ul>
+      <li>
+        <strong>Ein HEIC, das &bdquo;.jpg&ldquo; heißt.</strong> Ausgesprochen
+        häufig: Irgendetwas unterwegs hat es umbenannt, ohne es umzuwandeln, und
+        deshalb öffnet es weiterhin nicht. Jede auf den Umwandler gezogene Datei
+        wird an ihren ersten Bytes erkannt und nicht an ihrem Namen, eine solche
+        funktioniert also einwandfrei. Es ist auch der Grund, warum einer Datei,
+        die wirklich ein JPEG ist, das gesagt wird, statt sie in eine Kopie ihrer
+        selbst umzuwandeln.
+      </li>
+      <li>
+        <strong>Eine Datei, mehrere Bilder.</strong> Eine Serienaufnahme oder ein
+        Live Photo kann mehr als ein Standbild enthalten. Alle werden umgewandelt,
+        und die zusätzlichen werden nach dem ursprünglichen Namen durchnummeriert.
+        Die Videohälfte eines Live Photos ist eine eigene Datei, die das Telefon
+        neben dem HEIC aufbewahrt, sie ist also gar nicht darin, um umgewandelt zu
+        werden.
+      </li>
+      <li>
+        <strong>AVIF ist nicht HEIC.</strong> Sie sehen sich ähnlich &mdash;
+        derselbe Container, ein anderer Codec darin &mdash;, aber jeder aktuelle
+        Browser öffnet ein AVIF von Haus aus; es gibt also nichts umzuwandeln,
+        und das Werkzeug sagt das, statt so zu tun, als arbeite es.
+      </li>
+      <li>
+        <strong>Das Problem an der Quelle abstellen.</strong> Auf dem Telefon:
+        Einstellungen &rarr; Kamera &rarr; Formate &rarr; Maximale
+        Kompatibilität. Neue Fotos sind von da an JPEGs. Es braucht mehr
+        Speicher und ändert nichts an den Fotos, die Sie schon haben, aber es
+        heißt, das hier nie wieder tun zu müssen.
+      </li>
+      <li>
+        <strong>Teilen wandelt manchmal schon um.</strong> Ein Foto per AirDrop
+        oder E-Mail an ein Nicht-Apple-Gerät zu geben übergibt oft ein JPEG, weil
+        iOS auf dem Weg hinaus umwandelt. Ist ein Foto trotzdem als HEIC
+        angekommen, kam es auf einem Weg herüber, der das nicht tat.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Woran Sie erkennen, ob ein Umwandler hochlädt</h2>
+    <p>
+      Das gilt für jedes Werkzeug, nicht nur für dieses, und es dauert etwa
+      fünfzehn Sekunden.
+    </p>
+    <ol>
+      <li>
+        Öffnen Sie die Seite, öffnen Sie dann die Entwicklerwerkzeuge Ihres
+        Browsers und gehen Sie auf den Netzwerk-Tab.
+      </li>
+      <li>
+        Wandeln Sie ein Foto um und schauen Sie zu. Ein Werkzeug, das auf Ihrem
+        Gerät dekodiert, stellt in diesem Moment überhaupt keine Anfrage. Ein
+        Werkzeug, das hochlädt, stellt eine in der Größe Ihres Fotos &mdash; und
+        die Größe sehen Sie.
+      </li>
+      <li>
+        Oder, noch einfacher: Seite laden, Internetverbindung trennen und
+        versuchen, etwas umzuwandeln. Ein Werkzeug, das Ihr Foto zum Dekodieren
+        weggeschickt hat, hört auf zu arbeiten. Eines, das den Decoder mit sich
+        trägt, nicht.
+      </li>
+    </ol>
+    <p>
+      Der Umwandler hier ist so gebaut, dass er beide Prüfungen besteht, und eine
+      ausführlichere Fassung dieses Arguments steht in
+      <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
+      hochzuladen?</a>.
+    </p>
+  </section>

--- a/locales/de/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/de/pages/guides/convert-heic-to-jpg.toml
@@ -1,0 +1,17 @@
+#
+# Ratgeber: HEIC in JPG umwandeln - German.
+#
+
+nav = "HEIC zu JPG"
+title = "HEIC in JPG umwandeln (und was HEIC eigentlich ist)"
+description = "iPhones speichern Fotos als HEIC, und das halbe Internet kann keines öffnen. Was das Format ist, warum nur Safari es dekodiert, was das Umwandeln das Bild kostet, und wie es geht, ohne die Fotos irgendjemandem hochzuladen."
+heading = "Das Foto, das Ihr Telefon gespeichert hat, und das Format, das nichts öffnet"
+lede = """
+    Ein iPhone speichert Fotos als HEIC &mdash; kleiner und besser als JPEG, und
+    von einer ganzen Menge Software noch immer verweigert. Hier steht, was das
+    Format wirklich ist, was das Umwandeln das Bild kostet, und warum fast jeder
+    Umwandler es zuerst von Ihnen hochgeladen haben will."""
+updated = "20. August 2026"
+og_title = "Wie Sie HEIC in JPG umwandeln"
+og_description = "Warum iPhone-Fotos nicht öffnen, was das Umwandeln kostet, und wie es geht, ohne die Fotos jemandem zu übergeben."
+og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/embed-an-image-in-css.html
+++ b/locales/de/pages/guides/embed-an-image-in-css.html
@@ -1,0 +1,325 @@
+  <section>
+    <h2>Die kurze Antwort</h2>
+    <p>
+      Öffnen Sie <a href="../../bild-als-base64/">Bild als Data-URI</a>, ziehen
+      Sie das Bild hinein, wählen Sie <em>Eine CSS-Custom-Property</em> und fügen
+      Sie die Zeile oben in Ihr Stylesheet ein. Benutzen Sie sie dann als
+      <code>background-image: var(--logo)</code>, wo immer Sie sie brauchen.
+    </p>
+    <p>
+      Tun Sie das, wenn das Bild klein ist &mdash; ein Symbol, ein Aufzählungs­punkt,
+      ein Pfeil, ein Muster &mdash; und auf jeder Seite gebraucht wird. Tun Sie es
+      nicht mit einer Fotografie. Alles Weitere unten handelt davon, warum diese
+      beiden Sätze auseinandergehen, und woran Sie erkennen, welchen Fall Sie vor
+      sich haben.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was eine Data-URI eigentlich ist</h2>
+    <p>
+      Eine Adresse, die die Sache enthält, statt auf sie zu zeigen. Wo ein
+      Stylesheet normalerweise
+    </p>
+    <pre><code>background-image: url("logo.png");</code></pre>
+    <p>
+      sagt und der Browser <code>logo.png</code> holen geht, sagt eine Data-URI
+    </p>
+    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <p>
+      und es gibt nichts zu holen: Das Bild ist schon da, in Zeichen
+      ausgeschrieben. Es besteht aus drei Teilen. <code>data:</code> ist das
+      Schema. <code>image/png</code> ist der Medientyp, und der Browser glaubt
+      ihn vollständig &mdash; dazu unten mehr. Alles nach dem Komma ist die
+      Datei.
+    </p>
+    <p>
+      Das ist die ganze Idee. Es ist kein Trick und kein Hack; es steht seit 1998
+      in den Standards und funktioniert in jedem Browser, der seither
+      ausgeliefert wurde.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was es Ihnen bringt: eine Rundreise weniger</h2>
+    <p>
+      Die Ersparnis ist nicht die Bandbreite. Es ist die Anfrage.
+    </p>
+    <p>
+      Ein Browser kann <code>logo.png</code> nicht anfordern, bevor er das
+      Stylesheet gelesen hat, das es erwähnt, und er kann das Stylesheet nicht
+      lesen, bevor er es geholt hat. Ein gewöhnliches Hintergrundbild liegt also
+      mindestens zwei Rundreisen tief im Seitenaufbau, und auf einem Telefon in
+      einem langsamen Netz kann eine Rundreise ein paar hundert Millisekunden
+      dauern, ganz gleich wie klein die Datei ist. Ein 600 Byte großer Pfeil
+      kostet fast nichts an Übertragung und kann trotzdem eine Viertelsekunde
+      brauchen, um anzukommen.
+    </p>
+    <p>
+      Eingebettet kommt er mit dem Stylesheet an. Das ist der gesamte Nutzen, und
+      für ein kleines Symbol im sichtbaren Bereich ist er ein echter.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was es kostet: ein Drittel, und dann das Zwischenspeichern</h2>
+    <p>
+      <strong>Base64 legt rund ein Drittel drauf.</strong> Aus drei Bytes Datei
+      werden vier Zeichen, denn so viel braucht es, um beliebige Bytes mit nur
+      den Zeichen zu schreiben, die eine URL erlaubt. Es gibt keinen klugen
+      Encoder, der das umgeht. Aus einem 9&nbsp;KB großen PNG werden 12&nbsp;KB
+      Stylesheet.
+    </p>
+    <p>
+      <strong>Kompression gibt es nicht zurück.</strong> Das ist der Teil, den
+      Menschen wegannehmen. Gzip und Brotli arbeiten, indem sie Redundanz finden,
+      und ein PNG, ein JPEG und ein WebP wurden bereits komprimiert &mdash; da
+      ist kaum noch Redundanz drin, und Base64 fügt keine hinzu. In der Praxis
+      bekommen Sie etwa ein Zehntel des Drittels zurück, nicht das Ganze. (Ein
+      SVG ist der umgekehrte Fall, und davon handelt der nächste Abschnitt.)
+    </p>
+    <p>
+      <strong>Es hört auf, eine Datei zu sein.</strong> Das ist der Preis, der in
+      keiner Messung auftaucht, die Sie wahrscheinlich vornehmen, und der, auf
+      den es bei Größe ankommt:
+    </p>
+    <ul>
+      <li>
+        <strong>Es lässt sich nicht für sich zwischenspeichern.</strong> Ein
+        gewöhnliches Bild wird einmal geholt und ein Jahr lang wiederverwendet.
+        Ein eingebettetes ist Teil des Stylesheets, es lebt und stirbt also mit
+        dessen Cache-Eintrag.
+      </li>
+      <li>
+        <strong>Irgendetwas zu ändern lädt alles neu.</strong> Korrigieren Sie
+        einen Rand, liefern Sie ein neues Stylesheet aus, und jeder Besucher lädt
+        das eingebettete Bild gleich mit herunter &mdash; ein Bild, das sich seit
+        zwei Jahren nicht geändert hat.
+      </li>
+      <li>
+        <strong>Es liegt auf dem kritischen Pfad.</strong> Ein Stylesheet
+        blockiert das Rendern. Ein Bild nicht. Ein Bild einzubetten verschiebt es
+        aus der zweiten Kategorie in die erste: Die Seite kann nicht zeichnen,
+        bevor das Ganze samt Bild angekommen ist.
+      </li>
+      <li>
+        <strong>Es lässt sich nicht parallel holen.</strong> Browser laden vieles
+        gleichzeitig herunter. Ein eingebettetes Bild ist keine eigene Sache, es
+        bekommt davon also nichts.
+      </li>
+    </ul>
+    <p>
+      Grobe Schwellen &mdash; dort ändert sich der Rat, nicht das Verhalten eines
+      Browsers: unter etwa 2&nbsp;KB ist es ein klarer Gewinn; bis etwa
+      10&nbsp;KB lohnt es sich meist noch für etwas, das auf jeder Seite ist;
+      jenseits von 50&nbsp;KB ist es ein Fehler ohne Fehlermeldung.
+      <a href="../../bild-als-base64/">Das Werkzeug</a> sagt Ihnen, in welches
+      Band jedes Ergebnis fällt, mit der Zeichenzahl daneben.
+    </p>
+  </section>
+
+  <section>
+    <h2>Base64 ist für ein SVG nie richtig</h2>
+    <p>
+      Das ist der mit Abstand häufigste Fehler bei eingebetteten Bildern, und er
+      wird von Exportern und Build-Plugins genauso oft gemacht wie von Menschen.
+    </p>
+    <p>
+      Ein SVG ist Text. Eine URL trägt Text ohnehin. Nur eine Handvoll Zeichen
+      muss maskiert werden &mdash; <code>%</code>, <code>#</code>,
+      <code>&lt;</code>, <code>&gt;</code> und das Anführungszeichen, in das Sie
+      es gesetzt haben &mdash; und alles andere kann genau so bleiben, wie es
+      ist. So kodiert bekommen Sie eine URI, die typischerweise etwa ein Fünftel
+      kürzer ist als das Base64 derselben Datei und die sich danach wie Text
+      komprimiert und nicht wie Rauschen.
+    </p>
+    <p>
+      Sie ist außerdem noch lesbar:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <p>
+      Sie sehen die <code>viewBox</code>. Sie können die Füllfarbe in Ihrem
+      Editor ändern, ohne irgendetwas zu dekodieren. Base64-kodieren Sie dieselbe
+      Datei, und sie wird zu einer Wand aus Buchstaben, die niemand je wieder
+      anfasst. <a href="../../bild-als-base64/">Bild als Data-URI</a> macht das
+      automatisch für alles, was sich als SVG herausstellt, und hat ein Häkchen
+      für die seltene Werkzeugkette, die auf <code>;base64</code> besteht.
+    </p>
+  </section>
+
+  <section>
+    <h2>Der Anführungszeichen-Fehler, der nur SVGs kaputtmacht</h2>
+    <p>
+      CSS erlaubt es, <code>url()</code> ohne Anführungszeichen zu schreiben, und
+      bei einem gewöhnlichen Dateinamen ist das in Ordnung:
+    </p>
+    <pre><code>background-image: url(logo.png);</code></pre>
+    <p>
+      Machen Sie dasselbe mit einem prozentkodierten SVG, und es bricht. Ein
+      <code>url()</code>-Token ohne Anführungszeichen endet am ersten Leerzeichen,
+      an der ersten Klammer, am ersten Anführungszeichen oder Steuerzeichen
+      &mdash; und ein SVG ist voller Leerzeichen, zwischen jedem Attribut und
+      jeder Zahl in einem Pfad. Die Deklaration ist dann ungültig, CSS verwirft
+      ungültige Deklarationen stillschweigend, und Sie bekommen keinen Hintergrund
+      und keinen Fehler.
+    </p>
+    <p>
+      Die Lösung sind Anführungszeichen, jedes Mal:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
+    <p>
+      Das ist auch der Grund, warum ein Encoder Leerzeichen nicht maskieren muss
+      &mdash; sie sind innerhalb einer URL in Anführungszeichen völlig legal, und
+      jedes als <code>%20</code> zu maskieren kostete drei Zeichen je Leerzeichen
+      in der Datei. Die beiden Entscheidungen gehören zusammen: URI in
+      Anführungszeichen setzen, und die Leerzeichen dürfen bleiben. Jede Form,
+      die das Werkzeug erzeugt, ist genau deshalb in Anführungszeichen gesetzt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Der Medientyp muss stimmen</h2>
+    <p>
+      Eine Data-URI gibt ihren eigenen Typ an, und der Browser nimmt sie beim
+      Wort. Es gibt keine Rückfallerkennung wie bei einer geholten Datei: Sagen
+      Sie <code>image/png</code> über etwas, das in Wahrheit ein JPEG ist, und
+      das Bild erscheint nicht &mdash; ohne Meldung an irgendeiner nützlichen
+      Stelle.
+    </p>
+    <p>
+      Das zählt, weil Dateiendungen lügen. Ein als JPEG exportiertes und in
+      <code>logo.png</code> umbenanntes Foto ist etwas völlig Gewöhnliches auf
+      einer Festplatte. Die ersten Bytes einer Bilddatei dagegen sagen eindeutig,
+      was sie ist &mdash; jedes Format hat eine Signatur &mdash;, ein Werkzeug
+      sollte also die Datei lesen und nicht ihren Namen. Das hier tut es und sagt
+      Ihnen, wenn die beiden sich widersprechen.
+    </p>
+    <p>
+      Zwei Formate sind wissenswert, weil sie auf verwirrende Weise scheitern.
+      <strong>HEIC</strong>, worin ein iPhone fotografiert, und
+      <strong>TIFF</strong>, was Scanner erzeugen, ergeben beide vollkommen
+      gültige Data-URIs, die kein Browser außer Safari zeichnet. Die URI ist
+      nicht kaputt; das Format ist schlicht keines, das das Web unterstützt.
+      Wandeln Sie vorher um.
+    </p>
+  </section>
+
+  <section>
+    <h2>Die Metadaten, die Sie nicht veröffentlichen wollten</h2>
+    <p>
+      Eine Data-URI ist eine Kopie der Datei, Byte für Byte. Es wird nichts
+      dekodiert und neu kodiert, und das ist meist der Sinn &mdash; es geht keine
+      Qualität verloren &mdash;, aber es heißt auch, dass alles andere in der
+      Datei mitkommt.
+    </p>
+    <p>
+      Eine Fotografie direkt vom Telefon trägt EXIF: die GPS-Koordinaten des
+      Aufnahmeortes, den Zeitstempel, das Kameramodell und oft dessen
+      Seriennummer. Das können 30&nbsp;KB der Datei sein. Eingebettet werden
+      daraus 40&nbsp;KB Base64 in Ihrem Stylesheet, auf dem kritischen Pfad jeder
+      Seite &mdash; und eine Wohnanschrift, die in ein Repository eingecheckt
+      wird, in einer Form, in der niemand je auf die Idee kommt nachzusehen.
+    </p>
+    <p>
+      Entfernen Sie sie vorher mit dem
+      <a href="../../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>,
+      der den Container neu schreibt, ohne das Bild anzufassen; dazu gibt es
+      ebenfalls einen <a href="../exif-und-gps-daten-entfernen/">Ratgeber</a>.
+      Bild als Data-URI liest, wie viele Metadaten in einem JPEG, PNG oder WebP
+      stecken, und sagt es, bevor Sie irgendetwas kopieren.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wohin damit, wenn Sie es haben</h2>
+    <p>
+      Erscheint das Bild in einer Regel, legen Sie die URI in diese Regel.
+      Erscheint es in mehr als einer &mdash; und bei Symbolen ist das meist so,
+      sobald man den Hover-Zustand und das dunkle Farbschema mitzählt &mdash;,
+      deklarieren Sie es einmal als Custom Property:
+    </p>
+    <pre><code>:root {
+  --icon-search: url("data:image/svg+xml,%3Csvg ... %3E");
+}
+
+.search-field { background-image: var(--icon-search); }
+.search-button::before { content: var(--icon-search); }</code></pre>
+    <p>
+      Eine 3&nbsp;KB große URI, in vier Regeln eingefügt, sind 12&nbsp;KB
+      Stylesheet und vier Stellen zum Bearbeiten, wenn sich das Symbol ändert.
+      Die Custom Property ist je eine. Sie ist außerdem die Form, mit der Theming
+      funktioniert: Definieren Sie <code>--icon-search</code> in einer Media
+      Query neu, und jede Verwendung folgt.
+    </p>
+    <p>
+      Für ein <code>&lt;img&gt;</code>-Element statt CSS geben Sie
+      <code>width</code> und <code>height</code> an. Ein eingebettetes Bild lädt
+      sofort, eine fehlende Größe ist also ein Layout-Sprung, der zu schnell
+      passiert, um gesehen zu werden, und trotzdem gegen Sie zählt. Die Ausnahme
+      ist SVG: Eines, das nur eine <code>viewBox</code> trägt, hat keine eigene
+      Pixelgröße, und die Standardgröße 300&times;150 des Browsers auf das
+      Element zu schreiben nagelt ein skalierbares Bild auf eine Größe fest, die
+      niemand gewählt hat.
+    </p>
+    <p>
+      Lassen Sie <code>alt</code> leer, sofern Sie nichts Wahres hineinzuschreiben
+      haben. Nur Sie wissen, ob das Bild Bedeutung trägt oder Dekoration ist, und
+      eine aus einem Dateinamen geratene Beschreibung ist für jemanden mit einem
+      Screenreader schlechter als gar keine.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wann die Antwort &bdquo;lieber nicht&ldquo; lautet</h2>
+    <p>
+      Ist das Bild kodiert über etwa 50&nbsp;KB groß, ist Einbetten das falsche
+      Werkzeug, und keine Sorgfalt bei der Kodierung repariert das. Die
+      Alternativen, in der Reihenfolge, in der sie sich lohnen:
+    </p>
+    <ul>
+      <li>
+        <strong>Machen Sie es kleiner.</strong> Die meisten Bilder, die zu groß
+        zum Einbetten sind, sind allgemein zu groß. Der
+        <a href="../../bild-komprimieren/">Bildkompressor</a> bringt eine
+        Fotografie auf eine von Ihnen genannte Größe, und das
+        <a href="../../bildgroesse-aendern/">Bildgrößen-Ändern</a> schneidet die
+        Pixelmaße auf das herunter, was das Layout tatsächlich nutzt &mdash; und
+        das ist sehr oft das eigentliche Problem.
+      </li>
+      <li>
+        <strong>Zeichnen Sie es als SVG neu.</strong> Ein als 40&nbsp;KB großes
+        PNG exportiertes Symbol ist häufig ein 900 Byte großes SVG. Das ist kein
+        Kompressionsunterschied, das ist ein Formatunterschied &mdash; und es
+        löst obendrein das Retina-Problem.
+      </li>
+      <li>
+        <strong>Lassen Sie es eine Datei und laden Sie sie vor.</strong>
+        <code>&lt;link rel="preload" as="image"&gt;</code> startet den Abruf
+        sofort, ohne die Bytes auf den kritischen Pfad zu verschieben. Es bringt
+        den größten Teil des Nutzens des Einbettens und nichts von den
+        Cache-Kosten.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Nichts davon braucht einen Upload</h2>
+    <p>
+      Eine Datei als Base64 zu kodieren ist Rechnerei. Es sind zwei Funktionen,
+      die der Browser seit Anbeginn hat &mdash; <code>btoa</code> und
+      <code>encodeURIComponent</code> &mdash; und es gibt überhaupt keinen
+      technischen Grund, warum ein Bild zu einem Server und zurück reisen sollte,
+      um anders aufgeschrieben zu werden. Jeder Umwandler, der Ihre Datei dafür
+      hochlädt, lädt sie aus seinen eigenen Gründen hoch und nicht aus Ihren.
+    </p>
+    <p>
+      <a href="../../bild-als-base64/">Das Werkzeug hier</a> schickt sie
+      nirgendwohin: Die <code>Content-Security-Policy</code> der Seite nennt jede
+      Adresse, die sie kontaktieren darf, und keine davon gehört zu dieser Seite.
+      Laden Sie die Seite, trennen Sie die Internetverbindung und kodieren Sie
+      trotzdem etwas, wenn Sie lieber prüfen als glauben.
+      <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
+      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen, die Sie
+      an jedem Werkzeug durchführen können.
+    </p>
+  </section>

--- a/locales/de/pages/guides/embed-an-image-in-css.toml
+++ b/locales/de/pages/guides/embed-an-image-in-css.toml
@@ -1,0 +1,18 @@
+#
+# Ratgeber: Ein Bild in CSS einbetten - German.
+#
+
+nav = "Ein Bild in CSS einbetten"
+title = "Data-URIs in CSS: wann ein Bild eingebettet gehört und wann nicht"
+description = "Was eine Data-URI kostet, warum Base64 ein Drittel drauflegt und gzip es nicht zurückgibt, warum ein SVG nie base64 sein sollte, und der Anführungszeichen-Fehler, der eingebettete SVGs stillschweigend kaputtmacht."
+heading = "Wann ein Bild in Ihr CSS gehört - und wann nicht"
+lede = """
+    Ein ins Stylesheet geschriebenes Bild kommt mit ihm an: keine zweite
+    Anfrage, kein Warten. Es hört damit aber auch auf, eine Datei zu sein
+    &mdash; es kann also nicht für sich zwischengespeichert werden und wird jedes
+    Mal neu geladen, wenn sich irgendetwas drumherum ändert. Hier steht, wo
+    dieser Handel sich lohnt und wo er es stillschweigend nicht tut."""
+updated = "20. August 2026"
+og_title = "Wann ein Bild in Ihr CSS gehört"
+og_description = "Was eine Data-URI kostet, warum ein SVG nie base64 sein sollte, und der Anführungszeichen-Fehler, der eingebettete SVGs stillschweigend kaputtmacht."
+og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/make-a-qr-code.html
+++ b/locales/de/pages/guides/make-a-qr-code.html
@@ -1,0 +1,277 @@
+  <section>
+    <h2>Die kurze Antwort</h2>
+    <p>
+      Öffnen Sie den
+      <a href="../../qr-code-erstellen/">QR- &amp; Barcode-Generator</a>, fügen
+      Sie Ihren Link ein, lassen Sie die Stufe auf <strong>M</strong> und den
+      Rand auf <strong>4</strong>, und laden Sie das SVG herunter. Drucken Sie
+      ihn mindestens zwei Zentimeter breit, auf etwas Mattem, dunkel auf hell.
+      Scannen Sie dann den gedruckten mit einem Telefon, das nicht Ihres ist,
+      bevor Sie tausend davon bestellen.
+    </p>
+    <p>
+      Das deckt fast jeden Fall ab. Der Rest dieser Seite handelt davon, was zu
+      tun ist, wenn es keiner davon ist: ein Code, der Behandlung überstehen
+      muss, ein Code mit einem Logo darauf, ein Code auf etwas Kleinem, und die
+      eine Entscheidung, die sich leicht so falsch treffen lässt, dass Sie es
+      erst ein Jahr später merken.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was tatsächlich in einem QR-Code steckt</h2>
+    <p>
+      Eine Zeichenkette. Das ist alles. Einen QR-Code zu scannen übergibt dem
+      Telefon ein Stück Text, und alles Weitere &mdash; eine Seite öffnen, einem
+      Netz beitreten, anbieten, einen Kontakt zu speichern &mdash; ist das
+      Telefon, das die Form dieses Textes erkennt und anbietet, darauf zu
+      reagieren.
+    </p>
+    <p>
+      Es gibt also so etwas wie einen &bdquo;WLAN-QR-Code&ldquo; als Art von Code
+      gar nicht. Es gibt einen QR-Code, der
+      <code>WIFI:T:WPA;S:Mein Netz;P:das Passwort;;</code> enthält, und das kann
+      jedes Telefon der letzten zehn Jahre lesen. Genau deshalb zeigt Ihnen der
+      Generator die fertige Zeichenkette: Wenn ein Code nicht das tut, was Sie
+      erwartet haben, ist die Zeichenkette das Einzige, was anzusehen sich lohnt.
+    </p>
+    <p>
+      Es heißt auch, dass ein QR-Code sich nach dem Druck nicht ändern lässt,
+      nicht nach Hause telefonieren kann und nicht ablaufen kann &mdash; es sei
+      denn, jemand hat einen Link auf seinen eigenen Server hineingelegt, und
+      davon handelt der letzte Abschnitt hier.
+    </p>
+  </section>
+
+  <section>
+    <h2>Entscheidung eins: die Fehlerkorrekturstufe</h2>
+    <p>
+      Ein QR-Code trägt neben den Daten einen Satz Prüfwörter, so berechnet, dass
+      ein Lesegerät wieder aufbauen kann, was es nicht sehen konnte. Deshalb
+      scannt ein Code mit abgerissener Ecke noch. Wie viele dieser Prüfwörter es
+      gibt, ist die Stufe, und es gibt vier:
+    </p>
+    <ul>
+      <li><strong>L</strong> &mdash; rund 7&nbsp;% des Codes dürfen verloren gehen.</li>
+      <li><strong>M</strong> &mdash; rund 15&nbsp;%.</li>
+      <li><strong>Q</strong> &mdash; rund 25&nbsp;%.</li>
+      <li><strong>H</strong> &mdash; rund 30&nbsp;%.</li>
+    </ul>
+    <p>
+      Mehr Korrektur gibt es nicht umsonst: Die Prüfdaten kommen in dasselbe
+      Quadrat, derselbe Text braucht bei H also einen größeren, dichteren Code
+      als bei L. Grob gesagt verdoppelt der Weg von L nach H die Modulzahl für
+      dieselbe Zeichenkette, und dichtere Module sind für eine Kamera schwerer
+      aufzulösen. Hier gibt es einen echten Handel, und die Antwort hängt davon
+      ab, wohin der Code geht.
+    </p>
+    <p>
+      <strong>L</strong> ist für einen Bildschirm: ein Code in einer Folie, einer
+      E-Mail, einer Webseite. Nichts wird ihn beschädigen, und jedes zusätzliche
+      Modul macht ihn aus der Entfernung schwerer lesbar.
+    </p>
+    <p>
+      <strong>M</strong> ist die Voreinstellung und die richtige Antwort für die
+      meisten Drucksachen. Papier, das ein wenig angefasst wird, ein Flyer, eine
+      Visitenkarte.
+    </p>
+    <p>
+      <strong>Q und H</strong> sind für Codes, die misshandelt werden: eine
+      täglich abgewischte Speisekarte, ein Aufkleber auf einer Maschine in der
+      Werkstatt, ein Etikett auf einer Kiste, ein Code in einem Fenster mit
+      direkter Sonne. H ist außerdem das, was ein Logo in der Mitte möglich macht
+      &mdash; siehe unten.
+    </p>
+  </section>
+
+  <section>
+    <h2>Entscheidung zwei: der Rand, der Teil des Codes ist</h2>
+    <p>
+      Der weiße Raum um einen QR-Code ist kein Abstand und keine
+      Gestaltungsentscheidung. Ein Lesegerät nutzt ihn, um zu finden, wo das
+      Symbol endet. Die Spezifikation verlangt vier Module ruhige Fläche auf
+      jeder Seite, und ein bis an die Kante beschnittener Code ist der mit
+      Abstand häufigste Grund, warum ein gedruckter Code scheitert.
+    </p>
+    <p>
+      Das ist es wert, unverblümt gesagt zu werden, denn Beschneiden ist eine so
+      natürliche Handlung. Der Code sieht aus, als habe er zu viel Weiß um sich,
+      also wird er im Layout beschnitten, oder auf eine farbige Fläche gesetzt,
+      die bis an die Quadrate heranläuft, oder auf eine Fotografie gelegt. Jedes
+      davon nimmt die Grenze weg, die das Lesegerät benutzen wollte.
+    </p>
+    <p>
+      Sieht der Code mit seinem Rand zu groß aus, machen Sie den Code kleiner.
+      Nehmen Sie nicht den Rand weg.
+    </p>
+  </section>
+
+  <section>
+    <h2>Entscheidung drei: wie groß gedruckt wird</h2>
+    <p>
+      Die Faustregel, die den Kontakt mit der Wirklichkeit überstanden hat, heißt
+      <strong>eins zu zehn</strong>: Ein Code muss etwa ein Zehntel so breit sein
+      wie die Entfernung, aus der er gescannt wird.
+    </p>
+    <ul>
+      <li>Eine Visitenkarte oder eine Speisekarte, aus 30 cm gelesen: etwa 2 cm breit.</li>
+      <li>Ein Plakat, aus zwei Metern gelesen: etwa 20 cm.</li>
+      <li>Ein Buswartehäuschen oder ein Schaufenster, aus fünf Metern gelesen: etwa 50 cm.</li>
+    </ul>
+    <p>
+      Zwei Zentimeter sind eine Untergrenze und kein Ziel. Unterhalb von etwa
+      1,5 cm fängt ein gewöhnliches Telefon an zu kämpfen, ganz gleich wie gut
+      der Druck ist, denn die einzelnen Module nähern sich der Größe eines Pixels
+      in seiner Kamera.
+    </p>
+    <p>
+      Weniger Text heißt weniger Module heißt ein Code, der bei gegebener
+      Druckgröße aus der Entfernung liest &mdash; ein guter Grund, einen Code auf
+      <code>example.com/x</code> zeigen zu lassen und nicht auf eine URL mit
+      hundert Zeichen Tracking-Parametern am Ende.
+    </p>
+    <p>
+      Und drucken Sie aus dem <strong>SVG</strong>. Ein QR-Code besteht aus
+      Kanten, und ein PNG hat eine feste Pixelzahl, aus der es sie machen muss;
+      vergrößern Sie eines, und jede Kante wird weich &mdash; genau das, womit ein
+      Scanner Mühe hat. Ein SVG sind die Quadrate als Anweisungen, es kommt also
+      auf einer Visitenkarte wie auf einer Plakatwand scharf heraus.
+    </p>
+  </section>
+
+  <section>
+    <h2>Farbe, Kontrast und die zwei Fehler</h2>
+    <p>
+      Ein Lesegerät misst den Unterschied zwischen den dunklen und den hellen
+      Modulen, Kontrast ist also alles. Zwei Dinge gehen regelmäßig schief:
+    </p>
+    <p>
+      <strong>Heller Code auf dunklem Hintergrund.</strong> Es sieht auffällig
+      aus, und eine ganze Reihe Lesegeräte weist es rundweg ab: Sie suchen nach
+      dunkel auf hell und probieren die Umkehrung nicht. Manche schon. Sie werden
+      nicht wissen, welche Ihre Kundschaft hat.
+    </p>
+    <p>
+      <strong>Zu wenig Unterschied.</strong> Mittelgrau auf Weiß, oder zwei
+      Markenfarben ähnlicher Tiefe, können am Bildschirm einwandfrei messen und
+      auf Papier scheitern, sobald Tonwertzuwachs und die automatische Belichtung
+      eines Telefons ins Spiel kommen. Wenn Sie einen Code einfärben, halten Sie
+      den dunklen Teil wirklich dunkel.
+    </p>
+    <p>
+      Matt schlägt glänzend bei allem, was unter einer Lampe gescannt wird, und
+      beides schlägt den Druck auf eine Fotografie. Transparente Hintergründe
+      sind nützlich, um einen Code auf eine farbige Fläche zu setzen &mdash;
+      prüfen Sie aber, was am Ende dahinter landet, denn ein transparenter Code
+      auf einer dunklen Fläche ist der erste Fehler oben mit Zwischenschritten.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ein Logo in der Mitte</h2>
+    <p>
+      Das funktioniert, und es funktioniert wegen der Fehlerkorrektur und nicht
+      trotz ihr. Auf Stufe H lassen sich rund 30&nbsp;% der Module zerstören und
+      der Code ist noch lesbar &mdash; ein Logo, das deutlich weniger als das
+      verdeckt, in der Mitte, wo kein Suchmuster sitzt, ist also Schaden, den das
+      Lesegerät repariert.
+    </p>
+    <p>
+      Drei Dinge, an die Sie sich halten sollten. Nehmen Sie Stufe H. Halten Sie
+      das Logo unter etwa einem Fünftel der Fläche, gut unterhalb der
+      theoretischen Grenze, denn der Druck ist nicht das Einzige, was an Ihrer
+      Reserve knabbert. Und verdecken Sie nie die drei großen Quadrate in den
+      Ecken oder die kleineren daneben: An denen findet ein Lesegerät das Symbol
+      überhaupt erst und richtet es aus, und keine Fehlerkorrektur der Welt baut
+      sie wieder auf.
+    </p>
+    <p>
+      Testen Sie ihn dann an echten Telefonen. Ein Logo bringt einen Code von
+      &bdquo;funktioniert immer&ldquo; auf &bdquo;funktioniert mit so viel
+      Reserve&ldquo;, und der einzige Weg herauszufinden, wie viel Reserve übrig
+      ist, ist auszuprobieren.
+    </p>
+  </section>
+
+  <section>
+    <h2>Die Entscheidung, die Menschen bereuen: statisch oder &bdquo;dynamisch&ldquo;</h2>
+    <p>
+      Suchen Sie nach einem QR-Generator, und die meisten Treffer wollen, dass
+      Sie ein Konto anlegen &mdash; denn sie verkaufen <em>dynamische</em> Codes.
+      Ein dynamischer Code enthält nicht Ihren Link. Er enthält einen Kurzlink
+      auf den eigenen Server des Generators, der auf Ihren weiterleitet.
+    </p>
+    <p>
+      Was Sie dafür bekommen, ist echt: Sie können nach dem Druck ändern, wohin
+      der Code zeigt, und Sie bekommen eine Zählung jedes Scans. Für eine
+      Kampagne mit sechsstelliger Auflage ist das Geld wert.
+    </p>
+    <p>
+      Was es kostet, ist ebenfalls echt und vorher wissenswert statt nachher:
+    </p>
+    <ul>
+      <li>
+        <strong>Der Code hört auf zu funktionieren, wenn die aufhören.</strong>
+        Schließt der Dienst, läuft die Domain aus oder endet die kostenlose
+        Stufe, ist jeder gedruckte Code tot &mdash; und bis dahin kleben sie auf
+        zehntausend Speisekarten.
+      </li>
+      <li>
+        <strong>Jeder Scan sind Daten von jemand anderem.</strong> Die
+        Weiterleitung sieht die IP-Adresse, die Uhrzeit und das Gerät jeder
+        Person, die Ihren Code scannt.
+      </li>
+      <li>
+        <strong>Der Link gehört ihnen, nicht Ihnen.</strong> Wer ihn scannt,
+        sieht eine unbekannte Domain vorbeihuschen &mdash; und genau davor wird
+        Menschen gesagt, sie sollten misstrauisch sein.
+      </li>
+    </ul>
+    <p>
+      Der Mittelweg kostet nichts: Setzen Sie einen statischen QR-Code um eine
+      kurze URL <em>auf Ihrer eigenen Domain</em>, und leiten Sie die selbst
+      weiter. Sie behalten die Möglichkeit, das Ziel zu ändern, Sie behalten die
+      Auswertung, und nichts an dem Code hängt davon ab, dass es ein Unternehmen,
+      das Sie nie getroffen haben, nächstes Jahr noch gibt.
+    </p>
+    <p>
+      Der <a href="../../qr-code-erstellen/">Generator hier</a> erzeugt nur
+      statische Codes, und es gibt kein Konto anzulegen. Was Sie eintippen, ist
+      das, was der Code enthält.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bevor Sie tausend davon drucken</h2>
+    <p>
+      Scannen Sie den Code. Nicht den auf Ihrem Bildschirm &mdash; den gedruckten
+      Andruck, an dem Ort, an den er kommt, mit einem Telefon, das nicht das ist,
+      auf dem Sie ihn gemacht haben. Das dauert eine Minute und fängt die ganze
+      Sorte Probleme ab, von der diese Seite handelt: ein Rand, den das Layout
+      gefressen hat, ein Link ohne sein <code>https://</code>, eine Farbe, die
+      auf Papier anders gemessen hat, ein Code in einer Größe, die auf einem
+      Schreibtisch funktioniert und an einer Wand nicht.
+    </p>
+    <p>
+      Und prüfen Sie, was nach dem Scan passiert. Ein Code, der eine Seite
+      öffnet, die auf einem Telefon unlesbar ist, ist ein gescheiterter Code
+      &mdash; auch wenn er gescannt hat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nichts davon verlangt, irgendetwas hochzuladen</h2>
+    <p>
+      Ein QR-Code ist Rechnerei über einer Zeichenkette. Es gibt keine Datei zu
+      senden und nichts, was ein Server könnte und ein Browser nicht &mdash;
+      deshalb erledigt das <a href="../../qr-code-erstellen/">Werkzeug hier</a>
+      alles davon auf Ihrem eigenen Gerät und arbeitet mit getrennter
+      Netzverbindung.
+    </p>
+    <p>
+      Das zählt mehr, als es klingt, wegen dessen, was Menschen in QR-Codes
+      legen. Die häufigste Verwendung des WLAN-Formats ist das tatsächliche
+      Passwort eines Netzes, in eine Webseite getippt. Es lohnt sich zu wissen,
+      ob diese Seite irgendwohin hatte, wo sie es hinschicken konnte.
+    </p>
+  </section>

--- a/locales/de/pages/guides/make-a-qr-code.toml
+++ b/locales/de/pages/guides/make-a-qr-code.toml
@@ -1,0 +1,18 @@
+#
+# Ratgeber: Einen QR-Code erzeugen - German.
+#
+
+nav = "Einen QR-Code erzeugen"
+title = "Einen QR-Code erzeugen, der jedes Mal scannt"
+description = "Welche Fehlerkorrekturstufe Sie nehmen sollten, warum der weiße Rand um einen QR-Code Teil des Codes ist, wie groß Sie ihn drucken müssen, und was Sie der 'dynamische' Code eines kostenlosen Generators später kostet."
+heading = "Wie Sie einen QR-Code erzeugen, der auch auf dem Telefon eines anderen noch scannt"
+lede = """
+    Einen QR-Code zu erzeugen dauert eine Sekunde. Einen zu erzeugen, der auf
+    einer nassen Speisekarte, an einem Buswartehäuschen oder auf einem bei
+    schlechtem Licht auf Armlänge gehaltenen Telefon funktioniert, kostet vier
+    Entscheidungen &mdash; und alle vier fallen, bevor Sie irgendetwas drucken.
+    Hier steht, was jede davon tut."""
+updated = "20. August 2026"
+og_title = "Einen QR-Code erzeugen, der auch auf dem Telefon eines anderen noch scannt"
+og_description = "Die vier Entscheidungen, die darüber bestimmen, ob ein gedruckter QR-Code funktioniert: die Stufe, der Rand, die Größe, und wessen Adresse eigentlich darin steht."
+og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/de/pages/guides/turn-a-video-into-a-gif.html
@@ -1,0 +1,236 @@
+  <section>
+    <h2>Die kurze Antwort</h2>
+    <p>
+      Öffnen Sie den
+      <a href="../../video-in-gif-umwandeln/">Video-zu-GIF-Umwandler</a>, ziehen
+      Sie den Clip hinein, markieren Sie die gewünschten Sekunden und lassen Sie
+      die Breite bei 480 und die Rate bei 12 Bildern pro Sekunde. Das ist die
+      Einstellung, die die meisten GIFs wollen. Kommt die Datei zu groß heraus,
+      nehmen Sie die Breite herunter, bevor Sie irgendetwas anderes anfassen
+      &mdash; das ist die Einstellung, die doppelt zahlt.
+    </p>
+    <p>
+      Der Rest dieser Seite handelt vom Warum, denn &bdquo;mein GIF hat
+      14&nbsp;MB&ldquo; ist das Problem, das alle tatsächlich haben, und welcher
+      Regler zu drehen ist, liegt nicht auf der Hand.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum ein GIF eines Videos so riesig ist</h2>
+    <p>
+      Ein Video-Codec speichert <em>Bewegung</em>. Er schreibt alle paar Sekunden
+      ein volles Bild und für jedes Einzelbild dazwischen eine Beschreibung
+      davon, wie dieses Bild sich bewegt hat: Dieser Pixelblock ist vier nach
+      links gerutscht, dieser Bereich ist etwas dunkler geworden. Ein fünf
+      Sekunden langer Clip kann ein paar hundert Kilobyte groß sein, weil das
+      meiste davon Anweisungen zu einem Bild sind, das Sie schon haben.
+    </p>
+    <p>
+      GIF hat davon nichts. Es war 1989 fertig, bevor es irgendetwas davon gab.
+      Jedes Einzelbild ist ein Bild, für sich komprimiert, mit einem Verfahren,
+      das für Bildschirmfotos einer Tabellenkalkulation entworfen wurde. In dem
+      Format gibt es nirgends eine Bewegungsschätzung, und es gibt keine
+      Möglichkeit, eine hinzuzufügen.
+    </p>
+    <p>
+      Die Zahl, mit der zu rechnen ist, lautet also
+      <strong>das Zehnfache der Größe des Videos</strong>, und kein Umwandler
+      redet Sie davon herunter. Was ein guter tun kann, ist, nichts obendrauf zu
+      verschwenden und Ihnen die drei Einstellungen zu geben, die es tatsächlich
+      entscheiden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Die drei Einstellungen, und was jede kostet</h2>
+    <p>
+      Alles an der Größe eines GIFs läuft darauf hinaus, wie viele Pixel darin
+      stecken &mdash; und das ist die Länge mal die Rate mal die Fläche eines
+      Einzelbildes.
+    </p>
+    <ul>
+      <li>
+        <strong>Der Abschnitt &mdash; linear.</strong> Doppelt so lang sind
+        doppelt so viele Einzelbilder und etwa die doppelte Datei. Das ist die,
+        die die meisten schon verstehen, und es lohnt sich, dabei rücksichtslos
+        zu sein: Ein GIF, das seinen Punkt in drei Sekunden macht, ist ein
+        besseres GIF und obendrein ein kleineres.
+      </li>
+      <li>
+        <strong>Die Breite &mdash; quadratisch.</strong> Die Breite zu halbieren
+        halbiert die Höhe mit, es ist also ein <em>Viertel</em> der Pixel. Von
+        640 auf 320 zu gehen spart nicht etwas weniger als die Hälfte, sondern
+        rund drei Viertel. Das ist die Einstellung, nach der niemand zuerst
+        greift, und die, die sich am besten auszahlt.
+      </li>
+      <li>
+        <strong>Die Bildrate &mdash; linear.</strong> Zehn Bilder pro Sekunde
+        sind zwei Drittel der Größe von fünfzehn. Es ist auch die Einstellung,
+        bei der der Verlust am sichtbarsten ist, denn zu langsame Bewegung liest
+        sich als kaputt und nicht als klein.
+      </li>
+    </ul>
+    <p>
+      Ein durchgerechnetes Beispiel. Sechs Sekunden eines Handy-Clips in seinen
+      eigenen 1080&times;1920 bei 30 fps sind 180 Einzelbilder zu zwei Millionen
+      Pixeln: rund 350 Millionen Pixel, und das ist kein GIF, das ist eine
+      Geiselnahme. Dieselben sechs Sekunden mit 480 Breite und 12 fps sind 72
+      Einzelbilder zu 400.000 Pixeln &mdash; 30 Millionen, etwa ein Zwölftel
+      &mdash; und es sieht aus wie das, was Menschen mit einem GIF meinen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Welche Bildrate zu wählen ist</h2>
+    <p>
+      Zwölf ist hier die Voreinstellung und überraschend oft die richtige
+      Antwort. Es ist die Rate, die handgezeichnete Animation seit einem
+      Jahrhundert verwendet: schnell genug, dass das Auge sie als
+      zusammenhängende Bewegung liest, langsam genug, dass Sie nicht für
+      Einzelbilder zahlen, die niemand sehen kann.
+    </p>
+    <ul>
+      <li><strong>5&ndash;8</strong> &mdash; wirkt wie eine Diashow. Passt für
+        einen langsamen Schwenk oder eine Bildschirmaufnahme, in der sich nichts
+        schnell bewegt.</li>
+      <li><strong>10&ndash;15</strong> &mdash; normal. Liest sich als Bewegung.
+        Fast jedes lohnende GIF liegt hier.</li>
+      <li><strong>20&ndash;25</strong> &mdash; flüssig, und rund doppelt so groß
+        wie 12 für einen Unterschied, den die meisten Betrachter nicht benennen
+        könnten. Lohnt sich bei schneller Bewegung, einem Sportclip, allem mit
+        einem Reißschwenk darin.</li>
+    </ul>
+    <p>
+      Es gibt eine harte Obergrenze, die Sie ruhig kennen dürfen: GIF speichert
+      die Standzeit jedes Einzelbildes in Hundertstelsekunden, und jeder Browser
+      behandelt eine Verzögerung unter zwei Hundertsteln als zehn. 50 Bilder pro
+      Sekunde sind also das echte Maximum, und eine Datei, die 100 verlangt,
+      spielt stillschweigend mit 10. Ein Umwandler, der Ihnen 60 fps anbietet,
+      ignoriert das entweder oder wird Sie gleich überraschen.
+    </p>
+  </section>
+
+  <section>
+    <h2>256 Farben, und wofür Dithering da ist</h2>
+    <p>
+      Die andere Hälfte des Alters dieses Formats: Ein GIF trägt eine Tabelle mit
+      höchstens 256 Farben, und jedes Pixel ist eine Nummer, die darauf zeigt.
+      Ein Videobild hat bis zu sechzehn Millionen. Fast alles davon wird
+      weggeworfen, und wie es weggeworfen wird, ist das meiste dessen, wie ein
+      GIF aussieht.
+    </p>
+    <p>
+      Ein guter Umwandler zählt die Farben in <em>Ihrem</em> Clip und wählt 256,
+      die dazu passen, statt einen festen Satz zu nehmen. Eine Aufnahme eines
+      Waldes bekommt 256 Grüntöne; eine Aufnahme eines Sonnenuntergangs 256
+      Orangetöne. Genau das tut das Werkzeug hier, und zwar über jedes
+      Einzelbild des Abschnitts statt nur über das erste &mdash; eine Farbe, die
+      erst am Ende auftaucht, bekommt also trotzdem einen Platz.
+    </p>
+    <p>
+      <strong>Dithering</strong> ist das, was dort passiert, wo die benötigte
+      Farbe trotzdem fehlt. Statt eine ganze Fläche auf die nächstgelegene
+      verfügbare Farbe zu runden &mdash; was einen weichen Himmel in vier flache
+      Bänder mit sichtbaren Stufen dazwischen verwandelt &mdash;, wechselt es die
+      beiden nächstgelegenen Farben in einem feinen Muster ab, und aus normalem
+      Betrachtungsabstand mischt Ihr Auge sie zu der, die es nicht gibt.
+    </p>
+    <ul>
+      <li><strong>Lassen Sie es an</strong> für alles Fotografische: Himmel,
+        Haut, Verläufe, Schatten, Film.</li>
+      <li><strong>Schalten Sie es ab</strong> für flache Farbflächen:
+        Bildschirmaufnahmen, Strichzeichnungen, Logos, Zeichentrick, alles mit
+        großen Flächen eines Tons. Da gibt es keinen Verlauf zu schützen, und die
+        Datei wird ohne kleiner und sauberer.</li>
+    </ul>
+    <p>
+      Ein Detail, das wissenswert ist, wenn Sie Umwandler vergleichen. Die
+      naheliegende Art zu dithern &mdash; Fehlerverteilung, die die meisten
+      Bildbearbeitungsprogramme verwenden &mdash; macht das Ergebnis jedes Pixels
+      von den Pixeln ringsherum abhängig. In einer Animation heißt das, dass ein
+      unbewegter Hintergrund in jedem Einzelbild anders dithert, also sichtbar
+      kribbelt &mdash; und jedes Einzelbild muss vollständig gespeichert werden,
+      weil sich technisch jedes Pixel geändert hat. Die Alternative, ein
+      geordnetes Dithering, hängt nur davon ab, wo ein Pixel liegt, ein stehender
+      Hintergrund bleibt also vollkommen still. Das ist es, was dieses Werkzeug
+      verwendet, und es ist der Grund, warum seine Dateien kleiner und ruhiger
+      zugleich sind.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wann Sie besser gar kein GIF machen</h2>
+    <p>
+      Eine Frage, die sich lohnt, denn die ehrliche Antwort lautet oft
+      &bdquo;lieber nicht&ldquo;. Ein stummes, endlos laufendes MP4 oder WebM ist
+      etwa ein Zehntel so groß wie dieselbe Animation als GIF, spielt genauso ab
+      und ist ohnehin das, worin jede soziale Plattform Ihr GIF nach dem Hochladen
+      umwandelt.
+    </p>
+    <p>Behalten Sie das GIF dort, wo das Ziel wirklich eines braucht:</p>
+    <ul>
+      <li>irgendwo, wo nur ein Bild angenommen wird &mdash; eine Menge Chat-,
+        Forum-, Wiki- und E-Mail-Software;</li>
+      <li>eine README oder eine Dokumentationsseite, wo ein GIF direkt abspielt
+        und ein Video einen Player braucht;</li>
+      <li>eine Präsentation oder ein Dokument, das auch offline in Bewegung
+        bleiben muss;</li>
+      <li>ein Emoji, ein Sticker, eine Reaktion &mdash; klein genug, dass nichts
+        von der Rechnerei oben eine Rolle spielt.</li>
+    </ul>
+    <p>
+      Wo der Ton zählt, beantwortet sich die Frage von selbst: GIF hatte nie Ton
+      und wird nie welchen haben. Schneiden Sie stattdessen das Video &mdash; der
+      <a href="../../video-schneiden/">Video-Schneider</a> nimmt einen Abschnitt
+      heraus, ohne ein einziges Einzelbild davon neu zu kodieren.
+    </p>
+  </section>
+
+  <section>
+    <h2>Unter eine Größengrenze kommen</h2>
+    <p>
+      Der häufigste Grund, ein GIF überhaupt zu justieren, ist eine Grenze am
+      anderen Ende. Grob in der Reihenfolge, wie sehr sie beißen:
+    </p>
+    <ul>
+      <li><strong>E-Mail</strong> &mdash; 10 bis 25 MB für die ganze Nachricht,
+        und ein Anhang nahe daran wird von irgendetwas unterwegs entfernt oder
+        zurückgewiesen. Zielen Sie deutlich darunter.</li>
+      <li><strong>Chat und Foren</strong> &mdash; üblicherweise 8 bis 10 MB,
+        manchmal deutlich weniger für eine eingebettete Vorschau statt eines
+        Downloads.</li>
+      <li><strong>Eine GitHub-README</strong> &mdash; 10 MB je Datei, und alles
+        über ein paar Megabyte lässt die Seite auf einem Telefon kaputt
+        wirken.</li>
+      <li><strong>Sticker- und Emoji-Plätze</strong> &mdash; oft ein paar hundert
+        Kilobyte, was eine kleine Breite und einen kurzen Abschnitt bedeutet und
+        nicht eine niedrigere Bildrate.</li>
+    </ul>
+    <p>
+      Die Reihenfolge zum Ausprobieren, wenn Sie darüber liegen: den Abschnitt
+      kürzen, dann die Breite halbieren, dann die Rate senken, dann das Dithering
+      abschalten. Die ersten beiden sind mehr wert als die letzten beiden
+      zusammen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nichts davon braucht einen Upload</h2>
+    <p>
+      Ein Video in ein GIF umzuwandeln heißt dekodieren, skalieren, Farben zählen
+      und komprimieren &mdash; vier Dinge, die ein Browser seit Jahren von allein
+      kann. Das oben verlinkte Werkzeug erledigt alles davon auf Ihrem Gerät: Die
+      Datei wird von Ihrer Festplatte gelesen, die Einzelbilder werden von Ihrem
+      Browser dekodiert, und das GIF wird im Arbeitsspeicher zusammengesetzt und
+      an Ihre Downloads übergeben.
+    </p>
+    <p>
+      Und darum lohnt es sich hier mehr zu kümmern als sonst. Die Clips, aus
+      denen Menschen GIFs machen, sind persönliche &mdash; ein Moment aus einem
+      Familienvideo, eine Bildschirmaufnahme von etwas bei der Arbeit, ein paar
+      Sekunden eines Gesprächs. Ein Umwandler, der die hochgeladen haben will,
+      bittet um eine Kopie davon &mdash; und es gibt keinen technischen Grund
+      mehr, Ja zu sagen.
+    </p>
+  </section>

--- a/locales/de/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/de/pages/guides/turn-a-video-into-a-gif.toml
@@ -1,0 +1,17 @@
+#
+# Ratgeber: Aus einem Video ein GIF machen - German.
+#
+
+nav = "Aus einem Video ein GIF"
+title = "Aus einem Video ein GIF machen (und es klein halten)"
+description = "Welchen Abschnitt, welche Breite und welche Bildrate Sie wählen sollten, warum ein GIF eines Videos zehnmal so groß ist wie das Video, und wann Sie überhaupt eines nehmen sollten."
+heading = "Wie Sie aus einem Video ein GIF machen"
+lede = """
+    Ein GIF ist ein Format von 1987, das ganze Bilder speichert und keine
+    Bewegung &mdash; eines aus einem Video ist deshalb immer groß. Hier steht,
+    welche der drei Einstellungen Sie bewegen sollten, wenn es zu groß ist, und
+    wie viel jede davon bringt."""
+updated = "20. August 2026"
+og_title = "Aus einem Video ein GIF machen, und es klein halten"
+og_description = "Die drei Einstellungen, die die Größe eines GIFs bestimmen, was jede davon kostet, und wann ein GIF die ganz falsche Antwort ist."
+og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/tools/heic-to-jpg.html
+++ b/locales/de/tools/heic-to-jpg.html
@@ -1,0 +1,114 @@
+<main>
+  <!-- Schritt 1 &mdash; die Dateien -->
+  <section class="card">
+    <h2><span class="step">1</span> Ihre HEIC-Fotos wählen</h2>
+
+    <p class="card-lede">
+      Direkt vom Telefon, aus einem Backup oder von einer Speicherkarte kopiert.
+      Die Datei wird hier gelesen, auf diesem Gerät, und das Bild wird ebenfalls
+      hier dekodiert &mdash; auf dieser Seite gibt es keinen Upload-Schritt und
+      dahinter keinen Server.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alle von der Liste nehmen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Schritt 2 &mdash; was herauskommt -->
+  <section class="card" id="options-card">
+    <h2><span class="step">2</span> Sagen, was Sie zurückhaben wollen</h2>
+
+    <fieldset class="options">
+      <legend>Das Format</legend>
+
+      <div class="option-row">
+        <label for="format-select">Die Bilder schreiben als</label>
+        <select id="format-select">
+          <option value="image/jpeg" selected>JPEG &mdash; öffnet überall, auch in aus Versehen in diesem Jahrhundert Gebautem</option>
+          <option value="image/png">PNG &mdash; verlustfrei, und um ein Mehrfaches größer</option>
+          <option value="image/webp">WebP &mdash; kleiner als JPEG bei gleicher Qualität, und nur in modernen Browsern</option>
+        </select>
+      </div>
+
+      <div class="option-row" id="quality-row">
+        <label for="quality">Qualität</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="50" max="100" step="1" value="92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Die Fotodetails</legend>
+
+      <label class="check">
+        <input type="checkbox" id="keep-exif" checked>
+        <span>
+          <strong>Datum, Kamera und Einstellungen behalten</strong>
+          <span class="check-note">
+            Genau so übernommen, wie das Telefon sie geschrieben hat &mdash; das
+            umgewandelte Foto sortiert sich also weiter nach dem Aufnahmetag statt
+            nach dem Tag der Umwandlung. Dazu gehören auch die GPS-Koordinaten,
+            wenn das Foto welche hat; die Liste oben sagt, welche Ihrer Fotos das
+            sind. Schalten Sie das ab, und das JPEG kommt mit nichts als dem Bild
+            heraus.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary">
+        So oder so wird hier nichts an irgendjemanden ausgelesen: Die Wahl
+        betrifft, was in die Datei kommt, die Sie zurückbekommen, und nicht, was
+        diese Seite damit tut. Wollen Sie die Tags im Detail durchsehen oder sie
+        aus Fotos entfernen, die schon JPEGs sind, ist der
+        <a href="../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>
+        das Werkzeug dafür.
+      </p>
+    </fieldset>
+  </section>
+
+  <!-- Schritt 3 &mdash; der eine Klick -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Umwandeln</h2>
+
+    <div class="run-row">
+      <button type="button" id="convert-all" class="primary big" disabled>Umwandeln</button>
+    </div>
+
+    <!--
+      The decoder's own status line. This page is the only one on the site that
+      carries a codec, so it is the only one with anything to report here, and
+      saying where the megabyte came from is the point: it is served from this
+      origin, it is cached with the rest of the page, and it is what makes the
+      offline promise hold on a browser that cannot open a HEIC at all.
+    -->
+    <p id="engine-status" class="engine-status" role="status" aria-live="polite"></p>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Umgewandelt</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Alle als ZIP herunterladen</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/de/tools/heic-to-jpg.toml
+++ b/locales/de/tools/heic-to-jpg.toml
@@ -1,0 +1,309 @@
+#
+# HEIC zu JPG - German.
+#
+# Overrides for tools/heic-to-jpg/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "HEIC zu JPG"
+heading = "HEIC&nbsp;zu&nbsp;JPG <span class=\"h1-kw\">&mdash; iPhone-Fotos umwandeln</span>"
+tagline = "Die Fotos, die ein iPhone macht, in einem Format, das jedes Programm öffnet."
+
+title = "HEIC-zu-JPG-Umwandler &mdash; kostenlos, ohne Upload"
+description = "HEIC-Fotos vom iPhone im Browser in JPG umwandeln. Der Decoder läuft auf Ihrem eigenen Gerät: nichts wird hochgeladen, kein Konto, funktioniert offline, und Datum und Kameradaten dürfen mitkommen."
+og_title = "HEIC-Fotos zu JPGs machen, ohne sie hochzuladen"
+og_description = "Der Umwandler, der Ihre Fotos nicht haben will. Der HEIC-Decoder wird von dieser Seite ausgeliefert und läuft auf Ihrem eigenen Gerät, die Bilder verlassen es also nie."
+og_image_alt = "HEIC zu JPG - iPhone-Fotos in einem Format, das jedes Programm öffnet"
+
+pledge = """
+    Das Dekodieren läuft in Ihrem eigenen Browser, auf Ihrer eigenen Hardware.
+    HEIC ist das eine Bildformat, das ein Browser nicht von sich aus öffnet,
+    also trägt diese Seite den Decoder mit sich &mdash; rund 1,4 MB, von dieser
+    Seite ausgeliefert, nach dem ersten Besuch im Zwischenspeicher. Das ist der
+    ganze Grund, warum jeder andere HEIC-Umwandler Sie zum Hochladen auffordert:
+    Sie legen den Codec auf einen Server, und Ihre Fotos müssen zu ihm. Dieser
+    hier legt den Codec stattdessen hierher. Auf dieser Seite gibt es überhaupt
+    keine Netzfunktion und am anderen Ende keinen Server, an den ein Foto ginge."""
+
+live_hint = """
+      Glauben Sie es uns nicht: Öffnen Sie die DevTools, beobachten Sie den Tab
+      &bdquo;Netzwerk&ldquo; und wandeln Sie ein Foto um. Sie sehen die eigenen
+      Dateien dieser Seite laden, den Decoder darunter, und keine einzige
+      Anfrage, die ein Foto, ein Vorschaubild, einen Dateinamen oder ein Byte
+      Ihrer Auswahl trägt. Oder laden Sie die Seite einmal, trennen Sie die
+      Internetverbindung und wandeln Sie trotzdem einen ganzen Ordner um."""
+
+read_first = """
+, <code>src/heif.js</code> dafür, wie der
+      Decoder geladen wird und was er darf, <code>src/boxes.js</code> für das
+      Zerlegen des Containers, das die Metadaten des Fotos findet, und
+      <code>src/exif.js</code> dafür, was mit diesen Metadaten auf dem Weg in ein
+      JPEG geschieht. Die Engine selbst ist <code>vendor/libheif.js</code>,
+      unverändert, mit ihrer Lizenz daneben."""
+
+howto_heading = "HEIC-Fotos in JPG umwandeln"
+
+card = """
+            Die Fotos, die ein iPhone macht, in einem Format, das jedes Programm
+            öffnet &mdash; dekodiert auf Ihrem eigenen Gerät, nicht auf dem
+            Server von irgendwem."""
+
+[words]
+plural = "Fotos"
+choose = "ein Foto"
+analytics_extra = """, und auch keines der
+  Daten, Kameramodelle oder Koordinaten, die dieses Werkzeug daraus liest"""
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Keine Größengrenze"
+
+[[facts]]
+text = "Funktioniert offline"
+
+[[facts]]
+text = "Quelloffen"
+
+[[privacy]]
+title = "Ihre Fotos haben keinen Weg nach draußen."
+body = """
+ Die
+      Content-Security-Policy nennt jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehört zu dieser Seite. Es gibt hier keinen Endpunkt,
+      an dem Ihre Dateien gesammelt werden könnten, und nichts im Code, das sie
+      senden würde, gäbe es einen."""
+
+[[privacy]]
+title = "Der Decoder kam von hier, und er geht nirgendwohin."
+body = """
+ HEIC ist HEVC
+      in einem Box-Format, und außer Safari dekodiert es kein Browser &mdash;
+      also liefert diese Seite <code>libheif</code> aus, nach WebAssembly
+      kompiliert: rund 1,4 MB, in dieses Repository eingecheckt, von dieser
+      Herkunft ausgeliefert und vom Service Worker zwischengespeichert wie jede
+      andere Datei hier. Es wird nicht von einem CDN geholt, denn das setzte
+      einen Dritten in den Weg jedes Besuchs und nähme dem Werkzeug die
+      Offline-Fähigkeit. Die Binärdatei steckt im Skript statt daneben, und zwar
+      genau deshalb, damit zum Starten kein Abruf nötig ist."""
+
+[[privacy]]
+title = "Nichts hier ruft etwas ab."
+body = """
+ Es gibt weder
+      <code>fetch</code> noch <code>XMLHttpRequest</code> noch
+      <code>sendBeacon</code> in irgendeiner Datei, die für dieses Werkzeug
+      geschrieben wurde. Die mitgelieferte Engine enthält, wie jeder
+      Emscripten-Build, die Ladepfade, die eine <code>.wasm</code> von einer URL
+      holen würden; sie werden nicht genommen, weil die Binärdatei schon zur Hand
+      ist &mdash; und würde einer genommen, nennt <code>connect-src</code> Googles
+      Messendpunkte und sonst nichts, der Browser würde ihn also abweisen. Die
+      Richtlinie ist der Beweis, nicht das Versprechen."""
+
+[[privacy]]
+title = "Die Metadaten werden hier gelesen und Ihnen gemeldet."
+body = """
+ Die Liste auf der
+      Seite sagt, was jedes Foto mit sich trägt &mdash; das Datum, die Kamera und
+      ob GPS-Koordinaten darin stehen &mdash;, denn das möchten Sie vielleicht
+      wissen, bevor Sie das JPEG jemandem geben. Es wird von
+      <code>src/boxes.js</code> in diesem Browser aus der Datei gelesen, auf
+      dieser Seite angezeigt und in Ihr JPEG geschrieben oder weggelassen, ganz
+      wie Sie es wählen. Es gibt in diesem Repository kein eigenes
+      Analytics-Ereignis, das einen Dateinamen, ein Datum, eine Koordinate oder
+      eine Anzahl mitführt."""
+
+[[privacy]]
+title = "Was Google lädt - und was es nicht bekommt."
+body = """
+ Die Werbe- und
+      Messskripte kommen von Google, der Spenden-Button von Buy Me a Coffee.
+      Keinem davon wird irgendetwas über Ihre Fotos übergeben. Jede Zeile, die
+      eine Datei liest, dekodiert oder schreibt, wird von dieser Herkunft
+      ausgeliefert und ist im Repository aufgeführt."""
+
+[[privacy]]
+title = "Es funktioniert offline."
+body = """
+ Laden Sie die Seite einmal und trennen Sie die
+      Netzverbindung, und das Werkzeug bleibt unverändert &mdash; der Decoder ist
+      mit ihr zwischengespeichert. Das ist der einfachste Beweis von allen, und
+      hier ein stärkerer als irgendwo sonst auf dieser Seite: Ein Umwandler, der
+      Ihre Fotos zum Dekodieren wegschickte, brächte das unmöglich fertig."""
+
+[[howto]]
+title = "Wählen Sie Ihre HEIC-Fotos."
+body = """
+ Ziehen Sie sie auf das Auswahlfeld
+      oder wählen Sie sie von Hand, direkt aus einem Telefon-Backup oder einem
+      Ordner auf dem Schreibtisch. Der Browser liest sie von Ihrer Festplatte;
+      dabei wird nichts irgendwohin gesendet. Die Liste sagt, was jedes davon ist
+      und was darin steckt."""
+
+[[howto]]
+title = "Sehen Sie nach, was die Fotos mit sich tragen."
+body = """
+ Jede Zeile nennt das
+      Aufnahmedatum, die Kamera und &mdash; in Grün, weil das der bemerkenswerte
+      Teil ist &mdash;, ob die Datei GPS-Koordinaten enthält. Das wird aus dem
+      Container gelesen, ohne das Bild zu dekodieren, kostet also nichts und
+      erscheint sofort."""
+
+[[howto]]
+title = "Wählen Sie ein Format und entscheiden Sie über die Details."
+body = """
+ JPEG, sofern Sie
+      keinen Grund für etwas anderes haben: Es ist das Format, das überall
+      öffnet, und genau darum geht es beim Umwandeln. Der Qualitätsregler steht
+      auf 92 &mdash; die Einstellung, bei der eine Fotografie vom Original kaum
+      zu unterscheiden ist. Das Häkchen entscheidet, ob Datum, Kamera und Ort
+      mitkommen."""
+
+[[howto]]
+title = "Klicken Sie auf &bdquo;Umwandeln&ldquo; und laden Sie herunter."
+body = """
+ Der Decoder trifft bei
+      der ersten Umwandlung ein &mdash; rund 1,4 MB, einmal &mdash; und jedes
+      Foto danach wird auf Ihrem eigenen Gerät dekodiert und geschrieben. Eine
+      Datei gibt Ihnen eine Download-Schaltfläche; mehrere geben Ihnen zusätzlich
+      ein ZIP."""
+
+[[faq]]
+q = "Wird mein Foto irgendwohin hochgeladen?"
+a = """
+        Nein. Die Datei wird von Ihrem eigenen Browser auf Ihrer eigenen Hardware
+        gelesen, dekodiert und geschrieben. Dieses Werkzeug hat keinerlei
+        Netzfunktion &mdash; es ruft nie etwas ab und sendet nie etwas &mdash; und
+        die <code>Content-Security-Policy</code> der Seite nennt jede Adresse, die
+        sie kontaktieren darf; keine davon gehört zu dieser Seite. Das eine, was
+        tatsächlich lädt, ist der Decoder selbst, und der kommt von dieser Seite,
+        einmal, bevor Ihr Foto überhaupt beteiligt ist."""
+
+[[faq]]
+q = "Warum lädt diese Seite beim ersten Mal 1,4 MB herunter?"
+a = """
+        Weil HEIC das eine Bildformat ist, das ein Browser nicht öffnet. Es ist
+        ein HEVC-Einzelbild in einem Box-Container, und nur Safari, auf
+        Apple-Hardware, hat einen Decoder dafür; Chrome, Firefox und Edge weisen
+        die Datei schlicht ab. Ein HEIC-Umwandler braucht seinen Decoder also
+        irgendwoher, und dafür gibt es zwei Orte: einen Server oder die Seite.
+        Jeder andere Umwandler hat den Server gewählt, und genau deshalb brauchen
+        sie alle Ihre Fotos hochgeladen. Dieser trägt stattdessen
+        <code>libheif</code>, nach WebAssembly kompiliert. Es wird von dieser
+        Seite ausgeliefert, nach dem ersten Besuch zwischengespeichert, und es ist
+        der ganze Preis dafür, dass Ihre Fotos nirgendwohin gehen."""
+
+[[faq]]
+q = "Behält das JPEG Datum, Kamera und Ort?"
+a = """
+        Wenn Sie wollen &mdash; es ist ein Häkchen auf der Seite. Bleibt es
+        gesetzt, wird der EXIF-Block aus dem HEIC herauskopiert und genau so ins
+        JPEG geschrieben, wie das Telefon ihn geschrieben hat; das umgewandelte
+        Foto sortiert sich also weiter nach dem Aufnahmetag statt nach dem Tag der
+        Umwandlung &mdash; und das ist die übliche Klage über HEIC-Umwandler. Ein
+        Tag wird geändert, und nur eines: die Orientierung, die auf
+        &bdquo;aufrecht&ldquo; gesetzt wird, weil die Drehung bereits auf die
+        Pixel angewendet wurde und ein Betrachter, der sie noch einmal anwendete,
+        jedes Hochformatfoto auf die Seite legen würde. Nehmen Sie das Häkchen
+        heraus, und das JPEG kommt mit dem Bild und sonst nichts heraus."""
+
+[[faq]]
+q = "Entfernt es GPS-Koordinaten?"
+a = """
+        Es sagt Ihnen, dass sie da sind, und tut dann, worum Sie bitten. Die Zeile
+        zu jedem Foto sagt, ob die Datei Koordinaten trägt, bevor irgendetwas
+        umgewandelt wird &mdash; das ist mehr, als das Telefon tut. Nehmen Sie das
+        Häkchen bei &bdquo;Datum, Kamera und Einstellungen behalten&ldquo; heraus,
+        bleiben sie samt allem anderen aus dem JPEG; lassen Sie es gesetzt, kommen
+        sie mit. Wollen Sie die Tags im Detail durchsehen oder sie aus Fotos
+        entfernen, die schon JPEGs sind, ist der
+        <a href="../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>
+        das Werkzeug dafür &mdash; und er tut es, ohne das Bild neu zu
+        komprimieren."""
+
+[[faq]]
+q = "Wird das Bild neu komprimiert?"
+a = """
+        Ja, und das muss es: HEIC und JPEG sind verschiedene Codecs, es gibt also
+        keinen Weg vom einen zum anderen, ohne das Bild zu dekodieren und erneut
+        zu kodieren. Steuern können Sie, was das kostet. Der Qualitätsregler steht
+        standardmäßig auf 92, wo eine Fotografie vom Original sehr schwer zu
+        unterscheiden ist, und PNG steht im Menü für den Fall, dass Sie
+        überhaupt keinen Verlust wollen und es Ihnen nichts ausmacht, dass die
+        Datei fünf- bis zehnmal so groß wird."""
+
+[[faq]]
+q = "Was, wenn die Datei .jpg heißt, aber in Wahrheit ein HEIC ist?"
+a = """
+        Dann geht es trotzdem. Jede hier abgelegte Datei wird an ihren ersten
+        Bytes erkannt und nicht an ihrem Namen, denn der Name ist das, wofür sich
+        die zuletzt beteiligte App entschieden hat &mdash; und ein HEIC, das als
+        &bdquo;.jpg&ldquo; ankam, ist einer der häufigsten Gründe, warum Menschen
+        nach einem Werkzeug wie diesem suchen. Eine Datei, die wirklich ein JPEG
+        oder ein PNG ist, wird mit einer entsprechenden Meldung abgelehnt, statt
+        in eine Kopie ihrer selbst umgewandelt zu werden."""
+
+[[faq]]
+q = "Kann es ein Live Photo oder eine Serienaufnahme umwandeln?"
+a = """
+        Die Standbilder darin, ja. Ein HEIC kann mehr als ein Bild halten, und
+        jedes, das es hält, wird umgewandelt und nach dem Original mit einer
+        angehängten Nummer benannt. Die Videohälfte eines Live Photos ist eine
+        eigene Datei, die das Telefon neben dem HEIC aufbewahrt, sie ist hier also
+        gar nicht zum Umwandeln vorhanden. Tiefenkarten und Vorschaubilder stecken
+        im Container, sind aber keine Bilder, um die jemand gebeten hätte, und
+        bleiben unangetastet."""
+
+[[faq]]
+q = "Warum nimmt es mein AVIF nicht?"
+a = """
+        Weil es damit nichts zu tun gibt. AVIF ist derselbe Container wie HEIC,
+        nur mit AV1 statt HEVC darin, und jeder aktuelle Browser dekodiert eines
+        von Haus aus &mdash; ein Umwandler würde also ein Megabyte Engine
+        ausliefern, um ein Problem zu lösen, das Sie nicht haben. Brauchen Sie ein
+        AVIF als JPEG, lesen der
+        <a href="../bild-komprimieren/">Bildkompressor</a> und das
+        <a href="../bildgroesse-aendern/">Bildgrößen-Ändern</a> beide AVIF und
+        schreiben JPEG &mdash; mit dem Decoder, den Ihr Browser ohnehin hat."""
+
+[[faq]]
+q = "Ist es kostenlos, und brauche ich ein Konto?"
+a = """
+        Es ist kostenlos, und es gibt kein Konto, keine Anmeldung, keine
+        Testphase und kein Wasserzeichen. Es gibt auch keine Grenze für Anzahl
+        oder Größe der Dateien, weil es keinen Server gibt, der dafür zahlt
+        &mdash; die Arbeit passiert auf Ihrem eigenen Gerät. Die Seite trägt
+        Werbung, und die bezahlt sie; den Anzeigen wird nichts über Ihre Fotos
+        übergeben."""
+
+[[faq]]
+q = "Funktioniert es offline?"
+a = """
+        Ja, Decoder inklusive. Laden Sie die Seite einmal, trennen Sie dann die
+        Internetverbindung, und sie arbeitet an Ihren Fotos genau wie vorher
+        weiter. Das ist zugleich der stärkste verfügbare Beweis dafür, dass nichts
+        hochgeladen wird: Ein Umwandler, der Ihre HEICs zum Dekodieren
+        wegschickte, würde in dem Moment stehen bleiben, in dem Sie den Stecker
+        ziehen &mdash; dieser tut es nicht."""
+
+[schema]
+description = "HEIC- und HEIF-Fotos von einem iPhone in JPEG, PNG oder WebP umwandeln. Der HEIC-Decoder ist WebAssembly, das von der Seite selbst ausgeliefert wird - die Bilder werden also auf Ihrem eigenen Gerät dekodiert und nie hochgeladen. Datum, Kamera und Ort können ins JPEG mitgenommen oder weggelassen werden."
+features = [
+  "Wandelt HEIC und HEIF in JPEG, PNG oder WebP um",
+  "Dekodiert im Browser, in jedem Browser - nicht nur in Safari",
+  "Es wird nichts hochgeladen, und das Werkzeug arbeitet mit getrennter Netzverbindung",
+  "Nimmt Datum, Kamera und GPS ins JPEG mit, oder lässt sie weg",
+  "Sagt vor jeder Umwandlung, welche Fotos GPS-Koordinaten enthalten",
+  "Korrigiert das Orientierungs-Tag, damit Hochformatfotos nicht quer herauskommen",
+  "Erkennt Dateien an ihrem Inhalt, ein HEIC namens .jpg funktioniert also trotzdem",
+  "Wandelt jedes Bild einer Serienaufnahme oder eines Live Photos um, nicht nur das erste",
+  "Stapelverarbeitung, alle Ergebnisse in einem ZIP",
+]
+
+[picker]
+title = "HEIC-Fotos hierher ziehen"
+hint = "oder klicken zum Auswählen &mdash; .heic und .heif, wie sie auch gerade heißen"

--- a/locales/de/tools/image-to-data-uri.html
+++ b/locales/de/tools/image-to-data-uri.html
@@ -1,0 +1,143 @@
+<main>
+  <!-- Schritt 1 &mdash; die Dateien -->
+  <section class="card">
+    <h2><span class="step">1</span> Bilder wählen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Alle von der Liste nehmen</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Schritt 2 &mdash; die Zeile, die am Ende wirklich eingefügt wird -->
+  <section class="card" id="shape-card">
+    <h2><span class="step">2</span> Sagen, wohin es geht</h2>
+
+    <p class="card-lede">
+      Eine Data-URI für sich ist selten das, was jemand will. Gewollt ist die
+      Zeile, die ins Stylesheet kommt &mdash; wählen Sie also die Zeile, und das
+      Bild trifft schon korrekt in Anführungszeichen darin ein. Das ist der
+      Teil, der leicht schiefgeht und der nur bei SVGs scheitert.
+    </p>
+
+    <div class="shapes" id="shapes" role="radiogroup" aria-label="Was eingefügt wird">
+      <label class="shape">
+        <input type="radio" name="shape" value="uri" checked>
+        <span class="shape-body">
+          <strong>Die Data-URI für sich</strong>
+          <span class="shape-note">
+            Alles nach dem Komma ist die Datei. Fügen Sie sie überall dort ein,
+            wo eine URL hingehört.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-rule">
+        <span class="shape-body">
+          <strong>Eine CSS-Regel</strong>
+          <span class="shape-note">
+            Eine ganze Regel, mit einer nach der Datei benannten Klasse. Ändern
+            Sie den Selektor auf das, was Sie wirklich gestalten.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-var">
+        <span class="shape-body">
+          <strong>Eine CSS-Custom-Property</strong>
+          <span class="shape-note">
+            Einmal oben im Stylesheet deklariert und als
+            <code>var(--name)</code> so oft verwendet, wie Sie mögen. Das ist
+            die Wahl, wenn das Bild in mehr als einer Regel vorkommt.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="html">
+        <span class="shape-body">
+          <strong>Ein HTML-<code>&lt;img&gt;</code>-Element</strong>
+          <span class="shape-note">
+            Mit eingetragener Pixelgröße, damit die Seite nicht springt, während
+            der Rest davon lädt.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="markdown">
+        <span class="shape-body">
+          <strong>Markdown</strong>
+          <span class="shape-note">
+            Für eine README oder ein Issue: ein Bild, das mit dem Text reist,
+            statt irgendwo gehostet werden zu müssen.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary">
+      Der <code>alt</code>-Text bleibt mit Absicht leer. Nur Sie wissen, ob das
+      Bild Bedeutung trägt oder Dekoration ist, und eine aus einem Dateinamen
+      geratene Beschreibung ist für jemanden mit einem Screenreader schlechter
+      als gar keine.
+    </p>
+
+    <fieldset class="options">
+      <legend>SVG</legend>
+
+      <label class="check">
+        <input type="checkbox" id="svg-base64">
+        <span>
+          <strong>Die SVGs ebenfalls base64-kodieren</strong>
+          <span class="check-note">
+            Standardmäßig aus, denn ein SVG ist Text und Base64 ist für Bytes.
+            Die Prozentkodierung lässt das Markup im Stylesheet lesbar und ist
+            meist ein Fünftel kürzer. Schalten Sie das ein für die seltene
+            Werkzeugkette, die auf <code>;base64</code> besteht.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Schritt 3 &mdash; das Ergebnis. Hier gibt es mit Absicht keine
+       Schaltfläche: Das Kodieren ist sofort fertig, es gibt also nichts,
+       worauf ein Klick auf "Umwandeln" warten müsste. -->
+  <section class="card" id="output-card">
+    <h2><span class="step">3</span> Kopieren</h2>
+
+    <p id="empty-note" class="card-lede">
+      Noch nichts gewählt. Ziehen Sie oben ein Bild hinein, und die Zeile zum
+      Einfügen erscheint hier.
+    </p>
+
+    <div id="results" hidden>
+      <div class="results-head">
+        <p id="results-summary" class="results-summary"></p>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Alle kopieren</button>
+          <button type="button" id="download-all" class="ghost">Als eine Datei herunterladen</button>
+        </div>
+      </div>
+
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/de/tools/image-to-data-uri.toml
+++ b/locales/de/tools/image-to-data-uri.toml
@@ -1,0 +1,327 @@
+#
+# Bild als Data-URI - German.
+#
+# Overrides for tools/image-to-data-uri/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Bild als Data-URI"
+heading = "Bild&nbsp;als&nbsp;Data-URI <span class=\"h1-kw\">&mdash; ein Bild für CSS oder HTML base64-kodieren</span>"
+tagline = "Das ganze Bild als eine Zeile Text. Direkt in CSS oder HTML einfügen."
+
+title = "Bild als Data-URI &mdash; Base64 für CSS, kostenlos, ohne Upload"
+description = "Ein PNG, JPEG, SVG oder WebP in eine Data-URI verwandeln, die Sie in CSS oder HTML einfügen können. SVGs werden prozentkodiert statt base64-kodiert, bleiben also lesbar und kürzer. Läuft im Browser; nichts wird hochgeladen."
+og_title = "Ein Bild in eine Zeile verwandeln, die Sie in CSS einfügen können"
+og_description = "Base64 für Bilder, Prozentkodierung für SVG, und die fertige Regel, Custom Property oder img-Zeile drumherum. Läuft auf Ihrem eigenen Gerät; nichts wird hochgeladen."
+og_image_alt = "Bild als Data-URI - das Bild ins Stylesheet einfügen"
+
+pledge = """
+    Die Kodierung läuft in Ihrem eigenen Browser, auf Ihrer eigenen Hardware.
+    Sie ist Rechnerei auf Bytes, die die Seite ohnehin hat: kein Encoder, kein
+    Server und kein Netzschritt, den man weglassen könnte. Dieses Werkzeug hat
+    keinerlei Netzfunktion &mdash; nichts abzurufen, nichts zu senden &mdash;
+    und es gibt am anderen Ende dieser Seite keinen Server, an den ein Bild
+    ginge, selbst wenn es einen Weg dorthin gäbe."""
+
+live_hint = """
+      Glauben Sie es uns nicht: Öffnen Sie die DevTools, beobachten Sie den Tab
+      &bdquo;Netzwerk&ldquo; und ziehen Sie ein Bild hinein. Keine einzige
+      Anfrage trägt ein Bild, ein Vorschaubild, einen Dateinamen oder ein Byte
+      Ihrer Auswahl. Oder trennen Sie die Internetverbindung und kodieren Sie
+      trotzdem eines."""
+
+read_first = """
+, <code>src/encode.js</code> für die beiden
+      Kodierungen und die Begründung für jede, <code>src/sniff.js</code> dafür,
+      wie der Medientyp aus der Datei gelesen wird und nicht aus ihrem Namen, und
+      <code>src/metadata.js</code> für die Prüfung, die sagt, wie viel von dem,
+      was Sie gleich einfügen, gar nicht das Bild ist."""
+
+howto_heading = "Ein Bild in eine Data-URI verwandeln"
+
+card = """
+            Base64 für Bilder, Prozentkodierung für SVG, und die CSS-Regel oder
+            das <code>&lt;img&gt;</code>-Element schon drumherum gebaut."""
+
+[words]
+plural = "Bilder"
+choose = "ein Bild"
+analytics_extra = """, und auch keine der
+  Dateinamen, Größen oder kodierten Texte, die dieses Werkzeug erzeugt"""
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Keine Neukodierung"
+
+[[facts]]
+text = "Funktioniert offline"
+
+[[facts]]
+text = "Quelloffen"
+
+[[privacy]]
+title = "Ihre Bilder haben keinen Weg nach draußen."
+body = """
+ Die
+      Content-Security-Policy nennt jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehört zu dieser Seite. Es gibt hier keinen Endpunkt,
+      an dem Ihre Dateien gesammelt werden könnten, und nichts im Code, das sie
+      senden würde, gäbe es einen."""
+
+[[privacy]]
+title = "Nichts hier ruft etwas ab."
+body = """
+ Es gibt weder
+      <code>fetch</code> noch <code>XMLHttpRequest</code> noch
+      <code>sendBeacon</code> irgendwo in <code>src/</code>. Die Kodierung ist
+      <code>btoa</code> und <code>encodeURIComponent</code> &mdash; zwei
+      Funktionen, die der Browser seit Anbeginn hat und die beide Bytes nehmen
+      und Text zurückgeben, ohne irgendwohin zu gehen."""
+
+[[privacy]]
+title = "Die Vorschau ist der Beweis."
+body = """
+ Das Bild neben jedem Ergebnis wird
+      aus der Data-URI gezeichnet, die diese Seite eben gebaut hat, und nicht aus
+      Ihrer Datei. Es erscheint, weil die URI korrekt ist &mdash; auf Ihrem
+      Gerät, ohne beteiligten Server. Und erscheint es nicht, sagt die Seite das,
+      statt Ihnen etwas Kaputtes zu geben."""
+
+[[privacy]]
+title = "Die Metadaten-Warnung ist auf Ihrer Seite."
+body = """
+ Eine Data-URI kopiert die
+      Datei exakt, die GPS-Position einer Fotografie reist also mit ihr in Ihr
+      Stylesheet. Diese Seite liest, wie viel davon da ist, und sagt es Ihnen
+      &mdash; denn die Alternative ist, dass Sie es erfahren, nachdem es
+      eingecheckt ist."""
+
+[[privacy]]
+title = "Was Google lädt - und was es nicht bekommt."
+body = """
+ Die Werbe- und
+      Messskripte kommen von Google, der Spenden-Button von Buy Me a Coffee.
+      Keinem davon wird irgendetwas über Ihre Bilder übergeben. Jede Zeile, die
+      eine Datei liest oder kodiert, wird von dieser Herkunft ausgeliefert und
+      ist im Repository aufgeführt."""
+
+[[privacy]]
+title = "Es funktioniert offline."
+body = """
+ Trennen Sie die Netzverbindung, und das
+      Werkzeug bleibt unverändert, weil es nie einen Netzschritt darin gab. Das
+      ist der einfachste Beweis von allen."""
+
+[[howto]]
+title = "Wählen Sie Ihre Bilder."
+body = """
+ Ziehen Sie sie auf das Auswahlfeld oder
+      wählen Sie sie von Hand. Der Browser liest sie direkt von Ihrer Festplatte;
+      dabei wird nichts irgendwohin gesendet."""
+
+[[howto]]
+title = "Sagen Sie, wohin das Ergebnis geht."
+body = """
+ Die URI für sich, eine
+      CSS-Regel, eine Custom Property, ein <code>&lt;img&gt;</code>-Element oder
+      Markdown. Jede davon setzt die URI in Anführungszeichen &mdash; und das ist
+      das Detail, das entscheidet, ob ein eingebettetes SVG funktioniert oder
+      stillschweigend nicht."""
+
+[[howto]]
+title = "Lesen Sie, was es gekostet hat."
+body = """
+ Jedes Ergebnis sagt, aus wie vielen
+      Zeichen es geworden ist, um wie viel größer das als die Datei ist, und ob
+      es eine gute Idee ist, etwas dieser Größe einzubetten. Base64 legt ein
+      Drittel drauf; ob dieses Drittel eine gesparte Anfrage wert ist, hängt
+      ganz von der Größe ab &mdash; die Seite sagt Ihnen also, auf welcher Seite
+      der Grenze Sie stehen."""
+
+[[howto]]
+title = "Achten Sie auf die Warnungen."
+body = """
+ Trägt das Bild EXIF, ein Farbprofil
+      oder XMP, wird das benannt, samt der Zahl der Bytes Ihres Ergebnisses, die
+      darauf entfallen. Widerspricht die Dateiendung dem tatsächlichen Format,
+      nimmt die Seite das Format und sagt es Ihnen. Kann Ihr Browser das Ergebnis
+      nicht zeichnen, sagt sie auch das."""
+
+[[howto]]
+title = "Kopieren oder herunterladen."
+body = """
+ Eine Schaltfläche je Ergebnis und
+      eine für alle auf einmal &mdash; die Custom Properties kommen in einen
+      <code>:root</code>-Block gewickelt heraus, fertig zum Einfügen oben in ein
+      Stylesheet."""
+
+[[faq]]
+q = "Wird mein Bild irgendwohin hochgeladen?"
+a = """
+        Nein. Die Datei wird von Ihrem eigenen Browser auf Ihrer eigenen Hardware
+        gelesen und kodiert, mit zwei Funktionen, die der Browser ohnehin hat.
+        Dieses Werkzeug hat keinerlei Netzfunktion &mdash; es ruft nie etwas ab
+        und sendet nie etwas &mdash; und die <code>Content-Security-Policy</code>
+        der Seite nennt jede Adresse, die sie kontaktieren darf; keine davon
+        gehört zu dieser Seite."""
+
+[[faq]]
+q = "Was ist eine Data-URI?"
+a = """
+        Eine Art, eine ganze Datei dorthin zu schreiben, wo sonst eine
+        Webadresse stünde. Statt <code>url("logo.png")</code>, was dem Browser
+        sagt, er solle etwas holen gehen, schreiben Sie
+        <code>url("data:image/png;base64,iVBORw0...")</code>, was das Bild selbst
+        enthält. Der Browser dekodiert es an Ort und Stelle. Praktisch bedeutet
+        das eine Anfrage weniger: Das Bild kommt mit dem Stylesheet oder der
+        Seite an statt danach."""
+
+[[faq]]
+q = "Warum ist mein SVG nicht base64?"
+a = """
+        Weil Base64 die falsche Kodierung dafür ist. Ein SVG ist Text, und eine
+        URL kann Text ohnehin tragen &mdash; nur eine Handvoll Zeichen muss
+        maskiert werden. Diese prozentzukodieren und den Rest in Ruhe zu lassen
+        ergibt eine URI, die typischerweise ein Fünftel kürzer ist als das Base64
+        derselben Datei und die Sie in Ihrem Stylesheet noch lesen können: Die
+        Elementnamen, die Farben und die <code>viewBox</code> stehen alle noch da
+        und lassen sich bearbeiten. Es gibt ein Häkchen, um Base64 zu erzwingen
+        &mdash; für die seltene Werkzeugkette, die darauf besteht."""
+
+[[faq]]
+q = "Wie viel größer macht Base64 mein Bild?"
+a = """
+        Um etwa ein Drittel. Aus drei Bytes Datei werden vier Zeichen Base64, das
+        sind 33&nbsp;% noch vor dem <code>data:image/png;base64,</code> davor.
+        Das ist die Untergrenze, und sie ist unvermeidlich: So viel kostet es,
+        beliebige Bytes mit nur den Zeichen zu schreiben, die eine URL erlaubt.
+        Und es ist auch der Grund, warum die Seite die Zeichenzahl neben die
+        Dateigröße stellt, statt Sie es herausfinden zu lassen, wenn das
+        Stylesheet ausgeliefert ist."""
+
+[[faq]]
+q = "Wann ist es tatsächlich eine gute Idee, ein Bild einzubetten?"
+a = """
+        Wenn es klein ist und sofort gebraucht wird. Ein 2&nbsp;KB großes Symbol
+        in einem Stylesheet, das jede Seite lädt, ist ein klarer Gewinn: eine
+        Rundreise weniger, und das Bild ist da, sobald das CSS da ist. Ab etwa
+        10&nbsp;KB kippt der Handel. Ein eingebettetes Bild ist keine eigene
+        Datei mehr, kann also nicht für sich zwischengespeichert werden, nicht
+        parallel zu etwas anderem geholt werden und wird jedes Mal vollständig
+        neu geladen, wenn sich die Datei drumherum ändert &mdash; eine
+        200&nbsp;KB große Fotografie in einem Stylesheet sind 200&nbsp;KB
+        zusätzlich auf dem kritischen Pfad jeder Seite der Website. Die Seite
+        sagt Ihnen, auf welche Seite dieser Grenze jedes Ergebnis fällt."""
+
+[[faq]]
+q = "Macht gzip den Base64-Aufschlag wieder wett?"
+a = """
+        Weniger, als man denkt. Base64 einer bereits komprimierten Datei &mdash;
+        und ein PNG, ein JPEG und ein WebP sind das alle &mdash; komprimiert
+        schlecht, weil dem Kompressor kaum noch Redundanz bleibt; zurück bekommen
+        Sie typischerweise etwa ein Zehntel des Drittels, das Base64
+        hinzugefügt hat, und nicht das Ganze. Ein prozentkodiertes SVG ist der
+        umgekehrte Fall: Es ist weiter Text, komprimiert sich also ungefähr so
+        gut wie vorher &mdash; noch ein Grund, keines zu base64-kodieren."""
+
+[[faq]]
+q = "Ändert das mein Bild überhaupt?"
+a = """
+        Nein, und das ist ein bewusster Unterschied zu den meisten Werkzeugen
+        hier. Nichts wird zu Pixeln dekodiert und erneut kodiert: Die Bytes, die
+        von Ihrer Festplatte kamen, sind die Bytes, die in die URI gehen. Ein
+        JPEG bleibt exakt das JPEG, das es war, in derselben Qualität, mit
+        denselben Abmessungen. Es ist der Grund, warum sich das Ergebnis als
+        dieselbe Datei beschreiben lässt und nicht als Kopie davon."""
+
+[[faq]]
+q = "Dann gehen meine EXIF- und GPS-Daten also auch ins Stylesheet?"
+a = """
+        Ja &mdash; und das ist der Teil, über den man vor dem Einfügen nachdenken
+        sollte. Weil nichts neu kodiert wird, reist alles mit, was die Kamera
+        geschrieben hat: der Ort, der Zeitstempel, die Seriennummer der Kamera.
+        Bei einem Handyfoto können das 30&nbsp;KB der Datei sein, aus denen
+        40&nbsp;KB Base64 auf dem kritischen Pfad Ihrer Seite werden &mdash; und
+        eine Wohnanschrift in etwas, das in ein Repository eingecheckt wird. Die
+        Seite liest, wie viele Metadaten in einem JPEG, PNG oder WebP stecken,
+        und sagt es. Um sie vorher herauszunehmen, nehmen Sie den
+        <a href="../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>."""
+
+[[faq]]
+q = "Warum hat es einen anderen Typ genommen als die Endung meiner Datei?"
+a = """
+        Weil die Endung falsch sein kann und die Bytes nicht. Eine Datei namens
+        <code>logo.png</code>, die in Wahrheit als JPEG exportiert wurde, ist
+        häufig genug, dass jedes Bildwerkzeug damit umgehen muss &mdash; und eine
+        Data-URI, die den falschen Typ angibt, erscheint schlicht nicht: Es gibt
+        keine Rückfalloption und keine lesenswerte Fehlermeldung. Der Typ wird
+        also aus den ersten Bytes der Datei gelesen, die in jedem Format hier
+        eindeutig sagen, was sie ist, und die Seite sagt Ihnen, wenn die beiden
+        sich widersprechen."""
+
+[[faq]]
+q = "Die Vorschau ist leer. Was ist schiefgegangen?"
+a = """
+        An der URI vermutlich nichts. HEIC und TIFF ergeben beide vollkommen
+        gültige Data-URIs, die kein Browser außer Safari zeichnet &mdash; das
+        Bild fehlt also auch überall dort, wo Sie sie einfügen. Wandeln Sie es
+        zuerst mit dem <a href="../bild-komprimieren/">Bildkompressor</a> oder
+        dem <a href="../bildgroesse-aendern/">Bildgrößen-Ändern</a> nach PNG,
+        JPEG oder WebP um. Ist das Format ein gewöhnliches, ist wahrscheinlich
+        die Datei selbst beschädigt: Die Vorschau wird aus der URI gezeichnet,
+        die diese Seite gebaut hat &mdash; eine leere heißt also, dass das Bild
+        nicht dekodiert hat."""
+
+[[faq]]
+q = "Gibt es eine Größengrenze für eine Data-URI?"
+a = """
+        Keine, der Sie in CSS oder in einem <code>&lt;img&gt;</code>-Element
+        begegnen; moderne Browser setzen dort keine praktische Grenze. Was
+        Browser begrenzen, ist das Eintippen einer Data-URI in die Adressleiste,
+        was die meisten inzwischen für alles Nichttriviale verweigern &mdash; aus
+        Sicherheitsgründen, die mit dieser Verwendung nichts zu tun haben. Die
+        echte Grenze ist die von oben: Lange bevor irgendetwas Technisches
+        bricht, ist die Seite, in der es steckt, langsamer geworden, als sie mit
+        einer gewöhnlichen Bilddatei gewesen wäre."""
+
+[[faq]]
+q = "Ist es kostenlos, und brauche ich ein Konto?"
+a = """
+        Es ist kostenlos, und es gibt kein Konto, keine Anmeldung, keine
+        Testphase und kein Wasserzeichen. Es gibt auch keine Grenze für Anzahl
+        oder Größe der Dateien, weil es keinen Server gibt, der dafür zahlt
+        &mdash; die Arbeit passiert auf Ihrem eigenen Gerät. Die Seite trägt
+        Werbung, und die bezahlt sie; den Anzeigen wird nichts über Ihre Bilder
+        übergeben."""
+
+[[faq]]
+q = "Funktioniert es offline?"
+a = """
+        Ja. Laden Sie die Seite einmal, trennen Sie dann die Internetverbindung,
+        und sie arbeitet weiter. Das ist zugleich der einfachste Beweis dafür,
+        dass nichts hochgeladen wird: Ein Werkzeug, das Ihre Bilder zum Kodieren
+        wegschickt, würde in dem Moment stehen bleiben, in dem Sie den Stecker
+        ziehen."""
+
+[schema]
+description = "Ein PNG, JPEG, SVG, WebP, GIF oder ICO in eine Data-URI umwandeln, fertig zum Einfügen in CSS oder HTML. Base64 für Rasterformate und Prozentkodierung für SVG, eingefasst in eine CSS-Regel, eine Custom Property, ein img-Element oder Markdown - mit Angabe der Größenkosten und der eingebetteten Metadaten. Läuft vollständig im Browser, ohne Upload."
+features = [
+  "Base64-Data-URIs für PNG, JPEG, WebP, GIF, ICO, AVIF und mehr",
+  "Prozentkodierte SVG-Data-URIs, kürzer als Base64 und weiterhin lesbar",
+  "Fertige CSS-Regel, CSS-Custom-Property, HTML-img-Element oder Markdown, immer korrekt in Anführungszeichen",
+  "Der Medientyp aus den eigenen Bytes der Datei gelesen, nicht aus ihrer Endung",
+  "Sagt, was die Kodierung an Zeichen gekostet hat, und ob Einbetten in dieser Größe sich lohnt",
+  "Warnt, wenn EXIF, XMP oder ein Farbprofil gleich in Ihr Stylesheet kopiert wird",
+  "Kopiert die Datei Byte für Byte: keine Neukodierung, kein Qualitätsverlust",
+  "Stapelverarbeitung, alles auf einmal kopiert oder als eine Datei heruntergeladen",
+  "Läuft offline; kein Upload, kein Konto",
+]
+
+[picker]
+title = "Bilder hierher ziehen"
+hint = "oder klicken zum Auswählen &mdash; PNG, JPEG, SVG, WebP, GIF, ICO und mehr"

--- a/locales/de/tools/qr-barcode.html
+++ b/locales/de/tools/qr-barcode.html
@@ -1,0 +1,187 @@
+<main>
+  <!-- Schritt 1 &mdash; welche Art Code -->
+  <section class="card">
+    <h2><span class="step">1</span> Die Art des Codes wählen</h2>
+
+    <p class="card-lede">
+      Ein QR-Code fasst alles und ist das, wonach eine Telefonkamera sucht. Ein
+      Barcode fasst eine Zahl, und welcher es sein muss, wird meist für Sie
+      entschieden &mdash; vom Geschäft, vom Lager oder von der Spedition, die ihn
+      verlangt.
+    </p>
+
+    <div class="option-row">
+      <label for="symbology">Art des Codes</label>
+      <select id="symbology">
+        <optgroup label="Quadratisch">
+          <option value="qr" selected>QR-Code</option>
+        </optgroup>
+        <optgroup label="Balken">
+          <option value="code128">Code 128</option>
+          <option value="ean13">EAN-13</option>
+          <option value="upca">UPC-A</option>
+          <option value="ean8">EAN-8</option>
+          <option value="itf14">ITF-14</option>
+          <option value="itf">Interleaved 2 of 5</option>
+          <option value="code39">Code 39</option>
+        </optgroup>
+      </select>
+    </div>
+
+    <p class="field-summary" id="symbology-note"></p>
+  </section>
+
+  <!-- Schritt 2 &mdash; die Zeichenkette selbst -->
+  <section class="card">
+    <h2><span class="step">2</span> Sagen, was hineinkommt</h2>
+
+    <div class="option-row" id="format-row">
+      <label for="format">Was er enthält</label>
+      <select id="format"></select>
+    </div>
+
+    <p class="card-lede" id="format-note"></p>
+
+    <div id="fields" class="fields"></div>
+
+    <p id="input-error" class="error" role="alert" hidden></p>
+
+    <!--
+      The finished string, shown rather than hidden. A "Wi-Fi QR code" is an
+      ordinary QR code holding a line of text in a format phones recognise, and
+      when a phone does not act on one, this line is the thing to look at.
+    -->
+    <details class="encoded" id="encoded-panel">
+      <summary>Die exakte Zeichenkette, die dieser Code enthalten wird</summary>
+      <pre id="encoded"></pre>
+      <p class="field-summary" id="encoded-note"></p>
+    </details>
+  </section>
+
+  <!-- Schritt 3 &mdash; wie er gezeichnet wird -->
+  <section class="card">
+    <h2><span class="step">3</span> Das Aussehen wählen</h2>
+
+    <fieldset class="options" id="qr-options">
+      <legend>Der QR-Code</legend>
+
+      <div class="option-row">
+        <label for="level">Wie viel Schaden er aushält</label>
+        <select id="level">
+          <option value="L">L &mdash; rund 7 % wiederherstellbar, kleinster Code</option>
+          <option value="M" selected>M &mdash; rund 15 %, die übliche Wahl</option>
+          <option value="Q">Q &mdash; rund 25 %</option>
+          <option value="H">H &mdash; rund 30 %, für einen Druck, der abgenutzt wird</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="quiet">Rand, in Modulen</label>
+        <input type="number" id="quiet" value="4" min="0" max="16" step="1" inputmode="numeric">
+      </div>
+
+      <p class="field-summary">
+        Der Rand ist Teil des Codes und nicht Platz darum herum. Vier Module
+        verlangt die Spezifikation, und ein bis an die Kante beschnittener Code
+        ist einer, den viele Scanner überhaupt nicht sehen.
+      </p>
+    </fieldset>
+
+    <fieldset class="options" id="barcode-options" hidden>
+      <legend>Der Barcode</legend>
+
+      <div class="option-row">
+        <label for="bar-width">Schmalster Balken, in Pixeln</label>
+        <input type="number" id="bar-width" value="2" min="1" max="10" step="1" inputmode="numeric">
+      </div>
+
+      <div class="option-row">
+        <label for="bar-height">Höhe der Balken, in Pixeln</label>
+        <input type="number" id="bar-height" value="120" min="20" max="600" step="10" inputmode="numeric">
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="show-text" checked>
+        <span>
+          <strong>Die Zeichen darunter drucken</strong>
+          <span class="check-note">
+            Was ein Mensch liest, wenn der Scanner nicht will. Bei einem
+            Handels-Code stehen die Ziffern zusätzlich in den Rändern, und das
+            ist Absicht: Sie markieren den weißen Raum, den niemand abschneiden
+            sollte.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="code39-check-row" hidden>
+        <input type="checkbox" id="code39-check">
+        <span>
+          <strong>Ein Prüfzeichen ergänzen</strong>
+          <span class="check-note">
+            Code 39 trägt normalerweise keines. Manche Systeme bestehen darauf;
+            ergänzen Sie es nur, wenn Ihres das tut &mdash; ein Lesegerät, das
+            keines erwartet, liest es als zusätzliches Zeichen am Ende.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Farbe und Größe</legend>
+
+      <div class="colour-row">
+        <div class="option-row">
+          <label for="foreground">Der Code</label>
+          <input type="color" id="foreground" value="#000000">
+        </div>
+        <div class="option-row">
+          <label for="background">Dahinter</label>
+          <input type="color" id="background" value="#ffffff">
+        </div>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="transparent">
+        <span>
+          <strong>Gar kein Hintergrund</strong>
+          <span class="check-note">
+            Transparent, zum Aufsetzen auf etwas, das schon eine Farbe hat. Das
+            SVG und das PNG behalten ihn beide; was am Ende dahinter liegt, muss
+            hell sein, sonst findet ein Scanner keinen Kontrast.
+          </span>
+        </span>
+      </label>
+
+      <div class="option-row" id="size-row">
+        <label for="size">Größe des Bildes, in Pixeln</label>
+        <input type="number" id="size" value="512" min="64" max="4096" step="16" inputmode="numeric">
+      </div>
+
+      <p class="field-summary" id="size-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Schritt 4 &mdash; das Ergebnis -->
+  <section class="card" id="result-card">
+    <h2><span class="step">4</span> Nehmen</h2>
+
+    <div class="preview" id="preview" role="img" aria-label="Der Code, den Sie erzeugt haben"></div>
+
+    <p class="facts" id="facts"></p>
+
+    <div class="run-row">
+      <button type="button" id="download-svg" class="primary">Das SVG herunterladen</button>
+      <button type="button" id="download-png" class="primary">Das PNG herunterladen</button>
+      <button type="button" id="copy-png" class="ghost">Das Bild kopieren</button>
+    </div>
+
+    <p class="field-summary" id="download-note" role="status"></p>
+
+    <p class="field-summary">
+      Das SVG ist das, was Sie aufheben sollten. Es ist der Code als Anweisungen
+      statt als Pixel, druckt also in jeder Größe, ohne weich zu werden &mdash;
+      was hier mehr zählt als bei den meisten Bildern, denn eine verwaschene
+      Kante ist genau das, was ein Scanner nicht auflösen kann.
+    </p>
+  </section>
+</main>

--- a/locales/de/tools/qr-barcode.toml
+++ b/locales/de/tools/qr-barcode.toml
@@ -1,0 +1,348 @@
+#
+# QR- & Barcode-Generator - German.
+#
+# Overrides for tools/qr-barcode/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "QR-Code" and "Barcode" stay as they are: both are the German words, and no
+# translation of either is what anybody types.
+#
+
+name = "QR- & Barcode-Generator"
+heading = "QR-Code&nbsp;&amp;&nbsp;Barcode <span class=\"h1-kw\">&mdash; offline erzeugen</span>"
+tagline = "Eintippen, und es wird ein Code. Zum Erzeugen wird nichts gesendet."
+
+title = "QR-Code- &amp; Barcode-Generator &mdash; kostenlos, ohne Anmeldung, ohne Upload"
+description = "Einen QR-Code für einen Link, ein WLAN oder eine Kontaktkarte erzeugen, oder einen EAN-13-, UPC-A-, Code-128- oder Code-39-Barcode. Als SVG oder PNG herunterladen. Alles passiert in Ihrem Browser."
+og_title = "Einen QR-Code oder Barcode erzeugen, ohne irgendjemandem etwas zu senden"
+og_description = "Links, WLAN-Passwörter, Kontaktkarten und die Handels-Barcodes, in Ihrem eigenen Browser gezeichnet und als SVG oder PNG heruntergeladen. Kein Konto, kein Wasserzeichen, kein Zählpixel mitten in Ihrem Code."
+og_image_alt = "QR- & Barcode-Generator - einen QR-Code oder Barcode erzeugen, ohne Upload"
+
+pledge = """
+    Ein QR-Code ist Rechnerei über einer Zeichenkette: Es gibt keine Datei zu
+    senden und keinen Dienst zu fragen. Jeder Schritt &mdash; die Wahl des
+    Modus, die Version, die Reed-Solomon-Fehlerkorrektur, die Maske, die Balken
+    eines Barcodes und die Prüfziffer darunter &mdash; passiert in rund tausend
+    Zeilen JavaScript auf dieser Seite, die Sie lesen können. Dieses Werkzeug
+    hat keinerlei Netzfunktion, und das zählt hier mehr als auf den meisten
+    Seiten: Was kodiert wird, ist oft ein WLAN-Passwort."""
+
+live_hint = """
+      Glauben Sie es uns nicht: Öffnen Sie die DevTools, beobachten Sie den Tab
+      &bdquo;Netzwerk&ldquo; und tippen Sie ein Passwort in das WLAN-Formular.
+      Keine einzige Anfrage trägt ein Zeichen davon. Oder trennen Sie die
+      Internetverbindung und erzeugen Sie den Code trotzdem."""
+
+read_first = """
+, <code>src/qr-encode.js</code>
+      und <code>src/qr.js</code> für den QR-Code selbst &mdash; die Modi, die
+      Version und die Blöcke im einen, die Muster, die Maske und die Formatbits
+      im anderen &mdash;, <code>src/gf256.js</code> für die Fehlerkorrektur und
+      <code>src/barcode.js</code> für die gestreiften."""
+
+howto_heading = "Einen QR-Code erzeugen, ohne etwas hochzuladen"
+
+card = """
+            Ein QR-Code für einen Link, ein WLAN oder eine Kontaktkarte &mdash;
+            oder ein Handels-Barcode mit ausgerechneter Prüfziffer. SVG oder
+            PNG."""
+
+[words]
+plural = "Codes und der Text darin"
+choose = "den Inhalt"
+analytics_extra = """, und auch kein
+  einziges Zeichen dessen, was Sie eintippen"""
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Kein Ablaufdatum"
+
+[[facts]]
+text = "Funktioniert offline"
+
+[[facts]]
+text = "Quelloffen"
+
+[[privacy]]
+title = "Für das, was Sie eintippen, gibt es keinen Weg nach draußen."
+body = """
+ Die
+      Content-Security-Policy nennt jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehört zu dieser Seite. Es gibt hier keinen Endpunkt,
+      an dem ein WLAN-Passwort gesammelt werden könnte, und nichts im Code, das
+      es senden würde, gäbe es einen."""
+
+[[privacy]]
+title = "Nichts hier ruft etwas ab."
+body = """
+ Es gibt weder
+      <code>fetch</code> noch <code>XMLHttpRequest</code> noch
+      <code>sendBeacon</code> irgendwo in <code>src/</code>. Der Code wird durch
+      Rechnen aus der Zeichenkette gebaut und als SVG gezeichnet &mdash; auf
+      dieser Seite, auf Ihrem Gerät."""
+
+[[privacy]]
+title = "Der Code zeigt nicht auf uns."
+body = """
+ Was Sie eintippen, ist das, was der
+      Code enthält. Mehrere kostenlose Generatoren geben Ihnen einen Code
+      zurück, der einen Link auf ihre eigene Seite enthält, die dann auf Ihre
+      weiterleitet &mdash; jeder Scan wird also von ihnen gezählt, und der Code
+      hört an dem Tag auf zu funktionieren, an dem sie die Domain nicht mehr
+      bezahlen oder befinden, die kostenlose Stufe sei abgelaufen. Hier wird
+      nichts gekürzt, weitergeleitet oder gezählt: Die Zeichenkette auf der Seite
+      ist die Zeichenkette im Bild."""
+
+[[privacy]]
+title = "Das PNG entsteht aus dem SVG, das auf dem Schirm steht."
+body = """
+ Der Download ist
+      keine zweite Zeichnung, die von der Vorschau abweichen könnte. Dasselbe
+      Markup wird dem Browser übergeben und auf eine Leinwand gemalt &mdash; und
+      genau deshalb geht es, ohne irgendetwas zu kontaktieren: Es gibt darin
+      keine Schrift zu holen und kein Bild zu laden."""
+
+[[privacy]]
+title = "Was Google lädt - und was es nicht bekommt."
+body = """
+ Die Werbe- und
+      Messskripte kommen von Google, der Spenden-Button von Buy Me a Coffee.
+      Keinem davon wird irgendetwas übergeben, was Sie eintippen. Jede Zeile, die
+      aus einer Zeichenkette einen Code macht, wird von dieser Herkunft
+      ausgeliefert und ist im Repository aufgeführt."""
+
+[[privacy]]
+title = "Es funktioniert offline."
+body = """
+ Trennen Sie die Netzverbindung, und das
+      Werkzeug bleibt unverändert, weil es nie einen Netzschritt darin gab. Das
+      ist der einfachste Beweis von allen."""
+
+[[howto]]
+title = "Wählen Sie die Art des Codes."
+body = """
+ Ein QR-Code fasst alles und ist
+      das, wonach eine Telefonkamera sucht &mdash; also die Antwort, sofern Ihnen
+      niemand etwas anderes gesagt hat. Ein Barcode fasst eine Zahl, und welcher
+      es sein muss, entscheidet, wer ihn scannen wird: Ein Geschäft will einen
+      EAN-13 oder einen UPC-A, ein Versandkarton einen ITF-14, und alles Interne
+      ist meist Code 128."""
+
+[[howto]]
+title = "Sagen Sie, was hineinkommt."
+body = """
+ Ein Link ist der häufige Fall, und
+      die Felder darüber bauen die anderen Formate, die Telefone kennen: ein
+      WLAN, das anbietet, sich selbst beizutreten, eine Kontaktkarte, die
+      anbietet, gespeichert zu werden, eine E-Mail, eine SMS, eine Telefonnummer,
+      ein Ort auf einer Karte. Was Sie auch wählen: Die fertige Zeichenkette
+      steht auf der Seite &mdash; mehr enthält ein QR-Code nie."""
+
+[[howto]]
+title = "Entscheiden Sie, wie viel Schaden er aushalten darf."
+body = """
+ Die vier Stufen legen
+      mehr oder weniger Fehlerkorrektur hinein, und mehr Korrektur heißt ein
+      größerer, dichterer Code. L reicht für einen Bildschirm, M für gewöhnliches
+      Papier und H für etwas, das angefasst, klein gedruckt oder in der Sonne an
+      ein Fenster geklebt wird. Ein Code auf einer Speisekarte, die täglich
+      abgewischt wird, ist Q oder H wert."""
+
+[[howto]]
+title = "Setzen Sie Größe, Rand und Farben."
+body = """
+ Der Rand ist Teil des Codes: Vier
+      Module ruhige Fläche ringsherum verlangt die Spezifikation, und ihn zu
+      beschneiden ist der mit Abstand häufigste Grund, warum ein gedruckter Code
+      nicht scannt. Dunkel auf Hell, mit echtem Kontrast &mdash; ein Scanner
+      liest den Unterschied zwischen beiden, blasses Grau auf Weiß genügt also
+      nicht, und Hell auf Dunkel scheitert bei etlichen Lesegeräten rundweg."""
+
+[[howto]]
+title = "Prüfen Sie ihn mit dem Telefon, das Sie haben."
+body = """
+ Bevor Sie tausend davon
+      drucken, scannen Sie den auf Ihrem Bildschirm. Das dauert zehn Sekunden und
+      fängt die ganze Sorte Fehler ab, die eine Vorschau nicht zeigen kann: ein
+      WLAN-Passwort mit einem Zeichen, das maskiert werden musste, ein Link, dem
+      das <code>https://</code> fehlte, eine Barcode-Nummer mit einer Ziffer zu
+      wenig."""
+
+[[howto]]
+title = "Nehmen Sie das SVG."
+body = """
+ Es ist der Code als Anweisungen statt als
+      Pixel, druckt also in jeder Größe, ohne weich zu werden &mdash; und eine
+      weiche Kante ist genau das, was ein Scanner nicht auflösen kann. Nehmen Sie
+      zusätzlich das PNG, wenn das, wohin Sie es einfügen, kein SVG annimmt; es
+      wird mit einer ganzen Pixelzahl je Modul gezeichnet und hat deshalb
+      ebenfalls keine verwaschenen Kanten."""
+
+[[faq]]
+q = "Wird irgendetwas, was ich eintippe, irgendwohin gesendet?"
+a = """
+        Nein. Ein QR-Code ist Rechnerei über einer Zeichenkette, und diese
+        Rechnerei läuft in Ihrem eigenen Browser auf Ihrem eigenen Gerät. Dieses
+        Werkzeug hat keinerlei Netzfunktion &mdash; es ruft nie etwas ab und
+        sendet nie etwas &mdash; und die <code>Content-Security-Policy</code> der
+        Seite nennt jede Adresse, die sie kontaktieren darf; keine davon gehört zu
+        dieser Seite. Das ist hier mehr wert als auf den meisten Seiten, denn was
+        Menschen am häufigsten in einen QR-Code legen, ist das Passwort ihres
+        WLANs."""
+
+[[faq]]
+q = "Laufen diese Codes ab oder hören sie später auf zu funktionieren?"
+a = """
+        Nein, und sie können es gar nicht. Was Sie eintippen, ist das, was der
+        Code enthält &mdash; ihn zu scannen gibt also für immer genau diese
+        Zeichenkette zurück. Die Codes, die ablaufen, sind die mit der Adresse
+        eines anderen darin: Ein &bdquo;dynamischer&ldquo; QR-Code enthält einen
+        Link auf den Server des Generators, der auf Ihren weiterleitet &mdash;
+        womit jener jeden Scan zählen, das Ziel ändern oder es abschalten kann,
+        wenn eine Testphase endet. Hier wird durch nichts weitergeleitet."""
+
+[[faq]]
+q = "Ist es kostenlos, und darf ich es gewerblich nutzen?"
+a = """
+        Es ist kostenlos, es gibt kein Konto, kein Wasserzeichen und keine Grenze
+        dafür, wie viele Sie erzeugen, und Sie dürfen das Ergebnis auf ein
+        Produkt, ein Plakat oder eine Ladenfront setzen. QR Code ist eine
+        eingetragene Marke von Denso Wave, die erklärt haben, sie nicht gegen
+        Menschen durchzusetzen, die die Codes verwenden &mdash; die Spezifikation
+        ist als ISO/IEC 18004 veröffentlicht und frei umzusetzen, und genau das
+        tut diese Seite. Die Seite trägt Werbung, und die bezahlt sie."""
+
+[[faq]]
+q = "Welche Fehlerkorrekturstufe soll ich nehmen?"
+a = """
+        M, sofern Sie keinen Grund für etwas anderes haben. L ergibt den
+        kleinsten Code und reicht auf einem Bildschirm; M übersteht gewöhnliche
+        Behandlung; Q und H sind für einen Code, der klein gedruckt, laminiert,
+        an ein Fenster geklebt oder teilweise von einem Logo verdeckt wird. Jede
+        Stufe legt mehr Prüfdaten hinein, was bei gleicher Textmenge ein größeres
+        Symbol braucht &mdash; von L auf H zu gehen verdoppelt die Modulzahl für
+        dieselbe Zeichenkette ungefähr."""
+
+[[faq]]
+q = "Wie viel fasst ein QR-Code?"
+a = """
+        In der größten Größe, 177 Module im Quadrat, bis zu 7.089 Ziffern, 4.296
+        Großbuchstaben und Ziffern oder 2.953 Byte von allem anderen &mdash; und
+        das bei der schwächsten Fehlerkorrektur; bei der stärksten ist es etwa
+        ein Drittel davon. Praktisch ist die Grenze nicht das Format, sondern der
+        Scanner: Jenseits einiger hundert Zeichen werden die Module so klein,
+        dass eine gewöhnliche Telefonkamera sie auf Armlänge nicht mehr auflöst.
+        Ein langer Code ist meist ein Zeichen dafür, dass ein kurzer Link
+        hineingehört."""
+
+[[faq]]
+q = "Warum ist mein Code größer, wenn ich den Link klein schreibe?"
+a = """
+        Weil ein QR-Code einen Modus für Großbuchstaben und Ziffern hat, der zwei
+        Zeichen in elf Bit packt, und keinen solchen für Kleinbuchstaben, die je
+        acht Bit kosten. Eine als <code>HTTPS://EXAMPLE.COM/SEITE</code>
+        geschriebene URL kann ein Drittel kleiner sein als dieselbe URL in
+        Kleinbuchstaben. Schema und Host sind unabhängig von der Groß- und
+        Kleinschreibung, sie zu schreien ändert also nichts außer der Größe; der
+        Pfad nach dem Host ist es nicht &mdash; den lassen Sie in Ruhe."""
+
+[[faq]]
+q = "Kann es einen QR-Code auch lesen und nicht nur erzeugen?"
+a = """
+        Noch nicht. Einen zu lesen heißt, ein Bild zu dekodieren &mdash; das
+        Symbol in einer Fotografie zu finden, den Aufnahmewinkel
+        herauszurechnen und den Schaden zu reparieren &mdash;, und das ist eine
+        andere und erheblich größere Aufgabe, als einen zu zeichnen. Es ließe
+        sich hier zu denselben Bedingungen bauen wie alles andere, und es steht
+        auf der Liste. Bis dahin kann die Kamera Ihres Telefons es bereits, und
+        sie kann es gut."""
+
+[[faq]]
+q = "Wofür ist der Rand, und kann ich ihn kleiner machen?"
+a = """
+        Der weiße Raum um einen QR-Code ist Teil des Codes. Ein Lesegerät nutzt
+        ihn, um zu finden, wo das Symbol endet, und die Spezifikation verlangt
+        vier Module auf jeder Seite; ein Barcode will etwa zehn. Sie können ihn
+        hier auf null setzen, das Bild sieht dann aufgeräumter aus, und eine ganze
+        Reihe Scanner wird es daraufhin gar nicht mehr sehen &mdash; besonders
+        vor einem unruhigen Hintergrund. Ist der Platz das Problem, machen Sie
+        den Code kleiner, statt seinen Rand zu beschneiden."""
+
+[[faq]]
+q = "Welchen Barcode brauche ich?"
+a = """
+        Den, nach dem die Person fragt, die ihn scannt. EAN-13 ist der
+        Handels-Barcode außerhalb Nordamerikas und UPC-A der nordamerikanische
+        &mdash; beide brauchen eine Nummer, die Ihnen GS1 zuteilt, denn die
+        Nummer identifiziert Ihr Unternehmen und nicht nur das Produkt. EAN-8 ist
+        die Kurzfassung für kleine Verpackungen. ITF-14 kommt auf den
+        Versandkarton. Code 128 und Code 39 fassen neben Ziffern auch Text und
+        brauchen überhaupt keine Registrierung &mdash; was sie zur richtigen
+        Antwort für alles Interne macht: Anlagen, Regale, Auftragszettel."""
+
+[[faq]]
+q = "Was ist eine Prüfziffer, und warum hat das Werkzeug eine ergänzt?"
+a = """
+        Sie ist die letzte Ziffer eines Handels-Barcodes, aus den vorherigen
+        ausgerechnet, damit ein Scanner einen Lesefehler von einem Treffer
+        unterscheiden kann. EAN-13 will zwölf Ziffern und berechnet die
+        dreizehnte; UPC-A will elf und berechnet die zwölfte. Tippen Sie die
+        kurze Nummer, und diese Seite ergänzt sie. Tippen Sie die volle Nummer,
+        prüft sie die, die Sie gegeben haben &mdash; und weigert sich, statt sie
+        stillschweigend zu korrigieren, denn eine leise reparierte falsche Ziffer
+        ist ein Etikett, das als fremdes Produkt scannt."""
+
+[[faq]]
+q = "Kann ich ein Logo in die Mitte eines QR-Codes setzen?"
+a = """
+        Hier nicht, aber der Grund, warum es anderswo funktioniert, ist
+        wissenswert: Möglich macht es die Fehlerkorrektur. Auf Stufe H lassen
+        sich rund 30&nbsp;% der Module zerstören und der Code ist noch lesbar
+        &mdash; ein Logo, das deutlich weniger als das in der Mitte verdeckt, wo
+        kein Suchmuster sitzt, ist also reparabler Schaden. Schicken Sie den Code
+        auf Stufe H durch Ihr Bildbearbeitungsprogramm, halten Sie das Logo unter
+        etwa einem Fünftel der Fläche, und testen Sie ihn mit einem echten
+        Telefon, statt ihm zu vertrauen."""
+
+[[faq]]
+q = "Warum ist das SVG besser als das PNG?"
+a = """
+        Weil ein Code aus Kanten besteht und ein PNG eine feste Pixelzahl hat,
+        aus der es sie machen muss. Vergrößern Sie eines, und jede Kante wird
+        weich; eine weiche Kante ist genau das, womit ein Scanner Mühe hat, und
+        ein Drucker mit 1200 dpi, dem man ein 512-Pixel-PNG gibt, soll den
+        Unterschied erfinden. Ein SVG sind die Quadrate als Anweisungen, es
+        druckt also scharf auf einer Visitenkarte wie auf einer Plakatwand. Das
+        PNG hier wird mit einer ganzen Pixelzahl je Modul gezeichnet, und das ist
+        das Beste, was ein PNG kann."""
+
+[[faq]]
+q = "Funktioniert es offline?"
+a = """
+        Ja. Laden Sie die Seite einmal, trennen Sie dann die Internetverbindung,
+        und sie arbeitet weiter. Das ist zugleich der einfachste Beweis dafür,
+        dass nichts hochgeladen wird: Ein Werkzeug, das Ihren Text wegschickt,
+        um einen Code zeichnen zu lassen, würde in dem Moment stehen bleiben, in
+        dem Sie den Stecker ziehen."""
+
+[schema]
+description = "Aus einer Zeichenkette im Browser einen QR-Code oder einen linearen Barcode erzeugen. QR-Codes für Links, WLANs, Kontaktkarten, E-Mail, SMS, Telefonnummern und Koordinaten, mit allen vier Fehlerkorrekturstufen; EAN-13-, EAN-8-, UPC-A-, ITF-14-, Interleaved-2-of-5-, Code-128- und Code-39-Barcodes samt Prüfziffern. Als SVG oder PNG herunterladen. Es wird nichts hochgeladen."
+features = [
+  "QR-Codes in jeder Version von 1 bis 40, im numerischen, alphanumerischen und Byte-Modus",
+  "Alle vier Fehlerkorrekturstufen, mit ausgesprochenen Kosten je Stufe",
+  "Fertige Formate: WLAN, Kontaktkarte, E-Mail, SMS, Telefonnummer, Kartenposition",
+  "Zeigt die exakte Zeichenkette, die der Code enthalten wird, statt sie zu verbergen",
+  "EAN-13, EAN-8 und UPC-A, mit ausgerechneter oder geprüfter Prüfziffer",
+  "ITF-14 und Interleaved 2 of 5 für Kartons und Lagerhaltung",
+  "Code 128 mit automatischer Nutzung seines numerischen Modus, und Code 39 mit optionalem Prüfzeichen",
+  "Menschenlesbare Ziffern unter einem Barcode, an den richtigen Stellen",
+  "SVG als Ausgabe, damit es in jeder Größe scharf druckt, und ein PNG mit ganzer Pixelzahl je Modul",
+  "Beliebige zwei Farben, oder gar kein Hintergrund",
+  "Leitet nie weiter: kein Kurzlink, keine Zählung, nichts, was ablaufen kann",
+  "Läuft offline; kein Upload, kein Konto",
+]

--- a/locales/de/tools/video-to-gif.html
+++ b/locales/de/tools/video-to-gif.html
@@ -1,0 +1,169 @@
+<main>
+  <!-- Schritt 1 &mdash; die Datei -->
+  <section class="card">
+    <h2><span class="step">1</span> Ein Video wählen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Datei</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Größe</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Bild</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Länge</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Gelesen von</dt><dd id="src-path">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Schritt 2 &mdash; der Abschnitt -->
+  <section class="card" id="section-card" hidden>
+    <h2><span class="step">2</span> Den Abschnitt wählen</h2>
+
+    <p class="hint">
+      Spielen Sie den Clip ab und markieren Sie den gewünschten Teil.
+      <kbd>I</kbd> setzt den Anfang dorthin, wo der Abspielkopf steht,
+      <kbd>O</kbd> das Ende, und beide Griffe auf dem Balken lassen sich ziehen.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- The bar itself is built by src/range.js. -->
+    <div id="rangebar"></div>
+    <div class="rb-scale">
+      <span>0:00.000</span>
+      <span id="scale-end">&mdash;</span>
+    </div>
+
+    <div class="marks">
+      <label>Anfang
+        <input type="text" id="start-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-in" class="ghost" title="Den Anfang dorthin setzen, wo der Abspielkopf steht (I)">
+        Auf Abspielkopf setzen
+      </button>
+
+      <label>Ende
+        <input type="text" id="end-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-out" class="ghost" title="Das Ende dorthin setzen, wo der Abspielkopf steht (O)">
+        Auf Abspielkopf setzen
+      </button>
+
+      <div class="mark-actions">
+        <button type="button" id="play-section" class="ghost">Abschnitt abspielen</button>
+        <button type="button" id="whole-clip" class="ghost">Ganzer Clip</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Schritt 3 &mdash; das GIF -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Größe und Bildrate</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="width">Breite</label>
+        <select id="width">
+          <option value="240">240 px</option>
+          <option value="320">320 px</option>
+          <option value="480" selected>480 px</option>
+          <option value="640">640 px</option>
+          <option value="source">Originalgröße</option>
+          <option value="custom">Genau&hellip;</option>
+        </select>
+        <p class="field-note">
+          Die Höhe folgt, das Seitenverhältnis ändert sich also nie. Die Breite
+          ist das, was ein GIF kostet: halbe Breite ist ein Viertel der Pixel.
+        </p>
+        <p class="field-note" id="width-note" hidden></p>
+      </div>
+
+      <div class="field" id="custom-width-field" hidden>
+        <label for="custom-width">Genaue Breite</label>
+        <input type="number" id="custom-width" min="16" max="1920" step="1" value="480">
+        <p class="field-note">In Pixeln, zwischen 16 und 1920.</p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Bilder pro Sekunde</label>
+        <select id="fps">
+          <option value="5">5 &mdash; am kleinsten</option>
+          <option value="10">10</option>
+          <option value="12" selected>12 &mdash; flüssig genug</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+          <option value="25">25 &mdash; am flüssigsten</option>
+        </select>
+        <p class="field-note">
+          Nicht die eigene Rate des Videos: Die Einzelbilder werden daraus
+          abgetastet. Zwölf liest sich als Bewegung; über zwanzig wächst die
+          Datei schneller, als die Flüssigkeit sichtbar wird.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Dithering</label>
+        <select id="dither">
+          <option value="on" selected>An &mdash; weichere Verläufe</option>
+          <option value="off">Aus &mdash; flacher, kleiner</option>
+        </select>
+        <p class="field-note">
+          Mischt zwei Palettenfarben, wo die richtige fehlt. Geordnet, damit ein
+          stehender Hintergrund nicht flimmert.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="loop">
+          <input type="checkbox" id="loop" checked>
+          Endlos wiederholen
+        </label>
+        <p class="field-note">Aus spielt es einmal durch und hört auf.</p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Abschnitt</dt><dd id="sum-section">&mdash;</dd></div>
+      <div><dt>Ausgabe</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Einzelbilder</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Ungefähre Dateigröße</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="memory-note" class="field-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Das GIF erzeugen</button>
+      <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <img id="result-image" alt="Die fertige Animation, spielend">
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>GIF herunterladen</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/de/tools/video-to-gif.toml
+++ b/locales/de/tools/video-to-gif.toml
@@ -1,0 +1,259 @@
+#
+# Video zu GIF - German.
+#
+# Overrides for tools/video-to-gif/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Video zu GIF"
+heading = "Video&nbsp;zu&nbsp;GIF <span class=\"h1-kw\">&mdash; ein Video in ein GIF umwandeln</span>"
+tagline = "Abschnitt, Größe und Bildrate selbst wählen."
+
+title = "Video-zu-GIF-Umwandler &mdash; kostenlos, ohne Upload, auch offline"
+description = "Einen Teil eines MP4, MOV oder WebM in ein animiertes GIF verwandeln. Wählen Sie Abschnitt, Breite und Bildrate; die Einzelbilder werden in Ihrem Browser gelesen und das GIF dort geschrieben. Kein Upload."
+og_title = "Video zu GIF &mdash; ein GIF machen, ohne den Clip hochzuladen"
+og_description = "Markieren Sie die gewünschten Sekunden, wählen Sie Breite und Bildrate, und bekommen Sie ein animiertes GIF. Abtastung, Palette, Dithering und LZW passieren alle auf Ihrem eigenen Gerät."
+og_image_alt = "Video zu GIF - ein animiertes GIF im Browser machen, ohne dass etwas hochgeladen wird"
+
+pledge = """
+    Jedes Einzelbild wird von Ihrem eigenen Browser auf Ihrer eigenen Hardware
+    gelesen, skaliert, quantisiert und geschrieben. Nichts hier kann etwas
+    abrufen oder senden &mdash; dieses Werkzeug hat überhaupt keine Netzfunktion
+    &mdash; und am anderen Ende dieser Seite gibt es keinen Server, an den ein
+    Video ginge, selbst wenn es einen Weg dorthin gäbe."""
+
+live_hint = """
+      Glauben Sie es uns nicht: Öffnen Sie die DevTools, beobachten Sie den Tab
+      &bdquo;Netzwerk&ldquo; und erzeugen Sie ein GIF. Keine einzige Anfrage
+      trägt ein Einzelbild, einen Dateinamen oder ein Byte Ihrer Auswahl. Oder
+      trennen Sie die Internetverbindung und erzeugen Sie trotzdem eines &mdash;
+      ein Werkzeug, das Ihr Video zum Umwandeln wegschickt, würde schlicht stehen
+      bleiben."""
+
+read_first = """
+, <code>src/frames.js</code> für die beiden Wege, auf
+      denen die Einzelbilder aus einem Video gelesen werden,
+      <code>src/quantize.js</code> für die Palette und <code>src/gif.js</code>
+      für die Datei selbst, LZW inklusive. Keines davon importiert etwas, das
+      eine Anfrage stellen könnte."""
+
+howto_heading = "Ein Video in ein GIF verwandeln"
+
+card = """
+            Markieren Sie die gewünschten Sekunden, wählen Sie Breite und
+            Bildrate, und bekommen Sie ein animiertes GIF &mdash; samt Palette
+            und Dithering."""
+
+[words]
+plural = "Videos"
+choose = "ein Video"
+analytics_extra = """, und auch kein
+  Einzelbild, keine Dauer und keine Größe"""
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Kein Wasserzeichen"
+
+[[facts]]
+text = "Beliebige Länge"
+
+[[facts]]
+text = "Funktioniert offline"
+
+[[privacy]]
+title = "Ihre Videos haben keinen Weg nach draußen."
+body = """
+ Die
+      Content-Security-Policy nennt jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehört zu dieser Seite. Es gibt hier keinen Endpunkt,
+      an dem Ihre Datei gesammelt werden könnte, und nichts im Code, das sie
+      senden würde, gäbe es einen."""
+
+[[privacy]]
+title = "Nichts hier ruft etwas ab."
+body = """
+ Dieses Werkzeug hat überhaupt keine
+      Netzfunktion: keine Adresse zum Einfügen, nichts herunterzuladen, keine
+      Engine, die beim ersten Gebrauch nachgeladen wird. Jedes Byte, das Ihr
+      Video berührt, kam beim Laden der Seite von dieser Herkunft."""
+
+[[privacy]]
+title = "Das Dekodieren ist lokal."
+body = """
+ Die Einzelbilder laufen durch WebCodecs
+      in Ihrem eigenen Browser oder durch dieselbe Wiedergabe-Engine, die Ihnen
+      den Clip ohnehin zeigen würde. Welcher von beiden genommen wurde, steht
+      oben auf der Seite &mdash; denn es ändert, wie die Einzelbilder gewählt
+      werden, und das sollten Sie sehen können."""
+
+[[privacy]]
+title = "Das GIF wird hier geschrieben, in Code, den Sie lesen können."
+body = """
+ Palette,
+      Dithering und LZW-Kompression sind rund sechshundert Zeilen im eigenen
+      Ordner dieses Werkzeugs. Es gibt keinen Encoder-Dienst, keine zur Laufzeit
+      nachgeladene Bibliothek und in alldem keine Stelle, an der ein Bild
+      gesendet werden könnte."""
+
+[[privacy]]
+title = "Was Google lädt - und was es nicht bekommt."
+body = """
+ Die Werbe- und
+      Messskripte kommen von Google. Keinem von beiden wird irgendetwas über Ihr
+      Video übergeben: keine Datei, kein Einzelbild, kein Name, keine Größe,
+      keine Länge und nicht der Abschnitt, den Sie markiert haben. Jede Zeile,
+      die liest, abtastet, quantisiert oder kodiert, wird von dieser Herkunft
+      ausgeliefert und ist im Repository aufgeführt."""
+
+[[privacy]]
+title = "Was der Spenden-Button lädt - und was er nicht bekommt."
+body = """
+      Der Button &bdquo;Buy me a coffee&ldquo; in der Kopfzeile wird von einem
+      Skript von cdnjs.buymeacoffee.com gezeichnet und holt seine Schrift von
+      Google Fonts. Er ist ein Link und nicht mehr: Er meldet keinen Besuch, und
+      ihm wird nichts über Sie oder Ihr Video übergeben."""
+
+[[privacy]]
+title = "Es funktioniert offline."
+body = """
+ Trennen Sie die Netzverbindung, und alles auf
+      dieser Seite arbeitet weiter. Das ist der einfachste Beweis von allen."""
+
+[[howto]]
+title = "Wählen Sie ein Video."
+body = """
+ Ziehen Sie ein MP4, MOV, M4V oder WebM
+      auf das Auswahlfeld oder wählen Sie eines von Hand. Der Browser liest es
+      direkt von Ihrer Festplatte; dabei wird nichts irgendwohin gesendet."""
+
+[[howto]]
+title = "Markieren Sie den Abschnitt."
+body = """
+ Spielen Sie den Clip ab und drücken
+      Sie <kbd>I</kbd>, wo er beginnen soll, und <kbd>O</kbd>, wo er enden soll
+      &mdash; oder ziehen Sie die Griffe auf dem Balken. Ein GIF ist ein paar
+      Sekunden lang, und das ist die Einstellung, die entscheidet, ob die Datei
+      klein oder riesig wird &mdash; weit mehr als die anderen beiden."""
+
+[[howto]]
+title = "Wählen Sie Breite und Bildrate."
+body = """
+ 480 Pixel Breite und 12 Bilder pro
+      Sekunde passen zu den meisten Zwecken, für die es ein GIF gibt. Die Breite
+      zu halbieren viertelt die Pixel; zwölf Bilder pro Sekunde lesen sich als
+      Bewegung, ohne für die zu zahlen, die niemand sieht."""
+
+[[howto]]
+title = "Erzeugen und herunterladen."
+body = """
+ Die Einzelbilder werden gelesen, eine
+      Palette aus 256 Farben wird für die ganze Animation gewählt, und jedes
+      Einzelbild wird nur als der Teil des Bildes geschrieben, der sich geändert
+      hat. Es spielt auf der Seite ab, wenn es fertig ist &mdash; und das ist
+      dieselbe Datei, die der Download Ihnen gibt."""
+
+[[faq]]
+q = "Wird mein Video irgendwohin hochgeladen?"
+a = """
+        Nein. Es wird von Ihrem eigenen Browser auf Ihrer eigenen Hardware
+        gelesen, abgetastet und umgewandelt. Dieses Werkzeug hat keine
+        Serverseite, und die <code>Content-Security-Policy</code> der Seite nennt
+        jede Adresse, die sie kontaktieren darf &mdash; keine davon gehört zu
+        dieser Seite. Trennen Sie die Internetverbindung und erzeugen Sie
+        trotzdem ein GIF, wenn Sie lieber prüfen als glauben."""
+
+[[faq]]
+q = "Welche Videoformate kann ich umwandeln?"
+a = """
+        MP4, M4V und MOV werden direkt gelesen, egal was darin steckt: H.264,
+        HEVC, AV1 oder VP9, solange Ihr Browser diesen Codec dekodieren kann.
+        Alles andere, was Ihr Browser abspielen kann &mdash; allen voran WebM
+        &mdash; wird stattdessen gelesen, indem der Player auf jeden Zeitpunkt
+        gesprungen wird; das ist langsamer und etwas weniger genau darin, welches
+        Einzelbild wo landet. Eine Datei, die der Browser weder lesen noch
+        abspielen kann &mdash; in der Praxis AVI, WMV, FLV und die meisten MKVs
+        &mdash; wird mit einer entsprechenden Meldung abgelehnt, statt auf halbem
+        Weg zu scheitern."""
+
+[[faq]]
+q = "Warum ist mein GIF so groß?"
+a = """
+        Weil GIF ein Format von 1987 ist, das ganze Bilder speichert und keine
+        Bewegung. Es gibt keine Möglichkeit, aus einem fünf Sekunden langen Clip
+        eines zu machen, das so klein ist wie das fünf Sekunden lange MP4, aus
+        dem es kam &mdash; ein GIF eines Videos ist routinemäßig zehnmal so groß
+        wie das Video. Die drei Einstellungen, die es tatsächlich entscheiden,
+        sind der Reihe nach: wie lang der Abschnitt ist, wie breit das Bild ist
+        und wie viele Bilder pro Sekunde. Die Breite zu halbieren viertelt die
+        Pixel, und die Pixel sind es, die kosten."""
+
+[[faq]]
+q = "Warum nur 256 Farben?"
+a = """
+        Das ist das Format: Ein GIF trägt eine Tabelle von höchstens 256 Farben
+        und speichert jedes Pixel als Nummer darin. Dieses Werkzeug wählt diese
+        256, indem es die Farben in jedem Einzelbild Ihres Abschnitts zählt und
+        sie in 256 Gruppen teilt &mdash; Median Cut, die Standardmethode &mdash;,
+        die Palette passt also zu Ihrem Clip statt ein fester Farbsatz zu sein.
+        Wo eine Farbe fehlt, mischt das Dithering die beiden nächstgelegenen, so
+        dass ein Verlauf ein Verlauf bleibt und nicht zu Streifen wird."""
+
+[[faq]]
+q = "Was macht die Dithering-Einstellung?"
+a = """
+        Sie tauscht ein wenig Rauschen gegen viel weniger Streifenbildung. Ist
+        sie an, bleibt ein Himmel, der sonst zu vier flachen Bändern würde, ein
+        Verlauf &mdash; um den Preis einer feinen Textur und einer größeren
+        Datei. Ist sie aus, wird das Bild flacher und die Datei kleiner, was zu
+        Bildschirmaufnahmen, Strichzeichnungen und allem passt, was ohnehin aus
+        flachen Farbflächen besteht. Das hier verwendete Dithering ist geordnet
+        und nicht die fehlerverteilende Art, damit ein unveränderter Hintergrund
+        zwischen den Einzelbildern vollkommen still steht statt zu flimmern."""
+
+[[faq]]
+q = "Gibt es eine Grenze für Länge oder Größe?"
+a = """
+        Begrenzt ist der Abschnitt, und zwar durch den Arbeitsspeicher und nicht
+        durch eine Regel: Jedes seiner Einzelbilder wird gleichzeitig gehalten,
+        während die Palette gewählt wird &mdash; die Seite rechnet also aus, was
+        Ihre Einstellungen kosten würden, und sagt es Ihnen vor dem Start. Sie
+        weigert sich, statt den Tab den Speicher aufbrauchen und verschwinden zu
+        lassen. Ein kürzerer Abschnitt, eine kleinere Breite oder eine niedrigere
+        Bildrate bringen ihn alle herunter."""
+
+[[faq]]
+q = "Behält es den Ton?"
+a = """
+        Ein GIF kann keinen Ton tragen. Es gibt keine Fassung des Formats mit
+        Audio &mdash; und das ist der Hauptgrund, warum das Web GIFs
+        größtenteils durch stumm laufende Videos ersetzt hat. Ist der Ton
+        wichtig, behalten Sie das Video: Der
+        <a href="../video-schneiden/">Video-Schneider</a> schneidet einen
+        Abschnitt heraus, ohne ein einziges Einzelbild neu zu kodieren."""
+
+[[faq]]
+q = "Ist es kostenlos, und brauche ich ein Konto?"
+a = """
+        Es ist kostenlos, und es gibt kein Konto, keine Anmeldung, keine
+        Testphase und kein Wasserzeichen. Die Seite trägt Werbung, und die
+        bezahlt sie; den Anzeigen wird nichts über Ihr Video übergeben."""
+
+[schema]
+browser_requirements = "Benötigt JavaScript. Für MP4 und MOV braucht es einen Browser mit WebCodecs; alles, was der Browser abspielen kann, geht auch ohne."
+description = "Einen Abschnitt eines Videos im Browser in ein animiertes GIF umwandeln. Die Einzelbilder werden mit der gewählten Rate abgetastet, eine 256-Farben-Palette wird per Median Cut für die ganze Animation gewählt, und jedes Einzelbild wird nur als der veränderte Bereich geschrieben. Es wird nichts hochgeladen."
+features = [
+  "Wandelt MP4-, MOV-, M4V- und WebM-Video in ein animiertes GIF um",
+  "H.264-, HEVC-, AV1- und VP9-Quellen, dekodiert über WebCodecs",
+  "Den Abschnitt auf einer Zeitleiste markieren oder exakte Zeiten eintippen",
+  "Beliebige Breite, 5 bis 25 Bilder pro Sekunde, optionales geordnetes Dithering",
+  "Läuft offline; kein Upload, kein Konto, kein Wasserzeichen",
+]
+
+[picker]
+title = "Video hierher ziehen"
+hint = "oder klicken zum Auswählen &mdash; MP4, MOV, M4V, WebM und alles andere, was dieser Browser abspielt"

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -246,13 +246,41 @@ class BuildTheSite(unittest.TestCase):
         cls.unfinished = [locale['lang'] for locale in cls.locales
                           if not locale['is_base'] and not locale['complete']]
 
+        # And which individual PAGES are advertised, which is no longer the same
+        # question. A published language still holds back the pages it has not
+        # translated, so the sitemap is a set of pages rather than a set of
+        # languages. Worked out the way the build works it out, from the same
+        # survey, so the test cannot drift from the rule it is checking.
+        tools = [buildmod.sitelib.load_tool(path, site)
+                 for path in sorted((ROOT / 'tools').glob('*/tool.toml'))]
+        prose = [buildmod.sitelib.load_page(path, site, ROOT / 'pages')
+                 for path in sorted((ROOT / 'pages').glob('**/page.toml'))]
+        planned = buildmod.sitelib.load_toml(ROOT / 'config' / 'planned.toml')
+        buildmod.i18n.survey(cls.locales, tools, prose, planned, site)
+
+        slugs = ([''] + [tool['slug'] for tool in tools]
+                 + [page['slug'] for page in prose]
+                 + [site['guides']['slug'], site['roadmap']['slug']])
+        cls.advertised = {
+            buildmod.i18n.locale_path(locale, slug).strip('/')
+            for locale in cls.locales for slug in slugs
+            if buildmod.i18n.translated(locale, slug)
+        }
+
     @classmethod
     def tearDownClass(cls):
         cls.tmp.cleanup()
 
     def unpublished(self, name):
-        """Whether a written page belongs to a language that is not finished."""
-        return any(name.startswith(f'{lang}/') for lang in self.unfinished)
+        """Whether a written page is one the site does not advertise.
+
+        Two reasons a page is not advertised, and both end up here: its language
+        has not finished the frame, or its language has finished the frame and
+        not this page.
+        """
+        if any(name.startswith(f'{lang}/') for lang in self.unfinished):
+            return True
+        return name[:-len('index.html')].strip('/') not in self.advertised
 
     def test_it_reports_what_it_wrote(self):
         self.assertIn('index.html', self.written)
@@ -337,11 +365,13 @@ class BuildTheSite(unittest.TestCase):
     def test_the_sitemap_lists_every_page_of_a_published_language(self):
         """Every page that is offered to a reader is offered to a crawler.
 
-        Published, not built. A locale whose locale.toml says complete = false
-        is built - so it can be read and reviewed at a real address - and is
-        kept out of the sitemap until it is finished. The companion test below
-        checks the other half of that, which is the half that matters: nothing
-        half-translated is ever advertised.
+        Published, not built - and published a page at a time. A locale whose
+        locale.toml says complete = false is built, so it can be read and
+        reviewed at a real address, and is kept out of the sitemap entirely. A
+        locale that IS published still keeps out the individual pages it has not
+        translated yet. The companion test below checks the other half of that,
+        which is the half that matters: nothing half-translated is ever
+        advertised.
         """
         sitemap = (self.out / 'sitemap.xml').read_text(encoding='utf-8')
         site = buildmod.sitelib.load_toml(ROOT / 'config' / 'site.toml')

--- a/tests/python/test_i18n.py
+++ b/tests/python/test_i18n.py
@@ -38,7 +38,7 @@ def locale(**over):
         'lang': 'de', 'name': 'German', 'endonym': 'Deutsch', 'hreflang': 'de',
         'dir': 'ltr', 'complete': False, 'is_base': False, 'prefix': 'de/',
         'slugs': {}, 'site': SITE, 'tools': {}, 'pages': {}, 'bodies': {},
-        'planned': {}, 'missing': [],
+        'planned': {}, 'frame': [], 'debt': {},
     }
     base.update(over)
     return base
@@ -75,13 +75,26 @@ class Merging(unittest.TestCase):
             self.merge({'a': 'one'}, {'a': 'eins', 'b': 'zwei'})
         self.assertIn('b', str(caught.exception))
 
-    def test_a_list_of_a_different_length_is_refused(self):
-        # Merged in order, so five questions against four is not a shorter
-        # translation - it is one question that will render in English with
-        # nothing on the page to say which.
+    def test_a_list_longer_than_the_english_is_refused(self):
+        # Merged in order, so a locale may be behind the English but cannot be
+        # ahead of it: the extra entry has nothing to translate.
         with self.assertRaises(ConfigError) as caught:
-            self.merge({'faq': ['a', 'b', 'c']}, {'faq': ['a', 'b']})
+            self.merge({'faq': ['a', 'b']}, {'faq': ['a', 'b', 'c']})
         self.assertIn('3', str(caught.exception))
+
+    def test_a_shorter_list_falls_back_and_is_counted(self):
+        """English grows a category; ten locales do not break that afternoon.
+
+        This used to raise, and raising was wrong. A list that is short is a
+        locale that was finished before English added an entry - which is the
+        ordinary state of every locale here, most weeks. The tail falls back and
+        is counted like any other untranslated string.
+        """
+        missing = []
+        merged = self.merge({'cats': ['one', 'two', 'three']},
+                            {'cats': ['eins']}, missing)
+        self.assertEqual(merged['cats'], ['eins', 'two', 'three'])
+        self.assertEqual(missing, ['x.cats[1]', 'x.cats[2]'])
 
     def test_a_changed_type_is_refused(self):
         with self.assertRaises(ConfigError):
@@ -159,7 +172,8 @@ class TheRoadmapList(unittest.TestCase):
     def test_english_is_returned_unchanged(self):
         planned = {'note': 'x', 'group': []}
         self.assertIs(
-            i18n.localize_planned(planned, i18n.base_locale(SITE)), planned)
+            i18n.localize_planned(planned, i18n.base_locale(SITE), 'roadmap'),
+            planned)
 
     def test_an_untranslated_list_is_counted_against_the_locale(self):
         planned = {
@@ -168,10 +182,11 @@ class TheRoadmapList(unittest.TestCase):
                        'items': [['Rotate', 'quarter turns'], ['Filters', 'blur']]}],
         }
         de = locale()
-        i18n.localize_planned(planned, de)
-        # note + name + two items of two strings each.
-        self.assertEqual(len(de['missing']), 6)
-        self.assertIn('planned.group[0].items[0][0]', de['missing'])
+        i18n.localize_planned(planned, de, 'roadmap')
+        # note + name + two items of two strings each, charged to the roadmap
+        # page rather than to the language as a whole.
+        self.assertEqual(len(de['debt']['roadmap']), 6)
+        self.assertIn('planned.group[0].items[0][0]', de['debt']['roadmap'])
 
 
 class Slugs(unittest.TestCase):
@@ -200,20 +215,91 @@ class Slugs(unittest.TestCase):
 
 
 class Completeness(unittest.TestCase):
-    def test_an_unfinished_locale_may_fall_back(self):
-        i18n.check_complete(locale(complete=False, missing=['x.y']))
+    """What `complete = true` claims, and what it no longer claims.
 
-    def test_a_finished_locale_may_not(self):
+    It used to mean "every string in this language is translated", and English
+    grows a tool most weeks, so it was a claim that expired on its own. Now it
+    means "the frame around every page is translated" - a set that does not grow
+    when a tool ships - and an untranslated PAGE is held back by itself.
+    """
+
+    def test_an_unfinished_locale_may_fall_back(self):
+        i18n.check_complete(locale(complete=False, frame=['x.y']))
+
+    def test_a_finished_locale_may_not_fall_back_on_the_frame(self):
         with self.assertRaises(ConfigError) as caught:
-            i18n.check_complete(locale(complete=True, missing=['hub.lede']))
+            i18n.check_complete(locale(complete=True, frame=['hub.lede']))
         message = str(caught.exception)
         self.assertIn('hub.lede', message)
         # The error has to say what to do about it, because the right answer is
         # often "not yet" rather than "translate this now".
         self.assertIn('complete = false', message)
 
+    def test_a_finished_locale_may_still_owe_whole_pages(self):
+        """The change that lets English ship a tool without breaking ten builds.
+
+        A page nobody has translated yet is not an error. It falls back, it is
+        readable at its own URL, and `translated` is what keeps it out of the
+        sitemap and out of every hreflang set until somebody gets to it.
+        """
+        de = locale(complete=True, debt={'gif-maker': ['tools.gif-maker.body']})
+        i18n.check_complete(de)
+        self.assertFalse(i18n.translated(de, 'gif-maker'))
+        self.assertTrue(i18n.translated(de, 'compress-image'))
+
+    def test_an_unfinished_locale_publishes_no_page_at_all(self):
+        """Every page in it would be wearing an English nav."""
+        de = locale(complete=False)
+        self.assertFalse(i18n.translated(de, 'compress-image'))
+
     def test_english_is_complete_by_definition(self):
-        i18n.check_complete({'is_base': True, 'complete': True, 'missing': ['x']})
+        i18n.check_complete({'is_base': True, 'complete': True, 'frame': ['x']})
+        self.assertTrue(i18n.translated({'is_base': True}, 'anything'))
+
+
+class FallingBackInsideALanguage(unittest.TestCase):
+    """An English body sitting at a German address.
+
+    This could not happen before: a language with a fallback left in it was
+    never published, so nobody could reach the page. Holding pages back one at a
+    time means English prose now appears inside a published language, and the
+    links inside it were written for the English tree.
+    """
+
+    def relocate(self, html, slug, slugs=None):
+        de = locale(slugs=slugs if slugs is not None else
+                    {'trim-video': 'video-schneiden'})
+        return i18n.relocate(html, de, slug)
+
+    def test_a_link_is_pointed_at_the_translated_address(self):
+        found = self.relocate('<a href="../trim-video/">Trim</a>', 'reverse-video')
+        self.assertIn('href="/de/video-schneiden/"', found)
+
+    def test_a_page_with_no_translated_slug_keeps_its_english_one(self):
+        """It is falling back too, and lives at its English address here."""
+        found = self.relocate('<a href="../gif-maker/">GIF</a>', 'reverse-video')
+        self.assertIn('href="/de/gif-maker/"', found)
+
+    def test_a_guide_two_levels_down_resolves_from_its_own_folder(self):
+        found = self.relocate('<a href="../../trim-video/">Trim</a>',
+                              'guides/reverse-a-video')
+        self.assertIn('href="/de/video-schneiden/"', found)
+
+    def test_an_asset_is_left_where_it_is(self):
+        found = self.relocate('<img src="../../assets/x.svg">', 'guides/a-guide')
+        self.assertIn('src="/assets/x.svg"', found)
+
+    def test_an_absolute_or_external_link_is_untouched(self):
+        for href in ('https://example.com/x/', '/de/already/', '#section',
+                     'mailto:a@b.c'):
+            with self.subTest(href=href):
+                found = self.relocate(f'<a href="{href}">x</a>', 'a-tool')
+                self.assertIn(f'href="{href}"', found)
+
+    def test_a_fragment_survives_the_rewrite(self):
+        found = self.relocate('<a href="../trim-video/#faq">Trim</a>',
+                              'reverse-video')
+        self.assertIn('href="/de/video-schneiden/#faq"', found)
 
 
 class Advertising(unittest.TestCase):


### PR DESCRIPTION
Two changes. The second depends on the first.

## Publishing is now judged per page

`complete = true` meant *every string in this language is translated*, enforced by failing the build on any fallback. That reads like the strict option, but English is not finished either — a tool ships most weeks and arrives untranslated in every language at once, so the rule broke the build for ten languages every time English grew. German hit it three times while being written; the third time it was holding up nine other languages that had nothing to do with it.

The unit is now the page:

- a **page** that falls back is built and readable at its own address, and kept out of the sitemap, every hreflang set and the switcher until it is translated — the treatment an unfinished *language* used to get, given to the part that is actually unfinished;
- the **frame** (nav, footer, hub, `[ui]`) is still judged whole, because it is drawn around every page and there is no per-page way to hold it back. That is what `complete = true` now claims, and it is a set that does not grow when a tool ships;
- a **list shorter than English** falls back entry by entry instead of raising. Behind English is allowed; ahead is not.

Two consequences that are easy to miss, both with tests:

- **`survey`** works out every language's debt *before* the first page renders. The hreflang set on the English page is a fact about German, and English renders first — computing debt as each language went by had English advertising a German page that was still English, the exact reciprocity failure the rule exists to prevent. This was a real bug, caught by checking the output rather than the build's exit code.
- **`relocate`** rewrites links in a body that falls back. An English body at a German address carries links written for the English tree, so `../trim-video/` led nowhere. Each is resolved against the English page it was written on and re-emitted as a root-absolute address in this language. A page with no translated slug maps to itself, which is right rather than a gap.

## Restoring German

The squash that became #48 was taken from a point four commits back, so the German for **HEIC to JPG, image to data URI, QR and barcode, and video to GIF** — and their four guides — never reached `main`. Sixteen files, restored here with the German addresses for all eight.

Their slugs are added to **main's** `locale.toml`, not the one those commits carried: main's has since gained the two hub categories that shipped with the text tools, and that half is not mine to revert.

German is published, and the build now reports what is outstanding instead of refusing to run:

```
de: published, 8 of 40 pages still in English (built and readable, kept out of the sitemap)
```

## Checks

- `python build.py --clean` — exit 0, 475 pages, link check passing over all published pages
- `python -m unittest discover -s tests/python -t .` — **314 tests, OK** (305 before; 9 new cover `relocate` and the frame/page split)
- Verified in the output, not just the exit code: English `/gif-maker/` no longer advertises `hreflang="de"`; English `/compress-image/` still does; German fallback pages link to `/de/…` throughout.

## Note for the nine other locale PRs

They were all written against a 15-tool `main` and are now behind a 19-tool one. Before this change that made them unmergeable — six untranslated categories and eight untranslated pages were each a build failure. With this merged they can land as they are, publishing what they have translated and holding back the rest. They will each need their stale copy of `locales/de/` dropped in favour of main's, which is the one conflict they all share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)