### PR TITLE
Add Arabic, and make the frame's layout right-to-left safe

### DIFF
--- a/locales/ar/locale.toml
+++ b/locales/ar/locale.toml
@@ -1,0 +1,448 @@
+#
+# العربية.
+#
+# The first right-to-left locale, and the reason `dir="rtl"` in
+# templates/*.html and `locale['dir']` in build.py existed before this file
+# did - see README.md "Adding a language". What is here is the frame: the
+# hub, the guides index, the roadmap, the 404, the footer, and the words the
+# templates themselves use. The tools and the guides are NOT translated yet -
+# they stay in English, fall back page by page, and are held out of the
+# sitemap, the hreflang sets and the switcher exactly as an unfinished part of
+# any other locale is. See buildlib/i18n.py.
+#
+# Nothing structural is repeated here. There is no list of which tools exist,
+# no category ids, no ordering, no Content-Security-Policy - all of that is
+# decided once, in English, in config/site.toml, and a locale that tried to
+# restate any of it would be told so by the build.
+#
+# Modern Standard Arabic, formal register, written for a general reader rather
+# than for one dialect region. Decisions worth recording, because the next
+# translator into this file should not have to re-derive them:
+#
+#   * Arabic verbs and possessive suffixes carry the addressee's grammatical
+#     gender, and this site does not know its reader's. The masculine form is
+#     used as the generic, which is the default convention in Arabic software
+#     localization (Google, Microsoft and Apple all ship Arabic UIs this way)
+#     - not a claim about who is reading.
+#   * Western digits (0-9), not Eastern Arabic-Indic numerals (٠-٩). Version
+#     numbers, file sizes and counts on this site are typed by a build script
+#     and compared against what a browser's own devtools shows, and Western
+#     digits are what most Arabic technical writing on the web already uses.
+#   * "PDF", "GIF", "SVG", "JPG", "QR", "EXIF", "CSS" and similar acronyms
+#     stay in Latin letters, exactly as German keeps "EXIF" and Spanish keeps
+#     "GPS". They are what gets typed into a search box, transliterating them
+#     would invent a word nobody searches for, and several - PDF above all -
+#     are printed on the file's own icon in every operating system this site
+#     is used from.
+#   * Arabic's "few" (3-10) and "many" (11-99) plural forms are both real, but
+#     this file has only two slots to work with - see `guide_one`/`guide_many`
+#     below, which is the same limit Chinese, Japanese, Hindi and Korean run
+#     into for the opposite reason (no plural marking at all). The count this
+#     site actually shows is always past ten, so the "many" (11-99) form, a
+#     bare singular noun, is what both slots carry.
+#
+
+lang = "ar"
+name = "Arabic"
+endonym = "العربية"
+hreflang = "ar"
+dir = "rtl"
+
+# The frame is finished: the nav, the footer, the hub and every [ui] word in
+# this file are Arabic. That is all this flag claims - the tools and the
+# guides are still English, held back a page at a time. See the note at the
+# top of buildlib/i18n.py for why the unit is the page rather than the
+# language, and shared/css for the RTL layout work that had to land beside
+# this file before dir="rtl" was safe to ship at all.
+complete = true
+
+#
+# ---------------------------------------------------------------------------
+# The addresses.
+#
+# Keyed by the ENGLISH slug on the left, which is the name of the thing, and
+# never by the Arabic one. The Arabic is an address and appears only on the
+# right.
+#
+# Written in Arabic script rather than transliterated into Latin letters,
+# because that is what an Arabic speaker actually types - the same reasoning
+# German gives for writing its own slugs in German, applied to a script
+# rather than to a spelling. Korean and the CJK locales already prove a
+# non-Latin slug survives `location.pathname`; Arabic percent-encodes the
+# same way. An acronym that stays Latin in the running prose (PDF, GIF, SVG,
+# HEIC, QR) stays Latin inside the slug too, for the same reason.
+# ---------------------------------------------------------------------------
+#
+
+[slugs]
+# The tools.
+"compress-image" = "ضغط-الصور"
+"compress-pdf" = "ضغط-pdf"
+"crop-video" = "اقتصاص-الفيديو"
+"edit-audio" = "تحرير-الصوت"
+"exif-editor" = "إزالة-بيانات-exif"
+"redact-image" = "طمس-الصورة"
+"images-to-pdf" = "تحويل-الصور-إلى-pdf"
+"images-to-video" = "تحويل-الصور-إلى-فيديو"
+"resize-image" = "تغيير-حجم-الصورة"
+"trim-video" = "تقصير-الفيديو"
+"image-to-ico" = "إنشاء-فافيكون"
+"svg-to-image" = "تحويل-svg-إلى-png"
+"heic-to-jpg" = "تحويل-heic-إلى-jpg"
+"image-to-data-uri" = "تحويل-الصورة-إلى-base64"
+"qr-barcode" = "إنشاء-رمز-qr"
+"qr-barcode-reader" = "مسح-رمز-qr"
+"video-to-gif" = "تحويل-الفيديو-إلى-gif"
+"gif-analyzer" = "تحليل-gif"
+"gif-maker" = "إنشاء-gif"
+"grab-frame" = "استخراج-لقطة-من-الفيديو"
+"id-photo" = "صورة-شخصية-بيومترية"
+"merge-pdf" = "دمج-pdf"
+"reverse-video" = "تشغيل-الفيديو-عكسيا"
+"split-gif" = "تقسيم-gif-إلى-إطارات"
+"text-tools" = "تنسيق-json"
+"trim-audio" = "قص-الصوت"
+"password-generator" = "مولد-كلمات-المرور"
+"timelapse-video" = "إنشاء-فيديو-تايم-لابس"
+"hash-checksum" = "حساب-قيمة-التجزئة"
+
+# The indexes and the legal pages.
+"guides" = "أدلة"
+"roadmap" = "خارطة-الطريق"
+"privacy" = "الخصوصية"
+"terms" = "شروط-الاستخدام"
+
+# The guides. Each one keeps the "أدلة/" prefix written out, the same way the
+# German list keeps "ratgeber/" on every line - the parent slug above is not
+# inherited automatically, so it is repeated here.
+"guides/compress-an-image-to-a-target-size" = "أدلة/ضغط-الصورة-إلى-حجم-محدد"
+"guides/resize-an-image" = "أدلة/تغيير-حجم-الصورة"
+"guides/remove-exif-and-gps-data" = "أدلة/إزالة-بيانات-exif-و-gps"
+"guides/redact-an-image" = "أدلة/طمس-الصورة"
+"guides/make-a-pdf-smaller" = "أدلة/تصغير-حجم-pdf"
+"guides/combine-images-into-a-pdf" = "أدلة/دمج-الصور-في-pdf"
+"guides/turn-images-into-a-video" = "أدلة/تحويل-الصور-إلى-فيديو"
+"guides/trim-a-video" = "أدلة/تقصير-الفيديو"
+"guides/crop-a-video" = "أدلة/اقتصاص-الفيديو"
+"guides/is-it-safe-to-upload-files" = "أدلة/هل-رفع-الملفات-آمن"
+"guides/make-a-favicon" = "أدلة/إنشاء-فافيكون"
+"guides/convert-an-svg-to-png" = "أدلة/تحويل-svg-إلى-png"
+"guides/convert-heic-to-jpg" = "أدلة/تحويل-heic-إلى-jpg"
+"guides/embed-an-image-in-css" = "أدلة/تضمين-صورة-في-css"
+"guides/make-a-qr-code" = "أدلة/إنشاء-رمز-qr"
+"guides/turn-a-video-into-a-gif" = "أدلة/تحويل-الفيديو-إلى-gif"
+"guides/format-json-without-uploading-it" = "أدلة/تنسيق-json-دون-رفعه"
+"guides/grab-a-frame-from-a-video" = "أدلة/استخراج-لقطة-من-فيديو"
+"guides/make-a-gif-from-images" = "أدلة/إنشاء-gif-من-الصور"
+"guides/make-a-passport-photo" = "أدلة/عمل-صورة-شخصية-بيومترية"
+"guides/merge-and-split-pdf-files" = "أدلة/دمج-وتقسيم-ملفات-pdf"
+"guides/reverse-a-video" = "أدلة/تشغيل-الفيديو-عكسيا"
+"guides/split-a-gif-into-frames" = "أدلة/تقسيم-gif-إلى-إطارات"
+"guides/trim-an-audio-file" = "أدلة/قص-ملف-صوتي"
+"guides/whats-inside-a-gif" = "أدلة/ماذا-يوجد-داخل-gif"
+"guides/verify-a-file-checksum" = "أدلة/التحقق-من-قيمة-تجزئة-الملف"
+
+#
+# ---------------------------------------------------------------------------
+# The hub.
+# ---------------------------------------------------------------------------
+#
+
+[hub]
+title = "أدوات مجانية في المتصفح &mdash; بلا رفع، بلا تسجيل | abox.tools"
+description = "أدوات مجانية تعمل داخل متصفحك ولا ترفع ملفاتك أبدا. اجمع صورا في ملف PDF أو فيديو، اضغط صورة إلى حجم محدد بدقة، اقتصّ فيديو، أو احذف بيانات EXIF."
+heading = "صندوق أدوات لا يلامس خادما أبدا"
+og_title = "A Box of Tools &mdash; صندوق أدوات لا يلامس خادما أبدا"
+og_description = "أدوات صغيرة، كل واحدة لمهمة واحدة، تعمل بالكامل داخل متصفحك. ملفاتك لا تغادر جهازك أبدا."
+og_image_alt = "abox.tools - صندوق أدوات لا يلامس خادما أبدا"
+schema_description = "أدوات صغيرة، كل واحدة لمهمة واحدة، تنجز كل عملها داخل المتصفح. لا شيء يُرفع، ولا حاجة إلى حساب."
+schema_about = "أدوات متصفح لمعالجة الملفات محليا دون رفعها"
+
+lede = """
+    أدوات صغيرة، كل واحدة لمهمة واحدة، تنجز كل عملها داخل متصفحك. ملفاتك
+    تبقى على جهازك: لا شيء تحتاج إلى رفعه، ولا حساب عليك إنشاؤه، ولا شيء
+    يُتابَع."""
+
+support_note = """
+      هذه الأدوات مجانية وستبقى كذلك. إن وفّرت عليك إحداها عملا، فهذا هو
+      الموضع الوحيد في الموقع الذي يطلب منك شيئا."""
+
+[[hub.guarantees]]
+title = "ملفاتك لا تغادر جهازك أبدا"
+body = """
+        يفتحها متصفحك ويقرؤها ويعالجها بنفسه، على عتادك الخاص. تحدد
+        <code>Content-Security-Policy</code> الخاصة بكل أداة كل عنوان يحق
+        لها الاتصال به، ولا واحد منها يخصنا."""
+
+[[hub.guarantees]]
+title = "لا شيء عن ملفاتك يُرسَل إلى أي مكان"
+body = """
+        لا الملف، ولا صورة مصغرة عنه، ولا اسمه، ولا حجمه، ولا عددها. لا
+        تقرأ أي أداة هنا شيئا من ذلك، ولا يوجد خادم في الطرف الآخر
+        ليستقبله أصلا."""
+
+[[hub.guarantees]]
+title = "تعمل دون اتصال بالإنترنت"
+body = """
+        افتح أداة مرة واحدة، اقطع الاتصال بالإنترنت، وستواصل العمل على
+        ملفاتك كما كانت. يصعب تزييف هذا: أداة ترسل ملفاتك إلى مكان آخر
+        لمعالجتها كانت ستتوقف عن العمل فورا."""
+
+[[hub.categories]]
+id = "images"
+name = "الصور"
+note = "غيّر حجم صورة أو صغّرها أو احذف ما تكشفه بصمت عنك - لا شيء من ذلك يُرسَل إلى أي مكان."
+
+[[hub.categories]]
+id = "video-and-animation"
+name = "الفيديو والرسوم المتحركة"
+note = "قصّه أو حوّله أو ابنِ واحدا من صور ثابتة، دون أن يغادر المقطع جهازك."
+
+[[hub.categories]]
+id = "documents-and-audio"
+name = "المستندات والصوت"
+note = "أعد ترتيب مستند أو قصّ تسجيلا، دون إرسال أي منهما للمعالجة في مكان آخر."
+
+[[hub.categories]]
+id = "text-codes-and-passwords"
+name = "النصوص والرموز وكلمات المرور"
+note = "اقرأه أو تحقق منه أو أنشئه هنا - لا رمز وصول، ولا ملف إعدادات، ولا كلمة مرور تصل إلى خادم شخص آخر."
+
+#
+# ---------------------------------------------------------------------------
+# The guides index.
+# ---------------------------------------------------------------------------
+#
+
+[guides]
+nav = "كل الأدلة"
+title = "أدلة &mdash; كيف تنجز المهمة وما تكلفه كل إعداد"
+description = "أدلة واضحة لضغط ملفاتك وتغيير حجمها واقتصاصها وتحويلها. ماذا تعني الإعدادات، وماذا تكلف، ولماذا لا حاجة إلى رفعها."
+heading = "الأدلة"
+lede = """
+    دليل واحد لكل أداة، مكتوب لمن طُلب منه الوصول إلى حجم أو صيغة معينة
+    ويريد أن يعرف مسبقا ماذا يفعل الإعداد الذي يوشك على تحريكه. كل ما
+    يُشرح هنا يحدث على جهازك أنت."""
+og_title = "أدلة abox.tools"
+og_description = "كيف تضغط ملفاتك وتغيّر حجمها وتقتصّها وتقصّها وتحوّلها. وماذا تكلف كل خطوة. دون رفع أي شيء."
+og_image_alt = "abox.tools - صندوق أدوات لا يلامس خادما أبدا"
+
+[[guides.groups]]
+id = "doing-the-job"
+name = "إنجاز المهمة"
+note = "دليل واحد لكل أداة: عن ماذا تدور المهمة، وأي إعداد يهم، وماذا يكلف."
+
+[[guides.groups]]
+id = "before-you-upload"
+name = "قبل أن ترفع أي شيء"
+note = "ماذا يحدث فعلا حين تسلّم ملفا إلى موقع، وكيف تعرف إن كان ذلك ضروريا أصلا."
+
+#
+# ---------------------------------------------------------------------------
+# The roadmap.
+#
+# Only the frame. The list itself is config/planned.toml, and is not
+# translated yet - it stays English and falls back like any other page.
+# ---------------------------------------------------------------------------
+#
+
+[roadmap]
+nav = "خارطة الطريق"
+title = "خارطة الطريق &mdash; ما الذي يبنيه abox.tools تاليا"
+description = "كل أداة مخطط لها في abox.tools، مصنّفة ومعلَنة، مع الأدوات الجاهزة أصلا. كلها تعمل داخل المتصفح ولا ترفع شيئا."
+heading = "ما القادم"
+lede = """
+    كل ما في القائمتين أدناه ينجز عمله داخل متصفحك ولا يرفع شيئا &mdash;
+    هذا هو الشرط الذي يجب أن يجتازه أي اسم قبل أن يصل إلى هذه الصفحة
+    أصلا. الأعداد غير مكتوبة في أي مكان؛ يحسبها البناء من القائمتين
+    نفسيهما."""
+
+intro_heading = "كيف أُعدّت هذه القائمة"
+intro = """
+    <p>
+      ليست قائمة أمنيات. أُعدّت بمراجعة قائمة الأدوات في أكبر موقع
+      للصور المتحركة GIF ومقاطع الفيديو على الإنترنت، وهي أقرب ما
+      يوجد إلى فهرس لما يريد الناس فعله فعليا بملف، مع الإبقاء على كل
+      اسم يمكن بناؤه بحيث يحدث العمل على جهازك أنت ويستمر مع قطع
+      الاتصال بالشبكة.
+    </p>
+    <p>
+      معظم ما بقي يعمل بواجهات يوفرها المتصفح أصلا. بعضها يحتاج مرمّزا
+      (codec) مضمّنا في الأداة الوحيدة التي تستخدمه، وهذا مسموح به
+      &mdash; فالملف مع ذلك لا يغادر الجهاز. وما لا يجتاز هذا الشرط
+      تُرك دون وعد به، فبعض الفراغات الواضحة أدناه مقصودة.
+    </p>
+    <p>
+      الأدوات الموجودة أصلا تقف أعلى مجموعتها، موسومة بـ
+      <em>جاهزة</em> ومرتبطة بصفحتها الخاصة. كل ما تحتها لا يزال
+      قادما، ولن يصبح رابطا حتى يجهز.
+    </p>"""
+
+planned_heading = "كل نوع ملف، وما يمكن فعله به"
+
+og_title = "خارطة طريق abox.tools"
+og_description = "ما هو جاهز، وما القادم تاليا. كل شيء يعمل داخل متصفحك ولا يرفع شيئا."
+og_image_alt = "abox.tools - صندوق أدوات لا يلامس خادما أبدا"
+
+#
+# ---------------------------------------------------------------------------
+# The 404.
+#
+# Built in English only - GitHub Pages serves one file for the whole domain
+# and cannot know which language was being looked for - so nothing here is
+# used today. Translated anyway, for the same reason German's copy is.
+# ---------------------------------------------------------------------------
+#
+
+[not_found]
+title = "الصفحة غير موجودة &mdash; abox.tools"
+description = "هذا العنوان غير موجود على abox.tools. هذه هي الأدوات الموجودة فعلا. كلها مجانية، ولا واحدة منها ترفع ملفاتك إلى أي مكان."
+heading = "هذه الصفحة غير موجودة هنا"
+tools_heading = "كل الأدوات في مكان واحد"
+tools_note = "كلها مجانية، وكلها تعمل داخل متصفحك، ولا واحدة منها ترفع شيئا."
+
+lede = """
+    إما أن في العنوان خطأ إملائيا، أو أن ما كان في هذا الموضع قد انتقل.
+    لا شيء حدث لملفك ولا شيء ضاع: هذه الصفحة لم تحمل يوما شيئا يخصك
+    لتفقده."""
+
+#
+# ---------------------------------------------------------------------------
+# The footer.
+# ---------------------------------------------------------------------------
+#
+
+[footer]
+blurb = """
+        أدوات لا تلامس خادما أبدا. ملفاتك تبقى على جهازك &mdash; لا
+        شيء تحتاج إلى رفعه، ولا حساب عليك إنشاؤه."""
+base = "كل ادعاء في هذا الموقع مُعَدّ ليُتحقَّق منه، لا ليُصدَّق."
+
+#
+# ---------------------------------------------------------------------------
+# The frame's own words.
+#
+# Everything with {{ }} in it is a name the build resolves, and the build
+# refuses to render a name it cannot find - so these may be moved anywhere in
+# the sentence, and may not be renamed.
+# ---------------------------------------------------------------------------
+#
+
+[ui]
+languages = "اللغة"
+lang_auto = "تُعرَض هذه الصفحة بالإنجليزية، اللغة التي يفضّلها متصفحك."
+breadcrumb = "مسار التصفح"
+all_tools = "كل الأدوات"
+last_updated = "آخر تحديث"
+built_tag = "جاهزة"
+planned_count = "مخطَّط لها"
+built_count = "جاهزة"
+
+# See the house-style note at the top of this file: the count this site shows
+# is always past ten, so both forms carry the same bare singular noun, which
+# is the grammatically correct Arabic form for 11-99.
+guide_one = "دليل"
+guide_many = "دليل"
+
+footer_tools = "الأدوات"
+footer_site = "هذا الموقع"
+footer_contact = "تواصل معنا"
+footer_sitemap = "خريطة الموقع"
+footer_source = "اقرأ الشيفرة المصدرية على GitHub"
+
+guarantees_note = """
+    لا شيء من هذا عليك تصديقه دون تحقق.
+    <a href="{{ base }}{{ links.safety_guide }}/">
+      كيف تعرف ما إذا كانت أداة ما تحتاج فعلا إلى ملفاتك</a>
+    يعرض أربعة اختبارات يمكنك إجراؤها بنفسك، على هذا الموقع أو على أي
+    موقع آخر."""
+
+hub_guides_note = """
+    لست متأكدا أي إعداد تحرك أو ماذا يكلف؟
+    <a href="{{ base }}{{ links.guides }}/">لكل أداة دليل خاص بها</a>."""
+
+hub_roadmap_note = """
+    المزيد قادم، والقائمة معلَنة:
+    <a href="{{ base }}{{ links.roadmap }}/">اطّلع على المخطَّط تاليا</a>."""
+
+guides_all_note = """
+    كل دليل هنا يصف أداة تعمل على جهازك أنت:
+    <a href="{{ base }}">شاهدها كلها</a>."""
+
+[ui.tool]
+view_source = "عرض الشيفرة المصدرية"
+how_verified = "كيف يمكن التحقق من هذا"
+live_check = "فحص حي:"
+offline = "دون اتصال:"
+checking = "جارٍ الفحص&hellip;"
+questions_heading = "أسئلة"
+guide_heading = "النسخة الأطول"
+related_heading = "أيضا في الصندوق"
+privacy_heading = "كيف يمكن التحقق من وعد الخصوصية"
+
+pledge_line = """
+    {{ tool.words.plural }} لا تُرفع <strong>أبدا</strong>. لا يوجد خادم."""
+
+boot_title = "شيفرة هذه الصفحة لم تبدأ العمل."
+boot_body = """
+    فتح <code>index.html</code> مباشرة من مجلد يمنع المتصفح من تحميل وحدات
+    JavaScript، فلا يحدث شيء عند اختيار {{ tool.words.choose }}. قدّم
+    المجلد عبر HTTP بدلا من ذلك:"""
+boot_then = "ثم افتح <code>http://localhost:8080/</code>."
+
+noscript_title = "JavaScript معطَّل."
+noscript_body = "ينجز هذا التطبيق كل عمله داخل متصفحك، ولا يمكنه العمل دونه."
+
+offline_ready = "جاهزة &mdash; اقطع الاتصال بالإنترنت وستظل تعمل."
+offline_none = "غير متاحة في هذا المتصفح (كل شيء آخر يظل يعمل)."
+offline_insecure = "تحتاج إلى https:// أو localhost للتخزين المؤقت دون اتصال."
+offline_failed = "التخزين المؤقت غير متاح هنا، لكن لا شيء يُرفع في الحالتين."
+
+error_broke = "حدث خطأ ما: {detail}. أعد تحميل الصفحة لتبدأ من جديد."
+
+reading_one = "جارٍ قراءة {count} ملف&hellip;"
+reading_many = "جارٍ قراءة {count} ملف&hellip;"
+
+check_yourself = """
+      <strong>تحقّق بنفسك.</strong> لا شيء مما سبق عليك تصديقه دون تحقق.
+      تُولَّد هذه الصفحة من القوالب والإعدادات في المستودع بواسطة سكربت بناء
+      يمكنك قراءته وتشغيله بنفسك، والنتيجة موجودة في فرع <code>dist</code>
+      &mdash; فقارِن إذن بين ما يُقدَّم فعلا وما ينتجه بناء المصادر:"""
+
+read_first_lead = """
+      الملفات الجديرة بالقراءة أولا هي <code>config/site.toml</code> من أجل
+      سياسة أمان المحتوى (Content-Security-Policy)"""
+
+[ui.feedback]
+prompt = "هل أنجزت المهمة؟"
+up = "نعم"
+down = "لا"
+dismiss = "إغلاق"
+
+reason_prompt = "ما الذي حدث خطأ؟"
+reason_wrong = "نتيجة خاطئة"
+reason_failed = "لم تكتمل"
+reason_slow = "بطيئة جدا"
+reason_confusing = "مربكة"
+
+thanks = "شكرا &mdash; هذا يساعد."
+
+note = """
+      يُرسَل الجواب فقط، وفقط عند الضغط على زر. لا يُرسَل ملفك أبدا،
+      ولا اسمه، ولا أي شيء عنه."""
+
+[ui.guide]
+open_tool = "افتح {{ tool.name | e }}"
+
+[ui.picker]
+warning = """
+      <strong>هذه هي الميزة الوحيدة هنا التي تتصل بالشبكة.</strong>
+      جلب عنوان يُطلع ذلك الخادم على عنوان IP الخاص بك وعلى {{ tool.picker.urls.noun }}
+      الذي طلبته. يُنسَخ {{ tool.picker.urls.noun }} إلى الذاكرة المحلية فور وصوله ولا
+      يُطلَب مرة أخرى. لا شيء مما يخصك يُرسَل إلى الخارج &mdash; هذه الصفحة
+      ما زالت غير قادرة على رفع أي شيء."""
+label = "عنوان واحد في كل سطر"
+note = """
+      يجب أن يسمح الخادم بالاستخدام العابر للنطاقات لـ{{ tool.picker.urls.noun }} الخاص به.
+      كثير من المواقع لا تسمح بذلك، وستفشل تلك برسالة بدل أن تتعطل بصمت
+      لاحقا."""

