### PR TITLE
[Uncommit] Spanish guide translations

### DIFF
--- a/locales/es/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/es/pages/guides/combine-images-into-a-pdf.html
@@ -1,129 +1,130 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre <a href="../../imagenes-a-pdf/">Imágenes a PDF</a>, suelta las fotos
-      dentro, arrastra las fichas hasta que el orden esté bien, y crea el
-      documento. Los valores por defecto &mdash; páginas A4, un margen pequeño,
-      las fotografías copiadas sin recodificar &mdash; son lo que quiere casi
+      Abre <a href="../../imagenes-a-pdf/">Imágenes a PDF</a>, arrastra las
+      fotos dentro, mueve las fichas hasta dejar el orden bien y crea el
+      documento. Los valores de fábrica &mdash; páginas A4, un margen pequeño y
+      las fotografías copiadas sin recodificar &mdash; son los que quiere casi
       todo el mundo.
     </p>
     <p>
-      Las cuatro cosas que merecen un segundo pensamiento son el orden, el tamaño
-      de página, el ajuste de calidad y qué dice el documento terminado sobre ti.
-      En ese orden de frecuencia con que salen mal.
+      Solo hay cuatro cosas que merecen que te pares a pensarlas: el orden, el
+      tamaño de página, el ajuste de calidad y lo que el documento terminado
+      cuenta sobre ti. Van enumeradas de más a menos habitual entre las cosas
+      que salen mal.
     </p>
   </section>
 
   <section>
-    <h2>Pon bien el orden antes que nada</h2>
+    <h2>Antes que nada, deja el orden bien</h2>
     <p>
-      El orden de las páginas es lo que más veces sale mal, porque los nombres de
-      archivo se ordenan de formas que nadie espera. <code>IMG_2.jpg</code> va
-      después de <code>IMG_10.jpg</code> en una ordenación alfabética, ya que la
-      comparación es carácter a carácter y el <code>1</code> va antes que el
+      El orden de las páginas es lo que más veces se tuerce, porque los nombres
+      de archivo se ordenan de maneras que nadie espera. En una ordenación
+      alfabética, <code>IMG_2.jpg</code> va detrás de <code>IMG_10.jpg</code>:
+      la comparación es carácter a carácter y el <code>1</code> va antes que el
       <code>2</code>. Una carpeta de escaneos llamados <code>pagina1</code> a
-      <code>pagina12</code> llegará en el orden equivocado en casi cualquier
-      herramienta.
+      <code>pagina12</code> llegará desordenada en casi cualquier herramienta.
     </p>
     <p>
-      Ordenar por fecha de captura suele ser más fiable con fotografías, porque
-      fotografiaste las páginas en el orden en que estaban. En cualquier caso,
-      comprueba las fichas antes de pulsar el botón en vez de comprobar el PDF
-      después.
+      Con fotografías suele salir mejor ordenar por fecha de captura, porque las
+      páginas las fotografiaste en el orden en que estaban. En cualquier caso,
+      revisa las fichas antes de pulsar el botón y no el PDF después.
     </p>
   </section>
 
   <section>
-    <h2>La calidad: la parte que casi todas las herramientas hacen mal en silencio</h2>
+    <h2>La calidad: lo que casi todas las herramientas estropean sin decirlo</h2>
     <p>
-      Un PDF puede llevar datos JPEG directamente. Es una propiedad del formato:
-      los bytes comprimidos de un JPEG se pueden meter en el documento tal cual, y
-      el lector los descodifica igual que lo haría un navegador.
+      Un PDF admite datos JPEG tal cual. Es una propiedad del formato: los bytes
+      comprimidos de un JPEG entran en el documento sin tocarlos, y el lector los
+      descodifica igual que haría un navegador.
     </p>
     <p>
-      Esto importa porque significa que una fotografía no tiene por qué perder
-      nada al entrar en un PDF. Nunca se descodifica y nunca se vuelve a comprimir;
-      la imagen del documento es bit a bit la imagen de tu archivo. Muchas
-      herramientas la recodifican igualmente &mdash; es más simple renderizarlo
-      todo a un lienzo y codificar de forma uniforme &mdash; y el resultado es una
-      generación de calidad perdida sin motivo.
+      Y eso significa que una fotografía no tiene por qué perder nada al entrar
+      en un PDF. Ni se descodifica ni se vuelve a comprimir: la imagen del
+      documento es, bit a bit, la de tu archivo. Muchas herramientas la
+      recodifican de todas formas &mdash; les resulta más cómodo dibujarlo todo
+      en un lienzo y codificar de manera uniforme &mdash;, y el precio es una
+      generación de calidad perdida sin ningún motivo.
     </p>
     <p>
-      Los demás formatos no pueden colarse así. PNG, WebP, HEIC y los demás no
-      tienen ningún filtro equivalente en PDF, así que hay que convertirlos. Tú
-      eliges cómo:
+      Los demás formatos no pueden colarse así. PNG, WebP, HEIC y compañía no
+      tienen ningún filtro equivalente dentro del PDF, de modo que hay que
+      convertirlos. Cómo, lo eliges tú:
     </p>
     <ul>
       <li>
-        <strong>Recodificar como JPEG</strong> (lo predeterminado). El archivo más
-        pequeño, un pequeño coste de calidad, y la respuesta correcta para
-        fotografías.
+        <strong>Recodificar como JPEG</strong> (lo que viene puesto). Da el
+        archivo más pequeño a cambio de un pequeño coste de calidad, y es lo
+        acertado para fotografías.
       </li>
       <li>
-        <strong>Sin pérdidas.</strong> Guarda los píxeles exactos a costa de un
-        documento mucho más grande. La respuesta correcta para capturas de
-        pantalla, diagramas y cualquier cosa con texto o bordes nítidos, donde los
-        artefactos del JPEG se ven a la legua.
+        <strong>Sin pérdidas.</strong> Conserva los píxeles exactos a costa de
+        un documento mucho más grande. Es lo acertado para capturas de pantalla,
+        diagramas y cualquier cosa con texto o bordes nítidos, donde los
+        artefactos del JPEG saltan a la vista.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>El tamaño de página, y cuándo es mejor «ajustar a la imagen»</h2>
+    <h2>El tamaño de página, y cuándo conviene «ajustar a la imagen»</h2>
     <p>
-      Un tamaño de página estándar &mdash; A4, Carta, Oficio, A3, A5, Tabloide
-      &mdash; coloca cada imagen en una página de ese tamaño, escalada para que
-      quepa dentro de tu margen. Usa uno cuando el documento se vaya a imprimir, o
-      cuando alguien oficial lo vaya a archivar.
+      Un tamaño de página normalizado &mdash; A4, Carta, Oficio, A3, A5,
+      Tabloide &mdash; pone cada imagen en una página de esa medida, escalada
+      para que quepa dentro del margen. Elige uno cuando el documento vaya a
+      imprimirse, o cuando lo vaya a archivar alguien con sello.
     </p>
     <p>
-      «Exactamente el tamaño de cada imagen» hace que cada página coincida con su
-      imagen, así que no hay espacio en blanco ni escalado ninguno. Úsalo cuando el
-      PDF sea un contenedor de imágenes más que un documento: un porfolio, un
-      conjunto de capturas, un cómic. Queda mal impreso, porque cada página tiene
-      un tamaño distinto.
+      «Exactamente el tamaño de cada imagen» hace que cada página mida lo que
+      mide su imagen, así que no queda espacio en blanco ni hay escalado alguno.
+      Es lo que quieres cuando el PDF es un envoltorio para unas imágenes más
+      que un documento: un portafolio, una tanda de capturas, un cómic. Impreso
+      queda mal, porque cada página tiene un tamaño distinto.
     </p>
     <p>
-      Un margen merece la pena en cualquier cosa que se vaya a imprimir. Las
-      impresoras domésticas no pueden imprimir hasta el borde del papel, y una
-      fotografía colocada de borde a borde sale cortada.
+      Un margen compensa en cualquier cosa que vaya a acabar en papel. Las
+      impresoras domésticas no llegan hasta el borde de la hoja, y una fotografía
+      colocada de canto a canto sale cortada.
     </p>
     <h3>Páginas verticales a partir de fotografías horizontales</h3>
     <p>
-      Si fotografiaste hojas de papel con el móvil puesto de lado, todas las
-      imágenes serán horizontales y quedarán pequeñas en medio de una página
-      vertical. Girar cada una un cuarto de vuelta antes de construir el documento
-      es lo que lo arregla, y es una decisión por imagen y no global, porque casi
-      siempre unas cuantas entraron bien orientadas.
+      Si fotografiaste hojas de papel con el móvil de lado, todas las imágenes
+      saldrán horizontales y quedarán diminutas en mitad de una página vertical.
+      Lo que lo arregla es girar cada una un cuarto de vuelta antes de montar el
+      documento, y es una decisión imagen por imagen, no una general: casi
+      siempre hay unas cuantas que entraron bien orientadas.
     </p>
   </section>
 
   <section>
-    <h2>Qué dice el PDF terminado sobre ti</h2>
+    <h2>Lo que el PDF terminado cuenta sobre ti</h2>
     <p>
-      Un PDF lleva un bloque de información del documento: autor, productor, fecha
-      de creación y a veces el título. Según lo que lo haya escrito, eso puede
-      incluir el nombre de tu cuenta, el nombre de tu equipo y la hora exacta a la
-      que lo hiciste.
+      Todo PDF lleva un bloque de información del documento: autor, productor,
+      fecha de creación y, a veces, el título. Según qué programa lo haya
+      escrito, ahí puede acabar el nombre de tu cuenta, el de tu equipo y la
+      hora exacta a la que lo hiciste.
     </p>
     <p>
-      Merece la pena pensarlo, porque un PDF es algo que la gente le manda a otra
-      gente &mdash; una candidatura, una reclamación, un documento para un
-      casero. Los metadatos viajan con él y cualquier lector puede mostrarlos.
+      Conviene tenerlo presente, porque un PDF es justo la clase de archivo que
+      se le manda a otra persona: una candidatura, una reclamación, un papel que
+      te ha pedido el banco. Los metadatos viajan con él y cualquier lector
+      puede mostrarlos.
     </p>
     <p>
-      La herramienta de aquí deja ese bloque vacío salvo por su propio nombre: ni
+      Esta herramienta deja ese bloque vacío salvo por su propio nombre: ni
       nombres de archivo, ni nombre de equipo, ni nombre de usuario, ni fecha de
-      creación a menos que marques la casilla que la pide. Si usas otra
-      herramienta, merece la pena abrir una vez las propiedades del resultado para
-      ver qué ha escrito.
+      creación, a menos que marques la casilla que la pide. Si usas otra
+      herramienta, abre una vez las propiedades del resultado para ver qué ha
+      escrito ahí dentro.
     </p>
     <p>
-      Aparte: las propias imágenes. Si tus fotografías llevan etiquetas EXIF y
-      GPS, lo que les pase depende de la vía. Un JPEG copiado sin recodificar
-      conserva lo que llevara dentro; una imagen que se recodifica pierde las
-      etiquetas como efecto secundario. Si te importa, límpialas antes con el
-      <a href="../../eliminar-datos-exif/">visor y eliminador de EXIF</a> &mdash;
+      Y luego están las imágenes mismas. Si tus fotografías llevan etiquetas
+      EXIF y GPS, lo que sea de ellas depende del camino que tomen: un JPEG
+      copiado sin recodificar conserva lo que llevara dentro, mientras que una
+      imagen que se recodifica pierde las etiquetas de propina. Si te importa,
+      límpialas antes con el
+      <a href="../../eliminar-datos-exif/">visor y eliminador de EXIF</a>;
       <a href="../eliminar-datos-exif-y-gps/">su guía</a> explica qué hay ahí
       dentro.
     </p>
@@ -132,51 +133,51 @@
   <section>
     <h2>Si el PDF sale demasiado grande</h2>
     <p>
-      Las fotografías de móvil son grandes, y veinte de ellas hacen un documento
-      que el correo va a rechazar. Tres cosas que probar, por orden:
+      Las fotos de móvil son pesadas, y veinte de ellas dan un documento que el
+      correo va a rechazar. Tres cosas que probar, por este orden:
     </p>
     <p>
-      <strong>Reduce el lado más largo.</strong> Una fotografía de 4000 píxeles de
-      una hoja de papel lleva mucho más detalle del que va a usar ningún lector ni
-      ninguna impresora. Bajar el lado largo a algo así como 2000 píxeles suele
-      dejar el archivo en la cuarta parte y no cambia nada que nadie pueda ver en
-      una página.
+      <strong>Baja el lado más largo.</strong> Una fotografía de 4000 píxeles de
+      una hoja de papel lleva mucho más detalle del que van a aprovechar ni el
+      lector ni la impresora. Dejar el lado largo en unos 2000 píxeles suele
+      reducir el archivo a la cuarta parte sin cambiar nada que se pueda
+      apreciar en una página.
     </p>
     <p>
-      <strong>Usa JPEG en vez de sin pérdidas</strong> para cualquier cosa
-      fotográfica. Sin pérdidas es la respuesta correcta para diagramas y la
-      equivocada para la foto de una página.
+      <strong>Usa JPEG en lugar de la opción sin pérdidas</strong> para todo lo
+      que sea fotográfico. Sin pérdidas es lo acertado para un diagrama y lo
+      equivocado para la foto de una página.
     </p>
     <p>
-      <strong>Comprime el documento terminado.</strong> El
-      <a href="../../comprimir-pdf/">compresor de PDF</a> trabaja contra el tamaño
-      al que se dibuja cada imagen en la página y no contra su número de píxeles,
-      que es la medición que importa;
-      <a href="../reducir-el-tamano-de-un-pdf/">su guía</a> explica lo que cuesta
-      eso.
+      <strong>Comprime el documento ya terminado.</strong> El
+      <a href="../../comprimir-pdf/">compresor de PDF</a> trabaja sobre el
+      tamaño al que cada imagen se dibuja en la página, no sobre su número de
+      píxeles, que es la medida que de verdad cuenta;
+      <a href="../reducir-el-tamano-de-un-pdf/">su guía</a> explica lo que eso
+      cuesta.
     </p>
     <p>
-      La herramienta no lleva ningún límite dentro sobre cuántas imágenes puedes
-      usar. El techo práctico es la memoria de tu propio equipo, porque el
-      documento terminado se monta ahí antes de que lo descargues &mdash; unos
-      cientos de fotos de móvil a resolución completa es lo primero que lo nota, y
-      reducir el lado más largo mueve ese techo bastante lejos.
+      La herramienta no impone ningún límite de imágenes. El techo real es la
+      memoria de tu propio equipo, porque el documento se monta ahí antes de que
+      te lo descargues: unos cientos de fotos de móvil a resolución completa es
+      donde empieza a notarse, y bajar el lado más largo aleja bastante ese
+      techo.
     </p>
   </section>
 
   <section>
     <h2>Lo que esto no te va a dar</h2>
     <p>
-      Un PDF hecho a partir de fotografías es un PDF lleno de imágenes. Las
-      palabras que hay dentro no son texto: no puedes buscarlas, ni copiarlas, ni
-      hacer que un lector de pantalla las lea. Eso es una propiedad de aquello de
-      lo que partiste, no de la conversión.
+      Un PDF hecho con fotografías es un PDF lleno de imágenes. Las palabras que
+      se ven dentro no son texto: no puedes buscarlas, ni copiarlas, ni hacer
+      que un lector de pantalla las lea. Eso es una propiedad de lo que tenías al
+      empezar, no de la conversión.
     </p>
     <p>
-      Si necesitas texto buscable necesitas OCR, que es otro trabajo. Y si el
-      documento original todavía existe en alguna parte como documento, exportarlo
-      directamente a PDF siempre le ganará a fotografiarlo &mdash; más pequeño,
-      más nítido, buscable.
+      Si necesitas texto buscable, necesitas OCR, que es otro trabajo. Y si el
+      documento original todavía existe en alguna parte como documento,
+      exportarlo directamente a PDF siempre va a ganarle a fotografiarlo: más
+      pequeño, más nítido y buscable.
     </p>
   </section>
 
@@ -184,22 +185,22 @@
     <h2>Por qué esto no necesita una subida</h2>
     <p>
       Escribir un PDF es escribir un archivo estructurado: una cabecera, un
-      conjunto de objetos, una tabla de referencias cruzadas. No hay nada ahí que
-      un navegador no sepa hacer, ni nada en el trabajo que exija que las imágenes
-      viajen a ninguna parte.
+      conjunto de objetos, una tabla de referencias cruzadas. Ahí no hay nada
+      que un navegador no sepa hacer, ni nada en el trabajo que obligue a las
+      imágenes a viajar a ninguna parte.
     </p>
     <p>
-      Cosa que aquí merece preocupación, por lo que la gente mete en estos
-      documentos. Documentos de identidad, extractos bancarios, informes médicos,
-      contratos firmados &mdash; la razón entera de que alguien esté haciendo un
-      PDF suele ser que se lo va a mandar a una institución. La herramienta de
-      aquí no tiene ninguna función de red, y la
-      <code>Content-Security-Policy</code> de la página nombra todas las
-      direcciones que puede contactar, ninguna de las cuales es de este sitio.
+      Y aquí eso pesa más que en otros sitios, por lo que la gente suele meter
+      en estos documentos: documentos de identidad, extractos bancarios,
+      informes médicos, contratos firmados. Si alguien está montando un PDF,
+      casi siempre es porque va a mandárselo a una institución. Esta herramienta
+      no tiene ninguna función de red, y la
+      <code>Content-Security-Policy</code> de la página enumera todas las
+      direcciones con las que puede hablar, y ninguna es de este sitio.
     </p>
     <p>
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> explica cómo comprobarlo tú mismo, aquí o en
-      cualquier otra parte.
+      conversores en línea?</a> cuenta cómo comprobarlo por tu cuenta, aquí o en
+      cualquier otro sitio.
     </p>
   </section>

--- a/locales/es/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/es/pages/guides/combine-images-into-a-pdf.toml
@@ -8,18 +8,18 @@
 
 nav = "Imágenes en un PDF"
 
-title = "Cómo unir imágenes en un solo PDF"
-description = "Convierte fotos o escaneos en un único PDF: tamaño de página, orden y giro, por qué un JPEG no tiene por qué perder calidad al entrar, y qué le cuenta un PDF a la persona a la que se lo mandas."
+title = "Cómo juntar varias imágenes en un solo PDF"
+description = "Convierte fotos o escaneos en un único PDF: tamaño de página, orden y giro, por qué un JPEG no tiene por qué perder calidad al entrar, y qué cuenta el documento sobre quien lo envía."
 
-heading = "Cómo unir imágenes en un solo PDF"
+heading = "Cómo juntar varias imágenes en un solo PDF"
 lede = """
-    Alguien ha pedido «un PDF» y tú tienes once fotografías de papeles. Esto
-    cubre las decisiones que de verdad cambian el resultado &mdash; tamaño de
-    página, orden, calidad y qué dice el documento sobre ti &mdash; y cuáles
-    puedes ignorar."""
+    Te han pedido «un PDF» y lo que tienes son once fotografías de unos
+    papeles. Aquí están las decisiones que de verdad cambian el resultado
+    &mdash; el orden, el tamaño de página, la calidad y lo que el documento
+    cuenta sobre ti &mdash; y también las que puedes pasar por alto."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Cómo unir imágenes en un solo PDF"
-og_description = "Tamaño de página, orden y giro, por qué un JPEG no tiene por qué perder calidad al entrar, y qué le cuenta un PDF a la persona a la que se lo mandas."
+og_title = "Juntar varias imágenes en un solo PDF"
+og_description = "Tamaño de página, orden y giro, por qué un JPEG no tiene por qué perder calidad al entrar, y qué cuenta el documento sobre quien lo envía."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/es/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,169 +1,172 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre el <a href="../../comprimir-imagen/">compresor de imágenes</a>, suelta
-      la foto dentro, escribe el número que te han dado y pulsa el botón.
-      Codifica la imagen varias veces, se queda con el mejor resultado que cabe
-      por debajo de tu objetivo, y te dice lo que ha costado. Para la mayoría de
-      las fotografías y la mayoría de los objetivos, el resumen honesto es que no
-      vas a ser capaz de ver la diferencia.
+      Abre el <a href="../../comprimir-imagen/">compresor de imágenes</a>,
+      arrastra la foto dentro, escribe el número que te han dado y pulsa el
+      botón. Codifica la imagen varias veces, se queda con el mejor resultado
+      que cabe por debajo de tu objetivo y te dice lo que ha costado. Con la
+      mayoría de las fotografías y la mayoría de los objetivos, lo honesto es
+      decir que no vas a ver la diferencia.
     </p>
     <p>
-      El resto de esta página es para cuando eso no pasa: cuando el resultado se
-      ve blando, cuando un PNG apenas se mueve, o cuando quieres saber qué le
-      está haciendo la herramienta a tu foto antes de mandársela a alguien.
-    </p>
-  </section>
-
-  <section>
-    <h2>Qué está pidiendo de verdad un límite de tamaño</h2>
-    <p>
-      Un JPEG o un WebP no guarda tu fotografía. Guarda una descripción de ella,
-      y el ajuste de calidad decide hasta qué punto se le permite ser detallada.
-      Bájalo y el archivo se hace más pequeño porque la descripción se vuelve más
-      vaga: la textura fina se promedia, los degradados hacen bandas, y los
-      bordes cogen un halo tenue de bloques.
-    </p>
-    <p>
-      Así que un límite de tamaño es un presupuesto de detalle. La pregunta útil
-      no es «¿puedo llegar a 500&nbsp;KB?» &mdash; siempre puedes llegar a
-      cualquier número &mdash;, sino «¿cuánto de la imagen tengo que entregar
-      para llegar hasta ahí, y me importa para lo que voy a hacer con ella?».
-    </p>
-    <p>
-      Dos reglas prácticas. Una fotografía de una escena real &mdash; caras,
-      follaje, tela &mdash; esconde bien la compresión, porque el ojo no tiene
-      ninguna zona perfectamente plana en la que notar el daño. Una captura de
-      pantalla, un gráfico, un logotipo o cualquier cosa con colores planos
-      grandes y bordes duros de texto la enseña de inmediato, y normalmente
-      debería ser un PNG o un WebP en vez de un JPEG.
+      El resto de esta página es para cuando sí se nota: cuando el resultado
+      queda blando, cuando un PNG apenas se mueve, o cuando quieres saber qué le
+      está haciendo la herramienta a tu foto antes de mandársela a nadie.
     </p>
   </section>
 
   <section>
-    <h2>Por qué no hay ninguna fórmula, y qué hacer al respecto</h2>
+    <h2>Qué te está pidiendo en realidad un límite de tamaño</h2>
     <p>
-      No hay forma de calcular el ajuste de calidad que produce un archivo de
-      500&nbsp;KB. La relación entre los dos depende por completo de lo que haya
-      en la foto: con el mismo ajuste, una fotografía de una pared lisa puede
-      salir a la décima parte del tamaño de una fotografía de un bosque.
-      Cualquier herramienta que te ofrezca «calidad: 60» y cruce los dedos está
-      adivinando por ti.
+      Un JPEG o un WebP no guarda tu fotografía: guarda una descripción de ella,
+      y el ajuste de calidad decide hasta qué punto puede ser detallada esa
+      descripción. Si lo bajas, el archivo adelgaza porque la descripción se
+      vuelve más vaga: la textura fina se promedia, los degradados se rompen en
+      bandas y los bordes se rodean de un halo tenue de bloques.
     </p>
     <p>
-      El único método fiable es probar. Codificar la imagen, mirar el tamaño,
-      ajustar, volver a codificar. Hacerlo a mano es pesado, y por eso los
-      compresores piden un número de calidad &mdash; te trasladan la pesadez a
-      ti. Hacerlo automáticamente son unas ocho codificaciones, y ocho
-      codificaciones de una foto de móvil son una fracción de segundo en
-      cualquier equipo hecho esta década, que es por lo que la herramienta de
-      este sitio pide el tamaño y hace la búsqueda ella misma.
+      Un límite de tamaño es, entonces, un presupuesto de detalle. La pregunta
+      útil no es «¿llegaré a 500&nbsp;KB?» &mdash; a cualquier cifra se llega
+      siempre &mdash;, sino «¿cuánta imagen tengo que entregar para llegar hasta
+      ahí, y me importa para lo que voy a hacer con ella?».
     </p>
     <p>
-      Cada tamaño que informa es un archivo codificado de verdad, no una
-      estimación. Eso importa cuando un formulario tiene un límite duro: una
-      estimación optimista por un 2&nbsp;% es una subida rechazada.
+      Dos reglas prácticas. La fotografía de una escena real &mdash; caras,
+      hojas, tela &mdash; disimula bien la compresión, porque el ojo no
+      encuentra ninguna superficie perfectamente lisa donde detectar el daño.
+      Una captura de pantalla, un gráfico, un logotipo o cualquier cosa con
+      grandes zonas de color plano y bordes duros de texto la delata al
+      instante, y casi siempre debería ser un PNG o un WebP en vez de un JPEG.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué no hay ninguna fórmula, y qué hacer entonces</h2>
+    <p>
+      No existe forma de calcular qué ajuste de calidad produce un archivo de
+      500&nbsp;KB. La relación entre ambos depende por completo de lo que haya
+      dentro de la foto: con el mismo ajuste, la fotografía de una pared lisa
+      puede salir diez veces más pequeña que la de un bosque. Cualquier
+      herramienta que te ofrezca «calidad: 60» y se encomiende a la suerte está
+      adivinando en tu nombre.
+    </p>
+    <p>
+      El único método fiable es probar: codificar la imagen, mirar el tamaño,
+      corregir y volver a codificar. Hacerlo a mano es tedioso, y por eso los
+      compresores prefieren pedirte un número de calidad: te pasan a ti el
+      trabajo aburrido. Hacerlo de forma automática son unas ocho
+      codificaciones, y ocho codificaciones de una foto de móvil son una
+      fracción de segundo en cualquier equipo fabricado en esta década. De ahí
+      que la herramienta de este sitio te pida el tamaño y haga ella la
+      búsqueda.
+    </p>
+    <p>
+      Cada tamaño que aparece en pantalla es el de un archivo codificado de
+      verdad, no una estimación. Eso importa cuando un formulario tiene un
+      límite estricto: una estimación que se quede corta por un 2&nbsp;% es una
+      subida rechazada.
     </p>
   </section>
 
   <section>
     <h2>Gasta calidad antes que píxeles</h2>
     <p>
-      Solo hay dos formas de hacer más pequeño un archivo de imagen. Puedes
-      describir la misma foto con menos precisión, que es la calidad. O puedes
-      describir menos píxeles, que es redimensionar. No son equivalentes, y el
-      orden importa.
+      Solo hay dos maneras de aligerar un archivo de imagen. Puedes describir la
+      misma foto con menos precisión, que es la calidad. O puedes describir
+      menos píxeles, que es redimensionar. No son equivalentes, y el orden
+      importa.
     </p>
     <p>
-      La calidad va primero, porque el primer 30&nbsp;% de reducción de calidad
-      más o menos es genuinamente invisible en una fotografía &mdash; estás
-      tirando detalle que el formato guardaba con más cuidado del que ningún ojo
-      puede comprobar. Los píxeles van después, porque una vez que la calidad
-      baja lo bastante como para que se vean artefactos, una foto más pequeña con
-      una calidad decente se ve mejor que una foto a tamaño completo que ha
-      quedado arruinada. Menos píxeles buenos ganan a más píxeles malos.
+      La calidad va primero, porque el primer 30&nbsp;% de recorte, más o menos,
+      es de verdad invisible en una fotografía: estás tirando un detalle que el
+      formato guardaba con más cuidado del que ningún ojo puede comprobar. Los
+      píxeles van después, porque en cuanto la calidad baja lo suficiente como
+      para que aparezcan artefactos, una foto más pequeña con una calidad
+      decente se ve mejor que una foto a tamaño completo ya arruinada. Menos
+      píxeles buenos le ganan a más píxeles malos.
     </p>
     <p>
-      Esa es la estrategia entera, y merece la pena saberla aunque uses otra
-      herramienta: baja la calidad hasta que empiece a verse mal, y entonces haz
-      la foto más pequeña en lugar de seguir bajándola.
+      Ahí está la estrategia entera, y conviene conocerla aunque uses otra
+      herramienta: baja la calidad hasta que empiece a verse mal y, a partir de
+      ahí, encoge la foto en lugar de seguir bajándola.
     </p>
     <h3>Cuándo redimensionar a propósito</h3>
     <p>
-      A veces los píxeles nunca hicieron falta. Una foto de 4000 píxeles de ancho
-      mostrada en una columna de 600 píxeles de ancho de una página web lleva seis
-      veces el detalle que nadie va a ver. Si sabes dónde va a acabar la foto,
-      redimensiónala a eso primero y el problema de tamaño desaparece muchas veces
-      sin gastar nada de calidad. El
-      <a href="../../redimensionar-imagen/">redimensionador de imágenes</a> es la
-      herramienta para ese trabajo, y
+      A veces los píxeles nunca hicieron falta. Una foto de 4000 píxeles de
+      ancho que se muestra en una columna de 600 píxeles carga con seis veces el
+      detalle que alguien llegará a ver. Si sabes dónde va a acabar la foto,
+      redimensiónala primero a esa medida y el problema de tamaño desaparece
+      muchas veces sin gastar ni un punto de calidad. Para ese trabajo está el
+      <a href="../../redimensionar-imagen/">redimensionador de imágenes</a>, y
       <a href="../redimensionar-una-imagen/">su propia guía</a> explica cómo
-      elegir un tamaño.
+      elegir el tamaño.
     </p>
   </section>
 
   <section>
     <h2>Elegir un formato</h2>
     <p>
-      Merece la pena conocer tres formatos, y los navegadores saben escribir los
-      tres.
+      Hay tres formatos que conviene conocer, y los navegadores saben escribir
+      los tres.
     </p>
     <ul>
       <li>
         <strong>JPEG</strong> es para fotografías. Tiene pérdidas, lo entiende
-        todo lo que se ha fabricado jamás, y para una imagen de una escena real
-        sigue siendo una elección excelente. No puede guardar transparencia.
+        absolutamente todo lo que se ha fabricado nunca y, para la imagen de una
+        escena real, sigue siendo una elección excelente. No sabe guardar
+        transparencia.
       </li>
       <li>
-        <strong>WebP</strong> es para el mismo trabajo, hecho mejor: alrededor de
-        un 25&ndash;35&nbsp;% más pequeño que JPEG a una calidad que no puedes
-        distinguir, y conserva la transparencia. Lo lee cualquier navegador
-        actual. Unas pocas aplicaciones de escritorio antiguas y algunos
-        formularios de subida corporativos siguen sin leerlo, y esa es la única
-        razón de verdad para no usarlo.
+        <strong>WebP</strong> hace el mismo trabajo, pero mejor: entre un 25 y
+        un 35&nbsp;% más pequeño que JPEG con una calidad que no sabrás
+        distinguir, y además conserva la transparencia. Lo lee cualquier
+        navegador actual. Unas cuantas aplicaciones de escritorio antiguas y
+        algún formulario de subida corporativo siguen sin leerlo, y esa es la
+        única razón real para no usarlo.
       </li>
       <li>
         <strong>PNG</strong> no tiene pérdidas, lo que significa que es exacto y
-        es grande. Es la respuesta correcta para capturas de pantalla, logotipos,
-        dibujo de línea y cualquier cosa con bordes nítidos o color plano, y la
-        respuesta equivocada para una fotografía.
+        es grande. Es la respuesta acertada para capturas de pantalla,
+        logotipos, dibujo lineal y cualquier cosa con bordes nítidos o color
+        plano, y la equivocada para una fotografía.
       </li>
     </ul>
     <p>
-      Si no tienes ninguna restricción de quien te ha pedido el archivo, WebP te
-      llevará hasta el objetivo con menos daño visible que JPEG. Si el archivo va
-      a algo antiguo, o a un sistema que no puedes probar, JPEG es la respuesta
-      segura.
+      Si quien te ha pedido el archivo no te ha impuesto ninguna condición, WebP
+      te dejará en el objetivo con menos daño visible que JPEG. Si el archivo va
+      a parar a algo antiguo, o a un sistema que no puedes probar, JPEG es la
+      respuesta segura.
     </p>
   </section>
 
   <section>
-    <h2>Por qué tu PNG no se va a hacer mucho más pequeño</h2>
+    <h2>Por qué tu PNG no va a adelgazar mucho</h2>
     <p>
-      Esta es la sorpresa más habitual, y no es un fallo de la herramienta que
-      estés usando. PNG es un formato sin pérdidas: guarda los píxeles exactos, y
-      no tiene ningún mando de calidad que girar, porque girar uno lo convertiría
-      en otro formato. Todo lo que puede hacer un compresor de PNG es empaquetar
-      los mismos píxeles con más maña, que suele valer un pequeño porcentaje.
+      Esta es la sorpresa más habitual, y no es culpa de la herramienta que
+      estés usando. PNG es un formato sin pérdidas: guarda los píxeles exactos y
+      no tiene ningún mando de calidad que girar, porque girarlo lo convertiría
+      en otro formato. Lo único que puede hacer un compresor de PNG es empaquetar
+      esos mismos píxeles con más astucia, y eso suele valer un pequeño
+      porcentaje.
     </p>
     <p>
-      Así que si necesitas por narices un archivo mucho más pequeño y tiene que
-      seguir siendo un PNG, la única palanca que queda es el tamaño &mdash; menos
-      píxeles, o menos colores. Si puede dejar de ser un PNG, la pregunta es qué
-      lleva dentro:
+      Así que, si necesitas a la fuerza un archivo mucho más pequeño y tiene que
+      seguir siendo un PNG, la única palanca que te queda es el tamaño: menos
+      píxeles, o menos colores. Si puede dejar de ser un PNG, la pregunta pasa a
+      ser qué lleva dentro:
     </p>
     <ul>
       <li>
-        <strong>Una fotografía guardada como PNG.</strong> Muy común, casi
-        siempre por accidente, y la victoria más fácil de esta página:
-        convertirla a JPEG o WebP la dejará muchas veces de cinco a diez veces
+        <strong>Una fotografía guardada como PNG.</strong> Ocurre muchísimo,
+        casi siempre sin querer, y es la mejora más fácil de toda esta página:
+        convertirla a JPEG o a WebP la deja a menudo entre cinco y diez veces
         más pequeña sin ningún cambio visible.
       </li>
       <li>
         <strong>Una captura de pantalla o un diagrama.</strong> Conviértelo a
-        WebP, que también es sin pérdidas cuando se lo pides, y suele ser más
-        pequeño que PNG para los mismos píxeles. Pasarlo a JPEG dejará borrosos
-        los bordes del texto.
+        WebP, que también trabaja sin pérdidas cuando se lo pides y suele quedar
+        más pequeño que PNG con los mismos píxeles. Pasarlo a JPEG te dejará los
+        bordes del texto borrosos.
       </li>
       <li>
         <strong>Un logotipo con transparencia.</strong> WebP conserva la
@@ -176,41 +179,42 @@
   <section>
     <h2>Cómo saber si el resultado es lo bastante bueno</h2>
     <p>
-      Mirar una miniatura no demuestra nada &mdash; a tamaño de miniatura todo se
-      ve bien. Dos comprobaciones mejores:
+      Mirar una miniatura no demuestra nada: a tamaño de miniatura todo se ve
+      bien. Dos comprobaciones mejores:
     </p>
     <p>
-      <strong>Míralo a tamaño completo, en lo más plano del encuadre.</strong>
-      Cielo, piel, una pared pintada. El daño de la compresión aparece primero en
-      los degradados suaves, como bloques o bandas tenues, mucho antes de tocar
-      las zonas detalladas.
+      <strong>Míralo a tamaño completo y fíjate en lo más liso del
+      encuadre.</strong> El cielo, la piel, una pared pintada. El daño de la
+      compresión asoma primero en los degradados suaves, en forma de bloques o
+      bandas tenues, mucho antes de tocar las zonas con detalle.
     </p>
     <p>
-      <strong>Lee la medición, si la herramienta te da una.</strong> El compresor
-      de aquí descodifica su propio resultado y lo compara con el original, e
-      informa del SSIM: un número que compara brillo, contraste y estructura
-      locales en vez de contar píxeles cambiados, que se parece mucho más a lo
-      que molesta a un ojo. Por encima de 0,98 más o menos, las dos fotos cuesta
-      separarlas una al lado de la otra. Por debajo de 0,95 más o menos, míralo
-      antes de enviarlo. También informa del PSNR, la cifra clásica en
+      <strong>Lee la medición, si la herramienta te da una.</strong> Este
+      compresor descodifica su propio resultado, lo compara con el original y te
+      muestra el SSIM: un número que compara brillo, contraste y estructura
+      locales en lugar de contar píxeles cambiados, que se parece mucho más a lo
+      que le molesta a un ojo. Por encima de 0,98 aproximadamente, las dos fotos
+      cuesta distinguirlas incluso una al lado de la otra. Por debajo de 0,95,
+      míralo antes de enviarlo. También muestra el PSNR, la cifra clásica en
       decibelios, para quien la prefiera.
     </p>
     <p>
-      Las dos se calculan en tu propio equipo y se te muestran, que es el sentido
-      de tenerlas: convierten la «pérdida mínima de calidad» de una afirmación en
-      un número que puedes comprobar.
+      Las dos se calculan en tu propio equipo y se te enseñan, que es justo para
+      lo que están: convierten la «pérdida de calidad mínima» de una afirmación
+      en un número que puedes comprobar.
     </p>
   </section>
 
   <section>
     <h2>Tres cosas que conviene saber antes de mandar el archivo</h2>
     <p>
-      <strong>Comprimir quita los metadatos.</strong> Recodificar significa
-      descodificar la foto a píxeles y volver a codificar esos píxeles, y un
-      lienzo lleno de píxeles no lleva etiquetas &mdash; así que la posición GPS,
-      el modelo de cámara, las marcas de tiempo y todo lo demás sencillamente no
-      se escriben en el archivo nuevo. Normalmente eso es una ventaja. Si lo que
-      querías era quitar las etiquetas sin tocar la foto, eso es otro trabajo: el
+      <strong>Comprimir se lleva por delante los metadatos.</strong> Recodificar
+      consiste en descodificar la foto hasta convertirla en píxeles y volver a
+      codificar esos píxeles, y un lienzo lleno de píxeles no lleva ninguna
+      etiqueta: la posición GPS, el modelo de cámara, las fechas y todo lo demás
+      sencillamente no llegan a escribirse en el archivo nuevo. Normalmente eso
+      es una ventaja. Si lo que querías era quitar las etiquetas sin tocar la
+      foto, ese es otro trabajo: el
       <a href="../../eliminar-datos-exif/">visor y eliminador de EXIF</a>
       reescribe el contenedor sin volver a comprimir nada, y
       <a href="../eliminar-datos-exif-y-gps/">su guía</a> explica qué hay ahí
@@ -218,34 +222,34 @@
     </p>
     <p>
       <strong>No comprimas nunca dos veces el mismo archivo.</strong> Cada
-      codificación con pérdidas tira detalle para siempre, y codificar una foto ya
-      comprimida tira más &mdash; incluidos los artefactos de la primera pasada,
-      que conserva fielmente a costa de detalle real. Vuelve siempre al original y
-      comprime una sola vez.
+      codificación con pérdidas tira detalle para siempre, y codificar una foto
+      ya comprimida tira todavía más, empezando por los artefactos de la primera
+      pasada, que conserva con toda fidelidad a costa del detalle de verdad.
+      Vuelve siempre al original y comprime una sola vez.
     </p>
     <p>
-      <strong>Conserva el original.</strong> De una codificación con pérdidas no
-      hay vuelta atrás. Mandes lo que mandes, guarda en alguna parte el archivo
-      del que partiste.
+      <strong>Guarda el original.</strong> De una codificación con pérdidas no
+      hay vuelta atrás. Mandes lo que mandes, quédate en alguna parte con el
+      archivo del que partiste.
     </p>
   </section>
 
   <section>
     <h2>Nada de esto necesita una subida</h2>
     <p>
-      Todos los navegadores llevan años trayendo un codificador de JPEG, PNG y
-      WebP &mdash; es el mismo código que guarda una imagen desde un lienzo.
-      Comprimir una imagen es uno de los trabajos que no tiene ninguna razón
-      técnica para implicar a un servidor, y por eso la herramienta de aquí no
-      tiene ninguno: la imagen se descodifica, se codifica y se mide en tu propio
-      equipo, y en la <code>Content-Security-Policy</code> de la página no hay
-      ninguna dirección de este sitio a la que pudiera enviarse.
+      Todos los navegadores llevan años incluyendo un codificador de JPEG, PNG y
+      WebP: es el mismo código con el que se guarda una imagen desde un lienzo.
+      Comprimir una imagen es uno de esos trabajos que no tienen ninguna razón
+      técnica para pasar por un servidor, y por eso esta herramienta no tiene
+      ninguno. Tu foto se descodifica, se codifica y se mide en tu propio
+      equipo, y en la <code>Content-Security-Policy</code> de la página no
+      figura ninguna dirección de este sitio a la que pudiera enviarse.
     </p>
     <p>
-      La forma más sencilla de confirmarlo, aquí o en cualquier otra parte, es
-      cargar la página, desconectarse de internet y comprimir algo de todos modos.
-      Si sigue funcionando, no se estaba subiendo nada.
+      La forma más sencilla de confirmarlo, aquí o en cualquier otro sitio, es
+      cargar la página, desconectarse de internet y comprimir algo de todos
+      modos. Si sigue funcionando, no se estaba subiendo nada.
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea otras tres comprobaciones parecidas.
+      conversores en línea?</a> propone otras tres comprobaciones parecidas.
     </p>
   </section>

--- a/locales/es/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/es/pages/guides/compress-an-image-to-a-target-size.toml
@@ -8,18 +8,18 @@
 
 nav = "Comprimir una imagen"
 
-title = "Cómo comprimir una imagen a un tamaño de archivo exacto"
-description = "Un formulario pide 500 KB y tu foto ocupa 4 MB. Lo que cuesta de verdad un límite de tamaño, qué ajuste mover primero, y por qué un PNG no va a encoger como lo hace un JPEG."
+title = "Cómo reducir el peso de una imagen a un tamaño exacto"
+description = "El formulario pide 500 KB y tu foto pesa 4 MB. Qué te cuesta de verdad un límite de tamaño, qué ajuste tocar primero y por qué un PNG no adelgaza como lo hace un JPEG."
 
-heading = "Cómo comprimir una imagen a un tamaño de archivo exacto"
+heading = "Cómo reducir el peso de una imagen a un tamaño exacto"
 lede = """
-    Alguien te ha dado un número &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
-    &mdash; y tu foto no se acerca ni de lejos. Esto es lo que cuesta ese
-    número, en qué gastarlo, y cómo saber si el resultado sigue siendo lo
-    bastante bueno para enviarlo."""
+    Te han dado una cifra &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB &mdash; y
+    tu foto no se acerca ni de lejos. Esto es lo que cuesta esa cifra, en qué
+    conviene gastarla y cómo saber si lo que sale sigue siendo lo bastante
+    bueno para mandarlo."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Comprimir una imagen a un tamaño de archivo exacto"
-og_description = "Lo que cuesta de verdad un límite de tamaño, qué ajuste mover primero, y por qué un PNG no va a encoger como lo hace un JPEG."
+og_title = "Reducir el peso de una imagen a un tamaño exacto"
+og_description = "Qué te cuesta de verdad un límite de tamaño, qué ajuste tocar primero y por qué un PNG no adelgaza como lo hace un JPEG."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/convert-an-svg-to-png.html
+++ b/locales/es/pages/guides/convert-an-svg-to-png.html
@@ -1,17 +1,17 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre <a href="../../convertir-svg-a-png/">SVG a imagen</a>, suelta el
-      archivo dentro y di un tamaño. Si nadie te ha dicho qué tamaño usar,
-      <strong>1024 píxeles en el lado más largo</strong> es un buen valor por
-      defecto: lo bastante grande para casi todo y lo bastante pequeño para
-      mandarlo por correo. Deja el formato en PNG, deja el fondo en transparente y
+      Abre <a href="../../convertir-svg-a-png/">SVG a imagen</a>, arrastra el
+      archivo dentro y di un tamaño. Si nadie te ha dicho cuál,
+      <strong>1024 píxeles en el lado más largo</strong> es un buen punto de
+      partida: bastante grande para casi todo y bastante pequeño para mandarlo
+      por correo. Deja el formato en PNG, deja el fondo en transparente y
       llévate el archivo.
     </p>
     <p>
-      Todo lo de abajo es qué hacer cuando ese valor por defecto no basta &mdash;
-      cuando te han especificado un número, cuando va a una imprenta, o cuando
-      vuelve con mal aspecto.
+      El resto de esta página es para cuando ese valor no basta: cuando te han
+      dado un número concreto, cuando el archivo va a una imprenta o cuando lo
+      que sale tiene mal aspecto.
     </p>
   </section>
 
@@ -19,221 +19,228 @@
     <h2>Por qué el tamaño lo decides tú y no el archivo</h2>
     <p>
       Un JPEG es una rejilla de píxeles medidos; preguntar cuánto mide tiene
-      respuesta. Un SVG no es una imagen en absoluto, es un conjunto de
+      respuesta. Un SVG no es una imagen en absoluto, sino un juego de
       instrucciones &mdash; dibuja un círculo aquí, este trazado de este color
-      &mdash; y las instrucciones no tienen tamaño. Un navegador puede ejecutarlas
-      a 16 píxeles o a 4000 y el resultado es igual de nítido en ambos casos,
-      porque no está escalando nada. Está dibujando otra vez.
+      &mdash;, y las instrucciones no tienen tamaño. Un navegador puede
+      ejecutarlas a 16 píxeles o a 4000 y en los dos casos el resultado sale
+      igual de nítido, porque no está escalando nada: está volviendo a dibujar.
     </p>
     <p>
-      Por eso la conversión no puede elegir un número por ti, y por eso no te
-      cuesta nada elegir uno grande. Este es el único trabajo de imagen en el que
-      «hazlo más grande» es gratis.
+      Por eso la conversión no puede elegir el número por ti, y por eso elegir
+      uno grande no te cuesta nada. Es el único trabajo de imagen en el que
+      «hazlo más grande» sale gratis.
     </p>
     <p>
-      Casi todos los archivos SVG sí llevan un atributo <code>width</code> y
-      <code>height</code>, y una herramienta te lo enseñará &mdash; pero es un
-      valor por defecto, no un límite. Un icono que dice <code>width="24"</code>
-      solo dice que quien lo dibujó tenía en mente una barra de herramientas de
-      24&nbsp;píxeles.
+      Casi todos los archivos SVG llevan un atributo <code>width</code> y otro
+      <code>height</code>, y cualquier herramienta te los enseñará; pero eso es
+      una sugerencia, no un límite. Un icono que dice <code>width="24"</code>
+      solo está diciendo que quien lo dibujó pensaba en una barra de
+      herramientas de 24&nbsp;píxeles.
     </p>
   </section>
 
   <section>
     <h2>De dónde sale de verdad el número</h2>
-    <p><strong>Para una web.</strong> Coge el tamaño que ocupa la imagen en la
-      página en píxeles CSS y multiplícalo por la densidad de píxeles de las
-      pantallas que te importen. Un logotipo en un hueco de 200&nbsp;píxeles de
-      ancho necesita un archivo de 400&nbsp;píxeles para un portátil Retina y de
-      600 para un móvil reciente. Eso es todo lo que significan <code>@2x</code> y
-      <code>@3x</code>, y es por lo que una herramienta que los escriba te ahorra
-      hacer la cuenta tres veces.
+    <p><strong>Para una web.</strong> Toma el espacio que la imagen ocupa en la
+      página, en píxeles CSS, y multiplícalo por la densidad de las pantallas
+      que te importen. Un logotipo en un hueco de 200&nbsp;píxeles de ancho
+      necesita un archivo de 400&nbsp;píxeles para un portátil Retina y de 600
+      para un móvil reciente. Eso es todo lo que significan <code>@2x</code> y
+      <code>@3x</code>, y por eso una herramienta que te los genere sola te
+      ahorra hacer tres veces la misma cuenta.
     </p>
     <p><strong>Para el icono de una aplicación, una ficha de tienda o un
-      favicon.</strong> El número está publicado y no hay nada que calcular: lo
-      que diga la página de la tienda, exactamente. Para un favicon, no
-      rasterices en absoluto &mdash; <a href="../como-hacer-un-favicon/">haz un
-      .ico</a>, que guarda varios tamaños en un archivo, porque la pestaña de un
-      navegador, un marcador y un acceso directo de Windows piden todos tamaños
+      favicon.</strong> El número está publicado y no hay nada que calcular:
+      exactamente lo que diga la página de la tienda. Para un favicon, ni
+      rasterices &mdash; <a href="../como-hacer-un-favicon/">haz un .ico</a>,
+      que guarda varios tamaños en un solo archivo, porque la pestaña del
+      navegador, un marcador y un acceso directo de Windows piden tamaños
       distintos.
     </p>
     <p><strong>Para imprenta.</strong> Multiplica el tamaño físico en pulgadas
-      por la resolución de la impresora. Un logotipo que va en una tarjeta de
-      visita con dos pulgadas de ancho a 300&nbsp;PPP son 600 píxeles; el mismo
-      logotipo a lo ancho de una página A4, con 8,3&nbsp;pulgadas, son unos 2500.
-      Las imprentas piden 300&nbsp;PPP por costumbre, y para una lona de gran
-      formato que se ve desde el otro lado de una sala 150 sobran.
+      por la resolución de la impresora. Un logotipo de dos pulgadas de ancho en
+      una tarjeta de visita, a 300&nbsp;PPP, son 600 píxeles; ese mismo logotipo
+      a lo ancho de una página A4, que son 8,3&nbsp;pulgadas, ronda los 2500.
+      Las imprentas piden 300&nbsp;PPP por costumbre; para una lona de gran
+      formato, que se mira desde el otro extremo de una sala, con 150 vas
+      sobrado.
     </p>
     <p><strong>Para una vista previa social o una imagen OG.</strong> La
-      plataforma dice una caja &mdash; 1200&nbsp;&times;&nbsp;630 para casi todas
-      las vistas previas de enlaces &mdash; y la caja tiene otra forma que tu
-      logotipo. Para eso está el ajuste de «rellenar»: el dibujo centrado con sus
-      propias proporciones, con un color de fondo llenando el resto, en lugar de
-      un logotipo estirado que le cuenta a todo el mundo que no lo comprobaste.
+      plataforma te da un recuadro &mdash; 1200&nbsp;&times;&nbsp;630 para casi
+      todas las vistas previas de enlaces &mdash; y ese recuadro no tiene la
+      forma de tu logotipo. Para eso está la opción de rellenar: el dibujo
+      centrado y con sus proporciones intactas, y el resto cubierto por un color
+      de fondo, en lugar de un logotipo estirado que le anuncia a todo el mundo
+      que no lo miraste.
     </p>
     <p>
-      Cuando se apliquen dos de estos, usa el mayor. Un PNG más grande de lo
-      necesario es una descarga algo mayor; uno demasiado pequeño no se puede
-      arreglar después, por la razón del apartado siguiente.
-    </p>
-  </section>
-
-  <section>
-    <h2>No se puede volver atrás</h2>
-    <p>
-      Rasterizar es de ida. Una vez que el dibujo es un PNG son píxeles como los de
-      cualquier otra imagen, y ampliarlo después tiene que inventar detalle que
-      nunca se midió &mdash; el mismo resultado blando y emborronado que da ampliar
-      una fotografía.
-    </p>
-    <p>
-      Así que conserva el SVG. Es la copia maestra, casi siempre es el archivo más
-      pequeño, y todos los tamaños futuros salen de él perfectamente. El PNG es una
-      exportación para un uso concreto, y cuando necesites otro tamaño lo correcto
-      es volver a exportar y no redimensionar lo que exportaste.
-    </p>
-    <p>
-      Hay software que dice convertir un PNG de vuelta en un SVG. Lo que hace es
-      calcar: adivinar qué curvas podrían explicar una rejilla de píxeles. Funciona
-      pasablemente con dibujo plano de dos colores y produce disparates caros con
-      cualquier otra cosa, y nunca recupera lo que tenía el dibujo original.
+      Si te tocan dos de estos casos a la vez, quédate con el número mayor. Un
+      PNG más grande de lo necesario es una descarga algo más pesada; uno
+      demasiado pequeño no tiene arreglo después, por lo que cuenta el apartado
+      siguiente.
     </p>
   </section>
 
   <section>
-    <h2>Tres cosas cambian en cuanto se convierte en píxeles</h2>
+    <h2>No hay marcha atrás</h2>
     <p>
-      Un SVG rasterizado que se ve mal casi siempre se ve mal por una de estas tres
-      razones, y las tres conviene conocerlas antes de exportar y no después.
+      Rasterizar es un billete de ida. En cuanto el dibujo se convierte en PNG,
+      son píxeles como los de cualquier otra imagen, y ampliarlo después obliga
+      a inventar un detalle que nunca se midió: el mismo resultado blando y
+      emborronado que da ampliar una fotografía.
     </p>
     <p>
-      <strong>El texto se dibuja con la tipografía que tenga la máquina.</strong>
-      Un SVG que contiene texto no contiene la tipografía &mdash; nombra una y deja
-      que el renderizador la encuentre. Si la tipografía no está instalada, se usa
-      una sustituta, y la sustituta tiene otras formas de letra y otras anchuras,
-      así que el texto puede recolocarse o desbordarse. A un archivo que se trae su
-      tipografía de una dirección web le va todavía peor: a un SVG que se rasteriza
-      a través de un <code>&lt;img&gt;</code> no se le permite descargar
-      absolutamente nada, así que no llega nada.
+      Así que guarda el SVG. Es la copia maestra, casi siempre es además el
+      archivo más ligero, y de él salen perfectos todos los tamaños que
+      necesites en el futuro. El PNG es una exportación para un uso concreto, y
+      cuando te haga falta otro tamaño lo que toca es volver a exportar, no
+      redimensionar lo que exportaste.
+    </p>
+    <p>
+      Hay programas que dicen convertir un PNG de vuelta en SVG. Lo que hacen es
+      calcar: adivinar qué curvas podrían explicar una rejilla de píxeles.
+      Funciona a medias con dibujo plano de dos colores, produce disparates
+      carísimos con cualquier otra cosa y nunca recupera lo que tenía el dibujo
+      original.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tres cosas cambian en cuanto hay píxeles de por medio</h2>
+    <p>
+      Un SVG rasterizado que se ve mal se ve mal, casi siempre, por una de estas
+      tres razones, y las tres conviene conocerlas antes de exportar y no
+      después.
+    </p>
+    <p>
+      <strong>El texto se dibuja con la tipografía que haya en la
+      máquina.</strong> Un SVG con texto no lleva la tipografía dentro: nombra
+      una y deja que el renderizador la busque. Si no está instalada se usa una
+      sustituta, y la sustituta tiene otras formas de letra y otras anchuras, así
+      que el texto puede recolocarse o desbordarse. A un archivo que se trae la
+      tipografía de una dirección web le va todavía peor: un SVG rasterizado a
+      través de una etiqueta <code>&lt;img&gt;</code> no tiene permiso para
+      descargar absolutamente nada, así que no le llega nada.
     </p>
     <p>
       La solución es la que cualquier diseñador ya conoce: <strong>convertir el
       texto en contornos</strong> antes de exportar el SVG (Illustrator lo llama
-      Crear contornos, Figma lo llama Flatten, Inkscape lo llama Objeto a trazado).
-      Las letras se convierten en geometría, la tipografía deja de importar y la
-      imagen se ve igual en todas las máquinas. Hazlo sobre una copia &mdash; el
-      texto convertido en contornos ya no se puede editar como texto.
+      Crear contornos; Figma, Flatten; Inkscape, Objeto a trazado). Las letras
+      pasan a ser geometría, la tipografía deja de importar y la imagen se ve
+      igual en todas partes. Hazlo sobre una copia: el texto convertido en
+      contornos ya no se puede editar como texto.
     </p>
     <p>
-      <strong>Las líneas de un pelo se vuelven grises o desaparecen.</strong> Un
-      trazo que sale a menos de un píxel al tamaño que has elegido no se puede
-      dibujar como una línea sólida, así que se dibuja como una tenue. Por eso un
-      logotipo delicado rasterizado a 64&nbsp;píxeles se ve deslavado mientras que
-      el mismo archivo a 512 se ve perfecto. Si el requisito es un tamaño pequeño,
-      la respuesta es un dibujo simplificado con trazos más gruesos y no otro
-      ajuste de exportación &mdash; que es la misma razón por la que un favicon es
-      un símbolo y no un logotipo de palabra.
+      <strong>Los trazos finísimos se agrisan o desaparecen.</strong> Un trazo
+      que al tamaño elegido mide menos de un píxel no se puede dibujar como una
+      línea sólida, así que se dibuja pálido. De ahí que un logotipo delicado
+      rasterizado a 64&nbsp;píxeles salga apagado y sucio mientras que el mismo
+      archivo a 512 sale impecable. Si el tamaño pequeño es innegociable, la
+      respuesta es un dibujo simplificado y con trazos más gruesos, no otro
+      ajuste de exportación. Es la misma razón por la que un favicon es un
+      símbolo y no un logotipo tipográfico.
     </p>
     <p>
-      <strong>La animación se para.</strong> Un SVG animado rasteriza a una sola
-      imagen fija: el primer fotograma, sea cual sea. No hay ningún ajuste de
-      exportación que cambie eso. Si necesitas el movimiento, necesitas un GIF o un
-      vídeo, hechos de otra manera.
+      <strong>La animación se detiene.</strong> Un SVG animado rasteriza a una
+      sola imagen fija: el primer fotograma, sea el que sea. No hay ningún
+      ajuste de exportación que cambie eso. Si necesitas el movimiento,
+      necesitas un GIF o un vídeo, que se hacen de otra manera.
     </p>
   </section>
 
   <section>
     <h2>La transparencia, y qué formato elegir</h2>
     <p>
-      <strong>PNG</strong> salvo que tengas un motivo. No tiene pérdidas, conserva
-      la transparencia, y el color plano con bordes duros &mdash; que es de lo que
-      está hecho casi todo dibujo &mdash; se comprime bien en él. Un logotipo
-      rasterizado suele ser un PNG <em>más pequeño</em> de lo que sería un JPEG,
-      además de más limpio.
+      <strong>PNG</strong>, salvo que tengas un motivo para otra cosa. No tiene
+      pérdidas, conserva la transparencia y comprime bien el color plano con
+      bordes duros, que es de lo que está hecho casi cualquier dibujo. Un
+      logotipo rasterizado suele salir en PNG <em>más ligero</em> de lo que
+      saldría en JPEG, además de más limpio.
     </p>
     <p>
       <strong>JPEG</strong> no tiene transparencia en absoluto. Cada píxel
-      transparente tiene que convertirse en algún color, y si nadie elige uno por ti
-      se convierte en negro &mdash; de ahí viene ese resultado de logotipo sobre
-      caja negra que la gente da por hecho que es un error. Además tiene pérdidas de
-      la forma que peor se nota justo en este tipo de imagen: un anillo de
-      salpicaduras alrededor de cada borde duro. Úsalo cuando algo insista.
+      transparente tiene que convertirse en algún color y, si nadie elige uno,
+      se convierte en negro: de ahí sale ese logotipo sobre una caja negra que
+      todo el mundo da por hecho que es un fallo. Encima tiene pérdidas
+      justamente del tipo que peor se disimula en esta clase de imagen, un halo
+      de suciedad alrededor de cada borde duro. Úsalo cuando alguien insista.
     </p>
     <p>
-      <strong>WebP</strong> hace todo lo que hace PNG, en un archivo más pequeño, y
+      <strong>WebP</strong> hace todo lo que hace PNG en un archivo más ligero, y
       lo lee cualquier navegador actual. La razón para no usarlo es lo que pasa
       después del navegador: el software antiguo, algunas imprentas y bastantes
       formularios de subida siguen sin abrir uno.
     </p>
     <p>
-      Elegir un color de fondo con PNG es también algo perfectamente normal de
-      querer. La transparencia solo es útil cuando aquello sobre lo que aterriza la
-      imagen es de un color que no puedes predecir; cuando ya sabes que es una
-      página blanca, aplanar sobre blanco evita toda una categoría de sorpresas.
+      Poner un color de fondo en un PNG también es una elección perfectamente
+      razonable. La transparencia solo sirve de algo cuando no sabes de qué color
+      será aquello sobre lo que va a aterrizar la imagen; si ya sabes que es una
+      página blanca, aplanar sobre blanco te evita toda una familia de sorpresas.
     </p>
   </section>
 
   <section>
-    <h2>Cuando la exportación sale en blanco o mal</h2>
+    <h2>Cuando la exportación sale en blanco o sale mal</h2>
     <p>
-      <strong>Nada más que espacio vacío.</strong> Normalmente falta el atributo
-      <code>xmlns</code> en el elemento raíz. Un archivo sin él no es SVG a efectos
-      de una etiqueta de imagen, y se dibuja como nada. Abrir el archivo en un
-      navegador es la prueba rápida: si el navegador tampoco enseña nada, el
-      problema es el archivo y no el conversor.
+      <strong>No sale más que espacio vacío.</strong> Casi siempre falta el
+      atributo <code>xmlns</code> en el elemento raíz. Un archivo sin él no
+      cuenta como SVG para una etiqueta de imagen, y se dibuja como nada. Abrir
+      el archivo en un navegador es la prueba rápida: si el navegador tampoco
+      enseña nada, el problema está en el archivo y no en el conversor.
     </p>
     <p>
-      <strong>El dibujo sale pequeño, en la esquina superior izquierda.</strong> El
-      archivo tiene <code>width</code> y <code>height</code> pero no
+      <strong>El dibujo sale pequeño, en la esquina superior izquierda.</strong>
+      El archivo tiene <code>width</code> y <code>height</code> pero no
       <code>viewBox</code>, así que no hay ningún sistema de coordenadas que
-      escalar y el dibujo conserva sus unidades originales sobre un lienzo más
-      grande. Un buen conversor te pone un viewBox; si el tuyo no lo ha hecho,
-      añadir <code>viewBox="0 0 <em>ancho</em> <em>alto</em>"</code> al elemento
-      raíz a mano lo arregla, y el archivo es texto plano, así que puedes.
+      escalar y el dibujo se queda con sus unidades originales sobre un lienzo
+      más grande. Un buen conversor te pone un viewBox; si el tuyo no lo ha
+      hecho, se arregla añadiendo a mano
+      <code>viewBox="0 0 <em>ancho</em> <em>alto</em>"</code> al elemento raíz, y
+      el archivo es texto plano, así que puedes hacerlo.
     </p>
     <p>
       <strong>Falta parte de la imagen.</strong> Algo del archivo apuntaba a una
-      dirección en vez de contener el dibujo &mdash; una fotografía incrustada
+      dirección en vez de llevar el dibujo dentro: una fotografía incrustada
       guardada como enlace, una hoja de estilos, una tipografía. Un rasterizador
       que se niegue a descargar eso está haciendo lo correcto, y es la misma
-      negativa que impide que un SVG que te has bajado de algún sitio informe a
-      quien lo hizo. Vuelve a exportar desde el programa de dibujo con las imágenes
-      incrustadas.
+      negativa que impide que un SVG bajado de cualquier sitio le dé señales a
+      quien lo hizo. Vuelve a exportar desde el programa de dibujo con las
+      imágenes incrustadas.
     </p>
     <p>
-      <strong>Rechaza un tamaño muy grande.</strong> Los navegadores ponen un tope
-      a lo grande que puede ser un lienzo, y no se ponen de acuerdo en dónde:
-      pasados unos 16&nbsp;000&nbsp;píxeles de lado no vuelve nada, y Safari en un
-      iPhone o un iPad se rinde mucho antes, alrededor de
-      4096&nbsp;&times;&nbsp;4096. Una herramienta que te avisa te está salvando de
-      un archivo en blanco, porque eso es lo que produce un navegador cuando se
-      queda sin recursos, en vez de un mensaje de error.
+      <strong>Rechaza un tamaño muy grande.</strong> Los navegadores ponen un
+      tope a lo grande que puede ser un lienzo, y no se ponen de acuerdo en
+      dónde: pasados unos 16&nbsp;000&nbsp;píxeles de lado no vuelve nada, y
+      Safari en un iPhone o un iPad se rinde mucho antes, alrededor de
+      4096&nbsp;&times;&nbsp;4096. Una herramienta que te avisa te está
+      ahorrando un archivo en blanco, porque eso es lo que devuelve un navegador
+      cuando se queda sin recursos: no un mensaje de error.
     </p>
   </section>
 
   <section>
     <h2>Nada de esto necesita una subida</h2>
     <p>
-      Rasterizar un SVG es algo que cualquier navegador hace miles de veces al día
-      &mdash; es la misma maquinaria que dibuja un icono en una página web. No hay
-      ninguna razón técnica para que tu dibujo viaje a un servidor y vuelva
-      convertido en PNG, y la herramienta de aquí no lo manda a ninguna parte: la
-      <code>Content-Security-Policy</code> de la página nombra todas las
-      direcciones que puede contactar, y ninguna es de este sitio.
+      Rasterizar un SVG es algo que cualquier navegador hace miles de veces al
+      día: es la misma maquinaria con la que dibuja un icono en una página web.
+      No hay ninguna razón técnica para que tu dibujo viaje hasta un servidor y
+      vuelva convertido en PNG, y esta herramienta no lo manda a ninguna parte:
+      la <code>Content-Security-Policy</code> de la página enumera todas las
+      direcciones con las que puede hablar, y ninguna es de este sitio.
     </p>
     <p>
-      Y con SVG eso importa más de lo habitual, porque un SVG es un documento y no
-      una imagen. Puede contener un script y una dirección remota, y un logotipo
-      que te ha mandado una agencia es un archivo que no escribiste tú. Dibujado a
-      través de una etiqueta de imagen está en lo que la especificación llama
-      <em>modo estático seguro</em>: el script no se puede ejecutar y con la
-      dirección no se contacta nunca. Eso lo hace cumplir el navegador, no la web.
+      Con SVG eso pesa más de lo habitual, porque un SVG es un documento y no una
+      imagen. Puede contener un script y una dirección remota, y el logotipo que
+      te ha mandado una agencia es un archivo que no escribiste tú. Dibujado a
+      través de una etiqueta de imagen queda en lo que la especificación llama
+      <em>modo estático seguro</em>: el script no puede ejecutarse y con la
+      dirección no se contacta jamás. De eso se encarga el navegador, no la web.
     </p>
     <p>
-      Carga la página, desenchúfate de internet y convierte algo de todos modos si
-      prefieres comprobarlo a que te lo cuenten.
+      Si prefieres comprobarlo antes que creértelo, carga la página,
+      desconéctate de internet y convierte algo de todos modos.
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      conversores en línea?</a> propone otras tres comprobaciones que puedes
       hacerle a cualquier herramienta.
     </p>
   </section>

--- a/locales/es/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/es/pages/guides/convert-an-svg-to-png.toml
@@ -8,17 +8,18 @@
 
 nav = "Convertir un SVG a PNG"
 
-title = "Cómo convertir un SVG en un PNG al tamaño correcto"
-description = "Un vector no tiene tamaño propio en píxeles, así que el número lo eliges tú. De dónde sale ese número para una pantalla, para el icono de una aplicación y para una imprenta, y qué cambia cuando un dibujo se convierte en píxeles."
+title = "Cómo convertir un SVG a PNG con el tamaño adecuado"
+description = "Un vector no tiene un tamaño propio en píxeles, así que el número lo pones tú. De dónde sale ese número para una pantalla, para el icono de una aplicación y para una imprenta, y qué se pierde cuando un dibujo pasa a ser píxeles."
 
-heading = "Cómo convertir un SVG en un PNG al tamaño correcto"
+heading = "Cómo convertir un SVG a PNG con el tamaño adecuado"
 lede = """
-    Convertir es la mitad fácil. La pregunta que decide si el resultado sirve de
-    algo es la que nadie te responde: ¿cuántos píxeles? Esto es de dónde sale ese
-    número, y qué pierde un dibujo camino de convertirse en uno."""
+    Convertir es la parte fácil. La pregunta que decide si el resultado sirve
+    de algo es la que nadie te responde: ¿cuántos píxeles? Aquí verás de dónde
+    sale ese número y qué pierde un dibujo por el camino de convertirse en
+    uno."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Convertir un SVG en un PNG al tamaño correcto"
-og_description = "De dónde sale de verdad el número de píxeles, y las tres cosas que cambian cuando un dibujo se convierte en píxeles."
+og_title = "Convertir un SVG a PNG con el tamaño adecuado"
+og_description = "De dónde sale de verdad el número de píxeles, y las tres cosas que cambian cuando un dibujo pasa a ser píxeles."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/convert-heic-to-jpg.html
+++ b/locales/es/pages/guides/convert-heic-to-jpg.html
@@ -1,247 +1,248 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre el <a href="../../convertir-heic-a-jpg/">convertidor de HEIC a JPG</a>,
-      suelta las fotos dentro y pulsa «Convertir». Deja el control de calidad
-      donde está y deja marcado «conservar la fecha, la cámara y los ajustes»
-      salvo que tengas un motivo para no hacerlo. Te llevas JPEG de vuelta, un
-      botón de descarga por cada uno, o un zip si son varios.
+      Abre el <a href="../../convertir-heic-a-jpg/">convertidor de HEIC a
+      JPG</a>, arrastra las fotos dentro y pulsa «Convertir». Deja el control de
+      calidad donde está y deja marcado «conservar la fecha, la cámara y los
+      ajustes», salvo que tengas un motivo para no hacerlo. Te devuelve JPEG, con
+      un botón de descarga por cada uno, o un zip si son varios.
     </p>
     <p>
-      Mientras lo haces no se sube nada. Eso es raro en este trabajo en concreto,
-      y la razón es la mitad interesante de esta página.
+      Mientras tanto no se sube nada. En este trabajo en concreto eso es raro, y
+      el porqué es la mitad interesante de esta página.
     </p>
   </section>
 
   <section>
     <h2>Qué es HEIC en realidad</h2>
     <p>
-      HEIC no es realmente un formato de imagen como lo es JPEG. Es un contenedor
-      &mdash; la misma estructura de cajas con la que está construido un MP4
-      &mdash; con un fotograma fijo de vídeo <strong>HEVC</strong> dentro. HEVC,
-      también llamado H.265, es el códec que sustituyó al que usaba tu vieja
-      videocámara, y es muy bueno: una foto de iPhone en HEIC ocupa más o menos la
-      mitad que la misma foto en JPEG a la misma calidad.
+      HEIC no es un formato de imagen al modo de JPEG. Es un contenedor &mdash;
+      la misma estructura de cajas con la que está montado un MP4 &mdash; con un
+      fotograma fijo de vídeo <strong>HEVC</strong> dentro. HEVC, también
+      llamado H.265, es el códec que sucedió al de aquella videocámara que
+      tenías, y es muy bueno: una foto de iPhone en HEIC ocupa más o menos la
+      mitad que esa misma foto en JPEG con la misma calidad.
     </p>
     <p>
-      Apple se pasó a él en iOS 11, en 2017, y lo puso por defecto. Lo que
-      significa que, a menos que alguien haya entrado en los ajustes y haya
-      elegido «Más compatible», todas las fotos que ha hecho su móvil durante casi
-      una década están en un formato que:
+      Apple se pasó a él en iOS 11, en 2017, y lo dejó puesto de fábrica. O sea
+      que, salvo que alguien haya entrado en los ajustes y haya elegido «Más
+      compatible», todas las fotos que ha hecho su móvil en casi una década están
+      en un formato que:
     </p>
     <ul>
       <li>Windows no previsualiza sin una extensión de la Store;</li>
       <li>casi todos los formularios de subida de la web rechazan de plano;</li>
       <li>muchísimo software de escritorio antiguo no ha oído nombrar en su vida;</li>
-      <li>y ningún navegador salvo Safari va a mostrar.</li>
+      <li>y ningún navegador que no sea Safari va a mostrar.</li>
     </ul>
     <p>
       La foto está perfectamente. Es un archivo mejor de lo que habría sido el
-      JPEG. Sencillamente está escrito en un idioma que casi todo el mundo no
-      aprendió nunca.
+      JPEG. Lo único que pasa es que está escrito en un idioma que casi nadie
+      aprendió.
     </p>
   </section>
 
   <section>
     <h2>Por qué solo Safari abre una</h2>
     <p>
-      Esta es la parte que explica todos los conversores que has usado en tu vida,
-      así que merece un párrafo.
+      Esta es la parte que explica todos los conversores que has usado en tu
+      vida, así que merece un párrafo.
     </p>
     <p>
-      Descodificar HEVC necesita un descodificador de HEVC, y HEVC está patentado.
-      Las licencias las administra más de un consorcio de patentes, y distribuir un
-      descodificador significa pagarle a alguien. Los navegadores se apañan con
-      esto apoyándose en el sistema operativo &mdash; Chrome reproduce
-      <em>vídeo</em> HEVC en un equipo cuyo hardware ya tiene un descodificador con
-      licencia &mdash;, pero esa vía está cableada para la reproducción de vídeo y
-      no para imágenes fijas. Así que un HEIC entregado a un
-      <code>&lt;img&gt;</code> se rechaza, en Chrome, en Firefox y en Edge por
-      igual, en todos los sistemas operativos.
+      Descodificar HEVC exige un descodificador de HEVC, y HEVC está patentado.
+      Las licencias las administra más de un consorcio de patentes, y distribuir
+      un descodificador significa pagarle a alguien. Los navegadores lo sortean
+      apoyándose en el sistema operativo &mdash; Chrome reproduce <em>vídeo</em>
+      HEVC en un equipo cuyo hardware ya trae un descodificador con licencia
+      &mdash;, pero esa vía está pensada para la reproducción de vídeo y no para
+      imágenes fijas. Así que un HEIC entregado a un <code>&lt;img&gt;</code> se
+      rechaza, lo mismo en Chrome que en Firefox o en Edge, y en cualquier
+      sistema operativo.
     </p>
     <p>
-      Safari sobre hardware de Apple es la excepción, porque macOS e iOS tienen el
-      descodificador y a Safari se le permite pedírselo. En todo lo demás, la
-      imagen es sencillamente indescodificable para el navegador.
+      Safari sobre hardware de Apple es la excepción, porque macOS e iOS sí
+      tienen el descodificador y Safari tiene permiso para pedírselo. En todo lo
+      demás, la imagen es sencillamente indescifrable para el navegador.
     </p>
     <p>
-      Lo que le deja a un conversor exactamente dos opciones, y la elección entre
-      ellas es la historia entera de este tipo de herramienta.
+      Eso le deja a un conversor exactamente dos caminos, y la elección entre
+      ellos es la historia entera de esta clase de herramienta.
     </p>
   </section>
 
   <section>
     <h2>Por qué casi todos los conversores de HEIC quieren una subida</h2>
     <p>
-      Opción uno: poner el descodificador en un servidor. La foto se sube, se
-      descodifica en una máquina que no has visto nunca, se recodifica como JPEG y
-      se te devuelve. Esto es lo que hace prácticamente cualquier «conversor de
-      HEIC gratuito en línea», y es por lo que todos necesitan tus archivos. No es
-      pereza &mdash; el navegador de verdad no puede hacerlo por su cuenta.
+      Camino uno: poner el descodificador en un servidor. La foto se sube, se
+      descodifica en una máquina que no has visto nunca, se recodifica como JPEG
+      y se te devuelve. Es lo que hace prácticamente cualquier «conversor de HEIC
+      gratis en línea», y por eso todos necesitan tus archivos. No es pereza: el
+      navegador de verdad no puede hacerlo por su cuenta.
     </p>
     <p>
-      Lo que eso cuesta merece decirse sin rodeos. Las fotos de un móvil son los
-      archivos más personales que tiene casi todo el mundo, y un HEIC recién salido
-      de un iPhone suele llevar las coordenadas del sitio donde se tomó, con una
-      precisión de unos pocos metros, junto con la fecha al segundo y un
+      Lo que eso cuesta conviene decirlo sin rodeos. Las fotos del móvil son los
+      archivos más personales que tiene casi cualquiera, y un HEIC recién salido
+      de un iPhone suele llevar dentro las coordenadas del lugar donde se hizo,
+      con una precisión de pocos metros, además de la fecha al segundo y un
       identificador de la cámara. Subir una carpeta entera a un servicio gratuito
-      significa entregar las dos cosas: las imágenes y eso. Lo que pase después lo
-      rige una política de privacidad que no leíste, en un servidor que no puedes
-      inspeccionar, en una jurisdicción que no elegiste.
+      es entregar las dos cosas a la vez: las imágenes y todo eso. Lo que pase
+      después lo decide una política de privacidad que no leíste, en un servidor
+      que no puedes inspeccionar y en un país que no elegiste.
     </p>
     <p>
-      Opción dos: poner el descodificador en la página. Eso es lo que hace
-      <a href="../../convertir-heic-a-jpg/">este</a>. Lleva <code>libheif</code>,
+      Camino dos: poner el descodificador en la propia página. Es lo que hace
+      <a href="../../convertir-heic-a-jpg/">este</a>. Trae <code>libheif</code>
       compilado a WebAssembly, como un archivo servido desde este sitio &mdash;
-      unos 1,4 MB, descargados una vez y después guardados en caché. Tu navegador
-      lo ejecuta en tu propio equipo, en tu propio hardware, y la foto no va a
-      ninguna parte. Carga la página una vez y puedes desenchufarte de internet del
-      todo y sigue funcionando, cosa que ningún conversor que suba archivos puede
-      hacer y la prueba más sencilla que hay.
+      1,4 MB, que se descargan una vez y luego quedan en la caché &mdash;. Tu
+      navegador lo ejecuta en tu propio equipo, con tu propio hardware, y la foto
+      no va a ninguna parte. Carga la página una sola vez y podrás desconectarte
+      de internet por completo: seguirá funcionando. Ningún conversor que suba
+      archivos puede decir lo mismo, y esa es la prueba más sencilla que existe.
     </p>
     <p>
-      Los 1,4 MB son el precio entero. Si estás con una conexión con límite de
-      datos es un coste real y conviene saberlo; por eso la página lo dice en voz
-      alta en vez de descargarlo en silencio.
+      Esos 1,4 MB son el precio entero. Si estás con una conexión con límite de
+      datos es un coste real y conviene saberlo, y por eso la página lo dice en
+      voz alta en lugar de descargarlos a tus espaldas.
     </p>
   </section>
 
   <section>
     <h2>Qué le cuesta a la imagen convertirla</h2>
     <p>
-      HEIC y JPEG son códecs distintos, así que no hay forma de pasar de uno a otro
-      sin descodificar la imagen y volver a codificarla. Esa segunda codificación
-      tiene pérdidas. En la práctica esto importa mucho menos de lo que suena:
+      HEIC y JPEG son códecs distintos, así que no hay manera de pasar de uno a
+      otro sin descodificar la imagen y volver a codificarla, y esa segunda
+      codificación tiene pérdidas. En la práctica importa mucho menos de lo que
+      suena:
     </p>
     <ul>
       <li>
         <strong>Con calidad 92</strong> &mdash; que es donde arranca el conversor
-        &mdash; una fotografía es muy difícil de distinguir del original a
-        cualquier tamaño normal de visionado. Estarías buscando diferencias en
-        degradados suaves, como un cielo despejado, y por lo general no las vas a
-        encontrar.
+        &mdash;, una fotografía es dificilísima de distinguir del original a
+        cualquier tamaño normal de visionado. Tendrías que buscar diferencias en
+        degradados suaves, un cielo despejado por ejemplo, y lo normal es que no
+        las encuentres.
       </li>
       <li>
-        <strong>El JPEG será más grande.</strong> Normalmente entre un tercio más
-        grande y el doble, porque JPEG es un códec de 1992 y HEVC no. Ese es el
-        trato: un archivo más grande que abre todo.
+        <strong>El JPEG pesará más.</strong> Entre un tercio y el doble,
+        normalmente, porque JPEG es un códec de 1992 y HEVC no. Ese es el trato:
+        un archivo más pesado que abre absolutamente todo.
       </li>
       <li>
-        <strong>Convertir dos veces es lo que hay que evitar.</strong> Cada
-        codificación con pérdidas cuesta un poco. Convierte desde el HEIC
-        original, no desde un JPEG que ya te hizo alguien, y hazlo una sola vez.
+        <strong>Lo que hay que evitar es convertir dos veces.</strong> Cada
+        codificación con pérdidas cuesta un poco. Convierte a partir del HEIC
+        original, no de un JPEG que ya te hizo alguien, y hazlo una sola vez.
       </li>
     </ul>
     <p>
-      Si no quieres ninguna pérdida, PNG está en el menú de formatos. Prepárate
-      para el archivo: una fotografía en PNG suele ser de cinco a diez veces el
-      tamaño del JPEG, porque la compresión de PNG se diseñó para el color plano y
-      el dibujo de línea, no para la hierba y la piel.
+      Si no quieres perder nada, tienes PNG en el menú de formatos. Hazte a la
+      idea del tamaño: una fotografía en PNG suele ocupar entre cinco y diez
+      veces lo que el JPEG, porque la compresión de PNG se diseñó para el color
+      plano y el dibujo lineal, no para la hierba y la piel.
     </p>
   </section>
 
   <section>
     <h2>La fecha, la cámara y las coordenadas</h2>
     <p>
-      La queja habitual con los conversores de HEIC es que las fotos vuelven
-      habiendo perdido el día en que se tomaron, así que las imágenes de unas
-      vacaciones enteras se ordenan al final de la fototeca con la fecha de hoy.
-      Eso pasa porque convertir a través de un lienzo te da píxeles y nada más
-      &mdash; un lienzo no guarda etiquetas &mdash;, así que a menos que un
-      conversor vaya a buscar los metadatos por separado, sencillamente
-      desaparecen.
+      La queja de siempre con los conversores de HEIC es que las fotos vuelven
+      sin el día en que se hicieron, así que las imágenes de unas vacaciones
+      enteras se amontonan al final de la fototeca con la fecha de hoy. Eso pasa
+      porque convertir a través de un lienzo da píxeles y nada más &mdash; un
+      lienzo no guarda etiquetas &mdash;, de modo que, si el conversor no va a
+      buscar los metadatos por separado, desaparecen sin más.
     </p>
     <p>
-      La herramienta de aquí copia el bloque EXIF del HEIC y lo escribe en el JPEG,
-      así que la fecha sobrevive. Hay una casilla, y viene marcada. Desmárcala y el
-      JPEG sale con la imagen y nada más.
+      Este conversor copia el bloque EXIF del HEIC y lo escribe en el JPEG, así
+      que la fecha sobrevive. Hay una casilla, y viene marcada. Desmárcala y el
+      JPEG sale con la imagen y con nada más.
     </p>
     <p>
-      Antes de decidir, mira la lista: la fila de cada foto dice si el archivo
-      lleva coordenadas GPS, y lo dice antes de que se convierta nada. Si las fotos
+      Antes de decidir, mira la lista: la fila de cada foto te dice si el archivo
+      lleva coordenadas GPS, y te lo dice antes de convertir nada. Si las fotos
       van a algún sitio público, esa es la línea que hay que leer. Si van a tu
-      propia fototeca, conservar los metadatos es casi seguro lo que quieres.
+      propia fototeca, conservar los metadatos es casi con seguridad lo que
+      quieres.
     </p>
     <p>
-      Una etiqueta se cambia elijas lo que elijas, y conviene saber por qué. Un
-      HEIC anota su rotación en dos sitios: en el contenedor y en el bloque EXIF.
-      El descodificador aplica la rotación del contenedor mientras descodifica, así
-      que los píxeles que entrega ya están derechos. Si el EXIF siguiera diciendo
-      «gira esto 90 grados», un visor lo haría otra vez y todas las fotos
-      verticales saldrían de lado. Así que la etiqueta de orientación se pone en
-      «derecha» y todo lo demás se copia exactamente como lo escribió el móvil.
+      Hay una etiqueta que cambia elijas lo que elijas, y conviene saber por qué.
+      Un HEIC apunta su rotación en dos sitios: en el contenedor y en el bloque
+      EXIF. El descodificador aplica la del contenedor mientras descodifica, así
+      que los píxeles que entrega ya salen derechos. Si el EXIF siguiera diciendo
+      «gira esto 90 grados», el visor lo giraría otra vez y todas las fotos
+      verticales aparecerían tumbadas. Por eso la etiqueta de orientación se deja
+      en «sin girar» y todo lo demás se copia tal cual lo escribió el móvil.
     </p>
     <p>
-      Si lo que quieres es repasar las etiquetas en detalle, o quitarlas de fotos
-      que ya son JPEG, eso es otro trabajo y hay una
-      <a href="../eliminar-datos-exif-y-gps/">guía para ello</a>.
+      Si lo que quieres es repasar las etiquetas con detalle, o quitárselas a
+      fotos que ya son JPEG, ese es otro trabajo y tiene su
+      <a href="../eliminar-datos-exif-y-gps/">propia guía</a>.
     </p>
   </section>
 
   <section>
-    <h2>Cosas con las que la gente se topa</h2>
+    <h2>Con lo que suele tropezar la gente</h2>
     <ul>
       <li>
-        <strong>Un HEIC llamado «.jpg».</strong> Extremadamente común: algo por el
-        camino lo renombró sin convertirlo, que es por lo que sigue sin abrirse.
-        Todo archivo que se suelte en el conversor se identifica por sus primeros
-        bytes y no por su nombre, así que uno de estos funciona sin problema. Es
-        además la razón de que a un archivo que sea de verdad un JPEG se le diga
-        que lo es, en lugar de convertirlo en una copia de sí mismo.
+        <strong>Un HEIC que se llama «.jpg».</strong> Pasa constantemente: algo
+        por el camino lo renombró sin convertirlo, y por eso sigue sin abrirse.
+        Cada archivo que sueltas en el conversor se identifica por sus primeros
+        bytes y no por su nombre, así que uno de estos entra sin problema. Es
+        también la razón de que a un archivo que sí es un JPEG de verdad se le
+        diga que ya lo es, en vez de convertirlo en una copia de sí mismo.
       </li>
       <li>
         <strong>Un archivo, varias imágenes.</strong> Una ráfaga o una Live Photo
-        pueden llevar más de una imagen fija. Se convierten todas, y las de más se
-        numeran a partir del nombre original. La mitad de vídeo de una Live Photo
-        es un archivo aparte que el móvil guarda junto al HEIC, así que no está ahí
-        para convertirlo.
+        pueden llevar más de una imagen fija. Se convierten todas, y las
+        adicionales se numeran a partir del nombre original. La mitad de vídeo de
+        una Live Photo es un archivo aparte que el móvil guarda junto al HEIC, así
+        que ahí no está para convertirla.
       </li>
       <li>
-        <strong>AVIF no es HEIC.</strong> Se parecen &mdash; el mismo contenedor,
-        otro códec dentro &mdash;, pero cualquier navegador actual abre un AVIF de
-        forma nativa, así que no hay nada que convertir y la herramienta lo dice en
-        vez de fingir que trabaja.
+        <strong>AVIF no es HEIC.</strong> Se parecen &mdash; mismo contenedor,
+        otro códec dentro &mdash;, pero cualquier navegador actual abre un AVIF
+        directamente, así que no hay nada que convertir y la herramienta te lo
+        dice en vez de fingir que trabaja.
       </li>
       <li>
         <strong>Cortar el problema de raíz.</strong> En el móvil: Ajustes &rarr;
-        Cámara &rarr; Formatos &rarr; Más compatible. A partir de ahí las fotos
-        nuevas son JPEG. Ocupa más almacenamiento y no toca las fotos que ya
-        tienes, pero significa no volver a hacer esto nunca.
+        Cámara &rarr; Formatos &rarr; Más compatible. A partir de ahí, las fotos
+        nuevas salen en JPEG. Ocupa más almacenamiento y no toca las que ya
+        tienes, pero te ahorra volver a pasar por esto.
       </li>
       <li>
-        <strong>Compartir a veces ya convierte.</strong> Pasar una foto por AirDrop
-        o por correo a un dispositivo que no sea de Apple muchas veces entrega un
-        JPEG, porque iOS convierte a la salida. Si una foto ha llegado como HEIC de
-        todas formas, vino por una vía que no lo hizo.
+        <strong>Compartir a veces convierte solo.</strong> Pasar una foto por
+        AirDrop o por correo a un dispositivo que no sea de Apple suele entregar
+        un JPEG, porque iOS convierte a la salida. Si una foto te ha llegado en
+        HEIC de todos modos, es que vino por una vía que no lo hace.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Cómo saber si un conversor está subiendo tus fotos</h2>
+    <h2>Cómo saber si un conversor te está subiendo las fotos</h2>
     <p>
-      Esto vale para cualquier herramienta, no solo para esta, y lleva unos quince
-      segundos.
+      Esto sirve para cualquier herramienta, no solo para esta, y lleva unos
+      quince segundos.
     </p>
     <ol>
       <li>
-        Abre la página, después abre las herramientas de desarrollo de tu navegador
-        y ve a la pestaña Red.
+        Abre la página, abre después las herramientas de desarrollo del navegador
+        y ve a la pestaña «Red».
       </li>
       <li>
-        Convierte una foto y mira. Una herramienta que descodifica en tu equipo no
-        hace ninguna petición en ese momento. Una herramienta que sube hace una del
-        tamaño de tu foto, y el tamaño se ve.
+        Convierte una foto y mira. Una herramienta que descodifica en tu equipo
+        no lanza ninguna petición en ese momento. Una que sube lanza una del
+        tamaño de tu foto, y ese tamaño se ve a simple vista.
       </li>
       <li>
-        O, más sencillo todavía: carga la página, desconéctate de internet e
-        intenta convertir algo. Una herramienta que mandara tu foto fuera a
-        descodificar deja de funcionar. Una que lleva el descodificador dentro, no.
+        O, todavía más fácil: carga la página, desconéctate de internet e intenta
+        convertir algo. Una herramienta que mandara tu foto fuera a descodificar
+        se quedaría parada. Una que lleva el descodificador dentro, no.
       </li>
     </ol>
     <p>
-      El conversor de aquí está construido para pasar las dos comprobaciones, y hay
-      una versión más larga de este argumento en
+      Este conversor está hecho para pasar las dos comprobaciones, y hay una
+      versión más larga del argumento en
       <a href="../es-seguro-subir-archivos/">¿es seguro subir archivos?</a>.
     </p>
   </section>

--- a/locales/es/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/es/pages/guides/convert-heic-to-jpg.toml
@@ -8,18 +8,18 @@
 
 nav = "HEIC a JPG"
 
-title = "Cómo convertir HEIC a JPG (y qué es HEIC en realidad)"
-description = "Los iPhone guardan las fotos como HEIC, y media internet no sabe abrir una. Qué es el formato, por qué solo Safari lo descodifica, qué le cuesta a la imagen convertirla, y cómo hacerlo sin subirle las fotos a nadie."
+title = "Cómo pasar de HEIC a JPG (y qué es HEIC en realidad)"
+description = "Los iPhone guardan las fotos en HEIC y media internet no sabe abrir una. Qué es ese formato, por qué solo lo descodifica Safari, qué le cuesta a la imagen convertirla y cómo hacerlo sin entregarle tus fotos a nadie."
 
 heading = "La foto que guardó tu móvil, y el formato que no abre nada"
 lede = """
-    Un iPhone guarda las fotos como HEIC, que es más pequeño y mejor que JPEG y
-    que muchísimo software se sigue negando a abrir. Esto es qué es el formato en
-    realidad, qué le cuesta a la imagen convertirla, y por qué casi todos los
-    conversores quieren que la subas primero."""
+    Un iPhone guarda las fotos en HEIC: un formato más ligero y mejor que JPEG
+    que muchísimo software se sigue negando a abrir. Esto es lo que HEIC es en
+    realidad, lo que le cuesta a la imagen convertirla y por qué casi todos los
+    conversores quieren que se la subas primero."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Cómo convertir HEIC a JPG"
-og_description = "Por qué las fotos de iPhone no se abren, qué cuesta convertirlas, y cómo hacerlo sin entregarle las fotos a nadie."
+og_title = "Cómo pasar de HEIC a JPG"
+og_description = "Por qué las fotos de iPhone no se abren, qué cuesta convertirlas y cómo hacerlo sin entregárselas a nadie."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/crop-a-video.html
+++ b/locales/es/pages/guides/crop-a-video.html
@@ -1,139 +1,144 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre el <a href="../../recortar-video/">recortador de vídeo</a>, suelta el
-      clip dentro, arrastra la caja sobre la parte que quieras conservar &mdash;
-      o fíjala a una forma si te han dado una &mdash; y exporta. El clip que sale
-      dura exactamente lo mismo que el que entró, con su sincronía y su sonido
-      intactos.
+      Abre el <a href="../../recortar-video/">recortador de vídeo</a>, arrastra
+      el clip dentro, dibuja el recuadro sobre la parte que quieras conservar
+      &mdash; o fíjalo a una proporción, si te han dado una &mdash; y exporta. El
+      clip que sale dura exactamente lo mismo que el que entró, con la sincronía
+      y el sonido intactos.
     </p>
     <p>
-      A diferencia de cortar, esto sí tiene que escribir fotogramas nuevos. No es
-      una carencia de ninguna herramienta en concreto; es lo que es recortar. El
-      resto de esta página va de lo que cuesta eso y de cómo mantenerlo bajo.
+      A diferencia de cortar, esto sí obliga a escribir fotogramas nuevos. No es
+      una carencia de una herramienta concreta: es en qué consiste recortar. El
+      resto de esta página va de lo que eso cuesta y de cómo mantener el gasto
+      bajo.
     </p>
   </section>
 
   <section>
-    <h2>Por qué recortar no puede evitar una recodificación</h2>
+    <h2>Por qué recortar no puede librarse de una recodificación</h2>
     <p>
-      Un corte conserva fotogramas enteros, así que un buen cortador los traslada
-      intactos y no se descodifica nada. Un recorte conserva parte de cada
-      fotograma &mdash; y parte de un fotograma es otra imagen distinta. No hay
-      forma de guardar otra imagen sin escribir los píxeles de nuevo.
+      Un corte conserva fotogramas enteros, así que un buen cortador se limita a
+      trasladarlos y no descodifica nada. Un recorte conserva un trozo de cada
+      fotograma, y un trozo de un fotograma es otra imagen distinta. Y no hay
+      forma de guardar otra imagen sin volver a escribir los píxeles.
     </p>
     <p>
-      Hay una excepción muy estrecha, y conviene conocerla para reconocer cuándo
-      alguien la invoca. El vídeo se codifica en bloques, y si un recorte cayera
-      exactamente sobre los límites de bloque por los cuatro lados, parte de los
-      datos podría en principio reutilizarse. En la práctica, las propias
+      Existe una excepción muy estrecha, y conviene conocerla para saber
+      reconocer a quien la invoca. El vídeo se codifica por bloques, y si un
+      recorte cayera justo sobre los límites de bloque por los cuatro lados,
+      parte de los datos podría reaprovecharse en teoría. En la práctica, las
       dimensiones del fotograma, los vectores de movimiento y la predicción hay
-      que reescribirlos igualmente, así que no se construye nada real de esa
-      manera. Da por hecho que un recorte significa una recodificación.
+      que reescribirlos igual, así que nadie construye nada así. Da por hecho que
+      recortar es recodificar.
     </p>
     <p>
-      Lo que sí hará un recortador que se porte bien es no gastar <em>más</em> de
-      lo que gastaba el original en esa misma zona. Codificar una región recortada
-      a más bitrate que su origen solo hace el archivo más grande; no puede
-      devolver detalle que el original no tenía.
+      Lo que sí hace un recortador que se porte bien es no gastar <em>más</em> de
+      lo que gastaba el original en esa misma zona. Codificar una región
+      recortada con más bitrate del que traía solo engorda el archivo: no puede
+      devolver un detalle que el original nunca tuvo.
     </p>
   </section>
 
   <section>
     <h2>Las formas que te están pidiendo de verdad</h2>
     <p>
-      Casi todos los recortes se hacen porque en algún sitio exigen una proporción
-      concreta. La lista corta:
+      Casi todos los recortes se hacen porque en algún sitio exigen una
+      proporción concreta. La lista corta:
     </p>
     <ul>
       <li>
         <strong>9:16 &mdash; vertical.</strong> Historias, reels, shorts, TikTok.
-        Pantalla completa en un móvil sostenido normalmente. La razón más común
-        por la que alguien recorta un vídeo.
+        Pantalla completa en un móvil sujeto como se sujeta normalmente. Es el
+        motivo más frecuente por el que alguien recorta un vídeo.
       </li>
       <li>
-        <strong>1:1 &mdash; cuadrado.</strong> Publicaciones de feed en varias
-        plataformas. Funciona sostengas el móvil como lo sostengas, que es por lo
-        que sigue vivo.
+        <strong>1:1 &mdash; cuadrado.</strong> Publicaciones de muro en varias
+        plataformas. Funciona sujetes el móvil como lo sujetes, y por eso sigue
+        vivo.
       </li>
       <li>
-        <strong>4:5 &mdash; ligeramente vertical.</strong> La forma más grande que
-        permiten algunos feeds, así que ocupa más pantalla que un cuadrado sin ser
-        un vídeo vertical completo.
+        <strong>4:5 &mdash; ligeramente vertical.</strong> La forma más grande
+        que admiten algunos muros, así que ocupa más pantalla que un cuadrado sin
+        llegar a ser un vertical completo.
       </li>
       <li>
         <strong>16:9 &mdash; horizontal.</strong> El estándar del vídeo en
-        general. Normalmente recortas <em>hacia</em> esto solo para quitar bandas
-        negras, o <em>desde</em> esto para llegar a alguna de las anteriores.
+        general. Lo normal es recortar <em>hacia</em> esta forma solo para quitar
+        bandas negras, o <em>desde</em> ella para llegar a alguna de las
+        anteriores.
       </li>
     </ul>
     <p>
-      Fija la caja a la proporción en vez de arrastrar a ojo. Quedarte a unos
-      pocos píxeles significa que la plataforma recorta tu recorte, y no te va a
-      consultar por dónde.
+      Fija el recuadro a la proporción en lugar de arrastrarlo a ojo. Si te
+      quedas a unos píxeles, la plataforma recortará tu recorte, y no va a
+      preguntarte por dónde.
     </p>
   </section>
 
   <section>
-    <h2>Convertir un clip horizontal en vertical</h2>
+    <h2>Pasar un clip horizontal a vertical</h2>
     <p>
-      Este es el caso común más difícil, y conviene tener claro que recortar es un
-      apaño más que una solución.
+      Este es el caso frecuente más difícil, y conviene tener claro desde el
+      principio que recortar es más un apaño que una solución.
     </p>
     <p>
-      Un vídeo 16:9 recortado a 9:16 conserva alrededor del 32&nbsp;% del ancho de
-      la imagen. Lo que haya a los lados desaparece &mdash; y en un plano
-      horizontal, los lados suelen ser donde está el contexto. Si hay dos personas
-      hablando en lados opuestos del encuadre, ningún recorte único conserva a las
-      dos.
+      Un vídeo 16:9 recortado a 9:16 conserva alrededor del 32&nbsp;% del ancho
+      de la imagen. Todo lo que quede a los lados desaparece, y en un plano
+      horizontal los lados suelen ser justo donde está el contexto. Si hay dos
+      personas hablando en extremos opuestos del encuadre, no existe un recorte
+      único que las conserve a las dos.
     </p>
     <p>
-      Elige el recorte viendo el clip una vez y preguntándote dónde está de verdad
-      el sujeto la mayor parte del tiempo. Si la respuesta es «se mueve», un
-      recorte estático es la herramienta equivocada y lo que quieres es un editor
-      que pueda desplazar el recorte con el tiempo. Si la respuesta es «en el
-      centro, casi siempre», un recorte centrado sirve y lleva diez segundos.
+      Para elegir el recorte, mira el clip una vez y pregúntate dónde está de
+      verdad el sujeto la mayor parte del tiempo. Si la respuesta es «se mueve»,
+      un recorte fijo no es la herramienta adecuada y lo que necesitas es un
+      editor que sepa desplazar el recorte a lo largo del tiempo. Si la respuesta
+      es «en el centro, casi siempre», un recorte centrado vale y se hace en diez
+      segundos.
     </p>
     <p>
-      La alternativa que conviene recordar: muchas plataformas aceptan un vídeo
-      horizontal y le ponen ellas las bandas. Recortar es para cuando quieres la
-      pantalla completa, no para cuando quieres que te acepten el vídeo.
-    </p>
-  </section>
-
-  <section>
-    <h2>Por qué el ancho y el alto se mueven de dos en dos</h2>
-    <p>
-      Si notas que la caja de recorte rechaza los números impares, es el códec y no
-      la interfaz lo que se está poniendo difícil.
-    </p>
-    <p>
-      H.264 &mdash; el códec que hay dentro de un MP4 &mdash; guarda el color a la
-      mitad de resolución en horizontal y en vertical, porque el ojo es mucho menos
-      sensible al detalle de color que al de brillo. Eso significa que la imagen se
-      maneja en unidades de dos píxeles y no hay forma de describir un fotograma
-      con un número impar de píxeles de lado.
-    </p>
-    <p>
-      Las herramientas se apañan con esto redondeando tu recorte después de que lo
-      fijes, lo que mueve tu caja un píxel sin decírtelo, o no ofreciendo nunca más
-      que números pares desde el principio. Lo segundo es lo que pasa aquí.
+      Y una alternativa que conviene no olvidar: muchas plataformas aceptan un
+      vídeo horizontal y le ponen ellas las bandas. Recortar es para cuando
+      quieres la pantalla completa, no para cuando quieres que te admitan el
+      vídeo.
     </p>
   </section>
 
   <section>
-    <h2>Qué le pasa al sonido</h2>
+    <h2>Por qué el ancho y el alto van de dos en dos</h2>
     <p>
-      Nada, por la vía de MP4. Recortar cambia la imagen y no tiene ninguna razón
-      para tocar el audio, así que el audio se copia muestra a muestra sin
-      descodificarlo nunca &mdash; byte por byte lo que había en el archivo.
+      Si ves que el recuadro de recorte rechaza los números impares, lo que se
+      está poniendo difícil es el códec y no la interfaz.
     </p>
     <p>
-      Por la alternativa de grabación, descrita más abajo, el sonido se captura de
-      la reproducción y se vuelve a codificar, lo que cuesta algo de calidad. En
-      cualquiera de los dos casos hay una casilla para dejarlo fuera del todo, que
-      merece la pena usar cuando el clip va a un sitio donde se reproduce sin
-      sonido igualmente y quieres el archivo más pequeño posible.
+      H.264 &mdash; el códec que suele haber dentro de un MP4 &mdash; guarda el
+      color a la mitad de resolución en horizontal y en vertical, porque el ojo
+      es mucho menos sensible al detalle de color que al de brillo. Eso hace que
+      la imagen se maneje en unidades de dos píxeles, y no hay manera de describir
+      un fotograma con un número impar de píxeles de lado.
+    </p>
+    <p>
+      Las herramientas resuelven esto de dos maneras: redondeando tu recorte
+      después de que lo fijes, con lo que te mueven el recuadro un píxel sin
+      avisar, o no ofreciéndote nunca más que números pares. Aquí ocurre lo
+      segundo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué pasa con el sonido</h2>
+    <p>
+      Por el camino del MP4, nada. Recortar cambia la imagen y no tiene ninguna
+      razón para tocar el audio, así que el audio se copia muestra a muestra sin
+      llegar a descodificarse: byte a byte lo que había en el archivo.
+    </p>
+    <p>
+      Por el camino de la grabación, el que se describe más abajo, el sonido se
+      captura de la reproducción y se vuelve a codificar, lo que cuesta algo de
+      calidad. En los dos casos hay una casilla para dejarlo fuera por completo,
+      que compensa usar cuando el clip va a un sitio donde se reproduce sin
+      sonido de todos modos y quieres el archivo más ligero posible.
     </p>
   </section>
 
@@ -141,70 +146,70 @@
     <h2>Formatos, y cuánto tarda</h2>
     <p>
       <strong>MP4, M4V y MOV</strong> se leen directamente, lleven lo que lleven
-      dentro &mdash; H.264, HEVC, AV1 o VP9 &mdash;, siempre que tu navegador sepa
-      descodificar ese códec. A diferencia de cortar, recortar sí tiene que
-      descodificar, así que aquí el códec importa de una manera en que allí no.
+      dentro &mdash; H.264, HEVC, AV1 o VP9 &mdash;, siempre que tu navegador
+      sepa descodificar ese códec. A diferencia de cortar, recortar sí obliga a
+      descodificar, así que aquí el códec importa como allí no importaba.
     </p>
     <p>
-      <strong>Cualquier otra cosa que tu navegador sepa reproducir</strong>, WebM
-      la más evidente, se recorta reproduciéndola y grabando el resultado, lo que
-      funciona y tarda lo que dure el clip.
+      <strong>Cualquier otra cosa que tu navegador sepa reproducir</strong>, y
+      WebM es el caso claro, se recorta reproduciéndola y grabando el resultado,
+      lo que funciona y tarda lo que dure el clip.
     </p>
     <p>
-      <strong>AVI, WMV, FLV y casi todos los MKV</strong> el navegador no los sabe
-      ni leer ni reproducir, y la herramienta los rechaza con un mensaje en vez de
-      fallar a mitad de camino.
+      <strong>AVI, WMV, FLV y casi todos los MKV</strong> el navegador no los
+      sabe ni leer ni reproducir, y la herramienta los rechaza con un mensaje en
+      lugar de fallar a medio camino.
     </p>
     <p>
-      Cuenta con que un recorte lleve su tiempo en un clip largo, porque cada
-      fotograma se está descodificando y recodificando. La herramienta no lleva
-      ningún límite dentro, y el archivo se recorre de unos pocos megabytes en unos
-      pocos megabytes en vez de cargarlo entero; el techo práctico es el vídeo
-      terminado, que se monta en memoria antes de que lo descargues.
+      Cuenta con que un clip largo tarde, porque cada fotograma se descodifica y
+      se vuelve a codificar. La herramienta no impone ningún límite, y el archivo
+      se va recorriendo a trozos de unos pocos megabytes en lugar de cargarlo
+      entero; el techo real es el vídeo terminado, que se monta en memoria antes
+      de que te lo descargues.
     </p>
   </section>
 
   <section>
-    <h2>Recorta antes de hacer cualquier otra cosa</h2>
+    <h2>Corta primero, recorta después</h2>
     <p>
-      Si un clip necesita corte y recorte, corta primero &mdash; es gratis, y cada
-      segundo que quitas es un segundo que nadie tiene que recodificar. Después
-      recorta el clip más corto una sola vez.
+      Si un clip necesita corte y recorte, empieza por el corte: es gratis, y
+      cada segundo que quitas es un segundo que nadie tendrá que recodificar.
+      Después recorta el clip ya corto, una sola vez.
     </p>
     <p>
-      Hacerlo al revés significa recortar material que estás a punto de tirar, lo
-      que cuesta tiempo y calidad para nada. El
-      <a href="../../cortar-video/">cortador de vídeo</a> está al lado, y
+      Al revés estarías recortando material que vas a tirar acto seguido, lo que
+      cuesta tiempo y calidad para nada. El
+      <a href="../../cortar-video/">cortador de vídeo</a> está aquí al lado, y
       <a href="../cortar-un-video/">su guía</a> explica por qué ese paso no tiene
-      por qué costarte nada en absoluto.
+      por qué costarte absolutamente nada.
     </p>
     <p>
-      Y en general: cada paso con pérdidas se acumula. Un recorte de un original es
-      una generación. Un recorte de un corte de una exportación de una descarga son
-      cuatro, y se nota.
+      Y en general: los pasos con pérdidas se van sumando. Un recorte de un
+      original es una generación. Un recorte de un corte de una exportación de
+      una descarga son cuatro, y se nota a la primera.
     </p>
   </section>
 
   <section>
     <h2>Por qué esto no necesita una subida</h2>
     <p>
-      Descodificar y recodificar vídeo en un navegador es reciente y es real:
-      WebCodecs expone el mismo codificador por hardware que usa tu móvil para
-      grabar vídeo, y es rápido por la misma razón. El trabajo ocurre en el equipo
-      que ya tiene el archivo, que para un vídeo de varios gigabytes es además la
-      única disposición con sentido &mdash; subirlo y descargar el resultado cuesta
-      más tiempo que la propia codificación.
+      Descodificar y recodificar vídeo dentro de un navegador es algo reciente y
+      es real: WebCodecs da acceso al mismo codificador por hardware que usa tu
+      móvil para grabar, y es rápido por esa misma razón. El trabajo ocurre en el
+      equipo que ya tiene el archivo, que para un vídeo de varios gigabytes es
+      además la única forma que tiene sentido: subirlo y descargar el resultado
+      lleva más tiempo que la propia codificación.
     </p>
     <p>
-      La herramienta de aquí no tiene ninguna función de red, y la
-      <code>Content-Security-Policy</code> de la página nombra todas las
-      direcciones que puede contactar, ninguna de las cuales es de este sitio.
-      Desenchúfate de internet y recorta un clip de todos modos si prefieres
-      comprobarlo a que te lo cuenten.
+      Este recortador no tiene ninguna función de red, y la
+      <code>Content-Security-Policy</code> de la página enumera todas las
+      direcciones con las que puede hablar, y ninguna es de este sitio. Si
+      prefieres comprobarlo antes que creértelo, desconéctate de internet y
+      recorta un clip de todos modos.
     </p>
     <p>
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      conversores en línea?</a> propone otras tres comprobaciones que puedes
       hacerle a cualquier herramienta.
     </p>
   </section>

--- a/locales/es/pages/guides/crop-a-video.toml
+++ b/locales/es/pages/guides/crop-a-video.toml
@@ -7,18 +7,18 @@
 
 nav = "Recortar un vídeo"
 
-title = "Cómo recortar un vídeo a otra forma"
-description = "Deja un clip reducido a un cuadrado, a un vertical 9:16 o a una caja de píxeles exacta. Qué proporción quiere cada plataforma, por qué recortar tiene que recodificar cuando cortar no, y lo que eso cuesta."
+title = "Cómo recortar un vídeo y cambiarle la forma"
+description = "Deja un clip cuadrado, vertical 9:16 o del tamaño exacto que te pidan. Qué proporción quiere cada plataforma, por qué recortar obliga a recodificar cuando cortar no, y lo que eso cuesta."
 
-heading = "Cómo recortar un vídeo a otra forma"
+heading = "Cómo recortar un vídeo y cambiarle la forma"
 lede = """
-    Recortar cambia la forma de la imagen, lo que significa escribir fotogramas
-    nuevos &mdash; no hay manera de evitarlo, y cualquier herramienta que diga lo
-    contrario está haciendo otra cosa. Esto es lo que cuesta, y cómo gastarlo
+    Recortar cambia la forma de la imagen, y eso significa escribir fotogramas
+    nuevos: no hay manera de esquivarlo, y cualquier herramienta que diga lo
+    contrario está haciendo otra cosa. Esto es lo que cuesta y cómo gastarlo
     bien."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Cómo recortar un vídeo a otra forma"
-og_description = "Qué proporción quiere cada plataforma, por qué recortar tiene que recodificar cuando cortar no, y lo que eso cuesta."
+og_title = "Recortar un vídeo y cambiarle la forma"
+og_description = "Qué proporción quiere cada plataforma, por qué recortar obliga a recodificar cuando cortar no, y lo que eso cuesta."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/embed-an-image-in-css.html
+++ b/locales/es/pages/guides/embed-an-image-in-css.html
@@ -1,236 +1,235 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre <a href="../../imagen-a-base64/">Imagen a data URI</a>, suelta la
+      Abre <a href="../../imagen-a-base64/">Imagen a data URI</a>, arrastra la
       imagen dentro, elige <em>una propiedad personalizada de CSS</em> y pega la
-      línea al principio de tu hoja de estilos. Después úsala como
+      línea al principio de tu hoja de estilos. A partir de ahí la usas como
       <code>background-image: var(--logo)</code> donde te haga falta.
     </p>
     <p>
-      Hazlo cuando la imagen sea pequeña &mdash; un icono, una viñeta, una flecha,
-      un patrón &mdash; y haga falta en todas las páginas. No lo hagas con una
-      fotografía. Todo lo de abajo es por qué esas dos frases se contradicen, y
-      cómo saber cuál de los dos casos tienes delante.
+      Hazlo cuando la imagen sea pequeña &mdash; un icono, una viñeta, una
+      flecha, un patrón &mdash; y aparezca en todas las páginas. No lo hagas con
+      una fotografía. El resto de esta página explica por qué esas dos frases se
+      contradicen y cómo saber en cuál de los dos casos estás.
     </p>
   </section>
 
   <section>
     <h2>Qué es en realidad un data URI</h2>
     <p>
-      Una dirección que contiene la cosa en vez de apuntar a ella. Donde una hoja
-      de estilos diría normalmente
+      Una dirección que lleva la cosa dentro en vez de apuntar a ella. Donde una
+      hoja de estilos diría normalmente
     </p>
     <pre><code>background-image: url("logo.png");</code></pre>
     <p>
-      y el navegador va a buscar <code>logo.png</code>, un data URI dice
+      y el navegador sale a buscar <code>logo.png</code>, un data URI dice
     </p>
-    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <pre class="wrap"><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
     <p>
-      y no hay nada que buscar: la imagen ya está ahí, escrita en caracteres. Tiene
-      tres partes. <code>data:</code> es el esquema. <code>image/png</code> es el
-      tipo de medio, y el navegador se lo cree por completo &mdash; más sobre eso
-      abajo. Todo lo que va después de la coma es el archivo.
-    </p>
-    <p>
-      Esa es la idea entera. No es ningún truco ni ningún apaño; está en los
-      estándares desde 1998 y funciona en todos los navegadores publicados desde
-      entonces.
-    </p>
-  </section>
-
-  <section>
-    <h2>Lo que te compra: un viaje de ida y vuelta menos</h2>
-    <p>
-      El ahorro no es de ancho de banda. Es de la petición.
+      y no hay nada que buscar: la imagen ya está ahí, escrita en caracteres.
+      Tiene tres partes. <code>data:</code> es el esquema. <code>image/png</code>
+      es el tipo de medio, y el navegador se lo cree a pies juntillas &mdash;
+      volvemos a eso más abajo &mdash;. Y todo lo que viene después de la coma es
+      el archivo.
     </p>
     <p>
-      Un navegador no puede pedir <code>logo.png</code> hasta que ha leído la hoja
-      de estilos que lo menciona, y no puede leer la hoja de estilos hasta que se
-      la ha descargado. Así que una imagen de fondo corriente está al menos a dos
-      viajes de ida y vuelta de profundidad dentro de la carga de la página, y en
-      un móvil con red lenta un viaje de ida y vuelta pueden ser un par de cientos
-      de milisegundos por pequeño que sea el archivo. Una flecha de 600 bytes no
-      cuesta casi nada de transferir y puede costar igualmente un cuarto de segundo
-      en llegar.
-    </p>
-    <p>
-      Incrustada, llega con la hoja de estilos. Ese es el beneficio entero, y para
-      un icono pequeño que aparece en la primera pantalla es un beneficio de
-      verdad.
+      Esa es la idea entera. No es un truco ni un apaño: está en los estándares
+      desde 1998 y funciona en todos los navegadores publicados desde entonces.
     </p>
   </section>
 
   <section>
-    <h2>Lo que cuesta: un tercio, y después la caché</h2>
+    <h2>Lo que ganas: un viaje de ida y vuelta menos</h2>
     <p>
-      <strong>Base64 añade alrededor de un tercio.</strong> Tres bytes de archivo
-      se convierten en cuatro caracteres, porque eso es lo que hace falta para
-      escribir bytes arbitrarios usando solo los caracteres que permite una URL. No
-      hay ningún codificador ingenioso que lo evite. Un PNG de 9 KB son 12 KB de
-      hoja de estilos.
+      Lo que ahorras no es ancho de banda. Es la petición.
     </p>
     <p>
-      <strong>La compresión no lo devuelve.</strong> Esta es la parte que la gente
-      da por supuesta. Gzip y Brotli funcionan encontrando redundancia, y un PNG,
-      un JPEG y un WebP ya vienen comprimidos &mdash; les queda muy poca
-      redundancia, y base64 no añade ninguna. En la práctica recuperas algo así
-      como una décima parte de ese tercio, no el tercio entero. (Un SVG es el caso
-      contrario, y el apartado siguiente va de eso.)
+      Un navegador no puede pedir <code>logo.png</code> hasta que ha leído la
+      hoja de estilos que lo menciona, y no puede leer la hoja de estilos hasta
+      habérsela descargado. Así que una imagen de fondo corriente queda, como
+      mínimo, dos viajes de ida y vuelta hacia dentro de la carga de la página, y
+      en un móvil con red lenta un viaje de ida y vuelta pueden ser doscientos
+      milisegundos por pequeño que sea el archivo. Transferir una flecha de 600
+      bytes no cuesta nada, y aun así puede tardar un cuarto de segundo en
+      aparecer.
+    </p>
+    <p>
+      Incrustada, llega con la hoja de estilos. Ese es el beneficio entero, y
+      para un icono pequeño que se ve nada más entrar es un beneficio real.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lo que cuesta: un tercio, y luego la caché</h2>
+    <p>
+      <strong>Base64 añade alrededor de un tercio.</strong> Cada tres bytes de
+      archivo se convierten en cuatro caracteres, porque eso es lo que hace falta
+      para escribir bytes arbitrarios usando solo los caracteres que admite una
+      URL. No hay codificador ingenioso que lo esquive: un PNG de 9 KB son 12 KB
+      de hoja de estilos.
+    </p>
+    <p>
+      <strong>La compresión no te lo devuelve.</strong> Esta es la parte que
+      todo el mundo da por hecha. Gzip y Brotli trabajan buscando redundancia, y
+      un PNG, un JPEG o un WebP ya vienen comprimidos: les queda poquísima
+      redundancia, y base64 no aporta ninguna. En la práctica recuperas más o
+      menos una décima parte de ese tercio, no el tercio. (Con un SVG pasa justo
+      lo contrario, y de eso va el apartado siguiente.)
     </p>
     <p>
       <strong>Deja de ser un archivo.</strong> Este es el coste que no aparece en
-      ninguna medición que sea probable que hagas, y es el que importa cuando la
+      ninguna medición que vayas a hacer, y el que de verdad importa cuando la
       cosa crece:
     </p>
     <ul>
       <li>
-        <strong>No se puede cachear por su cuenta.</strong> Una imagen corriente
-        se descarga una vez y se reutiliza durante un año. Una incrustada es parte
+        <strong>No se puede cachear por su cuenta.</strong> Una imagen normal se
+        descarga una vez y se reutiliza durante un año. Una incrustada es parte
         de la hoja de estilos, así que vive y muere con la entrada de caché de la
         hoja de estilos.
       </li>
       <li>
-        <strong>Cambiar cualquier cosa lo vuelve a descargar todo.</strong>
-        Arregla un margen, publica una hoja de estilos nueva, y todos los
-        visitantes se vuelven a descargar con ella la imagen incrustada &mdash; una
+        <strong>Tocar cualquier cosa obliga a descargarlo todo otra
+        vez.</strong> Corriges un margen, publicas una hoja de estilos nueva, y
+        todos los visitantes se descargan con ella la imagen incrustada: una
         imagen que no ha cambiado en dos años.
       </li>
       <li>
-        <strong>Está en el camino crítico.</strong> Una hoja de estilos bloquea el
-        renderizado. Una imagen no. Incrustar una imagen la mueve de la segunda
-        categoría a la primera: la página no puede pintar hasta que ha llegado
-        todo, imagen incluida.
+        <strong>Se mete en el camino crítico.</strong> Una hoja de estilos
+        bloquea el renderizado; una imagen no. Incrustar una imagen la pasa de la
+        segunda categoría a la primera: la página no puede pintar hasta que ha
+        llegado todo, imagen incluida.
       </li>
       <li>
-        <strong>No se puede descargar en paralelo.</strong> Los navegadores bajan
-        muchas cosas a la vez. Una imagen incrustada no es una cosa aparte, así que
-        no se lleva nada de eso.
+        <strong>No se descarga en paralelo.</strong> Los navegadores bajan muchas
+        cosas a la vez. Una imagen incrustada no es una cosa aparte, así que no
+        se aprovecha de nada de eso.
       </li>
     </ul>
     <p>
-      Umbrales aproximados, que son donde cambia el consejo y no donde un navegador
-      haga nada distinto: por debajo de unos 2 KB es una victoria clara; hasta unos
-      10 KB suele seguir mereciendo la pena para algo que está en todas las
-      páginas; pasados los 50 KB es un error sin mensaje de error.
-      <a href="../../imagen-a-base64/">La herramienta</a> te dice en qué franja cae
-      cada resultado, con el número de caracteres al lado.
+      Los umbrales, muy a ojo &mdash; marcan dónde cambia el consejo, no dónde un
+      navegador hace algo distinto &mdash;: por debajo de unos 2 KB sale
+      claramente a cuenta; hasta unos 10 KB suele seguir compensando para algo
+      que aparece en todas las páginas; pasados los 50 KB es un error que no da
+      ningún error. <a href="../../imagen-a-base64/">La herramienta</a> te dice en
+      qué franja cae cada resultado, con el número de caracteres al lado.
     </p>
   </section>
 
   <section>
     <h2>No pases nunca un SVG a base64</h2>
     <p>
-      Este es el error más común de las imágenes incrustadas, y lo cometen los
-      exportadores y los complementos de compilación tanto como las personas.
+      Este es el fallo más habitual de las imágenes incrustadas, y lo cometen
+      tanto los exportadores y los complementos de compilación como las personas.
     </p>
     <p>
-      Un SVG es texto. Una URL ya lleva texto. Solo hay que escapar un puñado de
+      Un SVG es texto, y una URL ya lleva texto. Basta con escapar un puñado de
       caracteres &mdash; <code>%</code>, <code>#</code>, <code>&lt;</code>,
-      <code>&gt;</code> y la comilla con la que lo hayas envuelto &mdash; y todo lo
-      demás se puede dejar exactamente como está. Codificarlo así da un URI que
-      suele ser una quinta parte más corto que el base64 del mismo archivo, y que
-      después se comprime como texto en vez de como ruido.
+      <code>&gt;</code> y la comilla con la que lo hayas envuelto &mdash; y todo
+      lo demás puede quedarse tal cual. Codificado así sale un URI que suele ser
+      una quinta parte más corto que el base64 del mismo archivo, y que además se
+      comprime como texto en vez de como ruido.
     </p>
     <p>
-      Y además sigue siendo legible:
+      Y encima sigue siendo legible:
     </p>
-    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <pre class="wrap"><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
     <p>
-      Ves el <code>viewBox</code>. Puedes cambiar el color de relleno en tu editor
-      sin descodificar nada. Pasa el mismo archivo a base64 y se convierte en un
-      muro de letras que nadie va a volver a tocar jamás.
-      <a href="../../imagen-a-base64/">Imagen a data URI</a> hace esto
-      automáticamente con todo lo que resulte ser un SVG, y tiene una casilla para
-      esa rara cadena de herramientas que insiste en <code>;base64</code>.
+      Se ve el <code>viewBox</code>. Puedes cambiar el color de relleno en tu
+      editor sin descodificar nada. Pasa ese mismo archivo a base64 y se convierte
+      en un muro de letras que nadie va a volver a tocar.
+      <a href="../../imagen-a-base64/">Imagen a data URI</a> hace esto solo con
+      todo lo que resulte ser un SVG, y trae una casilla para esa rara cadena de
+      herramientas que insiste en <code>;base64</code>.
     </p>
   </section>
 
   <section>
-    <h2>El error de comillas que solo rompe los SVG</h2>
+    <h2>El fallo de comillas que solo rompe los SVG</h2>
     <p>
       CSS te deja escribir <code>url()</code> sin comillas, y para un nombre de
-      archivo corriente eso está bien:
+      archivo normal no pasa nada:
     </p>
     <pre><code>background-image: url(logo.png);</code></pre>
     <p>
       Haz lo mismo con un SVG codificado con porcentajes y se rompe. Un token
       <code>url()</code> sin comillas termina en el primer espacio, paréntesis,
-      comilla o carácter de control &mdash; y un SVG está lleno de espacios, entre
-      cada atributo y cada número de un trazado. La declaración queda entonces
-      inválida, CSS descarta las declaraciones inválidas en silencio, y te quedas
-      sin fondo y sin error.
+      comilla o carácter de control, y un SVG está lleno de espacios: entre cada
+      atributo y entre cada número de un trazado. La declaración queda inválida,
+      CSS descarta en silencio las declaraciones inválidas, y te quedas sin fondo
+      y sin ningún error.
     </p>
     <p>
       La solución son comillas, siempre:
     </p>
     <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
     <p>
-      Es además la razón de que un codificador no necesite escapar los espacios
-      &mdash; son perfectamente legales dentro de una URL entrecomillada, y escapar
-      cada uno como <code>%20</code> costaría tres caracteres por cada espacio del
-      archivo. Las dos decisiones van juntas: entrecomilla el URI y podrás dejar
-      los espacios en paz. Todas las formas que produce la herramienta van
-      entrecomilladas exactamente por esto.
+      Es también la razón por la que un codificador no necesita escapar los
+      espacios: dentro de una URL entrecomillada son perfectamente legales, y
+      escapar cada uno como <code>%20</code> costaría tres caracteres por cada
+      espacio del archivo. Las dos decisiones van juntas: entrecomilla el URI y
+      podrás dejar los espacios en paz. Todo lo que produce la herramienta sale
+      entrecomillado justamente por esto.
     </p>
   </section>
 
   <section>
     <h2>El tipo de medio tiene que estar bien</h2>
     <p>
-      Un data URI declara su propio tipo, y el navegador se lo cree. No hay ninguna
-      detección de reserva como la hay para un archivo descargado: di
-      <code>image/png</code> de algo que en realidad es un JPEG y la imagen no se
-      dibuja, sin ningún mensaje en ningún sitio útil.
+      Un data URI declara su propio tipo y el navegador se lo cree. Aquí no hay
+      ninguna detección de respaldo como la que sí existe para un archivo
+      descargado: di <code>image/png</code> de algo que en realidad es un JPEG y
+      la imagen no se dibuja, sin ningún mensaje en ningún sitio útil.
     </p>
     <p>
-      Cosa que importa porque las extensiones de archivo mienten. Una foto
-      exportada como JPEG y renombrada <code>logo.png</code> es algo corriente de
-      encontrarse en un disco. Los primeros bytes de un archivo de imagen, en
-      cambio, dicen sin ambigüedad qué es &mdash; todos los formatos tienen una
-      firma &mdash;, así que una herramienta debería leer el archivo y no su
-      nombre. La de aquí lo hace, y te avisa cuando los dos no coinciden.
+      Y eso importa, porque las extensiones de archivo mienten. Una foto
+      exportada como JPEG y renombrada <code>logo.png</code> es algo que se
+      encuentra en cualquier disco. Los primeros bytes de un archivo de imagen,
+      en cambio, dicen sin lugar a dudas qué es &mdash; todos los formatos tienen
+      su firma &mdash;, así que una herramienta debería leer el archivo y no su
+      nombre. Esta lo hace, y te avisa cuando los dos no coinciden.
     </p>
     <p>
       Hay dos formatos que conviene conocer porque fallan de forma confusa.
       <strong>HEIC</strong>, que es en lo que fotografía un iPhone, y
-      <strong>TIFF</strong>, que es lo que producen los escáneres, hacen los dos
-      data URI perfectamente válidos que ningún navegador salvo Safari va a
-      dibujar. El URI no está roto; sencillamente el formato no es de los que la
-      web soporta. Conviértelos antes.
+      <strong>TIFF</strong>, que es lo que sale de un escáner, producen data URI
+      perfectamente válidos que ningún navegador que no sea Safari va a dibujar.
+      El URI no está roto: es que el formato no es de los que la web admite.
+      Conviértelos antes.
     </p>
   </section>
 
   <section>
     <h2>Los metadatos que no querías publicar</h2>
     <p>
-      Un data URI es una copia del archivo, byte por byte. No se descodifica ni se
-      recodifica nada, que suele ser el sentido de todo esto &mdash; no se pierde
+      Un data URI es una copia del archivo, byte a byte. No se descodifica ni se
+      recodifica nada, que suele ser justamente la gracia &mdash; no se pierde
       calidad &mdash;, pero también significa que todo lo demás del archivo se
       viene contigo.
     </p>
     <p>
-      Una fotografía recién salida de un móvil lleva EXIF: las coordenadas GPS del
-      sitio donde se tomó, la marca de tiempo, el modelo de cámara y muchas veces
-      su número de serie. Eso pueden ser 30 KB del archivo. Incrustado, se
-      convierte en 40 KB de base64 dentro de tu hoja de estilos, en el camino
-      crítico de todas las páginas &mdash; y en una dirección de casa metida en un
-      repositorio, en una forma en la que nadie va a pensar en mirar.
+      Una fotografía recién salida de un móvil lleva EXIF: las coordenadas GPS
+      del lugar donde se hizo, la fecha, el modelo de cámara y muchas veces su
+      número de serie. Eso pueden ser 30 KB del archivo. Incrustado, se convierte
+      en 40 KB de base64 dentro de tu hoja de estilos, en el camino crítico de
+      todas las páginas, y en la dirección de una casa subida a un repositorio
+      con una forma en la que a nadie se le va a ocurrir mirar.
     </p>
     <p>
-      Quítalo antes con el <a href="../../eliminar-datos-exif/">visor y eliminador
-      de EXIF</a>, que reescribe el contenedor sin tocar la imagen; también hay una
-      <a href="../eliminar-datos-exif-y-gps/">guía sobre eso</a>. Imagen a data URI
-      lee cuántos metadatos hay en un JPEG, un PNG o un WebP y lo dice antes de que
-      copies nada.
+      Quítalo antes con el <a href="../../eliminar-datos-exif/">visor y
+      eliminador de EXIF</a>, que reescribe el contenedor sin tocar la imagen; y
+      hay una <a href="../eliminar-datos-exif-y-gps/">guía sobre eso</a>. Imagen
+      a data URI lee cuántos metadatos lleva un JPEG, un PNG o un WebP y te lo
+      dice antes de que copies nada.
     </p>
   </section>
 
   <section>
-    <h2>Dónde ponerlo, una vez que lo tienes</h2>
+    <h2>Dónde ponerlo, una vez lo tienes</h2>
     <p>
-      Si la imagen aparece en una regla, pon el URI en esa regla. Si aparece en más
-      de una &mdash; y los iconos suelen hacerlo, en cuanto cuentas el estado de
-      hover y el tema oscuro &mdash;, decláralo una vez como propiedad
+      Si la imagen aparece en una sola regla, pon el URI en esa regla. Si aparece
+      en más de una &mdash; y los iconos suelen hacerlo, en cuanto cuentas el
+      estado de hover y el tema oscuro &mdash;, decláralo una vez como propiedad
       personalizada:
     </p>
     <pre><code>:root {
@@ -240,57 +239,57 @@
 .campo-busqueda { background-image: var(--icono-buscar); }
 .boton-busqueda::before { content: var(--icono-buscar); }</code></pre>
     <p>
-      Un URI de 3 KB pegado en cuatro reglas son 12 KB de hoja de estilos y cuatro
-      sitios que editar cuando cambie el icono. La propiedad personalizada es uno
-      de cada. Es además la forma que hace que los temas funcionen: redefine
-      <code>--icono-buscar</code> dentro de una media query y todos sus usos van
-      detrás.
+      Un URI de 3 KB pegado en cuatro reglas son 12 KB de hoja de estilos y
+      cuatro sitios que editar cuando cambie el icono. Con la propiedad
+      personalizada es uno de cada. Es además lo que hace que los temas
+      funcionen: redefine <code>--icono-buscar</code> dentro de una media query y
+      todos sus usos van detrás.
     </p>
     <p>
-      Para una etiqueta <code>&lt;img&gt;</code> en vez de CSS, incluye
+      Para una etiqueta <code>&lt;img&gt;</code> en lugar de CSS, pon
       <code>width</code> y <code>height</code>. Una imagen incrustada carga al
-      instante, así que un tamaño ausente es un salto de maquetación que ocurre
-      demasiado rápido para verlo y que te sigue contando en contra. La excepción
-      es el SVG: uno que solo lleva un <code>viewBox</code> no tiene tamaño propio
-      en píxeles, y escribir en la etiqueta los 300&times;150 por defecto del
-      navegador clava una imagen escalable a un tamaño que no eligió nadie.
+      instante, así que un tamaño que falte es un salto de maquetación que ocurre
+      demasiado rápido para verlo y que te penaliza igual. La excepción es el
+      SVG: uno que solo lleva <code>viewBox</code> no tiene tamaño propio en
+      píxeles, y escribir en la etiqueta los 300&times;150 que el navegador pone
+      por defecto es fijar una imagen escalable a una medida que no eligió nadie.
     </p>
     <p>
       Deja el <code>alt</code> vacío salvo que tengas algo cierto que poner ahí.
-      Solo tú sabes si la imagen lleva significado o es decoración, y una
-      descripción adivinada a partir de un nombre de archivo es peor para alguien
-      que use un lector de pantalla que no tener ninguna descripción.
+      Solo tú sabes si la imagen significa algo o es decoración, y una
+      descripción adivinada a partir de un nombre de archivo es peor, para quien
+      use un lector de pantalla, que no poner ninguna.
     </p>
   </section>
 
   <section>
     <h2>Cuando la respuesta es «no lo hagas»</h2>
     <p>
-      Si la imagen pasa de unos 50 KB codificada, incrustarla es la herramienta
-      equivocada y no hay cuidado con la codificación que lo arregle. Las
-      alternativas, en el orden en que merece la pena probarlas:
+      Si la imagen pasa de unos 50 KB ya codificada, incrustarla es la
+      herramienta equivocada y no hay codificación cuidadosa que lo arregle. Las
+      alternativas, en el orden en que conviene probarlas:
     </p>
     <ul>
       <li>
-        <strong>Hazla más pequeña.</strong> Casi todas las imágenes que son
-        demasiado grandes para incrustarlas son demasiado grandes en general. El
+        <strong>Hazla más pequeña.</strong> Casi todas las imágenes demasiado
+        grandes para incrustarlas son demasiado grandes a secas. El
         <a href="../../comprimir-imagen/">compresor de imágenes</a> te dejará una
-        fotografía en un tamaño que tú digas, y el
+        fotografía en el tamaño que le digas, y el
         <a href="../../redimensionar-imagen/">redimensionador de imágenes</a>
-        recortará las dimensiones en píxeles hasta lo que usa de verdad la
-        maquetación &mdash; que muy a menudo es el problema real.
+        bajará las dimensiones en píxeles hasta lo que la maquetación usa de
+        verdad, que muchísimas veces es el problema de fondo.
       </li>
       <li>
-        <strong>Redibújala como SVG.</strong> Un icono exportado como PNG de 40 KB
-        es con frecuencia un SVG de 900 bytes. Eso no es una diferencia de
-        compresión, es una diferencia de formato, y además resuelve el problema de
-        las pantallas retina.
+        <strong>Redibújala como SVG.</strong> Un icono exportado en PNG de 40 KB
+        es a menudo un SVG de 900 bytes. Eso no es una diferencia de compresión,
+        es una diferencia de formato, y de paso resuelve el problema de las
+        pantallas retina.
       </li>
       <li>
         <strong>Déjala como archivo y precárgala.</strong>
         <code>&lt;link rel="preload" as="image"&gt;</code> arranca la descarga de
-        inmediato sin mover los bytes al camino crítico. Se lleva casi todo el
-        beneficio de incrustar y ninguno del coste de caché.
+        inmediato sin meter los bytes en el camino crítico. Te llevas casi todo
+        el beneficio de incrustar y nada del coste en caché.
       </li>
     </ul>
   </section>
@@ -299,20 +298,20 @@
     <h2>Nada de esto necesita una subida</h2>
     <p>
       Codificar un archivo en base64 es aritmética. Son dos funciones que el
-      navegador tiene desde el principio &mdash; <code>btoa</code> y
-      <code>encodeURIComponent</code> &mdash; y no hay absolutamente ninguna razón
-      técnica para que una imagen viaje a un servidor y vuelva para acabar escrita
-      de otra manera. Cualquier conversor que suba tu archivo para hacer esto lo
-      está subiendo por sus propios motivos, no por los tuyos.
+      navegador trae de serie &mdash; <code>btoa</code> y
+      <code>encodeURIComponent</code> &mdash;, y no existe ni una sola razón
+      técnica para que una imagen viaje hasta un servidor y vuelva solo para
+      quedar escrita de otra manera. Cualquier conversor que suba tu archivo para
+      esto lo está subiendo por sus motivos, no por los tuyos.
     </p>
     <p>
-      <a href="../../imagen-a-base64/">La herramienta de aquí</a> no lo manda a
-      ninguna parte: la <code>Content-Security-Policy</code> de la página nombra
-      todas las direcciones que puede contactar, y ninguna es de este sitio. Carga
-      la página, desenchúfate de internet y codifica algo de todos modos si
-      prefieres comprobarlo a que te lo cuenten.
+      <a href="../../imagen-a-base64/">Esta herramienta</a> no lo manda a ninguna
+      parte: la <code>Content-Security-Policy</code> de la página enumera todas
+      las direcciones con las que puede hablar, y ninguna es de este sitio. Si
+      prefieres comprobarlo antes que creértelo, carga la página, desconéctate de
+      internet y codifica algo de todos modos.
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      conversores en línea?</a> propone otras tres comprobaciones que puedes
       hacerle a cualquier herramienta.
     </p>
   </section>

--- a/locales/es/pages/guides/embed-an-image-in-css.toml
+++ b/locales/es/pages/guides/embed-an-image-in-css.toml
@@ -9,18 +9,18 @@
 nav = "Incrustar una imagen en CSS"
 
 title = "Data URI en CSS: cuándo incrustar una imagen y cuándo no"
-description = "Lo que cuesta un data URI, por qué base64 añade un tercio y gzip no lo devuelve, por qué un SVG nunca debería ir en base64, y el error de comillas que rompe los SVG incrustados en silencio."
+description = "Lo que cuesta un data URI, por qué base64 añade un tercio y gzip no te lo devuelve, por qué un SVG no debería ir nunca en base64, y el fallo de comillas que rompe los SVG incrustados sin avisar."
 
 heading = "Cuándo meter una imagen dentro de tu CSS y cuándo no"
 lede = """
-    Una imagen escrita dentro de una hoja de estilos llega con ella: sin una
-    segunda petición y sin esperas. También deja de ser un archivo &mdash; así
-    que no se puede cachear por su cuenta, y se vuelve a descargar cada vez que
-    cambia algo a su alrededor. Esto es dónde merece la pena hacer ese trato, y
-    dónde en silencio no."""
+    Una imagen escrita dentro de la hoja de estilos llega con ella: sin una
+    segunda petición y sin esperas. Pero también deja de ser un archivo, así que
+    no se puede cachear por su cuenta y se vuelve a descargar cada vez que
+    cambia cualquier cosa a su alrededor. Esto es dónde ese trato sale a cuenta
+    y dónde, sin que se note, no."""
 
 updated = "20 de agosto de 2026"
 
 og_title = "Cuándo meter una imagen dentro de tu CSS"
-og_description = "Lo que cuesta un data URI, por qué un SVG nunca debería ir en base64, y el error de comillas que rompe los SVG incrustados en silencio."
+og_description = "Lo que cuesta un data URI, por qué un SVG no debería ir nunca en base64, y el fallo de comillas que rompe los SVG incrustados sin avisar."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/es/pages/guides/is-it-safe-to-upload-files.html
@@ -1,146 +1,149 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Para casi todos los archivos, y casi siempre, subirlos no pasa nada. Los
-      conversores serios borran lo que les mandas en unas pocas horas y no tienen
-      ningún interés en tus fotos de vacaciones.
+      Con la mayoría de los archivos, y casi siempre, subirlos no tiene nada de
+      malo. Los conversores serios borran lo que les mandas al cabo de unas horas
+      y no tienen el menor interés en tus fotos de vacaciones.
     </p>
     <p>
       El problema no es que estén mintiendo. Es que
-      <strong>no tienes forma de saber si lo hacen</strong>. Una vez que un
-      archivo sale de tu equipo, cada promesa sobre lo que pasa después es una
-      promesa que te estás creyendo: cuánto tiempo se guarda, quién puede
-      alcanzarlo, si se copia a una copia de seguridad que sobreviva al
-      temporizador de borrado, qué le pasa si la empresa se vende o sufre una
+      <strong>no tienes manera de saber si lo hacen</strong>. En cuanto un
+      archivo sale de tu equipo, cada promesa sobre lo que ocurre después es una
+      promesa que estás aceptando a ciegas: cuánto tiempo se guarda, quién puede
+      llegar hasta él, si se copia a una copia de seguridad que sobreviva al
+      temporizador de borrado, qué será de él si la empresa se vende o sufre una
       brecha. Nada de eso se ve desde fuera.
     </p>
     <p>
-      Así que la pregunta útil no es «¿me fío de este sitio?». Es
-      <strong>«¿necesita este trabajo que mi archivo salga de aquí?»</strong>.
+      Así que la pregunta útil no es «¿me fío de este sitio?», sino
+      <strong>«¿de verdad hace falta que mi archivo salga de aquí?»</strong>.
       Para un número grande y creciente de trabajos la respuesta es que no, y
-      cuando la respuesta es que no, la pregunta de la confianza deja de ser una
-      pregunta que tengas que responder.
+      cuando la respuesta es que no, la cuestión de la confianza deja de ser algo
+      que tengas que resolver.
     </p>
   </section>
 
   <section>
-    <h2>Qué hace de verdad una «subida»</h2>
+    <h2>Qué hace realmente una «subida»</h2>
     <p>
-      Cuando un conversor te pide que elijas un archivo y después te enseña una
-      barra de progreso, tu navegador está copiando el archivo entero, byte por
-      byte, a través de internet hasta un ordenador que es de otra persona. Ese
-      ordenador lo escribe en un disco, ejecuta la conversión, escribe el
-      resultado en el mismo disco y te da un enlace.
+      Cuando un conversor te pide que elijas un archivo y acto seguido te enseña
+      una barra de progreso, tu navegador está copiando el archivo entero, byte a
+      byte, por internet, hasta un equipo que es de otra persona. Ese equipo lo
+      escribe en un disco, ejecuta la conversión, escribe el resultado en el
+      mismo disco y te da un enlace.
     </p>
     <p>
-      En ese momento tu archivo existe en al menos tres sitios que no elegiste: el
-      disco del servidor, los registros que hayan anotado la petición, y muchas
-      veces una red de distribución de contenidos que ha cacheado el resultado para
-      que la descarga sea rápida. Una política de borrado tiene que alcanzar los
-      tres. Casi todas dicen que lo hacen. Tú no puedes comprobar ninguno.
+      A partir de ese momento tu archivo existe en al menos tres sitios que no
+      elegiste: el disco del servidor, los registros que hayan anotado la
+      petición y, muy a menudo, una red de distribución de contenidos que ha
+      cacheado el resultado para que la descarga vaya rápida. Una política de
+      borrado tiene que llegar a los tres. Casi todas dicen que llegan. Tú no
+      puedes comprobar ninguno.
     </p>
     <p>
-      Conviene saber además que el archivo no es lo único que llega. El nombre del
-      archivo va con él, y también todo lo que hay dentro del archivo y que tú no
-      ves. Una foto recién salida de un móvil suele llevar las coordenadas GPS
-      exactas del sitio donde se tomó, la hora, el número de serie de la cámara y a
-      veces una miniatura incrustada de la imagen original de antes de que la
-      recortaras. La gente que tiene cuidado con la imagen muchas veces no lo tiene
-      con eso, porque nada en pantalla se lo enseña.
+      Y conviene saber que el archivo no es lo único que llega. Con él va su
+      nombre, y también todo lo que el archivo lleva dentro y tú no ves. Una foto
+      recién salida de un móvil suele traer las coordenadas GPS exactas del lugar
+      donde se hizo, la hora, el número de serie de la cámara y, a veces, una
+      miniatura incrustada de la imagen original, la de antes de que la
+      recortaras. Quien cuida la imagen muchas veces no cuida eso, porque nada en
+      la pantalla se lo enseña.
     </p>
   </section>
 
   <section>
-    <h2>Por qué casi todas las herramientas suben de todas formas</h2>
+    <h2>Por qué casi todas las herramientas suben de todos modos</h2>
     <p>
-      No porque quieran tus archivos. Porque durante casi toda la vida de la web no
-      había alternativa. Un navegador no podía descodificar un vídeo, recodificar
-      una imagen a una calidad elegida ni analizar un formato de archivo; un
-      servidor con FFmpeg e ImageMagick sí. Subir cosas no era un modelo de
-      negocio, era el único sitio donde podía ocurrir el trabajo.
+      No porque quieran tus archivos, sino porque durante casi toda la vida de la
+      web no hubo alternativa. Un navegador no podía descodificar un vídeo, ni
+      recodificar una imagen a una calidad elegida, ni analizar un formato de
+      archivo; un servidor con FFmpeg e ImageMagick sí. Subir cosas no era un
+      modelo de negocio: era el único lugar donde el trabajo podía ocurrir.
     </p>
     <p>
-      Eso dejó de ser cierto hace poco y sin ruido. Los navegadores traen hoy
-      WebAssembly, que ejecuta los mismos códecs compilados a una velocidad cercana
-      a la nativa; WebCodecs, que expone el codificador de vídeo por hardware que
-      ya está en tu equipo; y una API de lienzo que puede descodificar y
-      recodificar imágenes directamente. El trabajo para el que hacía falta un
-      servidor ocurre ahora en el dispositivo que ya tiene el archivo.
+      Eso dejó de ser cierto hace poco y sin hacer ruido. Hoy los navegadores
+      traen WebAssembly, que ejecuta esos mismos códecs compilados a una
+      velocidad cercana a la nativa; WebCodecs, que da acceso al codificador de
+      vídeo por hardware que ya está en tu equipo; y una API de lienzo capaz de
+      descodificar y recodificar imágenes por sí sola. El trabajo que exigía un
+      servidor ocurre ya en el dispositivo que tiene el archivo.
     </p>
     <p>
-      Muchas herramientas siguen subiendo, y hay razones honestas: una cadena de
-      procesos que nadie quiere reescribir, un formato sin descodificador del lado
-      del navegador, un trabajo genuinamente demasiado pesado para un móvil. Hay
-      también una razón menos honesta, y es que un servidor es donde viven las
-      cuentas, las cuotas y los planes de pago. Una herramienta que funciona por
-      completo en tu navegador es difícil de medir.
+      Muchas herramientas siguen subiendo, y hay motivos honestos: una cadena de
+      procesos que nadie quiere reescribir, un formato sin descodificador del
+      lado del navegador, un trabajo genuinamente demasiado pesado para un móvil.
+      Y hay un motivo menos honesto: el servidor es donde viven las cuentas, las
+      cuotas y los planes de pago. Una herramienta que funciona entera dentro de
+      tu navegador es difícil de medir.
     </p>
   </section>
 
   <section>
     <h2>Cuatro comprobaciones que puedes hacer tú</h2>
     <p>
-      Funcionan con cualquier herramienta, esta incluida. Ninguna exige creerse la
-      palabra de nadie, y la primera lleva unos diez segundos.
+      Sirven con cualquier herramienta, esta incluida. Ninguna exige creerse la
+      palabra de nadie, y la primera lleva diez segundos.
     </p>
 
-    <h3>1. Desenchufa</h3>
+    <h3>1. Córtale la red</h3>
     <p>
-      Carga la página, apaga el wifi o desenchufa el cable, e intenta usarla. Una
-      herramienta que hace su trabajo en tu navegador sigue exactamente igual que
-      antes. Una herramienta que sube se detiene de inmediato, porque lo que hacía
-      el trabajo ya no está a su alcance.
+      Carga la página, apaga el wifi o desconecta el cable e intenta usarla. Una
+      herramienta que hace el trabajo en tu navegador sigue exactamente igual que
+      antes. Una herramienta que sube se para en seco, porque lo que hacía el
+      trabajo ya no está a su alcance.
     </p>
     <p>
-      Esta es la prueba más fuerte que hay, y la más difícil de fingir, porque no
-      se puede responder con palabras. O la conversión termina sin red o no
+      Es la prueba más contundente que existe, y la más difícil de fingir, porque
+      no se puede responder con palabras: o la conversión termina sin red, o no
       termina.
     </p>
 
-    <h3>2. Mira la pestaña Red</h3>
+    <h3>2. Vigila la pestaña «Red»</h3>
     <p>
-      Abre las herramientas de desarrollo de tu navegador, elige Red y usa después
-      la herramienta. Todas las peticiones que hace la página aparecen listadas con
-      su tamaño. Si tu foto de 4&nbsp;MB se ha subido, hay una petición de
-      4&nbsp;MB en esa lista. Si lo más grande que sale de la página son unos pocos
-      kilobytes de publicidad, no se ha subido.
+      Abre las herramientas de desarrollo del navegador, ponte en «Red» y usa la
+      herramienta. Ahí aparecen listadas, con su tamaño, todas las peticiones que
+      hace la página. Si tu foto de 4&nbsp;MB se ha subido, hay una petición de
+      4&nbsp;MB en esa lista. Si lo más grande que sale de la página son unos
+      kilobytes de publicidad, no se ha subido nada.
     </p>
     <p>
-      Ordena por tamaño y mira lo de arriba. No necesitas entender las peticiones;
-      necesitas fijarte en si alguna tiene el tamaño de tu archivo.
+      Ordena por tamaño y mira lo de arriba. No hace falta que entiendas las
+      peticiones; hace falta que veas si alguna tiene el tamaño de tu archivo.
     </p>
 
     <h3>3. Lee la Content-Security-Policy</h3>
     <p>
       Mira el código fuente de la página y busca
-      <code>Content-Security-Policy</code>, cerca del principio. Es una lista de
-      las direcciones que esa página tiene permitido contactar, y la hace cumplir
-      tu navegador en vez de las buenas intenciones del sitio &mdash; una petición
-      a algo que no esté en la lista se rechaza, intente lo que intente el código.
+      <code>Content-Security-Policy</code>, cerca del principio. Es la lista de
+      direcciones que esa página tiene permiso para contactar, y la hace cumplir
+      tu navegador, no la buena voluntad del sitio: una petición a algo que no
+      esté en la lista se rechaza, intente lo que intente el código.
     </p>
     <p>
-      La directiva que importa es <code>connect-src</code>, que rige adónde puede
-      enviar datos la página. Si nombra una dirección que pertenece al sitio en el
-      que estás, la página puede mandar tu archivo ahí. Si no nombra nada, o solo
-      terceros como una red publicitaria, no puede.
+      La directiva que importa es <code>connect-src</code>, que decide adónde
+      puede enviar datos la página. Si nombra una dirección del propio sitio en el
+      que estás, la página puede mandar tu archivo ahí. Si no nombra ninguna, o
+      solo nombra terceros como una red publicitaria, no puede.
     </p>
     <p>
-      Una página sin ninguna Content-Security-Policy no es prueba de nada malo.
-      Solo significa que esta comprobación en concreto no tiene nada que decirte.
+      Que una página no tenga Content-Security-Policy no prueba nada malo.
+      Significa solo que esta comprobación en concreto no tiene nada que
+      contarte.
     </p>
 
     <h3>4. Lee el código</h3>
     <p>
       La menos cómoda y la más concluyente. Si una herramienta publica su código
       fuente y lo sirve sin ningún paso de compilación, los archivos que se ha
-      bajado tu navegador son los archivos que puedes leer. Búscales
+      bajado tu navegador son exactamente los archivos que puedes leer. Búscales
       <code>fetch</code>, <code>XMLHttpRequest</code> y <code>sendBeacon</code>
-      &mdash; las tres formas que tiene una página de enviar algo &mdash; y mira
+      &mdash; las tres maneras que tiene una página de enviar algo &mdash; y mira
       qué se les entrega.
     </p>
     <p>
-      Casi nadie va a hacer esto. Sigue importando que sea posible, porque una
-      afirmación que nadie puede comprobar no es realmente una afirmación.
+      Esto no lo va a hacer casi nadie. Sigue importando que se pueda hacer,
+      porque una afirmación que nadie puede comprobar no es del todo una
+      afirmación.
     </p>
   </section>
 
@@ -148,106 +151,105 @@
     <h2>Lo que «funciona en tu navegador» no significa</h2>
     <p>
       Conviene ser preciso, porque la frase se usa a la ligera y este sitio tiene
-      que exigirse el mismo listón que está proponiendo.
+      que aplicarse el mismo listón que está proponiendo.
     </p>
     <ul>
       <li>
-        <strong>No significa ninguna petición en absoluto.</strong> La propia
-        página llegó por la red, y casi todas las herramientas gratuitas llevan
+        <strong>No significa que no haya ninguna petición.</strong> La página
+        misma llegó por la red, y casi todas las herramientas gratuitas llevan
         publicidad o analítica que hablan con alguien. La afirmación va de tu
         <em>archivo</em>, no del tráfico en general.
       </li>
       <li>
-        <strong>No esconde tu dirección IP.</strong> Todos los sitios que visitas
-        la ven, este incluido. El procesamiento local va del contenido de tus
+        <strong>No esconde tu dirección IP.</strong> La ven todos los sitios que
+        visitas, este incluido. El procesamiento local va del contenido de tus
         archivos, no del anonimato.
       </li>
       <li>
-        <strong>No sobrevive a una función que descarga algo.</strong> Una
-        herramienta que te deja pegar una dirección web tiene que contactar con esa
-        dirección, y ese servidor se entera de tu IP y de qué has pedido. Eso es
-        inherente a la función y no un defecto suyo &mdash; pero es una excepción
-        real y una herramienta debería decirlo con claridad en vez de
-        redondearla.
+        <strong>Deja de valer en cuanto hay una función que descarga
+        algo.</strong> Una herramienta que te deja pegar una dirección web tiene
+        que contactar con esa dirección, y ese servidor se entera de tu IP y de
+        qué pediste. Va con la función y no es un defecto suyo, pero es una
+        excepción real y una herramienta debería decirlo con todas las letras en
+        lugar de pasarla por alto.
       </li>
       <li>
-        <strong>No es lo mismo que «borramos tus archivos».</strong> La segunda
-        frase va de lo que una empresa decide hacer. La primera va de lo que es
+        <strong>No es lo mismo que «borramos tus archivos».</strong> Esa segunda
+        frase habla de lo que una empresa decide hacer; la primera, de lo que es
         técnicamente posible. Solo una de las dos se puede comprobar.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Cuándo subir está genuinamente bien</h2>
+    <h2>Cuándo subir un archivo está perfectamente bien</h2>
     <p>
-      Esto no es un argumento de que toda subida sea un error. Manda el archivo
-      cuando el contenido no sea sensible y el trabajo sea más fácil así; cuando el
-      trabajo sea de verdad demasiado pesado para tu dispositivo; cuando el formato
-      no tenga descodificador del lado del navegador; o cuando estés usando un
-      servicio con el que ya tienes una relación y cuyas condiciones te has leído de
-      verdad.
+      Nada de esto es un alegato contra toda subida. Manda el archivo cuando el
+      contenido no sea delicado y así sea más fácil; cuando el trabajo sea de
+      verdad demasiado pesado para tu dispositivo; cuando el formato no tenga
+      descodificador del lado del navegador; o cuando estés usando un servicio con
+      el que ya tienes una relación y cuyas condiciones te has leído de verdad.
     </p>
     <p>
       Ten más cuidado cuando el archivo contenga algo que no publicarías:
       documentos de identidad, pruebas médicas, contratos, cualquier cosa con una
-      dirección o una cara que no pretendías compartir, o una foto cuyos datos de
-      ubicación no has mirado. Para esos, una herramienta que puedes comprobar
-      merece preferirse a una herramienta en la que tienes que confiar &mdash; no
-      porque sea probable que la de confianza te traicione, sino porque con la
-      comprobable la pregunta ni se plantea.
+      dirección o una cara que no pensabas compartir, o una foto cuyos datos de
+      ubicación no has mirado. Para esos casos, una herramienta que puedes
+      comprobar es preferible a una en la que tienes que confiar; no porque la de
+      confianza vaya a traicionarte, sino porque con la comprobable la pregunta ni
+      llega a plantearse.
     </p>
   </section>
 
   <section>
-    <h2>Cómo responde este sitio a esas cuatro comprobaciones</h2>
+    <h2>Cómo sale este sitio de esas cuatro comprobaciones</h2>
     <p>
-      Sería una guía muy rara la que te dijera que compruebes y después pidiera
+      Sería una guía muy rara la que te dijera que comprobaras y después pidiera
       quedar exenta. Así que, por orden:
     </p>
     <ul>
       <li>
-        <strong>Desenchufa.</strong> Abre cualquier herramienta de aquí,
-        desconéctate, y sigue funcionando. Cada página de herramienta tiene un
-        indicador en directo que dice si estás conectado ahora mismo, así que
-        puedes verlo cambiar.
+        <strong>Córtale la red.</strong> Abre cualquier herramienta de este
+        sitio, desconéctate y verás que sigue funcionando. Cada página de
+        herramienta lleva un indicador en directo que dice si estás conectado
+        ahora mismo, así que puedes verlo cambiar.
       </li>
       <li>
-        <strong>Pestaña Red.</strong> Convierte algo y lee la lista. Nada lleva tu
-        archivo, ni una miniatura suya, ni su nombre, ni su tamaño, ni nada leído
-        de dentro de él. En este sitio no hay ningún evento de analítica propio que
-        tenga nada de eso que enviar.
+        <strong>Pestaña «Red».</strong> Convierte algo y lee la lista. Nada lleva
+        tu archivo, ni una miniatura suya, ni su nombre, ni su tamaño, ni nada
+        leído de dentro de él. En este sitio no hay ningún evento de analítica
+        propio que tenga eso que enviar.
       </li>
       <li>
         <strong>Content-Security-Policy.</strong> Está al principio del código
         fuente de todas las páginas. <code>connect-src</code> nombra los puntos
         finales de publicidad y medición de Google y el botón de donación, y nada
-        más. <strong>Ninguna dirección de esa lista pertenece a este sitio</strong>,
-        porque este sitio no tiene servidor &mdash; son archivos estáticos. No hay
-        ningún sitio al que enviar un archivo aunque algo lo intentara.
+        más. <strong>Ninguna dirección de esa lista pertenece a este
+        sitio</strong>, porque este sitio no tiene servidor: son archivos
+        estáticos. No hay adónde enviar un archivo, ni aunque algo lo intentara.
       </li>
       <li>
-        <strong>Código.</strong> Todas las líneas son
-        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">públicas</a>.
+        <strong>El código.</strong> Cada línea es
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">pública</a>.
         La compilación quita comentarios y espacios en blanco y nada más, y puedes
-        ejecutarla tú mismo y comparar el resultado con lo que se está sirviendo.
+        ejecutarla tú y comparar el resultado con lo que se está sirviendo.
       </li>
     </ul>
     <p>
-      Las excepciones, declaradas en vez de escondidas: este sitio lleva publicidad
-      de Google y un contador de visitas, que hablan los dos con Google y a ninguno
-      de los cuales se le entrega nada sobre tus archivos; y la herramienta
-      <a href="../../imagenes-a-video/">Imágenes a vídeo</a> puede descargar una
-      imagen desde una dirección que pegues tú, lo que significa que ese servidor ve
-      tu IP. La <a href="../../privacidad/">página de privacidad</a> explica las dos
-      por completo.
+      Las excepciones, dichas en voz alta en lugar de escondidas: este sitio lleva
+      publicidad de Google y un contador de visitas, que hablan los dos con Google
+      y a ninguno de los cuales se le entrega nada sobre tus archivos; y la
+      herramienta <a href="../../imagenes-a-video/">Imágenes a vídeo</a> puede
+      descargar una imagen desde una dirección que pegues tú, con lo que ese
+      servidor ve tu IP. La <a href="../../privacidad/">página de privacidad</a>
+      explica las dos al detalle.
     </p>
     <p>
-      Todas las herramientas de aquí funcionan así: un
-      <a href="../../comprimir-imagen/">compresor de imágenes</a> que acierta un
-      tamaño que tú digas, un <a href="../../recortar-video/">recortador de
+      Todas las herramientas de este sitio funcionan igual: un
+      <a href="../../comprimir-imagen/">compresor de imágenes</a> que acierta el
+      tamaño que le pidas, un <a href="../../recortar-video/">recortador de
       vídeo</a>, un <a href="../../eliminar-datos-exif/">visor y eliminador de
-      EXIF</a> para los datos ocultos descritos más arriba en esta página,
+      EXIF</a> para esos datos ocultos de los que habla esta misma página,
       <a href="../../imagenes-a-video/">imágenes a vídeo</a> e
       <a href="../../imagenes-a-pdf/">imágenes a PDF</a>. Todas gratuitas, sin
       cuenta, y ninguna tiene adónde mandar tus archivos.

--- a/locales/es/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/es/pages/guides/is-it-safe-to-upload-files.toml
@@ -7,18 +7,18 @@
 
 nav = "¿Es seguro subir archivos?"
 
-title = "¿Es seguro subir archivos a los conversores en línea?"
-description = "Casi todos los conversores en línea mandan tu archivo a un servidor. Qué significa eso, qué le pasa ahí, y cuatro comprobaciones que te dicen si una herramienta lo necesita de verdad."
+title = "¿Es seguro subir archivos a un conversor en línea?"
+description = "Casi todos los conversores en línea mandan tu archivo a un servidor. Qué significa eso, qué le ocurre allí y cuatro comprobaciones que te dicen si la herramienta lo necesita de verdad."
 
-heading = "¿Es seguro subir archivos a los conversores en línea?"
+heading = "¿Es seguro subir archivos a un conversor en línea?"
 lede = """
-    Normalmente la respuesta honesta es «probablemente, pero no puedes
-    comprobarlo». Esto explica qué le hace de verdad una subida a tu archivo, por
-    qué casi todas las herramientas siguen haciéndola, y cuatro pruebas que te
+    La respuesta honesta suele ser «probablemente, pero no puedes
+    comprobarlo». Aquí verás qué le hace realmente una subida a tu archivo, por
+    qué casi todas las herramientas siguen pidiéndola y cuatro pruebas que te
     dicen si la que tienes delante la necesita."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "¿Es seguro subir archivos a los conversores en línea?"
-og_description = "Qué le pasa a un archivo que subes a un conversor, por qué casi todas las herramientas siguen pidiéndotelo, y cuatro comprobaciones que puedes hacer tú."
+og_title = "¿Es seguro subir archivos a un conversor en línea?"
+og_description = "Qué le ocurre a un archivo que subes a un conversor, por qué casi todas las herramientas te lo siguen pidiendo y cuatro comprobaciones que puedes hacer tú."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/make-a-favicon.html
+++ b/locales/es/pages/guides/make-a-favicon.html
@@ -1,136 +1,137 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre <a href="../../crear-favicon/">Imagen a ICO</a>, suelta dentro una
+      Abre <a href="../../crear-favicon/">Imagen a ICO</a>, arrastra dentro una
       imagen cuadrada de al menos 256 píxeles, deja el preajuste en <em>favicon
-      de una web</em> y descarga <code>favicon.ico</code>. Ponlo en la raíz de tu
-      sitio, de modo que responda en
+      de una web</em> y descarga <code>favicon.ico</code>. Colócalo en la raíz de
+      tu sitio, de modo que responda en
       <code>https://tusitio.com/favicon.ico</code>. Esa dirección la pide
-      cualquier navegador mencione o no tu HTML, así que estrictamente no hay nada
-      más que tengas que hacer.
+      cualquier navegador la mencione o no tu HTML, así que, en rigor, no hay
+      nada más que tengas que hacer.
     </p>
     <p>
-      Todo lo de abajo es la parte que marca la diferencia entre un icono que está
-      técnicamente presente y uno que se lee: qué tamaños entran, qué piden en su
-      lugar los iPhone y Android, y qué hacer cuando tu logotipo no sobrevive a
-      medir dieciséis píxeles de ancho.
+      El resto de esta página es lo que separa un icono que está técnicamente
+      puesto de uno que se lee: qué tamaños entran, qué piden en su lugar los
+      iPhone y Android, y qué hacer cuando tu logotipo no aguanta medir dieciséis
+      píxeles de ancho.
     </p>
   </section>
 
   <section>
-    <h2>Por qué es un conjunto de tamaños y no una imagen</h2>
+    <h2>Por qué es un juego de tamaños y no una imagen</h2>
     <p>
-      Un archivo <code>.ico</code> es un contenedor. Dentro hay varias imágenes
-      completas de la misma cosa a tamaños distintos, y quien esté leyendo el
-      archivo escoge la más cercana al tamaño que necesita.
+      Un archivo <code>.ico</code> es un contenedor. Dentro lleva varias imágenes
+      completas de lo mismo a tamaños distintos, y quien lee el archivo escoge la
+      más cercana al tamaño que necesita.
     </p>
     <p>
-      Eso suena a redundancia y no lo es. Un navegador que dibuja tu icono a
-      dieciséis píxeles tiene dos opciones: leer una versión de dieciséis píxeles
-      que hayas dibujado tú, o encoger una más grande sobre la marcha. Lo segundo
-      es peor, y de forma visible &mdash; un encogido automático de un logotipo
-      detallado produce papilla, mientras que una versión de dieciséis píxeles que
-      has mirado es algo que has tenido la oportunidad de simplificar. La razón
-      entera de que el formato guarde varios tamaños es darte esa oportunidad.
+      Suena a redundancia y no lo es. Un navegador que tiene que dibujar tu icono
+      a dieciséis píxeles solo tiene dos opciones: leer una versión de dieciséis
+      píxeles que hayas dibujado tú, o encoger una más grande sobre la marcha. Lo
+      segundo es peor, y se ve: encoger automáticamente un logotipo detallado da
+      un borrón, mientras que una versión de dieciséis píxeles que has mirado con
+      tus ojos es una versión que has tenido ocasión de simplificar. El formato
+      guarda varios tamaños precisamente para darte esa ocasión.
     </p>
     <p>
-      Tres tamaños es la convención para una web, y cada uno tiene su razón:
+      Tres tamaños es la convención para una web, y cada uno tiene su motivo:
     </p>
     <ul>
       <li>
-        <strong>16&times;16</strong> &mdash; la pestaña del navegador, la barra de
-        direcciones, el menú de marcadores. Este es el que ve la gente. Si solo
-        vas a acertar con uno, acierta con este.
+        <strong>16&times;16</strong> &mdash; la pestaña del navegador, la barra
+        de direcciones, el menú de marcadores. Este es el que ve la gente. Si
+        solo vas a acertar con uno, acierta con este.
       </li>
       <li>
-        <strong>32&times;32</strong> &mdash; una barra de marcadores, un acceso
-        directo de escritorio de Windows a tu sitio, y casi todos los navegadores
+        <strong>32&times;32</strong> &mdash; la barra de marcadores, un acceso
+        directo de escritorio de Windows a tu sitio y casi todos los navegadores
         en una pantalla de alta densidad, que dibujan el icono de la pestaña a
         partir de 32 y lo reducen.
       </li>
       <li>
         <strong>48&times;48</strong> &mdash; el tamaño al que Google lee el icono
-        de un sitio para los resultados de búsqueda, y la vista de iconos medianos
-        de Windows.
+        de un sitio para los resultados de búsqueda, y la vista de iconos
+        medianos de Windows.
       </li>
     </ul>
     <p>
-      Cualquier cosa más grande va en un PNG al lado del <code>.ico</code>, no
-      dentro, por razones que aparecen más abajo con los archivos para móvil.
+      Cualquier cosa más grande va en un PNG al lado del <code>.ico</code> y no
+      dentro, por razones que aparecen más abajo, con los archivos para móvil.
     </p>
   </section>
 
   <section>
     <h2>El problema de los dieciséis píxeles</h2>
     <p>
-      Esta es la parte de la que nadie te avisa. Dieciséis píxeles son unos cuatro
-      milímetros en una pantalla normal: una rejilla de 256 puntos en total, menos
-      que las letras de esta frase. Casi nada diseñado para funcionar en un cartel,
-      en una tarjeta de visita o en la cabecera de una web sobrevive a reducirse a
-      eso.
+      Esta es la parte de la que nadie avisa. Dieciséis píxeles son unos cuatro
+      milímetros en una pantalla normal: una rejilla de 256 puntos en total,
+      menos que las letras de esta misma frase. Casi nada de lo que se diseña
+      para funcionar en un cartel, en una tarjeta de visita o en la cabecera de
+      una web aguanta reducido a eso.
     </p>
     <p>
-      Lo que desaparece, por orden:
+      Lo que se pierde, por orden:
     </p>
     <ul>
       <li>
-        <strong>El texto.</strong> Un logotipo de palabra encogido dentro de un
-        cuadrado tiene unos tres píxeles de alto. No se convierte en texto
-        pequeño, se convierte en una barra gris. Por eso casi todas las empresas
+        <strong>El texto.</strong> Un logotipo tipográfico encajado dentro de un
+        cuadrado queda con unos tres píxeles de alto. No se convierte en texto
+        pequeño: se convierte en una barra gris. Por eso casi todas las empresas
         que tienen un símbolo además de un nombre usan solo el símbolo como
         favicon, y las que no tienen símbolo usan una sola letra.
       </li>
       <li>
         <strong>Las líneas finas.</strong> Un borde de un píxel en un logotipo de
-        512 píxeles es una treintaidosava parte de un píxel a dieciséis. Se dibuja
-        como una neblina gris tenue a lo largo del borde, o desaparece.
+        512 píxeles es una treintaidosava parte de píxel a dieciséis. Se dibuja
+        como una neblina gris a lo largo del borde, o directamente desaparece.
       </li>
       <li>
         <strong>Los degradados y las sombras.</strong> No hay sitio para una
-        transición. Una sombra suave se convierte en un fleco sucio.
+        transición. Una sombra suave acaba como un fleco sucio.
       </li>
       <li>
-        <strong>El detalle dentro del detalle.</strong> Un icono de un documento
-        con algo escrito encima se convierte en un rectángulo con un borrón.
+        <strong>El detalle dentro del detalle.</strong> Un icono de documento con
+        algo escrito encima se convierte en un rectángulo con una mancha.
       </li>
     </ul>
     <p>
-      La solución no es un ajuste, es otro dibujo: una marca simplificada con una o
-      dos formas, mucho contraste y nada de texto más allá de un solo carácter.
-      Dibuja esa versión a 32 o 48 píxeles a propósito, y úsala como origen.
+      La solución no es un ajuste, es otro dibujo: una marca simplificada con una
+      o dos formas, mucho contraste y nada de texto más allá de un solo carácter.
+      Dibuja esa versión a 32 o 48 píxeles a propósito y úsala como punto de
+      partida.
     </p>
     <p>
-      Lo que una herramienta sí puede hacer es enseñarte el problema antes de que
+      Lo que sí puede hacer una herramienta es enseñarte el problema antes de que
       lo publiques. La vista previa de <a href="../../crear-favicon/">Imagen a
       ICO</a> dibuja cada tamaño a su tamaño real en pantalla, que es la única
-      forma de juzgar esto &mdash; un icono de dieciséis píxeles mostrado a sesenta
-      y cuatro se ve bien y no te dice nada.
+      manera de juzgar esto: un icono de dieciséis píxeles mostrado a sesenta y
+      cuatro se ve estupendo y no te dice nada.
     </p>
   </section>
 
   <section>
     <h2>Tu logotipo no es cuadrado. ¿Rellenar o recortar?</h2>
     <p>
-      Un icono siempre es cuadrado, y casi ningún logotipo lo es, así que algo
-      tiene que pasar. Hay tres respuestas y no son igual de buenas.
+      Un icono siempre es cuadrado y casi ningún logotipo lo es, así que algo
+      tiene que pasar. Hay tres respuestas, y no valen lo mismo.
     </p>
     <p>
-      <strong>Rellenar</strong> conserva la imagen entera y le pone espacio arriba
-      y abajo. Es el valor por defecto seguro y la elección equivocada para un
-      logotipo de palabra ancho: meter algo tres veces más ancho que alto dentro
-      de un cuadrado lo deja ocupando un tercio del alto, que a dieciséis píxeles
-      son cinco píxeles de logotipo y once de nada.
+      <strong>Rellenar</strong> conserva la imagen entera y le añade espacio
+      arriba y abajo. Es el valor por defecto seguro, y la elección equivocada
+      para un logotipo tipográfico ancho: meter algo tres veces más ancho que
+      alto dentro de un cuadrado lo deja ocupando un tercio de la altura, y a
+      dieciséis píxeles eso son cinco píxeles de logotipo y once de nada.
     </p>
     <p>
-      <strong>Recortar al centro</strong> saca el mayor cuadrado del medio. Para un
-      conjunto &mdash; un símbolo con el nombre de la empresa al lado &mdash; esto
-      muchas veces corta por la mitad los dos. Mejor recorta el original tú
-      primero, dejando solo el símbolo, y convierte eso.
+      <strong>Recortar al centro</strong> se queda con el mayor cuadrado del
+      medio. Si lo que tienes es un conjunto &mdash; un símbolo con el nombre de
+      la empresa al lado &mdash;, esto suele partir los dos por la mitad. Mejor
+      recorta tú antes el original, quédate solo con el símbolo y convierte eso.
     </p>
     <p>
-      <strong>Estirar</strong> aplasta la imagen para que quepa. Casi no hay
-      ninguna situación en la que esto sea lo correcto, y se ofrece sobre todo para
-      que la herramienta no lo esté haciendo en silencio.
+      <strong>Estirar</strong> aplasta la imagen hasta que quepa. Casi no existe
+      la situación en la que sea lo correcto, y está ahí sobre todo para que la
+      herramienta no lo haga a escondidas.
     </p>
     <p>
       La respuesta general para un logotipo ancho: no conviertas el logotipo.
@@ -141,97 +142,97 @@
   <section>
     <h2>¿Transparente o con fondo sólido?</h2>
     <p>
-      Transparente suele ser lo correcto para una web. Las pestañas del navegador
-      son grises, blancas o casi negras según el navegador y el tema, y un icono
-      transparente se apoya en todas. Un icono con un fondo blanco pintado es un
-      rectángulo blanco en una barra de pestañas oscura.
+      Para una web, transparente suele ser lo correcto. Las pestañas del
+      navegador son grises, blancas o casi negras según el navegador y el tema, y
+      un icono transparente queda bien sobre todas. Un icono con un fondo blanco
+      pintado es un rectángulo blanco en una barra de pestañas oscura.
     </p>
     <p>
       Dos excepciones que conviene conocer:
     </p>
     <ul>
       <li>
-        <strong>Un logotipo que es oscuro y nada más</strong> desaparece en modo
+        <strong>Un logotipo que solo es oscuro</strong> desaparece en modo
         oscuro. Si tu marca es negra sobre blanco por naturaleza, dale un fondo de
-        color en vez de uno transparente, o un contorno claro.
+        color en vez de dejarlo transparente, o ponle un contorno claro.
       </li>
       <li>
         <strong>El icono táctil de Apple tiene que ser opaco.</strong> iOS lo
         dibuja sobre su propio mosaico redondeado y convierte la transparencia en
-        negro. Cualquier herramienta que produzca ese archivo debería aplanarlo por
-        ti; la de aquí lo hace, sobre blanco por defecto.
+        negro. Cualquier herramienta que produzca ese archivo debería aplanarlo
+        por ti; esta lo hace, sobre blanco salvo que digas otra cosa.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Los archivos que necesita una web y que no son el .ico</h2>
+    <h2>Los archivos que una web necesita además del .ico</h2>
     <p>
       <code>favicon.ico</code> cubre los navegadores y Windows. No cubre los
-      móviles, y aquí es donde casi todos los conjuntos de iconos caseros se paran
-      demasiado pronto. Otras tres plataformas piden sus propios archivos, con sus
-      propios nombres, y ninguna va a mirar dentro de un <code>.ico</code>:
+      móviles, y ahí es donde casi todos los juegos de iconos caseros se paran
+      demasiado pronto. Otras tres plataformas piden sus propios archivos, con
+      sus propios nombres, y ninguna va a mirar dentro de un <code>.ico</code>:
     </p>
     <ul>
       <li>
         <strong>iOS</strong> lee <code>apple-touch-icon.png</code> a
-        180&times;180 cuando alguien añade tu sitio a su pantalla de inicio. Sin
-        él, iOS usa una captura de la página, que parece un error.
+        180&times;180 cuando alguien añade tu sitio a la pantalla de inicio. Sin
+        él, iOS usa una captura de la página, que parece un fallo.
       </li>
       <li>
         <strong>Android y cualquier aviso de instalación</strong> leen un
         manifiesto de aplicación web &mdash; <code>site.webmanifest</code>
-        &mdash;, que apunta a PNG de 192 y de 512 píxeles. El de 512 es además lo
-        que enseña una aplicación web en su pantalla de arranque.
+        &mdash;, que apunta a PNG de 192 y de 512 píxeles. El de 512 es además el
+        que se ve en la pantalla de arranque de una aplicación web.
       </li>
       <li>
         <strong>Un mosaico del menú Inicio de Windows</strong> lee
         <code>browserconfig.xml</code>, que apunta a un PNG de 150&times;150. El
-        menos importante de los tres, y cuatro líneas de XML.
+        menos importante de los tres, y son cuatro líneas de XML.
       </li>
     </ul>
     <p>
-      Hay uno más que es fácil de hacer mal: los lanzadores de Android recortan un
-      icono adaptativo a la forma que le guste al móvil &mdash; círculo, cuadrado
-      redondeado, «squircle» &mdash; y solo se garantiza que sobreviva el 80&nbsp;%
-      central de la imagen. Un icono dibujado de borde a borde pierde las esquinas.
-      Eso es lo que es un icono <em>enmascarable</em>: la misma imagen dibujada
-      deliberadamente pequeña dentro del cuadrado, declarada aparte en el
-      manifiesto.
+      Hay uno más que es fácil de hacer mal: los lanzadores de Android recortan
+      un icono adaptativo a la forma que le apetezca al móvil &mdash; círculo,
+      cuadrado redondeado, «squircle» &mdash;, y lo único que se garantiza que
+      sobrevive es el 80&nbsp;% central de la imagen. Un icono dibujado de borde a
+      borde pierde las esquinas. En eso consiste un icono <em>enmascarable</em>:
+      la misma imagen dibujada aposta pequeña dentro del cuadrado, declarada
+      aparte en el manifiesto.
     </p>
     <p>
-      Marcar el conjunto para web en <a href="../../crear-favicon/">Imagen a
-      ICO</a> produce todos ellos, el manifiesto y el bloque de HTML que apunta a
-      ellos. Una cosa que ese bloque deja fuera a propósito es un
+      Si marcas el juego para web en <a href="../../crear-favicon/">Imagen a
+      ICO</a>, salen todos ellos, el manifiesto y el bloque de HTML que los
+      nombra. Una cosa que ese bloque deja fuera a propósito es un
       <code>&lt;link&gt;</code> para <code>favicon.ico</code>: los navegadores
-      piden esa dirección por su cuenta, y nombrarla además hace que el mismo
+      piden esa dirección por su cuenta, y nombrarla encima hace que el mismo
       archivo se descargue dos veces.
     </p>
   </section>
 
   <section>
-    <h2>El icono de una aplicación de Windows es otro conjunto</h2>
+    <h2>El icono de una aplicación de Windows es otro juego</h2>
     <p>
-      Si el icono es para un programa y no para un sitio, los tamaños cambian. Lo
-      que contiene el <code>app.ico</code> que trae por defecto el propio Visual
-      Studio es 16, 32, 48 y 256 &mdash; los tres tamaños del shell más el grande
-      del que dibujan el menú Inicio y la vista extragrande del Explorador.
+      Si el icono es para un programa y no para un sitio web, los tamaños
+      cambian. El <code>app.ico</code> que trae de serie el propio Visual Studio
+      contiene 16, 32, 48 y 256: los tres tamaños del shell más el grande con el
+      que dibujan el menú Inicio y la vista extragrande del Explorador.
     </p>
     <p>
       En una pantalla de alta densidad Windows pide además 20, 24, 40, 64 y 96, y
-      los remuestrea del tamaño más cercano que tenga cuando faltan. Que eso importe
-      o no depende de tu icono: una forma plana sobrevive al remuestreo, una
-      detallada no. Añadirlos más o menos duplica el archivo, que para una
-      aplicación no es nada &mdash; la cuenta es completamente distinta de la de un
-      favicon, donde el archivo se lo descarga cada visitante.
+      cuando no los encuentra los remuestrea del tamaño más cercano que tenga. Que
+      eso importe o no depende de tu icono: una forma plana aguanta el remuestreo,
+      una detallada no. Añadirlos duplica más o menos el archivo, cosa que para
+      una aplicación no significa nada; la cuenta aquí no se parece en nada a la
+      de un favicon, que se descarga cada visitante.
     </p>
     <p>
-      Una cosa más sobre el tamaño: la entrada de 256 es donde están los bytes.
+      Un apunte más sobre el peso: la entrada de 256 es donde están los bytes.
       Guardada sin comprimir son 264&nbsp;KB ella sola; guardada como PNG dentro
       del icono suele quedarse por debajo de 30. Las entradas PNG se leen desde
-      Windows Vista, así que la única razón para evitarlas es software genuinamente
-      más antiguo que eso, o un instalador o una herramienta incrustada que analice
-      los iconos por su cuenta.
+      Windows Vista, así que la única razón para evitarlas es software realmente
+      más antiguo que eso, o un instalador o una herramienta incrustada que
+      analice los iconos por su cuenta.
     </p>
   </section>
 
@@ -239,76 +240,77 @@
     <h2>Un Mac lee un archivo completamente distinto</h2>
     <p>
       Si el icono es para una aplicación de Mac y no de Windows, nada de lo
-      anterior sirve: macOS no lee <code>.ico</code> en absoluto. Lee
+      anterior vale: macOS no lee <code>.ico</code> en absoluto. Lee
       <code>.icns</code>, que es la misma idea en otro envoltorio &mdash; varios
-      tamaños en un contenedor &mdash; con tres diferencias que conviene conocer.
+      tamaños dentro de un contenedor &mdash; con tres diferencias que conviene
+      conocer.
     </p>
     <ul>
       <li>
-        <strong>Los tamaños son fijos.</strong> Apple publica diez ranuras y no hay
-        nada que elegir: 16, 32, 64, 128, 256, 512 y 1024 píxeles, con 32, 256 y
-        512 apareciendo dos veces porque cada uno es a la vez un tamaño propio y la
-        versión Retina del tamaño de debajo.
+        <strong>Los tamaños son fijos.</strong> Apple publica diez ranuras y no
+        hay nada que elegir: 16, 32, 64, 128, 256, 512 y 1024 píxeles, con 32, 256
+        y 512 apareciendo dos veces, porque cada uno es a la vez un tamaño propio
+        y la versión Retina del tamaño de debajo.
       </li>
       <li>
         <strong>Llega hasta 1024.</strong> Un <code>.ico</code> se para en 256, y
-        por eso un archivo de icono de Mac son varios cientos de kilobytes y un
-        favicon son quince. Para una aplicación que se distribuye una vez eso no es
+        de ahí que un archivo de icono de Mac ocupe varios cientos de kilobytes y
+        un favicon quince. Para una aplicación que se distribuye una vez eso no es
         nada; solo un favicon se lo descarga cada visitante.
       </li>
       <li>
-        <strong>1024 píxeles es lo que tiene que aguantar tu dibujo.</strong> Los
-        dos problemas son los extremos opuestos de la misma imagen: un favicon
-        tiene que funcionar cuando es diminuto, y un icono de Mac tiene que
-        aguantar cuando es enorme. Un logotipo exportado a 512 y ampliado a 1024 se
-        ve blando en una pantalla Retina, y la App Store no lo va a aceptar.
+        <strong>Tu dibujo tiene que aguantar a 1024 píxeles.</strong> Los dos
+        problemas son los extremos opuestos de la misma imagen: un favicon tiene
+        que funcionar siendo diminuto y un icono de Mac tiene que aguantar siendo
+        enorme. Un logotipo exportado a 512 y ampliado a 1024 se ve blando en una
+        pantalla Retina, y la App Store no lo va a aceptar.
       </li>
     </ul>
     <p>
-      Para usar uno: un paquete de aplicación lo guarda en
+      Para usarlo: un paquete de aplicación lo guarda en
       <code>TuApp.app/Contents/Resources/</code> y lo nombra en
-      <code>Info.plist</code>. Para una carpeta o una imagen de disco, selecciona el
-      <code>.icns</code> en el Finder, pulsa Comando-C, después haz Obtener
-      información sobre la cosa que quieras cambiar, haz clic en el icono pequeño de
+      <code>Info.plist</code>. Para una carpeta o una imagen de disco, selecciona
+      el <code>.icns</code> en el Finder, pulsa Comando-C, abre después Obtener
+      información sobre lo que quieras cambiar, haz clic en el icono pequeño de
       arriba a la izquierda y pulsa Comando-V.
     </p>
     <p>
-      Marcar <em>icono de macOS</em> en <a href="../../crear-favicon/">Imagen a
-      ICO</a> escribe uno, con o sin el archivo de Windows al lado. Cualquier cosa
-      que se distribuya en las dos plataformas quiere los dos, y los dos se dibujan
-      a partir de la misma imagen en la misma pasada.
+      Si marcas <em>icono de macOS</em> en <a href="../../crear-favicon/">Imagen
+      a ICO</a>, te escribe uno, con o sin el archivo de Windows al lado.
+      Cualquier cosa que se distribuya en las dos plataformas quiere los dos, y
+      los dos se dibujan a partir de la misma imagen en la misma pasada.
     </p>
   </section>
 
   <section>
     <h2>Comprobar que ha funcionado</h2>
     <p>
-      Los navegadores cachean los favicons con más ganas que casi cualquier otra
-      cosa, así que «lo he subido y no ha cambiado nada» suele ser una caché y no un
-      error. Dos cosas que probar antes de ponerte a editar archivos otra vez:
+      Los navegadores cachean los favicons con más empeño que casi cualquier otra
+      cosa, así que «lo he subido y no ha cambiado nada» suele ser la caché y no
+      un error. Dos cosas que probar antes de ponerte a tocar archivos otra vez:
     </p>
     <ul>
       <li>
         Abre <code>https://tusitio.com/favicon.ico</code> directamente. Si el
-        archivo se descarga, está ahí y lo que estás viendo es una caché. Si te sale
-        un 404, no está en la raíz.
+        archivo se descarga, está ahí y lo que ves es la caché. Si te sale un 404,
+        no está en la raíz.
       </li>
       <li>
-        Carga el sitio en una ventana privada, que normalmente tiene su propia caché
-        de iconos.
+        Carga el sitio en una ventana privada, que suele tener su propia caché de
+        iconos.
       </li>
     </ul>
     <p>
-      En Windows, un <code>.ico</code> se puede comprobar poniéndolo en una carpeta
-      y cambiando el Explorador entre sus tamaños de vista: pequeño, mediano, grande
-      y extragrande dibujan entradas distintas del mismo archivo, así que puedes ver
-      cada una tal como la verá el sistema.
+      En Windows, un <code>.ico</code> se comprueba dejándolo en una carpeta y
+      cambiando el Explorador entre sus tamaños de vista: pequeño, mediano, grande
+      y extragrande dibujan entradas distintas del mismo archivo, así que puedes
+      ver cada una tal como la verá el sistema.
     </p>
     <p>
-      En un Mac, un <code>.icns</code> se abre en Vista Previa, que lista todas las
-      ranuras en el lateral &mdash; y el mismo truco funciona en el Finder: déjalo
-      en una carpeta y mueve el control de tamaño de las opciones de vista para
-      verlo cambiar entre las imágenes de dentro.
+      En un Mac, un <code>.icns</code> se abre con Vista Previa, que lista todas
+      las ranuras en el lateral; y el mismo truco funciona en el Finder: déjalo en
+      una carpeta y mueve el control de tamaño de las opciones de vista para verlo
+      cambiar entre las imágenes de dentro.
     </p>
   </section>
 
@@ -316,20 +318,20 @@
     <h2>Nada de esto necesita una subida</h2>
     <p>
       Escalar una imagen es algo que cualquier navegador lleva años haciendo, y un
-      <code>.ico</code> es una cabecera de seis bytes, dieciséis bytes por imagen y
-      después las imágenes. No hay ningún paso en hacer uno que exija un servidor, y
-      la herramienta de aquí no usa ninguno: la
-      <code>Content-Security-Policy</code> de la página nombra todas las direcciones
-      que puede contactar, y ninguna es de este sitio.
+      <code>.ico</code> es una cabecera de seis bytes, dieciséis bytes por imagen
+      y después las imágenes. En hacer uno no hay ningún paso que exija un
+      servidor, y esta herramienta no usa ninguno: la
+      <code>Content-Security-Policy</code> de la página enumera todas las
+      direcciones con las que puede hablar, y ninguna es de este sitio.
     </p>
     <p>
-      Y aquí eso merece más preocupación de lo habitual. Un logotipo entregado a un
-      generador gratuito de favicons es, muy a menudo, una marca sin lanzar &mdash;
-      el icono es de las primeras cosas que se hacen y de las últimas que se
-      anuncian. Carga la página, desenchúfate de internet y haz uno de todos modos
-      si prefieres comprobarlo a que te lo cuenten.
+      Y aquí eso pesa más de lo habitual. Un logotipo entregado a un generador
+      gratuito de favicons es, muchísimas veces, una marca todavía sin lanzar: el
+      icono es de las primeras cosas que se hacen y de las últimas que se
+      anuncian. Si prefieres comprobarlo antes que creértelo, carga la página,
+      desconéctate de internet y haz uno de todos modos.
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      conversores en línea?</a> propone otras tres comprobaciones que puedes
       hacerle a cualquier herramienta.
     </p>
   </section>

--- a/locales/es/pages/guides/make-a-favicon.toml
+++ b/locales/es/pages/guides/make-a-favicon.toml
@@ -7,19 +7,19 @@
 
 nav = "Hacer un favicon"
 
-title = "Cómo hacer un favicon (y un icono de aplicación de Windows)"
-description = "Qué tamaños necesita de verdad un favicon.ico, qué archivos extra piden los iPhone, Android y un Mac, y por qué un logotipo que funciona en un cartel desaparece a dieciséis píxeles."
+title = "Cómo crear un favicon (y el icono de una aplicación de Windows)"
+description = "Qué tamaños necesita de verdad un favicon.ico, qué archivos aparte piden los iPhone, Android y un Mac, y por qué un logotipo que funciona en un cartel desaparece a dieciséis píxeles."
 
-heading = "Cómo hacer un favicon que todavía se lea a dieciséis píxeles"
+heading = "Cómo crear un favicon que aún se lea a dieciséis píxeles"
 lede = """
-    Un favicon no es una imagen pequeña de tu logotipo. Es un conjunto de
-    imágenes a tamaños fijos, dentro de un contenedor que casi nadie abre, y la
-    más pequeña de todas es la que ve la gente. Esto es qué tamaños necesitas,
-    qué archivos van al lado, y qué hacer cuando tu logotipo no sobrevive al
-    viaje hacia abajo."""
+    Un favicon no es una versión pequeña de tu logotipo. Es un juego de imágenes
+    a tamaños fijos, dentro de un contenedor que casi nadie abre, y la más
+    pequeña de todas es la que ve la gente. Aquí verás qué tamaños necesitas,
+    qué archivos van al lado y qué hacer cuando tu logotipo no aguanta el
+    encogimiento."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Hacer un favicon que todavía se lea a dieciséis píxeles"
-og_description = "Qué tamaños necesita un favicon.ico, los archivos extra que piden los iPhone y Android, y qué hacer cuando tu logotipo no sobrevive a encogerse."
+og_title = "Crear un favicon que aún se lea a dieciséis píxeles"
+og_description = "Qué tamaños necesita un favicon.ico, los archivos aparte que piden los iPhone y Android, y qué hacer cuando tu logotipo no aguanta encogerse."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/make-a-pdf-smaller.html
+++ b/locales/es/pages/guides/make-a-pdf-smaller.html
@@ -1,153 +1,153 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre el <a href="../../comprimir-pdf/">compresor de PDF</a>, suelta el
-      documento dentro y mira lo que te dice antes de cambiar nada. Lee el
-      archivo y enseña dónde está de verdad el tamaño &mdash; imágenes,
-      tipografías, texto y dibujo, y todo aquello a lo que ya no apunta nada del
-      documento. Esa sola pantalla suele responder la pregunta.
+      Abre el <a href="../../comprimir-pdf/">compresor de PDF</a>, arrastra el
+      documento dentro y lee lo que te dice antes de tocar nada. Analiza el
+      archivo y te enseña dónde está de verdad el peso: imágenes, tipografías,
+      texto y dibujo, y todo aquello a lo que ya no apunta nada del documento.
+      Esa sola pantalla suele responder la pregunta.
     </p>
     <p>
-      Si casi todo el tamaño son imágenes, puedes esperar un ahorro grande. Si
-      son tipografías y texto, no puedes, y ninguna herramienta puede. Cuál de
-      los dos tienes es la historia entera, y merece diez segundos de mirada.
+      Si casi todo el peso son imágenes, puedes esperar un ahorro grande. Si son
+      tipografías y texto, no puedes, y ninguna herramienta puede. Cuál de los
+      dos casos tienes delante es toda la historia, y merece diez segundos de
+      atención.
     </p>
   </section>
 
   <section>
-    <h2>Dónde está de verdad el tamaño de un PDF</h2>
+    <h2>Dónde está de verdad el peso de un PDF</h2>
     <p>
-      Un PDF es un contenedor de varias clases de cosas distintas, y no se
+      Un PDF es un contenedor con varias clases de cosas dentro, y no todas se
       comprimen igual.
     </p>
     <ul>
       <li>
         <strong>Imágenes.</strong> Fotografías y escaneos. Casi siempre el grueso
-        de un PDF grande, y la única parte con margen de verdad.
+        de un PDF grande, y la única parte con margen real.
       </li>
       <li>
         <strong>Tipografías incrustadas.</strong> Una tipografía completa puede
-        ser de cientos de kilobytes; un subconjunto con solo los caracteres usados
-        es mucho menos. En cualquier caso, las comprimió el programa que produjo
-        el archivo.
+        ocupar cientos de kilobytes; un subconjunto con solo los caracteres
+        usados, muchísimo menos. En cualquier caso, ya las comprimió el programa
+        que produjo el archivo.
       </li>
       <li>
-        <strong>Texto y dibujo vectorial.</strong> Instrucciones en vez de
-        píxeles: dibuja esta línea, pon esta palabra aquí. Compacto ya, y
-        comprimido ya.
+        <strong>Texto y dibujo vectorial.</strong> Instrucciones en lugar de
+        píxeles: traza esta línea, pon esta palabra aquí. Ya es compacto y ya
+        viene comprimido.
       </li>
       <li>
         <strong>Objetos a los que ya no apunta nada.</strong> Los PDF los
         acumulan. Editar un documento muchas veces añade el cambio en vez de
-        reescribir el archivo, así que una versión antigua de una página puede
-        quedarse ahí dentro indefinidamente. Reempaquetar el archivo los tira.
+        reescribir el archivo, así que una versión vieja de una página puede
+        quedarse ahí dentro para siempre. Reempaquetar el archivo los tira.
       </li>
     </ul>
     <p>
-      Así que los dos documentos que la gente le lleva a un compresor de PDF
-      tienen perspectivas completamente distintas. Un documento escaneado es en
-      esencia un montón de fotografías, y suele salir un 60&ndash;90&nbsp;% más
-      pequeño. Un contrato, una tesis o un informe exportado son texto, dibujo y
-      tipografías &mdash; todo ello comprimido ya por el programa que lo escribió
-      &mdash; y ahí el ahorro suele ser de un pequeño porcentaje, de reempaquetar
-      y tirar lo que no se referencia.
+      Por eso los dos documentos que la gente lleva a un compresor de PDF no
+      pueden esperar lo mismo. Un documento escaneado es, en el fondo, un montón
+      de fotografías, y suele salir entre un 60 y un 90&nbsp;% más pequeño. Un
+      contrato, una tesis o un informe exportado son texto, dibujo y tipografías
+      &mdash; todo ello ya comprimido por el programa que lo escribió &mdash;, y
+      ahí el ahorro suele quedarse en un porcentaje pequeño, el de reempaquetar y
+      tirar lo que ya no se usa.
     </p>
     <p>
       Cualquier herramienta que prometa «hasta un 90&nbsp;% más pequeño» sin
-      mirar tu archivo te está citando el mejor caso del primer tipo aplicado al
-      segundo.
+      haber mirado tu archivo te está citando el mejor caso del primer tipo para
+      venderte el segundo.
     </p>
   </section>
 
   <section>
-    <h2>Qué tienen que ver los PPP con esto</h2>
+    <h2>Qué pintan aquí los PPP</h2>
     <p>
-      Un PDF no guarda solo una imagen; anota de qué tamaño se dibuja esa imagen
-      en la página. Eso te da algo más útil que el número de píxeles: la
-      resolución efectiva.
+      Un PDF no guarda solo una imagen: anota además de qué tamaño se dibuja esa
+      imagen en la página. Eso da algo más útil que el número de píxeles, que es
+      la resolución efectiva.
     </p>
     <p>
-      Un escaneo de 4000 píxeles de ancho colocado a lo ancho de veinte
+      Un escaneo de 4000 píxeles de ancho colocado a lo largo de veinte
       centímetros de papel lleva unos 500 píxeles por pulgada. Una pantalla
-      enseña unos 100. Una buena impresora de oficina trabaja a 300 y no puede
-      aprovechar mucho más. Todo lo que hay por encima es detalle que nada en el
-      futuro del documento va a mostrar jamás &mdash; y suele ser casi todo el
-      archivo.
+      muestra unos 100. Una buena impresora de oficina trabaja a 300 y no puede
+      aprovechar mucho más. Todo lo que sobrepase eso es detalle que nada en el
+      futuro del documento va a enseñar jamás, y suele ser casi todo el archivo.
     </p>
     <p>
-      Por eso un compresor de PDF sensato pide unos PPP en vez de un porcentaje de
-      calidad. Tira primero los píxeles que están por encima de tu cifra, porque
-      esos no cuestan nada que nadie pueda ver, y solo entonces empieza a gastar
-      calidad de verdad.
+      De ahí que un compresor de PDF sensato te pida unos PPP y no un porcentaje
+      de calidad. Empieza tirando los píxeles que sobran de tu cifra, porque esos
+      no le cuestan nada a nadie, y solo después empieza a gastar calidad de
+      verdad.
     </p>
     <p>
-      Guía aproximada: <strong>150 PPP</strong> para un documento que se va a leer
-      en pantalla, <strong>200&ndash;300</strong> para algo que se va a imprimir,
-      <strong>72&ndash;100</strong> para un borrador que nadie va a guardar. Medir
-      contra el tamaño al que se dibuja la imagen es además la razón de que un
-      logotipo colocado pequeño no se trate igual que un escaneo a página completa
-      &mdash; el logotipo ya está cerca de su resolución efectiva y no hay nada que
-      quitarle.
+      Una guía aproximada: <strong>150 PPP</strong> para un documento que se va a
+      leer en pantalla, <strong>200&ndash;300</strong> para algo que se va a
+      imprimir y <strong>72&ndash;100</strong> para un borrador que nadie va a
+      guardar. Medir contra el tamaño al que se dibuja la imagen es además lo que
+      hace que un logotipo colocado pequeño no reciba el mismo trato que un
+      escaneo a página completa: el logotipo ya está cerca de su resolución
+      efectiva y no hay nada que quitarle.
     </p>
   </section>
 
   <section>
-    <h2>Qué debería y qué no debería tocar la compresión</h2>
+    <h2>Qué debería tocar la compresión y qué no</h2>
     <p>
-      Las imágenes se recodifican, así que esas pierden un poco. Nada más debería
-      tocarse en absoluto, y merece la pena comprobar que la herramienta que uses
-      lo respeta:
+      Las imágenes se recodifican, así que esas pierden algo. Lo demás no debería
+      tocarse en absoluto, y conviene comprobar que la herramienta que uses lo
+      respeta:
     </p>
     <ul>
       <li>
         <strong>El texto sigue siendo texto.</strong> Seleccionable, buscable,
-        copiable. Un compresor que aplane las páginas a imágenes producirá un
-        archivo muy pequeño y destruirá el documento &mdash; no puedes buscar en
-        él, los lectores de pantalla no pueden leerlo, y no hay vuelta atrás.
+        copiable. Un compresor que aplane las páginas a imágenes te dará un
+        archivo pequeñísimo y habrá destruido el documento: no se puede buscar en
+        él, los lectores de pantalla no pueden leerlo y no hay vuelta atrás.
       </li>
       <li>
-        <strong>Las tipografías siguen enteras.</strong> Sustituir tipografías
-        cambia el aspecto del documento en el equipo de otra persona, que es
-        justamente lo que el PDF existe para evitar.
+        <strong>Las tipografías siguen enteras.</strong> Sustituirlas cambia el
+        aspecto del documento en el equipo de otra persona, que es exactamente lo
+        que el PDF existe para evitar.
       </li>
       <li>
-        <strong>El dibujo vectorial se copia tal cual.</strong> Ya es pequeño, y
-        rasterizarlo lo haría a la vez más grande y peor.
+        <strong>El dibujo vectorial se copia tal cual.</strong> Ya es ligero, y
+        rasterizarlo lo dejaría a la vez más pesado y peor.
       </li>
       <li>
         <strong>Los formularios, los enlaces, los marcadores, la estructura de
-        accesibilidad y los adjuntos se llevan al archivo nuevo.</strong> Son
-        fáciles de perder en una reescritura y casi nunca se nota hasta que
+        accesibilidad y los adjuntos pasan al archivo nuevo.</strong> Son fáciles
+        de perder en una reescritura y casi nunca se echan en falta hasta que
         alguien necesita uno.
       </li>
     </ul>
     <p>
-      Una regla relacionada que un compresor debería seguir y muchos no siguen: si
-      recodificar una imagen no sale de verdad más pequeño que el original, hay
-      que devolver los bytes originales. Empeorar una imagen sin ningún ahorro es
-      el caso de pérdida pura, y pasa más a menudo de lo que uno pensaría con
-      imágenes que ya estaban bien comprimidas.
+      Y una regla emparentada que un compresor debería seguir y muchos no siguen:
+      si recodificar una imagen no la deja realmente más ligera que el original,
+      hay que devolver los bytes originales. Empeorar una imagen sin ahorrar nada
+      es pura pérdida, y pasa más a menudo de lo que parece con imágenes que ya
+      venían bien comprimidas.
     </p>
   </section>
 
   <section>
     <h2>Las imágenes que no se pueden comprimir</h2>
     <p>
-      Algunas imágenes de dentro de un PDF se saltan, y una buena herramienta las
-      nombra en vez de dejarlas fuera de la cuenta en silencio:
+      Algunas imágenes de dentro de un PDF se dejan pasar, y una buena
+      herramienta las nombra en lugar de descontarlas en silencio:
     </p>
     <ul>
       <li>
         <strong>Imágenes JPEG&nbsp;2000, JBIG2 y codificadas para fax
         (CCITT).</strong> Ningún navegador trae un descodificador para ninguna de
-        ellas, así que pasan intactas. Las dos últimas son de dos niveles &mdash;
-        solo blanco y negro &mdash; y suelen estar ya cerca de su tamaño mínimo.
+        ellas, así que pasan intactas. Las dos últimas son bitonales &mdash; solo
+        blanco y negro &mdash; y suelen estar ya cerca de su tamaño mínimo.
       </li>
       <li>
         <strong>Imágenes CMYK.</strong> Se dejan en paz a propósito.
-        Recodificarlas arriesga a desplazar los colores que sacaría una imprenta,
-        que es algo sorprendente que hacerle a un documento que alguien va a
-        imprimir.
+        Recodificarlas puede desplazar los colores que acabaría sacando una
+        imprenta, y esa es una sorpresa muy desagradable en un documento que
+        alguien va a imprimir.
       </li>
     </ul>
   </section>
@@ -155,24 +155,24 @@
   <section>
     <h2>Cosas que probar antes de comprimir</h2>
     <p>
-      A veces el archivo es grande por una razón para la que la compresión es la
-      respuesta equivocada.
+      A veces el archivo pesa por un motivo para el que la compresión no es la
+      respuesta.
     </p>
     <p>
-      <strong>¿Se escaneó cuando no hacía falta?</strong> Un documento impreso y
-      después escaneado es un montón de fotografías de texto. Si el original
-      todavía existe en alguna parte como documento, exportarlo a PDF producirá un
-      archivo de una fracción del tamaño y además buscable.
+      <strong>¿Se escaneó sin necesidad?</strong> Un documento impreso y luego
+      escaneado es un montón de fotografías de texto. Si el original todavía
+      existe en alguna parte como documento, exportarlo a PDF dará un archivo de
+      una fracción del peso y además buscable.
     </p>
     <p>
       <strong>¿Se exportó con ajustes de imprenta?</strong> Los procesadores de
       texto y los programas de diseño suelen exportar por defecto con calidad de
       imprenta. Volver a exportar para pantalla desde el archivo original suele
-      ganarle a comprimir la exportación.
+      dar mejor resultado que comprimir la exportación.
     </p>
     <p>
-      <strong>¿Tiene que ser un solo archivo?</strong> El límite de un correo es
-      por mensaje. Dividir un documento de 200 páginas en capítulos es a veces la
+      <strong>¿Tiene que ser un solo archivo?</strong> El límite del correo es por
+      mensaje. Partir un documento de 200 páginas por capítulos es, a veces, la
       solución honesta.
     </p>
   </section>
@@ -180,17 +180,17 @@
   <section>
     <h2>Los archivos cifrados, y por qué un compresor debería rechazarlos</h2>
     <p>
-      Un PDF protegido con contraseña lo rechaza la herramienta de aquí, y eso es
-      deliberado y no una función que falte &mdash; incluso cuando la contraseña
-      está en blanco, que es como guardan muchos escáneres y fotocopiadoras.
+      Un PDF protegido con contraseña lo rechaza esta herramienta, y es
+      deliberado, no una función que falte. También cuando la contraseña está en
+      blanco, que es como guardan muchos escáneres y fotocopiadoras.
     </p>
     <p>
       Quitarle la protección a un documento es un trabajo distinto de
-      comprimirlo. Una herramienta que lo hiciera en silencio estaría haciendo
-      algo que no le pediste, sobre un archivo que alguien había bloqueado a
-      propósito, y devolviéndote una copia que ya no tendría la propiedad que esa
-      persona quiso que tuviera. Quítale la protección tú primero, a propósito, si
-      es lo que quieres.
+      comprimirlo. Una herramienta que lo hiciera sin decir nada estaría haciendo
+      algo que no le pediste, sobre un archivo que alguien bloqueó a propósito, y
+      devolviéndote una copia que ya no tendría la propiedad que esa persona
+      quiso darle. Si es lo que quieres, quítale la protección tú primero y
+      sabiendo lo que haces.
     </p>
   </section>
 
@@ -198,12 +198,12 @@
     <h2>Comprobar el resultado</h2>
     <p>
       Ábrelo. Mira las imágenes con el zoom al máximo, comprueba que el texto
-      sigue siendo seleccionable y confirma el número de páginas.
+      sigue siendo seleccionable y cuenta las páginas.
     </p>
     <p>
-      La herramienta de aquí hace lo último por ti antes de ofrecerte el archivo:
-      vuelve a abrir el documento que acaba de escribir y le cuenta las páginas, en
-      tu propio equipo. Escribe además PDF 1.5, que entiende cualquier lector
+      Lo último te lo hace la herramienta antes de ofrecerte el archivo: vuelve a
+      abrir el documento que acaba de escribir y le cuenta las páginas, en tu
+      propio equipo. Escribe además PDF 1.5, que entiende cualquier lector
       publicado desde 2003, así que «se abre en mi equipo» es una aproximación
       razonable a «se abre en el suyo».
     </p>
@@ -213,22 +213,22 @@
     <h2>Por qué esto no necesita un servidor</h2>
     <p>
       Comprimir un PDF suena a trabajo de servidor, y durante casi toda la vida de
-      la web lo fue. Lo que implica en realidad es analizar la estructura del
-      archivo, encontrar los flujos de imagen, descodificarlos y recodificarlos
-      con los códecs que un navegador ya trae, y volver a escribir el documento.
+      la web lo fue. Lo que consiste en realidad es en analizar la estructura del
+      archivo, localizar los flujos de imagen, descodificarlos y recodificarlos
+      con los códecs que el navegador ya trae, y volver a escribir el documento.
       Todo eso funciona hoy dentro de un navegador.
     </p>
     <p>
-      Cosa que importa más con este tipo de archivo que con casi cualquier otro,
-      por lo que la gente comprime: contratos, informes médicos, extractos
-      bancarios, documentos de identidad, declaraciones de la renta. La
-      herramienta de aquí no tiene ninguna función de red, y la
-      <code>Content-Security-Policy</code> de la página nombra todas las
-      direcciones que puede contactar, ninguna de las cuales es de este sitio.
-      Cárgala, desenchúfate y comprime algo de todos modos.
+      Y con esta clase de archivo importa más que con casi ninguna otra, por lo
+      que la gente suele comprimir: contratos, informes médicos, extractos
+      bancarios, documentos de identidad, declaraciones de la renta. Este
+      compresor no tiene ninguna función de red, y la
+      <code>Content-Security-Policy</code> de la página enumera todas las
+      direcciones con las que puede hablar, y ninguna es de este sitio. Cárgala,
+      desconéctate y comprime algo de todos modos.
     </p>
     <p>
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea otras tres comprobaciones como esa.
+      conversores en línea?</a> propone otras tres comprobaciones como esa.
     </p>
   </section>

--- a/locales/es/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/es/pages/guides/make-a-pdf-smaller.toml
@@ -8,18 +8,18 @@
 
 nav = "Reducir un PDF"
 
-title = "Cómo reducir el tamaño de un PDF (y por qué algunos no encogen)"
-description = "Dónde está de verdad el tamaño de un PDF, por qué un escaneo se comprime un 80&nbsp;% y un contrato apenas se mueve, qué significan aquí los PPP, y qué no debería hacerle nunca un compresor a tu documento."
+title = "Cómo reducir el peso de un PDF (y por qué algunos no adelgazan)"
+description = "Dónde está de verdad el peso de un PDF, por qué un escaneo se comprime un 80 % y un contrato apenas se mueve, qué pintan aquí los PPP y qué no debería hacerle nunca un compresor a tu documento."
 
-heading = "Cómo reducir el tamaño de un PDF, y por qué algunos no encogen"
+heading = "Cómo reducir el peso de un PDF, y por qué algunos no adelgazan"
 lede = """
     Un PDF que no cabe en el límite de un correo es casi siempre un PDF lleno de
-    imágenes. Esto explica cómo saber si el tuyo lo es, qué cuesta comprimirlo, y
+    imágenes. Aquí verás cómo saber si el tuyo lo es, qué cuesta comprimirlo y
     por qué cualquier herramienta que prometa un porcentaje fijo no ha mirado tu
     archivo."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Cómo reducir el tamaño de un PDF"
-og_description = "Dónde está de verdad el tamaño de un PDF, por qué un escaneo encoge y un contrato no, y qué tienen que ver los PPP con esto."
+og_title = "Cómo reducir el peso de un PDF"
+og_description = "Dónde está de verdad el peso de un PDF, por qué un escaneo adelgaza y un contrato no, y qué pintan aquí los PPP."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/make-a-qr-code.html
+++ b/locales/es/pages/guides/make-a-qr-code.html
@@ -4,14 +4,14 @@
       Abre el <a href="../../generar-codigo-qr/">generador de QR y códigos de
       barras</a>, pega tu enlace, deja el nivel en <strong>M</strong> y el margen
       en <strong>4</strong>, y descarga el SVG. Imprímelo con al menos dos
-      centímetros de ancho, sobre algo mate, oscuro sobre claro. Y después escanea
+      centímetros de ancho, sobre algo mate y oscuro sobre claro. Y luego escanea
       el impreso con un móvil que no sea el tuyo antes de encargar mil.
     </p>
     <p>
       Eso cubre casi todos los casos. El resto de esta página es qué hacer cuando
-      no es uno de ellos: un código que tiene que aguantar que lo manoseen, un
-      código con un logotipo encima, un código que va en algo pequeño, y la única
-      decisión que es fácil de equivocar de una forma de la que no te enteras hasta
+      el tuyo no es uno de ellos: un código que va a acabar manoseado, un código
+      con un logotipo encima, un código que va en algo pequeño, y la única
+      decisión que se puede equivocar de una forma de la que no te enteras hasta
       un año después.
     </p>
   </section>
@@ -19,84 +19,85 @@
   <section>
     <h2>Qué hay de verdad dentro de un código QR</h2>
     <p>
-      Una cadena de texto. Eso es todo. Escanear un código QR le entrega al móvil
-      un trozo de texto, y todo lo demás &mdash; abrir una página, conectarse a una
+      Una cadena de texto. Nada más. Escanear un código QR le entrega al móvil un
+      trozo de texto, y todo lo demás &mdash; abrir una página, conectarse a una
       red, ofrecerse a guardar un contacto &mdash; es el móvil reconociendo la
       forma de ese texto y ofreciéndose a actuar.
     </p>
     <p>
-      Así que no existe eso de un «código QR de wifi» como tipo de código. Existe
-      un código QR que lleva <code>WIFI:T:WPA;S:Mi Red;P:la contraseña;;</code>,
-      que sabe leer cualquier móvil hecho en la última década. El generador te
-      enseña la cadena terminada exactamente por esto: cuando un código no hace lo
-      que esperabas, la cadena es lo único que merece la pena mirar.
+      Así que no existe el «código QR de wifi» como tipo de código. Lo que existe
+      es un código QR que lleva dentro
+      <code>WIFI:T:WPA;S:Mi Red;P:la contraseña;;</code>, que sabe leer cualquier
+      móvil fabricado en la última década. El generador te enseña la cadena
+      terminada justamente por esto: cuando un código no hace lo que esperabas, la
+      cadena es lo único que merece la pena mirar.
     </p>
     <p>
       Significa además que un código QR no se puede cambiar una vez impreso, no
-      puede llamar a casa y no puede caducar &mdash; salvo que alguien le haya
-      metido dentro un enlace a su propio servidor, que es el tema del último
-      apartado de aquí.
+      informa a nadie de nada y no caduca; salvo que alguien le haya metido dentro
+      un enlace a su propio servidor, que es de lo que va el último apartado de
+      esta página.
     </p>
   </section>
 
   <section>
     <h2>Decisión uno: el nivel de corrección de errores</h2>
     <p>
-      Un código QR lleva junto a los datos un conjunto de palabras de
-      comprobación, calculadas para que un lector pueda reconstruir lo que no ha
-      podido ver. Por eso un código con una esquina arrancada sigue escaneando.
-      Cuántas de esas palabras hay es el nivel, y hay cuatro:
+      Un código QR lleva, junto a los datos, un juego de palabras de comprobación
+      calculadas para que un lector pueda reconstruir lo que no ha llegado a ver.
+      Por eso un código con una esquina arrancada se sigue escaneando. Cuántas de
+      esas palabras lleva es el nivel, y hay cuatro:
     </p>
     <ul>
-      <li><strong>L</strong> &mdash; se puede perder alrededor del 7&nbsp;% del código.</li>
+      <li><strong>L</strong> &mdash; puede perderse alrededor del 7&nbsp;% del código.</li>
       <li><strong>M</strong> &mdash; alrededor del 15&nbsp;%.</li>
       <li><strong>Q</strong> &mdash; alrededor del 25&nbsp;%.</li>
       <li><strong>H</strong> &mdash; alrededor del 30&nbsp;%.</li>
     </ul>
     <p>
-      Más corrección no es gratis: los datos de comprobación van en el mismo
+      Más corrección no sale gratis: los datos de comprobación van en el mismo
       cuadrado, así que el mismo texto en H necesita un código más grande y más
-      denso que en L. A grandes rasgos, pasar de L a H duplica el número de módulos
-      para la misma cadena, y unos módulos más densos son más difíciles de resolver
-      para una cámara. Aquí hay un trato de verdad y la respuesta depende de adónde
-      vaya el código.
+      denso que en L. A grandes rasgos, pasar de L a H duplica el número de
+      módulos para la misma cadena, y unos módulos más apretados le cuestan más a
+      una cámara. Aquí hay una contrapartida real, y la respuesta depende de
+      adónde vaya a parar el código.
     </p>
     <p>
       <strong>L</strong> es para una pantalla: un código en una diapositiva, en un
       correo, en una página web. Nada lo va a dañar y cada módulo de más lo hace
-      más difícil de leer a distancia.
+      más difícil de leer de lejos.
     </p>
     <p>
-      <strong>M</strong> es el valor por defecto y la respuesta correcta para casi
+      <strong>M</strong> es el valor por defecto y la respuesta acertada para casi
       cualquier impresión. Papel que se va a manosear un poco, un folleto, una
       tarjeta de visita.
     </p>
     <p>
-      <strong>Q y H</strong> son para códigos que van a sufrir: una carta que se
-      limpia a diario, una pegatina en una máquina de un taller, una etiqueta en
-      una caja, un código en un escaparate que le da el sol directo. H es además lo
-      que hace posible un logotipo en el centro &mdash; ver más abajo.
+      <strong>Q y H</strong> son para códigos que van a sufrir: una carta de
+      restaurante que se limpia a diario, una pegatina en una máquina de un
+      taller, una etiqueta en una caja, un código en un escaparate al que le da el
+      sol de frente. H es además lo que hace posible poner un logotipo en el
+      centro, como se ve más abajo.
     </p>
   </section>
 
   <section>
-    <h2>Decisión dos: el margen, que forma parte del código</h2>
+    <h2>Decisión dos: el margen, que es parte del código</h2>
     <p>
-      El espacio en blanco de alrededor de un código QR no es relleno, y no es una
-      decisión de diseño. Un lector lo usa para saber dónde termina el símbolo. La
-      especificación pide cuatro módulos de espacio en calma por cada lado, y un
-      código recortado hasta su borde es la razón número uno de que un código
-      impreso falle.
+      El blanco que rodea a un código QR no es relleno, ni una decisión de diseño.
+      Un lector lo usa para saber dónde termina el símbolo. La especificación pide
+      cuatro módulos de zona de silencio por cada lado, y un código recortado
+      hasta el borde es la causa número uno de que un código impreso falle.
     </p>
     <p>
-      Merece la pena decirlo sin rodeos porque recortar es una cosa muy natural de
-      hacer. El código parece que tiene demasiado blanco alrededor, así que se
-      recorta en la maquetación, o se suelta sobre un panel de color que llega
-      hasta los cuadrados, o se pone encima de una fotografía. Cada una de esas
-      cosas le quita el límite que iba a usar el lector.
+      Conviene decirlo sin rodeos, porque recortarlo es de lo más natural del
+      mundo. El código parece tener demasiado blanco alrededor, así que se recorta
+      en la maquetación, o se coloca sobre un panel de color que llega hasta los
+      cuadrados, o se pone encima de una fotografía. Cada una de esas tres cosas le
+      quita el límite que el lector iba a usar.
     </p>
     <p>
-      Si el código parece demasiado grande con su margen, haz el código más
+      Si el código te parece demasiado grande con su margen, haz el código más
       pequeño. No le quites el margen.
     </p>
   </section>
@@ -104,82 +105,84 @@
   <section>
     <h2>Decisión tres: de qué tamaño imprimirlo</h2>
     <p>
-      La regla práctica que ha sobrevivido al contacto con la realidad es
-      <strong>uno a diez</strong>: un código tiene que medir de ancho más o menos
-      una décima parte de la distancia desde la que se va a escanear.
+      La regla práctica que ha sobrevivido al contacto con la realidad es la de
+      <strong>uno a diez</strong>: el código debe medir de ancho más o menos una
+      décima parte de la distancia desde la que se va a escanear.
     </p>
     <ul>
-      <li>Una tarjeta de visita o una carta, leída a 30 cm: unos 2 cm de ancho.</li>
-      <li>Un cartel leído a dos metros: unos 20 cm.</li>
-      <li>Una marquesina o un escaparate leídos a cinco metros: unos 50 cm.</li>
+      <li>Una tarjeta de visita o una carta, que se leen a 30 cm: unos 2 cm de ancho.</li>
+      <li>Un cartel que se lee a dos metros: unos 20 cm.</li>
+      <li>Una marquesina o un escaparate, a cinco metros: unos 50 cm.</li>
     </ul>
     <p>
-      Dos centímetros es un suelo, no un objetivo. Por debajo de 1,5 cm más o menos
-      un móvil corriente empieza a sufrir por buena que sea la impresión, porque los
-      módulos sueltos se acercan al tamaño de un píxel de su cámara.
+      Dos centímetros es un mínimo, no un objetivo. Por debajo de un centímetro y
+      medio, más o menos, un móvil corriente empieza a sufrir por buena que sea la
+      impresión, porque los módulos sueltos se acercan al tamaño de un píxel de su
+      cámara.
     </p>
     <p>
-      Menos texto significa menos módulos, y eso significa un código que se lee a
-      distancia para un tamaño impreso dado &mdash; que es un buen motivo para
-      apuntar un código a <code>ejemplo.com/x</code> y no a una URL con cien
+      Cuanto menos texto, menos módulos; y cuantos menos módulos, más lejos se lee
+      el código para un mismo tamaño impreso. Ese es un buen motivo para que un
+      código apunte a <code>ejemplo.com/x</code> y no a una URL con cien
       caracteres de parámetros de seguimiento al final.
     </p>
     <p>
-      Y imprime desde el <strong>SVG</strong>. Un código QR está hecho de bordes, y
-      un PNG tiene un número fijo de píxeles con los que hacerlos; amplía uno y
-      todos los bordes se ablandan, que es justo lo que le cuesta a un escáner. Un
-      SVG son los cuadrados como instrucciones, así que sale nítido tanto en una
-      tarjeta de visita como en una valla.
+      Y para imprimir, usa el <strong>SVG</strong>. Un código QR está hecho de
+      bordes, y un PNG tiene un número fijo de píxeles con los que dibujarlos:
+      amplíalo y todos los bordes se reblandecen, que es justo lo que le cuesta a
+      un escáner. Un SVG lleva los cuadrados como instrucciones, así que sale
+      nítido lo mismo en una tarjeta de visita que en una valla.
     </p>
   </section>
 
   <section>
-    <h2>Color, contraste y los dos errores</h2>
+    <h2>Color, contraste y los dos errores de siempre</h2>
     <p>
       Un lector mide la diferencia entre los módulos oscuros y los claros, así que
-      el contraste lo es todo. Hay dos cosas que salen mal a menudo:
+      el contraste lo es todo. Dos cosas salen mal muy a menudo:
     </p>
     <p>
-      <strong>Código claro sobre fondo oscuro.</strong> Queda llamativo, y bastantes
-      lectores lo rechazan de plano: buscan oscuro sobre claro y no prueban la
-      inversión. Algunos sí. No vas a saber cuáles tienen tus clientes.
+      <strong>Código claro sobre fondo oscuro.</strong> Queda llamativo, y
+      bastantes lectores lo rechazan de plano: buscan oscuro sobre claro y no
+      prueban la inversión. Algunos sí la prueban. No vas a saber cuáles tienen
+      tus clientes.
     </p>
     <p>
-      <strong>Poca diferencia.</strong> Un gris medio sobre blanco, o dos colores de
-      marca de peso parecido, pueden medir bien en pantalla y fallar en papel en
-      cuanto entran en juego la ganancia de tinta y la exposición automática de un
-      móvil. Si vas a colorear un código, mantén la parte oscura genuinamente
-      oscura.
+      <strong>Poca diferencia entre los dos.</strong> Un gris medio sobre blanco,
+      o dos colores de marca de peso parecido, pueden medir bien en pantalla y
+      fallar en papel en cuanto entran en juego la ganancia de tinta y la
+      exposición automática de un móvil. Si vas a colorear un código, que la parte
+      oscura sea de verdad oscura.
     </p>
     <p>
-      El mate le gana al brillo en cualquier cosa que se vaya a escanear bajo una
+      El mate le gana al satinado en cualquier cosa que vaya a escanearse bajo una
       luz, y los dos le ganan a imprimir sobre una fotografía. Los fondos
-      transparentes son útiles para poner un código sobre un panel de color &mdash;
-      pero comprueba qué acaba de verdad detrás, porque un código transparente sobre
-      un panel oscuro es el primer error de arriba con pasos de más.
+      transparentes vienen bien para colocar un código sobre un panel de color,
+      pero comprueba qué acaba habiendo detrás: un código transparente sobre un
+      panel oscuro es el primer error de este apartado, con un rodeo de más.
     </p>
   </section>
 
   <section>
     <h2>Un logotipo en el centro</h2>
     <p>
-      Esto funciona, y funciona gracias a la corrección de errores y no a pesar de
+      Esto funciona, y funciona gracias a la corrección de errores, no a pesar de
       ella. En el nivel H se puede destruir alrededor del 30&nbsp;% de los módulos
-      y el código sigue leyéndose, así que un logotipo que cubra bastante menos que
-      eso &mdash; en el centro, donde no hay ningún patrón de localización &mdash;
-      es un daño que el lector repara.
+      sin que el código deje de leerse, así que un logotipo que cubra bastante
+      menos que eso &mdash; en el centro, donde no hay ningún patrón de
+      localización &mdash; es un daño que el lector repara.
     </p>
     <p>
-      Tres cosas que respetar. Usa el nivel H. Mantén el logotipo por debajo de una
-      quinta parte del área más o menos, bien lejos del límite teórico, porque la
-      impresión no es lo único que se está comiendo tu margen. Y no tapes nunca los
-      tres cuadrados grandes de las esquinas ni los pequeños que hay cerca: así es
-      como un lector encuentra y orienta el símbolo, para empezar, y no hay
-      corrección de errores que los reconstruya.
+      Tres cosas que respetar. Usa el nivel H. Mantén el logotipo por debajo de
+      una quinta parte del área, más o menos, bien lejos del límite teórico,
+      porque la impresión no es lo único que se está comiendo tu margen. Y no
+      tapes jamás los tres cuadrados grandes de las esquinas ni los pequeños que
+      hay cerca: es así como un lector encuentra y orienta el símbolo antes que
+      nada, y no hay corrección de errores que los reconstruya.
     </p>
     <p>
       Y después pruébalo en móviles de verdad. Un logotipo lleva un código de
-      «siempre funciona» a «funciona con este margen», y la única forma de saber
+      «siempre funciona» a «funciona con este margen», y la única manera de saber
       cuánto margen queda es probarlo.
     </p>
   </section>
@@ -187,45 +190,46 @@
   <section>
     <h2>La decisión de la que la gente se arrepiente: estático o «dinámico»</h2>
     <p>
-      Busca un generador de QR y casi todos los resultados quieren que te hagas una
-      cuenta, porque están vendiendo códigos <em>dinámicos</em>. Un código dinámico
-      no contiene tu enlace. Contiene un enlace corto al propio servidor del
-      generador, que redirige al tuyo.
+      Busca un generador de QR y casi todos los resultados querrán que te hagas
+      una cuenta, porque lo que venden son códigos <em>dinámicos</em>. Un código
+      dinámico no contiene tu enlace: contiene un enlace corto al servidor del
+      propio generador, que redirige al tuyo.
     </p>
     <p>
-      Lo que eso te compra es real: puedes cambiar adónde apunta el código después
-      de imprimirlo, y te llevas un recuento de cada escaneo. Para una campaña con
-      una tirada de seis cifras, eso merece pagarse.
+      Lo que ganas con eso es real: puedes cambiar adónde apunta el código después
+      de haberlo impreso, y te llevas un recuento de cada escaneo. Para una
+      campaña con una tirada de seis cifras, eso se paga solo.
     </p>
     <p>
-      Lo que cuesta también es real, y merece saberse antes y no después:
+      Lo que cuesta también es real, y conviene saberlo antes y no después:
     </p>
     <ul>
       <li>
-        <strong>El código deja de funcionar cuando ellos dejan de funcionar.</strong>
-        Si el servicio cierra, el dominio caduca o el plan gratuito expira, todos
-        los códigos que imprimiste se quedan muertos &mdash; y para entonces están
-        en diez mil cartas.
+        <strong>El código deja de funcionar cuando ellos dejan de
+        funcionar.</strong> Si el servicio cierra, el dominio caduca o el plan
+        gratuito se acaba, todos los códigos que imprimiste quedan muertos, y para
+        entonces están en diez mil cartas.
       </li>
       <li>
-        <strong>Cada escaneo son datos de otra persona.</strong> La redirección ve
-        la dirección IP, la hora y el dispositivo de todo el que escanee tu código.
+        <strong>Cada escaneo son datos que se lleva otro.</strong> La redirección
+        ve la dirección IP, la hora y el dispositivo de todo el que escanee tu
+        código.
       </li>
       <li>
-        <strong>El enlace es suyo, no tuyo.</strong> Cualquiera que lo escanee ve
-        pasar un dominio desconocido, que es justo de lo que a la gente le están
+        <strong>El enlace es suyo, no tuyo.</strong> Quien lo escanee verá pasar
+        un dominio desconocido, que es exactamente de lo que a la gente le están
         diciendo que desconfíe.
       </li>
     </ul>
     <p>
-      El término medio no cuesta nada: pon un código QR estático alrededor de una
-      URL corta <em>de tu propio dominio</em>, y redirígela tú. Conservas la
+      El término medio no cuesta nada: haz un código QR estático alrededor de una
+      URL corta <em>de tu propio dominio</em> y redirígela tú. Conservas la
       capacidad de cambiar el destino, conservas la analítica, y nada del código
       depende de que una empresa que no conoces siga existiendo el año que viene.
     </p>
     <p>
-      El <a href="../../generar-codigo-qr/">generador de aquí</a> solo hace códigos
-      estáticos, y no tiene ninguna cuenta que crear. Lo que escribes es lo que
+      Este <a href="../../generar-codigo-qr/">generador</a> solo hace códigos
+      estáticos, y no hay ninguna cuenta que crear. Lo que escribes es lo que
       lleva el código.
     </p>
   </section>
@@ -233,16 +237,17 @@
   <section>
     <h2>Antes de imprimir mil</h2>
     <p>
-      Escanea el código. No el de tu pantalla &mdash; la prueba impresa, en el
-      sitio al que va, con un móvil que no sea aquel con el que lo hiciste. Eso
-      lleva un minuto y pilla la categoría entera de problemas de la que va esta
-      página: un margen que se comió la maquetación, un enlace al que le faltaba el
-      <code>https://</code>, un color que midió distinto en papel, un código impreso
-      a un tamaño que funciona en un escritorio y no en una pared.
+      Escanea el código. No el de tu pantalla: la prueba impresa, en el sitio
+      donde va a estar, con un móvil que no sea aquel con el que lo hiciste. Es un
+      minuto, y detecta toda la familia de problemas de la que va esta página: un
+      margen que se comió la maquetación, un enlace al que le faltaba el
+      <code>https://</code>, un color que midió distinto en papel, un código
+      impreso a un tamaño que funciona en un escritorio y no en una pared.
     </p>
     <p>
-      Y comprueba qué pasa después del escaneo. Un código que abre una página
-      ilegible en un móvil es un código que ha fallado, aunque haya escaneado.
+      Y comprueba qué pasa después de escanear. Un código que abre una página
+      ilegible en un móvil es un código que ha fallado, aunque haya escaneado
+      bien.
     </p>
   </section>
 
@@ -250,14 +255,14 @@
     <h2>Nada de esto exige subir nada</h2>
     <p>
       Un código QR es aritmética sobre una cadena de texto. No hay ningún archivo
-      que enviar ni nada que un servidor pueda hacer y un navegador no, y por eso
-      la <a href="../../generar-codigo-qr/">herramienta de aquí</a> lo hace todo en
-      tu propio equipo y funciona con la red desenchufada.
+      que enviar ni nada que pueda hacer un servidor y no pueda hacer un
+      navegador, y por eso <a href="../../generar-codigo-qr/">este generador</a>
+      lo hace todo en tu propio equipo y funciona con la red desconectada.
     </p>
     <p>
-      Y eso importa más de lo que suena, por lo que la gente mete en los códigos QR.
-      El uso más común del formato de wifi es la contraseña real de una red,
-      tecleada en una página web. Merece la pena saber si esa página tenía adónde
-      mandarla.
+      Y eso importa más de lo que suena, por lo que la gente mete dentro de un
+      código QR. El uso más habitual del formato de wifi es la contraseña real de
+      una red, tecleada en una página web. Merece la pena saber si esa página
+      tenía adónde mandarla.
     </p>
   </section>

--- a/locales/es/pages/guides/make-a-qr-code.toml
+++ b/locales/es/pages/guides/make-a-qr-code.toml
@@ -7,18 +7,18 @@
 
 nav = "Hacer un código QR"
 
-title = "Cómo hacer un código QR que escanee siempre"
-description = "Qué nivel de corrección de errores elegir, por qué el margen blanco de alrededor forma parte del código, de qué tamaño imprimirlo, y lo que te cuesta después el código «dinámico» de un generador gratuito."
+title = "Cómo crear un código QR que escanee siempre"
+description = "Qué nivel de corrección de errores elegir, por qué el blanco de alrededor es parte del código, de qué tamaño imprimirlo y qué te acaba costando el código «dinámico» de un generador gratuito."
 
-heading = "Cómo hacer un código QR que también escanee en el móvil de otro"
+heading = "Cómo crear un código QR que escanee también en el móvil de otro"
 lede = """
-    Hacer un código QR lleva un segundo. Hacer uno que funcione en una carta
-    mojada, en una marquesina o en un móvil sostenido con el brazo estirado y con
+    Crear un código QR lleva un segundo. Crear uno que funcione en una carta
+    mojada, en una marquesina o en un móvil sujeto con el brazo estirado y con
     mala luz lleva cuatro decisiones, y las cuatro se toman antes de imprimir
     nada. Esto es lo que hace cada una."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Hacer un código QR que también escanee en el móvil de otro"
-og_description = "Las cuatro decisiones que deciden si un código QR impreso funciona: el nivel, el margen, el tamaño y de quién es la dirección que lleva dentro."
+og_title = "Un código QR que escanee también en el móvil de otro"
+og_description = "Las cuatro decisiones de las que depende que un código QR impreso funcione: el nivel, el margen, el tamaño y de quién es la dirección que lleva dentro."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/es/pages/guides/remove-exif-and-gps-data.html
@@ -1,46 +1,47 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre el <a href="../../eliminar-datos-exif/">visor y eliminador de EXIF</a>,
-      suelta las fotos dentro y pulsa «Quitar todos los metadatos». Todas las
-      etiquetas, los bloques XMP e IPTC, los comentarios y la miniatura
-      incrustada se van, de todas las fotos de la lista a la vez. La imagen en sí
-      no se toca &mdash; no se vuelve a comprimir, no se descodifica y no cambia
-      ni un píxel.
+      Abre el <a href="../../eliminar-datos-exif/">visor y eliminador de
+      EXIF</a>, arrastra las fotos dentro y pulsa «Quitar todos los metadatos».
+      Se van todas las etiquetas, los bloques XMP e IPTC, los comentarios y la
+      miniatura incrustada, y se van de todas las fotos de la lista a la vez. La
+      imagen en sí no se toca: no se vuelve a comprimir, no se descodifica y no
+      cambia ni un píxel.
     </p>
     <p>
-      Antes de hacerlo, merece la pena mirar qué había ahí dentro. Suele ser más
-      de lo que la gente espera, y esa lista es el argumento para hacer esto.
+      Antes de hacerlo, merece la pena mirar qué había ahí dentro. Suele haber
+      más de lo que la gente espera, y esa lista es todo el argumento a favor de
+      hacer esto.
     </p>
   </section>
 
   <section>
-    <h2>Qué hay de verdad dentro de una foto</h2>
+    <h2>Qué lleva de verdad una foto dentro</h2>
     <p>
       Un JPEG no es solo una imagen comprimida. Es un contenedor, y junto a la
-      imagen hay varios bloques de información que escribieron ahí tu cámara, tu
-      móvil o tu editor.
+      imagen viajan varios bloques de información que escribieron ahí tu cámara,
+      tu móvil o tu editor.
     </p>
     <ul>
       <li>
         <strong>EXIF.</strong> El principal. Marca y modelo de cámara, objetivo,
         ajustes de exposición, ISO, la fecha y la hora al segundo, la orientación
-        en que hay que mostrar la imagen y &mdash; en un móvil con la ubicación
-        activada para la cámara &mdash; una posición GPS con una precisión de unos
-        pocos metros. Muchas veces también el número de serie del cuerpo de la
+        con la que hay que mostrar la imagen y &mdash; en un móvil con la
+        ubicación activada para la cámara &mdash; una posición GPS con precisión
+        de pocos metros. Muchas veces, además, el número de serie del cuerpo de la
         cámara.
       </li>
       <li>
-        <strong>GPS.</strong> Técnicamente forma parte del EXIF, y merece
-        nombrarse aparte porque es el que más importa. Se escribe en grados,
-        minutos y segundos, que es un formato que hace un trabajo excelente
-        pareciendo cualquier cosa menos una dirección.
+        <strong>GPS.</strong> Técnicamente es parte del EXIF, y merece mención
+        aparte porque es el que más importa. Se escribe en grados, minutos y
+        segundos, un formato que disimula magníficamente que lo que estás leyendo
+        es una dirección.
       </li>
       <li>
         <strong>XMP.</strong> Un paquete de XML que escriben los editores. Puede
-        llevar tu nombre, tu software, valoraciones, palabras clave, historial de
-        ediciones y una copia de algunos de los campos EXIF &mdash; y por eso
-        quitar solo el EXIF no basta.
+        llevar tu nombre, tu programa, valoraciones, palabras clave, historial de
+        ediciones y una copia de algunos campos EXIF; por eso quitar solo el EXIF
+        no basta.
       </li>
       <li>
         <strong>IPTC.</strong> Un bloque más antiguo con campos de pie de foto,
@@ -49,9 +50,9 @@
       </li>
       <li>
         <strong>La miniatura incrustada.</strong> Una segunda copia pequeña de la
-        imagen. Se genera cuando se escribe el archivo, y no siempre se vuelve a
-        generar cuando se edita la imagen &mdash; que es como una foto recortada
-        puede viajar con una miniatura de lo que se recortó.
+        imagen. Se genera al escribir el archivo y no siempre se regenera al
+        editar la imagen, que es como una foto recortada puede acabar viajando con
+        una miniatura de lo que recortaste.
       </li>
       <li>
         <strong>La nota del fabricante.</strong> Un bloque sin documentar de datos
@@ -63,138 +64,136 @@
   <section>
     <h2>Quién lo ve de verdad</h2>
     <p>
-      Esta es la parte en la que conviene ser preciso, porque tanto la versión
-      alarmada como la despreocupada están equivocadas.
+      Aquí conviene ser preciso, porque tanto la versión alarmista como la
+      despreocupada se equivocan.
     </p>
     <p>
-      <strong>Casi todas las redes sociales grandes quitan los metadatos cuando
-      publicas.</strong> Facebook, Instagram y X recodifican las imágenes subidas
-      y tiran las etiquetas por el camino. Eso no es un favor &mdash; se quedan
-      los datos de su lado &mdash;, pero sí significa que una foto publicada en
-      esos servicios no le entrega sus coordenadas a todo el que la vea.
+      <strong>Casi todas las redes sociales grandes quitan los metadatos al
+      publicar.</strong> Facebook, Instagram y X recodifican las imágenes que
+      subes y tiran las etiquetas por el camino. Eso no es un favor &mdash; los
+      datos se los quedan ellos &mdash;, pero sí significa que una foto publicada
+      en esos servicios no le entrega sus coordenadas a todo el que la mire.
     </p>
     <p>
       <strong>Casi todo lo demás las conserva.</strong> Un adjunto de correo. Un
       archivo enviado por casi cualquier aplicación de mensajería como
       «documento» en vez de como foto. Una imagen en un foro, un anuncio de
-      compraventa, una web personal, una unidad compartida, un informe de error,
+      compraventa, una web personal, una carpeta compartida, un informe de error,
       un ticket de soporte. En todos esos casos el archivo llega intacto, y
-      cualquiera que lo descargue puede leer las etiquetas con herramientas que
-      trae su propio sistema operativo.
+      cualquiera que lo descargue puede leer las etiquetas con herramientas que ya
+      trae su sistema operativo.
     </p>
     <p>
-      Los riesgos realistas son mundanos más que dramáticos: un anuncio de
-      compraventa fotografiado en casa, una foto de un niño tomada en su colegio,
-      una cuenta aparentemente anónima que publica fotos que comparten todas el
-      mismo número de serie de cámara, un «tomada la semana pasada» que se tomó en
-      marzo.
+      Los riesgos realistas son más cotidianos que dramáticos: un anuncio de
+      compraventa fotografiado en casa, la foto de un niño hecha en su colegio,
+      una cuenta supuestamente anónima cuyas fotos comparten todas el mismo número
+      de serie de cámara, un «hecha la semana pasada» que se hizo en marzo.
     </p>
   </section>
 
   <section>
-    <h2>¿Por qué no volver a guardarla y ya?</h2>
+    <h2>¿Y por qué no volver a guardarla y listo?</h2>
     <p>
       Volver a guardar una foto con un editor o un compresor sí quita los
-      metadatos &mdash; la imagen se descodifica a píxeles y se vuelve a
-      codificar, y un lienzo lleno de píxeles no lleva etiquetas. Funciona, y te
-      cuesta calidad, porque esa recodificación tiene pérdidas.
+      metadatos: la imagen se descodifica a píxeles y se vuelve a codificar, y un
+      lienzo lleno de píxeles no lleva etiquetas. Funciona, y te cuesta calidad,
+      porque esa recodificación tiene pérdidas.
     </p>
     <p>
       Quitar los metadatos como es debido no cuesta absolutamente nada. Las
-      etiquetas están en el contenedor <em>alrededor</em> de la imagen comprimida,
+      etiquetas están en el contenedor que <em>rodea</em> a la imagen comprimida,
       no dentro de ella, así que eliminarlas consiste en borrar entradas de una
-      lista y volver a escribir la lista. Los datos de imagen comprimidos se
-      copian byte por byte y el resultado descodifica exactamente los mismos
-      píxeles. Esa es la razón entera para usar una herramienta de metadatos en
-      vez de un conversor.
+      lista y volver a escribir la lista. Los datos de imagen se copian byte a
+      byte y el resultado descodifica exactamente los mismos píxeles. Esa es toda
+      la razón para usar una herramienta de metadatos y no un conversor.
     </p>
     <p>
-      La excepción es si ibas a recodificar de todas formas. Si ya estás
-      comprimiendo o redimensionando la foto, las etiquetas se van como efecto
-      secundario y no necesitas un segundo paso.
+      La excepción es que fueras a recodificar de todos modos. Si ya estás
+      comprimiendo o redimensionando la foto, las etiquetas se van de propina y no
+      necesitas un segundo paso.
     </p>
   </section>
 
   <section>
-    <h2>Lo único que hay que conservar: la orientación</h2>
+    <h2>Lo único que conviene conservar: la orientación</h2>
     <p>
       Los móviles no giran la imagen cuando giras el móvil. La graban tal como la
-      vio el sensor y añaden una etiqueta de orientación que dice cómo hay que
-      girarla para mostrarla. Quita todas las etiquetas y algunos visores enseñarán
-      tu foto de lado.
+      vio el sensor y le añaden una etiqueta de orientación que dice cómo hay que
+      girarla para verla bien. Quita todas las etiquetas y algunos visores te
+      enseñarán la foto tumbada.
     </p>
     <p>
-      Por eso la herramienta de aquí tiene una opción de «conservar la etiqueta de
-      orientación», activada por defecto. Vuelve a escribir un bloque EXIF diminuto
-      que contiene esa única etiqueta y nada más, y solo para las fotos que la
-      necesitaban de verdad. El GPS, las marcas de tiempo, el número de serie y
-      todo lo demás siguen fuera.
+      Por eso esta herramienta trae una opción de «conservar la etiqueta de
+      orientación», activada de fábrica. Vuelve a escribir un bloque EXIF
+      diminuto, con esa única etiqueta y nada más, y solo en las fotos que de
+      verdad la necesitaban. El GPS, las fechas, el número de serie y todo lo
+      demás siguen fuera.
     </p>
     <p>
-      Desactívala si prefieres que el archivo no lleve EXIF en absoluto &mdash; y
-      después comprueba el resultado antes de enviarlo, porque lo normal es que la
-      foto salga de lado.
+      Desactívala si prefieres que el archivo no lleve ni un byte de EXIF, y
+      comprueba después el resultado antes de enviarlo, porque lo normal es que la
+      foto salga tumbada.
     </p>
   </section>
 
   <section>
     <h2>Editar en lugar de quitar</h2>
     <p>
-      Quitarlo todo es la respuesta correcta para casi todo el mundo. A veces no
+      Quitarlo todo es la respuesta acertada para casi todo el mundo. A veces no
       lo es: un fotógrafo puede querer conservar la línea de derechos y los
-      ajustes de la cámara y que solo desaparezca la ubicación; alguien que
-      archiva puede necesitar corregir una fecha que estaba mal porque lo estaba
-      el reloj de la cámara.
+      ajustes de cámara y que solo desaparezca la ubicación; quien archiva puede
+      necesitar corregir una fecha equivocada porque lo estaba el reloj de la
+      cámara.
     </p>
     <p>
       Las dos cosas se pueden hacer. La ubicación se puede borrar por su cuenta, y
-      las etiquetas de texto, las fechas, el ISO, la orientación y la resolución
-      se pueden editar en el sitio.
+      las etiquetas de texto, las fechas, el ISO, la orientación y la resolución se
+      pueden corregir sin tocar nada más.
     </p>
     <p>
       Una advertencia que vale para cualquier herramienta que haga esto, no solo
       para esta: escribir el archivo reconstruye el bloque EXIF, y una nota del
-      fabricante contiene desplazamientos hacia el bloque <em>original</em>. Una
-      nota reconstruida puede dejar de ser legible, por tanto, para el propio
-      programa del fabricante. Si eso importa, borra la nota del fabricante o deja
-      el archivo sin editar.
+      fabricante contiene desplazamientos que apuntan al bloque <em>original</em>.
+      Una nota reconstruida puede dejar de ser legible, por tanto, para el propio
+      programa del fabricante. Si eso te importa, borra la nota del fabricante o
+      deja el archivo sin editar.
     </p>
   </section>
 
   <section>
-    <h2>Formatos, y los que no se pueden hacer así</h2>
+    <h2>Formatos, y los que no se pueden tratar así</h2>
     <p>
-      JPEG, PNG y WebP se pueden reescribir los tres limpiamente, y esos son los
-      tres con los que trabaja la herramienta de aquí.
+      JPEG, PNG y WebP se reescriben los tres limpiamente, y son los tres con los
+      que trabaja esta herramienta.
     </p>
     <p>
-      HEIC &mdash; lo que guarda un iPhone por defecto &mdash; y AVIF son formatos
-      de cajas construidos con átomos anidados, y necesitan un analizador
-      completamente distinto. La herramienta los reconoce y lo dice, en vez de
-      producir un archivo roto. Si tienes un HEIC, convertirlo a JPEG quitará los
-      metadatos como efecto secundario de la conversión.
+      HEIC &mdash; lo que guarda un iPhone de fábrica &mdash; y AVIF son formatos
+      de cajas, construidos con átomos anidados, y piden un analizador totalmente
+      distinto. La herramienta los reconoce y lo dice, en lugar de escupir un
+      archivo roto. Si tienes un HEIC, convertirlo a JPEG te quitará los metadatos
+      como efecto secundario de la conversión.
     </p>
     <p>
-      Un TIFF suelto tampoco se maneja, y por una razón más interesante: en un
-      TIFF los metadatos y los datos de píxeles se direccionan con los mismos
-      desplazamientos, así que quitar etiquetas significa reescribir el
+      Un TIFF suelto tampoco se trata, y por un motivo más interesante: en un TIFF
+      los metadatos y los datos de píxeles se direccionan con los mismos
+      desplazamientos, así que quitar etiquetas obliga a reescribir el
       direccionamiento de la propia imagen. Se puede hacer, y es otro trabajo.
     </p>
   </section>
 
   <section>
-    <h2>Una costumbre que merece la pena</h2>
+    <h2>Una costumbre que compensa</h2>
     <p>
-      Comprueba antes de publicar, no después. Leer las etiquetas lleva unos pocos
-      segundos y la lista de hallazgos nombra las cosas que conviene saber &mdash;
-      la posición, las marcas de tiempo, los números de serie &mdash; antes de la
-      tabla completa con todas las etiquetas, así que no tienes que saber qué
+      Comprueba antes de publicar, no después. Leer las etiquetas lleva unos
+      segundos, y el resumen de lo encontrado nombra lo que conviene saber &mdash;
+      la posición, las fechas, los números de serie &mdash; antes de la tabla
+      completa con todas las etiquetas, así que no hace falta que sepas qué
       buscar.
     </p>
     <p>
-      La posición se muestra primero en grados decimales, a propósito. «51 grados,
-      30 minutos, 26 segundos» no deja claro que una foto esté nombrando el
-      edificio en el que se tomó. Un par de decimales que puedes pegar en un mapa
+      La posición se muestra primero en grados decimales, y es a propósito. «51
+      grados, 30 minutos, 26 segundos» no deja claro que una foto esté nombrando
+      el edificio donde se hizo. Un par de decimales que puedes pegar en un mapa,
       sí.
     </p>
   </section>
@@ -202,23 +201,23 @@
   <section>
     <h2>No subas la foto para averiguar qué lleva dentro</h2>
     <p>
-      Hay una ironía particular en la forma habitual de resolver este problema:
-      alguien preocupado por lo que revela su foto la sube a una web para
-      averiguarlo. Ahora esa web tiene la foto, las coordenadas, la marca de
-      tiempo y el número de serie, y una copia de la imagen en un disco suyo.
+      La forma habitual de resolver este problema tiene su ironía: alguien
+      preocupado por lo que revela su foto la sube a una web para averiguarlo. Y
+      ahora esa web tiene la foto, las coordenadas, la fecha, el número de serie y
+      una copia de la imagen en un disco suyo.
     </p>
     <p>
-      No hay ningún motivo para eso. Leer y reescribir el contenedor que rodea a
-      un JPEG son unos cientos de líneas de análisis que un navegador ejecuta
-      perfectamente, y por eso la herramienta de aquí no tiene ninguna función de
-      red: ningún <code>fetch</code>, ningún <code>XMLHttpRequest</code>, nada que
-      pudiera enviar un archivo aunque algo lo intentara. Cárgala una vez,
+      No hace ninguna falta. Leer y reescribir el contenedor que rodea a un JPEG
+      son unos cientos de líneas de análisis que un navegador ejecuta sin
+      despeinarse, y por eso esta herramienta no tiene ninguna función de red:
+      ningún <code>fetch</code>, ningún <code>XMLHttpRequest</code>, nada capaz de
+      enviar un archivo ni aunque algo lo intentara. Cárgala una vez,
       desconéctate, y sigue funcionando.
     </p>
     <p>
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> explica cómo comprobar esa afirmación en este
-      sitio o en cualquier otro &mdash; y este es el tipo de archivo en el que más
-      merece la pena comprobarla.
+      conversores en línea?</a> cuenta cómo comprobar esa afirmación aquí o en
+      cualquier otro sitio, y este es el tipo de archivo con el que más compensa
+      comprobarla.
     </p>
   </section>

--- a/locales/es/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/es/pages/guides/remove-exif-and-gps-data.toml
@@ -8,18 +8,18 @@
 
 nav = "Datos EXIF y GPS"
 
-title = "Cómo quitar los datos EXIF y GPS de una foto"
-description = "Una foto salida de un móvil suele llevar el punto exacto en que se tomó, la hora al segundo y el número de serie de la cámara. Qué hay ahí dentro, quién puede leerlo, y cómo quitarlo sin tocar la imagen."
+title = "Cómo eliminar los datos EXIF y GPS de una foto"
+description = "Una foto salida de un móvil suele llevar el punto exacto donde se hizo, la hora al segundo y el número de serie de la cámara. Qué hay ahí dentro, quién puede leerlo y cómo quitarlo sin tocar la imagen."
 
 heading = "Lo que una foto cuenta de ti, y cómo quitarlo"
 lede = """
-    Una imagen recién salida de un móvil suele llevar las coordenadas del sitio
-    en que se tomó, la hora al segundo, y datos suficientes de la cámara como
-    para atarla a todas las demás fotos del mismo dispositivo. Nada de eso se ve
-    en pantalla. Esto es lo que hay ahí dentro y cómo quitarlo."""
+    Una imagen recién salida de un móvil suele llevar las coordenadas del lugar
+    donde se hizo, la hora al segundo y datos de la cámara suficientes para
+    atarla a todas las demás fotos del mismo dispositivo. Nada de eso se ve en
+    pantalla. Esto es lo que hay ahí dentro y cómo quitarlo."""
 
 updated = "20 de agosto de 2026"
 
 og_title = "Lo que una foto cuenta de ti, y cómo quitarlo"
-og_description = "Las coordenadas GPS, las marcas de tiempo y los números de serie viajan dentro de fotos corrientes. Qué hay ahí dentro, quién puede leerlo, y cómo eliminarlo."
+og_description = "Las coordenadas GPS, las fechas y los números de serie viajan dentro de fotos corrientes. Qué hay ahí dentro, quién puede leerlo y cómo eliminarlo."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/resize-an-image.html
+++ b/locales/es/pages/guides/resize-an-image.html
@@ -2,218 +2,222 @@
     <h2>La respuesta corta</h2>
     <p>
       Abre el <a href="../../redimensionar-imagen/">redimensionador de
-      imágenes</a>, suelta tu foto dentro, escribe un número &mdash; el ancho,
-      normalmente &mdash; y deja el otro en blanco. El alto sale de la forma de
-      la foto, que es casi siempre lo que se quería: «1920 de ancho» significa
-      «1920 de ancho y el alto que eso dé».
+      imágenes</a>, arrastra la foto dentro, escribe un solo número &mdash; el
+      ancho, casi siempre &mdash; y deja el otro campo vacío. El alto se calcula
+      solo, a partir de la forma de la foto, que es lo que casi todo el mundo
+      quiere decir en realidad: «1920 de ancho» significa «1920 de ancho y el
+      alto que le corresponda».
     </p>
     <p>
-      Todo lo de abajo es qué hacer cuando un número no basta: cuando te han dado
-      una caja con dos lados, cuando la foto tiene que hacerse más grande, o
-      cuando una carpeta entera de archivos tiene que salir igual.
+      El resto de esta guía trata de los casos en los que un número no basta:
+      cuando te dan un recuadro con dos medidas, cuando la foto tiene que
+      crecer, o cuando una carpeta entera tiene que salir toda igual.
     </p>
   </section>
 
   <section>
-    <h2>Encoger es seguro. Agrandar no.</h2>
+    <h2>Encoger es seguro; agrandar, no</h2>
     <p>
-      No son dos direcciones de la misma operación, y merece la pena tener claro
-      por qué.
+      No son dos direcciones de la misma operación, y conviene entender por qué.
     </p>
     <p>
-      <strong>Hacer una foto más pequeña</strong> tira información, y en el único
-      sentido benigno: entran más píxeles de los que salen, así que cada píxel
-      del resultado es el promedio de detalle real medido. Una copia pequeña bien
-      redimensionada suele verse <em>mejor</em> que el original visto a ese
-      tamaño, porque el promediado quita ruido. No se inventa nada.
+      <strong>Reducir una foto</strong> descarta información, en el único
+      sentido inofensivo del término: entran más píxeles de los que salen, así
+      que cada píxel del resultado es el promedio de detalle realmente medido.
+      Una copia pequeña bien hecha suele verse <em>mejor</em> que el original
+      mirado a ese tamaño, porque ese promedio se lleva por delante el ruido. No
+      se inventa nada.
     </p>
     <p>
-      <strong>Hacer una foto más grande</strong> tiene que inventar. El detalle
-      no falta del archivo; es que nunca se fotografió. Todo lo que puede hacer
-      cualquier ampliador es adivinar píxeles intermedios a partir de sus vecinos,
-      y una suposición entre dos valores conocidos es una rampa suave &mdash; por
-      eso una foto ampliada se ve blanda en vez de nítida. Es una copia más grande
-      de la misma foto, no una copia con más detalle.
+      <strong>Ampliarla</strong>, en cambio, obliga a inventar. El detalle no es
+      que falte en el archivo: es que nunca llegó a fotografiarse. Lo único que
+      puede hacer un ampliador es deducir los píxeles intermedios a partir de sus
+      vecinos, y deducir entre dos valores conocidos da siempre una transición
+      suave &mdash; de ahí que una foto ampliada se vea blanda en lugar de
+      nítida. Es la misma foto en grande, no una foto con más detalle.
     </p>
     <p>
-      Por eso «no agrandar nunca una foto más de lo que empezó» viene activado en
-      la herramienta de aquí. Desactívalo si de verdad necesitas el número de
-      píxeles &mdash; una imprenta que pide un tamaño mínimo, una plantilla que
-      rechaza cualquier cosa por debajo de un ancho &mdash;, pero hazlo sabiendo
-      que estás comprando píxeles, no detalle.
+      Por eso la opción de «no ampliar por encima del tamaño original» viene
+      activada de fábrica. Puedes desactivarla si de verdad necesitas ese número
+      de píxeles &mdash; una imprenta que exige un mínimo, una plantilla que
+      rechaza cualquier cosa por debajo de cierto ancho &mdash;, pero hazlo
+      sabiendo que lo que compras son píxeles, no detalle.
     </p>
     <p>
-      Los ampliadores de aprendizaje automático que sí parecen añadir detalle son
-      una cosa completamente distinta: se están inventando textura plausible a
+      Los ampliadores con aprendizaje automático, esos que sí parecen añadir
+      detalle, son otra cosa muy distinta: se inventan una textura verosímil a
       partir de un modelo de cómo suelen ser las imágenes. Para un fondo de
-      pantalla eso está bien. Para la fotografía de una persona, de un documento o
-      de cualquier cosa de la que alguien vaya a sacar una conclusión, entiende
-      que el detalle de más es ficción.
+      pantalla no pasa nada. Para la foto de una persona, de un documento o de
+      cualquier cosa sobre la que alguien vaya a sacar conclusiones, ten claro
+      que ese detalle de más es ficción.
     </p>
   </section>
 
   <section>
-    <h2>Tres formas de decir qué tamaño quieres</h2>
+    <h2>Tres maneras de decir qué tamaño quieres</h2>
     <p>
-      Casi todas las herramientas, esta incluida, aceptan las mismas tres, y le
-      van bien a trabajos distintos.
+      Casi todas las herramientas, esta incluida, admiten las mismas tres, y
+      cada una sirve para un tipo de trabajo.
     </p>
     <ul>
       <li>
-        <strong>Píxeles exactos.</strong> Úsalo cuando alguien te ha dado el
-        número: un avatar que tiene que ser de 400&times;400, un banner que tiene
-        que medir 1500 de ancho. Rellena un lado y deja que el otro lo siga, salvo
-        que te hayan dado los dos.
+        <strong>Píxeles exactos.</strong> Para cuando alguien te ha dado la
+        cifra: un avatar que tiene que ser de 400&times;400, un banner que tiene
+        que medir 1500 de ancho. Rellena un lado y deja el otro vacío, salvo que
+        te hayan dado los dos.
       </li>
       <li>
-        <strong>Un porcentaje.</strong> Úsalo cuando quieres que todo salga
-        proporcionalmente más pequeño y te da igual la cifra exacta &mdash; «a la
-        mitad» para un conjunto de fotos que van dentro de un documento.
+        <strong>Un porcentaje.</strong> Para cuando quieres que todo salga
+        proporcionalmente más pequeño y la cifra exacta te da igual: «a la
+        mitad» para un puñado de fotos que van dentro de un documento.
       </li>
       <li>
-        <strong>Un lado largo.</strong> El más útil de los tres para un lote
-        mezclado. «Lado más largo 1600» hace que todas las fotos quepan dentro de
-        un cuadrado de 1600 píxeles, sean verticales u horizontales, que es lo que
-        suele significar en la práctica «déjame todas estas a un tamaño
+        <strong>El lado más largo.</strong> La más útil de las tres cuando el
+        lote es variado. «Lado más largo, 1600» hace que todas las fotos quepan
+        en un cuadrado de 1600 píxeles, sean verticales u horizontales, que es
+        lo que en la práctica suele querer decir «déjame todo esto a un tamaño
         razonable».
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Cuando la caja tiene otra forma que la foto</h2>
+    <h2>Cuando el recuadro no tiene la forma de la foto</h2>
     <p>
-      Aquí es donde se decide de verdad el redimensionado. Si das un ancho y un
-      alto y no encajan con las proporciones de tu foto, algo tiene que ceder, y
-      hay exactamente cuatro cosas que pueden hacerlo:
+      Aquí es donde se decide de verdad un redimensionado. Si das el ancho y el
+      alto a la vez y no coinciden con las proporciones de tu foto, algo tiene
+      que ceder, y solo hay cuatro cosas que puedan ceder:
     </p>
     <ul>
       <li>
-        <strong>Encajar dentro de la caja.</strong> Se conserva la foto entera y
-        sale más pequeña que la caja en uno de los ejes. No se pierde nada y no se
-        deforma nada; simplemente no obtienes las dimensiones exactas que pediste.
-        Es la opción por defecto correcta para casi todo.
+        <strong>Ajustar dentro del recuadro.</strong> Se conserva la foto entera
+        y sale más pequeña que el recuadro por uno de los lados. No se pierde
+        nada ni se deforma nada; lo único que no obtienes son las medidas
+        exactas que pediste. Es la opción por defecto acertada para casi todo.
       </li>
       <li>
-        <strong>Llenar la caja y cortar lo que sobra.</strong> Obtienes
-        exactamente las dimensiones que pediste, y las partes de la foto que
-        cuelgan por fuera de los bordes desaparecen. Correcto para miniaturas,
-        avatares y portadas, donde la forma es fija y el sujeto está en el medio.
-        Incorrecto cuando lo que importa está cerca de un borde.
+        <strong>Llenar el recuadro y cortar lo que sobre.</strong> Obtienes
+        exactamente las medidas que pediste, y lo que quedaba fuera de los
+        bordes desaparece. Va bien para miniaturas, avatares y portadas, donde
+        la forma es fija y el motivo está en el centro; va mal en cuanto lo
+        importante queda cerca de un borde.
       </li>
       <li>
-        <strong>Rellenar.</strong> Se conserva la foto entera, centrada, con el
-        espacio sobrante relleno de un color que elijas tú. Correcto cuando un
-        sistema exige dimensiones exactas y no puedes perder nada de la imagen
-        &mdash; las fichas de producto suelen funcionar así.
+        <strong>Rellenar el sobrante.</strong> Se conserva la foto entera,
+        centrada, y el hueco que queda se rellena con un color que eliges tú. Es
+        lo correcto cuando un sistema exige medidas exactas y no te puedes
+        permitir perder nada de la imagen &mdash; las fichas de producto suelen
+        funcionar así.
       </li>
       <li>
-        <strong>Estirar.</strong> La foto se aplasta o se tira para que encaje.
-        Esto nunca es lo que quieres, salvo que lo estés haciendo a propósito, y
-        es lo que todo el mundo reconoce al instante como mal hecho.
+        <strong>Estirar.</strong> La foto se aplasta o se estira hasta encajar.
+        Esto no es nunca lo que quieres, salvo que lo hagas a propósito, y es el
+        único de los cuatro que cualquiera reconoce al instante como un error.
       </li>
     </ul>
     <p>
-      Si te sorprendes buscando el estirado, lo que probablemente quieres es
+      Si estás a punto de recurrir al estirado, lo que en realidad quieres es
       recortar.
     </p>
   </section>
 
   <section>
-    <h2>Recortar es otro trabajo, y muchas veces el correcto</h2>
+    <h2>Recortar es otro trabajo, y muchas veces el que toca</h2>
     <p>
-      Redimensionar cambia cuántos píxeles describen la foto entera. Recortar
-      cambia qué parte de la foto conservas. La gente busca lo primero cuando
-      quiere decir lo segundo sorprendentemente a menudo &mdash; «esto tiene que
-      ser cuadrado» es un problema de recorte, no de redimensionado.
+      Redimensionar cambia cuántos píxeles describen la foto entera; recortar
+      cambia qué parte de la foto conservas. Con más frecuencia de la que
+      parece, se pide lo primero queriendo lo segundo: «esto tiene que quedar
+      cuadrado» es un problema de recorte, no de redimensionado.
     </p>
     <p>
-      Hazlos en ese orden: recorta primero al encuadre que quieras, y después
-      redimensiona el resultado al tamaño que necesites. Hacerlo al revés
-      significa elegir el recorte sobre una foto que ya ha perdido píxeles.
+      El orden importa: recorta primero hasta el encuadre que quieras y
+      redimensiona después el resultado al tamaño que necesites. Al revés,
+      estarías eligiendo el encuadre sobre una foto que ya ha perdido píxeles.
     </p>
     <p>
-      La herramienta de aquí hace las dos cosas de una pasada precisamente por eso
-      &mdash; arrastra una caja, fíjala a una forma si necesitas una proporción
-      concreta, y después di de qué tamaño tiene que salir el resultado. Hacerlo
-      de una pasada significa además que la foto solo se codifica una vez, que
-      importa por lo que dice el apartado siguiente.
+      Precisamente por eso el redimensionador hace las dos cosas en una sola
+      pasada: arrastras un recuadro, lo fijas a una proporción si necesitas una
+      concreta, y luego dices de qué tamaño tiene que salir el resultado.
+      Hacerlo de una pasada tiene además otra ventaja, y es que la foto se
+      codifica una sola vez; el apartado siguiente explica por qué eso importa.
     </p>
     <h3>Recortar un lote entero</h3>
     <p>
-      Una caja dibujada sobre una foto se aplica a las demás como la misma zona
-      <em>relativa</em>: las mismas fracciones del ancho y el alto de cada
-      archivo. Para una carpeta de capturas o exportaciones que son todas del
-      mismo tamaño, eso es exactamente el mismo rectángulo. Para un lote mezclado
-      es el mismo encuadre y no el mismo rectángulo, que suele ser lo que se
-      quería pero conviene saberlo antes de confiarle cincuenta archivos.
+      El recuadro que dibujas sobre una foto se aplica a las demás como la misma
+      zona <em>relativa</em>: la misma fracción del ancho y del alto de cada
+      archivo. Si la carpeta son capturas o exportaciones del mismo tamaño, eso
+      es literalmente el mismo rectángulo. Si el lote es variado, es el mismo
+      encuadre pero no el mismo rectángulo, que suele ser lo que se buscaba,
+      aunque más vale saberlo antes de dejarle cincuenta archivos.
     </p>
   </section>
 
   <section>
-    <h2>Qué cuesta la recodificación, y cómo dejarla en una</h2>
+    <h2>Lo que cuesta volver a codificar, y cómo hacerlo una sola vez</h2>
     <p>
-      Redimensionar un JPEG o un WebP significa descodificarlo, escalar los
-      píxeles y volver a codificarlos &mdash; y ese último paso tiene pérdidas.
-      El escalado en sí no es lo que te cuesta calidad; la recodificación sí.
+      Redimensionar un JPEG o un WebP obliga a descodificarlo, escalar los
+      píxeles y volver a codificarlos, y ese último paso tiene pérdidas. Lo que
+      te cuesta calidad no es el escalado: es la recodificación.
     </p>
     <p>
-      De ahí salen dos cosas. Primera: el ajuste de calidad de la salida importa;
-      algo en torno a 80&ndash;85 es invisible en una fotografía y bastante más
-      pequeño que 100. Segunda: hazlo una vez. Redimensionar una foto que ya se ha
-      redimensionado dos veces significa tres generaciones de codificación con
+      De ahí se siguen dos cosas. Una: el ajuste de calidad de salida importa;
+      un valor de entre 80 y 85 es invisible en una fotografía y pesa bastante
+      menos que 100. Y dos: hazlo una sola vez. Redimensionar una foto que ya se
+      ha redimensionado dos veces son tres generaciones de codificación con
       pérdidas, y se nota.
     </p>
     <p>
-      Un PNG no tiene ese coste, porque no tiene pérdidas &mdash; un PNG
-      redimensionado son exactamente los píxeles escalados. Si estás pasando por
-      varios pasos y todavía no se ha decidido el formato final, trabajar en PNG
-      por el medio evita ir acumulando generaciones.
+      Un PNG no tiene ese coste, porque no pierde nada: un PNG redimensionado es
+      exactamente eso, los píxeles escalados. Si tienes por delante varios pasos
+      y aún no está decidido el formato final, pasar por PNG a mitad de camino
+      te evita ir acumulando generaciones.
     </p>
     <p>
-      Un detalle que conviene saber sobre la herramienta de aquí: un archivo que
-      no estás cambiando en nada se devuelve byte por byte en vez de
-      recodificarse. Pide «lado más largo 1600» en un lote y los que ya están por
-      debajo de 1600 salen intactos, con etiquetas y todo. Una herramienta que los
+      Un detalle del redimensionador que conviene conocer: si un archivo no va a
+      cambiar en nada, se te devuelve byte a byte en vez de recodificarse. Pide
+      «lado más largo, 1600» sobre un lote y los que ya están por debajo de 1600
+      salen intactos, con sus etiquetas y todo. Una herramienta que los
       recodificara en silencio te estaría costando calidad en archivos que nadie
-      le ha pedido cambiar.
+      le había pedido tocar.
     </p>
   </section>
 
   <section>
-    <h2>La transparencia y qué le pasa</h2>
+    <h2>La transparencia, y qué es de ella</h2>
     <p>
-      PNG y WebP pueden guardar transparencia. JPEG no &mdash; el formato no tiene
-      ningún canal alfa. Así que guardar una imagen transparente como JPEG obliga a
-      poner algo detrás, y ese algo es un color plano.
+      PNG y WebP saben guardar transparencia; JPEG no &mdash; el formato no
+      tiene canal alfa en absoluto. Así que guardar como JPEG una imagen
+      transparente obliga a poner algo detrás, y ese algo es un color plano.
     </p>
     <p>
-      Casi todas las herramientas usan blanco y no lo mencionan, lo que está bien
-      hasta que tu logotipo aterriza en una página oscura con una caja blanca
-      alrededor. Elige el color a propósito, o guarda como PNG o WebP y conserva
-      la transparencia. El mismo color se usa detrás de un marco rellenado, que es
-      el otro sitio donde la gente se topa con esto por sorpresa.
+      Casi todas las herramientas ponen blanco y no lo mencionan, lo cual no da
+      ningún problema hasta que tu logotipo aterriza en una página oscura con un
+      recuadro blanco alrededor. Elige el color a conciencia, o guarda en PNG o
+      WebP y quédate con la transparencia. Ese mismo color es el que rellena el
+      sobrante de un marco, que es el otro sitio donde esto suele pillar a la
+      gente por sorpresa.
     </p>
   </section>
 
   <section>
-    <h2>Qué herramienta, si te han dado un número</h2>
+    <h2>Qué herramienta usar, según el número que te hayan dado</h2>
     <p>
-      Se reparten dos números distintos, y necesitan herramientas distintas.
+      Los números que se reparten son de dos tipos, y cada uno pide una
+      herramienta distinta.
     </p>
     <p>
-      <strong>«1200 píxeles de ancho»</strong> es un problema de dimensiones. El
-      <a href="../../redimensionar-imagen/">redimensionador de imágenes</a> es el
-      indicado: dices cuántos píxeles quieres y te los da.
+      <strong>«1200 píxeles de ancho»</strong> es un problema de medidas. Para
+      eso está el <a href="../../redimensionar-imagen/">redimensionador de
+      imágenes</a>: le dices cuántos píxeles quieres y te los da.
     </p>
     <p>
-      <strong>«Por debajo de 500&nbsp;KB»</strong> es un problema de tamaño de
+      <strong>«Que no pase de 500&nbsp;KB»</strong> es un problema de peso del
       archivo, y redimensionar es solo una de las formas de resolverlo. El
-      <a href="../../comprimir-imagen/">compresor de imágenes</a> busca la calidad
-      más alta que cabe en tu objetivo y redimensiona solo si la calidad por sí
-      sola no llega;
-      <a href="../comprimir-una-imagen-a-un-tamano-exacto/">su guía</a> explica lo
-      que cuesta eso.
+      <a href="../../comprimir-imagen/">compresor de imágenes</a> busca la
+      calidad más alta que quepa en tu objetivo y solo redimensiona si con la
+      calidad no llega;
+      <a href="../comprimir-una-imagen-a-un-tamano-exacto/">su guía</a> cuenta
+      lo que eso cuesta.
     </p>
   </section>
 
@@ -221,18 +225,18 @@
     <h2>Nada de esto necesita una subida</h2>
     <p>
       Descodificar una imagen, escalarla y volver a codificarla son cosas que
-      cualquier navegador lleva años sabiendo hacer &mdash; es la misma maquinaria
-      que usa una página web para dibujar una imagen a otro tamaño. No hay ninguna
-      razón técnica para que tu foto viaje a un servidor y vuelva para salir más
-      pequeña, y la herramienta de aquí no la manda a ninguna parte: la
-      <code>Content-Security-Policy</code> de la página nombra todas las
-      direcciones que puede contactar, y ninguna es de este sitio.
+      cualquier navegador sabe hacer desde hace años: es la misma maquinaria con
+      la que una página web dibuja una imagen a otro tamaño. No hay ninguna
+      razón técnica para que tu foto viaje hasta un servidor y vuelva solo para
+      salir más pequeña, y esta herramienta no la manda a ninguna parte: la
+      <code>Content-Security-Policy</code> de la página enumera todas las
+      direcciones con las que puede hablar, y ninguna es de este sitio.
     </p>
     <p>
-      Carga la página, desenchúfate de internet y redimensiona algo de todos modos
-      si prefieres comprobarlo a que te lo cuenten.
+      Si prefieres comprobarlo antes que creértelo, carga la página,
+      desconéctate de internet y redimensiona algo de todos modos.
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea otras tres comprobaciones que puedes
+      conversores en línea?</a> propone otras tres comprobaciones que puedes
       hacerle a cualquier herramienta.
     </p>
   </section>

--- a/locales/es/pages/guides/resize-an-image.toml
+++ b/locales/es/pages/guides/resize-an-image.toml
@@ -7,17 +7,18 @@
 
 nav = "Redimensionar una imagen"
 
-title = "Cómo redimensionar una imagen sin destrozarla"
-description = "Qué le pasa a una foto cuando cambias sus dimensiones en píxeles: por qué encogerla es seguro y agrandarla no, qué hacer cuando la caja tiene otra forma, y cuándo conviene recortar en su lugar."
+title = "Cómo redimensionar una imagen sin que pierda calidad"
+description = "Qué le pasa a una foto cuando cambias sus dimensiones en píxeles: por qué reducirla es seguro y ampliarla no, qué hacer cuando el recuadro no tiene su forma y cuándo lo que toca es recortar."
 
-heading = "Cómo redimensionar una imagen sin destrozarla"
+heading = "Cómo redimensionar una imagen sin que pierda calidad"
 lede = """
-    Redimensionar es el único trabajo de imagen en el que el daño se decide
-    antes de pulsar el botón, según qué número escribas y qué forma pidas. Esto
-    es lo que le hace cada elección a la foto, y cuáles se pueden deshacer."""
+    Redimensionar es el único trabajo de imagen en el que el destrozo está
+    decidido antes de pulsar el botón: lo deciden el número que escribes y la
+    forma que pides. Esto es lo que le hace a la foto cada una de esas
+    decisiones, y cuáles tienen vuelta atrás."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Redimensionar una imagen sin destrozarla"
-og_description = "Por qué encogerla es seguro y agrandarla no, qué hacer cuando la caja tiene otra forma, y cuándo conviene recortar en su lugar."
+og_title = "Redimensionar una imagen sin que pierda calidad"
+og_description = "Por qué reducirla es seguro y ampliarla no, qué hacer cuando el recuadro no tiene su forma, y cuándo lo que toca es recortar."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/trim-a-video.html
+++ b/locales/es/pages/guides/trim-a-video.html
@@ -1,119 +1,119 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre el <a href="../../cortar-video/">cortador de vídeo</a>, suelta el clip
-      dentro, pulsa <kbd>I</kbd> y <kbd>O</kbd> para marcar cada trozo que
-      quieras &mdash; tantos como te apetezca &mdash; y exporta. En un MP4, un MOV
-      o un M4V, los fotogramas que conservas se trasladan al archivo nuevo tal y
-      como estaban &mdash; los mismos bytes, los mismos ajustes de codificación,
-      lo mismo en todo &mdash; y el sonido se copia muestra a muestra sin
-      descodificarlo.
+      Abre el <a href="../../cortar-video/">cortador de vídeo</a>, arrastra el
+      clip dentro, pulsa <kbd>I</kbd> y <kbd>O</kbd> para marcar cada trozo que
+      quieras conservar &mdash; tantos como te apetezca &mdash; y exporta. En un
+      MP4, un MOV o un M4V, los fotogramas que conservas pasan al archivo nuevo
+      tal cual estaban: los mismos bytes, los mismos ajustes de codificación,
+      idénticos en todo. Y el sonido se copia muestra a muestra sin llegar a
+      descodificarse.
     </p>
     <p>
-      Eso significa que un corte no te cuesta nada de calidad, y es rápido: sacar
-      un minuto de una grabación de cuatro gigabytes cuesta más o menos lo que
-      cuesta escribir ese minuto en disco, porque a los fotogramas se les apunta en
-      vez de cargarlos. El único sitio donde esto se nota es dónde cae de verdad tu
-      corte, que es el resto de esta página.
+      Eso quiere decir que un corte no te cuesta nada de calidad. Y es rápido:
+      sacar un minuto de una grabación de cuatro gigabytes cuesta más o menos lo
+      que cueste escribir ese minuto en disco, porque a los fotogramas se los
+      señala dentro del archivo en vez de cargarlos. Lo único donde esto se nota
+      es en dónde cae de verdad tu corte, y de eso va el resto de la página.
     </p>
   </section>
 
   <section>
-    <h2>Por qué un corte no tiene por qué perder nada de calidad</h2>
+    <h2>Por qué un corte no tiene por qué costar calidad</h2>
     <p>
       Cortar no cambia el aspecto de ningún fotograma. Cada fotograma que
-      conservas debe salir idéntico a como entró, así que no hay ninguna razón
-      para descodificarlo y volver a codificarlo &mdash; y todas las razones para
-      no hacerlo, ya que una recodificación tiene pérdidas y empeoraría
-      ligeramente el clip entero solo para acortarlo.
+      conservas tiene que salir idéntico a como entró, así que no hay ninguna
+      razón para descodificarlo y volver a codificarlo, y sí todas las razones
+      para no hacerlo: recodificar tiene pérdidas y empeoraría un poco el clip
+      entero solo para acortarlo.
     </p>
     <p>
-      Así que un buen cortador no recodifica. Lee el índice del archivo, calcula
-      qué fotogramas codificados caen dentro de tu rango, y escribe esos bytes en
-      un contenedor nuevo con un índice nuevo delante. Por esa vía no se
+      Por eso un buen cortador no recodifica. Lee el índice del archivo, calcula
+      qué fotogramas codificados caen dentro de tu rango y escribe esos bytes en
+      un contenedor nuevo con un índice nuevo delante. Por ese camino no se
       descodifica absolutamente nada.
     </p>
     <p>
-      Muchas herramientas recodifican igualmente, porque descodificar y volver a
-      codificar es mucho más sencillo de implementar que analizar el formato del
-      contenedor. Normalmente puedes saber cuál estás usando por lo que tarda: una
-      copia está limitada por lo rápido que escriba tu disco, y una recodificación
-      está limitada por lo rápido que codifique vídeo tu equipo, que es cien veces
-      más lento.
+      Muchas herramientas recodifican de todos modos, porque descodificar y
+      volver a codificar es mucho más sencillo de programar que analizar el
+      formato del contenedor. Suele distinguirse por lo que tarda: una copia va a
+      la velocidad a la que escriba tu disco y una recodificación va a la
+      velocidad a la que tu equipo codifique vídeo, que es cien veces más lenta.
     </p>
   </section>
 
   <section>
     <h2>Los fotogramas clave, y por qué tu corte puede caer antes</h2>
     <p>
-      Aquí está la restricción de la que se deriva todo lo demás sobre cortar.
+      Esta es la limitación de la que se deriva todo lo demás sobre cortar.
     </p>
     <p>
-      El vídeo no se guarda como una secuencia de imágenes completas. Eso sería
+      El vídeo no se guarda como una secuencia de imágenes completas: sería
       enorme. Casi todos los fotogramas se guardan como una descripción de en qué
       se diferencian de sus vecinos, lo que significa que no se pueden
-      descodificar por su cuenta &mdash; hacen falta los fotogramas de alrededor.
-      Solo un <strong>fotograma clave</strong> se sostiene solo como imagen
-      completa, y los fotogramas clave suelen estar separados entre uno y diez
-      segundos.
+      descodificar solos, porque hacen falta los de alrededor. El único que se
+      sostiene por sí mismo, como imagen completa, es el <strong>fotograma
+      clave</strong>, y los fotogramas clave suelen estar separados entre uno y
+      diez segundos.
     </p>
     <p>
-      Así que si marcas un corte dos segundos después del último fotograma clave,
-      un cortador que copia fotogramas no puede empezar ahí. Los fotogramas de tu
-      marca son ilegibles sin la tirada que lleva hasta ellos. Tiene que arrastrar
-      todo el tramo desde el fotograma clave anterior a tu marca.
+      Así que, si marcas un corte dos segundos después del último fotograma
+      clave, un cortador que copia fotogramas no puede empezar ahí: los
+      fotogramas de tu marca son ilegibles sin la tirada que lleva hasta ellos.
+      Tiene que arrastrar todo el tramo desde el fotograma clave anterior.
     </p>
     <p>
-      Lo que hace al respecto es la parte interesante. El formato de archivo tiene
-      una manera estándar de decir <em>empieza a reproducir en este punto</em>
-      &mdash; los fotogramas de más están en el archivo pero el contenedor le
-      indica al reproductor que se los salte. Cualquier reproductor corriente lo
-      respeta, y el clip empieza exactamente donde dijiste. Un reproductor que lo
-      ignore empezará antes, hasta el hueco de un fotograma clave.
+      Y lo interesante es qué hace a continuación. El formato de archivo tiene una
+      manera normalizada de decir <em>empieza a reproducir en este punto</em>: los
+      fotogramas de más están en el archivo, pero el contenedor le indica al
+      reproductor que se los salte. Cualquier reproductor corriente lo respeta, y
+      el clip empieza exactamente donde dijiste. Uno que lo ignore empezará antes,
+      como mucho lo que dure el hueco entre fotogramas clave.
     </p>
     <p>
-      La herramienta de aquí te dice en qué caso estás y por cuánto antes de
-      exportar, así que es una decisión y no una sorpresa.
+      Este cortador te dice en cuál de los dos casos estás y por cuánto, antes de
+      exportar, para que sea una decisión y no una sorpresa.
     </p>
   </section>
 
   <section>
     <h2>Cuándo aceptar una recodificación</h2>
     <p>
-      Existe un corte exacto, y funciona recodificando el tramo inicial &mdash;
-      descodificando desde el fotograma clave y escribiendo una tirada nueva de
-      fotogramas que sí empieza donde lo marcaste. Es más lento, y cuesta un poco
-      de calidad solo en ese tramo inicial.
+      Existe el corte exacto, y funciona recodificando el tramo inicial:
+      descodifica desde el fotograma clave y escribe una tirada nueva de
+      fotogramas que sí empieza donde tú marcaste. Es más lento y cuesta un poco
+      de calidad, pero solo en ese tramo inicial.
     </p>
     <p>
       Elígelo cuando el clip vaya a un sitio que no vaya a respetar la instrucción
-      del contenedor, o donde no puedas controlar el reproductor: algunos editores
-      de vídeo, algunos sistemas de emisión y videoconferencia, algunos
-      reproductores por hardware antiguos. Elige la copia para todo lo demás, que
-      es casi todo &mdash; un navegador, un móvil, una plataforma social, un
-      reproductor multimedia.
+      del contenedor, o donde no controles el reproductor: algunos editores de
+      vídeo, algunos sistemas de emisión y videoconferencia, algunos reproductores
+      por hardware antiguos. Para todo lo demás, que es casi todo &mdash; un
+      navegador, un móvil, una plataforma social, un reproductor multimedia
+      &mdash;, elige la copia.
     </p>
     <p>
-      Una tercera opción que no cuesta nada: mueve tu marca. Si la herramienta te
-      enseña dónde están los fotogramas clave, desplazar el corte al más cercano te
-      da un corte exacto sin ninguna recodificación. Rara vez merece la pena
-      renunciar a una copia por un segundo de diferencia.
+      Y hay una tercera opción que no cuesta nada: mueve la marca. Si la
+      herramienta te enseña dónde están los fotogramas clave, desplazar el corte
+      hasta el más cercano te da un corte exacto sin ninguna recodificación. Rara
+      vez compensa renunciar a una copia por un segundo de diferencia.
     </p>
   </section>
 
   <section>
-    <h2>Sacar un trozo del medio</h2>
+    <h2>Sacar un trozo de en medio</h2>
     <p>
-      Quitar un tramo es una operación distinta de conservar uno, y conviene saber
-      que está soportada, porque muchos cortadores solo hacen lo segundo. Marca la
-      parte que no quieres, elige quitarla, y lo que queda a cada lado se une en un
-      solo clip con el sonido trasladado en sincronía.
+      Quitar un tramo no es lo mismo que conservar uno, y conviene saber que se
+      puede, porque muchos cortadores solo hacen lo segundo. Marca la parte que no
+      quieres, elige quitarla, y lo que queda a cada lado se une en un solo clip
+      con el sonido trasladado en sincronía.
     </p>
     <p>
-      La unión tiene la misma restricción de fotograma clave en el punto en que se
-      reanuda la segunda mitad, por el mismo motivo. Funciona por las dos vías de
-      MP4 de aquí. Es lo único que no puede hacer la alternativa por grabación de
-      más abajo, porque una grabación se hace de una pasada desde un solo cabezal.
+      La unión arrastra la misma limitación de fotograma clave en el punto donde
+      se reanuda la segunda mitad, y por el mismo motivo. Funciona por los dos
+      caminos de MP4 que hay aquí. Es lo único que no puede hacer la alternativa
+      por grabación que se describe más abajo, porque una grabación se hace de una
+      pasada desde un único cursor de reproducción.
     </p>
   </section>
 
@@ -121,78 +121,78 @@
     <h2>Formatos, y la alternativa</h2>
     <p>
       <strong>MP4, M4V y MOV</strong> se leen directamente, lleven el códec que
-      lleven dentro &mdash; H.264, HEVC, AV1, VP9. Copiar fotogramas no implica
-      descodificarlos, así que esta vía funciona incluso con un códec para el que
-      tu navegador no tenga ningún descodificador, que es una consecuencia
-      agradable de no mirar las imágenes.
+      lleven dentro: H.264, HEVC, AV1, VP9. Copiar fotogramas no implica
+      descodificarlos, así que este camino funciona incluso con un códec para el
+      que tu navegador no tenga descodificador, que es una consecuencia muy
+      cómoda de no mirar las imágenes.
     </p>
     <p>
-      <strong>Cualquier otra cosa que tu navegador sepa reproducir</strong>, WebM
-      la más evidente, se corta reproduciéndola y grabando el resultado. Eso
+      <strong>Cualquier otra cosa que tu navegador sepa reproducir</strong>, y
+      WebM es el caso claro, se corta reproduciéndola y grabando el resultado. Eso
       funciona, y tiene dos costes: tarda lo que dure el trozo, y la imagen y el
       sonido se vuelven a codificar.
     </p>
     <p>
       <strong>AVI, WMV, FLV y casi todos los MKV</strong> el navegador no los sabe
-      ni leer ni reproducir, y la herramienta lo dice en vez de fallar a mitad de
-      camino. Convierte esos primero a MP4 con algo que sí los maneje.
+      ni leer ni reproducir, y la herramienta lo dice en lugar de fallar a medio
+      camino. Convierte esos a MP4 antes, con algo que sepa manejarlos.
     </p>
   </section>
 
   <section>
-    <h2>Dos cosas que salen mal en silencio en otras herramientas</h2>
+    <h2>Dos cosas que otras herramientas estropean sin decirlo</h2>
     <p>
       <strong>La rotación.</strong> Un móvil graba en horizontal y escribe una
-      instrucción de rotación dentro del archivo en vez de girar los píxeles. Un
+      instrucción de rotación dentro del archivo en lugar de girar los píxeles. Un
       cortador que copia fotogramas tiene que trasladar esa instrucción, o tu clip
-      vertical sale de lado &mdash; que es la forma clásica de arruinar un vídeo
-      cortado. La vía exacta de aquí gira los fotogramas mientras los recodifica y
-      escribe un archivo que no necesita ninguna rotación.
+      vertical saldrá tumbado, que es la forma clásica de arruinar un vídeo
+      cortado. El camino del corte exacto gira los fotogramas mientras los
+      recodifica y escribe un archivo que ya no necesita ninguna rotación.
     </p>
     <p>
-      <strong>La sincronía del audio.</strong> El audio y el vídeo se guardan como
-      flujos separados con sus propios tiempos, y no se cortan en los mismos
-      puntos. Si los dos no se alinean a propósito en el corte, el sonido se va
-      desplazando. Por la vía de copia de aquí el audio se copia muestra a muestra
-      sin descodificarlo, así que es byte por byte lo que había en el archivo, y
-      una marca de edición lo mantiene sincronizado con la imagen con una precisión
-      de una milésima de segundo.
+      <strong>La sincronía del sonido.</strong> El audio y el vídeo se guardan
+      como flujos separados, con sus propios tiempos, y no se cortan por los
+      mismos puntos. Si no se alinean a propósito en el corte, el sonido se va
+      desfasando. Por el camino de la copia, el audio se copia muestra a muestra
+      sin descodificarlo, así que es byte a byte lo que había en el archivo, y una
+      marca de edición lo mantiene a la par de la imagen con una precisión de una
+      milésima de segundo.
     </p>
   </section>
 
   <section>
     <h2>Cortar no es recortar</h2>
     <p>
-      Dos palabras que se usan una por otra. Cortar cambia la duración del clip;
-      recortar cambia la forma de la imagen. Si lo que quieres es una versión
-      cuadrada de un vídeo horizontal, o quitar las bandas negras de los lados, eso
-      es el <a href="../../recortar-video/">recortador de vídeo</a> &mdash; y, a
-      diferencia de cortar, sí tiene que recodificar, por la razón que explica
+      Dos palabras que se usan la una por la otra. Cortar cambia la duración del
+      clip; recortar cambia la forma de la imagen. Si lo que quieres es una
+      versión cuadrada de un vídeo horizontal, o quitarle las bandas negras de los
+      lados, eso es el <a href="../../recortar-video/">recortador de vídeo</a>; y,
+      a diferencia de cortar, sí tiene que recodificar, por el motivo que explica
       <a href="../recortar-un-video/">su guía</a>.
     </p>
   </section>
 
   <section>
-    <h2>Por qué esto no necesita una subida &mdash; y menos esto</h2>
+    <h2>Por qué esto no necesita una subida, y menos que nada esto</h2>
     <p>
-      El vídeo es el tipo de archivo que la gente más espera tener que subir,
-      porque los archivos son grandes y el trabajo suena pesado. Cortar es el caso
-      en el que eso es menos cierto: por la vía de copia el archivo apenas se lee.
-      La herramienta recorre el índice, calcula qué rangos de bytes conservar y los
-      escribe. Subir un archivo de cuatro gigabytes a un servidor para que haga eso
-      sería la forma más lenta posible de organizarlo.
+      El vídeo es el tipo de archivo que la gente más da por hecho que hay que
+      subir, porque los archivos son enormes y el trabajo suena pesado. Cortar es
+      justo el caso donde eso es menos cierto: por el camino de la copia el
+      archivo apenas se lee. La herramienta recorre el índice, calcula qué rangos
+      de bytes hay que conservar y los escribe. Subir cuatro gigabytes a un
+      servidor para que haga eso sería la manera más lenta posible de organizarlo.
     </p>
     <p>
-      Es además el tipo de archivo en el que subir cuesta más si prefieres no
-      hacerlo: el vídeo lleva caras, voces, casas y ubicaciones de una forma en que
-      un documento no. La herramienta de aquí no tiene ninguna función de red, y la
-      <code>Content-Security-Policy</code> de la página nombra todas las
-      direcciones que puede contactar, ninguna de las cuales es de este sitio.
+      Y es también el tipo de archivo cuya subida sale más cara si prefieres
+      evitarla: un vídeo lleva caras, voces, casas y ubicaciones como no las lleva
+      un documento. Este cortador no tiene ninguna función de red, y la
+      <code>Content-Security-Policy</code> de la página enumera todas las
+      direcciones con las que puede hablar, y ninguna es de este sitio.
     </p>
     <p>
-      Desenchúfate de internet y corta un clip de todos modos si prefieres
-      comprobarlo a que te lo cuenten.
+      Si prefieres comprobarlo antes que creértelo, desconéctate de internet y
+      corta un clip de todos modos.
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea otras tres comprobaciones parecidas.
+      conversores en línea?</a> propone otras tres comprobaciones parecidas.
     </p>
   </section>

--- a/locales/es/pages/guides/trim-a-video.toml
+++ b/locales/es/pages/guides/trim-a-video.toml
@@ -7,17 +7,17 @@
 
 nav = "Cortar un vídeo"
 
-title = "Cómo cortar un vídeo sin recodificarlo"
-description = "Cortar un clip no tiene por qué perder ni un byte de calidad. Por qué a veces el corte cae antes de donde lo marcaste, qué tiene que ver un fotograma clave con eso, y cuándo conviene aceptar una recodificación."
+title = "Cómo cortar un vídeo sin perder calidad"
+description = "Cortar un clip no tiene por qué costar ni un byte de calidad. Por qué a veces el corte cae antes de donde lo marcaste, qué pinta ahí un fotograma clave y cuándo compensa aceptar una recodificación."
 
 heading = "Cómo cortar un vídeo sin recodificarlo"
 lede = """
-    Cortar no cambia el aspecto de ningún fotograma, así que un buen cortador no
-    los toca &mdash; los traslada a un archivo nuevo tal y como estaban. Esto
-    explica qué te compra eso, y el único sitio donde se nota."""
+    Cortar no cambia el aspecto de ningún fotograma, así que un buen cortador ni
+    los toca: los traslada a un archivo nuevo tal cual estaban. Aquí verás qué
+    ganas con eso y el único sitio donde se nota."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Cómo cortar un vídeo sin recodificarlo"
-og_description = "Por qué a veces el corte cae antes de donde lo marcaste, qué tiene que ver un fotograma clave con eso, y cuándo conviene aceptar una recodificación."
+og_title = "Cortar un vídeo sin perder calidad"
+og_description = "Por qué a veces el corte cae antes de donde lo marcaste, qué pinta ahí un fotograma clave y cuándo compensa aceptar una recodificación."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/es/pages/guides/turn-a-video-into-a-gif.html
@@ -2,108 +2,108 @@
     <h2>La respuesta corta</h2>
     <p>
       Abre el <a href="../../convertir-video-a-gif/">convertidor de vídeo a
-      GIF</a>, suelta el clip dentro, marca los segundos que quieras, y deja el
+      GIF</a>, arrastra el clip dentro, marca los segundos que quieras y deja el
       ancho en 480 y la cadencia en 12 fotogramas por segundo. Ese es el ajuste
-      que quiere casi cualquier GIF. Si el archivo sale demasiado grande, baja el
-      ancho antes de tocar nada más &mdash; es el ajuste que paga dos veces.
+      que le viene bien a casi cualquier GIF. Si el archivo sale demasiado
+      grande, baja el ancho antes de tocar nada más: es el ajuste que rinde el
+      doble.
     </p>
     <p>
-      El resto de esta página va de por qué, porque «mi GIF ocupa 14 MB» es el
+      El resto de esta página explica por qué, porque «mi GIF ocupa 14 MB» es el
       problema que tiene todo el mundo de verdad, y cuál es el mando que hay que
-      girar no es evidente.
+      girar no salta a la vista.
     </p>
   </section>
 
   <section>
-    <h2>Por qué un GIF de un vídeo es tan enorme</h2>
+    <h2>Por qué un GIF sacado de un vídeo pesa tantísimo</h2>
     <p>
       Un códec de vídeo guarda <em>movimiento</em>. Escribe una imagen completa
-      cada par de segundos y después, para cada fotograma intermedio, una
-      descripción de cómo se movió esa imagen: este bloque de píxeles se deslizó
-      cuatro a la izquierda, esta zona se oscureció un poco. Un clip de cinco
-      segundos puede ser de unos cientos de kilobytes porque casi todo él son
-      instrucciones sobre una imagen que ya tienes.
+      cada par de segundos y, para cada fotograma intermedio, una descripción de
+      cómo se ha movido esa imagen: este bloque de píxeles se desplazó cuatro a la
+      izquierda, esta zona se oscureció un poco. Un clip de cinco segundos puede
+      ocupar unos cientos de kilobytes porque casi todo él son instrucciones sobre
+      una imagen que ya tienes.
     </p>
     <p>
       GIF no tiene nada de eso. Se terminó en 1989, antes de que existiera nada de
-      aquello. Cada fotograma es una imagen, comprimida por su cuenta con un
-      esquema diseñado para capturas de pantalla de una hoja de cálculo. En el
-      formato no hay ninguna estimación de movimiento por ninguna parte, y no hay
-      forma de añadirla.
+      aquello. Cada fotograma es una imagen entera, comprimida por su cuenta con
+      un esquema pensado para capturas de pantalla de una hoja de cálculo. En el
+      formato no hay estimación de movimiento por ninguna parte, y no hay manera
+      de añadírsela.
     </p>
     <p>
-      Así que el número que hay que esperar es <strong>diez veces el tamaño del
-      vídeo</strong>, y ningún conversor te va a librar de eso. Lo que sí puede
-      hacer uno bueno es no desperdiciar nada por encima, y darte los tres ajustes
-      que de verdad lo deciden.
+      Así que la cifra con la que hay que contar es <strong>diez veces el tamaño
+      del vídeo</strong>, y ningún conversor te va a librar de eso. Lo que sí
+      puede hacer uno bueno es no desperdiciar nada por encima de esa cifra y
+      darte los tres ajustes que de verdad la deciden.
     </p>
   </section>
 
   <section>
     <h2>Los tres ajustes, y lo que cuesta cada uno</h2>
     <p>
-      Todo lo relativo al tamaño de un GIF se reduce a cuántos píxeles contiene,
-      que es la duración por la cadencia por el área de un fotograma.
+      Todo lo que tiene que ver con el tamaño de un GIF se reduce a cuántos
+      píxeles contiene, que es la duración por la cadencia por el área de un
+      fotograma.
     </p>
     <ul>
       <li>
         <strong>El trozo &mdash; lineal.</strong> El doble de largo son el doble
-        de fotogramas y más o menos el doble de archivo. Este es el que casi todo
-        el mundo ya entiende, y merece la pena ser implacable: un GIF que dice lo
-        que tiene que decir en tres segundos es además de más pequeño, un GIF
-        mejor.
+        de fotogramas y más o menos el doble de archivo. Este es el que todo el
+        mundo entiende ya, y conviene ser implacable: un GIF que dice lo que tiene
+        que decir en tres segundos no solo pesa menos, es un GIF mejor.
       </li>
       <li>
         <strong>El ancho &mdash; cuadrático.</strong> Reducir el ancho a la mitad
-        reduce el alto con él, así que son <em>la cuarta parte</em> de los
-        píxeles. Pasar de 640 a 320 no ahorra un poco menos de la mitad; ahorra
-        alrededor de tres cuartas partes. Este es el ajuste que nadie toca primero
-        y el que mejor paga.
+        reduce el alto con él, así que quedan <em>la cuarta parte</em> de los
+        píxeles. Pasar de 640 a 320 no ahorra algo menos de la mitad: ahorra
+        alrededor de tres cuartas partes. Es el ajuste que nadie toca primero y el
+        que mejor paga.
       </li>
       <li>
         <strong>La cadencia &mdash; lineal.</strong> Diez fotogramas por segundo
-        son dos tercios del tamaño de quince. Es además el ajuste en el que la
-        pérdida se ve más, porque un movimiento demasiado lento se lee como roto y
-        no como pequeño.
+        son dos tercios del tamaño de quince. Es además el ajuste cuya pérdida más
+        se ve, porque un movimiento demasiado lento se lee como roto y no como
+        pequeño.
       </li>
     </ul>
     <p>
-      Un ejemplo hecho. Seis segundos de un clip de móvil a sus propios
+      Un ejemplo con números. Seis segundos de un clip de móvil a sus propios
       1080&times;1920 y 30 fps son 180 fotogramas de dos millones de píxeles: unos
-      350 millones de píxeles, que no es un GIF, es un secuestro. Los mismos seis
-      segundos a 480 de ancho y 12 fps son 72 fotogramas de 400 000 píxeles
-      &mdash; 30 millones, más o menos la doceava parte &mdash; y se parece a lo
-      que la gente entiende por un GIF.
+      350 millones de píxeles, que ya no es un GIF, es un secuestro en toda regla.
+      Esos mismos seis segundos a 480 de ancho y 12 fps son 72 fotogramas de
+      400 000 píxeles &mdash; 30 millones, más o menos la doceava parte &mdash;, y
+      eso ya se parece a lo que la gente entiende por un GIF.
     </p>
   </section>
 
   <section>
     <h2>Qué cadencia elegir</h2>
     <p>
-      Doce es el valor por defecto de aquí y la respuesta correcta
-      sorprendentemente a menudo. Es la cadencia que lleva usando un siglo la
-      animación dibujada a mano: lo bastante rápida como para que el ojo la lea
-      como movimiento continuo, lo bastante lenta como para no estar pagando por
-      fotogramas que nadie ve.
+      Doce es el valor por defecto aquí, y acierta sorprendentemente a menudo. Es
+      la cadencia que lleva usando un siglo la animación dibujada a mano: lo
+      bastante rápida para que el ojo la lea como movimiento continuo y lo
+      bastante lenta para no estar pagando por fotogramas que nadie ve.
     </p>
     <ul>
-      <li><strong>5&ndash;8</strong> &mdash; sensación de pase de diapositivas.
-        Vale para una panorámica lenta o para una grabación de pantalla donde no
-        se mueve nada rápido.</li>
-      <li><strong>10&ndash;15</strong> &mdash; normal. Se lee como movimiento.
+      <li><strong>5&ndash;8</strong> &mdash; sabe a pase de diapositivas. Sirve
+        para una panorámica lenta o para una grabación de pantalla donde no se
+        mueve nada deprisa.</li>
+      <li><strong>10&ndash;15</strong> &mdash; lo normal. Se lee como movimiento.
         Casi todos los GIF que merece la pena hacer están aquí.</li>
       <li><strong>20&ndash;25</strong> &mdash; fluido, y más o menos el doble de
-        tamaño que 12 por una diferencia que casi ningún espectador va a saber
-        nombrar. Merece la pena para movimiento rápido, un clip deportivo o
-        cualquier cosa con una panorámica de latigazo.</li>
+        tamaño que 12 a cambio de una diferencia que casi ningún espectador sabría
+        nombrar. Compensa con movimiento rápido, un clip deportivo o cualquier
+        cosa con un barrido de cámara.</li>
     </ul>
     <p>
-      Hay un techo duro que más vale conocer: GIF guarda cuánto se queda cada
+      Hay un tope estricto que más vale conocer: GIF guarda cuánto se queda cada
       fotograma en pantalla en centésimas de segundo, y todos los navegadores
-      tratan un retardo por debajo de dos centésimas como si fueran diez. Así que
-      50 fotogramas por segundo es el máximo real, y un archivo que pida 100 se
-      reproducirá a 10 sin decir nada. Un conversor que te ofrezca 60 fps o está
-      ignorando eso o está a punto de darte una sorpresa.
+      tratan un retardo menor de dos centésimas como si fuera de diez. Así que
+      cincuenta fotogramas por segundo es el máximo real, y un archivo que pida
+      cien se reproducirá a diez sin decir nada. Un conversor que te ofrezca 60 fps
+      o está ignorando eso o está a punto de darte una sorpresa.
     </p>
   </section>
 
@@ -111,70 +111,70 @@
     <h2>256 colores, y para qué sirve el tramado</h2>
     <p>
       La otra mitad de la edad del formato: un GIF lleva una tabla de 256 colores
-      como mucho, y cada píxel es un número que apunta dentro de ella. Un
-      fotograma de vídeo tiene hasta dieciséis millones. Casi todo eso se tira, y
-      cómo se tira es casi todo el aspecto que tiene un GIF.
+      como mucho, y cada píxel es un número que apunta a una entrada de esa tabla.
+      Un fotograma de vídeo tiene hasta dieciséis millones. Casi todos se tiran, y
+      cómo se tiran es casi todo el aspecto que acaba teniendo un GIF.
     </p>
     <p>
-      Un buen conversor cuenta los colores de <em>tu</em> clip y elige 256 que le
-      vayan bien, en vez de usar un conjunto fijo. Un plano de un bosque se lleva
-      256 verdes; un plano de un atardecer se lleva 256 naranjas. Eso es lo que
-      hace la herramienta de aquí, a lo largo de todos los fotogramas del trozo y
-      no solo del primero, así que un color que solo aparece al final también tiene
-      su sitio.
+      Un buen conversor cuenta los colores de <em>tu</em> clip y elige los 256 que
+      mejor le vayan, en lugar de tirar de una tabla fija. Un plano de un bosque se
+      lleva 256 verdes; un plano de un atardecer, 256 naranjas. Eso es lo que hace
+      esta herramienta, y lo hace mirando todos los fotogramas del trozo y no solo
+      el primero, así que un color que solo aparece al final también tiene su
+      sitio.
     </p>
     <p>
-      El <strong>tramado</strong> es lo que pasa donde el color que necesitas sigue
-      sin estar. En vez de redondear una zona entera al color más cercano
-      disponible &mdash; que convierte un cielo suave en cuatro franjas planas con
-      escalones visibles entre ellas &mdash;, alterna los dos colores más cercanos
-      en un patrón fino, y desde una distancia normal de visionado tu ojo los
-      mezcla y ve el que no está.
+      El <strong>tramado</strong> es lo que ocurre allí donde el color que
+      necesitas sigue sin estar. En vez de redondear una zona entera al color
+      disponible más cercano &mdash; que convierte un cielo suave en cuatro
+      franjas planas con escalones a la vista &mdash;, alterna los dos colores más
+      próximos en un patrón fino, y a una distancia normal de visionado tu ojo los
+      mezcla y ve el que falta.
     </p>
     <ul>
       <li><strong>Déjalo activado</strong> para cualquier cosa fotográfica:
         cielos, piel, degradados, sombras, cine.</li>
       <li><strong>Desactívalo</strong> para el color plano: grabaciones de
-        pantalla, dibujo de línea, logotipos, dibujos animados, cualquier cosa con
-        grandes zonas de un solo tono. No hay ningún degradado que proteger, y el
-        archivo queda más pequeño y más limpio sin él.</li>
+        pantalla, dibujo lineal, logotipos, dibujos animados, cualquier cosa con
+        grandes zonas de un solo tono. Ahí no hay ningún degradado que proteger, y
+        el archivo queda más pequeño y más limpio sin él.</li>
     </ul>
     <p>
-      Un detalle que conviene conocer si comparas conversores. La forma evidente de
+      Un detalle que conviene conocer si comparas conversores. La forma obvia de
       tramar &mdash; la difusión de error, que es la que usan casi todos los
-      editores de imagen &mdash; hace que el resultado de cada píxel dependa de los
-      píxeles de alrededor. En una animación eso significa que un fondo que no se
-      mueve trama distinto en cada fotograma, así que hormiguea a la vista, y hay
-      que guardar cada fotograma entero porque técnicamente ha cambiado cada píxel.
-      La alternativa, un tramado ordenado, depende solo de dónde está un píxel, así
-      que un fondo quieto se queda perfectamente quieto. Eso es lo que usa esta
-      herramienta, y es por lo que sus archivos son además de más tranquilos, más
-      pequeños.
+      editores de imagen &mdash; hace que el resultado de cada píxel dependa de
+      los de alrededor. En una animación eso significa que un fondo quieto se
+      trama distinto en cada fotograma, así que hormiguea a la vista, y encima hay
+      que guardar cada fotograma entero porque técnicamente ha cambiado cada
+      píxel. La alternativa, el tramado ordenado, depende solo de dónde está el
+      píxel, así que un fondo quieto se queda perfectamente quieto. Eso es lo que
+      usa esta herramienta, y por eso sus archivos, además de más estables, son
+      más pequeños.
     </p>
   </section>
 
   <section>
-    <h2>Cuándo no hacer un GIF en absoluto</h2>
+    <h2>Cuándo no hacer un GIF, sin más</h2>
     <p>
-      Merece la pena preguntárselo, porque la respuesta honesta muchas veces es «no
-      lo hagas». Un MP4 o un WebM mudo en bucle ocupa alrededor de la décima parte
-      que la misma animación en GIF, se reproduce igual, y es en lo que cualquier
-      plataforma social convierte tu GIF después de que lo subas de todas formas.
+      Merece la pena planteárselo, porque la respuesta honesta muchas veces es «no
+      lo hagas». Un MP4 o un WebM mudo y en bucle ocupa alrededor de la décima
+      parte que la misma animación en GIF, se reproduce igual, y es en lo que
+      cualquier plataforma social va a convertir tu GIF en cuanto lo subas.
     </p>
     <p>Quédate con el GIF cuando el destino necesite uno de verdad:</p>
     <ul>
-      <li>un sitio que solo acepta una imagen &mdash; mucho software de chat, de
-        foros, de wikis y de correo;</li>
+      <li>un sitio que solo acepta una imagen: mucho software de chat, de foros,
+        de wikis y de correo;</li>
       <li>un README o una página de documentación, donde un GIF se reproduce en
         línea y un vídeo necesita un reproductor;</li>
       <li>una presentación o un documento que tiene que seguir moviéndose sin
         conexión;</li>
-      <li>un emoji, una pegatina, una reacción &mdash; lo bastante pequeños como
-        para que nada de la aritmética de arriba importe.</li>
+      <li>un emoji, una pegatina, una reacción: tan pequeños que nada de la
+        aritmética de arriba importa.</li>
     </ul>
     <p>
-      Cuando el sonido importa, la pregunta se responde sola: GIF nunca ha tenido
-      audio y nunca lo tendrá. Corta el vídeo en su lugar &mdash; el
+      Cuando lo que importa es el sonido, la pregunta se responde sola: GIF nunca
+      ha tenido audio y nunca lo tendrá. Corta el vídeo y ya está: el
       <a href="../../cortar-video/">cortador de vídeo</a> te saca un trozo sin
       recodificar ni un fotograma.
     </p>
@@ -183,43 +183,44 @@
   <section>
     <h2>Bajar de un límite de tamaño</h2>
     <p>
-      Casi todo el motivo por el que alguien afina un GIF es un límite al otro
-      lado. Por orden aproximado de cuánto aprietan:
+      Casi siempre, si alguien se pone a afinar un GIF es porque hay un límite al
+      otro lado. Por orden aproximado de cuánto aprietan:
     </p>
     <ul>
       <li><strong>Correo</strong> &mdash; de 10 a 25 MB para el mensaje entero, y
-        un adjunto cerca de eso se lo quita o lo rebota algo por el camino.
-        Apunta bastante por debajo.</li>
-      <li><strong>Chat y foros</strong> &mdash; normalmente de 8 a 10 MB, a veces
-        mucho menos para una vista previa en línea en lugar de una descarga.</li>
+        un adjunto que se acerque a esa cifra se lo va a quitar o a rebotar algo
+        por el camino. Apunta bastante por debajo.</li>
+      <li><strong>Chat y foros</strong> &mdash; normalmente de 8 a 10 MB, y a
+        veces mucho menos si quieres una vista previa en línea en vez de una
+        descarga.</li>
       <li><strong>Un README de GitHub</strong> &mdash; 10 MB por archivo, y
         cualquier cosa por encima de un par de megabytes hace que la página
         parezca rota en un móvil.</li>
-      <li><strong>Los huecos de pegatinas y emojis</strong> &mdash; muchas veces
-        unos cientos de kilobytes, lo que significa un ancho pequeño y un trozo
-        corto, no una cadencia más baja.</li>
+      <li><strong>Las ranuras de pegatinas y emojis</strong> &mdash; muchas veces
+        unos cientos de kilobytes, lo que se traduce en un ancho pequeño y un
+        trozo corto, no en una cadencia más baja.</li>
     </ul>
     <p>
-      El orden en que hay que probar, cuando te pasas: acorta el trozo, después
-      reduce el ancho a la mitad, después baja la cadencia, después desactiva el
-      tramado. Los dos primeros valen más que los dos últimos juntos.
+      El orden en que conviene probar, cuando te pasas: acorta el trozo, reduce el
+      ancho a la mitad, baja la cadencia y, por último, desactiva el tramado. Los
+      dos primeros valen más que los dos últimos juntos.
     </p>
   </section>
 
   <section>
     <h2>Nada de esto necesita una subida</h2>
     <p>
-      Convertir un vídeo en un GIF es descodificar, redimensionar, contar colores y
-      comprimir &mdash; cuatro cosas que un navegador lleva años sabiendo hacer por
-      su cuenta. La herramienta enlazada arriba lo hace todo en tu equipo: el
-      archivo se lee de tu disco, los fotogramas los descodifica tu navegador, y el
-      GIF se monta en memoria y se entrega a tus descargas.
+      Convertir un vídeo en un GIF es descodificar, redimensionar, contar colores
+      y comprimir: cuatro cosas que un navegador lleva años sabiendo hacer por su
+      cuenta. La herramienta enlazada arriba lo hace todo en tu equipo. El archivo
+      se lee de tu disco, los fotogramas los descodifica tu navegador y el GIF se
+      monta en memoria y va a parar a tus descargas.
     </p>
     <p>
-      Y aquí eso merece más preocupación de lo habitual. Los clips que la gente
-      convierte en GIF son personales &mdash; un momento de un vídeo familiar, una
-      grabación de pantalla de algo del trabajo, unos segundos de una llamada. Un
-      conversor que quiere que se los subas está pidiendo una copia de ellos, y ya
-      no queda ninguna razón técnica para decir que sí.
+      Y aquí eso preocupa más de lo habitual. Los clips que la gente convierte en
+      GIF son personales: un momento de un vídeo familiar, una grabación de
+      pantalla de algo del trabajo, unos segundos de una llamada. Un conversor que
+      quiere que se los subas está pidiendo una copia de todo eso, y ya no queda
+      ninguna razón técnica para decirle que sí.
     </p>
   </section>

--- a/locales/es/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/es/pages/guides/turn-a-video-into-a-gif.toml
@@ -8,18 +8,18 @@
 
 nav = "Hacer un GIF a partir de un vídeo"
 
-title = "Cómo convertir un vídeo en un GIF (y que salga pequeño)"
-description = "Qué trozo, qué ancho y qué cadencia elegir, por qué un GIF de un vídeo ocupa diez veces lo que el vídeo, y cuándo conviene usar uno."
+title = "Cómo convertir un vídeo en GIF (y que no pese una barbaridad)"
+description = "Qué trozo, qué ancho y qué cadencia elegir, por qué un GIF sacado de un vídeo pesa diez veces lo que el vídeo, y cuándo compensa usar uno."
 
 heading = "Cómo convertir un vídeo en un GIF"
 lede = """
-    GIF es un formato de 1987 que guarda imágenes enteras en vez de movimiento,
-    así que uno hecho a partir de un vídeo siempre es grande. Esto es cuál de los
-    tres ajustes mover cuando sale demasiado grande, y cuánto te compra cada
+    GIF es un formato de 1987 que guarda imágenes enteras en lugar de
+    movimiento, así que uno sacado de un vídeo siempre pesa. Aquí verás cuál de
+    los tres ajustes mover cuando se te va de las manos y cuánto ahorra cada
     uno."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Cómo convertir un vídeo en un GIF y que salga pequeño"
-og_description = "Los tres ajustes que deciden el tamaño de un GIF, lo que cuesta cada uno, y cuándo un GIF es directamente la respuesta equivocada."
+og_title = "Convertir un vídeo en GIF sin que pese una barbaridad"
+og_description = "Los tres ajustes de los que depende el peso de un GIF, lo que cuesta cada uno y cuándo un GIF es directamente la respuesta equivocada."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"

--- a/locales/es/pages/guides/turn-images-into-a-video.html
+++ b/locales/es/pages/guides/turn-images-into-a-video.html
@@ -1,14 +1,14 @@
   <section>
     <h2>La respuesta corta</h2>
     <p>
-      Abre <a href="../../imagenes-a-video/">Imágenes a vídeo</a>, suelta las
-      fotos dentro, ponlas en orden, decide cuánto se mantiene cada una y crea el
-      vídeo. Te llevas un MP4 con vídeo H.264, que se reproduce prácticamente en
-      cualquier cosa.
+      Abre <a href="../../imagenes-a-video/">Imágenes a vídeo</a>, arrastra las
+      fotos dentro, ponlas en orden, decide cuánto se queda cada una en pantalla
+      y crea el vídeo. Te llevas un MP4 con vídeo H.264, que se reproduce
+      prácticamente en cualquier cosa.
     </p>
     <p>
-      Los dos ajustes que más veces obligan a una segunda pasada son la duración
-      y la resolución, y merece la pena entenderlos antes del primer renderizado
+      Los dos ajustes que más veces obligan a repetir el trabajo son la duración
+      y la resolución, así que conviene entenderlos antes del primer renderizado
       y no después.
     </p>
   </section>
@@ -21,39 +21,39 @@
     <p>
       <strong>La duración</strong> es cuánto tiempo se queda cada imagen en
       pantalla. Es el ajuste que de verdad te importa. Tres segundos es un valor
-      por defecto cómodo para un pase que alguien está mirando; uno o dos segundos
-      resulta ágil; cualquier cosa por encima de cinco se hace pesada, salvo que
-      haya una voz por encima.
+      cómodo para un pase que alguien está mirando; uno o dos segundos queda
+      ágil; a partir de cinco se hace pesado, salvo que haya una voz por encima.
     </p>
     <p>
       <strong>La cadencia</strong> es cuántas veces por segundo el vídeo repite
-      esa imagen. No cambia nada del aspecto del pase &mdash; una imagen fija
-      mantenida tres segundos se ve idéntica a 24 fotogramas por segundo y a 60
-      &mdash; y cambia bastante el tamaño del archivo y el tiempo de codificación.
+      esa misma imagen. No cambia nada del aspecto del pase &mdash; una imagen
+      fija que se queda tres segundos se ve idéntica a 24 fotogramas por segundo
+      que a 60 &mdash; y sí cambia bastante el peso del archivo y el tiempo de
+      codificación.
     </p>
     <p>
-      Así que para un pase de diapositivas normal, elige una cadencia baja. 24 o
-      30 sobran. La razón para subir es que haya movimiento en el vídeo: una
-      panorámica o un zoom sobre cada foto, o un fundido entre ellas, donde una
-      cadencia baja se ve como saltos.
+      Así que, para un pase de diapositivas normal, elige una cadencia baja: con
+      24 o 30 vas sobrado. El motivo para subirla es que haya movimiento en el
+      vídeo, una panorámica o un zoom sobre cada foto, o un fundido entre ellas,
+      porque ahí una cadencia baja se ve a saltos.
     </p>
   </section>
 
   <section>
-    <h2>La resolución, y las imágenes de otra forma</h2>
+    <h2>La resolución, y las imágenes que no tienen esa forma</h2>
     <p>
-      Un vídeo tiene un solo tamaño de fotograma para toda su duración. Tus
-      fotografías casi seguro que no comparten uno, así que algo tiene que
-      pasarles a las que no encajan &mdash; y ese algo es la decisión que merece
-      la pena tomar a propósito.
+      Un vídeo tiene un único tamaño de fotograma durante toda su duración. Tus
+      fotografías casi con seguridad no comparten uno, así que algo tiene que
+      pasarles a las que no encajan, y ese algo es una decisión que merece la pena
+      tomar a conciencia.
     </p>
     <p>
-      Empieza eligiendo la resolución según adónde va el vídeo:
+      Empieza eligiendo la resolución según adónde vaya el vídeo:
     </p>
     <ul>
       <li>
-        <strong>1920&times;1080</strong> para cualquier cosa general. Compatible
-        con todo, se reproduce en todas partes, y es lo que casi todo el mundo
+        <strong>1920&times;1080</strong> para cualquier uso general. Compatible
+        con todo, se reproduce en todas partes y es lo que casi todo el mundo
         entiende por HD.
       </li>
       <li>
@@ -63,131 +63,129 @@
       <li>
         <strong>3840&times;2160</strong> solo si las imágenes tienen de verdad
         tanto detalle y el destino lo va a mostrar. Son cuatro veces los píxeles,
-        cuatro veces el tiempo de codificación y más o menos cuatro veces el
-        archivo.
+        cuatro veces el tiempo de codificación y unas cuatro veces el archivo.
       </li>
     </ul>
     <p>
-      Después decide qué pasa con las que no encajan. Encajar cada imagen dentro
-      del fotograma la conserva entera y deja bandas a los lados &mdash; seguro, y
-      la respuesta correcta cuando las imágenes importan más que la presentación.
-      Llenar el fotograma y recortar lo que sobra queda mejor y le cortará la parte
-      de arriba a algunas. Mezclar fotografías verticales y horizontales en un
-      mismo vídeo es el caso en el que no hay ninguna buena respuesta; decidir de
-      antemano por qué lado prefieres equivocarte ahorra un renderizado.
+      Después decide qué pasa con las que no encajan. Ajustar cada imagen dentro
+      del fotograma la conserva entera y deja bandas a los lados: es lo seguro, y
+      lo acertado cuando las imágenes importan más que la presentación. Llenar el
+      fotograma y cortar lo que sobra queda mejor y le comerá la parte de arriba a
+      algunas. Mezclar fotografías verticales y horizontales en un mismo vídeo es
+      el caso en el que no hay ninguna respuesta buena; decidir de antemano por
+      qué lado prefieres equivocarte te ahorra un renderizado.
     </p>
   </section>
 
   <section>
-    <h2>El orden y la trampa de los nombres de archivo</h2>
+    <h2>El orden, y la trampa de los nombres de archivo</h2>
     <p>
       Como en cualquier trabajo por lotes, los nombres de archivo se ordenan de
-      una forma que no es la forma en que contaste. <code>foto2.jpg</code> va
-      después de <code>foto10.jpg</code> en una ordenación alfabética, porque la
-      comparación es carácter a carácter.
+      una manera que no es la manera en que tú contaste. En una ordenación
+      alfabética, <code>foto2.jpg</code> va detrás de <code>foto10.jpg</code>,
+      porque la comparación es carácter a carácter.
     </p>
     <p>
-      Ordenar por fecha de captura suele ser lo correcto para fotografías de un
-      evento, ya que las hiciste en el orden en que pasaron las cosas. Arrastrar
-      las fichas es lo correcto para cualquier cosa cuya historia no sea
-      cronológica. Compruébalo antes de renderizar: el vídeo es el único resultado
-      en el que arreglar el orden significa volver a hacer el trabajo entero.
+      Con fotografías de un evento, ordenar por fecha de captura suele ser lo
+      correcto, porque las hiciste en el orden en que fueron pasando las cosas.
+      Mover las fichas a mano es lo correcto cuando la historia no es cronológica.
+      Compruébalo antes de renderizar: el vídeo es el único resultado en el que
+      arreglar el orden significa repetir el trabajo entero.
     </p>
   </section>
 
   <section>
-    <h2>No hay banda sonora, y no es poca cosa</h2>
+    <h2>No hay banda sonora, y no es un detalle</h2>
     <p>
-      El MP4 que escribe esta herramienta tiene una única pista de vídeo y ninguna
-      pista de audio. Si tu pase necesita música o narración, harás falta un editor
-      de vídeo para ese paso.
+      El MP4 que escribe esta herramienta tiene una sola pista de vídeo y ninguna
+      de audio. Si tu pase necesita música o narración, para ese paso vas a
+      necesitar un editor de vídeo.
     </p>
     <p>
-      Merece la pena saber por qué, y no solo que es así: añadir audio significa
+      Y merece la pena saber por qué, no solo que es así: añadir audio significa
       descodificar un archivo de música, codificarlo a AAC e intercalarlo con el
       vídeo dentro del contenedor. Las tres cosas son trabajo de verdad, y hacerlas
-      mal produce un archivo que se va desincronizando mientras se reproduce. Está
-      en la lista en vez de estar a medio hacer.
+      mal produce un archivo que se va desincronizando conforme se reproduce. Está
+      en la lista de pendientes precisamente para no dejarlo a medias.
     </p>
     <p>
-      Una nota práctica si vas a añadir música después: elige primero la pista y
-      ajusta la duración por imagen para que el pase salga cerca de la duración de
-      la canción. Recortar la música para que quepa en el vídeo siempre suena peor
-      que ajustar el vídeo a la música.
+      Un consejo práctico si piensas ponerle música después: elige primero la
+      pista y ajusta la duración por imagen para que el pase se acerque a la
+      duración de la canción. Recortar la música para que quepa en el vídeo suena
+      siempre peor que ajustar el vídeo a la música.
     </p>
   </section>
 
   <section>
     <h2>Qué sale, y qué hacer si no se reproduce</h2>
     <p>
-      El objetivo es MP4 con H.264, y es la combinación más ampliamente
-      reproducible que hay. En un navegador sin WebCodecs la herramienta recurre a
-      grabar WebM &mdash; el mismo material en un contenedor que aceptan menos
-      editores y menos plataformas sociales.
+      El objetivo es MP4 con H.264, la combinación que se reproduce en más sitios
+      que ninguna otra. En un navegador sin WebCodecs, la herramienta recurre a
+      grabar WebM: el mismo material en un contenedor que aceptan menos editores y
+      menos plataformas sociales.
     </p>
     <p>
       Si acabas con un WebM y algo lo rechaza, la solución es un navegador
-      compatible con WebCodecs y no una conversión: las versiones actuales de
-      Chrome, Edge y Safari lo son todas. Volver a renderizar es mejor que
-      convertir, porque convertir significa otra generación de codificación con
-      pérdidas.
+      compatible con WebCodecs, no una conversión: las versiones actuales de
+      Chrome, Edge y Safari lo son. Volver a renderizar es mejor que convertir,
+      porque convertir significa otra generación de codificación con pérdidas.
     </p>
     <p>
-      La herramienta no lleva ningún límite dentro sobre cuántas imágenes puedes
-      usar. El techo es la memoria de tu propio equipo, porque el vídeo terminado
-      se monta ahí antes de que lo descargues &mdash; un pase largo en 4K es lo
-      primero que lo nota.
+      La herramienta no impone ningún límite de imágenes. El techo es la memoria
+      de tu propio equipo, porque el vídeo terminado se monta ahí antes de que te
+      lo descargues, y un pase largo en 4K es donde primero se nota.
     </p>
   </section>
 
   <section>
-    <h2>Hacer el archivo más pequeño</h2>
+    <h2>Aligerar el archivo</h2>
     <p>
-      Si el resultado es demasiado grande para donde vaya, por orden de lo que
+      Si el resultado es demasiado pesado para donde va, por orden de lo que
       ayuda de verdad:
     </p>
     <p>
       <strong>Baja la cadencia.</strong> En un pase de imágenes fijas esto no
-      cuesta nada visible y es el mayor ahorro que hay de una sola tacada.
+      cuesta nada visible y es el mayor ahorro que se consigue de una sola vez.
     </p>
     <p>
-      <strong>Baja la resolución.</strong> 1080p en vez de 4K es la cuarta parte
-      de los píxeles, y en la pantalla de un móvil nadie lo va a saber.
+      <strong>Baja la resolución.</strong> 1080p en lugar de 4K es la cuarta parte
+      de los píxeles, y en la pantalla de un móvil nadie va a notarlo.
     </p>
     <p>
-      <strong>Acórtalo.</strong> Tres segundos por imagen en vez de cinco es un
-      40&nbsp;% menos de duración y un 40&nbsp;% menos de archivo, y normalmente un
-      pase mejor.
+      <strong>Acórtalo.</strong> Tres segundos por imagen en lugar de cinco es un
+      40&nbsp;% menos de duración y un 40&nbsp;% menos de archivo, y normalmente
+      un pase mejor.
     </p>
     <p>
-      Reducir antes las fotografías de origen no ayuda mucho. El vídeo se codifica
-      a la resolución que elegiste, pase lo que pase, así que una foto de 4000
-      píxeles y una de 2000 producen casi el mismo número de bytes en un vídeo de
-      1080p. Sí hace la codificación más rápida, y mueve ese techo de memoria.
+      Reducir antes las fotografías de origen no ayuda gran cosa. El vídeo se
+      codifica a la resolución que elegiste pase lo que pase, así que una foto de
+      4000 píxeles y otra de 2000 dan casi los mismos bytes dentro de un vídeo de
+      1080p. Lo que sí hace es acelerar la codificación y alejar ese techo de
+      memoria.
     </p>
   </section>
 
   <section>
     <h2>Por qué esto no necesita un servidor, con una excepción declarada</h2>
     <p>
-      Codificar vídeo solía ser el caso más claro a favor de subir cosas: los
+      Codificar vídeo era el argumento más claro a favor de subir cosas: los
       navegadores no podían y una máquina con FFmpeg sí. WebCodecs cambió eso al
-      exponer el codificador por hardware que ya está en tu equipo, que es el mismo
-      que usa tu móvil para grabar vídeo en tiempo real. Componer los fotogramas es
-      un lienzo. Ninguno de los dos pasos necesita nada que no sea tu propio
+      dar acceso al codificador por hardware que ya está en tu equipo, el mismo
+      que usa tu móvil para grabar vídeo en tiempo real. Y componer los fotogramas
+      es un lienzo. Ninguno de los dos pasos necesita nada que no sea tu propio
       hardware.
     </p>
     <p>
-      Una excepción en esta herramienta en concreto, declarada en vez de escondida:
-      la función opcional de «añadir desde una dirección web» descarga una imagen
+      Esta herramienta tiene una excepción, dicha en voz alta y no escondida: la
+      función opcional de «añadir desde una dirección web» descarga una imagen
       desde una dirección que pegas tú, y el servidor de esa dirección ve tu IP y
-      qué has pedido. Eso es inherente a la función y no un defecto suyo, y es el
-      único paso de red que hay en toda la herramienta. No la uses y no sale nada
-      de tu equipo en absoluto.
+      qué le has pedido. Va con la función y no es un defecto suyo, y es el único
+      paso de red que hay en toda la herramienta. Si no la usas, de tu equipo no
+      sale absolutamente nada.
     </p>
     <p>
       <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
-      conversores en línea?</a> plantea cuatro comprobaciones que te dirán lo mismo
-      sobre cualquier herramienta, esta incluida.
+      conversores en línea?</a> propone cuatro comprobaciones que te dirán lo
+      mismo sobre cualquier herramienta, esta incluida.
     </p>
   </section>

--- a/locales/es/pages/guides/turn-images-into-a-video.toml
+++ b/locales/es/pages/guides/turn-images-into-a-video.toml
@@ -8,17 +8,17 @@
 
 nav = "Imágenes en un vídeo"
 
-title = "Cómo convertir una carpeta de imágenes en un vídeo"
-description = "Haz un pase de diapositivas en MP4 con tus fotos: qué controlan de verdad la cadencia y la duración, qué hacer con las imágenes que tienen otra forma, y por qué el resultado no lleva banda sonora."
+title = "Cómo convertir una carpeta de fotos en un vídeo"
+description = "Haz un pase de diapositivas en MP4 con tus fotos: qué controlan de verdad la cadencia y la duración, qué hacer con las imágenes que no tienen esa forma y por qué el resultado sale sin banda sonora."
 
-heading = "Cómo convertir una carpeta de imágenes en un vídeo"
+heading = "Cómo convertir una carpeta de fotos en un vídeo"
 lede = """
-    Un pase de diapositivas es fácil de hacer y fácil de renderizar dos veces,
+    Un pase de diapositivas es fácil de hacer y fácil de tener que repetir,
     porque dos de los ajustes no significan lo que parece. Esto es lo que
-    controla cada uno y qué elegir."""
+    controla cada uno y cuál elegir."""
 
 updated = "20 de agosto de 2026"
 
-og_title = "Cómo convertir una carpeta de imágenes en un vídeo"
-og_description = "Qué controlan de verdad la cadencia y la duración, qué hacer con las imágenes que tienen otra forma, y por qué no hay banda sonora."
+og_title = "Convertir una carpeta de fotos en un vídeo"
+og_description = "Qué controlan de verdad la cadencia y la duración, qué hacer con las imágenes que no tienen esa forma y por qué no hay banda sonora."
 og_image_alt = "abox.tools - herramientas que no tocan ningún servidor"


### PR DESCRIPTION
Recovered from uncommitted changes that were sitting in the worktree for `claude/website-i18n-es-guides`. That branch has no commits beyond `main`, so the working-tree state was the only copy of this work.

A revision pass over the fifteen Spanish guide pages — headings, lede, `description` and the `og_` strings. Content only: no build or locale-machinery changes.

**Verified:** `python build.py` completes cleanly on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)