### PR TITLE
[Uncommit] Italian guide translations

### DIFF
--- a/locales/it/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/it/pages/guides/combine-images-into-a-pdf.html
@@ -1,204 +1,206 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Apri <a href="../../immagini-in-pdf/">Immagini in PDF</a>, trascinaci
-      dentro le foto, sposta le tessere finché l'ordine non è giusto, e crea il
-      documento. Le impostazioni predefinite &mdash; pagine A4, un margine
-      piccolo, le fotografie copiate dentro senza essere ricodificate &mdash;
-      sono quello che vuole quasi tutti.
+      Apri <a href="../../immagini-in-pdf/">Immagini in PDF</a>, trascina dentro
+      le foto, sposta le tessere finché l'ordine non torna e crea il documento.
+      Le impostazioni di partenza &mdash; pagine A4, un margine piccolo, le
+      fotografie copiate dentro senza ricodifica &mdash; sono quelle che vanno
+      bene a quasi tutti.
     </p>
     <p>
-      Le quattro cose su cui vale la pena pensarci due volte sono l'ordine, la
-      dimensione della pagina, l'impostazione della qualità, e cosa dice di te
-      il documento finito. In quest'ordine di frequenza con cui vanno storte.
+      Le cose su cui conviene fermarsi un attimo sono quattro: l'ordine, la
+      dimensione della pagina, l'impostazione della qualità e quello che il
+      documento finito racconta di te. Le trovi qui sotto nell'ordine in cui
+      vanno storte.
     </p>
   </section>
 
   <section>
-    <h2>Sistema l'ordine prima di ogni altra cosa</h2>
+    <h2>L'ordine, prima di ogni altra cosa</h2>
     <p>
       L'ordine delle pagine è di gran lunga la cosa che si sbaglia più spesso,
-      perché i nomi dei file si ordinano in modi che nessuno si aspetta.
-      <code>IMG_2.jpg</code> viene dopo <code>IMG_10.jpg</code> in un ordine
-      alfabetico, perché il confronto è carattere per carattere e
+      perché i nomi dei file si mettono in fila in modi che nessuno si aspetta:
+      <code>IMG_2.jpg</code> finisce dopo <code>IMG_10.jpg</code> in un
+      ordinamento alfabetico, perché il confronto va carattere per carattere e
       <code>1</code> viene prima di <code>2</code>. Una cartella di scansioni
-      chiamate da <code>pagina1</code> a <code>pagina12</code> arriverà
-      nell'ordine sbagliato in quasi qualunque strumento.
+      chiamate da <code>pagina1</code> a <code>pagina12</code> arriva
+      nell'ordine sbagliato in quasi tutti gli strumenti.
     </p>
     <p>
-      Ordinare per data di scatto è di solito più affidabile per le fotografie,
-      perché hai fotografato le pagine nell'ordine in cui erano. In ogni caso,
-      controlla le tessere prima di premere il pulsante invece di controllare il
-      PDF dopo.
+      Con le fotografie l'ordinamento per data di scatto è di solito più
+      affidabile, visto che le pagine le hai fotografate nell'ordine in cui
+      stavano. In ogni caso, controlla le tessere prima di premere il pulsante,
+      invece di controllare il PDF dopo.
     </p>
   </section>
 
   <section>
-    <h2>La qualità: la parte che quasi tutti gli strumenti sbagliano in silenzio</h2>
+    <h2>La qualità, cioè la parte che quasi tutti gli strumenti sbagliano senza dirlo</h2>
     <p>
-      Un PDF sa portare direttamente i dati JPEG. È una proprietà del formato: i
-      byte compressi di un JPEG si possono lasciar cadere nel documento così
-      come sono, e il lettore li decodifica come farebbe un browser.
+      Un PDF sa portarsi dentro i dati JPEG così come sono. È una proprietà del
+      formato: i byte compressi di un JPEG si possono lasciar cadere nel
+      documento senza toccarli, e il lettore li decodifica come farebbe un
+      browser.
     </p>
     <p>
-      Conta perché vuol dire che una fotografia non deve perdere niente entrando
-      in un PDF. Non viene mai decodificata e non viene mai ricompressa;
-      l'immagine nel documento è bit per bit l'immagine nel tuo file. Molti
-      strumenti ricodificano lo stesso &mdash; è più semplice disegnare tutto su
-      una tela e codificare in modo uniforme &mdash; e il risultato è una
-      generazione di qualità persa per niente.
+      Conta perché vuol dire che entrando in un PDF una fotografia non deve
+      perdere niente: non viene mai decodificata e mai ricompressa, e
+      l'immagine dentro il documento è bit per bit l'immagine del tuo file.
+      Molti strumenti la ricodificano lo stesso, perché è più comodo disegnare
+      tutto su un canvas e poi codificare in modo uniforme, e il risultato è una
+      generazione di qualità buttata via per niente.
     </p>
     <p>
-      Gli altri formati non possono viaggiare così. PNG, WebP, HEIC e gli altri
-      non hanno un filtro corrispondente nel PDF, quindi vanno convertiti. Su
-      come, puoi scegliere:
+      Gli altri formati questa strada non la possono prendere. PNG, WebP, HEIC e
+      compagnia nel PDF non hanno un filtro corrispondente, quindi vanno
+      convertiti, e su come farlo puoi scegliere:
     </p>
     <ul>
       <li>
-        <strong>Ricodifica come JPEG</strong> (il comportamento predefinito).
-        File più leggero, un piccolo costo di qualità, ed è la risposta giusta
+        <strong>Ricodifica in JPEG</strong> (quello che succede di default).
+        File più leggero, un piccolo costo in qualità, ed è la risposta giusta
         per le fotografie.
       </li>
       <li>
         <strong>Senza perdita.</strong> Conserva i pixel esatti al prezzo di un
         documento molto più pesante. È la risposta giusta per screenshot, schemi
-        e qualunque cosa con dentro testo o bordi netti, dove gli artefatti del
-        JPEG si vedono subito.
+        e tutto ciò che contiene testo o bordi netti, dove gli artefatti del
+        JPEG saltano subito all'occhio.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>La dimensione della pagina, e quando «adatta all'immagine» è meglio</h2>
+    <h2>La dimensione della pagina, e quando conviene «su misura»</h2>
     <p>
-      Una dimensione di pagina standard &mdash; A4, Letter, Legal, A3, A5,
-      Tabloid &mdash; mette ogni immagine su una pagina di quella misura,
-      scalata per stare dentro il tuo margine. Usane una quando il documento
-      andrà in stampa, o quando qualcuno di ufficiale lo archivierà.
+      Un formato di pagina standard &mdash; A4, Letter, Legal, A3, A5, Tabloid
+      &mdash; mette ogni immagine su una pagina di quella misura, scalata per
+      stare dentro il margine che hai scelto. Usane uno quando il documento
+      andrà in stampa, o quando finirà nell'archivio di qualcuno che conta.
     </p>
     <p>
-      «Esattamente la dimensione di ogni immagine» rende ogni pagina uguale alla
-      sua immagine, quindi non c'è spazio bianco e non c'è alcuna scalatura.
-      Usalo quando il PDF è un contenitore di immagini invece che un documento:
-      un portfolio, una serie di screenshot, un fumetto. Stampato viene male,
-      perché ogni pagina ha una dimensione diversa.
+      «Esattamente la dimensione di ogni immagine» fa invece ogni pagina grande
+      quanto l'immagine che ci sta sopra: niente spazio bianco, nessuna
+      scalatura. Va bene quando il PDF è un contenitore di immagini più che un
+      documento &mdash; un portfolio, una serie di screenshot, un fumetto
+      &mdash; ma stampato viene male, perché ogni pagina ha una misura diversa.
     </p>
     <p>
-      Un margine vale la pena averlo su qualunque cosa verrà stampata. Le
-      stampanti di casa non sanno stampare fino al bordo del foglio, e una
+      Il margine, su qualunque cosa debba essere stampata, conviene tenerlo: le
+      stampanti di casa fino al bordo del foglio non ci arrivano, e una
       fotografia messa da bordo a bordo esce tagliata.
     </p>
     <h3>Pagine verticali da fotografie orizzontali</h3>
     <p>
-      Se hai fotografato dei fogli di carta con il telefono tenuto di traverso,
-      ogni immagine sarà orizzontale e starà piccola in mezzo a una pagina
-      verticale. La soluzione è ruotarne ciascuna di un quarto di giro prima di
-      costruire il documento, ed è una scelta per singola immagine e non
-      generale, perché di solito qualcuna è entrata dal verso giusto.
+      Se hai fotografato dei fogli con il telefono girato di lato, ogni immagine
+      sarà orizzontale e finirà piccola in mezzo a una pagina verticale. La
+      soluzione è ruotare di un quarto di giro le immagini interessate prima di
+      costruire il documento, e la scelta va fatta immagine per immagine, non
+      una volta per tutte, perché qualcuna sarà entrata dal verso giusto.
     </p>
   </section>
 
   <section>
-    <h2>Cosa dice di te il PDF finito</h2>
+    <h2>Cosa racconta di te il PDF finito</h2>
     <p>
-      Un PDF porta con sé un blocco di informazioni sul documento: autore,
-      produttore, data di creazione, a volte il titolo. A seconda di cosa
-      l'abbia scritto, ci possono finire il nome del tuo account, il nome del
-      tuo dispositivo, e l'ora esatta in cui l'hai fatto.
+      Un PDF si porta dietro un blocco di informazioni sul documento: autore,
+      programma che l'ha prodotto, data di creazione, a volte il titolo. A
+      seconda di chi l'abbia scritto, lì dentro possono finire il nome del tuo
+      account, il nome del tuo dispositivo e l'ora esatta in cui l'hai
+      fabbricato.
     </p>
     <p>
-      Vale la pena pensarci, perché un PDF è una cosa che le persone mandano ad
-      altre persone &mdash; una candidatura, una richiesta di rimborso, un
-      documento per il padrone di casa. I metadati viaggiano insieme a lui e
-      qualunque lettore può mostrarli.
+      Vale la pena pensarci, perché il PDF è per definizione una cosa che si
+      manda a qualcun altro: una candidatura, una richiesta di rimborso, un
+      documento per il proprietario di casa. I metadati viaggiano insieme al
+      file, e qualunque lettore li sa mostrare.
     </p>
     <p>
-      Lo strumento di qui lascia quel blocco vuoto tranne che per il proprio
-      nome: nessun nome di file, nessun nome di dispositivo, nessun nome utente,
-      e nessuna data di creazione se non spunti la casella apposta. Se usi un
-      altro strumento, vale la pena aprire una volta le proprietà del risultato
-      per vedere cosa ci ha scritto.
+      Lo strumento di qui quel blocco lo lascia vuoto, tranne il proprio nome:
+      nessun nome di file, nessun nome di dispositivo, nessun nome utente, e
+      nessuna data di creazione se non spunti la casella apposta. Se usi un
+      altro strumento, apri una volta le proprietà del risultato per vedere cosa
+      ci ha scritto dentro.
     </p>
     <p>
-      A parte: le immagini stesse. Se le tue fotografie portano con sé tag EXIF
-      e GPS, quello che gli succede dipende dalla via. Un JPEG copiato dentro
-      senza ricodifica tiene quello che aveva; un'immagine che viene
-      ricodificata perde i tag come effetto collaterale. Se la cosa ti
-      interessa, ripulisci prima le foto con il
-      <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>
-      &mdash; <a href="../rimuovere-i-dati-exif-e-gps/">la sua guida</a> spiega
-      cosa c'è là dentro.
+      Un inciso sulle immagini in sé: se le tue fotografie si portano dietro tag
+      EXIF e GPS, quello che gli succede dipende dalla strada che prendono. Un
+      JPEG copiato dentro senza ricodifica si tiene quello che aveva;
+      un'immagine ricodificata perde i tag per strada. Se la cosa ti interessa,
+      ripulisci le foto prima, con il
+      <a href="../../rimuovere-dati-exif/">Visualizzatore e rimozione EXIF</a>
+      &mdash; <a href="../rimuovere-i-dati-exif-e-gps/">la sua guida</a>
+      racconta cosa c'è là dentro.
     </p>
   </section>
 
   <section>
-    <h2>Se il PDF esce troppo pesante</h2>
+    <h2>Se il PDF viene troppo pesante</h2>
     <p>
-      Le fotografie da telefono sono pesanti, e venti di loro fanno un documento
-      che la mail rifiuterà. Tre cose da provare, in ordine:
+      Le fotografie fatte col telefono pesano, e venti di seguito fanno un
+      documento che la mail rifiuterà. Ci sono tre cose da provare, in
+      quest'ordine.
     </p>
     <p>
-      <strong>Rimpicciolisci il lato più lungo.</strong> La fotografia da 4000
-      pixel di un foglio di carta porta molto più dettaglio di quanto ne userà
-      qualunque lettore o stampante. Portare il lato lungo a qualcosa come 2000
-      pixel di solito divide il file per quattro e non cambia niente che
-      qualcuno possa vedere su una pagina.
+      <strong>Rimpicciolisci il lato lungo.</strong> La foto da 4000 pixel di un
+      foglio di carta porta molto più dettaglio di quanto ne userà qualunque
+      lettore o stampante: portare il lato lungo attorno ai 2000 pixel di solito
+      divide il file per quattro senza cambiare niente che si possa vedere su
+      una pagina.
     </p>
     <p>
-      <strong>Usa il JPEG invece del senza perdita</strong> per qualunque cosa
-      sia fotografica. Il senza perdita è la risposta giusta per gli schemi e
+      <strong>Scegli il JPEG invece del senza perdita</strong> per tutto ciò che
+      è fotografico. Il senza perdita è la risposta giusta per gli schemi e
       quella sbagliata per la foto di una pagina.
     </p>
     <p>
       <strong>Comprimi il documento finito.</strong> Il
-      <a href="../../comprimere-pdf/">compressore di PDF</a> lavora rispetto a
-      quanto grande viene disegnata ogni immagine sulla pagina invece che
-      rispetto al suo numero di pixel, che è la misura che conta;
-      <a href="../ridurre-le-dimensioni-di-un-pdf/">la sua guida</a> spiega
+      <a href="../../comprimere-pdf/">Compressore di PDF</a> ragiona su quanto
+      grande viene disegnata ogni immagine sulla pagina invece che sul suo
+      numero di pixel, che è poi la misura che conta;
+      <a href="../ridurre-le-dimensioni-di-un-pdf/">la sua guida</a> racconta
       quanto costa.
     </p>
     <p>
-      Nello strumento non c'è alcun limite al numero di immagini che puoi usare.
-      Il tetto pratico è la memoria del tuo dispositivo, perché il documento
-      finito viene assemblato lì prima che tu lo scarichi &mdash; qualche
-      centinaio di foto da telefono a piena risoluzione è la prima cosa a
-      sentirlo, e rimpicciolire il lato più lungo sposta quel tetto parecchio
-      più in là.
+      Sul numero di immagini lo strumento non pone alcun limite. Il tetto
+      pratico è la memoria del tuo dispositivo, visto che il documento finito
+      viene montato lì prima che tu lo scarichi: qualche centinaio di foto da
+      telefono a piena risoluzione è la prima cosa che lo va a toccare, e
+      rimpicciolire il lato lungo lo sposta parecchio più in là.
     </p>
   </section>
 
   <section>
-    <h2>Cosa questo non ti darà</h2>
+    <h2>Cosa da qui non otterrai</h2>
     <p>
-      Un PDF fatto di fotografie è un PDF pieno di immagini. Le parole che ci
-      sono dentro non sono testo: non le puoi cercare, non le puoi copiare, e
-      uno screen reader non le può leggere. È una proprietà di ciò da cui sei
-      partito, non della conversione.
+      Un PDF fatto di fotografie è un PDF pieno di immagini: le parole che ci
+      stanno dentro non sono testo, quindi non le cerchi, non le copi e uno
+      screen reader non le legge. È una proprietà di quello da cui sei partito,
+      non della conversione.
     </p>
     <p>
-      Se ti serve testo cercabile ti serve l'OCR, che è un altro lavoro. E se il
-      documento originale esiste ancora come documento da qualche parte,
-      esportarlo direttamente in PDF batterà sempre il fotografarlo &mdash; più
-      leggero, più nitido, cercabile.
+      Se ti serve testo cercabile ti serve l'OCR, che è un altro mestiere. E se
+      il documento originale esiste ancora come documento da qualche parte,
+      esportarlo direttamente in PDF batte sempre il fotografarlo: più leggero,
+      più nitido, cercabile.
     </p>
   </section>
 
   <section>
-    <h2>Perché questo non ha bisogno di un caricamento</h2>
+    <h2>Perché qui non serve caricare niente</h2>
     <p>
-      Scrivere un PDF è scrivere un file strutturato: un'intestazione, un
-      insieme di oggetti, una tabella di riferimenti incrociati. Non c'è niente
-      lì dentro che un browser non sappia fare, e niente in questo lavoro che
-      richieda alle immagini di andare da qualche parte.
+      Scrivere un PDF vuol dire scrivere un file strutturato: un'intestazione,
+      una serie di oggetti, una tabella di riferimenti incrociati. Lì dentro non
+      c'è niente che un browser non sappia fare, e in tutto il lavoro non c'è
+      niente che obblighi le immagini ad andare da qualche parte.
     </p>
     <p>
-      Ed è una cosa a cui qui vale la pena tenere, per quello che la gente mette
-      in questi documenti. Documenti d'identità, estratti conto, referti medici,
-      contratti firmati &mdash; tutto il motivo per cui una persona sta facendo
-      un PDF è di solito che lo sta mandando a un'istituzione. Lo strumento di
-      qui non ha alcuna funzione di rete, e la
-      <code>Content-Security-Policy</code> della pagina nomina tutti gli
-      indirizzi che può contattare, nessuno dei quali appartiene a questo sito.
+      Ed è una cosa a cui qui conviene tenere, visto cosa la gente ci mette in
+      questi documenti: carte d'identità, estratti conto, referti medici,
+      contratti firmati. Se uno sta facendo un PDF, di solito è perché lo deve
+      mandare a un ufficio. Lo strumento di qui non ha alcuna funzione di rete,
+      e la <code>Content-Security-Policy</code> della pagina nomina tutti gli
+      indirizzi che può contattare, nessuno dei quali è nostro.
     </p>
     <p>
       <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri

--- a/locales/it/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/it/pages/guides/combine-images-into-a-pdf.toml
@@ -4,14 +4,14 @@
 
 nav = "Immagini in un PDF"
 title = "Come unire delle immagini in un unico PDF"
