### PR TITLE
Ask the player for a frame before believing it can play the file

### DIFF
--- a/tools/timelapse-video/src/main.js
+++ b/tools/timelapse-video/src/main.js
@@ -100,8 +100,11 @@ const picker = wireFilePicker({
 
 /**
  * Ask the <video> element to open the file, and report what it made of it.
- * A browser that will not play a format still says so quickly, so this is also
- * the test for whether the playback path is available at all.
+ *
+ * This says the container was parsed, and nothing more. Whether a frame can
+ * actually be decoded out of it is a separate question, asked by
+ * `firstFrameLands` below - see the note there for why the two are not the
+ * same question.
  */
 function openInPlayer(video, url) {
   return new Promise((resolve) => {
@@ -124,6 +127,67 @@ function openInPlayer(video, url) {
     video.addEventListener('error', bad, { once: true });
     video.src = url;
     video.load();
+  });
+}
+
+/**
+ * How long to wait for the probe frame before giving up on the file.
+ *
+ * The same ten seconds a seek gets during the export itself, deliberately: a
+ * file too slow to answer here would be too slow there several hundred times
+ * over, so this is not a stricter test than the one it is standing in for.
+ */
+const PROBE_TIMEOUT = 10_000;
+
+/**
+ * Whether the player can actually produce a picture, and not merely a width.
+ *
+ * `loadedmetadata` is not a decode test, and treating it as one is what let a
+ * file through that then failed an hour and a half into the export. Matroska
+ * and WebM are the same container - WebM is a subset of Matroska - so Chrome
+ * opens an .mkv with its WebM demuxer, reads the video track's size and
+ * duration, and fires `loadedmetadata` having decoded nothing at all. A Dolby
+ * Vision track inside it gets as far as "3840 x 1540, 1h 30m" on the page and
+ * only fails when the first frame is demanded. `canPlayType` would have said
+ * so - it answers "" for dvh1 and "probably" for hvc1 - but nothing here knows
+ * which of the two is in the file until something tries to decode it.
+ *
+ * So: seek somewhere real and insist on a frame. `requestVideoFrameCallback`
+ * is the one API that means "a frame is on screen"; where it does not fire -
+ * a tab that is not compositing never presents anything - `readyState` of
+ * HAVE_CURRENT_DATA or better is the element's own claim to hold a decoded
+ * frame, which a track it cannot decode never reaches.
+ */
+function firstFrameLands(video, atSeconds) {
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const done = (ok) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      video.removeEventListener('error', onError);
+      video.removeEventListener('seeked', onSeeked);
+      resolve(ok);
+    };
+
+    const decoded = () => video.readyState >= 2 && !video.error;
+    const onError = () => done(false);
+    const onSeeked = () => {
+      if (typeof video.requestVideoFrameCallback === 'function') {
+        video.requestVideoFrameCallback(() => done(true));
+      }
+      setTimeout(() => done(decoded()), 500);
+    };
+
+    const timer = setTimeout(() => done(false), PROBE_TIMEOUT);
+    video.addEventListener('error', onError, { once: true });
+    video.addEventListener('seeked', onSeeked, { once: true });
+
+    // Somewhere other than zero, so this is a real seek and a real decode
+    // rather than whatever the element happened to buffer on load.
+    if (Math.abs(video.currentTime - atSeconds) < 1e-4) onSeeked();
+    else video.currentTime = atSeconds;
   });
 }
 
@@ -161,11 +225,35 @@ async function loadFile(picked) {
     }
 
     canReadDirectly = readable;
