### PR TITLE
Add Turkish, Indonesian and Traditional Chinese, and a locale-to-locale fallback

### DIFF
--- a/build.py
+++ b/build.py
@@ -225,8 +225,14 @@ def build(out, clean=False, minify_output=True, mangle_names=False):
             continue
         behind = i18n.debt_report(locale, tools, prose)
         if behind:
+            # A locale with `fallback` set shows its near relative's words on
+            # a page it has not translated itself, not English's - see
+            # buildlib/i18n.py. The count and the pages are the same either
+            # way: what changes is only what a reader sees while they wait.
+            near = locale['fallback_locale']
+            shows = f'still falling back to {near["lang"]}' if near else 'still in English'
             print(f'  {locale["lang"]}: published, {len(behind)} of '
-                  f'{len(tools) + len(prose)} pages still in English '
+                  f'{len(tools) + len(prose)} pages {shows} '
                   f'(built and readable, kept out of the sitemap): '
                   + ', '.join(sorted(behind)[:4])
                   + (' ...' if len(behind) > 4 else ''))

--- a/buildlib/i18n.py
+++ b/buildlib/i18n.py
@@ -97,6 +97,31 @@ Every language's debt is worked out by `survey` BEFORE any page is rendered,
 because the hreflang set on the English page is a fact about German. And an
 English body falling back inside German has its links rewritten by `relocate`,
 because it was written for a tree whose addresses are English.
+
+FALLING BACK TO A NEAR RELATIVE INSTEAD OF ENGLISH
+
+English is not the only sensible thing to fall back to. Traditional Chinese
+next to Simplified is the case this was built for: two scripts, one language,
+and a reader of one can make out the other far better than either can make
+out English. A locale names its near relative with `fallback` in
+locale.toml, `link_fallbacks` resolves the name once every locale is loaded,
+and `fallback_base` is where an untranslated key actually borrows the near
+relative's word instead of English's - the near relative's word if it has
+one, English's if it does not, so the chain never dead-ends.
+
+This changes what a reader SEES on an unfinished page. It changes nothing
+about what counts as FINISHED: `complete`, `debt`, `translated` and
+`published` are all still judged against this locale's own translation
+work, exactly as for a locale with no `fallback` - so a Traditional Chinese
+page showing Simplified Chinese prose is exactly as unfinished, and exactly
+as absent from the sitemap and the hreflang set, as one showing English
+would be. `fallback` is a courtesy to the reader of a half-built locale, not
+a second way to be complete.
+
+Only one level. `fallback` is refused if it names a locale that itself has a
+`fallback` - resolving a chain in dependency order is a real feature this
+does not need until a second locale wants to point at the first one that
+already borrows.
 """
 
 import posixpath
@@ -210,6 +235,7 @@ REQUIRED_LOCALE_KEYS = ('lang', 'name', 'endonym')
 
 RESERVED_LOCALE_KEYS = frozenset({
     'lang', 'name', 'endonym', 'hreflang', 'dir', 'complete', 'slugs',
+    'fallback',
 })
 
 # config/planned.toml, translated in locales/<lang>/planned.toml. It is a file
@@ -245,7 +271,53 @@ def load_locales(root, site):
         if locale['lang'] in seen:
             raise LocaleError(f'two locales both call themselves {locale["lang"]!r}')
         seen.add(locale['lang'])
+    link_fallbacks(locales)
     return locales
+
+
+def link_fallbacks(locales):
+    """Resolve each locale's `fallback` name to the locale object it names.
+
+    A page a locale has not translated normally shows English - see
+    `localize_tool` and `body_for`. `fallback` is the one exception: a
+    locale written in a script another locale already has a finished
+    translation in (Traditional Chinese next to Simplified, one day perhaps
+    Cantonese next to Mandarin) can name that locale instead, so an
+    untranslated page shows the near relative's words rather than English's.
+
+    Resolved here, once, rather than looked up by name every time a page is
+    rendered - a locale's own tools/pages tables are read straight off
+    `fallback_locale`, and doing that lookup by string on every tool and
+    every guide would be the same search repeated hundreds of times for an
+    answer that cannot change mid-build.
+
+    One level only. A chain would have to be resolved in dependency order,
+    and a locale falling back through two near relatives to reach English is
+    a design nobody has asked for yet - refusing it here is cheaper than
+    writing the topological sort for a feature with no user.
+    """
+    by_lang = {locale['lang']: locale for locale in locales}
+    for locale in locales:
+        name = locale.get('fallback')
+        locale['fallback_locale'] = None
+        if name is None:
+            continue
+        if name == locale['lang']:
+            raise LocaleError(
+                f'locales/{locale["lang"]}/locale.toml: fallback = {name!r} names '
+                'itself.')
+        if name not in by_lang:
+            raise LocaleError(
+                f'locales/{locale["lang"]}/locale.toml: fallback = {name!r} names '
+                f'no locale. Known: {", ".join(sorted(by_lang))}')
+        target = by_lang[name]
+        if target.get('fallback'):
+            raise LocaleError(
+                f'locales/{locale["lang"]}/locale.toml: fallback = {name!r}, but '
+                f'{name} itself falls back to {target["fallback"]!r}. Only one '
+                'level is supported - point both locales at the same target '
+                'instead of chaining them.')
+        locale['fallback_locale'] = target
 
 
 def base_locale(site):
@@ -260,6 +332,8 @@ def base_locale(site):
         'complete': True,
         'is_base': True,
         'prefix': '',
+        'fallback': None,
+        'fallback_locale': None,
         'slugs': {},
         'site': site,
         'tools': {},
@@ -302,6 +376,12 @@ def load_locale(path, site):
         'complete': bool(config.get('complete', False)),
         'is_base': False,
         'prefix': f'{config["lang"]}/',
+        # A name, not the locale itself - locales/*/locale.toml files are
+        # loaded one at a time, so the locale `fallback` names has not
+        # necessarily been read yet. `link_fallbacks` resolves the name to
+        # `fallback_locale` once every locale is loaded.
+        'fallback': config.get('fallback'),
+        'fallback_locale': None,
         'slugs': dict(config.get('slugs', {})),
         'tools': {},
         'pages': {},
@@ -616,6 +696,31 @@ def translate(source, over, keys, where, missing, path, transform=None):
                  over, where, missing, path, STRUCTURAL_KEYS, transform)
 
 
+def fallback_base(source, over_key, keys, locale, slug):
+    """What an untranslated key in `locale` falls back to: English, or - for
+    a locale with `fallback` set - its near relative's own words instead.
+
+    Returns a tree shaped like `source` but limited to `keys`, UNRELOCATED:
+    any link in it is still written relative to the page's generic position,
+    exactly as English's own markup is. That is what lets the result be fed
+    straight into `merge` as the new base and have `locale`'s own `relocate`
+    - applied once, by the caller, to whatever ends up falling back - resolve
+    it correctly for `locale`'s tree. Relocating it here, for the fallback
+    locale's own tree, would leave a Traditional Chinese page linking into
+    the middle of the Simplified Chinese site instead of its own.
+
+    `missing` is thrown away: which keys the near relative has not itself
+    translated is that locale's own debt, tallied when it is charged
+    directly, and must not also count against `locale`.
+    """
+    fallback = locale['fallback_locale']
+    if fallback is None:
+        return {key: source[key] for key in keys if key in source}
+    return translate(source, over_key(fallback), keys,
+                     f'locales/{fallback["lang"]}/ (as a fallback for {locale["lang"]})',
+                     [], 'fallback', transform=None)
+
+
 def localize_tool(tool, locale, site):
     """One tool, said in one language, at its own URL.
 
@@ -627,11 +732,12 @@ def localize_tool(tool, locale, site):
     slug = tool['slug']
     merged = dict(tool)
     debt = charge(locale, slug)
-    merged.update(translate(tool, locale['tools'].get(slug, {}),
-                            TRANSLATABLE_TOOL_KEYS,
-                            f'locales/{locale["lang"]}/tools/{slug}.toml',
-                            debt, f'tools.{slug}',
-                            lambda text: relocate(text, locale, slug)))
+    base = fallback_base(tool, lambda fb: fb['tools'].get(slug, {}),
+                         TRANSLATABLE_TOOL_KEYS, locale, slug)
+    merged.update(merge(base, locale['tools'].get(slug, {}),
+                        f'locales/{locale["lang"]}/tools/{slug}.toml',
+                        debt, f'tools.{slug}', STRUCTURAL_KEYS,
+                        lambda text: relocate(text, locale, slug)))
     merged['out_slug'] = locale['slugs'].get(slug, slug)
     merged['url'] = f'{site["domain"]}{locale["prefix"]}{merged["out_slug"]}/'
     return merged
@@ -658,11 +764,12 @@ def localize_page(page, locale, site):
     slug = page['slug']
     merged = dict(page)
     debt = charge(locale, slug)
-    merged.update(translate(page, locale['pages'].get(slug, {}),
-                            TRANSLATABLE_PAGE_KEYS,
-                            f'locales/{locale["lang"]}/pages/{slug}.toml',
-                            debt, f'pages.{slug}',
-                            lambda text: relocate(text, locale, slug)))
+    base = fallback_base(page, lambda fb: fb['pages'].get(slug, {}),
+                         TRANSLATABLE_PAGE_KEYS, locale, slug)
+    merged.update(merge(base, locale['pages'].get(slug, {}),
+                        f'locales/{locale["lang"]}/pages/{slug}.toml',
+                        debt, f'pages.{slug}', STRUCTURAL_KEYS,
+                        lambda text: relocate(text, locale, slug)))
     merged['out_slug'] = locale['slugs'].get(slug, slug)
     merged['url'] = f'{site["domain"]}{locale["prefix"]}{merged["out_slug"]}/'
     merged['depth'] = merged['out_slug'].count('/') + 1
@@ -743,18 +850,30 @@ def relocate(html, locale, slug):
 
 
 def body_for(locale, kind_name, slug, fallback):
-    """The translated body.html for a tool or a page, or the English one.
+    """The translated body.html for a tool or a page - this locale's own, its
+    `fallback` locale's, or the English one.
 
     Prose bodies are whole files rather than keys in a table, so they fall back
     as whole files too: a guide is either translated or it is not, and there is
     no useful halfway state where three of its paragraphs are in German.
