### PR TITLE
Give the decoder its frames back, so a 4K reversal is not a deadlock

### DIFF
--- a/tools/reverse-video/src/reverse.js
+++ b/tools/reverse-video/src/reverse.js
@@ -56,16 +56,18 @@ const MAX_BITRATE = 60_000_000;
 const QUEUE_LIMIT = 8;
 
 /**
- * How long the decode/encode queues may sit without draining before a
- * reversal gives up rather than waiting forever.
+ * How long the queues may sit without draining before a reversal gives up.
  *
- * A codec that has genuinely stalled - a hardware encoder the driver cannot
- * actually deliver on, say, despite `isConfigSupported` saying yes - does not
- * reliably fire `error`: the `dequeue` event this waits on simply never comes
- * again. Without a ceiling on that wait, `settle` spins quietly and the page
- * sits at "Preparing..." with nothing to show for it and nothing to click.
- * Thirty seconds is far past what a queue of eight frames takes to drain on
- * any hardware actually processing them, even in software at 4K.
+ * A stalled codec does not reliably report anything: it stops draining and the
+ * `dequeue` event this waits on simply never comes again. Without a ceiling on
+ * that wait the page sits at "Preparing..." forever, which is the one failure
+ * a visitor cannot tell from slow progress.
+ *
+ * The stall this was written for - holding a window of frames and starving the
+ * decoder's surface pool - is fixed above, so reaching this now means something
+ * genuinely unexplained. It is kept because an indefinite hang is a bad enough
+ * outcome to be worth a backstop, and thirty seconds is far longer than a queue
+ * of eight frames takes anywhere that is really working, software 4K included.
  */
 const STALL_TIMEOUT_MS = 30_000;
 
