### PR TITLE
Build the languages at once rather than one after another

### DIFF
--- a/build.py
+++ b/build.py
@@ -59,10 +59,12 @@ The build never reaches the network, whichever way it runs.
 import argparse
 import hashlib
 import html
+import os
 import re
 import shutil
 import subprocess
 import sys
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -91,11 +93,20 @@ def main(argv=None):
                         help='leave the output readable, for debugging')
     parser.add_argument('--check', action='store_true',
                         help='fail if the output differs from the committed dist branch')
+    parser.add_argument('--jobs', type=int, default=0, metavar='N',
+                        help='languages to build at once (default: one per core, '
+                             '1 to build them one at a time)')
     args = parser.parse_args(argv)
 
     out = (ROOT / args.out).resolve()
+    # 0 means "decide for me". Written as a number rather than as None so that
+    # --jobs 1 is a thing somebody can ask for and get: the languages build one
+    # after another, which is what to reach for when a traceback from inside a
+    # worker process is harder to read than the bug it is describing.
+    args.jobs = args.jobs if args.jobs > 0 else (os.cpu_count() or 1)
     try:
-        pages = build(out, clean=args.clean, minify_output=args.minify)
+        pages = build(out, clean=args.clean, minify_output=args.minify,
+                      jobs=args.jobs)
     except (sitelib.ConfigError, TemplateError, minify.MinifyError,
             cssmin.CssError) as err:
         print(f'build failed: {err}', file=sys.stderr)
@@ -110,7 +121,7 @@ def main(argv=None):
     return 0
 
 
-def build(out, clean=False, minify_output=True):
+def build(out, clean=False, minify_output=True, jobs=None):
     if clean and out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True, exist_ok=True)
@@ -184,11 +195,33 @@ def build(out, clean=False, minify_output=True):
     # and would advertise a German page that is still English.
     i18n.survey(locales, tools, prose, planned, site)
 
+    # One language at a time, or several at once. Each call writes only under
+    # its own out/<lang>/ - English at the root - and re-reads nothing, so the
+    # languages have nothing to say to each other and nothing to race over. The
+    # files that belong to the site rather than to a language are written
+    # outside this, below.
+    #
+    # Order is preserved by walking the futures in the order they were
+    # submitted rather than as they finish, because `written` becomes the
+    # printed list and a build that reports its pages in a different order
+    # every time is a build that looks different every time.
     written = []
-    for locale in locales:
-        written += build_locale(out, templates, locale, locales, site, tools,
-                                prose, planned, css_v, lang_v, feedback_v,
-                                offline_v, site_css, emit)
+
+    if jobs == 1 or len(locales) < 2:
+        for locale in locales:
+            written += build_locale(out, templates, locale, locales, site, tools,
+                                    prose, planned, css_v, lang_v, feedback_v,
+                                    offline_v, site_css, emit)
+    else:
+        with ProcessPoolExecutor(max_workers=jobs) as pool:
+            pending = [
+                pool.submit(build_locale, out, templates, locale, locales, site,
+                            tools, prose, planned, css_v, lang_v, feedback_v,
+                            offline_v, site_css, emit)
+                for locale in locales
+            ]
+            for future in pending:
+                written += future.result()
 
     # After every locale, because a locale only counts as finished once every
     # page in it has been rendered and had the chance to fall back. Raising


### PR DESCRIPTION
A full build took **513 seconds** on a 16-core machine. It now takes **225**.

The site is built fifteen times, once per language, and that happened in a single loop on a single core.

## Why it needed no rearranging

`build_locale` already writes only under its own `out/<lang>/` (English at the root) and already re-reads no source file — the tools and prose are parsed once in English and localized into copies. Files belonging to the site rather than to a language are written outside the loop.

So the languages had nothing to say to each other and nothing to race over. The loop was serial only because it was written as one.

## The interface

`--jobs N`, one worker per core by default. `--jobs 1` is kept as a real option rather than a fallback: when a traceback comes out of a worker process it is often harder to read than the bug it describes, and building one language at a time is the first thing to reach for.

Futures are walked in submission order rather than completion order, because that list becomes the printed page listing — a build whose report is ordered differently every run is a build that looks different every run.

## Verification

The bar here is not "it works", it is **byte-identical output**. `--check` compares the deployed branch byte for byte, so a parallel build differing in any way — even ordering — would quietly break the one claim the build exists to support.

```
file counts: seq=10262 par=10262
diff -r _seq _par
diff exit=0 (0 = identical)
```

10,262 files, no differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)