-description = "Trasforma foto o scansioni in un unico PDF: dimensione della pagina, ordine e rotazione, perché un JPEG non deve perdere qualità entrando, e cosa dice un PDF alla persona a cui lo mandi."
+description = "Da foto o scansioni a un PDF solo: formato della pagina, ordine e rotazione, perché entrando un JPEG non deve perdere qualità e cosa racconta il documento a chi lo riceve."
 heading = "Come unire delle immagini in un unico PDF"
 lede = """
-    Qualcuno ha chiesto «un PDF solo» e tu hai undici fotografie di fogli di
-    carta. Qui ci sono le scelte che cambiano davvero il risultato &mdash;
-    dimensione della pagina, ordine, qualità e cosa il documento dice di te
-    &mdash; e quali puoi ignorare."""
+    Ti hanno chiesto «un PDF solo» e tu hai undici fotografie di fogli di
+    carta. Qui trovi le scelte che cambiano davvero il risultato &mdash;
+    formato della pagina, ordine, qualità e quello che il documento racconta di
+    te &mdash; e quali invece puoi lasciar perdere."""
 updated = "20 agosto 2026"
 og_title = "Come unire delle immagini in un unico PDF"
-og_description = "Dimensione della pagina, ordine e rotazione, perché un JPEG non deve perdere qualità entrando, e cosa dice un PDF alla persona a cui lo mandi."
+og_description = "Formato della pagina, ordine e rotazione, perché entrando un JPEG non deve perdere qualità e cosa racconta il documento a chi lo riceve."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/it/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,248 +1,252 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Apri il <a href="../../comprimere-immagine/">compressore di immagini</a>,
-      trascinaci dentro la foto, scrivi il numero che ti hanno dato, e premi il
-      pulsante. Codifica l'immagine più volte, tiene il risultato migliore che
-      sta sotto il tuo obiettivo, e ti dice quanto è costato. Per quasi tutte le
-      fotografie e quasi tutti gli obiettivi, il riassunto onesto è che la
-      differenza non riuscirai a vederla.
+      Apri il <a href="../../comprimere-immagine/">Compressore di immagini</a>,
+      trascina dentro la foto, scrivi il numero che ti hanno dato e premi il
+      pulsante. Lo strumento codifica l'immagine più volte, tiene il risultato
+      migliore che sta sotto il limite e ti dice quanto è costato. Per quasi
+      tutte le fotografie e quasi tutti i limiti, la verità è che la differenza
+      non la vedrai.
     </p>
     <p>
-      Il resto di questa pagina è per quando non va così: quando il risultato si
-      vede morbido, quando un PNG quasi non si muove, o quando vuoi sapere cosa
-      sta davvero facendo lo strumento alla tua immagine prima di mandarla a
-      qualcuno.
-    </p>
-  </section>
-
-  <section>
-    <h2>Cosa chiede davvero un limite di peso</h2>
-    <p>
-      Un JPEG o un WebP non conserva la tua fotografia. Conserva una descrizione
-      di essa, e l'impostazione della qualità decide quanto dettagliata quella
-      descrizione può essere. Abbassala e il file si alleggerisce perché la
-      descrizione si fa più vaga: la texture fine viene mediata via, le sfumature
-      fanno bande, e i bordi si prendono un lieve alone di blocchi.
-    </p>
-    <p>
-      Quindi un limite di peso è un budget di dettaglio. La domanda utile non è
-      «riesco a centrare i 500&nbsp;KB» &mdash; qualunque numero lo si centra
-      sempre &mdash; ma «quanta parte dell'immagine devo cedere per arrivarci, e
-      conta per quello che ci devo fare?».
-    </p>
-    <p>
-      Due regole spannometriche. La fotografia di una scena reale &mdash; volti,
-      fogliame, tessuti &mdash; nasconde bene la compressione, perché l'occhio
-      non ha alcuna zona perfettamente piatta in cui notare il danno. Uno
-      screenshot, un grafico, un logo o qualunque cosa con grandi tinte piatte e
-      bordi netti di testo la mostrano subito, e di solito dovrebbero essere un
-      PNG o un WebP invece che un JPEG.
+      Il resto della pagina serve per i casi in cui non fila così liscio: quando
+      il risultato viene morbido, quando un PNG non si sposta di un grammo, o
+      quando prima di mandare l'immagine a qualcuno vuoi sapere cosa le sta
+      succedendo davvero.
     </p>
   </section>
 
   <section>
-    <h2>Perché non esiste una formula, e cosa farci</h2>
+    <h2>Cosa ti chiede, in realtà, un limite di peso</h2>
     <p>
-      Non c'è modo di calcolare l'impostazione di qualità che produce un file da
-      500&nbsp;KB. Il rapporto tra le due cose dipende interamente da cosa c'è
-      nell'immagine: alla stessa impostazione, la fotografia di un muro liscio
-      potrebbe uscire un decimo della fotografia di un bosco. Qualunque strumento
-      ti proponga «qualità: 60» e speri sta tirando a indovinare per conto tuo.
+      Un JPEG o un WebP la tua fotografia non la conserva: ne conserva una
+      descrizione, e l'impostazione della qualità decide quanto quella
+      descrizione può essere minuziosa. Abbassala e il file cala perché la
+      descrizione si fa più vaga: le texture fini vengono mediate, le sfumature
+      si spezzano in bande e i bordi si portano dietro un piccolo alone di
+      blocchi.
     </p>
     <p>
-      L'unico metodo affidabile è provare. Codifica l'immagine, guarda il peso,
-      correggi, codifica di nuovo. Farlo a mano è noioso, ed è per questo che i
-      compressori chiedono invece un numero di qualità &mdash; sposta la noia
-      addosso a te. Farlo automaticamente sono all'incirca otto codifiche, e otto
-      codifiche di una foto da telefono sono una frazione di secondo su
-      qualunque dispositivo fatto in questo decennio, che è il motivo per cui lo
-      strumento di questo sito chiede il peso e fa la ricerca da sé.
+      Un limite di peso, quindi, è un budget di dettaglio. La domanda utile non
+      è «riesco a stare nei 500&nbsp;KB», perché in un numero ci si sta sempre,
+      ma «quanta immagine devo lasciare per strada per arrivarci, e per quello
+      che ci devo fare cambia qualcosa?».
     </p>
     <p>
-      Ogni peso che riporta è un file davvero codificato, non una stima. Conta
-      quando un modulo ha un limite rigido: una stima ottimista del 2% è un
-      caricamento rifiutato.
-    </p>
-  </section>
-
-  <section>
-    <h2>Spendi la qualità prima dei pixel</h2>
-    <p>
-      Ci sono solo due modi di alleggerire il file di un'immagine. Puoi
-      descrivere la stessa immagine in modo meno preciso, ed è la qualità.
-      Oppure puoi descrivere meno pixel, ed è il ridimensionamento. Non sono
-      equivalenti, e l'ordine conta.
-    </p>
-    <p>
-      Prima va la qualità, perché il primo 30% circa di riduzione è davvero
-      invisibile su una fotografia &mdash; stai buttando via dettaglio che il
-      formato conservava con più cura di quanta ne possa verificare un occhio.
-      Poi vanno i pixel, perché una volta che la qualità scende abbastanza da
-      rendere visibili gli artefatti, un'immagine più piccola a una qualità
-      decente si vede meglio di un'immagine a piena dimensione ma rovinata. Meno
-      pixel buoni battono più pixel cattivi.
-    </p>
-    <p>
-      È tutta lì la strategia, e vale la pena conoscerla anche se usi un altro
-      strumento: abbassa la qualità finché non comincia a venire male, poi
-      rimpicciolisci l'immagine invece di abbassarla ancora.
-    </p>
-    <h3>Quando ridimensionare di proposito</h3>
-    <p>
-      A volte i pixel non servivano proprio. Una foto larga 4000 pixel mostrata
-      in una colonna larga 600 pixel dentro una pagina web porta sei volte il
-      dettaglio che qualcuno vedrà. Se sai dove finirà l'immagine,
-      ridimensionala prima a quella misura e il problema del peso spesso sparisce
-      senza spendere alcuna qualità. Lo strumento per quel lavoro è il
-      <a href="../../ridimensionare-immagine/">ridimensionatore di immagini</a>,
-      e <a href="../ridimensionare-un-immagine/">la sua guida</a> spiega come
-      scegliere una dimensione.
+      Due regole spannometriche. Le fotografie di scene reali &mdash; volti,
+      fogliame, tessuti &mdash; nascondono bene la compressione, perché non
+      offrono all'occhio nessuna zona perfettamente piatta in cui accorgersi del
+      danno. Uno screenshot, un grafico, un logo, e in generale tutto quello che
+      ha campiture piatte e bordi netti di testo, la mostrano subito: roba del
+      genere dovrebbe essere un PNG o un WebP, non un JPEG.
     </p>
   </section>
 
   <section>
-    <h2>Scegliere un formato</h2>
+    <h2>Perché una formula non esiste, e come si fa lo stesso</h2>
     <p>
-      Vale la pena conoscere tre formati, e i browser sanno scriverli tutti e
+      Non c'è modo di calcolare quale impostazione di qualità produce un file da
+      500&nbsp;KB, perché il rapporto tra le due cose dipende per intero da cosa
+      c'è nell'immagine: alla stessa impostazione, la foto di un muro liscio può
+      pesare un decimo della foto di un bosco. Uno strumento che ti propone
+      «qualità: 60» e incrocia le dita sta tirando a indovinare al posto tuo.
+    </p>
+    <p>
+      L'unico metodo che funziona è provare: codifichi, guardi il peso,
+      correggi, ricodifichi. A mano è una noia mortale, e infatti quasi tutti i
+      compressori ti chiedono un numero di qualità, che è un modo elegante di
+      passare la noia a te. Fatta invece dalla macchina, la ricerca sono circa
+      otto codifiche, e otto codifiche di una foto scattata col telefono sono
+      una frazione di secondo su qualsiasi dispositivo di questo decennio: ecco
+      perché lo strumento di questo sito ti chiede il peso e la ricerca se la fa
+      da solo.
+    </p>
+    <p>
+      Ogni peso che ti riporta è un file davvero codificato, non una stima. Fa
+      differenza quando il limite del modulo è rigido, perché una stima ottimista
+      del 2% è un caricamento rifiutato.
+    </p>
+  </section>
+
+  <section>
+    <h2>Spendi prima la qualità, poi i pixel</h2>
+    <p>
+      I modi per alleggerire il file di un'immagine sono soltanto due: descrivere
+      la stessa immagine con meno precisione, cioè la qualità, oppure descrivere
+      meno pixel, cioè il ridimensionamento. Non sono equivalenti, e l'ordine
+      conta.
+    </p>
+    <p>
+      Prima la qualità, perché su una fotografia il primo 30% circa di riduzione
+      è davvero invisibile: stai buttando via dettaglio che il formato
+      conservava con più scrupolo di quanto un occhio riesca a verificare. Poi i
+      pixel, perché quando la qualità scende tanto da far comparire gli
+      artefatti, un'immagine più piccola con una qualità decente si guarda molto
+      meglio di un'immagine a piena dimensione ma sfregiata. Pochi pixel buoni
+      battono tanti pixel cattivi.
+    </p>
+    <p>
+      La strategia è tutta qui, e vale anche se usi un altro strumento: abbassa
+      la qualità finché il risultato non comincia a peggiorare, e da lì in poi
+      rimpicciolisci l'immagine invece di continuare ad abbassarla.
+    </p>
+    <h3>Quando conviene ridimensionare a monte</h3>
+    <p>
+      A volte quei pixel non servivano proprio a nessuno. Una foto larga 4000
+      pixel mostrata dentro una colonna larga 600 porta sei volte il dettaglio
+      che qualcuno vedrà. Se sai già dove finirà l'immagine, portala prima a
+      quella misura: il problema del peso spesso si scioglie da solo senza
+      spendere un grammo di qualità. Lo strumento per quel lavoro è il
+      <a href="../../ridimensionare-immagine/">Ridimensionatore di
+      immagini</a>, e <a href="../ridimensionare-un-immagine/">la sua guida</a>
+      spiega come si sceglie una misura.
+    </p>
+  </section>
+
+  <section>
+    <h2>Scegliere il formato</h2>
+    <p>
+      I formati da conoscere sono tre, e i browser li sanno scrivere tutti e
       tre.
     </p>
     <ul>
       <li>
-        <strong>Il JPEG</strong> è per le fotografie. È con perdita, lo capisce
-        qualunque cosa sia mai stata costruita, e per l'immagine di una scena
-        reale resta un'ottima scelta. Non sa conservare la trasparenza.
+        <strong>Il JPEG</strong> è quello delle fotografie: è con perdita, lo
+        apre qualunque cosa sia mai stata costruita, e per l'immagine di una
+        scena reale resta un'ottima scelta. La trasparenza non la sa conservare.
       </li>
       <li>
-        <strong>Il WebP</strong> è per lo stesso lavoro, fatto meglio: dal 25 al
-        35% circa più leggero del JPEG a una qualità che non si distingue, e
-        tiene la trasparenza. Lo legge ogni browser attuale. Qualche vecchia
-        applicazione da scrivania e qualche modulo di caricamento aziendale
-        ancora no, che è l'unico motivo vero per non usarlo.
+        <strong>Il WebP</strong> fa lo stesso lavoro meglio: dal 25 al 35% circa
+        più leggero del JPEG a una qualità che non si distingue, e la
+        trasparenza la tiene. Lo legge qualunque browser attuale; qualche vecchio
+        programma da scrivania e qualche modulo di caricamento aziendale ancora
+        no, ed è l'unico motivo serio per lasciarlo stare.
       </li>
       <li>
-        <strong>Il PNG</strong> è senza perdita, il che vuol dire che è esatto ed
-        è pesante. È la risposta giusta per screenshot, loghi, disegni al tratto
-        e qualunque cosa con bordi netti o tinte piatte, ed è la risposta
+        <strong>Il PNG</strong> è senza perdita, cioè esatto e pesante. È la
+        risposta giusta per screenshot, loghi, disegni al tratto e in generale
+        per tutto ciò che ha bordi netti o campiture piatte, ed è la risposta
         sbagliata per una fotografia.
       </li>
     </ul>
     <p>
-      Se non hai vincoli da parte di chi ti ha chiesto il file, il WebP ti porta
-      all'obiettivo con meno danno visibile del JPEG. Se il file va dentro
-      qualcosa di vecchio, o dentro un sistema che non puoi provare, il JPEG è la
-      risposta sicura.
+      Se chi ti ha chiesto il file non ti ha imposto nulla, il WebP ti porta al
+      limite con meno danni visibili del JPEG. Se invece il file deve entrare in
+      qualcosa di vecchio, o in un sistema che non puoi provare prima, la
+      risposta sicura è il JPEG.
     </p>
   </section>
 
   <section>
-    <h2>Perché il tuo PNG non si alleggerirà granché</h2>
+    <h2>Perché il tuo PNG non cala quasi per niente</h2>
     <p>
-      È la sorpresa più comune, e non è un difetto dello strumento che stai
-      usando. Il PNG è un formato senza perdita: conserva i pixel esatti, e non
-      ha una manopola della qualità da girare, perché girarne una lo renderebbe
-      un formato diverso. Tutto quello che un compressore PNG può fare è
-      impacchettare gli stessi pixel in modo più furbo, cosa che di solito vale
-      qualche punto percentuale.
+      È la sorpresa più diffusa, e non è colpa dello strumento che stai usando.
+      Il PNG è un formato senza perdita: conserva i pixel esatti e non ha
+      nessuna manopola della qualità da girare, perché girarne una ne farebbe un
+      formato diverso. Tutto quello che un compressore PNG può fare è
+      impacchettare gli stessi identici pixel in modo più furbo, e di solito
+      valgono qualche punto percentuale.
     </p>
     <p>
-      Quindi se ti serve per forza un file molto più leggero e deve restare un
-      PNG, l'unica leva che resta è la dimensione &mdash; meno pixel, o meno
-      colori. Se può smettere di essere un PNG, la domanda è cosa c'è dentro:
+      Se il file deve calare parecchio e deve restare un PNG, l'unica leva che
+      ti resta è la dimensione: meno pixel, o meno colori. Se invece può smettere
+      di essere un PNG, la domanda diventa cosa c'è dentro:
     </p>
     <ul>
       <li>
-        <strong>Una fotografia salvata come PNG.</strong> Comunissimo, di solito
-        per sbaglio, ed è il guadagno più facile di questa pagina: convertirla in
-        JPEG o WebP spesso la rende da cinque a dieci volte più leggera senza
-        alcun cambiamento visibile.
+        <strong>Una fotografia salvata come PNG.</strong> Capita di continuo, di
+        solito per sbaglio, ed è il guadagno più facile di tutta questa pagina:
+        convertirla in JPEG o in WebP la rende spesso da cinque a dieci volte
+        più leggera senza che si veda alcuna differenza.
       </li>
       <li>
-        <strong>Uno screenshot o uno schema.</strong> Converti in WebP, che è
-        anche senza perdita quando glielo chiedi, ed è in genere più leggero del
-        PNG a parità di pixel. Passare al JPEG rende sfocati i bordi del testo.
+        <strong>Uno screenshot o uno schema.</strong> Passa al WebP, che sa
+        essere senza perdita anche lui se glielo chiedi ed è in genere più
+        leggero del PNG a parità di pixel. Il JPEG, qui, ti sfoca i bordi del
+        testo.
       </li>
       <li>
-        <strong>Un logo con trasparenza.</strong> Il WebP tiene la trasparenza;
-        il JPEG la riempirà di un colore pieno, che non è quasi mai quello che
-        volevi.
+        <strong>Un logo con la trasparenza.</strong> Il WebP la trasparenza la
+        tiene; il JPEG te la riempie di un colore pieno, che non è quasi mai
+        quello che volevi.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Come capire se il risultato è abbastanza buono</h2>
+    <h2>Come capire se il risultato regge</h2>
     <p>
-      Guardare una miniatura non dimostra niente &mdash; a dimensione miniatura
-      viene bene tutto. Due controlli migliori:
+      Guardare una miniatura non dimostra niente, perché a dimensione miniatura
+      viene bene tutto. Ci sono due controlli migliori.
     </p>
     <p>
-      <strong>Guardala a dimensione piena, sulla cosa più piatta
-      dell'inquadratura.</strong> Cielo, pelle, un muro dipinto. Il danno da
-      compressione si vede prima nelle sfumature morbide, come blocchi o bande
-      leggere, molto prima di toccare le zone dettagliate.
+      <strong>Guardala a dimensione piena, e proprio sulla parte più piatta
+      dell'inquadratura</strong>: il cielo, la pelle, un muro dipinto. Il danno
+      da compressione si vede prima nelle sfumature morbide, sotto forma di
+      blocchetti o di bande leggere, molto prima di arrivare alle zone
+      dettagliate.
     </p>
     <p>
       <strong>Leggi la misura, se lo strumento te ne dà una.</strong> Il
-      compressore di qui decodifica il proprio risultato e lo confronta con
-      l'originale, e riporta l'SSIM: un numero che confronta luminosità,
-      contrasto e struttura locali invece di contare i pixel cambiati, il che è
-      molto più vicino a ciò che dà fastidio a un occhio. Sopra lo 0,98 circa le
-      due immagini sono difficili da separare una accanto all'altra. Sotto lo
-      0,95 circa, guarda prima di mandare. Riporta anche il PSNR, il classico
-      valore in decibel, per chi lo preferisce.
+      compressore di qui decodifica il proprio risultato, lo confronta con
+      l'originale e ti riporta l'SSIM: un numero che mette a paragone luminosità,
+      contrasto e struttura locali invece di contare i pixel cambiati, ed è per
+      questo molto più vicino a ciò che a un occhio dà fastidio. Sopra lo 0,98
+      circa le due immagini sono difficili da distinguere anche affiancate; sotto
+      lo 0,95 circa, guardale prima di mandare qualcosa. Riporta anche il PSNR,
+      il classico valore in decibel, per chi preferisce quello.
     </p>
     <p>
-      Entrambi sono calcolati sul tuo dispositivo e mostrati a te, ed è tutto il
-      senso di averli: trasformano «perdita di qualità minima» da affermazione a
-      numero che puoi verificare.
+      Sono calcolati tutti e due sul tuo dispositivo e mostrati a te, ed è tutto
+      il senso di averli: trasformano «perdita di qualità minima» da
+      affermazione in un numero che puoi controllare.
     </p>
   </section>
 
   <section>
     <h2>Tre cose da sapere prima di mandare il file</h2>
     <p>
-      <strong>Comprimere toglie i metadati.</strong> Ricodificare vuol dire
-      decodificare l'immagine in pixel e ricodificare quei pixel, e una tela
-      piena di pixel non porta con sé alcun tag &mdash; quindi la posizione GPS,
-      il modello della fotocamera, gli orari e il resto semplicemente non
-      vengono scritti nel file nuovo. Di solito è un vantaggio. Se volevi via i
-      tag ma l'immagine intatta, è un altro lavoro: il
-      <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>
+      <strong>Comprimere porta via i metadati.</strong> Ricodificare vuol dire
+      decodificare l'immagine in pixel e ricodificare quei pixel, e un canvas
+      pieno di pixel non si porta dietro nessun tag: la posizione GPS, il modello
+      della fotocamera, le date e tutto il resto nel file nuovo non vengono
+      proprio scritti. Di solito è un vantaggio. Se però quello che volevi era
+      togliere i tag lasciando intatta l'immagine, è un altro lavoro: il
+      <a href="../../rimuovere-dati-exif/">Visualizzatore e rimozione EXIF</a>
       riscrive il contenitore senza ricomprimere niente, e
-      <a href="../rimuovere-i-dati-exif-e-gps/">la sua guida</a> spiega cosa c'è
-      là dentro.
+      <a href="../rimuovere-i-dati-exif-e-gps/">la sua guida</a> racconta cosa
+      c'è là dentro.
     </p>
     <p>
-      <strong>Non comprimere mai lo stesso file due volte.</strong> Ogni
-      codifica con perdita butta via dettaglio per sempre, e codificare
-      un'immagine già compressa ne butta via ancora &mdash; compresi gli
-      artefatti del primo passaggio, che conserva fedelmente a spese di
-      dettaglio vero. Torna sempre all'originale e comprimi una volta sola.
+      <strong>Non comprimere due volte lo stesso file.</strong> Ogni codifica
+      con perdita butta via dettaglio per sempre, e codificare un'immagine già
+      compressa ne butta via dell'altro, conservando per giunta con ogni cura
+      gli artefatti del primo giro a spese di dettaglio vero. Riparti sempre
+      dall'originale e comprimi una volta sola.
     </p>
     <p>
-      <strong>Tieni l'originale.</strong> Da una codifica con perdita non si
-      torna indietro. Qualunque cosa tu mandi, tieni da qualche parte il file da
-      cui sei partito.
+      <strong>Tieni da parte l'originale.</strong> Da una codifica con perdita
+      non si torna indietro, quindi qualunque cosa tu mandi, il file di partenza
+      conservalo da qualche parte.
     </p>
   </section>
 
   <section>
     <h2>Niente di tutto questo ha bisogno di un caricamento</h2>
     <p>
-      Ogni browser si porta dietro da anni un encoder JPEG, PNG e WebP &mdash; è
-      lo stesso codice che salva un'immagine da una tela. Comprimere un'immagine
-      è uno dei lavori che non hanno alcun motivo tecnico per coinvolgere un
-      server, ed è per questo che lo strumento di qui non ne ha uno: l'immagine
-      viene decodificata, codificata e misurata sul tuo dispositivo, e nella
-      <code>Content-Security-Policy</code> della pagina non c'è alcun indirizzo
-      appartenente a questo sito a cui spedirla.
+      Un encoder JPEG, PNG e WebP nei browser c'è da anni: è lo stesso codice che
+      salva un'immagine da un canvas. Comprimere un'immagine è uno di quei
+      lavori per cui non esiste alcuna ragione tecnica di tirare in ballo un
+      server, ed è per questo che lo strumento di qui un server non ce l'ha:
+      l'immagine viene decodificata, codificata e misurata sul tuo dispositivo,
+      e nella <code>Content-Security-Policy</code> della pagina non compare
+      nessun indirizzo nostro a cui spedirla.
     </p>
     <p>
-      Il modo più semplice per confermarlo, qui come altrove, è caricare la
-      pagina, staccare la connessione, e comprimere qualcosa lo stesso. Se
-      funziona ancora, non veniva caricato niente.
+      Il modo più semplice per verificarlo, qui come altrove, è caricare la
+      pagina, staccare la connessione e comprimere qualcosa lo stesso: se
+      funziona ancora, non stava andando via niente.
       <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
-      file sui convertitori online?</a> propone altre tre verifiche come questa.
+      file sui convertitori online?</a> ne propone altre tre come questa.
     </p>
   </section>

--- a/locales/it/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/it/pages/guides/compress-an-image-to-a-target-size.toml
@@ -4,14 +4,14 @@
 
 nav = "Comprimere un'immagine"
 title = "Come comprimere un'immagine a un peso esatto"
-description = "Un modulo di caricamento vuole 500 KB e la tua foto pesa 4 MB. Quanto costa davvero un limite di peso, quale impostazione muovere per prima, e perché un PNG non si rimpicciolisce come un JPEG."
+description = "Il modulo vuole 500 KB e la tua foto ne pesa 4 MB. Quanto costa davvero un limite di peso, quale impostazione muovere per prima e perché un PNG non cala come cala un JPEG."
 heading = "Come comprimere un'immagine a un peso esatto"
 lede = """
-    Qualcuno ti ha detto un numero &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
-    &mdash; e la tua foto non ci si avvicina nemmeno. Qui c'è quanto costa quel
-    numero, su cosa spenderlo, e come capire se il risultato è ancora abbastanza
-    buono da mandare."""
+    Ti hanno detto un numero &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
+    &mdash; e la tua foto non ci si avvicina nemmeno. Qui trovi quanto costa
+    quel numero, su cosa conviene spenderlo e come capire se quello che esce è
+    ancora abbastanza buono da mandare."""
 updated = "20 agosto 2026"
 og_title = "Comprimere un'immagine a un peso esatto"
-og_description = "Quanto costa davvero un limite di peso, quale impostazione muovere per prima, e perché un PNG non si rimpicciolisce come un JPEG."
+og_description = "Quanto costa davvero un limite di peso, quale impostazione muovere per prima e perché un PNG non cala come cala un JPEG."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/crop-a-video.html
+++ b/locales/it/pages/guides/crop-a-video.html
@@ -1,217 +1,221 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Apri il <a href="../../ritagliare-video/">ritagliatore di video</a>,
-      trascinaci dentro la clip, trascina il riquadro sulla parte che vuoi tenere
-      &mdash; oppure bloccalo su una forma, se te ne hanno data una &mdash; ed
-      esporta. La clip che esce è lunga esattamente come quella che è entrata,
+      Apri il <a href="../../ritagliare-video/">Ritagliatore di video</a>,
+      trascina dentro la clip, sposta il riquadro sulla parte che vuoi tenere
+      &mdash; o bloccalo su una forma, se te ne hanno imposta una &mdash; ed
+      esporta. La clip che esce dura esattamente quanto quella che è entrata,
       con i suoi tempi e il suo audio intatti.
     </p>
     <p>
-      A differenza del tagliare, questo lavoro deve scrivere fotogrammi nuovi.
-      Non è una mancanza di un particolare strumento; è cos'è il ritaglio. Il
-      resto di questa pagina riguarda quanto costa e come tenerlo basso.
+      A differenza del taglio, però, qui bisogna scrivere fotogrammi nuovi. Non
+      è il limite di un singolo strumento: è ritagliare che funziona così. Il
+      resto della pagina serve a dirti quanto costa e come tenere basso il
+      conto.
     </p>
   </section>
 
   <section>
-    <h2>Perché ritagliare non può evitare una ricodifica</h2>
+    <h2>Perché ritagliare non può evitare la ricodifica</h2>
     <p>
-      Un taglio tiene fotogrammi interi, quindi un buon tagliavideo li sposta
-      dall'altra parte intatti e non viene decodificato proprio niente. Un
-      ritaglio tiene una parte di ogni fotogramma &mdash; e una parte di
-      fotogramma è un'immagine diversa. Non c'è modo di conservare un'immagine
-      diversa senza riscrivere i pixel da capo.
+      Quando accorci un video tieni fotogrammi interi, e infatti un buon
+      tagliavideo li sposta dall'altra parte così come sono, senza decodificare
+      niente. Quando lo ritagli, invece, di ogni fotogramma ne tieni un pezzo, e
+      il pezzo di un fotogramma è un'immagine diversa: non esiste modo di
+      conservare un'immagine diversa senza riscriverne i pixel.
     </p>
     <p>
-      C'è un'eccezione stretta, e vale la pena conoscerla per riconoscere quando
-      qualcuno la sta rivendicando. Il video è codificato a blocchi, e se un
-      ritaglio cadesse esattamente sui confini dei blocchi su tutti e quattro i
-      lati, in linea di principio una parte dei dati si potrebbe riusare. In
-      pratica le dimensioni stesse del fotogramma, i vettori di movimento e la
-      predizione vanno riscritti comunque, quindi non c'è niente di reale
-      costruito così. Dai per scontato che un ritaglio voglia dire una
-      ricodifica.
+      Un'eccezione, strettissima, ci sarebbe, e vale la pena conoscerla giusto
+      per riconoscere chi te la sta vendendo. Il video è codificato a blocchi, e
+      se un ritaglio cadesse esattamente sul confine dei blocchi su tutti e
+      quattro i lati una parte dei dati, in teoria, si potrebbe riutilizzare. In
+      pratica le dimensioni del fotogramma, i vettori di movimento e la
+      predizione vanno riscritti lo stesso, e infatti non esiste niente di
+      concreto costruito così. Dai per scontato che ritagliare voglia dire
+      ricodificare.
     </p>
     <p>
-      Quello che un ritagliatore ben educato farà è non spendere <em>più</em> di
-      quanto spendesse l'originale sulla stessa zona. Codificare una zona
-      ritagliata a un bitrate più alto della sorgente rende il file solo più
-      pesante; non può rimettere dentro dettaglio che l'originale non aveva.
+      Quello che un ritagliatore fatto bene evita è di spendere <em>più</em> di
+      quanto spendesse l'originale sulla stessa porzione di immagine:
+      codificare la zona ritagliata a un bitrate più alto della sorgente rende
+      il file solo più pesante, perché il dettaglio che nell'originale non
+      c'era non lo rimette dentro nessuno.
     </p>
   </section>
 
   <section>
-    <h2>Le forme che ti stanno davvero chiedendo</h2>
+    <h2>Le forme che ti chiedono davvero</h2>
     <p>
