### PR TITLE
Send the feedback answer through the queue, not through a name a minifier owns

### DIFF
--- a/shared/feedback.js
+++ b/shared/feedback.js
@@ -138,15 +138,33 @@
   /**
    * The whole of what leaves this page, and only when a button is pressed.
    *
-   * gtag is missing whenever the measurement script is blocked, which is an
+   * THE QUEUE IS THE INTERFACE, NOT THE FUNCTION. `gtag` is an ordinary
+   * function declaration in analytics.js, and the deployed build renames
+   * declarations - so on the live site the global is called something else and
+   * `window.gtag` is undefined. This file used to look it up by name and return
+   * when it found nothing, which meant every answer was silently dropped in
+   * production and nowhere else: the readable build keeps the name, so it
+   * worked on a local server and in every test.
+   *
+   * What gtag does is push its own `arguments` onto window.dataLayer, and
+   * gtag.js reads that queue. `dataLayer` is a property name rather than a
+   * declaration, so no minifier touches it, and pushing to it directly is the
+   * same call by a route that cannot be renamed.
+   *
+   * A missing queue means the measurement script was blocked, which is an
    * ordinary thing for a browser to do and not something to show anybody an
    * error about. The panel thanks them either way: they answered, and whether
    * the answer arrived is not their problem.
    */
   function send(verdict, reason) {
-    if (typeof window.gtag !== 'function') return;
+    var queue = window.dataLayer;
+    if (!queue || typeof queue.push !== 'function') return;
+    // Named for what it is, and never looked up by that name - the payload is
+    // the arguments object, so what this function ends up being called in the
+    // built file does not matter.
+    function gtag() { queue.push(arguments); }
     try {
-      window.gtag('event', 'tool_feedback', {
+      gtag('event', 'tool_feedback', {
         tool_slug: slug,
         verdict: verdict,
         reason: reason,

--- a/templates/analytics.js
+++ b/templates/analytics.js
@@ -23,5 +23,14 @@
 window.dataLayer = window.dataLayer || [];
 function gtag() { dataLayer.push(arguments); }
 
+// Google's snippet stops at the line above, and this one puts back what the
+// build takes away. `gtag` is a function declaration, and the deployed build
+// renames declarations, so the global that every piece of documentation and
+// every other script on the page expects does not exist once it is minified.
+// A property name survives, so saying it this way makes the name real in both
+// builds. Found when shared/feedback.js sent nothing at all in production and
+// everything in every test.
+window.gtag = gtag;
+
 gtag('js', new Date());
 gtag('config', '{{ site.analytics_id }}');

--- a/tests/js/feedback.test.js
+++ b/tests/js/feedback.test.js
@@ -160,7 +160,15 @@ function run({ stored = null, gtag = true, refuseStorage = false, tool = 'compre
     addEventListener: (type, fn) => on.window.set(type, fn),
     setTimeout: (fn) => timers.push(fn),
   };
-  if (gtag) window.gtag = (...args) => sent.push(args);
+  // The queue, not a function - which is the whole point, and was once the
+  // bug. A stub that offered `window.gtag` passed while the deployed build,
+  // where that global has been renamed away, sent nothing at all. So the stub
+  // now offers exactly what a real page offers: an array called dataLayer.
+  if (gtag) {
+    window.dataLayer = {
+      push: (args) => sent.push(Array.from(args)),
+    };
+  }
 
   // eslint-disable-next-line no-new-func
   new Function('window', 'document', SOURCE)(window, document);
@@ -336,6 +344,8 @@ test('closing without pressing either button sends nothing', () => {
 });
 
 test('a blocked measurement script is not an error, and still thanks them', () => {
+  // No dataLayer at all, which is what a page whose measurement script never
+  // loaded actually looks like.
   const page = run({ gtag: false });
   page.click(page.link);
   page.tick();

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -927,5 +927,71 @@ class BuildMinified(unittest.TestCase):
                 sorted(p.relative_to(small).as_posix() for p in small.rglob('*')))
 
 
+class BuildMangled(unittest.TestCase):
+    """What survives having every name in the file changed.
+
+    This class exists because of one bug, and it is the kind that only the
+    deployed build can have. `gtag` is a function declaration in analytics.js;
+    esbuild renames declarations; so on the live site the global was called
+    something else and `window.gtag` was undefined. shared/feedback.js looked it
+    up by that name and returned when it found nothing, so every answer anybody
+    gave was dropped - in production only, because the readable build keeps the
+    name and so does every test stub. It worked perfectly everywhere it was
+    tested and nowhere that mattered.
+
+    So the rule now has a test: the things the outside world knows this site by
+    - a global it publishes, an event name, a parameter name - have to still be
+    spelled that way after the mangler has been over them.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.out = Path(cls.tmp.name) / 'mangled'
+        try:
+            buildmod.build(cls.out, clean=True, minify_output=True,
+                           mangle_names=True)
+        except Exception as error:
+            # esbuild is not installed, or not the pinned version. CI has it and
+            # the deploy needs it; a laptop without it should not fail here.
+            cls.tmp.cleanup()
+            raise unittest.SkipTest(f'no mangled build available: {error}')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def test_the_measurement_global_keeps_its_name(self):
+        """`gtag` is an interface, not an internal.
+
+        Anything else on the page that measures anything reaches for this by
+        name, because that is the name Google's own documentation gives it.
+        """
+        analytics = (self.out / 'analytics.js').read_text(encoding='utf-8')
+        self.assertIn('window.gtag=', analytics.replace(' ', ''))
+
+    def test_the_feedback_event_keeps_every_name_it_is_read_by(self):
+        """The event name and its three parameters are strings in a report.
+
+        A mangled parameter name would arrive at Google as a dimension nobody
+        had registered, which reports as nothing at all rather than as an error.
+        """
+        feedback = (self.out / 'feedback.js').read_text(encoding='utf-8')
+        for name in ('tool_feedback', 'tool_slug', 'verdict', 'reason'):
+            with self.subTest(name=name):
+                self.assertIn(name, feedback)
+
+    def test_the_answer_is_pushed_to_the_queue_rather_than_through_a_global(self):
+        """The fix itself, pinned.
+
+        `dataLayer` is a property and cannot be renamed; a global function can.
+        Reaching for the queue is what makes this work in a build where every
+        declaration has been given a one-letter name.
+        """
+        feedback = (self.out / 'feedback.js').read_text(encoding='utf-8')
+        self.assertIn('dataLayer', feedback)
+        self.assertNotIn('window.gtag', feedback)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Every answer anybody gave on the live site was thrown away. The panel appeared,
the thumb worked, the thank-you showed, the answer was written to `localStorage`
so it would not ask again — and nothing was sent. GA4 never saw a single
`tool_feedback` event, which is how this was found: by going to look for the
event and not finding it.

Fixes the feature shipped in #83.

## What was wrong

`templates/analytics.js` declares the tag function the way Google's snippet
does:

```js
function gtag() { dataLayer.push(arguments); }
```

That is a **function declaration**, and the deployed build renames
declarations. In the mangled output it is `function a()`, so `window.gtag` does
not exist on abox.tools — `window.a` does. Google's own measurement never
noticed, because configuration only needs the `dataLayer` push to have
happened.

`shared/feedback.js` opened its send with:

```js
if (typeof window.gtag !== 'function') return;
```

written so a blocked measurement script would not throw. On production that
guard is true every time, so the send returned before it sent anything —
silently, and only in the build that ships.

## The fix

Two changes, either of which would have been enough, and both worth having.

- **The queue is the interface, not the function.** `dataLayer` is a property
  name, which no minifier touches, and what `gtag` does is push its own
  `arguments` onto it. `feedback.js` now does exactly that, so it does not care
  what any function ends up being called. A missing queue still means the
  measurement script was blocked, which is what the old guard was actually for.
- **`analytics.js` says `window.gtag = gtag`.** A property survives mangling,
  so the global that Google's documentation and every other script on the page
  expect now exists in both builds rather than only in the readable one.

## Why it shipped, which matters more than the fix

It was tested three ways and all three shared one blind spot:

- the **unit tests** stubbed `window.gtag`, so the name existed;
- the **browser run** was against a `--no-minify` server, where the name
  survives;
- the **build tests** compared the plain and minified file lists, never the
  mangled output.

The mangler runs on deploy and nowhere else, so the one build that ships was the
one build never exercised. Everything was verified in a configuration that is
not the one users get.

So `BuildMangled` in `tests/python/test_build.py` now runs a **real mangled
build** and checks that the names the outside world knows this site by are still
spelled that way afterwards: `window.gtag` in `analytics.js`, and
`tool_feedback` / `tool_slug` / `verdict` / `reason` in `feedback.js`. It also
pins the fix, by refusing a `feedback.js` that mentions `window.gtag` at all.

The JavaScript stub now offers a `dataLayer` with a `push` rather than a `gtag`
function, so it can no longer pass against a shape production does not have.

## Testing

Against the artifact that actually ships, this time.

| Check | Result |
|---|---|
| Mangled `analytics.js` | `window.gtag=a` — the global is back |
| Mangled `feedback.js` | `push(arguments)}try{o("event","tool_feedback",{tool_slug:d,verdict:e,reason:t})}` |
| Mangled build, in a browser | `typeof window.gtag === "function"`; panel appeared; queue received `{tool_slug:"text-tools", verdict:"down", reason:"slow"}` |
| Production payload shape | a real hit carrying `en=tool_feedback&ep.tool_slug=text-tools&ep.verdict=up&ep.reason=none` |
| JavaScript suite | 1380 pass, 0 fail |
| `BuildMangled` | 3 pass |

One gap worth stating: in the local mangled run the outbound request is not
observable, because gtag switches to `sendBeacon` after the first few hits and
beacons do not appear in resource timing. What is confirmed there is that the
right entry reaches `dataLayer`, which is this file's responsibility; that the
same payload produces a real hit is confirmed separately, on production.

`BuildMangled` needs esbuild at the pinned version and skips without it, so a
laptop that has not installed it still gets a green suite — and CI, which has
it, does not.

## Note for after the merge

`tool_slug`, `verdict` and `reason` still need registering in GA4 as
event-scoped custom dimensions, and nothing is backfilled — so it is worth doing
before the fix reaches real traffic rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