-    canPlay = played.ok;
+
+    // Only the file that has to go through the player is asked for a frame.
+    // The direct path already knows the answer: VideoDecoder.isConfigSupported
+    // is a real decodability test on the real codec string, which is why this
+    // asymmetry existed and why it was invisible until an .mkv turned up.
+    let opensButCannotDecode = false;
+    if (canReadDirectly) {
+      canPlay = played.ok;
+    } else if (played.ok) {
+      picker.busy('Checking this browser can decode it...');
+      canPlay = await firstFrameLands(el.preview,
+        Math.min(1, (played.duration || 2) / 2));
+      opensButCannotDecode = !canPlay;
+    } else {
+      canPlay = false;
+    }
 
     if (!canReadDirectly && !canPlay) {
-      showError(`This browser cannot open this file: ${fallbackReason
-        ?? 'the format is not one it plays.'}`);
+      // Worth separating: "I do not know this format" and "I opened it and
+      // then could not decode a frame of it" send you to different answers,
+      // and the second one is the case that used to fail an hour in.
+      showError(opensButCannotDecode
+        ? 'This browser opened the file but cannot decode the video in it. '
+          + 'That is usually Dolby Vision, or HEVC on a machine with no '
+          + 'hardware support for it - the container reads fine and the '
+          + 'picture never arrives. Convert it to an ordinary MP4 (H.264) '
+          + 'first, and this will read it directly.'
+        : `This browser cannot open this file: ${fallbackReason
+          ?? 'the format is not one it plays.'}`);
       resetView();
       return;
     }
@@ -189,7 +277,7 @@ async function loadFile(picked) {
       return;
     }
 
-    await showPreview(played.ok);
+    await showPreview(canPlay);
     describeSource();
     fitSizeOptions();
 

--- a/tools/timelapse-video/src/playback.js
+++ b/tools/timelapse-video/src/playback.js
@@ -27,6 +27,25 @@ class AbortedError extends Error {
   }
 }
 