-      Quasi tutti i ritagli si fanno perché da qualche parte c'è una proporzione
-      obbligatoria. L'elenco corto:
+      Quasi tutti i ritagli nascono da una proporzione imposta da qualche parte.
+      La lista è corta:
     </p>
     <ul>
       <li>
-        <strong>9:16 &mdash; verticale.</strong> Storie, reel, short, TikTok. A
-        schermo pieno su un telefono tenuto normalmente. Il motivo più comune per
-        cui qualcuno ritaglia un video.
+        <strong>9:16, il verticale.</strong> Storie, reel, short, TikTok: a
+        schermo pieno su un telefono tenuto come lo si tiene sempre. È il motivo
+        più diffuso per cui si ritaglia un video.
       </li>
       <li>
-        <strong>1:1 &mdash; quadrato.</strong> I post nei feed di parecchie
-        piattaforme. Funziona da qualunque verso chi guarda tenga il telefono,
-        ed è per questo che resiste.
+        <strong>1:1, il quadrato.</strong> I post nei feed di parecchie
+        piattaforme. Regge da qualunque verso chi guarda tenga il telefono, ed è
+        per questo che non è mai passato di moda.
       </li>
       <li>
-        <strong>4:5 &mdash; leggermente verticale.</strong> La forma più grande
-        che certi feed consentono, quindi prende più schermo di un quadrato senza
-        essere un video verticale pieno.
+        <strong>4:5, il verticale leggero.</strong> La forma più grande che
+        certi feed accettano: prende più schermo di un quadrato senza essere un
+        verticale pieno.
       </li>
       <li>
-        <strong>16:9 &mdash; orizzontale.</strong> Lo standard del video in
-        generale. Di solito ritagli <em>verso</em> questa forma solo per togliere
-        le bande nere, o <em>da</em> questa forma per ottenere una delle
-        precedenti.
+        <strong>16:9, l'orizzontale.</strong> Lo standard del video in generale.
+        Di solito ci si ritaglia <em>verso</em> solo per togliere le bande nere,
+        oppure si parte <em>da</em> qui per arrivare a una delle forme sopra.
       </li>
     </ul>
     <p>
-      Blocca il riquadro sulla proporzione invece di trascinarlo a occhio.
-      Sbagliare di qualche pixel vuol dire che la piattaforma ritaglia il tuo
-      ritaglio, e non ti consulterà su dove.
+      Blocca il riquadro sulla proporzione, invece di trascinarlo a occhio:
+      sbagliare di qualche pixel vuol dire che sarà la piattaforma a ritagliare
+      il tuo ritaglio, e su dove farlo non ti chiederà il parere.
     </p>
   </section>
 
   <section>
-    <h2>Rendere verticale una clip orizzontale</h2>
+    <h2>Far diventare verticale una clip orizzontale</h2>
     <p>
-      È il caso comune più difficile, e vale la pena essere chiari che ritagliare
-      è un compromesso e non una soluzione.
+      È il caso comune più difficile, e conviene dirlo chiaramente: ritagliare
+      qui è un compromesso, non una soluzione.
     </p>
     <p>
-      Un video 16:9 ritagliato a 9:16 tiene circa il 32% della larghezza
-      dell'immagine. Tutto quello che sta ai lati sparisce &mdash; e in uno
-      scatto orizzontale, ai lati di solito c'è il contesto. Se due persone
-      parlano ai due estremi dell'inquadratura, non c'è un solo ritaglio che le
-      tenga entrambe.
+      Di un video 16:9 portato a 9:16 resta circa il 32% della larghezza, e
+      tutto quello che stava ai lati sparisce &mdash; peccato che in
+      un'inquadratura orizzontale ai lati ci sia proprio il contesto. Se due
+      persone parlano ai due estremi del quadro, non esiste un ritaglio che le
+      tenga tutte e due.
     </p>
     <p>
-      Scegli il ritaglio guardando la clip una volta e chiedendoti dove sta
-      davvero il soggetto per la maggior parte del tempo. Se la risposta è «si
-      muove», un ritaglio fisso è lo strumento sbagliato e quello che ti serve è
-      un programma di montaggio che sappia spostare il ritaglio nel tempo. Se la
-      risposta è «al centro, quasi sempre», un ritaglio centrato va benissimo e
-      richiede dieci secondi.
+      Per scegliere dove tagliare, guarda la clip una volta e chiediti dove sta
+      il soggetto per la maggior parte del tempo. Se la risposta è «si sposta
+      di continuo», il ritaglio fisso è lo strumento sbagliato e ti serve un
+      programma di montaggio che sappia muovere il riquadro nel tempo; se la
+      risposta è «quasi sempre al centro», un ritaglio centrato va benissimo e
+      ti porta via dieci secondi.
     </p>
     <p>
-      L'alternativa da ricordare: molte piattaforme accettano un video
-      orizzontale e ci mettono loro le bande. Il ritaglio serve per quando vuoi
-      lo schermo pieno, non per quando vuoi che il video venga accettato.
+      Tieni presente anche l'alternativa: parecchie piattaforme un video
+      orizzontale lo accettano eccome, e le bande te le mettono loro. Il
+      ritaglio serve quando vuoi lo schermo pieno, non quando vuoi solo che il
+      video passi.
     </p>
   </section>
 
   <section>
-    <h2>Perché larghezza e altezza si muovono di due in due</h2>
+    <h2>Perché larghezza e altezza vanno di due in due</h2>
     <p>
-      Se noti che il riquadro di ritaglio rifiuta i numeri dispari, a fare il
-      difficile è il codec e non l'interfaccia.
+      Se noti che il riquadro rifiuta i numeri dispari, a fare il difficile è il
+      codec e non l'interfaccia.
     </p>
     <p>
-      L'H.264 &mdash; il codec dentro un MP4 &mdash; conserva il colore a metà
-      risoluzione in orizzontale e in verticale, perché l'occhio è molto meno
-      sensibile al dettaglio di colore che a quello di luminosità. Vuol dire che
-      l'immagine viene gestita a unità di due pixel e non c'è modo di descrivere
-      un fotogramma con un numero dispari di pixel su un lato.
+      L'H.264, cioè quello che sta dentro un MP4, conserva il colore a metà
+      risoluzione sia in orizzontale sia in verticale, perché l'occhio è molto
+      meno sensibile al dettaglio di colore che a quello di luminosità:
+      l'immagine viene quindi gestita a coppie di pixel, e un fotogramma con un
+      numero dispari di pixel su un lato semplicemente non si può descrivere.
     </p>
     <p>
-      Gli strumenti se la cavano arrotondando il tuo ritaglio dopo che l'hai
-      impostato, cosa che sposta il riquadro di un pixel senza dirtelo, oppure
-      proponendo fin dall'inizio solo numeri pari. Qui succede la seconda.
+      Alcuni strumenti se la cavano arrotondando il tuo ritaglio dopo che l'hai
+      impostato, spostandoti il riquadro di un pixel senza dirti niente; altri
+      ti propongono da subito solo numeri pari. Qui succede la seconda cosa.
     </p>
   </section>
 
   <section>
     <h2>Cosa succede al suono</h2>
     <p>
-      Niente, sulla via dell'MP4. Ritagliare cambia l'immagine e non ha alcun
-      motivo di toccare l'audio, quindi l'audio viene copiato dall'altra parte
-      campione per campione senza essere mai decodificato &mdash; byte per byte
-      quello che c'era nel file.
+      Con l'MP4, niente. Ritagliare cambia l'immagine e non ha alcun motivo di
+      toccare l'audio, che infatti viene copiato dall'altra parte campione per
+      campione senza passare da un decodificatore: byte per byte quello che
+      stava nel file di partenza.
     </p>
     <p>
-      Sul ripiego della registrazione, descritto qui sotto, il suono viene
-      catturato dalla riproduzione e ricodificato, il che costa un po' di
-      qualità. In entrambi i casi c'è una casella per lasciarlo fuori del tutto,
-      che vale la pena usare quando la clip va in un posto che la riproduce muta
-      comunque e vuoi il file più leggero.
+      Quando invece si passa dal ripiego basato sulla registrazione, quello
+      descritto qui sotto, il suono viene catturato dalla riproduzione e
+      ricodificato, e un po' di qualità la lascia per strada. In tutti e due i
+      casi c'è una casella per toglierlo del tutto, che vale la pena spuntare
+      quando la clip va in un posto che la riproduce muta comunque e a te
+      interessa il file più leggero.
     </p>
   </section>
 
   <section>
-    <h2>I formati, e quanto ci mette</h2>
+    <h2>I formati, e quanto tempo ci vuole</h2>
     <p>
       <strong>MP4, M4V e MOV</strong> vengono letti direttamente, qualunque cosa
-      ci sia dentro &mdash; H.264, HEVC, AV1 o VP9 &mdash; purché il tuo browser
-      sappia decodificare quel codec. A differenza del tagliare, il ritagliare
-      deve decodificare, quindi qui il codec conta in un modo in cui là non
-      conta.
+      ci sia dentro &mdash; H.264, HEVC, AV1, VP9 &mdash; purché il tuo browser
+      quel codec lo sappia decodificare. A differenza del taglio, il ritaglio
+      deve decodificare per forza, e quindi qui il codec conta mentre là non
+      contava.
     </p>
     <p>
-      <strong>Tutto il resto che il tuo browser sa riprodurre</strong>, il WebM
-      in primis, viene ritagliato riproducendolo e registrando il risultato, cosa
-      che funziona e richiede tanto tempo quanto è lunga la clip.
+      <strong>Tutto il resto che il tuo browser sa riprodurre</strong>, WebM in
+      testa, viene ritagliato riproducendolo e registrando il risultato:
+      funziona, e ci mette esattamente il tempo che dura la clip.
     </p>
     <p>
       <strong>AVI, WMV, FLV e quasi tutti gli MKV</strong> il browser non li sa
-      né leggere né riprodurre, e lo strumento li rifiuta con un messaggio invece
-      di piantarsi a metà strada.
+      né leggere né riprodurre, e lo strumento li rifiuta con un messaggio
+      invece di piantarsi a metà.
     </p>
     <p>
-      Aspettati che un ritaglio richieda tempo vero su una clip lunga, perché
-      ogni fotogramma viene decodificato e ricodificato. Nello strumento non c'è
-      alcun limite, e il file viene percorso qualche megabyte alla volta invece
-      di essere caricato tutto; il tetto pratico è il video finito, che viene
-      assemblato in memoria prima che tu lo scarichi.
+      Su una clip lunga, aspettati che il ritaglio ci metta parecchio: ogni
+      fotogramma va decodificato e ricodificato. Un limite lo strumento non lo
+      pone, e il file viene percorso qualche megabyte alla volta invece di
+      essere caricato tutto in una volta; il tetto pratico è semmai il video
+      finito, che viene montato in memoria prima che tu lo scarichi.
     </p>
   </section>
 
   <section>
-    <h2>Ritaglia prima di fare qualunque altra cosa</h2>
+    <h2>Ritaglia per ultimo, accorcia per primo</h2>
     <p>
-      Se una clip ha bisogno sia di essere accorciata sia di essere ritagliata,
-      accorciala per prima &mdash; è gratis, e ogni secondo che tagli è un
-      secondo che nessuno deve ricodificare. Poi ritaglia una volta sola la clip
-      più corta.
+      Se una clip va sia accorciata sia ritagliata, comincia dall'accorciarla:
+      il taglio è gratis, e ogni secondo che butti via è un secondo che nessuno
+      dovrà ricodificare. Poi ritagli una volta sola, e su un file più corto.
     </p>
     <p>
-      Farlo al contrario vuol dire ritagliare riprese che stai per buttare, cosa
-      che costa tempo e qualità per niente. Il
-      <a href="../../tagliare-video/">tagliavideo</a> è qui accanto, e
+      Farlo nell'ordine opposto vuol dire ricodificare riprese che stai per
+      buttare, spendendo tempo e qualità per niente. Il
+      <a href="../../tagliare-video/">Tagliavideo</a> è qui accanto, e
       <a href="../tagliare-un-video/">la sua guida</a> spiega perché quel
-      passaggio non deve costarti proprio niente.
+      passaggio non dovrebbe costarti nulla.
     </p>
     <p>
-      Più in generale: ogni passaggio con perdita si somma. Un ritaglio di un
-      originale è una generazione. Un ritaglio di un taglio di un'esportazione di
-      uno scaricamento sono quattro, e si vede.
+      Vale in generale: ogni passaggio con perdita si somma al precedente. Un
+      ritaglio fatto sull'originale è una generazione sola; un ritaglio di un
+      taglio di un'esportazione di un file scaricato da qualche parte sono
+      quattro, e a quel punto si vede.
     </p>
   </section>
 
   <section>
-    <h2>Perché questo non ha bisogno di un caricamento</h2>
+    <h2>Perché qui non serve caricare niente</h2>
     <p>
-      Decodificare e ricodificare video in un browser è una cosa recente ed è una
-      cosa vera: WebCodecs espone lo stesso encoder hardware che il tuo telefono
-      usa per registrare video, ed è veloce per lo stesso motivo. Il lavoro
-      avviene sul dispositivo che ha già il file, il che per un video da parecchi
-      gigabyte è anche l'unica disposizione che abbia senso &mdash; caricarlo e
-      riscaricare il risultato costa più tempo della codifica.
+      Decodificare e ricodificare video dentro un browser è una possibilità
+      recente, ed è una possibilità vera: WebCodecs mette a disposizione lo
+      stesso encoder hardware che il tuo telefono usa per registrare, ed è
+      veloce per lo stesso motivo. Il lavoro avviene sul dispositivo che il file
+      ce l'ha già, che per un video da qualche gigabyte è anche l'unico modo
+      sensato di organizzare la cosa: caricarlo e riscaricare il risultato porta
+      via più tempo della codifica.
     </p>
     <p>
-      Lo strumento di qui non ha alcuna funzione di rete, e la
+      Lo strumento non ha alcuna funzione di rete, e la
       <code>Content-Security-Policy</code> della pagina nomina tutti gli
-      indirizzi che può contattare, nessuno dei quali appartiene a questo sito.
-      Stacca la connessione e ritaglia una clip lo stesso, se preferisci
-      verificare invece che crederci.
+      indirizzi che può contattare, nessuno dei quali è nostro. Stacca la
+      connessione e ritaglia una clip lo stesso, se preferisci verificare invece
+      che crederci.
     </p>
     <p>
       <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
-      file sui convertitori online?</a> propone altre tre verifiche che puoi fare
-      su qualunque strumento.
+      file sui convertitori online?</a> propone altre tre verifiche da fare su
+      qualunque strumento.
     </p>
   </section>

--- a/locales/it/pages/guides/crop-a-video.toml
+++ b/locales/it/pages/guides/crop-a-video.toml
@@ -4,14 +4,14 @@
 
 nav = "Ritagliare un video"
 title = "Come ritagliare un video in una forma diversa"
-description = "Riduci una clip a un quadrato, a un verticale 9:16 o a un riquadro di pixel esatto. Quale proporzione vuole ogni piattaforma, perché ritagliare deve ricodificare mentre tagliare no, e quanto costa."
+description = "Porta una clip a un quadrato, a un 9:16 verticale o a un riquadro di pixel esatto. Quale proporzione chiede ogni piattaforma, perché il ritaglio deve ricodificare mentre il taglio no, e quanto costa."
 heading = "Come ritagliare un video in una forma diversa"
 lede = """
-    Ritagliare cambia la forma dell'immagine, il che vuol dire scrivere
-    fotogrammi nuovi &mdash; non c'è modo di aggirarlo, e qualunque strumento
-    dica il contrario sta facendo un'altra cosa. Qui c'è quanto costa, e come
+    Ritagliare cambia la forma dell'immagine, e cambiare la forma vuol dire
+    scrivere fotogrammi nuovi: non c'è modo di aggirarlo, e uno strumento che
+    dica il contrario sta facendo un'altra cosa. Qui trovi quanto costa e come
     spenderlo bene."""
 updated = "20 agosto 2026"
 og_title = "Come ritagliare un video in una forma diversa"
-og_description = "Quale proporzione vuole ogni piattaforma, perché ritagliare deve ricodificare mentre tagliare no, e quanto costa."
+og_description = "Quale proporzione chiede ogni piattaforma, perché il ritaglio deve ricodificare mentre il taglio no, e quanto costa."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/it/pages/guides/is-it-safe-to-upload-files.html
@@ -1,149 +1,148 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Per quasi tutti i file, quasi sempre, caricare va bene. I convertitori
-      seri cancellano quello che mandi nel giro di qualche ora e non hanno alcun
-      interesse per le tue foto delle vacanze.
+      Per quasi tutti i file, quasi sempre, caricare va benissimo. I convertitori
+      seri cancellano quello che gli mandi nel giro di qualche ora, e delle tue
+      foto delle vacanze non se ne fanno niente.
     </p>
     <p>
-      Il problema non è che stiano mentendo. È che
+      Il punto non è che ti stiano mentendo. È che
       <strong>non hai modo di sapere se lo stanno facendo</strong>. Una volta che
-      un file lascia il tuo dispositivo, ogni promessa su quello che succede dopo
-      è una promessa che prendi sulla fiducia: per quanto viene tenuto, chi ci può
-      arrivare, se viene copiato in un backup che sopravvive al timer di
-      cancellazione, cosa gli succede se l'azienda viene venduta o violata.
-      Niente di tutto questo si vede da fuori.
+      un file ha lasciato il tuo dispositivo, qualunque promessa su cosa gli
+      succede dopo è una promessa che devi prendere per buona: quanto a lungo
+      resta lì, chi ci può arrivare, se finisce in un backup che sopravvive al
+      timer di cancellazione, cosa gli capita se l'azienda viene venduta o
+      bucata. Da fuori, di tutto questo, non si vede niente.
     </p>
     <p>
-      Quindi la domanda utile non è «mi fido di questo sito?». È
+      La domanda utile, quindi, non è «mi fido di questo sito?», ma
       <strong>«questo lavoro ha davvero bisogno che il mio file se ne
-      vada?»</strong>. Per un numero grande e crescente di lavori la risposta è
-      no, e quando la risposta è no, la domanda sulla fiducia smette di essere
-      una a cui devi rispondere.
+      vada?»</strong>. Per un numero di lavori grande e in continua crescita la
+      risposta è no, e quando la risposta è no la questione della fiducia
+      semplicemente non si pone più.
     </p>
   </section>
 
   <section>
-    <h2>Cosa fa davvero un «caricamento»</h2>
+    <h2>Cosa succede davvero quando «carichi»</h2>
     <p>
-      Quando un convertitore ti chiede di scegliere un file e poi ti mostra una
-      barra di avanzamento, il tuo browser sta copiando tutto il file, byte per
-      byte, attraverso internet, su un computer che è di qualcun altro. Quel
-      computer lo scrive su un disco, esegue la conversione, scrive il risultato
-      sullo stesso disco, e ti passa un link.
+      Quando un convertitore ti fa scegliere un file e poi ti mostra una barra di
+      avanzamento, il tuo browser sta copiando l'intero file, byte per byte,
+      attraverso internet, su un computer che è di qualcun altro. Quel computer
+      lo scrive su un disco, esegue la conversione, scrive il risultato sullo
+      stesso disco e ti passa un link.
     </p>
     <p>
       In quel momento il tuo file esiste in almeno tre posti che non hai scelto
-      tu: il disco del server, i registri che hanno annotato la richiesta, e
-      spesso una rete di distribuzione dei contenuti che ha messo in cache il
-      risultato perché lo scaricamento sia rapido. Una politica di cancellazione
+      tu: il disco del server, i log che hanno registrato la richiesta e, spesso,
+      una rete di distribuzione dei contenuti che ha messo in cache il risultato
+      per rendere veloce il download. Una politica di cancellazione, per valere,
       deve arrivare a tutti e tre. Quasi tutte dicono di arrivarci. Tu non ne
       puoi verificare nemmeno una.
     </p>
     <p>
-      Vale anche la pena saperlo: il file non è l'unica cosa che arriva. Il nome
-      del file va con lui, e ci va anche tutto quello che c'è dentro il file e
-      che tu non vedi. Una foto appena uscita da un telefono porta di solito le
-      coordinate GPS esatte del posto in cui è stata scattata, l'ora, il numero di
-      serie della fotocamera, e a volte una miniatura incorporata dell'immagine
-      originale, quella di prima che la ritagliassi. Chi sta attento all'immagine
-      spesso non sta attento a quello, perché sullo schermo non c'è niente che
-      glielo mostri.
+      Un'altra cosa che vale la pena sapere: il file non è l'unica cosa che
+      parte. Con lui va il nome, e va tutto quello che dentro al file c'è ma tu
+      non vedi. Una foto appena uscita da un telefono porta di solito le
+      coordinate GPS precise del posto in cui l'hai scattata, l'ora, il numero di
+      serie della fotocamera e a volte una miniatura incorporata dell'immagine
+      originale, cioè di prima che la ritagliassi. Chi sta attento all'immagine
+      spesso a tutto questo non pensa, perché sullo schermo non c'è niente che
+      glielo faccia vedere.
     </p>
   </section>
 
   <section>
     <h2>Perché quasi tutti gli strumenti caricano lo stesso</h2>
     <p>
-      Non perché vogliano i tuoi file. Perché per quasi tutta la vita del web non
-      c'era alternativa. Un browser non sapeva decodificare un video,
-      ricodificare un'immagine a una qualità scelta, o analizzare un formato di
-      file; un server con FFmpeg e ImageMagick sì. Caricare non era un modello di
-      business, era l'unico posto in cui il lavoro potesse avvenire.
+      Non perché vogliano i tuoi file, ma perché per quasi tutta la vita del web
+      non c'era altra strada. Un browser non sapeva decodificare un video,
+      ricodificare un'immagine a una qualità decisa da te o leggere il formato di
+      un file; un server con FFmpeg e ImageMagick sì. Caricare non era un modello
+      di business, era l'unico posto in cui il lavoro potesse succedere.
     </p>
     <p>
-      Ha smesso di essere vero di recente e in sordina. I browser ormai si
-      portano dietro WebAssembly, che esegue gli stessi codec compilati a una
-      velocità vicina a quella nativa, WebCodecs, che espone l'encoder video
-      hardware che il tuo dispositivo ha già, e un'API Canvas che sa decodificare
-      e ricodificare immagini direttamente. Il lavoro per cui serviva un server
-      adesso gira sul dispositivo che ha già il file.
+      Poi la cosa ha smesso di essere vera, di recente e senza far rumore. I
+      browser oggi si portano dietro WebAssembly, che esegue quegli stessi codec
+      compilati a velocità quasi nativa, WebCodecs, che mette a disposizione
+      l'encoder video hardware già presente nel tuo dispositivo, e un'API Canvas
+      che decodifica e ricodifica immagini direttamente. Il lavoro per cui
+      serviva un server, adesso, gira sul dispositivo che il file ce l'ha già.
     </p>
     <p>
-      Parecchi strumenti caricano ancora, e ci sono motivi onesti: una catena
-      esistente che nessuno vuole riscrivere, un formato senza decodificatore lato
-      browser, un lavoro davvero troppo pesante per un telefono. C'è anche un
-      motivo meno onesto, ed è che è sul server che vivono gli account, le quote e
-      i piani a pagamento. Uno strumento che gira interamente nel tuo browser è
-      difficile da contabilizzare.
+      Parecchi strumenti caricano ancora, e a volte per ragioni oneste: una
+      pipeline già in piedi che nessuno ha voglia di riscrivere, un formato per
+      cui nel browser un decodificatore non esiste, un lavoro davvero troppo
+      pesante per un telefono. E c'è anche una ragione meno onesta: è sul server
+      che vivono gli account, le quote e gli abbonamenti, e uno strumento che
+      gira per intero dentro il tuo browser è difficile da mettere a contatore.
     </p>
   </section>
 
   <section>
     <h2>Quattro verifiche che puoi fare da solo</h2>
     <p>
-      Funzionano su qualunque strumento, questo compreso. Nessuna richiede di
-      credere a nessuno sulla parola, e la prima richiede una decina di secondi.
+      Valgono per qualunque strumento, questo compreso. Nessuna ti chiede di
+      credere a qualcuno sulla parola, e la prima porta via una decina di
+      secondi.
     </p>
 
-    <h3>1. Stacca la spina</h3>
+    <h3>1. Stacca la connessione</h3>
     <p>
       Carica la pagina, poi spegni il wi-fi o stacca il cavo, e prova a usarla.
-      Uno strumento che fa il lavoro nel tuo browser continua esattamente come
-      prima. Uno strumento che carica si ferma subito, perché la cosa che faceva
-      il lavoro non è più raggiungibile.
+      Uno strumento che il lavoro lo fa nel tuo browser continua esattamente come
+      prima; uno strumento che carica si ferma subito, perché la cosa che
+      lavorava non è più raggiungibile.
     </p>
     <p>
