### PR TITLE
Turkish: the whole locale, 63 of 63 pages

### DIFF
--- a/locales/tr/locale.toml
+++ b/locales/tr/locale.toml
@@ -121,6 +121,17 @@ complete = true
 "guides/whats-inside-a-gif" = "rehberler/gifin-icinde-ne-var"
 "guides/verify-a-file-checksum" = "rehberler/dosya-saglama-toplamini-dogrulama"
 
+# The three that shipped after this file was first written. The tools keep
+# their Latin acronyms in the address for the reason given at the top: DICOM
+# and PDF are what a reader types, and a Turkish spelling of either would
+# invent a word nobody searches for.
+"dicom-viewer" = "dicom-goruntuleyici"
+"document-scanner" = "belge-tarayici"
+"redact-pdf" = "pdf-karartma"
+"guides/open-a-dicom-file" = "rehberler/dicom-dosyasi-acma"
+"guides/redact-a-pdf" = "rehberler/pdf-karartma"
+"guides/scan-a-document-with-your-phone" = "rehberler/telefonla-belge-tarama"
+
 #
 # ---------------------------------------------------------------------------
 # The hub.

--- a/locales/tr/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/tr/pages/guides/combine-images-into-a-pdf.html
@@ -1,0 +1,201 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../resimleri-pdfe-donusturme/">Görsellerden PDF'e</a>'yi açın,
+      resimleri bırakın, sıra doğru olana kadar kutucukları sürükleyin ve belgeyi
+      oluşturun. Varsayılanlar &mdash; A4 sayfalar, küçük bir kenar boşluğu,
+      yeniden kodlanmadan içeri kopyalanan fotoğraflar &mdash; çoğu insanın
+      istediği şeydir.
+    </p>
+    <p>
+      İkinci kez düşünmeye değen dört şey şunlardır: sıra, sayfa boyutu, kalite
+      ayarı ve bitmiş belgenin sizin hakkınızda söyledikleri. Ne sıklıkla ters
+      gittiklerinin sırasıyla.
+    </p>
+  </section>
+
+  <section>
+    <h2>Her şeyden önce sırayı doğru yapın</h2>
+    <p>
+      Sayfa sırası, en sık yanlış yapılan tek şeydir; çünkü dosya adları kimsenin
+      beklemediği biçimde sıralanır. Alfabetik bir sıralamada
+      <code>IMG_2.jpg</code>, <code>IMG_10.jpg</code>'den sonra gelir; çünkü
+      karşılaştırma karakter karakterdir ve <code>1</code>, <code>2</code>'den
+      öncedir. <code>page1</code>'den <code>page12</code>'ye adlandırılmış bir
+      tarama klasörü hemen her araçta yanlış sırayla gelecektir.
+    </p>
+    <p>
+      Fotoğraflar için çekim tarihine göre sıralamak genellikle daha güvenilirdir;
+      çünkü sayfaları oldukları sırayla fotoğrafladınız. Her hâlükârda, PDF'i
+      sonradan denetlemek yerine düğmeye basmadan önce kutucuklara bakın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kalite: çoğu aracın sessizce yanlış yaptığı kısım</h2>
+    <p>
+      Bir PDF, JPEG verisini doğrudan taşıyabilir. Bu, biçimin bir özelliğidir:
+      bir JPEG'in sıkıştırılmış baytları belgeye olduğu gibi bırakılabilir ve
+      okuyucu onları bir tarayıcının çözeceği gibi çözer.
+    </p>
+    <p>
+      Bunun önemi şudur: bir fotoğrafın PDF'e girerken hiçbir şey kaybetmesi
+      gerekmez. Hiçbir zaman çözülmez ve hiçbir zaman yeniden sıkıştırılmaz;
+      belgedeki resim, sizin dosyanızdaki resmin bitine bit aynısıdır. Yine de
+      birçok araç onu yeniden kodlar &mdash; her şeyi bir tuvale çizip tek
+      biçimde kodlamak daha basittir &mdash; ve sonuç, hiçbir sebep yokken bir
+      kuşak kalite kaybıdır.
+    </p>
+    <p>
+      Başka biçimler bu şekilde yolculuk edemez. PNG, WebP, HEIC ve gerisinin
+      PDF'te karşılık gelen bir süzgeci yoktur, yani dönüştürülmeleri gerekir.
+      Bunun nasıl olacağı sizin seçiminizdir:
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG olarak yeniden kodla</strong> (varsayılan). En küçük dosya,
+        küçük bir kalite bedeli ve fotoğraflar için doğru cevap.
+      </li>
+      <li>
+        <strong>Kayıpsız.</strong> Çok daha büyük bir belge pahasına piksellerin
+        tamını saklar. Ekran görüntüleri, şemalar ve JPEG bozulmalarının göze
+        battığı, içinde metin ya da keskin kenarlar olan her şey için doğru
+        cevap.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Sayfa boyutu ve &ldquo;resmin boyutuna uy&rdquo;un daha iyi olduğu an</h2>
+    <p>
+      Standart bir sayfa boyutu &mdash; A4, Letter, Legal, A3, A5, Tabloid
+      &mdash; her görseli o boyutta bir sayfaya, kenar boşluğunuzun içine sığacak
+      şekilde ölçekleyerek yerleştirir. Belge basılacaksa ya da resmî biri onu
+      dosyalayacaksa birini kullanın.
+    </p>
+    <p>
+      &ldquo;Tam olarak her resmin boyutu&rdquo;, her sayfayı kendi görseline
+      uydurur; yani ne beyaz boşluk ne de herhangi bir ölçekleme olur. PDF bir
+      belge değil de resimler için bir kap olduğunda kullanın: bir portfolyo, bir
+      ekran görüntüsü seti, bir çizgi roman. Basıldığında yanlış görünür, çünkü
+      her sayfa başka boyuttadır.
+    </p>
+    <p>
+      Basılacak her şeyde bir kenar boşluğu bulundurmaya değer. Ev yazıcıları
+      kâğıdın kenarına kadar basamaz ve kenardan kenara yerleştirilmiş bir
+      fotoğraf kırpılmış çıkar.
+    </p>
+    <h3>Yatay fotoğraflardan dikey sayfalar</h3>
+    <p>
+      Kâğıt sayfaları telefonu yan tutarak fotoğrafladıysanız her görsel yatay
+      olacak ve dikey bir sayfanın ortasında küçücük duracaktır. Bunu düzelten
+      şey, belgeyi kurmadan önce her birini çeyrek tur döndürmektir ve bu, genel
+      değil görsel başına bir seçimdir; çünkü genellikle birkaç tanesi doğru yönde
+      çekilmiştir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bitmiş PDF sizin hakkınızda ne söylüyor</h2>
+    <p>
+      Bir PDF bir belge bilgisi bloğu taşır: yazar, üretici, oluşturma tarihi,
+      bazen de başlık. Onu neyin yazdığına bağlı olarak bu, hesap adınızı, makine
+      adınızı ve onu yaptığınız tam zamanı içerebilir.
+    </p>
+    <p>
+      Bunu düşünmeye değer, çünkü bir PDF insanların başka insanlara gönderdiği
+      bir şeydir &mdash; bir iş başvurusu, bir talep, ev sahibi için bir belge.
+      Üstveri onunla birlikte yolculuk eder ve herhangi bir okuyucu onu
+      gösterebilir.
+    </p>
+    <p>
+      Buradaki araç, o bloğu kendi adı dışında boş bırakır: dosya adı yok, makine
+      adı yok, kullanıcı adı yok ve siz kutucuğu işaretlemedikçe oluşturma tarihi
+      de yok. Başka bir araç kullanıyorsanız, ne yazdığını görmek için sonucun
+      özelliklerini bir kez açmaya değer.
+    </p>
+    <p>
+      Ayrıca: görsellerin kendisi. Fotoğraflarınız EXIF ve GPS etiketleri
+      taşıyorsa onlara ne olacağı izlenen yola bağlıdır. Yeniden kodlanmadan
+      kopyalanan bir JPEG, içinde ne varsa korur; yeniden kodlanan bir görsel ise
+      etiketleri bir yan etki olarak kaybeder. Bu sizin için önemliyse
+      fotoğrafları önce
+      <a href="../../exif-verisi-silme/">EXIF Görüntüleyici ve Silici</a> ile
+      temizleyin &mdash; içinde ne olduğunu
+      <a href="../exif-ve-gps-verisini-silme/">kendi rehberi</a> anlatıyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>PDF fazla büyük çıkarsa</h2>
+    <p>
+      Telefon fotoğrafları büyüktür ve yirmi tanesi, e-postanın kabul etmeyeceği
+      bir belge yapar. Sırasıyla denenecek üç şey:
+    </p>
+    <p>
+      <strong>En uzun kenarı küçültün.</strong> Bir kâğıt sayfasının 4000 piksellik
+      fotoğrafı, hiçbir okuyucunun ya da yazıcının kullanmayacağı kadar çok ayrıntı
+      taşıyor demektir. Uzun kenarı 2000 piksel civarına indirmek dosyayı tipik
+      olarak dörtte birine düşürür ve bir sayfada kimsenin görebileceği hiçbir şeyi
+      değiştirmez.
+    </p>
+    <p>
+      Fotoğrafa benzeyen her şey için <strong>kayıpsız yerine JPEG kullanın</strong>.
+      Kayıpsız, şemalar için doğru, bir sayfa fotoğrafı için yanlış cevaptır.
+    </p>
+    <p>
+      <strong>Bitmiş belgeyi sıkıştırın.</strong>
+      <a href="../../pdf-sikistirma/">PDF Sıkıştırıcı</a>, her görselin piksel
+      sayısına karşı değil sayfada ne kadar büyük çizildiğine karşı çalışır; asıl
+      önemli ölçüm de budur.
+      <a href="../pdf-boyutunu-kucultme/">Kendi rehberi</a> bunun neye mal
+      olduğunu anlatıyor.
+    </p>
+    <p>
+      Araçta kaç görsel kullanabileceğinize dair yerleşik bir sınır yok. Pratikteki
+      tavan kendi makinenizin belleğidir; çünkü bitmiş belge, siz indirmeden önce
+      orada bir araya getirilir &mdash; tam çözünürlükte birkaç yüz telefon
+      fotoğrafı bunu ilk hissettiren şeydir ve en uzun kenarı küçültmek o tavanı
+      epeyce yukarı taşır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun size vermeyeceği şey</h2>
+    <p>
+      Fotoğraflardan yapılmış bir PDF, resim dolu bir PDF'tir. İçindeki kelimeler
+      metin değildir: onları arayamaz, kopyalayamaz ya da bir ekran okuyucuya
+      okutamazsınız. Bu, dönüşümün değil elinizde başladığınız şeyin bir
+      özelliğidir.
+    </p>
+    <p>
+      Aranabilir metne ihtiyacınız varsa OCR'a ihtiyacınız var demektir ki o başka
+      bir iştir. Ayrıca özgün belge bir yerde hâlâ belge olarak duruyorsa, onu
+      doğrudan PDF'e aktarmak fotoğraflamayı her zaman yener &mdash; daha küçük,
+      daha keskin, aranabilir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir PDF yazmak, yapılandırılmış bir dosya yazmaktır: bir başlık, bir nesneler
+      kümesi, bir çapraz başvuru tablosu. İçinde bir tarayıcının yapamayacağı
+      hiçbir şey yoktur ve işin resimlerin herhangi bir yere gitmesini gerektiren
+      bir yanı da yoktur.
+    </p>
+    <p>
+      Burada bunu önemsemeye değer, çünkü insanlar bu belgelerin içine ne
+      koyuyor: kimlik belgeleri, banka hesap özetleri, sağlık raporları, imzalı
+      sözleşmeler &mdash; birinin en baştan bir PDF yapmasının sebebi genellikle
+      onu bir kuruma gönderiyor olmasıdır. Buradaki aracın hiçbir türde ağ
+      özelliği yoktur ve sayfanın <code>Content-Security-Policy</code>'si iletişim
+      kurabileceği her adresi tek tek sayar; bunların hiçbiri bu siteye ait
+      değildir.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> bunu ister burada ister başka bir yerde kendiniz
+      nasıl denetleyeceğinizi anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/tr/pages/guides/combine-images-into-a-pdf.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: resimleri tek bir PDF'te birleştirme - Türkçe.
+#
+
+nav = "Resimleri PDF'te birleştirme"
+title = "Resimleri Tek Bir PDF'te Nasıl Birleştirirsiniz"
+description = "Fotoğrafları ya da taramaları tek bir PDF'e çevirin: sayfa boyutu, sıra ve döndürme, bir JPEG'in içeri girerken neden hiç kalite kaybetmesi gerekmediği ve bitmiş bir PDF'in gönderdiğiniz kişiye ne anlattığı."
+heading = "Resimler tek bir PDF'te nasıl birleştirilir"
+lede = """
+    Biri sizden &ldquo;tek bir PDF&rdquo; istedi, sizin elinizde ise on bir tane
+    kâğıt fotoğrafı var. Bu rehber, sonucu gerçekten değiştiren seçimleri
+    &mdash; sayfa boyutu, sıra, kalite ve belgenin sizin hakkınızda söyledikleri
+    &mdash; ve bunların hangilerini rahatça geçebileceğinizi anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Resimler tek bir PDF'te nasıl birleştirilir"
+og_description = "Sayfa boyutu, sıra ve döndürme, bir JPEG'in içeri girerken neden kalite kaybetmesi gerekmediği ve bir PDF'in gönderdiğiniz kişiye ne anlattığı."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/tr/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,0 +1,233 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../resim-sikistirma/">Görsel Sıkıştırıcı</a>'yı açın, fotoğrafı
+      bırakın, size verilen sayıyı yazın ve düğmeye basın. Araç resmi birkaç kez
+      kodlar, hedefinizin altına sığan en iyi sonucu tutar ve bunun neye mal
+      olduğunu söyler. Çoğu fotoğraf ve çoğu hedef için dürüst özet şudur: aradaki
+      farkı göremeyeceksiniz.
+    </p>
+    <p>
+      Bu sayfanın geri kalanı, bu olmadığında içindir: sonuç yumuşak göründüğünde,
+      bir PNG neredeyse hiç kıpırdamadığında ya da resminizi birine göndermeden
+      önce aracın ona tam olarak ne yaptığını bilmek istediğinizde.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir dosya boyutu sınırı aslında ne istiyor</h2>
+    <p>
+      Bir JPEG ya da bir WebP fotoğrafınızı saklamaz. Onun bir tarifini saklar ve
+      kalite ayarı, bu tarifin ne kadar ayrıntılı olabileceğine karar verir. Ayarı
+      düşürün, dosya küçülür; çünkü tarif belirsizleşir: ince doku ortalanıp gider,
+      renk geçişleri bantlanır ve kenarlar hafif bir blok halesi kapar.
+    </p>
+    <p>
+      Yani bir boyut sınırı, ayrıntı için bir bütçedir. İşe yarayan soru
+      &ldquo;500&nbsp;KB'yi tutturabilir miyim&rdquo; değil &mdash; her sayıyı her
+      zaman tutturabilirsiniz &mdash; &ldquo;oraya varmak için resmin ne kadarından
+      vazgeçmem gerekiyor ve bu, onunla yapacağım iş için önemli mi?&rdquo;
+      sorusudur.
+    </p>
+    <p>
+      İki kaba kural. Gerçek bir sahnenin fotoğrafı &mdash; yüzler, yapraklar,
+      kumaş &mdash; sıkıştırmayı iyi gizler; çünkü gözün hasarı fark edeceği
+      kusursuzca düz bir alan yoktur. Bir ekran görüntüsü, bir grafik, bir logo ya
+      da geniş düz renkleri ve sert metin kenarları olan her şey ise bunu hemen
+      gösterir ve genellikle JPEG olmak yerine PNG ya da WebP olmalıdır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Neden bir formül yok ve bu konuda ne yapmalı</h2>
+    <p>
+      500&nbsp;KB'lik bir dosya üreten kalite ayarını hesaplamanın bir yolu yoktur.
+      İkisi arasındaki ilişki tamamen resmin içindekine bağlıdır: aynı ayarda, düz
+      bir duvarın fotoğrafı bir ormanın fotoğrafının onda biri boyutunda çıkabilir.
+      Size &ldquo;kalite: 60&rdquo; önerip umut eden her araç, sizin adınıza tahmin
+      yürütüyordur.
+    </p>
+    <p>
+      Tek güvenilir yöntem denemektir. Görseli kodla, boyuta bak, ayarla, yeniden
+      kodla. Bunu elle yapmak yorucudur; sıkıştırıcıların bunun yerine bir kalite
+      sayısı istemesinin sebebi de budur &mdash; yorgunluğu size aktarır. Otomatik
+      yapmak kabaca sekiz kodlamadır ve bir telefon fotoğrafının sekiz kodlaması,
+      bu on yılda yapılmış herhangi bir makinede saniyenin küçük bir kısmıdır; bu
+      sitedeki aracın boyutu isteyip aramayı kendisi yapmasının sebebi de budur.
+    </p>
+    <p>
+      Bildirdiği her boyut bir tahmin değil, gerçekten kodlanmış bir dosyadır. Bir
+      formun katı bir sınırı olduğunda bu önemlidir: %2 iyimser bir tahmin,
+      reddedilmiş bir yükleme demektir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Piksel harcamadan önce kalite harcayın</h2>
+    <p>
+      Bir görsel dosyasını küçültmenin yalnızca iki yolu vardır. Aynı resmi daha az
+      hassas tarif edebilirsiniz ki bu kalitedir. Ya da daha az piksel tarif
+      edebilirsiniz ki bu boyutlandırmadır. Bunlar denk değildir ve sıra önemlidir.
+    </p>
+    <p>
+      Kalite önce gelir; çünkü kalite düşüşünün ilk %30 kadarı bir fotoğrafta
+      gerçekten görünmezdir &mdash; biçimin, hiçbir gözün denetleyemeyeceği kadar
+      özenle sakladığı ayrıntıyı atıyorsunuzdur. Pikseller sonra gelir; çünkü
+      kalite bozulmaların görüneceği kadar düştüğünde, makul kalitede küçük bir
+      resim, mahvedilmiş tam boyutlu bir resimden iyi görünür. Az sayıda iyi
+      piksel, çok sayıda kötü pikseli yener.
+    </p>
+    <p>
+      Bütün strateji budur ve başka bir araç kullansanız bile bilmeye değer:
+      kaliteyi yanlış görünmeye başlayana kadar düşürün, sonra daha da düşürmek
+      yerine resmi küçültün.
+    </p>
+    <h3>Bilerek ne zaman boyutlandırmalı</h3>
+    <p>
+      Bazen o piksellere zaten hiç ihtiyaç yoktu. Bir web sayfasında 600 piksel
+      genişliğinde bir sütunda gösterilen 4000 piksel genişliğindeki bir fotoğraf,
+      kimsenin göreceğinin altı katı ayrıntı taşıyor demektir. Resmin son yerini
+      biliyorsanız önce ona göre boyutlandırın; boyut sorunu çoğu zaman hiç kalite
+      harcanmadan ortadan kalkar. Bu iş için araç
+      <a href="../../resim-boyutlandirma/">Görsel Boyutlandırıcı</a>'dır ve boyut
+      seçmeyi <a href="../resim-boyutlandirma/">kendi rehberi</a> anlatıyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Biçim seçmek</h2>
+    <p>
+      Bilmeye değer üç biçim var ve tarayıcılar üçünü de yazabiliyor.
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG</strong> fotoğraflar içindir. Kayıplıdır, şimdiye kadar
+        yapılmış her şey tarafından anlaşılır ve gerçek bir sahnenin resmi için
+        hâlâ mükemmel bir seçimdir. Saydamlık saklayamaz.
+      </li>
+      <li>
+        <strong>WebP</strong> aynı işi daha iyi yapar: ayırt edemeyeceğiniz bir
+        kalitede JPEG'den kabaca %25&ndash;35 daha küçüktür ve saydamlığı korur.
+        Güncel her tarayıcı onu okur. Birkaç eski masaüstü uygulaması ve bazı
+        kurumsal yükleme formları hâlâ okumuyor; onu kullanmamak için tek gerçek
+        sebep de budur.
+      </li>
+      <li>
+        <strong>PNG</strong> kayıpsızdır; yani tamdır ve büyüktür. Ekran
+        görüntüleri, logolar, çizgi çalışmaları ve keskin kenarları ya da düz rengi
+        olan her şey için doğru, bir fotoğraf için yanlış cevaptır.
+      </li>
+    </ul>
+    <p>
+      Dosyayı isteyen taraftan gelen bir kısıt yoksa WebP sizi bir hedefe JPEG'den
+      daha az görünür hasarla götürür. Dosya eski bir şeyin ya da deneyemeyeceğiniz
+      bir sistemin içine gidiyorsa güvenli cevap JPEG'dir.
+    </p>
+  </section>
+
+  <section>
+    <h2>PNG'niz neden pek küçülmeyecek</h2>
+    <p>
+      Bu, en sık karşılaşılan sürprizdir ve kullandığınız araçtaki bir hata
+      değildir. PNG kayıpsız bir biçimdir: pikselleri tam olarak saklar ve
+      çevrilecek bir kalite düğmesi yoktur; çünkü birini çevirmek onu başka bir
+      biçim yapardı. Bir PNG sıkıştırıcısının yapabileceği tek şey aynı pikselleri
+      daha akıllıca paketlemektir ki bu genellikle yüzde birkaç eder.
+    </p>
+    <p>
+      Yani çok daha küçük bir dosyanız olması ve dosyanın PNG kalması gerekiyorsa
+      geriye kalan tek kol boyuttur &mdash; daha az piksel ya da daha az renk. PNG
+      olmaktan çıkabilecekse, soru içinde ne olduğudur:
+    </p>
+    <ul>
+      <li>
+        <strong>PNG olarak kaydedilmiş bir fotoğraf.</strong> Çok yaygın,
+        genellikle kazara ve bu sayfadaki en kolay kazanç: JPEG veya WebP'ye
+        çevirmek çoğu zaman onu görünür bir değişiklik olmadan beş ila on kat
+        küçültür.
+      </li>
+      <li>
+        <strong>Bir ekran görüntüsü ya da bir şema.</strong> WebP'ye çevirin; o da
+        istediğinizde kayıpsızdır ve aynı pikseller için genellikle PNG'den
+        küçüktür. JPEG'e gitmek metin kenarlarını bulandırır.
+      </li>
+      <li>
+        <strong>Saydamlığı olan bir logo.</strong> WebP saydamlığı korur; JPEG
+        onu düz bir renkle doldurur ki bu neredeyse hiçbir zaman istediğiniz şey
+        değildir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Sonucun yeterince iyi olup olmadığını nasıl anlarsınız</h2>
+    <p>
+      Bir küçük resme bakmak hiçbir şey kanıtlamaz &mdash; küçük resim boyutunda
+      her şey iyi görünür. Daha iyi iki denetim:
+    </p>
+    <p>
+      <strong>Tam boyutta ve karedeki en düz şeye bakın.</strong> Gökyüzü, ten,
+      boyalı bir duvar. Sıkıştırma hasarı, ayrıntılı alanlara dokunmadan çok önce,
+      önce yumuşak geçişlerde silik bloklar ya da bantlar olarak ortaya çıkar.
+    </p>
+    <p>
+      <strong>Araç size bir ölçüm veriyorsa onu okuyun.</strong> Buradaki
+      sıkıştırıcı kendi sonucunu yeniden çözüp özgün hâliyle karşılaştırır ve SSIM
+      bildirir: değişen piksel saymak yerine yerel parlaklığı, karşıtlığı ve yapıyı
+      karşılaştıran bir sayı; gözün itiraz ettiği şeye çok daha yakın. Kabaca
+      0,98'in üstünde iki resim yan yana bile ayırt edilemez. Yaklaşık 0,95'in
+      altında, göndermeden önce bakın. Tercih edenler için geleneksel desibel
+      rakamı olan PSNR de bildirilir.
+    </p>
+    <p>
+      İkisi de kendi makinenizde hesaplanır ve size gösterilir; onları bulundurmanın
+      amacı da budur: &ldquo;asgari kalite kaybı&rdquo;nı bir iddia olmaktan çıkarıp
+      denetleyebileceğiniz bir sayıya çevirir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dosyayı göndermeden önce bilmeye değer üç şey</h2>
+    <p>
+      <strong>Sıkıştırmak üstveriyi siler.</strong> Yeniden kodlamak, resmi
+      piksellere çözüp o pikselleri yeniden kodlamak demektir ve piksellerle dolu
+      bir tuval hiçbir etiket taşımaz &mdash; yani GPS konumu, kamera modeli, zaman
+      damgaları ve gerisi yeni dosyaya yazılmaz. Genellikle bu bir kazançtır.
+      Etiketlerin gitmesini ama resmin el değmemiş kalmasını istiyorsanız, o başka
+      bir iştir: <a href="../../exif-verisi-silme/">EXIF Görüntüleyici ve
+      Silici</a> kabı hiçbir şeyi yeniden sıkıştırmadan yeniden yazar ve içinde ne
+      olduğunu <a href="../exif-ve-gps-verisini-silme/">kendi rehberi</a>
+      anlatıyor.
+    </p>
+    <p>
+      <strong>Aynı dosyayı asla iki kez sıkıştırmayın.</strong> Her kayıplı kodlama
+      ayrıntıyı kalıcı olarak atar ve zaten sıkıştırılmış bir resmi kodlamak daha
+      fazlasını atar &mdash; buna ilk geçişten kalan bozulmalar da dâhildir; onları
+      gerçek ayrıntı pahasına sadakatle korur. Her zaman özgün dosyaya dönün ve bir
+      kez sıkıştırın.
+    </p>
+    <p>
+      <strong>Özgün dosyayı saklayın.</strong> Kayıplı bir kodlamadan geri dönüş
+      yoktur. Ne gönderirseniz gönderin, başladığınız dosyayı bir yerde saklayın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Her tarayıcı yıllardır bir JPEG, PNG ve WebP kodlayıcıyla geliyor &mdash; bir
+      resmi bir tuvalden kaydeden kodun aynısı. Bir görseli sıkıştırmak, bir
+      sunucunun karışmasını gerektiren hiçbir teknik sebebi olmayan işlerden
+      biridir; buradaki aracın bir sunucusu olmamasının sebebi de budur: resim
+      kendi makinenizde çözülür, kodlanır ve ölçülür ve sayfanın
+      <code>Content-Security-Policy</code>'sinde onun gönderilebileceği, bu siteye
+      ait bir adres yoktur.
+    </p>
+    <p>
+      Bunu ister burada ister başka bir yerde doğrulamanın en basit yolu sayfayı
+      yüklemek, internet bağlantısını kesmek ve yine de bir şey sıkıştırmaktır.
+      Hâlâ çalışıyorsa hiçbir şey yüklenmiyordu.
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> buna benzer üç denetim daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/tr/pages/guides/compress-an-image-to-a-target-size.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir resmi hedef boyuta sıkıştırma - Türkçe.
+#
+
+nav = "Resim sıkıştırma"
+title = "Bir Resim Tam Olarak İstenen Dosya Boyutuna Nasıl Sıkıştırılır"
+description = "Bir yükleme formu 500 KB istiyor, fotoğrafınız ise 4 MB. Bir boyut sınırının gerçek bedeli, önce hangi ayarı oynatmanız gerektiği ve bir PNG'nin neden bir JPEG gibi küçülmediği."
+heading = "Bir resim tam olarak istenen dosya boyutuna nasıl sıkıştırılır"
+lede = """
+    Biri size bir sayı söyledi &mdash; 100&nbsp;KB, 500&nbsp;KB, 2&nbsp;MB
+    &mdash; fotoğrafınız ise ona yakın bile değil. Bu rehber, o sayının neye mal
+    olduğunu, onu neye harcayacağınızı ve sonucun göndermeye yetecek kadar iyi
+    olup olmadığını nasıl anlayacağınızı anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir resmi tam olarak istenen dosya boyutuna sıkıştırma"
+og_description = "Bir boyut sınırının gerçek bedeli, önce hangi ayarı oynatmanız gerektiği ve bir PNG'nin neden bir JPEG gibi küçülmediği."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/convert-an-svg-to-png.html
+++ b/locales/tr/pages/guides/convert-an-svg-to-png.html
@@ -1,0 +1,233 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../svg-yi-pnge-donusturme/">SVG'den Görsele</a>'yi açın, dosyayı
+      bırakın ve bir boyut söyleyin. Size hangi boyutu kullanacağınızı söyleyen bir
+      şey yoksa <strong>en uzun kenarda 1024 piksel</strong> iyi bir varsayılandır:
+      hemen her şeye yetecek kadar büyük, e-postayla göndermeye yetecek kadar
+      küçük. Biçimi PNG'de, arka planı saydamda bırakın ve dosyayı alın.
+    </p>
+    <p>
+      Aşağıdaki her şey, bu varsayılan yetmediğinde ne yapılacağıdır &mdash; sizin
+      için bir sayı belirtildiğinde, iş baskıya gittiğinde ya da sonuç yanlış
+      göründüğünde.
+    </p>
+  </section>
+
+  <section>
+    <h2>Boyut neden dosyanın değil sizin kararınız</h2>
+    <p>
+      Bir JPEG, ölçülmüş piksellerden oluşan bir ızgaradır; ne kadar büyük olduğunu
+      sormanın bir cevabı vardır. Bir SVG ise hiç resim değildir, bir talimatlar
+      kümesidir &mdash; buraya bir daire çiz, şu yolu şu renkte çiz &mdash; ve
+      talimatların boyutu olmaz. Bir tarayıcı onları 16 pikselde de 4000'de de
+      uygulayabilir ve sonuç ikisinde de aynı keskinliktedir; çünkü hiçbir şeyi
+      ölçeklemiyordur. Yeniden çiziyordur.
+    </p>
+    <p>
+      Dönüşümün sizin yerinize bir sayı seçememesinin ve büyük bir sayı seçmenin
+      size hiçbir şeye mal olmamasının sebebi budur. Bu, &ldquo;daha büyük
+      yap&rdquo;ın bedava olduğu tek görsel işidir.
+    </p>
+    <p>
+      Çoğu SVG dosyası bir <code>width</code> ve <code>height</code> özniteliği
+      taşır ve bir araç bunu gösterir &mdash; ama bu bir sınır değil, bir
+      varsayılandır. <code>width="24"</code> diyen bir simge, yalnızca onu çizen
+      kişinin aklında 24&nbsp;piksellik bir araç çubuğu olduğunu söyler.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sayı gerçekte nereden geliyor</h2>
+    <p><strong>Bir web sitesi için.</strong> Görselin sayfada CSS pikseli cinsinden
+      kapladığı boyutu alın ve önemsediğiniz ekranların piksel yoğunluğuyla
+      çarpın. 200&nbsp;piksel genişliğindeki bir yuvadaki bir logo, bir Retina
+      dizüstü için 400&nbsp;piksellik, güncel bir telefon için 600 piksellik bir
+      dosya ister. <code>@2x</code> ve <code>@3x</code>'in anlamı budur ve onları
+      yazan bir aracın sizi aynı hesabı üç kez yapmaktan kurtarmasının sebebi de
+      budur.
+    </p>
+    <p><strong>Bir uygulama simgesi, bir mağaza kaydı ya da bir favicon için.</strong>
+      Sayı yayımlanmıştır ve hesaplanacak bir şey yoktur: mağazanın sayfası ne
+      diyorsa tam olarak o. Bir favicon için hiç piksele çevirmeyin &mdash;
+      <a href="../favicon-olusturma/">bir .ico yapın</a>; o, birkaç boyutu tek
+      dosyada tutar, çünkü bir tarayıcı sekmesi, bir yer imi ve bir Windows
+      kısayolunun hepsi başka boyut ister.
+    </p>
+    <p><strong>Baskı için.</strong> İnç cinsinden fiziksel boyutu yazıcının
+      çözünürlüğüyle çarpın. Bir kartvizite iki inç genişliğinde ve
+      300&nbsp;DPI'da girecek bir logo 600 pikseldir; aynı logo bir A4 sayfası
+      boyunca, yani 8,3&nbsp;inçte, yaklaşık 2500'dür. Matbaalar alışkanlıkla
+      300&nbsp;DPI ister; odanın öbür ucundan bakılan büyük boy bir afiş için ise
+      150 fazlasıyla yeter.
+    </p>
+    <p><strong>Bir sosyal ön izleme ya da bir OG görseli için.</strong> Platform bir
+      kutu belirtir &mdash; çoğu bağlantı ön izlemesi için
+      1200&nbsp;&times;&nbsp;630 &mdash; ve o kutu logonuzdan başka şekildedir.
+      &ldquo;Tamamla&rdquo; ayarının varlık sebebi budur: esnetilmiş ve herkese
+      denetlemediğinizi söyleyen bir logo yerine, kendi oranlarında ortalanmış bir
+      çizim ve gerisini dolduran bir arka plan rengi.
+    </p>
+    <p>
+      Bunlardan ikisi birden geçerliyse büyük olanı kullanın. Olması gerekenden
+      büyük bir PNG biraz daha büyük bir indirmedir; fazla küçük olan biri ise bir
+      sonraki bölümdeki sebeple, sonradan düzeltilemez.
+    </p>
+  </section>
+
+  <section>
+    <h2>Geri dönemezsiniz</h2>
+    <p>
+      Piksele çevirmek tek yönlüdür. Çizim bir kez PNG olduğunda, başka her resim
+      gibi piksellerden ibarettir ve sonradan büyütmek, hiç ölçülmemiş ayrıntıyı
+      uydurmak zorundadır &mdash; bir fotoğrafı büyütmekten aldığınız o yumuşak,
+      bulaşmış sonucun aynısı.
+    </p>
+    <p>
+      Bu yüzden SVG'yi saklayın. Ana kopya odur, neredeyse her zaman küçük olan
+      dosya odur ve gelecekteki her boyut ondan kusursuz çıkar. PNG, tek bir belirli
+      kullanım için bir dışa aktarımdır ve başka bir boyut gerektiğinde doğru
+      hamle, dışa aktardığınızı boyutlandırmak değil yeniden dışa aktarmaktır.
+    </p>
+    <p>
+      Bir PNG'yi SVG'ye geri dönüştürdüğünü iddia eden yazılımlar var. Yaptıkları
+      şey iz sürmektir: bir piksel ızgarasını hangi eğrilerin açıklayabileceğini
+      tahmin etmek. Düz iki renkli çizimlerde şöyle böyle çalışır, başka her şeyde
+      pahalı bir saçmalık üretir ve özgün çizimde olanı hiçbir zaman geri
+      getirmez.
+    </p>
+  </section>
+
+  <section>
+    <h2>Piksele dönüştüğü anda değişen üç şey</h2>
+    <p>
+      Yanlış görünen, piksele çevrilmiş bir SVG neredeyse her zaman şu üç sebepten
+      biri yüzünden yanlış görünür ve üçünü de dışa aktardıktan sonra değil önce
+      bilmeye değer.
+    </p>
+    <p>
+      <strong>Metin, makinede hangi yazı tipi varsa onunla çizilir.</strong> Metin
+      içeren bir SVG yazı tipini içermez &mdash; birinin adını verir ve bulmayı
+      çizicinin işine bırakır. Yazı tipi kurulu değilse bir yedeği kullanılır ve o
+      yedeğin harf biçimleri ve genişlikleri farklıdır; yani metin yeniden akabilir
+      ya da taşabilir. Yazı tipini bir web adresinden çeken bir dosyanın hâli daha
+      da kötüdür: bir <code>&lt;img&gt;</code> üzerinden piksele çevrilen bir SVG'nin
+      hiçbir şey getirmesine izin verilmez, yani hiçbir şey gelmez.
+    </p>
+    <p>
+      Çözüm her tasarımcının zaten bildiği çözümdür: SVG'yi dışa aktarmadan önce
+      <strong>metni dış hatlara çevirin</strong> (Illustrator buna Create Outlines,
+      Figma Flatten, Inkscape Object to Path diyor). Harfler geometriye dönüşür,
+      yazı tipi önemsizleşir ve resim her makinede aynı görünür. Bunu bir kopya
+      üzerinde yapın &mdash; dış hatlara çevrilmiş metin artık metin olarak
+      düzenlenemez.
+    </p>
+    <p>
+      <strong>Saç teli çizgiler grileşir ya da kaybolur.</strong> Seçtiğiniz
+      boyutta bir pikselden ince düşen bir çizgi düz bir çizgi olarak çizilemez,
+      yani silik çizilir. Zarif bir logonun 64&nbsp;pikselde soluk görünmesinin ama
+      aynı dosyanın 512'de kusursuz görünmesinin sebebi budur. Gereken küçük bir
+      boyutsa cevap başka bir dışa aktarma ayarı değil, daha kalın çizgileri olan
+      sadeleştirilmiş bir çizimdir &mdash; bir faviconun bir kelime logosu değil bir
+      sembol olmasının sebebi de aynıdır.
+    </p>
+    <p>
+      <strong>Canlandırma durur.</strong> Canlandırmalı bir SVG tek bir kareye
+      dönüşür: ilk kare neyse o. Bunu değiştiren bir dışa aktarma ayarı yoktur.
+      Harekete ihtiyacınız varsa, başka bir yolla yapılmış bir GIF'e ya da videoya
+      ihtiyacınız var demektir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Saydamlık ve hangi biçimin seçileceği</h2>
+    <p>
+      Bir sebebiniz yoksa <strong>PNG</strong>. Kayıpsızdır, saydamlığı korur ve
+      sert kenarlı düz renk &mdash; bir çizimin büyük kısmı bundan oluşur &mdash;
+      onun içinde iyi sıkışır. Piksele çevrilmiş bir logo genellikle JPEG olacağından
+      hem daha temiz hem de <em>daha küçük</em> bir PNG olur.
+    </p>
+    <p>
+      <strong>JPEG</strong>'in saydamlığı hiç yoktur. Her saydam pikselin bir renge
+      dönüşmesi gerekir ve sizin yerinize bir renk seçen olmazsa siyah olur &mdash;
+      insanların hata sandığı o siyah kutu içindeki logo sonucu buradan gelir. Ayrıca
+      tam da bu tür bir resimde en kötü görünen biçimde kayıplıdır: her sert kenarın
+      etrafında bir benek halkası. Bir şey ısrar ettiğinde kullanın.
+    </p>
+    <p>
+      <strong>WebP</strong>, PNG'nin yaptığı her şeyi daha küçük bir dosyada yapar ve
+      güncel her tarayıcı tarafından okunur. Kullanmama sebebi tarayıcıdan sonra
+      olanlardır: eski yazılımlar, bazı matbaalar ve hatırı sayılır sayıda yükleme
+      formu hâlâ bir tanesini açmıyor.
+    </p>
+    <p>
+      PNG ile bir arka plan rengi seçmek de gayet sıradan bir istektir. Saydamlık
+      yalnızca görselin üstüne düşeceği şey tahmin edemeyeceğiniz bir renk olduğunda
+      işe yarar; bunun beyaz bir sayfa olduğunu zaten biliyorsanız beyaza
+      düzleştirmek koca bir sürpriz sınıfından kurtarır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dışa aktarım boş ya da yanlış çıktığında</h2>
+    <p>
+      <strong>Boşluktan başka bir şey yok.</strong> Genellikle kök öğede eksik bir
+      <code>xmlns</code> özniteliği. Onsuz bir dosya, bir görsel etiketi açısından
+      SVG değildir ve hiçbir şey olarak çizilir. Dosyayı bir tarayıcıda açmak hızlı
+      denetimdir: tarayıcı da hiçbir şey göstermiyorsa sorun dönüştürücü değil
+      dosyadır.
+    </p>
+    <p>
+      <strong>Çizim küçük, sol üst köşede.</strong> Dosyada bir <code>width</code> ve
+      <code>height</code> var ama <code>viewBox</code> yok; yani ölçeklenecek bir
+      koordinat sistemi yok ve çizim daha büyük bir tuvalde kendi özgün birimlerini
+      koruyor. İyi bir dönüştürücü sizin için bir viewBox koyar; sizinki koymadıysa
+      kök öğeye elle
+      <code>viewBox="0 0 <em>genişlik</em> <em>yükseklik</em>"</code> eklemek bunu
+      düzeltir ve dosya düz metin olduğu için bunu yapabilirsiniz.
+    </p>
+    <p>
+      <strong>Resmin bir kısmı eksik.</strong> Dosyadaki bir şey çizimi içermek
+      yerine bir adresi göstermiş &mdash; bağlantı olarak saklanmış gömülü bir
+      fotoğraf, bir stil dosyası, bir yazı tipi. Bunları getirmeyi reddeden bir
+      çizici doğru olanı yapıyordur ve bu, bir yerden indirdiğiniz bir SVG'nin onu
+      yapana geri rapor vermesini engelleyen reddin aynısıdır. Çizim programından,
+      görseller gömülü olarak yeniden dışa aktarın.
+    </p>
+    <p>
+      <strong>Çok büyük bir boyutu reddediyor.</strong> Tarayıcılar bir tuvalin ne
+      kadar büyük olabileceğine tavan koyar ve nerede olduğu konusunda anlaşamazlar:
+      kenarda kabaca 16.000&nbsp;pikselin ötesinde hiçbir şey geri gelmez ve bir
+      iPhone ya da iPad'deki Safari çok daha erken, yaklaşık
+      4096&nbsp;&times;&nbsp;4096'da pes eder. Sizi uyaran bir araç, sizi boş bir
+      dosyadan kurtarıyordur; çünkü bir tarayıcı tükendiğinde bir hata iletisi değil
+      onu üretir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir SVG'yi piksele çevirmek, her tarayıcının günde binlerce kez yaptığı bir
+      şeydir &mdash; bir web sayfasında bir simge çizen mekanizmanın aynısı.
+      Çiziminizin bir PNG olarak çıkmak için bir sunucuya gidip gelmesinin teknik bir
+      sebebi yoktur ve buradaki araç onu hiçbir yere göndermez: sayfanın
+      <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi tek tek
+      sayar ve bunların hiçbiri bu siteye ait değildir.
+    </p>
+    <p>
+      Bu, SVG'de her zamankinden önemlidir; çünkü bir SVG bir resim değil bir
+      belgedir. İçinde bir betik ve uzak bir adres bulunabilir ve bir ajansın size
+      gönderdiği bir logo, sizin yazmadığınız bir dosyadır. Bir görsel etiketi
+      üzerinden çizildiğinde, belirtimin <em>güvenli durağan kip</em> dediği yerdedir:
+      betik çalışamaz ve adresle hiçbir zaman iletişim kurulmaz. Bunu web sitesi değil
+      tarayıcı zorunlu kılar.
+    </p>
+    <p>
+      Size söylenmesindense denetlemeyi tercih ederseniz sayfayı yükleyin, internet
+      bağlantısını kesin ve yine de bir şey dönüştürün.
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya yüklemek
+      güvenli mi?</a> herhangi bir araçta çalıştırabileceğiniz üç denetim daha
+      anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/tr/pages/guides/convert-an-svg-to-png.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir SVG'yi PNG'ye dönüştürme - Türkçe.
+#
+
+nav = "SVG'yi PNG'ye dönüştürme"
+title = "Bir SVG Doğru Boyutta PNG'ye Nasıl Dönüştürülür"
+description = "Bir vektörün kendine ait bir piksel boyutu yoktur; yani sayıyı siz seçersiniz. O sayının bir ekran, bir uygulama simgesi ve bir yazıcı için nereden geldiği ve bir çizim piksele dönüştüğünde nelerin değiştiği."
+heading = "Bir SVG doğru boyutta PNG'ye nasıl dönüştürülür"
+lede = """
+    Dönüştürmek işin kolay yarısı. Sonucun bir işe yarayıp yaramayacağına karar
+    veren soru, kimsenin size cevabını vermediği sorudur: kaç piksel? Bu rehber o
+    sayının nereden geldiğini ve bir çizimin piksele dönüşürken neleri
+    kaybettiğini anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir SVG'yi doğru boyutta PNG'ye dönüştürme"
+og_description = "Piksel sayısının gerçekte nereden geldiği ve bir çizim piksele dönüştüğünde değişen üç şey."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/convert-heic-to-jpg.html
+++ b/locales/tr/pages/guides/convert-heic-to-jpg.html
@@ -1,0 +1,243 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../heic-jpg-donusturme/">HEIC'ten JPG'ye dönüştürücüyü</a> açın,
+      fotoğrafları bırakın ve &ldquo;Dönüştür&rdquo;e basın. Kalite kaydırağını
+      olduğu yerde bırakın ve aksini gerektiren bir sebebiniz yoksa &ldquo;tarihi,
+      kamerayı ve ayarları koru&rdquo;yu işaretli bırakın. Geriye JPEG'ler
+      alırsınız; her birinin bir indirme düğmesi olur, birkaç tane varsa bir zip.
+    </p>
+    <p>
+      Siz bunu yaparken hiçbir şey yüklenmiyor. Bu, tam da bu iş için alışılmadık
+      bir durumdur ve sebebi bu sayfanın ilginç yarısıdır.
+    </p>
+  </section>
+
+  <section>
+    <h2>HEIC aslında nedir</h2>
+    <p>
+      HEIC, JPEG'in olduğu anlamda gerçekten bir görsel biçimi değildir. Bir
+      kaptır &mdash; bir MP4'ün kurulduğu kutu yapısının aynısı &mdash; ve içinde
+      bir <strong>HEVC</strong> videosunun tek bir karesi vardır. H.265 de denen
+      HEVC, eski kameranızın kullandığı kodlayıcının yerini alan kodlayıcıdır ve
+      çok iyidir: HEIC'teki bir iPhone fotoğrafı, aynı kalitedeki JPEG hâlinin
+      kabaca yarısı boyutundadır.
+    </p>
+    <p>
+      Apple 2017'de, iOS 11'de buna geçti ve varsayılan yaptı. Yani biri
+      Ayarlar'a girip &ldquo;En Uyumlu&rdquo;yu seçmediyse, telefonunun neredeyse
+      on yıldır çektiği her fotoğraf şu özelliklere sahip bir biçimdedir:
+    </p>
+    <ul>
+      <li>Windows, Mağaza'dan bir uzantı olmadan ön izlemesini göstermez;</li>
+      <li>çoğu web yükleme formu düpedüz reddeder;</li>
+      <li>epeyce eski masaüstü yazılımı adını bile duymamıştır;</li>
+      <li>ve Safari dışında hiçbir web tarayıcısı göstermez.</li>
+    </ul>
+    <p>
+      Fotoğrafta bir sorun yok. JPEG'in olacağından daha iyi bir dosya. Yalnızca
+      dünyanın çoğunun hiç öğrenmediği bir dilde yazılmış.
+    </p>
+  </section>
+
+  <section>
+    <h2>Neden bir tanesini yalnızca Safari açıyor</h2>
+    <p>
+      Bu kısım şimdiye kadar kullandığınız her dönüştürücüyü açıklıyor, o yüzden
+      bir paragrafa değer.
+    </p>
+    <p>
+      HEVC'yi çözmek bir HEVC çözücüsü ister ve HEVC patentlidir. Lisanslama birden
+      fazla patent havuzu tarafından yürütülür ve bir çözücü göndermek birine para
+      ödemek demektir. Tarayıcılar bunu işletim sistemine yaslanarak çözer &mdash;
+      Chrome, donanımında lisanslı bir çözücü zaten bulunan bir makinede HEVC
+      <em>videosu</em> oynatır &mdash; ama o yol video oynatımı için döşenmiştir,
+      duran görüntüler için değil. Yani <code>&lt;img&gt;</code>'e verilen bir HEIC,
+      her işletim sisteminde, Chrome'da da Firefox'ta da Edge'de de reddedilir.
+    </p>
+    <p>
+      Apple donanımındaki Safari istisnadır; çünkü macOS ve iOS çözücüye sahiptir ve
+      Safari'nin ona sormasına izin verilir. Başka her yerde resim, tarayıcı
+      açısından düpedüz çözülemezdir.
+    </p>
+    <p>
+      Bu da bir dönüştürücüye tam olarak iki seçenek bırakır ve ikisi arasındaki
+      seçim, bu tür bir aracın bütün hikâyesidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Neredeyse her HEIC dönüştürücüsü neden bir yükleme istiyor</h2>
+    <p>
+      Birinci seçenek: çözücüyü bir sunucuya koymak. Fotoğraf yüklenir, hiç
+      görmediğiniz bir makinede çözülür, JPEG olarak yeniden kodlanır ve geri
+      gönderilir. Hemen her &ldquo;ücretsiz çevrimiçi HEIC dönüştürücü&rdquo;nün
+      yaptığı budur ve hepsinin dosyalarınıza ihtiyaç duymasının sebebi de budur.
+      Tembellik değil &mdash; tarayıcı bunu gerçekten yardımsız yapamıyor.
+    </p>
+    <p>
+      Bunun bedeli konusunda açık sözlü olmaya değer. Telefondan çıkan fotoğraflar
+      çoğu insanın sahip olduğu en kişisel dosyalardır ve bir iPhone'dan doğrudan
+      çıkan bir HEIC tipik olarak, çekildiği yerin birkaç metre hassasiyetindeki
+      koordinatlarını, saniyesine kadar tarihi ve bir kamera tanımlayıcısını taşır.
+      Bir klasör dolusunu ücretsiz bir hizmete yüklemek, hem resimleri hem de bunu
+      teslim etmek demektir. Sonrasında ne olacağını, okumadığınız bir gizlilik
+      politikası, inceleyemediğiniz bir sunucu ve seçmediğiniz bir yargı bölgesi
+      belirler.
+    </p>
+    <p>
+      İkinci seçenek: çözücüyü sayfaya koymak. <a href="../../heic-jpg-donusturme/">Bu
+      araç</a> onu yapıyor. WebAssembly'ye derlenmiş <code>libheif</code>'i, bu
+      siteden sunulan bir dosya olarak taşıyor &mdash; yaklaşık 1,4 MB, bir kez
+      indirilip sonra önbelleğe alınıyor. Tarayıcınız onu kendi makinenizde, kendi
+      donanımınızda çalıştırır ve fotoğraf hiçbir yere gitmez. Sayfayı bir kez
+      yükleyin, sonra internet bağlantısını tamamen kesin, çalışmaya devam eder ki
+      bu, yükleme yapan hiçbir dönüştürücünün yapamayacağı bir şeydir ve var olan
+      en basit kanıttır.
+    </p>
+    <p>
+      1,4 MB'nin tamamı, ödenen bedeldir. Ölçülen bir bağlantıdaysanız bu gerçek bir
+      maliyettir ve bilmeye değer; sayfanın onu sessizce indirmek yerine yüksek
+      sesle söylemesinin sebebi de budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dönüştürmek resme neye mal oluyor</h2>
+    <p>
+      HEIC ve JPEG farklı kodlayıcılardır; yani resmi çözüp yeniden kodlamayı
+      içermeyen bir geçiş yolu yoktur. O ikinci kodlama kayıplıdır. Pratikte bu,
+      kulağa geldiğinden çok daha az önemlidir:
+    </p>
+    <ul>
+      <li>
+        <strong>92 kalitede</strong> &mdash; dönüştürücünün başladığı yer &mdash;
+        bir fotoğrafı normal bir izleme boyutunda özgün hâlinden ayırmak çok
+        zordur. Açık bir gökyüzü gibi yumuşak geçişlerde fark ararsınız ve
+        genellikle bulamazsınız.
+      </li>
+      <li>
+        <strong>JPEG daha büyük olacak.</strong> Genellikle üçte bir büyükle iki
+        katı arasında bir yerde; çünkü JPEG 1992'den kalma bir kodlayıcıdır, HEVC
+        ise değil. Takas budur: her şeyin açtığı, daha büyük bir dosya.
+      </li>
+      <li>
+        <strong>Kaçınılacak şey iki kez dönüştürmektir.</strong> Her kayıplı kodlama
+        bir parça bedele mal olur. Birinin sizin için çoktan yaptığı bir JPEG'den
+        değil, özgün HEIC'ten dönüştürün ve bunu bir kez yapın.
+      </li>
+    </ul>
+    <p>
+      Hiç kayıp istemiyorsanız biçim menüsünde PNG var. Dosyaya hazır olun: bir
+      fotoğraf PNG olarak, genellikle JPEG hâlinin beş ila on katı boyutundadır;
+      çünkü PNG'nin sıkıştırması çimen ve ten için değil, düz renk ve çizgi çalışması
+      için tasarlanmıştı.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tarih, kamera ve koordinatlar</h2>
+    <p>
+      HEIC dönüştürücüleriyle ilgili alışıldık şikâyet, fotoğrafların çekildikleri
+      günü kaybetmiş olarak geri gelmesidir; böylece bir tatil dolusu resim,
+      kütüphanenin en altına bugünün tarihiyle sıralanır. Bu, bir tuval üzerinden
+      dönüştürmenin size piksellerden başka bir şey vermemesinden olur &mdash; bir
+      tuval hiçbir etiket tutmaz &mdash; yani bir dönüştürücü gidip üstveriyi ayrıca
+      getirmediyse üstveri düpedüz gitmiştir.
+    </p>
+    <p>
+      Buradaki araç EXIF bloğunu HEIC'ten kopyalayıp JPEG'in içine yazar, böylece
+      tarih hayatta kalır. Bir onay kutusu var ve varsayılan olarak işaretli.
+      İşareti kaldırın, JPEG resimden başka bir şey olmadan çıksın.
+    </p>
+    <p>
+      Karar vermeden önce listeye bakın: her fotoğrafın satırı, dosyanın GPS
+      koordinatları taşıyıp taşımadığını söyler ve bunu herhangi bir şey
+      dönüştürülmeden önce söyler. Fotoğraflar herkese açık bir yere gidiyorsa
+      okunacak satır odur. Kendi kütüphanenize gidiyorlarsa üstveriyi korumak
+      neredeyse kesinlikle istediğiniz şeydir.
+    </p>
+    <p>
+      Ne seçerseniz seçin bir etiket değişir ve sebebini bilmeye değer. Bir HEIC
+      döndürmesini iki yerde kaydeder: kapta ve EXIF bloğunda. Çözücü, çözerken kabın
+      döndürmesini uygular, yani teslim edilen pikseller zaten doğru yöndedir. EXIF
+      hâlâ &ldquo;bunu 90 derece döndür&rdquo; deseydi bir görüntüleyici bunu bir
+      kez daha yapardı ve her dikey fotoğraf yan yatmış çıkardı. Bu yüzden yön
+      etiketi dik olarak ayarlanır ve geri kalan her şey telefonun yazdığı gibi,
+      olduğu gibi kopyalanır.
+    </p>
+    <p>
+      İstediğiniz şey etiketleri ayrıntısıyla gözden geçirmek ya da zaten JPEG olan
+      fotoğraflardan silmekse, o başka bir iştir ve onun için bir
+      <a href="../exif-ve-gps-verisini-silme/">rehberi var</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>İnsanları yanıltan şeyler</h2>
+    <ul>
+      <li>
+        <strong>&ldquo;.jpg&rdquo; adlı bir HEIC.</strong> Son derece yaygın: yol
+        boyunca bir şey onu dönüştürmeden yeniden adlandırmıştır; hâlâ
+        açılmamasının sebebi de budur. Dönüştürücüye bırakılan her dosya adından
+        değil ilk baytlarından tanınır, yani bunlardan biri sorunsuz çalışır.
+        Gerçekten JPEG olan bir dosyanın kendisinin bir kopyasına dönüştürülmek
+        yerine bunun söylenmesinin sebebi de budur.
+      </li>
+      <li>
+        <strong>Tek dosya, birkaç resim.</strong> Bir seri çekim ya da bir Live
+        Photo birden fazla kare tutabilir. Hepsi dönüştürülür ve fazladan olanlar
+        özgün adın ardından numaralanır. Bir Live Photo'nun video yarısı,
+        telefonun HEIC'in yanında tuttuğu ayrı bir dosyadır, yani dönüştürülmek
+        üzere orada değildir.
+      </li>
+      <li>
+        <strong>AVIF, HEIC değildir.</strong> Birbirlerine benzerler &mdash; aynı
+        kap, içinde farklı kodlayıcı &mdash; ama güncel her tarayıcı bir AVIF'i
+        kendiliğinden açar, yani dönüştürülecek bir şey yoktur ve araç, çalışıyormuş
+        gibi yapmak yerine bunu söyler.
+      </li>
+      <li>
+        <strong>Sorunu kaynağında durdurmak.</strong> Telefonda: Ayarlar &rarr;
+        Kamera &rarr; Biçimler &rarr; En Uyumlu. O andan sonra yeni fotoğraflar
+        JPEG olur. Daha fazla depolama kullanır ve zaten sahip olduğunuz fotoğraflara
+        dokunmaz, ama bunu bir daha hiç yapmamak demektir.
+      </li>
+      <li>
+        <strong>Paylaşmak bazen zaten dönüştürüyor.</strong> Bir fotoğrafı
+        Apple dışı bir cihaza AirDrop'lamak ya da e-postayla göndermek çoğu zaman
+        bir JPEG teslim eder; çünkü iOS çıkışta dönüştürür. Bir fotoğraf yine de
+        HEIC olarak geldiyse, dönüştürmeyen bir yoldan gelmiştir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bir dönüştürücünün yükleme yapıp yapmadığını nasıl anlarsınız</h2>
+    <p>
+      Bu, yalnızca bu araç için değil her araç için geçerlidir ve yaklaşık on beş
+      saniye sürer.
+    </p>
+    <ol>
+      <li>
+        Sayfayı açın, sonra tarayıcınızın geliştirici araçlarını açıp Ağ sekmesine
+        gidin.
+      </li>
+      <li>
+        Bir fotoğraf dönüştürün ve izleyin. Sizin makinenizde çözen bir araç o anda
+        hiçbir istek yapmaz. Yükleme yapan bir araç, fotoğrafınızın boyutunda bir
+        istek yapar ve boyutunu görebilirsiniz.
+      </li>
+      <li>
+        Ya da daha basiti: sayfayı yükleyin, internet bağlantısını kesin ve bir şey
+        dönüştürmeye çalışın. Fotoğrafınızı çözülmek üzere uzağa gönderen bir araç
+        çalışmayı bırakır. Çözücüyü taşıyan bir araç bırakmaz.
+      </li>
+    </ol>
+    <p>
+      Buradaki dönüştürücü iki denetimi de geçecek şekilde kuruldu ve bu tartışmanın
+      daha uzun bir sürümü
+      <a href="../dosya-yuklemek-guvenli-mi/">dosya yüklemek güvenli mi</a>
+      sayfasında.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/tr/pages/guides/convert-heic-to-jpg.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: telefonun kaydettiği biçim ve ondan nasıl çıkılacağı - Türkçe.
+#
+
+nav = "HEIC'ten JPG'ye"
+title = "HEIC Nasıl JPG'ye Dönüştürülür (ve HEIC Aslında Nedir)"
+description = "iPhone'lar fotoğrafları HEIC olarak kaydeder ve internetin yarısı bir tanesini açamaz. Bu biçimin ne olduğu, neden yalnızca Safari'nin onu çözdüğü, dönüştürmenin resme neye mal olduğu ve bunu fotoğrafları kimseye yüklemeden nasıl yapacağınız."
+heading = "Telefonunuzun kaydettiği fotoğraf ve hiçbir şeyin açmadığı biçim"
+lede = """
+    Bir iPhone fotoğrafları HEIC olarak kaydeder; bu biçim JPEG'den hem küçük hem
+    iyidir ve epeyce yazılım onu hâlâ açmayı reddediyor. Bu rehber biçimin
+    gerçekte ne olduğunu, dönüştürmenin resme neye mal olduğunu ve neredeyse her
+    dönüştürücünün neden önce sizden onu yüklemenizi istediğini anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "HEIC nasıl JPG'ye dönüştürülür"
+og_description = "iPhone fotoğraflarının neden açılmadığı, dönüştürmenin neye mal olduğu ve bunu fotoğrafları kimseye vermeden nasıl yapacağınız."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/crop-a-video.html
+++ b/locales/tr/pages/guides/crop-a-video.html
@@ -1,0 +1,204 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../video-kirpma/">Video Kırpıcı</a>'yı açın, klibi bırakın,
+      kutuyu tutmak istediğiniz kısmın üzerine sürükleyin &mdash; size bir şekil
+      verildiyse ona kilitleyin &mdash; ve dışa aktarın. Çıkan klip, giren kadar
+      uzundur; zamanlaması ve sesi el değmemiştir.
+    </p>
+    <p>
+      Kesmenin aksine bu iş yeni kareler yazmak zorundadır. Bu, herhangi bir aracın
+      eksikliği değildir; kırpmanın kendisi budur. Bu sayfanın geri kalanı bunun
+      neye mal olduğu ve bedeli küçük tutmakla ilgili.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kırpmak neden yeniden kodlamaktan kaçamaz</h2>
+    <p>
+      Bir kesme kareleri bütün hâlde tutar; yani iyi bir kesici onları el
+      değdirmeden karşıya taşır ve hiçbir şey çözülmez. Bir kırpma ise her karenin
+      bir kısmını tutar &mdash; ve bir karenin bir kısmı başka bir resimdir. Başka
+      bir resmi, pikselleri baştan yazmadan saklamanın yolu yoktur.
+    </p>
+    <p>
+      Dar bir istisna var ve birinin bunu iddia ettiğini tanıyabilmeniz için bilmeye
+      değer. Video bloklar hâlinde kodlanır ve bir kırpma dört kenarda da tam blok
+      sınırlarına denk gelseydi verinin bir kısmı ilkesel olarak yeniden
+      kullanılabilirdi. Pratikte karenin kendi boyutları, hareket vektörleri ve
+      kestirimi yine de yeniden yazılmak zorundadır; yani gerçekte hiçbir şey böyle
+      kurulmaz. Bir kırpmanın yeniden kodlama demek olduğunu varsayın.
+    </p>
+    <p>
+      İyi davranan bir kırpıcının yapacağı şey, aynı alana özgün dosyanın
+      harcadığından <em>fazlasını</em> harcamamaktır. Kırpılmış bir bölgeyi
+      kaynağından yüksek bir bit hızında kodlamak yalnızca dosyayı büyütür; özgün
+      dosyada olmayan ayrıntıyı geri koyamaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Aslında sizden istenen şekiller</h2>
+    <p>
+      Kırpmanın çoğu, bir yerin zorunlu bir en boy oranı olduğu için yapılır. Kısa
+      liste:
+    </p>
+    <ul>
+      <li>
+        <strong>9:16 &mdash; uzun.</strong> Hikâyeler, reels, shorts, TikTok.
+        Normal tutulan bir telefonda tam ekran. Birinin bir videoyu kırpmasının en
+        yaygın sebebi.
+      </li>
+      <li>
+        <strong>1:1 &mdash; kare.</strong> Birkaç platformda akış gönderileri.
+        İzleyen kişi telefonunu hangi yönde tutarsa tutsun çalışır; varlığını
+        sürdürmesinin sebebi de budur.
+      </li>
+      <li>
+        <strong>4:5 &mdash; hafif uzun.</strong> Bazı akışların izin verdiği en
+        büyük şekil; yani tam dikey bir video olmadan ekranın kareden fazlasını
+        kaplar.
+      </li>
+      <li>
+        <strong>16:9 &mdash; geniş.</strong> Genel olarak videonun standardı.
+        Buna <em>doğru</em> kırpmayı genellikle yalnızca siyah bantları kaldırmak
+        için, bundan <em>çıkarak</em> kırpmayı da yukarıdakilerden birine ulaşmak
+        için yaparsınız.
+      </li>
+    </ul>
+    <p>
+      Kutuyu göz kararı sürüklemek yerine orana kilitleyin. Birkaç piksel şaşmak,
+      platformun sizin kırpmanızı kırpması demektir ve nereden kırpacağını size
+      danışmaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Yatay bir klibi dikeye çevirmek</h2>
+    <p>
+      Bu, en zor yaygın durumdur ve kırpmanın bir çözüm değil bir uzlaşma olduğunu
+      açıkça söylemeye değer.
+    </p>
+    <p>
+      9:16'ya kırpılmış bir 16:9 videosu, resim genişliğinin yaklaşık %32'sini
+      korur. Yanlarda ne varsa gitmiştir &mdash; ve yatay bir çekimde bağlam
+      genellikle yanlardadır. İki kişi karenin karşıt yanlarında konuşuyorsa hiçbir
+      tek kırpma ikisini birden tutmaz.
+    </p>
+    <p>
+      Kırpmayı, klibi bir kez izleyip öznenin çoğu zaman gerçekte nerede olduğunu
+      sorarak seçin. Cevap &ldquo;yer değiştiriyor&rdquo; ise durağan bir kırpma
+      yanlış araçtır ve istediğiniz şey, kırpmayı zaman içinde kaydırabilen bir
+      düzenleyicidir. Cevap &ldquo;çoğunlukla ortada&rdquo; ise ortalanmış bir
+      kırpma gayet iyidir ve on saniye sürer.
+    </p>
+    <p>
+      Hatırlamaya değer alternatif: birçok platform yatay bir videoyu kabul edip
+      siyah bantları kendisi ekler. Kırpma, videonun kabul edilmesini istediğiniz
+      için değil, tam ekranı istediğiniz zaman içindir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Genişlik ve yükseklik neden ikişer ikişer değişiyor</h2>
+    <p>
+      Kırpma kutusunun tek sayıları reddettiğini fark ettiyseniz, zorluk çıkaran
+      arayüz değil kodlayıcıdır.
+    </p>
+    <p>
+      Bir MP4'ün içindeki kodlayıcı olan H.264, rengi yatayda ve dikeyde yarı
+      çözünürlükte saklar; çünkü göz, renk ayrıntısına parlaklığa olduğundan çok
+      daha az duyarlıdır. Bu, resmin iki piksellik birimler hâlinde ele alındığı ve
+      bir kenarında tek sayıda piksel olan bir kareyi tarif etmenin bir yolu
+      olmadığı anlamına gelir.
+    </p>
+    <p>
+      Araçlar bunu, siz kırpmayı ayarladıktan sonra yuvarlayarak &mdash; ki bu
+      kutunuzu size söylemeden bir piksel oynatır &mdash; ya da en baştan yalnızca
+      çift sayılar sunarak çözer. Burada olan ikincisidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sese ne oluyor</h2>
+    <p>
+      MP4 yolunda hiçbir şey. Kırpmak resmi değiştirir ve sese dokunmak için bir
+      sebebi yoktur; yani ses hiç çözülmeden örnek örnek karşıya kopyalanır &mdash;
+      dosyada ne varsa baytı baytına aynısı.
+    </p>
+    <p>
+      Aşağıda anlatılan kayıt yedeğinde ise ses, oynatımdan yakalanır ve yeniden
+      kodlanır; bu da bir parça kaliteye mal olur. Her hâlükârda sesi tamamen
+      dışarıda bırakan bir onay kutusu var; klip zaten sessiz oynatılan bir yere
+      gidiyorsa ve en küçük dosyayı istiyorsanız kullanmaya değer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Biçimler ve ne kadar sürdüğü</h2>
+    <p>
+      <strong>MP4, M4V ve MOV</strong>, tarayıcınız o kodlayıcıyı çözebildiği
+      sürece içlerinde ne olursa olsun &mdash; H.264, HEVC, AV1 ya da VP9 &mdash;
+      doğrudan okunur. Kesmenin aksine kırpmak çözmek zorundadır; yani kodlayıcı
+      burada, orada olmadığı biçimde önemlidir.
+    </p>
+    <p>
+      <strong>Tarayıcınızın oynatabildiği başka her şey</strong>, en bilineni WebM,
+      oynatılıp sonuç kaydedilerek kırpılır; bu yöntem çalışır ve klip ne kadar
+      uzunsa o kadar sürer.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV ve çoğu MKV</strong>'yi tarayıcı ne okuyabilir ne
+      oynatabilir; araç da yarı yolda çuvallamak yerine bir iletiyle reddeder.
+    </p>
+    <p>
+      Uzun bir klipte bir kırpmanın gerçek zaman almasını bekleyin; çünkü her kare
+      çözülüyor ve yeniden kodlanıyor. Araca yerleşik bir sınır yok ve dosya
+      bütünüyle yüklenmek yerine birkaç megabaytlık parçalar hâlinde geçiliyor;
+      pratikteki tavan, siz indirmeden önce bellekte bir araya getirilen bitmiş
+      videodur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Her şeyden önce kesin, sonra kırpın</h2>
+    <p>
+      Bir klibin hem kesilmesi hem kırpılması gerekiyorsa önce kesin &mdash;
+      bedavadır ve kestiğiniz her saniye, kimsenin yeniden kodlamak zorunda
+      olmadığı bir saniyedir. Sonra kısalmış klibi bir kez kırpın.
+    </p>
+    <p>
+      Tersini yapmak, birazdan atacağınız görüntüyü kırpmak demektir; bu da hiç
+      yoktan zaman ve kalite harcar. <a href="../../video-kesme/">Video Kesici</a>
+      hemen yanı başınızda ve o adımın size neden hiçbir şeye mal olması
+      gerekmediğini <a href="../video-kesme/">kendi rehberi</a> anlatıyor.
+    </p>
+    <p>
+      Daha genel olarak: her kayıplı adım üst üste biner. Özgün bir dosyanın bir
+      kırpması bir kuşaktır. Bir indirmenin bir dışa aktarımının bir kesmesinin bir
+      kırpması dört kuşaktır ve öyle de görünür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir tarayıcıda video çözüp yeniden kodlamak yenidir ve gerçektir: WebCodecs,
+      telefonunuzun video kaydetmek için kullandığı donanım kodlayıcısının aynısını
+      açar ve aynı sebeple hızlıdır. İş, dosyaya zaten sahip olan makinede olur ki
+      gigabaytlarca büyüklükteki bir video için anlamı olan tek düzen de budur
+      &mdash; onu yükleyip sonucu indirmek, kodlamanın kendisinden fazla zaman alır.
+    </p>
+    <p>
+      Buradaki aracın hiçbir türde ağ özelliği yoktur ve sayfanın
+      <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi tek
+      tek sayar; bunların hiçbiri bu siteye ait değildir. Size söylenmesindense
+      denetlemeyi tercih ederseniz internet bağlantısını kesin ve yine de bir klip
+      kırpın.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> herhangi bir araçta çalıştırabileceğiniz üç denetim
+      daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/crop-a-video.toml
+++ b/locales/tr/pages/guides/crop-a-video.toml
@@ -1,0 +1,21 @@
+#
+# Rehber: bir videoyu kırpma - Türkçe.
+#
+# "Kırpma" burada resmin şeklini değiştirmek demek; süreyi kısaltmak olan
+# "kesme" ayrı bir rehber ve iki kelime bu locale boyunca birbirine
+# karıştırılmıyor.
+#
+
+nav = "Video kırpma"
+title = "Bir Video Başka Bir Şekle Nasıl Kırpılır"
+description = "Bir klibi kareye, 9:16 dikeye ya da tam bir piksel kutusuna indirin. Hangi platformun hangi oranı istediği, kesme gerektirmezken kırpmanın neden yeniden kodlamak zorunda olduğu ve bunun bedeli."
+heading = "Bir video başka bir şekle nasıl kırpılır"
+lede = """
+    Kırpmak resmin şeklini değiştirir; bu da yeni kareler yazmak demektir
+    &mdash; bunun etrafından dolaşmanın bir yolu yok ve aksini iddia eden her
+    araç başka bir şey yapıyordur. Bu rehber bunun bedelini ve o bedeli iyi
+    harcamayı anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir video başka bir şekle nasıl kırpılır"
+og_description = "Hangi platformun hangi en boy oranını istediği, kesme gerektirmezken kırpmanın neden yeniden kodlamak zorunda olduğu ve bunun bedeli."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/embed-an-image-in-css.html
+++ b/locales/tr/pages/guides/embed-an-image-in-css.html
@@ -1,0 +1,314 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../resmi-base64e-donusturme/">Görselden Data URI'ye</a>'yi açın,
+      resmi bırakın, <em>Bir CSS özel özelliği</em>'ni seçin ve satırı stil
+      dosyanızın başına yapıştırın. Sonra ihtiyacınız olan her yerde
+      <code>background-image: var(--logo)</code> olarak kullanın.
+    </p>
+    <p>
+      Bunu resim küçükse &mdash; bir simge, bir madde imi, bir ok, bir desen
+      &mdash; ve her sayfada gerekiyorsa yapın. Bir fotoğrafla yapmayın.
+      Aşağıdaki her şey bu iki cümlenin neden farklı olduğu ve hangisine
+      baktığınızı nasıl anlayacağınızla ilgili.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir data URI aslında nedir</h2>
+    <p>
+      Bir şeyi göstermek yerine onu içeren bir adres. Bir stil dosyasının normalde
+    </p>
+    <pre><code>background-image: url("logo.png");</code></pre>
+    <p>
+      dediği ve tarayıcının gidip <code>logo.png</code>'yi getirdiği yerde, bir
+      data URI
+    </p>
+    <pre class="wrap"><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <p>
+      der ve getirilecek bir şey yoktur: resim, karakterlerle yazılmış olarak
+      zaten oradadır. Üç parçası vardır. <code>data:</code> şemadır.
+      <code>image/png</code> ortam türüdür ve tarayıcı ona tamamen inanır &mdash;
+      buna aşağıda döneceğiz. Virgülden sonraki her şey dosyanın kendisidir.
+    </p>
+    <p>
+      Bütün fikir budur. Bir numara ya da bir kurnazlık değildir; 1998'den beri
+      standartların içindedir ve o zamandan bu yana çıkmış her tarayıcıda
+      çalışır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Size kazandırdığı şey: bir gidiş dönüş eksiği</h2>
+    <p>
+      Kazanç bant genişliği değildir. İstektir.
+    </p>
+    <p>
+      Bir tarayıcı, <code>logo.png</code>'yi ondan söz eden stil dosyasını
+      okuyana kadar isteyemez ve o stil dosyasını da getirene kadar okuyamaz.
+      Yani sıradan bir arka plan görseli, sayfa yüklemesinde en az iki gidiş
+      dönüş derinliktedir ve yavaş bir ağdaki bir telefonda bir gidiş dönüş,
+      dosya ne kadar küçük olursa olsun birkaç yüz milisaniye olabilir. 600
+      baytlık bir ok işareti aktarım olarak neredeyse hiçbir şeye mal olmaz ama
+      yine de gelmesi çeyrek saniye tutabilir.
+    </p>
+    <p>
+      Satır içine alındığında stil dosyasıyla birlikte gelir. Bütün kazanç budur
+      ve sayfanın üst kısmında görünen küçük bir simge için gerçek bir
+      kazançtır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bedeli: üçte bir, sonra da önbellek</h2>
+    <p>
+      <strong>Base64 yaklaşık üçte bir ekler.</strong> Dosyanın üç baytı dört
+      karaktere dönüşür; çünkü rastgele baytları yalnızca bir URL'nin izin
+      verdiği karakterlerle yazmanın bedeli budur. Bundan kaçan akıllı bir
+      kodlayıcı yoktur. 9 KB'lik bir PNG, 12 KB'lik stil dosyası eder.
+    </p>
+    <p>
+      <strong>Sıkıştırma bunu geri vermez.</strong> İnsanların olmamış saydığı
+      kısım budur. Gzip ve Brotli fazlalık bularak çalışır; bir PNG, bir JPEG ve
+      bir WebP ise çoktan sıkıştırılmıştır &mdash; içlerinde çok az fazlalık
+      kalmıştır ve base64 fazlalık eklemez. Pratikte üçte birin onda biri kadarını
+      geri alırsınız, tamamını değil. (Bir SVG bunun tersi bir durumdur ve bir
+      sonraki bölüm de onunla ilgili.)
+    </p>
+    <p>
+      <strong>Dosya olmaktan çıkar.</strong> Bu, muhtemelen yapacağınız hiçbir
+      ölçümde görünmeyen bedeldir ve boyut büyüdüğünde asıl önemli olan da odur:
+    </p>
+    <ul>
+      <li>
+        <strong>Kendi başına önbelleğe alınamaz.</strong> Sıradan bir görsel bir
+        kez getirilir ve bir yıl boyunca yeniden kullanılır. Satır içine alınmış
+        biri stil dosyasının parçasıdır, yani stil dosyasının önbellek kaydıyla
+        birlikte yaşar ve ölür.
+      </li>
+      <li>
+        <strong>Bir şeyi değiştirmek her şeyi yeniden indirtir.</strong> Bir kenar
+        boşluğunu düzeltin, yeni bir stil dosyası yayına alın ve her ziyaretçi,
+        iki yıldır değişmemiş olan satır içi resmi de onunla birlikte yeniden
+        indirsin.
+      </li>
+      <li>
+        <strong>Kritik yolun üstündedir.</strong> Bir stil dosyası çizimi
+        engeller. Bir görsel engellemez. Bir resmi satır içine almak onu ikinci
+        sınıftan birinciye taşır: resim dâhil her şey gelene kadar sayfa
+        boyanamaz.
+      </li>
+      <li>
+        <strong>Paralel getirilemez.</strong> Tarayıcılar aynı anda birçok şey
+        indirir. Satır içi bir resim ayrı bir şey değildir, yani bundan hiç pay
+        almaz.
+      </li>
+    </ul>
+    <p>
+      Kaba eşikler &mdash; bunlar bir tarayıcının farklı bir şey yaptığı yerler
+      değil, tavsiyenin değiştiği yerlerdir: yaklaşık 2 KB'nin altında açık bir
+      kazançtır; 10 KB'ye kadar her sayfada bulunan bir şey için genellikle hâlâ
+      değer; 50 KB'yi geçtiğinde hata iletisi olmayan bir hatadır.
+      <a href="../../resmi-base64e-donusturme/">Araç</a> her sonucun hangi aralığa
+      düştüğünü, yanında karakter sayısıyla birlikte söyler.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir SVG'yi asla base64 yapmayın</h2>
+    <p>
+      Bu, satır içi görsellerdeki en yaygın tek hatadır ve dışa aktarıcılar ile
+      derleme eklentileri bunu insanlar kadar sık yapar.
+    </p>
+    <p>
+      Bir SVG metindir. Bir URL zaten metin taşır. Yalnızca bir avuç karakterin
+      kaçırılması gerekir &mdash; <code>%</code>, <code>#</code>,
+      <code>&lt;</code>, <code>&gt;</code> ve onu sardığınız tırnak &mdash; ve
+      geri kalan her şey tam olduğu gibi bırakılabilir. Böyle kodlamak size, aynı
+      dosyanın base64'ünden tipik olarak beşte bir kısa ve sonrasında gürültü gibi
+      değil metin gibi sıkışan bir URI verir.
+    </p>
+    <p>
+      Ayrıca hâlâ okunabilir:
+    </p>
+    <pre class="wrap"><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <p>
+      <code>viewBox</code>'ı görebilirsiniz. Dolgu rengini hiçbir şeyi çözmeden
+      düzenleyicinizde değiştirebilirsiniz. Aynı dosyayı base64 yapın; kimsenin
+      bir daha asla dokunmayacağı bir harf duvarına dönüşsün.
+      <a href="../../resmi-base64e-donusturme/">Görselden Data URI'ye</a>, SVG
+      olduğu anlaşılan her şey için bunu kendiliğinden yapar ve
+      <code>;base64</code> konusunda ısrar eden nadir araç zincirleri için bir
+      onay kutusu bulundurur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Yalnızca SVG'leri bozan tırnak hatası</h2>
+    <p>
+      CSS, <code>url()</code>'yi tırnaksız yazmanıza izin verir ve sıradan bir
+      dosya adı için bu sorunsuzdur:
+    </p>
+    <pre><code>background-image: url(logo.png);</code></pre>
+    <p>
+      Aynısını yüzde kodlamalı bir SVG'yle yapın, bozulsun. Tırnaksız bir
+      <code>url()</code> belirteci ilk boşlukta, parantezde, tırnakta ya da
+      denetim karakterinde biter &mdash; bir SVG ise her öznitelik ve bir
+      yoldaki her sayı arasında boşluk doludur. Bildirim böylece geçersiz olur,
+      CSS geçersiz bildirimleri sessizce atar ve elinizde ne arka plan ne de bir
+      hata kalır.
+    </p>
+    <p>
+      Çözüm, her seferinde tırnaktır:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
+    <p>
+      Bir kodlayıcının boşlukları kaçırmasına gerek olmamasının sebebi de budur
+      &mdash; tırnak içindeki bir URL'nin içinde gayet yasaldırlar ve her birini
+      <code>%20</code> olarak kaçırmak, dosyadaki her boşluk için üç karaktere mal
+      olurdu. İki karar birlikte gider: URI'yi tırnaklayın, boşluklara
+      dokunmanız gerekmesin. Aracın ürettiği her şeklin tırnaklanmasının sebebi
+      tam olarak budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ortam türü doğru olmak zorunda</h2>
+    <p>
+      Bir data URI kendi türünü bildirir ve tarayıcı sözüne inanır. Getirilen bir
+      dosyada olduğu gibi bir koklama yedeği yoktur: aslında JPEG olan bir şey
+      için <code>image/png</code> deyin, resim görüntülenmesin ve hiçbir işe yarar
+      yerde bir ileti çıkmasın.
+    </p>
+    <p>
+      Bunun önemi, dosya uzantılarının yalan söylemesindendir. JPEG olarak dışa
+      aktarılıp <code>logo.png</code> diye yeniden adlandırılmış bir fotoğraf, bir
+      diskte bulunması gayet sıradan bir şeydir. Bir görsel dosyasının ilk birkaç
+      baytı ise ne olduğunu tereddütsüz söyler &mdash; her biçimin bir imzası
+      vardır &mdash; yani bir araç adına değil dosyanın kendisine bakmalıdır.
+      Buradaki araç bakar ve ikisi çeliştiğinde size söyler.
+    </p>
+    <p>
+      Kafa karıştırıcı biçimde çuvalladıkları için bilmeye değer iki biçim var.
+      Bir iPhone'un fotoğraf çektiği biçim olan <strong>HEIC</strong> ve
+      tarayıcıların ürettiği <strong>TIFF</strong>; ikisi de Safari dışında
+      hiçbir tarayıcının çizmeyeceği ama gayet geçerli data URI'ler üretir. URI
+      bozuk değildir; biçim, düpedüz webin desteklediği bir biçim değildir. Önce
+      dönüştürün.
+    </p>
+  </section>
+
+  <section>
+    <h2>Yayımlamak istemediğiniz üstveri</h2>
+    <p>
+      Bir data URI, dosyanın baytı baytına bir kopyasıdır. Hiçbir şey çözülüp
+      yeniden kodlanmaz ki genellikle amaç da budur &mdash; kalite kaybı olmaz
+      &mdash; ama bu aynı zamanda dosyadaki diğer her şeyin de birlikte geldiği
+      anlamına gelir.
+    </p>
+    <p>
+      Telefondan doğrudan çıkan bir fotoğraf EXIF taşır: çekildiği yerin GPS
+      koordinatları, zaman damgası, kamera modeli ve çoğu zaman seri numarası. Bu,
+      dosyanın 30 KB'si olabilir. Satır içine alındığında, stil dosyanızda 40 KB
+      base64'e, her sayfanın kritik yoluna ve bir depoya işlenmiş, kimsenin
+      bakmayı akıl etmeyeceği bir biçimdeki bir ev adresine dönüşür.
+    </p>
+    <p>
+      Önce resme dokunmadan kabı yeniden yazan
+      <a href="../../exif-verisi-silme/">EXIF Görüntüleyici ve Silici</a> ile
+      temizleyin; onun da <a href="../exif-ve-gps-verisini-silme/">bir rehberi
+      var</a>. Görselden Data URI'ye, bir JPEG, PNG ya da WebP içinde ne kadar
+      üstveri olduğunu okur ve siz bir şey kopyalamadan önce söyler.
+    </p>
+  </section>
+
+  <section>
+    <h2>Elde ettikten sonra onu nereye koymalı</h2>
+    <p>
+      Resim tek bir kuralda görünüyorsa URI'yi o kurala koyun. Birden fazlasında
+      görünüyorsa &mdash; ki üzerine gelme durumunu ve koyu temayı da sayınca
+      simgeler genellikle öyledir &mdash; onu bir kez özel özellik olarak
+      tanımlayın:
+    </p>
+    <pre><code>:root {
+  --icon-search: url("data:image/svg+xml,%3Csvg ... %3E");
+}
+
+.search-field { background-image: var(--icon-search); }
+.search-button::before { content: var(--icon-search); }</code></pre>
+    <p>
+      Dört kurala yapıştırılmış 3 KB'lik bir URI, 12 KB stil dosyası ve simge
+      değiştiğinde düzenlenecek dört yer demektir. Özel özellik, her birinden bir
+      tane demektir. Ayrıca tema değiştirmeyi çalıştıran şekil de budur: bir ortam
+      sorgusunun içinde <code>--icon-search</code>'ü yeniden tanımlayın, onun her
+      kullanımı buna uysun.
+    </p>
+    <p>
+      CSS yerine bir <code>&lt;img&gt;</code> etiketi için <code>width</code> ve
+      <code>height</code> ekleyin. Satır içine alınmış bir görsel anında yüklenir,
+      yani eksik bir boyut, görülemeyecek kadar hızlı gerçekleşen ama yine de
+      aleyhinize sayılan bir düzen kaymasıdır. İstisna SVG'dir: yalnızca bir
+      <code>viewBox</code> taşıyan bir SVG'nin kendine ait bir piksel boyutu
+      yoktur ve tarayıcının 300&times;150 varsayılanını etikete yazmak,
+      ölçeklenebilir bir resmi kimsenin seçmediği bir boyuta çakar.
+    </p>
+    <p>
+      İçine koyacak doğru bir şeyiniz yoksa <code>alt</code>'u boş bırakın. Resmin
+      bir anlam taşıyıp taşımadığını ya da süs olup olmadığını yalnızca siz
+      bilirsiniz ve bir dosya adından tahmin edilmiş bir açıklama, ekran okuyucu
+      kullanan biri için hiç açıklama olmamasından daha kötüdür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cevabın &ldquo;yapmayın&rdquo; olduğu durum</h2>
+    <p>
+      Resim kodlandığında yaklaşık 50 KB'yi geçiyorsa satır içine almak yanlış
+      araçtır ve kodlamada ne kadar özenli olursanız olun bunu düzeltmez. Denemeye
+      değer sırayla alternatifler:
+    </p>
+    <ul>
+      <li>
+        <strong>Küçültün.</strong> Satır içine alınamayacak kadar büyük olan
+        görsellerin çoğu genel olarak da fazla büyüktür.
+        <a href="../../resim-sikistirma/">Görsel Sıkıştırıcı</a> bir fotoğrafı
+        söylediğiniz boyuta indirir ve
+        <a href="../../resim-boyutlandirma/">Görsel Boyutlandırıcı</a> piksel
+        boyutlarını düzenin gerçekten kullandığına düşürür &mdash; ki asıl sorun
+        çoğu zaman budur.
+      </li>
+      <li>
+        <strong>SVG olarak yeniden çizin.</strong> 40 KB'lik bir PNG olarak dışa
+        aktarılmış bir simge sık sık 900 baytlık bir SVG'dir. Bu bir sıkıştırma
+        farkı değil bir biçim farkıdır ve retina sorununu da çözer.
+      </li>
+      <li>
+        <strong>Dosya olarak bırakın ve ön yükleyin.</strong>
+        <code>&lt;link rel="preload" as="image"&gt;</code>, baytları kritik yola
+        taşımadan getirmeyi hemen başlatır. Satır içine almanın kazancının
+        çoğunu, önbellek bedelinin hiçbirini almadan verir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir dosyayı base64 olarak kodlamak bir aritmetiktir. Tarayıcının en
+      başından beri sahip olduğu iki işlevdir &mdash; <code>btoa</code> ve
+      <code>encodeURIComponent</code> &mdash; ve bir resmin başka türlü yazılmak
+      için bir sunucuya gidip gelmesinin en ufak bir teknik sebebi yoktur. Bunu
+      yapmak için dosyanızı yükleyen her dönüştürücü, onu sizin sebeplerinizle
+      değil kendi sebepleriyle yüklüyordur.
+    </p>
+    <p>
+      <a href="../../resmi-base64e-donusturme/">Buradaki araç</a> onu hiçbir yere
+      göndermez: sayfanın <code>Content-Security-Policy</code>'si iletişim
+      kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu siteye ait
+      değildir. Size söylenmesindense denetlemeyi tercih ederseniz sayfayı
+      yükleyin, internet bağlantısını kesin ve yine de bir şey kodlayın.
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> herhangi bir araçta çalıştırabileceğiniz üç denetim
+      daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/embed-an-image-in-css.toml
+++ b/locales/tr/pages/guides/embed-an-image-in-css.toml
@@ -1,0 +1,18 @@
+#
+# Rehber: bir resmi stil dosyasının içine koymak - Türkçe.
+#
+
+nav = "CSS'e resim gömme"
+title = "CSS'te Data URI: Bir Görsel Ne Zaman Gömülür, Ne Zaman Gömülmez"
+description = "Bir data URI'nin bedeli, base64'ün neden üçte bir eklediği ve gzip'in bunu neden geri vermediği, bir SVG'nin neden asla base64 olmaması gerektiği ve satır içi SVG'leri sessizce bozan tırnak hatası."
+heading = "Bir resim CSS'inizin içine ne zaman konur, ne zaman konmaz"
+lede = """
+    Bir stil dosyasına yazılmış bir görsel onunla birlikte gelir: ikinci bir
+    istek yok, bekleme yok. Ayrıca dosya olmaktan çıkar &mdash; yani kendi başına
+    önbelleğe alınamaz ve çevresindeki her şey değiştiğinde yeniden indirilir. Bu
+    rehber bu takasın nerede yapmaya değdiğini ve nerede sessizce değmediğini
+    anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir resim CSS'inizin içine ne zaman konur"
+og_description = "Bir data URI'nin bedeli, bir SVG'nin neden asla base64 olmaması gerektiği ve satır içi SVG'leri sessizce bozan tırnak hatası."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/format-json-without-uploading-it.html
+++ b/locales/tr/pages/guides/format-json-without-uploading-it.html
@@ -1,0 +1,297 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../json-bicimlendirme/">Metin ve Kod</a>'u açın, JSON'u kutuya
+      yapıştırın ve okuyun. Düzen siz yazdıkça oluşur, dil metinden bulunur ve
+      aksini söylemedikçe girinti iki boşluktur. Hiçbir şey yüklenmez, çünkü
+      gidecek bir yer yoktur: ayrıştırıcı, zaten açık olan sekmede çalışan birkaç
+      yüz satırlık JavaScript'tir.
+    </p>
+    <p>
+      Aşağıdaki her şey, bir yapılandırma dosyasını alternatiflerden herhangi
+      birine yapıştırmadan önce bilmeye değen kısımdır: bir biçimlendiricinin neyi
+      değiştirmesine izin var, çoğu yine de neyi değiştiriyor ve dosya hiç
+      ayrıştırılmadığında hata nasıl okunur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Biçimlendirmek nedir, ne değildir</h2>
+    <p>
+      JSON'un neredeyse hiç söz dizimi yoktur. Bir nesne, bir dizi, bir dizge, bir
+      sayı ve üç kelime: <code>true</code>, <code>false</code> ve
+      <code>null</code>. Bu parçaların arasında boşluğun bir anlamı yoktur: şu
+      dosya
+    </p>
+    <pre><code>{"name":"thing","tags":["local","offline"]}</code></pre>
+    <p>
+      ile şu dosya
+    </p>
+    <pre><code>{
+  "name": "thing",
+  "tags": [
+    "local",
+    "offline"
+  ]
+}</code></pre>
+    <p>
+      aynı belgedir. Biçimlendirmek, birinciden ikinciye geçme işidir ve
+      <em>işin tamamı budur</em>. Bir biçimlendiricinin dosyanıza yaptığı başka
+      her şey &mdash; yeniden sıralama, yuvarlama, düşürme &mdash; belgenin
+      söylediğinde, istenmeden yapılmış bir değişikliktir.
+    </p>
+    <p>
+      Bu değişikliklerin üçü, adını anmaya değecek kadar yaygındır; çünkü sessizce
+      olurlar ve bir öğleden sonrada yazılmış bir biçimlendiricinin varsayılan
+      olarak yaptığı şeydirler.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir biçimlendiricinin değiştirmemesi gereken üç şey</h2>
+
+    <h3>Anahtarlarınızın sırası</h3>
+    <p>
+      İnsanları yakalayan budur. JavaScript'te bir JSON biçimlendiricisi yazmanın
+      apaçık yolu <code>JSON.parse</code> ve ardından girintili bir
+      <code>JSON.stringify</code> çağırmaktır; bu ikili ise tamsayıya benzeyen
+      anahtarların sırasını korumaz:
+    </p>
+    <pre><code>Object.keys(JSON.parse('{"10":"a","2":"b","x":"c"}'))
+// ['2', '10', 'x']</code></pre>
+    <p>
+      Bu, kimsenin kodundaki bir hata değildir. JavaScript nesnelerinin, tamsayıya
+      benzeyen anahtarları önce ve artan sayısal sırada koyacağı belirtilmiştir ve
+      <code>JSON.parse</code>'tan geçen her değer bir JavaScript nesnesine dönüşür.
+      Böyle kurulmuş bir biçimlendirici, kimliğe, kapı numarasına, yıla ya da HTTP
+      durum koduna göre anahtarlanmış bir dosyayı yeniden dizer ve bunu tek kelime
+      etmeden yapar.
+    </p>
+    <p>
+      Bunun önemli olup olmadığı dosyaya bağlıdır. JSON nesneleri ilkesel olarak
+      sırasızdır, yani teknik olarak bozulan bir şey yoktur &mdash; ama deponuzdaki
+      sürüme karşı fark devasa olacak, inceleme okunmaz olacak ve akışın devamında
+      bir şey dosyayı sırasıyla okuyorsa davranış değişecektir.
+    </p>
+
+    <h3>Sayılarınızın haneleri</h3>
+    <p>
+      JSON bir sayının ne kadar büyük olabileceğini söylemez, JavaScript söyler:
+      her sayı bir çift duyarlıklı sayıdır. Yani çift duyarlıklıya ayrıştırıp geri
+      yazan bir biçimlendirici, çift duyarlıklının tutamadığı her şeyi kaybeder.
+    </p>
+    <pre><code>JSON.stringify(JSON.parse('{"id":123456789012345678901}'))
+// {"id":123456789012345680000}
+
+JSON.stringify(JSON.parse('{"size":1e999}'))
+// {"size":null}</code></pre>
+    <p>
+      Yirmi bir haneli bir kimlik &mdash; bir Twitter kimliği, bir Snowflake
+      kimliği, bir banka referansı &mdash; başka bir sayı olarak geri gelir ve bir
+      çift duyarlıklı için fazla büyük bir değer <code>null</code> olarak geri
+      gelir. İki dosya da hâlâ ayrıştırılır ve hiçbiri başladığınız dosya
+      değildir.
+    </p>
+    <p>
+      Çıkış yolu, sayıları hiç ayrıştırmamaktır. Bir biçimlendiricinin belgeyi
+      düzenli yazmak için yalnızca bir sayının nerede başlayıp nerede bittiğini
+      bilmesi gerekir; değerine hiçbir zaman ihtiyacı olmaz, yani güvenli olan şey
+      haneleri yazıldıkları gibi kopyalamaktır. Buradaki aracın yaptığı da budur.
+    </p>
+
+    <h3>Yinelenen anahtarlarınız</h3>
+    <p>
+      <code>{"a": 1, "a": 2}</code> geçerli JSON'dur ve standart, ikisinden
+      hangisinin kazandığını söylemekten kaçınır. Ayrıştırıcılar pratikte anlaşamaz:
+      çoğu sonuncuyu tutar, bazıları ilkini tutar, birkaçı belgeyi reddeder.
+      Birini sessizce çıktıya veren bir biçimlendirici bu kararı sizin yerinize
+      vermiş ve çok daha yararlı olan gerçeği &mdash; iki tane olduğunu &mdash;
+      gizlemiştir; ki bu neredeyse her zaman dosyadaki bir hatadır ve görmek
+      isteyeceğiniz bir hatadır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dosya ayrıştırılmadığında</h2>
+    <p>
+      Çuvallayan JSON'un çoğu egzotik değildir. Yaklaşık altı şeyden biridir ve
+      hata, nerede olduğunu bulabileceğiniz terimlerle söylüyorsa hangisi olduğunu
+      da söyler. <code>4193. konum</code> gibi bir ofset bunu yapmaz; bir satır ve
+      bir sütun yapar.
+    </p>
+    <ul>
+      <li>
+        <strong>Sondaki virgül.</strong> <code>{"a": 1,}</code> JavaScript'te
+        yasaldır, JSON'da değildir. En yaygın tek sebep; genellikle bir listenin
+        son girdisini silmekten geriye kalır.
+      </li>
+      <li>
+        <strong>Tek tırnak.</strong> <code>{'a': 1}</code> bir JavaScript nesne
+        sabitidir, JSON değildir. Dizgeler de anahtarlar da çift tırnaklıdır ve
+        anahtarlar her zaman tırnaklıdır.
+      </li>
+      <li>
+        <strong>Tırnaksız anahtar.</strong> <code>{a: 1}</code>, aynı hatanın öbür
+        yönden hâli &mdash; genellikle bir dosyadan değil koddan bir şey
+        yapıştırmaktan gelir.
+      </li>
+      <li>
+        <strong>Yorumlar.</strong> <code>// böyle bir şey</code> de JSON değildir.
+        O, VS Code ayarlarının ve <code>tsconfig.json</code>'ın kullandığı
+        JSONC'dir ve başka hiçbir yerde ayrıştırılmaz. Bir yorumun hayatta kalması
+        gerekiyorsa alışılmış yol bir anahtardır:
+        <code>"_comment": "..."</code>.
+      </li>
+      <li>
+        <strong>Bir dizgenin içinde gerçek bir satır sonu ya da sekme.</strong>
+        Bunların <code>\n</code> ve <code>\t</code> olarak yazılması gerekir. Bir
+        kabuk komutu ya da bir sertifika elle bir değere yapıştırıldığında
+        genellikle ters giden şey budur.
+      </li>
+      <li>
+        <strong>JSON'un izin vermediği bir sayı.</strong> Baştaki sıfırlar
+        (<code>01</code>), yalın bir ondalık nokta (<code>.5</code>),
+        <code>NaN</code>, <code>Infinity</code> ve <code>+1</code>; hepsi
+        insanların yazdığı şeylerdir ve hiçbiri JSON değildir.
+      </li>
+    </ul>
+    <p>
+      Hata olmadığı hâlde hataya benzeyen bir şey: bayt sırası imiyle başlayan bir
+      dosya. Çoğu düzenleyicide görünmezdir, boşluk değildir ve belgenin ilk
+      karakterini beklenmedik kılar. Kusursuz görünen bir dosyada hata 1. satır 1.
+      sütundaysa, olan budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Küçültmek ve genellikle ne kadar az kazandırdığı</h2>
+    <p>
+      Boşlukları sıkıp çıkarmak aynı işlemin tersidir ve neye yaradığı konusunda
+      gerçekçi olmaya değer. Boşluk son derece tekrarlıdır ve sizinle bir okuyucu
+      arasındaki her sunucu ve tarayıcı yanıtı zaten gzip ya da Brotli ile
+      sıkıştırır; onlar da tam olarak bu tür bir tekrarda çok iyidir.
+    </p>
+    <p>
+      Yani küçültülmüş JSON çoğu zaman dosya olarak yüzde otuz küçüktür ve tel
+      üzerinde yalnızca yüzde birkaç küçüktür. Ekmeğini gerçekten kazandığı yerler,
+      önünde sıkıştırma olmayanlardır: bir veritabanı sütunundaki bir değer, bir
+      günlük satırındaki bir alan, bir QR kodunun içindeki bir yük ya da birazdan
+      bir başlığa Base64'leyeceğiniz bir belge.
+    </p>
+    <p>
+      Bedeli okunurluktur ve dosya bir depoya işleniyorsa size farkları da
+      kaybettirir &mdash; tek satırlık bir dosya, içindeki herhangi bir şey
+      değiştiğinde baştan sona değişir. Düzenleyicinize girerken değil, çıkarken
+      küçültün.
+    </p>
+  </section>
+
+  <section>
+    <h2>Anahtarları sıralamak ve ne zaman sıralamamak</h2>
+    <p>
+      Her nesnenin anahtarlarını sıralamak burada varsayılan olarak uygulanmak
+      yerine bir seçenek olarak sunuluyor; çünkü bu, dosyada gerçek bir
+      değişikliktir ve değeri tamamen birazdan ne yapacağınıza bağlıdır.
+    </p>
+    <p>
+      Aynı şeyi söylemesi gereken iki belgeyi karşılaştırırken işe yarar &mdash;
+      iki ortamın yapılandırması, bir değişiklikten önceki ve sonraki bir API
+      yanıtı &mdash; ve biri anahtarlarını başka sırayla listeliyordur. Önce
+      ikisini de sıralamak, her şeyin farkını gerçekten farklı olan iki satırın
+      farkına çevirir.
+    </p>
+    <p>
+      Sıra bir işe yarıyorsa zarar verir. Bir <code>package.json</code>'ın neyin
+      önce geleceğine dair gelenekleri vardır; elle yazılmış bir yapılandırma çoğu
+      zaman ilgili ayarları gruplar; anahtarları bir araçla sıralanıp sonra
+      işlenmiş bir dosya ise devasa ve anlamsız tek bir işleme üretir. Özgün
+      dosyayı değil bir kopyayı sıralayın.
+    </p>
+    <p>
+      Bilmeye değer bir ayrıntı: buradaki sıralama kod noktalarına göre değil
+      anahtarların okunuşuna göredir; yani <code>item2</code>,
+      <code>item10</code>'dan sonra değil önce gelir. Kod noktasına göre sıralamak,
+      <code>item10</code>'u birlerin ortasına koyan şeydir; teknik olarak doğru ve
+      bir okuyucu için yararsızdır.
+    </p>
+  </section>
+
+  <section>
+    <h2>İki JSON dosyasını karşılaştırmak</h2>
+    <p>
+      Güvenilir yol, önce ikisini de aynı şekilde biçimlendirmektir. Aynı şeyi
+      söyleyen iki belge, biri küçültülmüş diğeri küçültülmemişse her satırda
+      farklı olabilir ve hiçbir karşılaştırma bunun ötesini göremez.
+    </p>
+    <p>
+      Yani: birincisini biçimlendirin, ikincisini biçimlendirin, sonra iki sonucu
+      karşılaştırın. Üç adım da burada aynı sayfadadır &mdash;
+      <em>Karşılaştır</em> sekmesinin kutuyu <em>Biçimlendir</em>'le paylaşmasının
+      sebebi tam olarak budur. İkisi anahtarlarını farklı sıralarda da
+      listeliyorsa, biçimlendirirken ikisini de sıralayın ve karşılaştırma
+      aradığınız farka çöksün.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kimsenin sayfaya koymadığı kısım</h2>
+    <p>
+      Bir JSON biçimlendirici arayın, üzerinde bir kutu olan onlarca site
+      bulacaksınız. O kutuya yapıştırmak bir yüklemedir. Panonuzda ne varsa
+      &mdash; içinde bir müşterinin adresi olan bir API yanıtı, bir bağlantı
+      dizgesi içeren bir yapılandırma dosyası, hata ayıkladığınız bir belirteç
+      &mdash; denetlemediğiniz bir makineye gönderilmiştir ve artık onların günlük
+      dosyası, onların hata raporu ve onların yedeğidir.
+    </p>
+    <p>
+      Bu, kötü niyet üzerine bir varsayım değildir. Gayet iyi niyetli bir site de
+      erişim günlükleri tutar, ölçüm çalıştırır ve bir barındırma sağlayıcısı
+      vardır. En güvenli veri hiç ayrılmamış veridir ve tamamen dizge işlemeden
+      ibaret bir iş için ayrılmasının hiçbir sebebi yoktur.
+    </p>
+    <p>
+      İki denetim; yalnızca burada değil, bu iddiada bulunan her sitede çalışır:
+    </p>
+    <ol>
+      <li>
+        <strong>Geliştirici araçlarını açın, Ağ sekmesini izleyin ve bir şey
+        biçimlendirin.</strong> Metniniz gönderiliyorsa onu taşıyan bir istek
+        vardır. Aynı anda başka hiçbir şey doğru olamaz.
+      </li>
+      <li>
+        <strong>İnternet bağlantısını kesin ve yeniden deneyin.</strong> İşi sizin
+        tarayıcınızda yapan bir araç bundan etkilenmez. Metninizi bir yere gönderen
+        bir araç anında ve tamamen çalışmayı bırakır.
+      </li>
+    </ol>
+    <p>
+      İkisinin de daha uzun bir sürümü, iki denetim daha eklenmiş hâliyle,
+      <a href="../dosya-yuklemek-guvenli-mi/">dosya yüklemek güvenli mi</a>
+      sayfasında.
+    </p>
+  </section>
+
+  <section>
+    <h2>Peki ya YAML, XML ve gerisi</h2>
+    <p>
+      Aynı sayfa XML, HTML, CSS ve YAML okur ve JSON ile bunların ilki ve
+      sonuncusu arasında dönüştürme yapar. Yukarıdan taşımaya değer iki şey var;
+      çünkü aynı savın başka bir kılıktaki hâli:
+    </p>
+    <ul>
+      <li>
+        <strong>YAML'ı JSON'a çevirmek yorumları kaybettirir</strong>; çünkü
+        JSON'un bir yorumu koyacak yeri yoktur. YAML'ın &ldquo;aynı düğüm iki
+        kez&rdquo; deme yolu olan bağlantı noktaları ve takma adlar da ifade
+        edilemez ve burada tahmin edilmek yerine reddedilir.
+      </li>
+      <li>
+        <strong><code>no</code> bir dizgedir.</strong> YAML 1.1'de
+        <code>yes</code>, <code>no</code>, <code>on</code> ve <code>off</code>
+        mantıksal değerlerdi; Norveç'i içeren bir ülke kodu listesinin eskiden
+        içinde <code>false</code> ile geri gelmesinin sebebi buydu. YAML 1.2 bundan
+        vazgeçti, bu araç da öyle &mdash; ama o kelimeler yine de tırnak içinde geri
+        yazılır; çünkü dosyayı sonra açan şey bir 1.1 okuyucusu olabilir.
+      </li>
+    </ul>
+  </section>

--- a/locales/tr/pages/guides/format-json-without-uploading-it.toml
+++ b/locales/tr/pages/guides/format-json-without-uploading-it.toml
@@ -1,0 +1,19 @@
+#
+# Rehber: JSON biçimlendirme ve bir biçimlendiricinin neyi değiştirmemesi
+# gerektiği - Türkçe.
+#
+
+nav = "JSON biçimlendirme"
+title = "JSON Yüklemeden Nasıl Biçimlendirilir"
+description = "JSON'u kendi tarayıcınızda nasıl düzenli yazar, denetler ve küçültürsünüz: bir biçimlendiricinin dosyanızda asla değiştirmemesi gereken şeyler, hata iletisinin nasıl okunacağı ve yapıştırdığınız sitenin neden önemli olduğu."
+heading = "JSON kimseye vermeden nasıl biçimlendirilir"
+lede = """
+    JSON biçimlendirmek boşlukları değiştirmeli, başka hiçbir şeyi değil. Bunu
+    yapmayı öneren araçların çoğu bundan fazlasını değiştiriyor ve hiçbiri bundan
+    söz etmiyor. Bu rehber nelere dikkat edeceğinizi, dosya ayrıştırılmadığında
+    hatanın nasıl okunacağını ve bir yapılandırma dosyasını yapıştırdığınız
+    kutunun neden üzerinde düşünmeye değdiğini anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "JSON'u kimseye vermeden biçimlendirmek"
+og_description = "Bir JSON biçimlendiricisinin dosyanızda asla değiştirmemesi gerekenler, ayrıştırma hatasının nasıl okunacağı ve yapıştırdığınız sitenin neden önemli olduğu."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/grab-a-frame-from-a-video.html
+++ b/locales/tr/pages/guides/grab-a-frame-from-a-video.html
@@ -1,0 +1,211 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../videodan-kare-yakalama/">Video Kare Yakalayıcı</a>'yı açın,
+      klibi bırakın, anı bulun ve <em>Bu kareyi yakala</em>'ya basın. İndirmeler
+      klasörünüze düşen şey, karenin videonun kendi çözünürlüğündeki hâlidir
+      &mdash; sayfadaki ön izleme ne boyutta olursa olsun, 4K bir klipten
+      3840&nbsp;&times;&nbsp;2160.
+    </p>
+    <p>
+      Dosya boyutu bir sorun değilse biçimi PNG'de bırakın. Bu sayfanın geri
+      kalanı, bu iki cümlenin neden bir ekran görüntüsüyle aynı şey olmadığı ve
+      farkın ne zaman önemsemeye değdiğiyle ilgili.
+    </p>
+  </section>
+
+  <section>
+    <h2>Duraklatılmış bir oynatıcının ekran görüntüsü neden başka bir resim</h2>
+    <p>
+      Bunu yapmanın bir yolu herkeste zaten var: duraklat, ekran görüntüsü tuşuna
+      bas, denetimleri kırp. İşe yarar ve hızlı bir paylaşım için doğru miktarda
+      çabadır. Ama o noktada resmin başına dört şey gelmiştir ve hiçbiri geri
+      alınamaz:
+    </p>
+    <ul>
+      <li>
+        <strong>Videonun değil pencerenin boyutundadır.</strong> Yarım ekran bir
+        oynatıcıdaki 4K bir klip size yarım ekran bir oynatıcının resmini verir.
+        Dosyada olup ekranda olmayan her piksel gitmiştir.
+      </li>
+      <li>
+        <strong>Ölçeklenmiştir.</strong> Oynatıcı kareyi o pencereye sığdırmak
+        için ne yaptıysa &mdash; yumuşatma, keskinleştirme ya da düpedüz yeniden
+        örnekleme &mdash; içine pişmiştir.
+      </li>
+      <li>
+        <strong>Ekran hattından geçmiştir.</strong> Renk yönetimi ve HDR bir
+        klipte, dosya için değil sizin ekranınız için seçilmiş bir ton eşleme
+        geçişi.
+      </li>
+      <li>
+        <strong>Genellikle mobilya da içerir.</strong> Denetimler, bir ilerleme
+        çubuğu, bir altyazı izi, imleç.
+      </li>
+    </ul>
+    <p>
+      Bir kare yakalayıcı dördünü de atlar: dosyanın gerçekten tuttuğu kareyi
+      çözer ve o pikselleri yazar. Resim, videonun olduğu boyuttadır ve üzerine
+      hiçbir şey çizilmemiştir.
+    </p>
+  </section>
+
+  <section>
+    <h2>İstediğiniz kareye konmak</h2>
+    <p>
+      Bu, çoğu aracın sessizce yanlış yaptığı kısımdır ve hangisinde olursa olsun
+      neye bakacağınızı bilmeye değer.
+    </p>
+    <p>
+      Video, izlediğiniz sırada dizilmiş bir resim şeridi değildir. Karelerin
+      çoğu, başka karelerden nasıl farklı olduklarının bir tarifi olarak saklanır
+      ve B kareleri olan herhangi bir dosyada saklanma sıraları gösterilme
+      sıraları değildir. Bir oynatıcıyı bir zaman damgasına götürüp ne çıkarsa
+      yakalayan bir araç, o oynatıcının nasıl yuvarladığına mahkûmdur ve
+      "bir kare ileri" adımını saniyenin otuzda birini ekleyerek atan bir araç,
+      tam olarak 30 fps olmayan her klipte yanılır &mdash; ki buna hemen her
+      telefon videosu dâhildir, çünkü ışık değiştikçe kare hızlarını
+      değiştirirler.
+    </p>
+    <p>
+      Çözüm, dosyanın kendi kare listesini okumak ve karelere o listedeki
+      yerlerinden seslenmektir. Bir MP4'te buradaki araç bunu yapar: kaydırak adım
+      başına bir kare oynar, ok tuşları bir kare oynar ve size 3.540 karenin
+      812'sinde olduğunuzu söyleyebilir; çünkü onları saymıştır. Doğrudan
+      okuyamadığı biçimlerde bunu söyler ve öyleymiş gibi yapmak yerine kabaca bir
+      kare kadar adım atar.
+    </p>
+    <p>
+      Herhangi bir kare yakalayıcıyı denemenin hızlı bir yolu: hareketi hızlı bir
+      şeyin birkaç karesinde ileri adımlayın. Resim bazen değişmiyorsa ya da ikişer
+      atlıyorsa araç zaman damgalarını tahmin ediyordur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hangi biçimde kaydetmeli</h2>
+    <p>
+      Gerçekte yalnızca üç cevap var ve seçim, resmin başına sonra ne geleceğiyle
+      ilgili.
+    </p>
+    <ul>
+      <li>
+        <strong>PNG</strong> &mdash; varsayılan ve kareyi tam olarak saklayan tek
+        biçim. Kare düzenlenecek, basılacak, başka bir kareyle karşılaştırılacak
+        ya da saklanacaksa bunu seçin. Ayrıca en büyüğüdür: 1080p'den birkaç
+        megabayt, 4K'dan yaklaşık sekiz megabayt bekleyin; çünkü PNG'nin
+        sıkıştırması fotoğrafa benzeyen görüntülerde iyi değildir.
+      </li>
+      <li>
+        <strong>JPEG</strong> &mdash; onda biri boyutunda ve evrensel olarak kabul
+        gören biçim. Bir küçük resim, bir ön izleme ya da doğrudan bir belgeye
+        veya bir sohbete gidecek her şey için bunu seçin. Videonun kendi
+        sıkıştırmasının üstüne ikinci bir kayıplı sıkıştırma turudur; yani daha
+        fazla düzenleme için yanlış başlangıç noktasıdır.
+      </li>
+      <li>
+        <strong>WebP</strong> &mdash; aynı görsel kalitede daha da küçüktür ve
+        artık önemli olan her yerde desteklenir. Tek çekince eski yazılımlardır:
+        bazı masaüstü uygulamaları hâlâ bir tanesini açmaz.
+      </li>
+    </ul>
+    <p>
+      Açık olmaya değen bir şey: bir videodan çıkan kare zaten sıkıştırılmış bir
+      resimdir. Onu PNG olarak kaydetmek bunu geri almaz ve klip yapılırken
+      kodlayıcının attığı ayrıntıyı geri getiremez. PNG'nin size kazandırdığı şey,
+      hiçbir şeyin <em>iki kez</em> atılmamasıdır. Kareyi sonradan renk
+      düzeltmesinden geçirecek ya da kırpacaksanız bu önemlidir; birine
+      gönderecekseniz değildir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir seferde çok sayıda kare yakalamak</h2>
+    <p>
+      Birkaç saniyede bir kare almak, tek bir anda kare almaktan başka bir iştir ve
+      kulağa geldiğinden daha sık karşınıza çıkar: uzun bir kaydın bir kontak
+      sayfası, aralarından bir kapak görseli seçmek için küçük resimler ya da bir
+      çekim boyunca odağı veya pozlamayı denetlemek için eşit aralıklı bir
+      görüntü örneği.
+    </p>
+    <p>
+      Bir aralık belirleyin, dizi düğmesine basın; araç klibi bir kez baştan sona
+      geçsin ve her işarette bir kare alsın. İki pratik not. Uzun bir klipte
+      aralığı bol tutun &mdash; bir saatlik görüntüden saniyede bir kare 3.600
+      resim demektir; aracın bir çalışmayı 500'de sınırlamasının sebebi de budur.
+      Ve aksini gerektiren bir sebebiniz yoksa bunun için JPEG seçin: yüz tane 4K
+      PNG, siz daha hiçbirini indirmeden sayfada tutulan bir gigabaytın büyük
+      kısmıdır.
+    </p>
+    <p>
+      Zaman koduyla adlandırılmış, tek bir ZIP olarak geri gelirler; böylece
+      gerçekleştikleri sıraya dizilirler ve her biri videoda yeniden bulunabilir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dikey videolar ve o klasik yan yatmış kare</h2>
+    <p>
+      Bir telefon videosundan hiç kare çekip yan yatmış hâlde aldıysanız, sebebi
+      budur. Bir telefon yatay çeker ve pikselleri döndürmek yerine dosyaya bir
+      çeyrek tur yazar. Oynatıcılar o turu okur ve uygular; yalnızca pikselleri
+      okuyan bir araç uygulamaz ve sonuç, doğru anın 90 derece döndürülmüş, gayet
+      iyi bir resmidir.
+    </p>
+    <p>
+      Dosyada yanlış bir şey yok ve kareyi sonradan yeniden döndürmek size sinir
+      bozukluğu dışında hiçbir şeye mal olmaz. Buradaki araç döndürmeyi izden okur
+      ve çizmeden önce uygular; yani dikey bir klip dikey bir resim verir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Geri getiremeyeceğiniz şeyler</h2>
+    <p>
+      Bir kare, ancak geldiği kare kadar iyi olabilir ve hangi aracı kullanırsanız
+      kullanın iki şey bunu sınırlar.
+    </p>
+    <p>
+      <strong>Hareket bulanıklığı karenin içindedir.</strong> Özne pozlama
+      sırasında hareket ediyorduysa o hareketin her karesi bulanıktır ve içeride
+      bulunacak keskin bir kare yoktur. Tek çözüm daha yüksek bir enstantane
+      hızıyla çekmektir ve bu, kayıttan önce olmak zorundadır.
+    </p>
+    <p>
+      <strong>Sıkıştırma da karenin içindedir.</strong> Video bir fotoğraftan çok
+      daha sert sıkıştırılır ve anahtar kareler arasındaki karelerde çok daha
+      serttir. Bir kare bloklu görünüyorsa bir iki kare öne ya da geriye
+      adımlamayı deneyin: bir anahtar kare eksiksiz saklanır ve genellikle
+      komşularından gözle görülür biçimde temiz görünür.
+    </p>
+    <p>
+      Karenin sonradan başka bir boyutta ya da şekilde olması gerekiyorsa bunu ayrı
+      bir adım olarak yapın:
+      <a href="../../resim-boyutlandirma/">Görsel Boyutlandırıcı</a>
+      boyutlandırır, kırpar ve dönüştürür; bunların her birinin neye mal olduğunu
+      <a href="../resim-boyutlandirma/">kendi rehberi</a> anlatıyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir tarayıcıda video çözmek yenidir ve gerçektir: WebCodecs, telefonunuzun
+      video oynatmak için kullandığı donanım çözücüsünün aynısını açar. İş, dosyaya
+      zaten sahip olan makinede olur ki gigabaytlarca büyüklükteki bir klip için
+      anlamı olan tek düzen de budur &mdash; 8 MB'lik tek bir resim almak için bir
+      saatlik 4K yüklemek her yönden kötü bir takastır.
+    </p>
+    <p>
+      Buradaki aracın hiçbir türde ağ özelliği yoktur ve sayfanın
+      <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi tek
+      tek sayar; bunların hiçbiri bu siteye ait değildir. Size söylenmesindense
+      denetlemeyi tercih ederseniz internet bağlantısını kesin ve yine de bir kare
+      yakalayın.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> herhangi bir araçta çalıştırabileceğiniz üç denetim
+      daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/grab-a-frame-from-a-video.toml
+++ b/locales/tr/pages/guides/grab-a-frame-from-a-video.toml
@@ -1,0 +1,16 @@
+#
+# Rehber: bir videodan kare almak - Türkçe.
+#
+
+nav = "Videodan kare yakalama"
+title = "Bir Videodan Kare Nasıl Resim Olarak Kaydedilir"
+description = "Bir klipten gerçek çözünürlüğünde kare alın: duraklatılmış bir oynatıcının ekran görüntüsü neden aynı resim değildir, hangi biçimde kaydetmelisiniz ve tam olarak istediğiniz kareye nasıl konarsınız."
+heading = "Bir videodan kare nasıl resim olarak kaydedilir"
+lede = """
+    Oynatıcıyı duraklatıp ekran görüntüsü tuşuna basmak size bir pencerenin
+    resmini verir. Bazen ihtiyacınız olan yalnızca budur. Bu rehber aradaki farkı
+    ve önemli olduğunda karenin kendisini nasıl alacağınızı anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir videodan kare nasıl resim olarak kaydedilir"
+og_description = "Duraklatılmış bir oynatıcının ekran görüntüsü neden o kare değildir, bir kareyi hangi biçimde kaydetmelisiniz ve tam olarak istediğiniz kareye nasıl konarsınız."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/tr/pages/guides/is-it-safe-to-upload-files.html
@@ -1,0 +1,254 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      Çoğu dosya için, çoğu zaman, yüklemek sorun değildir. Saygın dönüştürücüler
+      gönderdiğinizi birkaç saat içinde siler ve tatil fotoğraflarınızla
+      ilgilenmezler.
+    </p>
+    <p>
+      Sorun yalan söylüyor olmaları değildir.
+      <strong>Söyleyip söylemediklerini anlamanızın bir yolu olmamasıdır.</strong>
+      Bir dosya makinenizden ayrıldığı anda, sonrasında olacaklarla ilgili her
+      söz, güvene dayanarak kabul ettiğiniz bir sözdür: ne kadar saklandığı, ona
+      kimin erişebildiği, silme sayacından daha uzun yaşayan bir yedeğe kopyalanıp
+      kopyalanmadığı, şirket satılırsa ya da ihlale uğrarsa başına ne geleceği.
+      Bunların hiçbiri dışarıdan görünmez.
+    </p>
+    <p>
+      Yani işe yarayan soru &ldquo;bu siteye güveniyor muyum?&rdquo; değildir.
+      <strong>&ldquo;Bu işin dosyamın buradan ayrılmasına ihtiyacı var
+      mı?&rdquo;</strong> sorusudur. Giderek artan sayıda iş için cevap hayırdır ve
+      cevap hayır olduğunda güven sorusu, cevaplamak zorunda olduğunuz bir soru
+      olmaktan çıkar.
+    </p>
+  </section>
+
+  <section>
+    <h2>&ldquo;Yükleme&rdquo; aslında ne yapıyor</h2>
+    <p>
+      Bir dönüştürücü sizden bir dosya seçmenizi isteyip ardından bir ilerleme
+      çubuğu gösterdiğinde, tarayıcınız dosyanın tamamını, baytı baytına, internet
+      üzerinden bir başkasının sahip olduğu bir bilgisayara kopyalıyordur. O
+      bilgisayar onu bir diske yazar, dönüşümü yapar, sonucu aynı diske yazar ve
+      size bir bağlantı verir.
+    </p>
+    <p>
+      O anda dosyanız, sizin seçmediğiniz en az üç yerde bulunur: sunucunun diski,
+      isteği kaydeden günlükler ve çoğu zaman indirme hızlı olsun diye sonucu
+      önbelleğe almış bir içerik dağıtım ağı. Bir silme politikasının üçüne birden
+      ulaşması gerekir. Çoğu ulaştığını söyler. Hiçbirini
+      denetleyemezsiniz.
+    </p>
+    <p>
+      Bilmeye değer bir başka şey: giden tek şey dosya değildir. Dosya adı da
+      onunla gider, dosyanın içindeki göremediğiniz her şey de. Telefondan doğrudan
+      çıkan bir fotoğraf tipik olarak çekildiği yerin tam GPS koordinatlarını,
+      saati, kameranın seri numarasını ve bazen siz kırpmadan önceki özgün
+      görüntünün gömülü bir küçük resmini taşır. Resim konusunda dikkatli olan
+      insanlar çoğu zaman bu konuda dikkatli değildir; çünkü ekranda hiçbir şey
+      bunu onlara göstermez.
+    </p>
+  </section>
+
+  <section>
+    <h2>Çoğu araç neden yine de yükleme yapıyor</h2>
+    <p>
+      Dosyalarınızı istedikleri için değil. Çünkü webin ömrünün büyük kısmında bir
+      alternatif yoktu. Bir tarayıcı video çözemez, bir görseli seçilen bir
+      kalitede yeniden kodlayamaz ya da bir dosya biçimini ayrıştıramazdı;
+      FFmpeg ve ImageMagick'i olan bir sunucu yapabilirdi. Yükleme bir iş modeli
+      değildi, işin olabileceği tek yerdi.
+    </p>
+    <p>
+      Bu, yakın zamanda ve sessizce doğru olmaktan çıktı. Tarayıcılar artık aynı
+      derlenmiş kodlayıcıları yerele yakın hızda çalıştıran WebAssembly'yi,
+      makinenizde zaten bulunan donanım video kodlayıcısını açan WebCodecs'i ve
+      görselleri doğrudan çözüp yeniden kodlayabilen bir Canvas API'sini
+      beraberinde getiriyor. Bir zamanlar bir sunucu gerektiren iş, artık dosyaya
+      zaten sahip olan cihazda çalışıyor.
+    </p>
+    <p>
+      Bir sürü araç hâlâ yükleme yapıyor ve dürüst sebepler var: kimsenin yeniden
+      yazmak istemediği mevcut bir hat, tarayıcı tarafında çözücüsü olmayan bir
+      biçim, bir telefon için gerçekten fazla ağır bir iş. Bir de daha az dürüst
+      bir sebep var: hesapların, kotaların ve ücretli kademelerin yaşadığı yer
+      sunucudur. Tamamen tarayıcınızda çalışan bir aracı ölçmek zordur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kendiniz çalıştırabileceğiniz dört denetim</h2>
+    <p>
+      Bunlar, bu araç dâhil her araçta çalışır. Hiçbiri kimsenin sözüne inanmayı
+      gerektirmez ve ilki yaklaşık on saniye sürer.
+    </p>
+
+    <h3>1. Fişi çekin</h3>
+    <p>
+      Sayfayı yükleyin, sonra wi-fi'yi kapatın ya da kabloyu çıkarın ve kullanmayı
+      deneyin. İşini sizin tarayıcınızda yapan bir araç tam olarak eskisi gibi
+      devam eder. Yükleme yapan bir araç anında durur; çünkü işi yapan şeye artık
+      ulaşılamıyordur.
+    </p>
+    <p>
+      Bu, var olan en güçlü denemedir ve taklit edilmesi en zorudur; çünkü
+      kelimelerle cevaplanamaz. Dönüşüm ya ağ olmadan tamamlanır ya tamamlanmaz.
+    </p>
+
+    <h3>2. Ağ sekmesini izleyin</h3>
+    <p>
+      Tarayıcınızın geliştirici araçlarını açın, Ağ'ı seçin, sonra aracı kullanın.
+      Sayfanın yaptığı her istek boyutuyla birlikte listelenir. 4&nbsp;MB'lik
+      fotoğrafınız yüklendiyse o listede 4&nbsp;MB'lik bir istek vardır. Sayfadan
+      çıkan en büyük şey birkaç kilobaytlık reklamsa yüklenmemiştir.
+    </p>
+    <p>
+      Boyuta göre sıralayın ve en üste bakın. İstekleri anlamanız gerekmez;
+      içlerinden birinin dosyanız boyutunda olup olmadığını fark etmeniz
+      yeterlidir.
+    </p>
+
+    <h3>3. Content-Security-Policy'yi okuyun</h3>
+    <p>
+      Sayfa kaynağını görüntüleyin ve en üstlerde
+      <code>Content-Security-Policy</code>'yi arayın. O, sayfanın iletişim
+      kurmasına izin verilen adreslerin listesidir ve sitenin iyi niyetiyle değil
+      tarayıcınız tarafından zorunlu kılınır &mdash; listede olmayan bir şeye
+      yapılan istek, kod ne denerse denesin reddedilir.
+    </p>
+    <p>
+      Önemli olan yönerge, sayfanın nereye veri gönderebileceğini belirleyen
+      <code>connect-src</code>'dir. Bulunduğunuz siteye ait bir adres sayıyorsa
+      sayfa dosyanızı oraya gönderebilir. Hiçbir şey saymıyorsa ya da yalnızca bir
+      reklam ağı gibi üçüncü tarafları sayıyorsa gönderemez.
+    </p>
+    <p>
+      Hiç Content-Security-Policy'si olmayan bir sayfa kötü bir şeyin kanıtı
+      değildir. Yalnızca bu belirli denetimin size söyleyecek bir şeyi olmadığı
+      anlamına gelir.
+    </p>
+
+    <h3>4. Kodu okuyun</h3>
+    <p>
+      En zahmetlisi, en kesin sonuç vereni. Bir araç kaynağını yayımlıyor ve onu
+      bir derleme adımı olmadan sunuyorsa, tarayıcınızın getirdiği dosyalar
+      okuyabileceğiniz dosyalardır. İçlerinde <code>fetch</code>,
+      <code>XMLHttpRequest</code> ve <code>sendBeacon</code> arayın &mdash; bir
+      sayfanın bir şey gönderebileceği üç yol &mdash; ve onlara ne verildiğine
+      bakın.
+    </p>
+    <p>
+      Çoğu insan bunu yapmayacak. Yine de yapılabilir olması önemlidir; çünkü
+      kimsenin denetleyemediği bir iddia gerçekte bir iddia değildir.
+    </p>
+  </section>
+
+  <section>
+    <h2>&ldquo;Tarayıcınızda çalışır&rdquo; ne demek değildir</h2>
+    <p>
+      Kesin konuşmaya değer; çünkü bu ifade gevşek kullanılıyor ve bu sitenin de
+      önerdiği ölçüte kendini tutması gerekiyor.
+    </p>
+    <ul>
+      <li>
+        <strong>Hiç istek yok demek değildir.</strong> Sayfanın kendisi ağ
+        üzerinden geldi ve ücretsiz araçların çoğu, biriyle konuşan reklam ya da
+        ölçüm taşır. İddia, genel olarak trafik hakkında değil,
+        <em>dosyanız</em> hakkındadır.
+      </li>
+      <li>
+        <strong>IP adresinizi gizlemez.</strong> Ziyaret ettiğiniz her site onu
+        görür, bu site dâhil. Yerel işleme, anonimlikle değil dosyalarınızın
+        içeriğiyle ilgilidir.
+      </li>
+      <li>
+        <strong>Bir şey getiren bir özellikten sağ çıkmaz.</strong> Bir web adresi
+        yapıştırmanıza izin veren bir aracın o adresle iletişim kurması gerekir ve
+        o sunucu IP adresinizi ve ne istediğinizi öğrenir. Bu, özelliğin bir
+        kusuru değil doğasıdır &mdash; ama gerçek bir istisnadır ve bir araç bunu
+        yuvarlamak yerine açıkça söylemelidir.
+      </li>
+      <li>
+        <strong>&ldquo;Dosyalarınızı siliyoruz&rdquo; ile aynı şey
+        değildir.</strong> İkinci cümle bir şirketin yapmayı seçtiği şeyle
+        ilgilidir. Birincisi teknik olarak neyin mümkün olduğuyla. Yalnızca biri
+        denetlenebilir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Yüklemenin gerçekten sorun olmadığı durumlar</h2>
+    <p>
+      Bu, her yüklemenin bir hata olduğu savı değildir. İçerik hassas değilse ve iş
+      böyle daha kolaysa; iş gerçekten cihazınız için fazla ağırsa; biçimin
+      tarayıcı tarafında bir çözücüsü yoksa; ya da zaten bir ilişkiniz olan ve
+      koşullarını gerçekten okuduğunuz bir hizmeti kullanıyorsanız dosyayı
+      gönderin.
+    </p>
+    <p>
+      Dosya, herkese açık paylaşmayacağınız bir şey içeriyorsa daha dikkatli olun:
+      kimlik belgeleri, tıbbi taramalar, sözleşmeler, paylaşmayı istemediğiniz bir
+      adres ya da yüz içeren her şey veya konum verisine bakmadığınız bir fotoğraf.
+      Bunlar için, denetleyebileceğiniz bir aracı güvenmek zorunda olduğunuz bir
+      araca tercih etmeye değer &mdash; güvendiğinizin size ihanet etme ihtimali
+      yüksek olduğu için değil, denetlenebilir olanda sorunun hiç ortaya
+      çıkmamasından dolayı.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bu site o dört denetime nasıl cevap veriyor</h2>
+    <p>
+      Size denetleyin deyip sonra muaf tutulmak isteyen bir rehber tuhaf olurdu.
+      O hâlde, sırasıyla:
+    </p>
+    <ul>
+      <li>
+        <strong>Fişi çekin.</strong> Buradaki herhangi bir aracı açın, bağlantıyı
+        kesin, çalışmaya devam etsin. Her araç sayfasında, şu anda çevrimiçi olup
+        olmadığınızı söyleyen canlı bir gösterge var; böylece değiştiğini
+        izleyebilirsiniz.
+      </li>
+      <li>
+        <strong>Ağ sekmesi.</strong> Bir şey dönüştürün ve listeyi okuyun. Hiçbiri
+        dosyanızı, onun bir küçük resmini, adını, boyutunu ya da içinden okunan
+        herhangi bir şeyi taşımıyor. Bu sitede bunlardan birini gönderecek özel
+        bir ölçüm olayı yok.
+      </li>
+      <li>
+        <strong>Content-Security-Policy.</strong> Her sayfanın kaynağının en
+        üstünde. <code>connect-src</code>, Google'ın reklam ve ölçüm uç
+        noktalarını ve bağış düğmesini sayıyor, başka hiçbir şeyi değil.
+        <strong>O listedeki hiçbir adres bu siteye ait değil</strong>; çünkü bu
+        sitenin bir sunucusu yok &mdash; durağan dosyalardan ibaret. Bir şey
+        denese bile bir dosyanın gönderilebileceği bir yer yok.
+      </li>
+      <li>
+        <strong>Kod.</strong> Her satırı
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">herkese açık</a>.
+        Derleme yorumları ve boşlukları siler, başka hiçbir şeyi değil; onu
+        kendiniz çalıştırıp sonucu sunulanla karşılaştırabilirsiniz.
+      </li>
+    </ul>
+    <p>
+      İstisnalar, gömülmek yerine açıkça söyleniyor: bu site Google reklamları ve
+      bir ziyaret sayacı taşıyor; ikisi de Google'la konuşuyor ve hiçbirine
+      dosyalarınız hakkında bir şey verilmiyor; ayrıca
+      <a href="../../resimleri-videoya-donusturme/">Görsellerden Videoya</a> aracı,
+      yapıştırdığınız bir adresten bir görsel getirebiliyor ki bu da o sunucunun IP
+      adresinizi gördüğü anlamına geliyor.
+      <a href="../../gizlilik/">Gizlilik sayfası</a> ikisini de eksiksiz
+      anlatıyor.
+    </p>
+    <p>
+      Buradaki her araç böyle çalışıyor: söylediğiniz boyutu tutturan bir
+      <a href="../../resim-sikistirma/">görsel sıkıştırıcı</a>, bir
+      <a href="../../video-kirpma/">video kırpıcı</a>, bu sayfanın yukarısında
+      anlatılan gizli veri için bir
+      <a href="../../exif-verisi-silme/">EXIF görüntüleyici ve silici</a>,
+      <a href="../../resimleri-videoya-donusturme/">görsellerden videoya</a> ve
+      <a href="../../resimleri-pdfe-donusturme/">görsellerden PDF'e</a>. Hepsi
+      ücretsiz, hesap yok ve hiçbirinin dosyalarınızı gönderecek bir yeri yok.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/tr/pages/guides/is-it-safe-to-upload-files.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: çevrimiçi dönüştürücülere dosya yüklemek güvenli mi? - Türkçe.
+#
+
+nav = "Dosya yüklemek güvenli mi?"
+title = "Çevrimiçi Dönüştürücülere Dosya Yüklemek Güvenli mi?"
+description = "Çevrimiçi dönüştürücülerin çoğu dosyanızı bir sunucuya gönderir. Bunun ne anlama geldiği, dosyanın orada başına ne geldiği ve bir aracın buna gerçekten ihtiyacı olup olmadığını söyleyen dört denetim."
+heading = "Çevrimiçi dönüştürücülere dosya yüklemek güvenli mi?"
+lede = """
+    Dürüst cevap genellikle &ldquo;muhtemelen, ama denetleyemezsiniz&rdquo;dır.
+    Bu rehber, yüklemenin dosyanıza gerçekte ne yaptığını, çoğu aracın bunu neden
+    hâlâ yaptığını ve önünüzdekinin buna mecbur olup olmadığını söyleyen dört
+    denemeyi anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Çevrimiçi dönüştürücülere dosya yüklemek güvenli mi?"
+og_description = "Bir dönüştürücüye yüklediğiniz dosyanın başına ne geldiği, çoğu aracın neden hâlâ dosya istediği ve kendiniz çalıştırabileceğiniz dört denetim."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/make-a-favicon.html
+++ b/locales/tr/pages/guides/make-a-favicon.html
@@ -1,0 +1,332 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../favicon-olusturma/">Görselden ICO'ya</a>'yı açın, en az 256
+      piksellik kare bir resim bırakın, hazır ayarı <em>Web sitesi faviconu</em>'nda
+      bırakın ve <code>favicon.ico</code>'yu indirin. Onu sitenizin köküne koyun;
+      böylece <code>https://siteniz.com/favicon.ico</code> adresinde cevap versin.
+      HTML'iniz ondan söz etsin ya da etmesin, o adresi her tarayıcı ister; yani
+      kesin olarak yapmanız gereken başka bir şey yok.
+    </p>
+    <p>
+      Aşağıdaki her şey, teknik olarak var olan bir simge ile okunabilir bir simge
+      arasındaki farkı yaratan kısımdır: içine hangi boyutlar girer, iPhone'lar ve
+      Android bunun yerine ne ister ve logonuz on altı piksel genişliğinde olmaktan
+      sağ çıkmadığında ne yaparsınız.
+    </p>
+  </section>
+
+  <section>
+    <h2>Neden tek bir resim değil de bir boyutlar kümesi</h2>
+    <p>
+      Bir <code>.ico</code> dosyası bir kaptır. İçinde aynı şeyin farklı
+      boyutlardaki birkaç eksiksiz resmi vardır ve dosyayı okuyan şey, ihtiyaç
+      duyduğu boyuta en yakın olanı seçer.
+    </p>
+    <p>
+      Bu kulağa gereksiz tekrar gibi geliyor ama değil. Simgenizi on altı pikselde
+      çizen bir tarayıcının iki seçeneği vardır: sizin çizdiğiniz on altı
+      piksellik sürümü okumak ya da olduğu yerde daha büyük birini küçültmek.
+      İkincisi daha kötüdür ve gözle görülür biçimde öyledir &mdash; ayrıntılı bir
+      logonun otomatik küçültülmesi lapa üretir, oysa bakarak hazırladığınız on
+      altı piksellik bir sürüm, sadeleştirme şansı bulduğunuz bir şeydir. Biçimin
+      birkaç boyut tutmasının bütün sebebi size o şansı vermektir.
+    </p>
+    <p>
+      Bir web sitesi için gelenek üç boyuttur ve her birinin bir sebebi vardır:
+    </p>
+    <ul>
+      <li>
+        <strong>16&times;16</strong> &mdash; tarayıcı sekmesi, adres çubuğu, yer
+        imi menüsü. İnsanların gördüğü budur. Yalnızca birini doğru yapacaksanız
+        bunu doğru yapın.
+      </li>
+      <li>
+        <strong>32&times;32</strong> &mdash; bir yer imi çubuğu, sitenize giden
+        bir Windows masaüstü kısayolu ve yüksek yoğunluklu bir ekrandaki çoğu
+        tarayıcı; onlar sekme simgesini 32'den çizip küçültür.
+      </li>
+      <li>
+        <strong>48&times;48</strong> &mdash; Google'ın arama sonuçları için site
+        simgesini okuduğu boyut ve Windows'un orta simge görünümü.
+      </li>
+    </ul>
+    <p>
+      Daha büyük olan her şey, aşağıda mobil dosyalar bölümünde geçen sebeplerle,
+      <code>.ico</code>'nun içinde değil yanında bir PNG'de durmalıdır.
+    </p>
+  </section>
+
+  <section>
+    <h2>On altı piksel sorunu</h2>
+    <p>
+      Kimsenin sizi uyarmadığı kısım budur. On altı piksel, normal bir ekranda
+      yaklaşık dört milimetredir: toplam 256 noktalık bir ızgara; bu cümledeki
+      harflerden az. Bir tabelada, bir kartvizitte ya da bir web sitesi başlığında
+      çalışsın diye tasarlanmış neredeyse hiçbir şey buna indirgenmekten sağ
+      çıkmaz.
+    </p>
+    <p>
+      Sırasıyla kaybolanlar:
+    </p>
+    <ul>
+      <li>
+        <strong>Metin.</strong> Bir kareye küçültülmüş bir kelime logosu yaklaşık
+        üç piksel yüksekliğindedir. Küçük metin olmaz, gri bir çubuk olur. Adının
+        yanı sıra bir sembolü de olan hemen her şirketin faviconu olarak yalnızca
+        sembolü kullanmasının ve sembolü olmayanların tek bir harf
+        kullanmasının sebebi budur.
+      </li>
+      <li>
+        <strong>İnce çizgiler.</strong> 512 piksellik bir logodaki bir piksellik
+        çerçeve, on altıda bir pikselin otuz ikide biridir. Kenar boyunca silik
+        gri bir pus olarak görüntülenir ya da yok olur.
+      </li>
+      <li>
+        <strong>Renk geçişleri ve gölgeler.</strong> Bir geçişe yer yoktur.
+        Yumuşak bir gölge, kirli bir saçağa dönüşür.
+      </li>
+      <li>
+        <strong>Ayrıntının içindeki ayrıntı.</strong> Üzerinde yazı olan bir belge
+        simgesi, üzerinde leke olan bir dikdörtgene dönüşür.
+      </li>
+    </ul>
+    <p>
+      Çözüm bir ayar değil, başka bir çizimdir: bir ya da iki şekilden oluşan,
+      yüksek karşıtlıklı ve tek bir karakterin ötesinde metin içermeyen
+      sadeleştirilmiş bir işaret. O sürümü bilerek 32 ya da 48 pikselde çizin ve
+      kaynak olarak onu kullanın.
+    </p>
+    <p>
+      Bir aracın yapabileceği şey, siz yayımlamadan önce sorunu size
+      göstermektir. <a href="../../favicon-olusturma/">Görselden ICO'ya</a>'daki
+      ön izleme her boyutu ekranda gerçek boyutunda çizer; bunu değerlendirmenin tek
+      yolu da budur &mdash; altmış dörtte gösterilen on altı piksellik bir simge iyi
+      görünür ve size hiçbir şey söylemez.
+    </p>
+  </section>
+
+  <section>
+    <h2>Logonuz kare değil. Tamamlamak mı, kırpmak mı?</h2>
+    <p>
+      Bir simge her zaman karedir ve çoğu logo değildir; yani bir şeyin olması
+      gerekir. Üç cevap var ve hepsi eşit derecede iyi değil.
+    </p>
+    <p>
+      <strong>Tamamlamak</strong> resmin tamamını korur ve üstüne altına boşluk
+      koyar. Güvenli varsayılandır ve geniş bir kelime logosu için yanlış
+      seçimdir: yüksekliğinin üç katı genişlikte bir şeyi bir kareye sığdırmak, onu
+      yüksekliğin üçte birini kaplar hâlde bırakır ki bu, on altı pikselde beş
+      piksel logo ve on bir piksel hiçlik demektir.
+    </p>
+    <p>
+      <strong>Ortaya kırpmak</strong> merkezden en büyük kareyi alır. Bir kilit
+      düzen için &mdash; yanında şirket adı olan bir sembol &mdash; bu çoğu zaman
+      ikisini birden ortasından keser. Önce kaynağı kendiniz, yalnızca sembol
+      kalacak şekilde kırpıp sonra onu dönüştürmek daha iyidir.
+    </p>
+    <p>
+      <strong>Esnetmek</strong> resmi sığdırmak için ezer. Bunun doğru olduğu
+      neredeyse hiçbir durum yoktur ve esas olarak araç bunu sessizce yapmasın diye
+      sunulur.
+    </p>
+    <p>
+      Geniş bir logo için genel cevap: logoyu dönüştürmeyin. Onun tek başına işe
+      yarayan kısmını dönüştürün.
+    </p>
+  </section>
+
+  <section>
+    <h2>Saydam mı, düz bir arka plan mı?</h2>
+    <p>
+      Bir web sitesi için genellikle saydam doğrudur. Tarayıcı sekmeleri, tarayıcıya
+      ve temaya göre gri, beyaz ya da siyaha yakındır ve saydam bir simge hepsinin
+      üstünde durur. İçine beyaz arka plan boyanmış bir simge, koyu bir sekme
+      çubuğunda beyaz bir dikdörtgendir.
+    </p>
+    <p>
+      Bilmeye değer iki istisna:
+    </p>
+    <ul>
+      <li>
+        <strong>Yalnızca koyu renkten oluşan bir logo</strong> koyu kipte kaybolur.
+        İşaretiniz doğası gereği beyaz üzerine siyahsa, ona saydam yerine renkli bir
+        arka plan ya da açık renkli bir dış hat verin.
+      </li>
+      <li>
+        <strong>Apple dokunma simgesi opak olmak zorundadır.</strong> iOS onu kendi
+        yuvarlatılmış kutucuğuna çizer ve saydamlığı siyah olarak görüntüler. O
+        dosyayı üreten her araç onu sizin için düzleştirmelidir; buradaki araç
+        yapıyor, varsayılan olarak beyaza.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bir web sitesinin .ico dışında ihtiyaç duyduğu dosyalar</h2>
+    <p>
+      <code>favicon.ico</code>, tarayıcıları ve Windows'u kapsar. Telefonları
+      kapsamaz ve ev yapımı simge setlerinin çoğu da burada erken durur. Üç başka
+      platform kendi dosyalarını, kendi adlarıyla ister ve hiçbiri bir
+      <code>.ico</code>'nun içine bakmaz:
+    </p>
+    <ul>
+      <li>
+        <strong>iOS</strong>, biri sitenizi ana ekranına eklediğinde
+        180&times;180 boyutunda <code>apple-touch-icon.png</code> okur. O
+        olmadan iOS sayfanın bir ekran görüntüsünü kullanır ki bu bir hata gibi
+        görünür.
+      </li>
+      <li>
+        <strong>Android ve her kurulum istemi</strong> bir web uygulaması bildirimi
+        okur &mdash; <code>site.webmanifest</code> &mdash; o da 192 ve 512
+        piksellik PNG'leri gösterir. 512, aynı zamanda bir web uygulamasının açılış
+        ekranında gösterdiğidir.
+      </li>
+      <li>
+        <strong>Bir Windows başlat menüsü kutucuğu</strong>
+        <code>browserconfig.xml</code> okur, o da 150&times;150 bir PNG gösterir.
+        Üçünün içinde önemi en az olanı ve dört satırlık bir XML.
+      </li>
+    </ul>
+    <p>
+      Yanlış yapılması kolay bir tane daha var: Android başlatıcıları uyarlanabilir
+      bir simgeyi telefonun hoşuna giden şekle kırpar &mdash; daire, yumuşak kare,
+      yuvarlatılmış kare &mdash; ve görüntünün yalnızca orta %80'inin hayatta
+      kalacağı garanti edilir. Kenardan kenara çizilmiş bir simge köşelerini
+      kaybeder. <em>Maskelenebilir</em> bir simge de budur: aynı resmin, karenin
+      içinde bilerek küçük çizilmiş ve bildirimde ayrıca bildirilmiş hâli.
+    </p>
+    <p>
+      <a href="../../favicon-olusturma/">Görselden ICO'ya</a>'da web sitesi setini
+      işaretlemek bunların hepsini, bildirimi ve onları gösteren HTML bloğunu
+      üretir. O bloğun bilerek dışarıda bıraktığı bir şey,
+      <code>favicon.ico</code> için bir <code>&lt;link&gt;</code>'tir: tarayıcılar
+      o adresi kendiliğinden ister ve onu ayrıca adlandırmak aynı dosyanın iki kez
+      getirilmesine yol açar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir Windows uygulama simgesi başka bir kümedir</h2>
+    <p>
+      Simge bir site için değil bir program için ise boyutlar değişir. Visual
+      Studio'nun kendi varsayılan <code>app.ico</code>'sunun içerdiği şey 16, 32,
+      48 ve 256'dır &mdash; üç kabuk boyutu ile başlat menüsünün ve Explorer'ın çok
+      büyük görünümünün çizdiği büyük olan.
+    </p>
+    <p>
+      Yüksek yoğunluklu bir ekranda Windows ayrıca 20, 24, 40, 64 ve 96'yı da ister
+      ve yoklarsa elindeki en yakın boyuttan yeniden örnekler. Bunun önemli olup
+      olmadığı simgenize bağlıdır: düz bir şekil yeniden örneklemeden sağ çıkar,
+      ayrıntılı biri çıkmaz. Onları eklemek dosyayı kabaca iki katına çıkarır ki bu,
+      bir uygulama için hiçbir şeydir &mdash; hesap, dosyanın her ziyaretçi
+      tarafından getirildiği bir faviconunkinden tamamen farklıdır.
+    </p>
+    <p>
+      Boyutla ilgili bir şey daha: baytların bulunduğu yer 256 girdisidir.
+      Sıkıştırılmadan saklandığında tek başına 264&nbsp;KB'dir; simgenin içinde PNG
+      olarak saklandığında genellikle 30'un altındadır. PNG girdileri Windows
+      Vista'dan beri okunabiliyor, yani onlardan kaçınmanın tek sebebi gerçekten
+      bundan eski bir yazılım ya da simgeleri kendi ayrıştıran bir yükleyici veya
+      gömülü bir araçtır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir Mac tamamen başka bir dosya okur</h2>
+    <p>
+      Simge bir Windows uygulaması için değil bir Mac uygulaması içinse
+      yukarıdakilerin hiçbiri geçerli değildir: macOS <code>.ico</code>'yu hiç
+      okumaz. <code>.icns</code> okur; o da aynı fikrin başka bir sargıdaki hâlidir
+      &mdash; tek kapta birkaç boyut &mdash; ve bilmeye değer üç farkı vardır.
+    </p>
+    <ul>
+      <li>
+        <strong>Boyutlar sabittir.</strong> Apple on yuva yayımlar ve seçilecek bir
+        şey yoktur: 16, 32, 64, 128, 256, 512 ve 1024 piksel; 32, 256 ve 512 iki
+        kez görünür, çünkü her biri hem kendi başına bir boyut hem de bir
+        altındaki boyutun Retina sürümüdür.
+      </li>
+      <li>
+        <strong>1024'e kadar çıkar.</strong> Bir <code>.ico</code> 256'da durur; bir
+        Mac simge dosyasının birkaç yüz kilobayt, bir faviconun ise on beş kilobayt
+        olmasının sebebi budur. Bir kez gönderilen bir uygulama için bu hiçbir
+        şeydir; yalnızca bir favicon her ziyaretçi tarafından getirilir.
+      </li>
+      <li>
+        <strong>Çiziminizin sağ çıkması gereken şey 1024 pikseldir.</strong> İki
+        sorun aynı resmin karşıt uçlarıdır: bir faviconun minicikken çalışması,
+        bir Mac simgesinin ise kocamanken ayakta kalması gerekir. 512'de dışa
+        aktarılıp 1024'e büyütülmüş bir logo, bir Retina ekranda yumuşak görünür ve
+        App Store onu kabul etmez.
+      </li>
+    </ul>
+    <p>
+      Bir tanesini kullanmak için: bir uygulama paketi onu
+      <code>YourApp.app/Contents/Resources/</code> içinde tutar ve
+      <code>Info.plist</code> içinde adlandırır. Bir klasör ya da bir disk imajı
+      için, <code>.icns</code>'i Finder'da seçin, Command-C'ye basın, sonra
+      değiştirmek istediğiniz şeyde Get Info açın, sol üstteki küçük simgeye
+      tıklayın ve Command-V'ye basın.
+    </p>
+    <p>
+      <a href="../../favicon-olusturma/">Görselden ICO'ya</a>'da <em>macOS
+      simgesi</em>'ni işaretlemek, yanında Windows dosyası olsun ya da olmasın, bir
+      tane yazar. İki platformda da yayımlanan her şey ikisini birden ister ve
+      ikisi de aynı resimden, aynı geçişte çizilir.
+    </p>
+  </section>
+
+  <section>
+    <h2>İşe yaradığını denetlemek</h2>
+    <p>
+      Tarayıcılar faviconları neredeyse her şeyden daha sert önbelleğe alır; yani
+      &ldquo;yükledim ve hiçbir şey değişmedi&rdquo;, genellikle bir hata değil bir
+      önbellektir. Yeniden dosya düzenlemeye başlamadan önce denenecek iki şey:
+    </p>
+    <ul>
+      <li>
+        <code>https://siteniz.com/favicon.ico</code>'yu doğrudan açın. Dosya
+        iniyorsa oradadır ve siz bir önbelleğe bakıyorsunuzdur. 404 alıyorsanız
+        kökte değildir.
+      </li>
+      <li>
+        Siteyi, genellikle kendi simge önbelleği olan bir gizli pencerede yükleyin.
+      </li>
+    </ul>
+    <p>
+      Windows'ta bir <code>.ico</code>, bir klasöre konup Explorer'ın görünüm
+      boyutları arasında gezilerek denetlenebilir: küçük, orta, büyük ve çok büyük,
+      aynı dosyadan farklı girdiler çizer; böylece her birini sistemin göreceği gibi
+      görebilirsiniz.
+    </p>
+    <p>
+      Bir Mac'te bir <code>.icns</code>, her yuvayı yanda listeleyen Preview'da
+      açılır &mdash; ve aynı numara Finder'da da işler: onu bir klasöre bırakın ve
+      içindeki resimler arasında geçiş yapmasını izlemek için görünüm
+      seçeneklerindeki boyut kaydırağını sürükleyin.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir resmi ölçeklemek her tarayıcının yıllardır yaptığı bir şeydir ve bir
+      <code>.ico</code>, altı baytlık bir başlık, görsel başına on altı bayt ve
+      ardından görsellerdir. Bir tane yapmanın hiçbir adımı bir sunucu gerektirmez
+      ve buradaki araç bir tane kullanmaz: sayfanın
+      <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi tek
+      tek sayar ve bunların hiçbiri bu siteye ait değildir.
+    </p>
+    <p>
+      Burada bunu önemsemeye her zamankinden çok değer. Ücretsiz bir favicon
+      üreticisine verilen bir logo, epeyce sık, henüz yayımlanmamış bir markadır
+      &mdash; simge, yapılan ilk şeylerden ve duyurulan son şeylerden biridir. Size
+      söylenmesindense denetlemeyi tercih ederseniz sayfayı yükleyin, internet
+      bağlantısını kesin ve yine de bir tane yapın.
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> herhangi bir araçta çalıştırabileceğiniz üç denetim
+      daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/make-a-favicon.toml
+++ b/locales/tr/pages/guides/make-a-favicon.toml
@@ -1,0 +1,18 @@
+#
+# Rehber: favicon ve uygulama simgesi yapmak - Türkçe.
+#
+
+nav = "Favicon oluşturma"
+title = "Nasıl Favicon (ve Windows Uygulama Simgesi) Yapılır"
+description = "Bir favicon.ico'nun gerçekte hangi boyutlara ihtiyacı olduğu, iPhone'ların, Android'in ve bir Mac'in hangi ek dosyaları istediği ve bir afişte işe yarayan bir logonun on altı pikselde neden kaybolduğu."
+heading = "On altı pikselde hâlâ okunan bir favicon nasıl yapılır"
+lede = """
+    Bir favicon, logonuzun küçük bir resmi değildir. Sabit boyutlarda, çoğu
+    insanın hiç açmadığı bir kabın içinde duran bir resimler kümesidir ve
+    herkesin gerçekten gördüğü, bunların en küçüğüdür. Bu rehber hangi boyutlara
+    ihtiyacınız olduğunu, yanlarına hangi dosyaların gittiğini ve logonuz bu
+    küçülmeden sağ çıkmadığında ne yapacağınızı anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "On altı pikselde hâlâ okunan bir favicon yapmak"
+og_description = "Bir favicon.ico'nun hangi boyutlara ihtiyacı olduğu, iPhone'ların ve Android'in istediği ek dosyalar ve logonuz küçültülmekten sağ çıkmadığında ne yapacağınız."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/make-a-gif-from-images.html
+++ b/locales/tr/pages/guides/make-a-gif-from-images.html
@@ -1,0 +1,221 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../gif-olusturma/">GIF Yapıcı</a>'yı açın, resimleri bırakın,
+      oynamaları gereken sıraya dizin, her karenin ne kadar tutulacağını belirleyin
+      ve GIF'i yapın. Siz kaydetmeden önce sayfada oynar.
+    </p>
+    <p>
+      Aşağıdaki her şey, sonrasında ters giden iki şeyle ilgili: dosya beklenenden
+      çok daha büyüktür ya da canlandırma, sayıların söylediğinden yavaş oynar.
+      İkisinin de belirli sebepleri var ve hiçbiri araçtaki bir kusur değil.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir GIF neden beklediğinizden bu kadar büyük</h2>
+    <p>
+      640 pikselde 20 karelik bir GIF alışıldık biçimde 8 ila 15 MB'dir. Aynı
+      canlandırma MP4 olarak birkaç yüz kilobayttır. Bu, kötü yapılmış bir GIF
+      değildir; biçimin kendisi budur.
+    </p>
+    <p>
+      Kullandığınız diğer her hareketli görüntü biçimi <em>farkları</em> saklar. Bir
+      video kodlayıcısı bir tam kare yazar ve ondan sonraki kareler için yalnızca
+      neyin ve nereye hareket ettiğini yazar &mdash; durağan bir arka planın önünde
+      konuşan birinin videosunun kare başına neredeyse hiçbir şeye mal olmamasının
+      sebebi budur. Bir GIF bunu yapamaz. Her kare, kayıpsız bir sıkıştırıcıdan
+      geçirilmiş bütün pikseller olarak saklanır ve alet çantasının tamamı budur.
+    </p>
+    <p>
+      Ayrıca bir kalite ayarı da yoktur; çünkü kısılacak kayıplı bir adım yoktur.
+      %60 kalitede bir JPEG, arkasında gerçek bir kaydırak olan gerçek bir seçimdir;
+      bir GIF'in dengi yoktur. Yani boyut kabaca
+      <strong>alan &times; kare sayısı</strong>dır ve onu oynatmanın tek yolu bu iki
+      sayıdan birini oynatmaktır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Onu gerçekten küçülten üç şey</h2>
+    <p>
+      Yardım ettikleri sırayla:
+    </p>
+    <p>
+      <strong>1. Küçültün.</strong> Bu, birkaç seçenekten biri değil, seçeneğin
+      kendisidir. Boyut alandır; yani uzun kenarı yarıya indirmek dosyayı dörtte
+      bire düşürür: 640&nbsp;pikselden 320&nbsp;piksele inmek 12&nbsp;MB'yi yaklaşık
+      3&nbsp;MB'ye çevirir. Bir web sayfasındaki ya da bir sohbet penceresindeki bir
+      GIF zaten birkaç yüz piksel olarak izleniyor. Araçtaki varsayılanın
+      480&nbsp;piksel olmasının sebebi tam olarak budur ve 320&nbsp;piksel gayet
+      saygın bir cevaptır.
+    </p>
+    <p>
+      <strong>2. Daha az kare kullanın.</strong> Beşte bir saniye tutulan on kare,
+      onda bir saniyede yirmi kareyle aynı iki saniyelik canlandırmadır ve dosyanın
+      yarısıdır. Akıcılık doğrudan orantılı olarak bayta mal olur, yani onu
+      yalnızca hareketin gerektirdiği yerde harcayın.
+    </p>
+    <p>
+      <strong>3. Titremeyi kapatın ve renkleri düşürün.</strong> Bu, sezgiye
+      aykırıdır. Titreme (dither), paletin sahip olmadığı renkleri taklit etmek için
+      dönüşümlü piksellerden ince bir desen serper ve o desen
+      <em>gürültü</em>dür &mdash; ki kayıpsız bir sıkıştırıcının sıkıştıramadığı şey
+      tam olarak budur. Düz çizimlerde, ekran görüntülerinde ve çizgi çalışmalarında
+      onu kapatmak dosyanın üçte birini alabilir ve üstelik daha iyi görünebilir.
+      Fotoğraflarda ise kazanç karşılığında görünür bantlanma takas eder; ikisini de
+      deneyin ve bakın.
+    </p>
+    <p>
+      256'dan 64 renge düşmek de yardımcı olur, ama insanların umduğundan az: piksel
+      kaldırmak yerine kod kelimelerini kısaltır.
+    </p>
+    <p>
+      Bunların hiçbiri onu yeterince küçültmüyorsa dürüst cevap, yaptığınız şeyin
+      bir video olduğudur.
+      <a href="../resimleri-videoya-donusturme/">Aynı görselleri bir MP4'e
+      çevirmek</a> belki de onda biri boyutunda olacaktır ve bir GIF'i bir
+      <code>&lt;img&gt;</code> etiketinden başka bir şey için kabul eden her yer
+      &mdash; her sosyal ağ dâhil &mdash; onu yüklemede yine de videoya
+      dönüştürür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir GIF gerçekte ne kadar hızlı oynayabilir</h2>
+    <p>
+      Biçim, her karenin gecikmesini saniyenin yüzde biri cinsinden saklar; bu da
+      0,01 sn isteyip saniyede yüz kare alabileceğinizi düşündürür.
+      Alamazsınız.
+    </p>
+    <p>
+      Her tarayıcı, saniyenin yüzde ikisinin altındaki bir gecikmeyi saniyenin onda
+      birine yükseltir. Kural, sayfaların olabildiğince hızlı oynasın diye
+      ayarlanmış canlandırmalarla dolu olduğu ve günün makinelerinin buna
+      dayanamadığı 1990'lardan kalmadır ve konduğu her sebepten uzun yaşamıştır.
+      Hiçbir zaman kaldırılmadı ve bugün sizin GIF'iniz için de geçerli.
+    </p>
+    <p>
+      Yani pratikteki aralık şudur:
+    </p>
+    <ul>
+      <li><strong>0,02 sn</strong> (saniyede 50 kare) &mdash; bir GIF'in olmasına
+      izin verilen en hızlı hâl ve genellikle gerektiğinden hızlı.</li>
+      <li><strong>0,05 sn</strong> (saniyede 20 kare) &mdash; akıcı canlandırma ve
+      hareket canlandırıyorsanız başlanacak yer.</li>
+      <li><strong>0,1 sn</strong> (saniyede 10 kare) &mdash; klasik GIF görünümü.
+      Karelerin yarısı, dosyanın yarısı ve bilerek yapılmış gibi okunur.</li>
+      <li><strong>0,5 sn ve üstü</strong> &mdash; bir slayt gösterisi. Her resme
+      canlandırılıyor değil bakılıyordur.</li>
+    </ul>
+    <p>
+      0,02 sn'nin altındaki hiçbir şey sunulmuyor; çünkü var olan her tarayıcıda
+      sessizce 0,1 sn'ye dönüşecek bir sayıdır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Palet ve gerçekte neyi seçtiği</h2>
+    <p>
+      Bir GIF karesi en fazla 256 renk tutar. Bir fotoğrafta on binlerce renk
+      vardır. Birinin bunların 256'sını seçmesi gerekir ve o seçim, çıktının nasıl
+      göründüğüdür &mdash; başka her ayardan çok.
+    </p>
+    <p>
+      Araç bunu yapmanın iki yolunu sunar:
+    </p>
+    <p>
+      <strong>Her kare için en iyi renkler</strong>, her resme kendi 256'sını verir.
+      En keskin görünen budur ve her biri zaten tamamen farklı bir küme isteyen,
+      birbiriyle ilgisiz fotoğraflardan oluşan bir set için doğrudur.
+    </p>
+    <p>
+      <strong>Bütün GIF için tek palet</strong>, tüm karelerden aynı anda tek bir
+      tablo kurar. Kareler bir <em>dizi</em> olduğunda kullanın &mdash; aynı sahne,
+      birkaç an arayla. Kare başına paletle, resimdeki herhangi bir değişiklik hangi
+      256 rengin seçildiğini değiştirir ve arka planın tamamı her karede hafifçe
+      renk kaydırır. Ev yapımı bir GIF'i ev yapımı gösteren şey o titreşimdir.
+      Paylaşılan bir palet onu kaldırır ve üstüne daha küçük bir dosya yapar; çünkü
+      tablo her karede değil bir kez yazılır.
+    </p>
+    <p>
+      Daha az renk &mdash; 128, 64, 32 &mdash; düz olan her şeyde denemeye değer.
+      İçinde sekiz renk olan bir logo canlandırması 32'de hiçbir şey kaybetmez ve
+      farkı bir fotoğrafta anında görürsünüz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Saydamlık tek bittir ve hikâyenin tamamı budur</h2>
+    <p>
+      Bir GIF pikseli ya tam boyalıdır ya da tamamen görünmezdir. Arası yoktur: %50
+      gölge yok, yumuşak kenar yok, geçiş yok.
+    </p>
+    <p>
+      Yani kaynak görsellerinizde saydamlık varsa onu açmak saydam alanları saydam
+      tutar &mdash; ama şekilden hiçliğe bir geçiş olan her kenar yumuşatması, tam
+      ortadan kesilerek sert ve gözle görülür biçimde tırtıklı bir kenara dönüşür.
+      En çok yuvarlak şekiller ve metin zarar görür.
+    </p>
+    <p>
+      GIF'in hangi rengin üstünde duracağını biliyorsanız onu o renge düzleştirmek
+      her seferinde daha iyi görünecektir. Saydamlığı yalnızca üstüne düşeceği arka
+      plan gerçekten bilinmiyorsa koruyun &mdash; ve cevap "her arka planda yumuşak
+      bir kenara ihtiyacı var" ise bunun biçimi GIF değil, hareketli PNG ya da
+      WebP'dir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sıra, zamanlama ve döngünün yerine oturması</h2>
+    <p>
+      Keşfetmekten daha hızlı öğrenilebilecek birkaç şey:
+    </p>
+    <p>
+      <strong>Ada göre sıralama düzgün sayar.</strong> Bir render ya da dışa
+      aktarma dizisi kastettiğiniz gibi sıralanır; yani <code>frame_2</code>,
+      <code>frame_10</code>'dan sonra değil önce düşer. Tarihe göre sıralamak bir
+      kamera rulosunu çekildiği sıraya geri koyar ki dosya adları 0001'den yeniden
+      başlamışsa istediğiniz de budur.
+    </p>
+    <p>
+      <strong>Son kareye daha uzun süre verin.</strong> Her karesi aynı uzunlukta
+      olan bir döngü amansız okunur. Son kareyi yarım saniye kadar tutmak göze
+      dinlenecek bir yer verir ve bütün işi kasıtlı gösterir. Bunun için her karenin
+      kendi tutma süresi var.
+    </p>
+    <p>
+      <strong>Bir döngü sıçramamalı.</strong> Son kareden hemen sonra ilki gelir;
+      yani bu ikisi çok farklıysa döngü şak diye kopar. Ya onları birbirine
+      benzetin ya da son kareyi tutarak kesmeyi bilerek kullanın.
+    </p>
+    <p>
+      <strong>Bir kez oynat, bir kez oynat demektir.</strong> Bazı araçlar bir
+      döngü sayısı olarak bir yazar; çözücüler bu konuda hiçbir zaman tam
+      anlaşamamıştır &mdash; birkaçı iki kez oynatır. Burada "Bir kez oynat"ı
+      seçmek hiçbir döngü bilgisi yazmaz ki şimdiye kadar kurulmuş her çözücü buna
+      aynı şekilde davranır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir sunucuya ihtiyacı yok</h2>
+    <p>
+      Bir GIF yapmak, tarayıcının sunmadığı iki iştir: paleti seçmek ve pikselleri
+      LZW ile sıkıştırmak. İkisi de büyük değildir. İkisi birlikte belki dört yüz
+      satırdır, depoda yazılıdır ve buradaki her şey gibi kendi makinenizde çalışır
+      &mdash; sayfanın ağ fişi çekilmişken çalışmaya devam etmesinin sebebi de
+      budur.
+    </p>
+    <p>
+      Bu kadar çok GIF yapıcısının yükleme yapmasının sebebi işin zor olması
+      değildir. Reklamın ve hesapların bulunduğu yerin sunucu olmasıdır. Bir
+      fotoğraf setini bir canlandırmaya çevirmenin, fotoğraflarınızın bulundukları
+      odadan ayrılmasını gerektiren bir yanı yoktur.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> size bu araç dâhil herhangi bir araç hakkında aynı
+      şeyi söyleyecek dört denetim anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/make-a-gif-from-images.toml
+++ b/locales/tr/pages/guides/make-a-gif-from-images.toml
@@ -1,0 +1,16 @@
+#
+# Rehber: bir resim setinden GIF yapmak - Türkçe.
+#
+
+nav = "Resimlerden GIF"
+title = "Görsellerden Nasıl Hareketli GIF Yapılır"
+description = "Bir resim setini tek bir hareketli GIF'e çevirin: bir GIF gerçekte ne kadar hızlı oynayabilir, palet ayarı neyi değiştirir ve dosyayı gerçekten küçülten üç şey."
+heading = "Görsellerden nasıl hareketli GIF yapılır"
+lede = """
+    GIF'i yapmak kolay kısım. Okumaya değen kısım, gerçekten paylaşılabilecek
+    kadar küçük bir tane elde etmektir; çünkü bir GIF'in kalite kaydırağı yoktur
+    ve boyutunu oynatan yalnızca üç şey vardır."""
+updated = "20 Ağustos 2026"
+og_title = "Görsellerden nasıl hareketli GIF yapılır"
+og_description = "Bir GIF gerçekte ne kadar hızlı oynayabilir, palet ayarı neyi değiştirir ve dosyayı gerçekten küçülten üç şey."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/make-a-passport-photo.html
+++ b/locales/tr/pages/guides/make-a-passport-photo.html
@@ -1,0 +1,241 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      Düz ve eşit aydınlatılmış bir duvardan bir buçuk metre uzakta durun &mdash;
+      duvara yaslanarak değil. Telefonu bir başkası göz hizanızda tutsun ve resmi
+      çeksin. Ön kamerayı kol boyu mesafede kullanmayın. Sonra
+      <a href="../../biyometrik-vesikalik-fotograf/">Vesikalık Fotoğraf
+      Yapıcı</a>'yı açın ve ülkenizle belgenizi seçin. Araç, resmi ölçerek
+      tepenize, çenenize ve iki göz bebeğinize dört nokta koyar ve dördünden
+      hangisini ölçemediğini söyler; yanlış düşenleri sürükleyin, sonra
+      <em>Kutuyu oturt</em>'a basın.
+    </p>
+    <p>
+      Aşağıdaki her şey, bu cümlelerin her birinin neden orada olduğu ve sayılar
+      yine de yanlış çıktığında ne yapacağınızla ilgili.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gerçekte ne ölçülüyor</h2>
+    <p>
+      Dünyadaki her vesikalık fotoğraf standardı tek bir belgenin bir çeşitlemesidir:
+      ICAO Doc 9303; bir pasaportu bir sınırda makinede okunabilir kılan da odur.
+      Resimle ilgili iki şeyi kısıtlar ve bunlar insanların beklediği iki şey
+      değildir.
+    </p>
+    <ul>
+      <li>
+        <strong>Başınızın kareyi ne kadar doldurduğu</strong>; çenenin altından
+        başın tepesine kadar ölçülür &mdash; saç çizginizin değil
+        <em>saçınızın</em> tepesi. Genellikle fotoğrafın yüksekliğinin yüzde 70 ila
+        80'i.
+      </li>
+      <li>
+        <strong>Gözlerinizin nerede durduğu</strong>; alt kenardan yukarı doğru
+        ölçülür. Genellikle yolun yarısı ile beşte üçü arasında.
+      </li>
+    </ul>
+    <p>
+      Baskı boyutu &mdash; dünyanın büyük kısmında 35&nbsp;&times;&nbsp;45 mm,
+      Amerika Birleşik Devletleri ve Hindistan'da 2&nbsp;&times;&nbsp;2 inç,
+      Kanada'da 50&nbsp;&times;&nbsp;70 mm &mdash; kolay kısımdır ve çoğu aracın
+      doğru yapıp orada durduğu kısımdır. Şekli doğru, baş yüksekliğini yanlış
+      yapmak, gayet iyi görünen ve reddedilen bir fotoğraf üretir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Herkesin yanlış yaptığı ölçü baş yüksekliğidir</h2>
+    <p>
+      İki sebebi var ve zıt yönlere çekiyorlar.
+    </p>
+    <p>
+      <strong>Özçekim sorunu.</strong> Bir kol yaklaşık altmış santimetredir. Bu
+      kadar yakın bir mercek hem yüzü bozar &mdash; burun büyür, kulaklar küçülür
+      &mdash; hem de kareyi başla doldurur; yani başınızın tamamını içeren kırpmanın
+      etrafında neredeyse hiç yer kalmaz. Bazı ülkeler yalnızca bu bozulma yüzünden
+      reddeder. Telefonu bir buçuk metre uzakta bir başkasına tutturmak ve sonradan
+      kırpmak ikisini birden çözer.
+    </p>
+    <p>
+      <strong>Saç çizgisi sorunu.</strong> &ldquo;Tepe&rdquo;, saçınız olduğu
+      hâliyle başınızın en üst noktası demektir. İnsanlar o noktayı saç çizgilerine
+      indiriyor; bu da ölçülen başı gerçek başından kısa yapıyor, o da her kırpmanın
+      başı fazla küçük çıkarmasına yol açıyor. Uzun ya da hacimli saçınız varsa tepe
+      onun en üstüdür.
+    </p>
+    <p>
+      Ayrıca iki bant her yerde aynı değildir; bunu daha önce yapmış olanları
+      yakalayan kısım da budur. Birleşik Krallık, 45 mm'lik bir karede 29 ila 34 mm
+      ister. Almanya ve Schengen vizesi aynı karede 32 ila 36 mm ister. Alman
+      kuralına göre kırpılmış bir fotoğraf, İngiliz kuralının en tepesinde ya da
+      üstündedir ve bir Schengen vizesinden geçen bir fotoğraf Durham'dan geri
+      gelebilir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Fotoğrafları asıl reddettiren şey arka plandır</h2>
+    <p>
+      İçinde kitaplık olan bir fotoğrafı neredeyse kimse göndermez. Ama devasa
+      sayıda insan, beyaz bir duvara otuz santim mesafede çekilmiş ve duvarda kendi
+      başının yumuşak gri gölgesi olan bir fotoğraf gönderiyor. &ldquo;Düz beyaz arka
+      plan&rdquo;, boya hakkında bir cümle değildir. Gölgeler hakkında bir
+      cümledir.
+    </p>
+    <p>
+      Neredeyse hepsini üç şey düzeltir:
+    </p>
+    <ul>
+      <li>
+        <strong>Duvardan uzakta durun.</strong> Bir metre fazlasıyla yeter. Bir
+        gölgenin düşeceği bir yer gerekir ve bir metrede resmin içine değil,
+        arkanızdaki zemine düşer.
+      </li>
+      <li>
+        <strong>Işığa dönün.</strong> Bir pencere önünüzde olsun; arkanızda ya da
+        yanınızda değil. Yan ışık arka planın bir yarısını diğerinden koyu yapar ki
+        bu, rengin yanlış olmasından ayrı bir çuvallamadır ve başka bir çözümü
+        vardır.
+      </li>
+      <li>
+        <strong>Flaş kullanmayın.</strong> Başınızın arkasında bir parlama noktası
+        ve etrafında sert bir gölge üretir ki denetlenen şey tam olarak budur.
+      </li>
+    </ul>
+    <p>
+      ICAO'nun tercihinin beyaz değil açık gri olduğunu unutmayın. Açık tenli bir
+      yüzü de koyu saçı da arka plandan ayırır; saf beyaz ikisini de yapmaz. Birkaç
+      ülke &ldquo;beyaz ya da kırık beyaz&rdquo; diyor ve &ldquo;düz ve eşit&rdquo;
+      demek istiyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>İnsan bir denetçinin baktığı şeyler</h2>
+    <p>
+      Hiçbir araç bunları ölçemez; bu yüzden kendilerine ait bir paragrafa
+      değerler. Ayrıca hep birlikte, bir fotoğrafın geri gönderilmesinin en yaygın
+      ikinci sebebidirler.
+    </p>
+    <ul>
+      <li><strong>Nötr bir ifade, ağız kapalı.</strong> Hafif bir gülümsemeyi
+        reddeden ülkeler, izin verenlerden çoktur.</li>
+      <li><strong>İki göz de açık ve net görünür</strong>, üzerlerinde hiçbir şey
+        olmadan &mdash; saç yok, kalın çerçeve yok, parlama yok. Birkaç ülke artık
+        gözlüğe hiç izin vermiyor.</li>
+      <li><strong>Doğrudan kameraya bakmak</strong>, baş düz ve tam karşıda. Birkaç
+        dereceden fazla eğilmiş bir baş, bir denetçinin gözünden kaçmaz; kendi
+        fotoğrafına bakan neredeyse hiç kimsenin ise gözüne çarpmaz.</li>
+      <li><strong>Yüzü örten hiçbir şey olmamalı.</strong> Dinî sebeplerle takılan
+        baş örtülerine, yüz çenenin altından alnın üstüne kadar açık olmak koşuluyla
+        hemen her yerde izin verilir.</li>
+      <li><strong>Sade kıyafet, beyaz değil.</strong> Beyaz arka plan üzerinde beyaz,
+        sizi havada süzülen bir kafa gibi gösterir ve bazı ofisler bu yüzden
+        reddeder.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Baskı boyutu, DPI ve bir dosyanın neden yanlış boyutta basılabildiği</h2>
+    <p>
+      Sayısal bir resmin, bir şey piksellerinin kaçının bir inçe gireceğine karar
+      verene kadar fiziksel bir boyutu yoktur. O sayı dosyanın içinde durur &mdash;
+      ve bir web tarayıcısı bir JPEG yazdığında o alanı &ldquo;bu bir en boy
+      oranıdır, çözünürlük değil&rdquo; olarak yazar. Yani dosya ne kadar büyük
+      olduğu hakkında hiçbir şey söylemez ve onu basan şey tahmin eder.
+    </p>
+    <p>
+      Tam olarak doğru piksel sayısında olan bir fotoğrafın yine de matbaadan yanlış
+      boyutta çıkabilmesinin sebebi budur. 413&nbsp;&times;&nbsp;531 piksel
+      <em>gerçekten</em> 35&nbsp;&times;&nbsp;45 mm'dir, ama yalnızca 300 dpi'da ve
+      yalnızca dosya bunu söylüyorsa. Kullanmaya değer her araç bunu yazar;
+      Vesikalık Fotoğraf Yapıcı o birkaç baytı, resmi hiç çözmeden doğrudan yeniden
+      yazar.
+    </p>
+    <p>
+      300 dpi, hemen her belirtimin belirttiği tabandır. 600 ise iyi bir fotoğraf
+      laboratuvarının kullanacağıdır ve dosya boyutundan başka hiçbir şeye mal
+      olmaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tabanı da olan dosya boyutu kuralları</h2>
+    <p>
+      Çevrimiçi formlar, insanları şaşırtan bir biçimde kâğıt olanlardan katıdır:
+      birkaçı azami boyutun yanı sıra <em>asgari</em> bir dosya boyutu da dayatır.
+    </p>
+    <ul>
+      <li>Hint sınav portalları (SSC, UPSC ve gerisi): tam olarak
+        200&nbsp;&times;&nbsp;230 piksellik bir fotoğraf, JPEG,
+        <strong>20 ila 50 KB</strong>; ve 140&nbsp;&times;&nbsp;60 piksellik bir
+        imza, <strong>10 ila 20 KB</strong>.</li>
+      <li>Çin vize yüklemesi: 354&nbsp;&times;&nbsp;472 piksel, 40 ila 120 KB.</li>
+      <li>Birleşik Krallık pasaport yüklemesi: en az
+        600&nbsp;&times;&nbsp;750 piksel ve en az 50 KB.</li>
+    </ul>
+    <p>
+      Tabanın sebebi makuldür &mdash; onun altındaki bir dosya genellikle birinin
+      yanlışlıkla yüklediği bir küçük resimdir &mdash; ve sonucu can sıkıcıdır. Bir
+      200&nbsp;&times;&nbsp;230 fotoğrafı 46.000 pikseldir. Bir tarayıcının
+      yazacağı en iyi kalitede bile 15 KB'ye düşebilir ve daha az sıkıştırarak onu
+      büyütmenin bir yolu yoktur; çünkü daha azı yoktur.
+    </p>
+    <p>
+      Dürüst çözüm dolgudur: bir JPEG bir yorum bölümü taşıyabilir, her çözücü onu
+      atlar ve bir tane eklemek, resmin tek bir pikselini bile değiştirmeden dosyayı
+      uzatır. Aracın yaptığı budur ve dolgunun içine bunu söyleyen İngilizce bir
+      cümle yazar. Bunun yerine tabanı fotoğrafınızı <em>büyüterek</em> tutturan
+      her şeye dikkat edin &mdash; o, bir sayıyı tutturmak için atılmış gerçek
+      kalitedir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ucuza kendiniz basmak</h2>
+    <p>
+      Bir kabin altı fotoğraf için epeyce para alır. Herhangi bir fotoğraf tezgâhı
+      bir 6&nbsp;&times;&nbsp;4'ü kuruşa basar ve bir 6&nbsp;&times;&nbsp;4, makasa
+      da yer bırakarak sekiz tane 35&nbsp;&times;&nbsp;45 mm fotoğraf tutar.
+    </p>
+    <p>
+      Gönderirken doğru yapılacak iki şey:
+    </p>
+    <ul>
+      <li>
+        <strong>Yüzde 100'de basın.</strong> &ldquo;Sayfaya sığdır&rdquo;,
+        &ldquo;ölçekleyerek sığdır&rdquo; ve &ldquo;kenarlıksız&rdquo;, hepsi
+        sayfayı hafifçe yeniden boyutlandırır ve yüzde iki yeniden boyutlandırılmış
+        bir sayfa, hepsi yanlış boyutta sekiz fotoğraf demektir.
+      </li>
+      <li>
+        <strong>Bir çizgi boyunca değil, işaretlerin arasından kesin.</strong>
+        Kırpma işaretleri resimlerin üstünde değil aralarındaki boşluklarda durur;
+        bu hem doğru kesmeyi kolaylaştırır hem de sonradan kırpılacak mürekkep
+        bırakmaz.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin neden bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Yukarıdaki her adım, kendi makinenizin zaten çözmüş olduğu bir resim üzerinde
+      bir aritmetiktir: bir kırpma dikdörtgeni, bir ölçek, bir renk ortalaması, bir
+      JPEG kodlaması ve bir başlıkta bir avuç bayt. İçinde bir sunucunun yapıp bir
+      tarayıcının yapamayacağı hiçbir şey yoktur.
+    </p>
+    <p>
+      Dosyanın ne olduğu düşünülünce burada durup düşünmeye değer. Bir vesikalık
+      fotoğraf, yüzünüzün resmidir ve bir tanesini bir web sitesine yüklemek, o
+      siteye yüzünüzü, belgesine başvurduğunuz ülkeyi ve kabaca ne zaman
+      başvurduğunuzu söyler. Yükleme isteyen fotoğraf araçları genellikle bir hesap
+      da ister ve bu birleşim, tam olarak bunun bir veritabanıdır. Bunun var olması
+      için teknik bir sebep yoktur.
+      <a href="../dosya-yuklemek-guvenli-mi/">Bir aracın dosyalarınıza gerçekten
+      ihtiyacı olup olmadığını nasıl anlarsınız</a> sayfası, ihtiyacı olanları
+      olmayanlardan ayıran dört denetimi anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/make-a-passport-photo.toml
+++ b/locales/tr/pages/guides/make-a-passport-photo.toml
@@ -1,0 +1,18 @@
+#
+# Rehber: geri çevrilmeyen bir vesikalık fotoğraf - Türkçe.
+#
+
+nav = "Vesikalık fotoğraf çekme"
+title = "Evde Nasıl Vesikalık Fotoğraf Çekilir (ve Geri Çevrilmez)"
+description = "Bir vesikalık fotoğrafta gerçekte neyin ölçüldüğü - baş yüksekliği, göz hattı, arka plan - hangi ülkenin hangi sayıları istediği ve çevrimiçi bir formun dayattığı piksel ve KB sınırlarının nasıl tutturulacağı."
+heading = "Geri çevrilmeyen bir vesikalık fotoğraf nasıl çekilir"
+lede = """
+    Bir vesikalık fotoğraf, yüzünüzün belirli bir boyuttaki resmi değildir. Bir
+    ölçümler kümesidir ve çuvallayanlar neredeyse hiçbir zaman insanların
+    endişelendiği ölçümler olmaz. Bu rehber gerçekte neyin ölçüldüğünü, hangi
+    ülkenin hangi rakamları istediğini ve bir dosyayı fazla küçük diye reddeden
+    formlar hakkında ne yapacağınızı anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Geri çevrilmeyen bir vesikalık fotoğraf nasıl çekilir"
+og_description = "Baş yüksekliği, göz hattı, arka plan ve dosya boyutu - bir pasaport ofisinin neyi ölçtüğü ve bunu bir telefon ile düz bir duvarla nasıl tutturacağınız."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/make-a-pdf-smaller.html
+++ b/locales/tr/pages/guides/make-a-pdf-smaller.html
@@ -1,0 +1,224 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../pdf-sikistirma/">PDF Sıkıştırıcı</a>'yı açın, belgeyi bırakın
+      ve bir şey değiştirmeden önce size ne söylediğine bakın. Dosyayı okur ve
+      boyutun gerçekte nerede olduğunu gösterir &mdash; görseller, yazı tipleri,
+      metin ve çizim ve artık belgede hiçbir şeyin göstermediği her şey. O tek
+      ekran genellikle soruyu cevaplar.
+    </p>
+    <p>
+      Boyutun çoğu görsellerse büyük bir kazanç bekleyebilirsiniz. Yazı tipleri ve
+      metinse bekleyemezsiniz ve hiçbir araç bunu yapamaz. Hangisine sahip
+      olduğunuz hikâyenin tamamıdır ve bakmak için on saniyeye değer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir PDF'in boyutu gerçekte nerede</h2>
+    <p>
+      Bir PDF, birkaç farklı tür şey için bir kaptır ve bunlar aynı şekilde
+      sıkışmaz.
+    </p>
+    <ul>
+      <li>
+        <strong>Görseller.</strong> Fotoğraflar ve taramalar. Büyük bir PDF'in
+        neredeyse her zaman büyük kısmı ve içinde gerçek yer olan tek kısım.
+      </li>
+      <li>
+        <strong>Gömülü yazı tipleri.</strong> Tam bir yazı tipi yüzlerce kilobayt
+        olabilir; yalnızca kullanılan karakterlerden oluşan bir alt küme çok daha
+        azdır. Her hâlükârda, dosyayı üreten şey tarafından çoktan
+        sıkıştırılmışlardır.
+      </li>
+      <li>
+        <strong>Metin ve vektör çizim.</strong> Piksel değil talimat: şu çizgiyi
+        çiz, şu kelimeyi buraya koy. Zaten derli toplu ve zaten sıkıştırılmış.
+      </li>
+      <li>
+        <strong>Artık hiçbir şeyin göstermediği nesneler.</strong> PDF'ler bunları
+        biriktirir. Bir belgeyi düzenlemek, dosyayı yeniden yazmak yerine
+        değişikliği çoğu zaman sonuna ekler; yani bir sayfanın eski bir sürümü
+        orada süresiz oturabilir. Dosyayı yeniden paketlemek onları düşürür.
+      </li>
+    </ul>
+    <p>
+      Yani insanların bir PDF sıkıştırıcısına getirdiği iki belgenin beklentileri
+      tamamen farklıdır. Taranmış bir belge esasen bir fotoğraf yığınıdır ve
+      alışıldık biçimde %60&ndash;90 küçülür. Bir sözleşme, bir tez ya da dışa
+      aktarılmış bir rapor ise metin, çizim ve yazı tipleridir &mdash; hepsi onu
+      yazan yazılım tarafından çoktan sıkıştırılmıştır &mdash; ve oradaki kazanç
+      genellikle yeniden paketlemekten ve gösterilmeyeni düşürmekten gelen yüzde
+      birkaçtır.
+    </p>
+    <p>
+      Dosyanıza bakmadan &ldquo;%90'a varan küçülme&rdquo; vadeden her araç,
+      birinci türün en iyi durumunu ikinci tür için sunuyordur.
+    </p>
+  </section>
+
+  <section>
+    <h2>DPI'ın bununla ne ilgisi var</h2>
+    <p>
+      Bir PDF yalnızca bir resim tutmaz; o resmin sayfada ne kadar büyük
+      çizildiğini de kaydeder. Bu size piksel sayısından daha yararlı bir şey verir:
+      etkin çözünürlük.
+    </p>
+    <p>
+      Sekiz inç kâğıda yerleştirilmiş 4000 piksel genişliğinde bir tarama, inç
+      başına 500 piksel taşıyor demektir. Bir ekran yaklaşık 100 gösterir. İyi bir
+      ofis yazıcısı 300'de çalışır ve çok daha fazlasını kullanamaz. Bunun
+      üstündeki her şey, belgenin geleceğinde hiçbir şeyin göstermeyeceği bir
+      ayrıntıdır &mdash; ve genellikle dosyanın büyük kısmıdır.
+    </p>
+    <p>
+      Aklı başında bir PDF sıkıştırıcısının bir kalite yüzdesi yerine bir DPI
+      istemesinin sebebi budur. Önce rakamınızın üstündeki pikselleri atar; çünkü
+      onlar kimsenin görebileceği hiçbir şeye mal olmaz ve ancak ondan sonra gerçek
+      kalite harcamaya başlar.
+    </p>
+    <p>
+      Kaba kılavuz: ekranda okunacak bir belge için <strong>150 DPI</strong>,
+      basılacak bir şey için <strong>200&ndash;300</strong>, kimsenin saklamayacağı
+      bir taslak için <strong>72&ndash;100</strong>. Görselin ne kadar büyük
+      çizildiğine karşı ölçmek, küçük yerleştirilmiş bir logonun tam sayfa bir
+      taramayla aynı muameleyi görmemesinin de sebebidir &mdash; logo zaten etkin
+      çözünürlüğüne yakındır ve alınacak bir şey yoktur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sıkıştırmanın neye dokunması ve neye dokunmaması gerekir</h2>
+    <p>
+      Resimler yeniden kodlanır, yani onlar bir parça kaybeder. Başka hiçbir şeye
+      dokunulmamalıdır ve kullandığınız aracın buna uyup uymadığını denetlemeye
+      değer:
+    </p>
+    <ul>
+      <li>
+        <strong>Metin metin kalır.</strong> Seçilebilir, aranabilir, kopyalanabilir.
+        Sayfaları görsele düzleştiren bir sıkıştırıcı çok küçük bir dosya üretir ve
+        belgeyi mahveder &mdash; onu arayamazsınız, ekran okuyucular okuyamaz ve
+        bu asla geri alınamaz.
+      </li>
+      <li>
+        <strong>Yazı tipleri bütün kalır.</strong> Yazı tipi değiştirmek belgenin
+        bir başkasının makinesinde nasıl göründüğünü değiştirir ki PDF'in var olma
+        sebebi tam olarak bunu engellemektir.
+      </li>
+      <li>
+        <strong>Vektör çizim olduğu gibi kopyalanır.</strong> Zaten küçüktür ve onu
+        piksele çevirmek hem büyütür hem kötüleştirir.
+      </li>
+      <li>
+        <strong>Formlar, bağlantılar, yer imleri, erişilebilirlik yapısı ve
+        ekler karşıya taşınır.</strong> Bunlar bir yeniden yazımda kolayca
+        kaybedilir ve biri birine ihtiyaç duyana kadar nadiren fark edilir.
+      </li>
+    </ul>
+    <p>
+      Bir sıkıştırıcının uyması gereken ve çoğunun uymadığı ilgili bir kural: bir
+      görseli yeniden kodlamak gerçekten özgününden küçük çıkmıyorsa özgün baytları
+      geri koyun. Bir resmi hiçbir kazanç olmadan kötüleştirmek saf kayıp
+      durumudur ve zaten iyi sıkıştırılmış görsellerde sandığınızdan sık olur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sıkıştırılamayan resimler</h2>
+    <p>
+      Bir PDF'in içindeki bazı görseller atlanır ve iyi bir araç onları sessizce
+      hesabın dışında bırakmak yerine adlarını verir:
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG&nbsp;2000, JBIG2 ve faks kodlu (CCITT) görseller.</strong>
+        Hiçbir tarayıcı bunların hiçbiri için bir çözücüyle gelmez, yani el
+        değdirilmeden geçirilirler. Son ikisi iki düzeylidir &mdash; yalnızca siyah
+        ve beyaz &mdash; ve genellikle zaten en küçük hâllerine yakındır.
+      </li>
+      <li>
+        <strong>CMYK görseller.</strong> Bilerek el sürülmez. Onları yeniden
+        kodlamak, bir yazıcının üreteceği renkleri kaydırma riski taşır ki bu,
+        birinin basacağı bir belgeye yapılacak şaşırtıcı bir şeydir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Sıkıştırmadan önce denenecek şeyler</h2>
+    <p>
+      Bazen dosya, sıkıştırmanın yanlış cevap olduğu bir sebeple büyüktür.
+    </p>
+    <p>
+      <strong>Gerek yokken mi tarandı?</strong> Basılıp sonra taranmış bir belge,
+      metnin fotoğraf yığınıdır. Özgün belge bir yerde hâlâ belge olarak duruyorsa,
+      onu PDF'e aktarmak boyutun çok küçük bir kesri kadar ve üstelik aranabilir bir
+      dosya üretir.
+    </p>
+    <p>
+      <strong>Baskı ayarlarıyla mı dışa aktarıldı?</strong> Kelime işlemciler ve
+      tasarım yazılımları çoğu zaman varsayılan olarak baskı kalitesinde dışa
+      aktarır. Kaynak dosyadan ekran için yeniden dışa aktarmak, genellikle dışa
+      aktarılmışı sıkıştırmayı yener.
+    </p>
+    <p>
+      <strong>Tek dosya olmak zorunda mı?</strong> Bir e-posta sınırı ileti
+      başınadır. 200 sayfalık bir belgeyi bölümlere ayırmak bazen dürüst
+      çözümdür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Şifreli dosyalar ve bir sıkıştırıcının onları neden reddetmesi gerekir</h2>
+    <p>
+      Parola korumalı bir PDF buradaki araç tarafından reddedilir ve bu, eksik bir
+      özellik değil bilinçli bir tercihtir &mdash; parola boş olduğunda da; ki
+      birçok tarayıcı ve fotokopi makinesi böyle kaydeder.
+    </p>
+    <p>
+      Bir belgeden korumayı kaldırmak, onu sıkıştırmaktan başka bir iştir. Bunu
+      sessizce yapan bir araç, birinin bilerek kilitlediği bir dosyaya istemediğiniz
+      bir şeyi yapmış ve size, onun sahip olmasını istediği özelliği artık taşımayan
+      bir kopya vermiş olurdu. İstediğiniz buysa korumayı önce, bilerek kendiniz
+      kaldırın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sonucu denetlemek</h2>
+    <p>
+      Açın. Resimlere tam yakınlaştırmada bakın, metnin hâlâ seçilebilir olduğunu
+      denetleyin ve sayfa sayısını doğrulayın.
+    </p>
+    <p>
+      Buradaki araç bunların sonuncusunu dosyayı size sunmadan önce sizin yerinize
+      yapıyor: az önce yazdığı belgeyi yeniden açıyor ve sayfaları kendi
+      makinenizde sayıyor. Ayrıca 2003'ten beri çıkmış her okuyucunun anladığı PDF
+      1.5 yazıyor; yani &ldquo;benim makinemde açılıyor&rdquo;, &ldquo;onlarınkinde
+      de açılır&rdquo; için makul bir göstergedir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir sunucuya ihtiyacı yok</h2>
+    <p>
+      Bir PDF'i sıkıştırmak sunucu işi gibi geliyor ve webin ömrünün büyük kısmında
+      öyleydi. Gerçekte içerdiği şey, dosya yapısını ayrıştırmak, görsel akışlarını
+      bulmak, onları bir tarayıcının zaten beraberinde getirdiği kodlayıcılarla
+      çözüp yeniden kodlamak ve belgeyi geri yazmaktır. Bunların hepsi artık bir
+      tarayıcıda çalışıyor.
+    </p>
+    <p>
+      İnsanların ne sıkıştırdığı düşünülünce bu, çoğu dosya türünden çok bu tür için
+      önemlidir: sözleşmeler, sağlık raporları, banka hesap özetleri, kimlik
+      belgeleri, vergi beyannameleri. Buradaki aracın hiç ağ özelliği yoktur ve
+      sayfanın <code>Content-Security-Policy</code>'si iletişim kurabileceği her
+      adresi tek tek sayar; bunların hiçbiri bu siteye ait değildir. Yükleyin, fişi
+      çekin ve yine de bir şey sıkıştırın.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> buna benzer üç denetim daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/tr/pages/guides/make-a-pdf-smaller.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir PDF'i küçültmek - Türkçe.
+#
+
+nav = "PDF boyutunu küçültme"
+title = "Bir PDF Nasıl Küçültülür (ve Bazıları Neden Küçülmez)"
+description = "Bir PDF'in boyutunun gerçekte nerede olduğu, bir taramanın neden %80 sıkıştığı ama bir sözleşmenin neredeyse hiç kıpırdamadığı, burada DPI'ın ne anlama geldiği ve bir sıkıştırıcının belgenize asla yapmaması gerekenler."
+heading = "Bir PDF nasıl küçültülür ve bazıları neden küçülmez"
+lede = """
+    Bir e-posta sınırına sığmayan bir PDF, neredeyse her zaman resim dolu bir
+    PDF'tir. Bu rehber sizinkinin öyle olup olmadığını nasıl anlayacağınızı,
+    sıkıştırmanın neye mal olduğunu ve sabit bir yüzde vadeden her aracın neden
+    dosyanıza bakmamış olduğunu anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir PDF nasıl küçültülür"
+og_description = "Bir PDF'in boyutunun gerçekte nerede olduğu, bir taramanın neden küçüldüğü ama bir sözleşmenin küçülmediği ve DPI'ın bununla ne ilgisi olduğu."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/make-a-qr-code.html
+++ b/locales/tr/pages/guides/make-a-qr-code.html
@@ -1,0 +1,255 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../qr-kod-olusturma/">QR ve Barkod Üreteci</a>'ni açın,
+      bağlantınızı yapıştırın, düzeyi <strong>M</strong>'de ve kenar boşluğunu
+      <strong>4</strong>'te bırakın ve SVG'yi indirin. En az iki santimetre
+      genişliğinde, mat bir şeye, açık üzerine koyu basın. Sonra bin tane
+      sipariş etmeden önce basılı olanı sizinki olmayan bir telefonla okutun.
+    </p>
+    <p>
+      Bu, neredeyse her durumu kapsar. Bu sayfanın geri kalanı, durum bunlardan
+      biri olmadığında ne yapacağınızdır: elden ele geçmeye dayanması gereken bir
+      kod, üzerinde logo olan bir kod, küçük bir şeye gidecek bir kod ve bir yıl
+      sonra öğreneceğiniz biçimde yanlış yapılması kolay olan tek karar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir QR kodun içinde gerçekte ne var</h2>
+    <p>
+      Bir dizge. Tamamı bu. Bir QR kodu okutmak telefona bir metin parçası verir ve
+      geri kalan her şey &mdash; bir sayfa açmak, bir ağa katılmak, bir kişiyi
+      kaydetmeyi önermek &mdash; telefonun o metnin şeklini tanıyıp ona göre işlem
+      önermesidir.
+    </p>
+    <p>
+      Yani bir kod türü olarak "Wi-Fi QR kodu" diye bir şey yoktur. İçinde
+      <code>WIFI:T:WPA;S:Ağım;P:parola;;</code> tutan bir QR kod vardır ve son on
+      yılda yapılmış her telefon bunu nasıl okuyacağını bilir. Üretecin size
+      bitmiş dizgeyi göstermesinin sebebi tam olarak budur: bir kod beklediğinizi
+      yapmadığında bakmaya değen tek şey dizgedir.
+    </p>
+    <p>
+      Bu aynı zamanda bir QR kodun basıldıktan sonra değiştirilemeyeceği, eve haber
+      veremeyeceği ve süresinin dolamayacağı anlamına gelir &mdash; biri içine
+      kendi sunucusuna giden bir bağlantı koymadıysa; ki buradaki son bölümün konusu
+      da odur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Birinci karar: hata düzeltme düzeyi</h2>
+    <p>
+      Bir QR kod, verinin yanında bir denetim kod kelimeleri kümesi taşır; bunlar
+      bir okuyucunun göremediğini yeniden kurabilmesi için hesaplanmıştır. Bir
+      köşesi kopmuş bir kodun hâlâ okunmasının sebebi budur. Bu kod kelimelerinin
+      kaç tane olduğu düzeydir ve dört tanedir:
+    </p>
+    <ul>
+      <li><strong>L</strong> &mdash; kodun yaklaşık %7'si kaybedilebilir.</li>
+      <li><strong>M</strong> &mdash; yaklaşık %15.</li>
+      <li><strong>Q</strong> &mdash; yaklaşık %25.</li>
+      <li><strong>H</strong> &mdash; yaklaşık %30.</li>
+    </ul>
+    <p>
+      Daha fazla düzeltme bedava değildir: denetim verisi aynı karenin içine girer,
+      yani aynı metin H'de L'dekinden daha büyük ve daha yoğun bir kod ister. Kabaca,
+      L'den H'ye geçmek aynı dizge için modül sayısını iki katına çıkarır ve daha
+      yoğun modülleri bir kameranın ayırt etmesi zorlaşır. Burada gerçek bir takas
+      vardır ve cevap kodun nereye gideceğine bağlıdır.
+    </p>
+    <p>
+      <strong>L</strong> bir ekran içindir: bir slayttaki, bir e-postadaki, bir web
+      sayfasındaki kod. Ona hiçbir şey zarar vermeyecektir ve her fazladan modül
+      uzaktan okunmasını zorlaştırır.
+    </p>
+    <p>
+      <strong>M</strong> varsayılandır ve çoğu baskı için doğru cevaptır. Biraz
+      elden geçecek kâğıt, bir broşür, bir kartvizit.
+    </p>
+    <p>
+      <strong>Q ve H</strong>, hırpalanacak kodlar içindir: her gün silinen bir menü,
+      bir atölyedeki makinenin üstündeki bir etiket, bir kasanın üstündeki bir etiket,
+      doğrudan güneş alan bir vitrindeki kod. H, aynı zamanda ortadaki bir logoyu
+      mümkün kılan şeydir &mdash; aşağıya bakın.
+    </p>
+  </section>
+
+  <section>
+    <h2>İkinci karar: kodun bir parçası olan kenar boşluğu</h2>
+    <p>
+      Bir QR kodun etrafındaki beyaz boşluk bir dolgu değildir ve bir tasarım tercihi
+      de değildir. Bir okuyucu, sembolün nerede bittiğini bulmak için onu kullanır.
+      Belirtim her kenarda dört modül sessiz alan ister ve kenarına kadar kırpılmış
+      bir kod, basılı bir kodun çuvallamasının en yaygın tek sebebidir.
+    </p>
+    <p>
+      Bu konuda açık sözlü olmaya değer; çünkü kırpmak son derece doğal bir
+      davranıştır. Kodun etrafında fazla beyaz varmış gibi görünür, o yüzden düzende
+      kırpılır ya da karelerin dibine kadar gelen renkli bir panelin üstüne konur ya
+      da bir fotoğrafın üstüne yerleştirilir. Bunların her biri, okuyucunun
+      kullanacağı sınırı ortadan kaldırır.
+    </p>
+    <p>
+      Kod kenar boşluğuyla birlikte fazla büyük görünüyorsa kodu küçültün. Kenar
+      boşluğunu kaldırmayın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Üçüncü karar: ne kadar büyük basılacağı</h2>
+    <p>
+      Gerçekle temastan sağ çıkmış kaba kural <strong>bire on</strong>'dur: bir
+      kodun, okunacağı mesafenin yaklaşık onda biri kadar geniş olması gerekir.
+    </p>
+    <ul>
+      <li>30 cm'den okunan bir kartvizit ya da menü: yaklaşık 2 cm.</li>
+      <li>İki metreden okunan bir afiş: yaklaşık 20 cm.</li>
+      <li>Beş metreden okunan bir otobüs durağı ya da vitrin: yaklaşık 50 cm.</li>
+    </ul>
+    <p>
+      İki santimetre bir hedef değil bir tabandır. Yaklaşık 1,5 cm'nin altında,
+      baskı ne kadar iyi olursa olsun sıradan bir telefon zorlanmaya başlar; çünkü
+      tek tek modüller kamerasındaki bir pikselin boyutuna yaklaşır.
+    </p>
+    <p>
+      Daha az metin, daha az modül, dolayısıyla belirli bir basılı boyut için
+      uzaktan okunan bir kod demektir &mdash; bir kodu, sonunda yüz karakterlik
+      izleme parametresi olan bir adres yerine <code>example.com/x</code>'e
+      yöneltmek için iyi bir sebep.
+    </p>
+    <p>
+      Ve <strong>SVG</strong>'den basın. Bir QR kod kenarlardan oluşur ve bir
+      PNG'nin onları oluşturacak sabit sayıda pikseli vardır; birini büyütün, her
+      kenar yumuşasın; ki bir okuyucunun zorlandığı şey tam olarak budur. Bir SVG
+      ise kareleri talimat olarak taşır, yani bir kartvizitte de bir bilbordda da
+      keskin çıkar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Renk, karşıtlık ve iki hata</h2>
+    <p>
+      Bir okuyucu koyu modüllerle açık olanlar arasındaki farkı ölçer, yani
+      karşıtlık işin tamamıdır. İki şey düzenli olarak ters gider:
+    </p>
+    <p>
+      <strong>Koyu arka plan üzerine açık kod.</strong> Çarpıcı görünür ve epeyce
+      okuyucu bunu düpedüz reddeder: koyu üzerine açık arıyorlardır ve tersini
+      denemezler. Bazıları dener. Müşterilerinizin hangisine sahip olduğunu
+      bilemezsiniz.
+    </p>
+    <p>
+      <strong>Yeterince fark olmaması.</strong> Beyaz üzerine orta gri ya da benzer
+      ağırlıkta iki marka rengi, ekranda gayet iyi ölçülebilir ve mürekkep yayılması
+      ile bir telefonun otomatik pozlaması işin içine girdiğinde kâğıtta
+      çuvallayabilir. Bir kodu renklendiriyorsanız koyu kısmı gerçekten koyu tutun.
+    </p>
+    <p>
+      Bir ışık altında okutulacak her şey için mat, parlağı yener ve ikisi de bir
+      fotoğrafın üstüne basmayı yener. Saydam arka planlar bir kodu renkli bir
+      panelin üstüne koymak için yararlıdır &mdash; ama arkasında gerçekte ne
+      kaldığını denetleyin; çünkü koyu bir panelin üstündeki saydam bir kod,
+      yukarıdaki ilk hatanın fazladan adımlarla yapılmış hâlidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ortadaki logo</h2>
+    <p>
+      Bu işe yarar ve hata düzeltmeye rağmen değil, onun sayesinde işe yarar. H
+      düzeyinde modüllerin kabaca %30'u yok edilebilir ve kod yine de okunur; yani
+      bundan azını kaplayan bir logo &mdash; ortada, hiçbir bulucu deseninin
+      olmadığı yerde &mdash; okuyucunun onardığı bir hasardır.
+    </p>
+    <p>
+      Uyulacak üç şey. H düzeyini kullanın. Logoyu alanın yaklaşık beşte birinin
+      altında, kuramsal sınırın epeyce berisinde tutun; çünkü payınızı yiyen tek şey
+      baskı değildir. Ve köşelerdeki üç büyük kareyi ya da yanlarındaki küçükleri
+      asla kapatmayın: bir okuyucunun sembolü en baştan bulup yönlendirme biçimi
+      onlardır ve hiçbir miktarda hata düzeltme onları yeniden kurmaz.
+    </p>
+    <p>
+      Sonra gerçek telefonlarda deneyin. Bir logo, kodu "her zaman çalışır"dan "bu
+      kadar payla çalışır"a taşır ve ne kadar pay kaldığını bilmenin tek yolu
+      denemektir.
+    </p>
+  </section>
+
+  <section>
+    <h2>İnsanların pişman olduğu karar: durağan mı, "dinamik" mi</h2>
+    <p>
+      Bir QR üreteci arayın; sonuçların çoğu sizden hesap açmanızı isteyecektir;
+      çünkü <em>dinamik</em> kod satıyorlar. Dinamik bir kod sizin bağlantınızı
+      içermez. Üretecin kendi sunucusuna giden kısa bir bağlantı içerir, o da
+      sizinkine yönlendirir.
+    </p>
+    <p>
+      Size kazandırdığı şey gerçektir: kodun basıldıktan sonra nereyi gösterdiğini
+      değiştirebilirsiniz ve her okutmanın sayısını alırsınız. Altı haneli bir baskı
+      adedi olan bir kampanya için buna para ödemeye değer.
+    </p>
+    <p>
+      Bedeli de gerçektir ve sonradan değil önceden bilmeye değer:
+    </p>
+    <ul>
+      <li>
+        <strong>Onlar durduğunda kod çalışmayı bırakır.</strong> Hizmet kapanırsa,
+        alan adının süresi dolarsa ya da ücretsiz kademe biterse bastığınız her kod
+        ölür &mdash; ve o zamana kadar on bin menünün üstündedirler.
+      </li>
+      <li>
+        <strong>Her okutma bir başkasının verisidir.</strong> Yönlendirme, kodunuzu
+        okutan herkesin IP adresini, zamanını ve cihazını görür.
+      </li>
+      <li>
+        <strong>Bağlantı sizin değil onlarındır.</strong> Okutan herkes tanımadığı
+        bir alan adının geçip gittiğini görür ki insanlara şüphelenmeleri söylenen
+        şey tam olarak budur.
+      </li>
+    </ul>
+    <p>
+      Orta yol hiçbir şeye mal olmaz: <em>kendi alan adınızdaki</em> kısa bir
+      adresin etrafına durağan bir QR kod koyun ve yönlendirmeyi kendiniz yapın.
+      Hedefi değiştirme yeteneğini korursunuz, ölçümleri korursunuz ve kodla ilgili
+      hiçbir şey, hiç tanışmadığınız bir şirketin gelecek yıl da var olmasına
+      bağlı olmaz.
+    </p>
+    <p>
+      <a href="../../qr-kod-olusturma/">Buradaki üreteç</a> yalnızca durağan kod
+      yapar ve açılacak bir hesabı yoktur. Ne yazarsanız kodun tuttuğu şey odur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bin tane basmadan önce</h2>
+    <p>
+      Kodu okutun. Ekranınızdakini değil &mdash; basılı provayı, gideceği yerde, onu
+      yaptığınız telefon olmayan bir telefonla. Bu bir dakika sürer ve bu sayfanın
+      konusu olan sorun sınıfının tamamını yakalar: düzenin yediği bir kenar
+      boşluğu, <code>https://</code>'i eksik bir bağlantı, kâğıtta başka türlü ölçen
+      bir renk, bir masada işe yarayıp bir duvarda yaramayan bir boyutta basılmış
+      bir kod.
+    </p>
+    <p>
+      Ve okutmadan sonra ne olduğunu denetleyin. Bir telefonda okunmayan bir sayfa
+      açan kod, okunmuş olsa bile çuvallamış bir koddur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbiri bir şey yüklemeyi gerektirmiyor</h2>
+    <p>
+      Bir QR kod, bir dizge üzerinde bir aritmetiktir. Gönderilecek bir dosya ve bir
+      sunucunun yapıp bir tarayıcının yapamayacağı bir şey yoktur;
+      <a href="../../qr-kod-olusturma/">buradaki aracın</a> hepsini kendi
+      makinenizde yapmasının ve ağ fişi çekilmişken çalışmasının sebebi de budur.
+    </p>
+    <p>
+      Bu, kulağa geldiğinden önemlidir; çünkü insanlar QR kodların içine ne koyuyor.
+      Wi-Fi biçiminin en yaygın kullanımı, bir web sayfasına yazılmış, bir ağın
+      gerçek parolasıdır. O sayfanın onu gönderecek bir yeri olup olmadığını bilmeye
+      değer.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/make-a-qr-code.toml
+++ b/locales/tr/pages/guides/make-a-qr-code.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: gerçekten okunan bir QR kod yapmak - Türkçe.
+#
+
+nav = "QR kod oluşturma"
+title = "Her Seferinde Okunan Bir QR Kod Nasıl Yapılır"
+description = "Hangi hata düzeltme düzeyini seçmelisiniz, bir QR kodun etrafındaki beyaz boşluk neden kodun bir parçasıdır, ne kadar büyük basmalısınız ve ücretsiz bir üreticinin 'dinamik' kodu size sonradan neye mal olur."
+heading = "Bir başkasının telefonunda da okunan bir QR kod nasıl yapılır"
+lede = """
+    Bir QR kod yapmak bir saniye sürer. Islanmış bir menüde, bir otobüs
+    durağında ya da kötü ışıkta kol boyu tutulmuş bir telefonda çalışan bir tane
+    yapmak dört karar gerektirir ve dördü de siz bir şey basmadan önce verilir.
+    İşte her birinin ne yaptığı."""
+updated = "20 Ağustos 2026"
+og_title = "Bir başkasının telefonunda da okunan bir QR kod yapmak"
+og_description = "Basılı bir QR kodun çalışıp çalışmayacağına karar veren dört şey: düzey, kenar boşluğu, boyut ve içinde gerçekte kimin adresinin olduğu."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/merge-and-split-pdf-files.html
+++ b/locales/tr/pages/guides/merge-and-split-pdf-files.html
@@ -1,0 +1,218 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../pdf-birlestirme/">PDF Birleştirici ve Bölücü</a>'yü açın,
+      kullanmak istediğiniz her dosyayı bırakın ve sayfaları istediğiniz sıraya
+      sürükleyin. Sonra tek belge olarak mı yoksa birkaç belge olarak mı çıkacağını
+      söyleyin ve düğmeye basın. Hiçbir şey yüklenmez: dosyalar kendi tarayıcınız
+      tarafından açılır, parçalanır ve geri yazılır.
+    </p>
+    <p>
+      İnsanların ayrı ayrı aradığı üç iş &mdash; birleştirme, bölme, yeniden
+      sıralama &mdash; tek bir ekrandır; çünkü hepsi, sonunda başka bir cevap veren
+      tek bir işlemdir: bazı sayfaları seçin, bir sıraya koyun ve kaç dosya olarak
+      çıkacaklarına karar verin.
+    </p>
+  </section>
+
+  <section>
+    <h2>İki ya da daha fazla belgeyi birleştirmek</h2>
+    <p>
+      Önce birinci dosyayı, sonra ikincisini seçin; her birinin sayfaları geçerli
+      sıranın sonuna eklenir, yani baştan başlamadan farklı klasörlerden dosya
+      eklemeye devam edebilirsiniz. Yanlış sırada girdilerse bir sayfayı
+      tutamacından sürükleyin ya da her kutucuktaki okları kullanın.
+    </p>
+    <p>
+      Birleştirmek hiçbir şeyi yeniden kodlamaz. Her sayfanın içeriği ve
+      gösterdiği her yazı tipi, görsel ve vektör çizim olduğu gibi kopyalanır;
+      yani metin seçilebilir ve aranabilir kalır ve bir tarama aynı taramadır.
+      Birleşmiş dosya genellikle iki girdinin toplamından biraz küçüktür ki bu bir
+      sıkıştırma değildir &mdash; sayfaların etrafındaki yapının iki kez yerine bir
+      kez yazılmasıdır.
+    </p>
+    <p>
+      Sayfalar kendi boyutlarını korur. A4 bir raporu US Letter bir ekle
+      birleştirin, ikisini de içeren bir belge alın; dosyaların söylediği de budur.
+      Birinin sayfalarını tek bir kâğıt boyutuna ölçeklemek başka bir işlemdir ve
+      bir birleştiricinin sessizce yapması gereken bir şey değildir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir belgeyi birkaç parçaya bölmek</h2>
+    <p>
+      Kesmenin dört yolu var ve hangisini istediğiniz neden kestiğinize bağlı:
+    </p>
+    <ul>
+      <li>
+        <strong>Her şu kadar sayfada bir.</strong> Aslında ayrı belgelerden oluşan
+        bir yığının uzun bir taraması için &mdash; her biri iki sayfa olan on iki
+        maaş bordrosu.
+      </li>
+      <li>
+        <strong>Söylediğiniz sayfa numaralarında.</strong> Bölümleri
+        görebildiğiniz sayfalarda başlayan bir rapor için. Yazdığınız her sayı yeni
+        bir dosya başlatır.
+      </li>
+      <li>
+        <strong>Sayfa başına bir dosya.</strong> Bir yığından tek bir imza sayfası
+        ya da sertifika çekip almak için.
+      </li>
+      <li>
+        <strong>Geldikleri dosyalara geri.</strong> Yalnızca birden fazla dosyayı
+        birleştirdiğinizde sunulur ve düzenlemeden sonra işe yarar: üç taramadan
+        boş sayfaları tek seferde kaldırın, sonra üç dosyayı geri alın.
+      </li>
+    </ul>
+    <p>
+      Uzun bir belgeden yalnızca birkaç sayfa istiyorsanız onu hiç bölmeniz
+      gerekmez. İstediğiniz sayfaları aralık kutusuna yazın &mdash;
+      <code>1-3, 8, 12-</code> &mdash; &ldquo;Yalnızca bunları tut&rdquo;a basın ve
+      tek bir belge kurun.
+    </p>
+    <p>
+      Birden fazla çıktı dosyası tek bir ZIP olarak verilir. Elli indirme, elli
+      kaydetme istemi demektir ki kabaca herkesin pes ettiği yer orasıdır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sayfaları yeniden sıralamak, döndürmek ve kaldırmak</h2>
+    <p>
+      Taşımak için bir kutucuğu tutamacından sürükleyin. Her kutucuktaki oklar onu
+      bir yer oynatır ya da seferinde çeyrek tur döndürür &mdash; tarayıcıdan yan
+      çıkmış sayfanın çözümü de budur. &times; ise onu kaldırır.
+    </p>
+    <p>
+      Birkaç sayfadan fazlasını ilgilendiren her şey için bunun yerine aralık
+      kutusunu kullanın. Kâğıda yazacağınızı kabul eder: <code>1-3, 8, 12-</code>
+      ve ayrıca <code>odd</code>, <code>even</code>, <code>all</code> ve
+      <code>last</code>. Bunları tutun, bunları kaldırın ya da bunları döndürün.
+      Yaygın bir örnek: her ikinci sayfası baş aşağı olan çift taraflı bir tarama
+      <code>even</code> ve iki turdur.
+    </p>
+    <p>
+      Kutucukların üstündeki numaralar siz çalıştıkça yeniden numaralanır; yani her
+      zaman &ldquo;geldiği dosyadaki sayfa&rdquo; değil &ldquo;bitmiş belgedeki
+      konum&rdquo; anlamına gelirler. Siz düğmeye basana kadar hiçbir şey yazılmaz,
+      yani geri alınacak bir şey de yoktur &mdash; ve &ldquo;geldikleri hâle
+      dön&rdquo; her şeyin özgün sırasını geri getirir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Yeniden dizmeden ne sağ çıkar, ne çıkmaz</h2>
+    <p>
+      Bu, hiçbir aracın size söylemediği kısımdır ve birleştirilmiş bir belgenin
+      bazen ince bir biçimde bozuk hissettirmesinin sebebidir.
+    </p>
+    <p>
+      Bir PDF bir sayfa yığını değildir. Bir çizgedir ve epeyce bir kısmı herhangi
+      bir sayfayla değil belgeyle ilgilidir: yer imleri paneli, bağlantılar, form,
+      bir ekran okuyucunun izlediği okuma sırası, ilk dört sayfaya &ldquo;i, ii,
+      iii, iv&rdquo; diyen numaralandırma. Sayfaları oynatın; bunların her birinin
+      yeniden kurulması ya da düşürülmesi gerekir.
+    </p>
+    <ul>
+      <li>
+        <strong>Yer imleri yeniden kurulur.</strong> Sayfası hâlâ orada olan bir
+        girdi, sayfanın taşındığı yeri gösterir. Sayfasını kaldırdığınız bir girdi
+        gider &mdash; altında hayatta kalan girdileri yoksa; varsa bir başlık
+        olarak kalır, çünkü bir bölüm başlığı hâlâ bölümün olduğu yerdedir. Birkaç
+        dosyayı birleştirmek, her birinin yer imlerini dosyanın adını taşıyan bir
+        başlığın altına yuvalar; birleştirilmiş bir raporda gezinmeyi mümkün kılan
+        da budur.
+      </li>
+      <li>
+        <strong>Bağlantılar izlenir.</strong> 2. sayfadan 40. sayfaya giden bir
+        bağlantı, 40. sayfanın nereye gittiğini bilir; Word ve LaTeX'in her başlık
+        için yazdığı adlandırılmış hedefler dâhil. Hedefi gelmemiş bir bağlantı,
+        şimdi o konumda hangi sayfa varsa onu göstermek yerine arkasında hiçbir şey
+        olmadan bırakılır.
+      </li>
+      <li>
+        <strong>Doldurulmuş formlar sağ çıkar</strong> ve yeni belge bir form olarak
+        kaydedilir; böylece okuyucular ona öyle davranır. Bilmeye değer bir tuhaflık:
+        aynı ada sahip iki alan, herhangi bir okuyucu için <em>tek</em> alandır; yani
+        aynı formun iki kopyasını birleştirmek onları bağlar &mdash; birine
+        yazdığınız diğerini doldurur.
+      </li>
+      <li>
+        <strong>Etiketlenmiş okuma sırası sağ çıkmaz.</strong> Artık var olmayan bir
+        diziyi tarif eder ve bir ekran okuyucu için yanlış bir sıra, hiç sıra
+        olmamasından kötüdür. Bir belgenin erişilebilirlik etiketlemesi sizin için
+        önemliyse özgün dosyayı da yanınızda tutun.
+      </li>
+      <li>
+        <strong>Sayfa etiketleri sağ çıkmaz.</strong> &ldquo;iii, iv, 1, 2&rdquo;
+        numaralandırması, az önce değiştirdiğiniz bir sıra hakkında bir cümledir.
+      </li>
+      <li>
+        <strong>Ekler ve belge betikleri sağ çıkmaz.</strong> Belgeye eklenmiş
+        dosyalar herhangi bir sayfaya değil belgeye aittir. JavaScript çalıştıran,
+        bir formu bir yere gönderen ya da bir program başlatan eylemler yeni
+        dosyanıza taşınmaz ki bu, bir başkasından gelmiş sayfalar için doğru
+        varsayılandır.
+      </li>
+    </ul>
+    <p>
+      Sayısal imza özel bir durumdur ve hiçbir aracın kısıtı değildir: bir imza,
+      belgeyi durduğu hâliyle onaylar. Bir sayfayı oynatın, imza bozulsun; çünkü
+      size söylemek için orada olduğu şey tam olarak budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Parola korumalı dosyalar</h2>
+    <p>
+      Şifreli bir PDF reddedilir; birçok ofis fotokopi makinesinin ürettiği boş
+      parolalı tür de dâhil. Bir belgenin korumasını kaldırmak, sayfalarını
+      oynatmaktan başka bir iştir ve bunu sessizce yapan bir araç, istemediğiniz bir
+      şeyi yapıyor olurdu. Önce onu bir okuyucuda parolayla açın ve korumasız bir
+      kopya kaydedin.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sonucu denetlemek</h2>
+    <p>
+      Açın ve üç şeye bakın: sayfa sayısı, sıra ve &mdash; belgede varsa &mdash; yer
+      imleri paneli ile bir iki bağlantı.
+    </p>
+    <p>
+      Buradaki araç bunların ilkini dosyayı size sunmadan önce sizin yerinize
+      yapıyor. Biten her belge, özgün dosyalarınızı okuyan kodun aynısı tarafından
+      yeniden açılır ve sayfaları, dosyaya yazılmış sayıya inanmak yerine sayfa
+      ağacı gezilerek sayılır. Bu, istediğinizle çelişirse hiç indirme sunulmaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir sunucuya ihtiyacı yok</h2>
+    <p>
+      Birleştirmek sunucu işi gibi geliyor ve webin ömrünün büyük kısmında öyleydi.
+      Gerçekte içerdiği şey, dosya yapısını ayrıştırmak, bir sayfanın bağlı olduğu
+      nesneleri yeni bir dosyaya kopyalamak ve taze bir çapraz başvuru tablosu
+      yazmaktır. Hiçbir piksel çözülmez ve hiçbir şey çizilmez. Bir tarayıcı bunların
+      hepsini yıllardır yapabiliyor.
+    </p>
+    <p>
+      İnsanların <em>neyi</em> birleştirdiği düşünülünce bu, neredeyse her yerden çok
+      burada önemlidir. Birleştirilen belgeler bir yerden gelmiş olanlardır: bir
+      sözleşme ve imza sayfası, bir pasaport taraması ve bir banka hesap özeti, bir
+      sağlık raporu ve bir talep formu. Çevrimiçi bir birleştirici hepsini bir anda,
+      çoktan derlenmiş hâlde ve tek bir kişiden alır. Çoğu insanın hayatı boyunca
+      yaptığı en ele verici tek yükleme budur.
+    </p>
+    <p>
+      Buradaki aracın hiç ağ özelliği yoktur ve sayfanın
+      <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi tek
+      tek sayar; bunların hiçbiri bu siteye ait değildir. Yükleyin, fişi çekin ve
+      yine de bir şey birleştirin.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> buna benzer üç denetim daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/merge-and-split-pdf-files.toml
+++ b/locales/tr/pages/guides/merge-and-split-pdf-files.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: PDF sayfalarını birleştirmek, bölmek ve yeniden sıralamak - Türkçe.
+#
+
+nav = "PDF birleştirme ve bölme"
+title = "PDF Sayfaları Nasıl Birleştirilir, Bölünür ve Yeniden Sıralanır"
+description = "PDF'leri birleştirin, birini birkaç parçaya ayırın ve sayfaları oynatın: yeniden dizmeden neyin sağ çıktığı, hiçbir aracın karşıya taşıyamadığı şeyler ve bunların hiçbirinin neden belgelerinizi bir yere yüklemeyi gerektirmediği."
+heading = "PDF sayfaları nasıl birleştirilir, bölünür ve yeniden sıralanır"
+lede = """
+    İki belgeyi bir araya getirmek, birinin bir PDF'e yaptığı en sıradan şeydir
+    ve en sık, iki dosyayı birden bir yabancının sunucusuna vererek yapılanıdır.
+    Buna gerek yok. Bu rehber bunu nasıl yapacağınızı ve bir araç sayfaları
+    yeniden dizdiğinde nelerin sessizce kaybolduğunu anlatıyor."""
+updated = "22 Ağustos 2026"
+og_title = "PDF sayfaları nasıl birleştirilir, bölünür ve yeniden sıralanır"
+og_description = "PDF'leri birleştirin, birini birkaç parçaya ayırın, sayfaları oynatın - ve yeniden dizmeden neyin sağ çıkıp neyin çıkmadığını bilin."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/open-a-dicom-file.html
+++ b/locales/tr/pages/guides/open-a-dicom-file.html
@@ -1,0 +1,240 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../dicom-goruntuleyici/">DICOM Görüntüleyici</a>'yi açın ve
+      dosyaların bulunduğu klasörün tamamını üzerine sürükleyin. Kendi makinenizde
+      okunur, geldikleri seriye geri konur ve tarayıcının çektiği sırayla üst üste
+      dizilir. Hiçbir şey yüklenmez ve dosyalarınıza hiçbir şey geri yazılmaz.
+    </p>
+    <p>
+      Size bir disk verildiyse ve dosyalardan hangisini açacağınızı merak
+      ediyorsanız: hepsini, bir seferde. Bir BT ya da MR tek bir dosya değildir.
+      Dilim başına bir dosyadır ve bir göğüs çalışması bunlardan üç yüz tanedir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir hastane diskinde ne var</h2>
+    <p>
+      Genellikle dört şey ve yalnızca biri önemli.
+    </p>
+    <ul>
+      <li>
+        <strong>Bir taramalar klasörü</strong>; çoğu zaman <code>DICOM</code>,
+        <code>IMAGES</code> ya da <code>ST0001</code> adında olur ve içinde
+        <code>IM000001</code>, <code>I0000001</code> ya da uzun noktalı bir sayıyla
+        adlandırılmış dosyalar bulunur. Sık sık hiç uzantısı olmaz. Tarama
+        bunlardır.
+      </li>
+      <li>
+        <strong><code>DICOMDIR</code> adlı bir dosya.</strong> Gerisinin bir
+        dizini; bir görüntüleyici her dosyayı açmadan diskteki çalışmaları
+        listeleyebilsin diye yazılmıştır. Ona ihtiyacınız yok.
+      </li>
+      <li>
+        <strong>Bir görüntüleyici</strong>; bir Windows çalıştırılabiliri, bir
+        otomatik çalıştırma girdisi ya da ara sıra bir Java uygulamacığı olarak.
+        Disk yazıldığında ne güncelse ona göre derlenmiştir; bu kadar çoğunun artık
+        çalışmamasının sebebi de budur.
+      </li>
+      <li>
+        <strong>Hastanenin logosunu taşıyan bir HTML sayfası ya da bir PDF</strong>;
+        görüntüleyicinin nasıl başlatılacağını anlatır.
+      </li>
+    </ul>
+    <p>
+      Taramaların görüntüleyiciye ihtiyacı yoktur. Biçim yayımlanmış bir standarttır
+      ve dosyalar kendi başlarına okunabilir; diskteki çalıştırılabilir, onları
+      okuyabilecek bir programdır, tek program değil.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dosyaların neden uzantısı yok</h2>
+    <p>
+      Çünkü DICOM'un buna ihtiyacı yoktur. Her dosya kendi işaretini taşır: 128
+      baytlık hiçlik, sonra <code>DICM</code> dört harfi, sonra dosyanın geri
+      kalanının nasıl yazıldığını tarif eden küçük bir alanlar bloğu. Bir okuyucu,
+      <code>.dcm</code> ile biten bir ad yerine bu dört harfi arar.
+    </p>
+    <p>
+      Bir dosyayı <code>.dcm</code> olarak yeniden adlandırmanın hiçbir şeyi
+      değiştirmemesinin ve uzantıda ısrar eden bir görüntüleyicinin gereksiz yere
+      katı davranmasının sebebi de budur. Doğrudan bir hastane ağından yazılmış
+      dosyalarda 128 bayt ve işaret bile yoktur &mdash; önlerinde hiçbir şey olmayan
+      çıplak veridirler ve bir okuyucunun nasıl kodlandıklarını ilk alandan çıkarması
+      gerekir. Bu, bozuk değil normal bir dosyadır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pencere ve düzey; asıl önemli denetim</h2>
+    <p>
+      Tıbbi bir görüntüyü bir fotoğraftan ayıran tek şey budur ve bir görüntü
+      düzenleyicinin bir tanesine bakmak için işe yaramamasının sebebi de budur.
+    </p>
+    <p>
+      Bir BT dilimi yaklaşık dört bin ayrı değer tutar. Ekranınız iki yüz elli altı
+      gri gösterir. Birinin, hangi dört binin hangi iki yüz elli altıya eşleneceğine
+      karar vermesi gerekir ve o karar <strong>penceredir</strong>: altındaki her şey
+      siyah, üstündeki her şey beyazdır ve aradaki aralık grilere yayılır.
+    </p>
+    <p>
+      Pencereyi oynatın, aynı dosya başka bir tarama gibi görünsün. Bu bir çizim
+      bozukluğu değil, işin özüdür. Akciğer de kemik de dilimin içindedir ve aynı
+      anda görülemez: şişmiş akciğerin dokusunu gösteren bir pencere her kemiği saf
+      beyaz yapar, bir kaburgadaki trabeküler ayrıntıyı gösteren bir pencere ise
+      akciğerin tamamını saf siyah yapar.
+    </p>
+    <p>
+      Bir BT'de sayılar <strong>Hounsfield birimleridir</strong> ve tarayıcıya göre
+      değil mutlak olarak tanımlanmışlardır: dünyadaki her BT tarayıcısında, tanım
+      gereği su 0 ve hava &minus;1000'dir. Bir görüntüleyicinin adlandırılmış
+      pencereler sunabilmesinin &mdash; akciğer, kemik, beyin, yumuşak doku &mdash;
+      ve bunların sizin dosyanızda, taramanın okunduğu iş istasyonundakiyle aynı
+      anlama gelmesinin sebebi budur. Alışılmış olanlar:
+    </p>
+    <ul>
+      <li><strong>Yumuşak doku</strong> &mdash; merkez 40, genişlik 400.</li>
+      <li><strong>Akciğer</strong> &mdash; merkez &minus;600, genişlik 1500.</li>
+      <li><strong>Kemik</strong> &mdash; merkez 300, genişlik 1500.</li>
+      <li><strong>Beyin</strong> &mdash; merkez 40, genişlik 80. Dar bir pencere,
+        çünkü gri ve beyaz madde yalnızca birkaç birim farklıdır.</li>
+    </ul>
+    <p>
+      Bir MR'da böyle bir ölçek yoktur. Değerler diziye, sarmala ve tarayıcıya
+      bağlıdır; yani bir hazır ayarın adını koyacak bir şey yoktur ve başlanacak
+      pencere, dosyanın kendisinin istediğidir. Her tarama bir öneri taşır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dilimler neden bazen ters yönde kayıyor</h2>
+    <p>
+      Bir görüntüleyicinin dosyaları hangi sıraya koyacağına karar vermesi gerekir ve
+      dosyada kullanabileceği iki şey vardır.
+    </p>
+    <p>
+      <strong>Instance Number</strong> bir sayaçtır. Apaçık seçimdir ve dosyaları her
+      ne yazdıysa onun tarafından atanır; o da onları hastanın uzandığı yönde
+      numaralamak zorunda değildir. Ayaklardan yukarı doğru yeniden kurulmuş ve
+      baştan aşağı numaralanmış bir çalışma geriye doğru kayar ve iki yeniden
+      kurulumdan bir araya getirilmiş bir seri numaraları düpedüz
+      tekrarlayabilir.
+    </p>
+    <p>
+      <strong>Image Position (Patient)</strong>, dilimin milimetre cinsinden, tarayıcıya
+      değil hastaya sabitlenmiş bir koordinat sisteminde fiziksel olarak nerede
+      olduğudur. Buna göre sıralamak, numaralandırma ne yapmış olursa olsun doğrudur
+      ve yararlı bir yan etkisi vardır: dilimler bir kez fiziksel sıraya girdiğinde
+      aralarındaki boşluk ölçülebilir; yani bir görüntüleyici size dilimlerin
+      5&nbsp;mm arayla olduğunu söyleyebilir &mdash; ve birinin eksik olduğunu fark
+      edebilir ki dosya bunu hiçbir zaman söylemez.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir şey ölçmek</h2>
+    <p>
+      Bir tarama ölçülmüş veridir, yani üzerindeki bir uzunluk gerçek bir uzunluktur
+      &mdash; dosya piksellerinin birbirinden ne kadar uzak olduğunu söylüyorsa. Bu
+      tek bir alandır, Pixel Spacing, milimetre cinsinden ve esasen her BT ile
+      MR'da bulunur.
+    </p>
+    <p>
+      Ultrason görüntülerinde, taranmış belgelerde ve DICOM olarak kaydedilmiş ekran
+      görüntülerinde çoğu zaman eksiktir. Eksik olduğu yerde milimetre cinsinden
+      dürüst bir cevap yoktur ve yine de bir cevap veren bir görüntüleyici bir ölçek
+      uydurmuştur. Dosyanın cevaplayamadığı bir soruya doğru cevap, bir piksel
+      sayısıdır.
+    </p>
+    <p>
+      Kare olmayan piksellere de dikkat edin; BT dışında bu normaldir. Piksel
+      cinsinden ölçüp tek bir aralık rakamıyla çarpmak yalnızca ikisi aynı olduğunda
+      doğrudur; her eksenin kendi rakamıyla ölçülmesi gerekir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir tarama resmin dışında ne taşır</h2>
+    <p>
+      İnsanların yanıldığı kısım budur ve bu dosyalarda dikkatli olmanın sebebi de
+      budur.
+    </p>
+    <p>
+      Bir DICOM dosyası, biraz üstverisi olan bir resim değildir. İçinde bir resim
+      olan bir tıbbi kayıttır. Başlık bir alanlar listesidir ve tipik bir klinik
+      taramada şunları tutar:
+    </p>
+    <ul>
+      <li>hastanın adı, hastane numarası, doğum tarihi ve cinsiyeti;</li>
+      <li>hastanenin sistemindeki isteğin anahtarı olan erişim numarası;</li>
+      <li>yönlendiren doktor, çekimi yapan tekniker, raporlayan radyolog;</li>
+      <li>kurum, adresi ve bölüm;</li>
+      <li>tarayıcının üreticisi, modeli ve seri numarası;</li>
+      <li>taramanın saniyesine kadar tarihi ve saati;</li>
+      <li>ve geldiği arşive geri açılan kusursuz anahtarlar olan bir benzersiz
+        tanımlayıcılar kümesi &mdash; çalışma, seri, örnek.</li>
+    </ul>
+    <p>
+      Size verilen her dosya bunların hepsini taşır ve bunlar, dosya nereye giderse
+      onunla birlikte gider. Adı silmek yetmez: bir doğum tarihi, posta kodu
+      büyüklüğünde bir kurum ve bir tarama saati bir insanı kabaca bir ad kadar iyi
+      tanımlar; çalışma UID'si ise arşive erişimi olan herkes için onu tam olarak
+      tanımlar.
+    </p>
+    <p>
+      Bazı tarayıcılar hastanın adının ikinci bir kopyasını, anlamı hiçbir yerde
+      yayımlanmamış olan özel bir alanda da tutar ve çoğu anonimleştirici, içinde ne
+      olduğunu bilemediği için bu alana dokunmaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bakmak için taramayı yüklemeyin</h2>
+    <p>
+      Bu sorunun alışıldık çözülme biçimi, &ldquo;çevrimiçi dicom
+      görüntüleyici&rdquo; araması ve bir yükleme kutusudur. Az önce olan şey, bir
+      yabancının bir tıbbi kaydın kopyasına sahip olmasıdır: pikseller, ad, doğum
+      tarihi, hastane numarası ve arşive geri açılan anahtar.
+    </p>
+    <p>
+      Bunun bir sebebi yok. Bir DICOM dosyasını okumak, bir başlığı ayrıştırmak ve
+      birkaç tam sayıyı açmaktır; bir tarayıcı bunu gayet iyi yapar ve
+      <a href="../../dicom-goruntuleyici/">buradaki görüntüleyicinin</a> hiç ağ
+      özelliği olmamasının sebebi de budur: <code>fetch</code> yok,
+      <code>XMLHttpRequest</code> yok, bir şey denese bile bir dosya gönderebilecek
+      hiçbir şey yok. Sayfayı bir kez yükleyin, internet bağlantısını kesin, tarama
+      açmaya devam etsin.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> bu iddiayı ister bu sitede ister başka bir yerde nasıl
+      denetleyeceğinizi anlatıyor. Denetlemeye en çok değen dosya türü budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir tarayıcının yapamayacağı şeyler</h2>
+    <p>
+      İki şey ve ikisi hakkında da açık konuşmaya değer.
+    </p>
+    <p>
+      <strong>Bu bir tanısal görüntüleyici değildir.</strong> Ekranınız kalibre
+      edilmemiştir, tarayıcı doğrulanmış bir çizim zinciri değildir ve hiçbir web
+      sayfası bir düzenleyici değerlendirmeden geçmemiştir. Klinik bir karar vermek
+      için bir taramayı okumak, onun raporlandığı iş istasyonunun işidir. Diskte ne
+      olduğuna bakmak, bir ders sunumu için bir dilim çekmek, bir başlık okumak ya da
+      başka bir programın dosyayı neden reddettiğini bulmak ise bir tarayıcıda bir
+      tanesini açmak için gayet iyi sebeplerdir.
+    </p>
+    <p>
+      <strong>Bazı sıkıştırılmış taramalar çözülmez.</strong> DICOM birkaç
+      sıkıştırma şemasına izin verir ve tarayıcılar bunlardan birini uygular. Düz
+      dosyalar, çalışma uzunluğu kodlanmış olanlar, temel JPEG ve JPEG Lossless
+      &mdash; ki çoğu hastane dışa aktarımının kullandığı budur &mdash; hepsi
+      açılır. JPEG 2000, JPEG-LS ve video biçimleri, megabaytlarca derlenmiş
+      kütüphane olan kodlayıcılar ister. Resmin çözülemediği yerde başlık yine de
+      baştan sona okunabilir ki zaten geldiğiniz yarı genellikle odur.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/open-a-dicom-file.toml
+++ b/locales/tr/pages/guides/open-a-dicom-file.toml
@@ -1,0 +1,18 @@
+#
+# Rehber: bir DICOM dosyasını açmak - Türkçe.
+#
+
+nav = "DICOM dosyası açma"
+title = "Bir DICOM Dosyası (.dcm) Hiçbir Şey Kurmadan Nasıl Açılır"
+description = "Bir hastane diskinde ne var, dosyaların neden uzantısı yok, bir .dcm taraması tarayıcıda nasıl açılır, pencere ve düzey gerçekte ne yapar ve bir tarama resmin dışında hasta hakkında neler taşır."
+heading = "Bir DICOM dosyası nasıl açılır ve içinde ne var"
+lede = """
+    Bir hastane diski, uzantısı olmayan dosyalardan oluşan bir klasör ve Windows
+    XP için yazılmış bir görüntüleyicidir. Dosyalar DICOM'dur ve onlarda egzotik
+    hiçbir şey yoktur: bir tarama, alanlarla dolu bir başlık ve bir piksel
+    bloğudur. Bu rehber bir tanesine nasıl bakacağınızı, denetimlerin ne anlama
+    geldiğini ve dosyanın resmin dışında başka neler taşıdığını anlatıyor."""
+updated = "25 Ağustos 2026"
+og_title = "Bir DICOM dosyası hiçbir şey kurmadan nasıl açılır"
+og_description = "Bir hastane diskinde ne var, dosyaların neden uzantısı yok ve bir .dcm taraması resmin dışında hasta hakkında neler taşır."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/redact-a-pdf.html
+++ b/locales/tr/pages/guides/redact-a-pdf.html
@@ -1,0 +1,223 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../pdf-karartma/">PDF Karartıcı</a>'yı açın, belgeyi bırakın,
+      gitmesi gereken kelimeleri yazın, kastettiklerinizi işaretleyin ve
+      &ldquo;Onları çıkar&rdquo;a basın. Harfler sayfanın kendi çizim
+      talimatlarından silinir, aynı kelimeler yer imlerinden, yorumlardan, form
+      alanlarından ve belge özelliklerinden çıkarılır ve bitmiş dosya, size
+      sunulmadan önce gözünüzün önünde yeniden açılıp aranır.
+    </p>
+    <p>
+      Aşağıdaki her şey, o son cümlenin neden önemli olduğu ve zaten kullandığınız
+      aracın aynı şeyi söyleyip söyleyemeyeceğini nasıl anlayacağınızla ilgili.
+    </p>
+  </section>
+
+  <section>
+    <h2>Konu olan çuvallama</h2>
+    <p>
+      Bir PDF okuyucusunda bir adın üstüne siyah bir dikdörtgen çizin. Gördüğünüz
+      şey, üstünde siyah bir dikdörtgen olan bir addır. Çoğu okuyucunun
+      <em>kaydettiği</em> şey ise adı ve ondan ayrı olarak bir konumu, bir boyutu ve
+      bir rengi olan bir dikdörtgeni içeren bir belgedir.
+    </p>
+    <p>
+      Böyle çizilmiş bir dikdörtgen bir <strong>açıklamadır</strong>: sayfanın
+      içinde değil yanında duran bir nesne. Altındaki metin tam olarak olduğu
+      gibidir. Alanı seçip kopyala'ya basın, ya da dosyanın üstünde herhangi bir
+      metin çıkarıcı çalıştırın, ya da onu açıklamaları başka türlü çizen bir
+      programda açın; ad geri gelsin. Ekranda bunu gerçek bir karartmadan ayıran
+      hiçbir şey yoktur; hukukçu çalıştıran kuruluşların başına gelmeye devam
+      etmesinin sebebi tam olarak budur.
+    </p>
+    <p>
+      Bu, mahkeme dosyalarını, istihbarat değerlendirmelerini, sözleşmeleri ve
+      &mdash; Aralık 2025'te &mdash; Amerika Birleşik Devletleri Adalet Bakanlığı
+      belgelerinin toplu bir yayımında karartılmış adları ifşa etti; o adlar
+      yayımdan saatler sonra okunabiliyordu. Örüntü her zaman aynıdır. Dikdörtgen
+      açıklamaydı ve açıklama hiçbir zaman metin değildi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gerçek bir karartma bunun yerine ne yapar</h2>
+    <p>
+      Bir PDF'teki bir sayfa bir talimatlar listesidir: şu yazı tipini ayarla,
+      kalemi buraya götür, şu harf biçimlerini çiz. Sayfadaki kelimeler tam olarak
+      tek bir yerde, o çizim talimatlarının işlenenleri olarak bulunur:
+    </p>
+    <pre><code>BT /F1 12 Tf 72 700 Td (Sayin Bay Smith) Tj ET</code></pre>
+    <p>
+      Adı karartmak, <strong>o harfleri o talimattan silmek</strong> ve sayfayı geri
+      yazmak demektir. Ondan sonra geri getirilecek bir şey yoktur; dosya onu iyi
+      sakladığı için değil, harfler dosyada olmadığı için. Altında bir şey olan bir
+      dikdörtgen yoktur, çünkü altında bir şey yoktur.
+    </p>
+    <p>
+      Bir şeyin geri konması gerekir, yoksa sonuç gözle görülür biçimde yanlış olur.
+      Metin, kalem sayfa boyunca ilerletilerek çizilir; yani beş harf silmek satırın
+      geri kalanını beş harf sola çeker: sütunlar hizadan çıkar ve toplamlar yanlış
+      başlıkların altına kayar. Bunu düzgün yapan bir araç, kaldırılan harflerin ne
+      kadar ilerleyeceğini ölçer ve o mesafeyi, kalemi hiçbir şey çizmeden oynatan
+      bir aralık talimatı olarak geri koyar.
+    </p>
+    <p>
+      Siyah kutu, varsa, <em>sonradan</em> ve zaten boş olan bir boşluğun üstüne
+      çizilir. Belgeyi okuyan kişiye bir nezakettir &mdash; bir şeyin çıkarıldığının
+      işareti &mdash; ve karartmanın kendisi değildir. Bütün ayrım tek cümlede
+      budur: gerçek bir karartmada kutu süstür; sahte olanda kutu, karartmanın
+      <em>kendisidir</em>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir kelimenin sayfa dışında saklandığı dört yer</h2>
+    <p>
+      Bu, ilk kısmı düzgün yapmış olanları yakalayan kısımdır. Bir PDF metni aynı
+      anda birkaç yerde taşır ve bir okuyucu hepsini gösterir, arar ya da kopyalar.
+      Bir adı sayfadan kaldırıp bunlardan birinde bırakmak, onu kaldırmış olmaz.
+    </p>
+    <ul>
+      <li>
+        <strong>Belge özellikleri.</strong> Başlık, yazar ve bunun dışa aktarıldığı
+        dosyanın adı. Sayfalarından bir ad çıkarılmış ve özelliklerinde hâlâ
+        <code>Smith uzlasma taslak 3.docx</code> yazan bir belge karartılmamıştır.
+        Aynı bilginin genellikle bir XMP paketinde ikinci bir kopyası bulunur ve
+        onun da gitmesi gerekir.
+      </li>
+      <li>
+        <strong>Yer imleri.</strong> Bir okuyucunun yanındaki içindekiler listesi,
+        sayfa numaraları iliştirilmiş başlıklardan oluşan bir listedir &mdash; ve
+        bir başlık, sayfadaki hiçbir şeyin denetlemediği bir metin satırıdır.
+      </li>
+      <li>
+        <strong>Form alanları ve yorumlar.</strong> Birinin bir forma yazdığı şey
+        iki kez saklanır: bir kez alanın değeri olarak, bir kez de okuyucunun
+        çizdiği görünüm olarak. İkisinin de gitmesi gerekir. Bir yapışkan not, hem
+        metnini hem de onu yazanın adını taşır.
+      </li>
+      <li>
+        <strong>Karşılık metni.</strong> Bir PDF, bir dizi harf biçiminin başka bir
+        şey &ldquo;yazdığını&rdquo; bildirebilir; böylece bir bitişik harf ya da
+        tireyle bölünmüş bir satır, temsil ettiği kelime olarak kopyalanır. Bu, bir
+        belgenin bir şey gösterip Ctrl+C'de okuyucuya başka bir şey verebileceği
+        anlamına gelir ve yalnızca çizileni kaldıran bir karartma, paragrafı seçen
+        herkes için cümleyi olduğu gibi bırakırdı.
+      </li>
+    </ul>
+    <p>
+      Ekler beşincisidir. Bir PDF içinde bütün başka dosyalar taşıyabilir ve
+      sayfalara yaptığınız hiçbir şey onlara dokunmaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir dosya otuz saniyede nasıl denetlenir</h2>
+    <p>
+      Bunu, hangi araç üretmiş olursa olsun göndermek üzere olduğunuz her şeye
+      yapın. Yayımlanmış çuvallamaların her birini yakalayacak olan denetim budur.
+    </p>
+    <ol>
+      <li>
+        <strong>Bitmiş dosyayı açın ve Ctrl+F'ye basın</strong> (bir Mac'te Cmd+F).
+        Kaldırdığınız kelimeyi arayın. Gerçek bir karartma hiçbir şey döndürmez.
+        Okuyucu siyah bir dikdörtgene atlıyorsa kelime hâlâ oradadır ve dikdörtgen
+        onun üstünde oturuyordur.
+      </li>
+      <li>
+        <strong>Karartılmış alanı seçin ve kopyalayın.</strong> Dikdörtgenin
+        üzerinden sürükleyin, Ctrl+C'ye basın ve bir metin kutusuna yapıştırın. Bir
+        şey geliyorsa aynı çuvallamayı öbür yönden bulmuşsunuzdur.
+      </li>
+      <li>
+        <strong>Belgenin tamamını seçin ve onu kopyalayın.</strong> Ctrl+A, sonra
+        Ctrl+C; herhangi bir metin düzenleyiciye yapıştırın ve çıkanı okuyun.
+        Üçünün en yararlısı budur; çünkü belgeyi size bir metin çıkarıcının gördüğü
+        gibi gösterir &mdash; orada olduğunu hiç bilmediğiniz metin dâhil; ki
+        taranmış bir sayfada bu yaygındır.
+      </li>
+      <li>
+        <strong>Özelliklere bakın</strong> &mdash; çoğu okuyucuda Dosya → Özellikler
+        &mdash; ve yer imleri paneline. İkisi de bir adın, sayfa açısından kusursuz
+        bir karartmadan sağ çıktığı yerlerdir.
+      </li>
+    </ol>
+    <p>
+      <a href="../../pdf-karartma/">PDF Karartıcı</a> bunların birincisini ve
+      üçüncüsünü sizin yerinize çalıştırır ve sayıyı gösterir; çünkü bir aracın bir
+      şeyi kaldırdığını iddia etmesi kanıt değildir, bitmiş dosyada yapılan bir
+      arama ise kanıttır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Taranmış belgeler başka bir sorundur</h2>
+    <p>
+      Bir tarama, bir sayfanın fotoğrafıdır. Üzerindeki kelimeler metin değil
+      pikseldir ve metin katmanını ne kadar düzenlerseniz düzenleyin onlara
+      dokunmazsınız &mdash; çünkü ya metin katmanı yoktur ya da olan katman resmin
+      kendisi değil onun tarifidir.
+    </p>
+    <p>
+      Güncel tarayıcıların ve PDF araçlarının çoğu, sayfa aranabilsin diye resmin
+      üstüne optik karakter tanımayla yazılmış görünmez bir metin katmanı ekler. O
+      katman gerçek metindir ve kaldırılabilir. Kaldırmaya değer: bir aramanın, bir
+      kopyalamanın ve belge okuyan her otomatik sistemin bulacağı şey odur. Resimle
+      ilgili hiçbir şeyi değiştirmez; sayfaya bakan herkes için kelimeler orada hâlâ
+      gayet okunaklıdır.
+    </p>
+    <p>
+      Yani bir tarama için dürüst sıra şudur: kelimeleri metin katmanından çıkarın,
+      sonra resimle ayrıca ilgilenin &mdash; ki bu, pikselleri üzerine yazmak
+      demektir. <a href="../resim-karartma/">Görsel karartıcı</a> bunu yapar ve
+      yanındaki rehber, bir bulanıklaştırmanın ya da bir mozaiğin metin için neden
+      yeterli olmadığını anlatır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Neden basıp yeniden taramak olmasın</h2>
+    <p>
+      Çünkü işe yarar ve size başka her şeye mal olur. Karartılmış bir sayfayı basıp
+      yeniden taramak, sızdıracak metin katmanı olmayan bir belge üretir &mdash; ve
+      kimsenin arayamayacağı, hiçbir ekran okuyucunun okuyamayacağı, beş ila elli kat
+      büyük ve kalitesi ofis tarayıcısının canı ne isterse o olan bir belge. Ayrıca
+      sayfanın göründüğü gibi basılmış olmasına dayanır: bir açıklama, ekranda
+      görünüp kâğıtta görünmeyecek şekilde işaretlenebilir ve siyah kutunuz o olduğu
+      zaman, yazıcıdan çıkan sayfada ad durur.
+    </p>
+    <p>
+      Aynı sav, bazı araçların karartma olarak sunduğu &ldquo;görsele
+      düzleştir&rdquo; için de geçerlidir. Her sayfayı kendi fotoğrafına çevirir.
+      Kelimeler silinmek yerine örtülmüşse örtü artık kalıcıdır &mdash; ama belgeyle
+      ilgili başka her şey de onunla birlikte gitmiştir ve gönderdiğiniz dosya
+      kimsenin üzerinde çalışamayacağı bir dosyadır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bu iş neden yüklemeye en az değen iştir</h2>
+    <p>
+      Bir karartma hizmetine, karartılmamış dosyanın verilmesi gerekir. Bütün alışveriş
+      budur: özel sürüm önce, el değmemiş hâlde varır ve bir başkasının diskindeki
+      sürüm odur. Gizlilik politikası ne derse desin sıra tartışılamaz &mdash;
+      dikkat ettiğiniz belge, teslim ettiğiniz belgedir.
+    </p>
+    <p>
+      İnsanların ne karartığı bunu kulağa geldiğinden kötü yapar. Tanık ifadeleri,
+      sağlık raporları, ev sahibine gidecek banka hesap özetleri, bir müşterinin adı
+      geçen ve başka bir müşteriye gidecek bir sözleşme, üstünde ev adresi olan bir
+      başvuru. Belgeler bunlardır ve tam da bu yüzden onların aracının öbür ucunda bir
+      sunucu olmamalıdır.
+    </p>
+    <p>
+      <a href="../../pdf-karartma/">Bu sitenin karartıcısındaki</a> her şey kendi
+      tarayıcınızda olur: dosya sizin makinenizde okunur, düzenlenir, yazılır ve
+      denetlenir ve aradığınız kelimeler de sekmeden hiç çıkmaz. İnternet
+      bağlantısını kesin, çalışmaya devam etsin; hiçbir şeyin bir yere
+      gönderilmediğinin var olan en basit kanıtı budur. Bir yüklemenin gerçekte neyi
+      içerdiği için <a href="../dosya-yuklemek-guvenli-mi/">dosya yüklemek güvenli
+      mi</a> sayfasına bakın.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/redact-a-pdf.toml
+++ b/locales/tr/pages/guides/redact-a-pdf.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir PDF'i, kelimeler gerçekten gidecek şekilde karartmak - Türkçe.
+#
+
+nav = "PDF karartma"
+title = "Bir PDF, Metin Gerçekten Gidecek Şekilde Nasıl Karartılır"
+description = "Bir PDF okuyucusunda çizilen siyah bir kutu genellikle altındaki kelimeleri yerinde bırakır ve kopyala yapıştır onları doğrudan geri getirir. Gerçek bir karartmanın neyi kaldırdığı, bir kelimenin sayfanın dışında saklandığı dört yer ve bir dosyayı göndermeden önce nasıl denetleyeceğiniz."
+heading = "Bir PDF, metin gerçekten gidecek şekilde nasıl karartılır"
+lede = """
+    Bir adın üstündeki siyah dikdörtgen ile silinmiş bir ad ekranda birbirinin
+    aynısı görünür. Bunlardan biri seçilip kopyalanmaktan sağ çıkar. Bu rehber
+    aradaki farkı, bir kelimenin sayfada hiç bulunmayan saklanma yerlerini ve
+    hangisine sahip olduğunuzu söyleyen otuz saniyelik denetimi anlatıyor."""
+updated = "25 Ağustos 2026"
+og_title = "Bir PDF, metin gerçekten gidecek şekilde nasıl karartılır"
+og_description = "Bir PDF okuyucusundaki siyah kutu neden genellikle bir karartma değildir, bir kelimenin sayfanın dışında saklandığı dört yer ve bir dosyayı göndermeden önce nasıl denetleyeceğiniz."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/redact-an-image.html
+++ b/locales/tr/pages/guides/redact-an-image.html
@@ -1,0 +1,217 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../resim-karartma/">Görsel Karartıcı</a>'yı açın, resmi bırakın,
+      görünmemesi gereken her şeyin üstüne bir kutu sürükleyin ve &ldquo;Karart ve
+      kaydet&rdquo;e basın. Metin olarak okunan her şey için siyah dolguyu kullanın.
+      Geri aldığınız dosyada, kutuların olduğu yerde başka piksel değerleri vardır:
+      içinde kenara çekilecek bir dikdörtgen yoktur, çünkü içinde hiç dikdörtgen
+      yoktur.
+    </p>
+    <p>
+      Aşağıdaki her şey, o son cümlenin neden işin özü olduğu ve zaten kullandığınız
+      bir aracın aynı şeyi söyleyip söyleyemeyeceğini nasıl anlayacağınızla ilgili.
+    </p>
+  </section>
+
+  <section>
+    <h2>Örtmek ve kaldırmak ekranda birbirinin aynısı görünür</h2>
+    <p>
+      Bir PDF okuyucusunda, bir sunum destesinde, bir kelime işlemcide ya da
+      katmanlı bir görüntü düzenleyicide bir adın üstüne siyah bir dikdörtgen çizin;
+      gördüğünüz şey, üstünde siyah bir dikdörtgen olan bir addır. Bu programların
+      çoğunda <em>kaydettiğiniz</em> şey ise adı ve ondan ayrı olarak bir konumu,
+      bir boyutu ve bir rengi olan bir dikdörtgeni içeren bir belgedir.
+    </p>
+    <p>
+      O dosyayı açan herkes dikdörtgeni oynatabilir, silebilir ya da belgeyi
+      katmanları başka sırayla çizen bir programda açabilir. Ad hâlâ oradadır.
+      Ekranla ilgili hiçbir şey size hangisinin olduğunu söylemez; bunun hukukçusu
+      olan kuruluşların başına gelmeye devam etmesinin sebebi de tam olarak
+      budur.
+    </p>
+    <p>
+      Bu, mahkeme dosyalarını, devlet raporlarını, sözleşmeleri ve birden fazla
+      gazetenin taranmış belgelerini ifşa etti. Örüntü her zaman aynıdır: dikdörtgen
+      açıklamaydı ve açıklama resim değildi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gerçek bir karartma nedir</h2>
+    <p>
+      Bir resim, piksel başına bir tane olmak üzere bir sayılar ızgarasıdır. Onu
+      karartmak, <strong>ızgaraya başka sayılar yazmak</strong> ve sonra ızgarayı
+      kaydetmek demektir. Ondan sonra geri getirilecek bir şey yoktur; dosya onu iyi
+      sakladığı için değil, değerler dosyada olmadığı için. Bunun, meraklı biri
+      tarafından açılmaktan sağ çıkan tek sürümü budur.
+    </p>
+    <p>
+      Bilmeye değer üç sonuç; çünkü karartılmış bir dosyanın nasıl görünmesi
+      gerektiği bunlardır:
+    </p>
+    <ul>
+      <li>
+        <strong>Sonuç tek ve düz bir resimdir.</strong> Katman yok, nesne yok,
+        açıklama listesi yok, açılıp kapatılacak bir şey yok. Aracınız size içinde
+        katman olan bir dosya veriyorsa kaldırmamış, örtmüştür.
+      </li>
+      <li>
+        <strong>Düzenlenmiş eski bir dosya değil, yeni bir dosyadır.</strong>
+        Pikseller bir çözücüden ve bir kodlayıcıdan geçmiştir; yani çıkan şey
+        karartılmış ızgaradan yazılmıştır.
+      </li>
+      <li>
+        <strong>Üstveri de bir yan etki olarak gitmiştir.</strong> Bir piksel
+        ızgarası hiçbir kamera modeli, GPS konumu ya da zaman damgası taşımaz. Aksi
+        hâlde ne olacağı için
+        <a href="../exif-ve-gps-verisini-silme/">bir fotoğraf sizin hakkınızda ne
+        söyler</a> sayfasına bakın.
+      </li>
+    </ul>
+    <p>
+      Sonuncuyu açıkça yazmaya değer; çünkü kendine ait bir tuzak saklıyor. Birçok
+      fotoğraf bir <strong>gömülü küçük resim</strong> taşır: dosya oluşturulduğunda
+      yazılmış ve resim düzenlendiğinde her zaman yeniden üretilmeyen, resmin küçük
+      ikinci bir kopyası. Dosyayı yeniden kodlamak yerine yerinde düzenleyen bir
+      araçla karartılmış bir fotoğraf, karartılmamış özgün hâlin küçük resmiyle
+      birlikte yolculuk edebilir. Küçük bir resimdir ve üzerinden bir ad okumaya
+      fazlasıyla yeter.
+    </p>
+  </section>
+
+  <section>
+    <h2>Siyah, pikselleştirme ya da bulanıklaştırma &mdash; ve neden denk olmadıkları</h2>
+    <p>
+      Üçü de pikselleri üzerine yazar. Yalnızca biri geride hiçbir şey bırakmaz.
+    </p>
+    <h3>Siyah dolgu</h3>
+    <p>
+      Kutudaki her piksel aynı renge dönüşür. Orada olandan hiçbir şey hayatta
+      kalmaz: ne bir dış hat, ne bir ortalama parlaklık, ne karakter sayısı, ne de
+      kelimenin uzunluğu. Üçünün içinde &ldquo;bu geri alınabilir mi?&rdquo;
+      sorusuna düpedüz hayır cevabı verilen tek seçenek budur ve bir ad, bir adres,
+      bir hesap numarası, bir plaka, bir imza ya da bir barkod için kullanılacak olan
+      da budur.
+    </p>
+    <h3>Pikselleştirme</h3>
+    <p>
+      Kutu bloklara ayrılır ve her blok o bloğun ortalama rengine dönüşür. Özgün
+      pikseller gerçekten gitmiştir &mdash; ama bir ortalamalar ızgarası hâlâ altında
+      ne olduğunun bir ölçümüdür ve metin için o ölçüm yetebilir.
+    </p>
+    <p>
+      Saldırı ince değildir. Metin küçük bir olasılıklar kümesinden çizilir: bir yazı
+      tipi, bir boyut, bir konum ve bir dizge. Orada ne tür bir şey olduğunu tahmin
+      eden biri, her aday dizgeyi aynı şekilde çizebilir, her birini aynı blok
+      ızgarasıyla pikselleştirebilir ve ortalamaları sizinkiyle karşılaştırabilir.
+      Eşleşme genellikle tektir. Bu, gerçek pikselleştirilmiş ekran görüntülerinde
+      gösterildi ve bunu yapan yayımlanmış yazılım var.
+    </p>
+    <p>
+      Buna karar veren şey, <strong>mozaiğin kaç bloktan oluştuğudur</strong>. Bir
+      kelime boyunca iki blok, iki sayıdır ve iki sayı bir dizgeyi tanımlayamaz. Aynı
+      kelime boyunca kırk blok, kırk sayıdır ve kırk fazlasıyla yeter. Görsel
+      Karartıcı'nın bir ayara &ldquo;güçlü&rdquo; demek yerine resimdeki en ince
+      mozaiğin blok sayısını size söylemesinin sebebi budur &mdash; sayı olgudur,
+      sıfat ise onun hakkında bir görüştür.
+    </p>
+    <h3>Bulanıklaştırma</h3>
+    <p>
+      Her piksel, komşularının ağırlıklı ortalamasına dönüşür. Bu bir konvolüsyondur
+      ve konvolüsyonlar ilkesel olarak tersine çevrilebilir: bulanık bir kopyadan
+      özgününü geri kazanmak, standart yazılımı olan standart bir problemdir ve en
+      iyi, tam da burada önemli olan durumda çalışır: küçük bir yarıçapla
+      bulanıklaştırılmış net metin.
+    </p>
+    <p>
+      Bunların hiçbiri pikselleştirmeyi ve bulanıklaştırmayı işe yaramaz kılmaz. Bir
+      sokak fotoğrafının arka planındaki bir yüz, karşı taraftaki bir kapı numarası,
+      bir görüntülü görüşmede arkanızdaki bir meslektaşınızın ekranı &mdash; hepsi
+      gayet iyidir ve resmin resim gibi görünmesini sağlar. Kural basitçe şudur:
+      <strong>metin olarak okunuyorsa karartın.</strong>
+    </p>
+  </section>
+
+  <section>
+    <h2>Göndermeden önce dört denetim</h2>
+    <p>
+      Bunlar hep birlikte bir dakika sürer ve bu araç dâhil herhangi bir aracın
+      çıktısında çalışır. Denetleyebileceğiniz bir iddia, kabul etmeniz istenen bir
+      iddiadan değerlidir.
+    </p>
+    <ol>
+      <li>
+        <strong>Metni seçmeyi deneyin.</strong> Dosyayı açın ve örtülü alanın
+        üzerinden sürükleyin. Bir şey vurgulanıyorsa metin hâlâ belgededir ve siz
+        onun üstüne çizilmiş bir şekle bakıyorsunuzdur.
+      </li>
+      <li>
+        <strong>Bir düzenleyicide açın ve katman arayın.</strong> Karartılmış bir
+        görsel, &ldquo;Arka plan&rdquo; gibi bir şey denen tek bir katman gibi
+        görünür. Ayrı bir dikdörtgen nesnesi, özgününün onun altında olduğu anlamına
+        gelir.
+      </li>
+      <li>
+        <strong>Küçük resme bakın.</strong> Bazı dosya yöneticileri ve fotoğraf
+        görüntüleyicileri, resmi yeniden okumak yerine gömülü küçük resmi gösterir.
+        Küçük sürüm hâlâ örttüğünüz şeyi gösteriyorsa dosya yeniden kurulmamış,
+        düzenlenmiştir.
+      </li>
+      <li>
+        <strong>Kutunun kenarlarına sonuna kadar yakınlaşın.</strong> Piksellere
+        uygulanmış bir karartmanın tam sınırda sert bir kenarı vardır. Yumuşak ya da
+        yarı saydam bir kenar, resmin üstüne bir saydamlıkla bir şey çizildiği
+        anlamına gelir ve %100'ün altındaki bir saydamlık, üstüne renk tonu atılmış
+        bir özgün kopyadır.
+      </li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Yapabildiğiniz yerde örtmek yerine kırpın</h2>
+    <p>
+      Gizlediğiniz şey resmin kenarındaysa &mdash; hesap adı olan bir başlık, bir
+      tarayıcı sekmesi, kullanıcı adınızın bulunduğu bir görev çubuğu &mdash; onu
+      kırpıp atmak örtmekten güçlüdür ve daha temiz görünen bir dosya üretir.
+      Şüphelenilecek bir kutu yoktur; çünkü orada hiçbir şey yoktur.
+    </p>
+    <p>
+      <a href="../../resim-boyutlandirma/">Görsel Boyutlandırıcı</a> kırpar ve başka
+      neler yaptığını <a href="../resim-boyutlandirma/">kendi rehberi</a> anlatır.
+      Karartıcıyı ortadakiler için kullanın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Çoğu zaman en kötüsü bir ekran görüntüsüdür</h2>
+    <p>
+      Bir ekran görüntüsünde sizi tanımlayan tek şey genellikle resim değildir. Bir
+      tanesini göndermeden önce paylaşmak istediğiniz kısmın etrafındakilere bakın:
+      pencere başlığı, tarayıcının adres çubuğu ve otomatik tamamlama açılır
+      listesi, açık sekmeler, bir bildirim, saat ve tarih, görev çubuğu, köşedeki
+      oturum açmış bir avatar, wifi ağının adı. Bunlardan herhangi biri sizi bir yere
+      yerleştirebilir ve hiçbiri çekimi yaparken baktığınız şey değildi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir resmi okumak, bazı piksellerinin üstüne yazmak ve onu yeniden kodlamak, her
+      tarayıcının yıllardır yapabildiği şeylerdir. Pasaportunuzun, maaş bordronuzun
+      ya da banka hesap özetinizin bir fotoğrafının, üstüne siyah bir kutu konsun
+      diye bir yabancının sunucusuna gidip gelmesinin teknik bir sebebi yoktur
+      &mdash; ve bir karartma aracına verilen resimler tam olarak bunlardır.
+    </p>
+    <p>
+      Buradaki araç onu hiçbir yere göndermez: sayfanın
+      <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi tek tek
+      sayar ve bunların hiçbiri bu siteye ait değildir. Size söylenmesindense
+      denetlemeyi tercih ederseniz sayfayı yükleyin, internet bağlantısını kesin ve
+      yine de bir şey karartın.
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> herhangi bir araçta çalıştırabileceğiniz üç denetim
+      daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/redact-an-image.toml
+++ b/locales/tr/pages/guides/redact-an-image.toml
@@ -1,0 +1,18 @@
+#
+# Rehber: bir görseli, gizlenen kısım gerçekten gidecek şekilde karartmak -
+# Türkçe.
+#
+
+nav = "Görsel karartma"
+title = "Bir Görsel, Gizlenen Kısım Gerçekten Gidecek Şekilde Nasıl Karartılır"
+description = "Çoğu programda çizilen siyah kutular resmin üstünde oturur ve kenara çekilebilir. Gerçek bir karartmayı örtülmüş bir karartmadan ayıran şey, pikselleştirilmiş metnin neden geri okunabildiği ve bir dosyayı göndermeden önce nasıl denetleyeceğiniz."
+heading = "Bir görsel, gizlenen kısım gerçekten gidecek şekilde nasıl karartılır"
+lede = """
+    Bir şeyi örtmek ile onu kaldırmak ekranda birbirinin aynısı görünür ve hiç de
+    aynı şey değildir. Bu rehber aradaki farkı, insanların beklediğinden fazlasını
+    geride bırakan iki biçemi ve az önce hangisini yaptığınızı söyleyen denetimleri
+    anlatıyor."""
+updated = "23 Ağustos 2026"
+og_title = "Bir görsel, gizlenen kısım gerçekten gidecek şekilde nasıl karartılır"
+og_description = "Siyah bir dikdörtgen neden genellikle bir karartma değildir, pikselleştirilmiş metin neden geri okunabilir ve bir dosyayı göndermeden önce nasıl denetleyeceğiniz."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/tr/pages/guides/remove-exif-and-gps-data.html
@@ -1,0 +1,211 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../exif-verisi-silme/">EXIF Görüntüleyici ve Silici</a>'yi açın,
+      fotoğrafları bırakın ve &ldquo;Tüm üstveriyi sil&rdquo;e basın. Her etiket,
+      XMP ve IPTC blokları, yorumlar ve gömülü küçük resim, listedeki her fotoğrafta
+      tek seferde gider. Resmin kendisine dokunulmaz &mdash; yeniden sıkıştırılmaz,
+      çözülmez, tek bir pikseli bile değişmez.
+    </p>
+    <p>
+      Bunu yapmadan önce içinde ne olduğuna bakmaya değer. Genellikle insanların
+      beklediğinden fazlasıdır ve liste, bunu yapmanın gerekçesinin kendisidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir fotoğrafın içinde gerçekte ne var</h2>
+    <p>
+      Bir JPEG yalnızca sıkıştırılmış bir resim değildir. Bir kaptır ve resmin
+      yanında, kameranızın, telefonunuzun ya da düzenleyicinizin oraya yazdığı
+      birkaç bilgi bloğu durur.
+    </p>
+    <ul>
+      <li>
+        <strong>EXIF.</strong> Ana blok. Kamera markası ve modeli, mercek, pozlama
+        ayarları, ISO, saniyesine kadar tarih ve saat, resmin gösterilmesi gereken
+        yön ve &mdash; kamera için konum servisleri açık bir telefonda &mdash;
+        birkaç metre hassasiyetinde bir GPS konumu. Sık sık bir kamera gövdesi seri
+        numarası da.
+      </li>
+      <li>
+        <strong>GPS.</strong> Teknik olarak EXIF'in bir parçası ve ayrıca adını
+        anmaya değer; çünkü en çok önem taşıyan odur. Derece, dakika ve saniye
+        olarak yazılır ki bu, bir adrese benzememeyi çok iyi başaran bir biçimdir.
+      </li>
+      <li>
+        <strong>XMP.</strong> Düzenleyicilerin yazdığı bir XML paketi. Adınızı,
+        yazılımınızı, puanları, anahtar kelimeleri, düzenleme geçmişini ve EXIF
+        alanlarının bazılarının bir kopyasını taşıyabilir &mdash; yalnızca EXIF'i
+        silmenin neden yetmediğinin sebebi de budur.
+      </li>
+      <li>
+        <strong>IPTC.</strong> Basında ve stok fotoğrafçılığında kullanılan, daha
+        eski bir altyazı, imza, künye ve telif alanları bloğu.
+      </li>
+      <li>
+        <strong>Gömülü küçük resim.</strong> Görüntünün küçük ikinci bir kopyası.
+        Dosya yazıldığında üretilir ve resim düzenlendiğinde her zaman yeniden
+        üretilmez &mdash; kırpılmış bir fotoğrafın, kırpılıp atılan kısmın küçük
+        resmiyle yolculuk edebilmesinin sebebi budur.
+      </li>
+      <li>
+        <strong>Üretici notu.</strong> Belgelenmemiş bir üretici verisi bloğu.
+        Üretici dışında hiç kimse içinde ne olduğunu tam olarak bilmez.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bunu gerçekte kimler görüyor</h2>
+    <p>
+      Bu konuda kesin olmaya değer; çünkü hem telaşlı hem de küçümseyici sürümler
+      yanlıştır.
+    </p>
+    <p>
+      <strong>Büyük sosyal ağların çoğu, siz paylaştığınızda üstveriyi
+      siler.</strong> Facebook, Instagram ve X yüklenen görselleri yeniden kodlar ve
+      bu sırada etiketleri düşürür. Bu bir iyilik değildir &mdash; veriyi kendi
+      taraflarında tutarlar &mdash; ama bu hizmetlere gönderilen bir fotoğrafın
+      koordinatlarını her izleyene vermediği anlamına gelir.
+    </p>
+    <p>
+      <strong>Neredeyse başka her şey onu korur.</strong> Bir e-posta eki. Çoğu
+      sohbet uygulamasında fotoğraf yerine &ldquo;belge&rdquo; olarak gönderilmiş bir
+      dosya. Bir forumdaki resim, bir ilan, kişisel bir site, paylaşılan bir sürücü,
+      bir hata raporu, bir destek talebi. Bunların hepsinde dosya el değmemiş hâlde
+      varır ve onu indiren herkes etiketleri, işletim sistemleriyle birlikte gelen
+      araçlarla okuyabilir.
+    </p>
+    <p>
+      Gerçekçi riskler dramatik değil sıradandır: evde fotoğraflanmış bir satış
+      ilanı, bir çocuğun okulunda çekilmiş resmi, hepsi tek bir kamera seri numarasını
+      paylaşan fotoğraflar paylaşan görünüşte anonim bir hesap, aslında martta
+      çekilmiş bir &ldquo;geçen hafta çektim&rdquo;.
+    </p>
+  </section>
+
+  <section>
+    <h2>Neden yeniden kaydetmek olmasın?</h2>
+    <p>
+      Bir fotoğrafı bir düzenleyiciden ya da bir sıkıştırıcıdan geçirip yeniden
+      kaydetmek üstveriyi gerçekten siler &mdash; resim piksellere çözülür ve
+      yeniden kodlanır ve piksellerle dolu bir tuval hiçbir etiket taşımaz. İşe yarar
+      ve size kaliteye mal olur; çünkü o yeniden kodlama kayıplıdır.
+    </p>
+    <p>
+      Üstveriyi düzgünce silmek hiçbir şeye mal olmaz. Etiketler, sıkıştırılmış
+      resmin içinde değil <em>etrafındaki</em> kapta durur; yani onları temizlemek,
+      bir listeden girdi silmek ve listeyi geri yazmaktır. Sıkıştırılmış görüntü
+      verisi baytı baytına kopyalanır ve sonuç tam olarak aynı piksellere çözülür. Bir
+      dönüştürücü yerine bir üstveri aracı kullanmanın bütün sebebi budur.
+    </p>
+    <p>
+      İstisna, zaten yeniden kodlayacak olmanızdır. Fotoğrafı zaten sıkıştırıyor ya
+      da boyutlandırıyorsanız etiketler bir yan etki olarak gider ve ikinci bir adıma
+      ihtiyacınız olmaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Korunacak tek şey: yön</h2>
+    <p>
+      Telefonlar siz telefonu çevirdiğinizde resmi döndürmez. Onu sensörün gördüğü
+      gibi kaydeder ve gösterim için nasıl çevrilmesi gerektiğini söyleyen bir Yön
+      etiketi ekler. Her etiketi silin, bazı görüntüleyiciler fotoğrafınızı yan
+      göstersin.
+    </p>
+    <p>
+      Buradaki aracın, varsayılan olarak açık olan bir &ldquo;yön etiketini
+      koru&rdquo; seçeneği bulunmasının sebebi budur. Yalnızca o etiketi içeren ve
+      başka hiçbir şey içermeyen minik bir EXIF bloğu geri yazar ve bunu yalnızca
+      gerçekten ihtiyacı olan fotoğraflar için yapar. GPS, zaman damgaları, seri
+      numarası ve gerisi yine de gitmiştir.
+    </p>
+    <p>
+      Dosyanın hiç EXIF taşımamasını tercih ederseniz onu kapatın &mdash; ve sonra
+      göndermeden önce sonuca bakın; çünkü alışıldık sonuç yan yatmış bir
+      fotoğraftır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Silmek yerine düzenlemek</h2>
+    <p>
+      Her şeyi silmek çoğu insan için doğru cevaptır. Bazen değildir: bir fotoğrafçı
+      telif satırının ve kamera ayarlarının korunmasını ve yalnızca konumun gitmesini
+      isteyebilir; bir arşivci, kamera saati yanlış olduğu için yanlış olan bir
+      tarihi düzeltmek zorunda kalabilir.
+    </p>
+    <p>
+      İkisi de mümkün. Konum tek başına silinebilir ve metin etiketleri, tarihler,
+      ISO, yön ve çözünürlük yerinde düzenlenebilir.
+    </p>
+    <p>
+      Yalnızca bu araç için değil, bunu yapan her araç için geçerli bir çekince:
+      dosyayı yazmak EXIF bloğunu yeniden kurar ve bir üretici notu <em>özgün</em>
+      bloğun içine ofsetler barındırır. Bu yüzden yeniden kurulmuş bir üretici notu
+      artık üreticinin kendi yazılımı tarafından okunamayabilir. Bu sizin için
+      önemliyse üretici notunu silin ya da dosyayı düzenlemeden bırakın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Biçimler ve bu yolla yapılamayanlar</h2>
+    <p>
+      JPEG, PNG ve WebP'nin hepsi temizce yeniden yazılabilir ve buradaki aracın
+      işlediği üç biçim de bunlardır.
+    </p>
+    <p>
+      Bir iPhone'un varsayılan olarak kaydettiği biçim olan HEIC ve AVIF, iç içe
+      atomlardan kurulmuş kap biçimleridir ve tamamen başka bir ayrıştırıcı ister.
+      Araç onları tanır ve bozuk bir dosya üretmek yerine bunu söyler. Elinizde bir
+      HEIC varsa, onu JPEG'e dönüştürmek üstveriyi dönüşümün bir yan etkisi olarak
+      siler.
+    </p>
+    <p>
+      Çıplak bir TIFF de işlenmez ve bunun daha ilginç bir sebebi var: bir TIFF'te
+      üstveri ile piksel verisi aynı ofsetlerle adreslenir; yani etiketleri silmek,
+      resmin kendi adreslemesini yeniden yazmak demektir. Yapılabilir bir şeydir ve
+      başka bir iştir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Edinmeye değer bir alışkanlık</h2>
+    <p>
+      Paylaştıktan sonra değil, önce bakın. Etiketleri okumak birkaç saniye sürer ve
+      bulgular listesi, bilmeye değen şeylerin adını &mdash; konum, zaman damgaları,
+      seri numaraları &mdash; her etiketin bulunduğu tam tablodan önce verir; böylece
+      ne arayacağınızı bilmeniz gerekmez.
+    </p>
+    <p>
+      Konum bilerek önce ondalık derece olarak gösterilir. &ldquo;51 derece, 30
+      dakika, 26 saniye&rdquo;, bir fotoğrafın çekildiği binanın adını verdiğini
+      apaçık kılmaz. Bir haritaya yapıştırabileceğiniz bir ondalık çifti kılar.
+    </p>
+  </section>
+
+  <section>
+    <h2>İçinde ne olduğunu öğrenmek için fotoğrafı yüklemeyin</h2>
+    <p>
+      Bu sorunun alışıldık çözülme biçiminde ayrı bir ironi var: fotoğrafının neyi
+      ele verdiğinden endişelenen biri, öğrenmek için onu bir web sitesine yüklüyor.
+      Site artık fotoğrafa, koordinatlara, zaman damgasına ve seri numarasına ve
+      resmin kendi sahip olduğu bir diskteki bir kopyasına sahip.
+    </p>
+    <p>
+      Bunun bir sebebi yok. Bir JPEG'in etrafındaki kabı okumak ve yeniden yazmak,
+      bir tarayıcının gayet iyi çalıştırdığı birkaç yüz satırlık ayrıştırmadır;
+      buradaki aracın hiç ağ özelliği olmamasının sebebi de budur:
+      <code>fetch</code> yok, <code>XMLHttpRequest</code> yok, bir şey denese bile
+      bir dosya gönderebilecek hiçbir şey yok. Bir kez yükleyin, bağlantıyı kesin,
+      çalışmaya devam etsin.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> bu iddiayı ister bu sitede ister başka bir yerde nasıl
+      denetleyeceğinizi anlatıyor &mdash; ve denetlemeye en çok değen dosya türü
+      budur.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/tr/pages/guides/remove-exif-and-gps-data.toml
@@ -1,0 +1,18 @@
+#
+# Rehber: bir fotoğrafın içindeki üstveri ve nasıl silineceği - Türkçe.
+#
+
+nav = "EXIF ve GPS verisi"
+title = "Bir Fotoğraftan EXIF ve GPS Verisi Nasıl Silinir"
+description = "Telefondan çıkan bir fotoğraf genellikle çekildiği tam noktayı, saniyesine kadar saati ve kameranın seri numarasını taşır. İçinde ne var, kimler okuyabilir ve resme hiç dokunmadan bunu nasıl çıkarırsınız."
+heading = "Bir fotoğraf sizin hakkınızda ne söyler ve bunu nasıl çıkarırsınız"
+lede = """
+    Telefondan doğrudan çıkan bir resim tipik olarak çekildiği yerin
+    koordinatlarını, saniyesine kadar saati ve kamera hakkında, onu aynı cihazdan
+    çıkan her fotoğrafa bağlamaya yetecek kadar bilgi taşır. Bunların hiçbiri
+    ekranda görünmez. Bu rehber içinde ne olduğunu ve nasıl sileceğinizi
+    anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir fotoğraf sizin hakkınızda ne söyler ve bunu nasıl çıkarırsınız"
+og_description = "GPS koordinatları, zaman damgaları ve seri numaraları sıradan fotoğrafların içinde yolculuk eder. İçinde ne var, kimler okuyabilir ve nasıl temizlenir."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/resize-an-image.html
+++ b/locales/tr/pages/guides/resize-an-image.html
@@ -1,0 +1,230 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../resim-boyutlandirma/">Görsel Boyutlandırıcı</a>'yı açın,
+      resminizi bırakın, tek bir sayı yazın &mdash; genellikle genişlik &mdash; ve
+      diğerini boş bırakın. Yükseklik resmin şeklinden gelir ki neredeyse her zaman
+      istenen de budur: &ldquo;1920 genişliğinde&rdquo;, &ldquo;1920 genişliğinde ve
+      bunun getirdiği yükseklikte&rdquo; demektir.
+    </p>
+    <p>
+      Aşağıdaki her şey, tek bir sayının yetmediği durumlar içindir: iki kenarı da
+      verilmiş bir kutu aldığınızda, resmin büyümesi gerektiğinde ya da koca bir
+      klasör dolusu dosyanın aynı şekilde çıkması gerektiğinde.
+    </p>
+  </section>
+
+  <section>
+    <h2>Küçültmek güvenlidir. Büyütmek değildir.</h2>
+    <p>
+      Bunlar aynı işlemin iki yönü değildir ve sebebi konusunda açık olmaya değer.
+    </p>
+    <p>
+      <strong>Bir resmi küçültmek</strong> bilgiyi atar ve bunu tek iyicil anlamda
+      yapar: içeri giren piksel dışarı çıkandan fazladır, yani sonucun her pikseli
+      gerçekten ölçülmüş ayrıntıdan ortalanmıştır. İyi boyutlandırılmış küçük bir
+      kopya, o boyutta izlenen özgün hâlinden genellikle <em>daha iyi</em> görünür;
+      çünkü ortalama gürültüyü kaldırır. Hiçbir şey uydurulmaz.
+    </p>
+    <p>
+      <strong>Bir resmi büyütmek</strong> uydurmak zorundadır. Ayrıntı dosyada eksik
+      değildir; hiç fotoğraflanmamıştır. Herhangi bir büyütücünün yapabileceği tek
+      şey ara pikselleri komşularından tahmin etmektir ve bilinen iki değer
+      arasındaki bir tahmin, yumuşak bir rampadır &mdash; büyütülmüş bir fotoğrafın
+      keskin değil yumuşak görünmesinin sebebi de budur. Aynı resmin daha ayrıntılı
+      değil daha büyük bir kopyasıdır.
+    </p>
+    <p>
+      Buradaki araçta &ldquo;bir resmi asla başladığından büyük yapma&rdquo;nın
+      varsayılan olarak açık olmasının sebebi budur. Piksel sayısına gerçekten
+      ihtiyacınız varsa kapatın &mdash; asgari bir boyut isteyen bir matbaa, bir
+      genişliğin altındaki hiçbir şeyi kabul etmeyen bir şablon &mdash; ama ayrıntı
+      değil piksel satın aldığınızı bilerek yapın.
+    </p>
+    <p>
+      Ayrıntı ekliyormuş gibi görünen makine öğrenmeli büyütücüler tamamen başka bir
+      şeydir: resimlerin genellikle nasıl göründüğüne dair bir modelden akla yatkın
+      doku uyduruyorlardır. Bir duvar kâğıdı için bu sorun değildir. Bir insanın
+      fotoğrafı, bir belge ya da birinin bir sonuç çıkaracağı herhangi bir şey için
+      ise fazladan ayrıntının kurgu olduğunu bilin.
+    </p>
+  </section>
+
+  <section>
+    <h2>İstediğiniz boyutu söylemenin üç yolu</h2>
+    <p>
+      Bu araç dâhil çoğu araç aynı üçünü kabul eder ve bunlar farklı işlere uyar.
+    </p>
+    <ul>
+      <li>
+        <strong>Tam piksel.</strong> Birinin sayıyı belirttiği durumlarda kullanın:
+        400&times;400 olmak zorunda olan bir avatar, 1500 genişliğinde olmak zorunda
+        olan bir afiş. Size ikisi birden verilmedikçe bir kenarı doldurun ve
+        diğerinin gelmesine izin verin.
+      </li>
+      <li>
+        <strong>Bir yüzde.</strong> Her şeyin orantılı olarak küçülmesini istediğiniz
+        ve tam rakamı önemsemediğiniz durumlarda kullanın &mdash; bir belgeye girecek
+        bir fotoğraf seti için &ldquo;yarı boyut&rdquo;.
+      </li>
+      <li>
+        <strong>Bir uzun kenar.</strong> Karışık bir yığın için üçünün en
+        yararlısı. &ldquo;En uzun kenar 1600&rdquo;, dikey de yatay da olsa her
+        resmi 1600 piksellik bir karenin içine sığdırır ki pratikte &ldquo;bunların
+        hepsini makul bir boyuta getir&rdquo;in anlamı genellikle budur.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Kutu resimden başka şekilde olduğunda</h2>
+    <p>
+      Boyutlandırmanın asıl belirlendiği yer burasıdır. Hem bir genişlik hem bir
+      yükseklik verirseniz ve bunlar resminizin oranlarına uymuyorsa bir şeyin
+      esnemesi gerekir ve bunu yapabilecek tam olarak dört şey vardır:
+    </p>
+    <ul>
+      <li>
+        <strong>Kutunun içine sığdır.</strong> Resmin tamamı korunur ve bir eksende
+        kutudan küçük çıkar. Hiçbir şey kaybolmaz ve hiçbir şey bozulmaz; yalnızca
+        istediğiniz tam boyutları almazsınız. Neredeyse her şey için doğru varsayılan
+        budur.
+      </li>
+      <li>
+        <strong>Kutuyu doldur ve taşanı kes.</strong> İstediğiniz boyutları tam
+        olarak alırsınız ve resmin kenarlardan taşan kısımları gider. Şeklin sabit ve
+        öznenin ortada olduğu küçük resimler, avatarlar ve kapaklar için doğrudur.
+        Önemli olan şey bir kenara yakınsa yanlıştır.
+      </li>
+      <li>
+        <strong>Tamamla.</strong> Resmin tamamı ortalanmış olarak korunur ve artan
+        boşluk seçtiğiniz bir renkle doldurulur. Bir sistem tam boyut dayattığında ve
+        görüntüden hiçbir şey kaybedemediğinizde doğrudur &mdash; ürün ilanları çoğu
+        zaman böyle çalışır.
+      </li>
+      <li>
+        <strong>Esnet.</strong> Resim sığmak için ezilir ya da çekilir. Bunu bilerek
+        yapmıyorsanız asla istediğiniz şey değildir ve herkesin anında yanlış olduğunu
+        anladığı seçenek de budur.
+      </li>
+    </ul>
+    <p>
+      Kendinizi esnetmeye uzanırken bulursanız muhtemelen istediğiniz şey
+      kırpmaktır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kırpmak başka bir iştir ve çoğu zaman doğru olanıdır</h2>
+    <p>
+      Boyutlandırmak, resmin tamamını kaç pikselin tarif ettiğini değiştirir. Kırpmak,
+      resmin hangi kısmını tuttuğunuzu değiştirir. İnsanlar şaşırtıcı biçimde sık, esas
+      olarak ikincisini kastederken birincisine uzanır &mdash; &ldquo;bunun kare
+      olması gerek&rdquo; bir boyutlandırma değil bir kırpma sorunudur.
+    </p>
+    <p>
+      Bunları şu sırayla yapın: önce istediğiniz çerçevelemeye kırpın, sonra sonucu
+      ihtiyacınız olan boyuta getirin. Tersini yapmak, çoktan piksel kaybetmiş bir
+      resmin içinden kırpmayı seçmek demektir.
+    </p>
+    <p>
+      Buradaki aracın ikisini tek geçişte yapmasının sebebi budur &mdash; bir kutu
+      sürükleyin, belirli bir oran gerekiyorsa onu bir şekle kilitleyin, sonra sonucun
+      hangi boyutta çıkacağını söyleyin. Tek geçişte yapmak ayrıca resmin yalnızca bir
+      kez kodlanması demektir ki bunun önemi bir sonraki bölümdeki sebeptendir.
+    </p>
+    <h3>Koca bir yığını kırpmak</h3>
+    <p>
+      Bir resmin üstüne çizilen bir kutu, gerisine aynı <em>göreli</em> alan olarak
+      uygulanır: her dosyanın kendi genişliğinin ve yüksekliğinin aynı kesirleri.
+      Hepsi aynı boyutta olan bir ekran görüntüsü ya da dışa aktarım klasörü için bu,
+      tam olarak aynı dikdörtgendir. Karışık bir yığın için ise aynı dikdörtgen değil
+      aynı çerçevelemedir ki genellikle istenen budur ama elli dosyayı ona emanet
+      etmeden önce bilmeye değer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Yeniden kodlamanın bedeli ve bunu bir kezde tutmak</h2>
+    <p>
+      Bir JPEG'i ya da bir WebP'yi boyutlandırmak, onu çözmek, pikselleri ölçeklemek
+      ve yeniden kodlamak demektir &mdash; ve bu son adım kayıplıdır. Size kaliteye
+      mal olan şey ölçeklemenin kendisi değil, yeniden kodlamadır.
+    </p>
+    <p>
+      Bundan iki şey çıkar. Birincisi, çıkıştaki kalite ayarı önemlidir: bir fotoğraf
+      için 80&ndash;85 civarı bir yer görünmezdir ve 100'den hatırı sayılır ölçüde
+      küçüktür. İkincisi, bunu bir kez yapın. Zaten iki kez boyutlandırılmış bir
+      resmi boyutlandırmak, üç kuşak kayıplı kodlama demektir ve bu belli olur.
+    </p>
+    <p>
+      Bir PNG'nin böyle bir bedeli yoktur; çünkü kayıpsızdır &mdash; boyutlandırılmış
+      bir PNG, tam olarak ölçeklenmiş piksellerdir. Birkaç adımda çalışıyorsanız ve
+      son biçime henüz karar verilmediyse arada PNG'de çalışmak kuşakların üst üste
+      binmesini önler.
+    </p>
+    <p>
+      Buradaki araçla ilgili bilmeye değer bir ayrıntı: gerçekten hiç
+      değiştirmediğiniz bir dosya, yeniden kodlanmak yerine size baytı baytına geri
+      verilir. Bir yığın için &ldquo;en uzun kenar 1600&rdquo; isteyin; zaten 1600'ün
+      altında olanlar etiketleriyle birlikte el değmemiş çıksın. Onları sessizce
+      yeniden kodlayan bir araç, kimsenin değiştirmesini istemediği dosyalarda size
+      kaliteye mal oluyor olurdu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Saydamlık ve başına ne geldiği</h2>
+    <p>
+      PNG ve WebP saydamlık saklayabilir. JPEG saklayamaz &mdash; biçimde hiç alfa
+      kanalı yoktur. Yani saydam bir görseli JPEG olarak kaydetmek arkasına bir şey
+      koymak zorundadır ve o şey düz bir renktir.
+    </p>
+    <p>
+      Çoğu araç beyaz kullanır ve bundan söz etmez ki logonuz koyu bir sayfaya
+      etrafında beyaz bir kutuyla düşene kadar bu sorun değildir. Rengi bilerek seçin
+      ya da PNG veya WebP olarak kaydedip saydamlığı koruyun. Tamamlanmış bir
+      çerçevenin arkasında da aynı renk kullanılır; insanların bununla sürpriz
+      biçimde karşılaştığı öbür yer de orasıdır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Size bir sayı verildiyse hangi araç</h2>
+    <p>
+      İki farklı sayı veriliyor ve bunlar farklı araçlar istiyor.
+    </p>
+    <p>
+      <strong>&ldquo;1200 piksel genişliğinde&rdquo;</strong> bir boyut sorunudur. Araç
+      <a href="../../resim-boyutlandirma/">Görsel Boyutlandırıcı</a>'dır: kaç piksel
+      istediğinizi söylersiniz, o da size onu verir.
+    </p>
+    <p>
+      <strong>&ldquo;500&nbsp;KB'nin altında&rdquo;</strong> bir dosya boyutu
+      sorunudur ve boyutlandırmak onu çözmenin yollarından yalnızca biridir.
+      <a href="../../resim-sikistirma/">Görsel Sıkıştırıcı</a>, hedefinize sığan en
+      yüksek kaliteyi arar ve yalnızca kalite tek başına yetmiyorsa boyutlandırır;
+      bunun neye mal olduğunu
+      <a href="../resmi-hedef-boyuta-sikistirma/">kendi rehberi</a> anlatıyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir görseli çözmek, ölçeklemek ve yeniden kodlamak her tarayıcının yıllardır
+      yapabildiği şeylerdir &mdash; bir web sayfasının bir resmi başka bir boyutta
+      çizmek için kullandığı mekanizmanın aynısı. Fotoğrafınızın daha küçük çıkmak
+      için bir sunucuya gidip gelmesinin teknik bir sebebi yoktur ve buradaki araç
+      onu hiçbir yere göndermez: sayfanın <code>Content-Security-Policy</code>'si
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu siteye
+      ait değildir.
+    </p>
+    <p>
+      Size söylenmesindense denetlemeyi tercih ederseniz sayfayı yükleyin, internet
+      bağlantısını kesin ve yine de bir şey boyutlandırın.
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> herhangi bir araçta çalıştırabileceğiniz üç denetim
+      daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/resize-an-image.toml
+++ b/locales/tr/pages/guides/resize-an-image.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir görseli boyutlandırmak - Türkçe.
+#
+
+nav = "Görsel boyutlandırma"
+title = "Bir Görsel Bozmadan Nasıl Boyutlandırılır"
+description = "Piksel boyutlarını değiştirdiğinizde resminizin başına ne gelir: küçültmek neden güvenli, büyütmek neden değil, kutu yanlış şekilde olduğunda ne yapmalı ve ne zaman bunun yerine kırpmalı."
+heading = "Bir görsel bozmadan nasıl boyutlandırılır"
+lede = """
+    Boyutlandırma, hasarın düğmeye basmadan önce &mdash; hangi sayıyı yazdığınıza
+    ve hangi şekli istediğinize göre &mdash; belirlendiği tek görsel işidir. Bu
+    rehber her seçimin resme ne yaptığını ve hangilerinin geri alınabileceğini
+    anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir görseli bozmadan boyutlandırmak"
+og_description = "Küçültmek neden güvenli, büyütmek neden değil, kutu yanlış şekilde olduğunda ne yapmalı ve ne zaman bunun yerine kırpmalı."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/reverse-a-video.html
+++ b/locales/tr/pages/guides/reverse-a-video.html
@@ -1,0 +1,182 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../videoyu-ters-oynatma/">Video Tersleyici</a>'yi açın, klibi
+      bırakın, sesin de ters çevrilmesini isteyip istemediğinize karar verin ve dışa
+      aktarın. Çıkan şey, son karesi başa gelmiş aynı kliptir ve giren kadar
+      uzundur.
+    </p>
+    <p>
+      Kesmenin aksine bu iş her kareyi yeniden yazmak zorundadır &mdash; resmi de
+      sesi de. Bu, belirli bir aracın eksikliği değildir; ters çevirmenin kendisi
+      budur. Bu sayfanın geri kalanı bunun sebebi ve ne kadar bekleyeceğiniz için ne
+      anlama geldiğiyle ilgili.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir video neden düpedüz geriye doğru oynatılamaz</h2>
+    <p>
+      Bir video dosyası bir resim yığını değildir. Kabaca her elli karede bir tanesi
+      bütün bir resimdir &mdash; bir <em>anahtar kare</em> &mdash; ve aralarındaki
+      her şey, çevresindeki karelerden bu yana neyin değiştiğinin bir tarifidir. Bir
+      saatlik videonun bir telefona sığmasının sebebi budur.
+    </p>
+    <p>
+      Bu aynı zamanda bir çözücünün yalnızca ileri gidebileceği anlamına gelir. Size
+      bir klibin son karesini göstermek için önündeki anahtar kareyi bulup aradaki
+      her şeyi çözmesi gerekir. Sondan bir önceki kareyi isteyin, aynı işi baştan
+      yapsın.
+    </p>
+    <p>
+      Yani ters çevirme grup grup yapılır: bir grubu ileri doğru çöz, kareleri tut,
+      onları kodlayıcıya öbür sırayla ver, ondan önceki gruba geç. Apaçık alternatif
+      &mdash; klibin tamamını bir listeye çözüp listeyi geriye doğru gezmek &mdash;
+      1080p kare başına yaklaşık 3&nbsp;MB bellek, yani dakikada 5&nbsp;GB ister; bu
+      şekilde yapan araçların birkaç saniyeden uzun her şeyde çuvallamasının sebebi
+      de budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sese ne oluyor</h2>
+    <p>
+      Ters çevirme araçlarının en çok ayrıştığı yer burasıdır ve gerçekte ne
+      aldığınızı denetlemeye değer.
+    </p>
+    <p>
+      Ses, her biri bir öncekine karşı kodlanmış, birkaç on milisaniyelik paketler
+      hâlinde sıkıştırılır. O paketleri sondan başa yazmak bir izi geriye doğru
+      <em>oynatmaz</em> &mdash; kısa parçaları yanlış sırada ileri doğru oynatır ki
+      bu, bir ters çevirmeden çok bir kekemelik ya da bir arıza gibi duyulur. Sesi
+      düzgünce ters çevirmenin tek yolu, izin tamamını çözmek, örnekleri öbür sıraya
+      koymak ve yeniden kodlamaktır.
+    </p>
+    <p>
+      Burada olan budur ve <a href="../../video-kesme/">Video Kesici</a> ile
+      <a href="../../video-kirpma/">Video Kırpıcı</a> sese hiç dokunmazken burada
+      sesin yeniden kodlanmasının sebebi de budur: o işler bir şeyin <em>ne
+      zaman</em> olduğunu değiştirmez, bu iş ise başka hiçbir şeyi değiştirmez.
+    </p>
+    <p>
+      Resmi ters, sesi ise hiç istemiyorsanız &mdash; ki sessiz oynatılan bir akışa
+      gidecek her şey için alışıldık seçim budur &mdash; onay kutusunu kapatın. Daha
+      hızlıdır ve dosya daha küçüktür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Resme neye mal oluyor</h2>
+    <p>
+      Bir yeniden kodlama. Kareler, özgün dosyadaki hiçbir şeyin kodlanmadığı bir
+      sırayla çıkar; yani her birinin baştan yazılması gerekir.
+    </p>
+    <p>
+      İyi davranan bir aracın yapmayacağı şey, özgün dosyanın harcadığından
+      <em>fazlasını</em> harcamaktır. Ters çevrilmiş bir klip, gelen klibin tam
+      olarak aynı resimlerini tutar; yani daha yüksek bir bit hızının tarif edeceği
+      yeni bir şey yoktur: dosyayı daha iyi göstermeden büyütür. Buradaki kalite
+      ayarı o tavanın üstünde değil içinde oynar.
+    </p>
+    <p>
+      Her zamanki gibi kayıplı adımlar üst üste biner. Özgün bir dosyayı ters
+      çevirmek bir kuşaktır. Bir ekran kaydının bir indirmesinin bir dışa aktarımını
+      ters çevirmek dört kuşaktır ve öyle de görünür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Önce kesin, sonra ters çevirin</h2>
+    <p>
+      Klibin ikisi de gerekiyorsa önce kesin. Kesmek bedavadır &mdash; iyi bir kesici
+      kareleri çözmeden bütün hâlde karşıya taşır &mdash; ve çıkardığınız her saniye,
+      kimsenin yeniden çözüp kodlamak zorunda olmadığı bir saniyedir.
+    </p>
+    <p>
+      Tersini yapmak, birazdan atacağınız görüntüyü ters çevirmek demektir. Uzun bir
+      klipte bu, birkaç saniye süren bir işle dakikalar süren bir iş arasındaki
+      farktır. O ilk adımın size neden hiç kaliteye mal olması gerekmediğini
+      <a href="../video-kesme/">kesme rehberi</a> anlatıyor.
+    </p>
+    <p>
+      Aynı sıra kırpma için de geçerlidir: kesin, kırpın, ters çevirin; olabilecek en
+      kısa klibin bir yeniden kodlamasının bedelini ödeyin.
+    </p>
+  </section>
+
+  <section>
+    <h2>İnsanlar bunu gerçekte ne için kullanıyor</h2>
+    <ul>
+      <li>
+        <strong>Geri sarma şakası.</strong> Bir şey düşer, kırılır ya da su sıçratır
+        ve ters çevirmek onu yerine koyar. Şaka olarak okunur; çünkü geriye doğru
+        oynatılan gerçek görüntü apaçıktır &mdash; duman toplanır, su yukarı
+        tırmanır.
+      </li>
+      <li>
+        <strong>Elle bumerang.</strong> Kısa bir klibi ters çevirin ve
+        <a href="../../video-kesme/">Video Kesici</a> ile özgün hâline ekleyin;
+        genellikle bunu yapan uygulama olmadan ve onun değil sizin seçtiğiniz
+        uzunlukta, ileri-sonra-geri döngüsünü alın.
+      </li>
+      <li>
+        <strong>Ortaya çıkarmalar.</strong> Derli toplu son hâli çekin ve ters
+        çevirin; böylece bitmiş bir tabak malzemeye dönüşsün ya da birleştirilmiş bir
+        şey parçalarına ayrılsın. İleri sürümünden çekmesi daha kolaydır; işin özü de
+        budur.
+      </li>
+      <li>
+        <strong>Ters konuşma.</strong> Ki bu yalnızca ses gerçekten ters
+        çevrilmişse ilginçtir &mdash; yukarıya bakın.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Biçimler ve ne kadar sürdüğü</h2>
+    <p>
+      <strong>MP4, M4V ve MOV</strong>, tarayıcınız o kodlayıcıyı çözebildiği sürece
+      içlerinde ne olursa olsun &mdash; H.264, HEVC, AV1 ya da VP9 &mdash; doğrudan
+      okunur. Hızlı yol budur: dosya, seferinde bir kare grubu olmak üzere geriye
+      doğru gezilir; makineniz ne kadar hızlıysa o kadar hızlı.
+    </p>
+    <p>
+      <strong>Tarayıcınızın oynatabildiği başka her şey</strong>, en bilineni WebM,
+      tarayıcının kendi oynatıcısı klip boyunca seferinde bir an geriye adımlanarak
+      ters çevrilir. İşe yarar ve daha yavaştır; çünkü bu adımların her biri
+      tarayıcıya, önündeki anahtar kareden itibaren çözme yaptırır. Sayfa, siz
+      başlamadan önce iki yoldan hangisini kullandığını ve sebebini söyler.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV ve çoğu MKV</strong>'yi tarayıcı ne okuyabilir ne
+      oynatabilir; araç da yarı yolda çuvallamak yerine bir iletiyle reddeder.
+    </p>
+    <p>
+      Her hâlükârda bu, bu sitedeki daha yavaş işlerden biridir; çünkü her kare
+      çözülüp kodlanır ve bazı kareler birden fazla kez çözülür. Kısa bir klip
+      saniyeler sürer; uzun bir 4K klip ise başlatıp bırakmaya değer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir tarayıcıda video çözüp yeniden kodlamak yenidir ve gerçektir: WebCodecs,
+      telefonunuzun video kaydetmek için kullandığı donanım kodlayıcısının aynısını
+      açar ve aynı sebeple hızlıdır. İş, dosyaya zaten sahip olan makinede olur ki
+      büyük bir video için anlamı olan tek düzen de budur &mdash; onu yükleyip sonucu
+      indirmek, kodlamanın kendisinden fazla zaman alır.
+    </p>
+    <p>
+      Buradaki aracın hiçbir türde ağ özelliği yoktur ve sayfanın
+      <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi tek
+      tek sayar; bunların hiçbiri bu siteye ait değildir. Size söylenmesindense
+      denetlemeyi tercih ederseniz internet bağlantısını kesin ve yine de bir klibi
+      ters çevirin.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> herhangi bir araçta çalıştırabileceğiniz üç denetim
+      daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/reverse-a-video.toml
+++ b/locales/tr/pages/guides/reverse-a-video.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir videoyu ters oynatmak - Türkçe.
+#
+
+nav = "Videoyu ters oynatma"
+title = "Bir Video Nasıl Ters Oynatılır (Sesiyle Birlikte)"
+description = "Bir klibi geriye doğru oynatın: ters çevirmenin resme ve sese ne yaptığı, neden yeniden kodlamadan yapılamayacağı, neden kesmekten yavaş olduğu ve önce ne yapılması gerektiği."
+heading = "Bir video nasıl ters oynatılır"
+lede = """
+    Bir klibi geriye doğru oynatmak var olan en basit düzenleme gibi geliyor ve
+    bir video dosyasının en az hazırlıklı olduğu iş bu. Bu rehber gerçekte ne
+    olması gerektiğini, bunun bedelini ve ondan önce yapmaya değen tek adımı
+    anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir video nasıl ters oynatılır"
+og_description = "Bir çözücü neden geriye doğru çalışamaz, ters çevirmek resme ve sese neye mal olur ve önce yapmaya değen tek adım."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/scan-a-document-with-your-phone.html
+++ b/locales/tr/pages/guides/scan-a-document-with-your-phone.html
@@ -1,0 +1,236 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      Sayfayı, sayfayla aynı renkte olmayan bir şeyin üstüne koyun, üstünde durun,
+      kareyi doldurun ve tek bir fotoğraf çekin. Sonra
+      <a href="../../belge-tarayici/">Belge Tarayıcı</a>'yı açın, bulduğu dört
+      köşeyi denetleyin, &ldquo;renkli, ışığı dengelenmiş&rdquo; ya da &ldquo;siyah
+      beyaz&rdquo;ı seçin ve PDF'i kaydedin.
+    </p>
+    <p>
+      İşin tamamı bu. Geri kalanı, bu adımların her birinin neyi düzelttiğini
+      anlatıyor; çünkü hangi parçanın ne yaptığını bilmek, göndermek üzere olduğunuz
+      şeyin kabul edilip edilmeyeceğini üç saniyede anlamanızı sağlayan şeydir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir fotoğrafı bir taramadan gerçekte ne ayırır</h2>
+    <p>
+      Üç şey ve eşit derecede önemli değiller.
+    </p>
+    <ul>
+      <li>
+        <strong>Açı.</strong> Bir fotoğraf, nerede duruyorsanız oradan çekilir; yani
+        sayfa bir dikdörtgen değil bir dörtgendir. Herkesin fark ettiği ve geri
+        alması en kolay olan budur.
+      </li>
+      <li>
+        <strong>Işık.</strong> Bir tarayıcı sayfa boyunca eşit bir ışık sürükler. Bir
+        oda sürüklemez: lambanın altında parlak bir alan, ondan uzakta loş bir köşe
+        ve çok sık, bir yana düşen kendi gölgeniz vardır. Bir fotoğrafı fotoğraf gibi
+        gösteren şey gerçekte budur ve insanların &ldquo;otomatik karşıtlık&rdquo;la
+        düzeltmeye çalıştığı da budur; o da işi kötüleştirir.
+      </li>
+      <li>
+        <strong>Boyut.</strong> Bir sayfanın on iki megapiksellik fotoğrafı üç ila
+        beş megabayttır. Bunlardan yirmi tanesi, gönderildiği posta sunucularının
+        yarısından geri sekecek bir belgedir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Fotoğrafı çekmek</h2>
+    <p>
+      Beş şey, yarattıkları fark sırasıyla:
+    </p>
+    <ul>
+      <li>
+        <strong>Kareyi doldurun.</strong> Sonradan düzeltilemeyen tek şey budur.
+        Fotoğrafta olmayan ayrıntı dosyada da yoktur ve odanın öbür ucundan
+        fotoğraflanmış bir sayfa, hiçbir çözünürlükte kimsenin okuyamayacağı bir
+        sayfadır. Yakınlaştırmak yerine yaklaşın: telefon ikinci ve daha uzun bir
+        merceğe geçmediği sürece yakınlaştırmak aynı sensörün bir kırpmasıdır
+        &mdash; korumaya çalıştığınız pikselleri tam olarak o atar.
+      </li>
+      <li>
+        <strong>Başka renkte bir şeyin üstüne koyun.</strong> Beyaz bir masadaki
+        beyaz bir sayfanın, hiçbir şeyin bulabileceği bir kenarı neredeyse yoktur
+        &mdash; ne yazılımın ne de köşeleri elle sürüklemeye kalktığınızda sizin.
+        Koyu bir masa, bir kitap, bir mont: ne olursa.
+      </li>
+      <li>
+        <strong>Sayfayla ışığın arasına girmeyin.</strong> Sayfaya düşen kendi
+        gölgeniz, bir telefon taramasının kötü görünmesinin en yaygın tek sebebidir.
+        Doksan derece dönün, gitsin.
+      </li>
+      <li>
+        <strong>Odaklanmasını bekleyin, sonra kıpırdamayın.</strong> Kamera
+        titremesi hiçbir araçla geri alınamaz; kaçırılmış bir odak da öyle. Ekranda
+        sayfaya dokunun, oturmasını bekleyin, sonra düğmeye basın.
+      </li>
+      <li>
+        <strong>Sayfanın tamamını, köşeler dâhil kareye alın.</strong> Köşeler
+        kıymetli olduğu için değil, düzeltmenin onlardan ölçüldüğü için. Karenin
+        kenarından taşan bir sayfa yine de çalışır &mdash; fotoğrafın kenarı, sayfanın
+        kenarının yerini tutar &mdash; ama üç köşesi karede olan ve dördüncüsü tahmin
+        edilen bir sayfa, biraz yanlış çıkacak bir sayfadır.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Düzeltme: şekil neden açıdan önemli</h2>
+    <p>
+      Açıyı geri almak iyi anlaşılmış bir aritmetiktir. Herhangi bir yerden görülen
+      bir dikdörtgenin dört köşesi, onları yerine koyan dönüşümü belirler ve bunu her
+      piksele uygulamak düz bir sayfa verir. Bir sayfayı düzelttiğini iddia eden her
+      araç bunu yapıyordur.
+    </p>
+    <p>
+      Sessizce ters giden kısım, düz sayfanın <em>ne kadar büyük</em> olması
+      gerektiğidir. Apaçık yöntem, dörtgenin kenarlarını ölçüp oranlarını kullanmaktır
+      &mdash; ve açıyla çekilmiş bir fotoğraf uzaktaki kenarı kısaltır, yani bir A4
+      sayfası gözle görülür biçimde bodur çıkar. Yine de tarama gibi görünür.
+      Üstündeki her metin satırı düpedüz yanlış yüksekliktedir ve ekranda hiçbir şey
+      bunu söylemez.
+    </p>
+    <p>
+      Daha iyi cevap şudur: bilginin kendisi perspektifin içindedir. Kameranın
+      sıradan bir kamera olduğu dışında hiçbir şey bilinmese bile, bir dikdörtgenin
+      fotoğrafı hem dikdörtgenin gerçek oranlarını hem de kameranın odak uzaklığını
+      geri kazanmaya yeter. Buradaki
+      <a href="../../belge-tarayici/">Belge Tarayıcı</a> bunu yapar ve ardından
+      sayfanın hangi şekilde çıktığını ve bunun standart bir sayfa olup olmadığını
+      söyler &mdash; yani &ldquo;1:1,41; bu, A4 ya da A5'in şeklidir&rdquo; diyen bir
+      sayfa, düşünmeyi bırakabileceğiniz bir sayfadır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Işık: gerin değil, bölün</h2>
+    <p>
+      Dengesiz aydınlatılmış bir sayfanın karşıtlığını artırmak, parlak kısmı beyaz ve
+      karanlık kısmı siyah yapar ve karanlık kısımdaki yazı da onunla birlikte
+      kaybolur. Sorun hiçbir zaman karşıtlığın fazla düşük olması değildi. Kâğıdın bir
+      köşede başka bir köşedekiyle aynı parlaklıkta olmamasıdır; yani sayfanın tamamı
+      için doğru olan tek bir ayar yoktur.
+    </p>
+    <p>
+      İşe yarayan şey, kâğıdın <em>her noktada</em> ne kadar parlak olduğunu tahmin
+      edip ona bölmektir. Kâğıt, bir sayfanın herhangi bir küçük parçasında parlak
+      çoğunluktur; yani parlaklığı küçük karelerden oluşan bir ızgara boyunca ölçüp
+      her birinde yüksek bir değer almak, ışığın şeklini verir &mdash; metin, onu
+      oynatamayacak kadar koyu ve seyrektir. Ona bölün ve geriye eşit aydınlatılmış
+      mürekkep kalsın; gölge gitsin ve kâğıt beyaza dönsün.
+    </p>
+    <p>
+      &ldquo;Renkli, ışığı dengelenmiş&rdquo; ile &ldquo;gri tonlama&rdquo;nın yaptığı
+      budur. Renk belgenin bir parçasıysa renkliyi seçin: bir mühür, mavi mürekkeple
+      atılmış bir imza, vurgulanmış bir satır, birinin sonradan aslı mıydı diye
+      sorabileceği her şey.
+    </p>
+  </section>
+
+  <section>
+    <h2>Siyah beyaz ve dosyanın neden birden küçüldüğü</h2>
+    <p>
+      Fotoğraf olarak saklanan bir sayfa, her biri on altı milyon olası renge sahip
+      milyonlarca pikseldir ve kodlayıcı çabasını, bir metin sayfasında bulunmayan
+      ince renk geçişlerine harcar. Siyah beyaz olarak saklanan bir sayfa ise piksel
+      başına tek bittir &mdash; mürekkep ya da kâğıt &mdash; ve ezici biçimde tekrarlı
+      bir şey olarak sıkışır.
+    </p>
+    <p>
+      Fark küçük değildir: aynı sayfalarda kabaca on sekiz kat. Fotoğraf olarak on beş
+      megabayta ulaşan yirmi sayfalık bir sözleşme, tek bitlik sayfalar olarak bir
+      megabaytın altına iner &mdash; ki bu, e-postayla gönderilebilen bir belgeyle
+      gönderilemeyen bir belge arasındaki farktır ve her ofis tarayıcısının varsayılan
+      olarak bunu kullanmasının sebebidir.
+    </p>
+    <p>
+      Püf noktası, ara tonların olmamasıdır: sayfadaki bir fotoğraf bir nokta
+      karmaşasına dönüşür. Bunu basılı ve el yazısı sayfalar için kullanın &mdash;
+      belgelerin çoğu böyledir &mdash; ve üzerinde resim olan her şey için gri tonlama
+      kullanın.
+    </p>
+    <p>
+      Bilmeye değer bir ayrıntı; çünkü iyi bir aracın, kötü bir aracın siyah köşeli
+      sayfa ürettiği yerde neden başarılı olduğunu açıklıyor: mürekkep mi kâğıt mı
+      kararının <em>yerel</em> verilmesi gerekir. Sayfanın tamamı için tek bir eşik,
+      gölgedeki kâğıt ışıktaki mürekkepten koyu olduğunda işe yaramaz &mdash; ve
+      fotoğraflanmış bir sayfada çok sık öyledir. Her pikseli kendi küçük komşuluğunun
+      ortalamasına karşı karara bağlamak, bir gölgenin içindeki yazıyı okunur tutan
+      şeydir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Birkaç sayfa, tek belge</h2>
+    <p>
+      Sayfaları sırayla fotoğraflayın, hepsini birden ekleyin; eklendikleri sırayla tek
+      bir PDF'in sayfaları olsunlar. Dikkat edilecek iki şey:
+    </p>
+    <ul>
+      <li>
+        <strong>Dosya adları düşündüğünüz gibi sıralanmaz.</strong> Alfabetik bir
+        sıralamada <code>page2.jpg</code>, <code>page10.jpg</code>'den sonra gelir;
+        çünkü karşılaştırma karakter karakterdir. Sırayı sonradan PDF'te değil, önce
+        şeritte denetleyin.
+      </li>
+      <li>
+        <strong>Temizleme, belgenin tamamı için tek bir ayardır</strong> ve bilerek
+        öyledir. Farklı temizlenmiş sayfalar, birbirine zımbalanmış iki belge gibi
+        görünür ki bir taramanın kaçınmayı amaçladığı izlenim tam olarak budur. En kötü
+        sayfaya uyan kipi seçin.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Göndermeden önce</h2>
+    <ul>
+      <li>
+        <strong>PDF'i açın.</strong> Ön izlemeyi değil &mdash; dosyayı. Her sayfa,
+        doğru yönde, hiçbir kenardan kesilmemiş.
+      </li>
+      <li>
+        <strong>Sayfadaki en küçük şeyi okuyun.</strong> Bir referans numarası, bir
+        tarih, bir hesap numarası. Ekranda %100'de okuyamıyorsanız gönderdiğiniz kişi
+        de okuyamaz.
+      </li>
+      <li>
+        <strong>Köşelerin kırpılmadığını denetleyin.</strong> Bir formun kenarında
+        duran şey bir sayfa numarası, bir imza satırı ya da birinin sonradan eksik
+        olduğunu söyleyeceği kutudur.
+      </li>
+      <li>
+        <strong>Belgenin sizin hakkınızda ne söylediğine bakın.</strong> Bir PDF'in
+        yazar, üretici ve oluşturma tarihi için alanları vardır ve çoğu araç onları
+        doldurur. Bunun önemli olup olmadığı belgeyi kimin aldığına bağlıdır, ama orada
+        olduğunu bilmeye değer.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin neden bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Yukarıdaki her adım, kendi makinenizin zaten çözmüş olduğu bir resim üzerinde bir
+      aritmetiktir: dört köşe, bir dönüşüm, bir bölme, bir eşik ve baytı baytına yazılan
+      bir kap. İçinde bir sunucunun yapıp bir tarayıcının yapamayacağı hiçbir şey yok ve
+      bunu yapmak için indirilecek bir model de yok.
+    </p>
+    <p>
+      Bu dosyaların ne olduğu düşünülünce burada durup düşünmeye değer. İnsanlar rastgele
+      sayfa fotoğraflamaz. Bir pasaportu, bir maaş bordrosunu, bir kira sözleşmesini, bir
+      sağlık formunu, bir sözleşmeyi fotoğraflarlar &mdash; üzerinde bir ad, bir adres ve
+      bir hesap numarası olan ve tam da bir kurum istediği için taranan belgeleri. Bir
+      tanesini, köşeleri düzeltilsin diye bir web sitesine yüklemek, bir yabancıya
+      belgenin tamamını vermektir.
+      <a href="../dosya-yuklemek-guvenli-mi/">Bir aracın dosyalarınıza gerçekten ihtiyacı
+      olup olmadığını nasıl anlarsınız</a> sayfası, dosyanızı görmek zorunda olan araçları
+      düpedüz gören araçlardan ayıran dört denetimi anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/scan-a-document-with-your-phone.toml
+++ b/locales/tr/pages/guides/scan-a-document-with-your-phone.toml
@@ -1,0 +1,18 @@
+#
+# Rehber: bir belgeyi telefon kamerasıyla taramak - Türkçe.
+#
+
+nav = "Telefonla tarama"
+title = "Bir Belge Telefonla Nasıl Taranır (Uygulama Yok, Yükleme Yok)"
+description = "Bir sayfanın fotoğrafını, o sayfanın taramasından ayıran şey: açı, dengesiz ışık ve dosya boyutu. Fotoğrafın nasıl çekileceği, sonradan neyin düzeltileceği ve bunların hiçbirinin neden bir sunucuya ihtiyacı olmadığı."
+heading = "Bir belge telefonla nasıl taranır"
+lede = """
+    Biri sizden bir formu &ldquo;tarayıp geri göndermenizi&rdquo; istedi;
+    elinizde bir telefon var, tarayıcı yok. Bir sayfanın fotoğrafı ile taraması
+    arasındaki fark göründüğünden küçüktür ve büyük ölçüde açıyla ilgili değildir
+    &mdash; bu rehber onları gerçekte neyin ayırdığını ve her parça için ne
+    yapmanız gerektiğini anlatıyor."""
+updated = "25 Ağustos 2026"
+og_title = "Bir belge telefonla nasıl taranır"
+og_description = "Açı, gölge ve dosya boyutu - bir sayfanın fotoğrafını taramasından ayıran şey ve sayfayı yüklemeden her birini nasıl düzelteceğiniz."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/split-a-gif-into-frames.html
+++ b/locales/tr/pages/guides/split-a-gif-into-frames.html
@@ -1,0 +1,178 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../gifi-karelere-ayirma/">GIF Ayırıcı</a>'yı açın, GIF'i bırakın;
+      her kare indirebileceğiniz bir PNG olarak görünsün &mdash; teker teker ya da
+      hepsi tek bir ZIP olarak. Ayarlara dokunmayın, çoğu insanın kastettiği şeyi
+      tam olarak alın: her kare, canlandırmanın o anında göründüğü hâliyle, resmin
+      tamamı olarak.
+    </p>
+    <p>
+      Bu sayfanın geri kalanı, sonrasında insanları şaşırtan üç şeyle ilgili:
+      yalnızca küçük bir yamadan ibaret bir kare, başka bir yerde siyaha dönen
+      saydamlık ve kareler ayrı dosyalar hâline geldiğinde artık var olmayan
+      zamanlama.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir GIF karesi gerçekte nedir</h2>
+    <p>
+      Bir GIF bir resim yığını değildir. <em>Tek</em> bir resim ve ardından gelen bir
+      yamalar dizisidir.
+    </p>
+    <p>
+      İlkinden sonraki her kare, yalnızca değişen dikdörtgeni ve ardından tuvale ne
+      yapılacağına dair bir kuralı saklar. Ekrandaki geri kalan her şey, düpedüz daha
+      önceki karelerin orada bıraktığıdır. Durağan bir duvarın önünde konuşan bir
+      insan, kare başına bütün bir resim yerine kare başına bir yüz dikdörtgenine mal
+      olur ve hareket telafisi ile kayıplı adımı olmayan bir biçimin büsbütün
+      kullanılmaz olmamasının bütün sebebi budur.
+    </p>
+    <p>
+      Yani "bana 14. kareyi ver"in eşit derecede dürüst iki farklı cevabı vardır ve
+      araç ikisini de sunar:
+    </p>
+    <p>
+      <strong>Göründüğü hâliyle kare.</strong> O andaki resmin tamamı: kendinden
+      öncekilerin üstüne çizilmiş 14. kare. Varsayılan budur ve bir kontak sayfası,
+      bir küçük resim, paylaşılacak bir kare ya da bir video düzenleyicisine girecek
+      kareler için istediğiniz de budur.
+    </p>
+    <p>
+      <strong>Yalnızca o karenin sakladığı pikseller.</strong> Yamanın kendisi, kendi
+      boyutunda, kendi konumunda ve taşımadığı her şey saydam bırakılmış hâlde. 14.
+      kare, 60&nbsp;&times;&nbsp;40 piksellik bir ağız olabilir. Bir GIF'in
+      baytlarının nereye gittiğini açıklayan görünüm budur ve canlandırmadan resim
+      devşirmek yerine canlandırmayı düzenliyorsanız istediğiniz de budur.
+    </p>
+    <p>
+      Saklanmış bir kare bir parça gibi göründüğünde dosyanızda yanlış bir şey yoktur.
+      Dosya odur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Elden çıkarma kuralı ve bazı karelerin neden delik bıraktığı</h2>
+    <p>
+      Her kare ayrıca, bir sonraki kare çizilmeden önce kendi dikdörtgenine ne
+      olacağına dair dört talimattan birini taşır. Araç bunu, saklanmış görünümde her
+      karenin altında gösterir:
+    </p>
+    <p>
+      <strong>Ekranda kalır.</strong> Alışılmış olan. Yama düştüğü yerde kalır ve bir
+      sonraki kare üstüne çizer.
+    </p>
+    <p>
+      <strong>Sonrasında kendi alanını temizler.</strong> Bir sonraki kare düşmeden
+      önce dikdörtgen silinir. Hareketli saydam bir nesnesi olan bir canlandırmanın
+      yaptığı budur ve titreyen GIF'lerin klasik sebebi de budur.
+    </p>
+    <p>
+      <strong>Altındakini geri getirir.</strong> Tuval, bu kare çizmeden önceki hâline
+      döner &mdash; bir damga, sonra bir geri alma. Nadirdir ve ev yapımı GIF
+      okuyucularının en çok yanlış yaptığıdır.
+    </p>
+    <p>
+      Araçları karşılaştırıyorsanız bilmeye değer bir ayrıntı: belirtim, "alanını
+      temizler"in <em>arka plan rengini</em> geri getirmesi gerektiğini söyler, ama
+      1990'lardan bu yana her tarayıcı bunun yerine <em>saydama</em> temizler; çünkü
+      dönemin canlandırmalarının varsaydığı buydu. Bu araç bilerek tarayıcıları
+      izliyor; böylece aldığınız kareler gördüğünüz kareler oluyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Saydamlığa ne oluyor</h2>
+    <p>
+      GIF saydamlığı tek bittir. Bir piksel ya boyalıdır ya görünmezdir ve arası
+      yoktur &mdash; yumuşak kenar yok, kısmi gölge yok. Saydam arka planı olan bir
+      GIF'in sert ve hafif tırtıklı bir dış hattı olmasının sebebi budur.
+    </p>
+    <p>
+      PNG tam olarak bunu kayıpsız saklar; yani kareler saydamlıkları el değmemiş
+      hâlde çıkar ve hiçbir şey uydurulmaz. Kareler saydamlığı anlayan bir yere
+      gidiyorsa onu koruyun.
+    </p>
+    <p>
+      Gitmiyorsa bunun yerine bir renkle doldurun. Bir alfa kanalını yok sayan
+      yazılım onu genellikle siyah olarak çizer; yani tarayıcıda gayet iyi görünen bir
+      kare siyah arka planla varır &mdash; ve neredeyse her yerinde saydam olan
+      saklanmış bir yama, içinde bir ağız olan siyah bir dikdörtgen olarak varır.
+      Rengi baştan seçmek çözümdür. PNG'nin içine yazılır ve sonradan geri alınamaz;
+      varsayılan olmamasının tek sebebi de budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Karelerin taşıyamadığı şey: zamanlama</h2>
+    <p>
+      Bir PNG'nin, ekranda ne kadar kaldığını kaydedecek bir yeri yoktur. Bir
+      canlandırmayı PNG'lere ayırın, zamanlama gitsin; onu yeniden birleştirmek
+      istediğiniz an bu önemli olur.
+    </p>
+    <p>
+      ZIP'in içindeki <code>frames.txt</code> bunun içindir. Her karenin gecikmesini,
+      konumunu ve boyutunu listeler; böylece canlandırma
+      <a href="../../gif-olusturma/">GIF Yapıcı</a>'da ya da başka bir yerde yeniden
+      kurulabilir. Birkaç kilobayta mal olur ve sonradan yeniden kurmanın bir yolu
+      yoktur.
+    </p>
+    <p>
+      GIF gecikmeleri hakkında herkesi yakalayan iki şey:
+    </p>
+    <p>
+      <strong>Birim, saniyenin yüzde biridir</strong>, yani biçimin sahip olduğu en
+      ince adım 0,01&nbsp;sn'dir. Tam olarak 30&nbsp;fps olan bir GIF diye bir şey
+      yoktur; kare başına 0,03&nbsp;sn, 33,3&nbsp;fps'dir ve 0,04&nbsp;sn 25'tir.
+    </p>
+    <p>
+      <strong>0,02&nbsp;sn'nin altındaki her şey 0,10&nbsp;sn'de oynatılır.</strong>
+      Tarayıcılar bunu 1990'lardan beri sınırlıyor &mdash; dönemin dönen dünya
+      simgeleri için yazılmış ve hiç kaldırılmamış bir kural. Dosyası kare başına
+      0,01&nbsp;sn diyen bir GIF 100&nbsp;fps iddia eder ve 10'da oynar. Araç
+      gecikmeyi gerçekten oynatıldığı hâliyle gösterir ve ikisi farklıysa dosyanın ne
+      sakladığını da yanında söyler; çünkü ayırıp yeniden kurduğunuz bir GIF'in
+      özgününden yavaş çıkmasının sebebi o farktır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kare numaraları ve neden sıfırla dolduruldukları</h2>
+    <p>
+      Kareler <code>ad-001.png</code>, <code>ad-002.png</code> olarak, birden başlayıp
+      son sayının genişliğine kadar sıfırla doldurularak numaralanmış hâlde çıkar. Bu
+      bir süs değildir: <code>frame9.png</code>, her dosya yöneticisinde ve bir dizi
+      içe aktaran çoğu yazılımda <code>frame10.png</code>'den <em>sonra</em> sıralanır;
+      çünkü sayı değil metin sıralarlar. Doldurulmuş adlar her yerde doğru sıralanır ve
+      görüntü dizisi içe aktaran her video düzenleyicisi bunları bekler.
+    </p>
+    <p>
+      Uzun bir canlandırmayı "her ikinci kareyi tut" ile seyreltmek hiçbir şeyi yeniden
+      numaralamaz. 42. kare hâlâ 42. kare diye adlandırılır; böylece dosyalar hem
+      özgününe hem de zamanlama listesine hizalanır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir sunucuya ihtiyacı yok</h2>
+    <p>
+      Bir GIF okumak iki iştir: dosyanın bloklarını gezmek ve piksellerinin sarıldığı
+      LZW sıkıştırmasını geri almak. İkisi birlikte birkaç yüz satırdır, depoda
+      yazılıdır ve kendi makinenizde çalışır &mdash; sayfanın ağ fişi çekilmişken
+      çalışmaya devam etmesinin sebebi de budur.
+    </p>
+    <p>
+      Tarayıcınız bir GIF'i zaten oynatabilir, ama size parçalarını vermez: bir
+      <code>&lt;img&gt;</code> size bir canlandırma verir, birini bir tuvale çizmek
+      size sonsuza kadar ilk kareyi verir ve daha fazlasını yapan tek API Safari'de
+      yoktur. O yüzden biçim burada, her tarayıcıda aynı şekilde okunuyor &mdash; ve
+      onu kendiniz okumanız, size yamaları ve elden çıkarma kurallarını göstermeyi de
+      mümkün kılan şey.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> size bu araç dâhil herhangi bir araç hakkında aynı
+      şeyi söyleyecek dört denetim anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/split-a-gif-into-frames.toml
+++ b/locales/tr/pages/guides/split-a-gif-into-frames.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: hareketli bir GIF'i parçalarına ayırmak - Türkçe.
+#
+
+nav = "GIF'i ayırma"
+title = "Bir GIF Karelerine Nasıl Ayrılır (ve Bir Kare Gerçekte Nedir)"
+description = "Hareketli bir GIF'in her karesini PNG olarak alın: bazı kareler neden resmin yalnızca küçük bir yamasıdır, saydamlığa ne olur ve yeniden birleştirebilmek için zamanlamayı nasıl korursunuz."
+heading = "Bir GIF karelerine nasıl ayrılır"
+lede = """
+    Kareleri çıkarmak bir bırakma ve bir düğme sürer. Anlamaya değen şey, bir GIF
+    "karesi"nin gerçekte ne olduğudur; çünkü biçim, gördüğünüzden epeyce farklı bir
+    şey saklar &mdash; ve on dördüncü karenizin neden birinin ağzından oluşan bir
+    dikdörtgen olduğunun sebebi o farktır."""
+updated = "21 Ağustos 2026"
+og_title = "Bir GIF karelerine nasıl ayrılır"
+og_description = "Bir GIF'in her karesi PNG olarak: bazı kareler neden yalnızca bir yamadır, saydamlığa ne olur ve zamanlamayı nasıl korursunuz."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/trim-a-video.html
+++ b/locales/tr/pages/guides/trim-a-video.html
@@ -1,0 +1,187 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../video-kesme/">Video Kesici</a>'yi açın, klibi bırakın,
+      istediğiniz her parçayı işaretlemek için <kbd>I</kbd> ve <kbd>O</kbd>'ya basın
+      &mdash; kaç tane isterseniz &mdash; ve dışa aktarın. Bir MP4, MOV ya da
+      M4V'de tuttuğunuz kareler yeni dosyaya tam olduğu gibi taşınır &mdash; aynı
+      baytlar, aynı kodlayıcı ayarları, her şeyin aynısı &mdash; ve ses hiç
+      çözülmeden örnek örnek kopyalanır.
+    </p>
+    <p>
+      Bu, bir kesmenin size kalite olarak hiçbir şeye mal olmaması demektir ve
+      hızlıdır: dört gigabaytlık bir kayıttan bir dakika kesmek, kabaca o dakikayı
+      diske yazmanın maliyetindedir; çünkü kareler yüklenmez, gösterilir. Bunun
+      kendini gösterdiği tek yer kesmenizin gerçekte nereye düştüğüdür ve bu sayfanın
+      geri kalanı da odur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir kesmenin neden hiç kalite kaybetmesi gerekmiyor</h2>
+    <p>
+      Kesmek hiçbir karenin görünüşünü değiştirmez. Tuttuğunuz her karenin, girdiği
+      gibi çıkması gerekir; yani onu çözüp yeniden kodlamak için bir sebep yoktur
+      &mdash; ve yapmamak için her sebep vardır, çünkü yeniden kodlama kayıplıdır ve
+      klibi kısaltmak uğruna tamamını biraz kötüleştirirdi.
+    </p>
+    <p>
+      Bu yüzden iyi bir kesici yeniden kodlamaz. Dosyanın dizinini okur, hangi
+      kodlanmış karelerin aralığınıza düştüğünü hesaplar ve o baytları, önlerinde yeni
+      bir dizinle birlikte yeni bir kaba yazar. O yolda hiçbir şey çözülmez.
+    </p>
+    <p>
+      Bir sürü araç yine de yeniden kodlar; çünkü çözüp yeniden kodlamak, kap
+      biçimini ayrıştırmaktan çok daha basit uygulanır. Hangisini kullandığınızı
+      genellikle ne kadar sürdüğünden anlarsınız: bir kopyalama diskinizin yazma
+      hızıyla sınırlıdır, bir yeniden kodlama ise makinenizin video kodlama hızıyla
+      ki o da yüz kat yavaştır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Anahtar kareler ve kesmenizin neden erken düşebileceği</h2>
+    <p>
+      Kesmeyle ilgili her şeyin doğduğu kısıt burada.
+    </p>
+    <p>
+      Video, eksiksiz resimlerden oluşan bir dizi olarak saklanmaz. Bu devasa olurdu.
+      Karelerin çoğu, komşularından nasıl farklı olduklarının bir tarifi olarak
+      saklanır; yani kendi başlarına çözülemezler &mdash; çevrelerindeki karelere
+      ihtiyacınız vardır. Yalnızca bir <strong>anahtar kare</strong> eksiksiz bir
+      resim olarak tek başına durur ve anahtar kareler tipik olarak bir ila on saniye
+      arayla bulunur.
+    </p>
+    <p>
+      Yani bir kesmeyi son anahtar kareden iki saniye sonrasına işaretlerseniz,
+      kareleri kopyalayan bir kesici oradan başlayamaz. İşaretinizdeki kareler, onlara
+      götüren diziyi olmadan okunamaz. İşaretinizin önündeki anahtar kareden itibaren
+      tüm parçayı taşımak zorundadır.
+    </p>
+    <p>
+      Bu konuda ne yaptığı ilginç kısımdır. Dosya biçiminin <em>oynatmaya bu noktadan
+      başla</em> demenin standart bir yolu vardır &mdash; fazladan kareler dosyadadır
+      ama kap, oynatıcıya onları atlamasını söyler. Yaygın her oynatıcı buna uyar ve
+      klip tam olarak söylediğiniz yerde başlar. Bunu yok sayan bir oynatıcı, anahtar
+      kare aralığı kadar erken başlatır.
+    </p>
+    <p>
+      Buradaki araç, siz dışa aktarmadan önce hangi durumda olduğunuzu ve ne kadar
+      olduğunu söyler; böylece bu bir sürpriz değil bir karar olur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Yeniden kodlamayı ne zaman kabul etmeli</h2>
+    <p>
+      Tam bir kesme var ve açılış parçasını yeniden kodlayarak çalışıyor &mdash;
+      anahtar kareden itibaren çözerek ve gerçekten işaretlediğiniz yerde başlayan
+      yeni bir kareler dizisi yazarak. Daha yavaştır ve yalnızca o açılış parçasında
+      bir parça kaliteye mal olur.
+    </p>
+    <p>
+      Klip, kabın talimatına uymayacak bir yere ya da oynatıcıyı
+      denetleyemeyeceğiniz bir yere gidiyorsa bunu seçin: bazı video düzenleyicileri,
+      bazı yayın ve konferans sistemleri, bazı eski donanım oynatıcıları. Başka her
+      şey için &mdash; ki neredeyse her şeydir &mdash; kopyalamayı seçin: bir
+      tarayıcı, bir telefon, bir sosyal platform, bir medya oynatıcısı.
+    </p>
+    <p>
+      Hiçbir şeye mal olmayan üçüncü bir seçenek: işaretinizi oynatın. Araç size
+      anahtar karelerin nerede olduğunu gösteriyorsa kesmeyi en yakınına kaydırmak,
+      hiç yeniden kodlama olmadan tam bir kesme verir. Bir saniyelik fark için
+      kopyalamadan vazgeçmek nadiren buna değer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ortadan bir parça çıkarmak</h2>
+    <p>
+      Bir bölümü kesip çıkarmak, bir bölümü tutmaktan başka bir işlemdir ve
+      desteklendiğini bilmeye değer; çünkü birçok kesici yalnızca ikincisini yapar.
+      İstemediğiniz kısmı işaretleyin, onu kesip çıkarmayı seçin; iki yanda kalan,
+      sesi de adım adım taşınarak tek bir klipte birleştirilsin.
+    </p>
+    <p>
+      Birleşme yerinde, ikinci yarının devam ettiği noktada aynı anahtar kare kısıtı
+      vardır ve sebebi de aynıdır. Burada iki MP4 yolunda da çalışır. Aşağıdaki kayıt
+      yedeğinin yapamadığı tek şey budur; çünkü bir kayıt, tek bir oynatma
+      göstergesinden tek geçişte yapılır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Biçimler ve yedek yol</h2>
+    <p>
+      <strong>MP4, M4V ve MOV</strong>, içlerinde hangi kodlayıcı olursa olsun
+      doğrudan okunur &mdash; H.264, HEVC, AV1, VP9. Kareleri kopyalamak onları
+      çözmeyi içermez; yani bu yol, tarayıcınızda hiç çözücüsü olmayan bir kodlayıcı
+      için bile çalışır ki bu, resimlere bakmamanın hoş bir sonucudur.
+    </p>
+    <p>
+      <strong>Tarayıcınızın oynatabildiği başka her şey</strong>, en bilineni WebM,
+      oynatılıp sonuç kaydedilerek kesilir. Bu çalışır ve iki bedeli vardır: bölüm ne
+      kadar uzunsa o kadar sürer ve resim ile ses yeniden kodlanır.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV ve çoğu MKV</strong>'yi tarayıcı ne okuyabilir ne
+      oynatabilir; araç da yarı yolda çuvallamak yerine bunu söyler. Onları önce,
+      işleyebilen bir şeyle MP4'e çevirin.
+    </p>
+  </section>
+
+  <section>
+    <h2>Başka yerlerde sessizce ters giden iki şey</h2>
+    <p>
+      <strong>Döndürme.</strong> Bir telefon yatay çeker ve pikselleri döndürmek
+      yerine dosyaya bir döndürme talimatı yazar. Kareleri kopyalayan bir kesicinin o
+      talimatı karşıya taşıması gerekir; yoksa dikey klibiniz yan çıkar &mdash; ki
+      kesilmiş bir videonun mahvolmasının klasik yolu budur. Buradaki tam kesme yolu,
+      kareleri yeniden kodlarken döndürür ve hiç döndürmeye ihtiyacı olmayan bir dosya
+      yazar.
+    </p>
+    <p>
+      <strong>Ses eşlemesi.</strong> Ses ve video, kendi zamanlamaları olan ayrı
+      akışlar olarak saklanır ve aynı noktalardan doğranmazlar. İkisi kesme noktasında
+      bilerek hizalanmazsa ses kayar. Buradaki kopyalama yolunda ses hiç çözülmeden
+      örnek örnek kopyalanır, yani dosyada ne varsa baytı baytına odur ve bir düzenleme
+      işareti onu resimle binde bir saniye içinde adım adım tutar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kesmek, kırpmak değildir</h2>
+    <p>
+      Birbirinin yerine kullanılan iki kelime. Kesmek klibin uzunluğunu değiştirir;
+      kırpmak resmin şeklini değiştirir. İstediğiniz şey yatay bir videonun kare
+      sürümüyse ya da yanlardaki siyah bantların gitmesiyse, o
+      <a href="../../video-kirpma/">Video Kırpıcı</a>'dır &mdash; ve kesmenin aksine
+      o, <a href="../video-kirpma/">kendi rehberinin</a> anlattığı sebeple yeniden
+      kodlamak zorundadır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir yüklemeye ihtiyacı yok &mdash; özellikle de bunun</h2>
+    <p>
+      Video, insanların yüklemek zorunda kalacaklarını en çok bekledikleri dosya
+      türüdür; çünkü dosyalar büyüktür ve iş ağır gelir. Kesmek, bunun en az doğru
+      olduğu durumdur: kopyalama yolunda dosya neredeyse hiç okunmaz. Araç dizini
+      gezer, hangi bayt aralıklarının tutulacağını hesaplar ve onları yazar. Dört
+      gigabaytlık bir dosyayı, bunu yapabilsin diye bir sunucuya yüklemek, bunu
+      düzenlemenin olabilecek en yavaş yolu olurdu.
+    </p>
+    <p>
+      Ayrıca, istemiyorsanız yüklemenin en pahalıya patladığı dosya türüdür: video,
+      bir belgenin taşımadığı biçimde yüzler, sesler, evler ve konumlar taşır.
+      Buradaki aracın hiçbir türde ağ özelliği yoktur ve sayfanın
+      <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi tek tek
+      sayar; bunların hiçbiri bu siteye ait değildir.
+    </p>
+    <p>
+      Size söylenmesindense denetlemeyi tercih ederseniz internet bağlantısını kesin
+      ve yine de bir klip kesin.
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> buna benzer üç denetim daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/trim-a-video.toml
+++ b/locales/tr/pages/guides/trim-a-video.toml
@@ -1,0 +1,19 @@
+#
+# Rehber: bir videoyu kesmek - Türkçe.
+#
+# Burada "kesme" süreyi kısaltmak; şekli değiştirmek olan "kırpma" ayrı bir
+# rehber ve sondan bir önceki bölüm tam olarak bu ayrımı anlatıyor.
+#
+
+nav = "Video kesme"
+title = "Bir Video Yeniden Kodlamadan Nasıl Kesilir"
+description = "Bir klibi kesmek tek bir bayt kaliteye mal olmak zorunda değildir. Bir kesme neden bazen işaretlediğiniz yerden önce düşer, anahtar karenin bununla ne ilgisi var ve yeniden kodlamayı ne zaman kabul etmelisiniz."
+heading = "Bir video yeniden kodlamadan nasıl kesilir"
+lede = """
+    Kesmek hiçbir karenin görünüşünü değiştirmez; yani iyi bir kesici onlara
+    dokunmaz &mdash; onları olduğu gibi yeni bir dosyaya taşır. Bu rehber bunun
+    size ne kazandırdığını ve kendini gösterdiği tek yeri anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir video yeniden kodlamadan nasıl kesilir"
+og_description = "Bir kesme neden bazen işaretlediğiniz yerden önce düşer, anahtar karenin bununla ne ilgisi var ve yeniden kodlamayı ne zaman kabul etmelisiniz."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/trim-an-audio-file.html
+++ b/locales/tr/pages/guides/trim-an-audio-file.html
@@ -1,0 +1,223 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../ses-kesme/">Ses Kesici</a>'yi açın, kaydı bırakın, istediğiniz
+      her parçayı işaretlemek için <kbd>I</kbd> ve <kbd>O</kbd>'ya basın &mdash; kaç
+      tane isterseniz &mdash; ve dışa aktarın. Her kesme işaretlediğiniz tam örneğe
+      düşer, tutulan örnekler girdikleri gibi çıkar ve birleşme yerleri
+      tıklayamasınlar diye beş milisaniyelik bir geçiş alır.
+    </p>
+    <p>
+      İşin tamamı bu. Bu sayfanın geri kalanı, tamlığın bir pazarlama iddiası değil
+      gerçek olmasının sebebi ve iki ses parçasını birleştirdiğinizde gerçekten ters
+      giden tek şeyle ilgili.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir video kesmesi olamazken bir ses kesmesi neden tam olabilir</h2>
+    <p>
+      Video, eksiksiz resimlerden oluşan bir dizi olarak saklanmaz &mdash; bu devasa
+      olurdu. Karelerin çoğu, komşularından nasıl farklı olduklarının bir tarifi
+      olarak saklanır, yani kendi başlarına çözülemezler. Yalnızca bir
+      <strong>anahtar kare</strong> tek başına durur ve anahtar kareler tipik olarak
+      bir ila on saniye arayla bulunur. Bu yüzden kareleri kopyalayan bir kesici
+      istediğiniz yerden başlayamaz: bir anahtar kareden başlamak zorundadır; kesilmiş
+      bir videonun bazen işaretinizden bir iki saniye önce başlamasının sebebi de
+      budur. <a href="../video-kesme/">Video rehberi</a> büyük ölçüde bunu
+      anlatıyor.
+    </p>
+    <p>
+      Sesin bir dengi yoktur. Bir kayıt bir kez çözüldüğünde bir sayılar dizisidir
+      &mdash; kanal başına bir tane, saniyede on binlerce &mdash; ve her biri tamamen
+      kendi başına durur. 1.234.567. örneğin anlamlı olmak için 1.234.566. örneğe
+      ihtiyacı yoktur. Yani kesme herhangi bir örnekte yapılabilir ve "tam olarak
+      işaretlediğiniz yer" tam olarak bunu ifade eder: saniye cinsinden işaretiniz,
+      örnekleme hızıyla çarpılıp en yakın tam örneğe yuvarlanır. 48 kHz'de bu
+      yuvarlama en fazla on mikrosaniyedir.
+    </p>
+    <p>
+      Endişelenecek, oynatıcıya bağlı bir davranış da yoktur. Kesilmiş bir video, çoğu
+      oynatıcının uyduğu ve bazılarının yok saydığı bir düzenleme işaretine dayanır;
+      kesilmiş bir WAV ise yalnızca örneklerdir, yani bir oynatıcının anlaşmazlığa
+      düşeceği bir şey kalmaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Püf noktası: bir birleşme yeri bir süreksizliktir</h2>
+    <p>
+      Ses keserken gerçekten ters giden şey ve iyi bir kesicinin bunun için bir ayarı
+      olmasının sebebi burada.
+    </p>
+    <p>
+      Ses bir dalgadır. Bir kelimenin ortasından başka bir kelimenin ortasına
+      kestiğinizde, birinci parçanın sonundaki örnekle ikincinin başındaki örneğin hiç
+      ilişkisi yoktur: dalga biçimi tek bir örnekte aralığının tepesine yakın bir
+      yerden dibine yakın bir yere sıçrayabilir. Bu sıçramayı yapması istenen bir
+      hoparlör konisi, yapabildiği en keskin sesi çıkarır; siz de bunu birleşme
+      yerinde bir <strong>tık</strong> olarak duyarsınız.
+    </p>
+    <p>
+      Bunun kalite kaybıyla ya da biçimle hiç ilgisi yoktur. Kusursuzca temiz bir
+      kaydın kusursuzca kayıpsız bir kesmesinde de olur. Düpedüz bir süreksizliğin
+      sesidir. Tam örnekte kesip başka bir şey yapmayan bir kesici, tamamen dalga
+      biçiminde iki ucun nereye denk geldiğine bağlı olarak bazı birleşme yerlerinde
+      tıklar, bazılarında tıklamaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Beş milisaniyelik bir geçiş gerçekte ne yapıyor</h2>
+    <p>
+      Çözüm, kesmeden hemen önce düzeyi sessizliğe indirmek ve hemen sonra geri
+      yükseltmektir; böylece yapılacak bir sıçrama kalmaz. Buradaki
+      &ldquo;geçiş&rdquo;in tamamı budur: her kenarda birkaç yüz örneğe uygulanan bir
+      rampa.
+    </p>
+    <p>
+      Uzunluk, ilginç kısmıdır. Beş milisaniye, 48 kHz'de yaklaşık iki yüz kırk
+      örnektir. Bu, koninin yol alması için yeterince uzun &mdash; tık tamamen gitmiş
+      olur &mdash; ve bir geçiş olarak duyulamayacak kadar kısadır: beş milisaniye,
+      kabaca tek bir ünsüzü söylemenin beşte biri kadar zamandır. Düzeyin oynadığını
+      algılamazsınız. Yalnızca birleşme yerinin temiz olduğunu algılarsınız.
+    </p>
+    <p>
+      Daha uzun geçişler sunuluyor; çünkü bazı malzemeler onları ister. Kesintiye
+      uğrayan şeyin bir hece değil sürdürülen bir nota olduğu ve en kısa rampanın bile
+      duyulabilir bir pat bırakabildiği müzik birleştirirken yirmi ya da elli
+      milisaniyeye uzanmaya değer. Konuşma neredeyse hiçbir zaman beşten fazlasını
+      istemez.
+    </p>
+    <p>
+      Bir geçiş, yalnızca <em>gerçekten</em> bir kesme olan bir kenara aittir. Bir
+      parça kaydın en başında başlıyorsa önünden hiçbir şey kaldırılmamıştır &mdash;
+      dosya, herhangi bir şey kesilmeden önce de orada başlıyordu &mdash; yani onu
+      geçişle açmak, kimsenin istemediği bir düzenleme olurdu. Buradaki araç geçişleri
+      yalnızca bir birleşme yerinin bulunduğu yerlere koyar; hiçbir şey kesmemenin her
+      örneği el değmemiş bırakmasının sebebi de budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir MP3'ü kesmek ve çıkan şeyin neden WAV olduğu</h2>
+    <p>
+      Bir MP3, bir M4A, bir Ogg ya da bir Opus dosyası açıp kesebilirsiniz. Geri gelen
+      şey bir WAV'dır ve bunu bir özellik gibi sunmak yerine temsil ettiği takas
+      konusunda açık olmaya değer.
+    </p>
+    <p>
+      Sıkıştırılmış sesi kesmenin iki yolu var. Biri, sıkıştırılmış veriyi doğrudan
+      kesmek; kodlanmış kareleri çözmeden bütün hâlde yeni bir dosyaya taşımak. Bu
+      dosyayı küçük tutar ve kaliteye mal olmaz &mdash; ama bir MP3 karesi yaklaşık
+      yirmi altı milisaniye uzunluğundadır, yani her kesme en yakın kare sınırına
+      yuvarlanır ki bu, anahtar kare sorununun ses sürümüdür. Ayrıca biçime özgü bir
+      iştir: bir MP3 okuyucusu hiçbir Opus dosyasını kesmez.
+    </p>
+    <p>
+      Öbür yol, çözmek, tam örnekte kesmek ve örnekleri yazmaktır. Hiçbir şey
+      yuvarlanmaz, tarayıcının oynatabildiği her biçim aynı şekilde çalışır ve
+      geçişler ancak böyle mümkün olur &mdash; çözmediğiniz bir düzeye rampa
+      uygulayamazsınız. Bedeli, örneklerin bir biçimde geri yazılması gerekmesidir ve
+      hiçbir tarayıcı burada kullanılabilecek bir MP3 ya da AAC kodlayıcısıyla
+      gelmez. Bir WAV kodlayıcı istemez: önünde kısa bir başlık olan örneklerdir, yani
+      o adım hiçbir şey kaybettiremez.
+    </p>
+    <p>
+      Pratikteki sonuçlar: çıkan şey girenden çok daha büyüktür &mdash; stereoda
+      kabaca dakikada on megabayt &mdash; ve geldiği MP3'ten <em>daha iyi</em>
+      değildir; çünkü çoktan olmuş sıkıştırma geri alınamaz. Bir WAV'ı her şey açar ve
+      MP3'e ihtiyacı olan her şey ondan tek adımda bir tane yapabilir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir seferde birkaç parça işaretlemek</h2>
+    <p>
+      Çevrimiçi kesicilerin çoğu size tek bir tutamaç çifti verir ve hangi tek parçayı
+      tutacağınızı sorar. Bu, gerçek kayıtların çoğu için yanlış soruyu cevaplar. Bir
+      saatlik bir röportajın tek bir iyi kısmı yoktur; araya serpilmiş altı kısmı
+      vardır ve onları bir kez dinleyerek bulursunuz.
+    </p>
+    <p>
+      O yüzden dinlerken işaretleyin: bir parça başladığında <kbd>I</kbd>, bittiğinde
+      <kbd>O</kbd>, istediğiniz kadar. Her çift, süresini değiştirebileceğiniz ya da
+      yeniden sıralayabileceğiniz bir satıra ve dalga biçiminin üstüne çizilmiş bir
+      banda dönüşür. Bitmiş dosya, o satırların sırayla birleştirilmiş hâlidir.
+    </p>
+    <p>
+      Aynı işaret listesi ters soruyu da cevaplar. Gitmesini istediğiniz şey
+      "eee"ler, çalan telefon ve yanlış başlangıçlarsa <em>onları</em> işaretleyin ve
+      &ldquo;bunları kesip çıkar&rdquo;a geçin &mdash; bunun yerine işaretlemediğiniz
+      her şey birleştirilsin. Her iki durumda da aynı işaretler olduğu için ikisi
+      arasında gidip gelebilir ve hiçbir şeyi iki kez işaretlemeden bitmiş uzunluğun
+      değiştiğini izleyebilirsiniz.
+    </p>
+    <p>
+      İşaretlemek özenli bir iştir ve kapanan bir sekme buna mal olmamalıdır; bu
+      yüzden işaretler düz bir metin dosyası olarak kaydedilir ve geri yüklenir.
+      Düzen, <a href="../../video-kesme/">video kesicinin</a> yazdığı düzendir; yani
+      bir videoya karşı yapılmış işaretler onun çıkarılmış sesinin üstüne
+      bırakılabilir ve tersi de geçerlidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dalga biçimine bakın</h2>
+    <p>
+      Sesi ileri geri sararak işaretlemek tahmin işidir; gözle işaretlemek değildir.
+      Sessizlik sessizliğe benzer, bir öksürük öksürüğe benzer ve biri konuşmaya
+      başlamadan önceki dört saniyelik oda tonu, aranıp bulunmak yerine anında
+      görünür.
+    </p>
+    <p>
+      Bu en çok, insanların biraz yanlış yaptığı işaretler için önemlidir: bir cümlenin
+      başlangıcı genellikle nefesten <em>önceki</em> sessizlikte durmak ister,
+      sonrasında değil; ve sonu genellikle son ünsüzde bir kesme değil bir tempoluk oda
+      tonu ister. İkisi de resimde apaçıktır ve yalnızca kulakla tutturmak neredeyse
+      imkânsızdır. İşaretlenmiş bir parçanın uçlarını dalga biçimi boyunca sürükleyerek
+      oynatın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kesmek geçiş yapmak değildir ve düzenlemek de değildir</h2>
+    <p>
+      Birbirinin yerine kullanılan üç kelime. Kesmek, kaydın hangi kısımlarının hayatta
+      kalacağını değiştirir. Bir geçiş &mdash; saniyeler süren, müzikteki türü &mdash;
+      düzey üzerinde bilinçli bir etkidir ve yukarıda anlatılan birkaç milisaniye o
+      değildir; onlar, tesadüfen aynı aritmetiği kullanan bir tık temizliğidir.
+    </p>
+    <p>
+      İstediğiniz şey kaydın geriye doğru oynatılması, hızlandırılması, perdesi
+      oynamadan yavaşlatılması ya da fazla kısık kaydedildiği için yükseltilmesiyse, o
+      <a href="../../ses-duzenleme/">Ses Düzenleyici</a>'dir. Aynı çözücü ve aynı WAV
+      yazıcıdır; yalnızca arada başka bir aritmetik yapar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Kesmek, bir dizi üzerinde bir aritmetiktir. Tarayıcının zaten bir çözücüsü var
+      &mdash; dosyayı bir <code>&lt;audio&gt;</code> öğesinde oynatan çözücünün
+      aynısı &mdash; ve örnekler bir kez çözüldüğünde bazılarını tutup gerisini
+      düşürmek bir kopyalamadır. Bu tarifin içinde bir sunucunun daha iyi yapabileceği
+      hiçbir adım yoktur ve bir sunucuya gidiş dönüş, bütün işin en yavaş kısmı
+      olurdu.
+    </p>
+    <p>
+      Ayrıca yüklemenin insanların sandığından pahalıya patladığı bir dosya türüdür.
+      Kayıtlar seslerdir: röportajlar, dersler, aramalar, sesli notlar, terapi
+      oturumları, bir çocuğun saklamak istediğiniz bir sözü. Buradaki aracın hiçbir
+      türde ağ özelliği yoktur ve sayfanın <code>Content-Security-Policy</code>'si
+      iletişim kurabileceği her adresi tek tek sayar; bunların hiçbiri bu siteye ait
+      değildir.
+    </p>
+    <p>
+      Size söylenmesindense denetlemeyi tercih ederseniz internet bağlantısını kesin ve
+      yine de bir kayıt kesin.
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya
+      yüklemek güvenli mi?</a> buna benzer üç denetim daha anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/trim-an-audio-file.toml
+++ b/locales/tr/pages/guides/trim-an-audio-file.toml
@@ -1,0 +1,16 @@
+#
+# Rehber: bir ses dosyasını kesmek - Türkçe.
+#
+
+nav = "Ses dosyası kesme"
+title = "Ses Kalite Kaybetmeden Nasıl Kesilir"
+description = "Bir ses kesmesi gerçekte nereye düşer, bir video kesmesi olamazken o neden tam olabilir, bir birleşme yeri neden bazen tıklar ve beş milisaniyelik bir geçiş gerçekte ne yapar."
+heading = "Ses kalite kaybetmeden nasıl kesilir"
+lede = """
+    Bir ses kesmesi, her oynatıcıda, her zaman, işaretlediğiniz tam ana
+    düşebilir &mdash; ki bu video için doğru değildir. Bu rehber bunun sebebini,
+    tek gerçek püf noktasını ve bu konuda ne yapacağınızı anlatıyor."""
+updated = "21 Ağustos 2026"
+og_title = "Ses kalite kaybetmeden nasıl kesilir"
+og_description = "Bir video kesmesi olamazken bir ses kesmesi neden tam olabilir, bir birleşme yeri neden bazen tıklar ve beş milisaniyelik bir geçiş gerçekte ne yapar."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/tr/pages/guides/turn-a-video-into-a-gif.html
@@ -1,0 +1,210 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../videoyu-gife-donusturme/">Videodan GIF'e dönüştürücüyü</a> açın,
+      klibi bırakın, istediğiniz saniyeleri işaretleyin ve genişliği 480'de, hızı da
+      saniyede 12 karede bırakın. Çoğu GIF'in istediği ayar budur. Dosya fazla büyük
+      çıkarsa başka bir şeye dokunmadan önce genişliği düşürün &mdash; iki kez
+      kazandıran ayar odur.
+    </p>
+    <p>
+      Bu sayfanın geri kalanı bunun sebebiyle ilgili; çünkü herkesin gerçekte
+      yaşadığı sorun &ldquo;GIF'im 14 MB&rdquo;dır ve hangi düğmenin çevrileceği
+      apaçık değildir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir videonun GIF'i neden bu kadar devasa</h2>
+    <p>
+      Bir video kodlayıcısı <em>hareketi</em> saklar. Birkaç saniyede bir tam resim
+      yazar ve aradaki her kare için o resmin nasıl hareket ettiğinin bir tarifini
+      yazar: şu piksel bloğu dört birim sola kaydı, şu alan biraz koyulaştı. Beş
+      saniyelik bir klip birkaç yüz kilobayt olabilir; çünkü büyük kısmı, zaten
+      elinizde olan bir resim hakkındaki talimatlardır.
+    </p>
+    <p>
+      GIF'te bunların hiçbiri yok. 1989'da tamamlandı; bunların hiçbiri var olmadan
+      önce. Her kare bir resimdir; bir hesap tablosunun ekran görüntüsü için
+      tasarlanmış bir şemayla kendi başına sıkıştırılır. Biçimin hiçbir yerinde
+      hareket kestirimi yoktur ve eklemenin de yolu yoktur.
+    </p>
+    <p>
+      Yani beklenecek sayı <strong>videonun boyutunun on katıdır</strong> ve hiçbir
+      dönüştürücü sizi bundan vazgeçiremez. İyi bir dönüştürücünün yapabileceği şey,
+      bunun üstüne hiçbir şey israf etmemek ve size buna gerçekten karar veren üç
+      ayarı vermektir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Üç ayar ve her birinin bedeli</h2>
+    <p>
+      Bir GIF'in boyutuyla ilgili her şey, kaç piksel içerdiğine dayanır; o da uzunluk
+      çarpı hız çarpı bir karenin alanıdır.
+    </p>
+    <ul>
+      <li>
+        <strong>Bölüm &mdash; doğrusal.</strong> İki kat uzun, iki kat kare ve kabaca
+        iki kat dosya demektir. Çoğu insanın zaten anladığı ayar budur ve bu konuda
+        acımasız olmaya değer: derdini üç saniyede anlatan bir GIF, hem daha küçük hem
+        de daha iyi bir GIF'tir.
+      </li>
+      <li>
+        <strong>Genişlik &mdash; karesel.</strong> Genişliği yarıya indirmek
+        yüksekliği de yarıya indirir, yani piksellerin <em>dörtte biri</em> demektir.
+        640'tan 320'ye inmek yarıdan biraz az değil, kabaca dörtte üç kazandırır.
+        Kimsenin ilk uzanmadığı ve en çok kazandıran ayar budur.
+      </li>
+      <li>
+        <strong>Kare hızı &mdash; doğrusal.</strong> Saniyede on kare, on beşin üçte
+        ikisi boyutundadır. Ayrıca kaybın en görünür olduğu ayardır; çünkü fazla yavaş
+        hareket küçük değil bozuk okunur.
+      </li>
+    </ul>
+    <p>
+      İşlenmiş bir örnek. Bir telefon klibinin kendi 1080&times;1920'sinde ve 30
+      fps'de altı saniyesi, iki milyon pikselden 180 kare demektir: yaklaşık 350
+      milyon piksel; bu bir GIF değil, bir rehine krizidir. Aynı altı saniye 480
+      genişlikte ve 12 fps'de 400.000 pikselden 72 karedir &mdash; 30 milyon, kabaca
+      on ikide bir &mdash; ve insanların GIF derken kastettiği şeye benzer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hangi kare hızı seçilmeli</h2>
+    <p>
+      On iki buradaki varsayılandır ve şaşırtıcı biçimde sık, doğru cevaptır. Elle
+      çizilen canlandırmanın bir yüzyıldır kullandığı hızdır: gözün sürekli hareket
+      olarak okuyacağı kadar hızlı, kimsenin göremeyeceği karelerin bedelini
+      ödemeyeceğiniz kadar yavaş.
+    </p>
+    <ul>
+      <li><strong>5&ndash;8</strong> &mdash; slayt gösterisi hissi. Yavaş bir
+        kaydırma ya da hiçbir şeyin hızlı hareket etmediği bir ekran kaydı için
+        gayet iyi.</li>
+      <li><strong>10&ndash;15</strong> &mdash; normal. Hareket olarak okunur.
+        Yapmaya değer neredeyse her GIF buradadır.</li>
+      <li><strong>20&ndash;25</strong> &mdash; akıcı ve çoğu izleyicinin adını
+        koyamayacağı bir fark için kabaca 12'nin iki katı boyutunda. Hızlı hareket,
+        bir spor klibi, içinde ani bir kaydırma olan her şey için buna değer.</li>
+    </ul>
+    <p>
+      Bilmenizde fayda olan katı bir tavan var: GIF, her karenin ekranda ne kadar
+      kaldığını saniyenin yüzde biri cinsinden saklar ve her tarayıcı, yüzde ikinin
+      altındaki bir gecikmeyi on olarak işler. Yani gerçek azami hız saniyede 50
+      karedir ve 100 isteyen bir dosya sessizce 10'da oynar. Size 60 fps sunan bir
+      dönüştürücü ya bunu yok sayıyordur ya da sizi şaşırtmak üzeredir.
+    </p>
+  </section>
+
+  <section>
+    <h2>256 renk ve titremenin ne işe yaradığı</h2>
+    <p>
+      Biçimin yaşının öbür yarısı: bir GIF en fazla 256 renkten oluşan tek bir tablo
+      taşır ve her piksel, onun içine işaret eden bir sayıdır. Bir video karesinde on
+      altı milyona kadar renk vardır. Bunun neredeyse tamamı atılır ve nasıl atıldığı,
+      bir GIF'in görünüşünün büyük kısmıdır.
+    </p>
+    <p>
+      İyi bir dönüştürücü, sabit bir küme kullanmak yerine <em>sizin</em> klibinizdeki
+      renkleri sayar ve ona uyan 256 tanesini seçer. Bir orman çekimi 256 yeşil alır;
+      bir gün batımı çekimi 256 turuncu alır. Buradaki aracın yaptığı budur ve bunu
+      yalnızca ilk karede değil bölümün her karesinde yapar; böylece yalnızca sonda
+      görünen bir renk de yer bulur.
+    </p>
+    <p>
+      <strong>Titreme</strong>, ihtiyacınız olan rengin yine de eksik olduğu yerde
+      olan şeydir. Koca bir alanı en yakın mevcut renge yuvarlamak yerine &mdash; ki
+      bu, yumuşak bir gökyüzünü aralarında görünür basamaklar olan dört düz banda
+      çevirir &mdash; en yakın iki rengi ince bir desende dönüşümlü kullanır ve normal
+      bir izleme mesafesinden gözünüz onları, orada olmayan renge karıştırır.
+    </p>
+    <ul>
+      <li><strong>Fotoğrafa benzeyen her şeyde açık bırakın</strong>: gökyüzü, ten,
+        renk geçişleri, gölgeler, film.</li>
+      <li><strong>Düz renkte kapatın</strong>: ekran kayıtları, çizgi çalışmaları,
+        logolar, çizgi filmler, geniş tek ton alanları olan her şey. Korunacak bir
+        geçiş yoktur ve dosya onsuz hem küçük hem temizdir.</li>
+    </ul>
+    <p>
+      Dönüştürücüleri karşılaştırıyorsanız bilmeye değer bir ayrıntı. Titremenin apaçık
+      yolu &mdash; görüntü düzenleyicilerin çoğunun kullandığı hata yayılımı &mdash;
+      her pikselin sonucunu çevresindeki piksellere bağımlı kılar. Bir canlandırmada bu,
+      hareket etmeyen bir arka planın bile her karede farklı titremesi demektir; yani
+      gözle görülür biçimde kaynar ve her karenin tam olarak saklanması gerekir, çünkü
+      teknik olarak her piksel değişmiştir. Alternatifi olan sıralı titreme yalnızca bir
+      pikselin nerede olduğuna bağlıdır; yani durağan bir arka plan kusursuz biçimde
+      durağan kalır. Bu araç onu kullanıyor ve dosyalarının hem küçük hem sakin
+      olmasının sebebi de budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ne zaman hiç GIF yapmamalı</h2>
+    <p>
+      Sormaya değer; çünkü dürüst cevap çoğu zaman &ldquo;yapmayın&rdquo;dır. Sessiz,
+      döngüye alınmış bir MP4 ya da WebM, aynı canlandırmanın GIF hâlinin kabaca onda
+      biri boyutundadır, aynı şekilde oynar ve zaten her sosyal platformun siz
+      yükledikten sonra GIF'inizi çevirdiği şeydir.
+    </p>
+    <p>GIF'i, hedefin gerçekten bir tanesine ihtiyacı olduğu yerde koruyun:</p>
+    <ul>
+      <li>yalnızca görsel kabul eden bir yer &mdash; birçok sohbet, forum, viki ve
+        e-posta yazılımı;</li>
+      <li>bir GIF'in satır içinde oynadığı ve bir videonun oynatıcı gerektirdiği bir
+        README ya da belgelendirme sayfası;</li>
+      <li>çevrimdışıyken de hareket etmesi gereken bir sunum destesi ya da belge;</li>
+      <li>bir emoji, bir çıkartma, bir tepki &mdash; yukarıdaki boyut aritmetiğinin
+        hiçbirinin önemli olmayacağı kadar küçük.</li>
+    </ul>
+    <p>
+      Sesin önemli olduğu yerde soru kendi kendini cevaplar: GIF'in hiçbir zaman sesi
+      olmadı ve olmayacak. Bunun yerine videoyu kesin &mdash;
+      <a href="../../video-kesme/">Video Kesici</a>, tek bir karesini bile yeniden
+      kodlamadan bir bölüm çıkarır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir boyut sınırının altına inmek</h2>
+    <p>
+      Birinin bir GIF'i ayarlamasının sebebi çoğunlukla öbür uçtaki bir sınırdır.
+      Kabaca ne kadar sıktıkları sırasıyla:
+    </p>
+    <ul>
+      <li><strong>E-posta</strong> &mdash; iletinin tamamı için 10 ila 25 MB ve buna
+        yakın bir ek, aradaki bir şey tarafından soyulur ya da geri sektirilir. Epeyce
+        altını hedefleyin.</li>
+      <li><strong>Sohbet ve forumlar</strong> &mdash; yaygın olarak 8 ila 10 MB,
+        bazen bir indirme yerine satır içi ön izleme için çok daha azı.</li>
+      <li><strong>Bir GitHub README'si</strong> &mdash; dosya başına 10 MB ve birkaç
+        megabaytı geçen her şey sayfayı bir telefonda bozuk hissettirir.</li>
+      <li><strong>Çıkartma ve emoji yuvaları</strong> &mdash; çoğu zaman birkaç yüz
+        kilobayt; bu da düşük bir kare hızı değil, küçük bir genişlik ve kısa bir
+        bölüm demektir.</li>
+    </ul>
+    <p>
+      Sınırı aştığınızda denenecek sıra: bölümü kısaltın, sonra genişliği yarıya
+      indirin, sonra hızı düşürün, sonra titremeyi kapatın. İlk ikisi, son ikisinin
+      toplamından değerlidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir videoyu GIF'e çevirmek; çözmek, boyutlandırmak, renk saymak ve sıkıştırmaktır
+      &mdash; bir tarayıcının yıllardır kendi başına yapabildiği dört şey. En üstte
+      bağlantısı verilen araç hepsini sizin makinenizde yapar: dosya diskinizden
+      okunur, kareler tarayıcınız tarafından çözülür ve GIF bellekte bir araya getirilip
+      indirmelerinize verilir.
+    </p>
+    <p>
+      Burada bunu önemsemeye her zamankinden çok değer. İnsanların GIF'e çevirdiği
+      klipler kişisel olanlardır &mdash; bir aile videosundan bir an, işteki bir şeyin
+      ekran kaydı, bir aramadan birkaç saniye. Bunların yüklenmesini isteyen bir
+      dönüştürücü, onların bir kopyasını istiyordur ve evet demek için geriye teknik bir
+      sebep kalmamıştır.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/tr/pages/guides/turn-a-video-into-a-gif.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir videoyu GIF'e çevirmek - Türkçe.
+#
+
+nav = "Videodan GIF yapma"
+title = "Bir Video Nasıl GIF'e Çevrilir (ve Küçük Tutulur)"
+description = "Hangi bölümü, hangi genişliği ve hangi kare hızını seçmelisiniz, bir videonun GIF'i neden videonun on katı boyutunda olur ve GIF'i ne zaman kullanmalısınız."
+heading = "Bir video nasıl GIF'e çevrilir"
+lede = """
+    GIF, hareketi değil bütün resimleri saklayan, 1987'den kalma bir biçimdir;
+    yani bir videodan yapılanı her zaman büyüktür. Bu rehber, fazla büyük
+    olduğunda üç ayardan hangisini oynatacağınızı ve her birinin size ne
+    kazandırdığını anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir video nasıl GIF'e çevrilir ve küçük tutulur"
+og_description = "Bir GIF'in boyutuna karar veren üç ayar, her birinin bedeli ve GIF'in tamamen yanlış cevap olduğu durumlar."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/turn-images-into-a-video.html
+++ b/locales/tr/pages/guides/turn-images-into-a-video.html
@@ -1,0 +1,177 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../resimleri-videoya-donusturme/">Görsellerden Videoya</a>'yı açın,
+      resimleri bırakın, sıraya dizin, her birinin ne kadar tutulacağını belirleyin ve
+      videoyu oluşturun. Esasen her şeyde oynayan, H.264 videolu bir MP4 alırsınız.
+    </p>
+    <p>
+      En sık ikinci bir geçiş gerektiren iki ayar süre ve çözünürlüktür ve bunları ilk
+      çizimden sonra değil önce anlamaya değer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kare hızı ile süre aynı şey değildir</h2>
+    <p>
+      İnsanlara yeniden çizime mal olan karışıklık budur.
+    </p>
+    <p>
+      <strong>Süre</strong>, her resmin ekranda ne kadar kaldığıdır. Gerçekten
+      önemsediğiniz ayar budur. Üç saniye, birinin izlediği bir slayt gösterisi için
+      rahat bir varsayılandır; bir ila iki saniye çevik hissettirir; beşin üstündeki
+      her şey, üstünde bir anlatım yoksa ağır gelir.
+    </p>
+    <p>
+      <strong>Kare hızı</strong>, videonun o resmi saniyede kaç kez tekrarladığıdır.
+      Slayt gösterisinin görünüşüyle ilgili hiçbir şeyi değiştirmez &mdash; üç saniye
+      tutulan durağan bir görüntü, saniyede 24 karede de 60'ta da aynı görünür &mdash;
+      ve dosya boyutunu ile kodlama süresini epeyce değiştirir.
+    </p>
+    <p>
+      Yani düz bir slayt gösterisi için düşük bir kare hızı seçin. 24 ya da 30
+      fazlasıyla yeter. Yükseltmenin sebebi, videoda hareket olmasıdır: her fotoğraf
+      boyunca bir kaydırma ya da yakınlaştırma veya aralarında bir çapraz geçiş; düşük
+      bir kare hızının gözle görülür basamaklanma olarak ortaya çıktığı yerler.
+    </p>
+  </section>
+
+  <section>
+    <h2>Çözünürlük ve yanlış şekildeki resimler</h2>
+    <p>
+      Bir videonun tüm uzunluğu boyunca tek bir kare boyutu vardır. Fotoğraflarınızın
+      neredeyse kesinlikle hepsi tek bir boyutu paylaşmıyordur; yani sığmayanlara bir
+      şey olması gerekir &mdash; ve o şey, bilerek yapmaya değen seçimdir.
+    </p>
+    <p>
+      Çözünürlüğü, videonun gideceği yere göre seçerek başlayın:
+    </p>
+    <ul>
+      <li>
+        <strong>1920&times;1080</strong>, genel her şey için. Evrensel olarak
+        destekleniyor, her yerde oynuyor ve çoğu insanın HD derken kastettiği bu.
+      </li>
+      <li>
+        <strong>1080&times;1920</strong> &mdash; aynı sayıların ters çevrilmiş hâli
+        &mdash; telefon öncelikli bir hedef için: hikâyeler, reels, shorts.
+      </li>
+      <li>
+        <strong>3840&times;2160</strong>, yalnızca resimlerde gerçekten o kadar
+        ayrıntı varsa ve hedef onu gösterecekse. Dört kat piksel, dört kat kodlama
+        süresi ve kabaca dört kat dosya demektir.
+      </li>
+    </ul>
+    <p>
+      Sonra uyumsuzlara ne olacağına karar verin. Her resmi karenin içine sığdırmak
+      hepsini korur ve yanlarda bant bırakır &mdash; güvenlidir ve resimler sunumdan
+      önemliyken doğru cevaptır. Kareyi doldurup taşanı kırpmak daha iyi görünür ve
+      bazılarının üstünü keser. Dikey ve yatay fotoğrafları tek bir videoda karıştırmak,
+      iyi bir cevabın olmadığı durumdur; hangi yönde yanılmayı tercih edeceğinize
+      önceden karar vermek sizi yeniden çizimden kurtarır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sıra ve dosya adı tuzağı</h2>
+    <p>
+      Her yığın işinde olduğu gibi, dosya adları sizin saydığınız biçimde sıralanmaz.
+      Alfabetik bir sıralamada <code>photo2.jpg</code>, <code>photo10.jpg</code>'den
+      sonra gelir; çünkü karşılaştırma karakter karakterdir.
+    </p>
+    <p>
+      Bir etkinliğin fotoğrafları için çekim tarihine göre sıralamak genellikle
+      doğrudur; çünkü onları gerçekleştikleri sırayla çektiniz. Hikâyenin kronolojik
+      olmadığı her şey için kutucukları sürüklemek doğrudur. Çizimden önce denetleyin:
+      video, sırayı düzeltmenin bütün işi yeniden yapmak demek olduğu tek üründür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ses izi yok ve bu küçük bir şey değil</h2>
+    <p>
+      Bu aracın yazdığı MP4'ün tek bir video izi var ve hiç ses izi yok. Slayt
+      gösteriniz müzik ya da anlatım istiyorsa o adım için bir video düzenleyicisine
+      ihtiyacınız olacak.
+    </p>
+    <p>
+      Yalnızca öyle olduğunu değil sebebini de bilmeye değer: ses eklemek, bir müzik
+      dosyasını çözmek, onu AAC'ye kodlamak ve kapta videoyla iç içe geçirmek demektir.
+      Üçü de gerçek bir iştir ve kötü yapıldığında, oynadıkça eşlemesi kayan bir dosya
+      üretir. Yarım yapılmak yerine listede duruyor.
+    </p>
+    <p>
+      Sonradan müzik ekleyecekseniz pratik bir not: önce parçayı seçin ve resim başına
+      süreyi, slayt gösterisi şarkının uzunluğuna yakın çıkacak şekilde ayarlayın.
+      Müziği videoya sığdırmak için kesmek, videoyu müziğe sığdırmaktan her zaman kötü
+      duyulur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ne çıkıyor ve oynamazsa ne yapmalı</h2>
+    <p>
+      Hedef, H.264'lü MP4'tür ve var olan en yaygın oynatılabilir birleşimdir.
+      WebCodecs'i olmayan bir tarayıcıda araç, bunun yerine WebM kaydetmeye geri düşer
+      &mdash; aynı görüntü, daha az düzenleyicinin ve sosyal platformun kabul ettiği bir
+      kapta.
+    </p>
+    <p>
+      Elinizde bir WebM kalırsa ve bir şey onu reddederse çözüm bir dönüştürme değil,
+      WebCodecs'i destekleyen bir tarayıcıdır: Chrome, Edge ve Safari'nin güncel
+      sürümlerinin hepsi destekliyor. Yeniden çizmek dönüştürmekten iyidir; çünkü
+      dönüştürmek bir kuşak daha kayıplı kodlama demektir.
+    </p>
+    <p>
+      Araca yerleşik, kaç resim kullanabileceğinize dair bir sınır yok. Tavan kendi
+      makinenizin belleğidir; çünkü biten video, siz indirmeden önce orada bir araya
+      getirilir &mdash; uzun bir 4K slayt gösterisi bunu ilk hissettiren şeydir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dosyayı küçültmek</h2>
+    <p>
+      Sonuç gideceği yer için fazla büyükse, gerçekten işe yarama sırasıyla:
+    </p>
+    <p>
+      <strong>Kare hızını düşürün.</strong> Durağan bir slayt gösterisi için bu
+      görünür hiçbir şeye mal olmaz ve mevcut en büyük tek kazançtır.
+    </p>
+    <p>
+      <strong>Çözünürlüğü düşürün.</strong> 4K yerine 1080p, piksellerin dörtte
+      biridir ve bir telefon ekranında kimse anlamaz.
+    </p>
+    <p>
+      <strong>Kısaltın.</strong> Resim başına beş yerine üç saniye, uzunluktan %40 ve
+      dosyadan %40 kısar ve genellikle daha iyi bir slayt gösterisi olur.
+    </p>
+    <p>
+      Kaynak fotoğrafları önce küçültmek pek işe yaramaz. Video, ne olursa olsun
+      seçtiğiniz çözünürlükte kodlanır; yani 4000 piksellik bir fotoğrafla 2000
+      piksellik biri, bir 1080p videoda neredeyse aynı sayıda bayt üretir. Kodlamayı
+      hızlandırır ve o bellek tavanını yukarı taşır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun neden bir sunucuya ihtiyacı yok, bir istisnası da söylenmiş hâlde</h2>
+    <p>
+      Video kodlamak eskiden yükleme için en açık gerekçeydi: tarayıcılar yapamıyordu,
+      FFmpeg'i olan bir makine yapabiliyordu. WebCodecs bunu, makinenizde zaten bulunan
+      donanım kodlayıcısını açarak değiştirdi; o da telefonunuzun gerçek zamanlı video
+      kaydetmek için kullandığının aynısı. Kareleri bir araya getirmek bir tuvaldir.
+      İki adımın da kendi donanımınızdan başka bir şeye ihtiyacı yok.
+    </p>
+    <p>
+      Bu araca özgü bir istisna, gömülmek yerine açıkça söyleniyor: isteğe bağlı
+      &ldquo;bir web adresinden ekle&rdquo; özelliği, yapıştırdığınız bir adresten bir
+      görsel getirir ve o adresteki sunucu IP adresinizi ve ne istediğinizi görür. Bu,
+      özelliğin bir kusuru değil doğasıdır ve araçtaki tek ağ adımıdır. Onu kullanmayın,
+      makinenizden hiçbir şey ayrılmasın.
+    </p>
+    <p>
+      <a href="../dosya-yuklemek-guvenli-mi/">Çevrimiçi dönüştürücülere dosya yüklemek
+      güvenli mi?</a> size bu araç dâhil herhangi bir araç hakkında aynı şeyi söyleyecek
+      dört denetim anlatıyor.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/turn-images-into-a-video.toml
+++ b/locales/tr/pages/guides/turn-images-into-a-video.toml
@@ -1,0 +1,16 @@
+#
+# Rehber: görselleri videoya çevirmek - Türkçe.
+#
+
+nav = "Resimlerden video"
+title = "Bir Klasör Dolusu Görsel Nasıl Videoya Çevrilir"
+description = "Fotoğraflardan bir MP4 slayt gösterisi yapın: kare hızı ve süre gerçekte neyi denetler, yanlış şekildeki resimlerle nasıl başa çıkılır ve sonucun neden ses izi yoktur."
+heading = "Bir klasör dolusu görsel nasıl videoya çevrilir"
+lede = """
+    Bir slayt gösterisi yapması basit ve iki kez çizmesi kolay bir şeydir; çünkü
+    ayarlardan ikisi kulağa geldikleri anlama gelmez. Bu rehber her birinin neyi
+    denetlediğini ve ne seçmeniz gerektiğini anlatıyor."""
+updated = "20 Ağustos 2026"
+og_title = "Bir klasör dolusu görsel nasıl videoya çevrilir"
+og_description = "Kare hızı ve süre gerçekte neyi denetler, yanlış şekildeki resimlerle nasıl başa çıkılır ve neden ses izi yoktur."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/verify-a-file-checksum.html
+++ b/locales/tr/pages/guides/verify-a-file-checksum.html
@@ -1,0 +1,238 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      <a href="../../saglama-toplami-hesaplama/">Özet ve Sağlama Toplamı</a>'nı açın,
+      indirdiğiniz dosyayı üzerine bırakın ve indirme sayfasındaki sağlama toplamını
+      alttaki kutuya yapıştırın. Sayfa, sayının hangi algoritmadan geldiğini uzunluğuna
+      bakarak bulur ve tek bir cümleyle cevap verir.
+    </p>
+    <p>
+      Eşleşiyorsa diskinizdeki baytlar, yayıncının ölçtüğü baytlardır. Eşleşmiyorsa
+      dosyayı açmadan önce yeniden indirin. Aşağıdaki her şey, o cümlenin dışarıda
+      bıraktığıdır.
+    </p>
+  </section>
+
+  <section>
+    <h2>İndirme bağlantısının altındaki sayı nedir</h2>
+    <p>
+      Bir özet işlevinin çıktısıdır: bir dosyanın her baytını okuyan ve kısa, sabit
+      uzunlukta bir cevap üreten bir hesap. Aynı dosya her zaman aynı cevabı verir ve
+      tek bir bit farklı olan bir dosya tamamen başka bir cevap verir &mdash; neredeyse
+      aynı olan biri değil, ilgisiz biri. Dayanılan özelliğin tamamı budur.
+    </p>
+    <p>
+      Cevap kısa, dosya kısa olmadığı için hesap bilgiyi atar ve herhangi bir cevabı
+      paylaşan zorunlu olarak birçok dosya vardır. Bunlardan birini bilerek bulmak zor
+      olan kısımdır ve ne kadar zor olduğu, aşağıdaki algoritmaları birbirinden ayıran
+      şeydir.
+    </p>
+    <p>
+      Bir sağlama toplamıyla ilgili hiçbir şey gizli değildir ve hiçbir şey tersine
+      çevrilebilir değildir. Bu bir parmak izidir; iki insan aynı şeyi ellerinde
+      tuttukları konusunda anlaşabilsin diye yayımlanır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hangi algoritmaya bakıyorsunuz</h2>
+    <p>
+      Seçmek zorunda değilsiniz &mdash; yayıncı zaten seçti ve sizin işiniz aynısını
+      hesaplamak. Hangisi olduğunu yalnızca uzunluğundan anlarsınız:
+    </p>
+    <ul>
+      <li><strong>32 onaltılık karakter</strong> &mdash; MD5.</li>
+      <li><strong>40</strong> &mdash; SHA-1.</li>
+      <li><strong>64</strong> &mdash; SHA-256 ve en çok göreceğiniz budur.</li>
+      <li><strong>96</strong> &mdash; SHA-384.</li>
+      <li><strong>128</strong> &mdash; SHA-512.</li>
+    </ul>
+    <p>
+      İkisi de aynı uzunlukta değildir; aracın, yapıştırılan bir değeri kendisine
+      söylenmeden tanıyabilmesinin sebebi de budur. 63 karakter uzunluğunda bir dizge
+      hiçbir şeyin sağlama toplamı değildir; panonuza giderken bir karakterini kaybetmiş
+      bir SHA-256'dır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunu tarayıcısız, kendi makinenizde yapmak</h2>
+    <p>
+      Her işletim sistemi bunu yapan bir şeyle gelir ve bunun için bir sayfa kullansanız
+      bile komutu bilmeye değer &mdash; "sitenizin bunu dürüstçe hesapladığını nereden
+      bileyim" sorusuna, aynı dosyayı bilgisayarınızla gelen araçtan geçirmekten daha iyi
+      bir cevap yok.
+    </p>
+    <p><strong>Windows</strong>, PowerShell'de:</p>
+    <pre><code>Get-FileHash .\disk.iso -Algorithm SHA256</code></pre>
+    <p>
+      Daha eski makinelerde bunun yerine
+      <code>certutil -hashfile disk.iso SHA256</code> vardır; o da büyük harfle ve
+      aralarında boşluklarla yazdırır. Bir sağlama toplamı karşılaştırmasında büyük
+      küçük harf hiçbir zaman önemli değildir; harfler kelime değil, rakamdır.
+    </p>
+    <p><strong>macOS</strong>:</p>
+    <pre><code>shasum -a 256 disk.iso</code></pre>
+    <p><strong>Linux</strong>:</p>
+    <pre><code>sha256sum disk.iso</code></pre>
+    <p>
+      Üçü de aynı dosya için aynı dizgeyi yazdırır ve bu site de öyle. Bunlar
+      yayımlanmış test vektörleri olan kesin belirtimlerdir; bir uygulamanın kendi
+      görüşünü koymasına yer yoktur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gözlerinizi bozmadan karşılaştırmak</h2>
+    <p>
+      Altmış dört karakteri iki ekrandan okuyup aynı göründüklerine karar vermeyin.
+      İnsanlar ilk dördüne ve son dördüne bakıp durur ki bu, bir saldırganın geçmesini
+      ayarlayacağı karşılaştırmanın tam olarak kendisidir ve aynı zamanda dürüst bir
+      hatanın da böyle geçiştirildiği yerdir.
+    </p>
+    <p>
+      İkisini de sizin için karşılaştırabilecek bir şeye yapıştırın. Bir komut satırında
+      <code>-c</code> bayrağının varlık sebebi budur:
+    </p>
+    <pre><code>sha256sum -c SHA256SUMS</code></pre>
+    <p>
+      Bir tarayıcıda ise
+      <a href="../../saglama-toplami-hesaplama/">Özet ve Sağlama Toplamı</a>'ndaki
+      karşılaştırma kutusudur; değeri yayıncı hangi şekilde yazdıysa o şekilde kabul
+      eder &mdash; çıplak onaltılık, bir <code>sha256sum</code> çıktısı satırı, bütün
+      bir <code>SHA256SUMS</code> dosyası, <code>SHA256 (disk.iso) = &hellip;</code>
+      biçimi ya da bir betik etiketinden alınmış bir
+      <code>integrity="sha384-&hellip;"</code> özniteliği &mdash; ve tek bir cümleyle
+      evet ya da hayır der.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir eşleşme tam olarak neyi kanıtlar</h2>
+    <p>
+      Diskinizdeki baytların, o sayıyı yazan kişinin önünde duran baytlar olduğunu.
+      Bu gerçekten bilmeye değer bir şeydir ve çoğu insanın sandığından dardır; o
+      yüzden neyi kapsayıp neyi kapsamadığını listelemeye değer.
+    </p>
+    <p><strong>Bir eşleşmenin dışladıkları:</strong></p>
+    <ul>
+      <li>erken duran ve size eksiksiz görünen bir dosya bırakan bir indirme;</li>
+      <li>aktarım sırasında, bozulan bir diskte ya da kötü bir USB kablosunda
+        bozulma;</li>
+      <li>yanlış dosya &mdash; x86 yerine ARM derlemesi ya da geçen ayın sürümü;</li>
+      <li>duyurduğundan başka bir şey sunan bir yansı.</li>
+    </ul>
+    <p><strong>Bir eşleşmenin dışlamadıkları:</strong></p>
+    <ul>
+      <li><strong>dosyanın kötü niyetli olması.</strong> Bir yayıncı, kötücül yazılımı
+        başka her şey kadar isabetle ölçebilir. Bir sağlama toplamı "gönderdikleri şey
+        budur" der, hiçbir zaman "bu güvenlidir" demez;</li>
+      <li><strong>yayıncının ele geçirilmiş olması.</strong> Biri sunucudaki dosyayı
+        değiştirdiyse yanındaki sağlama toplamını da aynı dakikada değiştirmiştir. Ki
+        bu bizi bir sonraki bölüme getiriyor.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bütün işi anlamsız kılan hata</h2>
+    <p>
+      Sağlama toplamını dosyayla aynı sayfadan, aynı bağlantı üzerinden almak.
+    </p>
+    <p>
+      Neye karşı savunma yaptığınızı düşünün. Endişe bozulmuş bir indirmeyse sağlama
+      toplamı her yerden gelebilir ve denetim işe yarar. Endişe birinin dosyayı
+      kurcalamasıysa, dosyayı değiştirebilen kişi altındaki onaltılık satırı da
+      değiştirebilirdi; çünkü ikisi de aynı sunucudan, aynı bağlantı üzerinden geldi.
+      Sahtecinin imzayı onaylamasını istiyor olurdunuz.
+    </p>
+    <p>
+      Bir sağlama toplamı, size dosyanın gelmediği bir yoldan ulaştığında en
+      değerlidir:
+    </p>
+    <ul>
+      <li>zaten sahip olduğunuz bir anahtara karşı denetlenmiş, ayrık bir GPG imzası
+        olan bir <code>SHA256SUMS</code> dosyası &mdash; dağıtımların yayımladığı budur
+        ve gerçek cevap da budur;</li>
+      <li>indirme sayfası yerine bir posta listesindeki sürüm duyurusu ya da bir kaynak
+        deposundaki bir etiket;</li>
+      <li>başka bir alan adındaki ikinci bir yansı ve ikisinin birbiriyle
+        karşılaştırılması;</li>
+      <li>bunu sizin için, işletim sistemiyle gelen anahtarlara karşı yapan bir paket
+        yöneticisi.</li>
+    </ul>
+    <p>
+      Bunların hiçbiri aynı sayfadaki bir sağlama toplamını denetlemeyi yararsız
+      kılmaz. Bozuk indirmeyi yakalar ki insanların gerçekten başına gelen çuvallama
+      odur. Yalnızca kendinize başka bir şeyi yakaladığını söylemeyin.
+    </p>
+  </section>
+
+  <section>
+    <h2>MD5 ve SHA-1 kırıldı. Yine de bazen kullanın</h2>
+    <p>
+      İkisi de burada önemli olan en güçlü anlamda kırıldı: <em>çakışmalar</em> bilerek
+      kurulabiliyor. Aynı MD5'e sahip iki farklı dosya 2004'ten beri sıradan donanımda
+      kurulabiliyor ve 2017'de bir ekip aynı SHA-1'e sahip iki farklı PDF üretti. 2020'de
+      bu saldırının seçilmiş önek sürümü, kiralanmış birkaç on bin dolarlık hesaplamaya
+      kadar indi.
+    </p>
+    <p>
+      Bunun pratikteki anlamı: eşleşen bir MD5 artık size kimsenin dosyayı
+      kurcalamadığını söylemez; çünkü isteyen biri aynı sayıya sahip farklı bir dosya
+      kurabilirdi. Yine de indirmenin kesilmediğini ya da bozulmadığını söyler; çünkü
+      rastgele bir kaza bir çakışmaya denk gelmez &mdash; bu, hiçbir kazanın sahip
+      olmadığı bir olasılıktır.
+    </p>
+    <p>
+      Yani yayıncı bir MD5 ve başka bir şey yazmadıysa onu denetleyin. Hiç
+      denetlememekten değerlidir. Ve yayımlayan sizseniz bir SHA-256 yazın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Eşleşmedi. Şimdi ne olacak?</h2>
+    <ol>
+      <li>
+        <strong>Aynı yerden yeniden indirin.</strong> Kesilmiş ya da sürdürülmüş bir
+        aktarım açık ara en yaygın sebeptir ve ikinci bir kopya genellikle işi
+        halleder.
+      </li>
+      <li>
+        <strong>Doğru satırda olduğunuzu denetleyin.</strong> Sürüm sayfaları birkaç
+        dosya listeler; yükleyicinin sağlama toplamı hiçbir zaman arşivle eşleşmez ve
+        ARM derlemesi hiçbir zaman x86'yla eşleşmez.
+      </li>
+      <li>
+        <strong>Sürümü denetleyin.</strong> Yer imine eklenmiş sağlama toplamı
+        sayfaları, bir ara sürüm çıktığı gün bayatlar.
+      </li>
+      <li>
+        <strong>Başka bir yansı deneyin</strong> ve iki dosyanın sağlama toplamlarını
+        birbiriyle karşılaştırın. Birbiriyle uyuşup yayımlanan sayıyla uyuşmayan iki
+        yansı, ikisiyle de uyuşmayan tek bir yansıdan başka bir sorundur.
+      </li>
+      <li>
+        <strong>Bu arada onu açmayın.</strong> Sağlama toplamını geçemeyen bir dosya en
+        iyi ihtimalle hasarlıdır, en kötü ihtimalle istediğiniz dosya değildir.
+      </li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Bunu neden bir tarayıcıda yapmalı</h2>
+    <p>
+      Çünkü çoğu insan komut satırında değil ve çünkü apaçık alternatif &mdash; sizden
+      dosyayı yüklemenizi isteyen bir web sitesi &mdash; zaten emin olmadığınız bir
+      yükleyiciyle yapılacak tuhaf bir şey. Aktarım sırasında kurcalanıp
+      kurcalanmadığını öğrenmek için bir dosyayı bir yere göndermek, kurcalanabileceği
+      bir yer daha ekler.
+    </p>
+    <p>
+      <a href="../../saglama-toplami-hesaplama/">Özet ve Sağlama Toplamı</a>, dosyayı
+      kendi makinenizde dört megabaytlık parçalar hâlinde okur; yani yükleme yok, boyut
+      sınırı yok ve sayfanın kendisi dışında güvenilecek bir şey yok &mdash; ki onu
+      okuyabilirsiniz ve ağ fişi çekilmişken de çalışmaya devam eder. Kendi işletim
+      sisteminize güvenmeyi tercih ederseniz yukarıdaki bölümdeki komutu çalıştırın ve
+      iki cevabı karşılaştırın. Uyuşacaklar.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/verify-a-file-checksum.toml
+++ b/locales/tr/pages/guides/verify-a-file-checksum.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir indirmeyi yanındaki sağlama toplamına karşı denetlemek - Türkçe.
+#
+
+nav = "Sağlama toplamı doğrulama"
+title = "Bir İndirme Sağlama Toplamıyla Nasıl Doğrulanır (ve Bu Neyi Kanıtlar)"
+description = "Windows, macOS ve Linux'ta ya da tarayıcınızda bir MD5 veya SHA-256 sağlama toplamı nasıl denetlenir, bir eşleşme gerçekte neyi kanıtlar ve bütün işi anlamsız kılan hata."
+heading = "Bir indirme, sağlama toplamına karşı nasıl denetlenir"
+lede = """
+    Bir indirme bağlantısının altındaki onaltılık satır, dosyanın el değmemiş
+    geldiğini kanıtlayabilesiniz diye oradadır. Karşılaştırmak yaklaşık bir dakika
+    sürer. Karşılaştırmanın ne değerde olduğunu &mdash; ve onu değersiz kılan tek
+    alışkanlığı &mdash; bilmek bu sayfanın geri kalanını alır."""
+updated = "23 Ağustos 2026"
+og_title = "Bir indirmeyi sağlama toplamına karşı denetlemek ve bunun neyi kanıtladığı"
+og_description = "Bir indirme bağlantısının altındaki onaltılık ne işe yarar, herhangi bir işletim sisteminde nasıl karşılaştırılır ve onu dosyayla aynı sayfadan almak neden işin amacını ortadan kaldırır."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/guides/whats-inside-a-gif.html
+++ b/locales/tr/pages/guides/whats-inside-a-gif.html
@@ -1,0 +1,299 @@
+  <section>
+    <h2>Kısa cevap</h2>
+    <p>
+      Bir GIF; bir tuval, onun üstüne boyanacak bir dikdörtgenler listesi ve o
+      dikdörtgenlerdeki sayıların ne anlama geldiğini söyleyen bir renk tablosudur. Her
+      dikdörtgen üç şey taşır: ne kadar kalacağı, sonrasında ona ne yapılacağı ve
+      isteğe bağlı olarak kendine ait bir renk tablosu.
+    </p>
+    <p>
+      İnsanların bu biçimde şaşırtıcı bulduğu hemen her şey o listeden çıkar. GIF'iniz
+      devasaysa, sebep dikdörtgenlerin her seferinde tuvalin tamamı olması ya da içinde
+      üç yüz renk tablosu bulunmasıdır. Fazla yavaş oynuyorsa, sebep gecikmelerin
+      hiçbir tarayıcının altına inmeyeceği bir tabanın altında olmasıdır. Bulaşıyorsa,
+      sebep <em>elden çıkarma</em> denen alandır.
+    </p>
+    <p>
+      Belirli bir dosyada bunlardan hangisi olduğunu görmek için
+      <a href="../../gif-analiz-etme/">GIF Çözümleyici</a>'yi açın ve dosyayı bırakın.
+      Bu sayfanın geri kalanı, sayıların ne anlama geldiğidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kareler resim değil, dikdörtgendir</h2>
+    <p>
+      GIF'leri yalnızca oynarken görmüş insanları şaşırtan kısım budur. Bir kare,
+      canlandırmanın o andaki resmi değildir. Kendi konumu ve kendi boyutu olan, önceki
+      karelerin geride bıraktığının üstüne boyanmış bir dikdörtgendir.
+    </p>
+    <p>
+      O dikdörtgen tuvalin tamamı olabilir ve kötü yapılmış bir dosyada her zaman
+      öyledir. Ama bir GIF'in, resmin yalnızca son kareden bu yana değişen kısmını
+      saklamasına izin verilir &mdash; ve resmin çoğunun durduğu yerde bu, 12 MB'lik
+      bir dosyayla 900 KB'lik bir dosya arasındaki farktır. Çoğunlukla durağan bir
+      pencerenin ekran kaydının küçük olabilmesinin ve aynı kaydın özensiz bir
+      dönüştürücüden çıkanının olmamasının sebebi budur.
+    </p>
+    <p>
+      Hangisine sahip olduğunuzu canlandırmayı izleyerek anlayamazsınız. İkisi de aynı
+      görünür. Görmenin tek yolu, her karenin ne sakladığına bakmaktır; çözümleyicinin
+      tam olarak bu yüzden bir görünümü var: onu <em>her karenin yalnızca
+      sakladığı</em> hâline getirin; ya saydam bir arka planda küçük şekillerden oluşan
+      bir sıra görürsünüz ki bu, kodlayıcının işini yaptığı anlamına gelir, ya da
+      resmin tamamını tekrar tekrar görürsünüz ki bu, yapmadığı anlamına gelir.
+    </p>
+    <p>
+      Biçimin hiçbir yerinde hareket telafisi yoktur. Hiçbir şey, bir video
+      kodlayıcısının yapacağı gibi &ldquo;geçen seferkiyle aynı ama dört piksel
+      sola&rdquo; olarak saklanmaz. Değişen dikdörtgen numarası, GIF'in sahip olduğu
+      tek kazançtır ve epeyce değerlidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gecikmeler ve her tarayıcının dayattığı taban</h2>
+    <p>
+      Her kare, saniyenin yüzde biri cinsinden ne kadar tutulacağını saklar. Biçimin
+      sahip olduğu tek birim budur; yani bir dosyanın isteyebileceği en hızlı değer
+      0,01 saniyedir &mdash; saniyede yüz kare &mdash; ve en uzunu yaklaşık 655
+      saniyedir.
+    </p>
+    <p>
+      Saniyede yüz kare alamayacaktır. <strong>Her tarayıcı, 0,02 saniyenin altındaki
+      bir gecikmeyi 0,10'a yuvarlar.</strong> Kural, 1996'da dönemin dönen dünyaları ve
+      hareketli "yapım aşamasında" tabelaları için Netscape Navigator'a yazıldı ve o
+      günden beri her tarayıcı onu kopyaladı. Hiçbir zaman kaldırılmadı ve
+      kaldırılmayacak.
+    </p>
+    <p>
+      Yani kareleri 0,01 sn diyen bir GIF, saniyede yüz değil on karede oynar. Onu
+      yapan şeyin niyetinden on kat yavaş çalışır ve dosya buna dair hiçbir ipucu
+      vermez: içindeki gecikmeler tam olarak istenen gecikmelerdir. Bu, biçimdeki en
+      yaygın tek sürprizdir ve çözümleyicinin iki süre bildirmesinin sebebi de budur
+      &mdash; dosyanın söylediği ve bir tarayıcının onunla gerçekten yapacağı.
+    </p>
+    <p>
+      Dosya nerede yapılmış olursa olsun çözüm, 0,01 yerine 0,02 yazmaktır. Bu, gerçek
+      tavan olan saniyede 50 kareyi verir ve hiçbir şeyin ihtiyaç duyacağından
+      hızlıdır. Pratikte 0,05 sn &mdash; saniyede yirmi kare &mdash; kabaca istemeye
+      değecek en hızlı değerdir.
+    </p>
+    <p>
+      Gecikmelerin size söylediği bir şey daha. Hepsi aynıysa dosya, sabit hızlı bir
+      kare setinden yapılmıştır. Dağınıklarsa &mdash; burada 0,04, şurada 0,11 &mdash;
+      bir şey bir videoyu dönüştürüp kareler düşürmüş ve boşlukları kapatmak için
+      komşuları uzatmıştır. Ve sonuncusu gerisinden çok daha uzunsa bu bilinçlidir:
+      bir canlandırmayı döngüye girmeden önce duraklatmanın yolu budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Elden çıkarma: bulaşıp bulaşmayacağına karar veren alan</h2>
+    <p>
+      Her kare, süresi dolduğunda ekranda ne bırakılması gerektiğini söyler. Dört olası
+      cevap var ve bilmeye değerler; çünkü bir canlandırmanın yanlış görünebileceği
+      dört yoldan üçü, bu alanın yanlış olmasıdır.
+    </p>
+    <ul>
+      <li>
+        <strong>Yerinde bırak.</strong> Bir sonraki kare doğrudan bunun üstüne boyar.
+        Kareler opaksa ve birbirini tamamen kapatıyorsa doğrudur ve en ucuz
+        seçenektir; çünkü temizlenecek bir şey yoktur.
+      </li>
+      <li>
+        <strong>Arka plana geri temizle.</strong> Karenin dikdörtgeni, bir sonraki
+        çizmeden önce silinir. Saydamlığın istediği budur: onsuz, bir sonraki karenin
+        saydam kısımları altındaki önceki kareyi gösterir ve ayrı resimlerden oluşan bir
+        canlandırma, onların bir yığınına dönüşür.
+      </li>
+      <li>
+        <strong>Altındakini geri getir.</strong> Bu kare çizmeden önce tuvalde ne varsa
+        geri konur. Durağan bir arka planın üstünde hareket eden küçük bir nesnenin
+        saklanma biçimi budur &mdash; her kare nesneyi boyar, sonra arka plan geri
+        gelir ve yalnızca nesnenin dikdörtgeni yazılır.
+      </li>
+      <li>
+        <strong>Belirtilmemiş.</strong> Dosya söylemedi. Her görüntüleyici bunu
+        &ldquo;yerinde bırak&rdquo; olarak işler ki genellikle doğrudur ve ara sıra
+        saydam bir GIF'in bulaşmasının sebebidir.
+      </li>
+    </ul>
+    <p>
+      Belirtimle gerçeğin yollarının ayrıldığı bir ayrıntı. &ldquo;Arka plana geri
+      temizle&rdquo;, dosyanın başlığında bir arka plan rengi adlandırır ve her tarayıcı
+      onu yok sayıp bunun yerine saydama temizler. Yirmi beş yıldır böyle yapıyorlar. O
+      arka plan renginin görünmesine dayanan bir dosya, onu yapana, yapıldığı yerde doğru
+      görünür ve başka her yerde yanlış görünür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Renk tabloları ve mal oldukları 768 bayt</h2>
+    <p>
+      Bir GIF pikseli bir renk değildir. Her biri üç baytta saklanan, en fazla 256
+      renklik bir tabloya işaret eden bir sayıdır. Yani tam bir tablo 768 bayttır ve bir
+      dosyada her şeyin paylaştığı bir tane, ya kare başına bir tane ya da ikisi birden
+      olabilir.
+    </p>
+    <p>
+      İki düzen de meşrudur ve farklı takaslar yapar:
+    </p>
+    <ul>
+      <li>
+        <strong>Tek paylaşılan tablo</strong>, bütün dosya için 768 bayttır ve renkleri
+        kareler arasında sabit tutar. GIF titremesi &mdash; videodan yapılmış bir
+        dosyadaki o rahatsız edici titreşim &mdash; çok sık, paletin kareden kareye
+        sendelemesinden başka bir şey değildir.
+      </li>
+      <li>
+        <strong>Kare başına bir tablo</strong>, her karenin paylaşılan tabloda olmayan
+        renkleri kullanmasını sağlar ki sahne tamamen değiştiğinde bu önemlidir. Her
+        seferinde 768 bayta mal olur. 300 karelik bir canlandırmada bu, tek bir piksel
+        saklanmadan önce 230 KB renk tablosu demektir.
+      </li>
+    </ul>
+    <p>
+      İkinci ve daha sessiz bir bedeli var. Bir renk tablosunun uzunluğunun ikinin bir
+      kuvveti olması gerekir; yani dokuz renk kullanan bir kare yine on altılık bir
+      tablo alır ve 130 kullanan bir kare yine 256 alır. Bir miktar yukarı yuvarlama
+      kaçınılmazdır. Tabloları, piksellerinin hiç göstermediği beş bin renk bildiren bir
+      dosya ise başka bir şeydir: karede sonunda yer alandan başka bir resim için
+      kurulmuş paletler. Çözümleyici, kullanılmayan girdileri işaretler; böylece bunun
+      şekli bir bakışta görünür.
+    </p>
+  </section>
+
+  <section>
+    <h2>Baytlar gerçekte nereye gidiyor</h2>
+    <p>
+      Bir GIF'in her baytı az sayıda yerden birindedir ve bir dosyanın fazla büyük
+      olduğuna karar vermeden önce bunların ne olduğunu bilmeye değer.
+    </p>
+    <ul>
+      <li>
+        <strong>Sıkıştırılmış pikseller.</strong> Sağlıklı bir dosyada neredeyse
+        tamamı. Resmin kendisi, LZW'den geçirilmiş hâlde &mdash; 1984'ten kalma ve
+        hesap tablosu ekran görüntüleri için tasarlanmış bir sıkıştırma şeması; düz
+        renkte iyi, fotoğraflarda kötü olmasının sebebi de budur.
+      </li>
+      <li>
+        <strong>Renk tabloları.</strong> Yukarıdaki gibi, tam tablo başına 768 bayt.
+      </li>
+      <li>
+        <strong>Kare başına başlıklar.</strong> Her kare için sekiz bayt zamanlama ve
+        on bir bayt tanımlayıcı. Normal bir dosyada hiçbir şey; iki bin minik kareden
+        oluşan bir canlandırmada 38 KB.
+      </li>
+      <li>
+        <strong>Blok çerçeveleme.</strong> Sıkıştırılmış veri, her birinin önünde bir
+        uzunluk baytı olan en fazla 255 baytlık dizilere bölünür. Kabaca her 256 baytta
+        bir bayt; kaçınılmaz ve görmeye değer, çünkü aksi hâlde görünmez.
+      </li>
+      <li>
+        <strong>Üstveri.</strong> Yorumlar, renk profilleri ve XMP paketleri. Gerçekten
+        saçma sonuçlar üreten kısım budur: bir görüntü düzenleyici, yıllar önce yapılmış
+        bir düzenlemeyi tarif eden 40 KB'lik XML bırakabilir ve küçük bir GIF'te bu,
+        dosyanın büyük kısmıdır. Hiçbir görüntüleyici bunların hiçbirini çizmez.
+      </li>
+    </ul>
+    <p>
+      Buna tahmin yerine bir tablo olarak bakmanın sebebi, cevabın farklı dosyalarda
+      farklı olması ve çözümün cevaptan doğmasıdır. %95'i sıkıştırılmış piksel olan bir
+      dosya düpedüz çok fazla resimdir ve yalnızca daha az kare, daha küçük bir boyut
+      ya da daha az renk yardımcı olur. %30'u renk tablosu ya da %40'ı XMP olan bir
+      dosyanın ise çok daha ucuz bir sorunu vardır.
+    </p>
+  </section>
+
+  <section>
+    <h2>Döngü, biçimin bir parçası değildir</h2>
+    <p>
+      GIF belirtiminde bir canlandırmanın tekrarlandığını söyleyen bir alan yoktur.
+      Döngü, Netscape'in 1995'te icat ettiği bir bloktan gelir &mdash; içinde
+      <code>NETSCAPE2.0</code> dizgesi olan bir &ldquo;uygulama uzantısı&rdquo; &mdash;
+      ki her şey yine de onu uyguladı ve şimdi internetteki her hareketli GIF'in
+      içinde.
+    </p>
+    <p>
+      Bu, o bloğu olmayan bir dosyanın her tarayıcıda tam olarak bir kez oynayıp
+      duracağı ve onu yapana bozuk görüneceği anlamına gelir. Bir canlandırma yalnızca
+      bir kez oynuyorsa o blok eksiktir; denetlemeye değen ilk şeylerden biridir ve
+      hiçbir görüntüleyicide görünmez.
+    </p>
+    <p>
+      Blok bir sayı da belirtebilir &mdash; beş kez oyna ve dur. Sıfır sonsuz demektir
+      ve neredeyse her dosyanın söylediği de budur.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir GIF'in taşıyabildiği diğer şeyler</h2>
+    <p>
+      Hiç resim tutmayan ve her görüntüleyicinin atladığı üç blok:
+    </p>
+    <ul>
+      <li>
+        <strong>Yorumlar.</strong> Serbest metin; genellikle dosyayı yazan şeyin adı,
+        ara sıra da yazarın yayımlamayı seçmeyeceği bir şey. Hiçbir şey onu göstermez ve
+        dosyanın her kopyası onu taşır.
+      </li>
+      <li>
+        <strong>XMP.</strong> Adobe'nin XML üstverisi: dosyayı neyin, ne zaman, bazen
+        kimin düzenlediği. Sonunda 258 baytlık sihirli bir kuyrukla gelir; bu, blok
+        uzunlukları doğru çıksın diye kullanılan bir numaradır ve bir tanesini saf saf
+        okumanın size neden bir ekran dolusu ikili verdiğinin sebebidir.
+      </li>
+      <li>
+        <strong>Düz metin.</strong> 1989 belirtiminden kalma, görüntüleyiciden resmin
+        üstüne bir hücre ızgarasında metin çizmesini isteyen bir blok. Hiçbir şey
+        tarafından hiç uygulanmadı. Bir dosyada varsa, ne diyorsa görünmeyecektir.
+      </li>
+    </ul>
+    <p>
+      Üçünü de bir dosyayı bir yere göndermeden önce bilmeye değer: bunlar, bir GIF'in
+      sizin hakkınızda bir şey söyleyebilecek kısımlarıdır ve bir şey onları bilerek
+      temizlemedikçe her kopyadan ve yeniden yüklemeden sağ çıkarlar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hasarlı bir dosyayı okumak</h2>
+    <p>
+      GIF'ler kesilir &mdash; duran bir indirme, bozulan bir diskten kurtarılmış bir
+      dosya, bir uygulamanın yarısını yazdığı bir şey. Biçim, tek bir dizinlenmiş yapı
+      değil bir bloklar akışı olduğu için kesilmiş bir GIF genellikle durduğu noktaya
+      kadar hâlâ okunabilir: kopmadan önceki her kare eksiksiz ve sağlamdır.
+    </p>
+    <p>
+      Bunu bilmeye değer; çünkü çoğu yazılım dosyayı düpedüz reddeder. Okuyabildiği
+      kadar okuyup nerede durduğunu söyleyen bir çözümleyici, en azından ne kadarının
+      hayatta kaldığını ve eksik kısmın bir kare mi yoksa son iki yüz kare mi olduğunu
+      söyler.
+    </p>
+    <p>
+      Bunun tersi sorun da var: dosyanın bitiş işaretinden <em>sonra</em> duran baytlar.
+      Her çözücü o işarette durur, yani onlar hiç okunmaz ve hiç çizilmez ve genellikle
+      ters giden bir şey tarafından birincinin sonuna eklenmiş ikinci bir dosyadır. Saf
+      ağırlıktırlar ve kesip atmak hiçbir şey kaybettirmez.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbirinin bir yüklemeye ihtiyacı yok</h2>
+    <p>
+      Bir GIF'in yapısını okumak zorlu bir iş değildir &mdash; bir bloklar listesinde
+      bir gezinti ve küçük bir açıcı &mdash; ve bunu yapmak için dosyayı bir sunucuya
+      göndermenin hiçbir zaman teknik bir sebebi olmadı. Buradaki
+      <a href="../../gif-analiz-etme/">GIF Çözümleyici</a> her şeyi sayfanın içinde
+      yapıyor: blok gezintisi, LZW, ekrana çizilen kareler ve bayt muhasebesi.
+    </p>
+    <p>
+      Bu, çoğu işten çok bu iş için önemlidir; çünkü insanların en çok parçalarına
+      ayırmak istediği dosyalar, çoğu zaman paylaşmak konusunda en az emin oldukları
+      dosyalardır &mdash; kurtarılmış bir şey, birinin onlara gönderdiği bir şey, henüz
+      okumadıkları bir yorum bloğu olan bir şey.
+      <a href="../dosya-yuklemek-guvenli-mi/">Dosya yüklemek üzerine daha uzun sav</a>,
+      burada da bu sitenin her yerindeki kadar güçlü biçimde geçerlidir.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/whats-inside-a-gif.toml
+++ b/locales/tr/pages/guides/whats-inside-a-gif.toml
@@ -1,0 +1,17 @@
+#
+# Rehber: bir GIF dosyasının içinde gerçekte ne var - Türkçe.
+#
+
+nav = "GIF'in içinde ne var"
+title = "Bir GIF Dosyasının İçinde Gerçekte Ne Var (ve Sizinki Neden Bu Kadar Büyük)"
+description = "Kareler, gecikmeler, elden çıkarma yöntemleri ve renk tabloları anlatılıyor; tarayıcılar en hızlı gecikmeleri neden reddediyor ve bir GIF'in dosya boyutunun gerçekte nereye gittiğini nasıl bulursunuz."
+heading = "Bir GIF'in içinde gerçekte ne var"
+lede = """
+    Bir GIF, her birinin bir zamanlayıcısı ve bir renk tablosu olan bir
+    dikdörtgenler yığınıdır ve insanların bu biçim hakkındaki hemen her
+    şikâyeti bu üç şeyden birinden doğar. Bu rehber her parçanın ne yaptığını ve
+    dosyanızın boyutunu hangisine harcadığını nasıl öğreneceğinizi anlatıyor."""
+updated = "22 Ağustos 2026"
+og_title = "Bir GIF dosyasının içinde gerçekte ne var"
+og_description = "Kareler, gecikmeler, elden çıkarma ve paletler - her biri ne yapar, GIF'iniz neden söylediğinden yavaş oynar ve dosya boyutu nereye gitti."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/privacy.html
+++ b/locales/tr/pages/privacy.html
@@ -1,0 +1,196 @@
+  <section>
+    <h2>Dosyalarınız</h2>
+    <p>
+      Bu sitedeki her araç işini kendi tarayıcınızın içinde, kendi donanımınızda
+      yapar. Bir dosya seçtiğinizde onu, zaten açık olan sayfa okur. Bize
+      gönderilmez; çünkü gönderilebileceği bir sunucumuz yoktur &mdash; bu site,
+      arka ucu, veritabanı ve depolaması olmayan durağan dosyalardan oluşan bir
+      kümedir.
+    </p>
+    <p>
+      Bu, şunları hiçbir zaman almadığımız, görmediğimiz, saklamadığımız,
+      günlüklemediğimiz ya da işlemediğimiz anlamına gelir:
+    </p>
+    <ul>
+      <li>dosyalarınız, tamamen ya da kısmen</li>
+      <li>onların küçük resimleri ya da ön izlemeleri</li>
+      <li>adları, boyutları, ölçüleri ya da biçimleri</li>
+      <li>kaç tane seçtiğiniz ya da onlarla ne yaptığınız</li>
+      <li>EXIF ve GPS verisi dâhil, içlerinden okunan hiçbir şey</li>
+    </ul>
+    <p>
+      Bu, niyetlerimiz hakkında bir söz değildir. Her sayfa, sayfanın iletişim
+      kurmasına izin verilen her adresi tek tek sayan bir
+      <code>Content-Security-Policy</code> taşır ve bunu tarayıcı zorunlu kılar. O
+      adreslerin hiçbiri bize ait değildir. Politikayı herhangi bir sayfanın
+      kaynağının en üstünde okuyabilir ya da tarayıcınızın Ağ sekmesini açıp
+      izleyebilirsiniz: hiçbir istek dosyanızı taşımaz.
+    </p>
+    <p>
+      Bir araçla ürettiğiniz dosyalar tarayıcınızın kendi indirme mekanizmasına
+      verilir ve siz nereye söylerseniz oraya kaydedilir. O adıma da karışmayız.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tek istisna ve nerede geçerli olduğu</h2>
+    <p>
+      <a href="../resimleri-videoya-donusturme/">Görsellerden Videoya</a> aracının
+      bir &ldquo;bir web adresinden ekle&rdquo; özelliği var. İçine bir adres
+      yapıştırırsanız tarayıcınız o görseli, adını verdiğiniz sunucudan getirir ve
+      <strong>o sunucu IP adresinizi</strong> ve hangi dosyayı istediğinizi görür.
+      Bu kaçınılmazdır ve özelliğin doğasının kendisidir.
+    </p>
+    <p>
+      Yalnızca kendi yazdığınız adresler için gerçekleşir, görseller içeri girebilsin
+      ama veri dışarı çıkamasın diye kurulmuştur ve o aracın kendi sayfası bunu daha
+      ayrıntılı anlatır. Bu sitedeki başka hiçbir araç, içinde size ait bir şey olan
+      giden bir istek yapamaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ne toplanıyor ve kim topluyor</h2>
+    <p>
+      Bu site ücretsizdir ve bedeli reklamla ödenir. Bu, bu sayfalarda iki Google
+      ürününün çalıştığı ve çoğunda bir bağış düğmesinin bulunduğu anlamına gelir.
+      Listenin tamamı burada.
+    </p>
+
+    <h3>Google AdSense &mdash; reklamlar</h3>
+    <p>
+      Reklamları Google sunar ve hangilerini göreceğinize o karar verir. Bunu yapmak
+      için tarayıcınızda çerezler ya da benzeri tanımlayıcılar ayarlayabilir ve
+      okuyabilir; ayrıca IP adresinizi, ondan türetilmiş yaklaşık bir konumu, kullanıcı
+      aracınızı ve hangi sayfada olduğunuzu alır. Ayarlarınıza ve bulunduğunuz yere
+      bağlı olarak reklamlar, Google'ın büyük ölçüde başka sitelerdeki
+      etkinliğinizden kurduğu bir profille kişiselleştirilebilir.
+    </p>
+    <p>
+      Bunların hiçbirini almıyoruz, göremiyoruz ve Google'a dosyalarınız hakkında
+      hiçbir zaman bir şey göndermiyoruz. Google'ın, reklamlarını çalıştıran
+      sitelerden gelen veriyi nasıl kullandığına dair kendi açıklaması
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>
+      adresinde.
+    </p>
+
+    <h3>Google Analytics &mdash; ziyaret sayacı</h3>
+    <p>
+      Sayfa ziyaretlerini saymak için Google Analytics 4 kullanıyoruz; böylece hangi
+      araçlar üzerinde çalışmaya değdiğini biliyoruz. Görüntülediğiniz sayfayı, kabaca
+      ne zaman görüntülediğinizi, tarayıcınızda saklanan rastgele üretilmiş bir
+      tanımlayıcıyı, yaklaşık bir konumu, cihaz ve tarayıcı türünüzü ve sizi yönlendiren
+      siteyi kaydeder.
+    </p>
+    <p>
+      Başka hiçbir şey yapmayacak şekilde ayarlanmıştır ve bu ayar, okuyabileceğiniz
+      bir dosyadır: her sayfanın yanındaki <code>analytics.js</code>, bir sayfa
+      görüntüleme sayacı kurar ve içinde hiç özel olay yoktur. Bu sitedeki hiçbir şey
+      ona bir dosya, bir dosya adı, bir ölçü ya da bir sayı vermez &mdash; burada bunu
+      yapabilecek bir kod yoktur.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; bağış düğmesi</h3>
+    <p>
+      Merkez sayfa ve araç sayfaları, Buy Me a Coffee'nin sunucularından yüklenen bir
+      bağış düğmesi taşır. Onu yüklemek, içerik dağıtım ağlarının IP adresinizi ve bu
+      sitede olduğunuzu görmesi demektir; düğmenin yazısı da Google Fonts'tan getirilir
+      ve o da IP adresinizi görür. Başka bir şey gönderilmez ve siz gerçekten
+      tıklamadıkça başka bir şey olmaz; tıkladığınızda ise kendi politikaları altında
+      onların sitesindesinizdir. Bu sayfa ve
+      <a href="../kullanim-kosullari/">Kullanım Koşulları sayfası</a> düğmeyi
+      çizmez.
+    </p>
+
+    <h3>Barındırma</h3>
+    <p>
+      Site, Cloudflare'in arkasında GitHub Pages tarafından sunuluyor. Her web
+      barındırıcısı gibi onlar da, sayfayı teslim etmek ve hizmeti ayakta ve güvenli
+      tutmak için tarayıcınızın yaptığı istekleri işler &mdash; ki buna IP adresiniz,
+      istenen sayfa ve kullanıcı aracınız dâhildir. İkisinden de ziyaretçi başına
+      günlüklere erişimimiz yok.
+    </p>
+  </section>
+
+  <section>
+    <h2>Çerezler</h2>
+    <p>
+      Kendimize ait hiçbir çerez ayarlamıyoruz. Girişimiz ve oturumumuz yok ve
+      hatırladığımız tek bir tercih var.
+    </p>
+    <p>
+      <strong>Seçtiğiniz dil.</strong> Değiştiriciden bir dil seçerseniz o seçim,
+      açtığınız bir sonraki sayfa istediğiniz dilde olsun diye tarayıcınızın yerel
+      deposuna <code>abox-lang</code> adıyla yazılır. Bu bir çerez değildir: hiçbir
+      zaman bize ya da başka birine gönderilmez, bunu okuduğunuz cihazda kalır ve
+      tarayıcınızın site verisini temizlemek onu kaldırır. Hiç dil seçmezseniz hiçbir
+      şey yazılmaz &mdash; tarayıcınızın kendi dilinde gösterilen bir sayfa, olduğu
+      yerde eşleştirilip yeniden unutulmuştur.
+    </p>
+    <p>
+      Burada bulabileceğiniz her çerez ya da benzeri tanımlayıcı Google'a aittir ve
+      yukarıda anlatılan reklam ve ölçüm betikleri tarafından ayarlanır. Ziyaretleri
+      ölçmek ve reklamları seçip sınırlamak için kullanılırlar.
+    </p>
+    <h3>Nasıl kapatılır</h3>
+    <ul>
+      <li>
+        Reklam kişiselleştirmesi, tüm siteler için tek seferde
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">Reklam Merkezim</a>
+        üzerinden kapatılabilir.
+      </li>
+      <li>
+        Google Analytics her yerde, Google'ın
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">devre dışı bırakma tarayıcı eklentisiyle</a>
+        engellenebilir.
+      </li>
+      <li>
+        Tarayıcınızın kendi ayarları üçüncü taraf çerezleri engelleyebilir ya da
+        temizleyebilir ve herhangi bir içerik engelleyici, bu betiklerin en baştan
+        yüklenmesini durdurur.
+      </li>
+    </ul>
+    <p>
+      Hepsini engellemenizde bizim için hiçbir sakınca yok. <strong>Bu sitedeki her
+      araç betikler engelliyken çalışır ve ağ tamamen kesikken de çalışır.</strong>
+      Burada hiçbir şey bir reklamın arkasında tutulmuyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Veri üzerindeki haklarınız</h2>
+    <p>
+      Sizinle ilgili hiçbir kişisel veri tutmuyoruz; yani size gösterecek,
+      düzeltecek, dışa aktaracak ya da silecek bir şeyimiz yok &mdash; bize yapılan bir
+      talep, dürüstçe söylemek gerekirse boş dönerdi.
+    </p>
+    <p>
+      Yukarıda anlatılan veri, kendi denetleyicisi olarak hareket eden Google
+      tarafından tutuluyor. Bununla ilgili talepler onlara,
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">Google hesabınız</a>
+      ya da gizlilik iletişim kanalları üzerinden gitmek zorunda.
+    </p>
+  </section>
+
+  <section>
+    <h2>Çocuklar</h2>
+    <p>
+      Bu site çocuklara yönelik değildir ve kimseye yaşını sormaz; çünkü kimseden
+      hiçbir şey istemez. Hiçbir yaştan hiç kimseden bilerek kişisel veri toplamıyoruz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Değişiklikler ve bize nasıl ulaşırsınız</h2>
+    <p>
+      Bu sayfa değişirse üstündeki tarih de onunla birlikte değişir ve düzenleme, diğer
+      her şeyle birlikte herkese açık işleme geçmişinde durur.
+    </p>
+    <p>
+      Bunlarla ilgili sorular <a href="mailto:hi@abox.tools">hi@abox.tools</a>
+      adresine gidebilir ya da
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">depoda</a>
+      bir konu olarak açılabilir; orada cevap, aynı şeyi merak eden herkes tarafından
+      görülebilir.
+    </p>
+  </section>

--- a/locales/tr/pages/privacy.toml
+++ b/locales/tr/pages/privacy.toml
@@ -1,0 +1,16 @@
+#
+# Gizlilik ve Çerezler - Türkçe. Overrides for pages/privacy/page.toml.
+#
+
+nav = "Gizlilik ve Çerezler"
+title = "Gizlilik ve Çerezler &mdash; abox.tools"
+description = "abox.tools neyi topluyor, neyi toplamıyor. Dosyalarınız hiçbir zaman yüklenmez; reklamlar, ziyaret sayacı ve bağış düğmesi burada eksiksiz anlatılıyor."
+heading = "Gizlilik ve Çerezler"
+lede = """
+    Kısa sürümü: dosyalarınız hiçbir zaman yüklenmez, çünkü yüklenecek bir yer
+    yoktur. Bu sayfadaki diğer her şey reklamlar, ziyaret sayacı ve barındırma
+    hakkındadır &mdash; yani başka şirketlerin gerçekten karıştığı kısımlar."""
+updated = "22 Ağustos 2026"
+og_title = "Gizlilik ve Çerezler &mdash; abox.tools"
+og_description = "Dosyalarınız hiçbir zaman yüklenmez. Ne toplanıyor, kim topluyor ve nasıl kapatırsınız."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/pages/terms.html
+++ b/locales/tr/pages/terms.html
@@ -1,0 +1,148 @@
+  <section>
+    <h2>Bu site nedir</h2>
+    <p>
+      abox.tools, web tarayıcınızın içinde çalışan küçük araçlardan oluşan bir
+      derlemedir. Ticari işler dâhil her şey için ücretsiz kullanılabilirler. Satın
+      alınacak bir şey, oluşturulacak bir hesap, bir kullanım sınırı ve geri tutulmuş
+      bir özellik yoktur.
+    </p>
+    <p>
+      Siteyi kullanarak bu sayfadaki koşulları kabul etmiş olursunuz. Kabul
+      etmiyorsanız çare düpedüz sekmeyi kapatmaktır &mdash; burada size ait hiçbir şey
+      tutulmuyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dosyalarınız sizin kalır</h2>
+    <p>
+      Bu araçlarla açtığınız dosyalarda ve onlarla ürettiğiniz her şeyde zaten sahip
+      olduğunuz her hakkı korursunuz. İkisinde de hiçbir lisans, hiçbir mülkiyet ve
+      hiçbir türde menfaat iddia etmiyoruz.
+    </p>
+    <p>
+      Bu bir cömertlik değil, bir aritmetiktir: araçlar tamamen tarayıcınızda çalışır
+      ve dosyalarınız hiçbir zaman bize iletilmez; yani üzerinde hak sahibi
+      olabileceğimiz bir şey yoktur. <a href="../gizlilik/">Gizlilik sayfası</a> bunun
+      nasıl çalıştığını ve nasıl doğrulanacağını anlatıyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Siteyi sorumlulukla kullanmak</h2>
+    <p>
+      İşlediğiniz dosyalardan ve sonuçlarla ne yaptığınızdan siz sorumlusunuz.
+      Özellikle, bu araçları hakkınız olmayan materyalde ya da hukuka aykırı bir şey
+      üretmek için kullanmayın.
+    </p>
+    <p>
+      Bunu uygulatamayız ve aksini iddia da etmiyoruz. Dosyalarınızı hiçbir zaman
+      görmüyoruz; yani burada denetim yok, tarama yok ve kimin ne yaptığını bilmemizin
+      bir yolu yok. Yükümlülük gerçekten sizin.
+    </p>
+    <p>
+      Ayrıca lütfen sitenin kendisine müdahale etmeyin &mdash; barındırmaya saldırmak
+      ya da değiştirilmiş kopyaları özgün hâlleriymiş gibi gösterecek biçimde yeniden
+      dağıtmak gibi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Garanti yok</h2>
+    <p>
+      Site ve araçları <strong>olduğu gibi</strong> sunulur; satılabilirlik, belirli
+      bir amaca uygunluk ya da ihlal etmeme yönündeki her türlü zımni garanti dâhil,
+      açık ya da zımni hiçbir garanti verilmez.
+    </p>
+    <p>
+      Somut olarak: bir araç istemediğiniz bir sonuç üretebilir, anlamadığı bir
+      dosyada çuvallayabilir, tarayıcılar arasında farklı davranabilir ve sekme işlem
+      ortasında kapanırsa yaptığınız işi kaybettirebilir. Burada yaptığınız hiçbir şey
+      hiçbir yere kaydedilmiyor, o yüzden <strong>özgün dosyalarınızı saklayın</strong>.
+      Bu araçları, önemsediğiniz bir şeyin tek kopyası üzerinde kullanmayın.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sorumluluğun sınırlandırılması</h2>
+    <p>
+      Hukukun izin verdiği azami ölçüde, bu siteyi kullanmanızdan doğan hiçbir kayıp
+      ya da zarardan sorumlu değiliz &mdash; kaybolmuş, bozulmuş ya da kullanılamaz
+      hâle gelmiş dosyalar, kaybedilen zaman, kaybedilen kazanç ya da her türlü
+      dolaylı veya sonuçsal kayıp dâhil.
+    </p>
+    <p>
+      Buradaki hiçbir şey, hukuken sınırlandırılamayacak bir sorumluluğu
+      sınırlandırmaz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Erişilebilirlik</h2>
+    <p>
+      Site, ayakta kalacağına, ücretsiz kalacağına, belirli bir aracı koruyacağına ya
+      da var olmaya devam edeceğine dair hiçbir söz verilmeden sunulur. Araçlar haber
+      verilmeden değişebilir ya da kaldırılabilir.
+    </p>
+    <p>
+      Bu araçların kuruluş biçiminin bilmeye değer pratik bir sonucu var: bir araç
+      sayfası bir kez yüklendikten sonra çevrimdışı çalışmaya devam eder ve site
+      kapandı diye çalışmayı bırakmaz. Kod ayrıca herkese açıktır; yani bağımlı
+      olduğunuz bir aracı, burada ne olursa olsun siz çalışır hâlde tutabilirsiniz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Reklamlar ve diğer şirketler</h2>
+    <p>
+      Site, Google'dan reklam taşır, ziyaretleri Google Analytics ile sayar ve çoğu
+      sayfada bir bağış düğmesi gösterir. Bunların her birinin neleri içerdiği
+      <a href="../gizlilik/">Gizlilik sayfasında</a> eksiksiz anlatılıyor.
+    </p>
+    <p>
+      Reklamlar ve birine tıklayarak ulaştığınız hiçbir site bize ait değildir. Tek tek
+      reklamları biz seçmiyoruz, söylediklerini onaylamıyoruz ve götürdükleri sitelerden
+      ya da orada yaşadığınız hiçbir işlemden sorumlu değiliz. Aynısı bu sitedeki her
+      dış bağlantı için de geçerlidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kaynak kod</h2>
+    <p>
+      Bu sitenin kodu
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>
+      adresinde açıkça yayımlanıyor; çünkü &ldquo;buna neden güveneyim&rdquo; sorusunun
+      tek gerçek cevabı &ldquo;okuyun ve kendiniz denetleyin&rdquo;dir. O kodun yeniden
+      kullanımı bu sayfayla değil, depoda belirtilen lisans koşullarıyla düzenlenir. Bu
+      koşullar, web sitesini kullanmanızı kapsar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Uygulanacak hukuk</h2>
+    <p>
+      Bu site Kanada'dan işletilmektedir. Bu koşullar ve bunlardan ya da siteyi
+      kullanmanızdan doğan her türlü uyuşmazlık, kanunlar ihtilafı kuralları dikkate
+      alınmaksızın, Kanada'nın ve sitenin işletildiği eyaletin hukukuna tabidir.
+    </p>
+    <p>
+      Yaşadığınız yerdeki tüketici hukuku, bu koşulların aksi hâlde kısıtlayacağı
+      haklar veriyorsa o haklar geçerlidir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bu koşullardaki değişiklikler</h2>
+    <p>
+      Bu koşullar güncellenebilir. Güncellendiğinde üstteki tarih değişir ve düzenleme,
+      diğer her değişiklik gibi herkese açık işleme geçmişinde görünür. Bir
+      değişiklikten sonra siteyi kullanmaya devam etmek, güncellenmiş sürümü kabul
+      etmek demektir.
+    </p>
+    <p>
+      Sorular <a href="mailto:hi@abox.tools">hi@abox.tools</a> adresine gidebilir ya da
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">depoda</a>
+      bir konu olarak açılabilir.
+    </p>
+  </section>

--- a/locales/tr/pages/terms.toml
+++ b/locales/tr/pages/terms.toml
@@ -1,0 +1,16 @@
+#
+# Kullanım Koşulları - Türkçe. Overrides for pages/terms/page.toml.
+#
+
+nav = "Kullanım Koşulları"
+title = "Kullanım Koşulları &mdash; abox.tools"
+description = "Bu sitenin sunulduğu koşullar: ücretsiz, olduğu gibi, hesap yok, garanti yok ve dosyalarınız tamamen sizin kalır, çünkü hiçbir zaman bize gönderilmez."
+heading = "Kullanım Koşulları"
+lede = """
+    Açılacak bir hesap ve imzalanacak bir sözleşme yok; bu yüzden koşullar kısa.
+    Bu siteden ne bekleyebileceğinizi ve nelerin sözünü vermediğini
+    anlatıyorlar."""
+updated = "19 Ağustos 2026"
+og_title = "Kullanım Koşulları &mdash; abox.tools"
+og_description = "Ücretsiz, olduğu gibi, hesap yok, garanti yok. Dosyalarınız tamamen sizin kalır."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/tools/compress-pdf.html
+++ b/locales/tr/tools/compress-pdf.html
@@ -1,0 +1,166 @@
+<!--
+  tools/compress-pdf/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosya -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir PDF seçin</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="file-row" class="file-row" hidden>
+      <div class="file-facts">
+        <strong id="file-name" class="file-name"></strong>
+        <span id="file-facts" class="file-sub"></span>
+      </div>
+      <button type="button" id="clear-file" class="ghost danger">Başkasını seç</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; bu araç tek bir ekran tutabilseydi tutacağı ekran -->
+  <section class="card" id="inventory-card" hidden>
+    <h2><span class="step">2</span> Boyutun nerede olduğunu görün</h2>
+
+    <p class="card-lede">
+      "PDF sıkıştırma" tek bir adı paylaşan iki ayrı iştir. Bir tarama, üst üste
+      dizilmiş fotoğraflardır; onları yeniden kodlamak dosyanın büyük kısmını
+      kazandırır. Bir sözleşme ise metin ve yazı tipidir ve onu üreten yazılım
+      bunları zaten sıkıştırmıştır &mdash; içinde saklanan bir yüzde seksen
+      yoktur, hiçbir araç da öyle bir şey bulamaz. Elinizdekinin hangisi olduğu
+      bir görüş meselesi değil; o yüzden hiçbir şeye dokunulmadan önce burada.
+    </p>
+
+    <p id="verdict" class="verdict"></p>
+
+    <div class="breakdown">
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <ul id="breakdown-list" class="breakdown-list"></ul>
+    </div>
+
+    <p id="inventory-notes" class="field-summary"></p>
+  </section>
+
+  <!-- Adım 3 &mdash; ne kadar harcanacağı -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">3</span> Ne kadar sıkacağını söyleyin</h2>
+
+    <p class="card-lede">
+      Bir PDF, her görselin ne kadar büyük çizildiğini kaydeder; böylece bu araç
+      tahmin yürütmek yerine sayfanın gerçekte kullandığını ölçebilir. Yirmi
+      santimlik bir kâğıda yerleştirilmiş 4000 piksellik bir tarama inç başına
+      500 piksel taşır; 150'de de aynı basılır ve ekranda aynı görünür.
+      Kimsenin göremeyeceği pikseller ilk önce harcanır, çünkü hiçbir şeye mal
+      olmazlar.
+    </p>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Ne kadar kalite harcanabilir</legend>
+      <div class="presets" id="presets" role="radiogroup" aria-label="Ne kadar kalite harcanabilir">
+        <label class="preset">
+          <input type="radio" name="preset" value="smallest">
+          <span class="preset-body">
+            <strong>En küçük</strong>
+            <span class="preset-note">96 DPI. Yalnızca ekranda okunacak bir şey için.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="screen" checked>
+          <span class="preset-body">
+            <strong>Ekranda iyi</strong>
+            <span class="preset-note">130 DPI. E-postayla göndermeniz gereken bir dosya için olağan cevap.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="print">
+          <span class="preset-body">
+            <strong>Kâğıtta hâlâ iyi</strong>
+            <span class="preset-note">220 DPI. Daha küçük ve düzgün basılmaya devam eder.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="gentle">
+          <span class="preset-body">
+            <strong>Görsellere neredeyse dokunma</strong>
+            <span class="preset-note">Hiç yeniden boyutlandırma yok. Kazancın çoğu dosyayı yeniden paketlemekten gelir.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <details class="advanced">
+      <summary>İki sayıyı kendiniz belirleyin</summary>
+      <div class="option-row">
+        <label for="dpi-value">Çizilen alanın inçi başına en fazla piksel</label>
+        <div class="inline-pair">
+          <input type="number" id="dpi-value" min="0" max="1200" step="10" value="130" inputmode="numeric">
+          <span class="unit">DPI &mdash; 0, her görseli tam boyutunda bırakır</span>
+        </div>
+      </div>
+      <div class="option-row">
+        <label for="quality-value">JPEG kalitesi</label>
+        <div class="inline-pair">
+          <input type="range" id="quality-value" min="30" max="95" step="1" value="68">
+          <output id="quality-out" for="quality-value">68</output>
+        </div>
+      </div>
+    </details>
+
+    <label class="check">
+      <input type="checkbox" id="strip-meta" checked>
+      <span>
+        <strong>Dosyanın nereden geldiğine dair hatırladıklarını çıkar</strong>
+        <span class="check-note">
+          Onu yapan programın adı ve sürümü, ne zaman yapıldığı ve en son ne
+          zaman düzenlendiği, XMP paketi ve bir sayfa düzeni uygulamasının kendi
+          işini yeniden içeri alabilmek için geride bıraktığı özel yığın
+          &mdash; ki bu zaman zaman megabaytlarca olur. Belgeyi görüntülemek
+          için bunların hiçbiri gerekmez.
+        </span>
+      </span>
+    </label>
+
+    <p id="settings-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Adım 4 &mdash; tek tıklama -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Sıkıştırın</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Bu PDF'i sıkıştır</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>İndir</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <details id="per-image" class="advanced" hidden>
+        <summary>Her görsele ne oldu</summary>
+        <ul id="image-list" class="image-list"></ul>
+      </details>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/compress-pdf.toml
+++ b/locales/tr/tools/compress-pdf.toml
@@ -1,0 +1,263 @@
+#
+# PDF Sıkıştırıcı - Türkçe.
+#
+# Overrides for tools/compress-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "PDF Sıkıştırıcı"
+# İngilizcede olduğu gibi, ikinci yarı aranan ifade; ürün adı yüksek sesle
+# söylenen yarı olarak kalıyor.
+heading = "PDF&nbsp;Sıkıştırma <span class=\"h1-kw\">&mdash; bir belgeyi küçültün</span>"
+tagline = "Belgeyi hiçbir yere göndermeden küçültün."
+
+title = "PDF Sıkıştırma &mdash; Ücretsiz, Tarayıcınızda, Yüklemesiz"
+description = "Bir PDF'i yüklemeden küçültün. Dosyayı kendi tarayıcınız okur, yeniden sıkıştırır ve yeniden yazar; araç da hiçbir şeye dokunmadan önce boyutun asıl nerede olduğunu gösterir."
+og_title = "PDF sıkıştırma &mdash; ücretsiz, hiçbir şey yüklenmiyor"
+og_description = "Bir PDF'i kendi cihazınızda küçültün. Her görselin sayfada ne kadar büyük çizildiğini ölçer, böylece yalnızca kimsenin göremeyeceği pikselleri atar."
+og_image_alt = "PDF Sıkıştırma - bir belgeyi yüklemeden küçültün"
+
+pledge = """
+    Belge bu makinenin belleğinde açılır, parçalarına ayrılır ve yeniden
+    yazılır; bunu yapan kod da bu adresten sunuluyor. Buradaki hiçbir şey bir
+    yükleme yapamaz ve bu sayfanın öbür ucunda bir yüklemeyi alacak bir sunucu
+    yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir dosya sıkıştırın. Tek bir istek bile bir sayfa, bir görsel
+      ya da bir dosya adı taşımıyor. Ya da internet bağlantısını kesip yine de
+      bir tane sıkıştırın."""
+
+read_first = """
+, okuma ve yeniden yazma işinin tamamı için de
+      <code>src/reader.js</code> ile <code>src/writer.js</code> &mdash; ikisi de
+      ağa erişemez."""
+
+howto_heading = "Bir PDF nasıl küçültülür"
+
+card = """
+            İçindeki görselleri yeniden sıkıştırarak bir belgeyi küçültün. Önce
+            boyutun asıl nerede olduğunu gösterir ve elde edilecek bir şey
+            olmadığında bunu açıkça söyler."""
+
+[words]
+plural = "belgeleriniz"
+choose = "bir PDF"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "Belgenizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Bu araç o listeye hiçbir şey eklemez: isteğe bağlı
+      olanı bile yok, kendine ait bir ağ özelliği hiç yok. Dosyalarınızın
+      toplanabileceği bir uç nokta burada yok, olsaydı bile onu oraya gönderecek
+      bir kod yok."""
+
+[[privacy]]
+title = "Biçimin tamamı bu depoda."
+body = """
+ Bir PDF, nesnelerden oluşan bir
+      liste ve her birinin nerede başladığını gösteren bir tablodur.
+      <code>src/objects.js</code> bu söz dizimini okur,
+      <code>src/reader.js</code> tabloyu izler, <code>src/writer.js</code>
+      yenisini yazar ve üçü de istek yapabilecek hiçbir şeyi içeri almaz. Hiçbir
+      kitaplık getirilmiyor ve hiçbir şey bir sunucuda çizilmiyor."""
+
+[[privacy]]
+title = "Şifreli dosyalar açılmıyor, geri çevriliyor."
+body = """
+
+      Parola konmuş bir PDF geri çevrilir; tarayıcıların boş parolayla ürettiği
+      ve teknik olarak açılabilecek türü de dahil. Bir belgenin korumasını
+      kaldırmak, onu küçültmekten farklı bir iştir ve bunu sessizce yapmak bir
+      aracın sizin adınıza yapması şaşırtıcı olurdu."""
+
+[[privacy]]
+title = "Bir şey koymuyor, çıkarıyor."
+body = """
+ Bitmiş dosyada oluşturulma tarihi,
+      üretici satırı ya da onu yapan aracın adı yer almaz. Kutu işaretliyken XMP
+      paketini ve sayfa düzeni uygulamalarının geride bıraktığı özel blokları da
+      kaybeder &mdash; EXIF aracının öne sürdüğü aynı gerekçenin başka bir kaba
+      uygulanmış hâli."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine belgeniz hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir sayfa, ne bir ad, bir boyut ya da bir sayfa sayısı. Bir
+      PDF'i okuyan, çözen ya da yazan her satır bu kaynaktan sunuluyor ve depoda
+      listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de belgeniz
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu: belgenizi
+      sıkıştırılmak üzere uzağa gönderen bir araç dururdu."""
+
+[[howto]]
+title = "Bir PDF seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin.
+      Tarayıcı onu doğrudan diskinizden okur; siz bunu yaparken hiçbir yere
+      hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Boyutun nerede olduğuna bakın."
+body = """
+ İkinci adımın bütün
+      anlamı bu dökümde. Çubuk ağırlıklı olarak görsellerden oluşuyorsa bu
+      aracın çalışacağı bir malzeme var demektir. Ağırlıklı olarak yazı tipleri
+      ve sayfa içeriğiyse bunu söyler ve dürüst tasarruf yüzde birkaçtır
+      &mdash; buna bir dakika harcamadan önce bilmek daha iyidir."""
+
+[[howto]]
+title = "Ne kadar sıkacağını söyleyin."
+body = """
+ Adlandırılmış ayarlar
+      belirsiz notlar değil, çözünürlüklerdir: ekranda okumak için 96 DPI,
+      e-postayla göndermek için 130, hâlâ basılacak bir şey için 220. Her biri
+      görselin sayfada gerçekte ne kadar büyük çizildiğine göre ölçülür; yani
+      küçük resim olarak yerleştirilmiş bir fotoğraf, tam sayfa bir taramayla
+      aynı muameleyi görmez."""
+
+[[howto]]
+title = "Sıkıştırın ve denetlendiğini söyleyen satırı okuyun."
+body = """
+
+      Yeniden yazma bittiğinde bitmiş dosya bu sayfadaki aynı okuyucu
+      tarafından yeniden açılır ve sayfaları sayılır. Bu, orijinaliyle
+      uyuşmuyorsa çalışma başarısız olarak bildirilir ve indirme sunulmaz."""
+
+[[faq]]
+q = "PDF'im herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya, kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        yeniden sıkıştırılır ve yazılır. Bu aracın sunucu tarafı yoktur ve
+        sayfanın <code>Content-Security-Policy</code>'si iletişim kurabileceği
+        her adresi tek tek sayar &mdash; bunların hiçbiri bu siteye ait
+        değildir. Bu aracın isteğe bağlı bir ağ özelliği de hiç yoktur."""
+
+[[faq]]
+q = "PDF'im ne kadar küçülecek?"
+a = """
+        Tamamen içinde ne olduğuna bağlı; araç da bu yüzden hiçbir şeyi
+        sıkıştırmadan önce ölçüp size gösteriyor. Taranmış bir belge neredeyse
+        baştan sona fotoğraftır ve genellikle %60&ndash;90 küçülür. Bir sözleşme
+        ya da bir tez ise metin, vektör çizim ve gömülü yazı tiplerinden oluşur;
+        bunların hepsi onları üreten yazılım tarafından zaten sıkıştırılmıştır.
+        Oradaki tasarruf genellikle yüzde birkaçtır ve dosyayı yeniden
+        paketlemekten, artık başvurulmayanı atmaktan gelir. Dosyanıza bakmadan
+        sabit bir yüzde vaat eden her araç tahmin yürütüyordur."""
+
+[[faq]]
+q = "Bir PDF'i sıkıştırmak kalite kaybettirir mi?"
+a = """
+        İçindeki görseller yeniden kodlanır, dolayısıyla onlar için evet. Başka
+        hiçbir şeye dokunulmaz: metin metin kalır, seçilebilir ve aranabilir
+        hâlde; yazı tipleri bütün olarak korunur; vektör çizim aynen kopyalanır.
+        Araç ayrıca bir görseli boşuna bozmayı da reddeder &mdash; yeniden
+        kodlama orijinalinden küçük çıkmıyorsa orijinal baytlar olduğu gibi
+        belgeye geri konur."""
+
+[[faq]]
+q = "Buradaki DPI nedir, neden soruyor?"
+a = """
+        Bir PDF, her görselin sayfada ne kadar büyük çizildiğini kaydeder;
+        böylece araç etkin çözünürlüğü hesaplayabilir: yirmi santimlik bir
+        kâğıda yerleştirilmiş 4000 piksellik bir tarama inç başına 500 piksel
+        taşıyor demektir. Bunu ne bir ekran kullanabilir ne de kâğıt üzerinde
+        pek bir işe yarar; bu yüzden seçtiğiniz ayarın üzerindeki pikseller ilk
+        önce atılır &mdash; kimsenin göremeyeceği bir kaliteye mal olurlar. Bu
+        ölçüm, küçük yerleştirilmiş bir logonun tam sayfa bir taramayla aynı
+        muameleyi görmemesinin de sebebidir."""
+
+[[faq]]
+q = "Parola korumalı bir PDF'i açabilir mi?"
+a = """
+        Hayır ve bu bilinçli bir tercih. Şifreli bir belge, bunu söyleyen bir
+        mesajla geri çevrilir; parola boş olsa bile &mdash; ki pek çok tarayıcı
+        ve fotokopi makinesi böyle kaydeder. Bir dosyanın korumasını kaldırmak,
+        onu sıkıştırmaktan farklı bir iştir ve bunu sessizce yapan bir araç
+        sizin istemediğiniz bir şeyi yapıyor olurdu."""
+
+[[faq]]
+q = "Sıkıştıramadığı PDF'ler var mı?"
+a = """
+        İçlerindeki bazı görseller için evet. JPEG 2000, JBIG2 ve faks kodlu
+        (CCITT) görsellerin hiçbir tarayıcıda çözücüsü yoktur; bu yüzden
+        dokunulmadan geçirilir ve öyle bildirilir &mdash; son ikisi iki
+        seviyeli kodlayıcılardır ve zaten en küçük hâllerine yakındır. CMYK
+        görseller de olduğu gibi bırakılır, çünkü onları yeniden kodlamak bir
+        matbaanın üreteceği renkleri kaydırma riski taşır. Aracın atladığı her
+        şey, sebebiyle birlikte sonuçlarda adıyla belirtilir."""
+
+[[faq]]
+q = "Sıkıştırılmış dosya her yerde açılmaya devam eder mi?"
+a = """
+        Evet. Çıktı, 2003'ten beri sunulan her okuyucunun anladığı PDF 1.5
+        olarak yazılır ve araç bunu kendi cihazınızda kanıtlar: bitmiş dosyayı
+        size sunmadan önce yeniden açıp sayfalarını sayar. Formlar, bağlantılar,
+        yer imleri, erişilebilirlik yapısı ve gömülü ekler karşıya taşınır;
+        geride bırakılan şey, belgede artık hiçbir şeyin başvurmadığı
+        malzemedir."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok ve kendi cihazınızın
+        belleğinin izin verdiğinin ötesinde bir dosya boyutu sınırı yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara belgeniz hakkında hiçbir
+        şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: belgenizi sıkıştırılmak üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir PDF'i tarayıcınızda sıkıştırın. Görseller, sayfada gerçekte ne kadar büyük çizildiklerine göre yeniden sıkıştırılır ve belge yerel olarak yeniden yazılır; böylece hiçbir dosya yüklenmez."
+features = [
+  "Hiçbir şeyi sıkıştırmadan önce belgenin boyutunun asıl nerede olduğunu gösterir",
+  "Görselleri, sayfada ölçülen çözünürlüklerine göre yeniden sıkıştırır",
+  "Yeniden kodlamak küçültmeyecekse görseli olduğu gibi bırakır",
+  "Önceki bir düzenlemenin geride bıraktığı nesneleri ve isteğe bağlı üst veriyi atar",
+  "Bitmiş dosyayı sunmadan önce yeniden açıp denetler",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, dosya boyutu sınırı yok",
+]
+
+[picker]
+title = "Bir PDF'i buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; bir seferde tek belge"

--- a/locales/tr/tools/crop-video.html
+++ b/locales/tr/tools/crop-video.html
@@ -1,0 +1,152 @@
+<!--
+  tools/crop-video/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosya -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir video seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Dosya</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Boyut</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Kare</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Görüntü</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Ses</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; kırpma -->
+  <section class="card" id="crop-card" hidden>
+    <h2><span class="step">2</span> Kırpmayı ayarlayın</h2>
+
+    <p class="stage-hint">
+      Taşımak için kutunun içine, yeniden boyutlandırmak için herhangi bir
+      köşesine sürükleyin. Kutu odaktayken ok tuşları onu birer piksel
+      kaydırır, <kbd>Alt</kbd>&nbsp;+&nbsp;oklar yeniden boyutlandırır,
+      <kbd>Shift</kbd>'i basılı tutmak her adımı on yapar.
+    </p>
+
+    <!-- The crop box itself is added here by src/cropper.js. The stage is given
+         the video's own shape, so the box can be positioned in percentages and
+         needs no recalculating when the window is resized. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <div class="crop-controls">
+      <div class="aspect-row" role="group" aria-label="Kırpmayı bir şekle kilitle">
+        <button type="button" data-aspect="free" class="active">Serbest</button>
+        <button type="button" data-aspect="source">Orijinal</button>
+        <button type="button" data-aspect="1:1">1:1</button>
+        <button type="button" data-aspect="4:5">4:5</button>
+        <button type="button" data-aspect="9:16">9:16</button>
+        <button type="button" data-aspect="16:9">16:9</button>
+        <button type="button" data-aspect="4:3">4:3</button>
+        <button type="button" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="ghost" title="Kilitli şekli yan çevir">
+          Çevir
+        </button>
+      </div>
+
+      <div class="numbers">
+        <label>Sol<input type="number" id="crop-x" min="0" step="1"></label>
+        <label>Üst<input type="number" id="crop-y" min="0" step="1"></label>
+        <label>Genişlik<input type="number" id="crop-w" min="16" step="2"></label>
+        <label>Yükseklik<input type="number" id="crop-h" min="16" step="2"></label>
+        <div class="number-actions">
+          <button type="button" id="crop-max" class="ghost">En büyük</button>
+          <button type="button" id="crop-centre" class="ghost">Ortala</button>
+          <button type="button" id="crop-reset" class="ghost">Kareyi tümüyle</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="even-note">
+      Genişlik ve yükseklik ikişer ikişer ilerler, çünkü H.264'ün kenarı tek
+      sayı olan bir kareyi saklamanın yolu yoktur.
+    </p>
+  </section>
+
+  <!-- Adım 3 &mdash; dışa aktarma -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Kırpın</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Çıktı</label>
+        <select id="format">
+          <option value="mp4" selected>MP4 &mdash; kare kare yeniden kodlanır</option>
+          <option value="webm">WebM &mdash; oynarken kaydedilir</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Kalite</label>
+        <select id="quality">
+          <option value="low">Daha küçük dosya</option>
+          <option value="medium" selected>Dengeli</option>
+          <option value="high">En iyi kalite</option>
+        </select>
+        <p class="field-note">
+          Aynı alana orijinalin harcadığından asla fazlası değil &mdash; bunun
+          üzerinde yeniden kodlamak dosyayı yalnızca büyütür.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Sesi koru
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Çıktı karesi</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Tutulan</dt><dd id="sum-kept">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Nasıl</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Videoyu kırp</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Videoyu indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/crop-video.toml
+++ b/locales/tr/tools/crop-video.toml
@@ -1,0 +1,236 @@
+#
+# Video Kırpıcı - Türkçe.
+#
+# Overrides for tools/crop-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Kırpma" burada kadrajı kesmek anlamında; klibi kısaltmak "kesme" ve o başka
+# bir araç. locale.toml'un başındaki nota bakın: bu site üçünü ayırıyor.
+#
+
+name = "Video Kırpıcı"
+heading = "Video&nbsp;Kırpma <span class=\"h1-kw\">&mdash; videoyu çevrimiçi kırpın</span>"
+tagline = "Bir klibi asıl önemli olan kısma indirin."
+
+title = "Videoyu Çevrimiçi Kırpma &mdash; Ücretsiz, Yüklemesiz, Çevrimdışı Çalışır"
+description = "Bir MP4, MOV veya WebM'i istediğiniz şekle kırpın: kare, 9:16 ya da tam piksel kutusu. Tarayıcınızda çalışır: hiçbir şey yüklenmez, ses korunur, çevrimdışı da çalışır."
+og_title = "Video Kırpıcı &mdash; bir klibi yüklemeden kırpın"
+og_description = "Klibinizin üzerine bir kutu sürükleyin ve istediğiniz şekle kırpın. Kareler kendi cihazınızda çözülüp yeniden kodlanır, orijinal ses ise el değmeden karşıya taşınır."
+og_image_alt = "Video Kırpıcı - bir klibi tarayıcınızda kırpın, hiçbir şey yüklenmesin"
+
+pledge = """
+    Her kare kendi tarayıcınız tarafından, kendi donanımınızda çözülür,
+    kırpılır ve kodlanır. Buradaki hiçbir şey bir şey getiremez ya da
+    gönderemez &mdash; bu araçta hiçbir türde ağ özelliği yok &mdash; ve
+    olsaydı bile bu sayfanın öbür ucunda bir videonun gönderilebileceği bir
+    sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir klip kırpın. Tek bir istek bile bir kare, bir dosya adı ya
+      da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet bağlantısını
+      kesip yine de bir tane kırpın &mdash; videonuzu işlenmek üzere uzağa
+      gönderen bir araç öylece dururdu."""
+
+read_first = """
+, bir MP4 içindeki kareleri bulan okuyucu için
+      <code>src/demux.js</code> ve onları çözüp kırpan ve kodlayan döngü için
+      <code>src/transcode.js</code>. İkisi de istek yapabilecek hiçbir şeyi
+      içeri almaz."""
+
+howto_heading = "Bir video nasıl kırpılır"
+
+card = """
+            Bir klibin üzerine kutu sürükleyip onu o şekle indirin &mdash; akış
+            için kare, telefon için dikey ya da tam piksel kutusu."""
+
+[words]
+plural = "videolarınız"
+choose = "bir video"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Sesi korur"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[privacy]]
+title = "Videolarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu
+      sayfanın iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri
+      bu siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araçta hiçbir türde ağ
+      özelliği yok: yapıştırılacak bir adres, indirilecek bir şey, ilk
+      kullanımda getirilen bir motor yok. Videonuza dokunan her bayt, sayfa
+      yüklenirken bu kaynaktan geldi."""
+
+[[privacy]]
+title = "Çözme ve kodlama yerelde."
+body = """
+ Kareler kendi tarayıcınızdaki
+      WebCodecs'ten geçer ya da klibi zaten size gösterecek olan aynı oynatma
+      motorundan. Bitmiş dosya bu makinenin belleğinde kurulur ve doğrudan bir
+      indirmeye verilir."""
+
+[[privacy]]
+title = "Ses kopyalanıyor, dinlenmiyor."
+body = """
+ MP4 yolunda ses örnekleri hiç
+      çözülmeden karşıya taşınır &mdash; buradaki hiçbir şey onları tekrar sese
+      dönüştürmez ve dönüştürse bile hiçbir şey onları bir yere iletemezdi."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine videonuz hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir kare, ne bir ad, bir boyut, bir uzunluk ya da onu kırptığınız
+      şekil. Okuyan, çözen, kırpan ya da kodlayan her satır bu kaynaktan
+      sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de videonuz
+      hakkında bir şey verilir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Bir video seçin."
+body = """
+ Seçiciye bir MP4, MOV, M4V ya da WebM
+      bırakın veya elle seçin. Tarayıcı onu doğrudan diskinizden okur; siz bunu
+      yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Kutuyu tutmak istediğiniz yerin üzerine sürükleyin."
+body = """
+      Taşımak için içine, yeniden boyutlandırmak için herhangi bir köşesine
+      sürükleyin. Önce bir şekle kilitleyin &mdash; kare bir gönderi için 1:1,
+      telefon için 9:16, geniş kadraj için 16:9 &mdash; ya da altındaki dört
+      alana tam piksel kutusunu yazın."""
+
+[[howto]]
+title = "Ne kadar kalite harcayacağınızı seçin."
+body = """
+ Görüntünün yeniden
+      kodlanması gerekir, çünkü kırpılmış bir kare başka bir görüntüdür.
+      "Dengeli", dosyanın o alana zaten harcadığına yakın kalır; "En iyi kalite"
+      daha fazlasını harcar. Kapatmadığınız sürece ses korunur."""
+
+[[howto]]
+title = "Kırpın ve indirin."
+body = """
+ İş kendi donanımınızda olduğu için ne
+      kadar süreceği bir sıraya değil makinenize bağlıdır. Bitmiş video doğrudan
+      tarayıcınızın indirmelerine verilir."""
+
+[[faq]]
+q = "Videom herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur, çözülür,
+        kırpılır ve kodlanır. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Size
+        söylenene güvenmek yerine denetlemeyi tercih ediyorsanız internet
+        bağlantısını kesin ve yine de bir klip kırpın."""
+
+[[faq]]
+q = "Hangi video biçimlerini kırpabilirim?"
+a = """
+        MP4, M4V ve MOV içlerinde ne olursa olsun doğrudan okunur: H.264, HEVC,
+        AV1 ya da VP9 &mdash; yeter ki tarayıcınız o kodlayıcıyı çözebilsin.
+        Tarayıcınızın oynatabildiği başka her şey &mdash; en bilineni WebM
+        &mdash; bunun yerine oynatılıp sonucu kaydedilerek kırpılır; bu da
+        işe yarar ama klip ne kadar uzunsa o kadar sürer. Tarayıcının ne
+        okuyabildiği ne de oynatabildiği bir dosya, ki pratikte AVI, WMV, FLV ve
+        çoğu MKV demektir, yarı yolda başarısız olmak yerine bunu söyleyen bir
+        mesajla geri çevrilir."""
+
+[[faq]]
+q = "Videonun boyutunda veya uzunluğunda bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok ve dosya belleğe bir seferde tümüyle
+        okunmuyor &mdash; her seferinde birkaç megabaytlık parçalar hâlinde
+        geziliyor. Pratik tavan, indirmeden önce bellekte kurulan bitmiş video
+        ile makinenizin onu kodlamak için harcadığı süredir."""
+
+[[faq]]
+q = "Ses hayatta kalıyor mu?"
+a = """
+        MP4 yolunda tam olarak: ses hiç çözülmeden örnek örnek kopyalanır, yani
+        dosyada ne varsa bayt bayt odur. Kayıt yolunda ise oynatmadan yakalanıp
+        yeniden kodlanır ki bu biraz kaliteye mal olur. Her iki durumda da onu
+        tümüyle dışarıda bırakan bir onay kutusu var."""
+
+[[faq]]
+q = "Kırpmak kalite kaybettirir mi?"
+a = """
+        Görüntü yeniden kodlanır, çünkü kırpılmış bir kare başka bir görüntüdür
+        ve pikselleri yeniden yazmadan onu saklamanın bir yolu yoktur. Aracın
+        yapmayacağı şey, aynı alana orijinalin harcadığından fazlasını
+        harcamaktır; bunun üzerinde yeniden kodlamak dosyayı yalnızca
+        büyütür, daha iyi göstermez."""
+
+[[faq]]
+q = "Uzunluğu da kesebilir miyim?"
+a = """
+        Burada değil, yan kapıda. Bu araç görüntünün şeklini değiştirir, başka
+        hiçbir şeyi: çıkan klip, girenle tam olarak aynı uzunlukta, zamanlaması
+        ve sesi el değmemiş hâlde olur. Kesmek ayrı bir iştir ve ayrı bir
+        araçtır &mdash; <a href="../video-kesme/">Video Kesici</a>, bir klibin
+        tutmaya değer parçalarını işaretler ve tek bir dosya olarak, tek bir
+        kareyi bile yeniden kodlamadan kaydeder."""
+
+[[faq]]
+q = "Genişlik ve yükseklik neden ikişer ikişer ilerliyor?"
+a = """
+        Bir MP4'ün içindeki kodlayıcı olan H.264, görüntüyü bloklar hâlinde
+        saklar ve bir kenarında tek sayıda piksel olan bir kareyi tarif etmenin
+        yolu yoktur. Siz kırpmayı ayarladıktan sonra onu sessizce yuvarlamak
+        yerine, kutu en baştan yalnızca çift sayılar sunar."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara videonuz hakkında hiçbir
+        şey verilmiyor."""
+
+[schema]
+browser_requirements = "JavaScript gerekir. MP4 çıktısı için WebCodecs destekleyen bir tarayıcı gerekir; diğerleri WebM kaydına düşer."
+description = "Bir videoyu tarayıcıda istediğiniz şekle ya da tam piksel kutusuna kırpın. MP4, MOV ve M4V kare kare çözülüp yeniden kodlanır, orijinal ses el değmeden karşıya taşınır; tarayıcının oynatabildiği başka her şey kaydedilerek kırpılır. Hiçbir şey yüklenmez."
+features = [
+  "MP4, MOV, M4V ve WebM videoları kırpar",
+  "H.264, HEVC, AV1 ve VP9 kaynakları, WebCodecs üzerinden çözülür",
+  "Serbest kırpma, kilitli oranlar (1:1, 4:5, 9:16, 16:9, 4:3, 3:2) veya tam piksel kutusu",
+  "Orijinal sesi yeniden kodlamadan korur",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir videoyu buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; MP4, MOV, M4V, WebM ve bu tarayıcının oynattığı her şey"

--- a/locales/tr/tools/dicom-viewer.html
+++ b/locales/tr/tools/dicom-viewer.html
@@ -1,0 +1,254 @@
+<!--
+  tools/dicom-viewer/body.html, in Turkish.
+
+  Every id, class, data-phrase key and {placeholder} below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+
+  The window presets are the names a radiologist reads at a workstation, so
+  they are translated; the tag numbers, VR codes and transfer syntax names are
+  not, because those are looked up in the DICOM standard exactly as written.
+-->
+<main>
+  <!--
+    One numbered step, and then the viewer.
+
+    Every other tool on this site numbers its cards because every card is
+    something the visitor does. Here there is one thing to do - choose the
+    files - and everything below it is the scan. Numbering the picture would
+    promise a sequence of decisions that does not exist.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir tarama seçin</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p class="picker-note">
+      Bir klasör dolusu dosyayı bir seferde bırakın; serilerine geri konsunlar
+      ve sıraya dizilsinler. Hiçbir şey yüklenmez ve dosyalarınıza hiçbir şey
+      geri yazılmaz.
+    </p>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- The viewer. -->
+  <section class="card" id="viewer-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="save-frame" class="ghost" data-download>Bu kareyi PNG olarak kaydet</button>
+        <button type="button" id="copy-header" class="ghost">Başlığı kopyala</button>
+        <button type="button" id="download-header" class="ghost">İndir</button>
+      </div>
+    </div>
+
+    <div class="series-row" id="series-row" hidden>
+      <label for="series-pick" class="inline-label">Seri</label>
+      <select id="series-pick"></select>
+      <span class="count" id="series-note"></span>
+    </div>
+
+    <!--
+      The canvas is sized in CSS and its backing store is set to the frame's own
+      pixels, so a 512-pixel slice is drawn at 512 pixels and scaled by the
+      browser rather than resampled here. That is what makes the zoom honest:
+      what is on screen at 400% is the stored pixels made bigger, not a guess at
+      what was between them.
+    -->
+    <div class="viewport" id="viewport">
+      <canvas id="canvas" width="1" height="1" role="img"
+              aria-label="Ekrandaki kare, seçtiğiniz dosyadan çizilmiş"></canvas>
+      <div class="overlay overlay-tl" id="overlay-tl" hidden></div>
+      <div class="overlay overlay-tr" id="overlay-tr"></div>
+      <div class="overlay overlay-bl" id="overlay-bl"></div>
+      <div class="overlay overlay-br" id="overlay-br"></div>
+      <svg class="marks" id="marks" aria-hidden="true"></svg>
+      <p class="viewport-fail" id="viewport-fail" hidden></p>
+    </div>
+
+    <div class="scrub" id="scrub-row" hidden>
+      <button type="button" id="play" class="ghost" aria-label="Kareleri baştan sona oynat">▶</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" step="1"
+             aria-label="Hangi kesit ya da kare gösteriliyor">
+      <span class="count" id="scrub-label">&mdash;</span>
+    </div>
+
+    <div class="tools">
+      <fieldset class="modes">
+        <legend class="visually-hidden">Resmin üzerinde sürüklemek ne yapar</legend>
+        <label><input type="radio" name="mode" value="window" checked> Pencere ve seviye</label>
+        <label><input type="radio" name="mode" value="pan"> Kaydır</label>
+        <label><input type="radio" name="mode" value="measure"> Ölç</label>
+      </fieldset>
+
+      <div class="zoom">
+        <label for="zoom" class="inline-label">Yakınlaştırma</label>
+        <input type="range" id="zoom" min="5" max="800" step="5" value="100">
+        <span class="count" id="zoom-label">%100</span>
+        <button type="button" id="reset-view" class="ghost">Sığdır</button>
+      </div>
+    </div>
+
+    <div class="levels" id="levels">
+      <div class="level-field">
+        <label for="preset" class="inline-label">Pencere</label>
+        <select id="preset"></select>
+      </div>
+      <div class="level-field">
+        <label for="center" class="inline-label">Merkez</label>
+        <input type="number" id="center" step="1">
+      </div>
+      <div class="level-field">
+        <label for="width" class="inline-label">Genişlik</label>
+        <input type="number" id="width" step="1" min="1">
+      </div>
+      <label class="level-check"><input type="checkbox" id="invert"> Tersle</label>
+      <label class="level-check"><input type="checkbox" id="show-details"> Hasta bilgilerini resmin üzerinde göster</label>
+    </div>
+
+    <p class="hint" id="mode-hint"></p>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- What the file is. -->
+  <section class="card" id="facts-card" hidden>
+    <h2>Bu dosya nedir</h2>
+    <dl class="facts">
+      <div><dt>Nesne</dt><dd id="fact-sop">&mdash;</dd></div>
+      <div><dt>Modalite</dt><dd id="fact-modality">&mdash;</dd></div>
+      <div><dt>Görüntü</dt><dd id="fact-size">&mdash;</dd></div>
+      <div><dt>Saklanma biçimi</dt><dd id="fact-stored">&mdash;</dd></div>
+      <div><dt>Aktarım söz dizimi</dt><dd id="fact-syntax">&mdash;</dd></div>
+      <div><dt>Piksel aralığı</dt><dd id="fact-spacing">&mdash;</dd></div>
+      <div><dt>Değer aralığı</dt><dd id="fact-range">&mdash;</dd></div>
+      <div><dt>Dosya</dt><dd id="fact-file">&mdash;</dd></div>
+    </dl>
+
+    <ul class="notes" id="notes" hidden></ul>
+  </section>
+
+  <!-- What is in it about the person. -->
+  <section class="card" id="identity-card" hidden>
+    <h2>Bu dosyada hastayı ne tanımlıyor</h2>
+    <p class="card-lede">
+      Bu dosyadan, bu makinede okundu ve başka hiç kimseye gösterilmedi. Bu araç
+      hiçbir şey yazmaz: bunların hiçbirini çıkaramaz ve hiçbirini hiçbir yere
+      göndermemiştir. Burada olmasının sebebi, bir taramanın bir addan çok
+      fazlasını taşıması ve geri kalanının, özensiz bir anonimleştirmeden sağ
+      çıkan şey olmasıdır.
+    </p>
+    <ul class="identity" id="identity"></ul>
+    <p class="identity-extra" id="identity-extra"></p>
+  </section>
+
+  <!-- Every tag in the file. -->
+  <section class="card" id="tags-card" hidden>
+    <div class="toolbar">
+      <h2>Dosyadaki her etiket</h2>
+      <div class="toolbar-actions">
+        <label for="tag-search" class="visually-hidden">Etiketlerde ara</label>
+        <input type="search" id="tag-search" class="tag-search" placeholder="Ada, numaraya ya da değere göre ara">
+      </div>
+    </div>
+
+    <p class="card-lede" id="tags-lede"></p>
+
+    <div class="table-wrap">
+      <table class="tags">
+        <caption class="visually-hidden">Bu dosyadaki her öğe</caption>
+        <thead>
+          <tr>
+            <th scope="col">Etiket</th>
+            <th scope="col">VR</th>
+            <th scope="col">Ad</th>
+            <th scope="col">Değer</th>
+          </tr>
+        </thead>
+        <tbody id="tag-rows"></tbody>
+      </table>
+    </div>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!--
+    The tool's own sentences, kept out of the JavaScript so that a translator
+    can reach them. shared/js/phrases.js reads them back, and a key defined here
+    wins over the frame's one.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="mode.window">Pencereyi genişletmek ya da daraltmak için resim üzerinde yatay, merkezini kaydırmak için dikey sürükleyin. İki sayı da aşağıda ve içlerine yazmak da aynı şeyi yapar.</span>
+    <span data-phrase="mode.pan">Resmi kendi çerçevesi içinde taşımak için sürükleyin. Fare tekerleği yakınlaştırır, &laquo;Sığdır&raquo; ise geri koyar.</span>
+    <span data-phrase="mode.measure">Ölçmek için resmin üzerine bir çizgi sürükleyin. Dosya piksellerinin birbirine ne kadar uzak olduğunu söylüyorsa cevap milimetre cinsindendir; söylemiyorsa cevap piksel cinsindendir ve bunu söyler.</span>
+
+    <span data-phrase="probe.value">Sütun {column}, satır {row} konumunda {value}</span>
+    <span data-phrase="measure.pixels">{length} px &mdash; bu dosya piksellerinin birbirine ne kadar uzak olduğunu söylemiyor, bu yüzden bu milimetre cinsinden olamaz</span>
+
+    <span data-phrase="stack.position">Her kesitin hastadaki konumuna göre dizildi; tarayıcının onları aldığı sıra da budur.</span>
+    <span data-phrase="stack.number">Örnek numarasına göre dizildi: bu dosyalar sıralanacak bir hasta konumu taşımıyor.</span>
+    <span data-phrase="stack.gap">Kesitler arasındaki aralık baştan sona aynı değil, yani bu seriden en az bir kesit eksik.</span>
+
+    <span data-phrase="pixels.none">Bu dosyanın pikselleri {codec} ile sıkıştırılmış; bunu hiçbir tarayıcı çözemez ve bu sayfa da bunun için bir çözücü taşımaz. Dosya hakkındaki diğer her şey aşağıda.</span>
+    <span data-phrase="pixels.failed">Resim çözülemedi: {reason}. Aşağıdaki başlık tam olarak okundu.</span>
+    <span data-phrase="pixels.absent">Bu dosya hiç piksel verisi taşımıyor. Bir başlıktan ibaret ve içindeki her şey aşağıda.</span>
+    <span data-phrase="pixels.jpeg">Bu pikseller baseline JPEG, yani tarayıcının kendi çözücüsü onları açtı ve geri verdiği şey sekiz bit derinliğinde. Pencere yine çalışır; tarayıcının kaydettiği hassasiyetin tamamı orada değil.</span>
+
+    <span data-phrase="tags.count">{total} öğeden {shown} tanesi. {hidden} tane daha var.</span>
+    <span data-phrase="tags.all">Bu dosyadaki {total} öğenin tamamı.</span>
+    <span data-phrase="tags.found">&laquo;{query}&raquo; ile {total} öğe eşleşiyor.</span>
+    <span data-phrase="tags.found.one">&laquo;{query}&raquo; ile bir öğe eşleşiyor.</span>
+    <span data-phrase="tags.none">&laquo;{query}&raquo; ile hiçbir şey eşleşmiyor.</span>
+    <span data-phrase="tags.more">Kalan {count} tanesini göster</span>
+    <span data-phrase="tags.private">özel öğe</span>
+    <span data-phrase="tags.unknown">bu sözlükte yok</span>
+    <span data-phrase="tags.guessed">Dosya söylemedi; bu, veri sözlüğünün bu etiket için verdiği değer.</span>
+
+    <span data-phrase="working.one">{name} okunuyor&hellip;</span>
+    <span data-phrase="working.many">{total} dosyadan {at} tanesi okunuyor&hellip;</span>
+    <span data-phrase="error.none">Buradaki hiçbir şey DICOM olarak okunamadı. {why} Bu araç DICOM biçiminin kendisini okur, dolayısıyla başka dosyalar hakkında söyleyecek bir şeyi yoktur.</span>
+    <span data-phrase="error.skipped.one">Bir dosya atlandı: {files}</span>
+    <span data-phrase="error.skipped">{count} dosya atlandı: {files}</span>
+
+    <span data-phrase="series.number">Seri {number}</span>
+    <span data-phrase="series.files.one">1 dosya</span>
+    <span data-phrase="series.files">{count} dosya</span>
+    <span data-phrase="stack.spacing">Kesitler arası {gap}.</span>
+
+    <span data-phrase="at.position">{total} içinde {at}</span>
+    <span data-phrase="at.frame">{total} kareden {at}. kare</span>
+    <span data-phrase="at.instance">örnek {number}</span>
+
+    <span data-phrase="window.file">Dosyadan</span>
+    <span data-phrase="window.file.n">Dosyadan, {n}</span>
+    <span data-phrase="window.full">Bu karedeki her şey</span>
+    <span data-phrase="window.custom">Elle ayarlandı</span>
+    <span data-phrase="window.soft">Yumuşak doku</span>
+    <span data-phrase="window.lung">Akciğer</span>
+    <span data-phrase="window.bone">Kemik</span>
+    <span data-phrase="window.brain">Beyin</span>
+    <span data-phrase="window.liver">Karaciğer</span>
+    <span data-phrase="window.mediastinum">Mediasten</span>
+    <span data-phrase="window.angio">Anjiyografi</span>
+
+    <span data-phrase="facts.frames">{count} kare</span>
+    <span data-phrase="facts.nopixels">piksel verisi yok</span>
+    <span data-phrase="facts.nospacing">bu dosyada belirtilmemiş</span>
+    <span data-phrase="facts.signed">işaretli</span>
+    <span data-phrase="facts.unsigned">işaretsiz</span>
+    <span data-phrase="facts.stored.one">{bits} bit, {sign}, piksel başına 1 örnek, {photometric}</span>
+    <span data-phrase="facts.stored">{bits} bit, {sign}, piksel başına {samples} örnek, {photometric}</span>
+    <span data-phrase="facts.range">{low} ile {high} arası</span>
+    <span data-phrase="facts.colour">renkli &mdash; bildirilecek bir ölçüm yok</span>
+
+    <span data-phrase="identity.clean">Bu dosyada bir kişiyi adlandıran ya da numaralandıran hiçbir şey yok. Bir taramanın genellikle taşıdığı tanımlayıcılar ya yok ya da boş.</span>
+    <span data-phrase="identity.uids">Ayrıca kendine ait {count} tanımlayıcı taşıyor &mdash; çalışma, seri ve örnek UID'leri. Hiçbiri bir ad değil ve her biri, dosyayı üreten arşive açılan mükemmel bir anahtar.</span>
+    <span data-phrase="identity.private">Bir de anlamı hiçbir yerde yayımlanmamış {count} özel öğe: bazı tarayıcılar hastanın adının ikinci bir kopyasını bunlardan birinde tutar.</span>
+
+    <span data-phrase="copied">Kopyalandı.</span>
+    <span data-phrase="copy.failed">Tarayıcınız sayfanın kopyalamasına izin vermedi. Yanındaki indirme düğmesi aynı metni bir dosyaya yazar.</span>
+    <span data-phrase="saved">{name} kaydedildi.</span>
+  </div>
+</main>

--- a/locales/tr/tools/dicom-viewer.toml
+++ b/locales/tr/tools/dicom-viewer.toml
@@ -1,0 +1,382 @@
+#
+# DICOM Görüntüleyici - Türkçe.
+#
+# Overrides for tools/dicom-viewer/tool.toml. Only words: the slug, the
+# category, the icon and the list of shared parts stay where they are.
+#
+# Etiket adları, aktarım söz dizimi adları ve PS3.15 gibi standart
+# referansları Latin harflerinde kalıyor: bunlar bir okuyucunun DICOM
+# standardında arayacağı şeyler, çevrilecek kelimeler değil.
+#
+
+name = "DICOM Görüntüleyici"
+heading = "DICOM&nbsp;Görüntüleyici <span class=\"h1-kw\">&mdash; bir .dcm taramasını tarayıcınızda açın</span>"
+tagline = "BT, MR, röntgen ve ultrason; penceresi, başlığı ve ölçümleriyle."
+
+title = "DICOM Görüntüleyici &mdash; Bir .dcm Dosyasını Tarayıcınızda Açın, Yüklemesiz"
+description = "BT, MR, röntgen ve ultrason taramalarını tarayıcınızda açın. Pencere ve seviye, bütün bir seriyi kaydırma, milimetre cinsinden ölçüm, her DICOM etiketini okuma ve dosyada hastayı tam olarak neyin tanımladığını görme. Hiçbir şey yüklenmez."
+og_title = "DICOM Görüntüleyici &mdash; bir taramayı yüklemeden açın"
+og_description = "Kendi cihazınızda açılan bir .dcm dosyası: pencere ve seviye, sıraya dizilmiş bütün seri, milimetre cinsinden ölçümler ve başlıktaki her etiket. Yükleme yok, hesap yok."
+og_image_alt = "DICOM Görüntüleyici - bir BT, MR ya da röntgen taramasını tarayıcıda açın"
+
+pledge = """
+    Tarama kendi tarayıcınız tarafından açılır ve çözülür: başlık, pikseller,
+    pencere, ölçümler. Buradaki herhangi bir şey istese bile bu sayfanın öbür
+    ucunda korunan sağlık bilgilerinin gönderilebileceği bir sunucu yok ve dosya
+    hakkında hiçbir şey - ne hastanın adı, ne çalışma, ne de dosya adı - hiç
+    kimseye okunmaz."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir tarama açın. Tek bir istek bile bir görüntü, bir etiket ya
+      da bir dosya adı taşımıyor. Ya da internet bağlantısını kesip yine de bir
+      tane açın."""
+
+read_first = """
+, dosyayı gezen ayrıştırıcı için <code>src/dicom.js</code>,
+      piksel çözme için <code>src/pixels.js</code>, hastane dışa aktarmalarının
+      çoğunun kullandığı kodlayıcı için <code>src/jpeg-lossless.js</code> ve
+      pencere ile seviye için <code>src/window.js</code> &mdash; hiçbirinde ağa
+      erişebilecek tek bir satır yok."""
+
+howto_heading = "Bir DICOM dosyası nasıl açılır"
+
+card = """
+            Bir BT, MR, röntgen ya da ultrason taramasını kendi cihazınızda
+            açın. Penceresini ayarlayın, bütün seriyi kaydırın, milimetre
+            cinsinden ölçün ve başlıktaki her etiketi okuyun."""
+
+[words]
+plural = "taramalarınız"
+choose = "bir tarama"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "Taramanızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyanızın toplanabileceği bir uç nokta burada yok,
+      olsaydı bile onu oraya gönderecek bir kod yok. Burada eskiden
+      <code>connect-src 'none'</code> yazıyordu ki bu mutlaktı; reklam eklemek
+      buna mal oldu ve bunu söylemek anlaşmanın bir parçası."""
+
+[[privacy]]
+title = "Bu, burada diğer sayfalardan daha çok önemli."
+body = """
+
+      Bir DICOM dosyası, üzerine biraz üst veri iliştirilmiş bir resim değildir.
+      İçinde bir resim olan bir tıbbi kayıttır: hastanın adı, doğum tarihi,
+      hastane numarası, istem numarası, sevk eden doktor, kurum ve tarayıcının
+      seri numarası, hepsi başlıktaki alanlardır ve dosya nereye giderse onunla
+      birlikte giderler. Bakmak için bir tanesini bir siteye yüklemek, bunların
+      hepsini o siteyi kim işletiyorsa ona vermek demektir. Bu sayfa tam da bunu
+      yapmamak için var."""
+
+[[privacy]]
+title = "Okuyucu bu depodaki on dört dosya."
+body = """
+ Buradaki hiçbir şey herhangi bir
+      yerden getirilmiş bir kitaplık kullanmıyor. <code>src/dicom.js</code>
+      dosyayı geziyor, <code>src/dictionary.js</code> etiketlerin adlarını
+      biliyor, <code>src/pixels.js</code> baytları tekrar ölçüme çeviriyor,
+      <code>src/rle.js</code> ve <code>src/jpeg-lossless.js</code> bu sayfanın
+      çözebildiği iki sıkıştırılmış biçimi açıyor ve <code>src/window.js</code>
+      ölçüleni ekranınızın grilerine eşliyor."""
+
+[[privacy]]
+title = "Tanımlayıcılar size listeleniyor, başka hiç kimseye değil."
+body = """
+
+      Sayfa, dosyanızda kimin taraması olduğunu söyleyen ya da daraltan her alanı
+      basar; çünkü bu, bir kesiti paylaşmak üzere olan birinin cevabına ihtiyaç
+      duyduğu ve hiçbir görüntüleyicinin cevaplamadığı bir sorudur. Önünüzdeki
+      ekrana konur ve başka hiçbir yere gitmez: bu depoda bunlardan herhangi
+      birini taşıyan bir analitik olayı yok ve olsaydı bile sayfa onu
+      gönderemezdi."""
+
+[[privacy]]
+title = "Okur. Yazmaz."
+body = """
+ Burada dosyanızı değiştiren bir düğme yok ve
+      değiştirebilecek bir kod da yok. Yanınızda götürebileceğiniz şey, ekrandaki
+      karenin bir PNG'si ve başlığın metin kopyasıdır; ikisi de sayfada, zaten
+      üzerinde olandan kurulur. Orijinaliniz diskinizde el değmemiş durur;
+      sekmeyi kapatırsanız ne olacağının dürüst cevabı da budur."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine dosyanız hakkında bir şey verilmiyor: ne
+      pikseller, ne bir küçük resim, ne bir ad, bir etiket, bir hasta ya da bir
+      dosya adı. Bir taramayı ayrıştıran, çözen ya da çizen her satır bu
+      kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de dosyalarınız
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfanın her
+      parçası çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu:
+      taramanızı çizilmek üzere uzağa gönderen bir araç, siz fişi çeker çekmez
+      dururdu."""
+
+[[howto]]
+title = "Dosyaları seçin."
+body = """
+ Tek bir <code>.dcm</code> dosyası ya da diskteki
+      klasörün tamamı &mdash; bir BT ya da MR, kesit başına bir dosyadır ve
+      hepsini birden bırakmak seriyi yeniden bir araya getiren şeydir. Dosyalar
+      tarayıcı tarafından doğrudan diskinizden okunur; siz bunu yaparken hiçbir
+      yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Seriyi seçin."
+body = """
+ Bir çalışma genellikle birkaç seri taşır: önce
+      kılavuz görüntü, sonra her çekim. Her biri, tarayıcının aldığı sırayla
+      dizilir; bu sıra, her zaman aynı yönde ilerlemeyen numaralandırmadan değil,
+      her kesitin hastadaki konumundan hesaplanır."""
+
+[[howto]]
+title = "Pencereyi ayarlayın."
+body = """
+ Bir taramayı okunur yapan ve bir görsel
+      düzenleyicide bulunmayan denetim budur. Pencereyi genişletmek için görüntü
+      üzerinde yatay, merkezini kaydırmak için dikey sürükleyin ya da bir BT'de
+      adlandırılmış pencerelerden birini seçin &mdash; akciğer, kemik, beyin,
+      yumuşak doku &mdash; ki BT'de birimler dünyadaki her tarayıcıda aynıdır."""
+
+[[howto]]
+title = "Yığını kaydırın."
+body = """
+ Görüntünün altındaki kaydırıcı kesitler
+      arasında ilerler; görüntüye bir kez tıkladıktan sonra ok tuşları da aynı
+      şeyi yapar. Çok kareli bir dosya &mdash; bir ultrason döngüsü, bir
+      anjiyogram &mdash; yanındaki düğmeyle oynar."""
+
+[[howto]]
+title = "Bir şey ölçün."
+body = """
+ Ölç kipine geçin ve bir çizgi sürükleyin.
+      Dosya piksellerinin birbirine ne kadar uzak olduğunu söylüyorsa cevap
+      milimetre cinsindendir ve kare olmayan pikselleri hesaba katar; dosya
+      söylemiyorsa cevap piksel cinsindendir ve bir ölçek uydurmak yerine bunu
+      söyler."""
+
+[[howto]]
+title = "Başlığı okuyun."
+body = """
+ Dosyadaki her öğe; numarası, standardın ona
+      verdiği ad ve taşıdığı değerle, aranabilir hâlde. Onun üstünde ise bu
+      dosyada hastayı neyin tanımladığının listesi &mdash; ki bu, addan çok daha
+      fazlasıdır."""
+
+[[howto]]
+title = "İhtiyacınız olanı alın."
+body = """
+ Ekrandaki kareyi, ayarladığınız pencereyle
+      ve üzerine hiçbir şey yakılmadan PNG olarak ya da başlığın tamamını düz
+      metin olarak. İkisi de sayfada, zaten orada olandan kurulur."""
+
+[[faq]]
+q = "Taramam herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        çözülür ve çizilir. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Ağ
+        bağlantısını kesin, yine de tarama açar.
+        <br><br>
+        Bu, bu sitenin başka hiçbir sayfasında olmadığı kadar burada değerlidir.
+        Bir DICOM dosyası başlığında hastanın adını, doğum tarihini ve hastane
+        numarasını taşır; yani birini bir görüntüleyiciye yüklemek, bir yabancıya
+        bir resim değil bir tıbbi kayıt vermek demektir."""
+
+[[faq]]
+q = "Hangi DICOM dosyalarını açabiliyor?"
+a = """
+        Üç temel aktarım söz diziminin herhangi birindeki sıkıştırılmamış
+        dosyalar &mdash; örtük ve açık little endian ve kullanımdan kaldırılmış
+        big endian &mdash; ayrıca deflated, RLE Lossless, baseline JPEG ve bir
+        hastane diskindeki BT ve MR çalışmalarının çoğunun sıkıştırıldığı
+        JPEG Lossless.
+        <br><br>
+        JPEG 2000, JPEG-LS ve video için kullanılan MPEG ile HEVC söz dizimlerini
+        çözemez. Bunlar megabaytlarca derlenmiş kitaplık eden kodlayıcılar
+        gerektirir ve istendiğinde böyle bir şey indiren bir sayfa, çevrimdışı
+        çalışan bir sayfa olmazdı. Bunlardan birindeki bir dosya yine de açılır:
+        başlığın tamamı okunup gösterilir ve resmin yerine, size hiçbir şey
+        söylemeyen bozuk görsel simgesi yerine kodlayıcının adını veren bir satır
+        gelir."""
+
+[[faq]]
+q = "&laquo;Pencere ve seviye&raquo; nedir, neden gerekiyor?"
+a = """
+        Bir BT kesiti yaklaşık dört bin farklı değer taşır, ekranınız ise iki yüz
+        elli altı gri gösterir. Pencere, o aralığın hangi diliminin bu grilerin
+        hepsini alacağının seçimidir: altındaki her şey siyah, üstündeki her şey
+        beyaz ve arada kalan grilere yayılır.
+        <br><br>
+        Aynı dosyanın iki ayarda başka bir tarama gibi görünmesinin ve akciğerle
+        kemiğin aynı anda görülememesinin sebebi budur. Bir BT'de sayılar
+        Hounsfield birimidir ve mutlak olarak tanımlıdır &mdash; su 0, hava
+        &minus;1000 &mdash; dolayısıyla bu sayfadaki adlandırılmış pencereler bir
+        radyoloğun iş istasyonunda kullandığı sayıların aynısıdır. Bir MR'da ya
+        da ultrasonda böyle bir ölçek yoktur ve açılan pencere, dosyanın kendi
+        istediği penceredir."""
+
+[[faq]]
+q = "Ölçümümün piksel cinsinden olduğunu neden söylüyor?"
+a = """
+        Çünkü o dosya bir pikselin ne kadar büyük olduğunu söylemiyor. Bunu
+        milimetre cinsinden taşıyan şey Pixel Spacing (0028,0030) etiketidir ve
+        pek çok ultrason görüntüsü, taranmış belge ve ikincil yakalama bunu
+        taşımaz.
+        <br><br>
+        Orada olduğu yerde ölçüm milimetre cinsindendir ve her eksen kendi
+        aralığıyla ölçülür; pikselleri kare olmayan görüntülerde önemli olan da
+        budur. Olmadığı yerde dürüst cevap bir piksel sayısıdır ve bu araç bir
+        ölçek seçip sonucu bir uzunluk gibi sunmak yerine bunu söyler."""
+
+[[faq]]
+q = "Klasörümü birkaç seri olarak açtı. Neden?"
+a = """
+        Çünkü içindeki bu. Bir çalışma serilerden oluşur &mdash; kılavuz görüntü,
+        sonra her çekim ya da yeniden yapılandırma &mdash; ve her dosya hangisine
+        ait olduğunu Series Instance UID (0020,000E) içinde söyler. Açılır liste,
+        genellikle hepsini tek bir ad listesinde karışık tutan klasörden değil
+        bundan kurulur.
+        <br><br>
+        Bir seri içinde kesitler, her birinin hastadaki konumuna göre sıralanır;
+        bu da Image Position ve Image Orientation'dan hesaplanır. Instance Number
+        bariz anahtardır ve ilk tercih değil yedektir: onu dosyaları yazan şey
+        atar ve hastanın uzandığı yönde ilerlemek zorunda değildir."""
+
+[[faq]]
+q = "&laquo;Hastayı ne tanımlıyor&raquo; listesi ne demek?"
+a = """
+        Dosyanızda, taramanın kimin olduğunu söyleyen ya da kim olabileceğini
+        daraltan her alan; makinenizde bu dosyadan okunmuş hâliyle. Liste, DICOM
+        standardının PS3.15 bölümünden gelir &mdash; bir veri kümesine
+        kimliksizleştirilmiş denebilmesi için nelerin gitmesi gerektiğini söyleyen
+        bölüm.
+        <br><br>
+        Orada olmasının sebebi şu: insanların yanıldığı şey bir taramada bir ad
+        bulunması değildir. Başka ne kadar çok şey bulunduğudur: doğum tarihi,
+        istem numarası, sevk eden hekim, kurum, tarayıcının seri numarası ve
+        dosyayı üreten arşive geri açılan mükemmel anahtarlar olan çalışma
+        UID'leri. Yalnızca adı silinmiş bir tarama anonim değildir.
+        <br><br>
+        Bu araç size yalnızca gösterir. Hiçbir şey yazmaz ve hiçbir şey
+        değiştirmez, dolayısıyla bunların hiçbirini çıkaramaz."""
+
+[[faq]]
+q = "Bir taramayı anonimleştirebilir mi?"
+a = """
+        Hayır ve bilinçli olarak öyleymiş gibi de yapmıyor. Bu sayfa okur; bir
+        DICOM dosyası yazan bir kodu yoktur. Yaptığı şey, sizinkinde tam olarak ne
+        olduğunu söylemektir; öğrenmesi zor olan ve insanların yanıldığı kısım da
+        odur.
+        <br><br>
+        Tanımlayıcıları çıkaran bir araç, çıtası çok daha yüksek ayrı bir iştir
+        &mdash; dosyayı piksellere dokunmadan yeniden yazması, UID'leri bütün bir
+        çalışma boyunca tutarlı biçimde değiştirmesi ve bazı tarayıcıların adın
+        ikinci bir kopyasını sakladığı özel öğeler konusunda haklı olması gerekir.
+        Bu sitenin yol haritasında yer alıyor; bir görüntüleyiciye
+        cıvatalanmıyor."""
+
+[[faq]]
+q = "Uzantısı .dcm olmayan ya da bozuk bir dosyayı açabilir mi?"
+a = """
+        İkisine de evet. Uzantıya bakılmaz: denetlenen şey dosyanın kendisidir.
+        Olağan 128 baytlık ön ek olmadan yazılmış bir veri kümesi &mdash; ağdan
+        doğrudan çekilmiş bir tarama böyle görünür &mdash; kodlaması ilk
+        öğesinden hesaplanarak okunur ve sayfa bunu yaptığını söyler.
+        <br><br>
+        Ortasında biten bir dosya, gittiği yere kadar okunur. Hasardan önceki her
+        şey gösterilir ve hangi baytta durduğunu söyleyen bir not düşülür. Bir
+        görüntüleyicinin en çok istendiği durum budur; bu yüzden son on iki baytı
+        yüzünden dosyanın tamamını çöpe atmak yanlış davranış olurdu."""
+
+[[faq]]
+q = "Bu bir tanı görüntüleyicisi mi?"
+a = """
+        Hayır. Tıbbi cihaz değildir, hiçbir düzenleyici değerlendirmeden
+        geçmemiştir ve buradaki hiçbir şey klinik bir karar vermek için
+        kullanılmamalıdır. Ekranınız kalibre değildir, tarayıcı doğrulanmış bir
+        çizim zinciri değildir ve bunların ikisi de bir web sayfasının içinden
+        düzeltilemez.
+        <br><br>
+        İyi olduğu şey, insanların bir taramayı açtığı diğer her şeydir: bir
+        diskte ne olduğuna bakmak, bir ders sunumu ya da bir makale için kesit
+        almak, bir başlık okumak, başka bir programın dosyayı neden reddettiğini
+        anlamak ve bir taramanın kimin olduğu hakkında ne taşıdığını görmek."""
+
+[[faq]]
+q = "Dosyamı değiştiriyor mu?"
+a = """
+        Hayır. Bu araç yalnızca okur. Çıktı dosyası, yeniden kodlama ya da DICOM
+        yazan bir düğme yoktur &mdash; indirebileceğiniz şey, ekrandaki karenin
+        bir PNG'si ve başlığın düz metin kopyasıdır. Orijinaliniz diskinizde el
+        değmemiş durur."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok. Kendi makinenizin
+        belleğinin ötesinde dosya boyutu ya da kaç dosya açtığınız konusunda bir
+        sınır da yok. Sitede reklam var, masrafı karşılayan da o; reklamlara
+        dosyanız hakkında hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: taramanızı çizilmek üzere uzağa gönderen bir
+        araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "DICOM (.dcm) taramalarını tarayıcıda açın: BT, MR, röntgen ve ultrason; pencere ve seviye, sıraya dizilmiş bütün bir seri, milimetre cinsinden ölçümler ve başlıktaki her etiketle. Hiçbir şey yüklenmez."
+features = [
+  "BT, MR, röntgen, ultrason, PET ve ikincil yakalama dosyalarını açar",
+  "Sürükleyerek, yazarak ya da adlandırılmış BT hazır ayarıyla pencere ve seviye",
+  "Bütün bir klasörü serilere ayırıp hastadaki konuma göre sıralar",
+  "Çok kareli dosyalar döngü olarak oynar",
+  "Kare olmayan pikselleri hesaba katarak milimetre cinsinden ölçer",
+  "İmlecin altındaki piksel değerini Hounsfield birimiyle okur",
+  "Her DICOM etiketi, adı ve değeriyle, aranabilir hâlde",
+  "Dosyada hastayı neyin tanımladığını PS3.15 profiline göre listeler",
+  "RLE, baseline JPEG ve JPEG Lossless'ı harici bir kitaplık olmadan çözer",
+  "Kareyi PNG, başlığı düz metin olarak kaydeder",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, dosyanızda değişiklik yok",
+]
+
+[picker]
+title = "Bir taramayı buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; tek bir .dcm dosyası ya da onlardan oluşan bütün bir klasör"

--- a/locales/tr/tools/document-scanner.html
+++ b/locales/tr/tools/document-scanner.html
@@ -1,0 +1,382 @@
+<!--
+  tools/document-scanner/body.html, in Turkish.
+
+  Every id, class, data-phrase key and {placeholder} below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+
+  page.count and page.counts are singular and plural in English; Turkish does
+  not put a plural suffix on a counted noun, so both carry the same bare form.
+-->
+<main>
+  <!-- Adım 1 &mdash; fotoğraflar -->
+  <section class="card">
+    <h2><span class="step">1</span> Fotoğrafları seçin</h2>
+
+    <p class="card-lede">
+      Her sayfa için bir fotoğraf, üstünden herhangi bir yerden çekilmiş.
+      Sayfanın tamamı kadrajda olmalı ve dört köşesi görünür ya da neredeyse
+      görünür olsun &mdash; geri kalan her şey, açı, gölge, üzerinde durduğu
+      masa, zaten bu aracın işi. Birkaç tane ekleyin, ekleme sıranızla tek bir
+      belgenin sayfaları olsunlar.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="strip-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="detect-all" class="ghost">Her sayfayı yeniden bul</button>
+        <button type="button" id="clear-all" class="ghost danger">Hepsini kaldır</button>
+      </div>
+    </div>
+
+    <ul id="page-strip" class="page-strip"></ul>
+  </section>
+
+  <!-- Adım 2 &mdash; köşeler -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Köşeleri sayfanın üzerine koyun</h2>
+
+    <p id="edit-empty" class="field-summary">
+      Bir fotoğraf seçin; burada, dört köşesi sizin için bulunmuş hâlde
+      görünsün.
+    </p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Fotoğrafın herhangi bir yerine basın, en yakın köşe parmağınıza gelsin;
+        onu sayfanın köşesine sürükleyin. <kbd>Tab</kbd> klavyeden bir köşeye
+        ulaşır, ok tuşları onu birer piksel, <kbd>Shift</kbd> ile onar piksel
+        oynatır. Burada hiçbir şey nihai değil &mdash; tarama, dört köşe nerede
+        biterse oradan alınır.
+      </p>
+
+      <!-- The photo is a canvas rather than an <img> because it is drawn at
+           screen size from the decoded picture, and because the same canvas is
+           what the corner finder reads. The outline over it is an SVG polygon
+           in percentages, so it needs no redraw when the window changes. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="photo"></canvas>
+        </div>
+      </div>
+
+      <p id="detect-note" class="hint-line" role="status" aria-live="polite"></p>
+
+      <div class="frame-actions">
+        <button type="button" id="detect-one" class="ghost">Köşeleri yeniden bul</button>
+        <button type="button" id="whole-photo" class="ghost">Fotoğrafın tamamını kullan</button>
+        <button type="button" id="turn-left" class="ghost">Sola döndür</button>
+        <button type="button" id="turn-right" class="ghost">Sağa döndür</button>
+        <button type="button" id="undo" class="ghost" disabled>Geri al</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; temizleme -->
+  <section class="card" id="clean-card">
+    <h2><span class="step">3</span> Temizleyin</h2>
+
+    <p id="clean-empty" class="field-summary">
+      Düzeltilecek bir fotoğraf olduğunda düzeltilmiş sayfa burada görünür.
+    </p>
+
+    <div id="clean-controls" hidden>
+      <p class="card-lede">
+        Aşağıdaki şey gerçek sonuçtur; dosyayı yazan aynı kod tarafından
+        üretilmiştir &mdash; düzeltilmiş ve eşitsiz ışığı bölünüp atılmış hâlde.
+        Siz seçerken ekran boyutunda çizilir; dosyanın kendisi fotoğrafın kendi
+        çözünürlüğünde yapılır.
+      </p>
+
+      <div class="result-wrap">
+        <canvas id="scan-preview" class="scan-preview"></canvas>
+        <p id="scan-busy" class="progress-label" role="status" aria-live="polite" hidden>
+          Düzeltiliyor&hellip;
+        </p>
+      </div>
+
+      <ul id="scan-facts" class="result-facts"></ul>
+
+      <fieldset class="options" id="mode-group">
+        <legend>Işıkla ve renkle ne yapılacak</legend>
+
+        <label class="check">
+          <input type="radio" name="mode" value="colour" checked>
+          <span>
+            <strong>Renkli, eşitlenmiş</strong>
+            <span class="check-note">
+              Kâğıt sayfa boyunca ölçülür ve bölünüp atılır; böylece gölge gider
+              ve kâğıt beyaza döner, bir mühür, mavi mürekkeple atılmış bir imza
+              ya da vurgulanmış bir satır ise rengini korur. Rengin belgenin bir
+              parçası olduğu durumda kullanılacak olan.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="grey">
+          <span>
+            <strong>Gri tonlama</strong>
+            <span class="check-note">
+              Aynı eşitleme, renksiz. Renkliden küçüktür ve bir fotoğrafa ya da
+              bir imzaya siyah beyazdan daha yumuşak davranır.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="mono">
+          <span>
+            <strong>Siyah beyaz</strong>
+            <span class="check-note">
+              Her piksel, sayfanın tamamı için tek bir sayıya göre değil kendi
+              çevresine göre karara bağlanır; gölge içindeki yazıyı okunur tutan
+              da budur. Bir taramayı küçük yapan şey budur: yirmi sayfalık bir
+              sözleşme bu yolla bir megabaytın altına iner, fotoğraf olarak ise
+              on beş civarına çıkar. Ara tonu yoktur, bu yüzden üzerinde
+              fotoğraf olan hiçbir şey bunu kullanmamalıdır.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="photo">
+          <span>
+            <strong>Olduğu gibi bırak</strong>
+            <span class="check-note">
+              Düzeltilmiş ve başka hiçbir şey yapılmamış. Kâğıdın kendisinin
+              önemli olduğu bir sayfa için &mdash; eski bir şey, renkli bir şey,
+              bir fotoğraf.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row" id="strength-row">
+          <label for="strength">Ne kadar sert uygulansın</label>
+          <div class="inline-pair">
+            <input type="range" id="strength" min="0" max="100" step="5" value="50">
+            <output id="strength-value">50</output>
+          </div>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <p class="hint-line">
+        Ayar her sayfaya uygulanır. Bir belgede farklı temizlenmiş sayfalar iki
+        belge gibi görünür.
+      </p>
+    </div>
+  </section>
+
+  <!-- Adım 4 &mdash; dosya -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Belgeyi kaydedin</h2>
+
+    <p class="card-lede">
+      PDF burada, bu sayfanın belleğinde, sayfa sayfa yazılır. Bu aracın öbür
+      ucunda bir maaş bordrosunun, bir pasaportun ya da bir sözleşmenin
+      gönderilebileceği bir sunucu yok ve olsaydı bile onu gönderecek bir kod
+      yok.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Sayfa boyutu</label>
+        <select id="page-size">
+          <option value="fit" selected>Yaprağı sayfanın kendisine uydur</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 inç</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 inç</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+        </select>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Baskı çözünürlüğü</label>
+        <select id="dpi">
+          <option value="150">150 DPI</option>
+          <option value="200" selected>200 DPI</option>
+          <option value="300">300 DPI &mdash; ofis tarayıcısı</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Belirli bir piksel sayısının ne kadar büyük bir yaprak sayılacağı.
+          Belgenin basıldığı boyutu değiştirir, taramanın tek bir pikselini
+          değiştirmez.
+        </p>
+      </div>
+
+      <div class="field" id="margin-field" hidden>
+        <label for="margin">Kenar boşluğu</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="50" step="1" value="10"
+                 aria-label="Milimetre cinsinden kenar boşluğu">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="max-side">En uzun kenar</label>
+        <select id="max-side">
+          <option value="1600">1600 piksel &mdash; küçük</option>
+          <option value="2400" selected>2400 piksel</option>
+          <option value="3500">3500 piksel</option>
+          <option value="0">Fotoğrafın izin verdiği kadar</option>
+        </select>
+        <p class="field-note">
+          Düzeltilmiş sayfa için bir tavan. Bir sayfanın fotoğrafı, sayfanın
+          hak ettiğinden çok daha fazla piksel taşır ve uzun kenarda 2400,
+          A4'te yaklaşık 200 DPI eder.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kalite</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="82">
+          <output id="quality-value">%82</output>
+        </div>
+        <p class="field-note">
+          JPEG olarak saklanan renkli ve gri tonlama kipleri için. Siyah beyaz
+          sayfalar tam olarak saklanır, dolayısıyla bu onlara bir şey yapmaz.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="title">Belge başlığı <span class="optional">(isteğe bağlı)</span></label>
+        <input type="text" id="title" maxlength="120" placeholder="Boş bırakılırsa PDF hiçbir başlık taşımaz">
+        <p class="field-note">
+          Sayfaların dışında belgeye yazılan tek şey. Tarih yok, yazar yok ve bu
+          makine hakkında hiçbir şey yok &mdash; <code>src/document.js</code>'e
+          bakın.
+        </p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save-pdf" class="primary big" disabled>PDF olarak kaydet</button>
+      <button type="button" id="save-images" class="ghost big" disabled>Sayfaları görsel olarak kaydet</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden></p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>Bitmiş dosya</h3>
+        <a id="download" class="primary as-button" href="#" download>İndir</a>
+      </div>
+      <ul id="result-facts" class="result-facts"></ul>
+      <p class="hint-line">
+        Göndermeden önce açın. Belgedeki şey, 3. adımda ekranda olanın sayfa
+        sayfa kendisidir.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Every sentence the JavaScript puts on this page. They live here rather than
+    in src/, because src/ is copied byte for byte into all eleven languages and
+    a sentence written there would be English in ten of them. See
+    shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="detect.found">Dört köşe bulundu. Onları denetleyin ve
+      yanlış düşenleri sürükleyin.</span>
+    <span data-phrase="detect.unsure">Sayfanın kenarları emin olunacak kadar net
+      değildi. Bu köşeler bir tahmin &mdash; devam etmeden önce onları sayfanın
+      üzerine sürükleyin.</span>
+    <span data-phrase="detect.nothing">Bu fotoğraftan bir sayfa seçilemedi, bu
+      yüzden köşeler fotoğrafın kenarlarında. Onları sayfanın üzerine
+      sürükleyin.</span>
+    <span data-phrase="detect.flat">Bu resimde bulunacak bir şey yok &mdash;
+      içinde hiç kenar yok.</span>
+    <span data-phrase="detect.tiny">Bu resim, içinde sayfa bulunamayacak kadar
+      küçük.</span>
+    <span data-phrase="detect.edited">Bu köşeler artık sizin. &laquo;Köşeleri
+      yeniden bul&raquo; fotoğrafı baştan ölçer.</span>
+
+    <span data-phrase="corner.tl">Sol üst köşe</span>
+    <span data-phrase="corner.tr">Sağ üst köşe</span>
+    <span data-phrase="corner.br">Sağ alt köşe</span>
+    <span data-phrase="corner.bl">Sol alt köşe</span>
+    <span data-phrase="corner.at">{corner}, soldan {x}, üstten {y}. Ok tuşları
+      onu oynatır, Shift ile birlikte onar piksel oynatır.</span>
+
+    <span data-phrase="page.select">{index}. sayfayı düzenle</span>
+    <span data-phrase="page.remove">{index}. sayfayı kaldır</span>
+    <span data-phrase="page.earlier">{index}. sayfayı öne al</span>
+    <span data-phrase="page.later">{index}. sayfayı arkaya al</span>
+    <span data-phrase="page.count">{count} sayfa</span>
+    <span data-phrase="page.counts">{count} sayfa</span>
+
+    <span data-phrase="paper.a">A4 ya da A5</span>
+    <span data-phrase="paper.letter">US Letter</span>
+    <span data-phrase="paper.legal">US Legal</span>
+    <span data-phrase="paper.card">bir kartvizit</span>
+    <span data-phrase="shape.known">Sayfa {ratio} çıktı ki bu {paper}
+      şeklidir.</span>
+    <span data-phrase="shape.sideways">Sayfa {ratio} çıktı ki bu, yan yatmış
+      {paper} şeklidir.</span>
+    <span data-phrase="shape.unknown">Sayfa {ratio} çıktı ki bu standart bir
+      yaprak değil.</span>
+
+    <span data-phrase="method.perspective">Şekil, fotoğraftaki perspektiften
+      hesaplandı; yani resimde göründüğü şekil değil, sayfanın kendi
+      şeklidir.</span>
+    <span data-phrase="method.edges">Fotoğraf tam karşıdan çekilmiş, bu yüzden
+      şekil doğrudan kenarlardan ölçüldü.</span>
+
+    <span data-phrase="quality.good">{width} çarpı {height} piksel; o boyutta bir
+      sayfada yaklaşık {dpi} DPI &mdash; basmaya yeter.</span>
+    <span data-phrase="quality.fair">{width} çarpı {height} piksel; o boyutta bir
+      sayfada yaklaşık {dpi} DPI. Ekranda iyi, kâğıtta biraz yumuşak.</span>
+    <span data-phrase="quality.low">{width} çarpı {height} piksel; o boyutta bir
+      sayfada yaklaşık {dpi} DPI. Bu basılacaksa fotoğrafı daha yakından
+      çekin.</span>
+    <span data-phrase="quality.pixels">{width} çarpı {height} piksel.</span>
+    <span data-phrase="coverage.note">Sayfa, fotoğrafın %{percent}'ini doldurdu.</span>
+    <span data-phrase="coverage.small">Sayfa, fotoğrafın yalnızca %{percent}'ini
+      doldurdu; yani fotoğraflananın çoğu masaydı. Bir dahakine daha
+      yakından.</span>
+
+    <span data-phrase="strength.gentle">Yumuşak: kâğıt eşitlenir ve pek bir şey
+      daha yapılmaz. Soluk kurşun kalemli ya da üzerinde fotoğraf olan bir sayfa
+      için.</span>
+    <span data-phrase="strength.middling">Olağan ayar: kâğıt beyaza, basılı metin
+      siyaha döner.</span>
+    <span data-phrase="strength.hard">Sert: gri olan her şey siyaha ya da beyaza
+      itilir. Düz basılı bir sayfada en temiz sonucu verir, üzerinde resim olan
+      her şeyde ise yıkıcıdır.</span>
+
+    <span data-phrase="busy.page">{total} sayfadan {done}. sayfa&hellip;</span>
+    <span data-phrase="busy.writing">Belge yazılıyor&hellip;</span>
+
+    <span data-phrase="result.pdf">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.images">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.mono">Piksel başına bir bit olarak saklandı ve tam
+      olarak sıkıştırıldı; bu kadar küçük olmasının sebebi bu.</span>
+    <span data-phrase="result.jpeg">Sayfalar, seçtiğiniz kalitede JPEG olarak
+      saklanıyor.</span>
+    <span data-phrase="result.png">Sayfalar PNG olarak saklanıyor; PNG kayıpsızdır
+      ve iki renkli bir resmin istediği de budur &mdash; JPEG hem daha büyük olur
+      hem de her harfin çevresini bulandırırdı.</span>
+    <span data-phrase="result.clean">Tarih yok, yazar yok, makine adı yok:
+      belgede sayfalar dışında olan tek şey bu aracın adı.</span>
+
+    <span data-phrase="size.fit">Her yaprak, yukarıdaki çözünürlükte kendi
+      sayfasının gerçek boyutu olur. Hiçbir şeye bant eklenmez.</span>
+    <span data-phrase="size.named">Her sayfa, hangi şekilde çıkmış olursa olsun,
+      kenar boşluğunun içinde bir {name} yaprağa konur.</span>
+
+    <span data-phrase="error.decode">Bu tarayıcı {name} dosyasını açamadı. Bir
+      iPhone'dan gelen HEIC fotoğrafıysa önce dönüştürün.</span>
+    <span data-phrase="error.none">Önce en az bir fotoğraf seçin.</span>
+    <span data-phrase="error.failed">Dosya yapılırken bir şeyler ters gitti:
+      {detail}</span>
+  </div>
+</main>

--- a/locales/tr/tools/document-scanner.toml
+++ b/locales/tr/tools/document-scanner.toml
@@ -1,0 +1,296 @@
+#
+# Belge Tarayıcı - Türkçe.
+#
+# Overrides for tools/document-scanner/tool.toml. Only words: the slug, the
+# category, the icon and the list of shared parts stay where they are.
+#
+# Zhang ve He özel adlar, dolayısıyla Latin harflerinde kalıyor; Sauvola da
+# öyle. Bunlar aranabilir referanslar, çevrilecek kelimeler değil.
+#
+
+name = "Belge Tarayıcı"
+heading = "Belge&nbsp;Tarayıcı <span class=\"h1-kw\">&mdash; bir sayfanın fotoğrafı, düzeltilmiş</span>"
+tagline = "Sayfayı fotoğraflayın. Taranmış görünen bir şey geri alın."
+
+title = "Belge Tarayıcı &mdash; Fotoğraftan PDF Taramaya, Yüklemesiz"
+description = "Bir sayfanın telefon fotoğrafını düzeltilmiş, eşit aydınlatılmış bir PDF'e çevirin. Köşeler sizin için bulunur, perspektif geri alınır, gölge bölünüp atılır. Tamamen tarayıcınızda çalışır: hiçbir şey yüklenmez."
+og_title = "Bir belgeyi fotoğrafla, yüklemeden tarayın"
+og_description = "Sayfanın köşeleri bulunur, açı geri alınır ve eşitsiz ışık bölünüp atılır; hepsi kendi tarayıcınızda. İnsanların bu şekilde fotoğrafladığı şey bir pasaport, bir maaş bordrosu ya da bir sözleşmedir; yani tam da yüklenmemesi gereken şey."
+og_image_alt = "Belge Tarayıcı - bir sayfanın fotoğrafı, yüklenmeden düzeltilmiş ve temizlenmiş"
+
+pledge = """
+    Fotoğraf kendi tarayıcınız tarafından çözülür, düzeltilir, temizlenir ve bir
+    PDF'e yazılır; kullanılan tek şey aritmetik ve tarayıcının zaten beraberinde
+    getirdiği kodlayıcılardır. Bu aracın hiçbir türde ağ özelliği yoktur
+    &mdash; getirecek bir şey yok, gönderecek bir şey yok &mdash; ve bunun
+    burada önemli olmasının sebebi, insanların hangi sayfaları fotoğrafladığıdır:
+    bir pasaport, bir maaş bordrosu, bir kira sözleşmesi, bir ofisin
+    &laquo;tarayıp geri gönderin&raquo; dediği bir form."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir sayfa tarayın. Tek bir istek bile bir fotoğraf, bir küçük
+      resim, bir dosya adı ya da tek bir köşenin konumunu taşımıyor. Ya da
+      internet bağlantısını kesip yine de bir tane tarayın."""
+
+read_first = """
+, köşelerin hiçbir model olmadan nasıl bulunduğu için
+      <code>src/detect.js</code>, düzeltme için <code>src/warp.js</code> ve
+      eşitsiz ışığın nasıl bölünüp atıldığı için <code>src/clean.js</code>."""
+
+howto_heading = "Telefon kameranızla bir belge nasıl taranır"
+
+card = """
+            Bir sayfanın fotoğrafı, düzeltilip temizlenerek belgeye çevrilmiş.
+            Köşeler sizin için bulunur, açı geri alınır ve gölge bölünüp
+            atılır."""
+
+[words]
+plural = "belgeleriniz"
+choose = "bir sayfa fotoğrafı"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Belgelerinizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Fotoğraflarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Model yok; yani indirilecek bir şey de sorulacak bir şey de yok."
+body = """
+ Bir
+      sayfanın dört köşesini bulmak aritmetikle yapılıyor: görüntünün gradyanı,
+      içindeki düz çizgiler için bir oylama ve kazanan dikdörtgenin her
+      kenarının altında gerçekte ne olduğunun denetlenmesi. Ağırlık yok, çıkarım
+      çalışma zamanı yok, ilk kullanımda getirilen bir şey yok ve başkasının
+      belgesinde sizinkinden farklı davranan bir şey yok &mdash;
+      <code>src/detect.js</code>'e bakın."""
+
+[[privacy]]
+title = "Belge tarih, yazar ya da makine adı taşımaz."
+body = """
+ Bir tarama, insanların
+      başka insanlara gönderdiği bir şeydir; genellikle bir ofis istediği için.
+      Sayfaların kendisi dışında PDF'e yazılan tek şey bu aracın adıdır, bir de
+      yazarsanız bir başlık. Oluşturulma tarihi yok, yazar yok, seri numarası yok
+      ve saatinizden, dosya adlarınızdan ya da bilgisayarınızdan türetilmiş
+      hiçbir şey yok &mdash; <code>src/document.js</code>'e bakın."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir yerde
+      <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. İş, <code>getImageData</code>, baytlar
+      üzerinde birkaç döngü ve tarayıcının kendi JPEG kodlayıcısı &mdash;
+      hepsi makinenizde zaten kurulu."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu &mdash; ve bir pasaport taramadan önce çalıştırmaya değen de bu."""
+
+[[howto]]
+title = "Sayfayı fotoğraflayın."
+body = """
+ Yukarıdan, sayfanın tamamı kadrajda ve
+      dört köşesi görünür ya da neredeyse görünür olacak şekilde. Tam karşıdan
+      olması gerekmez ve eşit aydınlatılmış olması gerekmez: açı ve gölge zaten
+      bu aracın işidir. Önemli olan kadrajı doldurmaktır &mdash; odanın öbür
+      ucundan fotoğraflanmış bir sayfada geri kazanılacak ayrıntı yoktur."""
+
+[[howto]]
+title = "Dört köşeyi denetleyin."
+body = """
+ Fotoğraf okunurken sizin için
+      bulunurlar ve emin olunmadığında sayfa bunu söyler &mdash; kâğıtla aynı
+      renkteki bir masanın üzerindeki bir sayfanın kenarını görmek gerçekten
+      zordur. Fotoğrafın herhangi bir yerine basın, en yakın köşe parmağınıza
+      gelsin; ya da <kbd>Tab</kbd> ile birine ulaşıp ok tuşlarıyla oynatın."""
+
+[[howto]]
+title = "Işıkla ne yapılacağını seçin."
+body = """
+ &laquo;Renkli, eşitlenmiş&raquo;,
+      kâğıdın kendi parlaklığını sayfa boyunca ölçer ve bölüp atar; böylece gölge
+      gider, bir mühür ya da bir imza rengini korur. &laquo;Siyah beyaz&raquo;
+      daha ileri gider ve bir taramayı e-postayla gönderilebilecek kadar küçük
+      yapan da odur. Ekranda gördüğünüz şey gerçek sonuçtur; dosyayı yazan aynı
+      kod tarafından üretilmiştir."""
+
+[[howto]]
+title = "Diğer sayfaları ekleyin."
+body = """
+ Eklediğiniz her fotoğraf, listelendikleri
+      sırayla aynı belgenin bir başka sayfası olur ve her biri kendi köşelerini
+      korur. Şeritteki bir sayfanın üzerindeki oklar onu öne ya da arkaya
+      alır."""
+
+[[howto]]
+title = "PDF'i kaydedin ve göndermeden önce açın."
+body = """
+ Belge burada, bu
+      sayfanın belleğinde yazılır. Onu yapmak için hiçbir şey yüklenmedi ve onun
+      hakkında hiçbir şey hiçbir yere bildirilmedi."""
+
+[[faq]]
+q = "Belgem herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Fotoğraf kendi donanımınızda, kendi tarayıcınız tarafından
+        çözülür, düzeltilir, temizlenir ve bir PDF'e yazılır. Bu aracın hiçbir
+        türde ağ özelliği yoktur &mdash; hiçbir zaman bir şey getirmez ve hiçbir
+        zaman bir şey göndermez &mdash; ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar; bunların hiçbiri bu siteye ait değildir. Sayfayı bir kez
+        yükleyin, internet bağlantısını kesin, yine de çalışır."""
+
+[[faq]]
+q = "Model olmadan sayfanın köşelerini nasıl buluyor?"
+a = """
+        Bir dikdörtgeni oluşturan dört uzun düz kenarı arayarak. Fotoğraf
+        küçültülür, gradyanı alınır &mdash; görüntünün nerede ve hangi yönde
+        değiştiği &mdash; ve bir kenarın üzerinde duran her piksel, üzerinde
+        yatacağı düz çizgi için oy verir. Güçlü çizgiler aday dikdörtgenlere
+        eşlenir ve her aday, dört kenarı gezilerek puanlanır: her kenarın ne
+        kadarının altında gerçekten bir kenar var ve bu dördü tek bir şeyin
+        sınırı mı? Bir sayfa etrafındakinden ya daha açıktır ya daha koyu, ama
+        dört kenarında da aynı yönde farklıdır; bir metin satırının sayfanın alt
+        kenarı sanılmasını engelleyen de budur. Ağırlık yoktur, hiçbir şey
+        indirilmez ve aritmetik, içinden geçen her belge için aynı
+        aritmetiktir."""
+
+[[faq]]
+q = "Bulduğu köşeler yanlış. Şimdi ne olacak?"
+a = """
+        Onları sürükleyin. Köşeler bir başlangıç konumudur, asla bir karar değil:
+        tarama, dördü nerede biterse oradan alınır. Fotoğrafın herhangi bir
+        yerine basın, en yakın köşe parmağınıza sıçrasın &mdash; bu, küçük bir
+        tutamağı tutturmaktan kolaydır &mdash; ve ok tuşları odaktaki köşeyi
+        birer piksel oynatır. Sayfa ayrıca köşelerin bir bulgu değil bir tahmin
+        olduğu durumu söyler ve o sayfayı şeritte işaretler &mdash; kendi rengine
+        yakın bir masanın üzerinde duran bir sayfa bunun olağan sebebidir, çünkü
+        orada bulunacak neredeyse hiç kenar yoktur."""
+
+[[faq]]
+q = "Düzeltilmiş sayfa neden doğru şekilde çıkıyor da ezik çıkmıyor?"
+a = """
+        Çünkü şekil kenarlardan ölçülmüyor, perspektiften geri kazanılıyor. Açıyla
+        fotoğraflanmış bir sayfanın uzak kenarı kısalmış olur; bu yüzden bariz
+        yöntem &mdash; en uzun karşılıklı kenar çiftini alıp orana bu demek
+        &mdash; gözle görülür biçimde bodur bir A4 üretir ki çoğu web tarayıcının
+        size verdiği de budur. Bir dikdörtgenin fotoğrafı, kameranın sıradan bir
+        kamera olduğu bilgisinden başka bir şey gerekmeden, hem dikdörtgenin en
+        boy oranını hem de kameranın odak uzaklığını geri kazanmaya yetecek
+        bilgiyi gerçekten taşır; bu, Zhang ve He'nin 2003 tarihli bir sonucudur
+        ve <code>src/geometry.js</code>'in yaptığı da budur. Fotoğrafın tam
+        karşıdan çekildiği yerde çalışılacak bir perspektif yoktur ve gerekmez
+        de, çünkü o zaman kenarlar zaten kesindir &mdash; öyle durumlarda onlara
+        döner ve sayfa hangisinin cevap verdiğini söyler."""
+
+[[faq]]
+q = "&laquo;Temizleme&raquo; görüntüye aslında ne yapıyor?"
+a = """
+        Işığı bölüp atıyor. Kâğıdın kendi parlaklığı sayfa boyunca ölçülür
+        &mdash; bir mozaik ızgarası ve her karede parlaklığın yüksek bir yüzdelik
+        değeri; metin bunu oynatamayacak kadar koyu ve seyrektir &mdash; ve her
+        piksel, o noktada tahmin edilen kâğıda bölünür. Geriye kalan şey, eşit
+        aydınlatılmış mürekkeptir; gölge ve kenarlardaki karartı gitmiştir. Bu,
+        kontrastı artırmakla aynı şey değildir: fotoğraflanmış bir sayfanın
+        kontrastını artırmak parlak kısmı beyaz, koyu kısmı siyah ve koyu
+        kısımdaki yazıyı okunamaz yapar; &laquo;otomatik seviyeler&raquo;in bu
+        resimleri iyileştirmek yerine bozmasının sebebi de budur."""
+
+[[faq]]
+q = "Siyah beyaz kip neden bu kadar küçük?"
+a = """
+        Çünkü iki renkli bir resim, on altı milyon renkli bir resmin verisinin
+        gerçekten küçük bir kesridir ve burada öyle saklanır: piksel başına bir
+        bit, sekizi bir bayta paketlenmiş ve tam olarak sıkıştırılmış &mdash;
+        siyah beyaz bir resmin JPEG'i olarak değil. Aynı sayfalarda renkli kipten
+        yaklaşık on sekiz kat küçük çıkar; yani yirmi sayfalık bir sözleşme on
+        beş civarı yerine bir megabaytın altına iner. Eşikleme Sauvola'nın
+        yöntemidir; her pikseli, sayfanın tamamı için tek bir sayıya göre değil,
+        kendi komşuluğunun ortalamasına ve yayılımına göre karara bağlar
+        &mdash; gölge içindeki yazıyı ayakta tutan da budur. Ara tonu yoktur, bu
+        yüzden üzerinde fotoğraf olan bir sayfa diğer kiplerden birini
+        kullanmalıdır."""
+
+[[faq]]
+q = "Bir PDF'e birkaç sayfa koyabilir miyim?"
+a = """
+        Evet. Eklediğiniz her fotoğraf, listelendikleri sırayla bir başka sayfa
+        olur ve her sayfa kendi köşelerini korur &mdash; yani arka arkaya
+        fotoğraflanmış bir sayfa yığını tek bir belgeye dönüşür. Şeritteki her
+        sayfanın üzerindeki oklar onu öne ya da arkaya alır. Temizleme ayarı
+        bilinçli olarak hepsi için ortaktır: bir belgede farklı temizlenmiş
+        sayfalar iki belge gibi görünür."""
+
+[[faq]]
+q = "Metni okuyor mu, PDF'te arama yapabilecek miyim?"
+a = """
+        Hayır. Metin katmanı ve karakter tanıma yok: çıkan şey, bir sayfa
+        üzerinde sayfanın resmidir. Bunu doğru dürüst yapmak bir OCR motoru
+        demektir ki bu da indirilecek onlarca megabayt model eder &mdash; ve
+        maaş bordronuzu okuyabilmek için önce bir model getiren bir belge
+        tarayıcı, maaş bordroları hakkında eve haber vermek için bir sebebi olan
+        bir belge tarayıcı olurdu. Metin gerekiyorsa siyah beyaz kip, kendi
+        makinenizdeki OCR yazılımının en iyi çalıştığı türden bir dosya
+        üretir."""
+
+[[faq]]
+q = "Bulanık çıktı. Neden?"
+a = """
+        Neredeyse her zaman sayfa fotoğrafta küçük olduğu için. Ön izlemenin
+        altındaki panel, sayfanın kadrajın ne kadarını doldurduğunu ve o
+        boyutta bir kâğıtta bunun kabaca inç başına kaç noktaya denk geldiğini
+        söyler &mdash; yaklaşık 150 DPI'ın altında basılmış bir tarama yumuşak
+        görünür ve hiçbir aracın, dosyada hiç olmamış bir ayrıntı için
+        yapabileceği bir şey yoktur. Yakınlaştırmak yerine yaklaşın, sabit tutun
+        ve düğmeye basmadan önce kameranın sayfaya odaklanmasını bekleyin.
+        Kamera sarsıntısı diğer sebeptir ve o da geri kazanılamaz."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, sayfa sınırı yok,
+        filigran yok. Fotoğrafların boyutunda da bir sınır yok, çünkü bunun
+        masrafını ödeyen bir sunucu yok &mdash; iş sizin kendi cihazınızda
+        oluyor. Sitede reklam var, masrafı karşılayan da o; reklamlara
+        belgeleriniz hakkında hiçbir şey verilmiyor."""
+
+[schema]
+description = "Bir belgeyi tarayıcıda tarayın: bir sayfa fotoğraflayın; dört köşe bulunur, perspektif geri alınır, eşitsiz ışık bölünüp atılır ve sonuç bir PDF'e yazılır. Birden fazla sayfa tek bir belge olur. Hiçbir şey yüklenmez."
+features = [
+  "Sayfanın dört köşesini model olmadan, hiçbir şey indirmeden ve getirmeden bulur",
+  "Sayfanın gerçek şeklini perspektiften geri kazanır; böylece açılı bir fotoğraf ezik çıkmaz",
+  "Kontrastı artırmak yerine eşitsiz ışığı ve gölgeyi bölüp atar",
+  "Siyah beyaz sayfaları piksel başına bir bit olarak saklar; bir taramayı e-postayla gönderilebilecek kadar küçük yapan da budur",
+  "Birkaç fotoğraf, her biri kendi köşeleriyle tek bir PDF'in sayfaları olur",
+  "Köşeler sürüklenebilir ya da klavyeden birer piksel oynatılabilir",
+  "Köşelerin bir bulgu değil bir tahmin olduğu durumu söyler",
+  "Belgeye tarih, yazar ve makine adı yazmaz",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Sayfalarınızın fotoğraflarını buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; sayfa başına bir fotoğraf, sayfa sırasıyla"

--- a/locales/tr/tools/edit-audio.html
+++ b/locales/tr/tools/edit-audio.html
@@ -1,0 +1,175 @@
+<!--
+  tools/edit-audio/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosya -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir dosya seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Dosya</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Boyut</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Ses</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>En yüksek an</dt><dd id="src-peak">&mdash;</dd></div>
+      <div><dt>Okunduğu hâl</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <div class="wave-wrap" id="src-wave-wrap" hidden>
+      <canvas id="src-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="preview" controls preload="metadata"></audio>
+    </div>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; düzenlemeler -->
+  <section class="card" id="edit-card" hidden>
+    <h2><span class="step">2</span> Değiştirin</h2>
+
+    <div class="edit-block">
+      <label class="check" for="reverse">
+        <input type="checkbox" id="reverse">
+        Geriye oynat
+      </label>
+      <p class="field-note">
+        Örnekler sondan başa yazılır. Onlarla ilgili başka hiçbir şey değişmez;
+        yani iki kez ters çevirmek, başladığınız dosyayı tam olarak geri verir.
+      </p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="speed">Hız</label>
+        <input type="text" id="speed-value" class="value-box" inputmode="decimal"
+               spellcheck="false" autocomplete="off" aria-label="Çarpan olarak hız">
+      </div>
+
+      <!-- The slider is in octaves, not multiples: half speed and double speed
+           are then the same distance either side of the middle, which is how
+           they sound. main.js does the conversion. -->
+      <input type="range" id="speed" min="-2" max="2" step="0.01" value="0"
+             aria-describedby="speed-note">
+
+      <div class="presets" role="group" aria-label="Hız hazır ayarları">
+        <button type="button" class="ghost" data-speed="0.5">0,5&times;</button>
+        <button type="button" class="ghost" data-speed="0.75">0,75&times;</button>
+        <button type="button" class="ghost" data-speed="1">1&times;</button>
+        <button type="button" class="ghost" data-speed="1.25">1,25&times;</button>
+        <button type="button" class="ghost" data-speed="1.5">1,5&times;</button>
+        <button type="button" class="ghost" data-speed="2">2&times;</button>
+      </div>
+
+      <fieldset class="modes">
+        <legend>Perdeye ne olacak</legend>
+        <label class="mode">
+          <input type="radio" name="pitch" value="keep" checked>
+          <span>
+            <strong>Perdeyi koru</strong>
+            Bir ses yine aynı ses gibi duyulur, yalnızca daha hızlı ya da daha yavaş.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="pitch" value="move">
+          <span>
+            <strong>Kaymasına izin ver</strong>
+            Hızlı tiz, yavaş pes; bir bandın yaptığı gibi.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="speed-note"></p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="volume">Ses seviyesi</label>
+        <input type="text" id="volume-value" class="value-box" inputmode="decimal"
+               spellcheck="false" aria-label="Desibel cinsinden seviye değişimi">
+      </div>
+
+      <input type="range" id="volume" min="-24" max="24" step="0.5" value="0"
+             aria-describedby="volume-note">
+
+      <fieldset class="modes">
+        <legend>Ne kadar yüksek olsun</legend>
+        <label class="mode">
+          <input type="radio" name="level" value="gain" checked>
+          <span>
+            <strong>Bu kadar</strong>
+            Her örnek aynı sayıyla çarpılır. Başka hiçbir şey değişmez.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="level" value="normalize">
+          <span>
+            <strong>Gidebildiği kadar yüksek</strong>
+            En yüksek an tavanın hemen altına oturana kadar yükseltilir.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="volume-note"></p>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Süre</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Hız</dt><dd id="sum-speed">&mdash;</dd></div>
+      <div><dt>En yüksek an</dt><dd id="sum-peak">&mdash;</dd></div>
+      <div><dt>Yaklaşık</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="clip-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 3 &mdash; çıkan dosya -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Kaydedin</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">Ne yazılsın</label>
+        <select id="depth">
+          <option value="16" selected>16 bit WAV &mdash; her yerde çalar</option>
+          <option value="32">32 bit kayan noktalı WAV &mdash; hiçbir şey kırpılmaz</option>
+        </select>
+        <p class="field-note" id="depth-note">
+          Bir WAV örnekleri oldukları gibi tutar; yani bir tane yazmak kaliteye
+          mal olamaz. Küçük bir dosya değildir: yukarıdaki tahmine bakın.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary">Sesi düzenle</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Sesi indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/edit-audio.toml
+++ b/locales/tr/tools/edit-audio.toml
@@ -1,0 +1,274 @@
+#
+# Ses Düzenleyici - Türkçe.
+#
+# Overrides for tools/edit-audio/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Ses Düzenleyici"
+heading = "Ses&nbsp;Düzenleyici <span class=\"h1-kw\">&mdash; bir parçayı ters çevirin, hızlandırın ya da yükseltin</span>"
+tagline = "Geriye oynatın, hızını değiştirin, sessiz bir kaydı yükseltin &mdash; hepsi burada, kendi makinenizde."
+
+title = "Sesi Ters Çevirme, Hız Değiştirme ve Ses Yükseltme &mdash; Ücretsiz, Yüklemesiz"
+description = "Bir parçayı geriye oynatın, hızlandırın ya da yavaşlatın ve sessiz bir kaydı daha yüksek yapın. Bir videonun sesini de çıkarır. Tarayıcınızda çalışır: hiçbir şey yüklenmez."
+og_title = "Ses Düzenleyici &mdash; hiçbir şey yüklemeden ters çevirin, yeniden zamanlayın, yükseltin"
+og_description = "Bir parçayı ters çevirin, perdeyi kaydırarak ya da kaydırmadan hızını değiştirin ve seviyeyi ayarlayın; sonra bir WAV indirin. Dosyayı kendi tarayıcınız okur ve yazar."
+og_image_alt = "Ses Düzenleyici - tarayıcınızda sesi ters çevirin, yeniden zamanlayın ve yükseltin"
+
+pledge = """
+    Dosyanız kendi tarayıcınız tarafından, kendi donanımınızda okunur,
+    düzenlenir ve yazılır. Buradaki hiçbir şey bir şey getiremez ya da
+    gönderemez &mdash; bu araçta hiçbir türde ağ özelliği yok &mdash; ve
+    olsaydı bile bu sayfanın öbür ucunda bir kaydın gönderilebileceği bir sunucu
+    yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir şeyi ters çevirin. Tek bir istek bile bir örnek, bir dosya
+      adı ya da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet
+      bağlantısını kesip yine de bir parça düzenleyin &mdash; sesinizi işlenmek
+      üzere uzağa gönderen bir araç öylece dururdu."""
+
+read_first = """
+, dosyanızı tarayıcının kendi çözücüsüne veren yirmi
+      satır için <code>src/decode.js</code>, zaman esneticisi için
+      <code>src/stretch.js</code>, yeniden örnekleyici için
+      <code>src/speed.js</code> ve örneklerin önüne giden başlık için
+      <code>src/wav.js</code>. Hiçbiri istek yapabilecek bir şeyi içeri
+      almaz."""
+
+howto_heading = "Bir ses dosyası nasıl düzenlenir"
+
+card = """
+            Bir parçayı ters çevirin, perdeyi kaydırarak ya da kaydırmadan
+            hızını değiştirin ve sessiz bir kaydı yukarı getirin. Bir videonun
+            sesini de çıkarır."""
+
+[words]
+plural = "kayıtlarınız"
+choose = "bir dosya"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Video girer, ses çıkar"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[privacy]]
+title = "Kayıtlarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyanızın toplanabileceği bir uç nokta burada yok,
+      olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araçta hiçbir türde ağ
+      özelliği yok: yapıştırılacak bir adres, indirilecek bir şey, ilk
+      kullanımda getirilen bir motor yok. Sesinize dokunan her bayt, sayfa
+      yüklenirken bu kaynaktan geldi."""
+
+[[privacy]]
+title = "Çözücü, tarayıcınızda zaten olan çözücü."
+body = """
+
+      Dosya <code>decodeAudioData</code>'ya verilir; bir parçayı bir
+      <code>&lt;audio&gt;</code> öğesinde çalan kodun aynısı. Biçiminizi okumak
+      için buraya hiçbir şey getirilmiyor ve onu okumak için bu sayfanın
+      dışındaki hiçbir şeyden bir şey istenmiyor."""
+
+[[privacy]]
+title = "Bir videonun görüntüsü hiç çözülmez."
+body = """
+ Bir video bıraktığınızda
+      yalnızca ses parçası istenir. Kareler okunmaz, çözülmez, çizilmez ve
+      onlara bakılmaz &mdash; bu sayfada bunu yapabilecek bir kod yok ve çıkan
+      dosya ses tutar, başka hiçbir şey tutmaz."""
+
+[[privacy]]
+title = "Örnekler yeniden kodlanmaz, olduğu gibi yazılır."
+body = """
+
+      Bir WAV, bu sayfanın hesapladığı örneklerin önüne bir başlık konmuş
+      hâlidir. Döngüde kaydınız hakkında karar veren bir kodlayıcı yok ve o
+      kararların alınabileceği, yükleme diye tarif edilebilecek bir şey de
+      yok."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine kaydınız hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir örnek, ne bir ad, bir boyut, bir uzunluk ya da ne kadar
+      yüksek olduğu. Okuyan, düzenleyen ve yazan her satır bu kaynaktan sunuluyor
+      ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de dosyanız
+      hakkında bir şey verilir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Bir dosya seçin."
+body = """
+ Seçiciye bir MP3, WAV, FLAC, M4A, Ogg ya
+      da Opus dosyası bırakın &mdash; istediğiniz şey içindeki sesse bir video da
+      olur. Tarayıcı onu doğrudan diskinizden okur; siz bunu yaparken hiçbir yere
+      hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Geldiğiniz iş buysa onu ters çevirin."
+body = """
+ Tek bir onay
+      kutusu. Örnekler sondan başa yazılır ki bu tam olarak geri alınabilir: iki
+      kez yapın, örnek örnek başladığınız dosyayı elde edersiniz."""
+
+[[howto]]
+title = "Hızı ayarlayın."
+body = """
+ Kaydırıcıyı sürükleyin, bir çarpan yazın ya da
+      hazır ayarlardan birine basın. Sonra perdeye ne olacağını seçin: olduğu
+      yerde tutun &mdash; 1,5&times; hızda bir ders için isteyeceğiniz budur
+      &mdash; ya da hızla birlikte kaymasına izin verin; bir bandın yaptığı ve
+      bir sesi tizleştirip pesleştiren de budur."""
+
+[[howto]]
+title = "Seviyeyi ayarlayın."
+body = """
+ Ya desibel cinsinden bir değişim
+      belirtin ya da kaydın, en yüksek anı tavanın hemen altına oturana kadar
+      yükseltilmesini isteyin. Sayfa, siz hiçbir şeye basmadan önce o anın nereye
+      düşeceğini söyler ve seçtiğiniz ayar onu tam ölçeğin ötesine iterse sizi
+      uyarır."""
+
+[[howto]]
+title = "Kaydedin."
+body = """
+ İş kendi donanımınızda olduğu için ne kadar süreceği
+      bir sıraya değil makinenize bağlıdır. Çıkan şey bir WAV'dir &mdash;
+      örneklerin kendisi, önlerinde bir başlıkla &mdash; önce sayfada çalınır,
+      sonra doğrudan tarayıcınızın indirmelerine verilir."""
+
+[[faq]]
+q = "Sesim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        düzenlenir ve yazılır. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Size
+        söylenene güvenmek yerine denetlemeyi tercih ediyorsanız internet
+        bağlantısını kesin ve yine de bir parçayı ters çevirin."""
+
+[[faq]]
+q = "Bir videonun sesini alabilir miyim?"
+a = """
+        Evet ve bu, burada bir MP3 açmakla aynı iştir. Bir MP4, MOV ya da WebM
+        bırakın; yalnızca ses parçası çözülür: görüntü hiç okunmaz ve çıkan şey
+        içinde video olmayan bir ses dosyasıdır. Bu aynı zamanda bir klibin
+        sesini hiç düzenlemeden kaydetmenin de yoludur &mdash; her ayarı olduğu
+        gibi bırakın ve düğmeye basın."""
+
+[[faq]]
+q = "Hızı değiştirmek perdeyi değiştirir mi?"
+a = """
+        Yalnızca siz isterseniz. "Perdeyi koru", kaydı yaklaşık elli
+        milisaniyelik örtüşen pencerelere böler ve onları birbirine daha yakın ya
+        da daha uzak yeniden yerleştirir; her konumu, dalgalar kesiştikleri yerde
+        hizalanacak şekilde seçer &mdash; bir ses 1,5&times; hızda aynı ses
+        kalır. "Kaymasına izin ver" ise yeniden örnekler; bir bandı daha hızlı
+        çalmanın yaptığı budur: iki kat hız tam olarak bir oktav tizdir."""
+
+[[faq]]
+q = "Neden MP3 yerine WAV kaydediyor?"
+a = """
+        Çünkü hiçbir tarayıcı MP3 kodlayıcısı getirmez ve bu araç kaydınızı böyle
+        bir kodlayıcısı olan bir sunucuya göndermeyi reddeder. Bir WAV hiçbir
+        kodlayıcı gerektirmez &mdash; önüne kırk dört baytlık bir başlık konmuş
+        örneklerdir &mdash; yani hem dürüst seçenektir hem de kaliteye mal
+        olamayacak tek seçenektir. Daha büyüktür: stereoda dakikada yaklaşık on
+        megabayt. Her oynatıcı, telefon ve düzenleyici bir tanesini açar ve MP3
+        isteyen her şey ondan bir tane yapabilir."""
+
+[[faq]]
+q = "Hangi biçimleri açabilirim?"
+a = """
+        Tarayıcınızın çözdüğü her şeyi; pratikte bu MP3, WAV, FLAC, M4A ve AAC,
+        Ogg Vorbis ve Opus ile MP4, M4V, MOV ve WebM videoların içindeki ses
+        demektir. Dışarıda kalan, her yerdekiyle aynı kısa listedir: AVI, WMA ve
+        çoğu MKV. Bu tarayıcının okumayacağı bir dosya, yarı yolda başarısız
+        olmak yerine bunu söyleyen bir mesajla geri çevrilir."""
+
+[[faq]]
+q = "Daha yüksek yapmak sesi bozar mı?"
+a = """
+        Yalnızca tam ölçeğin ötesine geçerseniz ve sayfa siz geçmeden önce bunu
+        söyler. Dijital sesin sert bir tavanı vardır: bir örnek tam ölçekten daha
+        yüksek olamaz, dolayısıyla üstündeki her şey tavana yassılanır ve
+        bozulmanın sesi de budur. "Gidebildiği kadar yüksek", bunu yapamayan
+        ayardır &mdash; kaydın ne kadar yeri kaldığını hesaplar ve tam olarak o
+        kadarını kullanır. Tavanın altındaki her şey yalnızca çarpmadır: 6 dB
+        yükseltin, 6 dB indirin, örnekler başladıkları yerdedir."""
+
+[[faq]]
+q = "Ters çevirmek ya da yeniden zamanlamak kalite kaybettirir mi?"
+a = """
+        Ters çevirmek kaybettirmez: aynı örnekler öbür sırayla çıkar ve bu tamdır.
+        Hızı değiştirmek ise her örneği oynatır, yani bir kopyalama değil bir
+        hesaptır &mdash; yeniden örnekleyici yol boyunca düzgün filtreler, böylece
+        hızlandırmak yüksek notaları metalik bir çınlama olarak geri katlamaz ve
+        esneticinin pencereleri, hesabın denk getirdiği yere değil dalgaların
+        hizalandığı yere konur. İki yol da hiçbir şeyi yeniden kodlamaz, çünkü
+        burada yeniden kodlayacak bir kodlayıcı yok."""
+
+[[faq]]
+q = "Dosyanın uzunluğunda bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok. Pratik tavan bellek: kaydın tamamı bu
+        sayfaya bir seferde çözülür ve indirmeden önce bellekte bir WAV kurulur;
+        yani bir saatlik stereo, çalışmak için bir gigabaytın biraz altında yer
+        ister. Dört gigabaytlık bir WAV doğrudan reddedilir, çünkü biçimin kendi
+        boyut alanı böyle bir dosyayı tarif edemez."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara kaydınız hakkında hiçbir
+        şey verilmiyor."""
+
+[schema]
+browser_requirements = "JavaScript ve Web Audio destekleyen bir tarayıcı gerekir; bu da her güncel tarayıcı demektir. Dosyayı çalmak için tarayıcıda zaten olanın ötesinde bir kodlayıcı desteği gerekmez."
+description = "Bir ses parçasını tarayıcıda ters çevirin, perdeyi kaydırarak ya da kaydırmadan hızını değiştirin ve seviyesini ayarlayın. Bir videonun içindeki sesle de çalışır. Hiçbir şey yüklenmez ve sonuç WAV olarak yazılır, yani hiçbir şey yeniden kodlanmaz."
+features = [
+  "Bir parçayı tam olarak geriye oynatır",
+  "Hızı çeyrek kattan dört kata kadar değiştirir; perdeyi koruyarak ya da kaydırarak",
+  "Seviyeyi yükseltir ya da düşürür, ya da tam ölçeğin hemen altına normalleştirir",
+  "Bir MP4, MOV ya da WebM içindeki sesi, görüntüye dokunmadan çıkarır",
+  "Döngüde hiçbir kodlayıcı olmadan 16 bit ya da 32 bit kayan noktalı WAV yazar",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir ses dosyasını ya da videoyu buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; MP3, WAV, FLAC, M4A, Ogg ve MP4, MOV ya da WebM içindeki ses"

--- a/locales/tr/tools/exif-editor.html
+++ b/locales/tr/tools/exif-editor.html
@@ -1,0 +1,156 @@
+<!--
+  tools/exif-editor/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosyalar -->
+  <section class="card">
+    <h2><span class="step">1</span> Fotoğrafları seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Hepsini listeden çıkar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; tek tıklama -->
+  <section class="card" id="strip-card">
+    <h2><span class="step">2</span> Her şeyi silin</h2>
+
+    <p class="card-lede">
+      Tek düğme, listedeki her fotoğraf. Resim çözülmez, yeniden çizilmez ya da
+      yeniden sıkıştırılmaz &mdash; sıkıştırılmış görüntü verisi el değmeden
+      kopyalanır ve yalnızca etrafındaki üst veri atılır; yani sonuç, hiçbir şey
+      iliştirilmemiş aynı fotoğraftır.
+    </p>
+
+    <div class="strip-row">
+      <button type="button" id="strip-all" class="primary big" disabled>Tüm üst veriyi sil</button>
+      <span id="strip-status" class="strip-status" role="status" aria-live="polite"></span>
+    </div>
+
+    <!--
+      Two things are kept by default, and both are stated on the button's own
+      line rather than buried in a settings panel. "Remove all" that quietly
+      keeps things is a broken promise; "remove all except these two, and here
+      they are" is a choice.
+    -->
+    <fieldset class="keep-options">
+      <legend>Neler korunsun</legend>
+      <label class="check">
+        <input type="checkbox" id="keep-orientation" checked>
+        <span>
+          <strong>Yön etiketi</strong>
+          <span class="check-note">
+            Telefonlar bir fotoğrafı mercekten göründüğü gibi saklar ve hangi
+            tarafının üst olduğunu söyleyen tek bir etiket ekler. Onu silin, bazı
+            görüntüleyiciler fotoğrafı yan gösterir. Korunduğunda, yalnızca bu
+            etiketi içeren yeni bir EXIF bloğu yazılır &mdash; ve yalnızca
+            fotoğraf zaten doğru durmuyorsa.
+          </span>
+        </span>
+      </label>
+      <label class="check">
+        <input type="checkbox" id="keep-icc" checked>
+        <span>
+          <strong>Renk profili</strong>
+          <span class="check-note">
+            ICC profili, resimdeki sayıların renk olarak ne anlama geldiğini
+            söyler. Sizin hakkınızda hiçbir şey söylemez. Onu atmak, geniş
+            renk gamlı bir fotoğrafın renklerini gözle görülür biçimde
+            kaydırabilir; siz aksini söylemedikçe korunmasının sebebi de budur.
+          </span>
+        </span>
+      </label>
+      <p class="keep-summary" id="keep-summary"></p>
+    </fieldset>
+
+    <div id="clean-results" class="results" hidden>
+      <div class="results-head">
+        <h3>Temizlendi</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Hepsini zip olarak indir</button>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; okuma ve düzenleme -->
+  <section class="card" id="inspect-card">
+    <h2><span class="step">3</span> İçine bakın ve istediğinizi değiştirin</h2>
+
+    <p id="inspect-empty" class="empty-note">
+      Yukarıdan bir fotoğraf seçin; içindeki her şey burada görünsün: nerede
+      olduğunuz, ne zaman ve neyle çekildiği hakkında ne söylediği. Bunu
+      anlamak için hiçbir yere hiçbir şey gönderilmez.
+    </p>
+
+    <div id="inspector" hidden>
+      <div class="inspect-head">
+        <div class="inspect-file">
+          <img id="inspect-thumb" class="inspect-thumb" alt="" hidden>
+          <div>
+            <p class="inspect-name" id="inspect-name"></p>
+            <p class="inspect-sub" id="inspect-sub"></p>
+          </div>
+        </div>
+        <div class="inspect-switch">
+          <label for="inspect-select" class="visually-hidden">Hangi fotoğraf incelensin</label>
+          <select id="inspect-select"></select>
+        </div>
+      </div>
+
+      <!-- The findings: the part of this page that answers the actual question. -->
+      <section class="findings" aria-labelledby="findings-h">
+        <h3 id="findings-h">Bu dosya neyi ele veriyor</h3>
+        <ul id="findings-list" class="findings-list"></ul>
+      </section>
+
+      <!-- Whole blocks, each removable on its own. -->
+      <section class="blocks" aria-labelledby="blocks-h">
+        <h3 id="blocks-h">Bu dosyadaki bloklar</h3>
+        <ul id="block-list" class="block-list"></ul>
+      </section>
+
+      <!-- Every tag, editable. -->
+      <section class="tags" aria-labelledby="tags-h">
+        <h3 id="tags-h">Her etiket</h3>
+        <p class="tags-note" id="tags-note"></p>
+        <div id="tag-groups"></div>
+
+        <details class="add-tag" id="add-tag">
+          <summary>Etiket ekle</summary>
+          <div class="add-tag-body">
+            <label for="add-tag-select">Etiket</label>
+            <select id="add-tag-select"></select>
+            <label for="add-tag-value">Değer</label>
+            <input type="text" id="add-tag-value" spellcheck="false">
+            <button type="button" id="add-tag-go" class="ghost">Ekle</button>
+          </div>
+        </details>
+      </section>
+
+      <div class="save-row">
+        <button type="button" id="save-edits" class="primary" data-download disabled>Bu fotoğrafı kaydet</button>
+        <button type="button" id="revert-edits" class="ghost" disabled>Değişikliklerimi geri al</button>
+        <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
+      </div>
+      <p id="edit-error" class="error" role="alert" hidden></p>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/exif-editor.toml
+++ b/locales/tr/tools/exif-editor.toml
@@ -1,0 +1,240 @@
+#
+# EXIF Görüntüleyici ve Silici - Türkçe.
+#
+# Overrides for tools/exif-editor/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# EXIF, XMP, IPTC ve etiket adları (Orientation) Latin harflerinde kalıyor:
+# bunlar dosyanın içinde harfi harfine böyle yazar ve okuyucu onları başka
+# programlarda da böyle görür.
+#
+
+name = "EXIF Görüntüleyici ve Silici"
+heading = "EXIF&nbsp;Görüntüleyici ve Silici <span class=\"h1-kw\">&mdash; fotoğraf üst verisini silin</span>"
+tagline = "Bir fotoğrafın sizin hakkınızda ne söylediğini görün. Sonra onu çıkarın."
+
+title = "EXIF Görüntüleyici ve Silici &mdash; Ücretsiz Fotoğraf Üst Verisi Düzenleyici"
+description = "Bir fotoğrafta saklı EXIF ve GPS verisini görün, düzenleyin ya da tek tıklamayla hepsini silin. Tarayıcınızda: hiçbir şey yüklenmez ve fotoğraf hiçbir zaman yeniden kodlanmaz."
+og_title = "EXIF Görüntüleyici ve Silici &mdash; görün, düzenleyin ya da silin"
+og_description = "Bir fotoğrafta saklı üst veriyi okuyun ve tek tıklamayla hepsini silin. Kendi makinenizde çalışır; resmin kendisi hiçbir zaman yeniden kodlanmaz."
+og_image_alt = "EXIF Görüntüleyici ve Silici - bir fotoğraftaki üst veriyi okuyun, düzenleyin ya da silin"
+
+pledge = """
+    Dosya kendi tarayıcınız tarafından açılır, ayrıştırılır ve yeniden yazılır.
+    Bu aracın hiçbir türde ağ özelliği yoktur &mdash; getirecek bir şey yok,
+    gönderecek bir şey yok &mdash; ve olsaydı bile bu sayfanın öbür ucunda bir
+    fotoğrafın gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir fotoğrafı temizleyin. Tek bir istek bile bir görsel, bir
+      küçük resim, bir dosya adı ya da dosyanızdan okuduğumuz bir etiket
+      taşımıyor. Ya da internet bağlantısını kesip yine de bir tanesini
+      temizleyin."""
+
+read_first = """
+, EXIF ayrıştırıcısı için <code>src/tiff.js</code> ve
+      resmin kendisinin yalnızca kopyalandığının kanıtı için
+      <code>src/jpeg.js</code>."""
+
+howto_heading = "Bir fotoğraftan EXIF verisi nasıl silinir"
+
+card = """
+            Bir fotoğrafta saklı konumu, kamerayı ve seri numaralarını görün,
+            herhangi birini düzenleyin ya da tek tıklamayla hepsini silin."""
+
+[words]
+plural = "fotoğraflar"
+choose = "bir fotoğraf"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Resmi asla yeniden kodlamaz"
+
+[[privacy]]
+title = "Fotoğraflarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu kutudaki diğer araçların
+      aksine bunun bir "web adresinden yükle" özelliği ve hiçbir isteğe bağlı ağ
+      adımı yok. <code>src/</code> içinde hiçbir yerde <code>fetch</code>,
+      <code>XMLHttpRequest</code> ya da <code>sendBeacon</code> yok."""
+
+[[privacy]]
+title = "Okuduğumuz üst veri hiçbir zaman birine okunmaz."
+body = """
+ GPS konumunuz bu
+      sayfada gösterilir ve başka hiçbir yere gitmez. Bu depoda bir etiket, bir
+      dosya adı, bir boyut ya da bir sayı taşıyan özel bir analitik olayı
+      yoktur."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine fotoğraflarınız hakkında bir şey verilmiyor.
+      Bir dosyayı okuyan, ayrıştıran ya da yeniden yazan her satır bu kaynaktan
+      sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de dosyalarınız
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "Fotoğraflarınızı seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin.
+      Tarayıcı onları doğrudan diskinizden okur; siz bunu yaparken hiçbir yere
+      hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "İsterseniz içlerinde ne olduğunu okuyun."
+body = """
+ Bulgular listesi, her
+      etiketin tam tablosundan önce bilinmeye değer şeyleri adıyla anar &mdash;
+      GPS konumu, zaman damgaları, seri numaraları."""
+
+[[howto]]
+title = "\"Tüm üst veriyi sil\"e basın."
+body = """
+ Çoğu kişi için işin tamamı
+      budur. Her etiket, XMP ve IPTC blokları, yorumlar ve gömülü küçük resim;
+      listedeki her fotoğrafta hepsi birden gider."""
+
+[[howto]]
+title = "Ya da silmek yerine düzenleyin."
+body = """
+ Bir tarihi değiştirin, bir
+      telif satırını düzeltin, konumu atıp kamera ayarlarını koruyun &mdash;
+      sonra o fotoğrafı tek başına kaydedin."""
+
+[[faq]]
+q = "Fotoğrafım herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        ayrıştırılır ve yeniden yazılır. Bu aracın hiçbir türde ağ özelliği
+        yoktur &mdash; hiçbir zaman bir şey getirmez ve hiçbir zaman bir şey
+        göndermez &mdash; ve sayfanın <code>Content-Security-Policy</code>'si
+        iletişim kurabileceği her adresi tek tek sayar; bunların hiçbiri bu
+        siteye ait değildir."""
+
+[[faq]]
+q = "EXIF nedir ve bir fotoğrafta başka ne saklanır?"
+a = """
+        EXIF, bir kameranın resmin yanına yazdığı bir etiket bloğudur: marka ve
+        model, pozlama ayarları, saniyesine kadar tarih ve saat, çoğu zaman bir
+        GPS konumu ve bazen bir seri numarası. Fotoğraflar sık sık bunun ötesinde
+        de bir şeyler taşır &mdash; bir düzenleyiciden gelen XML'den oluşan bir
+        XMP paketi, açıklama ve künye alanlarından oluşan bir IPTC bloğu, bir
+        renk profili, görüntünün küçük ikinci bir kopyası olan bir küçük resim ve
+        belgelenmemiş üretici verisinden oluşan bir üretici notu. Bu araç
+        hepsini listeler."""
+
+[[faq]]
+q = "Üst veriyi silmek görüntü kalitesini düşürür mü?"
+a = """
+        Hayır ve fotoğrafı yeniden kaydetmek yerine böyle bir araç kullanmanın
+        başlıca sebebi budur. Üst veri, sıkıştırılmış resmin içinde değil
+        etrafındaki kapta durur. Onu silmek, bir listeden öğe silip listeyi
+        yeniden yazmak demektir; sıkıştırılmış görüntü verisi bayt bayt kopyalanır,
+        yani sonuç tam olarak aynı piksellere çözülür. Hiçbir şey çözülmez ve
+        hiçbir şey yeniden sıkıştırılmaz."""
+
+[[faq]]
+q = "Hangi dosya biçimlerini işliyor?"
+a = """
+        JPEG, PNG ve WebP. HEIC ve AVIF tanınır ama yeniden yazılmaz: iç içe
+        geçmiş atomlardan kurulmuş kap biçimleridir ve farklı bir ayrıştırıcı
+        gerektirirler; bu yüzden araç, bozuk bir dosya üretmek yerine bunu söyler.
+        Çıplak bir TIFF de işlenmez, çünkü bir TIFF'te üst veri ile pikseller aynı
+        ofsetlerle adreslenir."""
+
+[[faq]]
+q = "Üst veri silindikten sonra fotoğrafım döndürülmüş görünür mü?"
+a = """
+        Görünebilir ve bunun için bir ayar var. Telefonlar genellikle resmi
+        mercekten göründüğü gibi kaydeder ve nasıl döndürüleceğini söyleyen bir
+        Orientation etiketi ekler. O etiketi silin, bazı görüntüleyiciler
+        fotoğrafı yan gösterir. Varsayılan olarak açık olan "yön etiketini koru"
+        seçeneği, yalnızca o tek etiketi içeren ufacık bir EXIF bloğunu geri
+        yazar &mdash; ve yalnızca fotoğrafın gerçekten ihtiyacı olduğunda.
+        Dosyanın hiç EXIF taşımamasını tercih ediyorsanız kapatın."""
+
+[[faq]]
+q = "GPS konumunu siliyor mu?"
+a = """
+        Evet. Her şeyi silmek GPS dizininin tamamını siler; ayrıca konumu tek
+        başına silip gerisini de koruyabilirsiniz. Konum önce ondalık derece
+        olarak gösterilir; çünkü "51 derece, 30 dakika, 26 saniye", bir fotoğrafın
+        çekildiği binayı adlandırdığını bariz hâle getirmez."""
+
+[[faq]]
+q = "Bir etiketi silmek yerine değiştirebilir miyim?"
+a = """
+        Evet. Metin etiketleri, tarihler, ISO, yön ve çözünürlük düzenlenebilir ve
+        hiç etiketi olmayan bir fotoğrafa birkaç yaygın etiket eklenebilir. Bir
+        tek uyarı: dosyayı yazmak EXIF bloğunu yeniden kurar ve bir üretici notu
+        orijinal bloğa ofsetler içerir; dolayısıyla yeniden kurulmuş bir üretici
+        notu, sonrasında üreticinin kendi yazılımı tarafından okunamayabilir. Bu
+        sizin için önemliyse onu silin ya da dosyayı düzenlemeden bırakın."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok. Sitede reklam var,
+        masrafı karşılayan da o; reklamlara fotoğraflarınız hakkında hiçbir şey
+        verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: fotoğraflarınızı işlenmek üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir fotoğrafın içindeki EXIF, GPS, XMP ve IPTC üst verisini okuyun, tek tek etiketleri düzenleyin ya da tek tıklamayla hepsini silin. JPEG, PNG ve WebP; görüntü yeniden kodlanmadan tarayıcıda işlenir."
+features = [
+  "GPS konumu, kamera seri numaraları ve üretici notları dahil her EXIF etiketini gösterir",
+  "Tek tek etiketleri düzenler ya da siler ve dosyayı geri yazar",
+  "EXIF, GPS, XMP, IPTC, yorumlar ve gömülü küçük resmi tek tıklamayla siler",
+  "JPEG, PNG ve WebP",
+  "Yalnızca kabı yeniden yazar, böylece görüntü hiçbir zaman yeniden sıkıştırılmaz",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Fotoğrafları buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; JPEG, PNG ve WebP"

--- a/locales/tr/tools/gif-analyzer.html
+++ b/locales/tr/tools/gif-analyzer.html
@@ -1,0 +1,161 @@
+<!--
+  tools/gif-analyzer/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!--
+    One numbered step, and then six headings without numbers.
+
+    Every other tool on this site numbers all of its cards, because every card
+    is something the visitor does. Here there is exactly one thing to do -
+    choose a file - and everything below it is the answer. Numbering the answer
+    would promise a sequence of decisions that does not exist, and would leave
+    somebody looking for step 4's button.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir GIF seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- The summary, and the animation as the browser itself draws it. -->
+  <section class="card" id="summary-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="copy-report" class="ghost">Raporu kopyala</button>
+        <button type="button" id="download-report" class="ghost">İndir</button>
+      </div>
+    </div>
+
+    <div class="overview">
+      <div class="preview-wrap">
+        <!--
+          The browser's own decoder, drawing the file unchanged. Everything else
+          on this page is drawn by src/frames.js, so having both means a
+          disagreement between them is visible rather than hidden - and it is
+          the disagreement that would tell you this reader had a bug.
+        -->
+        <img id="preview" class="preview" alt="Animasyon, bu tarayıcının çizdiği hâliyle oynuyor">
+        <p class="preview-note">Tarayıcınızın kendi çözücüsü, dosyayı olduğu gibi oynatıyor.</p>
+      </div>
+
+      <dl class="facts">
+        <div><dt>Sürüm</dt><dd id="fact-version">&mdash;</dd></div>
+        <div><dt>Tuval</dt><dd id="fact-canvas">&mdash;</dd></div>
+        <div><dt>Dosya boyutu</dt><dd id="fact-size">&mdash;</dd></div>
+        <div><dt>Kareler</dt><dd id="fact-frames">&mdash;</dd></div>
+        <div><dt>Yazıldığı hâliyle</dt><dd id="fact-written">&mdash;</dd></div>
+        <div><dt>Oynadığı hâliyle</dt><dd id="fact-plays">&mdash;</dd></div>
+        <div><dt>Döngü</dt><dd id="fact-loops">&mdash;</dd></div>
+        <div><dt>Çizilen renkler</dt><dd id="fact-colors">&mdash;</dd></div>
+      </dl>
+    </div>
+
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- The readings. First, because it is what somebody came for. -->
+  <section class="card" id="findings-card" hidden>
+    <h2>Göze çarpanlar</h2>
+    <p class="card-lede">
+      Aşağıdaki her şey bu dosyadan ölçülmüştür. Hiçbiri neyi yapmak
+      istediğinize dair bir tahmin değildir.
+    </p>
+    <ul class="findings" id="findings"></ul>
+  </section>
+
+  <!-- The byte budget. -->
+  <section class="card" id="budget-card" hidden>
+    <h2>Baytlar nereye gitti</h2>
+    <p class="card-lede">
+      Dosyanın her baytı tam olarak bir satırdadır ve satırların toplamı
+      dosyayı verir. Vermeseydi, çubuk sessizce uzayıp sığdırmak yerine son
+      satır bunu söylerdi.
+    </p>
+
+    <div class="budget-bar" id="budget-bar" role="img" aria-labelledby="budget-caption"></div>
+    <p class="visually-hidden" id="budget-caption">
+      Aşağıdaki tablonun aynı rakamları, tek bir çubuk olarak çizilmiş.
+    </p>
+
+    <table class="budget">
+      <caption class="visually-hidden">Bu dosyanın baytları nereye gitti</caption>
+      <thead>
+        <tr>
+          <th scope="col">Bölüm</th>
+          <th scope="col" class="num">Bayt</th>
+          <th scope="col" class="num">Pay</th>
+        </tr>
+      </thead>
+      <tbody id="budget-rows"></tbody>
+      <tfoot>
+        <tr>
+          <th scope="row">Dosyanın tamamı</th>
+          <td class="num" id="budget-total">&mdash;</td>
+          <td class="num">%100</td>
+        </tr>
+      </tfoot>
+    </table>
+  </section>
+
+  <!-- Frame by frame. -->
+  <section class="card" id="frames-card" hidden>
+    <div class="toolbar">
+      <h2>Kare kare</h2>
+      <div class="toolbar-actions">
+        <label for="frame-view" class="inline-label">Göster</label>
+        <select id="frame-view">
+          <option value="composited" selected>her kareden sonraki tuval</option>
+          <option value="stored">yalnızca her karenin sakladığı</option>
+        </select>
+      </div>
+    </div>
+
+    <p class="card-lede" id="frames-lede"></p>
+
+    <ul class="frames" id="frames"></ul>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!-- The colours. -->
+  <section class="card" id="colors-card" hidden>
+    <h2>Renkler</h2>
+    <p class="card-lede" id="colors-lede"></p>
+
+    <div id="global-palette-wrap" hidden>
+      <h3>Genel tablo</h3>
+      <p class="palette-note" id="global-palette-note"></p>
+      <ul class="palette" id="global-palette"></ul>
+    </div>
+
+    <details id="local-palettes-wrap" hidden>
+      <summary id="local-palettes-summary">Kare başına tablolar</summary>
+      <div id="local-palettes"></div>
+    </details>
+  </section>
+
+  <!-- Everything in the file that is not a picture. -->
+  <section class="card" id="extras-card" hidden>
+    <h2>Başka ne var</h2>
+    <p class="card-lede">
+      Görüntü taşımayan bloklar. Bir görüntüleyici hepsini atlar ve dosyanın her
+      kopyası onları yine de taşır.
+    </p>
+    <ul class="extras" id="extras"></ul>
+  </section>
+</main>

--- a/locales/tr/tools/gif-analyzer.toml
+++ b/locales/tr/tools/gif-analyzer.toml
@@ -1,0 +1,309 @@
+#
+# GIF Çözümleyici - Türkçe.
+#
+# Overrides for tools/gif-analyzer/tool.toml. Only words: the slug, the
+# category, the icon and the list of shared parts stay where they are.
+#
+
+name = "GIF Çözümleyici"
+heading = "GIF&nbsp;Çözümleyici <span class=\"h1-kw\">&mdash; bir GIF'in içinde gerçekte ne var</span>"
+tagline = "Kareler, gecikmeler, paletler ve her baytın nereye gittiği."
+
+title = "GIF Çözümleyici &mdash; Kareler, Gecikmeler, Palet ve Dosya Boyutu, Yüklemesiz"
+description = "Bir GIF'i tarayıcınızda parçalarına ayırın: gecikmesi ve tasfiye kuralıyla her kare, renk tabloları, döngü sayısı ve dosya boyutunun nereye gittiğine dair bayt bayt bir döküm. Hiçbir şey yüklenmez."
+og_title = "GIF Çözümleyici &mdash; bir GIF'i tarayıcınızda parçalarına ayırın"
+og_description = "Her kare, her gecikme, her palet ve baytların nereye gittiğine dair dürüst bir hesap. Dosya kendi cihazınızda okunur ve hiçbir zaman yüklenmez."
+og_image_alt = "GIF Çözümleyici - kareler, gecikmeler, palet ve baytların nereye gittiği"
+
+pledge = """
+    Dosya kendi tarayıcınız tarafından açılır ve parçalarına ayrılır: blok
+    yapısı, LZW açma işlemi ve bu sayfada çizilen her kare bu makinede yapılır.
+    Buradaki herhangi bir şey istese bile, bu sayfanın öbür ucunda bir dosyanın
+    gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir GIF çözümleyin. Tek bir istek bile bir görsel, bir küçük
+      resim ya da bir dosya adı taşımıyor. Ya da internet bağlantısını kesip yine
+      de bir tanesini çözümleyin."""
+
+read_first = """
+, dosyayı gezen blok okuyucu için <code>src/gif.js</code>,
+      açıcı için <code>src/lzw.js</code> ve bayt muhasebesi için
+      <code>src/budget.js</code> &mdash; hiçbirinde ağa erişebilecek tek bir
+      satır yok."""
+
+howto_heading = "Bir GIF nasıl çözümlenir"
+
+card = """
+            Bir GIF'i açın ve içinde gerçekte ne olduğunu görün: gecikmesi ve
+            tasfiye kuralıyla her kare, renk tabloları ve dosya boyutunun nereye
+            gittiğine dair dürüst bir hesap."""
+
+[words]
+plural = "GIF'leriniz"
+choose = "bir GIF"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "GIF'inizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyanızın toplanabileceği bir uç nokta burada yok,
+      olsaydı bile onu oraya gönderecek bir kod yok. Burada eskiden
+      <code>connect-src 'none'</code> yazıyordu ki bu mutlaktı; reklam eklemek
+      buna mal oldu ve bunu söylemek anlaşmanın bir parçası."""
+
+[[privacy]]
+title = "Okuyucu bu depodaki dört dosya."
+body = """
+ Buradaki hiçbir şey, dosyada ne
+      olduğunu anlamak için tarayıcının kendi GIF çözücüsünü kullanmıyor; çünkü o
+      çözücü bir baytın nereye gittiğini söylemez. Bu yüzden biçim elle
+      okunuyor: <code>src/gif.js</code> blokları geziyor,
+      <code>src/lzw.js</code> pikselleri açıyor, <code>src/frames.js</code>
+      onları üst üste diziyor ve <code>src/budget.js</code> parçaları toplayıp
+      dosyanın boyutunu tutturup tutturmadığını denetliyor."""
+
+[[privacy]]
+title = "Yorumlar ve üst veri size gösteriliyor, başka hiç kimseye değil."
+body = """
+
+      Bir GIF bir yorum bloğu, bir düzenlemeyi anlatan bir XMP paketi ya da bir
+      renk profili taşıyabilir ve bu sayfa bunların hepsini basar. Onlar
+      önünüzdeki ekrana konur ve başka hiçbir yere gitmez: bu depoda bunlardan
+      herhangi birini taşıyan bir analitik olayı yok ve olsaydı bile sayfa onu
+      gönderemezdi."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine dosyanız hakkında bir şey verilmiyor: ne
+      dosya, ne bir küçük resim, ne bir ad, bir boyut, bir kare sayısı ya da bir
+      yorum. Bir GIF'i okuyan, açan ya da çizen her satır bu kaynaktan sunuluyor
+      ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de dosyalarınız
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfanın her
+      parçası çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu:
+      GIF'inizi çözümlenmek üzere uzağa gönderen bir araç, siz fişi çeker çekmez
+      dururdu."""
+
+[[howto]]
+title = "Bir GIF seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin. Tarayıcı
+      onu doğrudan diskinizden okur; siz bunu yaparken hiçbir yere hiçbir şey
+      gönderilmez."""
+
+[[howto]]
+title = "Önce özeti okuyun."
+body = """
+ Tuval boyutu, kare sayısı, animasyonun
+      ne kadar sürdüğünü söylediği ve gerçekte ne kadar oynadığı. Bu son ikisi
+      insanların beklediğinden daha sık farklı çıkar ve sebebi bir sonraki
+      bölümde."""
+
+[[howto]]
+title = "Göze çarpanlara bakın."
+body = """
+ Oradaki her satır sizin
+      dosyanızdan ölçülmüştür: hiçbir tarayıcının uymayacağı gecikmeler, eksik
+      bir döngü bloğu, hiçbir şeyin başvurmadığı renk tabloları, bazı karelerden
+      daha büyük olan üst veri. Hiçbiri neyi yapmak istediğinize dair bir tahmin
+      değildir."""
+
+[[howto]]
+title = "Baytların nereye gittiğini görün."
+body = """
+ Dosyanın her baytı tam
+      olarak bir satırdadır ve satırların toplamı dosyayı verir. Büyük kısmı
+      "sıkıştırılmış pikseller"de değilse, tablonun geri kalanı nerede olduğunu
+      söyler."""
+
+[[howto]]
+title = "Kareleri gezin."
+body = """
+ Her biri gecikmesini, dikdörtgenini,
+      tasfiye yöntemini ve boyutunu gösterir. "Her kareden sonraki tuval" ile
+      "yalnızca her karenin sakladığı" arasında geçiş yapın &mdash; dosyanın
+      iyileştirilmiş olup olmadığını ikincisiyle görürsünüz; çünkü iyi yapılmış
+      bir GIF küçücük dikdörtgenler saklar, kötü yapılmış olan ise her seferinde
+      görüntünün tamamını."""
+
+[[howto]]
+title = "Gerekirse raporu alın."
+body = """
+ Çözümlemenin tamamı düz metin
+      olarak; bir mesaja yapıştırmak ya da dosyanın yanında saklamak için. Zaten
+      ekranınızda duranlardan sayfa içinde kurulur."""
+
+[[faq]]
+q = "GIF'im herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        açılır ve çizilir. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Ağ
+        bağlantısını kesin, yine de GIF çözümler."""
+
+[[faq]]
+q = "GIF'im neden gecikmelerin söylediğinden yavaş oynuyor?"
+a = """
+        Çünkü her tarayıcı saniyenin yüzde ikisinin altındaki bir gecikmeye
+        uymayı reddeder ve kareyi onda bir saniye tutar. Kural 1996'da
+        Netscape'e, o zamanın dönen dünya küreleri ve "yapım aşamasında"
+        tabelaları için yazıldı ve o günden beri her tarayıcıya kopyalandı;
+        hiçbir zaman kaldırılmadı.
+        <br><br>
+        Yani kareleri hep 0,01 sn diyen bir GIF saniyede 100 kare oynamaz.
+        10 oynar ki bu, onu yapan neyse onun istediğinden beş ila on kat daha
+        yavaştır. Bu sayfa iki sayıyı da gösterir &mdash; dosyanın söylediğini ve
+        gerçekte yapacağını &mdash; ve etkilenen kareleri işaretler. Dosyayı
+        yapan neyse orada çözüm, 0,01 yerine 0,02 yazmaktır."""
+
+[[faq]]
+q = "&laquo;Tasfiye&raquo; ne demek?"
+a = """
+        Bir karenin süresi dolduğunda ekranda ne bırakılacağı; bir animasyonun
+        doğru mu görüneceğine yoksa bulaşacak mı olduğuna karar veren alan da bu.
+        <br><br>
+        <strong>Yerinde kalsın</strong>, bir sonraki karenin bunun üzerine
+        boyayacağı anlamına gelir; kareler opaksa ve birbirini kapatıyorsa
+        istediğiniz budur. <strong>Arka plana kadar temizle</strong> önce karenin
+        dikdörtgenini siler; saydamlığın ihtiyaç duyduğu şey budur &mdash; o
+        olmadan bir sonraki karenin saydam yerlerinden bir önceki görünür.
+        <strong>Altında ne varsa geri koy</strong>, bu kare çizilmeden önce orada
+        ne varsa onu geri getirir; sabit bir arka plan üzerinde hareket eden
+        küçük bir nesne böyle saklanır. <strong>Belirtilmemiş</strong> ise
+        dosyanın söylemediği anlamına gelir ve her görüntüleyici bunu "yerinde
+        kalsın" gibi işler."""
+
+[[faq]]
+q = "GIF'im neden bu kadar büyük?"
+a = """
+        "Baytlar nereye gitti" tablosu bunu genel olarak değil sizin dosyanız için
+        yanıtlar ve olası cevaplar birkaç tanedir.
+        <br><br>
+        Neredeyse tamamı <strong>sıkıştırılmış pikseller</strong> ise dosya
+        yalnızca çok fazla görüntüdür: GIF her kareyi bütün pikseller olarak
+        saklar; hareket telafisi ve kalite düğmesi yoktur, yani boyut kabaca alan
+        çarpı kare sayısıdır. Daha az kare, daha küçük boyut ya da daha az renk
+        tek kaldıraçtır.
+        <br><br>
+        Büyük bir dilim <strong>renk tabloları</strong> ise dosya kare başına
+        768 bayttan bir palet yazıyor demektir. Büyük bir dilim
+        <strong>üst veri</strong> ise bir düzenleyici geride bir XMP paketi
+        bırakmıştır ve bu, görüntüye dokunmadan kaldırılabilir. Kareler tuvalin
+        tamamını kaplıyorsa da kodlayıcı hangi bölümün gerçekten değiştiğini hiç
+        hesaplamamıştır &mdash; ki çekilmiş ya da kaydedilmiş her şeyde bu,
+        dosyanın büyük kısmıdır."""
+
+[[faq]]
+q = "İki kare görünümü arasındaki fark ne?"
+a = """
+        <strong>Her kareden sonraki tuval</strong>, bir görüntüleyicinin o anda
+        gösterdiğidir: bu kare, kendinden öncekilerin bıraktığının üzerine
+        çizilmiş hâlde. <strong>Yalnızca her karenin sakladığı</strong> ise
+        dosyanın o kare için gerçekten tuttuğu dikdörtgendir; tek başına, altında
+        hiçbir şey olmadan.
+        <br><br>
+        İlginç olan ikincisi. Bir GIF bir kareyi yalnızca görüntünün değişen
+        bölümü olarak saklayabilir; çoğunlukla sabit duran bir pencerenin ekran
+        kaydının küçük olabilmesinin sebebi budur. Dosyanızdaki her kare tuvalin
+        tamamıysa hiçbir şey bu işi yapmamıştır &mdash; ve bunu animasyonu
+        izleyerek anlayamazsınız, yalnızca saklanana bakarak anlarsınız."""
+
+[[faq]]
+q = "Dosyamda bir yorum ya da XMP olduğunu söylüyor. Bu ne?"
+a = """
+        Görüntüyle birlikte yolculuk eden ve hiçbir görüntüleyicinin çizmediği
+        metin. Bir yorum bloğu genellikle dosyayı yazan şeyin adıdır. Bir XMP
+        paketi ise bir görsel düzenleyicinin ne yaptığını kaydetmek için yazdığı
+        XML'dir ve düzenleme geçmişini, yazılım sürümünü ve bazen yazarın adını
+        taşıyabilir.
+        <br><br>
+        Bu sayfa ikisini de tam olarak basar, çünkü üst veriyle ilgili ilginç
+        soru onun var olması değil ne dediğidir. Size gösterilir ve başka hiç
+        kimseye gösterilmez: bu depoda bunların herhangi birini birine okuyan bir
+        şey yok."""
+
+[[faq]]
+q = "Bozuk bir GIF'i açabilir mi?"
+a = """
+        Dener ve nerede pes ettiğini söyler. Bir bloğun ortasında biten, blok
+        işaretinin olması gereken yerde bir bayt bulunan ya da sıkıştırılmış
+        verisi erken tükenen bir kare taşıyan bir dosya, o noktaya kadar okunan
+        her şeyi yine de gösterir ve sorun en üstte adıyla belirtilir. Bir
+        çözümleyicinin en çok istendiği durum tam da budur; bu yüzden tek bir
+        bozuk bayt yüzünden dosyanın tamamını çöpe atmak yanlış davranış
+        olurdu."""
+
+[[faq]]
+q = "Dosyamı değiştiriyor mu?"
+a = """
+        Hayır. Bu araç yalnızca okur. Çıktı dosyası, yeniden kodlama ya da GIF
+        yazan bir düğme yoktur &mdash; indirebileceğiniz tek şey çözümlemenin düz
+        metin bir kopyasıdır. Orijinaliniz diskinizde el değmemiş durur; sekmeyi
+        kapatırsanız ne olacağının dürüst cevabı da budur."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok. Kendi makinenizin
+        belleğinin ötesinde bir dosya boyutu sınırı da yok. Sitede reklam var,
+        masrafı karşılayan da o; reklamlara dosyanız hakkında hiçbir şey
+        verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: GIF'inizi çözümlenmek üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir GIF'i tarayıcıda parçalarına ayırın: gecikmesi, dikdörtgeni ve tasfiye yöntemiyle her kare, renk tabloları, döngü sayısı, varsa üst veri ve dosya boyutunun bayt bayt hesabı. Hiçbir şey yüklenmez."
+features = [
+  "Gecikmesi, dikdörtgeni, tasfiye yöntemi ve sıkıştırılmış boyutuyla her kare",
+  "Bir karenin iki görünümü: sakladığı şey ve bir görüntüleyicinin gördüğü tuval",
+  "Dosyanın boyutunu tutturan bir bayt bütçesi, böylece açıklanmayan hiçbir şey kalmaz",
+  "Çizilmiş renk tabloları, hiçbir pikselin başvurmadığı girdiler işaretli",
+  "Yorumları, XMP paketlerini, ICC profillerini ve Netscape döngü bloğunu okur",
+  "Hiçbir tarayıcının uymayacağı gecikmeleri ve animasyonun gerçekte ne hızda oynadığını bildirir",
+  "Bozuk ve yarıda kesilmiş dosyaları açar ve nerede durduklarını söyler",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, dosyanızda değişiklik yok",
+]
+
+[picker]
+title = "Bir GIF'i buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; hareketli ya da durağan, her boyutta"

--- a/locales/tr/tools/gif-maker.html
+++ b/locales/tr/tools/gif-maker.html
@@ -1,0 +1,182 @@
+<!--
+  tools/gif-maker/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; kareler -->
+  <section class="card">
+    <h2><span class="step">1</span> Görselleri seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Karelerin nasıl gösterileceğini değiştir">
+          <button type="button" data-view="large" class="active" aria-pressed="true">Büyük</button>
+          <button type="button" data-view="small" aria-pressed="false">Küçük</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Ada göre sırala</button>
+        <button type="button" data-sort="date" class="ghost">Tarihe göre sırala</button>
+        <button type="button" data-sort="reverse" class="ghost">Ters çevir</button>
+        <button type="button" id="clear-all" class="ghost danger">Hepsini kaldır</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Sıralamayı değiştirmek için herhangi bir kareyi
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> tutamağından
+      sürükleyin ya da her birinin üzerindeki okları kullanın. Buradaki sıra,
+      oynayacakları sıradır.
+    </p>
+
+    <ul id="frame-list" class="frame-list view-large"></ul>
+
+    <div id="bulk-delay" class="bulk" hidden>
+      <label for="bulk-amount">Her kareyi şu kadar tut</label>
+      <input type="number" id="bulk-amount" min="0.02" max="60" step="0.05" value="0.5">
+      <select id="bulk-unit" aria-label="Her karenin ne kadar tutulacağının birimi">
+        <option value="seconds" selected>saniye</option>
+        <option value="fps">saniyedeki kare</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Hepsine uygula</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Adım 2 &mdash; ayarlar -->
+  <section class="card">
+    <h2><span class="step">2</span> GIF ayarları</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="size">Boyut</label>
+        <select id="size">
+          <option value="480" selected>480 px &mdash; iyi bir varsayılan</option>
+          <option value="640">640 px</option>
+          <option value="320">320 px</option>
+          <option value="240">240 px</option>
+          <option value="original">Görsellerle aynı</option>
+          <option value="custom">Özel&hellip;</option>
+        </select>
+        <div id="size-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="1000" step="1" value="480"
+                 aria-label="Piksel olarak özel genişlik">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="1000" step="1" value="270"
+                 aria-label="Piksel olarak özel yükseklik">
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Görsel yerleşimi</label>
+        <select id="fit">
+          <option value="contain" selected>İçine sığdır (bantlı)</option>
+          <option value="cover">Kareyi doldur (kenarları kırpar)</option>
+          <option value="stretch">Doldurmak için esnet (bozar)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Arka plan rengi</label>
+        <input type="color" id="background" value="#ffffff">
+      </div>
+
+      <div class="field">
+        <label for="colors">Renkler</label>
+        <select id="colors">
+          <option value="256" selected>256 &mdash; bir GIF'in tuttuğu en fazla</option>
+          <option value="128">128</option>
+          <option value="64">64</option>
+          <option value="32">32 &mdash; en küçük dosya</option>
+        </select>
+        <p class="field-note">Daha az renk, daha küçük dosya, daha çok bantlaşma.</p>
+      </div>
+
+      <div class="field">
+        <label for="palette-mode">Palet</label>
+        <select id="palette-mode">
+          <option value="per-frame" selected>Her kare için en iyi renkler</option>
+          <option value="shared">GIF'in tamamı için tek palet</option>
+        </select>
+        <p class="field-note" id="palette-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Dithering</label>
+        <select id="dither">
+          <option value="on" selected>Açık &mdash; daha yumuşak geçişler</option>
+          <option value="off">Kapalı &mdash; daha düz, daha temiz kenarlar</option>
+        </select>
+        <p class="field-note">Logolar, çizgi çalışmaları ve ekran görüntüleri için kapatın.</p>
+      </div>
+
+      <div class="field">
+        <label for="loop-mode">Döngü</label>
+        <select id="loop-mode">
+          <option value="forever" selected>Sonsuza kadar döngü</option>
+          <option value="once">Bir kez oynat</option>
+          <option value="times">Belirli sayıda oynat&hellip;</option>
+        </select>
+        <input type="number" id="loop-times" class="spaced" min="1" max="1000" step="1" value="3"
+               aria-label="Animasyonun kaç kez oynayacağı" hidden>
+      </div>
+
+      <div class="field">
+        <label for="transparent">Saydamlık</label>
+        <select id="transparent">
+          <option value="off" selected>Arka plana düzleştir</option>
+          <option value="on">Saydam alanları koru</option>
+        </select>
+        <p class="field-note" id="transparent-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame" id="preview-frame">
+        <canvas id="preview" width="480" height="270" aria-label="İlk karenin ön izlemesi"></canvas>
+        <p id="preview-empty" class="preview-empty">Ön izleme için görsel ekleyin</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Kareler</dt><dd id="sum-frames">&mdash;</dd></div>
+        <div><dt>Süresi</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Kare boyutu</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Oynatma</dt><dd id="sum-loop">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; dışa aktarma -->
+  <section class="card">
+    <h2><span class="step">3</span> GIF'i yapın</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>GIF yap</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame"><img id="result-image" alt="Bitmiş animasyon, oynuyor"></div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>GIF'i indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/gif-maker.toml
+++ b/locales/tr/tools/gif-maker.toml
@@ -1,0 +1,251 @@
+#
+# GIF Yapıcı - Türkçe.
+#
+# Overrides for tools/gif-maker/tool.toml. Only words: the slug, the category,
+# the icon and the list of shared parts stay where they are.
+#
+
+name = "GIF Yapıcı"
+heading = "GIF&nbsp;Yapıcı <span class=\"h1-kw\">&mdash; görsellerden hareketli GIF</span>"
+tagline = "Bir dizi resmi tek bir animasyona çevirin."
+
+title = "GIF Yapıcı &mdash; Görsellerden Hareketli GIF, Ücretsiz ve Yüklemesiz"
+description = "JPG, PNG veya WebP görselleri hareketli bir GIF'e çevirin; ücretsiz ve tamamen tarayıcınızda. Sırayı, hızı ve boyutu siz belirleyin. Hiçbir şey yüklenmez ve çevrimdışı da çalışır."
+og_title = "GIF Yapıcı &mdash; görsellerden hareketli GIF, tarayıcınızda"
+og_description = "Kareleri sıralayın, her birinin ne kadar duracağını ayarlayın, bir boyut seçin ve bir GIF alın. Palet ve sıkıştırma kendi cihazınızda hesaplanır; hiçbir şey yüklenmez."
+og_image_alt = "GIF Yapıcı - bir dizi görseli tek bir hareketli GIF'e çevirin"
+
+pledge = """
+    Her kare kendi tarayıcınız tarafından çizilir, renk sayısı düşürülür ve
+    sıkıştırılır; bitmiş GIF de bu makinenin belleğinde kurulur. Buradaki
+    herhangi bir şey istese bile, bu sayfanın öbür ucunda bir görselin
+    gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir GIF yapın. Tek bir istek bile bir görsel, bir küçük resim ya
+      da bir dosya adı taşımıyor. Ya da internet bağlantısını kesip yine de bir
+      tane yapın."""
+
+read_first = """
+, her karenin indirgendiği palet için
+      <code>src/quantize.js</code> ve sıkıştırıcı ile onun girdiği dosya için
+      <code>src/lzw.js</code> ile <code>src/gif.js</code> &mdash; hiçbirinde ağa
+      erişebilecek tek bir satır yok."""
+
+howto_heading = "Görsellerden nasıl GIF yapılır"
+
+card = """
+            Resimleri sıraya koyun, her birinin ne kadar duracağını söyleyin ve
+            tek bir hareketli GIF alın. Renkler ve sıkıştırma kendi cihazınızda
+            hesaplanır."""
+
+[words]
+plural = "görselleriniz"
+choose = "görseller"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "Görsellerinizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok. Burada eskiden
+      <code>connect-src 'none'</code> yazıyordu ki bu mutlaktı; reklam eklemek
+      buna mal oldu ve bunu söylemek anlaşmanın bir parçası."""
+
+[[privacy]]
+title = "Kodlayıcı bu depodaki dört dosya."
+body = """
+ Bir GIF için renk indirgeyici
+      ve LZW sıkıştırıcısı gerekir ve tarayıcı ikisini de getirmez &mdash; bu
+      yüzden ikisi de burada, <code>src/quantize.js</code> ve
+      <code>src/lzw.js</code> içinde yazılı, kabı da <code>src/gif.js</code>
+      içinde. Bir tane yapmak için hiçbir şey getirilmiyor ve ilk kullanımda
+      indirilen bir motor yok."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine görselleriniz hakkında bir şey verilmiyor: ne
+      bir dosya, ne bir küçük resim, ne bir ad, bir boyut ya da bir sayı. Bir
+      görseli okuyan, çözen, çizen ya da sıkıştıran her satır bu kaynaktan
+      sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de görselleriniz
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfanın her
+      parçası çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu:
+      resimlerinizi GIF'e çevrilmek üzere uzağa gönderen bir araç, siz fişi çeker
+      çekmez dururdu."""
+
+[[howto]]
+title = "Görsellerinizi seçin."
+body = """
+ Seçiciye bir klasör bırakın ya da
+      dosyaları elle seçin. Tarayıcı onları doğrudan diskinizden okur; siz bunu
+      yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Oynayacakları sıraya koyun."
+body = """
+ Tutamağından sürükleyin ya da
+      okları kullanın. "Ada göre sırala" beklediğiniz gibi sayar, yani
+      <code>frame_2</code>, <code>frame_10</code>'dan önce gelir."""
+
+[[howto]]
+title = "Her karenin ne kadar duracağını ayarlayın."
+body = """
+ Kare başına
+      yarım saniye bir slayt gösterisidir; yirmide bir animasyondur. Ya her
+      kareye aynı süreyi bir seferde verin ya da bir tanesini oyalanması için
+      ayrı ayarlayın."""
+
+[[howto]]
+title = "Bir boyut ve renklerin nasıl seçileceğini belirleyin."
+body = """
+ Bir GIF
+      alanıyla ve kare sayısıyla büyür ve onu geri küçültecek bir kalite
+      kaydırıcısı yoktur; bu yüzden en çok önemli olan ayar boyuttur. Kare başına
+      256 renk en iyi görünen varsayılandır; tek bir ortak palet daha küçük ve
+      daha durağandır."""
+
+[[howto]]
+title = "GIF'i yapın ve indirin."
+body = """
+ Kendi donanımınızda kurulur, yani
+      ne kadar süreceği bir sıraya değil makinenize bağlıdır. Bitmiş animasyon
+      siz kaydetmeden önce sayfada oynar."""
+
+[[faq]]
+q = "Görsellerim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Görselleriniz kendi donanımınızda, kendi tarayıcınız tarafından
+        okunur, çizilir, renk sayısı düşürülür ve sıkıştırılır. Bu aracın sunucu
+        tarafı yoktur ve sayfanın <code>Content-Security-Policy</code>'si
+        iletişim kurabileceği her adresi tek tek sayar &mdash; bunların hiçbiri
+        bu siteye ait değildir. Ağ bağlantısını kesin, yine de GIF yapar."""
+
+[[faq]]
+q = "Hangi görsel biçimlerini kullanabilirim?"
+a = """
+        Tarayıcınızın çözebildiği her hareketsiz görsel biçimini; pratikte bu
+        JPG, PNG, WebP, GIF, AVIF ve Apple cihazlarda HEIC demektir. Burada
+        güncel tutulacak ayrı bir liste yok, çünkü çözme işi bizim değil
+        tarayıcının işi."""
+
+[[faq]]
+q = "GIF'im neden bu kadar büyük?"
+a = """
+        Çünkü bir GIF her kareyi bütün pikseller olarak saklar. Hareket telafisi
+        yoktur, hiçbir şey "geçen seferkiyle aynı ama kaymış" diye saklanmaz ve
+        bir kalite düğmesi yoktur: boyut kabaca alan çarpı kare sayısıdır ve onu
+        yalnızca üç şey aşağı çeker.
+        <br><br>
+        Daha küçük yapın &mdash; boyutu yarıya indirmek dosyayı dörtte bire
+        düşürür. Daha az kare kullanın ya da her birini daha uzun tutun. 64 ya da
+        32 renge inin ve dithering'i kapatın; bu, düz çalışmalarda kulağa
+        geldiğinden daha az, fotoğraflarda ise epeyce maliyetlidir. Yine de
+        sığmıyorsa dürüst cevap şudur: yaptığınız şey bir videodur ve onun MP4'ü
+        belki de onda biri kadar olur."""
+
+[[faq]]
+q = "Bir GIF ne kadar hızlı oynayabilir?"
+a = """
+        Sayının ima ettiği kadar hızlı değil. Biçim her karenin gecikmesini
+        saniyenin yüzde biri cinsinden saklar ve tarayıcılar 1990'lardan beri
+        bunun ikisinin altındaki her şeyi saniyenin onda birine sabitliyor
+        &mdash; o zamanın dönen dünya küreleri için yazılmış ve hiç kaldırılmamış
+        bir kural. Yani 0,01 sn'lik bir gecikme saniyede 100 kare oynamaz;
+        10 oynar. Bu araç bu yüzden size 0,02 sn'nin altını hiç sunmaz ve
+        0,05 sn (saniyede 20 kare) istemeye değer en hızlı sınır sayılır."""
+
+[[faq]]
+q = "Palet ayarı neyi değiştiriyor?"
+a = """
+        Bir GIF karesi en fazla 256 renk tutar ve birinin bunları seçmesi gerekir.
+        <br><br>
+        <strong>Her kare için en iyi renkler</strong>, her resim için ayrı ayrı
+        256 renk seçer; bu en keskin görünendir ve birbiriyle ilgisiz
+        fotoğraflardan oluşan bir set için doğru cevaptır. <strong>GIF'in tamamı
+        için tek palet</strong> ise bütün karelerden tek bir tablo kurar. Daha
+        küçük bir dosya yapar ve aynı sahnenin kareleri arasında palet
+        sıçradığında ortaya çıkan titremeyi durdurur &mdash; yani kareler bir
+        koleksiyon değil bir dizi olduğunda başvurulacak olan budur."""
+
+[[faq]]
+q = "Saydam bir arka planı koruyabilir miyim?"
+a = """
+        Görsellerinizde varsa evet: "Saydamlık"ı "Saydam alanları koru"ya alın.
+        Bunu yapmadan önce bilinmesi gereken bir şey var. GIF saydamlığı tek
+        bittir &mdash; bir piksel ya görünmezdir ya da tümüyle boyalı, arası
+        yoktur &mdash; dolayısıyla kenar yumuşatmalı kenarlar, yumuşak gölgeler
+        ve solmuş her şey sert bir kenara dönüşür. Animasyonunuz rengini
+        bildiğiniz bir arka plana gidecekse onu o renge düzleştirmek daha iyi
+        görünür."""
+
+[[faq]]
+q = "Kaç görsel kullanabileceğime dair bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok. Pratik tavan, kendi makinenizin belleği ve
+        çıkan dosyaya karşı sabrınızdır: resimler teker teker okunur, yani yüz
+        kare sorun değildir; ama 640 piksellik yüz kare aynı zamanda çok büyük
+        bir GIF demektir. Yukarıdaki "GIF'im neden bu kadar büyük?" başlığına
+        bakın."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok. Çıktıda filigran da
+        yok. Sitede reklam var, masrafı karşılayan da o; reklamlara görselleriniz
+        hakkında hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: görsellerinizi işlenmek üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir dizi görseli hareketli GIF'e çevirin. Kareler, palet ve sıkıştırmanın hepsi tarayıcınızda hesaplanır; böylece hiçbir görsel yüklenmez."
+features = [
+  "JPG, PNG, WebP, GIF ve AVIF görselleri tek bir hareketli GIF'te birleştirir",
+  "Kare başına bekleme süresi, sürükleyerek sıralama, ada veya tarihe göre sıralama",
+  "256, 128, 64 veya 32 renk, isteğe bağlı Floyd-Steinberg dithering",
+  "Tek ortak palet ya da her kare için en iyi renkler",
+  "İsteğe bağlı tek bitlik saydamlık; sonsuz, bir kez ya da belirli sayıda döngü",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Görselleri buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/tr/tools/grab-frame.html
+++ b/locales/tr/tools/grab-frame.html
@@ -1,0 +1,140 @@
+<!--
+  tools/grab-frame/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosya -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir video seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Dosya</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Boyut</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Kare</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Görüntü</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Kare sayısı</dt><dd id="src-frames">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; an -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Kareyi bulun</h2>
+
+    <p class="stage-hint">
+      Klip boyunca ilerlemek için kaydırıcıyı sürükleyin ya da oynatıp
+      istediğiniz yerde durun. <kbd>&larr;</kbd> ve <kbd>&rarr;</kbd> birer kare
+      atlar, <kbd>Shift</kbd> ile birlikte onar kare atlar, <kbd>Space</kbd> ise
+      oynatır ve duraklatır.
+    </p>
+
+    <!-- The picture you are looking at is the picture that gets saved: on the
+         exact path the canvas holds the decoded frame itself, drawn small here
+         and full size into the file. The <video> element is only for playing
+         and for the files this browser can play but this reader cannot open. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+        <p class="stage-busy" id="stage-busy" hidden>Çözülüyor&hellip;</p>
+      </div>
+    </div>
+
+    <div class="transport">
+      <div class="transport-buttons" role="group" aria-label="Klip boyunca ilerle">
+        <button type="button" id="step-back" class="ghost" title="Önceki kare (sol ok)"
+          aria-label="Önceki kare">&#9664;|</button>
+        <button type="button" id="play" class="ghost" title="Oynat veya duraklat (boşluk)"
+          aria-label="Oynat">&#9654;</button>
+        <button type="button" id="step-on" class="ghost" title="Sonraki kare (sağ ok)"
+          aria-label="Sonraki kare">|&#9654;</button>
+      </div>
+
+      <input type="range" id="scrub" min="0" max="1000" value="0" step="1"
+        aria-label="Klipteki konum">
+
+      <p class="readout">
+        <span id="at-time">0:00.000</span>
+        <span class="readout-dim" id="at-frame"></span>
+      </p>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; kare -->
+  <section class="card" id="grab-card" hidden>
+    <h2><span class="step">3</span> Kareyi alın</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Biçim</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; tam olarak kare</option>
+          <option value="image/jpeg">JPEG &mdash; daha küçük, kayıplı</option>
+          <option value="image/webp">WebP &mdash; daha da küçük, kayıplı</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Kalite <output id="quality-value">92</output></label>
+        <input type="range" id="quality" min="40" max="100" step="1" value="92">
+        <p class="field-note">
+          Kareyi olduğu gibi saklayan tek biçim PNG. Başka her şey, videonun
+          kendi sıkıştırmasının üzerine ikinci bir sıkıştırmadır.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="every">Her</label>
+        <div class="inline-pair">
+          <input type="number" id="every" min="0.1" max="600" step="0.5" value="5">
+          <span>saniyede bir</span>
+        </div>
+        <p class="field-note">
+          Bir kontak baskısı ya da arada bir küçük resim için. En fazla 500
+          kareyle sınırlı.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="grab" class="primary">Bu kareyi al</button>
+      <button type="button" id="grab-series" class="ghost">5 saniyede bir al</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 4 &mdash; çıkanlar -->
+  <section class="card" id="shots-card" hidden>
+    <h2><span class="step">4</span> Kareleriniz</h2>
+
+    <div class="toolbar">
+      <p class="count" id="shots-count" role="status" aria-live="polite"></p>
+      <div class="toolbar-actions">
+        <button type="button" id="download-all" class="ghost">Hepsini ZIP olarak indir</button>
+        <button type="button" id="clear" class="ghost danger">Temizle</button>
+      </div>
+    </div>
+
+    <ul class="shots" id="shots"></ul>
+  </section>
+</main>

--- a/locales/tr/tools/grab-frame.toml
+++ b/locales/tr/tools/grab-frame.toml
@@ -1,0 +1,245 @@
+#
+# Video Kare Yakalayıcı - Türkçe.
+#
+# Overrides for tools/grab-frame/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Video Kare Yakalayıcı"
+heading = "Video&nbsp;Kare&nbsp;Yakalayıcı <span class=\"h1-kw\">&mdash; videodan kare kaydedin</span>"
+tagline = "Herhangi bir andan tam kaliteli bir kare."
+
+title = "Videodan Kare Yakalama &mdash; Ücretsiz, Yüklemesiz, Çevrimdışı Çalışır"
+description = "Bir MP4, MOV veya WebM'in herhangi bir karesini tam boyutlu PNG ya da JPEG olarak kaydedin. Kare kare ilerleyin ya da birkaç saniyede bir alın. Tarayıcınızda çalışır: hiçbir şey yüklenmez."
+og_title = "Video Kare Yakalayıcı &mdash; klibi yüklemeden herhangi bir andan kare"
+og_description = "Anı bulun, tam kareye kadar adımlayın ve videonun kendi çözünürlüğünde kaydedin. Kareler kendi cihazınızda çözülür ve görüntü asla iki kez kodlanmaz."
+og_image_alt = "Video Kare Yakalayıcı - tarayıcınızda videodan kare kaydedin, hiçbir şey yüklenmesin"
+
+pledge = """
+    Kareler kendi tarayıcınız tarafından, kendi donanımınızda bulunur, çözülür
+    ve çizilir. Buradaki hiçbir şey bir şey getiremez ya da gönderemez &mdash;
+    bu araçta hiçbir türde ağ özelliği yok &mdash; ve olsaydı bile bu sayfanın
+    öbür ucunda bir videonun gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir kare yakalayın. Tek bir istek bile bir görsel, bir dosya adı
+      ya da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet bağlantısını
+      kesip yine de bir tane yakalayın &mdash; videonuzu işlenmek üzere uzağa
+      gönderen bir araç öylece dururdu."""
+
+read_first = """
+, bir MP4 içindeki kareleri bulan okuyucu için
+      <code>src/demux.js</code> ve istediğiniz kareyi çözen bölüm için
+      <code>src/frames.js</code>. İkisi de istek yapabilecek bir şeyi içeri
+      almaz."""
+
+howto_heading = "Bir videodan kare nasıl yakalanır"
+
+card = """
+            Bir klibin herhangi bir karesini, videonun kendi boyutunda görsel
+            olarak kaydedin &mdash; teker teker ya da birkaç saniyede bir."""
+
+[words]
+plural = "videolarınız"
+choose = "bir video"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Tam çözünürlük"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[privacy]]
+title = "Videolarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu
+      sayfanın iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri
+      bu siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araçta hiçbir türde ağ
+      özelliği yok: yapıştırılacak bir adres, indirilecek bir şey, ilk
+      kullanımda getirilen bir motor yok. Videonuza dokunan her bayt, sayfa
+      yüklenirken bu kaynaktan geldi."""
+
+[[privacy]]
+title = "Çözme işi yerelde."
+body = """
+ Kareler kendi tarayıcınızdaki
+      WebCodecs'ten geçer ya da klibi zaten size gösterecek olan aynı oynatma
+      motorundan. Görüntü bu makinede bir tuvale çizilir ve doğrudan bir
+      indirmeye verilir."""
+
+[[privacy]]
+title = "Dosya birkaç megabaytlık parçalar hâlinde okunuyor."
+body = """
+      Video, buradaki dosya türleri içinde belleğe güvenilir biçimde sığmayacak
+      olanıdır; bu yüzden asla bütün olarak yüklenmez. Okuyucu, istediğiniz
+      karenin çevresinden bir pencere alır &mdash; iki gigabaytlık bir klibin
+      küçük bir tanesi kadar hızlı açılmasının sebebi de budur."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine videonuz hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir kare, ne bir ad, bir boyut, bir uzunluk ya da durduğunuz an.
+      Okuyan, çözen ya da çizen her satır bu kaynaktan sunuluyor ve depoda
+      listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de videonuz
+      hakkında bir şey verilir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Bir video seçin."
+body = """
+ Seçiciye bir MP4, MOV, M4V ya da WebM
+      bırakın veya elle seçin. Tarayıcı onu doğrudan diskinizden okur; siz bunu
+      yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Anı bulun."
+body = """
+ Oynatıp istediğiniz yerde durdurun ya da kaydırıcıyı
+      sürükleyin &mdash; bir MP4'te kaydırıcı adım başına bir kare ilerler, yani
+      gördüğünüzle kaydettiğiniz arasında yuvarlama olmaz. Ok tuşları birer kare
+      atlar, <kbd>Shift</kbd> basılıyken onar."""
+
+[[howto]]
+title = "Bir biçim seçin."
+body = """
+ PNG, kareyi çözüldüğü hâliyle tam olarak
+      saklar; burada "tam kalite" bu demektir. JPEG ve WebP daha küçüktür ve
+      videonun kendi sıkıştırmasının üzerine ikinci bir sıkıştırmadır; bu bir ön
+      izleme için sorun değildir, sonradan düzenlenecek bir şey için değildir."""
+
+[[howto]]
+title = "Bir kare ya da bir dizi yakalayın."
+body = """
+ Tek kare doğrudan
+      indirmelerinize gider. "Her N saniyede bir" klibi bir kez gezer ve her
+      işarette bir kare alır &mdash; kontak baskısı ve küçük resimler için
+      kullanışlıdır &mdash; ve bunlar yüz tane kaydetme sorusu yerine tek bir
+      ZIP olarak çıkar."""
+
+[[faq]]
+q = "Videom herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur ve
+        çözülür. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Size
+        söylenene güvenmek yerine denetlemeyi tercih ediyorsanız internet
+        bağlantısını kesin ve yine de bir kare yakalayın."""
+
+[[faq]]
+q = "&quot;Tam kalite&quot; tam olarak ne demek?"
+a = """
+        İki şey. Kare, sayfadaki ön izlemenin boyutunda değil videonun kendi
+        çözünürlüğünde kaydedilir &mdash; 4K bir klip 3840 x 2160 bir görsel
+        verir. Ve PNG seçiliyken kare, çözücüden çıktığı hâliyle tam olarak
+        saklanır; yani dosya, videonun taşıdığı görüntüyü, üzerine ikinci bir
+        sıkıştırma turu binmeden taşır. Bir oynatıcı penceresinin ekran
+        görüntüsü bunların ikisini de vermez: o, pencerenin boyutundadır ve
+        oynatıcı görüntüyü ölçekleyip renk yönetiminden geçirdikten sonra
+        alınmıştır."""
+
+[[faq]]
+q = "Hangi video biçimlerinden kare alabilirim?"
+a = """
+        MP4, M4V ve MOV içlerinde ne olursa olsun doğrudan okunur: H.264, HEVC,
+        AV1 ya da VP9 &mdash; yeter ki tarayıcınız o kodlayıcıyı çözebilsin.
+        Aracın tek tek karelere eriştiği tam yol budur. Tarayıcınızın
+        oynatabildiği başka her şey &mdash; en bilineni WebM &mdash; oynatıcı
+        aranıp gösterdiği çizilerek ele alınır; bu da yine tam boyutlu bir görsel
+        kaydeder ama sizin istediğiniz kareye değil oynatıcının seçtiği kareye
+        denk gelir. Tarayıcının ne okuyabildiği ne de oynatabildiği bir dosya, ki
+        pratikte AVI, WMV, FLV ve çoğu MKV demektir, bunu söyleyen bir mesajla
+        geri çevrilir."""
+
+[[faq]]
+q = "Kare kare ilerleyebilir miyim?"
+a = """
+        Bir MP4'te evet, tam olarak: araç dosyanın kendi kare listesini okur, yani
+        ok tuşları gerçekten içinde bulunan görüntüler arasında hareket eder
+        &mdash; kare hızı gezinen bir klipte bile, ki orada saniyenin otuzda biri
+        gibi sabit bir adım kayardı. Oynatma yolunda böyle bir liste yoktur; bu
+        yüzden bir adım yaklaşık bir kare kadar bir dürtmedir ve sayfa bunu
+        söyler."""
+
+[[faq]]
+q = "Dikey çekilmiş telefon videom neden burada doğru duruyor?"
+a = """
+        Çünkü dönüş bilinçli olarak uygulandı. Bir telefon yatay çeker ve
+        pikselleri döndürmek yerine dosyaya çeyrek dönüş yazar; dolayısıyla bir
+        çözücünün verdiği kare yan yatmıştır ve her oynatıcı onu ekranınıza
+        giderken döndürür. Bu adımı atlayan bir araç, doğru anın makul görünen
+        ama yan yatmış bir görüntüsünü kaydeder. Bu araç dönüşü parçadan okur ve
+        hiçbir şey çizilmeden önce uygular."""
+
+[[faq]]
+q = "Videonun boyutunda veya uzunluğunda bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok ve dosya belleğe bir seferde tümüyle
+        okunmuyor &mdash; her seferinde birkaç megabaytlık parçalar hâlinde
+        geziliyor; uzun bir klibin kısa bir klip kadar hızlı açılmasının sebebi
+        de bu. Aldığınız kareler indirene kadar sayfada tutulur; yani pratik
+        tavan videonun kendisi değil, birkaç yüz tane 4K PNG'dir."""
+
+[[faq]]
+q = "Kareyi sonradan yeniden boyutlandırabilir veya kırpabilir miyim?"
+a = """
+        Burada değil, yan kapıda. Bu araç kareyi olduğu gibi kaydeder; boyutunu
+        ya da şeklini değiştirmek kendi kararlarını içeren ayrı bir iştir ve
+        <a href="../resim-boyutlandirma/">Görsel Boyutlandırıcı</a> ikisini de
+        yapar, o da hiçbir şey yüklemeden. Görüntüyü değiştirmeden dosyayı
+        küçültmek ise <a href="../resim-sikistirma/">Görsel Sıkıştırıcı</a>'nın
+        işi."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara videonuz hakkında hiçbir
+        şey verilmiyor."""
+
+[schema]
+browser_requirements = "JavaScript gerekir. Kare hassasiyetinde yakalama için WebCodecs destekleyen bir tarayıcı gerekir; diğerleri oynatıcıyı aramaya düşer."
+description = "Bir videonun herhangi bir karesini tarayıcıda tam boyutlu PNG, JPEG veya WebP olarak kaydedin. MP4, MOV ve M4V, WebCodecs üzerinden kare kare okunur; böylece istenen kare tam olarak kaydedilen karedir. Tarayıcının oynattığı başka her şey oynatıcıdan yakalanır. Hiçbir şey yüklenmez."
+features = [
+  "MP4, MOV, M4V ve WebM videodan kare kaydeder",
+  "H.264, HEVC, AV1 ve VP9 kaynakları, WebCodecs üzerinden çözülür",
+  "Dosyanın kendi kare listesi üzerinden kare kare ilerleme",
+  "Karenin birebir kopyası için PNG, daha küçüğü için JPEG ve WebP",
+  "Her N saniyede bir kare, hepsi birlikte ZIP olarak indirilir",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir videoyu buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; MP4, MOV, M4V, WebM ve bu tarayıcının oynattığı her şey"

--- a/locales/tr/tools/hash-checksum.html
+++ b/locales/tr/tools/hash-checksum.html
@@ -1,0 +1,191 @@
+<!--
+  tools/hash-checksum/body.html, in Turkish.
+
+  Every id, class, data-* attribute and data-slot below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!--
+    Three steps, and the third one is the reason anybody is here.
+
+    Computing a checksum is not the job. Finding out whether the file you just
+    downloaded is the file the publisher signed is the job, and a page that
+    stops at "here is your hash" leaves the last and only difficult part -
+    comparing sixty-four characters by eye - to the visitor. So the comparison
+    is a step of its own, it accepts the checksum in whatever shape it was
+    published in, and it answers in a sentence rather than in a colour.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir dosya seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <section class="card" id="run-card">
+    <h2><span class="step">2</span> Sağlama toplamları</h2>
+    <p class="card-lede">
+      MD5 ve SHA-256 varsayılan olarak hesaplanır, çünkü ikisi birlikte var olan
+      neredeyse her indirme sayfasını karşılar. Bir başkasını işaretleyin, dosya
+      onun için yeniden okunsun &mdash; yavaş olan yarı okumadır, bu yüzden dosya
+      seçilmeden önce işaretlenmiş olan her şey, üzerinden tek bir geçişte
+      çıkar.
+    </p>
+
+    <fieldset class="algorithms">
+      <legend class="visually-hidden">Hangi sağlama toplamları hesaplansın</legend>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="md5" checked>
+        <span class="algorithm-name">MD5</span>
+        <span class="algorithm-note">Çakışmalar 2004'ten beri ucuz. Yine de internetteki indirmelerin yarısının yanında basılan sayı bu.</span>
+      </label>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="sha1">
+        <span class="algorithm-name">SHA-1</span>
+        <span class="algorithm-note">2017'de herkesin gözü önünde kırıldı. Yine de Git bir nesneyi böyle adlandırıyor ve pek çok sürüm sayfasında hâlâ duruyor.</span>
+      </label>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="sha256" checked>
+        <span class="algorithm-name">SHA-256</span>
+        <span class="algorithm-note">Bugün bir sağlama toplamı dendiğinde kastedilen şey. Bir tane yayımlayan her dağıtım bunu yayımlıyor.</span>
+      </label>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="sha384">
+        <span class="algorithm-name">SHA-384</span>
+        <span class="algorithm-note">Kısaltılmış SHA-512. Çoğunlukla betik etiketlerindeki integrity özniteliklerinde karşınıza çıkar.</span>
+      </label>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="sha512">
+        <span class="algorithm-name">SHA-512</span>
+        <span class="algorithm-note">Daha geniş ve pratikte hiçbir zaman önemli olmuş bir yönden daha güçlü değil. Yine de bazı projeler onu yayımlıyor.</span>
+      </label>
+    </fieldset>
+
+    <div class="progress" id="progress" hidden>
+      <div class="progress-track" role="progressbar" id="progress-track"
+           aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+        <span class="progress-fill" id="progress-fill"></span>
+      </div>
+      <p class="progress-line">
+        <span id="progress-text" role="status" aria-live="polite"></span>
+        <button type="button" id="stop" class="ghost danger">Durdur</button>
+      </p>
+    </div>
+
+    <p class="stopped" id="stopped" hidden>
+      Durduruldu. Bu dosya için hiçbir şey hesaplanmadı.
+      <button type="button" id="restart" class="ghost">Baştan başla</button>
+    </p>
+
+    <div class="results" id="results" hidden>
+      <div class="toolbar">
+        <h3 class="file-name" id="file-name">&mdash;</h3>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Hepsini kopyala</button>
+          <button type="button" id="download-checksums" class="ghost">Dosya olarak kaydet</button>
+        </div>
+      </div>
+
+      <p class="file-facts" id="file-facts"></p>
+
+      <ul class="digests" id="digests">
+        <li class="digest" data-algorithm="md5" hidden>
+          <span class="digest-name">MD5</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>eşleşiyor</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>farklı</span>
+          <button type="button" class="ghost" data-slot="copy">Kopyala</button>
+        </li>
+        <li class="digest" data-algorithm="sha1" hidden>
+          <span class="digest-name">SHA-1</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>eşleşiyor</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>farklı</span>
+          <button type="button" class="ghost" data-slot="copy">Kopyala</button>
+        </li>
+        <li class="digest" data-algorithm="sha256" hidden>
+          <span class="digest-name">SHA-256</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>eşleşiyor</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>farklı</span>
+          <button type="button" class="ghost" data-slot="copy">Kopyala</button>
+        </li>
+        <li class="digest" data-algorithm="sha384" hidden>
+          <span class="digest-name">SHA-384</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>eşleşiyor</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>farklı</span>
+          <button type="button" class="ghost" data-slot="copy">Kopyala</button>
+        </li>
+        <li class="digest" data-algorithm="sha512" hidden>
+          <span class="digest-name">SHA-512</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>eşleşiyor</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>farklı</span>
+          <button type="button" class="ghost" data-slot="copy">Kopyala</button>
+        </li>
+      </ul>
+
+      <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+    </div>
+  </section>
+
+  <section class="card" id="compare-card">
+    <h2><span class="step">3</span> Olması gerekene karşı denetleyin</h2>
+    <p class="card-lede">
+      İndirme sayfasının size verdiği sağlama toplamını yapıştırın. Şekli önemli
+      değil &mdash; düz onaltılık, <code>sha256sum</code> çıktısı, bütün bir
+      <code>SHA256SUMS</code> dosyası, <code>SHA256 (dosya) = &hellip;</code>
+      biçimi ya da bir betik etiketinden alınmış <code>integrity</code>
+      özniteliği. Hangi algoritma olduğu uzunluğundan gelir, yani seçilecek bir
+      şey yok.
+    </p>
+
+    <label class="visually-hidden" for="expected">Olması gereken sağlama toplamı</label>
+    <textarea id="expected" rows="3" spellcheck="false" autocapitalize="off"
+              autocomplete="off"
+              placeholder="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"></textarea>
+
+    <p class="expected-read" id="expected-read" role="status" aria-live="polite" hidden>
+      <span data-read="one">Bu bir <b data-slot="algorithm"></b>.</span>
+      <span data-read="many">Bu bir liste. İçinde <b data-slot="count"></b> sağlama toplamı var.</span>
+      <span data-read="stray">Bu <b data-slot="length"></b> karakterlik onaltılık ve bunların hiçbiri bu uzunlukta değil. Olağan sebebi, sonunu kaybetmiş bir kopyalamadır.</span>
+      <span data-read="nothing">İçinde sağlama toplamına benzeyen bir şey yok.</span>
+    </p>
+
+    <div class="verdict" id="verdict" hidden>
+      <p class="verdict-line good" data-outcome="match">
+        <span class="verdict-mark">&#10003;</span>
+        <span>Bu, o sağlama toplamının tarif ettiği dosya. <b data-slot="algorithm"></b> değeri, yapıştırdığınızla karakter karakter aynı.</span>
+      </p>
+      <p class="verdict-line good" data-outcome="renamed">
+        <span class="verdict-mark">&#10003;</span>
+        <span>Baytlar eşleşiyor ama başka bir satırla. Yapıştırdığınız şey buna <b data-slot="name"></b> diyor, seçtiğiniz dosyanın adı ise başka. Ya size gelirken adı değiştirildi ya da denetlemek istediğiniz indirme bu değil &mdash; <b data-slot="algorithm"></b> her iki durumda da doğru.</span>
+      </p>
+      <p class="verdict-line bad" data-outcome="mismatch">
+        <span class="verdict-mark">&#10007;</span>
+        <span>Bu, o sağlama toplamının tarif ettiği dosya <b>değil</b>. <b data-slot="algorithm"></b> değeri farklı, yani baytlar farklı: yarıda kesilmiş bir indirme, yanlış sürüm ya da başka bir şey dağıtan bir yansı. Çalıştırmadan önce onu yeniden alın.</span>
+      </p>
+      <p class="verdict-line" data-outcome="waiting">
+        <span class="verdict-mark">&hellip;</span>
+        <span>Karşılaştırmak için <b data-slot="algorithm"></b> hesaplanıyor.</span>
+      </p>
+      <p class="verdict-line" data-outcome="nofile">
+        <span class="verdict-mark">&hellip;</span>
+        <span>Yukarıdan bir dosya seçin, eşleşip eşleşmediğini burası söylesin.</span>
+      </p>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/hash-checksum.toml
+++ b/locales/tr/tools/hash-checksum.toml
@@ -1,0 +1,352 @@
+#
+# Özet ve Sağlama Toplamı - Türkçe.
+#
+# Overrides for tools/hash-checksum/tool.toml. Only words: the slug, the
+# category, the icon and the list of shared parts stay where they are.
+#
+# Algoritma adları, komut adları (sha256sum, certutil), dosya adları
+# (SHA256SUMS) ve integrity özniteliği Latin harflerinde kalıyor: bunlar
+# yazılan ve aranan şeyler.
+#
+
+name = "Özet ve Sağlama Toplamı"
+heading = "Özet&nbsp;ve&nbsp;sağlama&nbsp;toplamı <span class=\"h1-kw\">&mdash; MD5, SHA-1, SHA-256, SHA-512</span>"
+tagline = "Bir indirmeyi, yayıncının bastığı sayıya karşı, kimseye göndermeden denetleyin."
+
+title = "SHA-256 ve MD5 Sağlama Toplamı Aracı &mdash; Bir İndirmeyi Doğrulayın, Yüklemesiz"
+description = "Herhangi bir dosyanın MD5, SHA-1, SHA-256, SHA-384 ya da SHA-512 değerini hesaplayın ve indirme sayfasının yayımladığı sağlama toplamıyla karşılaştırın. Dosya tarayıcınızda okunur ve hiçbir boyutta yüklenmez."
+og_title = "Bir indirmeyi kimseye yüklemeden doğrulayın"
+og_description = "MD5, SHA-1, SHA-256, SHA-384 ve SHA-512, kendi tarayıcınızda hesaplanır. Yayıncının bastığı sağlama toplamını yapıştırın, sayfa eşleşip eşleşmediğini söylesin. Boyut sınırı yok, çünkü dosya parçalar hâlinde okunur."
+og_image_alt = "Özet ve Sağlama Toplamı - bir indirmeyi tarayıcınızda doğrulayın, yükleme yok"
+
+pledge = """
+    Bir sağlama toplamı, dosyanızın baytları üzerinde yapılan bir hesaptır ve
+    burada, bu sayfada, kendi işlemcinizde yapılır. Dosya diskinizden dört
+    megabaytlık parçalar hâlinde okunur ve her parça sayılır sayılmaz atılır;
+    yani hiçbir şey hiçbir yerde bir araya getirilmez &mdash; ne bellekte, ne de
+    elbette bir sunucuda. Buradaki herhangi bir şey istese bile bu sayfanın öbür
+    ucunda bir dosyanın gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir dosya denetleyin. Tek bir istek bile ondan tek bir bayt,
+      adını ya da boyutunu taşımıyor. Ya da internet bağlantısını kesip yine de
+      bir tanesini denetleyin."""
+
+read_first = """
+, dört sıkıştırma işlevi için <code>src/md5.js</code>,
+      <code>src/sha1.js</code>, <code>src/sha256.js</code> ve
+      <code>src/sha512.js</code>, paylaştıkları dolgu için
+      <code>src/blocks.js</code> ve dosyanızı parçalar hâlinde okuyan döngü için
+      <code>src/hash.js</code> &mdash; hiçbirinde ağa erişebilecek tek bir satır
+      yok."""
+
+howto_heading = "Bir indirme, sağlama toplamına karşı nasıl denetlenir"
+
+card = """
+            Bir dosyanın MD5, SHA-1, SHA-256, SHA-384 ya da SHA-512 değerini
+            hesaplayın ve indirme sayfasının bastığıyla karşılaştırın. Her
+            boyutta: dosya parçalar hâlinde okunur, hiçbir zaman bütün olarak
+            tutulmaz."""
+
+[words]
+plural = "dosyalarınız"
+choose = "bir dosya"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Boyut sınırı yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "Dosyanızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyanızın toplanabileceği bir uç nokta burada yok,
+      olsaydı bile onu oraya gönderecek bir kod yok. Burada eskiden
+      <code>connect-src 'none'</code> yazıyordu ki bu mutlaktı; reklam eklemek
+      buna mal oldu ve bunu söylemek anlaşmanın bir parçası."""
+
+[[privacy]]
+title = "Dosya hiçbir boyutta bütün olarak tutulmaz."
+body = """
+
+      Dört megabaytlık parçalar hâlinde okunur ve her parça yürüyen duruma
+      katılıp bırakılır. Yani bu sayfanın kullandığı bellek, kırk gigabaytlık bir
+      disk imajı için de bir metin dosyası için de aynıdır ve pes ettiği bir
+      boyut yoktur. Tarayıcının kendi <code>crypto.subtle.digest</code>
+      çağrısının kullanılmamasının sebebi de budur: o, dosyanın tamamını bir
+      seferde bellekte ister ki bu araç tam da bu tavana sahip olmamak için
+      var."""
+
+[[privacy]]
+title = "Beş algoritma, bu depoda beş dosya."
+body = """
+ <code>src/md5.js</code>,
+      <code>src/sha1.js</code>, <code>src/sha256.js</code> ve
+      <code>src/sha512.js</code>, yayımlanmış şartnamelerin yazıya dökülmüş
+      hâlidir; her biri yaklaşık altmış satır ve sabit tabloları hesaplanmak
+      yerine tek tek yazılmış, böylece cevapla ilgili hiçbir şey tarayıcınıza
+      bağlı olamaz. Her biri, yayımlanmadan önce resmî test vektörlerine ve
+      işletim sisteminin kendi uygulamasına karşı denetlenir."""
+
+[[privacy]]
+title = "Yapıştırdığınız sağlama toplamı da hiçbir yere gönderilmez."
+body = """
+
+      Burada, sayfada, burada hesaplanan özetle karşılaştırılır.
+      Karşılaştırmayla ilgili hiçbir şey &mdash; ne değer, ne eşleşip
+      eşleşmediği, ne de dosyanın adı &mdash; kimseye okunmaz. Bu kulağa
+      geldiğinden daha önemli: bir sağlama toplamı artı bir dosya adı, onu
+      toplayana hangi yazılımın hangi sürümünü az önce indirdiğinizi tam olarak
+      söyler."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine dosyanız hakkında bir şey verilmiyor: ne
+      dosya, ne adı, ne boyutu, ne de özetlerden herhangi biri. Bir baytı okuyan
+      ya da özetleyen her satır bu kaynaktan sunuluyor ve depoda
+      listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de dosyalarınız
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfanın her
+      parçası çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu:
+      dosyanızı özetlenmek üzere uzağa gönderen bir araç, siz fişi çeker çekmez
+      dururdu."""
+
+[[howto]]
+title = "Dosyayı seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin. Doğrudan
+      diskinizden parçalar hâlinde okunur; siz bunu yaparken hiçbir yere hiçbir
+      şey gönderilmez ve sayfanın pes ettiği bir boyut yoktur."""
+
+[[howto]]
+title = "Okumasını bekleyin."
+body = """
+ MD5 ve SHA-256 varsayılan olarak, tek bir
+      geçişte hesaplanır. Çubuk, dosyanın ne kadarında olduğunu ve bunun ne
+      hızda gittiğini gösterir &mdash; büyük bir disk imajı, kopyalamak kadar
+      sürer, çünkü aynı miktarda okuma yapılır."""
+
+[[howto]]
+title = "Ne olması gerektiğini yapıştırın."
+body = """
+ İndirme sayfası size ne
+      verdiyse, hangi şekilde verdiyse: düz onaltılık, bir
+      <code>sha256sum</code> çıktısı satırı, bütün bir
+      <code>SHA256SUMS</code> dosyası ya da bir betik etiketinden alınmış
+      <code>integrity</code> özniteliği. Hangi algoritma olduğu uzunluğundan
+      anlaşılır ve doğru kutu kendini işaretler."""
+
+[[howto]]
+title = "Rengi değil cevabı okuyun."
+body = """
+ Sayfa, bunun o sağlama
+      toplamının tarif ettiği dosya olup olmadığını bir cümleyle söyler. Eşleşme,
+      baytların yayıncının ölçtüğü baytlarla aynı olduğu anlamına gelir.
+      Eşleşmeme ise aynı olmadıkları anlamına gelir ve indirme, açılmadan önce
+      yeniden alınmalıdır."""
+
+[[howto]]
+title = "Gerekiyorsa sağlama toplamlarını alın."
+body = """
+
+      Birini kopyalayın, hepsini kopyalayın ya da komut satırı araçlarının
+      yazdığı etiketli biçimde küçük bir metin dosyası olarak kaydedin; böylece
+      algoritma sayıyla birlikte yolculuk eder."""
+
+[[faq]]
+q = "Dosyam herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi tarayıcınız tarafından diskinizden okunur ve kendi
+        işlemcinizde, dört megabaytlık parçalar hâlinde özetlenir. Bu aracın
+        sunucu tarafı yoktur ve sayfanın <code>Content-Security-Policy</code>'si
+        iletişim kurabileceği her adresi tek tek sayar &mdash; bunların hiçbiri
+        bu siteye ait değildir. Ağ bağlantısını kesin, yine de çalışır."""
+
+[[faq]]
+q = "Boyut sınırı var mı?"
+a = """
+        Hayır. Dosya hiçbir zaman bütün olarak tutulmaz: parçalar hâlinde okunur
+        ve her parça sayılıp bırakılır; yani kırk gigabaytlık bir disk imajı, bir
+        metin dosyasıyla aynı birkaç megabayt belleği kullanır. Maliyeti
+        zamandır ve sayfa ilerledikçe bunun ne kadar olduğunu söyler.
+        <br><br>
+        Algoritmaların, daha hızlı olacak olan tarayıcının kendi
+        <code>crypto.subtle.digest</code> çağrısına verilmek yerine burada
+        yazılmış olmasının sebebi de budur. O çağrı mesajın tamamını tek bir
+        arabellekte alır ve ona bir dosyayı parçalar hâlinde vermenin yolu
+        yoktur; yani onu kullanmak, denetleyebileceğiniz en büyük dosyayı bu
+        sekmenin ne kadar belleğe izin verildiğinin insafına bırakırdı. Bir
+        telefonda bu birkaç yüz megabayttır ve insanların en çok denetlemek
+        istediği dosya bir disk imajıdır."""
+
+[[faq]]
+q = "Sağlama toplamı eşleşti. Bu aslında neyi kanıtladı?"
+a = """
+        Diskinizdeki baytların, o sayıyı yazan kişinin ölçtüğü baytlar olduğunu.
+        Daha fazlasını değil ve sınırları konusunda kesin olmaya değer.
+        <br><br>
+        İndirmenin yarıda kesilmediğini, bozuk bir diskten zarar görmediğini ya
+        da yolda başka bir şeyle değiştirilmediğini kanıtlar. Dosyanın güvenli
+        olduğunu <strong>kanıtlamaz</strong>, çünkü bir yayıncı zararlı bir
+        yazılımı da diğer her şey kadar doğru ölçebilir. Ve sağlama toplamı,
+        dosyayla aynı sayfadan, aynı bağlantı üzerinden geldiyse çok az şey
+        kanıtlar: birini değiştirebilen, diğerini de değiştirebilirdi. Bir
+        sağlama toplamı en çok, size farklı bir yoldan ulaştığında değerlidir
+        &mdash; imzalı bir <code>SHA256SUMS</code> dosyası, bir dağıtımın sürüm
+        duyurusu, ikinci bir yansı ya da onu zaten bilen bir paket yöneticisi."""
+
+[[faq]]
+q = "Eşleşmedi. Şimdi ne olacak?"
+a = """
+        Önce onu aynı yerden yeniden indirin. Yarıda kesilmiş ya da devam
+        ettirilmiş bir aktarım, en yaygın sebeptir ve ikinci bir kopya genelde
+        meseleyi çözer.
+        <br><br>
+        İkinci kopya da aynı yanlış cevabı veriyorsa doğru satırla
+        karşılaştırdığınızdan emin olun: sürüm sayfaları birkaç dosya listeler ve
+        ARM sürümünün sağlama toplamı x86 sürümüyle asla eşleşmez. Sonra sürüm
+        numarasını denetleyin. Bunların hepsi doğruysa ve yine eşleşmiyorsa
+        dosyayı açmayın. Onu başka bir yansıdan alın ve iki sağlama toplamını
+        birbiriyle karşılaştırın."""
+
+[[faq]]
+q = "Hangisini kullanmalıyım?"
+a = """
+        Yayıncı hangisini bastıysa onu. Bu işin bütün amacı onların sayısıyla
+        karşılaştırmaktır ve onlarınkini onlar adına siz seçemezsiniz.
+        <br><br>
+        Bir sağlama toplamını denetlemek yerine üretiyorsanız SHA-256 kullanın.
+        MD5 ve SHA-1, önemli olan anlamda kırıktır: aynı özete sahip iki farklı
+        dosya bilerek üretilebilir; MD5'te saatler içinde, SHA-1'de ise makul bir
+        masrafla. Bu, onları kazalara karşı işe yaramaz yapmaz &mdash; yarıda
+        kesilmiş bir indirme, orijinaliyle tesadüfen çakışmaz &mdash; ama hiçbiri
+        size kimsenin karışmadığını söyleyemez demektir. SHA-384 ve SHA-512
+        gayet iyidir ve pratikte daha iyi değildir; burada olmalarının sebebi
+        bazı projelerin onları yayımlamasıdır."""
+
+[[faq]]
+q = "MD5 kırıksa neden burada?"
+a = """
+        Çünkü hâlâ basılan şey o. Yansılar, donanım yazılımı indirmeleri,
+        üniversite yazılım sayfaları ve pek çok üretici sitesi yirmi yıl önce bir
+        MD5 yayımladı ve o sayfaya bir daha bakmadı; bir tane hesaplamayı
+        reddeden bir araç, ziyaretçilerinin gerçekten geldiği soruyu yanıtlamayı
+        reddediyor olurdu.
+        <br><br>
+        Bunun yerine yapabileceği şey, cevabın ne değerde olduğunu söylemektir;
+        onay kutusunun yanındaki notun yaptığı da budur. Eşleşen bir MD5, bozuk
+        bir indirmeyi hâlâ eler. Kasıtlı bir tanesini elemez."""
+
+[[faq]]
+q = "Karşılaştırma kutusuna hangi biçimleri yapıştırabilirim?"
+a = """
+        Alışıldık olanların hepsini ve hangisinin hangisi olduğunu kendisi
+        çıkarır.
+        <br><br>
+        Aralarında boşluk olsun olmasın düz onaltılık. Bir <code>md5sum</code> ya
+        da <code>sha256sum</code> çıktısı satırı, arkasında dosya adıyla. Kırk
+        satırlık bütün bir <code>SHA256SUMS</code> dosyası; bu durumda dosyanızı
+        adlandıran satır kullanılır. BSD biçimi,
+        <code>SHA256 (disk.iso) = &hellip;</code>. Önünde bir etiket, örneğin
+        <code>SHA-256: &hellip;</code>. Ve bir alt kaynak bütünlüğü özniteliği,
+        <code>sha384-&hellip;</code>; bu onaltılık değil base64'tür ve
+        karşılaştırılmadan önce çözülür.
+        <br><br>
+        Hangi algoritma olduğu uzunluğundan gelir: 32 onaltılık karakter bir MD5,
+        40 bir SHA-1, 64 bir SHA-256, 96 bir SHA-384 ve 128 bir SHA-512'dir.
+        İkisi aynı uzunlukta değildir, yani seçilecek bir şey ve yanlış
+        yapılacak bir şey yoktur."""
+
+[[faq]]
+q = "sha256sum ya da certutil ile aynı cevabı verir mi?"
+a = """
+        Evet, bayt bayt. Bunlar, yayımlanmış test vektörleri olan kesin
+        şartnamelerdir ve buradaki her algoritma her yapımda hem o vektörlere hem
+        de işletim sisteminin kendi uygulamasına karşı denetlenir.
+        <br><br>
+        Göreceğiniz tek fark sunumdur. Windows'un
+        <code>certutil -hashfile</code> komutu büyük harfle basar ve araya
+        boşluk koyar; bu sayfa küçük harfle basar ki neredeyse her yayıncının
+        kullandığı budur. Karşılaştırma ikisini de yok sayar, yani certutil'den
+        kopyalanmış bir sağlama toplamı, buraya yapıştırılmış küçük harfli bir
+        tanesiyle eşleşir."""
+
+[[faq]]
+q = "İki dosyayı birbirine karşı denetleyebilir miyim?"
+a = """
+        Evet, tek bir ek adımla: birincisini denetleyin, sağlama toplamını
+        kopyalayın, sonra ikincisini seçin ve o sağlama toplamını kutuya
+        yapıştırın. İki dosya aynıysa sayfa bunu söyler.
+        <br><br>
+        Bu, sağlama toplamlarının sessizce en iyi olduğu durum için bilinmeye
+        değer &mdash; yedek diskteki kopyanın gerçekten dizüstündekiyle aynı
+        dosya olup olmadığına karar vermek; ikisi de aynı boyutu ve aynı tarihi
+        iddia ederken."""
+
+[[faq]]
+q = "Dosyamı değiştiriyor mu?"
+a = """
+        Hayır. Bu araç yalnızca okur. Çıktı dosyası, yeniden kodlama ya da geri
+        yazılan bir şey yoktur &mdash; indirebileceğiniz tek şey, sağlama
+        toplamlarını listeleyen küçük bir metin dosyasıdır. Orijinaliniz
+        diskinizde el değmemiş durur; sekmeyi kapatırsanız ne olacağının dürüst
+        cevabı da budur."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok. Dosya boyutunda ve kaç
+        dosya denetlediğinizde bir sınır da yok. Sitede reklam var, masrafı
+        karşılayan da o; reklamlara dosyanız hakkında hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: dosyanızı özetlenmek üzere uzağa gönderen bir
+        araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Herhangi bir dosyanın MD5, SHA-1, SHA-256, SHA-384 ya da SHA-512 sağlama toplamını tarayıcıda hesaplayın ve bir indirme sayfasının yayımladığı değerle karşılaştırın. Dosya parçalar hâlinde okunur ve hiçbir zaman yüklenmez."
+features = [
+  "MD5, SHA-1, SHA-256, SHA-384 ve SHA-512, dosya üzerinde tek geçişte",
+  "Boyut sınırı yok: dosya parçalar hâlinde okunur ve hiçbir zaman bütün olarak tutulmaz",
+  "Beklenen değeri yayımlanmış herhangi bir biçimde yapıştırın; hangi algoritma olduğunu kendisi çıkarır",
+  "sha256sum çıktısını, SHA256SUMS dosyalarını, BSD etiketli biçimi ve integrity özniteliklerini okur",
+  "Dosyanın eşleşip eşleşmediğini yalnızca bir renkle değil bir cümleyle söyler",
+  "Bir sağlama toplamını, hepsini kopyalayın ya da etiketli bir metin dosyası olarak kaydedin",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, dosyanızda değişiklik yok",
+]
+
+[picker]
+title = "Bir dosyayı buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; her dosya, her boyut, hiçbir şey yüklenmez"

--- a/locales/tr/tools/heic-to-jpg.html
+++ b/locales/tr/tools/heic-to-jpg.html
@@ -1,0 +1,131 @@
+<!--
+  tools/heic-to-jpg/body.html, in Turkish.
+
+  Every id, class, option value and data-phrase key below is what src/main.js
+  and the frame reach for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosyalar -->
+  <section class="card">
+    <h2><span class="step">1</span> HEIC fotoğraflarınızı seçin</h2>
+
+    <p class="card-lede">
+      Doğrudan telefondan, bir yedekten ya da bir hafıza kartından kopyalanmış
+      hâlde. Dosya burada, bu makinede okunur ve resim de burada çözülür &mdash;
+      bu sayfada bir yükleme adımı ve arkasında bir sunucu yoktur.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Hepsini listeden çıkar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; ne çıkacağı -->
+  <section class="card" id="options-card">
+    <h2><span class="step">2</span> Ne istediğinizi söyleyin</h2>
+
+    <fieldset class="options">
+      <legend>Biçim</legend>
+
+      <div class="option-row">
+        <label for="format-select">Resimleri şu olarak yaz</label>
+        <select id="format-select">
+          <option value="image/jpeg" selected>JPEG &mdash; her yerde açılır, yanlışlıkla bu yüzyılda yapılmış şeylerde bile</option>
+          <option value="image/png">PNG &mdash; kayıpsız ve birkaç kat büyük</option>
+          <option value="image/webp">WebP &mdash; aynı kalitede JPEG'den küçük, yalnızca modern tarayıcılarda</option>
+        </select>
+      </div>
+
+      <div class="option-row" id="quality-row">
+        <label for="quality">Kalite</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="50" max="100" step="1" value="92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Fotoğraf ayrıntıları</legend>
+
+      <label class="check">
+        <input type="checkbox" id="keep-exif" checked>
+        <span>
+          <strong>Tarihi, kamerayı ve ayarları koru</strong>
+          <span class="check-note">
+            Telefonun yazdığı hâliyle tam olarak kopyalanır; böylece
+            dönüştürülmüş fotoğraf, dönüştürüldüğü güne göre değil çekildiği güne
+            göre sıralanmaya devam eder. Fotoğrafta varsa GPS koordinatları da
+            buna dahildir &mdash; yukarıdaki liste sizinkilerden hangisinde
+            olduğunu söyler. Bunu kapatın, JPEG resimden başka hiçbir şey
+            içermeden çıksın.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary">
+        Her iki durumda da buradaki hiçbir şey kimseye okunmaz: seçim, bu
+        sayfanın onunla ne yaptığıyla değil geri aldığınız dosyaya neyin
+        gireceğiyle ilgilidir. Etiketleri ayrıntılı gözden geçirmek ya da zaten
+        JPEG olan fotoğraflardan onları silmek isterseniz
+        <a href="../exif-verisi-silme/">EXIF Görüntüleyici ve Silici</a> bunun
+        aracıdır.
+      </p>
+    </fieldset>
+  </section>
+
+  <!-- Adım 3 &mdash; tek tıklama -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Dönüştürün</h2>
+
+    <div class="run-row">
+      <button type="button" id="convert-all" class="primary big" disabled>Dönüştür</button>
+    </div>
+
+    <!--
+      The decoder's own status line. This page is the only one on the site that
+      carries a codec, so it is the only one with anything to report here, and
+      saying where the megabyte came from is the point: it is served from this
+      origin, it is cached with the rest of the page, and it is what makes the
+      offline promise hold on a browser that cannot open a HEIC at all.
+    -->
+    <p id="engine-status" class="engine-status" role="status" aria-live="polite"></p>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Dönüştürüldü</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Hepsini zip olarak indir</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The frame's "offline" line says only that this page keeps working. What is
+    worth saying here is what that covers: the HEIC decoder is a vendored
+    WebAssembly engine, and it is cached with the rest. A key defined here wins
+    over the frame's one - see shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="offline.ready">hazır &mdash; çözücü de önbelleğe alındı,
+      yani bu, ağ bağlantısı kesikken de çalışır.</span>
+  </div>
+</main>

--- a/locales/tr/tools/heic-to-jpg.toml
+++ b/locales/tr/tools/heic-to-jpg.toml
@@ -1,0 +1,298 @@
+#
+# HEIC'ten JPG'ye - Türkçe.
+#
+# Overrides for tools/heic-to-jpg/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# libheif, WebAssembly, Emscripten ve 'wasm-unsafe-eval' olduğu gibi kalıyor:
+# birincisi bir kitaplığın adı, sonuncusu ise okuyucunun sayfanın kaynağında
+# harfi harfine arayacağı bir anahtar kelime.
+#
+
+name = "HEIC'ten JPG'ye"
+heading = "HEIC'ten&nbsp;JPG'ye <span class=\"h1-kw\">&mdash; iPhone fotoğraflarını dönüştürün</span>"
+tagline = "Bir iPhone'un ürettiği fotoğraflar, her şeyin açtığı bir biçimde."
+
+title = "HEIC'ten JPG'ye Dönüştürücü &mdash; Ücretsiz, Yüklemesiz"
+description = "iPhone HEIC fotoğraflarını tarayıcınızda JPG'ye dönüştürün. Çözücü kendi makinenizde çalışır: hiçbir şey yüklenmez, hesap gerekmez, çevrimdışı çalışır ve tarih ile kamera ayrıntıları da gelebilir."
+og_title = "HEIC fotoğrafları yüklemeden JPG'ye çevirin"
+og_description = "Fotoğraflarınızı istemeyen dönüştürücü. HEIC çözücüsü bu sayfadan sunulur ve kendi makinenizde çalışır; yani resimler oradan hiç ayrılmaz."
+og_image_alt = "HEIC'ten JPG'ye - iPhone fotoğrafları, her şeyin açtığı bir biçimde"
+
+pledge = """
+    Çözme işi kendi tarayıcınızda, kendi donanımınızda çalışır. HEIC, bir
+    tarayıcının kendi başına açmayacağı tek resim biçimidir; bu yüzden bu sayfa
+    çözücüyü yanında taşır &mdash; yaklaşık 1,4 MB, bu siteden sunulur ve ilk
+    ziyaretten sonra önbelleğe alınır. Diğer her HEIC dönüştürücüsünün sizden
+    yükleme istemesinin bütün sebebi budur: kodlayıcıyı bir sunucuya koydular ve
+    fotoğraflarınızın oraya gitmesi gerekiyor. Bu araç ise kodlayıcıyı buraya
+    koyuyor. Bu sayfada hiçbir türde ağ özelliği yok ve öbür ucunda bir
+    fotoğrafın gönderilebileceği bir sunucu da yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir fotoğraf dönüştürün. Bu sayfanın kendi dosyalarının
+      yüklendiğini, aralarında çözücüyü de göreceksiniz; ve tek bir istek bile bir
+      fotoğraf, bir küçük resim, bir dosya adı ya da seçtiğiniz şeyden tek bir
+      bayt taşımayacak. Ya da sayfayı bir kez yükleyin, internet bağlantısını
+      kesin ve bir klasör dolusunu yine de dönüştürün."""
+
+read_first = """
+, çözücünün nasıl yüklendiği ve neye izin verildiği için
+      <code>src/heif.js</code>, fotoğrafın üst verisini bulan kap ayrıştırması
+      için <code>src/boxes.js</code> ve o üst veriye bir JPEG'e girerken ne
+      olduğu için <code>src/exif.js</code>. Motorun kendisi
+      <code>vendor/libheif.js</code>'tir; değiştirilmemiş hâlde ve lisansı
+      yanında."""
+
+howto_heading = "HEIC fotoğrafları JPG'ye nasıl dönüştürülür"
+
+card = """
+            Bir iPhone'un ürettiği fotoğraflar, her şeyin açtığı bir biçimde
+            &mdash; birinin sunucusunda değil kendi makinenizde çözülmüş
+            hâlde."""
+
+[words]
+plural = "fotoğraflar"
+choose = "bir fotoğraf"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Boyut sınırı yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Fotoğraflarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Çözücü buradan geldi ve hiçbir yere gitmiyor."
+body = """
+ HEIC, bir kap
+      biçimi içindeki HEVC'dir ve Safari dışında hiçbir tarayıcı onu çözmez; bu
+      yüzden bu sayfa <code>libheif</code>'in WebAssembly'ye derlenmiş hâlini
+      taşır &mdash; yaklaşık 1,4 MB, bu depoya işlenmiş, bu kaynaktan sunulan ve
+      buradaki diğer her dosya gibi hizmet çalışanı tarafından önbelleğe alınan
+      bir dosya. Bir CDN'den getirilmiyor, çünkü bu her ziyaretin yoluna üçüncü
+      bir tarafı koyardı ve aracın çevrimdışı çalışmasını engellerdi. İkili
+      dosyanın betiğin yanında değil içinde olmasının sebebi de tam olarak
+      budur: onu başlatmak için hiçbir getirme gerekmesin diye."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araç için yazılmış hiçbir
+      dosyada <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Beraberinde gelen motor, her Emscripten
+      derlemesi gibi, bir <code>.wasm</code> dosyasını bir adresten getirecek
+      yükleyici yollarını içerir; onlara girilmiyor, çünkü ikili dosya zaten
+      elde &mdash; ve girilseydi bile <code>connect-src</code> yalnızca
+      Google'ın ölçüm uç noktalarını sayar, dolayısıyla tarayıcı bunu
+      reddederdi. Kanıt söz değil, politikadır."""
+
+[[privacy]]
+title = "Üst veri burada okunuyor ve size bildiriliyor."
+body = """
+ Sayfadaki liste
+      her fotoğrafın ne taşıdığını söyler &mdash; tarih, kamera ve içinde GPS
+      koordinatı olup olmadığı &mdash; çünkü bu, JPEG'i birine vermeden önce
+      bilmek isteyebileceğiniz bir şeydir. Dosyadan bu tarayıcıda
+      <code>src/boxes.js</code> tarafından okunur, bu sayfada gösterilir ve
+      tümüyle sizin seçiminize göre JPEG'inize yazılır ya da dışarıda bırakılır.
+      Bu depoda bir dosya adı, bir tarih, bir koordinat ya da bir sayı taşıyan
+      özel bir analitik olayı yoktur."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine
+      fotoğraflarınız hakkında bir şey verilmiyor. Bir dosyayı okuyan, çözen ya
+      da yazan her satır bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Sayfayı bir kez yükleyin ve ağ bağlantısını
+      kesin; araç hiç değişmez &mdash; çözücü de onunla birlikte önbelleğe
+      alınmıştır. Hepsinin içindeki en basit kanıt bu ve burada bu sitenin
+      herhangi bir yerinden daha güçlü: fotoğraflarınızı çözülmek üzere uzağa
+      gönderen bir dönüştürücü bunu asla başaramazdı."""
+
+[[howto]]
+title = "HEIC fotoğraflarınızı seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin;
+      doğrudan bir telefon yedeğinden ya da masaüstündeki bir klasörden.
+      Tarayıcı onları diskinizden okur; siz bunu yaparken hiçbir yere hiçbir şey
+      gönderilmez. Liste, her birinin ne olduğunu ve içinde ne bulunduğunu
+      söyler."""
+
+[[howto]]
+title = "Fotoğrafların ne taşıdığını denetleyin."
+body = """
+ Her satır çekildiği tarihi,
+      kamerayı ve &mdash; fark edilmeye değer kısım olduğu için yeşil renkte
+      &mdash; dosyanın GPS koordinatı taşıyıp taşımadığını adıyla söyler. Bu,
+      resim çözülmeden kaptan okunur; yani hiçbir şeye mal olmaz ve hemen
+      görünür."""
+
+[[howto]]
+title = "Bir biçim seçin ve ayrıntılara karar verin."
+body = """
+ Bir sebebiniz yoksa
+      JPEG: her yerde açılan biçim odur ve dönüştürmenin bütün amacı da budur.
+      Kalite kaydırıcısı 92'dedir; bir fotoğrafın orijinalinden ayırt edilmesinin
+      zor olduğu ayar budur. Onay kutusu ise tarihin, kameranın ve konumun
+      birlikte gelip gelmeyeceğine karar verir."""
+
+[[howto]]
+title = "\"Dönüştür\"e basın ve indirin."
+body = """
+ Çözücü ilk dönüştürmede gelir
+      &mdash; yaklaşık 1,4 MB, bir kez &mdash; ve ondan sonraki her fotoğraf
+      kendi makinenizde çözülüp yazılır. Tek dosya size bir indirme düğmesi
+      verir; birkaç dosya ayrıca bir zip verir."""
+
+[[faq]]
+q = "Fotoğrafım herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        çözülür ve yazılır. Bu aracın hiçbir türde ağ özelliği yoktur &mdash;
+        hiçbir zaman bir şey getirmez ve hiçbir zaman bir şey göndermez &mdash;
+        ve sayfanın <code>Content-Security-Policy</code>'si iletişim
+        kurabileceği her adresi tek tek sayar; bunların hiçbiri bu siteye ait
+        değildir. Yüklenen tek şey çözücünün kendisidir ve o da bu siteden, bir
+        kez ve fotoğrafınız işin içine girmeden önce gelir."""
+
+[[faq]]
+q = "Bu sayfa ilk seferde neden 1,4 MB indiriyor?"
+a = """
+        Çünkü HEIC, bir tarayıcının açmayacağı tek resim biçimidir. Bir kap
+        içindeki bir HEVC karesidir ve yalnızca Apple donanımındaki Safari'nin
+        onun için bir çözücüsü vardır; Chrome, Firefox ve Edge dosyayı öylece
+        reddeder. Yani bir HEIC dönüştürücüsünün bir yerden çözücüye ihtiyacı
+        vardır ve gelebileceği iki yer vardır: bir sunucu ya da sayfa. Diğer her
+        dönüştürücü sunucuyu seçti; hepsinin fotoğraflarınızın yüklenmesine
+        ihtiyaç duymasının sebebi tam olarak budur. Bu araç ise bunun yerine
+        <code>libheif</code>'in WebAssembly'ye derlenmiş hâlini taşır. Bu siteden
+        sunulur, ilk ziyaretten sonra önbelleğe alınır ve fotoğraflarınızın
+        hiçbir yere gitmemesinin bedelinin tamamıdır."""
+
+[[faq]]
+q = "JPEG tarihi, kamerayı ve konumu koruyor mu?"
+a = """
+        İsterseniz evet ve bu, sayfadaki bir onay kutusudur. Açık bırakılırsa
+        EXIF bloğu HEIC'ten kopyalanır ve telefonun yazdığı hâliyle tam olarak
+        JPEG'e yazılır; böylece dönüştürülmüş fotoğraf, dönüştürüldüğü güne göre
+        değil çekildiği güne göre sıralanır &mdash; ki HEIC dönüştürücüleriyle
+        ilgili olağan şikâyet de budur. Tek bir etiket değişir ve yalnızca o:
+        &laquo;dik&raquo; olarak ayarlanan yön etiketi; çünkü dönüş piksellere
+        zaten uygulanmıştır ve onu bir kez daha uygulayan bir görüntüleyici her
+        dikey fotoğrafı yan yatırırdı. Onay kutusunu kapatın; JPEG resimle
+        birlikte ve başka hiçbir şey olmadan çıksın."""
+
+[[faq]]
+q = "GPS koordinatlarını siliyor mu?"
+a = """
+        Orada olduklarını size söyler, sonra ne isterseniz onu yapar. Her
+        fotoğrafın satırı, siz bir şey dönüştürmeden önce dosyanın koordinat
+        taşıyıp taşımadığını söyler ki bu, telefonun yaptığından fazlasıdır.
+        "Tarihi, kamerayı ve ayarları koru"nun işaretini kaldırmak, onları diğer
+        her şeyle birlikte JPEG'in dışında bırakır; işaretli bırakmak onları
+        karşıya taşır. İstediğiniz şey etiketleri ayrıntılı gözden geçirmek ya da
+        zaten JPEG olan fotoğraflardan onları silmekse
+        <a href="../exif-verisi-silme/">EXIF Görüntüleyici ve Silici</a> bunun
+        aracıdır ve bunu resmi yeniden sıkıştırmadan yapar."""
+
+[[faq]]
+q = "Resim yeniden sıkıştırılıyor mu?"
+a = """
+        Evet ve öyle olmak zorunda: HEIC ve JPEG farklı kodlayıcılardır, yani
+        birinden diğerine resmi çözüp yeniden kodlamadan geçmenin yolu yoktur.
+        Denetleyebildiğiniz şey bunun ne kadara mal olacağıdır. Kalite kaydırıcısı
+        varsayılan olarak 92'dedir; bu değerde bir fotoğrafı orijinalinden ayırmak
+        çok zordur. Hiç kayıp istemediğiniz ve dosyanın beş ila on kat büyük
+        olmasını umursamadığınız durum için de menüde PNG vardır."""
+
+[[faq]]
+q = "Dosyanın adı .jpg ama aslında HEIC ise ne olur?"
+a = """
+        Yine çalışır. Buraya bırakılan her dosya adıyla değil ilk baytlarıyla
+        tanınır; çünkü ad, dosyaya en son dokunan uygulamanın ona ne demeye karar
+        verdiğidir &mdash; ve ".jpg" adıyla gelmiş bir HEIC, insanların böyle bir
+        aracı aramaya başlamasının en yaygın yollarından biridir. Gerçekten JPEG
+        ya da PNG olan bir dosya, kendisinin bir kopyasına dönüştürülmek yerine
+        bunu söyleyen bir mesajla geri çevrilir."""
+
+[[faq]]
+q = "Bir Live Photo'yu ya da bir seri çekimi dönüştürebilir mi?"
+a = """
+        İçindeki hareketsiz resimleri evet. Bir HEIC birden fazla resim tutabilir
+        ve tuttuğu her biri dönüştürülüp orijinal adının sonuna bir numara
+        eklenerek adlandırılır. Bir Live Photo'nun video yarısı, telefonun HEIC'in
+        yanında tuttuğu ayrı bir dosyadır; yani burada dönüştürülecek hâlde
+        değildir. Derinlik haritaları ve küçük resimler kabın içindedir ama
+        kimsenin istediği resimler değildir ve olduğu gibi bırakılır."""
+
+[[faq]]
+q = "AVIF dosyamı neden almıyor?"
+a = """
+        Çünkü ona yapılacak bir şey yok. AVIF, HEIC ile aynı kaptır; içinde HEVC
+        yerine AV1 vardır ve her güncel tarayıcı bir tanesini yerel olarak çözer
+        &mdash; yani bir dönüştürücü, sizde olmayan bir sorunu çözmek için bir
+        megabaytlık motor taşıyor olurdu. Bir AVIF'i JPEG olarak istiyorsanız
+        <a href="../resim-sikistirma/">Görsel Sıkıştırıcı</a> ve
+        <a href="../resim-boyutlandirma/">Görsel Boyutlandırıcı</a>, ikisi de
+        tarayıcınızın zaten sahip olduğu çözücüyü kullanarak AVIF okur ve JPEG
+        yazar."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok.
+        Dosyaların sayısında ya da boyutunda da bir sınır yok, çünkü bunların
+        bedelini ödeyen bir sunucu yok &mdash; iş sizin kendi cihazınızda oluyor.
+        Sitede reklam var, masrafı karşılayan da o; reklamlara fotoğraflarınız
+        hakkında hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet, çözücüsüyle birlikte. Sayfayı bir kez yükleyin, sonra internet
+        bağlantısını kesin; fotoğraflarınız üzerinde tam olarak eskisi gibi
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğine dair
+        var olan en güçlü kanıt: HEIC'lerinizi çözülmek üzere uzağa gönderen bir
+        dönüştürücü, siz fişi çeker çekmez dururdu; bu ise durmuyor."""
+
+[schema]
+description = "Bir iPhone'dan gelen HEIC ve HEIF fotoğrafları JPEG, PNG ya da WebP'ye dönüştürün. HEIC çözücüsü, sayfanın kendisinden sunulan WebAssembly'dir; yani resimler kendi makinenizde çözülür ve hiçbir zaman yüklenmez. Tarih, kamera ve konum JPEG'e taşınabilir ya da dışarıda bırakılabilir."
+features = [
+  "HEIC ve HEIF'i JPEG, PNG ya da WebP'ye dönüştürür",
+  "Yalnızca Safari'de değil, her tarayıcıda tarayıcı içinde çözer",
+  "Hiçbir şey yüklenmez ve araç ağ bağlantısı kesikken de çalışır",
+  "Tarihi, kamerayı ve GPS'i JPEG'e taşır ya da dışarıda bırakır",
+  "Hiçbir şey dönüştürülmeden önce hangi fotoğrafların GPS koordinatı taşıdığını söyler",
+  "Yön etiketini düzeltir, böylece dikey fotoğraflar yan çıkmaz",
+  "Dosyaları içeriklerine göre tanır, böylece .jpg adlı bir HEIC yine çalışır",
+  "Bir seri çekimdeki ya da Live Photo'daki yalnızca ilk resmi değil her resmi dönüştürür",
+  "Toplu işlem, tüm sonuçlar tek bir zip içinde",
+]
+
+[picker]
+title = "HEIC fotoğrafları buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; .heic ve .heif, adları ne olursa olsun"

--- a/locales/tr/tools/id-photo.html
+++ b/locales/tr/tools/id-photo.html
@@ -1,0 +1,250 @@
+<!--
+  tools/id-photo/body.html, in Turkish.
+
+  Every id, class, option value and data-phrase key below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; fotoğraf -->
+  <section class="card">
+    <h2><span class="step">1</span> Fotoğrafı seçin</h2>
+
+    <p class="card-lede">
+      Tarayıcınızın açabildiği her resim. Düz bir duvarın önünde, gün ışığında,
+      yaklaşık bir buçuk metreden çekilmiş bir telefon fotoğrafı, bu kuralların
+      çoğunun etrafında yazıldığı şeydir &mdash; ve doğrudan diskinizden okunur,
+      hiçbir yere gönderilmez.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="loaded" class="loaded-row" hidden>
+      <p id="loaded-name" class="loaded-name"></p>
+      <button type="button" id="clear-photo" class="ghost danger">Başkasını seç</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; kural -->
+  <section class="card" id="spec-card">
+    <h2><span class="step">2</span> Ülkeyi ve belgeyi seçin</h2>
+
+    <p class="card-lede">
+      Aşağıdaki her rakam, altında adı geçen kurumdan aktarılmış yayımlanmış
+      gerekliliktir. Bu listeyle ilgili hiçbir şey tahmin değildir ve hiçbir şey
+      getirilmez &mdash; <code>src/specs.js</code> içindeki bir tablodur ve
+      sayfayla birlikte sunulur.
+    </p>
+
+    <div class="option-row">
+      <label for="spec">Şartname</label>
+      <select id="spec"></select>
+    </div>
+
+    <dl class="spec-facts" id="spec-facts"></dl>
+
+    <ul class="spec-notes" id="spec-notes"></ul>
+
+    <p class="spec-source" id="spec-source"></p>
+
+    <!--
+      Only the "Anywhere else" entry unlocks these. A country's own numbers are
+      not editable on purpose: an editable rule is a rule somebody can quietly
+      break and then believe they met.
+    -->
+    <details class="custom-panel" id="custom-panel" hidden>
+      <summary>Kendiniz yazacağınız rakamlar</summary>
+      <div class="numbers">
+        <label>Genişlik (mm)<input type="number" id="custom-width" min="10" max="200" step="0.1" value="35"></label>
+        <label>Yükseklik (mm)<input type="number" id="custom-height" min="10" max="200" step="0.1" value="45"></label>
+        <label>DPI<input type="number" id="custom-dpi" min="72" max="1200" step="1" value="300"></label>
+      </div>
+      <div class="numbers">
+        <label>Kafa, en küçük (mm)<input type="number" id="custom-head-min" min="1" step="0.1" value="31.5"></label>
+        <label>Kafa, en büyük (mm)<input type="number" id="custom-head-max" min="1" step="0.1" value="36"></label>
+        <label>Arka plan
+          <select id="custom-background">
+            <option value="white">Düz beyaz</option>
+            <option value="off-white">Beyaz ya da kırık beyaz</option>
+            <option value="light-grey" selected>Düz açık gri</option>
+            <option value="cream">Açık gri ya da krem</option>
+          </select>
+        </label>
+      </div>
+      <div class="numbers">
+        <label>Yükleme genişliği (px)<input type="number" id="custom-px-width" min="20" max="4000" step="1" value="413"></label>
+        <label>Yükleme yüksekliği (px)<input type="number" id="custom-px-height" min="20" max="4000" step="1" value="531"></label>
+        <label>En küçük (KB)<input type="number" id="custom-min-kb" min="0" max="10000" step="1" value="0"></label>
+        <label>En büyük (KB)<input type="number" id="custom-max-kb" min="1" max="10000" step="1" value="200"></label>
+      </div>
+      <p class="hint-line">
+        Buradaki KB, 1024 bayt demektir; bu formların da kastettiği budur.
+      </p>
+    </details>
+  </section>
+
+  <!-- Adım 3 &mdash; çerçeveleme -->
+  <section class="card" id="frame-card">
+    <h2><span class="step">3</span> Yüzü işaretleyin ve çerçevelemeyi denetleyin</h2>
+
+    <p id="frame-empty" class="field-summary">Bir fotoğraf seçin, kırpma kutusu burada görünsün.</p>
+
+    <div id="frame-controls" hidden>
+      <p class="stage-hint" id="mark-hint">
+        Tepe, çene ve her iki bebek. Bir kuralın ölçtüğü şeyin tamamı bu dört
+        noktadır; yani kırpma, onlar nerede biterse oradan alınır &mdash; yanlış
+        düşenleri sürükleyin, sonra <strong>Kutuyu yerleştir</strong>'e basın.
+        Onları bulmak resmin kendisini okur: kafanızın arkasındaki duvara karşı
+        oluşan kenarı ve gözlerin bulunduğu daha koyu lekeleri. İçinde model yok
+        ve hiçbir şey getirilmiyor; bu bir hüküm değil bir başlangıç konumudur ve
+        düzeltmenin size ait olmasının ve alttaki panelin dört noktadan hangisini
+        ölçemediğini söylemesinin sebebi de budur.
+      </p>
+
+      <!--
+        Where the dots come from. Choosing "I'll place them" leaves them exactly
+        where they are and stops anything moving them again; moving one by hand
+        chooses it for you, because at that point they are yours.
+      -->
+      <div class="mark-mode" role="radiogroup" aria-label="Dört nokta nereden geliyor">
+        <label class="mark-mode-choice">
+          <input type="radio" name="mark-mode" id="mark-mode-auto" value="auto" checked>
+          <span>Benim için bul</span>
+        </label>
+        <label class="mark-mode-choice">
+          <input type="radio" name="mark-mode" id="mark-mode-manual" value="manual">
+          <span>Ben yerleştireceğim</span>
+        </label>
+      </div>
+
+      <p id="mark-note" class="hint-line" role="status" aria-live="polite"></p>
+      <ul id="mark-why" class="mark-why"></ul>
+
+      <!-- The crop box, its overlay and the four marks are all added here by
+           src/cropper.js and src/marks.js. The stage is given the picture's own
+           shape, so everything on it can be positioned in percentages. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <div class="frame-actions">
+        <button type="button" id="fit-box" class="primary">Kutuyu kurala yerleştir</button>
+        <button type="button" id="reset-marks" class="ghost">Yüzü yeniden bul</button>
+        <button type="button" id="whole-photo" class="ghost">Sığan en büyük kutu</button>
+      </div>
+
+      <p id="short-note" class="hint-line" hidden></p>
+
+      <!-- The live readout. Every line is measured from the box as it stands,
+           by the same function whether the box was fitted or dragged. -->
+      <ul class="checks" id="geometry-checks"></ul>
+
+      <p id="resample-note" class="field-summary"></p>
+    </div>
+  </section>
+
+  <!-- Adım 4 &mdash; arka plan -->
+  <section class="card" id="background-card">
+    <h2><span class="step">4</span> Arka plan</h2>
+
+    <p class="card-lede" id="background-lede">
+      Kırpmanın üst kısmındaki bir şeritten ve omuzların üstünde her iki yanından
+      okunur &mdash; kadrajın arka plandan başka bir şey olmaması gereken
+      bölümlerinden. RGB'de değil CIE Lab'da ölçülür; çünkü kırk RGB birimi
+      uzaktaki iki gri birbirinden ayırt edilemez, kırk birim mavi ise başka bir
+      renktir.
+    </p>
+
+    <div class="swatches" id="swatches" hidden>
+      <div class="swatch">
+        <span class="swatch-chip" id="swatch-found"></span>
+        <span class="swatch-label">Sizinki ne okunuyor<br><output id="swatch-found-text"></output></span>
+      </div>
+      <div class="swatch">
+        <span class="swatch-chip" id="swatch-wanted"></span>
+        <span class="swatch-label">Kuralın istediği<br><output id="swatch-wanted-text"></output></span>
+      </div>
+    </div>
+
+    <ul class="checks" id="background-checks"></ul>
+
+    <p class="field-note" id="background-note"></p>
+  </section>
+
+  <!-- Adım 5 &mdash; dosyalar -->
+  <section class="card" id="save-card">
+    <h2><span class="step">5</span> Kaydedin</h2>
+
+    <p class="card-lede" id="ready-line"></p>
+
+    <div class="settings">
+      <div class="field" id="dpi-field">
+        <label for="print-dpi">Baskı çözünürlüğü</label>
+        <select id="print-dpi">
+          <option value="300">300 dpi &mdash; neredeyse her kuralın belirttiği alt sınır</option>
+          <option value="600">600 dpi &mdash; iyi bir fotoğraf laboratuvarının kullanacağı</option>
+        </select>
+        <p class="field-note" id="dpi-note"></p>
+      </div>
+
+      <div class="field" id="paper-field">
+        <label for="paper">Basılacak sayfa</label>
+        <select id="paper"></select>
+        <p class="field-note" id="paper-note"></p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make" class="primary big" disabled>Dosyaları yap</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Bitti</h3>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+  <!--
+    The words script puts on the page, sitting in the markup so that a
+    translator meets them where they meet the rest of the page. The
+    `marks.why.*` lines are listed under the note, one line each, rather than
+    strung into the sentence: joining them would have meant a separator in the
+    JavaScript, and a semicolon is not the mark half these languages join with.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="marks.measured">Dördü de fotoğraftan ölçüldü &mdash; tepe
+      kafanızın dış hattından, bebekler kendi koyuluklarından, çene ise çene
+      hattının boyuna karıştığı yerden. Yine de denetleyin ve yanlış düşenleri
+      sürükleyin: kırpma, onların bittiği yerden alınır.</span>
+    <span data-phrase="marks.rough">Yerleştirildi ama hepsi ölçülmedi. Kutuyu
+      yerleştirmeden önce dört noktayı da denetleyin.</span>
+    <span data-phrase="marks.none">Bu fotoğrafta hiçbir şey ölçülemedi. Noktalar
+      bunun yerine açılış konumlarında duruyor &mdash; onları tepeye, çeneye ve
+      her iki bebeğe sürükleyin.</span>
+    <span data-phrase="marks.manual">Dört nokta sizin ve hiçbir şey onları
+      oynatmayacak. Her birini tepeye, çeneye ve bir bebeğe sürükleyin.</span>
+    <span data-phrase="marks.edited">Bir noktayı oynattınız, yani artık dördü de
+      sizin. &laquo;Benim için bul&raquo; resmi yeniden ölçer.</span>
+
+    <span data-phrase="marks.why.background">Arkanızdaki duvar, bir kafanın
+      kenarını bulacak kadar düz değil.</span>
+    <span data-phrase="marks.why.top">Kafa fotoğrafın üstünden taşıyor, yani
+      bulunacak bir tepe noktası yoktu.</span>
+    <span data-phrase="marks.why.eyes">Gözler seçilemedi, bu yüzden ikisi de bu
+      boyutta bir kafada genellikle bulundukları yere kondu.</span>
+    <span data-phrase="marks.why.chin">Çene, bu kafanın dış hattından değil bir
+      kafanın oranlarından geldi.</span>
+
+    <span data-phrase="marks.button.again">Yüzü yeniden bul</span>
+    <span data-phrase="marks.button.back">Noktaları geri koy</span>
+  </div>
+</main>

--- a/locales/tr/tools/id-photo.toml
+++ b/locales/tr/tools/id-photo.toml
@@ -1,0 +1,358 @@
+#
+# Vesikalık Fotoğraf Yapıcı - Türkçe.
+#
+# Overrides for tools/id-photo/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# Belge ve kurum adları (ICAO Doc 9303, Schengen, SSC, UPSC), renk uzayı adı
+# (CIE Lab) ve JFIF gibi biçim başlıkları olduğu gibi kalıyor: bunlar
+# okuyucunun önündeki formda göreceği ve arayacağı adlar.
+#
+
+name = "Vesikalık Fotoğraf Yapıcı"
+heading = "Vesikalık&nbsp;Fotoğraf Yapıcı <span class=\"h1-kw\">&mdash; şartnamesine uygun pasaport ve vize fotoğrafları</span>"
+tagline = "Ülkeyi seçin. O ülkenin kuralını tam olarak uygular."
+
+title = "Pasaport Fotoğrafı Yapıcı &mdash; Her Ülkenin Ölçüsü, Yüklemesiz"
+description = "Ülkenizin yayımlanmış kuralına uygun bir pasaport ya da vize fotoğrafı yapın: tam mm ve DPI, canlı kafa yüksekliği ve göz hattı yerleşimi, arka plan denetimi, basılabilir 4x6 sayfa ve portalın KB sınırına sığdırılmış bir dosya. Hiçbir şey yüklenmez."
+og_title = "Pasaport fotoğrafınızı ülkenizin tam kuralına göre, yüklemeden yapın"
+og_description = "Bir ülke ve bir belge seçin; kırpma kutusu o kuralın kafa yüksekliğini ve göz hattını alsın. Zorunlu boyut ve DPI'da basar ve yükleme dosyasını formun dayattığı KB aralığının içine yazar."
+og_image_alt = "Vesikalık Fotoğraf Yapıcı - şartnamesine uygun pasaport ve vize fotoğrafları, yüklemeden"
+
+pledge = """
+    Kırpma, ölçme, arka plan okuma ve baskı; hepsi kendi tarayıcınızda, kendi
+    donanımınızda, tarayıcının zaten beraberinde getirdiği JPEG kodlayıcısıyla
+    çalışır. Bu aracın hiçbir türde ağ özelliği yoktur &mdash; getirecek bir şey
+    yok, gönderecek bir şey yok &mdash; ve olsaydı bile bu sayfanın öbür ucunda
+    yüzünüzün fotoğrafının gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir pasaport fotoğrafı yapın. Tek bir istek bile bir resim, bir
+      küçük resim, bir dosya adı ya da seçtiğiniz şeyden tek bir bayt taşımıyor.
+      Ya da internet bağlantısını kesip yine de bir tane yapın."""
+
+read_first = """
+, kural kitabı için <code>src/specs.js</code> &mdash; her
+      ülkenin yayımlanmış rakamları, her birinin hangi kurumdan ve hangi tarihte
+      okunduğuyla &mdash; dört noktanın nasıl bulunduğu için
+      <code>src/detect.js</code> &mdash; bir dış hat ve iki koyu leke; içinde
+      hiçbir yerde model yok &mdash; o dört noktayı bir kırpmaya çeviren hesap
+      için <code>src/geometry.js</code> ve baskı çözünürlüğünü dosyaya yazan,
+      ayrıca fazla küçük bir yüklemeyi bir formun dayattığı boyuta çıkaran iki
+      başlık düzenlemesi için <code>src/jpeg.js</code>."""
+
+howto_heading = "Geri gönderilmeyecek bir pasaport fotoğrafı nasıl yapılır"
+
+card = """
+            Bir ülke ve bir belge seçin; kırpma kutusu o kuralın kafa
+            yüksekliğini ve göz hattını alsın. Tam mm ve DPI'da,
+            4&nbsp;&times;&nbsp;6 sayfayla birlikte basar ve yüklemeyi portalın
+            KB aralığına sıkıştırır."""
+
+[words]
+plural = "fotoğraflar"
+choose = "bir fotoğraf"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Yüzünüzün fotoğrafı bu makineden hiç ayrılmaz."
+body = """
+ Bu, çoğu araçtan çok
+      burada önemlidir: bu sayfanın ele aldığı dosya yüzünüzün bir resmidir ve
+      onunla yapmak üzere olduğunuz şey, belgesine başvurduğunuz ülkeyi
+      adlandırır. <code>Content-Security-Policy</code>, bu sayfanın iletişim
+      kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu siteye ait
+      değildir. Fotoğrafınızın toplanabileceği bir uç nokta burada yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir yerde
+      <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Kural kitabı, <code>src/specs.js</code>
+      içindeki bir tablodur; sayfayla birlikte sunulur ve onunla birlikte
+      önbelleğe alınır &mdash; bakılacak bir ülke listesi ve fotoğrafınızı uzaktan
+      karşılaştıracak bir şey yoktur."""
+
+[[privacy]]
+title = "Yüz, bir yüz modeli olmadan bulunuyor."
+body = """
+ İndirilecek ağırlık,
+      çıkarım çalışma zamanı ve getirilen hiçbir şey yok: tepe noktası,
+      kafanızın arkasındaki duvara karşı oluşan dış hattından; bebekler ise
+      yüzün, çevresinden daha koyu olan lekelerinden gelir. İçinde hiçbir şey
+      ten rengi okumaz ve bu şekilde yazılmasının bütün sebebi budur &mdash;
+      yanlış olan bir model eşitsiz biçimde yanlıştır; bazı yüzlerde
+      diğerlerinden daha kötüdür. Bu bir hüküm değil bir başlangıç konumudur:
+      sayfa dört noktadan hangisini ölçemediğini söyler, her nokta
+      sürüklenebilir kalır ve <em>Ben yerleştireceğim</em>'e geçmek onu tümüyle
+      kapatır."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine
+      fotoğrafınız, yüzünüz ya da hangi ülkenin kuralını seçtiğiniz hakkında bir
+      şey verilmiyor. Bir dosyayı okuyan, kırpan, ölçen ya da yazan her satır bu
+      kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "Fotoğrafı seçin."
+body = """
+ Düz bir duvarın önünde, gün ışığında,
+      yaklaşık bir buçuk metreden çekilmiş bir telefon fotoğrafı. Tarayıcı onu
+      doğrudan diskinizden okur; siz bunu yaparken hiçbir yere hiçbir şey
+      gönderilmez."""
+
+[[howto]]
+title = "Ülkeyi ve belgeyi seçin."
+body = """
+ Panel o zaman o kuralın baskı
+      boyutunu, kafa yüksekliği aralığını, göz hattını, arka plan rengini ve
+      yükleme sınırlarını gösterir &mdash; her rakamın hangi kurumdan geldiği ve
+      hangi tarihte okunduğuyla birlikte. O listedeki hiçbir şey tahmin değildir
+      ve size gönderilip de listede olmayan her şey &laquo;Başka bir yer&raquo;
+      altına girer."""
+
+[[howto]]
+title = "Yüzünüzdeki dört noktayı denetleyin."
+body = """
+ Tepe, çene ve her iki
+      bebek &mdash; kuralın ölçtüğü şeyin tamamı bu dört noktadır. Resmin
+      kendisi ölçülerek yerleştirilirler ve altlarındaki satır, bunlardan
+      hangisinin başarıldığını ve hangisinin hesaplanmak zorunda kaldığını
+      söyler; yanlış düşenleri sürükleyin ya da <em>Ben yerleştireceğim</em>'e
+      geçip dördünü de kendiniz yapın. Sonra <em>Kutuyu yerleştir</em>'e basın;
+      kırpma, o ülkenin istediği yere otursun."""
+
+[[howto]]
+title = "Dört denetimi ve arka planı okuyun."
+body = """
+ Kafa yüksekliği, göz
+      hattı, ortalama ve eğiklik; her biri kutunun o anki hâlinden ölçülür ve
+      her biri dışarıdaysa hangi yöne sürükleyeceğinizi söyler. Arka plan,
+      kırpmanın üstünden ve yanlarından okunur ve kuralın istediği renkle
+      karşılaştırılır &mdash; fotoğrafları asıl reddettiren şey olan eşitsizlik,
+      renkten ayrı olarak ölçülür."""
+
+[[howto]]
+title = "Üç dosyayı alın."
+body = """
+ Baskı; tam milimetrelerinde ve çözünürlüğü
+      dosyanın içine yazılmış hâlde, böylece bir dükkân onu doğru boyutta
+      bassın. Sayfa; bir 4&nbsp;&times;&nbsp;6'nın aldığı kadar kopya ve
+      aralarında kesim işaretleriyle. Ve yükleme; portalın dayattığı piksel
+      boyutunda ve iki ucundan da dayattığı KB aralığının içinde."""
+
+[[faq]]
+q = "Fotoğrafım herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Resim, tarayıcının zaten beraberinde getirdiği JPEG kodlayıcısıyla,
+        kendi donanımınızda, kendi tarayıcınız tarafından çözülür, kırpılır,
+        ölçülür ve yazılır. Bu aracın hiçbir türde ağ özelliği yoktur &mdash;
+        hiçbir zaman bir şey getirmez ve hiçbir zaman bir şey göndermez &mdash; ve
+        sayfanın <code>Content-Security-Policy</code>'si iletişim kurabileceği her
+        adresi tek tek sayar; bunların hiçbiri bu siteye ait değildir. Bu, çoğu
+        araçtan çok burada değerlidir: dosya, yüzünüzün bir fotoğrafıdır."""
+
+[[faq]]
+q = "Hangi ülkeler kapsanıyor?"
+a = """
+        Şimdiye kadar aktarılan şartnameler: ICAO standardının kendisi, Amerika
+        Birleşik Devletleri (pasaport ve farklı yükleme kuralları olan Diversity
+        Visa başvurusu), Birleşik Krallık, Schengen vizesi, Almanya, Kanada,
+        Avustralya, Hindistan (pasaport, 35&nbsp;&times;&nbsp;45&nbsp;mm baskı ve
+        SSC/UPSC form fotoğrafı ile imzası), Çin ve Japonya. Her kayıt, geldiği
+        kurumu ve okunduğu tarihi adıyla belirtir. Başka her şey &laquo;Başka bir
+        yer&raquo; altına girer; orada her rakamı siz yazarsınız &mdash; ve
+        dünyanın çoğu ICAO geometrisine göre belge verdiğinden, o kayıt onun
+        üzerinde başlar."""
+
+[[faq]]
+q = "Yüz modeli olmadan tepeyi, çeneyi ve gözleri nasıl buluyor?"
+a = """
+        Genel bir yüz bulucunun varsaymasına izin verilmeyen, bu aracınsa izin
+        verilen bir şeyi kullanarak: bu şartnamelerin her biri aynı sahneyi
+        dayatır &mdash; tek kişi, kameraya bakıyor, düz ve eşit aydınlatılmış bir
+        duvarın önünde. Bu yüzden duvarın rengi resmin kenarından okunur, o renk
+        olmayan her şey kişidir ve onun en üstü, saç dahil, tepe noktasıdır.
+        Bebekler, kendi çevrelerinden daha koyu, birbiriyle aynı hizada ve kafanın
+        ortasının iki yanında duran en iyi leke çifti olarak bulunur &mdash;
+        yerel bir karşılaştırmadır, yani içindeki hiçbir şey bir yüzün ne renk
+        olduğuna bağlı değildir. Bu yolla bulunamayan tek nokta çenedir; çünkü bir
+        çene hattı ile boyun arasındaki sınır, üzerinde renk değişimi olmayan
+        yumuşak bir kenardır. O, neredeyse tam olarak bir kafanın yarı
+        yüksekliğinde duran bebeklerden hesaplanır ve sonra dış hatta karşı
+        denetlenir. Hepsi <code>src/detect.js</code> içinde aritmetiktir: ağırlık
+        yok, çıkarım çalışma zamanı yok, getirilen bir şey yok ve içinden geçen
+        her yüz için aynı aritmetik. Asıl önemli olan da o son kısımdır; çünkü
+        hazır bir bulucu eşitsiz biçimde yanılır &mdash; bazı yüzlerde
+        diğerlerinden daha kötü &mdash; ve zaten fotoğrafları en sık reddedilen
+        insanlar, onun yüzüstü bırakacağı insanlardır."""
+
+[[faq]]
+q = "Yerleştirdiği noktalara ne kadar güvenmeliyim?"
+a = """
+        Başlamaya yetecek kadar, bakmayı atlayacak kadar değil. Dördünün de
+        yanıldığı bir fotoğraf vardır: desenli bir duvar ya da bir kitaplık,
+        kafayı bulacak bir dış hat bırakmaz; üstten kırpılmış bir kafanın resimde
+        tepe noktası hiç yoktur; gözlük, kalın bir kâkül ya da kapalı gözler
+        bebekleri yanlış bir ayrıntıya koyabilir. Bu yüzden araç, dört noktadan
+        hangisini ölçtüğünü ve hangisini hesaplamak zorunda kaldığını açıkça
+        söyler; içinde düz bir arka plan olmayan bir resimde bir cevap uydurmak
+        yerine doğrudan reddeder ve her noktayı sürüklenebilir bırakır. Kırpma,
+        noktaların bittiği yerden alınır; asla başladıkları yerden değil. Dördünü
+        de kendiniz yerleştirmeyi tercih ederseniz resmin üstündeki anahtar
+        <em>Ben yerleştireceğim</em> der ve herhangi bir noktayı elle oynatmak
+        kendiliğinden ona geçer &mdash; o andan itibaren onlar sizindir ve hiçbir
+        şey onları bir daha oynatmaz."""
+
+[[faq]]
+q = "Kafa yüksekliği kuralı nedir ve benimki neden sürekli kalıyor?"
+a = """
+        Bu şartnamelerin her biri, kafanın kadrajın ne kadarını doldurması
+        gerektiğini, çenenin altından saç dahil kafanın tepesine kadar ölçerek
+        belirtir &mdash; genellikle yüzde 70 ila 80, ki bu 45&nbsp;mm'lik bir
+        fotoğrafta 31,5 ila 36&nbsp;mm eder. Kalmanın olağan sebebi bir özçekimdir:
+        bir kol boyu yaklaşık 60&nbsp;cm'dir, bu da yüzü bozar ve kafayı kadrajda
+        fazla büyük gösterir. İkinci olağan sebep tepe noktasıdır &mdash; o, saç
+        çizgisi değil saçın tepesidir ve saç çizgisini işaretlemek her kafanın
+        fazla küçük çıkmasına yol açar."""
+
+[[faq]]
+q = "Dosya neden en az 20 KB olmalı ve nasıl doldurulabilir?"
+a = """
+        Hindistan sınav portalları, Çin vize formu ve Birleşik Krallık pasaport
+        yüklemesinin hepsi bir azami dosya boyutunun yanı sıra bir asgari boyut da
+        belirtir; çünkü bunun altındaki bir dosya genellikle birinin yanlışlıkla
+        yüklediği bir küçük resimdir. 200&nbsp;&times;&nbsp;230'luk bir fotoğraf
+        46.000 pikseldir ve bir tarayıcının yazacağı en iyi kalitede bile
+        15&nbsp;KB'ye düşebilir; daha az sıkıştırarak onu büyütmenin de yolu
+        yoktur. Bu yüzden araç, boşluklarla dolu bir JPEG yorum bölümü ekler. Bu,
+        JPEG standardının bir parçasıdır, her çözücü onu atlar ve resim bit bit
+        aynı resimdir &mdash; yalnızca dosya uzamıştır. Dolgu, dosyanın içinde
+        İngilizce olarak tam da bunu söyler."""
+
+[[faq]]
+q = "Arka planı denetliyor mu ve bir tanesini değiştirebilir mi?"
+a = """
+        Denetler ve değiştirmez. Renk, kırpmanın üst kısmındaki bir şeritten ve
+        omuzların üstünde her iki yanından okunur ve kuralın rengiyle RGB'de değil
+        CIE Lab'da karşılaştırılır &mdash; kırk RGB birimi uzaktaki iki gri
+        birbirinden ayırt edilemez, kırk birim mavi ise başka bir renktir.
+        Eşitsizlik ayrı olarak ölçülür; çünkü beyaz bir duvardaki bir gölge,
+        fotoğrafları asıl reddettiren şeydir ve bir renk sorunu değildir. Bir arka
+        planı değiştirmek, bir insanı bir resimden kesip çıkarmak demektir ki bu
+        bir bölütleme modelidir ve kötü olanı saçı yer. Duvardan otuz santim daha
+        uzakta durmak, bunların hiçbir filtreden daha fazlasını düzeltir."""
+
+[[faq]]
+q = "4 x 6 sayfa ne işe yarıyor?"
+a = """
+        Bir kabin, altı fotoğraf için birkaç yüz lira alır. Bir fotoğraf bayisi
+        6&nbsp;&times;&nbsp;4 basar, üstelik kuruşlara ve her biri bunu yapar. Bu
+        yüzden araç, kâğıdın aldığı kadar kopyayı yan yana dizer &mdash; bir
+        6&nbsp;&times;&nbsp;4 üzerinde 35&nbsp;&times;&nbsp;45 için sekiz &mdash;
+        aralarında kesim işaretleriyle ve hiçbir resmin üzerine bir şey basmadan.
+        Hiçbir şey sığdırmak için ölçeklenmez: her kopya tam olarak kuralın
+        istediği boyuttadır; çünkü bir tane daha sığsın diye onları yüzde iki
+        küçülten bir sayfa, hepsi yanlış boyutta sekiz fotoğraf demek olurdu. Onu
+        yüzde 100'de basın; bir sayfayı yanlış çıkaran şey &laquo;sayfaya
+        sığdır&raquo;dır."""
+
+[[faq]]
+q = "Pikseller aynıysa DPI neden önemli?"
+a = """
+        Çünkü bir JPEG ne boyutta olduğunu söyleyebilir ve söylemezse onu basan
+        her ne ise tahmin eder. Çözünürlük JFIF başlığında durur ve bir tarayıcı
+        tuvali o başlığı, birim alanı &laquo;bu bir en boy oranıdır, çözünürlük
+        değil&raquo; olarak ayarlanmış hâlde yazar. Bu araç o birkaç baytı yeniden
+        yazar, böylece dosya 300&nbsp;dpi der; 413&nbsp;&times;&nbsp;531 pikseli,
+        belirli bir boyutu olmayan bir görüntü yerine
+        35&nbsp;&times;&nbsp;45&nbsp;mm'lik bir fotoğrafa çeviren de budur. Bunu
+        yapmak için hiçbir şey çözülmez ve hiçbir kalite harcanmaz."""
+
+[[faq]]
+q = "İmza dosyasını da yapabilir mi?"
+a = """
+        Evet &mdash; SSC ve UPSC formları 140&nbsp;&times;&nbsp;60 piksel ve 10 ila
+        20&nbsp;KB arasında bir tane ister ve o da kendi şartnamesi olarak listede
+        yer alır. Onun için yüz yerleşimi kapatılır, çünkü bir imzanın göz hattı
+        yoktur; onun yerine denetlenen şey kâğıdın açık renk olduğu, üzerinde
+        mürekkep bulunduğu ve kırpmanın çizgili bir satırı ya da sayfanın kenarını
+        içine almadığıdır. O kuralın zor kısmı 20'nin altında kalmak değil,
+        10&nbsp;KB'ye ulaşmaktır."""
+
+[[faq]]
+q = "Bu, başvurumun kabul edileceğini garanti eder mi?"
+a = """
+        Hayır ve hiçbir araç dürüstçe edemez. Yaptığı şey, yayımlanmış rakamları
+        tam olarak uygulamak ve yaptığı her ölçümü size göstermektir; böylece bir
+        formun otomatik ölçtüğü şeyler &mdash; piksel boyutu, dosya boyutu, biçim
+        &mdash; doğru olur ve bir insan denetçinin ölçtüğü şeyler &mdash; kafa
+        yüksekliği, göz hattı, arka plan &mdash; sayılarıyla birlikte önünüzde
+        durur. Kurallar da değişir: buradaki her şartname hangi kurumdan geldiğini
+        ve ne zaman okunduğunu söyler; böylece bir tabloya güvenmek yerine
+        önünüzdeki formla karşılaştırabilirsiniz."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok ve yüzünüzün üzerine
+        basılan bir filigran yok. Kaç fotoğraf ürettiğinizde de bir sınır yok,
+        çünkü bunların masrafını ödeyen bir sunucu yok. Sitede reklam var, masrafı
+        karşılayan da o; reklamlara fotoğrafınız hakkında hiçbir şey
+        verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder &mdash; kural kitabı bir sorgu değil, sayfayla
+        birlikte sunulan bir dosyadır. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: fotoğrafınızı kırpılmak üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir ülkenin yayımlanmış şartnamesine uygun pasaport, vize ya da kimlik fotoğrafını tarayıcıda yapın. Seçilen belgenin baskı boyutunu, DPI'ını, kafa yüksekliği aralığını, göz hattını ve arka plan rengini uygular; tepeyi, çeneyi ve bebekleri bir yüz modeli çalıştırarak değil resmi ölçerek yerleştirir; her birinin canlı yerleşimini ve ölçümünü gösterir; arka planı denetler; kesim işaretleriyle basılabilir bir 4x6 sayfa dizer ve zorunlu piksel boyutunda, portalın KB aralığının içinde bir yükleme dosyası yazar. Hiçbir şey yüklenmez."
+features = [
+  "Her biri kaynağını ve okunduğu tarihi belirten yayımlanmış şartnamelerden bir kural kitabı",
+  "ICAO Doc 9303 geometrisi: kadrajın bir kesri olarak kafa yüksekliği ve alt kenardan göz hattı",
+  "Şartnamenin şekline kilitli bir kırpma kutusu; içinde göz ve çene bantları çizili",
+  "Tepe, çene ve iki bebek; kafanın dış hattından ve gözlerin koyuluğundan bulunur, hiçbir model beraberinde gelmez ve hiçbir şey getirilmez",
+  "Dördü de sürüklenebilir kalır; sayfa hangisini ölçtüğünü ve hangisini hesapladığını söyler",
+  "Canlı kafa yüksekliği, göz hattı, ortalama ve eğiklik; her biri hangi yöne düzeltileceğini söyler",
+  "Arka plan rengi ve eşitliği CIE Lab'da ölçülür ve ikisi ayrı ayrı bildirilir",
+  "Tam milimetrelerinde basar; çözünürlük JPEG başlığının içine yazılır",
+  "4 x 6, 5 x 7, A4 ya da Letter sayfa; aralarında kesim işaretleriyle dizilir ve hiçbir resmin üzerine bir şey basılmaz",
+  "Zorunlu piksel boyutunda, portalın KB aralığına iki ucundan da aranarak sığdırılmış bir yükleme dosyası",
+  "20-50 KB aralığında 200 x 230 SSC ve UPSC form fotoğrafları ve 10-20 KB aralığında 140 x 60 imzalar",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, yüz modeli yok",
+]
+
+[picker]
+title = "Bir fotoğrafı buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; tek fotoğraf; JPEG, PNG, WebP ya da tarayıcınızın açabildiği her şey"

--- a/locales/tr/tools/image-to-data-uri.html
+++ b/locales/tr/tools/image-to-data-uri.html
@@ -1,0 +1,148 @@
+<!--
+  tools/image-to-data-uri/body.html, in Turkish.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosyalar -->
+  <section class="card">
+    <h2><span class="step">1</span> Görselleri seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Hepsini listeden çıkar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; asıl yapıştırılan satır -->
+  <section class="card" id="shape-card">
+    <h2><span class="step">2</span> Nereye gideceğini söyleyin</h2>
+
+    <p class="card-lede">
+      Tek başına bir data URI, nadiren birinin istediği şeydir. İstenen, stil
+      dosyasına giren satırdır &mdash; o yüzden satırı seçin; resim, onun içine
+      çoktan tırnaklanmış olarak gelsin. Yanlış yapılması kolay olan ve yalnızca
+      SVG'lerde çuvallayan kısım da odur.
+    </p>
+
+    <div class="shapes" id="shapes" role="radiogroup" aria-label="Ne yapıştırılacak">
+      <label class="shape">
+        <input type="radio" name="shape" value="uri" checked>
+        <span class="shape-body">
+          <strong>Tek başına data URI</strong>
+          <span class="shape-note">
+            Virgülden sonraki her şey dosyanın kendisidir. Bir URL'nin gittiği her
+            yere yapıştırın.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-rule">
+        <span class="shape-body">
+          <strong>Bir CSS kuralı</strong>
+          <span class="shape-note">
+            Dosyanın adını taşıyan bir sınıfla, kuralın tamamı. Seçiciyi gerçekten
+            biçimlendirdiğiniz şeyle değiştirin.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-var">
+        <span class="shape-body">
+          <strong>Bir CSS özel özelliği</strong>
+          <span class="shape-note">
+            Stil dosyasının başında bir kez tanımlanır ve istediğiniz kadar
+            <code>var(--ad)</code> olarak kullanılır. Resim birden fazla kuralda
+            görünüyorsa seçilecek olan budur.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="html">
+        <span class="shape-body">
+          <strong>Bir HTML <code>&lt;img&gt;</code> etiketi</strong>
+          <span class="shape-note">
+            Piksel boyutu doldurulmuş hâlde; böylece sayfanın geri kalanı
+            yüklenirken sayfa zıplamaz.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="markdown">
+        <span class="shape-body">
+          <strong>Markdown</strong>
+          <span class="shape-note">
+            Bir README ya da bir konu için: barındırılacak bir yere ihtiyaç duymak
+            yerine metinle birlikte yolculuk eden bir resim.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary">
+      <code>alt</code> metni bilerek boş bırakılıyor. Resmin bir anlam taşıyıp
+      taşımadığını ya da süs olup olmadığını yalnızca siz bilirsiniz ve bir dosya
+      adından tahmin edilmiş bir açıklama, ekran okuyucu kullanan biri için hiç
+      açıklama olmamasından daha kötüdür.
+    </p>
+
+    <fieldset class="options">
+      <legend>SVG</legend>
+
+      <label class="check">
+        <input type="checkbox" id="svg-base64">
+        <span>
+          <strong>SVG'leri de base64 yap</strong>
+          <span class="check-note">
+            Varsayılan olarak kapalı; çünkü bir SVG metindir ve base64 baytlar
+            içindir. Yüzde kodlaması, işaretlemeyi stil dosyasında okunur bırakır
+            ve genellikle beşte bir daha kısadır. <code>;base64</code> konusunda
+            ısrar eden nadir araç zincirleri için bunu açın.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Adım 3 &mdash; sonuç. Burada bilerek bir düğme yok: kodlama anında olur,
+       yani bir "dönüştür" basışının bekleyeceği bir şey yok. -->
+  <section class="card" id="output-card">
+    <h2><span class="step">3</span> Kopyalayın</h2>
+
+    <p id="empty-note" class="card-lede">
+      Henüz bir şey seçilmedi. Yukarıya bir resim bırakın, yapıştırılacak satır
+      burada görünsün.
+    </p>
+
+    <div id="results" hidden>
+      <div class="results-head">
+        <p id="results-summary" class="results-summary"></p>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Hepsini kopyala</button>
+          <button type="button" id="download-all" class="ghost">Tek dosya olarak indir</button>
+        </div>
+      </div>
+
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/image-to-data-uri.toml
+++ b/locales/tr/tools/image-to-data-uri.toml
@@ -1,0 +1,316 @@
+#
+# Görselden Data URI'ye - Türkçe.
+#
+# Overrides for tools/image-to-data-uri/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# The cross-links in the FAQ carry the Turkish slugs from [slugs] in
+# locale.toml - ../exif-verisi-silme/, ../resim-sikistirma/ and
+# ../resim-boyutlandirma/ - because a published locale is held to every one of
+# its internal links landing on a page that was built.
+#
+# "data URI", "base64", "gzip", "EXIF", "XMP" ve etiket adları olduğu gibi
+# kalıyor: bunlar yazılan ve aranan adlar.
+#
+
+name = "Görselden Data URI'ye"
+heading = "Görselden&nbsp;Data&nbsp;URI'ye <span class=\"h1-kw\">&mdash; CSS ya da HTML için bir resmi base64 ile kodlayın</span>"
+tagline = "Resmin tamamı tek satır metin olarak. Doğrudan CSS ya da HTML içine yapıştırın."
+
+title = "Görselden Data URI'ye &mdash; CSS için Base64, Ücretsiz, Yüklemesiz"
+description = "Bir PNG, JPEG, SVG veya WebP'yi CSS ya da HTML içine yapıştırabileceğiniz bir data URI'ye çevirin. SVG'ler base64 yerine yüzde kodlamasıyla yazılır; böylece hem okunur kalır hem de daha kısadır. Tarayıcınızda çalışır, hiçbir şey yüklenmez."
+og_title = "Bir görseli CSS içine yapıştırabileceğiniz bir satıra çevirin"
+og_description = "Resimler için base64, SVG için yüzde kodlaması ve çevresinde hazır kural, özel özellik ya da img etiketi. Kendi makinenizde çalışır, hiçbir şey yüklenmez."
+og_image_alt = "Görselden Data URI'ye - resmi stil dosyasının içine yapıştırın"
+
+pledge = """
+    Kodlama kendi tarayıcınızda, kendi donanımınızda çalışır. Sayfanın zaten
+    elinde olan baytlar üzerinde bir aritmetiktir: kodlayıcı yok, sunucu yok ve
+    dışarıda bırakılacak bir ağ adımı yok. Bu aracın hiçbir türde ağ özelliği
+    yoktur &mdash; getirecek bir şey yok, gönderecek bir şey yok &mdash; ve
+    olsaydı bile bu sayfanın öbür ucunda bir resmin gönderilebileceği bir sunucu
+    yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir resim bırakın. Tek bir istek bile bir görsel, bir küçük
+      resim, bir dosya adı ya da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da
+      internet bağlantısını kesip yine de bir tane kodlayın."""
+
+read_first = """
+, iki kodlama ve her birinin ardındaki gerekçe
+      için <code>src/encode.js</code>, ortam türünün dosyanın adından değil
+      kendisinden nasıl okunduğu için <code>src/sniff.js</code> ve
+      yapıştırmak üzere olduğunuz şeyin ne kadarının resim olmadığını söyleyen
+      denetim için <code>src/metadata.js</code>."""
+
+howto_heading = "Bir görsel data URI'ye nasıl çevrilir"
+
+card = """
+            Resimler için base64, SVG için yüzde kodlaması ve çevresine çoktan
+            kurulmuş CSS kuralı ya da <code>&lt;img&gt;</code> etiketi."""
+
+[words]
+plural = "görseller"
+choose = "bir görsel"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Yeniden kodlama yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Görsellerinizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir
+      yerde <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Kodlama, <code>btoa</code> ve
+      <code>encodeURIComponent</code>'tir &mdash; tarayıcının en başından beri
+      sahip olduğu iki işlev; ikisi de bayt alır ve hiçbir yere gitmeden metin
+      döndürür."""
+
+[[privacy]]
+title = "Ön izleme, kanıtın kendisi."
+body = """
+ Her sonucun yanındaki resim, sizin
+      dosyanızdan değil bu sayfanın az önce kurduğu data URI'den çizilir. URI
+      doğru olduğu için, sizin makinenizde, hiçbir sunucu karışmadan görüntülenir
+      &mdash; ve görüntülenmezse sayfa size bozuk bir şey vermek yerine bunu
+      söyler."""
+
+[[privacy]]
+title = "Üstveri uyarısı sizin tarafınızda."
+body = """
+ Bir data URI dosyayı olduğu
+      gibi kopyalar; yani bir fotoğrafın GPS konumu da onunla birlikte stil
+      dosyanıza gider. Bu sayfa bunun ne kadarının orada olduğunu okur ve size
+      söyler; çünkü alternatifi, siz bunu depoya işlendikten sonra
+      öğrenmenizdir."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine
+      resimleriniz hakkında bir şey verilmiyor. Bir dosyayı okuyan ya da kodlayan
+      her satır bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "Görsellerinizi seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin. Tarayıcı
+      onları doğrudan diskinizden okur; siz bunu yaparken hiçbir yere hiçbir şey
+      gönderilmez."""
+
+[[howto]]
+title = "Sonucun nereye gideceğini söyleyin."
+body = """
+ URI'nin kendisi, bir CSS
+      kuralı, bir özel özellik, bir <code>&lt;img&gt;</code> etiketi ya da
+      Markdown. Hepsi URI'yi tırnak içine alır; satır içine alınmış bir SVG'nin
+      çalışıp çalışmayacağına sessizce karar veren ayrıntı da budur."""
+
+[[howto]]
+title = "Neye mal olduğunu okuyun."
+body = """
+ Her sonuç kaç karaktere dönüştüğünü,
+      bunun dosyadan ne kadar büyük olduğunu ve bu boyutta bir şeyi satır içine
+      almanın iyi bir fikir olup olmadığını söyler. Base64 üçte bir ekler; o üçte
+      birin kazanılan bir isteğe değip değmediği tamamen boyuta bağlıdır, bu
+      yüzden sayfa çizginin hangi tarafında olduğunuzu söyler."""
+
+[[howto]]
+title = "Uyarılara bakın."
+body = """
+ Resim EXIF, bir renk profili ya da XMP
+      taşıyorsa, sonucunuzun kaç baytının bunlar olduğuyla birlikte adı verilir.
+      Uzantı gerçek biçimle çelişiyorsa sayfa biçimi kullanır ve size söyler.
+      Tarayıcınız sonucu çizemiyorsa onu da söyler."""
+
+[[howto]]
+title = "Kopyalayın ya da indirin."
+body = """
+ Sonuç başına bir düğme, hepsi için
+      birden bir düğme &mdash; özel özellikler bir <code>:root</code> bloğuna
+      sarılı olarak, bir stil dosyasının başına yapıştırılmaya hazır çıkar."""
+
+[[faq]]
+q = "Görselim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya, tarayıcının zaten sahip olduğu iki işlevle, kendi
+        donanımınızda, kendi tarayıcınız tarafından okunur ve kodlanır. Bu aracın
+        hiçbir türde ağ özelliği yoktur &mdash; hiçbir zaman bir şey getirmez ve
+        hiçbir zaman bir şey göndermez &mdash; ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar; bunların hiçbiri bu siteye ait değildir."""
+
+[[faq]]
+q = "Data URI nedir?"
+a = """
+        Normalde bir web adresinin gideceği yere bütün bir dosyayı yazma
+        yöntemidir. Tarayıcıya gidip bir şey getirmesini söyleyen
+        <code>url("logo.png")</code> yerine, resmin kendisini içeren
+        <code>url("data:image/png;base64,iVBORw0...")</code> yazarsınız. Tarayıcı
+        onu olduğu yerde çözer. Pratikteki etkisi bir istek eksilmesidir: resim,
+        stil dosyasından ya da sayfadan sonra değil onlarla birlikte gelir."""
+
+[[faq]]
+q = "SVG'm neden base64 değil?"
+a = """
+        Çünkü base64 onun için yanlış kodlamadır. Bir SVG metindir ve bir URL
+        zaten metin taşıyabilir &mdash; yalnızca bir avuç karakterin kaçırılması
+        gerekir. Onları yüzde kodlamasıyla yazıp gerisine dokunmamak, aynı
+        dosyanın base64'ünden tipik olarak beşte bir daha kısa ve stil dosyanızda
+        hâlâ okuyabileceğiniz bir URI üretir: öğe adları, renkler ve
+        <code>viewBox</code> düzenlemek için yerli yerindedir. Bunda ısrar eden
+        nadir bir araç zinciri için base64'ü zorlayan bir onay kutusu var."""
+
+[[faq]]
+q = "Base64 görselimi ne kadar büyütüyor?"
+a = """
+        Yaklaşık üçte bir. Dosyanın üç baytı base64'ün dört karakteri olur; bu da
+        öndeki <code>data:image/png;base64,</code>'dan önce %33 demektir. Bu
+        tabandır ve kaçınılmazdır: rastgele baytları yalnızca bir URL'nin izin
+        verdiği karakterlerle yazmanın bedeli budur. Sayfanın karakter sayısını
+        dosya boyutunun yanında göstermesinin, siz bunu stil dosyası yayına
+        alındığında öğrenesiniz diye bırakmamasının sebebi de budur."""
+
+[[faq]]
+q = "Bir görseli satır içine almak ne zaman gerçekten iyi bir fikir?"
+a = """
+        Küçük olduğunda ve hemen gerektiğinde. Her sayfanın yüklediği bir stil
+        dosyasındaki 2 KB'lik bir simge açık bir kazançtır: bir gidiş dönüş
+        eksilir ve resim, CSS oradaysa oradadır. Yaklaşık 10 KB'den sonra takas
+        döner. Satır içine alınmış bir resim artık ayrı bir dosya değildir; yani
+        kendi başına önbelleğe alınamaz, başka bir şeyle paralel olarak
+        getirilemez ve çevresindeki dosya her değiştiğinde baştan sona yeniden
+        indirilir &mdash; bir stil dosyasındaki 200 KB'lik bir fotoğraf, sitedeki
+        her sayfanın kritik yoluna eklenen 200 KB demektir. Sayfa, her sonucun o
+        çizginin hangi tarafına düştüğünü size söyler."""
+
+[[faq]]
+q = "Gzip, base64'ün getirdiği fazlalığı geri alır mı?"
+a = """
+        İnsanların beklediğinden azını. Zaten sıkıştırılmış bir dosyanın
+        &mdash; bir PNG, bir JPEG ve bir WebP bunların hepsidir &mdash; base64'ü
+        kötü sıkışır; çünkü sıkıştırıcının bulacağı neredeyse hiç fazlalık
+        kalmamıştır; tipik olarak base64'ün eklediği üçte birin onda biri kadarını
+        geri alırsınız, tamamını değil. Yüzde kodlamasıyla yazılmış bir SVG ise
+        tam tersi bir durumdur: hâlâ metindir, yani eskiden ne kadar sıkışıyorsa o
+        kadar sıkışır &mdash; bir SVG'yi base64'lememek için bir sebep daha."""
+
+[[faq]]
+q = "Bu, görselimi herhangi bir şekilde değiştiriyor mu?"
+a = """
+        Hayır ve bu, buradaki araçların çoğundan bilinçli bir farktır. Hiçbir şey
+        piksele çözülüp yeniden kodlanmaz: diskinizden gelen baytlar, URI'ye giren
+        baytlardır. Bir JPEG, aynı kalitede ve aynı boyutlarda, tam olarak olduğu
+        JPEG kalır. Sonucun bir kopyası değil de aynı dosya olarak tarif
+        edilebilmesinin sebebi budur."""
+
+[[faq]]
+q = "Yani EXIF ve GPS verim de mi stil dosyasına giriyor?"
+a = """
+        Evet ve yapıştırmadan önce üzerinde düşünmeye değen kısım da budur. Hiçbir
+        şey yeniden kodlanmadığı için kameranın yazdığı her şey resimle birlikte
+        yolculuk eder: konum, zaman damgası, kameranın seri numarası. Bir telefon
+        fotoğrafında bu, dosyanın 30 KB'si olabilir; bu da sayfanızın kritik
+        yolunda 40 KB base64 ve bir depoya işlenecek bir şeyin içinde bir ev
+        adresi demektir. Sayfa, bir JPEG, PNG ya da WebP içinde ne kadar üstveri
+        olduğunu okur ve söyler. Önce onu çıkarmak için
+        <a href="../exif-verisi-silme/">EXIF Görüntüleyici ve Silici</a>'yi
+        kullanın."""
+
+[[faq]]
+q = "Neden dosyamın uzantısından farklı bir tür kullandı?"
+a = """
+        Çünkü uzantı yanlış olabilir, baytlar olamaz. Aslında JPEG olarak dışa
+        aktarılmış <code>logo.png</code> adlı bir dosya, her görsel aracının başa
+        çıkmak zorunda olduğu kadar yaygındır ve yanlış türü bildiren bir data URI
+        düpedüz görüntülenmez &mdash; bir yedeği ve okumaya değer bir hata iletisi
+        yoktur. Bu yüzden tür, dosyanın ilk birkaç baytından okunur &mdash;
+        buradaki her biçimde ne olduğunu tereddütsüz söyleyen kısım orasıdır
+        &mdash; ve ikisi çeliştiğinde sayfa size söyler."""
+
+[[faq]]
+q = "Ön izleme boş. Ne ters gitti?"
+a = """
+        Muhtemelen URI'yle ilgili bir şey değil. HEIC ve TIFF, Safari dışında
+        hiçbir tarayıcının çizmeyeceği ama gayet geçerli data URI'ler üretir; yani
+        resim, yapıştırdığınız yerde de eksik olacaktır &mdash; önce
+        <a href="../resim-sikistirma/">Görsel Sıkıştırıcı</a> ya da
+        <a href="../resim-boyutlandirma/">Görsel Boyutlandırıcı</a> ile PNG, JPEG
+        veya WebP'ye çevirin. Biçim sıradan bir biçimse dosyanın kendisi büyük
+        olasılıkla bozuktur: ön izleme bu sayfanın kurduğu URI'den çizilir, yani
+        boş bir ön izleme resmin çözülmediği anlamına gelir."""
+
+[[faq]]
+q = "Bir data URI'de boyut sınırı var mı?"
+a = """
+        CSS'te ya da bir <code>&lt;img&gt;</code> etiketinde karşılaşacağınız bir
+        sınır yok; güncel tarayıcılar orada pratikte bir tavan koymuyor.
+        Tarayıcıların sınırladığı şey, bir data URI'yi adres çubuğuna yazmaktır ki
+        çoğu artık bunu, bu kullanımla hiç ilgisi olmayan güvenlik sebepleriyle,
+        önemsiz olmayan her şey için reddediyor. Gerçek sınır yukarıdakidir: teknik
+        olarak bir şey bozulmadan çok önce, içinde bulunduğu sayfa sıradan bir
+        görsel dosyasıyla olacağından daha yavaş hâle gelmiştir."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Dosyaların
+        sayısında ya da boyutunda da bir sınır yok, çünkü bunların bedelini ödeyen
+        bir sunucu yok &mdash; iş sizin kendi cihazınızda oluyor. Sitede reklam
+        var, masrafı karşılayan da o; reklamlara görselleriniz hakkında hiçbir şey
+        verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: görsellerinizi kodlanmak üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir PNG, JPEG, SVG, WebP, GIF veya ICO'yu CSS ya da HTML içine yapıştırmaya hazır bir data URI'ye dönüştürün. Tarama biçimleri için base64, SVG için yüzde kodlaması; bir CSS kuralına, bir özel özelliğe, bir img etiketine ya da Markdown'a sarılı, boyut bedeli ve gömülü üstveri raporuyla. Tamamen tarayıcıda çalışır, yükleme yoktur."
+features = [
+  "PNG, JPEG, WebP, GIF, ICO, AVIF ve daha fazlası için base64 data URI'ler",
+  "Base64'ten kısa olan ve okunur kalan, yüzde kodlamalı SVG data URI'leri",
+  "Hazır CSS kuralı, CSS özel özelliği, HTML img etiketi ya da Markdown; her zaman doğru tırnaklanmış",
+  "Ortam türü, uzantıdan değil dosyanın kendi baytlarından okunur",
+  "Kodlamanın kaç karaktere mal olduğunu ve bu boyutta satır içine almanın değip değmediğini söyler",
+  "EXIF, XMP ya da bir renk profili stil dosyanıza kopyalanmak üzereyken uyarır",
+  "Dosyayı baytı baytına kopyalar: yeniden kodlama yok, kalite kaybı yok",
+  "Yığın işleme; her şey tek bir dosya olarak kopyalanır ya da indirilir",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Görselleri buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; PNG, JPEG, SVG, WebP, GIF, ICO ve daha fazlası"

--- a/locales/tr/tools/image-to-ico.html
+++ b/locales/tr/tools/image-to-ico.html
@@ -1,0 +1,192 @@
+<!--
+  tools/image-to-ico/body.html, in Turkish.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; resim -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir resim seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Hepsini listeden çıkar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="shape-note" class="field-summary" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; hangi standart -->
+  <section class="card" id="preset-card">
+    <h2><span class="step">2</span> Simgenin ne için olduğunu söyleyin</h2>
+
+    <p class="card-lede">
+      Bir simge dosyası tek bir resim değil, birkaç resimdir: aynı logo, onu
+      okuyan şeyin istediği her boyutta yeniden çizilir. Bunların hangi boyutlar
+      olduğu bir zevk meselesi değildir &mdash; bir tarayıcı üç tanesini ister,
+      yüksek yoğunluklu bir dizüstündeki bir uygulama on tanesini ister, bir Mac
+      kendi onunu ister ve Windows Vista'dan önce yazılmış bir şey onların
+      tamamen başka türlü saklanmasını ister.
+    </p>
+
+    <!--
+      Which files to write. Windows and macOS read different containers and
+      neither will look at the other's, so this is a set of checkboxes rather
+      than a menu: wanting both is the normal case for anything shipped on both.
+    -->
+    <fieldset class="options outputs">
+      <legend>Ne yapılacak</legend>
+
+      <label class="check">
+        <input type="checkbox" id="want-ico" checked>
+        <span>
+          <strong>Windows simgesi &mdash; <code>.ico</code></strong>
+          <span class="check-note">
+            Her tarayıcı tarafından favicon olarak, Windows tarafından da bir
+            uygulama, bir kısayol ve bir klasör için okunur. Boyutları aşağıdan
+            siz seçersiniz.
+          </span>
+        </span>
+      </label>
+
+      <label class="check">
+        <input type="checkbox" id="want-icns">
+        <span>
+          <strong>macOS simgesi &mdash; <code>.icns</code></strong>
+          <span class="check-note">
+            Bir Mac uygulama paketinin taşıdığı şey. Apple, 16 pikselden 1024
+            piksele tam olarak on yuva belirler; yani seçilecek bir şey yoktur:
+            onunun tamamı girer ve bunlar yedi çizimden çıkarılır, çünkü bir
+            Retina yuvası ile bir üstündeki boyut aynı resimdir.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="pack-row">
+        <input type="checkbox" id="want-pack">
+        <span>
+          <strong>Bir web sitesinin simge setinin geri kalanı</strong>
+          <span class="check-note">
+            Bir .ico, tarayıcı sekmesini ve Windows'u kapsar. Bir iPhone
+            ana ekranını, bir Android kurulum istemini ya da başlat menüsüne
+            sabitlenmiş bir kutucuğu kapsamaz &mdash; onlar 180 piksellik bir
+            PNG, bir web uygulaması bildirimi ve bir XML dosyası okur ve hiçbiri
+            bir .ico'nun içine bakmaz. Bunu işaretleyin, hepsini,
+            bildirimi ve sayfanıza yapıştıracağınız HTML bloğunu da alın.
+          </span>
+        </span>
+      </label>
+
+      <p id="output-summary" class="field-summary"></p>
+    </fieldset>
+
+    <div id="ico-settings">
+      <div class="presets" id="preset-list" role="radiogroup" aria-label="Simgenin ne için olduğu"></div>
+
+      <p id="preset-note" class="field-summary"></p>
+
+      <fieldset class="options" id="size-set">
+        <legend>.ico içine girecek boyutlar</legend>
+        <div class="size-grid" id="size-grid"></div>
+        <p id="size-summary" class="field-summary"></p>
+      </fieldset>
+    </div>
+
+    <fieldset class="options">
+      <legend>Nasıl çizileceği</legend>
+
+      <div class="option-row">
+        <label for="fit-select">Resim kare değilse</label>
+        <select id="fit-select">
+          <option value="pad" selected>Kareye tamamla &mdash; resmin tamamı korunur</option>
+          <option value="crop">Ortadaki kareye kırp</option>
+          <option value="stretch">Kareye esnet</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="background-mode">Arka plan</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Saydam</option>
+          <option value="colour">Bir renk</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Arka plan rengi" hidden>
+      </div>
+
+      <div class="option-row" id="storage-row">
+        <label for="storage-select">Her boyutun .ico içinde nasıl saklanacağı</label>
+        <select id="storage-select">
+          <option value="auto" selected>Otomatik &mdash; ucuza geliyorsa uyumlu, gelmiyorsa PNG</option>
+          <option value="png">Her boyut için PNG &mdash; en küçük dosya, Vista ya da üstünü ister</option>
+          <option value="bmp">Her boyut için sıkıştırılmamış &mdash; her şeyde açılır, birkaç kat büyük</option>
+        </select>
+      </div>
+
+      <p id="storage-note" class="field-summary"></p>
+    </fieldset>
+
+  </section>
+
+  <!-- Adım 3 &mdash; küçük hâline bakın, sonra alın -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Görüleceği boyutta denetleyin</h2>
+
+    <p class="card-lede">
+      Bir şey indirmeden önce bakmaya değen kısım burasıdır. 512 pikselde
+      kusursuz okunan bir logo, bir tarayıcı sekmesinde on altı piksel
+      genişliğindedir ve onun ince kısımları &mdash; bir kelime logosundaki
+      çizgiler, saç teli bir çerçeve, bir renk geçişi &mdash; bunu atlatamaz.
+      Aşağıdaki her kare, seçtiğiniz dosyadan gerçek boyutunda çizilir.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-strip" id="preview-strip"></div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make-icon" class="primary big" disabled>Simgeyi yap</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Hazır</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Hepsini zip olarak indir</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+
+      <!--
+        The block to paste into a page's <head>, shown rather than only zipped:
+        most people making a favicon are about to paste this into a template,
+        and a copy button is a shorter route than a download and a text editor.
+      -->
+      <div id="snippet" class="snippet" hidden>
+        <div class="snippet-head">
+          <h4>Bunu <code>&lt;head&gt;</code> içine yapıştırın</h4>
+          <button type="button" id="copy-snippet" class="ghost">Kopyala</button>
+        </div>
+        <pre id="snippet-text"></pre>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/image-to-ico.toml
+++ b/locales/tr/tools/image-to-ico.toml
@@ -1,0 +1,344 @@
+#
+# Görselden ICO'ya - Türkçe.
+#
+# Overrides for tools/image-to-ico/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Dosya adları (favicon.ico, app.ico, browserconfig.xml, Info.plist), Apple
+# anahtarları (CFBundleIconFile) ve araç adları (iconutil, Visual Studio)
+# olduğu gibi kalıyor: bunlar yazılan ve aranan adlar.
+#
+
+name = "Görselden ICO'ya"
+heading = "Görselden&nbsp;ICO'ya <span class=\"h1-kw\">&mdash; favicon, Windows ve macOS simge yapıcı</span>"
+tagline = "Bir resim girer. Bir tarayıcının, Windows'un ya da bir Mac'in istediği her boyut çıkar."
+
+title = "Görselden ICO'ya &mdash; Favicon, Uygulama Simgesi ya da ICNS Yapın, Yüklemesiz"
+description = "Bir PNG, JPEG veya SVG'yi tarayıcınızda gerçek, çok boyutlu bir .ico ya da bir macOS .icns dosyasına dönüştürün. Favicon, Windows uygulama simgesi, Mac uygulama simgesi ve bir sitenin ihtiyaç duyduğu Apple ile Android dosyaları. Hiçbir şey yüklenmez."
+og_title = "İçinde her boyutu olan bir .ico ya da .icns'i hiçbir şey yüklemeden yapın"
+og_description = "Bir web sitesi için favicon.ico, bir Windows programı için app.ico, bir Mac için .icns &mdash; indirmeden önce 16 piksellik ön izlemesiyle. Hepsi kendi makinenizde çalışır."
+og_image_alt = "Görselden ICO'ya - favicon, Windows ve macOS simge yapıcı, yükleme yok"
+
+pledge = """
+    Ölçekleme de simge dosyalarının kendisi de kendi tarayıcınızda üretilir.
+    Resim, tarayıcınızın zaten beraberinde getirdiği tuval tarafından çizilir ve
+    her kap &mdash; Windows <code>.ico</code>'su, macOS <code>.icns</code>'i
+    &mdash; o piksellerden, <code>src/ico.js</code> ve <code>src/icns.js</code>
+    içindeki, okuyabileceğiniz birkaç yüz satırla kurulur. Bu aracın hiçbir türde
+    ağ özelliği yoktur &mdash; getirecek bir şey yok, gönderecek bir şey yok
+    &mdash; ve olsaydı bile bu sayfanın öbür ucunda bir logonun
+    gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir simge yapın. Tek bir istek bile bir görsel, bir küçük resim,
+      bir dosya adı ya da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet
+      bağlantısını kesip yine de bir tane yapın."""
+
+read_first = """
+, iki simge biçimi için <code>src/ico.js</code> ve
+      <code>src/icns.js</code> &mdash; birinde dizin, girdiler ve maske;
+      diğerinde Apple'ın adlandırılmış on yuvası &mdash; ve sayfadaki her boyutun
+      nereden geldiği için <code>src/sizes.js</code>."""
+
+howto_heading = "Hiçbir şey yüklemeden nasıl .ico dosyası yapılır"
+
+card = """
+            Bir favicon, bir Windows uygulama simgesi ya da bir macOS .icns
+            &mdash; her boyut tek dosyada, indirmeden önce 16 piksellik
+            ön izlemesiyle."""
+
+[words]
+plural = "görseller"
+choose = "bir resim"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Logonuzun gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir yerde
+      <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Ölçekleme, bir tuvale yapılan bir
+      <code>drawImage</code>'dir; her simge de bu sayfada, o piksellerin önüne
+      <code>src/ico.js</code> ya da <code>src/icns.js</code> tarafından yazılmış
+      bir başlıktır."""
+
+[[privacy]]
+title = "Dosya kendi baytlarından tarif ediliyor."
+body = """
+ Bitmiş bir simgenin
+      yanında gösterilen boyut listesi, istediğiniz boyutların listesi değildir.
+      Az önce yazılan dosyadan <code>readIcoDirectory</code> ya da
+      <code>readIcnsElements</code> tarafından geri okunur; yani bir yazıcı
+      ayarlarla çelişseydi sayfa bunu söylerdi, siz Windows hiçbir şey çizmediğinde
+      ve macOS boş bir kâğıt çizdiğinde öğrenmezdiniz."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine resminiz
+      hakkında bir şey verilmiyor. Bir dosyayı okuyan, ölçekleyen ya da yazan her
+      satır bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "Resmi seçin."
+body = """
+ Seçiciye bir PNG, JPEG, WebP ya da SVG bırakın
+      veya birkaç tane seçip hepsini tek seferde dönüştürün. Kare olanı en
+      kolayıdır ve 256 pikselden yukarısı her boyut için yeterli ayrıntı taşır.
+      Tarayıcı onu doğrudan diskinizden okur; siz bunu yaparken hiçbir yere hiçbir
+      şey gönderilmez."""
+
+[[howto]]
+title = "İhtiyacınız olan dosyaları seçin."
+body = """
+ Windows ve bir tarayıcı
+      <code>.ico</code> okur; bir Mac <code>.icns</code> okur ve diğerine hiç
+      bakmaz. Birini işaretleyin ya da yaptığınız şey ikisinde de yayımlanacaksa
+      ikisini birden. Bir web sitesi ayrıca Apple, Android ve kutucuk görsellerini
+      de ister ve üçüncü kutu odur."""
+
+[[howto]]
+title = "Simgenin ne için olduğunu söyleyin."
+body = """
+ Bir web sitesi faviconu 16,
+      32 ve 48 pikseldir; bir Windows uygulaması 256'yı da ister; yüksek
+      yoğunluklu bir dizüstünde düzgün görünmesi gereken bir uygulama, Windows'un
+      %125 ve %150 ölçeklemede istediği ara boyutları ister. İşe uyanı seçin ya da
+      boyutları kendiniz işaretleyin. Listedeki her boyut, onu neyin istediğini
+      söyler. <code>.icns</code>'te böyle bir seçim yoktur: Apple tam olarak on
+      yuva belirler ve onu da girer."""
+
+[[howto]]
+title = "Şekli ve arka planı halledin."
+body = """
+ Bir simge karedir ve çoğu logo
+      değildir. Doldurun; resmin tamamı, üstünde ve altında boşlukla korunur.
+      Kırpın; ortası alınır. Esnetin; ezilir. Arkasına oturacak bir renk
+      seçmediğiniz sürece saydamlık saydamlık olarak korunur."""
+
+[[howto]]
+title = "İndirmeden önce 16 piksellik olana bakın."
+body = """
+ Simgenin en sık
+      görüleceği boyut odur ve ince çizgilerle küçük harflerin kaybolduğu yer de
+      orasıdır. Ön izlemedeki her kare, sizin dosyanızdan gerçek boyutunda
+      çizilir. En küçüğü bir lekeyse çözüm başka bir ayar değil, daha basit bir
+      çizimdir."""
+
+[[howto]]
+title = "Dosyaları alın."
+body = """
+ İçinde her boyutu olan tek bir .ico; istediğiniz
+      buysa <code>favicon.ico</code> adıyla, çünkü tarayıcıların aradığı adres
+      odur. İşaretlediyseniz yanında bir .icns; bir Mac uygulama paketine girmeye
+      hazır. Web sitesi setini de işaretleyin; Apple, Android ve Windows kutucuk
+      görsellerini, bildirimi ve sayfanıza yapıştıracağınız HTML bloğunu da alın.
+      Tek dosyadan fazlası tek bir zip olarak iner."""
+
+[[faq]]
+q = "Görselim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Resim kendi donanımınızda, kendi tarayıcınız tarafından çözülür ve
+        ölçeklenir; .ico da o piksellerden, bu sayfadan sunulan kodla kurulur. Bu
+        aracın hiçbir türde ağ özelliği yoktur &mdash; hiçbir zaman bir şey
+        getirmez ve hiçbir zaman bir şey göndermez &mdash; ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar; bunların hiçbiri bu siteye ait değildir."""
+
+[[faq]]
+q = "Bir favicon.ico hangi boyutları içermeli?"
+a = """
+        16, 32 ve 48. Bu bir tercih değildir: 16, bir tarayıcının bir sekmede
+        çizdiğidir; 32, Windows'un bir masaüstü kısayolu için kullandığı ve
+        birkaç tarayıcının bir yer imi için kullandığıdır; 48 ise Google'ın bir
+        site simgesini okuduğu boyuttur. Daha büyüğü .ico'nun içinde değil
+        yanında bir PNG'de olmalıdır &mdash; buradaki web sitesi setinin ürettiği
+        de budur."""
+
+[[faq]]
+q = "Bir Windows uygulama simgesi hangi boyutlara ihtiyaç duyar?"
+a = """
+        16, 32, 48 ve 256; Visual Studio'nun kendi varsayılan app.ico'sunun
+        tuttuğu da budur. 16 başlık çubuğu ve küçük Explorer görünümü, 32 masaüstü
+        ve görev çubuğu, 48 Explorer'ın orta simgeleri ve 256 başlat menüsü ile
+        çok büyük görünümdür. Yüksek yoğunluklu bir ekranda Windows ayrıca 20, 24,
+        40, 64 ve 96'yı da ister ve yoklarsa elindeki en yakın boyuttan yeniden
+        örnekler &mdash; "her ölçek" hazır ayarı onları da koyar."""
+
+[[faq]]
+q = "Dosya neden başladığım resimden büyük?"
+a = """
+        Çünkü bir .ico tek bir resim değil birkaç resimdir ve küçük olanlar, her
+        şey okuyabilsin diye sıkıştırılmadan saklanır. 32x32'lik bir girdi içinde
+        ne olursa olsun tam 4.264 bayttır ve sıkıştırılmamış bir 256x256 girdisi
+        264 KB'dir &mdash; 64'ün üstündeki boyutların varsayılan olarak PNG
+        saklanmasının sebebi de budur. "Her boyut için PNG" seçmek var olan en
+        küçük dosyayı yapar; her boyut için sıkıştırılmamışı seçmek ise en
+        uyumlusunu."""
+
+[[faq]]
+q = "PNG ve sıkıştırılmamış girdiler arasındaki fark ne?"
+a = """
+        Yalnızca piksellerin .ico içinde nasıl saklandığı. Sıkıştırılmamış bir
+        girdi, özgün Windows düzenidir &mdash; bir bit eşlem başlığı, baş aşağı
+        pikseller ve bir bitlik bir saydamlık maskesi &mdash; ve şimdiye kadar
+        çıkmış her Windows sürümü onu okuyabilir. Bir PNG girdisi ise simgenin
+        içine sıkıştırılmış bütün bir PNG dosyasıdır; büyük boyutlarda üç ila on
+        kat daha küçüktür ama yalnızca Windows Vista'dan itibaren anlaşılır.
+        Varsayılan, her birini kazandığı yerde kullanır: 64 piksele kadar
+        sıkıştırılmamış, üstünde PNG."""
+
+[[faq]]
+q = "256 pikselden büyük bir simge yapabilir mi?"
+a = """
+        Hayır ve hiçbir şey yapamaz. Biçim her kenarı tek bir baytta saklar ve
+        0'ın bir karşılığı vardır &mdash; 256 demektir. Tavan budur; yani içinde
+        512 piksellik bir görüntü olan bir .ico daha büyük bir simge değil bozuk
+        bir simgedir. 512 gerekiyorsa bir PNG gerekir ki web sitesi setinin
+        Android ve bir web uygulamasının açılış ekranı için içerdiği de odur."""
+
+[[faq]]
+q = "Saydamlığı koruyor mu?"
+a = """
+        Evet, her iki girdi türünde de; ayrıca alfa kanalının yanına eski bir
+        bitlik maskeyi de yazar, böylece alfayı okuyamayacak kadar eski yazılımlar
+        siyah bir kutu çizmek yerine simgeyi yine de kesip çıkarır. Bilinçli
+        olarak opak yapılan tek dosya, web sitesi setindeki Apple dokunma
+        simgesidir: iOS onu kendi kutucuğuna yerleştirir ve saydamlığı siyaha
+        çevirir; bu yüzden varsayılan olarak beyaz olan arka plan renginize
+        düzleştirilir."""
+
+[[faq]]
+q = "Logom geniş, kelime biçiminde. Ona ne olur?"
+a = """
+        Bir şey olmak zorunda, çünkü bir simge karedir. Doldurmak her şeyi korur
+        ve küçültür &mdash; 16 piksellik bir kareye doldurulmuş bir kelime logosu
+        yaklaşık üç piksel yüksekliğinde ve okunmazdır. Ortaya kırpmak genellikle
+        daha iyi sonuç verir: neredeyse her markanın faviconu için yaptığı gibi,
+        semboli kompozisyondan çıkarıp onu kullanın. Ön izleme, siz bir şey
+        indirmeden önce hangisinin hayatta kaldığını gösterir."""
+
+[[faq]]
+q = "Web sitesi setinde neler var ve hepsine ihtiyacım var mı?"
+a = """
+        Yedi PNG, bir web uygulaması bildirimi, bir browserconfig.xml ve
+        yapıştırılacak bir HTML bloğu. Onlara ihtiyacınız var, çünkü bir .ico
+        tarayıcıları ve Windows'u kapsar, başka hiçbir şeyi kapsamaz: bir iPhone
+        ana ekranı kendi adıyla 180 piksellik bir PNG okur, Android ve her kurulum
+        istemi bildirimi okur ve başlat menüsüne sabitlenmiş bir kutucuk XML'i
+        okur. Bunların hiçbiri bir .ico'nun içine bakmaz. Her şey burada, sizin
+        makinenizde üretilir ve zip'in içinde her dosyanın ne işe yaradığını
+        söyleyen bir not vardır."""
+
+[[faq]]
+q = "Bir macOS simgesi de yapabilir mi?"
+a = """
+        Evet &mdash; <em>macOS simgesi</em>'ni işaretleyin;
+        <code>.ico</code>'nun yanında ya da onun yerine bir <code>.icns</code>
+        alın. Aynı fikrin başka bir kabıdır ve iki sistem de diğerininkini
+        okumaz: Windows .ico ister, bir Mac uygulama paketi ise .icns ister.
+        Orada boyutlar bir seçim değildir, çünkü Apple tam olarak on yuva
+        yayımlar &mdash; 16, 32, 64, 128, 256, 512 ve 1024 piksel; bunlardan üçü,
+        bir altındaki boyutun Retina sürümü olarak iki kez görünür. Onu da girer;
+        yedi çizimden çıkarılırlar ve bir .icns'in daha büyük dosya olmasının
+        sebebi de budur."""
+
+[[faq]]
+q = ".icns dosyasını nasıl kullanırım?"
+a = """
+        Bir uygulama için, pakette
+        <code>YourApp.app/Contents/Resources/</code> içine konur ve
+        <code>Info.plist</code> içinde <code>CFBundleIconFile</code> altında
+        adlandırılır; her Mac paketleme aracının bunun için bir alanı vardır.
+        Başka her şey için dosyayı Finder'da seçin, Command-C'ye basın, sonra
+        değiştirmek istediğiniz klasör ya da disk imajında Get Info açın, sol
+        üstteki küçük simgeye tıklayın ve Command-V'ye basın."""
+
+[[faq]]
+q = ".icns, iconutil'in ürettiğiyle aynı mı?"
+a = """
+        Aynı dört harfli türlerle aynı on yuva ve her birinde PNG; bir
+        <code>.iconset</code> klasöründen <code>iconutil</code>'in ürettiği de
+        budur. Bilinçli tek fark: Apple'ın aracı ayrıca, ardından gelen türlerin
+        ve uzunlukların bir dizini olan bir <code>TOC&nbsp;</code> öğesi yazar. Bu,
+        biçimin parçası değil bir iyileştirmedir &mdash; onsuz bir okuyucu öğeleri
+        baştan sona gezer ve aynı cevaba varır &mdash; ve yanlış bir dizin,
+        dizinsizlikten kötüdür; bu yüzden dışarıda bırakılır."""
+
+[[faq]]
+q = "Aynı anda birkaç resmi dönüştürebilir miyim?"
+a = """
+        Evet. Listedeki her resim aynı ayarlarla kendi .ico'suna dönüşür ve yığın,
+        resim başına bir klasör içeren tek bir zip olarak iner &mdash; yoksa
+        ikisinin de adı favicon.ico olur ve biri diğerinin üzerine yazardı.
+        İşaretlediğiniz her çıktı, her resim için üretilir. O resmi ön izlemeye
+        koymak için herhangi bir satıra tıklayın."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok.
+        Dosyaların sayısında ya da boyutunda da bir sınır yok, çünkü bunların
+        bedelini ödeyen bir sunucu yok &mdash; iş sizin kendi cihazınızda oluyor.
+        Sitede reklam var, masrafı karşılayan da o; reklamlara görselleriniz
+        hakkında hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: logonuzu dönüştürülmek üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir görseli tarayıcıda çok boyutlu bir Windows ICO dosyasına ya da bir macOS ICNS dosyasına dönüştürün. Web sitesi faviconu, Windows uygulama simgesi ve yüksek yoğunluklu uygulama simgesi için hazır ayarlar, Apple'ın on icns yuvası, her boyutun gerçek piksel boyutunda ön izlemesi ve bir web sitesinin ihtiyaç duyduğu Apple, Android ve Windows kutucuk dosyalarından oluşan isteğe bağlı bir set. Hiçbir şey yüklenmez."
+features = [
+  "16'dan 256 piksele, gerçek çok boyutlu bir .ico yazar",
+  "16'dan 1024 piksele, Apple'ın on yuvasının hepsiyle bir macOS .icns yazar",
+  "Tek resimden, tek geçişte iki biçim; her boyut yalnızca bir kez çizilir",
+  "Web sitesi faviconu, Windows uygulama simgesi, yüksek yoğunluklu Windows ve azami uyum için hazır ayarlar",
+  "Her boyut onu neyin istediğini söyler, böylece hiçbir şey boşuna girmez",
+  "Küçük boyutlar için sıkıştırılmamış girdiler ve büyükler için PNG ya da tamamı ikisinden biri",
+  "Saydamlığı korur ve Vista öncesi saydamlık maskesini de yazar",
+  "Kare olmayan bir resmi doldurun, kırpın ya da esnetin; bir rengin üzerinde ya da hiçbir şeyin",
+  "İndirmeden önce her boyutu gerçek piksel boyutunda gösterir",
+  "İsteğe bağlı web sitesi seti: Apple dokunma simgesi, Android simgeleri, maskelenebilir simge, Windows kutucuğu, bildirim ve yapıştırılacak HTML",
+  "Toplu işlem, tüm sonuçlar tek bir zip içinde",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Bir resmi buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; PNG, JPEG, WebP, SVG ve tarayıcınızın açabildiği her şey"

--- a/locales/tr/tools/images-to-pdf.html
+++ b/locales/tr/tools/images-to-pdf.html
@@ -1,0 +1,235 @@
+<!--
+  tools/images-to-pdf/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; görseller -->
+  <section class="card">
+    <h2><span class="step">1</span> Görselleri seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" data-sort="name" class="ghost">Ada göre sırala</button>
+        <button type="button" data-sort="date" class="ghost">Tarihe göre sırala</button>
+        <button type="button" data-sort="reverse" class="ghost">Ters çevir</button>
+        <button type="button" id="clear-all" class="ghost danger">Hepsini kaldır</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Bu sırayla, sayfa başına bir görsel. Bir sayfayı taşımak için
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> tutamağından
+      sürükleyin ya da üzerindeki okları kullanın.
+    </p>
+
+    <ul id="image-list" class="image-list"></ul>
+  </section>
+
+  <!-- Adım 2 &mdash; sayfalar -->
+  <section class="card">
+    <h2><span class="step">2</span> Sayfa düzeni</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Sayfa boyutu</label>
+        <select id="page-size">
+          <option value="fit" selected>Sayfayı her görsele uydur</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 inç</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 inç</option>
+          <option value="a3">A3 &mdash; 297 &times; 420 mm</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+          <option value="tabloid">Tabloid &mdash; 11 &times; 17 inç</option>
+          <option value="custom">Özel&hellip;</option>
+        </select>
+        <div id="custom-size" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="1" max="5000" step="1" value="210"
+                 aria-label="Özel sayfa genişliği">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="1" max="5000" step="1" value="297"
+                 aria-label="Özel sayfa yüksekliği">
+          <select id="custom-unit" aria-label="Özel sayfa boyutunun birimi">
+            <option value="mm" selected>mm</option>
+            <option value="in">inç</option>
+          </select>
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Baskı çözünürlüğü</label>
+        <select id="dpi">
+          <option value="72">72 DPI &mdash; ekran</option>
+          <option value="96">96 DPI</option>
+          <option value="150" selected>150 DPI</option>
+          <option value="200">200 DPI</option>
+          <option value="300">300 DPI &mdash; baskı</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Belirli bir piksel sayısı için sayfanın ne kadar büyük olacağını
+          belirler. Görüntüyü değiştirmez.
+        </p>
+      </div>
+
+      <div class="field" id="orientation-field" hidden>
+        <label for="orientation">Yön</label>
+        <select id="orientation">
+          <option value="auto" selected>Her görsele uy</option>
+          <option value="portrait">Dikey</option>
+          <option value="landscape">Yatay</option>
+        </select>
+      </div>
+
+      <div class="field" id="fit-field" hidden>
+        <label for="fit">Görsel sayfada nasıl dursun</label>
+        <select id="fit">
+          <option value="contain" selected>Kenar boşluklarının içine sığdır</option>
+          <option value="cover">Sayfayı doldur (kenarları kırpar)</option>
+          <option value="stretch">Kenar boşluklarına kadar esnet (bozar)</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="margin">Kenar boşluğu</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="100" step="1" value="0"
+                 aria-label="Milimetre cinsinden kenar boşluğu">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="background">Sayfa rengi</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Kenar boşluklarında ve saydam olan her şeyin arkasında görünür.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="mode">Görsel kalitesi</label>
+        <select id="mode">
+          <option value="keep" selected>JPEG'leri tam olarak oldukları gibi koru</option>
+          <option value="jpeg">Her şeyi JPEG olarak yeniden kodla</option>
+          <option value="lossless">Kayıpsız &mdash; hiç sıkıştırma kaybı yok</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">JPEG kalitesi</label>
+        <select id="quality">
+          <option value="0.75">Daha küçük dosya</option>
+          <option value="0.88" selected>Dengeli</option>
+          <option value="0.95">En iyi kalite</option>
+        </select>
+        <p class="field-note">Yalnızca bu aracın yeniden kodlamak zorunda olduğu resimler için kullanılır.</p>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Büyük görselleri küçült</label>
+        <select id="max-side">
+          <option value="0" selected>Asla &mdash; tam boyutta kalsın</option>
+          <option value="4000">En uzun kenar 4000 px</option>
+          <option value="2000">En uzun kenar 2000 px</option>
+          <option value="1200">En uzun kenar 1200 px</option>
+        </select>
+        <p class="field-note" id="shrink-note"></p>
+      </div>
+    </div>
+
+    <details class="meta-panel">
+      <summary>Belge ayrıntıları &mdash; hepsi isteğe bağlı, hepsi varsayılan olarak boş</summary>
+      <div class="meta-body">
+        <p class="meta-note">
+          Bir PDF, kendisi hakkında küçük bir bilgi bloğu taşır ve çoğu araç bunu
+          siz istesiniz istemeyin bir zaman damgası ve bir program adıyla
+          doldurur. Bu araç buraya yazdığınızı yazar, başka bir şey yazmaz: dosya
+          adı yok, makine adı yok ve kutusunu işaretlemediğiniz sürece tarih yok.
+        </p>
+        <div class="settings">
+          <div class="field">
+            <label for="doc-title">Başlık</label>
+            <input type="text" id="doc-title" maxlength="200" spellcheck="false"
+                   placeholder="Boşsa yazılmaz">
+          </div>
+          <div class="field">
+            <label for="doc-author">Yazar</label>
+            <input type="text" id="doc-author" maxlength="200" spellcheck="false"
+                   placeholder="Boşsa yazılmaz">
+          </div>
+          <div class="field">
+            <label for="file-name">Dosya adı</label>
+            <div class="inline-pair">
+              <input type="text" id="file-name" maxlength="120" spellcheck="false"
+                     value="gorseller">
+              <span class="unit-label">.pdf</span>
+            </div>
+          </div>
+          <div class="field checkbox-field">
+            <label for="dated">
+              <input type="checkbox" id="dated">
+              Bugünün tarihini belgeye kaydet
+            </label>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="480" height="640" aria-label="Bir sayfanın ön izlemesi"></canvas>
+        <p id="preview-empty" class="preview-empty">Sayfaları görmek için görsel ekleyin</p>
+        <div id="preview-nav" class="preview-nav" hidden>
+          <button type="button" id="preview-prev" class="ghost" aria-label="Önceki sayfa">&lsaquo;</button>
+          <span id="preview-label" class="preview-label"></span>
+          <button type="button" id="preview-next" class="ghost" aria-label="Sonraki sayfa">&rsaquo;</button>
+        </div>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Sayfalar</dt><dd id="sum-pages">&mdash;</dd></div>
+        <div><dt>Sayfa boyutu</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Seçilen görseller</dt><dd id="sum-input">&mdash;</dd></div>
+        <div><dt>El değmeden kopyalanan</dt><dd id="sum-copied">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; dışa aktarma -->
+  <section class="card">
+    <h2><span class="step">3</span> PDF'i oluşturun</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>PDF oluştur</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>PDF'i indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/images-to-pdf.toml
+++ b/locales/tr/tools/images-to-pdf.toml
@@ -1,0 +1,225 @@
+#
+# Görsellerden PDF'e - Türkçe.
+#
+# Overrides for tools/images-to-pdf/tool.toml. Only words: the slug, the
+# category, the icon and the list of shared parts stay where they are.
+#
+
+name = "Görsellerden PDF'e"
+heading = "Görsellerden&nbsp;PDF'e <span class=\"h1-kw\">&mdash; JPG'den PDF'e dönüştürücü</span>"
+tagline = "Resimlerinizi tek bir belgeye koyun."
+
+title = "Görsellerden PDF Dönüştürücü &mdash; Ücretsiz JPG'den PDF'e, Yüklemesiz"
+description = "JPG, PNG veya WebP görselleri tek bir PDF'te birleştirin; ücretsiz ve tamamen tarayıcınızda. Fotoğraflar yeniden kodlanmadan girer ve hiçbir şey yüklenmez."
+og_title = "Görsellerden PDF'e &mdash; ücretsiz JPG'den PDF'e dönüştürücü"
+og_description = "Görselleri kendi cihazınızda tek bir PDF'te birleştirin. JPEG fotoğraflar el değmeden kopyalanır; yani hiçbir şey kalite kaybetmez ve hiçbir şey yüklenmez."
+og_image_alt = "Görsellerden PDF'e - resimleri yüklemeden tek bir belgede birleştirin"
+
+pledge = """
+    Belge bu makinenin belleğinde, sayfa sayfa yazılır; bunu yapan kod da bu
+    adresten sunuluyor. Buradaki hiçbir şey bir yükleme yapamaz ve bu sayfanın
+    öbür ucunda bir yüklemeyi alacak bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir PDF yapın. Tek bir istek bile bir görsel, bir küçük resim ya
+      da bir dosya adı taşımıyor. Ya da internet bağlantısını kesip yine de bir
+      tane yapın."""
+
+read_first = """
+, ve dosya yazma işinin tamamı için
+      <code>src/pdf.js</code> ile <code>src/document.js</code>; ikisi de ağa hiç
+      dokunmaz."""
+
+howto_heading = "Görseller PDF'e nasıl çevrilir"
+
+card = """
+            Görselleri tek bir PDF'te, sayfa başına bir resim olacak şekilde
+            birleştirin. JPEG fotoğraflar tam olarak oldukları gibi kopyalanır;
+            yani hiçbir şey kalite kaybetmez."""
+
+[words]
+plural = "görselleriniz"
+choose = "görseller"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "Görsellerinizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Bu araç o listeye hiçbir şey eklemez: isteğe bağlı
+      olanı bile yok, kendine ait bir ağ özelliği hiç yok. Dosyalarınızın
+      toplanabileceği bir uç nokta burada yok, olsaydı bile onları oraya
+      gönderecek bir kod yok."""
+
+[[privacy]]
+title = "PDF burada yazılıyor."
+body = """
+ Bir PDF, nesnelerden oluşan bir liste ve
+      her birinin nerede başladığını gösteren bir tablodur;
+      <code>src/pdf.js</code> ikisini de yazar. Hiçbir kitaplık getirilmiyor,
+      hiçbir şey bir sunucuda çizilmiyor ve bitmiş dosya bellekten doğrudan bir
+      indirmeye veriliyor."""
+
+[[privacy]]
+title = "Belgeye sizin hakkınızda hiçbir şey söylenmiyor."
+body = """
+ Çoğu araç bir
+      PDF'e bir zaman damgası ve onu yapan programın adını basar. Bu araç bir
+      başlığı, bir yazarı ve bir tarihi yalnızca siz yazarsanız yazar;
+      resimlerinizin dosya adları belgede hiç görünmez, makineniz hakkında bir
+      şey de görünmez."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine görselleriniz hakkında bir şey verilmiyor: ne
+      bir dosya, ne bir küçük resim, ne bir ad, bir boyut ya da bir sayı. Bir
+      resmi okuyan, çözen ya da yazan her satır bu kaynaktan sunuluyor ve depoda
+      listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de görselleriniz
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu: resimlerinizi
+      belge yapılmak üzere uzağa gönderen bir araç dururdu."""
+
+[[howto]]
+title = "Görsellerinizi seçin."
+body = """
+ Seçiciye bir klasör bırakın ya da
+      dosyaları elle seçin. Tarayıcı onları doğrudan diskinizden okur; siz bunu
+      yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Sayfaları sıraya koyun ve gerekenleri döndürün."
+body = """
+ Bir görsel,
+      gösterilen sırayla bir sayfa olur. Bir kutucuğu taşımak için tutamağından
+      sürükleyin ya da okları kullanın; döndürme düğmeleri bir sayfayı çeyrek
+      çeyrek çevirir ki yan taranmış bir belgenin genellikle ihtiyacı budur."""
+
+[[howto]]
+title = "Bir sayfa boyutu seçin."
+body = """
+ "Sayfayı her görsele uydur", her
+      sayfayı tam olarak kendi resmi yapar; hiçbir şey kırpılmaz ve beyaz bantlar
+      olmaz. Adlandırılmış boyutlar &mdash; A4, Letter, Legal ve gerisi &mdash;
+      bunun yerine her resmi sabit bir sayfaya yerleştirir, isterseniz bir
+      kenar boşluğuyla."""
+
+[[howto]]
+title = "PDF'i oluşturun ve indirin."
+body = """
+ Belge kendi cihazınızda yazılır,
+      yani ne kadar süreceği bir sıraya değil donanımınıza bağlıdır. Bitmiş dosya
+      doğrudan tarayıcınızın indirmelerine verilir."""
+
+[[faq]]
+q = "Görsellerim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Görselleriniz kendi donanımınızda, kendi tarayıcınız tarafından
+        okunur ve PDF de orada yazılır. Bu aracın sunucu tarafı yoktur ve
+        sayfanın <code>Content-Security-Policy</code>'si iletişim kurabileceği
+        her adresi tek tek sayar &mdash; bunların hiçbiri bu siteye ait
+        değildir. Buradaki bazı diğer araçların aksine bunun isteğe bağlı bir ağ
+        özelliği de hiç yoktur."""
+
+[[faq]]
+q = "PDF'e dönüştürmek kalite kaybettirir mi?"
+a = """
+        Varsayılan ayarda bir JPEG için hayır. PDF, JPEG verisini doğrudan
+        taşıyabilir; yani bir fotoğraf belgeye bayt bayt kopyalanır: hiç
+        çözülmez ve bir daha hiç sıkıştırılmaz, PDF'teki görüntü dosyadaki
+        görüntüdür. Diğer biçimlerin yeniden kodlanması gerekir, çünkü PDF'te
+        onlar için bir filtre yoktur &mdash; daha büyük bir dosya pahasına onları
+        tam olarak saklayan kayıpsız ayarı seçmediğiniz sürece."""
+
+[[faq]]
+q = "Hangi görsel biçimlerini kullanabilirim?"
+a = """
+        Tarayıcınızın çözebildiği her hareketsiz görseli; pratikte bu JPG, PNG,
+        WebP, GIF, AVIF ve Apple cihazlarda HEIC demektir. Burada güncel
+        tutulacak ayrı bir liste yok, çünkü çözme işi bizim değil tarayıcının
+        işi."""
+
+[[faq]]
+q = "Sayfa boyutunu ve sayfaların sırasını seçebilir miyim?"
+a = """
+        Evet. Sayfalar A4, Letter, Legal, A3, A5, Tabloid, yazdığınız bir boyut
+        ya da tam olarak her resmin boyutu olabilir. Sıralamak için kutucukları
+        sürükleyin, ada ya da tarihe göre sıralayın, herhangi birini çeyrek dönüş
+        döndürün ve milimetre cinsinden kenar boşluğu verin."""
+
+[[faq]]
+q = "Bir PDF'e kaç görsel koyabilirim?"
+a = """
+        Araçta yerleşik bir sınır yok. Pratik tavan kendi makinenizin belleği,
+        çünkü bitmiş belge siz indirmeden önce orada kuruluyor. Bunu ilk hisseden
+        şey, tam çözünürlükte birkaç yüz telefon fotoğrafıdır; ayarlardan en uzun
+        kenarı küçültmek o tavanı epeyce yukarı taşır."""
+
+[[faq]]
+q = "PDF, dosya adlarımı ya da bir zaman damgası içeriyor mu?"
+a = """
+        Siz istemedikçe hayır. Belge bilgi bloğu, bu aracın adı dışında boş
+        bırakılır: dosya adı yok, makine adı yok, kullanıcı adı yok ve kutusunu
+        işaretlemediğiniz sürece oluşturulma tarihi yok. Bu bilinçli bir tercih
+        &mdash; bir PDF, insanların başka insanlara gönderdiği bir şeydir."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok. Sitede reklam var,
+        masrafı karşılayan da o; reklamlara görselleriniz hakkında hiçbir şey
+        verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: görsellerinizi belge yapılmak üzere uzağa
+        gönderen bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "JPG, PNG ve WebP görselleri tek bir PDF belgesinde birleştirin. Her sayfa tarayıcınızda yazılır; böylece hiçbir görsel yüklenmez."
+features = [
+  "JPG, PNG, WebP, GIF ve AVIF görselleri tek bir PDF'te birleştirir",
+  "JPEG fotoğraflar yeniden kodlanmadan gömülür",
+  "A5'ten Tabloid'e sayfa boyutları ya da her görsele uydurulmuş sayfa",
+  "Sıralama, döndürme, kenar boşluğu ve sayfa rengi",
+  "Taramalar ve ekran görüntüleri için isteğe bağlı kayıpsız saklama",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Görselleri buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/tr/tools/images-to-video.html
+++ b/locales/tr/tools/images-to-video.html
@@ -1,0 +1,173 @@
+<!--
+  tools/images-to-video/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; görseller -->
+  <section class="card">
+    <h2><span class="step">1</span> Görselleri seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    {% include "partials/url-import.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Listenin nasıl gösterileceğini değiştir">
+          <button type="button" data-view="large" class="active">Büyük</button>
+          <button type="button" data-view="small">Küçük</button>
+          <button type="button" data-view="list">Liste</button>
+          <button type="button" data-view="details">Ayrıntılar</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Ada göre sırala</button>
+        <button type="button" data-sort="date" class="ghost">Tarihe göre sırala</button>
+        <button type="button" data-sort="reverse" class="ghost">Ters çevir</button>
+        <button type="button" id="clear-all" class="ghost danger">Hepsini kaldır</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Sıralamayı değiştirmek için herhangi bir görseli
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> tutamağından
+      sürükleyin ya da her birinin üzerindeki okları kullanın.
+    </p>
+
+    <ul id="image-list" class="image-list view-large"></ul>
+
+    <div id="bulk-duration" class="bulk" hidden>
+      <label for="bulk-amount">Her görseli şu kadar tut</label>
+      <input type="number" id="bulk-amount" min="1" max="3600" step="1" value="1">
+      <select id="duration-unit" aria-label="Her görselin ne kadar tutulacağının birimi">
+        <option value="frames" selected>kare</option>
+        <option value="seconds">saniye</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Hepsine uygula</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Adım 2 &mdash; ayarlar -->
+  <section class="card">
+    <h2><span class="step">2</span> Video ayarları</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="resolution">Çözünürlük</label>
+        <select id="resolution">
+          <option value="auto" selected>En yüksek çözünürlükle eşleş</option>
+          <option value="3840x2160">3840 &times; 2160 &mdash; 4K</option>
+          <option value="1920x1080">1920 &times; 1080 &mdash; 1080p</option>
+          <option value="1280x720">1280 &times; 720 &mdash; 720p</option>
+          <option value="1080x1080">1080 &times; 1080 &mdash; kare</option>
+          <option value="1080x1920">1080 &times; 1920 &mdash; dikey</option>
+          <option value="custom">Özel&hellip;</option>
+        </select>
+        <div id="resolution-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="7680" step="2" value="1920"
+                 aria-label="Piksel olarak özel çıktı genişliği">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="7680" step="2" value="1080"
+                 aria-label="Piksel olarak özel çıktı yüksekliği">
+        </div>
+        <p class="field-note" id="resolution-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Kare hızı</label>
+        <select id="fps">
+          <option value="12">12 fps</option>
+          <option value="15">15 fps</option>
+          <option value="24">24 fps &mdash; sinema</option>
+          <option value="25">25 fps &mdash; PAL</option>
+          <option value="30" selected>30 fps</option>
+          <option value="50">50 fps</option>
+          <option value="60">60 fps</option>
+          <option value="custom">Özel&hellip;</option>
+        </select>
+        <input type="number" id="fps-custom" class="spaced" min="1" max="120" step="1" value="30"
+               aria-label="Saniyedeki kare olarak özel kare hızı" hidden>
+        <p class="field-note" id="fps-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Görsel yerleşimi</label>
+        <select id="fit">
+          <option value="contain" selected>İçine sığdır (bantlı)</option>
+          <option value="blur">İçine sığdır, bulanık arka plan</option>
+          <option value="cover">Kareyi doldur (kenarları kırpar)</option>
+          <option value="stretch">Doldurmak için esnet (bozar)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Arka plan rengi</label>
+        <input type="color" id="background" value="#000000">
+      </div>
+
+      <div class="field">
+        <label for="quality">Kalite</label>
+        <select id="quality">
+          <option value="low">Daha küçük dosya</option>
+          <option value="medium" selected>Dengeli</option>
+          <option value="high">En iyi kalite</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="format">Biçim</label>
+        <select id="format">
+          <option value="auto" selected>MP4 (önerilen)</option>
+          <option value="webm">WebM (yedek)</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="640" height="360" aria-label="İlk karenin ön izlemesi"></canvas>
+        <p id="preview-empty" class="preview-empty">Ön izleme için görsel ekleyin</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Görseller</dt><dd id="sum-images">&mdash;</dd></div>
+        <div><dt>Süre</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Çıktı boyutu</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Toplam kare</dt><dd id="sum-frames">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; dışa aktarma -->
+  <section class="card">
+    <h2><span class="step">3</span> Videoyu oluşturun</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Video oluştur</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Videoyu indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/images-to-video.toml
+++ b/locales/tr/tools/images-to-video.toml
@@ -1,0 +1,237 @@
+#
+# Görsellerden Videoya - Türkçe.
+#
+# Overrides for tools/images-to-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Görsellerden Videoya"
+heading = "Görsellerden&nbsp;Videoya <span class=\"h1-kw\">&mdash; MP4 slayt gösterisi yapın</span>"
+tagline = "Bir görsel klasörünü videoya çevirin."
+
+title = "Görsel Dizisinden MP4'e &mdash; Ücretsiz, Yüklemesiz, Çevrimdışı Çalışır"
+description = "JPG, PNG veya WebP görselleri MP4 slayt gösterisi videosuna çevirin; ücretsiz ve tamamen tarayıcınızda. Hiçbir şey yüklenmez, kayıt gerekmez ve çevrimdışı da çalışır."
+og_title = "Görsel Dizisinden MP4'e &mdash; ücretsiz, tarayıcınızda"
+og_description = "Bir render dizisini, bir time-lapse'i ya da bir fotoğraf klasörünü MP4'e çevirin. Kodlama kendi cihazınızda çalışır; hiçbir şey yüklenmez."
+og_image_alt = "Görsellerden Videoya - bir görsel klasörünü MP4 slayt gösterisine çevirin"
+
+pledge = """
+    Her kare kendi tarayıcınız tarafından kodlanır ve video bu makinenin
+    belleğinde kurulur. Kodlayıcı ağa hiç dokunmaz ve dokunsaydı bile bu
+    sayfanın öbür ucunda bir görselin gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir video yapın. Tek bir istek bile bir görsel, bir küçük resim
+      ya da bir dosya adı taşımıyor. Ya da internet bağlantısını kesip yine de
+      bir tane yapın."""
+
+read_first = """
+, ve ağa hiç dokunmayan kodlama döngüsü için
+      <code>src/encoder.js</code>."""
+
+howto_heading = "Görseller videoya nasıl çevrilir"
+
+card = """
+            Bir görsel klasörünü MP4 slayt gösterisine çevirin. Kodlama kendi
+            cihazınızda, kendi donanımınızla çalışır."""
+
+[words]
+plural = "görselleriniz"
+choose = "görseller"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "Görsellerinizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok. Burada eskiden
+      <code>connect-src 'none'</code> yazıyordu ki bu mutlaktı; reklam eklemek
+      buna mal oldu ve bunu söylemek anlaşmanın bir parçası."""
+
+[[privacy]]
+title = "Kodlama yerelde."
+body = """
+ WebCodecs tarayıcınızda çalışır ve bitmiş
+      dosya doğrudan bir indirmeye verilir. Bu uygulamanın sunucu tarafı
+      yoktur."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine görselleriniz hakkında bir şey verilmiyor: ne
+      bir dosya, ne bir küçük resim, ne bir ad, bir boyut ya da bir sayı. Bir
+      görseli okuyan, çözen, yerleştiren ya da kodlayan her satır bu kaynaktan
+      sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de görselleriniz
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Bilinçli tek istisna."
+body = """
+ "Bir web adresinden ekle"yi
+      kullanırsanız, görseli getirmek için o sunucuyla iletişim kurulur ve o
+      sunucu IP adresinizi görür. Yalnızca sizin yapıştırdığınız görseller
+      getirilir ve yalnızca içeri doğru: <code>img-src</code> açılmıştır,
+      <code>connect-src</code> açılmamıştır. Aşağıdaki sayaç, iletişim kurulan
+      her dış kaynağı listeler."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, web adresinden
+      yükleme dışında her şey çalışmaya devam eder. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "Görsellerinizi seçin."
+body = """
+ Seçiciye bir klasör bırakın ya da
+      dosyaları elle seçin. Tarayıcı onları doğrudan diskinizden okur; siz bunu
+      yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Sıraya koyun ve her birinin ne kadar duracağını ayarlayın."
+body = """
+      Sıralamayı değiştirmek için sürükleyin. Bekleme süresi kare ya da saniye
+      olarak verilebilir; ya hepsine birden ya da tek tek."""
+
+[[howto]]
+title = "Bir çözünürlük ve kare hızı seçin."
+body = """
+ "En yüksek
+      çözünürlükle eşleş" en büyük görselinizi izler; hazır ayarlar 4K, 1080p,
+      720p, kare ve dikeyi kapsar ve hiçbiri uymazsa özel bir boyut da var."""
+
+[[howto]]
+title = "Videoyu oluşturun ve indirin."
+body = """
+ Kodlama kendi donanımınızda
+      çalışır, yani ne kadar süreceği bir sıraya değil makinenize bağlıdır.
+      Bitmiş MP4 doğrudan tarayıcınızın indirmelerine verilir."""
+
+[[faq]]
+q = "Görsellerim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Görselleriniz kendi donanımınızda, kendi tarayıcınız tarafından
+        okunur, yerleştirilir ve kodlanır. Bu aracın sunucu tarafı yoktur ve
+        sayfanın <code>Content-Security-Policy</code>'si iletişim kurabileceği
+        her adresi tek tek sayar &mdash; bunların hiçbiri bu siteye ait
+        değildir. Tek istisna, yapıştırdığınız bir görseli getiren isteğe bağlı
+        "bir web adresinden ekle" özelliğidir ve o sunucu IP adresinizi
+        görür."""
+
+[[faq]]
+q = "Hangi görsel biçimlerini kullanabilirim?"
+a = """
+        Tarayıcınızın çözebildiği her hareketsiz görsel biçimini; pratikte bu
+        JPG, PNG, WebP, GIF, AVIF ve Apple cihazlarda HEIC demektir. Burada
+        güncel tutulacak ayrı bir liste yok, çünkü çözme işi bizim değil
+        tarayıcının işi."""
+
+[[faq]]
+q = "Hangi video biçimini üretiyor?"
+a = """
+        H.264 görüntülü MP4 ki bu neredeyse her şeyde oynar. WebCodecs olmayan
+        bir tarayıcıda araç bunun yerine WebM kaydına düşer &mdash; aynı
+        görüntü, daha az düzenleyicinin kabul ettiği bir kapta."""
+
+[[faq]]
+q = "Bunu bir Blender veya After Effects render dizisi için kullanabilir miyim?"
+a = """
+        Evet &mdash; numaralandırılmış bir render dizisi tam da bunun için.
+        Render'ınızın yazdığı kareleri ekleyin, bekleme süresini kare başına bir
+        karede bırakın ve kare hızını render'la eşleştirin. "Ada göre sırala"
+        beklediğiniz gibi sayar, yani <code>frame_2</code>, sonrasına değil
+        <code>frame_10</code>'un öncesine düşer.
+        <br><br>
+        Başlamadan önce bilinmeye değer bir şey: H.264'ün alfa kanalı yoktur, bu
+        yüzden saydamlık karşıya taşınmaz, arka plan rengine düzleştirilir. Alfa
+        kanalını korumanız gerekiyorsa kareleri kendi düzenleyicinizde
+        birleştirin."""
+
+[[faq]]
+q = "Fotoğraflardan time-lapse yapabilir miyim?"
+a = """
+        Evet ve bu, bir render dizisiyle aynı iş: her fotoğrafı tek bir kare
+        tutun ve bir kare hızı seçin. 30 fps'te her otuz fotoğraf bir saniye
+        video olur; 12 fps'te aynı fotoğraflar iki buçuk saniye sürer.
+        <br><br>
+        "Tarihe göre sırala" bir kamera rulosunu çekildiği sıraya geri koyar ki
+        dosya adları 0001'den yeniden başlamışsa bu önemlidir. Farklı
+        boyutlardaki fotoğraflar sorun değil &mdash; "En yüksek çözünürlükle
+        eşleş" videoyu hiçbiri küçültülmeyecek şekilde boyutlandırır."""
+
+[[faq]]
+q = "Kaç görsel kullanabileceğime ya da videonun ne kadar uzun olabileceğine dair bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok. Pratik tavan kendi makinenizin belleği,
+        çünkü bitmiş video siz indirmeden önce orada kuruluyor. Bunu ilk hisseden
+        şey çok büyük 4K slayt gösterileridir."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok. Sitede reklam var,
+        masrafı karşılayan da o; reklamlara görselleriniz hakkında hiçbir şey
+        verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: görsellerinizi işlenmek üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[[faq]]
+q = "Müzik veya ses parçası ekleyebilir miyim?"
+a = """
+        Henüz değil. Araç yalnızca görüntü üretir: yazdığı MP4'te tek bir video
+        parçası vardır, ses parçası yoktur. Gerekiyorsa ses parçasını sonradan
+        bir video düzenleyicide ekleyin."""
+
+[schema]
+browser_requirements = "JavaScript gerekir. MP4 çıktısı için WebCodecs destekleyen bir tarayıcı gerekir; diğerleri WebM'e düşer."
+description = "Bir görsel klasörünü MP4 slayt gösterisi videosuna çevirin. Her adım tarayıcınızda çalışır; böylece hiçbir görsel yüklenmez."
+features = [
+  "JPG, PNG, WebP, GIF ve AVIF görselleri videoya dönüştürür",
+  "MP4 (H.264) çıktı, yedek olarak WebM",
+  "3840x2160'a kadar çözünürlükler, 12 ila 60 fps kare hızları",
+  "Görsel başına kare ya da saniye cinsinden bekleme süresi",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Görselleri buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+[picker.urls]
+summary = "Bir web adresinden ekle"
+button = "Görselleri indir"
+noun = "görsel"

--- a/locales/tr/tools/merge-pdf.html
+++ b/locales/tr/tools/merge-pdf.html
@@ -1,0 +1,166 @@
+<!--
+  tools/merge-pdf/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+  The range tokens - odd, even, all, last - are typed into the box and parsed
+  by src/ranges.js, so they stay in English here.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosyalar -->
+  <section class="card">
+    <h2><span class="step">1</span> PDF'lerinizi seçin</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <ul id="source-list" class="source-list" hidden></ul>
+  </section>
+
+  <!-- Adım 2 &mdash; sayfalar -->
+  <section class="card" id="pages-card" hidden>
+    <h2><span class="step">2</span> Sayfaları düzenleyin</h2>
+
+    <p class="card-lede">
+      Seçtiğiniz her dosyanın her sayfası, çıkacakları sırayla. Taşımak için
+      birini <span class="grip" aria-hidden="true">&#8942;&#8942;</span>
+      tutamağından sürükleyin, oklarla döndürün ya da &times; ile çıkarın.
+      Burada henüz hiçbir şey yazılmadı &mdash; belge, 4. adımda düğmeye
+      bastığınızda kurulur.
+    </p>
+
+    <div class="toolbar">
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="reverse" class="ghost">Ters çevir</button>
+        <button type="button" id="rotate-all" class="ghost">Her sayfayı döndür</button>
+        <button type="button" id="restore" class="ghost">Geldikleri hâle dön</button>
+        <button type="button" id="clear-all" class="ghost danger">Baştan başla</button>
+      </div>
+    </div>
+
+    <div class="range-row">
+      <label for="range">Sayfalar</label>
+      <input type="text" id="range" placeholder="1-3, 8, 12-" autocomplete="off"
+             spellcheck="false" aria-describedby="range-note">
+      <button type="button" id="range-keep" class="ghost">Yalnızca bunları tut</button>
+      <button type="button" id="range-drop" class="ghost">Bunları kaldır</button>
+      <button type="button" id="range-turn" class="ghost">Bunları döndür</button>
+    </div>
+    <p id="range-note" class="field-note">
+      Aşağıdaki numaralara göre; onlar da siz ilerledikçe yeniden verilir.
+      <code>odd</code>, <code>even</code>, <code>all</code> ve
+      <code>last</code> de çalışır.
+    </p>
+    <p id="range-error" class="error" role="alert" hidden></p>
+
+    <ul id="page-list" class="page-list"></ul>
+  </section>
+
+  <!-- Adım 3 &mdash; tek dosya ya da birkaçı -->
+  <section class="card" id="output-card" hidden>
+    <h2><span class="step">3</span> Tek belge mi, birkaç belge mi</h2>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Sayfalar nasıl yazılsın</legend>
+      <div class="presets" id="split-modes" role="radiogroup" aria-label="Sayfalar nasıl yazılsın">
+        <label class="preset">
+          <input type="radio" name="split" value="single" checked>
+          <span class="preset-body">
+            <strong>Tek belge</strong>
+            <span class="preset-note">Yukarıdaki her şey, o sırayla, tek bir PDF olarak.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="split" value="every">
+          <span class="preset-body">
+            <strong>Her kaç sayfada bir böl</strong>
+            <span class="preset-note">
+              Uzun bir tarama,
+              <input type="number" id="split-size" min="1" max="5000" step="1" value="10"
+                     inputmode="numeric" aria-label="Her dosyadaki sayfa sayısı">
+              sayfalık bölümlere kesilir.
+            </span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="split" value="at">
+          <span class="preset-body">
+            <strong>Şu sayfada böl&hellip;</strong>
+            <span class="preset-note">
+              Şunlardan önce kes:
+              <input type="text" id="split-at" placeholder="5, 9, 14" autocomplete="off"
+                     spellcheck="false" aria-label="Öncesinde kesilecek sayfa numaraları">
+              &mdash; her biri yeni bir dosya başlatır.
+            </span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="split" value="each">
+          <span class="preset-body">
+            <strong>Her sayfa kendi başına</strong>
+            <span class="preset-note">Sayfa başına bir PDF. Bir imza sayfasını çekip almak için kullanışlı.</span>
+          </span>
+        </label>
+        <label class="preset" id="by-file-preset" hidden>
+          <input type="radio" name="split" value="file">
+          <span class="preset-body">
+            <strong>Geldikleri dosyalara geri</strong>
+            <span class="preset-note">Seçtiğiniz her dosya için bir belge, düzenlemeleriniz korunmuş hâlde.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <label class="check">
+      <input type="checkbox" id="keep-bookmarks" checked>
+      <span>
+        <strong>Yer imlerini koru</strong>
+        <span class="check-note">
+          Her dosyanın kendisiyle geldiği içerik ağacı, gerçekten burada olan
+          sayfalara göre yeniden kurulur: sayfasını kaldırdığınız bir girdi
+          gider, bölümü hâlâ burada olan bir girdi kalır. Birkaç dosyayı
+          birleştirmek her birinin yer imlerini o dosyanın adıyla bir başlığın
+          altına koyar.
+        </span>
+      </span>
+    </label>
+
+    <p id="output-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Adım 4 &mdash; tek tıklama -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Bir araya getirin</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Belgeyi kur</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>İndir</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <ul id="file-list" class="out-list" hidden></ul>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/merge-pdf.toml
+++ b/locales/tr/tools/merge-pdf.toml
@@ -1,0 +1,306 @@
+#
+# PDF Birleştirici ve Bölücü - Türkçe.
+#
+# Overrides for tools/merge-pdf/tool.toml. Only words: the slug, the category,
+# the icon and the list of shared parts stay where they are.
+#
+
+name = "PDF Birleştirici ve Bölücü"
+heading = "PDF&nbsp;Birleştirme <span class=\"h1-kw\">&mdash; sayfaları bölün ve yeniden sıralayın</span>"
+tagline = "Sunucuya gidip gelmeden yerinden oynatılmış sayfalar."
+
+title = "PDF Birleştirme, Bölme ve Sayfa Sıralama &mdash; Ücretsiz, Yüklemesiz"
+description = "PDF'leri birleştirin, birini birkaç dosyaya bölün ve sayfaları istediğiniz sıraya sürükleyin &mdash; hepsi kendi tarayıcınızın içinde. Hiçbir şey yüklenmez, hesap gerekmez ve bitmiş dosya size sunulmadan önce yeniden açılıp sayılır."
+og_title = "PDF sayfalarını birleştirin, bölün ve sıralayın &mdash; hiçbir şey yüklenmez"
+og_description = "Belgeleri bir araya getirin, birini parçalara ayırın, sayfaları taşıyın, döndürün, çıkarın. Bunu kendi tarayıcınız yapar; yani dosya makinenizden hiç ayrılmaz."
+og_image_alt = "PDF sayfalarını yüklemeden birleştirin, bölün ve sıralayın"
+
+pledge = """
+    Seçtiğiniz her belge bu makinenin belleğinde açılır, parçalarına ayrılır ve
+    yeniden yazılır; bunu yapan kod da bu adresten sunuluyor. Buradaki hiçbir
+    şey bir yükleme yapamaz ve bu sayfanın öbür ucunda bir yüklemeyi alacak bir
+    sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve iki dosyayı birleştirin. Tek bir istek bile bir sayfa, bir
+      görsel ya da bir dosya adı taşımıyor. Ya da internet bağlantısını kesip
+      onları yine de birleştirin."""
+
+read_first = """
+, ve kopyalama işinin tamamı için
+      <code>src/assemble.js</code> &mdash; bir sayfanın bir belgeden nasıl
+      alınıp başkasına konduğu ve neyin bilinçli olarak geride bırakıldığı. O da
+      ağa erişemez, yanındaki okuyucu ve yazıcı da erişemez."""
+
+howto_heading = "Bir PDF nasıl birleştirilir, bölünür veya yeniden sıralanır"
+
+card = """
+            Belgeleri bir araya getirin, birini birkaç dosyaya kesin ve
+            sayfaları istediğiniz sıraya sürükleyin. Bağlantılar ve yer imleri
+            işaret ettikleri sayfaları izleyecek şekilde yeniden kurulur ve
+            bitmiş her dosya size sunulmadan önce yeniden açılıp sayılır."""
+
+[words]
+plural = "belgeleriniz"
+choose = "PDF'ler"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "Belgelerinizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Bu araç o listeye hiçbir şey eklemez: isteğe bağlı
+      olanı bile yok, kendine ait bir ağ özelliği hiç yok. Dosyalarınızın
+      toplanabileceği bir uç nokta burada yok, olsaydı bile onları oraya
+      gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Birleştirmek, yüklememeye en değer iştir."
+body = """
+ İnsanların bir araya
+      getirdiği belgeler, bir yerden gelmiş olanlardır: bir sözleşme ve imza
+      sayfası, bir pasaport taraması ve bir hesap özeti, bir doktor mektubu ve
+      bir talep formu. Çevrimiçi bir birleştirici bunların hepsine, tek bir
+      yerde, önceden derlenmiş hâlde sahip olur. Bunun ise tarayıcınızda bir
+      sayfası var ve öbür yarısı yok."""
+
+[[privacy]]
+title = "Biçimin tamamı bu depoda."
+body = """
+ Bir PDF, nesnelerden oluşan bir
+      liste ve her birinin nerede başladığını gösteren bir tablodur.
+      <code>src/objects.js</code> bu söz dizimini okur,
+      <code>src/reader.js</code> tabloyu izler, <code>src/assemble.js</code>
+      sayfaları belgeler arasında kopyalar ve <code>src/writer.js</code> sonucu
+      yazar. Dördü de istek yapabilecek hiçbir şeyi içeri almaz. Hiçbir kitaplık
+      getirilmiyor ve hiçbir şey bir sunucuda çizilmiyor."""
+
+[[privacy]]
+title = "Şifreli dosyalar açılmıyor, geri çevriliyor."
+body = """
+
+      Parola konmuş bir PDF geri çevrilir; tarayıcıların boş parolayla ürettiği
+      ve teknik olarak açılabilecek türü de dahil. Bir belgenin korumasını
+      kaldırmak, sayfalarını yerinden oynatmaktan farklı bir iştir ve bunu
+      sessizce yapmak bir aracın sizin adınıza yapması şaşırtıcı olurdu."""
+
+[[privacy]]
+title = "Bitmiş dosya nerede yapıldığına dair bir şey söylemez."
+body = """
+
+      Üretici satırı yok, oluşturulma tarihi yok, aracın adı yok. XMP paketini
+      ya da bir sayfa düzeni uygulamasının geride bıraktığı özel blokları da
+      taşımaz &mdash; onlar eskiden var olan belgeye aittir, sizin az önce
+      kurduğunuza değil. Sayfaların kendi içindeki her şey aynen kopyalanır: bu
+      araç sayfaları taşır, üzerlerinde yazanı yeniden yazmaz."""
+
+[[privacy]]
+title = "\"Bir sayfaya git\" olmayan eylemler kopyalanmaz."
+body = """
+
+      Bir PDF, açıldığında çalışan talimatlar taşıyabilir: şunu oynat, bu formu
+      şu adrese gönder, şu JavaScript'i çalıştır. Bu araçtan geçen sayfalar
+      başka sayfalara ve web adreslerine olan bağlantılarını korur, gerisini
+      kaybeder. Birinin sayfalarını yeniden sıralamak, onun belgesinin
+      betiklerini sizin yeni dosyanıza taşımak için bir sebep değildir."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine belgeleriniz hakkında bir şey verilmiyor: ne
+      bir dosya, ne bir sayfa, ne bir ad, bir boyut ya da bir sayfa sayısı. Bir
+      PDF'i okuyan, kopyalayan ya da yazan her satır bu kaynaktan sunuluyor ve
+      depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de belgeleriniz
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu:
+      belgelerinizi birleştirilmek üzere uzağa gönderen bir araç dururdu."""
+
+[[howto]]
+title = "PDF'lerinizi seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin ve
+      sonradan daha fazlasını ekleyin &mdash; her dosyanın sayfaları geçerli
+      sıranın sonuna eklenir; iki ayrı klasörü birleştirmeyi mümkün kılan da
+      budur. Tarayıcı onları doğrudan diskinizden okur."""
+
+[[howto]]
+title = "Sayfaları istediğiniz sıraya koyun."
+body = """
+
+      Bir sayfayı tutamağından sürükleyin ya da oklarla kaydırın. Yan taranmış
+      birini döndürün, birini çıkarın ya da bir dizisini bir seferde tutmak,
+      kaldırmak veya döndürmek için kutuya <code>1-3, 8, 12-</code> yazın.
+      Numaralar siz ilerledikçe yeniden verilir; yani gördüğünüz şey her zaman
+      bitmiş dosyanın kendisidir."""
+
+[[howto]]
+title = "Tek belge mi yoksa birkaç belge mi çıkacağını söyleyin."
+body = """
+
+      Olağan cevap tektir. Gerisi kesme yollarıdır: her kaç sayfada bir,
+      belirttiğiniz sayfa numaralarında, sayfa başına bir dosya ya da sayfaların
+      geldiği dosyalara geri. Birden fazla dosya tek bir ZIP olarak verilir;
+      yani elli kaydetme yerine bir kaydetme."""
+
+[[howto]]
+title = "Kurun ve denetlendiğini söyleyen satırı okuyun."
+body = """
+
+      Belgeler yazıldığında her biri bu sayfadaki aynı okuyucu tarafından
+      yeniden açılır ve sayfaları sayılır. Bu, istediğinizle uyuşmuyorsa çalışma
+      başarısız olarak bildirilir ve indirme sunulmaz."""
+
+[[faq]]
+q = "PDF'lerim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        kopyalanır ve yazılır. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Bu aracın
+        isteğe bağlı bir ağ özelliği de hiç yoktur."""
+
+[[faq]]
+q = "Kaç dosya birleştirebilirim ve ne kadar büyük olabilirler?"
+a = """
+        Araca yazılmış bir sınır yok. Sınır kendi makineniz: belgeler
+        üzerlerinde çalışılırken bellekte tutulur, yani bir dizüstü birkaç yüz
+        megabaytı şikâyet etmeden birleştirir ve bunun bir yerlerinde üstünde
+        zorlanır. Hiçbir şey ücretlendirilmiyor, kısıtlanmıyor, filigranlanmıyor
+        ya da sıraya alınmıyor; çünkü öbür uçta bunları yapacak kimse yok."""
+
+[[faq]]
+q = "Birleştirmek ya da bölmek kalite kaybettirir mi?"
+a = """
+        Hayır. Bir sayfadaki hiçbir şey yeniden kodlanmaz, yeniden çizilmez ya
+        da yeniden sıkıştırılmaz. Her sayfanın içerik akışı ve başvurduğu her
+        yazı tipi, görsel ve vektör çizim bayt bayt kopyalanır; yani metin
+        seçilebilir ve aranabilir kalır, bir fotoğraf da aynı fotoğraf olur.
+        Değişen tek şey sayfaların sırası ve etraflarındaki yapıdır."""
+
+[[faq]]
+q = "Yer imlerine ve bağlantılara ne oluyor?"
+a = """
+        İkisi de atılmaz, yeniden kurulur. Sayfası çıktıda duran bir yer imi, o
+        sayfa nereye taşındıysa oraya işaret eder; sayfasını kaldırdığınız bir
+        yer imi çıkarılır &mdash; altında hayatta kalan girdiler yoksa; varsa bir
+        başlık olarak kalır. Birkaç dosyayı birleştirmek her dosyanın yer
+        imlerini o dosyanın adıyla bir başlığın altına koyar. Sayfalar arası
+        bağlantılar da aynı şekilde izlenir; Word ve LaTeX'in yazdığı adlandırılmış
+        hedefler dahil. Hedefi gelmemiş bir bağlantı ise okuyucuyu yanlış bir
+        yere göndermek yerine arkasında hiçbir şey olmadan bırakılır. Web
+        adreslerine giden bağlantılar olduğu gibi korunur."""
+
+[[faq]]
+q = "Neler karşıya taşınmıyor?"
+a = """
+        Dört şey ve araç bunu küçük puntoda değil sonuçlarda söyler: ekran
+        okuyucuların kullandığı etiketli okuma sırası ağacı, sayfa etiketleri
+        ("iii, iv, 1, 2" numaralandırması), gömülü dosya ekleri ve "bir sayfaya
+        git" ya da "bir web adresi aç" olmayan her eylem &mdash; belge
+        JavaScript'i de dahil. İlk ikisi, sayfalar taşındıktan sonra artık var
+        olmayan bir sırayı tarif eder; sonuncusu ise yeni bir dosyaya taşımayı
+        istediğiniz bir şey değildir. Bir belgenin etiketlemesi sizin için
+        önemliyse orijinali de saklayın."""
+
+[[faq]]
+q = "Doldurulmuş formlar hayatta kalıyor mu?"
+a = """
+        Evet. Form alanları ve içlerine yazılanlar sayfalarıyla birlikte gelir ve
+        yeni belge bir form olarak kaydedilir; böylece okuyucular onu form gibi
+        işler. Birleştirirken bilinmesi gereken bir şey var: aynı adı taşıyan iki
+        alan, herhangi bir okuyucu için tek bir alandır; yani aynı formun iki
+        kopyasını birleştirirseniz bir sayfadaki bir kutuyu doldurmak diğerini de
+        doldurur. Araç bu durumu fark eder ve söyler."""
+
+[[faq]]
+q = "Parola korumalı bir PDF'i açabilir mi?"
+a = """
+        Hayır ve bu bilinçli bir tercih. Şifreli bir belge, bunu söyleyen bir
+        mesajla geri çevrilir; parola boş olsa bile &mdash; ki pek çok tarayıcı
+        ve fotokopi makinesi böyle kaydeder. Bir dosyanın korumasını kaldırmak,
+        sayfalarını taşımaktan farklı bir iştir ve bunu sessizce yapan bir araç
+        sizin istemediğiniz bir şeyi yapıyor olurdu."""
+
+[[faq]]
+q = "Neden sayfa ön izlemeleri yok?"
+a = """
+        Çünkü bir sayfayı çizmek eksiksiz bir PDF çizicisi demektir &mdash; yazı
+        tipleri, gölgelendirme, saydamlık grupları, karışım modları &mdash; ki bu
+        da bir küçük resim seti için getirilip çalıştırılacak bir megabayt ya da
+        daha fazla motor eder. Kutucukların bunun yerine gösterdiği şey, yeniden
+        sıralamanın gerçekte üzerinde çalıştığı şeydir: sayfa numarası, kâğıdın
+        şekli ve boyutu, yazılacağı dönüş ve hangi dosyadan geldiği. Dikey
+        sayfalardan oluşan bir yığındaki yatay bir tarama yine de bir bakışta
+        bellidir."""
+
+[[faq]]
+q = "Bitmiş dosya her yerde açılır mı?"
+a = """
+        Evet. Çıktı, PDF 1.5 olarak ya da verdiğiniz dosyalardan hangisi daha
+        yüksek bir sürüm gerektiriyorsa o sürümle yazılır ve 1.5, 2003'ten beri
+        sunulan her okuyucunun anladığı sürümdür. Araç ayrıca bunu kendi
+        cihazınızda kanıtlar: bitmiş her dosyayı size sunmadan önce yeniden açar
+        ve sayfa ağacını gezerek sayfalarını sayar."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok ve kendi cihazınızın
+        belleğinin izin verdiğinin ötesinde bir dosya boyutu sınırı yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara belgeleriniz hakkında
+        hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: belgelerinizi birleştirilmek üzere uzağa
+        gönderen bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "PDF'leri birleştirin, birini birkaç dosyaya bölün ve sayfaları tarayıcınızda yeniden sıralayın, döndürün ya da kaldırın. Sayfalar belgeler arasında yerel olarak kopyalanır; böylece hiçbir dosya yüklenmez."
+features = [
+  "İstediğiniz sayıda PDF'i birleştirir ve ilerledikçe dosya eklemenize izin verir",
+  "Sayfaları sıraya sürükleyin, döndürün, kaldırın ya da bir aralığa birden işlem yapın",
+  "Sayfa başına bir dosyaya, her kaç sayfada bir, belirli sayfa numaralarında ya da sayfaların geldiği dosyalara geri böler",
+  "Yer imlerini ve iç bağlantıları hayatta kalan sayfalara göre yeniden kurar",
+  "Doldurulmuş form alanlarını korur ve ikisi aynı adı paylaşıyorsa bunu söyler",
+  "Bitmiş her dosyayı sunmadan önce yeniden açıp sayar",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, dosya boyutu sınırı yok",
+]
+
+[picker]
+title = "PDF'lerinizi buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; tek dosya ya da birkaçı; sonradan daha fazlasını ekleyebilirsiniz"

--- a/locales/tr/tools/password-generator.html
+++ b/locales/tr/tools/password-generator.html
@@ -1,0 +1,308 @@
+<!--
+  tools/password-generator/body.html, in Turkish.
+
+  Every id, class and data-* attribute below is what src/main.js reaches for,
+  so they are the same in every language. Only the words change - including
+  the thirteen data- attributes on #strength and the three on #result, which
+  main.js reads once at boot and which are the whole of the strength readout.
+-->
+<main>
+  <!-- Adım 1 &mdash; iki şeyden hangisi -->
+  <section class="card">
+    <h2><span class="step">1</span> Ne üretileceğini seçin</h2>
+
+    <!--
+      A tab strip rather than two pages, because the choice between them is the
+      question this tool exists to help with and it should be one click, with
+      the answer to "which is stronger" visible on both sides of it.
+      `role="tablist"` and the arrow keys are wired in main.js.
+    -->
+    <div class="tabs" role="tablist" aria-label="Ne üretilecek">
+      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
+              aria-selected="true" aria-controls="options-password">Şifre</button>
+      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
+              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Parola cümlesi</button>
+    </div>
+
+    <p class="card-lede" id="mode-note">
+      Şifre, karakterlerden oluşan bir dizidir &mdash; kısa, güçlü ve bir şifre
+      yöneticisinde tutacağınız türden. Parola cümlesi ise bir listeden rastgele
+      seçilmiş kelimelerdir &mdash; yazması daha uzun, hatırlaması ve sesli
+      okuması kıyaslanmayacak kadar kolay ve ezberden yazmanız gereken bir avuç
+      sır için doğru cevap: şifre yöneticisinin kendi şifresi, dizüstünüzünki,
+      telefonunuzun yedek kodu.
+    </p>
+  </section>
+
+  <!-- Adım 2 &mdash; ayarlar, kip başına bir panel -->
+  <section class="card">
+    <h2><span class="step">2</span> Ayarlayın</h2>
+
+    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+      <div class="field">
+        <label for="length">Uzunluk</label>
+        <div class="slider-row">
+          <input type="range" id="length" min="6" max="128" value="20" step="1">
+          <output for="length" id="length-out">20</output>
+        </div>
+        <p class="field-note">
+          Uzunluk diğer her şeyi yener. Doksan dört karakterlik bir alfabeye bir
+          karakter eklemek, içinde hangi karakterlerin bulunması gerektiğine dair
+          her kuraldan daha değerlidir.
+        </p>
+      </div>
+
+      <div class="field checks">
+        <span class="checks-label">Çekilecek karakterler</span>
+        <label class="check" for="use-lower">
+          <input type="checkbox" id="use-lower" checked>
+          Küçük harf <code>a&ndash;z</code>
+        </label>
+        <label class="check" for="use-upper">
+          <input type="checkbox" id="use-upper" checked>
+          Büyük harf <code>A&ndash;Z</code>
+        </label>
+        <label class="check" for="use-digits">
+          <input type="checkbox" id="use-digits" checked>
+          Rakamlar <code>0&ndash;9</code>
+        </label>
+        <label class="check" for="use-symbols">
+          <input type="checkbox" id="use-symbols" checked>
+          Simgeler
+        </label>
+      </div>
+
+      <div class="field">
+        <label for="symbol-set">Hangi simgeler</label>
+        <select id="symbol-set">
+          <option value="full" selected>Hepsi</option>
+          <option value="safe">Yalnızca her sitenin kabul ettikleri</option>
+        </select>
+        <p class="field-note">
+          Şunlar: <code id="symbol-chars"></code>. Boşluk, iki tırnak işareti,
+          ters tırnak ve ters eğik çizgi iki kümeden de bilinçli olarak
+          çıkarıldı &mdash; diğer her şey kadar rastgeledirler ve çalışan bir
+          şifreyi bir destek talebine çeviren de onlardır.
+        </p>
+      </div>
+
+      <div class="field checks">
+        <label class="check" for="require-each">
+          <input type="checkbox" id="require-each">
+          Her kümeden en az bir karakter
+        </label>
+        <p class="field-note">
+          Israr eden kayıt formu için. Şifreyi güçlendirmez,
+          <em>zayıflatır</em>; çünkü daha önce mümkün olan bazı şifreleri eler
+          &mdash; aşağıdaki gösterge bunu zaten düşmüş durumda.
+        </p>
+
+        <label class="check" for="avoid-lookalikes">
+          <input type="checkbox" id="avoid-lookalikes">
+          Birbirine benzeyen karakterler olmasın
+        </label>
+        <p class="field-note">
+          <code>I l 1 |</code> ve <code>O 0</code> karakterlerini eler; ekrandan
+          okunup başka bir yere yazılması gereken bir şifre için. Bedelini
+          ödemek üzere bir iki karakter uzunluk ekleyin.
+        </p>
+      </div>
+    </div>
+
+    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+      <div class="field">
+        <label for="words">Kelimeler</label>
+        <div class="slider-row">
+          <input type="range" id="words" min="3" max="12" value="6" step="1">
+          <output for="words" id="words-out">6</output>
+        </div>
+        <p class="field-note">
+          Dört kelime, meşhur çizimdir ve bugün kullanmaya değer olanın
+          altındadır. Altı, önemli olan her şey için makul alt sınırdır; diğer
+          hepsini koruyan şifre içinse yedi.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="list">Kelime listesi</label>
+        <select id="list">
+          <option value="long" selected>Uzun liste &mdash; 7.776 kelime</option>
+          <option value="short">Kısa liste &mdash; 1.296 kısa kelime</option>
+        </select>
+        <p class="field-note">
+          Uzun liste kelime başına altı zar atışıdır, yani her biri 12,9 bit.
+          Kısa liste dört atıştır, her biri 10,3 bit ve içindeki her kelime beş
+          harf ya da daha kısadır; hiçbiri de bir başkasının başlangıcı değildir
+          &mdash; bir televizyon kumandasında yazacağınız ya da bir telefon
+          ekranından okuyacağınız bir parola cümlesi için kullanacağınız da
+          budur.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="separator">Kelimelerin arasına</label>
+        <select id="separator">
+          <option value="hyphen" selected>Bir tire</option>
+          <option value="space">Bir boşluk</option>
+          <option value="dot">Bir nokta</option>
+          <option value="underscore">Bir alt çizgi</option>
+          <option value="digit">Rastgele bir rakam</option>
+          <option value="none">Hiçbir şey</option>
+        </select>
+        <p class="field-note">
+          Bunlardan bir şey ekleyen tek seçenek rastgele rakamdır, çünkü bir
+          kural değil her birleşme yerinde yeni bir seçimdir. Diğerleri,
+          yapıştıracağınız kutunun neyi kabul edeceğiyle ilgilidir &mdash;
+          boşluk en okunaklı olanı ve bozulma ihtimali en yüksek olanıdır.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="capitals">Büyük harfler</label>
+        <select id="capitals">
+          <option value="lower" selected>Olduğu gibi bırak</option>
+          <option value="title">Her Kelimeyi Büyük Harfle Başlat</option>
+          <option value="upper">HEPSİ BÜYÜK HARF</option>
+        </select>
+        <p class="field-note">
+          Bu üçünün hiçbiri güç katmaz: hangisinin geçerli olduğu, herkesin bu
+          sayfadan okuyabileceği bir kuraldır; yani bir saldırganın tahmin etmesi
+          gereken bir şey değildir. Burada, büyük harf dayatan form için
+          bulunuyor.
+        </p>
+      </div>
+
+      <div class="field checks">
+        <label class="check" for="add-digit">
+          <input type="checkbox" id="add-digit">
+          Sonuna bir rakam koy
+        </label>
+        <label class="check" for="add-symbol">
+          <input type="checkbox" id="add-symbol">
+          Sonuna bir simge koy
+        </label>
+        <p class="field-note">
+          Aynı ısrarcı form için. Rakam gerçek bir seçimdir ve 3,3 bit değerinde;
+          simge sekiz tanenin arasından çekilir ve 3 bit değerinde.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; çıkan şey ve neye değdiği -->
+  <section class="card">
+    <h2><span class="step">3</span> Alın</h2>
+
+    <p id="no-classes" class="error" role="alert" hidden>
+      Çekilecek hiçbir şey kalmadı. 2. adımda en az bir karakter kümesini geri
+      açın.
+    </p>
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div class="result" id="result"
+         data-copied="Kopyalandı."
+         data-copy-failed="Tarayıcınız bu sayfanın panoya erişmesine izin vermedi. Kendiniz seçip kopyalayın.">
+      <output id="secret" class="secret" aria-live="polite"></output>
+      <div class="result-actions">
+        <button type="button" id="regenerate" class="primary">Bir tane daha üret</button>
+        <button type="button" id="copy" class="ghost" data-download>Kopyala</button>
+        <span id="copy-note" class="copy-note" role="status"></span>
+      </div>
+    </div>
+
+    <!--
+      The strength readout. Every word it can say is written here rather than
+      in main.js, in `data-` attributes read once at boot, because everything
+      in this file is translated for each language the site is served in and
+      nothing inside src/ is. The numbers come from strength.js; the sentences
+      around them come from whichever language this page is.
+    -->
+    <div class="strength" id="strength"
+         data-very-weak="Çok zayıf"
+         data-weak="Zayıf"
+         data-fair="İdare eder"
+         data-strong="Güçlü"
+         data-very-strong="Çok güçlü"
+         data-instant="Dosyayı ele geçiren herkes tarafından anında tahmin edilir."
+         data-minutes="Dakikalar içinde tahmin edilir."
+         data-hours="Bir gün içinde tahmin edilir."
+         data-days="Bir ay içinde tahmin edilir."
+         data-months="Bir yıl içinde tahmin edilir."
+         data-years="Yıllar sürer."
+         data-centuries="Yüzyıllar sürer."
+         data-ages="Donanımdan da onu kullanan herkesten de uzun ömürlü olur.">
+      <p class="strength-head">
+        <output id="bits">&mdash;</output>
+        <span class="strength-unit">bit entropi</span>
+        <span id="verdict" class="verdict"></span>
+      </p>
+      <div class="strength-bar" aria-hidden="true"><span id="strength-fill"></span></div>
+      <p class="strength-crack" id="crack"></p>
+      <p class="strength-space">
+        Bir saldırganın onu bulduğundan emin olmak için
+        <output id="space">&mdash;</output>
+        olasılığı denemesi gerekirdi.
+      </p>
+    </div>
+
+    <details class="assumptions">
+      <summary>Bu tahmin neyi varsayıyor</summary>
+      <p>
+        Saldırganın, şifrenizin saklandığı dosyayı çaldığını ve kendi donanımında
+        saniyede yüz milyar tahminle ona karşı deneme yaptığını &mdash; kabaca
+        hızlı bir özet işlevine karşı bir raf dolusu ekran kartı, ki ihlallerde
+        sürekli karşımıza çıkan türden. Düzgün seçilmiş bir şifre özetine,
+        bcrypt ya da Argon2'ye karşı aynı donanım saniyede birkaç bin tahmin
+        yapabilir ve yukarıdaki her cevap yaklaşık yirmi beş bit daha zor hâle
+        gelir. Saniyede on kez cevap veren bir giriş formuna karşı ise hepsi
+        erişilemezdir.
+      </p>
+      <p>
+        Rakam bilinçli olarak kötümser olanıdır ve <em>kesin</em> olmak için
+        gereken tahmin sayısıdır; ortalama bir saldırı cevabı bunun yarısında
+        bulur ki yukarıdaki tahminin kullandığı da budur.
+      </p>
+    </details>
+
+    <!--
+      Several at once, for the batch of accounts or the seed file. This is also
+      the page's only download, and the only thing on it that produces a file:
+      everything else is a string in a box.
+    -->
+    <div class="field bulk">
+      <label for="count">Ya da bir seferde birkaç tane üretin</label>
+      <div class="slider-row">
+        <input type="range" id="count" min="1" max="100" value="1" step="1">
+        <output for="count" id="count-out">1</output>
+      </div>
+      <ol class="batch" id="batch" start="2" hidden></ol>
+      <div class="result-actions">
+        <button type="button" id="copy-all" class="ghost" hidden>Hepsini kopyala</button>
+        <button type="button" id="download-txt" class="ghost" hidden>Metin dosyası olarak indir</button>
+      </div>
+      <p class="field-note">
+        İndirilen liste, zaten ekranınızda olandan bu sayfanın yazdığı düz bir
+        metin dosyasıdır. Tarayıcınız tarafından kendi diskinize kaydedilir ve
+        hiçbir şey onu bir yere göndermez &mdash; ama diskte şifre dolu bir
+        dosya, diskte şifre dolu bir dosyadır. Onları bir şifre yöneticisine
+        taşıyın ve dosyayı silin.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Said on the page rather than only in the panel above it, because it is the
+    question every visitor to a page like this one is actually asking and the
+    answer is unusually short.
+  -->
+  <section class="card note-card">
+    <h2>Burada hiçbir şey hatırlanmaz</h2>
+    <p>
+      Bu sayfanın ürettiği şey hiçbir zaman saklanmaz, listelenmez ve
+      gönderilmez. Temizlenecek bir geçmiş yok, çünkü tutulan bir geçmiş yok:
+      sayfayı yeniden yükleyin, size gösterdiği her şifre gitmiştir; bu sayfanın
+      kendi belleğinden de. Tek kopyalar sizin yaptıklarınızdır &mdash; pano ve
+      istediyseniz metin dosyası.
+    </p>
+  </section>
+</main>

--- a/locales/tr/tools/password-generator.toml
+++ b/locales/tr/tools/password-generator.toml
@@ -1,0 +1,368 @@
+#
+# Şifre ve Parola Cümlesi Üreteci - Türkçe.
+#
+# Overrides for tools/password-generator/tool.toml. Only words: the slug, the
+# category, the icon and the list of shared parts stay where they are.
+#
+# "Diceware", "correct horse battery staple" ve "P@ssw0rd!" olduğu gibi
+# kalıyor: ilki bir yöntemin adı, diğer ikisi ise bir noktayı kanıtlayan
+# birebir örnekler. Çevrilirlerse hiçbirinin anlamı kalmaz.
+#
+
+name = "Şifre ve Parola Cümlesi Üreteci"
+heading = "Şifre&nbsp;ve&nbsp;parola&nbsp;cümlesi <span class=\"h1-kw\">&mdash; tarayıcınızda üretilmiş güçlü ve rastgele bir tane</span>"
+tagline = "Burada, kendi tarayıcınız tarafından üretilir ve hiçbir yere gönderilmez. Hiçbir şey saklanmaz ve geçmiş yoktur."
+
+title = "Güçlü Rastgele Şifre ve Parola Cümlesi Üreteci &mdash; Hiçbir Şey Yüklenmez"
+description = "Güçlü ve rastgele bir şifre ya da beraberinde gelen 7.776 kelimelik listeden bir diceware parola cümlesi üretin. Tarayıcınızın kendi kriptografik üreteciyle çekilir, hiçbir yere gönderilmez, hiçbir zaman saklanmaz. Ücretsiz, kayıt gerekmez."
+og_title = "Şifrenizi hiçbir yere gönderemeyecek bir şifre üreteci"
+og_description = "Rastgele şifreler ve diceware parola cümleleri; kendi tarayıcınızda crypto.getRandomValues ile, sayfayla birlikte gelen bir kelime listesinden çekilir. Sunucu yok, hesap yok, geçmiş yok ve sonucun gerçekte ne kadar güçlü olduğuna dair dürüst bir sayı var."
+og_image_alt = "Şifre ve Parola Cümlesi Üreteci - güçlü rastgele şifreler, hiçbir şey yüklenmez"
+
+pledge = """
+    Her karakter, tarayıcının kendi kriptografik üreteci olan
+    <code>crypto.getRandomValues</code>'dan gelir; her kelime de bu klasörde
+    <code>src/wordlist.js</code> olarak bulunan bir listeden. <code>src/</code>
+    içinde hiçbir yerde <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+    <code>sendBeacon</code> yok; yani burada üretilen bir şifrenin bize ya da
+    başka birine ulaşabileceği bir kod yolu yok &mdash; ve hiçbir şey depolamaya
+    da yazılmıyor, dolayısıyla bu sayfayı yeniden yüklemek size gösterdiği her
+    şifreyi yok eder."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve <em>Bir tane daha üret</em>'e istediğiniz kadar basın. Tek bir
+      istek bile sonuçtan tek bir karakter taşımıyor. Ya da internet bağlantısını
+      kesip üretmeye devam edin."""
+
+read_first = """
+, bu sayfa ile ürettiği her şifre arasında duran kırk
+      satır için <code>src/random.js</code> &mdash; tek bir girdisi vardır ve o
+      girdi tarayıcının kendi üretecidir &mdash; ayarların nasıl bir dizeye
+      dönüştüğü için <code>src/generate.js</code> ve tahmin etmek yerine sayan
+      rakamın arkasındaki hesap için <code>src/strength.js</code>."""
+
+howto_heading = "Bir web sitesi görmeden nasıl güçlü bir şifre üretilir"
+
+card = """
+            Güçlü ve rastgele bir şifre ya da beraberinde gelen bir kelime
+            listesinden kurulmuş bir parola cümlesi. Kendi tarayıcınız tarafından
+            çekilir ve hiçbir yere gönderilmez."""
+
+[words]
+plural = "şifreler ve parola cümleleri"
+choose = "bir uzunluk"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Hiçbir şey saklanmaz"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Şifre, bunu okuduğunuz yerde üretiliyor."
+body = """
+ Bu sayfada, bu sayfa tarafından,
+      kendi işletim sisteminizin tarayıcıya verdiği rastgelelikten çekilir. Onu
+      üretmek için hiçbir şey istenmez ve var olduktan sonra hiçbir şey
+      bildirilmez. <code>Content-Security-Policy</code>, bu sayfanın iletişim
+      kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu siteye ait
+      değildir: üretilmiş bir şifrenin toplanabileceği bir uç nokta burada yok,
+      olsaydı bile onu gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir yerde
+      <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Kelime listesi indirilmiyor;
+      <code>src/wordlist.js</code>, sayfanın geri kalanıyla birlikte bu kaynaktan
+      sunuluyor ve onu okuyabilirsiniz."""
+
+[[privacy]]
+title = "Rastgelelik tarayıcınınki ve doğru türden."
+body = """
+ <code>crypto.getRandomValues</code>,
+      tarayıcıların anahtarlar ve belirteçler için sağladığı üreteçtir; işletim
+      sistemi tarafından tohumlanır ve yeniden tohumlanır. Bu klasörde hiçbir
+      yerde <code>Math.random</code> geçmez ve geçseydi gerçek bir kusur olurdu:
+      onun iç durumu bir avuç çıktıdan geri çıkarılabilir, bu da üreteceği her
+      şifreyi, onlardan birini görmüş olan herkes için hesaplanabilir kılar."""
+
+[[privacy]]
+title = "Hiçbir şey saklanmıyor, yani temizlenecek bir geçmiş yok."
+body = """
+ localStorage yok,
+      sessionStorage yok, çerez yok, adres parametresi yok ve tarayıcının
+      hatırlamayı önereceği bir <code>&lt;input&gt;</code> yok. Ekranda olan şey
+      bu sayfanın belleğindeki tek bir dizide var olur ve sekmeyi kapatmak
+      temizliğin tamamıdır. Burada üretilen herhangi bir şeyin tek kopyaları,
+      sizin yanınızda götürdükleridir."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine bu
+      sayfanın ürettiği şeyden tek bir karakter, uzunluğu, gücü ya da hangi
+      ayarların onu ürettiği verilmiyor. Bir karakter ya da bir kelime çeken her
+      satır bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu: rastgeleliğini bir sunucudan isteyen bir üreteç, siz fişi çeker
+      çekmez dururdu."""
+
+[[howto]]
+title = "Şifre mi parola cümlesi mi seçin."
+body = """
+ Şifre, rastgele karakterlerden
+      oluşan bir dizidir: saklaması kısa, yazması zahmetli ve şifre
+      yöneticinizin sizin yerinize doldurduğu yüzlerce hesap için tam da doğru
+      olan. Parola cümlesi ise bir listeden rastgele çekilmiş kelimelerdir: daha
+      uzun ama hatırlanabilir ve söylenebilir; ezberden yazmanız gereken birkaç
+      sır için gereken de budur &mdash; şifre yöneticinizin kendi şifresi,
+      dizüstünüzünki, telefonunuzun kurtarma kodu."""
+
+[[howto]]
+title = "Uzunluğu ya da kelime sayısını ayarlayın."
+body = """
+ Önemli olan ayar budur,
+      diğerleri çoğunlukla değildir. Korumaya değer her şey için yirmi karakter
+      ya da altı kelime makul bir alt sınırdır; diğerlerinin hepsini
+      sıfırlamaya yarayacak hesap için oradan yukarı çıkın. Alttaki gösterge siz
+      sürüklerken hareket eder, böylece her fazladan karakterin ne
+      kazandırdığını görebilirsiniz."""
+
+[[howto]]
+title = "Formun dayatacağı kuralları açın."
+body = """
+ &laquo;Her türden en az
+      bir tane&raquo;, sonda bir rakam, her sitenin kabul ettiği kısa listeden
+      bir simge. Bunların hiçbiri hiçbir şeyi güçlendirmez &mdash; ilki onu çok
+      hafif zayıflatır ve sayfa bunu zaten düşmüştür &mdash; ama arka arkaya
+      altı tane üretmeden bir kayıt formunu geçmenin yolu bunlardır."""
+
+[[howto]]
+title = "Rengi değil sayıyı okuyun."
+body = """
+ Bitler, dizeyi üreten ayarlardan
+      sayılır: alfabenin büyüklüğü, çekiliş sayısı ve başka hiçbir şey. Bu,
+      gerçek bir ölçümdür; kayıt sayfasındaki göstergenin aksine, ki o yalnızca
+      önündeki karakterleri puanlayabilir ve onları sizin mi yoksa bir üretecin
+      mi seçtiğini bilmesinin bir yolu yoktur."""
+
+[[howto]]
+title = "Ayrılmadan önce kopyalayın ve bir yere koyun."
+body = """
+ Burada geçmiş yok ve
+      geri istemenin bir yolu yok; sayfayı yeniden yüklemek onu yok eder. Önce
+      şifre yöneticisine, sonra kayıt formuna yapıştırın; böylece onu hatırlamak
+      zorunda olan taraf, bir şeyler ters gitmeden önce ona sahip olur."""
+
+[[howto]]
+title = "Gerekiyorsa bir yığın alın."
+body = """
+ Alttaki kaydırıcı bir seferde yüz
+      taneye kadar üretir ve onları düz bir metin dosyası olarak kaydeder; bu
+      dosyayı, zaten ekranınızda olandan bu sayfa yazar. Hesap kurmak ya da
+      başlangıç kimlik bilgileri dağıtmak için kullanışlıdır ve daha iyi bir
+      yere kavuştukları anda silmeye değer: diskinizdeki şifre dolu bir dosya
+      hâlâ şifre dolu bir dosyadır."""
+
+[[faq]]
+q = "Şifreler bir yere gönderiliyor ya da saklanıyor mu?"
+a = """
+        İkisi de değil. Kendi donanımınızda, tarayıcınızda üretilirler ve bu
+        aracın hiçbir türde ağ özelliği yoktur &mdash; hiçbir zaman bir şey
+        getirmez ve hiçbir zaman bir şey göndermez. Depolamaya da hiçbir şey
+        yazılmaz: localStorage yok, çerez yok, geçmiş yok. Sayfayı yeniden
+        yükleyin; size gösterdiği her şifre gitmiştir, hem ekrandan hem de kendi
+        belleğinden. Sayfanın <code>Content-Security-Policy</code>'si iletişim
+        kurabileceği her adresi sayar ve hiçbiri bize ait değildir; yani bir şey
+        denese bile bir şifrenin toplanabileceği bir yer yok."""
+
+[[faq]]
+q = "Rastgelelik nereden geliyor?"
+a = """
+        <code>crypto.getRandomValues</code>'dan; tarayıcıların kriptografik
+        kullanım için sağladığı, işletim sisteminizin kendi entropi havuzuyla
+        tohumlanan ve yeniden tohumlanan üreteçten. Bir tarayıcının TLS anahtar
+        malzemesi için kullandığı kaynağın aynısıdır. Bu araçta hiçbir yerde
+        <code>Math.random</code> kullanılmaz ve bu ayrım bir kılı kırk yarma
+        değildir: <code>Math.random</code>, iç durumunun tamamı birkaç ardışık
+        çıktıdan yeniden kurulabilen hızlı bir aritmetik üreteçtir; yani onun
+        üzerine kurulmuş bir şifre üreteci, rastgele görünen ve onlardan birini
+        görmüş olan herkes tarafından sayılıp dökülebilen şifreler üretir."""
+
+[[faq]]
+q = "Tarayıcıda üretilmiş bir şifre, masaüstü bir programdan çıkan kadar iyi mi?"
+a = """
+        Rastgelelik açısından evet &mdash; her iki durumda da aynı işletim
+        sistemi kaynağıdır, yalnızca başka bir kapıdan erişilir. Farklı olan,
+        odada başka ne olduğudur. Bir tarayıcı sekmesi eklentilerinizin yanında
+        çalışır ve sayfaları okuma izni olan bir eklenti bunu da okuyabilir. Bu,
+        bu sayfa dahil her web tabanlı üreteç için doğrudur ve elinizde varsa
+        şifre yöneticinizin yerleşik üretecini kullanmanın dürüst sebebi de
+        budur: aynı hesap, yanında daha az şey duran bir süreçte. Bu sayfa,
+        elinizde öyle bir şey olmadığı zamanlar içindir."""
+
+[[faq]]
+q = "Şifre mi parola cümlesi mi &mdash; hangisini kullanmalıyım?"
+a = """
+        Bir şifre yöneticisinin sizin için yazdığı her şey için şifre; çünkü ona
+        hiç bakmayacaksınız ve uzunluk bedavadır. Ezberden yazmanız ya da sesli
+        okumanız gereken birkaç şey için parola cümlesi: şifre yöneticisinin ana
+        şifresi, bir disk şifreleme anahtarı, uzaktan kurduğunuz bir cihaz. Uzun
+        listeden altı kelime 77 bittir; on iki karakterlik rastgele bir şifreden
+        güçlüdür ve sabahın dördünde doğru girmesi kıyaslanmayacak kadar
+        kolaydır."""
+
+[[faq]]
+q = "Bir şifre ne kadar uzun olmalı?"
+a = """
+        Tam alfabe üzerinden yirmi karakter yaklaşık 130 bittir ve uzunluğun
+        endişelenilecek şey olmaktan çıktığı noktanın ötesindedir. On altı
+        gayet iyidir. On iki, kaybetmeyi umursayacağınız her şey için alt
+        sınırdır ve hedef değil alt sınırdır. Bunun altında, sitenin onu düzgün
+        sakladığına bahse girmiş olursunuz ki son yirmi yılın ihlal bildirimleri
+        bu bahse girmemeniz gerektiğini söylüyor. Uzunluk, sayfadaki her ayarı
+        yener; bir karakter eklemek, hangi karakterlerin bulunması gerektiğine
+        dair her kuraldan daha değerlidir."""
+
+[[faq]]
+q = "Bir parola cümlesi kaç kelime olmalı?"
+a = """
+        Uzun listeden altı; başka şifreleri koruyorsa yedi. Meşhur dört
+        kelimelik çizim 2011'de yapıldı, 51 bittir ve bugün ciddi bir çevrimdışı
+        saldırının erişim menzilindedir. Beş 64'tür. Altı 77'dir ve bir
+        saldırganın sıradan bir hesap için harcayacağı her şeyin ötesindedir.
+        Uzun listeden her fazladan kelime 12,9 bit ekler ve bir şey ekleyen tek
+        parça kelimelerdir &mdash; tireler ve büyük harfler eklemez."""
+
+[[faq]]
+q = "&laquo;Bit&raquo; nedir ve bu sayfa neden onları sayıyor?"
+a = """
+        Bir bit, bir katına çıkmadır. Altmış bit demek, bu sayfanın
+        üretebileceği eşit olasılıklı 2^60 sonuç vardı demektir; yani nasıl
+        çalıştığını tam olarak bilen bir saldırganın hâlâ deneyecek o kadar şeyi
+        vardır. Bu, dizenin değil <em>sürecin</em> bir özelliğidir: sayfa bunu
+        kesin olarak söyleyebilir, çünkü seçimi yapan şey odur ve kaç seçim
+        yaptığını bilir. Bunu, karakterleri okuyup tahmin yürüten kayıt
+        formundaki renkli çubuktan ayıran şey budur. O çubukta
+        <code>correct horse battery staple</code> kötü puan alır ve 44 bit
+        değerindedir; <code>P@ssw0rd!</code> iyi puan alır ve neredeyse hiçbir
+        değeri yoktur."""
+
+[[faq]]
+q = "&laquo;Bir simge içermeli&raquo; kuralı bir şifreyi neden zayıflatıyor?"
+a = """
+        Çünkü bir kural yalnızca olasılıkları eleyebilir. Her kümeden en az bir
+        karakter istemek, tesadüfen öyle bir karakteri olmayan her şifreyi
+        eler ve olası şifrelerin daha küçük bir kümesi, aranacak daha küçük bir
+        sayı demektir. Etki küçüktür &mdash; tipik bir uzunlukta yarım bit
+        kadar &mdash; ve gerçektir; bu sayfa da gurur okşayan rakamı vermek
+        yerine onu düşer. Kuralın elediklerini değil gerçekten izin verdiği
+        şifreleri sayarak, tam olarak hesaplanır."""
+
+[[faq]]
+q = "Bu hangi kelime listesi ve saldırganın onu indirebilmesi önemli mi?"
+a = """
+        Electronic Frontier Foundation'ın diceware listeleri, değiştirilmeden
+        beraberinde geliyor: uzunda 7.776, kısada 1.296 kelime. Tam da bunun için
+        kuruldular &mdash; rahatsız edici hiçbir şey yok, eş sesli yok, yan yana
+        gelince üçüncü bir kelimeye dönüşen çift yok ve kısa listede bir
+        başkasının başlangıcı olan kelime yok. Ve hayır, listenin herkese açık
+        olması önemli değil: burada söylenen güç, bir saldırganın listeye sahip
+        olduğunu, bu sayfanın kaynağına baktığını ve kullandığınız her ayarı
+        bildiğini varsayar. Bilmediği tek şey, her seferinde 7.776'dan hangisinin
+        çıktığıdır. Sayıyı güvenilir kılan da bu varsayımdır."""
+
+[[faq]]
+q = "Parola cümlesi, olmayı bekleyen bir sözlük saldırısı değil mi?"
+a = """
+        Kelimeler bu şekilde seçildiğinde değil. Bir sözlük saldırısı
+        <em>insanların</em> seçtiği cümlelere karşı işe yarar, çünkü insanlar
+        birbirine yakışan kelimeleri, anlamlı bir sırada ve her gün kullandıkları
+        birkaç binin içinden seçer. Bu sayfa her kelimeyi bağımsız olarak,
+        düzgün dağılımla, sabit bir listeden ve sonucun kulağa hoş gelip
+        gelmediğine hiç bakmadan seçer &mdash; genellikle gelmemesinin sebebi de
+        budur. Listeyi ve uzunluğu bilen bir saldırganın karşısında yine de
+        7.776'nın kelime sayısı kuvveti vardır."""
+
+[[faq]]
+q = "Sayfadan ayrıldıktan sonra bir şifreyi geri alabilir miyim?"
+a = """
+        Hayır ve bu bilinçli bir tercih. Hiçbir yere hiçbir şey yazılmaz, yani
+        kurtarılacak bir şey yoktur: geçmiş paneli yok, &laquo;son
+        üretilenler&raquo; listesi yok, önbellek yok. Size geçen salı üretilen
+        şifreyi gösterebilen bir üreteç, onu saklamış bir üreteç olurdu ve sizin
+        erişebileceğiniz yerde saklanmış olmak, başka bir şeyin de
+        erişebileceği yerde saklanmış olmak demektir. Sayfadan ayrılmadan önce
+        onu bir şifre yöneticisine kopyalayın."""
+
+[[faq]]
+q = "Panoya kopyalamak güvenli mi?"
+a = """
+        Olağan risktir ve endişelenmekten çok bilmeye değer. Pano, sizin adınıza
+        çalışan diğer her şeyle paylaşılır, genellikle bir sonraki kopyalamaya
+        kadar orada kalır ve bazı kurulumlarda cihazlar arasında eşitlenir. Bu,
+        onu ait olduğu yere hemen yapıştırmak ve sonrasında başka bir şey
+        kopyalamak için iyi bir sebeptir; elle daha zayıf bir şifre yazmak için
+        bir sebep değildir. Bu sayfa panonuzu okuyamaz; yalnızca ona yazabilir
+        ve yalnızca siz düğmeye bastığınızda."""
+
+[[faq]]
+q = "Aynısını birden fazla yerde kullanmalı mıyım?"
+a = """
+        Hayır ve bu, bu sayfadaki diğer her şeyin üstünde duran tek tavsiyedir.
+        Ele geçirilen neredeyse her hesap, önce başka bir yerde doğru olan bir
+        şifreyle ele geçirilir: bir site ihlal edilir, liste yayımlanır ve aynı
+        adres ile şifre her yerde denenir. Site başına benzersiz bir şifre, bir
+        ihlali hepsi yerine tek bir hesaba indirger ve bir şifre yöneticisi
+        tutmanın sebebi de budur &mdash; içindeki herhangi bir şifrenin gücü
+        değil."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok ve kaç tane
+        ürettiğinizde bir sınır yok. Sitede reklam var, masrafı karşılayan da o;
+        reklamlara bu sayfanın ürettiği şey hakkında, ne kadar uzun ya da ne
+        kadar güçlü olduğu dahil, hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin, şifre
+        üretmeye devam eder. Rastgelelik kendi makinenizden gelir ve kelime
+        listesi zaten sayfadadır. Bu aynı zamanda hiçbir şeyin getirilmediğini ya
+        da gönderilmediğini kanıtlamanın en basit yolu: sayılarını bir sunucudan
+        isteyen bir üreteç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Tarayıcıda güçlü rastgele şifreler ve diceware parola cümleleri üretin. Karakterler crypto.getRandomValues ile, kelimeler ise beraberinde gelen 7.776 kelimelik EFF listesinden çekilir; sayfa, ürettiği şeyin tam entropisini bildirir. Hiçbir şey yüklenmez ve hiçbir şey saklanmaz."
+features = [
+  "94 karaktere kadar bir alfabeden, 6 ila 128 uzunluğunda rastgele şifreler",
+  "Beraberinde gelen 7.776 kelimelik listeden ya da 1.296 kelimelik kısa listeden diceware parola cümleleri",
+  "Her çekiliş crypto.getRandomValues'dan; modulo sapması yok sayılmaz, reddedilir",
+  "Bit cinsinden tam entropi; dizeden puanlanmaz, ayarlardan sayılır",
+  "\"Her türden bir tane olmalı\" kuralının maliyetini yok saymak yerine hesaplar",
+  "Yazılması gereken bir şifre için birbirine benzeyen karakterleri isteğe bağlı olarak dışarıda bırakır",
+  "Ayırıcı, büyük harf ve sondaki rakam ya da simge; her biri ne kattığı konusunda dürüst",
+  "Bir seferde yüz taneye kadar; kopyalanır ya da düz metin dosyası olarak kaydedilir",
+  "Hiçbir şey saklanmaz: geçmiş yok, localStorage yok, çerez yok",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]

--- a/locales/tr/tools/qr-barcode-reader.html
+++ b/locales/tr/tools/qr-barcode-reader.html
@@ -1,0 +1,265 @@
+<!--
+  tools/qr-barcode-reader/body.html, in Turkish.
+
+  Every id, class, data-phrase key, data-fact key, data-only value and
+  {placeholder} below is what src/main.js reaches for, so they are the same in
+  every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; resim nereden geliyor -->
+  <section class="card">
+    <h2><span class="step">1</span> Kodu gösterin</h2>
+
+    <p class="card-lede">
+      Bir fotoğraf, bir ekran görüntüsü ya da kamera. Hangisini seçerseniz
+      seçin, resim burada, bu sayfada, sizin makinenizde okunur &mdash; hiçbir
+      şey yüklenmez ve bir kamera karesi kaydedilmez, incelenip atılır.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div class="run-row">
+      <button type="button" id="start-camera" class="primary">Kamerayı kullan</button>
+      <button type="button" id="stop-camera" class="ghost" hidden>Kamerayı durdur</button>
+    </div>
+
+    <p class="field-summary" id="pick-note">
+      <kbd>Ctrl</kbd>+<kbd>V</kbd> ile doğrudan bir resim de yapıştırabilirsiniz
+      &mdash; ekrandaki bir kodun ekran görüntüsü en hızlı yoldur.
+    </p>
+
+    <p id="pick-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- The camera, which only appears once it is running -->
+  <section class="card" id="camera-card" hidden>
+    <h2>Kamera</h2>
+
+    <div class="viewfinder">
+      <video id="video" playsinline muted disablepictureinpicture></video>
+      <div class="reticle" aria-hidden="true"></div>
+    </div>
+
+    <div class="camera-controls">
+      <div class="option-row" id="camera-pick-row" hidden>
+        <label for="camera-pick">Hangi kamera</label>
+        <select id="camera-pick"></select>
+      </div>
+
+      <label class="check" id="torch-row" hidden>
+        <input type="checkbox" id="torch">
+        <span>
+          <strong>Işığı aç</strong>
+          <span class="check-note">
+            Yalnızca bazı kameralarda vardır ve yalnızca bazı tarayıcılar bir
+            sayfanın onu istemesine izin verir. Sunulmadığı yerde yok
+            demektir.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary" id="camera-status" role="status"></p>
+
+    <p class="field-summary">
+      Buradaki dürüst gösterge kamera ışığıdır: kareler gelirken yanar ve siz
+      durdurduğunuz anda söner. Bu iki nokta arasında hiçbir şey diske yazılmaz
+      ve bu sayfanın <code>Content-Security-Policy</code>'sinde bir resmin
+      gönderilebileceği bir adres yoktur.
+    </p>
+  </section>
+
+  <!-- Adım 2 &mdash; cevap -->
+  <section class="card" id="results-card" hidden>
+    <h2><span class="step">2</span> Ne diyor</h2>
+
+    <p class="card-lede">
+      Gösterilir, asla açılmaz. Basılı bir kod, kimsenin okuyamadığı bir
+      adrestir; üzerine yapıştırılmış bir çıkartmayı birinin zahmetine değer
+      kılan da tam olarak budur &mdash; bu yüzden dizenin tamamı önce burada,
+      bakmanız için durur ve gerçekten ulaşacağı sunucu kendi satırında
+      belirtilir.
+    </p>
+
+    <div id="results"></div>
+  </section>
+
+  <!--
+    One result. Cloned per code found, with only the values filled in from
+    script: every word in it is here, in the markup, because this file is
+    translated per language and src/*.js is one file serving all eleven.
+  -->
+  <template id="result-template">
+    <article class="result">
+      <header class="result-head">
+        <span class="result-kind"></span>
+        <span class="result-symbology"></span>
+      </header>
+
+      <pre class="result-text"></pre>
+
+      <div class="run-row">
+        <button type="button" class="primary copy">Metni kopyala</button>
+        <a class="as-button open" target="_blank" rel="noopener noreferrer nofollow" hidden>
+          Yeni sekmede aç
+        </a>
+      </div>
+
+      <dl class="result-rows"></dl>
+      <ul class="result-warnings"></ul>
+
+      <details class="result-facts">
+        <summary>Bu nasıl okundu</summary>
+
+        <dl class="facts-list">
+          <div><dt>Simge</dt><dd data-fact="symbol"></dd></div>
+          <div data-only="qr"><dt>Sürüm</dt><dd data-fact="version"></dd></div>
+          <div data-only="qr"><dt>Hata düzeltme</dt><dd data-fact="level"></dd></div>
+          <div data-only="qr"><dt>Maske</dt><dd data-fact="mask"></dd></div>
+          <div data-only="qr"><dt>Onarılan kod kelimesi</dt><dd data-fact="repaired"></dd></div>
+          <div data-only="qr"><dt>Yazılış kipi</dt><dd data-fact="mode"></dd></div>
+          <div data-only="qr" data-optional><dt>Bildirilen karakter kümesi</dt><dd data-fact="eci"></dd></div>
+          <div data-only="qr" data-optional><dt>Bir kümenin parçası</dt><dd data-fact="part"></dd></div>
+          <div data-only="linear" data-optional><dt>Uyuşan tarama satırı</dt><dd data-fact="lines"></dd></div>
+          <div><dt>Karakter</dt><dd data-fact="characters"></dd></div>
+          <div><dt>Bulunma yolu</dt><dd data-fact="how"></dd></div>
+        </dl>
+
+        <figure class="grid-figure" hidden>
+          <canvas class="grid" width="1" height="1"></canvas>
+          <figcaption>
+            Bu sayfanın örneklediği modüllerin geri çizilmiş hâli.
+            Fotoğrafladığınız koda benziyorsa doğru şeyi okumuştur; parazite
+            benziyorsa okumamıştır ve üstündeki cevaba güvenilmez.
+          </figcaption>
+        </figure>
+      </details>
+    </article>
+  </template>
+
+  <!--
+    The words script needs, sitting in the markup so that a translator meets
+    them where they meet the rest of the page. A `{host}` in one of these is
+    filled in with the host that was read; nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="kind.url">Bir web adresi</span>
+    <span data-phrase="kind.url-plain">Bir web adresi, şifresiz</span>
+    <span data-phrase="kind.wifi">Bir Wi-Fi ağı</span>
+    <span data-phrase="kind.vcard">Bir kartvizit</span>
+    <span data-phrase="kind.mecard">Bir kartvizit</span>
+    <span data-phrase="kind.email">Bir e-posta</span>
+    <span data-phrase="kind.phone">Bir telefon numarası</span>
+    <span data-phrase="kind.sms">Bir kısa mesaj</span>
+    <span data-phrase="kind.place">Haritada bir yer</span>
+    <span data-phrase="kind.otp">Bir iki adımlı doğrulama sırrı</span>
+    <span data-phrase="kind.other-scheme">Başka bir programın açacağı bir şey</span>
+    <span data-phrase="kind.number">Bir sayı</span>
+    <span data-phrase="kind.text">Düz metin</span>
+    <span data-phrase="symbology.qr">QR kod</span>
+
+
+    <span data-phrase="field.host">Gittiği yer</span>
+    <span data-phrase="field.port">Bağlantı noktası</span>
+    <span data-phrase="field.path">Yol</span>
+    <span data-phrase="field.ssid">Ağ adı</span>
+    <span data-phrase="field.security">Güvenlik</span>
+    <span data-phrase="field.password">Şifre</span>
+    <span data-phrase="field.hidden">Gizli ağ</span>
+    <span data-phrase="field.name">Ad</span>
+    <span data-phrase="field.org">Kurum</span>
+    <span data-phrase="field.title">Unvan</span>
+    <span data-phrase="field.phone">Telefon</span>
+    <span data-phrase="field.email">E-posta</span>
+    <span data-phrase="field.web">Web sitesi</span>
+    <span data-phrase="field.address">Adres</span>
+    <span data-phrase="field.note">Not</span>
+    <span data-phrase="field.to">Kime</span>
+    <span data-phrase="field.subject">Konu</span>
+    <span data-phrase="field.message">Mesaj</span>
+    <span data-phrase="field.number">Numara</span>
+    <span data-phrase="field.latitude">Enlem</span>
+    <span data-phrase="field.longitude">Boylam</span>
+    <span data-phrase="field.account">Hesap</span>
+    <span data-phrase="field.issuer">Veren</span>
+    <span data-phrase="field.secret">Sır</span>
+    <span data-phrase="field.scheme">Şema</span>
+
+    <span data-phrase="value.yes">Evet</span>
+    <span data-phrase="value.open-network">Açık &mdash; şifre yok</span>
+    <span data-phrase="value.none">Yok</span>
+    <span data-phrase="value.copied">Kopyalandı</span>
+    <span data-phrase="value.modules">{n} modül kare</span>
+
+    <span data-phrase="warn.userinfo">@ işaretinden önceki her şey bir kullanıcı
+      adıdır, bir adres değil. Bu bağlantı ne diyor görünürse görünsün, gittiği
+      yer {host}.</span>
+    <span data-phrase="warn.punycode">Bu adres Latin olmayan bir alfabeyle
+      yazılmış. Başka alfabelerdeki bazı harfler tam olarak bizimkiler gibi
+      görünür; bir adın, zaten güvendiğiniz bir ada benzetilmesi de böyle
+      olur.</span>
+    <span data-phrase="warn.unicode-host">Sunucu adında düz Latin alfabesinin
+      dışında karakterler var; bu, bir adı bir başkasına benzetmek için
+      kullanılabilir.</span>
+    <span data-phrase="warn.plain-http">Bu düz bir http:// adresi; yani ona
+      gönderdiğiniz her şey şifresiz yolculuk eder ve aradaki her şey onu
+      okuyabilir ya da değiştirebilir.</span>
+    <span data-phrase="warn.shortener">{host} bir yönlendirme. Gerçekten
+      varacağınız adres bu kodda yok ve ne olduğunu öğrenmek bir sunucuyla
+      iletişim kurmak demek olurdu &mdash; ki bu sayfa bunu asla yapmaz.</span>
+    <span data-phrase="warn.wifi-secret">Bu kod, düz metin hâlinde bir şifre
+      taşıyor. Kodu fotoğraflayan herkes ona sahip olur ve bu, kod bir duvara
+      asılmadan önce bilinmeye değer.</span>
+    <span data-phrase="warn.otp-secret">Bu, bir kimlik doğrulayıcı uygulamanın
+      tohumu: onu elinde tutan herkes o hesap için kodlarınızı süresiz
+      üretebilir. Bu sayfadan çıkmadı ve başka nereye gittiği konusunda dikkatli
+      olmaya değer.</span>
+    <span data-phrase="warn.not-openable">Bu bir web adresi değil, dolayısıyla
+      sunulacak bir bağlantı yok. Yukarıda tam olarak basılı; makinenizde bir
+      şeyin ona göre davranıp davranmayacağı sizinle o program arasında.</span>
+
+    <span data-phrase="mode.numeric">yalnızca rakam</span>
+    <span data-phrase="mode.alphanumeric">büyük harf ve rakam</span>
+    <span data-phrase="mode.byte">bayt</span>
+    <span data-phrase="mode.kanji">kanji</span>
+
+    <span data-phrase="how.local">blok blok hesaplanmış bir eşik</span>
+    <span data-phrase="how.inverted">koyuyla açığın yer değiştirmesi</span>
+    <span data-phrase="how.global">resmin tamamı için tek bir eşik</span>
+    <span data-phrase="how.softened">resmin önce yumuşatılması</span>
+    <span data-phrase="how.dense">, her satır denetlenerek</span>
+
+    <span data-phrase="status.reading">Resim okunuyor&hellip;</span>
+    <span data-phrase="status.nothing">O resimde kod bulunamadı. Simgenin
+      tamamının, beyaz kenar boşluğuyla birlikte kadrajda olması ve koyu
+      karelerin düzgün koyu olmasına yetecek ışığın bulunması gerekir.</span>
+    <span data-phrase="status.broken">O dosya resim olarak açılamadı.</span>
+    <span data-phrase="status.looking">Aranıyor&hellip; kodu sabit tutun ve
+      kadrajın yaklaşık yarısını onunla doldurun.</span>
+    <span data-phrase="status.on">Kamera açık. Hiçbir şey kaydedilmiyor.</span>
+
+    <span data-phrase="camera.denied">Tarayıcı bu sayfa için kamerayı reddetti.
+      Bu, değiştirebileceğiniz bir izin: adres çubuğundaki kamera simgesine
+      bakın. Bunun yerine bir resim seçmek hiçbir izin gerektirmez.</span>
+    <span data-phrase="camera.none">Bu makinede kamera bulunamadı. Yukarıya bir
+      fotoğraf ya da ekran görüntüsü bırakın, aynı şekilde okunacaktır.</span>
+    <span data-phrase="camera.busy">Kamera var ama başka bir şey onu
+      kullanıyor. Onu açık tutan neyse kapatın &mdash; genellikle bir görüntülü
+      görüşme &mdash; ve yeniden deneyin.</span>
+    <span data-phrase="camera.insecure">Bir tarayıcı kamerayı yalnızca https
+      üzerinden sunulan bir sayfaya verir; bu sayfa şu anda öyle değil.</span>
+    <span data-phrase="camera.unsupported">Bu tarayıcıda, bir sayfanın
+      isteyebileceği bir kamera arayüzü yok. Buradaki diğer her şey yine
+      çalışır.</span>
+    <span data-phrase="camera.failed">Kamera başlatılamadı ve tarayıcı nedenini
+      söylemedi.</span>
+
+    <span data-phrase="live.clean">resimleriniz hiçbir yere gitmedi. {total}
+      dosya yüklendi, hepsi bu sayfanın kendi dosyaları.</span>
+    <span data-phrase="live.dirty">bir şey {hosts} ile iletişim kurdu; bu araç
+      bunu asla yapmaz. Bunu araştırmaya değer sayın.</span>
+    <span data-phrase="live.platform">Sayfanın kendi reklam, ölçüm ve bağış
+      düğmesi betikleri {count} sunucudan yüklendi; hiçbirine bir resim, bir kare
+      ya da bir kodun söylediklerinden bir karakter verilmedi.</span>
+  </div>
+</main>

--- a/locales/tr/tools/qr-barcode-reader.toml
+++ b/locales/tr/tools/qr-barcode-reader.toml
@@ -1,0 +1,331 @@
+#
+# QR ve Barkod Okuyucu - Türkçe.
+#
+# Overrides for tools/qr-barcode-reader/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Simge adları, Reed-Solomon, ECI ve kısaltıcı adı (bit.ly) olduğu gibi
+# kalıyor; adres kısımları (http://, @) da öyle, çünkü sayfa okuyucuya bir
+# adreste tam olarak neye bakacağını söylüyor.
+#
+
+name = "QR ve Barkod Okuyucu"
+heading = "QR&nbsp;ve&nbsp;Barkod Okuyucu <span class=\"h1-kw\">&mdash; bir görselden ya da kameranızdan QR kod okuyun</span>"
+tagline = "Bir koda doğrultun ya da onun bir resmini bırakın. Burada okunur, başka hiçbir yerde."
+
+title = "QR Kod Okuyucu ve Barkod Tarayıcı &mdash; Bir Görselden, Hiçbir Şey Yüklenmez"
+description = "Bir fotoğraftan, ekran görüntüsünden ya da kameranızdan QR kod okuyun ve bağlantının nereye gittiğini açmadan önce tam olarak görün. EAN, UPC, Code 128, Code 39 ve ITF barkodları da. Hiçbir şey yüklenmez."
+og_title = "Resmi kimseye göndermeden QR kod okuyun"
+og_description = "Bir görselden ya da kameranızdan QR kod tarayın ve açmaya karar vermeden önce adresin tamamını görün. Resim makinenizden hiç ayrılmaz ve hiçbir kamera karesi kaydedilmez."
+og_image_alt = "QR ve Barkod Okuyucu - bir görselden ya da kameradan kod tarayın, hiçbir şey yüklenmesin"
+
+pledge = """
+    Bir kodu okumak, pikseller üzerinde yapılan bir hesaptır ve pikseller zaten
+    burada. Simgeyi bulmak, açıyı düzeltmek, maskeyi geri almak, hasarı
+    Reed-Solomon ile onarmak ve bitleri geri okumak; hepsi bu sayfada,
+    okuyabileceğiniz yaklaşık iki bin satırlık JavaScript içinde olur.
+    <strong>Kamera, bu sözün bir istisnası değil aynısıdır:</strong> bir kare bu
+    sekmeye piksel olarak gelir, incelenir ve gider. Hiçbir şey kaydedilmez,
+    hiçbir şey saklanmaz ve bu sayfanın bir tanesini gönderebileceği hiçbir türde
+    ağ özelliği yoktur."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve kamera açıkken bir kod tarayın. Tek bir istek bile bir kare ya
+      da onun söylediklerinden bir karakter taşımıyor. Ya da internet
+      bağlantısını kesip kodu yine de okuyun."""
+
+read_first = """
+, bir fotoğrafta simge bulmak için
+      <code>src/binarize.js</code> ve <code>src/detect.js</code> &mdash; eşik,
+      tanıma desenleri ve perspektif dönüşümü &mdash; onu geri okumak için
+      <code>src/qr-decode.js</code>, yanlış okunanı onarmak için
+      <code>src/reed-solomon.js</code>, çizgili olanlar için
+      <code>src/linear.js</code> ve bu sayfada bir kameraya dokunan her satır
+      olan <code>src/camera.js</code>."""
+
+howto_heading = "Resmi yüklemeden nasıl QR kod okunur"
+
+card = """
+            Bir fotoğraftan, ekran görüntüsünden ya da kameranızdan QR kod
+            okuyun &mdash; ve açmadan önce adresin tamamını görün. Barkodlar
+            da."""
+
+[picker]
+title = "Bir kodun resmini buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; bir fotoğraf, bir ekran görüntüsü, bir PNG, tarayıcınızın açabildiği her şey"
+
+[words]
+plural = "resimler ve içlerindeki kodlar"
+choose = "okunacak resmi"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Hiçbir şey kaydedilmez"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Resim hiçbir zaman yüklenmez ve kamera bunun istisnası değildir."
+body = """
+ Buraya
+      bıraktığınız bir fotoğraf, bu sayfadaki bir tuvale çözülür ve orada
+      okunur. Bir kamera karesi, saniyede otuz kez gelen aynı şeydir: o tuvale
+      çizilir, incelenir ve bir sonraki tarafından üzerine yazılır. Hiçbir kare
+      kaydedilmez, hiçbiri saklanmaz ve siz durdur'a bastığınızda kamera ışığının
+      sönmesi işin tamamıdır."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir yerde
+      <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok ve sayfanın
+      <code>Content-Security-Policy</code>'si, olsaydı bile bu kaynağın
+      gönderebileceği hiçbir adres bırakmıyor. Bu sayfanın kısaltılmış bir
+      bağlantının nerede bittiğini size söyleyememesinin sebebi de budur: bunu
+      öğrenmek sormak demektir ve o sormaz."""
+
+[[privacy]]
+title = "Adresi size gösterir. Onu asla açmaz."
+body = """
+ Basılı bir QR kod,
+      kimsenin okuyamadığı bir adrestir; üzerine yapıştırılmış bir çıkartmayı
+      birinin zahmetine değer kılan da tam olarak budur. Burada hiçbir şey
+      açılmaz. Dizenin tamamı bakmanız için basılır, gerçekten ulaşacağı sunucu
+      ayrı olarak belirtilir ve bir adresi bir başkası gibi gösteren numaralar
+      &mdash; bir <code>@</code>'in önündeki bir kullanıcı adı, harfleri
+      bizimkilere benzeyen bir alfabeyle yazılmış bir ad, bir yönlendirme
+      &mdash; göründükleri yerde adlarıyla anılır."""
+
+[[privacy]]
+title = "Neyi örneklediğini de size gösterir."
+body = """
+ Her QR sonucunun altında,
+      bu sayfanın fotoğrafınızdan gerçekten okuduğu modüllerin bir resmi vardır.
+      Taradığınız koda benziyorsa üstündeki cevap sağlamdır; parazite benziyorsa
+      değildir. Size bir dize verip başka bir şey vermeyen hiçbir okuyucu bu
+      şekilde denetlenemez."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine bir
+      resim, bir kare ya da birinden okunmuş bir şey verilmiyor. Pikselleri bir
+      dizeye çeviren her satır bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, kamera dahil araç hiç
+      değişmez; çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin
+      içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Resmi verin."
+body = """
+ Kutuya bir fotoğraf ya da ekran görüntüsü bırakın,
+      doğrudan bir tane yapıştırın ya da kamera düğmesine basın. Bir seferde
+      birkaç tane olabilir &mdash; her biri kendi başına okunur ve her biri kendi
+      cevabını alır. Zaten ekranınızda olan bir kodun ekran görüntüsü en hızlı ve
+      en güvenilir yoldur; çünkü işin içinde ne bir mercek, ne bir açı, ne de bir
+      ışık vardır."""
+
+[[howto]]
+title = "Simgenin tamamını, kenar boşluğuyla birlikte kadraja alın."
+body = """
+ Bir kodun
+      çevresindeki beyaz alan kodun bir parçasıdır: bir okuyucu simgenin nerede
+      bittiğini onunla bulur. Karelerin kenarına kadar kırpılmış bir fotoğraf,
+      bir kodun okunmamasının en yaygın tek sebebidir ve kadrajın yaklaşık
+      yarısını kodla doldurmak doğru ölçüdür &mdash; bundan yakını köşelerin
+      resmin dışında kalması demektir."""
+
+[[howto]]
+title = "Bir şeye karar vermeden önce adresi okuyun."
+body = """
+ Bir afişteki, bir
+      parkmetredeki ya da bir mektuptaki kodu taramanın amacı nereye gittiğini
+      öğrenmektir ve bir telefon kamerasının gerçekten yapmanıza izin vermediği
+      tek şey de budur. Sunucu burada kendi satırında basılır. Beklediğiniz bir
+      ad değilse geldiğiniz şeyi zaten aldınız ve açılacak bir şey kalmadı."""
+
+[[howto]]
+title = "Uyarıları, özellikle sessiz olanları ciddiye alın."
+body = """
+ Düz bir
+      <code>http://</code> adresi, göründüğü alfabede olmayan bir ad, bir
+      bağlantı kısaltıcı ya da adreste bir <code>@</code>'in önünde duran her şey
+      &mdash; bunların her biri göründükleri yerde adlarıyla anılır. Hiçbiri tek
+      başına bir şey kanıtlamaz. Hepsi, oraya gitmeden önce on saniyeye
+      değer."""
+
+[[howto]]
+title = "Okumuyorsa başka bir şeyi değiştirmeden önce ışığı değiştirin."
+body = """
+ Neredeyse
+      her başarısızlık bir eşik sorunudur: ortadan geçen bir yansıma, bir köşeyi
+      örten bir gölge ya da arka ışığı yakalayan bir açıdan fotoğraflanmış bir
+      ekran. Parlama kodun üzerinden çıkacak şekilde yer değiştirin ya da kamera
+      ışığını açın. O da olmazsa düz ve tam karşıdan tek bir fotoğraf çekip onu
+      bırakın &mdash; durağan bir resim, canlı bir karenin
+      yapabileceğinden çok daha kapsamlı bir arama görür."""
+
+[[howto]]
+title = "Cevap tuhaf görünüyorsa örneklenen resmi denetleyin."
+body = """
+ &laquo;Bu nasıl
+      okundu&raquo;yu açın ve küçük ızgaraya bakın. Bu sayfanın kodun ne olduğuna
+      inandığı şeyin, örneklediği modüllerden geri çizilmiş hâlidir. Bir simgeyi
+      yanlış okuyup makul bir şeye onarmış bir okuyucu bunu orada gösterir, başka
+      hiçbir yerde değil."""
+
+[[faq]]
+q = "Resim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır ve ondan okunan hiçbir şey de yüklenmiyor. Resim, bu sayfadaki bir
+        tuvale çözülür ve orada, bu siteden sunulan JavaScript tarafından okunur.
+        Bu aracın hiçbir türde ağ özelliği yoktur &mdash; hiçbir zaman bir şey
+        getirmez ve hiçbir zaman bir şey göndermez &mdash; ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar; bunların hiçbiri bize ait değildir. En açık kanıt
+        internet bağlantısını kesmektir: çalışmaya devam eder."""
+
+[[faq]]
+q = "Kamera bir şey kaydediyor mu?"
+a = """
+        Hayır. Bir kamera karesi bu sekmeye piksel olarak gelir, bir tuvale
+        çizilir, incelenir ve yaklaşık onda bir saniye sonra bir sonraki kare
+        tarafından üzerine yazılır. Diske hiçbir şey yazılmaz ve hiçbir şey
+        saklanmaz. Akış, siz durdur'a bastığınız anda, sekme arka plana
+        geçtiğinde ve sayfadan ayrıldığınızda durur &mdash; ve güvenilecek
+        gösterge kameranızdaki ışıktır, çünkü hiçbir sayfa onu
+        söndüremez."""
+
+[[faq]]
+q = "Bağlantıyı açmak yerine neden bana gösteriyor?"
+a = """
+        Çünkü işe yarar olan kısım bu. Bir QR kod, okuyamadığınız bir adrestir;
+        bir parkmetredeki kodun üzerine yapıştırılan bir çıkartmanın işe
+        yaramasının bütün sebebi de budur: nereye gittiğini öğrendiğinizde çoktan
+        oradasınızdır. Burada dize tam olarak basılır, sunucu kendi satırında
+        belirtilir ve onu açmak, okuduktan sonra basacağınız ayrı bir düğmedir.
+        Bu, fazladan bir tıklamadır ve biçimin en başından beri ihtiyaç duyduğu
+        tıklamadır."""
+
+[[faq]]
+q = "Neleri okuyabiliyor?"
+a = """
+        1'den 40'a kadar her sürümde, dört hata düzeltme seviyesinin hepsinde,
+        sayısal, alfasayısal, bayt ve kanji kipinde QR kodları; ECI karakter
+        kümeleri ve yapılandırılmış ekleme simgeleri sessizce atılmak yerine
+        bildirilir. Çizgili tarafta: EAN-13, EAN-8, UPC-A, UPC-E, ITF-14,
+        Interleaved 2 of 5, Code 128 ve Code 39. Data Matrix, PDF417, Aztec ve
+        MaxiCode okumaz."""
+
+[[faq]]
+q = "Kodumu okumuyor. Sorun ne?"
+a = """
+        Onda dokuz kez üç şeyden biridir. Beyaz kenar boşluğu kırpılmıştır ve bir
+        okuyucu simgenin nerede bittiğini o boşlukla bulur. Kodun bir bölümünde
+        bir yansıma ya da gölge vardır, yani hiçbir eşik koyu kareleri açık
+        olanlardan ayırmaz. Ya da kod kadrajda o kadar küçüktür ki modülleri bir
+        iki pikselden geniş değildir. Işığı değiştirin, kadrajın yaklaşık
+        yarısını doldurun ve resmi açıyla değil tam karşıdan çekin."""
+
+[[faq]]
+q = "Hasarlı ya da kısmen kapalı bir kodu okuyabilir mi?"
+a = """
+        Çoğu zaman evet ve bu, buradaki bir zekâ gösterisi değil biçimin
+        tasarlandığı gibi çalışmasıdır. Her QR kod Reed-Solomon denetim verisi
+        taşır ve H seviyesinde üretilmiş bir simge modüllerinin yaklaşık %30'unu
+        kaybedip yine de tam olarak yeniden kurulabilir. Sayfa, &laquo;bu nasıl
+        okundu&raquo; başlığı altında kaç kod kelimesini onarmak zorunda kaldığını
+        söyler; böylece sınıra ne kadar yaklaştığını görebilirsiniz. Yapmayacağı
+        şey tahmin etmektir: denetimlerin taşıyabileceğinin ötesinde hasar görmüş
+        bir simge, yanlış yanıtlanmak yerine okunamaz olarak bildirilir."""
+
+[[faq]]
+q = "Bir bit.ly bağlantısının nereye gittiğini neden söyleyemediğini yazıyor?"
+a = """
+        Çünkü bunu öğrenmek bit.ly'ye sormak demektir ve bu bir ağ isteğidir. Bu
+        sayfadaki diğer her iddia, burada bir şeyle iletişim kuran bir kodun
+        olmamasına dayanır ve bunun için sessizce bir istisna yapmak, cevaptan
+        daha az değerli olurdu. Bu yüzden kısaltıcı adıyla anılır ve gizlediği
+        şey dürüstçe bilinmez bırakılır. Onu çözmek istiyorsanız getirmeye razı
+        bir şeye yapıştırın."""
+
+[[faq]]
+q = "Bir QR kodu taramak güvenli mi?"
+a = """
+        Taramak güvenlidir. Riskli olan ona göre davranmaktır ve bu gerçek bir
+        risktir: parkmetrelerde, restoran masalarında ve kargo teslim
+        kartlarında gerçek kodun üzerine yapıştırılmış kodlar artık kendi adı
+        olacak kadar yaygındır. Onları işe yaratan şey, kimsenin bir koda bakarak
+        onu okuyamamasıdır. Onu açmadan okumak &mdash; ki bu sayfanın yaptığı
+        budur &mdash; bu avantajın tamamını ortadan kaldırır ve sunucuya bakmanın
+        aldığı on saniye savunmanın tamamıdır."""
+
+[[faq]]
+q = "Her sonucun altındaki küçük ızgara nedir?"
+a = """
+        Bu sayfanın resminizden gerçekten örneklediği modüllerin, modül başına bir
+        kare olacak şekilde geri çizilmiş hâli. Orada olmasının sebebi, okumanın
+        güvenilmek yerine gözle denetlenebilmesidir: o ızgara fotoğrafladığınız
+        koda benziyorsa üstündeki cevap doğru piksellerden gelmiştir. Neredeyse
+        hiçbir okuyucu bunu size göstermez ve denetleyebileceğiniz bir araçla
+        inanmak zorunda olduğunuz bir araç arasındaki fark budur."""
+
+[[faq]]
+q = "Bir resimdeki birkaç kodu okuyor mu?"
+a = """
+        Şimdilik resim başına bir tane. Bir seferde birkaç resim bırakın, her biri
+        kendi başına okunsun; kamera ise siz gezdirdikçe kod ardına kod okur ve
+        daha önce görmediği her yenisini tutar. Bir sayfa dolusu kod taşıyan tek
+        bir fotoğraf, onu kırpmayı ya da kamerayı onlara teker teker doğrultmayı
+        gerektiren bir iştir."""
+
+[[faq]]
+q = "Barkodumun istediğimden başka bir biçim olduğunu neden söyledi?"
+a = """
+        Çünkü bir barkod kendi adını taşımaz. UPC-A, ilk hanesi sıfır olan bir
+        EAN-13'tür; ITF-14, on dört haneli ve geçerli bir kontrol hanesi olan bir
+        Interleaved 2 of 5'tir ve sayısal kipindeki Code 128 başka hiçbir şeye
+        benzemez. Bu sayfanın bildirdiği şey, çubukların söylediği artı kontrol
+        hanesinin doğruladığı şeydir; simgenin kendisinin bildiği de bu
+        kadardır."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        kamerasıyla birlikte çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin
+        yüklenmediğini kanıtlamanın en basit yolu: resminizi çözülmek üzere uzağa
+        gönderen bir okuyucu, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir görselden, ekran görüntüsünden ya da canlı kameradan, tamamen tarayıcıda QR kod veya çizgisel barkod okuyun. Çözülen dizeyi ve bağlantılar için ulaşacağı sunucuyu, hiçbir şey açılmadan önce gösterir. Reed-Solomon hata düzeltmesiyle 1'den 40'a QR sürümlerini ve EAN-13, EAN-8, UPC-A, UPC-E, ITF-14, Interleaved 2 of 5, Code 128 ile Code 39'u destekler. Hiçbir şey yüklenmez ve hiçbir kamera karesi kaydedilmez."
+features = [
+  "Bir fotoğraftan, ekran görüntüsünden, yapıştırılmış bir görselden ya da canlı kameradan QR kod okur",
+  "1'den 40'a kadar her QR sürümü, dört hata düzeltme seviyesinin hepsi ve sayısal, alfasayısal, bayt ile kanji kipleri",
+  "Reed-Solomon düzeltmesi; çizilmiş, kırışmış ya da kısmen kapanmış bir kod yine okunur",
+  "Hizalama desenini kullanarak açıyı ve perspektifi düzeltir",
+  "Koyu üzerine açık basılmış kodları ve baş aşağı fotoğraflanmış kodları okur",
+  "EAN-13, EAN-8, UPC-A, UPC-E, ITF-14, Interleaved 2 of 5, Code 128 ve Code 39",
+  "Hiçbir şey açılmadan önce adresin tamamını ve gerçekten ulaştığı sunucuyu gösterir",
+  "Bir bağlantıyı gizleyen numaraları adıyla anar: @'in önündeki kullanıcı adı, benzer harfli alfabe, yönlendirme",
+  "Wi-Fi, kartvizit, e-posta, SMS, telefon ve harita içeriklerini okunabilir alanlara ayırır",
+  "Örneklediği modülleri çizer, böylece okuma güvenilmek yerine denetlenebilir",
+  "Hiçbir kamera karesi kaydedilmez ya da saklanmaz; akış sekmeyle birlikte durur",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]

--- a/locales/tr/tools/qr-barcode.html
+++ b/locales/tr/tools/qr-barcode.html
@@ -1,0 +1,194 @@
+<!--
+  tools/qr-barcode/body.html, in Turkish.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change - and the
+  symbology names are not words here but the names somebody will ask you for,
+  so EAN-13, UPC-A, ITF-14 and the rest stay as they are.
+-->
+<main>
+  <!-- Adım 1 &mdash; kodun türü -->
+  <section class="card">
+    <h2><span class="step">1</span> Kodun türünü seçin</h2>
+
+    <p class="card-lede">
+      Bir QR kod her şeyi taşır ve bir telefon kamerasının aradığı şeydir. Bir
+      barkod bir sayı taşır ve hangisine ihtiyacınız olduğuna genellikle sizin
+      yerinize karar verilir &mdash; onu isteyen mağaza, depo ya da nakliye
+      şirketi tarafından.
+    </p>
+
+    <div class="option-row">
+      <label for="symbology">Kod türü</label>
+      <select id="symbology">
+        <optgroup label="Kare">
+          <option value="qr" selected>QR kod</option>
+        </optgroup>
+        <optgroup label="Çizgili">
+          <option value="code128">Code 128</option>
+          <option value="ean13">EAN-13</option>
+          <option value="upca">UPC-A</option>
+          <option value="ean8">EAN-8</option>
+          <option value="itf14">ITF-14</option>
+          <option value="itf">Interleaved 2 of 5</option>
+          <option value="code39">Code 39</option>
+        </optgroup>
+      </select>
+    </div>
+
+    <p class="field-summary" id="symbology-note"></p>
+  </section>
+
+  <!-- Adım 2 &mdash; dizenin kendisi -->
+  <section class="card">
+    <h2><span class="step">2</span> İçine ne gireceğini söyleyin</h2>
+
+    <div class="option-row" id="format-row">
+      <label for="format">Ne taşıyacak</label>
+      <select id="format"></select>
+    </div>
+
+    <p class="card-lede" id="format-note"></p>
+
+    <div id="fields" class="fields"></div>
+
+    <p id="input-error" class="error" role="alert" hidden></p>
+
+    <!--
+      The finished string, shown rather than hidden. A "Wi-Fi QR code" is an
+      ordinary QR code holding a line of text in a format phones recognise, and
+      when a phone does not act on one, this line is the thing to look at.
+    -->
+    <details class="encoded" id="encoded-panel">
+      <summary>Bu kodun taşıyacağı tam dize</summary>
+      <pre id="encoded"></pre>
+      <p class="field-summary" id="encoded-note"></p>
+    </details>
+  </section>
+
+  <!-- Adım 3 &mdash; nasıl çizileceği -->
+  <section class="card">
+    <h2><span class="step">3</span> Nasıl görüneceğini seçin</h2>
+
+    <fieldset class="options" id="qr-options">
+      <legend>QR kod</legend>
+
+      <div class="option-row">
+        <label for="level">Ne kadar hasar alabilir</label>
+        <select id="level">
+          <option value="L">L &mdash; yaklaşık %7 kurtarılabilir, en küçük kod</option>
+          <option value="M" selected>M &mdash; yaklaşık %15, olağan tercih</option>
+          <option value="Q">Q &mdash; yaklaşık %25</option>
+          <option value="H">H &mdash; yaklaşık %30, yıpranacak bir baskı için</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="quiet">Modül cinsinden kenar boşluğu</label>
+        <input type="number" id="quiet" value="4" min="0" max="16" step="1" inputmode="numeric">
+      </div>
+
+      <p class="field-summary">
+        Kenar boşluğu, kodun çevresindeki alan değil kodun bir parçasıdır. Dört
+        modül, şartnamenin istediği şeydir ve kenarına kadar kırpılmış bir kodu
+        pek çok tarayıcı hiç göremez.
+      </p>
+    </fieldset>
+
+    <fieldset class="options" id="barcode-options" hidden>
+      <legend>Barkod</legend>
+
+      <div class="option-row">
+        <label for="bar-width">Piksel cinsinden en dar çubuk</label>
+        <input type="number" id="bar-width" value="2" min="1" max="10" step="1" inputmode="numeric">
+      </div>
+
+      <div class="option-row">
+        <label for="bar-height">Piksel cinsinden çubuk yüksekliği</label>
+        <input type="number" id="bar-height" value="120" min="20" max="600" step="10" inputmode="numeric">
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="show-text" checked>
+        <span>
+          <strong>Karakterleri altına bas</strong>
+          <span class="check-note">
+            Tarayıcı okumadığında bir insanın okuduğu şey. Bir perakende
+            kodunda haneler kenar boşluklarında da durur ve bu bilinçlidir:
+            kimsenin kırpmaması gereken beyaz alanı işaretlerler.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="code39-check-row" hidden>
+        <input type="checkbox" id="code39-check">
+        <span>
+          <strong>Bir kontrol karakteri ekle</strong>
+          <span class="check-note">
+            Code 39 normalde bir tane taşımaz. Bazı sistemler bunda ısrar eder;
+            yalnızca sizinki ediyorsa ekleyin, çünkü onu beklemeyen bir okuyucu
+            bunu sondaki fazladan bir karakter olarak okur.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Renk ve boyut</legend>
+
+      <div class="colour-row">
+        <div class="option-row">
+          <label for="foreground">Kod</label>
+          <input type="color" id="foreground" value="#000000">
+        </div>
+        <div class="option-row">
+          <label for="background">Arkası</label>
+          <input type="color" id="background" value="#ffffff">
+        </div>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="transparent">
+        <span>
+          <strong>Hiç arka plan olmasın</strong>
+          <span class="check-note">
+            Saydam; zaten bir rengi olan bir şeyin üzerine koymak için. SVG de
+            PNG de bunu korur; arkasında ne kalırsa kalsın açık renk olmalı,
+            yoksa bir tarayıcı hiç kontrast bulamaz.
+          </span>
+        </span>
+      </label>
+
+      <div class="option-row" id="size-row">
+        <label for="size">Piksel cinsinden resmin boyutu</label>
+        <input type="number" id="size" value="512" min="64" max="4096" step="16" inputmode="numeric">
+      </div>
+
+      <p class="field-summary" id="size-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Adım 4 &mdash; sonuç -->
+  <section class="card" id="result-card">
+    <h2><span class="step">4</span> Alın</h2>
+
+    <div class="preview" id="preview" role="img" aria-label="Ürettiğiniz kod"></div>
+
+    <p class="facts" id="facts"></p>
+
+    <div class="run-row">
+      <button type="button" id="download-svg" class="primary">SVG'yi indir</button>
+      <button type="button" id="download-png" class="primary">PNG'yi indir</button>
+      <button type="button" id="copy-png" class="ghost">Görseli kopyala</button>
+    </div>
+
+    <p class="field-summary" id="download-note" role="status"></p>
+
+    <p class="field-summary">
+      Saklanacak olan SVG'dir. Kodun piksel değil talimat hâlidir; yani her
+      boyutta yumuşamadan basılır &mdash; ki bu, çoğu resimden çok burada
+      önemlidir, çünkü bir tarayıcının çözemediği şey tam olarak bulanık bir
+      kenardır.
+    </p>
+  </section>
+</main>

--- a/locales/tr/tools/qr-barcode.toml
+++ b/locales/tr/tools/qr-barcode.toml
@@ -1,0 +1,333 @@
+#
+# QR ve Barkod Üreteci - Türkçe.
+#
+# Overrides for tools/qr-barcode/tool.toml. Only words: the slug, the category,
+# the icon and the CSP stay where they are.
+#
+# Barkod simgelerinin adları (EAN-13, UPC-A, ITF-14, Code 128, Code 39),
+# Reed-Solomon, GS1, Denso Wave ve ISO/IEC 18004 olduğu gibi kalıyor: bunlar
+# başkasının size söyleyeceği ve sizin arayacağınız adlar.
+#
+
+name = "QR ve Barkod Üreteci"
+heading = "QR&nbsp;ve&nbsp;Barkod <span class=\"h1-kw\">&mdash; çevrimdışı QR kod ya da barkod üretin</span>"
+tagline = "Yazın, koda dönüşsün. Bir tane üretmek için hiçbir şey gönderilmez."
+
+title = "QR Kod ve Barkod Üreteci &mdash; Ücretsiz, Kayıtsız, Hiçbir Şey Yüklenmez"
+description = "Bir bağlantı, bir Wi-Fi ağı ya da bir kartvizit için QR kod üretin; ya da EAN-13, UPC-A, Code 128 veya Code 39 barkodu. SVG ya da PNG olarak indirin. Hepsi tarayıcınızda olur."
+og_title = "Kimseye hiçbir şey göndermeden QR kod ya da barkod üretin"
+og_description = "Bağlantılar, Wi-Fi şifreleri, kartvizitler ve perakende barkodları; kendi tarayıcınızda çizilir ve SVG ya da PNG olarak indirilir. Hesap yok, filigran yok, kodunuzun ortasında izleme pikseli yok."
+og_image_alt = "QR ve Barkod Üreteci - QR kod ya da barkod üretin, hiçbir şey yüklenmesin"
+
+pledge = """
+    Bir QR kod, bir dize üzerinde yapılan bir hesaptır: gönderilecek bir dosya
+    ve sorulacak bir hizmet yoktur. Her adım &mdash; kipin seçilmesi, sürümün
+    belirlenmesi, Reed-Solomon hata düzeltmesi, maske, bir barkodun çubukları ve
+    altındaki kontrol hanesi &mdash; bu sayfada, okuyabileceğiniz yaklaşık bin
+    satırlık JavaScript içinde olur. Bu aracın hiçbir türde ağ özelliği yoktur ve
+    bu, çoğu sayfadan çok burada önemlidir: kodlanan şey çoğu zaman bir Wi-Fi
+    şifresidir."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve Wi-Fi formuna bir şifre yazın. Tek bir istek bile ondan tek bir
+      karakter taşımıyor. Ya da internet bağlantısını kesip kodu yine de
+      üretin."""
+
+read_first = """
+, QR kodun kendisi için <code>src/qr-encode.js</code> ve
+      <code>src/qr.js</code> &mdash; kipler, sürüm ve bloklar birinde;
+      desenler, maske ve biçim bitleri diğerinde &mdash; hata düzeltmesi için
+      <code>src/gf256.js</code> ve çizgili olanlar için
+      <code>src/barcode.js</code>."""
+
+howto_heading = "Hiçbir şey yüklemeden nasıl QR kod üretilir"
+
+card = """
+            Bir bağlantı, bir Wi-Fi ağı ya da bir kartvizit için QR kod &mdash;
+            ya da kontrol hanesi hesaplanmış bir perakende barkodu. SVG ya da
+            PNG."""
+
+[words]
+plural = "kodlar ve içlerindeki metin"
+choose = "içine ne gireceğini"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Süre sonu yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Yazdığınız şeyin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Bir Wi-Fi şifresinin toplanabileceği bir uç nokta
+      burada yok, olsaydı bile onu gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir yerde
+      <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Kod, dizeden aritmetikle kurulur ve bu
+      sayfada, sizin makinenizde bir SVG olarak çizilir."""
+
+[[privacy]]
+title = "Kod bizi işaret etmez."
+body = """
+ Yazdığınız şey, kodun taşıdığı şeydir.
+      Birkaç ücretsiz üreteç size, kendi sitelerine bir bağlantı içeren ve oradan
+      sizinkine yönlendiren bir kod verir &mdash; yani her tarama onlar
+      tarafından sayılır ve alan adının parasını ödemeyi bıraktıkları ya da
+      ücretsiz katmanın bittiğine karar verdikleri gün kod çalışmayı durdurur.
+      Burada hiçbir şey kısaltmaz, yönlendirmez ya da izlemez: sayfada gösterilen
+      dize, resimdeki dizedir."""
+
+[[privacy]]
+title = "PNG, ekrandaki SVG'den üretiliyor."
+body = """
+ İndirme, ön izlemeyle
+      uyuşmayabilecek ikinci bir çizim değildir. Aynı biçimlendirme tarayıcıya
+      verilir ve bir tuvale boyanır; bunun hiçbir şeyle iletişim kurmadan
+      yapılabilmesinin sebebi de budur: getirilecek bir yazı tipi ve içinde
+      yüklenecek bir görsel yoktur."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine
+      yazdığınız hiçbir şey verilmiyor. Bir dizeyi koda çeviren her satır bu
+      kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "Kodun türünü seçin."
+body = """
+ Bir QR kod her şeyi taşır ve bir telefon
+      kamerasının aradığı şeydir; yani biri size aksini söylemedikçe cevap odur.
+      Bir barkod bir sayı taşır ve hangisine ihtiyacınız olduğuna, onu tarayacak
+      olan karar verir &mdash; bir mağaza EAN-13 ya da UPC-A ister, bir sevkiyat
+      kolisi ITF-14 ve şirket içi olan her şey genellikle Code 128'dir."""
+
+[[howto]]
+title = "İçine ne gireceğini söyleyin."
+body = """
+ Yaygın olan bir bağlantıdır ve
+      üstündeki kutular telefonların bildiği diğer biçimleri kurar: kendini
+      katmayı öneren bir Wi-Fi ağı, kaydedilmeyi öneren bir kartvizit, bir
+      e-posta, bir kısa mesaj, bir telefon numarası, haritada bir yer. Hangisini
+      seçerseniz seçin, bitmiş dize sayfada gösterilir &mdash; bir QR kodun
+      taşıdığı tek şey budur."""
+
+[[howto]]
+title = "Ne kadar hasar alabileceğini seçin."
+body = """
+ Dört seviye, daha çok ya da
+      daha az hata düzeltmesi koyar ve daha çok düzeltme daha büyük, daha yoğun
+      bir kod demektir. L bir ekran için yeter, M sıradan kâğıt için ve H
+      tutulacak, küçük basılacak ya da güneşte bir camda duracak bir şey için.
+      Her gün silinen bir menüdeki bir kod, Q ya da H'ye değer."""
+
+[[howto]]
+title = "Boyutu, kenar boşluğunu ve renkleri ayarlayın."
+body = """
+ Kenar boşluğu kodun bir
+      parçasıdır: mevzuatın istediği şey çevresinde dört modülük sessiz alandır
+      ve onu kırpmak, basılı bir kodun taranmamasının en yaygın tek sebebidir.
+      Açık üzerine koyu, gerçek bir kontrastla &mdash; bir tarayıcı ikisi
+      arasındaki farkı okur, yani beyaz üzerine soluk gri olmaz ve koyu üzerine
+      açık, pek çok okuyucuda doğrudan başarısız olur."""
+
+[[howto]]
+title = "Elinizdeki telefonla denetleyin."
+body = """
+ Bin tane basmadan önce ekranınızdakini
+      tarayın. Bu on saniye sürer ve bir ön izlemenin yakalayamayacağı hata
+      sınıfının tamamını yakalar: kaçış karakteri gereken bir karakteri olan bir
+      Wi-Fi şifresi, <code>https://</code> eksik bir bağlantı, bir hane eksik bir
+      barkod numarası."""
+
+[[howto]]
+title = "SVG'yi alın."
+body = """
+ Kodun piksel değil talimat hâlidir; yani her
+      boyutta yumuşamadan basılır ve bir tarayıcının çözemediği şey tam olarak
+      yumuşak bir kenardır. Yapıştıracağınız yer SVG kabul etmiyorsa PNG'yi de
+      alın; o da modül başına tam sayıda pikselle çizilir, yani onun da bulanık
+      kenarı olmaz."""
+
+[[faq]]
+q = "Yazdığım hiçbir şey bir yere gönderiliyor mu?"
+a = """
+        Hayır. Bir QR kod, bir dize üzerinde yapılan bir hesaptır ve o hesap kendi
+        makinenizde, kendi tarayıcınızda çalışır. Bu aracın hiçbir türde ağ
+        özelliği yoktur &mdash; hiçbir zaman bir şey getirmez ve hiçbir zaman bir
+        şey göndermez &mdash; ve sayfanın <code>Content-Security-Policy</code>'si
+        iletişim kurabileceği her adresi tek tek sayar; bunların hiçbiri bu siteye
+        ait değildir. Bu, çoğu sayfadan çok burada değerlidir; çünkü insanların
+        bir QR koda en sık koyduğu şey Wi-Fi şifreleridir."""
+
+[[faq]]
+q = "Bu kodların süresi doluyor mu, sonradan çalışmayı bırakıyor mu?"
+a = """
+        Hayır ve bırakamazlar. Yazdığınız şey, kodun taşıdığı şeydir; yani onu
+        taramak sonsuza kadar tam olarak o dizeyi geri verir. Süresi dolan
+        kodlar, içinde başkasının adresi olanlardır: bir "dinamik" QR kod,
+        üretecin sunucusuna bir bağlantı taşır ve oradan sizinkine yönlendirir;
+        bu da her taramayı sayabilecekleri, nereye gittiğini
+        değiştirebilecekleri ya da bir deneme süresi bittiğinde
+        kapatabilecekleri anlamına gelir. Burada hiçbir şey hiçbir şeyin üzerinden
+        yönlendirmez."""
+
+[[faq]]
+q = "Ücretsiz mi ve ticari olarak kullanabilir miyim?"
+a = """
+        Ücretsiz; hesap yok, filigran yok ve kaç tane ürettiğinizde bir sınır
+        yok; sonucu bir ürüne, bir afişe ya da bir vitrine koyabilirsiniz. QR
+        Code, Denso Wave'in tescilli markasıdır ve şirket bu hakkı kodları
+        kullananlara karşı kullanmayacağını açıklamıştır &mdash; şartname
+        ISO/IEC 18004 olarak yayımlanmıştır ve uygulaması serbesttir; bu
+        sayfanın yaptığı da budur. Sitede reklam var, masrafı karşılayan da o."""
+
+[[faq]]
+q = "Hangi hata düzeltme seviyesini seçmeliyim?"
+a = """
+        Bir sebebiniz yoksa M. L en küçük kodu yapar ve bir ekranda gayet
+        iyidir; M sıradan bir kullanımdan sağ çıkar; Q ve H ise küçük
+        basılacak, lamine edilecek, bir cama yapıştırılacak ya da kısmen bir
+        logoyla kapatılacak bir kod içindir. Her bir üst basamak daha çok
+        denetim verisi koyar ki bu da aynı miktarda metin için daha büyük bir
+        simge gerektirir &mdash; L'den H'ye geçmek, aynı dize için modül sayısını
+        kabaca iki katına çıkarır."""
+
+[[faq]]
+q = "Bir QR kod ne kadar taşıyabilir?"
+a = """
+        En büyük boyutta, 177 modül kare, 7.089 rakama, 4.296 büyük harf ve
+        rakama ya da başka her şeyden 2.953 bayta kadar &mdash; ve bu, en zayıf
+        hata düzeltmesinde; en güçlüsünde bunların yaklaşık üçte biri kadar.
+        Pratikte sınır biçim değil tarayıcıdır: birkaç yüz karakterden sonra
+        modüller o kadar küçülür ki sıradan bir telefon kamerası onları kol
+        mesafesinden çözemez. Uzun bir kod genellikle, içine kısa bir bağlantının
+        girmesi gerektiğinin işaretidir."""
+
+[[faq]]
+q = "Bağlantıyı küçük harfle yazınca kodum neden büyüyor?"
+a = """
+        Çünkü bir QR kodun büyük harfler ve rakamlar için, iki karakteri on bir
+        bite paketleyen bir kipi vardır; küçük harf için böyle bir kip yoktur ve
+        her biri sekiz bite mal olur. <code>HTTPS://EXAMPLE.COM/PAGE</code> diye
+        yazılmış bir adres, küçük harfli hâlinden üçte bir daha küçük olabilir.
+        Şema ve sunucu adı büyük/küçük harfe duyarsızdır, yani onları bağırmak
+        boyuttan başka bir şeyi değiştirmez; sunucudan sonraki yol ise duyarlıdır,
+        onu olduğu gibi bırakın."""
+
+[[faq]]
+q = "Bir QR kodu üretmenin yanı sıra okuyabiliyor mu?"
+a = """
+        Bu sayfa okuyamaz ama yan kapıdaki okur:
+        <a href="../qr-kod-okuma/">okuyucu</a>, bir fotoğrafı, bir ekran
+        görüntüsünü ya da kameranızı alır ve dizeyi geri verir. Bir tane çizmekten
+        epeyce büyük bir iştir &mdash; simgeyi bir resimde bulmak, çekildiği açıyı
+        düzeltmek ve hasarı onarmak, bu sayfanın hiç yaşamadığı üç sorundur
+        &mdash; kendi başına bir araç olmasının ve burada bir düğme olmamasının
+        sebebi de budur. Diğer her şeyle aynı şartlarla çalışır: hiçbir şey
+        yüklenmez ve hiçbir kamera karesi saklanmaz."""
+
+[[faq]]
+q = "Kenar boşluğu ne işe yarıyor, onu küçültebilir miyim?"
+a = """
+        Bir QR kodun çevresindeki beyaz alan kodun bir parçasıdır. Bir okuyucu
+        simgenin nerede bittiğini onunla bulur ve şartname her kenarda dört modül
+        ister; bir barkod on kadar ister. Burada sıfıra ayarlayabilirsiniz ve
+        resim daha derli toplu görünür; sonra da pek çok tarayıcı onu hiç
+        göremez &mdash; özellikle kalabalık bir arka planda. Sorun yerse kodun
+        kenar boşluğunu kırpmak yerine kodu küçültün."""
+
+[[faq]]
+q = "Hangi barkoda ihtiyacım var?"
+a = """
+        Onu tarayacak kişi hangisini isterse. EAN-13 Kuzey Amerika dışındaki
+        perakende barkodu, UPC-A ise Kuzey Amerika'daki &mdash; ikisi de size
+        GS1 tarafından verilmiş bir numara gerektirir, çünkü numara yalnızca
+        ürünü değil şirketinizi tanımlar. EAN-8, küçük ambalajlar için kısa
+        sürümdür. ITF-14 sevkiyat kolisine gider. Code 128 ve Code 39 rakamın
+        yanı sıra metin de taşır ve hiçbir kayıt gerektirmez; bu da onları
+        şirket içi her şey için doğru cevap yapar: demirbaşlar, raflar, iş
+        emirleri."""
+
+[[faq]]
+q = "Kontrol hanesi nedir ve araç neden bir tane ekledi?"
+a = """
+        Bir perakende barkodunun, kendinden öncekilerden hesaplanan son
+        hanesidir; böylece bir tarayıcı yanlış okumayı doğru okumadan ayırabilir.
+        EAN-13 on iki hane ister ve on üçüncüyü hesaplar; UPC-A on bir ister ve
+        on ikinciyi hesaplar. Kısa numarayı yazın, bu sayfa onu eklesin. Tam
+        numarayı yazın, verdiğinizi denetlesin &mdash; ve sessizce düzeltmek
+        yerine reddetsin; çünkü sessizce düzeltilmiş yanlış bir hane, başkasının
+        ürünü olarak taranan bir etiket demektir."""
+
+[[faq]]
+q = "Bir QR kodun ortasına logo koyabilir miyim?"
+a = """
+        Burada değil; ama başka yerlerde işe yaramasının sebebi bilinmeye değer:
+        onu mümkün kılan hata düzeltmesidir. H seviyesinde modüllerin kabaca
+        %30'u yok edilebilir ve kod yine okunur; yani merkezde &mdash; hiçbir
+        tanıma deseninin bulunmadığı yerde &mdash; bundan azını kaplayan bir
+        logo, onarılabilir bir hasardır. Kodu H seviyesinde alıp görsel
+        düzenleyicinizden geçirin, logoyu alanın yaklaşık beşte birinin altında
+        tutun ve ona güvenmek yerine gerçek bir telefonla deneyin."""
+
+[[faq]]
+q = "SVG neden PNG'den iyi?"
+a = """
+        Çünkü bir kod kenarlardan oluşur ve bir PNG'nin onları yapacak sabit
+        sayıda pikseli vardır. Bir tanesini büyütün, her kenar yumuşar; yumuşak
+        bir kenar ise bir tarayıcının tam da zorlandığı şeydir ve 1200 dpi'lık
+        bir yazıcıya 512 piksellik bir PNG vermek, ondan aradaki farkı uydurmasını
+        istemektir. Bir SVG, kareleri talimat olarak taşır; yani bir kartvizitte
+        de bir bilbordda da keskin basılır. Buradaki PNG, modül başına tam sayıda
+        pikselle çizilir ki bir PNG'nin yapabileceğinin en iyisi budur."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: metninizi bir kod çizilsin diye uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Tarayıcıda bir dizeden QR kod ya da çizgisel barkod üretin. Bağlantılar, Wi-Fi ağları, kartvizitler, e-posta, SMS, telefon numaraları ve koordinatlar için QR kodlar; dört hata düzeltme seviyesinin hepsiyle. Kontrol haneleriyle birlikte EAN-13, EAN-8, UPC-A, ITF-14, Interleaved 2 of 5, Code 128 ve Code 39 barkodları. SVG ya da PNG olarak indirin. Hiçbir şey yüklenmez."
+features = [
+  "1'den 40'a kadar her sürümde QR kod; sayısal, alfasayısal ve bayt kipinde",
+  "Dört hata düzeltme seviyesinin hepsi, her birinin neye mal olduğu açıkça söylenerek",
+  "Hazır biçimler: Wi-Fi ağı, kartvizit, e-posta, kısa mesaj, telefon numarası, harita konumu",
+  "Kodun taşıyacağı dizeyi gizlemek yerine tam olarak gösterir",
+  "EAN-13, EAN-8 ve UPC-A; kontrol hanesi hesaplanmış ya da doğrulanmış hâlde",
+  "Koliler ve depolama için ITF-14 ve Interleaved 2 of 5",
+  "Sayısal kipini otomatik kullanan Code 128 ve isteğe bağlı kontrol karakteriyle Code 39",
+  "Barkodun altına, doğru yerlerine basılmış insan tarafından okunabilir haneler",
+  "Her boyutta keskin basılsın diye SVG çıktı ve modül başına tam piksellerle çizilmiş bir PNG",
+  "İstediğiniz iki renk ya da hiç arka plan yok",
+  "Asla yönlendirmez: kısa bağlantı yok, izleme yok, süresi dolabilecek hiçbir şey yok",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]

--- a/locales/tr/tools/redact-image.html
+++ b/locales/tr/tools/redact-image.html
@@ -1,0 +1,186 @@
+<!--
+  tools/redact-image/body.html, in Turkish.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; resim -->
+  <section class="card">
+    <h2><span class="step">1</span> Görseli seçin</h2>
+
+    <p class="card-lede">
+      Bir hesap özetinin ekran görüntüsü, bir pasaport fotoğrafı, üzerinde adres
+      olan bir fatura &mdash; insanların karartması gereken resimler, tam da bir
+      yabancının sunucusuna bu iş için yüklememeleri gereken resimlerdir. Bu
+      resim, tarayıcı tarafından doğrudan diskinizden okunur.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="loaded" class="loaded-row" hidden>
+      <p id="loaded-name" class="loaded-name"></p>
+      <button type="button" id="clear-image" class="ghost danger">Başkasını seç</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; kutular -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Görünmemesi gerekeni kapatın</h2>
+
+    <p id="edit-empty" class="field-summary">Bir görsel seçin; üzerine çizmek için burada görünsün.</p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Kutu çizmek için resim üzerinde sürükleyin. Taşımak için kutuyu, yeniden
+        boyutlandırmak için tutamaklarını sürükleyin ya da bir tanesine ulaşmak
+        için <kbd>Tab</kbd>'a basıp ok tuşlarını kullanın &mdash; <kbd>Alt</kbd>
+        ve oklar yeniden boyutlandırır, <kbd>Delete</kbd> kaldırır. Her kutunun
+        altında gördüğünüz şey gerçeğidir: ön izleme, dosyayı yazan aynı kod
+        tarafından, ekran boyutunda çizilir.
+      </p>
+
+      <!-- The picture is a canvas, not an <img>, because the redaction is
+           painted into it rather than laid over it. The boxes above it are
+           outlines and handles only; src/stage.js adds them. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="preview"></canvas>
+        </div>
+      </div>
+
+      <fieldset class="options" id="style-group">
+        <legend>Yeni bir kutu ne yapar</legend>
+
+        <label class="check">
+          <input type="radio" name="style" value="fill" checked>
+          <span>
+            <strong>Karart</strong>
+            <span class="check-note">
+              Kenardan kenara tek bir düz renk. Orada olandan hiçbir şey hayatta
+              kalmaz &mdash; ne bir dış hat, ne bir ortalama, ne de karakter
+              sayısı. Üçü içinde işi bitiren tek seçenek budur ve metin olarak
+              okunan her şey için kullanılacak olan da budur.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="style" value="pixelate">
+          <span>
+            <strong>Pikselleştir</strong>
+            <span class="check-note">
+              Her blok, o bloğun ortalama rengi olur. Orijinal pikseller
+              dosyadan gitmiştir, ama bir ortalamalar ızgarası hâlâ altında ne
+              olduğunun bir ölçümüdür &mdash; ve sıradan bir yazı tipindeki metin
+              için bu, yayımlanmış çalışmalarda orijinali yeniden kurmaya yetti.
+              Kalabalıktaki bir yüz için uygun; bir hesap numarası için değil.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="style" value="blur">
+          <span>
+            <strong>Bulanıklaştır</strong>
+            <span class="check-note">
+              Her piksel, komşularının ağırlıklı ortalaması olur.
+              Pikselleştirmeyle aynı itiraz, biraz daha keskin hâliyle:
+              bulanıklaştırma bir konvolüsyondur ve konvolüsyonlar ilkesel olarak
+              tersine çevrilebilir. Bir şeyin gizlenmesini değil yumuşamasını
+              istediğiniz yerde kullanın.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row">
+          <label for="strength">Pikselleştirme ve bulanıklaştırma ne kadar sert uygulansın</label>
+          <select id="strength">
+            <option value="light">Hafif</option>
+            <option value="medium" selected>Orta</option>
+            <option value="heavy">Sert</option>
+          </select>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <div class="frame-actions">
+        <button type="button" id="add-box" class="ghost">Ortaya bir kutu ekle</button>
+        <button type="button" id="undo" class="ghost" disabled>Geri al</button>
+        <button type="button" id="clear-boxes" class="ghost danger" disabled>Her kutuyu kaldır</button>
+      </div>
+
+      <p id="box-summary" class="field-summary"></p>
+      <ul id="region-list" class="region-list"></ul>
+      <p id="risk-note" class="hint-line warn-line" hidden></p>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; dosya -->
+  <section class="card" id="save-card">
+    <h2><span class="step">3</span> Karartılmış kopyayı kaydedin</h2>
+
+    <p class="card-lede">
+      Resim piksellere çözülür, kutular o piksellerin üzerine yazılır ve sonuç
+      yeni bir dosya olarak kodlanır. Katman, açıklama ve kutuların nerede
+      olduğuna dair bir kayıt yoktur; çünkü kapatılan pikseller, kodlayıcıya bir
+      şey verilmeden önce var olmayı bırakır.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Biçim</label>
+        <select id="format">
+          <option value="auto" selected>Otomatik &mdash; fotoğraf için JPEG, başka her şey için PNG</option>
+          <option value="png">PNG (kayıpsız)</option>
+          <option value="jpeg">JPEG</option>
+          <option value="webp">WebP</option>
+        </select>
+        <p class="field-note">
+          Karartma açısından hiçbir fark yaratmaz: pikseller kodlayıcı onları
+          görmeden çoktan gitmiştir. Yalnızca resmin geri kalanının neye mal
+          olacağına ve nasıl sıkıştırılacağına karar verir.
+        </p>
+      </div>
+
+      <div class="field" id="quality-row" hidden>
+        <label for="quality">Kalite</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="90">
+          <output id="quality-value">%90</output>
+        </div>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save" class="primary big" disabled>Karart ve kaydet</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden>
+      Tam boyutta karartılıyor&hellip;
+    </p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>Bitmiş dosya</h3>
+        <a id="download" class="primary as-button" href="#" download>İndir</a>
+      </div>
+
+      <!-- This is the blob itself, decoded again by the browser - not the
+           canvas it was made on. What is on screen here is the file. -->
+      <img id="result-image" class="result-image" alt="">
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <p class="hint-line">
+        Sonrasında onu açıp kapatılan metni seçmeyi deneyin ya da bir
+        düzenleyiciye yapıştırıp bir katman arayın. Bulunacak bir şey yok: tek
+        bir düz resim var ve kapattığınız kısımların üzerine, dosya yazılmadan
+        önce yazıldı.
+      </p>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/redact-image.toml
+++ b/locales/tr/tools/redact-image.toml
@@ -1,0 +1,264 @@
+#
+# Görsel Karartıcı - Türkçe.
+#
+# Overrides for tools/redact-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Bu sayfa da PDF karartıcısıyla aynı ayrım üzerine kurulu: "karartma"
+# piksellerin üzerine yazmak, "üstünü örtme" ise resmin üzerine bir nesne
+# koymak. İkisi ayrı tutulmazsa buradaki hiçbir cümle bir şey söylemez.
+#
+
+name = "Görsel Karartıcı"
+heading = "Görsel&nbsp;Karartıcı <span class=\"h1-kw\">&mdash; karartın, pikselleştirin ya da bulanıklaştırın</span>"
+tagline = "Kapattığınız şey dosyanın içinde örtülmez, dosyadan silinir."
+
+title = "Bir Görseli Karartma &mdash; Karartın, Pikselleştirin ya da Bulanıklaştırın, Yüklemesiz"
+description = "Bir fotoğraftaki ya da ekran görüntüsündeki bir ismi, adresi veya hesap numarasını kapatın ve resmi yeniden kodlayın; böylece gizlenen pikseller bir dikdörtgenin altında durmak yerine dosyadan gitmiş olur. Tamamen tarayıcınızda çalışır."
+og_title = "Bir görseli, kapatılan kısım gerçekten gidecek şekilde karartın"
+og_description = "Görünmemesi gerekenlerin üzerine kutular çizin. Altlarındaki pikseller dosya yazılmadan önce üzerine yazılır; yani taşınacak bir katman ve kurtarılacak bir şey kalmaz. Hiçbir şey yüklenmez."
+og_image_alt = "Görsel Karartıcı - kapatılan piksellerin üzerine yazılır, gizlenmez"
+
+pledge = """
+    Resim kendi tarayıcınız tarafından, zaten beraberinde getirdiği
+    kodlayıcılarla çözülür, üzeri boyanır ve yeniden kodlanır. Bu aracın hiçbir
+    türde ağ özelliği yoktur &mdash; getirecek bir şey yok, gönderecek bir şey
+    yok &mdash; ve bu, bu sitedeki neredeyse her yerden çok burada önemlidir:
+    insanların bir karartma aracına getirdiği resimler, üzerinde hâlâ okunabilir
+    bir isim, adres ya da hesap numarası olanlardır."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir şeyin ekran görüntüsünü karartın. Tek bir istek bile bir
+      görsel, bir küçük resim, bir dosya adı ya da tek bir kutunun konumunu
+      taşımıyor. Ya da internet bağlantısını kesip yine de bir tanesini
+      karartın."""
+
+read_first = """
+, piksellerin üzerine yazan üç işlev için
+      <code>src/redact.js</code> ve ekranda gördüğünüz şeyin neden aynı üç işlev
+      tarafından çizildiği için <code>src/preview.js</code>."""
+
+howto_heading = "Bir görsel, gizlenen kısım gerçekten gidecek şekilde nasıl karartılır"
+
+card = """
+            Bir resmin bir bölümünü karartın, pikselleştirin ya da
+            bulanıklaştırın. Kapatılan piksellerin üzerine dosya yazılmadan önce
+            yazılır; yani kenara itilecek bir katman yoktur."""
+
+[words]
+plural = "görseller"
+choose = "bir görsel"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Görsellerinizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Kapatılan pikseller çıkış yolunda değil burada var olmayı bırakıyor."
+body = """
+ Resim bir
+      piksel arabelleğine çözülür, kutular o arabelleğin üzerine yazılır ve
+      arabellek kodlayıcıya verilir. Bu sayfada, kutuları ayrı bir katman olarak
+      taşıyan bir resim sürümü yoktur; çünkü öyle bir sürüm hiç üretilmez
+      &mdash; <code>src/redact.js</code>'e bakın."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir yerde
+      <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. İş, <code>getImageData</code>, baytlar
+      üzerinde üç döngü ve <code>canvas.toBlob</code> &mdash; hepsi
+      tarayıcınızda zaten kurulu."""
+
+[[privacy]]
+title = "Kutular hiçbir yere bildirilmez."
+body = """
+ Nereye çizdiğiniz, kaç tane
+      olduğu, ne kadar büyük olduğu ve hangi stili seçtiğiniz, siz sayfayı
+      kapatana kadar bu sayfanın belleğinde tutulur. Bu depoda bunlardan
+      herhangi birini taşıyan özel bir analitik olayı yoktur ve bu sitenin bir
+      indirmeden sonra sorduğu tek soru, bir başparmak yönü ile aracın adını
+      gönderir, başka hiçbir şeyi."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu &mdash; ve bir pasaportu karartmadan önce çalıştırmaya değen de
+      bu."""
+
+[[howto]]
+title = "Görseli seçin."
+body = """
+ Bir ekran görüntüsü, bir tarama ya da bir
+      fotoğraf &mdash; tarayıcınızın açabildiği her şey. Doğrudan diskinizden
+      okunur; siz bunu yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Görünmemesi gerekenin üzerine bir kutu sürükleyin."
+body = """
+ Bir sonraki için
+      yeniden sürükleyin. Bir kutu taşınabilir, tutamaklarından yeniden
+      boyutlandırılabilir ya da Tab tuşuyla erişilip oklarla oynatılabilir.
+      Kutunun altında görünen şey gerçek sonuçtur; dosyayı yazan aynı kod
+      tarafından çizilmiştir."""
+
+[[howto]]
+title = "Karartma, pikselleştirme ya da bulanıklaştırma seçin &mdash; ve karartmayı tercih edin."
+body = """
+      Karartma altında hiçbir şey bırakmaz. Pikselleştirme ve bulanıklaştırma
+      ise pikselleri kendi ortalamalarıyla değiştirir; bu, arka plandaki bir yüz
+      için yeterlidir ve metin olarak okunan hiçbir şey için yeterli
+      değildir."""
+
+[[howto]]
+title = "\"Karart ve kaydet\"e basın, sonra dosyayı denetleyin."
+body = """
+      Sonrasında gösterilen resim, yeniden çözülmüş hâliyle bitmiş dosyadır. Onu
+      bir düzenleyicide açıp bir katman arayın ya da kapattığınız metni seçmeyi
+      deneyin: tek bir düz resim vardır ve kapattığınız kısımların üzerine, dosya
+      yazılmadan önce yazılmıştır."""
+
+[[faq]]
+q = "Görselim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya kendi donanımınızda, kendi tarayıcınız tarafından çözülür,
+        karartılır ve kodlanır. Bu aracın hiçbir türde ağ özelliği yoktur
+        &mdash; hiçbir zaman bir şey getirmez ve hiçbir zaman bir şey göndermez
+        &mdash; ve sayfanın <code>Content-Security-Policy</code>'si iletişim
+        kurabileceği her adresi tek tek sayar; bunların hiçbiri bu siteye ait
+        değildir. Sayfayı bir kez yükleyin, internet bağlantısını kesin, yine de
+        çalışır."""
+
+[[faq]]
+q = "Kapatılan kısım dosyadan gerçekten gitti mi?"
+a = """
+        Evet ve bu aracın var olma sebebi budur. Resim bir piksel arabelleğine
+        çözülür; kutular içlerindeki piksellerin üzerine yazar; sonra arabellek
+        yeni bir dosya olarak kodlanır. Orijinal değerler, kodlayıcıya bir şey
+        verilmeden önce bellekten gitmiştir; yani gizlenecek bir katman,
+        kaldırılacak bir açıklama ve geri alınacak bir geçmiş yoktur. Bunu,
+        başkasının iddiasını denetleyeceğiniz gibi denetleyebilirsiniz: sonucu
+        bir görsel düzenleyicide açıp ikinci bir katman arayın ya da kapattığınız
+        metni seçmeyi deneyin."""
+
+[[faq]]
+q = "Pikselleştirilmiş ya da bulanıklaştırılmış bir alan geri kazanılabilir mi?"
+a = """
+        Bazen ve seçim yapmadan önce okumaya değen tek şey budur. Karartma,
+        altındaki her şeyi tek bir düz renkle değiştirir; yani hiçbir şey hayatta
+        kalmaz &mdash; ne bir kenar, ne bir ortalama, ne de karakter sayısı.
+        Pikselleştirme her bloğu o bloğun ortalamasıyla değiştirir ve bir
+        ortalamalar ızgarası hâlâ altında ne olduğunun bir ölçümüdür: sıradan bir
+        yazı tipinde ve tahmin edilebilir bir boyuttaki metin için, yayımlanmış
+        çalışmalar aday dizeleri çizip ortalamalarını karşılaştırarak orijinali
+        yeniden kurmuştur. Bulanıklaştırma bir konvolüsyondur ve
+        konvolüsyonlar ilkesel olarak tersine çevrilebilir. Yani arka plandaki bir
+        yüzü isterseniz pikselleştirin ya da bulanıklaştırın; metin olarak okunan
+        her şeyi ise karartın."""
+
+[[faq]]
+q = "Bir belge düzenleyicide çizilmiş siyah bir dikdörtgen neden aynı şey değil?"
+a = """
+        Çünkü çoğu düzenleyici dikdörtgeni resmin içine değil yanına kaydeder. Bir
+        PDF okuyucuda, bir sunum programında, bir kelime işlemcide ya da katmanlı
+        bir görsel düzenleyicide çizilmiş bir şekil, sayfanın üzerinde duran ve
+        bir konumu olan bir nesnedir &mdash; onu taşımak, silmek ya da dosyayı
+        başka bir programda açmak, kapattığı şeyi olduğu gibi geri getirir.
+        Gazeteler, mahkemeler ve devlet kurumlarının hepsi bu şekilde
+        "karartılmış" belgeler yayımladı. Burada ise dikdörtgen hiç kaydedilmez:
+        o, orada olanların üzerine yazılmış bir dizi piksel değeridir."""
+
+[[faq]]
+q = "EXIF ve GPS verisini de siliyor mu?"
+a = """
+        Evet, yan etki olarak. Kaydetmek, piksellerle dolu bir tuvali kodlamak
+        demektir ve bir tuval hiçbir etiket taşımaz; dolayısıyla konum, kamera
+        modeli, zaman damgaları ve gömülü küçük resim yeni dosyaya hiç yazılmaz.
+        Burada küçük resim önemlidir: görüntünün küçük ikinci bir kopyasıdır, bir
+        fotoğraf düzenlendiğinde her zaman yeniden üretilmez ve karartılmamış bir
+        küçük resimle yolculuk eden karartılmış bir fotoğraf, bu emeği boşa
+        çıkarmanın gerçek bir yoludur. Üst verinin, resim hiç yeniden
+        kodlanmadan gitmesini istiyorsanız
+        <a href="../exif-verisi-silme/">EXIF Görüntüleyici ve Silici</a> bunun
+        yerine kabı yeniden yazar."""
+
+[[faq]]
+q = "Hangi biçimleri okuyabiliyor ve yazabiliyor?"
+a = """
+        Tarayıcınızın çözebildiği her şeyi okur; pratikte bu JPEG, PNG, WebP,
+        GIF, BMP ve &mdash; güncel tarayıcıların çoğunda &mdash; AVIF demektir.
+        JPEG, PNG ve WebP yazar, çünkü tarayıcıların beraberinde getirdiği
+        kodlayıcılar bunlardır. "Otomatik"te bir JPEG JPEG olarak, başka her şey
+        PNG olarak geri döner; bu da bir fotoğrafı fotoğraf boyutunda tutar ve
+        bir ekran görüntüsünde kalan metni keskin bırakır. Seçim, karartma
+        açısından hiçbir fark yaratmaz: pikseller kodlayıcı onları görmeden çoktan
+        gitmiştir."""
+
+[[faq]]
+q = "Bunu faresiz yapabilir miyim?"
+a = """
+        Evet. "Ortaya bir kutu ekle" resmin üzerine bir tane koyar, Tab kutular
+        arasında gezer, ok tuşları odaktakini oynatır ve Alt ile ok tuşları onu
+        yeniden boyutlandırır &mdash; Shift her adımı on piksel yapar &mdash;
+        Delete ise onu kaldırır. Her kutunun ayrıca resmin altında boyutunu,
+        konumunu, ne yaptığını ve onu kaldıracak bir düğmeyi taşıyan bir satırı
+        vardır; yani aracın tamamı klavyeden kullanılabilir ve bir ekran okuyucu
+        tarafından okunabilir."""
+
+[[faq]]
+q = "Telefonda çalışıyor mu?"
+a = """
+        Evet. Çizme, taşıma ve yeniden boyutlandırma; hepsi fare olayları değil
+        işaretçi olaylarıdır, yani bir parmak da aynı şekilde çalışır ve
+        tutamaklar dokunmatik ekranda daha büyük çizilir. Ekrandaki resim siz
+        çalışırken ekran boyutunda yeniden çizilir &mdash; dosyanın kendisi ise
+        düğmeye bastığınızda her zaman kendi tam çözünürlüğünde karartılır."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Resmin
+        boyutunda da bir sınır yok, çünkü bunun bedelini ödeyen bir sunucu yok
+        &mdash; iş sizin kendi cihazınızda oluyor. Sitede reklam var, masrafı
+        karşılayan da o; reklamlara görselleriniz hakkında hiçbir şey
+        verilmiyor."""
+
+[schema]
+description = "Bir görseli tarayıcıda karartın: görünmemesi gerekenlerin üzerine kutular çizip onları karartın, pikselleştirin ya da bulanıklaştırın. Kapatılan piksellerin üzerine dosya kodlanmadan önce yazılır; yani sonuç hiçbir katman, hiçbir açıklama ve hiçbir üst veri taşımaz. Hiçbir şey yüklenmez."
+features = [
+  "Kutu başına seçilen karartma, pikselleştirme ve bulanıklaştırma",
+  "Kapatılan piksellerin üzerine kodlamadan önce yazılır, yani kenara itilecek bir katman yoktur",
+  "Ön izleme, dosyayı yazan aynı kod tarafından çizilir",
+  "Bir ayara \"güçlü\" demek yerine bir mozaiğin kaç bloktan oluştuğunu bildirir",
+  "Fare kadar klavye ve dokunma da: her kutu faresiz eklenebilir, taşınabilir, yeniden boyutlandırılabilir ve kaldırılabilir",
+  "Yeniden kodlamanın yan etkisi olarak EXIF, GPS ve gömülü küçük resmi siler",
+  "Otomatik seçimle JPEG, PNG ve WebP çıktı",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Bir görseli buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; JPEG, PNG, WebP ve tarayıcınızın açabildiği her şey"

--- a/locales/tr/tools/redact-pdf.html
+++ b/locales/tr/tools/redact-pdf.html
@@ -1,0 +1,300 @@
+<!--
+  tools/redact-pdf/body.html, in Turkish.
+
+  Every id, class, data-phrase key and {placeholder} below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+
+  The count.* pairs are singular and plural in English. Turkish does not put a
+  plural suffix on a counted noun - "5 sayfa", never "5 sayfalar" - so both
+  members of each pair carry the same bare form, the same way guide_one and
+  guide_many do in locale.toml.
+-->
+<main>
+  <!-- Adım 1 &mdash; belge -->
+  <section class="card">
+    <h2><span class="step">1</span> PDF'inizi seçin</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <div id="doc-facts" class="doc-facts" hidden>
+      <p id="doc-name" class="doc-name"></p>
+      <p id="doc-sub" class="doc-sub"></p>
+      <ul id="doc-warnings" class="doc-warnings"></ul>
+    </div>
+  </section>
+
+  <!-- Adım 2 &mdash; bulma -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Neyin gitmesi gerektiğini söyleyin</h2>
+
+    <p class="card-lede">
+      Kelimeleri yazın &mdash; bir isim, bir adres, bir referans &mdash; ve
+      göründükleri her yer, üzerinde durdukları satırla birlikte aşağıda
+      listelensin. 4. adıma kadar hiçbir şey kaldırılmaz ve işaretlemediğiniz
+      hiçbir şey kaldırılmaz.
+    </p>
+
+    <label class="find-label" for="terms">Kelimeler ve ifadeler, her satıra bir tane</label>
+    <textarea id="terms" rows="3" spellcheck="false" autocomplete="off"
+              placeholder="Yılmaz&#10;Bağdat Caddesi 14&#10;REF-40219"></textarea>
+
+    <div class="find-row">
+      <button type="button" id="find" class="primary">Onları bul</button>
+      <label class="inline-check">
+        <input type="checkbox" id="match-case"> <span>Büyük/küçük harfe duyarlı</span>
+      </label>
+      <label class="inline-check">
+        <input type="checkbox" id="whole-word"> <span>Yalnızca tam kelimeler</span>
+      </label>
+    </div>
+
+    <fieldset class="finders">
+      <legend>Ya da genellikle hassas olan şeyleri arayın</legend>
+      <div class="chips" id="finders"></div>
+      <p class="field-note" id="finder-note">
+        Bunlar kalıptır ve bir kalıp, bir telefon numarasını bir referans
+        numarasından ayıramaz. Kart numaraları ve IBAN'lar kendi kontrol
+        haneleriyle denetlenir; gerisi sunulur, sizin yerinize asla işaretlenmez
+        ve her birini okumaya değer.
+      </p>
+    </fieldset>
+
+    <div class="toolbar" id="match-bar" hidden>
+      <span id="match-count" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="tick-all" class="ghost">Hepsini işaretle</button>
+        <button type="button" id="tick-none" class="ghost">İşaretleri kaldır</button>
+        <button type="button" id="clear-found" class="ghost danger">Listeyi temizle</button>
+      </div>
+    </div>
+
+    <ul id="match-list" class="match-list" hidden></ul>
+    <p id="match-more" class="field-note" hidden></p>
+  </section>
+
+  <!-- Adım 3 &mdash; sayfayı okuma -->
+  <section class="card" id="page-card" hidden>
+    <h2><span class="step">3</span> Sayfayı okuyun ve kelimeleri üzerinden seçin</h2>
+
+    <p class="card-lede">
+      Bu, metnin belgede saklandığı hâli; bir okuyucunun kopyalayacağı sırayla
+      &mdash; ki bu her zaman basıldığı sıra değildir. Çıkarmak için herhangi
+      bir kelimeye tıklayın, tutmak için tekrar tıklayın. Burada üstü çizili
+      olan her şey gidecek olandır.
+    </p>
+
+    <div class="pager">
+      <button type="button" id="prev-page" class="ghost">&#8592; Önceki</button>
+      <span id="page-of" class="count"></span>
+      <button type="button" id="next-page" class="ghost">Sonraki &#8594;</button>
+      <span class="pager-spacer"></span>
+      <span id="page-picked" class="count"></span>
+      <button type="button" id="clear-page" class="ghost danger">Bu sayfada her şeyi tut</button>
+    </div>
+
+    <p id="page-note" class="field-summary" hidden></p>
+
+    <div id="page-text" class="page-text" role="group" aria-label="Bu sayfanın metni"></div>
+  </section>
+
+  <!-- Adım 4 &mdash; işi yapma -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Kelimeleri çıkarın</h2>
+
+    <label class="check">
+      <input type="checkbox" id="opt-boxes" checked>
+      <span>
+        <strong>Her birinin yerine siyah bir kutu çiz</strong>
+        <span class="check-note">
+          Bir okuyucu bir şeyin kaldırıldığını görebilsin diye. Kutu burada
+          süstür, karartma değil: o çizildiğinde harfler dosyadan çoktan
+          gitmiştir. Kapatın, kelimeler kapladıkları boşluğu bırakarak öylece
+          yok olsun.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-elsewhere" checked>
+      <span>
+        <strong>Aynı kelimeleri belgenin geri kalanından da çıkar</strong>
+        <span class="check-note">
+          Yer imleri, yorumlar, yapışkan notlar ve form alanlarına yazılanlar.
+          Bir sayfadan kaldırılıp bir yer iminde bırakılan kelime kaldırılmış
+          değildir. Belgenin özellikleri bu ne derse desin gider; bir okuyucunun
+          sayfadaki harfler yerine kopyaladığı yedek metin de gider &mdash;
+          ikisi de kelimeyi başka bir yerin kopyalaması değil, belgenin kendisinin
+          söylemesidir.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-attachments" checked>
+      <span>
+        <strong>Ekleri ve çalışan her şeyi at</strong>
+        <span class="check-note">
+          Bir PDF içinde bütün dosyalar ve açıldığında çalışan JavaScript
+          taşıyabilir. İkisinde de kaldırdığınız kelimeler aranamaz ve ikisi de
+          bir belgeyi okumak için gerekmez.
+        </span>
+      </span>
+    </label>
+
+    <p class="field-summary" id="run-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Onları çıkar</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>İndir</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+      <ul id="check-terms" class="check-terms" hidden></ul>
+      <ul id="result-facts" class="result-facts"></ul>
+    </div>
+  </section>
+
+  <!--
+    The sentences this tool's JavaScript puts on screen. They live here rather
+    than in src/ because src/ is copied byte for byte into all eleven
+    languages; see "The strings in the JavaScript" in the repository README.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="load.notpdf">Bu bir PDF değil, dolayısıyla içinde çıkarılacak bir metin yok.</span>
+    <span data-phrase="load.encrypted">Bu PDF'te parola var. Bir belgenin
+      korumasını kaldırmak, içinden kelime çıkarmaktan farklı bir iştir ve bu
+      araç bunu arkanızdan yapmaz.</span>
+    <span data-phrase="load.broken">Bu dosya PDF olarak açılamadı ({detail}).</span>
+    <span data-phrase="load.nopages">Açıldı, ama içinde hiçbir sayfa bulunamadı.</span>
+    <span data-phrase="load.repaired">Bu belgenin çapraz başvuru tablosu
+      içeriğiyle uyuşmuyordu, bu yüzden nesneler taranarak okundu. Bu bir
+      onarımdır ve işe yaradı &mdash; sonucu bir yere göndermeden önce dikkatle
+      denetleyin.</span>
+
+    <span data-phrase="doc.sub">{pages} &middot; {words} metin &middot; {size}</span>
+    <span data-phrase="doc.notext">Bu sayfaların {count} tanesinde hiç metin
+      yok. Öyle bir sayfa, bir sayfanın resmidir ve bu aracın kaldıracağı bir şey
+      yoktur &mdash; resimdeki kelimeler tam olarak oldukları yerde kalır.</span>
+    <span data-phrase="doc.unreadable">Bu belgedeki {count} harf karakter olarak
+      okunamadı, çünkü kullandıkları yazı tipleri glifleri metne geri götüren bir
+      eşleme taşımıyor. O harfler aranamaz; bu yüzden aramaya güvenmek yerine
+      bulundukları sayfaları denetleyin.</span>
+    <span data-phrase="doc.scan">Bazı sayfalar bir resmin üzerine serilmiş
+      görünmez metin taşıyor; bir tarayıcı sayfadan ne anladığını böyle kaydeder.
+      O metni kaldırmak, bir aramanın ve bir kopyalamanın bulacağı şeyi kaldırır.
+      Resmi değiştirmez ve resimde kelimeler hâlâ okunaklıdır.</span>
+
+    <span data-phrase="find.none">Hiçbir sayfada eşleşme bulunamadı.</span>
+    <span data-phrase="find.some">{pages} üzerinde {count}.</span>
+    <span data-phrase="find.more">İlk {shown} tanesi listelendi. Gerisi de
+      bulundu ve hepsini işaretlerseniz onlar da çıkarılacak.</span>
+    <span data-phrase="find.terms">Bul'a basmadan önce yukarıya bir kelime yazın ya da bir kalıp seçin.</span>
+
+    <span data-phrase="page.of">{total} sayfadan {number}. sayfa</span>
+    <span data-phrase="page.picked">Bu sayfadan kaldırılacak: {count}</span>
+    <span data-phrase="page.notext">Bu sayfada metin yok. Ya boştur ya da bir
+      sayfanın resmidir &mdash; bir tarama, bir fotoğraf, kelimelerini şekil
+      olarak çizmiş bir dışa aktarma. Üzerinde hiçbir şey aranamaz ve üzerinden
+      hiçbir şey burada kaldırılamaz.</span>
+    <span data-phrase="page.unreadable">Bu sayfadaki {count} harf karakter
+      olarak okunamadı. Aşağıda &#9647; olarak gösteriliyorlar ve arama onları
+      bulmayacak.</span>
+    <span data-phrase="page.scan">Bu sayfadaki metin görünmez: sayfanın bir
+      resminin üzerine serilmiş durumda; bir tarama böyle aranabilir hâle
+      getirilir. Burada çıkardığınız şey, bir aramanın ve bir kopyalamanın
+      bulacağı şeydir. Resim kelimeleri korur.</span>
+
+    <span data-phrase="run.summary">{pages} üzerinden {words} çıkarılacak.</span>
+    <span data-phrase="run.nothing">Henüz hiçbir şey işaretlenmedi. 2. adımda bir kelime bulun ya da 3. adımda birine tıklayın.</span>
+    <span data-phrase="run.editing">Kelimeler çıkarılıyor&hellip;</span>
+    <span data-phrase="run.writing">Belge yazılıyor&hellip;</span>
+    <span data-phrase="run.checking">Bitmiş dosya açılıyor ve aranıyor&hellip;</span>
+    <span data-phrase="run.failed">Bu belge yeniden yazılırken bir şeyler ters gitti ({detail}).</span>
+    <span data-phrase="run.cancelled">Vazgeçildi. Hiçbir şey yazılmadı.</span>
+
+    <span data-phrase="result.headline">{words} kaldırıldı</span>
+    <span data-phrase="result.sub">{size} &middot; {pages} değişti &middot; {boxes}</span>
+    <span data-phrase="check.good">Burada yeniden açılıp bir okuyucunun yapacağı
+      gibi arandı: hiçbiri bitmiş dosyada değil.</span>
+    <span data-phrase="check.partial">Burada yeniden açılıp arandı:
+      işaretlediğiniz her geçiş gitmiş, bıraktıklarınız ise hâlâ orada.</span>
+    <span data-phrase="check.survived">Bu dosya YAZILMADI. Bitmiş belge yeniden
+      açıldı ve kaldırdıklarınızın bir kısmı içinde hâlâ bulunabiliyordu; yani
+      karartma tamamlanmadı. İndirmek için hiçbir şey sunulmuyor.</span>
+    <span data-phrase="check.pages">Bu dosya YAZILMADI. Bitmiş belge, girdiğinden
+      farklı sayıda sayfayla geri geldi; yani kelimelerin ötesinde bir şey ters
+      gitti. İndirmek için hiçbir şey sunulmuyor.</span>
+
+    <span data-phrase="fact.boxes">Boşlukların üzerine {count} çizildi.</span>
+    <span data-phrase="fact.noboxes">Hiç kutu çizilmedi; yani kelimeler gitti ve
+      nerede olduklarını söyleyen bir şey kalmadı.</span>
+    <span data-phrase="fact.elsewhere">Aynı kelimeler şuradan da çıkarıldı: {where}.</span>
+    <span data-phrase="fact.metadata">Belge özellikleri ve XMP paketi
+      kaldırıldı; yani bitmiş dosya onu neyin, ne zaman yaptığını ya da eskiden
+      ne adla anıldığını söylemiyor.</span>
+    <span data-phrase="fact.carried">{attachments} ve {actions} atıldı.</span>
+    <span data-phrase="fact.shared">Kaldırdıklarınızın bir kısmı, belgenin
+      birden fazla sayfada yeniden kullandığı bir blok tarafından çiziliyordu;
+      bu yüzden onu çizen her sayfadan gitti. Bu, işaretlediğinizden fazlasıdır,
+      asla azı değil.</span>
+    <span data-phrase="fact.overimage">Kaldırdığınız harflerin {count} tanesi
+      aynı sayfanın bir resminin üzerinde duruyordu. Metin katmanından çıktılar
+      ve resimde kaldılar: bir okuyucu artık onları arayamaz ya da kopyalayamaz,
+      ama hâlâ görebilir.</span>
+    <span data-phrase="fact.untouched">Her sayfadaki diğer her şey bayt bayt
+      kopyalandı. Hiçbir yazı tipi, resim ya da çizgi yeniden kodlanmadı.</span>
+
+    <span data-phrase="count.pages">{count} sayfa</span>
+    <span data-phrase="count.page">{count} sayfa</span>
+    <span data-phrase="count.words">{count} kelime</span>
+    <span data-phrase="count.word">{count} kelime</span>
+    <span data-phrase="count.pieces">{count} metin parçası</span>
+    <span data-phrase="count.piece">{count} metin parçası</span>
+    <span data-phrase="count.matches">{count} eşleşme</span>
+    <span data-phrase="count.match">{count} eşleşme</span>
+    <span data-phrase="count.boxes">{count} siyah kutu</span>
+    <span data-phrase="count.box">{count} siyah kutu</span>
+    <span data-phrase="count.attachments">{count} ek</span>
+    <span data-phrase="count.attachment">{count} ek</span>
+    <span data-phrase="count.actions">{count} eylem</span>
+    <span data-phrase="count.action">{count} eylem</span>
+    <span data-phrase="count.hosts">{count} sunucu</span>
+    <span data-phrase="count.host">{count} sunucu</span>
+
+    <!-- The space before {platform} belongs to these two rather than to the
+         phrase it lets in, because phrases.js collapses and trims the markup
+         it reads and a leading space would not survive the trip. -->
+    <span data-phrase="net.clean">belgeniz hiçbir yere gitmedi. {total} dosya
+      yüklendi, hepsi bu sayfanın kendi dosyaları. {platform}</span>
+    <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç
+      bunu asla yapmaz. Bunu araştırmaya değer sayın. {platform}</span>
+    <span data-phrase="net.platform">Sayfanın kendi reklam, ölçüm ve bağış
+      düğmesi betikleri {hosts} üzerinden yüklendi; hiçbirine bir belge, bir
+      belgeden bir kelime ya da aradığınız bir şey verilmedi.</span>
+
+    <span data-phrase="finder.email">E-posta adresleri</span>
+    <span data-phrase="finder.card">Kart numaraları</span>
+    <span data-phrase="finder.iban">Banka hesapları (IBAN)</span>
+    <span data-phrase="finder.nationalid">Kimlik ve sosyal güvenlik numaraları</span>
+    <span data-phrase="finder.phone">Telefon numaraları</span>
+  </div>
+</main>

--- a/locales/tr/tools/redact-pdf.toml
+++ b/locales/tr/tools/redact-pdf.toml
@@ -1,0 +1,362 @@
+#
+# PDF Karartıcı - Türkçe.
+#
+# Overrides for tools/redact-pdf/tool.toml. Only words: the slug, the category,
+# the icon and the list of shared parts stay where they are.
+#
+# Bu sayfanın tamamı tek bir ayrım üzerine kurulu: "karartma" burada harfleri
+# silmek, "üstünü örtme" ise sayfanın üzerine bir dikdörtgen çizmek. İkisi aynı
+# kelimeyle karşılansaydı bu aracın söylediği hiçbir cümle bir şey ifade
+# etmezdi; bu yüzden her yerde ayrı tutuluyorlar.
+#
+
+name = "PDF Karartıcı"
+heading = "PDF&nbsp;Karartma <span class=\"h1-kw\">&mdash; kelimeler çıkar, üstlerine kutu çizilmez</span>"
+tagline = "Harfler dosyadan silinir ve sonra bunu kanıtlamak için dosyada arama yapılır."
+
+title = "PDF Karartma &mdash; Metni Gerçekten Silin, Ücretsiz, Yüklemesiz"
+description = "Bir PDF'ten kelimeleri, üzerlerine siyah dikdörtgen çizmek yerine çıkarın. Harfler sayfanın kendi çizim talimatlarından silinir, bitmiş dosya yeniden açılıp gittiklerini kanıtlamak için aranır ve hiçbir şey yüklenmez."
+og_title = "Bir PDF'i doğru dürüst karartın &mdash; kelimeler silinir, örtülmez"
+og_description = "Çoğu araçtaki siyah dikdörtgen metnin üstünde durur ve altından kopyalanabilir. Bu araç harfleri dosyadan siler, sonra orada olmadıklarını göstermek için sonucu arar."
+og_image_alt = "Bir PDF'i metni örterek değil silerek karartın"
+
+pledge = """
+    Seçtiğiniz belge bu makinenin belleğinde açılır, okunur, düzenlenir ve
+    yeniden yazılır; bunu yapan kod da bu adresten sunuluyor. Buradaki hiçbir
+    şey bir yükleme yapamaz ve bu sayfanın öbür ucunda bir yüklemeyi alacak bir
+    sunucu yok. Ne dosya ne de aradığınız kelimeler sekmeden çıkar."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir şeyi karartın. Tek bir istek bile bir sayfa, bir kelime ya
+      da bir dosya adı taşımıyor. Ya da internet bağlantısını kesip yine de
+      karartın."""
+
+read_first = """
+, bir sayfadaki her kelimenin nasıl bulunup
+      konumlandırıldığı için <code>src/text.js</code> ve silme işleminin kendisi
+      için <code>src/edit.js</code> &mdash; sayfanın talimatlarından neyin
+      kesildiği ve satırın geri kalanı kaymasın diye neyin geri konduğu.
+      Hiçbiri ağa erişemez; yanlarındaki okuyucu ve yazıcı da erişemez."""
+
+howto_heading = "Bir PDF, kelimeler gerçekten gidecek şekilde nasıl karartılır"
+
+card = """
+            Bir PDF'ten kelimeleri örtmek yerine silin. Harfler sayfanın kendi
+            çizim talimatlarından çıkarılır, boşluk açık tutulur ki başka hiçbir
+            şey kaymasın ve bitmiş dosya, kelimelerin içinde olmadığını
+            kanıtlamak için burada yeniden açılıp aranır."""
+
+[words]
+plural = "belgeleriniz"
+choose = "bir PDF"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "Siyah bir dikdörtgen karartma değildir ve bu araç hiçbir şeyin üzerine öyle bir şey çizmez."
+body = """
+
+      Bir sayfayı karartmayı öneren neredeyse her programda &mdash; bir PDF
+      okuyucu, bir kelime işlemci, bir tasarım aracı &mdash; dikdörtgen, metnin
+      içine değil yanına kaydedilmiş bir nesnedir. Metin hâlâ oradadır, aynı
+      dosyada, aynı yerde; alanı seçip kopyala demek onu geri verir. Bu hata
+      mahkeme dosyalarını, istihbarat raporlarını ve Aralık 2025'te ABD Adalet
+      Bakanlığı belgelerinin toplu yayımında karartılmış isimleri yayımladı; o
+      isimler yayımdan saatler sonra okunabiliyordu. Bu araç harfleri sayfayı
+      çizen talimatlardan siler. Altında bir şey olan bir dikdörtgen yoktur,
+      çünkü altında hiçbir şey yoktur."""
+
+[[privacy]]
+title = "Bitmiş dosya, size sunulmadan önce burada yeniden açılıp aranır."
+body = """
+
+      Bu olana kadar yukarıdaki her iddia, bu aracın kendi ödevini kendi
+      notlandırmasıdır. Bu yüzden indirmeniz olmak üzere olan baytlar, sanki
+      onları bir yabancı göndermiş gibi aynı okuyucuya geri verilir, her sayfa
+      yeniden okunur, her yer imi, yorum, form alanı ve belge özelliği toplanır
+      ve kaldırdığınız kelimeler aranır. Sayı sonuçlarda yazar. Bir şey hayatta
+      kaldıysa çalışma başarısız olarak bildirilir ve indirme olmaz."""
+
+[[privacy]]
+title = "Kelimeler sekmeden hiç çıkmaz, arama da çıkmaz."
+body = """
+ Content-Security-Policy,
+      bu sayfanın iletişim kurabileceği her adresi tek tek sayar ve bunların
+      hiçbiri bu siteye ait değildir. Bu araç o listeye hiçbir şey eklemez:
+      isteğe bağlı olanı bile yok, kendine ait bir ağ özelliği hiç yok. Arama
+      kutusuna yazdığınız şey, bu sekmenin belleğindeki metinle karşılaştırılan
+      bir dizedir ve ikisinin de gidecek bir yeri yoktur."""
+
+[[privacy]]
+title = "Karartma, yükleme olarak en az hayatta kalabilen iştir."
+body = """
+
+      İnsanların ne karartığı, onun neden yüklenmemesi gerektiğinin sebebidir.
+      Bir tanık ifadesi, bir doktor mektubu, bir ev sahibine gidecek bir hesap
+      özeti, bir müşterinin adını taşıyıp başka bir müşteriye gidecek bir
+      sözleşme. Bunu, özel kısmı kaldırılsın diye bir yabancının sunucusuna
+      vermek demek, özel kısmın oraya önce ve el değmemiş hâlde varması ve
+      onların sakladığı sürümün o olması demektir. Bu sayfanın öbür yarısı
+      yoktur."""
+
+[[privacy]]
+title = "Geriye kalan el değmeden kopyalanır."
+body = """
+
+      Bir sayfada değişen tek baytlar, kaldırılan harflerin parçası olduğu metin
+      gösterme talimatlarıdır. Diğer her talimat ve sayfanın başvurduğu her yazı
+      tipi, resim ve çizgi, geldiği hâliyle aynen kopyalanır &mdash; hiçbir şey
+      yeniden çizilmez, yeniden kodlanmaz ya da yeniden akıtılmaz. Çıkarılanın
+      genişliği ölçülür ve bir boşluk talimatı olarak geri konur; böylece
+      satırın geri kalanı belgenin koyduğu yerde kalır."""
+
+[[privacy]]
+title = "Bir fotoğraftan kelime çıkaramaz ve hangi sayfaların öyle olduğunu söyler."
+body = """
+
+      Taranmış bir sayfa bir resimdir. Üzerindeki kelimeler metin değil
+      pikseldir ve buradaki hiçbir şey onlara dokunamaz. Tarama, bir tarayıcının
+      OCR'ının ürettiği görünmez aranabilir katmanı taşıyorsa bu araç o katmanı
+      kaldırır &mdash; bir aramanın ve bir kopyalamanın bulacağı şey oydu
+      &mdash; ve resmin kelimeleri hâlâ gösterdiğini sayfada açıkça söyler. O
+      resmin üstünü örtmek başka bir iştir;
+      <a href=\"../resim-karartma/\">görsel karartıcı</a> pikselleri üzerine
+      yazan araçtır."""
+
+[[privacy]]
+title = "Belge nereden geldiğini söylemeyi bırakır."
+body = """
+
+      Özellikler ve XMP paketi her çalışmada gider: üretici satırı yok,
+      oluşturulma tarihi yok, yazar yok, başlık yok ve bir sayfa düzeni
+      uygulamasının geride bıraktığı özel bloklardan hiçbiri yok. Sayfalarından
+      bir isim çıkarılmış ama özellikleri hâlâ
+      <code>Smith settlement draft 3.docx</code> diyen bir dosya karartılmış
+      değildir ve bu, bir onay kutusuna bırakılacak bir şey de değildir."""
+
+[[privacy]]
+title = "Şifreli dosyalar açılmıyor, geri çevriliyor."
+body = """
+
+      Parola konmuş bir PDF geri çevrilir; tarayıcıların boş parolayla ürettiği
+      ve teknik olarak açılabilecek türü de dahil. Bir belgenin korumasını
+      kaldırmak, içinden kelime çıkarmaktan farklı bir iştir ve bunu sessizce
+      yapmak bir aracın sizin adınıza yapması şaşırtıcı olurdu."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine belgeniz hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir sayfa, ne bir ad, bir boyut, bir sayfa sayısı ya da
+      aradığınız bir kelime. Bir PDF'i okuyan, düzenleyen ya da yazan her satır
+      bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki \"Buy me a coffee\" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de belgeleriniz
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu: belgenizi
+      karartılmak üzere uzağa gönderen bir araç dururdu."""
+
+[[howto]]
+title = "PDF'i seçin."
+body = """
+ Bilinçli olarak tek seferde tek belge:
+      karartma, sayfa sayfa bakılması gereken bir iştir ve bir dosyada kelime
+      işaretlemenize izin verip bunu sessizce başka bir dosyaya uygulayan bir
+      araç, yanlış şeyin gönderilmesinin tam da yoludur. Tarayıcı onu doğrudan
+      diskinizden okur."""
+
+[[howto]]
+title = "Neyin gitmesi gerektiğini söyleyin."
+body = """
+ Kelimeleri yazın &mdash; bir
+      isim, bir adres, bir referans &mdash; ve göründükleri her yer, üzerinde
+      durdukları satır ve bir onay kutusuyla listelenir. Kutunun yanındaki
+      bulucular e-posta adreslerini, kart numaralarını, IBAN'ları, kimlik ve
+      sosyal güvenlik numaralarını ve telefon numaralarını arar. Bunlar sunulur,
+      sizin yerinize asla işaretlenmez: bir kalıp, bir telefon numarasını bir
+      referanstan ayıramaz."""
+
+[[howto]]
+title = "Sayfayı okuyun ve kelimeleri üzerinden seçin."
+body = """
+
+      Panel, belgenin metnini gerçekte saklandığı hâliyle, bir okuyucunun
+      kopyalayacağı sırayla gösterir. Çıkarmak için herhangi bir kelimeye
+      tıklayın, tutmak için tekrar tıklayın. Üstü çizili olan her şey gidecek
+      olandır &mdash; bu da burayı seçim kadar inceleme yeri yapar ve düğmeye
+      basmadan önce her sayfada yapmaya değer."""
+
+[[howto]]
+title = "Onları çıkarın ve denetlendiğini söyleyen satırı okuyun."
+body = """
+
+      Harfler silinir, bıraktıkları boşluk açık tutulur, istediyseniz üzerine
+      siyah bir kutu çizilir ve aynı kelimeler yer imlerinden, yorumlardan, form
+      alanlarından ve belgenin özelliklerinden çıkarılır. Sonra bitmiş dosya
+      burada yeniden açılır ve aranır. Kaldırdığınız bir kelime hâlâ
+      bulunabiliyorsa indirme almazsınız ve bunu söyleyen bir mesaj alırsınız."""
+
+[[faq]]
+q = "Bu, bir PDF okuyucuda siyah kutu çizmekten nasıl farklı?"
+a = """
+        Bir okuyucuda çizilen dikdörtgen bir açıklamadır: bir konumu olan ve
+        sayfanın yanına kaydedilen bir nesne. Altındaki metin el değmemiştir. O
+        alanı seçip kopyala diyen, dosyayı başka bir programda açan ya da üzerine
+        herhangi bir metin çıkarıcı çalıştıran herkes kelimeleri geri alır. Bazı
+        okuyucular kaldırmayı doğru dürüst uygulayan bir \"karart\" komutu sunar
+        &mdash; bazıları ise yalnızca çizmeyi sunar. Bu araçta kenara
+        itilebilecek bir dikdörtgen yoktur: harfler sayfanın çizim
+        talimatlarından kesilir ve siyah kutu, açık bırakırsanız, zaten boş olan
+        bir boşluğun üzerine sonradan çizilir."""
+
+[[faq]]
+q = "Kelimelerin gerçekten gittiğini nasıl bilirim?"
+a = """
+        Çünkü araç bunu sizin makinenizde denetler ve sayıyı size gösterir. Dosya
+        yazıldığında bu sayfadaki aynı okuyucu tarafından yeniden açılır, her
+        sayfa okunur, her yer imi, yorum, form alanı ve özellik toplanır ve
+        kaldırdığınız her kelime aranır. Sonuç satırı kaç tane olduğunu ve kaç
+        tane kaldığını söyler. Cevap olması gereken şey değilse çalışma başarısız
+        olur ve indirmek için hiçbir şey sunulmaz. Sonrasında herhangi bir
+        okuyucuda kendiniz de denetleyebilirsiniz: Ctrl+F'ye basın ve kelimeyi
+        arayın."""
+
+[[faq]]
+q = "Bir kelime kaldırıldığında sayfanın geri kalanı kayar mı?"
+a = """
+        Hayır. Metin, kalemi sayfa boyunca ilerleterek çizilir; yani beş harfi
+        silmek normalde satırın geri kalanını beş harf sola çekerdi.
+        Kaldırılanın tam genişliği yazı tipinin kendi ölçülerinden hesaplanır ve
+        bir boşluk talimatı olarak geri konur; bu talimat kalemi hiçbir şey
+        çizmeden ilerletir. Sütunlar hizalı kalır, toplamlar da başlıklarının
+        altında kalır."""
+
+[[faq]]
+q = "Taranmış bir belgeyi karartabilir mi?"
+a = """
+        Resmi karartamaz ve bunu gizlemek yerine söyler. Bir tarama, bir sayfanın
+        fotoğrafıdır: kelimeler pikseldir ve kaldırılacak bir metin yoktur. Bir
+        taramanın çoğu zaman taşıdığı şey ise, sayfa aranabilsin diye tarayıcının
+        OCR'ının resmin üzerine yazdığı görünmez bir metin katmanıdır &mdash; bu
+        araç o katmanı bulur, seçtiklerinizi ondan kaldırır ve resmin
+        değişmediğini sayfada size söyler. Yani bir arama ve bir kopyalama artık
+        kelimeyi bulmaz, sayfaya bakan bir insan ise onu hâlâ okur. Bir resim
+        için <a href=\"../resim-karartma/\">görsel karartıcı</a> piksellerin
+        kendisini üzerine yazar."""
+
+[[faq]]
+q = "Belgenin sayfada olmayan kısımları ne olacak?"
+a = """
+        Onlar da ele alınıyor, çünkü bir karartma genellikle oradan sızar. Aynı
+        kelimeler yer imlerinden, yorumlardan ve yapışkan notlardan, form
+        alanlarına yazılanlardan, bir ekran okuyucuya verilen metinden ve bir
+        okuyucunun sayfadaki harfler <em>yerine</em> kopyaladığı yedek metinden
+        çıkarılır &mdash; bu sonuncusu, bağlı harfler ve tireyle bölünmüş
+        kelimeler düzgün kopyalansın diye vardır ve koca bir cümle
+        tutabilir. Belge özellikleri ile XMP paketi ise doğrudan kaldırılır.
+        Ekler ve dosya açıldığında çalışan her şey atılır, çünkü ikisinde de
+        kaldırdığınız kelimeler aranamaz."""
+
+[[faq]]
+q = "Belgelerim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        düzenlenir ve yazılır. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Arama
+        kutusuna yazdığınız şey bu sekmenin belleğindeki metinle karşılaştırılır
+        ve o da hiçbir yere gitmez."""
+
+[[faq]]
+q = "Neden diğer araçlardaki gibi sayfanın üzerine kutu sürükleyemiyorum?"
+a = """
+        Çünkü bir sayfayı çizmek eksiksiz bir PDF çizicisi demektir &mdash; yazı
+        tipleri, gölgelendirme, saydamlık, karışım modları &mdash; ki bu da
+        getirilip çalıştırılacak bir megabayt ya da daha fazla motor eder ve bu
+        site öyle bir şey sunmuyor. Bu, işe de uyuyor: bir dikdörtgen sürüklemek
+        bir <em>kâğıt alanı</em> seçer ve bir kâğıt alanı, altındaki metinle aynı
+        şey değildir; siyah kutu hatası da böyle başlar. Bunun yerine
+        aldığınız şey, belgenin metni, okuma sırasıyla ve her kelimesi
+        tıklanabilir hâlde. Bu aynı zamanda, sayfanın resminin söyleyemeyeceği
+        şeyi size söyleyebilen tek görünüm: önünüzdeki kelimeler gerçekten metin
+        mi."""
+
+[[faq]]
+q = "Bitmiş dosya her yerde açılır mı?"
+a = """
+        Evet. Çıktı, PDF 1.5 olarak ya da verdiğiniz dosya hangi sürümü
+        gerektiriyorsa o sürümle yazılır ve 1.5, 2003'ten beri sunulan her
+        okuyucunun anladığı sürümdür. Sayfadaki hiçbir şey yeniden kodlanmaz:
+        yazı tipleri, resimler ve vektör çizim bayt bayt gelir; yani metinden
+        geriye kalan tam olarak eskisi gibi seçilebilir ve aranabilir kalır."""
+
+[[faq]]
+q = "Parola korumalı bir PDF'i açabilir mi?"
+a = """
+        Hayır ve bu bilinçli bir tercih. Şifreli bir belge, bunu söyleyen bir
+        mesajla geri çevrilir; parola boş olsa bile &mdash; ki pek çok tarayıcı
+        ve fotokopi makinesi böyle kaydeder. Bir dosyanın korumasını kaldırmak,
+        içinden kelime çıkarmaktan farklı bir iştir ve bunu sessizce yapan bir
+        araç sizin istemediğiniz bir şeyi yapıyor olurdu."""
+
+[[faq]]
+q = "Boyut sınırı var mı ve bir ücreti var mı?"
+a = """
+        Araca yazılmış bir sınır yok. Sınır kendi makineniz: belge üzerinde
+        çalışılırken bellekte tutulur, yani bir dizüstü birkaç yüz megabaytı
+        şikâyet etmeden alır ve bunun bir yerlerinde üstünde zorlanır. Ücretsiz;
+        hesap yok, giriş yok, deneme süresi yok. Sitede reklam var, masrafı
+        karşılayan da o; reklamlara belgeleriniz hakkında hiçbir şey
+        verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: belgenizi karartılmak üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir PDF'i tarayıcınızda, metni örterek değil silerek karartın. Harfler sayfanın içerik akışından kaldırılır, bitmiş dosya gittiklerini kanıtlamak için yeniden açılıp aranır ve hiçbir şey yüklenmez."
+features = [
+  "Harflerin üzerine dikdörtgen çizmek yerine onları sayfadan siler",
+  "Bitmiş dosyayı yeniden açar ve kelimelerin gittiğini kanıtlamak için arar",
+  "Bir kelimenin her geçtiği yeri bulur ya da e-posta, kart numarası, IBAN ve kimlik numarası arar",
+  "Belgenin metnini okuma sırasıyla gösterir, böylece her kelimeye tıklanabilir",
+  "Aynı kelimeleri yer imlerinden, yorumlardan, form alanlarından ve özelliklerden kaldırır",
+  "Boşluğu açık tutar, böylece satırın geri kalanı kaymaz",
+  "Hangi sayfaların tarama olduğunu, yani kaldırılacak metin bulunmadığını söyler",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, dosya boyutu sınırı yok",
+]
+
+[picker]
+title = "PDF'inizi buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; bir seferde tek belge"

--- a/locales/tr/tools/resize-image.html
+++ b/locales/tr/tools/resize-image.html
@@ -1,0 +1,286 @@
+<!--
+  tools/resize-image/body.html, in Turkish.
+
+  Every id, class, data-* value and option value below is what src/main.js and
+  src/cropper.js reach for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosyalar -->
+  <section class="card">
+    <h2><span class="step">1</span> Görselleri seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Hepsini listeden çıkar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; kırpma -->
+  <section class="card" id="crop-card">
+    <h2><span class="step">2</span> İsterseniz kırpın</h2>
+
+    <p class="card-lede">
+      Kutu resmin tamamının üstünde başlar; yani bu adıma dokunmazsanız hiçbir
+      şey kırpılmaz. Her görsel kendi kutusunu taşır &mdash; üstüne çizmek için
+      yukarıdaki listeden birini seçin. Kırpma boyutlandırmadan önce olur; anlamı
+      olan tek sıra da budur: küçültüldükten sonra kesilen bir resim, ihtiyaç
+      duyduğu pikselleri çoktan atmıştır.
+    </p>
+
+    <p id="crop-empty" class="field-summary">Bir görsel ekleyin, kutu burada görünsün.</p>
+
+    <div id="crop-controls" hidden>
+      <p class="stage-hint">
+        <span id="stage-name" class="stage-name"></span>
+        Taşımak için kutunun içinden, yeniden boyutlandırmak için herhangi bir
+        köşesinden sürükleyin. Kutu odaktayken ok tuşları onu birer piksel
+        oynatır, <kbd>Alt</kbd>&nbsp;+&nbsp;oklar yeniden boyutlandırır ve
+        <kbd>Shift</kbd>'i basılı tutmak her adımı ona çıkarır.
+      </p>
+
+      <!-- The crop box itself is added here by src/cropper.js. The stage is
+           given the picture's own shape, so the box can be positioned in
+           percentages and needs no recalculating when the window is resized. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <p id="stage-note" class="stage-note" hidden></p>
+
+      <div class="crop-controls">
+        <div class="aspect-row" id="aspect-row" role="group" aria-label="Kırpmayı bir şekle kilitle">
+          <button type="button" data-aspect="free" class="active">Serbest</button>
+          <button type="button" data-aspect="source">Özgün</button>
+          <button type="button" data-aspect="1:1">1:1</button>
+          <button type="button" data-aspect="4:5">4:5</button>
+          <button type="button" data-aspect="9:16">9:16</button>
+          <button type="button" data-aspect="16:9">16:9</button>
+          <button type="button" data-aspect="4:3">4:3</button>
+          <button type="button" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="ghost" title="Kilitli şekli yan çevir">
+            Çevir
+          </button>
+        </div>
+
+        <div class="numbers">
+          <label>Sol<input type="number" id="crop-x" min="0" step="1"></label>
+          <label>Üst<input type="number" id="crop-y" min="0" step="1"></label>
+          <label>Genişlik<input type="number" id="crop-w" min="8" step="1"></label>
+          <label>Yükseklik<input type="number" id="crop-h" min="8" step="1"></label>
+          <div class="number-actions">
+            <button type="button" id="crop-max" class="ghost">En büyük</button>
+            <button type="button" id="crop-centre" class="ghost">Ortala</button>
+            <button type="button" id="crop-reset" class="ghost">Resmin tamamı</button>
+          </div>
+        </div>
+
+        <!--
+          Every image keeps its own box, which is the point. This is for the
+          case that is still worth one click: a folder of exports that all want
+          the same framing.
+        -->
+        <div class="apply-row" id="apply-row" hidden>
+          <button type="button" id="crop-apply-all" class="ghost">Bu kırpmayı her görsele uygula</button>
+          <p class="hint-line" id="apply-note"></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; boyut -->
+  <section class="card" id="resize-card">
+    <h2><span class="step">3</span> Ne boyutta olacağını söyleyin</h2>
+
+    <div class="option-row">
+      <label for="resize-mode">Boyutu şununla belirle</label>
+      <select id="resize-mode">
+        <option value="pixels" selected>Piksel cinsinden genişlik ve yükseklik</option>
+        <option value="longest">En uzun kenar</option>
+        <option value="percent">Şu anki hâlinin bir yüzdesi</option>
+        <option value="none">Hiçbiri &mdash; boyutu olduğu gibi bırak</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="pixels-fields">
+      <div class="numbers">
+        <label>Genişlik<input type="number" id="size-w" min="1" step="1" placeholder="otomatik" value="1920"></label>
+        <label>Yükseklik<input type="number" id="size-h" min="1" step="1" placeholder="otomatik"></label>
+        <div class="number-actions">
+          <button type="button" id="swap-size" class="ghost">Çevir</button>
+        </div>
+      </div>
+
+      <!--
+        Leaving one of them blank is the common case and the one worth
+        supporting properly: "1920 wide, whatever tall that makes it" needs no
+        decision about shapes at all.
+      -->
+      <p class="hint-line">
+        Resmin kendi şeklini koruması için birini doldurup diğerini boş bırakın.
+      </p>
+
+      <div class="presets" id="size-presets" role="group" aria-label="Yaygın boyutlar">
+        <button type="button" class="ghost" data-w="1920" data-h="1080">1920 &times; 1080</button>
+        <button type="button" class="ghost" data-w="1280" data-h="720">1280 &times; 720</button>
+        <button type="button" class="ghost" data-w="1080" data-h="1080">1080 &times; 1080</button>
+        <button type="button" class="ghost" data-w="600" data-h="">600 genişlik</button>
+      </div>
+
+      <div class="option-row" id="fit-row">
+        <label for="fit">Şekiller uyuşmazsa</label>
+        <select id="fit">
+          <option value="contain" selected>İçine sığdır &mdash; resmin tamamı, bir kenar kısa çıkar</option>
+          <option value="cover">Doldur &mdash; tam bu boyut, taşan kısım kesilir</option>
+          <option value="pad">Tamamla &mdash; tam bu boyut, çevresinde arka planla</option>
+          <option value="stretch">Esnet &mdash; tam bu boyut ve şekil bozulmuş hâlde</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>En uzun kenar<input type="number" id="size-longest" min="1" step="1" value="1920"></label>
+      </div>
+      <p class="hint-line">
+        Hangi kenar daha uzunsa o bu olur ve diğeri ona uyar. Aynı yığındaki
+        dikey ve yatay çekimlerin hepsi uzun kenarlarında aynı boyutta çıkar; bir
+        galerinin genellikle istediği de budur.
+      </p>
+      <div class="presets" id="longest-presets" role="group" aria-label="Yaygın uzun kenarlar">
+        <button type="button" class="ghost" data-longest="640">640</button>
+        <button type="button" class="ghost" data-longest="1280">1280</button>
+        <button type="button" class="ghost" data-longest="1920">1920</button>
+        <button type="button" class="ghost" data-longest="2560">2560</button>
+      </div>
+    </div>
+
+    <div class="size-fields" id="percent-fields" hidden>
+      <div class="numbers">
+        <label>Yüzde<input type="number" id="size-percent" min="1" max="1000" step="1" value="50"></label>
+      </div>
+      <div class="presets" id="percent-presets" role="group" aria-label="Yaygın yüzdeler">
+        <button type="button" class="ghost" data-percent="25">%25</button>
+        <button type="button" class="ghost" data-percent="50">%50</button>
+        <button type="button" class="ghost" data-percent="75">%75</button>
+        <button type="button" class="ghost" data-percent="200">%200</button>
+      </div>
+    </div>
+
+    <label class="check" id="enlarge-row">
+      <input type="checkbox" id="no-enlarge" checked>
+      <span>
+        <strong>Bir resmi asla başladığından büyük yapma</strong>
+        <span class="check-note">
+          Büyütmek, hiç fotoğraflanmamış pikseller uydurur; yani büyük bir çerçeve
+          istenen küçük bir resim ayrıntılı değil yumuşak çıkar. Bu açıkken,
+          istediğiniz boyuttan zaten küçük olan her şey kendi boyutunda bırakılır.
+        </span>
+      </span>
+    </label>
+
+    <p id="size-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Adım 4 &mdash; biçim ve tek tıklama -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Kaydedin</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Biçim</label>
+        <select id="format">
+          <option value="keep" selected>Her dosyanın geldiği biçimi koru</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/png">PNG</option>
+          <option value="image/webp">WebP</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kalite &mdash; <output id="quality-value" for="quality">85</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="85">
+        <p class="field-note">
+          Yalnızca JPEG ve WebP için; PNG'nin kalite düğmesi yoktur. 85, çoğu
+          insanın farkı ayırt edemez olduğu yerdir. 60'ın altında düz alanlar
+          bantlanmaya başlar.
+        </p>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Arka plan</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Resmin olmadığı yerde görünen şey: tamamlanmış bir çerçevenin arkasında
+          ve çıktı biçiminin alfa kanalı yoksa saydamlığın arkasında.
+        </p>
+      </div>
+    </div>
+
+    <p id="plan-summary" class="field-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Görselleri boyutlandır</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Bitti</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Hepsini zip olarak indir</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The big look at one result. A <dialog> opened with showModal() rather than
+    a div pretending to be one: the browser gives the focus trap, the Escape
+    key and the inert background for nothing, and gets all three right.
+
+    Both pictures in it are object URLs made on this page - the result, and the
+    original that was already decoded for the thumbnail. Opening this fetches
+    nothing and decodes nothing that was not already decoded.
+  -->
+  <dialog id="viewer" class="viewer" aria-labelledby="viewer-name">
+    <div class="viewer-head">
+      <h2 id="viewer-name" class="viewer-name"></h2>
+      <button type="button" id="viewer-close" class="ghost" aria-label="Kapat">Kapat</button>
+    </div>
+
+    <div class="viewer-stage">
+      <img id="viewer-image" alt="">
+    </div>
+
+    <p id="viewer-caption" class="viewer-caption"></p>
+
+    <dl class="viewer-facts" id="viewer-facts"></dl>
+
+    <div class="viewer-actions">
+      <button type="button" id="viewer-compare" class="ghost" aria-pressed="false">Özgün hâlini göster</button>
+      <a id="viewer-download" class="primary as-button" download>İndir</a>
+    </div>
+  </dialog>
+</main>

--- a/locales/tr/tools/resize-image.toml
+++ b/locales/tr/tools/resize-image.toml
@@ -1,0 +1,274 @@
+#
+# Görsel Boyutlandırıcı - Türkçe.
+#
+# Overrides for tools/resize-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# The two cross-links in the FAQ point at other tools, so their hrefs carry the
+# Turkish slugs from [slugs] in locale.toml - ../exif-verisi-silme/ and
+# ../resim-sikistirma/ - and not the English ones.
+#
+
+name = "Görsel Boyutlandırıcı"
+heading = "Görsel&nbsp;Boyutlandırıcı <span class=\"h1-kw\">&mdash; boyutlandırın, kırpın, dönüştürün</span>"
+tagline = "Boyutu söyleyin. Kutuyu çizin. Biçimi seçin."
+
+title = "Görsel Boyutlandırma &mdash; Kırpma ve Dönüştürme de Var, Yüklemesiz"
+description = "JPEG, PNG ve WebP görselleri tarayıcınızda boyutlandırın, kırpın ve dönüştürün. Tam piksel, yüzde ya da uzun kenar &mdash; tek bir görsel veya koca bir klasör. Hiçbir şey yüklenmez."
+og_title = "Bir görseli yüklemeden boyutlandırın, kırpın ve dönüştürün"
+og_description = "Boyutu piksel ya da yüzde olarak verin, bir kırpma kutusu sürükleyin, biçimi değiştirin &mdash; tek bir resim ya da koca bir yığın için. Hepsi kendi makinenizde çalışır."
+og_image_alt = "Görsel Boyutlandırıcı - yüklemeden boyutlandırın, kırpın, dönüştürün"
+
+pledge = """
+    Boyutlandırma, kırpma ve biçim değişikliğinin hepsi kendi tarayıcınızda,
+    kendi donanımınızda, tarayıcının zaten beraberinde getirdiği görsel
+    kodlayıcılarla çalışır. Bu aracın hiçbir türde ağ özelliği yoktur &mdash;
+    getirecek bir şey yok, gönderecek bir şey yok &mdash; ve olsaydı bile bu
+    sayfanın öbür ucunda bir resmin gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir fotoğrafı boyutlandırın. Tek bir istek bile bir görsel, bir
+      küçük resim, bir dosya adı ya da seçtiğiniz şeyden tek bir bayt taşımıyor.
+      Ya da internet bağlantısını kesip yine de bir tane boyutlandırın."""
+
+read_first = """
+, neyin korunacağına ve sonucun ne kadar
+      büyük çıkacağına karar veren aritmetik için <code>src/geometry.js</code> ve
+      kırpma ile boyutlandırmayı birlikte yapan tek <code>drawImage</code>
+      çağrısı için <code>src/codecs.js</code>."""
+
+howto_heading = "Bir görsel yüklemeden nasıl boyutlandırılır"
+
+card = """
+            Tam piksel, yüzde ya da uzun kenar &mdash; yol üstünde bir kırpma
+            kutusu ve bir biçim değişikliğiyle. Tek bir resim ya da bir klasör."""
+
+[words]
+plural = "görseller"
+choose = "bir görsel"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Görsellerinizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir
+      yerde <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Boyutlandırma, bir tuvale yapılan bir
+      <code>drawImage</code> ve bir <code>canvas.toBlob</code>'dur &mdash;
+      tarayıcınızda zaten kurulu olan ölçekleyici ve kodlayıcı."""
+
+[[privacy]]
+title = "Değiştirilmesi istenmeyen dosya değiştirilmez."
+body = """
+ Kırpma yoksa,
+      boyutlandırma yoksa ve biçim değişikliği yoksa seçtiğiniz dosya yeniden
+      kaydedilmez, size baytı baytına geri verilir. Bu yalnızca bir nezaket
+      değildir: bu aracın bir resmi sessizce yeniden kodlayamamasının ya da
+      yalnızca bakmak istediğiniz bir resmin üstverisini sessizce
+      düşürememesinin sebebi budur."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine
+      resimleriniz hakkında bir şey verilmiyor. Bir dosyayı okuyan, kırpan,
+      ölçekleyen ya da yazan her satır bu kaynaktan sunuluyor ve depoda
+      listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "Görsellerinizi seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin. Tarayıcı
+      onları doğrudan diskinizden okur; siz bunu yaparken hiçbir yere hiçbir şey
+      gönderilmez."""
+
+[[howto]]
+title = "İsterseniz kırpın."
+body = """
+ Kutu resmin tamamının üstünde başlar; yani
+      ona dokunmazsanız hiçbir şey kırpılmaz. Sürükleyin ya da bir şekle
+      kilitleyin &mdash; profil fotoğrafı için 1:1, hikâye için 9:16, küçük resim
+      için 16:9 &mdash; ve sığanların en büyüğü için "En büyük"e basın. Her görsel
+      kendi kutusunu taşır: bunun yerine bir başkasının üstüne çizmek için
+      listedeki herhangi bir satıra tıklayın. Hepsinin aynı şekilde
+      çerçevelenmesi gerekiyorsa onu da tek bir düğme yapar."""
+
+[[howto]]
+title = "Ne boyutta çıkacağını söyleyin."
+body = """
+ Bir genişlik, bir yükseklik
+      ya da ikisi; dikey ve yatay çekimleri birbiriyle aynı boyutta tutan bir uzun
+      kenar; ya da düpedüz bir yüzde. İki kutudan birini boş bırakın, resim kendi
+      şeklini korusun."""
+
+[[howto]]
+title = "Biçimi seçin, sonra düğmeye basın."
+body = """
+ Her dosyayı geldiği hâliyle
+      bırakın ya da hepsini JPEG, PNG veya WebP olarak yazın. Her sonuç neye
+      dönüştüğünü ve ne kadar küçüldüğünü söyler; arkasındaki her rakamla birlikte
+      tam boyutta açmak ve karşılaştırmak için yanındaki özgün hâliyle görmek üzere
+      birine tıklayın. Bir yığın tek bir zip olarak iner."""
+
+[[faq]]
+q = "Görselim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya, tarayıcının zaten beraberinde getirdiği JPEG, PNG ve WebP
+        kodlayıcılarıyla, kendi donanımınızda, kendi tarayıcınız tarafından
+        çözülür, kırpılır, ölçeklenir ve yazılır. Bu aracın hiçbir türde ağ
+        özelliği yoktur &mdash; hiçbir zaman bir şey getirmez ve hiçbir zaman bir
+        şey göndermez &mdash; ve sayfanın <code>Content-Security-Policy</code>'si
+        iletişim kurabileceği her adresi tek tek sayar; bunların hiçbiri bu siteye
+        ait değildir."""
+
+[[faq]]
+q = "Genişlik verip yükseklik vermezsem ne olur?"
+a = """
+        Yükseklik, resmin kendi şeklinden gelir ki neredeyse her zaman istenen de
+        budur: "1920 genişliğinde", "1920 genişliğinde ve bunun getirdiği yükseklikte"
+        demektir. İkisini birden doldurun, ikisi resmin şekliyle çelişebilir; "şekiller
+        uyuşmazsa" seçiminin ortaya çıktığı tek an da budur &mdash; kutunun içine
+        sığdır, kutuyu doldur ve taşanı kes, arka planla tamamla ya da esnetip
+        bozulmayı kabul et."""
+
+[[faq]]
+q = "Boyutlandırmak görselin kalitesini düşürür mü?"
+a = """
+        Bir resmi küçültmek, görebileceğiniz hiçbir biçimde düşürmez: içeri giren
+        piksel, dışarı çıkandan fazladır; yani korunan ayrıntı gerçek ayrıntıdır.
+        Bir resmi büyütmek ise hiç fotoğraflanmamış olanı ekleyemez &mdash; sonuç
+        aynı resmin daha keskin değil daha yumuşak bir kopyasıdır &mdash; "bir resmi
+        başladığından büyük yapma"nın varsayılan olarak açık olmasının sebebi de
+        budur. Bir parça bedeli olan şey, biçim JPEG ya da WebP ise sonrasındaki
+        yeniden kodlamadır; kalite kaydırağı da orada harcadığınızdır."""
+
+[[faq]]
+q = "Her görseli farklı kırpabilir miyim?"
+a = """
+        Evet &mdash; varsayılan da budur. Listedeki her görsel kendi pikselleriyle
+        kendi kutusunu taşır ve bir satıra tıklamak o görseli, kendi kutusu ve kendi
+        kilitli şekliyle birlikte ön izlemeye koyar. Birine yaptığınız hiçbir şey
+        bir diğerini etkilemez. Her kutu ayrıca resmin tamamının üstünde başlar;
+        yani hiç üstüne çizmediğiniz bir görsel hiç kırpılmaz."""
+
+[[faq]]
+q = "Koca bir yığını tek seferde aynı şekilde kırpabilir mi?"
+a = """
+        Evet, ön izlemenin altındaki düğmeyle. Diğer her görsele aynı göreli alanı
+        &mdash; kendi genişlik ve yüksekliğinin aynı kesirlerini &mdash; verir ki
+        hepsi aynı boyutta olan bir ekran görüntüsü ya da dışa aktarım seti için bu,
+        tam olarak aynı kutu demektir ve sayfa da bunu söyler. Bir şekil kilitliyse
+        bunun yerine her birine, o alanın içindeki o şekilden en büyük kutuyu verir;
+        yani 1:1'e ve ardından o düğmeye basmak, dikey ve yatay çekimlerin karışık
+        olduğu bir klasörden size kareler çıkarır. Her kutu sonrasında da
+        düzenlenebilir kalır."""
+
+[[faq]]
+q = "Hangi biçimleri okuyabiliyor ve yazabiliyor?"
+a = """
+        Tarayıcınızın çözebildiği her şeyi okur; pratikte bu JPEG, PNG, WebP, GIF,
+        BMP ve &mdash; güncel tarayıcıların çoğunda &mdash; AVIF demektir. JPEG, PNG
+        ve WebP yazar; çünkü tarayıcıların beraberinde getirdiği kodlayıcılar
+        bunlardır. "Biçimi koru"da bir JPEG JPEG kalır ve bir PNG PNG kalır;
+        tarayıcının yazamadığı bir şey, örneğin bir GIF ya da bir BMP, PNG olarak
+        çıkar &mdash; saydamlığı ve düz rengi bozulmadan koruyan biçim odur."""
+
+[[faq]]
+q = "JPEG olarak kaydettiğimde saydamlığa ne olur?"
+a = """
+        Arka plan rengiyle doldurulur; çünkü JPEG'in onu saklayacak bir alfa kanalı
+        yoktur. Rengi siz seçersiniz ve beyazdan başlar; çoğu insanın istediği ve
+        başka hemen her aracın size söylemeden yaptığı da budur. Tamamlanmış bir
+        çerçevenin arkasında da aynı renk kullanılır. Bunun yerine PNG ya da WebP
+        olarak kaydedin, saydamlık dokunulmadan geçsin."""
+
+[[faq]]
+q = "EXIF ve GPS verisini siliyor mu?"
+a = """
+        Gerçekten işlediği her şeyde evet, bir yan etki olarak: kırpmak ya da
+        boyutlandırmak, resmi piksellere çözmek ve o pikselleri yeniden kodlamak
+        demektir; piksellerle dolu bir tuval de hiçbir etiket taşımaz, yani konum,
+        kamera modeli ve zaman damgaları yeni dosyaya yazılmaz. Hiç değiştirmediğiniz
+        bir dosya ise başka bir durumdur &mdash; etiketleriyle birlikte, baytı
+        baytına geri verilir. Üstverinin gitmesini ama resmin el değmemiş kalmasını
+        istiyorsanız, kabı hiçbir şeyi yeniden sıkıştırmadan yeniden yazan
+        <a href="../exif-verisi-silme/">EXIF Görüntüleyici ve Silici</a>'yi
+        kullanın."""
+
+[[faq]]
+q = "Bunun görsel sıkıştırıcıdan farkı ne?"
+a = """
+        Bu araç boyutlarla ilgilidir: kaç piksel istediğinizi söylersiniz, o da size
+        onu verir. <a href="../resim-sikistirma/">Görsel Sıkıştırıcı</a> ise dosya
+        boyutuyla ilgilidir: kaç kilobayta izniniz olduğunu söylersiniz, o da sığan
+        en yüksek kaliteyi arar ve yalnızca kalite tek başına yetmiyorsa
+        boyutlandırır. Size "1200 piksel genişliğinde" dendiyse doğru yerdesiniz.
+        "500 KB'nin altında" dendiyse diğeri sizi daha yakına götürür."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Dosyaların
+        sayısında ya da boyutunda da bir sınır yok, çünkü bunların bedelini ödeyen
+        bir sunucu yok &mdash; iş sizin kendi cihazınızda oluyor. Sitede reklam var,
+        masrafı karşılayan da o; reklamlara görselleriniz hakkında hiçbir şey
+        verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin, çalışmaya
+        devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini kanıtlamanın en basit
+        yolu: görsellerinizi boyutlandırılmak üzere uzağa gönderen bir araç, siz fişi
+        çeker çekmez dururdu."""
+
+[schema]
+description = "JPEG, PNG ve WebP görselleri tarayıcıda boyutlandırın, kırpın ve dönüştürün. Tam bir piksel boyutu, bir yüzde ya da bir uzun kenar verin, bir kırpma kutusu sürükleyin ya da onu bir şekle kilitleyin ve sonucu JPEG, PNG veya WebP olarak yazın. Yığın işleme var ve hiçbir şey yüklenmez."
+features = [
+  "Tam piksele, bir uzun kenara ya da bir yüzdeye göre boyutlandırma",
+  "Bir kenarı doldurun, diğeri resmin kendi şeklinden gelsin",
+  "İçine sığdırın, doldurup kırpın, tam bir çerçeveye tamamlayın ya da esnetin",
+  "Görsel başına sürüklenebilir bir kırpma kutusu; 1:1, 4:5, 9:16, 16:9, 4:3 ya da 3:2'ye kilitlenebilir",
+  "Her görseli farklı kırpar ya da tek tıkla bütün yığına tek bir çerçeveleme uygular",
+  "Biten her resmi, arkasındaki her rakamla ve karşılaştırmak için özgün hâliyle birlikte tam boyutta açar",
+  "Bir kalite denetimi ve bir arka plan rengiyle JPEG, PNG ve WebP arasında dönüştürür",
+  "Siz istemedikçe bir resmi asla büyütmez",
+  "Değiştirilmesi istenmeyen dosyayı el değmemiş hâlde geri verir",
+  "Yığın işleme; tüm sonuçlar tek bir zip içinde",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Görselleri buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; JPEG, PNG, WebP ve tarayıcınızın açabildiği her şey"

--- a/locales/tr/tools/reverse-video.html
+++ b/locales/tr/tools/reverse-video.html
@@ -1,0 +1,95 @@
+<!--
+  tools/reverse-video/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosya -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir video seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Dosya</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Boyut</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Kare</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Görüntü</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Ses</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <div class="stage-wrap" id="preview-wrap" hidden>
+      <video id="preview" class="stage" playsinline controls></video>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; ters çevirme -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">2</span> Ters çevirin</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="quality">Kalite</label>
+        <select id="quality">
+          <option value="low">Daha küçük dosya</option>
+          <option value="medium" selected>Dengeli</option>
+          <option value="high">En iyi kalite</option>
+        </select>
+        <p class="field-note">
+          Aynı görüntüye orijinalin harcadığından asla fazlası değil &mdash;
+          ters çevrilmiş bir klip aynı kareleri taşır, dolayısıyla daha fazlasını
+          harcamak dosyayı yalnızca büyütür.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Sesi de ters çevir
+        </label>
+        <p class="field-note" id="audio-note">
+          Örnek örnek döndürülür, sonra AAC olarak yeniden kodlanır. Sessiz bir
+          klip için kapalı bırakın, daha hızlıdır.
+        </p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Çıktı karesi</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Kareler</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Nasıl</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Videoyu ters çevir</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Videoyu indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/reverse-video.toml
+++ b/locales/tr/tools/reverse-video.toml
@@ -1,0 +1,241 @@
+#
+# Video Tersleyici - Türkçe.
+#
+# Overrides for tools/reverse-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Video Tersleyici"
+heading = "Video&nbsp;Tersleyici <span class=\"h1-kw\">&mdash; videoyu geriye oynatın</span>"
+tagline = "Önce son kare, sesiyle birlikte."
+
+title = "Videoyu Çevrimiçi Ters Çevirme &mdash; Ücretsiz, Yüklemesiz, Çevrimdışı Çalışır"
+description = "Bir MP4, MOV veya WebM'i geriye oynatın; sesi de ters çevrilir. Tarayıcınızda çalışır: hiçbir şey yüklenmez, filigran yoktur ve çevrimdışı da çalışır."
+og_title = "Video Tersleyici &mdash; bir klibi yüklemeden geriye oynatın"
+og_description = "Bir videoyu ve içindeki sesi kare kare, kendi cihazınızda ters çevirin. Dosyayı kendi tarayıcınız okur, çözer ve yazar."
+og_image_alt = "Video Tersleyici - bir klibi tarayıcınızda geriye oynatın, hiçbir şey yüklenmesin"
+
+pledge = """
+    Her kare kendi tarayıcınız tarafından, kendi donanımınızda çözülür, ters
+    çevrilir ve yeniden kodlanır. Buradaki hiçbir şey bir şey getiremez ya da
+    gönderemez &mdash; bu araçta hiçbir türde ağ özelliği yok &mdash; ve
+    olsaydı bile bu sayfanın öbür ucunda bir videonun gönderilebileceği bir
+    sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir klibi ters çevirin. Tek bir istek bile bir kare, bir dosya
+      adı ya da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet
+      bağlantısını kesip yine de bir tanesini ters çevirin &mdash; videonuzu
+      işlenmek üzere uzağa gönderen bir araç öylece dururdu."""
+
+read_first = """
+, hangi karenin ne zaman çıkacağına karar veren hesap için
+      <code>src/timeline.js</code> ve dosyayı her seferinde bir kare grubu
+      geriye doğru gezen döngü için <code>src/reverse.js</code>. Hiçbiri istek
+      yapabilecek bir şeyi içeri almaz."""
+
+howto_heading = "Bir video nasıl ters çevrilir"
+
+card = """
+            Bir klibi geriye oynatın &mdash; görüntüsüyle ve sesiyle &mdash;
+            onu hiçbir yere göndermeden."""
+
+[words]
+plural = "videolarınız"
+choose = "bir video"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Sesi de ters çevirir"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[privacy]]
+title = "Videolarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu
+      sayfanın iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri
+      bu siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araçta hiçbir türde ağ
+      özelliği yok: yapıştırılacak bir adres, indirilecek bir şey, ilk
+      kullanımda getirilen bir motor yok. Videonuza dokunan her bayt, sayfa
+      yüklenirken bu kaynaktan geldi."""
+
+[[privacy]]
+title = "Çözme ve kodlama yerelde."
+body = """
+ Kareler kendi tarayıcınızdaki
+      WebCodecs'ten geçer ya da klibi zaten size gösterecek olan aynı oynatma
+      motorundan. Bitmiş dosya bu makinenin belleğinde kurulur ve doğrudan bir
+      indirmeye verilir."""
+
+[[privacy]]
+title = "Ses de burada ters çevriliyor."
+body = """
+ Bir parçayı ters çevirmek onu
+      çözmek demektir ve o çözme işi tarayıcının kendi işidir, bu makinede
+      çalışır. Hiçbir şey onu dinlemez, hiçbir şey saklamaz ve hiçbir şey onu
+      bir yere iletemez: burada bir bayt gönderen bir kod yolu yok."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine videonuz hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir kare, ne bir ad, bir boyut ya da bir uzunluk. Okuyan, çözen,
+      ters çeviren ya da kodlayan her satır bu kaynaktan sunuluyor ve depoda
+      listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de videonuz
+      hakkında bir şey verilir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Bir video seçin."
+body = """
+ Seçiciye bir MP4, MOV, M4V ya da WebM
+      bırakın veya elle seçin. Tarayıcı onu doğrudan diskinizden okur; siz bunu
+      yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Sese karar verin."
+body = """
+ &laquo;Sesi de ters çevir&raquo;, parçayı
+      örnek örnek döndürür; konuşmanın sessizlik olarak değil, geriye oynatılan
+      konuşma olarak çıkmasını sağlayan da budur. Sessiz bir klip için kapatın,
+      daha hızlıdır."""
+
+[[howto]]
+title = "Ne kadar kalite harcayacağınızı seçin."
+body = """
+ Görüntünün yeniden
+      kodlanması gerekir, çünkü kareler dosyadaki hiçbir şeyin kodlanmadığı bir
+      sırayla çıkar. &laquo;Dengeli&raquo;, orijinalin harcadığına yakın kalır;
+      &laquo;En iyi kalite&raquo; daha fazlasını harcar."""
+
+[[howto]]
+title = "Ters çevirin ve indirin."
+body = """
+ İş kendi donanımınızda olduğu
+      için ne kadar süreceği bir sıraya değil makinenize bağlıdır. Bitmiş video
+      doğrudan tarayıcınızın indirmelerine verilir."""
+
+[[faq]]
+q = "Videom herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur, çözülür,
+        ters çevrilir ve kodlanır. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Size
+        söylenene güvenmek yerine denetlemeyi tercih ediyorsanız internet
+        bağlantısını kesin ve yine de bir klibi ters çevirin."""
+
+[[faq]]
+q = "Hangi video biçimlerini ters çevirebilirim?"
+a = """
+        MP4, M4V ve MOV içlerinde ne olursa olsun doğrudan okunur: H.264, HEVC,
+        AV1 ya da VP9 &mdash; yeter ki tarayıcınız o kodlayıcıyı çözebilsin.
+        Tarayıcınızın oynatabildiği başka her şey &mdash; en bilineni WebM
+        &mdash; bunun yerine tarayıcının kendi oynatıcısı içinde geriye doğru
+        adım adım gezilerek ters çevrilir; bu da işe yarar ama daha yavaştır.
+        Tarayıcının ne okuyabildiği ne de oynatabildiği bir dosya, ki pratikte
+        AVI, WMV, FLV ve çoğu MKV demektir, yarı yolda başarısız olmak yerine
+        bunu söyleyen bir mesajla geri çevrilir. Çıkan şey her zaman bir
+        MP4'tür."""
+
+[[faq]]
+q = "Ses de ters çevriliyor mu?"
+a = """
+        Kapatmadığınız sürece evet. Parçanın tamamı çözülür, örnekler öbür sıraya
+        konur ve AAC olarak yeniden kodlanır. Bu ikinci kodlamadan kaçmanın yolu
+        yok: bir ses paketi, kendinden önceki pakete göre kodlanmış birkaç on
+        milisaniyelik sestir; dolayısıyla paketleri tersten yazmak, kısa
+        parçaları yanlış sırada ileriye doğru oynatırdı &mdash; ki bu bir ters
+        çevirmeye değil, bir arızaya benzer."""
+
+[[faq]]
+q = "Ters çevirmek kalite kaybettirir mi?"
+a = """
+        Görüntü ikinci kez kodlanır ve bu biraz kaliteye mal olur. Burada,
+        kesmede olduğu gibi bundan kaçınmak mümkün değil: ters çevrilmiş bir
+        klip, karelerini orijinal dosyadaki hiçbir şeyin kodlanmadığı bir sırada
+        gösterir; bu yüzden her karenin yeniden yazılması gerekir. Aracın
+        yapmayacağı şey orijinalin harcadığından fazlasını harcamaktır; bunun
+        üzerinde kodlamak dosyayı yalnızca büyütür, daha iyi göstermez."""
+
+[[faq]]
+q = "Videonun boyutunda veya uzunluğunda bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok ve dosya belleğe bir seferde tümüyle
+        okunmuyor &mdash; geriye doğru, kare grubu kare grubu geziliyor. Pratik
+        tavanlar, indirmeden önce bellekte kurulan bitmiş video ile sestir;
+        çünkü ters çevirmek ilk örneği yazabilmek için son örneği gerektirdiğinden
+        sesin bütün olarak tutulması gerekir."""
+
+[[faq]]
+q = "Neden bazı dosyalarda daha yavaş?"
+a = """
+        Çünkü iki ayrı giriş yolu var. Bir MP4 ya da MOV bu araç tarafından
+        doğrudan okunur ve her seferinde bir kare grubu çözülür ki bu makinenizin
+        gidebildiği kadar hızlıdır. Başka her şey, tarayıcının kendi
+        oynatıcısından klibin bir anı arkasından öbürü istenerek ters çevrilir ve
+        bu aramaların her biri tarayıcıyı kendinden önceki anahtar kareden
+        itibaren çözmeye zorlar. Sayfa, başlamadan önce hangisini kullandığını ve
+        nedenini söyler."""
+
+[[faq]]
+q = "Bir klibin yalnızca bir bölümünü ters çevirebilir miyim?"
+a = """
+        Burada değil. Bu araç bütününü ters çevirir: çıkan klip, girenle tam
+        olarak aynı uzunlukta olur, son kare başta. Önce istediğiniz bölümü
+        <a href="../video-kesme/">Video Kesici</a> ile kesin &mdash; ki o bunu
+        tek bir kareyi bile yeniden kodlamadan yapar &mdash; sonra oradan
+        çıkanı ters çevirin."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara videonuz hakkında hiçbir
+        şey verilmiyor."""
+
+[schema]
+browser_requirements = "JavaScript ve WebCodecs video kodlama destekleyen bir tarayıcı gerekir: Chrome, Edge, Safari 16.4 veya üzeri ya da Firefox 133 veya üzeri."
+description = "Bir videoyu tarayıcıda, sesiyle birlikte ters çevirin. MP4, MOV ve M4V sondan başlayarak grup grup çözülür ve orijinal kare zamanlarıyla yeniden kodlanır; tarayıcının oynatabildiği başka her şey bunun yerine geriye doğru adım adım gezilir. Hiçbir şey yüklenmez."
+features = [
+  "MP4, MOV, M4V ve WebM videoları ters çevirir",
+  "H.264, HEVC, AV1 ve VP9 kaynakları, WebCodecs üzerinden çözülür",
+  "Sesi örnek örnek ters çevirir ya da tümüyle dışarıda bırakır",
+  "Düzensiz kare hızları dahil, orijinal kare zamanlarını korur",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir videoyu buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; MP4, MOV, M4V, WebM ve bu tarayıcının oynattığı her şey"

--- a/locales/tr/tools/split-gif.html
+++ b/locales/tr/tools/split-gif.html
@@ -1,0 +1,114 @@
+<!--
+  tools/split-gif/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosya -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir GIF seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Dosya</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Boyut</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Görüntü</dt><dd id="src-picture">&mdash;</dd></div>
+      <div><dt>Kareler</dt><dd id="src-frames">&mdash;</dd></div>
+      <div><dt>Süresi</dt><dd id="src-duration">&mdash;</dd></div>
+      <div><dt>Tekrar</dt><dd id="src-loop">&mdash;</dd></div>
+    </dl>
+
+    <p id="notice" class="path-note" hidden></p>
+    <p id="error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; ne çıkacağı -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">2</span> Kareler nasıl çıksın</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="mode">Her PNG şunu taşısın</label>
+        <select id="mode">
+          <option value="composited" selected>Göründüğü hâliyle kare</option>
+          <option value="stored">Yalnızca o karenin sakladığı pikseller</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="background">Saydam alanlar</label>
+        <select id="background">
+          <option value="keep" selected>Saydam kalsın</option>
+          <option value="flatten">Bir renkle doldur&hellip;</option>
+        </select>
+        <div id="colour-row" class="inline-pair" hidden>
+          <input type="color" id="colour" value="#ffffff" aria-label="Saydam alanların doldurulacağı renk">
+          <span id="colour-note">Her kareye yazılır. Sonradan geri çıkarılamaz.</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="every">Şu kadarda bir kareyi koru</label>
+        <div class="inline-pair">
+          <input type="number" id="every" min="1" max="100" step="1" value="1">
+          <span id="every-note">kare</span>
+        </div>
+        <p class="field-note">
+          Bir kontak baskısı ya da uzun bir kayıt için hepsi yerine her ikinci ya
+          da her beşinci kareyi alın.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="timing">Zamanlama listesi</label>
+        <select id="timing">
+          <option value="yes" selected>ZIP'e frames.txt ekle</option>
+          <option value="no">Yalnızca kareler</option>
+        </select>
+        <p class="field-note">
+          Her karenin ne kadar tutulduğu ve nerede durduğu. Bir PNG klasörü bunu
+          kendi başına taşıyamaz.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="download-all" class="primary">Her kareyi ZIP olarak indir</button>
+      <button type="button" id="download-selected" class="ghost" hidden>Seçili kareleri indir</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; karelerin kendisi -->
+  <section class="card" id="frames-card" hidden>
+    <h2><span class="step">3</span> Kareler</h2>
+
+    <div class="toolbar">
+      <p class="count" id="frames-count" role="status" aria-live="polite"></p>
+      <div class="toolbar-actions">
+        <button type="button" id="select-all" class="ghost">Hepsini seç</button>
+        <button type="button" id="select-none" class="ghost">Hiçbirini seçme</button>
+        <button type="button" id="clear" class="ghost danger">Baştan başla</button>
+      </div>
+    </div>
+
+    <!-- Checkboxes rather than a click-to-select grid: this is a list of files
+         somebody is about to save, and a checkbox is the one control everybody
+         already knows is safe to press. -->
+    <ul class="frames" id="frames"></ul>
+  </section>
+</main>

--- a/locales/tr/tools/split-gif.toml
+++ b/locales/tr/tools/split-gif.toml
@@ -1,0 +1,258 @@
+#
+# GIF Ayırıcı - Türkçe.
+#
+# Overrides for tools/split-gif/tool.toml. Only words: the slug, the category,
+# the icon and the list of shared parts stay where they are.
+#
+
+name = "GIF Ayırıcı"
+heading = "GIF&nbsp;Ayırıcı <span class=\"h1-kw\">&mdash; her kare kendi PNG'si olarak</span>"
+tagline = "Her kare kendi PNG'si olarak dışarı."
+
+title = "GIF Ayırıcı &mdash; Her Kare Bir PNG, Ücretsiz ve Yüklemesiz"
+description = "Hareketli bir GIF'i karelerine ayırın ve her birini PNG olarak kaydedin; ücretsiz ve tamamen tarayıcınızda. Saydamlığı ve zamanlamayı korur. Hiçbir şey yüklenmez ve çevrimdışı da çalışır."
+og_title = "GIF Ayırıcı &mdash; bir animasyonu tarayıcınızda parçalarına ayırın"
+og_description = "Bir GIF'in her karesi kendi PNG'si olarak, gecikmeleri ve saydamlığı el değmemiş hâlde. Dosya kendi cihazınızda okunur ve hiçbir zaman yüklenmez."
+og_image_alt = "GIF Ayırıcı - bir GIF'in her karesi kendi PNG'si olarak"
+
+pledge = """
+    GIF kendi tarayıcınız tarafından okunur, açılır ve çizilir; her PNG de bu
+    makinenin belleğinde kodlanır. Buradaki herhangi bir şey istese bile, bu
+    sayfanın öbür ucunda bir animasyonun gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir GIF ayırın. Tek bir istek bile bir görsel, bir kare ya da
+      bir dosya adı taşımıyor. Ya da internet bağlantısını kesip yine de bir tane
+      ayırın."""
+
+read_first = """
+, kareleri açan okuyucu için <code>src/gif.js</code> ve
+      onları üst üste bindiren kurallar için <code>src/compose.js</code> &mdash;
+      ikisinde de ağa erişebilecek tek bir satır yok."""
+
+howto_heading = "Bir GIF karelere nasıl ayrılır"
+
+card = """
+            Bir animasyonu parçalarına ayırın: her kare kendi PNG'si olarak,
+            saydamlığı korunmuş ve zamanlaması yazılmış hâlde. GIF kendi
+            cihazınızda açılır."""
+
+[words]
+plural = "GIF'leriniz"
+choose = "bir GIF"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[facts]]
+text = "Dosyalar cihazınızda kalır"
+
+[[privacy]]
+title = "GIF'inizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok. Burada eskiden
+      <code>connect-src 'none'</code> yazıyordu ki bu mutlaktı; reklam eklemek
+      buna mal oldu ve bunu söylemek anlaşmanın bir parçası."""
+
+[[privacy]]
+title = "GIF okuyucu bu depodaki iki dosya."
+body = """
+ Bir tarayıcı GIF'i
+      oynatır ama parçalarını size vermez; bu yüzden biçim burada okunuyor:
+      <code>src/gif.js</code> kap ve LZW açıcısı,
+      <code>src/compose.js</code> ise kendinden öncekiler altına serildiğinde her
+      karenin nasıl görüneceğine karar veren tasfiye kuralları. Bir dosyayı açmak
+      için hiçbir şey getirilmiyor ve ilk kullanımda indirilen bir motor yok."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine animasyonunuz hakkında bir şey verilmiyor: ne
+      bir dosya, ne bir kare, ne bir ad, bir boyut ya da bir sayı. Bir görseli
+      okuyan, açan, çizen ya da kodlayan her satır bu kaynaktan sunuluyor ve
+      depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de dosyalarınız
+      hakkında bir şey verilir. Siz tıklamadıkça hiçbir şey olmaz ve
+      tıkladığınızda gideceğiniz yer başkasının sitesidir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfanın her
+      parçası çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu:
+      animasyonunuzu parçalarına ayrılmak üzere uzağa gönderen bir araç, siz fişi
+      çeker çekmez dururdu."""
+
+[[howto]]
+title = "GIF'i seçin."
+body = """
+ Seçiciye bırakın ya da elle seçin. Tarayıcı onu
+      doğrudan diskinizden okur ve sayfa bulduğunu söyler: boyutu, kare sayısı,
+      ne kadar oynadığı ve kaç kez tekrarladığı."""
+
+[[howto]]
+title = "Her PNG'nin ne taşıyacağına karar verin."
+body = """
+ <strong>Göründüğü
+      hâliyle kare</strong>, neredeyse herkesin istediğidir: animasyonun o
+      anındaki görüntünün tamamı. <strong>Yalnızca o karenin sakladığı
+      pikseller</strong> ise dosyanın gerçekten taşıdığı yamadır; kendi boyutunda
+      ve kendi yerinde, ki bir GIF böyle küçük kalır ve animasyonun görünüşü bu
+      değildir."""
+
+[[howto]]
+title = "Saydamlığa ne olacağına karar verin."
+body = """
+ PNG onu korur ki
+      dürüst varsayılan budur. Kareler saydamlığı yok sayan ve onu siyaha
+      çevirecek bir yere gidiyorsa onun yerine bir renkle doldurun."""
+
+[[howto]]
+title = "İstediğiniz kareleri seçin."
+body = """
+ Varsayılan olarak hepsi.
+      "Her ikinci kareyi koru" uzun bir kaydı seyreltir ve ızgaradaki onay
+      kutuları bunu geçersiz kılar &mdash; numaralandırma hiç değişmez, yani
+      komşularından ne kadar azını tutarsanız tutun 42. kare yine 42. karedir."""
+
+[[howto]]
+title = "İndirin."
+body = """
+ Izgaradan tek tek ya da yüzlerce kaydetme sorusu
+      yerine tek bir ZIP olarak hepsi birden. ZIP, her karenin ne kadar
+      tutulduğunu listeleyen bir <code>frames.txt</code> taşıyabilir; bir PNG
+      klasörünün kendi başına söyleyemediği tek şey de budur."""
+
+[[faq]]
+q = "GIF'im herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        açılır ve çizilir; her PNG de burada, bellekte kodlanır. Bu aracın sunucu
+        tarafı yoktur ve sayfanın <code>Content-Security-Policy</code>'si
+        iletişim kurabileceği her adresi tek tek sayar &mdash; bunların hiçbiri
+        bu siteye ait değildir. Ağ bağlantısını kesin, yine de GIF ayırır."""
+
+[[faq]]
+q = "Bir kare neden görüntünün küçük bir parçası gibi duruyor?"
+a = """
+        Çünkü dosyanın taşıdığı şey bu. Bir GIF, bir ilk görüntü ve ardından
+        gelen yamalardır: sonraki her kare yalnızca değişen dikdörtgeni saklar ve
+        ekrandaki geri kalan her şey, kendinden önceki karelerin orada bıraktığı
+        şeydir. Sabit bir duvarın önünde konuşan bir kafa bu yüzden kare başına
+        bir görüntü değil kare başına bir yüz saklar; biçimin devasa olmamasının
+        bütün sebebi de budur.
+        <br><br>
+        Bunu görmenizin sebebi "Yalnızca o karenin sakladığı pikseller"in seçili
+        olması. "Göründüğü hâliyle kare"ye geçin; o zaman her PNG, animasyonun o
+        andaki görüntüsünün tamamı olur."""
+
+[[faq]]
+q = "Saydamlığı koruyor mu?"
+a = """
+        Evet. GIF saydamlığı tek bittir &mdash; bir piksel ya boyalıdır ya
+        görünmez, arası yoktur &mdash; ve PNG bunu tam olarak saklar; dolayısıyla
+        kareler saydam alanları el değmemiş hâlde çıkar. Düz bir arka planı
+        tercih ederseniz "Saydam alanlar"ı bir renkle doldurmaya ayarlayın; o
+        renk PNG'nin içine yazılır ve sonradan geri alınamaz."""
+
+[[faq]]
+q = "Kare gecikmeleri neden beklediğim sayılar değil?"
+a = """
+        Bir GIF her gecikmeyi saniyenin yüzde biri cinsinden saklar ve
+        tarayıcılar 1990'lardan beri bunun ikisinin altındaki her şeyi saniyenin
+        onda birine sabitliyor &mdash; o zamanın dönen dünya küreleri için
+        yazılmış ve hiç kaldırılmamış bir kural. Yani dosyası 0,01 sn diyen bir
+        kare her yerde 0,10 sn'de oynatılır. Bu araç gecikmeyi gerçekten
+        oynatıldığı hâliyle gösterir ve ikisi farklıysa dosyanın sakladığını
+        yanında söyler."""
+
+[[faq]]
+q = "Kareleri tekrar bir araya getirebilir miyim?"
+a = """
+        Evet; bu sitedeki <a href="../gif-olusturma/">GIF Yapıcı</a> ile ya da
+        bir görsel klasörü kabul eden başka herhangi bir şeyle. ZIP'in içindeki
+        <code>frames.txt</code> tam da bunun için var: bir animasyonu ayırmak
+        zamanlamayı atar, çünkü bir PNG'nin ne kadar tutulduğunu kaydedecek bir
+        yeri yoktur; bu yüzden liste her karenin gecikmesini ve konumunu
+        dışarıya taşır."""
+
+[[faq]]
+q = "Kareler hangi biçimlerde kaydedilebilir?"
+a = """
+        PNG ve bilinçli olarak yalnızca PNG. Bir GIF karesi en fazla 256 renk ve
+        bir bit saydamlıktır; PNG bunu tam ve kayıpsız saklar, JPEG ise
+        saydamlığı atar, karenin hiç sahip olmadığı renkler uydurur ve düz
+        çalışmalarda genellikle <em>daha büyük</em> bir dosya yapar. JPEG
+        gerekiyorsa PNG'leri sonradan
+        <a href="../resim-boyutlandirma/">Görsel Boyutlandırıcı</a> ile
+        dönüştürün."""
+
+[[faq]]
+q = "Kaç kare okuyacağına dair bir sınır var mı?"
+a = """
+        Sabit bir sınır yok. Pratik tavan kendi makinenizin belleği: bir GIF
+        okunurken kare başına piksel başına yaklaşık bir bayta açılır, yani küçük
+        bir dosya çok büyük bir bellek demek olabilir ve bu sayfa sekmenin
+        ölmesine izin vermek yerine okumayı durdurur. Bu olursa bunu söyler ve
+        elde ettiği kareleri geri verir."""
+
+[[faq]]
+q = "Bozuk bir GIF'i açar mı?"
+a = """
+        Genellikle. Yarıda kesilmiş indirmeler, eksik bir bitiş işareti ve akışın
+        ortasında duran son bir kare hep yaygındır ve bunları reddeden bir
+        okuyucu, insanların en çok parçalarına ayırmak istediği dosyalar için tam
+        anlamıyla işe yaramaz. Tam olan hangi kareler varsa geri gelir, neyin
+        yanlış olduğunu söyleyen bir notla birlikte. Yalnızca hiç GIF olmayan bir
+        dosya doğrudan reddedilir."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok. Karelerde filigran da
+        yok. Sitede reklam var, masrafı karşılayan da o; reklamlara dosyalarınız
+        hakkında hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: animasyonunuzu işlenmek üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Hareketli bir GIF'i karelerine ayırın ve her birini PNG olarak kaydedin. Dosya tarayıcınızda açılır; böylece hiçbir animasyon yüklenmez."
+features = [
+  "Bir GIF'in her karesi kendi PNG'si olarak, saydamlığı korunmuş hâlde",
+  "Göründüğü hâliyle kare ya da yalnızca o karenin sakladığı pikseller",
+  "Her kare için gecikme, konum, boyut ve tasfiye kuralı gösterilir",
+  "Her ikinci veya her beşinci kareyi tutun ya da istediklerinizi işaretleyin",
+  "Hepsi için tek ZIP, animasyonu yeniden kurmak üzere isteğe bağlı zamanlama listesiyle",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir GIF'i buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; hareketli ya da durağan, her boyutta"

--- a/locales/tr/tools/svg-to-image.html
+++ b/locales/tr/tools/svg-to-image.html
@@ -1,0 +1,214 @@
+<!--
+  tools/svg-to-image/body.html, in Turkish.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosyalar -->
+  <section class="card">
+    <h2><span class="step">1</span> SVG dosyalarını seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Hepsini listeden çıkar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; boyut -->
+  <section class="card" id="size-card">
+    <h2><span class="step">2</span> Ne kadar büyük olacağını söyleyin</h2>
+
+    <p class="card-lede">
+      Bir vektörün sizin yerinize yanıtlayamadığı tek soru budur. Bir SVG'nin
+      içinde piksel yoktur &mdash; çizim talimatları vardır ve onları
+      söyleyeceğiniz her boyutta uygular. Aşağıdaki sayı, bir fotoğrafta olduğu
+      gibi zorladığınız bir sınır değildir; 24&nbsp;piksellik bir simgeden çıkan
+      4000 piksel, 24'ün olduğu kadar keskindir.
+    </p>
+
+    <div class="option-row">
+      <label for="size-mode">Boyutu şununla belirle</label>
+      <select id="size-mode">
+        <option value="scale" selected>Dosyanın istediği boyutun bir katı</option>
+        <option value="width">Piksel cinsinden genişlik</option>
+        <option value="height">Piksel cinsinden yükseklik</option>
+        <option value="longest">En uzun kenar</option>
+        <option value="box">İki kenarı da verilmiş bir kutu</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="scale-fields">
+      <div class="numbers">
+        <label>Çarpan<input type="number" id="size-scale" min="0.01" max="200" step="0.5" value="4"></label>
+      </div>
+      <div class="presets" id="scale-presets" role="group" aria-label="Yaygın çarpanlar">
+        <button type="button" class="ghost" data-scale="1">1&times;</button>
+        <button type="button" class="ghost" data-scale="2">2&times;</button>
+        <button type="button" class="ghost" data-scale="4">4&times;</button>
+        <button type="button" class="ghost" data-scale="8">8&times;</button>
+        <button type="button" class="ghost" data-scale="16">16&times;</button>
+      </div>
+      <p class="hint-line">
+        Listedeki her dosya kendi boyutundan çarpılır; böylece farklı boyutlarda
+        çizilmiş bir simge yığını birbirine göre orantısını korur.
+      </p>
+    </div>
+
+    <div class="size-fields" id="width-fields" hidden>
+      <div class="numbers">
+        <label>Genişlik<input type="number" id="size-width" min="1" step="1" value="1024"></label>
+      </div>
+      <div class="presets" id="width-presets" role="group" aria-label="Yaygın genişlikler">
+        <button type="button" class="ghost" data-width="256">256</button>
+        <button type="button" class="ghost" data-width="512">512</button>
+        <button type="button" class="ghost" data-width="1024">1024</button>
+        <button type="button" class="ghost" data-width="2048">2048</button>
+      </div>
+      <p class="hint-line">Yükseklik, çizimin şeklinden gelir.</p>
+    </div>
+
+    <div class="size-fields" id="height-fields" hidden>
+      <div class="numbers">
+        <label>Yükseklik<input type="number" id="size-height" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">Genişlik, çizimin şeklinden gelir.</p>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>En uzun kenar<input type="number" id="size-longest" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">
+        Hangi kenar daha uzunsa o bu olur ve diğeri ona uyar; böylece geniş bir
+        logo ile uzun bir logo, uzun kenarlarında aynı boyutta çıkar.
+      </p>
+    </div>
+
+    <div class="size-fields" id="box-fields" hidden>
+      <div class="numbers">
+        <label>Genişlik<input type="number" id="box-width" min="1" step="1" value="1200"></label>
+        <label>Yükseklik<input type="number" id="box-height" min="1" step="1" value="630"></label>
+      </div>
+      <div class="option-row">
+        <label for="box-fit">Çizim başka şekildeyse</label>
+        <select id="box-fit">
+          <option value="fit" selected>İçine sığdır &mdash; çizimin tamamı, bir kenar kısa çıkar</option>
+          <option value="pad">Doldur &mdash; tam bu boyut, iki yanında arka planla</option>
+          <option value="stretch">Esnet &mdash; tam bu boyut ve şekil bozulmuş hâlde</option>
+        </select>
+      </div>
+    </div>
+
+    <!--
+      The one thing people rasterise a vector for more than once: the same
+      drawing at 1x, 2x and 3x for a screen with more device pixels than CSS
+      pixels. Multiplied from the plan above rather than planned again, so an
+      @2x is exactly twice its @1x and cannot drift by a rounded pixel.
+    -->
+    <div class="option-row" id="density-row">
+      <label for="density">Yüksek yoğunluklu kopyaları da yaz</label>
+      <select id="density">
+        <option value="1" selected>Hayır &mdash; çizim başına tek dosya</option>
+        <option value="2">@2x de olsun &mdash; bir Retina ekran için</option>
+        <option value="3">@2x ve @3x &mdash; bir telefonun istediği tam set</option>
+      </select>
+    </div>
+
+    <p id="size-summary" class="field-summary"></p>
+    <p id="size-warning" class="field-summary warn" hidden></p>
+  </section>
+
+  <!-- Adım 3 &mdash; biçim -->
+  <section class="card" id="format-card">
+    <h2><span class="step">3</span> Biçimi seçin</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Biçim</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; saydamlığı korur, kenarlar tam</option>
+          <option value="image/jpeg">JPEG &mdash; saydamlık yok, fotoğraflarda daha küçük</option>
+          <option value="image/webp">WebP &mdash; saydamlık ve daha küçük bir dosya</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Kalite &mdash; <output id="quality-value" for="quality">90</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="90">
+        <p class="field-note">
+          Yalnızca JPEG ve WebP için; PNG kayıpsız olduğu için kalite düğmesi
+          yoktur. Düz renk ve sert kenarlar &mdash; bir SVG'nin büyük kısmı
+          bunlardan oluşur &mdash; tam da kayıplı bir kodlayıcının en kötü
+          başardığı şeydir; bu yüzden bu değer burada, bir fotoğrafta olacağından
+          daha yüksek durur.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="background-mode">Arka plan</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Saydam</option>
+          <option value="colour">Bir renk</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Arka plan rengi" hidden>
+        <p class="field-note" id="background-note"></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Adım 4 &mdash; bakın, sonra alın -->
+  <section class="card" id="run-card">
+    <h2><span class="step">4</span> Bakın, sonra kaydedin</h2>
+
+    <p class="card-lede">
+      Ön izleme, dosyayı yazan aynı kod tarafından, seçtiğiniz dosyadan, bu
+      makinede çizilir. Denetlemeye değen şey, bir çizim piksele dönüştüğünde
+      değişen iki şeydir: yarım piksel genişliğindeyken grileşmiş bir saç teli
+      çizgi ve varsa metin; ki o da webden getirilmiş bir yazı tipiyle değil bu
+      makinede bulunan bir yazı tipiyle çizilir.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-stage">
+        <canvas id="preview-canvas"></canvas>
+      </div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <p id="preview-empty" class="field-summary">Bir SVG ekleyin, burada görünsün.</p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Piksele çevir</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Bitti</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Hepsini zip olarak indir</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/svg-to-image.toml
+++ b/locales/tr/tools/svg-to-image.toml
@@ -1,0 +1,313 @@
+#
+# SVG'den Görsele - Türkçe.
+#
+# Overrides for tools/svg-to-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# viewBox, @2x, @3x ve image-set() olduğu gibi kalıyor: biri dosyanın içinde
+# harfi harfine böyle yazar, diğerleri de araçların beklediği dosya adları ve
+# bir CSS işlevidir.
+#
+
+name = "SVG'den Görsele"
+heading = "SVG'den&nbsp;Görsele <span class=\"h1-kw\">&mdash; bir vektörü istediğiniz boyutta PNG, JPEG ya da WebP'ye çevirin</span>"
+tagline = "Boyutu siz söyleyin. Bir vektörün kaybedecek kendi boyutu yok."
+
+title = "SVG'den PNG'ye &mdash; Bir Vektörü İstediğiniz Boyutta Çevirin, Yüklemesiz"
+description = "Bir SVG'yi tarayıcınızda istediğiniz boyutta PNG, JPEG ya da WebP'ye dönüştürün. Genişliği, bir çarpanı ya da bir kutuyu söyleyin; @2x ve @3x kopyalarını da alın. Saydamlık korunur, hiçbir şey yüklenmez."
+og_title = "Bir SVG'yi yüklemeden, istediğiniz boyutta PNG'ye çevirin"
+og_description = "Bir vektörün kendi piksel boyutu yoktur, yani sayıyı siz seçersiniz - 32 ya da 8000, ikisinde de aynı keskinlikte. Hepsi kendi makinenizde çalışır."
+og_image_alt = "SVG'den Görsele - bir vektörü istediğiniz boyutta PNG, JPEG ya da WebP'ye çevirin"
+
+pledge = """
+    Çizim, onu az önce ekranınıza koyan aynı motor tarafından piksele çevrilir.
+    Dosyanız diskinizden okunur, kök etiketi <code>src/svg.js</code> içindeki,
+    okuyabileceğiniz yüz satır tarafından istediğiniz boyuta göre yeniden yazılır
+    ve tarayıcınızın zaten beraberinde getirdiği bir tuvale çizilir. Bu aracın
+    hiçbir türde ağ özelliği yoktur &mdash; getirecek bir şey yok, gönderecek bir
+    şey yok &mdash; ve olsaydı bile bu sayfanın öbür ucunda bir logonun
+    gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir şeyi piksele çevirin. Tek bir istek bile bir dosya, bir küçük
+      resim, bir dosya adı ya da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da
+      internet bağlantısını kesip yine de bir tanesini dönüştürün."""
+
+read_first = """
+, bir dosyanın kendi boyutunun nasıl okunduğu ve kök
+      etiketinin nasıl yeniden yazıldığı için <code>src/svg.js</code> ve piksele
+      çevirme işini yapan sekiz satır için <code>src/render.js</code> &mdash; bir
+      &lt;img&gt;, bir <code>drawImage</code> ve bir <code>toBlob</code>;
+      aralarında başka hiçbir şey yok."""
+
+howto_heading = "Bir SVG, yüklenmeden nasıl PNG'ye dönüştürülür"
+
+card = """
+            Bir SVG'nin kendi piksel boyutu yoktur, yani sayıyı siz seçersiniz
+            &mdash; 32 ya da 8000 ve ikisinde de aynı keskinlikte."""
+
+[words]
+plural = "SVG dosyaları"
+choose = "bir SVG"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Çiziminizin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onları oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir yerde
+      <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Piksele çeviricinin tamamı, kendi dosyanızın
+      bir yığınını tutan bir <code>&lt;img&gt;</code>, bir tuvale tek bir
+      <code>drawImage</code> ve tek bir <code>canvas.toBlob</code>."""
+
+[[privacy]]
+title = "Bir SVG bir belgedir ve bu, onun eyleme geçemediği kiptir."
+body = """
+ Bir SVG bir
+      <code>&lt;script&gt;</code>, uzak bir
+      <code>&lt;image href=&quot;https://&hellip;&quot;&gt;</code>, bir stil
+      sayfası ve bir web yazı tipi taşıyabilir. Bir <code>&lt;img&gt;</code>
+      üzerinden çizildiğinde ise şartnamenin <em>güvenli durağan kip</em> dediği
+      durumdadır: betik çalışmaz ve o adreslerin hiçbiri getirilmez. Bu, bizim bir
+      sözümüz değil tarayıcının bir garantisidir ve bu sayfanın, hiç görmediği bir
+      dosyayı, o dosya eve haber veremeyecek şekilde açabilmesinin sebebi de
+      budur."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine çiziminiz
+      hakkında bir şey verilmiyor. Bir dosyayı okuyan, boyutlandıran ya da çizen
+      her satır bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "SVG'yi seçin."
+body = """
+ Seçiciye bir tane bırakın ya da bir klasör
+      dolusunu seçip hepsini tek seferde dönüştürün. Tarayıcı dosyayı doğrudan
+      diskinizden okur; siz bunu yaparken hiçbir yere hiçbir şey gönderilmez. Her
+      satır, dosyanın kendini hangi boyutta sandığını söyler &mdash; ve o boyut
+      <code>viewBox</code>'ından geldiyse ya da dosya hiçbir şey bildirmediği için
+      varsayıldıysa bunu farklı söyler."""
+
+[[howto]]
+title = "Ne kadar büyük olacağını söyleyin."
+body = """
+ Dosyanın kendi boyutunun bir
+      çarpanı en hızlı cevaptır ve bir yığın için doğru olandır: her çizim kendi
+      başlangıç noktasından ölçeklenir, böylece bir simge seti orantısını korur.
+      Bunun dışında bir genişlik, bir yükseklik, en uzun kenar ya da iki kenarı da
+      verilmiş bir kutu belirtin. Burada büyük bir sayının, bir fotoğraftaki gibi
+      bir bedeli yoktur &mdash; çizim o boyutta yeniden çizilir, o boyuta
+      esnetilmez."""
+
+[[howto]]
+title = "Gerekirse yüksek yoğunluklu kopyaları ekleyin."
+body = """
+ Bir telefon ve bir Retina
+      dizüstü, her CSS pikseli için iki ya da üç cihaz pikseli çizer; yani 200
+      piksellik bir logonun arkasında 400 ya da 600 piksellik bir dosya olmalıdır.
+      <code>@2x</code> ve <code>@3x</code> isteyin; Xcode'un, Android
+      araçlarının ve CSS <code>image-set()</code>'in beklediği adlarla çıksınlar
+      ve her biri ayrı ayrı yuvarlanmak yerine ilkinin tam iki ya da üç katı
+      olsun."""
+
+[[howto]]
+title = "Biçimi seçin ve saydamlığa karar verin."
+body = """
+ Bir sebebiniz yoksa PNG:
+      kayıpsızdır, saydamlığı korur ve düz renk onda iyi sıkışır. JPEG'in hiç
+      saydamlığı yoktur; bu yüzden siz seçseniz de seçmeseniz de bir arka plan
+      rengi boyanır &mdash; o olmadan her saydam piksel siyah çıkar. WebP ikisini
+      de yapar ve daha küçük bir dosya üretir; bedeli, onu okuyamayacak kadar eski
+      yazılımlardır."""
+
+[[howto]]
+title = "İndirmeden önce ön izlemeye bakın."
+body = """
+ Dosyayı yazan aynı kod
+      tarafından, sizin dosyanızdan, sizin makinenizde çizilir. Bir çizim piksele
+      dönüştüğünde iki şey değişir ve ikisi de burada görünür: yarım piksel
+      genişliğindeki bir saç teli çizgi grileşir ve varsa metin, webden getirilmiş
+      bir yazı tipiyle değil bu bilgisayarda bulunan bir yazı tipiyle çizilir."""
+
+[[howto]]
+title = "Dosyaları alın."
+body = """
+ Dosya başına bir indirme ya da yığının tamamı
+      tek bir zip olarak. Adlar geldikleri SVG'yi izler, kopyalarda
+      <code>@2x</code> ve <code>@3x</code> eklenir ve aynı adı alacak iki dosya,
+      biri sessizce diğerinin yerine geçmek yerine numaralandırılır."""
+
+[[faq]]
+q = "SVG'im herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Dosya kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        gördüğünüz diğer her resmi çizen aynı motor tarafından bir tuvale çizilir
+        ve bir indirme olarak geri verilir. Bu aracın hiçbir türde ağ özelliği
+        yoktur &mdash; hiçbir zaman bir şey getirmez ve hiçbir zaman bir şey
+        göndermez &mdash; ve sayfanın <code>Content-Security-Policy</code>'si
+        iletişim kurabileceği her adresi tek tek sayar; bunların hiçbiri bu siteye
+        ait değildir."""
+
+[[faq]]
+q = "Bir SVG'yi hangi boyutta piksele çevirmeliyim?"
+a = """
+        Onu okuyacak şey ne istiyorsa onu; görüleceği ekranın cihaz piksel
+        oranıyla çarpılmış hâlde. 200 CSS pikseli kaplayan bir logonun bir Retina
+        dizüstü için 400, güncel bir telefon için 600 piksele ihtiyacı vardır;
+        buradaki <code>@2x</code> ve <code>@3x</code> kopyaları da budur. Bir
+        uygulama simgesi ya da bir mağaza görseli için mağaza tam bir sayı söyler
+        ve o sayı odur. Size bir şey söylenmediğinde en uzun kenarda 1024 kullanışlı
+        bir varsayılandır: neredeyse her kullanım için yeterince büyük ve
+        e-postayla gönderilecek kadar küçük."""
+
+[[faq]]
+q = "Büyütmek kalite kaybettirir mi?"
+a = """
+        Hayır ve bu cevabın dürüstçe hayır olduğu tek yer burasıdır. Bir vektör
+        piksel değil talimattır; yani tarayıcı eğrileri, istenen boyutta yeniden
+        çizer. 24 piksellik bir simgeden çıkan 4000 piksel, 24'ün olduğu kadar
+        keskindir. Yapamayacağınız şey ters yöne gitmektir: bir kez PNG olduğunda
+        o da diğer her şey gibi pikseldir; bu yüzden sonucu sonradan
+        boyutlandırmak yerine ihtiyacınız olan boyutta piksele çevirin."""
+
+[[faq]]
+q = "SVG'imin genişliği ya da yüksekliği yok. Hangi boyutu alırım?"
+a = """
+        Varsa <code>viewBox</code>'ı &mdash; genişliği ve yüksekliği piksel değil
+        kullanıcı birimidir, ama dosyadaki tek sayılar onlardır ve bir tarayıcı
+        onları çizimin doğal boyutu olarak kabul eder. viewBox da yoksa sayfa,
+        satırın yanında <em>varsayılan</em> der ve bir <code>&lt;img&gt;</code>'in
+        onu çizeceği boyut olan 300&nbsp;&times;&nbsp;150'yi kullanır. Her iki
+        durumda da istediğiniz boyutu söyleyebilirsiniz ve dosya o boyutta
+        çizilir."""
+
+[[faq]]
+q = "PNG'de metin neden farklı görünüyor?"
+a = """
+        Çünkü yazı tipi SVG'nin içinde değildir. Metin çizen bir SVG bir yazı
+        tipini adlandırır ve onu bulmayı makineye bırakır; bir <code>@import</code>
+        ile Google Fonts'tan yazı tipi çeken bir dosya ise burada hiçbir şey alamaz:
+        bir <code>&lt;img&gt;</code> üzerinden çizilen bir SVG'nin hiçbir şey
+        getirmesine izin verilmez ve bu, onun dosyanızla eve haber vermesini
+        engelleyen kuralın aynısıdır. Çözüm, her tasarımcının zaten bildiği şeydir
+        &mdash; dışa aktarmadan önce metni çizim programında yollara dönüştürün. O
+        zaman metin geometridir ve her yerde aynı görünür."""
+
+[[faq]]
+q = "Aynı anda birkaç dosyayı dönüştürebilir mi?"
+a = """
+        Evet. Listedeki her SVG aynı ayarlarla çizilir ve yığın tek bir zip olarak
+        iner. Bir çarpan &mdash; &laquo;dosyanın istediği boyutun 4&times;'i&raquo;
+        &mdash; genellikle bir yığın için doğru ayardır; çünkü her çizim, hepsi
+        aynı piksel sayısına zorlanmak yerine kendi boyutundan ölçeklenir. O
+        dosyayı ön izlemeye koymak için herhangi bir satıra tıklayın."""
+
+[[faq]]
+q = "Bir boyut sınırı var mı?"
+a = """
+        Bizim değil tarayıcının sınırı. Bir tuval, bir kenarda 16.384 pikselin
+        biraz ötesinde pes eder ve iPhone ya da iPad'deki Safari yaklaşık 16,7
+        megapiksel alanda durur &mdash; 4096&nbsp;&times;&nbsp;4096. Bunun
+        üstünde sayfa, size boş bir görüntü vermek yerine uyarır; çünkü bir
+        tarayıcı tükendiğinde yaptığı şey budur: <code>toBlob</code> kendini
+        açıklayan bir hata bile vermeden hiçbir şey döndürür. 100 megapikselin
+        ötesinde araç reddeder, çünkü bu, tek bir bayt kodlanmadan önce
+        400&nbsp;MB tuval demektir."""
+
+[[faq]]
+q = "Saydamlığa ne oluyor?"
+a = """
+        PNG'de ve WebP'de korunur. JPEG'in hiç alfa kanalı yoktur; bu yüzden siz
+        isteseniz de istemeseniz de resmin tamamının arkasına bir renk boyanır
+        &mdash; o olmadan saydam olan her şey siyah çıkardı ki bu, JPEG'e değil
+        bir hataya benzer. PNG ile bir arka plan rengi seçmek de gayet olağan bir
+        istektir: çizimi bir delik bırakmak yerine o renge düzleştirir."""
+
+[[faq]]
+q = "İçinde betik ya da dış görsel olan bir SVG'yi okuyabilir mi?"
+a = """
+        Bir tanesini okuyabilir ve tam olarak bir tarayıcının çizmeye razı olduğu
+        parçaları çizer. Bir <code>&lt;img&gt;</code> üzerinden yüklenen bir SVG
+        <em>güvenli durağan kip</em>tedir: betikler çalışmaz, dış başvurular
+        getirilmez ve animasyon oynamaz &mdash; aldığınız şey ilk karedir. Yani
+        içinde uzak bir <code>&lt;image&gt;</code> olan bir dosya, o parça eksik
+        çıkar. Bu, tarayıcının sizin adınıza reddetmesidir ve bu sayfanın hiç
+        görmediği bir dosyayı güvenle açabilmesinin sebebidir."""
+
+[[faq]]
+q = "Bununla Görsel Boyutlandırıcı arasındaki fark ne?"
+a = """
+        Kaynağın ne olduğu. Görsel Boyutlandırıcı piksellerden başlar &mdash; bir
+        JPEG, bir PNG &mdash; yani onu büyütmek, hiç orada olmamış bir ayrıntıyı
+        uydurmak zorundadır. Bu araç ise bir çizimden başlar; yani uydurulacak bir
+        şey ve endişelenmeye değer bir üst sınır yoktur. Elinizdeki bir SVG ise
+        keskin bir sonuç veren budur; elinizdeki bir fotoğrafsa öbürüdür."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok.
+        Dosyaların sayısında ya da boyutunda da bir sınır yok, çünkü bunların
+        bedelini ödeyen bir sunucu yok &mdash; iş sizin kendi cihazınızda oluyor.
+        Sitede reklam var, masrafı karşılayan da o; reklamlara dosyalarınız
+        hakkında hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: çiziminizi çizilmek üzere uzağa gönderen bir
+        araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "Bir SVG'yi tarayıcıda istediğiniz boyutta PNG, JPEG ya da WebP'ye çevirin. Boyutu bir çarpanla, bir genişlikle, bir yükseklikle, en uzun kenarla ya da bir kutuyla belirleyin; @2x ve @3x kopyaları ekleyin; saydamlığı koruyun ya da düzleştirin ve bir yığını tek seferde dönüştürün. Hiçbir şey yüklenmez."
+features = [
+  "Vektörü her boyutta yeniden çizer, böylece sonuç hepsinde keskin olur",
+  "Bir çarpanla, bir genişlikle, bir yükseklikle, en uzun kenarla ya da yerleşimli bir kutuyla boyut",
+  "@2x ve @3x kopyaları; her biri iki kez yuvarlanmak yerine ilkinin tam katı",
+  "PNG, JPEG ve WebP; saydamlık korunmuş ya da bir renge düzleştirilmiş hâlde",
+  "Boyutu width, height ya da viewBox'tan okur ve hangisini kullandığını söyler",
+  "Bir tarayıcı tuvalinin gerçekte üretemeyeceği bir boyuttan önce uyarır",
+  "Ön izleme, dosyayı yazan aynı kod tarafından çizilir",
+  "Toplu işlem, tüm sonuçlar tek bir zip içinde",
+  "Dosyadaki betikler ve dış başvurular hiçbir zaman çalıştırılmaz ya da getirilmez",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Bir SVG'yi buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; bir seferde birkaç tane de olur"

--- a/locales/tr/tools/text-tools.html
+++ b/locales/tr/tools/text-tools.html
@@ -1,0 +1,206 @@
+<!--
+  tools/text-tools/body.html, in Turkish.
+
+  Every id, class, role, data-mode and option value below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dört işten hangisi -->
+  <section class="card">
+    <h2><span class="step">1</span> İşi seçin</h2>
+
+    <!--
+      A tab strip rather than four pages, because the four jobs share an input:
+      the JSON you just formatted is the JSON you want to diff against the one
+      from the other branch, and retyping it into a second tool is the thing
+      this arrangement exists to avoid. `role="tablist"` and the arrow keys are
+      wired in main.js.
+    -->
+    <div class="tabs" role="tablist" aria-label="Metinle ne yapılacak">
+      <button type="button" role="tab" id="tab-format" class="tab" data-mode="format"
+              aria-selected="true" aria-controls="options-format">Biçimlendir</button>
+      <button type="button" role="tab" id="tab-convert" class="tab" data-mode="convert"
+              aria-selected="false" tabindex="-1" aria-controls="options-convert">Dönüştür</button>
+      <button type="button" role="tab" id="tab-encode" class="tab" data-mode="encode"
+              aria-selected="false" tabindex="-1" aria-controls="options-encode">Kodla</button>
+      <button type="button" role="tab" id="tab-diff" class="tab" data-mode="diff"
+              aria-selected="false" tabindex="-1" aria-controls="options-diff">Karşılaştır</button>
+    </div>
+
+    <div class="settings" id="options-format" role="tabpanel" aria-labelledby="tab-format">
+      <div class="field">
+        <label for="language">Dil</label>
+        <select id="language">
+          <option value="auto" selected>Metinden kendisi bulsun</option>
+          <option value="json">JSON</option>
+          <option value="xml">XML</option>
+          <option value="html">HTML</option>
+          <option value="css">CSS</option>
+          <option value="yaml">YAML</option>
+        </select>
+        <p class="field-note" id="language-note">
+          Tahmin yalnızca bir başlangıç noktasıdır ve düzeltmek tek tıklamadır.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="indent">Girinti</label>
+        <select id="indent">
+          <option value="2" selected>İki boşluk</option>
+          <option value="4">Dört boşluk</option>
+          <option value="tab">Bir sekme</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="style">Düzen</label>
+        <select id="style">
+          <option value="pretty" selected>Düzenli yaz</option>
+          <option value="minify">Düz sıkıştır</option>
+        </select>
+        <p class="field-note" id="style-note"></p>
+      </div>
+
+      <div class="field checks">
+        <label class="check" for="sort-keys">
+          <input type="checkbox" id="sort-keys">
+          Her nesnenin anahtarlarını sırala
+        </label>
+        <p class="field-note">
+          Kod noktalarına göre değil anahtarların okunuşuna göre; yani
+          <code>item2</code>, <code>item10</code>'dan önce gelir. Yalnızca JSON.
+        </p>
+      </div>
+    </div>
+
+    <div class="settings" id="options-convert" role="tabpanel" aria-labelledby="tab-convert" hidden>
+      <div class="field">
+        <label for="conversion">Dönüştür</label>
+        <select id="conversion"></select>
+        <p class="field-note" id="conversion-note"></p>
+      </div>
+
+      <div class="field" id="root-field" hidden>
+        <label for="root-name">Dıştaki öğenin adı</label>
+        <input type="text" id="root-name" value="root" spellcheck="false" autocomplete="off">
+        <p class="field-note">
+          XML'in en üstte tek bir öğesi vardır, JSON'un yoktur; yani birinin
+          uydurulması gerekir.
+        </p>
+      </div>
+    </div>
+
+    <div class="settings" id="options-encode" role="tabpanel" aria-labelledby="tab-encode" hidden>
+      <div class="field">
+        <label for="codec">Kodlama</label>
+        <select id="codec"></select>
+        <p class="field-note" id="codec-note"></p>
+      </div>
+
+      <div class="field">
+        <fieldset class="modes">
+          <legend>Hangi yöne</legend>
+          <label class="mode">
+            <input type="radio" name="direction" value="encode" checked>
+            <span><strong>Kodla</strong> Düz metin girer, kodlanmış çıkar.</span>
+          </label>
+          <label class="mode">
+            <input type="radio" name="direction" value="decode">
+            <span><strong>Çöz</strong> Kodlanmış girer, düz metin çıkar.</span>
+          </label>
+        </fieldset>
+      </div>
+    </div>
+
+    <div class="settings" id="options-diff" role="tabpanel" aria-labelledby="tab-diff" hidden>
+      <div class="field">
+        <label for="view">Nasıl gösterilsin</label>
+        <select id="view">
+          <option value="split" selected>Yan yana</option>
+          <option value="unified">Tek sütun</option>
+        </select>
+      </div>
+
+      <div class="field checks">
+        <label class="check" for="only-changes">
+          <input type="checkbox" id="only-changes" checked>
+          Yalnızca değişeni göster, iki yanında üçer satırla
+        </label>
+        <label class="check" for="ignore-whitespace">
+          <input type="checkbox" id="ignore-whitespace">
+          Boşlukları yok say
+        </label>
+        <label class="check" for="ignore-case">
+          <input type="checkbox" id="ignore-case">
+          Büyük ve küçük harfi yok say
+        </label>
+        <label class="check" for="ignore-blank">
+          <input type="checkbox" id="ignore-blank">
+          Boş satırları yok say
+        </label>
+      </div>
+    </div>
+  </section>
+
+  <!-- Adım 2 &mdash; metnin kendisi -->
+  <section class="card">
+    <h2><span class="step">2</span> Yapıştırın</h2>
+
+    <!--
+      The picker is here for the file that is easier to drop than to open,
+      select all and copy. Nothing about it leaves the machine: the file is
+      read with FileReader into the box below, and that is the whole journey.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div class="panes" id="panes">
+      <div class="pane">
+        <div class="pane-head">
+          <label for="input" id="input-label">Metniniz</label>
+          <span class="count" id="input-count">boş</span>
+        </div>
+        <textarea id="input" spellcheck="false" autocomplete="off" autocapitalize="off"
+                  autocorrect="off" wrap="off"
+                  placeholder="JSON, XML, HTML, CSS ya da YAML'ı buraya yapıştırın - ya da yukarıya bir dosya bırakın."></textarea>
+      </div>
+
+      <div class="pane" id="pane-b" hidden>
+        <div class="pane-head">
+          <label for="input-b">Öteki</label>
+          <span class="count" id="input-b-count">boş</span>
+        </div>
+        <textarea id="input-b" spellcheck="false" autocomplete="off" autocapitalize="off"
+                  autocorrect="off" wrap="off"
+                  placeholder="Karşılaştırılacak sürümü yapıştırın."></textarea>
+      </div>
+    </div>
+
+    <div class="toolbar">
+      <p class="count" id="detected"></p>
+      <div class="toolbar-actions">
+        <button type="button" id="sample" class="ghost">Bir örnek dene</button>
+        <button type="button" id="swap" class="ghost" hidden>Yanları değiştir</button>
+        <button type="button" id="clear" class="ghost danger">Temizle</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; ne çıktı -->
+  <section class="card">
+    <h2><span class="step">3</span> Sonucu alın</h2>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div class="toolbar">
+      <p class="count" id="result-note">Henüz bir şey yok.</p>
+      <div class="toolbar-actions">
+        <button type="button" id="copy" class="ghost" disabled>Kopyala</button>
+        <a id="download" class="ghost as-button" hidden download>İndir</a>
+      </div>
+    </div>
+
+    <pre id="output" class="output" tabindex="0"></pre>
+
+    <div id="diff-view" class="diff" hidden></div>
+  </section>
+</main>

--- a/locales/tr/tools/text-tools.toml
+++ b/locales/tr/tools/text-tools.toml
@@ -1,0 +1,337 @@
+#
+# Metin ve Kod - Türkçe.
+#
+# Overrides for tools/text-tools/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# Biçim adları (JSON, XML, HTML, CSS, YAML, Base64), komut adları (git diff,
+# git apply, patch) ve dosya adları olduğu gibi kalıyor: bunlar yazılan ve
+# aranan adlar. "diff" için karşılaştırma, indirilen dosya için de yama.
+#
+
+name = "Metin ve Kod"
+heading = "Metin&nbsp;ve&nbsp;kod <span class=\"h1-kw\">&mdash; biçimlendirici, karşılaştırıcı, kodlayıcı ve dönüştürücü</span>"
+tagline = "Düzenli yazdırın, neyin değiştiğini görün, kodlayın ya da öbür biçime çevirin. Hiçbir şey bir başkasının sunucusuna yapıştırılmıyor."
+
+title = "JSON Biçimlendirici, Metin Karşılaştırma, Base64 ve YAML Dönüştürücü &mdash; Yüklemesiz"
+description = "JSON, XML, HTML, CSS ve YAML biçimlendirin, iki metni satır satır karşılaştırın, Base64 veya URL kodlayın ve JSON'u YAML ya da XML'e çevirin. Hepsi tarayıcınızda çalışır &mdash; hiçbir şey yüklenmez."
+og_title = "Metni bir sunucuya yapıştırmadan biçimlendirin, karşılaştırın, kodlayın ve dönüştürün"
+og_description = "Tek sayfada bir JSON biçimlendirici, bir karşılaştırıcı, bir kodlayıcı ve bir dönüştürücü; hepsi kendi makinenizde çalışıyor. Bir belirteci ya da bir yapılandırma dosyasını kimseye vermeden yapıştırın."
+og_image_alt = "Metin ve Kod - biçimlendirici, karşılaştırıcı, kodlayıcı ve dönüştürücü, yükleme yok"
+
+pledge = """
+    Dört işin de her biri, burada, bu sayfada yapılan, bir dizge üzerinde bir
+    aritmetiktir. Ayrıştırıcılar elle yazılmıştır ve <code>src/</code> içindedir
+    &mdash; <code>json.js</code>, <code>xml.js</code>, <code>css.js</code>,
+    <code>yaml.js</code> &mdash; karşılaştırma ise <code>diff.js</code> içindeki
+    Myers algoritmasıdır, <code>git diff</code>'in kullandığının aynısı. Bu aracın
+    hiçbir türde ağ özelliği yoktur &mdash; getirecek bir şey yok, gönderecek bir
+    şey yok &mdash; ve bu, sitenin başka hiçbir yerinde olmadığı kadar burada
+    önemlidir: insanların bir biçimlendiriciye yapıştırdığı şeyler erişim
+    belirteçleri, oturum çerezleri, müşteri kayıtları ve yayımlanmamış
+    kodlardır."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir şey biçimlendirin. Tek bir istek bile yapıştırdığınız şeyden
+      tek bir karakter taşımıyor. Ya da internet bağlantısını kesip yine de
+      biçimlendirin."""
+
+read_first = """
+, anahtarlarınızı yazdığınız sırada tutan
+      ayrıştırıcı için <code>src/json.js</code> ve karşılaştırma için
+      <code>src/diff.js</code> &mdash; yaklaşık iki yüz satır ve bu sayfanın
+      içinde en çok aritmetik barındıran kısım."""
+
+howto_heading = "Metin yüklemeden nasıl biçimlendirilir, karşılaştırılır ya da kodlanır"
+
+card = """
+            Tek sayfada bir JSON biçimlendirici, bir karşılaştırıcı, bir
+            kodlayıcı ve bir dönüştürücü. Bir belirteci ya da bir yapılandırma
+            dosyasını kimseye vermeden yapıştırın."""
+
+[words]
+plural = "metin ve kod"
+choose = "bir dosya"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Boyut sınırı yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Yapıştırdığınız şeyin gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu
+      sayfanın iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri
+      bu siteye ait değildir. Yapıştırılan bir belirtecin toplanabileceği bir uç
+      nokta burada yok, olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ <code>src/</code> içinde hiçbir
+      yerde <code>fetch</code>, <code>XMLHttpRequest</code> ya da
+      <code>sendBeacon</code> yok. Her ayrıştırıcı, her kodlayıcı ve
+      karşılaştırma, bu sayfada bir dizge alıp bir dizge döndüren
+      işlevlerdir."""
+
+[[privacy]]
+title = "Biçimlendiriciler kendilerine verileni koruyor."
+body = """
+ Bir JSON nesnesi,
+      anahtarları yazdığınız sırada ve sayıları yazdığınız gibi geri gelir; çünkü
+      <code>src/json.js</code>, tamsayı benzeri anahtarları yeniden sıralayan ve
+      yirmi haneli bir kimliği en yakın çift duyarlıklı sayıya çeviren
+      <code>JSON.parse</code> çağrısı değil, bir ayrıştırıcıdır.
+      <code>tests/js/text-format.test.js</code> içindeki testler tam olarak bunu
+      denetler."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan, bağış düğmesi de Buy Me a Coffee'den geliyor. Hiçbirine
+      metninizden tek bir karakter verilmiyor. Onu okuyan, ayrıştıran ya da yazan
+      her satır bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araç hiç değişmez;
+      çünkü içinde en baştan beri bir ağ adımı yoktu. Hepsinin içindeki en basit
+      kanıt bu."""
+
+[[howto]]
+title = "İşi seçin."
+body = """
+ Dört sekme ve hepsi tek bir kutuyu paylaşıyor:
+      <em>Biçimlendir</em>, JSON, XML, HTML, CSS ve YAML'ı düzenli yazar ya da
+      sıkıştırır; <em>Dönüştür</em>, JSON'u YAML veya XML'e ve geri çevirir;
+      <em>Kodla</em>, Base64, URL, HTML varlıkları, onaltılık ve ters bölü
+      kaçışlarını iki yönde de yapar; <em>Karşılaştır</em>, iki metin arasında
+      neyin değiştiğini gösterir."""
+
+[[howto]]
+title = "Yapıştırın ya da dosyayı bırakın."
+body = """
+ Seçip kopyalayabildiğiniz her şey
+      olur. Seçiciye bırakılan bir dosya kendi tarayıcınız tarafından okunur ve
+      kutuya konur &mdash; dışarıda bırakılacak bir yükleme adımı yok.
+      Karşılaştırırken iki dosya bırakın, biri bir yana biri öbür yana düşsün."""
+
+[[howto]]
+title = "Dili o bulsun ya da siz söyleyin."
+body = """
+ Menü, metni ne olarak okuduğunu
+      söyler ve düzeltmek tek tıklamadır. Bir tahmin yalnızca bir başlangıç
+      noktasıdır; sessizce uygulanmak yerine gösterilmesinin sebebi de budur."""
+
+[[howto]]
+title = "Girintiyi seçin ya da düz sıkıştırın."
+body = """
+ İki boşluk, dört ya da bir
+      sekme. Düz sıkıştırmak, yalnızca okumak için orada olan her boşluğu
+      çıkarılmış aynı belgedir ve sonuç bunun kaç bayt kazandırdığını söyler."""
+
+[[howto]]
+title = "Hatayı, hatanın olduğu yerde okuyun."
+body = """
+ Burada çuvallayan bir
+      ayrıştırıcı, "4193. konumda beklenmedik belirteç" demek yerine ne bulduğunu
+      ve hangi satır ile sütunda bulduğunu söyler. Bu genellikle başka hiçbir şey
+      açmadan bir yapılandırma dosyasını düzeltmeye yeter."""
+
+[[howto]]
+title = "Sonucu alın."
+body = """
+ Kopyalayın ya da dosya olarak indirin. Bir
+      karşılaştırma, birleşik biçimde bir <code>.patch</code> olarak iner; bir kod
+      incelemesinin, <code>git apply</code>'ın ve her karşılaştırma
+      görüntüleyicisinin beklediği de budur."""
+
+[[faq]]
+q = "Metnim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Bu sayfadaki her ayrıştırıcı, kodlayıcı ve karşılaştırma, kendi
+        donanımınızda, kendi tarayıcınızda çalışan bir işlevdir. Bu aracın hiçbir
+        türde ağ özelliği yoktur &mdash; hiçbir zaman bir şey getirmez ve hiçbir
+        zaman bir şey göndermez &mdash; ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar; bunların hiçbiri bu siteye ait değildir. Bunu bir erişim
+        belirteci, bir oturum çerezi ya da bir müşteri kaydı için kullanmanın
+        sebebi budur: bunlardan birini bir başkasının biçimlendiricisine
+        yapıştırmak, onu ona vermektir."""
+
+[[faq]]
+q = "JSON biçimlendirmek düzenden başka bir şeyi değiştirir mi?"
+a = """
+        Hayır ve bu kulağa geldiğinden zordur. Anahtarlar yazdığınız sırayı korur
+        &mdash; <code>JSON.parse</code> üzerine kurulmuş bir biçimlendirici,
+        tamsayı benzeri anahtarları sessizce öne alır; yani
+        <code>{"10":a,"2":b}</code>, <code>{"2":b,"10":a}</code> olarak geri
+        gelir. Sayılar yazdığınız haneleri korur; yani yirmi haneli bir kimlik son
+        üç hanesini bir çift duyarlıklı sayıya kaptırmaz ve <code>1e999</code>,
+        <code>null</code> olmaz. Yinelenen anahtarların ikisi de tutulur; çünkü
+        standart hangisinin kazandığını söylemez ve birini düşürmek, sizin yerinize
+        seçmek olurdu."""
+
+[[faq]]
+q = "Hangi dilleri biçimlendirebiliyor?"
+a = """
+        JSON, XML, HTML, CSS ve YAML. JSON, XML, HTML ve CSS ayrıca düz de
+        sıkıştırılabilir; YAML sıkıştırılamaz, çünkü onun kısa biçimi akış
+        biçimidir, o da okunmazdır ve okunmazlık, bir dosyayı YAML'da tutmanın
+        sebebinin tam tersidir. JavaScript bilinçli olarak listede değil &mdash;
+        aşağıdaki ilgili soruya bakın."""
+
+[[faq]]
+q = "Neden JavaScript, Python ya da SQL biçimlendirmiyor?"
+a = """
+        Çünkü bir programlama dilini düzenli yazmak, onu düzgünce ayrıştırmak
+        demektir ve neredeyse doğru yapan bir biçimlendirici, hiç olmamasından
+        kötüdür: iyi görünen ama başka bir şey yapan kod üretir. JSON, XML, CSS ve
+        YAML'ın dil bilgisi, elle okunacak ve çalıştırabileceğiniz testlerle
+        denetlenecek kadar küçüktür. Bir JavaScript biçimlendiricisi Prettier'dır;
+        o da bir megabaytlık ayrıştırıcıdır ve bir web sayfasında değil, sizin
+        düzenleyicinizde durması gerekir."""
+
+[[faq]]
+q = "Karşılaştırma tam olarak ne yapıyor?"
+a = """
+        Soldaki metni sağdakine çeviren en kısa düzenleme kümesini, Myers
+        algoritmasıyla bulur &mdash; <code>git diff</code>'in kullandığı algoritma.
+        Bir karşılaştırmayı okunur kılan şey en kısa olmasıdır: ortaya eklenmiş bir
+        satır, ondan sonraki her satır değişmiş gibi değil tek bir ekleme olarak
+        görünmelidir. Değişmiş bir satırın içinde farklı olan kelimeler de
+        işaretlenir; yani iki paragrafın karşılaştırması, iki koca paragrafı değil
+        yer değiştiren kelimeyi gösterir."""
+
+[[faq]]
+q = "İki yapıştırma yerine iki dosyayı karşılaştırabilir mi?"
+a = """
+        Evet. Karşılaştır sekmesi açıkken ikisini birden seçiciye bırakın; bıraktığınız
+        sırayla biri bir yana biri öbür yana düşer. Tarayıcınız tarafından bu sayfaya
+        okunurlar; gittikleri tek yer de burasıdır. Ters bıraktıysanız yanları
+        değiştirin."""
+
+[[faq]]
+q = "Bir karşılaştırmadan ne çıkıyor ve onu uygulayabilir miyim?"
+a = """
+        İnen dosya birleşik bir karşılaştırmadır &mdash; <code>git apply</code>,
+        <code>patch</code> ve her kod inceleme aracının okuduğu
+        <code>@@ -3,5 +3,5 @@</code> biçimi. Kopyala da panonuza aynı şeyi yapar.
+        Ekranda gördüğünüz onun bir görünümüdür: yan yana ya da tek sütunda,
+        hepsini istemediğiniz sürece değişmemiş kısımlar bir sayıya
+        katlanmış hâlde."""
+
+[[faq]]
+q = "Buradaki Base64, başka her yerdekiyle aynı Base64 mü?"
+a = """
+        Evet &mdash; kendisine karşı değil, RFC 4648'deki test vektörlerine karşı
+        denetleniyor. İki alfabe de çözülür; yani <code>-</code> ve <code>_</code>
+        ile yazılmış bir JWT, <code>+</code> ve <code>/</code> ile yazılmış biri
+        kadar kolay okunur ve 64 karakterde satır sonuna sarılmış girdi sizin için
+        açılır. Kodlama UTF-8 baytları üzerinden yapılır; yani şapkalı bir harf ya
+        da bir emoji gidiş dönüşten sağ çıkar."""
+
+[[faq]]
+q = "YAML'ımda no yazıyor, JSON'da dizge olarak çıktı. Neden?"
+a = """
+        Çünkü o bir dizgedir ve bu araç YAML'ı 1.1 olarak değil 1.2 olarak okur.
+        YAML 1.1'de <code>yes</code>, <code>no</code>, <code>on</code> ve
+        <code>off</code> mantıksal değerlerdi; Norveç'in ülke kodunu
+        <code>false</code>'a çeviren o meşhur hata da budur. YAML 1.2 bundan
+        vazgeçti, bu araç da öyle: metinden başka bir şey olarak okunanlar yalnızca
+        <code>true</code>, <code>false</code>, <code>null</code> ve
+        <code>~</code>'dir. Ters yönde ise bu kelimeler <em>tırnak içinde</em>
+        yazılır; bu araç onları tırnaksız da metin olarak okuyacak olsa bile
+        &mdash; çünkü dosyayı sonra açan şey okumayabilir. PyYAML hâlâ varsayılan
+        olarak 1.1 kullanıyor. Katı okuyup ihtiyatlı yazmak, iki durumda da doğru
+        olan tek birleşimdir."""
+
+[[faq]]
+q = "YAML'ı JSON'a çevirmek neyi kaybettirir?"
+a = """
+        Yorumları; çünkü JSON'un bir yorumu koyacak yeri yok. Bağlantı noktaları,
+        takma adlar ve etiketler tahmin edilmek yerine düpedüz reddedilir &mdash;
+        her biri JSON'un söyleyemeyeceği bir şey söyler ve sessizce bir yorum seçen
+        bir dönüştürücü, size dosyanın söylediği şey olmayan bir belge verirdi. Ters
+        yön hiçbir şey kaybettirmez: her JSON belgesi zaten bir YAML belgesidir."""
+
+[[faq]]
+q = "JSON'u XML'e çevirmek neyi kaybettirir?"
+a = """
+        Boş bir nesne, boş bir dizi ve boş bir dizge arasındaki farkı &mdash;
+        hepsi boş bir öğeye dönüşür &mdash; ve her değerin türünü; çünkü XML'in
+        türleri yoktur. Ters dönüşümün <code>8080</code>'in bir sayı olduğuna karar
+        vermek yerine her şeyi dizge bırakmasının sebebi de budur. Bir dizi,
+        yinelenen bir öğeye dönüşür &mdash; geri okunan tek şekil odur &mdash; ve
+        bir öğe adının taşıyamayacağı bir anahtarın sorunlu karakterleri,
+        hiçbir ayrıştırıcının okumayacağı bir belge olarak çıkmak yerine
+        değiştirilir."""
+
+[[faq]]
+q = "HTML'i yeniden girintilemek sayfanın görünüşünü değiştirir mi?"
+a = """
+        Değiştirebilir ve bu araç bu konuda dürüsttür. İki satır içi öğe arasındaki
+        boşluk, iki kelime arasındaki bir boşluktur; yani onu oynatmak bedelsiz
+        değildir. İki şey bunu dizginler: <code>&lt;pre&gt;</code> ve
+        <code>&lt;textarea&gt;</code> tam olduğu gibi kopyalanır ve metinden başka
+        bir şey içermeyen bir öğe tek satırda kalır. Geri kalan her şey düzenli
+        yazılır."""
+
+[[faq]]
+q = "Ne kadar büyük bir dosyayı kaldırabiliyor?"
+a = """
+        Burada konmuş bir sınır yok; çünkü bunun bedelini ödeyen bir sunucu yok.
+        Pratikteki tavan kendi makinenizdir: birkaç megabaytlık JSON gayet iyidir.
+        Ortak hiçbir yanı olmayan iki metnin karşılaştırması, zaten apaçık olanı
+        kanıtlamak için bir dakika harcamak yerine erken durur ve bunu söyler; çok
+        uzun bir karşılaştırma ise ilk birkaç bin satırı çizer ve gerisini indirilen
+        yamaya bırakır."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok ve ne kadar
+        yapıştırdığınıza dair bir sınır yok. Sitede reklam var, masrafı karşılayan
+        da o; reklamlara metniniz hakkında hiçbir şey verilmiyor."""
+
+[[faq]]
+q = "Çevrimdışı çalışıyor mu?"
+a = """
+        Evet. Sayfayı bir kez yükleyin, sonra internet bağlantısını kesin,
+        çalışmaya devam eder. Bu aynı zamanda hiçbir şeyin yüklenmediğini
+        kanıtlamanın en basit yolu: metninizi biçimlendirilmek üzere uzağa gönderen
+        bir araç, siz fişi çeker çekmez dururdu."""
+
+[schema]
+description = "JSON, XML, HTML, CSS ve YAML biçimlendirin ve küçültün, iki metni satır ve kelime düzeyinde karşılaştırın, Base64, URL, HTML varlıkları ve onaltılık kodlayıp çözün, JSON'u YAML ya da XML'e ve geri çevirin. Her şey tarayıcıda çalışır ve hiçbir şey yüklenmez."
+features = [
+  "JSON, XML, HTML ve CSS'i biçimlendirir ve küçültür, YAML'ı düzenli yazar",
+  "JSON anahtarlarının sırasını ve her sayının tam hanelerini korur",
+  "Bir hatanın hangi satır ve sütunda olduğunu kelimelerle söyler",
+  "İki metni Myers algoritmasıyla, yan yana ya da tek sütunda karşılaştırır",
+  "Değişmiş bir satırın içinde değişen kelimeleri işaretler",
+  "Bir karşılaştırmayı, bir kod incelemesinin okuyabileceği birleşik yama olarak indirir",
+  "İki alfabede Base64, yüzde kodlaması, HTML varlıkları, onaltılık ve ters bölü kaçışları",
+  "JSON'u YAML ve XML'e ve geri çevirir, her yönün neyi kaybettirdiğini söyler",
+  "YAML 1.2 okur; yani yes ve no dizge kalır",
+  "Yapıştırmanın yanı sıra bırakılan bir dosya üzerinde de çalışır",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Bir dosyayı buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; herhangi bir metin dosyası. Karşılaştırırken iki tane."

--- a/locales/tr/tools/timelapse-video.html
+++ b/locales/tr/tools/timelapse-video.html
@@ -1,0 +1,161 @@
+<!--
+  tools/timelapse-video/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosya -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir video seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div class="preview-wrap" id="preview-wrap" hidden>
+      <video id="preview" playsinline controls muted></video>
+      <canvas id="still" hidden></canvas>
+    </div>
+    <p id="preview-note" class="path-note" hidden></p>
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Dosya</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Boyut</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Kare</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Kare hızı</dt><dd id="src-fps">&mdash;</dd></div>
+      <div><dt>Görüntü</dt><dd id="src-codec">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; hız -->
+  <section class="card" id="speed-card" hidden>
+    <h2><span class="step">2</span> Hızı seçin</h2>
+
+    <div class="speed-row" role="group" aria-label="Klip ne kadar hızlandırılsın">
+      <button type="button" data-speed="2">2&times;</button>
+      <button type="button" data-speed="5">5&times;</button>
+      <button type="button" data-speed="10" class="active">10&times;</button>
+      <button type="button" data-speed="20">20&times;</button>
+      <button type="button" data-speed="30">30&times;</button>
+      <button type="button" data-speed="60">60&times;</button>
+      <button type="button" data-speed="120">120&times;</button>
+      <button type="button" data-speed="300">300&times;</button>
+    </div>
+
+    <!--
+      Two ways of saying the same thing, because people arrive with one of two
+      questions: "speed this up thirty times" and "make this fit in twenty
+      seconds". Typing in either box fills in the other.
+    -->
+    <div class="numbers">
+      <label>Hız
+        <span class="with-unit">
+          <input type="number" id="speed" min="1.1" max="1000" step="0.1" value="10">
+          <span class="unit">&times;</span>
+        </span>
+      </label>
+      <label>Bitmiş süre
+        <span class="with-unit">
+          <input type="number" id="length" min="0.1" step="0.1">
+          <span class="unit">sn</span>
+        </span>
+      </label>
+    </div>
+
+    <p class="interval-note" id="interval-note"></p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="fps">Oynatma hızı</label>
+        <select id="fps">
+          <option value="24">saniyede 24 kare</option>
+          <option value="30" selected>saniyede 30 kare</option>
+          <option value="60">saniyede 60 kare</option>
+        </select>
+        <p class="field-note">
+          Bitmiş klibin oynadığı hız. Klibin ne kadar hızlı olduğunu değiştirmez
+          &mdash; onu yukarıdaki hız belirler &mdash; yalnızca ne kadar akıcı
+          göründüğünü.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="size">Boyut</label>
+        <select id="size">
+          <option value="0" selected>Orijinal boyut</option>
+          <option value="1080">1080p</option>
+          <option value="720">720p</option>
+          <option value="480">480p</option>
+        </select>
+        <p class="field-note" id="size-note">
+          Yalnızca küçültür. Bir time-lapse genellikle küçük izlenir.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Kalite</label>
+        <select id="quality">
+          <option value="low">Daha küçük dosya</option>
+          <option value="medium" selected>Dengeli</option>
+          <option value="high">En iyi kalite</option>
+        </select>
+        <p class="field-note">
+          Buradaki video araçlarının genelde harcadığından yüksek, çünkü bir
+          time-lapse'in ardışık karelerinin sıkıştırılıp atılacak ortak yanı
+          azdır.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; dışa aktarma -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Time-lapse'i yapın</h2>
+
+    <dl class="summary" id="summary">
+      <div><dt>Tutulan kare</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Kare aralığı</dt><dd id="sum-interval">&mdash;</dd></div>
+      <div><dt>Bitmiş süre</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Çıktı karesi</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Okuma</dt><dd id="sum-read">&mdash;</dd></div>
+      <div><dt>Yaklaşık</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-note" class="path-note" hidden></p>
+
+    <p class="silent-note">
+      Sonuçta ses yoktur. Otuz kat hızlandırılmış konuşma ve müzik, konuşma ve
+      müzik değildir; yani burada tutmaya değer bir şey yok &mdash; ve onu
+      atmak, bir saatin time-lapse'inin birkaç megabayt olarak çıkmasının
+      sebebidir.
+    </p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Time-lapse yap</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline loop></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Time-lapse'i indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/timelapse-video.toml
+++ b/locales/tr/tools/timelapse-video.toml
@@ -1,0 +1,255 @@
+#
+# Time-Lapse Yapıcı - Türkçe.
+#
+# Overrides for tools/timelapse-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Time-lapse" Türkçede de bu şekilde yerleşmiş; "hızlandırılmış çekim" tarifi
+# doğru ama insanların arattığı kelime bu değil. Slug ve ad Latin harflerinde
+# kalıyor, locale.toml'un başındaki kısaltma kuralıyla aynı gerekçeyle.
+#
+
+name = "Time-Lapse Yapıcı"
+heading = "Time&#8209;Lapse&nbsp;Yapıcı <span class=\"h1-kw\">&mdash; uzun bir videoyu hızlandırın</span>"
+tagline = "Bir saatlik görüntü, yirmi saniyede."
+
+title = "Time-Lapse Video Yapıcı &mdash; Ücretsiz, Yüklemesiz, Çevrimdışı Çalışır"
+description = "Uzun bir videoyu time-lapse'e çevirin: 10 kat, 60 kat ya da yazdığınız herhangi bir hız. Tarayıcınızda çalışır, yani hiçbir şey yüklenmez, filigran yoktur ve çevrimdışı da çalışır."
+og_title = "Time-Lapse Yapıcı &mdash; bir videoyu yüklemeden hızlandırın"
+og_description = "Uzun bir klipten birkaç saniyede bir kare alın ve onları kısa bir klip olarak geri yazın. Dosyayı kendi tarayıcınız okur, çözer ve kodlar."
+og_image_alt = "Time-Lapse Yapıcı - uzun bir videoyu tarayıcınızda hızlandırın, hiçbir şey yüklenmesin"
+
+pledge = """
+    Her kare kendi tarayıcınız tarafından, kendi donanımınızda seçilir, çözülür
+    ve yeniden kodlanır. Buradaki hiçbir şey bir şey getiremez ya da gönderemez
+    &mdash; bu araçta hiçbir türde ağ özelliği yok &mdash; ve olsaydı bile bu
+    sayfanın öbür ucunda bir videonun gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir time-lapse yapın. Tek bir istek bile bir kare, bir dosya adı
+      ya da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet bağlantısını
+      kesip yine de bir tane yapın &mdash; videonuzu işlenmek üzere uzağa
+      gönderen bir araç öylece dururdu."""
+
+read_first = """
+, her karenin hangi andan geleceğine karar veren hesap için
+      <code>src/plan.js</code> ve dosyanın yalnızca o anların gerektirdiği
+      bölümlerini okuyan döngü için <code>src/decode.js</code>. Hiçbiri istek
+      yapabilecek bir şeyi içeri almaz."""
+
+howto_heading = "Bir videodan nasıl time-lapse yapılır"
+
+card = """
+            Uzun bir klibi kısa bir klibe çevirin &mdash; saatleri saniyelere
+            &mdash; onu hiçbir yere göndermeden."""
+
+[words]
+plural = "videolarınız"
+choose = "bir video"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Yazdığınız her hız"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[privacy]]
+title = "Videolarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu
+      sayfanın iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri
+      bu siteye ait değildir. Dosyanızın toplanabileceği bir uç nokta burada yok,
+      olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araçta hiçbir türde ağ
+      özelliği yok: yapıştırılacak bir adres, indirilecek bir şey, ilk
+      kullanımda getirilen bir motor yok. Videonuza dokunan her bayt, sayfa
+      yüklenirken bu kaynaktan geldi."""
+
+[[privacy]]
+title = "Çözme ve kodlama yerelde."
+body = """
+ Kareler kendi tarayıcınızdaki
+      WebCodecs'ten geçer ya da klibi zaten size gösterecek olan aynı oynatma
+      motorundan. Bitmiş dosya bu makinenin belleğinde kurulur ve doğrudan bir
+      indirmeye verilir."""
+
+[[privacy]]
+title = "Dosyanın büyük kısmı hiç okunmuyor bile."
+body = """
+ Bir time-lapse
+      birkaç saniyede bir kare ister; bu yüzden araç dosyanın bu anların
+      çevresindeki kısa bölümlerini okur ve gerisini atlar. Bu bir gizlilik
+      kararından çok bir hız kararı ama yine de bilinmeye değer: yerelde bile
+      videonuzun büyük kısmı hiç açılmıyor."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine videonuz hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir kare, ne bir ad, bir boyut ya da bir uzunluk. Okuyan, çözen,
+      örnekleyen ya da kodlayan her satır bu kaynaktan sunuluyor ve depoda
+      listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de videonuz
+      hakkında bir şey verilir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Bir video seçin."
+body = """
+ Seçiciye bir MP4, MOV, M4V ya da WebM
+      bırakın veya elle seçin. Tarayıcı onu doğrudan diskinizden okur; siz bunu
+      yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Ne kadar hızlı olacağını söyleyin."
+body = """
+ Hazır hızlardan birine
+      basın ya da kendinizinkini yazın. Sonucun ne kadar süreceğini söylemeyi
+      tercih ederseniz &mdash; &laquo;bu yirmi saniyeye sığsın&raquo; &mdash;
+      onu yazın, hız ona uyar."""
+
+[[howto]]
+title = "Aralığı denetleyin."
+body = """
+ Hızın altındaki satır, aracın
+      gerçekte ne yapmak üzere olduğunu söyler: orijinalin her kaç saniyesinde
+      bir kare. Bir fotoğrafçının kamerada ayarlayacağı sayı budur ve başlamadan
+      önce gözden geçirmeye değen de budur."""
+
+[[howto]]
+title = "Yapın ve indirin."
+body = """
+ İş kendi donanımınızda olduğu için ne
+      kadar süreceği bir sıraya değil makinenize bağlıdır. Bitmiş video doğrudan
+      tarayıcınızın indirmelerine verilir."""
+
+[[faq]]
+q = "Videom herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur, çözülür,
+        örneklenir ve kodlanır. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Size
+        söylenene güvenmek yerine denetlemeyi tercih ediyorsanız internet
+        bağlantısını kesin ve yine de bir time-lapse yapın."""
+
+[[faq]]
+q = "Hız aslında ne demek?"
+a = """
+        Girenle çıkan arasındaki oran. 60&times;'te bir saatlik görüntü bir
+        dakika olur; geri oynatırken kare hızınız ne olursa olsun. Altta yatan
+        şey şu: araç her <em>hız &divide; kare hızı</em> saniyede bir kare alır
+        &mdash; saniyede 30 karede 60&times;, iki saniyede bir kare demektir
+        &mdash; ve sayfa bu aralığı siz başlamadan önce gösterir, çünkü gerçekte
+        ne olduğunu söyleyen sayı odur."""
+
+[[faq]]
+q = "Hangi video biçimlerini hızlandırabilirim?"
+a = """
+        MP4, M4V ve MOV içlerinde ne olursa olsun doğrudan okunur: H.264, HEVC,
+        AV1 ya da VP9 &mdash; yeter ki tarayıcınız o kodlayıcıyı çözebilsin.
+        Tarayıcınızın oynatabildiği başka her şey &mdash; en bilineni WebM
+        &mdash; bunun yerine tarayıcının kendi oynatıcısı her ana aranarak
+        okunur; bu, oynattığı her biçimde çalışır. Tarayıcının ne okuyabildiği ne
+        de oynatabildiği bir dosya, ki pratikte AVI, WMV, FLV ve çoğu MKV
+        demektir, yarı yolda başarısız olmak yerine bunu söyleyen bir mesajla
+        geri çevrilir. Çıkan şey her zaman bir MP4'tür."""
+
+[[faq]]
+q = "Time-lapse'in neden sesi yok?"
+a = """
+        Çünkü tutmaya değer bir şey yok. Otuz kat hızlı oynatılan ses konuşma ya
+        da müzik değil, bir cıvıltıdır; alternatif ise &mdash; sesi kendi
+        hızında, önünden koşup gitmiş bir görüntünün altında tutmak &mdash;
+        istediğinizden başka bir klip olurdu. Bu yüzden parça atılır; bir saatlik
+        videonun birkaç megabayt olarak çıkmasının da başlıca sebebi budur. Sesi
+        tek başına istiyorsanız <a href="../ses-duzenleme/">Ses Düzenleyici</a>
+        onu kaydeder."""
+
+[[faq]]
+q = "Videonun tamamını dönüştürmekten daha mı hızlı?"
+a = """
+        Çok daha hızlı ve dosyayı doğrudan okumanın bütün anlamı bu. Bir kare
+        ancak kendinden önceki anahtar kareden başlanarak çözülebilir, ama
+        aradaki karelerin tutulması gerektiğini söyleyen bir kural yok &mdash;
+        yani bir saatin 60&times; time-lapse'i yüz bin karenin hepsini değil
+        birkaç binini çözer. Özet, düğmeye basmadan önce kaç kare okuyacağını tam
+        olarak söyler."""
+
+[[faq]]
+q = "Kalite kaybettiriyor mu?"
+a = """
+        Tuttuğu kareler ikinci kez kodlanır ve bu biraz kaliteye mal olur; bundan
+        kaçınmak mümkün değil, çünkü bitmiş klip onları orijinal dosyadaki hiçbir
+        şeyin kodlanmadığı zamanlarda gösterir. Bu aracın buradaki diğer video
+        araçlarından daha fazla harcadığı şey ise bilinçli olarak bit hızıdır. İki
+        saniye arayla çekilmiş iki karenin ortak yanı, saniyenin otuzda biri
+        arayla çekilmiş iki kareden çok daha azdır; yani bir kodlayıcının yeniden
+        kullanacağı şey azdır ve sıradan görüntü için ayarlanmış bir rakam
+        bloklu çıkardı."""
+
+[[faq]]
+q = "Videonun boyutunda veya uzunluğunda bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok ve dosya belleğe bir seferde tümüyle
+        okunmuyor &mdash; her anın çevresinden kısa bölümler hâlinde ve yalnızca
+        onlar okunuyor. Pratik tavan, indirmeden önce bellekte kurulan bitmiş
+        time-lapse'tir ve bir time-lapse tanımı gereği kısadır: özet, siz
+        başlamadan önce kabaca ne kadar büyük olacağını gösterir."""
+
+[[faq]]
+q = "Bir klibin yalnızca bir bölümünü hızlandırabilir miyim?"
+a = """
+        Burada değil. Bu araç ilk kareden son kareye kadar bütününü alır. Önce
+        istediğiniz bölümü <a href="../video-kesme/">Video Kesici</a> ile kesin
+        &mdash; ki o bunu tek bir kareyi bile yeniden kodlamadan yapar &mdash;
+        sonra oradan çıkanı hızlandırın."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara videonuz hakkında hiçbir
+        şey verilmiyor."""
+
+[schema]
+browser_requirements = "JavaScript ve WebCodecs video kodlama destekleyen bir tarayıcı gerekir: Chrome, Edge, Safari 16.4 veya üzeri ya da Firefox 133 veya üzeri."
+description = "Uzun bir videoyu tarayıcıda time-lapse'e çevirin. Orijinalin her birkaç saniyesinden bir kare alınır ve kareler saniyede 24, 30 ya da 60 kareyle kısa bir MP4 olarak geri yazılır. MP4, MOV ve M4V doğrudan ve yalnızca gereken anların çevresinden okunur; tarayıcının oynatabildiği başka her şey aranarak gezilir. Hiçbir şey yüklenmez."
+features = [
+  "MP4, MOV, M4V ve WebM videoyu 1,1 kattan 1000 kata kadar herhangi bir oranda hızlandırır",
+  "Hızı söyleyin ya da sonucun ne kadar süreceğini söyleyin",
+  "Dosyanın yalnızca seçilen anların gerektirdiği bölümlerini okur",
+  "Saniyede 24, 30 ya da 60 kare; orijinal boyutta ya da küçültülmüş",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir videoyu buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; MP4, MOV, M4V, WebM ve bu tarayıcının oynattığı her şey"

--- a/locales/tr/tools/trim-audio.html
+++ b/locales/tr/tools/trim-audio.html
@@ -1,0 +1,206 @@
+<!--
+  tools/trim-audio/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; kayıt -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir kayıt seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Dosya</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Boyut</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Ses</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>Okunduğu hâl</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; işaretler -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> İstediğiniz parçaları işaretleyin
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Baştan sona oynatın ve bir parçanın başlaması gereken yerde <kbd>I</kbd>'ya,
+      bitmesi gereken yerde <kbd>O</kbd>'ya basın. Bunu istediğiniz kadar yapın
+      &mdash; her çift aşağıda bir satır olur ve bitmiş dosya, o satırların
+      birbiri ardına gelmiş hâlidir. <kbd>U</kbd> sonuncuyu geri alır,
+      <kbd>Space</kbd> oynatır ve duraklatır, ok tuşları beş saniye atlar. Bir
+      okla birlikte <kbd>Shift</kbd>'i basılı tutmak her seferinde on milisaniye
+      oynatır.
+    </p>
+
+    <!-- Built by src/timeline.js: the waveform, a band for every part, the one
+         being marked, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <audio id="preview" class="player" controls preload="metadata"></audio>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Oynat</button>
+      <button type="button" id="back-5" class="ghost" title="Beş saniye geri">&minus;5sn</button>
+      <button type="button" id="forward-5" class="ghost" title="Beş saniye ileri">+5sn</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Başı işaretle</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Sonu işaretle</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Geri al</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Oynatma hızı">
+      <span class="speed-label">Hız</span>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normal</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The parts themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Parçalar <span class="segment-count" id="segment-count">henüz yok</span></h3>
+        <p class="segments-total">
+          Toplam tutulan <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">#</th>
+            <th scope="col">Başlangıç</th>
+            <th scope="col">Bitiş</th>
+            <th scope="col">Süre</th>
+            <th scope="col"><span class="visually-hidden">İşlemler</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Henüz hiçbir şey işaretlenmedi. Oynarken <kbd>I</kbd>'ya, sonra
+        <kbd>O</kbd>'ya basın ya da yukarıdaki düğmeleri kullanın.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Elle satır ekle</button>
+        <button type="button" id="reset-segments" class="ghost danger">Hepsini temizle</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">İşaretleri yükle&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Zaman damgası dosya biçimi">
+          <option value="seconds" selected>saniye</option>
+          <option value="HHMMSSmmm">SS:DD:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">İşaretleri kaydet</button>
+      </div>
+
+      <p class="field-note">
+        İşaretler düz bir metin dosyası olarak kaydedilir &mdash; her satır bir
+        parça, yukarıdaki biçimde &mdash; böylece uzun bir işaretleme oturumu
+        kapanan bir sekmeden sağ çıkar ve aynı dosya video kesiciye ya da o
+        düzeni okuyan başka herhangi bir araca verilebilir.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>İşaretli parçalarla ne yapılacak</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Onları tut</strong>
+          Bitmiş dosya, işaretli parçaların sırayla birleştirilmiş hâlidir.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Onları çıkar</strong>
+          İşaretli parçalar gider, geri kalan her şey birleştirilir.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Adım 3 &mdash; çıkan dosya -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Kesin</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">Ne yazılsın</label>
+        <select id="depth">
+          <option value="16" selected>16 bit WAV &mdash; her yerde çalar</option>
+          <option value="32">32 bit kayan noktalı WAV &mdash; tam olarak örnekler</option>
+        </select>
+        <p class="field-note">
+          Bir WAV örnekleri oldukları gibi tutar; yani bir tane yazmak kaliteye
+          mal olamaz. Küçük bir dosya değildir: aşağıdaki tahmine bakın.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="fade">Birleşme yerlerini yumuşat</label>
+        <select id="fade">
+          <option value="0">Kapalı &mdash; tam örneğin üzerinden kes</option>
+          <option value="0.005" selected>5 ms &mdash; tıklamayı durdurmaya yeter</option>
+          <option value="0.02">20 ms</option>
+          <option value="0.05">50 ms</option>
+        </select>
+        <p class="field-note" id="fade-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Tutulan</dt><dd id="sum-parts">&mdash;</dd></div>
+      <div><dt>Bitmiş süre</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Başlangıç</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>Birleşme yerleri</dt><dd id="sum-joins">&mdash;</dd></div>
+      <div><dt>Ses</dt><dd id="sum-sound">&mdash;</dd></div>
+      <div><dt>Yaklaşık</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Sesi kes</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" class="player" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Sesi indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/trim-audio.toml
+++ b/locales/tr/tools/trim-audio.toml
@@ -1,0 +1,318 @@
+#
+# Ses Kesici - Türkçe.
+#
+# Overrides for tools/trim-audio/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Ses Kesici"
+heading = "Ses&nbsp;Kesici <span class=\"h1-kw\">&mdash; sesi çevrimiçi kesin</span>"
+tagline = "Tutmaya değer parçaları oynarken işaretleyin. Onları tek dosya olarak, tam söylediğiniz yerden kesilmiş hâlde geri alın."
+
+title = "Sesi Çevrimiçi Kesme &mdash; Yalnızca İstediğiniz Parçalar, Yüklemesiz"
+description = "Bir kaydı oynatın, geçerken tutmaya değer her parçayı işaretleyin, sonra o parçaları tek dosya olarak kaydedin. Örnek hassasiyetinde kesimler, birleşme yerlerinde tıklama yok, hiçbir şey yüklenmez."
+og_title = "Ses Kesici &mdash; hiçbir şey yüklemeden yalnızca istediğiniz parçalar"
+og_description = "Oynarken tutmaya değer her parçayı işaretlemek için I ve O'ya basın. İşaretli parçalar tek dosya olarak, tam örneğin üzerinden kesilmiş hâlde ve hiçbir şey yüklenmeden yeniden yazılır."
+og_image_alt = "Ses Kesici - istediğiniz parçaları işaretleyip tek kayıt olarak kaydedin, tarayıcınızda"
+
+pledge = """
+    Kaydınız kendi tarayıcınız tarafından, kendi donanımınızda okunur,
+    işaretlenir, kesilir ve yazılır. Buradaki hiçbir şey bir şey getiremez ya da
+    gönderemez &mdash; bu araçta hiçbir türde ağ özelliği yok &mdash; ve
+    olsaydı bile bu sayfanın öbür ucunda bir kaydın gönderilebileceği bir sunucu
+    yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir şey kesin. Tek bir istek bile bir örnek, bir dosya adı ya da
+      seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet bağlantısını kesip
+      yine de bir kayıt kesin &mdash; sesinizi kesilmek üzere uzağa gönderen bir
+      araç öylece dururdu."""
+
+read_first = """
+, işaretler ve kaydedildikleri dosya için
+      <code>src/segments.js</code>, dosyanızı tarayıcının kendi çözücüsüne veren
+      yirmi satır için <code>src/decode.js</code>, bir işareti örnek dizisine
+      çeviren hesap ve onları kopyalayan döngü için <code>src/trim.js</code> ve
+      önlerine giden başlık için <code>src/wav.js</code>. Hiçbiri istek
+      yapabilecek bir şeyi içeri almaz."""
+
+howto_heading = "Bir ses dosyası nasıl kesilir"
+
+card = """
+            Oynarken tutmaya değer her parçayı işaretleyin, sonra onları tek
+            kayıt olarak kaydedin. Kesimler tam örneğin üzerine düşer ve
+            birleşme yerleri tıklamaz."""
+
+[words]
+plural = "kayıtlarınız"
+choose = "bir kayıt"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "İstediğiniz kadar parça"
+
+[[facts]]
+text = "Tam işaretlediğiniz yerden keser"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[privacy]]
+title = "Kayıtlarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu sayfanın
+      iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri bu
+      siteye ait değildir. Dosyanızın toplanabileceği bir uç nokta burada yok,
+      olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araçta hiçbir türde ağ
+      özelliği yok: yapıştırılacak bir adres, indirilecek bir şey, ilk
+      kullanımda getirilen bir motor yok. Sesinize dokunan her bayt, sayfa
+      yüklenirken bu kaynaktan geldi."""
+
+[[privacy]]
+title = "Çözücü, tarayıcınızda zaten olan çözücü."
+body = """
+
+      Dosya <code>decodeAudioData</code>'ya verilir; bir parçayı bir
+      <code>&lt;audio&gt;</code> öğesinde çalan kodun aynısı. Biçiminizi okumak
+      için buraya hiçbir şey getirilmiyor ve onu okumak için bu sayfanın
+      dışındaki hiçbir şeyden bir şey istenmiyor."""
+
+[[privacy]]
+title = "Bir videonun görüntüsü hiç çözülmez."
+body = """
+ Bir video bıraktığınızda
+      yalnızca ses parçası istenir. Kareler okunmaz, çözülmez, çizilmez ve
+      onlara bakılmaz &mdash; bu sayfada bunu yapabilecek bir kod yok ve çıkan
+      dosya ses tutar, başka hiçbir şey tutmaz."""
+
+[[privacy]]
+title = "Kesim, bu makinede, bellekte yapılan bir kopyalamadır."
+body = """
+
+      Kesmek, kanal başına parça başına tek bir <code>set</code> işlemidir:
+      tuttuğunuz örnekler, koyduğunuz sırayla yeni bir diziye taşınır. Bir şeyle
+      çarpılan tek örnekler, her tanışmanın içindeki birkaç yüz tanedir ve sayfa
+      düğmeye basmadan önce kaç tane olduğunu söyler."""
+
+[[privacy]]
+title = "Örnekler yeniden kodlanmaz, olduğu gibi yazılır."
+body = """
+
+      Bir WAV, bu sayfanın tuttuğu örneklerin önüne bir başlık konmuş hâlidir.
+      Döngüde kaydınız hakkında karar veren bir kodlayıcı yok ve o kararların
+      alınabileceği, yükleme diye tarif edilebilecek bir şey de yok."""
+
+[[privacy]]
+title = "İşaret dosyası sayfada üretiliyor."
+body = """
+ İşaretlerinizi
+      kaydetmek, zaten ekranda duran sayılardan bir metin dosyası yazar ve
+      doğrudan indirmelerinize gönderir. Bir tanesini yüklemek onu burada okur.
+      İkisi de ağa yaklaşmaz ve ikisi de zamanlardan başka bir şey taşımaz."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine kaydınız hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir örnek, ne bir ad, bir boyut, bir uzunluk ya da nereden
+      kestiğiniz. Okuyan, kesen ve yazan her satır bu kaynaktan sunuluyor ve
+      depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de kaydınız
+      hakkında bir şey verilir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Bir kayıt seçin."
+body = """
+ Seçiciye bir MP3, WAV, FLAC, M4A, Ogg ya
+      da Opus dosyası bırakın &mdash; istediğiniz şey sesinin bir parçasıysa bir
+      video da olur. Tarayıcı onu doğrudan diskinizden okur ve bir dalga formu
+      olarak çizer; siz bunu yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Oynatın ve istediğiniz parçaları işaretleyin."
+body = """
+ Bir parçanın
+      başlaması gereken yerde <kbd>I</kbd>'ya, bitmesi gereken yerde
+      <kbd>O</kbd>'ya basın. Bunu istediğiniz kadar yapın &mdash; her çift,
+      alttaki tabloda bir satır ve dalga formunda bir şerit olur. <kbd>U</kbd>
+      sonuncuyu geri alır, <kbd>Space</kbd> oynatır ve duraklatır, ok tuşları
+      beşer saniye atlar ve biriyle birlikte <kbd>Shift</kbd>'i basılı tutmak on
+      milisaniye oynatır. An yakalanması zorsa oynatmayı yavaşlatın."""
+
+[[howto]]
+title = "İşaretleri düzeltin."
+body = """
+ Her satır tek başına oynatılabilir,
+      içine tam bir zaman yazılarak yeniden zamanlanabilir, sırada yukarı aşağı
+      taşınabilir ya da silinebilir. Seçili parçanın iki ucu dalga formu boyunca
+      da sürüklenebilir; bir işareti, öncesindeki nefese değil sessizliğe koymanın
+      en hızlı yolu budur. Üstteki toplam, bitmiş kaydın süresidir."""
+
+[[howto]]
+title = "Onları tutun ya da onları çıkarın."
+body = """
+ Olağan yön tutmaktır:
+      bitmiş kayıt, işaretlediğiniz parçaların sırayla birleştirilmiş hâlidir.
+      Onları çıkarmak ise insanların isteyip nadiren bulduğu öbür iştir
+      &mdash; "ııı"ları, çalan telefonu ya da yanlış başlangıçları işaretleyin;
+      geriye kalan onlarsız birleştirilir."""
+
+[[howto]]
+title = "Kesin ve indirin."
+body = """
+ Her kesim, işaretlediğiniz örneğin
+      üzerine düşer; burada bir anahtar kareye yuvarlama yoktur, çünkü sesin
+      anahtar karesi yoktur. Seçmeye değen tek şey, her birleşme yerine ne kadar
+      tanışma konacağıdır &mdash; beş milisaniye bir tıklamayı durdurmaya yeter
+      ve tanışma olarak duyulamayacak kadar kısadır. Çıkan şey bir WAV'dir; önce
+      sayfada çalınır, sonra doğrudan tarayıcınızın indirmelerine verilir."""
+
+[[faq]]
+q = "Sesim herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        işaretlenir, kesilir ve yazılır. Bu aracın sunucu tarafı yoktur ve
+        sayfanın <code>Content-Security-Policy</code>'si iletişim kurabileceği
+        her adresi tek tek sayar &mdash; bunların hiçbiri bu siteye ait
+        değildir. Size söylenene güvenmek yerine denetlemeyi tercih ediyorsanız
+        internet bağlantısını kesin ve yine de bir kayıt kesin."""
+
+[[faq]]
+q = "Aynı kaydın birkaç parçasını tutabilir miyim?"
+a = """
+        Bu araç bunun için var. Oynarken istediğiniz kadar <kbd>I</kbd> ve
+        <kbd>O</kbd>'ya basın; her çift bir satır olur ve bitmiş dosya, o
+        satırların sırayla birleştirilmiş hâlidir, geri kalan her şey gitmiş
+        olarak. Çoğu çevrimiçi kesici size tek bir tutamak çifti verip hangi tek
+        aralığı tutacağınızı sorar; bu bir jenerik parçasının başını sonunu almak
+        için yeterlidir ve bir saatlik röportajı bir kez dinleyip tutmaya değer
+        altı cevabı almak için hiçbir işe yaramaz."""
+
+[[faq]]
+q = "Kesim tam işaretlediğim yere mi düşüyor?"
+a = """
+        Evet; her parçada, her oynatıcıda. Sesin videodan daha basit olduğu tek
+        yer burasıdır: çözülmüş bir kayıt bir sayı dizisidir ve her biri tek
+        başına durur; dolayısıyla geri yuvarlanacak bir anahtar kare karşılığı
+        ve bir kesimin erken başlaması için bir sebep yoktur. Sayfa, sonucun
+        başladığı örnek numarasını gösterir; bu da yaptığınız işaretin örnekleme
+        hızıyla çarpılıp en yakın tam örneğe yuvarlanmış hâlidir."""
+
+[[faq]]
+q = "Bir birleşme yeri neden tıklar ve tanışma ne işe yarar?"
+a = """
+        Çünkü bir kelimenin ortasından bir başkasının ortasına kesmek, birbiriyle
+        ilgisiz iki dalga formunu yan yana koyar ve aralarında sıçraması istenen
+        bir hoparlör bir tıklama üretir. Bu, kesimdeki bir hata değildir &mdash;
+        bir süreksizliğin sesi budur. Çözüm, her birleşme yerinin iki yanına
+        birkaç milisaniyelik bir tanışma koymaktır: koninin oraya varmasına
+        yetecek kadar uzun, tanışma olarak duyulamayacak kadar kısa. Beş
+        milisaniye varsayılandır ve kapatılabilir. Tanışma yalnızca gerçekten bir
+        kesim olan bir kenara konur; yani kaydın en başındaki ya da en sonundaki
+        bir kenar tam olarak olduğu gibi bırakılır."""
+
+[[faq]]
+q = "Bunun yerine kötü kısımları çıkarabilir miyim?"
+a = """
+        Evet. Onları işaretleyin, sonra "Onları çıkar"ı seçin: bu kez
+        işaretlemediğiniz <em>her şey</em> sırayla birleştirilir. Aynı işaret
+        listesi iki soruyu da yanıtlar; böylece ikisi arasında geçiş yapıp
+        süresinin değiştiğini hiçbir şeyi iki kez işaretlemeden
+        görebilirsiniz."""
+
+[[faq]]
+q = "İşaretlerimi kaydedip sonra dönebilir miyim?"
+a = """
+        Evet. "İşaretleri kaydet" düz bir metin dosyası yazar &mdash; her satır
+        bir parça, başlangıç ve bitiş virgülle ayrılmış &mdash; "İşaretleri
+        yükle" de birini geri okur. İki biçim sunuluyor: düz saniye ve
+        <code>SS:DD:SS.mmm</code>; ikisi de bu sitedeki video kesicinin yazdığı
+        düzendir, yani videoya karşı yapılmış bir dosya onun sesine bırakılabilir
+        ve tersi de olur. İşaretlemek özenli bir iştir ve kimse onu iki kez
+        yapmak zorunda kalmamalı."""
+
+[[faq]]
+q = "Hangi biçimleri açabilirim?"
+a = """
+        Tarayıcınızın çözdüğü her şeyi; pratikte bu MP3, WAV, FLAC, M4A ve AAC,
+        Ogg Vorbis ve Opus ile MP4, M4V, MOV ve WebM videoların içindeki ses
+        demektir. Dışarıda kalan, her yerdekiyle aynı kısa listedir: AVI, WMA ve
+        çoğu MKV. Bu tarayıcının okumayacağı bir dosya, yarı yolda başarısız
+        olmak yerine bunu söyleyen bir mesajla geri çevrilir."""
+
+[[faq]]
+q = "Neden MP3 yerine WAV kaydediyor?"
+a = """
+        Çünkü hiçbir tarayıcı MP3 kodlayıcısı getirmez ve bu araç kaydınızı böyle
+        bir kodlayıcısı olan bir sunucuya göndermeyi reddeder. Bir WAV hiçbir
+        kodlayıcı gerektirmez &mdash; önüne kısa bir başlık konmuş örneklerdir
+        &mdash; yani hem dürüst seçenektir hem de çıkış yolunda kaliteye mal
+        olamayacak tek seçenektir. Daha büyüktür: stereoda dakikada yaklaşık on
+        megabayt. Her oynatıcı, telefon ve düzenleyici bir tanesini açar ve MP3
+        isteyen her şey ondan bir tane yapabilir. Bir MP3'ü karelerini
+        kopyalayarak kesmek dosyayı küçük tutardı, ama aynı zamanda her kesimi en
+        yakın kare sınırına taşırdı; bu araç tam da bu yuvarlamayı yapmamak için
+        var."""
+
+[[faq]]
+q = "Kaydın uzunluğunda bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok. Pratik tavan bellek: kaydın tamamı bu
+        sayfaya bir seferde çözülür ve indirmeden önce bellekte bir WAV kurulur;
+        yani bir saatlik stereo, çalışmak için bir gigabaytın biraz altında yer
+        ister. Dört gigabaytlık bir WAV doğrudan reddedilir, çünkü biçimin kendi
+        boyut alanı böyle bir dosyayı tarif edemez."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara kaydınız hakkında hiçbir
+        şey verilmiyor."""
+
+[schema]
+browser_requirements = "JavaScript ve Web Audio destekleyen bir tarayıcı gerekir; bu da her güncel tarayıcı demektir. Dosyayı çalmak için tarayıcıda zaten olanın ötesinde bir kodlayıcı desteği gerekmez."
+description = "Bir kaydın istediğiniz kadar parçasını oynarken işaretleyin, sonra o parçaları tek dosya olarak kaydedin &mdash; ya da onları çıkarıp gerisini tutun. Kesimler tam işaretlenen örneğin üzerine düşer ve birleşme yerleri tıklamasın diye isteğe bağlı birkaç milisaniyelik tanışma konur. Hiçbir şey yüklenmez ve sonuç WAV olarak yazılır, yani hiçbir şey yeniden kodlanmaz."
+features = [
+  "Kayıt oynarken I ve O ile istediğiniz kadar parça işaretler",
+  "İşaretli parçaları seçtiğiniz sırayla tek dosyada birleştirir",
+  "Ya da işaretli parçaları çıkarıp geri kalan her şeyi tutar",
+  "Bir kareye ya da anahtar kareye yuvarlamadan, tam örneğin üzerinden keser",
+  "Her birleşme yerini birkaç milisaniye tanıştırır, böylece tıklayamaz",
+  "Dalga formunu çizer, böylece sessizlikler ve boşluklar gözle işaretlenebilir",
+  "İşaretleri düz metin zaman damgası dosyası olarak kaydeder ve geri yükler",
+  "Bir MP4, MOV ya da WebM içindeki sesi, görüntüye dokunmadan keser",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir ses dosyasını ya da videoyu buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; MP3, WAV, FLAC, M4A, Ogg ve MP4, MOV ya da WebM içindeki ses"

--- a/locales/tr/tools/trim-video.html
+++ b/locales/tr/tools/trim-video.html
@@ -1,0 +1,230 @@
+<!--
+  tools/trim-video/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; video -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir video seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <!-- One row a video, in the order they will be joined. Hidden until there
+         is more than one, because a list of one is furniture. -->
+    <ol class="clip-list" id="clip-list" hidden></ol>
+
+    <p id="join-note" class="path-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; işaretler -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> İstediğiniz parçaları işaretleyin
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Baştan sona oynatın ve bir parçanın başlaması gereken yerde <kbd>I</kbd>'ya,
+      bitmesi gereken yerde <kbd>O</kbd>'ya basın. Bunu istediğiniz kadar yapın
+      &mdash; her çift aşağıda bir satır olur ve bitmiş video, o satırların
+      birbiri ardına gelmiş hâlidir. <kbd>U</kbd> sonuncuyu geri alır,
+      <kbd>Space</kbd> oynatır ve duraklatır, ok tuşları beş saniye atlar.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- Built by src/timeline.js: a band for every segment, the one being
+         marked, a tick for every keyframe, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Oynat</button>
+      <button type="button" id="back-5" class="ghost" title="Beş saniye geri">&minus;5sn</button>
+      <button type="button" id="forward-5" class="ghost" title="Beş saniye ileri">+5sn</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Başı işaretle</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Sonu işaretle</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Geri al</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Oynatma hızı">
+      <span class="speed-label">Hız</span>
+      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normal</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The segments themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Parçalar <span class="segment-count" id="segment-count">henüz yok</span></h3>
+        <p class="segments-total">
+          Toplam tutulan <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">#</th>
+            <th scope="col">Başlangıç</th>
+            <th scope="col">Bitiş</th>
+            <th scope="col">Süre</th>
+            <th scope="col"><span class="visually-hidden">İşlemler</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Henüz hiçbir şey işaretlenmedi. Oynarken <kbd>I</kbd>'ya, sonra
+        <kbd>O</kbd>'ya basın ya da yukarıdaki düğmeleri kullanın.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Elle satır ekle</button>
+        <button type="button" id="reset-segments" class="ghost danger">Hepsini temizle</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">İşaretleri yükle&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Zaman damgası dosya biçimi">
+          <option value="seconds" selected>saniye</option>
+          <option value="HHMMSSmmm">SS:DD:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">İşaretleri kaydet</button>
+      </div>
+
+      <p class="field-note">
+        İşaretler düz bir metin dosyası olarak kaydedilir &mdash; her satır bir
+        parça, yukarıdaki biçimde &mdash; böylece uzun bir işaretleme oturumu
+        kapanan bir sekmeden sağ çıkar ve aynı dosya, o düzeni okuyan herhangi
+        bir araca verilebilir.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>İşaretli parçalarla ne yapılacak</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Onları tut</strong>
+          Bitmiş video, işaretli parçaların sırayla birleştirilmiş hâlidir.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Onları çıkar</strong>
+          İşaretli parçalar gider, geri kalan her şey birleştirilir.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Adım 3 &mdash; dışa aktarma -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Kesin</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="method">Nasıl kesilecek</label>
+        <select id="method">
+          <option value="copy" selected>Her baytı koru &mdash; hiçbir şey yeniden kodlanmaz</option>
+          <option value="exact">Tam burada kes &mdash; görüntüyü yeniden kodlar</option>
+          <option value="record">Oynarken kaydet</option>
+        </select>
+        <p class="field-note" id="method-note"></p>
+      </div>
+
+      <div class="field" id="frame-field" hidden>
+        <label for="frame">Kare boyutu</label>
+        <select id="frame">
+          <option value="first" selected>İlk videoyla aynı</option>
+          <option value="largest">En büyüğüyle aynı</option>
+          <option value="1080p">1920 &times; 1080</option>
+          <option value="720p">1280 &times; 720</option>
+        </select>
+        <p class="field-note">
+          Tek bir boyut dosyanın tamamını kapsar. Başka şekildeki bir video
+          bantlarla onun içine yerleştirilir, asla esnetilmez.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kalite</label>
+        <select id="quality">
+          <option value="low">Daha küçük dosya</option>
+          <option value="medium" selected>Dengeli</option>
+          <option value="high">En iyi kalite</option>
+        </select>
+        <p class="field-note">
+          Orijinalin harcadığından asla fazlası değil &mdash; bunun üzerinde
+          yeniden kodlamak dosyayı yalnızca büyütür.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Sesi koru
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Tutulan</dt><dd id="sum-clips">&mdash;</dd></div>
+      <div><dt>Bitmiş süre</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Başlangıç</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>Yaklaşık</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Görüntü</dt><dd id="sum-picture">&mdash;</dd></div>
+      <div><dt>Ses</dt><dd id="sum-sound">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Videoyu kes</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Videoyu indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/trim-video.toml
+++ b/locales/tr/tools/trim-video.toml
@@ -1,0 +1,317 @@
+#
+# Video Kesici - Türkçe.
+#
+# Overrides for tools/trim-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# Burada "kesme", klibi kısaltmak; kadrajı kesmek "kırpma" ve o yan kapıdaki
+# araç. locale.toml'un başındaki nota bakın.
+#
+
+name = "Video Kesici"
+heading = "Video&nbsp;Kesici <span class=\"h1-kw\">&mdash; videoyu çevrimiçi kesin</span>"
+tagline = "Tutmaya değer parçaları oynarken işaretleyin. Onları tek video olarak geri alın."
+
+title = "Videoyu Çevrimiçi Kesme &mdash; Yalnızca İstediğiniz Parçalar, Yüklemesiz"
+description = "Bir videoyu izleyin, oynarken tutmaya değer her parçayı işaretleyin, sonra o parçaları tek dosya olarak kaydedin. Tarayıcınızda çalışır: hiçbir şey yüklenmez, hiçbir şey yeniden kodlanmaz, çevrimdışı da çalışır."
+og_title = "Video Kesici &mdash; hiçbir şey yüklemeden yalnızca istediğiniz parçalar"
+og_description = "Oynarken tutmaya değer her parçayı işaretlemek için I ve O'ya basın. İşaretli parçalar tek video olarak, kare kare, hiçbir şey yüklenmeden yeniden yazılır."
+og_image_alt = "Video Kesici - istediğiniz parçaları işaretleyip tek video olarak kaydedin, tarayıcınızda"
+
+pledge = """
+    Videonuz kendi tarayıcınız tarafından, kendi donanımınızda okunur,
+    işaretlenir, kesilir ve yazılır. Buradaki hiçbir şey bir şey getiremez ya da
+    gönderemez &mdash; bu araçta hiçbir türde ağ özelliği yok &mdash; ve
+    olsaydı bile bu sayfanın öbür ucunda bir videonun gönderilebileceği bir
+    sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir video kesin. Tek bir istek bile bir kare, bir dosya adı ya
+      da seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet bağlantısını
+      kesip yine de bir tane kesin &mdash; videonuzu kesilmek üzere uzağa
+      gönderen bir araç öylece dururdu."""
+
+read_first = """
+, işaretler ve kaydedildikleri dosya için
+      <code>src/segments.js</code>, bir MP4 içindeki kareleri bulan okuyucu için
+      <code>src/demux.js</code>, bir işareti örnek dizisine çeviren hesap için
+      <code>src/ranges.js</code> ve o örnekleri yeni dosyaya taşıyan döngü için
+      <code>src/copy.js</code>. Hiçbiri istek yapabilecek bir şeyi içeri
+      almaz."""
+
+howto_heading = "Bir video nasıl kesilir"
+
+card = """
+            Oynarken tutmaya değer her parçayı işaretleyin, sonra onları tek
+            video olarak kaydedin. Kareler yeniden kodlanmaz, kopyalanır; yani
+            hiçbir şey kaybolmaz."""
+
+[words]
+plural = "videolarınız"
+choose = "bir video"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "İstediğiniz kadar parça"
+
+[[facts]]
+text = "Kalite kaybı yok"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[privacy]]
+title = "Videolarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu
+      sayfanın iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri
+      bu siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araçta hiçbir türde ağ
+      özelliği yok: yapıştırılacak bir adres, indirilecek bir şey, ilk
+      kullanımda getirilen bir motor yok. Videonuza dokunan her bayt, sayfa
+      yüklenirken bu kaynaktan geldi."""
+
+[[privacy]]
+title = "Olağan yolda hiçbir şey çözülmüyor bile."
+body = """
+
+      Kesmek hiçbir karenin görüntüsünü değiştirmez; bu yüzden işaretlediğiniz
+      parçaların kodlanmış kareleri yeni dosyaya bulundukları hâliyle taşınır.
+      Her biri diskinizdeki dosyanın bir dilimi olarak saklanır &mdash; hangi
+      baytlar olduğunu söyleyen bir not, baytların kendisi değil &mdash; ve
+      tarayıcınız onları ilk kez indirmeyi yazarken okur. Buradaki hiçbir şey
+      videonuzu tekrar bir görüntüye dönüştürmez."""
+
+[[privacy]]
+title = "İşaret dosyası sayfada üretiliyor."
+body = """
+ İşaretlerinizi
+      kaydetmek, zaten ekranda duran sayılardan bir metin dosyası yazar ve
+      doğrudan indirmelerinize gönderir. Bir tanesini yüklemek onu burada okur.
+      İkisi de ağa yaklaşmaz ve ikisi de zamanlardan başka bir şey taşımaz."""
+
+[[privacy]]
+title = "Ses kopyalanıyor, dinlenmiyor."
+body = """
+ Her iki MP4 yolunda da ses
+      örnekleri hiç çözülmeden karşıya taşınır &mdash; buradaki hiçbir şey
+      onları tekrar sese dönüştürmez ve dönüştürse bile hiçbir şey onları bir
+      yere iletemezdi."""
+
+[[privacy]]
+title = "Kareler nerede çözülüyorsa, burada çözülüyor."
+body = """
+ Tam
+      kesim ve bu tarayıcının oynatmayacağı bir dosyanın ön izlemesi, kendi
+      cihazınızdaki WebCodecs üzerinden geçer. Bu, videoyu zaten size gösterecek
+      olan aynı çözücüdür ve aynı yerde çalışır."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine videonuz hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir kare, ne bir ad, bir boyut, bir uzunluk ya da nereden
+      kestiğiniz. Okuyan, kesen ve yazan her satır bu kaynaktan sunuluyor ve
+      depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de videonuz
+      hakkında bir şey verilir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Bir video seçin."
+body = """
+ Seçiciye bir MP4, MOV, M4V ya da WebM
+      bırakın. Tarayıcı onu doğrudan diskinizden okur; siz bunu yaparken hiçbir
+      yere hiçbir şey gönderilmez. Birkaç tane bırakırsanız koyduğunuz sırayla
+      birleştirilirler."""
+
+[[howto]]
+title = "Oynatın ve istediğiniz parçaları işaretleyin."
+body = """
+ Bir parçanın
+      başlaması gereken yerde <kbd>I</kbd>'ya, bitmesi gereken yerde
+      <kbd>O</kbd>'ya basın. Bunu istediğiniz kadar yapın &mdash; her çift,
+      alttaki tabloda bir satır ve zaman çizelgesinde bir şerit olur.
+      <kbd>U</kbd> sonuncuyu geri alır, <kbd>Space</kbd> oynatır ve duraklatır,
+      ok tuşları beşer saniye atlar. An yakalanması zorsa oynatmayı
+      yavaşlatın."""
+
+[[howto]]
+title = "İşaretleri düzeltin."
+body = """
+ Her satır tek başına oynatılabilir,
+      içine tam bir zaman yazılarak yeniden zamanlanabilir, sırada yukarı aşağı
+      taşınabilir ya da silinebilir. Seçili parçanın iki ucu zaman çizelgesi
+      boyunca sürüklenebilir de. Üstteki toplam, bitmiş videonun süresidir."""
+
+[[howto]]
+title = "Onları tutun ya da onları çıkarın."
+body = """
+ Olağan yön tutmaktır:
+      bitmiş video, işaretlediğiniz parçaların sırayla birleştirilmiş hâlidir.
+      Onları çıkarmak ise insanların isteyip nadiren bulduğu öbür iştir
+      &mdash; reklamları, sessizlikleri ya da yanlış başlangıçları işaretleyin;
+      geriye kalan onlarsız birleştirilir."""
+
+[[howto]]
+title = "Kesin ve indirin."
+body = """
+ "Her baytı koru" kareleri el
+      değmeden taşır: hızlıdır ve kaliteye mal olamaz, ama her parça sizin
+      işaretinizden önceki anahtar karede başlar. "Tam burada kes" ise görüntüyü
+      çözüp yeniden yazar, böylece her parça seçtiğiniz karede başlar. Sayfa,
+      düğmeye basmadan önce hangisini alacağınızı ve bunun neye mal olduğunu
+      söyler."""
+
+[[faq]]
+q = "Videom herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        işaretlenir, kesilir ve yazılır. Bu aracın sunucu tarafı yoktur ve
+        sayfanın <code>Content-Security-Policy</code>'si iletişim kurabileceği
+        her adresi tek tek sayar &mdash; bunların hiçbiri bu siteye ait
+        değildir. Size söylenene güvenmek yerine denetlemeyi tercih
+        ediyorsanız internet bağlantısını kesin ve yine de bir video kesin."""
+
+[[faq]]
+q = "Aynı videonun birkaç parçasını tutabilir miyim?"
+a = """
+        Bu araç bunun için var. Oynarken istediğiniz kadar <kbd>I</kbd> ve
+        <kbd>O</kbd>'ya basın; her çift bir satır olur ve bitmiş video, o
+        satırların sırayla birleştirilmiş hâlidir, geri kalan her şey gitmiş
+        olarak. Çoğu çevrimiçi kesici size tek bir tutamak çifti verip hangi tek
+        aralığı tutacağınızı sorar; bu bir klibin başını sonunu almak için
+        yeterlidir ve bir saatlik görüntüyü bir kez izleyip tutmaya değer altı
+        anı almak için hiçbir işe yaramaz."""
+
+[[faq]]
+q = "Kesmek kalite kaybettirir mi?"
+a = """
+        Olağan yolda hayır ve önemli olan anlamda hayır. Kesmek hiçbir karenin
+        görüntüsünü değiştirmez; bu yüzden kareler yeni dosyaya oldukları gibi
+        taşınır: aynı baytlar, aynı kodlayıcı ayarları, her şey aynı. Burada bir
+        şeyi yeniden kodlayan tek yol tam kesimdir ve bunu düğmenin üzerinde
+        yazar."""
+
+[[faq]]
+q = "Bir parça neden işaretlediğimden daha erken başlıyor?"
+a = """
+        Videonun nasıl saklandığı yüzünden ve yalnızca biçimin standart bir
+        parçasını yok sayan oynatıcılarda. Çoğu kare, komşularından nasıl
+        ayrıldığının tarifi olarak tutulur; dolayısıyla onlar olmadan
+        çözülemezler. Yalnızca anahtar kare tek başına durur ve anahtar kareler
+        tipik olarak bir ile on saniye arayla gelir. Kareleri kopyalayan bir
+        kesim bu yüzden işaretinizden önceki anahtar kareden başlayan diziyi de
+        taşımak zorundadır &mdash; ve dosya <em>işaretinizde oynatmaya
+        başla</em> der ki bunu her yaygın oynatıcı yerine getirir. Her
+        oynatıcıda tam olması gerekiyorsa yeniden kodlayan "Tam burada kes"i
+        seçin. Sayfa, dışa aktarmadan önce hangi durumda olduğunuzu ve ne kadar
+        fark olduğunu söyler."""
+
+[[faq]]
+q = "Bunun yerine reklamları çıkarabilir miyim?"
+a = """
+        Evet. Onları işaretleyin, sonra "Onları çıkar"ı seçin: bu kez
+        işaretlemediğiniz <em>her şey</em> sırayla birleştirilir. Aynı işaret
+        listesi iki soruyu da yanıtlar; böylece ikisi arasında geçiş yapıp
+        süresinin değiştiğini hiçbir şeyi iki kez işaretlemeden
+        görebilirsiniz."""
+
+[[faq]]
+q = "İşaretlerimi kaydedip sonra dönebilir miyim?"
+a = """
+        Evet. "İşaretleri kaydet" düz bir metin dosyası yazar &mdash; her satır
+        bir parça, başlangıç ve bitiş virgülle ayrılmış &mdash; "İşaretleri
+        yükle" de birini geri okur. İki biçim sunuluyor: düz saniye ve
+        <code>SS:DD:SS.mmm</code>; ikisi de bu şekilde çalışan başka araçların
+        zaten kullandığı düzene uyar, yani burada yazılan bir dosya onlara
+        verilebilir, orada yazılan bir dosya da bu sayfaya bırakılabilir.
+        İşaretlemek özenli bir iştir ve kimse onu iki kez yapmak zorunda
+        kalmamalı."""
+
+[[faq]]
+q = "Hangi video biçimlerini kesebilirim?"
+a = """
+        MP4, M4V ve MOV içlerinde ne olursa olsun doğrudan okunur: H.264, HEVC,
+        AV1 ya da VP9. Kareleri kopyalamak onları çözmeyi gerektirmez; bu yüzden
+        bu yol, tarayıcınızın hiç çözücüsü olmayan bir kodlayıcı için bile
+        çalışır. Tarayıcınızın oynatabildiği başka her şey &mdash; en bilineni
+        WebM &mdash; bunun yerine oynatılıp sonucu kaydedilerek kesilir; bu da
+        işe yarar, sonuç ne kadar uzunsa o kadar sürer ve yalnızca tek parça
+        tutabilir. Tarayıcının ne okuyabildiği ne de oynatabildiği bir dosya, ki
+        pratikte AVI, WMV, FLV ve çoğu MKV demektir, yarı yolda başarısız olmak
+        yerine bunu söyleyen bir mesajla geri çevrilir."""
+
+[[faq]]
+q = "Videonun boyutunda veya uzunluğunda bir sınır var mı?"
+a = """
+        Araçta yerleşik bir sınır yok ve kopyalama yolunda dosya neredeyse hiç
+        okunmuyor: tuttuğunuz kareler yüklenmek yerine işaret ediliyor, yani
+        dört gigabaytlık bir kayıttan dört dakika tutmak, o dört dakikayı diske
+        yazmanın maliyetine yakın. Tam kesim ise dosyayı birkaç megabaytlık
+        parçalar hâlinde geziyor. Her iki durumda da pratik tavan, indirmeden
+        önce bellekte kurulan bitmiş dosyadır."""
+
+[[faq]]
+q = "Ses hayatta kalıyor mu?"
+a = """
+        Her iki MP4 yolunda da hiç çözülmeden örnek örnek kopyalanır, yani
+        dosyada ne varsa bayt bayt odur; bir düzenleme işareti de her parçayı
+        görüntüsüyle binde bir saniye hassasiyetinde hizalı tutar. Tek istisna,
+        sesi farklı tanımlanmış &mdash; diyelim ki farklı örnekleme hızlarında
+        &mdash; ayrı videoları birleştirmektir; orada ikisini çözmeden tek bir
+        parçaya koymanın yolu yoktur ve sayfa bunu yapmadan önce söyler. Kayıt
+        yolunda ise oynatmadan yakalanıp yeniden kodlanır. Her durumda onu
+        tümüyle dışarıda bırakan bir onay kutusu var."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara videonuz hakkında hiçbir
+        şey verilmiyor."""
+
+[schema]
+browser_requirements = "JavaScript gerekir. Kareleri kopyalamak hiçbir video kodlayıcı desteği gerektirmez; tam kesim için WebCodecs destekleyen bir tarayıcı gerekir ve diğer biçimler kayda düşer."
+description = "Bir videonun istediğiniz kadar parçasını oynarken işaretleyin, sonra o parçaları tek dosya olarak kaydedin &mdash; ya da onları çıkarıp gerisini tutun. MP4, MOV ve M4V, kodlanmış kareler el değmeden yeni bir dosyaya taşınarak kesilir ve orijinal ses örnek örnek karşıya taşınır; hiçbir şey yüklenmez ve hiçbir şey yeniden kodlanmaz."
+features = [
+  "Video oynarken I ve O ile istediğiniz kadar parça işaretler",
+  "İşaretli parçaları seçtiğiniz sırayla tek dosyada birleştirir",
+  "Ya da işaretli parçaları çıkarıp geri kalan her şeyi tutar",
+  "Yeniden kodlamadan keser, böylece kalite kaybolmaz",
+  "İşaretleri düz metin zaman damgası dosyası olarak kaydeder ve geri yükler",
+  "Kare hassasiyetinde işaretler, zaman çizelgesinde gösterilen anahtar karelerle",
+  "Orijinal sesi yeniden kodlamadan korur",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir videoyu buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; MP4, MOV, M4V, WebM. Birleştirmek için birkaç tane bırakın."

--- a/locales/tr/tools/video-to-gif.html
+++ b/locales/tr/tools/video-to-gif.html
@@ -1,0 +1,175 @@
+<!--
+  tools/video-to-gif/body.html, in Turkish.
+
+  Every id, class and template tag below is what src/main.js and the frame
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Adım 1 &mdash; dosya -->
+  <section class="card">
+    <h2><span class="step">1</span> Bir video seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>Dosya</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Boyut</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Kare</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Süre</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Görüntü</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Okuyan</dt><dd id="src-path">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 2 &mdash; bölüm -->
+  <section class="card" id="section-card" hidden>
+    <h2><span class="step">2</span> Bölümü seçin</h2>
+
+    <p class="hint">
+      Klibi oynatın ve istediğiniz kısmı işaretleyin. <kbd>I</kbd> başlangıcı
+      oynatma başlığının olduğu yere koyar, <kbd>O</kbd> bitişi koyar ve
+      çubuktaki iki tutamak da sürüklenebilir.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- The bar itself is built by src/range.js. -->
+    <div id="rangebar"></div>
+    <div class="rb-scale">
+      <span>0:00.000</span>
+      <span id="scale-end">&mdash;</span>
+    </div>
+
+    <div class="marks">
+      <label>Başlangıç
+        <input type="text" id="start-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-in" class="ghost" title="Başlangıcı oynatma başlığının olduğu yere koy (I)">
+        Başlığa ayarla
+      </button>
+
+      <label>Bitiş
+        <input type="text" id="end-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-out" class="ghost" title="Bitişi oynatma başlığının olduğu yere koy (O)">
+        Başlığa ayarla
+      </button>
+
+      <div class="mark-actions">
+        <button type="button" id="play-section" class="ghost">Bölümü oynat</button>
+        <button type="button" id="whole-clip" class="ghost">Klibin tamamı</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Adım 3 &mdash; GIF -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Boyut ve kare hızı</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="width">Genişlik</label>
+        <select id="width">
+          <option value="240">240 px</option>
+          <option value="320">320 px</option>
+          <option value="480" selected>480 px</option>
+          <option value="640">640 px</option>
+          <option value="source">Orijinal boyut</option>
+          <option value="custom">Tam olarak&hellip;</option>
+        </select>
+        <p class="field-note">
+          Yükseklik ona uyar, yani şekil hiç değişmez. Bir GIF'in maliyeti
+          genişliktir: yarı genişlik, dörtte bir piksel demektir.
+        </p>
+        <p class="field-note" id="width-note" hidden></p>
+      </div>
+
+      <div class="field" id="custom-width-field" hidden>
+        <label for="custom-width">Tam genişlik</label>
+        <input type="number" id="custom-width" min="16" max="1920" step="1" value="480">
+        <p class="field-note">Piksel olarak, 16 ile 1920 arasında.</p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Saniyedeki kare</label>
+        <select id="fps">
+          <option value="5">5 &mdash; en küçük</option>
+          <option value="10">10</option>
+          <option value="12" selected>12 &mdash; yeterince akıcı</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+          <option value="25">25 &mdash; en akıcı</option>
+        </select>
+        <p class="field-note">
+          Videonun kendi hızı değil: kareler ondan örneklenir. On iki, hareket
+          olarak okunur; yirminin üstünde dosya, akıcılığın görünmesinden daha
+          hızlı büyür.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Dithering</label>
+        <select id="dither">
+          <option value="on" selected>Açık &mdash; daha yumuşak geçişler</option>
+          <option value="off">Kapalı &mdash; daha düz, daha küçük</option>
+        </select>
+        <p class="field-note">
+          Doğrusunun bulunmadığı yerde iki palet rengini karıştırır. Sıralı
+          türden, yani sabit bir arka plan titremez.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="loop">
+          <input type="checkbox" id="loop" checked>
+          Sonsuza kadar döngü
+        </label>
+        <p class="field-note">Kapalıysa bir kez baştan sona oynar ve durur.</p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Bölüm</dt><dd id="sum-section">&mdash;</dd></div>
+      <div><dt>Çıktı</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Kareler</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Yaklaşık dosya boyutu</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="memory-note" class="field-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>GIF'i yap</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <img id="result-image" alt="Bitmiş animasyon, oynuyor">
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>GIF'i indir</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/tr/tools/video-to-gif.toml
+++ b/locales/tr/tools/video-to-gif.toml
@@ -1,0 +1,247 @@
+#
+# Videodan GIF'e - Türkçe.
+#
+# Overrides for tools/video-to-gif/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Videodan GIF'e"
+heading = "Videodan&nbsp;GIF'e <span class=\"h1-kw\">&mdash; videoyu GIF'e dönüştürün</span>"
+tagline = "Bölümü, boyutu ve kare hızını siz seçin."
+
+title = "Videodan GIF Dönüştürücü &mdash; Ücretsiz, Yüklemesiz, Çevrimdışı Çalışır"
+description = "Bir MP4, MOV veya WebM'in bir bölümünü hareketli GIF'e çevirin. Bölümü, genişliği ve kare hızını seçin; kareler okunur ve GIF tarayıcınızda yazılır. Hiçbir şey yüklenmez."
+og_title = "Videodan GIF'e &mdash; klibi yüklemeden GIF yapın"
+og_description = "İstediğiniz saniyeleri işaretleyin, bir genişlik ve kare hızı seçin, hareketli bir GIF alın. Kare örnekleme, palet, dithering ve LZW'nin hepsi kendi cihazınızda yapılır."
+og_image_alt = "Videodan GIF'e - tarayıcınızda hareketli GIF yapın, hiçbir şey yüklenmesin"
+
+pledge = """
+    Her kare kendi tarayıcınız tarafından, kendi donanımınızda okunur, yeniden
+    boyutlandırılır, renk sayısı düşürülür ve yazılır. Buradaki hiçbir şey bir
+    şey getiremez ya da gönderemez &mdash; bu araçta hiçbir türde ağ özelliği
+    yok &mdash; ve olsaydı bile bu sayfanın öbür ucunda bir videonun
+    gönderilebileceği bir sunucu yok."""
+
+live_hint = """
+      Bize güvenmek zorunda değilsiniz: geliştirici araçlarını açın, Ağ sekmesini
+      izleyin ve bir GIF yapın. Tek bir istek bile bir kare, bir dosya adı ya da
+      seçtiğiniz şeyden tek bir bayt taşımıyor. Ya da internet bağlantısını kesip
+      yine de bir tane yapın &mdash; videonuzu dönüştürülmek üzere uzağa gönderen
+      bir araç öylece dururdu."""
+
+read_first = """
+, karelerin bir videodan okunmasının iki yolu için
+      <code>src/frames.js</code>, palet için <code>src/quantize.js</code> ve
+      LZW'siyle birlikte dosyanın kendisi için <code>src/gif.js</code>. Hiçbiri
+      istek yapabilecek bir şeyi içeri almaz."""
+
+howto_heading = "Bir video GIF'e nasıl çevrilir"
+
+card = """
+            İstediğiniz saniyeleri işaretleyin, bir genişlik ve kare hızı seçin
+            ve hareketli bir GIF alın &mdash; paleti, dithering'i ve
+            hepsiyle."""
+
+[words]
+plural = "videolarınız"
+choose = "bir video"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "Her uzunlukta"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[privacy]]
+title = "Videolarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy, bu
+      sayfanın iletişim kurabileceği her adresi tek tek sayar ve bunların hiçbiri
+      bu siteye ait değildir. Dosyalarınızın toplanabileceği bir uç nokta burada
+      yok, olsaydı bile onu oraya gönderecek bir kod yok."""
+
+[[privacy]]
+title = "Burada hiçbir şey bir şey getirmiyor."
+body = """
+ Bu araçta hiçbir türde ağ
+      özelliği yok: yapıştırılacak bir adres, indirilecek bir şey, ilk
+      kullanımda getirilen bir motor yok. Videonuza dokunan her bayt, sayfa
+      yüklenirken bu kaynaktan geldi."""
+
+[[privacy]]
+title = "Çözme işi yerelde."
+body = """
+ Kareler kendi tarayıcınızdaki
+      WebCodecs'ten geçer ya da klibi zaten size gösterecek olan aynı oynatma
+      motorundan. Hangisinin kullanıldığı sayfanın üstünde yazar, çünkü bu
+      karelerin nasıl seçildiğini değiştirir ve bunu görebilmelisiniz."""
+
+[[privacy]]
+title = "GIF burada, okuyabileceğiniz bir kodla yazılıyor."
+body = """
+      Palet, dithering ve LZW sıkıştırması bu aracın kendi klasöründe yaklaşık
+      altı yüz satır. Bir kodlayıcı hizmeti, çalışma anında getirilen bir
+      kitaplık ya da bunların herhangi bir yerinde bir görselin
+      gönderilebileceği bir yer yok."""
+
+[[privacy]]
+title = "Google neyi yüklüyor, neyi almıyor."
+body = """
+ Reklam ve ölçüm betikleri
+      Google'dan geliyor. Hiçbirine videonuz hakkında bir şey verilmiyor: ne bir
+      dosya, ne bir kare, ne bir ad, bir boyut, bir uzunluk ya da işaretlediğiniz
+      bölüm. Okuyan, örnekleyen, renk sayısını düşüren ya da kodlayan her satır
+      bu kaynaktan sunuluyor ve depoda listeleniyor."""
+
+[[privacy]]
+title = "Bağış düğmesi neyi yüklüyor, neyi almıyor."
+body = """
+
+      Başlıktaki "Buy me a coffee" düğmesini cdnjs.buymeacoffee.com'dan gelen
+      bir betik çiziyor ve harflerini Google Fonts'tan alıyor. O bir bağlantıdan
+      ibarettir: hiçbir ziyareti bildirmez ve ona ne sizin ne de videonuz
+      hakkında bir şey verilir."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, bu sayfadaki her
+      şey çalışmaya devam eder. Hepsinin içindeki en basit kanıt bu."""
+
+[[howto]]
+title = "Bir video seçin."
+body = """
+ Seçiciye bir MP4, MOV, M4V ya da WebM
+      bırakın veya elle seçin. Tarayıcı onu doğrudan diskinizden okur; siz bunu
+      yaparken hiçbir yere hiçbir şey gönderilmez."""
+
+[[howto]]
+title = "Bölümü işaretleyin."
+body = """
+ Klibi oynatın ve başlaması gereken
+      yerde <kbd>I</kbd>'ya, bitmesi gereken yerde <kbd>O</kbd>'ya basın ya da
+      çubuktaki tutamakları sürükleyin. Bir GIF birkaç saniyeliktir &mdash;
+      dosyanın küçük mü yoksa devasa mı olacağına karar veren ayar, diğer
+      ikisinden çok daha fazla, budur."""
+
+[[howto]]
+title = "Genişliği ve kare hızını seçin."
+body = """
+ 480 piksel genişlik ve
+      saniyede 12 kare, bir GIF'in işine yarayan çoğu şeye uyar. Genişliği
+      yarıya indirmek piksel sayısını dörtte bire düşürür; saniyede on iki kare,
+      kimsenin görmediği kareleri ödemeden hareket olarak okunur."""
+
+[[howto]]
+title = "Yapın ve indirin."
+body = """
+ Kareler okunur, animasyonun tamamı için
+      256 renklik tek bir palet seçilir ve her kare yalnızca görüntünün değişen
+      bölümü olarak yazılır. Bittiğinde sayfada oynar; indirmenin size verdiği
+      de aynı dosyadır."""
+
+[[faq]]
+q = "Videom herhangi bir yere yükleniyor mu?"
+a = """
+        Hayır. Kendi donanımınızda, kendi tarayıcınız tarafından okunur,
+        örneklenir ve dönüştürülür. Bu aracın sunucu tarafı yoktur ve sayfanın
+        <code>Content-Security-Policy</code>'si iletişim kurabileceği her adresi
+        tek tek sayar &mdash; bunların hiçbiri bu siteye ait değildir. Size
+        söylenene güvenmek yerine denetlemeyi tercih ediyorsanız internet
+        bağlantısını kesin ve yine de bir GIF yapın."""
+
+[[faq]]
+q = "Hangi video biçimlerini dönüştürebilirim?"
+a = """
+        MP4, M4V ve MOV içlerinde ne olursa olsun doğrudan okunur: H.264, HEVC,
+        AV1 ya da VP9 &mdash; yeter ki tarayıcınız o kodlayıcıyı çözebilsin.
+        Tarayıcınızın oynatabildiği başka her şey &mdash; en bilineni WebM
+        &mdash; bunun yerine oynatıcı her ana ayrı ayrı aranarak okunur; bu daha
+        yavaştır ve hangi karenin nereye düşeceği konusunda biraz daha az
+        kesindir. Tarayıcının ne okuyabildiği ne de oynatabildiği bir dosya, ki
+        pratikte AVI, WMV, FLV ve çoğu MKV demektir, yarı yolda başarısız olmak
+        yerine bunu söyleyen bir mesajla geri çevrilir."""
+
+[[faq]]
+q = "GIF'im neden bu kadar büyük?"
+a = """
+        Çünkü GIF, hareketi değil bütün görüntüleri saklayan 1987'den kalma bir
+        biçim. Beş saniyelik bir klipten, geldiği beş saniyelik MP4 kadar küçük
+        bir GIF yapmanın yolu yok &mdash; bir videonun GIF'i çoğu zaman videonun
+        on katı olur. Bunu asıl belirleyen üç ayar, sırasıyla: bölümün ne kadar
+        uzun olduğu, görüntünün ne kadar geniş olduğu ve saniyedeki kare sayısı.
+        Genişliği yarıya indirmek piksel sayısını dörtte bire düşürür ve maliyeti
+        yaratan pikseldir."""
+
+[[faq]]
+q = "Neden yalnızca 256 renk?"
+a = """
+        Biçim böyle: bir GIF en fazla 256 renkten oluşan tek bir tablo taşır ve
+        her pikseli o tabloya bir sayı olarak saklar. Bu araç, bölümünüzün her
+        karesindeki renkleri sayıp 256 gruba bölerek o 256'yı seçer &mdash;
+        medyan kesme, standart yöntem &mdash; böylece palet sabit bir renk
+        kümesi olmak yerine klibinize uyar. Bir rengin eksik olduğu yerde
+        dithering en yakın iki rengi karıştırır, böylece bir geçiş çizgilere
+        dönüşmek yerine geçiş olarak kalır."""
+
+[[faq]]
+q = "Dithering ayarı ne yapıyor?"
+a = """
+        Az miktarda gürültüyü çok miktarda bantlaşmayla takas eder. Açıkken,
+        yoksa dört düz banda dönüşecek bir gökyüzü geçiş olarak kalır; bunun
+        bedeli hafif bir doku ve daha büyük bir dosyadır. Kapalıyken görüntü
+        daha düz, dosya daha küçük olur ki bu da ekran kayıtlarına, çizgi
+        çalışmalarına ve zaten düz renkten oluşan her şeye uyar. Burada
+        kullanılan dithering, hata yayan türden değil sıralı türdendir; böylece
+        değişmeyen bir arka plan kareler arasında titremek yerine tam olarak
+        sabit kalır."""
+
+[[faq]]
+q = "Uzunlukta veya boyutta bir sınır var mı?"
+a = """
+        Sınırlı olan bölüm ve bunu bir kural değil bellek belirliyor: palet
+        seçilirken bölümün her karesi aynı anda tutulur, bu yüzden sayfa
+        ayarlarınızın neye mal olacağını hesaplar ve başlamadan önce söyler.
+        Sekmenin belleği tüketip yok olmasına izin vermek yerine reddeder. Daha
+        kısa bir bölüm, daha küçük bir genişlik ya da daha düşük bir kare hızı,
+        üçü de bunu aşağı çeker."""
+
+[[faq]]
+q = "Sesi koruyor mu?"
+a = """
+        Bir GIF ses taşıyamaz. Biçimin sesi olan bir sürümü yok; webin GIF'lerin
+        yerine büyük ölçüde sessiz döngü videolarını koymasının başlıca sebebi de
+        bu. Ses önemliyse videoyu saklayın &mdash;
+        <a href="../video-kesme/">Video Kesici</a> ondan bir bölümü tek bir
+        kareyi bile yeniden kodlamadan keser."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap açmam gerekiyor mu?"
+a = """
+        Ücretsiz; hesap yok, giriş yok, deneme süresi yok, filigran yok. Sitede
+        reklam var, masrafı karşılayan da o; reklamlara videonuz hakkında hiçbir
+        şey verilmiyor."""
+
+[schema]
+browser_requirements = "JavaScript gerekir. MP4 ve MOV için WebCodecs destekleyen bir tarayıcı gerekir; tarayıcının oynatabildiği her şey onsuz da çalışır."
+description = "Bir videonun bir bölümünü tarayıcıda hareketli GIF'e dönüştürün. Kareler seçtiğiniz hızda örneklenir, animasyonun tamamı için medyan kesmeyle 256 renklik tek bir palet seçilir ve her kare yalnızca değişen bölge olarak yazılır. Hiçbir şey yüklenmez."
+features = [
+  "MP4, MOV, M4V ve WebM videoyu hareketli GIF'e dönüştürür",
+  "H.264, HEVC, AV1 ve VP9 kaynakları, WebCodecs üzerinden çözülür",
+  "Bölümü zaman çizelgesinde işaretleyin ya da tam zamanları yazın",
+  "Her genişlik, saniyede 5 ila 25 kare, isteğe bağlı sıralı dithering",
+  "Çevrimdışı çalışır; yükleme yok, hesap yok, filigran yok",
+]
+
+[picker]
+title = "Bir videoyu buraya bırakın"
+hint = "ya da göz atmak için tıklayın &mdash; MP4, MOV, M4V, WebM ve bu tarayıcının oynattığı her şey"


### PR DESCRIPTION
Turkish was published with its frame translated and one tool behind it. This
takes it to every page: 32 tools, 29 guides, the privacy page and the terms
page. The build no longer prints a `tr:` line at all, which is how a locale
says it has no English left — it is now in the sitemap, in the hreflang sets
and in the switcher for every page rather than for the frame alone.

## What is in it

- **32 tools**, each as `tool.toml` overrides plus a translated `body.html`.
- **29 guides**, plus **privacy** and **terms**.
- **Six new slugs** in `locales/tr/locale.toml` for the tools and guides that
  shipped after that file was written: `dicom-goruntuleyici`, `belge-tarayici`,
  `pdf-karartma` and their three guides.

## Decisions worth reviewing

**Every cross-link carries the Turkish slug.** `check_links` in `build.py`
refuses a build where a link on a published page leads to a page that was not
built, so an href left in English would have failed the build the moment the
locale claimed to be whole. Anchor text uses the Turkish name of the tool it
points at, taken from that tool's own locale file.

**"Kırpma" and "kesme" are kept rigidly apart.** English uses "trim" and "crop"
for two jobs that Turkish does not name with one word: `kırpma` changes the
shape of a picture or a frame, `kesme` shortens a clip in time, and `sıkıştırma`
reduces a file's size. The crop-a-video and trim-a-video guides sit next to each
other and link to each other, so a reader who confused them would end up in the
wrong tool.

**A counted noun takes no plural suffix.** "5 sayfa", never "5 sayfalar" — so
the English singular/plural phrase pairs (`count.page`/`count.pages`,
`series.files.one`/`series.files`) carry the same bare Turkish form, mirroring
what `guide_one`/`guide_many` already do in `locale.toml`.

**Names that get typed stay Latin and stay spelled as they are:** `favicon.ico`,
`app.ico`, `browserconfig.xml`, `Info.plist`, `CFBundleIconFile`, `iconutil`,
`PyYAML`, `git diff`, `git apply`, and the format acronyms. Somebody is going to
search for one of these, or paste it.

**`analytics_extra` is deliberately left out of every file.** It is prose, but
`buildlib/i18n.py` counts it as structure: it is the tail of a comment in
`templates/analytics.js` that the minifier strips before anything ships, so a
translation would be read by nobody and would put the locale into debt on that
tool.

## Checks

- `python build.py --clean --no-minify` — builds, and `tr` no longer appears in
  the per-locale debt list.
- `python -m unittest discover -t . -s tests/python` — passes.
- Every `data-phrase` key and every `{placeholder}` inside one was compared
  against the English `body.html` for the six tools that have a `#phrases`
  block; a dropped placeholder renders as literal text and the build cannot
  detect it.

Rebased on `main` at #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
