### PR TITLE
Give every tool page a way out that is not the footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,8 +317,10 @@ one.
    forgotten.
 2. Add the slug to the `order` of the matching `[[hub.categories]]` in
    `config/site.toml`, and set the same category id in the tool's `category`.
-   The card on the hub, the sitemap entry and the structured data follow from
-   that; there is no second place to remember.
+   The card on the hub, the sitemap entry, the structured data and the handful
+   of other tools every tool page links to all follow from that; there is no
+   second place to remember. See
+   [Why tool pages link to each other](#why-tool-pages-link-to-each-other).
 3. Run `python build.py`. If the tool is missing something, the build says so
    and writes nothing.
 4. If it belongs to a category that does not exist yet, add a
@@ -624,6 +626,38 @@ HTML.
 Neither link's text is written twice either. The tool page shows the guide's own
 `heading` and `description`; the guide shows the tool's own `name` and
 `tagline`. So neither page can promise something the other does not deliver.
+
+### Why tool pages link to each other
+
+Under the guide link, every tool page carries four more: "Also in the box", the
+nearest other tools. It closes a hole that was there from the start. A tool page
+linked up to the hub and across to its own guide and nowhere else, so somebody
+who arrived from a search for one tool was shown that tool and no route to the
+three beside it — and anything pointing at that page from outside stopped there
+instead of reaching the rest of the site.
+
+There is no list of related tools anywhere, and there should never be one.
+`order` in `[[hub.categories]]` already says which tools belong together,
+because it is what groups them on the front page; `related_tools()` in
+`build.py` reads the same order, so a second list cannot drift from the first.
+
+Two details in there are worth knowing before changing it:
+
+- **It is a ring, not the head of the category.** Each tool's list is read from
+  its own position and wraps round. Taking the first four of each category
+  instead would point all fourteen pages of `images-and-video` at the same four
+  names and leave the tail of it with nothing linking in — which is the half of
+  this that is about crawlers rather than readers.
+- **The category sorts the ring; it does not filter it.** `codes-and-data` and
+  `text-and-code` hold one tool each, so a strict reading of "same category"
+  would leave exactly `qr-barcode` and `text-tools` as the dead ends this is
+  meant to remove. A tool with siblings gets siblings, and a tool without gets
+  whatever the hub has nearest.
+
+`RELATED_COUNT` is four, and the `13rem` column minimum in
+`shared/css/tool-frame.css` is measured against it and against the 940px content
+column so the four land on one row. Changing either number without the other
+leaves an orphan on a second row.
 
 ---
 

--- a/build.py
+++ b/build.py
@@ -329,6 +329,10 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
                for category in root['hub']['categories']
                for slug in category['order'] if slug in by_slug]
 
+    # The few other tools each tool page points at, off the same hub order. See
+    # related_tools: one ring over every tool, siblings first.
+    related_of = related_tools(ordered)
+
     # What the footer on every page is built from. Derived from the folders that
     # exist rather than written down anywhere, so a new tool or a new legal page
     # reaches every footer on the site without a second edit.
@@ -350,7 +354,8 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
     written = []
     for tool in ltools:
         build_tool(dest_root, templates, locale, locales, site, tool, footer,
-                   links, lang_v, guide_of.get(tool['slug'], {}), emit)
+                   links, lang_v, guide_of.get(tool['slug'], {}),
+                   related_of.get(tool['slug'], []), emit)
         written.append(f'{locale["prefix"]}{tool["out_slug"]}/index.html')
 
     for page in lprose:
@@ -514,6 +519,54 @@ def tie_guides_to_tools(guides, by_slug):
     return owned
 
 