-      È la prova più forte che ci sia, e la più difficile da falsificare, perché
-      non si può rispondere con una formulazione. O la conversione si completa
-      senza rete o non si completa.
+      È la prova più forte che ci sia, ed è la più difficile da aggirare, perché
+      non ci si può rispondere con una frase scritta bene: o la conversione
+      arriva in fondo senza rete, o non ci arriva.
     </p>
 
     <h3>2. Guarda la scheda Rete</h3>
     <p>
-      Apri gli strumenti di sviluppo del tuo browser, scegli Rete, poi usa lo
-      strumento. Ogni richiesta che la pagina fa è elencata con la sua
-      dimensione. Se la tua foto da 4&nbsp;MB è stata caricata, in quell'elenco
-      c'è una richiesta da 4&nbsp;MB. Se la cosa più grande che esce dalla pagina
-      sono qualche kilobyte di pubblicità, non lo è stata.
+      Apri gli strumenti di sviluppo del browser, vai su Rete e poi usa lo
+      strumento: ogni richiesta che la pagina fa compare in elenco con la propria
+      dimensione. Se la tua foto da 4&nbsp;MB è stata caricata, in
+      quell'elenco c'è una richiesta da 4&nbsp;MB; se la cosa più grossa che esce
+      dalla pagina sono pochi kilobyte di pubblicità, non lo è stata.
     </p>
     <p>
-      Ordina per dimensione e guarda in cima. Non ti serve capire le richieste;
-      ti serve accorgerti se una di loro è della dimensione del tuo file.
+      Ordina per dimensione e guarda in cima. Non ti serve capire le richieste,
+      ti serve accorgerti se una di esse è grande quanto il tuo file.
     </p>
 
     <h3>3. Leggi la Content-Security-Policy</h3>
     <p>
-      Guarda il sorgente della pagina e cerca
-      <code>Content-Security-Policy</code>, vicino alla cima. È l'elenco degli
-      indirizzi che quella pagina può contattare, e a farlo rispettare è il tuo
-      browser e non le buone intenzioni del sito &mdash; una richiesta verso
-      qualcosa che non è nell'elenco viene rifiutata, qualunque cosa provi a fare
-      il codice.
+      Apri il sorgente della pagina e cerca <code>Content-Security-Policy</code>,
+      che sta vicino all'inizio. È l'elenco degli indirizzi che quella pagina può
+      contattare, e a farlo rispettare è il tuo browser, non le buone intenzioni
+      del sito: una richiesta verso qualcosa che nell'elenco non c'è viene
+      rifiutata, qualunque cosa provi a fare il codice.
     </p>
     <p>
-      La direttiva che conta è <code>connect-src</code>, che regola dove la
-      pagina può mandare dati. Se nomina un indirizzo appartenente al sito su cui
-      ti trovi, la pagina può mandarci il tuo file. Se non nomina niente, o
-      nomina solo terze parti come una rete pubblicitaria, non può.
+      La direttiva che conta è <code>connect-src</code>, che decide dove la
+      pagina può mandare dati. Se lì compare un indirizzo del sito su cui ti
+      trovi, la pagina il tuo file te lo può spedire; se non compare niente, o
+      compaiono solo terze parti come una rete pubblicitaria, non può.
     </p>
     <p>
       Una pagina senza alcuna Content-Security-Policy non è la prova di niente di
-      brutto. Vuol dire solo che questa particolare verifica non ha niente da
-      dirti.
+      brutto: vuol dire soltanto che questa verifica, lì, non ha niente da dirti.
     </p>
 
     <h3>4. Leggi il codice</h3>
     <p>
-      La meno comoda, la più conclusiva. Se uno strumento pubblica il proprio
-      sorgente e lo serve senza un passaggio di compilazione, i file che il tuo
-      browser ha recuperato sono i file che puoi leggere. Cercaci
+      La più scomoda e la più definitiva. Se uno strumento pubblica il proprio
+      sorgente e lo serve senza passaggi di compilazione, i file che il tuo
+      browser ha scaricato sono esattamente i file che puoi leggere. Cercaci
       <code>fetch</code>, <code>XMLHttpRequest</code> e <code>sendBeacon</code>
-      &mdash; i tre modi in cui una pagina può mandare qualcosa &mdash; e guarda
-      cosa gli viene passato.
+      &mdash; i tre modi che una pagina ha per mandare via qualcosa &mdash; e
+      guarda cosa gli viene passato.
     </p>
     <p>
-      Quasi nessuno lo farà. Conta lo stesso che sia possibile, perché
+      Non lo farà quasi nessuno. Conta lo stesso che sia possibile farlo, perché
       un'affermazione che nessuno è in grado di verificare non è davvero
       un'affermazione.
     </p>
@@ -152,112 +151,111 @@
   <section>
     <h2>Cosa non vuol dire «gira nel tuo browser»</h2>
     <p>
-      Vale la pena essere precisi, perché l'espressione viene usata alla leggera
-      e questo sito deve tenersi allo stesso standard che sta proponendo.
+      Qui conviene essere precisi, perché l'espressione si usa con troppa
+      leggerezza, e questo sito deve reggere lo stesso metro che sta proponendo.
     </p>
     <ul>
       <li>
         <strong>Non vuol dire nessuna richiesta.</strong> La pagina stessa è
         arrivata dalla rete, e quasi tutti gli strumenti gratuiti hanno
-        pubblicità o statistiche che parlano con qualcuno. L'affermazione
+        pubblicità o statistiche che con qualcuno parlano. L'affermazione
         riguarda il tuo <em>file</em>, non il traffico in generale.
       </li>
       <li>
-        <strong>Non nasconde il tuo indirizzo IP.</strong> Lo vede ogni sito che
-        visiti, questo compreso. L'elaborazione locale riguarda il contenuto dei
-        tuoi file, non l'anonimato.
+        <strong>Non nasconde il tuo indirizzo IP.</strong> Lo vede qualunque sito
+        tu visiti, questo compreso. L'elaborazione in locale riguarda il
+        contenuto dei tuoi file, non l'anonimato.
       </li>
       <li>
-        <strong>Non sopravvive a una funzione che recupera qualcosa.</strong>
-        Uno strumento che ti lascia incollare un indirizzo web deve contattare
-        quell'indirizzo, e quel server viene a sapere il tuo IP e cosa hai
-        chiesto. È insito nella funzione, non un suo difetto &mdash; ma è
-        un'eccezione vera e uno strumento dovrebbe dirlo chiaramente invece di
-        arrotondarla.
+        <strong>Non regge se c'è una funzione che va a prendere qualcosa
+        online.</strong> Uno strumento che ti lascia incollare un indirizzo web
+        quell'indirizzo lo deve contattare, e quel server viene a sapere il tuo
+        IP e cosa hai chiesto. Fa parte di come è fatta la funzione, non è un suo
+        difetto, ma resta un'eccezione vera, che uno strumento dovrebbe dire
+        chiaramente invece di far sparire nella media.
       </li>
       <li>
         <strong>Non è la stessa cosa di «cancelliamo i tuoi file».</strong> La
-        seconda frase riguarda quello che un'azienda sceglie di fare. La prima
-        riguarda quello che è tecnicamente possibile. Solo una delle due è
-        verificabile.
+        seconda frase parla di quello che un'azienda decide di fare, la prima di
+        quello che è tecnicamente possibile. Solo una delle due si può
+        verificare.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Quando caricare va davvero bene</h2>
+    <h2>Quando caricare va benissimo</h2>
     <p>
-      Questo non è un ragionamento per cui ogni caricamento è un errore. Manda il
-      file quando il contenuto non è delicato e il lavoro è più facile così;
-      quando il lavoro è davvero troppo pesante per il tuo dispositivo; quando il
-      formato non ha un decodificatore lato browser; o quando stai usando un
-      servizio con cui hai già un rapporto e di cui hai davvero letto le
-      condizioni.
+      Non è che ogni caricamento sia un errore. Manda pure il file quando il
+      contenuto non è delicato e così fai prima; quando il lavoro è davvero
+      troppo pesante per il tuo dispositivo; quando per quel formato un
+      decodificatore nel browser non c'è; o quando stai usando un servizio con
+      cui hai già un rapporto e di cui le condizioni le hai lette sul serio.
     </p>
     <p>
-      Stai più attento quando il file contiene qualcosa che non pubblicheresti:
-      documenti d'identità, esami medici, contratti, qualunque cosa con un
-      indirizzo o un volto che non avevi intenzione di condividere, o una foto di
-      cui non hai guardato i dati di posizione. Per quelli, uno strumento che
-      puoi verificare è da preferire a uno di cui ti devi fidare &mdash; non
-      perché quello di cui ti fidi sia probabile che ti tradisca, ma perché con
-      quello verificabile la domanda non si pone.
+      Stai più attento quando nel file c'è qualcosa che non pubblicheresti:
+      documenti d'identità, esami medici, contratti, qualsiasi cosa con un
+      indirizzo o un volto che non volevi condividere, o una foto di cui i dati
+      di posizione non li hai guardati. Per quelli, uno strumento che puoi
+      verificare è meglio di uno di cui ti devi fidare &mdash; non perché sia
+      probabile che quello di cui ti fidi ti tradisca, ma perché con quello
+      verificabile la domanda non te la devi proprio porre.
     </p>
   </section>
 
   <section>
-    <h2>Come risponde questo sito a quelle quattro verifiche</h2>
+    <h2>Come se la cava questo sito con quelle quattro verifiche</h2>
     <p>
-      Sarebbe una guida strana quella che ti dice di verificare e poi chiede
-      un'esenzione. Quindi, in ordine:
+      Sarebbe una guida curiosa quella che ti dice di verificare e poi chiede di
+      essere esentata. Quindi, in ordine:
     </p>
     <ul>
       <li>
-        <strong>Stacca la spina.</strong> Apri uno strumento qualsiasi di qui,
-        stacca la connessione, e continua a funzionare. La pagina di ogni
+        <strong>Stacca la connessione.</strong> Apri uno strumento qualsiasi di
+        qui, stacca la connessione, e continua a funzionare. La pagina di ogni
         strumento ha un indicatore dal vivo che ti dice se in questo momento sei
-        online, così puoi guardarlo cambiare.
+        online, così lo puoi guardare cambiare.
       </li>
       <li>
-        <strong>Scheda Rete.</strong> Converti qualcosa e leggi l'elenco. Non c'è
-        niente che porti con sé il tuo file, una sua miniatura, il suo nome, la
-        sua dimensione, o qualunque cosa ci sia stata letta dentro. Su questo
-        sito non esiste alcun evento di analytics personalizzato che abbia
-        qualcosa del genere da mandare.
+        <strong>Scheda Rete.</strong> Converti qualcosa e leggi l'elenco: non c'è
+        una sola richiesta che si porti dietro il tuo file, una sua miniatura, il
+        suo nome, la sua dimensione o qualunque cosa ci sia stata letta dentro.
+        Su questo sito non esiste alcun evento di analytics personalizzato che
+        avrebbe qualcosa del genere da mandare.
       </li>
       <li>
         <strong>Content-Security-Policy.</strong> Sta in cima al sorgente di ogni
         pagina. <code>connect-src</code> nomina gli endpoint pubblicitari e di
         misurazione di Google e il pulsante delle donazioni, e nient'altro.
-        <strong>Nessun indirizzo di quell'elenco appartiene a questo
-        sito</strong>, perché questo sito non ha un server &mdash; sono file
-        statici. Non c'è nessun posto dove un file potrebbe essere mandato, anche
-        se qualcosa ci provasse.
+        <strong>Nessuno degli indirizzi di quell'elenco è nostro</strong>,
+        perché questo sito un server non ce l'ha: sono file statici. Non esiste
+        un posto in cui un file possa essere mandato, nemmeno se qualcosa ci
+        provasse.
       </li>
       <li>
         <strong>Codice.</strong> Ogni riga è
         <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">pubblica</a>.
         La compilazione toglie i commenti e gli spazi e nient'altro, e la puoi
-        eseguire tu e confrontare il risultato con quello che viene servito.
+        eseguire tu, confrontando il risultato con quello che viene servito.
       </li>
     </ul>
     <p>
-      Le eccezioni, dichiarate invece che sepolte: questo sito ospita pubblicità
+      Le eccezioni, dichiarate invece che nascoste: questo sito ospita pubblicità
       di Google e un contatore delle visite, che parlano entrambi con Google e a
-      nessuno dei due viene passato niente sui tuoi file; e lo strumento
-      <a href="../../immagini-in-video/">Immagini in video</a> può recuperare
-      un'immagine da un indirizzo che incolli tu, il che vuol dire che quel
-      server vede il tuo IP. La <a href="../../privacy/">pagina sulla
-      privacy</a> le espone entrambe per intero.
+      cui dei tuoi file non viene passato niente; e lo strumento
+      <a href="../../immagini-in-video/">Immagini in video</a> può andare a
+      prendere un'immagine da un indirizzo che incolli tu, il che significa che
+      quel server vede il tuo IP. La <a href="../../privacy/">pagina sulla
+      privacy</a> le racconta tutte e due per esteso.
     </p>
     <p>
       Ogni strumento di qui funziona così: un
       <a href="../../comprimere-immagine/">compressore di immagini</a> che
-      centra un peso che dici tu, un
+      centra il peso che gli dici tu, un
       <a href="../../ritagliare-video/">ritagliatore di video</a>, un
       <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione EXIF</a>
-      per i dati nascosti descritti più su in questa pagina,
-      <a href="../../immagini-in-video/">immagini in video</a>, e
+      per i dati nascosti di cui si parla più su,
+      <a href="../../immagini-in-video/">immagini in video</a> e
       <a href="../../immagini-in-pdf/">immagini in PDF</a>. Tutti gratuiti,
       nessun account, e nessuno di loro ha un posto dove mandare i tuoi file.
     </p>

--- a/locales/it/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/it/pages/guides/is-it-safe-to-upload-files.toml
@@ -4,14 +4,14 @@
 
 nav = "È sicuro caricare i file?"
 title = "È sicuro caricare i propri file sui convertitori online?"