@@ -135,10 +137,9 @@ async function settle(decoder, encoder) {
       bestSeen = size;
       progressAt = Date.now();
     } else if (Date.now() - progressAt > STALL_TIMEOUT_MS) {
-      throw new Error('The video decoder or encoder stopped responding partway through, rather '
-        + 'than reporting an error. This usually means the browser accepted this file at this '
-        + 'resolution and quality but cannot actually deliver on it in hardware; a smaller '
-        + 'clip, a lower quality setting, or a different browser is worth trying.');
+      throw new Error('The video decoder or encoder stopped responding partway through, without '
+        + 'reporting a reason. A shorter clip, a lower quality setting, or a different browser '
+        + 'is worth trying.');
     }
 
     await new Promise((resolve) => {
@@ -294,16 +295,76 @@ export async function reverseExact({
    * shown in another.
    */
   let wanted = new Map();
-  let held = [];
+
+  /** The wanted frames' pixels, owned by us rather than by the decoder. */
+  let kept = [];
+
+  /** Copies still running. `flush` promises the callbacks ran, not that these did. */
+  let copies = [];
 
   const decoder = new VideoDecoder({
     output: (videoFrame) => {
-      if (wanted.has(videoFrame.timestamp)) held.push(videoFrame);
-      else videoFrame.close();
+      if (!wanted.has(videoFrame.timestamp)) {
+        videoFrame.close();
+        return;
+      }
+
+      // The pixels are copied out and the frame released immediately, rather
+      // than the frame being held until the window is ready to encode it.
+      //
+      // That is not a memory optimisation - the copy is the same size as the
+      // frame - it is what keeps the decoder running at all. A decoder hands
+      // back pictures from a small pool of surfaces, and it is a pool rather
+      // than an allocation: a dozen or so at 4K, whatever the machine has.
+      // While the application holds them it cannot decode, and holding a
+      // window of them is therefore not slow but stuck, because the frames
+      // that would release the pool are the ones still queued behind it. The
+      // budget in windowLimit() is counted in bytes and cannot see this, and
+      // at 4K it asks for about three times what the pool can spare.
+      const rect = videoFrame.visibleRect;
+      const slot = {
+        timestamp: videoFrame.timestamp,
+        format: videoFrame.format,
+        // Sized to the visible rectangle, which is what copyTo() writes out:
+        // a frame coded taller than it is shown has that padding dropped here
+        // rather than travelling with it.
+        width: rect ? rect.width : videoFrame.codedWidth,
+        height: rect ? rect.height : videoFrame.codedHeight,
+        displayWidth: videoFrame.displayWidth,
+        displayHeight: videoFrame.displayHeight,
+        colorSpace: videoFrame.colorSpace,
+        data: null,
+        layout: null,
+      };
+      kept.push(slot);
+
+      // Left to run rather than awaited in turn: each frame is released the
+      // moment its own copy lands, and making them queue behind one another
+      // would hold the surfaces this exists to give back.
+      const buffer = new ArrayBuffer(videoFrame.allocationSize());
+      copies.push(videoFrame.copyTo(buffer)
+        .then((layout) => {
+          slot.data = buffer;
+          slot.layout = layout;
+        })
+        .catch((error) => { failure ??= error; })
+        .finally(() => videoFrame.close()));
     },
     error: (error) => { failure ??= error; },
   });
   decoder.configure(decoderConfig(video));
+
+  /** A kept frame, built back into something the canvas will draw. */
+  const rebuild = (slot) => new VideoFrame(slot.data, {
+    format: slot.format,
+    codedWidth: slot.width,
+    codedHeight: slot.height,
+    timestamp: slot.timestamp,
+    layout: slot.layout,
+    displayWidth: slot.displayWidth,
+    displayHeight: slot.displayHeight,
+    colorSpace: slot.colorSpace,
+  });
 
   /** One held frame, drawn and encoded at the time the reversal gives it. */
   const emit = (videoFrame, index) => {
@@ -359,7 +420,8 @@ export async function reverseExact({
         const run = shown.slice(window.from, window.to + 1);
         wanted = new Map(
           run.map((index) => [micros(video.samples[index].pts, video.timescale), index]));
-        held = [];
+        kept = [];
+        copies = [];
 
         // Everything a frame is built from decodes before it, so the feed can
         // stop at the last frame of this run rather than finishing the group.
@@ -379,15 +441,21 @@ export async function reverseExact({
         }
 
         await decoder.flush();
+        // `flush` waits for the output callbacks, and each of those starts a
+        // copy rather than finishing one. The pixels are only ours after this.
+        await Promise.all(copies);
+        copies = [];
         if (failure) throw failure;
 
         // Last shown, first written. This is the reversal.
-        held.sort((a, b) => b.timestamp - a.timestamp);
-        for (const videoFrame of held) {
-          emit(videoFrame, wanted.get(videoFrame.timestamp));
+        kept.sort((a, b) => b.timestamp - a.timestamp);
+        for (const slot of kept) {
+          if (!slot.data) continue;   // its copy failed; `failure` already holds why
+          emit(rebuild(slot), wanted.get(slot.timestamp));
+          slot.data = null;
           await settle(decoder, encoder);
         }
-        held = [];
+        kept = [];
 
         onProgress?.({ phase: 'reversing', done: drawn, total });
       }
@@ -399,7 +467,12 @@ export async function reverseExact({
     if (!encoded.length) throw new Error('No frames could be decoded from this file.');
     if (!avcC) throw new Error('The encoder never reported a decoder configuration.');
   } finally {
-    for (const videoFrame of held) videoFrame.close();
+    // The frames themselves were handed back as they arrived, so what is left
+    // to drop here is the copies. Any still running own a frame apiece and
+    // close it themselves, so they are waited for rather than abandoned.
+    await Promise.allSettled(copies);
+    kept = [];
+    copies = [];
     if (decoder.state !== 'closed') decoder.close();
     if (encoder.state !== 'closed') encoder.close();
   }


### PR DESCRIPTION
Follow-up to #105, which did not fix this. The tool still hung at
"Preparing..." on a 4K clip, so I reproduced it instead of guessing again.

## What is actually wrong

The window of frames a reversal holds was held as `VideoFrame`s straight from
the decoder. A decoder does not allocate those - it hands them out of a small
fixed pool of surfaces, and **it cannot decode while the application is holding
them**. So the window is not just a memory budget, it is a claim on the
decoder's own working set, and `windowLimit()` counts bytes and cannot see
that.

At 4K the two disagree badly:

| | |
|---|---|
| decoded 4K frame | 11.9 MB |
| `windowLimit(3840, 2160)` from the 384 MB budget | **32 frames held** |
| frames this machine's decoder would actually give up | **11** |

Measured directly, feeding a 60-frame group and closing nothing: 24 chunks fed,
11 frames out, `decodeQueueSize` stuck at 9 and never moving again. It is a
deadlock rather than a slowdown, because the frames that would release the pool
are the ones still queued behind the ones being held. Nothing throws, so the
page sits at "Preparing..." forever - and 4K is exactly where people reach for
this tool.

This is why #105 changed nothing: it added a timeout, so the hang became a
30-second error, but the reversal still never produced a file.

## The fix

A wanted frame is now copied out and closed at once; the window holds the
pixels rather than the surfaces. The copy is the same size as the frame, so the
budget and `windowLimit()` are unchanged and still honest - what changes is
that the decoder gets its pool back immediately and keeps running.

Two details worth review:

- copies are left to run **concurrently** rather than awaited in turn. Making
  them queue would hold the surfaces this exists to give back, which is the bug
  again in a smaller form;
- they are awaited after `flush()`, because `flush()` only promises the output
  callbacks *ran*, not that the copies they started finished.

Frames are rebuilt sized to the **visible** rectangle, which is what `copyTo()`
writes out, so a frame coded taller than it is shown drops that padding here
rather than carrying it into the encoder.

## Verification, in a browser

Against a generated 3840x2160 clip, 120 frames in two ~60-frame groups - the
shape of the reported file (4,815 frames in 81 groups = 59.4 per group):

- **before:** no progress past `preparing`, then the #105 timeout at 30 s
- **after:** finishes in **12.3 s**, progress 32 → 60 → 92 → 120

Decoding the result back to check it is a real reversal and not merely a file
that finished: 120 frames out, and output frame N carries source frame 119-N at
every sampled position (0, 1, 30, 60, 119). Round-tripping one frame through
copy-out and rebuild before this was wired up gave a mean pixel difference of
0.5/255 against drawing the decoded frame directly, so nothing is being lost or
colour-shifted.

`node --test "tests/js/*.test.js"` passes, 1,530 tests. `windowLimit`'s
`width * height * 1.5` is exactly the NV12 buffer size, so its tests hold
unchanged and needed no edit.

## Caveats

**11 is this machine's number, not a constant.** The fix does not depend on it
- holding zero surfaces is correct whatever the pool size - but I have only
measured one GPU and browser.

**The reported file is still not the file I tested.** I reproduced the
*shape* - 4K, ~60-frame groups - not the clip itself. The deadlock I measured
is real and sufficient to cause exactly this symptom; I cannot promise it is
the only thing wrong with that particular file.

**The Python suite still has not run to completion** on this branch - it takes
well past ten minutes in my environment, unrelated to this change. I ran
`test_duplicates` (4 passed; `demux.js`/`mp4.js` are the declared copies and
neither is touched) and `test_imports` (22 passed). CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