+# How many other tools a tool page points at. Four is enough to be a route on
+# out of the page and few enough that the block stays a suggestion rather than
+# a second copy of the hub halfway down every tool.
+RELATED_COUNT = 4
+
+
+def related_tools(ordered, count=RELATED_COUNT):
+    """Map a tool's slug to the few other tools its page links to.
+
+    A tool page used to be a dead end. It links up to the hub and across to its
+    own guide and nowhere else, so a reader who arrived from a search for "heic
+    to jpg" was shown one tool and no route to the resize and the compress
+    sitting beside it on the front page.
+
+    Which tools are related is not written down anywhere new, and deliberately
+    so: `order` in config/site.toml already groups the tools by what they are
+    for, and that grouping is the hub's own. The tools a page points at are the
+    ones a reader would have found under the same heading on the front page,
+    which means there is no second list here to fall out of step with the first.
+
+    The list is a RING rather than the head of the category. Read from the
+    tool's own position and wrap round, and every tool links to `count` others
+    and every tool has something linking to it - inbound runs two to six across
+    the twenty-four, rather than the exact `count` a plain ring would give,
+    because sorting siblings to the front pulls the crowded categories forward.
+    Taking the first few of each category instead would point all fourteen pages
+    of `images-and-video` at the same four names and leave the tail of it with
+    nothing coming in at all, which is the half of the problem that is about
+    search engines rather than readers.
+
+    Two categories hold one tool each, `qr-barcode` and `text-tools`, so a
+    strict reading of "same category" would leave exactly those two pages as
+    the dead ends this exists to remove. The ring therefore runs over every
+    tool and the category merely sorts first: a tool with siblings gets
+    siblings, and a tool without gets the nearest thing the hub has.
+    """
+    total = len(ordered)
+    out = {}
+    for index, tool in enumerate(ordered):
+        ring = [ordered[(index + step) % total] for step in range(1, total)]
+        # Stable, so the same-category tools keep their ring order and the rest
+        # follow in theirs. Sorting on the bool is the whole of "siblings
+        # first, then whatever is nearest".
+        ring.sort(key=lambda other: other['category'] != tool['category'])
+        out[tool['slug']] = ring[:count]
+    return out
+
+
 def build_guides(out, templates, locale, locales, site, groups, guides, footer,
                  links, css_v, lang_v, emit):
     """The index of the written half of the site.
@@ -555,7 +608,7 @@ def build_guides(out, templates, locale, locales, site, groups, guides, footer,
 
 
 def build_tool(out, templates, locale, locales, site, tool, footer, links,
-               lang_v, guide, emit):
+               lang_v, guide, related, emit):
     root = locale['site']
     dest = out / tool['out_slug']
     dest.mkdir(parents=True, exist_ok=True)
@@ -648,6 +701,7 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
         'tool.html', frame(locale, locales, site, tool['slug'], '../', links, lang_v, {
             'tool': tool,
             'guide': guide,
+            'related': related,
             'ui': ui,
             'footer': footer,
             'csp': sitelib.render_csp(root['csp'], root.get('tool_csp', {}),

--- a/config/site.toml
+++ b/config/site.toml
@@ -488,6 +488,12 @@ offline = "Offline:"
 checking = "checking&hellip;"
 questions_heading = "Questions"
 guide_heading = "The longer version"
+
+# The heading over the handful of other tools at the foot of every tool page.
+# "Also in the box" rather than "Related tools" because the tools under it are
+# not always related - two categories hold one tool each, and those two pages
+# get the nearest thing the hub has instead. See related_tools() in build.py.
+related_heading = "Also in the box"
 privacy_heading = "How the privacy claim is verifiable"
 
 # The headline claim. The noun in the middle is this tool's own - "files",

--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -363,6 +363,7 @@ offline = "Offline:"
 checking = "wird geprüft&hellip;"
 questions_heading = "Fragen"
 guide_heading = "Die ausführliche Fassung"
+related_heading = "Auch im Werkzeugkasten"
 privacy_heading = "Wie sich der Datenschutz nachprüfen lässt"
 
 # Das Substantiv steht mitten im Satz, und das Verb am Ende - genau der Grund,

--- a/locales/es/locale.toml
+++ b/locales/es/locale.toml
@@ -323,6 +323,7 @@ offline = "Sin conexión:"
 checking = "comprobando&hellip;"
 questions_heading = "Preguntas"
 guide_heading = "La versión larga"
+related_heading = "También en la caja"
 privacy_heading = "Cómo se comprueba lo que promete"
 
 pledge_line = """

--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -339,6 +339,7 @@ offline = "Hors ligne :"
 checking = "vérification&hellip;"
 questions_heading = "Questions"
 guide_heading = "La version longue"