-description = "Quasi tutti i convertitori online mandano il tuo file a un server. Cosa vuol dire, cosa gli succede là, e quattro verifiche che ti dicono se uno strumento ne ha davvero bisogno."
+description = "Quasi tutti i convertitori online mandano il tuo file a un server. Cosa comporta, cosa gli succede una volta arrivato e quattro verifiche che ti dicono se quel server serviva davvero."
 heading = "È sicuro caricare i propri file sui convertitori online?"
 lede = """
-    Di solito la risposta onesta è «probabilmente sì, ma non lo puoi
-    verificare». Qui c'è cosa fa davvero un caricamento al tuo file, perché
-    quasi tutti gli strumenti lo fanno ancora, e quattro prove che ti dicono se
-    quello che hai davanti ne ha bisogno."""
+    La risposta onesta, di solito, è «probabilmente sì, ma non lo puoi
+    verificare». Qui trovi cosa comporta davvero un caricamento per il tuo
+    file, perché quasi tutti gli strumenti continuano a chiederlo e quattro
+    prove che ti dicono se quello che hai davanti ne ha bisogno."""
 updated = "20 agosto 2026"
 og_title = "È sicuro caricare i propri file sui convertitori online?"
-og_description = "Cosa succede a un file che carichi su un convertitore, perché quasi tutti gli strumenti lo chiedono ancora, e quattro verifiche che puoi fare da solo."
+og_description = "Cosa succede a un file che carichi su un convertitore, perché quasi tutti gli strumenti lo chiedono ancora e quattro verifiche che puoi fare da solo."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/make-a-pdf-smaller.html
+++ b/locales/it/pages/guides/make-a-pdf-smaller.html
@@ -1,232 +1,238 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Apri il <a href="../../comprimere-pdf/">compressore di PDF</a>, trascinaci
-      dentro il documento, e guarda cosa ti dice prima di cambiare qualcosa.
-      Legge il file e mostra dove sta davvero il peso &mdash; immagini,
-      caratteri, testo e disegno, e tutto quello a cui nel documento non fa più
-      riferimento nessuno. Quella schermata di solito risponde alla domanda.
+      Apri il <a href="../../comprimere-pdf/">Compressore di PDF</a>, trascina
+      dentro il documento e guarda cosa ti dice prima di toccare qualsiasi cosa.
+      Lo strumento legge il file e ti mostra dove sta davvero il peso &mdash;
+      immagini, caratteri, testo e disegno, più tutto quello a cui nel documento
+      non fa più riferimento nessuno &mdash; e quella schermata, di solito,
+      risponde già alla domanda.
     </p>
     <p>
-      Se quasi tutto il peso sono immagini, puoi aspettarti un grande risparmio.
-      Se sono caratteri e testo, no, e non può nessuno strumento. Quale dei due
-      hai in mano è tutta la storia, e vale dieci secondi di sguardo.
+      Se il peso è quasi tutto in immagini, aspettati un bel risparmio. Se sono
+      caratteri e testo, no, e non ci riesce nessuno strumento. Quale dei due
+      documenti hai fra le mani è tutta la storia, e per capirlo bastano dieci
+      secondi.
     </p>
   </section>
 
   <section>
     <h2>Dove sta davvero il peso di un PDF</h2>
     <p>
-      Un PDF è un contenitore per parecchi tipi diversi di cosa, e non si
-      comprimono allo stesso modo.
+      Un PDF è un contenitore che tiene insieme cose molto diverse fra loro, e
+      quelle cose non si comprimono allo stesso modo.
     </p>
     <ul>
       <li>
-        <strong>Immagini.</strong> Fotografie e scansioni. Quasi sempre il grosso
-        di un PDF pesante, e l'unica parte con vero spazio dentro.
+        <strong>Le immagini.</strong> Fotografie e scansioni: quasi sempre il
+        grosso di un PDF pesante, e l'unica parte in cui ci sia davvero
+        margine.
       </li>
       <li>
-        <strong>Caratteri incorporati.</strong> Un carattere intero può pesare
-        centinaia di kilobyte; un sottoinsieme dei soli segni davvero usati pesa
-        molto meno. In ogni caso, sono stati compressi da ciò che ha prodotto il
-        file.
+        <strong>I caratteri incorporati.</strong> Un carattere intero può
+        pesare centinaia di kilobyte, mentre un sottoinsieme con i soli segni
+        davvero usati pesa molto meno. In ogni caso, li ha già compressi il
+        programma che ha prodotto il file.
       </li>
       <li>
-        <strong>Testo e disegno vettoriale.</strong> Istruzioni invece di pixel:
-        traccia questa linea, metti questa parola qui. Già compatti, e già
-        compressi.
+        <strong>Il testo e il disegno vettoriale.</strong> Istruzioni invece che
+        pixel: traccia questa linea, metti questa parola qui. Sono già compatti
+        e sono già compressi.
       </li>
       <li>
-        <strong>Oggetti a cui non punta più niente.</strong> I PDF li accumulano.
-        Modificare un documento spesso aggiunge la modifica in coda invece di
-        riscrivere il file, quindi una vecchia versione di una pagina può restare
-        lì dentro all'infinito. Riimpacchettare il file li butta.
+        <strong>Gli oggetti che ormai non usa più nessuno.</strong> I PDF li
+        accumulano: modificare un documento spesso aggiunge la modifica in coda
+        invece di riscrivere il file, e così la vecchia versione di una pagina
+        può restare lì dentro per sempre. Ricompattare il file se ne libera.
       </li>
     </ul>
     <p>
-      Quindi i due documenti che la gente porta a un compressore di PDF hanno
-      prospettive completamente diverse. Un documento scansionato è in sostanza
-      una pila di fotografie, e di solito esce dal 60 al 90% più leggero. Un
-      contratto, una tesi o un rapporto esportato sono testo, disegno e
-      caratteri &mdash; tutti già compressi dal software che li ha scritti
-      &mdash; e lì il risparmio è di solito di qualche punto percentuale, dal
-      riimpacchettamento e dal buttare quello a cui nessuno fa riferimento.
+      I due documenti che di solito arrivano a un compressore di PDF, quindi,
+      partono da situazioni completamente diverse. Un documento scansionato è in
+      sostanza una pila di fotografie, e in genere esce dal 60 al 90% più
+      leggero. Un contratto, una tesi o un report esportato sono invece testo,
+      disegno e caratteri, tutta roba già compressa dal software che l'ha
+      scritta, e lì il risparmio si misura in qualche punto percentuale, quello
+      che si guadagna ricompattando e buttando via ciò che non serve più a
+      nessuno.
     </p>
     <p>
-      Qualunque strumento prometta «fino al 90% più leggero» senza guardare il
-      tuo file sta citando il caso migliore del primo tipo per il secondo.
+      Uno strumento che promette «fino al 90% in meno» senza aver guardato il
+      tuo file ti sta citando il caso migliore del primo tipo di documento per
+      venderti il secondo.
     </p>
   </section>
 
   <section>
     <h2>Cosa c'entrano i DPI</h2>
     <p>
-      Un PDF non contiene solo un'immagine; registra quanto grande viene
-      disegnata quell'immagine sulla pagina. Il che ti dà qualcosa di più utile
-      del numero di pixel: la risoluzione effettiva.
+      Un PDF non contiene soltanto un'immagine: registra anche quanto grande
+      quell'immagine viene disegnata sulla pagina. Ed è un'informazione più
+      utile del numero di pixel, perché ti dà la risoluzione effettiva.
     </p>
     <p>
       Una scansione larga 4000 pixel stesa su venti centimetri di carta porta
       500 pixel per pollice. Uno schermo ne mostra un centinaio. Una buona
-      stampante da ufficio lavora a 300 e non sa farsene di molto di più. Tutto
-      quello che sta sopra è dettaglio che niente nel futuro del documento
-      mostrerà mai &mdash; ed è di solito la maggior parte del file.
+      stampante da ufficio lavora a 300 e di più non saprebbe che farsene. Tutto
+      quello che sta sopra è dettaglio che nessuno, nel futuro di quel
+      documento, vedrà mai &mdash; ed è di solito la parte più grossa del file.
     </p>
     <p>
-      È per questo che un compressore di PDF sensato chiede dei DPI invece di
-      una percentuale di qualità. Butta per primi i pixel sopra la tua cifra,
-      perché quelli non costano niente che qualcuno possa vedere, e solo dopo
-      comincia a spendere qualità vera.
+      Per questo un compressore di PDF fatto con la testa ti chiede dei DPI e
+      non una percentuale di qualità: butta via per primi i pixel sopra la cifra
+      che gli hai dato, perché quelli non costano niente che qualcuno possa
+      vedere, e solo dopo comincia a spendere qualità vera.
     </p>
     <p>
-      Regola spannometrica: <strong>150 DPI</strong> per un documento che verrà
-      letto sullo schermo, <strong>200&ndash;300</strong> per qualcosa che verrà
-      stampato, <strong>72&ndash;100</strong> per una bozza che nessuno terrà.
-      Misurare rispetto a quanto grande viene disegnata l'immagine è anche il
-      motivo per cui un logo messo piccolo non viene trattato come una scansione
-      a pagina intera &mdash; il logo è già vicino alla propria risoluzione
-      effettiva e non c'è niente da prendere.
+      Come regola spannometrica: <strong>150 DPI</strong> per un documento che
+      verrà letto sullo schermo, <strong>200&ndash;300</strong> per qualcosa che
+      finirà stampato, <strong>72&ndash;100</strong> per una bozza che nessuno
+      conserverà. Ragionare su quanto grande viene disegnata l'immagine è anche
+      il motivo per cui un logo messo in piccolo non viene trattato come una
+      scansione a pagina intera: il logo è già vicino alla propria risoluzione
+      effettiva, e da lì non c'è niente da prendere.
     </p>
   </section>
 
   <section>
-    <h2>Cosa dovrebbe e cosa non dovrebbe toccare una compressione</h2>
+    <h2>Cosa una compressione dovrebbe toccare, e cosa no</h2>
     <p>
-      Le immagini vengono ricodificate, quindi quelle perdono un po'. Tutto il
-      resto non dovrebbe essere toccato affatto, e vale la pena controllare che
-      lo strumento che usi rispetti la regola:
+      Le immagini vengono ricodificate, e quindi qualcosa lo perdono. Tutto il
+      resto non andrebbe toccato per niente, e vale la pena controllare che lo
+      strumento che usi la regola la rispetti.
     </p>
     <ul>
       <li>
         <strong>Il testo resta testo.</strong> Selezionabile, cercabile,
-        copiabile. Un compressore che appiattisce le pagine in immagini
-        produrrà un file molto leggero e distruggerà il documento &mdash; non lo
-        puoi cercare, gli screen reader non lo possono leggere, e non si può
-        tornare indietro.
+        copiabile. Un compressore che appiattisce le pagine in immagini ti dà un
+        file leggerissimo e ti distrugge il documento: non lo cerchi più, gli
+        screen reader non lo leggono più, e indietro non si torna.
       </li>
       <li>
-        <strong>I caratteri restano interi.</strong> Sostituire i caratteri
-        cambia come si presenta il documento sul dispositivo di qualcun altro,
-        che è l'unica cosa che il PDF esiste per impedire.
+        <strong>I caratteri restano interi.</strong> Sostituirli cambia
+        l'aspetto del documento sul dispositivo di qualcun altro, che è
+        esattamente la cosa che il PDF esiste per impedire.
       </li>
       <li>
-        <strong>Il disegno vettoriale viene copiato tale e quale.</strong> È già
-        leggero, e rasterizzarlo lo renderebbe insieme più pesante e peggiore.
+        <strong>Il disegno vettoriale passa dall'altra parte tale e
+        quale.</strong> Pesa già poco, e rasterizzarlo lo renderebbe insieme più
+        pesante e peggiore.
       </li>
       <li>
         <strong>Moduli, link, segnalibri, struttura di accessibilità e allegati
-        passano dall'altra parte.</strong> Sono cose facili da perdere in una
-        riscrittura e di cui raramente ci si accorge finché a qualcuno non ne
+        arrivano dall'altra parte.</strong> Sono cose che in una riscrittura si
+        perdono facilmente, e di cui ci si accorge solo quando a qualcuno ne
         serve una.
       </li>
     </ul>
     <p>
-      Una regola collegata che un compressore dovrebbe seguire e che molti non
+      C'è poi una regola che un compressore dovrebbe seguire e che parecchi non
       seguono: se ricodificare un'immagine non la fa uscire davvero più leggera
-      dell'originale, rimetti dentro i byte originali. Peggiorare un'immagine
-      senza risparmio è il caso di pura perdita, e succede più spesso di quanto
-      si creda su immagini che erano già compresse bene.
+      dell'originale, allora rimetti dentro i byte di partenza. Peggiorare
+      un'immagine senza risparmiare niente è perdita e basta, e capita più
+      spesso di quanto si creda su immagini che erano già compresse bene.
     </p>
   </section>
 
   <section>
     <h2>Le immagini che non si possono comprimere</h2>
     <p>
-      Alcune immagini dentro un PDF vengono saltate, e un buon strumento le
-      nomina invece di lasciarle in silenzio fuori dall'aritmetica:
+      Alcune immagini dentro un PDF vengono saltate, e uno strumento serio te le
+      nomina invece di lasciarle fuori dal conto senza dire niente.
     </p>
     <ul>
       <li>
-        <strong>Immagini JPEG&nbsp;2000, JBIG2 e in codifica fax (CCITT).</strong>
-        Nessun browser si porta dietro un decodificatore per nessuna delle tre,
-        quindi passano intatte. Le ultime due sono in bianco e nero e di solito
-        sono già vicine al minimo.
+        <strong>Le immagini JPEG&nbsp;2000, JBIG2 e in codifica fax
+        (CCITT).</strong> Nessun browser si porta dietro un decodificatore per
+        nessuna delle tre, quindi passano intatte. Le ultime due sono in bianco
+        e nero e di solito sono già vicine al minimo possibile.
       </li>
       <li>
-        <strong>Immagini CMYK.</strong> Lasciate stare di proposito.
-        Ricodificarle rischia di spostare i colori che produrrebbe una
-        stampante, che è una cosa sorprendente da fare a un documento che
+        <strong>Le immagini CMYK.</strong> Lasciate stare di proposito:
+        ricodificarle rischia di spostare i colori che uscirebbero da una
+        stampante, il che sarebbe una brutta sorpresa da fare a un documento che
         qualcuno sta per stampare.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Cose da provare prima di comprimere</h2>
+    <h2>Cosa provare prima di comprimere</h2>
     <p>
-      A volte il file è pesante per un motivo a cui la compressione è la risposta
-      sbagliata.
+      A volte il file è pesante per una ragione a cui la compressione è la
+      risposta sbagliata.
     </p>
     <p>
-      <strong>È stato scansionato quando non ce n'era bisogno?</strong> Un
-      documento stampato e poi scansionato è una pila di fotografie di testo. Se
+      <strong>È stato scansionato quando non serviva?</strong> Un documento
+      stampato e poi scansionato è una pila di fotografie di testo. Se
       l'originale esiste ancora da qualche parte come documento, esportarlo in
-      PDF produrrà un file di una frazione del peso che è anche cercabile.
+      PDF ti dà un file che pesa una frazione e che per giunta è cercabile.
     </p>
     <p>
       <strong>È stato esportato con impostazioni da stampa?</strong> I programmi
-      di videoscrittura e di grafica esportano spesso in qualità di stampa per
-      impostazione predefinita. Riesportare per lo schermo dal file sorgente di
-      solito batte il comprimere l'esportazione.
+      di videoscrittura e di grafica esportano spesso in qualità di stampa senza
+      chiedertelo. Riesportare per lo schermo partendo dal file sorgente
+      funziona quasi sempre meglio che comprimere l'esportazione.
     </p>
     <p>
       <strong>Deve per forza essere un file solo?</strong> Il limite di una mail
-      vale per messaggio. Dividere un documento da 200 pagine in capitoli a
-      volte è la soluzione onesta.
+      vale per messaggio, quindi dividere in capitoli un documento da 200 pagine
+      a volte è la soluzione più onesta che ci sia.
     </p>
   </section>
 
   <section>
     <h2>I file cifrati, e perché un compressore dovrebbe rifiutarli</h2>
     <p>
-      Un PDF protetto da password viene rifiutato dallo strumento di qui, ed è
-      voluto invece che una funzione mancante &mdash; anche quando la password è
-      vuota, che è il modo in cui salvano moltissimi scanner e fotocopiatrici.
+      Un PDF protetto da password lo strumento di qui lo rifiuta, e non perché
+      gli manchi una funzione: è una scelta. Vale anche quando la password è
+      vuota, che è il modo in cui salvano moltissimi scanner e moltissime
+      fotocopiatrici.
     </p>
     <p>
       Togliere la protezione a un documento è un lavoro diverso dal comprimerlo.
       Uno strumento che lo facesse in silenzio starebbe facendo qualcosa che non
-      hai chiesto, a un file che qualcuno aveva deliberatamente bloccato, e ti
-      restituirebbe una copia che non ha più la proprietà che gli si voleva
-      dare. Se è quello che vuoi, togli prima tu la protezione, di proposito.
+      gli hai chiesto, su un file che qualcuno aveva bloccato apposta, e ti
+      restituirebbe una copia che quella proprietà non ce l'ha più. Se è proprio
+      quello che vuoi, la protezione toglila prima tu, di tua volontà.
     </p>
   </section>
 
   <section>
     <h2>Controllare il risultato</h2>
     <p>
-      Aprilo. Guarda le immagini a ingrandimento pieno, controlla che il testo
-      sia ancora selezionabile, e verifica il numero di pagine.
+      Aprilo: guarda le immagini a ingrandimento pieno, verifica che il testo si
+      selezioni ancora e conta le pagine.
     </p>
     <p>
-      Lo strumento di qui fa l'ultima cosa al posto tuo prima di offrirti il
-      file: riapre il documento che ha appena scritto e ne conta le pagine, sul
-      tuo dispositivo. Scrive anche in PDF 1.5, che ogni lettore uscito dal 2003
-      in poi capisce, quindi «si apre sul mio computer» è un ragionevole
-      surrogato di «si apre sul loro».
+      L'ultima cosa lo strumento la fa già al posto tuo prima di darti il file:
+      riapre il documento che ha appena scritto e ne conta le pagine, sul tuo
+      dispositivo. Scrive per giunta in PDF 1.5, che capisce qualunque lettore
+      uscito dal 2003 in poi, e quindi «sul mio computer si apre» è una
+      ragionevole garanzia che si aprirà anche sul loro.
     </p>
   </section>
 
   <section>
-    <h2>Perché questo non ha bisogno di un server</h2>
+    <h2>Perché qui non serve un server</h2>
     <p>
       Comprimere un PDF sembra un lavoro da server, e per quasi tutta la vita
-      del web lo è stato. Quello che comporta davvero è analizzare la struttura
-      del file, trovare i flussi delle immagini, decodificarli e ricodificarli
-      con i codec che un browser si porta già dietro, e riscrivere il documento.
-      Tutto questo ormai gira in un browser.
+      del web lo è stato. In concreto vuol dire leggere la struttura del file,
+      trovare i flussi delle immagini, decodificarli e ricodificarli con i codec
+      che il browser si porta già dietro, e riscrivere il documento: tutte cose
+      che ormai in un browser girano.
     </p>
     <p>
-      Il che conta per questo tipo di file più che per quasi tutti gli altri,
-      per quello che la gente comprime: contratti, referti medici, estratti
-      conto, documenti d'identità, dichiarazioni dei redditi. Lo strumento di
-      qui non ha proprio alcuna funzione di rete, e la
+      Cosa che per questo tipo di file conta più che per quasi ogni altro, visto
+      cosa la gente comprime: contratti, referti medici, estratti conto,
+      documenti d'identità, dichiarazioni dei redditi. Lo strumento di qui non
+      ha proprio alcuna funzione di rete, e la
       <code>Content-Security-Policy</code> della pagina nomina tutti gli
-      indirizzi che può contattare, nessuno dei quali appartiene a questo sito.
-      Caricala, stacca la spina, e comprimi qualcosa lo stesso.
+      indirizzi che può contattare, nessuno dei quali è nostro. Aprila, stacca
+      la connessione e comprimi qualcosa lo stesso.
     </p>
     <p>
       <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
-      file sui convertitori online?</a> propone altre tre verifiche come quella.
+      file sui convertitori online?</a> ne propone altre tre come questa.
     </p>
   </section>

--- a/locales/it/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/it/pages/guides/make-a-pdf-smaller.toml
@@ -3,15 +3,15 @@
 #
 
 nav = "Alleggerire un PDF"
-title = "Come alleggerire un PDF (e perché alcuni non si rimpiccioliscono)"
-description = "Dove sta davvero il peso di un PDF, perché una scansione si comprime dell'80% e un contratto quasi non si muove, cosa vogliono dire qui i DPI, e cosa un compressore non dovrebbe mai fare al tuo documento."
-heading = "Come alleggerire un PDF, e perché alcuni non si rimpiccioliscono"
+title = "Come alleggerire un PDF (e perché alcuni non calano)"
+description = "Dove sta davvero il peso di un PDF, perché una scansione cala dell'80% e un contratto non si muove, cosa c'entrano i DPI e cosa un compressore non dovrebbe mai fare al tuo documento."
+heading = "Come alleggerire un PDF, e perché alcuni non calano"
 lede = """
-    Un PDF che non entra nel limite di una mail è quasi sempre un PDF pieno di
-    immagini. Qui c'è come capire se il tuo lo è, quanto costa comprimerlo, e
-    perché qualunque strumento prometta una percentuale fissa non ha guardato il
-    tuo file."""
+    Il PDF che non entra nel limite di una mail è quasi sempre un PDF pieno di
+    immagini. Qui trovi come capire se il tuo lo è, quanto costa comprimerlo e
+    perché uno strumento che ti promette una percentuale fissa il tuo file non
+    l'ha nemmeno guardato."""
 updated = "20 agosto 2026"
 og_title = "Come alleggerire un PDF"
-og_description = "Dove sta davvero il peso di un PDF, perché una scansione si rimpicciolisce e un contratto no, e cosa c'entrano i DPI."
+og_description = "Dove sta davvero il peso di un PDF, perché una scansione cala e un contratto no, e cosa c'entrano i DPI."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/it/pages/guides/remove-exif-and-gps-data.html
@@ -1,63 +1,65 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Apri il <a href="../../rimuovere-dati-exif/">visualizzatore e rimozione
-      EXIF</a>, trascinaci dentro le foto, e premi «Rimuovi tutti i metadati».
-      Ogni tag, i blocchi XMP e IPTC, i commenti e la miniatura incorporata se ne
-      vanno, su tutte le foto dell'elenco in una volta. L'immagine in sé non
-      viene toccata &mdash; non ricompressa, non decodificata, non cambiata di un
-      pixel.
+      Apri il <a href="../../rimuovere-dati-exif/">Visualizzatore e rimozione
+      EXIF</a>, trascina dentro le foto e premi «Rimuovi tutti i metadati». Se
+      ne vanno tutti i tag, i blocchi XMP e IPTC, i commenti e la miniatura
+      incorporata, su tutte le foto dell'elenco in un colpo solo. L'immagine,
+      invece, non viene toccata: non ricompressa, non decodificata, non cambiata
+      di un pixel.
     </p>
     <p>
-      Prima di farlo, vale la pena guardare cosa c'era là dentro. Di solito è più
-      di quanto la gente si aspetti, e quell'elenco è la ragione stessa per fare
-      tutto questo.
+      Prima di premere, però, vale la pena guardare cosa c'era là dentro. Di
+      solito è più roba di quanta ce ne si aspetti, e quell'elenco è esattamente
+      il motivo per cui si fa tutto questo.
     </p>
   </section>
 
   <section>
     <h2>Cosa c'è davvero dentro una foto</h2>
     <p>
-      Un JPEG non è solo un'immagine compressa. È un contenitore, e accanto
-      all'immagine stanno parecchi blocchi di informazioni che la tua fotocamera,
-      il tuo telefono o il tuo programma di ritocco ci hanno scritto.
+      Un JPEG non è soltanto un'immagine compressa: è un contenitore, e accanto
+      all'immagine ci stanno diversi blocchi di informazioni che la tua
+      fotocamera, il tuo telefono o il tuo programma di ritocco hanno scritto
+      lì dentro.
     </p>
     <ul>
       <li>
-        <strong>EXIF.</strong> Il principale. Marca e modello della fotocamera,
-        obiettivo, impostazioni di esposizione, ISO, la data e l'ora al secondo,
-        l'orientamento in cui l'immagine va mostrata, e &mdash; su un telefono
-        con i servizi di localizzazione attivi per la fotocamera &mdash; una
-        posizione GPS accurata a pochi metri. Spesso anche il numero di serie del
+        <strong>EXIF.</strong> Il blocco principale: marca e modello della
+        fotocamera, obiettivo, impostazioni di esposizione, ISO, data e ora al
+        secondo, l'orientamento con cui l'immagine va mostrata e &mdash; su un
+        telefono che ha la localizzazione attiva per la fotocamera &mdash; una
+        posizione GPS precisa a pochi metri. Spesso anche il numero di serie del
         corpo macchina.
       </li>
       <li>
-        <strong>GPS.</strong> Tecnicamente parte dell'EXIF, e vale la pena
-        nominarlo a parte perché è quello che conta di più. È scritto in gradi,
-        primi e secondi, un formato che riesce benissimo a non sembrare un
+        <strong>GPS.</strong> Tecnicamente fa parte dell'EXIF, ma vale la pena
+        nominarlo a parte perché è quello che pesa di più. È scritto in gradi,
+        primi e secondi, un formato che riesce benissimo a non somigliare a un
         indirizzo.
       </li>
       <li>
-        <strong>XMP.</strong> Un pacchetto di XML che scrivono i programmi di
-        ritocco. Può portare il tuo nome, il tuo software, valutazioni, parole
-        chiave, cronologia delle modifiche, e una copia di alcuni campi EXIF
-        &mdash; motivo per cui rimuovere solo l'EXIF non basta.
+        <strong>XMP.</strong> Un pacchetto di XML che ci scrivono i programmi di
+        ritocco. Può contenere il tuo nome, il software che hai usato,
+        valutazioni, parole chiave, la cronologia delle modifiche e una copia di
+        alcuni campi EXIF: ecco perché togliere solo l'EXIF non basta.
       </li>
       <li>
-        <strong>IPTC.</strong> Un blocco più vecchio con campi di didascalia,
-        firma, crediti e copyright, usato nella stampa e nella fotografia
+        <strong>IPTC.</strong> Un blocco più vecchio, con i campi di didascalia,
+        firma, crediti e copyright, usato nell'editoria e nella fotografia
         d'archivio.
       </li>
       <li>
-        <strong>La miniatura incorporata.</strong> Una piccola seconda copia
-        dell'immagine. Viene generata quando il file viene scritto, e non sempre
-        viene rigenerata quando l'immagine viene modificata &mdash; ed è così che
-        una foto ritagliata può viaggiare con una miniatura di quello che è stato
-        ritagliato via.
+        <strong>La miniatura incorporata.</strong> Una seconda copia in piccolo
+        dell'immagine, generata quando il file viene scritto e non sempre
+        rigenerata quando l'immagine viene modificata: è così che una foto
+        ritagliata può girare portandosi dietro la miniatura di quello che era
+        stato tagliato via.
       </li>
       <li>
-        <strong>La maker note.</strong> Un blocco non documentato di dati del
-        produttore. Nessuno fuori dal produttore sa tutto quello che c'è dentro.
+        <strong>La maker note.</strong> Un blocco di dati del produttore, non
+        documentato. Cosa ci sia davvero dentro, fuori dal produttore, non lo sa
+        nessuno.
       </li>
     </ul>
   </section>
@@ -65,162 +67,162 @@
   <section>
     <h2>Chi lo vede davvero</h2>
     <p>
-      È la parte su cui vale la pena essere precisi, perché sia la versione
-      allarmata sia quella sbrigativa sono sbagliate.
+      Qui conviene essere precisi, perché sbagliano sia la versione allarmata sia
+      quella sbrigativa.
     </p>
     <p>
-      <strong>Quasi tutti i grandi social network tolgono i metadati quando
-      pubblichi.</strong> Facebook, Instagram e X ricodificano le immagini
-      caricate e nel farlo buttano i tag. Non è una gentilezza &mdash; i dati
-      dalla loro parte se li tengono &mdash; ma vuol dire che una foto pubblicata
-      su quei servizi non consegna le proprie coordinate a chiunque la guardi.
+      <strong>Quasi tutti i grandi social tolgono i metadati quando
+      pubblichi.</strong> Facebook, Instagram e X ricodificano le immagini che
+      ricevono, e nel farlo buttano via i tag. Non è un favore che ti fanno,
+      perché dalla loro parte quei dati se li tengono, ma vuol dire che una foto
+      pubblicata lì le proprie coordinate non le consegna a chiunque passi.
     </p>
     <p>
-      <strong>Quasi tutto il resto li tiene.</strong> Un allegato di posta. Un
-      file mandato con quasi ogni applicazione di chat come «documento» invece
-      che come foto. Un'immagine su un forum, un annuncio di un mercatino, un
-      sito personale, un'unità condivisa, una segnalazione di bug, un ticket di
-      assistenza. In tutti questi casi il file arriva intatto, e chiunque lo
-      scarichi può leggerne i tag con strumenti che arrivano insieme al suo
-      sistema operativo.
+      <strong>Quasi tutto il resto se li tiene.</strong> Un allegato di posta. Un
+      file mandato con quasi tutte le chat come «documento» invece che come foto.
+      Un'immagine su un forum, un annuncio su un sito di compravendita, un sito
+      personale, una cartella condivisa, la segnalazione di un bug, un ticket di
+      assistenza. In tutti questi casi il file arriva intatto, e chi se lo scarica
+      può leggerne i tag con strumenti che gli sono arrivati insieme al sistema
+      operativo.
     </p>
     <p>
-      I rischi realistici sono banali più che drammatici: un annuncio fotografato
-      in casa, la foto di un bambino scattata a scuola, un account
-      apparentemente anonimo che pubblica foto che condividono tutte lo stesso
-      numero di serie della fotocamera, un «scattata la settimana scorsa» che era
-      di marzo.
+      I rischi concreti sono più banali che drammatici: l'annuncio fotografato in
+      casa, la foto di un bambino scattata a scuola, l'account in apparenza
+      anonimo le cui foto portano tutte lo stesso numero di serie della
+      fotocamera, lo «scattata la settimana scorsa» che era di marzo.
     </p>
   </section>
 
   <section>
-    <h2>Perché non risalvarla e basta?</h2>
+    <h2>Perché non basta risalvarla</h2>
     <p>
-      Risalvare una foto passando da un programma di ritocco o da un compressore
-      rimuove davvero i metadati &mdash; l'immagine viene decodificata in pixel e
-      ricodificata, e una tela piena di pixel non porta con sé alcun tag.
+      Risalvare una foto con un programma di ritocco o con un compressore i
+      metadati li toglie sul serio: l'immagine viene decodificata in pixel e
+      ricodificata, e un canvas pieno di pixel nessun tag se lo porta dietro.
       Funziona, e ti costa qualità, perché quella ricodifica è con perdita.
     </p>
     <p>
-      Rimuovere i metadati come si deve non costa proprio niente. I tag stanno
-      nel contenitore <em>attorno</em> all'immagine compressa, non dentro,
-      quindi toglierli è cancellare voci da un elenco e riscrivere l'elenco. I
-      dati compressi dell'immagine vengono copiati byte per byte e il risultato
-      decodifica esattamente gli stessi pixel. È tutto lì il motivo per usare uno
-      strumento per i metadati invece di un convertitore.
+      Toglierli come si deve, invece, non costa niente. I tag stanno nel
+      contenitore <em>attorno</em> all'immagine compressa e non dentro di essa,
+      quindi rimuoverli vuol dire cancellare voci da un elenco e riscrivere
+      l'elenco: i dati compressi dell'immagine vengono copiati byte per byte, e
+      quello che esce decodifica esattamente gli stessi pixel. È tutto qui il
+      motivo per usare uno strumento per i metadati invece di un convertitore.
     </p>
     <p>
-      L'eccezione è se dovevi ricodificare comunque. Se stai già comprimendo o
-      ridimensionando la foto, i tag se ne vanno come effetto collaterale e non
-      ti serve un secondo passaggio.
+      L'eccezione è quando la ricodifica la dovevi fare comunque: se stai già
+      comprimendo o ridimensionando la foto, i tag se ne vanno per conto loro e
+      un secondo passaggio non ti serve.
     </p>
   </section>
 
   <section>
     <h2>L'unica cosa da tenere: l'orientamento</h2>
     <p>
-      I telefoni non ruotano l'immagine quando giri il telefono. La registrano
-      come l'ha vista il sensore e aggiungono un tag Orientation che dice come va
-      girata per mostrarla. Togli tutti i tag e certi visualizzatori mostreranno
-      la tua foto di traverso.
+      I telefoni l'immagine non la ruotano quando ruoti tu: la registrano come
+      l'ha vista il sensore e aggiungono un tag Orientation che dice come va
+      girata per mostrarla. Togli tutti i tag e qualche visualizzatore ti
+      mostrerà la foto coricata.
     </p>
     <p>
-      È per questo che lo strumento di qui ha un'opzione «tieni il tag di
-      orientamento», attiva di default. Riscrive un minuscolo blocco EXIF che
-      contiene quel solo tag e nient'altro, e solo per le foto che ne avevano
-      davvero bisogno. Il GPS, gli orari, il numero di serie e il resto se ne
+      Per questo lo strumento di qui ha l'opzione «tieni il tag di
+      orientamento», attiva di default: riscrive un blocco EXIF minuscolo che
+      contiene quel tag e nient'altro, e solo per le foto che ne avevano davvero
+      bisogno. Il GPS, gli orari, il numero di serie e tutto il resto se ne
       vanno lo stesso.
     </p>
     <p>
-      Toglila se preferisci che il file non porti alcun EXIF, proprio nessuno
-      &mdash; e poi controlla il risultato prima di mandarlo, perché una foto di
-      traverso è l'esito abituale.
+      Toglila pure, se vuoi un file che di EXIF non ne abbia proprio &mdash; ma
+      poi guarda il risultato prima di mandarlo in giro, perché la foto coricata
+      è l'esito tipico.
     </p>
   </section>
 
   <section>
     <h2>Modificare invece di rimuovere</h2>
     <p>
-      Rimuovere tutto è la risposta giusta per quasi tutti. A volte non lo è: un
-      fotografo può volere che la riga di copyright e le impostazioni della
-      fotocamera restino e che se ne vada solo la posizione; un archivista può
-      aver bisogno di correggere una data sbagliata perché lo era l'orologio
-      della fotocamera.
+      Togliere tutto è la risposta giusta per la stragrande maggioranza delle
+      persone, ma non sempre: un fotografo può volersi tenere la riga di
+      copyright e le impostazioni della fotocamera e far sparire solo la
+      posizione, e un archivista può aver bisogno di correggere una data
+      sbagliata perché sbagliato era l'orologio della fotocamera.
     </p>
     <p>
