### PR TITLE
Rewrite the German guides so they read as German

### DIFF
--- a/locales/de/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/de/pages/guides/combine-images-into-a-pdf.html
@@ -2,209 +2,202 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie <a href="../../bilder-in-pdf-umwandeln/">Bilder in PDF</a>,
-      ziehen Sie die Bilder hinein, schieben Sie die Kacheln zurecht, bis die
-      Reihenfolge stimmt, und erzeugen Sie das Dokument. Die Voreinstellungen
-      &mdash; A4-Seiten, ein kleiner Rand, Fotos ohne Neukodierung übernommen
-      &mdash; sind das, was die meisten wollen.
+      ziehen Sie die Bilder hinein, schieben Sie die Kacheln in die richtige
+      Reihenfolge und erzeugen Sie das Dokument. Mit den Voreinstellungen
+      &mdash; A4, ein schmaler Rand, Fotos unverändert übernommen &mdash;
+      fahren die meisten genau richtig.
     </p>
     <p>
-      Vier Dinge sind einen zweiten Gedanken wert: die Reihenfolge, die
-      Seitengröße, die Qualitätseinstellung und das, was das fertige Dokument
-      über Sie aussagt. In der Reihenfolge, in der sie am häufigsten schiefgehen.
-    </p>
-  </section>
-
-  <section>
-    <h2>Bringen Sie zuerst die Reihenfolge in Ordnung</h2>
-    <p>
-      Die Seitenreihenfolge ist das, was am häufigsten schiefgeht, weil sich
-      Dateinamen anders sortieren, als irgendjemand erwartet.
-      <code>IMG_2.jpg</code> kommt in einer alphabetischen Sortierung nach
-      <code>IMG_10.jpg</code>, denn verglichen wird Zeichen für Zeichen, und
-      <code>1</code> steht vor <code>2</code>. Ein Ordner mit Scans, die
-      <code>seite1</code> bis <code>seite12</code> heißen, kommt in fast jedem
-      Werkzeug in der falschen Reihenfolge an.
-    </p>
-    <p>
-      Nach Aufnahmedatum zu sortieren ist bei Fotos meist verlässlicher, weil Sie
-      die Seiten in der Reihenfolge fotografiert haben, in der sie lagen. So oder
-      so: Prüfen Sie die Kacheln vor dem Klick, statt hinterher das PDF zu
-      prüfen.
+      Vier Punkte lohnen einen zweiten Blick, hier in der Reihenfolge, in der
+      sie erfahrungsgemäß schiefgehen: die Reihenfolge der Seiten, das
+      Seitenformat, die Qualitätseinstellung und das, was das fertige Dokument
+      über Sie preisgibt.
     </p>
   </section>
 
   <section>
-    <h2>Qualität: der Teil, den die meisten Werkzeuge stillschweigend falsch machen</h2>
+    <h2>Zuerst die Reihenfolge</h2>
     <p>
-      Ein PDF kann JPEG-Daten direkt aufnehmen. Das ist eine Eigenschaft des
-      Formats: Die komprimierten Bytes eines JPEGs lassen sich so, wie sie sind,
-      in das Dokument legen, und der Reader dekodiert sie genauso, wie ein
-      Browser es täte.
+      Nichts geht so oft schief wie die Seitenreihenfolge, und schuld ist die
+      Sortierung nach Dateinamen. Alphabetisch wird Zeichen für Zeichen
+      verglichen, und weil <code>1</code> vor <code>2</code> steht, landet
+      <code>IMG_10.jpg</code> vor <code>IMG_2.jpg</code>. Ein Ordner mit Scans
+      von <code>seite1</code> bis <code>seite12</code> kommt deshalb in
+      praktisch jedem Werkzeug durcheinander an.
     </p>
     <p>
-      Das ist wichtig, weil es bedeutet, dass eine Fotografie auf dem Weg in ein
-      PDF nichts verlieren muss. Sie wird nie dekodiert und nie erneut
-      komprimiert; das Bild im Dokument ist Bit für Bit das Bild in Ihrer Datei.
-      Viele Werkzeuge kodieren trotzdem neu &mdash; es ist einfacher, alles auf
-      eine Leinwand zu zeichnen und einheitlich zu kodieren &mdash; und das
-      Ergebnis ist eine Generation Qualität, die ohne Grund verloren geht.
+      Bei abfotografierten Seiten ist die Sortierung nach Aufnahmedatum meist
+      die verlässlichere: Sie haben die Blätter ja in der Reihenfolge
+      fotografiert, in der sie lagen. Und in jedem Fall gilt &mdash; lieber
+      vorher die Kacheln durchsehen als hinterher das PDF.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qualität: der Punkt, an dem die meisten Werkzeuge stillschweigend patzen</h2>
+    <p>
+      Ein PDF kann JPEG-Daten unverändert aufnehmen &mdash; das ist im Format
+      so vorgesehen. Die komprimierten Bytes wandern, wie sie sind, in das
+      Dokument, und der Reader dekodiert sie am Ende genauso wie ein Browser.
     </p>
     <p>
-      Andere Formate können nicht so mitfahren. PNG, WebP, HEIC und die übrigen
-      haben in PDF keinen passenden Filter, sie müssen also umgewandelt werden.
-      Wie, das dürfen Sie entscheiden:
+      Der Gewinn daran: Eine Fotografie muss auf dem Weg ins PDF überhaupt
+      nichts einbüßen. Sie wird weder dekodiert noch neu komprimiert, und das
+      Bild im Dokument ist Bit für Bit dasselbe wie das in Ihrer Datei. Viele
+      Werkzeuge kodieren trotzdem neu, weil es bequemer ist, alles über eine
+      Leinwand laufen zu lassen und einheitlich auszugeben &mdash; und opfern
+      damit ohne Not eine Generation Qualität.
+    </p>
+    <p>
+      Andere Formate können nicht so mitfahren: Für PNG, WebP, HEIC und den
+      Rest hält PDF keinen passenden Filter bereit, sie müssen also umgewandelt
+      werden. Wie, das entscheiden Sie:
     </p>
     <ul>
       <li>
-        <strong>Als JPEG neu kodieren</strong> (die Voreinstellung). Kleinste
-        Datei, ein kleiner Qualitätsverlust, und die richtige Antwort für
-        Fotografien.
+        <strong>Neu als JPEG kodieren</strong> (die Voreinstellung). Die
+        kleinste Datei, ein geringer Qualitätsverlust &mdash; für Fotografien
+        das Richtige.
       </li>
       <li>
-        <strong>Verlustfrei.</strong> Speichert die exakten Pixel, um den Preis
-        eines viel größeren Dokuments. Die richtige Antwort für Screenshots,
+        <strong>Verlustfrei.</strong> Die Pixel bleiben exakt erhalten, das
+        Dokument wird dafür deutlich größer. Das Richtige für Screenshots,
         Diagramme und alles mit Text oder scharfen Kanten, wo JPEG-Artefakte
-        offensichtlich sind.
+        sofort ins Auge fallen.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Seitengröße, und wann &bdquo;an das Bild anpassen&ldquo; besser ist</h2>
+    <h2>Seitenformat, und wann &bdquo;an das Bild anpassen&ldquo; die bessere Wahl ist</h2>
     <p>
-      Eine Standardseitengröße &mdash; A4, Letter, Legal, A3, A5, Tabloid
-      &mdash; setzt jedes Bild auf eine Seite dieser Größe, eingepasst in Ihren
-      Rand. Nehmen Sie eine, wenn das Dokument gedruckt werden soll oder wenn
-      eine Behörde es ablegen wird.
+      Ein Standardformat &mdash; A4, Letter, Legal, A3, A5, Tabloid &mdash;
+      stellt jedes Bild auf eine Seite dieser Größe und passt es innerhalb
+      Ihres Randes ein. Das nehmen Sie, wenn gedruckt wird oder wenn eine
+      Behörde das Dokument zu den Akten legt.
     </p>
     <p>
-      &bdquo;Genau die Größe des jeweiligen Bildes&ldquo; macht jede Seite so
-      groß wie ihr Bild, es gibt also keinen Weißraum und überhaupt keine
-      Skalierung. Nehmen Sie das, wenn das PDF ein Behälter für Bilder ist und
-      kein Dokument: ein Portfolio, eine Reihe Screenshots, ein Comic. Gedruckt
-      sieht es falsch aus, weil jede Seite eine andere Größe hat.
+      &bdquo;Genau die Größe des jeweiligen Bildes&ldquo; schneidet jede Seite
+      auf ihr Bild zu: kein Weißraum, keine Skalierung. Das passt, solange das
+      PDF eher Behälter als Dokument ist &mdash; ein Portfolio, eine
+      Screenshot-Sammlung, ein Comic. Ausgedruckt sieht es merkwürdig aus, weil
+      dann jede Seite ein anderes Format hat.
     </p>
     <p>
-      Ein Rand lohnt sich bei allem, was gedruckt wird. Heimdrucker können nicht
-      bis an den Papierrand drucken, und ein randlos platziertes Foto kommt
-      beschnitten heraus.
+      Einen Rand sollten Sie stehen lassen, sobald gedruckt wird. Heimdrucker
+      kommen nicht bis an die Papierkante heran, und ein randlos gesetztes Foto
+      kommt beschnitten aus dem Gerät.
     </p>
     <h3>Hochformatseiten aus Querformatfotos</h3>
     <p>
-      Haben Sie Papierseiten mit quer gehaltenem Telefon fotografiert, ist jedes
-      Bild im Querformat und sitzt klein in der Mitte einer Hochformatseite.
-      Jedes einzelne vor dem Erzeugen des Dokuments um eine Vierteldrehung zu
-      drehen ist die Lösung, und es ist eine Entscheidung je Bild und keine
-      globale &mdash; denn meistens sind ein paar davon richtig herum
-      hineingegangen.
+      Wer Papier mit quer gehaltenem Handy abfotografiert, bekommt lauter
+      Querformatbilder, die klein in der Mitte einer Hochformatseite sitzen.
+      Abhilfe schafft eine Vierteldrehung vor dem Erzeugen des Dokuments
+      &mdash; und zwar pro Bild statt für den ganzen Stapel, weil ein paar
+      Aufnahmen erfahrungsgemäß doch richtig herum geraten sind.
     </p>
   </section>
 
   <section>
-    <h2>Was das fertige PDF über Sie aussagt</h2>
+    <h2>Was das fertige PDF über Sie verrät</h2>
     <p>
-      Ein PDF trägt einen Dokumentinformationsblock: Autor, Producer,
-      Erstellungsdatum, manchmal den Titel. Je nachdem, was es geschrieben hat,
-      kann das Ihren Kontonamen, Ihren Gerätenamen und die genaue Uhrzeit
-      enthalten, zu der Sie es gemacht haben.
+      Jedes PDF führt einen Info-Block mit sich: Autor, Producer,
+      Erstellungsdatum, manchmal einen Titel. Je nach erzeugendem Programm
+      stehen dort Ihr Kontoname, der Name Ihres Rechners und die Minute, in der
+      die Datei entstanden ist.
     </p>
     <p>
-      Darüber lohnt es sich nachzudenken, denn ein PDF ist etwas, das Menschen
-      anderen Menschen schicken &mdash; eine Bewerbung, ein Antrag, ein Dokument
-      für die Vermieterin. Die Metadaten reisen mit, und jeder Reader kann sie
-      anzeigen.
+      Das ist keine Kleinigkeit, denn ein PDF legt man in aller Regel an, um es
+      jemandem zu schicken &mdash; eine Bewerbung, ein Antrag, ein Nachweis für
+      die Hausverwaltung. Die Metadaten reisen mit, und jeder Reader zeigt sie
+      auf Knopfdruck an.
     </p>
     <p>
-      Das Werkzeug hier lässt diesen Block leer bis auf seinen eigenen Namen:
-      keine Dateinamen, kein Gerätename, kein Benutzername und kein
-      Erstellungsdatum, sofern Sie nicht das Häkchen dafür setzen. Nutzen Sie ein
-      anderes Werkzeug, lohnt es sich, einmal die Eigenschaften des Ergebnisses
-      zu öffnen und zu sehen, was es geschrieben hat.
+      Das Werkzeug hier lässt den Block bis auf seinen eigenen Namen leer:
+      keine Dateinamen, kein Rechnername, kein Benutzername, und ein
+      Erstellungsdatum nur dann, wenn Sie das Häkchen dafür setzen. Arbeiten
+      Sie mit einem anderen Programm, werfen Sie einmal einen Blick in die
+      Dokumenteigenschaften des Ergebnisses.
     </p>
     <p>
-      Davon getrennt: die Bilder selbst. Tragen Ihre Fotos EXIF- und GPS-Tags,
-      hängt es vom Weg ab, was damit passiert. Ein ohne Neukodierung
-      hineinkopiertes JPEG behält, was darin war; ein Bild, das neu kodiert wird,
-      verliert die Tags als Nebenwirkung. Falls das zählt, säubern Sie die Fotos
-      vorher mit dem
+      Davon zu trennen sind die Bilder selbst. Ob deren EXIF- und GPS-Tags
+      erhalten bleiben, hängt am Weg: Ein unverändert übernommenes JPEG behält
+      alles, was darin stand; ein neu kodiertes Bild verliert die Tags nebenbei.
+      Wenn Ihnen daran liegt, säubern Sie die Fotos vorher mit dem
       <a href="../../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>
-      &mdash; <a href="../exif-und-gps-daten-entfernen/">sein Ratgeber</a>
-      erklärt, was darin steckt.
+      &mdash; <a href="../exif-und-gps-daten-entfernen/">der zugehörige
+      Ratgeber</a> zeigt, was da alles zusammenkommt.
     </p>
   </section>
 
   <section>
-    <h2>Wenn das PDF zu groß wird</h2>
+    <h2>Wenn das PDF zu groß gerät</h2>
     <p>
-      Handyfotos sind groß, und zwanzig davon ergeben ein Dokument, das die
-      E-Mail zurückweist. Drei Dinge zum Ausprobieren, der Reihe nach:
+      Handyfotos sind groß, und zwanzig davon ergeben ein Dokument, an dem
+      jeder Mailserver scheitert. Drei Hebel, der Wirkung nach geordnet:
     </p>
     <p>
-      <strong>Die längste Seite verkleinern.</strong> Ein Foto eines Blatts
-      Papier mit 4000 Pixeln trägt weit mehr Detail, als irgendein Reader oder
-      Drucker je nutzen wird. Die lange Kante auf etwa 2000 Pixel zu bringen
-      viertelt die Datei üblicherweise und ändert nichts, was auf einer Seite
-      jemand sehen könnte.
+      <strong>Die lange Kante verkleinern.</strong> Ein Blatt Papier mit 4000
+      Pixeln Kantenlänge trägt weit mehr Detail, als Reader oder Drucker je
+      zeigen. Herunter auf rund 2000 Pixel viertelt die Datei üblicherweise,
+      und auf der Seite sieht das niemand.
     </p>
     <p>
-      <strong>JPEG statt verlustfrei nehmen</strong> für alles Fotografische.
-      Verlustfrei ist die richtige Antwort für Diagramme und die falsche für das
-      Foto einer Seite.
+      <strong>Für alles Fotografische JPEG statt verlustfrei.</strong>
+      Verlustfrei gehört zu Diagrammen, nicht zum Foto einer Textseite.
     </p>
     <p>
       <strong>Das fertige Dokument komprimieren.</strong> Der
-      <a href="../../pdf-verkleinern/">PDF-Kompressor</a> arbeitet daran, wie
-      groß jedes Bild auf der Seite dargestellt wird, und nicht an seiner
-      Pixelzahl &mdash; und das ist die Messung, auf die es ankommt;
-      <a href="../pdf-kleiner-machen/">sein Ratgeber</a> behandelt, was das
-      kostet.
+      <a href="../../pdf-verkleinern/">PDF-Kompressor</a> geht nicht über die
+      Pixelzahl, sondern darüber, wie groß ein Bild auf der Seite überhaupt
+      dargestellt wird &mdash; und das ist das Maß, auf das es ankommt. Was das
+      kostet, steht in <a href="../pdf-kleiner-machen/">seinem Ratgeber</a>.
     </p>
     <p>
-      Im Werkzeug ist keine Grenze dafür eingebaut, wie viele Bilder Sie
-      verwenden können. Die praktische Obergrenze ist der Arbeitsspeicher Ihres
-      Geräts, denn das fertige Dokument wird dort zusammengesetzt, bevor Sie es
-      herunterladen &mdash; ein paar hundert Handyfotos in voller Auflösung sind
-      das Erste, was sie zu spüren bekommt, und die längste Seite zu verkleinern
-      verschiebt diese Grenze weit nach hinten.
+      Eine Obergrenze für die Anzahl der Bilder gibt es im Werkzeug nicht. Die
+      praktische Grenze zieht der Arbeitsspeicher Ihres Geräts, denn das fertige
+      Dokument entsteht dort, bevor Sie es herunterladen &mdash; ein paar
+      hundert Handyfotos in voller Auflösung bekommen das als Erstes zu spüren,
+      und eine kleinere lange Kante schiebt die Grenze weit nach hinten.
     </p>
   </section>
 
   <section>
-    <h2>Was Sie damit nicht bekommen</h2>
+    <h2>Was dabei nicht herauskommt</h2>
     <p>
-      Ein PDF aus Fotografien ist ein PDF voller Bilder. Die Wörter darin sind
-      kein Text: Sie können sie weder durchsuchen noch kopieren, und ein
-      Screenreader kann sie nicht vorlesen. Das ist eine Eigenschaft dessen,
-      womit Sie angefangen haben, und nicht der Umwandlung.
+      Ein PDF aus Fotografien bleibt ein PDF voller Bilder. Die Wörter darin
+      sind kein Text: nicht durchsuchbar, nicht kopierbar, für einen
+      Screenreader schlicht nicht vorhanden. Das liegt am Ausgangsmaterial und
+      nicht an der Umwandlung.
     </p>
     <p>
-      Brauchen Sie durchsuchbaren Text, brauchen Sie OCR, und das ist eine andere
-      Aufgabe. Und existiert das ursprüngliche Dokument irgendwo noch als
-      Dokument, schlägt der direkte PDF-Export immer das Abfotografieren &mdash;
-      kleiner, schärfer, durchsuchbar.
+      Durchsuchbaren Text bekommen Sie nur über OCR, und das ist eine ganz
+      andere Aufgabe. Existiert das Original irgendwo noch als richtiges
+      Dokument, schlägt der direkte PDF-Export das Abfotografieren ohnehin um
+      Längen: kleiner, schärfer, durchsuchbar.
     </p>
   </section>
 
   <section>
-    <h2>Warum das keinen Upload braucht</h2>
+    <h2>Warum dafür kein Upload nötig ist</h2>
     <p>
-      Ein PDF zu schreiben heißt, eine strukturierte Datei zu schreiben: einen
-      Header, eine Menge Objekte, eine Querverweistabelle. Da ist nichts, was ein
-      Browser nicht könnte, und nichts an der Aufgabe verlangt, dass die Bilder
-      irgendwohin reisen.
+      Ein PDF zu schreiben heißt, eine strukturierte Datei zu schreiben:
+      Kopfteil, eine Reihe von Objekten, eine Querverweistabelle. Nichts davon
+      übersteigt einen Browser, und nichts an der Aufgabe verlangt, dass die
+      Bilder irgendwohin reisen.
     </p>
     <p>
-      Und das ist hier von Bedeutung, wegen dessen, was Menschen in solche
-      Dokumente legen. Ausweispapiere, Kontoauszüge, Arztbriefe, unterschriebene
-      Verträge &mdash; der Grund, warum überhaupt jemand ein PDF macht, ist meist
-      der, dass er es an eine Institution schickt. Das Werkzeug hier hat
-      keinerlei Netzfunktion, und die <code>Content-Security-Policy</code> der
-      Seite nennt jede Adresse, die sie kontaktieren darf; keine davon gehört zu
-      dieser Seite.
+      Hier zählt das besonders, wegen dessen, was in solchen Dokumenten landet.
+      Ausweispapiere, Kontoauszüge, Arztbriefe, unterschriebene Verträge
+      &mdash; wer überhaupt ein PDF anlegt, tut es meistens, weil das Dokument
+      an eine Behörde, eine Bank oder eine Versicherung geht. Das Werkzeug hier
+      hat keinerlei Netzfunktion, und die
+      <code>Content-Security-Policy</code> der Seite nennt jede Adresse, die
+      sie kontaktieren darf; keine davon gehört zu dieser Seite.
     </p>
     <p>
+      Wie Sie das selbst nachprüfen, hier wie anderswo, steht in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> legt dar, wie Sie das selbst
-      nachprüfen &mdash; hier und überall sonst.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/de/pages/guides/combine-images-into-a-pdf.toml
@@ -3,15 +3,15 @@
 #
 
 nav = "Bilder zu einem PDF"
-title = "Bilder zu einem PDF zusammenfügen"
-description = "Fotos oder Scans zu einem einzigen PDF machen: Seitengröße, Reihenfolge und Drehung, warum ein JPEG dabei keine Qualität verlieren muss, und was ein PDF dem verrät, dem Sie es schicken."
-heading = "Wie Sie Bilder zu einem PDF zusammenfügen"
+title = "Mehrere Bilder zu einem PDF zusammenfügen"
+description = "Aus Fotos oder Scans ein einziges PDF machen: Seitenformat, Reihenfolge und Drehung, warum ein JPEG dabei nichts an Qualität einbüßt und was das fertige Dokument über Sie verrät."
+heading = "So fügen Sie mehrere Bilder zu einem PDF zusammen"
 lede = """
-    Jemand hat um &bdquo;ein PDF&ldquo; gebeten, und Sie haben elf Fotos von
-    Papier. Hier stehen die Entscheidungen, die das Ergebnis wirklich verändern
-    &mdash; Seitengröße, Reihenfolge, Qualität und was das Dokument über Sie
-    aussagt &mdash; und welche davon Sie getrost ignorieren können."""
+    Jemand möchte &bdquo;ein PDF&ldquo;, und Sie haben elf Fotos von Papier.
+    Hier stehen die vier Entscheidungen, die das Ergebnis tatsächlich verändern
+    &mdash; Reihenfolge, Seitenformat, Qualität und das, was das Dokument über
+    Sie preisgibt &mdash; und woran Sie getrost vorbeigehen können."""
 updated = "20. August 2026"
-og_title = "Wie Sie Bilder zu einem PDF zusammenfügen"
-og_description = "Seitengröße, Reihenfolge und Drehung, warum ein JPEG dabei keine Qualität verlieren muss, und was ein PDF dem verrät, dem Sie es schicken."
+og_title = "So fügen Sie mehrere Bilder zu einem PDF zusammen"
+og_description = "Seitenformat, Reihenfolge und Drehung, warum ein JPEG dabei nichts an Qualität einbüßt und was das fertige Dokument über Sie verrät."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/de/pages/guides/compress-an-image-to-a-target-size.html
@@ -2,257 +2,252 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie den <a href="../../bild-komprimieren/">Bildkompressor</a>,
-      ziehen Sie das Foto hinein, tippen Sie die genannte Zahl ein und klicken
-      Sie auf die Schaltfläche. Er kodiert das Bild mehrfach, behält das beste
-      Ergebnis, das unter Ihre Zielgröße passt, und sagt Ihnen, was das gekostet
-      hat. Für die meisten Fotografien und die meisten Zielgrößen lautet die
-      ehrliche Zusammenfassung: Sie werden den Unterschied nicht sehen können.
+      ziehen Sie das Foto hinein, tippen Sie die geforderte Zahl ein und klicken
+      Sie auf die Schaltfläche. Das Werkzeug kodiert das Bild mehrfach, behält
+      das beste Ergebnis, das noch unter Ihre Grenze passt, und zeigt Ihnen, was
+      das gekostet hat. Bei den meisten Fotos und den meisten Zielgrößen lautet
+      die ehrliche Auskunft: Sie werden den Unterschied nicht sehen.
     </p>
     <p>
-      Der Rest dieser Seite ist für die Fälle, in denen das nicht eintritt: wenn
-      das Ergebnis weich aussieht, wenn ein PNG sich kaum rührt, oder wenn Sie
-      wissen wollen, was das Werkzeug mit Ihrem Bild eigentlich anstellt, bevor
-      Sie es jemandem schicken.
+      Der Rest dieser Seite ist für den Fall, dass es anders kommt &mdash; wenn
+      das Ergebnis weich wirkt, wenn ein PNG sich kaum bewegt, oder wenn Sie
+      einfach wissen wollen, was da mit Ihrem Bild geschieht, bevor Sie es aus
+      der Hand geben.
     </p>
   </section>
 
   <section>
-    <h2>Worum eine Größengrenze wirklich bittet</h2>
+    <h2>Was eine Größengrenze in Wirklichkeit von Ihnen verlangt</h2>
     <p>
-      Ein JPEG oder ein WebP speichert nicht Ihre Fotografie. Es speichert eine
-      Beschreibung davon, und die Qualitätseinstellung entscheidet, wie
-      detailliert diese Beschreibung sein darf. Drehen Sie sie herunter, wird die
-      Datei kleiner, weil die Beschreibung vager wird: feine Textur wird
-      weggemittelt, Verläufe bekommen Streifen, und Kanten fangen sich einen
-      schwachen Hof aus Blöcken ein.
+      Ein JPEG oder ein WebP speichert nicht Ihr Foto, sondern eine Beschreibung
+      davon &mdash; und die Qualitätseinstellung legt fest, wie genau diese
+      Beschreibung ausfallen darf. Drehen Sie sie herunter, schrumpft die Datei,
+      weil die Beschreibung ungenauer wird: Feine Textur wird weggemittelt,
+      Verläufe bekommen Streifen, und um Kanten legt sich ein blasser Kranz aus
+      Blöcken.
     </p>
     <p>
-      Eine Größengrenze ist also ein Budget für Detail. Die nützliche Frage ist
-      nicht &bdquo;kann ich 500&nbsp;KB treffen&ldquo; &mdash; jede Zahl lässt
-      sich treffen &mdash;, sondern &bdquo;wie viel vom Bild muss ich dafür
-      hergeben, und macht das für meinen Zweck etwas aus?&ldquo;
+      Eine Größengrenze ist damit nichts anderes als ein Budget für Bilddetail.
+      Und die interessante Frage lautet nicht, ob Sie 500&nbsp;KB treffen
+      &mdash; treffen lässt sich jede Zahl &mdash;, sondern: Wie viel Bild
+      kostet der Weg dorthin, und fällt das bei Ihrem Verwendungszweck
+      überhaupt auf?
     </p>
     <p>
-      Zwei Faustregeln. Eine Fotografie einer echten Szene &mdash; Gesichter,
-      Laub, Stoff &mdash; versteckt Kompression gut, weil das Auge keine
-      vollkommen glatte Fläche hat, an der ihm der Schaden auffiele. Ein
-      Screenshot, ein Diagramm, ein Logo oder irgendetwas mit großen flachen
-      Farbflächen und harten Textkanten zeigt ihn sofort &mdash; und sollte
-      meist ohnehin ein PNG oder ein WebP sein statt ein JPEG.
-    </p>
-  </section>
-
-  <section>
-    <h2>Warum es keine Formel gibt, und was man dagegen tut</h2>
-    <p>
-      Es gibt keine Möglichkeit, die Qualitätseinstellung auszurechnen, die eine
-      500&nbsp;KB große Datei ergibt. Der Zusammenhang zwischen beiden hängt
-      vollständig davon ab, was im Bild ist: Bei derselben Einstellung kommt die
-      Fotografie einer glatten Wand womöglich auf ein Zehntel der Größe der
-      Fotografie eines Waldes. Jedes Werkzeug, das Ihnen &bdquo;Qualität:
-      60&ldquo; anbietet und hofft, rät an Ihrer Stelle.
-    </p>
-    <p>
-      Die einzige verlässliche Methode ist Probieren. Bild kodieren, Größe
-      ansehen, nachjustieren, wieder kodieren. Das von Hand zu tun ist mühsam
-      &mdash; und deshalb fragen Kompressoren stattdessen nach einer Qualitätszahl:
-      Es verschiebt die Mühe zu Ihnen. Es automatisch zu tun sind ungefähr acht
-      Durchgänge, und acht Durchgänge eines Handyfotos sind auf jedem Gerät
-      dieses Jahrzehnts ein Bruchteil einer Sekunde &mdash; deshalb fragt das
-      Werkzeug dieser Seite nach der Größe und sucht selbst.
-    </p>
-    <p>
-      Jede Größe, die es meldet, ist eine echte kodierte Datei und keine
-      Schätzung. Das zählt, wenn ein Formular eine harte Grenze hat: Eine
-      Schätzung, die um 2&nbsp;% zu optimistisch ist, ist ein abgelehnter Upload.
+      Zwei Faustregeln helfen. Aufnahmen einer realen Szene &mdash; Gesichter,
+      Laub, Stoff &mdash; verkraften Kompression gut, weil dem Auge die glatte
+      Fläche fehlt, an der ihm der Schaden auffiele. Screenshots, Diagramme,
+      Logos und überhaupt alles mit großen einfarbigen Flächen und harten
+      Textkanten verraten ihn sofort &mdash; und gehören meist ohnehin ins PNG
+      oder WebP statt ins JPEG.
     </p>
   </section>
 
   <section>
-    <h2>Geben Sie Qualität aus, bevor Sie Pixel ausgeben</h2>
+    <h2>Warum es dafür keine Formel gibt</h2>
     <p>
-      Es gibt nur zwei Wege, eine Bilddatei kleiner zu machen. Sie können
-      dasselbe Bild ungenauer beschreiben &mdash; das ist Qualität. Oder Sie
-      können weniger Pixel beschreiben &mdash; das ist Skalieren. Die beiden sind
-      nicht gleichwertig, und die Reihenfolge zählt.
+      Die Qualitätseinstellung, die genau 500&nbsp;KB ergibt, lässt sich nicht
+      ausrechnen. Wie beides zusammenhängt, entscheidet allein der Bildinhalt:
+      Bei identischer Einstellung landet die glatte Hauswand womöglich bei einem
+      Zehntel dessen, was der Wald braucht. Wer Ihnen &bdquo;Qualität:
+      60&ldquo; vorsetzt und auf das Beste hofft, rät an Ihrer Stelle.
     </p>
     <p>
-      Qualität kommt zuerst, weil die ersten etwa 30&nbsp;% Qualitätsreduktion
-      bei einer Fotografie wirklich unsichtbar sind &mdash; Sie werfen Detail
-      weg, das das Format sorgfältiger gespeichert hat, als irgendein Auge es
-      nachprüfen kann. Pixel kommen danach, denn sobald die Qualität weit genug
-      fällt, dass Artefakte sichtbar werden, sieht ein kleineres Bild in
-      anständiger Qualität besser aus als ein Bild in voller Größe, das ruiniert
-      wurde. Weniger gute Pixel schlagen mehr schlechte.
+      Verlässlich ist nur Ausprobieren: kodieren, Größe ansehen, nachjustieren,
+      wieder kodieren. Von Hand ist das eine Fleißarbeit, und genau die schieben
+      Kompressoren Ihnen zu, wenn sie nach einer Qualitätszahl fragen statt nach
+      einer Größe. Automatisch sind es rund acht Durchgänge, und acht Durchgänge
+      über ein Handyfoto dauern auf jedem halbwegs aktuellen Gerät den Bruchteil
+      einer Sekunde. Deshalb fragt das Werkzeug hier nach der Größe und sucht
+      selbst.
     </p>
     <p>
-      Das ist die ganze Strategie, und sie ist wissenswert, auch wenn Sie ein
-      anderes Werkzeug benutzen: Drehen Sie die Qualität herunter, bis es anfängt
-      falsch auszusehen, und machen Sie dann das Bild kleiner, statt weiter
-      herunterzudrehen.
+      Jede Größe, die dabei angezeigt wird, stammt aus einer wirklich kodierten
+      Datei und ist keine Hochrechnung. Das zählt, sobald ein Formular eine
+      harte Obergrenze hat: Eine Schätzung, die um 2&nbsp;% zu optimistisch
+      ausfällt, ist ein abgelehnter Upload.
     </p>
-    <h3>Wann Sie mit Absicht skalieren</h3>
+  </section>
+
+  <section>
+    <h2>Erst Qualität ausgeben, dann Pixel</h2>
+    <p>
+      Eine Bilddatei lässt sich auf genau zwei Arten verkleinern. Entweder
+      beschreiben Sie dasselbe Bild ungenauer &mdash; das ist die Qualität.
+      Oder Sie beschreiben weniger Pixel &mdash; das ist die Skalierung.
+      Gleichwertig ist beides nicht, und auf die Reihenfolge kommt es an.
+    </p>
+    <p>
+      Die Qualität kommt zuerst dran, denn die ersten rund 30&nbsp;% sind bei
+      einer Fotografie tatsächlich unsichtbar: Sie werfen Detail weg, das das
+      Format sorgfältiger aufbewahrt hat, als ein Auge es je nachprüfen könnte.
+      Die Pixel kommen danach, denn sobald die Qualität so weit fällt, dass
+      Artefakte auftauchen, sieht ein kleineres Bild in ordentlicher Qualität
+      besser aus als ein ruiniertes in voller Größe. Wenige gute Pixel schlagen
+      viele kaputte.
+    </p>
+    <p>
+      Mehr Strategie steckt nicht dahinter &mdash; und sie gilt genauso, wenn
+      Sie mit einem anderen Programm arbeiten: Qualität herunterdrehen, bis es
+      anfängt, falsch auszusehen, und ab da lieber das Bild verkleinern als
+      weiter zu drehen.
+    </p>
+    <h3>Wann sich Skalieren von vornherein lohnt</h3>
     <p>
       Manchmal wurden die Pixel nie gebraucht. Ein 4000 Pixel breites Foto, das
-      auf einer Webseite in einer 600 Pixel breiten Spalte gezeigt wird, trägt
-      das Sechsfache des Details, das irgendjemand sehen wird. Kennen Sie das
-      endgültige Zuhause des Bildes, skalieren Sie zuerst darauf, und das
-      Größenproblem verschwindet oft, ohne dass überhaupt Qualität ausgegeben
-      wird. Das <a href="../../bildgroesse-aendern/">Bildgrößen-Ändern</a> ist
-      das Werkzeug dafür, und
-      <a href="../bild-skalieren/">sein eigener Ratgeber</a> behandelt die Wahl
-      einer Größe.
+      auf einer Webseite in einer 600 Pixel breiten Spalte steht, schleppt das
+      Sechsfache dessen mit, was jemals zu sehen sein wird. Wenn Sie wissen, wo
+      das Bild am Ende landet, skalieren Sie zuerst darauf &mdash; oft löst sich
+      das Größenproblem dann von allein, ohne einen Deut Qualität. Dafür ist das
+      <a href="../../bildgroesse-aendern/">Bildgrößen-Ändern</a> da; wie Sie die
+      passende Größe finden, steht in
+      <a href="../bild-skalieren/">dessen Ratgeber</a>.
     </p>
   </section>
 
   <section>
-    <h2>Ein Format wählen</h2>
+    <h2>Das richtige Format</h2>
     <p>
-      Drei Formate sind wissenswert, und Browser können alle drei schreiben.
+      Drei Formate sollten Sie kennen, und Browser schreiben alle drei.
     </p>
     <ul>
       <li>
-        <strong>JPEG</strong> ist für Fotografien. Es ist verlustbehaftet, es
-        wird von allem verstanden, was je gebaut wurde, und für ein Bild einer
-        echten Szene ist es weiterhin eine ausgezeichnete Wahl. Transparenz kann
-        es nicht speichern.
+        <strong>JPEG</strong> ist das Format für Fotos. Verlustbehaftet, aber
+        von wirklich jedem Gerät verstanden, und für eine reale Szene nach wie
+        vor eine ausgezeichnete Wahl. Transparenz kann es nicht.
       </li>
       <li>
-        <strong>WebP</strong> ist für dieselbe Aufgabe, besser gemacht: rund
-        25&ndash;35&nbsp;% kleiner als JPEG bei einer Qualität, die Sie nicht
-        unterscheiden können, und es behält Transparenz. Jeder aktuelle Browser
-        liest es. Ein paar ältere Desktop-Programme und manche
-        Unternehmens-Upload-Formulare tun es noch nicht &mdash; und das ist der
-        einzige echte Grund, es nicht zu nehmen.
+        <strong>WebP</strong> macht dieselbe Arbeit besser: bei nicht
+        unterscheidbarer Qualität rund 25&ndash;35&nbsp;% kleiner als JPEG, und
+        Transparenz bleibt erhalten. Jeder aktuelle Browser liest es. Dass ein
+        paar ältere Desktop-Programme und manche Upload-Formulare in Unternehmen
+        noch streiken, ist der einzige ernsthafte Grund, darauf zu verzichten.
       </li>
       <li>
-        <strong>PNG</strong> ist verlustfrei, was heißt: exakt und groß. Es ist
-        die richtige Antwort für Screenshots, Logos, Strichzeichnungen und alles
-        mit scharfen Kanten oder flachen Farbflächen &mdash; und die falsche für
-        eine Fotografie.
+        <strong>PNG</strong> ist verlustfrei &mdash; also exakt und groß.
+        Richtig für Screenshots, Logos, Strichzeichnungen und alles mit scharfen
+        Kanten oder einfarbigen Flächen, falsch für eine Fotografie.
       </li>
     </ul>
     <p>
-      Haben Sie keine Vorgabe von dem, der die Datei verlangt hat, bringt WebP
-      Sie mit weniger sichtbarem Schaden an eine Zielgröße als JPEG. Geht die
-      Datei in etwas Altes oder in ein System, das Sie nicht testen können, ist
-      JPEG die sichere Antwort.
+      Wenn Ihnen niemand ein Format vorschreibt, kommen Sie mit WebP bei weniger
+      sichtbarem Schaden an die Zielgröße als mit JPEG. Geht die Datei dagegen
+      in ein altes Programm oder in ein System, das Sie nicht ausprobieren
+      können, ist JPEG die sichere Wahl.
     </p>
   </section>
 
   <section>
-    <h2>Warum Ihr PNG nicht viel kleiner wird</h2>
+    <h2>Warum Ihr PNG kaum kleiner wird</h2>
     <p>
-      Das ist die häufigste Überraschung, und es ist kein Fehler in dem Werkzeug,
-      das Sie benutzen. PNG ist ein verlustfreies Format: Es speichert die
-      exakten Pixel und hat keinen Qualitätsregler zum Drehen, denn einen zu
-      drehen würde es zu einem anderen Format machen. Alles, was ein
-      PNG-Kompressor tun kann, ist, dieselben Pixel geschickter zu packen, und
-      das ist meist ein paar Prozent wert.
+      Das ist die häufigste Überraschung, und schuld ist nicht das Werkzeug.
+      PNG ist verlustfrei: Es speichert die exakten Pixel und hat gar keinen
+      Qualitätsregler, denn einen zu haben würde es zu einem anderen Format
+      machen. Ein PNG-Kompressor kann nichts weiter tun, als dieselben Pixel
+      geschickter zu packen &mdash; das bringt in der Regel ein paar Prozent.
     </p>
     <p>
-      Müssen Sie also eine viel kleinere Datei haben und muss es ein PNG bleiben,
-      ist der einzig verbliebene Hebel die Größe &mdash; weniger Pixel oder
-      weniger Farben. Darf es aufhören, ein PNG zu sein, lautet die Frage, was
-      darin steckt:
+      Muss die Datei also deutlich kleiner werden und muss es ein PNG bleiben,
+      hilft nur noch die Größe: weniger Pixel oder weniger Farben. Darf es das
+      PNG hinter sich lassen, kommt es darauf an, was drinsteckt:
     </p>
     <ul>
       <li>
-        <strong>Eine als PNG gespeicherte Fotografie.</strong> Sehr häufig, meist
-        aus Versehen, und der leichteste Gewinn auf dieser Seite: Sie nach JPEG
-        oder WebP umzuwandeln macht sie oft fünf- bis zehnmal kleiner, ohne
-        sichtbare Änderung.
+        <strong>Ein Foto, das als PNG gespeichert wurde.</strong> Passiert
+        ständig und meist versehentlich &mdash; und ist der leichteste Gewinn
+        auf dieser Seite: Als JPEG oder WebP wird es oft fünf- bis zehnmal
+        kleiner, ohne dass sich sichtbar etwas ändert.
       </li>
       <li>
-        <strong>Ein Screenshot oder ein Diagramm.</strong> Nach WebP umwandeln,
-        das auf Wunsch ebenfalls verlustfrei ist und bei denselben Pixeln
-        allgemein kleiner ausfällt als PNG. Nach JPEG zu gehen macht Textkanten
-        matschig.
+        <strong>Ein Screenshot oder ein Diagramm.</strong> Nach WebP umwandeln;
+        das kann auf Wunsch ebenfalls verlustfrei und fällt bei gleichen Pixeln
+        meist kleiner aus als PNG. JPEG würde die Textkanten matschig machen.
       </li>
       <li>
-        <strong>Ein Logo mit Transparenz.</strong> WebP behält die Transparenz;
-        JPEG füllt sie mit einer Volltonfarbe auf, und das ist fast nie das
-        Gewollte.
+        <strong>Ein Logo mit Transparenz.</strong> WebP behält sie; JPEG füllt
+        sie mit einer Volltonfarbe auf, und das wollte fast nie jemand.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Woran Sie erkennen, ob das Ergebnis gut genug ist</h2>
+    <h2>Woran Sie erkennen, ob das Ergebnis taugt</h2>
     <p>
-      Ein Vorschaubild anzusehen beweist nichts &mdash; in Vorschaugröße sieht
-      alles gut aus. Zwei bessere Prüfungen:
+      Ein Blick auf die Vorschau beweist gar nichts &mdash; in Briefmarkengröße
+      sieht alles gut aus. Zwei bessere Proben:
     </p>
     <p>
-      <strong>Sehen Sie es in voller Größe an, an der glattesten Stelle im
-      Bild.</strong> Himmel, Haut, eine gestrichene Wand. Kompressionsschaden
-      zeigt sich zuerst in weichen Verläufen, als schwache Blöcke oder Streifen
-      &mdash; lange bevor er detailreiche Bereiche erreicht.
+      <strong>Sehen Sie es in voller Größe an, und zwar an der glattesten Stelle
+      im Bild.</strong> Himmel, Haut, eine gestrichene Wand.
+      Kompressionsschäden zeigen sich zuerst in weichen Verläufen, als blasse
+      Blöcke oder Streifen, lange bevor sie die detailreichen Stellen erreichen.
     </p>
     <p>
-      <strong>Lesen Sie die Messung, wenn das Werkzeug eine gibt.</strong> Der
-      Kompressor hier dekodiert sein eigenes Ergebnis, vergleicht es mit dem
-      Original und meldet SSIM: eine Zahl, die lokale Helligkeit, Kontrast und
-      Struktur vergleicht, statt veränderte Pixel zu zählen &mdash; und das kommt
-      dem, woran sich ein Auge stört, sehr viel näher. Über etwa 0,98 sind die
-      beiden Bilder nebeneinander kaum zu trennen. Unter etwa 0,95 sehen Sie
-      hin, bevor Sie es verschicken. Er meldet außerdem PSNR, den klassischen
-      Dezibelwert, für alle, die den lieber mögen.
+      <strong>Lesen Sie die Messwerte, sofern das Werkzeug welche
+      liefert.</strong> Der Kompressor hier dekodiert sein eigenes Ergebnis,
+      hält es gegen das Original und nennt den SSIM-Wert: eine Zahl, die lokale
+      Helligkeit, Kontrast und Struktur vergleicht, statt veränderte Pixel zu
+      zählen &mdash; und die damit sehr viel näher an dem liegt, woran sich ein
+      Auge stört. Ab etwa 0,98 sind beide Bilder nebeneinander kaum
+      auseinanderzuhalten. Unter etwa 0,95 sollten Sie hinsehen, bevor Sie die
+      Datei verschicken. Wer den klassischen Dezibelwert bevorzugt, findet
+      daneben auch PSNR.
     </p>
     <p>
-      Beide werden auf Ihrem eigenen Gerät berechnet und Ihnen angezeigt, und
-      genau darum geht es: Es macht aus &bdquo;minimaler Qualitätsverlust&ldquo;
-      statt einer Behauptung eine Zahl, die Sie prüfen können.
+      Berechnet wird beides auf Ihrem Gerät, angezeigt wird es Ihnen &mdash; und
+      genau darin liegt der Sinn: Aus &bdquo;minimaler Qualitätsverlust&ldquo;
+      wird statt einer Behauptung eine nachprüfbare Zahl.
     </p>
   </section>
 
   <section>
-    <h2>Drei Dinge, die Sie vor dem Verschicken wissen sollten</h2>
+    <h2>Drei Dinge, bevor die Datei aus dem Haus geht</h2>
     <p>
-      <strong>Komprimieren entfernt die Metadaten.</strong> Neu zu kodieren
-      heißt, das Bild zu Pixeln zu dekodieren und diese Pixel erneut zu kodieren,
-      und eine Leinwand voller Pixel trägt keine Tags &mdash; GPS-Position,
-      Kameramodell, Zeitstempel und der Rest werden also schlicht nicht in die
-      neue Datei geschrieben. Meist ist das ein Bonus. Wollten Sie die Tags weg,
-      das Bild aber unangetastet, ist das eine andere Aufgabe: Der
+      <strong>Komprimieren löscht die Metadaten.</strong> Neu kodieren heißt:
+      das Bild zu Pixeln dekodieren und diese Pixel erneut kodieren &mdash; und
+      eine Leinwand voller Pixel trägt keine Tags. GPS-Position, Kameramodell,
+      Zeitstempel und der ganze Rest werden also schlicht nicht mitgeschrieben.
+      Meistens ist das ein willkommener Nebeneffekt. Sollen dagegen die Tags
+      verschwinden und das Bild unangetastet bleiben, ist das eine andere
+      Aufgabe: Der
       <a href="../../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>
-      schreibt den Container neu, ohne irgendetwas neu zu komprimieren, und
-      <a href="../exif-und-gps-daten-entfernen/">sein Ratgeber</a> erklärt, was
-      darin steckt.
+      schreibt nur den Container neu, ohne irgendetwas neu zu komprimieren; was
+      da alles drinsteht, erklärt
+      <a href="../exif-und-gps-daten-entfernen/">sein Ratgeber</a>.
     </p>
     <p>
       <strong>Komprimieren Sie dieselbe Datei nie zweimal.</strong> Jede
-      verlustbehaftete Kodierung wirft Detail dauerhaft weg, und ein bereits
-      komprimiertes Bild zu kodieren wirft mehr weg &mdash; einschließlich der
-      Artefakte des ersten Durchgangs, die getreu erhalten bleiben, auf Kosten
-      echten Details. Gehen Sie immer zum Original zurück und komprimieren Sie
-      einmal.
+      verlustbehaftete Kodierung wirft Detail unwiederbringlich weg, und ein
+      bereits komprimiertes Bild noch einmal zu kodieren wirft mehr weg als beim
+      ersten Mal &mdash; denn die Artefakte des ersten Durchgangs werden treu
+      mitgespeichert, und zwar auf Kosten echten Details. Gehen Sie immer aufs
+      Original zurück und komprimieren Sie einmal.
     </p>
     <p>
       <strong>Behalten Sie das Original.</strong> Aus einer verlustbehafteten
-      Kodierung führt kein Weg zurück. Was Sie auch verschicken: Bewahren Sie die
-      Datei auf, mit der Sie angefangen haben.
+      Kodierung führt kein Weg zurück. Was Sie auch verschicken &mdash; heben
+      Sie die Ausgangsdatei irgendwo auf.
     </p>
   </section>
 
   <section>
     <h2>Nichts davon braucht einen Upload</h2>
     <p>
-      Jeder Browser bringt seit Jahren einen JPEG-, PNG- und WebP-Encoder mit
-      &mdash; es ist derselbe Code, der ein Bild aus einer Leinwand speichert.
-      Ein Bild zu komprimieren ist eine der Aufgaben, die überhaupt keinen
-      technischen Grund haben, einen Server einzubeziehen, und deshalb hat das
-      Werkzeug hier keinen: Das Bild wird auf Ihrem eigenen Gerät dekodiert,
-      kodiert und gemessen, und in der <code>Content-Security-Policy</code> der
-      Seite steht keine Adresse, die zu dieser Seite gehörte und an die es
-      gesendet werden könnte.
+      Einen JPEG-, PNG- und WebP-Encoder bringt jeder Browser seit Jahren mit;
+      es ist derselbe Code, der ein Bild aus einer Leinwand speichert. Ein Bild
+      zu komprimieren gehört damit zu den Aufgaben, für die es technisch
+      überhaupt keinen Grund gibt, einen Server einzuschalten &mdash; und
+      deshalb hat das Werkzeug hier keinen. Dekodiert, kodiert und gemessen wird
+      auf Ihrem eigenen Gerät, und in der
+      <code>Content-Security-Policy</code> der Seite steht keine einzige
+      Adresse, die zu dieser Seite gehört und an die etwas gehen könnte.
     </p>
     <p>
-      Der einfachste Weg, das zu bestätigen &mdash; hier und überall sonst
-      &mdash; ist: Seite laden, Internetverbindung trennen und trotzdem etwas
-      komprimieren. Funktioniert es weiter, wurde nichts hochgeladen.
+      Am einfachsten überzeugen Sie sich selbst davon, hier wie anderswo, indem
+      Sie die Seite laden, die Internetverbindung trennen und trotzdem etwas
+      komprimieren. Geht es weiter, wurde nie etwas hochgeladen. Drei weitere
+      Proben dieser Art stehen in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen dieser
-      Art.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/de/pages/guides/compress-an-image-to-a-target-size.toml
@@ -2,16 +2,16 @@
 # Ratgeber: Ein Bild auf eine exakte Dateigroesse komprimieren - German.
 #
 
-nav = "Ein Bild komprimieren"
+nav = "Bild komprimieren"
 title = "Ein Bild auf eine exakte Dateigröße komprimieren"
-description = "Ein Upload-Formular will 500 KB, und Ihr Foto hat 4 MB. Was eine Größengrenze wirklich kostet, welche Einstellung zuerst zu bewegen ist, und warum ein PNG nicht so schrumpft wie ein JPEG."
-heading = "Wie Sie ein Bild auf eine exakte Dateigröße komprimieren"
+description = "Das Upload-Formular will 500 KB, Ihr Foto hat 4 MB. Was so eine Grenze an Bildqualität kostet, an welcher Einstellung Sie zuerst drehen und warum ein PNG nicht schrumpft wie ein JPEG."
+heading = "So komprimieren Sie ein Bild auf eine exakte Dateigröße"
 lede = """
-    Jemand hat Ihnen eine Zahl genannt &mdash; 100&nbsp;KB, 500&nbsp;KB,
-    2&nbsp;MB &mdash; und Ihr Foto ist weit davon entfernt. Hier steht, was
-    diese Zahl kostet, wofür Sie sie ausgeben und woran Sie erkennen, ob das
-    Ergebnis noch gut genug zum Verschicken ist."""
+    Irgendjemand hat Ihnen eine Zahl genannt &mdash; 100&nbsp;KB, 500&nbsp;KB,
+    2&nbsp;MB &mdash;, und Ihr Foto liegt weit darüber. Hier steht, was diese
+    Zahl an Bildqualität kostet, wofür Sie sie am besten ausgeben und woran Sie
+    merken, ob das Ergebnis noch verschickbar ist."""
 updated = "20. August 2026"
 og_title = "Ein Bild auf eine exakte Dateigröße komprimieren"
-og_description = "Was eine Größengrenze wirklich kostet, welche Einstellung zuerst zu bewegen ist, und warum ein PNG nicht so schrumpft wie ein JPEG."
+og_description = "Was eine Größengrenze an Bildqualität kostet, an welcher Einstellung Sie zuerst drehen und warum ein PNG nicht schrumpft wie ein JPEG."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/convert-an-svg-to-png.html
+++ b/locales/de/pages/guides/convert-an-svg-to-png.html
@@ -2,247 +2,251 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie <a href="../../svg-in-png-umwandeln/">SVG zu Bild</a>, ziehen
-      Sie die Datei hinein und nennen Sie eine Größe. Hat Ihnen niemand gesagt,
-      welche Größe es sein soll, sind
-      <strong>1024 Pixel auf der längsten Seite</strong> ein guter Standardwert:
-      groß genug für fast alles und klein genug zum Verschicken. Lassen Sie das
-      Format auf PNG, den Hintergrund auf transparent, und nehmen Sie die Datei.
+      Sie die Datei hinein und nennen Sie eine Größe. Hat Ihnen niemand eine
+      vorgegeben, fahren Sie mit <strong>1024 Pixeln auf der längeren
+      Seite</strong> gut: groß genug für fast jeden Zweck und klein genug für
+      den Mailanhang. Format auf PNG lassen, Hintergrund auf transparent lassen,
+      Datei mitnehmen.
     </p>
     <p>
-      Alles Weitere unten handelt davon, was zu tun ist, wenn dieser Standard
-      nicht reicht &mdash; wenn Ihnen eine Zahl vorgegeben wurde, wenn es in den
-      Druck geht, oder wenn es falsch aussehend zurückkommt.
+      Der Rest dieser Seite ist für die Fälle, in denen das nicht reicht &mdash;
+      wenn Ihnen eine Zahl vorgeschrieben wurde, wenn es in den Druck geht oder
+      wenn das Ergebnis seltsam aussieht.
     </p>
   </section>
 
   <section>
-    <h2>Warum die Größe Ihre Entscheidung ist und nicht die der Datei</h2>
+    <h2>Warum die Größe Ihre Sache ist und nicht die der Datei</h2>
     <p>
-      Ein JPEG ist ein Raster gemessener Pixel; die Frage, wie groß es ist, hat
-      eine Antwort. Ein SVG ist überhaupt kein Bild, es ist ein Satz Anweisungen
-      &mdash; zeichne hier einen Kreis, diesen Pfad in jener Farbe &mdash;, und
-      Anweisungen haben keine Größe. Ein Browser kann sie bei 16 Pixeln oder bei
-      4000 ausführen, und das Ergebnis ist so wie so gleich scharf, denn er
-      skaliert nichts. Er zeichnet neu.
+      Bei einem JPEG hat die Frage nach der Größe eine Antwort: Es ist ein
+      Raster aus abgemessenen Pixeln. Ein SVG dagegen ist gar kein Bild, sondern
+      eine Sammlung von Anweisungen &mdash; hier ein Kreis, dort dieser Pfad in
+      jener Farbe &mdash;, und Anweisungen haben keine Größe. Ein Browser führt
+      sie bei 16 Pixeln genauso aus wie bei 4000, und in beiden Fällen ist das
+      Ergebnis gleich scharf, denn skaliert wird dabei nichts. Es wird neu
+      gezeichnet.
     </p>
     <p>
-      Deshalb kann die Umwandlung Ihnen die Zahl nicht abnehmen, und deshalb
-      kostet es Sie nichts, eine große zu wählen. Das ist die eine Bildaufgabe,
-      bei der &bdquo;mach es größer&ldquo; gratis ist.
+      Deshalb kann Ihnen die Umwandlung die Zahl nicht abnehmen &mdash; und
+      deshalb kostet eine große Zahl auch nichts. Das ist die eine Bildaufgabe,
+      bei der &bdquo;dann eben größer&ldquo; gratis ist.
     </p>
     <p>
       Die meisten SVG-Dateien tragen zwar ein <code>width</code>- und ein
-      <code>height</code>-Attribut, und ein Werkzeug zeigt das an &mdash; aber es
-      ist eine Voreinstellung und keine Grenze. Ein Symbol, das
-      <code>width="24"</code> sagt, sagt nur, dass die Person, die es gezeichnet
-      hat, eine 24&nbsp;Pixel hohe Werkzeugleiste im Sinn hatte.
+      <code>height</code>-Attribut, und ein Werkzeug zeigt Ihnen das an. Es ist
+      aber eine Voreinstellung und keine Grenze: Ein Symbol mit
+      <code>width="24"</code> sagt nur, dass beim Zeichnen eine 24&nbsp;Pixel
+      hohe Werkzeugleiste im Kopf war.
     </p>
   </section>
 
   <section>
-    <h2>Woher die Zahl tatsächlich kommt</h2>
-    <p><strong>Für eine Website.</strong> Nehmen Sie die Größe, die das Bild auf
-      der Seite in CSS-Pixeln einnimmt, und multiplizieren Sie mit der
-      Pixeldichte der Bildschirme, die Ihnen wichtig sind. Ein Logo in einem 200
-      Pixel breiten Platz braucht eine 400-Pixel-Datei für ein Retina-Notebook
-      und 600 für ein neueres Telefon. Genau das bedeuten <code>@2x</code> und
-      <code>@3x</code> &mdash; und deshalb erspart Ihnen ein Werkzeug, das sie
-      schreibt, dieselbe Rechnung dreimal.
+    <h2>Woher die Zahl wirklich kommt</h2>
+    <p><strong>Für eine Website.</strong> Nehmen Sie den Platz, den das Bild auf
+      der Seite in CSS-Pixeln einnimmt, und multiplizieren Sie ihn mit der
+      Pixeldichte der Bildschirme, die Ihnen wichtig sind. Ein Logo in einer 200
+      Pixel breiten Lücke braucht 400 Pixel für ein Retina-Notebook und 600 für
+      ein neueres Handy. Mehr steckt hinter <code>@2x</code> und
+      <code>@3x</code> nicht &mdash; und deshalb erspart Ihnen ein Werkzeug, das
+      sie gleich mitschreibt, dieselbe Rechnung dreimal.
     </p>
-    <p><strong>Für ein App-Symbol, einen Store-Eintrag oder ein Favicon.</strong>
-      Die Zahl ist veröffentlicht, und es gibt nichts auszurechnen: genau das,
-      was die Seite des Stores sagt. Für ein Favicon rastern Sie gar nicht erst
-      &mdash; <a href="../favicon-selbst-erstellen/">erzeugen Sie eine .ico</a>,
-      die mehrere Größen in einer Datei hält, denn ein Browser-Tab, ein
-      Lesezeichen und eine Windows-Verknüpfung verlangen alle verschiedene.
+    <p><strong>Für ein App-Symbol, einen Store-Eintrag oder ein
+      Favicon.</strong> Da ist nichts zu rechnen: Die Zahl steht veröffentlicht
+      in den Vorgaben, und Sie nehmen genau die. Bei einem Favicon rastern Sie
+      am besten gar nicht erst, sondern
+      <a href="../favicon-selbst-erstellen/">erzeugen eine .ico</a> &mdash; die
+      hält mehrere Größen in einer Datei, und Browser-Tab, Lesezeichen und
+      Windows-Verknüpfung verlangen jeweils eine andere.
     </p>
-    <p><strong>Für den Druck.</strong> Multiplizieren Sie die physische Größe in
-      Zoll mit der Auflösung des Druckers. Ein Logo, das auf einer Visitenkarte
-      zwei Zoll breit bei 300&nbsp;DPI landet, sind 600 Pixel; dasselbe Logo über
-      eine A4-Seite, also 8,3&nbsp;Zoll, sind etwa 2500. Druckereien verlangen
-      300&nbsp;DPI als Selbstverständlichkeit, und für ein großformatiges Banner,
-      das man aus einiger Entfernung ansieht, reichen 150 gut aus.
+    <p><strong>Für den Druck.</strong> Physische Größe in Zoll mal Auflösung des
+      Druckers. Ein Logo, das auf einer Visitenkarte zwei Zoll breit wird,
+      ergibt bei 300&nbsp;DPI 600 Pixel; dasselbe Logo über die ganze
+      A4-Breite, also 8,3&nbsp;Zoll, rund 2500. Druckereien setzen
+      300&nbsp;DPI als selbstverständlich voraus; für ein großes Banner, das man
+      aus einigen Metern Entfernung sieht, genügen 150 locker.
     </p>
     <p><strong>Für eine Social-Vorschau oder ein OG-Bild.</strong> Die Plattform
-      nennt einen Rahmen &mdash; 1200&nbsp;&times;&nbsp;630 für die meisten
-      Link-Vorschauen &mdash; und der Rahmen hat ein anderes Verhältnis als Ihr
-      Logo. Dafür ist die Einstellung &bdquo;Auffüllen&ldquo; da: die Zeichnung
-      zentriert, in ihren eigenen Proportionen, mit einer Hintergrundfarbe für
-      den Rest &mdash; statt eines gedehnten Logos, das allen erzählt, dass Sie
-      nicht nachgesehen haben.
+      gibt einen Rahmen vor &mdash; bei den meisten Link-Vorschauen
+      1200&nbsp;&times;&nbsp;630 &mdash;, und der hat ein anderes
+      Seitenverhältnis als Ihr Logo. Dafür gibt es die Einstellung
+      &bdquo;Auffüllen&ldquo;: Die Zeichnung bleibt in ihren Proportionen und
+      sitzt mittig, den Rest übernimmt eine Hintergrundfarbe. Alles besser als
+      ein verzerrtes Logo, das jedem sofort verrät, dass niemand nachgesehen
+      hat.
     </p>
     <p>
-      Treffen zwei davon zu, nehmen Sie die größere. Ein PNG, das größer ist als
-      nötig, ist ein etwas größerer Download; eines, das zu klein ist, lässt sich
-      später nicht reparieren, aus dem Grund im nächsten Abschnitt.
-    </p>
-  </section>
-
-  <section>
-    <h2>Zurück geht es nicht</h2>
-    <p>
-      Rastern ist eine Einbahnstraße. Sobald die Zeichnung ein PNG ist, sind es
-      Pixel wie bei jedem anderen Bild, und es hinterher zu vergrößern muss
-      Detail erfinden, das nie gemessen wurde &mdash; dasselbe weiche,
-      verschmierte Ergebnis, das Sie beim Vergrößern einer Fotografie bekommen.
-    </p>
-    <p>
-      Bewahren Sie also das SVG auf. Es ist die Vorlage, es ist fast immer die
-      kleinere Datei, und jede künftige Größe kommt daraus einwandfrei heraus.
-      Das PNG ist ein Export für einen bestimmten Zweck, und wenn Sie eine andere
-      Größe brauchen, ist der richtige Schritt, erneut zu exportieren &mdash;
-      und nicht, das Exportierte zu skalieren.
-    </p>
-    <p>
-      Es gibt Software, die behauptet, ein PNG zurück in ein SVG zu verwandeln.
-      Was sie tut, ist nachzeichnen: raten, welche Kurven ein Pixelraster
-      erklären könnten. Bei flacher zweifarbiger Grafik funktioniert das
-      passabel, bei allem anderen erzeugt sie teuren Unsinn &mdash; und sie holt
-      nie zurück, was die ursprüngliche Zeichnung hatte.
+      Treffen zwei Fälle zu, nehmen Sie die größere Zahl. Ein PNG, das größer
+      ist als nötig, ist ein etwas längerer Download; eines, das zu klein geraten
+      ist, lässt sich hinterher nicht mehr retten &mdash; aus dem Grund, der im
+      nächsten Abschnitt steht.
     </p>
   </section>
 
   <section>
-    <h2>Drei Dinge ändern sich in dem Moment, in dem es Pixel werden</h2>
+    <h2>Zurück führt kein Weg</h2>
     <p>
-      Ein gerastertes SVG, das falsch aussieht, sieht fast immer aus einem dieser
-      drei Gründe falsch aus &mdash; und alle drei sind es wert, vor dem Export
-      gewusst zu werden statt danach.
+      Rastern ist eine Einbahnstraße. Ist die Zeichnung erst ein PNG, sind es
+      Pixel wie in jedem anderen Bild, und wer sie später vergrößert, muss Detail
+      erfinden, das nie gemessen wurde &mdash; mit demselben weichen,
+      verschmierten Ergebnis wie beim Aufblasen einer Fotografie.
     </p>
     <p>
-      <strong>Text wird in der Schrift gezeichnet, die das Gerät gerade
-      hat.</strong> Ein SVG, das Text enthält, enthält die Schrift nicht &mdash;
-      es nennt eine und überlässt es dem Renderer, sie zu finden. Ist die Schrift
-      nicht installiert, wird ein Ersatz genommen, und der Ersatz hat andere
-      Buchstabenformen und andere Breiten, der Text kann also umbrechen oder
-      überlaufen. Eine Datei, die sich ihre Schrift von einer Webadresse holt,
-      ergeht es noch schlechter: Ein SVG, das durch ein <code>&lt;img&gt;</code>
-      gerastert wird, darf überhaupt nichts abrufen, es kommt also nichts an.
+      Heben Sie das SVG also auf. Es ist die Vorlage, es ist fast immer die
+      kleinere Datei, und jede künftige Größe fällt daraus tadellos heraus. Das
+      PNG ist ein Export für einen bestimmten Zweck; brauchen Sie eine andere
+      Größe, exportieren Sie neu, statt am Exportierten herumzuskalieren.
     </p>
     <p>
-      Die Lösung ist die, die jeder Gestalter ohnehin kennt: <strong>Text vor dem
-      Export in Pfade umwandeln</strong> (Illustrator nennt es &bdquo;In Pfade
-      umwandeln&ldquo;, Figma &bdquo;Flatten&ldquo;, Inkscape &bdquo;Objekt in
-      Pfad&ldquo;). Die Buchstaben werden zu Geometrie, die Schrift hört auf eine
-      Rolle zu spielen, und das Bild sieht auf jedem Gerät gleich aus. Machen Sie
-      es an einer Kopie &mdash; in Pfade umgewandelter Text ist nicht mehr als
-      Text bearbeitbar.
-    </p>
-    <p>
-      <strong>Haarlinien werden grau oder verschwinden.</strong> Eine Linie, die
-      bei Ihrer gewählten Größe auf weniger als ein Pixel hinausläuft, kann nicht
-      als durchgezogene Linie gezeichnet werden, also wird sie blass gezeichnet.
-      Deshalb sieht ein feines Logo bei 64&nbsp;Pixeln ausgewaschen aus, während
-      dieselbe Datei bei 512 perfekt aussieht. Ist eine kleine Größe die Vorgabe,
-      lautet die Antwort: eine vereinfachte Zeichnung mit kräftigeren Linien
-      &mdash; und keine andere Exporteinstellung. Es ist derselbe Grund, aus dem
-      ein Favicon ein Zeichen ist und kein Schriftzug.
-    </p>
-    <p>
-      <strong>Animation hört auf.</strong> Ein animiertes SVG rastert zu einem
-      einzigen Standbild: was auch immer das erste Einzelbild ist. Es gibt keine
-      Exporteinstellung, die das ändert. Brauchen Sie die Bewegung, brauchen Sie
-      ein GIF oder ein Video, auf einem anderen Weg gemacht.
+      Es gibt Programme, die versprechen, ein PNG zurück in ein SVG zu
+      verwandeln. Was sie tun, heißt Nachzeichnen: Sie raten, welche Kurven ein
+      Pixelraster erklären könnten. Bei flacher zweifarbiger Grafik geht das
+      passabel, bei allem anderen kommt teurer Unsinn heraus &mdash; und was die
+      ursprüngliche Zeichnung hatte, holt es nie zurück.
     </p>
   </section>
 
   <section>
-    <h2>Transparenz, und welches Format zu wählen ist</h2>
+    <h2>Drei Dinge ändern sich, sobald daraus Pixel werden</h2>
     <p>
-      <strong>PNG</strong>, sofern Sie keinen Grund für etwas anderes haben. Es
-      ist verlustfrei, es behält Transparenz, und flache Farbflächen mit harten
-      Kanten &mdash; und daraus besteht eine Zeichnung größtenteils &mdash;
-      komprimieren sich darin gut. Ein gerastertes Logo ist als PNG meist
-      <em>kleiner</em>, als es als JPEG wäre, und dazu sauberer.
+      Wenn ein gerastertes SVG falsch aussieht, liegt es fast immer an einem
+      dieser drei Punkte. Alle drei sollte man vor dem Export kennen und nicht
+      danach.
     </p>
     <p>
-      <strong>JPEG</strong> hat überhaupt keine Transparenz. Jedes transparente
-      Pixel muss irgendeine Farbe werden, und wenn niemand eine wählt, wird es
-      schwarz &mdash; daher kommt das Ergebnis &bdquo;Logo auf schwarzem
-      Kasten&ldquo;, das Menschen für einen Fehler halten. Es ist außerdem auf
-      die Weise verlustbehaftet, die sich bei genau dieser Art Bild am
-      schlimmsten zeigt: ein Kranz aus Sprenkeln um jede harte Kante. Nehmen Sie
-      es, wenn etwas darauf besteht.
+      <strong>Text erscheint in der Schrift, die das Gerät gerade
+      hergibt.</strong> Ein SVG mit Text enthält die Schrift nicht &mdash; es
+      nennt nur eine und überlässt es dem Renderer, sie zu finden. Fehlt sie,
+      springt ein Ersatz ein, und der hat andere Buchstabenformen und andere
+      Laufweiten; der Text bricht dann um oder läuft über. Noch schlechter
+      ergeht es einer Datei, die ihre Schrift von einer Webadresse nachladen
+      will: Ein SVG, das über ein <code>&lt;img&gt;</code> gerastert wird, darf
+      überhaupt nichts abrufen, es kommt also nichts an.
+    </p>
+    <p>
+      Die Abhilfe kennt jede Gestalterin ohnehin: <strong>Text vor dem Export in
+      Pfade umwandeln</strong> (Illustrator: &bdquo;In Pfade umwandeln&ldquo;,
+      Figma: &bdquo;Flatten&ldquo;, Inkscape: &bdquo;Objekt in Pfad&ldquo;). Aus
+      den Buchstaben wird Geometrie, die Schrift spielt keine Rolle mehr, und
+      das Bild sieht auf jedem Gerät gleich aus. Machen Sie das an einer Kopie
+      &mdash; in Pfade umgewandelter Text lässt sich nicht mehr als Text
+      bearbeiten.
+    </p>
+    <p>
+      <strong>Haarlinien werden grau oder verschwinden ganz.</strong> Eine
+      Linie, die bei der gewählten Größe rechnerisch schmaler als ein Pixel
+      wird, lässt sich nicht als durchgezogene Linie zeichnen &mdash; also wird
+      sie blass gezeichnet. Genau deshalb wirkt ein filigranes Logo bei
+      64&nbsp;Pixeln ausgewaschen, während dieselbe Datei bei 512 tadellos
+      aussieht. Ist die kleine Größe Vorgabe, hilft keine andere
+      Exporteinstellung, sondern nur eine vereinfachte Zeichnung mit kräftigeren
+      Linien. Aus demselben Grund ist ein Favicon ein Zeichen und kein
+      Schriftzug.
+    </p>
+    <p>
+      <strong>Animationen bleiben stehen.</strong> Ein animiertes SVG rastert zu
+      einem einzigen Standbild, nämlich zum ersten Einzelbild. Daran ändert
+      keine Exporteinstellung etwas. Brauchen Sie die Bewegung, brauchen Sie ein
+      GIF oder ein Video &mdash; und einen anderen Weg dorthin.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparenz, und welches Format es sein sollte</h2>
+    <p>
+      <strong>PNG</strong>, solange nichts dagegen spricht. Verlustfrei, behält
+      Transparenz, und einfarbige Flächen mit harten Kanten &mdash; und daraus
+      besteht eine Zeichnung zum größten Teil &mdash; komprimiert es gut. Ein
+      gerastertes Logo wird als PNG meist <em>kleiner</em> als dieselbe Grafik
+      im JPEG, und obendrein sauberer.
+    </p>
+    <p>
+      <strong>JPEG</strong> kennt keine Transparenz. Jedes transparente Pixel
+      muss irgendeine Farbe annehmen, und wählt niemand eine, wird es schwarz
+      &mdash; daher das Logo im schwarzen Kasten, das viele für einen
+      Programmfehler halten. Dazu kommt: JPEG ist genau auf die Art
+      verlustbehaftet, die sich bei solchen Bildern am hässlichsten zeigt,
+      nämlich als Kranz aus Sprenkeln um jede harte Kante. Nehmen Sie es nur,
+      wenn etwas darauf besteht.
     </p>
     <p>
       <strong>WebP</strong> kann alles, was PNG kann, in einer kleineren Datei,
-      und wird von jedem aktuellen Browser gelesen. Der Grund, es nicht zu
-      nehmen, ist das, was nach dem Browser kommt: ältere Software, manche
-      Druckereien und eine ganze Reihe Upload-Formulare öffnen keines.
+      und jeder aktuelle Browser liest es. Der Grund, es trotzdem nicht zu
+      nehmen, liegt hinter dem Browser: ältere Software, manche Druckereien und
+      eine ganze Reihe von Upload-Formularen öffnen keines.
     </p>
     <p>
-      Bei PNG eine Hintergrundfarbe zu wählen ist ebenfalls ein völlig
-      gewöhnlicher Wunsch. Transparenz nützt nur dann etwas, wenn das, worauf das
-      Bild landet, eine Farbe ist, die Sie nicht vorhersagen können; wissen Sie
-      bereits, dass es eine weiße Seite ist, erspart Ihnen das Herunterrechnen
-      auf Weiß eine ganze Kategorie von Überraschungen.
+      Und eine Hintergrundfarbe auch beim PNG zu wählen ist ein völlig normaler
+      Wunsch. Transparenz nützt nur, solange Sie nicht wissen, auf welcher Farbe
+      das Bild landet; steht schon fest, dass es eine weiße Seite ist, erspart
+      Ihnen der Export gleich auf Weiß eine ganze Kategorie von Überraschungen.
     </p>
   </section>
 
   <section>
     <h2>Wenn der Export leer oder falsch herauskommt</h2>
     <p>
-      <strong>Nichts als leere Fläche.</strong> Meist ein fehlendes
-      <code>xmlns</code>-Attribut am Wurzelelement. Eine Datei ohne das ist für
-      ein Bild-Element kein SVG, und sie zeichnet sich als nichts. Die Datei im
-      Browser zu öffnen ist der schnelle Test: Zeigt der Browser ebenfalls
-      nichts, liegt es an der Datei und nicht am Konverter.
+      <strong>Nur leere Fläche.</strong> Meist fehlt das
+      <code>xmlns</code>-Attribut am Wurzelelement. Ohne das ist die Datei für
+      ein Bild-Element kein SVG, und sie zeichnet sich als nichts. Der schnelle
+      Test: die Datei im Browser öffnen. Zeigt auch der nichts, liegt es an der
+      Datei und nicht am Konverter.
     </p>
     <p>
-      <strong>Die Zeichnung ist klein, oben links in der Ecke.</strong> Die Datei
-      hat ein <code>width</code> und ein <code>height</code>, aber keine
-      <code>viewBox</code> &mdash; es gibt also kein Koordinatensystem zum
-      Skalieren, und die Grafik behält ihre ursprünglichen Einheiten auf einer
-      größeren Leinwand. Ein guter Konverter setzt Ihnen eine viewBox hinein; hat
-      Ihrer das nicht getan, behebt es
+      <strong>Die Zeichnung sitzt winzig in der linken oberen Ecke.</strong> Dann
+      hat die Datei zwar <code>width</code> und <code>height</code>, aber keine
+      <code>viewBox</code> &mdash; es fehlt also das Koordinatensystem, an dem
+      sich skalieren ließe, und die Grafik behält ihre ursprünglichen Einheiten
+      auf einer größeren Leinwand. Ein guter Konverter ergänzt die viewBox von
+      sich aus; hat Ihrer das nicht getan, tragen Sie
       <code>viewBox="0 0 <em>Breite</em> <em>Höhe</em>"</code> von Hand am
-      Wurzelelement &mdash; und die Datei ist reiner Text, Sie können das also.
+      Wurzelelement nach &mdash; die Datei ist reiner Text, das können Sie also
+      selbst.
     </p>
     <p>
-      <strong>Ein Teil des Bildes fehlt.</strong> Irgendetwas in der Datei zeigte
-      auf eine Adresse, statt die Grafik zu enthalten &mdash; ein eingebettetes
-      Foto, das als Verweis gespeichert ist, ein Stylesheet, eine Schrift. Ein
-      Rasterer, der sich weigert, das abzurufen, tut das Richtige, und es ist
-      dieselbe Weigerung, die verhindert, dass ein irgendwo heruntergeladenes SVG
-      seinem Urheber Bericht erstattet. Exportieren Sie aus dem Zeichenprogramm
-      neu, mit eingebetteten Bildern.
+      <strong>Ein Teil des Bildes fehlt.</strong> Dann verwies etwas in der Datei
+      auf eine Adresse, statt die Grafik selbst zu enthalten: ein eingebettetes
+      Foto, das nur verlinkt ist, ein Stylesheet, eine Schrift. Ein Rasterer, der
+      sich weigert, so etwas nachzuladen, tut genau das Richtige &mdash; es ist
+      dieselbe Weigerung, die verhindert, dass ein irgendwo heruntergeladenes
+      SVG seinem Urheber Meldung macht. Exportieren Sie im Zeichenprogramm neu,
+      diesmal mit eingebetteten Bildern.
     </p>
     <p>
-      <strong>Es verweigert eine sehr große Größe.</strong> Browser begrenzen,
-      wie groß eine Leinwand sein darf, und sie sind sich nicht einig, wo: ab
-      etwa 16.000&nbsp;Pixeln Seitenlänge kommt nichts mehr zurück, und Safari
-      auf einem iPhone oder iPad gibt viel früher auf, bei etwa
-      4096&nbsp;&times;&nbsp;4096. Ein Werkzeug, das Sie warnt, bewahrt Sie vor
-      einer leeren Datei &mdash; denn genau das erzeugt ein Browser, wenn ihm die
-      Luft ausgeht, und keine Fehlermeldung.
+      <strong>Eine sehr große Größe wird abgelehnt.</strong> Browser begrenzen,
+      wie groß eine Leinwand werden darf, und sie sind sich nicht einig, wo:
+      Jenseits von rund 16.000&nbsp;Pixeln Kantenlänge kommt nichts mehr zurück,
+      und Safari auf iPhone und iPad gibt viel früher auf, bei etwa
+      4096&nbsp;&times;&nbsp;4096. Ein Werkzeug, das Sie vorher warnt, bewahrt
+      Sie vor einer leeren Datei &mdash; denn genau die liefert ein Browser, wenn
+      ihm die Luft ausgeht, und eben keine Fehlermeldung.
     </p>
   </section>
 
   <section>
     <h2>Nichts davon braucht einen Upload</h2>
     <p>
-      Ein SVG zu rastern ist etwas, das jeder Browser tausendmal am Tag tut
-      &mdash; es ist dieselbe Maschinerie, die ein Symbol auf einer Webseite
-      zeichnet. Es gibt keinen technischen Grund, warum Ihre Grafik zu einem
-      Server und zurück reisen sollte, um als PNG herauszukommen, und das
-      Werkzeug hier schickt sie nirgendwohin: Die
-      <code>Content-Security-Policy</code> der Seite nennt jede Adresse, die sie
-      kontaktieren darf, und keine davon gehört zu dieser Seite.
+      Ein SVG zu rastern tut jeder Browser tausendmal am Tag &mdash; es ist
+      dieselbe Maschinerie, die ein Symbol auf einer Webseite zeichnet. Es gibt
+      keinen technischen Grund, warum Ihre Grafik zu einem Server und wieder
+      zurück reisen sollte, um als PNG herauszukommen, und das Werkzeug hier
+      schickt sie nirgendwohin: Die <code>Content-Security-Policy</code> der
+      Seite nennt jede Adresse, die sie kontaktieren darf, und keine davon gehört
+      zu dieser Seite.
     </p>
     <p>
-      Bei SVG zählt das mehr als sonst, denn ein SVG ist ein Dokument und kein
-      Bild. Es kann ein Skript und eine entfernte Adresse enthalten, und ein Logo,
-      das Ihnen eine Agentur geschickt hat, ist eine Datei, die Sie nicht
-      geschrieben haben. Durch ein Bild-Element gezeichnet, befindet es sich in
+      Bei SVG wiegt das schwerer als sonst, denn ein SVG ist ein Dokument und
+      kein Bild. Es kann ein Skript und eine entfernte Adresse enthalten, und das
+      Logo, das Ihnen eine Agentur geschickt hat, ist eine Datei, die Sie nicht
+      selbst geschrieben haben. Über ein Bild-Element gezeichnet, landet es in
       dem, was die Spezifikation <em>secure static mode</em> nennt: Das Skript
-      kann nicht laufen, und die Adresse wird nie kontaktiert. Das setzt der
-      Browser durch, nicht die Website.
+      kann nicht laufen, und die Adresse wird nie kontaktiert. Dafür sorgt der
+      Browser, nicht die Website.
     </p>
     <p>
-      Laden Sie die Seite, trennen Sie die Internetverbindung und wandeln Sie
-      trotzdem etwas um, wenn Sie lieber prüfen als glauben.
+      Wer lieber prüft als glaubt, lädt die Seite, trennt die
+      Internetverbindung und wandelt trotzdem etwas um. Drei weitere Proben, die
+      Sie an jedem Werkzeug durchführen können, stehen in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen, die Sie
-      an jedem Werkzeug durchführen können.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/de/pages/guides/convert-an-svg-to-png.toml
@@ -3,15 +3,15 @@
 #
 
 nav = "SVG in PNG umwandeln"
-title = "Ein SVG in der richtigen Größe in ein PNG umwandeln"
-description = "Ein Vektor hat keine eigene Pixelgröße, die Zahl gehört also Ihnen. Woher diese Zahl für einen Bildschirm, ein App-Symbol und einen Drucker kommt, und was sich ändert, wenn eine Zeichnung zu Pixeln wird."
-heading = "Wie Sie ein SVG in der richtigen Größe in ein PNG umwandeln"
+title = "SVG in PNG umwandeln, in der richtigen Größe"
+description = "Ein Vektor hat keine eigene Pixelgröße, die Zahl gehört also Ihnen. Woher sie für Bildschirm, App-Symbol und Drucker kommt und was sich ändert, sobald aus einer Zeichnung Pixel werden."
+heading = "So wandeln Sie ein SVG in der richtigen Größe in ein PNG um"
 lede = """
-    Das Umwandeln ist die leichte Hälfte. Die Frage, die entscheidet, ob das
-    Ergebnis zu etwas taugt, ist die, auf die Ihnen niemand eine Antwort in die
-    Hand gibt: wie viele Pixel? Hier steht, woher diese Zahl kommt, und was eine
-    Zeichnung auf dem Weg dahin verliert, eine zu werden."""
+    Das Umwandeln ist die leichte Hälfte. Über den Nutzen des Ergebnisses
+    entscheidet die Frage, auf die Ihnen niemand die Antwort mitliefert: wie
+    viele Pixel? Hier steht, woher diese Zahl kommt &mdash; und was eine
+    Zeichnung verliert, sobald sie eine wird."""
 updated = "20. August 2026"
-og_title = "Ein SVG in der richtigen Größe in ein PNG umwandeln"
-og_description = "Woher die Pixelzahl tatsächlich kommt, und die drei Dinge, die sich ändern, wenn eine Zeichnung zu Pixeln wird."
+og_title = "SVG in PNG umwandeln, in der richtigen Größe"
+og_description = "Woher die Pixelzahl wirklich kommt, und die drei Dinge, die sich ändern, sobald aus einer Zeichnung Pixel werden."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/convert-heic-to-jpg.html
+++ b/locales/de/pages/guides/convert-heic-to-jpg.html
@@ -3,264 +3,263 @@
     <p>
       Öffnen Sie den
       <a href="../../heic-in-jpg-umwandeln/">HEIC-zu-JPG-Umwandler</a>, ziehen
-      Sie die Fotos hinein und klicken Sie auf &bdquo;Umwandeln&ldquo;. Lassen
-      Sie den Qualitätsregler, wo er ist, und lassen Sie &bdquo;Datum, Kamera und
-      Einstellungen behalten&ldquo; gesetzt, sofern Sie keinen Grund dagegen
-      haben. Sie bekommen JPEGs zurück, je eine Download-Schaltfläche &mdash;
-      oder ein ZIP, wenn es mehrere sind.
+      Sie die Fotos hinein und klicken Sie auf &bdquo;Umwandeln&ldquo;. Den
+      Qualitätsregler lassen Sie stehen, und das Häkchen bei &bdquo;Datum,
+      Kamera und Einstellungen behalten&ldquo; lassen Sie gesetzt, solange
+      nichts dagegen spricht. Zurück kommen JPEGs, jedes mit einer eigenen
+      Schaltfläche &mdash; oder als ZIP, wenn es mehrere sind.
     </p>
     <p>
-      Dabei wird nichts hochgeladen. Das ist für genau diese Aufgabe
-      ungewöhnlich, und der Grund dafür ist die interessante Hälfte dieser Seite.
+      Hochgeladen wird dabei nichts. Für ausgerechnet diese Aufgabe ist das
+      ungewöhnlich, und warum das so ist, macht die interessantere Hälfte dieser
+      Seite aus.
     </p>
   </section>
 
   <section>
-    <h2>Was HEIC eigentlich ist</h2>
+    <h2>Was HEIC überhaupt ist</h2>
     <p>
-      HEIC ist nicht wirklich ein Bildformat in dem Sinne, in dem JPEG eines ist.
-      Es ist ein Container &mdash; dieselbe Box-Struktur, aus der ein MP4 gebaut
-      ist &mdash; mit einem Standbild aus <strong>HEVC</strong>-Video darin. HEVC,
-      auch H.265 genannt, ist der Codec, der den Ihres alten Camcorders abgelöst
-      hat, und er ist sehr gut: Ein iPhone-Foto als HEIC ist ungefähr halb so
-      groß wie dasselbe Foto als JPEG bei gleicher Qualität.
+      HEIC ist kein Bildformat in dem Sinne, in dem JPEG eines ist. Es ist ein
+      Container &mdash; dieselbe Box-Struktur, aus der auch ein MP4 gebaut ist
+      &mdash;, und darin steckt ein Einzelbild aus
+      <strong>HEVC</strong>-Video. HEVC, auch H.265 genannt, ist der Nachfolger
+      des Codecs aus Ihrem alten Camcorder, und er ist ausgesprochen gut: Ein
+      iPhone-Foto im HEIC ist bei gleicher Qualität ungefähr halb so groß wie
+      dasselbe Foto als JPEG.
     </p>
     <p>
-      Apple ist mit iOS 11 im Jahr 2017 darauf umgestiegen und hat es zur
-      Voreinstellung gemacht. Das heißt: Sofern niemand in die Einstellungen
-      gegangen ist und &bdquo;Maximale Kompatibilität&ldquo; gewählt hat, ist
-      jedes Foto, das dieses Telefon seit gut einem Jahrzehnt aufgenommen hat, in
-      einem Format, das
+      Apple hat 2017 mit iOS 11 umgestellt und HEIC zur Voreinstellung gemacht.
+      Das bedeutet: Solange niemand in den Einstellungen auf &bdquo;Maximale
+      Kompatibilität&ldquo; gewechselt hat, liegt jedes Foto aus gut einem
+      Jahrzehnt in einem Format, das
     </p>
     <ul>
       <li>Windows ohne eine Erweiterung aus dem Store nicht in der Vorschau
-        zeigt;</li>
-      <li>die meisten Upload-Formulare im Web rundweg ablehnen;</li>
-      <li>von dem eine ganze Menge älterer Desktop-Software nie gehört hat;</li>
-      <li>und das kein Webbrowser außer Safari anzeigt.</li>
+        anzeigt,</li>
+      <li>die meisten Upload-Formulare rundheraus ablehnen,</li>
+      <li>von dem eine Menge älterer Programme noch nie gehört hat,</li>
+      <li>und das außer Safari kein Browser darstellt.</li>
     </ul>
     <p>
-      Mit dem Foto ist alles in Ordnung. Es ist eine bessere Datei, als das JPEG
-      gewesen wäre. Es ist nur in einer Sprache geschrieben, die der größte Teil
-      der Welt nie gelernt hat.
+      Mit dem Foto selbst ist alles in Ordnung. Es ist die bessere Datei, als
+      das JPEG geworden wäre. Sie ist nur in einer Sprache geschrieben, die der
+      größte Teil der Welt nie gelernt hat.
     </p>
   </section>
 
   <section>
-    <h2>Warum nur Safari eines öffnet</h2>
+    <h2>Warum nur Safari eines aufbekommt</h2>
     <p>
-      Das ist der Teil, der jeden Umwandler erklärt, den Sie je benutzt haben, und
-      deshalb einen Absatz wert.
+      Dieser Abschnitt erklärt jeden Konverter, den Sie je benutzt haben, und
+      ist die paar Zeilen deshalb wert.
     </p>
     <p>
-      HEVC zu dekodieren braucht einen HEVC-Decoder, und HEVC ist patentiert. Die
-      Lizenzierung wird von mehr als einem Patentpool verwaltet, und einen
-      Decoder auszuliefern heißt, jemanden zu bezahlen. Browser gehen damit um,
-      indem sie sich auf das Betriebssystem stützen &mdash; Chrome spielt
-      HEVC-<em>Video</em> auf einem Gerät ab, dessen Hardware bereits einen
-      lizenzierten Decoder hat &mdash;, aber dieser Weg ist für die
-      Videowiedergabe verdrahtet und nicht für Standbilder. Ein an
-      <code>&lt;img&gt;</code> übergebenes HEIC wird also abgewiesen, in Chrome,
-      Firefox und Edge gleichermaßen, auf jedem Betriebssystem.
+      Wer HEVC dekodieren will, braucht einen HEVC-Decoder &mdash; und HEVC ist
+      patentiert. Die Lizenzen verwaltet mehr als ein Patentpool, und einen
+      Decoder auszuliefern heißt, jemanden zu bezahlen. Browser umgehen das,
+      indem sie sich auf das Betriebssystem stützen: Chrome spielt
+      HEVC-<em>Video</em> auf Geräten ab, deren Hardware ohnehin einen
+      lizenzierten Decoder mitbringt. Nur ist dieser Weg für die
+      Videowiedergabe verdrahtet und nicht für Standbilder. Ein HEIC, das an
+      <code>&lt;img&gt;</code> gereicht wird, fällt also durch &mdash; in
+      Chrome, Firefox und Edge gleichermaßen, auf jedem Betriebssystem.
     </p>
     <p>
-      Safari auf Apple-Hardware ist die Ausnahme, weil macOS und iOS den Decoder
+      Die Ausnahme ist Safari auf Apple-Hardware, weil macOS und iOS den Decoder
       haben und Safari ihn fragen darf. Überall sonst ist das Bild für den
-      Browser schlicht nicht dekodierbar.
+      Browser schlicht nicht zu dekodieren.
     </p>
     <p>
-      Womit einem Umwandler genau zwei Möglichkeiten bleiben &mdash; und die Wahl
-      zwischen ihnen ist die ganze Geschichte dieser Art von Werkzeug.
+      Damit bleiben einem Konverter genau zwei Möglichkeiten &mdash; und in der
+      Wahl zwischen ihnen steckt die ganze Geschichte dieser Werkzeuggattung.
     </p>
   </section>
 
   <section>
-    <h2>Warum fast jeder HEIC-Umwandler einen Upload will</h2>
+    <h2>Warum beinahe jeder HEIC-Konverter einen Upload verlangt</h2>
     <p>
       Möglichkeit eins: den Decoder auf einen Server legen. Das Foto wird
-      hochgeladen, auf einer Maschine dekodiert, die Sie nie gesehen haben, als
-      JPEG neu kodiert und zurückgeschickt. Das ist es, was nahezu jeder
-      &bdquo;kostenlose Online-HEIC-Umwandler&ldquo; tut, und es ist der Grund,
-      warum sie alle Ihre Dateien brauchen. Es ist keine Faulheit &mdash; der
-      Browser kann es ohne Hilfe wirklich nicht.
+      hochgeladen, auf einer Maschine dekodiert, die Sie nie zu Gesicht bekommen,
+      als JPEG neu kodiert und zurückgeschickt. So arbeitet praktisch jeder
+      &bdquo;kostenlose Online-HEIC-Konverter&ldquo;, und deshalb brauchen sie
+      alle Ihre Dateien. Das ist keine Bequemlichkeit &mdash; ohne Hilfe kann der
+      Browser es tatsächlich nicht.
     </p>
     <p>
-      Was das kostet, ist es wert, unverblümt gesagt zu werden. Fotos von einem
-      Telefon sind die persönlichsten Dateien, die die meisten Menschen besitzen,
-      und ein HEIC direkt vom iPhone trägt typischerweise die Koordinaten des
-      Aufnahmeortes auf wenige Meter genau, dazu das Datum auf die Sekunde und
-      eine Kamerakennung. Einen Ordner davon zu einem kostenlosen Dienst
-      hochzuladen heißt, beides zu übergeben: die Bilder und das. Was danach
-      passiert, regelt eine Datenschutzerklärung, die Sie nicht gelesen haben,
-      auf einem Server, den Sie nicht einsehen können, in einer Rechtsordnung,
-      die Sie nicht gewählt haben.
+      Was das kostet, sollte man unverblümt sagen. Fotos vom Handy sind die
+      persönlichsten Dateien, die die meisten überhaupt besitzen, und ein HEIC
+      direkt aus dem iPhone trägt in aller Regel die Koordinaten des
+      Aufnahmeorts auf wenige Meter genau mit sich, dazu das Datum auf die
+      Sekunde und eine Kamerakennung. Wer einen ganzen Ordner davon zu einem
+      Gratisdienst hochlädt, gibt beides aus der Hand: die Bilder und all das.
+      Was danach damit geschieht, regelt eine Datenschutzerklärung, die Sie nicht
+      gelesen haben, auf einem Server, in den Sie nicht hineinsehen können, in
+      einem Land, das Sie nicht ausgesucht haben.
     </p>
     <p>
       Möglichkeit zwei: den Decoder auf die Seite legen. Genau das tut
-      <a href="../../heic-in-jpg-umwandeln/">dieser hier</a>. Er trägt
-      <code>libheif</code>, nach WebAssembly kompiliert, als Datei, die von dieser
-      Seite ausgeliefert wird &mdash; rund 1,4 MB, einmal heruntergeladen und
-      danach zwischengespeichert. Ihr Browser führt sie auf Ihrem eigenen Gerät,
-      auf Ihrer eigenen Hardware aus, und das Foto geht nirgendwohin. Laden Sie
-      die Seite einmal, und Sie können die Internetverbindung völlig trennen, und
-      sie arbeitet weiter &mdash; etwas, das kein hochladender Umwandler kann,
-      und der einfachste Beweis, den es gibt.
+      <a href="../../heic-in-jpg-umwandeln/">dieser hier</a>. Er bringt
+      <code>libheif</code> mit, nach WebAssembly übersetzt, als Datei von dieser
+      Seite &mdash; rund 1,4 MB, einmal geladen und danach zwischengespeichert.
+      Ausgeführt wird sie von Ihrem Browser, auf Ihrem eigenen Gerät, und das
+      Foto bleibt, wo es ist. Laden Sie die Seite einmal, dann können Sie die
+      Internetverbindung vollständig kappen, und sie arbeitet weiter &mdash; was
+      kein hochladender Konverter kann und der denkbar einfachste Beweis ist.
     </p>
     <p>
-      Die 1,4 MB sind der ganze Preis. Sitzen Sie an einer volumenbegrenzten
-      Verbindung, sind sie ein echter Kostenpunkt und wissenswert; deshalb sagt
-      die Seite es laut, statt sie still herunterzuladen.
+      Diese 1,4 MB sind der ganze Preis. An einer Verbindung mit Datenvolumen
+      sind sie ein echter Posten und deshalb der Rede wert &mdash; und deshalb
+      sagt die Seite es laut, statt sie klammheimlich zu laden.
     </p>
   </section>
 
   <section>
-    <h2>Was das Umwandeln das Bild kostet</h2>
+    <h2>Was die Umwandlung das Bild kostet</h2>
     <p>
-      HEIC und JPEG sind verschiedene Codecs, es gibt also keinen Weg hinüber,
-      der nicht das Dekodieren des Bildes und ein erneutes Kodieren umfasst.
-      Dieses zweite Kodieren ist verlustbehaftet. In der Praxis zählt das viel
-      weniger, als es klingt:
+      HEIC und JPEG sind verschiedene Codecs. Es führt also kein Weg hinüber,
+      der nicht darin bestünde, das Bild zu dekodieren und neu zu kodieren, und
+      dieses zweite Kodieren ist verlustbehaftet. In der Praxis fällt das sehr
+      viel weniger ins Gewicht, als es klingt:
     </p>
     <ul>
       <li>
-        <strong>Bei Qualität 92</strong> &mdash; wo der Umwandler beginnt &mdash;
-        ist eine Fotografie in jeder normalen Betrachtungsgröße sehr schwer vom
-        Original zu unterscheiden. Sie suchen nach Unterschieden in weichen
-        Verläufen, etwa einem klaren Himmel, und werden sie im Allgemeinen nicht
-        finden.
+        <strong>Bei Qualität 92</strong> &mdash; damit fängt der Konverter an
+        &mdash; ist eine Fotografie in jeder normalen Betrachtungsgröße kaum vom
+        Original zu unterscheiden. Suchen müssten Sie in weichen Verläufen, etwa
+        in einem klaren Himmel, und finden werden Sie dort in der Regel nichts.
       </li>
       <li>
-        <strong>Das JPEG wird größer sein.</strong> Meist zwischen einem Drittel
-        größer und doppelt so groß, weil JPEG ein Codec von 1992 ist und HEVC
-        nicht. Das ist der Handel: eine größere Datei, die alles öffnet.
+        <strong>Das JPEG wird größer.</strong> Meist um ein Drittel bis auf das
+        Doppelte, denn JPEG ist ein Codec von 1992 und HEVC nicht. Das ist der
+        Handel: eine größere Datei, dafür eine, die überall aufgeht.
       </li>
       <li>
-        <strong>Zweimal umzuwandeln ist das, was Sie vermeiden sollten.</strong>
-        Jede verlustbehaftete Kodierung kostet ein wenig. Wandeln Sie vom
-        ursprünglichen HEIC um und nicht von einem JPEG, das jemand schon für Sie
-        gemacht hat, und tun Sie es einmal.
+        <strong>Zweimal umzuwandeln ist das, was Sie sich sparen
+        sollten.</strong> Jede verlustbehaftete Kodierung kostet ein wenig.
+        Gehen Sie vom ursprünglichen HEIC aus und nicht von einem JPEG, das
+        Ihnen schon jemand gemacht hat, und tun Sie es genau einmal.
       </li>
     </ul>
     <p>
-      Wollen Sie überhaupt keinen Verlust, steht PNG im Formatmenü. Stellen Sie
-      sich auf die Datei ein: Eine Fotografie als PNG ist üblicherweise fünf- bis
-      zehnmal so groß wie das JPEG, weil die Kompression von PNG für flache
-      Farbflächen und Strichzeichnungen entworfen wurde und nicht für Gras und
-      Haut.
+      Wollen Sie überhaupt keinen Verlust, steht PNG im Formatmenü. Rechnen Sie
+      dann aber mit der Dateigröße: Eine Fotografie als PNG ist üblicherweise
+      fünf- bis zehnmal so groß wie das JPEG, weil die PNG-Kompression für
+      einfarbige Flächen und Strichzeichnungen gedacht war und nicht für Gras
+      und Haut.
     </p>
   </section>
 
   <section>
-    <h2>Das Datum, die Kamera und die Koordinaten</h2>
+    <h2>Datum, Kamera und Koordinaten</h2>
     <p>
-      Die übliche Klage über HEIC-Umwandler ist, dass die Fotos ohne den Tag
-      zurückkommen, an dem sie aufgenommen wurden &mdash; ein ganzer Urlaub
-      sortiert sich dann unter dem heutigen Datum ans Ende der Mediathek. Das
-      passiert, weil das Umwandeln über eine Leinwand Ihnen Pixel gibt und sonst
-      nichts &mdash; eine Leinwand hält keine Tags &mdash;, also ist alles
-      schlicht weg, sofern ein Umwandler die Metadaten nicht eigens holt.
+      Die häufigste Klage über HEIC-Konverter lautet, dass die Fotos ohne ihr
+      Aufnahmedatum zurückkommen &mdash; ein ganzer Urlaub sortiert sich dann
+      unter dem heutigen Datum ans Ende der Mediathek. Das liegt daran, dass eine
+      Umwandlung über die Leinwand nur Pixel liefert und sonst nichts: Eine
+      Leinwand trägt keine Tags. Holt ein Konverter die Metadaten nicht eigens
+      nach, sind sie schlicht weg.
     </p>
     <p>
-      Das Werkzeug hier kopiert den EXIF-Block aus dem HEIC heraus und schreibt
-      ihn ins JPEG, das Datum überlebt also. Es gibt ein Häkchen, und es ist
-      standardmäßig gesetzt. Nehmen Sie es heraus, und das JPEG kommt mit dem
-      Bild und sonst nichts heraus.
+      Das Werkzeug hier liest den EXIF-Block aus dem HEIC heraus und schreibt ihn
+      ins JPEG, das Datum überlebt also. Dafür gibt es ein Häkchen, und es ist
+      von vornherein gesetzt. Nehmen Sie es heraus, kommt das JPEG mit dem Bild
+      heraus und mit sonst gar nichts.
     </p>
     <p>
-      Bevor Sie entscheiden, sehen Sie sich die Liste an: Die Zeile jedes Fotos
-      sagt, ob die Datei GPS-Koordinaten trägt, und sie sagt es, bevor
-      irgendetwas umgewandelt wird. Gehen die Fotos irgendwohin, wo sie
-      öffentlich sind, ist das die Zeile zum Lesen. Gehen sie in Ihre eigene
-      Mediathek, ist die Metadaten zu behalten mit ziemlicher Sicherheit das, was
-      Sie wollen.
+      Bevor Sie sich entscheiden, sehen Sie in die Liste: In der Zeile jedes
+      Fotos steht, ob die Datei GPS-Koordinaten trägt, und zwar bevor
+      irgendetwas umgewandelt wird. Gehen die Fotos an einen öffentlichen Ort,
+      ist das die Zeile, auf die es ankommt. Wandern sie in Ihre eigene
+      Mediathek, wollen Sie die Metadaten mit ziemlicher Sicherheit behalten.
     </p>
     <p>
-      Ein Tag wird geändert, was Sie auch wählen, und es lohnt sich zu wissen,
-      warum. Ein HEIC hält seine Drehung an zwei Stellen fest: im Container und
-      im EXIF-Block. Der Decoder wendet die Drehung des Containers beim
-      Dekodieren an, die übergebenen Pixel liegen also schon richtig herum. Stünde
-      im EXIF dann immer noch &bdquo;dreh das um 90 Grad&ldquo;, täte ein
-      Betrachter es noch einmal, und jedes Hochformatfoto käme quer heraus. Das
-      Orientierungs-Tag wird also auf aufrecht gesetzt, und alles andere wird
-      exakt so kopiert, wie das Telefon es geschrieben hat.
+      Ein Tag wird in jedem Fall geändert, und der Grund ist eine Erklärung wert.
+      Ein HEIC hält seine Drehung an zwei Stellen fest: im Container und im
+      EXIF-Block. Der Decoder wendet die Drehung des Containers schon beim
+      Dekodieren an, die herausgereichten Pixel liegen also bereits richtig
+      herum. Stünde im EXIF weiterhin &bdquo;um 90 Grad drehen&ldquo;, würde
+      jeder Betrachter das ein zweites Mal tun, und jedes Hochformatfoto käme
+      quer heraus. Das Orientierungs-Tag wird deshalb auf aufrecht gesetzt
+      &mdash; alles andere wird genau so übernommen, wie das Handy es
+      geschrieben hat.
     </p>
     <p>
-      Wollen Sie die Tags im Detail durchgehen oder sie aus Fotos entfernen, die
-      schon JPEGs sind, ist das eine andere Aufgabe, und dafür gibt es einen
-      <a href="../exif-und-gps-daten-entfernen/">eigenen Ratgeber</a>.
+      Wollen Sie die Tags im Einzelnen durchgehen oder sie aus Fotos entfernen,
+      die längst JPEGs sind, ist das eine andere Aufgabe, und dafür gibt es
+      einen <a href="../exif-und-gps-daten-entfernen/">eigenen Ratgeber</a>.
     </p>
   </section>
 
   <section>
-    <h2>Was Menschen überrascht</h2>
+    <h2>Worüber man dabei stolpert</h2>
     <ul>
       <li>
-        <strong>Ein HEIC, das &bdquo;.jpg&ldquo; heißt.</strong> Ausgesprochen
-        häufig: Irgendetwas unterwegs hat es umbenannt, ohne es umzuwandeln, und
-        deshalb öffnet es weiterhin nicht. Jede auf den Umwandler gezogene Datei
-        wird an ihren ersten Bytes erkannt und nicht an ihrem Namen, eine solche
-        funktioniert also einwandfrei. Es ist auch der Grund, warum einer Datei,
-        die wirklich ein JPEG ist, das gesagt wird, statt sie in eine Kopie ihrer
-        selbst umzuwandeln.
+        <strong>Ein HEIC, das &bdquo;.jpg&ldquo; heißt.</strong> Kommt ständig
+        vor: Irgendetwas hat die Datei unterwegs umbenannt, ohne sie
+        umzuwandeln, und deshalb geht sie nach wie vor nicht auf. Jede Datei, die
+        Sie auf den Konverter ziehen, wird an ihren ersten Bytes erkannt und
+        nicht an ihrem Namen &mdash; eine solche funktioniert also anstandslos.
+        Aus demselben Grund bekommt eine Datei, die wirklich ein JPEG ist, das
+        gesagt, statt in eine Kopie ihrer selbst verwandelt zu werden.
       </li>
       <li>
         <strong>Eine Datei, mehrere Bilder.</strong> Eine Serienaufnahme oder ein
-        Live Photo kann mehr als ein Standbild enthalten. Alle werden umgewandelt,
-        und die zusätzlichen werden nach dem ursprünglichen Namen durchnummeriert.
-        Die Videohälfte eines Live Photos ist eine eigene Datei, die das Telefon
-        neben dem HEIC aufbewahrt, sie ist also gar nicht darin, um umgewandelt zu
-        werden.
+        Live Photo kann mehr als ein Einzelbild enthalten. Umgewandelt werden
+        alle, die zusätzlichen durchnummeriert nach dem ursprünglichen Namen. Die
+        Videohälfte eines Live Photos liegt als eigene Datei neben dem HEIC, sie
+        steckt also gar nicht darin.
       </li>
       <li>
-        <strong>AVIF ist nicht HEIC.</strong> Sie sehen sich ähnlich &mdash;
-        derselbe Container, ein anderer Codec darin &mdash;, aber jeder aktuelle
-        Browser öffnet ein AVIF von Haus aus; es gibt also nichts umzuwandeln,
-        und das Werkzeug sagt das, statt so zu tun, als arbeite es.
+        <strong>AVIF ist nicht HEIC.</strong> Die beiden sehen sich ähnlich
+        &mdash; derselbe Container, ein anderer Codec darin &mdash;, aber ein
+        AVIF öffnet jeder aktuelle Browser von Haus aus. Da ist nichts
+        umzuwandeln, und das Werkzeug sagt Ihnen das, statt Arbeit vorzutäuschen.
       </li>
       <li>
-        <strong>Das Problem an der Quelle abstellen.</strong> Auf dem Telefon:
-        Einstellungen &rarr; Kamera &rarr; Formate &rarr; Maximale
-        Kompatibilität. Neue Fotos sind von da an JPEGs. Es braucht mehr
-        Speicher und ändert nichts an den Fotos, die Sie schon haben, aber es
-        heißt, das hier nie wieder tun zu müssen.
+        <strong>Das Übel an der Wurzel packen.</strong> Am Handy: Einstellungen
+        &rarr; Kamera &rarr; Formate &rarr; Maximale Kompatibilität. Von da an
+        sind neue Fotos JPEGs. Das kostet Speicherplatz und ändert nichts an den
+        Fotos, die Sie schon haben &mdash; aber Sie müssen das hier nie wieder
+        tun.
       </li>
       <li>
-        <strong>Teilen wandelt manchmal schon um.</strong> Ein Foto per AirDrop
-        oder E-Mail an ein Nicht-Apple-Gerät zu geben übergibt oft ein JPEG, weil
-        iOS auf dem Weg hinaus umwandelt. Ist ein Foto trotzdem als HEIC
-        angekommen, kam es auf einem Weg herüber, der das nicht tat.
+        <strong>Teilen wandelt manchmal von selbst um.</strong> Wer ein Foto per
+        AirDrop oder E-Mail an ein Gerät ohne Apple-Logo schickt, gibt oft schon
+        ein JPEG heraus, weil iOS auf dem Weg nach draußen umwandelt. Kam ein
+        Foto trotzdem als HEIC an, hat es einen Weg genommen, auf dem das nicht
+        passiert.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Woran Sie erkennen, ob ein Umwandler hochlädt</h2>
+    <h2>Woran Sie merken, ob ein Konverter hochlädt</h2>
     <p>
-      Das gilt für jedes Werkzeug, nicht nur für dieses, und es dauert etwa
-      fünfzehn Sekunden.
+      Das gilt für jedes Werkzeug und nicht nur für dieses, und es dauert eine
+      Viertelminute.
     </p>
     <ol>
       <li>
-        Öffnen Sie die Seite, öffnen Sie dann die Entwicklerwerkzeuge Ihres
-        Browsers und gehen Sie auf den Netzwerk-Tab.
+        Seite öffnen, dann die Entwicklerwerkzeuge des Browsers aufrufen und auf
+        den Tab &bdquo;Netzwerk&ldquo; wechseln.
       </li>
       <li>
-        Wandeln Sie ein Foto um und schauen Sie zu. Ein Werkzeug, das auf Ihrem
-        Gerät dekodiert, stellt in diesem Moment überhaupt keine Anfrage. Ein
-        Werkzeug, das hochlädt, stellt eine in der Größe Ihres Fotos &mdash; und
-        die Größe sehen Sie.
+        Ein Foto umwandeln und zusehen. Ein Werkzeug, das auf Ihrem Gerät
+        dekodiert, stellt in diesem Moment überhaupt keine Anfrage. Eines, das
+        hochlädt, stellt eine in der Größe Ihres Fotos &mdash; und diese Größe
+        steht da.
       </li>
       <li>
-        Oder, noch einfacher: Seite laden, Internetverbindung trennen und
-        versuchen, etwas umzuwandeln. Ein Werkzeug, das Ihr Foto zum Dekodieren
-        weggeschickt hat, hört auf zu arbeiten. Eines, das den Decoder mit sich
-        trägt, nicht.
+        Oder noch einfacher: Seite laden, Internetverbindung trennen und
+        trotzdem etwas umwandeln wollen. Ein Werkzeug, das Ihr Foto zum
+        Dekodieren weggeschickt hat, bleibt stehen. Eines, das den Decoder selbst
+        mitbringt, nicht.
       </li>
     </ol>
     <p>
-      Der Umwandler hier ist so gebaut, dass er beide Prüfungen besteht, und eine
-      ausführlichere Fassung dieses Arguments steht in
+      Der Konverter hier ist so gebaut, dass er beide Proben besteht. Ausführlich
+      steht dieselbe Überlegung in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      hochzuladen?</a>.
+      hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/de/pages/guides/convert-heic-to-jpg.toml
@@ -3,15 +3,15 @@
 #
 
 nav = "HEIC zu JPG"
-title = "HEIC in JPG umwandeln (und was HEIC eigentlich ist)"
-description = "iPhones speichern Fotos als HEIC, und das halbe Internet kann keines öffnen. Was das Format ist, warum nur Safari es dekodiert, was das Umwandeln das Bild kostet, und wie es geht, ohne die Fotos irgendjemandem hochzuladen."
-heading = "Das Foto, das Ihr Telefon gespeichert hat, und das Format, das nichts öffnet"
+title = "HEIC in JPG umwandeln (und was HEIC überhaupt ist)"
+description = "iPhones speichern Fotos als HEIC, und das halbe Internet bekommt keines auf. Was hinter dem Format steckt, warum nur Safari es dekodiert, was die Umwandlung das Bild kostet und wie sie ohne Upload gelingt."
+heading = "Das Foto, das Ihr Handy gespeichert hat, und das Format, das niemand öffnet"
 lede = """
-    Ein iPhone speichert Fotos als HEIC &mdash; kleiner und besser als JPEG, und
-    von einer ganzen Menge Software noch immer verweigert. Hier steht, was das
-    Format wirklich ist, was das Umwandeln das Bild kostet, und warum fast jeder
-    Umwandler es zuerst von Ihnen hochgeladen haben will."""
+    Ein iPhone speichert Fotos als HEIC: kleiner und besser als JPEG &mdash;
+    und von erstaunlich viel Software bis heute verweigert. Hier steht, was
+    hinter dem Format steckt, was die Umwandlung das Bild kostet und warum
+    beinahe jeder Konverter die Fotos erst einmal hochgeladen haben will."""
 updated = "20. August 2026"
-og_title = "Wie Sie HEIC in JPG umwandeln"
-og_description = "Warum iPhone-Fotos nicht öffnen, was das Umwandeln kostet, und wie es geht, ohne die Fotos jemandem zu übergeben."
+og_title = "So wandeln Sie HEIC in JPG um"
+og_description = "Warum iPhone-Fotos nirgends aufgehen, was die Umwandlung kostet und wie sie gelingt, ohne die Fotos aus der Hand zu geben."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/crop-a-video.html
+++ b/locales/de/pages/guides/crop-a-video.html
@@ -2,222 +2,220 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie den <a href="../../video-zuschneiden/">Video-Zuschneider</a>,
-      ziehen Sie den Clip hinein, ziehen Sie den Rahmen über den Teil, den Sie
-      behalten wollen &mdash; oder legen Sie ihn auf ein Format fest, wenn Ihnen
-      eines vorgegeben wurde &mdash; und exportieren Sie. Der Clip, der
-      herauskommt, ist genauso lang wie der, der hineinging, mit unversehrtem
-      Timing und Ton.
+      ziehen Sie den Clip hinein, legen Sie den Rahmen über den Teil, den Sie
+      behalten wollen &mdash; oder rasten Sie ihn auf ein vorgegebenes
+      Seitenverhältnis ein &mdash; und exportieren Sie. Heraus kommt ein Clip,
+      der genauso lang ist wie der hineingegangene, mit unversehrtem Timing und
+      unversehrtem Ton.
     </p>
     <p>
       Anders als beim Kürzen müssen hier neue Einzelbilder geschrieben werden.
-      Das ist kein Mangel eines bestimmten Werkzeugs; es ist das, was Zuschneiden
-      ist. Der Rest dieser Seite handelt davon, was das kostet und wie Sie es
-      klein halten.
+      Das ist kein Mangel eines bestimmten Werkzeugs, sondern das Wesen des
+      Zuschneidens. Der Rest dieser Seite handelt davon, was das kostet und wie
+      Sie den Preis klein halten.
     </p>
   </section>
 
   <section>
-    <h2>Warum Zuschneiden einer Neukodierung nicht ausweichen kann</h2>
+    <h2>Warum Zuschneiden ohne Neukodierung nicht geht</h2>
     <p>
-      Ein Schnitt behält ganze Einzelbilder, ein guter Schneider bewegt sie also
-      unangetastet hinüber und dekodiert überhaupt nichts. Ein Zuschnitt behält
-      einen Teil jedes Einzelbildes &mdash; und ein Teil eines Einzelbildes ist
-      ein anderes Bild. Es gibt keine Möglichkeit, ein anderes Bild zu speichern,
-      ohne die Pixel neu zu schreiben.
+      Beim Kürzen bleiben ganze Einzelbilder erhalten; ein gutes Werkzeug
+      schiebt sie unangetastet hinüber und dekodiert überhaupt nichts. Beim
+      Zuschneiden bleibt von jedem Einzelbild nur ein Ausschnitt übrig &mdash;
+      und ein Ausschnitt ist ein anderes Bild. Ein anderes Bild lässt sich nicht
+      speichern, ohne die Pixel neu zu schreiben.
     </p>
     <p>
-      Es gibt eine enge Ausnahme, und die sollte man kennen, um zu erkennen, wenn
-      jemand sie für sich beansprucht. Video wird in Blöcken kodiert, und läge
-      ein Zuschnitt auf allen vier Seiten exakt auf Blockgrenzen, ließen sich
-      Teile der Daten im Prinzip wiederverwenden. In der Praxis müssen die
-      Abmessungen des Einzelbildes, die Bewegungsvektoren und die Prädiktion
-      ohnehin alle neu geschrieben werden, es wird also nichts Echtes so gebaut.
-      Gehen Sie davon aus, dass ein Zuschnitt eine Neukodierung bedeutet.
+      Es gibt eine sehr enge Ausnahme, die man kennen sollte, um sie zu erkennen,
+      wenn jemand sich darauf beruft. Video wird in Blöcken kodiert, und läge ein
+      Zuschnitt auf allen vier Seiten exakt auf Blockgrenzen, ließe sich ein Teil
+      der Daten im Prinzip weiterverwenden. In der Praxis müssen die Abmessungen
+      des Einzelbildes, die Bewegungsvektoren und die Prädiktion ohnehin allesamt
+      neu geschrieben werden &mdash; nichts Ernsthaftes ist so gebaut. Rechnen Sie
+      damit, dass ein Zuschnitt eine Neukodierung bedeutet.
     </p>
     <p>
-      Was ein anständiger Zuschneider tut, ist: nicht <em>mehr</em> auszugeben,
-      als das Original für denselben Ausschnitt ausgegeben hat. Einen
-      zugeschnittenen Bereich mit höherer Bitrate zu kodieren als seine Quelle
-      macht die Datei nur größer; Detail, das das Original nicht hatte, kann es
-      nicht zurückbringen.
+      Woran man ein anständiges Werkzeug erkennt: Es gibt für denselben
+      Ausschnitt nicht <em>mehr</em> aus, als das Original dafür ausgegeben hat.
+      Einen Ausschnitt mit höherer Bitrate zu kodieren als seine Quelle macht die
+      Datei bloß größer &mdash; Detail, das im Original nie war, holt es nicht
+      zurück.
     </p>
   </section>
 
   <section>
-    <h2>Die Formate, nach denen Sie tatsächlich gefragt werden</h2>
+    <h2>Die Formate, nach denen tatsächlich gefragt wird</h2>
     <p>
-      Zugeschnitten wird meistens, weil irgendwo ein Seitenverhältnis
+      Zugeschnitten wird meist deshalb, weil irgendwo ein Seitenverhältnis
       vorgeschrieben ist. Die kurze Liste:
     </p>
     <ul>
       <li>
         <strong>9:16 &mdash; hochkant.</strong> Stories, Reels, Shorts, TikTok.
-        Bildschirmfüllend auf einem normal gehaltenen Telefon. Der häufigste
-        Grund, überhaupt ein Video zuzuschneiden.
+        Bildschirmfüllend auf einem normal gehaltenen Handy, und der häufigste
+        Grund, ein Video überhaupt zuzuschneiden.
       </li>
       <li>
         <strong>1:1 &mdash; quadratisch.</strong> Feed-Beiträge auf mehreren
-        Plattformen. Funktioniert, wie herum der Betrachter sein Telefon auch
-        hält &mdash; und deshalb hält es sich.
+        Plattformen. Es funktioniert, egal wie herum das Gegenüber sein Handy
+        hält &mdash; und genau deshalb hält es sich so hartnäckig.
       </li>
       <li>
         <strong>4:5 &mdash; leicht hochkant.</strong> Das größte Format, das
-        manche Feeds erlauben, es nimmt also mehr vom Schirm ein als ein Quadrat,
-        ohne ein volles Hochkantvideo zu sein.
+        manche Feeds zulassen. Es nimmt mehr Bildschirm ein als ein Quadrat, ohne
+        gleich ein volles Hochkantvideo zu sein.
       </li>
       <li>
-        <strong>16:9 &mdash; breit.</strong> Der Standard für Video überhaupt.
+        <strong>16:9 &mdash; breit.</strong> Der Standard für Video schlechthin.
         <em>Darauf</em> schneiden Sie meist nur zu, um schwarze Balken
-        loszuwerden, oder <em>davon</em> weg, um eines der obigen zu bekommen.
+        loszuwerden, und <em>davon</em> weg, um bei einem der anderen Formate zu
+        landen.
       </li>
     </ul>
     <p>
-      Legen Sie den Rahmen auf das Verhältnis fest, statt nach Augenmaß zu
-      ziehen. Ein paar Pixel daneben bedeutet, dass die Plattform Ihren Zuschnitt
-      zuschneidet &mdash; und sie fragt Sie nicht, wo.
+      Rasten Sie den Rahmen auf das Verhältnis ein, statt nach Augenmaß zu
+      ziehen. Ein paar Pixel daneben heißt, dass die Plattform Ihren Zuschnitt
+      noch einmal zuschneidet &mdash; und wo, fragt sie Sie nicht.
     </p>
   </section>
 
   <section>
     <h2>Aus einem Querformat-Clip ein Hochformat machen</h2>
     <p>
-      Das ist der schwierigste der häufigen Fälle, und es ist wichtig, klar zu
-      sagen: Zuschneiden ist hier ein Kompromiss und keine Lösung.
+      Das ist der schwierigste der üblichen Fälle, und man sollte offen sagen:
+      Zuschneiden ist hier ein Kompromiss und keine Lösung.
     </p>
     <p>
-      Ein auf 9:16 zugeschnittenes 16:9-Video behält etwa 32&nbsp;% der
-      Bildbreite. Was an den Seiten war, ist weg &mdash; und in einer
-      Querformataufnahme sind die Seiten meist dort, wo der Kontext steckt. Reden
-      zwei Personen an gegenüberliegenden Bildrändern, behält kein einziger
-      Zuschnitt beide.
+      Von einem 16:9-Video bleiben bei einem Zuschnitt auf 9:16 rund 32&nbsp;%
+      der Bildbreite übrig. Was an den Rändern war, ist fort &mdash; und in einer
+      Querformataufnahme steckt an den Rändern meist der Zusammenhang. Reden zwei
+      Personen an gegenüberliegenden Bildkanten, behält kein einziger Zuschnitt
+      beide.
     </p>
     <p>
-      Wählen Sie den Zuschnitt, indem Sie den Clip einmal ansehen und sich
-      fragen, wo das Motiv die meiste Zeit tatsächlich ist. Lautet die Antwort
-      &bdquo;es bewegt sich&ldquo;, ist ein starrer Zuschnitt das falsche
-      Werkzeug, und Sie brauchen ein Schnittprogramm, das den Ausschnitt über die
-      Zeit mitführen kann. Lautet sie &bdquo;meistens mittig&ldquo;, ist ein
-      zentrierter Zuschnitt in Ordnung und dauert zehn Sekunden.
+      Sehen Sie sich den Clip deshalb einmal an und fragen Sie sich, wo das Motiv
+      die meiste Zeit über wirklich steckt. Lautet die Antwort &bdquo;es wandert
+      herum&ldquo;, ist ein starrer Zuschnitt das falsche Werkzeug; dann brauchen
+      Sie ein Schnittprogramm, das den Ausschnitt über die Zeit mitführen kann.
+      Lautet sie &bdquo;überwiegend in der Mitte&ldquo;, genügt ein zentrierter
+      Zuschnitt, und der ist in zehn Sekunden gemacht.
     </p>
     <p>
-      Die Alternative, an die man sich erinnern sollte: Viele Plattformen nehmen
-      ein Querformatvideo an und legen selbst Balken darum. Zuschneiden ist
-      dafür da, den ganzen Schirm zu wollen &mdash; nicht dafür, dass das Video
-      angenommen wird.
-    </p>
-  </section>
-
-  <section>
-    <h2>Warum sich Breite und Höhe in Zweierschritten bewegen</h2>
-    <p>
-      Fällt Ihnen auf, dass der Zuschnittrahmen ungerade Zahlen verweigert, ist
-      das der Codec und nicht die Oberfläche, die sich zickig anstellt.
-    </p>
-    <p>
-      H.264 &mdash; der Codec in einem MP4 &mdash; speichert Farbe waagerecht und
-      senkrecht in halber Auflösung, weil das Auge für Farbdetails viel weniger
-      empfindlich ist als für Helligkeit. Das heißt, das Bild wird in
-      Zwei-Pixel-Einheiten verarbeitet, und es gibt keine Möglichkeit, ein
-      Einzelbild mit einer ungeraden Pixelzahl je Seite zu beschreiben.
-    </p>
-    <p>
-      Werkzeuge gehen damit um, indem sie Ihren Zuschnitt hinterher runden &mdash;
-      und Ihren Rahmen so um ein Pixel verschieben, ohne es zu sagen &mdash;
-      oder indem sie von vornherein nur gerade Zahlen anbieten. Das Zweite
-      passiert hier.
+      Und die Alternative, an die zu selten jemand denkt: Viele Plattformen
+      nehmen ein Querformatvideo an und legen die Balken selbst darum.
+      Zuschneiden brauchen Sie, wenn Sie den ganzen Bildschirm wollen &mdash;
+      nicht, damit das Video überhaupt angenommen wird.
     </p>
   </section>
 
   <section>
-    <h2>Was mit dem Ton passiert</h2>
+    <h2>Warum Breite und Höhe nur in Zweierschritten laufen</h2>
     <p>
-      Auf dem MP4-Weg nichts. Zuschneiden ändert das Bild und hat keinen Grund,
-      den Ton anzufassen &mdash; das Audio wird also Sample für Sample
-      übernommen, ohne je dekodiert zu werden: Byte für Byte das, was in der
-      Datei stand.
+      Wenn der Zuschnittrahmen ungerade Zahlen verweigert, stellt sich nicht die
+      Oberfläche an, sondern der Codec.
     </p>
     <p>
-      Auf dem unten beschriebenen Aufzeichnungsweg wird der Ton von der
-      Wiedergabe abgegriffen und neu kodiert, was ein wenig Qualität kostet. So
-      oder so gibt es ein Häkchen, um ihn ganz wegzulassen &mdash; das lohnt
-      sich, wenn der Clip ohnehin dorthin geht, wo stumm abgespielt wird, und Sie
-      die kleinste Datei wollen.
+      H.264 &mdash; der Codec in einem MP4 &mdash; speichert Farbe waagerecht wie
+      senkrecht nur in halber Auflösung, weil das Auge für Farbdetails weit
+      weniger empfindlich ist als für Helligkeit. Das Bild wird damit in
+      Zwei-Pixel-Einheiten verarbeitet, und ein Einzelbild mit einer ungeraden
+      Pixelzahl auf einer Seite lässt sich schlicht nicht beschreiben.
+    </p>
+    <p>
+      Werkzeuge lösen das entweder, indem sie Ihren Zuschnitt hinterher runden
+      und den Rahmen dabei stillschweigend um ein Pixel verschieben, oder indem
+      sie von vornherein nur gerade Zahlen zulassen. Hier passiert das Zweite.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was mit dem Ton geschieht</h2>
+    <p>
+      Auf dem MP4-Weg: nichts. Zuschneiden betrifft das Bild und hat keinen
+      Anlass, den Ton anzurühren &mdash; der wird Sample für Sample übernommen,
+      ohne je dekodiert zu werden, Byte für Byte so, wie er in der Datei stand.
+    </p>
+    <p>
+      Auf dem weiter unten beschriebenen Aufzeichnungsweg wird der Ton bei der
+      Wiedergabe abgegriffen und neu kodiert, was ein wenig Qualität kostet. In
+      beiden Fällen gibt es ein Häkchen, um ihn ganz wegzulassen &mdash; sinnvoll,
+      wenn der Clip ohnehin dorthin geht, wo stumm abgespielt wird, und Sie die
+      kleinstmögliche Datei wollen.
     </p>
   </section>
 
   <section>
     <h2>Formate, und wie lange es dauert</h2>
     <p>
-      <strong>MP4, M4V und MOV</strong> werden direkt gelesen, egal was darin
-      steckt &mdash; H.264, HEVC, AV1 oder VP9 &mdash;, solange Ihr Browser
-      diesen Codec dekodieren kann. Anders als beim Kürzen muss beim Zuschneiden
-      dekodiert werden, der Codec zählt hier also auf eine Weise, wie er es dort
-      nicht tut.
+      <strong>MP4, M4V und MOV</strong> werden direkt gelesen, gleich was darin
+      steckt &mdash; H.264, HEVC, AV1 oder VP9 &mdash;, sofern Ihr Browser diesen
+      Codec dekodieren kann. Anders als beim Kürzen muss beim Zuschneiden
+      dekodiert werden; der Codec spielt hier also eine Rolle, die er dort nicht
+      spielt.
     </p>
     <p>
-      <strong>Alles andere, was Ihr Browser abspielen kann</strong>, allen voran
-      WebM, wird zugeschnitten, indem es abgespielt und das Ergebnis
-      aufgezeichnet wird; das funktioniert und dauert so lange, wie der Clip lang
-      ist.
+      <strong>Alles Übrige, was Ihr Browser abspielen kann</strong> &mdash; allen
+      voran WebM &mdash;, wird zugeschnitten, indem es abgespielt und das
+      Ergebnis dabei aufgezeichnet wird. Das klappt, dauert aber genau so lange,
+      wie der Clip lang ist.
     </p>
     <p>
       <strong>AVI, WMV, FLV und die meisten MKVs</strong> kann der Browser weder
-      lesen noch abspielen, und das Werkzeug weist sie mit einer Meldung ab,
-      statt auf halbem Weg zu scheitern.
+      lesen noch abspielen. Das Werkzeug weist sie mit einer Meldung ab, statt
+      auf halber Strecke steckenzubleiben.
     </p>
     <p>
-      Rechnen Sie damit, dass ein Zuschnitt bei einem langen Clip echte Zeit
-      braucht, denn jedes Einzelbild wird dekodiert und neu kodiert. Im Werkzeug
-      ist keine Grenze eingebaut, und die Datei wird in Häppchen von wenigen
-      Megabyte durchlaufen statt ganz geladen; die praktische Obergrenze ist das
-      fertige Video, das vor dem Download im Arbeitsspeicher zusammengesetzt
-      wird.
-    </p>
-  </section>
-
-  <section>
-    <h2>Schneiden Sie zu, bevor Sie irgendetwas anderes tun</h2>
-    <p>
-      Muss ein Clip gekürzt und zugeschnitten werden, kürzen Sie zuerst &mdash;
-      das ist gratis, und jede Sekunde, die Sie herausnehmen, ist eine Sekunde,
-      die niemand neu kodieren muss. Schneiden Sie dann den kürzeren Clip einmal
-      zu.
-    </p>
-    <p>
-      Andersherum schneiden Sie Material zu, das Sie gleich wegwerfen &mdash; das
-      kostet Zeit und Qualität für nichts. Der
-      <a href="../../video-schneiden/">Video-Schneider</a> steht nebenan, und
-      <a href="../video-kuerzen/">sein Ratgeber</a> erklärt, warum dieser Schritt
-      Sie überhaupt nichts kosten muss.
-    </p>
-    <p>
-      Allgemeiner: Jeder verlustbehaftete Schritt summiert sich. Ein Zuschnitt
-      eines Originals ist eine Generation. Ein Zuschnitt eines Schnitts eines
-      Exports eines Downloads sind vier, und man sieht es.
+      Rechnen Sie bei einem langen Clip mit echter Wartezeit, denn jedes einzelne
+      Bild wird dekodiert und neu kodiert. Eine Grenze ist im Werkzeug nicht
+      eingebaut, und die Datei wird in Häppchen von wenigen Megabyte durchlaufen
+      statt vollständig geladen; die praktische Obergrenze setzt das fertige
+      Video, das vor dem Download im Arbeitsspeicher zusammengesetzt wird.
     </p>
   </section>
 
   <section>
-    <h2>Warum das keinen Upload braucht</h2>
+    <h2>Erst kürzen, dann zuschneiden &mdash; und beides so früh wie möglich</h2>
     <p>
-      Video im Browser zu dekodieren und neu zu kodieren ist neu, und es ist
-      echt: WebCodecs macht denselben Hardware-Encoder zugänglich, mit dem Ihr
-      Telefon Video aufnimmt, und es ist aus demselben Grund schnell. Die Arbeit
-      passiert auf dem Gerät, das die Datei ohnehin hat &mdash; und bei einem
-      mehrere Gigabyte großen Video ist das auch die einzige Anordnung, die Sinn
-      ergibt: Es hochzuladen und das Ergebnis herunterzuladen kostet mehr Zeit
-      als das Kodieren.
+      Muss ein Clip gekürzt und zugeschnitten werden, kürzen Sie zuerst: Das ist
+      umsonst zu haben, und jede Sekunde, die dabei wegfällt, ist eine Sekunde,
+      die niemand mehr neu kodieren muss. Erst danach schneiden Sie den kürzeren
+      Clip ein einziges Mal zu.
+    </p>
+    <p>
+      Andersherum schneiden Sie Material zu, das Sie gleich darauf wegwerfen
+      &mdash; und zahlen Zeit und Qualität für nichts. Der
+      <a href="../../video-schneiden/">Video-Schneider</a> steht gleich nebenan,
+      und <a href="../video-kuerzen/">sein Ratgeber</a> erklärt, warum dieser
+      Schritt Sie überhaupt nichts kosten muss.
+    </p>
+    <p>
+      Ganz allgemein summiert sich jeder verlustbehaftete Schritt. Der Zuschnitt
+      eines Originals ist eine Generation. Ein Zuschnitt, der auf einem Schnitt
+      sitzt, der auf einem Export sitzt, der auf einem Download sitzt, sind vier
+      &mdash; und das sieht man.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum dafür kein Upload nötig ist</h2>
+    <p>
+      Video im Browser zu dekodieren und neu zu kodieren ist eine junge
+      Möglichkeit, und sie ist echt: WebCodecs macht denselben Hardware-Encoder
+      zugänglich, mit dem Ihr Handy Video aufnimmt, und ist aus demselben Grund
+      schnell. Gearbeitet wird auf dem Gerät, das die Datei ohnehin schon hat
+      &mdash; bei einem Video von mehreren Gigabyte ist das auch die einzige
+      Anordnung, die Sinn ergibt: Hochladen und Ergebnis wieder herunterladen
+      dauert länger als das Kodieren selbst.
     </p>
     <p>
       Das Werkzeug hier hat keinerlei Netzfunktion, und die
       <code>Content-Security-Policy</code> der Seite nennt jede Adresse, die sie
-      kontaktieren darf; keine davon gehört zu dieser Seite. Trennen Sie die
-      Internetverbindung und schneiden Sie trotzdem einen Clip zu, wenn Sie
-      lieber prüfen als glauben.
+      kontaktieren darf; keine davon gehört zu dieser Seite. Wer lieber prüft als
+      glaubt, trennt die Internetverbindung und schneidet trotzdem einen Clip zu.
     </p>
     <p>
-      <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen, die Sie
-      an jedem Werkzeug durchführen können.
+      Drei weitere Proben, die Sie an jedem Werkzeug durchführen können, stehen
+      in <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher,
+      Dateien zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/crop-a-video.toml
+++ b/locales/de/pages/guides/crop-a-video.toml
@@ -4,14 +4,14 @@
 
 nav = "Video zuschneiden"
 title = "Ein Video auf ein anderes Format zuschneiden"
-description = "Einen Clip auf ein Quadrat, ein 9:16-Hochformat oder ein exaktes Pixelfenster zurechtschneiden. Welches Verhältnis welche Plattform will, warum Zuschneiden neu kodieren muss und Kürzen nicht, und was das kostet."
-heading = "Wie Sie ein Video auf ein anderes Format zuschneiden"
+description = "Einen Clip auf ein Quadrat, auf 9:16 hochkant oder auf ein exaktes Pixelfenster bringen. Welches Seitenverhältnis welche Plattform verlangt, warum Zuschneiden neu kodieren muss und Kürzen nicht, und was das kostet."
+heading = "So schneiden Sie ein Video auf ein anderes Format zu"
 lede = """
     Zuschneiden ändert die Form des Bildes, und das heißt: neue Einzelbilder
-    schreiben. Daran führt kein Weg vorbei, und jedes Werkzeug, das etwas
-    anderes behauptet, tut etwas anderes. Hier steht, was es kostet und wie Sie
-    es gut ausgeben."""
+    schreiben. Daran führt kein Weg vorbei &mdash; wer etwas anderes verspricht,
+    tut etwas anderes. Hier steht, was das kostet und wie Sie es sinnvoll
+    ausgeben."""
 updated = "20. August 2026"
-og_title = "Wie Sie ein Video auf ein anderes Format zuschneiden"
-og_description = "Welches Seitenverhältnis welche Plattform will, warum Zuschneiden neu kodieren muss und Kürzen nicht, und was das kostet."
+og_title = "So schneiden Sie ein Video auf ein anderes Format zu"
+og_description = "Welches Seitenverhältnis welche Plattform verlangt, warum Zuschneiden neu kodieren muss und Kürzen nicht, und was das kostet."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/embed-an-image-in-css.html
+++ b/locales/de/pages/guides/embed-an-image-in-css.html
@@ -2,178 +2,181 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie <a href="../../bild-als-base64/">Bild als Data-URI</a>, ziehen
-      Sie das Bild hinein, wählen Sie <em>Eine CSS-Custom-Property</em> und fügen
-      Sie die Zeile oben in Ihr Stylesheet ein. Benutzen Sie sie dann als
+      Sie das Bild hinein, wählen Sie <em>Eine CSS-Custom-Property</em> und
+      setzen Sie die Zeile oben in Ihr Stylesheet. Verwenden Sie sie dann als
       <code>background-image: var(--logo)</code>, wo immer Sie sie brauchen.
     </p>
     <p>
-      Tun Sie das, wenn das Bild klein ist &mdash; ein Symbol, ein Aufzählungs­punkt,
-      ein Pfeil, ein Muster &mdash; und auf jeder Seite gebraucht wird. Tun Sie es
-      nicht mit einer Fotografie. Alles Weitere unten handelt davon, warum diese
-      beiden Sätze auseinandergehen, und woran Sie erkennen, welchen Fall Sie vor
-      sich haben.
+      Machen Sie das bei kleinen Bildern &mdash; ein Symbol, ein
+      Aufzählungszeichen, ein Pfeil, ein Muster &mdash;, die auf jeder Seite
+      gebraucht werden. Machen Sie es nicht mit einer Fotografie. Alles Weitere
+      erklärt, warum diese beiden Sätze auseinandergehen und woran Sie erkennen,
+      welchen Fall Sie vor sich haben.
     </p>
   </section>
 
   <section>
-    <h2>Was eine Data-URI eigentlich ist</h2>
+    <h2>Was eine Data-URI überhaupt ist</h2>
     <p>
-      Eine Adresse, die die Sache enthält, statt auf sie zu zeigen. Wo ein
-      Stylesheet normalerweise
+      Eine Adresse, die die Sache selbst enthält, statt auf sie zu zeigen. Wo in
+      einem Stylesheet normalerweise
     </p>
     <pre><code>background-image: url("logo.png");</code></pre>
     <p>
-      sagt und der Browser <code>logo.png</code> holen geht, sagt eine Data-URI
+      steht und der Browser losgeht und <code>logo.png</code> holt, steht bei
+      einer Data-URI
     </p>
-    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <pre class="wrap"><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
     <p>
-      und es gibt nichts zu holen: Das Bild ist schon da, in Zeichen
-      ausgeschrieben. Es besteht aus drei Teilen. <code>data:</code> ist das
-      Schema. <code>image/png</code> ist der Medientyp, und der Browser glaubt
-      ihn vollständig &mdash; dazu unten mehr. Alles nach dem Komma ist die
-      Datei.
+      und es gibt nichts mehr zu holen: Das Bild ist bereits da, in Zeichen
+      ausgeschrieben. Drei Teile stecken darin. <code>data:</code> ist das
+      Schema. <code>image/png</code> ist der Medientyp, und den glaubt der
+      Browser aufs Wort &mdash; dazu weiter unten mehr. Alles hinter dem Komma
+      ist die Datei.
     </p>
     <p>
-      Das ist die ganze Idee. Es ist kein Trick und kein Hack; es steht seit 1998
-      in den Standards und funktioniert in jedem Browser, der seither
-      ausgeliefert wurde.
+      Mehr ist es nicht. Kein Trick, kein Hack: Das steht seit 1998 in den
+      Standards und funktioniert in jedem Browser, der seither erschienen ist.
     </p>
   </section>
 
   <section>
-    <h2>Was es Ihnen bringt: eine Rundreise weniger</h2>
+    <h2>Was es bringt: eine Rundreise weniger</h2>
     <p>
-      Die Ersparnis ist nicht die Bandbreite. Es ist die Anfrage.
+      Gespart wird nicht die Bandbreite, sondern die Anfrage.
     </p>
     <p>
       Ein Browser kann <code>logo.png</code> nicht anfordern, bevor er das
-      Stylesheet gelesen hat, das es erwähnt, und er kann das Stylesheet nicht
-      lesen, bevor er es geholt hat. Ein gewöhnliches Hintergrundbild liegt also
-      mindestens zwei Rundreisen tief im Seitenaufbau, und auf einem Telefon in
-      einem langsamen Netz kann eine Rundreise ein paar hundert Millisekunden
-      dauern, ganz gleich wie klein die Datei ist. Ein 600 Byte großer Pfeil
-      kostet fast nichts an Übertragung und kann trotzdem eine Viertelsekunde
-      brauchen, um anzukommen.
+      Stylesheet gelesen hat, in dem es steht, und er kann das Stylesheet nicht
+      lesen, bevor er es geholt hat. Ein gewöhnliches Hintergrundbild liegt damit
+      mindestens zwei Rundreisen tief im Seitenaufbau &mdash; und auf einem Handy
+      in einem schwachen Netz dauert eine Rundreise schnell ein paar hundert
+      Millisekunden, ganz gleich, wie klein die Datei ist. Ein Pfeil von 600 Byte
+      kostet an Übertragung so gut wie nichts und kann trotzdem eine
+      Viertelsekunde brauchen, bis er da ist.
     </p>
     <p>
-      Eingebettet kommt er mit dem Stylesheet an. Das ist der gesamte Nutzen, und
-      für ein kleines Symbol im sichtbaren Bereich ist er ein echter.
+      Eingebettet kommt er zusammen mit dem Stylesheet an. Das ist der ganze
+      Nutzen &mdash; und für ein kleines Symbol im sofort sichtbaren Bereich ist
+      er echt.
     </p>
   </section>
 
   <section>
-    <h2>Was es kostet: ein Drittel, und dann das Zwischenspeichern</h2>
+    <h2>Was es kostet: ein Drittel, und dann der Cache</h2>
     <p>
       <strong>Base64 legt rund ein Drittel drauf.</strong> Aus drei Bytes Datei
-      werden vier Zeichen, denn so viel braucht es, um beliebige Bytes mit nur
-      den Zeichen zu schreiben, die eine URL erlaubt. Es gibt keinen klugen
-      Encoder, der das umgeht. Aus einem 9&nbsp;KB großen PNG werden 12&nbsp;KB
+      werden vier Zeichen, denn so viel braucht es, um beliebige Bytes mit den
+      Zeichen zu schreiben, die eine URL zulässt. Kein noch so schlauer Encoder
+      kommt darum herum: Aus einem PNG von 9&nbsp;KB werden 12&nbsp;KB
       Stylesheet.
     </p>
     <p>
-      <strong>Kompression gibt es nicht zurück.</strong> Das ist der Teil, den
-      Menschen wegannehmen. Gzip und Brotli arbeiten, indem sie Redundanz finden,
-      und ein PNG, ein JPEG und ein WebP wurden bereits komprimiert &mdash; da
-      ist kaum noch Redundanz drin, und Base64 fügt keine hinzu. In der Praxis
-      bekommen Sie etwa ein Zehntel des Drittels zurück, nicht das Ganze. (Ein
-      SVG ist der umgekehrte Fall, und davon handelt der nächste Abschnitt.)
+      <strong>Die Kompression holt das nicht zurück.</strong> Diesen Punkt setzen
+      die meisten stillschweigend voraus, und er stimmt nicht. Gzip und Brotli
+      leben davon, Wiederholungen zu finden &mdash; und ein PNG, ein JPEG oder
+      ein WebP ist bereits komprimiert, da sind kaum noch Wiederholungen drin,
+      und Base64 fügt keine hinzu. In der Praxis kommt etwa ein Zehntel dieses
+      Drittels zurück, nicht das Ganze. (Beim SVG liegt der Fall genau umgekehrt,
+      davon handelt der nächste Abschnitt.)
     </p>
     <p>
-      <strong>Es hört auf, eine Datei zu sein.</strong> Das ist der Preis, der in
-      keiner Messung auftaucht, die Sie wahrscheinlich vornehmen, und der, auf
-      den es bei Größe ankommt:
+      <strong>Es ist keine Datei mehr.</strong> Das ist der Preis, der in keiner
+      Messung auftaucht, die Sie vermutlich vornehmen &mdash; und der, auf den es
+      ankommt, sobald das Bild eine gewisse Größe hat:
     </p>
     <ul>
       <li>
         <strong>Es lässt sich nicht für sich zwischenspeichern.</strong> Ein
-        gewöhnliches Bild wird einmal geholt und ein Jahr lang wiederverwendet.
-        Ein eingebettetes ist Teil des Stylesheets, es lebt und stirbt also mit
-        dessen Cache-Eintrag.
+        gewöhnliches Bild wird einmal geholt und dann ein Jahr lang
+        wiederverwendet. Ein eingebettetes gehört zum Stylesheet und lebt und
+        stirbt mit dessen Cache-Eintrag.
       </li>
       <li>
-        <strong>Irgendetwas zu ändern lädt alles neu.</strong> Korrigieren Sie
-        einen Rand, liefern Sie ein neues Stylesheet aus, und jeder Besucher lädt
-        das eingebettete Bild gleich mit herunter &mdash; ein Bild, das sich seit
-        zwei Jahren nicht geändert hat.
+        <strong>Eine Änderung lädt alles neu.</strong> Sie korrigieren einen
+        Abstand, das Stylesheet geht neu heraus &mdash; und jeder Besucher lädt
+        das eingebettete Bild gleich mit, ein Bild, das sich seit zwei Jahren
+        nicht verändert hat.
       </li>
       <li>
         <strong>Es liegt auf dem kritischen Pfad.</strong> Ein Stylesheet
-        blockiert das Rendern. Ein Bild nicht. Ein Bild einzubetten verschiebt es
-        aus der zweiten Kategorie in die erste: Die Seite kann nicht zeichnen,
+        blockiert das Rendern, ein Bild nicht. Einbetten verschiebt das Bild von
+        der zweiten Kategorie in die erste: Die Seite kann nichts zeichnen,
         bevor das Ganze samt Bild angekommen ist.
       </li>
       <li>
-        <strong>Es lässt sich nicht parallel holen.</strong> Browser laden vieles
-        gleichzeitig herunter. Ein eingebettetes Bild ist keine eigene Sache, es
-        bekommt davon also nichts.
+        <strong>Es lässt sich nicht parallel holen.</strong> Browser laden
+        vieles gleichzeitig. Ein eingebettetes Bild ist keine eigene Sache und
+        hat davon nichts.
       </li>
     </ul>
     <p>
-      Grobe Schwellen &mdash; dort ändert sich der Rat, nicht das Verhalten eines
-      Browsers: unter etwa 2&nbsp;KB ist es ein klarer Gewinn; bis etwa
-      10&nbsp;KB lohnt es sich meist noch für etwas, das auf jeder Seite ist;
-      jenseits von 50&nbsp;KB ist es ein Fehler ohne Fehlermeldung.
-      <a href="../../bild-als-base64/">Das Werkzeug</a> sagt Ihnen, in welches
-      Band jedes Ergebnis fällt, mit der Zeichenzahl daneben.
+      Grobe Schwellen &mdash; sie markieren, wo der Rat kippt, nicht, wo ein
+      Browser etwas anderes tut: Unter etwa 2&nbsp;KB ist es ein klarer Gewinn;
+      bis etwa 10&nbsp;KB lohnt es sich meist noch für etwas, das auf jeder
+      Seite auftaucht; jenseits von 50&nbsp;KB ist es ein Fehler, der keine
+      Fehlermeldung erzeugt.
+      <a href="../../bild-als-base64/">Das Werkzeug</a> nennt Ihnen zu jedem
+      Ergebnis das passende Band und die Zeichenzahl daneben.
     </p>
   </section>
 
   <section>
-    <h2>Base64 ist für ein SVG nie richtig</h2>
+    <h2>Ein SVG gehört nie in Base64</h2>
     <p>
-      Das ist der mit Abstand häufigste Fehler bei eingebetteten Bildern, und er
-      wird von Exportern und Build-Plugins genauso oft gemacht wie von Menschen.
+      Das ist mit Abstand der häufigste Fehler bei eingebetteten Bildern, und
+      Exportfunktionen und Build-Plugins machen ihn genauso oft wie Menschen.
     </p>
     <p>
-      Ein SVG ist Text. Eine URL trägt Text ohnehin. Nur eine Handvoll Zeichen
-      muss maskiert werden &mdash; <code>%</code>, <code>#</code>,
+      Ein SVG ist Text, und Text trägt eine URL ohnehin. Nur eine Handvoll
+      Zeichen muss maskiert werden &mdash; <code>%</code>, <code>#</code>,
       <code>&lt;</code>, <code>&gt;</code> und das Anführungszeichen, in das Sie
-      es gesetzt haben &mdash; und alles andere kann genau so bleiben, wie es
-      ist. So kodiert bekommen Sie eine URI, die typischerweise etwa ein Fünftel
-      kürzer ist als das Base64 derselben Datei und die sich danach wie Text
-      komprimiert und nicht wie Rauschen.
+      das Ganze gesetzt haben &mdash;, alles Übrige darf genau so bleiben, wie
+      es ist. So kodiert bekommen Sie eine URI, die typischerweise rund ein
+      Fünftel kürzer ausfällt als das Base64 derselben Datei und die sich
+      danach wie Text komprimiert und nicht wie Rauschen.
     </p>
     <p>
-      Sie ist außerdem noch lesbar:
+      Lesbar bleibt sie obendrein:
     </p>
-    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <pre class="wrap"><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
     <p>
-      Sie sehen die <code>viewBox</code>. Sie können die Füllfarbe in Ihrem
-      Editor ändern, ohne irgendetwas zu dekodieren. Base64-kodieren Sie dieselbe
-      Datei, und sie wird zu einer Wand aus Buchstaben, die niemand je wieder
-      anfasst. <a href="../../bild-als-base64/">Bild als Data-URI</a> macht das
-      automatisch für alles, was sich als SVG herausstellt, und hat ein Häkchen
-      für die seltene Werkzeugkette, die auf <code>;base64</code> besteht.
+      Sie sehen die <code>viewBox</code>. Sie können die Füllfarbe im Editor
+      ändern, ohne irgendetwas zu dekodieren. Base64-kodieren Sie dieselbe Datei,
+      wird daraus eine Wand aus Buchstaben, die nie wieder jemand anrührt.
+      <a href="../../bild-als-base64/">Bild als Data-URI</a> erledigt das von
+      selbst für alles, was sich als SVG entpuppt &mdash; und hält ein Häkchen
+      bereit für die seltene Werkzeugkette, die auf <code>;base64</code> besteht.
     </p>
   </section>
 
   <section>
-    <h2>Der Anführungszeichen-Fehler, der nur SVGs kaputtmacht</h2>
+    <h2>Der Anführungszeichen-Fehler, der nur SVGs zerlegt</h2>
     <p>
-      CSS erlaubt es, <code>url()</code> ohne Anführungszeichen zu schreiben, und
-      bei einem gewöhnlichen Dateinamen ist das in Ordnung:
+      CSS erlaubt <code>url()</code> auch ohne Anführungszeichen, und bei einem
+      gewöhnlichen Dateinamen geht das in Ordnung:
     </p>
     <pre><code>background-image: url(logo.png);</code></pre>
     <p>
-      Machen Sie dasselbe mit einem prozentkodierten SVG, und es bricht. Ein
-      <code>url()</code>-Token ohne Anführungszeichen endet am ersten Leerzeichen,
-      an der ersten Klammer, am ersten Anführungszeichen oder Steuerzeichen
-      &mdash; und ein SVG ist voller Leerzeichen, zwischen jedem Attribut und
-      jeder Zahl in einem Pfad. Die Deklaration ist dann ungültig, CSS verwirft
-      ungültige Deklarationen stillschweigend, und Sie bekommen keinen Hintergrund
-      und keinen Fehler.
+      Bei einem prozentkodierten SVG geht es schief. Ein
+      <code>url()</code>-Token ohne Anführungszeichen endet am ersten
+      Leerzeichen, an der ersten Klammer, am ersten Anführungszeichen oder
+      Steuerzeichen &mdash; und ein SVG ist voller Leerzeichen, zwischen jedem
+      Attribut und jeder Zahl in einem Pfad. Damit ist die Deklaration ungültig,
+      und ungültige Deklarationen wirft CSS wortlos weg: kein Hintergrund, keine
+      Fehlermeldung.
     </p>
     <p>
-      Die Lösung sind Anführungszeichen, jedes Mal:
+      Die Abhilfe sind Anführungszeichen, und zwar immer:
     </p>
     <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
     <p>
-      Das ist auch der Grund, warum ein Encoder Leerzeichen nicht maskieren muss
-      &mdash; sie sind innerhalb einer URL in Anführungszeichen völlig legal, und
-      jedes als <code>%20</code> zu maskieren kostete drei Zeichen je Leerzeichen
-      in der Datei. Die beiden Entscheidungen gehören zusammen: URI in
-      Anführungszeichen setzen, und die Leerzeichen dürfen bleiben. Jede Form,
-      die das Werkzeug erzeugt, ist genau deshalb in Anführungszeichen gesetzt.
+      Deshalb muss ein Encoder auch die Leerzeichen nicht maskieren &mdash;
+      innerhalb einer URL in Anführungszeichen sind sie völlig zulässig, und
+      jedes einzelne als <code>%20</code> zu schreiben kostete drei Zeichen pro
+      Leerzeichen in der Datei. Die beiden Entscheidungen hängen zusammen: URI in
+      Anführungszeichen setzen, dann dürfen die Leerzeichen bleiben. Genau darum
+      steht jede Form, die das Werkzeug ausgibt, in Anführungszeichen.
     </p>
   </section>
 
@@ -181,26 +184,26 @@
     <h2>Der Medientyp muss stimmen</h2>
     <p>
       Eine Data-URI gibt ihren eigenen Typ an, und der Browser nimmt sie beim
-      Wort. Es gibt keine Rückfallerkennung wie bei einer geholten Datei: Sagen
-      Sie <code>image/png</code> über etwas, das in Wahrheit ein JPEG ist, und
-      das Bild erscheint nicht &mdash; ohne Meldung an irgendeiner nützlichen
-      Stelle.
+      Wort. Anders als bei einer geholten Datei gibt es kein Nachschnüffeln als
+      Rückfallebene: Schreiben Sie <code>image/png</code> über etwas, das in
+      Wahrheit ein JPEG ist, erscheint das Bild einfach nicht &mdash; und nirgends
+      steht eine Meldung, die weiterhilft.
     </p>
     <p>
       Das zählt, weil Dateiendungen lügen. Ein als JPEG exportiertes und in
-      <code>logo.png</code> umbenanntes Foto ist etwas völlig Gewöhnliches auf
-      einer Festplatte. Die ersten Bytes einer Bilddatei dagegen sagen eindeutig,
-      was sie ist &mdash; jedes Format hat eine Signatur &mdash;, ein Werkzeug
-      sollte also die Datei lesen und nicht ihren Namen. Das hier tut es und sagt
-      Ihnen, wenn die beiden sich widersprechen.
+      <code>logo.png</code> umbenanntes Foto ist auf jeder Festplatte etwas ganz
+      Gewöhnliches. Die ersten Bytes einer Bilddatei dagegen sagen eindeutig,
+      was sie ist &mdash; jedes Format hat seine Signatur. Ein Werkzeug sollte
+      also die Datei lesen und nicht ihren Namen. Dieses hier tut das und meldet
+      sich, wenn beide sich widersprechen.
     </p>
     <p>
-      Zwei Formate sind wissenswert, weil sie auf verwirrende Weise scheitern.
+      Zwei Formate sollte man kennen, weil sie auf verwirrende Weise scheitern.
       <strong>HEIC</strong>, worin ein iPhone fotografiert, und
-      <strong>TIFF</strong>, was Scanner erzeugen, ergeben beide vollkommen
-      gültige Data-URIs, die kein Browser außer Safari zeichnet. Die URI ist
-      nicht kaputt; das Format ist schlicht keines, das das Web unterstützt.
-      Wandeln Sie vorher um.
+      <strong>TIFF</strong>, was aus Scannern kommt, ergeben beide vollkommen
+      gültige Data-URIs, die außer Safari kein Browser zeichnet. Kaputt ist nicht
+      die URI, sondern das Format ist keines, das das Web unterstützt. Wandeln
+      Sie vorher um.
     </p>
   </section>
 
@@ -208,35 +211,35 @@
     <h2>Die Metadaten, die Sie nicht veröffentlichen wollten</h2>
     <p>
       Eine Data-URI ist eine Kopie der Datei, Byte für Byte. Es wird nichts
-      dekodiert und neu kodiert, und das ist meist der Sinn &mdash; es geht keine
-      Qualität verloren &mdash;, aber es heißt auch, dass alles andere in der
-      Datei mitkommt.
+      dekodiert und neu kodiert &mdash; das ist meistens gerade der Sinn, denn so
+      geht keine Qualität verloren &mdash;, aber es heißt eben auch, dass alles
+      andere in der Datei mitfährt.
     </p>
     <p>
-      Eine Fotografie direkt vom Telefon trägt EXIF: die GPS-Koordinaten des
-      Aufnahmeortes, den Zeitstempel, das Kameramodell und oft dessen
+      Ein Foto direkt aus dem Handy trägt EXIF mit sich: die GPS-Koordinaten des
+      Aufnahmeorts, den Zeitstempel, das Kameramodell und oft dessen
       Seriennummer. Das können 30&nbsp;KB der Datei sein. Eingebettet werden
       daraus 40&nbsp;KB Base64 in Ihrem Stylesheet, auf dem kritischen Pfad jeder
-      Seite &mdash; und eine Wohnanschrift, die in ein Repository eingecheckt
-      wird, in einer Form, in der niemand je auf die Idee kommt nachzusehen.
+      einzelnen Seite &mdash; und eine Wohnanschrift, die ins Repository
+      eingecheckt wird, in einer Form, in der nie jemand nachsehen wird.
     </p>
     <p>
       Entfernen Sie sie vorher mit dem
       <a href="../../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>,
-      der den Container neu schreibt, ohne das Bild anzufassen; dazu gibt es
-      ebenfalls einen <a href="../exif-und-gps-daten-entfernen/">Ratgeber</a>.
-      Bild als Data-URI liest, wie viele Metadaten in einem JPEG, PNG oder WebP
-      stecken, und sagt es, bevor Sie irgendetwas kopieren.
+      der den Container neu schreibt, ohne das Bild anzurühren; auch dazu gibt es
+      einen <a href="../exif-und-gps-daten-entfernen/">eigenen Ratgeber</a>. Bild
+      als Data-URI liest aus, wie viele Metadaten in einem JPEG, PNG oder WebP
+      stecken, und sagt es Ihnen, bevor Sie irgendetwas kopieren.
     </p>
   </section>
 
   <section>
-    <h2>Wohin damit, wenn Sie es haben</h2>
+    <h2>Wohin damit, wenn Sie sie haben</h2>
     <p>
-      Erscheint das Bild in einer Regel, legen Sie die URI in diese Regel.
-      Erscheint es in mehr als einer &mdash; und bei Symbolen ist das meist so,
-      sobald man den Hover-Zustand und das dunkle Farbschema mitzählt &mdash;,
-      deklarieren Sie es einmal als Custom Property:
+      Taucht das Bild in einer einzigen Regel auf, gehört die URI in diese Regel.
+      Taucht es in mehreren auf &mdash; und bei Symbolen ist das meist so, sobald
+      man Hover-Zustand und dunkles Farbschema mitzählt &mdash;, deklarieren Sie
+      es einmal als Custom Property:
     </p>
     <pre><code>:root {
   --icon-search: url("data:image/svg+xml,%3Csvg ... %3E");
@@ -245,59 +248,58 @@
 .search-field { background-image: var(--icon-search); }
 .search-button::before { content: var(--icon-search); }</code></pre>
     <p>
-      Eine 3&nbsp;KB große URI, in vier Regeln eingefügt, sind 12&nbsp;KB
-      Stylesheet und vier Stellen zum Bearbeiten, wenn sich das Symbol ändert.
-      Die Custom Property ist je eine. Sie ist außerdem die Form, mit der Theming
-      funktioniert: Definieren Sie <code>--icon-search</code> in einer Media
-      Query neu, und jede Verwendung folgt.
+      Eine URI von 3&nbsp;KB, in vier Regeln eingesetzt, ergibt 12&nbsp;KB
+      Stylesheet und vier Stellen, die Sie beim nächsten Symbolwechsel anfassen
+      müssen. Bei der Custom Property ist es je eine. Sie ist zugleich die Form,
+      mit der Theming funktioniert: <code>--icon-search</code> in einer Media
+      Query neu definieren, und jede Verwendung zieht mit.
     </p>
     <p>
       Für ein <code>&lt;img&gt;</code>-Element statt CSS geben Sie
-      <code>width</code> und <code>height</code> an. Ein eingebettetes Bild lädt
-      sofort, eine fehlende Größe ist also ein Layout-Sprung, der zu schnell
-      passiert, um gesehen zu werden, und trotzdem gegen Sie zählt. Die Ausnahme
-      ist SVG: Eines, das nur eine <code>viewBox</code> trägt, hat keine eigene
-      Pixelgröße, und die Standardgröße 300&times;150 des Browsers auf das
-      Element zu schreiben nagelt ein skalierbares Bild auf eine Größe fest, die
-      niemand gewählt hat.
+      <code>width</code> und <code>height</code> an. Ein eingebettetes Bild ist
+      sofort da, eine fehlende Größe erzeugt also einen Layout-Sprung, der zu
+      schnell passiert, um gesehen zu werden, und der trotzdem gegen Sie
+      gerechnet wird. Die Ausnahme ist SVG: Eines, das nur eine
+      <code>viewBox</code> trägt, hat keine eigene Pixelgröße, und die
+      Standardgröße 300&times;150 des Browsers ins Element zu schreiben nagelt
+      ein skalierbares Bild auf ein Maß fest, das niemand gewählt hat.
     </p>
     <p>
-      Lassen Sie <code>alt</code> leer, sofern Sie nichts Wahres hineinzuschreiben
-      haben. Nur Sie wissen, ob das Bild Bedeutung trägt oder Dekoration ist, und
-      eine aus einem Dateinamen geratene Beschreibung ist für jemanden mit einem
-      Screenreader schlechter als gar keine.
+      Lassen Sie <code>alt</code> leer, solange Sie nichts Zutreffendes
+      hineinzuschreiben haben. Nur Sie wissen, ob das Bild Bedeutung trägt oder
+      Dekoration ist &mdash; und eine aus einem Dateinamen erratene Beschreibung
+      ist für jemanden am Screenreader schlechter als gar keine.
     </p>
   </section>
 
   <section>
     <h2>Wann die Antwort &bdquo;lieber nicht&ldquo; lautet</h2>
     <p>
-      Ist das Bild kodiert über etwa 50&nbsp;KB groß, ist Einbetten das falsche
-      Werkzeug, und keine Sorgfalt bei der Kodierung repariert das. Die
-      Alternativen, in der Reihenfolge, in der sie sich lohnen:
+      Ist das Bild kodiert größer als etwa 50&nbsp;KB, ist Einbetten das falsche
+      Werkzeug, und keine noch so sorgfältige Kodierung repariert das. Die
+      Alternativen, in der Reihenfolge, in der sie einen Versuch wert sind:
     </p>
     <ul>
       <li>
-        <strong>Machen Sie es kleiner.</strong> Die meisten Bilder, die zu groß
-        zum Einbetten sind, sind allgemein zu groß. Der
+        <strong>Machen Sie es kleiner.</strong> Die meisten Bilder, die zum
+        Einbetten zu groß sind, sind schlicht zu groß. Der
         <a href="../../bild-komprimieren/">Bildkompressor</a> bringt eine
-        Fotografie auf eine von Ihnen genannte Größe, und das
-        <a href="../../bildgroesse-aendern/">Bildgrößen-Ändern</a> schneidet die
-        Pixelmaße auf das herunter, was das Layout tatsächlich nutzt &mdash; und
-        das ist sehr oft das eigentliche Problem.
+        Fotografie auf eine Größe, die Sie nennen, und das
+        <a href="../../bildgroesse-aendern/">Bildgrößen-Ändern</a> stutzt die
+        Pixelmaße auf das, was das Layout tatsächlich nutzt &mdash; und genau
+        darin steckt sehr oft das eigentliche Problem.
       </li>
       <li>
-        <strong>Zeichnen Sie es als SVG neu.</strong> Ein als 40&nbsp;KB großes
-        PNG exportiertes Symbol ist häufig ein 900 Byte großes SVG. Das ist kein
-        Kompressionsunterschied, das ist ein Formatunterschied &mdash; und es
-        löst obendrein das Retina-Problem.
+        <strong>Zeichnen Sie es als SVG neu.</strong> Ein Symbol, das als PNG mit
+        40&nbsp;KB exportiert wurde, ist als SVG oft 900 Byte groß. Das ist kein
+        Unterschied in der Kompression, sondern einer im Format &mdash; und es
+        löst nebenbei das Retina-Problem.
       </li>
       <li>
         <strong>Lassen Sie es eine Datei und laden Sie sie vor.</strong>
-        <code>&lt;link rel="preload" as="image"&gt;</code> startet den Abruf
-        sofort, ohne die Bytes auf den kritischen Pfad zu verschieben. Es bringt
-        den größten Teil des Nutzens des Einbettens und nichts von den
-        Cache-Kosten.
+        <code>&lt;link rel="preload" as="image"&gt;</code> stößt den Abruf sofort
+        an, ohne die Bytes auf den kritischen Pfad zu schieben. Damit haben Sie
+        fast den ganzen Nutzen des Einbettens und keine der Cache-Kosten.
       </li>
     </ul>
   </section>
@@ -305,21 +307,21 @@
   <section>
     <h2>Nichts davon braucht einen Upload</h2>
     <p>
-      Eine Datei als Base64 zu kodieren ist Rechnerei. Es sind zwei Funktionen,
-      die der Browser seit Anbeginn hat &mdash; <code>btoa</code> und
-      <code>encodeURIComponent</code> &mdash; und es gibt überhaupt keinen
-      technischen Grund, warum ein Bild zu einem Server und zurück reisen sollte,
-      um anders aufgeschrieben zu werden. Jeder Umwandler, der Ihre Datei dafür
-      hochlädt, lädt sie aus seinen eigenen Gründen hoch und nicht aus Ihren.
+      Eine Datei nach Base64 zu kodieren ist Rechnerei. Es sind zwei Funktionen,
+      die der Browser seit jeher mitbringt &mdash; <code>btoa</code> und
+      <code>encodeURIComponent</code> &mdash;, und es gibt nicht den geringsten
+      technischen Grund, warum ein Bild dafür zu einem Server und zurück reisen
+      sollte, nur um anders aufgeschrieben zu werden. Wer Ihre Datei dafür
+      hochlädt, tut das aus eigenen Gründen und nicht aus Ihren.
     </p>
     <p>
       <a href="../../bild-als-base64/">Das Werkzeug hier</a> schickt sie
       nirgendwohin: Die <code>Content-Security-Policy</code> der Seite nennt jede
       Adresse, die sie kontaktieren darf, und keine davon gehört zu dieser Seite.
-      Laden Sie die Seite, trennen Sie die Internetverbindung und kodieren Sie
-      trotzdem etwas, wenn Sie lieber prüfen als glauben.
+      Wer lieber prüft als glaubt, lädt die Seite, trennt die
+      Internetverbindung und kodiert trotzdem etwas. Drei weitere Proben, die
+      Sie an jedem Werkzeug durchführen können, stehen in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen, die Sie
-      an jedem Werkzeug durchführen können.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/embed-an-image-in-css.toml
+++ b/locales/de/pages/guides/embed-an-image-in-css.toml
@@ -3,16 +3,16 @@
 #
 
 nav = "Ein Bild in CSS einbetten"
-title = "Data-URIs in CSS: wann ein Bild eingebettet gehört und wann nicht"
-description = "Was eine Data-URI kostet, warum Base64 ein Drittel drauflegt und gzip es nicht zurückgibt, warum ein SVG nie base64 sein sollte, und der Anführungszeichen-Fehler, der eingebettete SVGs stillschweigend kaputtmacht."
+title = "Data-URIs in CSS: wann ein Bild ins Stylesheet gehört und wann nicht"
+description = "Was eine Data-URI kostet, warum Base64 ein Drittel drauflegt und gzip es nicht zurückgibt, warum ein SVG nie base64 sein sollte und welcher Anführungszeichen-Fehler eingebettete SVGs klammheimlich zerlegt."
 heading = "Wann ein Bild in Ihr CSS gehört - und wann nicht"
 lede = """
-    Ein ins Stylesheet geschriebenes Bild kommt mit ihm an: keine zweite
-    Anfrage, kein Warten. Es hört damit aber auch auf, eine Datei zu sein
-    &mdash; es kann also nicht für sich zwischengespeichert werden und wird jedes
-    Mal neu geladen, wenn sich irgendetwas drumherum ändert. Hier steht, wo
-    dieser Handel sich lohnt und wo er es stillschweigend nicht tut."""
+    Ein Bild, das im Stylesheet steht, kommt mit ihm an: keine zweite Anfrage,
+    kein Warten. Dafür ist es keine Datei mehr &mdash; es lässt sich nicht für
+    sich zwischenspeichern und wird jedes Mal neu geladen, wenn sich irgendetwas
+    ringsherum ändert. Hier steht, wo sich dieser Handel lohnt und wo er
+    klammheimlich schadet."""
 updated = "20. August 2026"
 og_title = "Wann ein Bild in Ihr CSS gehört"
-og_description = "Was eine Data-URI kostet, warum ein SVG nie base64 sein sollte, und der Anführungszeichen-Fehler, der eingebettete SVGs stillschweigend kaputtmacht."
+og_description = "Was eine Data-URI kostet, warum ein SVG nie base64 sein sollte und welcher Anführungszeichen-Fehler eingebettete SVGs klammheimlich zerlegt."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/de/pages/guides/is-it-safe-to-upload-files.html
@@ -1,273 +1,276 @@
   <section>
     <h2>Die kurze Antwort</h2>
     <p>
-      Für die meisten Dateien ist Hochladen meistens unbedenklich. Seriöse
-      Konverter löschen, was Sie schicken, binnen weniger Stunden und haben kein
-      Interesse an Ihren Urlaubsfotos.
+      Bei den meisten Dateien ist Hochladen meistens unbedenklich. Seriöse
+      Konverter löschen, was Sie schicken, binnen weniger Stunden und haben an
+      Ihren Urlaubsfotos nicht das geringste Interesse.
     </p>
     <p>
-      Das Problem ist nicht, dass sie lügen. Es ist, dass
-      <strong>Sie keine Möglichkeit haben zu erkennen, ob sie es tun</strong>.
-      Sobald eine Datei Ihr Gerät verlässt, ist jedes Versprechen über das, was
-      danach geschieht, ein Versprechen auf Treu und Glauben: wie lange sie
-      aufbewahrt wird, wer sie erreichen kann, ob sie in ein Backup kopiert wurde,
-      das die Löschfrist überlebt, was mit ihr passiert, wenn das Unternehmen
-      verkauft oder eingebrochen wird. Nichts davon ist von außen sichtbar.
+      Das Problem ist nicht, dass sie lügen könnten. Das Problem ist, dass
+      <strong>Sie es nicht feststellen können</strong>. Sobald eine Datei Ihr
+      Gerät verlässt, ist jede Zusage über das, was danach kommt, eine Zusage auf
+      Treu und Glauben: wie lange sie liegen bleibt, wer an sie herankommt, ob
+      sie in einem Backup gelandet ist, das die Löschfrist überdauert, was mit
+      ihr geschieht, wenn die Firma verkauft oder gehackt wird. Von außen ist
+      davon nichts zu sehen.
     </p>
     <p>
-      Die nützliche Frage lautet also nicht &bdquo;vertraue ich dieser
-      Seite?&ldquo; Sie lautet:
-      <strong>&bdquo;Muss meine Datei für diese Aufgabe überhaupt weg?&ldquo;</strong>
-      Für eine große und wachsende Zahl von Aufgaben lautet die Antwort nein
-      &mdash; und wenn sie nein lautet, hört die Vertrauensfrage auf, eine Frage
-      zu sein, die Sie beantworten müssen.
+      Die brauchbare Frage lautet deshalb nicht &bdquo;Vertraue ich dieser
+      Seite?&ldquo;, sondern:
+      <strong>&bdquo;Muss meine Datei für diese Aufgabe überhaupt außer
+      Haus?&ldquo;</strong> Bei immer mehr Aufgaben lautet die Antwort nein
+      &mdash; und wenn sie nein lautet, ist die Vertrauensfrage gar keine Frage
+      mehr, die Sie beantworten müssten.
     </p>
   </section>
 
   <section>
-    <h2>Was &bdquo;Hochladen&ldquo; tatsächlich tut</h2>
+    <h2>Was beim Hochladen tatsächlich passiert</h2>
     <p>
-      Wenn ein Konverter Sie bittet, eine Datei zu wählen, und Ihnen dann einen
-      Fortschrittsbalken zeigt, kopiert Ihr Browser die ganze Datei, Byte für
-      Byte, durch das Internet auf einen Computer, der jemand anderem gehört.
-      Dieser Computer schreibt sie auf eine Festplatte, führt die Umwandlung aus,
-      schreibt das Ergebnis auf dieselbe Festplatte und gibt Ihnen einen Link.
+      Wenn ein Konverter Sie eine Datei auswählen lässt und dann einen
+      Fortschrittsbalken zeigt, kopiert Ihr Browser die ganze Datei Byte für Byte
+      übers Internet auf einen Rechner, der jemand anderem gehört. Der schreibt
+      sie auf eine Festplatte, führt die Umwandlung aus, legt das Ergebnis auf
+      dieselbe Festplatte und reicht Ihnen einen Link.
     </p>
     <p>
-      In diesem Moment existiert Ihre Datei an mindestens drei Orten, die Sie
-      nicht gewählt haben: der Festplatte des Servers, den Protokollen, die die
-      Anfrage festgehalten haben, und oft einem Content Delivery Network, das das
-      Ergebnis zwischengespeichert hat, damit der Download schnell geht. Eine
-      Löschrichtlinie muss alle drei erreichen. Die meisten sagen, sie tue das.
-      Nachprüfen können Sie keinen davon.
+      In diesem Moment liegt Ihre Datei an mindestens drei Orten, die Sie sich
+      nicht ausgesucht haben: auf der Festplatte des Servers, in den
+      Protokollen, die die Anfrage festgehalten haben, und häufig in einem
+      Content Delivery Network, das das Ergebnis für einen schnellen Download
+      zwischengespeichert hat. Eine Löschregel muss alle drei erreichen. Die
+      meisten Anbieter versichern, dass sie das tut. Nachsehen können Sie an
+      keinem der drei Orte.
     </p>
     <p>
-      Ebenfalls wissenswert: Die Datei ist nicht das Einzige, was ankommt. Der
-      Dateiname reist mit, und alles in der Datei, was Sie nicht sehen können,
-      auch. Ein Foto direkt vom Telefon trägt typischerweise die genauen
-      GPS-Koordinaten des Aufnahmeorts, die Uhrzeit, die Seriennummer der Kamera
-      und manchmal ein eingebettetes Vorschaubild des Originals von vor Ihrem
-      Zuschnitt. Menschen, die auf das Bild achten, achten darauf oft nicht, weil
-      nichts auf dem Bildschirm es ihnen zeigt.
+      Und die Datei ist nicht das Einzige, was ankommt. Der Dateiname reist mit
+      &mdash; und alles, was in der Datei steckt, ohne dass Sie es sehen. Ein
+      Foto direkt aus dem Handy trägt in aller Regel die genauen GPS-Koordinaten
+      des Aufnahmeorts mit sich, die Uhrzeit, die Seriennummer der Kamera und
+      mitunter ein eingebettetes Vorschaubild, das noch den Zustand vor Ihrem
+      Zuschnitt zeigt. Wer aufs Bild achtet, achtet darauf meist nicht &mdash;
+      weil nichts auf dem Bildschirm es zeigt.
     </p>
   </section>
 
   <section>
     <h2>Warum die meisten Werkzeuge trotzdem hochladen</h2>
     <p>
-      Nicht, weil sie Ihre Dateien wollen. Sondern weil es den größten Teil der
-      Geschichte des Web keine Alternative gab. Ein Browser konnte kein Video
-      dekodieren, kein Bild in gewählter Qualität neu kodieren und kein
-      Dateiformat zerlegen; ein Server mit FFmpeg und ImageMagick konnte es.
-      Hochladen war kein Geschäftsmodell, es war der einzige Ort, an dem die
-      Arbeit stattfinden konnte.
+      Nicht, weil sie es auf Ihre Dateien abgesehen hätten, sondern weil es den
+      größten Teil der Web-Geschichte über keine Alternative gab. Ein Browser
+      konnte kein Video dekodieren, kein Bild in einer gewünschten Qualität neu
+      kodieren und kein Dateiformat zerlegen; ein Server mit FFmpeg und
+      ImageMagick konnte das alles. Hochladen war kein Geschäftsmodell, es war
+      schlicht der einzige Ort, an dem die Arbeit stattfinden konnte.
     </p>
     <p>
-      Das hat vor Kurzem und leise aufgehört zu stimmen. Browser bringen heute
-      WebAssembly mit, das dieselben kompilierten Codecs nahezu in nativer
-      Geschwindigkeit ausführt, WebCodecs, das den Hardware-Video-Encoder
-      zugänglich macht, der ohnehin in Ihrem Gerät steckt, und eine Canvas-API,
-      die Bilder direkt dekodieren und neu kodieren kann. Die Arbeit, für die
-      früher ein Server nötig war, läuft heute auf dem Gerät, das die Datei
-      ohnehin hat.
+      Das hat vor Kurzem und ziemlich unbemerkt aufgehört zu stimmen. Browser
+      bringen heute WebAssembly mit, das dieselben kompilierten Codecs beinahe
+      in nativer Geschwindigkeit ausführt; WebCodecs, das den
+      Hardware-Video-Encoder zugänglich macht, der ohnehin in Ihrem Gerät sitzt;
+      und eine Canvas-API, die Bilder direkt dekodieren und neu kodieren kann.
+      Die Arbeit, für die früher ein Server nötig war, läuft heute auf dem Gerät,
+      das die Datei ohnehin hat.
     </p>
     <p>
-      Viele Werkzeuge laden trotzdem hoch, und dafür gibt es ehrliche Gründe:
-      eine bestehende Verarbeitungskette, die niemand neu schreiben will, ein
-      Format ohne Decoder auf der Browserseite, eine Aufgabe, die für ein Telefon
-      wirklich zu schwer ist. Es gibt auch einen weniger ehrlichen Grund: Ein
-      Server ist der Ort, an dem Konten, Kontingente und Bezahlstufen wohnen. Ein
-      Werkzeug, das vollständig in Ihrem Browser läuft, lässt sich schwer
-      abrechnen.
+      Viele Werkzeuge laden dennoch hoch, und dafür gibt es ehrliche Gründe: eine
+      gewachsene Verarbeitungskette, die niemand neu schreiben will; ein Format,
+      für das es im Browser keinen Decoder gibt; eine Aufgabe, die einem Handy
+      tatsächlich zu schwer ist. Es gibt auch einen weniger ehrlichen Grund: Auf
+      dem Server wohnen Konten, Kontingente und Bezahlstufen. Ein Werkzeug, das
+      vollständig in Ihrem Browser läuft, lässt sich schlecht abrechnen.
     </p>
   </section>
 
   <section>
-    <h2>Vier Prüfungen, die Sie selbst durchführen können</h2>
+    <h2>Vier Proben, die Sie selbst machen können</h2>
     <p>
-      Sie funktionieren bei jedem Werkzeug, auch bei diesem. Für keine davon
-      müssen Sie irgendjemandem etwas glauben, und die erste dauert etwa zehn
-      Sekunden.
+      Sie funktionieren bei jedem Werkzeug, dieses eingeschlossen. Für keine
+      davon müssen Sie irgendjemandem etwas glauben, und die erste ist in zehn
+      Sekunden erledigt.
     </p>
 
     <h3>1. Ziehen Sie den Stecker</h3>
     <p>
-      Laden Sie die Seite, schalten Sie dann Ihr WLAN aus oder ziehen Sie das
-      Kabel, und versuchen Sie, sie zu benutzen. Ein Werkzeug, das seine Arbeit
-      in Ihrem Browser erledigt, macht genau wie vorher weiter. Ein Werkzeug, das
-      hochlädt, bleibt sofort stehen, weil das, was die Arbeit tut, nicht mehr
-      erreichbar ist.
+      Laden Sie die Seite, schalten Sie dann das WLAN ab oder ziehen Sie das
+      Kabel, und versuchen Sie, das Werkzeug zu benutzen. Eines, das seine Arbeit
+      in Ihrem Browser erledigt, macht genauso weiter wie zuvor. Eines, das
+      hochlädt, bleibt auf der Stelle stehen, weil das, was die Arbeit tut, nicht
+      mehr erreichbar ist.
     </p>
     <p>
-      Das ist der stärkste Test, den es gibt, und der am schwersten zu
-      fälschende, weil er sich nicht mit Formulierungen beantworten lässt.
+      Das ist die stärkste Probe, die es gibt, und die am schwersten zu
+      fälschende, weil sich mit Formulierungen nichts daran drehen lässt.
       Entweder die Umwandlung läuft ohne Netz durch, oder sie tut es nicht.
     </p>
 
     <h3>2. Beobachten Sie den Netzwerk-Tab</h3>
     <p>
-      Öffnen Sie die Entwicklerwerkzeuge Ihres Browsers, wählen Sie
-      &bdquo;Netzwerk&ldquo; und benutzen Sie dann das Werkzeug. Jede Anfrage,
-      die die Seite stellt, wird mit ihrer Größe aufgeführt. Wurde Ihr
-      4&nbsp;MB-Foto hochgeladen, steht in dieser Liste eine 4&nbsp;MB-Anfrage.
-      Ist das Größte, was die Seite verlässt, ein paar Kilobyte Werbung, dann
-      wurde es das nicht.
+      Entwicklerwerkzeuge des Browsers öffnen, auf &bdquo;Netzwerk&ldquo;
+      wechseln, dann das Werkzeug benutzen. Jede Anfrage, die die Seite stellt,
+      steht dort mit ihrer Größe. Wurde Ihr 4&nbsp;MB großes Foto hochgeladen,
+      finden Sie in dieser Liste eine Anfrage über 4&nbsp;MB. Ist das Größte, was
+      die Seite verlässt, ein paar Kilobyte Werbung, wurde es das nicht.
     </p>
     <p>
-      Sortieren Sie nach Größe und sehen Sie sich das Obere an. Sie müssen die
-      Anfragen nicht verstehen; Sie müssen nur bemerken, ob eine davon so groß
-      ist wie Ihre Datei.
+      Sortieren Sie nach Größe und schauen Sie sich nur die obersten Zeilen an.
+      Verstehen müssen Sie die Anfragen nicht &mdash; Sie müssen bloß merken, ob
+      eine davon so groß ist wie Ihre Datei.
     </p>
 
     <h3>3. Lesen Sie die Content-Security-Policy</h3>
     <p>
-      Sehen Sie sich den Quelltext der Seite an und suchen Sie weiter oben nach
-      <code>Content-Security-Policy</code>. Es ist eine Liste der Adressen, die
-      diese Seite kontaktieren darf, und sie wird von Ihrem Browser durchgesetzt
-      und nicht von den guten Absichten der Seite &mdash; eine Anfrage an etwas,
-      das nicht auf der Liste steht, wird abgewiesen, was der Code auch versucht.
+      Quelltext der Seite ansehen und weiter oben nach
+      <code>Content-Security-Policy</code> suchen. Dort steht, welche Adressen
+      diese Seite überhaupt kontaktieren darf &mdash; und durchgesetzt wird das
+      von Ihrem Browser und nicht von den guten Absichten des Anbieters: Eine
+      Anfrage an etwas, das nicht auf der Liste steht, wird abgewiesen, was der
+      Code auch versuchen mag.
     </p>
     <p>
-      Die Direktive, auf die es ankommt, ist <code>connect-src</code>: Sie regelt,
-      wohin die Seite Daten senden darf. Nennt sie eine Adresse, die zu der
-      Seite gehört, auf der Sie sind, kann die Seite Ihre Datei dorthin senden.
-      Nennt sie nichts, oder nur Dritte wie ein Werbenetzwerk, kann sie es nicht.
+      Entscheidend ist die Direktive <code>connect-src</code>; sie regelt, wohin
+      die Seite Daten senden darf. Steht dort eine Adresse, die zu der Seite
+      gehört, auf der Sie gerade sind, kann die Seite Ihre Datei dorthin
+      schicken. Steht dort gar nichts oder nur Dritte wie ein Werbenetzwerk, kann
+      sie es nicht.
     </p>
     <p>
-      Eine Seite ganz ohne Content-Security-Policy ist kein Beleg für etwas
-      Schlechtes. Es heißt nur, dass diese eine Prüfung Ihnen nichts zu sagen
-      hat.
+      Eine Seite ganz ohne Content-Security-Policy ist noch kein Hinweis auf
+      etwas Schlechtes. Sie heißt nur, dass Ihnen ausgerechnet diese Probe nichts
+      verrät.
     </p>
 
     <h3>4. Lesen Sie den Code</h3>
     <p>
-      Am unbequemsten, am schlüssigsten. Veröffentlicht ein Werkzeug seinen
+      Am unbequemsten, dafür am eindeutigsten. Veröffentlicht ein Werkzeug seinen
       Quelltext und liefert ihn ohne Build-Schritt aus, sind die Dateien, die Ihr
-      Browser geholt hat, die Dateien, die Sie lesen können. Suchen Sie darin
-      nach <code>fetch</code>, <code>XMLHttpRequest</code> und
-      <code>sendBeacon</code> &mdash; den drei Wegen, auf denen eine Seite
-      überhaupt etwas senden kann &mdash; und sehen Sie nach, was ihnen übergeben
-      wird.
+      Browser geholt hat, genau die Dateien, die Sie lesen können. Suchen Sie
+      darin nach <code>fetch</code>, <code>XMLHttpRequest</code> und
+      <code>sendBeacon</code> &mdash; das sind die drei Wege, auf denen eine
+      Seite überhaupt etwas hinausschicken kann &mdash;, und sehen Sie nach, was
+      ihnen übergeben wird.
     </p>
     <p>
-      Die meisten werden das nicht tun. Es zählt trotzdem, dass es möglich ist,
-      denn eine Behauptung, die niemand nachprüfen kann, ist keine richtige
+      Die wenigsten werden sich diese Mühe machen. Dass es möglich ist, zählt
+      trotzdem: Eine Behauptung, die niemand nachprüfen kann, ist keine richtige
       Behauptung.
     </p>
   </section>
 
   <section>
-    <h2>Was &bdquo;läuft in Ihrem Browser&ldquo; nicht heißt</h2>
+    <h2>Was &bdquo;läuft in Ihrem Browser&ldquo; nicht bedeutet</h2>
     <p>
-      Genauigkeit lohnt sich hier, weil die Formulierung locker verwendet wird
-      und diese Seite sich an denselben Maßstab halten muss, den sie vorschlägt.
+      Hier lohnt sich Genauigkeit, weil die Formulierung reichlich lose verwendet
+      wird &mdash; und weil diese Seite sich an denselben Maßstab halten muss,
+      den sie anlegt.
     </p>
     <ul>
       <li>
         <strong>Es heißt nicht: überhaupt keine Anfragen.</strong> Die Seite
-        selbst kam über das Netz, und die meisten kostenlosen Werkzeuge tragen
-        Werbung oder Analyse, die mit jemandem spricht. Die Behauptung betrifft
-        Ihre <em>Datei</em>, nicht den Verkehr im Allgemeinen.
+        selbst kam übers Netz, und die meisten kostenlosen Werkzeuge tragen
+        Werbung oder Messung, die mit irgendjemandem spricht. Die Zusage betrifft
+        Ihre <em>Datei</em> und nicht den Datenverkehr im Allgemeinen.
       </li>
       <li>
-        <strong>Es verbirgt Ihre IP-Adresse nicht.</strong> Jede Seite, die Sie
-        besuchen, sieht sie, diese eingeschlossen. Lokale Verarbeitung geht um
-        den Inhalt Ihrer Dateien, nicht um Anonymität.
+        <strong>Es verbirgt Ihre IP-Adresse nicht.</strong> Die sieht jede Seite,
+        die Sie besuchen, diese eingeschlossen. Bei lokaler Verarbeitung geht es
+        um den Inhalt Ihrer Dateien, nicht um Anonymität.
       </li>
       <li>
-        <strong>Es überlebt keine Funktion, die etwas abruft.</strong> Ein
-        Werkzeug, das Sie eine Webadresse einfügen lässt, muss diese Adresse
-        kontaktieren, und jener Server erfährt Ihre IP und was Sie angefordert
-        haben. Das gehört zur Funktion und ist kein Fehler darin &mdash; aber es
-        ist eine echte Ausnahme, und ein Werkzeug sollte sie klar aussprechen,
-        statt sie abzurunden.
+        <strong>Eine Funktion, die etwas abruft, hebt es auf.</strong> Ein
+        Werkzeug, in das Sie eine Webadresse einfügen können, muss diese Adresse
+        kontaktieren, und der Server dahinter erfährt Ihre IP und was Sie
+        angefordert haben. Das gehört zur Funktion und ist kein Fehler darin
+        &mdash; aber es ist eine echte Ausnahme, und ein Werkzeug sollte sie
+        deutlich aussprechen, statt sie unter den Tisch fallen zu lassen.
       </li>
       <li>
         <strong>Es ist nicht dasselbe wie &bdquo;wir löschen Ihre
-        Dateien&ldquo;.</strong> Der zweite Satz handelt davon, was ein
-        Unternehmen zu tun beschließt. Der erste davon, was technisch möglich
-        ist. Nur einer von beiden ist nachprüfbar.
+        Dateien&ldquo;.</strong> Der zweite Satz handelt davon, wozu eine Firma
+        sich entschließt. Der erste davon, was technisch überhaupt möglich ist.
+        Nachprüfbar ist nur einer von beiden.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Wann Hochladen wirklich in Ordnung ist</h2>
+    <h2>Wann Hochladen völlig in Ordnung ist</h2>
     <p>
-      Das hier ist kein Argument dafür, dass jeder Upload ein Fehler ist.
-      Schicken Sie die Datei, wenn der Inhalt nicht heikel ist und die Aufgabe so
-      leichter geht; wenn die Arbeit für Ihr Gerät wirklich zu schwer ist; wenn
-      das Format auf der Browserseite keinen Decoder hat; oder wenn Sie einen
-      Dienst nutzen, zu dem Sie ohnehin eine Beziehung haben und dessen
+      Das hier ist kein Plädoyer dafür, dass jeder Upload ein Fehler wäre.
+      Schicken Sie die Datei ruhig, wenn der Inhalt nicht heikel ist und die
+      Aufgabe so leichter geht; wenn die Arbeit Ihrem Gerät wirklich zu schwer
+      ist; wenn es für das Format im Browser keinen Decoder gibt; oder wenn Sie
+      einen Dienst nutzen, zu dem Sie ohnehin eine Beziehung haben und dessen
       Bedingungen Sie tatsächlich gelesen haben.
     </p>
     <p>
-      Seien Sie vorsichtiger, wenn die Datei etwas enthält, das Sie nicht
-      öffentlich posten würden: Ausweispapiere, medizinische Aufnahmen, Verträge,
-      alles mit einer Adresse oder einem Gesicht, das Sie nicht teilen wollten,
-      oder ein Foto, dessen Ortsdaten Sie sich nicht angesehen haben. Dafür ist
-      ein Werkzeug, das Sie prüfen können, einem vorzuziehen, dem Sie vertrauen
-      müssen &mdash; nicht, weil das vertrauenswürdige Sie wahrscheinlich
-      hinterginge, sondern weil die Frage beim nachprüfbaren gar nicht erst
-      aufkommt.
+      Vorsichtiger sollten Sie werden, sobald in der Datei etwas steckt, das Sie
+      nicht öffentlich posten würden: Ausweispapiere, medizinische Aufnahmen,
+      Verträge, alles mit einer Anschrift oder einem Gesicht, das Sie nicht
+      herzeigen wollten, oder ein Foto, in dessen Ortsdaten Sie nie hineingesehen
+      haben. In solchen Fällen ist ein Werkzeug, das Sie prüfen können, einem
+      vorzuziehen, dem Sie vertrauen müssen &mdash; nicht, weil das
+      vertrauenswürdige Sie wahrscheinlich hinterginge, sondern weil sich beim
+      nachprüfbaren die Frage gar nicht erst stellt.
     </p>
   </section>
 
   <section>
-    <h2>Wie diese Seite die vier Prüfungen besteht</h2>
+    <h2>Wie diese Seite die vier Proben besteht</h2>
     <p>
-      Es wäre ein seltsamer Ratgeber, der Ihnen sagt zu prüfen und dann um eine
-      Ausnahme bittet. Also, der Reihe nach:
+      Es wäre ein merkwürdiger Ratgeber, der Ihnen zum Prüfen rät und dann um
+      eine Ausnahme für sich selbst bittet. Also der Reihe nach:
     </p>
     <ul>
       <li>
         <strong>Stecker ziehen.</strong> Öffnen Sie hier irgendein Werkzeug,
-        trennen Sie die Verbindung, und es arbeitet weiter. Jede Werkzeugseite
-        hat eine Live-Anzeige, die Ihnen sagt, ob Sie gerade online sind &mdash;
-        Sie können also zusehen, wie sie umspringt.
+        trennen Sie die Verbindung &mdash; es arbeitet weiter. Jede
+        Werkzeugseite hat eine Anzeige, die laufend meldet, ob Sie gerade online
+        sind; Sie können also zusehen, wie sie umspringt.
       </li>
       <li>
         <strong>Netzwerk-Tab.</strong> Wandeln Sie etwas um und lesen Sie die
-        Liste. Nichts trägt Ihre Datei, ein Vorschaubild davon, ihren Namen, ihre
-        Größe oder irgendetwas, was daraus gelesen wurde. Es gibt auf dieser
-        Seite kein eigenes Analytics-Ereignis, das davon etwas zu senden hätte.
+        Liste. Nichts darin trägt Ihre Datei, ein Vorschaubild davon, ihren
+        Namen, ihre Größe oder irgendetwas, was daraus gelesen wurde. Auf dieser
+        Seite gibt es kein eigenes Analytics-Ereignis, das davon etwas zu senden
+        hätte.
       </li>
       <li>
         <strong>Content-Security-Policy.</strong> Sie steht oben im Quelltext
         jeder Seite. <code>connect-src</code> nennt Googles Werbe- und
-        Messendpunkte und den Spenden-Button, und sonst nichts.
-        <strong>Keine Adresse auf dieser Liste gehört zu dieser Seite</strong>,
-        denn diese Seite hat keinen Server &mdash; sie besteht aus statischen
-        Dateien. Es gibt keinen Ort, an den eine Datei ginge, selbst wenn etwas
-        es versuchte.
+        Messendpunkte sowie den Spenden-Button, und sonst nichts.
+        <strong>Keine einzige Adresse auf dieser Liste gehört zu dieser
+        Seite</strong>, denn diese Seite hat keinen Server &mdash; sie besteht
+        aus statischen Dateien. Es gibt schlicht keinen Ort, an den eine Datei
+        gehen könnte, selbst wenn etwas es versuchte.
       </li>
       <li>
         <strong>Code.</strong> Jede Zeile ist
         <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">öffentlich</a>.
-        Der Build entfernt Kommentare und Leerraum und sonst nichts, und Sie
+        Der Build entfernt Kommentare und Leerraum, sonst nichts &mdash; Sie
         können ihn selbst ausführen und das Ergebnis mit dem vergleichen, was
-        ausgeliefert wird.
+        hier ausgeliefert wird.
       </li>
     </ul>
     <p>
       Die Ausnahmen, ausgesprochen statt vergraben: Diese Seite trägt
-      Google-Werbung und einen Besuchszähler, die beide mit Google sprechen und
-      denen beiden nichts über Ihre Dateien übergeben wird; und das Werkzeug
+      Google-Werbung und einen Besuchszähler; beide sprechen mit Google, und
+      beiden wird nichts über Ihre Dateien übergeben. Und das Werkzeug
       <a href="../../bilder-in-video-umwandeln/">Bilder in Video</a> kann ein
-      Bild von einer Adresse holen, die Sie einfügen &mdash; jener Server sieht
-      dabei Ihre IP. Die <a href="../../datenschutz/">Datenschutzseite</a> legt
-      beides vollständig dar.
+      Bild von einer Adresse holen, die Sie einfügen &mdash; der Server dahinter
+      sieht dabei Ihre IP. Die <a href="../../datenschutz/">Datenschutzseite</a>
+      legt beides vollständig offen.
     </p>
     <p>
-      Jedes Werkzeug hier funktioniert so: ein
+      Nach demselben Muster arbeitet jedes Werkzeug hier: der
       <a href="../../bild-komprimieren/">Bildkompressor</a>, der eine von Ihnen
-      genannte Größe trifft, ein
-      <a href="../../video-zuschneiden/">Video-Zuschneider</a>, ein
+      genannte Größe trifft, der
+      <a href="../../video-zuschneiden/">Video-Zuschneider</a>, der
       <a href="../../exif-daten-entfernen/">EXIF-Betrachter und -Entferner</a>
       für die weiter oben beschriebenen versteckten Daten,
       <a href="../../bilder-in-video-umwandeln/">Bilder in Video</a> und
-      <a href="../../bilder-in-pdf-umwandeln/">Bilder in PDF</a>. Alle kostenlos,
-      kein Konto, und keines von ihnen hat einen Ort, an den es Ihre Dateien
-      schicken könnte.
+      <a href="../../bilder-in-pdf-umwandeln/">Bilder in PDF</a>. Alles
+      kostenlos, ohne Konto &mdash; und keines davon hat einen Ort, an den es
+      Ihre Dateien überhaupt schicken könnte.
     </p>
   </section>

--- a/locales/de/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/de/pages/guides/is-it-safe-to-upload-files.toml
@@ -4,14 +4,15 @@
 
 nav = "Ist das Hochladen sicher?"
 title = "Ist es sicher, Dateien zu Online-Konvertern hochzuladen?"
-description = "Die meisten Online-Konverter schicken Ihre Datei an einen Server. Was das bedeutet, was dort damit geschieht, und vier Prüfungen, die zeigen, ob ein Werkzeug es überhaupt nötig hat."
+description = "Die meisten Online-Konverter schicken Ihre Datei an einen Server. Was dort damit geschieht, warum die Anbieter das tun und vier Proben, die zeigen, ob ein Werkzeug den Upload überhaupt nötig hat."
 heading = "Ist es sicher, Dateien zu Online-Konvertern hochzuladen?"
 lede = """
-    Die ehrliche Antwort lautet meist: &bdquo;Wahrscheinlich schon, aber Sie
-    können es nicht nachprüfen.&ldquo; Hier steht, was das Hochladen mit Ihrer
-    Datei tatsächlich macht, warum die meisten Werkzeuge es trotzdem tun, und
-    vier Tests, die zeigen, ob das Werkzeug vor Ihnen es nötig hat."""
+    Ehrlich beantwortet lautet die Antwort meist: &bdquo;Vermutlich schon
+    &mdash; nachprüfen können Sie es allerdings nicht.&ldquo; Hier steht, was
+    beim Hochladen wirklich mit Ihrer Datei passiert, warum die meisten
+    Werkzeuge trotzdem darauf bestehen, und mit welchen vier Proben Sie
+    herausfinden, ob das Werkzeug vor Ihnen den Upload überhaupt braucht."""
 updated = "20. August 2026"
 og_title = "Ist es sicher, Dateien zu Online-Konvertern hochzuladen?"
-og_description = "Was mit einer Datei geschieht, die Sie zu einem Konverter hochladen, warum die meisten Werkzeuge danach fragen, und vier Prüfungen, die Sie selbst durchführen können."
+og_description = "Was mit einer hochgeladenen Datei geschieht, warum die meisten Werkzeuge danach verlangen und vier Proben, die Sie selbst machen können."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/make-a-favicon.html
+++ b/locales/de/pages/guides/make-a-favicon.html
@@ -4,144 +4,144 @@
       Öffnen Sie <a href="../../favicon-erstellen/">Bild zu ICO</a>, ziehen Sie
       ein quadratisches Bild von mindestens 256 Pixeln hinein, lassen Sie die
       Voreinstellung auf <em>Website-Favicon</em> und laden Sie
-      <code>favicon.ico</code> herunter. Legen Sie sie in die Wurzel Ihrer Seite,
-      damit sie unter <code>https://ihreseite.de/favicon.ico</code> antwortet.
-      Nach dieser Adresse fragt jeder Browser, ob Ihr HTML sie erwähnt oder
-      nicht &mdash; mehr müssen Sie streng genommen nicht tun.
+      <code>favicon.ico</code> herunter. Die Datei gehört in die Wurzel Ihrer
+      Seite, damit sie unter <code>https://ihreseite.de/favicon.ico</code>
+      antwortet. Nach genau dieser Adresse fragt jeder Browser von sich aus,
+      ganz gleich, ob Ihr HTML sie erwähnt &mdash; streng genommen sind Sie
+      damit fertig.
     </p>
     <p>
-      Alles Weitere unten ist der Teil, der den Unterschied ausmacht zwischen
-      einem Symbol, das technisch vorhanden ist, und einem, das lesbar ist:
-      welche Größen hineingehören, was iPhones und Android stattdessen verlangen,
-      und was zu tun ist, wenn Ihr Logo es nicht übersteht, sechzehn Pixel breit
-      zu sein.
+      Alles Weitere macht den Unterschied zwischen einem Symbol, das technisch
+      vorhanden ist, und einem, das man auch lesen kann: welche Größen
+      hineingehören, was iPhone und Android stattdessen verlangen und was zu tun
+      ist, wenn Ihr Logo sechzehn Pixel Breite nicht übersteht.
     </p>
   </section>
 
   <section>
-    <h2>Warum es ein Satz Größen ist und nicht ein Bild</h2>
+    <h2>Warum es ein Satz Größen ist und kein einzelnes Bild</h2>
     <p>
       Eine <code>.ico</code>-Datei ist ein Behälter. Darin liegen mehrere
-      vollständige Bilder derselben Sache in verschiedenen Größen, und was auch
-      immer die Datei liest, nimmt sich das, das der benötigten Größe am nächsten
-      kommt.
+      vollständige Bilder derselben Sache in verschiedenen Größen, und wer immer
+      die Datei liest, greift sich das Bild, das der benötigten Größe am
+      nächsten kommt.
     </p>
     <p>
-      Das klingt nach Doppelung, ist es aber nicht. Ein Browser, der Ihr Symbol
+      Das klingt nach Doppelarbeit, ist aber keine. Ein Browser, der Ihr Symbol
       mit sechzehn Pixeln zeichnet, hat zwei Möglichkeiten: eine
-      Sechzehn-Pixel-Fassung lesen, die Sie gezeichnet haben, oder eine größere an
-      Ort und Stelle verkleinern. Das Zweite ist schlechter, und zwar sichtbar
-      &mdash; ein automatisch verkleinertes, detailreiches Logo ergibt Brei,
-      während eine Sechzehn-Pixel-Fassung, die Sie angesehen haben, etwas ist,
-      das Sie vereinfachen konnten. Der ganze Grund, warum das Format mehrere
-      Größen hält, ist, Ihnen diese Gelegenheit zu geben.
+      Sechzehn-Pixel-Fassung nehmen, die Sie gezeichnet haben, oder eine größere
+      an Ort und Stelle herunterrechnen. Die zweite ist schlechter, und zwar
+      sichtbar &mdash; automatisch verkleinert ergibt ein detailreiches Logo
+      Brei, während eine Sechzehn-Pixel-Fassung, die Sie selbst angesehen haben,
+      eine ist, die Sie vereinfachen konnten. Genau dafür hält das Format
+      mehrere Größen bereit: um Ihnen diese Gelegenheit zu geben.
     </p>
     <p>
-      Drei Größen sind für eine Website die Konvention, und jede hat einen Grund:
+      Für eine Website sind drei Größen üblich, und jede hat ihren Grund:
     </p>
     <ul>
       <li>
-        <strong>16&times;16</strong> &mdash; der Browser-Tab, die Adressleiste,
-        das Lesezeichenmenü. Das ist die, die Menschen sehen. Wenn Sie nur eine
-        richtig hinbekommen, dann diese.
+        <strong>16&times;16</strong> &mdash; Browser-Tab, Adressleiste,
+        Lesezeichenmenü. Das ist die Größe, die die Leute wirklich sehen. Wenn
+        nur eine gelingen soll, dann diese.
       </li>
       <li>
         <strong>32&times;32</strong> &mdash; die Lesezeichenleiste, eine
-        Windows-Desktop-Verknüpfung zu Ihrer Seite, und die meisten Browser auf
-        einem hochauflösenden Bildschirm, die das Tab-Symbol aus 32 zeichnen und
+        Windows-Verknüpfung auf dem Desktop und die meisten Browser auf einem
+        hochauflösenden Bildschirm, die das Tab-Symbol aus der 32er zeichnen und
         herunterskalieren.
       </li>
       <li>
         <strong>48&times;48</strong> &mdash; die Größe, in der Google ein
-        Seitensymbol für Suchergebnisse liest, und die mittlere Symbolansicht von
-        Windows.
+        Seitensymbol für die Suchergebnisse liest, und die Ansicht
+        &bdquo;Mittelgroße Symbole&ldquo; im Windows-Explorer.
       </li>
     </ul>
     <p>
-      Alles Größere gehört in ein PNG neben die <code>.ico</code> und nicht
-      hinein, aus Gründen, die bei den Mobil-Dateien weiter unten aufkommen.
+      Alles Größere gehört als PNG neben die <code>.ico</code> und nicht
+      hinein &mdash; warum, steht weiter unten bei den Dateien fürs Handy.
     </p>
   </section>
 
   <section>
     <h2>Das Sechzehn-Pixel-Problem</h2>
     <p>
-      Das ist der Teil, vor dem niemand warnt. Sechzehn Pixel sind auf einem
-      normalen Bildschirm etwa vier Millimeter: ein Raster aus insgesamt 256
-      Punkten, weniger als dieser Satz Buchstaben hat. Fast nichts, was für ein
-      Schild, eine Visitenkarte oder eine Website-Kopfzeile gestaltet wurde,
-      übersteht es, darauf verkleinert zu werden.
+      Davor warnt niemand. Sechzehn Pixel sind auf einem normalen Bildschirm
+      etwa vier Millimeter: ein Raster aus 16 mal 16 Punkten, 256 Stück
+      insgesamt. Fast nichts, was für ein Schild, eine Visitenkarte oder eine
+      Website-Kopfzeile gezeichnet wurde, übersteht die Reise dorthin.
     </p>
     <p>
-      Was verschwindet, der Reihe nach:
+      Was der Reihe nach verschwindet:
     </p>
     <ul>
       <li>
-        <strong>Text.</strong> Ein in ein Quadrat verkleinerter Schriftzug ist
-        etwa drei Pixel hoch. Er wird nicht zu kleiner Schrift, er wird zu einem
-        grauen Balken. Deshalb nimmt fast jedes Unternehmen, das neben dem Namen
-        auch ein Zeichen hat, für sein Favicon das Zeichen allein &mdash; und
-        deshalb nehmen die ohne Zeichen einen einzelnen Buchstaben.
+        <strong>Text.</strong> Ein Schriftzug, in ein Quadrat gestaucht, ist noch
+        rund drei Pixel hoch. Daraus wird keine kleine Schrift, daraus wird ein
+        grauer Balken. Deshalb nimmt fast jede Firma, die neben dem Namen auch
+        ein Zeichen hat, fürs Favicon das Zeichen allein &mdash; und deshalb
+        nehmen die ohne Zeichen einen einzelnen Buchstaben.
       </li>
       <li>
         <strong>Dünne Linien.</strong> Ein ein Pixel breiter Rahmen an einem
-        512-Pixel-Logo ist bei sechzehn ein Zweiunddreißigstel Pixel. Er kommt
-        als blasser grauer Schleier an der Kante heraus, oder er verschwindet.
+        512-Pixel-Logo ist bei sechzehn Pixeln ein Zweiunddreißigstel Pixel
+        breit. Er kommt als blasser grauer Schleier entlang der Kante heraus
+        &mdash; oder gar nicht.
       </li>
       <li>
-        <strong>Verläufe und Schatten.</strong> Für einen Übergang ist kein Platz.
-        Ein weicher Schlagschatten wird zu einem schmutzigen Saum.
+        <strong>Verläufe und Schatten.</strong> Für einen Übergang ist kein
+        Platz. Aus einem weichen Schlagschatten wird ein schmutziger Saum.
       </li>
       <li>
-        <strong>Detail im Detail.</strong> Ein Symbol eines Dokuments mit Schrift
-        darauf wird zu einem Rechteck mit einem Fleck.
+        <strong>Detail im Detail.</strong> Aus dem Symbol eines beschriebenen
+        Dokuments wird ein Rechteck mit einem Fleck darin.
       </li>
     </ul>
     <p>
-      Die Lösung ist keine Einstellung, sondern eine andere Zeichnung: ein
-      vereinfachtes Zeichen mit ein oder zwei Formen, hohem Kontrast und keinem
-      Text über ein einzelnes Zeichen hinaus. Zeichnen Sie diese Fassung bewusst
-      bei 32 oder 48 Pixeln und nehmen Sie sie als Quelle.
+      Abhilfe schafft keine Einstellung, sondern eine andere Zeichnung: ein
+      vereinfachtes Zeichen mit ein, zwei Formen, hohem Kontrast und keinem Text
+      über einen einzelnen Buchstaben hinaus. Zeichnen Sie diese Fassung bewusst
+      bei 32 oder 48 Pixeln und nehmen Sie sie als Vorlage.
     </p>
     <p>
-      Was ein Werkzeug tun kann, ist, Ihnen das Problem zu zeigen, bevor Sie es
-      veröffentlichen. Die Vorschau in
+      Was ein Werkzeug tun kann, ist, Ihnen das Problem vor der
+      Veröffentlichung zu zeigen. Die Vorschau in
       <a href="../../favicon-erstellen/">Bild zu ICO</a> zeichnet jede Größe in
-      ihrer echten Größe auf dem Bildschirm, und das ist die einzige Art, das zu
-      beurteilen &mdash; ein Sechzehn-Pixel-Symbol, mit vierundsechzig
-      dargestellt, sieht gut aus und sagt Ihnen nichts.
+      ihrer echten Größe auf den Bildschirm, und nur so lässt sich das
+      beurteilen: Ein Sechzehn-Pixel-Symbol, mit vierundsechzig dargestellt,
+      sieht prima aus und sagt Ihnen nichts.
     </p>
   </section>
 
   <section>
-    <h2>Ihr Logo ist nicht quadratisch. Auffüllen oder zuschneiden?</h2>
+    <h2>Ihr Logo ist nicht quadratisch &mdash; auffüllen oder zuschneiden?</h2>
     <p>
-      Ein Symbol ist immer quadratisch, und die meisten Logos sind es nicht, also
-      muss etwas geschehen. Es gibt drei Antworten, und sie sind nicht gleich
-      gut.
+      Ein Symbol ist immer quadratisch, die meisten Logos sind es nicht: Etwas
+      muss also geschehen. Es gibt drei Antworten, und sie taugen nicht gleich
+      viel.
     </p>
     <p>
       <strong>Auffüllen</strong> behält das ganze Bild und setzt Platz darüber
-      und darunter. Es ist die sichere Voreinstellung und die falsche Wahl für
-      einen breiten Schriftzug: Etwas dreimal so Breites wie Hohes in ein Quadrat
-      zu setzen lässt es ein Drittel der Höhe einnehmen &mdash; bei sechzehn
-      Pixeln also fünf Pixel Logo und elf Pixel nichts.
+      und darunter. Das ist die sichere Voreinstellung und die falsche Wahl für
+      einen breiten Schriftzug: Was dreimal so breit wie hoch ist, nimmt in einem
+      Quadrat ein Drittel der Höhe ein &mdash; bei sechzehn Pixeln also fünf
+      Pixel Logo und elf Pixel nichts.
     </p>
     <p>
-      <strong>Auf die Mitte zuschneiden</strong> nimmt das größte Quadrat aus
-      der Mitte. Bei einer Wort-Bild-Marke &mdash; einem Zeichen mit dem
-      Firmennamen daneben &mdash; schneidet das oft mitten durch beides. Besser,
-      Sie schneiden die Quelle vorher selbst auf das Zeichen allein zu und
-      wandeln dann das um.
+      <strong>Auf die Mitte zuschneiden</strong> nimmt das größte Quadrat aus der
+      Bildmitte. Bei einer Wort-Bild-Marke &mdash; einem Zeichen mit dem
+      Firmennamen daneben &mdash; geht der Schnitt gern quer durch beides.
+      Besser, Sie schneiden die Vorlage vorher selbst auf das Zeichen allein zu
+      und wandeln dann das um.
     </p>
     <p>
-      <strong>Dehnen</strong> staucht das Bild, damit es passt. Es gibt kaum eine
-      Lage, in der das richtig ist, und es wird vor allem deshalb angeboten,
-      damit das Werkzeug es nicht stillschweigend tut.
+      <strong>Dehnen</strong> staucht das Bild, bis es passt. Es gibt kaum eine
+      Lage, in der das richtig wäre &mdash; angeboten wird es vor allem deshalb,
+      damit das Werkzeug es nicht klammheimlich von sich aus tut.
     </p>
     <p>
-      Die allgemeine Antwort für ein breites Logo: Wandeln Sie nicht das Logo um.
-      Wandeln Sie den Teil davon um, der für sich allein funktioniert.
+      Die allgemeine Antwort für ein breites Logo lautet: Wandeln Sie nicht das
+      Logo um, sondern den Teil davon, der für sich allein funktioniert.
     </p>
   </section>
 
@@ -150,204 +150,204 @@
     <p>
       Für eine Website ist transparent meist richtig. Browser-Tabs sind grau,
       weiß oder fast schwarz, je nach Browser und Farbschema, und ein
-      transparentes Symbol sitzt auf allen davon. Ein Symbol mit
-      hineingemaltem weißem Hintergrund ist in einer dunklen Tableiste ein weißes
-      Rechteck.
+      transparentes Symbol sitzt auf allen dreien. Ein Symbol mit
+      hineingemaltem weißem Hintergrund ist in einer dunklen Tableiste schlicht
+      ein weißes Rechteck.
     </p>
     <p>
-      Zwei wissenswerte Ausnahmen:
+      Zwei Ausnahmen sollten Sie kennen:
     </p>
     <ul>
       <li>
-        <strong>Ein Logo, das dunkel ist und sonst nichts</strong>, verschwindet
-        im dunklen Modus. Ist Ihr Zeichen von Natur aus schwarz auf weiß, geben
-        Sie ihm einen farbigen Hintergrund statt eines transparenten, oder eine
-        helle Kontur.
+        <strong>Ein Logo, das nur dunkel ist</strong>, verschwindet im dunklen
+        Modus. Ist Ihr Zeichen von Haus aus schwarz auf weiß, geben Sie ihm einen
+        farbigen Hintergrund statt eines transparenten &mdash; oder eine helle
+        Kontur.
       </li>
       <li>
-        <strong>Das Apple-Touch-Symbol muss undurchsichtig sein.</strong> iOS
-        zeichnet es auf seine eigene abgerundete Kachel und macht aus Transparenz
-        Schwarz. Jedes Werkzeug, das diese Datei erzeugt, sollte sie für Sie
-        herunterrechnen; das hier tut es, standardmäßig auf Weiß.
+        <strong>Das Apple-Touch-Symbol muss deckend sein.</strong> iOS zeichnet
+        es auf seine eigene abgerundete Kachel und macht aus Transparenz Schwarz.
+        Jedes Werkzeug, das diese Datei erzeugt, sollte sie für Sie auf einen
+        Untergrund reduzieren; dieses hier tut es, standardmäßig auf Weiß.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Die Dateien, die eine Website braucht und die nicht die .ico sind</h2>
+    <h2>Die Dateien, die eine Website neben der .ico braucht</h2>
     <p>
-      <code>favicon.ico</code> deckt Browser und Windows ab. Sie deckt keine
-      Telefone ab, und hier hören die meisten selbstgemachten Symbolsätze zu
-      früh auf. Drei andere Plattformen verlangen ihre eigenen Dateien unter
-      ihren eigenen Namen, und keine davon sieht in eine <code>.ico</code>
+      <code>favicon.ico</code> deckt Browser und Windows ab. Handys deckt sie
+      nicht ab &mdash; und genau hier hören die meisten selbst gebauten
+      Symbolsätze zu früh auf. Drei weitere Plattformen verlangen eigene Dateien
+      unter eigenen Namen, und keine davon sieht in eine <code>.ico</code>
       hinein:
     </p>
     <ul>
       <li>
         <strong>iOS</strong> liest <code>apple-touch-icon.png</code> mit
-        180&times;180, wenn jemand Ihre Seite auf den Startbildschirm legt. Ohne
-        sie nimmt iOS einen Bildschirmausschnitt der Seite, und das sieht nach
-        einem Versehen aus.
+        180&times;180, sobald jemand Ihre Seite auf den Home-Bildschirm legt.
+        Fehlt sie, nimmt iOS einen Bildschirmausschnitt der Seite &mdash; und
+        das sieht nach Versehen aus.
       </li>
       <li>
         <strong>Android und jede Installationsaufforderung</strong> lesen ein
-        Web-App-Manifest &mdash; <code>site.webmanifest</code> &mdash;, das auf
-        PNGs mit 192 und 512 Pixeln zeigt. Die 512 ist auch das, was eine Web-App
-        auf ihrem Startbildschirm zeigt.
+        Web-App-Manifest, <code>site.webmanifest</code>, das auf PNGs mit 192 und
+        512 Pixeln zeigt. Die 512er ist zugleich das Bild, das eine Web-App auf
+        ihrem Splashscreen zeigt.
       </li>
       <li>
         <strong>Eine Kachel im Windows-Startmenü</strong> liest
-        <code>browserconfig.xml</code>, die auf ein 150&times;150-PNG zeigt. Von
-        den dreien die unwichtigste, und vier Zeilen XML.
+        <code>browserconfig.xml</code>, die auf ein PNG mit 150&times;150 zeigt.
+        Von den dreien die unwichtigste &mdash; und vier Zeilen XML.
       </li>
     </ul>
     <p>
-      Es gibt noch eine, die leicht schiefgeht: Android-Launcher schneiden ein
-      adaptives Symbol auf die Form zu, die dem Telefon gefällt &mdash; Kreis,
-      Squircle, abgerundetes Quadrat &mdash;, und nur die mittleren 80&nbsp;% des
-      Bildes überleben garantiert. Ein von Kante zu Kante gezeichnetes Symbol
-      verliert seine Ecken. Genau das ist ein <em>maskierbares</em> Symbol:
-      dasselbe Bild, bewusst klein in das Quadrat gezeichnet und im Manifest
-      gesondert deklariert.
+      Eine Sache geht dabei besonders leicht schief: Android-Launcher schneiden
+      ein adaptives Symbol auf die Form zu, die dem Handy gefällt &mdash; Kreis,
+      Squircle, abgerundetes Quadrat &mdash;, und garantiert überleben nur die
+      mittleren 80&nbsp;% des Bildes. Ein Symbol, das bis an die Kanten
+      gezeichnet ist, verliert seine Ecken. Genau darum geht es bei einem
+      <em>maskierbaren</em> Symbol: dasselbe Bild, bewusst klein ins Quadrat
+      gesetzt und im Manifest gesondert deklariert.
     </p>
     <p>
       Das Häkchen beim Website-Satz in
-      <a href="../../favicon-erstellen/">Bild zu ICO</a> erzeugt all das, das
-      Manifest und den HTML-Block, der darauf zeigt. Was dieser Block bewusst
-      weglässt, ist ein <code>&lt;link&gt;</code> für
-      <code>favicon.ico</code>: Browser fragen diese Adresse von sich aus ab, und
-      sie zusätzlich zu nennen sorgt dafür, dass dieselbe Datei zweimal geholt
-      wird.
+      <a href="../../favicon-erstellen/">Bild zu ICO</a> erzeugt all das, dazu
+      das Manifest und den HTML-Block, der darauf verweist. Was dieser Block
+      absichtlich weglässt, ist ein <code>&lt;link&gt;</code> auf
+      <code>favicon.ico</code>: Diese Adresse fragen Browser ohnehin von selbst
+      ab, und sie zusätzlich zu nennen führt nur dazu, dass dieselbe Datei
+      zweimal geholt wird.
     </p>
   </section>
 
   <section>
-    <h2>Ein Windows-Anwendungssymbol ist ein anderer Satz</h2>
+    <h2>Ein Windows-Programmsymbol ist ein anderer Satz</h2>
     <p>
-      Ist das Symbol für ein Programm und nicht für eine Seite, ändern sich die
-      Größen. Was die Standard-<code>app.ico</code> von Visual Studio selbst
-      enthält, sind 16, 32, 48 und 256 &mdash; die drei Shell-Größen plus die
-      große, aus der das Startmenü und die extragroße Explorer-Ansicht zeichnen.
+      Geht es um ein Programm statt um eine Website, ändern sich die Größen. In
+      der Standard-<code>app.ico</code> von Visual Studio stecken 16, 32, 48 und
+      256 &mdash; die drei Shell-Größen plus die große, aus der sich das
+      Startmenü und die Explorer-Ansicht &bdquo;Extra große Symbole&ldquo;
+      bedienen.
     </p>
     <p>
-      Auf einem hochauflösenden Bildschirm verlangt Windows außerdem 20, 24, 40,
-      64 und 96 und rechnet sie aus der nächstgelegenen vorhandenen Größe hoch,
-      wenn sie fehlen. Ob das zählt, hängt von Ihrem Symbol ab: Eine flache Form
-      übersteht das Hochrechnen, eine detailreiche nicht. Sie hinzuzufügen
-      verdoppelt die Datei ungefähr, was bei einer Anwendung überhaupt nichts ist
-      &mdash; die Rechnung ist völlig anders als bei einem Favicon, das von jedem
-      Besucher geholt wird.
+      Auf einem hochauflösenden Bildschirm verlangt Windows zusätzlich 20, 24,
+      40, 64 und 96 und rechnet sie, wenn sie fehlen, aus der nächstliegenden
+      vorhandenen Größe hoch. Ob das auffällt, hängt an Ihrem Symbol: Eine flache
+      Form übersteht das Hochrechnen, eine detailreiche nicht. Alle fünf
+      mitzunehmen verdoppelt die Datei ungefähr, und bei einem Programm ist das
+      vollkommen belanglos &mdash; die Rechnung sieht ganz anders aus als beim
+      Favicon, das jeder einzelne Besucher lädt.
     </p>
     <p>
-      Noch etwas zur Größe: Im 256er-Eintrag stecken die Bytes. Unkomprimiert
-      gespeichert ist er allein 264&nbsp;KB groß; als PNG im Symbol gespeichert
-      meist unter 30. PNG-Einträge sind seit Windows Vista lesbar, der einzige
-      Grund, sie zu meiden, ist also Software, die wirklich älter ist als das,
-      oder ein Installer oder eingebettetes Werkzeug, das Symbole selbst zerlegt.
+      Noch ein Wort zur Größe: Im 256er-Eintrag stecken die Bytes. Unkomprimiert
+      gespeichert ist er allein 264&nbsp;KB groß, als PNG im Symbol abgelegt
+      meist unter 30. PNG-Einträge sind seit Windows Vista lesbar; sie zu meiden
+      lohnt also nur wegen Software, die tatsächlich älter ist, oder wegen eines
+      Installers oder eingebetteten Werkzeugs, das Symbole selbst zerlegt.
     </p>
   </section>
 
   <section>
     <h2>Ein Mac liest eine ganz andere Datei</h2>
     <p>
-      Ist das Symbol für eine Mac-Anwendung statt für eine Windows-Anwendung,
-      gilt nichts vom Obigen: macOS liest <code>.ico</code> überhaupt nicht. Es
-      liest <code>.icns</code>, dieselbe Idee in einer anderen Hülle &mdash;
-      mehrere Größen in einem Behälter &mdash; mit drei wissenswerten
-      Unterschieden.
+      Geht es um ein Mac-Programm statt um ein Windows-Programm, gilt nichts vom
+      Vorstehenden: <code>.ico</code> liest macOS überhaupt nicht. Es liest
+      <code>.icns</code> &mdash; dieselbe Idee in anderer Verpackung, mehrere
+      Größen in einem Behälter &mdash;, mit drei bemerkenswerten Unterschieden.
     </p>
     <ul>
       <li>
-        <strong>Die Größen stehen fest.</strong> Apple veröffentlicht zehn
-        Plätze, und es gibt nichts zu wählen: 16, 32, 64, 128, 256, 512 und 1024
-        Pixel, wobei 32, 256 und 512 zweimal vorkommen, weil jede sowohl eine
-        eigene Größe ist als auch die Retina-Fassung der Größe darunter.
+        <strong>Die Größen liegen fest.</strong> Apple veröffentlicht zehn
+        Plätze, und zu wählen gibt es nichts: 16, 32, 64, 128, 256, 512 und 1024
+        Pixel, wobei 32, 256 und 512 zweimal vorkommen, weil jede zugleich eine
+        eigene Größe und die Retina-Fassung der Größe darunter ist.
       </li>
       <li>
         <strong>Es geht bis 1024.</strong> Eine <code>.ico</code> hört bei 256
-        auf, und deshalb ist eine Mac-Symboldatei mehrere hundert Kilobyte groß
-        und ein Favicon fünfzehn. Für eine einmal ausgelieferte Anwendung ist das
-        nichts; nur ein Favicon wird von jedem Besucher geholt.
+        auf &mdash; deshalb ist eine Mac-Symboldatei mehrere hundert Kilobyte
+        groß und ein Favicon fünfzehn. Bei einem Programm, das einmal
+        ausgeliefert wird, spielt das keine Rolle; nur das Favicon holt sich
+        jeder Besucher.
       </li>
       <li>
-        <strong>1024 Pixel sind das, was Ihre Grafik überstehen muss.</strong>
-        Die beiden Probleme sind entgegengesetzte Enden desselben Bildes: Ein
-        Favicon muss funktionieren, wenn es winzig ist, und ein Mac-Symbol muss
-        standhalten, wenn es riesig ist. Ein bei 512 exportiertes und auf 1024
-        aufgeblasenes Logo sieht auf einem Retina-Bildschirm weich aus, und der
-        App Store nimmt es nicht.
+        <strong>1024 Pixel muss Ihre Grafik aushalten.</strong> Die beiden
+        Probleme sind die entgegengesetzten Enden desselben Bildes: Ein Favicon
+        muss winzig funktionieren, ein Mac-Symbol riesig standhalten. Ein bei 512
+        exportiertes und auf 1024 aufgeblasenes Logo wirkt auf einem
+        Retina-Bildschirm weich &mdash; und der App Store nimmt es nicht.
       </li>
     </ul>
     <p>
-      Zur Verwendung: Ein Anwendungspaket hält sie unter
-      <code>IhreApp.app/Contents/Resources/</code> und benennt sie in
-      <code>Info.plist</code>. Für einen Ordner oder ein Festplattenabbild wählen
-      Sie die <code>.icns</code> im Finder aus, drücken Command-C, öffnen dann
-      &bdquo;Informationen&ldquo; für das, was Sie ändern wollen, klicken oben
-      links auf das kleine Symbol und drücken Command-V.
+      Zur Verwendung: Ein Programmpaket bewahrt die Datei unter
+      <code>IhreApp.app/Contents/Resources/</code> auf und benennt sie in
+      <code>Info.plist</code>. Für einen Ordner oder ein Festplattenabbild
+      markieren Sie die <code>.icns</code> im Finder, drücken Command-C, rufen
+      dann für das gewünschte Objekt &bdquo;Informationen&ldquo; auf, klicken
+      oben links auf das kleine Symbol und drücken Command-V.
     </p>
     <p>
       Das Häkchen bei <em>macOS-Symbol</em> in
-      <a href="../../favicon-erstellen/">Bild zu ICO</a> schreibt eine, mit oder
-      ohne die Windows-Datei daneben. Alles, was auf beiden Plattformen
-      ausgeliefert wird, will beide, und beide werden im selben Durchgang aus
-      demselben Bild gezeichnet.
+      <a href="../../favicon-erstellen/">Bild zu ICO</a> schreibt eine solche
+      Datei, mit oder ohne die Windows-Datei daneben. Was auf beiden Plattformen
+      erscheint, braucht beide &mdash; und beide entstehen im selben Durchgang
+      aus demselben Bild.
     </p>
   </section>
 
   <section>
-    <h2>Prüfen, ob es funktioniert hat</h2>
+    <h2>Nachsehen, ob es geklappt hat</h2>
     <p>
-      Browser halten Favicons härter im Zwischenspeicher als fast alles andere,
-      &bdquo;ich habe es hochgeladen und nichts hat sich geändert&ldquo; ist also
-      meist ein Cache und kein Fehler. Zwei Dinge zum Ausprobieren, bevor Sie
+      Favicons halten Browser hartnäckiger im Zwischenspeicher als fast alles
+      andere. &bdquo;Ich habe es hochgeladen, und nichts hat sich geändert&ldquo;
+      ist deshalb meistens ein Cache und kein Fehler. Zwei Dinge, bevor Sie
       wieder anfangen, Dateien zu bearbeiten:
     </p>
     <ul>
       <li>
-        Öffnen Sie <code>https://ihreseite.de/favicon.ico</code> direkt. Lädt die
-        Datei herunter, ist sie da und Sie sehen einen Cache. Bekommen Sie einen
-        404, liegt sie nicht in der Wurzel.
+        Rufen Sie <code>https://ihreseite.de/favicon.ico</code> direkt auf. Lädt
+        die Datei herunter, ist sie da und Sie sehen einen Cache. Kommt ein 404,
+        liegt sie nicht in der Wurzel.
       </li>
       <li>
-        Laden Sie die Seite in einem privaten Fenster, das meist einen eigenen
-        Symbol-Cache hat.
+        Öffnen Sie die Seite in einem privaten Fenster; das hat meist seinen
+        eigenen Symbol-Cache.
       </li>
     </ul>
     <p>
-      Unter Windows lässt sich eine <code>.ico</code> prüfen, indem Sie sie in
-      einen Ordner legen und den Explorer durch seine Ansichtsgrößen schalten:
-      Klein, Mittel, Groß und Extragroß zeichnen verschiedene Einträge aus
-      derselben Datei, Sie sehen also jeden so, wie das System ihn sieht.
+      Unter Windows prüfen Sie eine <code>.ico</code>, indem Sie sie in einen
+      Ordner legen und den Explorer durch seine Ansichten schalten: Kleine,
+      Mittelgroße, Große und Extra große Symbole zeichnen jeweils einen anderen
+      Eintrag aus derselben Datei &mdash; Sie sehen also jeden so, wie das System
+      ihn sieht.
     </p>
     <p>
-      Auf einem Mac öffnet sich eine <code>.icns</code> in der Vorschau, die
-      jeden Platz seitlich auflistet &mdash; und derselbe Trick funktioniert im
-      Finder: in einen Ordner legen und den Größenregler in den
-      Darstellungsoptionen ziehen, um zuzusehen, wie er zwischen den Bildern
-      darin wechselt.
+      Auf dem Mac öffnet sich eine <code>.icns</code> in der Vorschau, die jeden
+      Platz seitlich auflistet. Derselbe Trick geht im Finder: Datei in einen
+      Ordner legen und in den Darstellungsoptionen den Größenregler ziehen, um zu
+      sehen, wie zwischen den Bildern darin gewechselt wird.
     </p>
   </section>
 
   <section>
     <h2>Nichts davon braucht einen Upload</h2>
     <p>
-      Ein Bild zu skalieren ist etwas, das jeder Browser seit Jahren tut, und
-      eine <code>.ico</code> besteht aus einem Sechs-Byte-Header, sechzehn Byte
-      je Bild und dann den Bildern. Es gibt in ihrer Herstellung keinen Schritt,
-      der einen Server verlangt, und das Werkzeug hier benutzt keinen: Die
+      Ein Bild zu skalieren tut jeder Browser seit Jahren, und eine
+      <code>.ico</code> besteht aus einem Header von sechs Byte, sechzehn Byte je
+      Bild und dann den Bildern. In ihrer Herstellung gibt es keinen Schritt, der
+      nach einem Server verlangte, und das Werkzeug hier benutzt keinen: Die
       <code>Content-Security-Policy</code> der Seite nennt jede Adresse, die sie
       kontaktieren darf, und keine davon gehört zu dieser Seite.
     </p>
     <p>
-      Und darum lohnt es sich hier mehr zu kümmern als sonst. Ein Logo, das man
-      einem kostenlosen Favicon-Generator übergibt, ist recht häufig eine noch
-      nicht veröffentlichte Marke &mdash; das Symbol gehört zum Ersten, was
-      gemacht, und zum Letzten, was angekündigt wird. Laden Sie die Seite,
-      trennen Sie die Internetverbindung und erzeugen Sie trotzdem eines, wenn
-      Sie lieber prüfen als glauben.
+      Hier lohnt es sich, darauf zu achten, mehr noch als sonst. Was jemand einem
+      kostenlosen Favicon-Generator übergibt, ist ziemlich oft eine Marke, die
+      noch gar nicht vorgestellt wurde &mdash; das Symbol gehört zum Ersten, was
+      gemacht wird, und zum Letzten, was angekündigt wird. Wer lieber prüft als
+      glaubt, lädt die Seite, trennt die Internetverbindung und erzeugt trotzdem
+      eines. Drei weitere Proben, die Sie an jedem Werkzeug durchführen können,
+      stehen in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen, die Sie
-      an jedem Werkzeug durchführen können.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/make-a-favicon.toml
+++ b/locales/de/pages/guides/make-a-favicon.toml
@@ -4,15 +4,15 @@
 
 nav = "Ein Favicon erstellen"
 title = "Ein Favicon erstellen (und ein Windows-App-Symbol)"
-description = "Welche Größen eine favicon.ico wirklich braucht, welche zusätzlichen Dateien iPhones, Android und ein Mac verlangen, und warum ein Logo, das auf einem Plakat funktioniert, bei sechzehn Pixeln verschwindet."
-heading = "Wie Sie ein Favicon erstellen, das bei sechzehn Pixeln noch lesbar ist"
+description = "Welche Größen eine favicon.ico wirklich braucht, welche zusätzlichen Dateien iPhone, Android und Mac verlangen und warum ein Logo, das auf einem Plakat wirkt, bei sechzehn Pixeln verschwindet."
+heading = "So erstellen Sie ein Favicon, das bei sechzehn Pixeln noch lesbar ist"
 lede = """
-    Ein Favicon ist kein kleines Bild Ihres Logos. Es ist ein Satz Bilder in
-    festen Größen, in einem Behälter, den die meisten Menschen nie öffnen &mdash;
-    und das kleinste davon ist das, was alle tatsächlich sehen. Hier steht,
-    welche Größen Sie brauchen, welche Dateien danebengehören, und was zu tun
-    ist, wenn Ihr Logo den Weg nach unten nicht übersteht."""
+    Ein Favicon ist kein kleines Bild Ihres Logos. Es ist ein ganzer Satz Bilder
+    in festen Größen, verpackt in einen Behälter, den kaum jemand je öffnet
+    &mdash; und ausgerechnet das kleinste davon bekommen alle zu sehen. Hier
+    steht, welche Größen Sie brauchen, welche Dateien danebengehören und was zu
+    tun ist, wenn Ihr Logo den Weg nach unten nicht übersteht."""
 updated = "20. August 2026"
 og_title = "Ein Favicon erstellen, das bei sechzehn Pixeln noch lesbar ist"
-og_description = "Welche Größen eine favicon.ico braucht, die zusätzlichen Dateien, die iPhones und Android verlangen, und was zu tun ist, wenn Ihr Logo das Verkleinern nicht übersteht."
+og_description = "Welche Größen eine favicon.ico braucht, welche Dateien iPhone und Android zusätzlich verlangen und was zu tun ist, wenn Ihr Logo das Verkleinern nicht übersteht."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/make-a-pdf-smaller.html
+++ b/locales/de/pages/guides/make-a-pdf-smaller.html
@@ -2,62 +2,64 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie den <a href="../../pdf-verkleinern/">PDF-Kompressor</a>, ziehen
-      Sie das Dokument hinein, und sehen Sie sich an, was er Ihnen sagt, bevor
-      Sie irgendetwas ändern. Er liest die Datei und zeigt, wo die Größe
-      tatsächlich steckt &mdash; Bilder, Schriften, Text und Zeichnung, und
-      alles, worauf im Dokument nichts mehr verweist. Dieser eine Bildschirm
-      beantwortet die Frage meistens.
+      Sie das Dokument hinein und lesen Sie zuerst, was er Ihnen sagt, bevor Sie
+      irgendetwas verstellen. Er zerlegt die Datei und zeigt, wo die Größe
+      tatsächlich sitzt: in den Bildern, in den Schriften, in Text und Zeichnung
+      &mdash; und in allem, worauf im Dokument längst nichts mehr verweist.
+      Dieser eine Bildschirm beantwortet die Frage meistens schon.
     </p>
     <p>
-      Steckt der Großteil der Größe in Bildern, können Sie eine große Ersparnis
-      erwarten. Sind es Schriften und Text, können Sie das nicht, und kein
-      Werkzeug kann es. Welches von beiden Sie vor sich haben, ist die ganze
-      Geschichte, und es lohnt zehn Sekunden Hinsehen.
+      Steckt der Löwenanteil in Bildern, ist eine große Ersparnis drin. Sind es
+      Schriften und Text, ist sie es nicht &mdash; und zwar bei keinem Werkzeug.
+      Welcher der beiden Fälle vorliegt, ist die ganze Geschichte, und zehn
+      Sekunden Hinsehen sind sie wert.
     </p>
   </section>
 
   <section>
-    <h2>Wo die Größe eines PDFs wirklich steckt</h2>
+    <h2>Wo bei einem PDF die Größe wirklich sitzt</h2>
     <p>
-      Ein PDF ist ein Behälter für mehrere ganz verschiedene Dinge, und die
-      lassen sich nicht gleich gut komprimieren.
+      Ein PDF ist ein Behälter für höchst unterschiedliche Dinge, und die lassen
+      sich nicht gleich gut komprimieren.
     </p>
     <ul>
       <li>
-        <strong>Bilder.</strong> Fotografien und Scans. Fast immer der Großteil
-        eines großen PDFs, und der einzige Teil mit echtem Spielraum.
+        <strong>Bilder.</strong> Fotografien und Scans. Fast immer der
+        Löwenanteil eines großen PDFs &mdash; und der einzige Teil mit echtem
+        Spielraum.
       </li>
       <li>
         <strong>Eingebettete Schriften.</strong> Eine vollständige Schrift kann
-        hunderte Kilobyte groß sein; eine Teilmenge der tatsächlich benutzten
-        Zeichen ist weit weniger. So oder so wurden sie von dem Programm
-        komprimiert, das die Datei erzeugt hat.
+        einige hundert Kilobyte wiegen; nimmt man nur die tatsächlich benutzten
+        Zeichen, ist es ein Bruchteil davon. In beiden Fällen hat das Programm,
+        das die Datei erzeugt hat, sie bereits komprimiert.
       </li>
       <li>
         <strong>Text und Vektorzeichnung.</strong> Anweisungen statt Pixel:
-        zeichne diese Linie, setze dieses Wort hierhin. Ohnehin kompakt und
-        ohnehin komprimiert.
+        zieh diese Linie, setz dieses Wort hierhin. Ohnehin kompakt, ohnehin
+        komprimiert.
       </li>
       <li>
-        <strong>Objekte, auf die nichts mehr zeigt.</strong> PDFs sammeln davon
-        an. Ein Dokument zu bearbeiten hängt die Änderung oft an, statt die Datei
-        neu zu schreiben &mdash; eine alte Fassung einer Seite kann also
-        unbegrenzt darin sitzen bleiben. Das Neupacken der Datei wirft sie weg.
+        <strong>Objekte, auf die nichts mehr zeigt.</strong> Davon sammeln PDFs
+        einiges an. Wer ein Dokument bearbeitet, hängt die Änderung oft hinten
+        an, statt die Datei neu zu schreiben &mdash; eine alte Fassung einer
+        Seite kann also unbegrenzt darin liegen bleiben. Beim Neupacken fliegt
+        sie heraus.
       </li>
     </ul>
     <p>
-      Die beiden Dokumente, die Menschen zu einem PDF-Kompressor bringen, haben
-      also völlig verschiedene Aussichten. Ein gescanntes Dokument ist im
-      Wesentlichen ein Stapel Fotografien und wird üblicherweise 60&ndash;90&nbsp;%
-      kleiner. Ein Vertrag, eine Abschlussarbeit oder ein exportierter Bericht
-      besteht aus Text, Zeichnung und Schriften &mdash; alle bereits von der
-      Software komprimiert, die sie geschrieben hat &mdash; und die Ersparnis
-      liegt dort meist bei wenigen Prozent, aus dem Neupacken und dem Wegfallen
-      des Unverwiesenen.
+      Die zwei Dokumente, mit denen Leute zum PDF-Kompressor kommen, haben
+      deshalb völlig verschiedene Aussichten. Ein gescanntes Dokument ist im
+      Kern ein Stapel Fotografien und wird üblicherweise
+      60&ndash;90&nbsp;% kleiner. Ein Vertrag, eine Abschlussarbeit oder ein
+      exportierter Bericht besteht aus Text, Zeichnung und Schriften &mdash;
+      allesamt von der Software, die sie geschrieben hat, längst komprimiert
+      &mdash;, und da bleiben meist ein paar Prozent übrig, aus dem Neupacken
+      und aus dem, was niemand mehr braucht.
     </p>
     <p>
-      Jedes Werkzeug, das &bdquo;bis zu 90&nbsp;% kleiner&ldquo; verspricht, ohne
-      Ihre Datei anzusehen, nennt den besten Fall der ersten Sorte für die
+      Wer &bdquo;bis zu 90&nbsp;% kleiner&ldquo; verspricht, ohne Ihre Datei
+      gesehen zu haben, nennt Ihnen den besten Fall der ersten Sorte für die
       zweite.
     </p>
   </section>
@@ -65,92 +67,92 @@
   <section>
     <h2>Was DPI damit zu tun hat</h2>
     <p>
-      Ein PDF hält nicht nur ein Bild; es hält fest, wie groß dieses Bild auf der
-      Seite gezeichnet wird. Das gibt Ihnen etwas Nützlicheres als die Pixelzahl:
-      die effektive Auflösung.
+      Ein PDF speichert nicht nur ein Bild, sondern hält auch fest, wie groß
+      dieses Bild auf der Seite gezeichnet wird. Daraus ergibt sich etwas viel
+      Nützlicheres als die bloße Pixelzahl: die effektive Auflösung.
     </p>
     <p>
       Ein 4000 Pixel breiter Scan, über zwanzig Zentimeter Papier gelegt, trägt
       rund 500 Pixel pro Zoll. Ein Bildschirm zeigt etwa 100. Ein guter
-      Bürodrucker arbeitet mit 300 und kann kaum mehr nutzen. Alles darüber ist
-      Detail, das nichts in der Zukunft dieses Dokuments je darstellen wird
-      &mdash; und es ist meist der Großteil der Datei.
+      Bürodrucker arbeitet mit 300 und kann kaum mehr anfangen. Alles darüber ist
+      Detail, das in der Zukunft dieses Dokuments nie irgendwo erscheinen wird
+      &mdash; und es macht meist den größten Teil der Datei aus.
     </p>
     <p>
       Deshalb fragt ein vernünftiger PDF-Kompressor nach einer DPI-Zahl und nicht
       nach einem Qualitätsprozentsatz. Er wirft zuerst die Pixel oberhalb Ihres
-      Wertes weg, weil die nichts kosten, was irgendjemand sehen kann, und
-      beginnt erst danach, echte Qualität auszugeben.
+      Wertes weg, weil die nichts kosten, was irgendjemand zu sehen bekäme, und
+      fängt erst danach an, echte Qualität auszugeben.
     </p>
     <p>
-      Grobe Richtschnur: <strong>150 DPI</strong> für ein Dokument, das am
+      Als grobe Richtschnur: <strong>150 DPI</strong> für ein Dokument, das am
       Bildschirm gelesen wird, <strong>200&ndash;300</strong> für etwas, das
       gedruckt wird, <strong>72&ndash;100</strong> für einen Entwurf, den niemand
-      aufhebt. Daran zu messen, wie groß das Bild gezeichnet wird, ist auch der
-      Grund, warum ein klein platziertes Logo nicht wie ein ganzseitiger Scan
-      behandelt wird &mdash; das Logo ist schon nahe an seiner effektiven
-      Auflösung, da ist nichts zu holen.
+      aufhebt. Dass am Zeichenmaß und nicht an der Pixelzahl gemessen wird, ist
+      übrigens auch der Grund, warum ein klein platziertes Logo nicht behandelt
+      wird wie ein ganzseitiger Scan: Das Logo liegt schon nahe an seiner
+      effektiven Auflösung, da ist nichts zu holen.
     </p>
   </section>
 
   <section>
-    <h2>Was das Komprimieren anfassen sollte und was nicht</h2>
+    <h2>Was das Komprimieren anfassen darf und was nicht</h2>
     <p>
-      Die Bilder werden neu kodiert, die verlieren also ein wenig. Sonst sollte
-      überhaupt nichts angefasst werden, und es lohnt sich zu prüfen, ob das
-      Werkzeug, das Sie benutzen, sich daran hält:
+      Die Bilder werden neu kodiert, die verlieren also ein wenig. Alles Übrige
+      sollte unangetastet bleiben, und es lohnt sich nachzusehen, ob das
+      Werkzeug, das Sie verwenden, sich daran hält:
     </p>
     <ul>
       <li>
         <strong>Text bleibt Text.</strong> Markierbar, durchsuchbar, kopierbar.
-        Ein Kompressor, der Seiten zu Bildern plattdrückt, erzeugt eine sehr
-        kleine Datei und zerstört das Dokument &mdash; Sie können es nicht
-        durchsuchen, Screenreader können es nicht lesen, und rückgängig machen
-        lässt es sich nie.
+        Ein Kompressor, der Seiten zu Bildern plattwalzt, liefert eine sehr
+        kleine Datei und zerstört dabei das Dokument: nicht mehr durchsuchbar,
+        für Screenreader unlesbar, und rückgängig machen lässt sich das nie.
       </li>
       <li>
-        <strong>Schriften bleiben vollständig.</strong> Schriften zu ersetzen
-        ändert, wie das Dokument auf dem Gerät eines anderen aussieht &mdash; und
-        genau das zu verhindern ist der einzige Zweck von PDF.
+        <strong>Schriften bleiben vollständig.</strong> Schriften auszutauschen
+        ändert, wie das Dokument auf fremden Geräten aussieht &mdash; und genau
+        das zu verhindern ist der einzige Daseinszweck von PDF.
       </li>
       <li>
         <strong>Vektorzeichnung wird exakt übernommen.</strong> Sie ist ohnehin
-        klein, und sie zu rastern würde sie größer und schlechter machen.
+        klein, und sie zu rastern machte sie zugleich größer und schlechter.
       </li>
       <li>
         <strong>Formulare, Links, Lesezeichen, Barrierefreiheitsstruktur und
-        Anhänge werden mitgenommen.</strong> Die gehen bei einem Neuschreiben
-        leicht verloren und fallen selten auf, bis jemand eines davon braucht.
+        Anhänge kommen mit.</strong> Beim Neuschreiben gehen sie leicht verloren,
+        und es fällt selten auf &mdash; bis jemand eines davon braucht.
       </li>
     </ul>
     <p>
-      Eine verwandte Regel, an die sich ein Kompressor halten sollte und viele
-      sich nicht halten: Wird eine neu kodierte Datei nicht tatsächlich kleiner
-      als das Original, gehören die Originalbytes zurück. Ein Bild ohne Ersparnis
-      zu verschlechtern ist der Fall reinen Verlusts, und er passiert häufiger,
-      als man denkt &mdash; bei Bildern, die schon gut komprimiert waren.
+      Dazu eine Regel, an die sich ein Kompressor halten sollte und viele sich
+      nicht halten: Wird ein neu kodiertes Bild nicht tatsächlich kleiner als das
+      Original, gehören die Originalbytes zurück. Ein Bild zu verschlechtern,
+      ohne dabei etwas zu sparen, ist der Fall des reinen Verlusts &mdash; und er
+      tritt häufiger ein, als man denkt, nämlich bei Bildern, die schon gut
+      komprimiert waren.
     </p>
   </section>
 
   <section>
-    <h2>Die Bilder, die sich nicht komprimieren lassen</h2>
+    <h2>Die Bilder, an die niemand herankommt</h2>
     <p>
       Manche Bilder in einem PDF werden übersprungen, und ein gutes Werkzeug
-      benennt sie, statt sie stillschweigend aus der Rechnung zu lassen:
+      benennt sie, statt sie stillschweigend aus der Rechnung zu nehmen:
     </p>
     <ul>
       <li>
         <strong>JPEG&nbsp;2000, JBIG2 und faxkodierte (CCITT-)Bilder.</strong>
-        Kein Browser bringt für eines davon einen Decoder mit, sie werden also
+        Für keines davon bringt ein Browser einen Decoder mit, sie werden also
         unangetastet durchgereicht. Die letzten beiden sind Zweiton-Formate
-        &mdash; nur Schwarz und Weiß &mdash; und ohnehin meist schon nahe an
+        &mdash; nur Schwarz und Weiß &mdash; und liegen meist ohnehin dicht an
         ihrem Minimum.
       </li>
       <li>
-        <strong>CMYK-Bilder.</strong> Bewusst unberührt gelassen. Sie neu zu
-        kodieren riskiert, die Farben zu verschieben, die ein Drucker erzeugen
-        würde &mdash; ein überraschender Eingriff in ein Dokument, das jemand
-        drucken wird.
+        <strong>CMYK-Bilder.</strong> Bewusst in Ruhe gelassen. Sie neu zu
+        kodieren würde riskieren, die Farben zu verschieben, die am Ende aus dem
+        Drucker kommen &mdash; ein überraschender Eingriff in ein Dokument, das
+        jemand drucken wird.
       </li>
     </ul>
   </section>
@@ -162,54 +164,55 @@
       falsche Antwort ist.
     </p>
     <p>
-      <strong>Wurde gescannt, wo es nicht nötig war?</strong> Ein gedrucktes und
-      dann gescanntes Dokument ist ein Stapel Fotografien von Text. Existiert das
-      Original irgendwo noch als Dokument, ergibt ein PDF-Export daraus eine
-      Datei, die einen Bruchteil so groß und dazu durchsuchbar ist.
+      <strong>Wurde gescannt, wo es gar nicht nötig war?</strong> Ein
+      ausgedrucktes und dann eingescanntes Dokument ist ein Stapel Fotografien
+      von Text. Existiert das Original irgendwo noch als richtiges Dokument,
+      liefert ein PDF-Export daraus eine Datei, die einen Bruchteil so groß und
+      obendrein durchsuchbar ist.
     </p>
     <p>
-      <strong>Wurde mit Druckeinstellungen exportiert?</strong>
-      Textverarbeitungen und Layoutprogramme wählen oft standardmäßig einen
-      Export in Druckqualität. Aus der Quelldatei neu für den Bildschirm zu
-      exportieren schlägt meist das Komprimieren des Exports.
+      <strong>Wurde in Druckqualität exportiert?</strong> Textverarbeitungen und
+      Layoutprogramme stellen dafür gern von sich aus auf Druck um. Aus der
+      Quelldatei neu für den Bildschirm zu exportieren schlägt meist jedes
+      Komprimieren des Exports.
     </p>
     <p>
-      <strong>Muss es eine Datei sein?</strong> Ein E-Mail-Limit gilt je
-      Nachricht. Ein 200-seitiges Dokument in Kapitel zu teilen ist manchmal die
-      ehrliche Lösung.
+      <strong>Muss es eine einzige Datei sein?</strong> Ein Anhangslimit gilt pro
+      Nachricht. Ein 200-seitiges Dokument in Kapitel zu zerlegen ist manchmal
+      die ehrlichere Lösung.
     </p>
   </section>
 
   <section>
-    <h2>Verschlüsselte Dateien, und warum ein Kompressor sie ablehnen sollte</h2>
+    <h2>Verschlüsselte Dateien, und warum ein Kompressor sie abweisen sollte</h2>
     <p>
-      Ein passwortgeschütztes PDF wird vom Werkzeug hier abgelehnt, und das ist
-      Absicht und keine fehlende Funktion &mdash; auch dann, wenn das Passwort
-      leer ist, und genau so speichern viele Scanner und Kopierer.
+      Ein passwortgeschütztes PDF weist das Werkzeug hier ab, und das ist Absicht
+      und keine fehlende Funktion &mdash; auch dann, wenn das Passwort leer ist,
+      und genau so speichern viele Scanner und Kopierer.
     </p>
     <p>
-      Einem Dokument den Schutz zu nehmen ist eine andere Aufgabe als es zu
-      komprimieren. Ein Werkzeug, das es stillschweigend täte, würde etwas tun,
-      worum Sie nicht gebeten haben &mdash; an einer Datei, die jemand bewusst
-      verschlossen hat &mdash; und Ihnen eine Kopie zurückgeben, die jene
-      Eigenschaft nicht mehr hat, die sie haben sollte. Nehmen Sie den Schutz
-      vorher selbst weg, bewusst, wenn Sie das wollen.
+      Einem Dokument den Schutz zu nehmen ist eine andere Aufgabe, als es zu
+      komprimieren. Ein Werkzeug, das das stillschweigend täte, würde an einer
+      Datei, die jemand bewusst verschlossen hat, etwas tun, worum niemand
+      gebeten hat &mdash; und Ihnen eine Kopie zurückgeben, der genau die
+      Eigenschaft fehlt, die sie haben sollte. Nehmen Sie den Schutz vorher
+      selbst weg, wenn Sie das wollen, und tun Sie es bewusst.
     </p>
   </section>
 
   <section>
     <h2>Das Ergebnis prüfen</h2>
     <p>
-      Öffnen Sie es. Sehen Sie sich die Bilder bei voller Vergrößerung an, prüfen
-      Sie, ob der Text noch markierbar ist, und bestätigen Sie die Seitenzahl.
+      Öffnen Sie es. Sehen Sie sich die Bilder in voller Vergrößerung an, prüfen
+      Sie, ob der Text sich noch markieren lässt, und zählen Sie die Seiten nach.
     </p>
     <p>
-      Das Werkzeug hier erledigt das Letzte für Sie, bevor es die Datei anbietet:
-      Es öffnet das eben geschriebene Dokument erneut und zählt die Seiten, auf
-      Ihrem eigenen Gerät. Es schreibt außerdem PDF 1.5, das jeder seit 2003
-      ausgelieferte Reader versteht &mdash; &bdquo;es öffnet auf meinem
-      Gerät&ldquo; ist damit ein vernünftiger Ersatz für &bdquo;es öffnet auf
-      ihrem&ldquo;.
+      Das Letzte nimmt Ihnen das Werkzeug hier ab, bevor es die Datei
+      herausgibt: Es öffnet das eben geschriebene Dokument noch einmal und zählt
+      die Seiten, auf Ihrem eigenen Gerät. Und es schreibt PDF 1.5, das jeder
+      seit 2003 erschienene Reader versteht &mdash; &bdquo;bei mir geht es
+      auf&ldquo; ist damit ein brauchbarer Ersatz für &bdquo;bei den anderen
+      auch&ldquo;.
     </p>
   </section>
 
@@ -217,24 +220,24 @@
     <h2>Warum das keinen Server braucht</h2>
     <p>
       Ein PDF zu komprimieren klingt nach Serverarbeit, und den größten Teil der
-      Geschichte des Web war es das auch. Tatsächlich besteht es darin, die
-      Dateistruktur zu zerlegen, die Bildströme zu finden, diese mit den Codecs
-      zu dekodieren und neu zu kodieren, die ein Browser ohnehin mitbringt, und
-      das Dokument wieder herauszuschreiben. Das alles läuft heute in einem
-      Browser.
+      Web-Geschichte über war es das auch. Tatsächlich besteht die Arbeit darin,
+      die Dateistruktur zu zerlegen, die Bildströme darin zu finden, sie mit den
+      Codecs zu dekodieren und neu zu kodieren, die ein Browser ohnehin
+      mitbringt, und das Dokument wieder herauszuschreiben. Das alles läuft
+      inzwischen im Browser.
     </p>
     <p>
-      Und das zählt bei diesem Dateityp mehr als bei den meisten, wegen dessen,
-      was Menschen komprimieren: Verträge, Arztbriefe, Kontoauszüge,
+      Und bei diesem Dateityp wiegt das schwerer als bei den meisten, wegen
+      dessen, was die Leute komprimieren: Verträge, Arztbriefe, Kontoauszüge,
       Ausweispapiere, Steuererklärungen. Das Werkzeug hier hat überhaupt keine
       Netzfunktion, und die <code>Content-Security-Policy</code> der Seite nennt
       jede Adresse, die sie kontaktieren darf; keine davon gehört zu dieser
-      Seite. Laden Sie sie, ziehen Sie den Stecker, und komprimieren Sie trotzdem
+      Seite. Laden Sie sie, ziehen Sie den Stecker, komprimieren Sie trotzdem
       etwas.
     </p>
     <p>
+      Drei weitere Proben dieser Art stehen in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen dieser
-      Art.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/de/pages/guides/make-a-pdf-smaller.toml
@@ -4,14 +4,14 @@
 
 nav = "Ein PDF kleiner machen"
 title = "Ein PDF kleiner machen (und warum manche nicht schrumpfen)"
-description = "Wo die Größe eines PDFs wirklich steckt, warum ein Scan um 80 Prozent schrumpft und ein Vertrag sich kaum rührt, was DPI hier bedeutet, und was ein Kompressor mit Ihrem Dokument niemals tun sollte."
-heading = "Wie Sie ein PDF kleiner machen - und warum manche nicht schrumpfen"
+description = "Wo bei einem PDF die Größe wirklich sitzt, warum ein Scan um 80 Prozent schrumpft und ein Vertrag sich kaum rührt, was DPI hier bedeutet und was ein Kompressor mit Ihrem Dokument niemals anstellen darf."
+heading = "So machen Sie ein PDF kleiner - und warum manche nicht schrumpfen"
 lede = """
-    Ein PDF, das nicht unter ein E-Mail-Limit passt, ist fast immer ein PDF
-    voller Bilder. Hier steht, woran Sie erkennen, ob Ihres eines ist, was das
-    Komprimieren kostet, und warum jedes Werkzeug, das einen festen Prozentsatz
-    verspricht, Ihre Datei nicht angesehen hat."""
+    Ein PDF, das nicht unter das Anhangslimit passt, ist fast immer ein PDF
+    voller Bilder. Hier steht, woran Sie erkennen, ob Ihres dazugehört, was das
+    Komprimieren kostet und warum jedes Werkzeug, das einen festen Prozentsatz
+    verspricht, Ihre Datei gar nicht angesehen hat."""
 updated = "20. August 2026"
-og_title = "Wie Sie ein PDF kleiner machen"
-og_description = "Wo die Größe eines PDFs wirklich steckt, warum ein Scan schrumpft und ein Vertrag nicht, und was DPI damit zu tun hat."
+og_title = "So machen Sie ein PDF kleiner"
+og_description = "Wo bei einem PDF die Größe wirklich sitzt, warum ein Scan schrumpft und ein Vertrag nicht, und was DPI damit zu tun hat."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/make-a-qr-code.html
+++ b/locales/de/pages/guides/make-a-qr-code.html
@@ -4,52 +4,51 @@
       Öffnen Sie den
       <a href="../../qr-code-erstellen/">QR- &amp; Barcode-Generator</a>, fügen
       Sie Ihren Link ein, lassen Sie die Stufe auf <strong>M</strong> und den
-      Rand auf <strong>4</strong>, und laden Sie das SVG herunter. Drucken Sie
-      ihn mindestens zwei Zentimeter breit, auf etwas Mattem, dunkel auf hell.
-      Scannen Sie dann den gedruckten mit einem Telefon, das nicht Ihres ist,
-      bevor Sie tausend davon bestellen.
+      Rand auf <strong>4</strong> und laden Sie das SVG herunter. Drucken Sie ihn
+      mindestens zwei Zentimeter breit, auf etwas Mattem, dunkel auf hell. Und
+      scannen Sie den Andruck dann mit einem Handy, das nicht Ihres ist, bevor
+      Sie tausend Stück bestellen.
     </p>
     <p>
-      Das deckt fast jeden Fall ab. Der Rest dieser Seite handelt davon, was zu
-      tun ist, wenn es keiner davon ist: ein Code, der Behandlung überstehen
-      muss, ein Code mit einem Logo darauf, ein Code auf etwas Kleinem, und die
-      eine Entscheidung, die sich leicht so falsch treffen lässt, dass Sie es
-      erst ein Jahr später merken.
+      Damit ist fast jeder Fall abgedeckt. Der Rest dieser Seite handelt von
+      allem anderen: von einem Code, der etwas aushalten muss, von einem Code mit
+      Logo, von einem Code auf etwas sehr Kleinem &mdash; und von der einen
+      Entscheidung, die sich so falsch treffen lässt, dass Sie es erst ein Jahr
+      später merken.
     </p>
   </section>
 
   <section>
-    <h2>Was tatsächlich in einem QR-Code steckt</h2>
+    <h2>Was in einem QR-Code tatsächlich steckt</h2>
     <p>
-      Eine Zeichenkette. Das ist alles. Einen QR-Code zu scannen übergibt dem
-      Telefon ein Stück Text, und alles Weitere &mdash; eine Seite öffnen, einem
-      Netz beitreten, anbieten, einen Kontakt zu speichern &mdash; ist das
-      Telefon, das die Form dieses Textes erkennt und anbietet, darauf zu
-      reagieren.
+      Eine Zeichenkette. Mehr nicht. Beim Scannen bekommt das Handy ein Stück
+      Text gereicht, und alles Weitere &mdash; eine Seite öffnen, einem Netz
+      beitreten, einen Kontakt zum Speichern anbieten &mdash; ist das Handy, das
+      die Form dieses Textes erkennt und Ihnen anbietet, darauf zu reagieren.
     </p>
     <p>
-      Es gibt also so etwas wie einen &bdquo;WLAN-QR-Code&ldquo; als Art von Code
-      gar nicht. Es gibt einen QR-Code, der
-      <code>WIFI:T:WPA;S:Mein Netz;P:das Passwort;;</code> enthält, und das kann
-      jedes Telefon der letzten zehn Jahre lesen. Genau deshalb zeigt Ihnen der
-      Generator die fertige Zeichenkette: Wenn ein Code nicht das tut, was Sie
-      erwartet haben, ist die Zeichenkette das Einzige, was anzusehen sich lohnt.
+      Eine eigene Sorte &bdquo;WLAN-QR-Code&ldquo; gibt es deshalb gar nicht. Es
+      gibt einen QR-Code, in dem
+      <code>WIFI:T:WPA;S:Mein Netz;P:das Passwort;;</code> steht, und den liest
+      jedes Handy der letzten zehn Jahre. Genau dafür zeigt Ihnen der Generator
+      die fertige Zeichenkette: Wenn ein Code nicht das tut, was Sie erwartet
+      haben, ist die Zeichenkette das Einzige, was anzusehen sich lohnt.
     </p>
     <p>
-      Es heißt auch, dass ein QR-Code sich nach dem Druck nicht ändern lässt,
-      nicht nach Hause telefonieren kann und nicht ablaufen kann &mdash; es sei
-      denn, jemand hat einen Link auf seinen eigenen Server hineingelegt, und
-      davon handelt der letzte Abschnitt hier.
+      Daraus folgt auch: Ein QR-Code lässt sich nach dem Druck nicht mehr ändern,
+      er kann nicht nach Hause funken, und ablaufen kann er ebenfalls nicht
+      &mdash; es sei denn, jemand hat einen Link auf seinen eigenen Server
+      hineingelegt. Davon handelt der letzte Abschnitt.
     </p>
   </section>
 
   <section>
     <h2>Entscheidung eins: die Fehlerkorrekturstufe</h2>
     <p>
-      Ein QR-Code trägt neben den Daten einen Satz Prüfwörter, so berechnet, dass
-      ein Lesegerät wieder aufbauen kann, was es nicht sehen konnte. Deshalb
-      scannt ein Code mit abgerissener Ecke noch. Wie viele dieser Prüfwörter es
-      gibt, ist die Stufe, und es gibt vier:
+      Neben den Daten trägt ein QR-Code einen Satz Prüfwörter, berechnet so, dass
+      ein Lesegerät wieder aufbauen kann, was es nicht zu sehen bekam. Deshalb
+      lässt sich ein Code mit abgerissener Ecke noch scannen. Wie viele dieser
+      Prüfwörter mitfahren, ist die Stufe, und davon gibt es vier:
     </p>
     <ul>
       <li><strong>L</strong> &mdash; rund 7&nbsp;% des Codes dürfen verloren gehen.</li>
@@ -58,51 +57,51 @@
       <li><strong>H</strong> &mdash; rund 30&nbsp;%.</li>
     </ul>
     <p>
-      Mehr Korrektur gibt es nicht umsonst: Die Prüfdaten kommen in dasselbe
-      Quadrat, derselbe Text braucht bei H also einen größeren, dichteren Code
-      als bei L. Grob gesagt verdoppelt der Weg von L nach H die Modulzahl für
-      dieselbe Zeichenkette, und dichtere Module sind für eine Kamera schwerer
-      aufzulösen. Hier gibt es einen echten Handel, und die Antwort hängt davon
-      ab, wohin der Code geht.
+      Mehr Korrektur gibt es nicht umsonst: Die Prüfdaten müssen in dasselbe
+      Quadrat, derselbe Text braucht bei H also einen größeren und dichteren Code
+      als bei L. Grob gerechnet verdoppelt der Weg von L nach H die Zahl der
+      Module &mdash; und je dichter die Module, desto schwerer tut sich eine
+      Kamera. Hier steckt ein echter Handel, und wie er ausgeht, hängt daran, wo
+      der Code hinkommt.
     </p>
     <p>
-      <strong>L</strong> ist für einen Bildschirm: ein Code in einer Folie, einer
-      E-Mail, einer Webseite. Nichts wird ihn beschädigen, und jedes zusätzliche
-      Modul macht ihn aus der Entfernung schwerer lesbar.
+      <strong>L</strong> ist für den Bildschirm: ein Code auf einer Folie, in
+      einer E-Mail, auf einer Webseite. Beschädigen wird ihn nichts, und jedes
+      zusätzliche Modul macht ihn aus der Entfernung schwerer lesbar.
     </p>
     <p>
-      <strong>M</strong> ist die Voreinstellung und die richtige Antwort für die
-      meisten Drucksachen. Papier, das ein wenig angefasst wird, ein Flyer, eine
+      <strong>M</strong> ist die Voreinstellung und für die meisten Drucksachen
+      die richtige Wahl: Papier, das ein wenig angefasst wird, ein Flyer, eine
       Visitenkarte.
     </p>
     <p>
-      <strong>Q und H</strong> sind für Codes, die misshandelt werden: eine
-      täglich abgewischte Speisekarte, ein Aufkleber auf einer Maschine in der
-      Werkstatt, ein Etikett auf einer Kiste, ein Code in einem Fenster mit
-      direkter Sonne. H ist außerdem das, was ein Logo in der Mitte möglich macht
-      &mdash; siehe unten.
+      <strong>Q und H</strong> sind für Codes, denen übel mitgespielt wird: die
+      täglich abgewischte Speisekarte, der Aufkleber an einer Maschine in der
+      Werkstatt, das Etikett auf einer Kiste, der Code im Schaufenster mit
+      direkter Sonne. H ist außerdem das, was ein Logo in der Mitte überhaupt
+      möglich macht &mdash; dazu gleich mehr.
     </p>
   </section>
 
   <section>
-    <h2>Entscheidung zwei: der Rand, der Teil des Codes ist</h2>
+    <h2>Entscheidung zwei: der Rand, der zum Code gehört</h2>
     <p>
-      Der weiße Raum um einen QR-Code ist kein Abstand und keine
-      Gestaltungsentscheidung. Ein Lesegerät nutzt ihn, um zu finden, wo das
-      Symbol endet. Die Spezifikation verlangt vier Module ruhige Fläche auf
-      jeder Seite, und ein bis an die Kante beschnittener Code ist der mit
-      Abstand häufigste Grund, warum ein gedruckter Code scheitert.
+      Der weiße Bereich um einen QR-Code ist kein Abstand und keine
+      Gestaltungsfrage. Ein Lesegerät findet daran, wo das Symbol endet. Die
+      Spezifikation verlangt auf jeder Seite vier Module ruhige Fläche &mdash;
+      und ein bis an die Kante beschnittener Code ist mit Abstand der häufigste
+      Grund, warum ein gedruckter Code nicht funktioniert.
     </p>
     <p>
-      Das ist es wert, unverblümt gesagt zu werden, denn Beschneiden ist eine so
-      natürliche Handlung. Der Code sieht aus, als habe er zu viel Weiß um sich,
-      also wird er im Layout beschnitten, oder auf eine farbige Fläche gesetzt,
-      die bis an die Quadrate heranläuft, oder auf eine Fotografie gelegt. Jedes
-      davon nimmt die Grenze weg, die das Lesegerät benutzen wollte.
+      Das muss man deutlich sagen, denn Beschneiden ist eine so naheliegende
+      Handlung. Der Code sieht aus, als habe er zu viel Weiß um sich, also wird
+      er im Layout beschnitten, auf eine farbige Fläche gesetzt, die bis an die
+      Quadrate heranläuft, oder gleich auf ein Foto gelegt. Jedes Mal verschwindet
+      die Grenze, an der sich das Lesegerät orientieren wollte.
     </p>
     <p>
-      Sieht der Code mit seinem Rand zu groß aus, machen Sie den Code kleiner.
-      Nehmen Sie nicht den Rand weg.
+      Wirkt der Code mit seinem Rand zu groß, machen Sie den Code kleiner. Nur
+      den Rand nicht.
     </p>
   </section>
 
@@ -111,167 +110,166 @@
     <p>
       Die Faustregel, die den Kontakt mit der Wirklichkeit überstanden hat, heißt
       <strong>eins zu zehn</strong>: Ein Code muss etwa ein Zehntel so breit sein
-      wie die Entfernung, aus der er gescannt wird.
+      wie die Entfernung, aus der gescannt wird.
     </p>
     <ul>
-      <li>Eine Visitenkarte oder eine Speisekarte, aus 30 cm gelesen: etwa 2 cm breit.</li>
-      <li>Ein Plakat, aus zwei Metern gelesen: etwa 20 cm.</li>
-      <li>Ein Buswartehäuschen oder ein Schaufenster, aus fünf Metern gelesen: etwa 50 cm.</li>
+      <li>Visitenkarte oder Speisekarte, gelesen aus 30 cm: rund 2 cm breit.</li>
+      <li>Plakat, gelesen aus zwei Metern: rund 20 cm.</li>
+      <li>Buswartehäuschen oder Schaufenster, gelesen aus fünf Metern: rund 50 cm.</li>
     </ul>
     <p>
       Zwei Zentimeter sind eine Untergrenze und kein Ziel. Unterhalb von etwa
-      1,5 cm fängt ein gewöhnliches Telefon an zu kämpfen, ganz gleich wie gut
-      der Druck ist, denn die einzelnen Module nähern sich der Größe eines Pixels
-      in seiner Kamera.
+      1,5 cm kommt ein gewöhnliches Handy ins Straucheln, wie gut der Druck auch
+      sein mag: Die einzelnen Module nähern sich dann der Größe eines Pixels in
+      seiner Kamera.
     </p>
     <p>
-      Weniger Text heißt weniger Module heißt ein Code, der bei gegebener
-      Druckgröße aus der Entfernung liest &mdash; ein guter Grund, einen Code auf
-      <code>example.com/x</code> zeigen zu lassen und nicht auf eine URL mit
+      Weniger Text heißt weniger Module heißt ein Code, der sich bei gleicher
+      Druckgröße aus größerer Entfernung lesen lässt. Ein guter Grund, einen Code
+      auf <code>example.com/x</code> zeigen zu lassen statt auf eine URL mit
       hundert Zeichen Tracking-Parametern am Ende.
     </p>
     <p>
       Und drucken Sie aus dem <strong>SVG</strong>. Ein QR-Code besteht aus
-      Kanten, und ein PNG hat eine feste Pixelzahl, aus der es sie machen muss;
-      vergrößern Sie eines, und jede Kante wird weich &mdash; genau das, womit ein
-      Scanner Mühe hat. Ein SVG sind die Quadrate als Anweisungen, es kommt also
-      auf einer Visitenkarte wie auf einer Plakatwand scharf heraus.
+      Kanten, und ein PNG hat eine feste Zahl Pixel, aus denen es sie bauen muss;
+      vergrößern Sie eines, wird jede Kante weich &mdash; und genau damit tut
+      sich ein Scanner schwer. In einem SVG stehen die Quadrate als Anweisungen,
+      es kommt also auf der Visitenkarte so scharf heraus wie auf der Plakatwand.
     </p>
   </section>
 
   <section>
-    <h2>Farbe, Kontrast und die zwei Fehler</h2>
+    <h2>Farbe, Kontrast und die zwei üblichen Fehler</h2>
     <p>
-      Ein Lesegerät misst den Unterschied zwischen den dunklen und den hellen
-      Modulen, Kontrast ist also alles. Zwei Dinge gehen regelmäßig schief:
+      Ein Lesegerät misst den Unterschied zwischen dunklen und hellen Modulen
+      &mdash; alles hängt also am Kontrast. Zwei Dinge gehen regelmäßig schief:
     </p>
     <p>
-      <strong>Heller Code auf dunklem Hintergrund.</strong> Es sieht auffällig
-      aus, und eine ganze Reihe Lesegeräte weist es rundweg ab: Sie suchen nach
-      dunkel auf hell und probieren die Umkehrung nicht. Manche schon. Sie werden
-      nicht wissen, welche Ihre Kundschaft hat.
+      <strong>Heller Code auf dunklem Grund.</strong> Sieht auffällig aus, und
+      eine ganze Reihe Lesegeräte weist es rundheraus ab: Sie suchen dunkel auf
+      hell und probieren die Umkehrung gar nicht erst. Manche schon. Welche Ihre
+      Kundschaft im Handy hat, werden Sie nie erfahren.
     </p>
     <p>
-      <strong>Zu wenig Unterschied.</strong> Mittelgrau auf Weiß, oder zwei
-      Markenfarben ähnlicher Tiefe, können am Bildschirm einwandfrei messen und
-      auf Papier scheitern, sobald Tonwertzuwachs und die automatische Belichtung
-      eines Telefons ins Spiel kommen. Wenn Sie einen Code einfärben, halten Sie
-      den dunklen Teil wirklich dunkel.
+      <strong>Zu wenig Unterschied.</strong> Mittelgrau auf Weiß oder zwei
+      Hausfarben von ähnlicher Tiefe können sich am Bildschirm tadellos messen
+      lassen und auf Papier scheitern, sobald Tonwertzuwachs und die automatische
+      Belichtung eines Handys mitspielen. Wenn Sie einen Code einfärben, halten
+      Sie den dunklen Teil wirklich dunkel.
     </p>
     <p>
       Matt schlägt glänzend bei allem, was unter einer Lampe gescannt wird, und
-      beides schlägt den Druck auf eine Fotografie. Transparente Hintergründe
-      sind nützlich, um einen Code auf eine farbige Fläche zu setzen &mdash;
-      prüfen Sie aber, was am Ende dahinter landet, denn ein transparenter Code
-      auf einer dunklen Fläche ist der erste Fehler oben mit Zwischenschritten.
+      beides schlägt den Druck auf ein Foto. Transparente Hintergründe sind
+      praktisch, um einen Code auf eine farbige Fläche zu setzen &mdash; sehen
+      Sie aber nach, was am Ende wirklich dahinter landet: Ein transparenter Code
+      auf dunkler Fläche ist der erste Fehler von oben, nur auf Umwegen.
     </p>
   </section>
 
   <section>
     <h2>Ein Logo in der Mitte</h2>
     <p>
-      Das funktioniert, und es funktioniert wegen der Fehlerkorrektur und nicht
-      trotz ihr. Auf Stufe H lassen sich rund 30&nbsp;% der Module zerstören und
-      der Code ist noch lesbar &mdash; ein Logo, das deutlich weniger als das
-      verdeckt, in der Mitte, wo kein Suchmuster sitzt, ist also Schaden, den das
-      Lesegerät repariert.
+      Das funktioniert &mdash; und zwar wegen der Fehlerkorrektur und nicht ihr
+      zum Trotz. Auf Stufe H dürfen rund 30&nbsp;% der Module zerstört sein, ohne
+      dass der Code unlesbar wird. Ein Logo, das deutlich weniger verdeckt und
+      obendrein in der Mitte sitzt, wo kein Suchmuster liegt, ist also ein
+      Schaden, den das Lesegerät repariert.
     </p>
     <p>
-      Drei Dinge, an die Sie sich halten sollten. Nehmen Sie Stufe H. Halten Sie
-      das Logo unter etwa einem Fünftel der Fläche, gut unterhalb der
-      theoretischen Grenze, denn der Druck ist nicht das Einzige, was an Ihrer
-      Reserve knabbert. Und verdecken Sie nie die drei großen Quadrate in den
-      Ecken oder die kleineren daneben: An denen findet ein Lesegerät das Symbol
-      überhaupt erst und richtet es aus, und keine Fehlerkorrektur der Welt baut
-      sie wieder auf.
+      Drei Regeln dazu. Nehmen Sie Stufe H. Halten Sie das Logo unter etwa einem
+      Fünftel der Fläche, also mit deutlichem Abstand zur theoretischen Grenze
+      &mdash; denn der Druck ist nicht das Einzige, was an Ihrer Reserve knabbert.
+      Und verdecken Sie niemals die drei großen Quadrate in den Ecken oder die
+      kleineren daneben: Daran findet ein Lesegerät das Symbol überhaupt erst und
+      richtet es aus, und die baut keine Fehlerkorrektur der Welt wieder auf.
     </p>
     <p>
-      Testen Sie ihn dann an echten Telefonen. Ein Logo bringt einen Code von
+      Danach: an echten Handys ausprobieren. Ein Logo bringt einen Code von
       &bdquo;funktioniert immer&ldquo; auf &bdquo;funktioniert mit so viel
-      Reserve&ldquo;, und der einzige Weg herauszufinden, wie viel Reserve übrig
-      ist, ist auszuprobieren.
+      Reserve&ldquo;, und wie viel Reserve übrig ist, verrät nur der Versuch.
     </p>
   </section>
 
   <section>
-    <h2>Die Entscheidung, die Menschen bereuen: statisch oder &bdquo;dynamisch&ldquo;</h2>
+    <h2>Die Entscheidung, die später bereut wird: statisch oder &bdquo;dynamisch&ldquo;</h2>
     <p>
-      Suchen Sie nach einem QR-Generator, und die meisten Treffer wollen, dass
-      Sie ein Konto anlegen &mdash; denn sie verkaufen <em>dynamische</em> Codes.
-      Ein dynamischer Code enthält nicht Ihren Link. Er enthält einen Kurzlink
-      auf den eigenen Server des Generators, der auf Ihren weiterleitet.
+      Suchen Sie nach einem QR-Generator, wollen die meisten Treffer, dass Sie
+      ein Konto anlegen &mdash; denn sie verkaufen <em>dynamische</em> Codes. In
+      einem dynamischen Code steht nicht Ihr Link, sondern ein Kurzlink auf den
+      Server des Generators, der von dort auf Ihren weiterleitet.
     </p>
     <p>
       Was Sie dafür bekommen, ist echt: Sie können nach dem Druck ändern, wohin
-      der Code zeigt, und Sie bekommen eine Zählung jedes Scans. Für eine
-      Kampagne mit sechsstelliger Auflage ist das Geld wert.
+      der Code führt, und Sie bekommen jeden Scan gezählt. Bei einer Kampagne mit
+      sechsstelliger Auflage ist das sein Geld wert.
     </p>
     <p>
-      Was es kostet, ist ebenfalls echt und vorher wissenswert statt nachher:
+      Was es kostet, ist ebenso echt &mdash; und man sollte es vorher wissen und
+      nicht hinterher:
     </p>
     <ul>
       <li>
-        <strong>Der Code hört auf zu funktionieren, wenn die aufhören.</strong>
-        Schließt der Dienst, läuft die Domain aus oder endet die kostenlose
-        Stufe, ist jeder gedruckte Code tot &mdash; und bis dahin kleben sie auf
-        zehntausend Speisekarten.
+        <strong>Der Code hört auf zu funktionieren, wenn die anderen
+        aufhören.</strong> Macht der Dienst zu, läuft die Domain aus oder endet
+        die kostenlose Stufe, ist jeder gedruckte Code tot &mdash; und bis dahin
+        klebt er auf zehntausend Speisekarten.
       </li>
       <li>
-        <strong>Jeder Scan sind Daten von jemand anderem.</strong> Die
-        Weiterleitung sieht die IP-Adresse, die Uhrzeit und das Gerät jeder
-        Person, die Ihren Code scannt.
+        <strong>Jeder Scan sind Daten, die jemand anderem zufließen.</strong> Die
+        Weiterleitung sieht IP-Adresse, Uhrzeit und Gerät jedes Menschen, der
+        Ihren Code scannt.
       </li>
       <li>
-        <strong>Der Link gehört ihnen, nicht Ihnen.</strong> Wer ihn scannt,
-        sieht eine unbekannte Domain vorbeihuschen &mdash; und genau davor wird
-        Menschen gesagt, sie sollten misstrauisch sein.
+        <strong>Der Link gehört denen und nicht Ihnen.</strong> Wer scannt, sieht
+        eine fremde Domain vorbeihuschen &mdash; und genau davor wird allen
+        geraten, misstrauisch zu sein.
       </li>
     </ul>
     <p>
-      Der Mittelweg kostet nichts: Setzen Sie einen statischen QR-Code um eine
-      kurze URL <em>auf Ihrer eigenen Domain</em>, und leiten Sie die selbst
-      weiter. Sie behalten die Möglichkeit, das Ziel zu ändern, Sie behalten die
-      Auswertung, und nichts an dem Code hängt davon ab, dass es ein Unternehmen,
-      das Sie nie getroffen haben, nächstes Jahr noch gibt.
+      Der Mittelweg kostet nichts: einen statischen QR-Code um eine kurze URL
+      <em>auf Ihrer eigenen Domain</em> legen und diese selbst weiterleiten. Sie
+      können das Ziel weiterhin ändern, Sie behalten die Auswertung &mdash; und
+      nichts an dem Code hängt daran, ob es eine Firma, die Sie nie getroffen
+      haben, nächstes Jahr noch gibt.
     </p>
     <p>
       Der <a href="../../qr-code-erstellen/">Generator hier</a> erzeugt nur
-      statische Codes, und es gibt kein Konto anzulegen. Was Sie eintippen, ist
-      das, was der Code enthält.
+      statische Codes, und ein Konto gibt es nicht anzulegen. Was Sie eintippen,
+      ist das, was im Code steht.
     </p>
   </section>
 
   <section>
-    <h2>Bevor Sie tausend davon drucken</h2>
+    <h2>Bevor Sie tausend Stück drucken</h2>
     <p>
-      Scannen Sie den Code. Nicht den auf Ihrem Bildschirm &mdash; den gedruckten
-      Andruck, an dem Ort, an den er kommt, mit einem Telefon, das nicht das ist,
-      auf dem Sie ihn gemacht haben. Das dauert eine Minute und fängt die ganze
-      Sorte Probleme ab, von der diese Seite handelt: ein Rand, den das Layout
-      gefressen hat, ein Link ohne sein <code>https://</code>, eine Farbe, die
-      auf Papier anders gemessen hat, ein Code in einer Größe, die auf einem
-      Schreibtisch funktioniert und an einer Wand nicht.
+      Scannen Sie den Code. Nicht den auf Ihrem Bildschirm, sondern den
+      gedruckten Andruck, an dem Ort, an den er kommt, mit einem Handy, das nicht
+      das ist, auf dem Sie ihn gemacht haben. Das dauert eine Minute und fängt
+      die ganze Sorte Probleme ab, von der diese Seite handelt: einen Rand, den
+      das Layout gefressen hat, einen Link ohne sein <code>https://</code>, eine
+      Farbe, die sich auf Papier anders misst, eine Größe, die auf dem
+      Schreibtisch funktioniert und an der Wand nicht.
     </p>
     <p>
-      Und prüfen Sie, was nach dem Scan passiert. Ein Code, der eine Seite
-      öffnet, die auf einem Telefon unlesbar ist, ist ein gescheiterter Code
-      &mdash; auch wenn er gescannt hat.
+      Und sehen Sie nach, was nach dem Scan passiert. Ein Code, der eine Seite
+      öffnet, die auf einem Handy unlesbar ist, ist ein gescheiterter Code
+      &mdash; auch wenn das Scannen selbst geklappt hat.
     </p>
   </section>
 
   <section>
-    <h2>Nichts davon verlangt, irgendetwas hochzuladen</h2>
+    <h2>Nichts davon verlangt einen Upload</h2>
     <p>
       Ein QR-Code ist Rechnerei über einer Zeichenkette. Es gibt keine Datei zu
-      senden und nichts, was ein Server könnte und ein Browser nicht &mdash;
+      schicken und nichts, was ein Server könnte und ein Browser nicht &mdash;
       deshalb erledigt das <a href="../../qr-code-erstellen/">Werkzeug hier</a>
-      alles davon auf Ihrem eigenen Gerät und arbeitet mit getrennter
+      alles davon auf Ihrem eigenen Gerät und arbeitet auch mit gekappter
       Netzverbindung.
     </p>
     <p>
-      Das zählt mehr, als es klingt, wegen dessen, was Menschen in QR-Codes
-      legen. Die häufigste Verwendung des WLAN-Formats ist das tatsächliche
-      Passwort eines Netzes, in eine Webseite getippt. Es lohnt sich zu wissen,
-      ob diese Seite irgendwohin hatte, wo sie es hinschicken konnte.
+      Das wiegt schwerer, als es klingt, wegen dessen, was die Leute in QR-Codes
+      legen. Am häufigsten steht im WLAN-Format das tatsächliche Passwort eines
+      Netzes &mdash; getippt in eine Webseite. Ob diese Seite überhaupt einen Ort
+      hatte, an den sie es hätte schicken können, ist dann durchaus wissenswert.
     </p>
   </section>

--- a/locales/de/pages/guides/make-a-qr-code.toml
+++ b/locales/de/pages/guides/make-a-qr-code.toml
@@ -3,16 +3,16 @@
 #
 
 nav = "Einen QR-Code erzeugen"
-title = "Einen QR-Code erzeugen, der jedes Mal scannt"
-description = "Welche Fehlerkorrekturstufe Sie nehmen sollten, warum der weiße Rand um einen QR-Code Teil des Codes ist, wie groß Sie ihn drucken müssen, und was Sie der 'dynamische' Code eines kostenlosen Generators später kostet."
-heading = "Wie Sie einen QR-Code erzeugen, der auch auf dem Telefon eines anderen noch scannt"
+title = "Einen QR-Code erzeugen, der sich jedes Mal scannen lässt"
+description = "Welche Fehlerkorrekturstufe die richtige ist, warum der weiße Rand zum Code gehört, wie groß Sie ihn drucken müssen und was Sie der 'dynamische' Code eines Gratis-Generators ein Jahr später kostet."
+heading = "So erzeugen Sie einen QR-Code, der sich auch mit fremden Handys scannen lässt"
 lede = """
     Einen QR-Code zu erzeugen dauert eine Sekunde. Einen zu erzeugen, der auf
-    einer nassen Speisekarte, an einem Buswartehäuschen oder auf einem bei
-    schlechtem Licht auf Armlänge gehaltenen Telefon funktioniert, kostet vier
-    Entscheidungen &mdash; und alle vier fallen, bevor Sie irgendetwas drucken.
-    Hier steht, was jede davon tut."""
+    einer feuchten Speisekarte funktioniert, am Buswartehäuschen und auf einem
+    bei schlechtem Licht auf Armlänge gehaltenen Handy, kostet vier
+    Entscheidungen &mdash; und alle vier fallen, bevor irgendetwas gedruckt
+    wird. Hier steht, was jede davon bewirkt."""
 updated = "20. August 2026"
-og_title = "Einen QR-Code erzeugen, der auch auf dem Telefon eines anderen noch scannt"
-og_description = "Die vier Entscheidungen, die darüber bestimmen, ob ein gedruckter QR-Code funktioniert: die Stufe, der Rand, die Größe, und wessen Adresse eigentlich darin steht."
+og_title = "Einen QR-Code erzeugen, der sich auch mit fremden Handys scannen lässt"
+og_description = "Die vier Entscheidungen, an denen hängt, ob ein gedruckter QR-Code funktioniert: die Stufe, der Rand, die Größe und wessen Adresse eigentlich darin steht."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/de/pages/guides/remove-exif-and-gps-data.html
@@ -4,163 +4,162 @@
       Öffnen Sie den
       <a href="../../exif-daten-entfernen/">EXIF-Betrachter &amp; -Entferner</a>,
       ziehen Sie die Fotos hinein und klicken Sie auf &bdquo;Alle Metadaten
-      entfernen&ldquo;. Jedes Tag, die XMP- und IPTC-Blöcke, die Kommentare und
-      das eingebettete Vorschaubild verschwinden &mdash; bei allen Fotos auf der
-      Liste auf einmal. Das Bild selbst wird nicht angefasst: nicht neu
-      komprimiert, nicht dekodiert, um kein einziges Pixel verändert.
+      entfernen&ldquo;. Jedes Tag, der XMP- und der IPTC-Block, die Kommentare
+      und das eingebettete Vorschaubild sind damit weg &mdash; bei allen Fotos
+      auf der Liste in einem Rutsch. Das Bild selbst bleibt unangetastet: nicht
+      neu komprimiert, nicht dekodiert, kein Pixel verändert.
     </p>
     <p>
-      Bevor Sie das tun, lohnt sich ein Blick darauf, was darin stand. Es ist
-      meist mehr, als Menschen erwarten, und die Liste ist das eigentliche
-      Argument, das hier überhaupt zu tun.
+      Vorher lohnt sich allerdings ein Blick darauf, was da eigentlich stand. Es
+      ist meist mehr, als man erwartet &mdash; und diese Liste ist das eigentliche
+      Argument dafür, das hier überhaupt zu tun.
     </p>
   </section>
 
   <section>
     <h2>Was wirklich in einem Foto steckt</h2>
     <p>
-      Ein JPEG ist nicht nur ein komprimiertes Bild. Es ist ein Behälter, und
-      neben dem Bild sitzen mehrere Blöcke mit Angaben, die Ihre Kamera, Ihr
-      Telefon oder Ihr Bildbearbeitungsprogramm dort hineingeschrieben hat.
+      Ein JPEG ist nicht bloß ein komprimiertes Bild, sondern ein Behälter: Neben
+      dem Bild sitzen mehrere Blöcke voller Angaben, die Ihre Kamera, Ihr Handy
+      oder Ihr Bildbearbeitungsprogramm dort hineingeschrieben haben.
     </p>
     <ul>
       <li>
-        <strong>EXIF.</strong> Der wichtigste. Hersteller und Modell der Kamera,
-        Objektiv, Belichtungseinstellungen, ISO, Datum und Uhrzeit auf die
-        Sekunde, die Ausrichtung, in der das Bild gezeigt werden soll, und
-        &mdash; auf einem Telefon mit eingeschalteten Ortungsdiensten für die
-        Kamera &mdash; eine GPS-Position auf wenige Meter genau. Häufig dazu eine
+        <strong>EXIF.</strong> Der wichtigste Block. Hersteller und Modell der
+        Kamera, Objektiv, Belichtungseinstellungen, ISO, Datum und Uhrzeit auf
+        die Sekunde, die Ausrichtung, in der das Bild gezeigt werden soll, und
+        &mdash; auf einem Handy, dessen Kamera die Ortungsdienste nutzen darf
+        &mdash; eine GPS-Position auf wenige Meter genau. Häufig obendrein die
         Seriennummer des Kameragehäuses.
       </li>
       <li>
-        <strong>GPS.</strong> Technisch ein Teil von EXIF, und es lohnt sich, ihn
-        eigens zu nennen, weil er am meisten zählt. Er steht in Grad, Minuten und
-        Sekunden &mdash; einem Format, das ausgezeichnet darin ist, nicht wie
-        eine Adresse auszusehen.
+        <strong>GPS.</strong> Technisch gehört es zu EXIF, verdient aber eine
+        eigene Zeile, weil es am schwersten wiegt. Notiert wird es in Grad,
+        Minuten und Sekunden &mdash; einem Format, das hervorragend darin ist,
+        nicht wie eine Adresse auszusehen.
       </li>
       <li>
-        <strong>XMP.</strong> Ein Paket XML, das Bildbearbeitungsprogramme
-        schreiben. Es kann Ihren Namen, Ihre Software, Bewertungen, Stichwörter,
-        die Bearbeitungshistorie und eine Kopie einiger EXIF-Felder enthalten
-        &mdash; und deshalb reicht es nicht, allein EXIF zu entfernen.
+        <strong>XMP.</strong> Ein Päckchen XML, das Bildbearbeitungsprogramme
+        hinterlassen. Darin können Ihr Name stehen, Ihre Software, Bewertungen,
+        Stichwörter, die Bearbeitungshistorie und eine Kopie einiger EXIF-Felder
+        &mdash; weshalb es nicht genügt, allein EXIF zu löschen.
       </li>
       <li>
         <strong>IPTC.</strong> Ein älterer Block mit Feldern für Bildunterschrift,
-        Urheberzeile, Quelle und Copyright, in Presse und Bildagenturen üblich.
+        Urheberzeile, Quelle und Copyright, üblich in Presse und Bildagenturen.
       </li>
       <li>
         <strong>Das eingebettete Vorschaubild.</strong> Eine kleine zweite Kopie
-        des Bildes. Sie entsteht beim Schreiben der Datei und wird nicht immer
-        neu erzeugt, wenn das Bild bearbeitet wird &mdash; so kann ein
-        zugeschnittenes Foto mit einem Vorschaubild dessen reisen, was
-        weggeschnitten wurde.
+        des Bildes. Sie entsteht beim Schreiben der Datei und wird beim Bearbeiten
+        nicht immer neu erzeugt &mdash; so kann ein zugeschnittenes Foto mit
+        einer Vorschau dessen unterwegs sein, was Sie weggeschnitten haben.
       </li>
       <li>
         <strong>Die Maker Note.</strong> Ein undokumentierter Block mit
-        Herstellerdaten. Niemand außerhalb des Herstellers weiß alles, was darin
-        steht.
+        Herstellerdaten. Was da alles drinsteht, weiß außerhalb des Herstellers
+        niemand vollständig.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Wer es tatsächlich sieht</h2>
+    <h2>Wer das tatsächlich zu sehen bekommt</h2>
     <p>
-      Das ist der Teil, bei dem Genauigkeit zählt, denn sowohl die alarmierte als
-      auch die abwiegelnde Fassung ist falsch.
+      Hier lohnt sich Genauigkeit, denn sowohl die alarmierte als auch die
+      abwiegelnde Darstellung liegt daneben.
     </p>
     <p>
-      <strong>Die meisten großen sozialen Netzwerke entfernen Metadaten beim
+      <strong>Die großen sozialen Netzwerke entfernen Metadaten beim
       Posten.</strong> Facebook, Instagram und X kodieren hochgeladene Bilder neu
-      und werfen die Tags dabei weg. Das ist keine Freundlichkeit &mdash; sie
-      behalten die Daten auf ihrer Seite &mdash;, aber es heißt, dass ein dort
-      gepostetes Foto seine Koordinaten nicht jedem Betrachter übergibt.
+      und werfen die Tags dabei weg. Freundlichkeit ist das nicht &mdash; auf
+      ihrer Seite behalten sie die Daten &mdash;, aber es heißt: Ein dort
+      gepostetes Foto reicht seine Koordinaten nicht an jeden Betrachter weiter.
     </p>
     <p>
       <strong>Fast alles andere behält sie.</strong> Ein E-Mail-Anhang. Eine
-      Datei, die über die meisten Chat-Apps als &bdquo;Dokument&ldquo; statt als
-      Foto verschickt wird. Ein Bild in einem Forum, in einer
-      Marktplatz-Anzeige, auf einer privaten Seite, in einem geteilten Laufwerk,
-      in einem Fehlerbericht, in einem Support-Ticket. Überall dort kommt die
-      Datei unversehrt an, und jeder, der sie herunterlädt, kann die Tags mit
-      Werkzeugen lesen, die sein Betriebssystem mitbringt.
+      Datei, die in den meisten Chat-Apps als &bdquo;Dokument&ldquo; statt als
+      Foto verschickt wird. Ein Bild in einem Forum, in einer Kleinanzeige, auf
+      einer privaten Seite, in einem geteilten Laufwerk, in einem Fehlerbericht,
+      in einem Support-Ticket. Überall dort kommt die Datei unversehrt an, und
+      wer sie herunterlädt, liest die Tags mit Bordmitteln seines
+      Betriebssystems.
     </p>
     <p>
-      Die realistischen Risiken sind alltäglich statt dramatisch: eine
-      Marktplatz-Anzeige, zu Hause fotografiert; ein Bild eines Kindes,
-      aufgenommen an seiner Schule; ein scheinbar anonymes Konto, dessen Fotos
-      alle dieselbe Kamera-Seriennummer teilen; ein &bdquo;letzte Woche
-      aufgenommen&ldquo;, das im März entstand.
+      Die realistischen Risiken sind alltäglich statt dramatisch: die
+      Kleinanzeige, in der eigenen Wohnung fotografiert; das Bild eines Kindes,
+      aufgenommen vor seiner Schule; ein scheinbar anonymes Konto, dessen Fotos
+      alle dieselbe Kamera-Seriennummer tragen; ein &bdquo;letzte Woche
+      aufgenommen&ldquo;, das in Wahrheit aus dem März stammt.
     </p>
   </section>
 
   <section>
-    <h2>Warum nicht einfach neu speichern?</h2>
+    <h2>Warum nicht einfach neu abspeichern?</h2>
     <p>
       Ein Foto durch ein Bildbearbeitungsprogramm oder einen Kompressor neu zu
-      speichern entfernt die Metadaten tatsächlich &mdash; das Bild wird zu
-      Pixeln dekodiert und erneut kodiert, und eine Leinwand voller Pixel trägt
-      keine Tags. Es funktioniert, und es kostet Sie Qualität, denn diese
-      Neukodierung ist verlustbehaftet.
+      speichern entfernt die Metadaten tatsächlich: Das Bild wird zu Pixeln
+      dekodiert und erneut kodiert, und eine Leinwand voller Pixel trägt keine
+      Tags. Es funktioniert also &mdash; und kostet Sie Qualität, weil diese
+      Neukodierung verlustbehaftet ist.
     </p>
     <p>
-      Die Metadaten ordentlich zu entfernen kostet überhaupt nichts. Die Tags
-      sitzen im Behälter <em>um</em> das komprimierte Bild herum, nicht darin;
-      sie zu entfernen heißt also, Einträge aus einer Liste zu löschen und die
-      Liste wieder herauszuschreiben. Die komprimierten Bilddaten werden Byte für
-      Byte übernommen, und das Ergebnis dekodiert zu exakt denselben Pixeln. Das
-      ist der ganze Grund, ein Metadaten-Werkzeug zu nehmen statt eines
-      Konverters.
+      Die Metadaten ordentlich zu entfernen kostet dagegen gar nichts. Die Tags
+      sitzen im Behälter <em>um</em> das komprimierte Bild herum und nicht darin;
+      sie loszuwerden heißt, Einträge aus einer Liste zu streichen und die Liste
+      wieder herauszuschreiben. Die komprimierten Bilddaten werden Byte für Byte
+      übernommen, und das Ergebnis dekodiert zu exakt denselben Pixeln. Das ist
+      der ganze Grund, ein Metadaten-Werkzeug zu nehmen und keinen Konverter.
     </p>
     <p>
-      Die Ausnahme ist, wenn Sie ohnehin neu kodiert hätten. Komprimieren oder
-      skalieren Sie das Foto sowieso, verschwinden die Tags als Nebenwirkung, und
-      Sie brauchen keinen zweiten Schritt.
+      Die Ausnahme: Sie hätten ohnehin neu kodiert. Wenn Sie das Foto sowieso
+      komprimieren oder skalieren, fallen die Tags nebenbei weg, und ein zweiter
+      Arbeitsschritt erübrigt sich.
     </p>
   </section>
 
   <section>
-    <h2>Das eine, das bleiben sollte: die Ausrichtung</h2>
+    <h2>Das eine Tag, das bleiben sollte: die Ausrichtung</h2>
     <p>
-      Telefone drehen das Bild nicht, wenn Sie das Telefon drehen. Sie nehmen es
-      so auf, wie der Sensor es gesehen hat, und ergänzen ein
-      Orientation-Tag, das sagt, wie es zur Anzeige gedreht werden soll.
-      Entfernen Sie jedes Tag, zeigen manche Betrachter Ihr Foto quer.
+      Handys drehen das Bild nicht mit, wenn Sie das Gerät drehen. Sie nehmen
+      auf, was der Sensor gesehen hat, und legen ein Orientation-Tag dazu, das
+      angibt, wie es zur Anzeige gedreht gehört. Löschen Sie wirklich jedes Tag,
+      zeigen manche Betrachter Ihr Foto quer.
     </p>
     <p>
-      Deshalb hat das Werkzeug hier die Option &bdquo;das Orientierungs-Tag
-      behalten&ldquo;, standardmäßig aktiv. Sie schreibt einen winzigen
-      EXIF-Block zurück, der dieses eine Tag und sonst nichts enthält &mdash; und
-      nur bei Fotos, die es tatsächlich gebraucht haben. GPS, Zeitstempel,
-      Seriennummer und der Rest sind trotzdem weg.
+      Dafür gibt es im Werkzeug die Option &bdquo;das Orientierungs-Tag
+      behalten&ldquo;, von vornherein gesetzt. Sie schreibt einen winzigen
+      EXIF-Block zurück, in dem dieses eine Tag steht und sonst nichts &mdash;
+      und auch das nur bei Fotos, die es tatsächlich gebraucht haben. GPS,
+      Zeitstempel, Seriennummer und der Rest sind trotzdem fort.
     </p>
     <p>
-      Schalten Sie sie ab, wenn die Datei lieber gar kein EXIF tragen soll
-      &mdash; und prüfen Sie dann das Ergebnis, bevor Sie es verschicken, denn
-      ein quer liegendes Foto ist der übliche Ausgang.
+      Schalten Sie sie ab, wenn die Datei am Ende gar kein EXIF mehr tragen soll
+      &mdash; und sehen Sie sich das Ergebnis dann an, bevor Sie es
+      weitergeben: Ein quer liegendes Foto ist der übliche Ausgang.
     </p>
   </section>
 
   <section>
     <h2>Bearbeiten statt entfernen</h2>
     <p>
-      Alles zu entfernen ist für die meisten die richtige Antwort. Manchmal ist
-      es das nicht: Ein Fotograf möchte vielleicht die Copyright-Zeile und die
+      Alles zu entfernen ist für die meisten die richtige Antwort. Manchmal aber
+      eben nicht: Eine Fotografin möchte vielleicht die Copyright-Zeile und die
       Kameraeinstellungen behalten und nur den Ort loswerden; ein Archivar muss
-      womöglich ein Datum korrigieren, das falsch war, weil die Kamerauhr es war.
+      womöglich ein Datum geraderücken, das falsch war, weil die Kamerauhr falsch
+      ging.
     </p>
     <p>
-      Beides geht. Der Ort lässt sich einzeln löschen, und Text-Tags,
+      Beides ist möglich. Der Ort lässt sich einzeln löschen, und Text-Tags,
       Datumsangaben, ISO, Ausrichtung und Auflösung lassen sich an Ort und Stelle
       bearbeiten.
     </p>
     <p>
       Ein Vorbehalt, der für jedes Werkzeug dieser Art gilt und nicht nur für
-      dieses: Beim Schreiben der Datei wird der EXIF-Block neu aufgebaut, und
-      eine Maker Note enthält Offsets in den <em>ursprünglichen</em> Block. Eine
-      neu aufgebaute Maker Note ist daher womöglich für die Software des
-      Herstellers nicht mehr lesbar. Falls das zählt, löschen Sie die Maker Note
-      oder lassen Sie die Datei unbearbeitet.
+      dieses: Beim Schreiben wird der EXIF-Block neu aufgebaut, und eine Maker
+      Note enthält Offsets in den <em>ursprünglichen</em> Block. Eine neu
+      aufgebaute Maker Note kann für die Software des Herstellers deshalb
+      unlesbar werden. Falls Ihnen daran liegt, löschen Sie die Maker Note ganz
+      &mdash; oder lassen Sie die Datei unbearbeitet.
     </p>
   </section>
 
@@ -168,20 +167,20 @@
     <h2>Formate, und die, bei denen es so nicht geht</h2>
     <p>
       JPEG, PNG und WebP lassen sich alle sauber neu schreiben, und das sind die
-      drei, die das Werkzeug hier verarbeitet.
+      drei, die das Werkzeug hier bearbeitet.
     </p>
     <p>
-      HEIC &mdash; was ein iPhone standardmäßig speichert &mdash; und AVIF sind
-      Box-Formate aus verschachtelten Atomen und brauchen einen ganz anderen
-      Parser. Das Werkzeug erkennt sie und sagt das, statt eine kaputte Datei zu
-      erzeugen. Haben Sie ein HEIC, entfernt eine Umwandlung nach JPEG die
-      Metadaten als Nebenwirkung.
+      HEIC &mdash; was ein iPhone von Haus aus speichert &mdash; und AVIF sind
+      Box-Formate aus verschachtelten Atomen und brauchen einen völlig anderen
+      Parser. Das Werkzeug erkennt sie und sagt es Ihnen, statt eine kaputte
+      Datei auszuspucken. Haben Sie ein HEIC, entfernt schon die Umwandlung nach
+      JPEG die Metadaten nebenbei.
     </p>
     <p>
-      Ein reines TIFF wird ebenfalls nicht verarbeitet, und zwar aus einem
+      Ein reines TIFF wird ebenfalls nicht angefasst, und dafür gibt es einen
       interessanteren Grund: In einem TIFF werden Metadaten und Bilddaten über
-      dieselben Offsets adressiert &mdash; Tags zu entfernen heißt also, die
-      Adressierung des Bildes selbst neu zu schreiben. Machbar, und eine andere
+      dieselben Offsets adressiert. Tags zu entfernen hieße also, die Adressierung
+      des Bildes selbst neu zu schreiben. Machbar &mdash; aber eine andere
       Aufgabe.
     </p>
   </section>
@@ -189,42 +188,41 @@
   <section>
     <h2>Eine Gewohnheit, die sich lohnt</h2>
     <p>
-      Prüfen Sie vor dem Posten statt danach. Die Tags zu lesen dauert wenige
-      Sekunden, und die Fundliste nennt zuerst das Wissenswerte &mdash; die
-      Position, die Zeitstempel, die Seriennummern &mdash; und erst danach die
-      vollständige Tabelle jedes einzelnen Tags. Sie müssen also nicht wissen,
-      wonach Sie suchen.
+      Nachsehen, bevor Sie posten, und nicht danach. Die Tags zu lesen dauert ein
+      paar Sekunden, und die Fundliste nennt das Wissenswerte zuerst &mdash;
+      Position, Zeitstempel, Seriennummern &mdash; und erst danach die
+      vollständige Tabelle mit jedem einzelnen Tag. Sie müssen also gar nicht
+      wissen, wonach Sie suchen.
     </p>
     <p>
-      Die Position wird zuerst in Dezimalgrad angezeigt, mit Absicht.
-      &bdquo;51 Grad, 30 Minuten, 26 Sekunden&ldquo; macht nicht auf den ersten
-      Blick deutlich, dass ein Foto das Gebäude benennt, in dem es aufgenommen
-      wurde. Ein Zahlenpaar, das Sie in eine Karte einfügen können, schon.
+      Dass die Position zuerst in Dezimalgrad erscheint, hat einen Grund. Bei
+      &bdquo;52 Grad, 31 Minuten, 12 Sekunden&ldquo; fällt niemandem auf, dass
+      ein Foto damit das Gebäude benennt, in dem es entstanden ist. Bei einem
+      Zahlenpaar, das Sie in eine Karte einfügen können, schon.
     </p>
   </section>
 
   <section>
-    <h2>Laden Sie das Foto nicht hoch, um zu erfahren, was darin steckt</h2>
+    <h2>Laden Sie das Foto nicht hoch, um zu erfahren, was darin steht</h2>
     <p>
-      In der üblichen Art, dieses Problem zu lösen, liegt eine besondere Ironie:
-      Jemand, der sich sorgt, was sein Foto preisgibt, lädt es auf eine Website
-      hoch, um es herauszufinden. Die Seite hat nun das Foto, die Koordinaten,
-      den Zeitstempel und die Seriennummer &mdash; und eine Kopie des Bildes auf
+      In der üblichen Art, dieses Problem zu lösen, steckt eine besondere Ironie:
+      Wer sich sorgt, was sein Foto preisgibt, lädt es auf eine Website hoch, um
+      es herauszufinden. Und die hat nun das Foto, die Koordinaten, den
+      Zeitstempel und die Seriennummer &mdash; nebst einer Kopie des Bildes auf
       einer Festplatte, die ihr gehört.
     </p>
     <p>
-      Dafür gibt es keinen Grund. Den Behälter um ein JPEG zu lesen und neu zu
-      schreiben sind ein paar hundert Zeilen Parserei, die ein Browser
-      hervorragend ausführt &mdash; und deshalb hat das Werkzeug hier überhaupt
-      keine Netzfunktion: kein <code>fetch</code>, kein
-      <code>XMLHttpRequest</code>, nichts, das eine Datei senden könnte, selbst
-      wenn etwas es versuchte. Einmal laden, Verbindung trennen, und es arbeitet
-      weiter.
+      Nötig ist das nicht. Den Behälter um ein JPEG zu lesen und neu zu schreiben
+      sind ein paar hundert Zeilen Parserei, mit denen ein Browser hervorragend
+      zurechtkommt. Deshalb hat das Werkzeug hier überhaupt keine Netzfunktion:
+      kein <code>fetch</code>, kein <code>XMLHttpRequest</code>, nichts, das eine
+      Datei senden könnte, selbst wenn etwas es versuchte. Einmal laden,
+      Verbindung trennen, weiterarbeiten.
     </p>
     <p>
+      Wie Sie diese Behauptung hier wie überall sonst nachprüfen, steht in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> legt dar, wie Sie diese Behauptung
-      auf dieser Seite und auf jeder anderen nachprüfen &mdash; und das hier ist
-      der Dateityp, bei dem sich Nachprüfen am meisten lohnt.
+      zu Online-Konvertern hochzuladen?</a> &mdash; und dies ist der Dateityp,
+      bei dem sich das Nachprüfen am meisten lohnt.
     </p>
   </section>

--- a/locales/de/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/de/pages/guides/remove-exif-and-gps-data.toml
@@ -4,15 +4,15 @@
 
 nav = "EXIF- und GPS-Daten"
 title = "EXIF- und GPS-Daten aus einem Foto entfernen"
-description = "Ein Foto vom Telefon trägt meist den genauen Ort der Aufnahme, die Uhrzeit auf die Sekunde und die Seriennummer der Kamera. Was darin steckt, wer es lesen kann, und wie Sie es herausnehmen, ohne das Bild anzufassen."
-heading = "Was ein Foto über Sie verrät, und wie Sie es herausnehmen"
+description = "Ein Foto vom Handy trägt meist den genauen Aufnahmeort mit sich, die Uhrzeit auf die Sekunde und die Seriennummer der Kamera. Was da alles drinsteckt, wer es lesen kann und wie Sie es loswerden, ohne das Bild anzurühren."
+heading = "Was ein Foto über Sie verrät, und wie Sie es herausbekommen"
 lede = """
-    Ein Bild direkt vom Telefon trägt typischerweise die Koordinaten des Ortes,
-    an dem es aufgenommen wurde, die Uhrzeit auf die Sekunde genau, und genug
-    über die Kamera, um es mit jedem anderen Foto desselben Geräts zu
-    verknüpfen. Nichts davon ist auf dem Bildschirm zu sehen. Hier steht, was
-    darin steckt und wie Sie es entfernen."""
+    Ein Bild direkt aus dem Handy trägt in aller Regel die Koordinaten des
+    Aufnahmeorts, die Uhrzeit auf die Sekunde genau und genug über die Kamera,
+    um es mit jedem anderen Foto desselben Geräts zu verknüpfen. Auf dem
+    Bildschirm sehen Sie davon nichts. Hier steht, was da drinsteckt und wie Sie
+    es wieder loswerden."""
 updated = "20. August 2026"
-og_title = "Was ein Foto über Sie verrät, und wie Sie es herausnehmen"
-og_description = "GPS-Koordinaten, Zeitstempel und Seriennummern reisen in ganz gewöhnlichen Fotos mit. Was darin steckt, wer es lesen kann, und wie Sie es entfernen."
+og_title = "Was ein Foto über Sie verrät, und wie Sie es herausbekommen"
+og_description = "GPS-Koordinaten, Zeitstempel und Seriennummern reisen in ganz gewöhnlichen Fotos mit. Was da drinsteckt, wer es lesen kann und wie Sie es entfernen."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/resize-an-image.html
+++ b/locales/de/pages/guides/resize-an-image.html
@@ -2,124 +2,123 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie das <a href="../../bildgroesse-aendern/">Bildgrößen-Ändern</a>,
-      ziehen Sie Ihr Bild hinein, tippen Sie eine Zahl ein &mdash; meist die
-      Breite &mdash; und lassen Sie die andere leer. Die Höhe ergibt sich aus dem
-      Seitenverhältnis des Bildes, und das ist fast immer das Gewollte:
-      &bdquo;1920 breit&ldquo; heißt &bdquo;1920 breit und so hoch, wie das eben
-      wird&ldquo;.
+      ziehen Sie Ihr Bild hinein, tippen Sie eine einzige Zahl ein &mdash; meist
+      die Breite &mdash; und lassen Sie die andere leer. Die Höhe ergibt sich
+      dann aus dem Seitenverhältnis des Bildes, und das ist fast immer das
+      Gemeinte: &bdquo;1920 breit&ldquo; heißt &bdquo;1920 breit und so hoch, wie
+      das eben wird&ldquo;.
     </p>
     <p>
-      Alles Weitere unten handelt davon, was zu tun ist, wenn eine Zahl nicht
-      reicht: wenn Ihnen ein Rahmen mit zwei Seiten vorgegeben wurde, wenn das
-      Bild größer werden muss, oder wenn ein ganzer Ordner voller Dateien gleich
-      herauskommen soll.
+      Alles Weitere handelt davon, was zu tun ist, wenn eine Zahl nicht reicht:
+      wenn Ihnen ein Rahmen mit zwei Seiten vorgegeben wurde, wenn das Bild
+      größer werden muss oder wenn ein ganzer Ordner am Ende gleich aussehen
+      soll.
     </p>
   </section>
 
   <section>
-    <h2>Verkleinern ist unbedenklich. Vergrößern nicht.</h2>
+    <h2>Verkleinern ist harmlos. Vergrößern nicht.</h2>
     <p>
-      Das sind nicht zwei Richtungen desselben Vorgangs, und es lohnt sich, klar
-      zu sagen, warum.
+      Das sind nicht zwei Richtungen desselben Vorgangs, und der Unterschied
+      gehört ausgesprochen.
     </p>
     <p>
-      <strong>Ein Bild kleiner zu machen</strong> wirft Information weg, und zwar
-      im einzig harmlosen Sinn: Es gehen mehr Pixel hinein als heraus, jedes
-      Pixel des Ergebnisses ist also aus echtem, gemessenem Detail gemittelt.
-      Eine gut verkleinerte Kopie sieht meist <em>besser</em> aus als das
-      Original in dieser Größe betrachtet, weil das Mitteln Rauschen entfernt. Es
-      wird nichts erfunden.
+      <strong>Ein Bild kleiner zu machen</strong> wirft Information weg &mdash;
+      im einzigen harmlosen Sinn des Wortes: Es gehen mehr Pixel hinein, als
+      herauskommen, jedes Pixel des Ergebnisses ist also aus echtem, gemessenem
+      Detail gemittelt. Eine gut verkleinerte Kopie sieht meist sogar
+      <em>besser</em> aus als das Original in derselben Größe betrachtet, weil
+      beim Mitteln Rauschen verschwindet. Erfunden wird dabei nichts.
     </p>
     <p>
       <strong>Ein Bild größer zu machen</strong> muss erfinden. Das Detail fehlt
-      nicht in der Datei; es wurde nie fotografiert. Alles, was ein Vergrößerer
-      tun kann, ist, Zwischenpixel aus ihren Nachbarn zu raten, und eine
-      Schätzung zwischen zwei bekannten Werten ist eine glatte Rampe &mdash;
-      deshalb sieht ein vergrößertes Foto weich aus statt scharf. Es ist eine
-      größere Kopie desselben Bildes, keine detailreichere.
+      nicht etwa in der Datei &mdash; es wurde nie fotografiert. Alles, was ein
+      Vergrößerer tun kann, ist, Zwischenpixel aus ihren Nachbarn zu erraten, und
+      geraten wird zwischen zwei bekannten Werten immer eine glatte Rampe. Genau
+      deshalb wirkt ein vergrößertes Foto weich statt scharf: Es ist eine größere
+      Kopie desselben Bildes, keine detailreichere.
     </p>
     <p>
       Deshalb ist &bdquo;ein Bild nie größer machen, als es angefangen hat&ldquo;
-      im Werkzeug hier standardmäßig aktiv. Schalten Sie es ab, wenn Sie die
+      im Werkzeug hier von vornherein gesetzt. Schalten Sie es ab, wenn Sie die
       Pixelzahl wirklich brauchen &mdash; eine Druckerei, die eine Mindestgröße
-      verlangt, eine Vorlage, die unter einer bestimmten Breite nichts annimmt
-      &mdash;, aber tun Sie es im Wissen, dass Sie Pixel kaufen und kein Detail.
+      verlangt, eine Vorlage, die unterhalb einer bestimmten Breite nichts
+      annimmt. Aber tun Sie es im Wissen, dass Sie Pixel kaufen und kein Detail.
     </p>
     <p>
-      Die auf maschinellem Lernen beruhenden Vergrößerer, die tatsächlich Detail
+      Die Vergrößerer mit maschinellem Lernen, die tatsächlich Detail
       hinzuzufügen scheinen, sind etwas völlig anderes: Sie erfinden plausible
-      Textur aus einem Modell dessen, wie Bilder üblicherweise aussehen. Für ein
-      Hintergrundbild ist das in Ordnung. Bei einem Foto eines Menschen, eines
-      Dokuments oder von irgendetwas, aus dem jemand einen Schluss ziehen wird,
-      sollten Sie wissen: Das zusätzliche Detail ist Fiktion.
+      Textur aus einem Modell davon, wie Bilder üblicherweise aussehen. Für ein
+      Hintergrundbild geht das in Ordnung. Beim Foto eines Menschen, eines
+      Dokuments oder von irgendetwas, aus dem später jemand einen Schluss zieht,
+      sollte klar sein: Das zusätzliche Detail ist erfunden.
     </p>
   </section>
 
   <section>
     <h2>Drei Arten zu sagen, welche Größe Sie wollen</h2>
     <p>
-      Die meisten Werkzeuge, dieses eingeschlossen, nehmen dieselben drei an, und
-      sie passen zu verschiedenen Aufgaben.
+      Die meisten Werkzeuge, dieses eingeschlossen, verstehen dieselben drei, und
+      jede taugt für etwas anderes.
     </p>
     <ul>
       <li>
-        <strong>Exakte Pixel.</strong> Nehmen Sie das, wenn jemand die Zahl
-        vorgegeben hat: ein Profilbild, das 400&times;400 sein muss, ein Banner,
-        das 1500 breit sein muss. Füllen Sie eine Seite aus und lassen Sie die
-        andere folgen, sofern Ihnen nicht beide vorgegeben wurden.
+        <strong>Exakte Pixel.</strong> Für den Fall, dass Ihnen jemand die Zahl
+        vorgegeben hat: ein Profilbild, das 400&times;400 sein muss, ein Banner
+        mit 1500 Pixeln Breite. Tragen Sie eine Seite ein und lassen Sie die
+        andere folgen &mdash; es sei denn, es wurden Ihnen beide genannt.
       </li>
       <li>
-        <strong>Ein Prozentwert.</strong> Nehmen Sie das, wenn Sie alles
-        proportional kleiner wollen und die genaue Zahl Ihnen gleich ist &mdash;
-        &bdquo;halbe Größe&ldquo; für eine Reihe Fotos, die in ein Dokument
-        gehen.
+        <strong>Ein Prozentwert.</strong> Für den Fall, dass alles proportional
+        kleiner werden soll und Ihnen die genaue Zahl gleich ist: &bdquo;halbe
+        Größe&ldquo; für eine Reihe Fotos, die in ein Dokument wandern.
       </li>
       <li>
-        <strong>Eine lange Kante.</strong> Von den dreien die nützlichste für
-        einen gemischten Stapel. &bdquo;Längste Seite 1600&ldquo; lässt jedes
-        Bild in ein 1600-Pixel-Quadrat passen, ob im Hoch- oder im Querformat
-        &mdash; und das ist in der Praxis meist gemeint, wenn es heißt: &bdquo;Mach
-        die alle mal auf eine vernünftige Größe.&ldquo;
+        <strong>Eine lange Kante.</strong> Für einen gemischten Stapel die
+        nützlichste von allen. &bdquo;Längste Seite 1600&ldquo; bringt jedes Bild
+        in ein Quadrat von 1600 Pixeln, ob hoch oder quer &mdash; und das ist in
+        der Praxis fast immer gemeint, wenn jemand sagt: &bdquo;Mach die alle mal
+        auf eine vernünftige Größe.&ldquo;
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Wenn der Rahmen ein anderes Verhältnis hat als das Bild</h2>
+    <h2>Wenn der Rahmen ein anderes Format hat als das Bild</h2>
     <p>
-      Hier entscheidet sich das Skalieren wirklich. Geben Sie Breite und Höhe an
-      und passen die beiden nicht zu den Proportionen Ihres Bildes, muss etwas
-      nachgeben &mdash; und es gibt genau vier Dinge, die das können:
+      Hier entscheidet sich das Skalieren wirklich. Geben Sie Breite und Höhe
+      vor und passen die beiden nicht zu den Proportionen Ihres Bildes, muss
+      etwas nachgeben &mdash; und dafür gibt es genau vier Möglichkeiten:
     </p>
     <ul>
       <li>
-        <strong>In den Rahmen hineinpassen.</strong> Das ganze Bild bleibt und
-        kommt auf einer Achse kleiner heraus als der Rahmen. Nichts geht
-        verloren und nichts wird verzerrt; Sie bekommen nur nicht die exakten
-        Maße, die Sie verlangt haben. Für fast alles die richtige
+        <strong>In den Rahmen einpassen.</strong> Das ganze Bild bleibt erhalten
+        und fällt auf einer Achse kleiner aus als der Rahmen. Nichts geht
+        verloren, nichts wird verzerrt &mdash; Sie bekommen nur nicht exakt die
+        Maße, nach denen Sie gefragt haben. Für fast alles die richtige
         Voreinstellung.
       </li>
       <li>
         <strong>Den Rahmen ausfüllen und den Überstand abschneiden.</strong> Sie
-        bekommen genau die verlangten Maße, und die Teile des Bildes, die über
-        die Kanten hinausragen, sind weg. Richtig für Vorschaubilder,
-        Profilbilder und Titelbilder, wo das Format feststeht und das Motiv in
-        der Mitte ist. Falsch, wenn das Wichtige nahe an einer Kante liegt.
+        bekommen genau die verlangten Maße, und was über die Kanten hinausragt,
+        ist weg. Richtig für Vorschaubilder, Profilbilder und Titelbilder, wo das
+        Format feststeht und das Motiv mittig sitzt. Falsch, sobald das
+        Entscheidende nah an einer Kante liegt.
       </li>
       <li>
-        <strong>Auffüllen.</strong> Das ganze Bild bleibt, zentriert, und der
-        übrige Platz wird mit einer Farbe Ihrer Wahl gefüllt. Richtig, wenn ein
-        System exakte Maße verlangt und Sie nichts vom Bild verlieren dürfen
+        <strong>Auffüllen.</strong> Das ganze Bild bleibt, sitzt mittig, und der
+        übrige Platz bekommt eine Farbe Ihrer Wahl. Richtig, wenn ein System auf
+        exakten Maßen besteht und Ihnen nichts vom Bild verloren gehen darf
         &mdash; Produktanzeigen funktionieren oft so.
       </li>
       <li>
-        <strong>Dehnen.</strong> Das Bild wird gestaucht oder gezogen, damit es
-        passt. Das ist nie das Gewollte, außer Sie tun es mit Absicht &mdash; und
-        es ist das eine, das jeder sofort als falsch erkennt.
+        <strong>Dehnen.</strong> Das Bild wird gestaucht oder gezogen, bis es
+        passt. Gewollt ist das nie, außer man tut es mit Absicht &mdash; und es
+        ist das Einzige, was jeder sofort als falsch erkennt.
       </li>
     </ul>
     <p>
-      Wenn Sie zum Dehnen greifen wollen, wollen Sie vermutlich zuschneiden.
+      Wer zum Dehnen greifen möchte, will in Wahrheit meist zuschneiden.
     </p>
   </section>
 
@@ -127,121 +126,121 @@
     <h2>Zuschneiden ist eine andere Aufgabe - und oft die richtige</h2>
     <p>
       Skalieren ändert, wie viele Pixel das ganze Bild beschreiben. Zuschneiden
-      ändert, welchen Teil des Bildes Sie behalten. Erstaunlich oft greifen
-      Menschen zum Ersten, wenn sie das Zweite meinen &mdash; &bdquo;das muss
-      quadratisch sein&ldquo; ist ein Zuschnitt-Problem und kein Skalier-Problem.
+      ändert, welchen Teil des Bildes Sie überhaupt behalten. Erstaunlich oft
+      greifen Leute zum Ersten, wenn sie das Zweite meinen: &bdquo;Das muss
+      quadratisch sein&ldquo; ist keine Frage der Größe, sondern des Ausschnitts.
     </p>
     <p>
-      Machen Sie es in dieser Reihenfolge: erst auf die gewünschte Rahmung
-      zuschneiden, dann das Ergebnis auf die nötige Größe skalieren. Andersherum
-      wählen Sie den Ausschnitt aus einem Bild, das schon Pixel verloren hat.
+      Machen Sie es in dieser Reihenfolge: erst auf die gewünschte Bildwirkung
+      zuschneiden, dann das Ergebnis auf die nötige Größe bringen. Andersherum
+      suchen Sie den Ausschnitt aus einem Bild, das schon Pixel eingebüßt hat.
     </p>
     <p>
-      Genau deshalb macht das Werkzeug hier beides in einem Durchgang &mdash;
-      ziehen Sie einen Rahmen, legen Sie ihn auf ein Verhältnis fest, wenn Sie
-      eines brauchen, und sagen Sie dann, wie groß das Ergebnis herauskommen
-      soll. In einem Durchgang zu arbeiten heißt außerdem, dass das Bild nur
-      einmal kodiert wird &mdash; und warum das zählt, steht im nächsten
-      Abschnitt.
+      Genau deshalb erledigt das Werkzeug hier beides in einem Durchgang: Rahmen
+      ziehen, bei Bedarf auf ein Seitenverhältnis einrasten, dann sagen, wie groß
+      das Ergebnis werden soll. Ein Durchgang heißt außerdem, dass das Bild nur
+      ein einziges Mal kodiert wird &mdash; und warum das zählt, steht im
+      nächsten Abschnitt.
     </p>
     <h3>Einen ganzen Stapel zuschneiden</h3>
     <p>
-      Ein auf einem Bild gezogener Rahmen wird auf die übrigen als derselbe
-      <em>relative</em> Ausschnitt angewendet: dieselben Anteile der jeweils
-      eigenen Breite und Höhe. Bei einem Ordner gleich großer Screenshots oder
-      Exporte ist das exakt dasselbe Rechteck. Bei einem gemischten Stapel ist es
-      dieselbe Rahmung statt desselben Rechtecks &mdash; meist das Gewollte, aber
-      es lohnt sich, das zu wissen, bevor Sie ihm fünfzig Dateien anvertrauen.
+      Ein Rahmen, den Sie auf einem Bild ziehen, wird auf die übrigen als
+      derselbe <em>relative</em> Ausschnitt angewendet: dieselben Anteile der
+      jeweils eigenen Breite und Höhe. Bei einem Ordner gleich großer Screenshots
+      oder Exporte ist das exakt dasselbe Rechteck. Bei einem gemischten Stapel
+      ist es dieselbe Bildwirkung statt desselben Rechtecks &mdash; meist genau
+      das Gewollte, aber gut zu wissen, bevor Sie ihm fünfzig Dateien
+      anvertrauen.
     </p>
   </section>
 
   <section>
     <h2>Was die Neukodierung kostet, und wie Sie es bei einer belassen</h2>
     <p>
-      Ein JPEG oder ein WebP zu skalieren heißt: dekodieren, die Pixel skalieren
-      und sie erneut kodieren &mdash; und dieser letzte Schritt ist
-      verlustbehaftet. Nicht das Skalieren selbst kostet Sie Qualität, sondern
-      die Neukodierung.
+      Ein JPEG oder ein WebP zu skalieren heißt: dekodieren, die Pixel skalieren,
+      neu kodieren &mdash; und der letzte Schritt ist verlustbehaftet. Nicht das
+      Skalieren kostet Sie Qualität, sondern die Neukodierung.
     </p>
     <p>
-      Daraus folgt zweierlei. Erstens zählt die Qualitätseinstellung beim
-      Herausschreiben: irgendwo um 80&ndash;85 ist bei einer Fotografie
-      unsichtbar und deutlich kleiner als 100. Zweitens: einmal machen. Ein Bild
-      zu skalieren, das schon zweimal skaliert wurde, heißt drei Generationen
-      verlustbehafteter Kodierung, und man sieht es.
+      Zweierlei folgt daraus. Erstens zählt die Qualitätseinstellung beim
+      Herausschreiben: Irgendwo bei 80&ndash;85 ist der Unterschied bei einer
+      Fotografie unsichtbar und die Datei deutlich kleiner als bei 100. Zweitens:
+      einmal machen. Ein Bild zu skalieren, das schon zweimal skaliert wurde,
+      sind drei Generationen verlustbehafteter Kodierung &mdash; und das sieht
+      man.
     </p>
     <p>
-      Ein PNG hat diese Kosten nicht, weil es verlustfrei ist &mdash; ein
-      skaliertes PNG ist exakt das skalierte Pixelbild. Arbeiten Sie über mehrere
-      Schritte und steht das Endformat noch nicht fest, vermeidet PNG in der
-      Mitte das Aufstapeln von Generationen.
+      Beim PNG entfällt dieser Preis, weil es verlustfrei ist: Ein skaliertes PNG
+      enthält exakt die skalierten Pixel. Wenn Sie über mehrere Schritte
+      arbeiten und das Endformat noch offen ist, verhindert PNG in der Mitte,
+      dass sich Generationen aufstapeln.
     </p>
     <p>
-      Ein Detail des Werkzeugs hier ist wissenswert: Eine Datei, die Sie
-      tatsächlich gar nicht ändern, wird Byte für Byte zurückgereicht statt neu
+      Und ein Detail des Werkzeugs hier ist wissenswert: Eine Datei, an der sich
+      tatsächlich gar nichts ändert, wird Byte für Byte zurückgereicht statt neu
       kodiert. Verlangen Sie &bdquo;längste Seite 1600&ldquo; für einen Stapel,
-      kommen die, die ohnehin unter 1600 liegen, unangetastet heraus, samt Tags.
-      Ein Werkzeug, das sie stillschweigend neu kodierte, würde Sie Qualität an
+      kommen die, die ohnehin darunter liegen, unangetastet heraus, samt Tags.
+      Ein Werkzeug, das sie klammheimlich neu kodierte, würde Sie Qualität an
       Dateien kosten, um deren Änderung niemand gebeten hat.
     </p>
   </section>
 
   <section>
-    <h2>Transparenz, und was damit passiert</h2>
+    <h2>Transparenz, und was aus ihr wird</h2>
     <p>
-      PNG und WebP können Transparenz speichern. JPEG kann es nicht &mdash; das
-      Format hat überhaupt keinen Alphakanal. Ein transparentes Bild als JPEG zu
-      speichern muss also etwas dahinterlegen, und dieses Etwas ist eine flache
-      Farbe.
+      PNG und WebP können Transparenz speichern, JPEG nicht &mdash; einen
+      Alphakanal gibt es in diesem Format schlicht nicht. Wer ein transparentes
+      Bild als JPEG speichert, muss also etwas dahinterlegen, und dieses Etwas
+      ist eine einfarbige Fläche.
     </p>
     <p>
-      Die meisten Werkzeuge nehmen Weiß und erwähnen es nicht, was in Ordnung
-      ist, bis Ihr Logo mit einem weißen Kasten drumherum auf einer dunklen Seite
-      landet. Wählen Sie die Farbe bewusst, oder speichern Sie als PNG oder WebP
-      und behalten Sie die Transparenz. Dieselbe Farbe steht hinter einem
-      aufgefüllten Rahmen &mdash; die andere Stelle, an der Menschen dem
-      überrascht begegnen.
+      Die meisten Werkzeuge nehmen dafür Weiß und erwähnen es nicht &mdash; was
+      in Ordnung geht, bis Ihr Logo mit weißem Kasten drumherum auf einer dunklen
+      Seite landet. Wählen Sie die Farbe also bewusst, oder speichern Sie als PNG
+      oder WebP und behalten Sie die Transparenz. Dieselbe Farbe steht übrigens
+      auch hinter einem aufgefüllten Rahmen &mdash; die zweite Stelle, an der man
+      dem überrascht begegnet.
     </p>
   </section>
 
   <section>
     <h2>Welches Werkzeug, wenn Ihnen eine Zahl genannt wurde</h2>
     <p>
-      Es werden zwei verschiedene Zahlen genannt, und sie brauchen verschiedene
-      Werkzeuge.
+      Genannt werden zwei ganz verschiedene Zahlen, und sie verlangen
+      verschiedene Werkzeuge.
     </p>
     <p>
-      <strong>&bdquo;1200 Pixel breit&ldquo;</strong> ist ein Maß-Problem. Das
-      <a href="../../bildgroesse-aendern/">Bildgrößen-Ändern</a> ist das
-      richtige: Sie sagen, wie viele Pixel Sie wollen, und bekommen genau die.
+      <strong>&bdquo;1200 Pixel breit&ldquo;</strong> ist eine Frage der Maße.
+      Dafür ist das
+      <a href="../../bildgroesse-aendern/">Bildgrößen-Ändern</a> da: Sie sagen,
+      wie viele Pixel Sie wollen, und bekommen genau die.
     </p>
     <p>
-      <strong>&bdquo;Unter 500&nbsp;KB&ldquo;</strong> ist ein
-      Dateigrößen-Problem, und Skalieren ist nur einer der Wege, es zu lösen. Der
+      <strong>&bdquo;Unter 500&nbsp;KB&ldquo;</strong> ist eine Frage der
+      Dateigröße, und Skalieren ist nur einer der Wege dorthin. Der
       <a href="../../bild-komprimieren/">Bildkompressor</a> sucht die höchste
       Qualität, die in Ihre Zielgröße passt, und verkleinert nur dann, wenn
-      Qualität allein nicht reicht;
-      <a href="../bild-auf-groesse-komprimieren/">sein Ratgeber</a> behandelt,
-      was das kostet.
+      Qualität allein nicht ausreicht; was das kostet, steht in
+      <a href="../bild-auf-groesse-komprimieren/">seinem Ratgeber</a>.
     </p>
   </section>
 
   <section>
     <h2>Nichts davon braucht einen Upload</h2>
     <p>
-      Ein Bild zu dekodieren, zu skalieren und erneut zu kodieren sind Dinge, die
-      jeder Browser seit Jahren kann &mdash; es ist dieselbe Maschinerie, mit der
-      eine Webseite ein Bild in anderer Größe zeichnet. Es gibt keinen
-      technischen Grund, warum Ihr Foto zu einem Server und zurück reisen sollte,
-      um kleiner herauszukommen, und das Werkzeug hier schickt es nirgendwohin:
-      Die <code>Content-Security-Policy</code> der Seite nennt jede Adresse, die
-      sie kontaktieren darf, und keine davon gehört zu dieser Seite.
+      Ein Bild zu dekodieren, zu skalieren und neu zu kodieren kann jeder Browser
+      seit Jahren &mdash; es ist dieselbe Maschinerie, mit der eine Webseite ein
+      Bild in einer anderen Größe zeichnet. Es gibt keinen technischen Grund,
+      warum Ihr Foto zu einem Server und zurück reisen sollte, um kleiner
+      herauszukommen, und das Werkzeug hier schickt es nirgendwohin: Die
+      <code>Content-Security-Policy</code> der Seite nennt jede Adresse, die sie
+      kontaktieren darf, und keine davon gehört zu dieser Seite.
     </p>
     <p>
-      Laden Sie die Seite, trennen Sie die Internetverbindung und skalieren Sie
-      trotzdem etwas, wenn Sie lieber prüfen als glauben.
+      Wer lieber prüft als glaubt, lädt die Seite, trennt die
+      Internetverbindung und skaliert trotzdem etwas. Drei weitere Proben, die
+      Sie an jedem Werkzeug durchführen können, stehen in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen, die Sie
-      an jedem Werkzeug durchführen können.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/resize-an-image.toml
+++ b/locales/de/pages/guides/resize-an-image.toml
@@ -4,14 +4,14 @@
 
 nav = "Ein Bild skalieren"
 title = "Ein Bild skalieren, ohne es zu ruinieren"
-description = "Was mit einem Bild passiert, wenn Sie seine Pixelmaße ändern: warum Verkleinern unbedenklich ist und Vergrößern nicht, was zu tun ist, wenn der Rahmen das falsche Verhältnis hat, und wann Sie besser zuschneiden."
-heading = "Wie Sie ein Bild skalieren, ohne es zu ruinieren"
+description = "Was mit einem Bild geschieht, wenn Sie seine Pixelmaße ändern: warum Verkleinern harmlos ist und Vergrößern nicht, was zu tun ist, wenn der Rahmen das falsche Format hat, und wann Zuschneiden die bessere Antwort ist."
+heading = "So skalieren Sie ein Bild, ohne es zu ruinieren"
 lede = """
     Skalieren ist die eine Bildaufgabe, bei der der Schaden schon vor dem Klick
-    feststeht &mdash; durch die Zahl, die Sie eintippen, und das Verhältnis, das
-    Sie verlangen. Hier steht, was jede dieser Entscheidungen mit dem Bild macht
-    und welche davon sich rückgängig machen lässt."""
+    feststeht &mdash; entschieden von der Zahl, die Sie eintippen, und dem
+    Format, das Sie verlangen. Hier steht, was jede dieser Entscheidungen mit
+    dem Bild anstellt und welche davon sich zurücknehmen lässt."""
 updated = "20. August 2026"
 og_title = "Ein Bild skalieren, ohne es zu ruinieren"
-og_description = "Warum Verkleinern unbedenklich ist und Vergrößern nicht, was zu tun ist, wenn der Rahmen das falsche Verhältnis hat, und wann Sie besser zuschneiden."
+og_description = "Warum Verkleinern harmlos ist und Vergrößern nicht, was zu tun ist, wenn der Rahmen das falsche Format hat, und wann Zuschneiden die bessere Antwort ist."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/trim-a-video.html
+++ b/locales/de/pages/guides/trim-a-video.html
@@ -2,207 +2,208 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie den <a href="../../video-schneiden/">Video-Schneider</a>, ziehen
-      Sie den Clip hinein, drücken Sie <kbd>I</kbd> und <kbd>O</kbd>, um jeden
-      gewünschten Teil zu markieren &mdash; so viele Sie wollen &mdash; und
-      exportieren Sie. Bei einem MP4, MOV oder M4V werden die Einzelbilder, die
-      Sie behalten, genau so in die neue Datei bewegt, wie sie waren &mdash;
-      dieselben Bytes, dieselben Encoder-Einstellungen, dasselbe alles &mdash;
-      und der Ton wird Sample für Sample übernommen, ohne dekodiert zu werden.
+      Sie den Clip hinein, markieren Sie mit <kbd>I</kbd> und <kbd>O</kbd> jeden
+      Abschnitt, den Sie behalten wollen &mdash; so viele Sie mögen &mdash;, und
+      exportieren Sie. Bei einem MP4, MOV oder M4V wandern die Einzelbilder, die
+      Sie behalten, unverändert in die neue Datei: dieselben Bytes, dieselben
+      Encoder-Einstellungen, alles gleich. Und der Ton wird Sample für Sample
+      übernommen, ohne je dekodiert zu werden.
     </p>
     <p>
-      Das heißt, ein Schnitt kostet Sie keine Qualität, und er ist schnell: Eine
-      Minute aus einer vier Gigabyte großen Aufnahme herauszuschneiden kostet
-      etwa so viel, wie diese Minute auf die Festplatte zu schreiben, denn auf
-      die Einzelbilder wird gezeigt, statt sie zu laden. Die eine Stelle, an der
-      sich das bemerkbar macht, ist die, wo Ihr Schnitt tatsächlich landet
-      &mdash; und davon handelt der Rest dieser Seite.
+      Ein Schnitt kostet Sie also keine Qualität, und schnell ist er obendrein:
+      Eine Minute aus einer vier Gigabyte großen Aufnahme herauszuschneiden
+      dauert ungefähr so lange, wie diese Minute auf die Festplatte zu schreiben
+      &mdash; denn auf die Einzelbilder wird nur gezeigt, sie werden nicht
+      geladen. An genau einer Stelle macht sich das Verfahren trotzdem
+      bemerkbar: dort, wo Ihr Schnitt am Ende wirklich sitzt. Davon handelt der
+      Rest dieser Seite.
     </p>
   </section>
 
   <section>
     <h2>Warum ein Schnitt überhaupt keine Qualität kosten muss</h2>
     <p>
-      Kürzen ändert nichts daran, wie ein Einzelbild aussieht. Jedes Einzelbild,
-      das Sie behalten, soll genauso herauskommen, wie es hineinging &mdash; es
-      gibt also keinen Grund, es zu dekodieren und neu zu kodieren, und jeden
-      Grund, es nicht zu tun: Eine Neukodierung ist verlustbehaftet und würde
-      den ganzen Clip ein wenig schlechter machen, nur um ihn zu kürzen.
+      Kürzen ändert nichts am Aussehen eines Einzelbildes. Jedes Bild, das Sie
+      behalten, soll genauso herauskommen, wie es hineinging &mdash; es gibt also
+      keinen Grund, es zu dekodieren und neu zu kodieren, und jeden Grund, es
+      bleiben zu lassen: Eine Neukodierung ist verlustbehaftet und würde den
+      ganzen Clip ein wenig schlechter machen, bloß um ihn zu kürzen.
     </p>
     <p>
-      Ein guter Schneider kodiert also nicht neu. Er liest den Index der Datei,
+      Ein gutes Werkzeug kodiert deshalb nicht neu. Es liest den Index der Datei,
       ermittelt, welche kodierten Einzelbilder in Ihren Bereich fallen, und
       schreibt diese Bytes in einen neuen Container mit einem neuen Index davor.
-      Auf diesem Weg wird überhaupt nichts dekodiert.
+      Dekodiert wird auf diesem Weg überhaupt nichts.
     </p>
     <p>
       Viele Werkzeuge kodieren trotzdem neu, weil Dekodieren und Neukodieren
-      sehr viel einfacher umzusetzen ist, als das Containerformat zu zerlegen.
-      Welche Sorte Sie vor sich haben, erkennen Sie meist an der Dauer: Eine
-      Kopie ist dadurch begrenzt, wie schnell Ihre Festplatte schreibt, und eine
-      Neukodierung dadurch, wie schnell Ihr Gerät Video kodiert &mdash; und das
-      ist hundertmal langsamer.
+      sehr viel leichter umzusetzen ist, als das Containerformat zu zerlegen.
+      Woran Sie erkennen, welche Sorte Sie vor sich haben: an der Dauer. Eine
+      Kopie ist davon begrenzt, wie schnell Ihre Festplatte schreibt, eine
+      Neukodierung davon, wie schnell Ihr Gerät Video kodiert &mdash; und das ist
+      hundertmal langsamer.
     </p>
   </section>
 
   <section>
-    <h2>Keyframes, und warum Ihr Schnitt früher landen kann</h2>
+    <h2>Keyframes, und warum Ihr Schnitt früher sitzen kann</h2>
     <p>
-      Hier ist die Beschränkung, aus der alles am Kürzen folgt.
+      Aus dieser einen Beschränkung folgt alles Übrige.
     </p>
     <p>
-      Video wird nicht als Folge vollständiger Bilder gespeichert. Das wäre
-      riesig. Die meisten Einzelbilder werden als Beschreibung dessen
-      gespeichert, worin sie sich von ihren Nachbarn unterscheiden &mdash; sie
-      lassen sich also nicht für sich allein dekodieren, man braucht die
-      Einzelbilder ringsherum. Nur ein <strong>Keyframe</strong> steht als
-      vollständiges Bild für sich, und Keyframes liegen typischerweise eine bis
-      zehn Sekunden auseinander.
+      Video wird nicht als Folge vollständiger Bilder gespeichert &mdash; das
+      wäre gewaltig. Die meisten Einzelbilder halten nur fest, worin sie sich von
+      ihren Nachbarn unterscheiden, und lassen sich deshalb nicht für sich allein
+      dekodieren: Man braucht die Bilder ringsherum. Nur ein
+      <strong>Keyframe</strong> steht als vollständiges Bild für sich, und
+      Keyframes liegen typischerweise eine bis zehn Sekunden auseinander.
     </p>
     <p>
-      Markieren Sie also einen Schnitt zwei Sekunden nach dem letzten Keyframe,
-      kann ein Schneider, der Einzelbilder kopiert, dort nicht anfangen. Die
-      Einzelbilder an Ihrer Markierung sind ohne die Strecke davor unlesbar. Er
-      muss den ganzen Abschnitt ab dem Keyframe vor Ihrer Markierung mitnehmen.
+      Setzen Sie Ihre Marke also zwei Sekunden hinter den letzten Keyframe, kann
+      ein Werkzeug, das Einzelbilder kopiert, dort nicht anfangen: Die Bilder an
+      Ihrer Marke sind ohne den Anlauf davor nicht lesbar. Es muss den ganzen
+      Abschnitt ab dem Keyframe vor Ihrer Marke mitnehmen.
     </p>
     <p>
-      Was er damit anfängt, ist der interessante Teil. Das Dateiformat hat eine
-      genormte Möglichkeit zu sagen: <em>ab hier abspielen</em> &mdash; die
-      zusätzlichen Einzelbilder liegen in der Datei, aber der Container weist den
-      Player an, sie zu überspringen. Jeder gängige Player befolgt das, und der
-      Clip beginnt genau dort, wo Sie es gesagt haben. Ein Player, der es
-      ignoriert, beginnt früher, um bis zu den Keyframe-Abstand.
+      Interessant ist, was es damit anstellt. Das Dateiformat kennt eine genormte
+      Art zu sagen: <em>ab hier abspielen</em>. Die zusätzlichen Bilder liegen
+      dann zwar in der Datei, aber der Container weist den Player an, sie zu
+      überspringen. Jeder gängige Player hält sich daran, und der Clip beginnt
+      genau dort, wo Sie es wollten. Ein Player, der die Anweisung ignoriert,
+      beginnt früher &mdash; höchstens um den Keyframe-Abstand.
     </p>
     <p>
-      Das Werkzeug hier sagt Ihnen vor dem Export, in welchem Fall Sie sind und
-      um wie viel &mdash; es ist also eine Entscheidung und keine Überraschung.
+      Das Werkzeug hier sagt Ihnen vor dem Export, welcher Fall vorliegt und um
+      wie viel es geht. So wird daraus eine Entscheidung statt einer Überraschung.
     </p>
   </section>
 
   <section>
-    <h2>Wann eine Neukodierung hinzunehmen ist</h2>
+    <h2>Wann eine Neukodierung die bessere Wahl ist</h2>
     <p>
-      Es gibt einen exakten Schnitt, und er funktioniert, indem er den
-      Anfangsabschnitt neu kodiert &mdash; ab dem Keyframe dekodieren und eine
-      neue Folge von Einzelbildern schreiben, die wirklich dort beginnt, wo Sie
-      markiert haben. Er ist langsamer und kostet ein wenig Qualität, und zwar
-      nur auf diesem Anfangsabschnitt.
+      Es gibt auch den exakten Schnitt. Er funktioniert, indem der
+      Anfangsabschnitt neu kodiert wird: ab dem Keyframe dekodieren und eine neue
+      Folge von Einzelbildern schreiben, die tatsächlich dort beginnt, wo Sie
+      markiert haben. Das dauert länger und kostet ein wenig Qualität &mdash;
+      allerdings nur auf diesem Anfangsabschnitt.
     </p>
     <p>
-      Wählen Sie ihn, wenn der Clip dorthin geht, wo die Anweisung des
-      Containers nicht befolgt wird, oder wo Sie den Player nicht bestimmen
-      können: manche Schnittprogramme, manche Sende- und Konferenzsysteme,
-      manche älteren Hardware-Player. Wählen Sie die Kopie für alles andere, und
-      das ist so gut wie alles &mdash; ein Browser, ein Telefon, eine soziale
-      Plattform, ein Mediaplayer.
+      Nehmen Sie ihn, wenn der Clip dorthin geht, wo die Anweisung des Containers
+      nicht befolgt wird, oder wohin Sie den Player nicht bestimmen können: manche
+      Schnittprogramme, manche Sende- und Konferenzsysteme, manche ältere
+      Hardware-Player. Für alles andere &mdash; also für so ziemlich alles: einen
+      Browser, ein Handy, eine soziale Plattform, einen Mediaplayer &mdash;
+      nehmen Sie die Kopie.
     </p>
     <p>
-      Eine dritte Möglichkeit, die nichts kostet: Verschieben Sie Ihre
-      Markierung. Zeigt Ihnen das Werkzeug, wo die Keyframes liegen, gibt Ihnen
-      ein Stups auf den nächstgelegenen einen exakten Schnitt ganz ohne
-      Neukodierung. Für eine Sekunde Unterschied lohnt es sich selten, die Kopie
-      aufzugeben.
+      Und es gibt eine dritte Möglichkeit, die gar nichts kostet: die Marke
+      verschieben. Zeigt Ihnen das Werkzeug, wo die Keyframes sitzen, bekommen
+      Sie mit einem Stups auf den nächstgelegenen einen exakten Schnitt ganz ohne
+      Neukodierung. Wegen einer Sekunde Unterschied lohnt es sich selten, die
+      Kopie aufzugeben.
     </p>
   </section>
 
   <section>
     <h2>Ein Stück aus der Mitte herausnehmen</h2>
     <p>
-      Einen Abschnitt herauszuschneiden ist ein anderer Vorgang als einen zu
-      behalten, und es ist wert zu wissen, dass er unterstützt wird &mdash; denn
-      viele Schneider können nur das Zweite. Markieren Sie den Teil, den Sie
-      nicht wollen, wählen Sie, ihn herauszuschneiden, und was links und rechts
-      übrig bleibt, wird zu einem Clip zusammengefügt, mit dem Ton im Takt.
+      Einen Abschnitt herauszuschneiden ist etwas anderes, als einen zu behalten
+      &mdash; und dass es überhaupt geht, ist erwähnenswert, weil viele Werkzeuge
+      nur das Zweite können. Markieren Sie den Teil, den Sie nicht wollen, wählen
+      Sie &bdquo;herausschneiden&ldquo;, und was links und rechts übrig bleibt,
+      wird zu einem Clip zusammengefügt, mit dem Ton im Takt.
     </p>
     <p>
-      Die Nahtstelle hat an dem Punkt, an dem die zweite Hälfte wieder einsetzt,
-      dieselbe Keyframe-Beschränkung, aus demselben Grund. Es funktioniert hier
-      auf beiden MP4-Wegen. Es ist das eine, was die unten beschriebene
-      Aufzeichnung nicht kann, denn eine Aufzeichnung entsteht in einem Durchgang
-      aus einem Abspielkopf.
+      An der Nahtstelle, wo die zweite Hälfte wieder einsetzt, gilt dieselbe
+      Keyframe-Beschränkung, aus demselben Grund. Auf beiden MP4-Wegen
+      funktioniert das hier. Es ist das Einzige, was die weiter unten
+      beschriebene Aufzeichnung nicht kann &mdash; eine Aufzeichnung entsteht in
+      einem Durchgang aus einem Abspielkopf.
     </p>
   </section>
 
   <section>
-    <h2>Formate, und die Rückfalloption</h2>
+    <h2>Formate, und der Weg über die Aufzeichnung</h2>
     <p>
-      <strong>MP4, M4V und MOV</strong> werden direkt gelesen, egal welcher Codec
-      darin steckt &mdash; H.264, HEVC, AV1, VP9. Einzelbilder zu kopieren heißt
-      nicht, sie zu dekodieren, dieser Weg funktioniert also selbst bei einem
-      Codec, für den Ihr Browser überhaupt keinen Decoder hat &mdash; eine
-      angenehme Folge davon, sich die Bilder gar nicht erst anzusehen.
+      <strong>MP4, M4V und MOV</strong> werden direkt gelesen, gleich welcher
+      Codec darin steckt &mdash; H.264, HEVC, AV1, VP9. Einzelbilder zu kopieren
+      heißt nicht, sie zu dekodieren; dieser Weg funktioniert also selbst bei
+      einem Codec, für den Ihr Browser gar keinen Decoder besitzt. Eine
+      angenehme Folge davon, sich die Bilder erst gar nicht anzusehen.
     </p>
     <p>
-      <strong>Alles andere, was Ihr Browser abspielen kann</strong>, allen voran
-      WebM, wird gekürzt, indem es abgespielt und das Ergebnis aufgezeichnet
-      wird. Das funktioniert und hat zwei Kosten: Es dauert so lange, wie der
-      Abschnitt lang ist, und Bild und Ton werden neu kodiert.
+      <strong>Alles Übrige, was Ihr Browser abspielen kann</strong> &mdash; allen
+      voran WebM &mdash;, wird gekürzt, indem es abgespielt und das Ergebnis
+      dabei aufgezeichnet wird. Das klappt, hat aber zwei Kosten: Es dauert
+      genau so lange, wie der Abschnitt lang ist, und Bild und Ton werden neu
+      kodiert.
     </p>
     <p>
       <strong>AVI, WMV, FLV und die meisten MKVs</strong> kann der Browser weder
-      lesen noch abspielen, und das Werkzeug sagt das, statt auf halbem Weg zu
-      scheitern. Wandeln Sie diese zuerst mit etwas nach MP4 um, das damit
-      umgehen kann.
+      lesen noch abspielen, und das Werkzeug sagt Ihnen das, statt auf halber
+      Strecke steckenzubleiben. Wandeln Sie die vorher mit etwas nach MP4 um, das
+      damit zurechtkommt.
     </p>
   </section>
 
   <section>
-    <h2>Zwei Dinge, die anderswo stillschweigend schiefgehen</h2>
+    <h2>Zwei Dinge, die anderswo klammheimlich schiefgehen</h2>
     <p>
-      <strong>Drehung.</strong> Ein Telefon filmt im Querformat und schreibt eine
-      Drehanweisung in die Datei, statt die Pixel zu drehen. Ein Schneider, der
-      Einzelbilder kopiert, muss diese Anweisung mitnehmen &mdash; sonst kommt
-      Ihr Hochformat-Clip quer heraus, und das ist die klassische Art, wie ein
-      geschnittenes Video ruiniert wird. Der exakte Weg dreht hier die
-      Einzelbilder beim Neukodieren und schreibt eine Datei, die überhaupt keine
-      Drehung braucht.
+      <strong>Die Drehung.</strong> Ein Handy filmt im Querformat und schreibt
+      eine Drehanweisung in die Datei, statt die Pixel zu drehen. Ein Werkzeug,
+      das Einzelbilder kopiert, muss diese Anweisung mitnehmen &mdash; sonst kommt
+      Ihr Hochformat-Clip quer heraus, und das ist die klassische Art, ein
+      geschnittenes Video zu ruinieren. Der exakte Weg dreht die Bilder hier beim
+      Neukodieren gleich mit und schreibt eine Datei, die gar keine Drehung mehr
+      braucht.
     </p>
     <p>
-      <strong>Ton-Synchronität.</strong> Ton und Bild werden als getrennte
-      Ströme mit eigenem Timing gespeichert, und sie werden nicht an denselben
-      Stellen zerteilt. Werden die beiden am Schnitt nicht bewusst in Deckung
-      gebracht, läuft der Ton weg. Auf dem Kopierweg wird der Ton hier Sample für
-      Sample übernommen, ohne dekodiert zu werden &mdash; er ist also Byte für
-      Byte das, was in der Datei stand &mdash; und eine Edit-Markierung hält ihn
-      auf eine Tausendstelsekunde genau mit dem Bild im Takt.
+      <strong>Die Ton-Synchronität.</strong> Ton und Bild liegen als getrennte
+      Ströme mit eigenem Timing in der Datei, und sie werden nicht an denselben
+      Stellen zerteilt. Bringt man beide am Schnitt nicht bewusst in Deckung,
+      läuft der Ton davon. Auf dem Kopierweg wird der Ton hier Sample für Sample
+      übernommen, ohne dekodiert zu werden &mdash; er ist also Byte für Byte
+      das, was in der Datei stand &mdash;, und eine Edit-Markierung hält ihn auf
+      eine Tausendstelsekunde genau am Bild.
     </p>
   </section>
 
   <section>
     <h2>Kürzen ist nicht Zuschneiden</h2>
     <p>
-      Zwei Wörter, die füreinander verwendet werden. Kürzen ändert die Länge des
-      Clips; Zuschneiden ändert die Form des Bildes. Wollen Sie eine quadratische
-      Fassung eines Querformatvideos, oder die schwarzen Balken an den Seiten
-      weg, ist das der <a href="../../video-zuschneiden/">Video-Zuschneider</a>
-      &mdash; und anders als Kürzen muss er neu kodieren, aus dem Grund, den
-      <a href="../video-bildausschnitt-aendern/">sein Ratgeber</a> erklärt.
+      Zwei Wörter, die ständig füreinander einspringen. Kürzen ändert die Länge
+      des Clips, Zuschneiden die Form des Bildes. Wollen Sie eine quadratische
+      Fassung eines Querformatvideos oder die schwarzen Balken an den Seiten los,
+      ist der <a href="../../video-zuschneiden/">Video-Zuschneider</a> zuständig
+      &mdash; und anders als beim Kürzen muss dabei neu kodiert werden, aus dem
+      Grund, den <a href="../video-bildausschnitt-aendern/">sein Ratgeber</a>
+      erklärt.
     </p>
   </section>
 
   <section>
-    <h2>Warum das keinen Upload braucht - gerade das hier nicht</h2>
+    <h2>Warum das keinen Upload braucht - hier erst recht nicht</h2>
     <p>
-      Video ist der Dateityp, bei dem Menschen am ehesten erwarten, hochladen zu
-      müssen, denn die Dateien sind groß und die Arbeit klingt schwer. Kürzen ist
-      der Fall, in dem das am wenigsten zutrifft: Auf dem Kopierweg wird die
-      Datei kaum gelesen. Das Werkzeug läuft den Index ab, ermittelt, welche
-      Byte-Bereiche zu behalten sind, und schreibt sie heraus. Eine vier Gigabyte
-      große Datei auf einen Server zu laden, damit der das tun kann, wäre die
-      langsamste denkbare Anordnung.
+      Video ist der Dateityp, bei dem am ehesten alle mit einem Upload rechnen:
+      Die Dateien sind groß, die Arbeit klingt schwer. Beim Kürzen trifft das am
+      wenigsten zu &mdash; auf dem Kopierweg wird die Datei kaum gelesen. Das
+      Werkzeug läuft den Index ab, ermittelt, welche Byte-Bereiche bleiben
+      sollen, und schreibt sie heraus. Vier Gigabyte auf einen Server zu schieben,
+      damit der das erledigt, wäre die langsamste Anordnung, die sich denken
+      lässt.
     </p>
     <p>
-      Es ist auch der Dateityp, bei dem Hochladen am meisten kostet, wenn man es
-      lieber nicht täte: Video trägt Gesichter, Stimmen, Wohnungen und Orte auf
-      eine Weise, wie ein Dokument es nicht tut. Das Werkzeug hier hat keinerlei
-      Netzfunktion, und die <code>Content-Security-Policy</code> der Seite nennt
-      jede Adresse, die sie kontaktieren darf; keine davon gehört zu dieser
-      Seite.
+      Es ist zugleich der Dateityp, bei dem ein Upload am meisten kostet, wenn
+      man ihn lieber vermieden hätte: Video trägt Gesichter, Stimmen, Wohnungen
+      und Orte auf eine Weise, wie es ein Dokument nie tut. Das Werkzeug hier hat
+      keinerlei Netzfunktion, und die <code>Content-Security-Policy</code> der
+      Seite nennt jede Adresse, die sie kontaktieren darf; keine davon gehört zu
+      dieser Seite.
     </p>
     <p>
-      Trennen Sie die Internetverbindung und schneiden Sie trotzdem einen Clip,
-      wenn Sie lieber prüfen als glauben.
+      Wer lieber prüft als glaubt, trennt die Internetverbindung und schneidet
+      trotzdem einen Clip. Drei weitere Proben dieser Art stehen in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt drei weitere Prüfungen dieser
-      Art.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/trim-a-video.toml
+++ b/locales/de/pages/guides/trim-a-video.toml
@@ -4,14 +4,14 @@
 
 nav = "Ein Video kürzen"
 title = "Ein Video kürzen, ohne es neu zu kodieren"
-description = "Einen Clip zu schneiden muss kein einziges Byte Qualität kosten. Warum ein Schnitt manchmal früher landet als markiert, was ein Keyframe damit zu tun hat, und wann eine Neukodierung hinzunehmen ist."
-heading = "Wie Sie ein Video kürzen, ohne es neu zu kodieren"
+description = "Einen Clip zu schneiden muss kein einziges Byte Qualität kosten. Warum ein Schnitt manchmal früher sitzt als markiert, was ein Keyframe damit zu tun hat und wann eine Neukodierung die bessere Wahl ist."
+heading = "So kürzen Sie ein Video, ohne es neu zu kodieren"
 lede = """
-    Kürzen ändert nichts daran, wie ein Einzelbild aussieht, also fasst ein
-    guter Schneider sie gar nicht an &mdash; er bewegt sie genau so, wie sie
-    waren, in eine neue Datei. Hier steht, was Ihnen das einbringt, und die eine
-    Stelle, an der es sich bemerkbar macht."""
+    Kürzen ändert nichts daran, wie ein Einzelbild aussieht &mdash; ein gutes
+    Werkzeug rührt die Bilder deshalb gar nicht an, sondern schiebt sie
+    unverändert in eine neue Datei. Hier steht, was Ihnen das einbringt, und an
+    welcher einen Stelle es sich trotzdem bemerkbar macht."""
 updated = "20. August 2026"
-og_title = "Wie Sie ein Video kürzen, ohne es neu zu kodieren"
-og_description = "Warum ein Schnitt manchmal früher landet als markiert, was ein Keyframe damit zu tun hat, und wann eine Neukodierung hinzunehmen ist."
+og_title = "So kürzen Sie ein Video, ohne es neu zu kodieren"
+og_description = "Warum ein Schnitt manchmal früher sitzt als markiert, was ein Keyframe damit zu tun hat und wann eine Neukodierung die bessere Wahl ist."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/de/pages/guides/turn-a-video-into-a-gif.html
@@ -3,234 +3,232 @@
     <p>
       Öffnen Sie den
       <a href="../../video-in-gif-umwandeln/">Video-zu-GIF-Umwandler</a>, ziehen
-      Sie den Clip hinein, markieren Sie die gewünschten Sekunden und lassen Sie
-      die Breite bei 480 und die Rate bei 12 Bildern pro Sekunde. Das ist die
-      Einstellung, die die meisten GIFs wollen. Kommt die Datei zu groß heraus,
-      nehmen Sie die Breite herunter, bevor Sie irgendetwas anderes anfassen
-      &mdash; das ist die Einstellung, die doppelt zahlt.
+      Sie den Clip hinein, markieren Sie die Sekunden, die Sie wollen, und lassen
+      Sie die Breite bei 480 und die Rate bei 12 Bildern pro Sekunde. Das ist die
+      Einstellung, mit der die allermeisten GIFs gut fahren. Gerät die Datei zu
+      groß, nehmen Sie die Breite herunter, bevor Sie irgendetwas anderes
+      anfassen &mdash; die zahlt sich nämlich doppelt aus.
     </p>
     <p>
-      Der Rest dieser Seite handelt vom Warum, denn &bdquo;mein GIF hat
-      14&nbsp;MB&ldquo; ist das Problem, das alle tatsächlich haben, und welcher
-      Regler zu drehen ist, liegt nicht auf der Hand.
+      Der Rest dieser Seite handelt vom Warum. Denn &bdquo;mein GIF hat
+      14&nbsp;MB&ldquo; ist das Problem, das tatsächlich alle haben, und an
+      welchem Regler dann zu drehen ist, liegt keineswegs auf der Hand.
     </p>
   </section>
 
   <section>
-    <h2>Warum ein GIF eines Videos so riesig ist</h2>
+    <h2>Warum ein GIF aus einem Video so gewaltig wird</h2>
     <p>
       Ein Video-Codec speichert <em>Bewegung</em>. Er schreibt alle paar Sekunden
-      ein volles Bild und für jedes Einzelbild dazwischen eine Beschreibung
-      davon, wie dieses Bild sich bewegt hat: Dieser Pixelblock ist vier nach
-      links gerutscht, dieser Bereich ist etwas dunkler geworden. Ein fünf
-      Sekunden langer Clip kann ein paar hundert Kilobyte groß sein, weil das
-      meiste davon Anweisungen zu einem Bild sind, das Sie schon haben.
+      ein volles Bild und für jedes Einzelbild dazwischen nur die Beschreibung,
+      wie sich dieses Bild verändert hat: Dieser Pixelblock ist vier nach links
+      gerutscht, dieser Bereich ist etwas dunkler geworden. Ein fünf Sekunden
+      langer Clip kommt so mit ein paar hundert Kilobyte aus, weil das meiste
+      darin Anweisungen zu einem Bild sind, das Sie längst haben.
     </p>
     <p>
-      GIF hat davon nichts. Es war 1989 fertig, bevor es irgendetwas davon gab.
-      Jedes Einzelbild ist ein Bild, für sich komprimiert, mit einem Verfahren,
-      das für Bildschirmfotos einer Tabellenkalkulation entworfen wurde. In dem
-      Format gibt es nirgends eine Bewegungsschätzung, und es gibt keine
-      Möglichkeit, eine hinzuzufügen.
+      GIF kennt davon nichts. Es war 1989 fertig, bevor es all das gab. Jedes
+      Einzelbild ist ein eigenes Bild, für sich komprimiert, und zwar mit einem
+      Verfahren, das für Bildschirmfotos von Tabellenkalkulationen entworfen
+      wurde. Eine Bewegungsschätzung gibt es im Format nirgends, und nachrüsten
+      lässt sie sich auch nicht.
     </p>
     <p>
-      Die Zahl, mit der zu rechnen ist, lautet also
-      <strong>das Zehnfache der Größe des Videos</strong>, und kein Umwandler
-      redet Sie davon herunter. Was ein guter tun kann, ist, nichts obendrauf zu
-      verschwenden und Ihnen die drei Einstellungen zu geben, die es tatsächlich
-      entscheiden.
+      Rechnen Sie deshalb mit dem <strong>Zehnfachen der Videogröße</strong>
+      &mdash; kein Umwandler redet Sie da heraus. Was ein guter tun kann, ist,
+      obendrauf nichts zu verschwenden und Ihnen die drei Einstellungen zu geben,
+      an denen es wirklich hängt.
     </p>
   </section>
 
   <section>
     <h2>Die drei Einstellungen, und was jede kostet</h2>
     <p>
-      Alles an der Größe eines GIFs läuft darauf hinaus, wie viele Pixel darin
-      stecken &mdash; und das ist die Länge mal die Rate mal die Fläche eines
-      Einzelbildes.
+      Die Größe eines GIFs läuft am Ende immer darauf hinaus, wie viele Pixel
+      darin stecken: Länge mal Bildrate mal Fläche eines Einzelbildes.
     </p>
     <ul>
       <li>
         <strong>Der Abschnitt &mdash; linear.</strong> Doppelt so lang sind
-        doppelt so viele Einzelbilder und etwa die doppelte Datei. Das ist die,
-        die die meisten schon verstehen, und es lohnt sich, dabei rücksichtslos
-        zu sein: Ein GIF, das seinen Punkt in drei Sekunden macht, ist ein
-        besseres GIF und obendrein ein kleineres.
+        doppelt so viele Einzelbilder und ungefähr die doppelte Datei. Das
+        verstehen die meisten schon, und man darf ruhig rücksichtslos damit sein:
+        Ein GIF, das seinen Witz in drei Sekunden erzählt, ist das bessere GIF
+        &mdash; und obendrein das kleinere.
       </li>
       <li>
-        <strong>Die Breite &mdash; quadratisch.</strong> Die Breite zu halbieren
-        halbiert die Höhe mit, es ist also ein <em>Viertel</em> der Pixel. Von
-        640 auf 320 zu gehen spart nicht etwas weniger als die Hälfte, sondern
-        rund drei Viertel. Das ist die Einstellung, nach der niemand zuerst
-        greift, und die, die sich am besten auszahlt.
+        <strong>Die Breite &mdash; quadratisch.</strong> Wer die Breite halbiert,
+        halbiert die Höhe gleich mit und landet damit bei einem
+        <em>Viertel</em> der Pixel. Von 640 auf 320 spart also nicht knapp die
+        Hälfte, sondern rund drei Viertel. Das ist die Einstellung, an die
+        niemand zuerst denkt, und die, die am meisten bringt.
       </li>
       <li>
         <strong>Die Bildrate &mdash; linear.</strong> Zehn Bilder pro Sekunde
-        sind zwei Drittel der Größe von fünfzehn. Es ist auch die Einstellung,
-        bei der der Verlust am sichtbarsten ist, denn zu langsame Bewegung liest
-        sich als kaputt und nicht als klein.
+        sind zwei Drittel der Größe von fünfzehn. Hier fällt der Verlust
+        allerdings am ehesten auf: Zu langsame Bewegung liest sich als kaputt und
+        nicht als sparsam.
       </li>
     </ul>
     <p>
-      Ein durchgerechnetes Beispiel. Sechs Sekunden eines Handy-Clips in seinen
-      eigenen 1080&times;1920 bei 30 fps sind 180 Einzelbilder zu zwei Millionen
-      Pixeln: rund 350 Millionen Pixel, und das ist kein GIF, das ist eine
-      Geiselnahme. Dieselben sechs Sekunden mit 480 Breite und 12 fps sind 72
-      Einzelbilder zu 400.000 Pixeln &mdash; 30 Millionen, etwa ein Zwölftel
-      &mdash; und es sieht aus wie das, was Menschen mit einem GIF meinen.
+      Einmal durchgerechnet: Sechs Sekunden Handy-Clip in seinen eigenen
+      1080&times;1920 bei 30 fps sind 180 Einzelbilder zu zwei Millionen Pixeln
+      &mdash; rund 350 Millionen Pixel. Das ist kein GIF mehr, das ist eine
+      Zumutung. Dieselben sechs Sekunden mit 480 Pixeln Breite und 12 fps sind 72
+      Einzelbilder zu 400.000 Pixeln, also 30 Millionen und damit etwa ein
+      Zwölftel &mdash; und es sieht nach dem aus, was man landläufig unter einem
+      GIF versteht.
     </p>
   </section>
 
   <section>
-    <h2>Welche Bildrate zu wählen ist</h2>
+    <h2>Welche Bildrate es sein sollte</h2>
     <p>
       Zwölf ist hier die Voreinstellung und überraschend oft die richtige
-      Antwort. Es ist die Rate, die handgezeichnete Animation seit einem
-      Jahrhundert verwendet: schnell genug, dass das Auge sie als
-      zusammenhängende Bewegung liest, langsam genug, dass Sie nicht für
-      Einzelbilder zahlen, die niemand sehen kann.
+      Antwort. Es ist die Rate, mit der handgezeichneter Trickfilm seit einem
+      Jahrhundert arbeitet: schnell genug, dass das Auge zusammenhängende
+      Bewegung sieht, langsam genug, dass Sie nicht für Einzelbilder zahlen, die
+      niemand wahrnimmt.
     </p>
     <ul>
-      <li><strong>5&ndash;8</strong> &mdash; wirkt wie eine Diashow. Passt für
+      <li><strong>5&ndash;8</strong> &mdash; wirkt wie eine Diashow. Taugt für
         einen langsamen Schwenk oder eine Bildschirmaufnahme, in der sich nichts
-        schnell bewegt.</li>
+        Schnelles tut.</li>
       <li><strong>10&ndash;15</strong> &mdash; normal. Liest sich als Bewegung.
-        Fast jedes lohnende GIF liegt hier.</li>
+        Hier liegt praktisch jedes GIF, das die Mühe wert ist.</li>
       <li><strong>20&ndash;25</strong> &mdash; flüssig, und rund doppelt so groß
-        wie 12 für einen Unterschied, den die meisten Betrachter nicht benennen
-        könnten. Lohnt sich bei schneller Bewegung, einem Sportclip, allem mit
-        einem Reißschwenk darin.</li>
+        wie 12 für einen Unterschied, den die meisten nicht benennen könnten.
+        Lohnt sich bei schneller Bewegung, einem Sportclip, allem mit einem
+        Reißschwenk darin.</li>
     </ul>
     <p>
-      Es gibt eine harte Obergrenze, die Sie ruhig kennen dürfen: GIF speichert
-      die Standzeit jedes Einzelbildes in Hundertstelsekunden, und jeder Browser
-      behandelt eine Verzögerung unter zwei Hundertsteln als zehn. 50 Bilder pro
-      Sekunde sind also das echte Maximum, und eine Datei, die 100 verlangt,
-      spielt stillschweigend mit 10. Ein Umwandler, der Ihnen 60 fps anbietet,
-      ignoriert das entweder oder wird Sie gleich überraschen.
+      Eine harte Obergrenze gibt es auch, und die dürfen Sie ruhig kennen: GIF
+      speichert die Standzeit jedes Einzelbildes in Hundertstelsekunden, und
+      jeder Browser behandelt eine Verzögerung unter zwei Hundertsteln als zehn.
+      Das echte Maximum liegt damit bei 50 Bildern pro Sekunde, und eine Datei,
+      die 100 verlangt, spielt klammheimlich mit 10. Wer Ihnen 60 fps anbietet,
+      ignoriert das entweder &mdash; oder wird Sie gleich überraschen.
     </p>
   </section>
 
   <section>
-    <h2>256 Farben, und wofür Dithering da ist</h2>
+    <h2>256 Farben, und wofür Dithering gut ist</h2>
     <p>
-      Die andere Hälfte des Alters dieses Formats: Ein GIF trägt eine Tabelle mit
-      höchstens 256 Farben, und jedes Pixel ist eine Nummer, die darauf zeigt.
-      Ein Videobild hat bis zu sechzehn Millionen. Fast alles davon wird
-      weggeworfen, und wie es weggeworfen wird, ist das meiste dessen, wie ein
-      GIF aussieht.
+      Die andere Hälfte des Formatalters: Ein GIF führt eine einzige Tabelle mit
+      höchstens 256 Farben mit sich, und jedes Pixel ist nur eine Nummer, die
+      darauf zeigt. Ein Videobild hat bis zu sechzehn Millionen. Fast alles davon
+      fliegt raus &mdash; und wie es rausfliegt, macht den größten Teil davon
+      aus, wie ein GIF am Ende aussieht.
     </p>
     <p>
-      Ein guter Umwandler zählt die Farben in <em>Ihrem</em> Clip und wählt 256,
-      die dazu passen, statt einen festen Satz zu nehmen. Eine Aufnahme eines
-      Waldes bekommt 256 Grüntöne; eine Aufnahme eines Sonnenuntergangs 256
-      Orangetöne. Genau das tut das Werkzeug hier, und zwar über jedes
-      Einzelbild des Abschnitts statt nur über das erste &mdash; eine Farbe, die
-      erst am Ende auftaucht, bekommt also trotzdem einen Platz.
+      Ein guter Umwandler zählt die Farben in <em>Ihrem</em> Clip und wählt 256
+      aus, die dazu passen, statt einen festen Satz zu nehmen. Eine Waldaufnahme
+      bekommt 256 Grüntöne, ein Sonnenuntergang 256 Orangetöne. Genau das tut das
+      Werkzeug hier &mdash; und zwar über alle Einzelbilder des Abschnitts hinweg
+      statt nur über das erste, damit auch eine Farbe, die erst am Ende auftaucht,
+      noch einen Platz bekommt.
     </p>
     <p>
-      <strong>Dithering</strong> ist das, was dort passiert, wo die benötigte
-      Farbe trotzdem fehlt. Statt eine ganze Fläche auf die nächstgelegene
-      verfügbare Farbe zu runden &mdash; was einen weichen Himmel in vier flache
-      Bänder mit sichtbaren Stufen dazwischen verwandelt &mdash;, wechselt es die
-      beiden nächstgelegenen Farben in einem feinen Muster ab, und aus normalem
-      Betrachtungsabstand mischt Ihr Auge sie zu der, die es nicht gibt.
+      <strong>Dithering</strong> springt dort ein, wo die gebrauchte Farbe
+      trotzdem fehlt. Statt eine ganze Fläche auf die nächstgelegene verfügbare
+      Farbe zu runden &mdash; was aus einem weichen Himmel vier flache Bänder mit
+      sichtbaren Stufen dazwischen macht &mdash;, wechselt es die beiden
+      nächstgelegenen Farben in einem feinen Muster ab. Aus normalem Abstand
+      mischt Ihr Auge daraus die Farbe, die es gar nicht gibt.
     </p>
     <ul>
-      <li><strong>Lassen Sie es an</strong> für alles Fotografische: Himmel,
+      <li><strong>Lassen Sie es an</strong> bei allem Fotografischen: Himmel,
         Haut, Verläufe, Schatten, Film.</li>
-      <li><strong>Schalten Sie es ab</strong> für flache Farbflächen:
+      <li><strong>Schalten Sie es ab</strong> bei einfarbigen Flächen:
         Bildschirmaufnahmen, Strichzeichnungen, Logos, Zeichentrick, alles mit
-        großen Flächen eines Tons. Da gibt es keinen Verlauf zu schützen, und die
+        großen Flächen eines Tons. Da gibt es keinen Verlauf zu retten, und die
         Datei wird ohne kleiner und sauberer.</li>
     </ul>
     <p>
-      Ein Detail, das wissenswert ist, wenn Sie Umwandler vergleichen. Die
-      naheliegende Art zu dithern &mdash; Fehlerverteilung, die die meisten
-      Bildbearbeitungsprogramme verwenden &mdash; macht das Ergebnis jedes Pixels
-      von den Pixeln ringsherum abhängig. In einer Animation heißt das, dass ein
-      unbewegter Hintergrund in jedem Einzelbild anders dithert, also sichtbar
-      kribbelt &mdash; und jedes Einzelbild muss vollständig gespeichert werden,
-      weil sich technisch jedes Pixel geändert hat. Die Alternative, ein
-      geordnetes Dithering, hängt nur davon ab, wo ein Pixel liegt, ein stehender
-      Hintergrund bleibt also vollkommen still. Das ist es, was dieses Werkzeug
-      verwendet, und es ist der Grund, warum seine Dateien kleiner und ruhiger
-      zugleich sind.
+      Ein Detail, das beim Vergleichen von Umwandlern hilft. Die naheliegende Art
+      zu dithern &mdash; die Fehlerverteilung, mit der die meisten
+      Bildbearbeitungsprogramme arbeiten &mdash; lässt das Ergebnis jedes Pixels
+      von seinen Nachbarn abhängen. In einer Animation heißt das: Ein
+      unbewegter Hintergrund dithert in jedem Einzelbild anders und fängt
+      sichtbar an zu kribbeln &mdash; und jedes Einzelbild muss vollständig
+      gespeichert werden, weil sich technisch gesehen jedes Pixel geändert hat.
+      Die Alternative, ein geordnetes Dithering, hängt nur davon ab, wo ein Pixel
+      liegt; ein stehender Hintergrund bleibt damit vollkommen ruhig. Das benutzt
+      dieses Werkzeug, und deshalb werden seine Dateien zugleich kleiner und
+      ruhiger.
     </p>
   </section>
 
   <section>
     <h2>Wann Sie besser gar kein GIF machen</h2>
     <p>
-      Eine Frage, die sich lohnt, denn die ehrliche Antwort lautet oft
-      &bdquo;lieber nicht&ldquo;. Ein stummes, endlos laufendes MP4 oder WebM ist
+      Die Frage lohnt sich, denn ehrlicherweise lautet die Antwort oft
+      &bdquo;lieber nicht&ldquo;. Ein stummes MP4 oder WebM in Endlosschleife ist
       etwa ein Zehntel so groß wie dieselbe Animation als GIF, spielt genauso ab
-      und ist ohnehin das, worin jede soziale Plattform Ihr GIF nach dem Hochladen
-      umwandelt.
+      &mdash; und ist ohnehin das, worin jede soziale Plattform Ihr GIF nach dem
+      Hochladen umwandelt.
     </p>
-    <p>Behalten Sie das GIF dort, wo das Ziel wirklich eines braucht:</p>
+    <p>Beim GIF bleiben Sie, wo das Ziel wirklich eines verlangt:</p>
     <ul>
-      <li>irgendwo, wo nur ein Bild angenommen wird &mdash; eine Menge Chat-,
-        Forum-, Wiki- und E-Mail-Software;</li>
-      <li>eine README oder eine Dokumentationsseite, wo ein GIF direkt abspielt
-        und ein Video einen Player braucht;</li>
-      <li>eine Präsentation oder ein Dokument, das auch offline in Bewegung
+      <li>überall dort, wo nur ein Bild angenommen wird &mdash; in einer Menge
+        Chat-, Foren-, Wiki- und E-Mail-Software;</li>
+      <li>in einer README oder auf einer Dokumentationsseite, wo ein GIF direkt
+        losläuft und ein Video einen Player braucht;</li>
+      <li>in einer Präsentation oder einem Dokument, das auch offline in Bewegung
         bleiben muss;</li>
-      <li>ein Emoji, ein Sticker, eine Reaktion &mdash; klein genug, dass nichts
-        von der Rechnerei oben eine Rolle spielt.</li>
+      <li>als Emoji, Sticker oder Reaktion &mdash; klein genug, dass die ganze
+        Rechnerei von oben keine Rolle spielt.</li>
     </ul>
     <p>
       Wo der Ton zählt, beantwortet sich die Frage von selbst: GIF hatte nie Ton
-      und wird nie welchen haben. Schneiden Sie stattdessen das Video &mdash; der
-      <a href="../../video-schneiden/">Video-Schneider</a> nimmt einen Abschnitt
-      heraus, ohne ein einziges Einzelbild davon neu zu kodieren.
+      und wird nie welchen bekommen. Schneiden Sie dann lieber das Video &mdash;
+      der <a href="../../video-schneiden/">Video-Schneider</a> nimmt einen
+      Abschnitt heraus, ohne auch nur ein Einzelbild neu zu kodieren.
     </p>
   </section>
 
   <section>
     <h2>Unter eine Größengrenze kommen</h2>
     <p>
-      Der häufigste Grund, ein GIF überhaupt zu justieren, ist eine Grenze am
-      anderen Ende. Grob in der Reihenfolge, wie sehr sie beißen:
+      Der häufigste Anlass, überhaupt an einem GIF zu schrauben, ist eine Grenze
+      am anderen Ende. Grob danach geordnet, wie hart sie zubeißen:
     </p>
     <ul>
       <li><strong>E-Mail</strong> &mdash; 10 bis 25 MB für die ganze Nachricht,
-        und ein Anhang nahe daran wird von irgendetwas unterwegs entfernt oder
-        zurückgewiesen. Zielen Sie deutlich darunter.</li>
+        und ein Anhang nahe an dieser Grenze wird unterwegs von irgendetwas
+        entfernt oder zurückgewiesen. Zielen Sie deutlich darunter.</li>
       <li><strong>Chat und Foren</strong> &mdash; üblicherweise 8 bis 10 MB,
-        manchmal deutlich weniger für eine eingebettete Vorschau statt eines
-        Downloads.</li>
+        manchmal deutlich weniger, wenn es statt eines Downloads eine
+        eingebettete Vorschau geben soll.</li>
       <li><strong>Eine GitHub-README</strong> &mdash; 10 MB je Datei, und alles
-        über ein paar Megabyte lässt die Seite auf einem Telefon kaputt
+        jenseits von ein paar Megabyte lässt die Seite auf einem Handy kaputt
         wirken.</li>
-      <li><strong>Sticker- und Emoji-Plätze</strong> &mdash; oft ein paar hundert
-        Kilobyte, was eine kleine Breite und einen kurzen Abschnitt bedeutet und
-        nicht eine niedrigere Bildrate.</li>
+      <li><strong>Sticker- und Emoji-Plätze</strong> &mdash; oft nur ein paar
+        hundert Kilobyte. Das heißt: kleine Breite und kurzer Abschnitt, nicht
+        niedrigere Bildrate.</li>
     </ul>
     <p>
-      Die Reihenfolge zum Ausprobieren, wenn Sie darüber liegen: den Abschnitt
-      kürzen, dann die Breite halbieren, dann die Rate senken, dann das Dithering
-      abschalten. Die ersten beiden sind mehr wert als die letzten beiden
-      zusammen.
+      Liegen Sie darüber, probieren Sie es in dieser Reihenfolge: Abschnitt
+      kürzen, Breite halbieren, Rate senken, Dithering abschalten. Die ersten
+      beiden bringen mehr als die letzten beiden zusammen.
     </p>
   </section>
 
   <section>
     <h2>Nichts davon braucht einen Upload</h2>
     <p>
-      Ein Video in ein GIF umzuwandeln heißt dekodieren, skalieren, Farben zählen
-      und komprimieren &mdash; vier Dinge, die ein Browser seit Jahren von allein
-      kann. Das oben verlinkte Werkzeug erledigt alles davon auf Ihrem Gerät: Die
-      Datei wird von Ihrer Festplatte gelesen, die Einzelbilder werden von Ihrem
-      Browser dekodiert, und das GIF wird im Arbeitsspeicher zusammengesetzt und
-      an Ihre Downloads übergeben.
+      Ein Video in ein GIF zu verwandeln heißt: dekodieren, skalieren, Farben
+      zählen, komprimieren &mdash; vier Dinge, die ein Browser seit Jahren aus
+      eigener Kraft kann. Das oben verlinkte Werkzeug erledigt sie alle auf Ihrem
+      Gerät: Die Datei wird von Ihrer Festplatte gelesen, die Einzelbilder
+      dekodiert Ihr Browser, und das GIF entsteht im Arbeitsspeicher und wandert
+      von dort in Ihre Downloads.
     </p>
     <p>
-      Und darum lohnt es sich hier mehr zu kümmern als sonst. Die Clips, aus
-      denen Menschen GIFs machen, sind persönliche &mdash; ein Moment aus einem
-      Familienvideo, eine Bildschirmaufnahme von etwas bei der Arbeit, ein paar
-      Sekunden eines Gesprächs. Ein Umwandler, der die hochgeladen haben will,
-      bittet um eine Kopie davon &mdash; und es gibt keinen technischen Grund
-      mehr, Ja zu sagen.
+      Und darauf zu achten lohnt sich hier mehr als sonst. Die Clips, aus denen
+      GIFs werden, sind persönliche: ein Moment aus einem Familienvideo, eine
+      Bildschirmaufnahme von etwas aus der Arbeit, ein paar Sekunden aus einem
+      Gespräch. Ein Umwandler, der die hochgeladen haben will, bittet um eine
+      Kopie davon &mdash; und einen technischen Grund, Ja zu sagen, gibt es
+      längst nicht mehr.
     </p>
   </section>

--- a/locales/de/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/de/pages/guides/turn-a-video-into-a-gif.toml
@@ -4,14 +4,14 @@
 
 nav = "Aus einem Video ein GIF"
 title = "Aus einem Video ein GIF machen (und es klein halten)"
-description = "Welchen Abschnitt, welche Breite und welche Bildrate Sie wählen sollten, warum ein GIF eines Videos zehnmal so groß ist wie das Video, und wann Sie überhaupt eines nehmen sollten."
-heading = "Wie Sie aus einem Video ein GIF machen"
+description = "Welchen Abschnitt, welche Breite und welche Bildrate Sie wählen sollten, warum ein GIF zehnmal so groß wird wie das Video, aus dem es stammt, und wann sich ein GIF überhaupt lohnt."
+heading = "So machen Sie aus einem Video ein GIF"
 lede = """
-    Ein GIF ist ein Format von 1987, das ganze Bilder speichert und keine
-    Bewegung &mdash; eines aus einem Video ist deshalb immer groß. Hier steht,
-    welche der drei Einstellungen Sie bewegen sollten, wenn es zu groß ist, und
-    wie viel jede davon bringt."""
+    GIF ist ein Format von 1987, das ganze Bilder speichert und keine Bewegung
+    &mdash; eines aus einem Video wird deshalb immer groß. Hier steht, an
+    welcher der drei Einstellungen Sie drehen sollten, wenn es zu groß gerät,
+    und wie viel jede davon bringt."""
 updated = "20. August 2026"
 og_title = "Aus einem Video ein GIF machen, und es klein halten"
-og_description = "Die drei Einstellungen, die die Größe eines GIFs bestimmen, was jede davon kostet, und wann ein GIF die ganz falsche Antwort ist."
+og_description = "Die drei Einstellungen, an denen die Größe eines GIFs hängt, was jede davon kostet und wann ein GIF die vollkommen falsche Antwort ist."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"

--- a/locales/de/pages/guides/turn-images-into-a-video.html
+++ b/locales/de/pages/guides/turn-images-into-a-video.html
@@ -2,54 +2,54 @@
     <h2>Die kurze Antwort</h2>
     <p>
       Öffnen Sie <a href="../../bilder-in-video-umwandeln/">Bilder in Video</a>,
-      ziehen Sie die Bilder hinein, bringen Sie sie in die Reihenfolge, legen Sie
-      fest, wie lange jedes stehen bleibt, und erzeugen Sie das Video. Sie
-      bekommen ein MP4 mit H.264-Video, das praktisch überall abspielt.
+      ziehen Sie die Bilder hinein, bringen Sie sie in die richtige Reihenfolge,
+      legen Sie fest, wie lange jedes stehen bleibt, und erzeugen Sie das Video.
+      Heraus kommt ein MP4 mit H.264-Video, das praktisch überall abspielt.
     </p>
     <p>
       Die beiden Einstellungen, die am häufigsten einen zweiten Durchgang nötig
-      machen, sind die Standzeit und die Auflösung &mdash; und es lohnt sich,
+      machen, sind die Standzeit und die Auflösung &mdash; und es zahlt sich aus,
       sie vor dem ersten Rendern zu verstehen statt danach.
     </p>
   </section>
 
   <section>
-    <h2>Bildrate und Standzeit sind nicht dasselbe</h2>
+    <h2>Bildrate und Standzeit sind zweierlei</h2>
     <p>
-      Das ist die Verwechslung, die Menschen einen zweiten Render kostet.
+      An dieser Verwechslung scheitert der erste Durchgang am häufigsten.
     </p>
     <p>
-      Die <strong>Standzeit</strong> ist, wie lange jedes Bild auf dem Schirm
-      bleibt. Das ist die Einstellung, um die es Ihnen wirklich geht. Drei
-      Sekunden sind ein bequemer Standardwert für eine Diashow, die jemand
-      ansieht; ein bis zwei Sekunden wirken flott; alles über fünf zieht sich,
-      sofern nicht jemand darüber spricht.
+      Die <strong>Standzeit</strong> legt fest, wie lange jedes Bild auf dem
+      Bildschirm bleibt. Das ist die Einstellung, um die es Ihnen eigentlich
+      geht. Drei Sekunden sind ein bequemer Standardwert für eine Diashow, die
+      jemand anschaut; ein bis zwei Sekunden wirken flott; alles jenseits von
+      fünf zieht sich, sofern nicht jemand dazu erzählt.
     </p>
     <p>
-      Die <strong>Bildrate</strong> ist, wie oft pro Sekunde das Video dieses
-      Bild wiederholt. Am Aussehen der Diashow ändert sie nichts &mdash; ein
-      Standbild, das drei Sekunden steht, sieht bei 24 Bildern pro Sekunde
-      genauso aus wie bei 60 &mdash;, an Dateigröße und Kodierzeit aber eine
-      ganze Menge.
+      Die <strong>Bildrate</strong> legt fest, wie oft pro Sekunde das Video
+      dieses eine Bild wiederholt. Am Aussehen der Diashow ändert sie gar nichts
+      &mdash; ein Standbild, das drei Sekunden steht, sieht bei 24 Bildern pro
+      Sekunde genauso aus wie bei 60 &mdash;, an Dateigröße und Kodierzeit
+      dagegen eine ganze Menge.
     </p>
     <p>
-      Für eine schlichte Diashow wählen Sie also eine niedrige Bildrate. 24 oder
-      30 sind reichlich. Höher zu gehen lohnt nur, wenn Bewegung im Video ist:
-      ein Schwenk oder Zoom über jedes Foto, oder eine Überblendung dazwischen
-      &mdash; dort zeigt sich eine niedrige Bildrate als sichtbares Ruckeln.
+      Für eine schlichte Diashow nehmen Sie deshalb eine niedrige Bildrate; 24
+      oder 30 sind reichlich. Höher zu gehen lohnt nur, wenn Bewegung im Spiel
+      ist: ein Schwenk oder Zoom über jedes Foto oder eine Überblendung
+      dazwischen. Da zeigt sich eine niedrige Bildrate als sichtbares Ruckeln.
     </p>
   </section>
 
   <section>
-    <h2>Auflösung, und Bilder im falschen Format</h2>
+    <h2>Auflösung, und was mit Bildern im falschen Format geschieht</h2>
     <p>
-      Ein Video hat über seine ganze Länge eine einzige Bildgröße. Ihre Fotos
-      teilen sich mit ziemlicher Sicherheit nicht alle eine, also muss mit denen,
-      die nicht hineinpassen, etwas geschehen &mdash; und dieses Etwas ist die
+      Ein Video hat über seine ganze Länge genau eine Bildgröße. Ihre Fotos
+      teilen sich mit Sicherheit nicht alle dieselbe &mdash; mit denen, die nicht
+      hineinpassen, muss also etwas geschehen. Und dieses Etwas ist die
       Entscheidung, die man bewusst treffen sollte.
     </p>
     <p>
-      Fangen Sie damit an, die Auflösung danach zu wählen, wohin das Video geht:
+      Wählen Sie die Auflösung zuerst danach, wohin das Video geht:
     </p>
     <ul>
       <li>
@@ -58,42 +58,41 @@
       </li>
       <li>
         <strong>1080&times;1920</strong> &mdash; dieselben Zahlen andersherum
-        &mdash; für ein Ziel, das zuerst aufs Telefon schaut: Stories, Reels,
+        &mdash; für ein Ziel, das zuerst aufs Handy schaut: Stories, Reels,
         Shorts.
       </li>
       <li>
         <strong>3840&times;2160</strong> nur dann, wenn die Bilder wirklich so
-        viel Detail haben und das Ziel es auch zeigt. Es sind viermal so viele
-        Pixel, viermal die Kodierzeit und ungefähr viermal die Datei.
+        viel Detail hergeben und das Ziel es auch zeigt. Es sind viermal so viele
+        Pixel, viermal die Kodierzeit und ungefähr die vierfache Datei.
       </li>
     </ul>
     <p>
-      Entscheiden Sie dann, was mit den Abweichlern passiert. Jedes Bild in den
+      Danach entscheiden Sie, was mit den Abweichlern passiert. Jedes Bild in den
       Rahmen einzupassen behält es vollständig und lässt Balken an den Seiten
       &mdash; sicher, und die richtige Antwort, wenn die Bilder wichtiger sind
-      als die Präsentation. Den Rahmen auszufüllen und den Überstand
-      abzuschneiden sieht besser aus und schneidet manchen davon oben etwas ab.
-      Hoch- und Querformatfotos in einem Video zu mischen ist der Fall, für den
-      es keine gute Antwort gibt; vorher zu entscheiden, in welche Richtung Sie
-      lieber falsch liegen, erspart einen zweiten Render.
+      als die Wirkung. Den Rahmen auszufüllen und den Überstand abzuschneiden
+      sieht besser aus und köpft manche Aufnahme. Hoch- und Querformat in einem
+      Video zu mischen ist der Fall, für den es keine gute Antwort gibt &mdash;
+      und vorher zu entscheiden, in welche Richtung Sie lieber falsch liegen,
+      erspart Ihnen den zweiten Durchgang.
     </p>
   </section>
 
   <section>
-    <h2>Die Reihenfolge, und die Dateinamen-Falle</h2>
+    <h2>Die Reihenfolge, und die Falle mit den Dateinamen</h2>
     <p>
       Wie bei jeder Stapelverarbeitung sortieren sich Dateinamen anders, als Sie
-      gezählt haben. <code>foto2.jpg</code> kommt in einer alphabetischen
-      Sortierung nach <code>foto10.jpg</code>, weil Zeichen für Zeichen
-      verglichen wird.
+      gezählt haben. <code>foto2.jpg</code> kommt alphabetisch nach
+      <code>foto10.jpg</code>, weil Zeichen für Zeichen verglichen wird.
     </p>
     <p>
       Nach Aufnahmedatum zu sortieren ist bei Fotos von einem Ereignis meist
-      richtig, denn Sie haben sie in der Reihenfolge aufgenommen, in der es
-      geschah. Die Kacheln zu ziehen ist richtig für alles, wo die Geschichte
-      nicht chronologisch ist. Prüfen Sie es vor dem Rendern: Das Video ist das
-      eine Erzeugnis, bei dem eine Korrektur der Reihenfolge bedeutet, die ganze
-      Arbeit noch einmal zu machen.
+      richtig &mdash; Sie haben sie ja in der Reihenfolge aufgenommen, in der es
+      passierte. Die Kacheln von Hand zu ziehen ist richtig für alles, wo die
+      Geschichte nicht chronologisch verläuft. Prüfen Sie es vor dem Rendern: Das
+      Video ist das eine Erzeugnis, bei dem eine korrigierte Reihenfolge die
+      ganze Arbeit noch einmal bedeutet.
     </p>
   </section>
 
@@ -101,99 +100,99 @@
     <h2>Es gibt keine Tonspur, und das ist keine Kleinigkeit</h2>
     <p>
       Das MP4, das dieses Werkzeug schreibt, hat eine einzige Videospur und
-      überhaupt keine Tonspur. Braucht Ihre Diashow Musik oder eine Erzählstimme,
-      brauchen Sie für diesen Schritt ein Schnittprogramm.
+      überhaupt keine Tonspur. Braucht Ihre Diashow Musik oder eine
+      Erzählstimme, brauchen Sie für diesen Schritt ein Schnittprogramm.
     </p>
     <p>
-      Es lohnt sich zu wissen, warum, und nicht nur, dass: Ton hinzuzufügen
-      heißt, eine Musikdatei zu dekodieren, sie nach AAC zu kodieren und sie im
-      Container mit dem Video zu verschachteln. Alle drei sind echte Arbeit, und
-      schlecht gemacht ergeben sie eine Datei, die beim Abspielen aus dem Takt
-      läuft. Es steht auf der Liste, statt halbfertig dazustehen.
+      Warum das so ist, lohnt die Erklärung. Ton hinzuzufügen heißt: eine
+      Musikdatei dekodieren, sie nach AAC kodieren und sie im Container mit dem
+      Video verschachteln. Alle drei Schritte sind echte Arbeit, und schlecht
+      gemacht ergeben sie eine Datei, die beim Abspielen aus dem Takt läuft.
+      Deshalb steht es auf der Liste, statt halbfertig herumzustehen.
     </p>
     <p>
-      Ein praktischer Hinweis, falls Sie die Musik hinterher hinzufügen: Wählen
-      Sie zuerst das Stück und stellen Sie die Standzeit je Bild so ein, dass die
-      Diashow ungefähr auf die Länge des Liedes kommt. Die Musik auf das Video zu
-      kürzen klingt immer schlechter, als das Video auf die Musik zu legen.
+      Ein praktischer Hinweis, falls Sie die Musik hinterher hinzufügen: Suchen
+      Sie erst das Stück aus und stellen Sie die Standzeit je Bild so ein, dass
+      die Diashow ungefähr auf die Länge des Liedes kommt. Die Musik auf das
+      Video zu kürzen klingt immer schlechter, als das Video auf die Musik zu
+      legen.
     </p>
   </section>
 
   <section>
     <h2>Was herauskommt, und was zu tun ist, wenn es nicht abspielt</h2>
     <p>
-      MP4 mit H.264 ist das Ziel, und es ist die am breitesten abspielbare
-      Kombination, die es gibt. In einem Browser ohne WebCodecs weicht das
-      Werkzeug darauf aus, stattdessen WebM aufzuzeichnen &mdash; dasselbe
-      Material in einem Container, den weniger Schnittprogramme und soziale
-      Plattformen annehmen.
+      Das Ziel ist MP4 mit H.264, die am breitesten abspielbare Kombination, die
+      es gibt. In einem Browser ohne WebCodecs weicht das Werkzeug darauf aus,
+      stattdessen WebM aufzuzeichnen &mdash; dasselbe Material in einem
+      Container, den weniger Schnittprogramme und soziale Plattformen annehmen.
     </p>
     <p>
-      Landen Sie bei einem WebM und irgendetwas weist es zurück, ist die Lösung
-      ein Browser mit WebCodecs und keine Umwandlung: Aktuelle Fassungen von
-      Chrome, Edge und Safari können es alle. Neu zu rendern ist besser als
-      umzuwandeln, denn Umwandeln heißt eine weitere Generation verlustbehafteter
-      Kodierung.
+      Landen Sie bei einem WebM und irgendetwas weist es zurück, hilft ein
+      Browser mit WebCodecs und keine Umwandlung: Aktuelle Fassungen von Chrome,
+      Edge und Safari können es alle. Neu zu rendern ist besser als umzuwandeln,
+      denn Umwandeln heißt eine weitere Generation verlustbehafteter Kodierung.
     </p>
     <p>
-      Im Werkzeug ist keine Grenze dafür eingebaut, wie viele Bilder Sie
-      verwenden können. Die Obergrenze ist der Arbeitsspeicher Ihres Geräts, denn
-      das fertige Video wird dort zusammengesetzt, bevor Sie es herunterladen
-      &mdash; eine lange 4K-Diashow ist das Erste, was sie zu spüren bekommt.
+      Eine Grenze für die Anzahl der Bilder ist im Werkzeug nicht eingebaut. Die
+      Obergrenze setzt der Arbeitsspeicher Ihres Geräts, denn dort wird das
+      fertige Video zusammengesetzt, bevor Sie es herunterladen &mdash; eine lange
+      4K-Diashow bekommt das als Erstes zu spüren.
     </p>
   </section>
 
   <section>
     <h2>Die Datei kleiner machen</h2>
     <p>
-      Ist das Ergebnis zu groß für sein Ziel, in der Reihenfolge dessen, was
-      wirklich hilft:
+      Ist das Ergebnis zu groß für sein Ziel, hier die Hebel in der Reihenfolge,
+      in der sie wirklich etwas bringen:
     </p>
     <p>
       <strong>Die Bildrate senken.</strong> Bei einer Diashow aus Standbildern
-      kostet das nichts Sichtbares und ist die größte einzelne Ersparnis, die zu
+      kostet das nichts Sichtbares und ist die größte Einzelersparnis, die zu
       haben ist.
     </p>
     <p>
       <strong>Die Auflösung senken.</strong> 1080p statt 4K ist ein Viertel der
-      Pixel, und auf einem Telefonbildschirm merkt es niemand.
+      Pixel, und auf einem Handybildschirm merkt es niemand.
     </p>
     <p>
       <strong>Es kürzen.</strong> Drei Sekunden je Bild statt fünf sind
-      40&nbsp;% weniger Länge und 40&nbsp;% weniger Datei &mdash; und meist die
-      bessere Diashow.
+      40&nbsp;% weniger Laufzeit und 40&nbsp;% weniger Datei &mdash; und meist
+      die bessere Diashow.
     </p>
     <p>
-      Die Ausgangsfotos vorher zu verkleinern hilft kaum. Das Video wird ohnehin
-      in der von Ihnen gewählten Auflösung kodiert, ein Foto mit 4000 Pixeln und
-      eines mit 2000 ergeben in einem 1080p-Video also fast dieselbe Byte-Zahl.
-      Es macht die Kodierung schneller, und es verschiebt jene
-      Speicher-Obergrenze.
+      Die Ausgangsfotos vorher zu verkleinern hilft dagegen kaum. Kodiert wird
+      das Video ohnehin in der Auflösung, die Sie gewählt haben; ein Foto mit
+      4000 Pixeln und eines mit 2000 ergeben in einem 1080p-Video fast dieselbe
+      Byte-Zahl. Schneller wird das Kodieren dadurch schon &mdash; und die
+      Speichergrenze von oben rückt weiter weg.
     </p>
   </section>
 
   <section>
-    <h2>Warum das keinen Server braucht - mit einer genannten Ausnahme</h2>
+    <h2>Warum das keinen Server braucht - mit einer offen genannten Ausnahme</h2>
     <p>
       Video zu kodieren war einmal der klarste Fall fürs Hochladen: Browser
-      konnten es nicht, und eine Maschine mit FFmpeg schon. WebCodecs hat das
+      konnten es nicht, eine Maschine mit FFmpeg schon. WebCodecs hat das
       geändert, indem es den Hardware-Encoder zugänglich macht, der ohnehin in
-      Ihrem Gerät steckt &mdash; denselben, mit dem Ihr Telefon Video in Echtzeit
-      aufnimmt. Die Einzelbilder zusammenzusetzen ist eine Leinwand. Keiner der
-      beiden Schritte braucht etwas anderes als Ihre eigene Hardware.
+      Ihrem Gerät steckt &mdash; denselben, mit dem Ihr Handy Video in Echtzeit
+      aufnimmt. Die Einzelbilder zusammenzusetzen ist Sache einer Leinwand.
+      Keiner der beiden Schritte braucht mehr als Ihre eigene Hardware.
     </p>
     <p>
-      Eine Ausnahme bei genau diesem Werkzeug, ausgesprochen statt vergraben: Die
-      optionale Funktion &bdquo;von einer Webadresse hinzufügen&ldquo; holt ein
-      Bild von einer Adresse, die Sie einfügen, und der Server an jener Adresse
-      sieht Ihre IP und was Sie angefordert haben. Das gehört zur Funktion und
-      ist kein Fehler darin, und es ist der einzige Netzschritt im ganzen
-      Werkzeug. Benutzen Sie sie nicht, und es verlässt überhaupt nichts Ihr
-      Gerät.
+      Eine Ausnahme gibt es bei genau diesem Werkzeug, und sie gehört
+      ausgesprochen statt vergraben: Die Funktion &bdquo;von einer Webadresse
+      hinzufügen&ldquo; holt ein Bild von einer Adresse, die Sie einfügen, und
+      der Server dahinter sieht Ihre IP und was Sie angefordert haben. Das gehört
+      zur Funktion und ist kein Fehler darin &mdash; und es ist der einzige
+      Netzschritt im ganzen Werkzeug. Benutzen Sie sie nicht, dann verlässt
+      überhaupt nichts Ihr Gerät.
     </p>
     <p>
+      Vier Proben, die Ihnen dasselbe über jedes andere Werkzeug verraten
+      &mdash; dieses eingeschlossen &mdash;, stehen in
       <a href="../ist-das-hochladen-von-dateien-sicher/">Ist es sicher, Dateien
-      zu Online-Konvertern hochzuladen?</a> nennt vier Prüfungen, die Ihnen
-      dasselbe über jedes Werkzeug sagen &mdash; auch über dieses.
+      zu Online-Konvertern hochzuladen?</a>
     </p>
   </section>

--- a/locales/de/pages/guides/turn-images-into-a-video.toml
+++ b/locales/de/pages/guides/turn-images-into-a-video.toml
@@ -4,13 +4,14 @@
 
 nav = "Bilder in ein Video"
 title = "Aus einem Ordner voller Bilder ein Video machen"
-description = "Eine MP4-Diashow aus Fotos machen: was Bildrate und Standzeit wirklich steuern, wie Sie mit Bildern im falschen Format umgehen, und warum das Ergebnis keine Tonspur hat."
-heading = "Wie Sie aus einem Ordner voller Bilder ein Video machen"
+description = "Eine MP4-Diashow aus Fotos bauen: was Bildrate und Standzeit wirklich steuern, was mit Bildern im falschen Format geschieht und warum das Ergebnis keine Tonspur hat."
+heading = "So machen Sie aus einem Ordner voller Bilder ein Video"
 lede = """
-    Eine Diashow ist schnell gemacht und ebenso schnell zweimal gerendert, weil
-    zwei der Einstellungen nicht das bedeuten, wonach sie klingen. Hier steht,
-    was jede davon steuert und wofür Sie sich entscheiden sollten."""
+    Eine Diashow ist schnell gebaut &mdash; und ebenso schnell zweimal
+    gerendert, weil zwei der Einstellungen nicht das bedeuten, wonach sie
+    klingen. Hier steht, was jede davon steuert und wofür Sie sich entscheiden
+    sollten."""
 updated = "20. August 2026"
-og_title = "Wie Sie aus einem Ordner voller Bilder ein Video machen"
-og_description = "Was Bildrate und Standzeit wirklich steuern, wie Sie mit Bildern im falschen Format umgehen, und warum es keine Tonspur gibt."
+og_title = "So machen Sie aus einem Ordner voller Bilder ein Video"
+og_description = "Was Bildrate und Standzeit wirklich steuern, was mit Bildern im falschen Format geschieht und warum es keine Tonspur gibt."
 og_image_alt = "abox.tools - Werkzeuge, die keinen Server anfassen"


### PR DESCRIPTION
The fifteen translated guide bodies under `locales/de/pages/guides` tracked the English sentence for sentence — same paragraph breaks, same clause order, and a good number of constructions that were English shapes wearing German words ("Die Standzeit ist, wie lange…", "Worum eine Größengrenze wirklich bittet", "Es lohnt sich zu wissen, warum, und nicht nur, dass"). Read straight through they were comprehensible and audibly translated.

This rewrites all fifteen from the point rather than from the sentence, in the voice the German tool pages already established: Sie throughout, `&bdquo;…&ldquo;`, decimal commas, and idiom a German writer would reach for unprompted. Sentence boundaries and paragraph breaks moved where German wanted them. Every technical claim, every href and every `{{ }}` substitution stayed exactly where it was, and `[slugs]` was not touched.

### Voice changes worth naming

- **`Wie Sie X machen` → `So machen Sie X`.** "How to…" as an h1 does not survive translation; "So …" is what German how-to writing says. Applied to every heading that had one.
- **`Telefon` → `Handy`.** A Telefon is a landline. Every phone in these guides is a Handy or a Smartphone now.
- **Real German UI strings.** Windows Explorer views are Mittelgroße Symbole / Extra große Symbole, Get Info is Informationen, the iOS home screen is the Home-Bildschirm — and a splash screen is a Splashscreen, which the previous translation had collapsed into the same word as the home screen.
- **Two examples swapped** for ones that land in German, with the technical claim unchanged: the GIF guide's "it is a hostage situation" (a joke that does not cross the border) and the EXIF guide's London coordinates.

### Fixes to the existing German, not just its style

- `convert-an-svg-to-png`: "eine Datei, die sich ihre Schrift … holt, ergeht es noch schlechter" — wrong case, ungrammatical.
- `convert-heic-to-jpg`: "Was das kostet, ist es wert, unverblümt gesagt zu werden" — a calque that is not a German sentence.
- `make-a-qr-code`: "ob diese Seite irgendwohin hatte, wo sie es hinschicken konnte" — same.
- `embed-an-image-in-css`: two `<pre>` elements had lost the `class="wrap"` the English source carries. The long base64 and percent-encoded data URIs inside them would have overflowed the page on a phone.
- `make-a-qr-code`: the title claimed a code "der jedes Mal scannt" — `scannen` is not intransitive in German.

### Found in the English source rather than in the translation

- **`guides/crop-a-video`** heads a section "Crop before you do anything else" and its first sentence says "If a clip needs both trimming and cropping, **trim first**." The heading contradicts the section. The German heading now says what the section says ("Erst kürzen, dann zuschneiden — und beides so früh wie möglich"); the English is untouched and still wrong.
- **`guides/make-a-favicon`** says sixteen pixels is "a grid of 256 dots in total, fewer than the letters in this sentence". That sentence runs about 130 characters, so 256 is more, not fewer. The German drops the comparison and keeps the measurement (16 × 16, 256 dots, ~4 mm).
- **`guides/trim-a-video`** links the trim tool as "Video Cutter"; `guides/crop-a-video` links the same tool as "Video Trimmer". One of the two English link texts is wrong. (German uses Video-Schneider in both.)
- **`guides/trim-a-video`**: "and worth knowing is supported" is missing a word.

### Notes

- Branch is cut from `main` at 16add3c rather than from `claude/website-i18n-per-page` as originally planned — #59 and #60 landed on main mid-session, so main already contains the per-page-completeness and id-matching work this was meant to stack on. There is nothing left to stack; this merges on its own.
- `python build.py --clean --out dist-check` exits 0 with the link check passing, and `python -m unittest discover -s tests/python -t .` reports 314 tests, OK.
- Diff is 30 files, all under `locales/de/pages/guides/`. The German guides that exist only in English (`make-a-gif-from-images`, `make-a-passport-photo`, `reverse-a-video`, `format-json-without-uploading-it`, and the newer `grab-a-frame-from-a-video`) are untouched and still fall back cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
