### PR TITLE
Do not let printing a page name fail a build that succeeded

### DIFF
--- a/build.py
+++ b/build.py
@@ -84,6 +84,25 @@ LOCALES = ROOT / 'locales'
 
 
 def main(argv=None):
+    # This build writes pages whose paths are not ASCII - ar/, ja/, zh/ and the
+    # translated slugs under them - and then prints every one of them. On a
+    # console whose encoding is not UTF-8, which is the default on a good many
+    # Windows installations, printing the first Arabic path raises
+    # UnicodeEncodeError.
+    #
+    # The failure is worse than it sounds, because by then the build has
+    # already finished: every page is written and correct, and the process dies
+    # on the report. Anything reading the exit code - serve.ps1 refuses to
+    # start the server, CI would call it a failed build - sees a build that
+    # failed, and the only clue is a traceback about a codec.
+    #
+    # Replacing rather than raising: a path that cannot be spelled in the
+    # console's encoding is a cosmetic problem with one line of a listing, and
+    # never a reason to fail a build that has already succeeded.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, 'reconfigure'):
+            stream.reconfigure(encoding='utf-8', errors='replace')
+
     parser = argparse.ArgumentParser(description=__doc__.split('\n')[1])
     parser.add_argument('--out', default='dist', help='where to write (default: dist)')
     parser.add_argument('--clean', action='store_true', help='empty the output first')


### PR DESCRIPTION
On a console whose encoding is not UTF-8 — the default on a good many Windows installations — `python build.py` fails:

```
UnicodeEncodeError: 'gbk' codec can't encode character '\u0636' in position 7
```

## Why it is worse than it looks

By the time this happens **the build has already finished**. Every page is written and correct. The process dies printing the listing.

Everything downstream reads the exit code and believes it. `serve.ps1` raises `build failed` and never starts the server; CI would call it a failed build. The only clue is a traceback about a codec, which points at the listing rather than at anything wrong with the site — so it reads as "this project does not build on my machine".

## The change

Nineteen lines at the top of `main()`: reconfigure `stdout` and `stderr` to UTF-8 with `errors='replace'`.

Replacing rather than raising is the point. A path that cannot be spelled in the console's encoding is a cosmetic problem with one line of a listing, and never a reason to fail a build that has already succeeded.

## Verification

A full build with `PYTHONIOENCODING=gbk`, which exits 1 before this change and 0 after it, with the Arabic pages written either way:

```
EXIT=0
arabic pages written: yes
```

## Where it came from

Hit repeatedly while building the QA suite. It was worked around there — forcing `PYTHONIOENCODING=utf-8` on the process the tests spawn — rather than fixed here, which was the wrong end to fix it at: anyone cloning this repository onto such a machine sees a build that appears broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)