+related_heading = "Aussi dans la boîte"
 privacy_heading = "Comment cette promesse se vérifie"
 
 pledge_line = """

--- a/locales/hi/locale.toml
+++ b/locales/hi/locale.toml
@@ -272,6 +272,7 @@ offline = "ऑफ़लाइन:"
 checking = "जाँच जारी&hellip;"
 questions_heading = "सवाल"
 guide_heading = "विस्तार से"
+related_heading = "बॉक्स में और भी टूल"
 privacy_heading = "यह दावा कैसे जाँचा जा सकता है"
 
 pledge_line = """

--- a/locales/it/locale.toml
+++ b/locales/it/locale.toml
@@ -318,6 +318,7 @@ offline = "Offline:"
 checking = "verifica in corso&hellip;"
 questions_heading = "Domande"
 guide_heading = "La versione lunga"
+related_heading = "Anche nella cassetta"
 privacy_heading = "Come si verifica quello che promette"
 
 pledge_line = """

--- a/locales/ja/locale.toml
+++ b/locales/ja/locale.toml
@@ -274,6 +274,7 @@ offline = "オフライン:"
 checking = "確認中&hellip;"
 questions_heading = "よくある質問"
 guide_heading = "詳しい解説"
+related_heading = "箱の中のほかのツール"
 privacy_heading = "この主張をどう確かめられるか"
 
 pledge_line = """

--- a/locales/ko/locale.toml
+++ b/locales/ko/locale.toml
@@ -368,6 +368,7 @@ offline = "오프라인:"
 checking = "확인 중&hellip;"
 questions_heading = "자주 묻는 질문"
 guide_heading = "자세한 설명"
+related_heading = "상자 속 다른 도구"
 privacy_heading = "이 약속을 확인하는 방법"
 
 pledge_line = """

--- a/locales/nl/locale.toml
+++ b/locales/nl/locale.toml
@@ -320,6 +320,7 @@ offline = "Offline:"
 checking = "bezig met controleren&hellip;"
 questions_heading = "Vragen"
 guide_heading = "De uitgebreide versie"
+related_heading = "Ook in de gereedschapskist"
 privacy_heading = "Hoe de privacybelofte te controleren is"
 
 pledge_line = """

--- a/locales/pt/locale.toml
+++ b/locales/pt/locale.toml
@@ -321,6 +321,7 @@ offline = "Offline:"
 checking = "verificando&hellip;"
 questions_heading = "Perguntas"
 guide_heading = "A versão longa"
+related_heading = "Também na caixa"
 privacy_heading = "Como a promessa de privacidade se verifica"
 
 # O inglês escreve "Your {{ plural }} are never uploaded", e o particípio

--- a/locales/zh/locale.toml
+++ b/locales/zh/locale.toml
@@ -259,6 +259,7 @@ offline = "离线："
 checking = "检查中&hellip;"
 questions_heading = "常见问题"
 guide_heading = "详细版本"
