### PR TITLE
Take a frame off the GPU when that is the only place it exists

### DIFF
--- a/tests/js/reverse-video.test.js
+++ b/tests/js/reverse-video.test.js
@@ -243,6 +243,19 @@ test('the frame budget falls as the frames get bigger', () => {
   assert.equal(windowLimit(64, 64), 600);
 });
 
+test('a frame that can only be held as a bitmap gets a shorter window', () => {
+  // 4:2:0 is 1.5 bytes a pixel and an ImageBitmap is 4, so the same budget
+  // buys fewer of them - which is the whole reason the caller says which.
+  const readable = windowLimit(3840, 2160);
+  const onGpu = windowLimit(3840, 2160, undefined, 4);
+
+  assert.equal(readable, 32);
+  assert.equal(onGpu, 12);
+  assert.ok(onGpu < readable, 'a bitmap costs more, so fewer fit');
+  // The floor still holds: something has to be held however dear it is.
+  assert.equal(windowLimit(16000, 16000, undefined, 4), 4);
+});
+
 /* -------------------------------------------------------------- the writing */
 
 test('durations are the gaps between one written frame and the next', () => {

--- a/tools/reverse-video/src/reverse.js
+++ b/tools/reverse-video/src/reverse.js
@@ -126,6 +126,89 @@ export function chooseBitrate({ video, size, fps, quality }) {
   return Math.round(Math.min(MAX_BITRATE, Math.max(MIN_BITRATE, ceiling)));
 }
 
+/**
+ * What a frame costs when it cannot be read and has to be held as a bitmap.
+ *
+ * A mappable frame is handed over in the decoder's own 4:2:0, which is the 1.5
+ * bytes a pixel windowLimit() assumes. A bitmap is not: it is four. So a file
+ * whose frames arrive on the GPU gets a shorter window for the same budget,
+ * which is the honest trade rather than the same window at nearly three times
+ * the memory.
+ */
+const BITMAP_BYTES_PER_PIXEL = 4;
+
+/**
+ * Whether this file's frames arrive as pictures we can read.
+ *
+ * Decided by decoding a single keyframe and asking, rather than by guessing
+ * from the codec: it is a property of the machine's decoder, not of the file.
+ * A hardware HEVC decoder typically answers `null` here - the picture is on the
+ * GPU and was never in memory - and everything downstream has to know that
+ * before it chooses a window size.
+ */
+async function framesAreOpaque(video, file) {
+  const key = video.samples.findIndex((sample) => sample.isKey);
+  if (key < 0) return false;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const answer = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (probe.state !== 'closed') probe.close();
+      resolve(value);
+    };
+    // Nothing here is worth hanging the export over: if the probe says nothing
+    // in five seconds, assume readable frames and let the real run find out.
+    const timer = setTimeout(() => answer(false), 5000);
+
+    const probe = new VideoDecoder({
+      output: (frame) => {
+        const format = frame.format;
+        frame.close();
+        answer(format === null);
+      },
+      error: () => answer(false),
+    });
+
+    try {
+      probe.configure(decoderConfig(video));
+      const sample = video.samples[key];
+      file.slice(sample.offset, sample.offset + sample.size).arrayBuffer()
+        .then((data) => {
+          probe.decode(new EncodedVideoChunk({
+            type: 'key',
+            timestamp: micros(sample.pts, video.timescale),
+            data: new Uint8Array(data),
+          }));
+          return probe.flush();
+        })
+        .catch(() => answer(false));
+    } catch {
+      answer(false);
+    }
+  });
+}
+
+/**
+ * Run a flush, but do not wait on it forever.
+ *
+ * settle() watches the queues while frames are being fed; this watches the two
+ * points where everything has already been fed and the only thing left is a
+ * codec that may never answer.
+ */
+function withStallTimeout(promise, which) {
+  let timer = null;
+  const stalled = new Promise((resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(
+      `The video ${which} stopped responding partway through, without reporting a reason. `
+      + 'A shorter clip, a lower quality setting, or a different browser is worth trying.')),
+    STALL_TIMEOUT_MS);
+  });
+  return Promise.race([promise, stalled]).finally(() => clearTimeout(timer));
+}
+
 /** Wait until both queues have drained below the limit. */
 async function settle(decoder, encoder) {
   let bestSeen = decoder.decodeQueueSize + encoder.encodeQueueSize;
@@ -234,7 +317,12 @@ export async function reverseExact({
 
   const times = reversedTimes(video);
   const groups = gopRanges(video.samples);
-  const limit = windowLimit(video.codedWidth, video.codedHeight);
+  // What the decoder will actually hand back, learned from one frame rather
+  // than assumed. It decides both how a frame is taken out of the pool below
+  // and how many will fit in the budget, and those two have to agree.
+  const opaque = await framesAreOpaque(video, file);
+  const limit = windowLimit(
+    video.codedWidth, video.codedHeight, undefined, opaque ? BITMAP_BYTES_PER_PIXEL : 1.5);
 
   const canvas = document.createElement('canvas');
   canvas.width = frame.width;
@@ -321,41 +409,62 @@ export async function reverseExact({
       // that would release the pool are the ones still queued behind it. The
       // budget in windowLimit() is counted in bytes and cannot see this, and
       // at 4K it asks for about three times what the pool can spare.
-      const rect = videoFrame.visibleRect;
-      const slot = {
-        timestamp: videoFrame.timestamp,
-        format: videoFrame.format,
-        // Sized to the visible rectangle, which is what copyTo() writes out:
-        // a frame coded taller than it is shown has that padding dropped here
-        // rather than travelling with it.
-        width: rect ? rect.width : videoFrame.codedWidth,
-        height: rect ? rect.height : videoFrame.codedHeight,
-        displayWidth: videoFrame.displayWidth,
-        displayHeight: videoFrame.displayHeight,
-        colorSpace: videoFrame.colorSpace,
-        data: null,
-        layout: null,
-      };
-      kept.push(slot);
+      //
+      // Every line of this runs inside the decoder's own callback, so it is
+      // wrapped: a throw here would escape into the browser, leave `failure`
+      // unset and - the part that hangs - leave the frame unclosed, which
+      // starves the pool this whole routine exists to give back.
+      try {
+        const rect = videoFrame.visibleRect;
+        const slot = {
+          timestamp: videoFrame.timestamp,
+          format: videoFrame.format,
+          // Sized to the visible rectangle, which is what copyTo() writes out:
+          // a frame coded taller than it is shown has that padding dropped here
+          // rather than travelling with it.
+          width: rect ? rect.width : videoFrame.codedWidth,
+          height: rect ? rect.height : videoFrame.codedHeight,
+          displayWidth: videoFrame.displayWidth,
+          displayHeight: videoFrame.displayHeight,
+          colorSpace: videoFrame.colorSpace,
+          data: null,
+          layout: null,
+          bitmap: null,
+        };
+        kept.push(slot);
 
-      // Left to run rather than awaited in turn: each frame is released the
-      // moment its own copy lands, and making them queue behind one another
-      // would hold the surfaces this exists to give back.
-      const buffer = new ArrayBuffer(videoFrame.allocationSize());
-      copies.push(videoFrame.copyTo(buffer)
-        .then((layout) => {
-          slot.data = buffer;
-          slot.layout = layout;
-        })
-        .catch((error) => { failure ??= error; })
-        .finally(() => videoFrame.close()));
+        // Left to run rather than awaited in turn: each frame is released the
+        // moment its own copy lands, and making them queue behind one another
+        // would hold the surfaces this exists to give back.
+        //
+        // A frame with no `format` is one the decoder never put in memory we
+        // can read - a picture living on the GPU, which is what a hardware
+        // HEVC decoder usually returns. copyTo() cannot have it and throws, so
+        // that frame is taken out of the pool by drawing it into an
+        // ImageBitmap instead. Either way the surface goes back at once, which
+        // is the only thing the decoder cares about.
+        copies.push((slot.format === null
+          ? createImageBitmap(videoFrame).then((bitmap) => { slot.bitmap = bitmap; })
+          : (() => {
+            const buffer = new ArrayBuffer(videoFrame.allocationSize());
+            return videoFrame.copyTo(buffer).then((layout) => {
+              slot.data = buffer;
+              slot.layout = layout;
+            });
+          })())
+          .catch((error) => { failure ??= error; })
+          .finally(() => videoFrame.close()));
+      } catch (error) {
+        failure ??= error;
+        videoFrame.close();
+      }
     },
     error: (error) => { failure ??= error; },
   });
   decoder.configure(decoderConfig(video));
 
-  /** A kept frame, built back into something the canvas will draw. */
-  const rebuild = (slot) => new VideoFrame(slot.data, {
+  /** A kept frame, back in something the canvas will draw. Both kinds close(). */
+  const drawable = (slot) => (slot.bitmap ? slot.bitmap : new VideoFrame(slot.data, {
     format: slot.format,
     codedWidth: slot.width,
     codedHeight: slot.height,
@@ -364,7 +473,14 @@ export async function reverseExact({
     displayWidth: slot.displayWidth,
     displayHeight: slot.displayHeight,
     colorSpace: slot.colorSpace,
-  });
+  }));
+
+  /** Drop a kept frame that will not be drawn after all. */
+  const discard = (slot) => {
+    slot.bitmap?.close();
+    slot.bitmap = null;
+    slot.data = null;
+  };
 
   /** One held frame, drawn and encoded at the time the reversal gives it. */
   const emit = (videoFrame, index) => {
@@ -440,7 +556,10 @@ export async function reverseExact({
           }));
         }
 
-        await decoder.flush();
+        // Watched, because flush() is the other place a stalled decoder hides:
+        // settle() guards the feeding, but by here everything has been fed and
+        // a decoder that has stopped emitting simply never resolves this.
+        await withStallTimeout(decoder.flush(), 'decoder');
         // `flush` waits for the output callbacks, and each of those starts a
         // copy rather than finishing one. The pixels are only ours after this.
         await Promise.all(copies);
@@ -450,9 +569,10 @@ export async function reverseExact({
         // Last shown, first written. This is the reversal.
         kept.sort((a, b) => b.timestamp - a.timestamp);
         for (const slot of kept) {
-          if (!slot.data) continue;   // its copy failed; `failure` already holds why
-          emit(rebuild(slot), wanted.get(slot.timestamp));
-          slot.data = null;
+          // Its copy failed; `failure` already holds why.
+          if (!slot.data && !slot.bitmap) continue;
+          emit(drawable(slot), wanted.get(slot.timestamp));
+          discard(slot);
           await settle(decoder, encoder);
         }
         kept = [];
@@ -462,7 +582,7 @@ export async function reverseExact({
     }
 
     onProgress?.({ phase: 'finishing', done: drawn, total });
-    await encoder.flush();
+    await withStallTimeout(encoder.flush(), 'encoder');
     if (failure) throw failure;
     if (!encoded.length) throw new Error('No frames could be decoded from this file.');
     if (!avcC) throw new Error('The encoder never reported a decoder configuration.');
@@ -471,6 +591,7 @@ export async function reverseExact({
     // to drop here is the copies. Any still running own a frame apiece and
     // close it themselves, so they are waited for rather than abandoned.
     await Promise.allSettled(copies);
+    for (const slot of kept) discard(slot);
     kept = [];
     copies = [];
     if (decoder.state !== 'closed') decoder.close();

--- a/tools/reverse-video/src/timeline.js
+++ b/tools/reverse-video/src/timeline.js
@@ -131,8 +131,11 @@ export function gopRanges(samples) {
  * So the run is capped by bytes rather than by frames, and a group longer than
  * the cap is decoded more than once - see `frameWindows`.
  */
-export function windowLimit(width, height, budgetBytes = 384 << 20) {
-  const perFrame = Math.max(1, width * height * 1.5);  // 4:2:0, which is what a decoder hands back
+export function windowLimit(width, height, budgetBytes = 384 << 20, bytesPerPixel = 1.5) {
+  // 1.5 is 4:2:0, which is what a decoder hands back when it hands back pixels
+  // at all. A frame that only exists on the GPU has to be held as a bitmap
+  // instead, and the caller passes what that costs.
+  const perFrame = Math.max(1, width * height * bytesPerPixel);
   return Math.max(4, Math.min(600, Math.floor(budgetBytes / perFrame)));
 }
 


### PR DESCRIPTION
Third attempt at the reported hang, and the first one aimed at the right
file. The screenshot shows the codec: **`hvc1.1.6.H156.B0`** - hardware HEVC,
4K, 4,815 frames. Both #105 and #109 were written against H.264, which is what
I had been reproducing with.

## Why #109 did not fix it

#109 copies each wanted frame out of the decoder's pool with `copyTo()`. That
assumes a decoded frame is a picture *in memory*. A hardware decoder is under
no such obligation - it can hand back a frame that only ever existed on the
GPU, whose `format` is `null` and whose `allocationSize()` **throws** instead
of answering. Hardware HEVC is the common case for exactly that.

And the throw landed in the worst possible place - the decoder's own output
callback, which #109 left unguarded:

```js
const buffer = new ArrayBuffer(videoFrame.allocationSize());   // throws here
copies.push(videoFrame.copyTo(buffer) ... .finally(() => videoFrame.close()));
```

Nothing caught it, so `failure` stayed unset **and the frame was never
closed**. Every wanted frame leaked a surface, the pool ran dry, the decoder
stopped emitting - and since everything had been fed by then, the wait was
inside `flush()`, which `settle()`'s timeout does not watch. Same hang, same
"Preparing...", for a completely different reason than the one I fixed.

## The fix

Three changes, any one of which would have turned the hang into a message:

- **the output callback is wrapped**, and closes the frame on any failure. A
  picture this tool cannot read is a reason to stop, never a reason to keep the
  decoder's surface;
- **a frame with no `format` is taken out of the pool as an `ImageBitmap`**
  rather than by copying bytes - the one move available on a picture we are not
  allowed to read. `drawFitted()` draws either kind and both have `close()`, so
  nothing downstream changes;
- **`flush()` is watched** on both codecs, the way the feeding already was.

An `ImageBitmap` costs 4 bytes a pixel where the decoder's 4:2:0 costs 1.5, so
`windowLimit()` now takes what a frame actually costs, and which case applies
is found by **decoding one keyframe and asking** - it is a property of the
machine's decoder, not of the file's codec. At 4K that is a window of 12 rather
than 32. Fewer frames for the same 384 MB, which is the honest trade, not a
regression: the bitmap path at 32 would have been ~1 GB against a 384 MB
budget.

## Verification

In a browser, on a generated 3840x2160 clip, both ways round:

| | frames out | windows | path |
|---|---|---|---|
| frames read normally | 120 | 32 | `copyTo`, 0 bitmaps |
| frames forced onto the GPU | 120 | 12 | 120 `createImageBitmap`, 0 `copyTo` |

Decoding either result back: frame N carries source frame 119-N at every
sampled position, so both are whole reversals in the right order.

`node --test "tests/js/*.test.js"` - 1,531 pass, including a new one pinning
`windowLimit(3840,2160)` at 32 and `windowLimit(3840,2160,undefined,4)` at 12.
`test_duplicates` and `test_imports` pass (26).

## Caveats worth a reviewer's attention

**I still have not run this against an HEVC file.** This browser decodes HEVC
but will not encode it, and there is no ffmpeg here, so I could not synthesise
one. I exercised the new path by forcing `VideoFrame.format` to `null`, which
reproduces the *mechanism* - unreadable frames - but not HEVC itself. Whether
your decoder actually returns opaque frames for that clip is the one link I
have inferred rather than observed.

**What is no longer possible, regardless:** every route out of that callback
now closes the frame, and both flushes are watched. If this file still fails it
should now say something instead of sitting at "Preparing...", and whatever it
says will be worth more than this guess was.

**"It works when first created"** from the report - I could not reproduce a
first-run/later-run difference and do not yet have an explanation for it. If it
means something other than "an older build of the tool worked", that is a
separate thread worth pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
