### PR TITLE
Ask, once, whether the file that just downloaded was any good

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,53 @@ Two details in there are worth knowing before changing it:
 column so the four land on one row. Changing either number without the other
 leaves an orphan on a second row.
 
+### The one question a tool page asks
+
+A second and a half after a download, a small panel appears under the step it
+came from: *Did this do the job?*, a thumb up and a thumb down. A thumb down
+offers four fixed reasons — wrong result, did not finish, too slow, confusing —
+and that is the whole of it. `shared/feedback.js`.
+
+It exists because nothing else here can tell you whether a tool works. Nothing
+is uploaded, so there is no server log to read, and the page view already
+counted says a tool was opened and cannot say whether anybody left with a file
+they could use. A tool that quietly produces a broken GIF in one browser is
+invisible until somebody writes in.
+
+Four things keep it from being the thing the rest of this site argues against:
+
+- **It sends an answer, not a report.** One `gtag` event carrying the tool's
+  slug, `up` or `down`, and one of four fixed reasons. No filename, no size, no
+  count, no dimension, and **no free-text box** — a comment field on a page that
+  has just handled somebody's passport scan collects filenames and worse, which
+  is the reason the reasons are chips.
+- **It goes where the page view already goes.** `google-analytics.com` is
+  already in `connect-src` and already named in the `PLATFORM_HOSTS` list each
+  tool's network check reads, so this added **no origin, no CSP change**, and
+  the live check on the page still reads green after an answer is sent.
+- **It asks once and then leaves.** An answer buys six months of silence on that
+  tool, a dismissal thirty days, a second dismissal a year — in `localStorage`,
+  like the language choice and for the same reason.
+- **It never gets in the way.** A panel in the flow of the page, not a modal and
+  not a toast: no focus taken, nothing covered, no button blocked.
+
+Two things to know before changing it. It is a **frame script**, delivered like
+`shared/lang.js` from `/feedback.js?v=<hash>` and included only by
+`templates/tool.html` — not a `js_parts` module, which would have to be imported
+by every tool's `main.js` and is the only reason this cost no per-tool code at
+all. And it finds a download **by the click**, in three shapes already in the
+markup: `a[download]` with an href, a button whose id starts with `download`,
+and anything carrying `data-download`. The third is the opt-in for a save button
+named something else, which today is exactly one — exif-editor's "Save this
+photo". Because a tool's `body.html` is copied whole into each
+`locales/<lang>/tools/<slug>.html`, a translation is a chance to lose that
+attribute silently; `DownloadHooks` in `tests/python/test_build.py` fails if a
+locale copy carries a different number of them than the English body.
+
+The words are `[ui.feedback]` in `config/site.toml`, translated in every
+`locale.toml` beside the rest of the frame — so adding a string there is a debt
+in ten languages, and `complete = true` will not build until they are written.
+
 ---
 
 ## Languages

--- a/build.py
+++ b/build.py
@@ -143,6 +143,14 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     lang_js = emit.js_text((SHARED / 'lang.js').read_text(encoding='utf-8'), 'shared/lang.js')
     lang_v = sitelib.text_hash(lang_js)
 
+    # The one question a tool page asks, hashed for the same reason and served
+    # from the same place. Only tool pages include it - it has nothing to ask on
+    # a guide - but it is written once at the root rather than into each tool,
+    # so that moving from one tool to the next is not a second copy to fetch.
+    feedback_js = emit.js_text(
+        (SHARED / 'feedback.js').read_text(encoding='utf-8'), 'shared/feedback.js')
+    feedback_v = sitelib.text_hash(feedback_js)
+
     planned = sitelib.load_toml(CONFIG / 'planned.toml')
 
     tools = [sitelib.load_tool(path, site)
@@ -176,7 +184,8 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     written = []
     for locale in locales:
         written += build_locale(out, templates, locale, locales, site, tools,
-                                prose, planned, css_v, lang_v, site_css, emit)
+                                prose, planned, css_v, lang_v, feedback_v,
+                                site_css, emit)
 
     # After every locale, because a locale only counts as finished once every
     # page in it has been rendered and had the chance to fall back. Raising
@@ -257,6 +266,7 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
     copy_shared(out)
     write(out / 'site.css', site_css)
     write(out / 'lang.js', lang_js)
+    write(out / 'feedback.js', feedback_js)
 
     # Last, because it reads the finished tree rather than the sources. A link
     # is only checkable once everything it could point at has been written.