+related_heading = "工具箱里的其他工具"
 privacy_heading = "这个说法要怎么验证"
 
 pledge_line = """

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -585,6 +585,60 @@ button, .as-button {
 .tool-guide a { color: var(--accent); font-weight: 600; }
 .tool-guide-note { font-size: 0.88rem; color: var(--text-dim); }
 
+/* ---- the other tools --------------------------------------------------- */
+
+/* Four links out of the page, under the guide. Deliberately NOT the hub's
+   .tool-card: a card is a thing to choose between, and these are an aside at
+   the foot of a page whose own tool the reader has already chosen. Making them
+   look the same would put a second set of primary choices below the first.
+
+   auto-fit rather than a fixed count, so the row is four across on a desktop,
+   two on a tablet and one on a phone without a media query - the same
+   arrangement .tool-grid uses on the hub, at a smaller measure.
+
+   13rem is measured rather than picked: the column above is 940px and the gap
+   1.4rem, so a 15rem minimum fits 3.6 of them and RELATED_COUNT is 4 - a row
+   of three with a single orphan under it. 13rem fits 4.18, which is the four
+   on one line, and still falls to two by 620px and one by 380px. Changing
+   either number without the other brings the orphan back. */
+
+.tool-related {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(13rem, 1fr));
+  gap: 0.9rem 1.4rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tool-related li { display: grid; gap: 0.15rem; }
+
+.tool-related a {
+  display: flex;
+  gap: 0.45rem;
+  align-items: baseline;
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.93rem;
+  text-decoration: none;
+}
+
+.tool-related a:hover .tool-related-name,
+.tool-related a:focus-visible .tool-related-name { text-decoration: underline; }
+
+/* The emoji carries no meaning the name does not already carry - it is
+   aria-hidden in the markup - so it must not set the line's baseline or a row
+   whose neighbour has a taller glyph sits a pixel lower than the rest. */
+.tool-related-icon { font-size: 1rem; line-height: 1; }
+
+.tool-related-note {
+  font-size: 0.88rem;
+  color: var(--text-dim);
+  /* The taglines are one line each at desktop width and two at phone width;
+     without this the rows below them would not line up. */
+  text-wrap: pretty;
+}
+
 /* ---- footer ------------------------------------------------------------ */
 
 /* A link footer in the shape the large media-tool sites use: a few columns of

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -275,6 +275,30 @@
     <a href="{{ base }}{{ guide.out_slug }}/">{{ guide.heading }}</a>
     <span class="tool-guide-note">{{ guide.description }}</span>
   </p>
+{% endif %}
+  <!--
+    The way out of this page that is not the footer and not the back button.
+    Everything above is about one tool; a reader who has just finished with it
+    usually wants the neighbouring one, and until this block existed the only
+    route to it was the hub.
+
+    Which tools these are is worked out in related_tools() in build.py from the
+    hub's own category order, so there is no second list of "related" tools to
+    disagree with the first. `name` is escaped exactly as the hub escapes it -
+    it is the plain-text name that also goes into the structured data - and
+    `tagline` is not, because it is the same authored line the tool's own
+    header renders above.
+  -->
+{% if related %}  <h2 id="related-h">{{ ui.tool.related_heading }}</h2>
+  <ul class="tool-related">
+{% for other in related %}    <li>
+      <a href="{{ base }}{{ other.out_slug }}/">
+        <span class="tool-related-icon" aria-hidden="true">{{ other.icon }}</span>
+        <span class="tool-related-name">{{ other.name | e }}</span>
+      </a>
+      <span class="tool-related-note">{{ other.tagline }}</span>
+    </li>
+{% endfor %}  </ul>
 {% endif %}</section>
 
 {% include "partials/footer.html" %}

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -224,6 +224,69 @@ class GuidesAndTools(unittest.TestCase):
         self.assertIn('guides/b', str(caught.exception))
 
 
+class RelatedTools(unittest.TestCase):
+    """The ring of links out of every tool page.
+
+    The properties worth pinning down are the ones that make it a link graph
+    rather than a decoration: nothing points at itself, nothing points at the
+    same tool twice, and nothing is left with no way in.
+    """
+
+    @staticmethod
+    def tools(*pairs):
+        return [{'slug': slug, 'category': category} for slug, category in pairs]
+
+    def test_siblings_come_first(self):
+        ordered = self.tools(('a', 'x'), ('b', 'x'), ('c', 'y'), ('d', 'x'))
+        related = buildmod.related_tools(ordered, count=2)
+        self.assertEqual([t['slug'] for t in related['a']], ['b', 'd'])
+
+    def test_a_tool_never_links_to_itself(self):
+        ordered = self.tools(('a', 'x'), ('b', 'x'), ('c', 'x'))
+        for slug, others in buildmod.related_tools(ordered).items():
+            self.assertNotIn(slug, [t['slug'] for t in others])
+
+    def test_a_lone_tool_in_its_category_still_gets_links(self):
+        # qr-barcode and text-tools are the only tools in their categories, and
+        # a strict reading of "same category" would leave exactly those two
+        # pages as the dead ends this exists to remove.
+        ordered = self.tools(('a', 'x'), ('b', 'x'), ('lonely', 'z'))
+        related = buildmod.related_tools(ordered, count=2)
+        self.assertEqual([t['slug'] for t in related['lonely']], ['a', 'b'])
+
+    def test_the_ring_wraps(self):
+        # The last tool in the order reads round to the first rather than
+        # running out.
+        ordered = self.tools(('a', 'x'), ('b', 'x'), ('c', 'x'))
+        related = buildmod.related_tools(ordered, count=2)
+        self.assertEqual([t['slug'] for t in related['c']], ['a', 'b'])
+
+    def test_fewer_tools_than_asked_for_is_not_padded(self):
+        ordered = self.tools(('a', 'x'), ('b', 'x'))
+        self.assertEqual(len(buildmod.related_tools(ordered, count=4)['a']), 1)
+
+    def test_one_tool_on_its_own_gets_nothing(self):
+        self.assertEqual(buildmod.related_tools(self.tools(('a', 'x'))), {'a': []})
+
+    def test_no_tool_is_listed_twice_on_one_page(self):
+        ordered = self.tools(*[(chr(97 + n), 'x' if n % 2 else 'y')
+                               for n in range(9)])
+        for slug, others in buildmod.related_tools(ordered).items():
+            names = [t['slug'] for t in others]
+            self.assertEqual(len(names), len(set(names)), slug)
+
+    def test_every_real_tool_has_a_way_in(self):
+        # The half of this that is about search engines rather than readers: a
+        # tool nothing links to is a tool a crawler reaches only from the hub.
+        site = buildmod.sitelib.load_toml(ROOT / 'config' / 'site.toml')
+        ordered = [{'slug': slug, 'category': category['id']}
+                   for category in site['hub']['categories']
+                   for slug in category['order']]
+        related = buildmod.related_tools(ordered)
+        linked = {t['slug'] for others in related.values() for t in others}
+        self.assertEqual({t['slug'] for t in ordered} - linked, set())
+
+
 class BuildTheSite(unittest.TestCase):
     """A whole plain build, into a temporary directory.
 


