### PR TITLE
Make the audio trimmer's progress bar and Cancel button real, and stop a mark landing 0.9s early

### DIFF
--- a/tests/js/trim-audio.test.js
+++ b/tests/js/trim-audio.test.js
@@ -27,8 +27,8 @@ import {
   totalSeconds, trim,
 } from '../../tools/trim-audio/src/trim.js';
 import {
-  TIMESTAMP_FORMATS, formatClock, openSegment, parseClock, readTimestamps,
-  segmentRanges, totalCaptured, writeTimestamps,
+  TIMESTAMP_FORMATS, formatClock, formatDuration, openSegment, parseClock,
+  readTimestamps, segmentRanges, totalCaptured, writeTimestamps,
 } from '../../tools/trim-audio/src/segments.js';
 import { formatTime, parseTime } from '../../tools/trim-audio/src/timeline.js';
 import { summarise } from '../../tools/trim-audio/src/waveform.js';
@@ -232,6 +232,57 @@ test('trim stops when the signal is aborted', async () => {
   await assert.rejects(() => running, { name: 'AbortError' });
 });
 
+/*
+ * The two below are about the same thing, which is the one part of this file
+ * that is not arithmetic: whether the loop really hands the page back between
+ * sections.
+ *
+ * The test above cannot answer that. It aborts from inside onProgress, which
+ * is called from *within* the loop, so it would pass just as happily against a
+ * version that never yields at all - and that version is what shipped: it
+ * awaited a resolved promise, which queues a microtask and returns to the same
+ * task. The browser only repaints and only delivers a click between tasks, so
+ * the progress bar was frozen and Cancel was unpressable for the whole trim.
+ *
+ * Aborting from a timer is the same shape as a person clicking Cancel, and it
+ * can only work if the loop returns to the event loop. `budgetMs: 0` makes the
+ * yield happen every section so the test does not depend on how fast the
+ * machine running it is.
+ */
+
+test('the loop hands the page back between sections, not just the microtask queue', async () => {
+  const source = { channels: [ramp(4000)], sampleRate: 1000, frames: 4000 };
+  const sections = planSections(
+    Array.from({ length: 8 }, (_, i) => ({ start: i * 0.5, end: i * 0.5 + 0.4 })),
+    { sampleRate: 1000, totalFrames: 4000 });
+
+  let timerFired = false;
+  let firedDuringLoop = false;
+  setTimeout(() => { timerFired = true; }, 0);
+
+  await trim(source, sections, {
+    budgetMs: 0,
+    onProgress: () => { if (timerFired) firedDuringLoop = true; },
+  });
+
+  assert.equal(firedDuringLoop, true,
+    'a timer set before the trim has to get its turn while the trim is running');
+});
+
+test('a cancel that arrives the way a click does is honoured', async () => {
+  const source = { channels: [ramp(4000)], sampleRate: 1000, frames: 4000 };
+  const sections = planSections(
+    Array.from({ length: 8 }, (_, i) => ({ start: i * 0.5, end: i * 0.5 + 0.4 })),
+    { sampleRate: 1000, totalFrames: 4000 });
+
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 0);
+
+  await assert.rejects(
+    () => trim(source, sections, { budgetMs: 0, signal: controller.signal }),
+    { name: 'AbortError' });
+});
+
 /* --------------------------------------------------------- cutting it out */
 
 test('inverting the marks keeps everything they did not cover', () => {
@@ -263,6 +314,38 @@ test('formatClock always writes hours, minutes, seconds and thousandths', () => 
   assert.equal(formatClock(0), '00:00:00.000');
   assert.equal(formatClock(207.687), '00:03:27.687');
   assert.equal(formatClock(3661.5), '01:01:01.500');
+});
+
+test('a fraction that rounds up carries into the seconds instead of writing four digits', () => {
+  // The instant has to be rounded before it is taken apart. Flooring the
+  // seconds and rounding the fraction separately writes 3.9996 as
+  // "00:00:03.1000", which is not a time: it reads back as 3.1, nine tenths of
+  // a second from where the mark was put.
+  assert.equal(formatClock(3.9996), '00:00:04.000');
+  assert.equal(formatClock(59.9999), '00:01:00.000');
+  assert.equal(formatClock(3599.9999), '01:00:00.000');
+  assert.equal(formatClock(0.9995), '00:00:01.000');
+
+  for (const seconds of [3.9996, 59.9999, 0.9995, 3599.9999]) {
+    assert.ok(Math.abs(parseClock(formatClock(seconds)) - seconds) < 0.001,
+      `${seconds} has to read back as itself`);
+  }
+});
+
+test('the same carry, in the label a row and the playhead are written with', () => {
+  assert.equal(formatTime(3.9996), '0:04.000');
+  assert.equal(formatTime(59.9999), '1:00.000');
+  assert.equal(formatTime(3599.9999), '1:00:00.000');
+  assert.equal(parseTime(formatTime(59.9999)), 60);
+});
+
+test('a length is written the way a person reads it, and carries too', () => {
+  assert.equal(formatDuration(0), '0:00.0');
+  assert.equal(formatDuration(3), '0:03.0');
+  assert.equal(formatDuration(83.5), '1:23.5');
+  assert.equal(formatDuration(59.96), '1:00.0');
+  assert.equal(formatDuration(3599.96), '1:00:00.0');
+  assert.equal(formatDuration(Number.NaN), '-');
 });
 
 test('parseClock reads what the two formats write and what people type', () => {

--- a/tests/js/trim-video-segments.test.js
+++ b/tests/js/trim-video-segments.test.js
@@ -32,6 +32,17 @@ test('formatClock always writes hours, minutes, seconds and thousandths', () => 
   assert.equal(formatClock(36000), '10:00:00.000');
 });
 
+test('a fraction that rounds up carries into the seconds', () => {
+  // Rounding the fraction on its own writes 3.9996 as "00:00:03.1000" - four
+  // digits in a three-digit field, which reads back as 3.1. The marks file is
+  // shared with the audio trimmer, so both sides round the instant once,
+  // before taking it apart.
+  assert.equal(formatClock(3.9996), '00:00:04.000');
+  assert.equal(formatClock(59.9999), '00:01:00.000');
+  assert.equal(formatClock(3599.9999), '01:00:00.000');
+  assert.equal(parseClock(formatClock(59.9999)), 60);
+});
+
 test('formatClock never writes a negative time', () => {
   assert.equal(formatClock(-5), '00:00:00.000');
   assert.equal(formatClock(null), '00:00:00.000');

--- a/tools/trim-audio/README.md
+++ b/tools/trim-audio/README.md
@@ -106,6 +106,20 @@ strict nor too clever — a file with no header at all is still a list of times,
 line that cannot be read is counted rather than fatal, and a part that starts
 past the end of the recording you loaded is dropped with a message saying so.
 
+**One rounding rule, in every place a time is written.** The instant is rounded
+to milliseconds *once*, before it is taken apart into hours, minutes, seconds
+and thousandths. Doing it the other way round — floor the seconds, round the
+fraction — is the same arithmetic and a different answer: 3.9996 floors to 3
+and rounds to 1000, and the two get written next to each other as
+`00:00:03.1000`. That is four digits in a field that holds three, it reads back
+as 3.1, and it is how a mark made at 3.9996 s comes home nine tenths of a
+second early. `formatClock` in `src/segments.js`, `formatTime` in
+`src/timeline.js` — which is what a row's time box is filled with, so an
+unreadable label there moves the mark when the row is next edited — and
+`formatDuration` all round first. So does the video cutter, because the file
+above is shared and the two have to agree about the instant as well as the
+layout.
+
 ## The waveform is not decoration
 
 Marking sound by scrubbing is guesswork. Silence looks like silence, a cough
@@ -201,6 +215,17 @@ the context is created to match. A file whose format does not say is decoded at
   `cutChannels` producing the samples that went in, in order, with the ramps
   where the plan said.
 - **`src/segments.js`** — the timestamps file in both formats, round-tripping,
-  and the leniency: no header, unreadable lines, reversed times.
+  and the leniency: no header, unreadable lines, reversed times. The rounding
+  rule above has its own test, at the fractions that expose it.
+- **That the loop really hands the page back.** This is the one test here that
+  is about scheduling rather than arithmetic, and it exists because the first
+  version of that loop awaited a resolved promise. That queues a *microtask*,
+  and microtasks run to exhaustion inside the task that queued them: the
+  browser never gets in between, so the progress bar could not repaint and the
+  Cancel button could not be pressed — the click had nowhere to be delivered
+  until the trim was already over. A test that aborts from inside `onProgress`
+  passes either way, which is why the test here aborts from a timer, the way a
+  person's click arrives. `budgetMs` is an argument to `trim()` so that the
+  test can set it to zero and not depend on how fast the machine is.
 
 Run them with `node --test "tests/js/*.test.js"` from the repository root.

--- a/tools/trim-audio/src/main.js
+++ b/tools/trim-audio/src/main.js
@@ -3,7 +3,8 @@
 import { wireFilePicker } from './shared/file-picker.js';
 import { decodeAudio, UnreadableFile } from './decode.js';
 import {
-  openSegment, readTimestamps, segmentRanges, totalCaptured, writeTimestamps,
+  formatDuration, openSegment, readTimestamps, segmentRanges, totalCaptured,
+  writeTimestamps,
 } from './segments.js';
 import { Timeline, formatTime, parseTime } from './timeline.js';
 import {
@@ -847,16 +848,6 @@ function clearResult() {
 
 const channelWord = (count) => (
   count === 1 ? 'mono' : count === 2 ? 'stereo' : `${count} channels`);
-
-function formatDuration(seconds) {
-  if (!Number.isFinite(seconds)) return '-';
-  const whole = Math.floor(seconds);
-  const hours = Math.floor(whole / 3600);
-  const minutes = Math.floor((whole % 3600) / 60);
-  const rest = seconds - hours * 3600 - minutes * 60;
-  const shown = rest.toFixed(1).padStart(4, '0');
-  return hours ? `${hours}:${String(minutes).padStart(2, '0')}:${shown}` : `${minutes}:${shown}`;
-}
 
 function formatBytes(bytes) {
   if (bytes < 1024) return `${bytes} B`;

--- a/tools/trim-audio/src/segments.js
+++ b/tools/trim-audio/src/segments.js
@@ -52,13 +52,21 @@ const MIN_SEGMENT = 0.001;
  * HH:MM:SS.mmm, always with the hours, because that is what the file format
  * uses and a reader that has to guess whether the first field is hours or
  * minutes is a reader that will one day guess wrong.
+ *
+ * The instant is rounded to milliseconds **once, before it is taken apart**.
+ * Flooring the seconds and rounding the fraction separately is the same
+ * arithmetic and a different answer: 3.9996 floors to 3 and rounds to 1000,
+ * and the two are then written next to each other as `00:00:03.1000` - four
+ * digits in a field that holds three, and a time that reads back as 3.1. A
+ * mark is careful work and this is the format it is saved in, so nine tenths
+ * of a second is not a rounding error to shrug at.
  */
 export function formatClock(seconds) {
-  const safe = Math.max(0, Number(seconds) || 0);
-  const whole = Math.floor(safe);
+  const total = Math.round(Math.max(0, Number(seconds) || 0) * 1000);
+  const whole = Math.floor(total / 1000);
   const pad = (value, size) => String(value).padStart(size, '0');
   return `${pad(Math.floor(whole / 3600), 2)}:${pad(Math.floor(whole / 60) % 60, 2)}`
-    + `:${pad(whole % 60, 2)}.${pad(Math.round((safe - whole) * 1000), 3)}`;
+    + `:${pad(whole % 60, 2)}.${pad(total % 1000, 3)}`;
 }
 
 /**
@@ -175,4 +183,27 @@ export function readTimestamps(text) {
   }
 
   return { format, name, segments, skipped };
+}
+
+/**
+ * A *length* - how long something runs for - written for a person to read.
+ *
+ * Rounded to tenths once and then taken apart, for the reason formatClock
+ * above is: decomposing first and rounding the piece writes 59.96 seconds as
+ * "0:60.0", which is a minute that never learned it was a minute.
+ *
+ * Tenths rather than thousandths because this answers "how long is it", and
+ * nobody marks a recording against the length of the whole thing. The exact
+ * instants are formatClock's job.
+ */
+export function formatDuration(seconds) {
+  if (!Number.isFinite(seconds)) return '-';
+  const tenths = Math.round(Math.max(0, seconds) * 10);
+  const whole = Math.floor(tenths / 10);
+  const hours = Math.floor(whole / 3600);
+  const minutes = Math.floor((whole % 3600) / 60);
+  const shown = `${String(whole % 60).padStart(2, '0')}.${tenths % 10}`;
+  return hours
+    ? `${hours}:${String(minutes).padStart(2, '0')}:${shown}`
+    : `${minutes}:${shown}`;
 }

--- a/tools/trim-audio/src/timeline.js
+++ b/tools/trim-audio/src/timeline.js
@@ -34,15 +34,22 @@ function clamp(value, low, high) {
   return Math.max(low, Math.min(high, value));
 }
 
-/** mm:ss.mmm, which is short enough to read and exact enough to type back. */
+/**
+ * mm:ss.mmm, which is short enough to read and exact enough to type back.
+ *
+ * Rounded to milliseconds once, before it is taken apart: flooring the seconds
+ * and rounding the fraction separately writes 3.9996 as `0:03.1000`, which is
+ * four digits in a three-digit field and parses back as 3.1. This label is not
+ * only read - it is what a row's time box is filled with, so a number that
+ * cannot be read back is a mark that moves nine tenths of a second when
+ * somebody edits the row beside it.
+ */
 export function formatTime(seconds) {
-  const safe = Math.max(0, seconds || 0);
-  const whole = Math.floor(safe);
+  const total = Math.round(Math.max(0, seconds || 0) * 1000);
+  const whole = Math.floor(total / 1000);
   const hours = Math.floor(whole / 3600);
   const minutes = Math.floor((whole % 3600) / 60);
-  const rest = whole % 60;
-  const millis = Math.round((safe - whole) * 1000);
-  const tail = `${String(rest).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+  const tail = `${String(whole % 60).padStart(2, '0')}.${String(total % 1000).padStart(3, '0')}`;
   return hours
     ? `${hours}:${String(minutes).padStart(2, '0')}:${tail}`
     : `${minutes}:${tail}`;

--- a/tools/trim-audio/src/trim.js
+++ b/tools/trim-audio/src/trim.js
@@ -27,6 +27,33 @@
 /** Shorter than this and there is nothing to keep. One millisecond. */
 const MIN_SECTION = 0.001;
 
+/**
+ * How long to work before handing the page back, in milliseconds.
+ *
+ * A frame at 60 Hz is 16.7 ms; twelve leaves room for the repaint itself. It is
+ * a budget rather than a count of sections because sections are not the same
+ * size: one part of an hour-long recording is more work than two hundred parts
+ * of a jingle, and neither should decide how often the page gets a turn.
+ */
+const BUDGET_MS = 12;
+
+/**
+ * Hand the page back - properly.
+ *
+ * `await Promise.resolve()` does not do this, and that is the trap this
+ * constant exists to name. Awaiting an already-resolved promise queues a
+ * *microtask*, and microtasks run to exhaustion at the end of the task that
+ * queued them: the browser never gets between them to repaint, and it never
+ * gets between them to deliver a click. A loop that yields that way looks like
+ * it is being polite and is in fact one uninterruptible block of work - so the
+ * progress bar stays where it was, and the Cancel button cannot be pressed
+ * because the click event has nowhere to be dispatched until the loop is over.
+ *
+ * A timer is a new task. That is the whole difference, and it is the difference
+ * between a progress bar that means something and one that is decoration.
+ */
+const handBack = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+
 /* --------------------------------------------------------------- the marks */
 
 /**
@@ -190,21 +217,30 @@ export function cutChannels(channels, sections) {
  *
  * The work is fast - a copy and a few hundred multiplications a join - but
  * "fast" on a two-hour recording still means a moment, and a page that stops
- * answering looks broken. One section per turn, with a yield between them,
- * keeps the progress bar honest and the Cancel button live.
+ * answering looks broken. So the page is handed back whenever this has been
+ * working for longer than a frame: see `handBack` above for why that has to be
+ * a timer and cannot be a resolved promise.
+ *
+ * The budget is an argument because the tests set it to zero. A test that
+ * cancels from inside `onProgress` proves nothing about the Cancel button -
+ * that path never returns to the event loop either - so the tests here abort
+ * from a timer, the way a person's click does, and that only means something
+ * if this loop really yields.
  *
  * @param {{channels: Float32Array[], sampleRate: number, frames: number}} source
  * @param {ReturnType<typeof planSections>} sections
- * @param {{onProgress?: (done: number, label: string) => void, signal?: AbortSignal}} options
+ * @param {{onProgress?: (done: number, label: string) => void,
+ *          signal?: AbortSignal, budgetMs?: number}} options
  * @returns {Promise<{channels: Float32Array[], frames: number}>}
  */
-export async function trim(source, sections, { onProgress, signal } = {}) {
+export async function trim(source, sections, { onProgress, signal, budgetMs = BUDGET_MS } = {}) {
   const frames = sectionFrames(sections);
   if (!frames) throw new Error('There is nothing marked to keep.');
 
   const out = source.channels.map(() => new Float32Array(frames));
   let at = 0;
   let done = 0;
+  let since = performance.now();
 
   for (const section of sections) {
     signal?.throwIfAborted();
@@ -212,10 +248,14 @@ export async function trim(source, sections, { onProgress, signal } = {}) {
     at += section.frames;
     done += 1;
     onProgress?.(at / frames, `Copying part ${done} of ${sections.length}…`);
-    // Back to the event loop, so the bar repaints and Cancel is answerable.
-    await Promise.resolve();
+
+    if (performance.now() - since >= budgetMs) {
+      await handBack();
+      since = performance.now();
+    }
   }
 
+  signal?.throwIfAborted();
   return { channels: out, frames };
 }
 

--- a/tools/trim-video/README.md
+++ b/tools/trim-video/README.md
@@ -54,6 +54,14 @@ strict nor too clever: a file with no header at all is still a list of times, a
 line that cannot be read is counted rather than fatal, and a marked part that
 starts past the end of the video you loaded is dropped with a message saying so.
 
+The instant is rounded to milliseconds **once, before it is taken apart** into
+hours, minutes, seconds and thousandths. Flooring the seconds and rounding the
+fraction separately writes 3.9996 as `00:00:03.1000` — four digits in a field
+that holds three, which reads back as 3.1. The audio trimmer reads and writes
+this same file, so both sides round the same way; `formatClock` in
+`src/segments.js` and `formatTime` in `src/timeline.js` are the two places it
+matters.
+
 ## Why this is not just the cropper with different arithmetic
 
 A crop changes what every frame looks like, so every frame has to be written

--- a/tools/trim-video/src/segments.js
+++ b/tools/trim-video/src/segments.js
@@ -45,13 +45,21 @@ const MIN_SEGMENT = 0.02;
  * HH:MM:SS.mmm, always with the hours, because that is what the file format
  * uses and a reader that has to guess whether the first field is hours or
  * minutes is a reader that will one day guess wrong.
+ *
+ * The instant is rounded to milliseconds **once, before it is taken apart**.
+ * Flooring the seconds and rounding the fraction separately is the same
+ * arithmetic and a different answer: 3.9996 floors to 3 and rounds to 1000,
+ * and the two are then written next to each other as `00:00:03.1000` - four
+ * digits in a field that holds three, and a time that reads back as 3.1. The
+ * audio trimmer next door reads and writes this same file, so the two have to
+ * agree about the instant as well as about the layout.
  */
 export function formatClock(seconds) {
-  const safe = Math.max(0, Number(seconds) || 0);
-  const whole = Math.floor(safe);
+  const total = Math.round(Math.max(0, Number(seconds) || 0) * 1000);
+  const whole = Math.floor(total / 1000);
   const pad = (value, size) => String(value).padStart(size, '0');
   return `${pad(Math.floor(whole / 3600), 2)}:${pad(Math.floor(whole / 60) % 60, 2)}`
-    + `:${pad(whole % 60, 2)}.${pad(Math.round((safe - whole) * 1000), 3)}`;
+    + `:${pad(whole % 60, 2)}.${pad(total % 1000, 3)}`;
 }
 
 /**

--- a/tools/trim-video/src/timeline.js
+++ b/tools/trim-video/src/timeline.js
@@ -34,15 +34,22 @@ function clamp(value, low, high) {
   return Math.max(low, Math.min(high, value));
 }
 
-/** mm:ss.mmm, which is short enough to read and exact enough to type back. */
+/**
+ * mm:ss.mmm, which is short enough to read and exact enough to type back.
+ *
+ * Rounded to milliseconds once, before it is taken apart: flooring the seconds
+ * and rounding the fraction separately writes 3.9996 as `0:03.1000`, which is
+ * four digits in a three-digit field and parses back as 3.1. This label is not
+ * only read - it is what a row's time box is filled with, so a number that
+ * cannot be read back is a mark that moves nine tenths of a second when
+ * somebody edits the row beside it.
+ */
 export function formatTime(seconds) {
-  const safe = Math.max(0, seconds || 0);
-  const whole = Math.floor(safe);
+  const total = Math.round(Math.max(0, seconds || 0) * 1000);
+  const whole = Math.floor(total / 1000);
   const hours = Math.floor(whole / 3600);
   const minutes = Math.floor((whole % 3600) / 60);
-  const rest = whole % 60;
-  const millis = Math.round((safe - whole) * 1000);
-  const tail = `${String(rest).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+  const tail = `${String(whole % 60).padStart(2, '0')}.${String(total % 1000).padStart(3, '0')}`;
   return hours
     ? `${hours}:${String(minutes).padStart(2, '0')}:${tail}`
     : `${minutes}:${tail}`;


### PR DESCRIPTION
The audio trimmer works and this is not a rewrite of it. Two things it claims
are not true, though, and both were found by exercising the shipped page rather
than by reading it.

## 1. The progress bar was frozen and Cancel did nothing

`trim()` yields between sections. It did so with `await Promise.resolve()`,
under a comment saying that was *"back to the event loop, so the bar repaints
and Cancel is answerable"*.

It is not. Awaiting a resolved promise queues a **microtask**, and microtasks
run to exhaustion inside the task that queued them — the browser never gets in
between, so it cannot repaint and cannot deliver a click. The whole trim was one
uninterruptible block: the bar sat where it was, and the Cancel button could not
be pressed, because the click had nowhere to be dispatched until the work it was
meant to interrupt had finished.

Measured in the page, on the shipped build — 200 parts, and a 0 ms timer set
before the loop:

```
{ sections: 200, progressCalls: 200, timerFiredDuringLoop: false }
```

After, on a job big enough to matter (five minutes of 48 kHz stereo, 200 parts,
59 ms of copying):

```
{ sections: 200, elapsedMs: 59, macrotaskTurnsDuringTrim: 4 }
```

One turn per frame's worth of work. The budget is a millisecond count rather
than a section count because sections are not the same size — one part of an
hour-long recording is more work than two hundred parts of a jingle — and a job
that finishes inside one budget window never pays for a timer at all.

**The existing abort test passed against the broken version**, which is the more
interesting half of this: it aborted from inside `onProgress`, which is called
from within the loop, so it never needed the loop to yield. The two tests added
here abort *from a timer* and watch *for a timer* — the shape a person's click
actually has — and `budgetMs` is an argument so they can set it to zero and not
depend on how fast the machine is.

## 2. A mark at 3.9996 s was written as `00:00:03.1000`

`formatClock` floored the seconds and rounded the fraction separately. When the
fraction rounds up to 1000, the two get written next to each other:

```
formatClock(3.9996)  -> "00:00:03.1000"   parseClock reads it back as 3.1
formatClock(59.9999) -> "00:00:59.1000"   -> 59.1
```

Four digits in a field that holds three, and a mark nine tenths of a second from
where it was put. The marks file is this tool's one outside contract, so that is
a mark quietly moved rather than a display glitch.

The same arithmetic was in two more places:

| | wrote | now |
|---|---|---|
| `formatClock` — the marks file | `00:00:03.1000` | `00:00:04.000` |
| `formatTime` — the playhead, and a row's time box | `0:03.1000` | `0:04.000` |
| `formatDuration` — "Finished length" | `0:60.0` for 59.96 s | `1:00.0` |

`formatTime` is the one with teeth after the file: it fills the row's time
input, so a label that cannot be read back moves the mark the next time somebody
edits the row beside it.

All of them now round the instant to milliseconds **once, before taking it
apart** — the rule the frame grabber's `still.js` already documents for exactly
this reason.

### This also touches /trim-video/

`formatClock` and `formatTime` there are the same functions with the same fault
— it is where the audio tool got them. The two tools read and write each other's
marks files on purpose, so fixing one side only would leave them agreeing about
the layout and disagreeing about the instant. Same fix, same rule, and a test on
that side too.

`formatDuration` moved from `main.js` into `segments.js` on the way, because
`main.js` touches the DOM at import time and nothing in it can be reached by a
test.

## Checks

`node --test` 1261 pass (6 new). `python build.py --clean` completes. The page
was driven end to end afterwards: a 3-second 8 kHz WAV, one part marked
1.000–2.000 s, out comes 8,000 samples at 8 kHz mono 16-bit starting at source
sample 8,000, the first ~5 ms ramped by the join fade and sample 100 matching
the source exactly — unchanged, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
