### PR TITLE
Fix QA post-deploy workflow: check out this repo's own source

### DIFF
--- a/.github/workflows/qa-on-deploy.yml
+++ b/.github/workflows/qa-on-deploy.yml
@@ -40,6 +40,20 @@ jobs:
           repository: A-Box-of-Tools/qa
           path: qa
 
+      # The QA suite's lib/tools.ts, lib/csp.ts and hasFilePicker() all read
+      # this repo's own source (the tool list, config/site.toml's CSP
+      # allowlist, each tool's body.html) at test time rather than
+      # duplicating it - see its lib/site.ts. This workflow is triggered by
+      # a push to `dist`, though, which holds only the *built* output (see
+      # build.yml) and has no tools/ or config/ at all - so the source has to
+      # be checked out separately, pinned to main rather than whatever ref
+      # triggered this run.
+      - name: Check out this repo's source (tool/CSP metadata)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: etoolbox-src
+
       # GitHub Pages usually publishes within a minute of `dist` moving, but
       # that isn't guaranteed - poll rather than assume, so a slow publish is
       # a short wait here instead of a flaky red run against the old build.
@@ -75,6 +89,7 @@ jobs:
         working-directory: qa
         env:
           BASE_URL: https://abox.tools/
+          ETOOLBOX_DIR: ${{ github.workspace }}/etoolbox-src
         run: npx playwright test
 
       - name: Upload the HTML report


### PR DESCRIPTION
Follow-up to #106, which merged before this fix landed.

The QA suite's `lib/tools.ts`, `lib/csp.ts` and `hasFilePicker()` read this repo's own tool list, CSP allowlist and each tool's `body.html` at test time rather than duplicating them (see [A-Box-of-Tools/qa](https://github.com/A-Box-of-Tools/qa)'s `lib/site.ts`). `qa-on-deploy.yml` only checked out the `qa` repo, not this one - and the push that triggers it is to `dist`, which holds only the *built* output (see `build.yml`), not `tools/` or `config/`. So there was nothing for those lib functions to read on the runner, and `discoverTools()` threw `ENOENT` before a single test ran.

Caught by `A-Box-of-Tools/qa`'s own `report.yml` hitting the identical bug in its first run - same fix applied there: https://github.com/A-Box-of-Tools/qa/actions/runs/32767307056

Checks out `main` explicitly into `etoolbox-src` (pinned, since the triggering ref is `dist`) and points `ETOOLBOX_DIR` at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)