-      Si può fare in entrambi i casi. La posizione si può cancellare per conto
-      suo, e tag di testo, date, ISO, orientamento e risoluzione si possono
-      modificare sul posto.
+      Si può fare in tutti e due i casi: la posizione si cancella per conto suo,
+      e i tag di testo, le date, gli ISO, l'orientamento e la risoluzione si
+      possono modificare sul posto.
     </p>
     <p>
-      Un avvertimento che vale per ogni strumento che fa questo, non solo per
-      questo: scrivere il file ricostruisce il blocco EXIF, e una maker note
-      contiene offset che puntano dentro il blocco <em>originale</em>. Una maker
-      note ricostruita potrebbe quindi non essere più leggibile dal software del
-      produttore. Se la cosa ti interessa, cancella la maker note o lascia il
-      file non modificato.
+      Un avvertimento che vale per qualunque strumento faccia questo lavoro, non
+      solo per il nostro: riscrivere il file ricostruisce il blocco EXIF, e la
+      maker note contiene offset che puntano dentro il blocco <em>originale</em>.
+      Una maker note ricostruita, quindi, potrebbe non essere più leggibile dal
+      software del produttore. Se la cosa ti interessa, o cancelli la maker note
+      o lasci il file com'è.
     </p>
   </section>
 
   <section>
-    <h2>I formati, e quelli che non si possono fare così</h2>
+    <h2>I formati, e quelli che così non si possono trattare</h2>
     <p>
-      JPEG, PNG e WebP si possono riscrivere tutti in modo pulito, e sono i tre
-      che lo strumento di qui gestisce.
+      JPEG, PNG e WebP si riscrivono tutti in modo pulito, e sono i tre che lo
+      strumento di qui gestisce.
     </p>
     <p>
       L'HEIC &mdash; quello che un iPhone salva di default &mdash; e l'AVIF sono
-      formati a scatole costruiti con atomi annidati, e hanno bisogno di un
-      analizzatore del tutto diverso. Lo strumento li riconosce e lo dice invece
-      di produrre un file rotto. Se hai un HEIC, convertirlo in JPEG ne rimuoverà
+      formati a scatole, costruiti con atomi annidati, e vogliono un parser
+      completamente diverso: lo strumento li riconosce e te lo dice, invece di
+      sputare fuori un file rotto. Se hai un HEIC, convertirlo in JPEG ne toglie
       i metadati come effetto collaterale della conversione.
     </p>
     <p>
-      Nemmeno un TIFF nudo viene gestito, e per un motivo più interessante: in un
-      TIFF i metadati e i dati dei pixel sono indirizzati dagli stessi offset,
-      quindi rimuovere dei tag vuol dire riscrivere l'indirizzamento stesso
-      dell'immagine. È fattibile ed è un altro lavoro.
+      Nemmeno un TIFF nudo viene gestito, e per un motivo più interessante: in
+      un TIFF i metadati e i dati dei pixel sono raggiunti dagli stessi offset,
+      quindi togliere dei tag vuol dire riscrivere l'indirizzamento
+      dell'immagine stessa. Si può fare, ma è un altro lavoro.
     </p>
   </section>
 
   <section>
-    <h2>Un'abitudine che vale la pena prendere</h2>
+    <h2>Un'abitudine che conviene prendere</h2>
     <p>
-      Controlla prima di pubblicare invece che dopo. Leggere i tag richiede
-      qualche secondo e l'elenco dei riscontri nomina le cose che vale la pena
-      sapere &mdash; la posizione, gli orari, i numeri di serie &mdash; prima
-      della tabella completa di tutti i tag, così non devi sapere cosa cercare.
+      Controlla prima di pubblicare, non dopo. Leggere i tag porta via qualche
+      secondo, e l'elenco che ti torna nomina per prime le cose che vale la pena
+      sapere &mdash; la posizione, gli orari, i numeri di serie &mdash; e solo
+      dopo mostra la tabella completa, così non devi sapere in anticipo cosa
+      cercare.
     </p>
     <p>
-      La posizione è mostrata prima in gradi decimali, di proposito. «51 gradi,
-      30 primi, 26 secondi» non rende evidente che una foto nomina l'edificio in
-      cui è stata scattata. Una coppia di decimali che puoi incollare in una
-      mappa sì.
+      La posizione viene mostrata prima in gradi decimali, ed è una scelta
+      voluta: «51 gradi, 30 primi, 26 secondi» non rende affatto evidente che
+      quella foto sta indicando l'edificio in cui è stata scattata, mentre una
+      coppia di numeri decimali che puoi incollare in una mappa sì.
     </p>
   </section>
 
   <section>
-    <h2>Non caricare la foto per scoprire cosa c'è dentro</h2>
+    <h2>Non caricare la foto per scoprire cosa contiene</h2>
     <p>
-      C'è un'ironia particolare nel modo abituale in cui questo problema viene
-      risolto: una persona preoccupata di cosa riveli la propria foto la carica
-      su un sito per scoprirlo. Adesso il sito ha la foto, le coordinate,
-      l'orario e il numero di serie, e una copia dell'immagine su un disco che è
-      suo.
+      Il modo consueto di risolvere questo problema ha qualcosa di
+      involontariamente comico: uno si preoccupa di cosa riveli la propria foto e
+      per scoprirlo la carica su un sito. Adesso quel sito ha la foto, le
+      coordinate, l'orario, il numero di serie e una copia dell'immagine su un
+      disco che è suo.
     </p>
     <p>
-      Non ce n'è motivo. Leggere e riscrivere il contenitore attorno a un JPEG
-      sono qualche centinaio di righe di analisi che un browser esegue
-      benissimo, ed è per questo che lo strumento di qui non ha proprio alcuna
-      funzione di rete: nessun <code>fetch</code>, nessun
-      <code>XMLHttpRequest</code>, niente che potrebbe spedire un file anche se
-      qualcosa ci provasse. Caricalo una volta, stacca la connessione, e continua
-      a funzionare.
+      Non ce n'è alcun bisogno. Leggere e riscrivere il contenitore attorno a un
+      JPEG sono qualche centinaio di righe di parsing che un browser esegue
+      benissimo, ed è per questo che lo strumento di qui non ha proprio nessuna
+      funzione di rete: niente <code>fetch</code>, niente
+      <code>XMLHttpRequest</code>, niente che potrebbe spedire un file nemmeno
+      se qualcosa ci provasse. Caricalo una volta, stacca la connessione, e
+      continua a funzionare.
     </p>
     <p>
       <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
-      file sui convertitori online?</a> spiega come verificare quell'affermazione
-      su questo sito come su qualunque altro &mdash; e questo è il tipo di file
-      su cui vale più la pena verificare.
+      file sui convertitori online?</a> spiega come verificare questa
+      affermazione qui come su qualunque altro sito &mdash; e questo è il tipo
+      di file su cui conviene di più verificarla.
     </p>
   </section>

--- a/locales/it/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/it/pages/guides/remove-exif-and-gps-data.toml
@@ -4,15 +4,15 @@
 
 nav = "Dati EXIF e GPS"
 title = "Come rimuovere i dati EXIF e GPS da una foto"
-description = "Una foto fatta con un telefono di solito porta con sé il punto esatto in cui è stata scattata, l'ora al secondo e il numero di serie della fotocamera. Cosa c'è là dentro, chi può leggerlo, e come toglierlo senza toccare l'immagine."
+description = "Una foto scattata col telefono si porta dietro il punto esatto in cui l'hai scattata, l'ora al secondo e il numero di serie della fotocamera. Cosa c'è là dentro, chi lo legge e come toglierlo senza toccare l'immagine."
 heading = "Cosa dice di te una foto, e come toglierlo"
 lede = """
-    Un'immagine appena uscita da un telefono porta di solito le coordinate del
-    posto in cui è stata scattata, l'ora al secondo, e abbastanza sulla
-    fotocamera da legarla a ogni altra foto dello stesso dispositivo. Niente di
-    tutto questo si vede sullo schermo. Qui c'è cosa c'è là dentro e come
-    rimuoverlo."""
+    Un'immagine appena uscita da un telefono di solito porta con sé le
+    coordinate del posto in cui è stata scattata, l'ora al secondo e
+    abbastanza informazioni sulla fotocamera da legarla a ogni altra foto dello
+    stesso dispositivo. Sullo schermo, di tutto questo, non si vede niente:
+    ecco cosa c'è là dentro e come si toglie."""
 updated = "20 agosto 2026"
 og_title = "Cosa dice di te una foto, e come toglierlo"
-og_description = "Coordinate GPS, orari e numeri di serie viaggiano dentro foto comunissime. Cosa c'è là dentro, chi può leggerlo, e come toglierlo."
+og_description = "Coordinate GPS, orari e numeri di serie viaggiano dentro foto comunissime. Cosa c'è là dentro, chi lo legge e come si toglie."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/resize-an-image.html
+++ b/locales/it/pages/guides/resize-an-image.html
@@ -1,245 +1,250 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Apri il <a href="../../ridimensionare-immagine/">ridimensionatore di
-      immagini</a>, trascinaci dentro la tua immagine, scrivi un numero solo
-      &mdash; di solito la larghezza &mdash; e lascia vuoto l'altro campo.
-      L'altezza segue dalla forma dell'immagine, che è quasi sempre quello che
-      si voleva: «larga 1920» vuol dire «larga 1920 e alta quanto viene».
+      Apri il <a href="../../ridimensionare-immagine/">Ridimensionatore di
+      immagini</a>, trascina dentro la tua immagine, scrivi un numero solo
+      &mdash; di solito la larghezza &mdash; e l'altro campo lascialo vuoto:
+      l'altezza viene da sé, dalle proporzioni dell'immagine, che è quasi
+      sempre quello che volevi. «Larga 1920» vuol dire «larga 1920, e alta
+      quanto viene».
     </p>
     <p>
-      Tutto quello che segue è cosa fare quando un numero non basta: quando ti
-      hanno dato un riquadro con due lati, quando l'immagine deve diventare più
-      grande, o quando una cartella intera di file deve uscire uguale.
+      Tutto il resto della pagina riguarda i casi in cui un numero solo non
+      basta: quando ti hanno dato un riquadro con due lati, quando l'immagine
+      deve diventare più grande, o quando da una cartella intera deve uscire
+      roba tutta uguale.
     </p>
   </section>
 
   <section>
-    <h2>Rimpicciolire è sicuro. Ingrandire no.</h2>
+    <h2>Rimpicciolire è innocuo, ingrandire no</h2>
     <p>
-      Non sono due direzioni della stessa operazione, e vale la pena essere
-      chiari sul perché.
+      Non sono due versi della stessa operazione, e vale la pena capire perché.
     </p>
     <p>
-      <strong>Rimpicciolire un'immagine</strong> butta via informazione, e
-      nell'unico senso innocuo: entrano più pixel di quanti ne escano, quindi
-      ogni pixel del risultato è la media di dettaglio davvero misurato. Una
-      copia rimpicciolita bene di solito si vede <em>meglio</em> dell'originale
-      guardato a quella dimensione, perché la media toglie il rumore. Non viene
-      inventato niente.
+      <strong>Rimpicciolire</strong> butta via informazione, ma nell'unico modo
+      innocuo che ci sia: entrano più pixel di quanti ne escono, quindi ogni
+      pixel del risultato è la media di dettaglio davvero misurato. Una copia
+      rimpicciolita bene si vede spesso <em>meglio</em> dell'originale guardato
+      a quella misura, perché mediare toglie di mezzo il rumore. Nulla viene
+      inventato.
     </p>
     <p>
-      <strong>Ingrandire un'immagine</strong> deve inventare. Il dettaglio non
-      manca dal file; non è mai stato fotografato. Tutto quello che un
-      ingranditore può fare è indovinare i pixel intermedi dai vicini, e
-      un'ipotesi tra due valori noti è una rampa liscia &mdash; ed è per questo
-      che una foto ingrandita si vede morbida invece che nitida. È una copia più
-      grande della stessa immagine, non una più dettagliata.
-    </p>
-    <p>
-      È per questo che «non ingrandire mai un'immagine oltre la sua dimensione
-      di partenza» è attivo di default nello strumento di qui. Toglilo se ti
-      serve davvero il numero di pixel &mdash; una tipografia che chiede una
-      dimensione minima, un modello che rifiuta qualunque cosa sotto una certa
-      larghezza &mdash; ma fallo sapendo che stai comprando pixel, non
+      <strong>Ingrandire</strong>, invece, deve per forza inventare. Non è che
+      il dettaglio manchi dal file: non è mai stato fotografato. Tutto quello
+      che un ingranditore può fare è indovinare i pixel intermedi da quelli
+      vicini, e indovinare tra due valori noti significa tracciare una rampa
+      liscia; ecco perché una foto ingrandita viene morbida invece che nitida.
+      È una copia più grande della stessa immagine, non una copia con più
       dettaglio.
     </p>
     <p>
-      Gli ingranditori con apprendimento automatico che sembrano davvero
-      aggiungere dettaglio sono tutt'altra cosa: stanno inventando texture
-      plausibile a partire da un modello di come sono fatte di solito le
-      immagini. Per uno sfondo del desktop va benissimo. Per la fotografia di
-      una persona, di un documento, o di qualunque cosa da cui qualcuno trarrà
-      una conclusione, tieni presente che il dettaglio in più è finzione.
+      Per questo «non ingrandire mai un'immagine oltre la misura di partenza» è
+      attivo di default nello strumento di qui. Toglilo pure se il numero di
+      pixel ti serve davvero &mdash; una tipografia che pretende una misura
+      minima, un modulo che rifiuta qualunque cosa sotto una certa larghezza
+      &mdash; ma fallo sapendo che stai comprando pixel, non dettaglio.
+    </p>
+    <p>
+      Gli ingranditori basati sul machine learning, quelli che sembrano
+      davvero aggiungere dettaglio, sono tutta un'altra faccenda: inventano
+      texture verosimile a partire da un modello di come sono fatte di solito
+      le immagini. Per uno sfondo del desktop va benissimo; per la fotografia
+      di una persona, per un documento o per qualunque cosa da cui qualcuno
+      trarrà una conclusione, tieni presente che quel dettaglio in più è
+      inventato.
     </p>
   </section>
 
   <section>
-    <h2>Tre modi di dire che dimensione vuoi</h2>
+    <h2>Tre modi di dire che misura vuoi</h2>
     <p>
       Quasi tutti gli strumenti, questo compreso, accettano gli stessi tre, e
-      vanno bene per lavori diversi.
+      servono per lavori diversi.
     </p>
     <ul>
       <li>
-        <strong>Pixel esatti.</strong> Usalo quando qualcuno ha indicato il
-        numero: un'immagine profilo che deve essere 400&times;400, un'insegna
-        che deve essere larga 1500. Riempi un lato e lascia che l'altro segua,
-        a meno che non ti abbiano dato entrambi.
+        <strong>I pixel esatti.</strong> Quando il numero te l'ha dato qualcuno:
+        un'immagine del profilo che deve essere 400&times;400, un banner che
+        deve essere largo 1500. Riempi un lato solo e lascia che l'altro
+        segua, a meno che non te li abbiano imposti tutti e due.
       </li>
       <li>
-        <strong>Una percentuale.</strong> Usala quando vuoi tutto
-        proporzionalmente più piccolo e la cifra esatta non ti interessa
-        &mdash; «metà» per una serie di foto che va dentro un documento.
+        <strong>Una percentuale.</strong> Quando vuoi tutto proporzionalmente
+        più piccolo e la cifra precisa non ti interessa: «metà» per una serie
+        di foto che deve entrare in un documento.
       </li>
       <li>
-        <strong>Il lato lungo.</strong> Il più utile dei tre per un lotto
-        misto. «Lato più lungo 1600» fa stare ogni immagine dentro un quadrato
-        da 1600 pixel, che sia verticale od orizzontale, che è quello che in
-        pratica vuol dire di solito «fammele tutte di una dimensione
+        <strong>Il lato lungo.</strong> Il più utile dei tre quando i file sono
+        eterogenei. «Lato più lungo 1600» fa entrare ogni immagine in un
+        quadrato da 1600 pixel, verticale od orizzontale che sia, ed è quello
+        che in pratica si intende quando si dice «portamele tutte a una misura
         ragionevole».
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Quando il riquadro ha una forma diversa dall'immagine</h2>
+    <h2>Quando il riquadro ha una forma e l'immagine un'altra</h2>
     <p>
-      È qui che il ridimensionamento si decide davvero. Se dai sia una larghezza
-      sia un'altezza e non corrispondono alle proporzioni della tua immagine,
-      qualcosa deve cedere, e le cose che possono cedere sono esattamente
-      quattro:
+      È qui che il ridimensionamento si decide sul serio. Se dai sia una
+      larghezza sia un'altezza e le proporzioni non tornano con quelle della tua
+      immagine, qualcosa deve cedere, e le cose che possono cedere sono
+      esattamente quattro.
     </p>
     <ul>
       <li>
-        <strong>Stare dentro il riquadro.</strong> L'immagine viene tenuta tutta
-        ed esce più piccola del riquadro su un asse. Non si perde niente e non
-        si deforma niente; semplicemente non ottieni le misure esatte che avevi
-        chiesto. È il comportamento giusto per quasi tutto.
+        <strong>Farla stare dentro il riquadro.</strong> L'immagine resta tutta
+        e su un asse esce più piccola del riquadro: non perdi niente e non
+        deformi niente, solo non ottieni le misure esatte che avevi chiesto. È
+        il comportamento giusto per quasi tutto.
       </li>
       <li>
-        <strong>Riempire il riquadro e tagliare quello che avanza.</strong>
-        Ottieni esattamente le misure che avevi chiesto, e le parti di immagine
-        che sporgono dai bordi spariscono. Giusto per miniature, immagini
-        profilo e copertine, dove la forma è fissa e il soggetto sta in mezzo.
-        Sbagliato quando la cosa che conta sta vicino a un bordo.
+        <strong>Riempire il riquadro e tagliare quello che sborda.</strong>
+        Ottieni le misure esatte che avevi chiesto, e le parti che escono dai
+        bordi spariscono. Va bene per miniature, immagini del profilo e
+        copertine, dove la forma è fissa e il soggetto sta in mezzo; va male
+        quando la cosa che conta sta vicino a un bordo.
       </li>
       <li>
-        <strong>Riempire con lo sfondo.</strong> L'immagine viene tenuta tutta,
-        centrata, con lo spazio che avanza riempito da un colore che scegli tu.
-        Giusto quando un sistema pretende misure esatte e non puoi perdere
-        niente dell'immagine &mdash; le schede prodotto funzionano spesso così.
+        <strong>Riempire il resto con uno sfondo.</strong> L'immagine resta
+        tutta, centrata, e lo spazio che avanza viene coperto da un colore che
+        scegli tu. È la risposta giusta quando un sistema pretende misure
+        esatte e tu dell'immagine non puoi perdere niente &mdash; le schede
+        prodotto funzionano spesso così.
       </li>
       <li>
-        <strong>Stirarla.</strong> L'immagine viene schiacciata o tirata per
+        <strong>Deformarla.</strong> L'immagine viene schiacciata o tirata per
         entrare. Non è mai quello che vuoi, a meno che tu non lo stia facendo
-        apposta, ed è quella che chiunque riconosce all'istante come sbagliata.
+        apposta, ed è l'unica delle quattro che chiunque riconosce al volo come
+        sbagliata.
       </li>
     </ul>
     <p>
-      Se ti accorgi di star cercando lo stiramento, quello che probabilmente
-      vuoi è il ritaglio.
+      E se ti accorgi di stare cercando la deformazione, quello che vuoi
+      davvero, con ogni probabilità, è un ritaglio.
     </p>
   </section>
 
   <section>
     <h2>Ritagliare è un altro lavoro, e spesso è quello giusto</h2>
     <p>
-      Ridimensionare cambia quanti pixel descrivono tutta l'immagine. Ritagliare
-      cambia quale parte dell'immagine tieni. Si va a cercare la prima cosa
-      intendendo la seconda sorprendentemente spesso &mdash; «questa deve essere
+      Ridimensionare cambia quanti pixel descrivono tutta l'immagine;
+      ritagliare cambia quale parte dell'immagine tieni. Capita spesso di
+      cercare la prima cosa avendo in mente la seconda: «questa deve venire
       quadrata» è un problema di ritaglio, non di ridimensionamento.
     </p>
     <p>
-      Falli in quell'ordine: prima ritaglia l'inquadratura che vuoi, poi
-      ridimensiona il risultato alla dimensione che ti serve. Farlo al contrario
-      vuol dire scegliere il ritaglio dentro un'immagine che ha già perso pixel.
+      L'ordine è questo: prima ritagli l'inquadratura che ti interessa, poi
+      porti il risultato alla misura che ti serve. Al contrario, sceglieresti il
+      ritaglio dentro un'immagine che ha già perso pixel.
     </p>
     <p>
-      Lo strumento di qui li fa entrambi in un passaggio solo proprio per questo
-      &mdash; trascina un riquadro, bloccalo su una forma se ti serve una
-      proporzione precisa, poi di' che dimensione deve avere il risultato. Farlo
-      in un passaggio solo vuol dire anche che l'immagine viene codificata una
-      volta sola, il che conta per il motivo della sezione successiva.
+      Lo strumento di qui li fa tutti e due in un passaggio solo proprio per
+      questo: trascini un riquadro, lo blocchi su una forma se la proporzione
+      deve essere precisa, e poi dici quanto deve venire grande il risultato.
+      Fare tutto in un colpo vuol dire anche codificare l'immagine una volta
+      sola, e nella sezione dopo si capisce perché conta.
     </p>
-    <h3>Ritagliare un lotto intero</h3>
+    <h3>Ritagliare una serie intera</h3>
     <p>
       Un riquadro disegnato su un'immagine viene applicato alle altre come la
-      stessa area <em>relativa</em>: le stesse frazioni della larghezza e
-      dell'altezza di ciascun file. Per una cartella di screenshot o di
-      esportazioni tutti della stessa dimensione, è esattamente lo stesso
-      rettangolo. Per un lotto misto è la stessa inquadratura invece dello stesso
-      rettangolo, il che di solito è quello che si voleva ma vale la pena saperlo
-      prima di affidargli cinquanta file.
+      stessa area <em>relativa</em>, cioè le stesse frazioni della larghezza e
+      dell'altezza di ciascun file. Su una cartella di screenshot o di
+      esportazioni tutti della stessa misura, è lo stesso identico rettangolo;
+      su file di misure diverse è la stessa inquadratura invece dello stesso
+      rettangolo, che di solito è proprio quello che si voleva, ma conviene
+      saperlo prima di dargli in pasto cinquanta file.
     </p>
   </section>
 
   <section>
-    <h2>Quanto costa la ricodifica, e come tenerla a una sola</h2>
+    <h2>Quanto costa la ricodifica, e come farne una sola</h2>
     <p>
       Ridimensionare un JPEG o un WebP vuol dire decodificarlo, scalare i pixel
-      e ricodificarli &mdash; e quest'ultimo passaggio è con perdita. Non è la
-      scalatura in sé a costarti qualità; è la ricodifica.
+      e ricodificarli, e l'ultimo dei tre passaggi è con perdita: non è la
+      scalatura a costarti qualità, è la ricodifica.
     </p>
     <p>
-      Ne seguono due cose. Primo: l'impostazione della qualità in uscita conta,
-      e da qualche parte attorno a 80&ndash;85 è invisibile per una fotografia e
-      parecchio più leggera di 100. Secondo: fallo una volta sola.
-      Ridimensionare un'immagine che è già stata ridimensionata due volte vuol
-      dire tre generazioni di codifica con perdita, e si vede.
+      Da qui seguono due cose. La prima è che l'impostazione della qualità in
+      uscita conta, e che un valore attorno a 80&ndash;85 è invisibile su una
+      fotografia e molto più leggero di 100. La seconda è che questo lavoro va
+      fatto una volta sola: ridimensionare un'immagine già ridimensionata due
+      volte vuol dire tre generazioni di codifica con perdita, e a quel punto si
+      vede.
     </p>
     <p>
-      Un PNG non ha questo costo, perché è senza perdita &mdash; un PNG
-      ridimensionato è esattamente i pixel scalati. Se stai lavorando in più
-      passaggi e il formato finale non è ancora deciso, lavorare in PNG nel
-      frattempo evita di accumulare generazioni.
+      Un PNG questo costo non ce l'ha, perché è senza perdita: un PNG
+      ridimensionato è esattamente il risultato della scalatura. Se stai
+      lavorando per passaggi successivi e il formato finale non l'hai ancora
+      deciso, tenerti sul PNG nel frattempo ti evita di accumulare generazioni.
     </p>
     <p>