+/** What the four MediaError codes mean, in words somebody can act on. */
+const MEDIA_ERRORS = {
+  1: 'the read was aborted',
+  2: 'the file could not be read off the disk',
+  3: 'the browser could not decode the video in it',
+  4: 'the browser does not support this format or codec',
+};
+
+/**
+ * The element gave up. Say how far it got, because on a long clip that is the
+ * difference between "this file is not supported" and "it died two thirds of
+ * the way through", and the two have different answers.
+ */
+function playerDied(video, done, total) {
+  const why = MEDIA_ERRORS[video.error?.code] ?? 'the browser stopped being able to read it';
+  return new Error(`The player stopped after ${done} of ${total} frames: ${why}. `
+    + 'Converting the clip to an ordinary MP4 (H.264) first is the reliable fix.');
+}
+
 /**
  * @param {object} args
  * @param {HTMLVideoElement} args.video  already loaded with the file
@@ -47,7 +66,19 @@ export async function timelapseByPlaying({
     for (let i = 0; i < times.length; i += 1) {
       if (signal?.aborted) throw new AbortedError();
 
-      await seek(video, times[i]);
+      // A media element's error is sticky, and it can be set between two seeks
+      // rather than during one - where no listener of ours is attached to hear
+      // it. Without this check a dead element is seeked to the end of the list
+      // anyway, each seek waiting out its own timeout, and the failure is
+      // reported minutes later from wherever it happened to be noticed.
+      if (video.error) throw playerDied(video, i, times.length);
+
+      try {
+        await seek(video, times[i]);
+      } catch (error) {
+        if (error?.name === 'PlayerError') throw playerDied(video, i, times.length);
+        throw error;
+      }
       drawScaled(ctx, video, {
         // The element has already applied whatever rotation the file asks for,
         // so there is nothing left here to turn.
@@ -103,12 +134,16 @@ function seek(video, seconds) {
       }
     };
 
+    // Named rather than described: only the caller knows how far through the
+    // list this happened, and that is half of what the message has to say.
     const onError = () => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       video.removeEventListener('seeked', onSeeked);
-      reject(new Error('The browser stopped being able to play this file partway through.'));
+      const failure = new Error('the player errored during a seek');
+      failure.name = 'PlayerError';
+      reject(failure);
     };
 
     const timer = setTimeout(finish, SEEK_TIMEOUT);


### PR DESCRIPTION
A bug report against `/timelapse-video/` (#89): a 9.5 GB Dolby Vision MKV was
accepted, showed its size and duration on the page, was configured for a 300×
time-lapse — and then failed at the far end of a 541-seek export with

> The browser stopped being able to play this file partway through.

Ninety minutes of somebody's time for a file that was never going to work.

## Why it happened

`loadedmetadata` is not a decode test, and the playback path treated it as one:

```js
const ok = () => done({
  ok: video.videoWidth > 0 && video.videoHeight > 0,   // ← "playable"
  …
});
```

Matroska and WebM are the same container — WebM is a subset of Matroska — so
Chrome opens an `.mkv` with its WebM demuxer, reads the video track's size and
duration straight out of the track header, and fires `loadedmetadata` having
decoded nothing at all. The page duly showed **3840 × 1540** and **1h 30m** for a
track Chrome cannot decode. `canPlayType` knows:

| | |
|---|---|
| `video/x-matroska` | `maybe` |
| `video/x-matroska; codecs="hvc1…"` | `probably` |
| `video/x-matroska; codecs="dvh1…"` | *(empty — no)* |

…but nothing in a `<video>` element says which of the two is inside the file.

**The container is what let this through, not the codec.** The direct path was
never affected, which is why this went unnoticed:
`VideoDecoder.isConfigSupported` is a real test on the real codec string. I
checked by rewriting a sample entry from `avc1` to `dvh1` in an MP4 — `demux.js`
refuses it ("the video is stored as `dvh1`, which this reader does not know")
and Chrome will not even load it (`MEDIA_ERR_SRC_NOT_SUPPORTED`). Only the
playback path believed the container.

## The fix

`firstFrameLands` seeks somewhere real and insists on a frame before the file is
accepted: `requestVideoFrameCallback` — the one API that means a frame is on
screen — or a `readyState` of `HAVE_CURRENT_DATA`, which a track the browser
cannot decode never reaches. On a file that works it costs about half a second
(measured: 509 ms). On one that does not, it turns ninety minutes of wasted work
into a refusal that names the likely cause:

> This browser opened the file but cannot decode the video in it. That is
> usually Dolby Vision, or HEVC on a machine with no hardware support for it —
> the container reads fine and the picture never arrives. Convert it to an
> ordinary MP4 (H.264) first, and this will read it directly.

Two smaller things the same bug exposed:

- **A media element's error is sticky, and can be set *between* two seeks**,
  where no listener of ours is attached to hear it. The export loop now checks
  `video.error` each time round instead of seeking a dead element through the
  rest of the list, each seek waiting out its own ten-second timeout. That is
  why the reported failure surfaced at the very end (`1:30:00 / 1:30:11` in the
  screenshot) rather than where it actually went wrong.
- **The failure now says how far it got, and what the `MediaError` code meant.**
  "The player stopped after 137 of 541 frames: the browser could not decode the
  video in it" is a different problem from the same message at frame 2, and the
  old wording could not tell them apart.

## Checked

- `node --test "tests/js/*.test.js"` — 1,523 pass
- The affected Python modules pass; no prose changed, so no locale work
- In a browser: an intact MP4 still loads and exports unchanged (300 frames,
  10 s out of a 20 s clip), and the probe returns true on it in 509 ms — the
  risk of this change is a false negative on a working file, and that is the
  case it was tested against

## Honest limit

I could not synthesise a Dolby Vision MKV to demonstrate the true-negative end
to end, so that branch is reasoned from `canPlayType`, from the `MediaError`
code the report produced, and from the MP4 experiment above rather than observed
directly on the original file. Everything else here is measured.

## Not in this PR

No prose changed. The FAQ already promised that a file the browser cannot play
is "refused with a message saying so rather than failing halfway through" —
which this makes true again, rather than needing a rewrite in ten languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