--- a/shared/css/file-list.css
+++ b/shared/css/file-list.css
@@ -35,7 +35,7 @@
   align-self: stretch;
   width: 2.4rem;
   border: none;
-  border-left: 1px solid var(--border);
+  border-inline-start: 1px solid var(--border);
   border-radius: 0;
   background: transparent;
   color: var(--text-dim);

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -62,6 +62,13 @@ body {
 
 h1, h2 { line-height: 1.25; }
 
+/* A path or a URL is Latin script sitting inside an Arabic sentence, and the
+   bidi algorithm alone still lets the punctuation in it - the slashes in
+   config/site.toml, the colon in http:// - drift out of order. Isolating the
+   run keeps it internally left-to-right no matter which way the sentence
+   around it reads. */
+code { unicode-bidi: isolate; }
+
 main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
   max-width: 940px;
   margin-inline: auto;
@@ -90,6 +97,11 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
   border-radius: 6px;
   font-size: 0.82rem;
   overflow-x: auto;
+  /* A shell command is authored left-to-right regardless of the language
+     reading it, so it is set explicitly rather than left to inherit
+     `dir="rtl"`. */
+  direction: ltr;
+  text-align: start;
 }
 
 .boot-warning code {
@@ -118,6 +130,11 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
 .crumbs a { color: var(--text-dim); text-decoration: none; }
 .crumbs a:hover { color: var(--accent); text-decoration: underline; }
 .crumbs [aria-current="page"] { color: var(--text); }
+
+/* The separator in the markup is &rsaquo;, a glyph that points one way. Its
+   meaning is "deeper into the trail", not "toward the right", so it is
+   mirrored rather than reworded when the trail itself reads the other way. */
+[dir="rtl"] .crumbs [aria-hidden="true"] { display: inline-block; transform: scaleX(-1); }
 
 /* ------------------------------------------------------------------ topbar */
 
@@ -298,7 +315,7 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
 }
 
 .privacy h2 { margin: 0 0 0.6rem; font-size: 1rem; }