-      Un dettaglio che vale la pena sapere sullo strumento di qui: un file che
-      non stai cambiando affatto ti viene restituito byte per byte invece che
-      ricodificato. Chiedi «lato più lungo 1600» su un lotto e quelli già sotto
-      i 1600 escono intatti, tag compresi. Uno strumento che li ricodificasse in
-      silenzio ti starebbe costando qualità su file che nessuno gli aveva chiesto
-      di cambiare.
-    </p>
-  </section>
-
-  <section>
-    <h2>La trasparenza, e cosa le succede</h2>
-    <p>
-      PNG e WebP sanno conservare la trasparenza. Il JPEG no &mdash; nel formato
-      non c'è proprio alcun canale alfa. Quindi salvare un'immagine trasparente
-      come JPEG deve metterci qualcosa dietro, e quel qualcosa è un colore
-      pieno.
-    </p>
-    <p>
-      Quasi tutti gli strumenti usano il bianco e non lo dicono, il che va bene
-      finché il tuo logo non finisce su una pagina scura con un rettangolo bianco
-      attorno. Scegli il colore di proposito, oppure salva in PNG o WebP e tieni
-      la trasparenza. Lo stesso colore viene usato dietro una cornice di
-      riempimento, che è l'altro punto in cui la gente ci si imbatte per
-      sorpresa.
+      Un dettaglio dello strumento di qui che vale la pena conoscere: un file
+      che non stai cambiando affatto ti torna indietro byte per byte invece che
+      ricodificato. Chiedi «lato più lungo 1600» su una serie di immagini e
+      quelle già sotto i 1600 escono intatte, tag compresi. Uno strumento che le
+      ricodificasse in silenzio ti starebbe facendo perdere qualità su file che
+      nessuno gli aveva chiesto di toccare.
     </p>
   </section>
 
   <section>
-    <h2>Quale strumento, se ti hanno dato un numero</h2>
+    <h2>La trasparenza, e che fine fa</h2>
     <p>
-      Vengono dati due numeri diversi, e servono strumenti diversi.
+      PNG e WebP la trasparenza la sanno conservare. Il JPEG no: nel formato un
+      canale alfa non esiste proprio. Salvare come JPEG un'immagine trasparente
+      significa quindi metterle per forza qualcosa dietro, e quel qualcosa è un
+      colore pieno.
     </p>
     <p>
-      <strong>«Larga 1200 pixel»</strong> è un problema di misure. Quello giusto
-      è il <a href="../../ridimensionare-immagine/">ridimensionatore di
-      immagini</a>: dici quanti pixel vuoi e te li dà.
+      Quasi tutti gli strumenti usano il bianco senza dirtelo, il che va
+      benissimo finché il tuo logo non finisce su una pagina scura con un bel
+      rettangolo bianco intorno. Scegli il colore di proposito, oppure salva in
+      PNG o WebP e tieniti la trasparenza. Lo stesso colore viene usato anche
+      dietro una cornice di riempimento, che è l'altro punto in cui di solito si
+      scopre la cosa per caso.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quale strumento, a seconda del numero che ti hanno dato</h2>
+    <p>
+      I numeri che ti danno sono di due tipi, e vogliono due strumenti diversi.
     </p>
     <p>
-      <strong>«Sotto i 500&nbsp;KB»</strong> è un problema di peso del file, e
-      ridimensionare è solo uno dei modi di risolverlo. Il
-      <a href="../../comprimere-immagine/">compressore di immagini</a> cerca la
-      qualità più alta che sta nel tuo obiettivo e ridimensiona solo se la
-      qualità da sola non ci arriva;
+      <strong>«Larga 1200 pixel»</strong> è una questione di misure, e lo
+      strumento giusto è il
+      <a href="../../ridimensionare-immagine/">Ridimensionatore di
+      immagini</a>: gli dici quanti pixel vuoi e te li dà.
+    </p>
+    <p>
+      <strong>«Sotto i 500&nbsp;KB»</strong> è una questione di peso del file, e
+      ridimensionare è solo uno dei modi per risolverla. Il
+      <a href="../../comprimere-immagine/">Compressore di immagini</a> cerca la
+      qualità più alta che sta dentro il limite e ridimensiona soltanto se con
+      la qualità non ci arriva;
       <a href="../comprimere-un-immagine-a-una-dimensione-esatta/">la sua
-      guida</a> spiega quanto costa.
+      guida</a> racconta quanto costa.
     </p>
   </section>
 
   <section>
     <h2>Niente di tutto questo ha bisogno di un caricamento</h2>
     <p>
-      Decodificare un'immagine, scalarla e ricodificarla sono cose che ogni
-      browser sa fare da anni &mdash; è lo stesso meccanismo che una pagina web
-      usa per disegnare un'immagine a una dimensione diversa. Non c'è alcun
-      motivo tecnico per cui la tua foto debba andare fino a un server e tornare
-      per uscirne più piccola, e lo strumento di qui non la manda da nessuna
-      parte: la <code>Content-Security-Policy</code> della pagina nomina tutti
-      gli indirizzi che può contattare, e nessuno di questi appartiene a questo
-      sito.
+      Decodificare un'immagine, scalarla e ricodificarla sono cose che i browser
+      sanno fare da anni: è lo stesso meccanismo con cui una pagina web disegna
+      un'immagine a una misura diversa. Non esiste alcuna ragione tecnica per
+      cui la tua foto debba fare andata e ritorno da un server per uscirne più
+      piccola, e lo strumento di qui da nessuna parte la manda: la
+      <code>Content-Security-Policy</code> della pagina nomina tutti gli
+      indirizzi che può contattare, e nessuno di questi è nostro.
     </p>
     <p>
-      Carica la pagina, stacca la connessione, e ridimensiona qualcosa lo stesso
+      Carica la pagina, stacca la connessione e ridimensiona qualcosa lo stesso,
       se preferisci verificare invece che crederci.
       <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
-      file sui convertitori online?</a> propone altre tre verifiche che puoi
-      fare su qualunque strumento.
+      file sui convertitori online?</a> propone altre tre verifiche da fare su
+      qualunque strumento.
     </p>
   </section>

--- a/locales/it/pages/guides/resize-an-image.toml
+++ b/locales/it/pages/guides/resize-an-image.toml
@@ -4,14 +4,14 @@
 
 nav = "Ridimensionare un'immagine"
 title = "Come ridimensionare un'immagine senza rovinarla"
-description = "Cosa succede a un'immagine quando ne cambi le misure in pixel: perché rimpicciolire è sicuro e ingrandire no, cosa fare quando il riquadro ha la forma sbagliata, e quando conviene invece ritagliare."
+description = "Cosa succede a un'immagine quando ne cambi le misure in pixel: perché rimpicciolire è innocuo e ingrandire no, cosa fare quando il riquadro ha la forma sbagliata e quando invece conviene ritagliare."
 heading = "Come ridimensionare un'immagine senza rovinarla"
 lede = """
-    Ridimensionare è l'unico lavoro sulle immagini in cui il danno è deciso
-    prima di premere il pulsante, da quale numero scrivi e da quale forma
-    chiedi. Qui c'è cosa fa all'immagine ognuna di quelle scelte, e quali di
-    esse si possono disfare."""
+    Ridimensionare è l'unico lavoro sulle immagini in cui il danno è già
+    deciso prima di premere il pulsante, dal numero che scrivi e dalla forma
+    che chiedi. Qui trovi cosa combina all'immagine ognuna di quelle scelte, e
+    quali si possono ancora disfare."""
 updated = "20 agosto 2026"
 og_title = "Ridimensionare un'immagine senza rovinarla"
-og_description = "Perché rimpicciolire è sicuro e ingrandire no, cosa fare quando il riquadro ha la forma sbagliata, e quando conviene invece ritagliare."
+og_description = "Perché rimpicciolire è innocuo e ingrandire no, cosa fare quando il riquadro ha la forma sbagliata e quando invece conviene ritagliare."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/trim-a-video.html
+++ b/locales/it/pages/guides/trim-a-video.html
@@ -1,202 +1,208 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Apri il <a href="../../tagliare-video/">tagliavideo</a>, trascinaci dentro
-      la clip, premi <kbd>I</kbd> e <kbd>O</kbd> per segnare ogni pezzo che vuoi
-      &mdash; quanti ne vuoi &mdash; ed esporta. Su un MP4, un MOV o un M4V i
-      fotogrammi che tieni vengono spostati nel file nuovo esattamente com'erano
-      &mdash; gli stessi byte, le stesse impostazioni dell'encoder, tutto uguale
-      &mdash; e l'audio viene copiato campione per campione senza essere
-      decodificato.
+      Apri il <a href="../../tagliare-video/">Tagliavideo</a>, trascina dentro
+      la clip, premi <kbd>I</kbd> e <kbd>O</kbd> per segnare i pezzi che vuoi
+      tenere &mdash; quanti ne vuoi &mdash; ed esporta. Se il file è un MP4, un
+      MOV o un M4V i fotogrammi che tieni finiscono nel file nuovo esattamente
+      com'erano: gli stessi byte, le stesse impostazioni dell'encoder, nulla
+      toccato. L'audio viene copiato campione per campione, senza passare
+      nemmeno lui da un decodificatore.
     </p>
     <p>
-      Vuol dire che un taglio non ti costa niente in qualità, ed è veloce:
-      tirare fuori un minuto da una registrazione di quattro gigabyte costa più
-      o meno quanto costa scrivere quel minuto sul disco, perché i fotogrammi
-      vengono puntati invece che caricati. L'unico punto in cui la cosa si vede
-      è dove il tuo taglio cade davvero, ed è il resto di questa pagina.
-    </p>
-  </section>
-
-  <section>
-    <h2>Perché un taglio non deve far perdere alcuna qualità</h2>
-    <p>
-      Tagliare non cambia l'aspetto di alcun fotogramma. Ogni fotogramma che
-      tieni deve uscire identico a com'era entrato, quindi non c'è motivo di
-      decodificarlo e ricodificarlo &mdash; e ci sono tutti i motivi per non
-      farlo, visto che una ricodifica è con perdita e renderebbe tutta la clip
-      leggermente peggiore solo per accorciarla.
-    </p>
-    <p>
-      Quindi un buon tagliavideo non ricodifica. Legge l'indice del file, calcola
-      quali fotogrammi codificati cadono nel tuo intervallo, e scrive quei byte
-      dentro un contenitore nuovo con un indice nuovo davanti. Su quella via non
-      viene decodificato proprio niente.
-    </p>
-    <p>
-      Parecchi strumenti ricodificano lo stesso, perché decodificare e
-      ricodificare è molto più semplice da realizzare che analizzare il formato
-      del contenitore. Di solito riconosci quale dei due stai usando dal tempo
-      che ci mette: una copia è limitata da quanto in fretta scrive il tuo disco,
-      una ricodifica da quanto in fretta il tuo dispositivo codifica video, che è
-      cento volte più lento.
+      Il taglio, quindi, non ti costa un grammo di qualità, ed è anche svelto:
+      tirare fuori un minuto da una registrazione di quattro gigabyte prende
+      più o meno il tempo di scrivere quel minuto sul disco, perché i
+      fotogrammi vengono puntati e non caricati. L'unico punto in cui la cosa
+      si fa sentire è dove il taglio cade davvero, ed è di questo che parla il
+      resto della pagina.
     </p>
   </section>
 
   <section>
-    <h2>I fotogrammi chiave, e perché il tuo taglio può cadere prima</h2>
+    <h2>Perché un taglio non dovrebbe costare qualità</h2>
     <p>
-      Ecco il vincolo da cui discende tutto quello che riguarda il tagliare.
+      Quando accorci un video, l'aspetto dei fotogrammi non cambia: ognuno di
+      quelli che tieni deve uscire identico a com'è entrato. Non c'è quindi
+      alcuna ragione di decodificarlo e ricodificarlo, e ce ne sono parecchie
+      per non farlo, visto che la ricodifica è con perdita e peggiorerebbe un
+      po' tutta la clip solo per accorciarla.
     </p>
     <p>
-      Il video non è conservato come una sequenza di immagini complete. Sarebbe
-      enorme. Quasi tutti i fotogrammi sono conservati come una descrizione di
-      come differiscono dai vicini, il che vuol dire che non si possono
-      decodificare da soli &mdash; ti servono i fotogrammi attorno. Solo un
-      <strong>fotogramma chiave</strong> sta in piedi da solo come immagine
-      completa, e i fotogrammi chiave di solito distano da uno a dieci secondi.
+      Un buon tagliavideo, di conseguenza, non ricodifica: legge l'indice del
+      file, calcola quali fotogrammi codificati cadono dentro l'intervallo che
+      hai segnato e riscrive quei byte in un contenitore nuovo, con un indice
+      nuovo davanti. Lungo tutta questa strada non viene decodificato niente.
     </p>
     <p>
-      Quindi se segni un taglio due secondi dopo l'ultimo fotogramma chiave, un
-      tagliavideo che copia i fotogrammi non può cominciare lì. I fotogrammi in
-      corrispondenza del tuo segno sono illeggibili senza la serie che ci porta.
-      Deve portarsi tutto il tratto a partire dal fotogramma chiave davanti al
-      tuo segno.
-    </p>
-    <p>
-      Cosa ne fa è la parte interessante. Il formato del file ha un modo
-      standard per dire <em>comincia a riprodurre da questo punto</em> &mdash; i
-      fotogrammi in più stanno nel file ma il contenitore ordina al lettore di
-      saltarli. Ogni lettore diffuso lo rispetta, e la clip comincia esattamente
-      dove hai detto. Un lettore che lo ignora comincerà prima, fino a un
-      intervallo tra fotogrammi chiave.
-    </p>
-    <p>
-      Lo strumento di qui ti dice in quale dei due casi ti trovi e di quanto,
-      prima che tu esporti, così è una decisione e non una sorpresa.
+      Molti strumenti ricodificano lo stesso, semplicemente perché decodificare
+      e ricodificare è molto meno faticoso da programmare che leggere davvero
+      il formato del contenitore. Di solito capisci in quale dei due casi ti
+      trovi dal tempo che ci mette: una copia va veloce quanto scrive il tuo
+      disco, una ricodifica quanto il tuo dispositivo riesce a codificare
+      video, cioè cento volte più lentamente.
     </p>
   </section>
 
   <section>
-    <h2>Quando accettare una ricodifica</h2>
+    <h2>I fotogrammi chiave, e perché il taglio a volte cade prima</h2>
     <p>
-      C'è un taglio esatto, e funziona ricodificando il tratto iniziale &mdash;
-      decodificando dal fotogramma chiave, e riscrivendo una nuova serie di
-      fotogrammi che comincia davvero dove avevi segnato. È più lento, e costa un
-      po' di qualità, ma solo su quel tratto iniziale.
+      Qui c'è il vincolo da cui dipende tutto il resto.
     </p>
     <p>
-      Scegli quello quando la clip va in un posto che non rispetterà l'ordine del
-      contenitore, o dove non controlli il lettore: certi programmi di montaggio,
-      certi sistemi di trasmissione e videoconferenza, certi lettori hardware
-      vecchi. Scegli la copia per tutto il resto, che è quasi tutto &mdash; un
-      browser, un telefono, una piattaforma social, un lettore multimediale.
+      Un video non è conservato come una sequenza di immagini complete, perché
+      sarebbe enorme: quasi tutti i fotogrammi sono scritti come descrizione di
+      quanto differiscono da quelli vicini, e quindi da soli non si possono
+      decodificare, servono anche quelli intorno. Sta in piedi da solo, come
+      immagine completa, soltanto il <strong>fotogramma chiave</strong>, e tra
+      un fotogramma chiave e il successivo di solito passa da uno a dieci
+      secondi.
     </p>
     <p>
-      Una terza possibilità che non costa niente: sposta il tuo segno. Se lo
-      strumento ti mostra dove sono i fotogrammi chiave, portare il taglio sul
-      più vicino ti dà un taglio esatto senza alcuna ricodifica. Raramente vale
-      la pena rinunciare a una copia per un secondo di differenza.
+      Se segni il taglio due secondi dopo l'ultimo fotogramma chiave, dunque,
+      un tagliavideo che copia i fotogrammi da lì non può partire: i fotogrammi
+      che stanno in corrispondenza del tuo segno sono illeggibili senza la fila
+      che li precede. Deve per forza portarsi dietro anche il tratto che parte
+      dal fotogramma chiave prima del segno.
+    </p>
+    <p>
+      La parte interessante è cosa se ne fa. Il formato del file ha un modo
+      standard per dire <em>comincia a riprodurre da qui</em>: i fotogrammi in
+      più restano nel file, ma il contenitore dice al lettore di saltarli.
+      Qualunque lettore diffuso lo rispetta, e la clip parte esattamente dove
+      hai detto tu; se invece capita in mano a un lettore che lo ignora,
+      partirà prima, al massimo di un intervallo tra fotogrammi chiave.
+    </p>
+    <p>
+      Lo strumento ti dice in quale dei due casi ti trovi e di quanto, prima
+      che tu esporti, così è una decisione tua e non una sorpresa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quando conviene accettare la ricodifica</h2>
+    <p>
+      Il taglio al fotogramma esatto esiste, e si ottiene ricodificando solo il
+      tratto iniziale: si decodifica a partire dal fotogramma chiave e si
+      riscrive una serie di fotogrammi nuovi che comincia davvero dove avevi
+      segnato. È più lento e costa un po' di qualità, ma soltanto su quel primo
+      pezzetto.
+    </p>
+    <p>
+      Prendilo quando la clip finisce dove l'istruzione del contenitore non
+      verrà rispettata, o dove il lettore non lo decidi tu: certi programmi di
+      montaggio, certi sistemi di trasmissione e di videoconferenza, certi
+      lettori hardware di qualche anno fa. Per tutto il resto &mdash; un
+      browser, un telefono, un social, un lettore multimediale, cioè la quasi
+      totalità dei casi &mdash; va benissimo la copia.
+    </p>
+    <p>
+      C'è poi una terza strada che non costa niente: spostare il segno. Se lo
+      strumento ti fa vedere dove cadono i fotogrammi chiave, portare il taglio
+      su quello più vicino ti dà un taglio esatto senza nessuna ricodifica, e
+      per un secondo di differenza raramente vale la pena rinunciare alla
+      copia.
     </p>
   </section>
 
   <section>
     <h2>Togliere un pezzo in mezzo</h2>
     <p>
-      Togliere un pezzo è un'operazione diversa dal tenerne uno, e vale la pena
-      sapere che è supportata, perché parecchi tagliavideo fanno solo la seconda.
-      Segna la parte che non vuoi, scegli di toglierla, e quello che resta ai
-      due lati viene unito in una clip sola con l'audio portato dall'altra parte
-      in sincrono.
+      Togliere un pezzo non è la stessa cosa che tenerne uno, e vale la pena
+      dire che qui si può fare, perché parecchi tagliavideo sanno fare solo la
+      seconda. Segni la parte che non ti serve, scegli di eliminarla, e quello
+      che resta ai due lati viene ricucito in una clip sola, con l'audio
+      portato dall'altra parte in sincrono.
     </p>
     <p>
-      Nel punto in cui riprende la seconda metà, la giunzione ha lo stesso
-      vincolo dei fotogrammi chiave, per lo stesso motivo. Qui funziona su
-      entrambe le vie dell'MP4. È l'unica cosa che il ripiego della registrazione
-      qui sotto non sa fare, perché una registrazione si fa in un passaggio solo
-      da una sola testina.
+      Nel punto in cui riprende la seconda metà la giunzione ha lo stesso
+      vincolo dei fotogrammi chiave, per lo stesso motivo di prima. Con l'MP4
+      funziona in tutti e due i modi. È invece l'unica cosa che il ripiego
+      basato sulla registrazione, di cui si parla qui sotto, non riesce a fare:
+      una registrazione avviene in un passaggio solo, da una sola testina.
     </p>
   </section>
 
   <section>
-    <h2>I formati, e il ripiego</h2>
+    <h2>I formati, e cosa succede quando non basta</h2>
     <p>
       <strong>MP4, M4V e MOV</strong> vengono letti direttamente, qualunque
-      codec ci sia dentro &mdash; H.264, HEVC, AV1, VP9. Copiare i fotogrammi non
-      comporta decodificarli, quindi questa via funziona anche per un codec per
-      cui il tuo browser non ha proprio alcun decodificatore, che è una piacevole
-      conseguenza del non guardare le immagini.
+      codec ci sia dentro: H.264, HEVC, AV1, VP9. Copiare i fotogrammi non vuol
+      dire decodificarli, quindi si passa di qui anche con un codec per cui il
+      tuo browser non ha proprio alcun decodificatore &mdash; comodo effetto
+      collaterale del fatto che a nessuno serve guardare le immagini.
     </p>
     <p>
-      <strong>Tutto il resto che il tuo browser sa riprodurre</strong>, il WebM
-      in primis, viene tagliato riproducendolo e registrando il risultato.
-      Funziona, e ha due costi: richiede tanto tempo quanto è lungo il pezzo, e
-      l'immagine e il suono vengono ricodificati.
+      <strong>Tutto il resto che il tuo browser sa riprodurre</strong>, WebM in
+      testa, viene tagliato riproducendolo e registrando il risultato. Funziona,
+      e ha due prezzi: ci mette tanto tempo quanto è lungo il pezzo, e immagine
+      e suono passano da una ricodifica.
     </p>
     <p>
       <strong>AVI, WMV, FLV e quasi tutti gli MKV</strong> il browser non li sa
-      né leggere né riprodurre, e lo strumento lo dice invece di piantarsi a metà
-      strada. Convertili prima in MP4 con qualcosa che li gestisca.
+      né leggere né riprodurre, e lo strumento te lo dice subito invece di
+      piantarsi a metà. Convertili prima in MP4 con qualcosa che li gestisca.
     </p>
   </section>
 
   <section>
-    <h2>Due cose che altrove vanno storte in silenzio</h2>
+    <h2>Due cose che altrove si rovinano senza dire niente</h2>
     <p>
-      <strong>La rotazione.</strong> Un telefono filma in orizzontale e scrive
-      nel file un'istruzione di rotazione invece di girare i pixel. Un
-      tagliavideo che copia i fotogrammi deve portarsi dietro quell'istruzione, o
-      la tua clip verticale esce di traverso &mdash; che è il modo classico in
-      cui un video tagliato viene rovinato. La via esatta di qui gira i
-      fotogrammi mentre li ricodifica e scrive un file che non ha bisogno di
-      alcuna rotazione.
+      <strong>La rotazione.</strong> Un telefono riprende sempre in
+      orizzontale e nel file scrive un'istruzione di rotazione invece di girare
+      i pixel. Un tagliavideo che copia i fotogrammi deve portarsi dietro anche
+      quell'istruzione, altrimenti la tua clip verticale esce coricata: è il
+      modo classico in cui un video tagliato viene rovinato. La strada del
+      taglio esatto, qui, gira i fotogrammi mentre li ricodifica e produce un
+      file che di rotazioni non ha più bisogno.
     </p>
     <p>
-      <strong>Il sincrono dell'audio.</strong> Audio e video sono conservati come
-      flussi separati con tempi propri, e non vengono tagliati negli stessi
-      punti. Se i due non vengono allineati di proposito al taglio, il suono
-      slitta. Sulla via della copia di qui l'audio viene copiato campione per
-      campione senza essere decodificato, quindi è byte per byte quello che
-      c'era nel file, e un segno di montaggio lo tiene in sincrono con
-      l'immagine entro un millesimo di secondo.
+      <strong>Il sincrono dell'audio.</strong> Audio e video sono conservati
+      come flussi separati, ciascuno con i propri tempi, e non si tagliano
+      negli stessi punti. Se al taglio i due non vengono riallineati di
+      proposito, il suono slitta. Qui, sulla strada della copia, l'audio viene
+      copiato campione per campione senza essere decodificato, quindi è byte
+      per byte quello che stava nel file di partenza, e un segno di montaggio
+      lo tiene agganciato all'immagine entro il millesimo di secondo.
     </p>
   </section>
 
   <section>
     <h2>Tagliare non è ritagliare</h2>
     <p>
-      Due parole che vengono usate una per l'altra. Tagliare cambia la durata
-      della clip; ritagliare cambia la forma dell'immagine. Se quello che vuoi è
-      una versione quadrata di un video orizzontale, o le bande nere via dai
-      lati, è il <a href="../../ritagliare-video/">ritagliatore di video</a>
-      &mdash; e a differenza del tagliare, quello deve ricodificare, per il
-      motivo che spiega <a href="../ritagliare-un-video/">la sua guida</a>.
+      Sono due parole che si usano spesso una per l'altra: tagliare cambia la
+      durata della clip, ritagliare cambia la forma dell'immagine. Se quello
+      che ti serve è la versione quadrata di un video orizzontale, o le bande
+      nere tolte dai lati, il posto giusto è il
+      <a href="../../ritagliare-video/">Ritagliatore di video</a> &mdash; e
+      quello, a differenza del taglio, la ricodifica la deve fare per forza,
+      per il motivo che spiega <a href="../ritagliare-un-video/">la sua
+      guida</a>.
     </p>
   </section>
 
   <section>
-    <h2>Perché questo non ha bisogno di un caricamento &mdash; questo in particolare</h2>
+    <h2>Perché proprio qui non serve caricare niente</h2>
     <p>
-      Il video è il tipo di file per cui più di ogni altro ci si aspetta di dover
-      caricare qualcosa, perché i file sono pesanti e il lavoro suona gravoso.
-      Tagliare è il caso in cui è meno vero: sulla via della copia il file viene
-      letto a malapena. Lo strumento percorre l'indice, calcola quali intervalli
-      di byte tenere, e li riscrive. Caricare un file da quattro gigabyte su un
-      server perché possa fare questo sarebbe il modo più lento possibile di
-      organizzare la cosa.
+      Il video è il tipo di file per cui più di ogni altro si dà per scontato
+      di dover caricare qualcosa: i file pesano e il lavoro sembra impegnativo.
+      Tagliare è il caso in cui questo è meno vero di tutti, perché sulla
+      strada della copia il file viene appena sfiorato: lo strumento percorre
+      l'indice, calcola quali intervalli di byte tenere e li riscrive. Mandare
+      quattro gigabyte a un server perché faccia questo sarebbe il modo più
+      lento che si possa immaginare di organizzare la faccenda.
     </p>
     <p>
-      È anche il tipo di file in cui caricare costa di più, se preferiresti non
-      farlo: un video porta con sé volti, voci, case e luoghi in un modo in cui
-      un documento non lo fa. Lo strumento di qui non ha alcuna funzione di
+      Ed è anche il tipo di file che caricare costa di più, se preferiresti
+      evitarlo: in un video ci sono volti, voci, case e luoghi, cose che un
+      documento non si porta dietro. Lo strumento non ha alcuna funzione di
       rete, e la <code>Content-Security-Policy</code> della pagina nomina tutti
-      gli indirizzi che può contattare, nessuno dei quali appartiene a questo
-      sito.
+      gli indirizzi che può contattare, nessuno dei quali è nostro.
     </p>
     <p>
-      Stacca la connessione e taglia una clip lo stesso, se preferisci verificare
-      invece che crederci.
+      Stacca la connessione e taglia una clip lo stesso, se preferisci
+      verificare invece che crederci.
       <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
-      file sui convertitori online?</a> propone altre tre verifiche come questa.
+      file sui convertitori online?</a> ne propone altre tre come questa.
     </p>
   </section>

--- a/locales/it/pages/guides/trim-a-video.toml
+++ b/locales/it/pages/guides/trim-a-video.toml
@@ -4,14 +4,14 @@
 
 nav = "Tagliare un video"
 title = "Come tagliare un video senza ricodificarlo"
-description = "Accorciare una clip non deve costare un solo byte di qualità. Perché a volte un taglio cade prima di dove l'hai segnato, cosa c'entra un fotogramma chiave, e quando accettare una ricodifica."
+description = "Accorciare una clip non deve costare un grammo di qualità. Perché il taglio a volte cade prima di dove l'hai segnato, cosa c'entrano i fotogrammi chiave e quando conviene accettare una ricodifica."
 heading = "Come tagliare un video senza ricodificarlo"
 lede = """
