### PR TITLE
[Uncommit] French guide translations

### DIFF
--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -151,7 +151,7 @@ note = "Travailler ses photos et ses séquences sans les confier à personne."
 [[hub.categories]]
 id = "gif-and-animation"
 name = "GIF &amp; animation"
-note = "Créez une animation, ou décomposez-la, sans qu'elle quitte votre machine."
+note = "Fabriquer une animation, ou la décomposer image par image, sans qu'elle quitte votre machine."
 
 [[hub.categories]]
 id = "audio"
@@ -168,10 +168,13 @@ id = "codes-and-data"
 name = "Codes &amp; données"
 note = "Transformer ce que vous avez tapé en quelque chose qu'une machine sait lire, sans que cela quitte la page."
 
+# La seconde catégorie qui ne part pas d'un fichier, et la seule dont l'anglais
+# nomme les trois verbes ; le français les garde à l'infinitif comme les cinq
+# autres, et leur donne l'objet que l'anglais laisse au pronom.
 [[hub.categories]]
 id = "text-and-code"
 name = "Texte &amp; code"
-note = "Mettez-le en forme, comparez-le, encodez-le, sans coller un jeton ou un fichier de configuration sur le serveur de quelqu'un d'autre."
+note = "Lire, comparer et encoder ce que vous avez écrit, sans coller un jeton ni un fichier de configuration sur le serveur de quelqu'un d'autre."
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/fr/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/fr/pages/guides/combine-images-into-a-pdf.html
@@ -1,211 +1,209 @@
   <section>
     <h2>La réponse courte</h2>
     <p>
-      Ouvrez <a href="../../images-en-pdf/">Images en PDF</a>, déposez-y les
-      images, faites glisser les tuiles jusqu'à ce que l'ordre soit bon, et créez
-      le document. Les réglages par défaut &mdash; pages A4, petite marge,
-      photographies recopiées sans réencodage &mdash; sont ce que veulent la
+      Ouvrez <a href="../../images-en-pdf/">Images en PDF</a>, déposez-y vos
+      images, faites glisser les vignettes jusqu'à ce que l'ordre soit bon, puis
+      créez le document. Les réglages par défaut &mdash; pages A4, petite marge,
+      photographies recopiées sans être réencodées &mdash; conviennent à la
       plupart des gens.
     </p>
     <p>
-      Les quatre choses qui méritent réflexion sont l'ordre, le format de page,
-      le réglage de qualité, et ce que le document fini raconte sur vous. Dans
-      cet ordre de fréquence des erreurs.
+      Quatre points méritent réflexion&nbsp;: l'ordre, le format de page, le
+      réglage de qualité, et ce que le document terminé raconte sur vous. Dans
+      cet ordre, qui est celui de la fréquence des ennuis.
     </p>
   </section>
 
   <section>
-    <h2>Réglez l'ordre avant tout le reste</h2>
+    <h2>L'ordre des pages, avant tout le reste</h2>
     <p>
-      L'ordre des pages est de loin ce qu'on rate le plus, parce que les noms de
-      fichiers se trient d'une façon à laquelle personne ne s'attend.
-      <code>IMG_2.jpg</code> vient après <code>IMG_10.jpg</code> dans un tri
-      alphabétique, puisque la comparaison se fait caractère par caractère et que
-      <code>1</code> précède <code>2</code>. Un dossier de scans nommés
-      <code>page1</code> à <code>page12</code> arrivera dans le mauvais ordre
-      dans à peu près n'importe quel outil.
+      C'est l'erreur la plus courante, parce que les noms de fichiers se classent
+      d'une manière que personne n'anticipe. Dans un tri alphabétique,
+      <code>IMG_2.jpg</code> arrive après <code>IMG_10.jpg</code>&nbsp;: la
+      comparaison se fait caractère par caractère, et <code>1</code> précède
+      <code>2</code>. Un dossier de scans nommés <code>page1</code> à
+      <code>page12</code> arrivera dans le désordre dans à peu près n'importe
+      quel outil.
     </p>
     <p>
-      Trier par date de prise de vue est en général plus fiable pour des
-      photographies, parce que vous avez photographié les pages dans l'ordre où
-      elles étaient. Dans un cas comme dans l'autre, vérifiez les tuiles avant
-      d'appuyer sur le bouton, plutôt que de vérifier le PDF après.
+      Pour des photographies, le tri par date de prise de vue est en général plus
+      fiable&nbsp;: vous avez photographié les pages dans l'ordre où elles se
+      présentaient. Dans un cas comme dans l'autre, vérifiez les vignettes avant
+      d'appuyer, plutôt que le PDF une fois qu'il est fait.
     </p>
   </section>
 
   <section>
-    <h2>La qualité&nbsp;: ce que la plupart des outils ratent en silence</h2>
+    <h2>La qualité, là où beaucoup d'outils trichent en silence</h2>
     <p>
-      Un PDF sait transporter des données JPEG directement. C'est une propriété
-      du format&nbsp;: les octets compressés d'un JPEG peuvent être déposés tels
-      quels dans le document, et le lecteur les décode comme le ferait un
-      navigateur.
+      Un PDF sait transporter des données JPEG telles quelles. C'est une
+      propriété du format&nbsp;: les octets compressés d'un JPEG peuvent être
+      déposés dans le document sans transformation, et la liseuse les décode
+      comme le ferait un navigateur.
     </p>
     <p>
-      Cela compte, parce que cela veut dire qu'une photographie n'a rien à perdre
-      en entrant dans un PDF. Elle n'est jamais décodée et jamais recompressée
-      &nbsp;; l'image du document est bit pour bit l'image de votre fichier.
-      Beaucoup d'outils réencodent quand même &mdash; il est plus simple de tout
-      rendre sur un canvas et d'encoder uniformément &mdash; et le résultat est
-      une génération de qualité perdue pour rien.
+      L'important est là&nbsp;: une photographie n'a rien à perdre en entrant
+      dans un PDF. Elle n'est jamais décodée ni recompressée, et l'image du
+      document est bit pour bit celle de votre fichier. Beaucoup d'outils
+      réencodent quand même &mdash; il est plus simple de tout redessiner sur une
+      toile et d'encoder uniformément &mdash; et cela coûte une génération de
+      qualité pour rien.
     </p>
     <p>
-      Les autres formats ne peuvent pas voyager ainsi. Le PNG, le WebP, le HEIC
-      et le reste n'ont pas de filtre correspondant dans le PDF&nbsp;: ils
-      doivent donc être convertis. Vous avez le choix de la manière&nbsp;:
+      Les autres formats ne bénéficient pas de ce passe-droit. Le PNG, le WebP,
+      le HEIC et les autres n'ont pas de filtre correspondant dans le PDF&nbsp;:
+      il faut les convertir. Vous avez le choix de la manière.
     </p>
     <ul>
       <li>
-        <strong>Réencoder en JPEG</strong> (le réglage par défaut). Fichier le
-        plus léger, petit coût en qualité, et la bonne réponse pour des
+        <strong>Réencoder en JPEG</strong> (le réglage par défaut). Le fichier le
+        plus léger, un léger coût en qualité, et la bonne réponse pour des
         photographies.
       </li>
       <li>
-        <strong>Sans perte.</strong> Stocke les pixels exacts au prix d'un
-        document bien plus lourd. La bonne réponse pour les captures d'écran, les
-        schémas, et tout ce qui contient du texte ou des bords francs, où les
-        artefacts du JPEG sautent aux yeux.
+        <strong>Sans perte.</strong> Les pixels exacts sont conservés, au prix
+        d'un document bien plus lourd. La bonne réponse pour des captures
+        d'écran, des schémas et tout ce qui contient du texte ou des contours
+        nets, où les artefacts du JPEG sautent aux yeux.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Le format de page, et quand &laquo;&nbsp;ajuster à l'image&nbsp;&raquo; vaut mieux</h2>
+    <h2>Le format de page, et quand mieux vaut suivre l'image</h2>
     <p>
-      Un format de page standard &mdash; A4, Letter, Legal, A3, A5, Tabloid
-      &mdash; pose chaque image sur une page de ce format, mise à l'échelle pour
-      tenir dans votre marge. Prenez-en un quand le document sera imprimé, ou
-      quand quelqu'un d'officiel va le classer.
+      Un format normalisé &mdash; A4, Letter, Legal, A3, A5, Tabloid &mdash;
+      pose chaque image sur une page de cette taille, mise à l'échelle pour tenir
+      dans votre marge. À choisir quand le document sera imprimé, ou quand une
+      administration doit le classer.
     </p>
     <p>
-      &laquo;&nbsp;Exactement à la taille de chaque image&nbsp;&raquo; fait
-      correspondre chaque page à son image&nbsp;: il n'y a alors ni espace blanc
-      ni mise à l'échelle. Prenez-le quand le PDF est un contenant à images
-      plutôt qu'un document&nbsp;: un portfolio, un jeu de captures, une bande
-      dessinée. Cela a l'air faux à l'impression, parce que chaque page a une
+      &laquo;&nbsp;Exactement la taille de chaque image&nbsp;&raquo; fait
+      correspondre chaque page à son image&nbsp;: ni blanc perdu, ni mise à
+      l'échelle. À choisir quand le PDF sert de boîte à images plutôt que de
+      document &mdash; un portfolio, une série de captures d'écran, une bande
+      dessinée. À l'impression, en revanche, cela rend mal, chaque page ayant une
       taille différente.
     </p>
     <p>
-      Une marge vaut la peine sur tout ce qui sera imprimé. Les imprimantes
-      domestiques ne savent pas imprimer jusqu'au bord du papier, et une
+      Gardez une marge dès que le document sera imprimé. Les imprimantes
+      domestiques ne savent pas imprimer jusqu'au bord de la feuille, et une
       photographie posée bord à bord ressort rognée.
     </p>
-    <h3>Des pages verticales à partir de photographies horizontales</h3>
+    <h3>Des pages verticales à partir de photos horizontales</h3>
     <p>
-      Si vous avez photographié des feuilles de papier avec un téléphone tenu en
-      travers, chaque image sera horizontale et se posera toute petite au milieu
-      d'une page verticale. Faire pivoter chacune d'un quart de tour avant de
-      construire le document est ce qui corrige cela, et c'est un choix par image
-      plutôt que global, parce qu'en général quelques-unes étaient dans le bon
-      sens.
+      Si vous avez photographié des feuilles de papier en tenant le téléphone en
+      travers, toutes vos images seront horizontales et se retrouveront toutes
+      petites au milieu d'une page verticale. Le remède est de faire pivoter
+      chacune d'un quart de tour avant de construire le document &mdash; et cela
+      se décide image par image, pas globalement, parce qu'il y en a
+      généralement quelques-unes qui étaient dans le bon sens.
     </p>
   </section>
 
   <section>
-    <h2>Ce que le PDF fini raconte sur vous</h2>
+    <h2>Ce que le PDF terminé raconte sur vous</h2>
     <p>
-      Un PDF porte un bloc d'informations de document&nbsp;: auteur, producteur,
-      date de création, parfois le titre. Selon ce qui l'a écrit, cela peut
-      comprendre votre nom de compte, le nom de votre machine, et l'heure exacte
-      à laquelle vous l'avez fabriqué.
+      Un PDF porte un bloc d'informations sur le document&nbsp;: auteur,
+      producteur, date de création, parfois le titre. Selon le logiciel qui l'a
+      écrit, on peut y trouver le nom de votre compte, celui de votre machine, et
+      l'heure exacte à laquelle vous l'avez fabriqué.
     </p>
     <p>
-      Cela mérite réflexion, parce qu'un PDF est une chose que les gens envoient
-      à d'autres gens &mdash; une candidature, une réclamation, un document pour
-      un propriétaire. Les métadonnées voyagent avec, et n'importe quel lecteur
-      peut les afficher.
+      Cela mérite un instant d'attention, parce qu'un PDF est fait pour être
+      envoyé à quelqu'un&nbsp;: une candidature, un dossier, une pièce demandée
+      par un propriétaire. Les métadonnées voyagent avec, et n'importe quelle
+      liseuse les affiche.
     </p>
     <p>
-      L'outil d'ici laisse ce bloc vide, à l'exception de son propre nom&nbsp;:
-      pas de noms de fichiers, pas de nom de machine, pas de nom d'utilisateur,
-      et pas de date de création sauf si vous cochez la case qui en demande une.
-      Si vous utilisez un autre outil, cela vaut la peine d'ouvrir une fois les
-      propriétés du résultat pour voir ce qu'il a écrit.
+      L'outil de ce site laisse ce bloc vide, à l'exception de son propre
+      nom&nbsp;: pas de noms de fichiers, pas de nom de machine, pas de nom
+      d'utilisateur, et pas de date de création à moins que vous ne cochiez la
+      case. Si vous employez un autre outil, ouvrez une fois les propriétés du
+      résultat pour voir ce qu'il y a inscrit.
     </p>
     <p>
-      À part cela&nbsp;: les images elles-mêmes. Si vos photographies portent des
-      étiquettes EXIF et GPS, leur sort dépend du chemin. Un JPEG recopié sans
-      réencodage garde ce qu'il avait&nbsp;; une image réencodée perd les
-      étiquettes par effet de bord. Si cela compte, nettoyez les photos d'abord
-      avec le <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur
-      EXIF</a> &mdash; <a href="../supprimer-les-donnees-exif-et-gps/">son
-      guide</a> explique ce qu'il y a dedans.
+      Autre chose&nbsp;: les images elles-mêmes. Si vos photographies portent des
+      étiquettes EXIF et GPS, leur sort dépend du chemin pris. Un JPEG recopié
+      sans réencodage garde tout ce qu'il contenait&nbsp;; une image réencodée
+      perd ses étiquettes au passage. Si cela compte, nettoyez les photos
+      d'abord avec le <a href="../../supprimer-les-donnees-exif/">lecteur et
+      effaceur EXIF</a> &mdash;
+      <a href="../supprimer-les-donnees-exif-et-gps/">son guide</a> détaille ce
+      qui s'y trouve.
     </p>
   </section>
 
   <section>
-    <h2>Si le PDF ressort trop gros</h2>
+    <h2>Si le PDF ressort trop lourd</h2>
     <p>
-      Les photographies de téléphone sont lourdes, et vingt d'entre elles font un
-      document qu'un courriel refusera. Trois choses à essayer, dans
-      l'ordre&nbsp;:
+      Les photos de téléphone sont lourdes, et vingt d'entre elles font un
+      document que la messagerie refusera. Trois choses à essayer, dans l'ordre.
     </p>
     <p>
-      <strong>Réduisez le plus grand côté.</strong> Une photographie de 4000
-      pixels d'une feuille de papier transporte bien plus de détail qu'aucun
-      lecteur ni aucune imprimante n'en utilisera. Ramener le grand côté à
-      quelque chose comme 2000 pixels divise typiquement le fichier par quatre et
-      ne change rien que quiconque puisse voir sur une page.
+      <strong>Réduisez le plus grand côté.</strong> Une photo de 4000 pixels
+      représentant une feuille de papier transporte bien plus de détail
+      qu'aucune liseuse ni aucune imprimante n'en emploiera. Ramener le grand
+      côté vers 2000 pixels divise typiquement le fichier par quatre sans que
+      personne voie la différence sur une page.
     </p>
     <p>
-      <strong>Prenez le JPEG plutôt que le sans perte</strong> pour tout ce qui
-      est photographique. Le sans perte est la bonne réponse pour les schémas et
-      la mauvaise pour la photo d'une page.
+      <strong>Préférez le JPEG au sans-perte</strong> pour tout ce qui est
+      photographique. Le sans-perte est la bonne réponse pour un schéma, la
+      mauvaise pour la photo d'une page.
     </p>
     <p>
-      <strong>Compressez le document fini.</strong> Le
-      <a href="../../compresser-un-pdf/">compresseur de PDF</a> travaille par
-      rapport à la taille à laquelle chaque image est dessinée sur la page plutôt
-      que par rapport à son nombre de pixels, et c'est la mesure qui
-      compte&nbsp;; <a href="../reduire-la-taille-d-un-pdf/">son guide</a> traite
-      de ce que cela coûte.
+      <strong>Compressez le document une fois terminé.</strong> Le
+      <a href="../../compresser-un-pdf/">compresseur de PDF</a> raisonne sur la
+      taille à laquelle chaque image est dessinée sur la page plutôt que sur son
+      nombre de pixels, ce qui est la mesure qui compte&nbsp;;
+      <a href="../reduire-la-taille-d-un-pdf/">son guide</a> explique ce que cela
+      coûte.
     </p>
     <p>
-      Aucune limite n'est intégrée à l'outil quant au nombre d'images. Le plafond
-      pratique est la mémoire de votre propre machine, parce que le document fini
-      y est assemblé avant que vous le téléchargiez &mdash; quelques centaines de
-      photos de téléphone en pleine résolution est la première chose à s'en
-      ressentir, et réduire le plus grand côté repousse ce plafond bien plus
-      loin.
+      L'outil n'impose aucune limite au nombre d'images. Le vrai plafond est la
+      mémoire de votre machine, puisque le document terminé y est assemblé avant
+      que vous le téléchargiez&nbsp;: quelques centaines de photos de téléphone
+      en pleine résolution suffisent à le faire sentir, et réduire le grand côté
+      repousse ce plafond très loin.
     </p>
   </section>
 
   <section>
     <h2>Ce que cela ne vous donnera pas</h2>
     <p>
-      Un PDF fait de photographies est un PDF plein d'images. Les mots qui y
-      figurent ne sont pas du texte&nbsp;: vous ne pouvez ni les chercher, ni les
-      copier, ni les faire lire par un lecteur d'écran. C'est une propriété de ce
-      dont vous êtes parti, pas de la conversion.
+      Un PDF fabriqué à partir de photographies est un PDF plein d'images. Les
+      mots qui s'y trouvent ne sont pas du texte&nbsp;: on ne peut ni les
+      chercher, ni les copier, ni les faire lire par un lecteur d'écran. Cela
+      tient à ce dont vous êtes parti, pas à la conversion.
     </p>
     <p>
-      S'il vous faut du texte cherchable, il vous faut de l'OCR, qui est un autre
-      métier. Et si le document d'origine existe encore quelque part comme
-      document, l'exporter directement en PDF battra toujours le fait de le
-      photographier &mdash; plus léger, plus net, cherchable.
+      S'il vous faut du texte cherchable, il vous faut de l'OCR, et c'est un
+      autre travail. Et si le document d'origine existe encore quelque part sous
+      forme de document, l'exporter directement en PDF battra toujours la
+      photographie&nbsp;: plus léger, plus net, cherchable.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi cela ne demande pas d'envoi</h2>
+    <h2>Pourquoi cela n'exige pas d'envoi</h2>
     <p>
-      Écrire un PDF, c'est écrire un fichier structuré&nbsp;: un en-tête, un jeu
-      d'objets, une table de références croisées. Il n'y a rien là-dedans qu'un
-      navigateur ne sache faire, et rien dans ce travail qui exige que les images
-      voyagent où que ce soit.
+      Écrire un PDF, c'est écrire un fichier structuré&nbsp;: un en-tête, une
+      série d'objets, une table de références croisées. Rien là-dedans qu'un
+      navigateur ne sache faire, et rien qui oblige les images à voyager où que
+      ce soit.
     </p>
     <p>
-      Ce qui mérite attention ici, à cause de ce que les gens mettent dans ces
-      documents. Pièces d'identité, relevés bancaires, courriers médicaux,
-      contrats signés &mdash; toute la raison pour laquelle quelqu'un fabrique un
-      PDF est en général qu'il l'envoie à une institution. L'outil d'ici n'a
-      aucune fonction réseau, et la <code>Content-Security-Policy</code> de la
-      page nomme toutes les adresses qu'elle peut contacter, dont aucune
-      n'appartient à ce site.
+      Ce dont il vaut la peine de se soucier ici, vu ce qu'on met dans ces
+      documents&nbsp;: pièces d'identité, relevés bancaires, courriers médicaux,
+      contrats signés. Si l'on fabrique un PDF, c'est le plus souvent pour
+      l'envoyer à une institution. L'outil de ce site n'a aucune fonction réseau,
+      et la <code>Content-Security-Policy</code> de la page énumère toutes les
+      adresses qu'elle peut contacter, dont aucune n'appartient à ce site.
     </p>
     <p>
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose comment le vérifier
-      vous-même, ici comme ailleurs.
+      fichiers à un convertisseur en ligne&nbsp;?</a> explique comment le
+      vérifier vous-même, ici comme ailleurs.
     </p>
   </section>

--- a/locales/fr/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/fr/pages/guides/combine-images-into-a-pdf.toml
@@ -3,15 +3,15 @@
 #
 
 nav = "Des images dans un PDF"
-title = "Comment réunir des images dans un seul PDF"
-description = "Transformer des photos ou des scans en un seul PDF : format de page, ordre et rotation, pourquoi un JPEG n'a pas à perdre de qualité en entrant, et ce qu'un PDF raconte à la personne à qui vous l'envoyez."
-heading = "Comment réunir des images dans un seul PDF"
+title = "Comment réunir plusieurs images dans un seul PDF"
+description = "Transformer des photos ou des scans en un seul PDF : format de page, ordre et rotation, pourquoi un JPEG n'a rien à perdre en entrant, et ce que le document raconte à celui qui le reçoit."
+heading = "Comment réunir plusieurs images dans un seul PDF"
 lede = """
     On vous a demandé &laquo;&nbsp;un seul PDF&nbsp;&raquo; et vous avez onze
-    photographies de papier. Voici les choix qui changent vraiment le résultat
-    &mdash; format de page, ordre, qualité, et ce que le document dit de vous
-    &mdash; et ceux que vous pouvez ignorer."""
+    photos de feuilles de papier. Voici les choix qui changent vraiment le
+    résultat &mdash; ordre, format de page, qualité, et ce que le document dit
+    de vous &mdash; et ceux que vous pouvez ignorer."""
 updated = "20 août 2026"
-og_title = "Comment réunir des images dans un seul PDF"
-og_description = "Format de page, ordre et rotation, pourquoi un JPEG n'a pas à perdre de qualité en entrant, et ce qu'un PDF raconte à la personne à qui vous l'envoyez."
+og_title = "Comment réunir plusieurs images dans un seul PDF"
+og_description = "Format de page, ordre et rotation, pourquoi un JPEG n'a rien à perdre en entrant, et ce que le document raconte à celui qui le reçoit."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/fr/pages/guides/compress-an-image-to-a-target-size.html
@@ -2,178 +2,179 @@
     <h2>La réponse courte</h2>
     <p>
       Ouvrez le <a href="../../compresser-une-image/">compresseur d'images</a>,
-      déposez-y la photo, tapez le chiffre qu'on vous a donné et appuyez sur le
-      bouton. Il encode l'image plusieurs fois, garde le meilleur résultat qui
-      tienne sous votre cible, et vous dit ce que cela a coûté. Pour la plupart
-      des photographies et la plupart des cibles, le résumé honnête est que vous
+      déposez-y votre photo, tapez le chiffre qu'on vous a imposé et lancez.
+      L'outil encode l'image plusieurs fois, retient le meilleur résultat qui
+      tienne sous la cible et vous dit ce que cela a coûté. Pour la plupart des
+      photographies et la plupart des cibles, disons-le franchement&nbsp;: vous
       ne verrez pas la différence.
     </p>
     <p>
-      Le reste de cette page est pour les fois où cela ne se passe pas ainsi
-      &nbsp;: quand le résultat paraît mou, quand un PNG bouge à peine, ou quand
-      vous voulez savoir ce que l'outil fait réellement à votre image avant de
-      l'envoyer à quelqu'un.
+      Le reste de cette page est là pour les autres cas&nbsp;: quand le résultat
+      paraît mou, quand un PNG ne bouge presque pas, ou quand vous voulez savoir
+      ce que l'outil fait vraiment à votre image avant de l'envoyer à quelqu'un.
     </p>
   </section>
 
   <section>
     <h2>Ce qu'une limite de taille demande vraiment</h2>
     <p>
-      Un JPEG ou un WebP ne stocke pas votre photographie. Il en stocke une
-      description, et le réglage de qualité décide du niveau de détail auquel
-      cette description a droit. Baissez-le et le fichier rétrécit parce que la
-      description devient plus vague&nbsp;: les textures fines sont moyennées,
-      les dégradés se mettent en bandes, et les bords se couvrent d'un léger halo
-      de blocs.
+      Un JPEG ou un WebP n'enregistre pas votre photographie&nbsp;: il en
+      enregistre une description, et le réglage de qualité décide du degré de
+      détail auquel cette description a droit. Baissez-le, et le fichier
+      s'allège parce que la description devient plus vague &mdash; les textures
+      fines sont moyennées, les dégradés se cassent en bandes, et les contours
+      s'entourent d'un léger halo de blocs.
     </p>
     <p>
-      Une limite de taille est donc un budget de détail. La question utile n'est
-      pas &laquo;&nbsp;puis-je atteindre 500&nbsp;KB&nbsp;&raquo; &mdash; on peut
-      toujours atteindre n'importe quel chiffre &mdash; mais
-      &laquo;&nbsp;quelle part de l'image dois-je abandonner pour y arriver, et
-      est-ce que cela compte pour l'usage que j'en fais&nbsp;?&nbsp;&raquo;
+      Une limite de taille est donc un budget de détail. La bonne question n'est
+      pas &laquo;&nbsp;puis-je descendre à 500&nbsp;KB&nbsp;?&nbsp;&raquo; (on
+      atteint toujours n'importe quel chiffre) mais &laquo;&nbsp;quelle part de
+      l'image faut-il abandonner pour y arriver, et cela change-t-il quelque
+      chose à l'usage que j'en fais&nbsp;?&nbsp;&raquo;
     </p>
     <p>
-      Deux règles empiriques. Une photographie d'une scène réelle &mdash;
-      visages, feuillages, tissus &mdash; cache bien la compression, parce que
-      l'œil n'y trouve aucune zone parfaitement plate où remarquer les dégâts.
-      Une capture d'écran, un graphique, un logo ou tout ce qui a de grands
-      aplats et des bords de texte francs la montre immédiatement, et devrait en
-      général être un PNG ou un WebP plutôt qu'un JPEG.
+      Deux repères. Une photographie de scène réelle &mdash; des visages, du
+      feuillage, du tissu &mdash; encaisse très bien la compression, faute d'une
+      surface parfaitement lisse où l'œil pourrait repérer les dégâts. Une
+      capture d'écran, un graphique, un logo, tout ce qui mêle grands aplats et
+      contours de texte nets, la révèle aussitôt&nbsp;: ces images-là ont presque
+      toujours leur place en PNG ou en WebP, pas en JPEG.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi il n'y a pas de formule, et que faire à la place</h2>
+    <h2>Pourquoi il n'existe pas de formule, et comment s'en passer</h2>
     <p>
-      Il n'existe aucun moyen de calculer le réglage de qualité qui produit un
-      fichier de 500&nbsp;KB. Le rapport entre les deux dépend entièrement du
-      contenu de l'image&nbsp;: au même réglage, une photographie d'un mur nu
-      peut ressortir dix fois plus légère qu'une photographie de forêt. Tout
-      outil qui vous propose &laquo;&nbsp;qualité&nbsp;: 60&nbsp;&raquo; et croise
-      les doigts devine à votre place.
+      Aucun calcul ne donne le réglage de qualité qui produira un fichier de
+      500&nbsp;KB. Le rapport entre les deux dépend entièrement du contenu de
+      l'image&nbsp;: au même réglage, la photo d'un mur nu peut peser dix fois
+      moins que celle d'un sous-bois. Un outil qui vous propose
+      &laquo;&nbsp;qualité&nbsp;: 60&nbsp;&raquo; et espère que cela passera
+      devine à votre place.
     </p>
     <p>
-      La seule méthode fiable est d'essayer. Encoder l'image, regarder la taille,
-      ajuster, encoder à nouveau. Le faire à la main est fastidieux, et c'est
-      pourquoi les compresseurs demandent un chiffre de qualité à la place
-      &mdash; cela vous refile le fastidieux. Le faire automatiquement, c'est
-      environ huit encodages, et huit encodages d'une photo de téléphone
-      représentent une fraction de seconde sur toute machine construite cette
-      décennie&nbsp;: c'est pourquoi l'outil de ce site demande la taille et fait
-      la recherche lui-même.
+      La seule méthode qui tienne consiste à essayer&nbsp;: encoder, regarder la
+      taille, corriger, recommencer. À la main, c'est fastidieux, et c'est bien
+      pour cela que les compresseurs vous réclament un chiffre de qualité
+      &mdash; la corvée vous revient. Automatisée, la même chose représente
+      environ huit encodages, soit une fraction de seconde sur n'importe quelle
+      machine de cette décennie pour une photo de téléphone. D'où le parti pris
+      de l'outil de ce site&nbsp;: vous donnez la taille, il se charge de
+      chercher.
     </p>
     <p>
-      Chaque taille qu'il rapporte est un vrai fichier encodé, pas une
-      estimation. Cela compte quand un formulaire a une limite dure&nbsp;: une
-      estimation optimiste de 2&nbsp;%, c'est un envoi refusé.
+      Chaque taille annoncée correspond à un vrai fichier encodé, pas à une
+      estimation. La nuance compte devant un formulaire à limite stricte&nbsp;:
+      une estimation optimiste de 2&nbsp;%, c'est un envoi refusé.
     </p>
   </section>
 
   <section>
     <h2>Dépensez la qualité avant de dépenser les pixels</h2>
     <p>
-      Il n'y a que deux façons d'alléger un fichier image. Décrire la même image
-      moins précisément, c'est la qualité. Ou décrire moins de pixels, c'est le
-      redimensionnement. Ce n'est pas équivalent, et l'ordre compte.
+      Il n'y a que deux façons d'alléger un fichier image&nbsp;: décrire la même
+      image moins précisément, c'est la qualité&nbsp;; ou décrire moins de
+      pixels, c'est le redimensionnement. Les deux ne se valent pas, et l'ordre
+      compte.
     </p>
     <p>
-      La qualité passe en premier, parce que les 30&nbsp;% premiers de réduction
-      de qualité sont réellement invisibles sur une photographie &mdash; vous
-      jetez du détail que le format conservait plus soigneusement qu'aucun œil ne
-      peut le vérifier. Les pixels passent en second, parce qu'une fois la
-      qualité descendue assez bas pour que les artefacts se voient, une image
-      plus petite à une qualité correcte est plus belle qu'une image en taille
-      pleine mais abîmée. Moins de bons pixels valent mieux que davantage de
+      La qualité passe en premier, parce que sur une photographie on peut en
+      retirer près d'un tiers sans que cela se voie&nbsp;: le détail ainsi
+      abandonné, le format le conservait avec plus de soin qu'aucun œil n'est
+      capable d'en vérifier. Les pixels viennent en second, parce qu'une fois la
+      qualité descendue assez bas pour que les artefacts affleurent, une image
+      plus petite à une qualité correcte est plus belle qu'une image en pleine
+      taille mais abîmée. Peu de bons pixels valent mieux que beaucoup de
       mauvais.
     </p>
     <p>
-      C'est toute la stratégie, et elle vaut d'être connue même si vous utilisez
-      un autre outil&nbsp;: baissez la qualité jusqu'à ce que cela commence à
-      avoir l'air faux, puis réduisez l'image au lieu de la baisser davantage.
+      Voilà toute la stratégie, et elle vaut d'être connue même si vous employez
+      un autre outil&nbsp;: baissez la qualité jusqu'au moment où quelque chose
+      commence à sonner faux, puis réduisez l'image au lieu de baisser encore.
     </p>
-    <h3>Quand redimensionner exprès</h3>
+    <h3>Quand redimensionner délibérément</h3>
     <p>
-      Parfois, les pixels n'ont jamais été nécessaires. Une photo de 4000 pixels
-      de large affichée dans une colonne de 600 pixels sur une page web transporte
-      six fois le détail que quiconque verra. Si vous connaissez la destination
-      finale de l'image, redimensionnez-la d'abord et le problème de taille
-      disparaît souvent sans qu'une once de qualité soit dépensée. Le
-      <a href="../../redimensionner-une-image/">redimensionneur d'images</a> est
-      l'outil pour cela, et <a href="../redimensionner-une-image/">son propre
-      guide</a> traite du choix d'une taille.
+      Il arrive que les pixels n'aient jamais servi à rien. Une photo de 4000
+      pixels de large affichée dans une colonne de 600 pixels transporte six fois
+      le détail que qui que ce soit verra. Si vous connaissez la destination
+      finale de l'image, commencez par la mettre à cette taille&nbsp;: le
+      problème de poids disparaît souvent tout seul, sans avoir dépensé un gramme
+      de qualité. C'est le travail du
+      <a href="../../redimensionner-une-image/">redimensionneur d'images</a>, et
+      <a href="../redimensionner-une-image/">son guide</a> explique comment
+      choisir la bonne taille.
     </p>
   </section>
 
   <section>
     <h2>Choisir un format</h2>
     <p>
-      Trois formats valent d'être connus, et les navigateurs savent écrire les
+      Trois formats méritent d'être connus, et les navigateurs savent écrire les
       trois.
     </p>
     <ul>
       <li>
-        <strong>Le JPEG</strong> est fait pour les photographies. Il est avec
-        perte, il est compris par tout ce qui a jamais été fabriqué, et pour une
-        image de scène réelle il reste un excellent choix. Il ne sait pas stocker
-        de transparence.
+        <strong>Le JPEG</strong> est fait pour la photographie. Il travaille avec
+        perte, tout ce qui a jamais été fabriqué sait le lire, et pour une scène
+        réelle il reste un excellent choix. En revanche il ignore la
+        transparence.
       </li>
       <li>
-        <strong>Le WebP</strong> fait le même travail, en mieux&nbsp;: environ 25
-        à 35&nbsp;% plus léger que le JPEG à une qualité qu'on ne distingue pas,
-        et il garde la transparence. Tous les navigateurs actuels le lisent.
-        Quelques vieilles applications de bureau et certains formulaires d'envoi
-        d'entreprise ne le font toujours pas, ce qui est la seule vraie raison de
-        ne pas s'en servir.
+        <strong>Le WebP</strong> fait le même travail en mieux&nbsp;: de 25 à
+        35&nbsp;% plus léger qu'un JPEG à une qualité qu'on ne sait pas
+        distinguer, et il conserve la transparence. Tous les navigateurs actuels
+        le lisent&nbsp;; quelques logiciels de bureau anciens et certains
+        formulaires d'entreprise, non, et c'est la seule vraie raison de s'en
+        priver.
       </li>
       <li>
-        <strong>Le PNG</strong> est sans perte, c'est-à-dire exact et lourd.
-        C'est la bonne réponse pour les captures d'écran, les logos, le dessin au
-        trait et tout ce qui a des bords francs ou des aplats, et la mauvaise
-        réponse pour une photographie.
+        <strong>Le PNG</strong> est sans perte, donc exact et lourd. C'est la
+        bonne réponse pour une capture d'écran, un logo, un dessin au trait, tout
+        ce qui a des contours nets ou des aplats &mdash; et la mauvaise pour une
+        photographie.
       </li>
     </ul>
     <p>
-      Si celui qui vous a demandé le fichier ne vous impose rien, le WebP vous
-      amènera à la cible avec moins de dégâts visibles que le JPEG. Si le fichier
-      part dans quelque chose d'ancien, ou dans un système que vous ne pouvez pas
-      tester, le JPEG est la réponse sûre.
+      Si la personne qui vous réclame le fichier ne vous impose rien, le WebP
+      atteindra la cible avec moins de casse visible que le JPEG. Si le fichier
+      part dans un logiciel ancien, ou dans un système que vous n'avez aucun
+      moyen d'essayer, le JPEG reste la valeur sûre.
     </p>
   </section>
 
   <section>
     <h2>Pourquoi votre PNG ne maigrira pas beaucoup</h2>
     <p>
-      C'est la surprise la plus courante, et ce n'est pas un défaut de l'outil
-      que vous utilisez. Le PNG est un format sans perte&nbsp;: il stocke les
-      pixels exacts, et il n'a aucune molette de qualité à tourner, parce que
-      tourner une telle molette en ferait un autre format. Tout ce qu'un
-      compresseur PNG peut faire, c'est empaqueter les mêmes pixels plus
-      astucieusement, ce qui vaut en général quelques pour cent.
+      C'est la déconvenue la plus fréquente, et elle ne vient pas de l'outil que
+      vous utilisez. Le PNG est un format sans perte&nbsp;: il enregistre les
+      pixels exacts et n'a aucun curseur de qualité à baisser, puisqu'un tel
+      curseur en ferait un autre format. Tout ce qu'un compresseur de PNG peut
+      faire, c'est ranger les mêmes pixels plus habilement, ce qui rapporte en
+      général quelques pour cent.
     </p>
     <p>
-      Donc, s'il vous faut un fichier bien plus léger et qu'il doit rester un
-      PNG, le seul levier restant est la taille &mdash; moins de pixels, ou moins
-      de couleurs. S'il a le droit de cesser d'être un PNG, la question est ce
-      qu'il y a dedans&nbsp;:
+      S'il vous faut donc un fichier nettement plus léger et qu'il doit rester un
+      PNG, il ne reste qu'un levier&nbsp;: moins de pixels, ou moins de couleurs.
+      Si en revanche il a le droit de changer de format, tout dépend de ce qu'il
+      contient.
     </p>
     <ul>
       <li>
-        <strong>Une photographie enregistrée en PNG.</strong> Très courant, en
-        général par accident, et le gain le plus facile de cette page&nbsp;: la
-        convertir en JPEG ou en WebP la rendra souvent cinq à dix fois plus
-        légère sans changement visible.
+        <strong>Une photographie enregistrée en PNG.</strong> C'est fréquent,
+        c'est presque toujours involontaire, et c'est le gain le plus facile de
+        cette page&nbsp;: la convertir en JPEG ou en WebP la rend souvent cinq à
+        dix fois plus légère, sans changement visible.
       </li>
       <li>
-        <strong>Une capture d'écran ou un schéma.</strong> Convertissez en WebP,
-        qui est sans perte lui aussi quand vous le lui demandez, et qui est
-        généralement plus léger que le PNG pour les mêmes pixels. Passer en JPEG
-        rendra les bords du texte flous.
+        <strong>Une capture d'écran ou un schéma.</strong> Passez en WebP, qui
+        sait travailler sans perte lui aussi quand on le lui demande, et qui est
+        en général plus léger que le PNG à pixels égaux. Le JPEG, lui, rendrait
+        les contours du texte flous.
       </li>
       <li>
         <strong>Un logo avec transparence.</strong> Le WebP garde la
-        transparence&nbsp;; le JPEG la remplira d'une couleur unie, ce qui n'est
-        presque jamais ce que vous vouliez.
+        transparence&nbsp;; le JPEG la remplace par un aplat de couleur, ce qui
+        n'est presque jamais ce que vous cherchiez.
       </li>
     </ul>
   </section>
@@ -181,30 +182,30 @@
   <section>
     <h2>Comment savoir si le résultat est assez bon</h2>
     <p>
-      Regarder une vignette ne prouve rien &mdash; tout a l'air correct en
-      vignette. Deux vérifications valent mieux&nbsp;:
+      Juger sur une vignette ne prouve rien&nbsp;: à cette taille, tout paraît
+      correct. Deux vérifications valent mieux.
     </p>
     <p>
-      <strong>Regardez-la en taille réelle, sur la zone la plus plate de
-      l'image.</strong> Le ciel, la peau, un mur peint. Les dégâts de compression
-      apparaissent d'abord dans les dégradés doux, sous forme de blocs ou de
-      bandes légères, bien avant de toucher les zones détaillées.
+      <strong>Regardez l'image en taille réelle, à l'endroit le plus lisse du
+      cadre&nbsp;:</strong> un ciel, une peau, un mur peint. Les dégâts de la
+      compression se voient d'abord dans les dégradés doux, sous forme de bandes
+      ou de blocs à peine marqués, bien avant d'atteindre les zones détaillées.
     </p>
     <p>
-      <strong>Lisez la mesure, si l'outil vous en donne une.</strong> Le
-      compresseur d'ici décode son propre résultat et le compare à l'original, et
-      rapporte le SSIM&nbsp;: un chiffre qui compare la luminosité, le contraste
-      et la structure locales plutôt que de compter les pixels modifiés, ce qui
-      est bien plus proche de ce qui gêne un œil. Au-dessus de 0,98 environ, les
-      deux images sont difficiles à séparer côte à côte. En dessous de 0,95
-      environ, regardez avant d'envoyer. Il rapporte aussi le PSNR, le chiffre en
-      décibels traditionnel, pour qui le préfère.
+      <strong>Lisez la mesure, si l'outil vous en fournit une.</strong> Le
+      compresseur de ce site décode son propre résultat, le compare à l'original
+      et affiche le SSIM&nbsp;: un indice qui rapproche luminosité, contraste et
+      structure locales au lieu de compter les pixels modifiés, ce qui colle bien
+      mieux à ce qui gêne un œil. Au-dessus de 0,98 environ, les deux images sont
+      difficiles à départager côte à côte&nbsp;; en dessous de 0,95, regardez
+      avant d'envoyer. Le PSNR, le vieil indice en décibels, est affiché aussi,
+      pour qui le préfère.
     </p>
     <p>
-      Les deux sont calculés sur votre propre machine et vous sont montrés, et
-      c'est tout l'intérêt de les avoir&nbsp;: cela transforme
-      &laquo;&nbsp;perte de qualité minimale&nbsp;&raquo; d'une affirmation en un
-      chiffre vérifiable.
+      Les deux sont calculés sur votre machine et vous sont montrés, et c'est
+      tout leur intérêt&nbsp;: ils font d'une
+      &laquo;&nbsp;perte de qualité minime&nbsp;&raquo; annoncée un chiffre que
+      vous pouvez vérifier.
     </p>
   </section>
 
@@ -212,48 +213,46 @@
     <h2>Trois choses à savoir avant d'envoyer le fichier</h2>
     <p>
       <strong>Compresser efface les métadonnées.</strong> Réencoder, c'est
-      décoder l'image en pixels puis réencoder ces pixels, et un canvas plein de
-      pixels ne porte aucune étiquette &mdash; la position GPS, le modèle
-      d'appareil, les horodatages et le reste ne sont donc simplement pas écrits
-      dans le nouveau fichier. C'est généralement un bonus. Si vous vouliez les
-      étiquettes disparues mais l'image intacte, c'est un autre travail&nbsp;: le
+      décoder l'image en pixels puis réencoder ces pixels&nbsp;; or une toile
+      pleine de pixels ne porte aucune étiquette, si bien que la position GPS, le
+      modèle d'appareil, les horodatages et tout le reste ne sont tout simplement
+      pas réécrits. En général, tant mieux. Mais si vous vouliez les étiquettes
+      en moins et l'image intacte, c'est un autre travail&nbsp;: le
       <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a>
       réécrit le conteneur sans rien recompresser, et
-      <a href="../supprimer-les-donnees-exif-et-gps/">son guide</a> explique ce
-      qu'il y a dedans.
+      <a href="../supprimer-les-donnees-exif-et-gps/">son guide</a> détaille ce
+      qui s'y trouve.
     </p>
     <p>
       <strong>Ne compressez jamais deux fois le même fichier.</strong> Chaque
-      encodage avec perte jette du détail définitivement, et encoder une image
-      déjà compressée en jette davantage &mdash; y compris les artefacts de la
-      première passe, qu'il conserve fidèlement au prix du vrai détail. Repartez
-      toujours de l'original et compressez une seule fois.
+      encodage avec perte abandonne du détail pour de bon, et encoder une image
+      déjà compressée en abandonne davantage &mdash; en préservant fidèlement,
+      qui plus est, les artefacts du premier passage, au prix du détail qui
+      restait. Repartez toujours de l'original, et compressez une seule fois.
     </p>
     <p>
-      <strong>Gardez l'original.</strong> Il n'y a pas de retour possible après
-      un encodage avec perte. Quoi que vous envoyiez, gardez quelque part le
-      fichier de départ.
+      <strong>Gardez l'original.</strong> Un encodage avec perte ne se défait
+      pas. Quoi que vous envoyiez, conservez quelque part le fichier de départ.
     </p>
   </section>
 
   <section>
-    <h2>Rien de tout cela ne demande un envoi</h2>
+    <h2>Rien de tout cela n'exige un envoi</h2>
     <p>
-      Tous les navigateurs livrent un encodeur JPEG, PNG et WebP depuis des
-      années &mdash; c'est le même code qui enregistre une image depuis un
-      canvas. Compresser une image fait partie des travaux qui n'ont aucune
-      raison technique de faire intervenir un serveur, et c'est pourquoi l'outil
-      d'ici n'en a pas&nbsp;: l'image est décodée, encodée et mesurée sur votre
-      propre machine, et il n'y a dans la
-      <code>Content-Security-Policy</code> de la page aucune adresse appartenant
-      à ce site vers laquelle elle pourrait être envoyée.
+      Les navigateurs embarquent un encodeur JPEG, PNG et WebP depuis des années
+      &mdash; c'est le même code qui enregistre une image depuis une toile.
+      Compresser une image fait partie des travaux qui n'ont aucune raison
+      technique de passer par un serveur, et c'est pourquoi l'outil de ce site
+      n'en a pas&nbsp;: l'image est décodée, encodée et mesurée sur votre propre
+      machine, et la <code>Content-Security-Policy</code> de la page ne contient
+      aucune adresse appartenant à ce site vers laquelle elle pourrait partir.
     </p>
     <p>
-      La façon la plus simple de le confirmer, ici comme ailleurs, est de charger
-      la page, de couper la connexion, et de compresser quelque chose quand même.
-      Si cela fonctionne encore, rien n'était envoyé.
+      Le moyen le plus simple de le vérifier, ici comme ailleurs&nbsp;: chargez
+      la page, coupez la connexion, et compressez quelque chose quand même. Si
+      cela marche encore, c'est que rien ne partait.
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
-      vérifications du même genre.
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente trois autres
+      vérifications du même ordre.
     </p>
   </section>

--- a/locales/fr/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/fr/pages/guides/compress-an-image-to-a-target-size.toml
@@ -3,15 +3,14 @@
 #
 
 nav = "Compresser une image"
-title = "Comment compresser une image à une taille de fichier exacte"
-description = "Un formulaire d'envoi veut 500 KB et votre photo en fait 4 MB. Ce qu'une limite de taille coûte vraiment, quel réglage déplacer en premier, et pourquoi un PNG ne maigrit pas comme un JPEG."
-heading = "Comment compresser une image à une taille de fichier exacte"
+title = "Comment compresser une image à une taille précise"
+description = "Le formulaire veut 500 KB et votre photo en fait 4 MB. Ce qu'une limite de taille coûte vraiment, quel réglage baisser en premier, et pourquoi un PNG ne maigrit pas comme un JPEG."
+heading = "Comment compresser une image à une taille précise"
 lede = """
     On vous a donné un chiffre &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
-    &mdash; et votre photo en est très loin. Voici ce que ce chiffre coûte, à
-    quoi le dépenser, et comment savoir si le résultat est encore assez bon pour
-    être envoyé."""
+    &mdash; et votre photo en est loin. Voici ce que ce chiffre coûte, à quoi le
+    dépenser en priorité, et comment savoir si le résultat reste présentable."""
 updated = "20 août 2026"
-og_title = "Compresser une image à une taille de fichier exacte"
-og_description = "Ce qu'une limite de taille coûte vraiment, quel réglage déplacer en premier, et pourquoi un PNG ne maigrit pas comme un JPEG."
+og_title = "Compresser une image à une taille précise"
+og_description = "Ce qu'une limite de taille coûte vraiment, quel réglage baisser en premier, et pourquoi un PNG ne maigrit pas comme un JPEG."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/convert-an-svg-to-png.html
+++ b/locales/fr/pages/guides/convert-an-svg-to-png.html
@@ -1,253 +1,251 @@
   <section>
     <h2>La réponse courte</h2>
     <p>
-      Ouvrez <a href="../../convertir-svg-en-png/">SVG en image</a>, déposez-y le
-      fichier, et nommez une taille. Si rien ne vous a dit quelle taille prendre,
+      Ouvrez <a href="../../convertir-svg-en-png/">SVG en image</a>, déposez-y
+      votre fichier et donnez une taille. Si rien ne vous en impose une,
       <strong>1024 pixels sur le plus grand côté</strong> est un bon
-      défaut&nbsp;: assez grand pour presque tout et assez petit pour un
-      courriel. Laissez le format sur PNG, laissez le fond sur transparent, et
-      prenez le fichier.
+      choix&nbsp;: assez grand pour presque tout, assez léger pour tenir dans un
+      courriel. Laissez le format sur PNG, le fond sur transparent, et prenez le
+      fichier.
     </p>
     <p>
-      Tout ce qui suit est pour les cas où ce défaut ne suffit pas &mdash; quand
-      un chiffre vous a été imposé, quand cela part à l'impression, ou quand cela
-      revient avec l'air faux.
+      Tout ce qui suit vaut pour les cas où ce réglage ne suffit pas&nbsp;: quand
+      on vous a donné un chiffre, quand le résultat part à l'impression, ou quand
+      il revient bancal.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi la taille est votre décision et non celle du fichier</h2>
+    <h2>Pourquoi la taille vous appartient, et non au fichier</h2>
     <p>
-      Un JPEG est une grille de pixels mesurés&nbsp;; demander sa taille a une
-      réponse. Un SVG n'est pas une image du tout, c'est un jeu d'instructions
-      &mdash; dessine un cercle ici, ce tracé dans cette couleur &mdash; et des
+      Un JPEG est une grille de pixels mesurés&nbsp;; lui demander sa taille a un
+      sens. Un SVG n'est pas une image du tout, c'est une suite d'instructions
+      &mdash; trace un cercle ici, ce chemin dans cette couleur &mdash; et des
       instructions n'ont pas de taille. Un navigateur peut les exécuter à 16
-      pixels ou à 4000 et le résultat est aussi net dans les deux cas, parce
-      qu'il ne met rien à l'échelle. Il redessine.
+      pixels ou à 4000, le résultat sera aussi net dans les deux cas, parce qu'il
+      ne met rien à l'échelle&nbsp;: il redessine.
     </p>
     <p>
-      C'est pourquoi la conversion ne peut pas choisir un chiffre à votre place,
+      Voilà pourquoi la conversion ne peut pas choisir le chiffre à votre place,
       et pourquoi en choisir un grand ne vous coûte rien. C'est le seul travail
-      d'image où &laquo;&nbsp;fais-le plus grand&nbsp;&raquo; est gratuit.
+      d'image où &laquo;&nbsp;plus grand&nbsp;&raquo; est gratuit.
     </p>
     <p>
       La plupart des fichiers SVG portent bien un attribut <code>width</code> et
-      <code>height</code>, et un outil vous le montrera &mdash; mais c'est un
-      défaut, pas une limite. Une icône qui dit <code>width="24"</code> dit
-      seulement que la personne qui l'a dessinée avait en tête une barre d'outils
-      de 24&nbsp;pixels.
+      un attribut <code>height</code>, et un outil vous les montrera &mdash; mais
+      c'est une valeur par défaut, pas une limite. Une icône qui annonce
+      <code>width="24"</code> dit seulement que la personne qui l'a dessinée avait
+      en tête une barre d'outils de 24&nbsp;pixels.
     </p>
   </section>
 
   <section>
-    <h2>D'où vient réellement le chiffre</h2>
-    <p><strong>Pour un site web.</strong> Prenez la taille que l'image occupe sur
-      la page en pixels CSS et multipliez par la densité des écrans qui vous
-      importent. Un logo dans un emplacement de 200&nbsp;pixels de large a besoin
-      d'un fichier de 400&nbsp;pixels pour un portable Retina et de 600 pour un
+    <h2>D'où vient le chiffre, au juste</h2>
+    <p><strong>Pour un site web.</strong> Prenez la place que l'image occupe sur
+      la page, en pixels CSS, et multipliez par la densité des écrans qui vous
+      intéressent. Un logo dans un emplacement de 200&nbsp;pixels de large réclame
+      un fichier de 400&nbsp;pixels pour un portable Retina, et de 600 pour un
       téléphone récent. C'est tout ce que veulent dire <code>@2x</code> et
-      <code>@3x</code>, et c'est pourquoi un outil qui les écrit vous évite de
-      faire le calcul trois fois.
+      <code>@3x</code>, et c'est pourquoi un outil qui les écrit vous épargne de
+      refaire le calcul trois fois.
     </p>
     <p><strong>Pour une icône d'application, une fiche de boutique ou un
-      favicon.</strong> Le chiffre est publié et il n'y a rien à calculer&nbsp;:
-      ce que dit la page de la boutique, exactement. Pour un favicon, ne
+      favicon.</strong> Le chiffre est publié, il n'y a rien à calculer&nbsp;:
+      exactement ce que dit la page de la boutique. Pour un favicon, ne
       rastérisez pas du tout &mdash;
-      <a href="../creer-son-favicon/">fabriquez un .ico</a>, qui contient
-      plusieurs tailles dans un fichier, parce qu'un onglet de navigateur, un
-      signet et un raccourci Windows en réclament chacun une différente.
+      <a href="../creer-son-favicon/">fabriquez un .ico</a>, qui loge plusieurs
+      tailles dans un seul fichier, parce qu'un onglet de navigateur, un signet
+      et un raccourci Windows n'en demandent pas la même.
     </p>
-    <p><strong>Pour l'impression.</strong> Multipliez la taille physique en
-      pouces par la résolution de l'imprimante. Un logo qui va sur une carte de
-      visite sur deux pouces de large à 300&nbsp;DPI fait 600 pixels&nbsp;; le
-      même logo en travers d'une page A4, soit 8,3&nbsp;pouces, en fait environ
-      2500. Les imprimeries demandent 300&nbsp;DPI par principe, et pour une
-      bannière grand format regardée du bout d'une pièce, 150 suffit largement.
+    <p><strong>Pour l'impression.</strong> Multipliez la taille physique par la
+      résolution de l'imprimeur. Un logo de 5&nbsp;centimètres de large sur une
+      carte de visite, à 300&nbsp;DPI, fait environ 600 pixels&nbsp;; le même
+      logo sur toute la largeur d'une page A4, soit 21&nbsp;centimètres, en fait
+      environ 2500. Les imprimeurs demandent 300&nbsp;DPI par principe, et pour
+      une bâche grand format qu'on regarde depuis l'autre bout d'une salle, 150
+      suffisent largement.
     </p>
-    <p><strong>Pour un aperçu social ou une image OG.</strong> La plateforme
-      nomme un cadre &mdash; 1200&nbsp;&times;&nbsp;630 pour la plupart des
-      aperçus de liens &mdash; et le cadre n'a pas la forme de votre logo. C'est
-      à cela que sert le réglage &laquo;&nbsp;compléter&nbsp;&raquo;&nbsp;: le
-      dessin centré à ses propres proportions, avec une couleur de fond qui
-      remplit le reste, plutôt qu'un logo étiré qui annonce à tout le monde que
-      vous n'avez pas vérifié.
+    <p><strong>Pour un aperçu de réseau social ou une image OG.</strong> La
+      plateforme impose un cadre &mdash; 1200&nbsp;&times;&nbsp;630 pour la
+      plupart des aperçus de lien &mdash; et ce cadre n'a pas la forme de votre
+      logo. C'est à cela que sert le réglage
+      &laquo;&nbsp;compléter&nbsp;&raquo;&nbsp;: le dessin centré dans ses
+      propres proportions, une couleur de fond remplissant le reste, plutôt qu'un
+      logo étiré qui annonce à tout le monde que vous n'avez pas vérifié.
     </p>
     <p>
       Quand deux de ces cas s'appliquent, prenez le plus grand. Un PNG plus grand
-      que nécessaire est un téléchargement un peu plus lourd&nbsp;; un PNG trop
-      petit ne se rattrape pas ensuite, pour la raison exposée dans la section
-      suivante.
+      que nécessaire, c'est un téléchargement un peu plus lourd&nbsp;; un PNG trop
+      petit ne se rattrape pas, pour la raison qui suit.
     </p>
   </section>
 
   <section>
     <h2>On ne revient pas en arrière</h2>
     <p>
-      La rastérisation est à sens unique. Une fois le dessin devenu un PNG, ce
-      sont des pixels comme dans n'importe quelle autre image, et l'agrandir
-      ensuite doit inventer un détail qui n'a jamais été mesuré &mdash; le même
-      résultat mou et étalé qu'on obtient en agrandissant une photographie.
+      La rastérisation est à sens unique. Une fois le dessin devenu PNG, ce sont
+      des pixels comme dans n'importe quelle image, et l'agrandir ensuite oblige
+      à inventer du détail qui n'a jamais été mesuré &mdash; avec le même
+      résultat mou et étalé qu'en agrandissant une photographie.
     </p>
     <p>
-      Gardez donc le SVG. C'est la copie maîtresse, c'est presque toujours le
-      fichier le plus léger, et toutes les tailles futures en sortiront
-      parfaitement. Le PNG est un export pour un usage particulier, et quand il
-      vous faut une autre taille, le bon geste est de réexporter plutôt que de
-      redimensionner ce que vous aviez exporté.
+      Gardez donc le SVG. C'est l'original, c'est presque toujours le fichier le
+      plus léger, et toutes les tailles futures en sortiront parfaites. Le PNG
+      est un export destiné à un usage précis&nbsp;: quand il vous en faut une
+      autre taille, la bonne réaction est de réexporter, pas de redimensionner
+      l'export.
     </p>
     <p>
       Il existe des logiciels qui prétendent reconvertir un PNG en SVG. Ce qu'ils
-      font, c'est du tracé&nbsp;: deviner quelles courbes pourraient expliquer une
-      grille de pixels. Cela marche passablement sur un dessin plat à deux
-      couleurs et produit un galimatias coûteux sur tout le reste, et cela ne
-      retrouve jamais ce que le dessin d'origine contenait.
+      font, c'est du tracé automatique&nbsp;: deviner quelles courbes pourraient
+      expliquer une grille de pixels. Cela passe à peu près sur un aplat en deux
+      couleurs, et cela produit un charabia coûteux sur tout le reste &mdash;
+      sans jamais retrouver ce que contenait le dessin d'origine.
     </p>
   </section>
 
   <section>
-    <h2>Trois choses changent à l'instant où cela devient des pixels</h2>
+    <h2>Trois choses changent dès que le dessin devient des pixels</h2>
     <p>
-      Un SVG rastérisé qui a l'air faux a presque toujours l'air faux pour l'une
-      de ces trois raisons, et toutes les trois valent d'être connues avant
-      l'export plutôt qu'après.
+      Un SVG rastérisé qui a l'air raté l'est presque toujours pour l'une de ces
+      trois raisons, et les trois valent d'être connues avant l'export plutôt
+      qu'après.
     </p>
     <p>
-      <strong>Le texte est dessiné dans la police que possède la
-      machine.</strong> Un SVG qui contient du texte ne contient pas la police
-      &mdash; il en nomme une et laisse le moteur de rendu la trouver. Si la
-      police n'est pas installée, une police de remplacement est utilisée, et
-      cette remplaçante a d'autres dessins de lettres et d'autres
-      chasses&nbsp;: le texte peut donc se recomposer ou déborder. Un fichier qui
-      tire sa police d'une adresse web s'en tire encore plus mal&nbsp;: un SVG
-      rastérisé à travers un <code>&lt;img&gt;</code> n'a pas le droit de
-      récupérer quoi que ce soit, alors rien n'arrive.
+      <strong>Le texte est tracé avec la police que la machine possède.</strong>
+      Un SVG qui contient du texte ne contient pas la police&nbsp;: il en nomme
+      une et laisse le moteur de rendu la chercher. Si elle n'est pas installée,
+      une police de remplacement prend le relais, avec d'autres dessins de lettres
+      et d'autres chasses&nbsp;: le texte peut se réagencer ou déborder. Un
+      fichier qui va chercher sa police à une adresse web s'en tire encore plus
+      mal&nbsp;: un SVG rastérisé à travers une balise
+      <code>&lt;img&gt;</code> n'a pas le droit d'aller chercher quoi que ce soit,
+      donc rien n'arrive.
     </p>
     <p>
-      Le remède est celui que tout graphiste connaît déjà&nbsp;:
-      <strong>convertissez le texte en contours</strong> avant d'exporter le SVG
-      (Illustrator appelle cela Vectoriser, Figma dit Flatten, Inkscape dit Objet
-      en chemin). Les lettres deviennent de la géométrie, la police cesse
-      d'importer, et l'image a la même allure sur toutes les machines.
-      Faites-le sur une copie &mdash; un texte vectorisé n'est plus modifiable
-      comme texte.
+      Le remède est celui que tout graphiste connaît&nbsp;:
+      <strong>vectorisez le texte</strong> avant d'exporter le SVG (Illustrator
+      dit Vectoriser, Figma dit Flatten, Inkscape dit Objet en chemin). Les
+      lettres deviennent de la géométrie, la police cesse d'avoir de
+      l'importance, et le dessin est le même partout. Faites-le sur une copie
+      &mdash; un texte vectorisé n'est plus modifiable comme du texte.
     </p>
     <p>
-      <strong>Les filets virent au gris ou disparaissent.</strong> Un trait qui
-      revient à moins d'un pixel à la taille choisie ne peut pas être dessiné
-      comme une ligne pleine&nbsp;: il est donc dessiné faiblement. C'est
-      pourquoi un logo délicat rastérisé à 64&nbsp;pixels a l'air délavé quand le
-      même fichier à 512 est parfait. Si une petite taille est l'exigence, la
-      réponse est un dessin simplifié aux traits plus épais plutôt qu'un autre
+      <strong>Les traits fins virent au gris, ou s'effacent.</strong> Un trait
+      qui, à la taille choisie, représente moins d'un pixel ne peut pas être
+      tracé comme une ligne pleine&nbsp;: il est tracé comme une ligne pâle.
+      D'où un logo délicat rastérisé à 64&nbsp;pixels qui paraît délavé quand le
+      même fichier à 512 est impeccable. Si la petite taille est une contrainte,
+      la réponse est un dessin simplifié aux traits plus épais, pas un autre
       réglage d'export &mdash; c'est la même raison qui fait qu'un favicon est un
       symbole et non un mot.
     </p>
     <p>
       <strong>L'animation s'arrête.</strong> Un SVG animé se rastérise en une
-      seule image fixe&nbsp;: la première, quelle qu'elle soit. Aucun réglage
-      d'export n'y change rien. S'il vous faut le mouvement, il vous faut un GIF
-      ou une vidéo, fabriqués autrement.
+      seule image fixe, la première. Aucun réglage d'export n'y change rien. S'il
+      vous faut le mouvement, il vous faut un GIF ou une vidéo, fabriqués
+      autrement.
     </p>
   </section>
 
   <section>
     <h2>La transparence, et quel format choisir</h2>
     <p>
-      <strong>PNG</strong>, sauf raison particulière. Il est sans perte, il garde
-      la transparence, et les aplats à bords francs &mdash; qui sont l'essentiel
-      de ce dont un dessin est fait &mdash; s'y compressent bien. Un logo
-      rastérisé est en général un PNG <em>plus léger</em> qu'il ne serait un
-      JPEG, en plus d'être plus propre.
+      <strong>Le PNG</strong>, sauf raison contraire. Il est sans perte, il garde
+      la transparence, et les aplats à contours nets &mdash; c'est-à-dire
+      l'essentiel de ce dont un dessin est fait &mdash; s'y compriment bien. Un
+      logo rastérisé donne d'ordinaire un PNG <em>plus léger</em> qu'il ne
+      donnerait un JPEG, et plus propre par-dessus le marché.
     </p>
     <p>
-      <strong>Le JPEG</strong> n'a aucune transparence. Chaque pixel transparent
-      doit devenir une couleur, et si personne n'en choisit une pour vous, il
-      devient noir &mdash; c'est de là que vient le résultat du logo dans un
-      rectangle noir que l'on prend pour un bug. Il est en outre avec perte de la
-      façon qui se voit le plus mal sur exactement ce genre d'image&nbsp;: un
-      liseré de moucheture autour de chaque bord franc. Utilisez-le quand quelque
-      chose l'exige.
+      <strong>Le JPEG</strong> ne connaît pas la transparence. Chaque pixel
+      transparent doit devenir une couleur, et si personne n'en choisit une, il
+      devient noir &mdash; d'où le fameux logo sur pavé noir que l'on prend pour
+      un bug. C'est aussi un format avec perte, et la perte se voit au pire
+      justement sur ce genre d'image&nbsp;: un chapelet de fourmillements autour
+      de chaque contour franc. Ne l'employez que si quelque chose l'exige.
     </p>
     <p>
-      <strong>Le WebP</strong> fait tout ce que fait le PNG, dans un fichier plus
-      léger, et il est lu par tous les navigateurs actuels. La raison de ne pas
-      s'en servir est ce qui vient après le navigateur&nbsp;: les logiciels plus
-      anciens, certaines imprimeries et un bon nombre de formulaires d'envoi
-      refusent toujours d'en ouvrir un.
+      <strong>Le WebP</strong> fait tout ce que fait le PNG, en plus léger, et
+      tous les navigateurs actuels le lisent. La raison de s'en priver est ce qui
+      vient après le navigateur&nbsp;: des logiciels anciens, certains imprimeurs
+      et un bon nombre de formulaires d'envoi refusent encore de l'ouvrir.
     </p>
     <p>
-      Choisir une couleur de fond avec du PNG est aussi une chose parfaitement
-      ordinaire à vouloir. La transparence n'est utile que lorsque ce sur quoi
-      l'image atterrit est une couleur que vous ne pouvez pas prévoir&nbsp;;
-      quand vous savez déjà que c'est une page blanche, l'aplatir sur du blanc
-      évite toute une catégorie de surprises.
+      Choisir une couleur de fond avec le PNG est d'ailleurs une envie tout à
+      fait ordinaire. La transparence ne sert que lorsque le fond sur lequel
+      l'image atterrira est imprévisible&nbsp;; quand vous savez déjà que c'est
+      une page blanche, aplatir sur du blanc vous épargne toute une famille de
+      mauvaises surprises.
     </p>
   </section>
 
   <section>
-    <h2>Quand l'export ressort vide ou faux</h2>
+    <h2>Quand l'export ressort vide ou de travers</h2>
     <p>
-      <strong>Rien que du vide.</strong> En général un attribut
-      <code>xmlns</code> manquant sur l'élément racine. Un fichier sans lui n'est
-      pas du SVG pour une balise image, et il se dessine comme rien. Ouvrir le
-      fichier dans un navigateur est le test rapide&nbsp;: si le navigateur ne
-      montre rien non plus, le problème est le fichier et non le convertisseur.
+      <strong>Rien qu'un rectangle vide.</strong> C'est en général l'attribut
+      <code>xmlns</code> qui manque sur l'élément racine. Un fichier qui en est
+      dépourvu n'est pas du SVG aux yeux d'une balise image, et il se dessine
+      comme rien du tout. Le test rapide consiste à ouvrir le fichier dans un
+      navigateur&nbsp;: si le navigateur n'affiche rien non plus, le problème est
+      dans le fichier et non dans le convertisseur.
     </p>
     <p>
-      <strong>Le dessin est petit, dans le coin en haut à gauche.</strong> Le
-      fichier a une <code>width</code> et une <code>height</code> mais pas de
+      <strong>Le dessin est minuscule, en haut à gauche.</strong> Le fichier a
+      bien une <code>width</code> et une <code>height</code>, mais pas de
       <code>viewBox</code>&nbsp;: il n'y a donc aucun système de coordonnées à
-      mettre à l'échelle et le dessin garde ses unités d'origine sur un canvas
-      plus grand. Un bon convertisseur ajoute un viewBox pour vous&nbsp;; si le
-      vôtre ne l'a pas fait, ajouter à la main
+      mettre à l'échelle, et le dessin garde ses unités d'origine sur une toile
+      plus grande. Un bon convertisseur ajoute une viewBox pour vous&nbsp;; si le
+      vôtre ne l'a pas fait, écrire à la main
       <code>viewBox="0 0 <em>largeur</em> <em>hauteur</em>"</code> sur l'élément
-      racine corrige la chose, et le fichier est du texte brut, donc vous le
-      pouvez.
+      racine règle la chose, et le fichier est en texte brut, donc c'est à votre
+      portée.
     </p>
     <p>
-      <strong>Une partie de l'image manque.</strong> Quelque chose dans le
-      fichier pointait vers une adresse au lieu de contenir le dessin &mdash; une
-      photographie incorporée stockée comme lien, une feuille de style, une
-      police. Un rastériseur qui refuse d'aller les chercher fait ce qu'il faut,
-      et c'est le même refus qui empêche un SVG téléchargé quelque part de
-      rendre des comptes à celui qui l'a fabriqué. Réexportez depuis le logiciel
-      de dessin avec les images incorporées.
+      <strong>Une partie du dessin manque.</strong> Quelque chose, dans le
+      fichier, pointait vers une adresse au lieu de contenir le dessin&nbsp;: une
+      photographie liée plutôt qu'incorporée, une feuille de style, une police. Un
+      rastériseur qui refuse d'aller les chercher fait exactement ce qu'il faut,
+      et c'est ce même refus qui empêche un SVG téléchargé quelque part de rendre
+      des comptes à celui qui l'a fabriqué. Réexportez depuis le logiciel de
+      dessin en incorporant les images.
     </p>
     <p>
-      <strong>Il refuse une très grande taille.</strong> Les navigateurs
-      plafonnent la taille d'un canvas, et ils ne s'accordent pas sur
-      l'endroit&nbsp;: au-delà d'environ 16 000&nbsp;pixels de côté rien ne
-      revient, et Safari sur un iPhone ou un iPad abandonne bien plus tôt, vers
-      4096&nbsp;&times;&nbsp;4096. Un outil qui vous prévient vous épargne un
-      fichier vide, parce que c'est ce que produit un navigateur à court de
-      ressources plutôt qu'un message d'erreur.
+      <strong>Il refuse une très grande taille.</strong> Les navigateurs plafonnent
+      la taille d'une toile, et ils ne s'accordent pas sur la valeur&nbsp;:
+      au-delà de 16&nbsp;000&nbsp;pixels de côté environ, plus rien ne revient, et
+      Safari sur iPhone ou iPad abandonne bien plus tôt, autour de
+      4096&nbsp;&times;&nbsp;4096. Un outil qui vous avertit vous évite un fichier
+      vide, car c'est cela qu'un navigateur produit quand il renonce &mdash; pas
+      un message d'erreur.
     </p>
   </section>
 
   <section>
-    <h2>Rien de tout cela ne demande un envoi</h2>
+    <h2>Rien de tout cela n'exige un envoi</h2>
     <p>
-      Rastériser un SVG est une chose que tous les navigateurs font des milliers
-      de fois par jour &mdash; c'est la machinerie même qui dessine une icône sur
-      une page web. Il n'y a aucune raison technique pour que votre dessin voyage
-      jusqu'à un serveur et en revienne sous forme de PNG, et l'outil d'ici ne
-      l'envoie nulle part&nbsp;: la <code>Content-Security-Policy</code> de la
-      page nomme toutes les adresses qu'elle peut contacter, et aucune
-      n'appartient à ce site.
+      Rastériser un SVG, tous les navigateurs le font des milliers de fois par
+      jour&nbsp;: c'est la machinerie même qui dessine une icône sur une page
+      web. Rien n'oblige techniquement votre dessin à faire l'aller-retour
+      jusqu'à un serveur pour ressortir en PNG, et l'outil de ce site ne l'envoie
+      nulle part&nbsp;: la <code>Content-Security-Policy</code> de la page
+      énumère toutes les adresses qu'elle peut contacter, dont aucune n'appartient
+      à ce site.
     </p>
     <p>
-      Cela compte plus que d'habitude avec le SVG, parce qu'un SVG est un
-      document et non une image. Il peut contenir un script et une adresse
-      distante, et un logo qu'une agence vous a envoyé est un fichier que vous
-      n'avez pas écrit. Dessiné à travers une balise image, il est dans ce que la
-      spécification appelle le <em>mode statique sécurisé</em>&nbsp;: le script
-      ne peut pas s'exécuter et l'adresse n'est jamais contactée. C'est le
-      navigateur qui l'applique, pas le site web.
+      Cela compte plus qu'ailleurs avec le SVG, parce qu'un SVG est un document
+      plutôt qu'une image. Il peut contenir un script et une adresse distante, et
+      le logo qu'une agence vous a envoyé est un fichier que vous n'avez pas
+      écrit. Dessiné à travers une balise image, il se trouve dans ce que la
+      spécification appelle le <em>mode statique sécurisé</em>&nbsp;: le script ne
+      peut pas s'exécuter et l'adresse n'est jamais contactée. C'est le navigateur
+      qui l'impose, pas le site web.
     </p>
     <p>
-      Chargez la page, coupez votre connexion, et convertissez quelque chose
-      quand même, si vous préférez vérifier plutôt qu'on vous le dise.
+      Chargez la page, coupez votre connexion et convertissez quelque chose quand
+      même, si vous préférez vérifier plutôt qu'on vous le dise.
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
-      vérifications applicables à n'importe quel outil.
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente trois autres
+      vérifications valables pour n'importe quel outil.
     </p>
   </section>

--- a/locales/fr/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/fr/pages/guides/convert-an-svg-to-png.toml
@@ -4,14 +4,14 @@
 
 nav = "Convertir un SVG en PNG"
 title = "Comment convertir un SVG en PNG à la bonne taille"
-description = "Un vectoriel n'a pas de taille en pixels à lui : le nombre est à vous de le choisir. D'où vient ce nombre pour un écran, une icône d'application et une imprimante, et ce qui change quand un dessin devient des pixels."
+description = "Un fichier vectoriel n'a pas de taille en pixels : ce chiffre, c'est à vous de le donner. D'où il vient pour un écran, pour une icône d'application et pour une imprimante, et ce qui change quand un dessin devient des pixels."
 heading = "Comment convertir un SVG en PNG à la bonne taille"
 lede = """
-    Convertir est la moitié facile. La question qui décide si le résultat sert à
-    quelque chose est celle dont personne ne vous donne la réponse&nbsp;: combien
-    de pixels&nbsp;? Voici d'où vient ce nombre, et ce qu'un dessin perd en
-    chemin."""
+    Convertir est la partie facile. Ce qui décide si le résultat sert à quelque
+    chose, c'est la question dont personne ne vous donne la réponse&nbsp;:
+    combien de pixels&nbsp;? Voici d'où vient ce chiffre, et ce qu'un dessin
+    perd en route."""
 updated = "20 août 2026"
 og_title = "Convertir un SVG en PNG à la bonne taille"
-og_description = "D'où vient vraiment le nombre de pixels, et les trois choses qui changent quand un dessin devient des pixels."
+og_description = "D'où vient vraiment le nombre de pixels, et les trois choses qui changent dès qu'un dessin devient des pixels."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/convert-heic-to-jpg.html
+++ b/locales/fr/pages/guides/convert-heic-to-jpg.html
@@ -2,230 +2,230 @@
     <h2>La réponse courte</h2>
     <p>
       Ouvrez le <a href="../../convertir-heic-en-jpg/">convertisseur HEIC vers
-      JPG</a>, déposez-y les photos, et appuyez sur
+      JPG</a>, déposez-y vos photos et appuyez sur
       &laquo;&nbsp;Convertir&nbsp;&raquo;. Laissez le curseur de qualité où il
-      est et laissez cochée la case
+      est et laissez cochée l'option
       &laquo;&nbsp;garder la date, l'appareil et les réglages&nbsp;&raquo;, sauf
       raison contraire. Vous récupérez des JPEG, un bouton de téléchargement
-      chacun, ou un zip s'il y en a plusieurs.
+      chacun, ou une archive zip s'il y en a plusieurs.
     </p>
     <p>
-      Rien n'est envoyé pendant ce temps. C'est inhabituel pour ce travail-là en
-      particulier, et la raison est la moitié intéressante de cette page.
+      Rien n'est envoyé pendant l'opération. C'est peu courant pour ce travail
+      précis, et c'est même la moitié intéressante de cette page.
     </p>
   </section>
 
   <section>
     <h2>Ce qu'est réellement le HEIC</h2>
     <p>
-      Le HEIC n'est pas vraiment un format d'image au sens où le JPEG en est un.
-      C'est un conteneur &mdash; la même structure à boîtes dont est fait un MP4
-      &mdash; avec à l'intérieur une image fixe de vidéo <strong>HEVC</strong>.
-      Le HEVC, aussi appelé H.265, est le codec qui a remplacé celui de votre
-      vieux caméscope, et il est très bon&nbsp;: une photo d'iPhone en HEIC pèse
-      à peu près la moitié de la même photo en JPEG à qualité égale.
+      Le HEIC n'est pas vraiment un format d'image comme l'est le JPEG. C'est un
+      conteneur &mdash; la même structure en boîtes qui compose un MP4 &mdash;
+      abritant une image fixe de vidéo <strong>HEVC</strong>. Le HEVC, aussi
+      appelé H.265, est le codec qui a succédé à celui de votre vieux
+      caméscope, et il est très bon&nbsp;: une photo d'iPhone en HEIC pèse à peu
+      près la moitié de la même photo en JPEG, à qualité égale.
     </p>
     <p>
-      Apple y est passé dans iOS 11, en 2017, et l'a mis par défaut. Ce qui veut
-      dire qu'à moins d'être allé dans les Réglages choisir
-      &laquo;&nbsp;Le plus compatible&nbsp;&raquo;, chaque photo prise par son
-      téléphone depuis près d'une décennie est dans un format que&nbsp;:
+      Apple y est passé avec iOS 11, en 2017, et l'a mis par défaut. Autrement
+      dit, à moins d'être allé dans les Réglages choisir
+      &laquo;&nbsp;Le plus compatible&nbsp;&raquo;, toutes les photos prises avec
+      ce téléphone depuis bientôt dix ans sont dans un format que&nbsp;:
     </p>
     <ul>
-      <li>Windows ne prévisualise pas sans une extension du Store&nbsp;;</li>
-      <li>la plupart des formulaires d'envoi web rejettent d'emblée&nbsp;;</li>
-      <li>quantité de logiciels de bureau plus anciens n'ont jamais connu&nbsp;;</li>
-      <li>et qu'aucun navigateur web sauf Safari n'affiche.</li>
+      <li>Windows ne prévisualise pas sans une extension prise dans le
+        Store&nbsp;;</li>
+      <li>la plupart des formulaires d'envoi rejettent d'emblée&nbsp;;</li>
+      <li>quantité de logiciels de bureau un peu anciens n'ont jamais
+        connu&nbsp;;</li>
+      <li>et qu'aucun navigateur web, hormis Safari, n'affiche.</li>
     </ul>
     <p>
-      La photo va très bien. C'est un meilleur fichier que ne l'aurait été le
-      JPEG. Elle est simplement écrite dans une langue que la plus grande partie
-      du monde n'a jamais apprise.
+      La photo, elle, va très bien. C'est même un meilleur fichier que ne l'aurait
+      été le JPEG. Il est simplement écrit dans une langue que le reste du monde
+      n'a jamais apprise.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi seul Safari en ouvre un</h2>
+    <h2>Pourquoi seul Safari sait en ouvrir un</h2>
     <p>
-      C'est la partie qui explique tous les convertisseurs que vous avez jamais
-      utilisés&nbsp;: elle vaut donc un paragraphe.
+      Ce point explique tous les convertisseurs que vous avez jamais employés, il
+      mérite donc un paragraphe.
     </p>
     <p>
-      Décoder du HEVC demande un décodeur HEVC, et le HEVC est breveté. Les
-      licences sont administrées par plus d'un consortium de brevets, et livrer
-      un décodeur veut dire payer quelqu'un. Les navigateurs s'en tirent en
-      s'appuyant sur le système d'exploitation &mdash; Chrome lit de la
-      <em>vidéo</em> HEVC sur une machine dont le matériel a déjà un décodeur
-      sous licence &mdash; mais ce chemin est câblé pour la lecture vidéo et non
-      pour les images fixes. Un HEIC remis à <code>&lt;img&gt;</code> est donc
-      refusé, dans Chrome, Firefox et Edge pareillement, sur tous les systèmes
-      d'exploitation.
+      Décoder du HEVC réclame un décodeur HEVC, et le HEVC est breveté. Les
+      licences sont gérées par plusieurs consortiums de brevets, et livrer un
+      décodeur veut dire payer quelqu'un. Les navigateurs s'en tirent en
+      s'appuyant sur le système d'exploitation &mdash; Chrome lira une
+      <em>vidéo</em> HEVC sur une machine dont le matériel possède déjà un
+      décodeur sous licence &mdash; mais ce chemin est câblé pour la lecture
+      vidéo, pas pour les images fixes. Un HEIC confié à une balise
+      <code>&lt;img&gt;</code> est donc refusé, par Chrome, Firefox et Edge, sur
+      tous les systèmes.
     </p>
     <p>
-      Safari sur du matériel Apple est l'exception, parce que macOS et iOS ont le
-      décodeur et que Safari a le droit de le lui demander. Partout ailleurs,
-      l'image est tout simplement indécodable par le navigateur.
+      Safari sur matériel Apple fait exception, parce que macOS et iOS
+      embarquent le décodeur et que Safari a le droit de le solliciter. Partout
+      ailleurs, l'image est tout simplement indécodable par le navigateur.
     </p>
     <p>
-      Ce qui ne laisse à un convertisseur qu'exactement deux possibilités, et le
-      choix entre les deux est toute l'histoire de ce genre d'outil.
+      Il ne reste donc que deux options à un convertisseur, et le choix entre
+      elles résume toute l'histoire de ce genre d'outil.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi presque tous les convertisseurs HEIC veulent un envoi</h2>
+    <h2>Pourquoi presque tous les convertisseurs HEIC réclament un envoi</h2>
     <p>
-      Première possibilité&nbsp;: mettre le décodeur sur un serveur. La photo est
+      Première option&nbsp;: mettre le décodeur sur un serveur. La photo est
       envoyée, décodée sur une machine que vous n'avez jamais vue, réencodée en
-      JPEG, et renvoyée. C'est ce que fait à peu près tout
-      &laquo;&nbsp;convertisseur HEIC en ligne gratuit&nbsp;&raquo;, et c'est
-      pourquoi ils ont tous besoin de vos fichiers. Ce n'est pas de la paresse
-      &mdash; le navigateur en est réellement incapable tout seul.
+      JPEG et renvoyée. C'est ce que fait la quasi-totalité des
+      &laquo;&nbsp;convertisseurs HEIC en ligne gratuits&nbsp;&raquo;, et c'est
+      pourquoi ils réclament tous vos fichiers. Ce n'est pas de la paresse&nbsp;:
+      le navigateur en est réellement incapable tout seul.
     </p>
     <p>
       Ce que cela coûte mérite d'être dit sans détour. Les photos d'un téléphone
-      sont les fichiers les plus personnels que possèdent la plupart des gens, et
-      un HEIC sorti tout droit d'un iPhone porte typiquement les coordonnées du
-      lieu de la prise de vue, précises à quelques mètres, avec la date à la
-      seconde et un identifiant d'appareil. En envoyer un dossier à un service
-      gratuit, c'est remettre les images et cela avec. Ce qui se passe ensuite est
-      régi par une politique de confidentialité que vous n'avez pas lue, sur un
-      serveur que vous ne pouvez pas inspecter, dans une juridiction que vous
-      n'avez pas choisie.
+      sont les fichiers les plus personnels que la plupart des gens possèdent, et
+      un HEIC sorti d'un iPhone porte le plus souvent les coordonnées du lieu de
+      prise de vue, précises à quelques mètres, la date à la seconde et un
+      identifiant d'appareil. Envoyer un dossier entier à un service gratuit,
+      c'est livrer les images et tout cela avec. La suite est régie par une
+      politique de confidentialité que vous n'avez pas lue, sur un serveur que
+      vous ne pouvez pas inspecter, dans un pays que vous n'avez pas choisi.
     </p>
     <p>
-      Seconde possibilité&nbsp;: mettre le décodeur dans la page. C'est ce que
-      fait <a href="../../convertir-heic-en-jpg/">celui-ci</a>. Il emporte
-      <code>libheif</code>, compilé en WebAssembly, comme un fichier servi depuis
-      ce site &mdash; environ 1,4 MB, téléchargé une fois puis mis en cache.
-      Votre navigateur l'exécute sur votre propre machine, sur votre propre
-      matériel, et la photo ne va nulle part. Chargez la page une fois et vous
-      pouvez couper entièrement votre connexion sans qu'elle cesse de
-      fonctionner, ce qu'aucun convertisseur qui envoie ne sait faire et la preuve
-      la plus simple qui soit.
+      Seconde option&nbsp;: mettre le décodeur dans la page. C'est ce que fait
+      <a href="../../convertir-heic-en-jpg/">celui-ci</a>. Il embarque
+      <code>libheif</code>, compilé en WebAssembly et servi depuis ce site
+      &mdash; environ 1,4&nbsp;MB, téléchargés une fois puis mis en cache. Votre
+      navigateur l'exécute sur votre machine, sur votre propre matériel, et la
+      photo ne part nulle part. Chargez la page une fois, débranchez complètement
+      internet, elle continue de fonctionner&nbsp;: aucun convertisseur qui
+      envoie ne sait faire cela, et c'est la preuve la plus simple qui soit.
     </p>
     <p>
-      Les 1,4 MB sont le prix entier. Si vous êtes sur une connexion facturée au
-      volume, c'est un coût réel et il vaut la peine de le savoir&nbsp;: c'est
-      pourquoi la page le dit à voix haute au lieu de le télécharger en douce.
+      Ces 1,4&nbsp;MB sont le prix à payer, en entier. Sur une connexion facturée
+      au volume, c'est un vrai coût et il vaut la peine de le savoir&nbsp;; c'est
+      pourquoi la page le dit à voix haute au lieu de télécharger en douce.
     </p>
   </section>
 
   <section>
     <h2>Ce que la conversion coûte à l'image</h2>
     <p>
-      Le HEIC et le JPEG sont des codecs différents&nbsp;: il n'y a donc aucun
-      passage de l'un à l'autre qui n'implique pas de décoder l'image et de la
-      réencoder. Ce second encodage est avec perte. En pratique, cela compte bien
-      moins que cela n'en a l'air&nbsp;:
+      Le HEIC et le JPEG sont deux codecs différents&nbsp;: aucun chemin de l'un
+      à l'autre n'évite de décoder l'image puis de la réencoder, et ce second
+      encodage se fait avec perte. En pratique, la chose compte bien moins qu'il
+      n'y paraît.
     </p>
     <ul>
       <li>
-        <strong>À la qualité 92</strong> &mdash; là où le convertisseur commence
-        &mdash; une photographie est très difficile à distinguer de l'original à
-        toute taille de visionnage normale. Vous cherchez des différences dans
-        les dégradés doux, comme un ciel dégagé, et vous n'en trouverez
-        généralement pas.
+        <strong>À une qualité de 92</strong> &mdash; le point de départ du
+        convertisseur &mdash; une photographie est très difficile à distinguer de
+        l'original à une taille de lecture normale. Il faudrait chercher les
+        écarts dans les dégradés doux, un ciel dégagé par exemple, et vous n'en
+        trouverez généralement pas.
       </li>
       <li>
-        <strong>Le JPEG sera plus gros.</strong> En général entre un tiers de
-        plus et le double, parce que le JPEG est un codec de 1992 et que le HEVC
-        n'en est pas un. C'est le marché&nbsp;: un fichier plus gros que tout
-        ouvre.
+        <strong>Le JPEG sera plus lourd.</strong> D'un tiers à deux fois plus, en
+        général, parce que le JPEG est un codec de 1992 et que le HEVC n'en est
+        pas un. C'est le marché&nbsp;: un fichier plus lourd, que tout ouvre.
       </li>
       <li>
-        <strong>Ce qu'il faut éviter, c'est convertir deux fois.</strong> Chaque
-        encodage avec perte coûte un peu. Convertissez depuis le HEIC d'origine,
-        pas depuis un JPEG que quelqu'un a déjà fabriqué pour vous, et faites-le
-        une seule fois.
+        <strong>Ce qu'il faut éviter, c'est de convertir deux fois.</strong>
+        Chaque encodage avec perte prélève sa part. Partez du HEIC d'origine, pas
+        d'un JPEG que quelqu'un a déjà fabriqué pour vous, et n'y revenez pas.
       </li>
     </ul>
     <p>
-      Si vous ne voulez aucune perte, le PNG est au menu des formats. Préparez-vous
-      pour le fichier&nbsp;: une photographie en PNG pèse couramment cinq à dix
-      fois le JPEG, parce que la compression du PNG a été conçue pour les aplats
-      et le dessin au trait plutôt que pour l'herbe et la peau.
+      Si vous ne voulez aucune perte, le PNG figure au menu des formats.
+      Préparez-vous au poids&nbsp;: une photographie en PNG pèse couramment cinq à dix
+      fois le JPEG, la compression du PNG ayant été conçue pour les aplats et le
+      dessin au trait, pas pour l'herbe et la peau.
     </p>
   </section>
 
   <section>
     <h2>La date, l'appareil et les coordonnées</h2>
     <p>
-      Le reproche habituel fait aux convertisseurs HEIC est que les photos
-      reviennent en ayant perdu leur jour de prise de vue&nbsp;: toute une
-      photothèque de vacances se range alors en bas de la bibliothèque, à la date
-      du jour. Cela arrive parce que convertir à travers un canvas ne donne que
-      des pixels &mdash; un canvas ne contient aucune étiquette &mdash;&nbsp;;
-      donc, à moins qu'un convertisseur n'aille chercher les métadonnées à part,
-      elles ont simplement disparu.
+      Le reproche habituel fait aux convertisseurs HEIC, c'est que les photos
+      reviennent en ayant perdu leur date de prise de vue&nbsp;: tout un voyage
+      se retrouve alors classé à la fin de la photothèque, sous la date du jour.
+      Cela arrive parce que convertir en passant par une toile ne donne que des
+      pixels &mdash; une toile ne porte aucune étiquette &mdash; si bien qu'à
+      moins d'aller chercher les métadonnées séparément, elles disparaissent
+      purement et simplement.
     </p>
     <p>
-      L'outil d'ici copie le bloc EXIF depuis le HEIC et l'écrit dans le
-      JPEG&nbsp;: la date survit donc. Il y a une case, et elle est cochée par
-      défaut. Décochez-la et le JPEG ressort avec l'image et rien d'autre.
+      L'outil de ce site recopie le bloc EXIF du HEIC et l'écrit dans le
+      JPEG&nbsp;: la date survit. Une case le commande, cochée par défaut.
+      Décochez-la et le JPEG ressort avec l'image et rien d'autre.
     </p>
     <p>
-      Avant de décider, regardez la liste&nbsp;: la ligne de chaque photo dit si
-      le fichier porte des coordonnées GPS, et elle le dit avant que quoi que ce
-      soit soit converti. Si les photos partent quelque part de public, c'est la
-      ligne à lire. Si elles partent dans votre propre bibliothèque, garder les
-      métadonnées est presque certainement ce que vous voulez.
+      Avant de trancher, lisez la liste&nbsp;: la ligne de chaque photo indique
+      si le fichier porte des coordonnées GPS, et elle le dit avant toute
+      conversion. Si les photos partent vers un lieu public, c'est la ligne à
+      lire. Si elles rejoignent votre propre photothèque, garder les métadonnées
+      est presque à coup sûr ce que vous voulez.
     </p>
     <p>
-      Une étiquette est changée quel que soit votre choix, et il vaut la peine de
-      savoir pourquoi. Un HEIC enregistre sa rotation à deux endroits&nbsp;: dans
-      le conteneur, et dans le bloc EXIF. Le décodeur applique la rotation du
-      conteneur pendant le décodage&nbsp;: les pixels remis sont donc déjà dans
-      le bon sens. Si l'EXIF disait encore
-      &laquo;&nbsp;tournez ceci de 90 degrés&nbsp;&raquo;, un afficheur le ferait
-      une seconde fois et toutes les photos verticales ressortiraient couchées.
-      L'étiquette d'orientation est donc mise à &laquo;&nbsp;droite&nbsp;&raquo;
-      et tout le reste est recopié exactement comme le téléphone l'avait écrit.
+      Une étiquette est modifiée quoi que vous choisissiez, et il vaut la peine de
+      savoir pourquoi. Un HEIC note sa rotation à deux endroits&nbsp;: dans le
+      conteneur et dans le bloc EXIF. Le décodeur applique la rotation du
+      conteneur au moment du décodage&nbsp;; les pixels livrés sont donc déjà à
+      l'endroit. Si l'EXIF continuait d'annoncer
+      &laquo;&nbsp;tourner de 90 degrés&nbsp;&raquo;, une visionneuse le referait
+      et toutes vos photos verticales ressortiraient couchées. L'étiquette
+      d'orientation est donc remise à l'endroit, et tout le reste est recopié
+      exactement tel que le téléphone l'avait écrit.
     </p>
     <p>
-      Si ce que vous voulez, c'est parcourir les étiquettes en détail, ou les
-      retirer de photos qui sont déjà des JPEG, c'est un autre travail et il y a
-      <a href="../supprimer-les-donnees-exif-et-gps/">un guide pour cela</a>.
+      Si votre intention est d'examiner les étiquettes en détail, ou de les
+      effacer sur des photos qui sont déjà des JPEG, c'est un autre travail, et
+      il existe <a href="../supprimer-les-donnees-exif-et-gps/">un guide pour
+      cela</a>.
     </p>
   </section>
 
   <section>
-    <h2>Ce qui prend les gens au dépourvu</h2>
+    <h2>Les pièges classiques</h2>
     <ul>
       <li>
-        <strong>Un HEIC nommé &laquo;&nbsp;.jpg&nbsp;&raquo;.</strong> Extrêmement
-        courant&nbsp;: quelque chose l'a renommé en chemin sans le convertir, et
-        c'est pourquoi il refuse toujours de s'ouvrir. Chaque fichier déposé sur
-        le convertisseur est identifié par ses premiers octets plutôt que par son
-        nom&nbsp;: celui-là fonctionne donc très bien. C'est aussi pourquoi un
-        fichier qui est vraiment un JPEG se le fait dire au lieu d'être converti
-        en une copie de lui-même.
+        <strong>Un HEIC nommé &laquo;&nbsp;.jpg&nbsp;&raquo;.</strong> C'est
+        extrêmement fréquent&nbsp;: quelque chose l'a renommé en chemin sans le
+        convertir, d'où le refus persistant de s'ouvrir. Chaque fichier déposé sur
+        le convertisseur est identifié par ses premiers octets et non par son nom,
+        de sorte que celui-là passe très bien. C'est aussi pourquoi un fichier
+        qui est vraiment un JPEG s'entend le dire au lieu d'être converti en une
+        copie de lui-même.
       </li>
       <li>
         <strong>Un fichier, plusieurs images.</strong> Une rafale ou une Live
-        Photo peut contenir plus d'une image fixe. Toutes sont converties, et les
-        supplémentaires sont numérotées d'après le nom d'origine. La moitié vidéo
-        d'une Live Photo est un fichier séparé que le téléphone garde à côté du
-        HEIC&nbsp;: elle n'est donc pas là pour être convertie.
+        Photo peut contenir plus d'une image fixe. Toutes sont converties, les
+        supplémentaires étant numérotées à la suite du nom d'origine. La moitié
+        vidéo d'une Live Photo est un fichier distinct que le téléphone garde à
+        côté du HEIC&nbsp;: elle n'est donc pas là-dedans, et rien à convertir.
       </li>
       <li>
         <strong>L'AVIF n'est pas du HEIC.</strong> Ils se ressemblent &mdash; même
         conteneur, autre codec dedans &mdash; mais tous les navigateurs actuels
-        ouvrent un AVIF nativement&nbsp;: il n'y a donc rien à convertir et
-        l'outil le dit au lieu de faire semblant de travailler.
+        ouvrent un AVIF nativement&nbsp;: il n'y a rien à convertir, et l'outil le
+        dit plutôt que de faire semblant de travailler.
       </li>
       <li>
-        <strong>Arrêter le problème à la source.</strong> Sur le téléphone&nbsp;:
-        Réglages &rarr; Appareil photo &rarr; Formats &rarr; Le plus compatible.
-        Les nouvelles photos sont des JPEG à partir de là. Cela consomme plus de
-        stockage et cela ne touche pas aux photos que vous avez déjà, mais cela
-        veut dire ne plus jamais recommencer.
+        <strong>Régler le problème à la source.</strong> Sur le
+        téléphone&nbsp;: Réglages &rarr; Appareil photo &rarr; Formats &rarr; Le
+        plus compatible. Les nouvelles photos seront des JPEG. Cela consomme plus
+        d'espace et ne change rien aux photos déjà prises, mais cela vous évite de
+        recommencer un jour.
       </li>
       <li>
-        <strong>Le partage convertit, parfois.</strong> Envoyer une photo par
-        AirDrop ou par courriel vers un appareil non Apple remet souvent un JPEG,
-        parce qu'iOS convertit en sortie. Si une photo est arrivée en HEIC quand
-        même, c'est qu'elle est passée par un chemin qui ne le faisait pas.
+        <strong>Le partage convertit parfois tout seul.</strong> Envoyer une photo
+        par AirDrop ou par courriel vers un appareil qui n'est pas Apple livre
+        souvent un JPEG, iOS convertissant à la sortie. Si une photo vous est
+        malgré tout arrivée en HEIC, c'est qu'elle a pris un chemin qui ne le
+        faisait pas.
       </li>
     </ul>
   </section>
@@ -233,28 +233,28 @@
   <section>
     <h2>Comment savoir si un convertisseur envoie vos fichiers</h2>
     <p>
-      Cela vaut pour n'importe quel outil, pas seulement celui-ci, et cela prend
-      une quinzaine de secondes.
+      La méthode vaut pour n'importe quel outil, pas seulement celui-ci, et elle
+      prend une quinzaine de secondes.
     </p>
     <ol>
       <li>
-        Ouvrez la page, puis ouvrez les outils de développement de votre
-        navigateur et allez dans l'onglet Réseau.
+        Ouvrez la page, puis les outils de développement de votre navigateur, et
+        allez sur l'onglet Réseau.
       </li>
       <li>
         Convertissez une photo, et regardez. Un outil qui décode sur votre
         machine ne fait aucune requête à cet instant. Un outil qui envoie en fait
-        une de la taille de votre photo, et vous en voyez la taille.
+        une de la taille de votre photo &mdash; et cette taille est affichée.
       </li>
       <li>
-        Ou, plus simplement&nbsp;: chargez la page, coupez votre connexion, et
+        Ou, plus simplement&nbsp;: chargez la page, coupez la connexion, et
         essayez de convertir quelque chose. Un outil qui expédiait votre photo
-        ailleurs pour la décoder s'arrête. Un outil qui emporte le décodeur non.
+        pour la faire décoder s'arrête net. Un outil qui porte son décodeur, non.
       </li>
     </ol>
     <p>
-      Le convertisseur d'ici est construit pour passer les deux vérifications, et
-      il existe une version plus longue de cet argument dans
+      Le convertisseur proposé ici est fait pour passer les deux épreuves, et
+      l'argument est développé plus longuement dans
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">est-il sûr d'envoyer ses
       fichiers</a>.
     </p>

--- a/locales/fr/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/fr/pages/guides/convert-heic-to-jpg.toml
@@ -4,15 +4,15 @@
 
 nav = "HEIC vers JPG"
 title = "Comment convertir un HEIC en JPG (et ce qu'est vraiment le HEIC)"
-description = "Les iPhone enregistrent les photos en HEIC, et la moitié d'internet n'en ouvre pas une. Ce qu'est ce format, pourquoi seul Safari le décode, ce que la conversion coûte à l'image, et comment le faire sans envoyer les photos à personne."
+description = "Les iPhone enregistrent les photos en HEIC, et la moitié d'internet refuse de les ouvrir. Ce qu'est ce format, pourquoi seul Safari le décode, ce que la conversion coûte à l'image, et comment convertir sans confier ses photos à personne."
 heading = "La photo qu'a enregistrée votre téléphone, et le format que rien n'ouvre"
 lede = """
-    Un iPhone enregistre les photos en HEIC, format plus léger et meilleur que le
-    JPEG, et qu'une grande quantité de logiciels refuse toujours d'ouvrir. Voici
+    Un iPhone enregistre ses photos en HEIC, un format plus léger et meilleur
+    que le JPEG, et que quantité de logiciels refusent toujours d'ouvrir. Voici
     ce qu'est réellement ce format, ce que la conversion coûte à l'image, et
-    pourquoi presque tous les convertisseurs veulent que vous l'envoyiez
-    d'abord."""
+    pourquoi presque tous les convertisseurs veulent d'abord que vous leur
+    envoyiez vos fichiers."""
 updated = "20 août 2026"
 og_title = "Comment convertir un HEIC en JPG"
-og_description = "Pourquoi les photos d'iPhone ne s'ouvrent pas, ce que la conversion coûte, et comment le faire sans remettre les photos à qui que ce soit."
+og_description = "Pourquoi les photos d'iPhone ne s'ouvrent pas, ce que la conversion coûte, et comment convertir sans confier ses photos à qui que ce soit."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/crop-a-video.html
+++ b/locales/fr/pages/guides/crop-a-video.html
@@ -2,220 +2,218 @@
     <h2>La réponse courte</h2>
     <p>
       Ouvrez le <a href="../../recadrer-une-video/">recadreur de vidéos</a>,
-      déposez-y le clip, faites glisser le cadre sur la partie à garder &mdash;
-      ou verrouillez-le sur une forme si on vous en a imposé une &mdash; et
-      exportez. Le clip qui sort dure exactement aussi longtemps que celui qui
-      est entré, avec son rythme et son son intacts.
+      déposez-y votre clip, faites glisser le cadre sur la partie à garder
+      &mdash; ou verrouillez-le sur une proportion si on vous en a imposé une
+      &mdash; puis exportez. Le clip qui sort dure exactement aussi longtemps que
+      celui qui est entré, cadence et bande-son intactes.
     </p>
     <p>
-      Contrairement à la coupe, celui-ci doit écrire de nouvelles images. Ce
-      n'est pas un défaut d'un outil particulier&nbsp;; c'est ce qu'est le
-      recadrage. Le reste de cette page traite de ce que cela coûte et de la
-      façon de le garder petit.
+      Contrairement à la découpe, l'opération oblige à écrire de nouvelles
+      images. Ce n'est pas la faiblesse d'un outil en particulier&nbsp;: c'est ce
+      qu'est le recadrage. Reste à savoir ce que cela coûte et comment limiter la
+      note, ce à quoi le reste de cette page est consacré.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi le recadrage ne peut pas éviter un réencodage</h2>
+    <h2>Pourquoi un recadrage ne peut pas échapper au réencodage</h2>
     <p>
-      Une coupe garde des images entières&nbsp;: un bon coupeur les déplace donc
-      intactes et rien n'est décodé. Un recadrage garde une partie de chaque
-      image &mdash; et une partie d'image est une autre image. Il n'y a aucun
-      moyen de stocker une autre image sans réécrire les pixels.
+      Une découpe garde des images entières, qu'un bon outil déplace donc
+      intactes, sans rien décoder. Un recadrage, lui, ne garde qu'une partie de
+      chaque image &mdash; et une partie d'image est une autre image. Or on
+      n'enregistre pas une autre image sans en réécrire les pixels.
     </p>
     <p>
-      Il existe une exception étroite, et il vaut la peine de la connaître pour
-      reconnaître quand on vous en fait argument. La vidéo est encodée par blocs,
-      et si un recadrage tombait exactement sur des frontières de blocs des
+      Une exception existe, très étroite, et il vaut la peine de la connaître
+      pour reconnaître ceux qui s'en réclament. La vidéo est encodée par blocs
+      et, si un recadrage tombait exactement sur des frontières de blocs des
       quatre côtés, une partie des données pourrait en principe être réutilisée.
       En pratique, les dimensions de l'image, les vecteurs de mouvement et la
-      prédiction doivent de toute façon être réécrits&nbsp;: rien de réel ne se
-      construit ainsi. Considérez qu'un recadrage veut dire un réencodage.
+      prédiction sont de toute façon à réécrire&nbsp;; rien de sérieux ne se
+      construit ainsi. Tenez pour acquis qu'un recadrage suppose un réencodage.
     </p>
     <p>
-      Ce qu'un recadreur bien élevé fera, c'est ne pas dépenser
-      <em>davantage</em> que l'original ne dépensait sur la même zone. Encoder
-      une région recadrée à un débit plus élevé que sa source ne fait que grossir
-      le fichier&nbsp;; cela ne peut pas remettre un détail que l'original
-      n'avait pas.
+      Ce qu'un outil bien fait évitera, en revanche, c'est de dépenser
+      <em>plus</em> que l'original ne dépensait sur la même zone. Encoder une
+      région recadrée à un débit supérieur à celui de sa source ne fait que
+      gonfler le fichier&nbsp;; cela ne rend pas un détail que l'original n'avait
+      pas.
     </p>
   </section>
 
   <section>
-    <h2>Les formes qu'on vous réclame réellement</h2>
+    <h2>Les proportions qu'on vous demande vraiment</h2>
     <p>
-      La plupart des recadrages se font parce qu'un endroit impose une
-      proportion. La liste courte&nbsp;:
+      On recadre presque toujours parce qu'un site impose une proportion. Les
+      quatre à connaître&nbsp;:
     </p>
     <ul>
       <li>
         <strong>9:16 &mdash; vertical.</strong> Stories, reels, shorts, TikTok.
-        Plein écran sur un téléphone tenu normalement. La raison la plus courante
-        pour laquelle quiconque recadre une vidéo.
+        Plein écran sur un téléphone tenu droit. C'est de loin la première raison
+        de recadrer une vidéo.
       </li>
       <li>
-        <strong>1:1 &mdash; carré.</strong> Les posts de fil sur plusieurs
-        plateformes. Fonctionne dans les deux sens de tenue du téléphone, et
-        c'est pourquoi cela perdure.
+        <strong>1:1 &mdash; carré.</strong> Les publications de fil sur plusieurs
+        plateformes. Le carré tient aussi bien dans un sens que dans l'autre,
+        d'où sa longévité.
       </li>
       <li>
-        <strong>4:5 &mdash; légèrement vertical.</strong> La plus grande forme
-        que certains fils autorisent&nbsp;: elle prend donc plus d'écran qu'un
-        carré sans être une vidéo entièrement verticale.
+        <strong>4:5 &mdash; légèrement vertical.</strong> La plus grande
+        proportion que certains fils acceptent&nbsp;: elle occupe plus d'écran
+        qu'un carré sans être une vidéo entièrement verticale.
       </li>
       <li>
         <strong>16:9 &mdash; large.</strong> Le standard de la vidéo en général.
-        Vous ne recadrez en général <em>vers</em> ce format que pour retirer des
-        bandes noires, ou <em>depuis</em> ce format pour obtenir l'un des
-        précédents.
+        On recadre rarement <em>vers</em> ce format, sauf pour retirer des bandes
+        noires&nbsp;; on recadre surtout <em>à partir</em> de lui pour obtenir
+        l'un des trois précédents.
       </li>
     </ul>
     <p>
-      Verrouillez le cadre sur la proportion plutôt que de le tirer à l'œil.
-      Quelques pixels d'écart veulent dire que la plateforme recadrera votre
-      recadrage, et elle ne vous consultera pas sur l'endroit.
+      Verrouillez le cadre sur la proportion au lieu de l'ajuster à l'œil.
+      Quelques pixels d'écart, et c'est la plateforme qui recadrera votre
+      recadrage &mdash; sans vous demander où.
     </p>
   </section>
 
   <section>
-    <h2>Rendre vertical un clip horizontal</h2>
+    <h2>Faire un format vertical à partir d'un plan horizontal</h2>
     <p>
-      C'est le cas courant le plus difficile, et il vaut la peine de dire
-      clairement que le recadrage est un compromis plutôt qu'une solution.
+      C'est le cas courant le plus difficile, et autant le dire tout de
+      suite&nbsp;: le recadrage est ici un compromis, pas une solution.
     </p>
     <p>
-      Une vidéo 16:9 recadrée en 9:16 garde environ 32&nbsp;% de la largeur de
-      l'image. Tout ce qui est sur les côtés a disparu &mdash; et dans un plan
-      horizontal, les côtés sont en général là où se trouve le contexte. Si deux
-      personnes se parlent aux deux bords opposés du cadre, aucun recadrage
-      unique ne garde les deux.
+      Une vidéo 16:9 recadrée en 9:16 conserve environ 32&nbsp;% de la largeur de
+      l'image. Tout ce qui se trouvait sur les côtés disparaît &mdash; or dans un
+      plan horizontal, c'est justement sur les côtés que se trouve le contexte.
+      Si deux personnes se parlent aux deux bords du cadre, aucun recadrage ne
+      les gardera toutes les deux.
     </p>
     <p>
-      Choisissez le recadrage en regardant le clip une fois et en vous demandant
-      où le sujet se trouve réellement la plupart du temps. Si la réponse est
-      &laquo;&nbsp;il bouge&nbsp;&raquo;, un recadrage fixe est le mauvais outil
-      et ce qu'il vous faut est un logiciel de montage capable de faire suivre le
-      cadre dans le temps. Si la réponse est
-      &laquo;&nbsp;au centre, la plupart du temps&nbsp;&raquo;, un recadrage
-      centré convient très bien et prend dix secondes.
+      Pour choisir, regardez le clip une fois en vous demandant où se tient le
+      sujet la plupart du temps. Si la réponse est
+      &laquo;&nbsp;il se déplace&nbsp;&raquo;, un cadre fixe n'est pas le bon
+      outil et il vous faut un logiciel de montage capable de faire suivre le
+      cadre au fil du plan. Si la réponse est
+      &laquo;&nbsp;au centre, à peu près tout le temps&nbsp;&raquo;, un cadrage
+      centré fera parfaitement l'affaire, en dix secondes.
     </p>
     <p>
-      L'autre solution à garder en tête&nbsp;: beaucoup de plateformes acceptent
-      une vidéo horizontale et ajoutent les bandes elles-mêmes. Le recadrage est
-      pour quand vous voulez le plein écran, pas pour quand vous voulez que la
-      vidéo soit acceptée.
+      Une piste à ne pas oublier&nbsp;: beaucoup de plateformes acceptent une
+      vidéo horizontale et ajoutent elles-mêmes les bandes noires. On recadre
+      pour occuper tout l'écran, pas pour que la vidéo passe.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi la largeur et la hauteur avancent par deux</h2>
+    <h2>Pourquoi la largeur et la hauteur avancent de deux en deux</h2>
     <p>
-      Si vous remarquez que le cadre de recadrage refuse les nombres impairs,
-      c'est le codec qui fait des difficultés, pas l'interface.
+      Si le cadre refuse les nombres impairs, ce n'est pas l'interface qui fait
+      des difficultés, c'est le codec.
     </p>
     <p>
-      Le H.264 &mdash; le codec à l'intérieur d'un MP4 &mdash; stocke la couleur
-      à demi-résolution horizontalement et verticalement, parce que l'œil est
-      bien moins sensible au détail de couleur qu'à celui de luminosité. Cela veut
-      dire que l'image est traitée par unités de deux pixels et qu'il n'y a aucun
-      moyen de décrire une image dont un côté ferait un nombre impair de pixels.
+      Le H.264, le codec qu'on trouve à l'intérieur d'un MP4, enregistre la
+      couleur à demi-résolution en largeur comme en hauteur, parce que l'œil est
+      bien moins sensible aux détails de couleur qu'à ceux de luminosité.
+      L'image se manipule donc par unités de deux pixels, et rien ne permet de
+      décrire une image dont un côté ferait un nombre impair de pixels.
     </p>
     <p>
-      Les outils s'en accommodent en arrondissant votre recadrage une fois posé,
-      ce qui déplace votre cadre d'un pixel sans vous le dire, ou en ne proposant
-      que des nombres pairs dès le départ. C'est la seconde solution qui est
-      retenue ici.
+      Les outils s'en arrangent de deux façons&nbsp;: arrondir votre cadre une
+      fois posé, ce qui le déplace d'un pixel sans vous prévenir, ou ne proposer
+      que des nombres pairs dès le départ. C'est la seconde qui a été retenue
+      ici.
     </p>
   </section>
 
   <section>
     <h2>Ce qu'il advient du son</h2>
     <p>
-      Rien, sur le chemin MP4. Le recadrage change l'image et n'a aucune raison
-      de toucher à l'audio&nbsp;: l'audio est donc recopié échantillon par
-      échantillon sans être jamais décodé &mdash; octet pour octet ce qu'il y
-      avait dans le fichier.
+      Rien du tout, sur le chemin MP4. Le recadrage touche à l'image et n'a
+      aucune raison de toucher au son&nbsp;: l'audio est recopié échantillon par
+      échantillon, sans jamais être décodé, et ressort octet pour octet tel qu'il
+      était dans le fichier.
     </p>
     <p>
       Sur le repli par enregistrement, décrit plus bas, le son est capté à la
-      lecture et réencodé, ce qui coûte un peu de qualité. Dans les deux cas, une
-      case permet de le laisser entièrement de côté, ce qui vaut la peine quand
-      le clip part quelque part qui le lira muet de toute façon et que vous
-      voulez le fichier le plus léger.
+      lecture puis réencodé, ce qui coûte un peu de qualité. Dans les deux cas,
+      une case permet de le supprimer purement et simplement &mdash; utile quand
+      le clip part vers un endroit qui le lira muet de toute manière et que vous
+      cherchez le fichier le plus léger possible.
     </p>
   </section>
 
   <section>
-    <h2>Les formats, et le temps que cela prend</h2>
+    <h2>Les formats, et le temps que cela demande</h2>
     <p>
-      <strong>Le MP4, le M4V et le MOV</strong> sont lus directement, quel que
-      soit leur contenu &mdash; H.264, HEVC, AV1 ou VP9 &mdash; du moment que
-      votre navigateur sait décoder ce codec. Contrairement à la coupe, le
-      recadrage doit décoder&nbsp;: le codec compte donc ici d'une façon dont il
-      ne compte pas là-bas.
+      <strong>MP4, M4V et MOV</strong> sont lus directement, quel que soit leur
+      contenu &mdash; H.264, HEVC, AV1 ou VP9 &mdash; à condition que votre
+      navigateur sache décoder ce codec. Contrairement à la découpe, le recadrage
+      doit décoder&nbsp;; le codec compte donc ici, là où il ne comptait pas.
     </p>
     <p>
-      <strong>Tout le reste que votre navigateur sait lire</strong>, le WebM au
-      premier chef, est recadré en le jouant et en enregistrant le résultat, ce
-      qui marche et prend le temps que dure le clip.
+      <strong>Tout autre format que votre navigateur sait lire</strong>, le WebM
+      en premier lieu, est recadré en le jouant et en enregistrant le résultat.
+      Cela fonctionne, et cela dure aussi longtemps que le clip.
     </p>
     <p>
-      <strong>L'AVI, le WMV, le FLV et la plupart des MKV</strong>, le navigateur
-      ne sait ni les lire ni les jouer, et l'outil les refuse avec un message
-      plutôt que d'échouer à mi-course.
+      <strong>AVI, WMV, FLV et la plupart des MKV</strong>, le navigateur ne sait
+      ni les lire ni les jouer&nbsp;; l'outil les refuse par un message plutôt
+      que d'abandonner à mi-parcours.
     </p>
     <p>
-      Attendez-vous à ce qu'un recadrage prenne un temps réel sur un long clip,
-      parce que chaque image est décodée puis réencodée. Aucune limite n'est
-      intégrée à l'outil, et le fichier est parcouru quelques mégaoctets à la
-      fois plutôt que chargé en entier&nbsp;; le plafond pratique est la vidéo
-      finie, assemblée en mémoire avant que vous la téléchargiez.
-    </p>
-  </section>
-
-  <section>
-    <h2>Recadrez avant toute autre chose</h2>
-    <p>
-      Si un clip demande à la fois une coupe et un recadrage, coupez d'abord
-      &mdash; c'est gratuit, et chaque seconde retirée est une seconde que
-      personne n'a à réencoder. Recadrez ensuite le clip raccourci, une seule
-      fois.
-    </p>
-    <p>
-      Faire l'inverse revient à recadrer des images que vous êtes sur le point de
-      jeter, ce qui coûte du temps et de la qualité pour rien. Le
-      <a href="../../couper-une-video/">coupeur de vidéos</a> est juste à côté, et
-      <a href="../couper-une-video/">son guide</a> explique pourquoi cette étape
-      n'a pas à vous coûter quoi que ce soit.
-    </p>
-    <p>
-      Plus généralement&nbsp;: chaque étape avec perte s'accumule. Un recadrage
-      d'un original, c'est une génération. Un recadrage d'une coupe d'un export
-      d'un téléchargement, c'en est quatre, et cela se voit.
+      Sur un clip long, attendez-vous à patienter réellement, puisque chaque
+      image est décodée puis réencodée. L'outil n'impose aucune limite, et le
+      fichier est parcouru par tranches de quelques mégaoctets au lieu d'être
+      chargé en entier&nbsp;; le vrai plafond, c'est la vidéo terminée, qui est
+      assemblée en mémoire avant que vous la téléchargiez.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi cela ne demande pas d'envoi</h2>
+    <h2>Recadrez tôt, et coupez avant de recadrer</h2>
     <p>
-      Décoder et réencoder de la vidéo dans un navigateur est récent et c'est
-      réel&nbsp;: WebCodecs expose l'encodeur matériel même que votre téléphone
-      utilise pour enregistrer de la vidéo, et c'est rapide pour la même raison.
-      Le travail se passe sur la machine qui a déjà le fichier, ce qui est aussi,
-      pour une vidéo de plusieurs gigaoctets, la seule disposition qui ait du sens
-      &mdash; l'envoyer et retélécharger le résultat coûte plus de temps que
-      l'encodage.
+      Si un clip demande à la fois une découpe et un recadrage, commencez par la
+      découpe&nbsp;: elle est gratuite, et chaque seconde retirée est une seconde
+      que personne n'aura à réencoder. Recadrez ensuite le clip raccourci, une
+      seule fois.
     </p>
     <p>
-      L'outil d'ici n'a aucune fonction réseau, et la
-      <code>Content-Security-Policy</code> de la page nomme toutes les adresses
+      Dans l'autre ordre, vous recadrez des images que vous êtes sur le point de
+      jeter&nbsp;: du temps et de la qualité dépensés pour rien. Le
+      <a href="../../couper-une-video/">coupeur de vidéos</a> est juste à côté,
+      et <a href="../couper-une-video/">son guide</a> explique pourquoi cette
+      étape-là ne vous coûte rien.
+    </p>
+    <p>
+      Plus généralement, les étapes destructives s'additionnent. Recadrer un
+      original, c'est une génération. Recadrer la découpe d'un export d'un
+      téléchargement, c'en fait quatre &mdash; et cela se voit.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi rien de tout cela n'exige un envoi</h2>
+    <p>
+      Décoder et réencoder de la vidéo dans un navigateur est une possibilité
+      récente, mais bien réelle&nbsp;: WebCodecs donne accès à l'encodeur
+      matériel que votre téléphone utilise déjà pour filmer, et c'est rapide pour
+      cette raison même. Le travail se fait sur la machine qui détient déjà le
+      fichier, seule solution sensée pour une vidéo de plusieurs gigaoctets
+      &mdash; l'envoyer puis retélécharger le résultat prend plus de temps que
+      l'encodage lui-même.
+    </p>
+    <p>
+      L'outil proposé ici n'a aucune fonction réseau, et la
+      <code>Content-Security-Policy</code> de la page énumère toutes les adresses
       qu'elle peut contacter, dont aucune n'appartient à ce site. Coupez votre
       connexion et recadrez un clip quand même, si vous préférez vérifier plutôt
       qu'on vous le dise.
     </p>
     <p>
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
-      vérifications applicables à n'importe quel outil.
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente trois autres
+      vérifications valables pour n'importe quel outil.
     </p>
   </section>

--- a/locales/fr/pages/guides/crop-a-video.toml
+++ b/locales/fr/pages/guides/crop-a-video.toml
@@ -3,15 +3,18 @@
 #
 
 nav = "Recadrer une vidéo"
-title = "Comment recadrer une vidéo dans une autre forme"
-description = "Ramener un clip à un carré, à un format 9:16 vertical, ou à un cadre en pixels exact. Quelle proportion réclame chaque plateforme, pourquoi recadrer doit réencoder quand couper ne le fait pas, et ce que cela coûte."
-heading = "Comment recadrer une vidéo dans une autre forme"
+# On cherche en français "recadrer une vidéo" tout court, ou le format visé ;
+# le titre nomme donc les formats les plus demandés plutôt que la notion
+# abstraite de forme.
+title = "Comment recadrer une vidéo (carré, 9:16, 16:9)"
+description = "Passer un clip en carré, en 9:16 vertical ou à un cadre au pixel près. La proportion qu'attend chaque plateforme, pourquoi le recadrage réencode là où la découpe s'en dispense, et ce que cela coûte."
+heading = "Comment recadrer une vidéo dans une autre proportion"
 lede = """
-    Recadrer change la forme de l'image, ce qui veut dire écrire de nouvelles
-    images &mdash; il n'y a pas moyen d'y couper, et tout outil qui prétend le
-    contraire fait autre chose. Voici ce que cela coûte, et comment bien le
-    dépenser."""
+    Recadrer change la forme de l'image, donc écrit forcément de nouvelles
+    images&nbsp;: personne n'y échappe, et un outil qui prétend le contraire fait
+    autre chose. Voici ce que cela coûte, et comment bien dépenser ce
+    budget."""
 updated = "20 août 2026"
-og_title = "Comment recadrer une vidéo dans une autre forme"
-og_description = "Quelle proportion réclame chaque plateforme, pourquoi recadrer doit réencoder quand couper ne le fait pas, et ce que cela coûte."
+og_title = "Recadrer une vidéo dans une autre proportion"
+og_description = "La proportion qu'attend chaque plateforme, pourquoi le recadrage réencode là où la découpe s'en dispense, et ce que cela coûte."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/embed-an-image-in-css.html
+++ b/locales/fr/pages/guides/embed-an-image-in-css.html
@@ -2,328 +2,327 @@
     <h2>La réponse courte</h2>
     <p>
       Ouvrez <a href="../../image-en-base64/">Image en data URI</a>, déposez-y
-      l'image, choisissez <em>Une propriété personnalisée CSS</em>, et collez la
-      ligne en tête de votre feuille de style. Servez-vous-en ensuite comme
-      <code>background-image: var(--logo)</code> partout où il vous la faut.
+      votre image, choisissez <em>une propriété personnalisée CSS</em> et collez
+      la ligne en tête de votre feuille de style. Servez-vous-en ensuite avec
+      <code>background-image: var(--logo)</code>, partout où vous en avez besoin.
     </p>
     <p>
       Faites-le quand l'image est petite &mdash; une icône, une puce, un chevron,
-      un motif &mdash; et qu'elle est nécessaire sur toutes les pages. Ne le
-      faites pas avec une photographie. Tout ce qui suit explique pourquoi ces
-      deux phrases diffèrent, et comment savoir dans quel cas vous êtes.
+      un motif &mdash; et qu'elle sert sur toutes les pages. Ne le faites pas
+      avec une photographie. Tout ce qui suit explique la différence entre ces
+      deux phrases, et comment savoir dans quel cas vous êtes.
     </p>
   </section>
 
   <section>
-    <h2>Ce qu'est réellement un data URI</h2>
+    <h2>Ce qu'est une data URI</h2>
     <p>
-      Une adresse qui contient la chose au lieu de pointer vers elle. Là où une
-      feuille de style dirait normalement
+      Une adresse qui contient la chose au lieu de la désigner. Là où une feuille
+      de style écrirait normalement
     </p>
     <pre><code>background-image: url("logo.png");</code></pre>
     <p>
-      et où le navigateur va chercher <code>logo.png</code>, un data URI dit
+      et où le navigateur va chercher <code>logo.png</code>, une data URI dit
     </p>
-    <pre><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <pre class="wrap"><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
     <p>
-      et il n'y a rien à aller chercher&nbsp;: l'image est déjà là, écrite en
-      caractères. Il y a trois parties. <code>data:</code> est le schéma.
-      <code>image/png</code> est le type de média, et le navigateur le croit sur
+      et il n'y a plus rien à aller chercher&nbsp;: l'image est déjà là, écrite
+      en caractères. Il y a trois morceaux. <code>data:</code> est le schéma.
+      <code>image/png</code> est le type de média, et le navigateur y croit sur
       parole &mdash; on y revient plus bas. Tout ce qui suit la virgule est le
       fichier.
     </p>
     <p>
-      C'est toute l'idée. Ce n'est ni une astuce ni un bricolage&nbsp;; c'est
-      dans les standards depuis 1998 et cela fonctionne dans tous les navigateurs
-      sortis depuis.
+      C'est toute l'idée. Ce n'est ni une astuce ni un bricolage&nbsp;: c'est dans
+      les standards depuis 1998, et cela fonctionne dans tous les navigateurs
+      parus depuis.
     </p>
   </section>
 
   <section>
-    <h2>Ce que cela vous rapporte&nbsp;: un aller-retour de moins</h2>
+    <h2>Ce que cela rapporte&nbsp;: un aller-retour de moins</h2>
     <p>
-      L'économie n'est pas la bande passante. C'est la requête.
+      L'économie ne porte pas sur la bande passante, mais sur la requête.
     </p>
     <p>
-      Un navigateur ne peut pas demander <code>logo.png</code> avant d'avoir lu
-      la feuille de style qui le mentionne, et il ne peut pas lire cette feuille
-      de style avant de l'avoir récupérée. Une image de fond ordinaire est donc à
-      au moins deux allers-retours de profondeur dans le chargement de la page,
-      et sur un téléphone en réseau lent un aller-retour peut représenter deux
-      cents millisecondes quelle que soit la petitesse du fichier. Un chevron de
-      600 octets ne coûte presque rien à transférer et peut quand même coûter un
-      quart de seconde à arriver.
+      Un navigateur ne peut pas demander <code>logo.png</code> tant qu'il n'a pas
+      lu la feuille de style qui le mentionne, et il ne peut pas lire cette
+      feuille tant qu'il ne l'a pas récupérée. Une image de fond ordinaire se
+      trouve donc à deux allers-retours au moins dans le chargement de la page
+      &mdash; or sur un téléphone en réseau lent, un aller-retour peut coûter
+      deux cents millisecondes, quelle que soit la taille du fichier. Un chevron
+      de 600 octets ne coûte presque rien à transférer et peut malgré tout mettre
+      un quart de seconde à arriver.
     </p>
     <p>
-      Mis en ligne, il arrive avec la feuille de style. C'est là tout le
-      bénéfice, et pour une petite icône visible d'emblée, il est réel.
+      Incorporé, il arrive avec la feuille de style. Voilà tout le bénéfice, et
+      pour une petite icône visible d'emblée, il est réel.
     </p>
   </section>
 
   <section>
-    <h2>Ce que cela coûte&nbsp;: un tiers, puis la mise en cache</h2>
+    <h2>Ce que cela coûte&nbsp;: un tiers, puis le cache</h2>
     <p>
       <strong>Le base64 ajoute environ un tiers.</strong> Trois octets de fichier
-      deviennent quatre caractères, parce que c'est ce qu'il faut pour écrire des
-      octets quelconques avec les seuls caractères qu'une URL autorise. Il
-      n'existe aucun encodeur malin qui l'évite. Un PNG de 9 KB fait 12 KB de
+      deviennent quatre caractères, parce qu'il en faut autant pour écrire des
+      octets quelconques avec les seuls caractères qu'une URL autorise. Aucun
+      encodeur astucieux n'y échappe. Un PNG de 9&nbsp;KB fait 12&nbsp;KB de
       feuille de style.
     </p>
     <p>
-      <strong>La compression ne le rend pas.</strong> C'est la partie que les
-      gens balaient d'un revers de main. Le gzip et le Brotli travaillent en
-      trouvant de la redondance, et un PNG, un JPEG et un WebP ont déjà été
-      compressés &mdash; il ne leur reste presque aucune redondance, et le base64
-      n'en ajoute pas. En pratique, vous en récupérez quelque chose comme un
-      dixième du tiers, pas la totalité. (Un SVG est le cas inverse, et la
-      section suivante en parle.)
+      <strong>La compression ne vous les rend pas.</strong> C'est le point qu'on
+      croit acquis à tort. Gzip et Brotli travaillent en repérant des
+      redondances, or un PNG, un JPEG et un WebP sont déjà compressés&nbsp;: il
+      ne leur reste presque aucune redondance, et le base64 n'en ajoute pas. En
+      pratique, vous récupérez un dixième du tiers, pas le tiers entier. (Le SVG
+      est le cas inverse, et la section suivante lui est consacrée.)
     </p>
     <p>
-      <strong>Cela cesse d'être un fichier.</strong> C'est le coût qui
-      n'apparaîtra dans aucune mesure que vous êtes susceptible de prendre, et
-      c'est celui qui compte quand la taille monte&nbsp;:
+      <strong>Ce n'est plus un fichier.</strong> Voilà le coût qui n'apparaît
+      dans aucune mesure que vous ferez sans doute, et c'est celui qui compte
+      dès que le site grandit.
     </p>
     <ul>
       <li>
-        <strong>Cela ne peut plus être mis en cache pour soi-même.</strong> Une
-        image ordinaire est récupérée une fois et réutilisée un an. Une image en
-        ligne fait partie de la feuille de style&nbsp;: elle vit et meurt avec
-        l'entrée de cache de celle-ci.
+        <strong>Cela ne se met plus en cache séparément.</strong> Une image
+        ordinaire est récupérée une fois et réutilisée pendant un an&nbsp;; une
+        image incorporée fait partie de la feuille de style et suit le sort de
+        son entrée de cache.
       </li>
       <li>
-        <strong>Changer quoi que ce soit fait tout retélécharger.</strong>
-        Corrigez une marge, livrez une nouvelle feuille de style, et chaque
-        visiteur retélécharge l'image en ligne avec elle &mdash; une image qui
-        n'a pas changé depuis deux ans.
+        <strong>Le moindre changement fait tout retélécharger.</strong> Vous
+        corrigez une marge, vous publiez une nouvelle feuille de style, et chaque
+        visiteur retélécharge l'image avec &mdash; une image qui n'a pas changé
+        depuis deux ans.
       </li>
       <li>
-        <strong>C'est sur le chemin critique.</strong> Une feuille de style
-        bloque le rendu. Une image non. Mettre une image en ligne la fait passer
-        de la seconde catégorie à la première&nbsp;: la page ne peut pas se
-        peindre avant que le tout, image comprise, soit arrivé.
+        <strong>Cela passe sur le chemin critique.</strong> Une feuille de style
+        bloque l'affichage&nbsp;; une image, non. Incorporer une image la fait
+        passer de la seconde catégorie à la première&nbsp;: la page ne peut plus
+        rien peindre tant que l'ensemble, image comprise, n'est pas arrivé.
       </li>
       <li>
-        <strong>Cela ne peut plus être récupéré en parallèle.</strong> Les
-        navigateurs téléchargent beaucoup de choses à la fois. Une image en ligne
-        n'est plus une chose à part, elle ne bénéficie donc de rien de tout cela.
+        <strong>Cela ne se télécharge plus en parallèle.</strong> Les navigateurs
+        récupèrent plusieurs choses à la fois. Une image incorporée n'est plus
+        une chose à part&nbsp;: elle ne profite de rien.
       </li>
     </ul>
     <p>
-      Des seuils approximatifs, qui marquent l'endroit où le conseil change
-      plutôt que celui où un navigateur fait quoi que ce soit de
-      différent&nbsp;: sous 2 KB environ, c'est un gain net&nbsp;; jusqu'à 10 KB
-      environ, cela vaut encore le coup pour quelque chose présent sur toutes les
-      pages&nbsp;; passé 50 KB, c'est une erreur sans message d'erreur.
-      <a href="../../image-en-base64/">L'outil</a> vous dit dans quelle plage
-      tombe chaque résultat, avec le nombre de caractères à côté.
+      Les seuils, approximatifs, marquent le moment où le conseil change et non
+      celui où un navigateur ferait quoi que ce soit de différent&nbsp;: en
+      dessous de 2&nbsp;KB environ, c'est un gain net&nbsp;; jusqu'à 10&nbsp;KB,
+      cela vaut encore le coup pour un élément présent sur toutes les
+      pages&nbsp;; au-delà de 50&nbsp;KB, c'est une erreur qui ne produira aucun
+      message. <a href="../../image-en-base64/">L'outil</a> vous indique dans
+      quelle tranche tombe chaque résultat, avec le nombre de caractères à côté.
     </p>
   </section>
 
   <section>
-    <h2>Ne passez jamais un SVG en base64</h2>
+    <h2>Ne mettez jamais un SVG en base64</h2>
     <p>
-      C'est de loin l'erreur la plus courante en matière d'images en ligne, et
-      elle est commise par les exporteurs et les greffons de compilation aussi
-      souvent que par des humains.
+      C'est de loin l'erreur la plus répandue en matière d'images incorporées, et
+      les exporteurs et les greffons de compilation la commettent aussi souvent
+      que les humains.
     </p>
     <p>
       Un SVG est du texte. Une URL transporte déjà du texte. Seule une poignée de
       caractères doit être échappée &mdash; <code>%</code>, <code>#</code>,
       <code>&lt;</code>, <code>&gt;</code> et le guillemet dans lequel vous
-      l'avez enveloppé &mdash; et tout le reste peut rester exactement tel quel.
-      L'encoder ainsi vous donne un URI typiquement un cinquième plus court que
-      le base64 du même fichier, et qui se compresse ensuite comme du texte
-      plutôt que comme du bruit.
+      l'avez enveloppé &mdash; tout le reste peut rester exactement tel quel.
+      Encoder ainsi donne une URI plus courte d'environ un cinquième que le
+      base64 du même fichier, et qui se comprime ensuite comme du texte, pas
+      comme du bruit.
     </p>
     <p>
-      Il reste en outre lisible&nbsp;:
+      Et cela reste lisible&nbsp;:
     </p>
-    <pre><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <pre class="wrap"><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
     <p>
       Vous voyez le <code>viewBox</code>. Vous pouvez changer la couleur de
       remplissage dans votre éditeur sans rien décoder. Passez le même fichier en
-      base64 et cela devient un mur de lettres que plus personne ne touchera
+      base64 et il devient un mur de lettres auquel personne ne touchera plus
       jamais. <a href="../../image-en-base64/">Image en data URI</a> le fait
-      automatiquement pour tout ce qui s'avère être un SVG, et propose une case
-      pour la rare chaîne d'outils qui exige <code>;base64</code>.
+      automatiquement dès qu'il reconnaît un SVG, et propose une case pour la
+      rare chaîne d'outils qui exige <code>;base64</code>.
     </p>
   </section>
 
   <section>
     <h2>L'erreur de guillemets qui ne casse que les SVG</h2>
     <p>
-      Le CSS permet d'écrire <code>url()</code> sans guillemets, et pour un nom
-      de fichier ordinaire cela va très bien&nbsp;:
+      Le CSS autorise à écrire <code>url()</code> sans guillemets, et pour un nom
+      de fichier ordinaire cela ne pose aucun problème&nbsp;:
     </p>
     <pre><code>background-image: url(logo.png);</code></pre>
     <p>
-      Faites la même chose avec un SVG encodé en pourcents et cela casse. Un
-      jeton <code>url()</code> sans guillemets se termine au premier espace,
-      parenthèse, guillemet ou caractère de contrôle &mdash; et un SVG est plein
-      d'espaces, entre chaque attribut et chaque nombre d'un tracé. La
-      déclaration est alors invalide, le CSS jette les déclarations invalides en
-      silence, et vous n'obtenez ni fond ni erreur.
+      Faites la même chose avec un SVG encodé en pourcentages et tout casse. Un
+      jeton <code>url()</code> sans guillemets s'arrête au premier espace, à la
+      première parenthèse, au premier guillemet ou caractère de contrôle &mdash;
+      or un SVG est plein d'espaces, entre chaque attribut et chaque nombre d'un
+      chemin. La déclaration devient invalide, le CSS jette les déclarations
+      invalides sans rien dire, et vous vous retrouvez sans fond et sans erreur.
     </p>
     <p>
       Le remède, ce sont les guillemets, à chaque fois&nbsp;:
     </p>
     <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
     <p>
-      C'est aussi pourquoi un encodeur n'a pas besoin d'échapper les espaces
-      &mdash; ils sont parfaitement légaux à l'intérieur d'une URL entre
-      guillemets, et échapper chacun en <code>%20</code> coûterait trois
-      caractères par espace du fichier. Les deux décisions vont ensemble&nbsp;:
-      mettez l'URI entre guillemets, et vous pouvez laisser les espaces
-      tranquilles. Toutes les formes que produit l'outil sont entre guillemets
-      pour exactement cette raison.
+      C'est aussi pourquoi un encodeur n'a pas besoin d'échapper les
+      espaces&nbsp;: ils sont parfaitement légaux à l'intérieur d'une URL entre
+      guillemets, et les transformer un à un en <code>%20</code> coûterait trois
+      caractères par espace. Les deux décisions vont ensemble&nbsp;: mettez l'URI
+      entre guillemets, et vous pouvez laisser les espaces tranquilles. C'est
+      exactement pour cela que toutes les formes produites par l'outil sont entre
+      guillemets.
     </p>
   </section>
 
   <section>
     <h2>Le type de média doit être juste</h2>
     <p>
-      Un data URI déclare son propre type, et le navigateur le prend au mot. Il
-      n'y a pas de repli par reniflage comme pour un fichier récupéré&nbsp;:
-      dites <code>image/png</code> à propos de quelque chose qui est en réalité
-      un JPEG et l'image ne s'affiche pas, sans message nulle part où cela
-      servirait.
+      Une data URI déclare son propre type, et le navigateur la croit sur parole.
+      Il n'y a pas ici de reniflement de secours comme pour un fichier
+      récupéré&nbsp;: annoncez <code>image/png</code> à propos d'un fichier qui
+      est en réalité un JPEG, et l'image ne s'affiche pas, sans le moindre
+      message utile.
     </p>
     <p>
-      Ce qui compte, parce que les extensions mentent. Une photo exportée en JPEG
-      et renommée <code>logo.png</code> est une chose ordinaire à trouver sur un
-      disque. Les premiers octets d'un fichier image, en revanche, disent sans
-      ambiguïté ce qu'il est &mdash; chaque format a une signature &mdash;&nbsp;;
-      un outil devrait donc lire le fichier plutôt que son nom. Celui d'ici le
-      fait, et vous prévient quand les deux se contredisent.
+      Ce qui compte, parce que les extensions de fichiers mentent. Une photo
+      exportée en JPEG puis renommée <code>logo.png</code> est une chose banale à
+      trouver sur un disque. Les premiers octets d'un fichier image, en revanche,
+      disent sans ambiguïté ce qu'il est &mdash; chaque format a sa signature
+      &mdash; et un outil devrait donc lire le fichier plutôt que son nom. Celui
+      de ce site le fait, et vous prévient quand les deux se contredisent.
     </p>
     <p>
-      Deux formats valent d'être connus parce qu'ils échouent de façon déroutante.
-      Le <strong>HEIC</strong>, qui est ce dans quoi photographie un iPhone, et
-      le <strong>TIFF</strong>, qui est ce que produisent les scanners, font tous
-      deux des data URI parfaitement valides qu'aucun navigateur sauf Safari ne
-      dessinera. L'URI n'est pas cassé&nbsp;; le format n'est simplement pas un
-      format que le web prend en charge. Convertissez d'abord.
+      Deux formats méritent d'être signalés parce qu'ils échouent d'une manière
+      déroutante. Le <strong>HEIC</strong>, celui dans lequel photographie un
+      iPhone, et le <strong>TIFF</strong>, celui que produisent les scanners,
+      donnent tous deux des data URI parfaitement valides qu'aucun navigateur,
+      hormis Safari, ne dessinera. L'URI n'est pas cassée&nbsp;: c'est le format
+      que le web ne prend pas en charge. Convertissez d'abord.
     </p>
   </section>
 
   <section>
     <h2>Les métadonnées que vous ne vouliez pas publier</h2>
     <p>
-      Un data URI est une copie du fichier, octet pour octet. Rien n'est décodé
-      puis réencodé, ce qui est en général tout l'intérêt &mdash; aucune qualité
-      n'est perdue &mdash; mais cela veut dire aussi que tout le reste du fichier
-      suit.
+      Une data URI est une copie du fichier, octet pour octet. Rien n'est décodé
+      ni réencodé, ce qui est en général tout l'intérêt &mdash; aucune qualité
+      perdue &mdash; mais cela veut dire aussi que tout le reste du fichier suit.
     </p>
     <p>
-      Une photographie sortie tout droit d'un téléphone porte de l'EXIF&nbsp;: les
-      coordonnées GPS du lieu de la prise de vue, l'horodatage, le modèle
-      d'appareil et souvent son numéro de série. Cela peut représenter 30 KB du
-      fichier. Mis en ligne, cela devient 40 KB de base64 dans votre feuille de
-      style, sur le chemin critique de chaque page &mdash; et une adresse
-      personnelle versionnée dans un dépôt, sous une forme que personne ne
-      pensera jamais à regarder.
+      Une photographie sortie d'un téléphone porte de l'EXIF&nbsp;: les
+      coordonnées GPS du lieu de prise de vue, l'horodatage, le modèle
+      d'appareil et souvent son numéro de série. Cela peut représenter 30&nbsp;KB
+      du fichier. Une fois incorporé, cela fait 40&nbsp;KB de base64 dans votre
+      feuille de style, sur le chemin critique de chaque page &mdash; et une
+      adresse personnelle versée dans un dépôt, sous une forme que personne ne
+      songera jamais à regarder.
     </p>
     <p>
-      Retirez-les d'abord avec le
+      Nettoyez d'abord avec le
       <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur EXIF</a>,
-      qui réécrit le conteneur sans toucher à l'image&nbsp;; il y a aussi
-      <a href="../supprimer-les-donnees-exif-et-gps/">un guide pour cela</a>.
-      Image en data URI lit la quantité de métadonnées présentes dans un JPEG, un
-      PNG ou un WebP et le dit avant que vous ne copiiez quoi que ce soit.
+      qui réécrit le conteneur sans toucher à l'image&nbsp;; il existe
+      <a href="../supprimer-les-donnees-exif-et-gps/">un guide pour cela</a>
+      aussi. Image en data URI mesure la quantité de métadonnées d'un JPEG, d'un
+      PNG ou d'un WebP et vous le dit avant que vous ne copiiez quoi que ce soit.
     </p>
   </section>
 
   <section>
-    <h2>Où le mettre, une fois que vous l'avez</h2>
+    <h2>Où la mettre, une fois obtenue</h2>
     <p>
-      Si l'image apparaît dans une seule règle, mettez l'URI dans cette règle. Si
-      elle apparaît dans plusieurs &mdash; et les icônes le font en général, une
-      fois comptés l'état de survol et le thème sombre &mdash; déclarez-la une
-      fois comme propriété personnalisée&nbsp;:
+      Si l'image n'apparaît que dans une règle, mettez l'URI dans cette règle. Si
+      elle apparaît dans plusieurs &mdash; et c'est le cas des icônes dès qu'on
+      compte l'état de survol et le thème sombre &mdash; déclarez-la une fois
+      comme propriété personnalisée&nbsp;:
     </p>
     <pre><code>:root {
-  --icon-search: url("data:image/svg+xml,%3Csvg ... %3E");
+  --icone-recherche: url("data:image/svg+xml,%3Csvg ... %3E");
 }
 
-.search-field { background-image: var(--icon-search); }
-.search-button::before { content: var(--icon-search); }</code></pre>
+.champ-recherche { background-image: var(--icone-recherche); }
+.bouton-recherche::before { content: var(--icone-recherche); }</code></pre>
     <p>
-      Un URI de 3 KB collé dans quatre règles, ce sont 12 KB de feuille de style
-      et quatre endroits à modifier quand l'icône change. La propriété
-      personnalisée, c'est un seul de chaque. C'est aussi la forme qui fait
-      fonctionner les thèmes&nbsp;: redéfinissez <code>--icon-search</code> dans
-      une media query et chacun de ses usages suit.
+      Une URI de 3&nbsp;KB collée dans quatre règles, cela fait 12&nbsp;KB de
+      feuille de style et quatre endroits à corriger le jour où l'icône change.
+      La propriété personnalisée n'en fait qu'un de chaque. C'est aussi la forme
+      qui rend les thèmes possibles&nbsp;: redéfinissez
+      <code>--icone-recherche</code> dans une requête média et tous ses usages
+      suivent.
     </p>
     <p>
       Pour une balise <code>&lt;img&gt;</code> plutôt que du CSS, mettez
-      <code>width</code> et <code>height</code>. Une image en ligne se charge
-      instantanément&nbsp;: une taille manquante est donc un décalage de mise en
-      page trop rapide pour être vu et qui compte quand même contre vous.
-      L'exception est le SVG&nbsp;: celui qui ne porte qu'un <code>viewBox</code>
-      n'a pas de taille en pixels à lui, et écrire le défaut de 300&times;150 du
-      navigateur sur la balise fige une image extensible à une taille que
-      personne n'a choisie.
+      <code>width</code> et <code>height</code>. Une image incorporée se charge
+      instantanément&nbsp;: une taille manquante produit un décalage de mise en
+      page trop rapide pour être vu, et qui vous est quand même compté.
+      Exception&nbsp;: le SVG. Celui qui ne porte qu'un <code>viewBox</code> n'a
+      pas de taille en pixels à lui, et inscrire sur la balise le 300&times;150
+      par défaut du navigateur, c'est figer une image redimensionnable à une
+      taille que personne n'a choisie.
     </p>
     <p>
-      Laissez l'<code>alt</code> vide, sauf si vous avez quelque chose de vrai à
-      y mettre. Vous seul savez si l'image porte du sens ou n'est que décorative,
-      et une description devinée à partir d'un nom de fichier est pire, pour qui
+      Laissez l'<code>alt</code> vide tant que vous n'avez rien de vrai à y
+      mettre. Vous seul savez si l'image porte du sens ou si elle est décorative,
+      et une description devinée d'après un nom de fichier est pire, pour qui
       utilise un lecteur d'écran, que pas de description du tout.
     </p>
   </section>
 
   <section>
-    <h2>Quand la réponse est &laquo;&nbsp;ne le faites pas&nbsp;&raquo;</h2>
+    <h2>Quand la réponse est &laquo;&nbsp;non&nbsp;&raquo;</h2>
     <p>
-      Si l'image dépasse les 50 KB une fois encodée, la mise en ligne est le
-      mauvais outil et aucun soin apporté à l'encodage n'y changera rien. Les
-      solutions de rechange, dans l'ordre où il vaut la peine de les
-      essayer&nbsp;:
+      Si l'image dépasse 50&nbsp;KB une fois encodée, l'incorporation n'est pas
+      le bon outil, et aucun soin apporté à l'encodage n'y changera rien. Les
+      solutions de rechange, dans l'ordre où les essayer&nbsp;:
     </p>
     <ul>
       <li>
-        <strong>Alléger l'image.</strong> La plupart des images trop grosses pour
-        être mises en ligne sont trop grosses tout court. Le
+        <strong>L'alléger.</strong> La plupart des images trop lourdes pour être
+        incorporées sont trop lourdes tout court. Le
         <a href="../../compresser-une-image/">compresseur d'images</a> amènera
-        une photographie à une taille que vous nommez, et le
+        une photographie à la taille que vous nommez, et le
         <a href="../../redimensionner-une-image/">redimensionneur d'images</a>
         ramènera les dimensions en pixels à ce que la mise en page utilise
-        réellement &mdash; ce qui est très souvent le vrai problème.
+        vraiment &mdash; ce qui, très souvent, est le vrai problème.
       </li>
       <li>
-        <strong>La redessiner en SVG.</strong> Une icône exportée en PNG de 40 KB
-        est fréquemment un SVG de 900 octets. Ce n'est pas une différence de
-        compression, c'est une différence de format, et cela règle aussi le
-        problème du Retina.
+        <strong>La redessiner en SVG.</strong> Une icône exportée en PNG de
+        40&nbsp;KB fait fréquemment 900 octets en SVG. Ce n'est pas une
+        différence de compression, c'est une différence de format &mdash; et cela
+        règle du même coup la question des écrans Retina.
       </li>
       <li>
         <strong>La laisser en fichier et la précharger.</strong>
         <code>&lt;link rel="preload" as="image"&gt;</code> lance la récupération
-        immédiatement sans déplacer les octets sur le chemin critique. Cela
-        rapporte l'essentiel du bénéfice de la mise en ligne sans son coût de
-        mise en cache.
+        immédiatement sans faire passer les octets sur le chemin critique. Vous
+        gagnez l'essentiel du bénéfice de l'incorporation sans en payer le coût
+        de cache.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Rien de tout cela ne demande un envoi</h2>
+    <h2>Rien de tout cela n'exige un envoi</h2>
     <p>
-      Encoder un fichier en base64 est de l'arithmétique. Ce sont deux fonctions
-      que le navigateur possède depuis le début &mdash; <code>btoa</code> et
-      <code>encodeURIComponent</code> &mdash; et il n'y a absolument aucune
-      raison technique pour qu'une image voyage jusqu'à un serveur et en revienne
-      pour être écrite autrement. Tout convertisseur qui envoie votre fichier
-      pour faire cela l'envoie pour ses propres raisons, pas pour les vôtres.
+      Encoder un fichier en base64, c'est de l'arithmétique. Ce sont deux
+      fonctions que le navigateur possède depuis l'origine &mdash;
+      <code>btoa</code> et <code>encodeURIComponent</code> &mdash; et rien,
+      absolument rien, n'oblige techniquement une image à faire l'aller-retour
+      jusqu'à un serveur pour être écrite autrement. Un convertisseur qui vous
+      fait envoyer le fichier pour cela l'envoie pour ses raisons à lui, pas pour
+      les vôtres.
     </p>
     <p>
-      <a href="../../image-en-base64/">L'outil d'ici</a> ne l'envoie nulle
-      part&nbsp;: la <code>Content-Security-Policy</code> de la page nomme toutes
-      les adresses qu'elle peut contacter, et aucune n'appartient à ce site.
-      Chargez la page, coupez votre connexion, et encodez quelque chose quand
-      même, si vous préférez vérifier plutôt qu'on vous le dise.
+      <a href="../../image-en-base64/">L'outil de ce site</a> ne l'envoie nulle
+      part&nbsp;: la <code>Content-Security-Policy</code> de la page énumère
+      toutes les adresses qu'elle peut contacter, dont aucune n'appartient à ce
+      site. Chargez la page, coupez votre connexion, et encodez quelque chose
+      quand même, si vous préférez vérifier plutôt qu'on vous le dise.
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
-      vérifications applicables à n'importe quel outil.
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente trois autres
+      vérifications valables pour n'importe quel outil.
     </p>
   </section>

--- a/locales/fr/pages/guides/make-a-favicon.html
+++ b/locales/fr/pages/guides/make-a-favicon.html
@@ -3,41 +3,40 @@
     <p>
       Ouvrez <a href="../../creer-un-favicon/">Image en ICO</a>, déposez-y une
       image carrée d'au moins 256 pixels, laissez le préréglage sur
-      <em>Favicon de site</em>, et téléchargez <code>favicon.ico</code>.
-      Posez-le à la racine de votre site, pour qu'il réponde à
-      <code>https://votresite.com/favicon.ico</code>. Cette adresse est demandée
-      par tous les navigateurs, que votre HTML la mentionne ou non&nbsp;: il n'y
-      a donc rien d'autre que vous soyez strictement obligé de faire.
+      <em>favicon de site web</em> et téléchargez <code>favicon.ico</code>.
+      Placez-le à la racine de votre site, de façon qu'il réponde à
+      <code>https://votresite.com/favicon.ico</code>. Cette adresse, tous les
+      navigateurs la demandent, que votre HTML la mentionne ou non&nbsp;: à
+      proprement parler, vous n'avez rien d'autre à faire.
     </p>
     <p>
-      Tout ce qui suit est ce qui fait la différence entre une icône
-      techniquement présente et une icône lisible&nbsp;: quelles tailles entrent
-      dedans, ce que réclament plutôt les iPhone et Android, et quoi faire quand
-      votre logo ne survit pas à ses seize pixels de large.
+      Tout ce qui suit fait la différence entre une icône techniquement présente
+      et une icône lisible&nbsp;: quelles tailles y mettre, ce que réclament de
+      leur côté les iPhone et les Android, et que faire quand votre logo ne
+      survit pas à seize pixels de large.
     </p>
   </section>
 
   <section>
     <h2>Pourquoi c'est un jeu de tailles et non une image</h2>
     <p>
-      Un fichier <code>.ico</code> est un conteneur. Dedans se trouvent plusieurs
-      images complètes de la même chose à des tailles différentes, et ce qui lit
-      le fichier prend celle qui est la plus proche de la taille dont il a
-      besoin.
+      Un fichier <code>.ico</code> est un conteneur. Il abrite plusieurs images
+      complètes de la même chose à des tailles différentes, et le logiciel qui le
+      lit prend celle qui se rapproche le plus de la taille dont il a besoin.
     </p>
     <p>
-      Cela a l'air redondant et ne l'est pas. Un navigateur qui dessine votre
-      icône à seize pixels a deux possibilités&nbsp;: lire une version de seize
-      pixels que vous avez dessinée, ou en réduire une plus grande sur-le-champ.
-      La seconde est pire, et visiblement &mdash; la réduction automatique d'un
-      logo détaillé produit une bouillie, alors qu'une version de seize pixels
-      que vous avez regardée est une chose que vous avez eu l'occasion de
-      simplifier. Toute la raison pour laquelle le format contient plusieurs
-      tailles est de vous donner cette occasion.
+      Cela ressemble à de la redondance, et ce n'en est pas. Un navigateur qui
+      doit dessiner votre icône à seize pixels a deux possibilités&nbsp;: lire une
+      version de seize pixels que vous avez dessinée, ou réduire une plus grande
+      sur-le-champ. La seconde donne un résultat inférieur, et cela se voit
+      &mdash; la réduction automatique d'un logo détaillé donne de la bouillie,
+      là où une version de seize pixels que vous avez regardée est une version
+      que vous avez eu l'occasion de simplifier. Si le format loge plusieurs
+      tailles, c'est précisément pour vous laisser cette occasion.
     </p>
     <p>
-      Trois tailles sont la convention pour un site web, et chacune a sa
-      raison&nbsp;:
+      Pour un site web, la convention est de trois tailles, et chacune a sa
+      raison d'être.
     </p>
     <ul>
       <li>
@@ -46,126 +45,126 @@
         n'en réussissez qu'une, réussissez celle-là.
       </li>
       <li>
-        <strong>32&times;32</strong> &mdash; une barre de signets, un raccourci
+        <strong>32&times;32</strong> &mdash; la barre de signets, un raccourci
         Windows vers votre site sur le bureau, et la plupart des navigateurs sur
-        un écran haute densité, qui tirent l'icône de l'onglet du 32 et la
-        réduisent.
+        écran haute densité, qui partent du 32 pour dessiner l'onglet.
       </li>
       <li>
         <strong>48&times;48</strong> &mdash; la taille à laquelle Google lit
-        l'icône d'un site pour les résultats de recherche, et la vue à icônes
-        moyennes de Windows.
+        l'icône d'un site pour ses résultats de recherche, et l'affichage
+        &laquo;&nbsp;icônes moyennes&nbsp;&raquo; de Windows.
       </li>
     </ul>
     <p>
-      Tout ce qui est plus grand a sa place dans un PNG à côté du
-      <code>.ico</code>, pas dedans, pour des raisons qui reviennent plus bas au
-      sujet des fichiers mobiles.
+      Au-delà, la place est dans un PNG posé à côté du <code>.ico</code>, pas
+      dedans, pour des raisons qui apparaissent plus bas avec les fichiers pour
+      mobile.
     </p>
   </section>
 
   <section>
     <h2>Le problème des seize pixels</h2>
     <p>
-      C'est la partie dont personne ne vous prévient. Seize pixels, c'est environ
-      quatre millimètres sur un écran normal&nbsp;: une grille de 256 points en
-      tout, moins que les lettres de cette phrase. Presque rien de ce qui a été
-      conçu pour fonctionner sur une enseigne, une carte de visite ou un en-tête
-      de site ne survit à une telle réduction.
+      Voilà ce dont personne ne vous prévient. Seize pixels, c'est environ quatre
+      millimètres sur un écran ordinaire&nbsp;: une grille de 256 points en tout,
+      moins que le nombre de lettres de cette phrase. Presque rien de ce qui a
+      été dessiné pour une enseigne, une carte de visite ou un en-tête de site
+      n'y survit.
     </p>
     <p>
       Ce qui disparaît, dans l'ordre&nbsp;:
     </p>
     <ul>
       <li>
-        <strong>Le texte.</strong> Un mot réduit dans un carré fait environ trois
-        pixels de haut. Il ne devient pas du petit texte, il devient une barre
-        grise. C'est pourquoi presque toutes les entreprises qui ont un symbole
-        en plus d'un nom se servent du symbole seul comme favicon, et pourquoi
-        celles qui n'ont pas de symbole utilisent une seule lettre.
+        <strong>Le texte.</strong> Un logotype réduit dans un carré fait environ
+        trois pixels de haut. Il ne devient pas du petit texte, il devient une
+        barre grise. C'est pourquoi presque toutes les entreprises qui possèdent
+        un symbole en plus d'un nom prennent le symbole seul comme favicon, et
+        pourquoi celles qui n'en ont pas se rabattent sur une seule lettre.
       </li>
       <li>
         <strong>Les traits fins.</strong> Un contour d'un pixel sur un logo de
-        512 pixels fait un trente-deuxième de pixel à seize. Il se rend en une
-        vague brume grise le long du bord, ou disparaît.
+        512 pixels vaut un trente-deuxième de pixel à seize. Il se rend par un
+        vague halo gris le long du bord, ou par rien.
       </li>
       <li>
         <strong>Les dégradés et les ombres.</strong> Il n'y a pas la place pour
-        une transition. Une ombre portée douce devient une frange sale.
+        une transition&nbsp;: une ombre portée douce devient une frange sale.
       </li>
       <li>
-        <strong>Le détail dans le détail.</strong> L'icône d'un document couvert
+        <strong>Le détail dans le détail.</strong> Une icône de document couvert
         d'écriture devient un rectangle avec une tache.
       </li>
     </ul>
     <p>
       Le remède n'est pas un réglage, c'est un autre dessin&nbsp;: une marque
-      simplifiée à une ou deux formes, à fort contraste, et sans texte au-delà
-      d'un seul caractère. Dessinez cette version à 32 ou 48 pixels
-      délibérément, et servez-vous-en comme source.
+      simplifiée, une ou deux formes, un fort contraste, et pas de texte au-delà
+      d'un caractère. Dessinez cette version-là exprès à 32 ou 48 pixels, et
+      partez d'elle.
     </p>
     <p>
       Ce qu'un outil peut faire, c'est vous montrer le problème avant que vous ne
       le publiiez. L'aperçu d'<a href="../../creer-un-favicon/">Image en ICO</a>
       dessine chaque taille à sa taille réelle à l'écran, seule façon d'en juger
-      &mdash; une icône de seize pixels affichée à soixante-quatre a l'air très
-      bien et ne vous apprend rien.
+      &mdash; une icône de seize pixels affichée à soixante-quatre a fière allure
+      et ne vous apprend rien.
     </p>
   </section>
 
   <section>
-    <h2>Votre logo n'est pas carré. Compléter ou recadrer&nbsp;?</h2>
+    <h2>Votre logo n'est pas carré. Compléter ou rogner&nbsp;?</h2>
     <p>
-      Une icône est toujours carrée, et la plupart des logos ne le sont
-      pas&nbsp;: quelque chose doit donc arriver. Il y a trois réponses et elles
-      ne se valent pas.
+      Une icône est toujours carrée et la plupart des logos ne le sont pas&nbsp;:
+      il faut donc bien qu'il se passe quelque chose. Trois réponses possibles,
+      et elles ne se valent pas.
     </p>
     <p>
-      <strong>Compléter</strong> garde l'image entière et met de l'espace
-      au-dessus et au-dessous. C'est le choix sûr par défaut et le mauvais choix
-      pour un mot large&nbsp;: faire tenir dans un carré quelque chose de trois
-      fois plus large que haut le laisse occuper un tiers de la hauteur, ce qui
-      fait à seize pixels cinq pixels de logo et onze de rien.
+      <strong>Compléter</strong> conserve toute l'image et ajoute du vide
+      au-dessus et en dessous. C'est le choix prudent, et le mauvais choix pour
+      un logotype tout en largeur&nbsp;: faire tenir dans un carré une forme
+      trois fois plus large que haute lui laisse un tiers de la hauteur, soit
+      cinq pixels de logo et onze de rien du tout, à seize pixels.
     </p>
     <p>
-      <strong>Recadrer au milieu</strong> prend le plus grand carré du centre.
-      Pour un ensemble &mdash; un symbole avec le nom de l'entreprise à côté
-      &mdash; cela coupe souvent les deux en plein milieu. Mieux vaut recadrer la
-      source vous-même d'abord, jusqu'au symbole seul, puis convertir cela.
+      <strong>Rogner au centre</strong> prend le plus grand carré possible au
+      milieu. Sur un ensemble symbole + nom accolés, cela coupe le plus souvent
+      les deux. Mieux vaut rogner vous-même la source d'abord, jusqu'au symbole
+      seul, et convertir cela.
     </p>
     <p>
-      <strong>Étirer</strong> écrase l'image pour la faire entrer. Il n'existe
-      pratiquement aucune situation où c'est le bon choix, et il est proposé
-      surtout pour que l'outil ne le fasse pas en silence.
+      <strong>Étirer</strong> écrase l'image pour la faire entrer. Il n'existe à
+      peu près aucune situation où c'est le bon choix, et l'option n'est là que
+      pour que l'outil ne le fasse pas en douce.
     </p>
     <p>
-      La réponse générale pour un logo large&nbsp;: ne convertissez pas le logo.
-      Convertissez la partie du logo qui tient debout toute seule.
+      La règle générale pour un logo tout en largeur&nbsp;: ne convertissez pas
+      le logo. Convertissez la partie qui tient debout toute seule.
     </p>
   </section>
 
   <section>
-    <h2>Transparent ou fond uni&nbsp;?</h2>
+    <h2>Fond transparent ou fond plein&nbsp;?</h2>
     <p>
-      Transparent est en général le bon choix pour un site web. Les onglets de
-      navigateur sont gris, blancs ou presque noirs selon le navigateur et le
-      thème, et une icône transparente se pose sur tous. Une icône avec un fond
-      blanc peint dedans est un rectangle blanc dans une barre d'onglets sombre.
+      Pour un site web, la transparence est en général le bon choix. Les onglets
+      des navigateurs sont gris, blancs ou presque noirs selon le navigateur et
+      le thème, et une icône transparente se pose sur tous. Une icône dont le
+      fond blanc a été peint devient un rectangle blanc dans une barre d'onglets
+      sombre.
     </p>
     <p>
-      Deux exceptions valent d'être connues&nbsp;:
+      Deux exceptions à connaître.
     </p>
     <ul>
       <li>
-        <strong>Un logo qui n'est que sombre</strong> disparaît en mode sombre.
-        Si votre marque est noire sur blanc par nature, donnez-lui un fond coloré
-        plutôt que transparent, ou un contour clair.
+        <strong>Un logo entièrement sombre</strong> disparaît en mode sombre. Si
+        votre marque est noire sur blanc par nature, donnez-lui un fond coloré
+        plutôt qu'un fond transparent, ou un contour clair.
       </li>
       <li>
-        <strong>L'icône Apple touch doit être opaque.</strong> iOS la dessine sur
-        sa propre tuile arrondie et rend la transparence en noir. Tout outil qui
-        produit ce fichier devrait l'aplatir pour vous&nbsp;; celui d'ici le
-        fait, sur du blanc par défaut.
+        <strong>L'icône tactile Apple doit être opaque.</strong> iOS la dessine
+        sur sa propre tuile aux coins arrondis et rend la transparence en noir.
+        Tout outil qui produit ce fichier devrait l'aplatir pour vous&nbsp;;
+        celui d'ici le fait, sur du blanc par défaut.
       </li>
     </ul>
   </section>
@@ -176,174 +175,179 @@
       <code>favicon.ico</code> couvre les navigateurs et Windows. Il ne couvre
       pas les téléphones, et c'est là que la plupart des jeux d'icônes faits
       maison s'arrêtent trop tôt. Trois autres plateformes réclament leurs
-      propres fichiers, sous leurs propres noms, et aucune n'ira regarder dans un
-      <code>.ico</code>&nbsp;:
+      propres fichiers, sous leurs propres noms, et aucune n'ira regarder à
+      l'intérieur d'un <code>.ico</code>.
     </p>
     <ul>
       <li>
         <strong>iOS</strong> lit <code>apple-touch-icon.png</code> en
         180&times;180 quand quelqu'un ajoute votre site à son écran d'accueil.
-        Sans lui, iOS utilise une capture de la page, ce qui a l'air d'une
-        erreur.
+        Sans lui, iOS se rabat sur une capture de la page, ce qui a tout l'air
+        d'une erreur.
       </li>
       <li>
         <strong>Android et toutes les invites d'installation</strong> lisent un
         manifeste d'application web &mdash; <code>site.webmanifest</code> &mdash;
-        qui pointe vers des PNG de 192 et 512 pixels. Le 512 est aussi ce qu'une
-        application web montre sur son écran de démarrage.
+        qui désigne des PNG de 192 et de 512 pixels. Le 512 sert aussi d'écran de
+        démarrage à une application web.
       </li>
       <li>
         <strong>Une tuile du menu Démarrer de Windows</strong> lit
-        <code>browserconfig.xml</code>, qui pointe vers un PNG de 150&times;150.
-        Le moins important des trois, et quatre lignes de XML.
+        <code>browserconfig.xml</code>, qui désigne un PNG de 150&times;150. Le
+        moins important des trois, et quatre lignes de XML.
       </li>
     </ul>
     <p>
-      Il y en a une dernière facile à rater&nbsp;: les lanceurs Android rognent
+      Il y en a un dernier, facile à rater&nbsp;: les lanceurs Android rognent
       une icône adaptative à la forme que le téléphone préfère &mdash; cercle,
-      carré arrondi, &laquo;&nbsp;squircle&nbsp;&raquo; &mdash; et seuls les
-      80&nbsp;% centraux de l'image sont garantis de survivre. Une icône dessinée
-      bord à bord perd ses coins. C'est cela, une icône
-      <em>masquable</em>&nbsp;: la même image dessinée délibérément petite à
-      l'intérieur du carré, déclarée séparément dans le manifeste.
+      carré adouci, carré arrondi &mdash; et seuls les 80&nbsp;% centraux de
+      l'image sont garantis. Une icône dessinée bord à bord y perd ses coins.
+      C'est cela, une icône <em>maskable</em>&nbsp;: le même dessin, tracé
+      délibérément petit à l'intérieur du carré, et déclaré à part dans le
+      manifeste.
     </p>
     <p>
-      Cocher le jeu pour site web dans
-      <a href="../../creer-un-favicon/">Image en ICO</a> produit tous ces
-      fichiers, le manifeste, et le bloc de HTML qui pointe vers eux. Une chose
-      que ce bloc omet délibérément, c'est un <code>&lt;link&gt;</code> vers
+      Cocher le jeu &laquo;&nbsp;site web&nbsp;&raquo; dans
+      <a href="../../creer-un-favicon/">Image en ICO</a> produit tout cela, le
+      manifeste compris, ainsi que le bloc de HTML qui y renvoie. Ce que ce bloc
+      omet délibérément, c'est une balise <code>&lt;link&gt;</code> pour
       <code>favicon.ico</code>&nbsp;: les navigateurs demandent cette adresse
-      d'eux-mêmes, et la nommer en plus fait récupérer le même fichier deux fois.
+      d'eux-mêmes, et la nommer en plus fait télécharger le même fichier deux
+      fois.
     </p>
   </section>
 
   <section>
-    <h2>Une icône d'application Windows est un autre jeu</h2>
+    <h2>Une icône d'application Windows, c'est un autre jeu</h2>
     <p>
-      Si l'icône est pour un programme et non pour un site, les tailles changent.
-      Ce que contient l'<code>app.ico</code> livrée par défaut avec Visual Studio,
-      ce sont 16, 32, 48 et 256 &mdash; les trois tailles du shell plus la grande
-      dont se servent le menu Démarrer et la vue très grande de l'Explorateur.
+      Si l'icône est destinée à un programme et non à un site, les tailles
+      changent. L'<code>app.ico</code> livré par défaut avec Visual Studio
+      contient du 16, du 32, du 48 et du 256 &mdash; les trois tailles de
+      l'interface système, plus la grande dont se servent le menu Démarrer et
+      l'affichage &laquo;&nbsp;très grandes icônes&nbsp;&raquo; de
+      l'explorateur.
     </p>
     <p>
-      Sur un écran haute densité, Windows réclame aussi 20, 24, 40, 64 et 96, et
-      les rééchantillonne depuis la taille la plus proche dont il dispose quand
-      elles manquent. Que cela compte ou non dépend de votre icône&nbsp;: une
-      forme plate survit au rééchantillonnage, une forme détaillée non. Les
-      ajouter double à peu près le fichier, ce qui pour une application ne
-      représente rien du tout &mdash; le calcul est complètement différent de
-      celui d'un favicon, que chaque visiteur récupère.
+      Sur un écran haute densité, Windows demande en plus du 20, du 24, du 40, du
+      64 et du 96, et les rééchantillonne depuis la taille la plus proche
+      lorsqu'elles manquent. Que cela compte ou non dépend de votre icône&nbsp;:
+      une forme simple survit au rééchantillonnage, une forme détaillée non. Les
+      ajouter double à peu près le fichier, ce qui, pour une application, n'est
+      rien du tout &mdash; le calcul n'a rien à voir avec celui d'un favicon, que
+      chaque visiteur télécharge.
     </p>
     <p>
-      Encore une chose au sujet de la taille&nbsp;: c'est l'entrée 256 qui pèse.
-      Stockée sans compression, elle fait 264&nbsp;KB à elle seule&nbsp;; stockée
-      en PNG dans l'icône, elle est en général sous les 30. Les entrées PNG sont
-      lisibles depuis Windows Vista&nbsp;: la seule raison de les éviter est donc
-      un logiciel réellement plus ancien que cela, ou un installeur ou un outil
-      embarqué qui analyse les icônes lui-même.
+      Un mot encore sur le poids&nbsp;: c'est l'entrée en 256 qui pèse. Stockée
+      sans compression, elle fait à elle seule 264&nbsp;KB&nbsp;; stockée en PNG
+      à l'intérieur de l'icône, elle tombe en général sous les 30. Les entrées
+      PNG sont lisibles depuis Windows Vista&nbsp;: la seule raison de s'en
+      priver serait un logiciel réellement plus ancien, ou un installeur ou un
+      outil embarqué qui analyse les icônes lui-même.
     </p>
   </section>
 
   <section>
     <h2>Un Mac lit un tout autre fichier</h2>
     <p>
-      Si l'icône est pour une application Mac et non Windows, rien de ce qui
-      précède ne s'applique&nbsp;: macOS ne lit pas du tout le <code>.ico</code>.
-      Il lit le <code>.icns</code>, qui est la même idée dans un autre emballage
-      &mdash; plusieurs tailles dans un conteneur &mdash; avec trois différences
-      à connaître.
+      Si l'icône est destinée à une application Mac plutôt qu'à une application
+      Windows, rien de ce qui précède ne s'applique&nbsp;: macOS ne lit pas du
+      tout le <code>.ico</code>. Il lit le <code>.icns</code>, qui est la même
+      idée dans un autre emballage &mdash; plusieurs tailles dans un conteneur
+      &mdash; avec trois différences à connaître.
     </p>
     <ul>
       <li>
-        <strong>Les tailles sont imposées.</strong> Apple publie dix emplacements
-        et il n'y a rien à choisir&nbsp;: 16, 32, 64, 128, 256, 512 et 1024
-        pixels, les 32, 256 et 512 apparaissant deux fois parce que chacune est à
-        la fois une taille à part entière et la version Retina de la taille
+        <strong>Les tailles sont imposées.</strong> Apple publie dix
+        emplacements et il n'y a rien à choisir&nbsp;: 16, 32, 64, 128, 256, 512
+        et 1024 pixels, le 32, le 256 et le 512 figurant deux fois puisque chacun
+        est à la fois une taille à part entière et la version Retina de la taille
         inférieure.
       </li>
       <li>
         <strong>Cela monte jusqu'à 1024.</strong> Un <code>.ico</code> s'arrête à
-        256, et c'est pourquoi un fichier d'icône Mac fait plusieurs centaines de
-        kilooctets quand un favicon en fait quinze. Pour une application livrée
-        une fois, ce n'est rien&nbsp;; il n'y a qu'un favicon à être récupéré par
-        chaque visiteur.
+        256, et c'est pourquoi un fichier d'icône Mac pèse plusieurs centaines de
+        kilooctets quand un favicon en pèse quinze. Pour une application livrée
+        une fois, cela ne coûte rien&nbsp;; il n'y a qu'un favicon que chaque
+        visiteur télécharge.
       </li>
       <li>
-        <strong>1024 pixels, c'est ce à quoi votre dessin doit survivre.</strong>
-        Les deux problèmes sont les deux extrémités de la même image&nbsp;: un
-        favicon doit fonctionner tout petit, et une icône Mac doit tenir debout
-        en très grand. Un logo exporté en 512 et gonflé à 1024 a l'air mou sur un
-        écran Retina, et l'App Store ne le prendra pas.
+        <strong>C'est à 1024 pixels que votre dessin doit tenir.</strong> Les
+        deux problèmes sont les deux extrémités de la même image&nbsp;: un
+        favicon doit fonctionner minuscule, et une icône Mac doit tenir en très
+        grand. Un logo exporté en 512 puis agrandi à 1024 paraît mou sur un écran
+        Retina, et l'App Store le refusera.
       </li>
     </ul>
     <p>
-      Pour s'en servir&nbsp;: un bundle d'application le garde dans
+      Pour s'en servir&nbsp;: un paquet d'application le range dans
       <code>VotreApp.app/Contents/Resources/</code> et le nomme dans
       <code>Info.plist</code>. Pour un dossier ou une image disque, sélectionnez
       le <code>.icns</code> dans le Finder, faites Commande-C, puis Lire les
-      informations sur la chose à changer, cliquez la petite icône en haut à
+      informations sur l'élément à changer, cliquez la petite icône en haut à
       gauche et faites Commande-V.
     </p>
     <p>
       Cocher <em>icône macOS</em> dans
       <a href="../../creer-un-favicon/">Image en ICO</a> en écrit un, avec ou
-      sans le fichier Windows à côté. Tout ce qui sort sur les deux plateformes
-      veut les deux, et les deux sont tirés de la même image en une seule passe.
+      sans le fichier Windows à côté. Tout ce qui est livré sur les deux
+      plateformes veut les deux, et les deux sont tirés de la même image en une
+      seule passe.
     </p>
   </section>
 
   <section>
     <h2>Vérifier que cela a marché</h2>
     <p>
-      Les navigateurs mettent les favicons en cache plus durement que presque
+      Les navigateurs mettent les favicons en cache plus obstinément que presque
       tout le reste&nbsp;: &laquo;&nbsp;je l'ai mis en ligne et rien n'a
-      changé&nbsp;&raquo; est donc en général un cache plutôt qu'une erreur. Deux
-      choses à essayer avant de vous remettre à modifier des fichiers&nbsp;:
+      changé&nbsp;&raquo; est le plus souvent une affaire de cache, pas d'erreur.
+      Deux choses à essayer avant de rouvrir vos fichiers.
     </p>
     <ul>
       <li>
         Ouvrez directement <code>https://votresite.com/favicon.ico</code>. Si le
-        fichier se télécharge, il est là et vous regardez un cache. Si vous
+        fichier se télécharge, il est bien là et vous regardez un cache. Si vous
         obtenez une 404, il n'est pas à la racine.
       </li>
       <li>
-        Chargez le site dans une fenêtre privée, qui a en général son propre
+        Chargez le site dans une fenêtre privée, qui a d'ordinaire son propre
         cache d'icônes.
       </li>
     </ul>
     <p>
-      Sous Windows, un <code>.ico</code> se vérifie en le mettant dans un dossier
-      et en faisant défiler les tailles d'affichage de l'Explorateur&nbsp;:
+      Sur Windows, on vérifie un <code>.ico</code> en le posant dans un dossier
+      et en faisant défiler les tailles d'affichage de l'explorateur&nbsp;:
       petites, moyennes, grandes et très grandes icônes tirent des entrées
-      différentes du même fichier, et vous voyez donc chacune telle que le
+      différentes du même fichier, ce qui vous les montre chacune telle que le
       système la verra.
     </p>
     <p>
-      Sur un Mac, un <code>.icns</code> s'ouvre dans Aperçu, qui liste chaque
-      emplacement sur le côté &mdash; et la même astuce marche dans le
-      Finder&nbsp;: déposez-le dans un dossier et faites glisser le curseur de
-      taille des options d'affichage pour le voir basculer d'une image à l'autre.
+      Sur un Mac, un <code>.icns</code> s'ouvre dans Aperçu, qui liste tous les
+      emplacements dans la colonne latérale &mdash; et la même astuce fonctionne
+      dans le Finder&nbsp;: posez-le dans un dossier et tirez le curseur de
+      taille des options d'affichage pour le voir passer d'une image à l'autre.
     </p>
   </section>
 
   <section>
-    <h2>Rien de tout cela ne demande un envoi</h2>
+    <h2>Rien de tout cela n'exige un envoi</h2>
     <p>
-      Mettre une image à l'échelle est une chose que tous les navigateurs font
-      depuis des années, et un <code>.ico</code>, c'est un en-tête de six octets,
-      seize octets par image, puis les images. Il n'y a dans sa fabrication
-      aucune étape qui exige un serveur, et l'outil d'ici n'en utilise
-      pas&nbsp;: la <code>Content-Security-Policy</code> de la page nomme toutes
-      les adresses qu'elle peut contacter, et aucune n'appartient à ce site.
+      Redimensionner une image, tous les navigateurs le font depuis des années,
+      et un <code>.ico</code>, ce sont six octets d'en-tête, seize octets par
+      image, puis les images. Aucune étape de sa fabrication ne réclame un
+      serveur, et l'outil de ce site n'en emploie aucun&nbsp;: la
+      <code>Content-Security-Policy</code> de la page énumère toutes les adresses
+      qu'elle peut contacter, dont aucune n'appartient à ce site.
     </p>
     <p>
-      Cela mérite plus d'attention ici qu'ailleurs. Un logo confié à un
-      générateur de favicons gratuit est, assez souvent, une marque non encore
-      dévoilée &mdash; l'icône est l'une des premières choses fabriquées et l'une
-      des dernières annoncées. Chargez la page, coupez votre connexion, et
-      fabriquez-en une quand même, si vous préférez vérifier plutôt qu'on vous le
-      dise. <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer
-      ses fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
-      vérifications applicables à n'importe quel outil.
+      Ce qui mérite ici plus d'attention qu'ailleurs. Un logo confié à un
+      générateur de favicons gratuit est bien souvent une marque encore
+      inconnue&nbsp;: l'icône fait partie des toutes premières choses fabriquées
+      et des toutes dernières annoncées. Chargez la page, coupez votre connexion,
+      et fabriquez-en une quand même, si vous préférez vérifier plutôt qu'on vous
+      le dise.
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente trois autres
+      vérifications valables pour n'importe quel outil.
     </p>
   </section>

--- a/locales/fr/pages/guides/make-a-favicon.toml
+++ b/locales/fr/pages/guides/make-a-favicon.toml
@@ -4,15 +4,15 @@
 
 nav = "Créer un favicon"
 title = "Comment créer un favicon (et une icône d'application Windows)"
-description = "Quelles tailles un favicon.ico réclame vraiment, quels fichiers supplémentaires demandent les iPhone, Android et un Mac, et pourquoi un logo qui marche sur une affiche disparaît à seize pixels."
+description = "Quelles tailles un favicon.ico contient vraiment, quels fichiers supplémentaires réclament les iPhone, Android et un Mac, et pourquoi un logo qui tient sur une affiche disparaît à seize pixels."
 heading = "Comment créer un favicon qui se lise encore à seize pixels"
 lede = """
     Un favicon n'est pas une petite image de votre logo. C'est un jeu d'images à
-    des tailles fixes, dans un conteneur que presque personne n'ouvre, et la plus
-    petite d'entre elles est celle que tout le monde voit réellement. Voici les
-    tailles qu'il vous faut, les fichiers qui les accompagnent, et quoi faire
-    quand votre logo ne survit pas au voyage."""
+    des tailles imposées, rangées dans un conteneur que presque personne
+    n'ouvre, et la plus petite est celle que tout le monde voit. Voici les
+    tailles nécessaires, les fichiers qui les accompagnent, et que faire quand
+    votre logo ne survit pas au voyage."""
 updated = "20 août 2026"
 og_title = "Créer un favicon qui se lise encore à seize pixels"
-og_description = "Quelles tailles un favicon.ico réclame, les fichiers supplémentaires que demandent les iPhone et Android, et quoi faire quand votre logo ne survit pas à la réduction."
+og_description = "Les tailles que contient un favicon.ico, les fichiers supplémentaires que réclament les iPhone et Android, et que faire quand votre logo ne survit pas à la réduction."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/make-a-pdf-smaller.html
+++ b/locales/fr/pages/guides/make-a-pdf-smaller.html
@@ -2,240 +2,243 @@
     <h2>La réponse courte</h2>
     <p>
       Ouvrez le <a href="../../compresser-un-pdf/">compresseur de PDF</a>,
-      déposez-y le document, et regardez ce qu'il vous dit avant de changer quoi
-      que ce soit. Il lit le fichier et montre où se trouve vraiment le poids
-      &mdash; images, polices, texte et dessin, et tout ce à quoi plus rien dans
-      le document ne renvoie. Cet écran répond en général à la question.
+      déposez-y votre document et lisez ce qu'il vous dit avant de toucher au
+      moindre réglage. Il lit le fichier et vous montre où le poids se trouve
+      vraiment&nbsp;: images, polices, texte et tracés, et tout ce que plus rien
+      dans le document ne référence. Cet écran-là suffit en général à répondre à
+      la question.
     </p>
     <p>
-      Si l'essentiel du poids est fait d'images, vous pouvez espérer une grosse
-      économie. Si c'est des polices et du texte, non, et aucun outil ne le peut.
-      Lequel des deux vous avez est toute l'histoire, et cela vaut dix secondes
-      de regard.
+      Si le poids est surtout dans les images, attendez-vous à une belle
+      économie. S'il est dans les polices et le texte, il n'y en aura pas, et
+      aucun outil n'y changera rien. Savoir dans quel cas vous êtes, c'est toute
+      l'affaire, et cela mérite dix secondes de lecture.
     </p>
   </section>
 
   <section>
     <h2>Où se trouve vraiment le poids d'un PDF</h2>
     <p>
-      Un PDF est un conteneur pour plusieurs sortes de choses, et elles ne se
-      compressent pas pareil.
+      Un PDF est un conteneur pour plusieurs sortes de contenus, et elles ne se
+      compressent pas de la même façon.
     </p>
     <ul>
       <li>
-        <strong>Les images.</strong> Photographies et scans. Presque toujours
-        l'essentiel d'un gros PDF, et la seule partie où il y ait vraiment de la
-        marge.
+        <strong>Les images.</strong> Photographies et numérisations. Presque
+        toujours le gros d'un PDF volumineux, et la seule partie où il reste
+        vraiment de la place.
       </li>
       <li>
-        <strong>Les polices incorporées.</strong> Une police complète peut faire
-        des centaines de kilooctets&nbsp;; un sous-ensemble des caractères
-        réellement utilisés, bien moins. Dans les deux cas, elles ont été
-        compressées par ce qui a produit le fichier.
+        <strong>Les polices incorporées.</strong> Une police complète peut peser
+        quelques centaines de kilooctets&nbsp;; réduite aux seuls caractères
+        employés, bien moins. Dans les deux cas, le logiciel qui a produit le
+        fichier les a déjà compressées.
       </li>
       <li>
-        <strong>Le texte et le dessin vectoriel.</strong> Des instructions
-        plutôt que des pixels&nbsp;: trace cette ligne, pose ce mot ici. Déjà
+        <strong>Le texte et les tracés vectoriels.</strong> Des instructions, pas
+        des pixels&nbsp;: tirer cette ligne, poser ce mot ici. C'est déjà
         compact, et déjà compressé.
       </li>
       <li>
-        <strong>Les objets vers lesquels plus rien ne pointe.</strong> Les PDF en
-        accumulent. Modifier un document ajoute souvent le changement à la suite
-        plutôt que de réécrire le fichier&nbsp;: une ancienne version d'une page
-        peut donc y rester indéfiniment. Réempaqueter le fichier les jette.
+        <strong>Les objets que plus rien ne désigne.</strong> Les PDF en
+        accumulent&nbsp;: modifier un document ajoute souvent la correction à la
+        fin au lieu de réécrire le fichier, si bien qu'une ancienne version d'une
+        page peut y séjourner indéfiniment. Réempaqueter le fichier les élimine.
       </li>
     </ul>
     <p>
-      Les deux documents que les gens apportent à un compresseur de PDF ont donc
-      des perspectives complètement différentes. Un document numérisé est pour
-      l'essentiel une pile de photographies, et ressort couramment 60 à 90&nbsp;%
-      plus léger. Un contrat, une thèse ou un rapport exporté, c'est du texte, du
-      dessin et des polices &mdash; tous déjà compressés par le logiciel qui les
-      a écrits &mdash; et l'économie y est en général de quelques pour cent,
-      obtenue en réempaquetant et en jetant ce qui n'est plus référencé.
+      Les deux documents qu'on apporte à un compresseur de PDF n'ont donc pas du
+      tout les mêmes perspectives. Un document numérisé est pour l'essentiel une
+      pile de photographies&nbsp;: il ressort couramment 60 à 90&nbsp;% plus
+      léger. Un contrat, un mémoire ou un rapport exporté, ce sont du texte, des
+      tracés et des polices, tous déjà compressés par le logiciel qui les a
+      écrits&nbsp;; l'économie s'y compte en quelques pour cent, gagnés au
+      réempaquetage et à l'élimination de ce qui ne sert plus.
     </p>
     <p>
-      Tout outil qui promet &laquo;&nbsp;jusqu'à 90&nbsp;% plus
-      léger&nbsp;&raquo; sans regarder votre fichier cite le meilleur cas du
-      premier type à propos du second.
+      Tout outil qui promet &laquo;&nbsp;jusqu'à 90&nbsp;% de
+      réduction&nbsp;&raquo; sans avoir regardé votre fichier annonce le meilleur
+      cas du premier type à quelqu'un qui apporte le second.
     </p>
   </section>
 
   <section>
     <h2>Ce que le DPI vient faire là-dedans</h2>
     <p>
-      Un PDF ne contient pas seulement une image&nbsp;; il enregistre la taille à
-      laquelle cette image est dessinée sur la page. Cela vous donne quelque
-      chose de plus utile que le nombre de pixels&nbsp;: la résolution effective.
+      Un PDF ne se contente pas de contenir une image&nbsp;: il note aussi la
+      taille à laquelle elle est dessinée sur la page. On obtient donc mieux
+      qu'un nombre de pixels &mdash; une résolution effective.
     </p>
     <p>
-      Un scan de 4000 pixels de large étalé sur vingt centimètres de papier
-      transporte 500 pixels par pouce. Un écran en montre environ 100. Une bonne
-      imprimante de bureau travaille à 300 et ne sait guère faire plus. Tout ce
-      qui dépasse est du détail que rien dans l'avenir du document n'affichera
-      jamais &mdash; et c'est en général l'essentiel du fichier.
+      Une numérisation de 4000 pixels de large étalée sur une vingtaine de
+      centimètres de papier fait environ 500 DPI. Un écran en affiche une
+      centaine.
+      Une bonne imprimante de bureau travaille à 300 et ne sait guère faire
+      mieux. Tout ce qui dépasse est du détail que rien, dans l'avenir du
+      document, n'affichera jamais &mdash; et c'est en général l'essentiel du
+      fichier.
     </p>
     <p>
-      C'est pourquoi un compresseur de PDF sensé demande un DPI plutôt qu'un
-      pourcentage de qualité. Il jette d'abord les pixels au-dessus de votre
-      chiffre, parce qu'ils ne coûtent rien que quiconque puisse voir, et ce
-      n'est qu'ensuite qu'il commence à dépenser de la vraie qualité.
+      D'où le choix, chez un compresseur de PDF sensé, de vous demander un DPI
+      plutôt qu'un pourcentage de qualité. Il commence par jeter les pixels
+      au-dessus de votre chiffre, puisque ceux-là ne coûtent rien que l'œil
+      puisse voir&nbsp;; ce n'est qu'ensuite qu'il entame la qualité pour de
+      bon.
     </p>
     <p>
-      Repère approximatif&nbsp;: <strong>150 DPI</strong> pour un document qui
-      sera lu à l'écran, <strong>200 à 300</strong> pour ce qui sera imprimé,
-      <strong>72 à 100</strong> pour un brouillon que personne ne gardera. Mesurer
-      par rapport à la taille à laquelle l'image est dessinée est aussi ce qui
-      fait qu'un logo posé en petit n'est pas traité comme un scan pleine page
-      &mdash; le logo est déjà proche de sa résolution effective et il n'y a rien
-      à y prendre.
+      En pratique&nbsp;: <strong>150 DPI</strong> pour un document destiné à
+      l'écran, <strong>200 à 300</strong> pour quelque chose qui sera imprimé,
+      <strong>72 à 100</strong> pour un brouillon que personne ne conservera. Se
+      régler sur la taille à laquelle l'image est dessinée explique aussi qu'un
+      logo posé en petit ne soit pas traité comme une numérisation pleine
+      page&nbsp;: le logo est déjà proche de sa résolution effective, il n'y a
+      rien à lui prendre.
     </p>
   </section>
 
   <section>
-    <h2>Ce que compresser doit et ne doit pas toucher</h2>
+    <h2>Ce qu'une compression doit toucher, et ce qu'elle doit laisser</h2>
     <p>
-      Les images sont réencodées&nbsp;: elles perdent donc un peu. Rien d'autre
-      ne devrait être touché, et il vaut la peine de vérifier que l'outil que
-      vous utilisez s'y tient&nbsp;:
+      Les images sont réencodées, donc elles perdent un peu. Rien d'autre ne
+      devrait bouger, et il vaut la peine de vérifier que l'outil que vous
+      employez s'y tient.
     </p>
     <ul>
       <li>
         <strong>Le texte reste du texte.</strong> Sélectionnable, cherchable,
         copiable. Un compresseur qui aplatit les pages en images produira un
-        fichier très léger et détruira le document &mdash; vous ne pouvez plus le
-        chercher, les lecteurs d'écran ne peuvent plus le lire, et cela ne se
-        défait jamais.
+        fichier très léger et détruira le document&nbsp;: plus de recherche, plus
+        rien de lisible pour un lecteur d'écran, et aucun retour en arrière
+        possible.
       </li>
       <li>
-        <strong>Les polices restent entières.</strong> Remplacer des polices
-        change l'aspect du document sur la machine de quelqu'un d'autre, ce qui
-        est la seule chose que le PDF existe pour empêcher.
+        <strong>Les polices restent entières.</strong> Substituer une police
+        change l'allure du document sur la machine d'un autre, ce que le PDF
+        existe précisément pour empêcher.
       </li>
       <li>
-        <strong>Le dessin vectoriel est recopié à l'identique.</strong> Il est
-        déjà léger, et le rastériser le rendrait à la fois plus lourd et moins
-        bon.
+        <strong>Les tracés vectoriels sont recopiés à l'identique.</strong> Ils
+        sont déjà légers, et les transformer en pixels les rendrait à la fois
+        plus lourds et moins beaux.
       </li>
       <li>
-        <strong>Les formulaires, les liens, les signets, la structure
-        d'accessibilité et les pièces jointes sont repris.</strong> Ce sont des
-        choses faciles à perdre dans une réécriture et qu'on remarque rarement
-        avant que quelqu'un en ait besoin.
+        <strong>Formulaires, liens, signets, structure d'accessibilité et pièces
+        jointes suivent.</strong> Ce sont les premières choses qu'une réécriture
+        fait perdre, et on ne s'en aperçoit qu'au moment où quelqu'un en a
+        besoin.
       </li>
     </ul>
     <p>
-      Une règle voisine qu'un compresseur devrait suivre et que beaucoup ne
-      suivent pas&nbsp;: si le réencodage d'une image ne ressort pas réellement
-      plus petit que l'original, il faut remettre les octets d'origine. Abîmer une
-      image sans rien économiser est le cas de perte pure, et cela arrive plus
-      souvent qu'on ne le croirait sur des images déjà bien compressées.
+      Une règle voisine, qu'un compresseur devrait suivre et que beaucoup
+      ignorent&nbsp;: si le réencodage d'une image ne la rend pas réellement plus
+      légère que l'originale, il faut remettre les octets d'origine. Abîmer une
+      image sans rien gagner, c'est de la perte sèche, et cela arrive plus
+      souvent qu'on ne croit sur des images déjà bien compressées.
     </p>
   </section>
 
   <section>
-    <h2>Les images qui ne peuvent pas être compressées</h2>
+    <h2>Les images qu'on ne peut pas compresser</h2>
     <p>
-      Certaines images à l'intérieur d'un PDF sont passées, et un bon outil les
-      nomme plutôt que de les laisser discrètement hors du calcul&nbsp;:
+      Certaines images d'un PDF sont laissées de côté, et un bon outil les nomme
+      au lieu de les faire disparaître discrètement de ses calculs.
     </p>
     <ul>
       <li>
-        <strong>Les images JPEG&nbsp;2000, JBIG2 et codées fax (CCITT).</strong>
-        Aucun navigateur ne livre de décodeur pour l'une d'elles&nbsp;: elles
-        sont donc transmises intactes. Les deux dernières sont bitonales &mdash;
-        noir et blanc seulement &mdash; et sont en général déjà proches de leur
-        plus petite taille.
+        <strong>Les images JPEG&nbsp;2000, JBIG2 et fax (CCITT).</strong> Aucun
+        navigateur n'embarque de décodeur pour l'une ou l'autre&nbsp;: elles sont
+        transmises telles quelles. Les deux dernières sont en noir et blanc pur
+        et sont d'ordinaire déjà au plus léger.
       </li>
       <li>
-        <strong>Les images CMJN.</strong> Laissées tranquilles délibérément. Les
-        réencoder risquerait de déplacer les couleurs qu'une imprimerie
-        produirait, ce qui est une drôle d'initiative à prendre sur un document
-        que quelqu'un va imprimer.
+        <strong>Les images CMJN.</strong> Laissées intactes à dessein. Les
+        réencoder risquerait de déplacer les couleurs qu'une imprimante
+        produira, ce qui est une drôle de chose à faire à un document destiné à
+        l'impression.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Choses à essayer avant de compresser</h2>
+    <h2>À essayer avant de compresser</h2>
     <p>
-      Parfois, le fichier est gros pour une raison à laquelle la compression est
-      la mauvaise réponse.
+      Il arrive que le fichier soit lourd pour une raison à laquelle la
+      compression n'est pas la bonne réponse.
     </p>
     <p>
-      <strong>A-t-il été scanné alors que ce n'était pas nécessaire&nbsp;?</strong>
-      Un document imprimé puis scanné est une pile de photographies de texte. Si
-      l'original existe encore quelque part comme document, l'exporter en PDF
-      produira un fichier d'une fraction du poids, et cherchable en prime.
+      <strong>A-t-il été numérisé alors qu'il n'y avait pas lieu&nbsp;?</strong>
+      Un document imprimé puis passé au scanner est une pile de photographies de
+      texte. Si l'original existe encore quelque part sous forme de document,
+      l'exporter en PDF donnera un fichier bien plus léger &mdash; et cherchable
+      par-dessus le marché.
     </p>
     <p>
-      <strong>A-t-il été exporté aux réglages d'impression&nbsp;?</strong> Les
-      traitements de texte et les logiciels de mise en page proposent souvent par
-      défaut un export en qualité d'impression. Réexporter pour l'écran depuis le
-      fichier source bat en général la compression de l'export.
+      <strong>A-t-il été exporté en qualité impression&nbsp;?</strong> Les
+      traitements de texte et les logiciels de mise en page choisissent souvent
+      l'export imprimable par défaut. Réexporter depuis le fichier source en
+      réglage écran fait presque toujours mieux que compresser l'export.
     </p>
     <p>
-      <strong>Faut-il vraiment que ce soit un seul fichier&nbsp;?</strong> Une
-      limite de courriel est par message. Découper un document de 200 pages en
-      chapitres est parfois le remède honnête.
+      <strong>Faut-il vraiment un seul fichier&nbsp;?</strong> La limite d'un
+      courriel s'applique au message. Découper un document de 200 pages en
+      chapitres est parfois la solution honnête.
     </p>
   </section>
 
   <section>
-    <h2>Les fichiers chiffrés, et pourquoi un compresseur devrait les refuser</h2>
+    <h2>Les fichiers chiffrés, et pourquoi un compresseur doit les refuser</h2>
     <p>
-      Un PDF protégé par mot de passe est refusé par l'outil d'ici, et c'est
-      délibéré et non une fonction manquante &mdash; y compris quand le mot de
-      passe est vide, ce qui est la façon dont enregistrent beaucoup de scanners
-      et de photocopieurs.
+      Un PDF protégé par mot de passe est refusé ici, et c'est délibéré, non pas
+      une fonction manquante &mdash; y compris quand le mot de passe est vide, ce
+      que produisent quantité de scanners et de photocopieurs.
     </p>
     <p>
-      Retirer la protection d'un document est un autre métier que le compresser.
-      Un outil qui le ferait en silence ferait quelque chose que vous n'avez pas
-      demandé, à un fichier que quelqu'un avait délibérément verrouillé, et vous
-      rendrait une copie qui n'aurait plus la propriété qu'on avait voulu lui
-      donner. Retirez la protection vous-même d'abord, délibérément, si c'est ce
-      que vous voulez.
+      Ôter la protection d'un document n'est pas le même travail que le
+      compresser. Un outil qui le ferait en silence agirait sans qu'on le lui
+      demande, sur un fichier que quelqu'un avait délibérément verrouillé, et
+      vous rendrait une copie dépourvue de la propriété qu'on avait voulu lui
+      donner. Si c'est ce que vous cherchez, retirez la protection d'abord, en
+      connaissance de cause.
     </p>
   </section>
 
   <section>
     <h2>Vérifier le résultat</h2>
     <p>
-      Ouvrez-le. Regardez les images en zoom maximal, vérifiez que le texte est
-      toujours sélectionnable, et confirmez le nombre de pages.
+      Ouvrez-le. Regardez les images au zoom maximum, assurez-vous que le texte
+      reste sélectionnable, et comptez les pages.
     </p>
     <p>
-      L'outil d'ici fait le dernier point pour vous avant de proposer le
-      fichier&nbsp;: il rouvre le document qu'il vient d'écrire et compte les
-      pages, sur votre propre machine. Il écrit en outre du PDF 1.5, que comprend
-      tout lecteur sorti depuis 2003&nbsp;: &laquo;&nbsp;il s'ouvre sur ma
-      machine&nbsp;&raquo; est donc un indice raisonnable de
-      &laquo;&nbsp;il s'ouvre sur la leur&nbsp;&raquo;.
+      L'outil fait ce dernier point à votre place avant même de vous proposer le
+      fichier&nbsp;: il rouvre le document qu'il vient d'écrire et en compte les
+      pages, sur votre machine. Il écrit par ailleurs du PDF 1.5, que toutes les
+      liseuses parues depuis 2003 comprennent&nbsp;: &laquo;&nbsp;il s'ouvre chez
+      moi&nbsp;&raquo; est donc un indice raisonnable qu'il s'ouvrira chez
+      l'autre.
     </p>
   </section>
 
   <section>
     <h2>Pourquoi cela ne demande pas de serveur</h2>
     <p>
-      Compresser un PDF a l'air d'un travail de serveur, et pendant l'essentiel
-      de la vie du web ç'en a été un. Ce que cela implique réellement, c'est
-      analyser la structure du fichier, trouver les flux d'images, les décoder et
-      les réencoder avec les codecs qu'un navigateur embarque déjà, et réécrire
-      le document. Tout cela tourne dans un navigateur aujourd'hui.
+      Compresser un PDF a des airs de travail de serveur, et pendant la plus
+      grande partie de l'histoire du web c'en était un. Concrètement, il s'agit
+      d'analyser la structure du fichier, d'y trouver les flux d'images, de les
+      décoder et de les réencoder avec des codecs que le navigateur embarque
+      déjà, puis de réécrire le document. Tout cela s'exécute désormais dans un
+      navigateur.
     </p>
     <p>
-      Ce qui compte plus pour ce type de fichier que pour la plupart, à cause de
-      ce que les gens compressent&nbsp;: contrats, courriers médicaux, relevés
-      bancaires, pièces d'identité, déclarations d'impôts. L'outil d'ici n'a
-      aucune fonction réseau, et la <code>Content-Security-Policy</code> de la
-      page nomme toutes les adresses qu'elle peut contacter, dont aucune
-      n'appartient à ce site. Chargez-le, débranchez, et compressez quelque chose
-      quand même.
+      Ce qui compte plus ici qu'ailleurs, vu ce qu'on compresse&nbsp;: des
+      contrats, des courriers médicaux, des relevés bancaires, des pièces
+      d'identité, des déclarations d'impôts. L'outil de ce site n'a aucune
+      fonction réseau, et la <code>Content-Security-Policy</code> de la page
+      énumère toutes les adresses qu'elle peut contacter, dont aucune n'appartient
+      à ce site. Chargez-le, débranchez, et compressez quelque chose quand même.
     </p>
     <p>
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
-      vérifications du même genre.
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente trois autres
+      vérifications du même ordre.
     </p>
   </section>

--- a/locales/fr/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/fr/pages/guides/make-a-pdf-smaller.toml
@@ -3,15 +3,15 @@
 #
 
 nav = "Alléger un PDF"
-title = "Comment alléger un PDF (et pourquoi certains ne maigrissent pas)"
-description = "Où se trouve vraiment le poids d'un PDF, pourquoi un scan perd 80 % et un contrat bouge à peine, ce que veut dire le DPI ici, et ce qu'un compresseur ne devrait jamais faire à votre document."
-heading = "Comment alléger un PDF, et pourquoi certains ne maigrissent pas"
+title = "Comment réduire la taille d'un PDF (et pourquoi certains résistent)"
+description = "Où se trouve vraiment le poids d'un PDF, pourquoi un scan perd 80 % quand un contrat bouge à peine, ce que le DPI vient faire là-dedans, et ce qu'un compresseur ne devrait jamais toucher."
+heading = "Comment réduire la taille d'un PDF, et pourquoi certains résistent"
 lede = """
     Un PDF qui ne passe pas la limite d'un courriel est presque toujours un PDF
-    plein d'images. Voici comment savoir si c'est le cas du vôtre, ce que le
-    compresser coûte, et pourquoi tout outil qui promet un pourcentage fixe n'a
-    pas regardé votre fichier."""
+    plein d'images. Voici comment savoir si c'est le cas du vôtre, ce que sa
+    compression coûte, et pourquoi tout outil qui annonce un pourcentage fixe
+    n'a pas regardé votre fichier."""
 updated = "20 août 2026"
-og_title = "Comment alléger un PDF"
+og_title = "Comment réduire la taille d'un PDF"
 og_description = "Où se trouve vraiment le poids d'un PDF, pourquoi un scan maigrit et un contrat non, et ce que le DPI vient faire là-dedans."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/make-a-qr-code.html
+++ b/locales/fr/pages/guides/make-a-qr-code.html
@@ -4,15 +4,15 @@
       Ouvrez le <a href="../../generateur-de-qr-code/">générateur de QR codes et
       de codes-barres</a>, collez votre lien, laissez le niveau sur
       <strong>M</strong> et la marge sur <strong>4</strong>, et téléchargez le
-      SVG. Imprimez-le sur au moins deux centimètres de large, sur un support
-      mat, sombre sur clair. Scannez ensuite l'exemplaire imprimé avec un
-      téléphone qui n'est pas le vôtre avant d'en commander mille.
+      SVG. Imprimez-le sur au moins deux centimètres de côté, sur un support mat,
+      foncé sur clair. Puis scannez l'épreuve imprimée avec un téléphone qui
+      n'est pas le vôtre, avant d'en commander mille.
     </p>
     <p>
-      Cela couvre à peu près tous les cas. Le reste de cette page est pour les
-      autres&nbsp;: un code qui doit survivre à la manipulation, un code avec un
-      logo dessus, un code destiné à un petit support, et la seule décision
-      facile à rater d'une façon dont vous ne vous apercevrez qu'un an plus tard.
+      Cela couvre presque tous les cas. Le reste de cette page traite des
+      autres&nbsp;: un code qui doit survivre aux manipulations, un code avec un
+      logo dessus, un code destiné à un très petit support, et la seule décision
+      qu'on regrette parfois un an plus tard.
     </p>
   </section>
 
@@ -21,256 +21,261 @@
     <p>
       Une chaîne de caractères. C'est tout. Scanner un QR code remet au téléphone
       un morceau de texte, et tout le reste &mdash; ouvrir une page, rejoindre un
-      réseau, proposer d'enregistrer un contact &mdash; c'est le téléphone qui
-      reconnaît la forme de ce texte et propose d'agir dessus.
+      réseau, proposer d'enregistrer un contact &mdash; n'est que le téléphone
+      reconnaissant la forme de ce texte et proposant d'agir en conséquence.
     </p>
     <p>
-      Il n'existe donc pas de &laquo;&nbsp;QR code Wi-Fi&nbsp;&raquo; comme genre
-      de code. Il existe un QR code contenant
+      Il n'existe donc pas de &laquo;&nbsp;QR code Wi-Fi&nbsp;&raquo; comme
+      catégorie de code. Il existe un QR code contenant
       <code>WIFI:T:WPA;S:Mon Réseau;P:le mot de passe;;</code>, que tous les
       téléphones fabriqués depuis dix ans savent lire. Le générateur vous montre
-      la chaîne finie pour exactement cette raison&nbsp;: quand un code ne fait
-      pas ce que vous attendiez, la chaîne est la seule chose qui vaille d'être
-      regardée.
+      la chaîne finale précisément pour cette raison&nbsp;: quand un code ne fait
+      pas ce que vous attendiez, la chaîne est la seule chose qui vaille la peine
+      d'être regardée.
     </p>
     <p>
-      Cela veut dire aussi qu'un QR code ne peut pas être changé une fois
-      imprimé, ne peut pas téléphoner à la maison, et ne peut pas expirer &mdash;
-      sauf si quelqu'un y a mis un lien vers son propre serveur, ce qui est le
-      sujet de la dernière section d'ici.
+      Cela veut dire aussi qu'un QR code ne se modifie pas une fois imprimé, ne
+      rend de comptes à personne et n'expire pas &mdash; à moins que quelqu'un
+      n'y ait glissé un lien vers son propre serveur, ce dont traite la dernière
+      section de cette page.
     </p>
   </section>
 
   <section>
-    <h2>Décision un&nbsp;: le niveau de correction d'erreurs</h2>
+    <h2>Premier choix&nbsp;: le niveau de correction d'erreurs</h2>
     <p>
-      Un QR code transporte un jeu de mots de contrôle à côté des données,
-      calculés pour qu'un lecteur puisse reconstruire ce qu'il n'a pas pu voir.
-      C'est pourquoi un code auquel il manque un coin se scanne encore. Le nombre
-      de ces mots de contrôle, c'est le niveau, et il y en a quatre&nbsp;:
+      Un QR code transporte, à côté des données, une série de mots de contrôle
+      calculés pour qu'un lecteur puisse reconstituer ce qu'il n'a pas pu voir.
+      C'est pourquoi un code auquel il manque un coin se lit encore. Le nombre de
+      ces mots de contrôle, c'est le niveau, et il y en a quatre.
     </p>
     <ul>
-      <li><strong>L</strong> &mdash; environ 7&nbsp;% du code peut être perdu.</li>
+      <li><strong>L</strong> &mdash; environ 7&nbsp;% du code peut être
+        perdu.</li>
       <li><strong>M</strong> &mdash; environ 15&nbsp;%.</li>
       <li><strong>Q</strong> &mdash; environ 25&nbsp;%.</li>
       <li><strong>H</strong> &mdash; environ 30&nbsp;%.</li>
     </ul>
     <p>
-      Plus de correction n'est pas gratuit&nbsp;: les données de contrôle vont
-      dans le même carré, si bien que le même texte au niveau H demande un code
-      plus grand et plus dense qu'au niveau L. En gros, passer de L à H double le
-      nombre de modules pour la même chaîne, et des modules plus denses sont plus
-      difficiles à résoudre pour un appareil photo. Il y a là un vrai marché, et
-      la réponse dépend de la destination du code.
+      Cette robustesse n'est pas gratuite&nbsp;: les données de contrôle tiennent
+      dans le même carré, si bien que le même texte en H exige un code plus grand
+      et plus dense qu'en L. En gros, passer de L à H double le nombre de modules
+      pour une même chaîne, et des modules plus serrés sont plus durs à résoudre
+      pour une caméra. Il y a donc un vrai arbitrage, et la réponse dépend de la
+      destination du code.
     </p>
     <p>
-      <strong>L</strong> est pour un écran&nbsp;: un code dans une diapositive,
-      un courriel, une page web. Rien ne va l'abîmer et chaque module
-      supplémentaire le rend plus difficile à lire de loin.
+      <strong>L</strong> est fait pour un écran&nbsp;: un code dans une
+      diapositive, un courriel, une page web. Rien ne viendra l'abîmer, et chaque
+      module supplémentaire le rend plus difficile à lire de loin.
     </p>
     <p>
-      <strong>M</strong> est le défaut et la bonne réponse pour la plupart des
-      impressions. Du papier qui sera un peu manipulé, un prospectus, une carte
-      de visite.
+      <strong>M</strong> est la valeur par défaut et la bonne réponse pour la
+      plupart des impressions&nbsp;: du papier qui sera un peu manipulé, un
+      prospectus, une carte de visite.
     </p>
     <p>
-      <strong>Q et H</strong> sont pour les codes qui vont être malmenés&nbsp;:
-      un menu essuyé tous les jours, un autocollant sur une machine d'atelier,
-      une étiquette sur une caisse, un code en vitrine qui prend le soleil
-      direct. Le H est aussi ce qui rend possible un logo au milieu &mdash; voir
-      plus bas.
-    </p>
-  </section>
-
-  <section>
-    <h2>Décision deux&nbsp;: la marge, qui fait partie du code</h2>
-    <p>
-      L'espace blanc autour d'un QR code n'est pas du remplissage, et ce n'est pas
-      un choix graphique. Un lecteur s'en sert pour trouver où le symbole
-      s'arrête. La spécification demande quatre modules de silence de chaque côté,
-      et un code rogné au ras du bord est de loin la première raison pour laquelle
-      un code imprimé échoue.
-    </p>
-    <p>
-      Cela mérite d'être dit sans détour parce que le rognage est une chose si
-      naturelle à faire. Le code a l'air d'avoir trop de blanc autour&nbsp;: il se
-      fait donc recadrer dans la maquette, ou poser sur un aplat de couleur qui
-      vient jusqu'aux carrés, ou posé sur une photographie. Chacune de ces
-      opérations retire la frontière dont le lecteur allait se servir.
-    </p>
-    <p>
-      Si le code paraît trop grand avec sa marge, faites le code plus petit. Ne
-      retirez pas la marge.
+      <strong>Q et H</strong> sont pour les codes qui vont en voir de toutes les
+      couleurs&nbsp;: une carte de restaurant essuyée tous les jours, un
+      autocollant sur une machine d'atelier, une étiquette de caisse, un code en
+      vitrine exposé au plein soleil. Le H est aussi ce qui rend possible un logo
+      au centre, voir plus bas.
     </p>
   </section>
 
   <section>
-    <h2>Décision trois&nbsp;: à quelle taille l'imprimer</h2>
+    <h2>Deuxième choix&nbsp;: la marge, qui fait partie du code</h2>
     <p>
-      La règle empirique qui a survécu au contact du réel est
-      <strong>un pour dix</strong>&nbsp;: un code doit faire environ un dixième
-      de la distance depuis laquelle il sera scanné.
+      Le blanc autour d'un QR code n'est pas de la mise en page, et ce n'est pas
+      un parti pris graphique. Le lecteur s'en sert pour savoir où le symbole
+      s'arrête. La spécification réclame quatre modules de silence de chaque
+      côté, et un code rogné à ras est de très loin la première cause d'échec
+      d'un code imprimé.
+    </p>
+    <p>
+      Autant le dire franchement, car le rognage est un geste naturel&nbsp;: le
+      code paraît avoir trop de blanc autour de lui, alors on le recadre dans la
+      maquette, on le pose sur un aplat de couleur qui vient toucher les carrés,
+      ou on l'incruste sur une photographie. Chacune de ces trois choses supprime
+      la frontière dont le lecteur allait se servir.
+    </p>
+    <p>
+      Si le code paraît trop gros avec sa marge, réduisez le code. Ne retirez pas
+      la marge.
+    </p>
+  </section>
+
+  <section>
+    <h2>Troisième choix&nbsp;: la taille d'impression</h2>
+    <p>
+      La règle qui a survécu au contact du réel est celle du
+      <strong>dixième</strong>&nbsp;: un code doit faire environ le dixième de la
+      distance depuis laquelle on le scannera.
     </p>
     <ul>
-      <li>Une carte de visite ou un menu, lus à 30 cm&nbsp;: environ 2 cm de côté.</li>
-      <li>Une affiche lue à deux mètres&nbsp;: environ 20 cm.</li>
-      <li>Un abribus ou une vitrine lus à cinq mètres&nbsp;: environ 50 cm.</li>
+      <li>Une carte de visite ou une carte de restaurant, lue à 30&nbsp;cm&nbsp;:
+        environ 2&nbsp;cm de côté.</li>
+      <li>Une affiche lue à deux mètres&nbsp;: environ 20&nbsp;cm.</li>
+      <li>Un abribus ou une vitrine lus à cinq mètres&nbsp;: environ
+        50&nbsp;cm.</li>
     </ul>
     <p>
-      Deux centimètres est un plancher plutôt qu'une cible. En dessous d'environ
-      1,5 cm, un téléphone ordinaire commence à peiner quelle que soit la qualité
-      de l'impression, parce que les modules individuels approchent la taille d'un
-      pixel de son capteur.
+      Deux centimètres sont un plancher, pas un objectif. En dessous d'un
+      centimètre et demi environ, un téléphone ordinaire commence à peiner quelle
+      que soit la qualité de l'impression, les modules approchant alors la taille
+      d'un pixel de sa caméra.
     </p>
     <p>
-      Moins de texte veut dire moins de modules, ce qui veut dire un code qui se
-      lit de loin pour une taille imprimée donnée &mdash; bonne raison de pointer
-      un code vers <code>exemple.com/x</code> plutôt que vers une URL avec cent
-      caractères de paramètres de suivi à la fin.
+      Moins de texte, c'est moins de modules, donc un code qui se lit de plus
+      loin à taille imprimée égale &mdash; bonne raison de faire pointer un code
+      vers <code>exemple.fr/x</code> plutôt que vers une adresse suivie de cent
+      caractères de paramètres de suivi.
     </p>
     <p>
-      Et imprimez depuis le <strong>SVG</strong>. Un QR code est fait de bords, et
-      un PNG a un nombre fixe de pixels pour les faire&nbsp;; agrandissez-en un et
-      chaque bord s'adoucit, ce qui est précisément ce qui gêne un scanner. Un SVG,
-      ce sont les carrés sous forme d'instructions&nbsp;: il ressort net sur une
-      carte de visite comme sur un panneau publicitaire.
+      Et imprimez depuis le <strong>SVG</strong>. Un QR code est fait de
+      contours, or un PNG n'a qu'un nombre fixe de pixels pour les
+      construire&nbsp;: agrandissez-le et chaque contour s'adoucit, ce qui est
+      précisément ce qui gêne un scanner. Un SVG décrit les carrés sous forme
+      d'instructions&nbsp;: il ressort net sur une carte de visite comme sur un
+      panneau publicitaire.
     </p>
   </section>
 
   <section>
-    <h2>Couleur, contraste, et les deux erreurs</h2>
+    <h2>La couleur, le contraste, et les deux erreurs</h2>
     <p>
-      Un lecteur mesure la différence entre les modules sombres et les
-      clairs&nbsp;: le contraste, c'est tout. Deux choses tournent mal
-      régulièrement&nbsp;:
+      Un lecteur mesure l'écart entre les modules foncés et les clairs&nbsp;:
+      tout est là. Deux choses tournent régulièrement mal.
     </p>
     <p>
-      <strong>Un code clair sur fond sombre.</strong> C'est spectaculaire, et bon
-      nombre de lecteurs le refusent d'emblée&nbsp;: ils cherchent du sombre sur
-      clair et n'essaient pas l'inversion. Certains le font. Vous ne saurez pas
-      lesquels vos clients ont.
+      <strong>Un code clair sur fond foncé.</strong> C'est graphiquement
+      séduisant, et bon nombre de lecteurs le refusent purement et
+      simplement&nbsp;: ils cherchent du foncé sur clair et n'essaient pas
+      l'inversion. Certains l'essaient. Vous ne saurez jamais lesquels vos
+      clients ont dans la poche.
     </p>
     <p>
       <strong>Pas assez d'écart.</strong> Un gris moyen sur blanc, ou deux
-      couleurs de marque de poids voisin, peuvent très bien se mesurer à l'écran
-      et échouer sur le papier une fois l'étalement de l'encre et l'exposition
-      automatique d'un téléphone entrés en jeu. Si vous colorez un code, gardez
-      la partie sombre réellement sombre.
+      couleurs de marque de densité voisine, peuvent très bien se mesurer à
+      l'écran et échouer sur le papier dès que l'encre s'étale et que l'exposition
+      automatique d'un téléphone entre en jeu. Si vous colorez un code, gardez la
+      partie foncée vraiment foncée.
     </p>
     <p>
-      Le mat bat le brillant pour tout ce qui sera scanné sous une lampe, et les
-      deux battent l'impression sur une photographie. Les fonds transparents sont
-      utiles pour poser un code sur un aplat de couleur &mdash; mais vérifiez ce
-      qui finit derrière, parce qu'un code transparent sur un aplat sombre est la
-      première erreur ci-dessus avec des étapes en plus.
+      Le mat vaut mieux que le brillant dès que le code sera scanné sous une
+      lampe, et les deux valent mieux qu'une impression sur photographie. Les
+      fonds transparents sont commodes pour poser un code sur un aplat coloré
+      &mdash; mais regardez ce qui se retrouve réellement derrière, car un code
+      transparent sur un aplat sombre, c'est la première erreur ci-dessus avec
+      des étapes en plus.
     </p>
   </section>
 
   <section>
-    <h2>Un logo au milieu</h2>
+    <h2>Un logo au centre</h2>
     <p>
-      Cela fonctionne, et cela fonctionne grâce à la correction d'erreurs plutôt
-      que malgré elle. Au niveau H, environ 30&nbsp;% des modules peuvent être
-      détruits sans que le code cesse d'être lisible&nbsp;: un logo qui en couvre
-      nettement moins &mdash; au centre, là où ne se trouve aucun motif de
-      repérage &mdash; est un dégât que le lecteur répare.
+      Cela fonctionne, et cela fonctionne grâce à la correction d'erreurs, non
+      malgré elle. Au niveau H, environ 30&nbsp;% des modules peuvent être
+      détruits sans que le code cesse d'être lisible&nbsp;: un logo qui en
+      recouvre nettement moins, au centre, là où ne se trouve aucun motif de
+      repérage, est un dégât que le lecteur répare.
     </p>
     <p>
-      Trois règles à tenir. Utilisez le niveau H. Gardez le logo sous environ un
-      cinquième de la surface, bien en deçà de la limite théorique, parce que
-      l'impression n'est pas la seule chose à grignoter votre marge. Et ne
-      couvrez jamais les trois grands carrés des coins ni les plus petits qui les
-      accompagnent&nbsp;: c'est ainsi qu'un lecteur trouve et oriente le symbole
-      en premier lieu, et aucune correction d'erreurs ne les reconstruit.
+      Trois règles à respecter. Employez le niveau H. Gardez le logo sous le
+      cinquième de la surface environ, bien en deçà de la limite théorique, car
+      l'impression n'est pas la seule chose à entamer votre réserve. Et ne
+      couvrez jamais les trois grands carrés des coins, ni les plus petits qui
+      les accompagnent&nbsp;: c'est par eux qu'un lecteur trouve et oriente le
+      symbole, et aucune correction d'erreurs ne les reconstitue.
     </p>
     <p>
-      Testez-le ensuite sur de vrais téléphones. Un logo fait passer un code de
+      Puis essayez sur de vrais téléphones. Un logo fait passer un code de
       &laquo;&nbsp;marche toujours&nbsp;&raquo; à
-      &laquo;&nbsp;marche avec cette marge-là&nbsp;&raquo;, et le seul moyen de
-      savoir combien de marge il reste est d'essayer.
+      &laquo;&nbsp;marche avec telle réserve&nbsp;&raquo;, et le seul moyen de
+      savoir ce qu'il en reste est d'essayer.
     </p>
   </section>
 
   <section>
     <h2>La décision qu'on regrette&nbsp;: statique ou &laquo;&nbsp;dynamique&nbsp;&raquo;</h2>
     <p>
-      Cherchez un générateur de QR code et la plupart des résultats voudront que
-      vous créiez un compte, parce qu'ils vendent des codes <em>dynamiques</em>.
-      Un code dynamique ne contient pas votre lien. Il contient un lien court vers
-      le serveur du générateur, qui redirige vers le vôtre.
+      Cherchez un générateur de QR codes&nbsp;: la plupart des résultats
+      voudront vous faire créer un compte, parce qu'ils vendent des codes
+      <em>dynamiques</em>. Un code dynamique ne contient pas votre lien&nbsp;: il
+      contient un lien court vers le serveur du générateur, qui redirige vers le
+      vôtre.
     </p>
     <p>
-      Ce que cela vous rapporte est réel&nbsp;: vous pouvez changer la
-      destination du code après l'impression, et vous obtenez un décompte de
-      chaque scan. Pour une campagne à six chiffres d'exemplaires, cela vaut
-      qu'on paie.
+      Ce que cela vous apporte est réel&nbsp;: vous pouvez changer la destination
+      du code après l'impression, et vous obtenez le décompte de chaque scan.
+      Pour une campagne tirée à cent mille exemplaires, cela vaut son prix.
     </p>
     <p>
-      Ce que cela coûte est réel aussi, et vaut d'être su avant plutôt
-      qu'après&nbsp;:
+      Ce que cela coûte est réel aussi, et mieux vaut le savoir avant qu'après.
     </p>
     <ul>
       <li>
-        <strong>Le code cesse de fonctionner quand ils cessent de
-        fonctionner.</strong> Si le service ferme, si le domaine expire, ou si
-        l'offre gratuite se termine, chaque code que vous avez imprimé meurt
-        &mdash; et à ce moment-là ils sont sur dix mille menus.
+        <strong>Le code meurt le jour où le prestataire s'arrête.</strong> Si le
+        service ferme, si le domaine n'est pas renouvelé, si l'offre gratuite
+        expire, tous les codes que vous avez imprimés deviennent muets &mdash; et
+        d'ici là, ils sont sur dix mille cartes de restaurant.
       </li>
       <li>
-        <strong>Chaque scan est la donnée de quelqu'un d'autre.</strong> La
-        redirection voit l'adresse IP, l'heure et l'appareil de chaque personne
-        qui scanne votre code.
+        <strong>Chaque scan alimente les données de quelqu'un d'autre.</strong>
+        La redirection voit l'adresse IP, l'heure et l'appareil de chaque
+        personne qui scanne votre code.
       </li>
       <li>
-        <strong>Le lien est le leur, pas le vôtre.</strong> Quiconque le scanne
-        voit passer un domaine inconnu, ce dont on dit précisément aux gens de se
-        méfier.
+        <strong>Le lien est le sien, pas le vôtre.</strong> Qui scanne voit
+        passer un domaine inconnu, c'est-à-dire exactement ce dont on répète aux
+        gens de se méfier.
       </li>
     </ul>
     <p>
-      La voie du milieu ne coûte rien&nbsp;: faites un QR code statique autour
-      d'une URL courte <em>sur votre propre domaine</em>, et redirigez-la
-      vous-même. Vous gardez la possibilité de changer la destination, vous
-      gardez les statistiques, et rien du code ne dépend de la survie, l'an
-      prochain, d'une entreprise que vous n'avez jamais rencontrée.
+      La voie moyenne ne coûte rien&nbsp;: mettez un QR code statique autour
+      d'une adresse courte <em>sur votre propre domaine</em>, et faites la
+      redirection vous-même. Vous gardez la possibilité de changer la
+      destination, vous gardez les statistiques, et plus rien dans le code ne
+      dépend de la survie l'an prochain d'une entreprise que vous n'avez jamais
+      rencontrée.
     </p>
     <p>
-      Le <a href="../../generateur-de-qr-code/">générateur d'ici</a> ne fait que
-      des codes statiques, et il n'y a aucun compte à créer. Ce que vous tapez est
-      ce que le code contient.
+      Le <a href="../../generateur-de-qr-code/">générateur de ce site</a> ne
+      fabrique que des codes statiques, et il n'y a aucun compte à créer. Ce que
+      vous tapez est ce que le code contient.
     </p>
   </section>
 
   <section>
     <h2>Avant d'en imprimer mille</h2>
     <p>
-      Scannez le code. Pas celui de votre écran &mdash; l'épreuve imprimée, à
-      l'endroit où elle va, avec un téléphone qui n'est pas celui sur lequel vous
-      l'avez fabriqué. Cela prend une minute et attrape toute la catégorie de
-      problèmes dont parle cette page&nbsp;: une marge mangée par la maquette, un
-      lien à qui il manque son <code>https://</code>, une couleur qui s'est
-      mesurée autrement sur le papier, un code imprimé à une taille qui marche sur
-      un bureau et pas sur un mur.
+      Scannez le code. Pas celui de votre écran&nbsp;: l'épreuve imprimée, posée
+      là où elle ira, avec un téléphone qui n'est pas celui sur lequel vous
+      l'avez fabriquée. Cela prend une minute et attrape toute la famille de
+      problèmes dont traite cette page&nbsp;: une marge mangée par la maquette,
+      un lien auquel manque son <code>https://</code>, une couleur qui se
+      comporte autrement sur papier, une taille d'impression qui marche sur un
+      bureau et pas sur un mur.
     </p>
     <p>
       Et vérifiez ce qui se passe après le scan. Un code qui ouvre une page
-      illisible sur un téléphone est un code qui a échoué, même s'il s'est scanné.
+      illisible sur un téléphone est un code raté, même s'il s'est bien scanné.
     </p>
   </section>
 
   <section>
-    <h2>Rien de tout cela n'exige d'envoyer quoi que ce soit</h2>
+    <h2>Rien de tout cela ne demande d'envoyer quoi que ce soit</h2>
     <p>
-      Un QR code est de l'arithmétique sur une chaîne de caractères. Il n'y a
-      aucun fichier à envoyer et rien qu'un serveur puisse faire qu'un navigateur
-      ne puisse pas, et c'est pourquoi
-      <a href="../../generateur-de-qr-code/">l'outil d'ici</a> fait tout sur votre
-      propre machine et fonctionne réseau débranché.
+      Un QR code, c'est de l'arithmétique sur une chaîne de caractères. Il n'y a
+      aucun fichier à transmettre et rien qu'un serveur puisse faire qu'un
+      navigateur ne sache faire, et c'est pourquoi
+      <a href="../../generateur-de-qr-code/">l'outil de ce site</a> fait tout sur
+      votre machine et fonctionne réseau débranché.
     </p>
     <p>
-      Cela compte plus que cela n'en a l'air, à cause de ce que les gens mettent
-      dans les QR codes. L'usage le plus courant du format Wi-Fi, c'est le mot de
-      passe réel d'un réseau, tapé dans une page web. Il vaut la peine de savoir
-      si cette page avait quelque part où l'envoyer.
+      Cela compte plus qu'il n'y paraît, vu ce que les gens mettent dans un QR
+      code. L'usage le plus répandu du format Wi-Fi consiste à y taper le vrai
+      mot de passe d'un réseau, dans une page web. Autant savoir si cette page
+      avait quelque part où l'envoyer.
     </p>
   </section>

--- a/locales/fr/pages/guides/make-a-qr-code.toml
+++ b/locales/fr/pages/guides/make-a-qr-code.toml
@@ -1,17 +1,20 @@
 #
 # Guide : creer un QR code qui se scanne vraiment - French.
 #
+# La description evite les guillemets : elle part telle quelle dans une balise
+# meta, ou l'entite &laquo; ne serait pas interpretee.
+#
 
 nav = "Créer un QR code"
 title = "Comment créer un QR code qui se scanne à tous les coups"
-description = "Quel niveau de correction d'erreurs choisir, pourquoi la marge blanche autour d'un QR code fait partie du code, à quelle taille l'imprimer, et ce que le code « dynamique » d'un générateur gratuit vous coûtera plus tard."
+description = "Quel niveau de correction d'erreurs choisir, pourquoi la marge blanche fait partie du code, à quelle taille l'imprimer, et ce qu'un code dynamique de générateur gratuit vous coûtera plus tard."
 heading = "Comment créer un QR code qui se scanne encore sur le téléphone d'un autre"
 lede = """
-    Créer un QR code prend une seconde. En créer un qui fonctionne sur un menu
-    mouillé, un abribus, ou un téléphone tenu à bout de bras dans une mauvaise
-    lumière demande quatre décisions, et toutes les quatre se prennent avant que
-    vous imprimiez quoi que ce soit. Voici ce que chacune fait."""
+    Créer un QR code prend une seconde. En créer un qui fonctionne sur une carte
+    de restaurant mouillée, un abribus ou un téléphone tenu à bout de bras dans
+    une mauvaise lumière demande quatre décisions &mdash; et toutes se prennent
+    avant l'impression. Voici ce que chacune change."""
 updated = "20 août 2026"
 og_title = "Créer un QR code qui se scanne encore sur le téléphone d'un autre"
-og_description = "Les quatre décisions qui font qu'un QR code imprimé fonctionne : le niveau, la marge, la taille, et l'adresse de qui se trouve réellement dedans."
+og_description = "Les quatre décisions qui font qu'un QR code imprimé fonctionne : le niveau, la marge, la taille, et l'adresse de qui se trouve vraiment dedans."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/fr/pages/guides/remove-exif-and-gps-data.html
@@ -2,232 +2,230 @@
     <h2>La réponse courte</h2>
     <p>
       Ouvrez le <a href="../../supprimer-les-donnees-exif/">lecteur et effaceur
-      EXIF</a>, déposez-y les photos, et appuyez sur
-      &laquo;&nbsp;Tout supprimer&nbsp;&raquo;. Chaque étiquette, les blocs XMP
-      et IPTC, les commentaires et la vignette incorporée partent, sur toutes les
-      photos de la liste d'un coup. L'image elle-même n'est pas touchée &mdash;
-      ni recompressée, ni décodée, ni changée d'un seul pixel.
+      EXIF</a>, déposez-y vos photos et appuyez sur
+      &laquo;&nbsp;Tout supprimer&nbsp;&raquo;. Toutes les étiquettes, les blocs
+      XMP et IPTC, les commentaires et la vignette incorporée disparaissent d'un
+      coup, sur toutes les photos de la liste. L'image, elle, n'est pas
+      touchée&nbsp;: ni recompressée, ni décodée, pas un pixel de changé.
     </p>
     <p>
-      Avant de le faire, cela vaut la peine de regarder ce qu'il y avait dedans.
-      C'est en général plus que ce que les gens imaginent, et cette liste est
-      l'argument même en faveur de l'opération.
+      Avant d'appuyer, jetez un œil à ce qu'il y avait là. Il y a d'ordinaire
+      plus qu'on ne l'imagine, et cette liste est à elle seule l'argument en
+      faveur de l'opération.
     </p>
   </section>
 
   <section>
-    <h2>Ce qu'il y a réellement dans une photo</h2>
+    <h2>Ce qu'une photo contient réellement</h2>
     <p>
-      Un JPEG n'est pas seulement une image compressée. C'est un conteneur, et à
-      côté de l'image se trouvent plusieurs blocs d'informations que votre
-      appareil, votre téléphone ou votre logiciel de retouche y ont écrits.
+      Un JPEG n'est pas qu'une image compressée&nbsp;: c'est un conteneur, et à
+      côté de l'image s'y trouvent plusieurs blocs d'informations écrits par
+      votre appareil, votre téléphone ou votre logiciel de retouche.
     </p>
     <ul>
       <li>
         <strong>L'EXIF.</strong> Le principal. Marque et modèle de l'appareil,
-        objectif, réglages d'exposition, ISO, date et heure à la seconde,
-        orientation dans laquelle l'image doit être montrée, et &mdash; sur un
-        téléphone dont la localisation est active pour l'appareil photo &mdash;
-        une position GPS précise à quelques mètres. Souvent aussi un numéro de
-        série de boîtier.
+        objectif, réglages d'exposition, sensibilité ISO, date et heure à la
+        seconde, orientation d'affichage &mdash; et, sur un téléphone dont la
+        localisation est activée pour l'appareil photo, une position GPS précise
+        à quelques mètres. Souvent aussi le numéro de série du boîtier.
       </li>
       <li>
-        <strong>Le GPS.</strong> Techniquement une partie de l'EXIF, et qui vaut
-        d'être nommée à part parce que c'est celle qui compte le plus. Elle est
-        écrite en degrés, minutes et secondes, format qui réussit très bien à ne
-        pas ressembler à une adresse.
+        <strong>Le GPS.</strong> Techniquement une partie de l'EXIF, qu'il vaut
+        la peine de nommer à part parce que c'est la plus lourde de conséquences.
+        Elle est écrite en degrés, minutes et secondes, un format qui réussit
+        remarquablement bien à ne pas ressembler à une adresse.
       </li>
       <li>
         <strong>Le XMP.</strong> Un paquet de XML qu'écrivent les logiciels de
-        retouche. Il peut porter votre nom, votre logiciel, des notes, des
-        mots-clés, un historique de modifications, et une copie de certains
-        champs EXIF &mdash; c'est pourquoi supprimer l'EXIF seul ne suffit pas.
+        retouche. Il peut porter votre nom, celui de votre logiciel, des notes,
+        des mots-clés, un historique de modifications et une copie de certains
+        champs EXIF &mdash; raison pour laquelle effacer l'EXIF seul ne suffit
+        pas.
       </li>
       <li>
-        <strong>L'IPTC.</strong> Un bloc plus ancien de champs de légende, de
-        signature, de crédit et de copyright, utilisé dans la presse et la photo
-        de stock.
+        <strong>L'IPTC.</strong> Un bloc plus ancien&nbsp;: légende, signature,
+        crédit, mentions de droits. On le trouve dans la presse et les banques
+        d'images.
       </li>
       <li>
-        <strong>La vignette incorporée.</strong> Une petite deuxième copie de
-        l'image. Elle est produite au moment de l'écriture du fichier, et elle
-        n'est pas toujours refaite quand l'image est modifiée &mdash; c'est ainsi
-        qu'une photo recadrée peut voyager avec une vignette de ce qui a été
-        coupé.
+        <strong>La vignette incorporée.</strong> Une petite seconde copie de
+        l'image, fabriquée au moment où le fichier est écrit et pas toujours
+        refaite quand l'image est modifiée. C'est ainsi qu'une photo recadrée
+        peut voyager avec une vignette montrant ce qu'on venait d'en retirer.
       </li>
       <li>
-        <strong>La note de fabricant.</strong> Un bloc de données non documenté.
-        Personne en dehors du fabricant ne sait tout ce qu'il contient.
+        <strong>La note du fabricant.</strong> Un bloc de données non documenté.
+        Personne, hors du fabricant, ne sait tout ce qui s'y trouve.
       </li>
     </ul>
   </section>
 
   <section>
-    <h2>Qui le voit réellement</h2>
+    <h2>Qui le voit vraiment</h2>
     <p>
-      C'est la partie où il vaut la peine d'être exact, parce que la version
-      alarmiste et la version dédaigneuse sont fausses toutes les deux.
+      C'est le passage où il faut être exact, parce que la version alarmiste et
+      la version désinvolte sont fausses toutes les deux.
     </p>
     <p>
-      <strong>La plupart des grands réseaux sociaux effacent les métadonnées
-      quand vous publiez.</strong> Facebook, Instagram et X réencodent les images
-      envoyées et jettent les étiquettes au passage. Ce n'est pas une gentillesse
-      &mdash; ils gardent les données de leur côté &mdash; mais cela veut bien
-      dire qu'une photo publiée sur ces services ne remet pas ses coordonnées à
-      chaque personne qui la regarde.
+      <strong>La plupart des grands réseaux sociaux effacent les métadonnées à
+      la publication.</strong> Facebook, Instagram et X réencodent les images
+      reçues et jettent les étiquettes au passage. Ce n'est pas une amabilité
+      &mdash; ils conservent les données de leur côté &mdash; mais cela veut dire
+      qu'une photo publiée là ne livre pas ses coordonnées à tous ceux qui la
+      regardent.
     </p>
     <p>
       <strong>Presque tout le reste les conserve.</strong> Une pièce jointe de
-      courriel. Un fichier envoyé sur la plupart des messageries comme
+      courriel. Un fichier transmis par messagerie en tant que
       &laquo;&nbsp;document&nbsp;&raquo; plutôt que comme photo. Une image sur un
-      forum, une annonce de petites annonces, un site personnel, un disque
-      partagé, un rapport de bug, un ticket de support. Dans tous ces cas le
-      fichier arrive intact, et quiconque le télécharge peut en lire les
-      étiquettes avec des outils livrés avec son système d'exploitation.
+      forum, une annonce sur un site de petites annonces, un site personnel, un
+      disque partagé, un rapport de bug, un ticket d'assistance. Dans tous ces
+      cas, le fichier arrive intact et quiconque le télécharge en lit les
+      étiquettes avec les outils fournis d'origine par son système.
     </p>
     <p>
-      Les risques réalistes sont banals plutôt que spectaculaires&nbsp;: une
-      annonce photographiée à la maison, une photo d'enfant prise dans son école,
-      un compte apparemment anonyme qui publie des photos partageant toutes le
-      même numéro de série d'appareil, un
-      &laquo;&nbsp;pris la semaine dernière&nbsp;&raquo; qui a été pris en mars.
+      Les risques réalistes sont ordinaires plutôt que spectaculaires&nbsp;: une
+      annonce photographiée chez soi, une photo d'enfant prise dans son école, un
+      compte prétendument anonyme dont toutes les images portent le même numéro
+      de série d'appareil, un &laquo;&nbsp;pris la semaine
+      dernière&nbsp;&raquo; qui date en réalité de mars.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi ne pas simplement réenregistrer&nbsp;?</h2>
+    <h2>Pourquoi ne pas simplement réenregistrer la photo&nbsp;?</h2>
     <p>
       Réenregistrer une photo dans un logiciel de retouche ou un compresseur
-      supprime bien les métadonnées &mdash; l'image est décodée en pixels puis
-      réencodée, et un canvas plein de pixels ne porte aucune étiquette. Cela
-      fonctionne, et cela vous coûte de la qualité, parce que ce réencodage est
+      efface bien les métadonnées&nbsp;: l'image est décodée en pixels puis
+      réencodée, et une toile pleine de pixels ne porte aucune étiquette. Cela
+      marche, et cela vous coûte de la qualité, puisque ce réencodage se fait
       avec perte.
     </p>
     <p>
-      Supprimer les métadonnées proprement ne coûte rien du tout. Les étiquettes
-      se trouvent dans le conteneur <em>autour</em> de l'image compressée, pas
-      dedans&nbsp;: les retirer, c'est effacer des entrées d'une liste et
-      réécrire la liste. Les données d'image compressées sont recopiées octet
-      pour octet et le résultat décode exactement les mêmes pixels. C'est là
-      toute la raison d'utiliser un outil de métadonnées plutôt qu'un
-      convertisseur.
+      Effacer les métadonnées proprement, en revanche, ne coûte rien. Les
+      étiquettes se tiennent dans le conteneur, <em>autour</em> de l'image
+      compressée et non dedans&nbsp;; les retirer revient à supprimer des lignes
+      d'une liste et à réécrire la liste. Les données d'image compressées, elles,
+      sont recopiées octet pour octet, et le résultat redonne exactement les
+      mêmes pixels. Voilà toute la raison de préférer un outil de métadonnées à
+      un convertisseur.
     </p>
     <p>
-      L'exception est le cas où vous alliez réencoder de toute façon. Si vous
-      compressez ou redimensionnez déjà la photo, les étiquettes partent par
-      effet de bord et vous n'avez pas besoin d'une seconde étape.
+      Une exception&nbsp;: si vous alliez réencoder de toute façon. Quand vous
+      compressez ou redimensionnez déjà la photo, les étiquettes tombent
+      d'elles-mêmes et la seconde étape est inutile.
     </p>
   </section>
 
   <section>
-    <h2>La seule chose à garder&nbsp;: l'orientation</h2>
+    <h2>La seule à garder&nbsp;: l'orientation</h2>
     <p>
-      Les téléphones ne font pas pivoter l'image quand vous tournez le téléphone.
-      Ils l'enregistrent telle que le capteur l'a vue et ajoutent une étiquette
-      d'orientation qui dit comment la tourner pour l'affichage. Retirez toutes
-      les étiquettes et certains afficheurs montreront votre photo couchée.
+      Un téléphone ne fait pas pivoter l'image quand vous le tournez. Il
+      l'enregistre telle que le capteur l'a vue et y ajoute une étiquette
+      d'orientation qui indique comment la redresser à l'affichage. Retirez
+      toutes les étiquettes, et certaines visionneuses vous montreront une photo
+      couchée.
     </p>
     <p>
-      C'est pourquoi l'outil d'ici a une option
-      &laquo;&nbsp;garder l'étiquette d'orientation&nbsp;&raquo;, active par
-      défaut. Elle réécrit un minuscule bloc EXIF contenant cette seule étiquette
-      et rien d'autre, et seulement pour les photos qui en avaient réellement
-      besoin. Le GPS, les horodatages, le numéro de série et le reste ont toujours
-      disparu.
+      D'où l'option &laquo;&nbsp;garder l'étiquette
+      d'orientation&nbsp;&raquo;, active par défaut. Elle réécrit un minuscule
+      bloc EXIF contenant cette seule étiquette et rien d'autre, et seulement
+      pour les photos qui en avaient besoin. Le GPS, les horodatages, le numéro
+      de série et tout le reste ont bel et bien disparu.
     </p>
     <p>
-      Décochez-la si vous préférez que le fichier ne porte plus le moindre EXIF
-      &mdash; et vérifiez alors le résultat avant de l'envoyer, parce qu'une
-      photo couchée est le dénouement habituel.
+      Décochez-la si vous tenez à ce que le fichier ne porte plus le moindre
+      EXIF &mdash; mais vérifiez alors le résultat avant l'envoi, car la photo
+      couchée est l'issue habituelle.
     </p>
   </section>
 
   <section>
     <h2>Modifier au lieu de supprimer</h2>
     <p>
-      Tout supprimer est la bonne réponse pour la plupart des gens. Parfois non
-      &nbsp;: un photographe peut vouloir garder la ligne de copyright et les
-      réglages de l'appareil et n'effacer que le lieu&nbsp;; un archiviste peut
-      avoir besoin de corriger une date fausse parce que l'horloge de l'appareil
+      Tout effacer est la bonne réponse pour la plupart des gens. Pas pour
+      tous&nbsp;: un photographe voudra parfois conserver la mention de droits et
+      les réglages de prise de vue et n'effacer que le lieu&nbsp;; un archiviste
+      aura besoin de corriger une date fausse parce que l'horloge du boîtier
       l'était.
     </p>
     <p>
-      Les deux sont possibles. Le lieu peut être supprimé seul, et les étiquettes
-      de texte, les dates, l'ISO, l'orientation et la résolution peuvent être
-      modifiés sur place.
+      Les deux sont possibles. Le lieu se supprime seul, et les étiquettes de
+      texte, les dates, la sensibilité, l'orientation et la résolution se
+      modifient sur place.
     </p>
     <p>
-      Une réserve qui vaut pour tous les outils qui font cela, pas seulement pour
-      celui-ci&nbsp;: écrire le fichier reconstruit le bloc EXIF, et une note de
-      fabricant contient des décalages vers le bloc <em>d'origine</em>. Une note
-      reconstruite peut donc ne plus être lisible par le logiciel du fabricant.
-      Si cela compte, supprimez la note de fabricant ou laissez le fichier tel
-      quel.
+      Une réserve, qui vaut pour tous les outils du genre et pas seulement pour
+      celui-ci&nbsp;: écrire le fichier reconstruit le bloc EXIF, or une note de
+      fabricant contient des décalages qui pointent vers le bloc
+      <em>d'origine</em>. Une note reconstruite risque donc de n'être plus
+      lisible par le logiciel du fabricant. Si cela compte pour vous, supprimez
+      la note de fabricant, ou laissez le fichier tel quel.
     </p>
   </section>
 
   <section>
     <h2>Les formats, et ceux qui ne se traitent pas ainsi</h2>
     <p>
-      Le JPEG, le PNG et le WebP peuvent tous être réécrits proprement, et ce
-      sont les trois que prend en charge l'outil d'ici.
+      Le JPEG, le PNG et le WebP se réécrivent proprement&nbsp;; ce sont les
+      trois que l'outil prend en charge.
     </p>
     <p>
       Le HEIC &mdash; ce qu'un iPhone enregistre par défaut &mdash; et l'AVIF
-      sont des formats à boîtes faits d'atomes imbriqués, et demandent un tout
-      autre analyseur. L'outil les reconnaît et le dit plutôt que de produire un
-      fichier cassé. Si vous avez un HEIC, le convertir en JPEG supprimera les
-      métadonnées par effet de bord de la conversion.
+      sont des formats à boîtes, faits d'atomes imbriqués, et réclament un tout
+      autre analyseur. L'outil les reconnaît et le dit, plutôt que de produire un
+      fichier cassé. Si vous avez un HEIC, le convertir en JPEG effacera les
+      métadonnées au passage.
     </p>
     <p>
-      Un TIFF nu n'est pas pris en charge non plus, et pour une raison plus
-      intéressante&nbsp;: dans un TIFF, les métadonnées et les données de pixels
-      sont adressées par les mêmes décalages, si bien que retirer des étiquettes
-      revient à réécrire l'adressage de l'image elle-même. C'est faisable, et
-      c'est un autre travail.
-    </p>
-  </section>
-
-  <section>
-    <h2>Une habitude qui vaut la peine</h2>
-    <p>
-      Vérifiez avant de publier plutôt qu'après. Lire les étiquettes prend
-      quelques secondes et la liste des trouvailles nomme ce qui vaut d'être su
-      &mdash; la position, les horodatages, les numéros de série &mdash; avant le
-      tableau complet de toutes les étiquettes&nbsp;: vous n'avez donc pas besoin
-      de savoir quoi chercher.
-    </p>
-    <p>
-      La position est d'abord montrée en degrés décimaux, exprès.
-      &laquo;&nbsp;51 degrés, 30 minutes, 26 secondes&nbsp;&raquo; ne rend pas
-      évident qu'une photo nomme le bâtiment où elle a été prise. Une paire de
-      décimaux que vous pouvez coller dans une carte, si.
+      Le TIFF nu n'est pas pris en charge non plus, et pour une raison plus
+      intéressante&nbsp;: dans un TIFF, les métadonnées et les pixels sont
+      repérés par les mêmes décalages, si bien qu'ôter des étiquettes revient à
+      réécrire l'adressage de l'image elle-même. C'est faisable&nbsp;; c'est un
+      autre travail.
     </p>
   </section>
 
   <section>
-    <h2>N'envoyez pas la photo pour savoir ce qu'il y a dedans</h2>
+    <h2>Une bonne habitude</h2>
     <p>
-      Il y a une ironie particulière dans la façon dont ce problème se résout
-      d'habitude&nbsp;: quelqu'un qui s'inquiète de ce que révèle sa photo
-      l'envoie à un site web pour le savoir. Le site a maintenant la photo, les
-      coordonnées, l'horodatage et le numéro de série, plus une copie de l'image
-      sur un disque qui lui appartient.
+      Vérifiez avant de publier, pas après. Lire les étiquettes prend quelques
+      secondes, et la liste des trouvailles met en tête ce qui mérite votre
+      attention &mdash; la position, les horodatages, les numéros de série
+      &mdash; avant le tableau exhaustif&nbsp;: vous n'avez donc pas besoin de
+      savoir quoi chercher.
     </p>
     <p>
-      Il n'y a aucune raison à cela. Lire et réécrire le conteneur autour d'un
-      JPEG représente quelques centaines de lignes d'analyse qu'un navigateur
-      exécute parfaitement, et c'est pourquoi l'outil d'ici n'a aucune fonction
+      La position est affichée d'abord en degrés décimaux, et c'est
+      délibéré&nbsp;: &laquo;&nbsp;51 degrés, 30 minutes, 26
+      secondes&nbsp;&raquo; ne laisse pas deviner qu'une photo désigne le
+      bâtiment où elle a été prise. Deux nombres à coller dans une carte, si.
+    </p>
+  </section>
+
+  <section>
+    <h2>N'envoyez pas la photo pour savoir ce qu'elle contient</h2>
+    <p>
+      La façon dont ce problème se règle d'ordinaire ne manque pas
+      d'ironie&nbsp;: inquiet de ce que sa photo révèle, on l'envoie à un site
+      web pour le découvrir. Le site dispose désormais de la photo, des
+      coordonnées, de l'horodatage et du numéro de série, plus d'une copie de
+      l'image sur un disque qui lui appartient.
+    </p>
+    <p>
+      Rien ne le justifie. Lire et réécrire le conteneur qui entoure un JPEG,
+      c'est quelques centaines de lignes d'analyse qu'un navigateur exécute sans
+      broncher&nbsp;; c'est pourquoi l'outil de ce site n'a aucune fonction
       réseau&nbsp;: pas de <code>fetch</code>, pas de
-      <code>XMLHttpRequest</code>, rien qui puisse envoyer un fichier même si
-      quelque chose essayait. Chargez-le une fois, coupez la connexion, et il
+      <code>XMLHttpRequest</code>, rien qui pourrait envoyer un fichier même si
+      quelque chose s'y essayait. Chargez-le une fois, coupez la connexion, il
       continue de fonctionner.
     </p>
     <p>
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose comment vérifier
-      cette affirmation, sur ce site comme sur n'importe quel autre &mdash; et
-      c'est le type de fichier pour lequel cela vaut le plus la peine de
-      vérifier.
+      fichiers à un convertisseur en ligne&nbsp;?</a> explique comment vérifier
+      cette promesse, ici comme ailleurs &mdash; et c'est avec ce type de fichier
+      que la vérification vaut le plus la peine.
     </p>
   </section>

--- a/locales/fr/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/fr/pages/guides/remove-exif-and-gps-data.toml
@@ -4,15 +4,15 @@
 
 nav = "Données EXIF et GPS"
 title = "Comment supprimer les données EXIF et GPS d'une photo"
-description = "Une photo sortie d'un téléphone porte en général l'endroit exact où elle a été prise, l'heure à la seconde, et le numéro de série de l'appareil. Ce qu'il y a dedans, qui peut le lire, et comment le retirer sans toucher à l'image."
-heading = "Ce qu'une photo raconte sur vous, et comment le retirer"
+description = "Une photo prise au téléphone porte en général le lieu exact de la prise de vue, l'heure à la seconde et le numéro de série du boîtier. Ce qu'il y a dedans, qui peut le lire, et comment l'effacer sans toucher à l'image."
+heading = "Ce qu'une photo raconte sur vous, et comment l'effacer"
 lede = """
-    Une image sortie tout droit d'un téléphone porte typiquement les coordonnées
-    du lieu où elle a été prise, l'heure à la seconde, et assez de choses sur
-    l'appareil pour la relier à toutes les autres photos du même téléphone. Rien
-    de tout cela n'est visible à l'écran. Voici ce qu'il y a dedans et comment le
-    supprimer."""
+    Une image sortie tout droit d'un téléphone porte le plus souvent les
+    coordonnées du lieu de la prise de vue, l'heure à la seconde, et de quoi la
+    rattacher à toutes les autres photos du même appareil. Rien de tout cela
+    n'apparaît à l'écran. Voici ce qui s'y trouve, et comment le faire
+    disparaître."""
 updated = "20 août 2026"
-og_title = "Ce qu'une photo raconte sur vous, et comment le retirer"
+og_title = "Ce qu'une photo raconte sur vous, et comment l'effacer"
 og_description = "Coordonnées GPS, horodatages et numéros de série voyagent à l'intérieur des photos ordinaires. Ce qu'il y a dedans, qui peut le lire, et comment l'effacer."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/resize-an-image.html
+++ b/locales/fr/pages/guides/resize-an-image.html
@@ -3,84 +3,83 @@
     <p>
       Ouvrez le <a href="../../redimensionner-une-image/">redimensionneur
       d'images</a>, déposez-y votre image, tapez un seul chiffre &mdash; la
-      largeur, en général &mdash; et laissez l'autre vide. La hauteur découle de
-      la forme de l'image, ce qui est presque toujours ce qu'on
-      voulait&nbsp;: &laquo;&nbsp;1920 de large&nbsp;&raquo; veut dire
-      &laquo;&nbsp;1920 de large et la hauteur que cela donne&nbsp;&raquo;.
+      largeur, le plus souvent &mdash; et laissez l'autre champ vide. La hauteur
+      se déduit des proportions de l'image, ce qui est presque toujours ce qu'on
+      attendait&nbsp;: &laquo;&nbsp;1920 de large&nbsp;&raquo; veut dire
+      &laquo;&nbsp;1920 de large, et la hauteur qui va avec&nbsp;&raquo;.
     </p>
     <p>
-      Tout ce qui suit est pour les cas où un seul chiffre ne suffit pas&nbsp;:
-      quand on vous a donné un cadre à deux côtés, quand l'image doit grossir, ou
-      quand tout un dossier de fichiers doit ressortir pareil.
+      Tout ce qui suit concerne les cas où un seul chiffre ne suffit pas&nbsp;:
+      quand on vous impose un cadre à deux côtés, quand l'image doit grossir, ou
+      quand un dossier entier doit ressortir uniforme.
     </p>
   </section>
 
   <section>
-    <h2>Réduire est sans danger. Agrandir ne l'est pas.</h2>
+    <h2>Réduire ne coûte rien. Agrandir, si.</h2>
     <p>
-      Ce ne sont pas deux sens d'une même opération, et il vaut la peine de dire
-      clairement pourquoi.
+      Ce ne sont pas les deux sens d'une même opération, et il vaut la peine
+      d'expliquer pourquoi.
     </p>
     <p>
-      <strong>Réduire une image</strong> jette de l'information, et dans le seul
-      sens bénin du terme&nbsp;: il entre plus de pixels qu'il n'en sort, et
-      chaque pixel du résultat est donc une moyenne de détail réellement mesuré.
-      Une copie réduite proprement est en général <em>plus belle</em> que
-      l'original regardé à cette taille, parce que le moyennage supprime le
-      bruit. Rien n'est inventé.
+      <strong>Réduire une image</strong> jette de l'information, mais dans le
+      seul sens inoffensif du mot&nbsp;: il entre plus de pixels qu'il n'en sort,
+      et chaque pixel du résultat est donc la moyenne de détails réellement
+      mesurés. Une réduction bien faite est même souvent <em>plus belle</em> que
+      l'original regardé à cette taille, parce que la moyenne efface le bruit.
+      Rien n'est inventé.
     </p>
     <p>
-      <strong>Agrandir une image</strong> doit inventer. Le détail ne manque pas
-      dans le fichier&nbsp;; il n'a jamais été photographié. Tout ce qu'un
-      agrandisseur peut faire, c'est deviner les pixels intermédiaires d'après
-      leurs voisins, et une supposition entre deux valeurs connues est une rampe
-      douce &mdash; c'est pourquoi une photo agrandie paraît molle plutôt que
-      nette. C'est une copie plus grande de la même image, pas une copie plus
+      <strong>Agrandir une image</strong> oblige à inventer. Le détail ne manque
+      pas au fichier&nbsp;: il n'a jamais été photographié. Tout ce qu'un
+      logiciel peut faire, c'est deviner les pixels intermédiaires d'après leurs
+      voisins, et une hypothèse entre deux valeurs connues donne une transition
+      douce &mdash; d'où l'aspect mou, jamais net, d'une photo agrandie. Vous
+      obtenez une copie plus grande de la même image, pas une image plus
       détaillée.
     </p>
     <p>
-      C'est pourquoi &laquo;&nbsp;ne jamais agrandir une image au-delà de sa
-      taille de départ&nbsp;&raquo; est actif par défaut dans l'outil d'ici.
-      Décochez-le si vous avez réellement besoin du nombre de pixels &mdash; une
-      imprimerie qui exige une taille minimale, un gabarit qui refuse tout ce qui
-      est sous une largeur &mdash; mais faites-le en sachant que vous achetez des
-      pixels, pas du détail.
+      D'où le garde-fou activé par défaut dans l'outil&nbsp;: ne jamais dépasser
+      la taille de départ. Désactivez-le si le nombre de pixels vous est
+      réellement imposé &mdash; une imprimerie qui exige un minimum, un gabarit
+      qui refuse en dessous d'une certaine largeur &mdash; mais sachez alors que
+      vous achetez des pixels, pas du détail.
     </p>
     <p>
-      Les agrandisseurs par apprentissage automatique qui semblent, eux, ajouter
-      du détail sont une tout autre chose&nbsp;: ils inventent une texture
-      plausible à partir d'un modèle de ce à quoi les images ressemblent
-      d'habitude. Pour un fond d'écran, c'est très bien. Pour la photographie
-      d'une personne, d'un document, ou de tout ce dont quelqu'un tirera une
-      conclusion, comprenez que le détail supplémentaire est une fiction.
+      Les agrandissements par apprentissage automatique, qui semblent bel et bien
+      ajouter du détail, relèvent d'autre chose&nbsp;: ils inventent une texture
+      vraisemblable à partir d'un modèle de ce à quoi les images ressemblent
+      d'ordinaire. Pour un fond d'écran, aucun problème. Pour la photo d'une
+      personne, d'un document, ou de quoi que ce soit dont quelqu'un tirera une
+      conclusion, gardez en tête que le détail ajouté est une fiction.
     </p>
   </section>
 
   <section>
-    <h2>Trois façons de dire la taille voulue</h2>
+    <h2>Trois façons d'indiquer la taille voulue</h2>
     <p>
       La plupart des outils, celui-ci compris, acceptent les mêmes trois, et
-      elles conviennent à des travaux différents.
+      chacune convient à un usage.
     </p>
     <ul>
       <li>
-        <strong>Des pixels exacts.</strong> À utiliser quand quelqu'un a précisé
-        le nombre&nbsp;: un avatar qui doit faire 400&times;400, une bannière qui
-        doit faire 1500 de large. Remplissez un côté et laissez l'autre suivre,
-        sauf si on vous a donné les deux.
+        <strong>Des pixels exacts.</strong> Quand on vous a donné le
+        nombre&nbsp;: un avatar de 400&times;400, une bannière de 1500 de large.
+        Renseignez un seul côté et laissez l'autre suivre, sauf si on vous a
+        imposé les deux.
       </li>
       <li>
-        <strong>Un pourcentage.</strong> À utiliser quand vous voulez tout
-        proportionnellement plus petit sans vous soucier du chiffre exact &mdash;
-        &laquo;&nbsp;moitié moins&nbsp;&raquo; pour un jeu de photos destinées à
-        un document.
+        <strong>Un pourcentage.</strong> Quand vous voulez tout réduire dans les
+        mêmes proportions sans vous soucier du chiffre final &mdash;
+        &laquo;&nbsp;deux fois plus petit&nbsp;&raquo; pour une série de photos
+        destinées à un document.
       </li>
       <li>
-        <strong>Un plus grand côté.</strong> La plus utile des trois pour un lot
-        mêlé. &laquo;&nbsp;Plus grand côté 1600&nbsp;&raquo; fait tenir chaque
-        image dans un carré de 1600 pixels, qu'elle soit verticale ou
-        horizontale, ce qui est en pratique ce que veut dire
-        &laquo;&nbsp;mets-moi tout ça à une taille raisonnable&nbsp;&raquo;.
+        <strong>Le plus grand côté.</strong> La plus commode des trois pour un
+        lot hétéroclite. &laquo;&nbsp;Plus grand côté à 1600&nbsp;&raquo; fait
+        tenir chaque image dans un carré de 1600 pixels, qu'elle soit verticale
+        ou horizontale&nbsp;: c'est ce que veut dire, en pratique,
+        &laquo;&nbsp;remets-moi tout ça à une taille raisonnable&nbsp;&raquo;.
       </li>
     </ul>
   </section>
@@ -88,72 +87,71 @@
   <section>
     <h2>Quand le cadre n'a pas la forme de l'image</h2>
     <p>
-      C'est là que le redimensionnement se décide réellement. Si vous donnez une
-      largeur et une hauteur qui ne correspondent pas aux proportions de votre
-      image, quelque chose doit céder, et il n'y a exactement que quatre choses
-      qui le peuvent&nbsp;:
+      C'est là que tout se joue. Si vous donnez une largeur et une hauteur qui ne
+      correspondent pas aux proportions de votre image, quelque chose doit
+      céder&nbsp;; il n'existe que quatre manières de céder.
     </p>
     <ul>
       <li>
-        <strong>Tenir dans le cadre.</strong> L'image entière est gardée et
-        ressort plus petite que le cadre sur un axe. Rien n'est perdu et rien
-        n'est déformé&nbsp;; vous n'obtenez simplement pas les dimensions exactes
-        demandées. C'est le bon comportement par défaut pour à peu près tout.
+        <strong>Tenir dans le cadre.</strong> L'image entière est conservée et
+        ressort plus petite que le cadre sur un des deux axes. Rien n'est perdu,
+        rien n'est déformé&nbsp;; simplement, vous n'obtenez pas exactement les
+        dimensions demandées. C'est le bon réglage par défaut dans presque tous les cas.
       </li>
       <li>
         <strong>Remplir le cadre et couper ce qui dépasse.</strong> Vous obtenez
-        exactement les dimensions demandées, et les parties de l'image qui
-        débordent ont disparu. Bon pour les vignettes, les avatars et les
-        couvertures, où la forme est imposée et le sujet est au milieu. Mauvais
-        quand ce qui compte est près d'un bord.
+        les dimensions exactes, et ce qui débordait a disparu. Parfait pour une
+        vignette, un avatar ou une couverture, où la forme est imposée et le
+        sujet occupe le centre. Mauvais dès que l'essentiel se trouve près d'un
+        bord.
       </li>
       <li>
-        <strong>Compléter.</strong> L'image entière est gardée, centrée, et
-        l'espace restant est rempli d'une couleur que vous choisissez. Bon quand
-        un système exige des dimensions exactes et que vous ne pouvez rien perdre
-        de l'image &mdash; les fiches produit fonctionnent souvent ainsi.
+        <strong>Compléter par une marge.</strong> L'image entière est conservée
+        et centrée, l'espace restant étant rempli d'une couleur de votre choix.
+        Indiqué quand un système exige des dimensions au pixel près et que vous
+        ne pouvez rien sacrifier de l'image &mdash; les fiches produit
+        fonctionnent souvent ainsi.
       </li>
       <li>
-        <strong>Étirer.</strong> L'image est écrasée ou tirée pour entrer. Ce
-        n'est jamais ce que vous voulez, sauf à le faire exprès, et c'est celui
-        que tout le monde reconnaît instantanément comme faux.
+        <strong>Étirer.</strong> L'image est écrasée ou tirée pour entrer dans le
+        cadre. Ce n'est jamais ce qu'on veut, sauf à le faire exprès, et c'est le
+        seul défaut que tout le monde repère au premier coup d'œil.
       </li>
     </ul>
     <p>
-      Si vous vous surprenez à tendre la main vers l'étirement, ce que vous
-      voulez sans doute, c'est recadrer.
+      Si l'étirement vous tente, c'est probablement un recadrage qu'il vous faut.
     </p>
   </section>
 
   <section>
     <h2>Recadrer est un autre travail, et souvent le bon</h2>
     <p>
-      Redimensionner change le nombre de pixels qui décrivent l'image entière.
-      Recadrer change la partie de l'image que vous gardez. Les gens tendent la
-      main vers le premier en pensant au second étonnamment souvent &mdash;
-      &laquo;&nbsp;il faut que ce soit carré&nbsp;&raquo; est un problème de
-      recadrage, pas de redimensionnement.
+      Redimensionner change le nombre de pixels qui décrivent toute l'image.
+      Recadrer change la portion d'image que vous gardez. On confond les deux
+      étonnamment souvent&nbsp;: &laquo;&nbsp;il me le faut carré&nbsp;&raquo;
+      est un problème de recadrage, pas de redimensionnement.
     </p>
     <p>
-      Faites-les dans cet ordre&nbsp;: recadrez d'abord selon le cadrage voulu,
-      puis redimensionnez le résultat à la taille voulue. Faire l'inverse revient
-      à choisir le recadrage dans une image qui a déjà perdu des pixels.
+      Procédez dans cet ordre&nbsp;: recadrez d'abord pour obtenir le cadrage
+      voulu, redimensionnez ensuite le résultat. Dans l'autre sens, vous
+      choisissez votre cadrage dans une image qui a déjà perdu des pixels.
     </p>
     <p>
-      L'outil d'ici fait les deux en une passe pour cette raison &mdash; tracez
-      un cadre, verrouillez-le sur une forme s'il vous faut une proportion
-      précise, puis dites la taille de sortie voulue. Le faire en une passe veut
-      aussi dire que l'image n'est encodée qu'une fois, ce qui compte pour la
-      raison exposée dans la section suivante.
+      C'est pour cette raison que l'outil enchaîne les deux en une seule
+      passe&nbsp;: tracez un cadre, verrouillez-le sur une proportion si on vous
+      en impose une, puis indiquez la taille de sortie. Une seule passe veut
+      aussi dire un seul encodage, ce qui compte pour la raison exposée juste
+      après.
     </p>
     <h3>Recadrer tout un lot</h3>
     <p>
-      Un cadre tracé sur une image est appliqué aux autres comme la même zone
+      Le cadre tracé sur une image est reporté sur les autres comme une zone
       <em>relative</em>&nbsp;: les mêmes fractions de la largeur et de la hauteur
-      propres à chaque fichier. Pour un dossier de captures ou d'exports tous de
-      la même taille, c'est exactement le même rectangle. Pour un lot mêlé, c'est
-      le même cadrage plutôt que le même rectangle, ce qui est en général ce
-      qu'on voulait, mais vaut d'être su avant de lui confier cinquante fichiers.
+      propres à chaque fichier. Sur un dossier de captures ou d'exports tous de
+      même taille, cela revient au même rectangle exactement. Sur un lot
+      hétéroclite, c'est le même cadrage et non le même rectangle &mdash;
+      généralement ce qu'on cherchait, mais mieux vaut le savoir avant de lui
+      confier cinquante fichiers.
     </p>
   </section>
 
@@ -161,90 +159,91 @@
     <h2>Ce que coûte le réencodage, et comment n'en faire qu'un</h2>
     <p>
       Redimensionner un JPEG ou un WebP, c'est le décoder, mettre les pixels à
-      l'échelle, et les réencoder &mdash; et cette dernière étape est avec perte.
-      Ce n'est pas la mise à l'échelle elle-même qui vous coûte de la
-      qualité&nbsp;; c'est le réencodage.
+      l'échelle, puis les réencoder &mdash; et c'est cette dernière étape qui se
+      paie. La mise à l'échelle, en elle-même, ne coûte pas de qualité&nbsp;; le
+      réencodage, si.
     </p>
     <p>
       Deux conséquences. D'abord, le réglage de qualité en sortie compte&nbsp;:
-      quelque part autour de 80 à 85, c'est invisible pour une photographie et
-      considérablement plus léger que 100. Ensuite, ne le faites qu'une fois.
-      Redimensionner une image déjà redimensionnée deux fois, ce sont trois
-      générations d'encodage avec perte, et cela se voit.
+      autour de 80 à 85, c'est invisible sur une photographie et nettement plus
+      léger que 100. Ensuite, faites-le une seule fois. Redimensionner une image
+      qui l'a déjà été deux fois, cela fait trois générations d'encodage avec
+      perte, et cela finit par se voir.
     </p>
     <p>
-      Un PNG n'a pas ce coût, parce qu'il est sans perte &mdash; un PNG
+      Le PNG échappe à cette dépense, puisqu'il est sans perte&nbsp;: un PNG
       redimensionné, ce sont exactement les pixels mis à l'échelle. Si vous
-      travaillez en plusieurs étapes et que le format final n'est pas encore
-      décidé, passer par du PNG au milieu évite d'empiler les générations.
+      enchaînez plusieurs étapes et que le format final n'est pas encore arrêté,
+      travailler en PNG entre-temps évite d'empiler les générations.
     </p>
     <p>
-      Un détail vaut d'être connu à propos de l'outil d'ici&nbsp;: un fichier que
-      vous ne changez pas réellement vous est rendu octet pour octet plutôt que
-      réencodé. Demandez &laquo;&nbsp;plus grand côté 1600&nbsp;&raquo; sur un
-      lot et ceux qui sont déjà sous 1600 ressortent intacts, étiquettes
-      comprises. Un outil qui les réencoderait discrètement vous coûterait de la
-      qualité sur des fichiers que personne ne lui avait demandé de changer.
+      Un détail à connaître sur l'outil de ce site&nbsp;: un fichier auquel il
+      n'a rien à changer vous est rendu octet pour octet, sans réencodage.
+      Demandez &laquo;&nbsp;plus grand côté à 1600&nbsp;&raquo; sur un lot, et
+      ceux qui sont déjà en dessous ressortent intacts, étiquettes comprises. Un
+      outil qui les réencoderait sans le dire vous coûterait de la qualité sur
+      des fichiers que personne ne lui avait demandé de toucher.
     </p>
   </section>
 
   <section>
     <h2>La transparence, et ce qu'elle devient</h2>
     <p>
-      Le PNG et le WebP savent stocker la transparence. Le JPEG non &mdash; il
-      n'y a aucun canal alpha dans ce format. Enregistrer une image transparente
-      en JPEG oblige donc à mettre quelque chose derrière, et ce quelque chose
-      est une couleur unie.
+      Le PNG et le WebP savent enregistrer la transparence. Le JPEG, non&nbsp;:
+      le format n'a pas de canal alpha du tout. Enregistrer une image
+      transparente en JPEG oblige donc à mettre quelque chose derrière, et ce
+      quelque chose est un aplat de couleur.
     </p>
     <p>
-      La plupart des outils prennent du blanc sans le dire, ce qui va très bien
-      jusqu'au jour où votre logo atterrit sur une page sombre avec un rectangle
-      blanc autour. Choisissez la couleur délibérément, ou enregistrez en PNG ou
-      en WebP et gardez la transparence. La même couleur sert derrière un cadre
-      complété, l'autre endroit où l'on rencontre cela par surprise.
+      La plupart des outils prennent du blanc sans vous prévenir&nbsp;; tout va
+      bien jusqu'au jour où votre logo se retrouve sur une page sombre, cerné
+      d'un rectangle blanc. Choisissez la couleur vous-même, ou enregistrez en
+      PNG ou en WebP et gardez la transparence. C'est la même couleur qui remplit
+      les marges d'un cadre complété, l'autre occasion de découvrir la chose par
+      surprise.
     </p>
   </section>
 
   <section>
-    <h2>Quel outil, si on vous a donné un chiffre</h2>
+    <h2>Quel outil, selon le chiffre qu'on vous a donné</h2>
     <p>
-      Deux chiffres différents circulent, et ils appellent des outils différents.
+      Deux sortes de chiffres circulent, et elles n'appellent pas le même outil.
     </p>
     <p>
       <strong>&laquo;&nbsp;1200 pixels de large&nbsp;&raquo;</strong> est un
-      problème de dimensions. Le
-      <a href="../../redimensionner-une-image/">redimensionneur d'images</a> est
-      le bon&nbsp;: vous dites combien de pixels vous voulez et il vous les
-      donne.
+      problème de dimensions&nbsp;: c'est l'affaire du
+      <a href="../../redimensionner-une-image/">redimensionneur d'images</a>,
+      qui vous donne le nombre de pixels que vous demandez.
     </p>
     <p>
-      <strong>&laquo;&nbsp;Sous 500&nbsp;KB&nbsp;&raquo;</strong> est un problème
-      de taille de fichier, et le redimensionnement n'est qu'une des façons de le
-      résoudre. Le <a href="../../compresser-une-image/">compresseur d'images</a>
-      cherche la meilleure qualité qui tienne dans votre cible et ne
-      redimensionne que si la qualité seule n'y arrive pas&nbsp;;
+      <strong>&laquo;&nbsp;Moins de 500&nbsp;KB&nbsp;&raquo;</strong> est un
+      problème de poids de fichier, et le redimensionnement n'est qu'un des
+      moyens de le régler. Le
+      <a href="../../compresser-une-image/">compresseur d'images</a> cherche la
+      meilleure qualité qui tienne dans la cible et ne redimensionne que si la
+      qualité seule n'y suffit pas&nbsp;;
       <a href="../compresser-une-image-a-une-taille-precise/">son guide</a>
-      traite de ce que cela coûte.
+      explique ce que cela coûte.
     </p>
   </section>
 
   <section>
-    <h2>Rien de tout cela ne demande un envoi</h2>
+    <h2>Rien de tout cela n'exige un envoi</h2>
     <p>
-      Décoder une image, la mettre à l'échelle et la réencoder sont des choses
-      que tous les navigateurs savent faire depuis des années &mdash; c'est la
-      machinerie même dont une page web se sert pour dessiner une image à une
-      autre taille. Il n'y a aucune raison technique pour que votre photo voyage
-      jusqu'à un serveur et en revienne pour ressortir plus petite, et l'outil
-      d'ici ne l'envoie nulle part&nbsp;: la
-      <code>Content-Security-Policy</code> de la page nomme toutes les adresses
-      qu'elle peut contacter, et aucune n'appartient à ce site.
+      Décoder une image, la mettre à l'échelle et la réencoder&nbsp;: les
+      navigateurs savent le faire depuis des années, et c'est exactement la
+      machinerie qu'une page web emploie pour afficher une image à une autre
+      taille. Rien, techniquement, n'oblige votre photo à faire l'aller-retour
+      jusqu'à un serveur pour ressortir plus petite &mdash; et l'outil de ce site
+      ne l'envoie nulle part&nbsp;: la
+      <code>Content-Security-Policy</code> de la page énumère toutes les adresses
+      qu'elle peut contacter, dont aucune n'appartient à ce site.
     </p>
     <p>
-      Chargez la page, coupez votre connexion, et redimensionnez quelque chose
+      Chargez la page, coupez votre connexion et redimensionnez quelque chose
       quand même, si vous préférez vérifier plutôt qu'on vous le dise.
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
-      vérifications applicables à n'importe quel outil.
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente trois autres
+      vérifications valables pour n'importe quel outil.
     </p>
   </section>

--- a/locales/fr/pages/guides/resize-an-image.toml
+++ b/locales/fr/pages/guides/resize-an-image.toml
@@ -4,14 +4,14 @@
 
 nav = "Redimensionner une image"
 title = "Comment redimensionner une image sans l'abîmer"
-description = "Ce qui arrive à une image quand on change ses dimensions en pixels : pourquoi réduire est sans danger et agrandir ne l'est pas, que faire quand le cadre n'a pas la bonne forme, et quand recadrer plutôt."
+description = "Ce qui arrive à une image quand on change ses dimensions en pixels : pourquoi réduire ne coûte rien et agrandir se paie, que faire quand le cadre n'a pas la bonne forme, et quand recadrer plutôt."
 heading = "Comment redimensionner une image sans l'abîmer"
 lede = """
     Le redimensionnement est le seul travail d'image où les dégâts sont décidés
     avant d'appuyer sur le bouton, par le chiffre que vous tapez et la forme que
-    vous demandez. Voici ce que chaque choix fait à l'image, et lesquels vous
-    pouvez défaire."""
+    vous réclamez. Voici ce que chaque choix fait à l'image, et lesquels se
+    rattrapent."""
 updated = "20 août 2026"
 og_title = "Redimensionner une image sans l'abîmer"
-og_description = "Pourquoi réduire est sans danger et agrandir ne l'est pas, que faire quand le cadre n'a pas la bonne forme, et quand recadrer plutôt."
+og_description = "Pourquoi réduire ne coûte rien et agrandir se paie, que faire quand le cadre n'a pas la bonne forme, et quand recadrer plutôt."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/trim-a-video.html
+++ b/locales/fr/pages/guides/trim-a-video.html
@@ -1,123 +1,123 @@
   <section>
     <h2>La réponse courte</h2>
     <p>
-      Ouvrez le <a href="../../couper-une-video/">coupeur de vidéos</a>, déposez-y
-      le clip, appuyez sur <kbd>I</kbd> et <kbd>O</kbd> pour marquer chaque
-      passage voulu &mdash; autant que vous voulez &mdash; et exportez. Sur un
-      MP4, un MOV ou un M4V, les images que vous gardez sont déplacées dans le
-      nouveau fichier exactement telles qu'elles étaient &mdash; mêmes octets,
-      mêmes réglages d'encodeur, même tout &mdash; et le son est recopié
-      échantillon par échantillon sans être décodé.
+      Ouvrez le <a href="../../couper-une-video/">coupeur de vidéos</a>,
+      déposez-y votre clip, marquez chaque passage à garder avec les touches
+      <kbd>I</kbd> et <kbd>O</kbd> &mdash; autant de passages que vous voulez
+      &mdash; puis exportez. Sur un MP4, un MOV ou un M4V, les images conservées
+      passent dans le nouveau fichier telles quelles&nbsp;: mêmes octets, mêmes
+      réglages d'encodeur, rien de retouché. Le son, lui, est recopié échantillon
+      par échantillon, sans jamais être décodé.
     </p>
     <p>
-      Cela veut dire qu'une coupe ne vous coûte rien en qualité, et qu'elle est
-      rapide&nbsp;: sortir une minute d'un enregistrement de quatre gigaoctets
-      coûte à peu près ce que coûte l'écriture de cette minute sur le disque,
-      parce que les images sont pointées plutôt que chargées. Le seul endroit où
-      cela se voit, c'est là où votre coupe tombe réellement, et c'est le reste
-      de cette page.
-    </p>
-  </section>
-
-  <section>
-    <h2>Pourquoi une coupe n'a pas à perdre de qualité</h2>
-    <p>
-      Couper ne change l'aspect d'aucune image. Chaque image que vous gardez est
-      censée ressortir identique à ce qu'elle était en entrant&nbsp;: il n'y a
-      donc aucune raison de la décoder et de la réencoder &mdash; et toutes les
-      raisons de ne pas le faire, puisqu'un réencodage est avec perte et
-      dégraderait légèrement tout le clip dans le seul but de le raccourcir.
-    </p>
-    <p>
-      Un bon coupeur ne réencode donc pas. Il lit l'index du fichier, détermine
-      quelles images encodées tombent dans votre intervalle, et écrit ces octets
-      dans un nouveau conteneur avec un nouvel index devant. Rien n'est décodé du
-      tout sur ce chemin.
-    </p>
-    <p>
-      Bien des outils réencodent quand même, parce que décoder et réencoder est
-      bien plus simple à implémenter que d'analyser le format du conteneur. On
-      reconnaît en général lequel des deux on utilise à la durée&nbsp;: une copie
-      est limitée par la vitesse d'écriture de votre disque, et un réencodage par
-      la vitesse à laquelle votre machine encode de la vidéo, ce qui est cent
-      fois plus lent.
+      Une découpe ne coûte donc rien en qualité, et elle est presque
+      instantanée&nbsp;: extraire une minute d'un enregistrement de quatre
+      gigaoctets revient à peu près à écrire cette minute sur le disque, puisque
+      les images sont désignées et non chargées. Reste un seul endroit où la
+      découpe se voit, celui où votre coupe tombe vraiment&nbsp;; c'est tout le
+      sujet de cette page.
     </p>
   </section>
 
   <section>
-    <h2>Les images clés, et pourquoi votre coupe peut tomber plus tôt</h2>
+    <h2>Pourquoi une découpe n'a aucune raison de dégrader l'image</h2>
     <p>
-      Voici la contrainte dont découle tout ce qui concerne la coupe.
+      Découper ne modifie l'aspect d'aucune image. Chaque image gardée doit
+      ressortir identique à ce qu'elle était en entrant&nbsp;: la décoder pour la
+      réencoder ne sert à rien et nuit à tout, puisque le réencodage est
+      destructif et abîmerait légèrement l'ensemble du clip au seul motif de le
+      raccourcir.
     </p>
     <p>
-      La vidéo n'est pas stockée comme une suite d'images complètes. Ce serait
-      énorme. La plupart des images sont stockées comme une description de ce qui
-      les différencie de leurs voisines, ce qui veut dire qu'elles ne peuvent pas
-      être décodées seules &mdash; il vous faut les images autour d'elles. Seule
-      une <strong>image clé</strong> se tient toute seule comme une image
-      complète, et les images clés sont typiquement espacées d'une à dix
-      secondes.
+      Un bon outil de découpe s'en abstient donc. Il lit l'index du fichier,
+      repère les images encodées qui tombent dans l'intervalle demandé, et
+      recopie ces octets dans un nouveau conteneur précédé d'un nouvel index. Sur
+      ce chemin-là, rien n'est décodé.
     </p>
     <p>
-      Donc, si vous marquez une coupe deux secondes après la dernière image clé,
-      un coupeur qui recopie les images ne peut pas commencer là. Les images à
-      votre marque sont illisibles sans la suite qui y mène. Il doit emporter
-      toute la portion depuis l'image clé qui précède votre marque.
+      Beaucoup d'outils réencodent quand même, tout simplement parce que décoder
+      puis réencoder demande bien moins de travail que d'analyser le format du
+      conteneur. La durée trahit en général celui des deux que vous avez sous la
+      main&nbsp;: une copie va aussi vite que votre disque écrit, un réencodage
+      aussi vite que votre machine encode de la vidéo, c'est-à-dire cent fois
+      plus lentement.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les images clés, et pourquoi votre coupe tombe parfois trop tôt</h2>
+    <p>
+      Tout ce qui concerne la découpe découle d'une seule contrainte, la voici.
     </p>
     <p>
-      Ce qu'il en fait est la partie intéressante. Le format de fichier a une
-      façon standard de dire <em>commencer la lecture à ce point</em> &mdash; les
-      images supplémentaires sont dans le fichier mais le conteneur ordonne au
-      lecteur de les sauter. Tout lecteur grand public le respecte, et le clip
-      commence exactement là où vous l'avez dit. Un lecteur qui l'ignore
-      démarrera plus tôt, de l'écart entre images clés au maximum.
+      Une vidéo n'est pas une suite d'images complètes&nbsp;; ce serait démesuré.
+      La plupart des images ne sont enregistrées que par ce qui les distingue de
+      leurs voisines, si bien qu'elles sont indécodables isolément&nbsp;: il faut
+      celles qui les entourent. Seule une <strong>image clé</strong> se suffit à
+      elle-même, et les images clés sont espacées d'une à dix secondes selon les
+      fichiers.
     </p>
     <p>
-      L'outil d'ici vous dit dans quel cas vous êtes et de combien avant
-      l'export&nbsp;: c'est donc une décision plutôt qu'une surprise.
+      Si vous placez donc une coupe deux secondes après la dernière image clé, un
+      outil qui recopie les images ne peut pas commencer là&nbsp;: à cet endroit,
+      les images sont illisibles sans la série qui y conduit. Il lui faut
+      emporter toute la portion depuis l'image clé qui précède votre marque.
+    </p>
+    <p>
+      Ce qu'il en fait ensuite est la partie intéressante. Le format de fichier
+      prévoit une manière normalisée de dire <em>la lecture commence
+      ici</em>&nbsp;: les images excédentaires restent dans le fichier, mais le
+      conteneur ordonne au lecteur de les sauter. Tous les lecteurs courants
+      respectent cette consigne, et le clip démarre exactement là où vous l'avez
+      demandé. Un lecteur qui l'ignore démarrera plus tôt, d'un écart entre
+      images clés au maximum.
+    </p>
+    <p>
+      L'outil proposé ici vous indique avant l'export dans quel cas vous êtes, et
+      de combien&nbsp;: vous décidez, au lieu de découvrir.
     </p>
   </section>
 
   <section>
     <h2>Quand accepter un réencodage</h2>
     <p>
-      Il existe une coupe exacte, et elle fonctionne en réencodant la portion
-      d'ouverture &mdash; en décodant depuis l'image clé, et en écrivant une
-      nouvelle suite d'images qui commence réellement là où vous avez marqué.
-      Elle est plus lente, et elle coûte un peu de qualité sur cette portion
-      d'ouverture seulement.
+      Il existe aussi une coupe exacte. Elle réencode la portion
+      d'ouverture&nbsp;: décodage à partir de l'image clé, puis écriture d'une
+      nouvelle série d'images qui commence réellement à votre marque. C'est plus
+      lent, et cela coûte un peu de qualité &mdash; sur cette seule portion
+      d'ouverture.
     </p>
     <p>
-      Choisissez-la quand le clip part quelque part qui ne respectera pas
-      l'instruction du conteneur, ou quand vous ne maîtrisez pas le
-      lecteur&nbsp;: certains logiciels de montage, certains systèmes de
-      diffusion et de visioconférence, certains lecteurs matériels plus anciens.
-      Choisissez la copie pour tout le reste, c'est-à-dire pour presque tout
-      &mdash; un navigateur, un téléphone, une plateforme sociale, un lecteur
-      multimédia.
+      Choisissez-la lorsque le clip part vers un endroit qui ne respectera pas la
+      consigne du conteneur, ou dont vous ne maîtrisez pas le lecteur&nbsp;:
+      certains logiciels de montage, certaines chaînes de diffusion ou de
+      visioconférence, certains lecteurs matériels anciens. Partout ailleurs
+      &mdash; c'est-à-dire presque partout, du navigateur au téléphone en passant
+      par les réseaux sociaux et les lecteurs multimédias &mdash; la copie fait
+      l'affaire.
     </p>
     <p>
-      Une troisième option qui ne coûte rien&nbsp;: déplacez votre marque. Si
-      l'outil vous montre où sont les images clés, pousser la coupe jusqu'à la
-      plus proche vous donne une coupe exacte sans le moindre réencodage. Il est
-      rare qu'une seconde d'écart vaille qu'on renonce à une copie.
+      Il reste une troisième solution, gratuite celle-là&nbsp;: déplacer votre
+      marque. Si l'outil vous montre où se trouvent les images clés, amener la
+      coupe jusqu'à la plus proche donne une coupe exacte sans le moindre
+      réencodage. Une seconde d'écart vaut rarement qu'on renonce à une copie.
     </p>
   </section>
 
   <section>
-    <h2>Retirer un morceau du milieu</h2>
+    <h2>Supprimer un passage au milieu</h2>
     <p>
-      Couper un passage est une opération différente d'en garder un, et il vaut
-      la peine de savoir que c'est possible, parce que bien des coupeurs ne font
-      que la seconde. Marquez la partie dont vous ne voulez pas, choisissez de la
-      couper, et ce qui reste de part et d'autre est raccordé en un seul clip,
-      avec le son repris au pas.
+      Retirer un passage n'est pas la même opération qu'en garder un, et il vaut
+      la peine de savoir que c'est possible ici&nbsp;: beaucoup d'outils ne
+      savent faire que la seconde. Marquez la partie dont vous ne voulez pas,
+      demandez sa suppression, et ce qui subsiste de part et d'autre est raccordé
+      en un seul clip, son compris et sans décalage.
     </p>
     <p>
       Le raccord subit la même contrainte d'image clé à l'endroit où la seconde
-      moitié reprend, pour la même raison. Cela fonctionne sur les deux chemins
-      MP4 d'ici. C'est la seule chose que le repli par enregistrement, plus bas,
-      ne sait pas faire, parce qu'un enregistrement se fait en une passe depuis
+      moitié reprend, et pour la même raison. Les deux chemins MP4 le savent
+      faire. C'est la seule chose hors de portée du repli par enregistrement
+      décrit plus bas, parce qu'un enregistrement se fait en une passe, depuis
       une seule tête de lecture.
     </p>
   </section>
@@ -125,84 +125,85 @@
   <section>
     <h2>Les formats, et le repli</h2>
     <p>
-      <strong>Le MP4, le M4V et le MOV</strong> sont lus directement, quel que
-      soit le codec à l'intérieur &mdash; H.264, HEVC, AV1, VP9. Recopier des
-      images n'implique pas de les décoder&nbsp;: ce chemin fonctionne donc même
-      pour un codec dont votre navigateur n'a aucun décodeur, agréable
-      conséquence du fait de ne pas regarder les images.
+      <strong>MP4, M4V et MOV</strong> sont lus directement, quel que soit le
+      codec qu'ils contiennent&nbsp;: H.264, HEVC, AV1, VP9. Recopier des images
+      ne suppose pas de les décoder, si bien que ce chemin fonctionne même avec
+      un codec dont votre navigateur n'a aucun décodeur &mdash; l'avantage
+      inattendu de ne jamais regarder les images.
     </p>
     <p>
-      <strong>Tout le reste que votre navigateur sait lire</strong>, le WebM au
-      premier chef, est coupé en le jouant et en enregistrant le résultat. Cela
-      marche, et cela coûte deux choses&nbsp;: cela prend le temps que dure le
-      passage, et l'image et le son sont réencodés.
+      <strong>Tout autre format que votre navigateur sait lire</strong>, le WebM
+      en premier lieu, est découpé en le jouant et en enregistrant le résultat.
+      Cela fonctionne, à deux frais près&nbsp;: l'opération dure aussi longtemps
+      que le passage lui-même, et l'image comme le son sont réencodés.
     </p>
     <p>
-      <strong>L'AVI, le WMV, le FLV et la plupart des MKV</strong>, le navigateur
-      ne sait ni les lire ni les jouer, et l'outil le dit plutôt que d'échouer à
-      mi-course. Convertissez-les d'abord en MP4 avec quelque chose qui les
-      prend en charge.
-    </p>
-  </section>
-
-  <section>
-    <h2>Deux choses qui tournent mal en silence ailleurs</h2>
-    <p>
-      <strong>La rotation.</strong> Un téléphone filme à l'horizontale et écrit
-      une instruction de rotation dans le fichier plutôt que de tourner les
-      pixels. Un coupeur qui recopie les images doit reporter cette instruction,
-      sinon votre clip vertical ressort couché &mdash; c'est la façon classique
-      dont une vidéo coupée est gâchée. Le chemin exact d'ici tourne les images en
-      les réencodant et écrit un fichier qui n'a besoin d'aucune rotation.
-    </p>
-    <p>
-      <strong>La synchronisation du son.</strong> L'audio et la vidéo sont
-      stockés comme des flux séparés avec leur propre rythme, et ils ne sont pas
-      découpés aux mêmes points. Si les deux ne sont pas alignés délibérément à
-      la coupe, le son dérive. Sur le chemin par copie d'ici, l'audio est recopié
-      échantillon par échantillon sans être décodé&nbsp;: il est donc octet pour
-      octet ce qu'il y avait dans le fichier, et une marque de montage le garde
-      au pas de l'image au millième de seconde près.
+      <strong>AVI, WMV, FLV et la plupart des MKV</strong>, le navigateur ne sait
+      ni les lire ni les jouer&nbsp;; l'outil vous le dit d'emblée au lieu
+      d'abandonner à mi-parcours. Convertissez-les d'abord en MP4 avec un
+      logiciel qui les prend en charge.
     </p>
   </section>
 
   <section>
-    <h2>Couper n'est pas recadrer</h2>
+    <h2>Deux pièges qui passent inaperçus ailleurs</h2>
     <p>
-      Deux mots qu'on emploie l'un pour l'autre. Couper change la durée du
-      clip&nbsp;; recadrer change la forme de l'image. Si ce que vous voulez est
-      une version carrée d'une vidéo horizontale, ou les bandes noires enlevées
-      sur les côtés, c'est le
-      <a href="../../recadrer-une-video/">recadreur de vidéos</a> &mdash; et,
-      contrairement à la coupe, lui doit réencoder, pour la raison
-      qu'<a href="../recadrer-une-video/">expose son guide</a>.
+      <strong>La rotation.</strong> Un téléphone filme à l'horizontale et inscrit
+      dans le fichier une consigne de rotation plutôt que de faire pivoter les
+      pixels. Un outil qui recopie les images doit reporter cette consigne&nbsp;;
+      sinon votre clip vertical ressort couché, et c'est la façon classique de
+      gâcher une vidéo découpée. Le chemin exact proposé ici fait pivoter les
+      images pendant qu'il les réencode, et écrit un fichier qui n'a plus besoin
+      d'aucune rotation.
+    </p>
+    <p>
+      <strong>La synchronisation du son.</strong> Le son et l'image forment deux
+      flux distincts, chacun avec sa cadence propre, et ils ne se découpent pas
+      aux mêmes endroits. Sans un alignement délibéré au point de coupe, le son
+      se décale. Sur le chemin par copie, l'audio est recopié échantillon par
+      échantillon sans être décodé&nbsp;: il est donc octet pour octet celui du
+      fichier d'origine, et une marque de montage le maintient calé sur l'image
+      au millième de seconde près.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi cela ne demande pas d'envoi &mdash; celui-ci surtout</h2>
+    <h2>Découper n'est pas recadrer</h2>
     <p>
-      La vidéo est le type de fichier pour lequel les gens s'attendent le plus à
-      devoir faire un envoi, parce que les fichiers sont gros et que le travail a
-      l'air lourd. La coupe est le cas où c'est le moins vrai&nbsp;: sur le
-      chemin par copie, le fichier est à peine lu. L'outil parcourt l'index,
-      détermine quelles plages d'octets garder, et les écrit. Envoyer un fichier
-      de quatre gigaoctets à un serveur pour qu'il fasse cela serait la façon la
-      plus lente possible de s'y prendre.
+      Deux mots qu'on emploie souvent l'un pour l'autre. Découper change la durée
+      du clip&nbsp;; recadrer change la forme de l'image. Si ce que vous cherchez
+      est une version carrée d'une vidéo horizontale, ou des bandes noires
+      enlevées sur les côtés, allez voir le
+      <a href="../../recadrer-une-video/">recadreur de vidéos</a> &mdash;
+      lequel, contrairement à la découpe, doit bel et bien réencoder, pour la
+      raison qu'<a href="../recadrer-une-video/">expose son guide</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi rien de tout cela n'exige un envoi &mdash; et celui-ci moins que tout</h2>
+    <p>
+      La vidéo est le type de fichier pour lequel on s'attend le plus à devoir
+      passer par un envoi&nbsp;: les fichiers sont gros et le travail paraît
+      lourd. La découpe est justement le cas où c'est le moins vrai. Sur le
+      chemin par copie, le fichier est à peine lu&nbsp;: l'outil parcourt
+      l'index, détermine les plages d'octets à garder, et les écrit. Expédier
+      quatre gigaoctets à un serveur pour lui faire faire cela serait la manière
+      la plus lente de s'y prendre.
     </p>
     <p>
-      C'est aussi le type de fichier où l'envoi coûte le plus cher si vous
-      préférez l'éviter&nbsp;: la vidéo porte des visages, des voix, des
-      logements et des lieux d'une façon qu'un document ne connaît pas. L'outil
-      d'ici n'a aucune fonction réseau, et la
-      <code>Content-Security-Policy</code> de la page nomme toutes les adresses
-      qu'elle peut contacter, dont aucune n'appartient à ce site.
+      C'est aussi le type de fichier dont l'envoi coûte le plus cher, si vous
+      préférez l'éviter&nbsp;: une vidéo transporte des visages, des voix, des
+      logements et des lieux comme aucun document ne le fait. L'outil proposé ici
+      n'a aucune fonction réseau, et la <code>Content-Security-Policy</code> de
+      la page énumère toutes les adresses qu'elle peut contacter, dont aucune
+      n'appartient à ce site.
     </p>
     <p>
-      Coupez votre connexion et coupez un clip quand même, si vous préférez
+      Coupez votre connexion et découpez un clip quand même, si vous préférez
       vérifier plutôt qu'on vous le dise.
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose trois autres
-      vérifications du même genre.
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente trois autres
+      vérifications du même ordre.
     </p>
   </section>

--- a/locales/fr/pages/guides/trim-a-video.toml
+++ b/locales/fr/pages/guides/trim-a-video.toml
@@ -3,15 +3,16 @@
 #
 
 nav = "Couper une vidéo"
-title = "Comment couper une vidéo sans la réencoder"
-description = "Couper un clip n'a pas à perdre un seul octet de qualité. Pourquoi une coupe tombe parfois plus tôt que là où vous l'avez marquée, ce qu'une image clé vient y faire, et quand accepter un réencodage."
-heading = "Comment couper une vidéo sans la réencoder"
+# En français, la recherche porte sur la perte de qualité plutôt que sur le
+# réencodage, qui est le mot du métier ; le réencodage arrive au sous-titre.
+title = "Comment couper une vidéo sans perte de qualité"
+description = "Raccourcir un clip ne devrait pas coûter un seul octet. Pourquoi la coupe tombe parfois avant votre marque, ce que les images clés viennent y faire, et quand réencoder."
+heading = "Comment couper une vidéo sans perte de qualité"
 lede = """
-    Couper ne change l'aspect d'aucune image&nbsp;: un bon coupeur n'y touche
-    donc pas &mdash; il les déplace dans un nouveau fichier exactement telles
-    qu'elles étaient. Voici ce que cela vous rapporte, et le seul endroit où cela
-    se voit."""
+    Couper ne change l'aspect d'aucune image. Un bon outil n'y touche donc pas,
+    il les déplace telles quelles dans un nouveau fichier. Voici ce que cela
+    vous fait gagner, et le seul endroit où cela se voit."""
 updated = "20 août 2026"
-og_title = "Comment couper une vidéo sans la réencoder"
-og_description = "Pourquoi une coupe tombe parfois plus tôt que là où vous l'avez marquée, ce qu'une image clé vient y faire, et quand accepter un réencodage."
+og_title = "Couper une vidéo sans perdre en qualité"
+og_description = "Pourquoi la coupe tombe parfois avant votre marque, ce que les images clés viennent y faire, et quand accepter un réencodage."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/fr/pages/guides/turn-a-video-into-a-gif.html
@@ -2,231 +2,232 @@
     <h2>La réponse courte</h2>
     <p>
       Ouvrez le <a href="../../video-en-gif/">convertisseur de vidéo en GIF</a>,
-      déposez-y le clip, marquez les secondes voulues, et laissez la largeur à
-      480 et la cadence à 12 images par seconde. C'est le réglage que veulent la
-      plupart des GIF. Si le fichier ressort trop gros, baissez la largeur avant
-      de toucher à quoi que ce soit d'autre &mdash; c'est le réglage qui paie
-      deux fois.
+      déposez-y votre clip, marquez les secondes qui vous intéressent, et laissez
+      la largeur à 480 et la cadence à 12 images par seconde. C'est le réglage
+      qui convient à la plupart des GIF. Si le fichier ressort trop lourd,
+      baissez la largeur avant de toucher à quoi que ce soit d'autre&nbsp;: c'est
+      le réglage qui rapporte deux fois.
     </p>
     <p>
       Le reste de cette page explique pourquoi, parce que
-      &laquo;&nbsp;mon GIF fait 14 MB&nbsp;&raquo; est le problème que tout le
-      monde a réellement, et que le bouton à tourner n'est pas évident.
+      &laquo;&nbsp;mon GIF fait 14&nbsp;MB&nbsp;&raquo; est le problème que tout
+      le monde a vraiment, et que le bon bouton n'est pas celui qu'on croit.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi un GIF tiré d'une vidéo est si énorme</h2>
+    <h2>Pourquoi le GIF d'une vidéo est aussi énorme</h2>
     <p>
-      Un codec vidéo stocke du <em>mouvement</em>. Il écrit une image complète
-      toutes les deux secondes environ puis, pour chaque image intermédiaire, une
-      description de la façon dont cette image a bougé&nbsp;: ce bloc de pixels a
-      glissé de quatre vers la gauche, cette zone s'est un peu assombrie. Un clip
-      de cinq secondes peut faire quelques centaines de kilooctets parce que
-      l'essentiel est fait d'instructions à propos d'une image que vous avez
-      déjà.
+      Un codec vidéo enregistre du <em>mouvement</em>. Il écrit une image
+      complète toutes les deux secondes environ puis, pour chaque image
+      intermédiaire, la description de ce qui a bougé&nbsp;: ce bloc de pixels a
+      glissé de quatre vers la gauche, cette zone s'est légèrement assombrie. Un
+      clip de cinq secondes peut tenir en quelques centaines de kilooctets parce
+      que l'essentiel n'est qu'une série d'instructions portant sur une image que
+      vous avez déjà.
     </p>
     <p>
-      Le GIF n'a rien de tout cela. Il a été achevé en 1989, avant que rien de
-      cela n'existe. Chaque image est une image, compressée pour elle-même avec
-      un procédé conçu pour des captures d'écran de tableur. Il n'y a aucune
-      estimation de mouvement nulle part dans le format, et aucun moyen d'en
-      ajouter une.
+      Le GIF n'a rien de tout cela. Le format date de 1987, sa dernière révision
+      de 1989, et rien de ce qui précède n'existait alors. Chaque image y est une
+      image entière, compressée pour elle-même, avec un procédé conçu pour des
+      captures d'écran de tableur. Il n'y a aucune estimation de mouvement dans
+      le format, et aucun moyen d'en ajouter une.
     </p>
     <p>
       Le chiffre à attendre est donc <strong>dix fois le poids de la
-      vidéo</strong>, et aucun convertisseur ne vous en dissuadera. Ce qu'un bon
-      convertisseur peut faire, c'est ne rien gaspiller par-dessus, et vous donner
-      les trois réglages qui en décident réellement.
+      vidéo</strong>, et aucun convertisseur ne vous en dispensera. Ce qu'un bon
+      convertisseur peut faire, c'est ne rien gaspiller par-dessus, et vous
+      confier les trois réglages qui décident vraiment.
     </p>
   </section>
 
   <section>
     <h2>Les trois réglages, et ce que chacun coûte</h2>
     <p>
-      Tout ce qui fait le poids d'un GIF se ramène au nombre de pixels qu'il
-      contient, c'est-à-dire la durée multipliée par la cadence multipliée par la
-      surface d'une image.
+      Tout, dans le poids d'un GIF, se ramène au nombre de pixels qu'il contient,
+      c'est-à-dire la durée multipliée par la cadence multipliée par la surface
+      d'une image.
     </p>
     <ul>
       <li>
-        <strong>Le passage &mdash; linéaire.</strong> Deux fois plus long, c'est
-        deux fois plus d'images et à peu près deux fois le fichier. C'est celui
-        que la plupart des gens comprennent déjà, et il vaut la peine d'être
-        impitoyable&nbsp;: un GIF qui fait son effet en trois secondes est un
-        meilleur GIF en plus d'être un GIF plus léger.
+        <strong>Le passage &mdash; effet linéaire.</strong> Deux fois plus long,
+        c'est deux fois plus d'images et à peu près deux fois le poids. C'est
+        celui que tout le monde comprend déjà, et il faut être impitoyable&nbsp;:
+        un GIF qui fait mouche en trois secondes est un meilleur GIF autant qu'un
+        GIF plus léger.
       </li>
       <li>
-        <strong>La largeur &mdash; quadratique.</strong> Diviser la largeur par
-        deux divise la hauteur avec elle&nbsp;: c'est donc le <em>quart</em> des
-        pixels. Passer de 640 à 320 n'économise pas un peu moins de la
-        moitié&nbsp;; cela économise environ les trois quarts. C'est le réglage
-        vers lequel personne ne tend la main en premier et celui qui paie le
-        mieux.
+        <strong>La largeur &mdash; effet quadratique.</strong> Diviser la largeur
+        par deux divise la hauteur avec elle&nbsp;: cela fait un
+        <em>quart</em> des pixels. Passer de 640 à 320 n'économise pas un peu
+        moins de la moitié, mais à peu près les trois quarts. C'est le réglage
+        auquel personne ne pense en premier, et c'est le plus rentable.
       </li>
       <li>
-        <strong>La cadence &mdash; linéaire.</strong> Dix images par seconde,
-        c'est les deux tiers du poids de quinze. C'est aussi le réglage où la
-        perte est la plus visible, parce qu'un mouvement trop lent se lit comme
-        cassé plutôt que comme léger.
+        <strong>La cadence &mdash; effet linéaire.</strong> Dix images par
+        seconde pèsent les deux tiers de quinze. C'est aussi le réglage où la
+        perte se voit le plus, parce qu'un mouvement trop lent se lit comme un
+        défaut plutôt que comme une économie.
       </li>
     </ul>
     <p>
-      Un exemple chiffré. Six secondes d'un clip de téléphone à ses
-      1080&times;1920 et 30 images par seconde, ce sont 180 images de deux
-      millions de pixels&nbsp;: environ 350 millions de pixels, ce qui n'est pas
-      un GIF mais une prise d'otages. Les mêmes six secondes à 480 de large et 12
-      images par seconde font 72 images de 400 000 pixels &mdash; 30 millions,
-      soit environ un douzième &mdash; et cela ressemble à ce que les gens
-      appellent un GIF.
+      Un exemple chiffré. Six secondes d'un clip de téléphone à sa résolution
+      d'origine, 1080&times;1920 à 30 images par seconde, cela fait 180 images de
+      deux millions de pixels, soit quelque 350 millions de pixels&nbsp;: ce
+      n'est plus un GIF, c'est une prise d'otage. Les mêmes six secondes en 480
+      de large à 12 images par seconde donnent 72 images de 400&nbsp;000 pixels
+      &mdash; 30 millions, environ un douzième &mdash; et cela ressemble enfin à
+      ce que les gens appellent un GIF.
     </p>
   </section>
 
   <section>
     <h2>Quelle cadence choisir</h2>
     <p>
-      Douze est le défaut ici et la bonne réponse étonnamment souvent. C'est la
-      cadence qu'emploie l'animation dessinée à la main depuis un siècle&nbsp;:
-      assez rapide pour que l'œil la lise comme un mouvement continu, assez lente
-      pour que vous ne payiez pas des images que personne ne voit.
+      Douze est la valeur par défaut ici, et elle est la bonne étonnamment
+      souvent. C'est la cadence du dessin animé traditionnel depuis un
+      siècle&nbsp;: assez rapide pour que l'œil y lise un mouvement continu,
+      assez lente pour ne pas payer des images que personne ne verra.
     </p>
     <ul>
-      <li><strong>5 à 8</strong> &mdash; un air de diaporama. Convient pour un
-        panoramique lent ou une capture d'écran où rien ne bouge vite.</li>
-      <li><strong>10 à 15</strong> &mdash; normal. Se lit comme du mouvement. À
-        peu près tout GIF qui vaut la peine d'être fait est là-dedans.</li>
-      <li><strong>20 à 25</strong> &mdash; fluide, et à peu près le double du
-        poids de 12 pour une différence que la plupart des spectateurs ne sauront
-        pas nommer. Cela vaut le coup pour du mouvement rapide, un clip sportif,
-        tout ce qui contient un panoramique filé.</li>
+      <li><strong>5 à 8</strong> &mdash; un air de diaporama. Parfait pour un
+        panoramique lent ou une capture d'écran où rien ne va vite.</li>
+      <li><strong>10 à 15</strong> &mdash; le registre normal. Cela se lit comme
+        du mouvement, et presque tout GIF qui mérite d'exister est là.</li>
+      <li><strong>20 à 25</strong> &mdash; fluide, et environ deux fois le poids
+        de 12 pour une différence que peu de spectateurs sauraient nommer. Cela
+        se justifie sur un mouvement rapide, un extrait sportif, un
+        panoramique filé.</li>
     </ul>
     <p>
-      Il existe un plafond dur autant le savoir&nbsp;: le GIF stocke la durée
-      d'affichage de chaque image en centièmes de seconde, et tous les
-      navigateurs traitent un délai inférieur à deux centièmes comme s'il en
-      valait dix. Le vrai maximum est donc de 50 images par seconde, et un fichier
-      qui en demande 100 jouera en silence à 10. Un convertisseur qui vous propose
-      du 60 images par seconde soit l'ignore, soit s'apprête à vous surprendre.
+      Il existe un plafond dur, autant le connaître&nbsp;: le GIF enregistre la
+      durée d'affichage de chaque image en centièmes de seconde, et tous les
+      navigateurs traitent un délai inférieur à deux centièmes comme s'il valait
+      dix. Le vrai maximum est donc de 50 images par seconde, et un fichier qui
+      en réclame 100 se lira en réalité à 10, sans rien vous dire. Un convertisseur qui vous propose
+      du 60 images par seconde ignore ce point, ou s'apprête à vous surprendre.
     </p>
   </section>
 
   <section>
     <h2>256 couleurs, et à quoi sert le tramage</h2>
     <p>
-      L'autre moitié de l'âge du format&nbsp;: un GIF porte une table d'au plus
-      256 couleurs, et chaque pixel est un numéro qui pointe dedans. Une image de
-      vidéo en a jusqu'à seize millions. Presque tout cela est jeté, et la façon
-      dont c'est jeté fait l'essentiel de l'allure d'un GIF.
+      L'autre héritage de son âge&nbsp;: un GIF porte une table d'au plus
+      256 couleurs, et chaque pixel n'est qu'un numéro pointant dedans. Une image
+      de vidéo en compte jusqu'à seize millions. La quasi-totalité est donc
+      jetée, et la manière dont on la jette fait l'essentiel de l'allure d'un
+      GIF.
     </p>
     <p>
       Un bon convertisseur compte les couleurs de <em>votre</em> clip et en
-      choisit 256 qui lui conviennent, plutôt que d'utiliser un jeu figé. Un plan
-      de forêt reçoit 256 verts&nbsp;; un plan de coucher de soleil reçoit 256
-      oranges. C'est ce que fait l'outil d'ici, sur chaque image du passage plutôt
-      que sur la première seulement, si bien qu'une couleur qui n'apparaît qu'à la
-      fin a quand même sa place.
+      choisit 256 qui lui conviennent, au lieu de puiser dans un jeu fixe. Un
+      plan de sous-bois obtient 256 verts&nbsp;; un coucher de soleil, 256
+      orangés. C'est ce que fait l'outil de ce site, sur toutes les images du
+      passage et pas seulement sur la première, de sorte qu'une couleur qui
+      n'apparaît qu'à la fin garde sa place.
     </p>
     <p>
-      <strong>Le tramage</strong> est ce qui se passe là où la couleur dont vous
-      avez besoin manque encore. Au lieu d'arrondir toute une zone à la couleur
-      disponible la plus proche &mdash; ce qui transforme un ciel doux en quatre
-      aplats aux marches visibles &mdash; il alterne les deux couleurs les plus
-      proches selon un motif fin, et à une distance de vue normale votre œil les
-      mélange en celle qui n'est pas là.
+      <strong>Le tramage</strong> prend le relais là où la couleur nécessaire
+      manque encore. Plutôt que d'arrondir toute une zone à la couleur
+      disponible la plus proche &mdash; ce qui transforme un ciel dégradé en
+      quatre bandes plates aux marches bien visibles &mdash; il alterne les deux
+      couleurs les plus proches selon un motif fin&nbsp;; à distance normale de
+      lecture, votre œil les mélange et reconstitue celle qui manquait.
     </p>
     <ul>
-      <li><strong>Laissez-le activé</strong> pour tout ce qui est
-        photographique&nbsp;: ciels, peau, dégradés, ombres, film.</li>
+      <li><strong>Laissez-le actif</strong> pour tout ce qui est
+        photographique&nbsp;: ciels, peaux, dégradés, ombres, images de
+        film.</li>
       <li><strong>Désactivez-le</strong> pour les aplats&nbsp;: captures d'écran,
-        dessin au trait, logos, dessins animés, tout ce qui a de grandes zones
-        d'une seule teinte. Il n'y a pas de dégradé à protéger, et le fichier est
-        plus léger et plus propre sans lui.</li>
+        dessin au trait, logos, animation, tout ce qui présente de grandes zones
+        d'une seule teinte. Il n'y a aucun dégradé à protéger, et le fichier
+        ressort plus léger et plus propre.</li>
     </ul>
     <p>
       Un détail à connaître si vous comparez des convertisseurs. La façon évidente
-      de tramer &mdash; la diffusion d'erreur, qu'utilisent la plupart des
-      logiciels d'image &mdash; fait dépendre le résultat de chaque pixel des
-      pixels qui l'entourent. Dans une animation, cela veut dire qu'un fond qui ne
-      bouge pas est tramé différemment à chaque image&nbsp;: il grouille
-      visiblement, et chaque image doit être stockée en entier parce que chaque
-      pixel a techniquement changé. L'autre solution, un tramage ordonné, ne
-      dépend que de la position du pixel&nbsp;: un fond immobile reste donc
-      parfaitement immobile. C'est ce qu'utilise cet outil, et c'est pourquoi ses
-      fichiers sont à la fois plus légers et plus calmes.
+      de tramer &mdash; la diffusion d'erreur, celle qu'emploient la plupart des
+      logiciels de retouche &mdash; fait dépendre le résultat de chaque pixel de
+      ceux qui l'entourent. Dans une animation, un arrière-plan immobile se trame
+      donc différemment à chaque image&nbsp;: il grouille visiblement, et chaque
+      image doit être stockée en entier puisque, techniquement, tous les pixels
+      ont changé. L'autre méthode, le tramage ordonné, ne dépend que de la
+      position du pixel&nbsp;: un fond immobile reste parfaitement immobile.
+      C'est celle qu'emploie cet outil, et c'est pourquoi ses fichiers sont à la
+      fois plus légers et plus calmes.
     </p>
   </section>
 
   <section>
     <h2>Quand ne pas faire de GIF du tout</h2>
     <p>
-      La question mérite d'être posée, parce que la réponse honnête est souvent
-      &laquo;&nbsp;ne le faites pas&nbsp;&raquo;. Un MP4 ou un WebM muet en boucle
-      pèse environ un dixième de la même animation en GIF, se lit de la même
-      façon, et c'est de toute manière ce en quoi toutes les plateformes sociales
-      convertissent votre GIF après l'envoi.
+      La question mérite d'être posée, car la réponse honnête est souvent
+      &laquo;&nbsp;n'en faites pas&nbsp;&raquo;. Un MP4 ou un WebM muet et en
+      boucle pèse environ le dixième de la même animation en GIF, se comporte de
+      la même manière, et c'est de toute façon ce en quoi les plateformes
+      sociales convertissent votre GIF une fois reçu.
     </p>
-    <p>Gardez le GIF là où la destination en a réellement besoin&nbsp;:</p>
+    <p>Gardez le GIF là où la destination en réclame vraiment un&nbsp;:</p>
     <ul>
       <li>un endroit qui n'accepte qu'une image &mdash; beaucoup de messageries,
         de forums, de wikis et de logiciels de courriel&nbsp;;</li>
-      <li>un README ou une page de documentation, où un GIF joue dans le fil du
-        texte quand une vidéo réclame un lecteur&nbsp;;</li>
+      <li>un README ou une page de documentation, où un GIF s'anime dans le fil
+        du texte quand une vidéo réclame un lecteur&nbsp;;</li>
       <li>une présentation ou un document qui doit continuer de bouger hors
         ligne&nbsp;;</li>
-      <li>un emoji, un autocollant, une réaction &mdash; assez petits pour que
-        rien de l'arithmétique ci-dessus ne compte.</li>
+      <li>un émoji, un autocollant, une réaction &mdash; assez petits pour que
+        toute l'arithmétique ci-dessus n'ait plus d'importance.</li>
     </ul>
     <p>
-      Là où le son compte, la question se répond d'elle-même&nbsp;: le GIF n'a
+      Quand le son compte, la question se règle d'elle-même&nbsp;: le GIF n'a
       jamais eu d'audio et n'en aura jamais. Coupez plutôt la vidéo &mdash; le
       <a href="../../couper-une-video/">coupeur de vidéos</a> en extrait un
-      passage sans réencoder une seule image.
+      passage sans en réencoder une seule image.
     </p>
   </section>
 
   <section>
     <h2>Passer sous une limite de taille</h2>
     <p>
-      La raison principale pour laquelle on règle un GIF est une limite à l'autre
-      bout. Dans l'ordre approximatif de leur dureté&nbsp;:
+      Si l'on règle un GIF, c'est presque toujours à cause d'une limite au bout
+      de la chaîne. Grossièrement, par ordre de sévérité&nbsp;:
     </p>
     <ul>
-      <li><strong>Le courriel</strong> &mdash; 10 à 25 MB pour tout le message, et
-        une pièce jointe proche de cela se fait retirer ou rejeter par quelque
-        chose en chemin. Visez bien en dessous.</li>
-      <li><strong>Les messageries et les forums</strong> &mdash; couramment 8 à
-        10 MB, parfois bien moins pour un aperçu en ligne plutôt qu'un
-        téléchargement.</li>
-      <li><strong>Un README GitHub</strong> &mdash; 10 MB par fichier, et tout ce
-        qui dépasse deux mégaoctets donne à la page l'air d'être cassée sur un
+      <li><strong>Le courriel</strong> &mdash; de 10 à 25&nbsp;MB pour le message
+        entier, et une pièce jointe qui frôle ce plafond se fait retirer ou
+        rejeter par un serveur quelque part au milieu. Visez bien en
+        dessous.</li>
+      <li><strong>Messageries et forums</strong> &mdash; couramment 8 à
+        10&nbsp;MB, parfois beaucoup moins pour un aperçu affiché dans le fil
+        plutôt qu'un téléchargement.</li>
+      <li><strong>Un README sur GitHub</strong> &mdash; 10&nbsp;MB par fichier,
+        et au-delà de deux mégaoctets la page paraît cassée sur un
         téléphone.</li>
-      <li><strong>Les emplacements d'autocollants et d'emojis</strong> &mdash;
-        souvent quelques centaines de kilooctets, ce qui veut dire une petite
+      <li><strong>Les emplacements d'autocollants et d'émojis</strong> &mdash;
+        souvent quelques centaines de kilooctets, ce qui appelle une petite
         largeur et un passage court, pas une cadence plus basse.</li>
     </ul>
     <p>
-      L'ordre à essayer quand vous dépassez&nbsp;: raccourcir le passage, puis
-      diviser la largeur par deux, puis baisser la cadence, puis désactiver le
-      tramage. Les deux premiers valent plus que les deux derniers réunis.
+      L'ordre à suivre quand vous dépassez&nbsp;: raccourcir le passage, puis
+      diviser la largeur par deux, puis baisser la cadence, puis couper le
+      tramage. Les deux premiers rapportent plus que les deux derniers réunis.
     </p>
   </section>
 
   <section>
-    <h2>Rien de tout cela ne demande un envoi</h2>
+    <h2>Rien de tout cela n'exige un envoi</h2>
     <p>
       Convertir une vidéo en GIF, c'est décoder, redimensionner, compter des
-      couleurs et compresser &mdash; quatre choses qu'un navigateur sait faire
-      tout seul depuis des années. L'outil lié en haut fait tout cela sur votre
+      couleurs et compresser&nbsp;: quatre choses qu'un navigateur sait faire
+      seul depuis des années. L'outil mis en lien plus haut fait tout sur votre
       machine&nbsp;: le fichier est lu sur votre disque, les images sont décodées
       par votre navigateur, et le GIF est assemblé en mémoire puis remis à vos
       téléchargements.
     </p>
     <p>
-      Cela mérite plus d'attention ici qu'ailleurs. Les clips que les gens
-      transforment en GIF sont des clips personnels &mdash; un moment d'une vidéo
-      de famille, une capture d'écran de quelque chose au travail, quelques
-      secondes d'un appel. Un convertisseur qui veut qu'on les lui envoie demande
-      une copie de tout cela, et il ne reste plus aucune raison technique de dire
-      oui.
+      Ce qui mérite ici plus d'attention qu'ailleurs. Les clips qu'on transforme
+      en GIF sont des clips personnels&nbsp;: un instant d'une vidéo de famille,
+      l'enregistrement d'un écran au travail, quelques secondes d'un appel. Un
+      convertisseur qui veut les recevoir demande à en avoir une copie, et il n'y
+      a plus aucune raison technique de dire oui.
     </p>
   </section>

--- a/locales/fr/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/fr/pages/guides/turn-a-video-into-a-gif.toml
@@ -3,15 +3,15 @@
 #
 
 nav = "Faire un GIF depuis une vidéo"
-title = "Comment transformer une vidéo en GIF (et le garder léger)"
-description = "Quel passage, quelle largeur et quelle cadence choisir, pourquoi un GIF tiré d'une vidéo pèse dix fois la vidéo, et quand en faire un tout court."
+title = "Comment transformer une vidéo en GIF (sans qu'il pèse une tonne)"
+description = "Quel passage, quelle largeur et quelle cadence choisir, pourquoi un GIF tiré d'une vidéo pèse dix fois la vidéo, et quand il vaut mieux ne pas en faire du tout."
 heading = "Comment transformer une vidéo en GIF"
 lede = """
-    Le GIF est un format de 1987 qui stocke des images entières plutôt que du
-    mouvement&nbsp;: celui qu'on tire d'une vidéo est donc toujours gros. Voici
-    lequel des trois réglages déplacer quand il est trop gros, et ce que chacun
-    vous rapporte."""
+    Le GIF est un format de 1987 qui enregistre des images entières plutôt que
+    du mouvement&nbsp;: celui qu'on tire d'une vidéo est donc toujours lourd.
+    Voici lequel des trois réglages déplacer quand il l'est trop, et ce que
+    chacun rapporte."""
 updated = "20 août 2026"
-og_title = "Comment transformer une vidéo en GIF, et le garder léger"
-og_description = "Les trois réglages qui décident du poids d'un GIF, ce que chacun coûte, et quand le GIF est carrément la mauvaise réponse."
+og_title = "Transformer une vidéo en GIF, sans qu'il pèse une tonne"
+og_description = "Les trois réglages qui décident du poids d'un GIF, ce que chacun coûte, et les cas où le GIF est carrément la mauvaise réponse."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/turn-images-into-a-video.html
+++ b/locales/fr/pages/guides/turn-images-into-a-video.html
@@ -1,200 +1,201 @@
   <section>
     <h2>La réponse courte</h2>
     <p>
-      Ouvrez <a href="../../images-en-video/">Images en vidéo</a>, déposez-y les
-      images, mettez-les en ordre, réglez la durée d'affichage de chacune, et
-      créez la vidéo. Vous obtenez un MP4 avec de la vidéo H.264, qui se lit sur
-      à peu près n'importe quoi.
+      Ouvrez <a href="../../images-en-video/">Images en vidéo</a>, déposez-y vos
+      images, mettez-les dans l'ordre, réglez la durée d'affichage de chacune et
+      lancez la création. Vous obtenez un MP4 en H.264, qui se lit à peu près
+      partout.
     </p>
     <p>
-      Les deux réglages qui demandent le plus souvent une seconde passe sont la
-      durée et la résolution, et ils valent d'être compris avant le premier rendu
-      plutôt qu'après.
+      Deux réglages obligent souvent à tout refaire une seconde fois&nbsp;: la
+      durée et la résolution. Autant les comprendre avant le premier rendu plutôt
+      qu'après.
     </p>
   </section>
 
   <section>
-    <h2>La cadence et la durée ne sont pas la même chose</h2>
+    <h2>Cadence et durée ne sont pas la même chose</h2>
     <p>
-      C'est la confusion qui coûte un nouveau rendu.
+      C'est la confusion qui coûte un second rendu.
     </p>
     <p>
-      <strong>La durée</strong> est le temps que chaque image reste à l'écran.
-      C'est le réglage qui vous intéresse réellement. Trois secondes est un
-      défaut confortable pour un diaporama que quelqu'un regarde&nbsp;; une à
-      deux secondes donne un rythme alerte&nbsp;; au-delà de cinq, cela traîne à
-      moins qu'une voix ne le commente.
+      <strong>La durée</strong>, c'est le temps pendant lequel chaque image reste
+      à l'écran. C'est le réglage qui vous intéresse vraiment. Trois secondes
+      conviennent bien à un diaporama qu'on regarde&nbsp;; une à deux secondes
+      donnent un rythme enlevé&nbsp;; au-delà de cinq, cela traîne, sauf s'il y a
+      un commentaire par-dessus.
     </p>
     <p>
-      <strong>La cadence</strong> est le nombre de fois par seconde où la vidéo
-      répète cette image. Elle ne change rien à l'allure du diaporama &mdash; une
-      image fixe tenue trois secondes est identique à 24 images par seconde et à
-      60 &mdash; et elle change beaucoup le poids du fichier et le temps
-      d'encodage.
+      <strong>La cadence</strong>, c'est le nombre de fois par seconde où la
+      vidéo répète cette image. Elle ne change rien à l'allure du diaporama
+      &mdash; une image fixe tenue trois secondes est identique à 24 images par
+      seconde et à 60 &mdash; mais elle change beaucoup le poids du fichier et la
+      durée de l'encodage.
     </p>
     <p>
-      Pour un simple diaporama, prenez donc une cadence basse. 24 ou 30 suffit
-      largement. La raison de monter est la présence de mouvement dans la
-      vidéo&nbsp;: un panoramique ou un zoom sur chaque photo, ou un fondu
-      enchaîné entre elles, où une cadence basse se voit comme des saccades.
+      Pour un diaporama d'images fixes, prenez donc une cadence basse&nbsp;: 24
+      ou 30 suffisent amplement. La seule raison de monter, c'est le mouvement
+      &mdash; un panoramique ou un zoom sur chaque photo, un fondu enchaîné entre
+      deux &mdash; où une cadence basse se voit sous forme de saccades.
     </p>
   </section>
 
   <section>
     <h2>La résolution, et les images qui n'ont pas la bonne forme</h2>
     <p>
-      Une vidéo a une seule taille d'image sur toute sa durée. Vos photographies
-      n'en partagent presque certainement pas une seule&nbsp;: quelque chose doit
-      donc arriver à celles qui n'entrent pas &mdash; et ce quelque chose est le
-      choix qu'il vaut la peine de faire délibérément.
+      Une vidéo a une seule taille d'image d'un bout à l'autre. Vos photographies
+      ne la partagent certainement pas toutes&nbsp;: il faut donc bien qu'il
+      arrive quelque chose à celles qui ne rentrent pas, et c'est le choix qui
+      mérite d'être fait sciemment.
     </p>
     <p>
-      Commencez par choisir la résolution en fonction de la destination de la
-      vidéo&nbsp;:
+      Commencez par déduire la résolution de la destination de la vidéo.
     </p>
     <ul>
       <li>
-        <strong>1920&times;1080</strong> pour tout usage général. Prise en charge
-        universellement, se lit partout, et c'est ce que la plupart des gens
-        appellent la HD.
+        <strong>1920&times;1080</strong> pour un usage général. Reconnu partout,
+        lu partout, et c'est ce que la plupart des gens appellent la HD.
       </li>
       <li>
-        <strong>1080&times;1920</strong> &mdash; les mêmes nombres dans l'autre
+        <strong>1080&times;1920</strong> &mdash; les mêmes chiffres dans l'autre
         sens &mdash; pour une destination pensée pour le téléphone&nbsp;:
         stories, reels, shorts.
       </li>
       <li>
-        <strong>3840&times;2160</strong> seulement si les images ont réellement
-        autant de détail et si la destination le montrera. C'est quatre fois les
-        pixels, quatre fois le temps d'encodage, et à peu près quatre fois le
-        fichier.
+        <strong>3840&times;2160</strong> seulement si les images ont vraiment ce
+        niveau de détail et si la destination le montrera. C'est quatre fois plus
+        de pixels, quatre fois plus de temps d'encodage et à peu près quatre fois
+        le poids.
       </li>
     </ul>
     <p>
       Décidez ensuite du sort des images qui ne correspondent pas. Les faire
-      tenir dans le cadre garde tout et laisse des bandes sur les côtés &mdash;
-      sûr, et la bonne réponse quand les images comptent plus que la présentation.
-      Remplir le cadre et rogner le débord a plus d'allure et coupera le haut de
-      certaines. Mêler photographies verticales et horizontales dans une même
-      vidéo est le cas où il n'y a pas de bonne réponse&nbsp;; décider à l'avance
-      de quel côté vous préférez avoir tort épargne un nouveau rendu.
+      tenir dans le cadre les conserve entièrement et laisse des bandes sur les
+      côtés&nbsp;: sans risque, et c'est la bonne réponse quand les images
+      comptent plus que la présentation. Remplir le cadre et couper ce qui
+      dépasse rend mieux, et rognera le haut de certaines. Mêler des photos
+      verticales et horizontales dans une même vidéo est le cas où aucune réponse
+      n'est bonne&nbsp;; décider à l'avance de quel côté vous préférez avoir tort
+      vous épargnera un second rendu.
     </p>
   </section>
 
   <section>
     <h2>L'ordre, et le piège des noms de fichiers</h2>
     <p>
-      Comme pour tout traitement par lots, les noms de fichiers se trient d'une
-      façon qui n'est pas celle dont vous avez compté.
-      <code>photo2.jpg</code> vient après <code>photo10.jpg</code> dans un tri
-      alphabétique, parce que la comparaison se fait caractère par caractère.
+      Comme dans tout traitement par lots, les noms de fichiers se classent
+      autrement que vous ne les avez comptés&nbsp;: dans un tri alphabétique,
+      <code>photo2.jpg</code> arrive après <code>photo10.jpg</code>, puisque la
+      comparaison se fait caractère par caractère.
     </p>
     <p>
-      Trier par date de prise de vue est en général juste pour des photographies
-      d'un événement, puisque vous les avez prises dans l'ordre où il s'est
-      déroulé. Faire glisser les tuiles est juste pour tout ce dont le récit
-      n'est pas chronologique. Vérifiez avant de lancer le rendu&nbsp;: la vidéo
-      est l'objet où corriger l'ordre veut dire refaire tout le travail.
+      Le tri par date de prise de vue convient d'ordinaire à des photos
+      d'événement, prises dans l'ordre où les choses se sont passées. Faire
+      glisser les vignettes convient partout où le récit n'est pas
+      chronologique. Vérifiez avant de lancer le rendu&nbsp;: la vidéo est le
+      seul objet où corriger l'ordre veut dire tout recommencer.
     </p>
   </section>
 
   <section>
     <h2>Il n'y a pas de bande-son, et ce n'est pas un détail</h2>
     <p>
-      Le MP4 qu'écrit cet outil a une seule piste vidéo et aucune piste audio. Si
-      votre diaporama a besoin de musique ou d'une voix, il vous faudra un
-      logiciel de montage pour cette étape.
+      Le MP4 que produit cet outil n'a qu'une piste vidéo, sans aucune piste
+      audio. Si votre diaporama demande une musique ou une voix, il vous faudra
+      un logiciel de montage pour cette étape.
     </p>
     <p>
-      Il vaut la peine de savoir pourquoi, et pas seulement que&nbsp;: ajouter de
-      l'audio veut dire décoder un fichier de musique, l'encoder en AAC, et
-      l'entrelacer avec la vidéo dans le conteneur. Les trois sont du vrai
-      travail, et les faire mal produit un fichier qui se désynchronise à la
-      lecture. C'est sur la liste plutôt qu'à moitié fait.
+      Autant savoir pourquoi&nbsp;: ajouter du son suppose de décoder un fichier
+      musical, de l'encoder en AAC et de l'entrelacer avec la vidéo dans le
+      conteneur. Ces trois étapes sont du vrai travail, et mal faites elles
+      donnent un fichier dont le son se décale à mesure qu'on l'écoute. Le sujet
+      est sur la liste des choses à faire, plutôt qu'à moitié fait.
     </p>
     <p>
-      Une note pratique si vous ajoutez la musique après&nbsp;: choisissez
-      d'abord le morceau et réglez la durée par image pour que le diaporama
-      ressorte proche de la longueur de la chanson. Rogner la musique pour
-      qu'elle entre dans la vidéo sonne toujours plus mal que d'ajuster la vidéo
-      à la musique.
+      Un conseil pratique si vous ajoutez la musique après coup&nbsp;: choisissez
+      le morceau d'abord, puis réglez la durée par image pour que le diaporama
+      tombe à peu près sur la longueur de la chanson. Couper la musique pour
+      qu'elle rentre dans la vidéo sonne toujours moins bien que l'inverse.
     </p>
   </section>
 
   <section>
     <h2>Ce qui sort, et que faire si cela refuse de se lire</h2>
     <p>
-      La cible est du MP4 avec du H.264, la combinaison la plus largement lisible
-      qui soit. Dans un navigateur sans WebCodecs, l'outil se rabat sur un
-      enregistrement WebM &mdash; les mêmes images dans un conteneur que moins
-      d'éditeurs et de plateformes sociales acceptent.
+      La cible est le MP4 en H.264, la combinaison la plus universellement
+      lisible qui soit. Dans un navigateur dépourvu de WebCodecs, l'outil se
+      rabat sur un enregistrement en WebM &mdash; les mêmes images, dans un
+      conteneur que moins de logiciels de montage et de plateformes acceptent.
     </p>
     <p>
-      Si vous vous retrouvez avec un WebM et que quelque chose le refuse, le
-      remède est un navigateur qui prend en charge WebCodecs plutôt qu'une
-      conversion&nbsp;: les versions actuelles de Chrome, Edge et Safari le font
-      toutes. Refaire le rendu vaut mieux que convertir, parce que convertir veut
-      dire une génération de plus d'encodage avec perte.
+      Si vous vous retrouvez avec un WebM que quelque chose refuse, le remède
+      n'est pas une conversion mais un navigateur qui prend en charge
+      WebCodecs&nbsp;: les versions actuelles de Chrome, d'Edge et de Safari le
+      font toutes. Refaire le rendu vaut mieux que convertir, puisque convertir
+      ajoute une génération d'encodage avec perte.
     </p>
     <p>
-      Aucune limite n'est intégrée à l'outil quant au nombre d'images. Le plafond
-      est la mémoire de votre propre machine, parce que la vidéo finie y est
-      assemblée avant que vous la téléchargiez &mdash; un long diaporama en 4K
-      est la première chose à s'en ressentir.
+      L'outil n'impose aucune limite au nombre d'images. Le plafond est la
+      mémoire de votre machine, puisque la vidéo terminée y est assemblée avant
+      le téléchargement&nbsp;: un long diaporama en 4K est le premier à s'en
+      apercevoir.
     </p>
   </section>
 
   <section>
     <h2>Alléger le fichier</h2>
     <p>
-      Si le résultat est trop lourd pour sa destination, dans l'ordre de ce qui
-      aide réellement&nbsp;:
+      Si le résultat est trop lourd pour sa destination, voici ce qui aide
+      vraiment, dans l'ordre.
     </p>
     <p>
-      <strong>Baissez la cadence.</strong> Pour un diaporama d'images fixes, cela
-      ne coûte rien de visible et c'est la plus grosse économie disponible d'un
-      seul coup.
+      <strong>Baissez la cadence.</strong> Sur un diaporama d'images fixes, cela
+      ne coûte rien de visible et c'est de loin la plus grosse économie
+      disponible.
     </p>
     <p>
-      <strong>Baissez la résolution.</strong> Du 1080p au lieu de la 4K, c'est le
-      quart des pixels, et sur un écran de téléphone personne ne le saura.
+      <strong>Baissez la résolution.</strong> Du 1080p au lieu de la 4K, c'est
+      quatre fois moins de pixels&nbsp;; sur un écran de téléphone, personne n'y
+      verra rien.
     </p>
     <p>
       <strong>Raccourcissez.</strong> Trois secondes par image au lieu de cinq,
-      c'est 40&nbsp;% de durée en moins et 40&nbsp;% de fichier en moins, et en
+      c'est 40&nbsp;% de durée et 40&nbsp;% de poids en moins &mdash; et en
       général un meilleur diaporama.
     </p>
     <p>
-      Réduire d'abord les photographies source n'aide pas beaucoup. La vidéo est
-      encodée à la résolution que vous avez choisie de toute façon&nbsp;: une
-      photo de 4000 pixels et une de 2000 produisent presque le même nombre
-      d'octets dans une vidéo 1080p. Cela accélère l'encodage, en revanche, et
-      cela repousse ce plafond de mémoire.
+      Réduire les photos d'origine, en revanche, n'apporte pas grand-chose. La
+      vidéo est encodée à la résolution que vous avez choisie de toute
+      manière&nbsp;: une photo de 4000 pixels et une de 2000 produisent presque
+      le même nombre d'octets dans une vidéo en 1080p. Cela accélère l'encodage,
+      cela repousse le plafond de mémoire, et c'est tout.
     </p>
   </section>
 
   <section>
-    <h2>Pourquoi cela ne demande pas de serveur, avec une exception dite</h2>
+    <h2>Pourquoi cela ne demande pas de serveur, à une exception près</h2>
     <p>
-      Encoder de la vidéo était naguère le cas le plus clair en faveur de
-      l'envoi&nbsp;: les navigateurs ne savaient pas le faire, et une machine
-      dotée de FFmpeg le savait. WebCodecs a changé cela en exposant l'encodeur
-      matériel qui est déjà dans votre machine, celui-là même que votre téléphone
-      utilise pour enregistrer de la vidéo en temps réel. Composer les images,
-      c'est un canvas. Aucune des deux étapes n'a besoin d'autre chose que de
+      Encoder de la vidéo était naguère l'argument le plus net en faveur de
+      l'envoi&nbsp;: les navigateurs ne savaient pas le faire, une machine dotée
+      de FFmpeg si. WebCodecs a changé la donne en donnant accès à l'encodeur
+      matériel déjà présent dans votre machine, celui-là même que votre téléphone
+      utilise pour filmer en temps réel. Quant à composer les images, c'est
+      l'affaire d'une toile. Ni l'une ni l'autre étape ne réclame autre chose que
       votre propre matériel.
     </p>
     <p>
-      Une exception sur cet outil précis, dite plutôt qu'enterrée&nbsp;: la
-      fonction facultative &laquo;&nbsp;ajouter depuis une adresse web&nbsp;&raquo;
-      récupère une image à une adresse que vous collez, et le serveur qui se
-      trouve à cette adresse voit votre IP et ce que vous avez demandé. C'est
-      inhérent à la fonction plutôt qu'un défaut, et c'est la seule étape réseau
-      de tout l'outil. Ne vous en servez pas et rien ne quitte votre machine.
+      Une exception sur cet outil précis, dite clairement plutôt
+      qu'enfouie&nbsp;: la fonction facultative
+      &laquo;&nbsp;ajouter depuis une adresse web&nbsp;&raquo; va chercher une
+      image à l'adresse que vous collez, et le serveur concerné voit votre
+      adresse IP ainsi que ce que vous avez demandé. Cela tient à la fonction
+      elle-même, non à un défaut, et c'est la seule étape réseau de tout l'outil.
+      Ne vous en servez pas, et rien ne quitte votre machine.
     </p>
     <p>
       <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
-      fichiers à un convertisseur en ligne&nbsp;?</a> expose quatre vérifications
-      qui vous diront la même chose de n'importe quel outil, celui-ci compris.
+      fichiers à un convertisseur en ligne&nbsp;?</a> présente quatre
+      vérifications qui vous en diront autant sur n'importe quel outil, celui-ci
+      compris.
     </p>
   </section>

--- a/locales/fr/pages/guides/turn-images-into-a-video.toml
+++ b/locales/fr/pages/guides/turn-images-into-a-video.toml
@@ -3,14 +3,14 @@
 #
 
 nav = "Des images en vidéo"
-title = "Comment transformer un dossier d'images en vidéo"
-description = "Faire un diaporama MP4 à partir de photos : ce que contrôlent vraiment la cadence et la durée, comment traiter les images qui n'ont pas la bonne forme, et pourquoi le résultat n'a pas de bande-son."
-heading = "Comment transformer un dossier d'images en vidéo"
+title = "Comment faire une vidéo à partir d'un dossier de photos"
+description = "Fabriquer un diaporama MP4 : ce que contrôlent vraiment la cadence et la durée, que faire des images qui n'ont pas la bonne forme, et pourquoi le résultat n'a pas de bande-son."
+heading = "Comment faire une vidéo à partir d'un dossier de photos"
 lede = """
-    Un diaporama est une chose simple à fabriquer et facile à fabriquer deux
-    fois, parce que deux des réglages ne veulent pas dire ce qu'ils ont l'air de
-    vouloir dire. Voici ce que chacun contrôle et lequel choisir."""
+    Un diaporama est simple à fabriquer, et facile à fabriquer deux fois&nbsp;:
+    deux de ses réglages ne veulent pas dire ce qu'ils ont l'air de vouloir
+    dire. Voici ce que chacun commande, et lequel choisir."""
 updated = "20 août 2026"
-og_title = "Comment transformer un dossier d'images en vidéo"
-og_description = "Ce que contrôlent vraiment la cadence et la durée, comment traiter les images qui n'ont pas la bonne forme, et pourquoi il n'y a pas de bande-son."
+og_title = "Faire une vidéo à partir d'un dossier de photos"
+og_description = "Ce que contrôlent vraiment la cadence et la durée, que faire des images qui n'ont pas la bonne forme, et pourquoi il n'y a pas de bande-son."
 og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"


### PR DESCRIPTION
Recovered from uncommitted changes sitting in the worktree for `claude/website-i18n-french`, which was squash-merged as #55.

28 files, content only: a wording pass over the French guide pages, plus `locales/fr/locale.toml`.

**Three things handled deliberately:**

- The same worktree also held a **staged** change stripping the `id` fields off `[[hub.categories]]` and deleting `merge_by_id` from `buildlib/i18n.py`, across ten locales. That is a stale revert of work already in `main` — the by-id matching that stops an inserted English category silently relabelling every category after it. It is left behind, not carried here.
- The worktree's `locales/fr/planned.toml` is left out: it predates the trim of the English `config/planned.toml` and would put the locale ahead of English, which the build refuses.
- The worktree's `locale.toml` predates `ui.lang_auto`, so copying it wholesale dropped that key and failed the build. The wording changes were applied as a patch on top of `main`'s version instead, keeping `lang_auto` intact.

**Verified:** `python build.py` completes cleanly on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)