### PR TITLE
Trigger the QA run from the build finishing, not from the dist push

### DIFF
--- a/.github/workflows/qa-on-deploy.yml
+++ b/.github/workflows/qa-on-deploy.yml
@@ -1,12 +1,19 @@
 #
 # Asks A-Box-of-Tools/qa to re-run its suite once a deploy actually lands.
 #
-# Triggered on a push to `dist` rather than `main` or a GitHub Release:
-# `dist` is what GitHub Pages serves (see build.yml), and deploys here are
-# continuous - every push to main that changes the built output becomes one,
-# with no release or tag involved. A push to `dist` is the one event that
-# means "a visitor's browser now sees something different", which is what
-# this is meant to catch.
+# Triggered by the Build workflow finishing, rather than by the push to
+# `dist` that it makes.
+#
+# `on: push: branches: [dist]` is the obvious way to write this and it does
+# not work. build.yml publishes with the GITHUB_TOKEN that actions/checkout
+# configured, and GitHub deliberately does not let a GITHUB_TOKEN push start
+# another workflow run - otherwise a workflow that commits could trigger
+# itself forever. The symptom is silence: `dist` moves, Pages redeploys, and
+# nothing here ever runs. It was written that way first, and the only runs
+# this workflow had were manual ones.
+#
+# `workflow_run` is the trigger meant for chaining and is not suppressed. It
+# only fires for workflows defined on the default branch, which build.yml is.
 #
 # This only dispatches; it does not run the suite itself. The qa repo's own
 # report.yml runs it and publishes the result to that repo's gh-pages
@@ -28,8 +35,9 @@
 name: QA (post-deploy)
 
 on:
-  push:
-    branches: [dist]
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -44,6 +52,13 @@ concurrency:
 jobs:
   qa:
     runs-on: ubuntu-latest
+    # Only a build that succeeded and actually published. build.yml runs on
+    # pull requests too and skips its publish step there, so a pull request
+    # build finishing is not a deploy and there is nothing new to check.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     steps:
       # GitHub Pages usually publishes within a minute of `dist` moving, but
       # that isn't guaranteed. Waiting here rather than in the qa repo keeps


### PR DESCRIPTION
The post-deploy QA workflow has never actually run on a deploy. `dist` has moved since it was added (`Build 78861a0`, #109) and the only runs it has had were manual `workflow_dispatch` ones.

**Cause.** `build.yml` publishes to `dist` using the `GITHUB_TOKEN` that `actions/checkout` configured, and [GitHub deliberately does not let a `GITHUB_TOKEN` push start another workflow run](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow) — otherwise a workflow that commits could trigger itself forever. So `on: push: branches: [dist]` never fires. It fails silently, which is why it looked configured correctly.

**Fix.** Trigger on the Build workflow completing instead:

```yaml
on:
  workflow_run:
    workflows: ["Build"]
    types: [completed]
  workflow_dispatch:
```

`workflow_run` is the trigger meant for chaining and is not suppressed. It only fires for workflows defined on the default branch, which `build.yml` is.

The job is guarded on the build having succeeded *and* having come from a push — `build.yml` runs on pull requests too and skips its publish step there, so a PR build finishing is not a deploy and there is nothing new to check.

### Verifying it

This can only be confirmed by merging it and watching the next real deploy: `workflow_run` reads the workflow definition from the default branch, so it cannot fire from a branch. After merge, the next push to `main` that changes the built output should produce a "QA (post-deploy)" run a minute or two after Build finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)