-    Tagliare non cambia l'aspetto di alcun fotogramma, quindi un buon
-    tagliavideo non li tocca &mdash; li sposta in un file nuovo esattamente
-    com'erano. Qui c'è cosa ti fa guadagnare, e l'unico punto in cui si
-    vede."""
+    Quando accorci un video l'aspetto dei fotogrammi non cambia, e infatti un
+    buon tagliavideo non li tocca nemmeno: li sposta in un file nuovo
+    esattamente com'erano. Qui trovi cosa ci guadagni e l'unico punto in cui
+    la cosa si fa sentire."""
 updated = "20 agosto 2026"
 og_title = "Come tagliare un video senza ricodificarlo"
-og_description = "Perché a volte un taglio cade prima di dove l'hai segnato, cosa c'entra un fotogramma chiave, e quando accettare una ricodifica."
+og_description = "Perché il taglio a volte cade prima di dove l'hai segnato, cosa c'entrano i fotogrammi chiave e quando conviene accettare una ricodifica."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"

--- a/locales/it/pages/guides/turn-images-into-a-video.html
+++ b/locales/it/pages/guides/turn-images-into-a-video.html
@@ -1,197 +1,203 @@
   <section>
-    <h2>La risposta corta</h2>
+    <h2>In breve</h2>
     <p>
-      Apri <a href="../../immagini-in-video/">Immagini in video</a>, trascinaci
-      dentro le foto, mettile in ordine, imposta quanto viene tenuta ciascuna, e
-      crea il video. Ottieni un MP4 con video H.264, che si riproduce
-      praticamente ovunque.
+      Apri <a href="../../immagini-in-video/">Immagini in video</a>, trascina
+      dentro le foto, mettile nell'ordine che vuoi, decidi quanto deve restare
+      in campo ciascuna e crea il video. Quello che esce è un MP4 con codifica
+      H.264, cioè il formato che si apre praticamente ovunque.
     </p>
     <p>
-      Le due impostazioni che più spesso richiedono un secondo giro sono la
-      durata e la risoluzione, e vale la pena capirle prima del primo render e
-      non dopo.
-    </p>
-  </section>
-
-  <section>
-    <h2>La frequenza dei fotogrammi e la durata non sono la stessa cosa</h2>
-    <p>
-      È la confusione che costa alla gente un secondo render.
-    </p>
-    <p>
-      La <strong>durata</strong> è quanto ogni immagine resta sullo schermo. È
-      l'impostazione che ti interessa davvero. Tre secondi sono un buon valore
-      predefinito per una presentazione che qualcuno guarda; uno o due secondi
-      danno un ritmo svelto; oltre i cinque si trascina, a meno che non ci sia
-      una voce sopra.
-    </p>
-    <p>
-      La <strong>frequenza dei fotogrammi</strong> è quante volte al secondo il
-      video ripete quell'immagine. Non cambia niente di come si presenta la
-      presentazione &mdash; un'immagine ferma tenuta per tre secondi si vede
-      identica a 24 fotogrammi al secondo e a 60 &mdash; e cambia parecchio il
-      peso del file e il tempo di codifica.
-    </p>
-    <p>
-      Quindi per una presentazione semplice scegli una frequenza bassa. 24 o 30
-      abbondano. Il motivo per salire è se nel video c'è movimento: una
-      panoramica o uno zoom su ogni foto, o una dissolvenza incrociata tra loro,
-      dove una frequenza bassa si vede come scatti.
+      Le impostazioni su cui si torna quasi sempre una seconda volta sono due,
+      la durata e la risoluzione, e conviene averle chiare prima del render
+      invece che dopo.
     </p>
   </section>
 
   <section>
-    <h2>La risoluzione, e le immagini della forma sbagliata</h2>
+    <h2>Frequenza dei fotogrammi e durata sono due cose diverse</h2>
     <p>
-      Un video ha una sola dimensione di fotogramma per tutta la sua durata. Le
-      tue fotografie quasi certamente non ne condividono una, quindi a quelle che
-      non ci stanno deve succedere qualcosa &mdash; e quel qualcosa è la scelta
-      che vale la pena fare di proposito.
+      È l'equivoco che più spesso costringe a rifare il render da capo.
     </p>
     <p>
-      Comincia scegliendo la risoluzione in base a dove va il video:
+      La <strong>durata</strong> è il tempo per cui ogni immagine resta in
+      campo, ed è l'impostazione che ti interessa davvero: tre secondi sono la
+      misura comoda per una presentazione che qualcuno sta guardando, uno o due
+      secondi danno un ritmo svelto, oltre i cinque si trascina, a meno che
+      sopra non ci sia una voce che racconta.
+    </p>
+    <p>
+      La <strong>frequenza dei fotogrammi</strong> è invece quante volte al
+      secondo il video ripete quella stessa immagine. Su quello che si vede non
+      cambia nulla &mdash; un'immagine ferma tenuta tre secondi è identica a 24
+      fotogrammi al secondo e a 60 &mdash; mentre sul peso del file e sui tempi
+      di codifica cambia parecchio.
+    </p>
+    <p>
+      Per una presentazione di immagini ferme, quindi, tieniti basso: 24 o 30
+      bastano e avanzano. L'unico motivo per salire è il movimento &mdash; una
+      panoramica o uno zoom sulle foto, una dissolvenza incrociata tra l'una e
+      l'altra &mdash; perché lì una frequenza bassa si vede, e si vede come uno
+      scatto.
+    </p>
+  </section>
+
+  <section>
+    <h2>La risoluzione, e le foto che non hanno la forma giusta</h2>
+    <p>
+      Un video ha una sola dimensione di fotogramma per tutta la sua durata,
+      mentre le tue fotografie quasi sicuramente non ce l'hanno tutte uguale: a
+      quelle che non ci stanno dentro dovrà succedere qualcosa, ed è meglio che
+      sia una tua decisione.
+    </p>
+    <p>
+      Parti dalla risoluzione, e scegliela in base a dove il video andrà a
+      finire:
     </p>
     <ul>
       <li>
-        <strong>1920&times;1080</strong> per qualunque cosa generica. Supportato
-        universalmente, si riproduce dappertutto, ed è quello che quasi tutti
-        intendono per HD.
+        <strong>1920&times;1080</strong> per l'uso generico: lo apre tutto, si
+        riproduce ovunque, ed è quello che quasi tutti chiamano HD.
       </li>
       <li>
-        <strong>1080&times;1920</strong> &mdash; gli stessi numeri al contrario
-        &mdash; per una destinazione pensata per il telefono: storie, reel,
-        short.
+        <strong>1080&times;1920</strong>, gli stessi numeri scambiati, se il
+        video nasce per il telefono: storie, reel, short.
       </li>
       <li>
-        <strong>3840&times;2160</strong> solo se le immagini hanno davvero tutto
-        quel dettaglio e la destinazione lo mostrerà. Sono quattro volte i pixel,
-        quattro volte il tempo di codifica, e all'incirca quattro volte il file.
+        <strong>3840&times;2160</strong> solo se le foto quel dettaglio ce
+        l'hanno davvero e chi le guarderà potrà vederlo: sono quattro volte i
+        pixel, quattro volte il tempo di codifica e all'incirca quattro volte
+        il peso.
       </li>
     </ul>
     <p>
-      Poi decidi cosa succede a quelle che non corrispondono. Far stare ogni
-      immagine dentro il fotogramma la tiene tutta e lascia delle bande ai lati
-      &mdash; scelta prudente, ed è la risposta giusta quando le immagini
-      contano più della presentazione. Riempire il fotogramma e tagliare quello
-      che avanza viene meglio e a qualcuna taglierà la parte alta. Mescolare foto
-      verticali e orizzontali in un solo video è il caso in cui non c'è una
-      risposta buona; decidere in anticipo da che parte preferisci sbagliare ti
-      risparmia un secondo render.
+      Poi decidi cosa fare di quelle che non tornano. Se fai stare l'immagine
+      intera dentro il fotogramma non perdi niente, ma ti restano le bande ai
+      lati: è la scelta prudente, ed è quella giusta quando contano più le foto
+      della resa. Se invece riempi il fotogramma e tagli quello che sborda il
+      risultato è più bello, però a qualcuna taglierai la testa. Il caso senza
+      soluzione è il video che mescola verticali e orizzontali: lì una risposta
+      giusta non c'è, e quello che ti evita di rifare tutto è decidere in
+      anticipo da che parte preferisci sbagliare.
     </p>
   </section>
 
   <section>
-    <h2>L'ordine, e la trappola dei nomi di file</h2>
+    <h2>L'ordine, e la trappola dei nomi dei file</h2>
     <p>
-      Come in ogni lavoro a lotti, i nomi dei file si ordinano in un modo che non
-      è quello in cui hai contato tu. <code>foto2.jpg</code> viene dopo
-      <code>foto10.jpg</code> in un ordine alfabetico, perché il confronto è
+      Come in tutti i lavori su tanti file insieme, l'ordine alfabetico dei
+      nomi non è l'ordine in cui li hai contati tu: <code>foto2.jpg</code>
+      finisce dopo <code>foto10.jpg</code>, perché il confronto avviene
       carattere per carattere.
     </p>
     <p>
-      Ordinare per data di scatto è di solito giusto per le fotografie di un
-      evento, visto che le hai scattate nell'ordine in cui le cose sono
-      successe. Trascinare le tessere è giusto per tutto ciò in cui la storia non
-      è cronologica. Controlla prima di renderizzare: il video è l'unico
-      manufatto in cui sistemare l'ordine vuol dire rifare tutto il lavoro.
+      Per le foto di un evento, ordinare per data di scatto di solito è la cosa
+      giusta, visto che le hai scattate nell'ordine in cui le cose sono
+      successe; quando invece il racconto non è cronologico conviene trascinare
+      le tessere a mano. In ogni caso controlla prima di lanciare il render,
+      perché qui, a differenza di quasi tutto il resto, rimettere in ordine
+      vuol dire rifare il lavoro da capo.
     </p>
   </section>
 
   <section>
-    <h2>Non c'è colonna sonora, e non è una cosa da poco</h2>
+    <h2>Colonna sonora non ce n'è, e non è un dettaglio</h2>
     <p>
-      L'MP4 che questo strumento scrive ha una sola traccia video e nessuna
-      traccia audio. Se la tua presentazione ha bisogno di musica o di una voce
-      fuori campo, per quel passaggio ti servirà un programma di montaggio.
+      L'MP4 che esce da qui ha una sola traccia video e nessuna traccia audio.
+      Se alla tua presentazione servono una musica o una voce fuori campo,
+      per quel passaggio dovrai passare da un programma di montaggio.
     </p>
     <p>
-      Vale la pena sapere il perché, invece del solo fatto: aggiungere l'audio
-      vuol dire decodificare un file musicale, codificarlo in AAC, e intrecciarlo
-      con il video dentro il contenitore. Tutte e tre sono lavoro vero, e farle
-      male produce un file che perde il sincrono mentre scorre. È nella lista,
-      invece che fatto a metà.
+      Vale la pena sapere anche il perché, e non solo che è così: aggiungere
+      l'audio vorrebbe dire decodificare un file musicale, ricodificarlo in AAC
+      e intrecciarlo al video dentro il contenitore. Sono tre lavori veri, e
+      farli male produce un file che mentre scorre perde il sincrono; per
+      questo la cosa sta nella lista di quello che manca, invece di stare qui
+      dentro fatta a metà.
     </p>
     <p>
-      Una nota pratica se poi la musica la aggiungi: scegli prima il brano e
-      imposta la durata per immagine in modo che la presentazione esca vicina
-      alla lunghezza della canzone. Tagliare la musica per farla stare nel video
-      suona sempre peggio che far stare il video nella musica.
+      Una nota pratica, se poi la musica la aggiungi: scegli prima il brano e
+      regola la durata per immagine in modo che la presentazione venga lunga
+      quanto la canzone. Accorciare la musica per farla stare nel video suona sempre
+      peggio del contrario.
     </p>
   </section>
 
   <section>
     <h2>Cosa esce, e cosa fare se non si riproduce</h2>
     <p>
-      L'obiettivo è l'MP4 con H.264, ed è la combinazione più ampiamente
-      riproducibile che ci sia. In un browser senza WebCodecs lo strumento
-      ripiega sulla registrazione in WebM &mdash; le stesse riprese in un
-      contenitore che meno programmi di montaggio e meno piattaforme social
+      L'obiettivo è l'MP4 con H.264, che è la combinazione più riproducibile in
+      circolazione. In un browser senza WebCodecs lo strumento ripiega sulla
+      registrazione in WebM: le stesse identiche immagini, dentro un
+      contenitore che parecchi programmi di montaggio e parecchi social non
       accettano.
     </p>
     <p>
-      Se ti ritrovi con un WebM e qualcosa lo rifiuta, la soluzione è un browser
-      che supporti WebCodecs, non una conversione: le versioni attuali di Chrome,
-      Edge e Safari lo fanno tutte. Rifare il render è meglio che convertire,
-      perché convertire vuol dire un'altra generazione di codifica con perdita.
+      Se ti ritrovi un WebM e da qualche parte te lo rifiutano, la soluzione
+      non è convertirlo ma cambiare browser: le versioni recenti di Chrome,
+      Edge e Safari supportano WebCodecs tutte e tre. Rifare il render è meglio
+      che convertire, perché convertire vuol dire un altro giro di codifica con
+      perdita.
     </p>
     <p>
-      Nello strumento non c'è alcun limite al numero di immagini che puoi usare.
-      Il tetto è la memoria del tuo dispositivo, perché il video finito viene
-      assemblato lì prima che tu lo scarichi &mdash; una lunga presentazione in
-      4K è la prima cosa a sentirlo.
+      Sul numero di immagini lo strumento non pone alcun limite. Il tetto è la
+      memoria del tuo dispositivo, visto che il video finito viene montato lì
+      prima che tu lo scarichi, ed è una presentazione lunga in 4K la prima
+      cosa che lo va a toccare.
     </p>
   </section>
 
   <section>
-    <h2>Alleggerire il file</h2>
+    <h2>Far pesare meno il file</h2>
     <p>
-      Se il risultato è troppo pesante per il posto dove sta andando, in ordine
-      di cosa aiuta davvero:
+      Se quello che esce è troppo pesante per il posto dove deve andare, ecco
+      cosa aiuta davvero, in ordine di efficacia.
     </p>
     <p>
-      <strong>Abbassa la frequenza dei fotogrammi.</strong> Per una presentazione
-      di immagini ferme non costa niente di visibile ed è il singolo risparmio
-      più grande a disposizione.
+      <strong>Abbassa la frequenza dei fotogrammi.</strong> Su una
+      presentazione di immagini ferme non si vede nulla, ed è di gran lunga il risparmio più
+      grosso che hai a disposizione.
     </p>
     <p>
-      <strong>Abbassa la risoluzione.</strong> 1080p invece di 4K è un quarto dei
-      pixel, e sullo schermo di un telefono non se ne accorgerà nessuno.
+      <strong>Abbassa la risoluzione.</strong> 1080p invece di 4K è un quarto
+      dei pixel, e sullo schermo di un telefono non se ne accorge nessuno.
     </p>
     <p>
-      <strong>Accorciala.</strong> Tre secondi a immagine invece di cinque sono
-      il 40% in meno di durata e il 40% in meno di file, e di solito una
+      <strong>Accorciala.</strong> Tre secondi a immagine invece di cinque
+      tolgono il 40% alla durata e il 40% al peso, e di solito ne esce una
       presentazione migliore.
     </p>
     <p>
-      Rimpicciolire prima le fotografie di partenza non aiuta granché. Il video
-      viene comunque codificato alla risoluzione che hai scelto, quindi una foto
-      da 4000 pixel e una da 2000 producono quasi lo stesso numero di byte in un
-      video 1080p. Rende però la codifica più rapida, e sposta quel tetto di
+      Rimpicciolire le foto di partenza, invece, serve a poco: il video viene
+      comunque codificato alla risoluzione che hai scelto, quindi in un 1080p
+      una foto da 4000 pixel e una da 2000 producono quasi lo stesso numero di
+      byte. Rende però la codifica più veloce, e allontana quel tetto di
       memoria.
     </p>
   </section>
 
   <section>
-    <h2>Perché questo non ha bisogno di un server, con un'eccezione dichiarata</h2>
+    <h2>Perché qui non serve un server, con l'unica eccezione dichiarata</h2>
     <p>
-      Codificare video era il caso più chiaro a favore del caricamento: i browser
-      non lo sapevano fare, e una macchina con FFmpeg sì. WebCodecs ha cambiato
-      le cose esponendo l'encoder hardware che il tuo dispositivo ha già, che è
-      lo stesso che il tuo telefono usa per registrare video in tempo reale.
-      Comporre i fotogrammi è una tela. Nessuno dei due passaggi ha bisogno di
-      altro che del tuo hardware.
+      Codificare un video è stato per anni l'argomento più solido a favore del
+      caricamento: i browser non lo sapevano fare, una macchina con FFmpeg sì.
+      Poi è arrivato WebCodecs, che mette a disposizione l'encoder hardware già
+      presente nel tuo dispositivo &mdash; lo stesso che il tuo telefono usa
+      per registrare un video in tempo reale &mdash; e comporre i fotogrammi
+      uno dietro l'altro è un lavoro da canvas. Né l'uno né l'altro passaggio
+      ha bisogno di qualcosa che non sia il tuo hardware.
     </p>
     <p>
-      Un'eccezione su questo strumento in particolare, dichiarata invece che
-      sepolta: la funzione facoltativa «aggiungi da un indirizzo web» recupera
-      un'immagine da un indirizzo che incolli tu, e il server a
-      quell'indirizzo vede il tuo IP e cosa hai chiesto. È insita nella funzione
-      e non è un suo difetto, ed è l'unico passaggio di rete di tutto lo
-      strumento. Non usarla e dal tuo dispositivo non esce proprio niente.
+      Su questo strumento un'eccezione c'è, e la diciamo invece di
+      nasconderla: la funzione facoltativa «aggiungi da un indirizzo web»
+      scarica un'immagine dall'indirizzo che incolli tu, e il server che sta a
+      quell'indirizzo vede il tuo IP e cosa gli hai chiesto. È il modo in cui
+      quella funzione funziona, non un suo difetto, ed è l'unico momento in cui
+      tutto lo strumento tocca la rete. Se non la usi, dal tuo dispositivo non
+      esce assolutamente niente.
     </p>
     <p>
       <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
-      file sui convertitori online?</a> propone quattro verifiche che ti diranno
-      la stessa cosa su qualunque strumento, questo compreso.
+      file sui convertitori online?</a> mette in fila quattro verifiche che ti
+      dicono la stessa cosa su qualunque strumento, questo compreso.
     </p>
   </section>

--- a/locales/it/pages/guides/turn-images-into-a-video.toml
+++ b/locales/it/pages/guides/turn-images-into-a-video.toml
@@ -3,14 +3,14 @@
 #
 
 nav = "Immagini in un video"
-title = "Come trasformare una cartella di immagini in un video"
-description = "Fai una presentazione in MP4 con delle foto: cosa controllano davvero la frequenza dei fotogrammi e la durata, come gestire le immagini della forma sbagliata, e perché il risultato non ha colonna sonora."
-heading = "Come trasformare una cartella di immagini in un video"
+title = "Come trasformare una cartella di foto in un video"
+description = "Una presentazione in MP4 partendo dalle tue foto: cosa cambiano davvero la durata e la frequenza dei fotogrammi, cosa fare con le immagini della forma sbagliata e perché non esce con la musica."
+heading = "Come trasformare una cartella di foto in un video"
 lede = """
-    Una presentazione è una cosa semplice da fare e facile da rifare due volte,
-    perché due delle impostazioni non vogliono dire quello che sembra. Qui c'è
-    cosa controlla ciascuna e cosa scegliere."""
+    Una presentazione si mette insieme in un attimo, e in un attimo la si rifà
+    da capo, perché due delle impostazioni non vogliono dire quello che sembra.
+    Qui trovi cosa comanda ciascuna e cosa conviene scegliere."""
 updated = "20 agosto 2026"
-og_title = "Come trasformare una cartella di immagini in un video"
-og_description = "Cosa controllano davvero la frequenza dei fotogrammi e la durata, come gestire le immagini della forma sbagliata, e perché non c'è colonna sonora."
+og_title = "Come trasformare una cartella di foto in un video"
+og_description = "Cosa cambiano davvero la durata e la frequenza dei fotogrammi, cosa fare con le immagini della forma sbagliata e perché non esce con la musica."
 og_image_alt = "abox.tools - strumenti che non toccano nessun server"


### PR DESCRIPTION
Recovered from uncommitted changes sitting in the worktree for `claude/website-i18n-italian`.

18 files, content only: a wording pass over the Italian guide pages.

**Left out deliberately:** the same worktree's `locales/it/planned.toml` and `locales/es/planned.toml`. Both predate the trim of the English `config/planned.toml` and carry 8 GIF items where English now has 6, which the build refuses — a locale may lag English, never lead it. `main` already has the correct versions.

**Verified:** `python build.py` completes cleanly on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)