+
+    A body borrowed from the fallback locale is read straight off disk,
+    UNRELOCATED - it is written relative to the generic page position, the
+    same as an English body is, so `relocate` below resolves it correctly
+    for THIS locale in one pass. Relocating it twice, once for the fallback
+    locale and once for this one, is how a Traditional Chinese page would
+    end up linking into the middle of the Simplified Chinese site instead of
+    its own - see `fallback_base`, which the same reasoning is written out
+    in full for.
     """
     key = f'{kind_name}/{slug}'
     if key in locale['bodies']:
         return locale['bodies'][key]
     if not locale['is_base']:
         locale['debt'].setdefault(slug, []).append(f'{kind_name}.{slug}.body')
-        return relocate(fallback, locale, slug)
+        near = locale['fallback_locale']
+        source = near['bodies'].get(key) if near else None
+        return relocate(fallback if source is None else source, locale, slug)
     return fallback
 
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -128,8 +128,20 @@ Both work with the script blocked.
 
 Set `hreflang` where it differs from `lang` - `pt-BR` is a language and a
 region, and `hreflang` is the only place that distinction is expressed. Set
-`dir = "rtl"` for Arabic or Hebrew; note that the stylesheets have not been
-written for it yet, so that is a layout job as well as a translation one.
+`dir = "rtl"` for Arabic or Hebrew; the shared stylesheets use logical
+properties (`inset-inline-start`, `margin-inline-end`, …) rather than
+`left`/`right` for anything that describes reading order, and mirror
+correctly as a result - a tool's own `styles.css` may not, if it was written
+before this and has not been checked yet.
+
+Set `fallback = "<lang>"` if this locale is a close relative of one that
+already has translated tools and guides - Traditional Chinese pointing at
+Simplified is the case this exists for. A page this locale has not
+translated yet then shows the fallback locale's words instead of English's,
+which is a real improvement for the reader but changes nothing about what
+counts as finished: `complete` and the per-page debt are still judged
+against this locale's own work, exactly as without `fallback`. See
+"FALLING BACK TO A NEAR RELATIVE INSTEAD OF ENGLISH" in buildlib/i18n.py.
 
 ## The strings in the JavaScript
 

--- a/locales/id/locale.toml
+++ b/locales/id/locale.toml
@@ -1,0 +1,446 @@
+#
+# Bahasa Indonesia.
+#
+# What is here is the frame: the hub, the guides index, the roadmap, the 404,
+# the footer, and the words the templates themselves use. The tools and the
+# guides are NOT translated yet - they stay in English, fall back page by
+# page, and are held out of the sitemap, the hreflang sets and the switcher
+# exactly as an unfinished part of any other locale is. See buildlib/i18n.py.
+#
+# Nothing structural is repeated here. There is no list of which tools exist,
+# no category ids, no ordering, no Content-Security-Policy - all of that is
+# decided once, in English, in config/site.toml, and a locale that tried to
+# restate any of it would be told so by the build.
+#
+# House style, decided here:
+#
+#   * Formal "Anda", capitalized, throughout - the register Indonesian
+#     software and government-facing writing already uses, warm rather than
+#     bureaucratic.
+#   * "Pangkas" for cropping a frame, "potong" for shortening a clip's
+#     length, "kompres" for reducing a file's size - three different
+#     Indonesian verbs kept apart on purpose, because this site tells the
+#     three jobs apart too.
+#   * "Pas foto" for a passport/ID photo - the term every Indonesian photo
+#     studio and government form already uses, not a translation of
+#     "passport photo".
+#   * "PDF", "GIF", "SVG", "JPG", "QR", "EXIF" and similar acronyms stay in
+#     Latin letters - what gets typed into a search box, and what appears on
+#     the file's own icon in every operating system.
+#
+
+lang = "id"
+name = "Indonesian"
+endonym = "Bahasa Indonesia"
+hreflang = "id"
+
+# The frame is finished: the nav, the footer, the hub and every [ui] word in
+# this file are Indonesian. That is all this flag claims - the tools and the
+# guides are still English, held back a page at a time. See the note at the
+# top of buildlib/i18n.py for why the unit is the page rather than the
+# language.
+complete = true
+
+#
+# ---------------------------------------------------------------------------
+# The addresses.
+#
+# Keyed by the ENGLISH slug on the left, which is the name of the thing, and
+# never by the Indonesian one. The Indonesian is an address and appears only
+# on the right.
+# ---------------------------------------------------------------------------
+#
+
+[slugs]
+# The tools.
+"compress-image" = "kompres-gambar"
+"compress-pdf" = "kompres-pdf"
+"crop-video" = "pangkas-video"
+"edit-audio" = "sunting-audio"
+"exif-editor" = "hapus-data-exif"
+"redact-image" = "sensor-gambar"
+"images-to-pdf" = "gambar-ke-pdf"
+"images-to-video" = "gambar-ke-video"
+"resize-image" = "ubah-ukuran-gambar"
+"trim-video" = "potong-video"
+"image-to-ico" = "buat-favicon"
+"svg-to-image" = "svg-ke-png"
+"heic-to-jpg" = "heic-ke-jpg"
+"image-to-data-uri" = "gambar-ke-base64"
+"qr-barcode" = "buat-kode-qr"
+"qr-barcode-reader" = "pindai-kode-qr"
+"video-to-gif" = "video-ke-gif"
+"gif-analyzer" = "analisis-gif"
+"gif-maker" = "buat-gif"
+"grab-frame" = "ambil-bingkai-video"
+"id-photo" = "pas-foto-biometrik"
+"merge-pdf" = "gabung-pdf"
+"reverse-video" = "putar-video-terbalik"
+"split-gif" = "pisah-gif-ke-bingkai"
+"text-tools" = "format-json"
+"trim-audio" = "potong-audio"
+"password-generator" = "pembuat-kata-sandi"
+"timelapse-video" = "buat-video-time-lapse"
+"hash-checksum" = "hitung-checksum"
+
+# The indexes and the legal pages.
+"guides" = "panduan"
+"roadmap" = "peta-jalan"
+"privacy" = "privasi"
+"terms" = "ketentuan-penggunaan"
+
+# The guides. Each one keeps the "panduan/" prefix written out, the same way
+# the German list keeps "ratgeber/" on every line - the parent slug above is
+# not inherited automatically, so it is repeated here.
+"guides/compress-an-image-to-a-target-size" = "panduan/kompres-gambar-ke-ukuran-tertentu"
+"guides/resize-an-image" = "panduan/ubah-ukuran-gambar"
+"guides/remove-exif-and-gps-data" = "panduan/hapus-data-exif-dan-gps"
+"guides/redact-an-image" = "panduan/sensor-gambar"
+"guides/make-a-pdf-smaller" = "panduan/perkecil-ukuran-pdf"
+"guides/combine-images-into-a-pdf" = "panduan/gabung-gambar-ke-pdf"
+"guides/turn-images-into-a-video" = "panduan/gambar-ke-video"
+"guides/trim-a-video" = "panduan/potong-video"
+"guides/crop-a-video" = "panduan/pangkas-video"
+"guides/is-it-safe-to-upload-files" = "panduan/apakah-aman-mengunggah-file"
+"guides/make-a-favicon" = "panduan/buat-favicon"
+"guides/convert-an-svg-to-png" = "panduan/svg-ke-png"
+"guides/convert-heic-to-jpg" = "panduan/heic-ke-jpg"
+"guides/embed-an-image-in-css" = "panduan/menyisipkan-gambar-di-css"
+"guides/make-a-qr-code" = "panduan/buat-kode-qr"
+"guides/turn-a-video-into-a-gif" = "panduan/video-ke-gif"
+"guides/format-json-without-uploading-it" = "panduan/format-json-tanpa-mengunggah"
+"guides/grab-a-frame-from-a-video" = "panduan/ambil-bingkai-dari-video"
+"guides/make-a-gif-from-images" = "panduan/buat-gif-dari-gambar"
+"guides/make-a-passport-photo" = "panduan/membuat-pas-foto"
+"guides/merge-and-split-pdf-files" = "panduan/gabung-dan-pisah-file-pdf"
+"guides/reverse-a-video" = "panduan/memutar-video-terbalik"
+"guides/split-a-gif-into-frames" = "panduan/pisah-gif-ke-bingkai"
+"guides/trim-an-audio-file" = "panduan/potong-file-audio"
+"guides/whats-inside-a-gif" = "panduan/apa-isi-di-dalam-gif"
+"guides/verify-a-file-checksum" = "panduan/memverifikasi-checksum-file"
+
+#
+# ---------------------------------------------------------------------------
+# The hub.
+# ---------------------------------------------------------------------------
+#
+
+[hub]
+title = "Alat Peramban Gratis &mdash; Tanpa Unggah, Tanpa Masuk Akun | abox.tools"
+description = "Alat peramban gratis yang tidak pernah mengunggah file Anda. Gabungkan gambar menjadi PDF atau MP4, kompres gambar ke ukuran tertentu, pangkas video, atau hapus data EXIF."
+heading = "Kotak alat yang tidak pernah menyentuh server"
+og_title = "A Box of Tools &mdash; alat yang tidak pernah menyentuh server"
+og_description = "Alat kecil untuk satu tugas, yang berjalan sepenuhnya di peramban Anda. File Anda tidak pernah meninggalkan perangkat Anda."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"
+schema_description = "Alat kecil untuk satu tugas yang melakukan semua pekerjaannya di dalam peramban Anda. Tidak ada yang diunggah dan tidak perlu akun."
+schema_about = "Alat file berbasis peramban yang memproses file secara lokal tanpa mengunggahnya"
+
+lede = """
+    Alat kecil untuk satu tugas, yang melakukan semua pekerjaannya di
+    dalam peramban Anda. File Anda tetap di perangkat Anda: tidak ada yang
+    perlu diunggah, tidak perlu membuat akun, dan tidak ada yang dilacak."""
+
+support_note = """
+      Alat-alat ini gratis dan akan selalu begitu. Jika salah satu
+      memudahkan pekerjaan Anda, inilah satu-satunya tempat di situs ini
+      yang meminta sesuatu dari Anda."""
+
+[[hub.guarantees]]
+title = "File Anda tidak pernah meninggalkan perangkat Anda"
+body = """
+        Peramban Anda sendiri membuka, membaca, dan memprosesnya,
+        menggunakan perangkat keras Anda sendiri.
+        <code>Content-Security-Policy</code> setiap alat menyebutkan
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik
+        kami."""
+
+[[hub.guarantees]]
+title = "Tidak ada apa pun tentang file Anda yang dikirim ke mana pun"
+body = """
+        Bukan filenya, bukan gambar mininya, bukan namanya, ukurannya,
+        atau berapa banyak yang Anda pilih. Tidak ada alat di sini yang
+        membaca semua itu. Tidak ada server di sisi lain alat-alat ini
+        untuk membacanya."""
+
+[[hub.guarantees]]
+title = "Berfungsi tanpa koneksi internet"
+body = """
+        Buka satu alat sekali, putuskan koneksi internet, dan alat itu
+        akan terus bekerja pada file Anda persis seperti sebelumnya. Ini
+        sulit dipalsukan: alat yang mengirim file Anda ke tempat lain
+        untuk diproses akan langsung berhenti bekerja."""
+
+[[hub.categories]]
+id = "images"
+name = "Gambar"
+note = "Ubah ukuran, perkecil, atau hapus apa yang secara diam-diam dicatat sebuah foto tentang Anda - tidak satu pun dikirim ke mana pun."
+
+[[hub.categories]]
+id = "video-and-animation"
+name = "Video &amp; Animasi"
+note = "Potong, ubah, atau buat satu dari gambar diam, tanpa rekamannya meninggalkan perangkat Anda."
+
+[[hub.categories]]
+id = "documents-and-audio"
+name = "Dokumen &amp; Audio"
+note = "Susun ulang dokumen atau potong rekaman, tanpa mengirim keduanya untuk diproses di tempat lain."
+
+[[hub.categories]]
+id = "text-codes-and-passwords"
+name = "Teks, Kode &amp; Kata Sandi"
+note = "Baca, verifikasi, atau buat di sini - tidak ada token, file konfigurasi, atau kata sandi yang sampai ke server orang lain."
+
+#
+# ---------------------------------------------------------------------------
+# The guides index.
+# ---------------------------------------------------------------------------
+#
+
+[guides]
+nav = "Semua Panduan"
+title = "Panduan &mdash; cara mengerjakannya dan biaya setiap pilihan"
+description = "Panduan jelas untuk mengompres, mengubah ukuran, memangkas, dan mengonversi file Anda sendiri - apa arti pengaturannya, apa biayanya, dan mengapa tidak perlu mengunggah."
+heading = "Panduan"
+lede = """
+    Satu panduan untuk setiap alat, ditulis untuk orang yang diminta
+    mencapai ukuran atau format tertentu dan ingin tahu lebih dulu apa
+    sebenarnya yang dilakukan pengaturan yang akan mereka geser. Semua
+    yang dijelaskan di sini terjadi di perangkat Anda sendiri."""
+og_title = "Panduan abox.tools"
+og_description = "Cara mengompres, mengubah ukuran, memangkas, memotong, dan mengonversi file Anda sendiri - dan biaya setiap pengaturan. Tanpa unggahan sama sekali."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"
+
+[[guides.groups]]
+id = "doing-the-job"
+name = "Mengerjakan tugasnya"
+note = "Satu untuk setiap alat: apa inti tugasnya, pengaturan mana yang penting, dan apa biayanya."
+
+[[guides.groups]]
+id = "before-you-upload"
+name = "Sebelum Anda mengunggah apa pun"
+note = "Apa yang sebenarnya terjadi saat Anda menyerahkan file ke sebuah situs, dan cara mengetahui apakah itu memang perlu."
+
+#
+# ---------------------------------------------------------------------------
+# The roadmap.
+#
+# Only the frame. The list itself is config/planned.toml, and is not
+# translated yet - it stays English and falls back like any other page.
+# ---------------------------------------------------------------------------
+#
+
+[roadmap]
+nav = "Peta Jalan"
+title = "Peta Jalan &mdash; apa yang sedang dibangun abox.tools selanjutnya"
+description = "Setiap alat yang direncanakan untuk abox.tools, dikelompokkan dan terbuka, ditambah yang sudah selesai. Semuanya berjalan di peramban Anda dan tidak mengunggah apa pun."
+heading = "Apa yang akan datang"
+lede = """
+    Semua yang ada di kedua daftar di bawah ini mengerjakan tugasnya di
+    dalam peramban Anda dan tidak mengunggah apa pun &mdash; itulah aturan
+    yang harus dilewati sebuah nama sebelum masuk ke sini sama sekali.
+    Jumlahnya tidak dicatat di mana pun; proses build membacanya dari
+    kedua daftar."""
+
+intro_heading = "Bagaimana daftar ini disusun"
+intro = """
+    <p>
+      Ini bukan daftar keinginan. Daftar ini disusun dengan menelusuri
+      daftar alat dari situs GIF dan video daring terbesar, hal yang
+      paling mendekati katalog tentang apa yang sebenarnya ingin dilakukan
+      orang terhadap sebuah file, dan menyimpan setiap entri yang bisa
+      dibangun sehingga pekerjaannya terjadi di perangkat Anda sendiri dan
+      terus berjalan meski koneksi jaringan diputus.
+    </p>
+    <p>
+      Sebagian besar yang tersisa berjalan dengan API yang sudah dimiliki
+      peramban. Beberapa memerlukan codec yang disertakan langsung di satu
+      alat yang menggunakannya, dan itu diperbolehkan &mdash; filenya
+      tetap tidak pernah meninggalkan perangkat. Apa pun yang tidak lolos
+      syarat ini ditinggalkan alih-alih dijanjikan, jadi beberapa
+      kekosongan yang tampak jelas di bawah ini memang disengaja.
+    </p>
+    <p>
+      Alat yang sudah ada berada di bagian atas kelompoknya, ditandai
+      <em>Selesai</em> dan tertaut ke halamannya sendiri. Semua yang ada
+      di bawahnya masih akan datang, dan tidak akan menjadi tautan sampai
+      benar-benar selesai.
+    </p>"""
+
+planned_heading = "Setiap jenis file, dan apa yang bisa dilakukan terhadapnya"
+
+og_title = "Peta jalan abox.tools"
+og_description = "Apa yang sudah selesai, dan apa selanjutnya. Semuanya berjalan di peramban Anda dan tidak mengunggah apa pun."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"
+
+#
+# ---------------------------------------------------------------------------
+# The 404.
+#
+# Built in English only - GitHub Pages serves one file for the whole domain
+# and cannot know which language was being looked for - so nothing here is
+# used today. Translated anyway, for the same reason German's copy is.
+# ---------------------------------------------------------------------------
+#
+
+[not_found]
+title = "Halaman tidak ditemukan &mdash; abox.tools"
+description = "Alamat itu tidak ada di abox.tools. Berikut alat-alat yang memang ada - semuanya gratis, dan tidak satu pun mengunggah file Anda ke mana pun."
+heading = "Halaman itu tidak ada di sini"
+tools_heading = "Semua alat, di satu tempat"
+tools_note = "Semuanya gratis, semuanya berjalan di peramban Anda, tidak satu pun mengunggah apa pun."
+
+lede = """
+    Entah ada salah ketik di alamatnya, atau sesuatu yang dulu ada di
+    alamat itu sudah dipindahkan. Tidak terjadi apa-apa pada file Anda
+    dan tidak ada yang hilang: halaman ini tidak pernah menyimpan apa pun
+    milik Anda yang bisa hilang."""
+
+#
+# ---------------------------------------------------------------------------
+# The footer.
+# ---------------------------------------------------------------------------
+#
+
+[footer]
+blurb = """
+        Alat yang tidak pernah menyentuh server. File Anda tetap di
+        perangkat Anda &mdash; tidak ada yang perlu diunggah, tidak perlu
+        membuat akun."""
+base = "Setiap klaim di situs ini dimaksudkan untuk diperiksa, bukan dipercaya begitu saja."
+
+#
+# ---------------------------------------------------------------------------
+# The frame's own words.
+#
+# Everything with {{ }} in it is a name the build resolves, and the build
+# refuses to render a name it cannot find - so these may be moved anywhere in
+# the sentence, and may not be renamed.
+# ---------------------------------------------------------------------------
+#
+
+[ui]
+languages = "Bahasa"
+lang_auto = "Halaman ini ditampilkan dalam bahasa Indonesia, bahasa yang diminta peramban Anda."
+breadcrumb = "Jejak navigasi"
+all_tools = "Semua alat"
+last_updated = "Terakhir diperbarui"
+built_tag = "Selesai"
+planned_count = "direncanakan"
+built_count = "selesai"
+
+guide_one = "panduan"
+guide_many = "panduan"
+
+footer_tools = "Alat"
+footer_site = "Situs ini"
+footer_contact = "Hubungi kami"
+footer_sitemap = "Peta situs"
+footer_source = "Baca kode sumber di GitHub"
+
+guarantees_note = """
+    Anda tidak perlu memercayai semua itu begitu saja.
+    <a href="{{ base }}{{ links.safety_guide }}/">
+      Cara mengetahui apakah sebuah alat benar-benar membutuhkan file
+      Anda</a>
+    memberikan empat pemeriksaan yang bisa Anda jalankan sendiri, di situs
+    ini atau situs mana pun."""
+
+hub_guides_note = """
+    Tidak yakin pengaturan mana yang harus digeser, atau apa biayanya?
+    <a href="{{ base }}{{ links.guides }}/">Ada panduan untuk setiap
+    alat</a>."""
+
+hub_roadmap_note = """
+    Masih akan ada lebih banyak lagi, dan daftarnya terbuka untuk dilihat:
+    <a href="{{ base }}{{ links.roadmap }}/">lihat apa yang direncanakan
+    selanjutnya</a>."""
+
+guides_all_note = """
+    Setiap panduan di sini menjelaskan alat yang berjalan di perangkat
+    Anda sendiri:
+    <a href="{{ base }}">lihat semuanya</a>."""
+
+[ui.tool]
+view_source = "Lihat kode sumber"
+how_verified = "Cara memverifikasi ini"
+live_check = "Pemeriksaan langsung:"
+offline = "Luring:"
+checking = "memeriksa&hellip;"
+questions_heading = "Pertanyaan"
+guide_heading = "Versi lebih lengkap"
+related_heading = "Juga ada di dalam kotak"
+privacy_heading = "Cara memverifikasi klaim privasi ini"
+
+pledge_line = """
+    {{ tool.words.plural }} Anda <strong>tidak pernah diunggah</strong>.
+    Tidak ada server."""
+
+boot_title = "Kode halaman ini tidak berjalan."
+boot_body = """
+    Membuka <code>index.html</code> langsung dari sebuah folder memblokir
+    modul JavaScript, sehingga tidak akan terjadi apa-apa saat Anda
+    memilih {{ tool.words.choose }}. Sajikan folder tersebut lewat http
+    sebagai gantinya:"""
+boot_then = "Lalu buka <code>http://localhost:8080/</code>."
+
+noscript_title = "JavaScript dinonaktifkan."
+noscript_body = "Aplikasi ini melakukan semua pekerjaannya di dalam peramban Anda, dan tidak bisa berjalan tanpanya."
+
+offline_ready = "siap &mdash; putuskan koneksi internet dan ini akan tetap berfungsi."
+offline_none = "tidak tersedia di peramban ini (semua yang lain tetap berfungsi)."
+offline_insecure = "membutuhkan https:// atau localhost untuk menyimpan cache demi penggunaan luring."
+offline_failed = "penyimpanan cache tidak tersedia di sini, tetapi tidak ada yang diunggah dengan cara apa pun."
+
+error_broke = "Ada yang tidak berjalan dengan benar: {detail}. Muat ulang halaman untuk memulai dari awal."
+
+reading_one = "Membaca {count} file&hellip;"
+reading_many = "Membaca {count} file&hellip;"
+
+check_yourself = """
+      <strong>Periksa sendiri.</strong> Anda tidak perlu memercayai semua
+      ini begitu saja. Halaman ini dihasilkan dari templat dan konfigurasi
+      di repositori oleh skrip build yang bisa Anda baca dan jalankan
+      sendiri, dan hasilnya dikirim ke cabang <code>dist</code> &mdash;
+      jadi Anda bisa membandingkan apa yang disajikan dengan apa yang
+      dihasilkan oleh build dari kode sumbernya:"""
+
+read_first_lead = """
+      File yang layak dibaca lebih dulu adalah
+      <code>config/site.toml</code> untuk Content-Security-Policy"""
+
+[ui.feedback]
+prompt = "Apakah ini berhasil?"
+up = "Ya"
+down = "Tidak"
+dismiss = "Tutup"
+
+reason_prompt = "Apa yang salah?"
+reason_wrong = "Hasil salah"
+reason_failed = "Tidak selesai"
+reason_slow = "Terlalu lambat"
+reason_confusing = "Membingungkan"
+
+thanks = "Terima kasih &mdash; ini membantu."
+
+note = """
+      Hanya jawabannya yang dikirim, dan hanya saat Anda menekan tombol.
+      File Anda, namanya, atau apa pun tentangnya tidak pernah dikirim."""
+
+[ui.guide]
+open_tool = "Buka {{ tool.name | e }}"
+
+[ui.picker]
+warning = """
+      <strong>Ini satu-satunya fitur di sini yang terhubung ke
+      jaringan.</strong> Mengambil sebuah alamat memberi tahu server
+      tersebut alamat IP Anda dan {{ tool.picker.urls.noun }} mana yang
+      Anda minta. {{ tool.picker.urls.noun }} disalin ke memori lokal
+      begitu tiba dan tidak akan diminta lagi. Tidak ada apa pun milik
+      Anda yang pernah dikirim keluar &mdash; halaman ini tetap tidak
+      bisa melakukan unggahan dalam bentuk apa pun."""
+label = "Satu alamat per baris"
+note = """
+      Server harus mengizinkan penggunaan lintas asal untuk
+      {{ tool.picker.urls.noun }} miliknya. Banyak situs tidak
+      mengizinkannya, dan situs-situs itu akan gagal dengan sebuah pesan
+      alih-alih rusak diam-diam di kemudian hari."""

--- a/locales/tr/locale.toml
+++ b/locales/tr/locale.toml
@@ -1,0 +1,436 @@
+#
+# Türkçe.
+#
+# What is here is the frame: the hub, the guides index, the roadmap, the 404,
+# the footer, and the words the templates themselves use. The tools and the
+# guides are NOT translated yet - they stay in English, fall back page by
+# page, and are held out of the sitemap, the hreflang sets and the switcher
+# exactly as an unfinished part of any other locale is. See buildlib/i18n.py.
+#
+# Nothing structural is repeated here. There is no list of which tools exist,
+# no category ids, no ordering, no Content-Security-Policy - all of that is
+# decided once, in English, in config/site.toml, and a locale that tried to
+# restate any of it would be told so by the build.
+#
+# House style, decided here:
+#
+#   * Formal, impersonal register - the possessive/second-person suffix
+#     (-ınız/-iniz, as in "dosyalarınız") rather than an imperative or a bare
+#     "sen" form. That is the register Turkish software and documentation
+#     already uses, and it does not force a guess about who is reading.
+#   * "Sıkıştırma", "kırpma", "kesme" kept distinct on purpose: this site
+#     tells apart cropping a frame (kırpma), shortening a clip (kesme) and
+#     reducing a file's size (sıkıştırma), and Turkish has three different
+#     verbs for exactly that split.
+#   * "PDF", "GIF", "SVG", "JPG", "QR", "EXIF" and similar acronyms stay in
+#     Latin letters - what gets typed into a search box, and what appears on
+#     the file's own icon in every operating system.
+#   * No dotless/dotted-I confusion in the slugs: [slugs] below is ASCII, the
+#     way Turkish web addresses conventionally drop diacritics (ı, ğ, ş, ç,
+#     ö, ü each fold to their plain Latin letter), the same reasoning German
+#     gives for oe/ue/ae/ss in its own [slugs].
+#
+
+lang = "tr"
+name = "Turkish"
+endonym = "Türkçe"
+hreflang = "tr"
+
+# The frame is finished: the nav, the footer, the hub and every [ui] word in
+# this file are Turkish. That is all this flag claims - the tools and the
+# guides are still English, held back a page at a time. See the note at the
+# top of buildlib/i18n.py for why the unit is the page rather than the
+# language.
+complete = true
+
+#
+# ---------------------------------------------------------------------------
+# The addresses.
+#
+# Keyed by the ENGLISH slug on the left, which is the name of the thing, and
+# never by the Turkish one. The Turkish is an address and appears only on the
+# right.
+# ---------------------------------------------------------------------------
+#
+
+[slugs]
+# The tools.
+"compress-image" = "resim-sikistirma"
+"compress-pdf" = "pdf-sikistirma"
+"crop-video" = "video-kirpma"
+"edit-audio" = "ses-duzenleme"
+"exif-editor" = "exif-verisi-silme"
+"redact-image" = "resim-karartma"
+"images-to-pdf" = "resimleri-pdfe-donusturme"
+"images-to-video" = "resimleri-videoya-donusturme"
+"resize-image" = "resim-boyutlandirma"
+"trim-video" = "video-kesme"
+"image-to-ico" = "favicon-olusturma"
+"svg-to-image" = "svg-yi-pnge-donusturme"
+"heic-to-jpg" = "heic-jpg-donusturme"
+"image-to-data-uri" = "resmi-base64e-donusturme"
+"qr-barcode" = "qr-kod-olusturma"
+"qr-barcode-reader" = "qr-kod-okuma"
+"video-to-gif" = "videoyu-gife-donusturme"
+"gif-analyzer" = "gif-analiz-etme"
+"gif-maker" = "gif-olusturma"
+"grab-frame" = "videodan-kare-yakalama"
+"id-photo" = "biyometrik-vesikalik-fotograf"
+"merge-pdf" = "pdf-birlestirme"
+"reverse-video" = "videoyu-ters-oynatma"
+"split-gif" = "gifi-karelere-ayirma"
+"text-tools" = "json-bicimlendirme"
+"trim-audio" = "ses-kesme"
+"password-generator" = "sifre-olusturucu"
+"timelapse-video" = "time-lapse-video-olusturma"
+"hash-checksum" = "saglama-toplami-hesaplama"
+
+# The indexes and the legal pages.
+"guides" = "rehberler"
+"roadmap" = "yol-haritasi"
+"privacy" = "gizlilik"
+"terms" = "kullanim-kosullari"
+
+# The guides. Each one keeps the "rehberler/" prefix written out, the same
+# way the German list keeps "ratgeber/" on every line - the parent slug above
+# is not inherited automatically, so it is repeated here.
+"guides/compress-an-image-to-a-target-size" = "rehberler/resmi-hedef-boyuta-sikistirma"
+"guides/resize-an-image" = "rehberler/resim-boyutlandirma"
+"guides/remove-exif-and-gps-data" = "rehberler/exif-ve-gps-verisini-silme"
+"guides/redact-an-image" = "rehberler/resim-karartma"
+"guides/make-a-pdf-smaller" = "rehberler/pdf-boyutunu-kucultme"
+"guides/combine-images-into-a-pdf" = "rehberler/resimleri-pdfde-birlestirme"
+"guides/turn-images-into-a-video" = "rehberler/resimleri-videoya-donusturme"
+"guides/trim-a-video" = "rehberler/video-kesme"
+"guides/crop-a-video" = "rehberler/video-kirpma"
+"guides/is-it-safe-to-upload-files" = "rehberler/dosya-yuklemek-guvenli-mi"
+"guides/make-a-favicon" = "rehberler/favicon-olusturma"
+"guides/convert-an-svg-to-png" = "rehberler/svg-yi-pnge-donusturme"
+"guides/convert-heic-to-jpg" = "rehberler/heic-jpg-donusturme"
+"guides/embed-an-image-in-css" = "rehberler/cssye-resim-gomme"
+"guides/make-a-qr-code" = "rehberler/qr-kod-olusturma"
+"guides/turn-a-video-into-a-gif" = "rehberler/videoyu-gife-donusturme"
+"guides/format-json-without-uploading-it" = "rehberler/json-yuklemeden-bicimlendirme"
+"guides/grab-a-frame-from-a-video" = "rehberler/videodan-kare-yakalama"
+"guides/make-a-gif-from-images" = "rehberler/resimlerden-gif-olusturma"
+"guides/make-a-passport-photo" = "rehberler/vesikalik-fotograf-cekme"
+"guides/merge-and-split-pdf-files" = "rehberler/pdf-birlestirme-ve-bolme"
+"guides/reverse-a-video" = "rehberler/videoyu-ters-oynatma"
+"guides/split-a-gif-into-frames" = "rehberler/gifi-karelere-ayirma"
+"guides/trim-an-audio-file" = "rehberler/ses-dosyasi-kesme"
+"guides/whats-inside-a-gif" = "rehberler/gifin-icinde-ne-var"
+"guides/verify-a-file-checksum" = "rehberler/dosya-saglama-toplamini-dogrulama"
+
+#
+# ---------------------------------------------------------------------------
+# The hub.
+# ---------------------------------------------------------------------------
+#
+
+[hub]
+title = "Ücretsiz Tarayıcı Araçları &mdash; Yükleme Yok, Üyelik Yok | abox.tools"
+description = "Dosyalarınızı asla yüklemeyen ücretsiz tarayıcı araçları. Resimleri PDF veya MP4'e birleştirin, bir resmi tam boyuta sıkıştırın, video kırpın veya EXIF verisini silin."
+heading = "Sunucuya hiç dokunmayan bir araç kutusu"
+og_title = "A Box of Tools &mdash; sunucuya hiç dokunmayan araçlar"
+og_description = "Tamamen tarayıcınızda çalışan, tek işe özel küçük araçlar. Dosyalarınız cihazınızdan asla çıkmaz."
+og_image_alt = "abox.tools - sunucuya hiç dokunmayan araçlar"
+schema_description = "Tüm işini tarayıcınızın içinde yapan, tek işe özel küçük araçlar. Hiçbir şey yüklenmez ve hesap gerekmez."
+schema_about = "Dosyaları yüklemeden yerel olarak işleyen tarayıcı tabanlı dosya araçları"
+
+lede = """
+    Tüm işini tarayıcınızın içinde yapan, tek işe özel küçük araçlar.
+    Dosyalarınız cihazınızda kalır: yükleyecek bir şey yok, oluşturulacak
+    bir hesap yok, izlenecek hiçbir şey yok."""
+
+support_note = """
+      Bu araçlar ücretsizdir ve öyle kalacaktır. Biri size bir işi
+      kolaylaştırdıysa, sitede sizden bir şey isteyen tek yer burasıdır."""
+
+[[hub.guarantees]]
+title = "Dosyalarınız cihazınızdan asla çıkmaz"
+body = """
+        Kendi tarayıcınız onları kendi donanımınızda açar, okur ve işler.
+        Her aracın <code>Content-Security-Policy</code>'si, iletişim
+        kurabileceği her adresi belirtir ve bunların hiçbiri bize ait
+        değildir."""
+
+[[hub.guarantees]]
+title = "Dosyalarınız hakkında hiçbir şey hiçbir yere gönderilmez"
+body = """
+        Ne dosya, ne küçük resmi, ne adı, ne boyutu, ne de kaç tane
+        seçtiğiniz. Buradaki hiçbir araç bunlardan hiçbirini okumaz. Bunu
+        okuyacak bir sunucu da zaten yoktur."""
+
+[[hub.guarantees]]
+title = "Çevrimdışı çalışır"
+body = """
+        Bir aracı bir kez açın, internet bağlantısını kesin; dosyalarınız
+        üzerinde tıpkı önceki gibi çalışmaya devam eder. Bunu taklit etmek
+        zordur: dosyalarınızı işlenmek üzere başka bir yere gönderen bir
+        araç bu noktada basitçe duraklardı."""
+
+[[hub.categories]]
+id = "images"
+name = "Resimler"
+note = "Birini yeniden boyutlandırın, küçültün veya bir fotoğrafın sizin hakkınızda sessizce kaydettiği şeyi çıkarın - hiçbiri hiçbir yere gönderilmez."
+
+[[hub.categories]]
+id = "video-and-animation"
+name = "Video ve Animasyon"
+note = "Görüntü cihazınızdan çıkmadan kesin, dönüştürün veya durgun resimlerden bir tane oluşturun."
+
+[[hub.categories]]
+id = "documents-and-audio"
+name = "Belgeler ve Ses"
+note = "İkisini de işlenmek üzere göndermeden bir belgeyi yeniden düzenleyin veya bir kaydı kesin."
+
+[[hub.categories]]
+id = "text-codes-and-passwords"
+name = "Metin, Kodlar ve Parolalar"
+note = "Burada okuyun, doğrulayın veya oluşturun - hiçbir jeton, yapılandırma dosyası veya parola başkasının sunucusuna ulaşmaz."
+
+#
+# ---------------------------------------------------------------------------
+# The guides index.
+# ---------------------------------------------------------------------------
+#
+
+[guides]
+nav = "Tüm Rehberler"
+title = "Rehberler &mdash; işi nasıl yapacağınız ve her seçimin bedeli"
+description = "Kendi dosyalarınızı sıkıştırma, yeniden boyutlandırma, kırpma ve dönüştürme üzerine anlaşılır rehberler - ayarların ne anlama geldiği, bedeli ve neden yükleme gerekmediği."
+heading = "Rehberler"
+lede = """
+    Her araç için bir rehber, kendisine bir boyut veya biçim söylenen ve
+    hareket ettireceği ayarın gerçekte ne yaptığını önceden bilmek isteyen
+    kişi için yazıldı. Burada anlatılan her şey kendi cihazınızda
+    gerçekleşir."""
+og_title = "abox.tools rehberleri"
+og_description = "Kendi dosyalarınızı nasıl sıkıştırır, yeniden boyutlandırır, kırpar, keser ve dönüştürürsünüz - ve her ayarın bedeli nedir. Hiçbir yükleme olmadan."
+og_image_alt = "abox.tools - sunucuya hiç dokunmayan araçlar"
+
+[[guides.groups]]
+id = "doing-the-job"
+name = "İşi yapmak"
+note = "Her araç için bir tane: iş neyle ilgili, hangi ayar önemli ve bedeli ne."
+
+[[guides.groups]]
+id = "before-you-upload"
+name = "Bir şey yüklemeden önce"
+note = "Bir dosyayı bir siteye vermek gerçekte ne yapar ve bunun gerekli olup olmadığını nasıl anlarsınız."
+
+#
+# ---------------------------------------------------------------------------
+# The roadmap.
+#
+# Only the frame. The list itself is config/planned.toml, and is not
+# translated yet - it stays English and falls back like any other page.
+# ---------------------------------------------------------------------------
+#
+
+[roadmap]
+nav = "Yol Haritası"
+title = "Yol Haritası &mdash; abox.tools sırada ne inşa ediyor"
+description = "abox.tools için planlanan her araç, gruplandırılmış ve açık şekilde, ayrıca zaten tamamlananlar. Hepsi tarayıcınızda çalışır ve hiçbir şey yüklemez."
+heading = "Sırada ne var"
+lede = """
+    Aşağıdaki iki listedeki her şey işini tarayıcınızın içinde yapar ve
+    hiçbir şey yüklemez &mdash; buraya girmeden önce bir adın geçmesi
+    gereken kural budur. Sayılar hiçbir yerde yazılı değildir; derleme
+    bunları iki listeden okur."""
+
+intro_heading = "Bu liste nasıl oluşturuldu"
+intro = """
+    <p>
+      Bu bir dilek listesi değil. En büyük çevrimiçi GIF ve video sitesinin
+      araç listesi taranarak oluşturuldu - insanların bir dosyaya gerçekte
+      ne yapmak istediğinin kataloğuna en yakın şey budur - ve işin kendi
+      cihazınızda gerçekleşecek ve ağ bağlantısı kesikken de çalışmaya
+      devam edecek şekilde inşa edilebilecek her giriş tutuldu.
+    </p>
+    <p>
+      Hayatta kalanların çoğu tarayıcının zaten sunduğu arayüzlerle çalışır.
+      Birkaçı, onu kullanan tek araca gömülü bir codec gerektirir - bu da
+      izinlidir, çünkü dosya yine de cihazdan çıkmaz. Bu çıtayı aşamayan
+      her şey söz verilmek yerine dışarıda bırakıldı, bu yüzden aşağıdaki
+      bazı belirgin boşluklar kasıtlıdır.
+    </p>
+    <p>
+      Zaten var olan araçlar kendi grubunun en üstünde, <em>Hazır</em>
+      olarak işaretlenmiş ve kendi sayfasına bağlanmış şekilde durur.
+      Altındaki her şey henüz gelmedi ve hazır olana kadar bir bağlantı
+      olmayacak.
+    </p>"""
+
+planned_heading = "Her dosya türü ve onunla yapılabilecekler"
+
+og_title = "abox.tools yol haritası"
+og_description = "Ne hazır, sırada ne var. Her şey tarayıcınızda çalışır ve hiçbir şey yüklemez."
+og_image_alt = "abox.tools - sunucuya hiç dokunmayan araçlar"
+
+#
+# ---------------------------------------------------------------------------
+# The 404.
+#
+# Built in English only - GitHub Pages serves one file for the whole domain
+# and cannot know which language was being looked for - so nothing here is
+# used today. Translated anyway, for the same reason German's copy is.
+# ---------------------------------------------------------------------------
+#
+
+[not_found]
+title = "Sayfa bulunamadı &mdash; abox.tools"
+description = "Bu adres abox.tools üzerinde yok. İşte var olan araçlar - hepsi ücretsiz ve hiçbiri dosyalarınızı hiçbir yere yüklemiyor."
+heading = "Bu sayfa burada yok"
+tools_heading = "Tüm araçlar tek yerde"
+tools_note = "Hepsi ücretsiz, hepsi tarayıcınızda çalışır, hiçbiri hiçbir şey yüklemez."
+
+lede = """
+    Ya adreste bir yazım hatası var ya da o adreste olan bir şey taşındı.
+    Dosyanıza hiçbir şey olmadı ve hiçbir şey kaybolmadı: bu sayfa
+    kaybedebileceği hiçbir şeyinizi hiç tutmadı."""
+
+#
+# ---------------------------------------------------------------------------
+# The footer.
+# ---------------------------------------------------------------------------
+#
+
+[footer]
+blurb = """
+        Sunucuya hiç dokunmayan araçlar. Dosyalarınız cihazınızda kalır
+        &mdash; yükleyecek bir şey yok, oluşturulacak bir hesap yok."""
+base = "Bu sitedeki her iddia inanılmak için değil, doğrulanmak için var."
+
+#
+# ---------------------------------------------------------------------------
+# The frame's own words.
+#
+# Everything with {{ }} in it is a name the build resolves, and the build
+# refuses to render a name it cannot find - so these may be moved anywhere in
+# the sentence, and may not be renamed.
+# ---------------------------------------------------------------------------
+#
+
+[ui]
+languages = "Dil"
+lang_auto = "Bu sayfa, tarayıcınızın tercih ettiği dil olan Türkçe olarak gösteriliyor."
+breadcrumb = "Gezinme yolu"
+all_tools = "Tüm araçlar"
+last_updated = "Son güncelleme"
+built_tag = "Hazır"
+planned_count = "planlanan"
+built_count = "hazır"
+
+guide_one = "rehber"
+guide_many = "rehber"
+
+footer_tools = "Araçlar"
+footer_site = "Bu site"
+footer_contact = "Bize ulaşın"
+footer_sitemap = "Site haritası"
+footer_source = "Kaynak kodu GitHub'da okuyun"
+
+guarantees_note = """
+    Bunların hiçbirine güvenmeniz gerekmez.
+    <a href="{{ base }}{{ links.safety_guide }}/">
+      Bir aracın dosyalarınıza gerçekten ihtiyacı olup olmadığını nasıl
+      anlarsınız</a>
+    kendi başınıza çalıştırabileceğiniz dört kontrol sunar, bu sitede de
+    başka herhangi bir sitede de."""
+
+hub_guides_note = """
+    Hangi ayarı hareket ettireceğinizden veya bedelinin ne olduğundan emin
+    değil misiniz?
+    <a href="{{ base }}{{ links.guides }}/">Her araç için bir rehber
+    var</a>."""
+
+hub_roadmap_note = """
+    Daha fazlası geliyor ve liste açık:
+    <a href="{{ base }}{{ links.roadmap }}/">sırada ne planlandığını
+    görün</a>."""
+
+guides_all_note = """
+    Buradaki her rehber kendi cihazınızda çalışan bir aracı anlatır:
+    <a href="{{ base }}">hepsini görün</a>."""
+
+[ui.tool]
+view_source = "Kaynak kodu görüntüle"
+how_verified = "Bu nasıl doğrulanır"
+live_check = "Canlı kontrol:"
+offline = "Çevrimdışı:"
+checking = "kontrol ediliyor&hellip;"
+questions_heading = "Sorular"
+guide_heading = "Uzun sürüm"
+related_heading = "Kutuda ayrıca"
+privacy_heading = "Gizlilik iddiası nasıl doğrulanabilir"
+
+pledge_line = """
+    {{ tool.words.plural }} <strong>asla yüklenmez</strong>. Sunucu yoktur."""
+
+boot_title = "Bu sayfanın kodu başlamadı."
+boot_body = """
+    <code>index.html</code> dosyasını doğrudan bir klasörden açmak
+    JavaScript modüllerini engeller, bu yüzden {{ tool.words.choose }}
+    seçildiğinde hiçbir şey olmaz. Klasörü bunun yerine http üzerinden
+    sunun:"""
+boot_then = "Ardından <code>http://localhost:8080/</code> adresini açın."
+
+noscript_title = "JavaScript devre dışı."
+noscript_body = "Bu uygulama tüm işini tarayıcınızın içinde yapar ve onsuz çalışamaz."
+
+offline_ready = "hazır &mdash; internet bağlantısını kesin, bu yine de çalışır."
+offline_none = "bu tarayıcıda kullanılamıyor (diğer her şey çalışmaya devam eder)."
+offline_insecure = "çevrimdışı kullanım için önbelleğe almak https:// veya localhost gerektirir."
+offline_failed = "önbelleğe alma burada mümkün değil, ancak zaten hiçbir şey yüklenmiyor."
+
+error_broke = "Bir şeyler bozuldu: {detail}. Baştan başlamak için sayfayı yeniden yükleyin."
+
+reading_one = "{count} dosya okunuyor&hellip;"
+reading_many = "{count} dosya okunuyor&hellip;"
+
+check_yourself = """
+      <strong>Kendiniz kontrol edin.</strong> Yukarıdakilerin hiçbirine
+      güvenmeniz gerekmez. Bu sayfa, depodaki şablonlardan ve
+      yapılandırmadan, okuyup kendiniz çalıştırabileceğiniz bir derleme
+      betiği tarafından üretilir ve sonuç <code>dist</code> dalına işlenir
+      &mdash; yani sunulan şeyi kaynakların bir derlemesinin ürettiğiyle
+      karşılaştırabilirsiniz:"""
+
+read_first_lead = """
+      Önce okunmaya değer dosyalar, Content-Security-Policy için
+      <code>config/site.toml</code>"""
+
+[ui.feedback]
+prompt = "İşe yaradı mı?"
+up = "Evet"
+down = "Hayır"
+dismiss = "Kapat"
+
+reason_prompt = "Ne yanlış gitti?"
+reason_wrong = "Yanlış sonuç"
+reason_failed = "Tamamlanmadı"
+reason_slow = "Çok yavaş"
+reason_confusing = "Kafa karıştırıcı"
+
+thanks = "Teşekkürler &mdash; bu yardımcı oluyor."
+
+note = """
+      Yalnızca yanıt gönderilir, yalnızca bir düğmeye bastığınızda.
+      Dosyanız, adı veya onun hakkında hiçbir şey asla gönderilmez."""
+
+[ui.guide]
+open_tool = "{{ tool.name | e }} aracını açın"
+
+[ui.picker]
+warning = """
+      <strong>Ağa dokunan tek özellik budur.</strong> Bir adresi almak, o
+      sunucuya IP adresinizi ve istediğiniz {{ tool.picker.urls.noun }}'i
+      bildirir. {{ tool.picker.urls.noun }}, geldiğinde yerel belleğe
+      kopyalanır ve bir daha istenmez. Sizden hiçbir şey dışarı
+      gönderilmez &mdash; bu sayfa yine de hiçbir türde yükleme yapamaz."""
+label = "Satır başına bir adres"
+note = """
+      Sunucu, {{ tool.picker.urls.noun }}'inin kaynaklar arası kullanımına
+      izin vermelidir. Birçok site buna izin vermez ve bunlar daha sonra
+      sessizce bozulmak yerine bir mesajla başarısız olur."""

--- a/locales/zh-TW/locale.toml
+++ b/locales/zh-TW/locale.toml
@@ -1,0 +1,339 @@
+#
+# 繁體中文.
+#
+# The frame: the hub, the guides index, the roadmap, the 404, the footer, and
+# the words the templates themselves use. Tools and guides are NOT translated
+# yet - they stay in whatever language they fall back to (see `fallback`
+# below) and are held out of the sitemap, the hreflang sets and the switcher
+# exactly as an unfinished part of any other locale is.
+#
+# HOW THIS FILE WAS MADE, AND WHAT THAT MEANS FOR MAINTAINING IT
+#
+# locales/zh/ was "written, not translated" - its own header says so at
+# length, and the result reads as native Chinese rather than as English in
+# Chinese characters. This file is NOT that. It is locales/zh/'s prose put
+# through script conversion (simplified -> traditional glyphs) plus the
+# handful of vocabulary swaps a Taiwan reader actually notices - 文件 ->
+# 檔案 for a computer file (and 文档 -> 文件 for the *document* sense, which
+# swaps the other way), 服务器 -> 伺服器, 网络/网线 -> 網路/網路線, 缓存 ->
+# 快取, 内存 -> 記憶體, 视频 -> 影片, 硬件 -> 硬體, 源码/代码 -> 原始碼/程式
+# 碼, 联系 -> 聯絡, 接口 -> 介面, 链接 -> 連結, 文件夹 -> 資料夾, 缩略图 ->
+# 縮圖, 设置 -> 設定, 信息 -> 資訊, and 干/干活 reworded away entirely - 幹
+# is the traditional form of 干 and is vulgar in Taiwan Mandarin, so every
+# "干完/照干不误" in the source became "做完/照常運作" rather than a literal
+# character conversion.
+#
+# That is a mechanical pass, not a native Taiwan rewrite, and the two are not
+# the same quality bar. If locales/zh/'s wording changes, this file is the
+# next place to check, and a native Taiwan reader improving a line here is
+# improving the file rather than fighting it.
+#
+# `fallback = "zh"` (see buildlib/i18n.py) is what makes that gap survivable
+# for tools and guides: a page this locale has not translated shows
+# locales/zh/'s Simplified-script version rather than English, and only
+# falls all the way to English where zh has not translated it either. The
+# FRAME below is not part of that - `complete = true` still means every
+# string here is genuinely Traditional Chinese, the same rule every other
+# locale is held to.
+#
+# No [slugs] table, for the same reason locales/zh/ has none: a Han slug has
+# to be percent-encoded to survive being pasted around, and pinyin or zhuyin
+# is not a phrase anybody searches for. The keyword weight goes into the
+# title, the description and the h1 instead.
+#
+# `hreflang` is zh-Hant rather than zh-TW, on the same reasoning locales/zh/
+# gives for zh-Hans over zh-CN: the distinction that matters to a reader here
+# is the script, not the country, and zh-Hant is what tells Google that.
+#
+
+lang = "zh-TW"
+name = "Chinese (Traditional)"
+endonym = "繁體中文"
+hreflang = "zh-Hant"
+
+# Read locales/zh/'s prose first when a tool or guide is genuinely
+# translated here - `fallback` only changes what an UNTRANSLATED page
+# borrows, not how `complete` is judged.
+fallback = "zh"
+
+complete = true
+
+#
+# ---------------------------------------------------------------------------
+# The hub.
+# ---------------------------------------------------------------------------
+#
+
+[hub]
+title = "免費線上工具箱 | 不上傳檔案，不用註冊 | abox.tools"
+description = "全部免費，檔案不用上傳。圖片拼成 PDF 或 MP4、把圖片壓到指定大小、裁切影片、清除 EXIF，都在你自己的瀏覽器裡做完。"
+heading = "一箱子工具，都不走伺服器"
+og_title = "A Box of Tools | 不走伺服器的工具"
+og_description = "一個工具只做一件事，全程在你的瀏覽器裡跑。檔案不會離開這台機器。"
+og_image_alt = "abox.tools - 不走伺服器的工具"
+schema_description = "一個工具只做一件事，活全在瀏覽器裡做完。沒有東西要上傳，也不用帳號。"
+schema_about = "在瀏覽器裡就地處理檔案、不需要上傳的檔案工具"
+
+lede = """
+    一個工具只做一件事，全程在你的瀏覽器裡跑。檔案留在你自己的機器上，沒有\
+    東西要傳，沒有帳號要註冊，也沒人在旁邊記你做了什麼。"""
+
+support_note = """
+      這些工具免費，以後也一樣。要是哪個真幫你省了事，全站開口跟你要點什麼\
+      的地方，就這一處。"""
+
+[[hub.guarantees]]
+title = "檔案不出你這台機器"
+body = """
+        打開、讀取、處理，全是你自己的瀏覽器在做，用的是你自己的硬體。每個\
+        工具的 <code>Content-Security-Policy</code> 都把允許連的地址列全了，\
+        裡面沒有一個是我們的。"""
+
+[[hub.guarantees]]
+title = "連你檔案的資訊也傳不出去"
+body = """
+        檔案本身不傳，縮圖、檔案名稱、大小、選了幾個，一樣不傳。這裡沒有哪個\
+        工具去讀這些，另一頭也沒有伺服器等著收。"""
+
+[[hub.guarantees]]
+title = "斷網照樣能用"
+body = """
+        把工具打開一次，然後拔掉網路線，它照常運作，跟連網時沒有差別。這一步\
+        很難作假。真要把檔案送出去處理，斷網當場就停。"""
+
+[[hub.categories]]
+id = "images"
+name = "圖片"
+note = "壓縮、改尺寸，或者抹掉照片悄悄記下的那些資訊，全都不出這台機器。"
+
+[[hub.categories]]
+id = "video-and-animation"
+name = "影片與動畫"
+note = "剪片、轉格式，或者用照片拼一段，素材都不出這台機器。"
+
+[[hub.categories]]
+id = "documents-and-audio"
+name = "文件與音訊"
+note = "拼接文件、剪輯錄音，兩樣都不用送出去處理。"
+
+[[hub.categories]]
+id = "text-codes-and-passwords"
+name = "文字、代碼與密碼"
+note = "看一看、核一核，或者就在這裡產生。令牌、設定檔和密碼都不會落到別人的伺服器上。"
+
+#
+# ---------------------------------------------------------------------------
+# The guides index.
+# ---------------------------------------------------------------------------
+#
+
+[guides]
+nav = "全部指南"
+title = "指南 | 這件事怎麼做，每個選擇又要付出什麼"
+description = "壓縮、縮放、裁剪、剪輯、轉格式，一件一件說清楚。設定到底動了什麼，代價在哪裡，為什麼這些都用不著上傳。"
+heading = "指南"
+lede = """
+    一個工具一篇。寫給那些被人要求交出某個大小、某種格式，又想弄明白手上這個\
+    設定到底在動什麼的人。這裡講的每一步，都發生在你自己的機器上。"""
+og_title = "abox.tools 指南"
+og_description = "怎麼壓縮、縮放、裁剪、剪輯、轉換自己的檔案，每個設定又要付出什麼。全程用不著上傳。"
+og_image_alt = "abox.tools - 不走伺服器的工具"
+
+[[guides.groups]]
+id = "doing-the-job"
+name = "把工作做完"
+note = "一個工具一篇：這活要做什麼，哪個設定真管用，代價又是什麼。"
+
+[[guides.groups]]
+id = "before-you-upload"
+name = "上傳之前"
+note = "把檔案交給一個網站，到底等於交出了什麼，以及這一步是不是非做不可。"
+
+#
+# ---------------------------------------------------------------------------
+# The roadmap. Only the frame - the list itself is config/planned.toml, which
+# has no locale file yet and is therefore still English on this page.
+# ---------------------------------------------------------------------------
+#
+
+[roadmap]
+nav = "路線圖"
+title = "路線圖 | abox.tools 接下來做什麼"
+description = "abox.tools 打算做的工具都在這裡，分好類，公開列著，已經做完的也在。全都在瀏覽器裡跑，全都不上傳。"
+heading = "接下來做什麼"
+lede = """
+    下面兩份清單上的每一項，都得在你的瀏覽器裡運作，都得不上傳東西。過不了\
+    這一關，名字根本上不了榜。兩個數字沒寫死在任何地方，是建置腳本從清單上\
+    數出來的。"""
+
+intro_heading = "這份清單是怎麼定出來的"
+intro = """
+    <p>
+      這不是許願單。做法是把網上最大那家 GIF 和影片站點的工具列表從頭到尾過\
+      一遍，那份列表大概是現存最接近「人們到底想拿檔案做什麼」的一份目錄，\
+      然後只留下那些能做到在你自己機器上完成、拔了網路線也照常運作的條目。
+    </p>
+    <p>
+      留下來的絕大多數，靠瀏覽器本來就帶的介面就夠了。少數幾個得把編解碼器\
+      打包進唯一用到它的那個工具裡，這也算過關，檔案照樣不出這台機器。達不到\
+      這條線的寧可不寫，所以下面幾個看著很明顯的空缺，是故意空著的。
+    </p>
+    <p>
+      已經做出來的排在各自分組最前面，標著<em>已完成</em>，點進去就是它自己\
+      的頁面。下面的都還沒做，做出來之前不會變成連結。
+    </p>"""
+
+planned_heading = "每一類檔案，以及能拿它做什麼"
+
+og_title = "abox.tools 路線圖"
+og_description = "哪些做好了，接下來做什麼。全都在瀏覽器裡跑，全都不上傳。"
+og_image_alt = "abox.tools - 不走伺服器的工具"
+
+#
+# ---------------------------------------------------------------------------
+# The 404. Built in English only today, but translated anyway.
+# ---------------------------------------------------------------------------
+#
+
+[not_found]
+title = "頁面不存在 | abox.tools"
+description = "abox.tools 上沒有這個地址。下面這些工具是真有的，全部免費，也沒有一個會把你的檔案傳去別處。"
+heading = "這個頁面不在這裡"
+tools_heading = "全部工具，都在這裡"
+tools_note = "全部免費，全在你的瀏覽器裡跑，沒有一個上傳東西。"
+
+lede = """
+    要麼地址打錯了，要麼原來在這裡的東西挪了地方。你的檔案沒事，也沒丟掉\
+    什麼。本站從來沒拿到過你的東西，想丟也無從丟起。"""
+
+#
+# ---------------------------------------------------------------------------
+# The footer.
+# ---------------------------------------------------------------------------
+#
+
+[footer]
+blurb = """
+        不走伺服器的工具。檔案留在你自己的機器上，沒有東西要傳，也不用註冊\
+        帳號。"""
+base = "本站說的每一句話，都是寫來給你核對的，不是寫來讓你信的。"
+
+#
+# ---------------------------------------------------------------------------
+# The frame's own words. Everything with {{ }} in it is a name the build
+# resolves, and the build refuses to render a name it cannot find.
+# ---------------------------------------------------------------------------
+#
+
+[ui]
+languages = "語言"
+lang_auto = "你的瀏覽器要的是繁體中文，所以這個頁面按繁體中文顯示。"
+breadcrumb = "麵包屑導覽"
+all_tools = "全部工具"
+last_updated = "最後更新"
+built_tag = "已完成"
+planned_count = "項計畫中"
+built_count = "項已完成"
+
+guide_one = "篇指南"
+guide_many = "篇指南"
+
+footer_tools = "工具"
+footer_site = "本站"
+footer_contact = "聯絡我們"
+footer_sitemap = "網站地圖"
+footer_source = "在 GitHub 上讀原始碼"
+
+guarantees_note = """
+    上面這些不用你信。
+    <a href="{{ base }}{{ links.safety_guide }}/">
+      怎麼判斷一個工具是不是真需要你的檔案</a>
+    裡有四項你自己動手就能做的檢查，用在本站管用，用在別家也一樣。"""
+
+hub_guides_note = """
+    不知道該動哪個設定，也不清楚代價？
+    <a href="{{ base }}{{ links.guides }}/">每個工具都配了一篇指南</a>。"""
+
+hub_roadmap_note = """
+    後面還有，清單也是公開的。
+    <a href="{{ base }}{{ links.roadmap }}/">看看接下來做什麼</a>。"""
+
+guides_all_note = """
+    這裡每篇指南講的工具，都跑在你自己的機器上。
+    <a href="{{ base }}">全都在這裡</a>。"""
+
+[ui.tool]
+view_source = "檢視原始碼"
+how_verified = "這條怎麼核實"
+live_check = "即時檢查："
+offline = "離線："
+checking = "檢查中&hellip;"
+questions_heading = "常見問題"
+guide_heading = "說得更細的版本"
+related_heading = "工具箱裡還有"
+privacy_heading = "這條隱私承諾怎麼核實"
+
+pledge_line = """
+    你的{{ tool.words.plural }}<strong>不會上傳</strong>。這裡根本沒有伺服器。"""
+
+boot_title = "這個頁面的程式碼沒有跑起來。"
+boot_body = """
+    直接從資料夾裡打開 <code>index.html</code>，瀏覽器會擋下 JavaScript 模組，\
+    於是你選好{{ tool.words.choose }}之後，頁面不會有任何反應。改用 http 把這個\
+    資料夾提供出去："""
+boot_then = "然後打開 <code>http://localhost:8080/</code>。"
+
+noscript_title = "JavaScript 被停用了。"
+noscript_body = "這個頁面全部的工作都在你的瀏覽器裡完成，沒有 JavaScript 就跑不起來。"
+
+offline_ready = "已就緒——斷網之後這一頁照樣能用。"
+offline_none = "這個瀏覽器裡用不了（其餘的照樣能用）。"
+offline_insecure = "離線快取需要 https:// 或者 localhost。"
+offline_failed = "這裡快取不了，不過反正什麼都不會上傳。"
+
+error_broke = "出錯了：{detail}。重新載入頁面即可從頭開始。"
+
+reading_one = "正在讀取 {count} 個檔案&hellip;"
+reading_many = "正在讀取 {count} 個檔案&hellip;"
+
+check_yourself = """
+      <strong>你可以自己核對。</strong>上面這些不用你信。這個頁面是儲存庫裡的\
+      範本和設定產生出來的，建置腳本你能讀，也能自己跑一遍，跑出來的結果就\
+      提交在 <code>dist</code> 分支上。拿實際發給你的內容，跟你自己從原始碼\
+      建置出來的結果對一遍就知道了："""
+
+read_first_lead = """
+      最值得先讀的幾個檔案：<code>config/site.toml</code> 裡是
+      Content-Security-Policy"""
+
+[ui.feedback]
+prompt = "這次管用嗎？"
+up = "管用"
+down = "不管用"
+dismiss = "關閉"
+
+reason_prompt = "哪裡不對？"
+reason_wrong = "結果不對"
+reason_failed = "沒跑完"
+reason_slow = "太慢"
+reason_confusing = "不會用"
+
+thanks = "謝謝，這很有用。"
+
+note = """
+      發出去的只有你這個回答，而且只在你按下按鈕的時候。你的檔案、它的名字，\
+      以及跟它有關的任何東西，一樣都不發。"""
+
+[ui.guide]
+open_tool = "打開{{ tool.name | e }}"
+
+[ui.picker]
+warning = """
+      <strong>這是唯一一處會碰網路的功能。</strong>
+      抓一個網址，等於告訴那台伺服器你的 IP 位址，以及你要的是哪個{{ tool.picker.urls.noun }}。\
+      {{ tool.picker.urls.noun }}到手之後複製進本機記憶體，不會再請求第二次。你這邊\
+      始終沒有東西發出去，這個頁面照樣做不了任何形式的上傳。"""
+label = "一行一個網址"
+note = """
+      對方伺服器得允許跨域使用它的{{ tool.picker.urls.noun }}。很多站點不允許，\
+      這類會當場失敗並說明原因，不會過一陣子悄沒聲地出問題。"""

--- a/tests/python/test_i18n.py
+++ b/tests/python/test_i18n.py
@@ -37,6 +37,7 @@ def locale(**over):
     base = {
         'lang': 'de', 'name': 'German', 'endonym': 'Deutsch', 'hreflang': 'de',
         'dir': 'ltr', 'complete': False, 'is_base': False, 'prefix': 'de/',
+        'fallback': None, 'fallback_locale': None,
         'slugs': {}, 'site': SITE, 'tools': {}, 'pages': {}, 'bodies': {},
         'planned': {}, 'frame': [], 'debt': {},
     }
@@ -369,6 +370,119 @@ class FallingBackInsideALanguage(unittest.TestCase):
         found = self.relocate('<a href="../trim-video/#faq">Trim</a>',
                               'reverse-video')
         self.assertIn('href="/de/video-schneiden/#faq"', found)
+
+
+class FallingBackToANearRelative(unittest.TestCase):
+    """`fallback`: what an untranslated page shows when a near relative's
+    words are a better stand-in than English's - Traditional Chinese next to
+    Simplified is the case this exists for.
+    """
+
+    def test_link_fallbacks_resolves_the_name(self):
+        zh = {'lang': 'zh'}
+        tw = {'lang': 'zh-TW', 'fallback': 'zh'}
+        i18n.link_fallbacks([zh, tw])
+        self.assertIs(tw['fallback_locale'], zh)
+        self.assertIsNone(zh['fallback_locale'])
+
+    def test_a_locale_with_no_fallback_gets_none(self):
+        de = {'lang': 'de'}
+        i18n.link_fallbacks([de])
+        self.assertIsNone(de['fallback_locale'])
+
+    def test_naming_itself_is_refused(self):
+        with self.assertRaises(ConfigError):
+            i18n.link_fallbacks([{'lang': 'zh-TW', 'fallback': 'zh-TW'}])
+
+    def test_naming_an_unknown_locale_is_refused(self):
+        with self.assertRaises(ConfigError) as caught:
+            i18n.link_fallbacks([{'lang': 'zh-TW', 'fallback': 'zh'}])
+        self.assertIn('zh', str(caught.exception))
+
+    def test_a_chain_is_refused(self):
+        """Only one level - a fallback's own fallback would have to be
+        resolved in dependency order first, and nothing has asked for a
+        second level yet."""
+        x = {'lang': 'x'}
+        y = {'lang': 'y', 'fallback': 'x'}
+        z = {'lang': 'z', 'fallback': 'y'}
+        with self.assertRaises(ConfigError) as caught:
+            i18n.link_fallbacks([x, y, z])
+        self.assertIn('y', str(caught.exception))
+
+    def test_an_untranslated_page_borrows_the_near_relatives_word(self):
+        page = {'slug': 'a-guide', 'nav': 'A guide'}
+        zh = locale(lang='zh', prefix='zh/',
+                   pages={'a-guide': {'nav': '一篇指南'}})
+        tw = locale(lang='zh-TW', prefix='zh-TW/', fallback='zh',
+                   fallback_locale=zh)
+        found = i18n.localize_page(page, tw, SITE)
+        self.assertEqual(found['nav'], '一篇指南')
+
+    def test_a_page_neither_has_falls_back_to_english(self):
+        """The chain never dead-ends: the near relative's own gap is filled
+        from English, exactly as it would be for the near relative itself."""
+        page = {'slug': 'a-guide', 'nav': 'A guide'}
+        zh = locale(lang='zh', prefix='zh/')
+        tw = locale(lang='zh-TW', prefix='zh-TW/', fallback='zh',
+                   fallback_locale=zh)
+        found = i18n.localize_page(page, tw, SITE)
+        self.assertEqual(found['nav'], 'A guide')
+
+    def test_the_locales_own_translation_still_wins(self):
+        page = {'slug': 'a-guide', 'nav': 'A guide'}
+        zh = locale(lang='zh', prefix='zh/',
+                   pages={'a-guide': {'nav': '一篇指南'}})
+        tw = locale(lang='zh-TW', prefix='zh-TW/', fallback='zh',
+                   fallback_locale=zh,
+                   pages={'a-guide': {'nav': '一篇指南（繁體）'}})
+        found = i18n.localize_page(page, tw, SITE)
+        self.assertEqual(found['nav'], '一篇指南（繁體）')
+
+    def test_a_borrowed_link_is_relocated_for_this_locale_not_the_near_relative(self):
+        """The regression this mechanism could ship with on day one: a page
+        borrowed from `zh` linking into `zh`'s own tree instead of
+        `zh-TW`'s, because it was relocated once for `zh` and again for
+        `zh-TW` on top of that. It must be relocated exactly once, against
+        the address `zh-TW` itself gives the linked page."""
+        page = {'slug': 'guide-a', 'nav': 'Guide A'}
+        zh = locale(lang='zh', prefix='zh/', slugs={'guide-b': 'zh-b'},
+                   pages={'guide-a': {'nav': '<a href="../guide-b/">B</a>'}})
+        tw = locale(lang='zh-TW', prefix='zh-TW/', fallback='zh',
+                   fallback_locale=zh, slugs={'guide-b': 'tw-b'})
+        found = i18n.localize_page(page, tw, SITE)
+        self.assertIn('href="/zh-TW/tw-b/"', found['nav'])
+
+    def test_a_body_borrows_the_near_relatives_and_is_relocated_once(self):
+        """`body_for` has the same borrowed-link hazard `localize_page` does,
+        for a whole file rather than one key - see the test above."""
+        zh = locale(lang='zh', prefix='zh/', slugs={'guide-b': 'zh-b'},
+                   bodies={'pages/guide-a': '<a href="../guide-b/">B</a>'})
+        tw = locale(lang='zh-TW', prefix='zh-TW/', fallback='zh',
+                   fallback_locale=zh, slugs={'guide-b': 'tw-b'})
+        found = i18n.body_for(tw, 'pages', 'guide-a', 'English fallback')
+        self.assertIn('href="/zh-TW/tw-b/"', found)
+        self.assertEqual(tw['debt']['guide-a'], ['pages.guide-a.body'])
+
+    def test_a_body_neither_has_falls_back_to_english(self):
+        zh = locale(lang='zh', prefix='zh/')
+        tw = locale(lang='zh-TW', prefix='zh-TW/', fallback='zh',
+                   fallback_locale=zh)
+        found = i18n.body_for(tw, 'pages', 'guide-a', 'English fallback')
+        self.assertEqual(found, 'English fallback')
+
+    def test_debt_is_unaffected_by_the_fallback(self):
+        """Showing the near relative's words is a courtesy to the reader,
+        not a second way to be finished: the page is exactly as
+        untranslated, and exactly as absent from the sitemap and the
+        hreflang set, as if it had fallen back to English."""
+        page = {'slug': 'a-guide', 'nav': 'A guide'}
+        zh = locale(lang='zh', prefix='zh/',
+                   pages={'a-guide': {'nav': '一篇指南'}})
+        tw = locale(lang='zh-TW', prefix='zh-TW/', fallback='zh',
+                   fallback_locale=zh, complete=True)
+        i18n.localize_page(page, tw, SITE)
+        self.assertFalse(i18n.translated(tw, 'a-guide'))
 
 
 class Advertising(unittest.TestCase):


### PR DESCRIPTION
## What

- **\`locales/tr/\`** and **\`locales/id/\`** — frame-only locales (nav, footer, hub, guides index, roadmap frame, 404, every \`[ui]\` string) for Turkish and Indonesian, plus a full \`[slugs]\` table for each. Both LTR, both \`complete = true\`. Tools and guides are not translated yet and fall back page by page, same as every other locale started.
- **\`locales/zh-TW/\`** — Traditional Chinese, same frame-only scope, but built as a documented script conversion of \`locales/zh/\`'s existing native Simplified prose (glyph conversion + the Taiwan vocabulary swaps a reader actually notices — 文件→檔案, 服务器→伺服器, 缓存→快取, etc.) rather than an independent rewrite. The file's own header says so, so a native reviewer knows it's a starting point.
- **A locale-to-locale fallback**, in \`buildlib/i18n.py\`: a locale can now set \`fallback = "<lang>"\` so an untranslated tool/guide page shows that locale's words instead of English's, falling further to English only where the fallback locale hasn't translated it either. \`locales/zh-TW/\` uses this with \`fallback = "zh"\`.

## Why the fallback feature

Traditional and Simplified Chinese are the same language in two scripts — a zh-TW reader can make out zh's Simplified prose far better than they can make out English. Rather than leave zh-TW's untranslated pages in English while zh already has all 29 tools translated, an untranslated zh-TW page now borrows zh's content.

**This changes nothing about what counts as finished.** \`complete\`, the per-page debt, the sitemap, and the hreflang set are all still judged purely on zh-TW's own translation work — a zh-TW page showing borrowed Simplified prose is exactly as unpublished as one showing English would be. \`fallback\` is a reader courtesy, not a second way to be complete. Reasoning at length in \`buildlib/i18n.py\`'s module docstring.

The one real hazard this design has to avoid: a page borrowed from zh must not carry links pointing into zh's own tree instead of zh-TW's (which is exactly what happens if the borrowed text gets relocated twice — once for zh, once for zh-TW). \`fallback_base\` keeps the borrowed content unrelocated until the very end so it's relocated exactly once, for the tree it's actually being served on. There's a regression test for this specific failure mode.

## Also fixes

\`lang_auto\` in \`locales/tr/\` and \`locales/id/\` — every locale's \`lang_auto\` string is supposed to name **itself** (German's says "shown in German"). Caught this before either locale shipped; the same mistake slipped into Arabic and is fixed separately in #103.

## Verification

- Clean build across all 14 locales; log confirms \`zh-TW: published, 57 of 57 pages still falling back to zh\` rather than English.
- Direct output inspection: a zh-TW tool page shows zh's Simplified prose, and an internal link inside that borrowed prose resolves to \`/zh-TW/...\`, not \`/zh/...\`.
- \`zh-TW\`'s own hreflang set and sitemap correctly exclude pages it hasn't translated itself, even though those pages render zh's content.
- Full Python test suite: 407 tests, all green, including 11 new tests for the fallback mechanism (link resolution, self-reference and chain rejection, borrowing, the locale's-own-translation-still-wins case, debt independence from the fallback, and the double-relocation regression for both \`localize_page\`/\`localize_tool\` and \`body_for\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)