### PR DESCRIPTION
A tool page linked up to the hub and across to its own guide and nowhere else.
Somebody who arrived from a search for one tool was shown that tool and no
route to the three sitting beside it on the front page, and anything pointing
at that page from outside stopped there rather than reaching the rest of the
site.

Every tool page now ends with four more links — **"Also in the box"**, the
nearest other tools. 96 new internal links across the 24 tools.

## Where the list comes from

There is no list of related tools anywhere, and there should never be one. The
`order` in `[[hub.categories]]` already says which tools belong together,
because it is what groups them on the front page. `related_tools()` in
`build.py` reads that same order, so a second list cannot drift from the first,
and a new tool gets its links from the line that was already going to be added
for it in `config/site.toml`.

Two decisions are the whole design:

- **It is a ring, not the head of the category.** Each tool's list is read from
  its own position and wraps round. Taking the first four of each category
  instead would point all fourteen pages of `images-and-video` at the same four
  names and leave the tail of it with nothing linking in — the half of this
  that is about crawlers rather than readers.
- **The category sorts the ring, it does not filter it.** `codes-and-data` and
  `text-and-code` hold one tool each, so a strict reading of "same category"
  would have left exactly `qr-barcode` and `text-tools` as the dead ends this
  exists to remove. A tool with siblings gets siblings; a tool without gets
  whatever the hub has nearest.

Measured over the real config: every tool has exactly 4 outbound links, inbound
runs 2–6, and **no tool has zero inbound**. Inbound is not an even 4 because
sorting siblings to the front pulls the crowded categories forward; what the
test pins down is that the floor is not zero.

## Things a reviewer should know

**The block is deliberately not the hub's `.tool-card`.** A card is a thing to
choose between; these are an aside at the foot of a page whose own tool the
reader has already chosen. Making them look the same would put a second set of
primary choices under the first.

**The `13rem` column minimum is measured, not picked.** Against `RELATED_COUNT`
and the 940px content column, `15rem` fits 3.6 columns — a row of three with an
orphan under it. `13rem` fits 4.18. Changing either number without the other
brings the orphan back, which is why both are written down next to each other.
Confirmed in a browser: 4 columns at 940px, 3 at 800, 2 at 480–620, 1 at 380
and below, no horizontal overflow at any width.

**`ui.tool.related_heading` is translated in all ten locales in this PR rather
than left to fall back.** It has to be — `check_complete` counts `[ui]` as part
of the frame, so one untranslated key there is a hard `LocaleError` on every
locale claiming `complete = true`, not the per-page debt a new tool creates.
The German, Dutch and Italian strings reach for each language's own word for
the toolbox rather than translating "box" literally.

## Verification

- Full clean build of all eleven languages: **exit 0, 585 pages**, link checker
  clean, and every locale still reporting `published` — so nothing dropped out
  of a sitemap or an hreflang set.
- **333 Python tests** (8 new in `RelatedTools`) and **1373 JavaScript tests**
  pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