@@ -282,7 +292,7 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
 
 
 def build_locale(out, templates, locale, locales, site, tools, prose, planned,
-                 css_v, lang_v, site_css, emit):
+                 css_v, lang_v, feedback_v, site_css, emit):
     """The whole site, in one language, under out/<lang>/ - or at the root of
     out/ for English, whose pages keep the addresses they have always had.
 
@@ -361,7 +371,7 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
     written = []
     for tool in ltools:
         build_tool(dest_root, templates, locale, locales, site, tool, footer,
-                   links, lang_v, guide_of.get(tool['slug'], {}),
+                   links, lang_v, feedback_v, guide_of.get(tool['slug'], {}),
                    related_of.get(tool['slug'], []), emit)
         written.append(f'{locale["prefix"]}{tool["out_slug"]}/index.html')
 
@@ -615,7 +625,7 @@ def build_guides(out, templates, locale, locales, site, groups, guides, footer,
 
 
 def build_tool(out, templates, locale, locales, site, tool, footer, links,
-               lang_v, guide, related, emit):
+               lang_v, feedback_v, guide, related, emit):
     root = locale['site']
     dest = out / tool['out_slug']
     dest.mkdir(parents=True, exist_ok=True)
@@ -686,12 +696,13 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
     # {% include %} a partial that uses them - the URL importer's warning being
     # the one that does.
     #
-    # [ui.tool] on every tool page and [ui.picker] only where there is a picker
-    # to describe. The second is not a tidiness: those strings name
-    # {{ tool.picker.urls.noun }}, which a tool that does not fetch addresses
-    # has never defined, so rendering them everywhere fails the build on the
-    # first tool that does not.
-    parts = ['tool'] + (['picker'] if sitelib.wants_urls(tool) else [])
+    # [ui.tool] and [ui.feedback] on every tool page, and [ui.picker] only where
+    # there is a picker to describe. The last is not a tidiness: those strings
+    # name {{ tool.picker.urls.noun }}, which a tool that does not fetch
+    # addresses has never defined, so rendering them everywhere fails the build
+    # on the first tool that does not.
+    parts = (['tool', 'feedback']
+             + (['picker'] if sitelib.wants_urls(tool) else []))
     ui_context = {'site': root, 'tool': tool, 'base': '../', 'links': links}
     ui = i18n.render_ui(templates, root['ui'], ui_context,
                         f'ui [{locale["lang"]}]', include=parts)
@@ -726,6 +737,9 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
             'csp': sitelib.render_csp(root['csp'], root.get('tool_csp', {}),
                                       sitelib.picker_csp(tool), tool['csp']),
             'css_href': css_href,
+            # Root-absolute and versioned, exactly like lang_href beside it and
+            # for the same cache reason. Only a tool page asks for this one.
+            'feedback_href': f'/feedback.js?v={feedback_v}',
             'jsonld': sitelib.tool_jsonld(root, tool),
             'body': body,
         })))
@@ -1385,10 +1399,10 @@ def copy_shared(out):
         # shared/css feeds the stylesheets the build assembles, and shared/js is
         # copied into each tool's src/shared/ by build_tool - minified, cached by
         # that tool's service worker. Copying either here would publish a second,
-        # raw copy at the site root that nothing references; site.css and
-        # lang.js are written separately, minified, by the caller - copying the
-        # source over either here would undo that.
-        if path.name in ('css', 'js', 'site.css', 'lang.js'):
+        # raw copy at the site root that nothing references; site.css, lang.js
+        # and feedback.js are written separately, minified, by the caller -
+        # copying the source over one of them here would undo that.
+        if path.name in ('css', 'js', 'site.css', 'lang.js', 'feedback.js'):
             continue
         if path.is_dir():
             shutil.copytree(path, out / path.name, dirs_exist_ok=True)

--- a/config/site.toml
+++ b/config/site.toml
@@ -531,6 +531,45 @@ read_first_lead = """
       Content-Security-Policy"""
 
 #
+# The one question this site asks, on the tool page, after a download. Its own
+# table rather than more of [ui.tool] because it is the only part of the frame
+# that sends anything, and the words that say so should be as easy to find as
+# the code that does it - shared/feedback.js.
+#
+
+[ui.feedback]
+prompt = "Did this do the job?"
+
+# Labels rather than visible words: the buttons are a thumb up and a thumb down,
+# which need no translation, and these are what a screen reader and a tooltip
+# say instead. "Yes" and "No" rather than "Good" and "Bad" - the question above
+# them is a question, and the answer to it is not a rating.
+up = "Yes"
+down = "No"
+dismiss = "Close"
+
+reason_prompt = "What went wrong?"
+
+# Four fixed answers, and there will never be a fifth without a reason. They are
+# chips and not a comment box on purpose: this panel appears on a page that has
+# just handled somebody's passport scan or their payslip, and a free-text field
+# there collects filenames and worse - see shared/feedback.js. Each one is a
+# thing the site could actually go and fix.
+reason_wrong = "Wrong result"
+reason_failed = "Did not finish"
+reason_slow = "Too slow"
+reason_confusing = "Confusing"
+
+thanks = "Thank you &mdash; that helps."
+
+# Said where the asking happens rather than in a policy page nobody opens. It
+# has to stay true of shared/feedback.js: the answer, the tool it is about, and
+# nothing else.
+note = """
+      Only the answer is sent, and only when you press a button. Never your
+      file, its name, or anything about it."""
+
+#
 # The one line a guide carries that a legal page does not: the link to the
 # tool the guide is about. Its own table because it needs {{ tool }}, and a
 # guide about no tool in particular - "is it safe to upload files" - has not

--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -407,6 +407,26 @@ read_first_lead = """
       Zuerst lesenswert sind <code>config/site.toml</code> für die
       Content-Security-Policy"""
 
+[ui.feedback]
+# Die Beschriftungen der Daumen sind nur für Screenreader und den Tooltip - die
+# Symbole selbst brauchen keine Übersetzung.
+prompt = "Hat das geklappt?"
+up = "Ja"
+down = "Nein"
+dismiss = "Schließen"
+
+reason_prompt = "Was ist schiefgelaufen?"
+reason_wrong = "Falsches Ergebnis"
+reason_failed = "Nicht fertig geworden"
+reason_slow = "Zu langsam"
+reason_confusing = "Verwirrend"
+
+thanks = "Danke &mdash; das hilft."
+
+note = """
+      Gesendet wird nur die Antwort, und nur auf Knopfdruck. Nie Ihre Datei,
+      nie ihr Name, nie irgendetwas darüber."""
+
 [ui.guide]
 open_tool = "{{ tool.name | e }} öffnen"
 

--- a/locales/de/tools/exif-editor.html
+++ b/locales/de/tools/exif-editor.html
@@ -141,7 +141,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>Dieses Foto speichern</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>Dieses Foto speichern</button>
         <button type="button" id="revert-edits" class="ghost" disabled>Meine Änderungen verwerfen</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/es/locale.toml
+++ b/locales/es/locale.toml
@@ -356,6 +356,26 @@ read_first_lead = """
       Los archivos por los que conviene empezar son <code>config/site.toml</code>,
       donde está la Content-Security-Policy"""
 
+[ui.feedback]
+# Las etiquetas de los pulgares son para el lector de pantalla y el tooltip: los
+# iconos ya se entienden solos.
+prompt = "¿Te ha servido?"
+up = "Sí"
+down = "No"
+dismiss = "Cerrar"
+
+reason_prompt = "¿Qué ha fallado?"
+reason_wrong = "Resultado incorrecto"
+reason_failed = "No terminó"
+reason_slow = "Demasiado lento"
+reason_confusing = "Confuso"
+
+thanks = "Gracias &mdash; nos sirve."
+
+note = """
+      Solo se envía la respuesta, y solo cuando pulsas un botón. Nunca tu
+      archivo, ni su nombre, ni nada sobre él."""
+
 [ui.guide]
 open_tool = "Abrir {{ tool.name | e }}"
 

--- a/locales/es/tools/exif-editor.html
+++ b/locales/es/tools/exif-editor.html
@@ -140,7 +140,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>Guardar esta foto</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>Guardar esta foto</button>
         <button type="button" id="revert-edits" class="ghost" disabled>Deshacer mis cambios</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -374,6 +374,26 @@ read_first_lead = """
       Les fichiers à lire en premier sont <code>config/site.toml</code> pour la
       Content-Security-Policy"""
 
+[ui.feedback]
+# Les libellés des pouces servent au lecteur d'écran et à l'infobulle : les
+# icônes, elles, se passent de traduction.
+prompt = "Est-ce que ça a marché&nbsp;?"
+up = "Oui"
+down = "Non"
+dismiss = "Fermer"
+
+reason_prompt = "Qu'est-ce qui n'a pas marché&nbsp;?"
+reason_wrong = "Mauvais résultat"
+reason_failed = "N'a pas abouti"
+reason_slow = "Trop lent"
+reason_confusing = "Peu clair"
+
+thanks = "Merci &mdash; c'est utile."
+
+note = """
+      Seule la réponse est envoyée, et seulement quand vous cliquez. Jamais
+      votre fichier, ni son nom, ni quoi que ce soit à son sujet."""
+
 [ui.guide]
 open_tool = "Ouvrir {{ tool.name | e }}"
 

--- a/locales/fr/tools/exif-editor.html
+++ b/locales/fr/tools/exif-editor.html
@@ -140,7 +140,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>Enregistrer cette photo</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>Enregistrer cette photo</button>
         <button type="button" id="revert-edits" class="ghost" disabled>Annuler mes modifications</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/hi/locale.toml
+++ b/locales/hi/locale.toml
@@ -325,6 +325,25 @@ read_first_lead = """
       सबसे पहले पढ़ने लायक फ़ाइलें ये हैं &mdash; Content-Security-Policy के लिए
       <code>config/site.toml</code>"""
 
+[ui.feedback]
+# अंगूठे के लेबल सिर्फ़ स्क्रीन रीडर और टूलटिप के लिए हैं - चिह्न खुद ही समझ आ जाते हैं।
+prompt = "क्या इससे काम बन गया?"
+up = "हाँ"
+down = "नहीं"
+dismiss = "बंद करें"
+
+reason_prompt = "क्या गड़बड़ हुई?"
+reason_wrong = "नतीजा गलत आया"
+reason_failed = "पूरा ही नहीं हुआ"
+reason_slow = "बहुत धीमा"
+reason_confusing = "समझ नहीं आया"
+
+thanks = "शुक्रिया &mdash; इससे मदद मिलती है।"
+
+note = """
+      सिर्फ़ आपका जवाब भेजा जाता है, वह भी तभी जब आप बटन दबाते हैं। आपकी फ़ाइल,
+      उसका नाम या उससे जुड़ी कोई बात कभी नहीं।"""
+
 [ui.guide]
 open_tool = "{{ tool.name | e }} खोलें"
 

--- a/locales/hi/tools/exif-editor.html
+++ b/locales/hi/tools/exif-editor.html
@@ -140,7 +140,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>यह फ़ोटो सहेजिए</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>यह फ़ोटो सहेजिए</button>
         <button type="button" id="revert-edits" class="ghost" disabled>मेरे बदलाव वापस लीजिए</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/it/locale.toml
+++ b/locales/it/locale.toml
@@ -353,6 +353,26 @@ read_first_lead = """
       I file da leggere per primi sono <code>config/site.toml</code> per la
       Content-Security-Policy"""
 
+[ui.feedback]
+# Le etichette dei pollici servono allo screen reader e al tooltip: le icone si
+# capiscono da sole.
+prompt = "Ha funzionato?"
+up = "Sì"
+down = "No"
+dismiss = "Chiudi"
+
+reason_prompt = "Cosa è andato storto?"
+reason_wrong = "Risultato sbagliato"
+reason_failed = "Non è arrivato in fondo"
+reason_slow = "Troppo lento"
+reason_confusing = "Poco chiaro"
+
+thanks = "Grazie &mdash; ci serve."
+
+note = """
+      Viene inviata solo la risposta, e solo quando premi un pulsante. Mai il
+      tuo file, né il suo nome, né niente che lo riguardi."""
+
 [ui.guide]
 open_tool = "Apri {{ tool.name | e }}"
 

--- a/locales/it/tools/exif-editor.html
+++ b/locales/it/tools/exif-editor.html
@@ -140,7 +140,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>Salva questa foto</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>Salva questa foto</button>
         <button type="button" id="revert-edits" class="ghost" disabled>Annulla le mie modifiche</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/ja/locale.toml
+++ b/locales/ja/locale.toml
@@ -313,6 +313,26 @@ read_first_lead = """
       まず読むとよいのは、Content-Security-Policyについては\
       <code>config/site.toml</code>"""
 
+[ui.feedback]
+# 親指のラベルはスクリーンリーダーとツールチップのためのもので、アイコン自体は
+# 訳す必要がありません。
+prompt = "うまくいきましたか？"
+up = "はい"
+down = "いいえ"
+dismiss = "閉じる"
+
+reason_prompt = "何がうまくいきませんでしたか？"
+reason_wrong = "結果が違う"
+reason_failed = "最後まで進まない"
+reason_slow = "遅すぎる"
+reason_confusing = "使い方が分かりにくい"
+
+thanks = "ありがとうございます &mdash; 助かります。"
+
+note = """
+      送られるのは答えだけ、しかもボタンを押したときだけです。ファイルも、その
+      名前も、それにまつわる情報も、送られることはありません。"""
+
 [ui.guide]
 open_tool = "{{ tool.name | e }}を開く"
 

--- a/locales/ja/tools/exif-editor.html
+++ b/locales/ja/tools/exif-editor.html
@@ -128,7 +128,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>この写真を保存</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>この写真を保存</button>
         <button type="button" id="revert-edits" class="ghost" disabled>変更を取り消す</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/ko/locale.toml
+++ b/locales/ko/locale.toml
@@ -394,6 +394,26 @@ read_first_lead = """
       먼저 읽어 볼 파일을 꼽자면, Content-Security-Policy는
       <code>config/site.toml</code>"""
 
+[ui.feedback]
+# 엄지 아이콘의 레이블은 스크린 리더와 툴팁을 위한 것입니다. 아이콘 자체는
+# 번역이 필요 없습니다.
+prompt = "원하는 결과가 나왔나요?"
+up = "예"
+down = "아니요"
+dismiss = "닫기"
+
+reason_prompt = "무엇이 잘못됐나요?"
+reason_wrong = "결과가 잘못됨"
+reason_failed = "끝까지 진행되지 않음"
+reason_slow = "너무 느림"
+reason_confusing = "쓰기 어려움"
+
+thanks = "고맙습니다 &mdash; 큰 도움이 됩니다."
+
+note = """
+      보내지는 것은 답변뿐이고, 그것도 버튼을 눌렀을 때만입니다. 파일도, 파일
+      이름도, 파일에 관한 어떤 정보도 보내지 않습니다."""
+
 [ui.guide]
 open_tool = "{{ tool.name | e }} 열기"
 

--- a/locales/ko/tools/exif-editor.html
+++ b/locales/ko/tools/exif-editor.html
@@ -139,7 +139,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>이 사진 저장하기</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>이 사진 저장하기</button>
         <button type="button" id="revert-edits" class="ghost" disabled>바꾼 것 되돌리기</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/nl/locale.toml
+++ b/locales/nl/locale.toml
@@ -357,6 +357,26 @@ read_first_lead = """
       De bestanden die je als eerste wilt lezen zijn <code>config/site.toml</code>
       voor de Content-Security-Policy"""
 
+[ui.feedback]
+# De labels bij de duimen zijn voor de schermlezer en de tooltip; de icoontjes
+# spreken voor zich.
+prompt = "Heeft dit geholpen?"
+up = "Ja"
+down = "Nee"
+dismiss = "Sluiten"
+
+reason_prompt = "Wat ging er mis?"
+reason_wrong = "Verkeerd resultaat"
+reason_failed = "Kwam niet af"
+reason_slow = "Te traag"
+reason_confusing = "Onduidelijk"
+
+thanks = "Bedankt &mdash; daar hebben we wat aan."
+
+note = """
+      Alleen je antwoord wordt verstuurd, en alleen als je op een knop drukt.
+      Nooit je bestand, niet de naam ervan, en niets erover."""
+
 [ui.guide]
 # "Open de tool X" rather than "X openen": several tool names in Dutch are verb
 # phrases - "Afbeeldingsformaat wijzigen" - and "Afbeeldingsformaat wijzigen

--- a/locales/nl/tools/exif-editor.html
+++ b/locales/nl/tools/exif-editor.html
@@ -140,7 +140,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>Deze foto opslaan</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>Deze foto opslaan</button>
         <button type="button" id="revert-edits" class="ghost" disabled>Mijn wijzigingen ongedaan maken</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/pt/locale.toml
+++ b/locales/pt/locale.toml
@@ -355,6 +355,26 @@ read_first_lead = """
       Os primeiros arquivos que valem a leitura são <code>config/site.toml</code>
       para a Content-Security-Policy"""
 
+[ui.feedback]
+# Os rótulos dos polegares são para o leitor de tela e a dica de ferramenta; os
+# ícones já se explicam sozinhos.
+prompt = "Resolveu o que você precisava?"
+up = "Sim"
+down = "Não"
+dismiss = "Fechar"
+
+reason_prompt = "O que deu errado?"
+reason_wrong = "Resultado errado"
+reason_failed = "Não terminou"
+reason_slow = "Lento demais"
+reason_confusing = "Confuso"
+
+thanks = "Obrigado &mdash; isso ajuda."
+
+note = """
+      Só a resposta é enviada, e só quando você aperta um botão. Nunca o seu
+      arquivo, nem o nome dele, nem nada a respeito."""
+
 [ui.guide]
 open_tool = "Abrir {{ tool.name | e }}"
 

--- a/locales/pt/tools/exif-editor.html
+++ b/locales/pt/tools/exif-editor.html
@@ -140,7 +140,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>Salvar esta foto</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>Salvar esta foto</button>
         <button type="button" id="revert-edits" class="ghost" disabled>Desfazer minhas mudanças</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/locales/zh/locale.toml
+++ b/locales/zh/locale.toml
@@ -295,6 +295,25 @@ read_first_lead = """
       最值得先读的几个文件：<code>config/site.toml</code> 里是
       Content-Security-Policy"""
 
+[ui.feedback]
+# 大拇指按钮的标签是给屏幕阅读器和悬停提示用的，图标本身不用翻译。
+prompt = "这次弄成了吗？"
+up = "成了"
+down = "没成"
+dismiss = "关闭"
+
+reason_prompt = "哪里不对？"
+reason_wrong = "结果不对"
+reason_failed = "没跑完"
+reason_slow = "太慢了"
+reason_confusing = "不会用"
+
+thanks = "谢谢 &mdash; 这很有帮助。"
+
+note = """
+      只有你的回答会被发出去，而且只在你按下按钮时。你的文件、文件名，以及跟它
+      有关的任何信息，都不会。"""
+
 [ui.guide]
 open_tool = "打开{{ tool.name | e }}"
 

--- a/locales/zh/tools/exif-editor.html
+++ b/locales/zh/tools/exif-editor.html
@@ -134,7 +134,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>保存这张照片</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>保存这张照片</button>
         <button type="button" id="revert-edits" class="ghost" disabled>撤销我的改动</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -904,6 +904,121 @@ footer a:hover { text-decoration: underline; }
 .logo-band { fill: var(--accent); }
 .logo-latch { fill: var(--accent-pale); }
 
+/* --------------------------------------------------------------- feedback */
+
+/*
+  "Did this do the job?" - see shared/feedback.js and templates/partials/
+  feedback.html. It is deliberately quieter than anything around it: it sits in
+  the flow of the page rather than over it, it is the width of the content
+  column rather than the width of the screen, and it uses --surface-2 so it
+  reads as an aside next to the result it is asking about rather than as a
+  second thing to do.
+*/
+.feedback {
+  max-width: 940px;
+  margin: 1rem auto 0;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  animation: feedback-in 220ms ease-out;
+}
+
+@keyframes feedback-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: none; }
+}
+
+/* It arrives on its own, unasked. Something that moves without being touched is
+   the first thing to switch off when the visitor has said they want less of
+   that - and it has no meaning it needs the movement to carry. */
+@media (prefers-reduced-motion: reduce) {
+  .feedback { animation: none; }
+}
+
+.feedback-ask {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.8rem;
+}
+
+.feedback-q {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+/* Pushes the close button to the far end, and is what lets the question keep
+   its natural width instead of being stretched by the row. */
+.feedback-votes {
+  display: flex;
+  gap: 0.4rem;
+  margin-inline-end: auto;
+}
+
+.feedback-vote {
+  background: var(--surface);
+  border-color: var(--border);
+  font-size: 1.05rem;
+  line-height: 1;
+  padding: 0.35rem 0.75rem;
+}
+
+.feedback-vote:hover { border-color: var(--accent); }
+
+.feedback-close {
+  background: none;
+  border-color: transparent;
+  color: var(--text-dim);
+  padding: 0.25rem 0.45rem;
+  font-size: 0.9rem;
+}
+
+.feedback-close:hover { color: var(--text); }
+
+.feedback-why {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.8rem;
+}
+
+.feedback-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+/* Four of these have to fit a phone without becoming a column of full-width
+   buttons, which is why they are small and wrap rather than stretch. */
+.feedback-chip {
+  background: var(--surface);
+  border-color: var(--border);
+  font-size: 0.85rem;
+  padding: 0.3rem 0.65rem;
+}
+
+.feedback-chip:hover { border-color: var(--accent); }
+
+.feedback-thanks {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--ok);
+}
+
+/* What is sent, in the smallest type on the panel. Small because it is a
+   footnote to a question, not the question - and present because the answer to
+   "what does this send" should be in front of somebody who is deciding whether
+   to press the button, not two pages away. */
+.feedback-note {
+  margin: 0.45rem 0 0;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  line-height: 1.45;
+}
+
 /* ------------------------------------------------------------- ad placement */
 
 /* Auto ads inject their own <ins> elements wherever Google decides, so their

--- a/shared/feedback.js
+++ b/shared/feedback.js
@@ -1,0 +1,244 @@
+/**
+ * The one question this site asks: did the file you just downloaded do the job?
+ *
+ * GENERATED FILE - do not edit; see shared/feedback.js.
+ *
+ * WHY THIS IS ALLOWED TO EXIST ON A SITE THAT MEASURES NOTHING
+ *
+ * The tools here work or they do not, and until this file there was no way to
+ * find out which. Nothing is uploaded, so there is no server log to read; the
+ * page view already counted says a tool was opened and cannot say whether
+ * anybody left with a file they could use. A tool that quietly produces a
+ * broken GIF on one browser is invisible for as long as nobody writes in.
+ *
+ * So: two buttons, after a download, once. Four rules keep that from becoming
+ * the thing the rest of this site is arguing against.
+ *
+ *   1. IT SENDS AN ANSWER, NOT A REPORT. The tool's slug, "up" or "down", and
+ *      one of four fixed reasons. There is no filename in it, no size, no
+ *      count, no dimension, no format, and no free-text box that could carry
+ *      any of those by accident - which is the whole reason the reasons are
+ *      chips rather than a comment field. The panel prints that same promise
+ *      where it is asking, in the language of the page around it.
+ *   2. IT GOES WHERE THE PAGE VIEW ALREADY GOES. The one call is a gtag event
+ *      to the measurement host every page here already loads, and which the
+ *      live network check on the page already accounts for. No new origin, no
+ *      widened Content-Security-Policy, and nothing under this site's control
+ *      gains the ability to receive anything.
+ *   3. IT ASKS ONCE AND THEN LEAVES. An answer buys silence for six months on
+ *      that tool, a dismissal thirty days, a second dismissal a year. Kept in
+ *      localStorage rather than a cookie, for the same reason shared/lang.js
+ *      keeps the language choice there: a cookie would be sent to a server on
+ *      every request, and this is nobody's business but the browser's.
+ *   4. IT NEVER GETS IN THE WAY. It is a panel in the flow of the page, not a
+ *      modal and not a toast: it takes no focus, covers nothing, blocks no
+ *      button, and waits a second and a half after the click so that it is not
+ *      competing with the browser's own download bar for the eye.
+ *
+ * WHAT COUNTS AS A DOWNLOAD
+ *
+ * There is no one place a download happens - a tool either offers an <a
+ * download> or runs a button that builds a blob and saves it through an anchor
+ * it never puts in the page - so this listens for the click rather than for the
+ * save. Three shapes, all of them already in the markup: an anchor with a
+ * download attribute and something to download, a button whose id starts with
+ * "download", and anything carrying data-download, which is how a save button
+ * named something else opts in.
+ *
+ * Delegated from the document in the capture phase, so a tool that stops the
+ * event on the way up is still counted, and so a link built after the page
+ * loaded needs no wiring of its own. That is what makes this a frame script and
+ * not a shared module: no tool imports it, and no tool.toml asks for it.
+ */
+(function () {
+  'use strict';
+
+  var KEY = 'abox-feedback-';
+
+  // A state and the moment it was written. Read out of storage a visitor can
+  // edit, and used to decide whether to stay quiet, so it is checked on the way
+  // in rather than trusted because of where it came from.
+  var STATE = /^(a|d1|d2)\.(\d{1,15})$/;
+
+  // How long each state buys, in days. An answer is worth the most silence:
+  // they told us, and asking again in a month would be asking them to tell us
+  // twice. A first dismissal is worth a month, because "not now" is not
+  // "never" - and a second one is, near enough.
+  var SILENCE = { a: 180, d1: 30, d2: 365 };
+  var DAY = 86400000;
+
+  // Long enough not to compete with the browser's own download bar, short
+  // enough that it is plainly a response to the click and not something that
+  // wandered in on its own.
+  var DELAY = 1500;
+
+  var THANKS = 2500;
+
+  var panel = document.getElementById('feedback');
+  if (!panel) return;
+
+  var slug = panel.getAttribute('data-tool') || '';
+  var ask = panel.querySelector('.feedback-ask');
+  var why = panel.querySelector('.feedback-why');
+  var thanks = panel.querySelector('.feedback-thanks');
+  var note = panel.querySelector('.feedback-note');
+  if (!slug || !ask || !why || !thanks) return;
+
+  // Whether this page load has already had its one question. Set at the click
+  // rather than when the panel appears, so a second download inside the delay
+  // does not queue a second panel.
+  var asked = false;
+
+  // A "down" with no reason chosen yet. Held rather than sent, because sending
+  // the verdict now and the reason afterwards would be two events for one
+  // answer and a verdict counted twice. Flushed when they choose a reason, when
+  // they close the panel, or when the page goes away underneath them.
+  var pending = null;
+
+  /* ------------------------------------------------------------ remembering */
+
+  function stored() {
+    try {
+      var raw = window.localStorage.getItem(KEY + slug);
+      return raw && STATE.test(raw) ? STATE.exec(raw) : null;
+    } catch (err) {
+      // Storage disabled, or a browser in a mode that throws rather than
+      // returning null. Not knowing is a perfectly good state to be in here: it
+      // asks, which is what happens to somebody who has never seen it.
+      return null;
+    }
+  }
+
+  function remember(state) {
+    try {
+      window.localStorage.setItem(KEY + slug, state + '.' + Date.now());
+    } catch (err) { /* see stored() */ }
+  }
+
+  /** Whether this tool has already had its answer, or its refusal, recently. */
+  function silent() {
+    var was = stored();
+    if (!was) return false;
+    var when = Number(was[2]);
+    // A clock that has moved backwards leaves a timestamp in the future, which
+    // would otherwise silence this tool until the date it claims. Treat that as
+    // no answer at all rather than as a very long one.
+    if (when > Date.now()) return false;
+    return Date.now() - when < SILENCE[was[1]] * DAY;
+  }
+
+  /** The state a dismissal moves to. A second refusal, and it stops asking. */
+  function refusal() {
+    var was = stored();
+    return was && was[1].charAt(0) === 'd' ? 'd2' : 'd1';
+  }
+
+  /* ---------------------------------------------------------------- sending */
+
+  /**
+   * The whole of what leaves this page, and only when a button is pressed.
+   *
+   * gtag is missing whenever the measurement script is blocked, which is an
+   * ordinary thing for a browser to do and not something to show anybody an
+   * error about. The panel thanks them either way: they answered, and whether
+   * the answer arrived is not their problem.
+   */
+  function send(verdict, reason) {
+    if (typeof window.gtag !== 'function') return;
+    try {
+      window.gtag('event', 'tool_feedback', {
+        tool_slug: slug,
+        verdict: verdict,
+        reason: reason,
+      });
+    } catch (err) { /* as above */ }
+  }
+
+  function flush() {
+    if (pending === null) return;
+    send('down', pending);
+    pending = null;
+  }
+
+  /* ------------------------------------------------------------------ panel */
+
+  function show(after) {
+    // Under the step the download was in, rather than wherever the frame left
+    // it: the panel belongs where the eye already is. A trigger outside a
+    // section - none today, but this file cannot require it - leaves the panel
+    // where it was rendered, which is directly under the tool.
+    var host = after && after.closest ? after.closest('section') : null;
+    if (host && host.parentNode && !host.contains(panel)) {
+      host.insertAdjacentElement('afterend', panel);
+    }
+    panel.hidden = false;
+  }
+
+  function settle(state) {
+    remember(state);
+    ask.hidden = true;
+    why.hidden = true;
+    if (note) note.hidden = true;
+    thanks.hidden = false;
+    window.setTimeout(function () { panel.hidden = true; }, THANKS);
+  }
+
+  panel.addEventListener('click', function (event) {
+    var target = event.target;
+    if (!target || !target.closest) return;
+
+    var vote = target.closest('[data-verdict]');
+    if (vote) {
+      if (vote.getAttribute('data-verdict') === 'up') {
+        send('up', 'none');
+        settle('a');
+      } else {
+        // Not sent yet - see `pending`. The answer is committed either way: the
+        // chips are an invitation, and closing on them is still a no.
+        pending = 'none';
+        ask.hidden = true;
+        why.hidden = false;
+      }
+      return;
+    }
+
+    var chip = target.closest('[data-reason]');
+    if (chip) {
+      pending = chip.getAttribute('data-reason');
+      flush();
+      settle('a');
+      return;
+    }
+
+    if (target.closest('.feedback-close')) {
+      // Closing after choosing "no" is still a "no", and counts as an answer.
+      // Only somebody who closed without pressing either button has said
+      // nothing, and for them `pending` is null and this sends nothing.
+      var answered = pending !== null;
+      flush();
+      settle(answered ? 'a' : refusal());
+    }
+  });
+
+  // The tab going away with a "no" chosen and no reason picked. pagehide rather
+  // than unload: it is the one that fires on a phone, where a tab is more often
+  // backgrounded than closed.
+  window.addEventListener('pagehide', flush);
+
+  /* --------------------------------------------------------------- the ask */
+
+  if (silent()) return;
+
+  document.addEventListener('click', function (event) {
+    if (asked) return;
+    var target = event.target;
+    if (!target || !target.closest) return;
+
+    var trigger = target.closest(
+      'a[download][href], button[id^="download"], [data-download]');
+    if (!trigger || trigger.disabled) return;
+
+    asked = true;
+    window.setTimeout(function () { show(trigger); }, DELAY);
+  }, true);
+}());

--- a/templates/analytics.js
+++ b/templates/analytics.js
@@ -11,6 +11,13 @@
   This measures page visits. It is never given anything about your {{ words.plural }}: no
   file, no thumbnail, no filename, no dimension, no count{{ words.analytics_extra }}. Nothing here
   can see any of that, and there is no custom event in this file to carry it.
+
+  One event does exist, and it is not in this file: shared/feedback.js sends
+  `tool_feedback` when somebody answers the thumbs up or thumbs down that
+  appears after a download. It carries three things - which tool, "up" or
+  "down", and one of four fixed reasons - and it is sent only on a press of one
+  of those buttons. The list above still holds: no file, no filename, no
+  dimension, no count, and no free-text field that could carry one by accident.
 */
 
 window.dataLayer = window.dataLayer || [];

--- a/templates/partials/feedback.html
+++ b/templates/partials/feedback.html
@@ -1,0 +1,65 @@
+<!--
+  "Did this do the job?" - asked once, after a download, and never again for
+  months. shared/feedback.js sets out why a site that measures nothing is
+  allowed to ask this, and the four rules that keep it small.
+
+  Rendered here, hidden, and moved next to the step the download came from when
+  it is actually asked. Rendered rather than built in JavaScript because every
+  word in it is translated, and the translations live in [ui.feedback] in
+  config/site.toml and in each locale.toml beside the rest of the frame - a
+  panel assembled in script would either carry English into ten languages or
+  need a second copy of those strings to fall out of step with.
+
+  `data-tool` is the English slug in every language. It is what the answer is
+  filed under, so it has to mean the same thing whichever page it came from.
+
+  The four reasons are `data-reason` values and not free text, and that is a
+  privacy decision rather than a design one: a comment box on a page that has
+  just handled somebody's passport scan collects filenames and worse. Four
+  fixed strings can only ever say one of four things.
+-->
+<div id="feedback" class="feedback" data-tool="{{ tool.slug }}" role="status" hidden>
+  <div class="feedback-ask">
+    <p class="feedback-q">{{ ui.feedback.prompt }}</p>
+    <div class="feedback-votes">
+      <button type="button" class="feedback-vote" data-verdict="up"
+              title="{{ ui.feedback.up }}" aria-label="{{ ui.feedback.up }}">
+        <span aria-hidden="true">&#128077;</span>
+      </button>
+      <button type="button" class="feedback-vote" data-verdict="down"
+              title="{{ ui.feedback.down }}" aria-label="{{ ui.feedback.down }}">
+        <span aria-hidden="true">&#128078;</span>
+      </button>
+    </div>
+    <button type="button" class="feedback-close"
+            title="{{ ui.feedback.dismiss }}" aria-label="{{ ui.feedback.dismiss }}">
+      <span aria-hidden="true">&#10005;</span>
+    </button>
+  </div>
+
+  <div class="feedback-why" hidden>
+    <p class="feedback-q">{{ ui.feedback.reason_prompt }}</p>
+    <div class="feedback-chips">
+      <button type="button" class="feedback-chip" data-reason="wrong">{{ ui.feedback.reason_wrong }}</button>
+      <button type="button" class="feedback-chip" data-reason="failed">{{ ui.feedback.reason_failed }}</button>
+      <button type="button" class="feedback-chip" data-reason="slow">{{ ui.feedback.reason_slow }}</button>
+      <button type="button" class="feedback-chip" data-reason="confusing">{{ ui.feedback.reason_confusing }}</button>
+    </div>
+  </div>
+
+  <p class="feedback-thanks" hidden>{{ ui.feedback.thanks }}</p>
+
+  <!--
+    What is sent, said where it is being asked rather than in a policy page.
+    The claim is checkable in the file named beside it, which is the same deal
+    every other claim on this page is offered under.
+  -->
+  <p class="feedback-note">{{ ui.feedback.note }}</p>
+</div>
+
+<!--
+  `defer` rather than blocking, unlike shared/lang.js: nothing here has to
+  happen before the first paint, and the panel cannot be asked for until there
+  is a result to download.
+-->
+<script src="{{ feedback_href }}" defer></script>

--- a/templates/sw.js
+++ b/templates/sw.js
@@ -64,8 +64,11 @@ self.addEventListener('fetch', (event) => {
         // is the whole point of this worker. Anything else gets the failure,
         // because handing HTML back to something that asked for a script only
         // turns "offline" into a MIME-type error in the console - which is
-        // exactly what /lang.js, the one root-absolute file a tool page asks
-        // for and does not precache, did before this line said `navigate`.
+        // exactly what /lang.js, one of the two root-absolute files a tool page
+        // asks for and does not precache, did before this line said `navigate`.
+        // /feedback.js is the other, and is deliberately in the same position:
+        // offline there is nothing for it to ask about, because there is no
+        // measurement call to carry the answer.
         request.mode === 'navigate'
           ? caches.match('index.html')
           : Promise.reject(new Error('offline and not cached'))

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -226,6 +226,8 @@
 
 {{ body }}
 
+{% include "partials/feedback.html" %}
+
 <!--
   ============================================================================
   THE WRITTEN PART OF THE PAGE

--- a/tests/js/feedback.test.js
+++ b/tests/js/feedback.test.js
@@ -1,0 +1,449 @@
+/**
+ * shared/feedback.js - the one question a tool page asks, and how rarely.
+ *
+ * Run the way tests/js/lang.test.js runs its subject, and for the same reason:
+ * the file is a frame script rather than a module, so there is nothing to
+ * import. The source is read off disk and evaluated with a hand-built window
+ * and document in front of it.
+ *
+ * The stub is the point. Every decision this file makes - whether to ask at
+ * all, what one press sends, how long an answer buys - is a function of what is
+ * in localStorage, which element was clicked, and which button was pressed
+ * after that. All three are values in a DOM, so faking the DOM is how the
+ * question gets asked. Two things in particular are worth checking here and
+ * nowhere else:
+ *
+ *   - that ONE answer sends exactly ONE event, however it is finished. A "no"
+ *     followed by a reason, a "no" followed by closing the panel, and a "no"
+ *     followed by the tab going away are three routes to the same answer, and
+ *     an implementation that sent the verdict early would count two of them
+ *     twice. A browser would not tell you; a counter in Google Analytics would,
+ *     six weeks later.
+ *   - that nothing but the answer is in the event. That is the promise the
+ *     panel prints on itself, and it is one assertion.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const SOURCE = readFileSync(
+  fileURLToPath(new URL('../../shared/feedback.js', import.meta.url)),
+  'utf8',
+);
+
+const DAY = 86400000;
+
+/** A storage that behaves like localStorage, or one that refuses to. */
+function storage(refuse = false) {
+  const held = new Map();
+  return {
+    held,
+    getItem(key) {
+      if (refuse) throw new Error('storage is disabled');
+      return held.has(key) ? held.get(key) : null;
+    },
+    setItem(key, value) {
+      if (refuse) throw new Error('storage is disabled');
+      held.set(key, String(value));
+    },
+  };
+}
+
+/**
+ * One element.
+ *
+ * `selectors` is the set of selector strings this element answers to, and
+ * closest() walks up matching against exactly the strings the source passes -
+ * so a test fails if the source starts asking for something the markup does not
+ * offer, which is the failure this stub exists to catch.
+ */
+function el(selectors = [], attrs = {}) {
+  const node = {
+    selectors: new Set(selectors),
+    attrs,
+    children: [],
+    parentNode: null,
+    hidden: false,
+    getAttribute: (name) => (name in attrs ? attrs[name] : null),
+    closest(query) {
+      const wanted = query.split(',').map((part) => part.trim());
+      let at = node;
+      while (at) {
+        if (wanted.some((part) => at.selectors.has(part))) return at;
+        at = at.parentNode;
+      }
+      return null;
+    },
+    querySelector(query) {
+      for (const child of node.children) {
+        if (child.selectors.has(query.trim())) return child;
+        const deeper = child.querySelector(query);
+        if (deeper) return deeper;
+      }
+      return null;
+    },
+    contains(other) {
+      let at = other;
+      while (at) {
+        if (at === node) return true;
+        at = at.parentNode;
+      }
+      return false;
+    },
+    insertAdjacentElement(where, other) {
+      node.inserted = { where, other };
+      other.parentNode = node.parentNode;
+    },
+    append(child) {
+      child.parentNode = node;
+      node.children.push(child);
+      return child;
+    },
+  };
+  return node;
+}
+
+/**
+ * The panel as templates/partials/feedback.html renders it, and a page with a
+ * download link in a step section.
+ *
+ * `stored` is what localStorage holds for this tool before the page loads,
+ * which is how the "ask once" rules are put on trial.
+ */
+function run({ stored = null, gtag = true, refuseStorage = false, tool = 'compress-pdf' } = {}) {
+  const local = storage(refuseStorage);
+  if (stored && !refuseStorage) local.held.set(`abox-feedback-${tool}`, stored);
+
+  // Hidden where the partial renders it hidden: the panel itself, the reasons
+  // behind the thumb down, and the thank-you. Which of them is on screen is
+  // most of what the assertions below read.
+  const panel = el(['#feedback'], { 'data-tool': tool });
+  panel.hidden = true;
+  const ask = panel.append(el(['.feedback-ask']));
+  const why = panel.append(el(['.feedback-why']));
+  why.hidden = true;
+  const thanks = panel.append(el(['.feedback-thanks']));
+  thanks.hidden = true;
+  const note = panel.append(el(['.feedback-note']));
+  const up = ask.append(el(['[data-verdict]'], { 'data-verdict': 'up' }));
+  const down = ask.append(el(['[data-verdict]'], { 'data-verdict': 'down' }));
+  const close = ask.append(el(['.feedback-close']));
+  const chips = {};
+  for (const reason of ['wrong', 'failed', 'slow', 'confusing']) {
+    chips[reason] = why.append(el(['[data-reason]'], { 'data-reason': reason }));
+  }
+
+  // The page the panel is asking about: a step section holding the download.
+  const section = el(['section']);
+  const main = el(['main']);
+  main.append(section);
+  const link = section.append(el(['a[download][href]']));
+  const button = section.append(el(['button[id^="download"]']));
+  const marked = section.append(el(['[data-download]']));
+  const unrelated = section.append(el(['.cancel']));
+
+  const sent = [];
+  const timers = [];
+  const on = { document: new Map(), panel: new Map(), window: new Map() };
+
+  panel.addEventListener = (type, fn) => on.panel.set(type, fn);
+
+  const document = {
+    getElementById: (id) => (id === 'feedback' ? panel : null),
+    addEventListener: (type, fn) => on.document.set(type, fn),
+  };
+
+  const window = {
+    localStorage: local,
+    addEventListener: (type, fn) => on.window.set(type, fn),
+    setTimeout: (fn) => timers.push(fn),
+  };
+  if (gtag) window.gtag = (...args) => sent.push(args);
+
+  // eslint-disable-next-line no-new-func
+  new Function('window', 'document', SOURCE)(window, document);
+
+  /** Every timer that is due, in the order it was set. */
+  const tick = () => {
+    while (timers.length) timers.shift()();
+  };
+
+  const click = (target, where = 'document') => {
+    const fn = on[where].get('click');
+    if (fn) fn({ target });
+  };
+
+  return {
+    panel, ask, why, thanks, note, section, link, button, marked, unrelated,
+    up, down, close, chips, sent, timers, tick, click,
+    listening: on.document.has('click'),
+    pagehide: () => {
+      const fn = on.window.get('pagehide');
+      if (fn) fn();
+    },
+    press: (target) => click(target, 'panel'),
+    stored: () => local.held.get(`abox-feedback-${tool}`) || null,
+  };
+}
+
+/** A stored state, written this many days ago. */
+const aged = (state, days) => `${state}.${Date.now() - days * DAY}`;
+
+/* ------------------------------------------------------- what counts as one */
+
+test('a download link asks the question', () => {
+  const page = run();
+  page.click(page.link);
+  assert.equal(page.panel.hidden, true, 'not before the delay is up');
+  page.tick();
+  assert.equal(page.panel.hidden, false);
+});
+
+test('a button named download asks it too', () => {
+  const page = run();
+  page.click(page.button);
+  page.tick();
+  assert.equal(page.panel.hidden, false);
+});
+
+test('so does a save button that opted in with data-download', () => {
+  // exif-editor's "Save this photo", which saves a file and is named nothing
+  // like "download". The attribute is how it says so.
+  const page = run();
+  page.click(page.marked);
+  page.tick();
+  assert.equal(page.panel.hidden, false);
+});
+
+test('any other button on the page does not', () => {
+  const page = run();
+  page.click(page.unrelated);
+  page.tick();
+  assert.equal(page.panel.hidden, true);
+});
+
+test('a disabled trigger does not', () => {
+  const page = run();
+  page.button.disabled = true;
+  page.click(page.button);
+  page.tick();
+  assert.equal(page.panel.hidden, true);
+});
+
+test('two downloads still only ask once', () => {
+  const page = run();
+  page.click(page.link);
+  page.click(page.button);
+  assert.equal(page.timers.length, 1);
+});
+
+test('it moves next to the step the download was in', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  assert.deepEqual(page.section.inserted, { where: 'afterend', other: page.panel });
+});
+
+/* --------------------------------------------------------- what is sent */
+
+test('a thumb up sends one event, and only the answer', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.up);
+
+  assert.equal(page.sent.length, 1);
+  const [type, name, params] = page.sent[0];
+  assert.equal(type, 'event');
+  assert.equal(name, 'tool_feedback');
+  // The whole payload, asserted whole rather than key by key: this is the
+  // promise the panel prints on itself, and a field added by accident should
+  // fail here rather than reach anybody's browser.
+  assert.deepEqual(params, {
+    tool_slug: 'compress-pdf', verdict: 'up', reason: 'none',
+  });
+});
+
+test('a thumb down sends nothing until it is finished', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.down);
+
+  assert.equal(page.sent.length, 0);
+  assert.equal(page.ask.hidden, true);
+  assert.equal(page.why.hidden, false, 'the reasons are offered instead');
+});
+
+test('a reason finishes it, as one event carrying that reason', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.down);
+  page.press(page.chips.slow);
+
+  assert.equal(page.sent.length, 1);
+  assert.deepEqual(page.sent[0][2], {
+    tool_slug: 'compress-pdf', verdict: 'down', reason: 'slow',
+  });
+});
+
+test('closing on the reasons is still a no, sent once', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.down);
+  page.press(page.close);
+
+  assert.equal(page.sent.length, 1);
+  assert.deepEqual(page.sent[0][2], {
+    tool_slug: 'compress-pdf', verdict: 'down', reason: 'none',
+  });
+});
+
+test('a tab going away with a no chosen sends it, and sends it once', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.down);
+  page.pagehide();
+  page.pagehide();
+
+  assert.equal(page.sent.length, 1);
+  assert.equal(page.sent[0][2].verdict, 'down');
+});
+
+test('a reason already sent is not sent again when the tab goes', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.down);
+  page.press(page.chips.wrong);
+  page.pagehide();
+
+  assert.equal(page.sent.length, 1);
+});
+
+test('closing without pressing either button sends nothing', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.close);
+
+  assert.equal(page.sent.length, 0);
+});
+
+test('a blocked measurement script is not an error, and still thanks them', () => {
+  const page = run({ gtag: false });
+  page.click(page.link);
+  page.tick();
+  page.press(page.up);
+
+  assert.equal(page.thanks.hidden, false);
+  // And it is remembered, so a browser that blocks measurement is asked once
+  // rather than on every download it ever makes.
+  assert.match(page.stored(), /^a\.\d+$/);
+});
+
+/* ------------------------------------------------------- how rarely it asks */
+
+test('an answer is remembered', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.up);
+  assert.match(page.stored(), /^a\.\d+$/);
+});
+
+test('a first dismissal is remembered as one', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.close);
+  assert.match(page.stored(), /^d1\.\d+$/);
+});
+
+test('a second dismissal is remembered as the last one', () => {
+  const page = run({ stored: aged('d1', 40) });
+  page.click(page.link);
+  page.tick();
+  page.press(page.close);
+  assert.match(page.stored(), /^d2\.\d+$/);
+});
+
+test('closing after a no counts as an answer, not as a refusal', () => {
+  const page = run();
+  page.click(page.link);
+  page.tick();
+  page.press(page.down);
+  page.press(page.close);
+  assert.match(page.stored(), /^a\.\d+$/);
+});
+
+test('a recent answer is not asked about again', () => {
+  const page = run({ stored: aged('a', 30) });
+  assert.equal(page.listening, false, 'it does not even watch for a download');
+});
+
+test('an answer from six months ago is asked again', () => {
+  const page = run({ stored: aged('a', 200) });
+  page.click(page.link);
+  page.tick();
+  assert.equal(page.panel.hidden, false);
+});
+
+test('a dismissal buys a month, and not a year', () => {
+  assert.equal(run({ stored: aged('d1', 10) }).listening, false);
+
+  const later = run({ stored: aged('d1', 40) });
+  later.click(later.link);
+  later.tick();
+  assert.equal(later.panel.hidden, false);
+});
+
+test('a second dismissal buys a year', () => {
+  assert.equal(run({ stored: aged('d2', 300) }).listening, false);
+
+  const later = run({ stored: aged('d2', 400) });
+  later.click(later.link);
+  later.tick();
+  assert.equal(later.panel.hidden, false);
+});
+
+test('a timestamp from the future is treated as no answer at all', () => {
+  // A clock that has been moved backwards would otherwise silence this tool
+  // until the date the stored value claims, which could be years.
+  const page = run({ stored: `a.${Date.now() + 400 * DAY}` });
+  page.click(page.link);
+  page.tick();
+  assert.equal(page.panel.hidden, false);
+});
+
+test('a value that is not one of ours is ignored', () => {
+  const page = run({ stored: 'yes please' });
+  page.click(page.link);
+  page.tick();
+  assert.equal(page.panel.hidden, false);
+});
+
+test('storage that throws asks, and answering does not break', () => {
+  const page = run({ refuseStorage: true });
+  page.click(page.link);
+  page.tick();
+  page.press(page.up);
+  assert.equal(page.sent.length, 1);
+  assert.equal(page.thanks.hidden, false);
+});
+
+test('a page with no panel does nothing at all', () => {
+  // Every page that is not a tool page. The script is only included on tool
+  // pages today, and this is what stops that being load-bearing.
+  const timers = [];
+  const window = { localStorage: storage(), addEventListener: () => {}, setTimeout: (fn) => timers.push(fn) };
+  const document = { getElementById: () => null, addEventListener: () => { throw new Error('listened anyway'); } };
+  // eslint-disable-next-line no-new-func
+  new Function('window', 'document', SOURCE)(window, document);
+  assert.equal(timers.length, 0);
+});

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -287,6 +287,50 @@ class RelatedTools(unittest.TestCase):
         self.assertEqual({t['slug'] for t in ordered} - linked, set())
 
 
+class DownloadHooks(unittest.TestCase):
+    """Every save button a locale copy could have dropped the hook from.
+
+    shared/feedback.js finds a download by the click, and it recognises three
+    shapes in the markup: an <a download>, a button whose id starts with
+    "download", and anything carrying data-download. The first two are
+    structure, and a translator has no reason to touch either. The third is an
+    attribute on a button whose visible words ARE translated - and a tool's
+    body.html is copied whole into locales/<lang>/tools/<slug>.html, so a
+    translation is a chance to lose it.
+
+    Losing it is silent: the tool still works, the button still saves the file,
+    and that one language simply stops being asked the question. This is the
+    only thing that would notice.
+    """
+
+    def counts(self, text):
+        return len(re.findall(r'data-download', text))
+
+    def test_every_locale_copy_keeps_the_hook(self):
+        for source in sorted(ROOT.glob('tools/*/body.html')):
+            slug = source.parent.name
+            wanted = self.counts(source.read_text(encoding='utf-8'))
+            for copy in sorted(ROOT.glob(f'locales/*/tools/{slug}.html')):
+                with self.subTest(tool=slug, lang=copy.parent.parent.name):
+                    self.assertEqual(
+                        self.counts(copy.read_text(encoding='utf-8')), wanted,
+                        f'{copy.relative_to(ROOT)} has a different number of '
+                        'data-download attributes than the English body it is a '
+                        'translation of')
+
+    def test_the_tool_that_needs_one_has_one(self):
+        """exif-editor saves through a button named nothing like "download".
+
+        Named here rather than inferred, because the rule this is protecting is
+        not "some tool has the attribute" - it is that a save button which does
+        not announce itself in one of the other two ways has to opt in, and
+        exif-editor is the one that does not.
+        """
+        body = (ROOT / 'tools' / 'exif-editor' / 'body.html').read_text(encoding='utf-8')
+        self.assertIn('id="save-edits"', body)
+        self.assertRegex(body, r'id="save-edits"[^>]*data-download')
+
+
 class BuildTheSite(unittest.TestCase):
     """A whole plain build, into a temporary directory.
 