-.privacy ul { margin: 0; padding-left: 1.1rem; }
+.privacy ul { margin: 0; padding-inline-start: 1.1rem; }
 .privacy li { margin-bottom: 0.35rem; font-size: 0.92rem; }
 .privacy code {
   background: var(--surface-2);
@@ -520,7 +537,7 @@ button, .as-button {
 
 .how-to {
   margin: 0;
-  padding-left: 1.2rem;
+  padding-inline-start: 1.2rem;
   display: grid;
   gap: 0.5rem;
   font-size: 0.92rem;
@@ -911,6 +928,10 @@ footer a:hover { text-decoration: underline; }
    read. */
 .lang-auto-back::after { content: "\00a0\2192"; }
 
+/* The arrow points forward through the sentence, and forward is the other
+   direction in a right-to-left page. */
+[dir="rtl"] .lang-auto-back::after { content: "\00a0\2190"; }
+
 /* The way back to the hub, with the site mark on it. It heads the brand column
    now rather than sitting inline in a sentence, so it is a flex row and carries
    its own weight and colour. */
@@ -925,7 +946,7 @@ footer a:hover { text-decoration: underline; }
 .site-logo {
   width: 1.35em;
   height: 1.35em;
-  margin-right: 0.15em;
+  margin-inline-end: 0.15em;
 }
 
 .logo-lid { stroke: var(--accent); }

--- a/shared/site.css
+++ b/shared/site.css
@@ -158,6 +158,12 @@ code {
   font-family: ui-monospace, SFMono-Regular, "Cascadia Mono", Consolas, monospace;
   font-size: 0.92em;
   overflow-wrap: anywhere;
+  /* A path or a URL is Latin script sitting inside an Arabic sentence, and
+     the bidi algorithm alone still lets the punctuation in it - the slashes
+     in config/site.toml, the colon in http:// - drift out of order. Isolating
+     the run keeps it internally left-to-right no matter which way the
+     sentence around it reads. */
+  unicode-bidi: isolate;
 }
 
 /* ---- categories -------------------------------------------------------- */
@@ -338,7 +344,7 @@ code {
 .site-logo {
   width: 1.35em;
   height: 1.35em;
-  margin-right: 0.15em;
+  margin-inline-end: 0.15em;
 }
 
 .logo-lid { stroke: var(--accent); }
@@ -368,6 +374,11 @@ code {
 .crumbs a { color: var(--text-dim); text-decoration: none; }
 .crumbs a:hover { color: var(--accent); text-decoration: underline; }
 .crumbs [aria-current="page"] { color: var(--text); }
+
+/* The separator in the markup is &rsaquo;, a glyph that points one way. Its
+   meaning is "deeper into the trail", not "toward the right", so it is
+   mirrored rather than reworded when the trail itself reads the other way. */
+[dir="rtl"] .crumbs [aria-hidden="true"] { display: inline-block; transform: scaleX(-1); }
 
 /* A guide with a crumb above it does not also need the header's usual gap. */
 .crumbs + .hub-head { padding-top: 1.5rem; }
@@ -459,7 +470,7 @@ code {
 }
 
 .legal p, .prose p { margin: 0 0 0.85rem; }
-.legal ul, .prose ul { margin: 0 0 0.95rem; padding-left: 1.25rem; }
+.legal ul, .prose ul { margin: 0 0 0.95rem; padding-inline-start: 1.25rem; }
 .legal li, .prose li { margin: 0.3rem 0; }
 .legal a, .prose a { color: var(--accent); }
 
@@ -477,6 +488,10 @@ code {
   border-radius: 8px;
   font-size: 0.86rem;
   line-height: 1.5;
+  /* A code block is authored left-to-right regardless of the language reading
+     it, so it is set explicitly rather than left to inherit `dir="rtl"`. */
+  direction: ltr;
+  text-align: start;
 }
 
 .legal pre code, .prose pre code { overflow-wrap: normal; }
@@ -727,6 +742,10 @@ footer a:hover { text-decoration: underline; }
    of the page around it would be the one word on the line the reader cannot
    read. */
 .lang-auto-back::after { content: "\00a0\2192"; }
+
+/* The arrow points forward through the sentence, and forward is the other
+   direction in a right-to-left page. */
+[dir="rtl"] .lang-auto-back::after { content: "\00a0\2190"; }
 
 /* The brand and the language control share the top line of the header. A flex
    row rather than the control positioned on top of the header, so that nothing

--- a/tools/compress-pdf/styles.css
+++ b/tools/compress-pdf/styles.css
@@ -220,7 +220,7 @@
 }
 
 .advanced[open] summary { border-bottom: 1px solid var(--border); }
-.advanced > *:not(summary) { margin-left: 0.9rem; margin-right: 0.9rem; }
+.advanced > *:not(summary) { margin-inline: 0.9rem; }
 .advanced > *:first-of-type:not(summary) { margin-top: 0.9rem; }
 .advanced > *:last-child:not(summary) { margin-bottom: 0.9rem; }
 
@@ -314,7 +314,7 @@ a.primary { text-decoration: none; display: inline-block; }
 
 .result-facts {
   margin: 0.8rem 0 0;
-  padding-left: 1.1rem;
+  padding-inline-start: 1.1rem;
   font-size: 0.87rem;
   line-height: 1.6;
   color: var(--text-dim);

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -23,7 +23,7 @@
 .source dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 
@@ -234,7 +234,7 @@
   display: flex;
   gap: 0.4rem;
   flex-wrap: wrap;
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .even-note {
@@ -284,7 +284,7 @@
 .summary dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   font-variant-numeric: tabular-nums;
 }
 

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -23,7 +23,7 @@
 .source dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 
@@ -92,7 +92,7 @@ audio {
 
 .value-box {
   width: 6.5rem;
-  text-align: right;
+  text-align: end;
   font-variant-numeric: tabular-nums;
   font-weight: 600;
 }
@@ -184,7 +184,7 @@ input[type="range"] {
 .summary dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
   font-variant-numeric: tabular-nums;
 }

--- a/tools/exif-editor/styles.css
+++ b/tools/exif-editor/styles.css
@@ -29,8 +29,12 @@
 
 .file-row.selected {
   border-color: var(--accent);
+  /* box-shadow has no logical offset, so the flip is a second rule rather
+     than a second property. */
   box-shadow: inset 3px 0 0 var(--accent);
 }
+
+[dir="rtl"] .file-row.selected { box-shadow: inset -3px 0 0 var(--accent); }
 
 .file-row.unreadable { border-color: color-mix(in srgb, var(--danger) 45%, var(--border)); }
 
@@ -46,7 +50,7 @@
   background: transparent;
   border: none;
   border-radius: 0;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
 }
 
@@ -259,23 +263,23 @@
   border-radius: var(--radius);
   border: 1px solid var(--border);
   background: var(--surface-2);
-  border-left-width: 4px;
+  border-inline-start-width: 4px;
 }
 
 .finding-high {
-  border-left-color: var(--danger);
+  border-inline-start-color: var(--danger);
   background: color-mix(in srgb, var(--danger) 7%, var(--surface));
 }
 
 .finding-medium {
-  border-left-color: var(--accent);
+  border-inline-start-color: var(--accent);
   background: color-mix(in srgb, var(--accent) 6%, var(--surface));
 }
 
-.finding-low { border-left-color: var(--text-dim); }
+.finding-low { border-inline-start-color: var(--text-dim); }
 
 .finding-clean {
-  border-left-color: var(--ok);
+  border-inline-start-color: var(--ok);
   background: color-mix(in srgb, var(--ok) 7%, var(--surface));
 }
 
@@ -380,7 +384,7 @@
 }
 
 .tag-table thead th {
-  text-align: left;
+  text-align: start;
   font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -401,12 +405,12 @@
 .tag-table tbody tr:last-child td { border-bottom: none; }
 
 .tag-table tbody th {
-  text-align: left;
+  text-align: start;
   font-weight: 600;
   white-space: nowrap;
 }
 
-.tag-name { margin-right: 0.4rem; }
+.tag-name { margin-inline-end: 0.4rem; }
 
 .tag-id {
   font: 0.74rem/1 ui-monospace, SFMono-Regular, Consolas, monospace;
@@ -416,7 +420,7 @@
 /* Same three levels as the badges, so a colour means one thing on this page. */
 .tag-risk {
   display: inline-block;
-  margin-right: 0.4rem;
+  margin-inline-end: 0.4rem;
   font-size: 0.68rem;
   font-weight: 700;
   text-transform: uppercase;
@@ -461,7 +465,7 @@
   overflow-wrap: anywhere;
 }
 
-.tag-actions { text-align: right; }
+.tag-actions { text-align: end; }
 
 .tag-delete {
   border: 1px solid var(--border);

--- a/tools/gif-analyzer/styles.css
+++ b/tools/gif-analyzer/styles.css
@@ -91,7 +91,7 @@
 .facts dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 .facts dd.warn { color: var(--danger); }
@@ -105,16 +105,16 @@
   gap: 0.7rem;
   padding: 0.7rem 0.8rem;
   border: 1px solid var(--border);
-  border-left-width: 3px;
+  border-inline-start-width: 3px;
   border-radius: 7px;
   margin-bottom: 0.6rem;
   font-size: 0.9rem;
   background: var(--surface-2);
 }
 
-.finding.bad { border-left-color: var(--danger); }
-.finding.warn { border-left-color: #c08a2b; }
-.finding.note { border-left-color: var(--accent); }
+.finding.bad { border-inline-start-color: var(--danger); }
+.finding.warn { border-inline-start-color: #c08a2b; }
+.finding.note { border-inline-start-color: var(--accent); }
 
 .finding-mark { flex: none; font-size: 0.9rem; line-height: 1.5; }
 .finding.bad .finding-mark { color: var(--danger); }
@@ -149,7 +149,7 @@
   width: 10px;
   height: 10px;
   border-radius: 2px;
-  margin-right: 0.5rem;
+  margin-inline-end: 0.5rem;
   flex: none;
 }
 
@@ -172,7 +172,7 @@
 }
 
 .budget th, .budget td {
-  text-align: left;
+  text-align: start;
   padding: 0.5rem 0.4rem;
   border-bottom: 1px solid var(--border);
   vertical-align: top;
@@ -194,7 +194,7 @@
 }
 
 .budget .num {
-  text-align: right;
+  text-align: end;
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
@@ -203,7 +203,7 @@
 
 .budget-note {
   flex-basis: 100%;
-  margin-left: 1.1rem;
+  margin-inline-start: 1.1rem;
   margin-top: 0.15rem;
   font-weight: 400;
   color: var(--text-dim);
@@ -270,7 +270,7 @@
 }
 
 .frame-facts dt { color: var(--text-dim); flex: none; }
-.frame-facts dd { margin: 0; text-align: right; overflow-wrap: anywhere; }
+.frame-facts dd { margin: 0; text-align: end; overflow-wrap: anywhere; }
 
 .more-row { margin-top: 1rem; }
 

--- a/tools/gif-maker/styles.css
+++ b/tools/gif-maker/styles.css
@@ -14,10 +14,10 @@
   background: transparent;
   padding: 0.35rem 0.65rem;
   font-size: 0.82rem;
-  border-right: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
 }
 
-.view-switch button:last-child { border-right: none; }
+.view-switch button:last-child { border-inline-end: none; }
 .view-switch button:hover { background: var(--surface-2); }
 
 .view-switch button.active {
@@ -81,8 +81,8 @@
   z-index: 3;
 }
 
-.frame-item.insert-before::after { left: -7px; }
-.frame-item.insert-after::after { right: -7px; }
+.frame-item.insert-before::after { inset-inline-start: -7px; }
+.frame-item.insert-after::after { inset-inline-end: -7px; }
 
 /* ------------------------------------------------------------- drag handle */
 
@@ -90,7 +90,7 @@
   position: absolute;
   z-index: 2;
   top: 0.35rem;
-  left: 0.35rem;
+  inset-inline-start: 0.35rem;
   display: grid;
   place-items: center;
   width: 1.75rem;
@@ -141,7 +141,7 @@
 .order-badge {
   position: absolute;
   top: 0.35rem;
-  left: 0.35rem;
+  inset-inline-start: 0.35rem;
   background: rgb(0 0 0 / 70%);
   color: #fff;
   font-size: 0.75rem;
@@ -153,7 +153,7 @@
 .remove-btn {
   position: absolute;
   top: 0.35rem;
-  right: 0.35rem;
+  inset-inline-end: 0.35rem;
   width: 1.5rem;
   height: 1.5rem;
   border: none;

--- a/tools/grab-frame/styles.css
+++ b/tools/grab-frame/styles.css
@@ -23,7 +23,7 @@
 .source dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 
@@ -88,7 +88,7 @@
    worse than no spinner at all. */
 .stage-busy {
   position: absolute;
-  left: 0.6rem;
+  inset-inline-start: 0.6rem;
   bottom: 0.6rem;
   margin: 0;
   padding: 0.2rem 0.5rem;
@@ -133,7 +133,7 @@
 .readout-dim {
   color: var(--text-dim);
   font-weight: 400;
-  margin-left: 0.4rem;
+  margin-inline-start: 0.4rem;
 }
 
 /* ---------------------------------------------------------------- settings */

--- a/tools/heic-to-jpg/styles.css
+++ b/tools/heic-to-jpg/styles.css
@@ -102,7 +102,7 @@
   width: 2.5rem;
   font-size: 0.95rem;
   font-weight: 700;
-  text-align: right;
+  text-align: end;
   font-variant-numeric: tabular-nums;
 }
 

--- a/tools/id-photo/styles.css
+++ b/tools/id-photo/styles.css
@@ -100,7 +100,7 @@
 
 .spec-notes {
   margin: 0 0 0.9rem;
-  padding-left: 1.1rem;
+  padding-inline-start: 1.1rem;
   font-size: 0.86rem;
   line-height: 1.6;
   color: var(--text-dim);
@@ -117,8 +117,8 @@
   line-height: 1.55;
   color: var(--text-dim);
   max-width: 74ch;
-  border-left: 3px solid var(--border);
-  padding-left: 0.7rem;
+  border-inline-start: 3px solid var(--border);
+  padding-inline-start: 0.7rem;
 }
 
 .custom-panel {

--- a/tools/image-to-data-uri/styles.css
+++ b/tools/image-to-data-uri/styles.css
@@ -197,8 +197,8 @@
   line-height: 1.55;
   max-width: 62ch;
   color: var(--text);
-  border-left: 3px solid var(--accent);
-  padding-left: 0.6rem;
+  border-inline-start: 3px solid var(--accent);
+  padding-inline-start: 0.6rem;
 }
 
 .result-actions { display: flex; gap: 0.4rem; align-items: flex-start; flex-wrap: wrap; }

--- a/tools/images-to-pdf/styles.css
+++ b/tools/images-to-pdf/styles.css
@@ -46,14 +46,14 @@
   z-index: 3;
 }
 
-.image-item.insert-before::after { left: -7px; }
-.image-item.insert-after::after { right: -7px; }
+.image-item.insert-before::after { inset-inline-start: -7px; }
+.image-item.insert-after::after { inset-inline-end: -7px; }
 
 .drag-handle {
   position: absolute;
   z-index: 2;
   top: 0.35rem;
-  left: 0.35rem;
+  inset-inline-start: 0.35rem;
   display: grid;
   place-items: center;
   width: 1.75rem;
@@ -104,7 +104,7 @@
 .order-badge {
   position: absolute;
   bottom: 0.35rem;
-  left: 0.35rem;
+  inset-inline-start: 0.35rem;
   background: rgb(0 0 0 / 70%);
   color: #fff;
   font-size: 0.75rem;
@@ -116,7 +116,7 @@
 .remove-btn {
   position: absolute;
   top: 0.35rem;
-  right: 0.35rem;
+  inset-inline-end: 0.35rem;
   width: 1.5rem;
   height: 1.5rem;
   border: none;
@@ -289,7 +289,7 @@
 }
 .summary > div:last-child { border-bottom: none; }
 .summary dt { color: var(--text-dim); }
-.summary dd { margin: 0; font-variant-numeric: tabular-nums; font-weight: 600; text-align: right; }
+.summary dd { margin: 0; font-variant-numeric: tabular-nums; font-weight: 600; text-align: end; }
 
 /* ------------------------------------------------------------------ export */
 

--- a/tools/images-to-video/styles.css
+++ b/tools/images-to-video/styles.css
@@ -14,10 +14,10 @@
   background: transparent;
   padding: 0.35rem 0.65rem;
   font-size: 0.82rem;
-  border-right: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
 }
 
-.view-switch button:last-child { border-right: none; }
+.view-switch button:last-child { border-inline-end: none; }
 .view-switch button:hover { background: var(--surface-2); }
 
 .view-switch button.active {
@@ -90,15 +90,14 @@
   width: 4px;
 }
 
-.view-large .insert-before::after, .view-small .insert-before::after { left: -7px; }
-.view-large .insert-after::after,  .view-small .insert-after::after  { right: -7px; }
+.view-large .insert-before::after, .view-small .insert-before::after { inset-inline-start: -7px; }
+.view-large .insert-after::after,  .view-small .insert-after::after  { inset-inline-end: -7px; }
 
 .view-list .insert-before::after,
 .view-list .insert-after::after,
 .view-details .insert-before::after,
 .view-details .insert-after::after {
-  left: -2px;
-  right: -2px;
+  inset-inline: -2px;
   height: 4px;
 }
 
@@ -137,12 +136,12 @@
 
 /* Sits over the thumbnail in grid views, inline in the row views. */
 .view-large .drag-handle,
-.view-small .drag-handle { top: 0.35rem; left: 0.35rem; }
+.view-small .drag-handle { top: 0.35rem; inset-inline-start: 0.35rem; }
 
 .view-small .drag-handle { width: 1.5rem; height: 1.5rem; font-size: 0.8rem; }
 
 .view-list .drag-handle,
-.view-details .drag-handle { position: static; flex: none; margin-right: 0.1rem; }
+.view-details .drag-handle { position: static; flex: none; margin-inline-end: 0.1rem; }
 
 .thumb-wrap {
   position: relative;
@@ -167,7 +166,7 @@
 .order-badge {
   position: absolute;
   top: 0.35rem;
-  left: 0.35rem;
+  inset-inline-start: 0.35rem;
   background: rgb(0 0 0 / 70%);
   color: #fff;
   font-size: 0.75rem;
@@ -179,7 +178,7 @@
 .remove-btn {
   position: absolute;
   top: 0.35rem;
-  right: 0.35rem;
+  inset-inline-end: 0.35rem;
   width: 1.5rem;
   height: 1.5rem;
   border: none;

--- a/tools/merge-pdf/styles.css
+++ b/tools/merge-pdf/styles.css
@@ -136,14 +136,14 @@
   z-index: 3;
 }
 
-.page-item.insert-before::after { left: -6px; }
-.page-item.insert-after::after { right: -6px; }
+.page-item.insert-before::after { inset-inline-start: -6px; }
+.page-item.insert-after::after { inset-inline-end: -6px; }
 
 .drag-handle {
   position: absolute;
   z-index: 2;
   top: 0.35rem;
-  left: 0.35rem;
+  inset-inline-start: 0.35rem;
   display: grid;
   place-items: center;
   width: 1.6rem;
@@ -206,7 +206,7 @@
 .turn-badge {
   position: absolute;
   bottom: 0.15rem;
-  right: 0.2rem;
+  inset-inline-end: 0.2rem;
   font-size: 0.65rem;
   font-weight: 700;
   color: var(--accent-deep);
@@ -215,7 +215,7 @@
 .remove-btn {
   position: absolute;
   top: 0.35rem;
-  right: 0.35rem;
+  inset-inline-end: 0.35rem;
   width: 1.5rem;
   height: 1.5rem;
   border: none;
@@ -381,7 +381,7 @@ a.primary { text-decoration: none; display: inline-block; }
 
 .result-facts {
   margin: 0.8rem 0 0;
-  padding-left: 1.1rem;
+  padding-inline-start: 1.1rem;
   font-size: 0.87rem;
   line-height: 1.6;
   color: var(--text-dim);

--- a/tools/password-generator/styles.css
+++ b/tools/password-generator/styles.css
@@ -74,7 +74,7 @@
 
 .slider-row output {
   min-width: 2.6rem;
-  text-align: right;
+  text-align: end;
   font-variant-numeric: tabular-nums;
   font-weight: 700;
   font-size: 1.05rem;

--- a/tools/qr-barcode-reader/styles.css
+++ b/tools/qr-barcode-reader/styles.css
@@ -249,7 +249,8 @@ kbd {
 
 .result-warnings li {
   position: relative;
-  padding: 0.6rem 0.8rem 0.6rem 2.2rem;
+  padding-block: 0.6rem;
+  padding-inline: 2.2rem 0.8rem;
   border-radius: 7px;
   font-size: 0.86rem;
   line-height: 1.55;
@@ -260,7 +261,7 @@ kbd {
 .result-warnings li::before {
   content: "\26A0";
   position: absolute;
-  left: 0.8rem;
+  inset-inline-start: 0.8rem;
   top: 0.55rem;
   font-size: 0.95rem;
 }

--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -322,7 +322,7 @@ kbd {
   border: 0;
   background: none;
   color: var(--text-dim);
-  text-align: left;
+  text-align: start;
   font: inherit;
   font-variant-numeric: tabular-nums;
   cursor: pointer;
@@ -378,7 +378,7 @@ kbd {
 
 .result-facts {
   margin: 0.7rem 0 0;
-  padding-left: 1.1rem;
+  padding-inline-start: 1.1rem;
   font-size: 0.85rem;
   line-height: 1.6;
   color: var(--text-dim);

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -38,7 +38,7 @@
   padding: 0.6rem 0.7rem;
   font: inherit;
   color: inherit;
-  text-align: left;
+  text-align: start;
   background: none;
   border: none;
   border-radius: 0;
@@ -91,11 +91,15 @@ button.file-main-wrap:focus-visible {
 .file-shown {
   border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
   background: color-mix(in srgb, var(--accent) 10%, var(--surface-2));
+  /* box-shadow has no logical offset, so the flip is a second rule rather
+     than a second property. */
   box-shadow: inset 4px 0 0 var(--accent);
 }
 
+[dir="rtl"] .file-shown { box-shadow: inset -4px 0 0 var(--accent); }
+
 .file-shown .file-name { color: var(--accent); }
-.file-shown .file-main-wrap { padding-left: 0.95rem; }
+.file-shown .file-main-wrap { padding-inline-start: 0.95rem; }
 
 .file-badge {
   flex: none;
@@ -340,7 +344,7 @@ button.file-main-wrap:focus-visible {
   display: flex;
   gap: 0.4rem;
   flex-wrap: wrap;
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .apply-row {
@@ -661,7 +665,7 @@ button.file-main-wrap:focus-visible {
 .viewer-facts dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   word-break: break-word;
   font-variant-numeric: tabular-nums;
 }
@@ -677,7 +681,7 @@ button.file-main-wrap:focus-visible {
 
 @media (max-width: 620px) {
   .numbers input { width: 5.2rem; }
-  .number-actions { margin-left: 0; }
+  .number-actions { margin-inline-start: 0; }
   .viewer { width: 100vw; max-width: 100vw; max-height: 100vh; border-radius: 0; }
   .viewer-stage { max-height: 52vh; }
   .viewer-stage img { max-height: 48vh; }

--- a/tools/reverse-video/styles.css
+++ b/tools/reverse-video/styles.css
@@ -23,7 +23,7 @@
 .source dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 
@@ -101,7 +101,7 @@
 .summary dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   font-variant-numeric: tabular-nums;
 }
 

--- a/tools/split-gif/styles.css
+++ b/tools/split-gif/styles.css
@@ -23,7 +23,7 @@
 .source dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 

--- a/tools/text-tools/styles.css
+++ b/tools/text-tools/styles.css
@@ -199,7 +199,7 @@ textarea:focus-visible, .output:focus-visible {
 
 .ln {
   padding: 0 0.5rem;
-  text-align: right;
+  text-align: end;
   color: var(--text-dim);
   background: color-mix(in srgb, var(--border) 25%, transparent);
   user-select: none;

--- a/tools/timelapse-video/styles.css
+++ b/tools/timelapse-video/styles.css
@@ -42,7 +42,7 @@
 .source dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 
@@ -157,7 +157,7 @@
 .summary dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   font-variant-numeric: tabular-nums;
 }
 

--- a/tools/trim-audio/styles.css
+++ b/tools/trim-audio/styles.css
@@ -23,7 +23,7 @@
 .source dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 
@@ -49,7 +49,7 @@ kbd {
 }
 
 .editing {
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
   font-size: 0.8rem;
   font-weight: 400;
   color: var(--text-dim);
@@ -232,7 +232,7 @@ audio.player {
 }
 
 .transport button { padding: 0.4rem 0.9rem; font-size: 0.86rem; }
-.transport kbd { margin-right: 0.3rem; }
+.transport kbd { margin-inline-end: 0.3rem; }
 
 .speed-row {
   margin-top: 0.6rem;
@@ -242,7 +242,7 @@ audio.player {
   align-items: center;
 }
 
-.speed-label { font-size: 0.8rem; color: var(--text-dim); margin-right: 0.2rem; }
+.speed-label { font-size: 0.8rem; color: var(--text-dim); margin-inline-end: 0.2rem; }
 
 .speed {
   padding: 0.25rem 0.6rem;
@@ -282,7 +282,7 @@ audio.player {
 .segments-head h3 { margin: 0; font-size: 1rem; }
 
 .segment-count {
-  margin-left: 0.35rem;
+  margin-inline-start: 0.35rem;
   font-size: 0.8rem;
   font-weight: 400;
   color: var(--text-dim);
@@ -305,7 +305,7 @@ audio.player {
 }
 
 .segment-table th {
-  text-align: left;
+  text-align: start;
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--text-dim);
@@ -432,7 +432,7 @@ audio.player {
 }
 
 .summary dt { color: var(--text-dim); flex: none; }
-.summary dd { margin: 0; font-weight: 600; text-align: right; overflow-wrap: anywhere; }
+.summary dd { margin: 0; font-weight: 600; text-align: end; overflow-wrap: anywhere; }
 
 /* ------------------------------------------------------------------ export */
 

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -45,8 +45,12 @@
    thumbnail beside it still reads as a picture. */
 .clip.selected {
   border-color: var(--accent);
+  /* box-shadow has no logical offset, so the flip is a second rule rather
+     than a second property. */
   box-shadow: inset 3px 0 0 var(--accent);
 }
+
+[dir="rtl"] .clip.selected { box-shadow: inset -3px 0 0 var(--accent); }
 
 .clip-shot {
   flex: none;
@@ -84,7 +88,7 @@
   font: inherit;
   font-weight: 600;
   font-size: 0.9rem;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -105,7 +109,7 @@
 }
 
 .editing {
-  margin-left: 0.5rem;
+  margin-inline-start: 0.5rem;
   font-size: 0.8rem;
   font-weight: 400;
   color: var(--text-dim);
@@ -292,7 +296,7 @@ kbd {
 }
 
 .transport button { padding: 0.4rem 0.9rem; font-size: 0.86rem; }
-.transport kbd { margin-right: 0.3rem; }
+.transport kbd { margin-inline-end: 0.3rem; }
 
 .speed-row {
   margin-top: 0.6rem;
@@ -302,7 +306,7 @@ kbd {
   align-items: center;
 }
 
-.speed-label { font-size: 0.8rem; color: var(--text-dim); margin-right: 0.2rem; }
+.speed-label { font-size: 0.8rem; color: var(--text-dim); margin-inline-end: 0.2rem; }
 
 .speed {
   padding: 0.25rem 0.6rem;
@@ -342,7 +346,7 @@ kbd {
 .segments-head h3 { margin: 0; font-size: 1rem; }
 
 .segment-count {
-  margin-left: 0.35rem;
+  margin-inline-start: 0.35rem;
   font-size: 0.8rem;
   font-weight: 400;
   color: var(--text-dim);
@@ -365,7 +369,7 @@ kbd {
 }
 
 .segment-table th {
-  text-align: left;
+  text-align: start;
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--text-dim);
@@ -494,7 +498,7 @@ kbd {
 }
 
 .summary dt { color: var(--text-dim); flex: none; }
-.summary dd { margin: 0; font-weight: 600; text-align: right; overflow-wrap: anywhere; }
+.summary dd { margin: 0; font-weight: 600; text-align: end; overflow-wrap: anywhere; }
 
 /* ------------------------------------------------------------------ export */
 
@@ -580,7 +584,7 @@ kbd {
 @media (max-width: 620px) {
   .clip { flex-wrap: wrap; }
   .clip-body { flex-basis: 100%; order: 3; }
-  .clip-actions { margin-left: auto; }
+  .clip-actions { margin-inline-start: auto; }
   .tl-handle { width: 16px; }
   .tl-handle-start { left: -9px; }
   .tl-handle-end { right: -9px; }

--- a/tools/video-to-gif/styles.css
+++ b/tools/video-to-gif/styles.css
@@ -23,7 +23,7 @@
 .source dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   overflow-wrap: anywhere;
 }
 
@@ -142,6 +142,9 @@
   top: -6px;
   bottom: -6px;
   width: 2px;
+  /* Left, not inline-start: a scrub bar reads its `left` in pixels from
+     JavaScript and stays oriented start-to-end of the clip in every
+     language, the same way a video timeline does everywhere else. */
   margin-left: -1px;
   background: var(--text);
   pointer-events: none;
@@ -190,7 +193,7 @@
   display: flex;
   gap: 0.4rem;
   flex-wrap: wrap;
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 /* ---------------------------------------------------------------- settings */
@@ -234,7 +237,7 @@
 .summary dd {
   margin: 0;
   font-weight: 600;
-  text-align: right;
+  text-align: end;
   font-variant-numeric: tabular-nums;
 }
 


### PR DESCRIPTION
## What

- **`locales/ar/locale.toml`** — a new locale with `dir = "rtl"`, `complete = true`. Translates the frame (nav, footer, hub, guides index, roadmap frame, 404, every `[ui]` string) into Arabic, plus a full `[slugs]` table giving every tool and guide an Arabic-script address (e.g. `/ar/ضغط-الصور/`). Tool and guide pages are **not** translated in this PR and fall back to English page by page — the same state every other locale started in, and the build's own debt-tracking treats it that way (`ar: published, 57 of 57 pages still in English`).
- **RTL stylesheet pass.** README.md already documented `dir = "rtl"` as an option but flagged that "the stylesheets have not been written for it yet" — this is that work. Converted physical `left`/`right`/`margin-left`/`padding-left`/`border-left` rules that describe reading-order layout (card badges, drag-and-drop insertion markers, accent-stripe borders, table alignment, list indents) to logical properties across `shared/site.css`, `shared/css/tool-frame.css`, `shared/css/file-list.css`, and 24 tool stylesheets.

## What was deliberately left alone

Crop-box compass handles, image guide overlays, and video/audio timeline scrubbers/playheads stay physical (`left`/`right`), with a comment at each spot — those describe a picture's or a clip's own coordinates, not reading direction, and timelines conventionally stay left-to-right even in RTL apps.

## Other RTL fixes

- `[dir="rtl"]` overrides for the three `box-shadow` accent stripes CSS can't flip with a logical property.
- A mirrored breadcrumb separator (`&rsaquo;` flips via `transform: scaleX(-1)`) and a flipped "you were sent here" arrow.
- `unicode-bidi: isolate` on `<code>`, so an Arabic sentence containing a path or a URL (`config/site.toml`, `http://localhost:8080/`) doesn't get its punctuation visually reordered.

## Verification

- `python -m unittest discover -t . -s tests/python` — passes.
- `python build.py --clean --no-minify` — succeeds; log reports `ar: published, 57 of 57 pages still in English` (expected: frame is done, pages aren't).
- Live browser checks: `<html dir="rtl" lang="ar">` set correctly; breadcrumb separator and language-menu edge mirror correctly; crop-tool handles stay pinned to their real image edges instead of mirroring; English pages unaffected (`dir` absent, same layout as before).

## Follow-up (not in this PR)

Translating the 30 tools and 25 guides into Arabic, one page at a time — same incremental path every other locale is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)