### PR TITLE
Wire the shared frame up on the DICOM viewer

### DIFF
--- a/tools/dicom-viewer/body.html
+++ b/tools/dicom-viewer/body.html
@@ -207,6 +207,16 @@
     <span data-phrase="stack.spacing">Slices are {gap} apart.</span>
 
     <span data-phrase="at.position">{at} of {total}</span>
+    <span data-phrase="net.clean">your scan has gone nowhere. {total} files
+      loaded, all of them this page's own. {platform}</span>
+    <span data-phrase="net.dirty">something contacted {hosts}, which this tool
+      never does. Treat that as worth investigating. {platform}</span>
+    <span data-phrase="net.platform.one">The page's own ad, measurement and
+      donate-button scripts loaded from {hosts} host; not one of them was given
+      a scan, a pixel of one, or a word from its header.</span>
+    <span data-phrase="net.platform.many">The page's own ad, measurement and
+      donate-button scripts loaded from {hosts} hosts; not one of them was given
+      a scan, a pixel of one, or a word from its header.</span>
     <span data-phrase="at.frame">frame {at} of {total}</span>
     <span data-phrase="at.instance">instance {number}</span>
 

--- a/tools/dicom-viewer/src/main.js
+++ b/tools/dicom-viewer/src/main.js
@@ -19,6 +19,13 @@ const el = {
   dropzone: $('dropzone'),
   fileInput: $('file-input'),
   loadError: $('load-error'),
+
+  privacyToggle: $('privacy-toggle'),
+  privacyPanel: $('privacy-panel'),
+  networkCount: $('network-count'),
+  networkDot: $('network-dot'),
+  offlineStatus: $('offline-status'),
+  offlineDot: $('offline-dot'),
   working: $('working'),
 
   viewerCard: $('viewer-card'),
@@ -1216,3 +1223,100 @@ function hideError() {
 el.modeHint.textContent = phrase('mode.window');
 el.viewport.dataset.mode = 'window';
 el.viewport.tabIndex = 0;
+
+/* -------------------------------------------------------------------- trust */
+
+el.privacyToggle.addEventListener('click', () => {
+  const opening = el.privacyPanel.hidden;
+  el.privacyPanel.hidden = !opening;
+  el.privacyToggle.setAttribute('aria-expanded', String(opening));
+});
+
+// The hosts this page loads its own advertising, measurement and donate-button
+// from. Like the ad scripts, they are something the page fetches without the
+// visitor asking, and they are handed nothing - so they belong in this bucket
+// rather than being reported as an intruder.
+const PLATFORM_HOSTS = /(^|\.)(googlesyndication\.com|doubleclick\.net|googleadservices\.com|googletagservices\.com|adtrafficquality\.google|googletagmanager\.com|google-analytics\.com|gstatic\.com|googleapis\.com|buymeacoffee\.com|cloudflareinsights\.com|google\.[a-z]{2,3}(\.[a-z]{2})?)$/;
+
+/**
+ * Watch what the page fetches and say so on the page itself.
+ *
+ * The claim on trial is not "this page is silent" - it is not silent, it
+ * carries ads - but "nothing has carried your document away".
+ */
+function monitorNetwork() {
+  const platform = new Set();
+  const unexplained = new Set();
+
+  const inspect = (entries) => {
+    for (const entry of entries) {
+      if (entry.name.startsWith('blob:') || entry.name.startsWith('data:')) continue;
+      const url = new URL(entry.name, window.location.href);
+      if (url.origin === window.location.origin) continue;
+      if (PLATFORM_HOSTS.test(url.hostname)) platform.add(url.hostname);
+      else unexplained.add(url.hostname);
+    }
+
+    const total = performance.getEntriesByType('resource')
+      .filter((entry) => !entry.name.startsWith('blob:') && !entry.name.startsWith('data:'))
+      .length;
+
+    const clean = unexplained.size === 0;
+    // One phrase per number rather than a pluralising helper: the frame does
+    // the same for reading.one and reading.many, and a language whose plural
+    // is not a suffix has to be able to translate the two separately.
+    const note_ = platform.size
+      ? phrase(platform.size === 1 ? 'net.platform.one' : 'net.platform.many',
+               { hosts: platform.size })
+      : '';
+
+    el.networkCount.textContent = clean
+      ? phrase('net.clean', { total, platform: note_ })
+      : phrase('net.dirty', { hosts: [...unexplained].join(', '), platform: note_ });
+    el.networkCount.className = clean ? 'good' : 'warn';
+    el.networkDot.className = `live-dot ${clean ? 'good' : 'warn'}`;
+  };
+
+  inspect(performance.getEntriesByType('resource'));
+  try {
+    new PerformanceObserver((list) => inspect(list.getEntries()))
+      .observe({ type: 'resource', buffered: true });
+  } catch {
+    // PerformanceObserver is unavailable; the snapshot above still stands.
+  }
+}
+
+async function registerServiceWorker() {
+  const failed = (message, detail) => {
+    el.offlineStatus.textContent = message;
+    el.offlineDot.className = 'live-dot';
+    if (detail) el.offlineStatus.title = detail;
+  };
+
+  if (!('serviceWorker' in navigator)) {
+    failed(phrase('offline.none'));
+    return;
+  }
+  if (!window.isSecureContext) {
+    failed(phrase('offline.insecure'));
+    return;
+  }
+
+  try {
+    await navigator.serviceWorker.register('sw.js');
+    await navigator.serviceWorker.ready;
+    el.offlineStatus.textContent = phrase('offline.ready');
+    el.offlineStatus.className = 'good';
+    el.offlineDot.className = 'live-dot good';
+  } catch (error) {
+    failed(phrase('offline.failed'), error.message);
+  }
+}
+
+/* --------------------------------------------------------------------- boot */
+
+monitorNetwork();
+registerServiceWorker();
+
+// Reached only if every step above ran without throwing.
+document.getElementById('boot-warning')?.remove();


### PR DESCRIPTION
Of the thirty-two tools, `dicom-viewer` was the only one whose `main.js` never touched the frame the template puts around it. The markup was all there — `templates/tool.html` writes it for every tool — but nothing attached to it.

## What that looked like on the live site

- **The "your scripts did not run" warning stayed up permanently.** It is the fallback for a page whose JavaScript never loaded, so every visitor was told the page was broken while it worked perfectly.
- **"How this is verified" did nothing.**
- **The live network check never ran.** The pledge said it was checking; no number ever arrived.
- Neither did the offline indicator.

This is the wrong tool for that to happen on. It is the page whose whole argument is that a scan carrying a patient's name, date of birth and hospital number is read without leaving the machine — and the control that demonstrates it was the one not running.

## Two changes to the copied block

It called a `plural()` helper that `redact-pdf` defines locally, along with the `count.*` phrases behind it. That threw `ReferenceError: plural is not defined` and stopped the boot before the warning could be removed — which was the failure the tests were reporting.

It now picks between `net.platform.one` and `net.platform.many`, the convention the frame itself uses for `reading.one`/`reading.many`, and for the stated reason: a language whose plural is not a suffix has to be able to translate the two separately. The three `net.*` phrases live in `body.html`, because a sentence a visitor reads never lives in the JavaScript.

Wording is about a scan rather than a document, since that is what this tool is handed.

## Verification

- The ten frame tests that were failing now pass, on both browsers
- The viewer's own nine functional tests still pass
- Python suite: 377 tests, OK

## Worth a separate look

This ~103-line block is copy-pasted across all thirty-two tools and, unlike the MP4 reader, is **not** declared in `tests/python/test_duplicates.py`. Nothing keeps the copies in step, which is how one tool came to ship without it at all. Not changed here — that is a design decision rather than a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)