@@ -387,6 +431,59 @@ class BuildTheSite(unittest.TestCase):
         worker = (self.out / slug / 'sw.js').read_text(encoding='utf-8')
         version = page.split('styles.css?v=')[1].split('"')[0].split("'")[0]
         self.assertIn(f'styles.css?v={version}', worker)
+
+    def test_a_tool_page_asks_its_question(self):
+        """The panel, and the one script that can act on it.
+
+        Both halves, because either on its own is a page that looks right and
+        does nothing: markup with no script never appears, and a script with no
+        markup returns on its first line.
+        """
+        slug = sorted(p.parent.name for p in ROOT.glob('tools/*/tool.toml'))[0]
+        page = (self.out / slug / 'index.html').read_text(encoding='utf-8')
+        self.assertIn('id="feedback"', page)
+        self.assertIn(f'data-tool="{slug}"', page)
+        self.assertIn('/feedback.js?v=', page)
+        self.assertTrue((self.out / 'feedback.js').is_file())
+
+    def test_the_question_is_asked_in_the_language_of_the_page(self):
+        """A translated tool page asks in that language, not in English.
+
+        The frame's words fall back to English wherever a locale has not
+        written them, and a fallback is not an error - so without this, adding a
+        string to the frame and never translating it would show up as an English
+        sentence in the middle of a Japanese page and nothing would say so.
+
+        Read off the two <p class="feedback-q"> the panel renders rather than
+        off the whole page, because the whole page also carries the partial's
+        own comment, and that comment quotes the English question.
+        """
+        finished = [locale for locale in self.locales
+                    if not locale['is_base'] and locale['complete']]
+        if not finished:
+            self.skipTest('no locale has finished the frame')
+
+        def questions(page):
+            return re.findall(r'<p class="feedback-q">(.*?)</p>',
+                              page.read_text(encoding='utf-8'), re.S)
+
+        slug = sorted(p.parent.name for p in ROOT.glob('tools/*/tool.toml'))[0]
+        english = questions(self.out / slug / 'index.html')
+        self.assertEqual(len(english), 2, 'the panel asks two questions')
+
+        for locale in finished:
+            with self.subTest(lang=locale['lang']):
+                path = buildmod.i18n.locale_path(locale, slug).strip('/')
+                asked = questions(self.out / path / 'index.html')
+                self.assertEqual(len(asked), len(english))
+                for said, in_english in zip(asked, english):
+                    self.assertNotEqual(said.strip(), in_english.strip())
+
+    def test_the_hub_does_not_ask_it(self):
+        """Nothing to download there, so nothing to ask about."""
+        hub = (self.out / 'index.html').read_text(encoding='utf-8')
+        self.assertNotIn('id="feedback"', hub)
+        self.assertNotIn('feedback.js', hub)
 
     def test_a_vendored_engine_is_copied_and_precached(self):
         """Any tool with a vendor/ folder gets it byte for byte, and cached.

--- a/tools/exif-editor/body.html
+++ b/tools/exif-editor/body.html
@@ -137,7 +137,7 @@
       </section>
 
       <div class="save-row">
-        <button type="button" id="save-edits" class="primary" disabled>Save this photo</button>
+        <button type="button" id="save-edits" class="primary" data-download disabled>Save this photo</button>
         <button type="button" id="revert-edits" class="ghost" disabled>Undo my changes</button>
         <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
       </div>


### PR DESCRIPTION
Nothing on this site can tell you whether a tool actually works. Nothing is
uploaded, so there is no server log to read, and the page view already counted
says a tool was opened — it cannot say whether anybody left with a file they
could use. A tool that quietly produces a broken GIF in one browser is invisible
until somebody writes in, and most people do not write in.

So a small panel now appears a second and a half after a download, under the
step it came from: **Did this do the job?**, a thumb up and a thumb down. A thumb
down offers four fixed reasons — *wrong result, did not finish, too slow,
confusing* — and that is the whole of it.

## The four rules it lives by

- **It sends an answer, not a report.** One `gtag` event carrying the tool's
  slug, `up` or `down`, and one of four reasons. No filename, no size, no count,
  no dimension, and **no free-text box**. That last one is a privacy decision
  rather than a design one: this panel appears on a page that has just handled
  somebody's passport scan, and a comment field there collects filenames and
  worse. Four fixed strings can only ever say one of four things.
- **It goes where the page view already goes.** `google-analytics.com` is
  already in `connect-src` and already named in the `PLATFORM_HOSTS` list every
  tool's own network check reads — so this adds **no origin and no CSP change**,
  and the live check on the page still reads green after an answer is sent.
- **It asks once and then leaves.** An answer buys six months of silence on that
  tool, a dismissal thirty days, a second dismissal a year — in `localStorage`,
  like the language choice and for the same reason.
- **It never gets in the way.** A panel in the flow of the page, not a modal and
  not a toast: no focus taken, nothing covered, no button blocked, and it waits
  long enough not to compete with the browser's own download bar.

## Why it cost no per-tool code

It is a **frame script** like `shared/lang.js`, served from
`/feedback.js?v=<hash>` and included only by `templates/tool.html` — not a
`js_parts` module, which would have had to be imported by all twenty-four
`main.js` files.

And it finds a download **by the click**, in three shapes already in the markup:
an `<a download>` with an href, a button whose id starts with `download`, and
anything carrying `data-download`. The third is the opt-in for a save button
named something else, and today that is exactly one — exif-editor's "Save this
photo".

No `tool.toml` and no `main.js` was touched.

## The one thing here that can rot quietly

A tool's `body.html` is copied whole into each
`locales/<lang>/tools/<slug>.html`, so a translation is a chance to lose that
`data-download` attribute — and losing it is silent, because the tool still
works and that one language simply stops being asked. `DownloadHooks` in
`tests/python/test_build.py` fails if a locale copy carries a different number of
them than the English body.

## Considered and rejected: a collector of our own

A Cloudflare Worker at `abox.tools/api/feedback` would have owned the data
outright and survived ad blockers. It was not worth what it cost: `'self'` added
to `connect-src`, and a rewrite of the claim at the top of `templates/tool.html`
that there is no origin here under this site's control. That sentence is
load-bearing. The send is one function, so if the volume ever justifies owning
properly, swapping it is a small change plus two prose claims.

## Prose that changed, and why

`templates/analytics.js` said *"there is no custom event in this file to carry
it"*. Still literally true — the event lives in `feedback.js` — but leaving it
unqualified would have been misleading, so it now names the one event and states
exactly what it carries.

## Testing

- **Python: 379 tests, OK.** Adds `DownloadHooks` plus three build assertions
  (the panel and its script are on a tool page, the question is asked in the
  language of the page, the hub does not ask it).
- **JavaScript: 1380 tests, 0 fail**, including 27 new ones for
  `shared/feedback.js`. The ones that earn their place check that **one answer
  sends exactly one event** however it is finished — a reason, a close, or the
  tab going away are three routes to the same answer, and an implementation that
  sent the verdict early would double-count two of them. A browser would not
  tell you; a counter in GA would, six weeks later.
- **Both build modes** clean. `feedback.js` minifies to 2.7 KB.
- **Driven in a real browser** on text-tools (anchor trigger) and qr-barcode
  (button trigger): the panel lands under the right section, sends nothing until
  pressed, stays quiet on the next visit, and the page's own network check still
  reports the file went nowhere. Light and dark both resolve from the existing
  token set.

## One step left, and it is not in this repository

`tool_slug`, `verdict` and `reason` have to be registered in **GA4 Admin → Data
display → Custom definitions** as event-scoped custom dimensions. Until then the
event arrives and cannot be reported on, and nothing is backfilled. Ad blockers
will eat 20–40%, so read it as a signal between tools rather than a census.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
