### PR TITLE
Indonesian: the whole locale, 65 of 65 pages

### DIFF
--- a/locales/id/locale.toml
+++ b/locales/id/locale.toml
@@ -130,6 +130,13 @@ complete = true
 "guides/redact-a-pdf" = "panduan/sensor-pdf"
 "guides/scan-a-document-with-your-phone" = "panduan/memindai-dokumen-dengan-ponsel"
 
+# The stacker, which shipped after the three above. "Tumpuk" is the ordinary
+# word for piling one thing on another, and it is what the tool does to a
+# burst; RAW keeps its Latin spelling because that is what is printed on the
+# camera menu the reader just came from.
+"stack-images" = "tumpuk-gambar"
+"guides/stack-photos-to-reduce-noise" = "panduan/tumpuk-foto-untuk-mengurangi-derau"
+
 #
 # ---------------------------------------------------------------------------
 # The hub.

--- a/locales/id/locale.toml
+++ b/locales/id/locale.toml
@@ -119,6 +119,17 @@ complete = true
 "guides/whats-inside-a-gif" = "panduan/apa-isi-di-dalam-gif"
 "guides/verify-a-file-checksum" = "panduan/memverifikasi-checksum-file"
 
+# The three that shipped after this file was first written. The tools keep
+# their Latin acronyms in the address for the reason given at the top: DICOM
+# and PDF are what a reader types, and an Indonesian spelling of either would
+# invent a word nobody searches for.
+"dicom-viewer" = "penampil-dicom"
+"document-scanner" = "pemindai-dokumen"
+"redact-pdf" = "sensor-pdf"
+"guides/open-a-dicom-file" = "panduan/membuka-file-dicom"
+"guides/redact-a-pdf" = "panduan/sensor-pdf"
+"guides/scan-a-document-with-your-phone" = "panduan/memindai-dokumen-dengan-ponsel"
+
 #
 # ---------------------------------------------------------------------------
 # The hub.

--- a/locales/id/pages/guides/combine-images-into-a-pdf.html
+++ b/locales/id/pages/guides/combine-images-into-a-pdf.html
@@ -1,0 +1,206 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../gambar-ke-pdf/">Gambar ke PDF</a>, jatuhkan gambarnya,
+      seret ubinnya sampai urutannya benar, lalu buat dokumennya. Bawaannya
+      &mdash; halaman A4, margin kecil, foto disalin masuk tanpa dikodekan ulang
+      &mdash; adalah yang diinginkan kebanyakan orang.
+    </p>
+    <p>
+      Empat hal yang layak dipikirkan sekali lagi adalah urutannya, ukuran
+      halamannya, setelan kualitasnya, dan apa yang dikatakan dokumen jadinya
+      tentang Anda. Dalam urutan seberapa sering masing-masing keliru.
+    </p>
+  </section>
+
+  <section>
+    <h2>Benarkan urutannya sebelum yang lain</h2>
+    <p>
+      Urutan halaman adalah satu hal yang paling sering keliru, karena nama file
+      terurut dengan cara yang tidak diduga siapa pun. <code>IMG_2.jpg</code>
+      datang setelah <code>IMG_10.jpg</code> dalam pengurutan alfabetis, karena
+      perbandingannya karakter demi karakter dan <code>1</code> sebelum
+      <code>2</code>. Satu folder pindaian bernama <code>halaman1</code> sampai
+      <code>halaman12</code> akan tiba dalam urutan yang salah di hampir semua
+      alat.
+    </p>
+    <p>
+      Mengurutkan menurut tanggal pengambilan biasanya lebih bisa diandalkan
+      untuk foto, karena Anda memotret halamannya dalam urutan susunannya.
+      Bagaimanapun juga, periksa ubinnya sebelum Anda menekan tombolnya
+      alih-alih memeriksa PDF-nya sesudahnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kualitas: bagian yang diam-diam dikacaukan kebanyakan alat</h2>
+    <p>
+      Sebuah PDF bisa membawa data JPEG secara langsung. Itu sifat formatnya:
+      byte terkompres sebuah JPEG bisa dijatuhkan ke dalam dokumennya apa adanya,
+      dan pembacanya mendekodekannya dengan cara yang sama seperti sebuah
+      peramban.
+    </p>
+    <p>
+      Ini penting karena artinya sebuah foto tidak harus kehilangan apa pun dalam
+      perjalanannya masuk ke sebuah PDF. Ia tidak pernah didekodekan dan tidak
+      pernah dikompres lagi; gambar di dalam dokumennya bit demi bit sama dengan
+      gambar di file Anda. Banyak alat tetap mengodekan ulang &mdash; lebih
+      sederhana menggambar semuanya ke sebuah kanvas lalu mengodekan seragam
+      &mdash; dan hasilnya satu generasi kualitas hilang tanpa alasan.
+    </p>
+    <p>
+      Format lain tidak bisa menumpang seperti itu. PNG, WebP, HEIC, dan
+      sisanya tidak punya filter yang cocok di PDF, jadi mereka harus diubah.
+      Anda mendapat pilihan tentang caranya:
+    </p>
+    <ul>
+      <li>
+        <strong>Kodekan ulang sebagai JPEG</strong> (bawaannya). File terkecil,
+        sedikit ongkos kualitas, dan jawaban yang benar untuk foto.
+      </li>
+      <li>
+        <strong>Tanpa kehilangan.</strong> Menyimpan pikselnya persis dengan
+        ongkos dokumen yang jauh lebih besar. Jawaban yang benar untuk tangkapan
+        layar, diagram, dan apa pun yang ada teks atau tepi tajam di dalamnya,
+        tempat artefak JPEG kelihatan jelas.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Ukuran halaman, dan kapan &ldquo;paskan ke gambarnya&rdquo; lebih baik</h2>
+    <p>
+      Ukuran halaman standar &mdash; A4, Letter, Legal, A3, A5, Tabloid &mdash;
+      menaruh setiap gambar di halaman seukuran itu, diskalakan agar muat di
+      dalam margin Anda. Pakai satu ketika dokumennya akan dicetak, atau ketika
+      seseorang yang resmi akan mengarsipkannya.
+    </p>
+    <p>
+      &ldquo;Tepat seukuran tiap gambar&rdquo; membuat setiap halaman sesuai
+      gambarnya, jadi tidak ada ruang putih dan sama sekali tidak ada
+      penskalaan. Pakai itu ketika PDF-nya sebuah wadah untuk gambar alih-alih
+      sebuah dokumen: portofolio, kumpulan tangkapan layar, sebuah komik. Ia
+      tampak keliru ketika dicetak, karena setiap halamannya berbeda ukuran.
+    </p>
+    <p>
+      Margin layak dipunyai pada apa pun yang akan dicetak. Pencetak rumahan
+      tidak bisa mencetak sampai ke tepi kertas, dan foto yang ditaruh dari tepi
+      ke tepi keluar terpotong.
+    </p>
+    <h3>Halaman potret dari foto lanskap</h3>
+    <p>
+      Kalau Anda memotret halaman kertas dengan ponsel yang dipegang menyamping,
+      setiap gambarnya akan berupa lanskap dan akan duduk kecil di tengah sebuah
+      halaman potret. Memutar masing-masing seperempat putaran sebelum Anda
+      membangun dokumennya itulah yang membereskannya, dan itu pilihan per gambar
+      alih-alih pilihan menyeluruh, karena biasanya beberapa di antaranya sudah
+      masuk dengan arah yang benar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang dikatakan PDF jadinya tentang Anda</h2>
+    <p>
+      Sebuah PDF membawa blok informasi dokumen: penulis, produser, tanggal
+      pembuatan, kadang judulnya. Tergantung apa yang menulisnya, itu bisa
+      memuat nama akun Anda, nama mesin Anda, dan waktu persis Anda membuatnya.
+    </p>
+    <p>
+      Itu layak dipikirkan, karena PDF adalah hal yang dikirim orang kepada orang
+      lain &mdash; lamaran kerja, sebuah klaim, sebuah dokumen untuk pemilik
+      kontrakan. Metadatanya bepergian bersamanya dan pembaca mana pun bisa
+      menampilkannya.
+    </p>
+    <p>
+      Alat di sini membiarkan blok itu kosong kecuali namanya sendiri: tidak ada
+      nama file, tidak ada nama mesin, tidak ada nama pengguna, dan tidak ada
+      tanggal pembuatan kecuali Anda mencentang kotak yang memintanya. Kalau Anda
+      memakai alat lain, layak membuka properti hasilnya sekali untuk melihat apa
+      yang ditulisnya.
+    </p>
+    <p>
+      Terpisah dari itu: gambarnya sendiri. Kalau foto Anda membawa tag EXIF dan
+      GPS, apa yang terjadi pada mereka tergantung jalurnya. JPEG yang disalin
+      masuk tanpa dikodekan ulang menyimpan apa pun yang ada di dalamnya; gambar
+      yang dikodekan ulang kehilangan tagnya sebagai efek samping. Kalau itu
+      penting, bersihkan fotonya lebih dulu dengan
+      <a href="../../hapus-data-exif/">Penampil &amp; Penghapus EXIF</a> &mdash;
+      <a href="../hapus-data-exif-dan-gps/">panduannya</a> menjelaskan apa saja
+      yang ada di dalamnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kalau PDF-nya keluar terlalu besar</h2>
+    <p>
+      Foto ponsel itu besar, dan dua puluh di antaranya membuat dokumen yang akan
+      ditolak email. Tiga hal untuk dicoba, berurutan:
+    </p>
+    <p>
+      <strong>Kecilkan sisi terpanjangnya.</strong> Foto 4000 piksel selembar
+      kertas membawa jauh lebih banyak detail daripada yang akan dipakai pembaca
+      atau pencetak mana pun. Menurunkan sisi panjangnya ke sekitar 2000 piksel
+      biasanya menyeperempatkan file-nya dan tidak mengubah apa pun yang bisa
+      dilihat orang di sebuah halaman.
+    </p>
+    <p>
+      <strong>Pakai JPEG alih-alih tanpa kehilangan</strong> untuk apa pun yang
+      bersifat foto. Tanpa kehilangan adalah jawaban yang benar untuk diagram dan
+      jawaban yang keliru untuk foto sebuah halaman.
+    </p>
+    <p>
+      <strong>Kompres dokumen jadinya.</strong>
+      <a href="../../kompres-pdf/">Kompresor PDF</a> bekerja terhadap seberapa
+      besar setiap gambar digambar di halamannya alih-alih terhadap jumlah
+      pikselnya, dan itulah pengukuran yang penting;
+      <a href="../perkecil-ukuran-pdf/">panduannya</a> membahas berapa harganya.
+    </p>
+    <p>
+      Tidak ada batas yang dibangun ke dalam alatnya soal berapa banyak gambar
+      yang bisa Anda pakai. Langit-langit praktisnya adalah memori mesin Anda
+      sendiri, karena dokumen jadinya dirakit di sana sebelum Anda mengunduhnya
+      &mdash; beberapa ratus foto ponsel pada resolusi penuh adalah yang pertama
+      merasakannya, dan mengecilkan sisi terpanjangnya menggeser langit-langit itu
+      cukup jauh.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang tidak akan diberikannya kepada Anda</h2>
+    <p>
+      PDF yang dibuat dari foto adalah PDF yang penuh gambar. Kata-kata di
+      dalamnya bukan teks: Anda tidak bisa mencarinya, menyalinnya, atau
+      menyuruh pembaca layar membacanya. Itu sifat dari apa yang Anda mulai,
+      bukan sifat pengubahannya.
+    </p>
+    <p>
+      Kalau Anda butuh teks yang bisa dicari, Anda butuh OCR, dan itu pekerjaan
+      yang berbeda. Dan kalau dokumen aslinya masih ada sebagai sebuah dokumen di
+      suatu tempat, mengekspornya langsung ke PDF akan selalu mengalahkan
+      memotretnya &mdash; lebih kecil, lebih tajam, bisa dicari.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh unggahan</h2>
+    <p>
+      Menulis sebuah PDF adalah menulis sebuah file berstruktur: sebuah header,
+      sekumpulan objek, sebuah tabel rujukan silang. Tidak ada apa pun di
+      dalamnya yang tidak bisa dilakukan sebuah peramban, dan tidak ada apa pun
+      tentang pekerjaannya yang menuntut gambarnya bepergian ke mana pun.
+    </p>
+    <p>
+      Dan itu layak dipedulikan di sini, karena apa yang ditaruh orang di dokumen
+      semacam ini. Surat identitas, rekening koran, surat medis, kontrak
+      bertanda tangan &mdash; seluruh alasan seseorang membuat sebuah PDF sama
+      sekali biasanya adalah karena mereka mengirimkannya ke sebuah lembaga. Alat
+      di sini tidak punya fitur jaringan dalam bentuk apa pun, dan
+      <code>Content-Security-Policy</code> halamannya menyebut satu per satu
+      setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan cara memeriksanya sendiri, di sini atau di
+      mana pun lain.
+    </p>
+  </section>

--- a/locales/id/pages/guides/combine-images-into-a-pdf.toml
+++ b/locales/id/pages/guides/combine-images-into-a-pdf.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: menggabungkan gambar menjadi satu PDF - Bahasa Indonesia.
+#
+
+nav = "Gambar menjadi PDF"
+title = "Cara Menggabungkan Gambar Menjadi Satu PDF"
+description = "Ubah foto atau pindaian menjadi satu PDF: ukuran halaman, urutan dan rotasinya, kenapa sebuah JPEG tidak perlu kehilangan kualitas sedikit pun dalam perjalanannya masuk, dan apa yang dikatakan sebuah PDF kepada orang yang Anda kirimi."
+
+heading = "Cara menggabungkan gambar menjadi satu PDF"
+lede = """
+    Seseorang meminta &ldquo;satu PDF&rdquo; dan Anda punya sebelas foto kertas.
+    Ini membahas pilihan yang benar-benar mengubah hasilnya &mdash; ukuran
+    halaman, urutan, kualitas, dan apa yang dikatakan dokumennya tentang Anda
+    &mdash; dan mana di antaranya yang bisa Anda abaikan."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara menggabungkan gambar menjadi satu PDF"
+og_description = "Ukuran halaman, urutan dan rotasinya, kenapa sebuah JPEG tidak perlu kehilangan kualitas dalam perjalanannya masuk, dan apa yang dikatakan sebuah PDF kepada orang yang Anda kirimi."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/compress-an-image-to-a-target-size.html
+++ b/locales/id/pages/guides/compress-an-image-to-a-target-size.html
@@ -1,0 +1,258 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../kompres-gambar/">Kompresor Gambar</a>, jatuhkan
+      fotonya, ketik angka yang diberikan kepada Anda, lalu tekan tombolnya. Ia
+      mengodekan gambarnya beberapa kali, menyimpan hasil terbaik yang muat di
+      bawah sasaran Anda, lalu memberi tahu berapa harganya. Untuk kebanyakan
+      foto dan kebanyakan sasaran, ringkasan jujurnya adalah Anda tidak akan bisa
+      melihat bedanya.
+    </p>
+    <p>
+      Sisa halaman ini untuk ketika itu tidak terjadi: ketika hasilnya tampak
+      lembek, ketika sebuah PNG nyaris tidak bergerak, atau ketika Anda ingin
+      tahu apa sebenarnya yang dilakukan alatnya pada gambar Anda sebelum Anda
+      mengirimnya kepada seseorang.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang sebenarnya diminta sebuah batas ukuran file</h2>
+    <p>
+      Sebuah JPEG atau WebP tidak menyimpan foto Anda. Ia menyimpan sebuah
+      keterangan tentangnya, dan setelan kualitasnya menentukan seberapa rinci
+      keterangan itu boleh. Turunkan dan file-nya menjadi lebih kecil karena
+      keterangannya menjadi lebih kabur: tekstur halus dirata-ratakan hilang,
+      gradien menjadi berpita, dan tepi mendapat halo blok yang samar.
+    </p>
+    <p>
+      Jadi batas ukuran adalah anggaran untuk detail. Pertanyaan yang berguna
+      bukan &ldquo;bisakah saya mencapai 500&nbsp;KB&rdquo; &mdash; Anda selalu
+      bisa mencapai angka mana pun &mdash; melainkan &ldquo;berapa banyak dari
+      gambarnya yang harus saya relakan untuk sampai ke sana, dan apakah itu
+      penting untuk apa yang saya lakukan dengannya?&rdquo;
+    </p>
+    <p>
+      Dua patokan kasar. Foto adegan nyata &mdash; wajah, dedaunan, kain &mdash;
+      menyembunyikan kompresi dengan baik, karena mata tidak punya area yang
+      benar-benar datar untuk menyadari kerusakannya. Tangkapan layar, bagan,
+      logo, atau apa pun dengan warna datar yang luas dan tepi teks yang keras
+      memperlihatkannya langsung, dan biasanya sebaiknya berupa PNG atau WebP
+      alih-alih JPEG sama sekali.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa tidak ada rumusnya, dan apa yang dilakukan tentang itu</h2>
+    <p>
+      Tidak ada cara menghitung setelan kualitas yang menghasilkan file
+      500&nbsp;KB. Hubungan antara keduanya sepenuhnya tergantung pada apa yang
+      ada di gambarnya: pada setelan yang sama, foto sebuah dinding polos bisa
+      keluar sepersepuluh ukuran foto sebuah hutan. Alat mana pun yang menawari
+      Anda &ldquo;kualitas: 60&rdquo; lalu berharap sedang menebak atas nama
+      Anda.
+    </p>
+    <p>
+      Satu-satunya metode yang bisa diandalkan adalah mencoba. Kodekan gambarnya,
+      lihat ukurannya, sesuaikan, kodekan lagi. Melakukan itu dengan tangan
+      melelahkan, dan itulah sebabnya kompresor meminta sebuah angka kualitas
+      sebagai gantinya &mdash; ia memindahkan kelelahannya kepada Anda.
+      Melakukannya otomatis kira-kira delapan pengodean, dan delapan pengodean
+      sebuah foto ponsel adalah sepersekian detik di mesin mana pun yang dibuat
+      dekade ini, dan itulah sebabnya alat situs ini meminta ukurannya lalu
+      melakukan pencariannya sendiri.
+    </p>
+    <p>
+      Setiap ukuran yang dilaporkannya adalah file terkodekan yang sungguhan,
+      bukan perkiraan. Itu penting ketika sebuah formulir punya batas keras:
+      perkiraan yang 2% terlalu optimistis adalah unggahan yang ditolak.
+    </p>
+  </section>
+
+  <section>
+    <h2>Belanjakan kualitas sebelum Anda membelanjakan piksel</h2>
+    <p>
+      Hanya ada dua cara membuat sebuah file gambar lebih kecil. Anda bisa
+      menggambarkan gambar yang sama dengan kurang tepat, dan itu kualitas. Atau
+      Anda bisa menggambarkan lebih sedikit piksel, dan itu pengubahan ukuran.
+      Keduanya tidak setara, dan urutannya penting.
+    </p>
+    <p>
+      Kualitas duluan, karena sekitar 30% pertama penurunan kualitas sungguh tak
+      terlihat pada sebuah foto &mdash; Anda sedang membuang detail yang disimpan
+      formatnya lebih cermat daripada yang bisa diperiksa mata mana pun. Piksel
+      belakangan, karena begitu kualitasnya turun cukup jauh sehingga artefaknya
+      terlihat, gambar yang lebih kecil pada kualitas yang layak tampak lebih
+      baik daripada gambar berukuran penuh yang sudah rusak. Lebih sedikit piksel
+      yang baik mengalahkan lebih banyak piksel yang buruk.
+    </p>
+    <p>
+      Itulah seluruh strateginya, dan ia layak diketahui bahkan kalau Anda
+      memakai alat lain: turunkan kualitasnya sampai ia mulai tampak keliru, lalu
+      kecilkan gambarnya alih-alih menurunkannya lebih jauh.
+    </p>
+    <h3>Kapan mengubah ukuran dengan sengaja</h3>
+    <p>
+      Kadang pikselnya memang tidak pernah dibutuhkan. Foto selebar 4000 piksel
+      yang ditampilkan di kolom selebar 600 piksel di sebuah halaman web membawa
+      enam kali detail yang akan dilihat siapa pun. Kalau Anda tahu rumah akhir
+      gambarnya, ubah ukurannya ke sana lebih dulu dan masalah ukurannya sering
+      lenyap tanpa kualitas apa pun dibelanjakan sama sekali.
+      <a href="../../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a> adalah alat
+      untuk pekerjaan itu, dan
+      <a href="../ubah-ukuran-gambar/">panduannya sendiri</a> membahas cara
+      memilih sebuah ukuran.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memilih format</h2>
+    <p>
+      Tiga format layak diketahui, dan peramban bisa menulis ketiganya.
+    </p>
+    <ul>
+      <li>
+        <strong>JPEG</strong> untuk foto. Ia merugikan, ia dipahami segala hal
+        yang pernah dibuat, dan untuk gambar sebuah adegan nyata ia masih pilihan
+        yang sangat baik. Ia tidak bisa menyimpan transparansi.
+      </li>
+      <li>
+        <strong>WebP</strong> untuk pekerjaan yang sama, dikerjakan lebih baik:
+        kira-kira 25&ndash;35% lebih kecil daripada JPEG pada kualitas yang tidak
+        bisa Anda bedakan, dan ia menyimpan transparansi. Setiap peramban masa
+        kini membacanya. Beberapa aplikasi desktop yang lebih tua dan sebagian
+        formulir unggahan perusahaan masih tidak, dan itu satu-satunya alasan
+        sungguhan untuk tidak memakainya.
+      </li>
+      <li>
+        <strong>PNG</strong> tanpa kehilangan, artinya ia tepat dan ia besar. Ia
+        jawaban yang benar untuk tangkapan layar, logo, gambar garis, dan apa pun
+        yang bertepi tajam atau berwarna datar, dan jawaban yang keliru untuk
+        sebuah foto.
+      </li>
+    </ul>
+    <p>
+      Kalau Anda tidak punya kekangan dari siapa pun yang meminta file-nya, WebP
+      akan membawa Anda ke sebuah sasaran dengan kerusakan yang lebih sedikit
+      terlihat daripada JPEG. Kalau file-nya akan masuk ke sesuatu yang tua, atau
+      ke sebuah sistem yang tidak bisa Anda uji, JPEG adalah jawaban yang aman.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa PNG Anda tidak akan jauh lebih kecil</h2>
+    <p>
+      Inilah kejutan yang paling umum, dan itu bukan bug di alat mana pun yang
+      Anda pakai. PNG adalah format tanpa kehilangan: ia menyimpan piksel yang
+      persis, dan ia tidak punya tombol kualitas untuk diputar, karena memutar
+      satu akan menjadikannya format yang berbeda. Yang bisa dilakukan kompresor
+      PNG hanyalah mengemas piksel yang sama dengan lebih cerdik, dan itu
+      biasanya bernilai beberapa persen.
+    </p>
+    <p>
+      Jadi kalau Anda harus punya file yang jauh lebih kecil dan ia harus tetap
+      PNG, satu-satunya tuas yang tersisa adalah ukuran &mdash; lebih sedikit
+      piksel, atau lebih sedikit warna. Kalau ia boleh berhenti menjadi PNG,
+      pertanyaannya adalah apa isinya:
+    </p>
+    <ul>
+      <li>
+        <strong>Sebuah foto yang disimpan sebagai PNG.</strong> Sangat umum,
+        biasanya karena tidak sengaja, dan kemenangan termudah di halaman ini:
+        mengubahnya menjadi JPEG atau WebP sering membuatnya lima sampai sepuluh
+        kali lebih kecil tanpa perubahan yang terlihat.
+      </li>
+      <li>
+        <strong>Sebuah tangkapan layar atau diagram.</strong> Ubah menjadi WebP,
+        yang juga tanpa kehilangan kalau Anda memintanya begitu, dan umumnya
+        lebih kecil daripada PNG untuk piksel yang sama. Pergi ke JPEG akan
+        membuat tepi teksnya kabur.
+      </li>
+      <li>
+        <strong>Sebuah logo dengan transparansi.</strong> WebP menyimpan
+        transparansinya; JPEG akan mengisinya dengan warna padat, dan itu hampir
+        tidak pernah yang Anda mau.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bagaimana tahu apakah hasilnya cukup baik</h2>
+    <p>
+      Melihat sebuah gambar mini tidak membuktikan apa-apa &mdash; semuanya
+      tampak baik-baik saja pada ukuran gambar mini. Dua pemeriksaan yang lebih
+      baik:
+    </p>
+    <p>
+      <strong>Lihat pada ukuran penuh, pada benda paling datar di
+      bingkainya.</strong> Langit, kulit, dinding bercat. Kerusakan kompresi
+      muncul lebih dulu di gradien yang mulus, sebagai blok atau pita samar, jauh
+      sebelum ia menyentuh area yang rinci.
+    </p>
+    <p>
+      <strong>Baca pengukurannya, kalau alatnya memberi Anda satu.</strong>
+      Kompresor di sini mendekodekan hasilnya sendiri lalu membandingkannya
+      dengan aslinya, dan melaporkan SSIM: sebuah angka yang membandingkan
+      kecerahan, kontras, dan struktur setempat alih-alih menghitung piksel yang
+      berubah, dan itu jauh lebih dekat dengan apa yang dikeluhkan sebuah mata.
+      Di atas kira-kira 0,98 kedua gambarnya sulit dipisahkan berdampingan. Di
+      bawah sekitar 0,95, lihat dulu sebelum Anda mengirim. Ia juga melaporkan
+      PSNR, angka desibel tradisionalnya, untuk siapa pun yang lebih
+      menyukainya.
+    </p>
+    <p>
+      Keduanya dihitung di mesin Anda sendiri lalu ditampilkan kepada Anda, dan
+      itulah gunanya memilikinya: ia mengubah &ldquo;kehilangan kualitas
+      minimal&rdquo; dari sebuah klaim menjadi angka yang bisa Anda periksa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tiga hal yang layak diketahui sebelum Anda mengirim file-nya</h2>
+    <p>
+      <strong>Mengompres membersihkan metadatanya.</strong> Mengodekan ulang
+      berarti mendekodekan gambarnya menjadi piksel lalu mengodekan piksel itu
+      lagi, dan kanvas yang penuh piksel tidak membawa tag &mdash; jadi posisi
+      GPS, model kamera, cap waktu, dan sisanya sekadar tidak ditulis ke file
+      barunya. Biasanya itu bonus. Kalau Anda ingin tagnya hilang tapi gambarnya
+      tidak tersentuh, itu pekerjaan yang berbeda:
+      <a href="../../hapus-data-exif/">Penampil &amp; Penghapus EXIF</a> menulis
+      ulang wadahnya tanpa mengompres ulang apa pun, dan
+      <a href="../hapus-data-exif-dan-gps/">panduannya</a> menjelaskan apa saja
+      yang ada di dalamnya.
+    </p>
+    <p>
+      <strong>Jangan pernah mengompres file yang sama dua kali.</strong> Setiap
+      pengodean yang merugikan membuang detail secara permanen, dan mengodekan
+      gambar yang sudah terkompres membuang lebih banyak lagi &mdash; termasuk
+      artefak dari jalan pertamanya, yang dijaganya dengan setia dengan
+      mengorbankan detail yang sungguhan. Selalu kembali ke aslinya lalu kompres
+      sekali.
+    </p>
+    <p>
+      <strong>Simpan aslinya.</strong> Tidak ada jalan kembali dari sebuah
+      pengodean yang merugikan. Apa pun yang Anda kirim, simpan file yang Anda
+      mulai di suatu tempat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Setiap peramban sudah mengirimkan pengode JPEG, PNG, dan WebP
+      bertahun-tahun &mdash; ia kode yang sama yang menyimpan sebuah gambar dari
+      sebuah kanvas. Mengompres sebuah gambar adalah salah satu pekerjaan yang
+      sama sekali tidak punya alasan teknis melibatkan sebuah server, dan itulah
+      sebabnya alat di sini tidak punya satu: gambarnya didekodekan, dikodekan,
+      dan diukur di mesin Anda sendiri, dan tidak ada alamat di
+      <code>Content-Security-Policy</code> halamannya yang milik situs ini untuk
+      dikirimi.
+    </p>
+    <p>
+      Cara paling sederhana memastikannya, di sini atau di mana pun lain, adalah
+      memuat halamannya, memutuskan koneksi internet, lalu tetap mengompres
+      sesuatu. Kalau ia masih bekerja, tidak ada yang diunggah.
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain seperti itu.
+    </p>
+  </section>

--- a/locales/id/pages/guides/compress-an-image-to-a-target-size.toml
+++ b/locales/id/pages/guides/compress-an-image-to-a-target-size.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: mengompres gambar ke ukuran tertentu - Bahasa Indonesia.
+#
+
+nav = "Mengompres gambar"
+title = "Cara Mengompres Gambar ke Ukuran File yang Tepat"
+description = "Sebuah formulir unggahan meminta 500 KB dan foto Anda 4 MB. Berapa sebenarnya harga sebuah batas ukuran, setelan mana yang digerakkan lebih dulu, dan kenapa sebuah PNG tidak akan menyusut seperti JPEG."
+
+heading = "Cara mengompres gambar ke ukuran file yang tepat"
+lede = """
+    Seseorang sudah menyebutkan sebuah angka kepada Anda &mdash; 100&nbsp;KB,
+    500&nbsp;KB, 2&nbsp;MB &mdash; dan foto Anda jauh dari itu. Inilah berapa
+    harga angka itu, untuk apa membelanjakannya, dan bagaimana tahu apakah
+    hasilnya masih cukup baik untuk dikirim."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Mengompres gambar ke ukuran file yang tepat"
+og_description = "Berapa sebenarnya harga sebuah batas ukuran, setelan mana yang digerakkan lebih dulu, dan kenapa sebuah PNG tidak akan menyusut seperti JPEG."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/convert-an-svg-to-png.html
+++ b/locales/id/pages/guides/convert-an-svg-to-png.html
@@ -1,0 +1,252 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../svg-ke-png/">SVG ke Gambar</a>, jatuhkan file-nya, lalu
+      sebutkan sebuah ukuran. Kalau tidak ada yang memberi tahu Anda ukuran apa
+      yang dipakai, <strong>1024 piksel di sisi terpanjang</strong> adalah bawaan
+      yang baik: cukup besar untuk hampir apa saja dan cukup kecil untuk dikirim
+      lewat surel. Biarkan formatnya di PNG, biarkan latarnya transparan, lalu
+      ambil file-nya.
+    </p>
+    <p>
+      Semua di bawah ini adalah apa yang dilakukan ketika bawaan itu tidak cukup
+      baik &mdash; ketika sebuah angka sudah ditetapkan untuk Anda, ketika ia
+      akan dicetak, atau ketika ia kembali tampak keliru.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ukurannya keputusan Anda dan bukan keputusan file-nya</h2>
+    <p>
+      Sebuah JPEG adalah kisi piksel terukur; menanyakan seberapa besar dia punya
+      jawaban. Sebuah SVG sama sekali bukan sebuah gambar, ia sekumpulan
+      instruksi &mdash; gambar lingkaran di sini, jalur ini dalam warna itu
+      &mdash; dan instruksi tidak punya ukuran. Sebuah peramban bisa
+      melaksanakannya pada 16 piksel atau pada 4000 dan hasilnya sama tajamnya
+      bagaimanapun juga, karena ia tidak sedang menskalakan apa pun. Ia sedang
+      menggambar lagi.
+    </p>
+    <p>
+      Itulah sebabnya pengubahannya tidak bisa memilih sebuah angka untuk Anda,
+      dan sebabnya memilih yang besar tidak mengorbankan apa pun. Inilah
+      satu-satunya pekerjaan gambar yang &ldquo;buat lebih besar&rdquo;-nya
+      gratis.
+    </p>
+    <p>
+      Kebanyakan file SVG memang membawa atribut <code>width</code> dan
+      <code>height</code>, dan sebuah alat akan menampilkannya &mdash; tapi itu
+      sebuah bawaan, bukan sebuah batas. Ikon yang berkata
+      <code>width="24"</code> hanya berkata bahwa orang yang menggambarnya punya
+      bilah alat 24&nbsp;piksel dalam pikirannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dari mana sebenarnya angkanya datang</h2>
+    <p><strong>Untuk sebuah situs web.</strong> Ambil ukuran yang ditempati
+      gambarnya di halamannya dalam piksel CSS lalu kalikan dengan kepadatan
+      piksel layar yang Anda pedulikan. Sebuah logo di slot selebar
+      200&nbsp;piksel butuh file 400&nbsp;piksel untuk laptop Retina dan 600
+      untuk ponsel keluaran baru. Itulah seluruh yang dimaksud
+      <code>@2x</code> dan <code>@3x</code>, dan itulah sebabnya alat yang
+      menuliskannya menghemat Anda mengerjakan hitungannya tiga kali.
+    </p>
+    <p><strong>Untuk ikon aplikasi, iklan toko, atau favicon.</strong> Angkanya
+      diterbitkan dan tidak ada yang perlu diperhitungkan: apa pun yang dikatakan
+      halaman tokonya, persis. Untuk sebuah favicon, jangan diraster sama sekali
+      &mdash; <a href="../buat-favicon/">buat sebuah .ico</a>, yang menyimpan
+      beberapa ukuran dalam satu file, karena tab peramban, sebuah markah, dan
+      pintasan Windows semuanya meminta ukuran yang berbeda.
+    </p>
+    <p><strong>Untuk cetak.</strong> Kalikan ukuran fisiknya dalam inci dengan
+      resolusi pencetaknya. Sebuah logo yang akan masuk ke kartu nama selebar dua
+      inci pada 300&nbsp;DPI adalah 600 piksel; logo yang sama melintasi halaman
+      A4, pada 8,3&nbsp;inci, adalah sekitar 2500. Percetakan meminta
+      300&nbsp;DPI sebagai kelaziman, dan untuk spanduk format besar yang dilihat
+      dari seberang ruangan 150 sudah lebih dari cukup.
+    </p>
+    <p><strong>Untuk pratinjau sosial atau gambar OG.</strong> Lapaknya
+      menyebutkan sebuah kotak &mdash; 1200&nbsp;&times;&nbsp;630 untuk
+      kebanyakan pratinjau tautan &mdash; dan kotaknya berbeda bentuk dari logo
+      Anda. Untuk itulah setelan &ldquo;isi sisanya&rdquo; ada: gambarnya
+      diletakkan di tengah pada proporsinya sendiri, dengan sebuah warna latar
+      mengisi sisanya, alih-alih logo yang teregang yang memberi tahu semua orang
+      bahwa Anda tidak memeriksanya.
+    </p>
+    <p>
+      Ketika dua di antaranya berlaku, pakai yang lebih besar. PNG yang lebih
+      besar daripada yang dibutuhkannya adalah unduhan yang sedikit lebih besar;
+      yang terlalu kecil tidak bisa dibetulkan belakangan, karena alasan di
+      bagian berikutnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Anda tidak bisa kembali</h2>
+    <p>
+      Perasteran itu satu arah. Begitu gambarnya menjadi sebuah PNG, ia piksel
+      seperti gambar lain mana pun, dan membesarkannya sesudahnya harus mengarang
+      detail yang tidak pernah terukur &mdash; hasil lembek dan tercoreng yang
+      sama seperti yang Anda dapat dari membesarkan sebuah foto.
+    </p>
+    <p>
+      Jadi simpan SVG-nya. Ia salinan induknya, ia hampir selalu file yang lebih
+      kecil, dan setiap ukuran di masa depan keluar darinya dengan sempurna.
+      PNG-nya adalah sebuah ekspor untuk satu pemakaian tertentu, dan ketika Anda
+      butuh ukuran lain, langkah yang benar adalah mengekspor lagi alih-alih
+      mengubah ukuran yang sudah Anda ekspor.
+    </p>
+    <p>
+      Ada perangkat lunak yang mengaku mengubah sebuah PNG kembali menjadi SVG.
+      Yang dilakukannya adalah menjiplak: menebak kurva mana yang mungkin
+      menjelaskan sebuah kisi piksel. Ia bekerja lumayan pada karya seni datar
+      dua warna dan menghasilkan omong kosong yang mahal pada apa pun yang lain,
+      dan ia tidak pernah memulihkan apa yang dimiliki gambar aslinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tiga hal berubah begitu ia menjadi piksel</h2>
+    <p>
+      SVG yang dirasterkan yang tampak keliru hampir selalu tampak keliru karena
+      salah satu dari tiga hal ini, dan ketiganya layak diketahui sebelum Anda
+      mengekspor alih-alih sesudahnya.
+    </p>
+    <p>
+      <strong>Teks digambar dengan fon apa pun yang dimiliki mesinnya.</strong>
+      SVG yang memuat teks tidak memuat fonnya &mdash; ia menyebut satu lalu
+      membiarkan perendernya mencarinya. Kalau fonnya tidak terpasang, sebuah
+      pengganti dipakai, dan penggantinya punya bentuk huruf yang berbeda dan
+      lebar yang berbeda, jadi teksnya bisa tertata ulang atau meluber. File yang
+      menarik fonnya dari sebuah alamat web bernasib lebih buruk lagi: SVG yang
+      dirasterkan lewat sebuah <code>&lt;img&gt;</code> sama sekali tidak
+      diizinkan mengambil apa pun, jadi tidak ada yang tiba.
+    </p>
+    <p>
+      Solusinya adalah yang sudah diketahui setiap perancang: <strong>ubah teks
+      menjadi outline</strong> sebelum mengekspor SVG-nya (Illustrator
+      menyebutnya Create Outlines, Figma menyebutnya Flatten, Inkscape
+      menyebutnya Object to Path). Hurufnya menjadi geometri, fonnya berhenti jadi
+      soal, dan gambarnya tampak sama di setiap mesin. Kerjakan pada salinan
+      &mdash; teks yang sudah di-outline tidak lagi bisa disunting sebagai teks.
+    </p>
+    <p>
+      <strong>Garis rambut menjadi abu-abu atau lenyap.</strong> Goresan yang
+      terhitung kurang dari satu piksel pada ukuran pilihan Anda tidak bisa
+      digambar sebagai garis padat, jadi ia digambar sebagai garis samar. Inilah
+      sebabnya logo yang halus yang dirasterkan pada 64&nbsp;piksel tampak pucat
+      sementara file yang sama pada 512 tampak sempurna. Kalau ukuran kecil
+      memang syaratnya, jawabannya adalah gambar yang disederhanakan dengan
+      goresan yang lebih tebal alih-alih setelan ekspor yang berbeda &mdash; dan
+      itu alasan yang sama kenapa sebuah favicon berupa lambang dan bukan logo
+      kata.
+    </p>
+    <p>
+      <strong>Animasi berhenti.</strong> SVG beranimasi terraster menjadi satu
+      gambar diam: bingkai pertamanya, apa pun itu. Tidak ada setelan ekspor yang
+      mengubah ini. Kalau Anda butuh gerakannya, Anda butuh sebuah GIF atau
+      video, dibuat dengan cara yang berbeda.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparansi, dan format mana yang dipilih</h2>
+    <p>
+      <strong>PNG</strong> kecuali Anda punya alasan. Ia tanpa kehilangan, ia
+      menyimpan transparansi, dan warna datar dengan tepi keras &mdash; dan
+      itulah sebagian besar penyusun sebuah gambar vektor &mdash; terkompres
+      dengan baik di dalamnya. Logo yang dirasterkan biasanya berupa PNG yang
+      <em>lebih kecil</em> daripada kalau ia JPEG, sekaligus lebih bersih.
+    </p>
+    <p>
+      <strong>JPEG</strong> sama sekali tidak punya transparansi. Setiap piksel
+      transparan harus menjadi suatu warna, dan kalau tidak ada yang memilihkan
+      satu untuk Anda ia menjadi hitam &mdash; dan dari situlah hasil
+      logo-di-kotak-hitam yang dikira orang sebuah bug berasal. Ia juga merugikan
+      dengan cara yang paling kelihatan justru pada jenis gambar ini: sebuah
+      lingkaran bintik-bintik di sekeliling setiap tepi keras. Pakai ketika ada
+      yang bersikeras memintanya.
+    </p>
+    <p>
+      <strong>WebP</strong> melakukan semua yang dilakukan PNG, dalam file yang
+      lebih kecil, dan dibaca setiap peramban masa kini. Alasan untuk tidak
+      memakainya adalah apa yang terjadi setelah perambannya: perangkat lunak
+      yang lebih tua, sebagian percetakan, dan cukup banyak formulir unggahan
+      masih tidak mau membukanya.
+    </p>
+    <p>
+      Memilih warna latar dengan PNG juga hal yang sangat biasa untuk diinginkan.
+      Transparansi hanya berguna ketika apa pun tempat gambarnya mendarat berwarna
+      yang tidak bisa Anda ramalkan; ketika Anda sudah tahu ia sebuah halaman
+      putih, meratakannya ke putih menghindari satu kategori kejutan yang utuh.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ketika ekspornya keluar kosong atau keliru</h2>
+    <p>
+      <strong>Tidak ada apa-apa selain ruang kosong.</strong> Biasanya atribut
+      <code>xmlns</code> yang hilang di elemen akarnya. File tanpa itu bukanlah
+      SVG sejauh yang dipahami sebuah tag gambar, dan ia tergambar sebagai
+      ketiadaan. Membuka file-nya di sebuah peramban adalah uji cepatnya: kalau
+      perambannya juga tidak menampilkan apa-apa, file-nyalah masalahnya
+      alih-alih pengubahnya.
+    </p>
+    <p>
+      <strong>Gambarnya kecil, di sudut kiri atas.</strong> File-nya punya
+      <code>width</code> dan <code>height</code> tapi tidak punya
+      <code>viewBox</code>, jadi tidak ada sistem koordinat untuk diskalakan dan
+      karya seninya mempertahankan satuan aslinya di atas kanvas yang lebih
+      besar. Pengubah yang baik memasukkan sebuah viewBox untuk Anda; kalau punya
+      Anda belum, menambahkan
+      <code>viewBox="0 0 <em>lebar</em> <em>tinggi</em>"</code> ke elemen akarnya
+      dengan tangan membereskannya, dan file-nya teks biasa jadi Anda bisa.
+    </p>
+    <p>
+      <strong>Sebagian gambarnya hilang.</strong> Sesuatu di dalam file-nya
+      menunjuk ke sebuah alamat alih-alih memuat karya seninya &mdash; sebuah
+      foto tersemat yang disimpan sebagai tautan, sebuah lembar gaya, sebuah fon.
+      Peraster yang menolak mengambilnya sedang melakukan hal yang benar, dan itu
+      penolakan yang sama yang mencegah SVG yang Anda unduh dari suatu tempat
+      melapor balik ke siapa pun yang membuatnya. Ekspor ulang dari program
+      gambarnya dengan gambar-gambarnya disematkan.
+    </p>
+    <p>
+      <strong>Ia menolak ukuran yang sangat besar.</strong> Peramban membatasi
+      seberapa besar sebuah kanvas boleh, dan mereka tidak sepakat soal di mana:
+      lewat sekitar 16.000&nbsp;piksel di satu sisi tidak ada yang kembali, dan
+      Safari di sebuah iPhone atau iPad menyerah jauh lebih awal, di sekitar
+      4096&nbsp;&times;&nbsp;4096. Alat yang memperingatkan Anda sedang
+      menyelamatkan Anda dari file yang kosong, karena itulah yang dihasilkan
+      sebuah peramban ketika ia kehabisan alih-alih sebuah pesan galat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Merasterkan sebuah SVG adalah sesuatu yang dilakukan setiap peramban ribuan
+      kali sehari &mdash; ia mesin yang sama yang menggambar sebuah ikon di
+      halaman web. Tidak ada alasan teknis bagi karya seni Anda untuk bepergian
+      ke sebuah server dan kembali supaya ia keluar sebagai PNG, dan alat di sini
+      tidak mengirimnya ke mana pun: <code>Content-Security-Policy</code>
+      halamannya menyebut satu per satu setiap alamat yang boleh dihubunginya,
+      dan tidak satu pun milik situs ini.
+    </p>
+    <p>
+      Itu lebih penting daripada biasanya dengan SVG, karena sebuah SVG adalah
+      sebuah dokumen alih-alih sebuah gambar. Ia bisa memuat sebuah skrip dan
+      sebuah alamat jauh, dan logo yang dikirimkan sebuah agensi kepada Anda
+      adalah file yang tidak Anda tulis. Digambar lewat sebuah tag gambar, ia
+      berada dalam apa yang disebut spesifikasinya sebagai <em>secure static
+      mode</em>: skripnya tidak bisa berjalan dan alamatnya tidak pernah
+      dihubungi. Perambannya yang menegakkan itu, bukan situs webnya.
+    </p>
+    <p>
+      Muat halamannya, cabut koneksi internet, lalu ubah sesuatu kalau Anda lebih
+      suka memeriksa daripada diberi tahu.
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain yang bisa Anda
+      jalankan pada alat mana pun.
+    </p>
+  </section>

--- a/locales/id/pages/guides/convert-an-svg-to-png.toml
+++ b/locales/id/pages/guides/convert-an-svg-to-png.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: mengubah SVG menjadi PNG - Bahasa Indonesia.
+#
+
+nav = "Mengubah SVG menjadi PNG"
+title = "Cara Mengubah SVG Menjadi PNG pada Ukuran yang Tepat"
+description = "Sebuah vektor tidak punya ukuran piksel miliknya sendiri, jadi angkanya Anda yang pilih. Dari mana angka itu datang untuk sebuah layar, sebuah ikon aplikasi, dan sebuah pencetak, dan apa yang berubah ketika sebuah gambar menjadi piksel."
+
+heading = "Cara mengubah SVG menjadi PNG pada ukuran yang tepat"
+lede = """
+    Mengubahnya adalah separuh yang mudah. Pertanyaan yang menentukan apakah
+    hasilnya berguna adalah pertanyaan yang jawabannya tidak diberikan siapa pun
+    kepada Anda: berapa piksel? Inilah dari mana angka itu datang, dan apa yang
+    hilang dari sebuah gambar dalam perjalanannya menjadi piksel."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Mengubah SVG menjadi PNG pada ukuran yang tepat"
+og_description = "Dari mana sebenarnya jumlah pikselnya datang, dan tiga hal yang berubah ketika sebuah gambar menjadi piksel."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/convert-heic-to-jpg.html
+++ b/locales/id/pages/guides/convert-heic-to-jpg.html
@@ -1,0 +1,258 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../heic-ke-jpg/">Pengubah HEIC ke JPG</a>, jatuhkan
+      fotonya, lalu tekan &ldquo;Ubah&rdquo;. Biarkan penggeser kualitasnya di
+      tempatnya dan biarkan &ldquo;simpan tanggal, kamera, dan setelannya&rdquo;
+      tercentang kecuali Anda punya alasan lain. Anda mendapat JPEG kembali, satu
+      tombol unduh masing-masing, atau sebuah zip kalau ada beberapa.
+    </p>
+    <p>
+      Tidak ada yang diunggah saat Anda melakukannya. Itu tidak biasa untuk
+      pekerjaan yang satu ini, dan alasannya adalah separuh yang menarik dari
+      halaman ini.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa sebenarnya HEIC itu</h2>
+    <p>
+      HEIC sebenarnya bukan format gambar seperti halnya JPEG. Ia sebuah wadah
+      &mdash; struktur kotak yang sama yang menyusun sebuah MP4 &mdash; dengan
+      sebuah bingkai diam video <strong>HEVC</strong> di dalamnya. HEVC, yang
+      juga disebut H.265, adalah kodek yang menggantikan kodek yang dipakai
+      camcorder lama Anda, dan ia sangat bagus: foto iPhone dalam HEIC kira-kira
+      separuh ukuran foto yang sama sebagai JPEG pada kualitas yang sama.
+    </p>
+    <p>
+      Apple beralih ke sana di iOS 11, pada 2017, dan menjadikannya bawaan.
+      Artinya, kecuali seseorang sudah masuk ke Settings lalu memilih &ldquo;Most
+      Compatible&rdquo;, setiap foto yang diambil ponsel mereka selama hampir
+      satu dekade ada dalam format yang:
+    </p>
+    <ul>
+      <li>tidak akan dipratinjau Windows tanpa sebuah ekstensi dari Store;</li>
+      <li>ditolak mentah-mentah kebanyakan formulir unggahan web;</li>
+      <li>tidak pernah didengar sangat banyak perangkat lunak desktop yang lebih
+        tua;</li>
+      <li>dan tidak akan ditampilkan peramban web mana pun selain Safari.</li>
+    </ul>
+    <p>
+      Fotonya baik-baik saja. Ia file yang lebih baik daripada JPEG-nya nanti.
+      Ia sekadar ditulis dalam bahasa yang tidak pernah dipelajari sebagian besar
+      dunia.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa hanya Safari yang membukanya</h2>
+    <p>
+      Inilah bagian yang menjelaskan setiap pengubah yang pernah Anda pakai, jadi
+      ia layak satu paragraf.
+    </p>
+    <p>
+      Mendekodekan HEVC butuh sebuah dekoder HEVC, dan HEVC itu dipatenkan.
+      Perizinannya dikelola lebih dari satu kumpulan paten, dan mengirimkan
+      sebuah dekoder berarti membayar seseorang. Peramban menangani ini dengan
+      bersandar pada sistem operasinya &mdash; Chrome akan memutar
+      <em>video</em> HEVC di mesin yang perangkat kerasnya sudah punya dekoder
+      berlisensi &mdash; tapi jalur itu dipasang untuk pemutaran video dan bukan
+      untuk gambar diam. Jadi HEIC yang diserahkan ke
+      <code>&lt;img&gt;</code> ditolak, di Chrome, Firefox, dan Edge sama saja,
+      di setiap sistem operasi.
+    </p>
+    <p>
+      Safari di perangkat keras Apple adalah pengecualiannya, karena macOS dan
+      iOS punya dekodernya dan Safari boleh memintanya. Di semua tempat lain,
+      gambarnya sekadar tidak bisa didekodekan peramban.
+    </p>
+    <p>
+      Yang meninggalkan sebuah pengubah tepat dua pilihan, dan pilihan di antara
+      keduanya adalah seluruh cerita alat semacam ini.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa hampir setiap pengubah HEIC menginginkan unggahan</h2>
+    <p>
+      Pilihan satu: taruh dekodernya di sebuah server. Fotonya diunggah,
+      didekodekan di mesin yang belum pernah Anda lihat, dikodekan ulang sebagai
+      JPEG, lalu dikirim kembali. Inilah yang dilakukan hampir setiap
+      &ldquo;pengubah HEIC daring gratis&rdquo;, dan itulah sebabnya mereka semua
+      butuh file Anda. Itu bukan kemalasan &mdash; perambannya memang sungguh
+      tidak bisa melakukannya tanpa bantuan.
+    </p>
+    <p>
+      Berapa harganya layak dinyatakan dengan blak-blakan. Foto dari sebuah
+      ponsel adalah file paling pribadi yang dimiliki kebanyakan orang, dan HEIC
+      yang langsung dari iPhone biasanya membawa koordinat tempat ia diambil,
+      akurat sampai beberapa meter, berikut tanggalnya sampai ke detik dan sebuah
+      pengenal kamera. Mengunggah satu folder penuh ke layanan gratis berarti
+      menyerahkan gambarnya sekaligus itu. Apa yang terjadi berikutnya diatur
+      oleh kebijakan privasi yang tidak Anda baca, di sebuah server yang tidak
+      bisa Anda periksa, di sebuah yurisdiksi yang tidak Anda pilih.
+    </p>
+    <p>
+      Pilihan dua: taruh dekodernya di halamannya. Itulah yang dilakukan
+      <a href="../../heic-ke-jpg/">yang ini</a>. Ia membawa
+      <code>libheif</code>, yang dikompilasi menjadi WebAssembly, sebagai file
+      yang disajikan dari situs ini &mdash; sekitar 1,4 MB, diunduh sekali lalu
+      disinggahkan. Peramban Anda menjalankannya di mesin Anda sendiri, di
+      perangkat keras Anda sendiri, dan fotonya tidak pergi ke mana pun. Muat
+      halamannya sekali dan Anda bisa mencabut koneksi internet sama sekali dan
+      ia terus bekerja, dan itu hal yang tidak bisa dilakukan pengubah yang
+      mengunggah dan bukti paling sederhana yang ada.
+    </p>
+    <p>
+      1,4 MB itu seluruh harganya. Kalau Anda memakai koneksi berkuota, itu
+      ongkos yang nyata dan layak diketahui; itulah sebabnya halamannya
+      mengatakannya dengan lantang alih-alih mengunduhnya diam-diam.
+    </p>
+  </section>
+
+  <section>
+    <h2>Berapa harga pengubahannya bagi gambarnya</h2>
+    <p>
+      HEIC dan JPEG adalah kodek yang berbeda, jadi tidak ada jalan menyeberang
+      yang tidak melibatkan pendekodean gambarnya lalu pengodeannya lagi.
+      Pengodean kedua itu merugikan. Pada praktiknya ini jauh kurang penting
+      daripada kedengarannya:
+    </p>
+    <ul>
+      <li>
+        <strong>Pada kualitas 92</strong> &mdash; tempat pengubahnya mulai
+        &mdash; sebuah foto sangat sulit dibedakan dari aslinya pada ukuran
+        pandang normal mana pun. Anda akan mencari perbedaan di gradien yang
+        mulus, seperti langit yang cerah, dan Anda umumnya tidak akan
+        menemukannya.
+      </li>
+      <li>
+        <strong>JPEG-nya akan lebih besar.</strong> Biasanya di suatu tempat
+        antara sepertiga lebih besar dan dua kali lipat ukurannya, karena JPEG
+        adalah kodek dari 1992 dan HEVC bukan. Itulah pertukarannya: file yang
+        lebih besar yang bisa dibuka segala hal.
+      </li>
+      <li>
+        <strong>Mengubah dua kali itulah yang harus dihindari.</strong> Setiap
+        pengodean yang merugikan berbiaya sedikit. Ubah dari HEIC aslinya, bukan
+        dari JPEG yang sudah dibuatkan seseorang untuk Anda, dan kerjakan
+        sekali.
+      </li>
+    </ul>
+    <p>
+      Kalau Anda sama sekali tidak ingin kehilangan apa pun, PNG ada di menu
+      formatnya. Siapkan diri untuk file-nya: sebuah foto sebagai PNG biasanya
+      lima sampai sepuluh kali ukuran JPEG-nya, karena kompresi PNG dirancang
+      untuk warna datar dan gambar garis alih-alih untuk rumput dan kulit.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tanggal, kamera, dan koordinatnya</h2>
+    <p>
+      Keluhan yang biasa tentang pengubah HEIC adalah fotonya kembali sudah
+      kehilangan hari pengambilannya, sehingga foto seliburan penuh terurut ke
+      dasar galeri di bawah tanggal hari ini. Itu terjadi karena mengubah lewat
+      sebuah kanvas memberi Anda piksel dan tidak lebih &mdash; sebuah kanvas
+      tidak menyimpan tag &mdash; jadi kecuali sebuah pengubah pergi mengambil
+      metadatanya secara terpisah, ia sekadar hilang.
+    </p>
+    <p>
+      Alat di sini menyalin blok EXIF-nya dari HEIC-nya lalu menuliskannya ke
+      JPEG-nya, jadi tanggalnya selamat. Ada sebuah kotak centang, dan ia
+      tercentang secara bawaan. Lepas centangnya dan JPEG-nya keluar dengan
+      gambarnya dan tidak lebih.
+    </p>
+    <p>
+      Sebelum Anda memutuskan, lihat daftarnya: baris setiap foto mengatakan
+      apakah file-nya membawa koordinat GPS, dan ia mengatakannya sebelum apa pun
+      diubah. Kalau fotonya akan pergi ke suatu tempat yang publik, itulah baris
+      yang harus dibaca. Kalau mereka akan masuk ke galeri Anda sendiri,
+      menyimpan metadatanya hampir pasti yang Anda mau.
+    </p>
+    <p>
+      Satu tag diubah apa pun yang Anda pilih, dan layak diketahui kenapa. Sebuah
+      HEIC merekam rotasinya di dua tempat: di wadahnya, dan di blok EXIF-nya.
+      Dekodernya menerapkan rotasi wadahnya sambil mendekodekan, jadi piksel yang
+      diserahkan sudah tegak. Kalau EXIF-nya lalu masih berkata &ldquo;putar ini
+      90 derajat&rdquo;, sebuah penampil akan melakukannya sekali lagi dan setiap
+      foto potret akan keluar miring. Jadi tag orientasinya disetel ke tegak dan
+      semua yang lain disalin persis seperti yang ditulis ponselnya.
+    </p>
+    <p>
+      Kalau yang Anda mau adalah menelusuri tagnya dengan rinci, atau
+      membersihkannya dari foto yang sudah berupa JPEG, itu pekerjaan yang
+      berbeda dan ada
+      <a href="../hapus-data-exif-dan-gps/">panduannya sendiri</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hal-hal yang menjebak orang</h2>
+    <ul>
+      <li>
+        <strong>HEIC bernama &ldquo;.jpg&rdquo;.</strong> Sangat umum: sesuatu di
+        sepanjang jalan menamainya ulang tanpa mengubahnya, dan itulah sebabnya
+        ia tetap tidak mau terbuka. Setiap file yang dijatuhkan ke pengubahnya
+        dikenali dari byte pertamanya alih-alih dari namanya, jadi salah satu
+        dari ini bekerja dengan baik. Itu juga sebabnya file yang memang sungguh
+        JPEG diberi tahu begitu alih-alih diubah menjadi salinan dirinya
+        sendiri.
+      </li>
+      <li>
+        <strong>Satu file, beberapa gambar.</strong> Sebuah burst atau Live Photo
+        bisa menyimpan lebih dari satu gambar diam. Semuanya diubah, dan yang
+        tambahan dinomori mengikuti nama aslinya. Bagian video sebuah Live Photo
+        adalah file terpisah yang disimpan ponselnya di sebelah HEIC-nya, jadi ia
+        tidak ada di sana untuk diubah.
+      </li>
+      <li>
+        <strong>AVIF bukan HEIC.</strong> Keduanya mirip &mdash; wadah yang sama,
+        kodek yang berbeda di dalamnya &mdash; tapi setiap peramban masa kini
+        membuka sebuah AVIF secara bawaan, jadi tidak ada yang perlu diubah dan
+        alatnya mengatakannya alih-alih berpura-pura bekerja.
+      </li>
+      <li>
+        <strong>Menghentikan masalahnya di sumbernya.</strong> Di ponselnya:
+        Settings &rarr; Camera &rarr; Formats &rarr; Most Compatible. Foto baru
+        menjadi JPEG sejak saat itu. Ia memakai lebih banyak penyimpanan dan ia
+        tidak menyentuh foto yang sudah Anda punya, tapi ia berarti tidak pernah
+        melakukan ini lagi.
+      </li>
+      <li>
+        <strong>Berbagi kadang sudah mengubah.</strong> Meng-AirDrop atau
+        mengirim surel sebuah foto ke perangkat non-Apple sering menyerahkan
+        sebuah JPEG, karena iOS mengubahnya di jalan keluar. Kalau sebuah foto
+        toh tiba sebagai HEIC, ia menyeberang lewat rute yang tidak begitu.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bagaimana tahu apakah sebuah pengubah mengunggah</h2>
+    <p>
+      Ini berlaku untuk alat mana pun, bukan hanya yang ini, dan ia memakan
+      sekitar lima belas detik.
+    </p>
+    <ol>
+      <li>
+        Buka halamannya, lalu buka alat pengembang peramban Anda dan pergi ke tab
+        Network.
+      </li>
+      <li>
+        Ubah sebuah foto, dan perhatikan. Alat yang mendekodekan di mesin Anda
+        sama sekali tidak membuat permintaan pada saat itu. Alat yang mengunggah
+        membuat satu seukuran foto Anda, dan Anda bisa melihat ukurannya.
+      </li>
+      <li>
+        Atau, lebih sederhana: muat halamannya, putuskan koneksi internet, lalu
+        coba ubah sesuatu. Alat yang mengirim foto Anda pergi untuk didekodekan
+        berhenti bekerja. Alat yang membawa dekodernya tidak.
+      </li>
+    </ol>
+    <p>
+      Pengubah di sini dibangun untuk lolos kedua pemeriksaan itu, dan ada versi
+      yang lebih panjang dari argumen ini di
+      <a href="../apakah-aman-mengunggah-file/">amankah mengunggah file</a>.
+    </p>
+  </section>

--- a/locales/id/pages/guides/convert-heic-to-jpg.toml
+++ b/locales/id/pages/guides/convert-heic-to-jpg.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: mengubah HEIC menjadi JPG - Bahasa Indonesia.
+#
+
+nav = "HEIC ke JPG"
+title = "Cara Mengubah HEIC Menjadi JPG (dan Apa Sebenarnya HEIC Itu)"
+description = "iPhone menyimpan foto sebagai HEIC, dan separuh internet tidak bisa membukanya. Format itu apa, kenapa hanya Safari yang mendekodekannya, berapa harga pengubahannya bagi gambarnya, dan bagaimana melakukannya tanpa mengunggah fotonya kepada siapa pun."
+
+heading = "Foto yang disimpan ponsel Anda, dan format yang tidak mau dibuka apa pun"
+lede = """
+    iPhone menyimpan foto sebagai HEIC, yang lebih kecil dan lebih baik daripada
+    JPEG dan yang masih ditolak sangat banyak perangkat lunak. Inilah apa
+    sebenarnya format itu, berapa harga pengubahannya bagi gambarnya, dan kenapa
+    hampir setiap pengubah ingin Anda mengunggahnya lebih dulu."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara mengubah HEIC menjadi JPG"
+og_description = "Kenapa foto iPhone tidak mau terbuka, berapa harga pengubahannya, dan bagaimana melakukannya tanpa menyerahkan fotonya kepada siapa pun."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/crop-a-video.html
+++ b/locales/id/pages/guides/crop-a-video.html
@@ -1,0 +1,216 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../pangkas-video/">Pemangkas Video</a>, jatuhkan klipnya,
+      seret kotaknya ke bagian yang ingin Anda simpan &mdash; atau kunci ke
+      sebuah bentuk kalau Anda sudah diberi satu &mdash; lalu ekspor. Klip yang
+      keluar persis sepanjang yang masuk, dengan pewaktuan dan suaranya utuh.
+    </p>
+    <p>
+      Tidak seperti pemotongan, yang ini harus menulis bingkai baru. Itu bukan
+      kekurangan alat tertentu; itulah pemangkasan. Sisa halaman ini adalah
+      tentang berapa harganya dan bagaimana menjaganya tetap kecil.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa pemangkasan tidak bisa menghindari pengodean ulang</h2>
+    <p>
+      Pemotongan menyimpan bingkai utuh, jadi pemotong yang baik memindahkannya
+      tanpa disentuh dan sama sekali tidak ada yang didekodekan. Pemangkasan
+      menyimpan sebagian dari setiap bingkai &mdash; dan sebagian bingkai adalah
+      gambar yang berbeda. Tidak ada cara menyimpan gambar yang berbeda tanpa
+      menuliskan pikselnya dari awal.
+    </p>
+    <p>
+      Ada satu pengecualian sempit, dan ia layak diketahui supaya Anda bisa
+      mengenali ketika seseorang mengaku memakainya. Video dikodekan dalam blok,
+      dan kalau sebuah pangkasan mendarat persis di batas blok pada keempat
+      sisinya, sebagian datanya pada prinsipnya bisa dipakai ulang. Pada
+      praktiknya dimensi bingkainya sendiri, vektor geraknya, dan prediksinya
+      tetap harus ditulis ulang, jadi tidak ada yang sungguh dibangun dengan cara
+      ini. Anggap saja pemangkasan berarti pengodean ulang.
+    </p>
+    <p>
+      Yang akan dilakukan pemangkas yang tahu diri adalah tidak menghabiskan
+      <em>lebih</em> daripada yang dihabiskan aslinya untuk area yang sama.
+      Mengodekan wilayah yang dipangkas pada bitrate lebih tinggi daripada
+      sumbernya hanya membuat file-nya lebih besar; ia tidak bisa mengembalikan
+      detail yang memang tidak dimiliki aslinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bentuk yang sebenarnya diminta dari Anda</h2>
+    <p>
+      Kebanyakan pemangkasan dilakukan karena suatu tempat mensyaratkan rasio
+      aspek tertentu. Daftar singkatnya:
+    </p>
+    <ul>
+      <li>
+        <strong>9:16 &mdash; jangkung.</strong> Story, reel, short, TikTok.
+        Layar penuh di ponsel yang dipegang normal. Alasan paling umum orang
+        memangkas sebuah video sama sekali.
+      </li>
+      <li>
+        <strong>1:1 &mdash; persegi.</strong> Unggahan di lini masa beberapa
+        lapak. Bekerja ke arah mana pun penontonnya memegang ponselnya, dan
+        itulah sebabnya ia bertahan.
+      </li>
+      <li>
+        <strong>4:5 &mdash; sedikit jangkung.</strong> Bentuk terbesar yang
+        diizinkan sebagian lini masa, jadi ia memakan lebih banyak layar
+        daripada persegi tanpa menjadi video vertikal penuh.
+      </li>
+      <li>
+        <strong>16:9 &mdash; lebar.</strong> Standar untuk video pada umumnya.
+        Anda biasanya memangkas <em>menjadi</em> ini hanya untuk membuang bilah
+        hitam, atau <em>dari</em> ini untuk mendapatkan salah satu di atas.
+      </li>
+    </ul>
+    <p>
+      Kunci kotaknya ke rasionya alih-alih menyeret dengan perkiraan mata.
+      Meleset beberapa piksel berarti lapaknya memangkas pangkasan Anda, dan ia
+      tidak akan berunding dengan Anda soal di mana.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mengubah klip lanskap menjadi tegak</h2>
+    <p>
+      Inilah kasus umum yang paling sulit, dan layak dinyatakan terus terang
+      bahwa pemangkasan adalah kompromi alih-alih solusi.
+    </p>
+    <p>
+      Video 16:9 yang dipangkas menjadi 9:16 menyimpan sekitar 32% lebar
+      gambarnya. Apa pun yang ada di sisinya hilang &mdash; dan pada bidikan
+      lanskap, sisinya biasanya tempat konteksnya berada. Kalau dua orang
+      berbicara di sisi bingkai yang berlawanan, tidak ada satu pangkasan pun
+      yang menyimpan keduanya.
+    </p>
+    <p>
+      Pilih pangkasannya dengan menonton klipnya sekali lalu bertanya di mana
+      sebenarnya subjeknya berada di sebagian besar durasinya. Kalau jawabannya
+      &ldquo;ia bergerak&rdquo;, pangkasan diam adalah alat yang keliru dan yang
+      Anda butuhkan adalah penyunting yang bisa menggeser pangkasannya sepanjang
+      waktu. Kalau jawabannya &ldquo;di tengah, sebagian besarnya&rdquo;,
+      pangkasan yang terpusat sudah cukup dan memakan sepuluh detik.
+    </p>
+    <p>
+      Alternatif yang layak diingat: banyak lapak menerima video lanskap lalu
+      memberinya bilah hitam sendiri. Pemangkasan itu untuk ketika Anda ingin
+      layar penuh, bukan untuk ketika Anda ingin videonya diterima.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa lebar dan tingginya bergerak dua-dua</h2>
+    <p>
+      Kalau Anda memperhatikan kotak pangkasnya menolak angka ganjil, itu
+      kodeknya yang rewel, bukan antarmukanya.
+    </p>
+    <p>
+      H.264 &mdash; kodek di dalam sebuah MP4 &mdash; menyimpan warna pada
+      setengah resolusi secara mendatar dan menegak, karena mata jauh lebih
+      kurang peka pada detail warna daripada pada kecerahan. Itu berarti
+      gambarnya ditangani dalam satuan dua piksel dan tidak ada cara menggambarkan
+      bingkai dengan jumlah piksel ganjil di salah satu sisinya.
+    </p>
+    <p>
+      Alat menangani ini dengan membulatkan pangkasan Anda setelah Anda
+      menyetelnya, yang menggeser kotak Anda sepiksel tanpa memberi tahu, atau
+      dengan hanya pernah menawarkan angka genap sejak awal. Yang kedua itulah
+      yang terjadi di sini.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang terjadi pada suaranya</h2>
+    <p>
+      Tidak ada, pada jalur MP4. Pemangkasan mengubah gambarnya dan tidak punya
+      alasan menyentuh audionya, jadi audionya disalin sampel demi sampel tanpa
+      pernah didekodekan &mdash; byte demi byte sama dengan yang ada di
+      file-nya.
+    </p>
+    <p>
+      Pada jalur cadangan lewat perekaman, yang dijelaskan di bawah, suaranya
+      ditangkap dari pemutarannya lalu dikodekan lagi, dan itu mengorbankan
+      sedikit kualitas. Bagaimanapun juga ada kotak centang untuk membuangnya
+      sekalian, dan itu layak dipakai ketika klipnya toh akan pergi ke tempat
+      yang memutarnya tanpa suara dan Anda mau file sekecil mungkin.
+    </p>
+  </section>
+
+  <section>
+    <h2>Format, dan berapa lama waktunya</h2>
+    <p>
+      <strong>MP4, M4V, dan MOV</strong> dibaca langsung, apa pun isinya &mdash;
+      H.264, HEVC, AV1, atau VP9 &mdash; selama peramban Anda bisa mendekodekan
+      kodek itu. Tidak seperti pemotongan, pemangkasan memang harus mendekodekan,
+      jadi kodeknya penting di sini dengan cara yang tidak berlaku di sana.
+    </p>
+    <p>
+      <strong>Apa pun lain yang bisa diputar peramban Anda</strong>, WebM yang
+      paling jelas, dipangkas dengan memutarnya lalu merekam hasilnya, yang
+      bekerja dan memakan waktu selama panjang klipnya.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV, dan kebanyakan MKV</strong> tidak bisa dibaca maupun
+      diputar peramban, dan alatnya menolaknya dengan sebuah pesan alih-alih
+      gagal di tengah jalan.
+    </p>
+    <p>
+      Harapkan sebuah pemangkasan memakan waktu sungguhan pada klip yang panjang,
+      karena setiap bingkai sedang didekodekan dan dikodekan ulang. Tidak ada
+      batas yang dibangun ke dalam alatnya, dan file-nya disusuri beberapa
+      megabita sekali jalan alih-alih dimuat utuh; langit-langit praktisnya
+      adalah video jadinya, yang dirakit di memori sebelum Anda mengunduhnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pangkas sebelum Anda melakukan hal lain</h2>
+    <p>
+      Kalau sebuah klip butuh pemotongan dan pemangkasan, potong lebih dulu
+      &mdash; itu gratis, dan setiap detik yang Anda buang adalah satu detik yang
+      tidak perlu dikodekan ulang siapa pun. Lalu pangkas klip yang lebih pendek
+      itu sekali.
+    </p>
+    <p>
+      Melakukannya terbalik berarti memangkas rekaman yang sebentar lagi Anda
+      buang, dan itu mengorbankan waktu dan kualitas untuk apa-apa.
+      <a href="../../potong-video/">Pemotong Video</a> ada di sebelah, dan
+      <a href="../potong-video/">panduannya</a> menjelaskan kenapa langkah itu
+      sama sekali tidak perlu mengorbankan apa pun dari Anda.
+    </p>
+    <p>
+      Secara lebih umum: setiap langkah yang merugikan itu bertumpuk. Satu
+      pangkasan atas sebuah asli adalah satu generasi. Pangkasan atas potongan
+      atas ekspor atas unduhan adalah empat, dan hasilnya kelihatan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh unggahan</h2>
+    <p>
+      Mendekodekan dan mengodekan ulang video di sebuah peramban itu baru dan ia
+      nyata: WebCodecs membuka pengode perangkat keras yang sama yang dipakai
+      ponsel Anda untuk merekam video, dan ia cepat karena alasan yang sama.
+      Pekerjaannya terjadi di mesin yang sudah memegang file-nya, dan untuk video
+      berukuran beberapa gigabita itu juga satu-satunya pengaturan yang masuk
+      akal &mdash; mengunggah lalu mengunduh hasilnya memakan lebih banyak waktu
+      daripada pengodeannya sendiri.
+    </p>
+    <p>
+      Alat di sini tidak punya fitur jaringan dalam bentuk apa pun, dan
+      <code>Content-Security-Policy</code> halamannya menyebut satu per satu
+      setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+      Cabut koneksi internet lalu pangkas sebuah klip kalau Anda lebih suka
+      memeriksa daripada diberi tahu.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain yang bisa Anda
+      jalankan pada alat mana pun.
+    </p>
+  </section>

--- a/locales/id/pages/guides/crop-a-video.toml
+++ b/locales/id/pages/guides/crop-a-video.toml
@@ -1,0 +1,24 @@
+#
+# Panduan: memangkas video - Bahasa Indonesia.
+#
+# "Pangkas" di sepanjang halaman ini, dan tidak pernah "potong": memangkas
+# mengubah bentuk gambarnya, memotong memendekkan klipnya, dan panduan
+# pemotongan ada di sebelah.
+#
+
+nav = "Memangkas video"
+title = "Cara Memangkas Video ke Bentuk Lain"
+description = "Pangkas sebuah klip menjadi persegi, potret 9:16, atau kotak piksel yang tepat. Rasio mana yang diminta tiap lapak, kenapa pemangkasan harus mengodekan ulang padahal pemotongan tidak, dan berapa harganya."
+
+heading = "Cara memangkas video ke bentuk lain"
+lede = """
+    Memangkas mengubah bentuk gambarnya, dan itu berarti menulis bingkai baru
+    &mdash; tidak ada jalan memutarnya, dan alat mana pun yang mengaku
+    sebaliknya sedang melakukan hal lain. Inilah berapa harganya, dan bagaimana
+    membelanjakannya dengan baik."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara memangkas video ke bentuk lain"
+og_description = "Rasio aspek mana yang diminta tiap lapak, kenapa pemangkasan harus mengodekan ulang padahal pemotongan tidak, dan berapa harganya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/embed-an-image-in-css.html
+++ b/locales/id/pages/guides/embed-an-image-in-css.html
@@ -1,0 +1,329 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../gambar-ke-base64/">Gambar ke Data URI</a>, jatuhkan
+      gambarnya, pilih <em>Sebuah properti khusus CSS</em>, lalu tempelkan
+      barisnya ke bagian atas lembar gaya Anda. Lalu pakai sebagai
+      <code>background-image: var(--logo)</code> di mana pun Anda
+      membutuhkannya.
+    </p>
+    <p>
+      Lakukan itu ketika gambarnya kecil &mdash; sebuah ikon, sebuah bulatan
+      butir, sebuah tanda panah, sebuah pola &mdash; dan ia dibutuhkan di setiap
+      halaman. Jangan lakukan dengan sebuah foto. Semua di bawah ini adalah
+      kenapa dua kalimat itu berbeda, dan bagaimana tahu Anda sedang melihat yang
+      mana.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa sebenarnya sebuah data URI</h2>
+    <p>
+      Sebuah alamat yang memuat bendanya alih-alih menunjuk padanya. Kalau sebuah
+      lembar gaya biasanya berkata
+    </p>
+    <pre><code>background-image: url("logo.png");</code></pre>
+    <p>
+      dan perambannya pergi mengambil <code>logo.png</code>, sebuah data URI
+      berkata
+    </p>
+    <pre class="wrap"><code>background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg...");</code></pre>
+    <p>
+      dan tidak ada yang perlu diambil: gambarnya sudah ada di sana, tertulis
+      dalam karakter. Ada tiga bagian. <code>data:</code> adalah skemanya.
+      <code>image/png</code> adalah jenis medianya, dan perambannya
+      memercayainya sepenuhnya &mdash; lebih lanjut soal itu di bawah. Semua
+      setelah komanya adalah file-nya.
+    </p>
+    <p>
+      Itulah seluruh gagasannya. Ia bukan trik atau akal-akalan; ia sudah ada di
+      standarnya sejak 1998 dan bekerja di setiap peramban yang dirilis sejak
+      itu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang Anda dapat: satu perjalanan bolak-balik lebih sedikit</h2>
+    <p>
+      Penghematannya bukan lebar pita. Melainkan permintaannya.
+    </p>
+    <p>
+      Sebuah peramban tidak bisa meminta <code>logo.png</code> sampai ia membaca
+      lembar gaya yang menyebutnya, dan ia tidak bisa membaca lembar gayanya
+      sampai ia mengambilnya. Jadi gambar latar biasa berada setidaknya dua
+      perjalanan bolak-balik dalamnya di pemuatan halamannya, dan di sebuah
+      ponsel di jaringan yang lambat, satu perjalanan bolak-balik bisa beberapa
+      ratus milidetik tanpa peduli sekecil apa file-nya. Tanda panah 600 byte
+      nyaris tidak berbiaya untuk ditransfer dan tetap bisa berbiaya seperempat
+      detik untuk tiba.
+    </p>
+    <p>
+      Kalau disisipkan, ia tiba bersama lembar gayanya. Itulah seluruh
+      manfaatnya, dan untuk ikon kecil yang muncul di bagian atas layar itu
+      manfaat yang nyata.
+    </p>
+  </section>
+
+  <section>
+    <h2>Berapa harganya: sepertiga, lalu penyinggahannya</h2>
+    <p>
+      <strong>Base64 menambah sekitar sepertiga.</strong> Tiga byte file menjadi
+      empat karakter, karena itulah yang dibutuhkan untuk menuliskan byte
+      sembarang hanya dengan karakter yang diizinkan sebuah URL. Tidak ada
+      pengode cerdik yang menghindarinya. PNG 9 KB adalah 12 KB lembar gaya.
+    </p>
+    <p>
+      <strong>Kompresi tidak mengembalikannya.</strong> Inilah bagian yang
+      diandaikan orang begitu saja. Gzip dan Brotli bekerja dengan menemukan
+      pengulangan, dan sebuah PNG, JPEG, dan WebP sudah dikompres &mdash; sangat
+      sedikit pengulangan yang tersisa di dalamnya, dan base64 tidak menambahkan
+      apa pun. Pada praktiknya Anda mendapat kembali sekitar sepersepuluh dari
+      sepertiganya, bukan seluruhnya. (SVG adalah kasus sebaliknya, dan bagian
+      berikutnya tentang itu.)
+    </p>
+    <p>
+      <strong>Ia berhenti menjadi sebuah file.</strong> Inilah ongkos yang tidak
+      muncul di pengukuran mana pun yang mungkin Anda ambil, dan inilah yang
+      penting pada skala besar:
+    </p>
+    <ul>
+      <li>
+        <strong>Ia tidak bisa disinggahkan sendiri.</strong> Gambar biasa diambil
+        sekali lalu dipakai ulang selama setahun. Yang disisipkan adalah bagian
+        dari lembar gayanya, jadi ia hidup dan mati mengikuti entri singgahan
+        lembar gayanya.
+      </li>
+      <li>
+        <strong>Mengubah apa pun mengunduh ulang semuanya.</strong> Perbaiki
+        sebuah margin, kirimkan lembar gaya baru, dan setiap pengunjung mengunduh
+        gambar yang disisipkan itu lagi bersamanya &mdash; sebuah gambar yang
+        belum berubah selama dua tahun.
+      </li>
+      <li>
+        <strong>Ia berada di jalur kritis.</strong> Lembar gaya menahan
+        penggambaran. Gambar tidak. Menyisipkan sebuah gambar memindahkannya dari
+        kategori kedua ke kategori pertama: halamannya tidak bisa terlukis sampai
+        seluruhnya, gambarnya termasuk, sudah tiba.
+      </li>
+      <li>
+        <strong>Ia tidak bisa diambil secara paralel.</strong> Peramban mengunduh
+        banyak hal sekaligus. Gambar yang disisipkan bukan hal yang terpisah,
+        jadi ia tidak mendapat satu pun dari itu.
+      </li>
+    </ul>
+    <p>
+      Ambang kasarnya, yang merupakan tempat nasihatnya berubah alih-alih tempat
+      sebuah peramban melakukan sesuatu yang berbeda: di bawah sekitar 2 KB ia
+      kemenangan yang jelas; sampai sekitar 10 KB ia biasanya masih sepadan untuk
+      sesuatu yang ada di setiap halaman; lewat 50 KB ia sebuah kekeliruan tanpa
+      pesan galat. <a href="../../gambar-ke-base64/">Alatnya</a> memberi tahu
+      Anda setiap hasilnya mendarat di pita yang mana, dengan jumlah karakternya
+      di sebelahnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Jangan pernah mem-base64-kan sebuah SVG</h2>
+    <p>
+      Inilah kekeliruan tunggal yang paling umum pada gambar yang disisipkan, dan
+      ia dibuat pengekspor dan pengaya bangun sesering dibuat orang.
+    </p>
+    <p>
+      SVG adalah teks. Sebuah URL sudah membawa teks. Hanya segelintir karakter
+      yang harus dilepaskan &mdash; <code>%</code>, <code>#</code>,
+      <code>&lt;</code>, <code>&gt;</code>, dan tanda kutip yang Anda pakai
+      membungkusnya &mdash; dan semua yang lain bisa dibiarkan persis apa adanya.
+      Mengodekannya dengan cara itu memberi Anda URI yang biasanya sekitar
+      seperlima lebih pendek daripada base64 file yang sama, dan yang sesudahnya
+      terkompres seperti teks alih-alih seperti derau.
+    </p>
+    <p>
+      Ia juga masih terbaca:
+    </p>
+    <pre class="wrap"><code>background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E...");</code></pre>
+    <p>
+      Anda bisa melihat <code>viewBox</code>-nya. Anda bisa mengubah warna
+      isiannya di penyunting Anda tanpa mendekodekan apa pun. Base64-kan file
+      yang sama dan ia menjadi tembok huruf yang tidak akan pernah disentuh
+      siapa pun lagi. <a href="../../gambar-ke-base64/">Gambar ke Data URI</a>
+      melakukan ini secara otomatis untuk apa pun yang ternyata sebuah SVG, dan
+      punya sebuah kotak centang untuk rantai perkakas langka yang bersikeras
+      meminta <code>;base64</code>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kekeliruan tanda kutip yang hanya merusak SVG</h2>
+    <p>
+      CSS mengizinkan Anda menulis <code>url()</code> tanpa tanda kutip, dan
+      untuk nama file biasa itu tidak masalah:
+    </p>
+    <pre><code>background-image: url(logo.png);</code></pre>
+    <p>
+      Lakukan hal yang sama dengan SVG berkode persen dan ia rusak. Token
+      <code>url()</code> tanpa tanda kutip berakhir di spasi, kurung, tanda
+      kutip, atau karakter kendali yang pertama &mdash; dan sebuah SVG penuh
+      spasi, di antara setiap atribut dan setiap angka di sebuah jalur.
+      Deklarasinya lalu menjadi tidak sah, CSS membuang deklarasi yang tidak sah
+      secara diam-diam, dan Anda tidak mendapat latar dan tidak mendapat galat.
+    </p>
+    <p>
+      Solusinya adalah tanda kutip, setiap kali:
+    </p>
+    <pre><code>background-image: url("data:image/svg+xml,%3Csvg ... %3E");</code></pre>
+    <p>
+      Itu juga sebabnya sebuah pengode tidak perlu melepaskan spasinya &mdash;
+      mereka sepenuhnya sah di dalam URL yang berkutip, dan melepaskan
+      masing-masing sebagai <code>%20</code> akan berbiaya tiga karakter untuk
+      setiap spasi di file-nya. Kedua keputusannya berjalan bersama: beri tanda
+      kutip pada URI-nya, dan Anda bisa membiarkan spasinya. Setiap bentuk yang
+      dihasilkan alatnya diberi tanda kutip persis karena alasan ini.
+    </p>
+  </section>
+
+  <section>
+    <h2>Jenis medianya harus benar</h2>
+    <p>
+      Sebuah data URI menyatakan jenisnya sendiri, dan perambannya menerimanya
+      apa adanya. Tidak ada pengendusan cadangan seperti yang ada untuk file yang
+      diambil: katakan <code>image/png</code> tentang sesuatu yang sebenarnya
+      JPEG dan gambarnya tidak tergambar, tanpa pesan di mana pun yang berguna.
+    </p>
+    <p>
+      Dan itu penting karena ekstensi file berbohong. Foto yang diekspor sebagai
+      JPEG lalu dinamai ulang <code>logo.png</code> adalah hal biasa yang
+      ditemukan di sebuah disk. Beberapa byte pertama sebuah file gambar, di sisi
+      lain, mengatakan ia apa tanpa ambiguitas &mdash; setiap format punya sebuah
+      tanda tangan &mdash; jadi sebuah alat sebaiknya membaca file-nya alih-alih
+      namanya. Yang di sini melakukannya, dan memberi tahu Anda ketika keduanya
+      tidak sepakat.
+    </p>
+    <p>
+      Dua format layak diketahui karena mereka gagal dengan cara yang
+      membingungkan. <strong>HEIC</strong>, yang menjadi format pemotretan
+      iPhone, dan <strong>TIFF</strong>, yang dihasilkan pemindai, keduanya
+      membuat data URI yang sepenuhnya sah yang tidak akan digambar peramban mana
+      pun selain Safari. URI-nya tidak rusak; formatnya sekadar bukan format yang
+      didukung web. Ubah dulu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Metadata yang tidak Anda maksudkan untuk diterbitkan</h2>
+    <p>
+      Data URI adalah salinan file-nya, byte demi byte. Tidak ada yang
+      didekodekan dan dikodekan ulang, dan biasanya itulah intinya &mdash; tidak
+      ada kualitas yang hilang &mdash; tapi ia juga berarti semua yang lain di
+      file-nya ikut serta.
+    </p>
+    <p>
+      Foto yang langsung dari sebuah ponsel membawa EXIF: koordinat GPS tempat ia
+      diambil, cap waktunya, model kameranya, dan sering nomor serinya. Itu bisa
+      30 KB dari file-nya. Kalau disisipkan, ia menjadi 40 KB base64 di lembar
+      gaya Anda, di jalur kritis setiap halaman &mdash; dan sebuah alamat rumah
+      yang tersimpan di sebuah repositori, dalam bentuk yang tidak akan pernah
+      terpikir siapa pun untuk dilihat.
+    </p>
+    <p>
+      Bersihkan lebih dulu dengan
+      <a href="../../hapus-data-exif/">Penampil &amp; Penghapus EXIF</a>, yang
+      menulis ulang wadahnya tanpa menyentuh gambarnya; ada
+      <a href="../hapus-data-exif-dan-gps/">panduannya</a> juga. Gambar ke Data
+      URI membaca berapa banyak metadata yang ada di sebuah JPEG, PNG, atau WebP
+      lalu mengatakannya sebelum Anda menyalin apa pun.
+    </p>
+  </section>
+
+  <section>
+    <h2>Di mana menaruhnya, setelah Anda punya</h2>
+    <p>
+      Kalau gambarnya muncul di satu aturan, taruh URI-nya di aturan itu. Kalau
+      ia muncul di lebih dari satu &mdash; dan ikon biasanya begitu, begitu Anda
+      menghitung keadaan tunjuk dan tema gelapnya &mdash; nyatakan sekali sebagai
+      sebuah properti khusus:
+    </p>
+    <pre><code>:root {
+  --icon-search: url("data:image/svg+xml,%3Csvg ... %3E");
+}
+
+.search-field { background-image: var(--icon-search); }
+.search-button::before { content: var(--icon-search); }</code></pre>
+    <p>
+      URI 3 KB yang ditempelkan ke empat aturan adalah 12 KB lembar gaya dan
+      empat tempat untuk disunting ketika ikonnya berubah. Properti khususnya
+      adalah satu dari masing-masing. Ia juga bentuk yang membuat penemaan
+      bekerja: definisikan ulang <code>--icon-search</code> di dalam sebuah kueri
+      media dan setiap pemakaiannya mengikuti.
+    </p>
+    <p>
+      Untuk sebuah tag <code>&lt;img&gt;</code> alih-alih CSS, sertakan
+      <code>width</code> dan <code>height</code>. Gambar yang disisipkan dimuat
+      seketika, jadi ukuran yang hilang adalah pergeseran tata letak yang terjadi
+      terlalu cepat untuk dilihat dan tetap dihitung merugikan Anda.
+      Pengecualiannya adalah SVG: yang hanya membawa sebuah <code>viewBox</code>
+      tidak punya ukuran piksel miliknya sendiri, dan menuliskan bawaan
+      300&times;150 peramban ke tagnya memaku sebuah gambar yang bisa diskalakan
+      pada ukuran yang tidak dipilih siapa pun.
+    </p>
+    <p>
+      Biarkan <code>alt</code>-nya kosong kecuali Anda punya sesuatu yang benar
+      untuk ditaruh di dalamnya. Hanya Anda yang tahu apakah gambarnya membawa
+      makna atau sekadar hiasan, dan keterangan yang ditebak dari sebuah nama
+      file lebih buruk bagi orang yang memakai pembaca layar daripada tidak ada
+      keterangan sama sekali.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ketika jawabannya &ldquo;jangan&rdquo;</h2>
+    <p>
+      Kalau gambarnya lebih dari sekitar 50 KB setelah dikodekan, penyisipan
+      adalah alat yang keliru dan kecermatan sebanyak apa pun pada pengodeannya
+      tidak membereskannya. Alternatifnya, dalam urutan yang layak dicoba:
+    </p>
+    <ul>
+      <li>
+        <strong>Kecilkan.</strong> Kebanyakan gambar yang terlalu besar untuk
+        disisipkan memang terlalu besar secara umum.
+        <a href="../../kompres-gambar/">Kompresor Gambar</a> akan membawa sebuah
+        foto ke ukuran yang Anda sebutkan, dan
+        <a href="../../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a> akan
+        memotong dimensi pikselnya turun ke yang sebenarnya dipakai tata letaknya
+        &mdash; dan itu sangat sering masalah yang sesungguhnya.
+      </li>
+      <li>
+        <strong>Gambar ulang sebagai SVG.</strong> Ikon yang diekspor sebagai PNG
+        40 KB sering kali adalah SVG 900 byte. Itu bukan perbedaan kompresi, itu
+        perbedaan format, dan ia juga menyelesaikan masalah retinanya.
+      </li>
+      <li>
+        <strong>Biarkan sebagai sebuah file lalu pramuat.</strong>
+        <code>&lt;link rel="preload" as="image"&gt;</code> memulai pengambilannya
+        segera tanpa memindahkan byte-nya ke jalur kritis. Ia mendapat sebagian
+        besar manfaat penyisipan dan tidak satu pun ongkos penyinggahannya.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Mengodekan sebuah file sebagai base64 adalah hitungan. Ia dua fungsi yang
+      sudah dipunyai peramban sejak awal &mdash; <code>btoa</code> dan
+      <code>encodeURIComponent</code> &mdash; dan sama sekali tidak ada alasan
+      teknis bagi sebuah gambar untuk bepergian ke sebuah server dan kembali
+      supaya ia ditulis dengan cara yang berbeda. Pengubah mana pun yang
+      mengunggah file Anda untuk melakukan ini sedang mengunggahnya demi alasannya
+      sendiri, bukan demi alasan Anda.
+    </p>
+    <p>
+      <a href="../../gambar-ke-base64/">Alat di sini</a> tidak mengirimnya ke
+      mana pun: <code>Content-Security-Policy</code> halamannya menyebut satu per
+      satu setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+      ini. Muat halamannya, cabut koneksi internet, lalu kodekan sesuatu kalau
+      Anda lebih suka memeriksa daripada diberi tahu.
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain yang bisa Anda
+      jalankan pada alat mana pun.
+    </p>
+  </section>

--- a/locales/id/pages/guides/embed-an-image-in-css.toml
+++ b/locales/id/pages/guides/embed-an-image-in-css.toml
@@ -1,0 +1,24 @@
+#
+# Panduan: menyisipkan gambar di CSS - Bahasa Indonesia.
+#
+# Potongan kode tidak diterjemahkan, termasuk nama properti khusus di dalamnya:
+# itu kode yang disalin pembacanya, bukan prosa.
+#
+
+nav = "Menyisipkan gambar di CSS"
+title = "Data URI di CSS: Kapan Menyisipkan Gambar, dan Kapan Tidak"
+description = "Berapa harga sebuah data URI, kenapa base64 menambah sepertiga dan gzip tidak mengembalikannya, kenapa sebuah SVG tidak boleh berupa base64, dan kekeliruan tanda kutip yang diam-diam merusak SVG yang disisipkan."
+
+heading = "Kapan menaruh gambar di dalam CSS Anda, dan kapan tidak"
+lede = """
+    Gambar yang ditulis ke dalam sebuah lembar gaya tiba bersamanya: tidak ada
+    permintaan kedua, tidak ada penantian. Ia juga berhenti menjadi sebuah file
+    &mdash; jadi ia tidak bisa disinggahkan sendiri, dan ia diunduh lagi setiap
+    kali apa pun di sekitarnya berubah. Inilah tempat pertukaran itu layak
+    dilakukan, dan tempat diam-diam ia tidak layak."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Kapan menaruh gambar di dalam CSS Anda"
+og_description = "Berapa harga sebuah data URI, kenapa sebuah SVG tidak boleh berupa base64, dan kekeliruan tanda kutip yang diam-diam merusak SVG yang disisipkan."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/format-json-without-uploading-it.html
+++ b/locales/id/pages/guides/format-json-without-uploading-it.html
@@ -1,0 +1,314 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../format-json/">Teks &amp; Kode</a>, tempelkan JSON-nya
+      ke kotaknya, lalu baca. Penataannya terjadi sambil Anda mengetik,
+      bahasanya diperhitungkan dari teksnya, dan indentasinya dua spasi kecuali
+      Anda mengatakan lain. Tidak ada yang diunggah, karena tidak ada tujuan ke
+      mana pun baginya: pembacanya beberapa ratus baris JavaScript yang berjalan
+      di tab yang sudah Anda buka.
+    </p>
+    <p>
+      Semua di bawah ini adalah bagian yang layak diketahui sebelum Anda
+      menempelkan sebuah file konfigurasi ke alternatif mana pun: apa yang boleh
+      diubah sebuah pemformat, apa yang tetap diubah kebanyakan dari mereka, dan
+      cara membaca galatnya ketika file-nya sama sekali tidak mau terbaca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa itu memformat, dan apa yang bukan</h2>
+    <p>
+      JSON nyaris tidak punya sintaks. Sebuah objek, sebuah larik, sebuah teks,
+      sebuah angka, dan ketiga kata <code>true</code>, <code>false</code>, serta
+      <code>null</code>. Di antara potongan-potongan itu, spasi tidak berarti
+      apa-apa: file
+    </p>
+    <pre><code>{"name":"thing","tags":["local","offline"]}</code></pre>
+    <p>
+      dan file
+    </p>
+    <pre><code>{
+  "name": "thing",
+  "tags": [
+    "local",
+    "offline"
+  ]
+}</code></pre>
+    <p>
+      adalah dokumen yang sama. Memformat adalah urusan berpindah dari yang
+      pertama ke yang kedua, dan <em>itulah seluruh pekerjaannya</em>. Apa pun
+      lain yang dilakukan sebuah pemformat pada file Anda &mdash; menyusun ulang,
+      membulatkan, membuang &mdash; adalah perubahan pada apa yang dikatakan
+      dokumennya, dibuat tanpa diminta.
+    </p>
+    <p>
+      Tiga dari perubahan itu cukup umum sehingga layak disebutkan, karena mereka
+      diam-diam dan karena itulah yang dilakukan secara bawaan oleh sebuah
+      pemformat yang ditulis dalam satu sore.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tiga hal yang tidak boleh diubah sebuah pemformat</h2>
+
+    <h3>Urutan kunci Anda</h3>
+    <p>
+      Inilah yang menjebak orang. Cara gamblang menulis pemformat JSON dalam
+      JavaScript adalah memanggil <code>JSON.parse</code> lalu
+      <code>JSON.stringify</code> dengan sebuah indentasi, dan pasangan itu tidak
+      menjaga urutan kunci yang tampak seperti bilangan bulat:
+    </p>
+    <pre><code>Object.keys(JSON.parse('{"10":"a","2":"b","x":"c"}'))
+// ['2', '10', 'x']</code></pre>
+    <p>
+      Itu bukan bug di kode siapa pun. Objek JavaScript memang dispesifikasikan
+      untuk menaruh kunci yang mirip bilangan bulat lebih dulu, dalam urutan
+      numerik menaik, dan setiap nilai yang melewati <code>JSON.parse</code>
+      menjadi sebuah objek JavaScript. Pemformat yang dibangun begitu akan
+      menyusun ulang file yang berkunci id, nomor porta, tahun, atau kode status
+      HTTP, dan akan melakukannya tanpa sepatah kata pun.
+    </p>
+    <p>
+      Apakah itu penting tergantung file-nya. Objek JSON pada prinsipnya tidak
+      berurutan, jadi secara teknis tidak ada yang rusak &mdash; tapi diff-nya
+      terhadap versi di repositori Anda akan luar biasa besar, tinjauannya tidak
+      akan terbaca, dan kalau ada apa pun di hilir yang membaca file-nya secara
+      berurutan, perilakunya berubah.
+    </p>
+
+    <h3>Digit angka Anda</h3>
+    <p>
+      JSON tidak mengatakan seberapa besar sebuah angka boleh, dan JavaScript
+      mengatakannya: setiap angka adalah sebuah double. Jadi pemformat yang
+      membaca menjadi sebuah double lalu mencetaknya kembali kehilangan apa pun
+      yang tidak bisa ditampung sebuah double.
+    </p>
+    <pre><code>JSON.stringify(JSON.parse('{"id":123456789012345678901}'))
+// {"id":123456789012345680000}
+
+JSON.stringify(JSON.parse('{"size":1e999}'))
+// {"size":null}</code></pre>
+    <p>
+      Sebuah id dua puluh satu digit &mdash; id Twitter, id Snowflake, sebuah
+      nomor rujukan bank &mdash; kembali sebagai angka yang berbeda, dan nilai
+      yang terlalu besar untuk sebuah double kembali sebagai <code>null</code>.
+      Kedua file-nya tetap terbaca, dan tidak satu pun adalah file yang Anda
+      mulai.
+    </p>
+    <p>
+      Jalan keluarnya adalah sama sekali tidak membaca angkanya. Pemformat hanya
+      perlu tahu di mana sebuah angka mulai dan berakhir untuk menata dokumennya;
+      ia tidak pernah butuh nilainya, jadi hal yang aman adalah menyalin
+      digitnya persis seperti mereka ditulis. Itulah yang dilakukan alat di
+      sini.
+    </p>
+
+    <h3>Kunci ganda Anda</h3>
+    <p>
+      <code>{"a": 1, "a": 2}</code> adalah JSON yang sah, dan standarnya menolak
+      mengatakan mana dari keduanya yang menang. Pembaca berbeda-beda pada
+      praktiknya: kebanyakan menyimpan yang terakhir, sebagian menyimpan yang
+      pertama, beberapa menolak dokumennya. Pemformat yang diam-diam
+      mengeluarkan salah satunya sudah membuat keputusan itu untuk Anda, dan
+      sudah menyembunyikan fakta yang jauh lebih berguna bahwa tadinya ada dua
+      &mdash; dan itu hampir selalu sebuah kekeliruan di file-nya, dan
+      kekeliruan yang ingin Anda lihat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ketika file-nya tidak mau terbaca</h2>
+    <p>
+      Kebanyakan JSON yang gagal tidak aneh-aneh. Ia salah satu dari sekitar enam
+      hal, dan galatnya memberi tahu Anda yang mana kalau ia mengatakan di mana
+      letaknya dalam istilah yang bisa Anda temukan. Sebuah offset seperti
+      <code>position 4193</code> bukan itu; sebuah baris dan kolom baru itu.
+    </p>
+    <ul>
+      <li>
+        <strong>Koma di ujung.</strong> <code>{"a": 1,}</code> sah di JavaScript
+        dan tidak di JSON. Penyebab tunggal yang paling umum, biasanya
+        ditinggalkan setelah menghapus entri terakhir sebuah daftar.
+      </li>
+      <li>
+        <strong>Tanda kutip tunggal.</strong> <code>{'a': 1}</code> adalah
+        literal objek JavaScript, bukan JSON. Teks dan kuncinya sama-sama
+        berkutip ganda, dan kuncinya selalu berkutip.
+      </li>
+      <li>
+        <strong>Kunci tanpa kutip.</strong> <code>{a: 1}</code>, kekeliruan yang
+        sama dari arah sebaliknya &mdash; biasanya dari menempelkan sesuatu dari
+        kode alih-alih dari sebuah file.
+      </li>
+      <li>
+        <strong>Komentar.</strong> <code>// seperti ini</code> juga bukan JSON.
+        Itu JSONC, yang dipakai setelan VS Code dan <code>tsconfig.json</code>,
+        dan ia tidak akan terbaca di tempat lain mana pun. Kalau sebuah komentar
+        harus selamat, kelazimannya adalah sebuah kunci:
+        <code>"_comment": "..."</code>.
+      </li>
+      <li>
+        <strong>Baris baru atau tab sungguhan di dalam sebuah teks.</strong>
+        Mereka harus ditulis sebagai <code>\n</code> dan <code>\t</code>. Inilah
+        yang biasanya keliru ketika sebuah perintah shell atau sebuah sertifikat
+        ditempelkan ke sebuah nilai dengan tangan.
+      </li>
+      <li>
+        <strong>Angka yang tidak diizinkan JSON.</strong> Nol di depan
+        (<code>01</code>), titik desimal telanjang (<code>.5</code>),
+        <code>NaN</code>, <code>Infinity</code>, dan <code>+1</code> semuanya hal
+        yang ditulis orang dan tidak satu pun adalah JSON.
+      </li>
+    </ul>
+    <p>
+      Satu yang bukan galat tapi tampak seperti galat: file yang mulai dengan
+      sebuah byte-order mark. Ia tak terlihat di kebanyakan penyunting, ia bukan
+      spasi, dan ia membuat karakter pertama dokumennya menjadi tak terduga.
+      Kalau galatnya di baris 1, kolom 1 pada file yang tampak sempurna, itulah
+      yang terjadi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memampatkan, dan betapa sedikit biasanya yang didapat</h2>
+    <p>
+      Memeras spasinya keluar adalah operasi yang sama secara terbalik, dan layak
+      bersikap realistis tentang apa yang didapat darinya. Spasi sangat berulang,
+      dan setiap server dan peramban di antara Anda dan seorang pembaca sudah
+      mengompres tanggapannya dengan gzip atau Brotli, yang sangat pandai justru
+      pada pengulangan semacam itu.
+    </p>
+    <p>
+      Jadi JSON yang dimampatkan sering tiga puluh persen lebih kecil sebagai
+      sebuah file dan hanya beberapa persen lebih kecil di sepanjang kabel.
+      Tempat ia memang mendapatkan nafkahnya adalah tempat yang tidak ada
+      kompresi di depannya: sebuah nilai di kolom basis data, sebuah kolom di
+      baris log, sebuah muatan di dalam kode QR, atau sebuah dokumen yang hendak
+      Anda Base64-kan ke dalam sebuah header.
+    </p>
+    <p>
+      Yang dikorbankannya adalah keterbacaan, dan kalau file-nya disimpan di
+      sebuah repositori ia juga mengorbankan diff Anda &mdash; file satu baris
+      berubah seluruhnya kapan pun apa pun di dalamnya berubah. Mampatkan di
+      jalan keluar dari penyunting Anda, bukan di jalan masuknya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mengurutkan kuncinya, dan kapan jangan</h2>
+    <p>
+      Mengurutkan kunci setiap objek ditawarkan di sini sebagai pilihan alih-alih
+      diterapkan secara bawaan, karena ia perubahan yang nyata pada file-nya dan
+      nilainya sepenuhnya tergantung pada apa yang hendak Anda lakukan.
+    </p>
+    <p>
+      Ia membantu ketika Anda membandingkan dua dokumen yang seharusnya
+      mengatakan hal yang sama &mdash; konfigurasi dua lingkungan, sebuah
+      tanggapan API sebelum dan sesudah sebuah perubahan &mdash; dan salah satunya
+      mendaftar kuncinya dalam urutan yang berbeda. Mengurutkan keduanya lebih
+      dulu mengubah diff atas segalanya menjadi diff atas dua baris yang memang
+      berbeda.
+    </p>
+    <p>
+      Ia merugikan ketika urutannya sedang melakukan sesuatu. Sebuah
+      <code>package.json</code> punya kelaziman soal apa yang datang lebih dulu;
+      konfigurasi yang ditulis tangan sering mengelompokkan setelan yang
+      berhubungan; dan file yang kuncinya diurutkan sebuah alat lalu disimpan
+      menghasilkan satu commit yang sangat besar dan tanpa makna. Urutkan sebuah
+      salinan, bukan aslinya.
+    </p>
+    <p>
+      Satu detail yang layak diketahui: pengurutan di sini menurut cara kuncinya
+      terbaca alih-alih menurut titik kodenya, jadi <code>item2</code> datang
+      sebelum <code>item10</code> alih-alih sesudahnya. Mengurutkan menurut titik
+      kode itulah yang menaruh <code>item10</code> di tengah-tengah angka satuan,
+      dan itu secara teknis benar dan tidak berguna bagi seorang pembaca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Membandingkan dua file JSON</h2>
+    <p>
+      Cara yang bisa diandalkan adalah memformat keduanya dengan cara yang sama
+      lebih dulu. Dua dokumen yang mengatakan hal yang sama bisa berbeda di
+      setiap barisnya kalau yang satu dimampatkan dan yang lain tidak, dan tidak
+      ada diff yang bisa melihat menembus itu.
+    </p>
+    <p>
+      Jadi: format yang pertama, format yang kedua, lalu bandingkan kedua
+      hasilnya. Ketiga langkahnya ada di halaman yang sama di sini &mdash; tab
+      <em>Bandingkan</em> berbagi kotaknya dengan <em>Format</em> persis karena
+      alasan ini. Kalau keduanya juga mendaftar kuncinya dalam urutan yang
+      berbeda, urutkan keduanya sambil Anda memformatnya dan perbandingannya
+      mengerucut ke perbedaan yang Anda cari.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bagian yang tidak ditaruh siapa pun di halamannya</h2>
+    <p>
+      Cari sebuah pemformat JSON dan Anda akan menemukan puluhan situs dengan
+      sebuah kotak di atasnya. Menempelkan ke kotak itu adalah sebuah unggahan.
+      Apa pun yang ada di papan klip Anda &mdash; sebuah tanggapan API yang ada
+      alamat seorang pelanggan di dalamnya, sebuah file konfigurasi dengan
+      sebuah connection string, sebuah token yang sedang Anda awakutu &mdash;
+      sudah dikirim ke sebuah mesin yang tidak Anda kendalikan, dan ia kini file
+      log mereka, laporan galat mereka, dan cadangan mereka.
+    </p>
+    <p>
+      Ini bukan andai-andai tentang niat jahat. Situs yang sangat berniat baik
+      pun tetap menyimpan log akses, tetap menjalankan analitik, dan tetap punya
+      penyedia hosting. Data yang paling aman adalah data yang tidak pernah
+      pergi, dan untuk pekerjaan yang seluruhnya berupa manipulasi teks sama
+      sekali tidak ada alasan baginya untuk pergi.
+    </p>
+    <p>
+      Dua pemeriksaan, dan keduanya bekerja pada situs mana pun yang membuat
+      klaim ini, bukan hanya yang ini:
+    </p>
+    <ol>
+      <li>
+        <strong>Buka DevTools, perhatikan tab Network, lalu format
+        sesuatu.</strong> Kalau teks Anda sedang dikirim, ada sebuah permintaan
+        yang membawanya. Tidak ada hal lain yang bisa benar pada saat yang sama.
+      </li>
+      <li>
+        <strong>Putuskan koneksi internet lalu coba lagi.</strong> Alat yang
+        mengerjakan pekerjaannya di peramban Anda tidak terpengaruh. Alat yang
+        mengirim teks Anda ke suatu tempat berhenti bekerja, seketika dan
+        sepenuhnya.
+      </li>
+    </ol>
+    <p>
+      Ada versi yang lebih panjang dari keduanya, dengan dua pemeriksaan lagi, di
+      <a href="../apakah-aman-mengunggah-file/">amankah mengunggah file</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bagaimana dengan YAML, XML, dan sisanya</h2>
+    <p>
+      Halaman yang sama membaca XML, HTML, CSS, dan YAML, serta mengubah antara
+      JSON dan yang pertama serta yang terakhir dari mereka. Dua hal layak dibawa
+      dari atas, karena mereka argumen yang sama dalam jas yang berbeda:
+    </p>
+    <ul>
+      <li>
+        <strong>Mengubah YAML menjadi JSON kehilangan komentarnya</strong>,
+        karena JSON tidak punya tempat menaruh satu pun. Anchor dan alias
+        &mdash; cara YAML mengatakan &ldquo;simpul yang sama dua kali&rdquo;
+        &mdash; juga tidak bisa diungkapkan, dan ditolak di sini alih-alih
+        ditebak-tebak.
+      </li>
+      <li>
+        <strong><code>no</code> adalah sebuah teks.</strong> Di YAML 1.1,
+        <code>yes</code>, <code>no</code>, <code>on</code>, dan <code>off</code>
+        adalah boolean, dan itulah sebabnya daftar kode negara yang memuat
+        Norwegia dulu kembali dengan <code>false</code> di dalamnya. YAML 1.2
+        membuang itu dan begitu juga yang ini &mdash; tapi kata-kata itu tetap
+        ditulis kembali dalam tanda kutip, karena apa pun yang membuka file-nya
+        berikutnya bisa jadi pembaca 1.1.
+      </li>
+    </ul>
+  </section>

--- a/locales/id/pages/guides/format-json-without-uploading-it.toml
+++ b/locales/id/pages/guides/format-json-without-uploading-it.toml
@@ -1,0 +1,24 @@
+#
+# Panduan: memformat JSON tanpa mengunggahnya - Bahasa Indonesia.
+#
+# Potongan kode dan pesan galat tidak diterjemahkan: itulah yang muncul di
+# layar pembacanya, huruf demi huruf.
+#
+
+nav = "Memformat JSON"
+title = "Cara Memformat JSON Tanpa Mengunggahnya"
+description = "Cara menata, memeriksa, dan memampatkan JSON di peramban Anda sendiri - apa yang tidak boleh diubah sebuah pemformat pada file Anda, cara membaca pesan galatnya, dan kenapa situs tempat Anda menempelkannya itu penting."
+
+heading = "Cara memformat JSON tanpa menyerahkannya kepada siapa pun"
+lede = """
+    Memformat JSON seharusnya mengubah spasinya dan tidak lebih. Kebanyakan alat
+    yang menawarkan melakukannya mengubah lebih dari itu, dan tidak satu pun
+    menyebutkannya. Inilah apa yang harus diwaspadai, cara membaca galatnya
+    ketika file-nya tidak mau terbaca, dan kenapa kotak tempat Anda menempelkan
+    sebuah file konfigurasi layak dipikirkan."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Memformat JSON tanpa menyerahkannya kepada siapa pun"
+og_description = "Apa yang tidak boleh diubah sebuah pemformat JSON pada file Anda, cara membaca galat pembacaannya, dan kenapa situs tempat Anda menempelkannya itu penting."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/grab-a-frame-from-a-video.html
+++ b/locales/id/pages/guides/grab-a-frame-from-a-video.html
@@ -1,0 +1,221 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../ambil-bingkai-video/">Pengambil Bingkai Video</a>,
+      jatuhkan klipnya, temukan momennya, lalu tekan <em>Ambil bingkai ini</em>.
+      Yang mendarat di unduhan Anda adalah bingkainya pada resolusi videonya
+      sendiri &mdash; 3840 &times; 2160 dari sebuah klip 4K, seberapa pun ukuran
+      pratinjau di halamannya.
+    </p>
+    <p>
+      Biarkan formatnya di PNG kecuali ukuran file-nya jadi masalah. Sisa halaman
+      ini adalah tentang kenapa dua kalimat itu bukan hal yang sama dengan sebuah
+      tangkapan layar, dan kapan perbedaannya layak dipedulikan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa tangkapan layar dari pemutar yang dijeda adalah gambar yang berbeda</h2>
+    <p>
+      Semua orang sudah punya cara melakukan ini: jeda, tekan tombol tangkapan
+      layar, pangkas kendalinya. Ia bekerja, dan untuk berbagi cepat itu takaran
+      usaha yang tepat. Tapi empat hal sudah terjadi pada gambarnya saat itu, dan
+      tidak satu pun bisa diurungkan:
+    </p>
+    <ul>
+      <li>
+        <strong>Ia seukuran jendelanya, bukan seukuran videonya.</strong> Klip 4K
+        di pemutar setengah layar memberi Anda gambar sebuah pemutar setengah
+        layar. Setiap piksel yang ada di file-nya dan tidak di layar hilang.
+      </li>
+      <li>
+        <strong>Ia sudah diskalakan.</strong> Apa pun yang dilakukan pemutarnya
+        untuk memaskan bingkainya ke jendela itu &mdash; pelembutan, penajaman,
+        atau sekadar pengambilan sampel ulang &mdash; sudah terpanggang di
+        dalamnya.
+      </li>
+      <li>
+        <strong>Ia sudah melewati saluran tampilan.</strong> Manajemen warna, dan
+        pada klip HDR sebuah tahap pemetaan nada yang dipilih untuk monitor Anda
+        alih-alih untuk file-nya.
+      </li>
+      <li>
+        <strong>Ia biasanya memuat perabot.</strong> Kendali, bilah kemajuan,
+        trek subtitel, kursor.
+      </li>
+    </ul>
+    <p>
+      Pengambil bingkai melewati keempatnya: ia mendekodekan bingkai yang
+      sebenarnya disimpan file-nya lalu menuliskan piksel itu. Gambarnya seukuran
+      videonya, dan tidak ada yang menggambar di atasnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mendarat di bingkai yang Anda maksud</h2>
+    <p>
+      Inilah bagian yang diam-diam dikacaukan kebanyakan alat, dan layak
+      diketahui apa yang harus dicari di alat mana pun.
+    </p>
+    <p>
+      Video bukan seuntai gambar dalam urutan Anda menontonnya. Kebanyakan
+      bingkai disimpan sebagai keterangan tentang bedanya mereka dengan bingkai
+      lain, dan di file mana pun yang ada bingkai-B-nya, urutan penyimpanannya
+      bukan urutan penampilannya. Alat yang menggeser sebuah pemutar ke sebuah
+      cap waktu lalu mengambil apa pun yang muncul bergantung pada belas kasihan
+      cara pemutar itu membulatkan, dan alat yang melangkah "maju satu bingkai"
+      dengan menambahkan sepertiga puluh detik keliru pada setiap klip yang bukan
+      tepat 30 fps &mdash; dan itu termasuk hampir setiap video ponsel, karena
+      mereka mengubah-ubah frame rate-nya saat cahayanya berubah.
+    </p>
+    <p>
+      Solusinya adalah membaca daftar bingkai milik file-nya sendiri lalu
+      mengalamati mereka menurut tempatnya di daftar itu. Pada sebuah MP4, alat di
+      sini melakukan itu: penggesernya bergerak satu bingkai sekali langkah,
+      tombol panah bergerak satu bingkai, dan ia bisa memberi tahu Anda bahwa Anda
+      ada di bingkai 812 dari 3.540 karena ia menghitungnya. Pada format yang
+      tidak bisa dibacanya langsung, ia mengatakannya, dan melangkah kira-kira
+      sebingkai alih-alih berpura-pura.
+    </p>
+    <p>
+      Cara cepat menguji pengambil bingkai mana pun: langkahkan maju melewati
+      beberapa bingkai dari sesuatu yang bergerak cepat. Kalau gambarnya kadang
+      tidak berubah, atau melompat dua, alatnya sedang menebak-nebak cap waktu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Format apa yang dipakai menyimpannya</h2>
+    <p>
+      Sebenarnya hanya ada tiga jawaban, dan pilihannya soal apa yang terjadi
+      pada gambarnya setelah itu.
+    </p>
+    <ul>
+      <li>
+        <strong>PNG</strong> &mdash; bawaannya, dan satu-satunya yang menyimpan
+        bingkainya persis. Pilih itu kalau gambar diamnya akan disunting,
+        dicetak, dibandingkan dengan bingkai lain, atau disimpan. Ia juga yang
+        terbesar: harapkan beberapa megabita dari 1080p dan sekitar delapan dari
+        4K, karena gambar yang bersifat foto bukan keahlian kompresi PNG.
+      </li>
+      <li>
+        <strong>JPEG</strong> &mdash; sepersepuluh ukurannya, dan diterima di
+        mana-mana. Pilih itu untuk gambar mini, pratinjau, atau apa pun yang
+        langsung masuk ke sebuah dokumen atau obrolan. Ia putaran kedua kompresi
+        yang merugikan di atas kompresi videonya sendiri, jadi ia titik awal yang
+        keliru untuk penyuntingan lanjutan.
+      </li>
+      <li>
+        <strong>WebP</strong> &mdash; lebih kecil lagi pada kualitas tampak yang
+        sama, dan sekarang didukung di semua tempat yang penting. Satu catatannya
+        adalah perangkat lunak lama: sebagian aplikasi desktop masih tidak mau
+        membukanya.
+      </li>
+    </ul>
+    <p>
+      Satu hal yang layak dinyatakan terus terang: bingkai dari sebuah video
+      sudah berupa gambar terkompres. Menyimpannya sebagai PNG tidak mengurungkan
+      itu, dan tidak bisa memulihkan detail yang dibuang kodeknya saat klipnya
+      dibuat. Yang Anda dapat dari PNG adalah tidak ada yang dibuang
+      <em>dua kali</em>. Kalau Anda akan mengoreksi warna atau memangkas gambar
+      diamnya sesudahnya, itu penting; kalau Anda mengirimkannya kepada seseorang,
+      tidak.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mengambil banyak sekaligus</h2>
+    <p>
+      Satu gambar diam setiap beberapa detik adalah pekerjaan yang berbeda dari
+      satu gambar diam pada satu momen, dan ia muncul lebih sering daripada
+      kedengarannya: lembar kontak sebuah rekaman panjang, gambar mini untuk
+      memilih gambar sampul, sampel rekaman yang merata untuk memeriksa fokus
+      atau pencahayaan di sepanjang pengambilan.
+    </p>
+    <p>
+      Setel sebuah selang, tekan tombol serinya, dan alatnya menyusuri klipnya
+      sekali lalu mengambil satu gambar diam di setiap tanda. Dua catatan praktis.
+      Buat selangnya longgar pada klip yang panjang &mdash; satu gambar diam
+      sedetik dari rekaman satu jam adalah 3.600 gambar, dan itulah sebabnya
+      alatnya membatasi satu jalan pada 500. Dan pilih JPEG untuk ini kecuali Anda
+      punya alasan lain: seratus PNG 4K adalah hampir satu gigabita yang ditahan
+      di halamannya sebelum Anda mengunduh satu pun.
+    </p>
+    <p>
+      Mereka kembali sebagai satu ZIP, dinamai menurut kode waktunya, sehingga
+      mereka terurut sesuai urutan kejadiannya dan masing-masing bisa ditemukan
+      lagi di videonya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Video potret, dan gambar diam miring yang klasik</h2>
+    <p>
+      Kalau Anda pernah menarik bingkai dari video ponsel lalu mendapatkannya
+      miring, inilah sebabnya. Sebuah ponsel merekam dalam lanskap lalu menulis
+      seperempat putaran ke dalam file-nya alih-alih memutar pikselnya. Pemutar
+      membaca putaran itu lalu menerapkannya; alat yang hanya membaca pikselnya
+      tidak, dan hasilnya gambar yang sangat baik dari momen yang benar, terputar
+      90 derajat.
+    </p>
+    <p>
+      Tidak ada yang salah dengan file-nya, dan memutar ulang gambar diamnya
+      sesudahnya tidak mengorbankan apa pun selain kejengkelan. Alat di sini
+      membaca rotasinya dari treknya lalu menerapkannya sebelum menggambar, jadi
+      klip potret memberi gambar potret.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang tidak bisa Anda dapatkan kembali</h2>
+    <p>
+      Gambar diam hanya bisa sebaik bingkai asalnya, dan dua hal membatasi itu
+      alat mana pun yang Anda pakai.
+    </p>
+    <p>
+      <strong>Buram gerak ada di dalam bingkainya.</strong> Kalau subjeknya
+      bergerak selama pencahayaannya, setiap bingkai gerakan itu buram, dan tidak
+      ada bingkai tajam di sana untuk ditemukan. Merekam pada kecepatan rana yang
+      lebih tinggi adalah satu-satunya solusi, dan itu harus terjadi sebelum
+      perekamannya.
+    </p>
+    <p>
+      <strong>Kompresi juga ada di dalam bingkainya.</strong> Video dikompres
+      jauh lebih keras daripada sebuah foto, dan jauh lebih keras pada bingkai di
+      antara keyframe-nya. Kalau sebuah gambar diam tampak kotak-kotak, coba
+      melangkah satu dua bingkai ke salah satu arah: keyframe disimpan utuh dan
+      sering tampak jelas lebih bersih daripada tetangganya.
+    </p>
+    <p>
+      Dan kalau gambar diamnya perlu berbeda ukuran atau bentuk sesudahnya,
+      kerjakan itu sebagai langkah terpisah:
+      <a href="../../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a> mengubah
+      ukuran, memangkas, dan mengubah format, dan
+      <a href="../ubah-ukuran-gambar/">panduannya</a> membahas berapa harga
+      masing-masingnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh unggahan</h2>
+    <p>
+      Mendekodekan video di sebuah peramban itu baru dan ia nyata: WebCodecs
+      membuka dekoder perangkat keras yang sama yang dipakai ponsel Anda untuk
+      memutar video. Pekerjaannya terjadi di mesin yang sudah memegang file-nya,
+      dan untuk klip berukuran beberapa gigabita itu juga satu-satunya pengaturan
+      yang masuk akal &mdash; mengunggah satu jam 4K untuk mendapat kembali satu
+      gambar 8 MB adalah pertukaran yang buruk ke segala arah.
+    </p>
+    <p>
+      Alat di sini tidak punya fitur jaringan dalam bentuk apa pun, dan
+      <code>Content-Security-Policy</code> halamannya menyebut satu per satu
+      setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+      Cabut koneksi internet lalu ambil sebuah bingkai kalau Anda lebih suka
+      memeriksa daripada diberi tahu.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain yang bisa Anda
+      jalankan pada alat mana pun.
+    </p>
+  </section>

--- a/locales/id/pages/guides/grab-a-frame-from-a-video.toml
+++ b/locales/id/pages/guides/grab-a-frame-from-a-video.toml
@@ -1,0 +1,19 @@
+#
+# Panduan: mengambil bingkai dari video - Bahasa Indonesia.
+#
+
+nav = "Mengambil sebuah bingkai"
+title = "Cara Menyimpan Bingkai dari Video sebagai Gambar"
+description = "Dapatkan gambar diam dari sebuah klip pada resolusi aslinya: kenapa tangkapan layar dari pemutar yang dijeda bukan gambar yang sama, format apa yang dipakai menyimpannya, dan bagaimana mendarat tepat di bingkai yang Anda maksud."
+
+heading = "Cara menyimpan bingkai dari video sebagai gambar"
+lede = """
+    Menjeda pemutarnya lalu menekan tombol tangkapan layar memberi Anda gambar
+    sebuah jendela. Kadang itu sudah cukup. Inilah apa bedanya, dan bagaimana
+    mendapatkan bingkainya sendiri ketika itu penting."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara menyimpan bingkai dari video sebagai gambar"
+og_description = "Kenapa tangkapan layar dari pemutar yang dijeda bukan bingkainya, format apa yang dipakai menyimpan sebuah gambar diam, dan bagaimana mendarat tepat di bingkai yang Anda maksud."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/is-it-safe-to-upload-files.html
+++ b/locales/id/pages/guides/is-it-safe-to-upload-files.html
@@ -1,0 +1,268 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Untuk kebanyakan file, sebagian besar waktu, mengunggah tidak masalah.
+      Pengubah yang terpandang menghapus apa yang Anda kirim dalam beberapa jam
+      dan tidak berminat pada foto liburan Anda.
+    </p>
+    <p>
+      Masalahnya bukan bahwa mereka berbohong. Melainkan bahwa
+      <strong>Anda tidak punya cara mengetahui apakah mereka berbohong</strong>.
+      Begitu sebuah file meninggalkan mesin Anda, setiap janji tentang apa yang
+      terjadi berikutnya adalah janji yang Anda terima atas dasar kepercayaan:
+      berapa lama ia disimpan, siapa yang bisa menjangkaunya, apakah ia disalin
+      ke sebuah cadangan yang hidup lebih lama daripada pewaktu penghapusannya,
+      apa yang terjadi padanya kalau perusahaannya dijual atau dibobol. Tidak
+      satu pun dari itu terlihat dari luar.
+    </p>
+    <p>
+      Jadi pertanyaan yang berguna bukan &ldquo;apakah saya memercayai situs
+      ini?&rdquo; Melainkan
+      <strong>&ldquo;apakah pekerjaan ini butuh file saya pergi sama
+      sekali?&rdquo;</strong> Untuk sejumlah besar pekerjaan yang terus bertambah,
+      jawabannya tidak, dan ketika jawabannya tidak, pertanyaan kepercayaannya
+      berhenti menjadi pertanyaan yang harus Anda jawab.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa sebenarnya yang dilakukan &ldquo;unggah&rdquo;</h2>
+    <p>
+      Ketika sebuah pengubah meminta Anda memilih sebuah file lalu menampilkan
+      sebuah bilah kemajuan, peramban Anda sedang menyalin seluruh file-nya, byte
+      demi byte, melintasi internet ke sebuah komputer milik orang lain. Komputer
+      itu menulisnya ke sebuah disk, menjalankan pengubahannya, menulis hasilnya
+      ke disk yang sama, lalu menyerahkan sebuah tautan kepada Anda.
+    </p>
+    <p>
+      Pada saat itu file Anda ada di setidaknya tiga tempat yang tidak Anda
+      pilih: disk servernya, log apa pun yang merekam permintaannya, dan sering
+      sebuah jaringan pengiriman konten yang menyinggahkan hasilnya supaya
+      unduhannya cepat. Sebuah kebijakan penghapusan harus menjangkau ketiganya.
+      Kebanyakan berkata mereka begitu. Anda tidak bisa memeriksa satu pun.
+    </p>
+    <p>
+      Layak diketahui juga: file-nya bukan satu-satunya yang tiba. Nama file-nya
+      ikut serta, dan begitu juga semua di dalam file-nya yang tidak bisa Anda
+      lihat. Foto yang langsung dari sebuah ponsel biasanya membawa koordinat GPS
+      persis tempat ia diambil, waktunya, nomor seri kameranya, dan kadang sebuah
+      gambar mini tersemat dari gambar aslinya sebelum Anda memangkasnya. Orang
+      yang berhati-hati soal gambarnya sering tidak berhati-hati soal itu, karena
+      tidak ada apa pun di layar yang menunjukkannya kepada mereka.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa kebanyakan alat tetap mengunggah</h2>
+    <p>
+      Bukan karena mereka menginginkan file Anda. Melainkan karena sepanjang
+      hampir seluruh usia web tidak ada alternatifnya. Sebuah peramban tidak bisa
+      mendekodekan video, mengodekan ulang sebuah gambar pada kualitas pilihan,
+      atau membaca sebuah format file; sebuah server dengan FFmpeg dan ImageMagick
+      bisa. Mengunggah bukan model bisnis, ia satu-satunya tempat pekerjaannya
+      bisa terjadi.
+    </p>
+    <p>
+      Itu berhenti benar belum lama ini dan secara diam-diam. Peramban kini
+      mengirimkan WebAssembly, yang menjalankan kodek terkompilasi yang sama pada
+      kecepatan mendekati asli, WebCodecs, yang membuka pengode video perangkat
+      keras yang sudah ada di mesin Anda, dan sebuah Canvas API yang bisa
+      mendekodekan dan mengodekan ulang gambar secara langsung. Pekerjaan yang
+      dulu membutuhkan sebuah server kini berjalan di perangkat yang sudah
+      memegang file-nya.
+    </p>
+    <p>
+      Banyak alat masih mengunggah, dan ada alasan yang jujur: sebuah alur kerja
+      yang sudah ada yang tidak ingin ditulis ulang siapa pun, sebuah format yang
+      tidak punya dekoder di sisi peramban, sebuah pekerjaan yang memang sungguh
+      terlalu berat untuk sebuah ponsel. Ada juga alasan yang kurang jujur, yaitu
+      bahwa sebuah server adalah tempat akun, kuota, dan paket berbayar tinggal.
+      Alat yang berjalan sepenuhnya di peramban Anda sulit ditakar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Empat pemeriksaan yang bisa Anda jalankan sendiri</h2>
+    <p>
+      Semua ini bekerja pada alat mana pun, termasuk yang ini. Tidak satu pun
+      menuntut menerima kata siapa pun tentang apa pun, dan yang pertama memakan
+      sekitar sepuluh detik.
+    </p>
+
+    <h3>1. Cabut koneksinya</h3>
+    <p>
+      Muat halamannya, lalu matikan wifi Anda atau cabut kabelnya, dan coba
+      pakai. Alat yang mengerjakan pekerjaannya di peramban Anda berjalan terus
+      persis seperti sebelumnya. Alat yang mengunggah berhenti seketika, karena
+      benda yang mengerjakan pekerjaannya tidak lagi terjangkau.
+    </p>
+    <p>
+      Inilah uji terkuat yang ada, dan yang paling sulit dipalsukan, karena ia
+      tidak bisa dijawab dengan pilihan kata. Entah pengubahannya rampung tanpa
+      jaringan entah tidak.
+    </p>
+
+    <h3>2. Perhatikan tab Network</h3>
+    <p>
+      Buka alat pengembang peramban Anda, pilih Network, lalu pakai alatnya.
+      Setiap permintaan yang dibuat halamannya didaftar lengkap dengan ukurannya.
+      Kalau foto 4&nbsp;MB Anda diunggah, ada permintaan 4&nbsp;MB di daftar itu.
+      Kalau hal terbesar yang meninggalkan halamannya adalah beberapa kilobita
+      iklan, ia tidak diunggah.
+    </p>
+    <p>
+      Urutkan menurut ukurannya lalu lihat bagian atasnya. Anda tidak perlu
+      memahami permintaannya; Anda perlu menyadari apakah salah satunya seukuran
+      file Anda.
+    </p>
+
+    <h3>3. Baca Content-Security-Policy-nya</h3>
+    <p>
+      Lihat sumber halamannya lalu cari
+      <code>Content-Security-Policy</code>, dekat bagian atasnya. Ia sebuah
+      daftar alamat yang boleh dihubungi halaman itu, dan ia ditegakkan peramban
+      Anda alih-alih oleh niat baik situsnya &mdash; permintaan ke apa pun yang
+      tidak ada di daftarnya ditolak, apa pun yang dicoba kodenya.
+    </p>
+    <p>
+      Arahan yang penting adalah <code>connect-src</code>, yang mengatur ke mana
+      halamannya boleh mengirim data. Kalau ia menyebutkan sebuah alamat milik
+      situs tempat Anda berada, halamannya bisa mengirim file Anda ke sana. Kalau
+      ia tidak menyebutkan apa pun, atau hanya pihak ketiga seperti sebuah
+      jaringan iklan, ia tidak bisa.
+    </p>
+    <p>
+      Halaman yang sama sekali tidak punya Content-Security-Policy bukan bukti
+      hal yang buruk. Ia sekadar berarti pemeriksaan yang satu ini tidak punya
+      apa-apa untuk diberitahukan kepada Anda.
+    </p>
+
+    <h3>4. Baca kodenya</h3>
+    <p>
+      Paling tidak praktis, paling meyakinkan. Kalau sebuah alat menerbitkan
+      sumbernya lalu menyajikannya tanpa langkah bangun, file yang diambil
+      peramban Anda adalah file yang bisa Anda baca. Cari di dalamnya
+      <code>fetch</code>, <code>XMLHttpRequest</code>, dan
+      <code>sendBeacon</code> &mdash; ketiga cara sebuah halaman bisa mengirim
+      apa pun &mdash; lalu lihat apa yang diberikan kepada mereka.
+    </p>
+    <p>
+      Kebanyakan orang tidak akan melakukan ini. Tetap penting bahwa itu mungkin,
+      karena klaim yang tidak bisa diperiksa siapa pun sebenarnya bukan klaim.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang tidak berarti &ldquo;berjalan di peramban Anda&rdquo;</h2>
+    <p>
+      Layak dinyatakan dengan tepat, karena frasanya dipakai secara longgar dan
+      situs ini harus memegang dirinya pada standar yang sama dengan yang
+      diusulkannya.
+    </p>
+    <ul>
+      <li>
+        <strong>Ia tidak berarti sama sekali tidak ada permintaan.</strong>
+        Halamannya sendiri tiba lewat jaringan, dan kebanyakan alat gratis
+        membawa iklan atau analitik yang berbicara dengan seseorang. Klaimnya
+        tentang <em>file</em> Anda, bukan tentang lalu lintas pada umumnya.
+      </li>
+      <li>
+        <strong>Ia tidak menyembunyikan alamat IP Anda.</strong> Setiap situs
+        yang Anda kunjungi melihatnya, yang ini termasuk. Pemrosesan setempat
+        adalah tentang isi file Anda, bukan tentang keanoniman.
+      </li>
+      <li>
+        <strong>Ia tidak selamat dari sebuah fitur yang mengambil
+        sesuatu.</strong> Alat yang membiarkan Anda menempelkan sebuah alamat web
+        harus menghubungi alamat itu, dan server itu mengetahui IP Anda dan apa
+        yang Anda minta. Itu melekat pada fiturnya, bukan cacat di dalamnya
+        &mdash; tapi ia sebuah pengecualian yang nyata dan sebuah alat sebaiknya
+        mengatakannya terus terang alih-alih membulatkannya.
+      </li>
+      <li>
+        <strong>Ia tidak sama dengan &ldquo;kami menghapus file
+        Anda.&rdquo;</strong> Kalimat kedua tentang apa yang dipilih sebuah
+        perusahaan untuk dilakukan. Yang pertama tentang apa yang secara teknis
+        mungkin. Hanya satu di antaranya yang bisa diperiksa.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Kapan mengunggah memang tidak masalah</h2>
+    <p>
+      Ini bukan argumen bahwa setiap unggahan adalah kekeliruan. Kirim file-nya
+      ketika isinya tidak sensitif dan pekerjaannya lebih mudah begitu; ketika
+      pekerjaannya memang sungguh terlalu berat untuk perangkat Anda; ketika
+      formatnya tidak punya dekoder di sisi peramban; atau ketika Anda memakai
+      sebuah layanan yang sudah punya hubungan dengan Anda dan yang ketentuannya
+      memang sudah Anda baca.
+    </p>
+    <p>
+      Lebih berhati-hatilah ketika file-nya memuat sesuatu yang tidak akan Anda
+      unggah ke publik: dokumen identitas, pindaian medis, kontrak, apa pun yang
+      ada alamat atau wajah yang tidak Anda niatkan untuk dibagikan, atau sebuah
+      foto yang data lokasinya belum Anda lihat. Untuk yang seperti itu, alat
+      yang bisa Anda periksa layak lebih dipilih daripada alat yang harus Anda
+      percayai &mdash; bukan karena yang dipercayai itu mungkin mengkhianati
+      Anda, melainkan karena dengan yang bisa diperiksa, pertanyaannya tidak
+      timbul.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bagaimana situs ini menjawab keempat pemeriksaan itu</h2>
+    <p>
+      Akan aneh sebuah panduan yang menyuruh Anda memeriksa lalu meminta
+      dikecualikan. Jadi, berurutan:
+    </p>
+    <ul>
+      <li>
+        <strong>Cabut koneksinya.</strong> Buka alat mana pun di sini, putuskan
+        koneksinya, dan ia terus bekerja. Setiap halaman alat punya penanda
+        langsung yang memberi tahu Anda apakah Anda sedang daring, jadi Anda bisa
+        memperhatikannya berubah.
+      </li>
+      <li>
+        <strong>Tab Network.</strong> Ubah sesuatu lalu baca daftarnya. Tidak ada
+        yang membawa file Anda, gambar mininya, namanya, ukurannya, atau apa pun
+        yang dibaca darinya. Tidak ada peristiwa analitik khusus di situs ini
+        yang punya satu pun dari itu untuk dikirim.
+      </li>
+      <li>
+        <strong>Content-Security-Policy.</strong> Ia ada di bagian atas sumber
+        setiap halaman. <code>connect-src</code> menyebutkan titik akhir iklan
+        dan pengukuran milik Google serta tombol donasinya, dan tidak lebih.
+        <strong>Tidak ada alamat di daftar itu yang milik situs ini</strong>,
+        karena situs ini tidak punya server &mdash; ia file statis. Tidak ada
+        tujuan bagi sebuah file untuk dikirim bahkan seandainya ada yang mencoba.
+      </li>
+      <li>
+        <strong>Kode.</strong> Setiap barisnya
+        <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">publik</a>.
+        Proses bangunnya membuang komentar dan spasi dan tidak lebih, dan Anda
+        bisa menjalankannya sendiri lalu membandingkan hasilnya dengan yang
+        sedang disajikan.
+      </li>
+    </ul>
+    <p>
+      Pengecualiannya, dinyatakan alih-alih dikubur: situs ini memasang iklan
+      Google dan sebuah pencacah kunjungan, keduanya berbicara dengan Google dan
+      tidak satu pun diberi apa pun tentang file Anda; dan alat
+      <a href="../../gambar-ke-video/">Gambar ke Video</a> bisa mengambil sebuah
+      gambar dari alamat yang Anda tempelkan, yang berarti server itu melihat IP
+      Anda. <a href="../../privasi/">Halaman privasinya</a> memaparkan keduanya
+      selengkapnya.
+    </p>
+    <p>
+      Setiap alat di sini bekerja seperti ini: sebuah
+      <a href="../../kompres-gambar/">kompresor gambar</a> yang memenuhi ukuran
+      yang Anda sebutkan, sebuah
+      <a href="../../pangkas-video/">pemangkas video</a>, sebuah
+      <a href="../../hapus-data-exif/">penampil dan penghapus EXIF</a> untuk data
+      tersembunyi yang dijelaskan lebih jauh di halaman ini,
+      <a href="../../gambar-ke-video/">gambar ke video</a>, dan
+      <a href="../../gambar-ke-pdf/">gambar ke PDF</a>. Semuanya gratis, tanpa
+      akun, dan tidak satu pun punya tujuan untuk mengirim file Anda.
+    </p>
+  </section>

--- a/locales/id/pages/guides/is-it-safe-to-upload-files.toml
+++ b/locales/id/pages/guides/is-it-safe-to-upload-files.toml
@@ -1,0 +1,24 @@
+#
+# Panduan: amankah mengunggah file - Bahasa Indonesia.
+#
+# Halaman ini menutup dengan situs ini menjawab pemeriksaannya sendiri, jadi
+# tautannya harus benar: setiap tautan alat memakai slug bahasa Indonesia.
+#
+
+nav = "Amankah mengunggah file?"
+title = "Amankah Mengunggah File ke Pengubah Daring?"
+description = "Kebanyakan pengubah daring mengirim file Anda ke sebuah server. Apa artinya, apa yang terjadi padanya di sana, dan empat pemeriksaan yang memberi tahu Anda apakah sebuah alat memang harus begitu."
+
+heading = "Amankah mengunggah file ke pengubah daring?"
+lede = """
+    Biasanya jawaban yang jujur adalah &ldquo;mungkin aman, tapi Anda tidak bisa
+    memeriksanya.&rdquo; Ini menjelaskan apa yang sebenarnya dilakukan
+    pengunggahan terhadap file Anda, kenapa kebanyakan alat masih
+    melakukannya, dan empat uji yang memberi tahu Anda apakah alat di hadapan
+    Anda memang harus."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Amankah mengunggah file ke pengubah daring?"
+og_description = "Apa yang terjadi pada file yang Anda unggah ke sebuah pengubah, kenapa kebanyakan alat masih memintanya, dan empat pemeriksaan yang bisa Anda jalankan sendiri."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/make-a-favicon.html
+++ b/locales/id/pages/guides/make-a-favicon.html
@@ -1,0 +1,352 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../buat-favicon/">Gambar ke ICO</a>, jatuhkan sebuah
+      gambar persegi berukuran setidaknya 256 piksel, biarkan prasetelnya di
+      <em>Favicon situs web</em>, lalu unduh <code>favicon.ico</code>. Taruh di
+      akar situs Anda, sehingga ia menjawab di
+      <code>https://situsanda.com/favicon.ico</code>. Alamat itu diminta setiap
+      peramban entah HTML Anda menyebutnya atau tidak, jadi tidak ada lagi yang
+      benar-benar harus Anda lakukan.
+    </p>
+    <p>
+      Semua di bawah ini adalah bagian yang membuat bedanya ikon yang secara
+      teknis ada dengan ikon yang terbaca: ukuran mana yang masuk, apa yang
+      diminta iPhone dan Android sebagai gantinya, dan apa yang dilakukan ketika
+      logo Anda tidak selamat menjadi selebar enam belas piksel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ia sekumpulan ukuran alih-alih satu gambar</h2>
+    <p>
+      File <code>.ico</code> adalah sebuah wadah. Di dalamnya ada beberapa gambar
+      utuh dari benda yang sama pada ukuran yang berbeda, dan apa pun yang
+      membaca file-nya memilih yang paling dekat dengan ukuran yang
+      dibutuhkannya.
+    </p>
+    <p>
+      Itu terdengar seperti pemborosan padahal bukan. Peramban yang menggambar
+      ikon Anda pada enam belas piksel punya dua pilihan: membaca versi enam
+      belas piksel yang Anda gambar, atau mengecilkan yang lebih besar di
+      tempat. Yang kedua lebih buruk, dan kelihatan &mdash; pengecilan otomatis
+      sebuah logo yang rinci menghasilkan bubur, sedangkan versi enam belas piksel
+      yang sudah Anda lihat adalah sesuatu yang sempat Anda sederhanakan. Seluruh
+      alasan formatnya menyimpan beberapa ukuran adalah untuk memberi Anda
+      kesempatan itu.
+    </p>
+    <p>
+      Tiga ukuran adalah kelaziman untuk sebuah situs web, dan masing-masing
+      punya alasan:
+    </p>
+    <ul>
+      <li>
+        <strong>16&times;16</strong> &mdash; tab peramban, bilah alamat, menu
+        markah. Inilah yang dilihat orang. Kalau Anda hanya bisa membenarkan
+        satu, benarkan yang ini.
+      </li>
+      <li>
+        <strong>32&times;32</strong> &mdash; bilah markah, pintasan desktop
+        Windows ke situs Anda, dan kebanyakan peramban di layar berkepadatan
+        tinggi, yang menggambar ikon tabnya dari 32 lalu menskalakannya turun.
+      </li>
+      <li>
+        <strong>48&times;48</strong> &mdash; ukuran ketika Google membaca ikon
+        sebuah situs untuk hasil pencarian, dan tampilan ikon sedang Windows.
+      </li>
+    </ul>
+    <p>
+      Apa pun yang lebih besar pantasnya di sebuah PNG di sebelah
+      <code>.ico</code>-nya, bukan di dalamnya, karena alasan yang muncul di
+      bagian file ponsel di bawah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Masalah enam belas piksel</h2>
+    <p>
+      Inilah bagian yang tidak diperingatkan siapa pun kepada Anda. Enam belas
+      piksel kira-kira empat milimeter di layar biasa: sebuah kisi berisi 256
+      titik seluruhnya, lebih sedikit daripada huruf di kalimat ini. Hampir tidak
+      ada yang dirancang untuk berhasil di sebuah papan nama, kartu nama, atau
+      header situs web yang selamat ketika dikecilkan ke sana.
+    </p>
+    <p>
+      Yang lenyap, berurutan:
+    </p>
+    <ul>
+      <li>
+        <strong>Teks.</strong> Logo kata yang dikecilkan ke dalam sebuah persegi
+        tingginya sekitar tiga piksel. Ia tidak menjadi teks kecil, ia menjadi
+        sebatang abu-abu. Inilah sebabnya hampir setiap perusahaan yang punya
+        lambang sekaligus nama memakai lambangnya saja sebagai faviconnya, dan
+        sebabnya yang tidak punya lambang memakai satu huruf.
+      </li>
+      <li>
+        <strong>Garis tipis.</strong> Tepi selebar satu piksel di logo 512 piksel
+        adalah sepertiga puluh dua piksel pada enam belas. Ia tergambar sebagai
+        kabut abu-abu samar di sepanjang tepinya, atau lenyap.
+      </li>
+      <li>
+        <strong>Gradien dan bayangan.</strong> Tidak ada ruang untuk sebuah
+        peralihan. Bayangan jatuh yang lembut menjadi rumbai kotor.
+      </li>
+      <li>
+        <strong>Detail di dalam detail.</strong> Ikon sebuah dokumen bertulisan
+        menjadi sebuah persegi panjang bercoreng.
+      </li>
+    </ul>
+    <p>
+      Solusinya bukan sebuah setelan, melainkan gambar yang berbeda: sebuah
+      lambang yang disederhanakan dengan satu atau dua bentuk, kontras tinggi, dan
+      tanpa teks di luar satu karakter. Gambar versi itu pada 32 atau 48 piksel
+      dengan sengaja, lalu pakai sebagai sumbernya.
+    </p>
+    <p>
+      Yang bisa dilakukan sebuah alat adalah menunjukkan masalahnya kepada Anda
+      sebelum Anda menerbitkannya. Pratinjau di
+      <a href="../../buat-favicon/">Gambar ke ICO</a> menggambar setiap ukuran
+      pada ukuran sebenarnya di layar, dan itulah satu-satunya cara menilai ini
+      &mdash; ikon enam belas piksel yang ditampilkan pada enam puluh empat
+      tampak baik-baik saja dan tidak memberi tahu Anda apa-apa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Logo Anda tidak persegi. Isi sisanya atau pangkas?</h2>
+    <p>
+      Ikon selalu persegi, dan kebanyakan logo tidak, jadi sesuatu harus terjadi.
+      Ada tiga jawaban dan ketiganya tidak sama baiknya.
+    </p>
+    <p>
+      <strong>Mengisi sisanya</strong> menjaga seluruh gambarnya lalu menaruh
+      ruang di atas dan di bawahnya. Ia bawaan yang aman dan pilihan yang keliru
+      untuk logo kata yang lebar: memaskan sesuatu yang tiga kali lebih lebar
+      daripada tinggi ke dalam sebuah persegi membuatnya menempati sepertiga
+      tingginya, dan pada enam belas piksel itu lima piksel logo dan sebelas
+      piksel ketiadaan.
+    </p>
+    <p>
+      <strong>Memangkas ke bagian tengah</strong> mengambil persegi terbesar dari
+      tengahnya. Untuk sebuah gabungan &mdash; lambang dengan nama perusahaan di
+      sebelahnya &mdash; ini sering memotong keduanya sekaligus. Lebih baik
+      pangkas sumbernya sendiri lebih dulu, sampai tinggal lambangnya saja, lalu
+      ubah yang itu.
+    </p>
+    <p>
+      <strong>Meregangkan</strong> menjepit gambarnya supaya muat. Hampir tidak
+      ada keadaan yang membuat ini benar, dan ia ditawarkan terutama supaya
+      alatnya tidak diam-diam melakukannya.
+    </p>
+    <p>
+      Jawaban umum untuk logo yang lebar: jangan ubah logonya. Ubah bagian
+      darinya yang berhasil berdiri sendiri.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparan atau latar padat?</h2>
+    <p>
+      Transparan biasanya benar untuk sebuah situs web. Tab peramban berwarna
+      abu-abu, putih, atau nyaris hitam tergantung perambannya dan temanya, dan
+      ikon transparan duduk di atas semuanya. Ikon yang latar putihnya sudah
+      terlukis adalah persegi panjang putih di bilah tab yang gelap.
+    </p>
+    <p>
+      Dua pengecualian yang layak diketahui:
+    </p>
+    <ul>
+      <li>
+        <strong>Logo yang gelap dan tidak lebih</strong> lenyap dalam mode gelap.
+        Kalau lambang Anda pada dasarnya hitam di atas putih, beri ia latar
+        berwarna alih-alih yang transparan, atau sebuah siluet terang.
+      </li>
+      <li>
+        <strong>Ikon sentuh Apple harus buram.</strong> iOS menggambarnya di
+        ubinnya sendiri yang bersudut bulat lalu menggambarkan transparansinya
+        sebagai hitam. Alat mana pun yang menghasilkan file itu seharusnya
+        meratakannya untuk Anda; yang di sini melakukannya, ke putih secara
+        bawaan.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>File yang dibutuhkan sebuah situs web yang bukan .ico-nya</h2>
+    <p>
+      <code>favicon.ico</code> mencakup peramban dan Windows. Ia tidak mencakup
+      ponsel, dan di sinilah kebanyakan set ikon buatan sendiri berhenti terlalu
+      awal. Tiga lapak lain meminta file mereka sendiri, dengan nama mereka
+      sendiri, dan tidak satu pun akan melihat ke dalam sebuah <code>.ico</code>:
+    </p>
+    <ul>
+      <li>
+        <strong>iOS</strong> membaca <code>apple-touch-icon.png</code> pada
+        180&times;180 ketika seseorang menambahkan situs Anda ke layar utamanya.
+        Tanpa itu, iOS memakai tangkapan layar halamannya, dan itu tampak seperti
+        kekeliruan.
+      </li>
+      <li>
+        <strong>Android dan setiap ajakan pemasangan</strong> membaca sebuah
+        manifes aplikasi web &mdash; <code>site.webmanifest</code> &mdash; yang
+        menunjuk ke PNG 192 dan 512 piksel. Yang 512 juga yang ditampilkan sebuah
+        aplikasi web di layar pembukanya.
+      </li>
+      <li>
+        <strong>Ubin menu mulai Windows</strong> membaca
+        <code>browserconfig.xml</code>, yang menunjuk ke sebuah PNG
+        150&times;150. Yang paling kecil kepentingannya dari ketiganya, dan empat
+        baris XML.
+      </li>
+    </ul>
+    <p>
+      Ada satu lagi yang gampang keliru: peluncur Android memangkas ikon adaptif
+      ke bentuk apa pun yang disukai ponselnya &mdash; lingkaran, persegi
+      membulat, persegi bersudut bulat &mdash; dan hanya bagian tengah 80%
+      gambarnya yang dijamin selamat. Ikon yang digambar dari tepi ke tepi
+      kehilangan sudutnya. Itulah yang dimaksud ikon <em>maskable</em>: gambar
+      yang sama digambar dengan sengaja kecil di dalam perseginya, dinyatakan
+      terpisah di dalam manifesnya.
+    </p>
+    <p>
+      Mencentang set situs web di <a href="../../buat-favicon/">Gambar ke ICO</a>
+      menghasilkan semua itu, manifesnya, dan blok HTML yang menunjuk ke mereka.
+      Satu hal yang sengaja ditinggalkan blok itu adalah sebuah
+      <code>&lt;link&gt;</code> untuk <code>favicon.ico</code>: peramban meminta
+      alamat itu dengan sendirinya, dan menyebutnya juga membuat file yang sama
+      diambil dua kali.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ikon aplikasi Windows adalah set yang berbeda</h2>
+    <p>
+      Kalau ikonnya untuk sebuah program alih-alih sebuah situs, ukurannya
+      berubah. Yang dimuat <code>app.ico</code> bawaan milik Visual Studio sendiri
+      adalah 16, 32, 48, dan 256 &mdash; ketiga ukuran shell-nya ditambah yang
+      besar yang menjadi sumber gambar menu mulai dan tampilan sangat besar
+      Explorer.
+    </p>
+    <p>
+      Di layar berkepadatan tinggi, Windows juga meminta 20, 24, 40, 64, dan 96,
+      lalu mengambil sampel ulang dari ukuran terdekat yang dimilikinya ketika
+      mereka tidak ada. Apakah itu penting tergantung ikon Anda: bentuk yang datar
+      selamat dari pengambilan sampel ulangnya, yang rinci tidak. Menambahkannya
+      kira-kira menggandakan file-nya, dan untuk sebuah aplikasi itu sama sekali
+      bukan apa-apa &mdash; hitungannya sama sekali berbeda dari sebuah favicon,
+      yang diambil setiap pengunjung.
+    </p>
+    <p>
+      Satu hal lagi soal ukuran: entri 256-nya adalah tempat byte-nya berada.
+      Disimpan tanpa kompresi ia 264&nbsp;KB sendirian; disimpan sebagai PNG di
+      dalam ikonnya ia biasanya di bawah 30. Entri PNG sudah bisa dibaca sejak
+      Windows Vista, jadi satu-satunya alasan menghindarinya adalah perangkat
+      lunak yang memang sungguh lebih tua daripada itu, atau sebuah pemasang atau
+      alat tersemat yang membaca ikonnya sendiri.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sebuah Mac membaca file yang sama sekali berbeda</h2>
+    <p>
+      Kalau ikonnya untuk aplikasi Mac alih-alih aplikasi Windows, tidak satu pun
+      di atas berlaku: macOS sama sekali tidak membaca <code>.ico</code>. Ia
+      membaca <code>.icns</code>, yang gagasannya sama dalam bungkus yang berbeda
+      &mdash; beberapa ukuran dalam satu wadah &mdash; dengan tiga perbedaan yang
+      layak diketahui.
+    </p>
+    <ul>
+      <li>
+        <strong>Ukurannya tetap.</strong> Apple menerbitkan sepuluh slot dan
+        tidak ada yang perlu dipilih: 16, 32, 64, 128, 256, 512, dan 1024 piksel,
+        dengan 32, 256, dan 512 muncul dua kali karena masing-masing sekaligus
+        ukuran tersendiri dan versi Retina dari ukuran di bawahnya.
+      </li>
+      <li>
+        <strong>Ia naik sampai 1024.</strong> Sebuah <code>.ico</code> berhenti di
+        256, dan itulah sebabnya file ikon Mac berukuran beberapa ratus kilobita
+        dan sebuah favicon lima belas. Untuk aplikasi yang dikirimkan sekali itu
+        bukan apa-apa; hanya faviconlah yang diambil setiap pengunjung.
+      </li>
+      <li>
+        <strong>1024 piksel adalah yang harus dilalui karya seni Anda.</strong>
+        Kedua masalahnya adalah dua ujung berlawanan dari gambar yang sama:
+        sebuah favicon harus berhasil ketika ia mungil, dan ikon Mac harus
+        bertahan ketika ia raksasa. Logo yang diekspor pada 512 lalu ditiup
+        menjadi 1024 tampak lembek di layar Retina, dan App Store tidak akan
+        menerimanya.
+      </li>
+    </ul>
+    <p>
+      Untuk memakainya: sebuah paket aplikasi menyimpannya di
+      <code>YourApp.app/Contents/Resources/</code> lalu menamainya di
+      <code>Info.plist</code>. Untuk sebuah folder atau image disk, pilih
+      <code>.icns</code>-nya di Finder, tekan Command-C, lalu buka Get Info pada
+      benda yang ingin Anda ubah, klik ikon kecil di kiri atas, dan tekan
+      Command-V.
+    </p>
+    <p>
+      Mencentang <em>ikon macOS</em> di
+      <a href="../../buat-favicon/">Gambar ke ICO</a> menulis satu, dengan atau
+      tanpa file Windows di sebelahnya. Apa pun yang dirilis di kedua lapak
+      menginginkan keduanya, dan keduanya digambar dari gambar yang sama dalam
+      satu jalan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memeriksa bahwa ia berhasil</h2>
+    <p>
+      Peramban menyinggahkan favicon lebih keras daripada hampir apa pun lain,
+      jadi &ldquo;saya sudah mengunggahnya dan tidak ada yang berubah&rdquo;
+      biasanya sebuah singgahan alih-alih sebuah kekeliruan. Dua hal untuk dicoba
+      sebelum Anda mulai menyunting file lagi:
+    </p>
+    <ul>
+      <li>
+        Buka <code>https://situsanda.com/favicon.ico</code> langsung. Kalau
+        file-nya terunduh, ia ada di sana dan Anda sedang melihat sebuah
+        singgahan. Kalau Anda mendapat 404, ia tidak di akarnya.
+      </li>
+      <li>
+        Muat situsnya di jendela pribadi, yang biasanya punya singgahan ikonnya
+        sendiri.
+      </li>
+    </ul>
+    <p>
+      Di Windows, sebuah <code>.ico</code> bisa diperiksa dengan menaruhnya di
+      sebuah folder lalu mengganti-ganti ukuran tampilan Explorer: kecil, sedang,
+      besar, dan sangat besar menggambar entri yang berbeda dari file yang sama,
+      jadi Anda bisa melihat masing-masing sebagaimana sistemnya akan
+      melihatnya.
+    </p>
+    <p>
+      Di sebuah Mac, sebuah <code>.icns</code> terbuka di Preview, yang mendaftar
+      setiap slotnya di sisinya &mdash; dan trik yang sama bekerja di Finder:
+      jatuhkan di sebuah folder lalu seret penggeser ukuran di opsi tampilannya
+      untuk memperhatikannya bertukar-tukar di antara gambar di dalamnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Menskalakan sebuah gambar adalah sesuatu yang sudah dilakukan setiap
+      peramban bertahun-tahun, dan sebuah <code>.ico</code> adalah header enam
+      byte, enam belas byte per gambar, lalu gambarnya. Tidak ada langkah dalam
+      membuatnya yang menuntut sebuah server, dan alat di sini tidak memakai
+      satu: <code>Content-Security-Policy</code> halamannya menyebut satu per
+      satu setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+      ini.
+    </p>
+    <p>
+      Itu layak dipedulikan di sini lebih daripada biasanya. Logo yang diserahkan
+      ke pembuat favicon gratis cukup sering adalah merek yang belum dirilis
+      &mdash; ikonnya salah satu hal pertama yang dibuat dan salah satu hal
+      terakhir yang diumumkan. Muat halamannya, cabut koneksi internet, lalu buat
+      satu kalau Anda lebih suka memeriksa daripada diberi tahu.
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain yang bisa Anda
+      jalankan pada alat mana pun.
+    </p>
+  </section>

--- a/locales/id/pages/guides/make-a-favicon.toml
+++ b/locales/id/pages/guides/make-a-favicon.toml
@@ -1,0 +1,25 @@
+#
+# Panduan: membuat favicon - Bahasa Indonesia.
+#
+# Nama file (favicon.ico, apple-touch-icon.png, site.webmanifest,
+# browserconfig.xml, app.ico, Info.plist) tetap seperti adanya: itulah nama
+# yang harus diketik pembacanya, huruf demi huruf.
+#
+
+nav = "Membuat favicon"
+title = "Cara Membuat Favicon (dan Ikon Aplikasi Windows)"
+description = "Ukuran apa saja yang sebenarnya dibutuhkan sebuah favicon.ico, file tambahan apa yang diminta iPhone, Android, dan sebuah Mac, dan kenapa logo yang berhasil di sebuah poster lenyap pada enam belas piksel."
+
+heading = "Cara membuat favicon yang tetap terbaca pada enam belas piksel"
+lede = """
+    Favicon bukan gambar kecil dari logo Anda. Ia sekumpulan gambar pada ukuran
+    tetap, di dalam sebuah wadah yang tidak pernah dibuka kebanyakan orang, dan
+    yang terkecil di antaranya adalah yang sebenarnya dilihat semua orang. Inilah
+    ukuran mana yang Anda butuhkan, file apa yang mendampinginya, dan apa yang
+    dilakukan ketika logo Anda tidak selamat dalam perjalanannya ke bawah."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Membuat favicon yang tetap terbaca pada enam belas piksel"
+og_description = "Ukuran apa saja yang dibutuhkan sebuah favicon.ico, file tambahan yang diminta iPhone dan Android, dan apa yang dilakukan ketika logo Anda tidak selamat dari pengecilan."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/make-a-gif-from-images.html
+++ b/locales/id/pages/guides/make-a-gif-from-images.html
@@ -1,0 +1,237 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../buat-gif/">Pembuat GIF</a>, jatuhkan gambarnya, susun
+      dalam urutan seharusnya mereka diputar, setel berapa lama setiap bingkai
+      ditahan, lalu buat GIF-nya. Ia diputar di halamannya sebelum Anda
+      menyimpannya.
+    </p>
+    <p>
+      Semua di bawah ini adalah tentang dua hal yang keliru sesudahnya: file-nya
+      jauh lebih besar daripada dugaan, atau animasinya diputar lebih lambat
+      daripada yang dikatakan angkanya. Keduanya punya sebab tertentu dan tidak
+      satu pun kesalahan alatnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa sebuah GIF jauh lebih besar daripada dugaan Anda</h2>
+    <p>
+      GIF 20 bingkai pada 640 piksel rutin berukuran 8 sampai 15 MB. Animasi yang
+      sama sebagai MP4 adalah beberapa ratus kilobita. Itu bukan GIF yang dibuat
+      dengan buruk; memang begitulah formatnya.
+    </p>
+    <p>
+      Setiap format gambar bergerak lain yang pernah Anda pakai menyimpan
+      <em>selisih</em>. Kodek video menulis satu bingkai penuh lalu, untuk
+      bingkai sesudahnya, hanya apa yang bergerak dan ke mana ia bergerak &mdash;
+      dan itulah sebabnya video orang yang berbicara di depan latar diam nyaris
+      tidak berbiaya per bingkainya. Sebuah GIF tidak bisa melakukan itu. Setiap
+      bingkai disimpan sebagai piksel utuh, dilewatkan melalui kompresor tanpa
+      kehilangan, dan itulah seluruh perkakasnya.
+    </p>
+    <p>
+      Juga tidak ada setelan kualitas, karena tidak ada langkah merugikan yang
+      bisa dikecilkan. JPEG pada kualitas 60% adalah pilihan sungguhan dengan
+      penggeser sungguhan di belakangnya; GIF tidak punya padanannya. Jadi
+      ukurannya kira-kira <strong>luas &times; jumlah bingkai</strong>, dan
+      satu-satunya cara menggerakkannya adalah menggerakkan salah satu dari kedua
+      angka itu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tiga hal yang benar-benar membuatnya lebih kecil</h2>
+    <p>
+      Dalam urutan seberapa besar bantuannya:
+    </p>
+    <p>
+      <strong>1. Kecilkan.</strong> Ini bukan salah satu dari beberapa pilihan,
+      ini pilihannya. Ukuran adalah luas, jadi menyetengahkan sisi panjangnya
+      menyeperempatkan file-nya: 640&nbsp;px turun ke 320&nbsp;px mengubah
+      12&nbsp;MB menjadi sekitar 3&nbsp;MB. GIF di sebuah halaman web atau di
+      jendela obrolan toh dilihat pada beberapa ratus piksel. 480&nbsp;px adalah
+      bawaan di alatnya persis karena alasan ini, dan 320&nbsp;px adalah jawaban
+      yang sangat terhormat.
+    </p>
+    <p>
+      <strong>2. Pakai lebih sedikit bingkai.</strong> Sepuluh bingkai yang
+      ditahan seperlima detik masing-masing adalah animasi dua detik yang sama
+      dengan dua puluh bingkai pada sepersepuluh, dan separuh file-nya.
+      Kehalusan berbiaya byte secara sebanding, jadi belanjakan ia hanya di tempat
+      gerakannya membutuhkannya.
+    </p>
+    <p>
+      <strong>3. Matikan dithering, dan turunkan jumlah warnanya.</strong> Yang
+      ini berlawanan dengan naluri. Dithering menaburkan pola halus berisi piksel
+      berselang-seling untuk memalsukan warna yang tidak dimiliki paletnya, dan
+      pola itu adalah <em>derau</em> &mdash; dan justru itulah yang tidak bisa
+      dikompres sebuah kompresor tanpa kehilangan. Pada karya seni datar,
+      tangkapan layar, dan gambar garis, mematikannya bisa memangkas sepertiga
+      file-nya dan tampak lebih baik pula. Pada foto, ia menukar pita warna yang
+      terlihat dengan penghematannya, jadi coba keduanya lalu lihat.
+    </p>
+    <p>
+      Menurunkan dari 256 ke 64 warna juga membantu, meski kurang dari harapan
+      orang: ia memendekkan kata kodenya alih-alih membuang piksel mana pun.
+    </p>
+    <p>
+      Kalau tidak satu pun dari itu membuatnya cukup kecil, jawaban yang jujur
+      adalah bahwa yang Anda buat itu sebuah video.
+      <a href="../gambar-ke-video/">Mengubah gambar yang sama menjadi sebuah
+      MP4</a> mungkin sepersepuluh ukurannya, dan setiap tempat yang menerima
+      sebuah GIF untuk apa pun selain sebuah tag <code>&lt;img&gt;</code>
+      &mdash; termasuk setiap jejaring sosial &mdash; toh mengubahnya menjadi
+      video saat diunggah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Seberapa cepat sebuah GIF sebenarnya bisa diputar</h2>
+    <p>
+      Formatnya menyimpan jeda setiap bingkai dalam perseratus detik, yang
+      seolah-olah berarti Anda bisa meminta 0,01d lalu mendapat seratus bingkai
+      sedetik. Anda tidak bisa.
+    </p>
+    <p>
+      Setiap peramban menjepit jeda di bawah dua perseratus detik naik ke
+      sepersepuluh detik. Aturannya berasal dari 1990-an, ketika halaman penuh
+      animasi yang disetel berputar secepat mungkin dan mesin masa itu tidak
+      sanggup bertahan, dan ia hidup lebih lama daripada setiap alasan
+      pengenalannya. Ia tidak pernah dicabut, dan ia berlaku untuk GIF Anda hari
+      ini.
+    </p>
+    <p>
+      Jadi rentang praktisnya adalah:
+    </p>
+    <ul>
+      <li><strong>0,02d</strong> (50 bingkai sedetik) &mdash; secepat yang boleh
+      dicapai sebuah GIF, dan lebih cepat daripada yang biasanya
+      dibutuhkannya.</li>
+      <li><strong>0,05d</strong> (20 bingkai sedetik) &mdash; animasi yang halus,
+      dan tempat memulai kalau Anda menganimasikan gerakan.</li>
+      <li><strong>0,1d</strong> (10 bingkai sedetik) &mdash; rupa GIF yang
+      klasik. Separuh bingkainya, separuh file-nya, dan ia terbaca sebagai
+      disengaja.</li>
+      <li><strong>0,5d ke atas</strong> &mdash; sebuah tayangan slide. Setiap
+      gambar sedang dipandangi alih-alih dianimasikan.</li>
+    </ul>
+    <p>
+      Apa pun di bawah 0,02d tidak ditawarkan, karena itu angka yang akan
+      diam-diam menjadi 0,1d di setiap peramban yang ada.
+    </p>
+  </section>
+
+  <section>
+    <h2>Paletnya, dan apa yang sebenarnya dipilihnya</h2>
+    <p>
+      Sebuah bingkai GIF menyimpan paling banyak 256 warna. Sebuah foto punya
+      puluhan ribu. Sesuatu harus memilih 256 di antaranya, dan pilihan itulah
+      rupa keluarannya &mdash; lebih daripada setelan mana pun lainnya.
+    </p>
+    <p>
+      Alatnya menawarkan dua cara membuatnya:
+    </p>
+    <p>
+      <strong>Warna terbaik untuk setiap bingkai</strong> memberi setiap gambar
+      256 miliknya sendiri. Ia tampak paling tajam, dan ia benar untuk sekumpulan
+      foto yang tidak berhubungan, tempat masing-masing toh menginginkan
+      sekumpulan warna yang sama sekali berbeda.
+    </p>
+    <p>
+      <strong>Satu palet untuk seluruh GIF-nya</strong> membangun satu tabel dari
+      setiap bingkainya sekaligus. Pakai itu ketika bingkainya sebuah
+      <em>runtutan</em> &mdash; adegan yang sama, berselang beberapa momen.
+      Dengan palet per bingkai, perubahan apa pun pada gambarnya mengubah 256
+      warna mana yang terpilih, dan seluruh latarnya bergeser warna sedikit di
+      setiap bingkai. Kerlipan itulah yang membuat GIF buatan sendiri tampak
+      buatan sendiri. Palet bersama menghilangkannya, dan sekaligus menghasilkan
+      file yang lebih kecil, karena tabelnya ditulis sekali alih-alih di setiap
+      bingkai.
+    </p>
+    <p>
+      Lebih sedikit warna &mdash; 128, 64, 32 &mdash; layak dicoba pada apa pun
+      yang datar. Animasi logo dengan delapan warna di dalamnya tidak kehilangan
+      apa pun pada 32, dan Anda bisa langsung melihat bedanya pada sebuah foto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparansi itu satu bit, dan itulah seluruh ceritanya</h2>
+    <p>
+      Sebuah piksel GIF entah terlukis penuh entah sama sekali tak terlihat.
+      Tidak ada apa pun di antaranya: tidak ada bayangan 50%, tidak ada tepi
+      lembut, tidak ada lesapan.
+    </p>
+    <p>
+      Jadi kalau gambar sumber Anda punya transparansi, menyalakannya menjaga
+      area transparannya tetap transparan &mdash; tapi setiap tepi yang
+      dihaluskan, yang berupa gradien dari bentuknya menuju ketiadaan, dipotong
+      di titik tengahnya menjadi tepi yang keras dan tampak bergerigi. Bentuk
+      bulat dan teks paling menderita.
+    </p>
+    <p>
+      Kalau Anda tahu di atas warna apa GIF-nya akan duduk, meratakannya ke warna
+      itu akan tampak lebih baik setiap kali. Simpan transparansinya hanya ketika
+      latar tempatnya mendarat memang sungguh tidak diketahui &mdash; dan kalau
+      jawabannya "ia butuh tepi lembut di atas latar apa pun", format untuk itu
+      adalah PNG atau WebP animasi, bukan GIF.
+    </p>
+  </section>
+
+  <section>
+    <h2>Urutan, pewaktuan, dan membuat lupnya duduk pas</h2>
+    <p>
+      Beberapa hal yang lebih cepat diketahui daripada ditemukan sendiri:
+    </p>
+    <p>
+      <strong>Urutkan menurut nama dengan hitungan yang benar.</strong> Runtutan
+      render atau ekspor terurut sesuai maksud Anda, jadi <code>bingkai_2</code>
+      mendarat sebelum <code>bingkai_10</code> alih-alih sesudahnya. Mengurutkan
+      menurut tanggal mengembalikan galeri kamera ke urutan pengambilannya, dan
+      itulah yang Anda mau ketika nama file-nya sudah mulai ulang dari 0001.
+    </p>
+    <p>
+      <strong>Beri bingkai terakhir waktu lebih lama.</strong> Lup yang setiap
+      bingkainya sama panjang terbaca seperti tanpa jeda. Menahan bingkai
+      terakhirnya sekitar setengah detik memberi mata tempat beristirahat dan
+      membuat keseluruhannya tampak disengaja. Setiap bingkai punya waktu tahan
+      sendiri untuk ini.
+    </p>
+    <p>
+      <strong>Sebuah lup seharusnya tidak melompat.</strong> Bingkai terakhir
+      langsung disusul yang pertama, jadi kalau keduanya sangat berbeda, lupnya
+      terasa menyentak. Buat keduanya mirip, atau justru manfaatkan potongannya
+      dengan menahan bingkai terakhirnya.
+    </p>
+    <p>
+      <strong>Putar sekali berarti putar sekali.</strong> Sebagian alat menulis
+      hitungan lup satu, dan dekoder tidak pernah sepenuhnya sepakat soal itu
+      &mdash; beberapa memutarnya dua kali. Memilih "Putar sekali" di sini sama
+      sekali tidak menulis informasi lup, dan setiap dekoder yang pernah dibangun
+      memperlakukannya dengan cara yang sama.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh server</h2>
+    <p>
+      Membuat sebuah GIF adalah dua pekerjaan yang tidak ditawarkan peramban:
+      memilih paletnya, dan mengompres pikselnya dengan LZW. Tidak satu pun besar.
+      Keduanya mungkin empat ratus baris bersama-sama, keduanya tertulis di
+      repositori, dan keduanya berjalan di mesin Anda sendiri seperti semua yang
+      lain di sini &mdash; dan itulah sebabnya halamannya terus bekerja dengan
+      jaringan tercabut.
+    </p>
+    <p>
+      Alasan begitu banyak pembuat GIF mengunggah bukanlah bahwa pekerjaannya
+      sulit. Melainkan bahwa server adalah tempat iklan dan akunnya berada. Tidak
+      ada apa pun tentang mengubah sekumpulan foto menjadi sebuah animasi yang
+      menuntut foto Anda meninggalkan ruangan tempatnya berada.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan empat pemeriksaan yang akan memberi tahu
+      Anda hal yang sama tentang alat mana pun, termasuk yang ini.
+    </p>
+  </section>

--- a/locales/id/pages/guides/make-a-gif-from-images.toml
+++ b/locales/id/pages/guides/make-a-gif-from-images.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: membuat GIF dari gambar - Bahasa Indonesia.
+#
+
+nav = "Gambar menjadi GIF"
+title = "Cara Membuat GIF Animasi dari Gambar"
+description = "Ubah sekumpulan gambar menjadi satu GIF animasi: seberapa cepat sebuah GIF sebenarnya bisa diputar, apa yang diubah setelan paletnya, dan tiga hal yang benar-benar membuat file-nya lebih kecil."
+
+heading = "Cara membuat GIF animasi dari gambar"
+lede = """
+    Membuat GIF-nya adalah bagian yang mudah. Mendapatkan satu yang cukup kecil
+    untuk benar-benar diunggah adalah bagian yang layak dibaca, karena sebuah GIF
+    tidak punya penggeser kualitas dan hanya tiga hal yang sama sekali
+    menggerakkan ukurannya."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara membuat GIF animasi dari gambar"
+og_description = "Seberapa cepat sebuah GIF sebenarnya bisa diputar, apa yang diubah setelan paletnya, dan tiga hal yang benar-benar membuat file-nya lebih kecil."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/make-a-passport-photo.html
+++ b/locales/id/pages/guides/make-a-passport-photo.html
@@ -1,0 +1,252 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Berdirilah satu setengah meter dari dinding polos yang tercahayai rata
+      &mdash; bukan menempel padanya. Minta orang lain memegang ponselnya
+      setinggi mata Anda lalu memotret. Jangan pakai kamera depan sepanjang
+      lengan. Lalu buka
+      <a href="../../pas-foto-biometrik/">Pembuat Pas Foto</a> dan pilih negara
+      serta dokumen Anda. Ia menaruh empat titik di puncak kepala, dagu, dan
+      masing-masing pupil Anda dengan mengukur gambarnya, lalu memberi tahu mana
+      dari keempatnya yang tidak bisa diukurnya; seret yang mendarat keliru, lalu
+      tekan <em>Paskan kotaknya</em>.
+    </p>
+    <p>
+      Semua di bawah ini adalah kenapa setiap kalimat itu ada di sana, dan apa
+      yang dilakukan ketika angkanya tetap keluar keliru.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang sebenarnya diukur</h2>
+    <p>
+      Setiap standar pas foto paspor di dunia adalah variasi dari satu dokumen:
+      ICAO Doc 9303, yang menjadikan sebuah paspor bisa dibaca mesin di
+      perbatasan. Ia mengekang dua hal tentang gambarnya, dan keduanya bukan dua
+      hal yang diduga orang.
+    </p>
+    <ul>
+      <li>
+        <strong>Seberapa banyak bingkai yang diisi kepala Anda</strong>, diukur
+        dari bawah dagu sampai puncak kepala &mdash; puncak
+        <em>rambut</em> Anda, bukan garis rambut Anda. Biasanya 70 sampai 80
+        persen tinggi fotonya.
+      </li>
+      <li>
+        <strong>Di mana mata Anda duduk</strong>, diukur naik dari tepi bawahnya.
+        Biasanya antara setengah dan tiga perlima tingginya.
+      </li>
+    </ul>
+    <p>
+      Ukuran cetaknya &mdash; 35 &times; 45 mm di sebagian besar dunia, 2
+      &times; 2 inci di Amerika Serikat dan India, 50 &times; 70 mm di Kanada
+      &mdash; adalah bagian yang mudah, dan itulah bagian yang dibenarkan
+      kebanyakan alat lalu berhenti di situ. Membenarkan bentuknya dan
+      mengelirukan tinggi kepalanya menghasilkan foto yang tampak sangat
+      baik-baik saja dan ditolak.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tinggi kepala adalah yang dikelirukan semua orang</h2>
+    <p>
+      Ada dua alasan, dan keduanya tarik-menarik ke arah berlawanan.
+    </p>
+    <p>
+      <strong>Masalah swafoto.</strong> Lengan panjangnya sekitar enam puluh
+      sentimeter. Lensa sedekat itu sekaligus membuat wajahnya melenceng &mdash;
+      hidungnya membesar, telinganya mengecil &mdash; dan mengisi bingkainya
+      dengan kepala, sehingga pangkasan yang memuat seluruh kepala Anda nyaris
+      tidak punya ruang di sekelilingnya. Sebagian negara akan menolak
+      pelencengannya saja. Meminta orang lain memegang ponselnya satu setengah
+      meter jauhnya, lalu memangkas masuk sesudahnya, membereskan keduanya
+      sekaligus.
+    </p>
+    <p>
+      <strong>Masalah garis rambut.</strong> &ldquo;Puncak kepala&rdquo; berarti
+      bagian paling atas kepala Anda dengan rambut apa adanya. Orang memindahkan
+      titik itu turun ke garis rambut mereka, yang membuat kepala terukurnya
+      lebih pendek daripada kepala aslinya, yang membuat setiap pangkasan keluar
+      dengan kepala yang terlalu kecil. Kalau rambut Anda tinggi atau mengembang,
+      puncak kepalanya adalah bagian paling atasnya.
+    </p>
+    <p>
+      Dan kedua rentangnya tidak sama di mana-mana, dan itulah bagian yang
+      menjebak orang yang pernah melakukan ini sebelumnya. Britania Raya meminta
+      29 sampai 34 mm dari bingkai 45 mm. Jerman dan visa Schengen meminta 32
+      sampai 36 mm dari bingkai yang sama. Foto yang dipangkas menurut aturan
+      Jerman berada tepat di puncak aturan Britania atau melewatinya, dan foto
+      yang lolos untuk visa Schengen bisa kembali dari Durham.
+    </p>
+  </section>
+
+  <section>
+    <h2>Latar itulah yang sebenarnya membuat foto ditolak</h2>
+    <p>
+      Hampir tidak ada yang mengajukan foto yang ada rak bukunya. Sangat banyak
+      orang mengajukan foto yang diambil sejengkal dari dinding putih, dengan
+      bayangan abu-abu lembut kepalanya sendiri di sana. &ldquo;Latar putih
+      polos&rdquo; bukan pernyataan tentang cat. Ia pernyataan tentang bayangan.
+    </p>
+    <p>
+      Tiga hal membereskan hampir semuanya:
+    </p>
+    <ul>
+      <li>
+        <strong>Berdirilah menjauh dari dindingnya.</strong> Satu meter sudah
+        lebih dari cukup. Bayangan butuh tempat mendarat, dan pada satu meter ia
+        mendarat di lantai di belakang Anda alih-alih di gambarnya.
+      </li>
+      <li>
+        <strong>Hadapkan diri ke cahayanya.</strong> Jendela di depan Anda, bukan
+        di belakang Anda dan bukan di salah satu sisi. Cahaya samping membuat
+        separuh latarnya lebih gelap daripada separuh lainnya, dan itu kegagalan
+        yang terpisah dari warnanya yang keliru dan punya solusi yang berbeda.
+      </li>
+      <li>
+        <strong>Jangan pakai lampu kilat.</strong> Ia menghasilkan titik panas di
+        belakang kepala Anda dan bayangan keras di sekelilingnya, dan justru
+        itulah hal yang sedang diperiksa.
+      </li>
+    </ul>
+    <p>
+      Perhatikan bahwa abu-abu muda adalah pilihan ICAO alih-alih putih. Ia
+      memisahkan wajah yang cerah dari latarnya dan rambut gelap dari latarnya
+      juga, dan putih murni tidak melakukan keduanya. Beberapa negara berkata
+      &ldquo;putih atau putih gading&rdquo; dan maksudnya &ldquo;polos dan
+      rata&rdquo;.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hal-hal yang dilihat pemeriksa manusia</h2>
+    <p>
+      Tidak ada alat yang bisa mengukur ini, jadi mereka layak satu paragraf
+      sendiri. Mereka juga, bersama-sama, alasan paling umum kedua sebuah foto
+      dikembalikan.
+    </p>
+    <ul>
+      <li><strong>Ekspresi netral, mulut tertutup.</strong> Senyum tipis ditolak
+        lebih banyak negara daripada yang mengizinkannya.</li>
+      <li><strong>Kedua mata terbuka dan terlihat jelas</strong>, tanpa apa pun
+        melintasinya &mdash; tanpa rambut, tanpa bingkai tebal, tanpa silau.
+        Beberapa negara tidak lagi mengizinkan kacamata sama sekali.</li>
+      <li><strong>Menatap lurus ke kamera</strong>, kepala datar dan tegak lurus.
+        Kepala yang miring lebih dari beberapa derajat disadari seorang pemeriksa
+        dan hampir tidak disadari siapa pun yang melihat fotonya sendiri.</li>
+      <li><strong>Tidak ada yang menutupi wajahnya.</strong> Penutup kepala yang
+        dikenakan karena alasan keagamaan diizinkan hampir di mana-mana, asalkan
+        wajahnya dari bawah dagu sampai puncak dahi bersih.</li>
+      <li><strong>Pakaian polos, bukan putih.</strong> Putih di atas latar putih
+        membuat Anda tampak seperti kepala yang melayang, dan sebagian kantor
+        menolaknya karena alasan itu.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Ukuran cetak, DPI, dan kenapa sebuah file bisa tercetak pada ukuran yang salah</h2>
+    <p>
+      Gambar digital tidak punya ukuran fisik sampai ada yang memutuskan berapa
+      banyak pikselnya yang masuk ke satu inci. Angka itu tinggal di file-nya
+      &mdash; dan ketika sebuah peramban web menulis sebuah JPEG, ia menulis
+      kolom itu sebagai &ldquo;ini rasio aspek, bukan resolusi&rdquo;. Jadi
+      file-nya tidak mengatakan apa-apa tentang seberapa besar dirinya, dan apa
+      pun yang mencetaknya akan menebak.
+    </p>
+    <p>
+      Itulah sebabnya foto yang jumlah pikselnya sudah tepat tetap bisa keluar
+      dari percetakan dengan ukuran yang salah. 413 &times; 531 piksel
+      <em>adalah</em> 35 &times; 45 mm, tapi hanya pada 300 dpi, dan hanya kalau
+      file-nya mengatakan begitu. Alat mana pun yang layak dipakai menuliskannya;
+      Pembuat Pas Foto menulis ulang beberapa byte itu langsung, tanpa
+      mendekodekan gambarnya.
+    </p>
+    <p>
+      300 dpi adalah lantai yang dinyatakan hampir setiap spesifikasi. 600 adalah
+      yang akan dipakai lab foto yang bagus, dan tidak berbiaya apa pun selain
+      ukuran file.
+    </p>
+  </section>
+
+  <section>
+    <h2>Aturan ukuran file yang punya lantai</h2>
+    <p>
+      Formulir daring lebih ketat daripada formulir kertas dengan cara yang
+      mengejutkan orang: beberapa di antaranya menegakkan ukuran file
+      <em>minimum</em> sekaligus maksimum.
+    </p>
+    <ul>
+      <li>Portal ujian India (SSC, UPSC, dan sisanya): foto tepat pada
+        200 &times; 230 piksel, JPEG, <strong>20 sampai 50 KB</strong>; dan tanda
+        tangan pada 140 &times; 60 piksel, <strong>10 sampai 20 KB</strong>.</li>
+      <li>Unggahan visa Tiongkok: 354 &times; 472 piksel, 40 sampai 120 KB.</li>
+      <li>Unggahan paspor Britania Raya: setidaknya 600 &times; 750 piksel, dan
+        setidaknya 50 KB.</li>
+    </ul>
+    <p>
+      Alasan adanya lantai itu masuk akal &mdash; file di bawahnya biasanya
+      sebuah gambar mini yang diunggah orang karena keliru &mdash; dan akibatnya
+      merepotkan. Foto 200 &times; 230 adalah 46.000 piksel. Pada kualitas
+      terbaik yang bisa ditulis sebuah peramban, ia masih bisa mendarat di 15 KB,
+      dan tidak ada cara membuatnya lebih besar dengan mengompresnya lebih
+      sedikit, karena tidak ada yang lebih sedikit lagi.
+    </p>
+    <p>
+      Solusi yang jujur adalah pengisian: sebuah JPEG bisa membawa segmen
+      komentar, setiap dekoder melewatinya, dan menambahkan satu membuat file-nya
+      lebih panjang tanpa mengubah satu piksel pun gambarnya. Itulah yang
+      dilakukan alatnya, dan ia menulis sebuah kalimat bahasa Inggris ke dalam
+      isiannya yang mengatakan begitu. Waspadalah terhadap apa pun yang mencapai
+      lantainya dengan <em>membesarkan</em> foto Anda sebagai gantinya &mdash;
+      itu kualitas sungguhan yang dibuang demi memenuhi sebuah angka.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mencetaknya sendiri, dengan murah</h2>
+    <p>
+      Studio foto memungut biaya lumayan untuk enam lembar. Gerai cetak foto mana
+      pun akan mencetak sebuah 6 &times; 4 dengan harga receh, dan sebuah
+      6 &times; 4 memuat delapan foto 35 &times; 45 mm dengan ruang untuk
+      guntingnya.
+    </p>
+    <p>
+      Dua hal yang harus dibenarkan ketika Anda mengirim satu:
+    </p>
+    <ul>
+      <li>
+        <strong>Cetak pada 100 persen.</strong> &ldquo;Paskan ke halaman&rdquo;,
+        &ldquo;skalakan agar muat&rdquo;, dan &ldquo;tanpa batas tepi&rdquo;
+        semuanya sedikit mengubah ukuran lembarnya, dan lembar yang ukurannya
+        berubah dua persen adalah delapan foto yang semuanya salah ukuran.
+      </li>
+      <li>
+        <strong>Potong di antara tandanya, bukan sepanjang sebuah garis.</strong>
+        Tanda potong duduk di sela-selanya alih-alih di atas gambarnya, dan itu
+        sekaligus lebih mudah dipotong dengan akurat dan tidak meninggalkan tinta
+        untuk dirapikan sesudahnya.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Kenapa tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Setiap langkah di atas adalah hitungan atas sebuah gambar yang sudah
+      didekodekan mesin Anda sendiri: sebuah persegi panjang pangkasan, sebuah
+      penskalaan, sebuah rata-rata warna, sebuah pengodean JPEG, dan segenggam
+      byte di sebuah header. Tidak ada apa pun di dalamnya yang bisa dilakukan
+      sebuah server dan tidak bisa dilakukan sebuah peramban.
+    </p>
+    <p>
+      Dan itu layak direnungkan sejenak, karena file-nya apa. Pas foto paspor
+      adalah gambar wajah Anda, dan mengunggah satu ke sebuah situs web memberi
+      tahu situs itu wajah Anda, negara yang dokumennya Anda ajukan, dan
+      kira-kira kapan Anda mengajukannya. Alat foto yang menuntut unggahan
+      biasanya menuntut sebuah akun juga, dan gabungannya adalah sebuah basis
+      data berisi persis itu. Tidak ada alasan teknis bagi itu untuk ada. Lihat
+      <a href="../apakah-aman-mengunggah-file/">cara mengetahui apakah sebuah
+      alat sungguh membutuhkan file Anda</a> untuk empat pemeriksaan yang
+      memisahkan yang membutuhkannya dari yang tidak.
+    </p>
+  </section>

--- a/locales/id/pages/guides/make-a-passport-photo.toml
+++ b/locales/id/pages/guides/make-a-passport-photo.toml
@@ -1,0 +1,21 @@
+#
+# Panduan: membuat pas foto - Bahasa Indonesia.
+#
+
+nav = "Membuat pas foto"
+title = "Cara Mengambil Pas Foto Paspor di Rumah (dan Tidak Ditolak)"
+description = "Apa yang sebenarnya diukur pada sebuah pas foto paspor - tinggi kepala, garis mata, latar - negara mana meminta angka yang mana, dan bagaimana memenuhi batas piksel dan KB yang ditegakkan sebuah formulir daring."
+
+heading = "Cara mengambil pas foto paspor yang tidak dikembalikan"
+lede = """
+    Pas foto paspor bukan gambar wajah Anda pada ukuran tertentu. Ia sekumpulan
+    pengukuran, dan yang gagal hampir tidak pernah yang dikhawatirkan orang.
+    Inilah apa yang sebenarnya diukur, negara mana meminta angka yang mana, dan
+    apa yang dilakukan tentang formulir yang menolak sebuah file karena terlalu
+    kecil."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara mengambil pas foto paspor yang tidak dikembalikan"
+og_description = "Tinggi kepala, garis mata, latar, dan ukuran file - apa yang diukur kantor paspor, dan bagaimana memenuhinya dengan sebuah ponsel dan dinding polos."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/make-a-pdf-smaller.html
+++ b/locales/id/pages/guides/make-a-pdf-smaller.html
@@ -1,0 +1,240 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../kompres-pdf/">Kompresor PDF</a>, jatuhkan dokumennya,
+      lalu lihat apa yang dikatakannya kepada Anda sebelum Anda mengubah apa pun.
+      Ia membaca file-nya lalu menunjukkan di mana sebenarnya ukurannya berada
+      &mdash; gambar, fon, teks dan gambar vektor, serta apa pun yang tidak lagi
+      dirujuk apa pun di dokumennya. Satu layar itu biasanya sudah menjawab
+      pertanyaannya.
+    </p>
+    <p>
+      Kalau sebagian besar ukurannya adalah gambar, Anda bisa mengharapkan
+      penghematan besar. Kalau ia fon dan teks, tidak bisa, dan tidak ada alat
+      yang bisa. Anda punya yang mana dari keduanya itulah seluruh ceritanya, dan
+      ia layak sepuluh detik untuk dilihat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Di mana sebenarnya ukuran sebuah PDF berada</h2>
+    <p>
+      Sebuah PDF adalah wadah untuk beberapa jenis benda yang berbeda, dan mereka
+      tidak terkompres dengan cara yang sama.
+    </p>
+    <ul>
+      <li>
+        <strong>Gambar.</strong> Foto dan pindaian. Hampir selalu bagian terbesar
+        dari sebuah PDF yang besar, dan satu-satunya bagian yang punya ruang
+        sungguhan di dalamnya.
+      </li>
+      <li>
+        <strong>Fon yang tersemat.</strong> Sebuah fon utuh bisa ratusan
+        kilobita; sebuah subset karakter yang benar-benar dipakai jauh lebih
+        kecil. Bagaimanapun juga, mereka sudah dikompres oleh apa pun yang
+        menghasilkan file-nya.
+      </li>
+      <li>
+        <strong>Teks dan gambar vektor.</strong> Instruksi alih-alih piksel:
+        gambar garis ini, taruh kata ini di sini. Sudah ringkas, dan sudah
+        terkompres.
+      </li>
+      <li>
+        <strong>Objek yang tidak lagi ditunjuk apa pun.</strong> PDF menumpuk
+        ini. Menyunting sebuah dokumen sering menambahkan perubahannya alih-alih
+        menulis ulang file-nya, jadi versi lama sebuah halaman bisa duduk di sana
+        tanpa batas waktu. Mengemas ulang file-nya membuang mereka.
+      </li>
+    </ul>
+    <p>
+      Jadi dua dokumen yang dibawa orang ke sebuah kompresor PDF punya prospek
+      yang sama sekali berbeda. Dokumen hasil pindaian pada dasarnya setumpuk
+      foto, dan biasanya keluar 60&ndash;90% lebih kecil. Sebuah kontrak, sebuah
+      tesis, atau sebuah laporan hasil ekspor adalah teks, gambar vektor, dan fon
+      &mdash; semuanya sudah dikompres oleh perangkat lunak yang menulisnya
+      &mdash; dan penghematan di sana biasanya beberapa persen, dari pengemasan
+      ulang dan pembuangan yang tidak dirujuk.
+    </p>
+    <p>
+      Alat mana pun yang menjanjikan &ldquo;sampai 90% lebih kecil&rdquo; tanpa
+      melihat file Anda sedang mengutip kasus terbaik dari jenis yang pertama
+      untuk jenis yang kedua.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa hubungan DPI dengan ini</h2>
+    <p>
+      Sebuah PDF tidak sekadar menyimpan sebuah gambar; ia mencatat seberapa
+      besar gambar itu digambar di halamannya. Itu memberi Anda sesuatu yang
+      lebih berguna daripada jumlah piksel: resolusi efektifnya.
+    </p>
+    <p>
+      Pindaian selebar 4000 piksel yang ditaruh melintasi delapan inci kertas
+      membawa 500 piksel per inci. Sebuah layar menampilkan sekitar 100. Pencetak
+      kantor yang bagus bekerja pada 300 dan tidak bisa memakai lebih banyak.
+      Semua di atas itu adalah detail yang tidak akan pernah ditampilkan apa pun
+      di masa depan dokumennya &mdash; dan biasanya itulah sebagian besar
+      file-nya.
+    </p>
+    <p>
+      Itulah sebabnya kompresor PDF yang masuk akal meminta sebuah DPI alih-alih
+      persentase kualitas. Ia membuang piksel di atas angka Anda lebih dulu,
+      karena piksel itu tidak mengorbankan apa pun yang bisa dilihat siapa pun,
+      dan baru sesudah itu mulai membelanjakan kualitas yang sebenarnya.
+    </p>
+    <p>
+      Panduan kasarnya: <strong>150 DPI</strong> untuk dokumen yang akan dibaca
+      di layar, <strong>200&ndash;300</strong> untuk sesuatu yang akan dicetak,
+      <strong>72&ndash;100</strong> untuk draf yang tidak akan disimpan siapa
+      pun. Mengukur terhadap seberapa besar gambarnya digambar juga itulah
+      sebabnya sebuah logo yang ditaruh kecil tidak diperlakukan sama dengan
+      pindaian sehalaman penuh &mdash; logonya sudah mendekati resolusi
+      efektifnya dan tidak ada yang bisa diambil.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang boleh dan tidak boleh disentuh pengompresan</h2>
+    <p>
+      Gambarnya dikodekan ulang, jadi yang itu kehilangan sedikit. Tidak ada yang
+      lain yang boleh disentuh sama sekali, dan layak memeriksa bahwa alat apa
+      pun yang Anda pakai berpegang pada itu:
+    </p>
+    <ul>
+      <li>
+        <strong>Teks tetap teks.</strong> Bisa dipilih, bisa dicari, bisa
+        disalin. Kompresor yang meratakan halamannya menjadi gambar akan
+        menghasilkan file yang sangat kecil dan menghancurkan dokumennya &mdash;
+        Anda tidak bisa mencarinya, pembaca layar tidak bisa membacanya, dan itu
+        tidak akan pernah bisa diurungkan.
+      </li>
+      <li>
+        <strong>Fon tetap utuh.</strong> Mengganti fon mengubah rupa dokumennya
+        di mesin orang lain, dan itu satu hal yang justru menjadi alasan
+        keberadaan PDF.
+      </li>
+      <li>
+        <strong>Gambar vektor disalin persis.</strong> Ia sudah kecil, dan
+        mengubahnya menjadi piksel akan membuatnya sekaligus lebih besar dan
+        lebih buruk.
+      </li>
+      <li>
+        <strong>Formulir, tautan, markah, struktur aksesibilitas, dan lampiran
+        ikut terbawa.</strong> Semua itu gampang hilang dalam sebuah penulisan
+        ulang dan jarang disadari sampai ada yang membutuhkan salah satunya.
+      </li>
+    </ul>
+    <p>
+      Sebuah aturan terkait yang harus diikuti sebuah kompresor dan yang tidak
+      diikuti banyak kompresor: kalau mengodekan ulang sebuah gambar ternyata
+      tidak keluar lebih kecil daripada aslinya, kembalikan byte aslinya.
+      Membuat sebuah gambar lebih buruk tanpa penghematan adalah kasus rugi
+      murni, dan itu terjadi lebih sering daripada dugaan Anda pada gambar yang
+      memang sudah terkompres dengan baik.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gambar yang tidak bisa dikompres</h2>
+    <p>
+      Sebagian gambar di dalam sebuah PDF dilewati, dan alat yang baik
+      menyebutkannya alih-alih diam-diam meninggalkannya dari hitungannya:
+    </p>
+    <ul>
+      <li>
+        <strong>Gambar JPEG&nbsp;2000, JBIG2, dan berkode faks (CCITT).</strong>
+        Tidak ada peramban yang mengirimkan dekoder untuk satu pun dari mereka,
+        jadi mereka dilewatkan tanpa disentuh. Dua yang terakhir bertingkat dua
+        &mdash; hitam dan putih saja &mdash; dan biasanya sudah mendekati ukuran
+        terkecilnya.
+      </li>
+      <li>
+        <strong>Gambar CMYK.</strong> Dibiarkan dengan sengaja. Mengodekannya
+        ulang berisiko menggeser warna yang akan dihasilkan sebuah pencetak, dan
+        itu hal yang mengejutkan untuk dilakukan pada dokumen yang akan dicetak
+        seseorang.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Hal yang perlu dicoba sebelum mengompres</h2>
+    <p>
+      Kadang file-nya besar karena alasan yang jawabannya bukan pengompresan.
+    </p>
+    <p>
+      <strong>Apakah ia dipindai padahal tidak perlu?</strong> Dokumen yang
+      dicetak lalu dipindai adalah setumpuk foto teks. Kalau aslinya masih ada di
+      suatu tempat sebagai sebuah dokumen, mengekspornya ke PDF akan menghasilkan
+      file sepersekian ukurannya yang juga bisa dicari.
+    </p>
+    <p>
+      <strong>Apakah ia diekspor pada setelan cetak?</strong> Pengolah kata dan
+      perangkat lunak desain sering memakai ekspor kualitas cetak sebagai
+      bawaannya. Mengekspor ulang untuk layar dari file sumbernya biasanya
+      mengalahkan mengompres hasil ekspornya.
+    </p>
+    <p>
+      <strong>Apakah ia harus satu file?</strong> Batas email berlaku per pesan.
+      Memisah dokumen 200 halaman menjadi bab-bab kadang solusi yang jujur.
+    </p>
+  </section>
+
+  <section>
+    <h2>File terenkripsi, dan kenapa sebuah kompresor harus menolaknya</h2>
+    <p>
+      PDF yang dilindungi kata sandi ditolak alat di sini, dan itu disengaja
+      alih-alih fitur yang hilang &mdash; termasuk ketika kata sandinya kosong,
+      dan begitulah banyak pemindai dan mesin fotokopi menyimpan.
+    </p>
+    <p>
+      Melepas perlindungan sebuah dokumen adalah pekerjaan yang berbeda dari
+      mengompresnya. Alat yang melakukannya diam-diam akan melakukan sesuatu yang
+      tidak Anda minta, pada file yang sengaja dikunci seseorang, dan
+      menyerahkan kembali kepada Anda salinan yang tidak lagi punya sifat yang
+      mereka niatkan. Lepas perlindungannya sendiri lebih dulu, dengan sengaja,
+      kalau memang itu yang Anda mau.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memeriksa hasilnya</h2>
+    <p>
+      Buka. Lihat gambarnya pada perbesaran penuh, periksa bahwa teksnya masih
+      bisa dipilih, dan pastikan jumlah halamannya.
+    </p>
+    <p>
+      Alat di sini mengerjakan yang terakhir itu untuk Anda sebelum ia menawarkan
+      file-nya: ia membuka lagi dokumen yang baru saja ditulisnya lalu menghitung
+      halamannya, di mesin Anda sendiri. Ia juga menulis PDF 1.5, yang dipahami
+      setiap pembaca yang dirilis sejak 2003, jadi &ldquo;ia terbuka di mesin
+      saya&rdquo; adalah perkiraan yang masuk akal untuk &ldquo;ia terbuka di
+      mesin mereka&rdquo;.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh server</h2>
+    <p>
+      Mengompres sebuah PDF terdengar seperti pekerjaan server, dan sepanjang
+      hampir seluruh usia web memang begitu. Yang sebenarnya dilibatkannya adalah
+      membaca struktur file-nya, menemukan aliran gambarnya, mendekodekan dan
+      mengodekan ulang yang itu dengan kodek yang sudah dibawa sebuah peramban,
+      lalu menuliskan dokumennya kembali. Semua itu berjalan di sebuah peramban
+      sekarang.
+    </p>
+    <p>
+      Dan itu lebih penting untuk jenis file ini daripada kebanyakan yang lain,
+      karena apa yang dikompres orang: kontrak, surat medis, rekening koran,
+      dokumen identitas, surat pemberitahuan pajak. Alat di sini sama sekali
+      tidak punya fitur jaringan, dan <code>Content-Security-Policy</code>
+      halamannya menyebut satu per satu setiap alamat yang boleh dihubunginya,
+      dan tidak satu pun milik situs ini. Muat, cabut koneksi, lalu kompres
+      sesuatu.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain seperti itu.
+    </p>
+  </section>

--- a/locales/id/pages/guides/make-a-pdf-smaller.toml
+++ b/locales/id/pages/guides/make-a-pdf-smaller.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: memperkecil ukuran PDF - Bahasa Indonesia.
+#
+
+nav = "Memperkecil ukuran PDF"
+title = "Cara Memperkecil Ukuran PDF (dan Kenapa Sebagian Tidak Mau Menyusut)"
+description = "Di mana sebenarnya ukuran sebuah PDF berada, kenapa sebuah pindaian menyusut 80% sementara sebuah kontrak nyaris tidak bergerak, apa arti DPI di sini, dan apa yang tidak boleh dilakukan sebuah kompresor pada dokumen Anda."
+
+heading = "Cara memperkecil ukuran PDF, dan kenapa sebagian tidak mau menyusut"
+lede = """
+    PDF yang tidak muat di batas email hampir selalu PDF yang penuh gambar. Ini
+    menjelaskan cara mengetahui apakah punya Anda begitu, berapa harga
+    mengompresnya, dan kenapa alat mana pun yang menjanjikan persentase tetap
+    belum melihat file Anda."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara memperkecil ukuran PDF"
+og_description = "Di mana sebenarnya ukuran sebuah PDF berada, kenapa sebuah pindaian menyusut sementara sebuah kontrak tidak, dan apa hubungan DPI dengan itu."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/make-a-qr-code.html
+++ b/locales/id/pages/guides/make-a-qr-code.html
@@ -1,0 +1,273 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../buat-kode-qr/">Pembuat QR &amp; Barcode</a>, tempelkan
+      tautan Anda, biarkan tingkatnya di <strong>M</strong> dan marginnya di
+      <strong>4</strong>, lalu unduh SVG-nya. Cetak setidaknya selebar dua
+      sentimeter, di atas sesuatu yang matte, gelap di atas terang. Lalu pindai
+      yang tercetak dengan ponsel yang bukan punya Anda sebelum Anda memesan
+      seribu di antaranya.
+    </p>
+    <p>
+      Itu mencakup hampir setiap kasus. Sisa halaman ini adalah apa yang
+      dilakukan ketika ia bukan salah satunya: kode yang harus selamat dari
+      penanganan, kode dengan logo di atasnya, kode yang akan ditaruh di sesuatu
+      yang kecil, dan satu keputusan yang gampang dikelirukan dengan cara yang
+      baru Anda ketahui setahun kemudian.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa sebenarnya yang ada di dalam sebuah kode QR</h2>
+    <p>
+      Sebuah teks. Itulah seluruhnya. Memindai sebuah kode QR menyerahkan sepotong
+      teks kepada ponselnya, dan semua yang lain &mdash; membuka sebuah halaman,
+      bergabung ke sebuah jaringan, menawarkan menyimpan sebuah kontak &mdash;
+      adalah ponselnya yang mengenali bentuk teks itu lalu menawarkan
+      menindaklanjutinya.
+    </p>
+    <p>
+      Jadi tidak ada yang namanya "kode QR Wi-Fi" sebagai sejenis kode. Yang ada
+      adalah kode QR yang menyimpan
+      <code>WIFI:T:WPA;S:Jaringan Saya;P:kata sandinya;;</code>, yang bisa dibaca
+      setiap ponsel buatan satu dekade terakhir. Pembuatnya menampilkan teks
+      jadinya kepada Anda persis karena alasan ini: ketika sebuah kode tidak
+      melakukan yang Anda harapkan, teksnya adalah satu-satunya hal yang layak
+      dilihat.
+    </p>
+    <p>
+      Ia juga berarti sebuah kode QR tidak bisa diubah setelah dicetak, tidak
+      bisa menelepon pulang, dan tidak bisa kedaluwarsa &mdash; kecuali ada yang
+      menaruh sebuah tautan ke server mereka sendiri di dalamnya, dan itulah
+      pokok bagian terakhir di sini.
+    </p>
+  </section>
+
+  <section>
+    <h2>Keputusan satu: tingkat koreksi galatnya</h2>
+    <p>
+      Sebuah kode QR membawa sekumpulan codeword periksa di samping datanya,
+      dihitung supaya sebuah pembaca bisa membangun ulang apa yang tidak bisa
+      dilihatnya. Itulah sebabnya kode yang sudutnya robek tetap terpindai. Berapa
+      banyak codeword itu adalah tingkatnya, dan ada empat:
+    </p>
+    <ul>
+      <li><strong>L</strong> &mdash; sekitar 7% kodenya boleh hilang.</li>
+      <li><strong>M</strong> &mdash; sekitar 15%.</li>
+      <li><strong>Q</strong> &mdash; sekitar 25%.</li>
+      <li><strong>H</strong> &mdash; sekitar 30%.</li>
+    </ul>
+    <p>
+      Koreksi yang lebih banyak tidak gratis: data periksanya masuk ke persegi
+      yang sama, jadi teks yang sama pada H butuh kode yang lebih besar dan lebih
+      rapat daripada pada L. Kira-kira, berpindah dari L ke H menggandakan jumlah
+      modulnya untuk teks yang sama, dan modul yang lebih rapat lebih sulit
+      dipisahkan sebuah kamera. Ada pertukaran yang nyata di sini dan jawabannya
+      tergantung ke mana kodenya akan pergi.
+    </p>
+    <p>
+      <strong>L</strong> untuk sebuah layar: kode di sebuah slide, sebuah surel,
+      sebuah halaman web. Tidak ada yang akan merusaknya dan setiap modul
+      tambahan membuatnya lebih sulit dibaca dari jauh.
+    </p>
+    <p>
+      <strong>M</strong> adalah bawaannya dan jawaban yang benar untuk kebanyakan
+      pencetakan. Kertas yang akan sedikit ditangani, selebaran, kartu nama.
+    </p>
+    <p>
+      <strong>Q dan H</strong> untuk kode yang akan diperlakukan kasar: menu yang
+      dilap setiap hari, stiker di sebuah mesin di bengkel, label di sebuah peti,
+      kode di jendela yang terkena matahari langsung. H juga yang memungkinkan
+      sebuah logo di tengahnya &mdash; lihat di bawah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Keputusan dua: marginnya, yang merupakan bagian dari kodenya</h2>
+    <p>
+      Ruang putih di sekeliling sebuah kode QR bukan isian, dan bukan pilihan
+      desain. Sebuah pembaca memakainya untuk menemukan di mana simbolnya
+      berakhir. Spesifikasinya meminta empat modul ruang tenang di setiap
+      sisinya, dan kode yang dipangkas sampai ke tepinya adalah alasan tunggal
+      yang paling umum sebuah kode tercetak gagal.
+    </p>
+    <p>
+      Ini layak dinyatakan blak-blakan karena memangkas adalah hal yang begitu
+      wajar untuk dilakukan. Kodenya tampak punya terlalu banyak putih di
+      sekelilingnya, jadi ia dipangkas di tata letaknya, atau dijatuhkan ke sebuah
+      panel berwarna yang merapat sampai ke kotak-kotaknya, atau ditaruh di atas
+      sebuah foto. Masing-masing itu membuang batas yang akan dipakai pembacanya.
+    </p>
+    <p>
+      Kalau kodenya tampak terlalu besar dengan marginnya, kecilkan kodenya.
+      Jangan buang marginnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Keputusan tiga: seberapa besar mencetaknya</h2>
+    <p>
+      Patokan kasar yang selamat dari benturan dengan kenyataan adalah
+      <strong>satu banding sepuluh</strong>: sebuah kode perlu selebar kira-kira
+      sepersepuluh jarak dari mana ia akan dipindai.
+    </p>
+    <ul>
+      <li>Kartu nama atau menu, dibaca dari 30 cm: sekitar 2 cm lebarnya.</li>
+      <li>Poster yang dibaca dari dua meter: sekitar 20 cm.</li>
+      <li>Halte bus atau etalase toko yang dibaca dari lima meter: sekitar 50 cm.</li>
+    </ul>
+    <p>
+      Dua sentimeter itu lantai, bukan sasaran. Di bawah sekitar 1,5 cm sebuah
+      ponsel biasa mulai kepayahan tanpa peduli sebagus apa cetakannya, karena
+      masing-masing modulnya mendekati ukuran sebuah piksel di kameranya.
+    </p>
+    <p>
+      Teks yang lebih sedikit berarti modul yang lebih sedikit berarti kode yang
+      terbaca dari jauh pada ukuran cetak tertentu &mdash; dan itu alasan yang
+      bagus untuk mengarahkan sebuah kode ke <code>contoh.com/x</code> alih-alih
+      ke sebuah URL dengan seratus karakter parameter pelacakan di ujungnya.
+    </p>
+    <p>
+      Dan cetak dari <strong>SVG</strong>-nya. Sebuah kode QR terbuat dari tepi,
+      dan sebuah PNG punya jumlah piksel yang tetap untuk membuatnya; besarkan
+      satu dan setiap tepinya melembek, dan justru itulah yang menyulitkan sebuah
+      pemindai. SVG adalah kotaknya sebagai instruksi, jadi ia keluar tajam di
+      sebuah kartu nama maupun sebuah baliho.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warna, kontras, dan dua kekeliruannya</h2>
+    <p>
+      Sebuah pembaca mengukur selisih antara modul gelap dan modul terangnya,
+      jadi kontras adalah seluruhnya. Dua hal rutin keliru:
+    </p>
+    <p>
+      <strong>Kode terang di atas latar gelap.</strong> Ia tampak mencolok, dan
+      cukup banyak pembaca menolaknya mentah-mentah: mereka mencari gelap di atas
+      terang dan tidak mencoba kebalikannya. Sebagian mencoba. Anda tidak akan
+      tahu pelanggan Anda punya yang mana.
+    </p>
+    <p>
+      <strong>Selisihnya tidak cukup.</strong> Abu-abu sedang di atas putih, atau
+      dua warna merek yang bobotnya mirip, bisa terukur baik-baik saja di layar
+      lalu gagal di kertas begitu penyebaran tinta dan pencahayaan otomatis
+      sebuah ponsel terlibat. Kalau Anda mewarnai sebuah kode, jaga bagian
+      gelapnya benar-benar gelap.
+    </p>
+    <p>
+      Matte mengalahkan glossy untuk apa pun yang akan dipindai di bawah cahaya,
+      dan keduanya mengalahkan mencetak ke atas sebuah foto. Latar transparan
+      berguna untuk menaruh sebuah kode ke panel berwarna &mdash; tapi periksa
+      apa yang sebenarnya berakhir di belakangnya, karena kode transparan di atas
+      panel gelap adalah kekeliruan pertama di atas dengan langkah tambahan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Logo di tengahnya</h2>
+    <p>
+      Ini bekerja, dan ia bekerja karena koreksi galatnya alih-alih meski ada
+      koreksi galatnya. Pada tingkat H kira-kira 30% modulnya boleh dihancurkan
+      dan kodenya tetap terbaca, jadi logo yang menutupi lebih sedikit daripada
+      itu &mdash; di tengah, tempat tidak ada pola pencari duduk &mdash; adalah
+      kerusakan yang diperbaiki pembacanya.
+    </p>
+    <p>
+      Tiga hal yang harus dipegang. Pakai tingkat H. Jaga logonya di bawah
+      seperlima luasnya, jauh di bawah batas teoretisnya, karena cetakan bukan
+      satu-satunya hal yang menggerogoti kelonggaran Anda. Dan jangan pernah
+      menutupi tiga persegi besar di sudutnya atau yang lebih kecil di dekatnya:
+      itulah cara sebuah pembaca menemukan dan mengarahkan simbolnya sejak awal,
+      dan tidak ada koreksi galat sebanyak apa pun yang membangunnya kembali.
+    </p>
+    <p>
+      Lalu uji di ponsel sungguhan. Sebuah logo membawa sebuah kode dari "selalu
+      bekerja" menjadi "bekerja dengan kelonggaran sekian", dan satu-satunya cara
+      mengetahui berapa kelonggaran yang tersisa adalah mencobanya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Keputusan yang disesali orang: statis atau "dinamis"</h2>
+    <p>
+      Cari sebuah pembuat QR dan kebanyakan hasilnya ingin Anda membuat sebuah
+      akun, karena mereka menjual kode <em>dinamis</em>. Kode dinamis tidak memuat
+      tautan Anda. Ia memuat sebuah tautan pendek ke server pembuatnya sendiri,
+      yang mengalihkan ke tautan Anda.
+    </p>
+    <p>
+      Yang Anda dapat dari situ nyata: Anda bisa mengubah ke mana kodenya menunjuk
+      setelah ia dicetak, dan Anda mendapat hitungan setiap pemindaian. Untuk
+      sebuah kampanye dengan cetakan enam digit, itu sepadan dibayar.
+    </p>
+    <p>
+      Berapa harganya juga nyata, dan layak diketahui sebelumnya alih-alih
+      sesudahnya:
+    </p>
+    <ul>
+      <li>
+        <strong>Kodenya berhenti bekerja ketika mereka berhenti bekerja.</strong>
+        Kalau layanannya tutup, domainnya kedaluwarsa, atau paket gratisnya
+        habis, setiap kode yang Anda cetak mati &mdash; dan saat itu mereka sudah
+        ada di sepuluh ribu menu.
+      </li>
+      <li>
+        <strong>Setiap pemindaian adalah data orang lain.</strong> Pengalihannya
+        melihat alamat IP, waktu, dan perangkat setiap orang yang memindai kode
+        Anda.
+      </li>
+      <li>
+        <strong>Tautannya milik mereka, bukan milik Anda.</strong> Siapa pun yang
+        memindainya melihat sebuah domain asing berkelebat, dan justru itulah yang
+        sedang diberitahukan kepada orang-orang untuk dicurigai.
+      </li>
+    </ul>
+    <p>
+      Jalan tengahnya tidak berbiaya: taruh kode QR statis di sekeliling sebuah
+      URL pendek <em>di domain Anda sendiri</em>, lalu alihkan itu sendiri. Anda
+      menyimpan kemampuan mengubah tujuannya, Anda menyimpan analitiknya, dan
+      tidak ada apa pun tentang kodenya yang bergantung pada perusahaan yang belum
+      pernah Anda temui masih ada tahun depan.
+    </p>
+    <p>
+      <a href="../../buat-kode-qr/">Pembuat di sini</a> hanya membuat kode
+      statis, dan ia tidak punya akun untuk dibuat. Yang Anda ketik itulah yang
+      disimpan kodenya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Sebelum Anda mencetak seribu di antaranya</h2>
+    <p>
+      Pindai kodenya. Bukan yang di layar Anda &mdash; cetakan contohnya, di
+      tempat ia akan ditaruh, dengan ponsel yang bukan ponsel tempat Anda
+      membuatnya. Itu memakan satu menit dan menangkap seluruh kategori masalah
+      yang menjadi pokok halaman ini: margin yang dimakan tata letaknya, tautan
+      yang kehilangan <code>https://</code>-nya, warna yang terukur berbeda di
+      kertas, kode yang dicetak pada ukuran yang bekerja di meja dan tidak di
+      dinding.
+    </p>
+    <p>
+      Dan periksa apa yang terjadi setelah pemindaiannya. Kode yang membuka
+      halaman yang tidak terbaca di sebuah ponsel adalah kode yang gagal, meskipun
+      ia terpindai.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini menuntut mengunggah apa pun</h2>
+    <p>
+      Kode QR adalah hitungan atas sebuah teks. Tidak ada file untuk dikirim dan
+      tidak ada yang bisa dilakukan sebuah server yang tidak bisa dilakukan sebuah
+      peramban, dan itulah sebabnya <a href="../../buat-kode-qr/">alat di
+      sini</a> melakukan semuanya di mesin Anda sendiri dan bekerja dengan
+      jaringan tercabut.
+    </p>
+    <p>
+      Itu lebih penting daripada kedengarannya, karena apa yang ditaruh orang di
+      kode QR. Pemakaian paling umum untuk format Wi-Fi adalah kata sandi
+      sesungguhnya sebuah jaringan, diketik ke sebuah halaman web. Layak
+      diketahui apakah halaman itu punya tempat untuk mengirimnya.
+    </p>
+  </section>

--- a/locales/id/pages/guides/make-a-qr-code.toml
+++ b/locales/id/pages/guides/make-a-qr-code.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: membuat kode QR - Bahasa Indonesia.
+#
+
+nav = "Membuat kode QR"
+title = "Cara Membuat Kode QR yang Terpindai Setiap Kali"
+description = "Tingkat koreksi galat mana yang dipilih, kenapa margin putih di sekeliling sebuah kode QR adalah bagian dari kodenya, seberapa besar mencetaknya, dan berapa harga kode 'dinamis' sebuah pembuat gratis bagi Anda belakangan."
+
+heading = "Cara membuat kode QR yang tetap terpindai di ponsel orang lain"
+lede = """
+    Membuat kode QR memakan sedetik. Membuat satu yang bekerja di menu yang
+    basah, halte bus, atau ponsel yang dipegang sepanjang lengan di bawah cahaya
+    yang buruk memakan empat keputusan, dan keempatnya dibuat sebelum Anda
+    mencetak apa pun. Inilah apa yang dilakukan masing-masing."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Membuat kode QR yang tetap terpindai di ponsel orang lain"
+og_description = "Empat keputusan yang menentukan apakah kode QR tercetak bekerja: tingkatnya, marginnya, ukurannya, dan alamat siapa yang sebenarnya ada di dalamnya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/merge-and-split-pdf-files.html
+++ b/locales/id/pages/guides/merge-and-split-pdf-files.html
@@ -1,0 +1,233 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../gabung-pdf/">Penggabung &amp; Pemisah PDF</a>,
+      jatuhkan setiap file yang ingin Anda pakai, lalu seret halamannya ke
+      urutan yang Anda mau. Lalu sebutkan apakah ia keluar sebagai satu dokumen
+      atau beberapa, dan tekan tombolnya. Tidak ada yang diunggah: file-nya
+      dibuka, dibongkar, dan ditulis kembali oleh peramban Anda sendiri.
+    </p>
+    <p>
+      Tiga pekerjaan yang dicari orang secara terpisah &mdash; gabung, pisah,
+      susun ulang &mdash; adalah satu layar, karena ketiganya satu operasi dengan
+      jawaban yang berbeda di ujungnya: pilih beberapa halaman, taruh mereka
+      dalam sebuah urutan, lalu putuskan mereka keluar sebagai berapa file.
+    </p>
+  </section>
+
+  <section>
+    <h2>Menggabungkan dua dokumen atau lebih</h2>
+    <p>
+      Pilih file pertama, lalu pilih yang kedua; halaman masing-masing masuk ke
+      ujung urutan yang sedang berjalan, jadi Anda bisa terus menambahkan file
+      dari folder yang berbeda-beda tanpa mengulang dari awal. Kalau mereka masuk
+      dalam urutan yang salah, seret sebuah halaman lewat pegangannya, atau pakai
+      panah pada setiap ubinnya.
+    </p>
+    <p>
+      Menggabung tidak mengodekan ulang apa pun. Isi setiap halaman dan setiap
+      fon, gambar, serta gambar vektor yang dirujuknya disalin persis, jadi teksnya
+      tetap bisa dipilih dan dicari dan sebuah pindaian tetap pindaian yang sama.
+      File gabungannya biasanya sedikit lebih kecil daripada kedua masukannya
+      dijumlahkan, dan itu bukan pengompresan &mdash; itu struktur di sekeliling
+      halamannya yang ditulis sekali alih-alih dua kali.
+    </p>
+    <p>
+      Halaman menyimpan ukurannya sendiri. Gabungkan laporan A4 dengan lampiran
+      US Letter dan Anda mendapat dokumen yang memuat keduanya, dan begitulah
+      yang dikatakan file-nya. Menskalakan halaman orang ke satu ukuran kertas
+      adalah operasi yang berbeda dan bukan operasi yang boleh dilakukan sebuah
+      penggabung diam-diam.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memisah satu dokumen menjadi beberapa</h2>
+    <p>
+      Ada empat cara memotong, dan Anda mau yang mana tergantung kenapa Anda
+      memotong:
+    </p>
+    <ul>
+      <li>
+        <strong>Setiap sekian halaman.</strong> Untuk pindaian panjang dari
+        sesuatu yang aslinya setumpuk dokumen terpisah &mdash; dua belas slip
+        gaji, masing-masing dua halaman.
+      </li>
+      <li>
+        <strong>Pada nomor halaman yang Anda sebutkan.</strong> Untuk laporan
+        berbab yang mulai di halaman yang bisa Anda lihat. Setiap nomor yang Anda
+        ketik memulai sebuah file baru.
+      </li>
+      <li>
+        <strong>Satu file per halaman.</strong> Untuk menarik selembar tanda
+        tangan atau sertifikat dari sebuah kumpulan.
+      </li>
+      <li>
+        <strong>Kembali menjadi file asalnya.</strong> Hanya ditawarkan ketika
+        Anda sudah menggabungkan lebih dari satu file, dan berguna setelah
+        penyuntingan: buang halaman kosong dari tiga pindaian sekaligus, lalu
+        dapatkan kembali tiga file.
+      </li>
+    </ul>
+    <p>
+      Kalau Anda hanya mau beberapa halaman dari dokumen yang panjang, Anda sama
+      sekali tidak perlu memisahnya. Ketik halaman yang Anda mau di kotak
+      rentangnya &mdash; <code>1-3, 8, 12-</code> &mdash; tekan &ldquo;Simpan
+      hanya ini&rdquo;, lalu bangun satu dokumen.
+    </p>
+    <p>
+      Lebih dari satu file keluaran diserahkan sebagai satu ZIP. Lima puluh
+      unduhan adalah lima puluh permintaan penyimpanan, dan kira-kira di situlah
+      siapa pun menyerah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Menyusun ulang, memutar, dan membuang halaman</h2>
+    <p>
+      Seret sebuah ubin lewat pegangannya untuk memindahkannya. Panah pada setiap
+      ubin menggesernya satu tempat, atau memutarnya seperempat putaran sekali
+      tekan &mdash; dan itulah solusi untuk halaman yang keluar miring dari
+      pemindainya. Tanda &times; membuangnya.
+    </p>
+    <p>
+      Untuk apa pun yang melibatkan lebih dari satu dua halaman, pakai kotak
+      rentangnya. Ia menerima apa yang akan Anda tulis di kertas:
+      <code>1-3, 8, 12-</code>, dan juga <code>odd</code>, <code>even</code>,
+      <code>all</code>, serta <code>last</code>. Simpan yang itu, buang yang itu,
+      atau putar yang itu. Satu yang umum: pindaian bolak-balik yang setiap
+      halaman keduanya terbalik adalah <code>even</code> dan dua putaran.
+    </p>
+    <p>
+      Nomor di ubinnya dinomori ulang sambil Anda bekerja, jadi mereka selalu
+      berarti &ldquo;posisi di dokumen jadinya&rdquo; alih-alih &ldquo;halaman di
+      file mana pun asalnya&rdquo;. Tidak ada yang ditulis sampai Anda menekan
+      tombolnya, jadi tidak ada yang perlu diurungkan &mdash; dan &ldquo;kembali
+      ke keadaan datangnya&rdquo; memulihkan urutan asli semuanya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang selamat dari penyusunan ulang, dan apa yang tidak</h2>
+    <p>
+      Inilah bagian yang tidak diberitahukan alat mana pun kepada Anda, dan
+      itulah sebabnya dokumen gabungan kadang terasa rusak secara halus.
+    </p>
+    <p>
+      Sebuah PDF bukan setumpuk halaman. Ia sebuah graf, dan cukup banyak
+      bagiannya adalah tentang dokumennya alih-alih tentang halaman mana pun:
+      panel markahnya, tautannya, formulirnya, urutan baca yang diikuti pembaca
+      layar, penomoran yang menyebut empat halaman pertama &ldquo;i, ii, iii,
+      iv&rdquo;. Pindahkan halamannya dan setiap satu dari itu harus dibangun
+      ulang atau dibuang.
+    </p>
+    <ul>
+      <li>
+        <strong>Markah dibangun ulang.</strong> Entri yang halamannya masih ada
+        menunjuk ke mana pun ia berpindah. Entri yang halamannya Anda buang ikut
+        hilang &mdash; kecuali ia punya entri yang selamat di bawahnya, dan dalam
+        hal itu ia bertahan sebagai judul, karena judul sebuah bab tetap ada di
+        tempat babnya berada. Menggabungkan beberapa file menyarangkan markah
+        masing-masing di bawah sebuah judul yang dinamai sesuai file-nya, dan
+        itulah yang membuat laporan gabungan bisa dijelajahi sama sekali.
+      </li>
+      <li>
+        <strong>Tautan diikuti.</strong> Tautan dari halaman 2 ke halaman 40 tahu
+        ke mana halaman 40 pergi, termasuk tujuan bernama yang ditulis Word dan
+        LaTeX untuk setiap judul. Tautan yang sasarannya tidak ikut serta
+        dibiarkan tanpa apa pun di belakangnya, alih-alih menunjuk ke halaman apa
+        pun yang kebetulan kini berada di posisi itu.
+      </li>
+      <li>
+        <strong>Formulir yang sudah diisi selamat</strong>, dan dokumen barunya
+        didaftarkan sebagai sebuah formulir sehingga pembaca memperlakukannya
+        begitu. Satu keanehan yang layak diketahui: dua kolom dengan nama yang
+        sama adalah <em>satu</em> kolom bagi pembaca mana pun, jadi menggabungkan
+        dua salinan formulir yang sama menautkan keduanya &mdash; mengetik di
+        satu mengisi yang lain.
+      </li>
+      <li>
+        <strong>Urutan baca bertag tidak.</strong> Ia menggambarkan sebuah
+        runtutan yang tidak ada lagi, dan urutan yang keliru lebih buruk bagi
+        pembaca layar daripada tidak ada sama sekali. Kalau penandaan aksesibilitas
+        sebuah dokumen penting, simpan aslinya di sebelahnya.
+      </li>
+      <li>
+        <strong>Label halaman tidak.</strong> Penomoran &ldquo;iii, iv, 1,
+        2&rdquo; adalah pernyataan tentang sebuah urutan yang baru saja Anda
+        ubah.
+      </li>
+      <li>
+        <strong>Lampiran dan skrip dokumen tidak.</strong> File yang dilampirkan
+        ke dokumennya milik dokumennya, bukan milik halaman mana pun. Tindakan
+        yang menjalankan JavaScript, mengirimkan sebuah formulir ke suatu tempat,
+        atau meluncurkan sebuah program tidak dibawa ke dalam file baru Anda, dan
+        itu bawaan yang benar untuk halaman yang datang dari orang lain.
+      </li>
+    </ul>
+    <p>
+      Tanda tangan digital adalah kasus khusus, dan bukan keterbatasan alat mana
+      pun: sebuah tanda tangan mengesahkan dokumen sebagaimana ia berdiri.
+      Pindahkan sebuah halaman dan ia rusak, karena persis itulah yang harus
+      diberitahukannya kepada Anda.
+    </p>
+  </section>
+
+  <section>
+    <h2>File yang dilindungi kata sandi</h2>
+    <p>
+      PDF terenkripsi ditolak, termasuk jenis berkata sandi kosong yang
+      dihasilkan banyak mesin fotokopi kantor. Melepas perlindungan sebuah dokumen
+      adalah pekerjaan yang berbeda dari memindahkan halamannya, dan alat yang
+      melakukannya diam-diam akan melakukan sesuatu yang tidak Anda minta. Buka
+      di sebuah pembaca dengan kata sandinya lalu simpan salinan tanpa
+      perlindungan lebih dulu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memeriksa hasilnya</h2>
+    <p>
+      Buka, lalu periksa tiga hal: jumlah halamannya, urutannya, dan &mdash;
+      kalau dokumennya memilikinya &mdash; panel markahnya serta satu dua
+      tautannya.
+    </p>
+    <p>
+      Alat di sini mengerjakan yang pertama untuk Anda sebelum ia menawarkan
+      file-nya. Setiap dokumen jadi dibuka lagi oleh kode yang sama yang membaca
+      berkas asli Anda, dan halamannya dihitung dengan menyusuri pohon halamannya
+      alih-alih memercayai hitungan yang tertulis di file-nya. Kalau itu tidak
+      sesuai dengan yang Anda minta, sama sekali tidak ada unduhan yang
+      ditawarkan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh server</h2>
+    <p>
+      Menggabung terdengar seperti pekerjaan server, dan sepanjang hampir seluruh
+      usia web memang begitu. Yang sebenarnya dilibatkannya adalah membaca
+      struktur file-nya, menyalin objek yang dibutuhkan sebuah halaman ke sebuah
+      file baru, lalu menulis tabel rujukan silang yang baru. Tidak ada piksel
+      yang didekodekan dan tidak ada yang digambar. Sebuah peramban sudah bisa
+      melakukan semuanya bertahun-tahun.
+    </p>
+    <p>
+      Dan itu lebih penting di sini daripada hampir di mana pun lain, karena
+      <em>apa</em> yang digabungkan orang. Dokumen yang disatukan adalah dokumen
+      yang datang dari suatu tempat: sebuah kontrak dan lembar tanda tangannya,
+      pindaian paspor dan rekening koran, surat medis dan formulir klaim.
+      Penggabung daring menerima semuanya sekaligus, sudah tersusun rapi, dari
+      satu orang. Ia unggahan paling terbuka yang pernah dibuat kebanyakan orang.
+    </p>
+    <p>
+      Alat di sini sama sekali tidak punya fitur jaringan, dan
+      <code>Content-Security-Policy</code> halamannya menyebut satu per satu
+      setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+      Muat, cabut koneksi, lalu gabungkan sesuatu.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain seperti itu.
+    </p>
+  </section>

--- a/locales/id/pages/guides/merge-and-split-pdf-files.toml
+++ b/locales/id/pages/guides/merge-and-split-pdf-files.toml
@@ -1,0 +1,21 @@
+#
+# Panduan: menggabung dan memisah file PDF - Bahasa Indonesia.
+#
+
+nav = "Menggabung &amp; memisah PDF"
+title = "Cara Menggabung, Memisah, dan Menyusun Ulang Halaman PDF"
+description = "Gabungkan PDF, potong satu menjadi beberapa, dan pindahkan halamannya: apa yang selamat dari penyusunan ulang, apa yang tidak bisa dibawa alat mana pun, dan kenapa tidak satu pun dari itu perlu mengunggah dokumen Anda ke mana pun."
+
+heading = "Cara menggabung, memisah, dan menyusun ulang halaman PDF"
+lede = """
+    Menyatukan dua dokumen adalah hal paling biasa yang dilakukan siapa pun
+    pada sebuah PDF, dan yang paling sering dikerjakan dengan menyerahkan kedua
+    file itu ke server orang asing. Ia tidak membutuhkannya. Ini membahas cara
+    melakukannya, dan apa yang diam-diam hilang ketika sebuah alat menyusun ulang
+    halaman."""
+
+updated = "22 Agustus 2026"
+
+og_title = "Cara menggabung, memisah, dan menyusun ulang halaman PDF"
+og_description = "Gabungkan PDF, potong satu menjadi beberapa, pindahkan halamannya - dan ketahui apa yang selamat dari penyusunan ulang dan apa yang tidak."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/open-a-dicom-file.html
+++ b/locales/id/pages/guides/open-a-dicom-file.html
@@ -1,0 +1,258 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../penampil-dicom/">Penampil DICOM</a> lalu seret seluruh
+      folder file-nya ke atasnya. Mereka dibaca di mesin Anda sendiri,
+      dikembalikan ke seri asalnya, lalu disusun dalam urutan pengambilan
+      pemindainya. Tidak ada yang diunggah, dan tidak ada yang ditulis kembali ke
+      file Anda.
+    </p>
+    <p>
+      Kalau Anda diberi sebuah cakram dan bertanya-tanya file yang mana yang
+      harus dibuka: semuanya, sekaligus. Sebuah CT atau MR bukan satu file. Ia
+      satu file per irisan, dan sebuah studi dada adalah tiga ratus di
+      antaranya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa isi sebuah cakram rumah sakit</h2>
+    <p>
+      Biasanya empat hal, dan hanya satu di antaranya yang penting.
+    </p>
+    <ul>
+      <li>
+        <strong>Sebuah folder pindaian</strong>, sering bernama
+        <code>DICOM</code>, <code>IMAGES</code>, atau <code>ST0001</code>, berisi
+        file bernama <code>IM000001</code>, <code>I0000001</code>, atau sebuah
+        angka panjang bertitik. Sering kali sama sekali tanpa ekstensi. Inilah
+        pindaiannya.
+      </li>
+      <li>
+        <strong>Sebuah file bernama <code>DICOMDIR</code></strong>. Sebuah indeks
+        atas sisanya, ditulis supaya sebuah penampil bisa mendaftar studi di
+        cakramnya tanpa membuka setiap file. Anda tidak membutuhkannya.
+      </li>
+      <li>
+        <strong>Sebuah penampil</strong>, sebagai sebuah eksekutabel Windows,
+        sebuah entri autorun, atau sesekali sebuah applet Java. Ia dikompilasi
+        untuk apa pun yang berlaku ketika cakramnya dibakar, dan itulah sebabnya
+        begitu banyak di antaranya tidak lagi berjalan.
+      </li>
+      <li>
+        <strong>Sebuah halaman HTML atau PDF</strong> berlogo rumah sakitnya,
+        yang menjelaskan cara menjalankan penampilnya.
+      </li>
+    </ul>
+    <p>
+      Pindaiannya tidak membutuhkan penampilnya. Formatnya adalah standar yang
+      diterbitkan dan file-nya terbaca sendiri; eksekutabel di cakramnya adalah
+      satu program yang bisa membacanya, bukan satu-satunya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa file-nya tidak punya ekstensi</h2>
+    <p>
+      Karena DICOM tidak membutuhkannya. Setiap file membawa penandanya sendiri:
+      128 byte ketiadaan, lalu keempat huruf <code>DICM</code>, lalu sebuah blok
+      kecil kolom yang menggambarkan bagaimana sisa file-nya ditulis. Sebuah
+      pembaca memeriksa keempat huruf itu alih-alih nama yang berakhiran
+      <code>.dcm</code>.
+    </p>
+    <p>
+      Dan itu juga sebabnya menamai ulang sebuah file menjadi <code>.dcm</code>
+      tidak mengubah apa pun, dan sebabnya penampil yang bersikeras meminta
+      ekstensinya bersikap ketat tanpa perlu. File yang ditulis langsung dari
+      jaringan rumah sakit bahkan tidak punya 128 byte dan penandanya &mdash;
+      mereka data telanjang tanpa apa pun di depannya, dan sebuah pembaca harus
+      memperhitungkan bagaimana mereka dikodekan dari kolom pertamanya. Itu file
+      yang normal, bukan yang rusak.
+    </p>
+  </section>
+
+  <section>
+    <h2>Jendela dan level, kendali yang penting</h2>
+    <p>
+      Inilah satu hal yang membuat sebuah gambar medis berbeda dari sebuah foto,
+      dan alasan sebuah penyunting gambar tidak berguna untuk melihatnya.
+    </p>
+    <p>
+      Sebuah irisan CT menyimpan sekitar empat ribu nilai berbeda. Layar Anda
+      menampilkan dua ratus lima puluh enam abu-abu. Sesuatu harus memutuskan
+      empat ribu yang mana memetakan ke dua ratus lima puluh enam yang mana, dan
+      keputusan itulah <strong>jendelanya</strong>: semua di bawahnya hitam, semua
+      di atasnya putih, dan rentang di antaranya disebar ke seluruh abu-abunya.
+    </p>
+    <p>
+      Geser jendelanya dan file yang sama tampak seperti pindaian yang berbeda.
+      Itu bukan artefak penggambaran, itu intinya. Paru dan tulang sama-sama ada
+      di irisannya dan tidak bisa dilihat pada saat yang sama: jendela yang
+      menampilkan tekstur paru yang mengembang membuat setiap tulang putih murni,
+      dan jendela yang menampilkan detail trabekula di sebuah iga membuat seluruh
+      parunya hitam murni.
+    </p>
+    <p>
+      Pada sebuah CT, angkanya adalah <strong>satuan Hounsfield</strong>, dan
+      mereka didefinisikan secara mutlak alih-alih per pemindai: air adalah 0 dan
+      udara adalah &minus;1000, menurut definisinya, di setiap pemindai CT di
+      dunia. Itulah sebabnya sebuah penampil bisa menawarkan jendela bernama
+      &mdash; paru, tulang, otak, jaringan lunak &mdash; dan membuatnya berarti
+      hal yang sama pada file Anda seperti pada stasiun kerja tempat pindaiannya
+      dibaca. Yang biasa:
+    </p>
+    <ul>
+      <li><strong>Jaringan lunak</strong> &mdash; pusat 40, lebar 400.</li>
+      <li><strong>Paru</strong> &mdash; pusat &minus;600, lebar 1500.</li>
+      <li><strong>Tulang</strong> &mdash; pusat 300, lebar 1500.</li>
+      <li><strong>Otak</strong> &mdash; pusat 40, lebar 80. Yang sempit, karena
+        materi kelabu dan materi putih hanya berbeda beberapa satuan.</li>
+    </ul>
+    <p>
+      Pada sebuah MR tidak ada skala seperti itu. Nilainya tergantung
+      sekuensnya, koilnya, dan pemindainya, jadi tidak ada yang bisa dijadikan
+      nama sebuah prasetel dan jendela awalnya adalah jendela yang diminta
+      file-nya sendiri. Setiap pindaian membawa sebuah saran.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa irisannya kadang tergulir ke arah yang salah</h2>
+    <p>
+      Sebuah penampil harus memutuskan urutan apa yang dipakai menaruh file-nya,
+      dan ada dua hal di file-nya yang bisa dipakainya.
+    </p>
+    <p>
+      <strong>Instance Number</strong> adalah sebuah pencacah. Ia pilihan yang
+      gamblang dan ia ditetapkan apa pun yang menulis file-nya, yang tidak harus
+      menomorinya ke arah tubuh pasiennya membujur. Studi yang direkonstruksi
+      dari kaki ke atas lalu dinomori dari kepala ke bawah tergulir mundur, dan
+      seri yang dirakit dari dua rekonstruksi bisa mengulangi nomornya
+      terang-terangan.
+    </p>
+    <p>
+      <strong>Image Position (Patient)</strong> adalah di mana irisannya secara
+      fisik berada, dalam milimeter, dalam sebuah sistem koordinat yang terpaku
+      pada pasiennya alih-alih pada pemindainya. Mengurutkan menurut itu benar
+      apa pun yang dilakukan penomorannya, dan ia punya efek samping yang
+      berguna: begitu irisannya berada dalam urutan fisik, jarak di antaranya bisa
+      diukur, jadi sebuah penampil bisa memberi tahu Anda bahwa irisannya
+      berjarak 5&nbsp;mm &mdash; dan menyadari ketika salah satunya hilang, dan
+      itu tidak pernah dikatakan file-nya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mengukur sesuatu</h2>
+    <p>
+      Pindaian adalah data terukur, jadi sebuah panjang di atasnya adalah panjang
+      yang sungguhan &mdash; kalau file-nya mengatakan seberapa jauh jarak antar
+      pikselnya. Itu satu kolom, Pixel Spacing, dalam milimeter, dan ia ada di
+      pada dasarnya setiap CT dan MR.
+    </p>
+    <p>
+      Ia sering hilang pada gambar USG, pada dokumen hasil pindaian, dan pada
+      tangkapan layar yang disimpan sebagai DICOM. Ketika ia hilang, tidak ada
+      jawaban yang jujur dalam milimeter, dan penampil yang tetap memberi satu
+      sudah mengarang sebuah skala. Hitungan piksel adalah jawaban yang benar
+      untuk pertanyaan yang tidak bisa dijawab file-nya.
+    </p>
+    <p>
+      Waspadai juga piksel yang tidak persegi, dan itu normal di luar CT.
+      Mengukur dalam piksel lalu mengalikan dengan satu angka jarak benar hanya
+      ketika keduanya sepakat; setiap sumbu harus diukur dengan jaraknya sendiri.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang dibawa sebuah pindaian selain gambarnya</h2>
+    <p>
+      Inilah bagian yang salah dipahami orang, dan alasan untuk berhati-hati
+      dengan file seperti ini.
+    </p>
+    <p>
+      File DICOM bukan sebuah gambar dengan sedikit metadata terlampir. Ia sebuah
+      rekam medis dengan sebuah gambar di dalamnya. Headernya adalah sebuah
+      daftar kolom, dan pada pindaian klinis yang lazim ia menyimpan:
+    </p>
+    <ul>
+      <li>nama pasiennya, nomor rumah sakitnya, tanggal lahirnya, dan jenis
+        kelaminnya;</li>
+      <li>nomor aksesinya, yang merupakan kunci ke permintaan di dalam sistem
+        rumah sakitnya;</li>
+      <li>dokter yang merujuk, radiografer yang mengerjakan, radiolog yang
+        membacakan;</li>
+      <li>institusinya, alamatnya, dan departemennya;</li>
+      <li>pabrikan pemindainya, modelnya, dan nomor serinya;</li>
+      <li>tanggal dan waktu pindaiannya sampai ke detik;</li>
+      <li>dan sekumpulan pengenal unik &mdash; studi, seri, instans &mdash; yang
+        merupakan kunci sempurna kembali ke arsip asalnya.</li>
+    </ul>
+    <p>
+      File mana pun yang diberikan kepada Anda membawa semua itu, dan ia
+      bepergian bersama file-nya ke mana pun file-nya pergi. Menghapus namanya
+      tidak cukup: sebuah tanggal lahir, sebuah institusi sebesar satu kode pos,
+      dan sebuah waktu pindaian mengenali satu orang kira-kira sebaik sebuah nama,
+      dan UID studinya mengenali mereka dengan persis bagi siapa pun yang punya
+      akses ke arsipnya.
+    </p>
+    <p>
+      Sebagian pemindai juga menyimpan salinan kedua nama pasiennya di sebuah
+      kolom privat, yaitu kolom yang maknanya tidak diterbitkan di mana pun dan
+      yang dibiarkan kebanyakan penganonim karena mereka tidak bisa tahu apa
+      isinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Jangan mengunggah pindaiannya untuk melihatnya</h2>
+    <p>
+      Cara yang biasa masalah ini diselesaikan adalah pencarian
+      &ldquo;dicom viewer online&rdquo; dan sebuah kotak unggahan. Yang baru saja
+      terjadi adalah seorang asing punya salinan sebuah rekam medis: pikselnya,
+      namanya, tanggal lahirnya, nomor rumah sakitnya, dan kunci kembali ke
+      arsipnya.
+    </p>
+    <p>
+      Tidak ada alasan untuk itu. Membaca file DICOM adalah membaca sebuah header
+      dan membongkar beberapa bilangan bulat, dan sebuah peramban melakukan itu
+      dengan sangat baik, dan itulah sebabnya
+      <a href="../../penampil-dicom/">penampil di sini</a> sama sekali tidak
+      punya fitur jaringan: tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, tidak ada apa pun yang bisa mengirim sebuah
+      file bahkan seandainya ada yang mencoba. Muat halamannya sekali, putuskan
+      koneksi internet, dan ia terus membuka pindaian.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan cara memeriksa klaim itu di situs ini atau
+      di mana pun lain. Inilah jenis file yang paling layak diperiksa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang tidak bisa dilakukan sebuah peramban</h2>
+    <p>
+      Dua hal, dan keduanya layak dinyatakan terus terang.
+    </p>
+    <p>
+      <strong>Ia bukan penampil diagnostik.</strong> Layar Anda tidak
+      terkalibrasi, perambannya bukan rantai penggambaran yang tervalidasi, dan
+      tidak ada halaman web yang sudah melewati penilaian regulasi. Membaca
+      sebuah pindaian untuk membuat keputusan klinis adalah pekerjaan bagi
+      stasiun kerja tempat ia dibacakan. Melihat apa yang ada di cakramnya,
+      menarik sebuah irisan untuk bahan ajar, membaca sebuah header, atau mencari
+      tahu kenapa program lain menolak file-nya semuanya alasan yang sangat baik
+      untuk membuka satu di sebuah peramban.
+    </p>
+    <p>
+      <strong>Sebagian pindaian terkompres tidak akan terdekodekan.</strong>
+      DICOM mengizinkan beberapa skema kompresi dan peramban mewujudkan salah
+      satunya. File polos, yang berkode run-length, baseline JPEG, dan JPEG
+      Lossless &mdash; yang dipakai kebanyakan ekspor rumah sakit &mdash;
+      semuanya terbuka. JPEG 2000, JPEG-LS, dan format videonya butuh kodek yang
+      berupa pustaka terkompilasi berukuran megabita. Ketika gambarnya tidak bisa
+      didekodekan, headernya tetap sepenuhnya terbaca, dan itu biasanya separuh
+      yang toh Anda cari.
+    </p>
+  </section>

--- a/locales/id/pages/guides/open-a-dicom-file.toml
+++ b/locales/id/pages/guides/open-a-dicom-file.toml
@@ -1,0 +1,25 @@
+#
+# Panduan: membuka file DICOM - Bahasa Indonesia.
+#
+# Nama kolom DICOM dan nama file di sebuah cakram rumah sakit (DICOMDIR,
+# IM000001, Instance Number, Image Position) tetap seperti adanya: itulah yang
+# tertulis di cakram dan di standarnya.
+#
+
+nav = "Membuka file DICOM"
+title = "Cara Membuka File DICOM (.dcm) Tanpa Memasang Apa Pun"
+description = "Apa isi sebuah cakram rumah sakit, kenapa file-nya tidak punya ekstensi, bagaimana membuka pindaian .dcm di sebuah peramban, apa sebenarnya yang dilakukan jendela dan level, dan apa yang dibawa sebuah pindaian tentang pasiennya selain gambarnya."
+
+heading = "Cara membuka file DICOM, dan apa isinya"
+lede = """
+    Cakram rumah sakit adalah sebuah folder berisi file tanpa ekstensi dan
+    sebuah penampil yang ditulis untuk Windows XP. File-nya DICOM, dan tidak ada
+    yang aneh tentangnya: sebuah pindaian adalah sebuah header penuh kolom dan
+    sebuah blok piksel. Inilah cara melihatnya, apa arti kendalinya, dan apa lagi
+    yang dibawa file-nya selain gambarnya."""
+
+updated = "25 Agustus 2026"
+
+og_title = "Cara membuka file DICOM tanpa memasang apa pun"
+og_description = "Apa isi sebuah cakram rumah sakit, kenapa file-nya tidak punya ekstensi, dan apa yang dibawa sebuah pindaian .dcm tentang pasiennya selain gambarnya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/redact-a-pdf.html
+++ b/locales/id/pages/guides/redact-a-pdf.html
@@ -1,0 +1,244 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../sensor-pdf/">Penyensor PDF</a>, jatuhkan dokumennya,
+      ketik kata-kata yang harus hilang, centang yang Anda maksud, lalu tekan
+      &ldquo;Keluarkan&rdquo;. Hurufnya dihapus dari instruksi menggambar
+      halamannya sendiri, kata yang sama dikeluarkan dari markah, komentar, kolom
+      formulir, dan properti dokumennya, dan file jadinya dibuka lagi lalu dicari
+      di hadapan Anda sebelum ia ditawarkan kepada Anda.
+    </p>
+    <p>
+      Semua di bawah ini adalah kenapa anak kalimat terakhir itu yang penting,
+      dan bagaimana mengetahui apakah alat yang sudah Anda pakai bisa mengatakan
+      hal yang sama.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kegagalan yang menjadi pokok bahasan ini</h2>
+    <p>
+      Gambar sebuah persegi hitam di atas sebuah nama di sebuah pembaca PDF. Yang
+      Anda lihat adalah sebuah nama dengan persegi hitam di atasnya. Yang
+      <em>disimpan</em> kebanyakan pembaca adalah sebuah dokumen yang memuat
+      namanya dan, secara terpisah, sebuah persegi dengan sebuah posisi, sebuah
+      ukuran, dan sebuah warna.
+    </p>
+    <p>
+      Persegi yang digambar begitu adalah sebuah <strong>anotasi</strong>: sebuah
+      objek yang duduk di sebelah halamannya alih-alih di dalamnya. Teks di
+      bawahnya persis seperti sebelumnya. Pilih areanya lalu tekan salin, atau
+      jalankan pengekstrak teks apa pun di atas file-nya, atau buka di sebuah
+      program yang menggambar anotasi secara berbeda, dan namanya kembali. Tidak
+      ada apa pun di layar yang membedakan itu dari penyensoran sungguhan, dan
+      persis itulah sebabnya hal ini terus menimpa organisasi yang memperkerjakan
+      pengacara.
+    </p>
+    <p>
+      Ia sudah menerbitkan berkas pengadilan, penilaian intelijen, kontrak, dan
+      &mdash; pada Desember 2025 &mdash; nama-nama yang dihitamkan di sebuah
+      rilis besar dokumen Departemen Kehakiman Amerika Serikat, yang terbaca
+      dalam hitungan jam setelah penerbitannya. Polanya selalu sama. Perseginya
+      adalah anotasinya, dan anotasinya tidak pernah teksnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang dilakukan penyensoran sungguhan sebagai gantinya</h2>
+    <p>
+      Sebuah halaman di dalam PDF adalah sebuah daftar instruksi: setel fon ini,
+      pindahkan penanya ke sini, gambar glif ini. Kata-kata di halamannya ada di
+      tepat satu tempat, sebagai operan instruksi menggambar itu:
+    </p>
+    <pre><code>BT /F1 12 Tf 72 700 Td (Dear Mr Smith) Tj ET</code></pre>
+    <p>
+      Menyensor namanya berarti <strong>menghapus huruf itu dari instruksi
+      itu</strong> lalu menuliskan halamannya kembali. Setelah itu tidak ada yang
+      bisa dipulihkan, bukan karena file-nya menyembunyikannya dengan baik
+      melainkan karena hurufnya tidak ada di file-nya. Tidak ada persegi dengan
+      sesuatu di bawahnya, karena tidak ada apa pun di bawahnya.
+    </p>
+    <p>
+      Satu hal harus ditaruh kembali, atau hasilnya kelihatan keliru. Teks
+      digambar dengan memajukan sebuah pena melintasi halamannya, jadi menghapus
+      lima huruf menarik sisa barisnya lima huruf ke kiri: kolomnya berhenti
+      sejajar dan totalnya menggeser ke bawah judul yang salah. Alat yang
+      melakukan ini dengan benar mengukur seberapa jauh huruf yang dibuang itu
+      akan memajukan penanya lalu menaruh jarak itu kembali sebagai instruksi
+      jarak, yang memindahkan penanya tanpa menggambar apa pun.
+    </p>
+    <p>
+      Kotak hitamnya, kalau ada, digambar <em>sesudahnya</em>, di atas sebuah
+      celah yang sudah kosong. Ia sebuah kesopanan bagi siapa pun yang membaca
+      dokumennya &mdash; sebuah tanda bahwa ada yang dikeluarkan &mdash; dan
+      bukan penyensorannya. Itulah seluruh perbedaannya dalam satu kalimat: pada
+      penyensoran sungguhan, kotaknya hiasan; pada yang palsu, kotaknya
+      <em>adalah</em> penyensorannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Empat tempat sebuah kata bersembunyi yang bukan halamannya</h2>
+    <p>
+      Inilah bagian yang menjebak orang yang sudah mengerjakan bagian pertamanya
+      dengan benar. Sebuah PDF membawa teks di beberapa tempat sekaligus, dan
+      sebuah pembaca akan menampilkan, mencari, atau menyalin semuanya. Membuang
+      sebuah nama dari halamannya lalu meninggalkannya di salah satu tempat ini
+      berarti belum membuangnya.
+    </p>
+    <ul>
+      <li>
+        <strong>Properti dokumennya.</strong> Judul, penulis, dan nama file
+        asal ekspornya. Dokumen yang halamannya sudah dikeluarkan sebuah nama
+        tapi propertinya masih berbunyi
+        <code>Smith settlement draft 3.docx</code> belum disensor. Biasanya ada
+        salinan kedua informasi yang sama di sebuah paket XMP, yang juga harus
+        hilang.
+      </li>
+      <li>
+        <strong>Markah.</strong> Kerangka di sisi sebuah pembaca adalah sebuah
+        daftar judul dengan nomor halaman terlampir &mdash; dan sebuah judul
+        adalah sebaris teks yang tidak dikendalikan apa pun di halamannya.
+      </li>
+      <li>
+        <strong>Kolom formulir dan komentar.</strong> Apa yang diketik seseorang
+        ke dalam sebuah formulir disimpan dua kali: sekali sebagai nilai
+        kolomnya dan sekali sebagai tampilan yang digambar pembacanya. Keduanya
+        harus hilang. Catatan tempel membawa teksnya dan nama siapa pun yang
+        menulisnya.
+      </li>
+      <li>
+        <strong>Teks penggantinya.</strong> Sebuah PDF boleh menyatakan bahwa
+        serangkaian glif &ldquo;mengeja&rdquo; sesuatu yang lain, sehingga sebuah
+        ligatur atau baris bertanda hubung tersalin sebagai kata yang
+        diwakilinya. Artinya sebuah dokumen bisa menampilkan satu hal lalu
+        menyerahkan hal lain kepada pembacanya pada Ctrl+C, dan penyensoran yang
+        hanya membuang yang tergambar akan meninggalkan kalimatnya utuh bagi
+        siapa pun yang memilih paragrafnya.
+      </li>
+    </ul>
+    <p>
+      Lampiran adalah yang kelima. Sebuah PDF bisa membawa file utuh lain di
+      dalamnya, dan tidak ada yang Anda lakukan pada halamannya yang
+      menyentuhnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bagaimana memeriksa sebuah file, dalam tiga puluh detik</h2>
+    <p>
+      Lakukan ini pada apa pun yang hendak Anda kirim, alat apa pun yang
+      menghasilkannya. Inilah pemeriksaan yang akan menangkap setiap satu dari
+      kegagalan yang sudah terbit itu.
+    </p>
+    <ol>
+      <li>
+        <strong>Buka file jadinya lalu tekan Ctrl+F</strong> (Cmd+F di sebuah
+        Mac). Cari kata yang Anda buang. Penyensoran sungguhan tidak
+        mengembalikan apa pun. Kalau pembacanya melompat ke sebuah persegi
+        hitam, katanya masih ada di sana dan perseginya sedang duduk di atasnya.
+      </li>
+      <li>
+        <strong>Pilih area yang dihitamkan lalu salin.</strong> Seret melintasi
+        perseginya, tekan Ctrl+C, lalu tempelkan ke sebuah kotak teks. Kalau ada
+        yang tiba, Anda menemukan kegagalan yang sama dari arah sebaliknya.
+      </li>
+      <li>
+        <strong>Pilih seluruh dokumennya lalu salin itu.</strong> Ctrl+A lalu
+        Ctrl+C, tempelkan ke penyunting teks mana pun, lalu baca apa yang keluar.
+        Inilah yang paling berguna dari ketiganya, karena ia menunjukkan
+        dokumennya kepada Anda sebagaimana dilihat sebuah pengekstrak teks
+        &mdash; termasuk teks yang tidak pernah Anda tahu ada di sana, dan pada
+        halaman hasil pindaian itu umum.
+      </li>
+      <li>
+        <strong>Lihat propertinya</strong> &mdash; File → Properties di
+        kebanyakan pembaca &mdash; dan panel markahnya. Keduanya tempat sebuah
+        nama selamat dari penyensoran yang sempurna di halamannya.
+      </li>
+    </ol>
+    <p>
+      <a href="../../sensor-pdf/">Penyensor PDF</a> menjalankan yang pertama dan
+      yang ketiga untuk Anda lalu menampilkan hitungannya, karena alat yang
+      menegaskan bahwa ia sudah membuang sesuatu bukanlah bukti dan sebuah
+      pencarian atas file jadinya adalah bukti.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dokumen hasil pindaian adalah masalah yang berbeda</h2>
+    <p>
+      Pindaian adalah foto sebuah halaman. Kata-kata di atasnya adalah piksel,
+      bukan teks, dan menyunting lapisan teksnya sebanyak apa pun tidak
+      menyentuhnya &mdash; karena tidak ada lapisan teks, atau karena yang ada di
+      sana menggambarkan gambarnya alih-alih menjadi gambarnya.
+    </p>
+    <p>
+      Kebanyakan pemindai dan alat PDF masa kini menambahkan lapisan teks tak
+      kasatmata di atas gambarnya, ditulis pengenalan karakter optis, supaya
+      halamannya bisa dicari. Lapisan itu teks yang sungguhan dan bisa dibuang.
+      Membuangnya layak dilakukan: itulah yang akan ditemukan sebuah pencarian,
+      sebuah salinan, dan setiap sistem otomatis yang membaca dokumen. Ia tidak
+      mengubah apa pun tentang gambarnya, yang di dalamnya kata-katanya tetap
+      terbaca sempurna oleh siapa pun yang memandangi halamannya.
+    </p>
+    <p>
+      Jadi untuk sebuah pindaian, urutan yang jujur adalah: keluarkan kata-katanya
+      dari lapisan teksnya, lalu tangani gambarnya secara terpisah &mdash; dan
+      itu berarti menimpa piksel. Itulah yang dilakukan
+      <a href="../sensor-gambar/">penyensor gambar</a>, dan panduan di sebelahnya
+      menjelaskan kenapa sebuah pemburaman atau mosaik tidak cukup baik untuk
+      teks.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa tidak dicetak saja lalu dipindai ulang</h2>
+    <p>
+      Karena ia berhasil, dan ia mengorbankan semua yang lain dari Anda.
+      Mencetak halaman yang sudah disensor lalu memindainya kembali memang
+      menghasilkan dokumen tanpa lapisan teks yang bisa bocor &mdash; dan sebuah
+      dokumen yang tidak bisa dicari siapa pun, tidak bisa dibaca pembaca layar
+      mana pun, yang lima sampai lima puluh kali ukurannya, dan yang kualitasnya
+      terserah suasana hati pemindai kantornya. Ia juga bertumpu pada halamannya
+      tercetak sebagaimana ia tampak: sebuah anotasi bisa ditandai supaya tampil
+      di layar dan tidak di kertas, dan ketika itulah kotak hitam Anda, lembar
+      yang keluar dari pencetaknya ada namanya.
+    </p>
+    <p>
+      Argumen yang sama berlaku untuk &ldquo;ratakan menjadi gambar&rdquo;, yang
+      ditawarkan sebagian alat sebagai penyensoran. Ia mengubah setiap halaman
+      menjadi foto dirinya sendiri. Kalau kata-katanya ditutupi alih-alih
+      dihapus, penutupannya kini permanen &mdash; tapi semua yang lain tentang
+      dokumennya ikut hilang, dan file yang Anda kirim adalah file yang tidak
+      bisa dikerjakan siapa pun.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini pekerjaan yang paling tidak layak diunggah</h2>
+    <p>
+      Sebuah layanan penyensoran harus diberi file yang belum disensor. Itulah
+      seluruh transaksinya: versi pribadinya tiba lebih dulu, utuh, dan menjadi
+      versi yang ada di disk orang lain. Apa pun yang dikatakan kebijakan
+      privasinya, urutannya tidak bisa dibantah &mdash; dokumen yang Anda
+      hati-hatikan adalah dokumen yang Anda serahkan.
+    </p>
+    <p>
+      Apa yang disensor orang membuat ini lebih buruk daripada kedengarannya.
+      Keterangan saksi, surat medis, rekening koran yang dikirim ke pemilik
+      kontrakan, kontrak yang memuat nama satu klien tapi hendak dikirim ke klien
+      lain, sebuah berkas yang ada alamat rumah di atasnya. Itulah dokumennya,
+      dan persis itulah sebabnya alat untuk mereka tidak boleh punya server di
+      ujung lainnya.
+    </p>
+    <p>
+      Semua di <a href="../../sensor-pdf/">penyensor situs ini</a> terjadi di
+      peramban Anda sendiri: file-nya dibaca, disunting, ditulis, dan diperiksa
+      di mesin Anda, dan kata yang Anda cari juga tidak pernah meninggalkan
+      tabnya. Cabut koneksi internet dan ia terus bekerja, dan itu bukti paling
+      sederhana yang ada bahwa tidak ada yang dikirim ke mana pun. Lihat
+      <a href="../apakah-aman-mengunggah-file/">amankah mengunggah file</a> untuk
+      apa yang sebenarnya dilibatkan sebuah unggahan.
+    </p>
+  </section>

--- a/locales/id/pages/guides/redact-a-pdf.toml
+++ b/locales/id/pages/guides/redact-a-pdf.toml
@@ -1,0 +1,21 @@
+#
+# Panduan: menyensor sebuah PDF - Bahasa Indonesia.
+#
+
+nav = "Menyensor PDF"
+title = "Cara Menyensor PDF Supaya Teksnya Sungguh Hilang"
+description = "Kotak hitam yang digambar di sebuah pembaca PDF biasanya meninggalkan kata-kata di bawahnya, dan salin-tempel mengembalikannya begitu saja. Apa yang dibuang penyensoran sungguhan, empat tempat sebuah kata bersembunyi di luar halamannya, dan bagaimana memeriksa sebuah file sebelum Anda mengirimnya."
+
+heading = "Cara menyensor PDF supaya teksnya sungguh hilang"
+lede = """
+    Persegi hitam di atas sebuah nama dan sebuah nama yang sudah dihapus tampak
+    identik di layar. Salah satunya selamat ketika dipilih dan disalin. Inilah
+    bedanya, tempat-tempat sebuah kata bersembunyi yang sama sekali bukan di
+    halamannya, dan pemeriksaan tiga puluh detik yang memberi tahu Anda punya
+    yang mana dari keduanya."""
+
+updated = "25 Agustus 2026"
+
+og_title = "Cara menyensor PDF supaya teksnya sungguh hilang"
+og_description = "Kenapa kotak hitam di sebuah pembaca PDF biasanya bukan penyensoran, empat tempat sebuah kata bersembunyi di luar halamannya, dan bagaimana memeriksa sebuah file sebelum Anda mengirimnya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/redact-an-image.html
+++ b/locales/id/pages/guides/redact-an-image.html
@@ -1,0 +1,234 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../sensor-gambar/">Penyensor Gambar</a>, jatuhkan
+      gambarnya, seret sebuah kotak di atas setiap hal yang tidak boleh terlihat,
+      lalu tekan &ldquo;Sensor dan simpan&rdquo;. Pakai isian hitam untuk apa pun
+      yang terbaca sebagai teks. File yang Anda dapatkan kembali punya nilai
+      piksel yang berbeda di tempat kotaknya berada: tidak ada persegi di
+      dalamnya untuk digeser, karena sama sekali tidak ada persegi di dalamnya.
+    </p>
+    <p>
+      Semua di bawah ini adalah kenapa kalimat terakhir itu adalah seluruh
+      intinya, dan bagaimana mengetahui apakah alat yang sudah Anda pakai bisa
+      mengatakan hal yang sama.
+    </p>
+  </section>
+
+  <section>
+    <h2>Menutupi dan membuang tampak identik di layar</h2>
+    <p>
+      Gambar sebuah persegi hitam di atas sebuah nama di pembaca PDF, dek slide,
+      pengolah kata, atau penyunting gambar berlapis, dan yang Anda lihat adalah
+      sebuah nama dengan persegi hitam di atasnya. Yang Anda <em>simpan</em>, di
+      kebanyakan program itu, adalah sebuah dokumen yang memuat namanya dan,
+      secara terpisah, sebuah persegi dengan sebuah posisi, sebuah ukuran, dan
+      sebuah warna.
+    </p>
+    <p>
+      Siapa pun yang membuka file itu bisa memindahkan perseginya, menghapusnya,
+      atau membuka dokumennya di program yang menggambar lapisannya dalam urutan
+      berbeda. Namanya masih ada di sana. Tidak ada apa pun di layar yang memberi
+      tahu Anda mana dari kedua hal itu yang baru saja terjadi, dan persis itulah
+      sebabnya hal ini terus menimpa organisasi yang punya pengacara.
+    </p>
+    <p>
+      Ia sudah menerbitkan berkas pengadilan, laporan pemerintah, kontrak, dan
+      dokumen hasil pindaian lebih dari satu surat kabar. Polanya selalu sama:
+      perseginya adalah anotasinya, dan anotasinya bukan gambarnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa itu penyensoran sungguhan</h2>
+    <p>
+      Sebuah gambar adalah kisi angka, satu per piksel. Menyensornya berarti
+      <strong>menulis angka yang berbeda ke dalam kisinya</strong> lalu menyimpan
+      kisinya. Setelah itu tidak ada yang bisa dipulihkan, bukan karena file-nya
+      menyembunyikannya dengan baik melainkan karena nilainya tidak ada di
+      file-nya. Itulah satu-satunya versi dari ini yang selamat ketika dibuka
+      orang yang penasaran.
+    </p>
+    <p>
+      Tiga akibat yang layak diketahui, karena itulah rupa yang seharusnya
+      dipunyai file yang disensor:
+    </p>
+    <ul>
+      <li>
+        <strong>Hasilnya satu gambar yang rata.</strong> Tidak ada lapisan, tidak
+        ada objek, tidak ada daftar anotasi, tidak ada yang bisa dinyalakan
+        dimatikan. Kalau alat Anda menyerahkan kembali file yang ada lapisannya,
+        ia menutupi alih-alih membuang.
+      </li>
+      <li>
+        <strong>Ia file baru, bukan file lama yang disunting.</strong> Pikselnya
+        melewati sebuah dekoder dan sebuah pengode, jadi yang keluar ditulis dari
+        kisi yang sudah disensor.
+      </li>
+      <li>
+        <strong>Metadatanya ikut hilang</strong>, sebagai efek samping. Kisi
+        piksel tidak membawa model kamera, posisi GPS, atau cap waktu. Lihat
+        <a href="../hapus-data-exif-dan-gps/">apa yang dikatakan sebuah foto
+        tentang Anda</a> untuk apa yang tadinya akan ada di sana.
+      </li>
+    </ul>
+    <p>
+      Yang terakhir itu layak diuraikan, karena ia menyembunyikan jebakannya
+      sendiri. Banyak foto membawa <strong>gambar mini yang tersemat</strong>:
+      salinan kedua yang kecil dari gambarnya, ditulis ketika file-nya dibuat dan
+      tidak selalu dihasilkan ulang ketika gambarnya disunting. Foto yang disensor
+      oleh alat yang menyunting file-nya di tempat, alih-alih mengodekannya
+      ulang, bisa bepergian dengan gambar mini berisi aslinya yang belum
+      disensor. Ia gambar yang kecil, dan ia dengan mudah cukup besar untuk
+      membaca sebuah nama darinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hitam, pikselasi, atau buram &mdash; dan kenapa ketiganya tidak setara</h2>
+    <p>
+      Ketiganya menimpa pikselnya. Hanya satu di antaranya yang tidak
+      meninggalkan apa pun.
+    </p>
+    <h3>Isian hitam</h3>
+    <p>
+      Setiap piksel di dalam kotaknya menjadi warna yang sama. Tidak ada apa pun
+      tentang yang tadinya ada di sana yang selamat: bukan sebuah siluet, bukan
+      sebuah kecerahan rata-rata, bukan jumlah karakternya, bukan panjang katanya.
+      Ia satu-satunya dari ketiganya yang pertanyaan &ldquo;bisakah ini
+      diurungkan?&rdquo;-nya berjawab tidak secara datar, dan itulah yang dipakai
+      untuk sebuah nama, alamat, nomor rekening, pelat nomor, tanda tangan, atau
+      barcode.
+    </p>
+    <h3>Pikselasi</h3>
+    <p>
+      Kotaknya dipotong menjadi blok dan setiap blok menjadi warna rata-rata blok
+      itu. Piksel aslinya memang sungguh hilang &mdash; tapi kisi berisi
+      rata-rata tetaplah sebuah pengukuran atas apa yang ada di bawahnya, dan
+      untuk teks pengukuran itu bisa cukup.
+    </p>
+    <p>
+      Serangannya tidak halus. Teks digambar dari sekumpulan kecil kemungkinan:
+      sebuah fon, sebuah ukuran, sebuah posisi, dan sebuah teks. Orang yang
+      menduga jenis hal apa yang tadinya ada di sana bisa menggambar setiap
+      kandidat teks dengan cara yang sama, memikselasi masing-masing dengan kisi
+      blok yang sama, lalu membandingkan rata-ratanya dengan punya Anda.
+      Kecocokannya biasanya tunggal. Ini sudah diperagakan pada tangkapan layar
+      terpikselasi yang sungguhan, dan ada perangkat lunak terbit yang
+      melakukannya.
+    </p>
+    <p>
+      Yang menentukan adalah <strong>berapa banyak blok yang menyusun
+      mosaiknya</strong>. Dua blok melintasi sebuah kata adalah dua angka, dan dua
+      angka tidak bisa mengenali sebuah teks. Empat puluh blok melintasi kata yang
+      sama adalah empat puluh angka, dan empat puluh sudah lebih dari cukup.
+      Itulah sebabnya Penyensor Gambar memberi tahu Anda jumlah blok untuk mosaik
+      terhalus di gambarnya alih-alih menyebut sebuah setelan
+      &ldquo;kuat&rdquo; &mdash; angkanya adalah faktanya, dan kata sifatnya
+      adalah pendapat tentangnya.
+    </p>
+    <h3>Buram</h3>
+    <p>
+      Setiap piksel menjadi rata-rata terbobot dari tetangganya. Itu sebuah
+      konvolusi, dan konvolusi pada prinsipnya bisa dibalik: memulihkan aslinya
+      dari salinan yang diburamkan adalah masalah baku dengan perangkat lunak
+      baku, dan ia paling berhasil justru pada kasus yang penting di sini, yaitu
+      teks tajam yang diburamkan dengan radius kecil.
+    </p>
+    <p>
+      Tidak satu pun dari ini membuat pikselasi dan pemburaman tak berguna. Wajah
+      di latar belakang foto jalanan, nomor rumah di seberang jalan, layar rekan
+      kerja di belakang Anda pada sebuah panggilan video &mdash; semua itu
+      baik-baik saja, dan mereka menjaga gambarnya tetap tampak seperti gambar.
+      Aturannya sederhana saja: <strong>kalau ia terbaca sebagai teks,
+      hitamkan.</strong>
+    </p>
+  </section>
+
+  <section>
+    <h2>Empat pemeriksaan sebelum Anda mengirimnya</h2>
+    <p>
+      Semuanya bersama-sama memakan satu menit dan mereka bekerja pada keluaran
+      alat mana pun, termasuk yang ini. Klaim yang bisa Anda periksa lebih
+      berharga daripada klaim yang Anda diminta menerimanya.
+    </p>
+    <ol>
+      <li>
+        <strong>Coba pilih teksnya.</strong> Buka file-nya lalu seret melintasi
+        area yang tertutup. Kalau ada yang tersorot, teksnya masih ada di
+        dokumennya dan Anda sedang melihat sebuah bentuk yang digambar di
+        atasnya.
+      </li>
+      <li>
+        <strong>Buka di sebuah penyunting lalu cari lapisan.</strong> Satu
+        lapisan, bernama sesuatu seperti &ldquo;Background&rdquo;, itulah rupa
+        gambar yang disensor. Objek persegi yang terpisah berarti aslinya ada di
+        bawahnya.
+      </li>
+      <li>
+        <strong>Lihat gambar mininya.</strong> Sebagian pengelola file dan
+        penampil foto menampilkan gambar mini yang tersemat alih-alih membaca
+        ulang gambarnya. Kalau versi kecilnya masih menampilkan yang Anda tutupi,
+        file-nya disunting alih-alih dibangun ulang.
+      </li>
+      <li>
+        <strong>Perbesar sampai maksimal di tepi kotaknya.</strong> Penyensoran
+        yang diterapkan pada pikselnya punya tepi keras tepat di batasnya. Tepi
+        yang lembut atau setengah tembus pandang berarti sesuatu digambar di atas
+        gambarnya dengan sebuah kelegapan, dan kelegapan di bawah 100% adalah
+        salinan aslinya dengan semburat di atasnya.
+      </li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Pangkas alih-alih tutupi, kalau bisa</h2>
+    <p>
+      Kalau hal yang Anda sembunyikan ada di tepi gambarnya &mdash; sebuah header
+      berisi nama akun, sebuah tab peramban, sebuah bilah tugas berisi nama
+      pengguna Anda &mdash; memangkasnya lebih kuat daripada menutupinya dan
+      menghasilkan file yang tampak lebih bersih. Tidak ada kotak yang perlu
+      dicurigai karena sama sekali tidak ada apa pun di sana.
+    </p>
+    <p>
+      <a href="../../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a> memangkas,
+      dan <a href="../ubah-ukuran-gambar/">panduannya</a> membahas apa lagi yang
+      dilakukannya. Pakai penyensornya untuk yang ada di tengah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tangkapan layar sering jadi pelanggar terburuk</h2>
+    <p>
+      Gambarnya biasanya bukan satu-satunya hal di sebuah tangkapan layar yang
+      mengenali Anda. Sebelum mengirim satu, lihat apa yang mengelilingi bagian
+      yang Anda maksud untuk dibagikan: judul jendelanya, bilah alamat peramban
+      dan daftar pelengkapan otomatisnya, tab yang terbuka, sebuah notifikasi, jam
+      dan tanggalnya, bilah tugasnya, avatar akun yang masuk di sudutnya, nama
+      jaringan wifinya. Satu saja di antaranya bisa menempatkan Anda, dan tidak
+      satu pun dari mereka yang sedang Anda lihat ketika Anda mengambil
+      bidikannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Membaca sebuah gambar, menulis di atas sebagian pikselnya, lalu
+      mengodekannya lagi adalah hal-hal yang sudah bisa dilakukan setiap peramban
+      bertahun-tahun. Tidak ada alasan teknis bagi foto paspor Anda, slip gaji
+      Anda, atau rekening koran Anda untuk bepergian ke server orang asing dan
+      kembali hanya untuk diberi kotak hitam &mdash; dan justru gambar seperti
+      itulah yang diserahkan orang ke sebuah alat penyensor.
+    </p>
+    <p>
+      Alat di sini tidak mengirimnya ke mana pun:
+      <code>Content-Security-Policy</code> halamannya menyebut satu per satu
+      setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+      Muat halamannya, cabut koneksi internet, lalu sensor sesuatu kalau Anda
+      lebih suka memeriksa daripada diberi tahu.
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain yang bisa Anda
+      jalankan pada alat mana pun.
+    </p>
+  </section>

--- a/locales/id/pages/guides/redact-an-image.toml
+++ b/locales/id/pages/guides/redact-an-image.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: menyensor sebuah gambar - Bahasa Indonesia.
+#
+
+nav = "Menyensor sebuah gambar"
+title = "Cara Menyensor Gambar Supaya Bagian yang Disembunyikan Sungguh Hilang"
+description = "Kotak hitam yang digambar di kebanyakan program duduk di atas gambarnya dan bisa digeser. Apa yang membedakan penyensoran sungguhan dari penutupan, kenapa teks yang dipikselasi bisa dibaca kembali, dan bagaimana memeriksa sebuah file sebelum Anda mengirimnya."
+
+heading = "Cara menyensor gambar supaya bagian yang disembunyikan sungguh hilang"
+lede = """
+    Menutupi sesuatu dan membuangnya tampak identik di layar dan sama sekali
+    bukan hal yang sama. Inilah bedanya, dua gaya yang meninggalkan lebih banyak
+    daripada dugaan orang, dan pemeriksaan yang memberi tahu Anda Anda baru saja
+    melakukan yang mana dari keduanya."""
+
+updated = "23 Agustus 2026"
+
+og_title = "Cara menyensor gambar supaya bagian yang disembunyikan sungguh hilang"
+og_description = "Kenapa persegi hitam biasanya bukan penyensoran, kenapa teks yang dipikselasi bisa dibaca kembali, dan bagaimana memeriksa sebuah file sebelum Anda mengirimnya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/remove-exif-and-gps-data.html
+++ b/locales/id/pages/guides/remove-exif-and-gps-data.html
@@ -1,0 +1,229 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../hapus-data-exif/">Penampil &amp; Penghapus EXIF</a>,
+      jatuhkan fotonya, lalu tekan &ldquo;Hapus semua metadata&rdquo;. Setiap
+      tag, blok XMP dan IPTC-nya, komentarnya, dan gambar mini yang tersemat
+      hilang, pada setiap foto di daftarnya sekaligus. Gambarnya sendiri tidak
+      tersentuh &mdash; tidak dikompres ulang, tidak didekodekan, tidak berubah
+      satu piksel pun.
+    </p>
+    <p>
+      Sebelum Anda melakukan itu, layak dilihat apa yang tadinya ada di dalamnya.
+      Biasanya lebih banyak daripada dugaan orang, dan daftar itulah alasan untuk
+      melakukan ini sama sekali.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa sebenarnya yang ada di dalam sebuah foto</h2>
+    <p>
+      Sebuah JPEG bukan sekadar gambar terkompres. Ia sebuah wadah, dan di
+      sebelah gambarnya duduk beberapa blok informasi yang ditulis kamera,
+      ponsel, atau penyunting Anda di sana.
+    </p>
+    <ul>
+      <li>
+        <strong>EXIF.</strong> Yang utama. Merek dan model kamera, lensa,
+        setelan pencahayaan, ISO, tanggal dan waktunya sampai ke detik,
+        orientasi yang seharusnya dipakai menampilkan gambarnya, dan &mdash; di
+        ponsel yang layanan lokasinya menyala untuk kameranya &mdash; posisi GPS
+        yang akurat sampai beberapa meter. Sering kali juga nomor seri bodi
+        kameranya.
+      </li>
+      <li>
+        <strong>GPS.</strong> Secara teknis bagian dari EXIF, dan layak
+        disebutkan tersendiri karena inilah yang paling penting. Ia ditulis dalam
+        derajat, menit, dan detik, dan itu format yang sangat berhasil membuat
+        dirinya tidak tampak seperti sebuah alamat.
+      </li>
+      <li>
+        <strong>XMP.</strong> Sebuah paket XML yang ditulis penyunting. Ia bisa
+        membawa nama Anda, perangkat lunak Anda, peringkat, kata kunci, riwayat
+        suntingan, dan salinan sebagian kolom EXIF-nya &mdash; dan itulah
+        sebabnya menghapus EXIF saja tidak cukup.
+      </li>
+      <li>
+        <strong>IPTC.</strong> Blok yang lebih tua berisi kolom keterangan,
+        nama penulis, kredit, dan hak cipta, dipakai di dunia pers dan fotografi
+        stok.
+      </li>
+      <li>
+        <strong>Gambar mini yang tersemat.</strong> Salinan kedua yang kecil dari
+        gambarnya. Ia dihasilkan ketika file-nya ditulis, dan ia tidak selalu
+        dihasilkan ulang ketika gambarnya disunting &mdash; dan begitulah foto
+        yang sudah dipangkas bisa bepergian dengan gambar mini berisi apa yang
+        dipangkas keluar.
+      </li>
+      <li>
+        <strong>Maker note.</strong> Blok data pabrikan yang tidak
+        didokumentasikan. Tidak ada orang di luar pabrikannya yang tahu semua
+        yang ada di dalamnya.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Siapa yang sebenarnya melihatnya</h2>
+    <p>
+      Inilah bagian yang layak diuraikan dengan akurat, karena baik versi yang
+      panik maupun versi yang meremehkan sama-sama keliru.
+    </p>
+    <p>
+      <strong>Kebanyakan jejaring sosial besar membersihkan metadata ketika Anda
+      mengunggah.</strong> Facebook, Instagram, dan X mengodekan ulang gambar yang
+      diunggah lalu membuang tagnya dalam prosesnya. Ini bukan kebaikan hati
+      &mdash; mereka menyimpan datanya di pihak mereka &mdash; tapi memang
+      artinya foto yang diunggah ke layanan itu tidak menyerahkan koordinatnya
+      kepada setiap penonton.
+    </p>
+    <p>
+      <strong>Hampir semua yang lain menyimpannya.</strong> Lampiran email. File
+      yang dikirim lewat kebanyakan aplikasi obrolan sebagai
+      &ldquo;dokumen&rdquo; alih-alih sebagai foto. Gambar di sebuah forum, di
+      sebuah iklan lapak jual beli, di situs pribadi, di drive bersama, di
+      laporan bug, di tiket dukungan. Di semua itu file-nya tiba utuh, dan siapa
+      pun yang mengunduhnya bisa membaca tagnya dengan alat yang sudah dibawa
+      sistem operasi mereka.
+    </p>
+    <p>
+      Risiko yang realistis itu biasa saja alih-alih dramatis: iklan lapak jual
+      beli yang difoto di rumah, gambar seorang anak yang diambil di sekolahnya,
+      akun yang tampaknya anonim yang mengunggah foto-foto yang semuanya berbagi
+      satu nomor seri kamera, sebuah &ldquo;diambil minggu lalu&rdquo; yang
+      ternyata diambil bulan Maret.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa tidak simpan ulang saja?</h2>
+    <p>
+      Menyimpan ulang sebuah foto lewat sebuah penyunting atau kompresor memang
+      membuang metadatanya &mdash; gambarnya didekodekan menjadi piksel lalu
+      dikodekan lagi, dan kanvas yang penuh piksel tidak membawa tag. Itu
+      bekerja, dan itu mengorbankan kualitas Anda, karena pengodean ulang itu
+      merugikan.
+    </p>
+    <p>
+      Membuang metadatanya dengan benar sama sekali tidak berbiaya. Tagnya duduk
+      di dalam wadah <em>di sekeliling</em> gambar terkompresnya, bukan di
+      dalamnya, jadi membersihkannya berarti menghapus entri dari sebuah daftar
+      lalu menuliskan daftar itu kembali. Data gambar terkompresnya disalin byte
+      demi byte dan hasilnya terdekodekan menjadi piksel yang persis sama. Itulah
+      seluruh alasan memakai alat metadata alih-alih sebuah pengubah.
+    </p>
+    <p>
+      Pengecualiannya adalah kalau Anda toh akan mengodekan ulang. Kalau Anda
+      memang sedang mengompres atau mengubah ukuran fotonya, tagnya hilang
+      sebagai efek samping dan Anda tidak butuh langkah kedua.
+    </p>
+  </section>
+
+  <section>
+    <h2>Satu hal yang perlu disimpan: orientasi</h2>
+    <p>
+      Ponsel tidak memutar gambarnya ketika Anda memutar ponselnya. Mereka
+      merekamnya sebagaimana sensornya melihatnya lalu menambahkan tag Orientation
+      yang mengatakan bagaimana ia harus diputar untuk ditampilkan. Bersihkan
+      setiap tag dan sebagian penampil akan menampilkan foto Anda miring.
+    </p>
+    <p>
+      Itulah sebabnya alat di sini punya pilihan &ldquo;simpan tag
+      orientasinya&rdquo;, yang menyala secara bawaan. Ia menulis kembali sebuah
+      blok EXIF mungil berisi satu tag itu dan tidak lebih, dan hanya untuk foto
+      yang memang membutuhkannya. GPS-nya, cap waktunya, nomor serinya, dan
+      sisanya tetap hilang.
+    </p>
+    <p>
+      Matikan kalau Anda lebih suka file-nya sama sekali tidak membawa EXIF
+      &mdash; lalu periksa hasilnya sebelum Anda mengirimnya, karena foto yang
+      miring adalah akibat yang biasa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Menyunting alih-alih membuang</h2>
+    <p>
+      Membuang semuanya adalah jawaban yang benar untuk kebanyakan orang. Kadang
+      tidak: seorang fotografer mungkin ingin baris hak cipta dan setelan
+      kameranya tetap ada dan hanya lokasinya yang hilang; seorang arsiparis
+      mungkin perlu membetulkan tanggal yang keliru karena jam kameranya yang
+      keliru.
+    </p>
+    <p>
+      Keduanya mungkin. Lokasinya bisa dihapus sendirian, dan tag teks, tanggal,
+      ISO, orientasi, serta resolusinya bisa disunting di tempat.
+    </p>
+    <p>
+      Satu catatan yang berlaku untuk setiap alat yang melakukan ini, bukan hanya
+      yang ini: menulis file-nya membangun ulang blok EXIF-nya, dan sebuah maker
+      note memuat offset ke dalam blok <em>aslinya</em>. Maker note yang dibangun
+      ulang karena itu bisa jadi tidak lagi terbaca oleh perangkat lunak milik
+      pabrikannya sendiri. Kalau itu penting, hapus maker note-nya atau biarkan
+      file-nya tidak disunting.
+    </p>
+  </section>
+
+  <section>
+    <h2>Format, dan yang tidak bisa dikerjakan dengan cara ini</h2>
+    <p>
+      JPEG, PNG, dan WebP semuanya bisa ditulis ulang dengan bersih, dan ketiga
+      itulah yang ditangani alat di sini.
+    </p>
+    <p>
+      HEIC &mdash; yang disimpan iPhone secara bawaan &mdash; dan AVIF adalah
+      format wadah yang dibangun dari atom bersarang, dan butuh pembaca yang
+      sama sekali berbeda. Alatnya mengenalinya lalu mengatakannya alih-alih
+      menghasilkan file yang rusak. Kalau Anda punya sebuah HEIC, mengubahnya
+      menjadi JPEG akan membuang metadatanya sebagai efek samping pengubahannya.
+    </p>
+    <p>
+      TIFF telanjang juga tidak ditangani, dan karena alasan yang lebih menarik:
+      di sebuah TIFF, metadata dan data pikselnya dialamati oleh offset yang
+      sama, jadi membuang tagnya berarti menulis ulang pengalamatan gambarnya
+      sendiri. Itu bisa dilakukan dan itu pekerjaan yang berbeda.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kebiasaan yang layak dipunyai</h2>
+    <p>
+      Periksa sebelum Anda mengunggah alih-alih sesudahnya. Membaca tagnya
+      memakan beberapa detik dan daftar temuannya menyebutkan hal-hal yang layak
+      diketahui &mdash; posisinya, cap waktunya, nomor serinya &mdash; sebelum
+      tabel lengkap setiap tagnya, jadi Anda tidak perlu tahu apa yang harus
+      dicari.
+    </p>
+    <p>
+      Posisinya ditampilkan dalam derajat desimal lebih dulu, dengan sengaja.
+      &ldquo;51 derajat, 30 menit, 26 detik&rdquo; tidak membuatnya jelas bahwa
+      sebuah foto menyebutkan bangunan tempat ia diambil. Sepasang bilangan
+      desimal yang bisa Anda tempelkan ke sebuah peta membuatnya jelas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Jangan mengunggah fotonya untuk mencari tahu apa isinya</h2>
+    <p>
+      Ada ironi khas pada cara masalah ini biasa diselesaikan: seseorang yang
+      khawatir tentang apa yang diungkapkan fotonya mengunggahnya ke sebuah situs
+      web untuk mencari tahu. Situs itu kini punya fotonya, koordinatnya, cap
+      waktunya, dan nomor serinya, plus salinan gambarnya di sebuah disk milik
+      mereka.
+    </p>
+    <p>
+      Tidak ada alasan untuk itu. Membaca dan menulis ulang wadah di sekeliling
+      sebuah JPEG adalah beberapa ratus baris pembacaan yang bisa dijalankan
+      sebuah peramban dengan sangat baik, dan itulah sebabnya alat di sini sama
+      sekali tidak punya fitur jaringan: tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, tidak ada apa pun yang bisa mengirim sebuah
+      file bahkan seandainya ada yang mencoba. Muat sekali, putuskan koneksi, dan
+      ia terus bekerja.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan cara memeriksa klaim itu di situs ini atau
+      di mana pun lain &mdash; dan inilah jenis file yang paling layak
+      diperiksa.
+    </p>
+  </section>

--- a/locales/id/pages/guides/remove-exif-and-gps-data.toml
+++ b/locales/id/pages/guides/remove-exif-and-gps-data.toml
@@ -1,0 +1,21 @@
+#
+# Panduan: menghapus data EXIF dan GPS - Bahasa Indonesia.
+#
+
+nav = "Data EXIF dan GPS"
+title = "Cara Menghapus Data EXIF dan GPS dari Sebuah Foto"
+description = "Foto dari sebuah ponsel biasanya membawa titik persis tempat ia diambil, waktunya sampai ke detik, dan nomor seri kameranya. Apa saja yang ada di dalamnya, siapa yang bisa membacanya, dan bagaimana mengeluarkannya tanpa menyentuh gambarnya."
+
+heading = "Apa yang dikatakan sebuah foto tentang Anda, dan bagaimana mengeluarkannya"
+lede = """
+    Gambar yang langsung dari sebuah ponsel biasanya membawa koordinat tempat ia
+    diambil, waktunya sampai ke detik, dan cukup banyak tentang kameranya untuk
+    mengaitkannya dengan setiap foto lain dari perangkat yang sama. Tidak satu
+    pun terlihat di layar. Inilah apa saja yang ada di dalamnya dan bagaimana
+    membuangnya."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Apa yang dikatakan sebuah foto tentang Anda, dan bagaimana mengeluarkannya"
+og_description = "Koordinat GPS, cap waktu, dan nomor seri bepergian di dalam foto biasa. Apa saja yang ada di dalamnya, siapa yang bisa membacanya, dan bagaimana membersihkannya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/resize-an-image.html
+++ b/locales/id/pages/guides/resize-an-image.html
@@ -1,0 +1,251 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a>,
+      jatuhkan gambar Anda, ketik satu angka &mdash; lebarnya, biasanya &mdash;
+      lalu biarkan yang satunya kosong. Tingginya mengikuti bentuk gambarnya, dan
+      itu hampir selalu yang dimaksudkan: &ldquo;lebar 1920&rdquo; berarti
+      &ldquo;lebar 1920 dan setinggi apa pun yang dihasilkannya&rdquo;.
+    </p>
+    <p>
+      Semua di bawah ini adalah apa yang dilakukan ketika satu angka tidak cukup:
+      ketika Anda diberi sebuah kotak dengan dua sisi, ketika gambarnya harus
+      menjadi lebih besar, atau ketika satu folder penuh file harus keluar sama
+      semua.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mengecilkan itu aman. Membesarkan tidak.</h2>
+    <p>
+      Keduanya bukan dua arah dari operasi yang sama, dan layak dinyatakan dengan
+      jelas kenapa.
+    </p>
+    <p>
+      <strong>Membuat sebuah gambar lebih kecil</strong> membuang informasi, dan
+      dalam satu-satunya makna yang jinak: ada lebih banyak piksel yang masuk
+      daripada yang keluar, jadi setiap piksel hasilnya dirata-ratakan dari detail
+      terukur yang nyata. Salinan yang dikecilkan dengan baik biasanya tampak
+      <em>lebih baik</em> daripada aslinya yang dilihat pada ukuran itu, karena
+      perataannya menghilangkan derau. Tidak ada yang dikarang.
+    </p>
+    <p>
+      <strong>Membuat sebuah gambar lebih besar</strong> harus mengarang.
+      Detailnya bukan hilang dari file-nya; ia tidak pernah difoto. Yang bisa
+      dilakukan pembesar mana pun hanyalah menebak piksel antara dari tetangganya,
+      dan tebakan di antara dua nilai yang diketahui adalah sebuah landaian yang
+      mulus &mdash; dan itulah sebabnya foto yang dibesarkan tampak lembek
+      alih-alih tajam. Ia salinan yang lebih besar dari gambar yang sama, bukan
+      gambar yang lebih rinci.
+    </p>
+    <p>
+      Itulah sebabnya &ldquo;jangan pernah membuat gambar lebih besar daripada
+      saat ia mulai&rdquo; menyala secara bawaan di alat ini. Matikan kalau Anda
+      memang sungguh butuh jumlah pikselnya &mdash; sebuah percetakan yang meminta
+      ukuran minimum, sebuah templat yang menolak apa pun di bawah suatu lebar
+      &mdash; tapi lakukan dengan tahu bahwa Anda membeli piksel, bukan detail.
+    </p>
+    <p>
+      Pembesar berbasis pembelajaran mesin yang memang tampak menambahkan detail
+      adalah hal yang sama sekali berbeda: mereka mengarang tekstur yang masuk
+      akal dari sebuah model tentang bagaimana gambar biasanya terlihat. Untuk
+      sebuah wallpaper itu tidak masalah. Untuk foto seseorang, sebuah dokumen,
+      atau apa pun yang akan ditarik kesimpulan darinya oleh siapa pun, pahami
+      bahwa detail tambahannya adalah fiksi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tiga cara menyebutkan ukuran yang Anda mau</h2>
+    <p>
+      Kebanyakan alat, termasuk yang ini, menerima ketiga yang sama, dan mereka
+      cocok untuk pekerjaan yang berbeda.
+    </p>
+    <ul>
+      <li>
+        <strong>Piksel yang tepat.</strong> Pakai ini ketika seseorang sudah
+        menyebutkan angkanya: avatar yang harus 400&times;400, spanduk yang harus
+        lebar 1500. Isi satu sisinya lalu biarkan yang lain mengikuti kecuali Anda
+        diberi keduanya.
+      </li>
+      <li>
+        <strong>Sebuah persentase.</strong> Pakai ini ketika Anda ingin semuanya
+        mengecil secara sebanding dan tidak peduli angka persisnya &mdash;
+        &ldquo;setengah ukuran&rdquo; untuk sekumpulan foto yang akan masuk ke
+        sebuah dokumen.
+      </li>
+      <li>
+        <strong>Sisi terpanjang.</strong> Yang paling berguna dari ketiganya untuk
+        kumpulan yang campur aduk. &ldquo;Sisi terpanjang 1600&rdquo; membuat
+        setiap gambar muat di dalam persegi 1600 piksel entah ia potret entah
+        lanskap, dan itulah yang biasanya dimaksud dengan &ldquo;buat semuanya
+        seukuran yang masuk akal&rdquo; pada praktiknya.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Ketika kotaknya berbeda bentuk dari gambarnya</h2>
+    <p>
+      Di sinilah pengubahan ukuran sebenarnya ditentukan. Kalau Anda memberi
+      lebar sekaligus tinggi dan keduanya tidak sesuai proporsi gambar Anda,
+      sesuatu harus mengalah, dan tepat ada empat hal yang bisa:
+    </p>
+    <ul>
+      <li>
+        <strong>Muat di dalam kotaknya.</strong> Seluruh gambarnya disimpan dan
+        keluar lebih kecil daripada kotaknya di salah satu sumbunya. Tidak ada
+        yang hilang dan tidak ada yang melenceng; Anda hanya tidak mendapat
+        dimensi persis yang Anda minta. Inilah bawaan yang benar untuk hampir
+        semuanya.
+      </li>
+      <li>
+        <strong>Isi kotaknya lalu potong kelebihannya.</strong> Anda mendapat
+        persis dimensi yang Anda minta, dan bagian gambar yang menjuntai di luar
+        tepinya hilang. Benar untuk gambar mini, avatar, dan sampul, tempat
+        bentuknya tetap dan subjeknya di tengah. Keliru ketika hal yang penting
+        berada dekat sebuah tepi.
+      </li>
+      <li>
+        <strong>Isi sisanya.</strong> Seluruh gambarnya disimpan, diletakkan di
+        tengah, dengan ruang sisanya diisi warna yang Anda pilih. Benar ketika
+        sebuah sistem menuntut dimensi yang tepat dan Anda tidak boleh kehilangan
+        bagian mana pun dari gambarnya &mdash; iklan produk sering bekerja begitu.
+      </li>
+      <li>
+        <strong>Regangkan.</strong> Gambarnya dijepit atau ditarik supaya muat.
+        Ini tidak pernah menjadi yang Anda mau kecuali Anda melakukannya dengan
+        sengaja, dan inilah yang langsung dikenali semua orang sebagai keliru.
+      </li>
+    </ul>
+    <p>
+      Kalau Anda mendapati diri Anda menjangkau peregangan, yang mungkin Anda mau
+      adalah pemangkasan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memangkas adalah pekerjaan yang berbeda, dan sering kali yang benar</h2>
+    <p>
+      Mengubah ukuran mengubah berapa banyak piksel yang menggambarkan seluruh
+      gambarnya. Memangkas mengubah bagian mana dari gambarnya yang Anda simpan.
+      Orang menjangkau yang pertama padahal maksudnya yang kedua secara
+      mengejutkan sering &mdash; &ldquo;ini harus persegi&rdquo; adalah masalah
+      pemangkasan, bukan pengubahan ukuran.
+    </p>
+    <p>
+      Kerjakan dalam urutan itu: pangkas ke pembingkaian yang Anda mau lebih dulu,
+      lalu ubah ukuran hasilnya ke ukuran yang Anda butuhkan. Melakukannya
+      terbalik berarti memilih pangkasannya dari gambar yang sudah kehilangan
+      piksel.
+    </p>
+    <p>
+      Alat di sini mengerjakan keduanya dalam satu jalan karena alasan itu
+      &mdash; seret sebuah kotak, kunci ke sebuah bentuk kalau Anda butuh rasio
+      tertentu, lalu sebutkan hasilnya harus keluar seukuran apa. Mengerjakannya
+      dalam satu jalan juga berarti gambarnya hanya dikodekan sekali, dan itu
+      penting karena alasan di bagian berikutnya.
+    </p>
+    <h3>Memangkas satu kumpulan penuh</h3>
+    <p>
+      Kotak yang digambar pada satu gambar diterapkan ke sisanya sebagai area
+      <em>relatif</em> yang sama: pecahan yang sama dari lebar dan tinggi setiap
+      file-nya sendiri. Untuk satu folder tangkapan layar atau hasil ekspor yang
+      semuanya seukuran, itu persis persegi panjang yang sama. Untuk kumpulan yang
+      campur aduk, itu pembingkaian yang sama alih-alih persegi panjang yang sama,
+      dan itu biasanya yang dimaksudkan tapi layak diketahui sebelum Anda
+      memercayainya dengan lima puluh file.
+    </p>
+  </section>
+
+  <section>
+    <h2>Berapa harga pengodean ulangnya, dan bagaimana menjaganya tetap satu</h2>
+    <p>
+      Mengubah ukuran sebuah JPEG atau WebP berarti mendekodekannya, menskalakan
+      pikselnya, lalu mengodekannya lagi &mdash; dan langkah terakhir itu
+      merugikan. Penskalaannya sendiri bukan yang mengorbankan kualitas Anda;
+      pengodean ulangnyalah.
+    </p>
+    <p>
+      Dua hal mengikuti dari itu. Pertama, setelan kualitas di jalan keluarnya
+      penting: sekitar 80&ndash;85 tak terlihat untuk sebuah foto dan jauh lebih
+      kecil daripada 100. Kedua, kerjakan sekali. Mengubah ukuran gambar yang
+      sudah dua kali diubah ukurannya berarti tiga generasi pengodean yang
+      merugikan, dan itu kelihatan.
+    </p>
+    <p>
+      PNG tidak punya ongkos seperti itu, karena ia tanpa kehilangan &mdash; PNG
+      yang diubah ukurannya persis piksel yang sudah diskalakan. Kalau Anda
+      bekerja melalui beberapa langkah dan format akhirnya belum diputuskan,
+      bekerja dalam PNG di tengah-tengah menghindari penumpukan generasi.
+    </p>
+    <p>
+      Satu detail yang layak diketahui tentang alat di sini: file yang sebenarnya
+      sama sekali tidak Anda ubah diserahkan kembali byte demi byte alih-alih
+      dikodekan ulang. Minta &ldquo;sisi terpanjang 1600&rdquo; pada sebuah
+      kumpulan dan yang sudah di bawah 1600 keluar tanpa disentuh, lengkap dengan
+      tagnya. Alat yang diam-diam mengodekan ulang mereka akan mengorbankan
+      kualitas Anda pada file yang tidak diminta siapa pun untuk diubah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Transparansi, dan apa yang terjadi padanya</h2>
+    <p>
+      PNG dan WebP bisa menyimpan transparansi. JPEG tidak &mdash; sama sekali
+      tidak ada kanal alfa di formatnya. Jadi menyimpan gambar transparan sebagai
+      JPEG harus menaruh sesuatu di belakangnya, dan sesuatu itu adalah warna
+      datar.
+    </p>
+    <p>
+      Kebanyakan alat memakai putih dan tidak menyebutkannya, dan itu tidak
+      masalah sampai logo Anda mendarat di halaman gelap dengan kotak putih di
+      sekelilingnya. Pilih warnanya dengan sengaja, atau simpan sebagai PNG atau
+      WebP lalu simpan transparansinya. Warna yang sama dipakai di belakang
+      bingkai yang diisi, dan itulah tempat lain orang menjumpai ini secara tak
+      terduga.
+    </p>
+  </section>
+
+  <section>
+    <h2>Alat yang mana, kalau Anda diberi sebuah angka</h2>
+    <p>
+      Dua angka yang berbeda dibagikan orang, dan keduanya butuh alat yang
+      berbeda.
+    </p>
+    <p>
+      <strong>&ldquo;Lebar 1200 piksel&rdquo;</strong> adalah masalah dimensi.
+      <a href="../../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a> itulah
+      alatnya: Anda sebutkan berapa piksel yang Anda mau dan ia memberikannya.
+    </p>
+    <p>
+      <strong>&ldquo;Di bawah 500&nbsp;KB&rdquo;</strong> adalah masalah ukuran
+      file, dan mengubah ukuran hanya salah satu cara menyelesaikannya.
+      <a href="../../kompres-gambar/">Kompresor Gambar</a> mencari kualitas
+      tertinggi yang muat di sasaran Anda dan mengubah ukurannya hanya kalau
+      kualitas sendiri tidak sanggup sampai ke sana;
+      <a href="../kompres-gambar-ke-ukuran-tertentu/">panduannya</a> membahas
+      berapa harganya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Mendekodekan sebuah gambar, menskalakannya, lalu mengodekannya lagi adalah
+      hal-hal yang sudah bisa dilakukan setiap peramban bertahun-tahun &mdash; ia
+      mesin yang sama yang dipakai sebuah halaman web untuk menggambar sebuah
+      gambar pada ukuran yang berbeda. Tidak ada alasan teknis bagi foto Anda
+      untuk bepergian ke sebuah server dan kembali supaya ia keluar lebih kecil,
+      dan alat di sini tidak mengirimnya ke mana pun:
+      <code>Content-Security-Policy</code> halamannya menyebut satu per satu
+      setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+    </p>
+    <p>
+      Muat halamannya, cabut koneksi internet, lalu ubah ukuran sesuatu kalau
+      Anda lebih suka memeriksa daripada diberi tahu.
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain yang bisa Anda
+      jalankan pada alat mana pun.
+    </p>
+  </section>

--- a/locales/id/pages/guides/resize-an-image.toml
+++ b/locales/id/pages/guides/resize-an-image.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: mengubah ukuran gambar - Bahasa Indonesia.
+#
+
+nav = "Mengubah ukuran gambar"
+title = "Cara Mengubah Ukuran Gambar Tanpa Merusaknya"
+description = "Apa yang terjadi pada sebuah gambar ketika Anda mengubah dimensi pikselnya: kenapa mengecilkan itu aman dan membesarkan tidak, apa yang dilakukan ketika kotaknya berbeda bentuk, dan kapan sebaiknya memangkas saja."
+
+heading = "Cara mengubah ukuran gambar tanpa merusaknya"
+lede = """
+    Mengubah ukuran adalah satu-satunya pekerjaan gambar yang kerusakannya
+    ditentukan sebelum Anda menekan tombolnya, oleh angka mana yang Anda ketik
+    dan bentuk mana yang Anda minta. Inilah apa yang dilakukan setiap pilihan
+    pada gambarnya, dan mana di antaranya yang bisa Anda urungkan."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Mengubah ukuran gambar tanpa merusaknya"
+og_description = "Kenapa mengecilkan itu aman dan membesarkan tidak, apa yang dilakukan ketika kotaknya berbeda bentuk, dan kapan sebaiknya memangkas saja."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/reverse-a-video.html
+++ b/locales/id/pages/guides/reverse-a-video.html
@@ -1,0 +1,197 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../putar-video-terbalik/">Pemutar Balik Video</a>,
+      jatuhkan klipnya, putuskan apakah Anda mau suaranya ikut dibalik, lalu
+      ekspor. Yang keluar adalah klip yang sama dengan bingkai terakhirnya di
+      depan, persis sepanjang yang masuk.
+    </p>
+    <p>
+      Tidak seperti pemotongan, yang ini harus menulis setiap bingkainya lagi
+      &mdash; suaranya sekalian, bukan hanya gambarnya. Itu bukan kekurangan
+      sebuah alat tertentu; itulah pembalikan. Sisa halaman ini adalah alasannya,
+      dan apa artinya bagi berapa lama Anda akan menunggu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa sebuah video tidak bisa begitu saja diputar mundur</h2>
+    <p>
+      File video bukan setumpuk gambar. Kira-kira satu bingkai dari setiap lima
+      puluh adalah gambar utuh &mdash; sebuah <em>keyframe</em> &mdash; dan semua
+      di antaranya adalah keterangan tentang apa yang berubah sejak bingkai di
+      sekitarnya. Itulah sebabnya video satu jam muat di sebuah ponsel.
+    </p>
+    <p>
+      Itu juga berarti sebuah dekoder hanya bisa maju. Untuk menampilkan bingkai
+      terakhir sebuah klip, ia harus menemukan keyframe di depannya lalu
+      mendekodekan semua yang ada di antaranya. Minta bingkai kedua dari
+      belakang dan ia mengerjakan pekerjaan yang sama sekali lagi.
+    </p>
+    <p>
+      Jadi pembalikan dikerjakan segrup demi segrup: dekodekan satu grup maju,
+      tahan bingkainya, serahkan ke pengode dalam urutan sebaliknya, pindah ke
+      grup sebelumnya. Alternatif yang gamblang &mdash; dekodekan seluruh klipnya
+      menjadi sebuah daftar lalu susuri daftar itu mundur &mdash; butuh sekitar
+      3&nbsp;MB memori per bingkai 1080p, atau 5&nbsp;GB per menit, dan itulah
+      sebabnya alat yang melakukannya begitu tumbang pada apa pun yang lebih
+      panjang dari beberapa detik.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang terjadi pada suaranya</h2>
+    <p>
+      Di sinilah alat pembalik paling berbeda satu sama lain, dan di sinilah
+      layak diperiksa apa yang sebenarnya Anda dapatkan.
+    </p>
+    <p>
+      Suara dikompres dalam paket berdurasi beberapa puluh milidetik,
+      masing-masing dikodekan terhadap paket sebelumnya. Menuliskan paket itu
+      dari belakang ke depan <em>tidak</em> memutar sebuah trek mundur &mdash; ia
+      memutar potongan-potongan pendek maju dalam urutan yang salah, dan itu
+      terdengar seperti tersendat atau rusak alih-alih seperti pembalikan.
+      Satu-satunya cara membalik suara dengan benar adalah mendekodekan seluruh
+      treknya, menaruh sampelnya dalam urutan sebaliknya, lalu mengodekannya
+      lagi.
+    </p>
+    <p>
+      Itulah yang terjadi di sini, dan itulah sebabnya suaranya dikodekan ulang
+      padahal <a href="../../potong-video/">Pemotong Video</a> dan
+      <a href="../../pangkas-video/">Pemangkas Video</a> tidak pernah
+      menyentuhnya: pekerjaan itu tidak mengubah <em>kapan</em> sesuatu terjadi,
+      dan yang ini tidak mengubah apa pun selain itu.
+    </p>
+    <p>
+      Kalau Anda mau gambarnya mundur dan tanpa suara sama sekali &mdash; dan
+      itulah pilihan yang biasa untuk apa pun yang akan masuk ke lini masa yang
+      memutar tanpa suara &mdash; matikan kotak centangnya. Ia lebih cepat, dan
+      file-nya lebih kecil.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang dikorbankan dari gambarnya</h2>
+    <p>
+      Satu kali pengodean ulang. Bingkainya keluar dalam urutan yang tidak
+      dikodekan oleh apa pun di file aslinya, jadi masing-masing harus ditulis
+      dari awal.
+    </p>
+    <p>
+      Yang tidak akan dilakukan alat yang tahu diri adalah menghabiskan
+      <em>lebih</em> daripada yang dihabiskan aslinya. Klip yang dibalik
+      menyimpan persis gambar yang sama dengan klip yang datang, jadi bitrate
+      yang lebih tinggi tidak punya apa-apa yang baru untuk digambarkan: ia
+      membuat file-nya lebih besar tanpa membuatnya tampak lebih baik. Setelan
+      kualitas di sini bergerak di dalam langit-langit itu alih-alih di atasnya.
+    </p>
+    <p>
+      Seperti biasa, langkah yang merugikan itu bertumpuk. Membalik sebuah asli
+      adalah satu generasi. Membalik hasil ekspor dari sebuah unduhan dari sebuah
+      rekaman layar adalah empat, dan hasilnya kelihatan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Potong dulu, baru balik</h2>
+    <p>
+      Kalau klipnya butuh keduanya, potong lebih dulu. Pemotongan itu gratis
+      &mdash; pemotong yang baik memindahkan bingkai utuh tanpa mendekodekannya
+      &mdash; dan setiap detik yang Anda buang adalah satu detik yang tidak perlu
+      didekodekan dan dikodekan lagi oleh siapa pun.
+    </p>
+    <p>
+      Melakukannya terbalik berarti membalik rekaman yang sebentar lagi Anda
+      buang. Pada klip yang panjang, itu bedanya pekerjaan yang memakan beberapa
+      detik dengan yang memakan beberapa menit.
+      <a href="../potong-video/">Panduan pemotongan</a> membahas kenapa langkah
+      pertama itu sama sekali tidak perlu mengorbankan kualitas Anda.
+    </p>
+    <p>
+      Urutan yang sama berlaku untuk pemangkasan: potong, pangkas, balik, dan
+      Anda hanya membayar satu pengodean ulang dari klip sependek mungkin.
+    </p>
+  </section>
+
+  <section>
+    <h2>Untuk apa orang sebenarnya memakainya</h2>
+    <ul>
+      <li>
+        <strong>Gurauan putar balik.</strong> Sesuatu jatuh, pecah, atau
+        tercebur, dan pembalikan mengembalikannya. Ia terbaca sebagai lelucon
+        karena rekaman sungguhan yang diputar mundur tidak mungkin salah dikenali
+        &mdash; asap berkumpul, air memanjat.
+      </li>
+      <li>
+        <strong>Boomerang buatan sendiri.</strong> Balik sebuah klip pendek lalu
+        sambungkan ke aslinya dengan
+        <a href="../../potong-video/">Pemotong Video</a>; Anda mendapat lup
+        maju-lalu-mundur tanpa aplikasi yang biasanya membuatnya, dan sepanjang
+        yang Anda mau alih-alih sepanjang yang dimaunya.
+      </li>
+      <li>
+        <strong>Pengungkapan.</strong> Rekam keadaan akhir yang sudah rapi lalu
+        balik, sehingga sepiring hidangan jadi kembali menjadi bahan-bahannya
+        atau sesuatu yang sudah terpasang terurai. Lebih mudah direkam daripada
+        versi majunya, dan itulah intinya.
+      </li>
+      <li>
+        <strong>Ucapan terbalik.</strong> Yang hanya menarik kalau suaranya
+        sungguh dibalik &mdash; lihat di atas.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Format, dan berapa lama waktunya</h2>
+    <p>
+      <strong>MP4, M4V, dan MOV</strong> dibaca langsung, apa pun isinya &mdash;
+      H.264, HEVC, AV1, atau VP9 &mdash; selama peramban Anda bisa mendekodekan
+      kodek itu. Inilah jalur cepatnya: file-nya disusuri mundur segrup bingkai
+      demi segrup, secepat yang bisa dicapai mesin Anda.
+    </p>
+    <p>
+      <strong>Apa pun lain yang bisa diputar peramban Anda</strong>, WebM yang
+      paling jelas, dibalik dengan melangkahkan pemutar milik peramban itu
+      sendiri mundur melalui klipnya, satu momen sekali langkah. Ia bekerja, dan
+      ia lebih lambat, karena setiap langkah itu membuat perambannya mendekodekan
+      dari keyframe di depannya. Halamannya mengatakan jalur mana dari keduanya
+      yang dipakainya sebelum Anda mulai, dan kenapa.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV, dan kebanyakan MKV</strong> tidak bisa dibaca
+      maupun diputar peramban, dan alatnya menolaknya dengan sebuah pesan
+      alih-alih gagal di tengah jalan.
+    </p>
+    <p>
+      Bagaimanapun juga ini salah satu pekerjaan yang lebih lambat di situs ini,
+      karena setiap bingkai didekodekan dan dikodekan dan sebagian bingkai
+      didekodekan lebih dari sekali. Klip pendek hitungan detik; klip 4K yang
+      panjang layak dimulai lalu ditinggalkan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh unggahan</h2>
+    <p>
+      Mendekodekan dan mengodekan ulang video di sebuah peramban itu baru dan ia
+      nyata: WebCodecs membuka pengode perangkat keras yang sama yang dipakai
+      ponsel Anda untuk merekam video, dan ia cepat karena alasan yang sama.
+      Pekerjaannya terjadi di mesin yang sudah memegang file-nya, dan untuk video
+      besar itu juga satu-satunya pengaturan yang masuk akal &mdash; mengunggah
+      lalu mengunduh hasilnya memakan lebih banyak waktu daripada pengodeannya
+      sendiri.
+    </p>
+    <p>
+      Alat di sini tidak punya fitur jaringan dalam bentuk apa pun, dan
+      <code>Content-Security-Policy</code> halamannya menyebut satu per satu
+      setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+      Cabut koneksi internet lalu balik sebuah klip kalau Anda lebih suka
+      memeriksa daripada diberi tahu.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain yang bisa Anda
+      jalankan pada alat mana pun.
+    </p>
+  </section>

--- a/locales/id/pages/guides/reverse-a-video.toml
+++ b/locales/id/pages/guides/reverse-a-video.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: memutar video terbalik - Bahasa Indonesia.
+#
+
+nav = "Memutar video terbalik"
+title = "Cara Memutar Video Terbalik (Beserta Suaranya)"
+description = "Putar sebuah klip mundur: apa yang dilakukan pembalikan pada gambar dan suaranya, kenapa ia tidak bisa dilakukan tanpa pengodean ulang, kenapa ia lebih lambat daripada pemotongan, dan apa yang perlu dikerjakan lebih dulu."
+
+heading = "Cara memutar video terbalik"
+lede = """
+    Memutar sebuah klip mundur terdengar seperti suntingan paling sederhana yang
+    ada, dan justru itulah yang paling tidak disiapkan oleh sebuah file video.
+    Inilah apa yang sebenarnya harus terjadi, berapa harganya, dan satu langkah
+    yang layak dikerjakan sebelumnya."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara memutar video terbalik"
+og_description = "Kenapa sebuah dekoder tidak bisa berjalan mundur, apa yang dikorbankan pembalikan dari gambar dan suaranya, dan satu langkah yang layak dikerjakan lebih dulu."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/scan-a-document-with-your-phone.html
+++ b/locales/id/pages/guides/scan-a-document-with-your-phone.html
@@ -1,0 +1,252 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Taruh halamannya di atas sesuatu yang tidak sewarna dengan halamannya,
+      berdirilah di atasnya, isi bingkainya, lalu ambil satu foto. Lalu buka
+      <a href="../../pemindai-dokumen/">Pemindai Dokumen</a>, periksa keempat
+      sudut yang ditemukannya, pilih &ldquo;warna, diratakan&rdquo; atau
+      &ldquo;hitam putih&rdquo;, lalu simpan PDF-nya.
+    </p>
+    <p>
+      Itulah seluruh pekerjaannya. Sisanya menjelaskan apa yang dibetulkan setiap
+      langkah itu, karena mengetahui bagian mana yang melakukan apa itulah yang
+      membuat Anda bisa tahu, dalam tiga detik, apakah benda yang hendak Anda
+      kirim akan diterima.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang sebenarnya memisahkan sebuah foto dari sebuah pindaian</h2>
+    <p>
+      Tiga hal, dan ketiganya tidak sama pentingnya.
+    </p>
+    <ul>
+      <li>
+        <strong>Sudutnya.</strong> Foto diambil dari mana pun Anda berdiri, jadi
+        halamannya berupa segi empat alih-alih persegi panjang. Inilah yang
+        disadari semua orang dan yang paling mudah diurungkan.
+      </li>
+      <li>
+        <strong>Cahayanya.</strong> Sebuah pemindai menyeret cahaya yang rata
+        melintasi halamannya. Sebuah ruangan tidak: ada bercak terang di bawah
+        lampunya, sudut yang redup jauh darinya, dan sangat sering bayangan Anda
+        sendiri melintasi salah satu sisinya. Inilah yang sebenarnya membuat
+        sebuah foto tampak seperti foto, dan inilah yang coba dibetulkan orang
+        dengan &ldquo;kontras otomatis&rdquo;, yang justru memperburuknya.
+      </li>
+      <li>
+        <strong>Ukurannya.</strong> Foto dua belas megapiksel sebuah halaman
+        adalah tiga sampai lima megabita. Dua puluh di antaranya adalah dokumen
+        yang akan dipantulkan separuh server surel yang dikiriminya.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Mengambil fotonya</h2>
+    <p>
+      Lima hal, dalam urutan seberapa besar bedanya:
+    </p>
+    <ul>
+      <li>
+        <strong>Isi bingkainya.</strong> Inilah satu-satunya yang tidak bisa
+        dibetulkan sesudahnya. Detail yang tidak ada di fotonya tidak ada di
+        file-nya, dan halaman yang difoto dari seberang ruangan adalah halaman
+        yang tidak bisa dibaca siapa pun pada resolusi berapa pun. Mendekatlah
+        alih-alih memperbesar: kecuali ponselnya beralih ke lensa kedua yang
+        lebih panjang, memperbesar adalah sebuah pangkasan atas sensor yang sama
+        &mdash; ia membuang persis piksel yang sedang Anda coba simpan.
+      </li>
+      <li>
+        <strong>Taruh di atas sesuatu yang beda warna.</strong> Halaman putih di
+        atas meja putih nyaris tidak punya tepi untuk ditemukan apa pun &mdash;
+        bukan perangkat lunaknya, dan bukan juga Anda, ketika Anda hendak
+        menyeret sudutnya dengan tangan. Meja gelap, sebuah buku, sebuah mantel:
+        apa saja.
+      </li>
+      <li>
+        <strong>Jangan berdiri di antara halamannya dan cahayanya.</strong>
+        Bayangan Anda sendiri melintasi halamannya adalah alasan tunggal yang
+        paling umum sebuah pindaian ponsel tampak buruk. Berputarlah sembilan
+        puluh derajat dan ia hilang.
+      </li>
+      <li>
+        <strong>Biarkan ia memfokus, lalu tahan diam.</strong> Guncangan kamera
+        tidak bisa dipulihkan alat mana pun, dan begitu juga fokus yang meleset.
+        Ketuk halamannya di layar, tunggu sampai ia tenang, lalu tekan tombolnya.
+      </li>
+      <li>
+        <strong>Masukkan seluruh halamannya, sudutnya termasuk.</strong> Bukan
+        karena sudutnya berharga, melainkan karena dari situlah pelurusannya
+        diukur. Halaman yang keluar dari tepi bingkainya tetap bekerja &mdash;
+        tepi fotonya menggantikan tepi halamannya &mdash; tapi halaman dengan
+        tiga sudut di bingkainya dan satu yang ditebak adalah halaman yang akan
+        keluar sedikit keliru.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Meluruskan: kenapa bentuknya lebih penting daripada sudutnya</h2>
+    <p>
+      Mengurungkan sudutnya adalah sepotong hitungan yang sudah dipahami dengan
+      baik. Empat sudut sebuah persegi panjang yang dilihat dari mana pun
+      menentukan transformasi yang mengembalikannya, dan menerapkannya ke setiap
+      piksel memberi halaman yang datar. Alat mana pun yang mengaku meluruskan
+      sebuah halaman sedang melakukan itu.
+    </p>
+    <p>
+      Bagian yang diam-diam keliru adalah <em>seberapa besar</em> halaman
+      datarnya seharusnya. Metode yang gamblang adalah mengukur tepi segi empatnya
+      lalu memakai rasionya &mdash; dan foto yang diambil dari sudut memendekkan
+      tepi jauhnya, jadi selembar A4 keluar tampak jelas pendek. Ia tetap tampak
+      seperti pindaian. Setiap baris teks di atasnya sekadar salah tingginya, dan
+      tidak ada apa pun di layar yang mengatakannya.
+    </p>
+    <p>
+      Jawaban yang lebih baik adalah bahwa perspektifnya sendiri membawa
+      informasinya: asalkan kameranya kamera biasa, foto sebuah persegi panjang
+      cukup untuk memulihkan baik proporsi sebenarnya persegi panjangnya maupun
+      panjang fokus kameranya.
+      <a href="../../pemindai-dokumen/">Pemindai Dokumen</a> di sini melakukan
+      itu, lalu memberi tahu Anda halamannya keluar berbentuk apa dan apakah itu
+      lembar standar &mdash; jadi halaman yang berkata &ldquo;1:1,41, dan itu
+      bentuk A4 atau A5&rdquo; adalah halaman yang bisa Anda berhenti pikirkan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cahayanya: bagi, jangan regangkan</h2>
+    <p>
+      Menaikkan kontras halaman yang tercahayai tidak rata membuat bagian
+      terangnya putih dan bagian gelapnya hitam, dan tulisan di bagian gelapnya
+      lenyap bersamanya. Masalahnya tidak pernah kontrasnya yang terlalu rendah.
+      Melainkan kertasnya tidak sama kecerahannya di satu sudut dengan di sudut
+      lain, jadi tidak ada satu penyesuaian pun yang benar untuk seluruh
+      halamannya.
+    </p>
+    <p>
+      Yang berhasil adalah memperkirakan seberapa cerah kertasnya
+      <em>di setiap titik</em> lalu membaginya. Kertas adalah mayoritas terang
+      dari petak kecil mana pun di sebuah halaman, jadi mengukur kecerahannya di
+      seluruh kisi ubin kecil lalu mengambil nilai yang tinggi di masing-masing
+      memberi bentuk cahayanya &mdash; teks terlalu gelap dan terlalu jarang
+      untuk menggerakkannya. Bagilah dengan itu dan yang tersisa adalah tintanya,
+      tercahayai rata, dengan bayangannya hilang dan kertasnya kembali putih.
+    </p>
+    <p>
+      Inilah yang dilakukan &ldquo;warna, diratakan&rdquo; dan &ldquo;skala
+      abu-abu&rdquo;. Pilih warna ketika warnanya bagian dari dokumennya: sebuah
+      stempel, tanda tangan bertinta biru, baris yang distabilo, apa pun yang
+      belakangan mungkin ditanyakan orang apakah ia asli.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hitam putih, dan kenapa file-nya tiba-tiba menjadi kecil</h2>
+    <p>
+      Halaman yang disimpan sebagai foto adalah jutaan piksel dengan enam belas
+      juta kemungkinan warna masing-masing, dan kodeknya membelanjakan usahanya
+      pada gradien halus yang tidak dimiliki sebuah halaman teks. Halaman yang
+      disimpan sebagai hitam putih adalah satu bit per piksel &mdash; tinta atau
+      kertas &mdash; dan terkompres seperti benda yang teramat berulang itu.
+    </p>
+    <p>
+      Bedanya tidak kecil: pada halaman yang sama ia kira-kira delapan belas kali.
+      Kontrak dua puluh halaman yang mencapai lima belas megabita sebagai foto
+      mendarat di bawah satu megabita sebagai halaman satu bit &mdash; dan itu
+      bedanya dokumen yang bisa dikirim lewat surel dengan yang tidak bisa, dan
+      alasan setiap pemindai kantor memakainya sebagai bawaan.
+    </p>
+    <p>
+      Jebakannya adalah tidak ada nada tengah: sebuah foto di halamannya menjadi
+      kekacauan titik-titik. Pakai untuk halaman cetak dan tulisan tangan, dan
+      itulah wujud kebanyakan dokumen, lalu pakai skala abu-abu untuk apa pun
+      yang ada gambarnya.
+    </p>
+    <p>
+      Satu detail yang layak diketahui, karena ia menjelaskan kenapa alat yang
+      bagus berhasil di tempat yang buruk menghasilkan halaman bersudut hitam:
+      keputusan tinta atau kertas harus dibuat <em>secara setempat</em>. Satu
+      ambang untuk seluruh halamannya tidak bisa bekerja ketika kertas di dalam
+      bayangannya lebih gelap daripada tinta di bawah cahayanya &mdash; dan pada
+      halaman yang difoto ia sangat sering begitu. Memutuskan setiap piksel
+      terhadap rata-rata lingkungan kecilnya sendiri itulah yang menjaga tulisan
+      di dalam sebuah bayangan tetap terbaca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Beberapa halaman, satu dokumen</h2>
+    <p>
+      Foto halamannya berurutan, tambahkan semuanya sekaligus, dan mereka menjadi
+      halaman-halaman satu PDF dalam urutan mereka ditambahkan. Dua hal yang
+      perlu diperhatikan:
+    </p>
+    <ul>
+      <li>
+        <strong>Nama file tidak terurut seperti dugaan Anda.</strong>
+        <code>halaman2.jpg</code> datang setelah <code>halaman10.jpg</code> dalam
+        pengurutan alfabetis, karena perbandingannya karakter demi karakter.
+        Periksa urutannya di barisnya sebelum Anda menyimpan alih-alih di PDF-nya
+        sesudahnya.
+      </li>
+      <li>
+        <strong>Pembersihannya satu setelan untuk seluruh dokumennya</strong>,
+        dan itu disengaja. Halaman yang dibersihkan secara berbeda tampak seperti
+        dua dokumen yang distaples jadi satu, dan persis itulah kesan yang
+        seharusnya dihindari sebuah pindaian. Pilih mode yang cocok untuk halaman
+        yang paling buruk.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Sebelum Anda mengirimnya</h2>
+    <ul>
+      <li>
+        <strong>Buka PDF-nya.</strong> Bukan pratinjaunya &mdash; file-nya.
+        Setiap halaman, arah yang benar, tidak ada yang terpotong di sebuah tepi.
+      </li>
+      <li>
+        <strong>Baca hal terkecil di halamannya.</strong> Sebuah nomor rujukan,
+        sebuah tanggal, sebuah nomor rekening. Kalau Anda tidak bisa membacanya di
+        layar pada 100%, orang yang Anda kirimi juga tidak bisa.
+      </li>
+      <li>
+        <strong>Periksa sudutnya tidak terpangkas.</strong> Yang duduk di tepi
+        sebuah formulir adalah nomor halaman, garis tanda tangan, atau kotak yang
+        belakangan akan dikatakan seseorang hilang.
+      </li>
+      <li>
+        <strong>Periksa apa yang dikatakan dokumennya tentang Anda.</strong>
+        Sebuah PDF punya kolom untuk penulis, produser, dan tanggal pembuatan,
+        dan kebanyakan alat mengisinya. Apakah itu penting tergantung siapa yang
+        menerimanya, tapi layak diketahui bahwa ia ada di sana.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Kenapa tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Setiap langkah di atas adalah hitungan atas sebuah gambar yang sudah
+      didekodekan mesin Anda sendiri: empat sudut, sebuah transformasi, sebuah
+      pembagian, sebuah ambang, dan sebuah wadah yang ditulis sebyte demi sebyte.
+      Tidak ada apa pun di dalamnya yang bisa dilakukan sebuah server dan tidak
+      bisa dilakukan sebuah peramban, dan tidak ada yang butuh sebuah model
+      diunduh untuk melakukannya.
+    </p>
+    <p>
+      Dan itu layak direnungkan sejenak, karena file-nya apa. Orang tidak memotret
+      halaman secara acak. Mereka memotret sebuah paspor, slip gaji, surat sewa,
+      formulir medis, sebuah kontrak &mdash; dokumen dengan nama, alamat, dan
+      nomor rekening di atasnya, yang dipindai justru karena sebuah lembaga
+      memintanya. Mengunggah satu ke sebuah situs web untuk diluruskan sudutnya
+      menyerahkan seluruh dokumennya kepada orang asing. Lihat
+      <a href="../apakah-aman-mengunggah-file/">cara mengetahui apakah sebuah
+      alat sungguh membutuhkan file Anda</a> untuk empat pemeriksaan yang
+      memisahkan alat yang harus melihat file Anda dari alat yang sekadar
+      melihatnya.
+    </p>
+  </section>

--- a/locales/id/pages/guides/scan-a-document-with-your-phone.toml
+++ b/locales/id/pages/guides/scan-a-document-with-your-phone.toml
@@ -1,0 +1,22 @@
+#
+# Panduan: memindai dokumen dengan ponsel - Bahasa Indonesia.
+#
+
+nav = "Memindai dengan ponsel"
+title = "Cara Memindai Dokumen dengan Ponsel Anda (Tanpa Aplikasi, Tanpa Unggah)"
+description = "Apa yang memisahkan foto sebuah halaman dari pindaian sebuah halaman: sudutnya, cahaya yang tidak rata, dan ukuran file-nya. Bagaimana mengambil fotonya, apa yang dibetulkan sesudahnya, dan kenapa tidak satu pun dari itu butuh server."
+
+heading = "Cara memindai dokumen dengan ponsel Anda"
+lede = """
+    Seseorang meminta Anda &ldquo;memindai dan mengembalikan&rdquo; sebuah
+    formulir, dan Anda punya sebuah ponsel dan tidak punya pemindai. Jarak antara
+    foto sebuah halaman dan pindaian sebuah halaman lebih kecil daripada
+    tampaknya, dan ia sebagian besar bukan soal sudutnya &mdash; inilah apa yang
+    sebenarnya memisahkan keduanya, dan apa yang dilakukan tentang tiap
+    bagiannya."""
+
+updated = "25 Agustus 2026"
+
+og_title = "Cara memindai dokumen dengan ponsel Anda"
+og_description = "Sudutnya, bayangannya, dan ukuran file-nya - apa yang memisahkan foto sebuah halaman dari pindaian sebuah halaman, dan bagaimana membetulkan masing-masing tanpa mengunggah halamannya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/split-a-gif-into-frames.html
+++ b/locales/id/pages/guides/split-a-gif-into-frames.html
@@ -1,0 +1,193 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../pisah-gif-ke-bingkai/">Pemisah GIF</a>, jatuhkan
+      GIF-nya, dan setiap bingkai muncul sebagai PNG yang bisa Anda unduh &mdash;
+      satu per satu, atau semuanya sebagai satu ZIP. Biarkan setelannya apa
+      adanya dan Anda mendapat persis yang dimaksud kebanyakan orang: setiap
+      bingkai sebagai gambar utuh, seperti rupanya pada momen itu di animasinya.
+    </p>
+    <p>
+      Sisa halaman ini adalah tentang tiga hal yang mengejutkan orang
+      sesudahnya: bingkai yang hanya berupa tambalan kecil, transparansi yang
+      berubah hitam di tempat lain, dan pewaktuan yang tidak ada lagi begitu
+      bingkainya menjadi file terpisah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa sebenarnya sebuah bingkai GIF</h2>
+    <p>
+      GIF bukan setumpuk gambar. Ia <em>satu</em> gambar, diikuti serangkaian
+      tambalan.
+    </p>
+    <p>
+      Setiap bingkai setelah yang pertama hanya menyimpan persegi panjang yang
+      berubah, berikut sebuah aturan tentang apa yang dilakukan pada kanvasnya
+      sesudah itu. Semua hal lain di layar sekadar apa yang ditinggalkan bingkai
+      sebelumnya di sana. Orang yang berbicara di depan dinding yang diam memakan
+      biaya sebuah persegi panjang berisi wajah per bingkai alih-alih gambar utuh
+      per bingkai, dan itulah seluruh alasan format tanpa kompensasi gerak dan
+      tanpa langkah yang merugikan ini tidak sama sekali tidak terpakai.
+    </p>
+    <p>
+      Jadi ada dua jawaban yang berbeda dan sama jujurnya untuk "berikan saya
+      bingkai 14", dan alatnya menawarkan keduanya:
+    </p>
+    <p>
+      <strong>Bingkainya sebagaimana ia tampak.</strong> Gambar utuh pada momen
+      itu: bingkai 14 digambar di atas semua yang sebelumnya. Inilah bawaannya,
+      dan inilah yang Anda mau untuk sebuah lembar kontak, sebuah gambar mini,
+      sebuah gambar diam untuk diunggah, atau bingkai yang akan masuk ke sebuah
+      penyunting video.
+    </p>
+    <p>
+      <strong>Hanya piksel yang disimpan bingkai itu.</strong> Tambalannya
+      sendiri, pada ukurannya sendiri, di posisinya sendiri, dengan semua yang
+      tidak dibawanya dibiarkan transparan. Bingkai 14 bisa jadi
+      60&nbsp;&times;&nbsp;40 piksel berisi mulut. Inilah tampilan yang
+      menjelaskan ke mana byte sebuah GIF pergi, dan inilah yang Anda mau kalau
+      Anda menyunting animasinya alih-alih memanen gambar darinya.
+    </p>
+    <p>
+      Tidak ada yang salah dengan file Anda ketika sebuah bingkai tersimpan
+      tampak seperti serpihan. Memang begitulah file-nya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Aturan pembuangan, dan kenapa sebagian bingkai meninggalkan lubang</h2>
+    <p>
+      Setiap bingkai juga membawa salah satu dari empat instruksi tentang apa
+      yang terjadi pada persegi panjangnya sebelum bingkai berikutnya digambar.
+      Alatnya menampilkannya di bawah setiap bingkai pada tampilan tersimpan:
+    </p>
+    <p>
+      <strong>Bertahan di layar.</strong> Yang biasa. Tambalannya tetap di tempat
+      ia mendarat dan bingkai berikutnya menggambar di atasnya.
+    </p>
+    <p>
+      <strong>Membersihkan areanya sesudahnya.</strong> Persegi panjangnya dihapus
+      sebelum bingkai berikutnya mendarat. Inilah yang dilakukan animasi dengan
+      objek transparan yang bergerak, dan ini juga penyebab klasik GIF yang
+      berkedip-kedip.
+    </p>
+    <p>
+      <strong>Memulihkan apa yang ada di bawahnya.</strong> Kanvasnya kembali ke
+      rupanya sebelum bingkai ini menggambar &mdash; sebuah cap, lalu sebuah
+      pengurungan. Jarang, dan yang paling sering salah dipahami pembaca GIF
+      buatan sendiri.
+    </p>
+    <p>
+      Satu detail yang layak diketahui kalau Anda membandingkan alat:
+      spesifikasinya mengatakan "membersihkan areanya" seharusnya memulihkan
+      <em>warna latar</em>, tapi setiap peramban sejak 1990-an membersihkannya
+      menjadi <em>transparan</em>, karena itulah yang diandaikan animasi masa itu.
+      Alat ini mengikuti peramban dengan sengaja, jadi bingkai yang Anda dapat
+      adalah bingkai yang Anda lihat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang terjadi pada transparansinya</h2>
+    <p>
+      Transparansi GIF itu satu bit. Sebuah piksel entah terlukis entah tak
+      terlihat, dan tidak ada apa pun di antaranya &mdash; tidak ada tepi lembut,
+      tidak ada bayangan separuh. Itulah sebabnya GIF berlatar transparan punya
+      siluet yang keras dan sedikit bergerigi.
+    </p>
+    <p>
+      PNG menyimpan persis itu, tanpa kehilangan, jadi bingkainya keluar dengan
+      transparansinya utuh dan tidak ada yang dikarang.  Simpan itu kalau
+      bingkainya akan pergi ke tempat yang memahami transparansi.
+    </p>
+    <p>
+      Isi dengan sebuah warna kalau tidak. Perangkat lunak yang mengabaikan kanal
+      alfa biasanya menggambarnya hitam, jadi bingkai yang tampak baik-baik saja
+      di peramban tiba dengan latar hitam &mdash; dan sebuah tambalan tersimpan,
+      yang transparan hampir di seluruhnya, tiba sebagai persegi panjang hitam
+      berisi mulut. Memilih warnanya di muka adalah solusinya. Ia ditulis ke dalam
+      PNG-nya dan tidak bisa diurungkan sesudahnya, dan itulah satu-satunya alasan
+      ia bukan bawaannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pewaktuannya, yang tidak bisa dibawa bingkainya</h2>
+    <p>
+      Sebuah PNG tidak punya tempat untuk mencatat berapa lama ia ada di layar.
+      Pisah sebuah animasi menjadi PNG dan pewaktuannya hilang, dan itu penting
+      begitu Anda ingin menyusunnya kembali.
+    </p>
+    <p>
+      Untuk itulah <code>frames.txt</code> di dalam ZIP-nya ada. Ia mendaftar
+      jeda, posisi, dan ukuran setiap bingkai, sehingga animasinya bisa dibangun
+      ulang di <a href="../../buat-gif/">Pembuat GIF</a> atau di tempat lain mana
+      pun. Ia memakan beberapa kilobita dan tidak ada cara untuk menyusunnya
+      kembali belakangan.
+    </p>
+    <p>
+      Dua hal tentang jeda GIF yang menjebak semua orang:
+    </p>
+    <p>
+      <strong>Satuannya perseratus detik</strong>, jadi langkah terhalus yang
+      dipunyai formatnya adalah 0,01&nbsp;d. Tidak ada yang namanya GIF
+      30&nbsp;fps yang tepat; 0,03&nbsp;d per bingkai adalah 33,3&nbsp;fps dan
+      0,04&nbsp;d adalah 25.
+    </p>
+    <p>
+      <strong>Apa pun di bawah 0,02&nbsp;d diputar pada 0,10&nbsp;d.</strong>
+      Peramban sudah menjepitnya sejak 1990-an &mdash; sebuah aturan yang ditulis
+      untuk bola dunia berputar masa itu dan tidak pernah dicabut. GIF yang
+      file-nya berkata 0,01&nbsp;d per bingkai mengaku 100&nbsp;fps dan diputar
+      pada 10. Alatnya menampilkan jedanya sebagaimana ia benar-benar diputar,
+      dan menyebutkan apa yang disimpan file-nya di sebelahnya ketika keduanya
+      berbeda, karena selisih itulah sebabnya GIF yang Anda pisah lalu bangun
+      ulang bisa keluar lebih lambat daripada aslinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Nomor bingkai, dan kenapa ia diberi nol di depan</h2>
+    <p>
+      Bingkainya keluar sebagai <code>nama-001.png</code>,
+      <code>nama-002.png</code>, dinomori mulai dari satu dan diberi nol di depan
+      sampai selebar nomor terakhirnya. Itu bukan hiasan:
+      <code>bingkai9.png</code> terurut <em>setelah</em>
+      <code>bingkai10.png</code> di setiap pengelola file dan di kebanyakan
+      perangkat lunak yang mengimpor sebuah runtutan, karena mereka mengurutkan
+      teks alih-alih angka. Nama yang diberi nol di depan terurut benar di mana
+      saja, dan setiap penyunting video yang mengimpor runtutan gambar
+      mengharapkannya.
+    </p>
+    <p>
+      Menjarangkan animasi yang panjang dengan "simpan setiap bingkai kedua"
+      tidak menomori ulang apa pun. Bingkai 42 tetap bernama bingkai 42, jadi
+      file-nya sejajar dengan aslinya dan dengan daftar pewaktuannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh server</h2>
+    <p>
+      Membaca sebuah GIF itu dua pekerjaan: menyusuri blok file-nya, dan membuka
+      kompresi LZW tempat pikselnya terbungkus. Bersama-sama keduanya beberapa
+      ratus baris, keduanya tertulis di repositori, dan keduanya berjalan di
+      mesin Anda sendiri &mdash; dan itulah sebabnya halamannya terus bekerja
+      dengan jaringan tercabut.
+    </p>
+    <p>
+      Peramban Anda sudah bisa memutar sebuah GIF, tapi ia tidak akan menyerahkan
+      bagian-bagiannya: sebuah <code>&lt;img&gt;</code> memberi Anda sebuah
+      animasi, menggambar satu ke sebuah kanvas memberi Anda bingkai pertama
+      selamanya, dan satu-satunya API yang berbuat lebih tidak ada di Safari.
+      Jadi formatnya dibaca sendiri di sini, dengan cara yang sama di setiap
+      peramban &mdash; dan membacanya sendiri juga itulah yang memungkinkan
+      menampilkan tambalan dan aturan pembuangannya kepada Anda sama sekali.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan empat pemeriksaan yang akan memberi tahu
+      Anda hal yang sama tentang alat mana pun, termasuk yang ini.
+    </p>
+  </section>

--- a/locales/id/pages/guides/split-a-gif-into-frames.toml
+++ b/locales/id/pages/guides/split-a-gif-into-frames.toml
@@ -1,0 +1,21 @@
+#
+# Panduan: memisah GIF menjadi bingkai - Bahasa Indonesia.
+#
+
+nav = "Pisah sebuah GIF"
+title = "Cara Memisah GIF Menjadi Bingkai (dan Apa Sebenarnya Sebuah Bingkai)"
+description = "Dapatkan setiap bingkai sebuah GIF animasi sebagai PNG: kenapa sebagian bingkai hanya berupa tambalan kecil dari gambarnya, apa yang terjadi pada transparansinya, dan bagaimana menyimpan pewaktuannya supaya Anda bisa menyusunnya kembali."
+
+heading = "Cara memisah GIF menjadi bingkai"
+lede = """
+    Mengeluarkan bingkainya cukup satu jatuhan dan satu tombol. Yang layak
+    dipahami adalah apa sebenarnya sebuah "bingkai" GIF itu, karena formatnya
+    menyimpan sesuatu yang agak berbeda dari yang Anda lihat &mdash; dan
+    perbedaan itulah sebabnya bingkai keempat belas Anda berupa sebuah persegi
+    panjang berisi mulut seseorang."""
+
+updated = "21 Agustus 2026"
+
+og_title = "Cara memisah GIF menjadi bingkai"
+og_description = "Setiap bingkai sebuah GIF sebagai PNG: kenapa sebagian bingkai hanya berupa tambalan, apa yang terjadi pada transparansinya, dan bagaimana menyimpan pewaktuannya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/stack-photos-to-reduce-noise.html
+++ b/locales/id/pages/guides/stack-photos-to-reduce-noise.html
@@ -1,0 +1,312 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../tumpuk-gambar/">Penumpuk Gambar</a>, jatuhkan seluruh
+      burst-nya, lalu pilih metodenya menurut apa yang ingin Anda singkirkan:
+    </p>
+    <ul>
+      <li><strong>Derau</strong>, dan tidak ada yang bergerak &mdash; rata-rata.</li>
+      <li><strong>Derau</strong>, dan ada yang bergerak &mdash; sigma clipping.</li>
+      <li><strong>Orang, mobil, sebuah pesawat</strong> &mdash; median.</li>
+      <li><strong>Langit gelap yang Anda mau jadi jejak bintang</strong> &mdash; terangkan.</li>
+      <li><strong>Bidikan makro yang kedalaman bidangnya nyaris tidak ada</strong> &mdash; penumpukan fokus.</li>
+    </ul>
+    <p>
+      Biarkan penyejajarannya menyala kalau kameranya ada di tangan Anda dan
+      matikan kalau ia ada di atas tripod. File RAW bisa masuk langsung; tidak
+      perlu mengembangkannya lebih dulu.
+    </p>
+    <p>
+      Semua di bawah ini adalah kenapa kelima baris itu seperti itu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa sebuah burst menyimpan lebih banyak daripada satu bingkai</h2>
+    <p>
+      Foto yang diambil di bawah cahaya yang buruk adalah gambarnya ditambah
+      derau, dan deraunya berbeda setiap kali. Bagian terakhir itulah yang
+      membuat penumpukan berhasil. Ambil bidikan yang sama enam belas kali dan
+      gambarnya identik di keenam belasnya sementara deraunya tidak, jadi
+      merata-ratakannya menyisakan gambarnya dan membatalkan sebagian besar
+      deraunya.
+    </p>
+    <p>
+      Peningkatannya sebesar akar jumlah bingkainya. Empat bingkai menyetengahkan
+      deraunya. Enam belas menyeperempatkannya. Seratus memangkasnya sepersepuluh.
+      Itu kurva yang kejam untuk dijalani &mdash; naik dari enam belas bingkai ke
+      enam puluh empat memberi Anda peningkatan yang sama lagi, untuk empat kali
+      pemotretannya &mdash; dan itulah sebabnya hampir setiap tumpukan yang
+      praktis berada di antara delapan dan tiga puluh bingkai.
+    </p>
+    <p>
+      Ada keuntungan kedua yang lebih tenang. Merata-ratakan enam belas bingkai
+      delapan bit memberi hasil dengan gradasi yang lebih halus daripada yang
+      dimiliki satu pun di antaranya, karena derau yang membuat setiap bingkai
+      membulat berbeda justru itulah yang membuat rata-ratanya mendarat di antara
+      tingkatannya. Menumpuk kumpulan yang berderau tidak hanya membuang derau;
+      ia memulihkan nada yang dikuantisasi hilang oleh satu bingkai.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pertanyaan yang memilih metodenya</h2>
+    <p>
+      Bukan &ldquo;apa yang ingin saya simpan&rdquo; melainkan <strong>apa yang
+      berbeda antar bingkainya</strong>. Semua yang lain mengikuti.
+    </p>
+
+    <h3>Tidak ada yang bergerak: rata-rata</h3>
+    <p>
+      Rata-rata biasa. Ia pengurangan derau paling ampuh yang tersedia pada
+      kumpulan yang satu-satunya beda antar bingkainya adalah deraunya, dan ia
+      yang paling mudah dirusak: satu bingkai yang ada burungnya menaruh sebuah
+      burung samar melintasi seluruh tumpukannya, karena sebuah rata-rata tidak
+      punya pendapat tentang nilai yang tidak sepakat dengan yang lain. Ia sekadar
+      memasukkannya.
+    </p>
+
+    <h3>Ada yang melintasi bingkainya: median</h3>
+    <p>
+      Sejajarkan selusin foto sebuah alun-alun yang ramai lalu lihat satu piksel.
+      Di sebagian besarnya ia trotoar; di satu dua di antaranya ia mantel
+      seseorang. Urutkan kedua belas nilai itu lalu ambil yang tengah dan Anda
+      mendapat trotoar, karena mantelnya tidak pernah menjadi mayoritas.
+    </p>
+    <p>
+      Lakukan itu untuk setiap piksel dan alun-alunnya keluar kosong. Inilah trik
+      di balik setiap artikel &ldquo;buang turis dari foto liburan Anda&rdquo;,
+      dan ia tidak butuh apa pun yang lebih pintar daripada sebuah burst dan
+      kesabaran. Satu hal yang dituntutnya adalah bahwa <strong>tidak ada bagian
+      pemandangannya yang ditempati lebih dari separuh waktunya</strong>. Orang
+      yang berdiri diam di delapan dari dua belas bingkai Anda adalah mayoritas di
+      piksel itu, dan mediannya akan menyimpannya.
+    </p>
+
+    <h3>Keduanya: sigma clipping</h3>
+    <p>
+      Mediannya membuang sebagian besar informasinya demi mendapatkan
+      ketegarannya &mdash; sebelas dari dua belas nilai Anda dibuang di setiap
+      pikselnya, jadi ia mengurangi derau jauh lebih sedikit daripada yang akan
+      dilakukan sebuah rata-rata atas kumpulan yang sama.
+    </p>
+    <p>
+      Sigma clipping adalah kompromi itu, dan ia biasanya bawaan yang benar untuk
+      kumpulan dunia nyata mana pun. Ia melihat setiap piksel di seluruh
+      bingkainya, memperhitungkan apa biasanya piksel itu dan seberapa banyak ia
+      berubah-ubah, lalu merata-ratakan hanya nilai yang sepakat dengan itu.
+      Sebuah mobil yang melintas di satu bingkai dikeluarkan dari piksel itu;
+      setiap bingkai lain tetap dihitung di mana-mana. Anda mendapat kekebalan
+      mediannya terhadap hal-hal yang bergerak dan sebagian besar pengurangan
+      derau rata-ratanya.
+    </p>
+    <p>
+      Ambangnya dalam simpangan baku, dan dua adalah titik mulai yang biasa.
+      Lebih rendah menolak lebih banyak, dan mulai menolak detail yang sungguhan
+      bersama mobilnya.
+    </p>
+
+    <h3>Hanya yang terang yang penting: terangkan</h3>
+    <p>
+      Simpan nilai paling terang yang pernah dimiliki setiap piksel. Foto langit
+      malam sebagai dua ratus pencahayaan sepertiga puluh detik lalu terangkan
+      mereka bersama-sama, dan setiap bintang menggambar busurnya sendiri
+      melintasi hasilnya &mdash; sebuah jejak bintang, dirakit dari pencahayaan
+      pendek yang masing-masing tidak pernah kelebihan cahaya. Metode yang sama
+      merakit sebuah kembang api dari bingkai ledakannya sendiri, dan sebuah
+      lukisan cahaya dari berjalan berkeliling ruangan gelap dengan sebuah senter.
+    </p>
+    <p>
+      Lawannya, gelapkan, adalah yang pendiam dari pasangan itu: sebuah piksel
+      hanya tetap terang kalau ia terang di <em>setiap</em> bingkainya, jadi
+      pantulan di sebuah jendela, lampu depan yang lewat, dan tetes hujan yang
+      tercahayai lampu kilat semuanya lenyap.
+    </p>
+
+    <h3>Subjeknya lebih dalam daripada fokusnya: penumpukan fokus</h3>
+    <p>
+      Bidikan makro pada f/8 punya mungkin satu milimeter yang terfokus, dan itu
+      tidak cukup untuk seekor serangga. Jawabannya adalah mengambil dua puluh
+      bingkai di sepanjang cincin fokus lalu menyimpan, dari masing-masing, hanya
+      bagian yang tajam di dalamnya. Alatnya mengukur seberapa banyak setiap
+      piksel berbeda dari tetangganya &mdash; besar di sebuah tepi, nyaris nol di
+      sebuah keburaman &mdash; lalu mengambil pemenangnya.
+    </p>
+    <p>
+      Yang ini menginginkan tripod lebih daripada yang lain mana pun, karena
+      memutar cincin fokusnya dengan tangan menggerakkan kameranya, dan bingkai
+      yang diambil dari sedikit lebih jauh bukanlah gambar yang sama pada fokus
+      yang berbeda.
+    </p>
+  </section>
+
+  <section>
+    <h2>Menyejajarkan bingkainya</h2>
+    <p>
+      Penumpukan adalah hitungan per piksel, jadi ia mengandaikan bahwa piksel
+      tertentu adalah bagian pemandangan yang sama di setiap bingkainya. Kalau
+      dipegang tangan, ia tidak: sebuah burst bergeser sejauh puluhan piksel, dan
+      merata-ratakan itu menghasilkan keburaman alih-alih gambar yang bersih.
+      Itulah alasan tunggal yang paling umum percobaan pertama menumpuk
+      mengecewakan.
+    </p>
+    <p>
+      Jadi bingkainya diukur terhadap salah satu dari mereka lalu dipindahkan
+      kembali ke tempatnya lebih dulu, sampai sepersekian piksel. Tiga setelan:
+    </p>
+    <ul>
+      <li>
+        <strong>Geser saja</strong> benar untuk hampir semua yang dipegang tangan.
+        Ia membetulkan pergeserannya dan goyangannya.
+      </li>
+      <li>
+        <strong>Geser, rotasi, dan skala</strong> untuk kumpulan yang Anda juga
+        sedikit berputar, atau yang zoomnya merayap. Ia berbiaya satu pengukuran
+        lagi per bingkai dan sama sekali tidak berbiaya apa pun ketika bingkainya
+        ternyata lurus.
+      </li>
+      <li>
+        <strong>Tidak sama sekali</strong> untuk tripod terkunci atau runtutan
+        intervalometer, tempat bingkainya sudah sejajar dan mengukurnya adalah
+        waktu yang terbuang.
+      </li>
+    </ul>
+    <p>
+      Yang tidak bisa dibetulkan penyejajaran apa pun adalah subjek yang bergerak
+      alih-alih kamera yang bergerak, dan ia juga tidak bisa membetulkan foto yang
+      diambil dari satu langkah ke kiri. Bergeser ke samping mengubah seberapa
+      banyak benda dekatnya bergeser relatif terhadap benda jauhnya, dan tidak ada
+      satu koreksi pun yang menggambarkan keduanya sekaligus. Berputar di tempat
+      tidak masalah; berjalan masalah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Di mana file RAW cocok</h2>
+    <p>
+      Anda bisa menjatuhkan CR2, CR3, NEF, ARW, DNG, RAF, RW2, ORF, dan sisanya
+      langsung, dan layak dinyatakan dengan tepat apa yang terjadi pada mereka,
+      karena ia bukan yang dilakukan sebuah pengubah RAW.
+    </p>
+    <p>
+      Setiap file RAW sudah memuat sebuah <strong>JPEG berukuran penuh yang
+      digambar kameranya ketika ia mengambil bidikannya</strong>. Ia yang
+      ditampilkan punggung kameranya kepada Anda dan yang digambar sistem operasi
+      Anda sebagai gambar mininya. Penumpuknya menemukan gambar itu lalu
+      memakainya. Ia tidak mendekodekan data sensornya.
+    </p>
+    <p>
+      Dua akibatnya, satu baik dan satu layak diketahui:
+    </p>
+    <ul>
+      <li>
+        <strong>Ia cepat.</strong> Menemukan pratinjaunya berarti membaca
+        beberapa kilobita direktori lalu satu irisan, jadi bingkai 60&nbsp;MB
+        terbuka kira-kira secepat sebuah JPEG. Dua puluh di antaranya terbuka
+        dalam waktu yang akan dihabiskan sebuah pengubah RAW untuk satu.
+        Halamannya menunjukkan kepada Anda betapa sedikit file Anda yang
+        sebenarnya dibacanya.
+      </li>
+      <li>
+        <strong>Ia penggambaran kameranya, bukan penggambaran Anda.</strong>
+        Delapan bit per kanal, dengan keseimbangan putih dan gaya gambar yang
+        disetel di kameranya &mdash; bukan dua belas atau empat belas bit data
+        sensor linear yang akan Anda dapat dari sebuah pengubah.
+      </li>
+    </ul>
+    <p>
+      Untuk pengurangan derau, jejak bintang, membuang orang yang lewat, dan
+      penumpukan fokus, pertukaran itu hampir selalu layak diambil: pratinjaunya
+      beresolusi penuh dan mereka toh yang akan Anda dapat sebagai sebuah JPEG.
+      Kalau Anda mendorong bayangannya keras-keras, atau menumpuk untuk
+      astrofotografi yang bit terakhir rentang dinamisnya adalah seluruh intinya,
+      kembangkan bingkainya di sebuah pengubah RAW lebih dulu lalu tumpuk TIFF
+      atau JPEG yang diberikannya. Itu masuk dengan cara yang sama.
+    </p>
+  </section>
+
+  <section>
+    <h2>Berapa harganya untuk dijalankan</h2>
+    <p>
+      Layak diketahui karena itulah bedanya tumpukan yang memakan delapan detik
+      dengan yang memakan dua menit.
+    </p>
+    <p>
+      Enam dari ketujuh metodenya hanya pernah perlu mengingat satu hal. Sebuah
+      maksimum berjalan tidak peduli pada bingkai yang sudah dilihatnya, dan
+      begitu juga sebuah total berjalan, jadi metode itu membaca setiap bingkai
+      tepat sekali lalu memakai memori yang sama untuk seratus bingkai seperti
+      untuk dua.
+    </p>
+    <p>
+      Mediannya tidak bisa bekerja begitu, karena Anda tidak bisa tahu nilai
+      tengah sebuah kumpulan sampai Anda punya seluruhnya. Dua puluh bingkai 24
+      megapiksel adalah sekitar 1,4&nbsp;GB piksel yang ditahan sekaligus, dan
+      tidak ada peramban yang akan memberikannya kepada Anda, jadi gambarnya
+      dipotong menjadi pita mendatar lalu ditumpuk sepita demi sepita &mdash;
+      benar, dan lebih lambat, karena bingkainya dibaca lagi untuk setiap pitanya.
+    </p>
+    <p>
+      Alatnya memperhitungkan semua ini sebelum Anda menekan tombolnya lalu
+      memberi tahu Anda: seberapa besar hasilnya nanti, kira-kira berapa banyak
+      memori yang dibutuhkannya, dan berapa kali bingkai Anda akan didekodekan.
+      Kalau ia bilang jalannya akan berpita, menurunkan resolusi kerjanya satu
+      langkah memangkas memorinya menjadi seperempat dan hampir selalu
+      mengubahnya kembali menjadi satu jalan tunggal &mdash; dan kalau Anda
+      menumpuk untuk membuang derau, resolusi setengah toh sudah akan tampak lebih
+      bersih daripada resolusi penuh.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memotret untuk itu</h2>
+    <p>
+      Sebagian besar kualitas sebuah tumpukan ditentukan sebelum perangkat lunak
+      mana pun melihatnya.
+    </p>
+    <ul>
+      <li>
+        <strong>Potret lebih banyak bingkai daripada dugaan Anda.</strong> Kurva
+        akarnya tidak kenal ampun di ujung bawahnya dan murah hati di ujung
+        atasnya: naik dari empat ke sembilan bingkai adalah perubahan yang lebih
+        besar dan terlihat daripada naik dari dua puluh ke empat puluh.
+      </li>
+      <li>
+        <strong>Jangan mengubah pencahayaannya antar bingkai.</strong> Penumpukan
+        mengandaikan bingkainya adalah pemandangan yang sama pada kecerahan yang
+        sama. Kunci pencahayaannya, atau alatnya akan merata-ratakan dua gambar
+        yang berbeda.
+      </li>
+      <li>
+        <strong>Untuk membuang orang, tunggu di antara bingkainya.</strong> Sebuah
+        burst yang diambil dalam dua detik menangkap orang yang sama di tempat
+        yang sama di setiap bingkainya, dan mediannya menyimpannya. Sepuluh
+        bingkai berselang beberapa detik bekerja jauh lebih baik daripada lima
+        puluh dalam sebuah burst.
+      </li>
+      <li>
+        <strong>Untuk jejak bintang, jaga selanya tetap pendek.</strong>
+        Terangkan menggambar persis yang direkam bingkainya, jadi jeda antar
+        pencahayaan menjadi sebuah garis putus yang terlihat di setiap jejaknya.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini meninggalkan mesin Anda</h2>
+    <p>
+      Setumpuk dua puluh bingkai RAW adalah sekitar satu gigabita foto, dan itu
+      banyak untuk diserahkan kepada sebuah situs web demi diambil rata-ratanya.
+      <a href="../../tumpuk-gambar/">Penumpuk Gambar</a> membaca file-nya dari
+      disk Anda sendiri lalu mengerjakan hitungannya di peramban Anda sendiri.
+      Tidak ada langkah unggah, tidak ada akun, dan tidak ada antrean, dan Anda
+      bisa memeriksa klaim itu seperti Anda akan memeriksa klaim siapa pun: buka
+      panel jaringan peramban Anda selagi ia berjalan, atau sekadar cabut koneksi
+      internet lalu tetap tumpuk mereka.
+    </p>
+    <p>
+      Pertanyaan terkaitnya &mdash; bagaimana tahu, untuk alat mana pun, apakah
+      menyerahkan sebuah file kepadanya memang perlu &mdash; adalah
+      <a href="../apakah-aman-mengunggah-file/">panduannya sendiri</a>.
+    </p>
+  </section>

--- a/locales/id/pages/guides/stack-photos-to-reduce-noise.toml
+++ b/locales/id/pages/guides/stack-photos-to-reduce-noise.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: menumpuk foto untuk mengurangi derau - Bahasa Indonesia.
+#
+
+nav = "Menumpuk foto"
+title = "Cara Menumpuk Foto untuk Mengurangi Derau, atau Membuang Orang"
+description = "Menumpuk menggabungkan sebuah burst bingkai menjadi satu gambar. Metode mana yang dipakai tergantung apa yang ingin Anda hilangkan: derau, orang yang lewat, atau kedalaman bidang yang tipis pada sebuah bidikan makro. Cara kerja masing-masing, berapa harganya, dan di mana file RAW cocok."
+
+heading = "Cara menumpuk foto untuk mengurangi derau, atau membuang orang"
+lede = """
+    Sebuah burst bingkai menyimpan lebih banyak informasi daripada satu pun di
+    antaranya. Merata-ratakannya membatalkan deraunya; mengambil nilai tengah
+    setiap pikselnya menghapus apa pun yang hanya ada sebagian waktu. Anda mau
+    yang mana sepenuhnya tergantung apa yang bergerak."""
+
+updated = "25 Agustus 2026"
+
+og_title = "Cara menumpuk foto untuk mengurangi derau, atau membuang orang"
+og_description = "Rata-ratakan sebuah burst untuk membunuh derau, ambil mediannya untuk mengosongkan alun-alun yang ramai, terangkan untuk jejak bintang. Metode mana menyelesaikan masalah mana, dan di mana file RAW cocok."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/trim-a-video.html
+++ b/locales/id/pages/guides/trim-a-video.html
@@ -1,0 +1,204 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../potong-video/">Pemotong Video</a>, jatuhkan klipnya,
+      tekan <kbd>I</kbd> dan <kbd>O</kbd> untuk menandai setiap bagian yang Anda
+      mau &mdash; sebanyak yang Anda suka &mdash; lalu ekspor. Pada sebuah MP4,
+      MOV, atau M4V, bingkai yang Anda simpan dipindahkan ke file barunya persis
+      seperti sebelumnya &mdash; byte yang sama, setelan pengode yang sama,
+      semuanya sama &mdash; dan suaranya disalin sampel demi sampel tanpa
+      didekodekan.
+    </p>
+    <p>
+      Artinya sebuah pemotongan tidak mengorbankan kualitas apa pun dari Anda,
+      dan ia cepat: memotong satu menit dari rekaman empat gigabita memakan
+      kira-kira sebanyak biaya menulis satu menit itu ke disk, karena bingkainya
+      ditunjuk alih-alih dimuat. Satu tempat yang memperlihatkan ini adalah di
+      mana potongan Anda sebenarnya mendarat, dan itulah sisa halaman ini.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa sebuah pemotongan sama sekali tidak perlu kehilangan kualitas</h2>
+    <p>
+      Memotong tidak mengubah rupa satu bingkai pun. Setiap bingkai yang Anda
+      simpan seharusnya keluar identik dengan saat ia masuk, jadi tidak ada
+      alasan mendekodekannya lalu mengodekannya lagi &mdash; dan ada segala
+      alasan untuk tidak, karena pengodean ulang itu merugikan dan akan membuat
+      seluruh klipnya sedikit lebih buruk demi memendekkannya.
+    </p>
+    <p>
+      Jadi pemotong yang baik tidak mengodekan ulang. Ia membaca indeks
+      file-nya, memperhitungkan bingkai terkodekan mana yang jatuh di rentang
+      Anda, lalu menulis byte itu ke sebuah wadah baru dengan indeks baru di
+      depannya. Sama sekali tidak ada yang didekodekan di jalur itu.
+    </p>
+    <p>
+      Banyak alat tetap mengodekan ulang, karena mendekodekan dan mengodekan
+      ulang jauh lebih sederhana diwujudkan daripada membaca format wadahnya.
+      Anda biasanya bisa tahu Anda sedang memakai yang mana dari berapa lama
+      waktunya: penyalinan dibatasi seberapa cepat disk Anda menulis, dan
+      pengodean ulang dibatasi seberapa cepat mesin Anda mengodekan video, yang
+      seratus kali lebih lambat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Keyframe, dan kenapa potongan Anda bisa mendarat lebih awal</h2>
+    <p>
+      Inilah kekangan yang menjadi asal segala hal tentang pemotongan.
+    </p>
+    <p>
+      Video tidak disimpan sebagai runtutan gambar utuh. Itu akan sangat besar.
+      Kebanyakan bingkai disimpan sebagai keterangan tentang bedanya mereka
+      dengan tetangganya, dan itu berarti mereka tidak bisa didekodekan sendirian
+      &mdash; Anda butuh bingkai di sekitarnya. Hanya sebuah
+      <strong>keyframe</strong> yang berdiri sendiri sebagai gambar utuh, dan
+      keyframe biasanya berjarak satu sampai sepuluh detik.
+    </p>
+    <p>
+      Jadi kalau Anda menandai sebuah potongan dua detik setelah keyframe
+      terakhir, pemotong yang menyalin bingkai tidak bisa mulai di sana. Bingkai
+      di tanda Anda tidak terbaca tanpa rangkaian yang menuju ke sana. Ia harus
+      membawa seluruh bentangan dari keyframe di depan tanda Anda.
+    </p>
+    <p>
+      Yang dilakukannya soal itulah bagian yang menarik. Format file-nya punya
+      cara baku untuk berkata <em>mulai putar di titik ini</em> &mdash; bingkai
+      tambahannya ada di file-nya tapi wadahnya menyuruh pemutarnya melewatinya.
+      Setiap pemutar arus utama mematuhinya, dan klipnya mulai persis di tempat
+      yang Anda sebutkan. Pemutar yang mengabaikannya akan mulai lebih awal,
+      sejauh-jauhnya sepanjang jarak antar keyframe.
+    </p>
+    <p>
+      Alat di sini memberi tahu Anda Anda berada di kasus yang mana dan seberapa
+      jauh sebelum Anda mengekspor, jadi ia sebuah keputusan alih-alih sebuah
+      kejutan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kapan sebaiknya menerima pengodean ulang</h2>
+    <p>
+      Ada potongan yang tepat, dan ia bekerja dengan mengodekan ulang bentangan
+      pembukanya &mdash; mendekodekan dari keyframe-nya, lalu menuliskan
+      rangkaian bingkai baru yang sungguh mulai di tempat yang Anda tandai. Ia
+      lebih lambat, dan ia mengorbankan sedikit kualitas hanya pada bentangan
+      pembuka itu.
+    </p>
+    <p>
+      Pilih itu ketika klipnya akan pergi ke tempat yang tidak akan mematuhi
+      instruksi wadahnya, atau ke tempat yang pemutarnya tidak bisa Anda
+      kendalikan: sebagian penyunting video, sebagian sistem siaran dan
+      konferensi, sebagian pemutar perangkat keras yang lebih tua. Pilih
+      penyalinannya untuk semua yang lain, dan itu hampir semuanya &mdash; sebuah
+      peramban, sebuah ponsel, sebuah lapak media sosial, sebuah pemutar media.
+    </p>
+    <p>
+      Pilihan ketiga yang tidak berbiaya: geser tanda Anda. Kalau alatnya
+      menunjukkan di mana keyframe-nya berada, menggeser potongannya ke yang
+      terdekat memberi Anda potongan yang tepat sama sekali tanpa pengodean
+      ulang. Jarang sekali selisih satu detik sepadan dengan melepaskan sebuah
+      penyalinan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mengeluarkan sepotong dari tengah</h2>
+    <p>
+      Memotong keluar sebuah bagian adalah operasi yang berbeda dari menyimpan
+      satu bagian, dan layak diketahui bahwa ia didukung, karena banyak pemotong
+      hanya melakukan yang kedua. Tandai bagian yang tidak Anda mau, pilih untuk
+      memotongnya keluar, dan yang tersisa di kedua sisinya disambung menjadi
+      satu klip dengan suaranya dibawa seiring.
+    </p>
+    <p>
+      Sambungannya punya kekangan keyframe yang sama di titik tempat separuh
+      keduanya melanjut, karena alasan yang sama. Ia bekerja di kedua jalur MP4
+      di sini. Ia satu hal yang tidak bisa dilakukan jalur cadangan lewat
+      perekaman di bawah, karena sebuah rekaman dibuat dalam satu jalan dari satu
+      kepala pemutar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Format, dan jalur cadangannya</h2>
+    <p>
+      <strong>MP4, M4V, dan MOV</strong> dibaca langsung, apa pun kodek di
+      dalamnya &mdash; H.264, HEVC, AV1, VP9. Menyalin bingkai tidak melibatkan
+      pendekodeannya, jadi jalur ini bekerja bahkan untuk kodek yang sama sekali
+      tidak punya dekoder di peramban Anda, dan itu akibat yang menyenangkan dari
+      tidak melihat gambarnya.
+    </p>
+    <p>
+      <strong>Apa pun lain yang bisa diputar peramban Anda</strong>, WebM yang
+      paling jelas, dipotong dengan memutarnya lalu merekam hasilnya. Itu
+      bekerja, dan ia punya dua ongkos: ia memakan waktu selama panjang
+      bagiannya, dan gambar serta suaranya dikodekan lagi.
+    </p>
+    <p>
+      <strong>AVI, WMV, FLV, dan kebanyakan MKV</strong> tidak bisa dibaca maupun
+      diputar peramban, dan alatnya mengatakannya alih-alih gagal di tengah
+      jalan. Ubah dulu yang itu menjadi MP4 dengan sesuatu yang menanganinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dua hal yang diam-diam keliru di tempat lain</h2>
+    <p>
+      <strong>Rotasi.</strong> Sebuah ponsel merekam dalam lanskap lalu menulis
+      instruksi rotasi ke dalam file-nya alih-alih memutar pikselnya. Pemotong
+      yang menyalin bingkai harus membawa instruksi itu ikut, atau klip potret
+      Anda keluar miring &mdash; dan itulah cara klasik sebuah video yang
+      dipotong menjadi rusak. Jalur yang tepat di sini memutar bingkainya sambil
+      mengodekannya ulang lalu menulis file yang sama sekali tidak butuh rotasi.
+    </p>
+    <p>
+      <strong>Sinkron audio.</strong> Audio dan video disimpan sebagai aliran
+      terpisah dengan pewaktuannya sendiri, dan keduanya tidak dipotong di titik
+      yang sama. Kalau keduanya tidak disejajarkan dengan sengaja di potongannya,
+      suaranya melenceng. Pada jalur penyalinan di sini, audionya disalin sampel
+      demi sampel tanpa didekodekan, jadi ia byte demi byte sama dengan yang ada
+      di file-nya, dan sebuah tanda sunting menjaganya seiring gambarnya sampai
+      seperseribu detik.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memotong bukan memangkas</h2>
+    <p>
+      Dua kata yang saling dipakai untuk yang lain. Memotong mengubah panjang
+      klipnya; memangkas mengubah bentuk gambarnya. Kalau yang Anda mau adalah
+      versi persegi dari video lanskap, atau bilah hitam hilang dari sisinya,
+      itulah <a href="../../pangkas-video/">Pemangkas Video</a> &mdash; dan tidak
+      seperti pemotongan, ia memang harus mengodekan ulang, karena alasan yang
+      dijelaskan <a href="../pangkas-video/">panduannya</a>.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh unggahan &mdash; terutama yang ini</h2>
+    <p>
+      Video adalah jenis file yang paling dikira orang harus diunggah, karena
+      file-nya besar dan pekerjaannya terdengar berat. Pemotongan adalah kasus
+      yang paling tidak begitu: pada jalur penyalinan, file-nya nyaris tidak
+      dibaca sama sekali. Alatnya menyusuri indeksnya, memperhitungkan rentang
+      byte mana yang disimpan, lalu menuliskannya. Mengunggah file empat gigabita
+      ke sebuah server supaya ia bisa melakukan itu akan menjadi cara paling
+      lambat yang mungkin untuk mengaturnya.
+    </p>
+    <p>
+      Ia juga jenis file yang mengunggahnya paling mahal kalau Anda lebih suka
+      tidak: video membawa wajah, suara, rumah, dan lokasi dengan cara yang tidak
+      dilakukan sebuah dokumen. Alat di sini tidak punya fitur jaringan dalam
+      bentuk apa pun, dan <code>Content-Security-Policy</code> halamannya
+      menyebut satu per satu setiap alamat yang boleh dihubunginya, dan tidak
+      satu pun milik situs ini.
+    </p>
+    <p>
+      Cabut koneksi internet lalu potong sebuah klip kalau Anda lebih suka
+      memeriksa daripada diberi tahu.
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain seperti itu.
+    </p>
+  </section>

--- a/locales/id/pages/guides/trim-a-video.toml
+++ b/locales/id/pages/guides/trim-a-video.toml
@@ -1,0 +1,24 @@
+#
+# Panduan: memotong video - Bahasa Indonesia.
+#
+# "Potong" di sepanjang halaman ini: memotong memendekkan klipnya, memangkas
+# mengubah bentuk gambarnya, dan halaman ini menutup dengan menjelaskan
+# bedanya.
+#
+
+nav = "Memotong video"
+title = "Cara Memotong Video Tanpa Mengodekannya Ulang"
+description = "Memotong sebuah klip tidak perlu kehilangan satu byte pun kualitas. Kenapa sebuah potongan kadang mendarat lebih awal daripada tanda Anda, apa hubungan keyframe dengan itu, dan kapan sebaiknya menerima pengodean ulang."
+
+heading = "Cara memotong video tanpa mengodekannya ulang"
+lede = """
+    Memotong tidak mengubah rupa satu bingkai pun, jadi pemotong yang baik tidak
+    menyentuhnya &mdash; ia memindahkannya ke file baru persis seperti
+    sebelumnya. Ini menjelaskan apa yang Anda dapat dari situ, dan satu tempat
+    yang memperlihatkannya."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara memotong video tanpa mengodekannya ulang"
+og_description = "Kenapa sebuah potongan kadang mendarat lebih awal daripada tanda Anda, apa hubungan keyframe dengan itu, dan kapan sebaiknya menerima pengodean ulang."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/trim-an-audio-file.html
+++ b/locales/id/pages/guides/trim-an-audio-file.html
@@ -1,0 +1,243 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../potong-audio/">Pemotong Audio</a>, jatuhkan rekamannya,
+      tekan <kbd>I</kbd> dan <kbd>O</kbd> untuk menandai setiap bagian yang Anda
+      mau &mdash; sebanyak yang Anda suka &mdash; lalu ekspor. Setiap potongan
+      mendarat pada sampel persis yang Anda tandai, sampel yang disimpan keluar
+      seperti saat ia masuk, dan sambungannya mendapat lesapan lima milidetik
+      supaya tidak bisa berdetak.
+    </p>
+    <p>
+      Itulah seluruh pekerjaannya. Sisa halaman ini adalah tentang kenapa
+      ketepatannya nyata alih-alih klaim pemasaran, dan tentang satu hal yang
+      memang keliru ketika Anda menyambung dua potong suara.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa potongan audio bisa tepat padahal potongan video tidak</h2>
+    <p>
+      Video tidak disimpan sebagai runtutan gambar utuh &mdash; itu akan sangat
+      besar. Kebanyakan bingkai disimpan sebagai keterangan tentang bedanya
+      mereka dengan tetangganya, jadi mereka tidak bisa didekodekan sendirian.
+      Hanya sebuah <strong>keyframe</strong> yang berdiri sendiri, dan keyframe
+      biasanya berjarak satu sampai sepuluh detik. Pemotong yang menyalin bingkai
+      karena itu tidak bisa mulai di mana pun Anda suka: ia harus mulai di sebuah
+      keyframe, dan itulah sebabnya video yang dipotong kadang mulai satu dua
+      detik sebelum tanda Anda.
+      <a href="../potong-video/">Panduan videonya</a> sebagian besar tentang itu.
+    </p>
+    <p>
+      Suara tidak punya padanannya. Begitu sebuah rekaman didekodekan, ia sebuah
+      rangkaian angka &mdash; satu per kanal, puluhan ribu kali sedetik &mdash;
+      dan setiap satunya berdiri sepenuhnya sendiri. Sampel 1.234.567 tidak butuh
+      sampel 1.234.566 untuk menjadi bermakna. Jadi sebuah potongan bisa dibuat
+      di sampel mana pun, dan "tepat di tempat yang Anda tandai" berarti persis
+      begitu: tanda Anda dalam detik, dikali laju sampelnya, dibulatkan ke sampel
+      utuh terdekat. Pada 48 kHz pembulatan itu paling banyak sepuluh mikrodetik.
+    </p>
+    <p>
+      Juga tidak ada perilaku yang tergantung pemutar untuk dikhawatirkan. Video
+      yang dipotong bergantung pada sebuah tanda sunting yang dipatuhi kebanyakan
+      pemutar dan diabaikan sebagian; WAV yang dipotong sekadar sampelnya, jadi
+      tidak ada lagi yang bisa diperselisihkan sebuah pemutar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Jebakannya: sebuah sambungan adalah keterputusan</h2>
+    <p>
+      Inilah hal yang sebenarnya keliru ketika Anda memotong audio, dan alasan
+      pemotong yang baik punya sebuah setelan untuknya.
+    </p>
+    <p>
+      Suara adalah gelombang. Ketika Anda memotong dari tengah satu kata langsung
+      ke tengah kata lain, sampel di ujung potongan pertama dan sampel di awal
+      potongan kedua sama sekali tidak berhubungan: bentuk gelombangnya bisa
+      melompat dari dekat puncak rentangnya ke dekat dasarnya dalam satu sampel.
+      Kerucut pengeras suara yang disuruh membuat lompatan itu membuat suara
+      paling tajam yang sanggup dibuatnya, dan Anda mendengarnya sebagai sebuah
+      <strong>detak</strong> atau tik di sambungannya.
+    </p>
+    <p>
+      Ini tidak ada hubungannya dengan kehilangan kualitas atau dengan formatnya.
+      Ia terjadi pada potongan yang sempurna tanpa kehilangan dari rekaman yang
+      sempurna bersih. Ia sekadar bunyi sebuah keterputusan. Pemotong yang
+      memotong pada sampel yang tepat dan tidak melakukan apa pun lagi akan
+      berdetak di sebagian sambungan dan tidak di sebagian lain, sepenuhnya
+      tergantung di mana di dalam bentuk gelombangnya kedua ujungnya kebetulan
+      mendarat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa sebenarnya yang dilakukan lesapan lima milidetik</h2>
+    <p>
+      Solusinya adalah menurunkan levelnya ke sunyi tepat sebelum potongannya
+      lalu menaikkannya kembali tepat sesudahnya, sehingga tidak ada lagi
+      lompatan yang harus dibuat. Itulah seluruh yang dimaksud dengan
+      &ldquo;lesapan&rdquo; di sini: sebuah landaian yang diterapkan pada
+      beberapa ratus sampel di setiap tepinya.
+    </p>
+    <p>
+      Panjangnya adalah bagian yang menarik. Lima milidetik kira-kira dua ratus
+      empat puluh sampel pada 48 kHz. Itu cukup panjang bagi kerucutnya untuk
+      bergerak &mdash; detaknya hilang sama sekali &mdash; dan jauh terlalu
+      pendek untuk didengar sebagai sebuah lesapan: lima milidetik kira-kira
+      seperlima waktu yang dibutuhkan untuk mengucapkan satu konsonan. Anda tidak
+      akan merasakan levelnya bergerak. Anda hanya akan merasakan bahwa
+      sambungannya bersih.
+    </p>
+    <p>
+      Lesapan yang lebih panjang ditawarkan karena sebagian bahan
+      menginginkannya. Dua puluh atau lima puluh milidetik layak dijangkau ketika
+      Anda menyambung musik, tempat hal yang terpotong adalah nada yang bertahan
+      alih-alih sebuah suku kata dan landaian terpendek masih bisa meninggalkan
+      letupan yang terdengar. Ucapan hampir tidak pernah butuh lebih dari lima.
+    </p>
+    <p>
+      Sebuah lesapan hanya pantas berada di tepi yang <em>memang</em> sebuah
+      potongan. Kalau sebuah bagian mulai tepat di awal rekamannya, tidak ada
+      yang dibuang di depannya &mdash; file-nya memang mulai di sana sebelum apa
+      pun dipotong &mdash; jadi melesapkannya masuk akan menjadi suntingan yang
+      tidak diminta siapa pun. Alat di sini menaruh lesapan hanya di tempat
+      sebuah sambungan ada, dan itulah sebabnya tidak memotong apa pun sama
+      sekali membiarkan setiap sampel tak tersentuh.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memotong sebuah MP3, dan kenapa yang keluar adalah WAV</h2>
+    <p>
+      Anda bisa membuka sebuah MP3, M4A, Ogg, atau file Opus lalu memotongnya.
+      Yang kembali adalah sebuah WAV, dan layak dinyatakan dengan jelas
+      pertukaran apa yang diwakilinya alih-alih menyajikannya sebagai sebuah
+      fitur.
+    </p>
+    <p>
+      Ada dua cara memotong audio terkompres. Satu adalah memotong data
+      terkompresnya langsung, memindahkan bingkai terkodekan yang utuh ke sebuah
+      file baru tanpa mendekodekannya. Itu menjaga file-nya tetap kecil dan tidak
+      mengorbankan kualitas &mdash; tapi sebuah bingkai MP3 panjangnya sekitar
+      dua puluh enam milidetik, jadi setiap potongan dibulatkan ke batas bingkai
+      terdekat, dan itu versi audio dari masalah keyframe. Ia juga pekerjaan yang
+      khas per format: pembaca MP3 tidak memotong file Opus apa pun.
+    </p>
+    <p>
+      Cara yang lain adalah mendekodekan, memotong pada sampel yang tepat, lalu
+      menuliskan sampelnya. Tidak ada yang dibulatkan, setiap format yang bisa
+      diputar peramban bekerja dengan cara yang sama, dan lesapannya bisa ada
+      sama sekali &mdash; Anda tidak bisa melandaikan level yang belum Anda
+      dekodekan. Ongkosnya adalah sampelnya harus dituliskan kembali dalam suatu
+      format, dan tidak ada peramban yang mengirimkan pengode MP3 atau AAC yang
+      bisa dipakai di sini. Sebuah WAV tidak butuh pengode: ia sampelnya dengan
+      sebuah header pendek di depan, jadi langkah itu tidak bisa kehilangan apa
+      pun.
+    </p>
+    <p>
+      Akibat praktisnya: yang keluar jauh lebih besar daripada yang masuk
+      &mdash; kira-kira sepuluh megabita semenit dalam stereo &mdash; dan ia
+      tidak <em>lebih baik</em> daripada MP3 asalnya, karena kompresi yang sudah
+      terjadi tidak bisa diurungkan. Segala hal bisa membuka sebuah WAV, dan apa
+      pun yang butuh sebuah MP3 bisa membuatnya dari situ dalam satu langkah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Menandai beberapa bagian sekaligus</h2>
+    <p>
+      Kebanyakan pemotong daring memberi Anda satu pasang pegangan lalu bertanya
+      bentangan tunggal mana yang disimpan. Itu menjawab pertanyaan yang keliru
+      untuk kebanyakan rekaman nyata. Wawancara satu jam tidak punya satu bagian
+      yang bagus; ia punya enam, tersebar, dan Anda menemukannya dengan
+      mendengarkannya sekali.
+    </p>
+    <p>
+      Jadi tandai sambil Anda mendengarkan: <kbd>I</kbd> di tempat sebuah bagian
+      mulai, <kbd>O</kbd> di tempat ia berakhir, sebanyak yang Anda suka. Setiap
+      pasang menjadi sebuah baris yang bisa Anda ubah waktunya atau susun
+      ulang, dan sebuah pita yang digambar di atas bentuk gelombangnya. File
+      jadinya adalah baris-baris itu yang disambung berurutan.
+    </p>
+    <p>
+      Daftar tanda yang sama juga menjawab pertanyaan sebaliknya. Kalau yang Anda
+      mau hilang adalah "eee"-nya, dering telepon, dan awalan yang gagal, tandai
+      <em>itu</em> lalu beralihlah ke &ldquo;potong keluar&rdquo; &mdash; semua
+      yang tidak Anda tandai yang disambung sebagai gantinya. Tandanya sama
+      bagaimanapun juga, jadi Anda bisa bolak-balik di antara keduanya lalu
+      memperhatikan panjang jadinya berubah tanpa menandai apa pun dua kali.
+    </p>
+    <p>
+      Menandai itu pekerjaan yang cermat, dan tab yang tertutup tidak boleh
+      mengorbankannya, jadi tandanya disimpan sebagai file teks biasa lalu bisa
+      dimuat kembali. Tata letaknya adalah tata letak yang ditulis
+      <a href="../../potong-video/">pemotong video</a>, dan itu berarti tanda
+      yang dibuat pada sebuah video bisa dijatuhkan ke audio hasil ekstraksinya
+      dan sebaliknya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lihat bentuk gelombangnya</h2>
+    <p>
+      Menandai suara dengan menggeser-geser pemutar itu tebak-tebakan; menandainya
+      dengan mata tidak. Sunyi tampak seperti sunyi, batuk tampak seperti batuk,
+      dan empat detik nada ruangan sebelum seseorang mulai bicara langsung
+      terlihat alih-alih harus dicari.
+    </p>
+    <p>
+      Ini paling penting untuk tanda yang sedikit dikelirukan orang: awal sebuah
+      kalimat biasanya sebaiknya duduk di keheningan <em>sebelum</em> tarikan
+      napasnya, bukan sesudahnya, dan ujungnya biasanya sebaiknya menyisakan satu
+      ketuk nada ruangan alih-alih dipotong pada konsonan terakhirnya. Keduanya
+      gamblang di gambarnya dan hampir mustahil dikenai dengan telinga saja.
+      Seret ujung sebuah bagian yang ditandai di sepanjang bentuk gelombangnya
+      untuk menggesernya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memotong bukan melesapkan, dan bukan menyunting</h2>
+    <p>
+      Tiga kata yang saling dipakai untuk yang lain. Memotong mengubah bagian
+      mana dari rekamannya yang selamat. Sebuah lesapan &mdash; yang jenis
+      musikal, selama beberapa detik &mdash; adalah efek yang disengaja pada
+      levelnya, dan beberapa milidetik yang dijelaskan di atas bukan itu; mereka
+      penghilangan detak yang kebetulan memakai hitungan yang sama.
+    </p>
+    <p>
+      Kalau yang Anda mau adalah rekamannya diputar mundur, dipercepat,
+      diperlambat tanpa nadanya bergeser, atau dinaikkan karena ia direkam
+      terlalu pelan, itulah <a href="../../sunting-audio/">Penyunting Audio</a>.
+      Ia dekoder yang sama dan penulis WAV yang sama; ia hanya melakukan hitungan
+      yang berbeda di antaranya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh unggahan</h2>
+    <p>
+      Memotong adalah hitungan atas sebuah larik. Peramban sudah punya sebuah
+      dekoder &mdash; ia dekoder yang sama yang memutar file-nya di sebuah elemen
+      <code>&lt;audio&gt;</code> &mdash; dan begitu sampelnya didekodekan,
+      menyimpan sebagian dan membuang sisanya adalah sebuah penyalinan. Tidak ada
+      langkah dalam keterangan itu yang bisa dikerjakan sebuah server dengan lebih
+      baik, dan sekali perjalanan bolak-balik ke sana akan menjadi bagian
+      terlambat dari seluruh pekerjaannya.
+    </p>
+    <p>
+      Ia juga jenis file yang mengunggahnya lebih mahal daripada dugaan orang.
+      Rekaman adalah suara: wawancara, kuliah, panggilan, pesan suara, sesi
+      terapi, seorang anak yang mengucapkan sesuatu yang ingin Anda simpan. Alat
+      di sini tidak punya fitur jaringan dalam bentuk apa pun, dan
+      <code>Content-Security-Policy</code> halamannya menyebut satu per satu
+      setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+    </p>
+    <p>
+      Cabut koneksi internet lalu potong sebuah rekaman kalau Anda lebih suka
+      memeriksa daripada diberi tahu.
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan tiga pemeriksaan lain seperti itu.
+    </p>
+  </section>

--- a/locales/id/pages/guides/trim-an-audio-file.toml
+++ b/locales/id/pages/guides/trim-an-audio-file.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: memotong file audio - Bahasa Indonesia.
+#
+
+nav = "Memotong file audio"
+title = "Cara Memotong Audio Tanpa Kehilangan Kualitas"
+description = "Di mana sebenarnya sebuah potongan audio mendarat, kenapa ia bisa tepat padahal potongan video tidak, kenapa sebuah sambungan kadang berdetak, dan apa sebenarnya yang dilakukan lesapan lima milidetik."
+
+heading = "Cara memotong audio tanpa kehilangan kualitas"
+lede = """
+    Potongan audio bisa mendarat pada saat persis yang Anda tandai, di setiap
+    pemutar, selalu &mdash; dan itu tidak berlaku untuk video. Ini menjelaskan
+    kenapa, apa satu jebakan yang sesungguhnya, dan apa yang dilakukan
+    tentangnya."""
+
+updated = "21 Agustus 2026"
+
+og_title = "Cara memotong audio tanpa kehilangan kualitas"
+og_description = "Kenapa potongan audio bisa tepat padahal potongan video tidak, kenapa sebuah sambungan kadang berdetak, dan apa sebenarnya yang dilakukan lesapan lima milidetik."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/turn-a-video-into-a-gif.html
+++ b/locales/id/pages/guides/turn-a-video-into-a-gif.html
@@ -1,0 +1,231 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../video-ke-gif/">Pengubah Video ke GIF</a>, jatuhkan
+      klipnya, tandai detik yang Anda mau, lalu biarkan lebarnya di 480 dan
+      lajunya di 12 bingkai sedetik. Itulah setelan yang diinginkan kebanyakan
+      GIF. Kalau file-nya keluar terlalu besar, turunkan lebarnya sebelum Anda
+      menyentuh yang lain &mdash; itulah setelan yang membayar dua kali.
+    </p>
+    <p>
+      Sisa halaman ini adalah tentang kenapa, karena &ldquo;GIF saya 14 MB&rdquo;
+      adalah masalah yang sebenarnya dipunyai semua orang, dan tombol mana yang
+      harus diputar tidaklah gamblang.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa GIF dari sebuah video begitu raksasa</h2>
+    <p>
+      Kodek video menyimpan <em>gerakan</em>. Ia menulis satu gambar penuh setiap
+      beberapa detik lalu, untuk setiap bingkai di antaranya, sebuah keterangan
+      tentang bagaimana gambar itu bergerak: blok piksel ini menggeser empat ke
+      kiri, area ini menjadi sedikit lebih gelap. Klip lima detik bisa beberapa
+      ratus kilobita karena sebagian besarnya adalah instruksi tentang gambar
+      yang sudah Anda punya.
+    </p>
+    <p>
+      GIF tidak punya satu pun dari itu. Ia rampung pada 1989, sebelum satu pun
+      dari itu ada. Setiap bingkai adalah sebuah gambar, dikompres sendirian
+      dengan skema yang dirancang untuk tangkapan layar sebuah lembar kerja.
+      Tidak ada perkiraan gerak di mana pun dalam formatnya dan tidak ada cara
+      menambahkannya.
+    </p>
+    <p>
+      Jadi angka yang harus diharapkan adalah <strong>sepuluh kali ukuran
+      videonya</strong>, dan tidak ada pengubah yang bisa membujuk Anda keluar
+      dari itu. Yang bisa dilakukan pengubah yang baik adalah tidak memboroskan
+      apa pun di atas itu, dan memberi Anda tiga setelan yang benar-benar
+      menentukannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ketiga setelannya, dan berapa harga masing-masing</h2>
+    <p>
+      Semua tentang ukuran sebuah GIF berujung pada berapa banyak piksel yang
+      dimuatnya, yaitu panjangnya kali lajunya kali luas satu bingkainya.
+    </p>
+    <ul>
+      <li>
+        <strong>Bagiannya &mdash; linear.</strong> Dua kali lebih panjang adalah
+        dua kali lebih banyak bingkai dan kira-kira dua kali file-nya. Inilah
+        yang sudah dipahami kebanyakan orang, dan layak bersikap tega soal ini:
+        GIF yang menyampaikan maksudnya dalam tiga detik adalah GIF yang lebih
+        baik sekaligus lebih kecil.
+      </li>
+      <li>
+        <strong>Lebarnya &mdash; kuadratik.</strong> Menyetengahkan lebarnya
+        menyetengahkan tingginya sekalian, jadi ia <em>seperempat</em> pikselnya.
+        Turun dari 640 ke 320 tidak menghemat sedikit di bawah separuh; ia
+        menghemat sekitar tiga perempat. Inilah setelan yang tidak dijangkau
+        siapa pun lebih dulu dan yang paling menguntungkan.
+      </li>
+      <li>
+        <strong>Frame rate-nya &mdash; linear.</strong> Sepuluh bingkai sedetik
+        adalah dua pertiga ukuran lima belas. Ia juga setelan yang kerugiannya
+        paling terlihat, karena gerakan yang terlalu lambat terbaca sebagai rusak
+        alih-alih sebagai kecil.
+      </li>
+    </ul>
+    <p>
+      Sebuah contoh terhitung. Enam detik klip ponsel pada 1080&times;1920
+      miliknya sendiri dan 30 fps adalah 180 bingkai berisi dua juta piksel:
+      sekitar 350 juta piksel, dan itu bukan GIF, itu penyanderaan. Enam detik
+      yang sama pada lebar 480 dan 12 fps adalah 72 bingkai berisi 400.000 piksel
+      &mdash; 30 juta, sekitar seperduabelas &mdash; dan ia tampak seperti yang
+      dimaksud orang dengan sebuah GIF.
+    </p>
+  </section>
+
+  <section>
+    <h2>Frame rate mana yang dipilih</h2>
+    <p>
+      Dua belas adalah bawaan di sini dan jawaban yang benar secara mengejutkan
+      sering. Itulah laju yang dipakai animasi gambar tangan selama satu abad:
+      cukup cepat sehingga mata membacanya sebagai gerakan yang menerus, cukup
+      lambat sehingga Anda tidak membayar bingkai yang tidak bisa dilihat siapa
+      pun.
+    </p>
+    <ul>
+      <li><strong>5&ndash;8</strong> &mdash; terasa seperti tayangan slide. Cukup
+        untuk geseran lambat atau rekaman layar yang tidak ada yang bergerak
+        cepat.</li>
+      <li><strong>10&ndash;15</strong> &mdash; normal. Terbaca sebagai gerakan.
+        Hampir setiap GIF yang layak dibuat ada di sini.</li>
+      <li><strong>20&ndash;25</strong> &mdash; halus, dan kira-kira dua kali
+        ukuran 12 untuk perbedaan yang tidak akan bisa disebutkan kebanyakan
+        penonton. Sepadan untuk gerakan cepat, klip olahraga, apa pun yang ada
+        geseran kilatnya.</li>
+    </ul>
+    <p>
+      Ada langit-langit keras yang sebaiknya Anda tahu: GIF menyimpan berapa lama
+      setiap bingkai bertahan di layar dalam perseratus detik, dan setiap
+      peramban memperlakukan jeda di bawah dua perseratus sebagai sepuluh. Jadi
+      50 bingkai sedetik adalah maksimum yang sesungguhnya, dan file yang meminta
+      100 akan diam-diam diputar pada 10. Pengubah yang menawari Anda 60 fps
+      entah mengabaikan itu entah sebentar lagi mengejutkan Anda.
+    </p>
+  </section>
+
+  <section>
+    <h2>256 warna, dan untuk apa dithering</h2>
+    <p>
+      Separuh lain dari usia formatnya: sebuah GIF membawa satu tabel berisi
+      paling banyak 256 warna, dan setiap piksel adalah sebuah angka yang
+      menunjuk ke dalamnya. Sebuah bingkai video punya sampai enam belas juta.
+      Hampir semuanya dibuang, dan bagaimana ia dibuang adalah sebagian besar
+      rupa sebuah GIF.
+    </p>
+    <p>
+      Pengubah yang baik menghitung warna di klip <em>Anda</em> lalu memilih 256
+      yang cocok dengannya, alih-alih memakai kumpulan yang tetap. Bidikan sebuah
+      hutan mendapat 256 hijau; bidikan matahari terbenam mendapat 256 jingga.
+      Itulah yang dilakukan alat di sini, di seluruh bingkai bagiannya alih-alih
+      hanya yang pertama, jadi warna yang hanya muncul di akhir tetap mendapat
+      tempat.
+    </p>
+    <p>
+      <strong>Dithering</strong> adalah yang terjadi ketika warna yang Anda
+      butuhkan tetap tidak ada. Alih-alih membulatkan seluruh area ke warna
+      terdekat yang tersedia &mdash; yang mengubah langit yang mulus menjadi
+      empat pita datar dengan langkah yang terlihat di antaranya &mdash; ia
+      menyelang-nyelingkan dua warna terdekat dalam pola halus, dan dari jarak
+      pandang normal mata Anda mencampur keduanya menjadi warna yang tidak ada
+      itu.
+    </p>
+    <ul>
+      <li><strong>Biarkan menyala</strong> untuk apa pun yang bersifat foto:
+        langit, kulit, gradien, bayangan, film.</li>
+      <li><strong>Matikan</strong> untuk warna datar: rekaman layar, gambar
+        garis, logo, kartun, apa pun yang punya area luas berisi satu corak.
+        Tidak ada gradien untuk dilindungi, dan file-nya lebih kecil dan lebih
+        bersih tanpanya.</li>
+    </ul>
+    <p>
+      Satu detail yang layak diketahui kalau Anda membandingkan pengubah. Cara
+      dithering yang gamblang &mdash; penyebaran galat, yang dipakai kebanyakan
+      penyunting gambar &mdash; membuat hasil setiap piksel bergantung pada
+      piksel di sekitarnya. Pada sebuah animasi, itu berarti latar yang tidak
+      bergerak tetap ter-dither berbeda di setiap bingkai, jadi ia terlihat
+      merayap, dan setiap bingkai harus disimpan utuh karena secara teknis setiap
+      pikselnya berubah. Alternatifnya, dither berurutan, hanya bergantung pada
+      di mana sebuah piksel berada, jadi latar yang diam tetap benar-benar diam.
+      Itulah yang dipakai alat ini, dan itulah sebabnya file-nya lebih kecil
+      sekaligus lebih tenang.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kapan sebaiknya tidak membuat GIF sama sekali</h2>
+    <p>
+      Layak ditanyakan, karena jawaban yang jujur sering kali &ldquo;jangan&rdquo;.
+      MP4 atau WebM yang bisu dan berputar terus adalah sekitar sepersepuluh
+      ukuran animasi yang sama sebagai GIF, diputar dengan cara yang sama, dan
+      itulah yang toh dijadikan setiap lapak media sosial dari GIF Anda setelah
+      Anda mengunggahnya.
+    </p>
+    <p>Simpan GIF-nya kalau tujuannya memang sungguh membutuhkannya:</p>
+    <ul>
+      <li>tempat yang hanya menerima sebuah gambar &mdash; banyak perangkat lunak
+        obrolan, forum, wiki, dan email;</li>
+      <li>sebuah README atau halaman dokumentasi, tempat sebuah GIF diputar
+        sebaris dan sebuah video butuh pemutar;</li>
+      <li>sebuah dek slide atau dokumen yang harus terus bergerak tanpa
+        internet;</li>
+      <li>sebuah emoji, stiker, reaksi &mdash; cukup kecil sehingga tidak satu
+        pun hitungan ukuran di atas jadi soal.</li>
+    </ul>
+    <p>
+      Kalau suaranya penting, pertanyaannya menjawab dirinya sendiri: GIF tidak
+      pernah punya audio dan tidak akan pernah punya. Potong videonya saja
+      &mdash; <a href="../../potong-video/">Pemotong Video</a> mengambil sebuah
+      bagian tanpa mengodekan ulang satu bingkai pun darinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Masuk ke bawah sebuah batas ukuran</h2>
+    <p>
+      Sebagian besar alasan orang menyetel sebuah GIF adalah sebuah batas di
+      ujung sana. Dalam urutan kasar seberapa menggigitnya:
+    </p>
+    <ul>
+      <li><strong>Email</strong> &mdash; 10 sampai 25 MB untuk seluruh pesannya,
+        dan lampiran yang mendekati itu dibuang atau dipantulkan oleh sesuatu di
+        tengah jalan. Bidik jauh di bawahnya.</li>
+      <li><strong>Obrolan dan forum</strong> &mdash; biasanya 8 sampai 10 MB,
+        kadang jauh lebih kecil untuk pratinjau sebaris alih-alih sebuah
+        unduhan.</li>
+      <li><strong>README GitHub</strong> &mdash; 10 MB per file, dan apa pun di
+        atas beberapa megabita membuat halamannya terasa rusak di sebuah
+        ponsel.</li>
+      <li><strong>Slot stiker dan emoji</strong> &mdash; sering beberapa ratus
+        kilobita, dan itu berarti lebar yang kecil dan bagian yang pendek, bukan
+        frame rate yang lebih rendah.</li>
+    </ul>
+    <p>
+      Urutan yang dicoba ketika Anda kelebihan: perpendek bagiannya, lalu
+      setengahkan lebarnya, lalu turunkan lajunya, lalu matikan dithering-nya.
+      Dua yang pertama lebih berharga daripada dua yang terakhir disatukan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Mengubah sebuah video menjadi GIF adalah mendekodekan, mengubah ukuran,
+      menghitung warna, dan mengompres &mdash; empat hal yang sudah bisa
+      dilakukan sebuah peramban sendiri bertahun-tahun. Alat yang ditautkan di
+      atas melakukan semuanya di mesin Anda: file-nya dibaca dari disk Anda,
+      bingkainya didekodekan oleh peramban Anda, dan GIF-nya dirakit di memori
+      lalu diserahkan ke unduhan Anda.
+    </p>
+    <p>
+      Itu layak dipedulikan di sini lebih daripada biasanya. Klip yang diubah
+      orang menjadi GIF adalah klip pribadi &mdash; sebuah momen dari video
+      keluarga, rekaman layar sesuatu di tempat kerja, beberapa detik sebuah
+      panggilan. Pengubah yang ingin itu diunggah sedang meminta salinannya, dan
+      tidak ada lagi alasan teknis untuk mengiyakan.
+    </p>
+  </section>

--- a/locales/id/pages/guides/turn-a-video-into-a-gif.toml
+++ b/locales/id/pages/guides/turn-a-video-into-a-gif.toml
@@ -1,0 +1,20 @@
+#
+# Panduan: mengubah video menjadi GIF - Bahasa Indonesia.
+#
+
+nav = "Membuat GIF dari video"
+title = "Cara Mengubah Video Menjadi GIF (dan Menjaganya Tetap Kecil)"
+description = "Bagian mana, lebar berapa, dan frame rate mana yang dipilih, kenapa GIF dari sebuah video sepuluh kali ukuran videonya, dan kapan sebaiknya memakai GIF sama sekali."
+
+heading = "Cara mengubah video menjadi GIF"
+lede = """
+    GIF adalah format dari tahun 1987 yang menyimpan gambar utuh alih-alih
+    gerakan, jadi GIF yang dibuat dari sebuah video selalu besar. Ini tentang
+    setelan mana dari ketiganya yang digerakkan ketika ia terlalu besar, dan
+    seberapa banyak yang Anda dapat dari masing-masing."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara mengubah video menjadi GIF, dan menjaganya tetap kecil"
+og_description = "Tiga setelan yang menentukan ukuran sebuah GIF, berapa harga masing-masing, dan kapan GIF adalah jawaban yang sama sekali keliru."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/turn-images-into-a-video.html
+++ b/locales/id/pages/guides/turn-images-into-a-video.html
@@ -1,0 +1,200 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../gambar-ke-video/">Gambar ke Video</a>, jatuhkan
+      gambarnya, susun urutannya, tentukan berapa lama masing-masing ditahan,
+      lalu buat videonya. Anda mendapat sebuah MP4 dengan video H.264, yang bisa
+      diputar di hampir apa saja.
+    </p>
+    <p>
+      Dua setelan yang paling sering butuh putaran kedua adalah durasi dan
+      resolusinya, dan keduanya layak dipahami sebelum render pertama alih-alih
+      sesudahnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Frame rate dan durasi bukan hal yang sama</h2>
+    <p>
+      Inilah kebingungan yang membuat orang harus merender ulang.
+    </p>
+    <p>
+      <strong>Durasi</strong> adalah berapa lama setiap gambar bertahan di layar.
+      Itulah setelan yang sebenarnya Anda pedulikan. Tiga detik adalah bawaan
+      yang nyaman untuk tayangan slide yang sedang ditonton orang; satu sampai
+      dua detik terasa cepat; lebih dari lima terasa berlarut kecuali ada narasi
+      di atasnya.
+    </p>
+    <p>
+      <strong>Frame rate</strong> adalah berapa kali sedetik videonya mengulang
+      gambar itu. Ia sama sekali tidak mengubah rupa tayangan slidenya &mdash;
+      gambar diam yang ditahan tiga detik tampak identik pada 24 bingkai per
+      detik dan pada 60 &mdash; dan ia mengubah ukuran file serta waktu
+      pengodeannya cukup banyak.
+    </p>
+    <p>
+      Jadi untuk tayangan slide biasa, pilih frame rate yang rendah. 24 atau 30
+      sudah lebih dari cukup. Alasan untuk naik lebih tinggi adalah kalau ada
+      gerakan di videonya: geseran atau perbesaran melintasi setiap foto, atau
+      lesapan silang di antaranya, tempat frame rate rendah terlihat sebagai
+      langkah-langkah patah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Resolusi, dan gambar yang bentuknya tidak pas</h2>
+    <p>
+      Sebuah video punya satu ukuran bingkai sepanjang durasinya. Foto Anda
+      hampir pasti tidak semuanya berbagi satu ukuran, jadi sesuatu harus terjadi
+      pada yang tidak muat &mdash; dan sesuatu itulah pilihan yang layak dibuat
+      dengan sengaja.
+    </p>
+    <p>
+      Mulailah dengan memilih resolusinya dari ke mana videonya akan pergi:
+    </p>
+    <ul>
+      <li>
+        <strong>1920&times;1080</strong> untuk apa pun yang umum. Didukung di
+        mana-mana, bisa diputar di mana saja, dan itulah yang dimaksud
+        kebanyakan orang dengan HD.
+      </li>
+      <li>
+        <strong>1080&times;1920</strong> &mdash; angka yang sama dibalik &mdash;
+        untuk tujuan yang mengutamakan ponsel: story, reel, short.
+      </li>
+      <li>
+        <strong>3840&times;2160</strong> hanya kalau gambarnya memang punya
+        detail sebanyak itu dan tujuannya akan menampilkannya. Ia empat kali
+        pikselnya, empat kali waktu pengodeannya, dan kira-kira empat kali
+        file-nya.
+      </li>
+    </ul>
+    <p>
+      Lalu putuskan apa yang terjadi pada yang tidak pas. Memaskan setiap gambar
+      di dalam bingkainya menjaga seluruhnya dan meninggalkan bilah di sisinya
+      &mdash; aman, dan itulah jawaban yang benar ketika gambarnya lebih penting
+      daripada penyajiannya. Mengisi bingkainya lalu memangkas kelebihannya
+      tampak lebih baik dan akan memotong bagian atas sebagian gambarnya.
+      Mencampur foto potret dan lanskap dalam satu video adalah kasus yang tidak
+      punya jawaban baik; memutuskan lebih dulu ke arah mana Anda lebih rela
+      keliru menghemat satu render ulang.
+    </p>
+  </section>
+
+  <section>
+    <h2>Urutan, dan jebakan nama file</h2>
+    <p>
+      Seperti pada pekerjaan kumpulan mana pun, nama file terurut dengan cara
+      yang bukan cara Anda menghitung. <code>foto2.jpg</code> datang setelah
+      <code>foto10.jpg</code> dalam pengurutan alfabetis, karena
+      perbandingannya karakter demi karakter.
+    </p>
+    <p>
+      Mengurutkan menurut tanggal pengambilan biasanya benar untuk foto sebuah
+      acara, karena Anda memotretnya dalam urutan kejadiannya. Menyeret ubinnya
+      benar untuk apa pun yang ceritanya tidak kronologis. Periksa sebelum Anda
+      merender: video adalah satu-satunya hasil yang perbaikan urutannya berarti
+      mengulang seluruh pekerjaannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak ada suaranya, dan itu bukan perkara kecil</h2>
+    <p>
+      MP4 yang ditulis alat ini punya satu trek video dan sama sekali tidak punya
+      trek audio. Kalau tayangan slide Anda butuh musik atau narasi, Anda akan
+      butuh sebuah penyunting video untuk langkah itu.
+    </p>
+    <p>
+      Layak diketahui kenapa, alih-alih sekadar bahwa: menambahkan audio berarti
+      mendekodekan sebuah file musik, mengodekannya ke AAC, dan menyelang-nyeling
+      dengan videonya di dalam wadahnya. Ketiganya pekerjaan sungguhan, dan
+      melakukannya dengan buruk menghasilkan file yang makin lama makin tidak
+      sinkron saat diputar. Ia ada di daftar alih-alih dikerjakan setengah-setengah.
+    </p>
+    <p>
+      Satu catatan praktis kalau Anda memang menambahkan musik sesudahnya: pilih
+      lagunya lebih dulu lalu setel durasi per gambar supaya tayangan slidenya
+      keluar mendekati panjang lagunya. Memotong musiknya supaya pas dengan
+      videonya selalu terdengar lebih buruk daripada memaskan videonya dengan
+      musiknya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang keluar, dan apa yang dilakukan kalau ia tidak mau diputar</h2>
+    <p>
+      MP4 dengan H.264 adalah sasarannya, dan itulah kombinasi yang paling luas
+      bisa diputar. Di peramban tanpa WebCodecs, alatnya mundur ke merekam WebM
+      sebagai gantinya &mdash; rekaman yang sama di dalam wadah yang diterima
+      lebih sedikit penyunting dan lapak media sosial.
+    </p>
+    <p>
+      Kalau Anda berakhir dengan sebuah WebM dan sesuatu menolaknya, solusinya
+      adalah peramban yang mendukung WebCodecs alih-alih sebuah pengubahan: versi
+      terkini Chrome, Edge, dan Safari semuanya mendukung. Merender ulang lebih
+      baik daripada mengubah, karena mengubah berarti satu generasi lagi
+      pengodean yang merugikan.
+    </p>
+    <p>
+      Tidak ada batas yang dibangun ke dalam alatnya soal berapa banyak gambar
+      yang bisa Anda pakai. Langit-langitnya adalah memori mesin Anda sendiri,
+      karena video jadinya dirakit di sana sebelum Anda mengunduhnya &mdash;
+      tayangan slide 4K yang panjang adalah yang pertama merasakannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Membuat file-nya lebih kecil</h2>
+    <p>
+      Kalau hasilnya terlalu besar untuk ke mana pun ia akan pergi, dalam urutan
+      apa yang benar-benar membantu:
+    </p>
+    <p>
+      <strong>Turunkan frame rate-nya.</strong> Untuk tayangan slide yang diam,
+      ini tidak mengorbankan apa pun yang terlihat dan merupakan penghematan
+      tunggal terbesar yang tersedia.
+    </p>
+    <p>
+      <strong>Turunkan resolusinya.</strong> 1080p alih-alih 4K adalah seperempat
+      pikselnya, dan di layar ponsel tidak ada yang akan tahu.
+    </p>
+    <p>
+      <strong>Perpendek.</strong> Tiga detik per gambar alih-alih lima adalah 40%
+      lebih pendek dan 40% lebih kecil file-nya, dan biasanya tayangan slide yang
+      lebih baik.
+    </p>
+    <p>
+      Mengecilkan foto sumbernya lebih dulu tidak banyak membantu. Videonya
+      dikodekan pada resolusi yang Anda pilih bagaimanapun juga, jadi foto 4000
+      piksel dan foto 2000 piksel menghasilkan jumlah byte yang hampir sama di
+      dalam video 1080p. Ia memang membuat pengodeannya lebih cepat, dan ia
+      menggeser langit-langit memori itu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kenapa ini tidak butuh server, dengan satu pengecualian yang dinyatakan</h2>
+    <p>
+      Mengodekan video dulu adalah alasan paling gamblang untuk mengunggah:
+      peramban tidak bisa melakukannya, dan mesin dengan FFmpeg bisa. WebCodecs
+      mengubah itu dengan membuka pengode perangkat keras yang sudah ada di mesin
+      Anda, yang sama dengan yang dipakai ponsel Anda untuk merekam video secara
+      langsung. Menyusun bingkainya adalah sebuah kanvas. Tidak satu pun dari
+      kedua langkah itu butuh apa pun selain perangkat keras Anda sendiri.
+    </p>
+    <p>
+      Satu pengecualian pada alat yang satu ini, dinyatakan alih-alih dikubur:
+      fitur opsional &ldquo;tambahkan dari sebuah alamat web&rdquo; mengambil
+      sebuah gambar dari alamat yang Anda tempelkan, dan server di alamat itu
+      melihat IP Anda dan apa yang Anda minta. Itu melekat pada fiturnya
+      alih-alih menjadi cacat di dalamnya, dan itulah satu-satunya langkah
+      jaringan di mana pun di dalam alatnya. Jangan pakai dan sama sekali tidak
+      ada yang meninggalkan mesin Anda.
+    </p>
+    <p>
+      <a href="../apakah-aman-mengunggah-file/">Amankah mengunggah file ke
+      pengubah daring?</a> memaparkan empat pemeriksaan yang akan memberi tahu
+      Anda hal yang sama tentang alat mana pun, termasuk yang ini.
+    </p>
+  </section>

--- a/locales/id/pages/guides/turn-images-into-a-video.toml
+++ b/locales/id/pages/guides/turn-images-into-a-video.toml
@@ -1,0 +1,19 @@
+#
+# Panduan: mengubah gambar menjadi video - Bahasa Indonesia.
+#
+
+nav = "Gambar menjadi video"
+title = "Cara Mengubah Satu Folder Gambar Menjadi Video"
+description = "Buat tayangan slide MP4 dari foto: apa yang sebenarnya dikendalikan frame rate dan durasi, bagaimana menangani gambar yang bentuknya tidak pas, dan kenapa hasilnya tidak bersuara."
+
+heading = "Cara mengubah satu folder gambar menjadi video"
+lede = """
+    Tayangan slide itu sederhana untuk dibuat dan gampang untuk dirender dua
+    kali, karena dua setelannya tidak berarti seperti kedengarannya. Inilah apa
+    yang dikendalikan masing-masing dan apa yang sebaiknya dipilih."""
+
+updated = "20 Agustus 2026"
+
+og_title = "Cara mengubah satu folder gambar menjadi video"
+og_description = "Apa yang sebenarnya dikendalikan frame rate dan durasi, bagaimana menangani gambar yang bentuknya tidak pas, dan kenapa tidak ada suaranya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/verify-a-file-checksum.html
+++ b/locales/id/pages/guides/verify-a-file-checksum.html
@@ -1,0 +1,258 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      Buka <a href="../../hitung-checksum/">Hash &amp; Checksum</a>, jatuhkan
+      file yang Anda unduh ke atasnya, lalu tempelkan checksum dari halaman
+      unduhannya ke kotak di bawah. Halamannya memperhitungkan angkanya berasal
+      dari algoritma yang mana dari panjangnya, lalu menjawab dalam satu kalimat.
+    </p>
+    <p>
+      Kalau ia cocok, byte di disk Anda adalah byte yang diukur penerbitnya.
+      Kalau tidak, unduh lagi file-nya sebelum Anda membukanya. Semua di bawah
+      ini adalah apa yang tidak disebutkan kalimat itu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Angka di bawah tautan unduhan itu apa</h2>
+    <p>
+      Ia keluaran sebuah fungsi hash: sebuah perhitungan yang membaca setiap byte
+      sebuah file lalu menghasilkan jawaban pendek berpanjang tetap. File yang
+      sama selalu memberi jawaban yang sama, dan file yang berbeda satu bit saja
+      memberi jawaban yang sama sekali berbeda &mdash; bukan yang nyaris identik,
+      melainkan yang tidak berhubungan. Sifat itulah seluruh yang diandalkan.
+    </p>
+    <p>
+      Karena jawabannya pendek dan file-nya tidak, perhitungannya membuang
+      informasi, dan mau tidak mau ada banyak file yang berbagi jawaban tertentu
+      mana pun. Menemukan salah satunya dengan sengaja itulah bagian yang sulit,
+      dan seberapa sulitnya itulah yang membedakan algoritma di bawah satu sama
+      lain.
+    </p>
+    <p>
+      Tidak ada yang rahasia tentang sebuah checksum dan tidak ada yang bisa
+      dibalik darinya. Ia sebuah sidik jari, diterbitkan supaya dua orang bisa
+      sepakat bahwa mereka memegang benda yang sama.
+    </p>
+  </section>
+
+  <section>
+    <h2>Anda sedang melihat algoritma yang mana</h2>
+    <p>
+      Anda tidak perlu memilih &mdash; penerbitnya sudah memilih, dan tugas Anda
+      adalah menghitung yang sama. Anda bisa tahu yang mana hanya dari
+      panjangnya:
+    </p>
+    <ul>
+      <li><strong>32 karakter heksadesimal</strong> &mdash; MD5.</li>
+      <li><strong>40</strong> &mdash; SHA-1.</li>
+      <li><strong>64</strong> &mdash; SHA-256, dan inilah yang paling akan Anda lihat.</li>
+      <li><strong>96</strong> &mdash; SHA-384.</li>
+      <li><strong>128</strong> &mdash; SHA-512.</li>
+    </ul>
+    <p>
+      Tidak ada dua di antaranya yang sama panjang, dan itulah sebabnya alatnya
+      bisa mengenali sebuah nilai yang ditempelkan tanpa diberi tahu. Teks
+      sepanjang 63 karakter bukan checksum apa pun; ia sebuah SHA-256 yang
+      kehilangan satu karakter dalam perjalanan ke papan klip Anda.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mengerjakannya di mesin Anda sendiri, tanpa peramban</h2>
+    <p>
+      Setiap sistem operasi membawa sesuatu yang melakukan ini, dan perintahnya
+      layak diketahui bahkan kalau Anda memakai sebuah halaman untuk itu &mdash;
+      tidak ada jawaban yang lebih baik untuk "bagaimana saya tahu situs Anda
+      menghitungnya dengan jujur" selain menjalankan file yang sama melalui alat
+      yang datang bersama komputer Anda.
+    </p>
+    <p><strong>Windows</strong>, di PowerShell:</p>
+    <pre><code>Get-FileHash .\disk.iso -Algorithm SHA256</code></pre>
+    <p>
+      Mesin yang lebih tua punya <code>certutil -hashfile disk.iso SHA256</code>
+      sebagai gantinya, yang mencetak dalam huruf besar dengan spasi di dalamnya.
+      Besar kecilnya huruf tidak pernah jadi soal dalam perbandingan checksum;
+      hurufnya adalah digit, bukan kata.
+    </p>
+    <p><strong>macOS</strong>:</p>
+    <pre><code>shasum -a 256 disk.iso</code></pre>
+    <p><strong>Linux</strong>:</p>
+    <pre><code>sha256sum disk.iso</code></pre>
+    <p>
+      Ketiganya mencetak teks yang sama untuk file yang sama, dan begitu juga
+      situs ini. Mereka spesifikasi yang tepat dengan vektor uji yang
+      diterbitkan; tidak ada ruang bagi sebuah wujud implementasi untuk punya
+      pendapat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Membandingkannya tanpa membuat mata juling</h2>
+    <p>
+      Jangan membaca enam puluh empat karakter dari dua layar lalu memutuskan
+      keduanya tampak sama. Orang memeriksa empat karakter pertama dan empat
+      terakhir lalu berhenti, dan persis itulah perbandingan yang akan diatur
+      seorang penyerang supaya lolos, dan itu juga cara sebuah kekeliruan jujur
+      dilambaikan lewat.
+    </p>
+    <p>
+      Tempelkan keduanya ke sesuatu yang bisa membandingkannya untuk Anda. Di
+      sebuah baris perintah, untuk itulah bendera <code>-c</code> ada:
+    </p>
+    <pre><code>sha256sum -c SHA256SUMS</code></pre>
+    <p>
+      Di sebuah peramban, itulah kotak perbandingan di
+      <a href="../../hitung-checksum/">Hash &amp; Checksum</a>, yang menerima
+      nilainya dalam bentuk apa pun yang ditulis penerbitnya &mdash; heksadesimal
+      telanjang, sebaris keluaran <code>sha256sum</code>, sebuah file
+      <code>SHA256SUMS</code> utuh, bentuk
+      <code>SHA256 (disk.iso) = &hellip;</code>, atau sebuah atribut
+      <code>integrity="sha384-&hellip;"</code> dari sebuah tag skrip &mdash; lalu
+      mengatakan ya atau tidak dalam satu kalimat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang dibuktikan sebuah kecocokan, persisnya</h2>
+    <p>
+      Bahwa byte di disk Anda adalah byte yang ada di hadapan seseorang ketika
+      mereka menuliskan angka itu. Itu hal yang sungguh berguna untuk diketahui
+      dan ia lebih sempit daripada dugaan kebanyakan orang, jadi layak
+      didaftarkan apa yang dicakupnya dan apa yang tidak.
+    </p>
+    <p><strong>Sebuah kecocokan menyingkirkan:</strong></p>
+    <ul>
+      <li>unduhan yang berhenti lebih awal lalu meninggalkan Anda file yang tampak utuh;</li>
+      <li>kerusakan dalam perjalanan, di disk yang mulai gagal, atau di kabel USB yang buruk;</li>
+      <li>file yang keliru &mdash; hasil bangun ARM alih-alih yang x86, atau rilis
+        bulan lalu;</li>
+      <li>mirror yang diam-diam menyajikan sesuatu selain yang diiklankannya.</li>
+    </ul>
+    <p><strong>Sebuah kecocokan tidak menyingkirkan:</strong></p>
+    <ul>
+      <li><strong>file-nya sendiri jahat.</strong> Sebuah penerbit bisa mengukur
+        perangkat perusak sama persis akuratnya dengan apa pun yang lain. Sebuah
+        checksum berkata "inilah yang mereka kirimkan", tidak pernah "ini
+        aman";</li>
+      <li><strong>penerbitnya sudah dibobol.</strong> Kalau ada yang mengganti
+        file-nya di servernya, mereka mengganti checksum di sebelahnya pada menit
+        yang sama. Yang membawa kita ke bagian berikutnya.</li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Kekeliruan yang membuat seluruh latihannya sia-sia</h2>
+    <p>
+      Mengambil checksum-nya dari halaman yang sama, lewat koneksi yang sama,
+      dengan file-nya.
+    </p>
+    <p>
+      Pikirkan apa yang sedang Anda pertahankan. Kalau kekhawatirannya adalah
+      unduhan yang rusak, checksum-nya bisa datang dari mana saja dan
+      pemeriksaannya bekerja. Kalau kekhawatirannya adalah seseorang mengutak-atik
+      file-nya, maka siapa pun yang bisa mengubah file-nya bisa mengubah baris
+      heksadesimal yang tercetak di bawahnya, karena keduanya datang dari server
+      yang sama lewat koneksi yang sama. Anda akan meminta pemalsunya
+      mengukuhkan tanda tangannya.
+    </p>
+    <p>
+      Sebuah checksum paling berharga ketika ia mencapai Anda lewat rute yang
+      tidak dilalui file-nya:
+    </p>
+    <ul>
+      <li>sebuah file <code>SHA256SUMS</code> dengan tanda tangan GPG terpisah,
+        diperiksa terhadap kunci yang sudah Anda punya &mdash; inilah yang
+        diterbitkan distribusi dan inilah jawaban yang sesungguhnya;</li>
+      <li>pengumuman rilisnya di sebuah milis, atau sebuah tag di sebuah
+        repositori sumber, alih-alih halaman unduhannya;</li>
+      <li>sebuah mirror kedua di domain yang berbeda, lalu keduanya dibandingkan
+        satu sama lain;</li>
+      <li>sebuah pengelola paket, yang mengerjakan ini untuk Anda terhadap kunci
+        yang dikirim bersama sistem operasinya.</li>
+    </ul>
+    <p>
+      Tidak satu pun dari itu membuat memeriksa checksum dari halaman yang sama
+      jadi tak berguna. Ia menangkap unduhan yang rusak, dan itulah kegagalan
+      yang benar-benar menimpa orang. Hanya saja jangan mengatakan pada diri
+      sendiri bahwa ia menangkap hal lain.
+    </p>
+  </section>
+
+  <section>
+    <h2>MD5 dan SHA-1 sudah patah. Pakai saja, kadang-kadang</h2>
+    <p>
+      Keduanya sudah dipatahkan dalam makna terkuat yang penting di sini:
+      <em>tabrakan</em> bisa dibangun dengan sengaja. Dua file berbeda dengan MD5
+      yang sama sudah bisa dibangun di perangkat keras biasa sejak 2004, dan pada
+      2017 sebuah tim menghasilkan dua PDF berbeda dengan SHA-1 yang sama. Pada
+      2020, versi berawalan pilihan dari serangan itu turun ke beberapa puluh
+      ribu dolar komputasi sewaan.
+    </p>
+    <p>
+      Apa artinya pada praktiknya: MD5 yang cocok tidak lagi memberi tahu Anda
+      bahwa tidak ada yang mengutak-atik file-nya, karena orang yang mau bisa saja
+      sudah membangun file berbeda dengan angka yang sama. Ia tetap memberi tahu
+      Anda bahwa unduhannya tidak terpotong atau rusak, karena kecelakaan acak
+      tidak akan mendarat pada sebuah tabrakan &mdash; itu peluang yang tidak
+      pernah dimiliki kecelakaan mana pun.
+    </p>
+    <p>
+      Jadi kalau penerbitnya mencetak sebuah MD5 dan tidak lebih, periksa. Ia
+      lebih berharga daripada tidak memeriksa. Dan kalau Anda yang menerbitkan,
+      cetak sebuah SHA-256.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ia tidak cocok. Sekarang bagaimana?</h2>
+    <ol>
+      <li>
+        <strong>Unduh lagi</strong>, dari tempat yang sama. Transfer yang
+        terputus atau dilanjutkan adalah sejauh ini penyebab paling umum dan
+        salinan kedua biasanya menyelesaikannya.
+      </li>
+      <li>
+        <strong>Periksa Anda ada di baris yang benar.</strong> Halaman rilis
+        mendaftar beberapa file; checksum untuk pemasangnya tidak akan pernah
+        cocok dengan arsipnya, dan hasil bangun ARM tidak akan pernah cocok
+        dengan yang x86.
+      </li>
+      <li>
+        <strong>Periksa versinya.</strong> Halaman checksum yang dimarkahi jadi
+        basi pada hari sebuah rilis kecil dikirimkan.
+      </li>
+      <li>
+        <strong>Coba mirror yang lain</strong> lalu bandingkan checksum kedua
+        file-nya satu sama lain. Dua mirror yang sepakat satu sama lain dan tidak
+        sepakat dengan angka yang diterbitkan adalah masalah yang berbeda dari
+        satu mirror yang tidak sepakat dengan keduanya.
+      </li>
+      <li>
+        <strong>Jangan buka sementara itu.</strong> File yang gagal checksum-nya
+        paling baik berarti rusak dan paling buruk berarti bukan file yang Anda
+        minta.
+      </li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>Kenapa mengerjakan ini di sebuah peramban sama sekali</h2>
+    <p>
+      Karena baris perintah bukan tempat kebanyakan orang berada, dan karena
+      alternatif yang gamblang &mdash; sebuah situs web yang meminta Anda
+      mengunggah file-nya &mdash; adalah hal yang aneh untuk dilakukan pada
+      sebuah pemasang yang sudah Anda ragukan. Mengirim sebuah file ke suatu
+      tempat untuk mencari tahu apakah ia diutak-atik dalam perjalanan menambahkan
+      satu tempat lagi ia bisa diutak-atik.
+    </p>
+    <p>
+      <a href="../../hitung-checksum/">Hash &amp; Checksum</a> membaca file-nya
+      dalam potongan empat megabita di mesin Anda sendiri, jadi tidak ada
+      unggahan, tidak ada batas ukuran, dan tidak ada yang perlu dipercayai selain
+      halamannya sendiri &mdash; yang bisa Anda baca, dan yang terus bekerja
+      dengan jaringan tercabut. Kalau Anda lebih suka memercayai sistem operasi
+      Anda sendiri, jalankan perintah dari bagian di atas lalu bandingkan kedua
+      jawabannya. Mereka akan sepakat.
+    </p>
+  </section>

--- a/locales/id/pages/guides/verify-a-file-checksum.toml
+++ b/locales/id/pages/guides/verify-a-file-checksum.toml
@@ -1,0 +1,24 @@
+#
+# Panduan: memverifikasi checksum sebuah file - Bahasa Indonesia.
+#
+# Perintah di dalam badan halamannya tidak diterjemahkan: itulah yang diketik
+# orang, huruf demi huruf.
+#
+
+nav = "Memverifikasi checksum"
+title = "Cara Memverifikasi Unduhan dengan Checksum-nya (dan Apa yang Dibuktikannya)"
+description = "Cara memeriksa checksum MD5 atau SHA-256 di Windows, macOS, dan Linux atau di peramban Anda, apa yang sebenarnya dibuktikan sebuah kecocokan, dan kekeliruan yang membuat seluruh latihannya sia-sia."
+
+heading = "Cara memeriksa unduhan terhadap checksum-nya"
+lede = """
+    Baris heksadesimal di bawah sebuah tautan unduhan ada di sana supaya Anda
+    bisa membuktikan file-nya tiba utuh. Membandingkannya memakan sekitar satu
+    menit. Mengetahui berapa nilai perbandingan itu &mdash; dan satu kebiasaan
+    yang membuatnya tidak bernilai sama sekali &mdash; memakan sisa halaman
+    ini."""
+
+updated = "23 Agustus 2026"
+
+og_title = "Memeriksa unduhan terhadap checksum-nya, dan apa yang dibuktikannya"
+og_description = "Untuk apa heksadesimal di bawah sebuah tautan unduhan, bagaimana membandingkannya di sistem operasi mana pun, dan kenapa mengambilnya dari halaman yang sama dengan file-nya mementahkan maksudnya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/guides/whats-inside-a-gif.html
+++ b/locales/id/pages/guides/whats-inside-a-gif.html
@@ -1,0 +1,330 @@
+  <section>
+    <h2>Jawaban singkatnya</h2>
+    <p>
+      GIF adalah sebuah kanvas, sebuah daftar persegi panjang untuk dilukiskan ke
+      atasnya, dan sebuah tabel warna yang mengatakan apa arti angka di dalam
+      persegi panjang itu. Setiap persegi panjang membawa tiga hal: berapa lama
+      membiarkannya terpasang, apa yang dilakukan padanya sesudahnya, dan secara
+      opsional sebuah tabel warna miliknya sendiri.
+    </p>
+    <p>
+      Hampir semua yang dianggap orang mengejutkan tentang formatnya keluar dari
+      daftar itu. Kalau GIF Anda raksasa, itu karena persegi panjangnya adalah
+      seluruh kanvasnya setiap kali, atau karena ada tiga ratus tabel warna di
+      dalamnya. Kalau ia diputar terlalu lambat, itu karena jedanya di bawah
+      sebuah lantai yang tidak akan dilewati peramban mana pun. Kalau ia
+      mengotor, itu kolom yang disebut <em>pembuangan</em>.
+    </p>
+    <p>
+      Untuk melihat yang mana dari itu untuk file tertentu, buka
+      <a href="../../analisis-gif/">Penganalisis GIF</a> lalu jatuhkan file-nya.
+      Sisa halaman ini adalah apa arti angka-angkanya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bingkai adalah persegi panjang, bukan gambar</h2>
+    <p>
+      Inilah bagian yang mengejutkan orang yang hanya pernah melihat GIF diputar.
+      Sebuah bingkai bukan gambar animasinya pada momen itu. Ia sebuah persegi
+      panjang, dengan posisi dan ukurannya sendiri, dilukiskan di atas apa pun
+      yang ditinggalkan bingkai sebelumnya.
+    </p>
+    <p>
+      Persegi panjang itu bisa berupa seluruh kanvasnya, dan di file yang dibuat
+      dengan buruk ia selalu begitu. Tapi sebuah GIF boleh menyimpan hanya bagian
+      gambarnya yang berubah sejak bingkai terakhir &mdash; dan ketika sebagian
+      besar gambarnya diam, itulah bedanya file 12 MB dengan file 900 KB. Itulah
+      sebabnya rekaman layar sebuah jendela yang sebagian besar diam bisa kecil,
+      dan sebabnya rekaman yang sama dari pengubah yang sembrono tidak.
+    </p>
+    <p>
+      Anda tidak bisa tahu Anda punya yang mana dengan menonton animasinya.
+      Keduanya tampak identik. Satu-satunya cara melihatnya adalah melihat apa
+      yang disimpan setiap bingkainya, dan itu tampilan yang dimiliki
+      penganalisisnya persis karena alasan ini: alihkan ke <em>hanya yang
+      disimpan setiap bingkai</em> dan Anda entah melihat sederet bentuk kecil di
+      atas latar transparan, yang berarti pengodenya bekerja, entah melihat
+      seluruh gambarnya lagi dan lagi, yang berarti tidak.
+    </p>
+    <p>
+      Tidak ada kompensasi gerak di mana pun dalam formatnya. Tidak ada yang
+      pernah disimpan sebagai &ldquo;sama seperti terakhir tapi digeser empat
+      piksel ke kiri&rdquo;, seperti yang akan dilakukan sebuah kodek video. Trik
+      persegi-panjang-yang-berubah adalah satu-satunya penghematan yang dimiliki
+      GIF, dan ia sangat berharga.
+    </p>
+  </section>
+
+  <section>
+    <h2>Jeda, dan lantai yang ditegakkan setiap peramban</h2>
+    <p>
+      Setiap bingkai menyimpan berapa lama menahannya, dalam perseratus detik.
+      Itulah satu-satunya satuan yang dipunyai formatnya, jadi tercepat yang bisa
+      diminta sebuah file adalah 0,01 detik &mdash; seratus bingkai sedetik
+      &mdash; dan terlama adalah sekitar 655 detik.
+    </p>
+    <p>
+      Ia tidak akan mendapat seratus bingkai sedetik. <strong>Setiap peramban
+      membulatkan jeda di bawah 0,02 detik naik ke 0,10.</strong> Aturannya
+      ditulis ke dalam Netscape Navigator pada 1996, untuk bola dunia berputar
+      dan papan sedang-dibangun beranimasi masa itu, dan setiap peramban sesudahnya
+      menyalinnya. Tidak ada yang pernah mencabutnya, dan tidak akan ada.
+    </p>
+    <p>
+      Jadi GIF yang bingkainya semua berkata 0,01d diputar pada sepuluh bingkai
+      sedetik, bukan seratus. Ia berjalan sepuluh kali lebih lambat daripada niat
+      apa pun yang membuatnya, dan file-nya tidak memberi petunjuk soal ini:
+      jedanya di dalamnya persis seperti yang diminta. Inilah kejutan tunggal
+      yang paling umum di formatnya, dan itulah sebabnya penganalisisnya
+      melaporkan dua durasi &mdash; apa yang dikatakan file-nya, dan apa yang
+      sebenarnya akan dilakukan sebuah peramban dengannya.
+    </p>
+    <p>
+      Solusinya, di mana pun file-nya dibuat, adalah menulis 0,02 alih-alih 0,01.
+      Itu memberi 50 bingkai sedetik, yang merupakan langit-langit yang
+      sesungguhnya, dan lebih cepat daripada yang dibutuhkan apa pun. Pada
+      praktiknya 0,05d &mdash; dua puluh bingkai sedetik &mdash; kira-kira
+      secepat yang layak diminta.
+    </p>
+    <p>
+      Satu hal lagi yang diberitahukan jedanya kepada Anda. Kalau semuanya
+      identik, file-nya dibuat dari sekumpulan bingkai pada laju tetap. Kalau
+      mereka berserak &mdash; 0,04 di sini, 0,11 di sana &mdash; sesuatu mengubah
+      sebuah video lalu membuang bingkai, meregangkan tetangganya untuk menutupi
+      celahnya. Dan kalau yang terakhir jauh lebih panjang daripada sisanya, itu
+      disengaja: begitulah cara Anda membuat sebuah animasi berhenti sejenak
+      sebelum ia berputar lagi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pembuangan: kolom yang menentukan apakah ia mengotor</h2>
+    <p>
+      Setiap bingkai mengatakan apa yang seharusnya tertinggal di layar ketika
+      waktunya habis. Ada empat jawaban yang mungkin dan mereka layak diketahui,
+      karena tiga dari empat cara sebuah animasi bisa tampak keliru adalah kolom
+      ini yang keliru.
+    </p>
+    <ul>
+      <li>
+        <strong>Biarkan di tempatnya.</strong> Bingkai berikutnya melukis
+        langsung di atas yang ini. Benar ketika bingkainya buram dan saling
+        menutupi sepenuhnya, dan pilihan yang paling murah, karena tidak ada yang
+        harus dibersihkan.
+      </li>
+      <li>
+        <strong>Bersihkan kembali ke latarnya.</strong> Persegi panjang bingkainya
+        dihapus sebelum yang berikutnya menggambar. Inilah yang dibutuhkan
+        transparansi: tanpanya, bagian tembus pandang bingkai berikutnya
+        menampilkan bingkai sebelumnya di bawahnya, dan animasi berisi gambar
+        terpisah berubah menjadi tumpukan gambar.
+      </li>
+      <li>
+        <strong>Pulihkan apa yang ada di bawahnya.</strong> Apa pun yang ada di
+        kanvasnya sebelum bingkai ini menggambar ditaruh kembali. Begitulah objek
+        kecil yang bergerak di atas latar diam disimpan &mdash; setiap bingkai
+        melukis objeknya, lalu latarnya kembali, dan hanya persegi panjang
+        objeknya yang pernah ditulis.
+      </li>
+      <li>
+        <strong>Tidak dinyatakan.</strong> File-nya tidak mengatakan. Setiap
+        penampil memperlakukannya sebagai &ldquo;biarkan di tempatnya&rdquo;, dan
+        itu biasanya benar dan sesekali menjadi sebab sebuah GIF transparan
+        mengotor.
+      </li>
+    </ul>
+    <p>
+      Satu detail tempat spesifikasinya dan kenyataannya berpisah jalan.
+      &ldquo;Bersihkan kembali ke latarnya&rdquo; menyebutkan sebuah warna latar
+      di header file-nya, dan setiap peramban mengabaikannya lalu membersihkan
+      menjadi transparan. Mereka sudah begitu selama dua puluh lima tahun. File
+      yang mengandalkan warna latar itu muncul akan tampak benar bagi siapa pun
+      yang membuatnya di apa pun yang membuatnya, dan keliru di mana-mana lain.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tabel warna, dan 768 byte yang dimakannya</h2>
+    <p>
+      Sebuah piksel GIF bukan sebuah warna. Ia sebuah angka, yang menunjuk ke
+      dalam sebuah tabel berisi paling banyak 256 warna, masing-masing disimpan
+      sebagai tiga byte. Tabel penuh karena itu 768 byte, dan sebuah file bisa
+      punya satu yang dipakai bersama semuanya, atau satu per bingkai, atau
+      keduanya.
+    </p>
+    <p>
+      Kedua pengaturannya sah dan mereka bertukar secara berbeda:
+    </p>
+    <ul>
+      <li>
+        <strong>Satu tabel bersama</strong> adalah 768 byte untuk seluruh
+        file-nya, dan ia menjaga warnanya tetap stabil antar bingkai. Kerlipan
+        GIF &mdash; kilauan tidak enak pada file yang dibuat dari video &mdash;
+        sangat sering sekadar paletnya yang terhuyung dari bingkai ke bingkai.
+      </li>
+      <li>
+        <strong>Satu tabel per bingkai</strong> membiarkan setiap bingkai memakai
+        warna yang tidak dimiliki tabel bersamanya, dan itu penting ketika
+        adegannya berubah total. Ia berbiaya 768 byte setiap kali. Pada animasi
+        300 bingkai itu 230 KB tabel warna sebelum satu piksel pun disimpan.
+      </li>
+    </ul>
+    <p>
+      Ada ongkos kedua yang lebih tenang. Panjang sebuah tabel warna harus
+      pangkat dua, jadi bingkai yang memakai sembilan warna tetap mendapat tabel
+      berisi enam belas dan bingkai yang memakai 130 tetap mendapat 256. Sebagian
+      pembulatan ke atas tidak terhindarkan. File yang tabelnya menyatakan lima
+      ribu warna yang tidak pernah dirujuk pikselnya adalah hal lain: palet yang
+      dibangun untuk gambar selain yang akhirnya berada di bingkainya.
+      Penganalisisnya menandai entri yang tidak terpakai supaya bentuk hal itu
+      terlihat sekilas.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ke mana byte-nya sebenarnya pergi</h2>
+    <p>
+      Setiap byte sebuah GIF ada di salah satu dari sejumlah kecil tempat, dan
+      layak diketahui tempat apa saja itu sebelum memutuskan sebuah file terlalu
+      besar.
+    </p>
+    <ul>
+      <li>
+        <strong>Piksel terkompres.</strong> Pada file yang sehat, hampir
+        semuanya. Gambarnya sendiri, dilewatkan melalui LZW &mdash; skema
+        kompresi dari 1984 yang dirancang untuk tangkapan layar lembar kerja, dan
+        itulah sebabnya ia bagus pada warna datar dan buruk pada foto.
+      </li>
+      <li>
+        <strong>Tabel warna.</strong> 768 byte per tabel penuh, seperti di atas.
+      </li>
+      <li>
+        <strong>Header per bingkai.</strong> Delapan byte pewaktuan dan sebelas
+        byte deskriptor untuk setiap bingkai. Bukan apa-apa pada file normal;
+        pada animasi berisi dua ribu bingkai mungil, 38 KB.
+      </li>
+      <li>
+        <strong>Pembingkaian blok.</strong> Data terkompresnya dipotong menjadi
+        rangkaian berisi paling banyak 255 byte, masing-masing dengan sebuah byte
+        panjang di depannya. Sekitar satu byte dari setiap 256, tidak
+        terhindarkan, dan layak dilihat karena kalau tidak ia tak terlihat.
+      </li>
+      <li>
+        <strong>Metadata.</strong> Komentar, profil warna, dan paket XMP. Inilah
+        yang menghasilkan hasil yang sungguh konyol: sebuah penyunting gambar
+        bisa meninggalkan 40 KB XML yang menggambarkan sebuah suntingan yang
+        dibuat bertahun-tahun lalu, dan pada GIF yang kecil itu sebagian besar
+        file-nya. Tidak ada penampil yang menggambar satu pun darinya.
+      </li>
+    </ul>
+    <p>
+      Alasan melihat ini sebagai sebuah tabel alih-alih menebak adalah jawabannya
+      berbeda untuk file yang berbeda, dan solusinya mengikuti jawabannya. File
+      yang 95% piksel terkompres sekadar berisi banyak gambar, dan hanya lebih
+      sedikit bingkai, ukuran yang lebih kecil, atau lebih sedikit warna yang
+      akan membantu. File yang 30% tabel warna atau 40% XMP punya masalah yang
+      jauh lebih murah.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perputaran bukan bagian dari formatnya</h2>
+    <p>
+      Tidak ada kolom di spesifikasi GIF yang mengatakan sebuah animasi
+      berulang. Perputaran berasal dari sebuah blok yang ditemukan Netscape pada
+      1995 &mdash; sebuah &ldquo;application extension&rdquo; dengan teks
+      <code>NETSCAPE2.0</code> di dalamnya &mdash; yang toh diwujudkan segala hal
+      dan yang kini ada di setiap GIF beranimasi di internet.
+    </p>
+    <p>
+      Artinya file tanpa blok itu diputar tepat sekali lalu berhenti, di setiap
+      peramban, dan tampak rusak bagi siapa pun yang membuatnya. Kalau sebuah
+      animasi hanya diputar sekali, blok itulah yang hilang; ia salah satu hal
+      pertama yang layak diperiksa dan ia tak terlihat di penampil mana pun.
+    </p>
+    <p>
+      Bloknya juga bisa menyebutkan sebuah hitungan &mdash; putar lima kali lalu
+      berhenti. Nol berarti selamanya, dan itulah yang dikatakan hampir setiap
+      file.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hal-hal lain yang bisa dibawa sebuah GIF</h2>
+    <p>
+      Tiga blok yang tidak menyimpan gambar dan yang dilewati setiap penampil:
+    </p>
+    <ul>
+      <li>
+        <strong>Komentar.</strong> Teks bebas, biasanya nama apa pun yang menulis
+        file-nya, sesekali sesuatu yang tidak akan dipilih penulisnya untuk
+        diterbitkan. Tidak ada yang menampilkannya, dan setiap salinan file-nya
+        membawanya.
+      </li>
+      <li>
+        <strong>XMP.</strong> Metadata XML milik Adobe: apa yang menyunting
+        file-nya, kapan, kadang siapa. Ia tiba dengan sebuah ekor ajaib 258 byte
+        di ujungnya, sebuah trik untuk membuat panjang bloknya keluar benar, dan
+        itulah sebabnya membacanya secara naif memberi Anda selayar penuh biner.
+      </li>
+      <li>
+        <strong>Plain text.</strong> Sebuah blok dari spesifikasi 1989 yang
+        meminta penampilnya menggambar teks di atas gambarnya dalam sebuah kisi
+        sel. Ia tidak pernah diwujudkan apa pun. Kalau sebuah file punya satu,
+        apa pun yang dikatakannya tidak akan muncul.
+      </li>
+    </ul>
+    <p>
+      Ketiganya layak diketahui sebelum mengirim sebuah file ke suatu tempat:
+      mereka bagian dari sebuah GIF yang bisa mengatakan sesuatu tentang Anda, dan
+      mereka selamat dari setiap penyalinan dan pengunggahan ulang kecuali ada
+      yang sengaja membersihkannya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Membaca file yang rusak</h2>
+    <p>
+      GIF bisa terpotong &mdash; unduhan yang berhenti, file yang dipulihkan dari
+      disk yang mulai gagal, sesuatu yang ditulis setengah oleh sebuah aplikasi.
+      Karena formatnya sebuah aliran blok alih-alih satu struktur terindeks, GIF
+      yang terpotong biasanya masih terbaca sampai titik ia berhenti: setiap
+      bingkai sebelum putusnya utuh dan lengkap.
+    </p>
+    <p>
+      Itu layak diketahui karena kebanyakan perangkat lunak akan sekadar menolak
+      file-nya. Penganalisis yang membaca sejauh yang bisa lalu mengatakan di
+      mana ia berhenti setidaknya akan memberi tahu Anda berapa banyak yang
+      selamat, dan apakah bagian yang hilang itu satu bingkai atau dua ratus yang
+      terakhir.
+    </p>
+    <p>
+      Masalah sebaliknya juga ada: byte yang duduk <em>setelah</em> penanda akhir
+      file-nya. Setiap dekoder berhenti di penanda itu, jadi mereka tidak pernah
+      dibaca dan tidak pernah digambar, dan mereka biasanya file kedua yang
+      ditempelkan ke yang pertama oleh sesuatu yang tidak beres. Mereka beban
+      murni dan memotongnya tidak menghilangkan apa pun.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tidak satu pun dari ini butuh unggahan</h2>
+    <p>
+      Membaca struktur sebuah GIF bukan pekerjaan yang menuntut &mdash; ia sebuah
+      penyusuran melalui daftar blok dan satu dekompresor kecil &mdash; dan tidak
+      pernah ada alasan teknis untuk mengirim file-nya ke sebuah server untuk
+      melakukannya. <a href="../../analisis-gif/">Penganalisis GIF</a> di sini
+      melakukan seluruhnya di halamannya: penyusuran bloknya, LZW-nya, bingkai
+      yang digambar di layar, dan perhitungan byte-nya.
+    </p>
+    <p>
+      Itu lebih penting untuk pekerjaan ini daripada kebanyakan yang lain, karena
+      file yang paling ingin dibongkar orang sering kali file yang paling tidak
+      mereka yakini untuk dibagikan &mdash; sesuatu yang dipulihkan, sesuatu yang
+      dikirimkan seseorang kepada mereka, sesuatu yang ada blok komentarnya yang
+      belum mereka baca. <a href="../apakah-aman-mengunggah-file/">Argumen yang
+      lebih panjang tentang mengunggah file</a> berlaku di sini sekuat di mana
+      pun di situs ini.
+    </p>
+  </section>

--- a/locales/id/pages/guides/whats-inside-a-gif.toml
+++ b/locales/id/pages/guides/whats-inside-a-gif.toml
@@ -1,0 +1,21 @@
+#
+# Panduan: apa isi di dalam sebuah GIF - Bahasa Indonesia.
+#
+
+nav = "Apa isi di dalam sebuah GIF"
+title = "Apa Sebenarnya Isi Sebuah File GIF (dan Kenapa Punya Anda Begitu Besar)"
+description = "Bingkai, jeda, metode pembuangan, dan tabel warna dijelaskan, kenapa peramban menolak jeda tercepatnya, dan bagaimana memperhitungkan ke mana sebenarnya ukuran file sebuah GIF pergi."
+
+heading = "Apa sebenarnya isi di dalam sebuah GIF"
+lede = """
+    GIF adalah setumpuk persegi panjang, masing-masing dengan sebuah pewaktu dan
+    sebuah tabel warna, dan hampir setiap keluhan orang tentang formatnya
+    berasal dari salah satu dari ketiga hal itu. Inilah apa yang dilakukan setiap
+    bagiannya, dan bagaimana mencari tahu yang mana yang dipakai file Anda untuk
+    membelanjakan ukurannya."""
+
+updated = "22 Agustus 2026"
+
+og_title = "Apa sebenarnya isi di dalam sebuah file GIF"
+og_description = "Bingkai, jeda, pembuangan, dan palet - apa yang dilakukan masing-masing, kenapa GIF Anda diputar lebih lambat daripada yang dikatakannya, dan ke mana ukuran file-nya pergi."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/privacy.html
+++ b/locales/id/pages/privacy.html
@@ -1,0 +1,209 @@
+  <section>
+    <h2>File Anda</h2>
+    <p>
+      Setiap alat di situs ini mengerjakan pekerjaannya di dalam peramban Anda
+      sendiri, di perangkat keras Anda sendiri. Ketika Anda memilih sebuah file,
+      ia dibaca oleh halaman yang sudah Anda buka. Ia tidak dikirim kepada kami,
+      karena tidak ada server kami untuk dikirimi &mdash; situs ini adalah
+      sekumpulan file statis, tanpa backend, tanpa basis data, dan tanpa
+      penyimpanan.
+    </p>
+    <p>
+      Artinya kami tidak pernah menerima, melihat, menyimpan, mencatat, atau
+      memproses:
+    </p>
+    <ul>
+      <li>file Anda, seluruhnya maupun sebagian</li>
+      <li>gambar mini atau pratinjaunya</li>
+      <li>nama, ukuran, dimensi, atau formatnya</li>
+      <li>berapa banyak yang Anda pilih, atau apa yang Anda lakukan dengannya</li>
+      <li>apa pun yang dibaca darinya, termasuk data EXIF dan GPS</li>
+    </ul>
+    <p>
+      Ini bukan janji tentang niat kami. Setiap halaman membawa sebuah
+      <code>Content-Security-Policy</code> yang menyebut satu per satu setiap
+      alamat yang boleh dihubungi halamannya, dan perambannya menegakkannya.
+      Tidak satu pun alamat itu milik kami. Anda bisa membaca kebijakannya di
+      bagian atas sumber halaman mana pun, atau membuka tab Network peramban Anda
+      lalu memperhatikan: tidak ada permintaan yang membawa file Anda.
+    </p>
+    <p>
+      File yang Anda hasilkan dengan sebuah alat diserahkan ke mekanisme unduhan
+      milik peramban Anda sendiri lalu disimpan di mana pun Anda menyuruhnya.
+      Kami juga tidak terlibat di langkah itu.
+    </p>
+  </section>
+
+  <section>
+    <h2>Satu pengecualiannya, dan di mana ia berlaku</h2>
+    <p>
+      Alat <a href="../gambar-ke-video/">Gambar ke Video</a> punya fitur
+      &ldquo;tambahkan dari sebuah alamat web&rdquo;. Kalau Anda menempelkan
+      sebuah alamat ke dalamnya, peramban Anda mengambil gambar itu dari server
+      mana pun yang Anda sebutkan, dan <strong>server itu melihat alamat IP
+      Anda</strong> serta file mana yang Anda minta. Itu tidak terhindarkan, dan
+      itulah seluruh hakikat fiturnya.
+    </p>
+    <p>
+      Ia hanya pernah terjadi untuk alamat yang Anda ketik sendiri, ia dibangun
+      supaya gambar bisa masuk tapi data tidak bisa keluar, dan halaman alat itu
+      sendiri menjelaskannya lebih rinci. Tidak ada alat lain di situs ini yang
+      bisa membuat permintaan keluar dengan apa pun milik Anda di dalamnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Apa yang dikumpulkan, dan oleh siapa</h2>
+    <p>
+      Situs ini gratis dan dibiayai iklan. Artinya dua produk Google berjalan di
+      halaman-halaman ini, dan sebuah tombol donasi berjalan di sebagian
+      besarnya. Inilah daftar lengkapnya.
+    </p>
+
+    <h3>Google AdSense &mdash; iklannya</h3>
+    <p>
+      Google menyajikan iklannya dan memutuskan mana yang Anda lihat. Untuk
+      melakukan itu ia bisa menyetel dan membaca cookie atau pengenal serupa di
+      peramban Anda, dan ia menerima alamat IP Anda, sebuah lokasi perkiraan yang
+      diturunkan darinya, agen pengguna Anda, dan halaman mana yang sedang Anda
+      buka. Tergantung setelan Anda dan di mana Anda berada, iklannya bisa
+      dipersonalisasi memakai sebuah profil yang dipegang Google tentang Anda,
+      yang sebagian besar dibangun dari aktivitas Anda di situs lain.
+    </p>
+    <p>
+      Kami tidak menerima satu pun dari itu, kami tidak bisa melihatnya, dan kami
+      tidak pernah mengirim apa pun kepada Google tentang file Anda. Keterangan
+      Google sendiri tentang cara ia memakai data dari situs yang menjalankan
+      iklannya ada di
+      <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer nofollow">policies.google.com/technologies/partner-sites</a>.
+    </p>
+
+    <h3>Google Analytics &mdash; pencacah kunjungannya</h3>
+    <p>
+      Kami memakai Google Analytics 4 untuk menghitung kunjungan halaman, supaya
+      kami tahu alat mana yang layak dikerjakan. Ia merekam halaman yang Anda
+      lihat, kira-kira kapan, sebuah pengenal yang dihasilkan secara acak dan
+      disimpan di peramban Anda, sebuah lokasi perkiraan, jenis perangkat dan
+      peramban Anda, serta situs yang merujuk Anda.
+    </p>
+    <p>
+      Ia disetel untuk tidak melakukan apa pun lagi, dan setelannya adalah sebuah
+      file yang bisa Anda baca: <code>analytics.js</code> di sebelah setiap
+      halaman menyiapkan sebuah pencacah tampilan halaman dan sama sekali tidak
+      memuat peristiwa khusus. Tidak ada di situs ini yang menyerahkan kepadanya
+      sebuah file, sebuah nama file, sebuah dimensi, atau sebuah jumlah &mdash;
+      tidak ada kode di sini yang bisa.
+    </p>
+
+    <h3>Buy Me a Coffee &mdash; tombol donasinya</h3>
+    <p>
+      Halaman pusatnya dan halaman alatnya membawa sebuah tombol donasi, yang
+      dimuat dari server Buy Me a Coffee. Memuatnya berarti CDN mereka melihat
+      alamat IP Anda dan bahwa Anda sedang di situs ini, dan huruf tombolnya
+      diambil dari Google Fonts, yang juga melihat alamat IP Anda. Tidak ada yang
+      lain yang dikirim, dan tidak ada yang terjadi lebih lanjut kecuali Anda
+      benar-benar mengekliknya, dan pada saat itu Anda berada di situs mereka di
+      bawah kebijakan mereka. Halaman ini dan
+      <a href="../ketentuan-penggunaan/">halaman Ketentuan</a> tidak menggambar
+      tombolnya.
+    </p>
+
+    <h3>Hosting</h3>
+    <p>
+      Situsnya disajikan GitHub Pages, di belakang Cloudflare. Seperti host web
+      mana pun, mereka memproses permintaan yang dibuat peramban Anda &mdash;
+      yang mencakup alamat IP Anda, halaman yang diminta, dan agen pengguna Anda
+      &mdash; untuk mengantarkan halamannya dan menjaga layanannya tetap hidup
+      dan aman. Kami tidak punya akses ke log per pengunjung dari keduanya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cookie</h2>
+    <p>
+      Kami tidak menyetel cookie apa pun milik kami sendiri. Kami tidak punya
+      masuk akun dan tidak punya sesi, dan hanya ada satu preferensi yang pernah
+      kami ingat.
+    </p>
+    <p>
+      <strong>Bahasa yang Anda pilih.</strong> Kalau Anda memilih sebuah bahasa
+      dari pengalihnya, pilihan itu ditulis ke penyimpanan lokal peramban Anda,
+      dengan nama <code>abox-lang</code>, supaya halaman berikutnya yang Anda buka
+      berbahasa seperti yang Anda minta. Ia bukan sebuah cookie: ia tidak pernah
+      dikirim kepada kami atau kepada siapa pun lain, ia tinggal di perangkat
+      tempat Anda membaca ini, dan membersihkan data situs peramban Anda
+      menghapusnya. Kalau Anda tidak pernah memilih sebuah bahasa, sama sekali
+      tidak ada yang ditulis &mdash; halaman yang ditampilkan dalam bahasa
+      peramban Anda sendiri dicocokkan di tempat lalu dilupakan lagi.
+    </p>
+    <p>
+      Setiap cookie atau pengenal serupa yang mungkin Anda temukan di sini milik
+      Google dan disetel oleh skrip iklan dan analitik yang dijelaskan di atas.
+      Mereka dipakai untuk mengukur kunjungan, serta untuk memilih dan membatasi
+      iklan.
+    </p>
+    <h3>Cara mematikannya</h3>
+    <ul>
+      <li>
+        Personalisasi iklan bisa dimatikan, untuk semua situs sekaligus, di
+        <a href="https://myadcenter.google.com/" target="_blank" rel="noopener noreferrer nofollow">My Ad Center</a>.
+      </li>
+      <li>
+        Google Analytics bisa diblokir di mana-mana dengan
+        <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer nofollow">pengaya peramban penolakan</a>
+        milik Google.
+      </li>
+      <li>
+        Setelan peramban Anda sendiri bisa memblokir atau membersihkan cookie
+        pihak ketiga, dan pemblokir konten mana pun akan menghentikan skrip ini
+        dimuat sejak awal.
+      </li>
+    </ul>
+    <p>
+      Memblokir semuanya tidak masalah bagi kami. <strong>Setiap alat di situs
+      ini bekerja dengan skripnya diblokir, dan bekerja dengan jaringannya
+      terputus sama sekali.</strong> Tidak ada di sini yang ditahan di balik
+      sebuah iklan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hak Anda atas datanya</h2>
+    <p>
+      Kami tidak memegang data pribadi apa pun tentang Anda, jadi tidak ada yang
+      bisa kami tunjukkan, betulkan, ekspor, atau hapus untuk Anda &mdash; sebuah
+      permintaan kepada kami akan kembali kosong, sejujurnya.
+    </p>
+    <p>
+      Data yang dijelaskan di atas dipegang Google, yang bertindak sebagai
+      pengendalinya sendiri atas data itu. Permintaan tentangnya harus pergi
+      kepada mereka, lewat
+      <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer nofollow">akun Google Anda</a>
+      atau kontak privasi mereka.
+    </p>
+  </section>
+
+  <section>
+    <h2>Anak-anak</h2>
+    <p>
+      Situs ini tidak ditujukan kepada anak-anak dan tidak menanyakan usia siapa
+      pun, karena ia tidak menanyakan apa pun kepada siapa pun. Kami sengaja
+      tidak mengumpulkan data pribadi dari siapa pun, pada usia berapa pun.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perubahan, dan cara menghubungi kami</h2>
+    <p>
+      Kalau halaman ini berubah, tanggal di atasnya berubah bersamanya, dan
+      suntingannya ada di riwayat commit publik bersama semua yang lain.
+    </p>
+    <p>
+      Pertanyaan tentang semua ini bisa dikirim ke
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, atau diajukan sebagai
+      sebuah isu di
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">repositorinya</a>,
+      tempat jawabannya terlihat oleh semua orang lain yang bertanya-tanya hal
+      yang sama.
+    </p>
+  </section>

--- a/locales/id/pages/privacy.toml
+++ b/locales/id/pages/privacy.toml
@@ -1,0 +1,25 @@
+#
+# Privasi & Cookie - Bahasa Indonesia.
+#
+# Nama produk (Google AdSense, Google Analytics, Buy Me a Coffee, GitHub Pages,
+# Cloudflare) dan nama kunci penyimpanan (abox-lang) tetap seperti adanya:
+# itulah yang dilihat pembaca di setelan perambannya.
+#
+
+nav = "Privasi &amp; Cookie"
+
+title = "Privasi &amp; Cookie &mdash; abox.tools"
+description = "Apa yang dikumpulkan dan tidak dikumpulkan abox.tools. File Anda tidak pernah diunggah; iklannya, pencacah kunjungannya, dan tombol donasinya masing-masing dijelaskan selengkapnya."
+
+heading = "Privasi &amp; Cookie"
+lede = """
+    Versi singkatnya: file Anda tidak pernah diunggah, karena tidak ada tujuan
+    untuk mengunggahnya. Semua yang lain di halaman ini adalah tentang iklannya,
+    pencacah kunjungannya, dan hostingnya &mdash; bagian yang memang melibatkan
+    perusahaan lain."""
+
+updated = "22 Agustus 2026"
+
+og_title = "Privasi &amp; Cookie &mdash; abox.tools"
+og_description = "File Anda tidak pernah diunggah. Apa yang dikumpulkan, oleh siapa, dan bagaimana mematikannya."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/pages/terms.html
+++ b/locales/id/pages/terms.html
@@ -1,0 +1,161 @@
+  <section>
+    <h2>Situs ini apa</h2>
+    <p>
+      abox.tools adalah kumpulan alat kecil yang berjalan di dalam peramban web
+      Anda. Mereka gratis dipakai, untuk apa pun, termasuk pekerjaan komersial.
+      Tidak ada yang perlu dibeli, tidak ada akun untuk dibuat, tidak ada batas
+      pemakaian, dan tidak ada fitur yang ditahan.
+    </p>
+    <p>
+      Dengan memakai situs ini Anda menerima ketentuan di halaman ini. Kalau Anda
+      tidak menerimanya, jalan keluarnya sekadar menutup tabnya &mdash; tidak ada
+      milik Anda yang ditahan di sini.
+    </p>
+  </section>
+
+  <section>
+    <h2>File Anda tetap milik Anda</h2>
+    <p>
+      Anda menyimpan setiap hak yang sudah Anda punya atas file yang Anda buka
+      dengan alat ini, dan atas apa pun yang Anda hasilkan dengannya. Kami tidak
+      mengklaim lisensi, kepemilikan, atau kepentingan dalam bentuk apa pun atas
+      keduanya.
+    </p>
+    <p>
+      Ini bukan kemurahan hati, ini hitungan: alatnya berjalan sepenuhnya di
+      peramban Anda dan file Anda tidak pernah dikirimkan kepada kami, jadi tidak
+      ada apa pun untuk kami punyai haknya.
+      <a href="../privasi/">Halaman Privasi</a> memaparkan cara itu bekerja dan
+      cara memverifikasinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Memakai situs ini dengan bertanggung jawab</h2>
+    <p>
+      Anda bertanggung jawab atas file yang Anda proses dan atas apa yang Anda
+      lakukan dengan hasilnya. Khususnya, jangan memakai alat ini pada bahan yang
+      Anda tidak punya haknya, atau untuk menghasilkan apa pun yang melanggar
+      hukum.
+    </p>
+    <p>
+      Kami tidak bisa menegakkan ini dan kami tidak berpura-pura sebaliknya. Kami
+      tidak pernah melihat file Anda, jadi tidak ada moderasi di sini, tidak ada
+      pemindaian, dan tidak ada cara bagi kami untuk tahu apa yang dilakukan
+      siapa pun. Kewajibannya sungguh milik Anda.
+    </p>
+    <p>
+      Mohon juga jangan mengganggu situsnya sendiri &mdash; menyerang hostingnya,
+      atau menyebarkan ulang salinan yang diubah dengan cara yang mengesankan
+      bahwa mereka aslinya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Tanpa jaminan</h2>
+    <p>
+      Situsnya dan alatnya disediakan <strong>apa adanya</strong>, tanpa jaminan
+      dalam bentuk apa pun, tersurat maupun tersirat, termasuk jaminan tersirat
+      apa pun tentang kelayakan dagang, kesesuaian untuk tujuan tertentu, atau
+      tidak melanggar hak pihak lain.
+    </p>
+    <p>
+      Konkretnya: sebuah alat bisa menghasilkan hasil yang tidak Anda mau, bisa
+      gagal pada file yang tidak dipahaminya, bisa berperilaku berbeda antar
+      peramban, dan bisa kehilangan pekerjaan kalau tabnya ditutup di tengah
+      operasi. Tidak ada yang Anda lakukan di sini disimpan di mana pun, jadi
+      <strong>simpan berkas asli Anda</strong>. Jangan memakai alat ini pada
+      satu-satunya salinan dari apa pun yang Anda pedulikan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pembatasan tanggung jawab</h2>
+    <p>
+      Sejauh yang diizinkan hukum, kami tidak bertanggung jawab atas kehilangan
+      atau kerusakan apa pun yang timbul dari pemakaian Anda atas situs ini
+      &mdash; termasuk file yang hilang, rusak, atau tidak bisa dipakai, waktu
+      yang hilang, keuntungan yang hilang, atau kerugian tidak langsung maupun
+      turutan apa pun.
+    </p>
+    <p>
+      Tidak ada di sini yang membatasi tanggung jawab yang secara hukum tidak
+      boleh dibatasi.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ketersediaan</h2>
+    <p>
+      Situsnya ditawarkan tanpa janji bahwa ia akan tetap hidup, tetap gratis,
+      mempertahankan alat tertentu mana pun, atau terus ada sama sekali. Alat
+      bisa berubah atau dibuang tanpa pemberitahuan.
+    </p>
+    <p>
+      Satu akibat praktis dari cara alat ini dibangun layak diketahui: begitu
+      sebuah halaman alat sudah dimuat, ia terus bekerja tanpa internet, dan ia
+      tidak berhenti bekerja karena situsnya mati. Kodenya juga publik, jadi alat
+      yang Anda andalkan bisa Anda jaga tetap berjalan sendiri apa pun yang
+      terjadi di sini.
+    </p>
+  </section>
+
+  <section>
+    <h2>Iklan dan perusahaan lain</h2>
+    <p>
+      Situsnya membawa iklan dari Google, menghitung kunjungan dengan Google
+      Analytics, dan menampilkan sebuah tombol donasi di sebagian besar
+      halamannya. Apa yang dilibatkan masing-masing dijelaskan selengkapnya di
+      <a href="../privasi/">halaman Privasi</a>.
+    </p>
+    <p>
+      Iklannya, dan situs mana pun yang Anda capai dengan mengekliknya, bukan
+      milik kami. Kami tidak memilih iklan satu per satu, tidak mendukung apa
+      yang mereka katakan, dan tidak bertanggung jawab atas situs yang mereka
+      tuju atau atas urusan apa pun yang Anda jalani di sana. Hal yang sama
+      berlaku untuk setiap tautan luar lain di situs ini.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kode sumbernya</h2>
+    <p>
+      Kode situs ini diterbitkan secara terbuka di
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">github.com/A-Box-of-Tools/website</a>,
+      karena &ldquo;baca dan periksa sendiri&rdquo; adalah satu-satunya jawaban
+      yang sesungguhnya untuk &ldquo;kenapa saya harus memercayai ini&rdquo;.
+      Pemakaian ulang kode itu diatur ketentuan lisensi yang dinyatakan di
+      repositorinya, bukan oleh halaman ini. Ketentuan ini mencakup pemakaian
+      Anda atas situs webnya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hukum yang berlaku</h2>
+    <p>
+      Situs ini dioperasikan dari Kanada. Ketentuan ini, dan sengketa apa pun
+      yang timbul darinya atau dari pemakaian Anda atas situsnya, diatur hukum
+      Kanada dan hukum provinsi tempat situsnya dioperasikan, tanpa memperhatikan
+      aturan pertentangan hukum.
+    </p>
+    <p>
+      Kalau hukum perlindungan konsumen di tempat Anda tinggal memberi Anda hak
+      yang kalau tidak akan dibatasi ketentuan ini, hak itu tetap berlaku.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perubahan atas ketentuan ini</h2>
+    <p>
+      Ketentuan ini bisa diperbarui. Ketika diperbarui, tanggal di atasnya
+      berubah, dan suntingannya muncul di riwayat commit publik seperti setiap
+      perubahan lain. Terus memakai situsnya setelah sebuah perubahan berarti
+      menerima versi yang diperbarui.
+    </p>
+    <p>
+      Pertanyaan bisa dikirim ke
+      <a href="mailto:hi@abox.tools">hi@abox.tools</a>, atau diajukan sebagai
+      sebuah isu di
+      <a href="https://github.com/A-Box-of-Tools/website" target="_blank" rel="noopener noreferrer">repositorinya</a>.
+    </p>
+  </section>

--- a/locales/id/pages/terms.toml
+++ b/locales/id/pages/terms.toml
@@ -1,0 +1,20 @@
+#
+# Ketentuan Penggunaan - Bahasa Indonesia.
+#
+
+nav = "Ketentuan Penggunaan"
+
+title = "Ketentuan Penggunaan &mdash; abox.tools"
+description = "Ketentuan yang mendasari penawaran situs ini: gratis, apa adanya, tanpa akun, tanpa jaminan, dan file Anda tetap sepenuhnya milik Anda karena mereka tidak pernah dikirim kepada kami."
+
+heading = "Ketentuan Penggunaan"
+lede = """
+    Tidak ada akun untuk dibuka dan tidak ada perjanjian untuk ditandatangani,
+    jadi ini pendek. Mereka menggambarkan apa yang boleh Anda harapkan dari situs
+    ini, dan apa yang tidak dijanjikannya."""
+
+updated = "19 Agustus 2026"
+
+og_title = "Ketentuan Penggunaan &mdash; abox.tools"
+og_description = "Gratis, apa adanya, tanpa akun, tanpa jaminan. File Anda tetap sepenuhnya milik Anda."
+og_image_alt = "abox.tools - alat yang tidak pernah menyentuh server"

--- a/locales/id/tools/compress-pdf.html
+++ b/locales/id/tools/compress-pdf.html
@@ -1,0 +1,167 @@
+<!--
+  tools/compress-pdf/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="file-row" class="file-row" hidden>
+      <div class="file-facts">
+        <strong id="file-name" class="file-name"></strong>
+        <span id="file-facts" class="file-sub"></span>
+      </div>
+      <button type="button" id="clear-file" class="ghost danger">Pilih yang lain</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; layar yang akan dipertahankan alat ini kalau hanya boleh satu -->
+  <section class="card" id="inventory-card" hidden>
+    <h2><span class="step">2</span> Lihat di mana ukurannya berada</h2>
+
+    <p class="card-lede">
+      "Kompres PDF" adalah dua pekerjaan berbeda yang memakai satu nama.
+      Pindaian adalah setumpuk foto, dan mengodekannya ulang bernilai sebagian
+      besar isi file. Sebuah kontrak adalah teks dan font, yang sudah dikompres
+      oleh apa pun yang membuatnya &mdash; tidak ada delapan puluh persen yang
+      bersembunyi di dalamnya, dan tidak ada alat yang bisa menemukannya. Anda
+      punya yang mana dari keduanya bukan soal pendapat, jadi ini dia sebelum
+      apa pun disentuh.
+    </p>
+
+    <p id="verdict" class="verdict"></p>
+
+    <div class="breakdown">
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <ul id="breakdown-list" class="breakdown-list"></ul>
+    </div>
+
+    <p id="inventory-notes" class="field-summary"></p>
+  </section>
+
+  <!-- Langkah 3 &mdash; berapa banyak yang boleh dibelanjakan -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">3</span> Sebutkan seberapa keras memerasnya</h2>
+
+    <p class="card-lede">
+      Sebuah PDF mencatat seberapa besar setiap gambar digambar, sehingga alat
+      ini bisa mengukur apa yang benar-benar dipakai halaman alih-alih menebak.
+      Pindaian 4000 piksel yang ditempatkan selebar delapan inci kertas membawa
+      500 piksel per inci; pada 150 ia tercetak sama dan tampak sama di layar.
+      Piksel yang tidak bisa dilihat siapa pun dibelanjakan lebih dulu, karena
+      tidak ada biayanya.
+    </p>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Berapa banyak kualitas yang boleh dibelanjakan</legend>
+      <div class="presets" id="presets" role="radiogroup" aria-label="Berapa banyak kualitas yang boleh dibelanjakan">
+        <label class="preset">
+          <input type="radio" name="preset" value="smallest">
+          <span class="preset-body">
+            <strong>Paling kecil</strong>
+            <span class="preset-note">96 DPI. Untuk sesuatu yang hanya perlu dibaca di layar.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="screen" checked>
+          <span class="preset-body">
+            <strong>Bagus di layar</strong>
+            <span class="preset-note">130 DPI. Jawaban biasa untuk file yang perlu Anda kirim lewat email.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="print">
+          <span class="preset-body">
+            <strong>Masih bagus di kertas</strong>
+            <span class="preset-note">220 DPI. Lebih kecil, dan tetap tercetak dengan benar.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="preset" value="gentle">
+          <span class="preset-body">
+            <strong>Nyaris tidak menyentuh gambarnya</strong>
+            <span class="preset-note">Tanpa pengubahan ukuran sama sekali. Sebagian besar penghematan datang dari mengemas ulang file.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <details class="advanced">
+      <summary>Tentukan sendiri kedua angkanya</summary>
+      <div class="option-row">
+        <label for="dpi-value">Piksel terbanyak per inci ruang gambar</label>
+        <div class="inline-pair">
+          <input type="number" id="dpi-value" min="0" max="1200" step="10" value="130" inputmode="numeric">
+          <span class="unit">DPI &mdash; 0 membiarkan setiap gambar pada ukuran penuhnya</span>
+        </div>
+      </div>
+      <div class="option-row">
+        <label for="quality-value">Kualitas JPEG</label>
+        <div class="inline-pair">
+          <input type="range" id="quality-value" min="30" max="95" step="1" value="68">
+          <output id="quality-out" for="quality-value">68</output>
+        </div>
+      </div>
+    </details>
+
+    <label class="check">
+      <input type="checkbox" id="strip-meta" checked>
+      <span>
+        <strong>Keluarkan apa yang diingat file tentang asal-usulnya</strong>
+        <span class="check-note">
+          Nama dan versi program yang membuatnya, kapan ia dibuat dan terakhir
+          disunting, paket XMP, dan gumpalan privat yang ditinggalkan aplikasi
+          tata letak agar bisa mengimpor ulang pekerjaannya sendiri &mdash; yang
+          kadang berukuran megabyte. Tidak satu pun dibutuhkan untuk menampilkan
+          dokumen.
+        </span>
+      </span>
+    </label>
+
+    <p id="settings-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Langkah 4 &mdash; satu klik -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Kompres</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Kompres PDF ini</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Unduh</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <details id="per-image" class="advanced" hidden>
+        <summary>Apa yang terjadi pada setiap gambar</summary>
+        <ul id="image-list" class="image-list"></ul>
+      </details>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/compress-pdf.toml
+++ b/locales/id/tools/compress-pdf.toml
@@ -1,0 +1,269 @@
+#
+# Kompres PDF - Bahasa Indonesia.
+#
+# Overrides for tools/compress-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Kompresor PDF"
+heading = "Kompres&nbsp;PDF <span class=\"h1-kw\">&mdash; perkecil ukuran PDF</span>"
+tagline = "Perkecil sebuah dokumen tanpa mengirimnya ke mana pun."
+
+title = "Kompres PDF &mdash; Gratis, di Peramban Anda, Tanpa Unggah"
+description = "Perkecil ukuran PDF tanpa mengunggahnya. File dibaca, dikompres ulang, dan ditulis kembali oleh peramban Anda sendiri, dan alat ini menunjukkan di mana ukurannya sebenarnya berada sebelum menyentuh apa pun."
+og_title = "Kompres PDF &mdash; gratis, dan tidak ada yang diunggah"
+og_description = "Perkecil PDF di perangkat Anda sendiri. Alat ini mengukur seberapa besar setiap gambar digambar di halaman, jadi yang dibuang hanya piksel yang tidak bisa dilihat siapa pun."
+og_image_alt = "Kompres PDF - perkecil dokumen tanpa mengunggahnya"
+
+pledge = """
+    Dokumen dibuka, dibongkar, dan ditulis kembali di memori mesin ini, oleh
+    kode yang disajikan dari alamat ini. Tidak ada di sini yang bisa melakukan
+    unggahan, dan tidak ada server di ujung lain halaman ini untuk
+    menerimanya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu kompres sebuah file. Tidak satu pun permintaan membawa halaman,
+      gambar, atau nama file. Atau cabut koneksi internet dan tetap kompres
+      satu."""
+
+read_first = """
+, dan <code>src/reader.js</code> serta
+      <code>src/writer.js</code> untuk seluruh proses pembacaan dan penulisan
+      ulang, yang keduanya tidak bisa menjangkau jaringan."""
+
+howto_heading = "Cara memperkecil ukuran PDF"
+
+card = """
+            Perkecil dokumen dengan mengompres ulang gambar di dalamnya. Alat
+            ini menunjukkan lebih dulu di mana ukurannya sebenarnya berada, dan
+            mengatakan terus terang kalau tidak ada yang bisa diperoleh."""
+
+[words]
+plural = "dokumen"
+choose = "sebuah PDF"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "Dokumen Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy
+      menyebut satu per satu setiap alamat yang boleh dihubungi halaman ini, dan
+      tidak satu pun milik situs ini. Alat ini tidak menambahkan apa pun ke
+      daftar itu: ia tidak punya fitur jaringan sendiri, bahkan yang opsional
+      sekalipun. Tidak ada titik akhir di sini tempat file Anda bisa
+      dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya ada."""
+
+[[privacy]]
+title = "Seluruh formatnya ada di repositori ini."
+body = """
+ Sebuah PDF adalah daftar objek
+      dan tabel yang mencatat di mana setiap objek dimulai.
+      <code>src/objects.js</code> membaca sintaksisnya,
+      <code>src/reader.js</code> mengikuti tabelnya,
+      <code>src/writer.js</code> menulis yang baru, dan tidak satu pun dari
+      ketiganya mengimpor sesuatu yang bisa membuat permintaan. Tidak ada
+      pustaka yang diambil dan tidak ada yang digambar di server."""
+
+[[privacy]]
+title = "File terenkripsi ditolak, bukan dibuka."
+body = """
+ PDF dengan kata sandi ditolak,
+      termasuk jenis yang dihasilkan pemindai dengan kata sandi kosong dan yang
+      secara teknis akan terbuka. Melepas proteksi sebuah dokumen adalah
+      pekerjaan yang berbeda dari memperkecilnya, dan melakukannya diam-diam
+      akan menjadi hal yang mengejutkan bagi sebuah alat yang bertindak atas
+      nama Anda."""
+
+[[privacy]]
+title = "Ia mengeluarkan hal-hal, bukan memasukkan."
+body = """
+ File yang sudah jadi tidak
+      membawa tanggal pembuatan, tidak ada baris produser, dan tidak ada nama
+      alat yang membuatnya. Dengan kotaknya dicentang, ia juga kehilangan paket
+      XMP dan blok-blok privat yang ditinggalkan aplikasi tata letak &mdash;
+      argumen yang sama dengan alat EXIF, diterapkan pada wadah yang
+      berbeda."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran
+      berasal dari Google. Tidak satu pun diberi apa pun tentang dokumen Anda:
+      bukan file, bukan halaman, bukan nama, ukuran, atau jumlah halaman. Setiap
+      baris yang membaca, mendekode, atau menulis PDF disajikan dari asal ini
+      dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di
+      bagian atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil
+      hurufnya dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau dokumen Anda. Tidak
+      ada yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap berfungsi. Itulah bukti yang paling sederhana: alat yang
+      mengirim dokumen Anda ke tempat lain untuk dikompres akan berhenti."""
+
+[[howto]]
+title = "Pilih sebuah PDF."
+body = """
+ Jatuhkan ke pemilih file atau pilih sendiri.
+      Peramban membacanya langsung dari disk Anda; tidak ada yang dikirim ke mana
+      pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Lihat di mana ukurannya berada."
+body = """
+ Rincian inilah inti dari
+      langkah kedua. Kalau batangnya sebagian besar gambar, alat ini punya
+      sesuatu untuk dikerjakan. Kalau sebagian besar berupa font dan isi
+      halaman, ia akan mengatakannya, dan penghematan yang jujur hanya beberapa
+      persen &mdash; lebih baik tahu itu sebelum Anda menghabiskan satu
+      menit."""
+
+[[howto]]
+title = "Sebutkan seberapa keras memerasnya."
+body = """
+ Pilihan yang diberi nama
+      itu adalah resolusi, bukan nilai yang samar: 96 DPI untuk dibaca di layar,
+      130 untuk dikirim lewat email, 220 untuk sesuatu yang masih harus dicetak.
+      Masing-masing diukur terhadap seberapa besar gambar itu sebenarnya
+      digambar di halaman, sehingga foto yang ditempatkan sebagai gambar mini
+      tidak diperlakukan seperti pindaian satu halaman penuh."""
+
+[[howto]]
+title = "Kompres, lalu periksa baris yang mengatakan bahwa hasilnya sudah diperiksa."
+body = """
+ Setelah penulisan ulang selesai,
+      file yang sudah jadi dibuka lagi oleh pembaca yang sama di halaman ini dan
+      halamannya dihitung. Kalau itu tidak cocok dengan aslinya, prosesnya
+      dilaporkan gagal dan tidak ada unduhan yang ditawarkan."""
+
+[[faq]]
+q = "Apakah PDF saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File dibaca, dikompres ulang, dan ditulis oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya sisi
+        server, dan <code>Content-Security-Policy</code> halaman ini menyebut
+        satu per satu setiap alamat yang boleh dihubunginya &mdash; tidak satu
+        pun milik situs ini. Alat ini sama sekali tidak punya fitur jaringan
+        opsional."""
+
+[[faq]]
+q = "Seberapa kecil PDF saya nanti?"
+a = """
+        Sepenuhnya tergantung isinya, dan itulah sebabnya alat ini mengukur dan
+        menunjukkannya kepada Anda sebelum mengompres apa pun. Dokumen hasil
+        pindaian hampir seluruhnya berupa foto dan biasanya menjadi 60&ndash;90%
+        lebih kecil. Sebuah kontrak atau skripsi berisi teks, gambar vektor, dan
+        font tertanam, yang semuanya sudah dikompres oleh apa pun yang
+        membuatnya; di situ penghematannya biasanya beberapa persen saja, dari
+        mengemas ulang file dan membuang yang tidak lagi dirujuk. Alat mana pun
+        yang menjanjikan persentase tetap tanpa melihat file Anda sedang
+        menebak."""
+
+[[faq]]
+q = "Apakah mengompres PDF menurunkan kualitas?"
+a = """
+        Gambar di dalamnya dikodekan ulang, jadi ya, untuk bagian itu. Tidak ada
+        yang lain disentuh: teks tetap teks, bisa dipilih dan dicari, font tetap
+        utuh, dan gambar vektor disalin persis. Alat ini juga menolak membuat
+        sebuah gambar lebih buruk tanpa hasil &mdash; kalau pengodean ulang
+        ternyata tidak lebih kecil dari aslinya, byte aslinya dikembalikan ke
+        dokumen tanpa disentuh."""
+
+[[faq]]
+q = "Apa itu DPI di sini, dan kenapa ditanyakan?"
+a = """
+        Sebuah PDF mencatat seberapa besar setiap gambar digambar di halaman,
+        sehingga alat ini bisa menghitung resolusi efektifnya: pindaian 4000
+        piksel yang ditempatkan selebar delapan inci kertas membawa 500 piksel
+        per inci. Tidak ada layar dan sangat sedikit kertas yang bisa
+        memakainya, jadi piksel di atas setelan yang Anda pilih dibuang lebih
+        dulu &mdash; piksel itu memakan kualitas yang tidak bisa dilihat siapa
+        pun. Pengukuran itulah sebabnya logo yang ditempatkan kecil tidak
+        diperlakukan sama dengan pindaian satu halaman penuh."""
+
+[[faq]]
+q = "Bisakah ia membuka PDF yang dilindungi kata sandi?"
+a = """
+        Tidak, dan itu disengaja. Dokumen terenkripsi ditolak dengan pesan yang
+        mengatakannya, bahkan ketika kata sandinya kosong &mdash; dan begitulah
+        banyak pemindai serta mesin fotokopi menyimpan. Melepas proteksi sebuah
+        file adalah pekerjaan yang berbeda dari mengompresnya, dan alat yang
+        melakukannya diam-diam berarti melakukan sesuatu yang tidak Anda
+        minta."""
+
+[[faq]]
+q = "Adakah PDF yang tidak bisa dikompresnya?"
+a = """
+        Sebagian gambar di dalamnya, ya. Gambar JPEG 2000, JBIG2, dan berkode
+        faks (CCITT) tidak punya dekoder di peramban mana pun, jadi mereka
+        dilewatkan tanpa disentuh dan dilaporkan sebagaimana adanya &mdash; dua
+        yang terakhir adalah kodek dua tingkat dan biasanya memang sudah
+        mendekati ukuran terkecilnya. Gambar CMYK juga dibiarkan, karena
+        mengodekannya ulang berisiko menggeser warna yang akan dihasilkan
+        pencetak. Semua yang dilewati alat ini disebutkan namanya di hasil,
+        beserta alasannya."""
+
+[[faq]]
+q = "Apakah file hasil kompresi masih bisa dibuka di mana-mana?"
+a = """
+        Ya. Keluarannya ditulis sebagai PDF 1.5, yang dipahami setiap pembaca
+        yang dirilis sejak 2003, dan alat ini membuktikannya di perangkat Anda
+        sendiri: ia membuka lagi file yang sudah jadi dan menghitung halamannya
+        sebelum menawarkannya kepada Anda. Formulir, tautan, markah, struktur
+        aksesibilitas, dan lampiran tertanam ikut terbawa; yang ditinggalkan
+        adalah materi yang tidak lagi dirujuk apa pun di dalam dokumen."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada batas ukuran file selain yang diizinkan memori perangkat Anda
+        sendiri. Situs ini memasang iklan, dan itulah yang membiayainya; iklan
+        tidak diberi apa pun tentang dokumen Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim dokumen Anda ke tempat lain untuk dikompres
+        akan berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Kompres PDF di peramban Anda. Gambar dikompres ulang terhadap seberapa besar mereka sebenarnya digambar di halaman, dan dokumen ditulis ulang secara lokal, jadi tidak ada file yang pernah diunggah."
+features = [
+  "Menunjukkan di mana ukuran dokumen sebenarnya berada sebelum mengompres apa pun",
+  "Mengompres ulang gambar terhadap resolusi terukurnya di halaman",
+  "Membiarkan sebuah gambar kalau pengodean ulang tidak membuatnya lebih kecil",
+  "Membuang objek yang ditinggalkan suntingan sebelumnya, dan metadata opsional",
+  "Membuka dan memeriksa kembali file yang sudah jadi sebelum menawarkannya",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa batas ukuran file",
+]
+
+[picker]
+title = "Jatuhkan PDF di sini"
+hint = "atau klik untuk menelusuri &mdash; satu dokumen sekali jalan"

--- a/locales/id/tools/crop-video.html
+++ b/locales/id/tools/crop-video.html
@@ -1,0 +1,153 @@
+<!--
+  tools/crop-video/body.html, in Indonesian.
+
+  Every id, class, data-aspect and option value below is what src/main.js and
+  src/cropper.js reach for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Ukuran</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Bingkai</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Audio</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; pangkasan -->
+  <section class="card" id="crop-card" hidden>
+    <h2><span class="step">2</span> Tentukan pangkasannya</h2>
+
+    <p class="stage-hint">
+      Seret di dalam kotak untuk memindahkannya, atau sudut mana pun untuk
+      mengubah ukurannya. Saat kotaknya terfokus, tombol panah menggesernya satu
+      piksel sekali tekan, <kbd>Alt</kbd>&nbsp;+&nbsp;panah mengubah ukurannya,
+      dan menahan <kbd>Shift</kbd> membuat setiap langkah menjadi sepuluh.
+    </p>
+
+    <!-- The crop box itself is added here by src/cropper.js. The stage is given
+         the video's own shape, so the box can be positioned in percentages and
+         needs no recalculating when the window is resized. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <div class="crop-controls">
+      <div class="aspect-row" role="group" aria-label="Kunci pangkasan ke sebuah bentuk">
+        <button type="button" data-aspect="free" class="active">Bebas</button>
+        <button type="button" data-aspect="source">Asli</button>
+        <button type="button" data-aspect="1:1">1:1</button>
+        <button type="button" data-aspect="4:5">4:5</button>
+        <button type="button" data-aspect="9:16">9:16</button>
+        <button type="button" data-aspect="16:9">16:9</button>
+        <button type="button" data-aspect="4:3">4:3</button>
+        <button type="button" data-aspect="3:2">3:2</button>
+        <button type="button" id="swap-aspect" class="ghost" title="Balikkan bentuk yang terkunci">
+          Balik
+        </button>
+      </div>
+
+      <div class="numbers">
+        <label>Kiri<input type="number" id="crop-x" min="0" step="1"></label>
+        <label>Atas<input type="number" id="crop-y" min="0" step="1"></label>
+        <label>Lebar<input type="number" id="crop-w" min="16" step="2"></label>
+        <label>Tinggi<input type="number" id="crop-h" min="16" step="2"></label>
+        <div class="number-actions">
+          <button type="button" id="crop-max" class="ghost">Terbesar</button>
+          <button type="button" id="crop-centre" class="ghost">Tengah</button>
+          <button type="button" id="crop-reset" class="ghost">Seluruh bingkai</button>
+        </div>
+      </div>
+    </div>
+
+    <p class="even-note">
+      Lebar dan tinggi bergerak dua-dua, karena H.264 tidak punya cara menyimpan
+      bingkai dengan sisi ganjil.
+    </p>
+  </section>
+
+  <!-- Langkah 3 &mdash; ekspor -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Pangkas</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Keluaran</label>
+        <select id="format">
+          <option value="mp4" selected>MP4 &mdash; dikodekan ulang bingkai demi bingkai</option>
+          <option value="webm">WebM &mdash; direkam sambil diputar</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Kualitas</label>
+        <select id="quality">
+          <option value="low">File lebih kecil</option>
+          <option value="medium" selected>Seimbang</option>
+          <option value="high">Kualitas terbaik</option>
+        </select>
+        <p class="field-note">
+          Tidak pernah lebih dari yang dibelanjakan aslinya untuk area yang sama
+          &mdash; mengodekan di atas itu hanya membuat file lebih besar.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Simpan suaranya
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Bingkai keluaran</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Yang disimpan</dt><dd id="sum-kept">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Caranya</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Pangkas video</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh video</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/crop-video.toml
+++ b/locales/id/tools/crop-video.toml
@@ -1,0 +1,243 @@
+#
+# Pemangkas Video - Bahasa Indonesia.
+#
+# Overrides for tools/crop-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Pangkas" di sini berarti mengubah bentuk gambar; memendekkan durasi klip
+# adalah "potong" dan itu alat yang berbeda. Kedua kata dijaga terpisah di
+# seluruh locale ini.
+#
+
+name = "Pemangkas Video"
+heading = "Pemangkas&nbsp;Video <span class=\"h1-kw\">&mdash; pangkas video daring</span>"
+tagline = "Potong klip sampai tersisa bagian yang penting."
+
+title = "Pangkas Video Daring &mdash; Gratis, Tanpa Unggah, Jalan Tanpa Internet"
+description = "Pangkas MP4, MOV, atau WebM ke bentuk apa pun - persegi, 9:16, atau kotak piksel yang persis. Berjalan di peramban Anda: tidak ada yang diunggah, suaranya tetap ada, jalan tanpa internet."
+og_title = "Pemangkas Video &mdash; pangkas klip tanpa mengunggahnya"
+og_description = "Seret sebuah kotak di atas klip Anda dan pangkas ke bentuk apa pun. Bingkainya didekode dan dikodekan ulang di perangkat Anda sendiri, dan suara aslinya dibawa menyeberang tanpa disentuh."
+og_image_alt = "Pemangkas Video - pangkas klip di peramban Anda, tanpa ada yang diunggah"
+
+pledge = """
+    Setiap bingkai didekode, dipangkas, dan dikodekan oleh peramban Anda
+    sendiri, di perangkat keras Anda sendiri. Tidak ada di sini yang bisa
+    mengambil atau mengirim apa pun &mdash; alat ini sama sekali tidak punya
+    fitur jaringan &mdash; dan seandainya pun ada, tidak ada server di ujung
+    lain halaman ini untuk menerima sebuah video."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu pangkas sebuah klip. Tidak satu pun permintaan membawa bingkai, nama
+      file, atau satu byte pun dari yang Anda pilih. Atau cabut koneksi internet
+      dan tetap pangkas satu &mdash; alat yang mengirim video Anda ke tempat lain
+      untuk diproses akan langsung berhenti."""
+
+read_first = """
+, <code>src/demux.js</code> untuk pembaca yang mencari
+      bingkai di dalam MP4, dan <code>src/transcode.js</code> untuk perulangan
+      yang mendekode, memangkas, dan mengodekannya. Tidak satu pun mengimpor
+      sesuatu yang bisa membuat permintaan."""
+
+howto_heading = "Cara memangkas video"
+
+card = """
+            Seret sebuah kotak di atas klip dan potong sampai tinggal bentuk itu
+            &mdash; persegi untuk lini masa, tinggi untuk ponsel, atau kotak
+            piksel yang persis."""
+
+[words]
+plural = "video"
+choose = "sebuah video"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Suaranya tetap ada"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[privacy]]
+title = "Video Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Alat ini sama sekali tidak punya
+      fitur jaringan: tidak ada alamat untuk ditempelkan, tidak ada yang
+      diunduh, tidak ada mesin yang diambil saat pertama dipakai. Setiap byte
+      yang menyentuh video Anda datang dari asal ini ketika halaman dimuat."""
+
+[[privacy]]
+title = "Pendekodean dan pengodean berjalan lokal."
+body = """
+ Bingkainya melewati WebCodecs di
+      peramban Anda sendiri, atau melewati mesin pemutar yang sama yang toh akan
+      menampilkan klip itu kepada Anda. File yang sudah jadi dibangun di memori
+      mesin ini dan diserahkan langsung ke unduhan."""
+
+[[privacy]]
+title = "Suaranya disalin, bukan didengarkan."
+body = """
+ Di jalur MP4, sampel audio dipindahkan
+      menyeberang tanpa didekode sama sekali &mdash; tidak ada di sini yang
+      pernah mengubahnya kembali menjadi suara, dan tidak ada yang bisa
+      meneruskannya ke mana pun seandainya ada."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang video Anda: bukan file,
+      bukan bingkai, bukan nama, ukuran, durasi, atau bentuk hasil pangkasan
+      Anda. Setiap baris yang membaca, mendekode, memangkas, atau mengodekan
+      disajikan dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau video Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih sebuah video."
+body = """
+ Jatuhkan MP4, MOV, M4V, atau WebM ke
+      pemilih file, atau pilih sendiri. Peramban membacanya langsung dari disk
+      Anda; tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Seret kotaknya ke bagian yang ingin Anda simpan."
+body = """
+ Seret di
+      dalamnya untuk memindahkan dan sudut mana pun untuk mengubah ukuran. Kunci
+      dulu ke sebuah bentuk &mdash; 1:1 untuk unggahan persegi, 9:16 untuk
+      ponsel, 16:9 untuk bingkai lebar &mdash; atau ketikkan kotak piksel yang
+      persis ke empat kolom di bawahnya."""
+
+[[howto]]
+title = "Pilih berapa banyak kualitas yang dibelanjakan."
+body = """
+ Gambarnya harus
+      dikodekan ulang, karena bingkai yang dipangkas adalah gambar yang berbeda.
+      "Seimbang" menjaganya tetap dekat dengan apa yang sudah dibelanjakan file
+      itu untuk area tersebut; "Kualitas terbaik" membelanjakan lebih. Suaranya
+      tetap ada kecuali Anda mematikannya."""
+
+[[howto]]
+title = "Pangkas dan unduh."
+body = """
+ Pekerjaannya terjadi di perangkat keras Anda
+      sendiri, jadi lamanya tergantung mesin Anda, bukan pada antrean. Video yang
+      sudah jadi diserahkan langsung ke unduhan peramban Anda."""
+
+[[faq]]
+q = "Apakah video saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca, didekode, dipangkas, dan dikodekan oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya sisi
+        server, dan <code>Content-Security-Policy</code> halaman ini menyebut
+        satu per satu setiap alamat yang boleh dihubunginya &mdash; tidak satu
+        pun milik situs ini. Cabut koneksi internet dan tetap pangkas sebuah klip
+        kalau Anda lebih suka memeriksa daripada diberi tahu."""
+
+[[faq]]
+q = "Format video apa saja yang bisa saya pangkas?"
+a = """
+        MP4, M4V, dan MOV dibaca langsung, apa pun isinya: H.264, HEVC, AV1, atau
+        VP9, selama peramban Anda bisa mendekode kodek itu. Apa pun lain yang
+        bisa diputar peramban Anda &mdash; yang paling jelas WebM &mdash;
+        dipangkas dengan cara memutarnya dan merekam hasilnya, yang berhasil tapi
+        memakan waktu selama klipnya. File yang tidak bisa dibaca maupun diputar
+        peramban, yang dalam praktiknya berarti AVI, WMV, FLV, dan sebagian besar
+        MKV, ditolak dengan pesan alih-alih gagal di tengah jalan."""
+
+[[faq]]
+q = "Adakah batas ukuran atau durasi videonya?"
+a = """
+        Tidak ada batas yang tertanam di alat ini, dan file tidak dibaca ke
+        memori sekaligus &mdash; ia ditelusuri beberapa megabyte sekali jalan.
+        Batas praktisnya adalah video yang sudah jadi, yang dirakit di memori
+        sebelum Anda mengunduhnya, dan waktu yang dibutuhkan mesin Anda untuk
+        mengodekannya."""
+
+[[faq]]
+q = "Apakah suaranya selamat?"
+a = """
+        Di jalur MP4, persis: audio disalin sampel demi sampel tanpa pernah
+        didekode, jadi ia sama persis byte demi byte dengan yang ada di file. Di
+        jalur perekaman, ia ditangkap dari pemutaran dan dikodekan ulang, yang
+        memakan sedikit kualitas. Bagaimanapun ada kotak centang untuk
+        meninggalkannya sama sekali."""
+
+[[faq]]
+q = "Apakah memangkas menurunkan kualitas?"
+a = """
+        Gambarnya dikodekan ulang, karena bingkai yang dipangkas adalah gambar
+        yang berbeda dan tidak ada cara menyimpannya tanpa menulis pikselnya dari
+        awal. Yang tidak akan dilakukan alat ini adalah membelanjakan lebih
+        banyak daripada aslinya untuk area yang sama, karena mengodekan di atas
+        itu hanya membuat file lebih besar tanpa membuatnya tampak lebih
+        baik."""
+
+[[faq]]
+q = "Bisakah saya memotong durasinya juga?"
+a = """
+        Tidak di sini, tapi di sebelah. Alat ini mengubah bentuk gambar dan tidak
+        lebih: klip yang keluar sama persis panjangnya dengan yang masuk, dengan
+        waktu dan suaranya utuh. Memotong durasi adalah pekerjaan terpisah dan
+        alat terpisah &mdash; <a href="../potong-video/">Pemotong Video</a>
+        menandai bagian klip yang layak disimpan dan menyimpannya sebagai satu
+        file, tanpa mengodekan ulang satu bingkai pun."""
+
+[[faq]]
+q = "Kenapa lebar dan tingginya bergerak dua-dua?"
+a = """
+        H.264, kodek di dalam MP4, menyimpan gambar dalam blok dan tidak punya
+        cara menggambarkan bingkai dengan jumlah piksel ganjil di salah satu
+        sisinya. Alih-alih diam-diam membulatkan pangkasan Anda setelah Anda
+        menetapkannya, kotaknya sejak awal hanya menawarkan angka genap."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang video Anda."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript. Keluaran MP4 memerlukan peramban dengan WebCodecs; selain itu kembali ke perekaman WebM."
+description = "Pangkas video ke bentuk apa pun atau kotak piksel yang persis di peramban. MP4, MOV, dan M4V didekode dan dikodekan ulang bingkai demi bingkai dengan audio asli dibawa menyeberang tanpa disentuh; apa pun lain yang bisa diputar peramban dipangkas dengan merekamnya. Tidak ada yang diunggah."
+features = [
+  "Memangkas video MP4, MOV, M4V, dan WebM",
+  "Sumber H.264, HEVC, AV1, dan VP9, didekode lewat WebCodecs",
+  "Pangkasan bebas, rasio terkunci (1:1, 4:5, 9:16, 16:9, 4:3, 3:2), atau kotak piksel yang persis",
+  "Menjaga audio asli tanpa mengodekannya ulang",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan video di sini"
+hint = "atau klik untuk menelusuri &mdash; MP4, MOV, M4V, WebM, dan apa pun lain yang bisa diputar peramban ini"

--- a/locales/id/tools/dicom-viewer.html
+++ b/locales/id/tools/dicom-viewer.html
@@ -1,0 +1,265 @@
+<!--
+  tools/dicom-viewer/body.html, in Indonesian.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+
+  The column headings of the tag table keep "VR": it is the two-letter code
+  written in the file itself, and a reader checking a tag against the standard
+  is looking for those letters.
+-->
+<main>
+  <!--
+    One numbered step, and then the viewer.
+
+    Every other tool on this site numbers its cards because every card is
+    something the visitor does. Here there is one thing to do - choose the
+    files - and everything below it is the scan. Numbering the picture would
+    promise a sequence of decisions that does not exist.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah pindaian</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p class="picker-note">
+      Jatuhkan isi satu folder penuh sekaligus dan mereka dikembalikan ke serinya
+      lalu disusun berurutan. Tidak ada yang diunggah, dan tidak ada yang ditulis
+      kembali ke file Anda.
+    </p>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Penampilnya. -->
+  <section class="card" id="viewer-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="save-frame" class="ghost" data-download>Simpan bingkai ini sebagai PNG</button>
+        <button type="button" id="copy-header" class="ghost">Salin headernya</button>
+        <button type="button" id="download-header" class="ghost">Unduh</button>
+      </div>
+    </div>
+
+    <div class="series-row" id="series-row" hidden>
+      <label for="series-pick" class="inline-label">Seri</label>
+      <select id="series-pick"></select>
+      <span class="count" id="series-note"></span>
+    </div>
+
+    <!--
+      The canvas is sized in CSS and its backing store is set to the frame's own
+      pixels, so a 512-pixel slice is drawn at 512 pixels and scaled by the
+      browser rather than resampled here. That is what makes the zoom honest:
+      what is on screen at 400% is the stored pixels made bigger, not a guess at
+      what was between them.
+    -->
+    <div class="viewport" id="viewport">
+      <canvas id="canvas" width="1" height="1" role="img"
+              aria-label="Bingkai di layar, digambar dari file yang Anda pilih"></canvas>
+      <div class="overlay overlay-tl" id="overlay-tl" hidden></div>
+      <div class="overlay overlay-tr" id="overlay-tr"></div>
+      <div class="overlay overlay-bl" id="overlay-bl"></div>
+      <div class="overlay overlay-br" id="overlay-br"></div>
+      <svg class="marks" id="marks" aria-hidden="true"></svg>
+      <p class="viewport-fail" id="viewport-fail" hidden></p>
+    </div>
+
+    <div class="scrub" id="scrub-row" hidden>
+      <button type="button" id="play" class="ghost" aria-label="Putar melalui bingkainya">▶</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" step="1"
+             aria-label="Irisan atau bingkai mana yang ditampilkan">
+      <span class="count" id="scrub-label">&mdash;</span>
+    </div>
+
+    <div class="tools">
+      <fieldset class="modes">
+        <legend class="visually-hidden">Apa yang dilakukan seretan pada gambarnya</legend>
+        <label><input type="radio" name="mode" value="window" checked> Jendela &amp; level</label>
+        <label><input type="radio" name="mode" value="pan"> Geser</label>
+        <label><input type="radio" name="mode" value="measure"> Ukur</label>
+      </fieldset>
+
+      <div class="zoom">
+        <label for="zoom" class="inline-label">Perbesaran</label>
+        <input type="range" id="zoom" min="5" max="800" step="5" value="100">
+        <span class="count" id="zoom-label">100%</span>
+        <button type="button" id="reset-view" class="ghost">Paskan</button>
+      </div>
+    </div>
+
+    <div class="levels" id="levels">
+      <div class="level-field">
+        <label for="preset" class="inline-label">Jendela</label>
+        <select id="preset"></select>
+      </div>
+      <div class="level-field">
+        <label for="center" class="inline-label">Pusat</label>
+        <input type="number" id="center" step="1">
+      </div>
+      <div class="level-field">
+        <label for="width" class="inline-label">Lebar</label>
+        <input type="number" id="width" step="1" min="1">
+      </div>
+      <label class="level-check"><input type="checkbox" id="invert"> Balikkan</label>
+      <label class="level-check"><input type="checkbox" id="show-details"> Tampilkan detail pasiennya di atas gambarnya</label>
+    </div>
+
+    <p class="hint" id="mode-hint"></p>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- File ini apa. -->
+  <section class="card" id="facts-card" hidden>
+    <h2>File ini apa</h2>
+    <dl class="facts">
+      <div><dt>Objek</dt><dd id="fact-sop">&mdash;</dd></div>
+      <div><dt>Modalitas</dt><dd id="fact-modality">&mdash;</dd></div>
+      <div><dt>Gambar</dt><dd id="fact-size">&mdash;</dd></div>
+      <div><dt>Disimpan sebagai</dt><dd id="fact-stored">&mdash;</dd></div>
+      <div><dt>Sintaks transfer</dt><dd id="fact-syntax">&mdash;</dd></div>
+      <div><dt>Jarak piksel</dt><dd id="fact-spacing">&mdash;</dd></div>
+      <div><dt>Rentang nilai</dt><dd id="fact-range">&mdash;</dd></div>
+      <div><dt>File</dt><dd id="fact-file">&mdash;</dd></div>
+    </dl>
+
+    <ul class="notes" id="notes" hidden></ul>
+  </section>
+
+  <!-- Apa isinya tentang orangnya. -->
+  <section class="card" id="identity-card" hidden>
+    <h2>Apa di file ini yang mengenali pasiennya</h2>
+    <p class="card-lede">
+      Dibaca dari file ini, di mesin ini, dan tidak ditampilkan kepada siapa pun
+      lain. Alat ini tidak menulis apa pun: ia tidak bisa mengeluarkan satu pun
+      darinya, dan ia tidak mengirimkan satu pun ke mana pun. Ia ada di sini
+      karena sebuah pindaian membawa jauh lebih banyak daripada sebuah nama, dan
+      sisanya itulah yang selamat dari penganoniman yang sembrono.
+    </p>
+    <ul class="identity" id="identity"></ul>
+    <p class="identity-extra" id="identity-extra"></p>
+  </section>
+
+  <!-- Setiap tag di dalam file-nya. -->
+  <section class="card" id="tags-card" hidden>
+    <div class="toolbar">
+      <h2>Setiap tag di dalam file-nya</h2>
+      <div class="toolbar-actions">
+        <label for="tag-search" class="visually-hidden">Cari di tagnya</label>
+        <input type="search" id="tag-search" class="tag-search" placeholder="Cari menurut nama, nomor, atau nilai">
+      </div>
+    </div>
+
+    <p class="card-lede" id="tags-lede"></p>
+
+    <div class="table-wrap">
+      <table class="tags">
+        <caption class="visually-hidden">Setiap elemen di dalam file ini</caption>
+        <thead>
+          <tr>
+            <th scope="col">Tag</th>
+            <th scope="col">VR</th>
+            <th scope="col">Nama</th>
+            <th scope="col">Nilai</th>
+          </tr>
+        </thead>
+        <tbody id="tag-rows"></tbody>
+      </table>
+    </div>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!--
+    The tool's own sentences, kept out of the JavaScript so that a translator
+    can reach them. shared/js/phrases.js reads them back, and a key defined here
+    wins over the frame's one.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="mode.window">Seret melintasi gambarnya untuk melebarkan atau menyempitkan jendelanya, dan ke atas atau ke bawah untuk menggeser pusatnya. Kedua angkanya ada di bawah, dan mengetik ke dalamnya melakukan hal yang sama.</span>
+    <span data-phrase="mode.pan">Seret untuk memindahkan gambarnya di dalam bingkainya. Roda gulir memperbesar, dan &ldquo;Paskan&rdquo; mengembalikannya.</span>
+    <span data-phrase="mode.measure">Seret sebuah garis melintasi gambarnya untuk mengukurnya. Kalau file-nya mengatakan seberapa jauh jarak antar pikselnya, jawabannya dalam milimeter; kalau tidak, jawabannya dalam piksel dan ia mengatakannya.</span>
+
+    <span data-phrase="probe.value">{value} di kolom {column}, baris {row}</span>
+    <span data-phrase="measure.pixels">{length} px &mdash; file ini tidak mengatakan seberapa jauh jarak antar pikselnya, jadi ini tidak bisa dalam milimeter</span>
+
+    <span data-phrase="stack.position">Disusun menurut letak setiap irisan di dalam tubuh pasiennya, dan itulah urutan pengambilan pemindainya.</span>
+    <span data-phrase="stack.number">Disusun menurut nomor instansnya: file-file ini tidak membawa letak di dalam tubuh pasien untuk diurutkan.</span>
+    <span data-phrase="stack.gap">Jarak antar irisannya tidak sama sepanjang serinya, jadi setidaknya satu irisan hilang dari seri ini.</span>
+
+    <span data-phrase="pixels.none">Piksel file ini dikompres dengan {codec}, yang tidak bisa didekodekan peramban mana pun dan yang dekodernya tidak dibawa halaman ini. Semua hal lain tentang file-nya ada di bawah.</span>
+    <span data-phrase="pixels.failed">Gambarnya tidak bisa didekodekan: {reason}. Header di bawah dibaca utuh.</span>
+    <span data-phrase="pixels.absent">File ini sama sekali tidak membawa data piksel. Ia sebuah header, dan semua isinya ada di bawah.</span>
+    <span data-phrase="pixels.jpeg">Piksel ini adalah baseline JPEG, jadi dekoder milik peramban sendiri yang membukanya dan yang diserahkannya kembali sedalam delapan bit. Jendelanya tetap bekerja; ketelitian yang direkam pemindainya tidak seluruhnya ada di sana.</span>
+
+    <span data-phrase="tags.count">{shown} dari {total} elemen. {hidden} lagi.</span>
+    <span data-phrase="tags.all">Semua {total} elemen di file ini.</span>
+    <span data-phrase="tags.found">{total} elemen cocok dengan &ldquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.found.one">Satu elemen cocok dengan &ldquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.none">Tidak ada yang cocok dengan &ldquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.more">Tampilkan {count} sisanya</span>
+    <span data-phrase="tags.private">elemen privat</span>
+    <span data-phrase="tags.unknown">tidak ada di kamus ini</span>
+    <span data-phrase="tags.guessed">File-nya tidak mengatakannya; inilah yang diberikan kamus datanya untuk tag ini.</span>
+
+    <span data-phrase="working.one">Membaca {name}&hellip;</span>
+    <span data-phrase="working.many">Membaca {at} dari {total}&hellip;</span>
+    <span data-phrase="error.none">Tidak ada di sini yang bisa dibaca sebagai DICOM. {why} Alat ini membaca format DICOM itu sendiri, jadi ia tidak punya apa-apa untuk dikatakan tentang file lain.</span>
+    <span data-phrase="error.skipped.one">Satu file dilewati: {files}</span>
+    <span data-phrase="error.skipped">{count} file dilewati: {files}</span>
+
+    <span data-phrase="series.number">Seri {number}</span>
+    <span data-phrase="series.files.one">1 file</span>
+    <span data-phrase="series.files">{count} file</span>
+    <span data-phrase="stack.spacing">Jarak antar irisannya {gap}.</span>
+
+    <span data-phrase="at.position">{at} dari {total}</span>
+    <span data-phrase="net.clean">pindaian Anda tidak pergi ke mana pun. {total}
+      file dimuat, semuanya milik halaman ini sendiri. {platform}</span>
+    <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak
+      pernah dilakukan alat ini. Anggap itu layak diselidiki. {platform}</span>
+    <span data-phrase="net.platform.one">Skrip iklan, pengukuran, dan tombol
+      donasi milik halaman ini dimuat dari {hosts} host; tidak satu pun diberi
+      sebuah pindaian, sebuah pikselnya, atau sepatah kata dari headernya.</span>
+    <span data-phrase="net.platform.many">Skrip iklan, pengukuran, dan tombol
+      donasi milik halaman ini dimuat dari {hosts} host; tidak satu pun diberi
+      sebuah pindaian, sebuah pikselnya, atau sepatah kata dari headernya.</span>
+    <span data-phrase="at.frame">bingkai {at} dari {total}</span>
+    <span data-phrase="at.instance">instans {number}</span>
+
+    <span data-phrase="window.file">Dari file-nya</span>
+    <span data-phrase="window.file.n">Dari file-nya, {n}</span>
+    <span data-phrase="window.full">Semua di bingkai ini</span>
+    <span data-phrase="window.custom">Disetel sendiri</span>
+    <span data-phrase="window.soft">Jaringan lunak</span>
+    <span data-phrase="window.lung">Paru</span>
+    <span data-phrase="window.bone">Tulang</span>
+    <span data-phrase="window.brain">Otak</span>
+    <span data-phrase="window.liver">Hati</span>
+    <span data-phrase="window.mediastinum">Mediastinum</span>
+    <span data-phrase="window.angio">Angiografi</span>
+
+    <span data-phrase="facts.frames">{count} bingkai</span>
+    <span data-phrase="facts.nopixels">tidak ada data piksel</span>
+    <span data-phrase="facts.nospacing">tidak dinyatakan di file ini</span>
+    <span data-phrase="facts.signed">bertanda</span>
+    <span data-phrase="facts.unsigned">tak bertanda</span>
+    <span data-phrase="facts.stored.one">{bits} bit, {sign}, 1 sampel per piksel, {photometric}</span>
+    <span data-phrase="facts.stored">{bits} bit, {sign}, {samples} sampel per piksel, {photometric}</span>
+    <span data-phrase="facts.range">{low} sampai {high}</span>
+    <span data-phrase="facts.colour">warna &mdash; tidak ada yang terukur untuk dilaporkan</span>
+
+    <span data-phrase="identity.clean">Tidak ada di file ini yang menamai atau menomori seseorang. Pengenal yang biasanya dibawa sebuah pindaian entah tidak ada entah kosong.</span>
+    <span data-phrase="identity.uids">Ia juga membawa {count} pengenal miliknya sendiri &mdash; UID studinya, serinya, dan instansnya. Tidak satu pun berupa nama, dan setiap satunya adalah kunci sempurna ke dalam arsip yang membuat file itu.</span>
+    <span data-phrase="identity.private">Dan {count} elemen privat, yang maknanya tidak diterbitkan di mana pun: sebagian pemindai menyimpan salinan kedua nama pasiennya di salah satunya.</span>
+
+    <span data-phrase="copied">Tersalin.</span>
+    <span data-phrase="copy.failed">Peramban Anda tidak mengizinkan halaman ini menyalin. Tombol unduh di sebelahnya menulis teks yang sama ke sebuah file.</span>
+    <span data-phrase="saved">{name} tersimpan.</span>
+  </div>
+</main>

--- a/locales/id/tools/dicom-viewer.toml
+++ b/locales/id/tools/dicom-viewer.toml
@@ -1,0 +1,413 @@
+#
+# Penampil DICOM - Bahasa Indonesia.
+#
+# Overrides for tools/dicom-viewer/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama tag DICOM dibiarkan dalam bahasa Inggris dengan nomornya - Pixel Spacing
+# (0028,0030), Series Instance UID (0020,000E) - karena itulah yang tertulis di
+# dalam file dan di dalam standarnya, dan pembaca yang mencarinya akan mencari
+# nama itu. Begitu juga nama sintaks transfer dan kodeknya, serta PS3.15.
+#
+# Halaman inilah tempat janji situs ini paling tajam, jadi kalimat tentang apa
+# yang ada di dalam file-nya diterjemahkan selengkap kalimat tentang ke mana ia
+# tidak pergi. Penampil yang diam-diam menampilkan gambarnya dan tidak
+# mengatakan apa pun tentang empat puluh kolom pengenal di belakangnya memenuhi
+# bunyi janjinya dan meleset dari maksudnya.
+#
+
+name = "Penampil DICOM"
+heading = "Penampil&nbsp;DICOM <span class=\"h1-kw\">&mdash; buka pindaian .dcm di peramban Anda</span>"
+tagline = "CT, MR, rontgen, dan USG, lengkap dengan jendela, headernya, dan pengukurannya."
+
+title = "Penampil DICOM &mdash; Buka File .dcm di Peramban Anda, Tanpa Unggah"
+description = "Buka pindaian CT, MR, rontgen, dan USG di peramban Anda. Jendela dan levelnya, gulir satu seri utuh, ukur dalam milimeter, baca setiap tag DICOM, dan lihat persis apa di dalam file-nya yang mengenali pasiennya. Tidak ada yang diunggah."
+og_title = "Penampil DICOM &mdash; buka sebuah pindaian tanpa mengunggahnya"
+og_description = "File .dcm yang dibuka di mesin Anda sendiri: jendela dan level, seluruh serinya tersusun berurutan, pengukuran dalam milimeter, dan setiap tag di headernya. Tanpa unggah, tanpa akun."
+og_image_alt = "Penampil DICOM - buka pindaian CT, MR, atau rontgen di peramban"
+
+pledge = """
+    Pindaiannya dibuka dan didekodekan oleh peramban Anda sendiri: headernya,
+    pikselnya, jendelanya, pengukurannya. Tidak ada server di ujung lain halaman
+    ini untuk menerima informasi kesehatan yang dilindungi, bahkan seandainya ada
+    di sini yang menginginkannya, dan tidak ada apa pun tentang file-nya - bukan
+    nama pasiennya, bukan studinya, bukan nama file-nya - yang dibacakan kepada
+    siapa pun."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu buka sebuah pindaian. Tidak satu pun permintaan membawa sebuah gambar,
+      sebuah tag, atau sebuah nama file. Atau cabut koneksi internet dan tetap
+      buka satu."""
+
+read_first = """
+, <code>src/dicom.js</code> untuk pembaca yang
+      menyusuri file-nya, <code>src/pixels.js</code> untuk pendekodean pikselnya,
+      <code>src/jpeg-lossless.js</code> untuk kodek yang dipakai kebanyakan
+      ekspor rumah sakit, dan <code>src/window.js</code> untuk jendela dan
+      levelnya &mdash; tidak satu pun punya baris yang bisa menjangkau
+      jaringan."""
+
+howto_heading = "Cara membuka file DICOM"
+
+card = """
+            Buka pindaian CT, MR, rontgen, atau USG di mesin Anda sendiri. Atur
+            jendela dan levelnya, gulir seluruh serinya, ukur dalam milimeter,
+            dan baca setiap tag di headernya."""
+
+[words]
+plural = "pindaian"
+choose = "sebuah pindaian"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "Pindaian Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy
+      menyebut satu per satu setiap alamat yang boleh dihubungi halaman ini, dan
+      tidak satu pun milik situs ini. Tidak ada titik akhir di sini tempat file
+      Anda bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada. Dulu di sini tertulis <code>connect-src 'none'</code>, yang mutlak;
+      menambahkan iklan mengorbankan itu, dan mengatakannya adalah bagian dari
+      kesepakatannya."""
+
+[[privacy]]
+title = "Ini lebih penting di sini daripada di halaman lain."
+body = """
+
+      File DICOM bukan sebuah gambar dengan sedikit metadata di atasnya. Ia sebuah
+      rekam medis dengan sebuah gambar di dalamnya: nama pasiennya, tanggal
+      lahirnya, nomor rumah sakitnya, nomor aksesinya, dokter yang merujuk,
+      institusinya, dan nomor seri pemindainya semuanya adalah kolom di dalam
+      headernya, dan semuanya bepergian bersama file-nya ke mana pun ia pergi.
+      Mengunggah satu ke sebuah situs web untuk melihatnya berarti menyerahkan
+      semua itu kepada siapa pun yang menjalankan situs itu. Itulah hal yang
+      justru tidak dilakukan halaman ini."""
+
+[[privacy]]
+title = "Pembacanya adalah empat belas file di repositori ini."
+body = """
+ Tidak ada di sini yang
+      memakai pustaka yang diambil dari mana pun. <code>src/dicom.js</code>
+      menyusuri file-nya, <code>src/dictionary.js</code> tahu tagnya disebut apa,
+      <code>src/pixels.js</code> mengubah byte-nya kembali menjadi pengukuran,
+      <code>src/rle.js</code> dan <code>src/jpeg-lossless.js</code> membuka dua
+      bentuk terkompres yang bisa didekodekan halaman ini, dan
+      <code>src/window.js</code> memetakan yang terukur ke abu-abu di layar
+      Anda."""
+
+[[privacy]]
+title = "Pengenalnya didaftar untuk Anda, dan untuk tidak seorang pun lainnya."
+body = """
+
+      Halaman ini mencetak setiap kolom di file Anda yang menamai atau
+      mempersempit siapa orang di dalamnya, karena itu pertanyaan yang butuh
+      jawaban bagi orang yang hendak membagikan sebuah irisan dan tidak ada
+      penampil yang menjawabnya. Ia ditaruh di layar di hadapan Anda dan tidak
+      pergi ke tempat lain: tidak ada peristiwa analitik di repositori ini yang
+      membawa satu pun darinya, dan halaman ini tidak akan bisa mengirimnya
+      seandainya ada."""
+
+[[privacy]]
+title = "Ia membaca. Ia tidak menulis."
+body = """
+ Tidak ada tombol di sini yang mengubah
+      file Anda, dan tidak ada kode yang bisa. Yang bisa Anda bawa pulang adalah
+      sebuah PNG dari bingkai di layar dan sebuah salinan teks dari headernya,
+      keduanya dibangun di halaman ini dari yang sudah ada di atasnya. Berkas asli
+      Anda tetap tak tersentuh di disk Anda, dan itu juga jawaban jujur untuk apa
+      yang terjadi kalau Anda menutup tabnya."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan
+      pengukuran berasal dari Google. Tidak satu pun diberi apa pun tentang file
+      Anda: bukan pikselnya, bukan gambar mininya, bukan sebuah nama, sebuah tag,
+      seorang pasien, atau sebuah nama file. Setiap baris yang membaca,
+      mendekodekan, atau menggambar sebuah pindaian disajikan dari asal ini dan
+      terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+
+      Tombol "Buy me a coffee" di headernya digambar oleh sebuah skrip dari
+      cdnjs.buymeacoffee.com dan mengambil hurufnya dari Google Fonts. Ia sebuah
+      tautan dan tidak lebih: ia tidak melaporkan kunjungan, dan ia tidak diberi
+      apa pun tentang Anda atau file Anda. Tidak ada yang terjadi kecuali Anda
+      mengekliknya, dan yang akan Anda tuju lewat klik itu adalah situs orang
+      lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan setiap bagian
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana: alat yang
+      mengirim pindaian Anda pergi untuk digambar akan berhenti pada saat Anda
+      mencabut koneksi."""
+
+[[howto]]
+title = "Pilih file-nya."
+body = """
+ Satu file <code>.dcm</code>, atau seluruh folder
+      dari cakramnya &mdash; sebuah CT atau MR adalah satu file per irisan, dan
+      menjatuhkan semuanya sekaligus itulah yang menyusun kembali serinya. File
+      dibaca langsung dari disk Anda oleh peramban; tidak ada yang dikirim ke mana
+      pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Pilih serinya."
+body = """
+ Sebuah studi biasanya memuat beberapa: pindaian
+      pendahulunya, lalu setiap akuisisinya. Masing-masing disusun dalam urutan
+      pengambilan pemindainya, diperhitungkan dari letak setiap irisan di dalam
+      tubuh pasiennya alih-alih dari penomorannya, yang tidak selalu berjalan ke
+      arah yang sama."""
+
+[[howto]]
+title = "Atur jendelanya."
+body = """
+ Inilah kendali yang membuat sebuah pindaian
+      terbaca, dan yang tidak dimiliki sebuah penyunting gambar. Seret melintasi
+      gambarnya untuk melebarkan jendelanya dan ke atas atau ke bawah untuk
+      menggeser pusatnya, atau pilih salah satu jendela bernama &mdash; paru,
+      tulang, otak, jaringan lunak &mdash; pada sebuah CT, tempat satuannya sama
+      di setiap pemindai di dunia."""
+
+[[howto]]
+title = "Gulir tumpukannya."
+body = """
+ Penggeser di bawah gambarnya berpindah melalui
+      irisannya, dan tombol panah melakukan hal yang sama begitu Anda mengeklik
+      gambarnya. File multi-bingkai &mdash; sebuah lup USG, sebuah angiogram
+      &mdash; diputar dengan tombol di sebelahnya."""
+
+[[howto]]
+title = "Ukur sesuatu."
+body = """
+ Beralihlah ke Ukur lalu seret sebuah garis. Kalau
+      file-nya mengatakan seberapa jauh jarak antar pikselnya, jawabannya dalam
+      milimeter dan memperhitungkan piksel yang tidak persegi; kalau file-nya
+      tidak mengatakannya, jawabannya dalam piksel dan ia mengatakan begitu
+      alih-alih mengarang sebuah skala."""
+
+[[howto]]
+title = "Baca headernya."
+body = """
+ Setiap elemen di dalam file-nya, lengkap dengan
+      nomornya, sebutannya menurut standarnya, dan isinya, bisa dicari. Di atasnya,
+      daftar apa saja di file yang satu ini yang mengenali pasiennya &mdash; dan
+      itu jauh lebih banyak daripada namanya."""
+
+[[howto]]
+title = "Ambil yang Anda butuhkan."
+body = """
+ Bingkai di layar sebagai sebuah PNG,
+      dengan jendela yang Anda setel dan tanpa apa pun yang terbakar ke dalamnya,
+      atau seluruh headernya sebagai teks biasa. Keduanya dibangun di halaman ini
+      dari yang sudah ada di atasnya."""
+
+[[faq]]
+q = "Apakah pindaian saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File-nya dibaca, didekodekan, dan digambar oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya sisi server,
+        dan <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya &mdash; tidak satu pun milik situs
+        ini. Cabut koneksi jaringan dan ia tetap membuka pindaian.
+        <br><br>
+        Di sini itu lebih berarti daripada di halaman mana pun lain di situs ini.
+        File DICOM membawa nama pasiennya, tanggal lahirnya, dan nomor rumah
+        sakitnya di dalam headernya, jadi mengunggah satu ke sebuah penampil
+        berarti menyerahkan sebuah rekam medis kepada orang asing, bukan sebuah
+        gambar."""
+
+[[faq]]
+q = "File DICOM yang mana saja yang bisa dibukanya?"
+a = """
+        File tanpa kompresi dalam ketiga sintaks transfer dasarnya &mdash; implicit
+        dan explicit little endian, serta big endian yang sudah dipensiunkan
+        &mdash; ditambah deflated, RLE Lossless, baseline JPEG, dan JPEG Lossless,
+        yang dipakai untuk mengompres sebagian besar studi CT dan MR di sebuah
+        cakram rumah sakit.
+        <br><br>
+        Ia tidak bisa mendekodekan JPEG 2000, JPEG-LS, atau sintaks MPEG dan HEVC
+        yang dipakai untuk video. Semua itu butuh kodek yang berupa pustaka
+        terkompilasi berukuran megabita, dan halaman yang mengunduh satu saat
+        dibutuhkan bukanlah halaman yang jalan tanpa internet. File dalam salah
+        satunya tetap terbuka: seluruh headernya dibaca dan ditampilkan, dan
+        gambarnya diganti dengan sebaris tulisan yang menyebutkan kodeknya,
+        alih-alih dengan ikon gambar rusak yang tidak memberi tahu Anda
+        apa-apa."""
+
+[[faq]]
+q = "Apa itu &ldquo;jendela dan level&rdquo;, dan kenapa saya membutuhkannya?"
+a = """
+        Sebuah irisan CT menyimpan sekitar empat ribu nilai berbeda dan layar Anda
+        menampilkan dua ratus lima puluh enam abu-abu. Jendelanya adalah pilihan
+        bagian mana dari rentang itu yang mendapat semuanya: semua di bawahnya
+        hitam, semua di atasnya putih, dan yang di antaranya disebar ke seluruh
+        abu-abunya.
+        <br><br>
+        Itulah sebabnya file yang sama tampak seperti pindaian yang berbeda di
+        bawah dua setelan, dan sebabnya paru dan tulang tidak bisa dilihat
+        sekaligus. Pada sebuah CT angkanya adalah satuan Hounsfield, yang
+        didefinisikan secara mutlak &mdash; air adalah 0 dan udara adalah
+        &minus;1000 &mdash; jadi jendela bernama di halaman ini adalah angka yang
+        sama yang dipakai seorang radiolog di stasiun kerjanya. Pada sebuah MR atau
+        USG tidak ada skala semacam itu, dan jendela yang terbuka adalah jendela
+        yang diminta file-nya sendiri."""
+
+[[faq]]
+q = "Kenapa ia bilang pengukuran saya dalam piksel?"
+a = """
+        Karena file itu tidak mengatakan seberapa besar sebuah pikselnya. Pixel
+        Spacing (0028,0030) adalah yang membawa itu, dalam milimeter, dan sangat
+        banyak gambar USG, dokumen hasil pindaian, dan secondary capture memang
+        tidak memilikinya.
+        <br><br>
+        Kalau ia ada, pengukurannya dalam milimeter dan setiap sumbunya diukur
+        dengan jaraknya sendiri, dan itu penting pada gambar yang pikselnya tidak
+        persegi. Kalau ia tidak ada, jawaban yang jujur adalah hitungan piksel, dan
+        ini mengatakannya alih-alih memilih sebuah skala lalu menyajikan hasilnya
+        sebagai sebuah panjang."""
+
+[[faq]]
+q = "Ia membuka folder saya sebagai beberapa seri. Kenapa?"
+a = """
+        Karena memang itu isinya. Sebuah studi terdiri dari seri &mdash; pindaian
+        pendahulunya, lalu setiap akuisisi atau rekonstruksinya &mdash; dan setiap
+        file mengatakan ia milik yang mana di Series Instance UID (0020,000E).
+        Daftar pilihannya dibangun dari itu alih-alih dari foldernya, yang biasanya
+        memuat semuanya tercampur dalam satu daftar nama.
+        <br><br>
+        Di dalam sebuah seri, irisannya diurutkan menurut letak masing-masing di
+        dalam tubuh pasiennya, diperhitungkan dari Image Position dan Image
+        Orientation. Instance Number adalah kunci yang gamblang dan ia menjadi
+        cadangan alih-alih pilihan pertama: ia ditetapkan oleh apa pun yang menulis
+        file-nya dan tidak harus berjalan ke arah yang sama dengan tubuh
+        pasiennya."""
+
+[[faq]]
+q = "Apa maksud daftar &ldquo;apa yang mengenali pasiennya&rdquo;?"
+a = """
+        Itu setiap kolom di file Anda yang menamai orang di dalam pindaian itu,
+        atau yang mempersempit siapa dia mungkin, dibaca dari file ini di mesin
+        Anda. Daftarnya berasal dari PS3.15 standar DICOM &mdash; bagian yang
+        mengatakan apa saja yang harus hilang sebelum sebuah kumpulan data bisa
+        disebut sudah dinirkenalkan.
+        <br><br>
+        Ia ada di sana karena yang salah dipahami orang bukanlah bahwa sebuah
+        pindaian memuat sebuah nama. Melainkan berapa banyak lagi yang dimuatnya:
+        tanggal lahirnya, nomor aksesinya, dokter yang merujuk, institusinya, nomor
+        seri pemindainya, dan UID studinya, yang merupakan kunci sempurna kembali
+        ke arsip yang membuat file itu. Pindaian yang namanya sudah dikosongkan dan
+        tidak lebih dari itu tidaklah anonim.
+        <br><br>
+        Alat ini hanya menunjukkan kepada Anda. Ia tidak menulis apa pun dan tidak
+        mengubah apa pun, jadi ia tidak bisa mengeluarkan satu pun darinya."""
+
+[[faq]]
+q = "Bisakah ia menganonimkan sebuah pindaian?"
+a = """
+        Tidak, dan ia sengaja tidak berpura-pura bisa. Halaman ini membaca; ia
+        tidak punya kode yang menulis sebuah file DICOM. Yang dilakukannya adalah
+        memberi tahu Anda persis apa yang ada di dalam punya Anda, dan itulah
+        bagian yang sulit dicari tahu dan bagian yang salah dipahami orang.
+        <br><br>
+        Alat yang mengeluarkan pengenalnya adalah pekerjaan terpisah dengan
+        tuntutan yang jauh lebih tinggi &mdash; ia harus menulis ulang file-nya
+        tanpa menyentuh pikselnya, mengganti UID-nya secara konsisten di seluruh
+        satu studi, dan tepat soal elemen privat yang dipakai sebagian pemindai
+        untuk menyembunyikan salinan kedua namanya. Ia ada di peta jalan situs ini
+        alih-alih ditempelkan ke sebuah penampil."""
+
+[[faq]]
+q = "Bisakah ia membuka file tanpa ekstensi .dcm, atau yang rusak?"
+a = """
+        Bisa, keduanya. Ekstensinya tidak dilihat: yang diperiksa adalah file-nya
+        sendiri. Kumpulan data yang ditulis tanpa pembuka 128 byte yang biasa
+        &mdash; dan begitulah rupa sebuah pindaian yang ditarik langsung dari
+        jaringan &mdash; dibaca dengan memperhitungkan pengodeannya dari elemen
+        pertamanya, dan halamannya mengatakan bahwa itulah yang dilakukannya.
+        <br><br>
+        File yang berakhir di tengah jalan dibaca sejauh ia sampai. Semua yang
+        sebelum kerusakannya ditampilkan, dengan catatan yang menyebutkan di byte
+        mana ia berhenti. Itulah justru kasus yang paling membutuhkan sebuah
+        penampil, jadi membuang seluruh file-nya gara-gara dua belas byte
+        terakhirnya akan menjadi perilaku yang keliru."""
+
+[[faq]]
+q = "Apakah ini penampil diagnostik?"
+a = """
+        Bukan. Ia bukan perangkat medis, ia belum melewati penilaian regulasi apa
+        pun, dan tidak ada di sini yang boleh dipakai untuk membuat keputusan
+        klinis. Layar Anda tidak terkalibrasi, peramban bukan rantai penggambaran
+        yang tervalidasi, dan tidak satu pun dari keduanya bisa dibereskan dari
+        dalam sebuah halaman web.
+        <br><br>
+        Ia bagus untuk semua hal lain yang membuat orang membuka sebuah pindaian:
+        memeriksa apa yang ada di sebuah cakram, mengambil sebuah irisan untuk
+        bahan ajar atau sebuah makalah, membaca sebuah header, mencari tahu kenapa
+        program lain menolak file-nya, dan melihat apa yang dibawa sebuah pindaian
+        tentang orang di dalamnya."""
+
+[[faq]]
+q = "Apakah ia mengubah file saya?"
+a = """
+        Tidak. Alat ini hanya membaca. Tidak ada file keluaran, tidak ada
+        pengodean ulang, dan tidak ada tombol di sini yang menulis sebuah DICOM
+        &mdash; yang bisa Anda unduh adalah sebuah PNG dari bingkai di layar dan
+        salinan teks biasa dari headernya. Berkas asli Anda tetap tak tersentuh di
+        disk Anda."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis; tidak ada akun, tidak ada masuk, dan tidak ada masa uji coba.
+        Tidak ada batas ukuran file atau berapa banyak file yang Anda buka selain
+        memori mesin Anda sendiri. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang file Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia terus
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim pindaian Anda pergi untuk digambar akan
+        berhenti pada saat Anda mencabut koneksi."""
+
+[schema]
+description = "Buka pindaian DICOM (.dcm) di peramban: CT, MR, rontgen, dan USG, lengkap dengan jendela dan level, seluruh seri tersusun berurutan, pengukuran dalam milimeter, dan setiap tag di headernya. Tidak ada yang diunggah."
+features = [
+  "Membuka file CT, MR, rontgen, USG, PET, dan secondary capture",
+  "Jendela dan level dengan menyeret, dengan mengetik, atau lewat prasetel CT bernama",
+  "Seluruh folder disusun menjadi seri dan diurutkan menurut letaknya di dalam tubuh pasien",
+  "File multi-bingkai diputar sebagai sebuah lup",
+  "Mengukur dalam milimeter, dengan piksel tak persegi diperhitungkan",
+  "Membaca nilai piksel di bawah kursor dalam satuan Hounsfield",
+  "Setiap tag DICOM lengkap dengan nama dan nilainya, bisa dicari",
+  "Mendaftar apa saja di dalam file yang mengenali pasiennya, dari profil PS3.15",
+  "Mendekodekan RLE, baseline JPEG, dan JPEG Lossless tanpa pustaka pihak ketiga",
+  "Menyimpan bingkainya sebagai PNG dan headernya sebagai teks biasa",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa perubahan pada file Anda",
+]
+
+[picker]
+title = "Jatuhkan sebuah pindaian di sini"
+hint = "atau klik untuk menelusuri &mdash; satu file .dcm, atau satu folder penuh"

--- a/locales/id/tools/document-scanner.html
+++ b/locales/id/tools/document-scanner.html
@@ -1,0 +1,388 @@
+<!--
+  tools/document-scanner/body.html, in Indonesian.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; fotonya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih fotonya</h2>
+
+    <p class="card-lede">
+      Sebuah foto tiap halaman, diambil dari mana pun di atasnya. Seluruh
+      halamannya harus ada di dalam bingkai, dan keempat sudutnya sebaiknya
+      terlihat atau hampir terlihat &mdash; selebihnya, sudutnya, bayangannya,
+      meja tempatnya terbaring, itulah yang menjadi tugas alat ini. Tambahkan
+      beberapa dan mereka menjadi halaman-halaman satu dokumen, dalam urutan Anda
+      menambahkannya.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="strip-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="detect-all" class="ghost">Cari setiap halaman lagi</button>
+        <button type="button" id="clear-all" class="ghost danger">Buang semua</button>
+      </div>
+    </div>
+
+    <ul id="page-strip" class="page-strip"></ul>
+  </section>
+
+  <!-- Langkah 2 &mdash; sudutnya -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Taruh sudutnya di halamannya</h2>
+
+    <p id="edit-empty" class="field-summary">
+      Pilih sebuah foto dan ia muncul di sini, dengan keempat sudutnya dicarikan
+      untuk Anda.
+    </p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Tekan di mana pun pada fotonya dan sudut terdekat datang ke jari Anda;
+        seret ke sudut halamannya. <kbd>Tab</kbd> menjangkau sebuah sudut dari
+        papan ketik, tombol panah memindahkannya satu piksel dan
+        <kbd>Shift</kbd> bersamanya sepuluh. Tidak ada di sini yang final
+        &mdash; pindaiannya diambil dari di mana pun keempat sudutnya berakhir.
+      </p>
+
+      <!-- The photo is a canvas rather than an <img> because it is drawn at
+           screen size from the decoded picture, and because the same canvas is
+           what the corner finder reads. The outline over it is an SVG polygon
+           in percentages, so it needs no redraw when the window changes. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="photo"></canvas>
+        </div>
+      </div>
+
+      <p id="detect-note" class="hint-line" role="status" aria-live="polite"></p>
+
+      <div class="frame-actions">
+        <button type="button" id="detect-one" class="ghost">Cari sudutnya lagi</button>
+        <button type="button" id="whole-photo" class="ghost">Pakai seluruh fotonya</button>
+        <button type="button" id="turn-left" class="ghost">Putar ke kiri</button>
+        <button type="button" id="turn-right" class="ghost">Putar ke kanan</button>
+        <button type="button" id="undo" class="ghost" disabled>Urungkan</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; pembersihannya -->
+  <section class="card" id="clean-card">
+    <h2><span class="step">3</span> Bersihkan</h2>
+
+    <p id="clean-empty" class="field-summary">
+      Halaman yang sudah lurus muncul di sini begitu ada foto untuk diluruskan.
+    </p>
+
+    <div id="clean-controls" hidden>
+      <p class="card-lede">
+        Yang di bawah adalah hasil sebenarnya, dihasilkan oleh kode yang sama
+        yang menulis file-nya &mdash; sudah lurus, dan dengan cahaya yang tidak
+        rata sudah dibagi keluar. Ia digambar seukuran layar selagi Anda memilih;
+        file-nya sendiri dibuat pada resolusi fotonya.
+      </p>
+
+      <div class="result-wrap">
+        <canvas id="scan-preview" class="scan-preview"></canvas>
+        <p id="scan-busy" class="progress-label" role="status" aria-live="polite" hidden>
+          Meluruskan&hellip;
+        </p>
+      </div>
+
+      <ul id="scan-facts" class="result-facts"></ul>
+
+      <fieldset class="options" id="mode-group">
+        <legend>Apa yang dilakukan pada cahaya dan warnanya</legend>
+
+        <label class="check">
+          <input type="radio" name="mode" value="colour" checked>
+          <span>
+            <strong>Warna, diratakan</strong>
+            <span class="check-note">
+              Kertasnya diukur di seluruh halaman lalu dibagi keluar, sehingga
+              bayangannya hilang dan kertasnya kembali putih, sementara sebuah
+              stempel, tanda tangan bertinta biru, atau baris yang distabilo
+              tetap berwarna seperti semula. Inilah yang dipakai ketika warnanya
+              bagian dari dokumennya.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="grey">
+          <span>
+            <strong>Skala abu-abu</strong>
+            <span class="check-note">
+              Perataan yang sama, tanpa warnanya. Lebih kecil daripada warna dan
+              lebih murah hati kepada sebuah foto atau tanda tangan daripada
+              hitam putih.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="mono">
+          <span>
+            <strong>Hitam putih</strong>
+            <span class="check-note">
+              Setiap piksel diputuskan terhadap sekelilingnya sendiri alih-alih
+              terhadap satu angka untuk seluruh halaman, dan itulah yang menjaga
+              tulisan di dalam bayangan tetap terbaca. Inilah yang membuat sebuah
+              pindaian kecil: kontrak dua puluh halaman keluar di bawah satu
+              megabita dengan cara ini dan di sekitar lima belas sebagai foto. Ia
+              tidak punya nada tengah, jadi apa pun yang ada fotonya sebaiknya
+              tidak memakainya.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="photo">
+          <span>
+            <strong>Biarkan saja</strong>
+            <span class="check-note">
+              Diluruskan dan tidak lebih. Untuk halaman yang kertasnya sendiri
+              penting &mdash; sesuatu yang tua, sesuatu yang berwarna, sebuah
+              foto.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row" id="strength-row">
+          <label for="strength">Seberapa keras mendorongnya</label>
+          <div class="inline-pair">
+            <input type="range" id="strength" min="0" max="100" step="5" value="50">
+            <output id="strength-value">50</output>
+          </div>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <p class="hint-line">
+        Setelannya berlaku untuk setiap halaman. Halaman dalam satu dokumen yang
+        dibersihkan secara berbeda tampak seperti dua dokumen.
+      </p>
+    </div>
+  </section>
+
+  <!-- Langkah 4 &mdash; file-nya -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Simpan dokumennya</h2>
+
+    <p class="card-lede">
+      PDF-nya ditulis di sini, di dalam memori halaman ini, satu halaman sekali
+      jalan. Tidak ada server di ujung lain alat ini untuk menerima slip gaji,
+      paspor, atau kontrak, dan tidak ada kode yang akan mengirimnya seandainya
+      ada.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Ukuran halaman</label>
+        <select id="page-size">
+          <option value="fit" selected>Paskan lembarnya ke halamannya sendiri</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 in</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+        </select>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Resolusi cetak</label>
+        <select id="dpi">
+          <option value="150">150 DPI</option>
+          <option value="200" selected>200 DPI</option>
+          <option value="300">300 DPI &mdash; pemindai kantor</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Seberapa besar selembar kertas yang disebut oleh sejumlah piksel
+          tertentu. Ia mengubah ukuran cetak dokumennya, dan tidak satu piksel pun
+          dari pindaiannya.
+        </p>
+      </div>
+
+      <div class="field" id="margin-field" hidden>
+        <label for="margin">Margin</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="50" step="1" value="10"
+                 aria-label="Margin dalam milimeter">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Sisi terpanjang</label>
+        <select id="max-side">
+          <option value="1600">1600 piksel &mdash; kecil</option>
+          <option value="2400" selected>2400 piksel</option>
+          <option value="3500">3500 piksel</option>
+          <option value="0">Sebesar yang diizinkan fotonya</option>
+        </select>
+        <p class="field-note">
+          Sebuah langit-langit untuk halaman yang sudah lurus. Foto sebuah halaman
+          menyimpan jauh lebih banyak piksel daripada yang pantas bagi halamannya,
+          dan 2400 di sisi panjangnya kira-kira 200 DPI di atas A4.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kualitas</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="82">
+          <output id="quality-value">82%</output>
+        </div>
+        <p class="field-note">
+          Untuk mode warna dan skala abu-abu, yang disimpan sebagai JPEG. Halaman
+          hitam putih disimpan dengan tepat, jadi ini tidak berpengaruh
+          padanya.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="title">Judul dokumen <span class="optional">(opsional)</span></label>
+        <input type="text" id="title" maxlength="120" placeholder="Kalau dibiarkan kosong, PDF-nya tidak membawa judul">
+        <p class="field-note">
+          Satu-satunya yang ditulis ke dalam dokumennya selain halamannya. Tidak
+          ada tanggal, tidak ada penulis, dan tidak ada apa pun tentang mesin ini
+          &mdash; lihat <code>src/document.js</code>.
+        </p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save-pdf" class="primary big" disabled>Simpan sebagai PDF</button>
+      <button type="button" id="save-images" class="ghost big" disabled>Simpan halamannya sebagai gambar</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden></p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>File jadinya</h3>
+        <a id="download" class="primary as-button" href="#" download>Unduh</a>
+      </div>
+      <ul id="result-facts" class="result-facts"></ul>
+      <p class="hint-line">
+        Buka sebelum Anda mengirimnya. Yang ada di dokumennya adalah yang ada di
+        layar pada langkah 3, halaman demi halaman.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Every sentence the JavaScript puts on this page. They live here rather than
+    in src/, because src/ is copied byte for byte into all eleven languages and
+    a sentence written there would be English in ten of them. See
+    shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="detect.found">Keempat sudutnya ditemukan. Periksa, dan
+      seret yang mendarat keliru.</span>
+    <span data-phrase="detect.unsure">Tepi halamannya tidak cukup jelas untuk
+      diyakini. Sudut-sudut ini sebuah tebakan &mdash; seret ke halamannya
+      sebelum Anda lanjut.</span>
+    <span data-phrase="detect.nothing">Tidak ada halaman yang bisa dikenali dari
+      foto ini, jadi sudutnya berada di tepi fotonya. Seret ke halamannya.</span>
+    <span data-phrase="detect.flat">Tidak ada yang bisa ditemukan di gambar ini
+      &mdash; ia sama sekali tidak punya tepi di dalamnya.</span>
+    <span data-phrase="detect.tiny">Gambar ini terlalu kecil untuk menemukan
+      sebuah halaman di dalamnya.</span>
+    <span data-phrase="detect.edited">Sudut-sudut ini sekarang milik Anda.
+      &ldquo;Cari sudutnya lagi&rdquo; mengukur fotonya dari awal.</span>
+
+    <span data-phrase="corner.tl">Sudut kiri atas</span>
+    <span data-phrase="corner.tr">Sudut kanan atas</span>
+    <span data-phrase="corner.br">Sudut kanan bawah</span>
+    <span data-phrase="corner.bl">Sudut kiri bawah</span>
+    <span data-phrase="corner.at">{corner}, pada {x} melintang dan {y} ke bawah.
+      Tombol panah memindahkannya, dan Shift bersamanya memindahkannya sepuluh
+      piksel sekali tekan.</span>
+
+    <span data-phrase="page.select">Sunting halaman {index}</span>
+    <span data-phrase="page.remove">Buang halaman {index}</span>
+    <span data-phrase="page.earlier">Pindahkan halaman {index} lebih awal</span>
+    <span data-phrase="page.later">Pindahkan halaman {index} lebih akhir</span>
+    <span data-phrase="page.count">{count} halaman</span>
+    <span data-phrase="page.counts">{count} halaman</span>
+
+    <span data-phrase="paper.a">A4 atau A5</span>
+    <span data-phrase="paper.letter">US Letter</span>
+    <span data-phrase="paper.legal">US Legal</span>
+    <span data-phrase="paper.card">sebuah kartu nama</span>
+    <span data-phrase="shape.known">Halamannya keluar {ratio}, dan itu bentuk
+      {paper}.</span>
+    <span data-phrase="shape.sideways">Halamannya keluar {ratio}, dan itu bentuk
+      {paper} dalam posisi menyamping.</span>
+    <span data-phrase="shape.unknown">Halamannya keluar {ratio}, dan itu bukan
+      lembar standar.</span>
+
+    <span data-phrase="method.perspective">Bentuknya diperhitungkan dari
+      perspektif di dalam fotonya, jadi ia bentuk halamannya alih-alih bentuk yang
+      tampak di gambarnya.</span>
+    <span data-phrase="method.edges">Fotonya diambil tegak lurus, jadi bentuknya
+      diukur langsung dari tepinya.</span>
+
+    <span data-phrase="quality.good">{width} kali {height} piksel, sekitar {dpi}
+      DPI di atas halaman seukuran itu &mdash; cukup untuk dicetak.</span>
+    <span data-phrase="quality.fair">{width} kali {height} piksel, sekitar {dpi}
+      DPI di atas halaman seukuran itu. Baik di layar, sedikit lembek di
+      kertas.</span>
+    <span data-phrase="quality.low">{width} kali {height} piksel, sekitar {dpi}
+      DPI di atas halaman seukuran itu. Ambil fotonya lebih dekat kalau ini harus
+      dicetak.</span>
+    <span data-phrase="quality.pixels">{width} kali {height} piksel.</span>
+    <span data-phrase="coverage.note">Halamannya mengisi {percent}% fotonya.</span>
+    <span data-phrase="coverage.small">Halamannya hanya mengisi {percent}%
+      fotonya, jadi sebagian besar yang difoto adalah meja. Lebih dekat lain
+      kali.</span>
+
+    <span data-phrase="strength.gentle">Lembut: kertasnya diratakan dan tidak
+      banyak lagi. Untuk halaman dengan pensil samar atau sebuah foto di
+      atasnya.</span>
+    <span data-phrase="strength.middling">Setelan yang biasa: kertasnya kembali
+      putih dan teks tercetak kembali hitam.</span>
+    <span data-phrase="strength.hard">Keras: apa pun yang abu-abu didorong ke
+      hitam atau ke putih. Paling bersih pada halaman cetak polos, dan merusak
+      pada apa pun yang ada gambarnya.</span>
+
+    <span data-phrase="busy.page">Halaman {done} dari {total}&hellip;</span>
+    <span data-phrase="busy.writing">Menulis dokumennya&hellip;</span>
+
+    <span data-phrase="result.pdf">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.images">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.mono">Disimpan pada satu bit per piksel dan
+      dikompres dengan tepat, dan itulah sebabnya ia sekecil ini.</span>
+    <span data-phrase="result.jpeg">Halamannya disimpan sebagai JPEG pada kualitas
+      yang Anda pilih.</span>
+    <span data-phrase="result.png">Halamannya disimpan sebagai PNG, yang tanpa
+      kehilangan dan itulah yang diinginkan gambar dua warna &mdash; JPEG akan
+      sekaligus lebih besar dan buram di sekeliling setiap huruf.</span>
+    <span data-phrase="result.clean">Tidak ada tanggal, tidak ada penulis, tidak
+      ada nama mesin: satu-satunya yang ada di dokumennya selain halamannya adalah
+      nama alat ini.</span>
+
+    <span data-phrase="size.fit">Setiap lembar menjadi seukuran halamannya sendiri
+      yang sebenarnya, pada resolusi di atas. Tidak ada yang diberi bilah
+      kosong.</span>
+    <span data-phrase="size.named">Setiap halaman ditaruh di atas lembar {name},
+      di dalam marginnya, apa pun bentuk yang keluar.</span>
+
+    <span data-phrase="error.decode">Peramban ini tidak bisa membuka {name}. Kalau
+      itu foto HEIC dari sebuah iPhone, ubah dulu.</span>
+    <span data-phrase="error.none">Pilih setidaknya satu foto dulu.</span>
+    <span data-phrase="error.failed">Ada yang tidak beres saat membuat file-nya:
+      {detail}</span>
+  </div>
+</main>

--- a/locales/id/tools/document-scanner.toml
+++ b/locales/id/tools/document-scanner.toml
@@ -1,0 +1,311 @@
+#
+# Pemindai Dokumen - Bahasa Indonesia.
+#
+# Overrides for tools/document-scanner/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama orang di sebuah rujukan akademis (Zhang, He) dan nama metode (Sauvola)
+# tetap seperti adanya: itulah yang dicari pembaca yang ingin memeriksanya.
+#
+
+name = "Pemindai Dokumen"
+heading = "Pemindai&nbsp;Dokumen <span class=\"h1-kw\">&mdash; foto sebuah halaman, diluruskan</span>"
+tagline = "Foto halamannya. Dapatkan sesuatu yang tampak seperti hasil pindaian."
+
+title = "Pemindai Dokumen &mdash; Foto Menjadi PDF Pindaian, Tanpa Unggah"
+description = "Ubah foto ponsel sebuah halaman menjadi PDF yang lurus dan tercahayai rata. Sudutnya dicarikan untuk Anda, perspektifnya diluruskan, bayangannya dibagi keluar. Berjalan sepenuhnya di peramban Anda: tidak ada yang diunggah."
+og_title = "Pindai sebuah dokumen dengan sebuah foto, tanpa mengunggahnya"
+og_description = "Sudut halamannya ditemukan, sudut pandangnya diluruskan, dan cahaya yang tidak rata dibagi keluar, di peramban Anda sendiri. Yang difoto orang dengan cara ini adalah paspor, slip gaji, atau kontrak, dan itu persis yang tidak boleh diunggah."
+og_image_alt = "Pemindai Dokumen - foto sebuah halaman, diluruskan dan dibersihkan, tanpa mengunggahnya"
+
+pledge = """
+    Fotonya didekodekan, diluruskan, dibersihkan, dan ditulis ke dalam sebuah PDF
+    oleh peramban Anda sendiri, tanpa apa pun selain hitungan dan kodek yang
+    memang sudah dibawanya. Alat ini tidak punya fitur jaringan dalam bentuk apa
+    pun &mdash; tidak ada yang diambil, tidak ada yang dikirim &mdash; dan alasan
+    hal itu penting di sini adalah apa yang biasa difoto orang halamannya:
+    paspor, slip gaji, surat sewa, formulir yang diminta sebuah kantor untuk
+    &ldquo;dipindai dan dikembalikan&rdquo;."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu pindai sebuah halaman. Tidak satu pun permintaan membawa sebuah foto,
+      gambar mini, nama file, atau posisi satu sudut pun. Atau cabut koneksi
+      internet dan tetap pindai satu."""
+
+read_first = """
+, <code>src/detect.js</code> untuk cara sudutnya
+      ditemukan tanpa model apa pun, <code>src/warp.js</code> untuk
+      pelurusannya, dan <code>src/clean.js</code> untuk cara cahaya yang tidak
+      rata dibagi keluar."""
+
+howto_heading = "Cara memindai dokumen dengan kamera ponsel Anda"
+
+card = """
+            Foto sebuah halaman, diluruskan dan dibersihkan menjadi sebuah
+            dokumen. Sudutnya dicarikan untuk Anda, sudut pandangnya diluruskan,
+            dan bayangannya dibagi keluar."""
+
+[words]
+plural = "dokumen"
+choose = "sebuah foto halaman"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Dokumen Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy
+      menyebut satu per satu setiap alamat yang boleh dihubungi halaman ini, dan
+      tidak satu pun milik situs ini. Tidak ada titik akhir di sini tempat foto
+      Anda bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada model, jadi tidak ada yang perlu diunduh dan tidak ada yang perlu ditanyakan."
+body = """
+ Menemukan
+      keempat sudut sebuah halaman dilakukan dengan hitungan: gradien gambarnya,
+      sebuah pemungutan suara untuk garis lurus di dalamnya, dan sebuah
+      pemeriksaan atas apa yang sebenarnya ada di bawah setiap sisi persegi
+      panjang yang menang. Tanpa bobot, tanpa runtime inferensi, tanpa apa pun
+      yang diambil saat pemakaian pertama, dan tanpa apa pun yang berperilaku
+      berbeda pada dokumen orang lain dibanding pada dokumen Anda &mdash; lihat
+      <code>src/detect.js</code>."""
+
+[[privacy]]
+title = "Dokumennya tidak membawa tanggal, penulis, atau nama mesin."
+body = """
+ Pindaian adalah
+      sesuatu yang dikirim orang kepada orang lain, biasanya karena sebuah kantor
+      memintanya. Satu-satunya yang ditulis ke dalam PDF-nya selain halamannya
+      sendiri adalah nama alat ini, dan sebuah judul kalau Anda mengetiknya.
+      Tidak ada tanggal pembuatan, tidak ada penulis, tidak ada nomor seri, dan
+      tidak ada apa pun yang diturunkan dari jam Anda, nama file Anda, atau
+      komputer Anda &mdash; lihat <code>src/document.js</code>."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada
+      <code>fetch</code>, tidak ada <code>XMLHttpRequest</code>, dan tidak ada
+      <code>sendBeacon</code> di mana pun di dalam <code>src/</code>.
+      Pekerjaannya adalah <code>getImageData</code>, beberapa perulangan atas
+      byte-nya, dan pengode JPEG milik peramban sendiri &mdash; semuanya sudah
+      terpasang di mesin Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana &mdash; dan yang layak dijalankan
+      sebelum Anda memindai sebuah paspor."""
+
+[[howto]]
+title = "Foto halamannya."
+body = """
+ Dari atas, dengan seluruh halamannya di dalam
+      bingkai dan keempat sudutnya terlihat atau hampir terlihat. Ia tidak harus
+      tegak lurus dan tidak harus tercahayai rata: sudut dan bayangan itulah yang
+      menjadi tugas alat ini. Yang penting adalah mengisi bingkainya &mdash;
+      halaman yang difoto dari seberang ruangan tidak punya detail di dalamnya
+      untuk dipulihkan."""
+
+[[howto]]
+title = "Periksa keempat sudutnya."
+body = """
+ Mereka dicarikan untuk Anda ketika
+      fotonya dibaca, dan halamannya mengatakannya ketika ia tidak yakin &mdash;
+      halaman di atas meja yang warnanya sama dengan kertasnya memang sungguh
+      sulit dilihat tepinya. Tekan di mana pun pada fotonya dan sudut terdekat
+      datang ke jari Anda, atau jangkau satu dengan <kbd>Tab</kbd> lalu
+      pindahkan dengan tombol panah."""
+
+[[howto]]
+title = "Pilih apa yang dilakukan pada cahayanya."
+body = """
+ &ldquo;Warna, diratakan&rdquo;
+      mengukur kertasnya di seluruh halaman lalu membaginya keluar, sehingga
+      bayangannya hilang dan sebuah stempel atau tanda tangan tetap berwarna.
+      &ldquo;Hitam putih&rdquo; melangkah lebih jauh dan itulah yang membuat
+      sebuah pindaian cukup kecil untuk dikirim lewat email. Yang Anda lihat di
+      layar adalah hasil sebenarnya, dihasilkan oleh kode yang sama yang menulis
+      file-nya."""
+
+[[howto]]
+title = "Tambahkan halaman lainnya."
+body = """
+ Setiap foto yang Anda tambahkan menjadi
+      halaman lain dari dokumen yang sama, dalam urutan mereka didaftar, dan
+      masing-masing menyimpan sudutnya sendiri. Panah pada sebuah halaman di
+      barisnya memindahkannya lebih awal atau lebih akhir."""
+
+[[howto]]
+title = "Simpan PDF-nya, dan buka sebelum Anda mengirimnya."
+body = """
+ Dokumennya
+      ditulis di sini, di dalam memori halaman ini. Tidak ada yang diunggah untuk
+      membuatnya, dan tidak ada apa pun tentangnya yang dilaporkan ke mana
+      pun."""
+
+[[faq]]
+q = "Apakah dokumen saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Fotonya didekodekan, diluruskan, dibersihkan, dan ditulis ke dalam
+        sebuah PDF oleh peramban Anda sendiri di perangkat keras Anda sendiri.
+        Alat ini tidak punya fitur jaringan dalam bentuk apa pun &mdash; ia tidak
+        pernah mengambil apa pun dan tidak pernah mengirim apa pun &mdash; dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs ini.
+        Muat halamannya sekali, cabut koneksi internet, dan ia tetap bekerja."""
+
+[[faq]]
+q = "Bagaimana ia menemukan sudut halamannya tanpa model?"
+a = """
+        Dengan mencari empat tepi lurus panjang yang menyusun sebuah persegi
+        panjang. Fotonya dikecilkan, gradiennya diambil &mdash; di mana gambarnya
+        berubah, dan ke arah mana &mdash; dan setiap piksel yang duduk di sebuah
+        tepi memberi suara untuk garis lurus tempat ia akan terbaring. Garis yang
+        kuat dipasangkan menjadi calon persegi panjang, dan setiap calon dinilai
+        dengan menyusuri keempat sisinya lalu menanyakan seberapa banyak dari
+        masing-masing sisi yang benar-benar punya tepi di bawahnya, dan apakah
+        keempatnya adalah batas dari satu benda: sebuah halaman lebih terang
+        daripada sekelilingnya, atau lebih gelap, tapi ia sama di keempat sisinya,
+        dan itulah yang mencegah sebaris teks dikira sebagai bagian bawah
+        halamannya. Tidak ada bobot, tidak ada yang diunduh, dan hitungannya adalah
+        hitungan yang sama untuk setiap dokumen yang melewatinya."""
+
+[[faq]]
+q = "Sudut yang ditemukannya salah. Sekarang bagaimana?"
+a = """
+        Seret. Sudutnya adalah posisi awal dan tidak pernah sebuah keputusan:
+        pindaiannya diambil dari di mana pun keempatnya berakhir. Tekan di mana pun
+        pada fotonya dan sudut terdekat melompat ke jari Anda, dan itu lebih mudah
+        daripada mengenai sebuah pegangan kecil, dan tombol panah memindahkan sudut
+        yang terfokus satu piksel sekali tekan. Halamannya juga memberi tahu Anda
+        ketika sudutnya sebuah tebakan alih-alih sebuah temuan, dan menandai
+        halaman itu di barisnya &mdash; halaman yang terbaring di meja yang kurang
+        lebih sewarna dengannya adalah alasan yang biasa, karena di sana memang
+        hampir tidak ada tepi untuk ditemukan."""
+
+[[faq]]
+q = "Kenapa halaman yang diluruskan keluar dengan bentuk yang benar, dan tidak gepeng?"
+a = """
+        Karena bentuknya dipulihkan dari perspektifnya alih-alih diukur dari
+        tepinya. Halaman yang difoto dari sudut mengalami pemendekan pada tepi
+        jauhnya, jadi metode yang gamblang &mdash; ambil pasangan tepi berlawanan
+        yang terpanjang lalu sebut itu rasionya &mdash; menghasilkan A4 yang
+        kelihatan pendek, dan itulah yang diberikan kebanyakan pemindai web. Foto
+        sebuah persegi panjang sebenarnya membawa cukup informasi untuk memulihkan
+        baik rasio aspek persegi panjangnya maupun panjang fokus kameranya, asalkan
+        kameranya kamera biasa; itu hasil dari Zhang dan He pada tahun 2003, dan
+        itulah yang dilakukan <code>src/geometry.js</code>. Kalau fotonya diambil
+        tegak lurus, tidak ada perspektif untuk dijadikan pangkal dan memang tidak
+        dibutuhkan, karena tepinya lalu menjadi tepat &mdash; jadi ia kembali ke
+        tepinya, dan halamannya mengatakan yang mana dari keduanya yang
+        menjawab."""
+
+[[faq]]
+q = "Apa sebenarnya yang dilakukan &ldquo;dibersihkan&rdquo; pada gambarnya?"
+a = """
+        Ia membagi keluar cahayanya. Kecerahan kertasnya sendiri diukur di seluruh
+        halaman &mdash; sebuah kisi ubin, dan di setiap ubin sebuah persentil tinggi
+        dari kecerahannya, yang terlalu gelap dan terlalu jarang untuk digerakkan
+        teks &mdash; dan setiap piksel dibagi dengan kertas yang diperkirakan di
+        titik itu. Yang tersisa adalah tintanya, tercahayai rata, dengan bayangan
+        dan peredupannya hilang. Itu tidak sama dengan menaikkan kontras: menaikkan
+        kontras sebuah halaman yang difoto membuat bagian terangnya putih, bagian
+        gelapnya hitam, dan tulisan di bagian gelapnya tak terbaca, dan itulah
+        sebabnya &ldquo;auto levels&rdquo; membuat gambar semacam ini lebih buruk
+        alih-alih lebih baik."""
+
+[[faq]]
+q = "Kenapa mode hitam putihnya jauh lebih kecil?"
+a = """
+        Karena gambar dengan dua warna di dalamnya memang sepersekian data dari
+        gambar dengan enam belas juta warna, dan di sini ia disimpan begitu: satu
+        bit per piksel, dipak delapan per byte dan dikompres dengan tepat, alih-alih
+        sebagai JPEG dari sebuah gambar hitam putih. Pada halaman yang sama ia
+        keluar sekitar delapan belas kali lebih kecil daripada mode warnanya, jadi
+        kontrak dua puluh halaman mendarat di bawah satu megabita alih-alih di
+        sekitar lima belas. Ambangnya adalah ambang Sauvola, yang memutuskan setiap
+        piksel terhadap rata-rata dan sebaran lingkungannya sendiri alih-alih
+        terhadap satu angka untuk seluruh halaman &mdash; itulah yang menjaga
+        tulisan di dalam sebuah bayangan. Ia tidak punya nada tengah, jadi halaman
+        yang ada fotonya sebaiknya memakai salah satu mode lain."""
+
+[[faq]]
+q = "Bisakah saya menaruh beberapa halaman dalam satu PDF?"
+a = """
+        Bisa. Setiap foto yang Anda tambahkan menjadi halaman lain, dalam urutan
+        mereka didaftar, dan setiap halaman menyimpan sudutnya sendiri &mdash; jadi
+        setumpuk halaman yang difoto satu demi satu menjadi satu dokumen. Panah pada
+        setiap halaman di barisnya memindahkannya lebih awal atau lebih akhir.
+        Setelan pembersihannya dipakai bersama oleh semuanya dengan sengaja: halaman
+        dalam satu dokumen yang dibersihkan secara berbeda tampak seperti dua
+        dokumen."""
+
+[[faq]]
+q = "Apakah ia membaca teksnya, supaya saya bisa mencari di PDF-nya?"
+a = """
+        Tidak. Tidak ada lapisan teks dan tidak ada pengenalan karakter: yang keluar
+        adalah gambar sebuah halaman di atas sebuah halaman. Melakukannya dengan
+        benar berarti sebuah mesin OCR, yang berarti puluhan megabita model untuk
+        diunduh &mdash; dan pemindai dokumen yang mengambil sebuah model sebelum
+        bisa membaca slip gaji Anda akan menjadi pemindai dokumen yang punya alasan
+        untuk menelepon pulang soal slip gaji. Kalau Anda butuh teksnya, mode hitam
+        putihnya menghasilkan persis jenis file yang paling cocok bagi perangkat
+        lunak OCR di mesin Anda sendiri."""
+
+[[faq]]
+q = "Hasilnya buram. Kenapa?"
+a = """
+        Hampir selalu karena halamannya kecil di dalam fotonya. Panel di bawah
+        pratinjaunya mengatakan seberapa banyak bingkai yang diisi halamannya dan
+        kira-kira berapa titik per inci artinya di atas selembar seukuran itu
+        &mdash; di bawah sekitar 150 DPI sebuah pindaian yang dicetak tampak lembek,
+        dan tidak ada alat yang bisa berbuat apa-apa tentang detail yang memang tidak
+        pernah ada di file-nya. Mendekatlah alih-alih memperbesar, tahan diam, dan
+        biarkan kameranya memfokus pada halamannya sebelum menekan tombolnya. Guncang
+        kamera adalah penyebab yang satunya, dan itu juga tidak bisa dipulihkan."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis; tidak ada akun, tidak ada masuk, tidak ada masa uji coba, tidak ada
+        batas halaman, dan tidak ada tanda air. Tidak ada batas ukuran fotonya juga,
+        karena tidak ada server yang membayarnya &mdash; pekerjaannya terjadi di
+        mesin Anda sendiri. Situs ini memasang iklan, dan itulah yang membiayainya;
+        iklan tidak diberi apa pun tentang dokumen Anda."""
+
+[schema]
+description = "Pindai sebuah dokumen di peramban: foto sebuah halaman, dan keempat sudutnya ditemukan, perspektifnya diluruskan, cahaya yang tidak rata dibagi keluar, dan hasilnya ditulis ke dalam sebuah PDF. Beberapa halaman menjadi satu dokumen. Tidak ada yang diunggah."
+features = [
+  "Menemukan keempat sudut halamannya tanpa model, tanpa apa pun yang diunduh dan tanpa apa pun yang diambil",
+  "Memulihkan bentuk asli halamannya dari perspektifnya, jadi foto yang miring tidak keluar gepeng",
+  "Membagi keluar cahaya dan bayangan yang tidak rata alih-alih menaikkan kontras",
+  "Halaman hitam putih disimpan pada satu bit per piksel, dan itulah yang membuat sebuah pindaian cukup kecil untuk dikirim lewat email",
+  "Beberapa foto menjadi halaman-halaman satu PDF, masing-masing dengan sudutnya sendiri",
+  "Sudutnya bisa diseret, atau dipindahkan dari papan ketik satu piksel sekali tekan",
+  "Mengatakan kapan sudutnya sebuah tebakan alih-alih sebuah temuan",
+  "Tidak menulis tanggal, penulis, atau nama mesin ke dalam dokumennya",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan foto halaman Anda di sini"
+hint = "atau klik untuk menelusuri &mdash; satu foto per halaman, dalam urutan halamannya"

--- a/locales/id/tools/edit-audio.html
+++ b/locales/id/tools/edit-audio.html
@@ -1,0 +1,176 @@
+<!--
+  tools/edit-audio/body.html, in Indonesian.
+
+  Every id, class, data-speed and option value below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah file</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Ukuran</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Suara</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>Momen terkeras</dt><dd id="src-peak">&mdash;</dd></div>
+      <div><dt>Dibaca sebagai</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <div class="wave-wrap" id="src-wave-wrap" hidden>
+      <canvas id="src-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="preview" controls preload="metadata"></audio>
+    </div>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; suntingannya -->
+  <section class="card" id="edit-card" hidden>
+    <h2><span class="step">2</span> Ubah</h2>
+
+    <div class="edit-block">
+      <label class="check" for="reverse">
+        <input type="checkbox" id="reverse">
+        Putar terbalik
+      </label>
+      <p class="field-note">
+        Sampelnya ditulis dari yang terakhir lebih dulu. Tidak ada hal lain
+        tentangnya yang berubah, jadi membalik dua kali mengembalikan persis file
+        yang Anda mulai.
+      </p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="speed">Kecepatan</label>
+        <input type="text" id="speed-value" class="value-box" inputmode="decimal"
+               spellcheck="false" autocomplete="off" aria-label="Kecepatan, sebagai kelipatan">
+      </div>
+
+      <!-- The slider is in octaves, not multiples: half speed and double speed
+           are then the same distance either side of the middle, which is how
+           they sound. main.js does the conversion. -->
+      <input type="range" id="speed" min="-2" max="2" step="0.01" value="0"
+             aria-describedby="speed-note">
+
+      <div class="presets" role="group" aria-label="Pilihan kecepatan siap pakai">
+        <button type="button" class="ghost" data-speed="0.5">0,5&times;</button>
+        <button type="button" class="ghost" data-speed="0.75">0,75&times;</button>
+        <button type="button" class="ghost" data-speed="1">1&times;</button>
+        <button type="button" class="ghost" data-speed="1.25">1,25&times;</button>
+        <button type="button" class="ghost" data-speed="1.5">1,5&times;</button>
+        <button type="button" class="ghost" data-speed="2">2&times;</button>
+      </div>
+
+      <fieldset class="modes">
+        <legend>Apa yang terjadi pada nadanya</legend>
+        <label class="mode">
+          <input type="radio" name="pitch" value="keep" checked>
+          <span>
+            <strong>Jaga nadanya</strong>
+            Sebuah suara tetap terdengar seperti suara yang sama, hanya lebih cepat atau lebih lambat.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="pitch" value="move">
+          <span>
+            <strong>Biarkan bergerak</strong>
+            Lebih cepat berarti lebih tinggi dan lebih lambat berarti lebih rendah, seperti pita kaset.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="speed-note"></p>
+    </div>
+
+    <div class="edit-block">
+      <div class="block-head">
+        <label for="volume">Volume</label>
+        <input type="text" id="volume-value" class="value-box" inputmode="decimal"
+               spellcheck="false" aria-label="Perubahan volume, dalam desibel">
+      </div>
+
+      <input type="range" id="volume" min="-24" max="24" step="0.5" value="0"
+             aria-describedby="volume-note">
+
+      <fieldset class="modes">
+        <legend>Seberapa keras dibuatnya</legend>
+        <label class="mode">
+          <input type="radio" name="level" value="gain" checked>
+          <span>
+            <strong>Sebanyak ini</strong>
+            Setiap sampel dikalikan angka yang sama. Tidak ada hal lain yang berubah.
+          </span>
+        </label>
+        <label class="mode">
+          <input type="radio" name="level" value="normalize">
+          <span>
+            <strong>Sekeras yang bisa</strong>
+            Dinaikkan sampai momen terkerasnya duduk tepat di bawah langit-langit.
+          </span>
+        </label>
+      </fieldset>
+
+      <p class="field-note" id="volume-note"></p>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Durasi</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Kecepatan</dt><dd id="sum-speed">&mdash;</dd></div>
+      <div><dt>Momen terkeras</dt><dd id="sum-peak">&mdash;</dd></div>
+      <div><dt>Kira-kira</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="clip-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 3 &mdash; file yang keluar -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Simpan</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">Apa yang ditulis</label>
+        <select id="depth">
+          <option value="16" selected>WAV 16-bit &mdash; bisa diputar di mana-mana</option>
+          <option value="32">WAV float 32-bit &mdash; tidak ada yang dipangkas</option>
+        </select>
+        <p class="field-note" id="depth-note">
+          Sebuah WAV memuat sampelnya apa adanya, jadi menulisnya tidak mungkin
+          memakan kualitas. Ia bukan file kecil: lihat perkiraan di atas.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary">Sunting audionya</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh audio</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/edit-audio.toml
+++ b/locales/id/tools/edit-audio.toml
@@ -1,0 +1,283 @@
+#
+# Penyunting Audio - Bahasa Indonesia.
+#
+# Overrides for tools/edit-audio/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Penyunting Audio"
+heading = "Penyunting&nbsp;Audio <span class=\"h1-kw\">&mdash; balik, percepat, atau kuatkan sebuah trek</span>"
+tagline = "Putar terbalik, ubah kecepatannya, angkat rekaman yang pelan &mdash; semuanya di sini, di mesin Anda."
+
+title = "Balik Audio, Ubah Kecepatan &amp; Naikkan Volume &mdash; Gratis, Tanpa Unggah"
+description = "Putar sebuah trek secara terbalik, percepat atau perlambat, dan buat rekaman yang pelan menjadi lebih keras. Bisa juga mengeluarkan suara dari sebuah video. Berjalan di peramban Anda: tidak ada yang diunggah."
+og_title = "Penyunting Audio &mdash; balik, atur ulang waktu, dan kuatkan tanpa mengunggah apa pun"
+og_description = "Balik sebuah trek, ubah kecepatannya dengan atau tanpa menggeser nadanya, dan atur levelnya - lalu unduh sebuah WAV. File dibaca dan ditulis oleh peramban Anda sendiri."
+og_image_alt = "Penyunting Audio - balik, atur ulang waktu, dan kuatkan audio di peramban Anda"
+
+pledge = """
+    File Anda dibaca, disunting, dan ditulis oleh peramban Anda sendiri, di
+    perangkat keras Anda sendiri. Tidak ada di sini yang bisa mengambil atau
+    mengirim apa pun &mdash; alat ini sama sekali tidak punya fitur jaringan
+    &mdash; dan seandainya pun ada, tidak ada server di ujung lain halaman ini
+    untuk menerima sebuah rekaman."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu balik sesuatu. Tidak satu pun permintaan membawa sampel, nama file,
+      atau satu byte pun dari yang Anda pilih. Atau cabut koneksi internet dan
+      tetap sunting sebuah trek &mdash; alat yang mengirim audio Anda ke tempat
+      lain untuk diproses akan langsung berhenti."""
+
+read_first = """
+, <code>src/decode.js</code> untuk dua puluh baris
+      yang menyerahkan file Anda ke dekoder milik peramban sendiri,
+      <code>src/stretch.js</code> untuk perentang waktunya,
+      <code>src/speed.js</code> untuk pengambil sampel ulangnya, dan
+      <code>src/wav.js</code> untuk header yang dipasang di depan sampelnya.
+      Tidak satu pun mengimpor sesuatu yang bisa membuat permintaan."""
+
+howto_heading = "Cara menyunting file audio"
+
+card = """
+            Balik sebuah trek, ubah kecepatannya dengan atau tanpa menggeser
+            nadanya, dan angkat rekaman yang pelan. Bisa juga mengeluarkan suara
+            dari sebuah video."""
+
+[words]
+plural = "rekaman"
+choose = "sebuah file"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Video masuk, audio keluar"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[privacy]]
+title = "Rekaman Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Alat ini sama sekali tidak punya
+      fitur jaringan: tidak ada alamat untuk ditempelkan, tidak ada yang diunduh,
+      tidak ada mesin yang diambil saat pertama dipakai. Setiap byte yang
+      menyentuh audio Anda datang dari asal ini ketika halaman dimuat."""
+
+[[privacy]]
+title = "Dekodernya adalah yang sudah ada di peramban Anda."
+body = """
+ File diserahkan ke
+      <code>decodeAudioData</code>, kode yang sama yang memutar sebuah lagu di
+      elemen <code>&lt;audio&gt;</code>. Tidak ada yang dikirim ke sini untuk
+      membaca format Anda, dan tidak ada yang diminta dari apa pun di luar
+      halaman ini untuk membacanya."""
+
+[[privacy]]
+title = "Gambar sebuah video tidak pernah didekode sama sekali."
+body = """
+ Ketika Anda menjatuhkan sebuah video,
+      hanya jalur audionya yang diminta. Bingkainya tidak dibaca, tidak didekode,
+      tidak digambar, dan tidak dilihat &mdash; tidak ada kode di halaman ini
+      yang bisa, dan file yang keluar memuat suara dan tidak lebih."""
+
+[[privacy]]
+title = "Sampelnya dituliskan, bukan dikodekan lagi."
+body = """
+ Sebuah WAV adalah sampel yang dihitung
+      halaman ini dengan header di depannya. Tidak ada encoder dalam
+      perulangannya yang mengambil keputusan tentang rekaman Anda, dan tidak ada
+      yang bisa disebut unggahan untuk membuat hal itu terjadi."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang rekaman Anda: bukan
+      file, bukan sampel, bukan nama, ukuran, durasi, atau seberapa keras
+      suaranya. Setiap baris yang membaca, menyunting, dan menulis disajikan dari
+      asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau file Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih sebuah file."
+body = """
+ Jatuhkan file MP3, WAV, FLAC, M4A, Ogg,
+      atau Opus ke pemilih file &mdash; atau sebuah video, kalau yang Anda mau
+      adalah suaranya. Peramban membacanya langsung dari disk Anda; tidak ada
+      yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Balik, kalau itu tujuan Anda datang."
+body = """
+ Satu kotak centang. Sampelnya ditulis
+      dari yang terakhir lebih dulu, dan itu persis bisa dibalik lagi: lakukan
+      dua kali dan Anda mendapatkan file yang Anda mulai, sampel demi
+      sampel."""
+
+[[howto]]
+title = "Atur kecepatannya."
+body = """
+ Seret penggesernya, ketik sebuah kelipatan,
+      atau tekan salah satu pilihan siap pakainya. Lalu pilih apa yang terjadi
+      pada nadanya: tahan di tempatnya, yang Anda inginkan untuk kuliah pada
+      1,5&times;, atau biarkan bergerak mengikuti kecepatannya, yang dilakukan
+      pita kaset dan yang membuat suara naik atau turun."""
+
+[[howto]]
+title = "Atur levelnya."
+body = """
+ Sebutkan perubahannya dalam desibel, atau minta
+      rekamannya dinaikkan sampai momen terkerasnya duduk tepat di bawah langit-
+      langit. Halaman ini mengatakan di mana momen itu akan mendarat sebelum Anda
+      menekan apa pun, dan memperingatkan Anda kalau setelan yang Anda pilih akan
+      mendorongnya melewati skala penuh."""
+
+[[howto]]
+title = "Simpan."
+body = """
+ Pekerjaannya terjadi di perangkat keras Anda sendiri,
+      jadi lamanya tergantung mesin Anda, bukan pada antrean. Yang keluar adalah
+      sebuah WAV &mdash; sampelnya sendiri, dengan header di depannya &mdash;
+      diputar dulu di halaman ini, lalu diserahkan langsung ke unduhan peramban
+      Anda."""
+
+[[faq]]
+q = "Apakah audio saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca, disunting, dan ditulis oleh peramban Anda sendiri di
+        perangkat keras Anda sendiri. Alat ini tidak punya sisi server, dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya &mdash; tidak satu pun milik situs
+        ini. Cabut koneksi internet dan tetap balik sebuah trek kalau Anda lebih
+        suka memeriksa daripada diberi tahu."""
+
+[[faq]]
+q = "Bisakah saya mengeluarkan audio dari sebuah video?"
+a = """
+        Bisa, dan di sini itu pekerjaan yang sama dengan membuka sebuah MP3.
+        Jatuhkan MP4, MOV, atau WebM dan hanya jalur audionya yang didekode:
+        gambarnya tidak pernah dibaca, dan yang keluar adalah file suara tanpa
+        video di dalamnya. Itu juga cara menyimpan suara dari sebuah klip tanpa
+        menyuntingnya sama sekali &mdash; biarkan setiap setelan apa adanya dan
+        tekan tombolnya."""
+
+[[faq]]
+q = "Apakah mengubah kecepatan mengubah nadanya?"
+a = """
+        Hanya kalau Anda memintanya. "Jaga nadanya" memotong rekaman menjadi
+        jendela-jendela bertumpang tindih sepanjang kira-kira lima puluh
+        milidetik dan menaruhnya kembali lebih rapat atau lebih renggang,
+        memilih setiap posisi agar gelombangnya sejajar di titik potongnya
+        &mdash; sebuah suara tetap suara yang sama pada 1,5&times;. "Biarkan
+        bergerak" mengambil sampel ulang, yang sama dengan memutar pita kaset
+        lebih cepat: dua kali kecepatan berarti persis satu oktaf naik."""
+
+[[faq]]
+q = "Kenapa ia menyimpan WAV alih-alih MP3?"
+a = """
+        Karena tidak ada peramban yang menyertakan encoder MP3, dan alat ini
+        menolak mengirim rekaman Anda ke server yang punya. Sebuah WAV sama
+        sekali tidak butuh encoder &mdash; ia adalah sampel dengan header empat
+        puluh empat byte di depannya &mdash; jadi ia sekaligus pilihan yang jujur
+        dan satu-satunya yang tidak mungkin memakan kualitas. Ukurannya lebih
+        besar: sekitar sepuluh megabyte per menit dalam stereo. Setiap pemutar,
+        ponsel, dan penyunting bisa membukanya, dan apa pun yang mau MP3 bisa
+        membuatnya dari situ."""
+
+[[faq]]
+q = "Format apa saja yang bisa saya buka?"
+a = """
+        Apa pun yang bisa didekode peramban Anda, yang dalam praktiknya berarti
+        MP3, WAV, FLAC, M4A dan AAC, Ogg Vorbis dan Opus, serta audio di dalam
+        video MP4, M4V, MOV, dan WebM. Yang tertinggal adalah daftar pendek yang
+        sama seperti di tempat lain: AVI, WMA, dan sebagian besar MKV. File yang
+        tidak mau dibaca peramban ini ditolak dengan pesan, alih-alih gagal di
+        tengah jalan."""
+
+[[faq]]
+q = "Apakah membuatnya lebih keras akan membuatnya pecah?"
+a = """
+        Hanya kalau Anda membawanya melewati skala penuh, dan halaman ini memberi
+        tahu Anda sebelum itu terjadi. Audio digital punya langit-langit yang
+        keras: sebuah sampel tidak bisa lebih keras daripada skala penuh, jadi
+        apa pun di atasnya diratakan ke langit-langit, dan begitulah bunyi suara
+        yang pecah. "Sekeras yang bisa" adalah setelan yang tidak mungkin
+        melakukan itu &mdash; ia menghitung berapa ruang yang masih dimiliki
+        rekaman itu dan memakai persis sebanyak itu. Semua di bawah langit-langit
+        hanyalah perkalian dan tidak lebih: naikkan 6 dB lalu turunkan 6 dB dan
+        sampelnya kembali ke tempat semula."""
+
+[[faq]]
+q = "Apakah membalik atau mengubah waktu menurunkan kualitas?"
+a = """
+        Membalik tidak: sampel yang sama keluar dalam urutan terbalik, dan itu
+        persis. Mengubah kecepatan menggeser setiap sampel, jadi itu aritmetika,
+        bukan penyalinan &mdash; pengambil sampel ulangnya menyaring dengan benar
+        di tengah jalan, jadi mempercepat tidak melipat nada tinggi kembali ke
+        bawah menjadi dering logam, dan jendela perentangnya ditempatkan di
+        tempat gelombangnya sejajar, bukan di mana pun aritmetikanya mendarat.
+        Tidak ada jalur yang mengodekan ulang apa pun, karena tidak ada encoder
+        di sini untuk mengodekan ulang."""
+
+[[faq]]
+q = "Adakah batas durasi file-nya?"
+a = """
+        Tidak ada batas yang tertanam di alat ini. Batas praktisnya adalah
+        memori: seluruh rekaman didekode ke halaman ini sekaligus, dan sebuah WAV
+        dirakit di memori sebelum Anda mengunduhnya, jadi satu jam stereo
+        membutuhkan ruang kerja sedikit di bawah satu gigabyte. WAV empat
+        gigabyte ditolak mentah-mentah, karena kolom ukuran milik formatnya
+        sendiri tidak bisa menggambarkannya."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang rekaman Anda."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript dan peramban dengan Web Audio, yang berarti setiap peramban masa kini. Tidak butuh dukungan kodek melebihi yang sudah dimiliki peramban untuk memutar file itu."
+description = "Balik sebuah trek audio, ubah kecepatannya dengan atau tanpa menggeser nadanya, dan atur levelnya, di peramban. Berlaku juga untuk audio di dalam sebuah video. Tidak ada yang diunggah dan hasilnya ditulis sebagai WAV, jadi tidak ada yang dikodekan ulang."
+features = [
+  "Memutar sebuah trek terbalik, persis",
+  "Mengubah kecepatan dari seperempat sampai empat kali, menjaga nadanya atau menggesernya",
+  "Menaikkan atau menurunkan level, atau menormalkannya sampai tepat di bawah skala penuh",
+  "Mengeluarkan audio dari MP4, MOV, atau WebM tanpa menyentuh gambarnya",
+  "Menulis WAV 16-bit atau float 32-bit, tanpa encoder di dalam perulangannya",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan file audio atau video di sini"
+hint = "atau klik untuk menelusuri &mdash; MP3, WAV, FLAC, M4A, Ogg, dan suara di dalam MP4, MOV, atau WebM"

--- a/locales/id/tools/exif-editor.html
+++ b/locales/id/tools/exif-editor.html
@@ -1,0 +1,156 @@
+<!--
+  tools/exif-editor/body.html, in Indonesian.
+
+  Every id, class and data-download below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file-nya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih foto</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Keluarkan semua dari daftar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; satu klik -->
+  <section class="card" id="strip-card">
+    <h2><span class="step">2</span> Hapus semuanya</h2>
+
+    <p class="card-lede">
+      Satu tombol, setiap foto di daftar. Gambarnya tidak didekode, tidak
+      digambar ulang, dan tidak dikompres ulang &mdash; data gambar terkompresinya
+      disalin tanpa disentuh dan hanya metadata di sekelilingnya yang dibuang,
+      jadi hasilnya adalah foto yang sama tanpa apa pun yang menempel.
+    </p>
+
+    <div class="strip-row">
+      <button type="button" id="strip-all" class="primary big" disabled>Hapus semua metadata</button>
+      <span id="strip-status" class="strip-status" role="status" aria-live="polite"></span>
+    </div>
+
+    <!--
+      Two things are kept by default, and both are stated on the button's own
+      line rather than buried in a settings panel. "Remove all" that quietly
+      keeps things is a broken promise; "remove all except these two, and here
+      they are" is a choice.
+    -->
+    <fieldset class="keep-options">
+      <legend>Apa yang disimpan</legend>
+      <label class="check">
+        <input type="checkbox" id="keep-orientation" checked>
+        <span>
+          <strong>Tag orientasi</strong>
+          <span class="check-note">
+            Ponsel menyimpan sebuah foto sebagaimana dilihat sensornya dan
+            menambahkan satu tag yang mengatakan sisi mana yang di atas. Hapus itu
+            dan sebagian penampil menampilkannya miring. Kalau disimpan, sebuah
+            blok EXIF baru ditulis yang memuat tag ini dan tidak lebih &mdash; dan
+            hanya ketika fotonya memang belum menghadap benar.
+          </span>
+        </span>
+      </label>
+      <label class="check">
+        <input type="checkbox" id="keep-icc" checked>
+        <span>
+          <strong>Profil warna</strong>
+          <span class="check-note">
+            Profil ICC mengatakan apa arti angka-angka di dalam gambar sebagai
+            warna. Ia tidak mengatakan apa pun tentang Anda. Membuangnya bisa
+            menggeser warna sebuah foto bergamut lebar secara kasatmata, dan itulah
+            sebabnya ia disimpan kecuali Anda mengatakan lain.
+          </span>
+        </span>
+      </label>
+      <p class="keep-summary" id="keep-summary"></p>
+    </fieldset>
+
+    <div id="clean-results" class="results" hidden>
+      <div class="results-head">
+        <h3>Sudah dibersihkan</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Unduh semua sebagai zip</button>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; membaca dan menyunting -->
+  <section class="card" id="inspect-card">
+    <h2><span class="step">3</span> Lihat ke dalam, dan ubah sesuka Anda</h2>
+
+    <p id="inspect-empty" class="empty-note">
+      Pilih sebuah foto di atas dan semua yang ada di dalamnya muncul di sini: apa
+      yang dikatakannya tentang di mana Anda berada, kapan, dan dengan apa. Tidak
+      ada yang dikirim ke mana pun untuk mengetahui itu.
+    </p>
+
+    <div id="inspector" hidden>
+      <div class="inspect-head">
+        <div class="inspect-file">
+          <img id="inspect-thumb" class="inspect-thumb" alt="" hidden>
+          <div>
+            <p class="inspect-name" id="inspect-name"></p>
+            <p class="inspect-sub" id="inspect-sub"></p>
+          </div>
+        </div>
+        <div class="inspect-switch">
+          <label for="inspect-select" class="visually-hidden">Foto mana yang diperiksa</label>
+          <select id="inspect-select"></select>
+        </div>
+      </div>
+
+      <!-- The findings: the part of this page that answers the actual question. -->
+      <section class="findings" aria-labelledby="findings-h">
+        <h3 id="findings-h">Apa yang dibocorkan file ini</h3>
+        <ul id="findings-list" class="findings-list"></ul>
+      </section>
+
+      <!-- Whole blocks, each removable on its own. -->
+      <section class="blocks" aria-labelledby="blocks-h">
+        <h3 id="blocks-h">Blok di dalam file ini</h3>
+        <ul id="block-list" class="block-list"></ul>
+      </section>
+
+      <!-- Every tag, editable. -->
+      <section class="tags" aria-labelledby="tags-h">
+        <h3 id="tags-h">Setiap tag</h3>
+        <p class="tags-note" id="tags-note"></p>
+        <div id="tag-groups"></div>
+
+        <details class="add-tag" id="add-tag">
+          <summary>Tambahkan sebuah tag</summary>
+          <div class="add-tag-body">
+            <label for="add-tag-select">Tag</label>
+            <select id="add-tag-select"></select>
+            <label for="add-tag-value">Nilai</label>
+            <input type="text" id="add-tag-value" spellcheck="false">
+            <button type="button" id="add-tag-go" class="ghost">Tambah</button>
+          </div>
+        </details>
+      </section>
+
+      <div class="save-row">
+        <button type="button" id="save-edits" class="primary" data-download disabled>Simpan foto ini</button>
+        <button type="button" id="revert-edits" class="ghost" disabled>Batalkan perubahan saya</button>
+        <span id="save-status" class="save-status" role="status" aria-live="polite"></span>
+      </div>
+      <p id="edit-error" class="error" role="alert" hidden></p>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/exif-editor.toml
+++ b/locales/id/tools/exif-editor.toml
@@ -1,0 +1,240 @@
+#
+# Penampil dan Penghapus EXIF - Bahasa Indonesia.
+#
+# Overrides for tools/exif-editor/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Penampil dan Penghapus EXIF"
+heading = "Penampil &amp; Penghapus&nbsp;EXIF <span class=\"h1-kw\">&mdash; hapus metadata foto</span>"
+tagline = "Lihat apa yang dikatakan sebuah foto tentang Anda. Lalu keluarkan."
+
+title = "Penampil &amp; Penghapus EXIF &mdash; Penyunting Metadata Foto Gratis"
+description = "Lihat data EXIF dan GPS yang tersembunyi di dalam sebuah foto, sunting, atau bersihkan semuanya dalam satu klik. Di peramban Anda: tidak ada yang diunggah, dan fotonya tidak pernah dikodekan ulang."
+og_title = "Penampil &amp; Penghapus EXIF &mdash; lihat, sunting, atau bersihkan"
+og_description = "Baca metadata yang tersembunyi di dalam sebuah foto dan hapus semuanya dalam satu klik. Berjalan di perangkat Anda sendiri; gambarnya sendiri tidak pernah dikodekan ulang."
+og_image_alt = "Penampil dan Penghapus EXIF - baca, sunting, atau bersihkan metadata di dalam sebuah foto"
+
+pledge = """
+    File dibuka, diurai, dan ditulis ulang oleh peramban Anda sendiri. Alat ini
+    tidak punya fitur jaringan dalam bentuk apa pun &mdash; tidak ada yang
+    diambil, tidak ada yang dikirim &mdash; dan seandainya pun ada, tidak ada
+    server di ujung lain halaman ini untuk menerima sebuah foto."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu bersihkan sebuah foto. Tidak satu pun permintaan membawa gambar,
+      gambar mini, nama file, atau tag yang kami baca dari file Anda. Atau cabut
+      koneksi internet dan tetap bersihkan satu."""
+
+read_first = """
+, <code>src/tiff.js</code> untuk pengurai EXIF-nya,
+      dan <code>src/jpeg.js</code> untuk bukti bahwa gambarnya sendiri hanya
+      pernah disalin."""
+
+howto_heading = "Cara menghapus data EXIF dari sebuah foto"
+
+card = """
+            Lihat lokasi, kamera, dan nomor seri yang tersembunyi di dalam
+            sebuah foto, sunting salah satunya, atau bersihkan semuanya dalam
+            satu klik."""
+
+[words]
+plural = "foto"
+choose = "sebuah foto"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "Tidak pernah mengodekan ulang gambarnya"
+
+[[privacy]]
+title = "Foto Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Berbeda dari alat lain di kotak ini,
+      yang satu ini tidak punya fitur "muat dari alamat web" dan sama sekali
+      tidak punya langkah jaringan opsional. Tidak ada <code>fetch</code>, tidak
+      ada <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di
+      mana pun di dalam <code>src/</code>."""
+
+[[privacy]]
+title = "Metadata yang kami baca tidak pernah dibacakan keluar."
+body = """
+ Posisi GPS Anda ditampilkan di halaman
+      ini dan tidak pergi ke mana pun. Tidak ada peristiwa pengukuran khusus di
+      repositori ini yang membawa sebuah tag, nama file, ukuran, atau jumlah."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang foto Anda. Setiap baris
+      yang membaca, mengurai, atau menulis ulang sebuah file disajikan dari asal
+      ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau file Anda. Tidak ada
+      yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih foto Anda."
+body = """
+ Jatuhkan ke pemilih file atau pilih sendiri.
+      Peramban membacanya langsung dari disk Anda; tidak ada yang dikirim ke mana
+      pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Baca isinya, kalau Anda mau."
+body = """
+ Daftar temuannya menyebut hal-hal yang
+      layak diketahui &mdash; posisi GPS, stempel waktu, nomor seri &mdash;
+      sebelum tabel lengkap berisi setiap tag."""
+
+[[howto]]
+title = "Tekan \"Hapus semua metadata\"."
+body = """
+ Itulah seluruh pekerjaan bagi kebanyakan
+      orang. Setiap tag, blok XMP dan IPTC, komentar, dan gambar mini
+      tertanamnya semua hilang, pada setiap foto di daftar sekaligus."""
+
+[[howto]]
+title = "Atau sunting alih-alih menghapus."
+body = """
+ Ubah sebuah tanggal, betulkan baris hak
+      cipta, buang lokasinya dan simpan setelan kameranya &mdash; lalu simpan
+      foto itu sendiri."""
+
+[[faq]]
+q = "Apakah foto saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File dibaca, diurai, dan ditulis ulang oleh peramban Anda sendiri
+        di perangkat keras Anda sendiri. Alat ini tidak punya fitur jaringan
+        dalam bentuk apa pun &mdash; ia tidak pernah mengambil apa pun dan tidak
+        pernah mengirim apa pun &mdash; dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+        ini."""
+
+[[faq]]
+q = "Apa itu EXIF, dan apa lagi yang bersembunyi di dalam sebuah foto?"
+a = """
+        EXIF adalah blok tag yang ditulis kamera di samping gambarnya: merek dan
+        modelnya, setelan pencahayaannya, tanggal dan waktu sampai ke detik,
+        sering kali posisi GPS, dan kadang sebuah nomor seri. Foto sering membawa
+        lebih dari itu &mdash; paket XMP berisi XML dari sebuah penyunting, blok
+        IPTC berisi kolom keterangan dan penulis, sebuah profil warna, salinan
+        kecil kedua dari gambarnya sebagai gambar mini, dan catatan pembuat
+        berisi data produsen yang tidak terdokumentasi. Alat ini
+        mendaftarkan semuanya."""
+
+[[faq]]
+q = "Apakah menghapus metadata menurunkan kualitas gambar?"
+a = """
+        Tidak, dan inilah alasan utama memakai alat seperti ini alih-alih
+        menyimpan ulang fotonya. Metadata duduk di wadah yang mengelilingi gambar
+        terkompresi, bukan di dalamnya. Menghapusnya berarti menghapus butir dari
+        sebuah daftar dan menulis daftarnya kembali; data gambar terkompresinya
+        disalin byte demi byte, jadi hasilnya terdekode menjadi piksel yang sama
+        persis. Tidak ada yang didekode dan tidak ada yang dikompres ulang."""
+
+[[faq]]
+q = "Format file apa saja yang ditanganinya?"
+a = """
+        JPEG, PNG, dan WebP. HEIC dan AVIF dikenali tapi tidak ditulis ulang:
+        keduanya adalah format kotak yang dibangun dari atom bersarang dan butuh
+        pengurai yang berbeda, jadi alat ini mengatakannya alih-alih menghasilkan
+        file yang rusak. TIFF telanjang juga tidak ditangani, karena di dalam
+        TIFF metadata dan pikselnya dialamati oleh ofset yang sama."""
+
+[[faq]]
+q = "Apakah foto saya akan tampak terputar setelah metadatanya dihapus?"
+a = """
+        Bisa, dan ada setelan untuk itu. Ponsel biasanya merekam gambarnya
+        sebagaimana dilihat sensor dan menambahkan tag Orientasi yang mengatakan
+        cara memutarnya. Hapus tag itu dan sebagian penampil menampilkan foto
+        Anda miring. Pilihan "jaga tag orientasi", yang menyala secara bawaan,
+        menulis kembali blok EXIF mungil yang tidak memuat apa pun selain tag itu
+        &mdash; dan hanya ketika fotonya memang membutuhkannya. Matikan kalau Anda
+        lebih suka file-nya sama sekali tidak membawa EXIF."""
+
+[[faq]]
+q = "Apakah ia menghapus lokasi GPS?"
+a = """
+        Ya. Menghapus semuanya menghapus seluruh direktori GPS-nya, dan Anda juga
+        bisa menghapus lokasinya saja dan menyimpan sisanya. Posisinya
+        ditampilkan dalam derajat desimal lebih dulu, karena "51 derajat, 30
+        menit, 26 detik" tidak membuatnya terang bahwa sebuah foto menyebut
+        bangunan tempat ia diambil."""
+
+[[faq]]
+q = "Bisakah saya mengubah sebuah tag alih-alih menghapusnya?"
+a = """
+        Bisa. Tag teks, tanggal, ISO, orientasi, dan resolusi semuanya bisa
+        disunting, dan beberapa tag umum bisa ditambahkan ke foto yang tidak
+        punya. Satu catatan: menulis file-nya membangun ulang blok EXIF, dan
+        catatan pembuat memuat ofset ke dalam blok aslinya, jadi catatan pembuat
+        yang dibangun ulang mungkin tidak bisa dibaca lagi oleh perangkat lunak
+        milik produsennya. Hapus catatan itu atau biarkan file-nya tanpa
+        suntingan kalau hal itu penting bagi Anda."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, dan tidak ada masa uji coba.
+        Situs ini memasang iklan, dan itulah yang membiayainya; iklan tidak
+        diberi apa pun tentang foto Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim foto Anda ke tempat lain untuk diproses akan
+        berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Baca metadata EXIF, GPS, XMP, dan IPTC di dalam sebuah foto, sunting tag satu per satu, atau hapus semuanya dalam satu klik. JPEG, PNG, dan WebP, diproses di peramban tanpa mengodekan ulang gambarnya."
+features = [
+  "Menampilkan setiap tag EXIF, termasuk posisi GPS, nomor seri kamera, dan catatan pembuat",
+  "Menyunting atau menghapus tag satu per satu dan menulis file-nya kembali",
+  "Menghapus EXIF, GPS, XMP, IPTC, komentar, dan gambar mini tertanam dalam satu klik",
+  "JPEG, PNG, dan WebP",
+  "Hanya menulis ulang wadahnya, jadi gambarnya tidak pernah dikompres ulang",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan foto di sini"
+hint = "atau klik untuk menelusuri &mdash; JPEG, PNG, dan WebP"

--- a/locales/id/tools/gif-analyzer.html
+++ b/locales/id/tools/gif-analyzer.html
@@ -1,0 +1,161 @@
+<!--
+  tools/gif-analyzer/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!--
+    One numbered step, and then six headings without numbers.
+
+    Every other tool on this site numbers all of its cards, because every card
+    is something the visitor does. Here there is exactly one thing to do -
+    choose a file - and everything below it is the answer. Numbering the answer
+    would promise a sequence of decisions that does not exist, and would leave
+    somebody looking for step 4's button.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah GIF</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Ringkasannya, dan animasinya sebagaimana digambar peramban sendiri. -->
+  <section class="card" id="summary-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="copy-report" class="ghost">Salin laporannya</button>
+        <button type="button" id="download-report" class="ghost">Unduh laporannya</button>
+      </div>
+    </div>
+
+    <div class="overview">
+      <div class="preview-wrap">
+        <!--
+          The browser's own decoder, drawing the file unchanged. Everything else
+          on this page is drawn by src/frames.js, so having both means a
+          disagreement between them is visible rather than hidden - and it is
+          the disagreement that would tell you this reader had a bug.
+        -->
+        <img id="preview" class="preview" alt="Animasinya, diputar sebagaimana digambar peramban ini">
+        <p class="preview-note">Dekoder milik peramban Anda sendiri, memutar file itu apa adanya.</p>
+      </div>
+
+      <dl class="facts">
+        <div><dt>Versi</dt><dd id="fact-version">&mdash;</dd></div>
+        <div><dt>Kanvas</dt><dd id="fact-canvas">&mdash;</dd></div>
+        <div><dt>Ukuran file</dt><dd id="fact-size">&mdash;</dd></div>
+        <div><dt>Bingkai</dt><dd id="fact-frames">&mdash;</dd></div>
+        <div><dt>Sebagaimana ditulis</dt><dd id="fact-written">&mdash;</dd></div>
+        <div><dt>Sebagaimana diputar</dt><dd id="fact-plays">&mdash;</dd></div>
+        <div><dt>Pengulangan</dt><dd id="fact-loops">&mdash;</dd></div>
+        <div><dt>Warna yang digambar</dt><dd id="fact-colors">&mdash;</dd></div>
+      </dl>
+    </div>
+
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- Temuannya. Lebih dulu, karena itulah yang dicari orang. -->
+  <section class="card" id="findings-card" hidden>
+    <h2>Apa yang menonjol</h2>
+    <p class="card-lede">
+      Semua di bawah ini diukur dari file ini. Tidak ada di sini yang berupa
+      tebakan tentang apa yang Anda maksud untuk dibuat.
+    </p>
+    <ul class="findings" id="findings"></ul>
+  </section>
+
+  <!-- Anggaran byte. -->
+  <section class="card" id="budget-card" hidden>
+    <h2>Ke mana byte-nya pergi</h2>
+    <p class="card-lede">
+      Setiap byte file berada tepat di satu baris, dan baris-barisnya berjumlah
+      sama dengan file. Kalau tidak, baris terakhirlah yang akan mengatakannya,
+      bukan batangnya yang diam-diam melar agar pas.
+    </p>
+
+    <div class="budget-bar" id="budget-bar" role="img" aria-labelledby="budget-caption"></div>
+    <p class="visually-hidden" id="budget-caption">
+      Angka yang sama dengan tabel di bawah, digambar sebagai satu batang.
+    </p>
+
+    <table class="budget">
+      <caption class="visually-hidden">Ke mana byte file ini pergi</caption>
+      <thead>
+        <tr>
+          <th scope="col">Bagian</th>
+          <th scope="col" class="num">Byte</th>
+          <th scope="col" class="num">Porsi</th>
+        </tr>
+      </thead>
+      <tbody id="budget-rows"></tbody>
+      <tfoot>
+        <tr>
+          <th scope="row">Seluruh file</th>
+          <td class="num" id="budget-total">&mdash;</td>
+          <td class="num">100%</td>
+        </tr>
+      </tfoot>
+    </table>
+  </section>
+
+  <!-- Bingkai demi bingkai. -->
+  <section class="card" id="frames-card" hidden>
+    <div class="toolbar">
+      <h2>Bingkai demi bingkai</h2>
+      <div class="toolbar-actions">
+        <label for="frame-view" class="inline-label">Tampilkan</label>
+        <select id="frame-view">
+          <option value="composited" selected>kanvas setelah setiap bingkai</option>
+          <option value="stored">hanya yang disimpan setiap bingkai</option>
+        </select>
+      </div>
+    </div>
+
+    <p class="card-lede" id="frames-lede"></p>
+
+    <ul class="frames" id="frames"></ul>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!-- Warnanya. -->
+  <section class="card" id="colors-card" hidden>
+    <h2>Warnanya</h2>
+    <p class="card-lede" id="colors-lede"></p>
+
+    <div id="global-palette-wrap" hidden>
+      <h3>Tabel global</h3>
+      <p class="palette-note" id="global-palette-note"></p>
+      <ul class="palette" id="global-palette"></ul>
+    </div>
+
+    <details id="local-palettes-wrap" hidden>
+      <summary id="local-palettes-summary">Tabel per bingkai</summary>
+      <div id="local-palettes"></div>
+    </details>
+  </section>
+
+  <!-- Semua di dalam file yang bukan gambar. -->
+  <section class="card" id="extras-card" hidden>
+    <h2>Apa lagi yang ada di dalamnya</h2>
+    <p class="card-lede">
+      Blok-blok yang tidak membawa gambar. Sebuah penampil melewati semuanya, dan
+      setiap salinan file tetap membawanya.
+    </p>
+    <ul class="extras" id="extras"></ul>
+  </section>
+</main>

--- a/locales/id/tools/gif-analyzer.toml
+++ b/locales/id/tools/gif-analyzer.toml
@@ -1,0 +1,318 @@
+#
+# Penganalisis GIF - Bahasa Indonesia.
+#
+# Overrides for tools/gif-analyzer/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Cara pembuangan" untuk disposal, dipakai konsisten dengan Pemisah GIF.
+#
+
+name = "Penganalisis GIF"
+heading = "Penganalisis&nbsp;GIF <span class=\"h1-kw\">&mdash; apa sebenarnya isi sebuah GIF</span>"
+tagline = "Bingkai, jeda, palet, dan ke mana setiap byte pergi."
+
+title = "Penganalisis GIF &mdash; Bingkai, Jeda, Palet, dan Ukuran File, Tanpa Unggah"
+description = "Bongkar sebuah GIF di peramban Anda: setiap bingkai dengan jeda dan cara pembuangannya, tabel warnanya, jumlah pengulangannya, dan rincian byte demi byte tentang ke mana ukuran file-nya pergi. Tidak ada yang diunggah."
+og_title = "Penganalisis GIF &mdash; bongkar sebuah GIF di peramban Anda"
+og_description = "Setiap bingkai, setiap jeda, setiap palet, dan laporan jujur tentang ke mana byte-nya pergi. File dibaca di perangkat Anda sendiri dan tidak pernah diunggah."
+og_image_alt = "Penganalisis GIF - bingkai, jeda, palet, dan ke mana byte-nya pergi"
+
+pledge = """
+    File dibuka dan dibongkar oleh peramban Anda sendiri: struktur bloknya,
+    dekompresi LZW-nya, dan setiap bingkai yang digambar di halaman ini semuanya
+    dikerjakan di mesin ini. Tidak ada server di ujung lain halaman ini untuk
+    menerima sebuah file, bahkan seandainya ada sesuatu di sini yang
+    menginginkannya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu analisis sebuah GIF. Tidak satu pun permintaan membawa gambar, gambar
+      mini, atau nama file. Atau cabut koneksi internet dan tetap analisis
+      satu."""
+
+read_first = """
+, <code>src/gif.js</code> untuk pembaca blok yang
+      menelusuri file, <code>src/lzw.js</code> untuk dekompresornya, dan
+      <code>src/budget.js</code> untuk penghitungan byte-nya &mdash; tidak satu
+      pun punya baris yang bisa menjangkau jaringan."""
+
+howto_heading = "Cara menganalisis GIF"
+
+card = """
+            Buka sebuah GIF dan lihat apa sebenarnya isinya: setiap bingkai
+            dengan jeda dan cara pembuangannya, tabel warnanya, dan laporan
+            jujur tentang ke mana ukuran file-nya pergi."""
+
+[words]
+plural = "GIF"
+choose = "sebuah GIF"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "GIF Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya ada.
+      Dulu ini tertulis <code>connect-src 'none'</code>, yang mutlak; memasang
+      iklan memakan itu, dan mengatakannya adalah bagian dari kesepakatan."""
+
+[[privacy]]
+title = "Pembacanya adalah empat file di repositori ini."
+body = """
+ Tidak ada di sini yang memakai dekoder
+      GIF milik peramban untuk mengetahui isi file, karena dekoder itu tidak akan
+      mengatakan ke mana sebuah byte pergi. Jadi formatnya dibaca sendiri:
+      <code>src/gif.js</code> menelusuri bloknya, <code>src/lzw.js</code>
+      mengembangkan pikselnya, <code>src/frames.js</code> menumpuknya, dan
+      <code>src/budget.js</code> menjumlahkan bagian-bagiannya kembali dan
+      memeriksa apakah totalnya sama dengan ukuran file."""
+
+[[privacy]]
+title = "Komentar dan metadata ditampilkan kepada Anda, dan bukan kepada siapa pun lain."
+body = """
+ Sebuah GIF bisa membawa blok
+      komentar, paket XMP yang menjelaskan sebuah suntingan, atau profil warna,
+      dan halaman ini mencetak semuanya. Semua itu ditaruh di layar di depan Anda
+      dan tidak pergi ke mana pun: tidak ada peristiwa pengukuran di repositori
+      ini yang membawa satu pun darinya, dan halaman ini tidak akan bisa
+      mengirimnya seandainya ada."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang file Anda: bukan
+      file-nya, bukan gambar mini, bukan nama, ukuran, jumlah bingkai, atau
+      komentar. Setiap baris yang membaca, mendekompresi, atau menggambar GIF
+      disajikan dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau file Anda. Tidak ada
+      yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan setiap bagian
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana: alat yang
+      mengirim GIF Anda ke tempat lain untuk dianalisis akan berhenti begitu Anda
+      mencabut koneksi."""
+
+[[howto]]
+title = "Pilih sebuah GIF."
+body = """
+ Jatuhkan ke pemilih file, atau pilih sendiri.
+      Peramban membacanya langsung dari disk Anda; tidak ada yang dikirim ke mana
+      pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Baca ringkasannya lebih dulu."
+body = """
+ Ukuran kanvas, jumlah bingkai,
+      berapa lama animasi itu mengaku berjalan, dan berapa lama ia sebenarnya
+      diputar. Dua yang terakhir lebih sering berbeda daripada yang orang duga,
+      dan alasannya ada di bagian berikutnya."""
+
+[[howto]]
+title = "Lihat apa yang menonjol."
+body = """
+ Setiap baris di situ diukur dari file
+      Anda: jeda yang tidak akan dipatuhi peramban mana pun, blok pengulangan
+      yang hilang, tabel warna yang tidak dirujuk apa pun, metadata yang lebih
+      besar daripada sebagian bingkainya. Tidak ada yang berupa tebakan tentang
+      apa yang Anda maksud untuk dibuat."""
+
+[[howto]]
+title = "Lihat ke mana byte-nya pergi."
+body = """
+ Setiap byte file berada tepat di satu
+      baris, dan baris-barisnya berjumlah sama dengan file. Kalau sebagian
+      besarnya tidak ada di "piksel terkompresi", sisa tabelnya mengatakan ia ada
+      di mana."""
+
+[[howto]]
+title = "Telusuri bingkainya."
+body = """
+ Masing-masing menampilkan jeda, persegi
+      panjangnya, cara pembuangannya, dan ukurannya. Beralihlah antara "kanvas
+      setelah setiap bingkai" dan "hanya yang disimpan setiap bingkai" &mdash;
+      yang kedua adalah cara Anda melihat apakah file-nya dioptimalkan, karena
+      GIF yang dibuat dengan baik menyimpan persegi panjang mungil dan yang
+      dibuat asal-asalan menyimpan gambar utuh setiap kali."""
+
+[[howto]]
+title = "Ambil laporannya kalau Anda butuh."
+body = """
+ Seluruh analisis sebagai teks biasa,
+      untuk ditempelkan ke sebuah pesan atau disimpan di samping file-nya. Ia
+      dibangun di halaman ini dari apa yang sudah ada di layar Anda."""
+
+[[faq]]
+q = "Apakah GIF saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File dibaca, didekompresi, dan digambar oleh peramban Anda sendiri
+        di perangkat keras Anda sendiri. Alat ini tidak punya sisi server, dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya &mdash; tidak satu pun milik situs
+        ini. Cabut koneksi jaringan dan ia tetap menganalisis GIF."""
+
+[[faq]]
+q = "Kenapa GIF saya diputar lebih lambat daripada yang dikatakan jedanya?"
+a = """
+        Karena setiap peramban menolak mematuhi jeda di bawah dua perseratus
+        detik dan menahan bingkainya sepersepuluh detik. Aturan itu ditulis ke
+        dalam Netscape pada 1996, untuk bola dunia berputar dan tanda "sedang
+        dibangun" pada zaman itu, dan telah disalin ke setiap peramban sejak
+        itu; tidak pernah ada yang mencabutnya.
+        <br><br>
+        Jadi GIF yang semua bingkainya berkata 0,01 dtk tidak diputar pada 100
+        bingkai per detik. Ia diputar pada 10, yang lima sampai sepuluh kali
+        lebih lambat daripada yang dimaksudkan pembuatnya. Halaman ini
+        menampilkan kedua angkanya &mdash; apa kata file dan apa yang sebenarnya
+        akan terjadi &mdash; dan menandai bingkai yang terkena. Perbaikannya, di
+        alat apa pun yang membuat file itu, adalah menulis 0,02 alih-alih
+        0,01."""
+
+[[faq]]
+q = "Apa arti &ldquo;cara pembuangan&rdquo;?"
+a = """
+        Apa yang harus ditinggalkan di layar ketika waktu sebuah bingkai habis,
+        dan itulah bidang yang menentukan sebuah animasi tampak benar atau
+        belepotan.
+        <br><br>
+        <strong>Biarkan di tempatnya</strong> berarti bingkai berikutnya mengecat
+        di atas yang ini, yang Anda inginkan ketika bingkainya buram dan saling
+        menutupi. <strong>Bersihkan kembali ke latar</strong> menghapus persegi
+        panjang bingkai itu lebih dulu, yang dibutuhkan transparansi &mdash;
+        tanpa itu, bagian tembus pandang bingkai berikutnya menampilkan bingkai
+        sebelumnya di bawahnya. <strong>Kembalikan apa yang ada di bawahnya</strong>
+        mengembalikan apa pun yang ada di sana sebelum bingkai ini menggambar,
+        dan begitulah objek kecil yang bergerak di atas latar diam disimpan. Dan
+        <strong>tidak ditentukan</strong> berarti file-nya tidak mengatakannya,
+        dan setiap penampil memperlakukannya sebagai "biarkan di tempatnya"."""
+
+[[faq]]
+q = "Kenapa GIF saya begitu besar?"
+a = """
+        Tabel "Ke mana byte-nya pergi" menjawabnya untuk file Anda yang ini,
+        bukan secara umum, dan hanya ada beberapa jawaban yang mungkin.
+        <br><br>
+        Kalau hampir seluruhnya adalah <strong>piksel terkompresi</strong>,
+        file-nya memang berisi banyak gambar: GIF menyimpan setiap bingkai
+        sebagai piksel utuh, tanpa kompensasi gerak dan tanpa tombol kualitas,
+        jadi ukurannya kira-kira luas dikalikan jumlah bingkai. Lebih sedikit
+        bingkai, ukuran lebih kecil, atau lebih sedikit warna adalah satu-satunya
+        tuas.
+        <br><br>
+        Kalau irisan besarnya adalah <strong>tabel warna</strong>, file itu
+        menulis satu palet per bingkai seharga 768 byte masing-masing. Kalau
+        irisan besarnya adalah <strong>metadata</strong>, sebuah penyunting
+        meninggalkan paket XMP dan itu bisa dibuang tanpa menyentuh gambarnya. Dan
+        kalau bingkainya semua menutupi seluruh kanvas, encoder-nya tidak pernah
+        menghitung bagian mana yang sebenarnya berubah &mdash; yang pada apa pun
+        yang difilmkan atau direkam adalah sebagian besar isi file."""
+
+[[faq]]
+q = "Apa bedanya dua tampilan bingkai itu?"
+a = """
+        <strong>Kanvas setelah setiap bingkai</strong> adalah apa yang ditampilkan
+        sebuah penampil pada momen itu: bingkai ini digambar di atas apa pun yang
+        ditinggalkan bingkai sebelumnya. <strong>Hanya yang disimpan setiap
+        bingkai</strong> adalah persegi panjang yang benar-benar dimuat file untuk
+        bingkai itu, berdiri sendiri, tanpa apa pun di bawahnya.
+        <br><br>
+        Yang kedua adalah yang menarik. Sebuah GIF boleh menyimpan sebuah bingkai
+        hanya sebagai bagian gambar yang berubah, dan itulah sebabnya rekaman
+        layar dari jendela yang sebagian besarnya diam bisa berukuran kecil. Kalau
+        setiap bingkai di file Anda adalah kanvas penuh, tidak ada yang melakukan
+        pekerjaan itu &mdash; dan Anda tidak bisa mengetahuinya dengan menonton
+        animasinya, hanya dengan melihat apa yang disimpan."""
+
+[[faq]]
+q = "Katanya file saya memuat komentar atau XMP. Apa itu?"
+a = """
+        Teks yang ikut menumpang bersama gambar dan yang tidak digambar penampil
+        mana pun. Blok komentar biasanya berisi nama apa pun yang menulis file
+        itu. Paket XMP adalah XML yang ditulis penyunting gambar untuk mencatat
+        apa yang dilakukannya, dan ia bisa membawa riwayat suntingan, versi
+        perangkat lunak, dan kadang nama penulisnya.
+        <br><br>
+        Halaman ini mencetak keduanya secara lengkap, karena pertanyaan menarik
+        soal metadata adalah apa isinya, bukan bahwa ia ada. Itu ditampilkan
+        kepada Anda dan bukan kepada siapa pun lain: tidak ada apa pun di
+        repositori ini yang membacakannya kepada siapa pun."""
+
+[[faq]]
+q = "Bisakah ia membuka GIF yang rusak?"
+a = """
+        Ia berusaha, dan ia memberi tahu di mana ia menyerah. File yang berakhir
+        di tengah blok, punya byte di tempat penanda blok seharusnya berada, atau
+        membawa bingkai yang data terkompresinya habis lebih awal, tetap akan
+        menampilkan semua yang terbaca sebelum titik itu, dengan masalahnya
+        disebutkan di bagian atas. Justru untuk kasus itulah sebuah penganalisis
+        paling dibutuhkan, jadi membuang seluruh file gara-gara satu byte buruk
+        akan menjadi perilaku yang salah."""
+
+[[faq]]
+q = "Apakah ia mengubah file saya?"
+a = """
+        Tidak. Alat ini hanya membaca. Tidak ada file keluaran, tidak ada
+        pengodean ulang, dan tidak ada tombol di sini yang menulis sebuah GIF
+        &mdash; satu-satunya yang bisa Anda unduh adalah salinan teks biasa dari
+        analisisnya. File asli Anda tidak tersentuh di disk Anda, yang juga
+        merupakan jawaban jujur atas apa yang terjadi kalau Anda menutup tab."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, dan tidak ada masa uji coba.
+        Tidak ada batas ukuran file selain memori mesin Anda sendiri. Situs ini
+        memasang iklan, dan itulah yang membiayainya; iklan tidak diberi apa pun
+        tentang file Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim GIF Anda ke tempat lain untuk dianalisis akan
+        berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Bongkar sebuah GIF di peramban: setiap bingkai dengan jeda, persegi panjang, dan cara pembuangannya, tabel warnanya, jumlah pengulangannya, metadata apa pun, dan laporan byte demi byte tentang ukuran file. Tidak ada yang diunggah."
+features = [
+  "Setiap bingkai dengan jeda, persegi panjang, cara pembuangan, dan ukuran terkompresinya",
+  "Kedua tampilan sebuah bingkai: apa yang disimpannya, dan kanvas yang dilihat penampil",
+  "Anggaran byte yang totalnya sama dengan file, jadi tidak ada yang tak terjelaskan",
+  "Tabel warna digambar keluar, dengan entri yang tidak pernah dirujuk piksel mana pun ditandai",
+  "Membaca komentar, paket XMP, profil ICC, dan blok pengulangan Netscape",
+  "Melaporkan jeda yang tidak akan dipatuhi peramban mana pun, dan laju sebenarnya animasi itu",
+  "Membuka file yang rusak dan terpotong dan mengatakan di mana ia berhenti",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa mengubah file Anda",
+]
+
+[picker]
+title = "Jatuhkan GIF di sini"
+hint = "atau klik untuk menelusuri &mdash; bergerak atau diam, ukuran berapa pun"

--- a/locales/id/tools/gif-maker.html
+++ b/locales/id/tools/gif-maker.html
@@ -1,0 +1,181 @@
+<!--
+  tools/gif-maker/body.html, in Indonesian.
+
+  Every id, class, data-view, data-sort and option value below is what
+  src/main.js reaches for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; bingkainya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih gambar</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Ubah cara bingkai ditampilkan">
+          <button type="button" data-view="large" class="active" aria-pressed="true">Besar</button>
+          <button type="button" data-view="small" aria-pressed="false">Kecil</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Urutkan berdasarkan nama</button>
+        <button type="button" data-sort="date" class="ghost">Urutkan berdasarkan tanggal</button>
+        <button type="button" data-sort="reverse" class="ghost">Balik urutan</button>
+        <button type="button" id="clear-all" class="ghost danger">Hapus semua</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Seret bingkai mana pun lewat pegangan <span class="grip" aria-hidden="true">&#8942;&#8942;</span>-nya
+      untuk mengurutkan ulang, atau pakai panah pada masing-masingnya. Urutan di sini adalah urutan mainnya.
+    </p>
+
+    <ul id="frame-list" class="frame-list view-large"></ul>
+
+    <div id="bulk-delay" class="bulk" hidden>
+      <label for="bulk-amount">Tahan setiap bingkai selama</label>
+      <input type="number" id="bulk-amount" min="0.02" max="60" step="0.05" value="0.5">
+      <select id="bulk-unit" aria-label="Satuan untuk berapa lama setiap bingkai ditahan">
+        <option value="seconds" selected>detik</option>
+        <option value="fps">bingkai per detik</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Terapkan ke semua</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Langkah 2 &mdash; setelan -->
+  <section class="card">
+    <h2><span class="step">2</span> Setelan GIF</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="size">Ukuran</label>
+        <select id="size">
+          <option value="480" selected>480 px &mdash; bawaan yang baik</option>
+          <option value="640">640 px</option>
+          <option value="320">320 px</option>
+          <option value="240">240 px</option>
+          <option value="original">Ikuti gambarnya</option>
+          <option value="custom">Sesuai keinginan&hellip;</option>
+        </select>
+        <div id="size-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="1000" step="1" value="480"
+                 aria-label="Lebar sesuai keinginan dalam piksel">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="1000" step="1" value="270"
+                 aria-label="Tinggi sesuai keinginan dalam piksel">
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Cara gambar dipaskan</label>
+        <select id="fit">
+          <option value="contain" selected>Muat di dalam (dengan bilah)</option>
+          <option value="cover">Penuhi bingkai (memangkas tepinya)</option>
+          <option value="stretch">Regangkan sampai penuh (mengubah bentuk)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Warna latar</label>
+        <input type="color" id="background" value="#ffffff">
+      </div>
+
+      <div class="field">
+        <label for="colors">Warna</label>
+        <select id="colors">
+          <option value="256" selected>256 &mdash; sebanyak yang bisa dimuat GIF</option>
+          <option value="128">128</option>
+          <option value="64">64</option>
+          <option value="32">32 &mdash; file paling kecil</option>
+        </select>
+        <p class="field-note">Makin sedikit warna, makin kecil file, makin banyak pita warna.</p>
+      </div>
+
+      <div class="field">
+        <label for="palette-mode">Palet</label>
+        <select id="palette-mode">
+          <option value="per-frame" selected>Warna terbaik untuk setiap bingkai</option>
+          <option value="shared">Satu palet untuk seluruh GIF</option>
+        </select>
+        <p class="field-note" id="palette-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Titik-titik campur</label>
+        <select id="dither">
+          <option value="on" selected>Nyala &mdash; gradasi lebih halus</option>
+          <option value="off">Mati &mdash; lebih rata, tepi lebih bersih</option>
+        </select>
+        <p class="field-note">Matikan untuk logo, seni garis, dan tangkapan layar.</p>
+      </div>
+
+      <div class="field">
+        <label for="loop-mode">Pengulangan</label>
+        <select id="loop-mode">
+          <option value="forever" selected>Ulang terus</option>
+          <option value="once">Putar sekali</option>
+          <option value="times">Putar sejumlah tertentu&hellip;</option>
+        </select>
+        <input type="number" id="loop-times" class="spaced" min="1" max="1000" step="1" value="3"
+               aria-label="Berapa kali animasi diputar" hidden>
+      </div>
+
+      <div class="field">
+        <label for="transparent">Transparansi</label>
+        <select id="transparent">
+          <option value="off" selected>Ratakan ke warna latar</option>
+          <option value="on">Jaga area transparan</option>
+        </select>
+        <p class="field-note" id="transparent-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame" id="preview-frame">
+        <canvas id="preview" width="480" height="270" aria-label="Pratinjau bingkai pertama"></canvas>
+        <p id="preview-empty" class="preview-empty">Tambahkan gambar untuk melihat pratinjau</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Bingkai</dt><dd id="sum-frames">&mdash;</dd></div>
+        <div><dt>Berjalan selama</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Ukuran bingkai</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Diputar</dt><dd id="sum-loop">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; ekspor -->
+  <section class="card">
+    <h2><span class="step">3</span> Buat GIF-nya</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Buat GIF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame"><img id="result-image" alt="Animasi yang sudah jadi, sedang diputar"></div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh GIF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/gif-maker.toml
+++ b/locales/id/tools/gif-maker.toml
@@ -1,0 +1,255 @@
+#
+# Pembuat GIF - Bahasa Indonesia.
+#
+# Overrides for tools/gif-maker/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Pembuat GIF"
+heading = "Pembuat&nbsp;GIF <span class=\"h1-kw\">&mdash; gambar menjadi GIF bergerak</span>"
+tagline = "Ubah sekumpulan gambar menjadi satu animasi."
+
+title = "Pembuat GIF &mdash; Gambar ke GIF Bergerak, Gratis dan Tanpa Unggah"
+description = "Ubah gambar JPG, PNG, atau WebP menjadi GIF bergerak, gratis dan sepenuhnya di peramban Anda. Atur urutan, kecepatan, dan ukurannya. Tidak ada yang diunggah, dan jalan tanpa internet."
+og_title = "Pembuat GIF &mdash; gambar menjadi GIF bergerak, di peramban Anda"
+og_description = "Urutkan bingkainya, atur berapa lama setiap bingkai ditahan, pilih ukuran, dan dapatkan sebuah GIF. Palet dan kompresinya dihitung di perangkat Anda sendiri; tidak ada yang diunggah."
+og_image_alt = "Pembuat GIF - ubah sekumpulan gambar menjadi satu GIF bergerak"
+
+pledge = """
+    Setiap bingkai digambar, dikuantisasi, dan dikompres oleh peramban Anda
+    sendiri, dan GIF yang sudah jadi dirakit di memori mesin ini. Tidak ada
+    server di ujung lain halaman ini untuk menerima sebuah gambar, bahkan
+    seandainya ada sesuatu di sini yang menginginkannya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu buat sebuah GIF. Tidak satu pun permintaan membawa gambar, gambar
+      mini, atau nama file. Atau cabut koneksi internet dan tetap buat satu."""
+
+read_first = """
+, <code>src/quantize.js</code> untuk palet yang
+      dipakai setiap bingkai, dan <code>src/lzw.js</code> serta
+      <code>src/gif.js</code> untuk kompresornya dan file tempatnya masuk
+      &mdash; tidak satu pun punya baris yang bisa menjangkau jaringan."""
+
+howto_heading = "Cara membuat GIF dari gambar"
+
+card = """
+            Urutkan gambarnya, sebutkan berapa lama setiap gambar ditahan, dan
+            dapatkan satu GIF bergerak. Warna dan kompresinya dihitung di
+            perangkat Anda sendiri."""
+
+[words]
+plural = "gambar"
+choose = "beberapa gambar"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "Gambar Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya ada.
+      Dulu ini tertulis <code>connect-src 'none'</code>, yang mutlak; memasang
+      iklan memakan itu, dan mengatakannya adalah bagian dari kesepakatan."""
+
+[[privacy]]
+title = "Encoder-nya adalah empat file di repositori ini."
+body = """
+ Sebuah GIF butuh kuantiser warna dan
+      kompresor LZW, dan peramban tidak menyediakan keduanya &mdash; jadi
+      keduanya ditulis di sini, di <code>src/quantize.js</code> dan
+      <code>src/lzw.js</code>, dengan wadahnya di <code>src/gif.js</code>. Tidak
+      ada yang diambil untuk membuatnya, dan tidak ada mesin yang diunduh saat
+      pertama dipakai."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang gambar Anda: bukan file,
+      bukan gambar mini, bukan nama, ukuran, atau jumlah. Setiap baris yang
+      membaca, mendekode, menggambar, atau mengompres sebuah gambar disajikan
+      dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau gambar Anda. Tidak
+      ada yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan setiap bagian
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana: alat yang
+      mengirim gambar Anda ke tempat lain untuk dijadikan GIF akan berhenti
+      begitu Anda mencabut koneksi."""
+
+[[howto]]
+title = "Pilih gambar Anda."
+body = """
+ Jatuhkan sebuah folder ke pemilih file,
+      atau pilih file-nya sendiri. Peramban membacanya langsung dari disk Anda;
+      tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Urutkan sesuai urutan mainnya."
+body = """
+ Seret lewat pegangannya, atau pakai
+      panahnya. "Urutkan berdasarkan nama" menghitung seperti yang Anda harapkan,
+      jadi <code>frame_2</code> mendarat sebelum <code>frame_10</code>."""
+
+[[howto]]
+title = "Atur berapa lama setiap bingkai ditahan."
+body = """
+ Setengah detik per bingkai adalah
+      slide; seperdua puluh detik adalah animasi. Beri semua bingkai waktu tahan
+      yang sama sekaligus, atau bedakan salah satunya supaya berlama-lama."""
+
+[[howto]]
+title = "Pilih ukuran, dan cara warnanya dipilih."
+body = """
+ Sebuah GIF tumbuh mengikuti luasnya
+      dan jumlah bingkainya, dan tidak ada penggeser kualitas untuk menurunkannya
+      lagi, jadi ukuran adalah setelan yang paling menentukan. 256 warna per
+      bingkai adalah bawaan yang paling enak dilihat; satu palet bersama lebih
+      kecil dan lebih stabil."""
+
+[[howto]]
+title = "Buat GIF-nya dan unduh."
+body = """
+ Ia dibangun di perangkat keras Anda
+      sendiri, jadi lamanya tergantung mesin Anda, bukan pada antrean. Animasi
+      yang sudah jadi diputar di halaman sebelum Anda menyimpannya."""
+
+[[faq]]
+q = "Apakah gambar saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Gambar Anda dibaca, digambar, dikuantisasi, dan dikompres oleh
+        peramban Anda sendiri di perangkat keras Anda sendiri. Alat ini tidak
+        punya sisi server, dan <code>Content-Security-Policy</code> halaman ini
+        menyebut satu per satu setiap alamat yang boleh dihubunginya &mdash;
+        tidak satu pun milik situs ini. Cabut koneksi jaringan dan ia tetap
+        membuat GIF."""
+
+[[faq]]
+q = "Format gambar apa saja yang bisa saya pakai?"
+a = """
+        Format gambar diam apa pun yang bisa didekode peramban Anda, yang dalam
+        praktiknya berarti JPG, PNG, WebP, GIF, AVIF, dan di perangkat Apple,
+        HEIC. Tidak ada daftar terpisah yang harus dijaga tetap mutakhir di sini,
+        karena pendekodean adalah tugas peramban, bukan tugas kami."""
+
+[[faq]]
+q = "Kenapa GIF saya begitu besar?"
+a = """
+        Karena sebuah GIF menyimpan setiap bingkai sebagai piksel utuh. Tidak ada
+        kompensasi gerak, tidak ada yang disimpan sebagai "sama seperti tadi tapi
+        digeser", dan tidak ada tombol kualitas: ukurannya kira-kira luas
+        dikalikan jumlah bingkai, dan hanya tiga hal yang menurunkannya.
+        <br><br>
+        Perkecil &mdash; memangkas ukuran jadi separuh membuat file-nya tinggal
+        seperempat. Pakai lebih sedikit bingkai, atau tahan setiap bingkai lebih
+        lama. Turunkan ke 64 atau 32 warna, dan matikan titik-titik campur, yang
+        biayanya lebih ringan daripada kedengarannya pada gambar datar dan sangat
+        besar pada foto. Kalau tetap tidak muat, jawaban jujurnya adalah bahwa
+        yang Anda buat itu sebenarnya video, dan MP4-nya mungkin hanya sepersepuluh
+        ukurannya."""
+
+[[faq]]
+q = "Secepat apa sebuah GIF bisa diputar?"
+a = """
+        Tidak secepat yang disiratkan angkanya. Formatnya menyimpan jeda setiap
+        bingkai dalam perseratus detik, dan peramban sudah membatasi apa pun di
+        bawah dua perseratus menjadi sepersepuluh detik sejak 1990-an &mdash;
+        aturan yang ditulis untuk bola dunia berputar pada zaman itu dan tidak
+        pernah dicabut. Jadi jeda 0,01 dtk tidak diputar pada 100 bingkai per
+        detik; ia diputar pada 10. Karena itu alat ini tidak akan menawarkan apa
+        pun di bawah 0,02 dtk, dan 0,05 dtk (20 bingkai per detik) kira-kira
+        secepat yang layak diminta."""
+
+[[faq]]
+q = "Apa yang diubah setelan palet?"
+a = """
+        Satu bingkai GIF memuat paling banyak 256 warna, dan sesuatu harus
+        memilihnya.
+        <br><br>
+        <strong>Warna terbaik untuk setiap bingkai</strong> memilih 256 untuk
+        setiap gambar secara terpisah, yang tampak paling tajam dan merupakan
+        jawaban yang tepat untuk sekumpulan foto yang tidak berhubungan.
+        <strong>Satu palet untuk seluruh GIF</strong> membangun satu tabel dari
+        semua bingkai sekaligus. Ia membuat file lebih kecil, dan menghentikan
+        kedipan yang muncul ketika palet tersentak-sentak di antara bingkai dari
+        adegan yang sama &mdash; jadi itulah yang dipilih ketika bingkainya adalah
+        sebuah rangkaian, bukan sebuah kumpulan."""
+
+[[faq]]
+q = "Bisakah saya menjaga latar tetap transparan?"
+a = """
+        Bisa, kalau gambar Anda memang punya: ubah "Transparansi" menjadi "Jaga
+        area transparan". Satu hal yang perlu diketahui sebelum melakukannya.
+        Transparansi GIF hanya satu bit &mdash; sebuah piksel entah tidak terlihat
+        entah dicat penuh, tanpa apa pun di antaranya &mdash; jadi tepi yang
+        dihaluskan, bayangan lembut, dan apa pun yang memudar akan berubah menjadi
+        tepi keras. Kalau animasi Anda akan diletakkan di atas latar yang warnanya
+        Anda ketahui, meratakannya ke warna itu akan tampak lebih baik."""
+
+[[faq]]
+q = "Adakah batas berapa banyak gambar yang bisa saya pakai?"
+a = """
+        Tidak ada batas yang tertanam di alat ini. Batas praktisnya adalah memori
+        mesin Anda sendiri dan kesabaran Anda terhadap file yang keluar:
+        gambarnya dibaca satu per satu, jadi seratus bingkai tidak masalah, tapi
+        seratus bingkai pada 640 px juga berarti GIF yang sangat besar. Lihat
+        "Kenapa GIF saya begitu besar?" di atas."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, dan tidak ada masa uji coba.
+        Tidak ada tanda air pada keluarannya juga. Situs ini memasang iklan, dan
+        itulah yang membiayainya; iklan tidak diberi apa pun tentang gambar
+        Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim gambar Anda ke tempat lain untuk diproses
+        akan berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Ubah sekumpulan gambar menjadi GIF bergerak. Bingkai, palet, dan kompresinya semua dihitung di peramban Anda, jadi tidak ada gambar yang pernah diunggah."
+features = [
+  "Menggabungkan gambar JPG, PNG, WebP, GIF, dan AVIF menjadi satu GIF bergerak",
+  "Waktu tahan per bingkai, seret untuk mengurutkan ulang, urutkan berdasarkan nama atau tanggal",
+  "256, 128, 64, atau 32 warna, dengan titik-titik campur Floyd-Steinberg opsional",
+  "Satu palet bersama atau warna terbaik untuk setiap bingkai",
+  "Transparansi satu bit opsional, dan ulang terus, sekali, atau sejumlah tertentu",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan gambar di sini"
+hint = "atau klik untuk menelusuri &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/id/tools/grab-frame.html
+++ b/locales/id/tools/grab-frame.html
@@ -1,0 +1,140 @@
+<!--
+  tools/grab-frame/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Ukuran</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Bingkai</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Jumlah bingkai</dt><dd id="src-frames">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; momennya -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Temukan bingkainya</h2>
+
+    <p class="stage-hint">
+      Seret penggeser untuk bergerak melewati klip, atau putar dan berhentilah di
+      tempat yang Anda mau. <kbd>&larr;</kbd> dan <kbd>&rarr;</kbd> melangkah satu
+      bingkai sekali tekan, <kbd>Shift</kbd> bersamanya melangkah sepuluh, dan
+      <kbd>Space</kbd> memutar dan menjeda.
+    </p>
+
+    <!-- The picture you are looking at is the picture that gets saved: on the
+         exact path the canvas holds the decoded frame itself, drawn small here
+         and full size into the file. The <video> element is only for playing
+         and for the files this browser can play but this reader cannot open. -->
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+        <p class="stage-busy" id="stage-busy" hidden>Mendekode&hellip;</p>
+      </div>
+    </div>
+
+    <div class="transport">
+      <div class="transport-buttons" role="group" aria-label="Bergerak melewati klip">
+        <button type="button" id="step-back" class="ghost" title="Bingkai sebelumnya (panah kiri)"
+          aria-label="Bingkai sebelumnya">&#9664;|</button>
+        <button type="button" id="play" class="ghost" title="Putar atau jeda (spasi)"
+          aria-label="Putar">&#9654;</button>
+        <button type="button" id="step-on" class="ghost" title="Bingkai berikutnya (panah kanan)"
+          aria-label="Bingkai berikutnya">|&#9654;</button>
+      </div>
+
+      <input type="range" id="scrub" min="0" max="1000" value="0" step="1"
+        aria-label="Posisi di dalam klip">
+
+      <p class="readout">
+        <span id="at-time">0:00.000</span>
+        <span class="readout-dim" id="at-frame"></span>
+      </p>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; gambar diamnya -->
+  <section class="card" id="grab-card" hidden>
+    <h2><span class="step">3</span> Ambil gambarnya</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; persis bingkainya</option>
+          <option value="image/jpeg">JPEG &mdash; lebih kecil, ada kehilangan</option>
+          <option value="image/webp">WebP &mdash; lebih kecil lagi, ada kehilangan</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Kualitas <output id="quality-value">92</output></label>
+        <input type="range" id="quality" min="40" max="100" step="1" value="92">
+        <p class="field-note">
+          Hanya PNG yang menyimpan bingkainya apa adanya. Selain itu adalah
+          kompresi kedua di atas kompresi videonya sendiri.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="every">Setiap</label>
+        <div class="inline-pair">
+          <input type="number" id="every" min="0.1" max="600" step="0.5" value="5">
+          <span>detik</span>
+        </div>
+        <p class="field-note">
+          Untuk lembar kontak, atau gambar mini sesekali. Dibatasi 500 gambar
+          diam.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="grab" class="primary">Ambil bingkai ini</button>
+      <button type="button" id="grab-series" class="ghost">Ambil satu setiap 5 detik</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 4 &mdash; apa yang keluar -->
+  <section class="card" id="shots-card" hidden>
+    <h2><span class="step">4</span> Gambar diam Anda</h2>
+
+    <div class="toolbar">
+      <p class="count" id="shots-count" role="status" aria-live="polite"></p>
+      <div class="toolbar-actions">
+        <button type="button" id="download-all" class="ghost">Unduh semua sebagai ZIP</button>
+        <button type="button" id="clear" class="ghost danger">Bersihkan</button>
+      </div>
+    </div>
+
+    <ul class="shots" id="shots"></ul>
+  </section>
+</main>

--- a/locales/id/tools/grab-frame.toml
+++ b/locales/id/tools/grab-frame.toml
@@ -1,0 +1,252 @@
+#
+# Pengambil Bingkai Video - Bahasa Indonesia.
+#
+# Overrides for tools/grab-frame/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Pengambil Bingkai Video"
+heading = "Pengambil&nbsp;Bingkai&nbsp;Video <span class=\"h1-kw\">&mdash; simpan bingkai dari video</span>"
+tagline = "Gambar diam berkualitas penuh dari titik mana pun."
+
+title = "Ambil Bingkai dari Video &mdash; Gratis, Tanpa Unggah, Jalan Tanpa Internet"
+description = "Simpan bingkai mana pun dari MP4, MOV, atau WebM sebagai PNG atau JPEG ukuran penuh. Melangkah bingkai demi bingkai, atau ambil satu setiap beberapa detik. Berjalan di peramban Anda: tidak ada yang diunggah."
+og_title = "Pengambil Bingkai Video &mdash; gambar diam dari titik mana pun, tanpa mengunggah klipnya"
+og_description = "Temukan momennya, melangkah ke bingkai yang persis, dan simpan pada resolusi asli videonya. Bingkainya didekode di perangkat Anda sendiri dan gambarnya tidak pernah dikodekan dua kali."
+og_image_alt = "Pengambil Bingkai Video - simpan bingkai dari video di peramban Anda, tanpa ada yang diunggah"
+
+pledge = """
+    Bingkainya dicari, didekode, dan digambar oleh peramban Anda sendiri, di
+    perangkat keras Anda sendiri. Tidak ada di sini yang bisa mengambil atau
+    mengirim apa pun &mdash; alat ini sama sekali tidak punya fitur jaringan
+    &mdash; dan seandainya pun ada, tidak ada server di ujung lain halaman ini
+    untuk menerima sebuah video."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu ambil sebuah bingkai. Tidak satu pun permintaan membawa gambar, nama
+      file, atau satu byte pun dari yang Anda pilih. Atau cabut koneksi internet
+      dan tetap ambil satu &mdash; alat yang mengirim video Anda ke tempat lain
+      untuk diproses akan langsung berhenti."""
+
+read_first = """
+, <code>src/demux.js</code> untuk pembaca yang mencari
+      bingkai di dalam MP4, dan <code>src/frames.js</code> untuk bagian yang
+      mendekode bingkai yang Anda minta. Tidak satu pun mengimpor sesuatu yang
+      bisa membuat permintaan."""
+
+howto_heading = "Cara mengambil bingkai dari video"
+
+card = """
+            Simpan bingkai mana pun dari sebuah klip sebagai gambar, pada ukuran
+            asli videonya &mdash; satu per satu, atau satu setiap beberapa
+            detik."""
+
+[words]
+plural = "video"
+choose = "sebuah video"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Resolusi penuh"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[privacy]]
+title = "Video Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Alat ini sama sekali tidak punya
+      fitur jaringan: tidak ada alamat untuk ditempelkan, tidak ada yang diunduh,
+      tidak ada mesin yang diambil saat pertama dipakai. Setiap byte yang
+      menyentuh video Anda datang dari asal ini ketika halaman dimuat."""
+
+[[privacy]]
+title = "Pendekodean berjalan lokal."
+body = """
+ Bingkainya melewati WebCodecs di peramban
+      Anda sendiri, atau melewati mesin pemutar yang sama yang toh akan
+      menampilkan klip itu kepada Anda. Gambarnya digambar ke sebuah kanvas di
+      mesin ini dan diserahkan langsung ke unduhan."""
+
+[[privacy]]
+title = "File dibaca beberapa megabyte sekali jalan."
+body = """
+ Video adalah satu-satunya jenis file
+      di sini yang tidak bisa dipastikan muat di memori, jadi ia tidak pernah
+      dimuat utuh. Pembaca mengambil sebuah jendela di sekitar bingkai apa pun
+      yang Anda minta &mdash; itu juga sebabnya klip dua gigabyte terbuka
+      secepat klip kecil."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang video Anda: bukan file,
+      bukan bingkai, bukan nama, ukuran, durasi, atau momen tempat Anda berhenti.
+      Setiap baris yang membaca, mendekode, atau menggambar disajikan dari asal
+      ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau video Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih sebuah video."
+body = """
+ Jatuhkan MP4, MOV, M4V, atau WebM ke
+      pemilih file, atau pilih sendiri. Peramban membacanya langsung dari disk
+      Anda; tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Temukan momennya."
+body = """
+ Putar dan berhentilah di tempat yang Anda
+      mau, atau seret penggeser &mdash; pada MP4 penggeser bergerak satu bingkai
+      sekali langkah, jadi tidak ada pembulatan antara yang Anda lihat dan yang
+      Anda simpan. Tombol panah melangkah satu bingkai sekali tekan, dan tahan
+      <kbd>Shift</kbd> untuk sepuluh."""
+
+[[howto]]
+title = "Pilih formatnya."
+body = """
+ PNG menyimpan bingkainya persis seperti hasil
+      dekode, dan itulah arti "kualitas penuh" di sini. JPEG dan WebP lebih kecil
+      dan merupakan kompresi kedua di atas kompresi videonya sendiri, yang tidak
+      masalah untuk pratinjau dan tidak untuk apa pun yang disunting
+      sesudahnya."""
+
+[[howto]]
+title = "Ambil satu, atau ambil serangkaian."
+body = """
+ Satu bingkai langsung masuk ke
+      unduhan Anda. "Setiap N detik" menelusuri klip sekali dan mengambil gambar
+      diam di setiap tanda &mdash; berguna untuk lembar kontak dan gambar mini
+      &mdash; dan hasilnya keluar sebagai satu ZIP, bukan seratus permintaan
+      simpan."""
+
+[[faq]]
+q = "Apakah video saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca dan didekode oleh peramban Anda sendiri di perangkat
+        keras Anda sendiri. Alat ini tidak punya sisi server, dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya &mdash; tidak satu pun milik situs
+        ini. Cabut koneksi internet dan tetap ambil sebuah bingkai kalau Anda
+        lebih suka memeriksa daripada diberi tahu."""
+
+[[faq]]
+q = "Apa sebenarnya arti &quot;kualitas penuh&quot;?"
+a = """
+        Dua hal. Gambar diamnya disimpan pada resolusi asli videonya, bukan pada
+        ukuran pratinjau di halaman &mdash; klip 4K memberi gambar
+        3840&nbsp;x&nbsp;2160. Dan dengan PNG dipilih, bingkainya disimpan persis
+        seperti keluar dari dekoder, jadi file itu memuat gambar yang dimuat
+        videonya, tanpa putaran kompresi kedua di atasnya. Tangkapan layar
+        jendela pemutar tidak memberi keduanya: ia seukuran jendela, diambil
+        setelah pemutar menskalakan dan mengelola warnanya."""
+
+[[faq]]
+q = "Dari format video apa saja saya bisa mengambil bingkai?"
+a = """
+        MP4, M4V, dan MOV dibaca langsung, apa pun isinya: H.264, HEVC, AV1, atau
+        VP9, selama peramban Anda bisa mendekode kodek itu. Itulah jalur yang
+        persis, tempat alat ini mengalamati bingkai satu per satu. Apa pun lain
+        yang bisa diputar peramban Anda &mdash; yang paling jelas WebM &mdash;
+        ditangani dengan mencari posisi di pemutar dan menggambar apa yang
+        ditampilkannya, yang tetap menyimpan gambar ukuran penuh tapi mendarat
+        pada bingkai yang dipilih pemutar, bukan yang Anda minta. File yang tidak
+        bisa dibaca maupun diputar peramban, yang dalam praktiknya berarti AVI,
+        WMV, FLV, dan sebagian besar MKV, ditolak dengan pesan."""
+
+[[faq]]
+q = "Bisakah saya melangkah satu bingkai sekali waktu?"
+a = """
+        Pada MP4, bisa, persis: alat ini membaca daftar bingkai milik file itu
+        sendiri, jadi tombol panah bergerak di antara gambar-gambar yang memang
+        ada di dalamnya &mdash; termasuk pada klip yang laju bingkainya
+        berubah-ubah, di mana langkah tetap seperseratus tiga puluh detik akan
+        melenceng. Di jalur pemutaran tidak ada daftar seperti itu, jadi satu
+        langkah adalah geseran kira-kira satu bingkai dan halaman ini
+        mengatakannya."""
+
+[[faq]]
+q = "Kenapa video ponsel saya yang tegak sudah menghadap benar di sini?"
+a = """
+        Karena rotasinya diterapkan dengan sengaja. Ponsel merekam melintang dan
+        menulis seperempat putaran ke dalam file alih-alih memutar pikselnya,
+        jadi bingkai yang diserahkan dekoder terbaring miring dan setiap pemutar
+        memutarnya dalam perjalanan ke layar Anda. Alat yang melewati langkah itu
+        menyimpan gambar yang masuk akal dari momen yang benar, dalam keadaan
+        miring. Alat ini membaca putaran itu dari jalurnya dan menerapkannya
+        sebelum apa pun digambar."""
+
+[[faq]]
+q = "Adakah batas ukuran atau durasi videonya?"
+a = """
+        Tidak ada batas yang tertanam di alat ini, dan file tidak dibaca ke
+        memori sekaligus &mdash; ia ditelusuri beberapa megabyte sekali jalan,
+        dan itulah sebabnya klip panjang terbuka secepat klip pendek. Gambar diam
+        yang Anda ambil ditahan di halaman sampai Anda mengunduhnya, jadi batas
+        praktisnya adalah beberapa ratus PNG 4K, bukan videonya sendiri."""
+
+[[faq]]
+q = "Bisakah saya mengubah ukuran atau memangkas gambarnya sesudahnya?"
+a = """
+        Tidak di sini, tapi di sebelah. Alat ini menyimpan bingkainya apa adanya;
+        mengubah ukuran atau bentuknya adalah pekerjaan terpisah dengan
+        keputusannya sendiri, dan
+        <a href="../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a> melakukan
+        keduanya, juga tanpa mengunggah apa pun. Memperkecil filenya tanpa
+        mengubah gambarnya adalah
+        <a href="../kompres-gambar/">Kompresor Gambar</a>."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang video Anda."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript. Pengambilan yang persis per bingkai memerlukan peramban dengan WebCodecs; selain itu kembali ke pencarian posisi di pemutar."
+description = "Simpan bingkai mana pun dari sebuah video sebagai PNG, JPEG, atau WebP ukuran penuh di peramban. MP4, MOV, dan M4V dibaca bingkai demi bingkai lewat WebCodecs sehingga bingkai persis yang diminta itulah yang disimpan; apa pun lain yang bisa diputar peramban ditangkap dari pemutarnya. Tidak ada yang diunggah."
+features = [
+  "Menyimpan gambar diam dari video MP4, MOV, M4V, dan WebM",
+  "Sumber H.264, HEVC, AV1, dan VP9, didekode lewat WebCodecs",
+  "Melangkah bingkai demi bingkai lewat daftar bingkai milik file itu sendiri",
+  "PNG untuk salinan persis bingkainya, atau JPEG dan WebP untuk yang lebih kecil",
+  "Satu gambar diam setiap N detik, diunduh bersama sebagai satu ZIP",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan video di sini"
+hint = "atau klik untuk menelusuri &mdash; MP4, MOV, M4V, WebM, dan apa pun lain yang bisa diputar peramban ini"

--- a/locales/id/tools/hash-checksum.html
+++ b/locales/id/tools/hash-checksum.html
@@ -1,0 +1,191 @@
+<!--
+  tools/hash-checksum/body.html, in Indonesian.
+
+  Every id, class, data-algorithm, data-slot, data-read and data-outcome below
+  is what src/main.js reaches for, so they are the same in every language. Only
+  the words change.
+-->
+<main>
+  <!--
+    Three steps, and the third one is the reason anybody is here.
+
+    Computing a checksum is not the job. Finding out whether the file you just
+    downloaded is the file the publisher signed is the job, and a page that
+    stops at "here is your hash" leaves the last and only difficult part -
+    comparing sixty-four characters by eye - to the visitor. So the comparison
+    is a step of its own, it accepts the checksum in whatever shape it was
+    published in, and it answers in a sentence rather than in a colour.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah file</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <section class="card" id="run-card">
+    <h2><span class="step">2</span> Checksum-nya</h2>
+    <p class="card-lede">
+      MD5 dan SHA-256 dihitung secara bawaan, karena berdua mereka mencakup
+      hampir setiap halaman unduhan yang ada. Centang yang lain dan file dibaca
+      lagi untuknya &mdash; membaca adalah bagian yang lambat, jadi semua yang
+      dicentang sebelum file dipilih keluar dari satu kali jalan atasnya.
+    </p>
+
+    <fieldset class="algorithms">
+      <legend class="visually-hidden">Checksum mana yang dihitung</legend>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="md5" checked>
+        <span class="algorithm-name">MD5</span>
+        <span class="algorithm-note">Benturan sudah murah sejak 2004. Tetap angka yang dicetak di sebelah separuh unduhan di internet.</span>
+      </label>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="sha1">
+        <span class="algorithm-name">SHA-1</span>
+        <span class="algorithm-note">Dipatahkan di depan umum pada 2017. Tetap cara Git menamai sebuah objek, dan tetap ada di banyak halaman rilis.</span>
+      </label>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="sha256" checked>
+        <span class="algorithm-name">SHA-256</span>
+        <span class="algorithm-note">Arti sebuah checksum hari ini. Setiap distribusi yang menerbitkan satu menerbitkan yang ini.</span>
+      </label>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="sha384">
+        <span class="algorithm-name">SHA-384</span>
+        <span class="algorithm-note">SHA-512 yang dipendekkan. Kebanyakan muncul di atribut integrity pada tag skrip.</span>
+      </label>
+
+      <label class="algorithm">
+        <input type="checkbox" data-algorithm="sha512">
+        <span class="algorithm-name">SHA-512</span>
+        <span class="algorithm-note">Lebih lebar, dan tidak lebih kuat dengan cara apa pun yang pernah penting dalam praktik. Sebagian proyek tetap menerbitkannya.</span>
+      </label>
+    </fieldset>
+
+    <div class="progress" id="progress" hidden>
+      <div class="progress-track" role="progressbar" id="progress-track"
+           aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+        <span class="progress-fill" id="progress-fill"></span>
+      </div>
+      <p class="progress-line">
+        <span id="progress-text" role="status" aria-live="polite"></span>
+        <button type="button" id="stop" class="ghost danger">Hentikan</button>
+      </p>
+    </div>
+
+    <p class="stopped" id="stopped" hidden>
+      Dihentikan. Tidak ada yang dihitung untuk file ini.
+      <button type="button" id="restart" class="ghost">Mulai lagi</button>
+    </p>
+
+    <div class="results" id="results" hidden>
+      <div class="toolbar">
+        <h3 class="file-name" id="file-name">&mdash;</h3>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Salin semuanya</button>
+          <button type="button" id="download-checksums" class="ghost">Simpan sebagai file</button>
+        </div>
+      </div>
+
+      <p class="file-facts" id="file-facts"></p>
+
+      <ul class="digests" id="digests">
+        <li class="digest" data-algorithm="md5" hidden>
+          <span class="digest-name">MD5</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>cocok</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>berbeda</span>
+          <button type="button" class="ghost" data-slot="copy">Salin</button>
+        </li>
+        <li class="digest" data-algorithm="sha1" hidden>
+          <span class="digest-name">SHA-1</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>cocok</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>berbeda</span>
+          <button type="button" class="ghost" data-slot="copy">Salin</button>
+        </li>
+        <li class="digest" data-algorithm="sha256" hidden>
+          <span class="digest-name">SHA-256</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>cocok</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>berbeda</span>
+          <button type="button" class="ghost" data-slot="copy">Salin</button>
+        </li>
+        <li class="digest" data-algorithm="sha384" hidden>
+          <span class="digest-name">SHA-384</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>cocok</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>berbeda</span>
+          <button type="button" class="ghost" data-slot="copy">Salin</button>
+        </li>
+        <li class="digest" data-algorithm="sha512" hidden>
+          <span class="digest-name">SHA-512</span>
+          <code class="digest-value" data-slot="value"></code>
+          <span class="digest-verdict is-match" data-slot="match" hidden>cocok</span>
+          <span class="digest-verdict is-differs" data-slot="differs" hidden>berbeda</span>
+          <button type="button" class="ghost" data-slot="copy">Salin</button>
+        </li>
+      </ul>
+
+      <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+    </div>
+  </section>
+
+  <section class="card" id="compare-card">
+    <h2><span class="step">3</span> Periksa terhadap seharusnya berapa</h2>
+    <p class="card-lede">
+      Tempelkan checksum yang diberikan halaman unduhan kepada Anda. Bentuknya
+      tidak masalah &mdash; hex telanjang, keluaran <code>sha256sum</code>,
+      seluruh file <code>SHA256SUMS</code>, bentuk
+      <code>SHA256 (file) = &hellip;</code>, atau atribut <code>integrity</code>
+      dari sebuah tag skrip. Algoritma mana itu mengikuti panjangnya, jadi tidak
+      ada yang perlu dipilih.
+    </p>
+
+    <label class="visually-hidden" for="expected">Checksum yang seharusnya dimilikinya</label>
+    <textarea id="expected" rows="3" spellcheck="false" autocapitalize="off"
+              autocomplete="off"
+              placeholder="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"></textarea>
+
+    <p class="expected-read" id="expected-read" role="status" aria-live="polite" hidden>
+      <span data-read="one">Itu sebuah <b data-slot="algorithm"></b>.</span>
+      <span data-read="many">Itu sebuah daftar. Ada <b data-slot="count"></b> checksum di dalamnya.</span>
+      <span data-read="stray">Itu <b data-slot="length"></b> karakter hex, dan tidak satu pun dari ini sepanjang itu. Salinan yang kehilangan ujungnya adalah alasan yang biasa.</span>
+      <span data-read="nothing">Tidak ada di dalamnya yang tampak seperti checksum.</span>
+    </p>
+
+    <div class="verdict" id="verdict" hidden>
+      <p class="verdict-line good" data-outcome="match">
+        <span class="verdict-mark">&#10003;</span>
+        <span>Ini file yang digambarkan checksum itu. <b data-slot="algorithm"></b>-nya sama dengan yang Anda tempelkan, karakter demi karakter.</span>
+      </p>
+      <p class="verdict-line good" data-outcome="renamed">
+        <span class="verdict-mark">&#10003;</span>
+        <span>Byte-nya cocok, tapi barisnya berbeda. Yang Anda tempelkan menyebut ini <b data-slot="name"></b>, dan file yang Anda pilih bernama lain. Entah ia diganti nama dalam perjalanan kepada Anda, entah ia bukan unduhan yang Anda maksud untuk diperiksa &mdash; <b data-slot="algorithm"></b>-nya benar bagaimanapun.</span>
+      </p>
+      <p class="verdict-line bad" data-outcome="mismatch">
+        <span class="verdict-mark">&#10007;</span>
+        <span>Ini <b>bukan</b> file yang digambarkan checksum itu. <b data-slot="algorithm"></b>-nya berbeda, jadi byte-nya berbeda: unduhan yang terputus, versi yang salah, atau cermin yang membagikan sesuatu yang lain. Ambil lagi sebelum Anda menjalankannya.</span>
+      </p>
+      <p class="verdict-line" data-outcome="waiting">
+        <span class="verdict-mark">&hellip;</span>
+        <span>Sedang menghitung <b data-slot="algorithm"></b> untuk dibandingkan.</span>
+      </p>
+      <p class="verdict-line" data-outcome="nofile">
+        <span class="verdict-mark">&hellip;</span>
+        <span>Pilih sebuah file di atas dan bagian ini akan mengatakan apakah ia cocok.</span>
+      </p>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/hash-checksum.toml
+++ b/locales/id/tools/hash-checksum.toml
@@ -1,0 +1,360 @@
+#
+# Hash dan Checksum - Bahasa Indonesia.
+#
+# Overrides for tools/hash-checksum/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama algoritma, nama perintah (sha256sum, certutil), dan nama file
+# (SHA256SUMS) tetap dalam bentuk Latinnya: itulah yang diketik dan dicari
+# orang. "Checksum" juga dipakai apa adanya - itu kata yang tertulis di halaman
+# unduhan yang sedang dilihat pembaca.
+#
+
+name = "Hash dan Checksum"
+heading = "Hash&nbsp;dan&nbsp;checksum <span class=\"h1-kw\">&mdash; MD5, SHA-1, SHA-256, SHA-512</span>"
+tagline = "Periksa sebuah unduhan terhadap angka yang dicetak penerbitnya, tanpa mengirimnya ke siapa pun."
+
+title = "Alat Checksum SHA-256 &amp; MD5 &mdash; Verifikasi Unduhan, Tanpa Unggah"
+description = "Hitung MD5, SHA-1, SHA-256, SHA-384, atau SHA-512 file apa pun dan bandingkan dengan checksum yang diterbitkan halaman unduhan. File dibaca di peramban Anda dan tidak pernah diunggah, pada ukuran berapa pun."
+og_title = "Verifikasi sebuah unduhan tanpa mengunggahnya ke siapa pun"
+og_description = "MD5, SHA-1, SHA-256, SHA-384, dan SHA-512, dihitung di peramban Anda sendiri. Tempelkan checksum yang dicetak penerbitnya dan halaman ini mengatakan apakah cocok. Tanpa batas ukuran, karena file dibaca sepotong demi sepotong."
+og_image_alt = "Hash dan Checksum - verifikasi unduhan di peramban Anda, tanpa unggah"
+
+pledge = """
+    Sebuah checksum adalah aritmetika atas byte file Anda, dan itu dikerjakan di
+    sini, di halaman ini, di prosesor Anda sendiri. File dibaca dari disk Anda
+    empat megabyte sekali jalan dan setiap potongan dibuang begitu selesai
+    dihitung, jadi tidak ada yang pernah dirakit di mana pun &mdash; tidak di
+    memori, dan pasti tidak di sebuah server. Tidak ada server di ujung lain
+    halaman ini untuk menerima sebuah file, bahkan seandainya ada sesuatu di
+    sini yang menginginkannya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu periksa sebuah file. Tidak satu pun permintaan membawa satu byte pun
+      darinya, atau namanya, atau ukurannya. Atau cabut koneksi internet dan
+      tetap periksa satu."""
+
+read_first = """
+, <code>src/md5.js</code>, <code>src/sha1.js</code>,
+      <code>src/sha256.js</code>, dan <code>src/sha512.js</code> untuk empat
+      fungsi kompresinya, <code>src/blocks.js</code> untuk pengisian yang mereka
+      pakai bersama, dan <code>src/hash.js</code> untuk perulangan yang membaca
+      file Anda sepotong demi sepotong &mdash; tidak satu pun punya baris yang
+      bisa menjangkau jaringan."""
+
+howto_heading = "Cara memeriksa unduhan terhadap checksum-nya"
+
+card = """
+            Hitung MD5, SHA-1, SHA-256, SHA-384, atau SHA-512 sebuah file dan
+            bandingkan dengan yang dicetak halaman unduhannya. Ukuran berapa
+            pun: file dibaca sepotong demi sepotong, tidak pernah ditahan
+            utuh."""
+
+[words]
+plural = "file"
+choose = "sebuah file"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa batas ukuran"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "File Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya ada.
+      Dulu ini tertulis <code>connect-src 'none'</code>, yang mutlak; memasang
+      iklan memakan itu, dan mengatakannya adalah bagian dari kesepakatan."""
+
+[[privacy]]
+title = "File tidak pernah ditahan utuh, pada ukuran berapa pun."
+body = """
+ Ia dibaca empat megabyte sekali jalan
+      dan setiap potongan dihitung ke dalam keadaan berjalan lalu dibuang. Jadi
+      memori yang dipakai halaman ini sama saja untuk image disk empat puluh
+      gigabyte dan untuk sebuah file teks, dan tidak ada ukuran di mana ia
+      menyerah. Itu juga sebabnya <code>crypto.subtle.digest</code> milik
+      peramban tidak dipakai: ia menuntut seluruh file ada di memori sekaligus,
+      dan justru batas itulah yang tidak ingin dimiliki alat ini."""
+
+[[privacy]]
+title = "Lima algoritma, lima file di repositori ini."
+body = """
+ <code>src/md5.js</code>,
+      <code>src/sha1.js</code>, <code>src/sha256.js</code>, dan
+      <code>src/sha512.js</code> adalah spesifikasi yang diterbitkan, ditulis
+      keluar, sekitar enam puluh baris masing-masing, dengan tabel konstantanya
+      dituliskan alih-alih dihitung supaya tidak ada bagian dari jawabannya yang
+      bisa bergantung pada peramban Anda. Masing-masing diperiksa terhadap vektor
+      uji resminya dan terhadap implementasi milik sistem operasi sebelum
+      dikirim."""
+
+[[privacy]]
+title = "Checksum yang Anda tempelkan juga tidak dikirim ke mana pun."
+body = """
+ Ia dibandingkan di sini, di halaman ini,
+      terhadap digest yang dihitung di sini. Tidak ada apa pun tentang
+      perbandingan itu &mdash; bukan nilainya, bukan apakah ia cocok, bukan nama
+      file-nya &mdash; yang dibacakan kepada siapa pun. Itu lebih penting
+      daripada kedengarannya: sebuah checksum ditambah nama file memberi tahu
+      siapa pun yang mengumpulkannya persis versi mana dari perangkat lunak mana
+      yang baru saja Anda unduh."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang file Anda: bukan
+      file-nya, bukan namanya, ukurannya, atau digest mana pun. Setiap baris yang
+      membaca atau meng-hash satu byte disajikan dari asal ini dan terdaftar di
+      repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau file Anda. Tidak ada
+      yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan setiap bagian
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana: alat yang
+      mengirim file Anda ke tempat lain untuk di-hash akan berhenti begitu Anda
+      mencabut koneksi."""
+
+[[howto]]
+title = "Pilih file-nya."
+body = """
+ Jatuhkan ke pemilih file, atau pilih sendiri.
+      Ia dibaca langsung dari disk Anda sepotong demi sepotong; tidak ada yang
+      dikirim ke mana pun saat Anda melakukannya, dan tidak ada ukuran di mana
+      halaman ini menyerah."""
+
+[[howto]]
+title = "Biarkan ia membaca."
+body = """
+ MD5 dan SHA-256 dihitung secara bawaan, dalam
+      satu kali jalan. Batangnya menunjukkan sudah sejauh mana ia menelusuri file
+      dan secepat apa itu berjalan &mdash; image disk yang besar memakan waktu
+      kira-kira selama menyalinnya, karena jumlah bacaannya sama."""
+
+[[howto]]
+title = "Tempelkan seharusnya berapa."
+body = """
+ Apa pun yang diberikan halaman unduhan
+      kepada Anda, dalam bentuk apa pun: hex telanjang, satu baris keluaran
+      <code>sha256sum</code>, seluruh file <code>SHA256SUMS</code>, atau atribut
+      <code>integrity</code> dari sebuah tag skrip. Algoritma mana itu mengikuti
+      panjangnya, dan kotak yang tepat mencentang dirinya sendiri."""
+
+[[howto]]
+title = "Baca jawabannya, bukan warnanya."
+body = """
+ Halaman ini mengatakan dalam satu kalimat
+      apakah ini file yang digambarkan checksum itu. Cocok berarti byte-nya sama
+      persis dengan yang diukur penerbitnya. Tidak cocok berarti tidak, dan
+      unduhannya harus diambil lagi sebelum dibuka."""
+
+[[howto]]
+title = "Ambil checksum-nya kalau Anda butuh."
+body = """
+ Salin satu, salin semuanya, atau simpan
+      sebagai file teks kecil dalam bentuk bertanda yang ditulis alat baris
+      perintah, sehingga nama algoritmanya ikut bersama angkanya."""
+
+[[faq]]
+q = "Apakah file saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca dari disk Anda oleh peramban Anda sendiri dan di-hash di
+        prosesor Anda sendiri, empat megabyte sekali jalan. Alat ini tidak punya
+        sisi server, dan <code>Content-Security-Policy</code> halaman ini
+        menyebut satu per satu setiap alamat yang boleh dihubunginya &mdash;
+        tidak satu pun milik situs ini. Cabut koneksi jaringan dan ia tetap
+        bekerja."""
+
+[[faq]]
+q = "Adakah batas ukurannya?"
+a = """
+        Tidak. File tidak pernah ditahan utuh: ia dibaca sepotong demi sepotong
+        dan setiap potongan dihitung lalu dibuang, jadi image disk empat puluh
+        gigabyte memakai memori beberapa megabyte yang sama dengan sebuah file
+        teks. Yang dimakannya adalah waktu, dan halaman ini memberi tahu Anda
+        berapa sambil berjalan.
+        <br><br>
+        Inilah alasan algoritmanya ditulis di sini alih-alih diserahkan ke
+        <code>crypto.subtle.digest</code> milik peramban, yang akan lebih cepat.
+        Panggilan itu mengambil seluruh pesan dalam satu penyangga dan tidak ada
+        cara memberinya sebuah file sepotong demi sepotong, jadi memakainya akan
+        menaruh file terbesar yang bisa Anda periksa pada belas kasihan berapa
+        banyak memori yang kebetulan diizinkan untuk tab ini. Di ponsel itu
+        beberapa ratus megabyte, dan file yang paling ingin diperiksa orang
+        adalah image disk."""
+
+[[faq]]
+q = "Checksum-nya cocok. Apa sebenarnya yang sudah dibuktikan?"
+a = """
+        Bahwa byte di disk Anda adalah byte yang diukur seseorang ketika ia
+        menuliskan angka itu. Tidak lebih, dan batasnya layak disebut dengan
+        tepat.
+        <br><br>
+        Itu membuktikan unduhannya tidak terpotong, tidak rusak oleh disk yang
+        buruk, dan tidak ditukar dengan sesuatu yang lain dalam perjalanan. Itu
+        <strong>tidak</strong> membuktikan file-nya aman, karena penerbit bisa
+        mengukur malware seakurat apa pun yang lain. Dan itu membuktikan sangat
+        sedikit kalau checksum-nya datang dari halaman yang sama, lewat koneksi
+        yang sama, dengan file-nya: siapa pun yang bisa mengubah yang satu bisa
+        mengubah yang lain. Sebuah checksum paling bernilai ketika ia sampai
+        kepada Anda lewat jalur yang berbeda &mdash; file <code>SHA256SUMS</code>
+        bertanda tangan, pengumuman rilis sebuah distribusi, cermin kedua, atau
+        pengelola paket yang memang sudah mengetahuinya."""
+
+[[faq]]
+q = "Tidak cocok. Sekarang bagaimana?"
+a = """
+        Unduh lagi dulu, dari tempat yang sama. Transfer yang terputus atau
+        dilanjutkan adalah penyebab yang jauh paling umum, dan salinan kedua
+        biasanya menyelesaikannya.
+        <br><br>
+        Kalau salinan kedua memberi jawaban salah yang sama, periksa apakah Anda
+        membandingkan terhadap baris yang tepat: halaman rilis mencantumkan
+        beberapa file, dan checksum untuk versi ARM tidak akan pernah cocok
+        dengan yang x86. Lalu periksa nomor versinya. Kalau semua itu sudah benar
+        dan tetap tidak cocok, jangan buka file-nya. Ambil dari cermin yang
+        berbeda dan bandingkan kedua checksum-nya satu sama lain."""
+
+[[faq]]
+q = "Saya harus pakai yang mana?"
+a = """
+        Yang mana pun yang dicetak penerbitnya. Inti dari latihan ini adalah
+        membandingkan terhadap angka mereka, dan Anda tidak bisa memilihkan angka
+        mereka untuk mereka.
+        <br><br>
+        Kalau Anda yang menghasilkan checksum alih-alih memeriksanya, pakai
+        SHA-256. MD5 dan SHA-1 keduanya rusak dalam pengertian yang penting: dua
+        file berbeda dengan digest yang sama bisa dibangun dengan sengaja, dalam
+        hitungan jam untuk MD5 dan dengan biaya sedang untuk SHA-1. Itu tidak
+        membuatnya tidak berguna terhadap kecelakaan &mdash; unduhan yang
+        terpotong tidak akan berbenturan dengan aslinya secara kebetulan &mdash;
+        tapi itu berarti keduanya tidak bisa memberi tahu Anda bahwa tidak ada
+        yang mengutak-atik. SHA-384 dan SHA-512 baik-baik saja dan dalam praktik
+        tidak lebih baik; keduanya ada di sini karena sebagian proyek
+        menerbitkannya."""
+
+[[faq]]
+q = "Kenapa MD5 ada di sini kalau ia sudah rusak?"
+a = """
+        Karena itulah yang masih dicetak. Cermin unduhan, unduhan firmware,
+        halaman perangkat lunak universitas, dan sangat banyak situs vendor
+        menerbitkan MD5 dua puluh tahun lalu dan tidak pernah menengok halaman
+        itu lagi, dan alat yang menolak menghitungnya berarti menolak menjawab
+        pertanyaan yang sebenarnya dibawa pengunjungnya.
+        <br><br>
+        Yang bisa dilakukannya sebagai gantinya adalah mengatakan apa nilai
+        jawabannya, dan itulah yang dilakukan catatan di sebelah kotak
+        centangnya. MD5 yang cocok tetap menyingkirkan kemungkinan unduhan yang
+        rusak. Ia tidak menyingkirkan kemungkinan yang disengaja."""
+
+[[faq]]
+q = "Format apa saja yang bisa saya tempelkan ke kotak pembanding?"
+a = """
+        Semua yang lazim, dan ia sendiri yang menentukan mana yang mana.
+        <br><br>
+        Hex telanjang, dengan atau tanpa spasi di dalamnya. Satu baris keluaran
+        <code>md5sum</code> atau <code>sha256sum</code>, dengan nama file
+        sesudahnya. Seluruh file <code>SHA256SUMS</code> berisi empat puluh
+        baris, dan dalam hal itu baris yang menyebut nama file Anda yang dipakai.
+        Bentuk BSD, <code>SHA256 (disk.iso) = &hellip;</code>. Label di depannya,
+        seperti <code>SHA-256: &hellip;</code>. Dan atribut integritas
+        subsumber, <code>sha384-&hellip;</code>, yang berupa base64 alih-alih hex
+        dan didekode sebelum dibandingkan.
+        <br><br>
+        Algoritma mana itu datang dari panjangnya: 32 karakter hex adalah MD5,
+        40 adalah SHA-1, 64 adalah SHA-256, 96 adalah SHA-384, dan 128 adalah
+        SHA-512. Tidak ada dua yang sama panjangnya, jadi tidak ada yang perlu
+        dipilih dan tidak ada yang bisa salah."""
+
+[[faq]]
+q = "Apakah ia memberi jawaban yang sama dengan sha256sum atau certutil?"
+a = """
+        Ya, byte demi byte. Ini adalah spesifikasi yang pasti dengan vektor uji
+        yang diterbitkan, dan setiap algoritma di sini diperiksa terhadap vektor
+        itu dan terhadap implementasi milik sistem operasi pada setiap build.
+        <br><br>
+        Satu-satunya perbedaan yang akan Anda lihat adalah penyajiannya.
+        <code>certutil -hashfile</code> di Windows mencetak dengan huruf besar
+        dan menyisipkan spasi; halaman ini mencetak huruf kecil, yang dipakai
+        hampir setiap penerbit. Perbandingannya mengabaikan keduanya, jadi
+        checksum yang disalin dari certutil cocok dengan yang huruf kecil
+        ditempelkan di sini."""
+
+[[faq]]
+q = "Bisakah saya memeriksa dua file satu sama lain?"
+a = """
+        Bisa, dengan satu langkah tambahan: periksa yang pertama, salin
+        checksum-nya, lalu pilih yang kedua dan tempelkan checksum itu ke
+        kotaknya. Kalau kedua file identik, halaman ini akan mengatakannya.
+        <br><br>
+        Itu layak diketahui untuk kasus yang diam-diam paling cocok bagi checksum
+        &mdash; memutuskan apakah salinan di drive cadangan benar-benar file yang
+        sama dengan yang di laptop, ketika keduanya mengaku berukuran sama dan
+        bertanggal sama."""
+
+[[faq]]
+q = "Apakah ia mengubah file saya?"
+a = """
+        Tidak. Alat ini hanya membaca. Tidak ada file keluaran, tidak ada
+        pengodean ulang, dan tidak ada yang ditulis kembali &mdash; satu-satunya
+        yang bisa Anda unduh adalah file teks kecil berisi daftar checksum-nya.
+        File asli Anda tidak tersentuh di disk Anda, yang juga merupakan jawaban
+        jujur atas apa yang terjadi kalau Anda menutup tab."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, dan tidak ada masa uji coba.
+        Tidak ada batas ukuran file dan tidak ada batas berapa banyak file yang
+        Anda periksa. Situs ini memasang iklan, dan itulah yang membiayainya;
+        iklan tidak diberi apa pun tentang file Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim file Anda ke tempat lain untuk di-hash akan
+        berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Hitung checksum MD5, SHA-1, SHA-256, SHA-384, atau SHA-512 file apa pun di peramban, dan bandingkan dengan nilai yang diterbitkan sebuah halaman unduhan. File dibaca sepotong demi sepotong dan tidak pernah diunggah."
+features = [
+  "MD5, SHA-1, SHA-256, SHA-384, dan SHA-512, dalam satu kali jalan atas file",
+  "Tanpa batas ukuran: file dibaca sepotong demi sepotong dan tidak pernah ditahan utuh",
+  "Tempelkan nilai yang diharapkan dalam bentuk terbitan apa pun dan ia menentukan sendiri algoritmanya",
+  "Membaca keluaran sha256sum, file SHA256SUMS, bentuk bertanda BSD, dan atribut integrity",
+  "Mengatakan dalam satu kalimat apakah file-nya cocok, bukan sekadar lewat warna",
+  "Salin satu checksum, semuanya, atau simpan sebagai file teks bertanda",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa mengubah file Anda",
+]
+
+[picker]
+title = "Jatuhkan sebuah file di sini"
+hint = "atau klik untuk menelusuri &mdash; file apa pun, ukuran berapa pun, tidak ada yang diunggah"

--- a/locales/id/tools/heic-to-jpg.html
+++ b/locales/id/tools/heic-to-jpg.html
@@ -1,0 +1,133 @@
+<!--
+  tools/heic-to-jpg/body.html, in Indonesian.
+
+  Every id, class, option value and data-phrase key below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file-nya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih foto HEIC Anda</h2>
+
+    <p class="card-lede">
+      Langsung dari ponselnya, dari sebuah cadangan, atau disalin dari sebuah
+      kartu memori. File-nya dibaca di sini, di mesin ini, dan gambarnya
+      didekodekan di sini juga &mdash; tidak ada langkah unggah di halaman ini
+      dan tidak ada server di belakangnya.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Keluarkan semua dari daftar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; apa yang keluar -->
+  <section class="card" id="options-card">
+    <h2><span class="step">2</span> Sebutkan apa yang Anda mau kembali</h2>
+
+    <fieldset class="options">
+      <legend>Formatnya</legend>
+
+      <div class="option-row">
+        <label for="format-select">Tulis gambarnya sebagai</label>
+        <select id="format-select">
+          <option value="image/jpeg" selected>JPEG &mdash; terbuka di mana saja, termasuk hal-hal yang dibuat abad ini karena kekeliruan</option>
+          <option value="image/png">PNG &mdash; tanpa kehilangan, dan beberapa kali lipat ukurannya</option>
+          <option value="image/webp">WebP &mdash; lebih kecil daripada JPEG pada kualitas yang sama, dan hanya peramban masa kini</option>
+        </select>
+      </div>
+
+      <div class="option-row" id="quality-row">
+        <label for="quality">Kualitas</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="50" max="100" step="1" value="92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+
+      <p class="field-summary" id="format-note"></p>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Detail fotonya</legend>
+
+      <label class="check">
+        <input type="checkbox" id="keep-exif" checked>
+        <span>
+          <strong>Simpan tanggal, kamera, dan setelannya</strong>
+          <span class="check-note">
+            Disalin persis seperti yang ditulis ponselnya, sehingga foto hasilnya
+            tetap terurut menurut hari pengambilannya alih-alih hari
+            pengubahannya. Ini termasuk koordinat GPS-nya kalau fotonya
+            memilikinya &mdash; daftar di atas mengatakan foto Anda yang mana
+            saja. Matikan ini dan JPEG-nya keluar tanpa apa-apa di dalamnya
+            selain gambarnya.
+          </span>
+        </span>
+      </label>
+
+      <p class="field-summary">
+        Bagaimanapun juga, tidak ada di sini yang dibacakan kepada siapa pun:
+        pilihannya soal apa yang masuk ke file yang Anda dapatkan kembali, bukan
+        soal apa yang dilakukan halaman ini terhadapnya. Kalau Anda ingin
+        menelusuri tagnya dengan rinci, atau membuangnya dari foto yang sudah
+        berupa JPEG,
+        <a href="../hapus-data-exif/">Penampil &amp; Penghapus EXIF</a> adalah
+        alatnya.
+      </p>
+    </fieldset>
+  </section>
+
+  <!-- Langkah 3 &mdash; satu klik itu -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Ubah</h2>
+
+    <div class="run-row">
+      <button type="button" id="convert-all" class="primary big" disabled>Ubah</button>
+    </div>
+
+    <!--
+      The decoder's own status line. This page is the only one on the site that
+      carries a codec, so it is the only one with anything to report here, and
+      saying where the megabyte came from is the point: it is served from this
+      origin, it is cached with the rest of the page, and it is what makes the
+      offline promise hold on a browser that cannot open a HEIC at all.
+    -->
+    <p id="engine-status" class="engine-status" role="status" aria-live="polite"></p>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Sudah diubah</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Unduh semuanya sebagai satu zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The frame's "offline" line says only that this page keeps working. What is
+    worth saying here is what that covers: the HEIC decoder is a vendored
+    WebAssembly engine, and it is cached with the rest. A key defined here wins
+    over the frame's one - see shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="offline.ready">siap &mdash; dekodernya ikut disinggahkan,
+      jadi ini bekerja dengan jaringan tercabut.</span>
+  </div>
+</main>

--- a/locales/id/tools/heic-to-jpg.toml
+++ b/locales/id/tools/heic-to-jpg.toml
@@ -1,0 +1,309 @@
+#
+# HEIC ke JPG - Bahasa Indonesia.
+#
+# Overrides for tools/heic-to-jpg/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama teknis (HEIC, HEIF, HEVC, AV1, EXIF, libheif, WebAssembly) tetap seperti
+# adanya, dan tautan di dalam jawaban memakai slug bahasa Indonesia dari
+# locale.toml, kalau tidak build akan menolaknya.
+#
+
+name = "HEIC ke JPG"
+heading = "HEIC&nbsp;ke&nbsp;JPG <span class=\"h1-kw\">&mdash; ubah foto iPhone</span>"
+tagline = "Foto yang dibuat iPhone, dalam format yang bisa dibuka apa saja."
+
+title = "Pengubah HEIC ke JPG &mdash; Gratis, Tanpa Unggah"
+description = "Ubah foto HEIC dari iPhone menjadi JPG di peramban Anda. Dekodernya berjalan di mesin Anda sendiri: tidak ada yang diunggah, tanpa akun, jalan tanpa internet, dan tanggal serta detail kameranya bisa ikut serta."
+og_title = "Ubah foto HEIC menjadi JPG tanpa mengunggahnya"
+og_description = "Pengubah yang tidak menginginkan foto Anda. Dekoder HEIC-nya disajikan dari halaman ini dan berjalan di mesin Anda sendiri, jadi gambarnya tidak pernah meninggalkannya."
+og_image_alt = "HEIC ke JPG - foto iPhone dalam format yang bisa dibuka apa saja"
+
+pledge = """
+    Pendekodeannya berjalan di peramban Anda sendiri, di perangkat keras Anda
+    sendiri. HEIC adalah satu-satunya format gambar yang tidak akan dibuka
+    peramban dengan sendirinya, jadi halaman ini membawa dekodernya serta
+    &mdash; sekitar 1,4 MB, disajikan dari situs ini, disimpan di singgahan
+    setelah kunjungan pertama. Itulah alasan utuh mengapa setiap pengubah HEIC
+    lain meminta Anda mengunggah: mereka menaruh kodeknya di sebuah server dan
+    foto Anda harus pergi ke sana. Yang ini menaruh kodeknya di sini saja. Tidak
+    ada fitur jaringan di halaman ini sama sekali, dan tidak ada server di ujung
+    lainnya untuk menerima sebuah foto."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu ubah sebuah foto. Anda akan melihat file milik halaman ini dimuat,
+      termasuk dekodernya, dan tidak satu pun permintaan membawa foto, gambar
+      mini, nama file, atau satu byte pun dari yang Anda pilih. Atau muat
+      halamannya sekali, cabut koneksi internet, dan ubah satu folder penuh."""
+
+read_first = """
+, <code>src/heif.js</code> untuk cara
+      dekodernya dimuat dan apa yang boleh dilakukannya, <code>src/boxes.js</code>
+      untuk pembacaan wadah yang menemukan metadata fotonya, dan
+      <code>src/exif.js</code> untuk apa yang terjadi pada metadata itu dalam
+      perjalanannya ke sebuah JPEG. Mesinnya sendiri adalah
+      <code>vendor/libheif.js</code>, tanpa perubahan, dengan lisensinya di
+      sebelahnya."""
+
+howto_heading = "Cara mengubah foto HEIC menjadi JPG"
+
+card = """
+            Foto yang dibuat iPhone, dalam format yang bisa dibuka apa saja
+            &mdash; didekodekan di mesin Anda sendiri, bukan di server siapa
+            pun."""
+
+[words]
+plural = "foto"
+choose = "sebuah foto"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa batas ukuran"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Foto Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut satu
+      per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak satu pun
+      milik situs ini. Tidak ada titik akhir di sini tempat file Anda bisa
+      dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya ada."""
+
+[[privacy]]
+title = "Dekodernya datang dari sini, dan ia tidak pergi ke mana-mana."
+body = """
+ HEIC adalah HEVC di
+      dalam sebuah format wadah, dan tidak ada peramban selain Safari yang akan
+      mendekodekannya, jadi halaman ini mengirimkan <code>libheif</code> yang
+      dikompilasi menjadi WebAssembly &mdash; sekitar 1,4 MB, disimpan di
+      repositori ini, disajikan dari asal ini, dan disinggahkan oleh service
+      worker seperti setiap file lain di sini. Ia tidak diambil dari sebuah CDN,
+      karena itu akan menaruh pihak ketiga di jalur setiap kunjungan dan akan
+      membuat alat ini berhenti bekerja tanpa internet. Binernya berada di dalam
+      skripnya alih-alih di sebelahnya justru supaya tidak ada pengambilan yang
+      dibutuhkan untuk memulainya."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada
+      <code>fetch</code>, tidak ada <code>XMLHttpRequest</code>, dan tidak ada
+      <code>sendBeacon</code> di file mana pun yang ditulis untuk alat ini.
+      Mesin yang disertakan, seperti setiap hasil bangun Emscripten, memuat jalur
+      pemuat yang akan mengambil sebuah <code>.wasm</code> dari sebuah URL; jalur
+      itu tidak ditempuh, karena binernya sudah ada di tangan &mdash; dan
+      seandainya pun ditempuh, <code>connect-src</code> menyebut titik akhir
+      pengukuran milik Google dan tidak lebih, jadi peramban akan menolaknya.
+      Kebijakannya adalah buktinya, bukan janjinya."""
+
+[[privacy]]
+title = "Metadatanya dibaca di sini dan dilaporkan kepada Anda."
+body = """
+ Daftar di halaman ini
+      mengatakan apa yang dibawa setiap foto &mdash; tanggalnya, kameranya, dan
+      apakah ada koordinat GPS di dalamnya &mdash; karena itu hal yang mungkin
+      ingin Anda ketahui sebelum menyerahkan JPEG-nya kepada orang lain. Itu
+      dibaca dari file-nya oleh <code>src/boxes.js</code> di peramban ini,
+      ditampilkan di halaman ini, dan ditulis ke JPEG Anda atau ditinggalkan,
+      sepenuhnya terserah Anda. Tidak ada peristiwa analitik khusus di repositori
+      ini yang membawa nama file, tanggal, koordinat, atau jumlah."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan
+      pengukuran berasal dari Google, dan tombol donasi dari Buy Me a Coffee.
+      Tidak satu pun diberi apa pun tentang foto Anda. Setiap baris yang membaca,
+      mendekodekan, atau menulis sebuah file disajikan dari asal ini dan terdaftar
+      di repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Muat halamannya sekali lalu putuskan koneksi
+      jaringan, dan alat ini tidak berubah &mdash; dekodernya ikut disinggahkan.
+      Itulah bukti yang paling sederhana, dan di sini ia lebih kuat daripada di
+      mana pun lagi di situs ini: pengubah yang mengirim foto Anda pergi untuk
+      didekodekan sama sekali tidak akan sanggup melakukannya."""
+
+[[howto]]
+title = "Pilih foto HEIC Anda."
+body = """
+ Jatuhkan ke pemilihnya atau pilih sendiri,
+      langsung dari cadangan sebuah ponsel atau sebuah folder di desktop.
+      Peramban membacanya langsung dari disk Anda; tidak ada yang dikirim ke mana
+      pun saat Anda melakukannya. Daftarnya mengatakan masing-masing itu apa dan
+      apa isinya."""
+
+[[howto]]
+title = "Periksa apa yang dibawa fotonya."
+body = """
+ Setiap baris menyebutkan tanggal
+      pengambilannya, kameranya, dan &mdash; dengan warna hijau, karena inilah
+      bagian yang layak diperhatikan &mdash; apakah file-nya menyimpan koordinat
+      GPS. Itu dibaca dari wadahnya tanpa mendekodekan gambarnya, jadi tidak ada
+      biayanya dan langsung muncul."""
+
+[[howto]]
+title = "Pilih format, dan putuskan soal detailnya."
+body = """
+ JPEG kecuali Anda punya
+      alasan: itulah format yang terbuka di mana saja, dan itulah seluruh maksud
+      pengubahan ini. Penggeser kualitasnya ada di 92, yaitu setelan ketika
+      sebuah foto sulit dibedakan dari aslinya. Kotak centangnya menentukan
+      apakah tanggal, kamera, dan lokasinya ikut serta."""
+
+[[howto]]
+title = "Tekan \"Ubah\", lalu unduh."
+body = """
+ Dekodernya datang pada pengubahan
+      pertama &mdash; sekitar 1,4 MB, sekali saja &mdash; dan setiap foto sesudah
+      itu didekodekan dan ditulis di mesin Anda sendiri. Satu file memberi Anda
+      sebuah tombol unduh; beberapa file memberi Anda sebuah zip juga."""
+
+[[faq]]
+q = "Apakah foto saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File-nya dibaca, didekodekan, dan ditulis oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya fitur
+        jaringan dalam bentuk apa pun &mdash; ia tidak pernah mengambil apa pun
+        dan tidak pernah mengirim apa pun &mdash; dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+        ini. Satu-satunya yang memang dimuat adalah dekodernya sendiri, dan itu
+        datang dari situs ini, sekali, sebelum foto Anda terlibat sama
+        sekali."""
+
+[[faq]]
+q = "Kenapa halaman ini mengunduh 1,4 MB pada kali pertama?"
+a = """
+        Karena HEIC adalah satu-satunya format gambar yang tidak akan dibuka
+        sebuah peramban. Ia adalah sebuah bingkai HEVC di dalam sebuah wadah, dan
+        hanya Safari, di perangkat keras Apple, yang punya dekoder untuknya;
+        Chrome, Firefox, dan Edge langsung menolak file-nya. Jadi sebuah pengubah
+        HEIC butuh dekoder dari suatu tempat, dan ada dua tempat asalnya: sebuah
+        server, atau halamannya. Setiap pengubah lain memilih server, dan itu
+        persis alasan mereka semua butuh foto Anda diunggah. Yang ini membawa
+        <code>libheif</code> yang dikompilasi menjadi WebAssembly sebagai
+        gantinya. Ia disajikan dari situs ini, disinggahkan setelah kunjungan
+        pertama, dan itulah seluruh harga dari foto Anda yang tidak pergi ke mana
+        pun."""
+
+[[faq]]
+q = "Apakah JPEG-nya menyimpan tanggal, kamera, dan lokasinya?"
+a = """
+        Kalau Anda mau, dan itu sebuah kotak centang di halaman ini. Kalau
+        dibiarkan menyala, blok EXIF-nya disalin dari HEIC-nya dan ditulis ke
+        JPEG-nya persis seperti yang ditulis ponselnya, sehingga foto hasilnya
+        tetap terurut menurut hari pengambilannya alih-alih hari pengubahannya
+        &mdash; dan itulah keluhan yang biasa muncul soal pengubah HEIC. Satu tag
+        diubah dan hanya satu: orientasinya, yang disetel ke "tegak", karena
+        rotasinya sudah diterapkan pada pikselnya dan penampil yang menerapkannya
+        sekali lagi akan memiringkan setiap foto potret. Matikan kotak centangnya
+        dan JPEG-nya keluar dengan gambarnya saja dan tidak ada yang lain."""
+
+[[faq]]
+q = "Apakah ia membuang koordinat GPS?"
+a = """
+        Ia memberi tahu Anda bahwa koordinatnya ada, lalu melakukan apa pun yang
+        Anda minta. Baris untuk setiap foto mengatakan apakah file-nya membawa
+        koordinat sebelum Anda mengubah apa pun, dan itu lebih dari yang
+        dilakukan ponselnya. Melepas centang "simpan tanggal, kamera, dan
+        setelannya" meninggalkannya di luar JPEG bersama semua yang lain;
+        membiarkannya tercentang membawanya ikut. Kalau yang Anda inginkan adalah
+        menelusuri tagnya dengan rinci, atau membuangnya dari foto yang sudah
+        berupa JPEG, <a href="../hapus-data-exif/">Penampil &amp; Penghapus
+        EXIF</a> adalah alatnya, dan ia melakukannya tanpa mengompres ulang
+        gambarnya."""
+
+[[faq]]
+q = "Apakah gambarnya dikompres ulang?"
+a = """
+        Ya, dan memang harus: HEIC dan JPEG adalah kodek yang berbeda, jadi tidak
+        ada cara berpindah dari satu ke yang lain tanpa mendekodekan gambarnya
+        dan mengodekannya lagi. Yang bisa Anda kendalikan adalah seberapa mahal
+        biayanya. Penggeser kualitasnya secara bawaan di 92, yaitu ketika sebuah
+        foto sangat sulit dibedakan dari aslinya, dan PNG ada di menunya untuk
+        kasus ketika Anda tidak ingin kehilangan apa pun dan tidak keberatan
+        file-nya menjadi lima sampai sepuluh kali lipat ukurannya."""
+
+[[faq]]
+q = "Bagaimana kalau file-nya bernama .jpg tapi sebenarnya HEIC?"
+a = """
+        Tetap bekerja. Setiap file yang dijatuhkan di sini dikenali dari byte
+        pertamanya alih-alih dari namanya, karena namanya adalah apa pun yang
+        diputuskan aplikasi terakhir yang menyentuhnya &mdash; dan sebuah HEIC
+        yang datang bernama ".jpg" adalah salah satu cara paling umum orang
+        berakhir mencari alat seperti ini. File yang memang sungguh JPEG atau PNG
+        ditolak dengan pesan yang mengatakannya, alih-alih diubah menjadi salinan
+        dirinya sendiri."""
+
+[[faq]]
+q = "Bisakah ia mengubah sebuah Live Photo, atau sebuah burst?"
+a = """
+        Gambar diamnya, bisa. Sebuah HEIC bisa menyimpan lebih dari satu gambar,
+        dan setiap yang disimpannya diubah dan dinamai sesuai aslinya dengan
+        sebuah angka di ujungnya. Bagian video dari sebuah Live Photo adalah file
+        terpisah yang disimpan ponselnya di sebelah HEIC-nya, jadi ia tidak ada di
+        sini untuk diubah. Peta kedalaman dan gambar mini ada di dalam wadahnya
+        tapi bukan gambar yang diminta siapa pun, dan dibiarkan saja."""
+
+[[faq]]
+q = "Kenapa ia tidak mau menerima AVIF saya?"
+a = """
+        Karena tidak ada yang perlu dilakukan padanya. AVIF adalah wadah yang sama
+        dengan HEIC dengan AV1 di dalamnya alih-alih HEVC, dan setiap peramban
+        masa kini mendekodekannya secara bawaan &mdash; jadi sebuah pengubah akan
+        mengirimkan satu megabita mesin untuk menyelesaikan masalah yang tidak
+        Anda punya. Kalau Anda butuh sebuah AVIF sebagai JPEG,
+        <a href="../kompres-gambar/">Kompresor Gambar</a> dan
+        <a href="../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a> sama-sama
+        membaca AVIF dan menulis JPEG memakai dekoder yang sudah dimiliki
+        peramban Anda."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis; tidak ada akun, tidak ada masuk, tidak ada masa uji coba, tidak
+        ada tanda air. Tidak ada batas jumlah atau ukuran file-nya juga, karena
+        tidak ada server yang membayarnya &mdash; pekerjaannya terjadi di mesin
+        Anda sendiri. Situs ini memasang iklan, dan itulah yang membiayainya;
+        iklan tidak diberi apa pun tentang foto Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya, dekodernya termasuk. Muat halamannya sekali, lalu putuskan koneksi
+        internet dan ia terus bekerja pada foto Anda persis seperti sebelumnya.
+        Itu juga bukti terkuat yang tersedia bahwa tidak ada yang diunggah:
+        pengubah yang mengirim HEIC Anda pergi untuk didekodekan akan berhenti
+        pada saat Anda mencabut koneksi, dan yang ini tidak."""
+
+[schema]
+description = "Ubah foto HEIC dan HEIF dari sebuah iPhone menjadi JPEG, PNG, atau WebP. Dekoder HEIC-nya adalah WebAssembly yang disajikan dari halamannya sendiri, jadi gambarnya didekodekan di mesin Anda sendiri dan tidak pernah diunggah. Tanggal, kamera, dan lokasinya bisa dibawa ke dalam JPEG-nya atau ditinggalkan."
+features = [
+  "Mengubah HEIC dan HEIF menjadi JPEG, PNG, atau WebP",
+  "Mendekodekan di peramban, di peramban mana pun - bukan hanya Safari",
+  "Tidak ada yang diunggah, dan alatnya bekerja dengan jaringan tercabut",
+  "Membawa tanggal, kamera, dan GPS ke dalam JPEG-nya, atau meninggalkannya",
+  "Mengatakan foto mana yang menyimpan koordinat GPS sebelum apa pun diubah",
+  "Membetulkan tag orientasi, jadi foto potret tidak keluar miring",
+  "Mengenali file dari isinya, jadi HEIC bernama .jpg tetap bekerja",
+  "Mengubah setiap gambar di sebuah burst atau Live Photo, bukan hanya yang pertama",
+  "Kumpulan, dengan semua hasilnya dalam satu zip",
+]
+
+[picker]
+title = "Jatuhkan foto HEIC di sini"
+hint = "atau klik untuk menelusuri &mdash; .heic dan .heif, apa pun kebetulan namanya"

--- a/locales/id/tools/id-photo.html
+++ b/locales/id/tools/id-photo.html
@@ -1,0 +1,255 @@
+<!--
+  tools/id-photo/body.html, in Indonesian.
+
+  Every id, class, name, option value and data-phrase key below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; fotonya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih fotonya</h2>
+
+    <p class="card-lede">
+      Gambar apa pun yang bisa dibuka peramban Anda. Foto ponsel yang diambil di
+      depan dinding polos, di bawah cahaya siang, dari jarak sekitar satu setengah
+      meter adalah yang menjadi dasar penulisan hampir semua aturan ini &mdash;
+      dan ia dibaca langsung dari disk Anda, tidak dikirim ke mana pun.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="loaded" class="loaded-row" hidden>
+      <p id="loaded-name" class="loaded-name"></p>
+      <button type="button" id="clear-photo" class="ghost danger">Pilih yang lain</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; aturannya -->
+  <section class="card" id="spec-card">
+    <h2><span class="step">2</span> Pilih negara dan dokumennya</h2>
+
+    <p class="card-lede">
+      Setiap angka di bawah adalah persyaratan resmi, disalin dari lembaga yang
+      disebut di bawahnya. Tidak ada di daftar ini yang ditebak, dan tidak ada di
+      dalamnya yang diambil dari jaringan &mdash; ia sebuah tabel di
+      <code>src/specs.js</code>, disajikan bersama halamannya.
+    </p>
+
+    <div class="option-row">
+      <label for="spec">Spesifikasi</label>
+      <select id="spec"></select>
+    </div>
+
+    <dl class="spec-facts" id="spec-facts"></dl>
+
+    <ul class="spec-notes" id="spec-notes"></ul>
+
+    <p class="spec-source" id="spec-source"></p>
+
+    <!--
+      Only the "Anywhere else" entry unlocks these. A country's own numbers are
+      not editable on purpose: an editable rule is a rule somebody can quietly
+      break and then believe they met.
+    -->
+    <details class="custom-panel" id="custom-panel" hidden>
+      <summary>Angkanya, untuk Anda ketik sendiri</summary>
+      <div class="numbers">
+        <label>Lebar (mm)<input type="number" id="custom-width" min="10" max="200" step="0.1" value="35"></label>
+        <label>Tinggi (mm)<input type="number" id="custom-height" min="10" max="200" step="0.1" value="45"></label>
+        <label>DPI<input type="number" id="custom-dpi" min="72" max="1200" step="1" value="300"></label>
+      </div>
+      <div class="numbers">
+        <label>Kepala, terkecil (mm)<input type="number" id="custom-head-min" min="1" step="0.1" value="31.5"></label>
+        <label>Kepala, terbesar (mm)<input type="number" id="custom-head-max" min="1" step="0.1" value="36"></label>
+        <label>Latar
+          <select id="custom-background">
+            <option value="white">Putih polos</option>
+            <option value="off-white">Putih atau putih gading</option>
+            <option value="light-grey" selected>Abu-abu muda polos</option>
+            <option value="cream">Abu-abu muda atau krem</option>
+          </select>
+        </label>
+      </div>
+      <div class="numbers">
+        <label>Lebar unggahan (px)<input type="number" id="custom-px-width" min="20" max="4000" step="1" value="413"></label>
+        <label>Tinggi unggahan (px)<input type="number" id="custom-px-height" min="20" max="4000" step="1" value="531"></label>
+        <label>Terkecil (KB)<input type="number" id="custom-min-kb" min="0" max="10000" step="1" value="0"></label>
+        <label>Terbesar (KB)<input type="number" id="custom-max-kb" min="1" max="10000" step="1" value="200"></label>
+      </div>
+      <p class="hint-line">
+        KB di sini berarti 1024 byte, dan itulah yang dimaksud formulir-formulir
+        ini dengannya.
+      </p>
+    </details>
+  </section>
+
+  <!-- Langkah 3 &mdash; pembingkaiannya -->
+  <section class="card" id="frame-card">
+    <h2><span class="step">3</span> Tandai wajahnya, dan periksa pembingkaiannya</h2>
+
+    <p id="frame-empty" class="field-summary">Pilih sebuah foto dan kotak pangkasnya muncul di sini.</p>
+
+    <div id="frame-controls" hidden>
+      <p class="stage-hint" id="mark-hint">
+        Puncak kepala, dagu, dan masing-masing pupil. Keempat titik itulah seluruh
+        yang diukur sebuah aturan, jadi pangkasannya diambil dari di mana pun
+        mereka berakhir &mdash; seret yang mendarat keliru, lalu tekan
+        <strong>Paskan kotaknya</strong>. Menemukannya berarti membaca gambarnya
+        sendiri: tepi kepala Anda terhadap dinding di belakangnya, dan bercak
+        yang lebih gelap tempat mata berada. Tidak ada model di dalamnya dan tidak
+        ada yang diambil, dan ia sebuah posisi awal alih-alih sebuah putusan, dan
+        itulah sebabnya ia milik Anda untuk dibetulkan dan sebabnya panel di bawah
+        mengatakan mana dari keempatnya yang tidak bisa diukurnya.
+      </p>
+
+      <!--
+        Where the dots come from. Choosing "I'll place them" leaves them exactly
+        where they are and stops anything moving them again; moving one by hand
+        chooses it for you, because at that point they are yours.
+      -->
+      <div class="mark-mode" role="radiogroup" aria-label="Dari mana keempat titiknya datang">
+        <label class="mark-mode-choice">
+          <input type="radio" name="mark-mode" id="mark-mode-auto" value="auto" checked>
+          <span>Carikan untuk saya</span>
+        </label>
+        <label class="mark-mode-choice">
+          <input type="radio" name="mark-mode" id="mark-mode-manual" value="manual">
+          <span>Saya yang menaruhnya</span>
+        </label>
+      </div>
+
+      <p id="mark-note" class="hint-line" role="status" aria-live="polite"></p>
+      <ul id="mark-why" class="mark-why"></ul>
+
+      <!-- The crop box, its overlay and the four marks are all added here by
+           src/cropper.js and src/marks.js. The stage is given the picture's own
+           shape, so everything on it can be positioned in percentages. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <div class="frame-actions">
+        <button type="button" id="fit-box" class="primary">Paskan kotaknya ke aturan</button>
+        <button type="button" id="reset-marks" class="ghost">Cari wajahnya lagi</button>
+        <button type="button" id="whole-photo" class="ghost">Kotak terbesar yang muat</button>
+      </div>
+
+      <p id="short-note" class="hint-line" hidden></p>
+
+      <!-- The live readout. Every line is measured from the box as it stands,
+           by the same function whether the box was fitted or dragged. -->
+      <ul class="checks" id="geometry-checks"></ul>
+
+      <p id="resample-note" class="field-summary"></p>
+    </div>
+  </section>
+
+  <!-- Langkah 4 &mdash; latarnya -->
+  <section class="card" id="background-card">
+    <h2><span class="step">4</span> Latarnya</h2>
+
+    <p class="card-lede" id="background-lede">
+      Dibaca dari sebuah pita melintang di bagian atas pangkasannya dan turun di
+      kedua sisinya, di atas bahu &mdash; bagian bingkai yang seharusnya tidak
+      berisi apa pun selain latar. Diukur dalam CIE Lab alih-alih dalam RGB,
+      karena dua abu-abu berjarak empat puluh satuan RGB tidak bisa dibedakan,
+      sedangkan empat puluh satuan biru adalah warna yang berbeda.
+    </p>
+
+    <div class="swatches" id="swatches" hidden>
+      <div class="swatch">
+        <span class="swatch-chip" id="swatch-found"></span>
+        <span class="swatch-label">Punya Anda terbaca sebagai<br><output id="swatch-found-text"></output></span>
+      </div>
+      <div class="swatch">
+        <span class="swatch-chip" id="swatch-wanted"></span>
+        <span class="swatch-label">Yang diminta aturannya<br><output id="swatch-wanted-text"></output></span>
+      </div>
+    </div>
+
+    <ul class="checks" id="background-checks"></ul>
+
+    <p class="field-note" id="background-note"></p>
+  </section>
+
+  <!-- Langkah 5 &mdash; file-nya -->
+  <section class="card" id="save-card">
+    <h2><span class="step">5</span> Simpan</h2>
+
+    <p class="card-lede" id="ready-line"></p>
+
+    <div class="settings">
+      <div class="field" id="dpi-field">
+        <label for="print-dpi">Resolusi cetak</label>
+        <select id="print-dpi">
+          <option value="300">300 dpi &mdash; batas bawah yang dinyatakan hampir setiap aturan</option>
+          <option value="600">600 dpi &mdash; yang akan dipakai lab foto yang bagus</option>
+        </select>
+        <p class="field-note" id="dpi-note"></p>
+      </div>
+
+      <div class="field" id="paper-field">
+        <label for="paper">Lembar untuk mencetak</label>
+        <select id="paper"></select>
+        <p class="field-note" id="paper-note"></p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make" class="primary big" disabled>Buat file-nya</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Selesai</h3>
+      </div>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+  <!--
+    The words script puts on the page, sitting in the markup so that a
+    translator meets them where they meet the rest of the page. The
+    `marks.why.*` lines are listed under the note, one line each, rather than
+    strung into the sentence: joining them would have meant a separator in the
+    JavaScript, and a semicolon is not the mark half these languages join with.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="marks.measured">Keempatnya diukur dari fotonya &mdash;
+      puncak kepala dari siluet kepala Anda, pupilnya dari gelapnya, dagunya dari
+      tempat rahang bertemu leher. Periksa juga, dan seret yang mendarat keliru:
+      pangkasannya diambil dari tempat mereka berakhir.</span>
+    <span data-phrase="marks.rough">Sudah ditaruh, tapi tidak semuanya terukur.
+      Periksa keempat titiknya sebelum Anda memaskan kotaknya.</span>
+    <span data-phrase="marks.none">Tidak ada yang bisa diukur pada foto ini.
+      Titik-titiknya berada di posisi awalnya sebagai gantinya &mdash; seret
+      mereka ke puncak kepala, dagu, dan masing-masing pupil.</span>
+    <span data-phrase="marks.manual">Keempat titiknya milik Anda, dan tidak ada
+      yang akan memindahkannya. Seret masing-masing ke puncak kepala, dagu, dan
+      sebuah pupil.</span>
+    <span data-phrase="marks.edited">Anda sudah memindahkan sebuah titik, jadi
+      keempatnya sekarang milik Anda. &ldquo;Carikan untuk saya&rdquo; mengukur
+      gambarnya sekali lagi.</span>
+
+    <span data-phrase="marks.why.background">Dinding di belakang Anda tidak cukup
+      polos untuk mencari tepi sebuah kepala terhadapnya.</span>
+    <span data-phrase="marks.why.top">Kepalanya keluar dari bagian atas fotonya,
+      jadi tidak ada puncak kepala yang bisa ditemukan.</span>
+    <span data-phrase="marks.why.eyes">Matanya tidak bisa dikenali, jadi keduanya
+      ditaruh di tempat kepala seukuran ini biasanya memilikinya.</span>
+    <span data-phrase="marks.why.chin">Dagunya datang dari proporsi sebuah kepala
+      alih-alih dari siluet kepala yang ini.</span>
+
+    <span data-phrase="marks.button.again">Cari wajahnya lagi</span>
+    <span data-phrase="marks.button.back">Kembalikan titiknya</span>
+  </div>
+</main>

--- a/locales/id/tools/id-photo.toml
+++ b/locales/id/tools/id-photo.toml
@@ -1,0 +1,382 @@
+#
+# Pembuat Pas Foto - Bahasa Indonesia.
+#
+# Overrides for tools/id-photo/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Pas foto" adalah kata yang dipakai orang di sini untuk foto dokumen, jadi
+# itulah yang dipakai di seluruh halaman. Nama lembaga dan formulir (ICAO,
+# SSC, UPSC, Diversity Visa, Schengen) tetap seperti adanya, karena itulah yang
+# tertulis di formulirnya.
+#
+
+name = "Pembuat Pas Foto"
+heading = "Pembuat&nbsp;Pas&nbsp;Foto <span class=\"h1-kw\">&mdash; foto paspor dan visa sesuai aturan</span>"
+tagline = "Pilih negaranya. Ia menerapkan aturan negara itu, persis."
+
+title = "Pembuat Pas Foto Paspor &mdash; Ukuran Setiap Negara, Tanpa Unggah"
+description = "Buat foto paspor atau visa sesuai aturan resmi negara Anda: mm dan DPI yang tepat, hamparan tinggi kepala dan garis mata secara langsung, pemeriksaan latar, lembar cetak 4x6, dan file yang dipadatkan ke batas KB milik portalnya. Tidak ada yang diunggah."
+og_title = "Buat foto paspor sesuai aturan persis negara Anda, tanpa mengunggahnya"
+og_description = "Pilih sebuah negara dan sebuah dokumen, dan kotak pangkasnya mengambil tinggi kepala dan garis mata aturan itu. Mencetak pada ukuran dan DPI yang diwajibkan, dan menulis file unggahannya di dalam rentang KB yang dituntut formulirnya."
+og_image_alt = "Pembuat Pas Foto - foto paspor dan visa sesuai aturan, tanpa unggah"
+
+pledge = """
+    Pemangkasan, pengukuran, pembacaan latar, dan pencetakannya semua berjalan
+    di peramban Anda sendiri, di perangkat keras Anda sendiri, memakai pengode
+    JPEG yang memang sudah dibawanya. Alat ini tidak punya fitur jaringan dalam
+    bentuk apa pun &mdash; tidak ada yang diambil, tidak ada yang dikirim
+    &mdash; dan seandainya pun ada, tidak ada server di ujung lain halaman ini
+    untuk menerima foto wajah Anda."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu buat sebuah foto paspor. Tidak satu pun permintaan membawa gambar,
+      gambar mini, nama file, atau satu byte pun dari yang Anda pilih. Atau
+      cabut koneksi internet dan tetap buat satu."""
+
+read_first = """
+, <code>src/specs.js</code> untuk buku aturannya
+      &mdash; angka resmi setiap negara, lengkap dengan lembaga penerbitnya dan
+      tanggal masing-masing dibaca &mdash; <code>src/detect.js</code> untuk cara
+      keempat titiknya ditemukan &mdash; sebuah siluet dan dua bercak gelap,
+      tanpa model apa pun di dalamnya &mdash; <code>src/geometry.js</code> untuk
+      hitungan yang mengubah keempat titik itu menjadi sebuah pangkasan, dan
+      <code>src/jpeg.js</code> untuk dua suntingan header yang menaruh resolusi
+      cetaknya ke dalam file dan menaikkan unggahan yang terlalu kecil sampai
+      ukuran yang dituntut sebuah formulir."""
+
+howto_heading = "Cara membuat pas foto paspor yang tidak dikembalikan"
+
+card = """
+            Pilih sebuah negara dan sebuah dokumen, dan kotak pangkasnya
+            mengambil tinggi kepala dan garis mata aturan itu. Mencetak pada mm
+            dan DPI yang tepat, dengan lembar 4&nbsp;&times;&nbsp;6, dan
+            memadatkan unggahannya ke dalam rentang KB milik portalnya."""
+
+[words]
+plural = "foto"
+choose = "sebuah foto"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Foto wajah Anda tidak pernah meninggalkan mesin ini."
+body = """
+ Di sini hal itu lebih
+      penting daripada di kebanyakan alat: file yang ditangani halaman ini adalah
+      gambar wajah Anda, dan yang hendak Anda lakukan dengannya menyebutkan
+      negara yang dokumennya Anda ajukan.
+      <code>Content-Security-Policy</code> menyebut satu per satu setiap alamat
+      yang boleh dihubungi halaman ini, dan tidak satu pun milik situs ini. Tidak
+      ada titik akhir di sini tempat foto Anda bisa dikumpulkan."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada
+      <code>fetch</code>, tidak ada <code>XMLHttpRequest</code>, dan tidak ada
+      <code>sendBeacon</code> di mana pun di dalam <code>src/</code>. Buku
+      aturannya adalah sebuah tabel di <code>src/specs.js</code>, disajikan
+      bersama halamannya dan disinggahkan bersamanya &mdash; tidak ada daftar
+      negara yang perlu dicari dan tidak ada apa pun untuk memeriksa foto Anda
+      dari jauh."""
+
+[[privacy]]
+title = "Wajahnya ditemukan tanpa model wajah."
+body = """
+ Tidak ada bobot yang perlu
+      diunduh, tidak ada runtime inferensi, dan tidak ada yang diambil: puncak
+      kepalanya datang dari siluet kepala Anda terhadap dinding di belakangnya,
+      pupilnya dari bercak-bercak wajah yang lebih gelap daripada sekelilingnya.
+      Tidak ada di dalamnya yang membaca warna kulit, dan itulah seluruh alasan ia
+      ditulis begitu &mdash; sebuah model yang keliru keliru secara tidak merata,
+      lebih parah pada sebagian wajah daripada yang lain. Ia sebuah posisi awal,
+      bukan sebuah putusan: halaman ini mengatakan titik mana dari keempatnya yang
+      tidak bisa diukurnya, setiap titik tetap bisa diseret, dan beralih ke
+      <em>Saya yang menaruhnya</em> mematikannya sama sekali."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan
+      pengukuran berasal dari Google, dan tombol donasi dari Buy Me a Coffee.
+      Tidak satu pun diberi apa pun tentang foto Anda, wajah Anda, atau aturan
+      negara mana yang Anda pilih. Setiap baris yang membaca, memangkas,
+      mengukur, atau menulis sebuah file disajikan dari asal ini dan terdaftar di
+      repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih fotonya."
+body = """
+ Sebuah foto ponsel di depan dinding polos, di
+      bawah cahaya siang, diambil dari jarak sekitar satu setengah meter.
+      Peramban membacanya langsung dari disk Anda; tidak ada yang dikirim ke mana
+      pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Pilih negara dan dokumennya."
+body = """
+ Panelnya lalu menampilkan ukuran
+      cetak, rentang tinggi kepala, garis mata, warna latar, dan batas unggahan
+      aturan itu &mdash; berikut lembaga asal setiap angkanya dan tanggal angka
+      itu dibaca. Tidak ada satu pun di daftar itu yang ditebak, dan apa pun yang
+      dikirimkan kepada Anda tapi tidak ada di sana masuk lewat
+      &ldquo;Di tempat lain&rdquo;."""
+
+[[howto]]
+title = "Periksa empat titik di wajah Anda."
+body = """
+ Puncak kepala, dagu, dan
+      masing-masing pupil &mdash; keempat titik itulah seluruh yang diukur
+      aturannya. Mereka ditaruh dengan mengukur gambarnya sendiri, dan baris di
+      bawahnya mengatakan mana dari keempatnya yang berhasil dan mana yang harus
+      diperhitungkan; seret yang mendarat keliru, atau beralihlah ke <em>Saya yang
+      menaruhnya</em> dan kerjakan keempatnya sendiri. Lalu tekan <em>Paskan
+      kotaknya</em> dan pangkasannya mendarat di tempat yang diinginkan negara
+      itu."""
+
+[[howto]]
+title = "Baca empat pemeriksaannya, dan latarnya."
+body = """
+ Tinggi kepala, garis mata,
+      pemusatan, dan kemiringan, masing-masing diukur dari kotaknya apa adanya
+      dan masing-masing mengatakan ke arah mana harus diseret kalau meleset.
+      Latarnya dibaca dari bagian atas dan sisi-sisi pangkasannya lalu
+      dibandingkan dengan warna yang diminta aturannya &mdash; ketidakrataan,
+      yang sebenarnya paling sering membuat foto ditolak, diukur terpisah dari
+      warnanya."""
+
+[[howto]]
+title = "Ambil ketiga file-nya."
+body = """
+ Cetakannya, pada milimeter yang tepat
+      dengan resolusinya tertulis di dalam file sehingga sebuah kios mencetaknya
+      pada ukuran yang benar. Lembarnya, dengan sebanyak mungkin salinan yang
+      muat di 4&nbsp;&times;&nbsp;6 dan tanda potong di sela-selanya. Dan
+      unggahannya, pada ukuran piksel yang dituntut portalnya dan di dalam
+      rentang KB yang ditegakkannya di kedua ujung."""
+
+[[faq]]
+q = "Apakah foto saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Gambarnya didekodekan, dipangkas, diukur, dan ditulis oleh
+        peramban Anda sendiri di perangkat keras Anda sendiri, memakai pengode
+        JPEG yang memang sudah dibawa peramban itu. Alat ini tidak punya fitur
+        jaringan dalam bentuk apa pun &mdash; ia tidak pernah mengambil apa pun
+        dan tidak pernah mengirim apa pun &mdash; dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+        ini. Di sini itu lebih berarti daripada di kebanyakan alat: file-nya
+        adalah foto wajah Anda."""
+
+[[faq]]
+q = "Negara mana saja yang tercakup?"
+a = """
+        Spesifikasi yang sejauh ini sudah disalin adalah standar ICAO itu
+        sendiri, Amerika Serikat (paspor dan pendaftaran Diversity Visa, yang
+        aturan unggahannya berbeda), Britania Raya, visa Schengen, Jerman,
+        Kanada, Australia, India (paspor, cetakan
+        35&nbsp;&times;&nbsp;45&nbsp;mm, serta foto dan tanda tangan formulir
+        SSC/UPSC), Tiongkok, dan Jepang. Setiap entri menyebutkan lembaga
+        asalnya dan tanggal ia dibaca. Selain itu masuk lewat &ldquo;Di tempat
+        lain&rdquo;, tempat setiap angkanya Anda ketik sendiri &mdash; dan
+        karena sebagian besar dunia menerbitkan menurut geometri ICAO, entri itu
+        dimulai dari sana."""
+
+[[faq]]
+q = "Bagaimana ia menemukan puncak kepala, dagu, dan mata tanpa model wajah?"
+a = """
+        Dengan memakai sesuatu yang tidak boleh diandaikan sebuah pendeteksi
+        wajah umum tapi boleh diandaikan alat ini: setiap spesifikasi ini
+        menuntut adegan yang sama &mdash; satu orang, menghadap kamera, di depan
+        dinding polos yang tercahayai rata. Jadi warna dindingnya dibaca dari
+        tepi gambarnya, semua yang bukan warna itu adalah orangnya, dan bagian
+        teratasnya adalah puncak kepala, rambut termasuk. Pupilnya ditemukan
+        sebagai pasangan bercak terbaik yang lebih gelap daripada sekelilingnya
+        sendiri, sejajar satu sama lain dan berada di kedua sisi tengah kepala
+        &mdash; sebuah perbandingan yang bersifat setempat, jadi tidak ada di
+        dalamnya yang bergantung pada warna sebuah wajah. Dagulah yang tidak bisa
+        ditemukan dengan cara ini, karena rahang terhadap leher adalah tepi lunak
+        tanpa perubahan warna di seberangnya; ia diperhitungkan dari pupilnya,
+        yang duduk hampir persis di setengah tinggi sebuah kepala, lalu
+        dicocokkan dengan siluetnya. Semuanya hitungan di
+        <code>src/detect.js</code>: tanpa bobot, tanpa runtime inferensi, tanpa
+        apa pun yang diambil, dan hitungan yang sama untuk setiap wajah yang
+        melewatinya. Bagian terakhir itulah yang penting, karena sebuah pendeteksi
+        yang dikirimkan keliru secara tidak merata &mdash; lebih parah pada
+        sebagian wajah daripada yang lain &mdash; dan orang-orang yang fotonya
+        sudah paling sering ditolak adalah yang akan dikecewakannya."""
+
+[[faq]]
+q = "Seberapa jauh saya boleh percaya pada titik yang ditaruhnya?"
+a = """
+        Cukup untuk dijadikan titik mulai, tidak cukup untuk melewatkan
+        memeriksanya. Masing-masing dari keempatnya punya foto yang membuatnya
+        keliru: dinding bermotif atau rak buku tidak meninggalkan siluet untuk
+        mencari sebuah kepala, kepala yang terpotong di atas sama sekali tidak
+        punya puncak di gambarnya, dan kacamata, poni tebal, atau mata terpejam
+        bisa menaruh pupilnya pada bagian yang salah. Jadi alat ini mengatakan
+        dengan lantang mana dari keempatnya yang diukurnya dan mana yang harus
+        diperhitungkan, menolak mentah-mentah gambar tanpa latar polos alih-alih
+        mengarang jawaban, dan membiarkan setiap titik bisa diseret. Pangkasannya
+        diambil dari tempat titik-titiknya berakhir, tidak pernah dari tempat
+        mereka bermula. Kalau Anda lebih suka menaruh keempatnya sendiri, sakelar
+        di atas gambarnya berbunyi <em>Saya yang menaruhnya</em>, dan
+        memindahkan titik mana pun dengan tangan beralih ke sana dengan
+        sendirinya &mdash; sejak saat itu mereka milik Anda dan tidak ada lagi
+        yang akan memindahkannya."""
+
+[[faq]]
+q = "Apa itu aturan tinggi kepala, dan kenapa punya saya terus gagal?"
+a = """
+        Setiap spesifikasi ini menyatakan berapa banyak bingkai yang harus diisi
+        kepalanya, diukur dari bawah dagu sampai puncak kepala, rambut termasuk
+        &mdash; biasanya 70 sampai 80 persen, yang untuk foto 45&nbsp;mm berarti
+        31,5 sampai 36&nbsp;mm. Alasan yang biasa membuatnya gagal adalah swafoto:
+        panjang lengan sekitar 60&nbsp;cm, yang membuat wajahnya melenceng dan
+        menaruh kepalanya terlalu besar di bingkainya. Alasan kedua yang biasa
+        adalah puncak kepalanya &mdash; itu bagian teratas rambutnya, bukan garis
+        rambutnya, dan menandai garis rambut membuat setiap kepala keluar terlalu
+        kecil."""
+
+[[faq]]
+q = "Kenapa file-nya harus paling sedikit 20 KB, dan bagaimana ia bisa dipadatkan?"
+a = """
+        Portal ujian India, formulir visa Tiongkok, dan unggahan paspor Britania
+        Raya sama-sama menyatakan ukuran file minimum di samping maksimumnya,
+        karena file di bawahnya biasanya sebuah gambar mini yang diunggah orang
+        karena keliru. Foto 200&nbsp;&times;&nbsp;230 adalah 46.000 piksel, dan
+        pada kualitas terbaik yang bisa ditulis sebuah peramban ia masih bisa
+        mendarat di 15&nbsp;KB, tanpa cara membuatnya lebih besar dengan
+        mengompres lebih sedikit. Jadi alat ini menambahkan sebuah segmen komentar
+        JPEG yang penuh spasi. Itu bagian dari standar JPEG, setiap dekoder
+        melewatinya, dan gambarnya sama bit demi bit &mdash; hanya file-nya yang
+        lebih panjang. Isian itu mengatakan persis begitu, dalam bahasa Inggris,
+        di dalam file-nya."""
+
+[[faq]]
+q = "Apakah ia memeriksa latarnya, dan bisakah ia menggantinya?"
+a = """
+        Ia memeriksa dan tidak akan mengganti. Warnanya dibaca dari sebuah pita
+        melintang di bagian atas pangkasannya dan turun di kedua sisinya, di atas
+        bahu, lalu dibandingkan dengan warna aturannya dalam CIE Lab alih-alih
+        dalam RGB &mdash; dua abu-abu berjarak empat puluh satuan RGB tidak bisa
+        dibedakan, sedangkan empat puluh satuan biru adalah warna yang berbeda.
+        Ketidakrataannya diukur terpisah, karena bayangan di dinding putihlah yang
+        sebenarnya membuat foto ditolak, dan itu bukan masalah warna. Mengganti
+        sebuah latar berarti menggunting seseorang keluar dari sebuah gambar, dan
+        itu sebuah model segmentasi, yang kalau buruk memakan rambut. Berdiri
+        setengah meter lebih jauh dari dinding membereskan lebih banyak dari ini
+        daripada filter mana pun."""
+
+[[faq]]
+q = "Lembar 4 x 6 itu untuk apa?"
+a = """
+        Sebuah studio foto memungut biaya lumayan untuk enam lembar. Sebuah gerai
+        cetak foto mencetak 6&nbsp;&times;&nbsp;4 dengan harga receh dan semuanya
+        bisa melakukannya. Jadi alat ini menata sebanyak mungkin salinan foto Anda
+        yang muat di kertasnya &mdash; delapan, untuk 35&nbsp;&times;&nbsp;45 di
+        atas 6&nbsp;&times;&nbsp;4 &mdash; dengan tanda potong di sela-selanya dan
+        tidak ada yang tercetak di atas sebuah gambar. Tidak ada yang diskalakan
+        agar muat: setiap salinan tepat seukuran yang diminta aturannya, karena
+        lembar yang mengecilkannya dua persen supaya satu lagi muat akan menjadi
+        delapan foto yang semuanya salah ukuran. Cetak pada 100 persen;
+        &ldquo;paskan ke halaman&rdquo;-lah yang membuat sebuah lembar keluar
+        salah."""
+
+[[faq]]
+q = "Kenapa DPI-nya penting kalau pikselnya sama saja?"
+a = """
+        Karena sebuah JPEG bisa menyatakan seberapa besar dirinya, dan kalau tidak,
+        apa pun yang mencetaknya akan menebak. Resolusinya tinggal di header JFIF,
+        dan sebuah kanvas peramban menulis header itu dengan kolom satuannya
+        disetel ke &ldquo;ini rasio aspek, bukan resolusi&rdquo;. Alat ini menulis
+        ulang beberapa byte itu sehingga file-nya menyatakan 300&nbsp;dpi, dan
+        itulah yang mengubah 413&nbsp;&times;&nbsp;531 piksel menjadi foto
+        35&nbsp;&times;&nbsp;45&nbsp;mm alih-alih sebuah gambar tanpa ukuran
+        tertentu. Tidak ada yang didekodekan untuk melakukannya dan tidak ada
+        kualitas yang dikorbankan."""
+
+[[faq]]
+q = "Bisakah ia membuat file tanda tangannya juga?"
+a = """
+        Bisa &mdash; formulir SSC dan UPSC meminta satu pada
+        140&nbsp;&times;&nbsp;60 piksel dan antara 10 sampai 20&nbsp;KB, dan itu
+        ada di daftarnya sebagai spesifikasinya sendiri. Hamparan wajahnya
+        dimatikan untuk itu, karena sebuah tanda tangan tidak punya garis mata, dan
+        yang diperiksa sebagai gantinya adalah bahwa kertasnya terang, bahwa ada
+        tinta di atasnya, dan bahwa pangkasannya tidak ikut mengambil garis bergaris
+        atau tepi halamannya. Mencapai 10&nbsp;KB adalah bagian sulit dari aturan
+        itu, bukan bertahan di bawah 20."""
+
+[[faq]]
+q = "Apakah ini menjamin permohonan saya diterima?"
+a = """
+        Tidak, dan tidak ada alat yang jujur bisa menjaminnya. Yang dilakukannya
+        adalah menerapkan angka resminya persis dan menunjukkan kepada Anda setiap
+        pengukuran yang dibuatnya, sehingga hal-hal yang diukur sebuah formulir
+        secara otomatis &mdash; ukuran piksel, ukuran file, format &mdash; sudah
+        benar, dan hal-hal yang diukur seorang pemeriksa manusia &mdash; tinggi
+        kepala, garis mata, latar &mdash; ada di hadapan Anda lengkap dengan
+        angkanya. Aturannya juga berubah: setiap spesifikasi di sini menyebutkan
+        lembaga asalnya dan kapan ia dibaca, jadi Anda bisa mencocokkannya dengan
+        formulir di depan Anda alih-alih memercayai sebuah tabel."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis; tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan tidak
+        ada tanda air tercetak melintang di wajah Anda. Tidak ada batas berapa
+        banyak foto yang Anda buat juga, karena tidak ada server yang membayarnya.
+        Situs ini memasang iklan, dan itulah yang membiayainya; iklan tidak diberi
+        apa pun tentang foto Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia terus
+        bekerja &mdash; buku aturannya adalah sebuah file yang disajikan bersama
+        halamannya, bukan sebuah pencarian. Itu juga cara paling sederhana untuk
+        membuktikan tidak ada yang diunggah: alat yang mengirim foto Anda pergi
+        untuk dipangkas akan berhenti pada saat Anda mencabut koneksi."""
+
+[schema]
+description = "Buat foto paspor, visa, atau identitas sesuai spesifikasi resmi sebuah negara di peramban. Menerapkan ukuran cetak, DPI, rentang tinggi kepala, garis mata, dan warna latar dokumen yang dipilih, menaruh puncak kepala, dagu, dan pupil dengan mengukur gambarnya alih-alih menjalankan sebuah model wajah, menampilkan hamparan dan pengukuran masing-masing secara langsung, memeriksa latarnya, menata lembar cetak 4x6 lengkap dengan tanda potong, dan menulis file unggahan pada ukuran piksel yang diwajibkan di dalam rentang KB milik portalnya. Tidak ada yang diunggah."
+features = [
+  "Buku aturan berisi spesifikasi resmi, masing-masing menyebutkan lembaganya dan tanggal ia dibaca",
+  "Geometri ICAO Doc 9303: tinggi kepala sebagai pecahan dari bingkainya, dan garis mata di atas tepi bawahnya",
+  "Kotak pangkas terkunci pada bentuk spesifikasinya, dengan pita mata dan pita dagu tergambar di dalamnya",
+  "Puncak kepala, dagu, dan kedua pupil ditemukan dari siluet kepala dan gelapnya mata, tanpa model yang dikirimkan dan tanpa apa pun yang diambil",
+  "Keempatnya tetap bisa diseret, dengan halamannya mengatakan mana yang diukurnya dan mana yang diperhitungkannya",
+  "Tinggi kepala, garis mata, pemusatan, dan kemiringan secara langsung, masing-masing mengatakan ke arah mana harus dibetulkan",
+  "Warna dan kerataan latar diukur dalam CIE Lab, dengan keduanya dilaporkan terpisah",
+  "Mencetak pada milimeter yang tepat, dengan resolusinya tertulis di dalam header JPEG",
+  "Lembar 4 x 6, 5 x 7, A4, atau Letter, berjajar dengan tanda potong di sela-selanya dan tidak ada yang menimpa gambar",
+  "File unggahan pada ukuran piksel yang diwajibkan, dicari sampai masuk rentang KB portalnya di kedua ujung",
+  "Foto formulir SSC dan UPSC pada 200 x 230 dalam 20-50 KB, dan tanda tangan pada 140 x 60 dalam 10-20 KB",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa model wajah",
+]
+
+[picker]
+title = "Jatuhkan sebuah foto di sini"
+hint = "atau klik untuk menelusuri &mdash; satu foto, JPEG, PNG, WebP, atau apa pun lain yang bisa dibuka peramban Anda"

--- a/locales/id/tools/image-to-data-uri.html
+++ b/locales/id/tools/image-to-data-uri.html
@@ -1,0 +1,148 @@
+<!--
+  tools/image-to-data-uri/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file-nya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih gambar</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Keluarkan semua dari daftar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; baris yang benar-benar ditempelkan -->
+  <section class="card" id="shape-card">
+    <h2><span class="step">2</span> Sebutkan ia akan ke mana</h2>
+
+    <p class="card-lede">
+      Sebuah data URI yang berdiri sendiri jarang menjadi yang diinginkan orang.
+      Yang mereka inginkan adalah baris yang masuk ke lembar gaya &mdash; jadi
+      pilih barisnya, dan gambarnya datang di dalamnya sudah ditandakutip. Itulah
+      bagian yang mudah salah dan yang hanya gagal pada SVG.
+    </p>
+
+    <div class="shapes" id="shapes" role="radiogroup" aria-label="Apa yang ditempelkan">
+      <label class="shape">
+        <input type="radio" name="shape" value="uri" checked>
+        <span class="shape-body">
+          <strong>Data URI-nya sendiri</strong>
+          <span class="shape-note">
+            Semua setelah komanya adalah file-nya. Tempelkan di mana pun sebuah
+            URL bisa ditaruh.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-rule">
+        <span class="shape-body">
+          <strong>Sebuah aturan CSS</strong>
+          <span class="shape-note">
+            Satu aturan utuh, dengan sebuah kelas bernama sesuai file-nya. Ubah
+            selektornya menjadi apa pun yang sebenarnya Anda gayakan.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="css-var">
+        <span class="shape-body">
+          <strong>Sebuah properti khusus CSS</strong>
+          <span class="shape-note">
+            Dideklarasikan sekali di bagian atas lembar gaya dan dipakai sebagai
+            <code>var(--nama)</code> sesering yang Anda mau. Inilah yang dipilih
+            ketika gambarnya muncul di lebih dari satu aturan.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="html">
+        <span class="shape-body">
+          <strong>Sebuah tag <code>&lt;img&gt;</code> HTML</strong>
+          <span class="shape-note">
+            Dengan ukuran pikselnya sudah diisikan, jadi halamannya tidak
+            melompat sementara sisanya dimuat.
+          </span>
+        </span>
+      </label>
+
+      <label class="shape">
+        <input type="radio" name="shape" value="markdown">
+        <span class="shape-body">
+          <strong>Markdown</strong>
+          <span class="shape-note">
+            Untuk sebuah README atau sebuah isu: gambar yang bepergian bersama
+            teksnya alih-alih butuh tempat untuk dititipkan.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary">
+      Teks <code>alt</code> sengaja dibiarkan kosong. Hanya Anda yang tahu apakah
+      gambarnya membawa makna atau sekadar hiasan, dan keterangan yang ditebak
+      dari sebuah nama file lebih buruk bagi orang yang memakai pembaca layar
+      daripada tidak ada keterangan sama sekali.
+    </p>
+
+    <fieldset class="options">
+      <legend>SVG</legend>
+
+      <label class="check">
+        <input type="checkbox" id="svg-base64">
+        <span>
+          <strong>Base64-kan SVG-nya juga</strong>
+          <span class="check-note">
+            Mati secara bawaan, karena sebuah SVG adalah teks dan base64 untuk
+            byte. Pengodean persen membiarkan markahnya terbaca di lembar gaya
+            dan biasanya seperlima lebih pendek. Nyalakan untuk rantai perkakas
+            langka yang bersikeras meminta <code>;base64</code>.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Langkah 3 &mdash; hasilnya. Sengaja tidak ada tombol di sini: pengodeannya
+       seketika, jadi tidak ada yang perlu ditunggu sebuah tekanan "ubah". -->
+  <section class="card" id="output-card">
+    <h2><span class="step">3</span> Salin</h2>
+
+    <p id="empty-note" class="card-lede">
+      Belum ada yang dipilih. Jatuhkan sebuah gambar di atas dan baris untuk
+      ditempelkan muncul di sini.
+    </p>
+
+    <div id="results" hidden>
+      <div class="results-head">
+        <p id="results-summary" class="results-summary"></p>
+        <div class="toolbar-actions">
+          <button type="button" id="copy-all" class="ghost">Salin semua</button>
+          <button type="button" id="download-all" class="ghost">Unduh sebagai satu file</button>
+        </div>
+      </div>
+
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/image-to-data-uri.toml
+++ b/locales/id/tools/image-to-data-uri.toml
@@ -1,0 +1,329 @@
+#
+# Gambar ke Data URI - Bahasa Indonesia.
+#
+# Overrides for tools/image-to-data-uri/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Tautan silang di FAQ memakai slug Indonesia dari [slugs] di locale.toml -
+# ../hapus-data-exif/, ../kompres-gambar/, dan ../ubah-ukuran-gambar/ - karena
+# locale yang sudah diterbitkan diharuskan setiap tautan internalnya mendarat
+# di halaman yang benar-benar dibangun.
+#
+# "data URI", "base64", "gzip", "EXIF", dan "XMP" tetap seperti adanya: itulah
+# yang diketik dan dicari orang.
+#
+
+name = "Gambar ke Data URI"
+heading = "Gambar&nbsp;ke&nbsp;Data&nbsp;URI <span class=\"h1-kw\">&mdash; kodekan gambar sebagai base64 untuk CSS atau HTML</span>"
+tagline = "Seluruh gambar sebagai satu baris teks. Tempelkan langsung ke CSS atau HTML."
+
+title = "Gambar ke Data URI &mdash; Kodekan Base64 untuk CSS, Gratis, Tanpa Unggah"
+description = "Ubah PNG, JPEG, SVG, atau WebP menjadi data URI yang bisa Anda tempelkan ke CSS atau HTML. SVG dikodekan dengan persen alih-alih base64, jadi ia tetap terbaca dan lebih pendek. Berjalan di peramban Anda; tidak ada yang diunggah."
+og_title = "Ubah sebuah gambar menjadi satu baris yang bisa Anda tempelkan ke CSS"
+og_description = "Base64 untuk gambar raster, pengodean persen untuk SVG, dan aturan CSS, properti khusus, atau tag img yang sudah jadi mengelilinginya. Berjalan di mesin Anda sendiri; tidak ada yang diunggah."
+og_image_alt = "Gambar ke Data URI - tempelkan gambarnya ke dalam lembar gaya"
+
+pledge = """
+    Pengodeannya berjalan di peramban Anda sendiri, di perangkat keras Anda
+    sendiri. Ia adalah aritmetika atas byte yang sudah dipegang halaman ini:
+    tanpa encoder, tanpa server, dan tanpa langkah jaringan untuk ditinggalkan.
+    Alat ini tidak punya fitur jaringan dalam bentuk apa pun &mdash; tidak ada
+    yang diambil, tidak ada yang dikirim &mdash; dan seandainya pun ada, tidak
+    ada server di ujung lain halaman ini untuk menerima sebuah gambar."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu jatuhkan sebuah gambar. Tidak satu pun permintaan membawa gambar,
+      gambar mini, nama file, atau satu byte pun dari yang Anda pilih. Atau cabut
+      koneksi internet dan tetap kodekan satu."""
+
+read_first = """
+, <code>src/encode.js</code> untuk dua pengodeannya
+      beserta alasan di balik masing-masing, <code>src/sniff.js</code> untuk
+      bagaimana tipe medianya dibaca dari file-nya sendiri alih-alih dari
+      namanya, dan <code>src/metadata.js</code> untuk pemeriksaan yang mengatakan
+      berapa banyak dari yang akan Anda tempelkan itu bukan gambarnya."""
+
+howto_heading = "Cara mengubah gambar menjadi data URI"
+
+card = """
+            Base64 untuk gambar raster, pengodean persen untuk SVG, dan aturan
+            CSS atau tag <code>&lt;img&gt;</code> yang sudah dibangun
+            mengelilinginya."""
+
+[words]
+plural = "gambar"
+choose = "sebuah gambar"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa pengodean ulang"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Gambar Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di mana
+      pun di dalam <code>src/</code>. Pengodeannya adalah <code>btoa</code> dan
+      <code>encodeURIComponent</code> &mdash; dua fungsi yang sudah dimiliki
+      peramban sejak awal; keduanya mengambil byte dan mengembalikan teks tanpa
+      pergi ke mana pun."""
+
+[[privacy]]
+title = "Pratinjaunya adalah buktinya."
+body = """
+ Gambar di sebelah setiap hasil digambar
+      dari data URI yang baru saja dibangun halaman ini, bukan dari file Anda. Ia
+      tampil karena URI-nya benar, di mesin Anda, tanpa server yang terlibat
+      &mdash; dan kalau ia tidak tampil, halaman ini mengatakannya alih-alih
+      menyerahkan sesuatu yang rusak kepada Anda."""
+
+[[privacy]]
+title = "Peringatan metadatanya berpihak pada Anda."
+body = """
+ Sebuah data URI menyalin file-nya
+      persis, jadi titik GPS sebuah foto ikut masuk ke lembar gaya Anda
+      bersamanya. Halaman ini membaca berapa banyak dari itu yang ada dan
+      memberi tahu Anda, karena alternatifnya adalah Anda mengetahuinya setelah
+      ia diserahkan ke repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google, dan tombol donasi dari Buy Me a Coffee. Tidak satu pun diberi
+      apa pun tentang gambar Anda. Setiap baris yang membaca atau mengodekan
+      sebuah file disajikan dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih gambar Anda."
+body = """
+ Jatuhkan ke pemilih file atau pilih sendiri.
+      Peramban membacanya langsung dari disk Anda; tidak ada yang dikirim ke mana
+      pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Sebutkan hasilnya akan ke mana."
+body = """
+ URI-nya sendiri, sebuah aturan CSS,
+      sebuah properti khusus, sebuah tag <code>&lt;img&gt;</code>, atau Markdown.
+      Semuanya menaruh URI-nya di dalam tanda kutip, dan itulah detail yang
+      menentukan apakah sebuah SVG sebaris berhasil atau diam-diam tidak."""
+
+[[howto]]
+title = "Baca berapa biayanya."
+body = """
+ Setiap hasil mengatakan ia menjadi berapa
+      karakter, seberapa besar itu dibanding file-nya, dan apakah menaruh sesuatu
+      seukuran itu sebaris adalah ide yang baik. Base64 menambah sepertiga;
+      apakah sepertiga itu sepadan dengan satu permintaan yang dihemat sepenuhnya
+      tergantung ukurannya, jadi halaman ini mengatakan Anda ada di sisi mana."""
+
+[[howto]]
+title = "Perhatikan peringatannya."
+body = """
+ Kalau gambarnya membawa EXIF, sebuah profil
+      warna, atau XMP, ia disebutkan namanya beserta berapa byte dari hasil Anda
+      yang berisi itu. Kalau ekstensinya bertentangan dengan format
+      sesungguhnya, halaman ini memakai formatnya dan memberi tahu Anda. Kalau
+      peramban Anda tidak bisa menggambar hasilnya, ia mengatakan itu juga."""
+
+[[howto]]
+title = "Salin, atau unduh."
+body = """
+ Satu tombol per hasil, dan satu untuk semuanya
+      sekaligus &mdash; properti khususnya keluar terbungkus dalam sebuah blok
+      <code>:root</code>, siap ditempelkan di bagian atas sebuah lembar gaya."""
+
+[[faq]]
+q = "Apakah gambar saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File dibaca dan dikodekan oleh peramban Anda sendiri di perangkat
+        keras Anda sendiri, dengan dua fungsi yang sudah dimiliki peramban. Alat
+        ini tidak punya fitur jaringan dalam bentuk apa pun &mdash; ia tidak
+        pernah mengambil apa pun dan tidak pernah mengirim apa pun &mdash; dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+        ini."""
+
+[[faq]]
+q = "Apa itu data URI?"
+a = """
+        Cara menuliskan seluruh isi sebuah file di tempat yang biasanya diisi
+        alamat web. Alih-alih <code>url("logo.png")</code>, yang menyuruh peramban
+        pergi mengambil sesuatu, Anda menulis
+        <code>url("data:image/png;base64,iVBORw0...")</code>, yang memuat
+        gambarnya sendiri. Peramban mendekodenya di tempat. Efek praktisnya adalah
+        satu permintaan lebih sedikit: gambarnya datang bersama lembar gaya atau
+        halamannya alih-alih sesudahnya."""
+
+[[faq]]
+q = "Kenapa SVG saya bukan base64?"
+a = """
+        Karena base64 adalah pengodean yang salah untuknya. Sebuah SVG adalah
+        teks, dan sebuah URL sudah bisa membawa teks &mdash; hanya segelintir
+        karakter yang harus dikaburkan. Mengodekan yang segelintir itu dengan
+        persen dan membiarkan sisanya menghasilkan URI yang biasanya seperlima
+        lebih pendek daripada base64 file yang sama, dan yang masih bisa Anda baca
+        di lembar gaya Anda: nama elemennya, warnanya, dan
+        <code>viewBox</code>-nya semua masih di sana untuk disunting. Ada sebuah
+        kotak centang untuk memaksa base64 demi rantai perkakas langka yang
+        bersikeras memintanya."""
+
+[[faq]]
+q = "Seberapa besar base64 membuat gambar saya?"
+a = """
+        Sekitar sepertiga. Tiga byte file menjadi empat karakter base64, yang
+        berarti 33% sebelum <code>data:image/png;base64,</code> di depannya. Itu
+        lantainya, dan itu tidak terhindarkan: itulah biaya menuliskan byte
+        sembarang hanya dengan karakter yang diizinkan sebuah URL. Itu juga
+        sebabnya halaman ini menampilkan jumlah karakternya di sebelah ukuran
+        file, alih-alih membiarkan Anda mengetahuinya ketika lembar gayanya sudah
+        dirilis."""
+
+[[faq]]
+q = "Kapan menaruh gambar sebaris benar-benar ide yang baik?"
+a = """
+        Ketika ia kecil dan dibutuhkan segera. Ikon 2 KB di lembar gaya yang
+        dimuat setiap halaman adalah kemenangan yang jelas: satu perjalanan
+        bolak-balik lebih sedikit, dan gambarnya sudah ada begitu CSS-nya ada.
+        Melewati sekitar 10 KB, takarannya berbalik. Gambar yang disebariskan
+        bukan lagi file terpisah, jadi ia tidak bisa disinggahkan sendiri, tidak
+        bisa diambil paralel dengan apa pun, dan diunduh utuh setiap kali file di
+        sekelilingnya berubah &mdash; foto 200 KB di sebuah lembar gaya berarti
+        200 KB yang ditambahkan ke jalur kritis setiap halaman di situs itu.
+        Halaman ini memberi tahu Anda setiap hasil jatuh di sisi mana dari garis
+        itu."""
+
+[[faq]]
+q = "Apakah gzip membatalkan tambahan dari base64?"
+a = """
+        Kurang dari yang orang duga. Base64 dari file yang sudah terkompresi
+        &mdash; dan PNG, JPEG, serta WebP semuanya begitu &mdash; sulit
+        dikompres, karena nyaris tidak ada kemubaziran tersisa untuk ditemukan
+        kompresornya; Anda biasanya mendapat kembali kira-kira sepersepuluh dari
+        sepertiga yang ditambahkan base64, bukan seluruhnya. SVG berkode persen
+        adalah kasus sebaliknya: ia masih teks, jadi ia terkompres kira-kira
+        sebaik sebelumnya, dan itu satu alasan lagi untuk tidak
+        mem-base64-kannya."""
+
+[[faq]]
+q = "Apakah ini mengubah gambar saya sama sekali?"
+a = """
+        Tidak, dan itu perbedaan yang disengaja dari kebanyakan alat di sini.
+        Tidak ada yang didekode menjadi piksel lalu dikodekan lagi: byte yang
+        datang dari disk Anda adalah byte yang masuk ke URI-nya. Sebuah JPEG tetap
+        persis JPEG yang sama, pada kualitas yang sama, dengan dimensi yang sama.
+        Itulah sebabnya hasilnya bisa disebut file yang sama alih-alih salinannya."""
+
+[[faq]]
+q = "Jadi data EXIF dan GPS saya ikut masuk ke lembar gaya juga?"
+a = """
+        Ya, dan inilah bagian yang layak dipikirkan sebelum Anda menempelkannya.
+        Karena tidak ada yang dikodekan ulang, semua yang ditulis kamera ikut
+        bepergian bersama gambarnya: lokasinya, stempel waktunya, nomor seri
+        kameranya. Pada foto ponsel itu bisa 30 KB dari file, yang menjadi 40 KB
+        base64 di jalur kritis halaman Anda, dan sebuah alamat rumah di dalam
+        sesuatu yang akan diserahkan ke sebuah repositori. Halaman ini membaca
+        berapa banyak metadata di dalam JPEG, PNG, atau WebP dan mengatakannya.
+        Untuk mengeluarkannya lebih dulu, pakai
+        <a href="../hapus-data-exif/">Penampil dan Penghapus EXIF</a>."""
+
+[[faq]]
+q = "Kenapa ia memakai tipe yang berbeda dari ekstensi file saya?"
+a = """
+        Karena ekstensinya bisa salah dan byte-nya tidak bisa. File bernama
+        <code>logo.png</code> yang sebenarnya diekspor sebagai JPEG cukup lazim
+        sehingga setiap alat gambar harus menghadapinya, dan data URI yang
+        menyatakan tipe yang salah begitu saja tidak tampil &mdash; tidak ada
+        cadangan dan tidak ada pesan galat yang layak dibaca. Jadi tipenya dibaca
+        dari beberapa byte pertama file, yang menyatakan apa ia sebenarnya secara
+        tegas di setiap format di sini, dan halaman ini memberi tahu Anda ketika
+        keduanya bertentangan."""
+
+[[faq]]
+q = "Pratinjaunya kosong. Apa yang salah?"
+a = """
+        Mungkin bukan soal URI-nya. HEIC dan TIFF sama-sama menghasilkan data URI
+        yang sepenuhnya sah tapi tidak akan digambar peramban mana pun kecuali Safari,
+        jadi gambarnya juga akan hilang di mana pun Anda menempelkannya &mdash;
+        ubah dulu ke PNG, JPEG, atau WebP dengan
+        <a href="../kompres-gambar/">Kompresor Gambar</a> atau
+        <a href="../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a>. Kalau
+        formatnya format biasa, file-nya sendiri kemungkinan besar rusak:
+        pratinjaunya digambar dari URI yang dibangun halaman ini, jadi pratinjau
+        yang kosong berarti gambarnya tidak terdekode."""
+
+[[faq]]
+q = "Adakah batas ukuran pada sebuah data URI?"
+a = """
+        Bukan batas yang akan Anda temui di CSS atau di sebuah tag
+        <code>&lt;img&gt;</code>; peramban masa kini tidak menerapkan batas
+        praktis di sana. Yang memang dibatasi peramban adalah mengetikkan data URI
+        ke bilah alamat, yang kini ditolak sebagian besar peramban untuk apa pun
+        yang tidak sepele, dengan alasan keamanan yang sama sekali tidak
+        berhubungan dengan penggunaan ini. Batas yang sebenarnya adalah yang di
+        atas: jauh sebelum ada yang rusak secara teknis, halaman tempatnya berada
+        sudah menjadi lebih lambat daripada kalau memakai file gambar biasa."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Tidak ada batas jumlah atau ukuran file-nya juga,
+        karena tidak ada server yang membayarnya &mdash; pekerjaannya terjadi di
+        mesin Anda sendiri. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang gambar Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim gambar Anda ke tempat lain untuk dikodekan
+        akan berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Ubah PNG, JPEG, SVG, WebP, GIF, atau ICO menjadi data URI yang siap ditempelkan ke CSS atau HTML. Base64 untuk format raster dan pengodean persen untuk SVG, dibungkus dalam aturan CSS, properti khusus, tag img, atau Markdown, dengan biaya ukurannya dan metadata tertanam apa pun dilaporkan. Berjalan sepenuhnya di peramban tanpa unggahan."
+features = [
+  "Data URI base64 untuk PNG, JPEG, WebP, GIF, ICO, AVIF, dan lainnya",
+  "Data URI SVG berkode persen, yang lebih pendek daripada base64 dan tetap terbaca",
+  "Aturan CSS, properti khusus CSS, tag img HTML, atau Markdown siap pakai, selalu ditandakutip dengan benar",
+  "Tipe medianya dibaca dari byte file itu sendiri, bukan dari ekstensinya",
+  "Mengatakan pengodeannya memakan berapa karakter, dan apakah menyebariskan pada ukuran itu sepadan",
+  "Memperingatkan ketika EXIF, XMP, atau profil warna akan tersalin ke lembar gaya Anda",
+  "Menyalin file byte demi byte: tanpa pengodean ulang dan tanpa kehilangan kualitas",
+  "Kumpulan, dengan semuanya disalin atau diunduh sebagai satu file",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan gambar di sini"
+hint = "atau klik untuk menelusuri &mdash; PNG, JPEG, SVG, WebP, GIF, ICO, dan lainnya"

--- a/locales/id/tools/image-to-ico.html
+++ b/locales/id/tools/image-to-ico.html
@@ -1,0 +1,193 @@
+<!--
+  tools/image-to-ico/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; gambarnya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih gambar</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Keluarkan semua dari daftar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="shape-note" class="field-summary" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; standar yang mana -->
+  <section class="card" id="preset-card">
+    <h2><span class="step">2</span> Sebutkan ikonnya untuk apa</h2>
+
+    <p class="card-lede">
+      Sebuah file ikon bukan satu gambar melainkan beberapa: logo yang sama
+      digambar lagi pada setiap ukuran yang diminta oleh yang membacanya. Ukuran
+      mana saja itu bukan soal selera &mdash; sebuah peramban mau tiga di
+      antaranya, sebuah aplikasi di laptop berkepadatan tinggi mau sepuluh,
+      sebuah Mac mau sepuluh miliknya sendiri, dan sesuatu yang ditulis sebelum
+      Windows Vista mau semuanya disimpan dengan cara yang sama sekali berbeda.
+    </p>
+
+    <!--
+      Which files to write. Windows and macOS read different containers and
+      neither will look at the other's, so this is a set of checkboxes rather
+      than a menu: wanting both is the normal case for anything shipped on both.
+    -->
+    <fieldset class="options outputs">
+      <legend>Apa yang dibuat</legend>
+
+      <label class="check">
+        <input type="checkbox" id="want-ico" checked>
+        <span>
+          <strong>Ikon Windows &mdash; <code>.ico</code></strong>
+          <span class="check-note">
+            Dibaca setiap peramban sebagai favicon, dan oleh Windows untuk
+            sebuah aplikasi, sebuah pintasan, dan sebuah folder. Ukurannya Anda
+            sendiri yang pilih di bawah.
+          </span>
+        </span>
+      </label>
+
+      <label class="check">
+        <input type="checkbox" id="want-icns">
+        <span>
+          <strong>Ikon macOS &mdash; <code>.icns</code></strong>
+          <span class="check-note">
+            Inilah yang dibawa sebuah paket aplikasi Mac. Apple menamai tepat
+            sepuluh slot, dari 16 piksel sampai 1024, jadi tidak ada yang perlu
+            dipilih: kesepuluhnya masuk, digambar dari tujuh render karena sebuah
+            slot Retina dan ukuran di atasnya adalah gambar yang sama.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="pack-row">
+        <input type="checkbox" id="want-pack">
+        <span>
+          <strong>Sisa set ikon sebuah situs web</strong>
+          <span class="check-note">
+            Sebuah .ico mencakup tab peramban dan Windows. Ia tidak mencakup
+            layar utama iPhone, ajakan pemasangan Android, atau ubin yang
+            disematkan ke menu mulai &mdash; ketiganya membaca PNG 180px, sebuah
+            manifes aplikasi web, dan sebuah file XML, dan tidak satu pun dari
+            mereka mau melihat ke dalam sebuah .ico. Centang ini dan Anda
+            mendapatkan semuanya juga, manifesnya, serta blok HTML untuk
+            ditempelkan ke halaman Anda.
+          </span>
+        </span>
+      </label>
+
+      <p id="output-summary" class="field-summary"></p>
+    </fieldset>
+
+    <div id="ico-settings">
+      <div class="presets" id="preset-list" role="radiogroup" aria-label="Ikonnya untuk apa"></div>
+
+      <p id="preset-note" class="field-summary"></p>
+
+      <fieldset class="options" id="size-set">
+        <legend>Ukuran yang masuk ke .ico</legend>
+        <div class="size-grid" id="size-grid"></div>
+        <p id="size-summary" class="field-summary"></p>
+      </fieldset>
+    </div>
+
+    <fieldset class="options">
+      <legend>Bagaimana ia digambar</legend>
+
+      <div class="option-row">
+        <label for="fit-select">Kalau gambarnya tidak persegi</label>
+        <select id="fit-select">
+          <option value="pad" selected>Isi sisanya sampai persegi &mdash; seluruh gambarnya terjaga</option>
+          <option value="crop">Pangkas ke persegi di bagian tengah</option>
+          <option value="stretch">Regangkan sampai persegi</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="background-mode">Latar</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparan</option>
+          <option value="colour">Sebuah warna</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Warna latar" hidden>
+      </div>
+
+      <div class="option-row" id="storage-row">
+        <label for="storage-select">Bagaimana tiap ukuran disimpan di dalam .ico</label>
+        <select id="storage-select">
+          <option value="auto" selected>Otomatis &mdash; kompatibel selagi murah, PNG kalau tidak</option>
+          <option value="png">PNG untuk setiap ukuran &mdash; file terkecil, butuh Vista atau lebih baru</option>
+          <option value="bmp">Tanpa kompresi untuk setiap ukuran &mdash; terbuka di mana saja, beberapa kali lipat ukurannya</option>
+        </select>
+      </div>
+
+      <p id="storage-note" class="field-summary"></p>
+    </fieldset>
+
+  </section>
+
+  <!-- Langkah 3 &mdash; lihat kecilnya, lalu ambil -->
+  <section class="card" id="run-card">
+    <h2><span class="step">3</span> Periksa pada ukuran ia akan dilihat</h2>
+
+    <p class="card-lede">
+      Inilah bagian yang layak dilihat sebelum Anda mengunduh apa pun. Logo yang
+      terbaca sempurna pada 512 piksel lebarnya enam belas piksel di sebuah tab
+      peramban, dan bagian tipisnya &mdash; goresan pada logo kata, garis rambut
+      di tepinya, sebuah gradien &mdash; tidak selamat dari itu. Setiap kotak di
+      bawah digambar pada ukuran sebenarnya dari file yang Anda pilih.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-strip" id="preview-strip"></div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="make-icon" class="primary big" disabled>Buat ikonnya</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Siap</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Unduh semuanya sebagai satu zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+
+      <!--
+        The block to paste into a page's <head>, shown rather than only zipped:
+        most people making a favicon are about to paste this into a template,
+        and a copy button is a shorter route than a download and a text editor.
+      -->
+      <div id="snippet" class="snippet" hidden>
+        <div class="snippet-head">
+          <h4>Tempelkan ini ke <code>&lt;head&gt;</code> Anda</h4>
+          <button type="button" id="copy-snippet" class="ghost">Salin</button>
+        </div>
+        <pre id="snippet-text"></pre>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/image-to-ico.toml
+++ b/locales/id/tools/image-to-ico.toml
@@ -1,0 +1,356 @@
+#
+# Gambar ke ICO - Bahasa Indonesia.
+#
+# Overrides for tools/image-to-ico/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama file (favicon.ico, app.ico, browserconfig.xml, Info.plist), kunci Apple
+# (CFBundleIconFile), dan nama alat (iconutil, Visual Studio) tetap seperti
+# adanya: itulah nama yang diketik dan dicari orang.
+#
+
+name = "Gambar ke ICO"
+heading = "Gambar&nbsp;ke&nbsp;ICO <span class=\"h1-kw\">&mdash; pembuat favicon serta ikon Windows dan macOS</span>"
+tagline = "Satu gambar masuk. Setiap ukuran yang diminta peramban, Windows, atau sebuah Mac, keluar."
+
+title = "Gambar ke ICO &mdash; Buat Favicon, Ikon Aplikasi, atau ICNS, Tanpa Unggah"
+description = "Ubah PNG, JPEG, atau SVG menjadi .ico multi-ukuran yang sungguhan atau .icns macOS di peramban Anda. Favicon, ikon aplikasi Windows, ikon aplikasi Mac, plus file Apple dan Android yang dibutuhkan sebuah situs. Tidak ada yang diunggah."
+og_title = "Buat .ico atau .icns berisi setiap ukurannya, tanpa mengunggah apa pun"
+og_description = "favicon.ico untuk sebuah situs web, app.ico untuk program Windows, .icns untuk sebuah Mac - dengan pratinjau pada 16 piksel sebelum Anda mengunduh. Semuanya berjalan di mesin Anda sendiri."
+og_image_alt = "Gambar ke ICO - pembuat favicon serta ikon Windows dan macOS, tanpa unggah"
+
+pledge = """
+    Penskalaannya dan file ikonnya sendiri sama-sama dibuat di peramban Anda
+    sendiri. Gambarnya digambar oleh kanvas yang memang sudah dibawa peramban
+    Anda, dan setiap wadah &mdash; <code>.ico</code> Windows, <code>.icns</code>
+    macOS &mdash; dirakit dari piksel itu oleh beberapa ratus baris di
+    <code>src/ico.js</code> dan <code>src/icns.js</code> yang bisa Anda baca.
+    Alat ini tidak punya fitur jaringan dalam bentuk apa pun &mdash; tidak ada
+    yang diambil, tidak ada yang dikirim &mdash; dan seandainya pun ada, tidak
+    ada server di ujung lain halaman ini untuk menerima sebuah logo."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu buat sebuah ikon. Tidak satu pun permintaan membawa gambar, gambar
+      mini, nama file, atau satu byte pun dari yang Anda pilih. Atau cabut
+      koneksi internet dan tetap buat satu."""
+
+read_first = """
+, <code>src/ico.js</code> dan
+      <code>src/icns.js</code> untuk dua format ikonnya &mdash; direktori,
+      entri, dan maskernya di yang satu, sepuluh slot bernama milik Apple di yang
+      lain &mdash; dan <code>src/sizes.js</code> untuk asal setiap ukuran di
+      halaman ini."""
+
+howto_heading = "Cara membuat file .ico tanpa mengunggah apa pun"
+
+card = """
+            Sebuah favicon, ikon aplikasi Windows, atau .icns macOS &mdash;
+            setiap ukuran dalam satu file, dengan pratinjau pada 16 piksel
+            sebelum Anda mengunduh."""
+
+[words]
+plural = "gambar"
+choose = "sebuah gambar"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Logo Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di mana
+      pun di dalam <code>src/</code>. Penskalaannya adalah sebuah
+      <code>drawImage</code> ke sebuah kanvas; setiap ikon adalah sebuah header
+      yang ditulis di depan piksel itu, di halaman ini, oleh
+      <code>src/ico.js</code> atau <code>src/icns.js</code>."""
+
+[[privacy]]
+title = "File itu digambarkan dari byte-nya sendiri."
+body = """
+ Daftar ukuran yang ditampilkan di
+      sebelah ikon yang sudah jadi bukan daftar ukuran yang Anda minta. Ia dibaca
+      kembali dari file yang baru saja ditulis oleh
+      <code>readIcoDirectory</code> atau <code>readIcnsElements</code>; artinya
+      kalau sebuah penulis bertentangan dengan setelannya, halaman ini akan
+      mengatakannya, dan Anda tidak perlu mengetahuinya ketika Windows tidak
+      menggambar apa pun dan macOS menggambar kertas kosong."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google, dan tombol donasi dari Buy Me a Coffee. Tidak satu pun diberi
+      apa pun tentang gambar Anda. Setiap baris yang membaca, menskalakan, atau
+      menulis sebuah file disajikan dari asal ini dan terdaftar di
+      repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih gambarnya."
+body = """
+ Jatuhkan sebuah PNG, JPEG, WebP, atau SVG ke
+      pemilihnya, atau pilih beberapa dan ubah semuanya sekaligus. Yang persegi
+      paling mudah, dan di atas 256 piksel sudah membawa cukup detail untuk
+      setiap ukuran. Peramban membacanya langsung dari disk Anda; tidak ada yang
+      dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Pilih file yang Anda butuhkan."
+body = """
+ Windows dan sebuah peramban membaca
+      <code>.ico</code>; sebuah Mac membaca <code>.icns</code> dan sama sekali
+      tidak melihat yang satunya. Centang salah satu, atau keduanya kalau yang
+      Anda buat akan dirilis di keduanya. Sebuah situs web juga meminta gambar
+      Apple, Android, dan ubinnya, dan itulah kotak yang ketiga."""
+
+[[howto]]
+title = "Sebutkan ikonnya untuk apa."
+body = """
+ Favicon situs web berukuran 16, 32, dan
+      48 piksel; aplikasi Windows juga meminta 256; aplikasi yang harus tampak
+      rapi di laptop berkepadatan tinggi meminta ukuran antara yang diminta
+      Windows pada penskalaan 125% dan 150%. Pilih yang cocok dengan
+      pekerjaannya, atau centang sendiri ukurannya. Setiap ukuran di daftar
+      mengatakan apa yang memintanya. Pada <code>.icns</code> tidak ada pilihan
+      seperti itu: Apple menetapkan tepat sepuluh slot, dan semuanya masuk."""
+
+[[howto]]
+title = "Urus bentuk dan latarnya."
+body = """
+ Sebuah ikon berbentuk persegi dan
+      kebanyakan logo tidak. Isi sisanya; seluruh gambarnya terjaga, dengan ruang
+      di atas dan di bawahnya. Pangkas; bagian tengahnya yang diambil. Regangkan;
+      ia terjepit. Transparansi terjaga sebagai transparansi kecuali Anda memilih
+      sebuah warna untuk duduk di belakangnya."""
+
+[[howto]]
+title = "Lihat yang 16 piksel sebelum Anda mengunduh."
+body = """
+ Itulah ukuran yang paling sering dilihat
+      orang dari sebuah ikon, dan di situlah garis tipis dan huruf kecil hilang.
+      Setiap kotak di pratinjaunya digambar dari file Anda pada ukuran
+      sebenarnya. Kalau yang terkecil berupa noda, solusinya bukan setelan lain
+      melainkan gambar yang lebih sederhana."""
+
+[[howto]]
+title = "Ambil file-nya."
+body = """
+ Satu .ico berisi setiap ukurannya; kalau itu
+      yang Anda mau, dengan nama <code>favicon.ico</code>, karena itulah alamat
+      yang dicari peramban. Sebuah .icns di sebelahnya kalau Anda mencentangnya;
+      siap masuk ke sebuah paket aplikasi Mac. Centang juga set situs webnya, dan
+      dapatkan gambar Apple, Android, dan ubin Windows-nya, manifesnya, serta
+      blok HTML untuk ditempelkan ke halaman Anda. Lebih dari satu file turun
+      sebagai satu zip."""
+
+[[faq]]
+q = "Apakah gambar saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Gambar didekode dan diskalakan di perangkat keras Anda sendiri oleh
+        peramban Anda sendiri; .ico-nya lalu dirakit dari piksel itu oleh kode
+        yang disajikan dari halaman ini. Alat ini tidak punya fitur jaringan dalam
+        bentuk apa pun &mdash; ia tidak pernah mengambil apa pun dan tidak pernah
+        mengirim apa pun &mdash; dan <code>Content-Security-Policy</code> halaman
+        ini menyebut satu per satu setiap alamat yang boleh dihubunginya, dan
+        tidak satu pun milik situs ini."""
+
+[[faq]]
+q = "Ukuran apa saja yang seharusnya ada di dalam favicon.ico?"
+a = """
+        16, 32, dan 48. Itu bukan soal selera: 16 adalah yang digambar peramban di
+        sebuah tab; 32 adalah yang dipakai Windows untuk pintasan desktop dan yang
+        dipakai beberapa peramban untuk markah; dan 48 adalah ukuran ketika Google
+        membaca ikon sebuah situs. Yang lebih besar seharusnya berada di sebuah
+        PNG di sebelah .ico-nya, bukan di dalamnya &mdash; dan itulah yang
+        dihasilkan set situs web di sini."""
+
+[[faq]]
+q = "Ukuran apa saja yang dibutuhkan ikon aplikasi Windows?"
+a = """
+        16, 32, 48, dan 256; itu pula yang dimuat app.ico bawaan milik Visual
+        Studio sendiri. 16 untuk bilah judul dan tampilan Explorer kecil, 32 untuk
+        desktop dan bilah tugas, 48 untuk ikon sedang di Explorer, dan 256 untuk
+        menu mulai serta tampilan sangat besar. Di layar berkepadatan tinggi,
+        Windows juga meminta 20, 24, 40, 64, dan 96, dan kalau tidak ada ia
+        mengambil sampel ulang dari ukuran terdekat yang dimilikinya &mdash;
+        pilihan siap pakai "setiap skala" memasukkannya juga."""
+
+[[faq]]
+q = "Kenapa file-nya lebih besar daripada gambar yang saya mulai?"
+a = """
+        Karena sebuah .ico bukan satu gambar melainkan beberapa, dan yang kecil
+        disimpan tanpa dikompres supaya segalanya bisa membacanya. Entri 32x32
+        selalu tepat 4.264 byte apa pun isinya, dan entri 256x256 tanpa kompresi
+        berukuran 264 KB &mdash; itulah sebabnya ukuran di atas 64 disimpan
+        sebagai PNG secara bawaan. Memilih "PNG untuk setiap ukuran" menghasilkan
+        file terkecil yang mungkin; memilih tanpa kompresi untuk setiap ukuran
+        menghasilkan yang paling kompatibel."""
+
+[[faq]]
+q = "Apa bedanya entri PNG dan entri tanpa kompresi?"
+a = """
+        Hanya bagaimana pikselnya disimpan di dalam .ico. Entri tanpa kompresi
+        adalah tata letak Windows yang asli &mdash; sebuah header bitmap, piksel
+        terbalik, dan masker transparansi satu bit &mdash; dan setiap versi
+        Windows yang pernah dirilis bisa membacanya. Entri PNG adalah seluruh file
+        PNG yang dimampatkan ke dalam ikonnya; ia tiga sampai sepuluh kali lebih
+        kecil pada ukuran besar tapi hanya dipahami sejak Windows Vista.
+        Bawaannya memakai masing-masing di tempat ia menang: tanpa kompresi sampai
+        64 piksel, PNG di atasnya."""
+
+[[faq]]
+q = "Bisakah ia membuat ikon lebih besar dari 256 piksel?"
+a = """
+        Tidak, dan tidak ada yang bisa. Formatnya menyimpan setiap sisi dalam satu
+        byte dan 0 punya arti sendiri &mdash; ia berarti 256. Itulah langit-langitnya;
+        jadi .ico yang memuat gambar 512 piksel bukan ikon yang lebih besar
+        melainkan ikon yang rusak. Kalau Anda butuh 512, Anda butuh sebuah PNG, dan
+        itulah yang disertakan set situs web untuk Android dan layar pembuka sebuah
+        aplikasi web."""
+
+[[faq]]
+q = "Apakah ia menjaga transparansi?"
+a = """
+        Ya, pada kedua jenis entri; ia juga menulis masker satu bit yang lama di
+        sebelah kanal alfanya, sehingga perangkat lunak yang terlalu tua untuk
+        membaca alfa tetap memotong ikonnya alih-alih menggambar kotak hitam.
+        Satu-satunya file yang sengaja dibuat buram adalah ikon sentuh Apple di
+        dalam set situs web: iOS menaruhnya di ubinnya sendiri dan mengubah
+        transparansi menjadi hitam, jadi ia diratakan ke warna latar Anda, yang
+        secara bawaan putih."""
+
+[[faq]]
+q = "Logo saya lebar, berbentuk kata. Apa yang terjadi padanya?"
+a = """
+        Sesuatu harus terjadi, karena sebuah ikon berbentuk persegi. Mengisi
+        sisanya menjaga semuanya dan mengecilkannya &mdash; logo kata yang diisi
+        ke dalam persegi 16 piksel tingginya sekitar tiga piksel dan tidak
+        terbaca. Memangkas ke tengah biasanya memberi hasil lebih baik: keluarkan
+        simbolnya dari komposisinya dan pakai itu, seperti yang dilakukan hampir
+        setiap merek untuk faviconnya. Pratinjaunya menunjukkan yang mana yang
+        selamat sebelum Anda mengunduh apa pun."""
+
+[[faq]]
+q = "Apa isi set situs webnya, dan apakah saya butuh semuanya?"
+a = """
+        Tujuh PNG, sebuah manifes aplikasi web, sebuah browserconfig.xml, dan
+        sebuah blok HTML untuk ditempelkan. Anda memang membutuhkannya, karena
+        sebuah .ico mencakup peramban dan Windows dan tidak lebih: layar utama
+        iPhone membaca PNG 180 piksel dengan namanya sendiri, Android dan setiap
+        ajakan pemasangan membaca sebuah manifes, dan ubin yang disematkan ke menu
+        mulai membaca sebuah XML. Tidak satu pun dari itu melihat ke dalam sebuah
+        .ico. Semuanya dihasilkan di sini, di mesin Anda, dan di dalam zip-nya ada
+        catatan yang menyebutkan setiap file itu untuk apa."""
+
+[[faq]]
+q = "Bisakah ia membuat ikon macOS juga?"
+a = """
+        Bisa &mdash; centang <em>ikon macOS</em>; dapatkan sebuah
+        <code>.icns</code> di sebelah <code>.ico</code>-nya atau sebagai
+        gantinya. Ia wadah lain untuk gagasan yang sama, dan kedua sistem tidak
+        membaca punya yang lain: Windows mau .ico, paket aplikasi Mac mau .icns. Di
+        sana ukuran bukan sebuah pilihan, karena Apple menerbitkan tepat sepuluh
+        slot &mdash; 16, 32, 64, 128, 256, 512, dan 1024 piksel; tiga di antaranya
+        muncul dua kali sebagai versi Retina dari ukuran di bawahnya. Semuanya
+        masuk; mereka diambil dari tujuh gambar, dan itulah sebabnya sebuah .icns
+        adalah file yang lebih besar."""
+
+[[faq]]
+q = "Bagaimana saya memakai file .icns-nya?"
+a = """
+        Untuk sebuah aplikasi, ia ditaruh di dalam paketnya di
+        <code>YourApp.app/Contents/Resources/</code> dan dinamai di
+        <code>Info.plist</code> di bawah <code>CFBundleIconFile</code>; setiap alat
+        pengemas Mac punya kolom untuk itu. Untuk hal lain, pilih file-nya di
+        Finder, tekan Command-C, lalu buka Get Info pada folder atau image disk
+        yang ingin Anda ubah, klik ikon kecil di kiri atas, dan tekan Command-V."""
+
+[[faq]]
+q = "Apakah .icns-nya sama dengan yang dihasilkan iconutil?"
+a = """
+        Sepuluh slot yang sama dengan empat huruf tipe yang sama dan PNG di
+        masing-masingnya; itu pula yang dihasilkan <code>iconutil</code> dari
+        sebuah folder <code>.iconset</code>. Satu-satunya perbedaan yang disengaja:
+        alat Apple juga menulis elemen <code>TOC&nbsp;</code>, sebuah direktori
+        berisi tipe dan panjang yang menyusul. Itu sebuah pengoptimalan, bukan
+        bagian dari formatnya &mdash; tanpanya sebuah pembaca menelusuri elemennya
+        dari awal ke akhir dan sampai pada jawaban yang sama &mdash; dan direktori
+        yang salah lebih buruk daripada tidak ada direktori; karena itu ia
+        ditinggalkan."""
+
+[[faq]]
+q = "Bisakah saya mengubah beberapa gambar sekaligus?"
+a = """
+        Bisa. Setiap gambar di daftar menjadi .ico-nya sendiri dengan setelan yang
+        sama, dan kumpulannya turun sebagai satu zip berisi satu folder per gambar
+        &mdash; kalau tidak, keduanya akan bernama favicon.ico dan yang satu akan
+        menimpa yang lain. Setiap keluaran yang Anda centang dihasilkan untuk
+        setiap gambar. Klik baris mana pun untuk menaruh gambar itu di
+        pratinjaunya."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis; tidak ada akun, tidak ada masuk, tidak ada masa uji coba, tidak
+        ada tanda air. Tidak ada batas jumlah atau ukuran file-nya juga, karena
+        tidak ada server yang membayarnya &mdash; pekerjaannya terjadi di
+        perangkat Anda sendiri. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang gambar Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet, dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim logo Anda ke tempat lain untuk diubah akan
+        berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Ubah sebuah gambar menjadi file ICO Windows multi-ukuran atau file ICNS macOS di peramban. Pilihan siap pakai untuk favicon situs web, ikon aplikasi Windows, dan ikon aplikasi berkepadatan tinggi, sepuluh slot icns milik Apple, pratinjau setiap ukuran pada ukuran piksel sebenarnya, dan set opsional berisi file Apple, Android, dan ubin Windows yang dibutuhkan sebuah situs. Tidak ada yang diunggah."
+features = [
+  "Menulis .ico multi-ukuran yang sungguhan, dari 16 sampai 256 piksel",
+  "Menulis .icns macOS dari 16 sampai 1024 piksel, lengkap dengan sepuluh slot Apple",
+  "Dua format dari satu gambar dalam satu kali jalan; setiap ukuran hanya digambar sekali",
+  "Pilihan siap pakai untuk favicon situs web, ikon aplikasi Windows, Windows berkepadatan tinggi, dan kompatibilitas maksimum",
+  "Setiap ukuran mengatakan apa yang memintanya, jadi tidak ada yang masuk sia-sia",
+  "Entri tanpa kompresi untuk ukuran kecil dan PNG untuk yang besar, atau semuanya salah satu",
+  "Menjaga transparansi dan juga menulis masker transparansi pra-Vista",
+  "Isi sisanya, pangkas, atau regangkan gambar yang tidak persegi; di atas sebuah warna atau tanpa apa pun",
+  "Menampilkan setiap ukuran pada ukuran piksel sebenarnya sebelum Anda mengunduh",
+  "Set situs web opsional: ikon sentuh Apple, ikon Android, ikon maskable, ubin Windows, manifes, dan HTML untuk ditempelkan",
+  "Kumpulan, dengan semua hasilnya dalam satu zip",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan sebuah gambar di sini"
+hint = "atau klik untuk menelusuri &mdash; PNG, JPEG, WebP, SVG, dan apa pun lain yang bisa dibuka peramban Anda"

--- a/locales/id/tools/images-to-pdf.html
+++ b/locales/id/tools/images-to-pdf.html
@@ -1,0 +1,236 @@
+<!--
+  tools/images-to-pdf/body.html, in Indonesian.
+
+  Every id, class, data-sort and option value below is what src/main.js reaches
+  for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; gambar -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih gambar</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" data-sort="name" class="ghost">Urutkan berdasarkan nama</button>
+        <button type="button" data-sort="date" class="ghost">Urutkan berdasarkan tanggal</button>
+        <button type="button" data-sort="reverse" class="ghost">Balik urutan</button>
+        <button type="button" id="clear-all" class="ghost danger">Hapus semua</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Satu gambar per halaman, dalam urutan ini. Seret lewat pegangan
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> untuk memindahkan
+      sebuah halaman, atau pakai panah padanya.
+    </p>
+
+    <ul id="image-list" class="image-list"></ul>
+  </section>
+
+  <!-- Langkah 2 &mdash; halamannya -->
+  <section class="card">
+    <h2><span class="step">2</span> Penyiapan halaman</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Ukuran halaman</label>
+        <select id="page-size">
+          <option value="fit" selected>Paskan halaman ke setiap gambar</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 in</option>
+          <option value="a3">A3 &mdash; 297 &times; 420 mm</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+          <option value="tabloid">Tabloid &mdash; 11 &times; 17 in</option>
+          <option value="custom">Sesuai keinginan&hellip;</option>
+        </select>
+        <div id="custom-size" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="1" max="5000" step="1" value="210"
+                 aria-label="Lebar halaman sesuai keinginan">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="1" max="5000" step="1" value="297"
+                 aria-label="Tinggi halaman sesuai keinginan">
+          <select id="custom-unit" aria-label="Satuan untuk ukuran halaman sesuai keinginan">
+            <option value="mm" selected>mm</option>
+            <option value="in">in</option>
+          </select>
+        </div>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Resolusi cetak</label>
+        <select id="dpi">
+          <option value="72">72 DPI &mdash; layar</option>
+          <option value="96">96 DPI</option>
+          <option value="150" selected>150 DPI</option>
+          <option value="200">200 DPI</option>
+          <option value="300">300 DPI &mdash; cetak</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Menentukan seberapa besar sebuah halaman untuk jumlah piksel tertentu.
+          Ia tidak mengubah gambarnya.
+        </p>
+      </div>
+
+      <div class="field" id="orientation-field" hidden>
+        <label for="orientation">Orientasi</label>
+        <select id="orientation">
+          <option value="auto" selected>Ikuti setiap gambar</option>
+          <option value="portrait">Tegak</option>
+          <option value="landscape">Melintang</option>
+        </select>
+      </div>
+
+      <div class="field" id="fit-field" hidden>
+        <label for="fit">Bagaimana gambar duduk di halaman</label>
+        <select id="fit">
+          <option value="contain" selected>Muat di dalam margin</option>
+          <option value="cover">Penuhi halaman (memangkas tepinya)</option>
+          <option value="stretch">Regangkan sampai margin (mengubah bentuk)</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="margin">Margin</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="100" step="1" value="0"
+                 aria-label="Margin dalam milimeter">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="background">Warna halaman</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Tampak di margin, dan di belakang apa pun yang tembus pandang.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="mode">Kualitas gambar</label>
+        <select id="mode">
+          <option value="keep" selected>Biarkan JPEG persis seperti adanya</option>
+          <option value="jpeg">Kodekan ulang semuanya sebagai JPEG</option>
+          <option value="lossless">Tanpa kehilangan &mdash; sama sekali tanpa kehilangan kompresi</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kualitas JPEG</label>
+        <select id="quality">
+          <option value="0.75">File lebih kecil</option>
+          <option value="0.88" selected>Seimbang</option>
+          <option value="0.95">Kualitas terbaik</option>
+        </select>
+        <p class="field-note">Dipakai hanya untuk gambar yang harus dikodekan ulang alat ini.</p>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Perkecil gambar besar</label>
+        <select id="max-side">
+          <option value="0" selected>Jangan pernah &mdash; tetap ukuran penuh</option>
+          <option value="4000">Sisi terpanjang 4000 px</option>
+          <option value="2000">Sisi terpanjang 2000 px</option>
+          <option value="1200">Sisi terpanjang 1200 px</option>
+        </select>
+        <p class="field-note" id="shrink-note"></p>
+      </div>
+    </div>
+
+    <details class="meta-panel">
+      <summary>Rincian dokumen &mdash; semuanya opsional, semuanya kosong secara bawaan</summary>
+      <div class="meta-body">
+        <p class="meta-note">
+          Sebuah PDF membawa blok kecil berisi informasi tentang dirinya, dan
+          sebagian besar alat mengisinya dengan stempel waktu dan nama program,
+          diminta atau tidak. Alat ini menulis apa yang Anda ketik di sini dan
+          tidak lebih: tidak ada nama file, tidak ada nama mesin, dan tidak ada
+          tanggal kecuali Anda mencentang kotaknya.
+        </p>
+        <div class="settings">
+          <div class="field">
+            <label for="doc-title">Judul</label>
+            <input type="text" id="doc-title" maxlength="200" spellcheck="false"
+                   placeholder="Ditinggalkan kalau kosong">
+          </div>
+          <div class="field">
+            <label for="doc-author">Penulis</label>
+            <input type="text" id="doc-author" maxlength="200" spellcheck="false"
+                   placeholder="Ditinggalkan kalau kosong">
+          </div>
+          <div class="field">
+            <label for="file-name">Nama file</label>
+            <div class="inline-pair">
+              <input type="text" id="file-name" maxlength="120" spellcheck="false"
+                     value="gambar">
+              <span class="unit-label">.pdf</span>
+            </div>
+          </div>
+          <div class="field checkbox-field">
+            <label for="dated">
+              <input type="checkbox" id="dated">
+              Catat tanggal hari ini di dalam dokumen
+            </label>
+          </div>
+        </div>
+      </div>
+    </details>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="480" height="640" aria-label="Pratinjau satu halaman"></canvas>
+        <p id="preview-empty" class="preview-empty">Tambahkan gambar untuk melihat halamannya</p>
+        <div id="preview-nav" class="preview-nav" hidden>
+          <button type="button" id="preview-prev" class="ghost" aria-label="Halaman sebelumnya">&lsaquo;</button>
+          <span id="preview-label" class="preview-label"></span>
+          <button type="button" id="preview-next" class="ghost" aria-label="Halaman berikutnya">&rsaquo;</button>
+        </div>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Halaman</dt><dd id="sum-pages">&mdash;</dd></div>
+        <div><dt>Ukuran halaman</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Gambar yang dipilih</dt><dd id="sum-input">&mdash;</dd></div>
+        <div><dt>Disalin tanpa disentuh</dt><dd id="sum-copied">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; ekspor -->
+  <section class="card">
+    <h2><span class="step">3</span> Buat PDF-nya</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Buat PDF</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh PDF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/images-to-pdf.toml
+++ b/locales/id/tools/images-to-pdf.toml
@@ -1,0 +1,230 @@
+#
+# Gambar ke PDF - Bahasa Indonesia.
+#
+# Overrides for tools/images-to-pdf/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Gambar ke PDF"
+heading = "Gambar&nbsp;ke&nbsp;PDF <span class=\"h1-kw\">&mdash; pengubah JPG ke PDF</span>"
+tagline = "Masukkan gambar Anda ke dalam satu dokumen."
+
+title = "Pengubah Gambar ke PDF &mdash; JPG ke PDF Gratis, Tanpa Unggah"
+description = "Gabungkan gambar JPG, PNG, atau WebP menjadi satu PDF, gratis dan sepenuhnya di peramban Anda. Foto masuk tanpa dikodekan ulang, dan tidak ada yang diunggah."
+og_title = "Gambar ke PDF &mdash; pengubah JPG ke PDF gratis"
+og_description = "Gabungkan gambar menjadi satu PDF di perangkat Anda sendiri. Foto JPEG disalin masuk tanpa disentuh, jadi tidak ada yang kehilangan kualitas dan tidak ada yang diunggah."
+og_image_alt = "Gambar ke PDF - gabungkan gambar menjadi satu dokumen tanpa mengunggahnya"
+
+pledge = """
+    Dokumen ditulis di memori mesin ini, satu halaman sekali jalan, oleh kode
+    yang disajikan dari alamat ini. Tidak ada di sini yang bisa melakukan
+    unggahan, dan tidak ada server di ujung lain halaman ini untuk
+    menerimanya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu buat sebuah PDF. Tidak satu pun permintaan membawa gambar, gambar
+      mini, atau nama file. Atau cabut koneksi internet dan tetap buat satu."""
+
+read_first = """
+, dan <code>src/pdf.js</code> serta
+      <code>src/document.js</code> untuk seluruh penulisan file-nya, yang tidak
+      pernah menyentuh jaringan."""
+
+howto_heading = "Cara mengubah gambar menjadi PDF"
+
+card = """
+            Gabungkan gambar menjadi satu PDF, satu gambar per halaman. Foto
+            JPEG disalin masuk persis seperti adanya, jadi tidak ada yang
+            kehilangan kualitas."""
+
+[words]
+plural = "gambar"
+choose = "beberapa gambar"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "Gambar Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Alat ini tidak menambahkan apa pun ke daftar itu:
+      ia tidak punya fitur jaringan sendiri, bahkan yang opsional sekalipun.
+      Tidak ada titik akhir di sini tempat file Anda bisa dikumpulkan, dan tidak
+      ada kode yang akan mengirimnya seandainya ada."""
+
+[[privacy]]
+title = "PDF-nya ditulis di sini."
+body = """
+ Sebuah PDF adalah daftar objek dan tabel yang
+      mencatat di mana setiap objek dimulai, dan <code>src/pdf.js</code> menulis
+      keduanya. Tidak ada pustaka yang diambil, tidak ada yang digambar di
+      server, dan file yang sudah jadi diserahkan langsung ke unduhan dari
+      memori."""
+
+[[privacy]]
+title = "Dokumen tidak diberi tahu apa pun tentang Anda."
+body = """
+ Sebagian besar alat mencap sebuah PDF
+      dengan stempel waktu dan nama program yang membuatnya. Alat ini menulis
+      judul, penulis, dan tanggal hanya kalau Anda mengetiknya; nama file gambar
+      Anda tidak pernah muncul di dalam dokumen, begitu pula apa pun tentang
+      mesin Anda."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang gambar Anda: bukan file,
+      bukan gambar mini, bukan nama, ukuran, atau jumlah. Setiap baris yang
+      membaca, mendekode, atau menulis sebuah gambar disajikan dari asal ini dan
+      terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau gambar Anda. Tidak
+      ada yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap berfungsi. Itulah bukti yang paling sederhana: alat yang
+      mengirim gambar Anda ke tempat lain untuk dijadikan dokumen akan
+      berhenti."""
+
+[[howto]]
+title = "Pilih gambar Anda."
+body = """
+ Jatuhkan sebuah folder ke pemilih file,
+      atau pilih file-nya sendiri. Peramban membacanya langsung dari disk Anda;
+      tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Urutkan halamannya, dan putar yang perlu diputar."
+body = """
+ Satu gambar menjadi satu halaman, dalam
+      urutan yang ditampilkan. Seret sebuah kotak lewat pegangannya untuk
+      memindahkannya, atau pakai panahnya; tombol putar memutar sebuah halaman
+      seperempat sekali tekan, dan itulah yang biasanya dibutuhkan pindaian yang
+      miring."""
+
+[[howto]]
+title = "Pilih ukuran halaman."
+body = """
+ "Paskan halaman ke setiap gambar" membuat
+      setiap halaman persis seukuran gambarnya, tanpa ada yang terpangkas dan
+      tanpa pita putih. Ukuran bernama &mdash; A4, Letter, Legal, dan
+      seterusnya &mdash; menempatkan setiap gambar pada halaman tetap, dengan
+      margin kalau Anda mau."""
+
+[[howto]]
+title = "Buat PDF-nya dan unduh."
+body = """
+ Dokumen ditulis di mesin Anda sendiri,
+      jadi lamanya tergantung perangkat keras Anda, bukan pada antrean. File yang
+      sudah jadi diserahkan langsung ke unduhan peramban Anda."""
+
+[[faq]]
+q = "Apakah gambar saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Gambar Anda dibaca dan PDF-nya ditulis oleh peramban Anda sendiri
+        di perangkat keras Anda sendiri. Alat ini tidak punya sisi server, dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya &mdash; tidak satu pun milik situs
+        ini. Berbeda dari sebagian alat lain di sini, alat ini sama sekali tidak
+        punya fitur jaringan opsional."""
+
+[[faq]]
+q = "Apakah mengubah ke PDF menurunkan kualitas?"
+a = """
+        Tidak untuk JPEG, pada setelan bawaan. PDF bisa membawa data JPEG secara
+        langsung, jadi sebuah foto disalin ke dalam dokumen byte demi byte: ia
+        tidak pernah didekode dan tidak pernah dikompres lagi, dan gambar di dalam
+        PDF adalah gambar di dalam file. Format lain harus dikodekan ulang, karena
+        PDF tidak punya filter untuknya &mdash; kecuali Anda memilih setelan tanpa
+        kehilangan, yang menyimpannya persis dengan biaya file yang lebih
+        besar."""
+
+[[faq]]
+q = "Format gambar apa saja yang bisa saya pakai?"
+a = """
+        Gambar diam apa pun yang bisa didekode peramban Anda, yang dalam
+        praktiknya berarti JPG, PNG, WebP, GIF, AVIF, dan di perangkat Apple,
+        HEIC. Tidak ada daftar terpisah yang harus dijaga tetap mutakhir di sini,
+        karena pendekodean adalah tugas peramban, bukan tugas kami."""
+
+[[faq]]
+q = "Bisakah saya memilih ukuran halaman dan urutan halamannya?"
+a = """
+        Bisa. Halaman bisa berukuran A4, Letter, Legal, A3, A5, Tabloid, ukuran
+        yang Anda ketik, atau persis seukuran setiap gambar. Seret kotaknya untuk
+        mengurutkan ulang, urutkan berdasarkan nama atau tanggal, putar mana pun
+        seperempat putaran, dan atur margin dalam milimeter."""
+
+[[faq]]
+q = "Berapa banyak gambar yang bisa saya masukkan ke satu PDF?"
+a = """
+        Tidak ada batas yang tertanam di alat ini. Batas praktisnya adalah memori
+        mesin Anda sendiri, karena dokumen yang sudah jadi dirakit di sana sebelum
+        Anda mengunduhnya. Beberapa ratus foto ponsel pada resolusi penuh adalah
+        yang pertama merasakannya; memperkecil sisi terpanjangnya, di setelan,
+        menggeser batas itu jauh sekali."""
+
+[[faq]]
+q = "Apakah PDF-nya memuat nama file saya atau stempel waktu?"
+a = """
+        Tidak, kecuali Anda memintanya. Blok informasi dokumen dibiarkan kosong
+        kecuali nama alat ini: tidak ada nama file, tidak ada nama mesin, tidak
+        ada nama pengguna, dan tidak ada tanggal pembuatan kecuali Anda mencentang
+        kotaknya. Itu disengaja &mdash; sebuah PDF adalah sesuatu yang dikirim
+        orang kepada orang lain."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, dan tidak ada masa uji coba.
+        Situs ini memasang iklan, dan itulah yang membiayainya; iklan tidak
+        diberi apa pun tentang gambar Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim gambar Anda ke tempat lain untuk dijadikan
+        dokumen akan berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Gabungkan gambar JPG, PNG, dan WebP menjadi satu dokumen PDF. Setiap halaman ditulis di peramban Anda, jadi tidak ada gambar yang pernah diunggah."
+features = [
+  "Menggabungkan gambar JPG, PNG, WebP, GIF, dan AVIF menjadi satu PDF",
+  "Foto JPEG ditanamkan tanpa dikodekan ulang",
+  "Ukuran halaman dari A5 sampai Tabloid, atau halaman yang dipaskan ke setiap gambar",
+  "Mengurutkan ulang, memutar, mengatur margin dan warna halaman",
+  "Penyimpanan tanpa kehilangan opsional untuk pindaian dan tangkapan layar",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan gambar di sini"
+hint = "atau klik untuk menelusuri &mdash; JPEG, PNG, WebP, GIF, AVIF"

--- a/locales/id/tools/images-to-video.html
+++ b/locales/id/tools/images-to-video.html
@@ -1,0 +1,173 @@
+<!--
+  tools/images-to-video/body.html, in Indonesian.
+
+  Every id, class, data-view, data-sort and option value below is what
+  src/main.js reaches for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; gambar -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih gambar</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    {% include "partials/url-import.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <div class="view-switch" role="group" aria-label="Ubah cara daftar ditampilkan">
+          <button type="button" data-view="large" class="active">Besar</button>
+          <button type="button" data-view="small">Kecil</button>
+          <button type="button" data-view="list">Daftar</button>
+          <button type="button" data-view="details">Rincian</button>
+        </div>
+        <button type="button" data-sort="name" class="ghost">Urutkan berdasarkan nama</button>
+        <button type="button" data-sort="date" class="ghost">Urutkan berdasarkan tanggal</button>
+        <button type="button" data-sort="reverse" class="ghost">Balik urutan</button>
+        <button type="button" id="clear-all" class="ghost danger">Hapus semua</button>
+      </div>
+    </div>
+
+    <p id="reorder-hint" class="reorder-hint" hidden>
+      Seret gambar mana pun lewat pegangan <span class="grip" aria-hidden="true">&#8942;&#8942;</span>-nya
+      untuk mengurutkan ulang, atau pakai panah pada masing-masingnya.
+    </p>
+
+    <ul id="image-list" class="image-list view-large"></ul>
+
+    <div id="bulk-duration" class="bulk" hidden>
+      <label for="bulk-amount">Tahan setiap gambar selama</label>
+      <input type="number" id="bulk-amount" min="1" max="3600" step="1" value="1">
+      <select id="duration-unit" aria-label="Satuan untuk berapa lama setiap gambar ditahan">
+        <option value="frames" selected>bingkai</option>
+        <option value="seconds">detik</option>
+      </select>
+      <button type="button" id="apply-bulk" class="ghost">Terapkan ke semua</button>
+      <span class="bulk-note" id="bulk-note"></span>
+    </div>
+  </section>
+
+  <!-- Langkah 2 &mdash; setelan -->
+  <section class="card">
+    <h2><span class="step">2</span> Setelan video</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="resolution">Resolusi</label>
+        <select id="resolution">
+          <option value="auto" selected>Ikuti resolusi tertinggi</option>
+          <option value="3840x2160">3840 &times; 2160 &mdash; 4K</option>
+          <option value="1920x1080">1920 &times; 1080 &mdash; 1080p</option>
+          <option value="1280x720">1280 &times; 720 &mdash; 720p</option>
+          <option value="1080x1080">1080 &times; 1080 &mdash; persegi</option>
+          <option value="1080x1920">1080 &times; 1920 &mdash; tegak</option>
+          <option value="custom">Sesuai keinginan&hellip;</option>
+        </select>
+        <div id="resolution-custom" class="inline-pair" hidden>
+          <input type="number" id="custom-width" min="16" max="7680" step="2" value="1920"
+                 aria-label="Lebar keluaran sesuai keinginan dalam piksel">
+          <span aria-hidden="true">&times;</span>
+          <input type="number" id="custom-height" min="16" max="7680" step="2" value="1080"
+                 aria-label="Tinggi keluaran sesuai keinginan dalam piksel">
+        </div>
+        <p class="field-note" id="resolution-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Laju bingkai</label>
+        <select id="fps">
+          <option value="12">12 fps</option>
+          <option value="15">15 fps</option>
+          <option value="24">24 fps &mdash; film</option>
+          <option value="25">25 fps &mdash; PAL</option>
+          <option value="30" selected>30 fps</option>
+          <option value="50">50 fps</option>
+          <option value="60">60 fps</option>
+          <option value="custom">Sesuai keinginan&hellip;</option>
+        </select>
+        <input type="number" id="fps-custom" class="spaced" min="1" max="120" step="1" value="30"
+               aria-label="Laju bingkai sesuai keinginan dalam bingkai per detik" hidden>
+        <p class="field-note" id="fps-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="fit">Cara gambar dipaskan</label>
+        <select id="fit">
+          <option value="contain" selected>Muat di dalam (dengan bilah)</option>
+          <option value="blur">Muat di dalam, latar buram</option>
+          <option value="cover">Penuhi bingkai (memangkas tepinya)</option>
+          <option value="stretch">Regangkan sampai penuh (mengubah bentuk)</option>
+        </select>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Warna latar</label>
+        <input type="color" id="background" value="#000000">
+      </div>
+
+      <div class="field">
+        <label for="quality">Kualitas</label>
+        <select id="quality">
+          <option value="low">File lebih kecil</option>
+          <option value="medium" selected>Seimbang</option>
+          <option value="high">Kualitas terbaik</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format">
+          <option value="auto" selected>MP4 (disarankan)</option>
+          <option value="webm">WebM (cadangan)</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+    </div>
+
+    <div class="preview-row">
+      <div class="preview-frame">
+        <canvas id="preview" width="640" height="360" aria-label="Pratinjau bingkai pertama"></canvas>
+        <p id="preview-empty" class="preview-empty">Tambahkan gambar untuk melihat pratinjau</p>
+      </div>
+      <dl class="summary" id="summary">
+        <div><dt>Gambar</dt><dd id="sum-images">&mdash;</dd></div>
+        <div><dt>Durasi</dt><dd id="sum-duration">&mdash;</dd></div>
+        <div><dt>Ukuran keluaran</dt><dd id="sum-size">&mdash;</dd></div>
+        <div><dt>Total bingkai</dt><dd id="sum-frames">&mdash;</dd></div>
+      </dl>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; ekspor -->
+  <section class="card">
+    <h2><span class="step">3</span> Buat videonya</h2>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Buat video</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh video</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/images-to-video.toml
+++ b/locales/id/tools/images-to-video.toml
@@ -1,0 +1,242 @@
+#
+# Gambar ke Video - Bahasa Indonesia.
+#
+# Overrides for tools/images-to-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Gambar ke Video"
+heading = "Gambar&nbsp;ke&nbsp;Video <span class=\"h1-kw\">&mdash; buat slide MP4</span>"
+tagline = "Ubah satu folder gambar menjadi sebuah video."
+
+title = "Urutan Gambar ke MP4 &mdash; Gratis, Tanpa Unggah, Jalan Tanpa Internet"
+description = "Ubah gambar JPG, PNG, atau WebP menjadi video slide MP4, gratis dan sepenuhnya di peramban Anda. Tidak ada yang diunggah, tanpa pendaftaran, dan jalan tanpa internet."
+og_title = "Urutan Gambar ke MP4 &mdash; gratis, di peramban Anda"
+og_description = "Ubah urutan render, time-lapse, atau satu folder foto menjadi MP4. Pengodean berjalan di perangkat Anda sendiri; tidak ada yang diunggah."
+og_image_alt = "Gambar ke Video - ubah satu folder gambar menjadi slide MP4"
+
+pledge = """
+    Setiap bingkai dikodekan oleh peramban Anda sendiri dan videonya dibangun di
+    memori mesin ini. Encoder-nya tidak pernah menyentuh jaringan, dan tidak ada
+    server di ujung lain halaman ini untuk menerima sebuah gambar bahkan
+    seandainya ia menyentuhnya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu buat sebuah video. Tidak satu pun permintaan membawa gambar, gambar
+      mini, atau nama file. Atau cabut koneksi internet dan tetap buat satu."""
+
+read_first = """
+, dan <code>src/encoder.js</code> untuk perulangan
+      pengodean yang tidak pernah menyentuh jaringan."""
+
+howto_heading = "Cara mengubah gambar menjadi video"
+
+card = """
+            Ubah satu folder gambar menjadi slide MP4. Pengodean berjalan di
+            perangkat Anda sendiri, memakai perangkat keras Anda sendiri."""
+
+[words]
+plural = "gambar"
+choose = "beberapa gambar"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "Gambar Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya ada.
+      Dulu ini tertulis <code>connect-src 'none'</code>, yang mutlak; memasang
+      iklan memakan itu, dan mengatakannya adalah bagian dari kesepakatan."""
+
+[[privacy]]
+title = "Pengodean berjalan lokal."
+body = """
+ WebCodecs berjalan di peramban Anda dan file
+      yang sudah jadi diserahkan langsung ke unduhan. Aplikasi ini tidak punya
+      sisi server."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang gambar Anda: bukan file,
+      bukan gambar mini, bukan nama, ukuran, atau jumlah. Setiap baris yang
+      membaca, mendekode, menyusun, atau mengodekan sebuah gambar disajikan dari
+      asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau gambar Anda. Tidak
+      ada yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Satu pengecualian yang disengaja."
+body = """
+ Kalau Anda memakai "Tambah dari alamat
+      web", server itu dihubungi untuk mengambil gambarnya dan akan melihat
+      alamat IP Anda. Hanya gambar yang Anda tempelkan yang pernah diambil, dan
+      hanya masuk: <code>img-src</code> dibuka, <code>connect-src</code> tidak.
+      Penghitung di bawah mencantumkan setiap asal luar yang dihubungi."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semuanya kecuali
+      pemuatan lewat alamat web tetap berfungsi. Itulah bukti yang paling
+      sederhana."""
+
+[[howto]]
+title = "Pilih gambar Anda."
+body = """
+ Jatuhkan sebuah folder ke pemilih file,
+      atau pilih file-nya sendiri. Peramban membacanya langsung dari disk Anda;
+      tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Urutkan dan atur berapa lama masing-masing ditahan."
+body = """
+ Seret untuk mengurutkan ulang. Waktu
+      tahan bisa diberikan dalam bingkai atau dalam detik, untuk semua gambar
+      sekaligus atau satu gambar sekali jalan."""
+
+[[howto]]
+title = "Pilih resolusi dan laju bingkai."
+body = """
+ "Ikuti resolusi tertinggi" mengikuti
+      gambar terbesar Anda; pilihan siap pakainya mencakup 4K, 1080p, 720p,
+      persegi, dan tegak, dan ada ukuran sesuai keinginan kalau tidak ada yang
+      cocok."""
+
+[[howto]]
+title = "Buat videonya dan unduh."
+body = """
+ Pengodean berjalan di perangkat keras
+      Anda sendiri, jadi lamanya tergantung mesin Anda, bukan pada antrean. MP4
+      yang sudah jadi diserahkan langsung ke unduhan peramban Anda."""
+
+[[faq]]
+q = "Apakah gambar saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Gambar Anda dibaca, disusun, dan dikodekan oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya sisi
+        server, dan <code>Content-Security-Policy</code> halaman ini menyebut
+        satu per satu setiap alamat yang boleh dihubunginya &mdash; tidak satu
+        pun milik situs ini. Satu-satunya pengecualian adalah fitur opsional
+        "tambah dari alamat web", yang mengambil gambar yang Anda tempelkan, dan
+        server itu melihat alamat IP Anda."""
+
+[[faq]]
+q = "Format gambar apa saja yang bisa saya pakai?"
+a = """
+        Format gambar diam apa pun yang bisa didekode peramban Anda, yang dalam
+        praktiknya berarti JPG, PNG, WebP, GIF, AVIF, dan di perangkat Apple,
+        HEIC. Tidak ada daftar terpisah yang harus dijaga tetap mutakhir di sini,
+        karena pendekodean adalah tugas peramban, bukan tugas kami."""
+
+[[faq]]
+q = "Format video apa yang dihasilkannya?"
+a = """
+        MP4 dengan video H.264, yang bisa diputar di hampir apa pun. Di peramban
+        tanpa WebCodecs, alat ini kembali ke perekaman WebM &mdash; rekaman yang
+        sama dalam wadah yang diterima lebih sedikit penyunting."""
+
+[[faq]]
+q = "Bisakah saya memakai ini untuk urutan render Blender atau After Effects?"
+a = """
+        Bisa &mdash; urutan render bernomor justru itulah gunanya alat ini.
+        Tambahkan bingkai yang ditulis perender Anda, biarkan waktu tahannya satu
+        bingkai masing-masing, dan atur laju bingkainya agar cocok dengan
+        render-nya. "Urutkan berdasarkan nama" menghitung seperti yang Anda
+        harapkan, jadi <code>frame_2</code> mendarat sebelum
+        <code>frame_10</code>, bukan sesudahnya.
+        <br><br>
+        Satu hal yang perlu diketahui sebelum mulai: H.264 tidak punya kanal
+        alfa, jadi transparansi diratakan ke warna latar alih-alih dibawa serta.
+        Kalau Anda perlu menjaga alfanya, susun bingkainya di penyunting Anda
+        saja."""
+
+[[faq]]
+q = "Bisakah saya membuat time-lapse dari foto?"
+a = """
+        Bisa, dan itu pekerjaan yang sama dengan urutan render: tahan setiap foto
+        selama satu bingkai dan pilih laju bingkainya. Pada 30 fps setiap tiga
+        puluh foto menjadi satu detik video; pada 12 fps foto yang sama itu
+        berjalan dua setengah detik.
+        <br><br>
+        "Urutkan berdasarkan tanggal" mengembalikan isi kamera ke urutan
+        pengambilannya, yang penting kalau nama file-nya sudah mulai lagi dari
+        0001. Foto dengan ukuran berbeda tidak masalah &mdash; "Ikuti resolusi
+        tertinggi" menetapkan ukuran video sehingga tidak ada satu pun yang
+        diperkecil."""
+
+[[faq]]
+q = "Adakah batas berapa banyak gambar, atau berapa panjang videonya?"
+a = """
+        Tidak ada batas yang tertanam di alat ini. Batas praktisnya adalah memori
+        mesin Anda sendiri, karena video yang sudah jadi dirakit di sana sebelum
+        Anda mengunduhnya. Slide 4K yang sangat besar adalah yang pertama
+        merasakannya."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, dan tidak ada masa uji coba.
+        Situs ini memasang iklan, dan itulah yang membiayainya; iklan tidak
+        diberi apa pun tentang gambar Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim gambar Anda ke tempat lain untuk diproses
+        akan berhenti begitu Anda mencabut koneksi."""
+
+[[faq]]
+q = "Bisakah saya menambahkan musik atau lagu latar?"
+a = """
+        Belum. Alat ini hanya menghasilkan video: MP4 yang ditulisnya punya satu
+        jalur video dan tidak punya jalur audio. Tambahkan lagu latar sesudahnya
+        di penyunting video kalau Anda membutuhkannya."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript. Keluaran MP4 memerlukan peramban dengan WebCodecs; selain itu kembali ke WebM."
+description = "Ubah satu folder gambar menjadi video slide MP4. Setiap langkah berjalan di peramban Anda, jadi tidak ada gambar yang pernah diunggah."
+features = [
+  "Mengubah gambar JPG, PNG, WebP, GIF, dan AVIF menjadi video",
+  "Keluaran MP4 (H.264), dengan WebM sebagai cadangan",
+  "Resolusi sampai 3840x2160, laju bingkai dari 12 sampai 60 fps",
+  "Waktu tahan per gambar dalam bingkai atau detik",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan gambar di sini"
+hint = "atau klik untuk menelusuri &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+[picker.urls]
+summary = "Tambah dari alamat web"
+button = "Unduh gambar"
+noun = "gambar"

--- a/locales/id/tools/merge-pdf.html
+++ b/locales/id/tools/merge-pdf.html
@@ -1,0 +1,164 @@
+<!--
+  tools/merge-pdf/body.html, in Indonesian.
+
+  The range tokens - odd, even, all, last - are typed into the box and parsed
+  by src/ranges.js, so they stay in English. Every id, class and option value
+  is what src/main.js reaches for. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file-nya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih PDF Anda</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <ul id="source-list" class="source-list" hidden></ul>
+  </section>
+
+  <!-- Langkah 2 &mdash; halamannya -->
+  <section class="card" id="pages-card" hidden>
+    <h2><span class="step">2</span> Susun halamannya</h2>
+
+    <p class="card-lede">
+      Setiap halaman dari setiap file yang Anda pilih, dalam urutan mereka akan
+      keluar. Seret salah satunya lewat pegangan
+      <span class="grip" aria-hidden="true">&#8942;&#8942;</span> untuk
+      memindahkannya, putar dengan panahnya, atau keluarkan dengan &times;.
+      Belum ada apa pun di sini yang ditulis &mdash; dokumennya dirakit ketika
+      Anda menekan tombol di langkah 4.
+    </p>
+
+    <div class="toolbar">
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="reverse" class="ghost">Balik urutan</button>
+        <button type="button" id="rotate-all" class="ghost">Putar setiap halaman</button>
+        <button type="button" id="restore" class="ghost">Kembali ke asalnya</button>
+        <button type="button" id="clear-all" class="ghost danger">Mulai lagi</button>
+      </div>
+    </div>
+
+    <div class="range-row">
+      <label for="range">Halaman</label>
+      <input type="text" id="range" placeholder="1-3, 8, 12-" autocomplete="off"
+             spellcheck="false" aria-describedby="range-note">
+      <button type="button" id="range-keep" class="ghost">Simpan hanya ini</button>
+      <button type="button" id="range-drop" class="ghost">Buang yang ini</button>
+      <button type="button" id="range-turn" class="ghost">Putar yang ini</button>
+    </div>
+    <p id="range-note" class="field-note">
+      Menurut nomor di bawah, yang berubah seiring Anda bekerja. <code>odd</code>,
+      <code>even</code>, <code>all</code>, dan <code>last</code> juga berlaku.
+    </p>
+    <p id="range-error" class="error" role="alert" hidden></p>
+
+    <ul id="page-list" class="page-list"></ul>
+  </section>
+
+  <!-- Langkah 3 &mdash; satu file, atau beberapa -->
+  <section class="card" id="output-card" hidden>
+    <h2><span class="step">3</span> Satu dokumen, atau beberapa</h2>
+
+    <fieldset class="presets-set">
+      <legend class="visually-hidden">Bagaimana halamannya ditulis keluar</legend>
+      <div class="presets" id="split-modes" role="radiogroup" aria-label="Bagaimana halamannya ditulis keluar">
+        <label class="preset">
+          <input type="radio" name="split" value="single" checked>
+          <span class="preset-body">
+            <strong>Satu dokumen</strong>
+            <span class="preset-note">Semua di atas, dalam urutan itu, sebagai satu PDF.</span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="split" value="every">
+          <span class="preset-body">
+            <strong>Pisah setiap sekian halaman</strong>
+            <span class="preset-note">
+              Pindaian panjang dipotong menjadi bab-bab berisi
+              <input type="number" id="split-size" min="1" max="5000" step="1" value="10"
+                     inputmode="numeric" aria-label="Jumlah halaman di setiap file">
+              halaman.
+            </span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="split" value="at">
+          <span class="preset-body">
+            <strong>Pisah pada halaman&hellip;</strong>
+            <span class="preset-note">
+              Potong sebelum
+              <input type="text" id="split-at" placeholder="5, 9, 14" autocomplete="off"
+                     spellcheck="false" aria-label="Nomor halaman yang dipotong sebelumnya">
+              &mdash; masing-masing memulai file baru.
+            </span>
+          </span>
+        </label>
+        <label class="preset">
+          <input type="radio" name="split" value="each">
+          <span class="preset-body">
+            <strong>Setiap halaman berdiri sendiri</strong>
+            <span class="preset-note">Satu PDF per halaman. Berguna untuk menarik keluar lembar tandatangan.</span>
+          </span>
+        </label>
+        <label class="preset" id="by-file-preset" hidden>
+          <input type="radio" name="split" value="file">
+          <span class="preset-body">
+            <strong>Kembali ke file asalnya</strong>
+            <span class="preset-note">Satu dokumen per file yang Anda pilih, dengan suntingan Anda tetap ada.</span>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+
+    <label class="check">
+      <input type="checkbox" id="keep-bookmarks" checked>
+      <span>
+        <strong>Simpan markahnya</strong>
+        <span class="check-note">
+          Kerangka yang dibawa setiap file, dibangun ulang terhadap halaman yang
+          benar-benar ada di sini: entri yang halamannya Anda buang ikut hilang,
+          dan yang babnya masih ada tetap tinggal. Menggabungkan beberapa file
+          menempatkan markah masing-masing di bawah judul bernama file itu.
+        </span>
+      </span>
+    </label>
+
+    <p id="output-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Langkah 4 &mdash; satu klik -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Satukan</h2>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Bangun dokumennya</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Unduh</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <ul id="file-list" class="out-list" hidden></ul>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/merge-pdf.toml
+++ b/locales/id/tools/merge-pdf.toml
@@ -1,0 +1,317 @@
+#
+# Penggabung dan Pemisah PDF - Bahasa Indonesia.
+#
+# Overrides for tools/merge-pdf/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# Token rentang halaman - odd, even, all, last - diketik ke dalam kotaknya dan
+# diurai oleh src/ranges.js, jadi tetap dalam bahasa Inggris di sini.
+#
+
+name = "Penggabung dan Pemisah PDF"
+heading = "Gabungkan&nbsp;PDF <span class=\"h1-kw\">&mdash; pisah dan urutkan halaman juga</span>"
+tagline = "Halaman dipindah-pindah tanpa perjalanan bolak-balik ke server."
+
+title = "Gabungkan PDF, Pisah &amp; Urutkan Halaman &mdash; Gratis, Tanpa Unggah"
+description = "Gabungkan PDF, pisahkan satu menjadi beberapa, dan seret halaman ke urutan yang Anda mau &mdash; semuanya di dalam peramban Anda sendiri. Tidak ada yang diunggah, tidak ada akun, dan file yang sudah jadi dibuka lagi dan dihitung sebelum ditawarkan kepada Anda."
+og_title = "Gabungkan, pisahkan &amp; urutkan halaman PDF &mdash; tidak ada yang diunggah"
+og_description = "Satukan dokumen, potong satu menjadi beberapa bagian, pindahkan halaman, putar, keluarkan. Peramban Anda sendiri yang melakukannya, jadi file-nya tidak pernah meninggalkan mesin Anda."
+og_image_alt = "Gabungkan, pisahkan, dan urutkan halaman PDF tanpa mengunggahnya"
+
+pledge = """
+    Setiap dokumen yang Anda pilih dibuka, dibongkar, dan ditulis kembali di
+    memori mesin ini, oleh kode yang disajikan dari alamat ini. Tidak ada di
+    sini yang bisa melakukan unggahan, dan tidak ada server di ujung lain
+    halaman ini untuk menerimanya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu gabungkan dua file. Tidak satu pun permintaan membawa halaman,
+      gambar, atau nama file. Atau cabut koneksi internet dan tetap gabungkan
+      keduanya."""
+
+read_first = """
+, dan <code>src/assemble.js</code> untuk seluruh
+      proses penyalinannya &mdash; bagaimana sebuah halaman diangkat dari satu
+      dokumen dan diletakkan di dokumen lain, dan apa yang sengaja ditinggalkan.
+      Ia tidak bisa menjangkau jaringan, begitu pula pembaca dan penulis di
+      sebelahnya."""
+
+howto_heading = "Cara menggabungkan, memisahkan, atau mengurutkan PDF"
+
+card = """
+            Satukan dokumen, potong satu menjadi beberapa, dan seret halaman ke
+            urutan yang Anda mau. Tautan dan markah dibangun ulang agar mengikuti
+            halaman yang ditunjuknya, dan setiap file yang sudah jadi dibuka lagi
+            dan dihitung sebelum ditawarkan kepada Anda."""
+
+[words]
+plural = "dokumen"
+choose = "beberapa PDF"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "Dokumen Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Alat ini tidak menambahkan apa pun ke daftar itu:
+      ia tidak punya fitur jaringan sendiri, bahkan yang opsional sekalipun.
+      Tidak ada titik akhir di sini tempat file Anda bisa dikumpulkan, dan tidak
+      ada kode yang akan mengirimnya seandainya ada."""
+
+[[privacy]]
+title = "Menggabungkan adalah pekerjaan yang paling layak untuk tidak diunggah."
+body = """
+ Dokumen yang disatukan orang adalah
+      dokumen yang datang dari suatu tempat: sebuah kontrak dan halaman
+      tandatangannya, pindaian paspor dan rekening koran, surat dokter dan
+      formulir klaim. Penggabung daring memiliki semuanya, di satu tempat, sudah
+      tersusun rapi. Yang ini hanya punya sebuah halaman di peramban Anda dan
+      tidak punya belahan yang lain."""
+
+[[privacy]]
+title = "Seluruh formatnya ada di repositori ini."
+body = """
+ Sebuah PDF adalah daftar objek dan
+      tabel yang mencatat di mana setiap objek dimulai.
+      <code>src/objects.js</code> membaca sintaksisnya,
+      <code>src/reader.js</code> mengikuti tabelnya,
+      <code>src/assemble.js</code> menyalin halaman antar dokumen, dan
+      <code>src/writer.js</code> menulis hasilnya. Tidak satu pun dari keempatnya
+      mengimpor sesuatu yang bisa membuat permintaan. Tidak ada pustaka yang
+      diambil dan tidak ada yang digambar di server."""
+
+[[privacy]]
+title = "File terenkripsi ditolak, bukan dibuka."
+body = """
+ PDF dengan kata sandi ditolak,
+      termasuk jenis yang dihasilkan pemindai dengan kata sandi kosong dan yang
+      secara teknis akan terbuka. Melepas proteksi sebuah dokumen adalah
+      pekerjaan yang berbeda dari memindah-mindah halamannya, dan melakukannya
+      diam-diam akan menjadi hal yang mengejutkan bagi sebuah alat yang bertindak
+      atas nama Anda."""
+
+[[privacy]]
+title = "File yang sudah jadi tidak mengatakan apa pun tentang tempat pembuatannya."
+body = """
+ Tidak ada baris produser, tidak ada
+      tanggal pembuatan, tidak ada nama alat. Ia juga tidak membawa paket XMP
+      atau blok-blok privat yang ditinggalkan aplikasi tata letak &mdash; semua
+      itu milik dokumen yang dulu ada, bukan dokumen yang baru saja Anda bangun.
+      Apa pun di dalam halamannya sendiri disalin persis: alat ini memindahkan
+      halaman, ia tidak menulis ulang apa yang ada di atasnya."""
+
+[[privacy]]
+title = "Tindakan yang bukan \"pergi ke sebuah halaman\" tidak disalin."
+body = """
+ Sebuah PDF bisa membawa instruksi yang
+      berjalan saat ia dibuka: putar ini, kirim formulir ini ke alamat itu,
+      jalankan JavaScript ini. Halaman yang melewati alat ini menyimpan tautannya
+      ke halaman lain dan ke alamat web, dan kehilangan sisanya. Mengurutkan
+      ulang halaman milik orang lain bukan alasan untuk membawa skrip dokumennya
+      ke file baru Anda."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang dokumen Anda: bukan
+      file, bukan halaman, bukan nama, ukuran, atau jumlah halaman. Setiap baris
+      yang membaca, menyalin, atau menulis PDF disajikan dari asal ini dan
+      terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau dokumen Anda. Tidak
+      ada yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap berfungsi. Itulah bukti yang paling sederhana: alat yang
+      mengirim dokumen Anda ke tempat lain untuk digabungkan akan berhenti."""
+
+[[howto]]
+title = "Pilih PDF Anda."
+body = """
+ Jatuhkan ke pemilih file atau pilih sendiri,
+      dan tambahkan lagi nanti &mdash; halaman setiap file masuk ke ujung urutan
+      yang sedang berjalan, dan itulah yang membuat penggabungan dua folder
+      terpisah menjadi mungkin. Peramban membacanya langsung dari disk Anda."""
+
+[[howto]]
+title = "Urutkan halamannya sesuai keinginan Anda."
+body = """
+ Seret sebuah halaman lewat
+      pegangannya, atau geser dengan panahnya. Putar halaman yang terpindai
+      miring, keluarkan satu, atau ketik <code>1-3, 8, 12-</code> di kotaknya
+      untuk menyimpan, membuang, atau memutar sederet halaman sekaligus. Nomornya
+      berubah seiring Anda bekerja, jadi yang Anda lihat selalu sama dengan file
+      yang sudah jadi nanti."""
+
+[[howto]]
+title = "Sebutkan apakah hasilnya satu dokumen atau beberapa."
+body = """
+ Satu adalah jawaban yang biasa.
+      Sisanya adalah cara-cara memotong: setiap sekian halaman, pada nomor
+      halaman yang Anda sebutkan, satu file per halaman, atau kembali ke file
+      asal halamannya. Lebih dari satu file diserahkan sebagai satu ZIP, jadi
+      cukup sekali simpan alih-alih lima puluh kali."""
+
+[[howto]]
+title = "Bangun, lalu baca baris yang mengatakan bahwa hasilnya sudah diperiksa."
+body = """
+ Setelah dokumennya ditulis,
+      masing-masing dibuka lagi oleh pembaca yang sama di halaman ini dan
+      halamannya dihitung. Kalau itu tidak cocok dengan yang Anda minta,
+      prosesnya dilaporkan gagal dan tidak ada unduhan yang ditawarkan."""
+
+[[faq]]
+q = "Apakah PDF saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Semuanya dibaca, disalin, dan ditulis oleh peramban Anda sendiri
+        di perangkat keras Anda sendiri. Alat ini tidak punya sisi server, dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya &mdash; tidak satu pun milik situs
+        ini. Alat ini sama sekali tidak punya fitur jaringan opsional."""
+
+[[faq]]
+q = "Berapa banyak file yang bisa saya gabungkan, dan seberapa besar ukurannya?"
+a = """
+        Tidak ada batas yang tertulis di alat ini. Batasnya adalah mesin Anda
+        sendiri: dokumennya ditahan di memori selama dikerjakan, jadi sebuah
+        laptop akan menggabungkan beberapa ratus megabyte tanpa mengeluh dan akan
+        kepayahan di suatu titik di atas itu. Tidak ada yang ditagih, dicekik,
+        diberi tanda air, atau diantrekan, karena tidak ada siapa pun di ujung
+        sana untuk melakukan satu pun dari itu."""
+
+[[faq]]
+q = "Apakah menggabungkan atau memisahkan menurunkan kualitas?"
+a = """
+        Tidak. Tidak ada apa pun di sebuah halaman yang dikodekan ulang, digambar
+        ulang, atau dikompres ulang. Aliran isi setiap halaman dan setiap font,
+        gambar, serta gambar vektor yang dirujuknya disalin byte demi byte, jadi
+        teks tetap bisa dipilih dan dicari dan sebuah foto tetap foto yang sama.
+        Yang berubah hanyalah urutan halaman dan struktur di sekitarnya."""
+
+[[faq]]
+q = "Apa yang terjadi pada markah dan tautan?"
+a = """
+        Keduanya dibangun ulang, bukan dibuang. Markah yang halamannya masih ada
+        di keluaran menunjuk ke tempat halaman itu berpindah; markah yang
+        halamannya Anda buang ikut dikeluarkan, kecuali kalau ada entri yang
+        selamat di bawahnya, dan dalam hal itu ia tetap ada sebagai judul.
+        Menggabungkan beberapa file menempatkan markah setiap file di bawah judul
+        bernama file itu. Tautan antarhalaman diikuti dengan cara yang sama,
+        termasuk tujuan bernama yang ditulis Word dan LaTeX, dan tautan yang
+        sasarannya tidak ikut serta dibiarkan tanpa apa pun di belakangnya
+        alih-alih mengirim pembacanya ke tempat yang salah. Tautan ke alamat web
+        dijaga apa adanya."""
+
+[[faq]]
+q = "Apa yang tidak ikut terbawa?"
+a = """
+        Empat hal, dan alat ini mengatakannya di hasil, bukan di catatan kecil.
+        Pohon urutan baca bertanda yang dipakai pembaca layar, label halaman
+        (penomoran "iii, iv, 1, 2"), lampiran file tertanam, dan tindakan apa pun
+        yang bukan "pergi ke sebuah halaman" maupun "buka sebuah alamat web"
+        &mdash; termasuk JavaScript dokumen. Dua yang pertama menggambarkan urutan
+        yang sudah tidak ada begitu halaman dipindahkan; yang terakhir bukan
+        sesuatu yang Anda minta untuk dibawa ke file baru. Kalau penandaan sebuah
+        dokumen penting bagi Anda, simpan juga aslinya."""
+
+[[faq]]
+q = "Apakah formulir yang sudah diisi tetap selamat?"
+a = """
+        Ya. Kolom formulir dan apa yang sudah diketik ke dalamnya ikut bersama
+        halamannya, dan dokumen baru itu didaftarkan sebagai formulir sehingga
+        pembaca memperlakukannya begitu. Satu hal yang perlu diketahui saat
+        menggabungkan: dua kolom dengan nama yang sama adalah satu kolom bagi
+        pembaca mana pun, jadi kalau Anda menggabungkan dua salinan formulir yang
+        sama, mengisi sebuah kotak di satu halaman akan mengisinya juga di
+        halaman lain. Alat ini menyadari kasus itu dan mengatakannya."""
+
+[[faq]]
+q = "Bisakah ia membuka PDF yang dilindungi kata sandi?"
+a = """
+        Tidak, dan itu disengaja. Dokumen terenkripsi ditolak dengan pesan yang
+        mengatakannya, bahkan ketika kata sandinya kosong &mdash; dan begitulah
+        banyak pemindai serta mesin fotokopi menyimpan. Melepas proteksi sebuah
+        file adalah pekerjaan yang berbeda dari memindahkan halamannya, dan alat
+        yang melakukannya diam-diam berarti melakukan sesuatu yang tidak Anda
+        minta."""
+
+[[faq]]
+q = "Kenapa tidak ada pratinjau halaman?"
+a = """
+        Karena menggambar sebuah halaman berarti perender PDF yang lengkap
+        &mdash; font, gradasi, grup transparansi, mode pencampuran &mdash; yang
+        berarti satu megabyte atau lebih mesin yang harus diambil dan dijalankan
+        demi sekumpulan gambar mini. Yang ditampilkan kotaknya adalah hal-hal yang
+        benar-benar dipakai saat mengurutkan ulang: nomor halaman, bentuk dan
+        ukuran kertasnya, rotasi yang akan ditulis untuknya, dan dari file mana ia
+        berasal. Pindaian melintang di tumpukan halaman tegak tetap terlihat
+        sekilas."""
+
+[[faq]]
+q = "Apakah file yang sudah jadi bisa dibuka di mana-mana?"
+a = """
+        Ya. Keluarannya ditulis sebagai PDF 1.5 atau versi tertinggi yang
+        dibutuhkan salah satu file yang Anda berikan, dan 1.5 dipahami setiap
+        pembaca yang dirilis sejak 2003. Alat ini juga membuktikannya di perangkat
+        Anda sendiri: ia membuka lagi setiap file yang sudah jadi dan menghitung
+        halamannya dengan menelusuri pohon halaman sebelum menawarkannya kepada
+        Anda."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada batas ukuran file selain yang diizinkan memori mesin Anda
+        sendiri. Situs ini memasang iklan, dan itulah yang membiayainya; iklan
+        tidak diberi apa pun tentang dokumen Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim dokumen Anda ke tempat lain untuk
+        digabungkan akan berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Gabungkan PDF, pisahkan satu menjadi beberapa file, dan urutkan ulang, putar, atau buang halaman di peramban Anda. Halaman disalin antar dokumen secara lokal, jadi tidak ada file yang pernah diunggah."
+features = [
+  "Menggabungkan berapa pun jumlah PDF, dan membiarkan Anda terus menambah file sambil jalan",
+  "Seret halaman ke urutannya, putar, buang, atau kerjakan sederet sekaligus",
+  "Memisah menjadi satu file per halaman, setiap sekian halaman, pada nomor halaman, atau kembali ke file asal halamannya",
+  "Membangun ulang markah dan tautan internal terhadap halaman yang selamat",
+  "Menjaga kolom formulir yang sudah diisi, dan mengatakannya kalau dua di antaranya bernama sama",
+  "Membuka dan menghitung ulang setiap file yang sudah jadi sebelum menawarkannya",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa batas ukuran file",
+]
+
+[picker]
+title = "Jatuhkan PDF Anda di sini"
+hint = "atau klik untuk menelusuri &mdash; satu file atau beberapa, dan Anda bisa menambah lagi nanti"

--- a/locales/id/tools/password-generator.html
+++ b/locales/id/tools/password-generator.html
@@ -1,0 +1,313 @@
+<!--
+  tools/password-generator/body.html, in Indonesian.
+
+  The thirteen data-* attributes on #strength and the three on #result are the
+  whole strength readout: src/main.js reads them once at boot and never writes
+  a sentence of its own, so every one of them has to be translated here and
+  every attribute name has to stay exactly as it is. Same for every id, class,
+  data-mode and option value.
+-->
+<main>
+  <!-- Langkah 1 &mdash; yang mana dari dua hal ini -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih apa yang dibuat</h2>
+
+    <!--
+      A tab strip rather than two pages, because the choice between them is the
+      question this tool exists to help with and it should be one click, with
+      the answer to "which is stronger" visible on both sides of it.
+      `role="tablist"` and the arrow keys are wired in main.js.
+    -->
+    <div class="tabs" role="tablist" aria-label="Apa yang dibuat">
+      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
+              aria-selected="true" aria-controls="options-password">Kata sandi</button>
+      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
+              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Frasa sandi</button>
+    </div>
+
+    <p class="card-lede" id="mode-note">
+      Kata sandi adalah deretan karakter &mdash; pendek, kuat, dan sesuatu yang
+      akan Anda simpan di pengelola kata sandi. Frasa sandi adalah kata-kata yang
+      dipilih acak dari sebuah daftar &mdash; lebih panjang untuk diketik, jauh
+      lebih mudah diingat dan dibacakan, dan jawaban yang tepat untuk segelintir
+      rahasia yang harus Anda ketik dari ingatan: kata sandi utama pengelola kata
+      sandi, laptop Anda, kode cadangan ponsel Anda.
+    </p>
+  </section>
+
+  <!-- Langkah 2 &mdash; setelannya, satu panel per mode -->
+  <section class="card">
+    <h2><span class="step">2</span> Siapkan</h2>
+
+    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+      <div class="field">
+        <label for="length">Panjang</label>
+        <div class="slider-row">
+          <input type="range" id="length" min="6" max="128" value="20" step="1">
+          <output for="length" id="length-out">20</output>
+        </div>
+        <p class="field-note">
+          Panjang mengalahkan segala yang lain. Menambah satu karakter pada
+          alfabet sembilan puluh empat karakter lebih bernilai daripada aturan
+          apa pun tentang karakter mana yang harus muncul di dalamnya.
+        </p>
+      </div>
+
+      <div class="field checks">
+        <span class="checks-label">Karakter yang ditarik</span>
+        <label class="check" for="use-lower">
+          <input type="checkbox" id="use-lower" checked>
+          Huruf kecil <code>a&ndash;z</code>
+        </label>
+        <label class="check" for="use-upper">
+          <input type="checkbox" id="use-upper" checked>
+          Huruf besar <code>A&ndash;Z</code>
+        </label>
+        <label class="check" for="use-digits">
+          <input type="checkbox" id="use-digits" checked>
+          Angka <code>0&ndash;9</code>
+        </label>
+        <label class="check" for="use-symbols">
+          <input type="checkbox" id="use-symbols" checked>
+          Simbol
+        </label>
+      </div>
+
+      <div class="field">
+        <label for="symbol-set">Simbol yang mana</label>
+        <select id="symbol-set">
+          <option value="full" selected>Semuanya</option>
+          <option value="safe">Hanya yang diterima setiap situs</option>
+        </select>
+        <p class="field-note">
+          Yang ini: <code id="symbol-chars"></code>. Spasi, kedua tanda kutip,
+          aksen kuburan, dan garis miring terbalik sengaja ditinggalkan dari
+          kedua himpunan &mdash; mereka seacak yang lain dan merekalah yang
+          mengubah kata sandi yang berfungsi menjadi tiket dukungan.
+        </p>
+      </div>
+
+      <div class="field checks">
+        <label class="check" for="require-each">
+          <input type="checkbox" id="require-each">
+          Setidaknya satu karakter dari setiap himpunan
+        </label>
+        <p class="field-note">
+          Untuk formulir pendaftaran yang bersikeras. Itu membuat kata sandinya
+          <em>lebih lemah</em>, bukan lebih kuat, karena menyingkirkan sebagian
+          kata sandi yang tadinya mungkin &mdash; bacaan di bawah sudah
+          menguranginya.
+        </p>
+
+        <label class="check" for="avoid-lookalikes">
+          <input type="checkbox" id="avoid-lookalikes">
+          Tanpa karakter yang mirip
+        </label>
+        <p class="field-note">
+          Membuang <code>I l 1 |</code> dan <code>O 0</code>, untuk kata sandi
+          yang harus dibaca dari layar dan diketik di tempat lain. Tambahkan satu
+          dua karakter panjang untuk membayarnya.
+        </p>
+      </div>
+    </div>
+
+    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+      <div class="field">
+        <label for="words">Kata</label>
+        <div class="slider-row">
+          <input type="range" id="words" min="3" max="12" value="6" step="1">
+          <output for="words" id="words-out">6</output>
+        </div>
+        <p class="field-note">
+          Empat kata adalah gambar yang terkenal itu dan berada di bawah yang
+          layak dipakai hari ini. Enam adalah dasar yang masuk akal untuk apa pun
+          yang penting, dan tujuh untuk kata sandi yang menjaga semua yang lain.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="list">Daftar kata</label>
+        <select id="list">
+          <option value="long" selected>Daftar panjang &mdash; 7.776 kata</option>
+          <option value="short">Daftar pendek &mdash; 1.296 kata pendek</option>
+        </select>
+        <p class="field-note">
+          Daftar panjang adalah enam lemparan dadu per kata, jadi 12,9 bit
+          masing-masing. Daftar pendek adalah empat lemparan, 10,3 bit
+          masing-masing, dan setiap kata di dalamnya lima huruf atau kurang tanpa
+          ada kata yang merupakan awalan kata lain &mdash; dan itulah yang
+          dipakai untuk frasa sandi yang akan Anda ketik di remote televisi atau
+          baca di layar ponsel.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="separator">Di antara katanya</label>
+        <select id="separator">
+          <option value="hyphen" selected>Tanda hubung</option>
+          <option value="space">Spasi</option>
+          <option value="dot">Titik</option>
+          <option value="underscore">Garis bawah</option>
+          <option value="digit">Angka acak</option>
+          <option value="none">Tidak ada</option>
+        </select>
+        <p class="field-note">
+          Angka acak adalah satu-satunya dari semua ini yang menambah sesuatu,
+          karena ia adalah pilihan baru di setiap sambungan alih-alih sebuah
+          aturan. Sisanya soal apa yang akan diterima kotak tempat Anda
+          menempelkannya &mdash; spasi paling mudah dibaca dan paling mungkin
+          dikacaukan.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="capitals">Huruf besar</label>
+        <select id="capitals">
+          <option value="lower" selected>Biarkan apa adanya</option>
+          <option value="title">Awali Setiap Kata Dengan Huruf Besar</option>
+          <option value="upper">SEMUA HURUF BESAR</option>
+        </select>
+        <p class="field-note">
+          Tidak satu pun dari ketiganya menambah kekuatan: mana yang berlaku
+          adalah aturan yang bisa dibaca siapa pun dari halaman ini, jadi itu
+          bukan sesuatu yang harus ditebak penyerang. Ia ada di sini untuk
+          formulir yang menuntut huruf besar.
+        </p>
+      </div>
+
+      <div class="field checks">
+        <label class="check" for="add-digit">
+          <input type="checkbox" id="add-digit">
+          Akhiri dengan angka
+        </label>
+        <label class="check" for="add-symbol">
+          <input type="checkbox" id="add-symbol">
+          Akhiri dengan simbol
+        </label>
+        <p class="field-note">
+          Untuk formulir yang sama bersikerasnya. Angkanya adalah pilihan
+          sungguhan dan bernilai 3,3 bit; simbolnya ditarik dari delapan dan
+          bernilai 3.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; apa yang keluar, dan berapa nilainya -->
+  <section class="card">
+    <h2><span class="step">3</span> Ambil</h2>
+
+    <p id="no-classes" class="error" role="alert" hidden>
+      Tidak ada lagi yang bisa ditarik. Nyalakan kembali setidaknya satu himpunan
+      karakter di langkah 2.
+    </p>
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div class="result" id="result"
+         data-copied="Tersalin."
+         data-copy-failed="Peramban Anda tidak mengizinkan halaman ini menjangkau papan klip. Pilih dan salin sendiri.">
+      <output id="secret" class="secret" aria-live="polite"></output>
+      <div class="result-actions">
+        <button type="button" id="regenerate" class="primary">Buat lagi</button>
+        <button type="button" id="copy" class="ghost" data-download>Salin</button>
+        <span id="copy-note" class="copy-note" role="status"></span>
+      </div>
+    </div>
+
+    <!--
+      The strength readout. Every word it can say is written here rather than
+      in main.js, in `data-` attributes read once at boot, because everything
+      in this file is translated for each language the site is served in and
+      nothing inside src/ is. The numbers come from strength.js; the sentences
+      around them come from whichever language this page is.
+    -->
+    <div class="strength" id="strength"
+         data-very-weak="Sangat lemah"
+         data-weak="Lemah"
+         data-fair="Lumayan"
+         data-strong="Kuat"
+         data-very-strong="Sangat kuat"
+         data-instant="Ditebak seketika, oleh siapa pun yang mendapatkan file-nya."
+         data-minutes="Ditebak dalam hitungan menit."
+         data-hours="Ditebak dalam sehari."
+         data-days="Ditebak dalam sebulan."
+         data-months="Ditebak dalam setahun."
+         data-years="Akan memakan waktu bertahun-tahun."
+         data-centuries="Akan memakan waktu berabad-abad."
+         data-ages="Akan bertahan lebih lama daripada perangkat kerasnya, dan semua orang yang memakainya.">
+      <p class="strength-head">
+        <output id="bits">&mdash;</output>
+        <span class="strength-unit">bit entropi</span>
+        <span id="verdict" class="verdict"></span>
+      </p>
+      <div class="strength-bar" aria-hidden="true"><span id="strength-fill"></span></div>
+      <p class="strength-crack" id="crack"></p>
+      <p class="strength-space">
+        Seorang penyerang harus menelusuri
+        <output id="space">&mdash;</output>
+        kemungkinan untuk memastikan menemukannya.
+      </p>
+    </div>
+
+    <details class="assumptions">
+      <summary>Apa yang diandaikan perkiraan itu</summary>
+      <p>
+        Bahwa penyerang sudah mencuri file tempat kata sandi Anda disimpan dan
+        menebaknya terhadap file itu di perangkat keras mereka sendiri pada
+        seratus miliar tebakan per detik &mdash; kira-kira satu rak kartu grafis
+        melawan hash yang cepat, jenis yang terus muncul di kebocoran. Melawan
+        hash kata sandi yang dipilih dengan benar, bcrypt atau Argon2, perangkat
+        keras yang sama hanya sanggup beberapa ribu per detik dan setiap jawaban
+        di atas menjadi sekitar dua puluh lima bit lebih sulit. Melawan formulir
+        masuk yang menjawab sepuluh kali per detik, semuanya tidak terjangkau.
+      </p>
+      <p>
+        Angkanya sengaja diambil yang pesimistis, dan itu jumlah tebakan untuk
+        <em>memastikan</em>; serangan rata-rata menemukan jawabannya di
+        separuhnya, dan itulah yang dipakai perkiraan di atas.
+      </p>
+    </details>
+
+    <!--
+      Several at once, for the batch of accounts or the seed file. This is also
+      the page's only download, and the only thing on it that produces a file:
+      everything else is a string in a box.
+    -->
+    <div class="field bulk">
+      <label for="count">Atau buat beberapa sekaligus</label>
+      <div class="slider-row">
+        <input type="range" id="count" min="1" max="100" value="1" step="1">
+        <output for="count" id="count-out">1</output>
+      </div>
+      <ol class="batch" id="batch" start="2" hidden></ol>
+      <div class="result-actions">
+        <button type="button" id="copy-all" class="ghost" hidden>Salin semua</button>
+        <button type="button" id="download-txt" class="ghost" hidden>Unduh sebagai file teks</button>
+      </div>
+      <p class="field-note">
+        Daftar yang diunduh adalah file teks biasa yang ditulis halaman ini dari
+        yang sudah ada di layar Anda. Ia disimpan oleh peramban Anda, ke disk
+        Anda sendiri, dan tidak ada yang mengirimnya ke mana pun &mdash; tapi
+        file penuh kata sandi di disk tetaplah file penuh kata sandi di disk.
+        Pindahkan ke pengelola kata sandi dan hapus file itu.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Said on the page rather than only in the panel above it, because it is the
+    question every visitor to a page like this one is actually asking and the
+    answer is unusually short.
+  -->
+  <section class="card note-card">
+    <h2>Tidak ada di sini yang diingat</h2>
+    <p>
+      Apa yang dibuat halaman ini tidak pernah disimpan, tidak pernah
+      didaftarkan, dan tidak pernah dikirim. Tidak ada riwayat untuk dibersihkan
+      karena tidak ada yang disimpan: muat ulang halamannya dan setiap kata sandi
+      yang pernah ditampilkannya hilang, termasuk dari memori halaman ini
+      sendiri. Satu-satunya salinan adalah yang Anda buat &mdash; papan klip, dan
+      file teks kalau Anda memintanya.
+    </p>
+  </section>
+</main>

--- a/locales/id/tools/password-generator.toml
+++ b/locales/id/tools/password-generator.toml
@@ -1,0 +1,386 @@
+#
+# Pembuat Kata Sandi dan Frasa Sandi - Bahasa Indonesia.
+#
+# Overrides for tools/password-generator/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Kata sandi" untuk password dan "frasa sandi" untuk passphrase; keduanya
+# dijaga terpisah karena seluruh halaman ini soal kapan memakai yang mana.
+# "Diceware" dan nama API (crypto.getRandomValues, Math.random) tetap Latin.
+#
+
+name = "Pembuat Kata Sandi dan Frasa Sandi"
+heading = "Kata&nbsp;sandi&nbsp;dan&nbsp;frasa&nbsp;sandi <span class=\"h1-kw\">&mdash; acak dan kuat, dibuat di peramban Anda</span>"
+tagline = "Dibuat di sini, oleh peramban Anda sendiri, dan tidak pernah dikirim ke mana pun. Tidak ada yang disimpan dan tidak ada riwayat."
+
+title = "Pembuat Kata Sandi &amp; Frasa Sandi Acak yang Kuat &mdash; Tanpa Unggah"
+description = "Buat kata sandi acak yang kuat, atau frasa sandi diceware dari daftar 7.776 kata yang disertakan. Ditarik oleh generator kriptografis milik peramban Anda sendiri, tidak pernah dikirim ke mana pun, tidak pernah disimpan. Gratis, tanpa pendaftaran."
+og_title = "Pembuat kata sandi yang tidak mungkin mengirim kata sandi Anda ke mana pun"
+og_description = "Kata sandi acak dan frasa sandi diceware, ditarik oleh crypto.getRandomValues di peramban Anda sendiri dari daftar kata yang ikut bersama halamannya. Tanpa server, tanpa akun, tanpa riwayat, dan dengan hitungan jujur seberapa kuat hasilnya."
+og_image_alt = "Pembuat Kata Sandi dan Frasa Sandi - kata sandi acak yang kuat, tanpa ada yang diunggah"
+
+pledge = """
+    Setiap karakter datang dari <code>crypto.getRandomValues</code>, generator
+    kriptografis milik peramban sendiri, dan setiap kata dari daftar yang ikut
+    di folder ini sebagai <code>src/wordlist.js</code>. Tidak ada
+    <code>fetch</code>, tidak ada <code>XMLHttpRequest</code>, dan tidak ada
+    <code>sendBeacon</code> di mana pun di dalam <code>src/</code>, jadi tidak
+    ada jalur kode yang bisa membuat kata sandi yang dibuat di sini sampai
+    kepada kami atau siapa pun &mdash; dan tidak ada yang ditulis ke penyimpanan
+    juga, jadi memuat ulang halaman ini menghancurkan setiap kata sandi yang
+    pernah ditampilkannya kepada Anda."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu tekan <em>Buat lagi</em> sebanyak yang Anda mau. Tidak satu pun
+      permintaan membawa satu karakter pun dari hasilnya. Atau cabut koneksi
+      internet dan teruslah membuat."""
+
+read_first = """
+, <code>src/random.js</code> untuk empat puluh
+      baris yang berdiri antara halaman ini dan setiap kata sandi yang dibuatnya
+      &mdash; ia punya tepat satu masukan, dan masukan itu adalah generator
+      milik peramban sendiri &mdash; <code>src/generate.js</code> untuk bagaimana
+      setelan berubah menjadi sebuah string, dan <code>src/strength.js</code>
+      untuk aritmetika di balik angkanya, yang menghitung alih-alih menebak."""
+
+howto_heading = "Cara membuat kata sandi yang kuat tanpa dilihat sebuah situs web"
+
+card = """
+            Kata sandi acak yang kuat, atau frasa sandi yang dibangun dari
+            daftar kata yang disertakan. Ditarik oleh peramban Anda sendiri dan
+            tidak pernah dikirim ke mana pun."""
+
+[words]
+plural = "kata sandi dan frasa sandi"
+choose = "sebuah panjang"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tidak ada yang disimpan"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Kata sandinya dibuat di tempat Anda membaca ini."
+body = """
+ Ia ditarik di halaman ini, oleh
+      halaman ini, dari keacakan yang diserahkan sistem operasi Anda sendiri ke
+      peramban. Tidak ada yang diminta untuk menghasilkannya dan tidak ada yang
+      dilaporkan setelah ia ada. <code>Content-Security-Policy</code> menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini: tidak ada titik akhir di sini tempat kata sandi
+      yang dibuat bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya
+      seandainya ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di mana
+      pun di dalam <code>src/</code>. Daftar katanya tidak diunduh; ia adalah
+      <code>src/wordlist.js</code>, disajikan dari asal ini bersama sisa
+      halamannya, dan Anda bisa membacanya."""
+
+[[privacy]]
+title = "Keacakannya milik peramban, dan jenisnya yang tepat."
+body = """
+ <code>crypto.getRandomValues</code>
+      adalah generator yang disediakan peramban untuk kunci dan token, ditaburi
+      dan ditaburi ulang oleh sistem operasi. <code>Math.random</code> tidak
+      muncul di mana pun di folder ini, dan akan menjadi cacat sungguhan kalau
+      muncul: keadaan internalnya bisa dipulihkan dari segelintir keluaran, yang
+      membuat setiap kata sandi yang akan pernah dihasilkannya bisa dihitung oleh
+      siapa pun yang pernah melihat salah satunya."""
+
+[[privacy]]
+title = "Tidak ada yang disimpan, jadi tidak ada riwayat untuk dibersihkan."
+body = """
+ Tidak ada localStorage, tidak ada
+      sessionStorage, tidak ada cookie, tidak ada parameter URL, dan tidak ada
+      <code>&lt;input&gt;</code> yang akan ditawarkan peramban untuk diingat. Apa
+      yang ada di layar berada di satu larik di memori halaman ini, dan menutup
+      tab adalah seluruh pembersihannya. Satu-satunya salinan dari apa pun yang
+      dibuat di sini adalah yang Anda bawa pergi."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google, dan tombol donasi dari Buy Me a Coffee. Tidak satu pun diberi
+      satu karakter pun dari yang dibuat halaman ini, atau panjangnya, atau
+      kekuatannya, atau setelan mana yang menghasilkannya. Setiap baris yang
+      menarik sebuah karakter atau sebuah kata disajikan dari asal ini dan
+      terdaftar di repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana: generator yang meminta keacakannya dari
+      sebuah server akan berhenti begitu Anda mencabut koneksi."""
+
+[[howto]]
+title = "Pilih kata sandi atau frasa sandi."
+body = """
+ Kata sandi adalah deretan karakter
+      acak: pendek untuk disimpan, merepotkan untuk diketik, dan justru tepat
+      untuk ratusan akun yang diisikan pengelola kata sandi Anda. Frasa sandi
+      adalah kata-kata yang ditarik acak dari sebuah daftar: lebih panjang, tapi
+      bisa diingat dan diucapkan, dan itulah yang Anda butuhkan untuk segelintir
+      rahasia yang harus Anda ketik dari ingatan &mdash; kata sandi utama
+      pengelola kata sandi itu sendiri, laptop Anda, kode pemulihan ponsel
+      Anda."""
+
+[[howto]]
+title = "Tetapkan panjangnya, atau jumlah katanya."
+body = """
+ Inilah setelan yang penting dan yang
+      lain sebagian besar tidak. Dua puluh karakter, atau enam kata, adalah dasar
+      yang masuk akal untuk apa pun yang layak dilindungi; naikkan dari situ
+      untuk akun yang bisa dipakai orang untuk menyetel ulang semua akun lain.
+      Bacaan di bawahnya bergerak saat Anda menyeret, jadi Anda bisa melihat apa
+      yang dibeli setiap karakter tambahan."""
+
+[[howto]]
+title = "Nyalakan aturan yang akan dipaksakan formulirnya."
+body = """
+ &ldquo;Setidaknya satu dari
+      masing-masing&rdquo;, satu angka di akhir, satu simbol dari daftar pendek
+      yang diterima setiap situs. Tidak satu pun dari ini membuat apa pun lebih
+      kuat &mdash; yang pertama justru membuatnya sedikit lebih lemah, dan
+      halaman ini sudah menguranginya &mdash; tapi itulah cara Anda lolos dari
+      formulir pendaftaran tanpa membuat enam kali berturut-turut."""
+
+[[howto]]
+title = "Baca angkanya, bukan warnanya."
+body = """
+ Bit-nya dihitung dari setelan yang
+      menghasilkan string itu: besarnya alfabet, jumlah tarikan, dan tidak lebih.
+      Itu pengukuran sungguhan, tidak seperti meteran di halaman pendaftaran,
+      yang hanya bisa menilai karakter di depannya dan tidak punya cara
+      mengetahui apakah Anda yang memilihnya atau sebuah generator."""
+
+[[howto]]
+title = "Salin, dan taruh di suatu tempat, sebelum Anda pergi."
+body = """
+ Tidak ada riwayat di sini dan tidak ada
+      cara memintanya kembali; memuat ulang halaman menghancurkannya. Tempelkan
+      ke pengelola kata sandi lebih dulu dan ke formulir pendaftaran kemudian,
+      supaya yang harus mengingatnya sudah memilikinya sebelum ada yang bisa
+      salah."""
+
+[[howto]]
+title = "Ambil sekumpulan kalau Anda butuh."
+body = """
+ Penggeser di bagian bawah membuat sampai
+      seratus sekaligus dan akan menyimpannya sebagai file teks biasa, ditulis
+      oleh halaman ini dari yang sudah ada di layar Anda. Berguna untuk menyiapkan
+      akun atau membagikan kredensial awal, dan layak dihapus begitu semuanya ada
+      di tempat yang lebih baik: file penuh kata sandi di disk Anda tetaplah file
+      penuh kata sandi."""
+
+[[faq]]
+q = "Apakah kata sandinya dikirim ke suatu tempat, atau disimpan?"
+a = """
+        Tidak keduanya. Semuanya dibuat di peramban Anda, di perangkat keras Anda
+        sendiri, dan alat ini tidak punya fitur jaringan dalam bentuk apa pun
+        &mdash; ia tidak pernah mengambil apa pun dan tidak pernah mengirim apa
+        pun. Tidak ada juga yang ditulis ke penyimpanan: tidak ada localStorage,
+        tidak ada cookie, tidak ada riwayat. Muat ulang halamannya dan setiap
+        kata sandi yang pernah ditampilkannya hilang, dari layar dan dari
+        memorinya sendiri. <code>Content-Security-Policy</code> halaman ini
+        menyebut satu per satu setiap alamat yang boleh dihubunginya dan tidak
+        satu pun milik kami, jadi tidak ada tempat sebuah kata sandi bisa
+        dikumpulkan bahkan kalau ada yang mencoba."""
+
+[[faq]]
+q = "Dari mana keacakannya datang?"
+a = """
+        <code>crypto.getRandomValues</code>, generator yang disediakan peramban
+        untuk keperluan kriptografis, ditaburi dan ditaburi ulang oleh kolam
+        entropi milik sistem operasi Anda. Itu sumber yang sama yang dipakai
+        peramban untuk bahan kunci TLS. <code>Math.random</code> tidak dipakai di
+        mana pun di alat ini, dan pembedaan itu bukan sikap cerewet:
+        <code>Math.random</code> adalah generator aritmetis cepat yang seluruh
+        keadaan internalnya bisa direkonstruksi dari beberapa keluaran berurutan,
+        jadi pembuat kata sandi yang dibangun di atasnya menghasilkan kata sandi
+        yang tampak acak dan bisa dicacah oleh siapa pun yang pernah melihat
+        salah satunya."""
+
+[[faq]]
+q = "Apakah kata sandi yang dibuat di peramban sebaik yang dari program desktop?"
+a = """
+        Untuk keacakannya, ya &mdash; sumbernya sama-sama sistem operasi, hanya
+        dicapai lewat pintu yang berbeda. Yang berbeda adalah apa lagi yang ada
+        di ruangan itu. Sebuah tab peramban berjalan berdampingan dengan ekstensi
+        Anda, dan ekstensi yang punya izin membaca halaman bisa membaca halaman
+        ini. Itu berlaku untuk setiap pembuat kata sandi berbasis web termasuk
+        yang ini, dan itulah alasan jujur untuk memakai generator bawaan
+        pengelola kata sandi Anda kalau Anda punya: aritmetikanya sama, dalam
+        proses yang lebih sedikit tetangganya. Halaman ini untuk saat Anda tidak
+        punya yang siap pakai."""
+
+[[faq]]
+q = "Kata sandi atau frasa sandi &mdash; saya sebenarnya harus pakai yang mana?"
+a = """
+        Kata sandi untuk segala yang diketikkan pengelola kata sandi untuk Anda,
+        karena Anda tidak akan pernah melihatnya dan panjang itu gratis. Frasa
+        sandi untuk segelintir hal yang harus Anda ketik dari ingatan atau
+        bacakan: kata sandi utama pengelola kata sandi, kunci enkripsi disk,
+        perangkat yang Anda siapkan dari jarak jauh. Enam kata dari daftar
+        panjang adalah 77 bit, yang lebih kuat daripada kata sandi acak dua belas
+        karakter dan jauh lebih mudah dibuat benar pada pukul empat pagi."""
+
+[[faq]]
+q = "Seberapa panjang sebaiknya sebuah kata sandi?"
+a = """
+        Dua puluh karakter dari alfabet penuh kira-kira 130 bit dan sudah melewati
+        titik di mana panjang berhenti menjadi hal yang perlu dikhawatirkan. Enam
+        belas cukup. Dua belas adalah dasar untuk apa pun yang sayang kalau
+        hilang, dan itu dasar, bukan sasaran. Di bawah itu Anda bergantung pada
+        situsnya menyimpannya dengan benar, dan itu taruhan yang dua puluh tahun
+        pemberitahuan kebocoran menyarankan agar tidak Anda ambil. Panjang
+        mengalahkan setiap setelan lain di halaman ini; menambah satu karakter
+        lebih bernilai daripada aturan apa pun tentang karakter mana yang harus
+        muncul."""
+
+[[faq]]
+q = "Berapa kata sebaiknya sebuah frasa sandi?"
+a = """
+        Enam dari daftar panjang, dan tujuh kalau ia menjaga kata sandi lain.
+        Gambar empat kata yang terkenal itu dibuat pada 2011, bernilai 51 bit,
+        dan hari ini sudah dalam jangkauan serangan luring yang serius. Lima
+        adalah 64. Enam adalah 77, yang melewati apa pun yang akan dibelanjakan
+        penyerang untuk satu akun biasa. Setiap kata tambahan dari daftar panjang
+        menambah 12,9 bit, dan hanya kata-katanya yang menambah apa pun &mdash;
+        tanda hubung dan huruf besarnya tidak."""
+
+[[faq]]
+q = "Apa itu &ldquo;bit&rdquo;, dan kenapa halaman ini menghitungnya?"
+a = """
+        Satu bit adalah satu penggandaan. Enam puluh bit berarti ada 2^60 hasil
+        yang sama-sama mungkin dihasilkan halaman ini, jadi penyerang yang tahu
+        persis cara kerjanya tetap punya sebanyak itu untuk dicoba. Itu sifat
+        <em>prosesnya</em>, bukan sifat string-nya: halaman ini bisa menyebutkannya
+        dengan tepat karena ia yang melakukan pemilihan dan tahu berapa banyak
+        pilihan yang dibuatnya. Itulah bedanya dengan batang berwarna di formulir
+        pendaftaran, yang membaca karakternya lalu menebak. Di batang itu,
+        <code>correct horse battery staple</code> bernilai buruk padahal bernilai
+        44 bit, dan <code>P@ssw0rd!</code> bernilai bagus padahal nyaris tidak
+        bernilai apa pun."""
+
+[[faq]]
+q = "Kenapa &ldquo;harus mengandung simbol&rdquo; justru membuat kata sandi lebih lemah?"
+a = """
+        Karena sebuah aturan hanya bisa membuang kemungkinan. Mensyaratkan
+        setidaknya satu karakter dari setiap himpunan menyingkirkan setiap kata
+        sandi yang kebetulan tidak punya satu pun, dan himpunan kata sandi yang
+        lebih kecil berarti jumlah yang lebih kecil untuk dicari. Efeknya kecil
+        &mdash; sekitar setengah bit pada panjang yang lazim &mdash; dan nyata,
+        dan halaman ini menguranginya alih-alih menyebutkan angka yang lebih
+        menyanjung. Itu dihitung dengan tepat, dengan mencacah kata sandi yang
+        benar-benar diizinkan aturan itu, bukan yang tidak."""
+
+[[faq]]
+q = "Daftar kata yang mana ini, dan apakah masalah kalau penyerang bisa mengunduhnya?"
+a = """
+        Ini daftar diceware milik Electronic Frontier Foundation, disertakan tanpa
+        diubah: 7.776 kata untuk yang panjang dan 1.296 untuk yang pendek. Daftar
+        itu dibangun justru untuk ini &mdash; tidak ada yang menyinggung, tidak
+        ada homofon, tidak ada pasangan yang menyatu menjadi kata ketiga, dan di
+        daftar pendek tidak ada kata yang merupakan awalan kata lain. Dan tidak,
+        tidak masalah bahwa daftarnya publik: kekuatan yang disebutkan di sini
+        mengandaikan penyerang memilikinya, sedang melihat sumber halaman ini, dan
+        tahu setiap setelan yang Anda pakai. Satu-satunya yang tidak mereka tahu
+        adalah kata mana dari 7.776 itu yang muncul setiap kali. Andaian itulah
+        yang membuat angkanya bisa dipercaya."""
+
+[[faq]]
+q = "Bukankah frasa sandi hanya serangan kamus yang menunggu terjadi?"
+a = """
+        Tidak kalau katanya dipilih dengan cara ini. Serangan kamus mempan
+        terhadap frasa yang dipilih <em>orang</em>, karena orang memilih kata yang
+        cocok satu sama lain, dalam urutan yang masuk akal, dari beberapa ribu
+        kata yang mereka pakai sehari-hari. Halaman ini memilih setiap kata secara
+        mandiri, seragam, dari daftar tetap, tanpa peduli apakah hasilnya enak
+        dibaca &mdash; dan itulah sebabnya biasanya tidak. Penyerang yang tahu
+        daftarnya dan panjangnya tetap menghadapi 7.776 pangkat jumlah katanya."""
+
+[[faq]]
+q = "Bisakah saya mendapatkan kembali sebuah kata sandi setelah meninggalkan halaman ini?"
+a = """
+        Tidak, dan itu disengaja. Tidak ada yang dicatat di mana pun, jadi tidak
+        ada yang bisa dipulihkan: tidak ada panel riwayat, tidak ada daftar
+        &ldquo;baru saja dibuat&rdquo;, tidak ada singgahan. Generator yang bisa
+        menunjukkan kata sandi Selasa lalu berarti generator yang menyimpannya,
+        dan disimpan di tempat yang bisa Anda capai berarti disimpan di tempat
+        yang bisa dicapai sesuatu yang lain. Salin ke pengelola kata sandi sebelum
+        Anda beranjak."""
+
+[[faq]]
+q = "Apakah menyalinnya ke papan klip aman?"
+a = """
+        Itu risiko biasa, dan layak diketahui alih-alih dicemaskan. Papan klip
+        dipakai bersama oleh semua yang berjalan sebagai Anda, biasanya bertahan
+        sampai penyalinan berikutnya, dan di sebagian penyiapan ia disinkronkan
+        antar perangkat. Itu alasan bagus untuk segera menempelkannya di tempat
+        yang seharusnya lalu menyalin sesuatu yang lain sesudahnya, dan bukan
+        alasan untuk mengetik kata sandi yang lebih lemah dengan tangan. Halaman
+        ini tidak bisa membaca papan klip Anda; ia hanya bisa menulis ke sana, dan
+        hanya ketika Anda menekan tombolnya."""
+
+[[faq]]
+q = "Bolehkah saya memakai yang sama di lebih dari satu tempat?"
+a = """
+        Tidak, dan itu satu-satunya nasihat di halaman ini yang mengalahkan semua
+        yang lain di sini. Hampir setiap akun yang diambil alih diambil alih
+        dengan kata sandi yang lebih dulu benar di tempat lain: sebuah situs
+        bocor, daftarnya diterbitkan, dan alamat serta kata sandi yang sama dicoba
+        di mana-mana. Kata sandi unik per situs mengubah sebuah kebocoran menjadi
+        satu akun alih-alih semuanya, dan itulah alasan memelihara pengelola kata
+        sandi &mdash; bukan kekuatan satu pun kata sandi yang disimpannya."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada batas berapa banyak yang Anda buat. Situs ini memasang iklan,
+        dan itulah yang membiayainya; iklan sama sekali tidak diberi apa pun
+        tentang yang dibuat halaman ini, termasuk berapa panjangnya atau seberapa
+        kuat."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet, dan ia tetap
+        membuat kata sandi. Keacakannya datang dari mesin Anda sendiri dan daftar
+        katanya sudah ada di halaman. Itu juga cara paling sederhana untuk
+        membuktikan tidak ada yang diambil atau dikirim: generator yang meminta
+        angkanya dari sebuah server akan berhenti begitu Anda mencabut
+        koneksi."""
+
+[schema]
+description = "Buat kata sandi acak yang kuat dan frasa sandi diceware di peramban. Karakter ditarik dengan crypto.getRandomValues dan kata dari daftar EFF 7.776 kata yang disertakan; halaman ini melaporkan entropi persis dari yang dibuatnya. Tidak ada yang diunggah dan tidak ada yang disimpan."
+features = [
+  "Kata sandi acak dari alfabet sampai 94 karakter, panjang 6 sampai 128",
+  "Frasa sandi diceware dari daftar 7.776 kata yang disertakan, atau daftar pendek 1.296 kata",
+  "Setiap tarikan dari crypto.getRandomValues, dengan bias modulo ditolak alih-alih diabaikan",
+  "Entropi persis dalam bit, dihitung dari setelannya alih-alih dinilai dari string-nya",
+  "Menghitung biaya aturan \"harus mengandung satu dari masing-masing\" alih-alih mengabaikannya",
+  "Pengecualian opsional untuk karakter yang mirip, demi kata sandi yang harus diketik",
+  "Pemisah, huruf besar, dan angka atau simbol di akhir, masing-masing jujur soal apa yang ditambahkannya",
+  "Sampai seratus sekaligus, disalin atau disimpan sebagai file teks biasa",
+  "Tidak ada yang disimpan: tanpa riwayat, tanpa localStorage, tanpa cookie",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]

--- a/locales/id/tools/qr-barcode-reader.html
+++ b/locales/id/tools/qr-barcode-reader.html
@@ -1,0 +1,274 @@
+<!--
+  tools/qr-barcode-reader/body.html, in Indonesian.
+
+  Every id, class, data-phrase key, data-fact name and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language.
+  Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; dari mana gambarnya datang -->
+  <section class="card">
+    <h2><span class="step">1</span> Tunjukkan kodenya</h2>
+
+    <p class="card-lede">
+      Sebuah foto, tangkapan layar, atau kameranya. Mana pun yang Anda pilih,
+      gambarnya dibaca di sini, di halaman ini, di mesin Anda &mdash; tidak ada
+      yang diunggah, dan sebuah bingkai kamera diperiksa lalu dibuang alih-alih
+      direkam.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div class="run-row">
+      <button type="button" id="start-camera" class="primary">Pakai kameranya</button>
+      <button type="button" id="stop-camera" class="ghost" hidden>Hentikan kameranya</button>
+    </div>
+
+    <p class="field-summary" id="pick-note">
+      Anda juga bisa menempelkan sebuah gambar langsung dengan
+      <kbd>Ctrl</kbd>+<kbd>V</kbd> &mdash; tangkapan layar dari kode yang ada di
+      layar adalah jalan masuk tercepat.
+    </p>
+
+    <p id="pick-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Kameranya, yang baru muncul setelah menyala -->
+  <section class="card" id="camera-card" hidden>
+    <h2>Kameranya</h2>
+
+    <div class="viewfinder">
+      <video id="video" playsinline muted disablepictureinpicture></video>
+      <div class="reticle" aria-hidden="true"></div>
+    </div>
+
+    <div class="camera-controls">
+      <div class="option-row" id="camera-pick-row" hidden>
+        <label for="camera-pick">Kamera yang mana</label>
+        <select id="camera-pick"></select>
+      </div>
+
+      <label class="check" id="torch-row" hidden>
+        <input type="checkbox" id="torch">
+        <span>
+          <strong>Nyalakan lampunya</strong>
+          <span class="check-note">
+            Hanya sebagian kamera yang punya, dan hanya sebagian peramban yang
+            mengizinkan sebuah halaman memintanya. Kalau tidak ditawarkan,
+            berarti tidak ada.
+          </span>
+        </span>
+      </label>
+    </div>
+
+    <p class="field-summary" id="camera-status" role="status"></p>
+
+    <p class="field-summary">
+      Lampu kamera adalah penanda yang jujur di sini: ia menyala selagi bingkai
+      berdatangan dan padam pada saat Anda berhenti. Tidak ada apa pun di antara
+      dua titik itu yang ditulis ke disk, dan tidak ada alamat di
+      <code>Content-Security-Policy</code> halaman ini yang bisa dikirimi sebuah
+      gambar.
+    </p>
+  </section>
+
+  <!-- Langkah 2 &mdash; jawabannya -->
+  <section class="card" id="results-card" hidden>
+    <h2><span class="step">2</span> Apa yang dikatakannya</h2>
+
+    <p class="card-lede">
+      Ditampilkan, tidak pernah dibuka. Kode tercetak adalah alamat yang tidak
+      bisa dibaca siapa pun, dan justru itulah yang membuat sebuah stiker di
+      atasnya sepadan dengan repotnya seseorang &mdash; jadi seluruh teksnya ada
+      di sini untuk dilihat lebih dulu, dengan host yang sebenarnya akan dituju
+      disebutkan di barisnya sendiri.
+    </p>
+
+    <div id="results"></div>
+  </section>
+
+  <!--
+    One result. Cloned per code found, with only the values filled in from
+    script: every word in it is here, in the markup, because this file is
+    translated per language and src/*.js is one file serving all eleven.
+  -->
+  <template id="result-template">
+    <article class="result">
+      <header class="result-head">
+        <span class="result-kind"></span>
+        <span class="result-symbology"></span>
+      </header>
+
+      <pre class="result-text"></pre>
+
+      <div class="run-row">
+        <button type="button" class="primary copy">Salin teksnya</button>
+        <a class="as-button open" target="_blank" rel="noopener noreferrer nofollow" hidden>
+          Buka di tab baru
+        </a>
+      </div>
+
+      <dl class="result-rows"></dl>
+      <ul class="result-warnings"></ul>
+
+      <details class="result-facts">
+        <summary>Bagaimana yang satu ini dibaca</summary>
+
+        <dl class="facts-list">
+          <div><dt>Simbol</dt><dd data-fact="symbol"></dd></div>
+          <div data-only="qr"><dt>Versi</dt><dd data-fact="version"></dd></div>
+          <div data-only="qr"><dt>Koreksi galat</dt><dd data-fact="level"></dd></div>
+          <div data-only="qr"><dt>Masker</dt><dd data-fact="mask"></dd></div>
+          <div data-only="qr"><dt>Codeword yang diperbaiki</dt><dd data-fact="repaired"></dd></div>
+          <div data-only="qr"><dt>Ditulis sebagai</dt><dd data-fact="mode"></dd></div>
+          <div data-only="qr" data-optional><dt>Set karakter yang dinyatakan</dt><dd data-fact="eci"></dd></div>
+          <div data-only="qr" data-optional><dt>Satu dari sebuah set</dt><dd data-fact="part"></dd></div>
+          <div data-only="linear" data-optional><dt>Garis pindai yang sepakat</dt><dd data-fact="lines"></dd></div>
+          <div><dt>Karakter</dt><dd data-fact="characters"></dd></div>
+          <div><dt>Ditemukan lewat</dt><dd data-fact="how"></dd></div>
+        </dl>
+
+        <figure class="grid-figure" hidden>
+          <canvas class="grid" width="1" height="1"></canvas>
+          <figcaption>
+            Modul yang disampel halaman ini, digambar kembali. Kalau ini tampak
+            seperti kode yang Anda foto, ia membaca yang benar; kalau tampak
+            seperti semut di layar, tidak, dan jawaban di atas jangan dipercaya.
+          </figcaption>
+        </figure>
+      </details>
+    </article>
+  </template>
+
+  <!--
+    The words script needs, sitting in the markup so that a translator meets
+    them where they meet the rest of the page. A `{host}` in one of these is
+    filled in with the host that was read; nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="kind.url">Sebuah alamat web</span>
+    <span data-phrase="kind.url-plain">Sebuah alamat web, tanpa enkripsi</span>
+    <span data-phrase="kind.wifi">Sebuah jaringan Wi-Fi</span>
+    <span data-phrase="kind.vcard">Sebuah kartu kontak</span>
+    <span data-phrase="kind.mecard">Sebuah kartu kontak</span>
+    <span data-phrase="kind.email">Sebuah email</span>
+    <span data-phrase="kind.phone">Sebuah nomor telepon</span>
+    <span data-phrase="kind.sms">Sebuah pesan teks</span>
+    <span data-phrase="kind.place">Sebuah tempat di peta</span>
+    <span data-phrase="kind.otp">Sebuah rahasia autentikasi dua faktor</span>
+    <span data-phrase="kind.other-scheme">Sesuatu untuk dibuka program lain</span>
+    <span data-phrase="kind.number">Sebuah angka</span>
+    <span data-phrase="kind.text">Teks biasa</span>
+    <span data-phrase="symbology.qr">Kode QR</span>
+
+
+    <span data-phrase="field.host">Menuju</span>
+    <span data-phrase="field.port">Porta</span>
+    <span data-phrase="field.path">Jalur</span>
+    <span data-phrase="field.ssid">Nama jaringan</span>
+    <span data-phrase="field.security">Keamanan</span>
+    <span data-phrase="field.password">Kata sandi</span>
+    <span data-phrase="field.hidden">Jaringan tersembunyi</span>
+    <span data-phrase="field.name">Nama</span>
+    <span data-phrase="field.org">Organisasi</span>
+    <span data-phrase="field.title">Jabatan</span>
+    <span data-phrase="field.phone">Telepon</span>
+    <span data-phrase="field.email">Email</span>
+    <span data-phrase="field.web">Situs web</span>
+    <span data-phrase="field.address">Alamat</span>
+    <span data-phrase="field.note">Catatan</span>
+    <span data-phrase="field.to">Kepada</span>
+    <span data-phrase="field.subject">Perihal</span>
+    <span data-phrase="field.message">Pesan</span>
+    <span data-phrase="field.number">Nomor</span>
+    <span data-phrase="field.latitude">Lintang</span>
+    <span data-phrase="field.longitude">Bujur</span>
+    <span data-phrase="field.account">Akun</span>
+    <span data-phrase="field.issuer">Diterbitkan oleh</span>
+    <span data-phrase="field.secret">Rahasia</span>
+    <span data-phrase="field.scheme">Skema</span>
+
+    <span data-phrase="value.yes">Ya</span>
+    <span data-phrase="value.open-network">Terbuka &mdash; tanpa kata sandi</span>
+    <span data-phrase="value.none">Tidak ada</span>
+    <span data-phrase="value.copied">Tersalin</span>
+    <span data-phrase="value.modules">{n} modul persegi</span>
+
+    <span data-phrase="warn.userinfo">Semua sebelum @ adalah nama pengguna, bukan
+      alamat. Apa pun yang tampak dikatakan tautan ini, ia menuju {host}.</span>
+    <span data-phrase="warn.punycode">Alamat ini ditulis dalam aksara non-Latin.
+      Sebagian huruf di abjad lain berbentuk persis seperti huruf kita, dan
+      begitulah sebuah nama dibuat tampak seperti nama yang sudah Anda
+      percayai.</span>
+    <span data-phrase="warn.unicode-host">Nama host-nya mengandung karakter di
+      luar abjad Latin biasa, dan itu bisa dipakai untuk membuat satu nama tampak
+      seperti nama lain.</span>
+    <span data-phrase="warn.plain-http">Ini alamat http:// polos, jadi apa pun
+      yang Anda kirim ke sana bepergian tanpa enkripsi dan apa pun yang ada di
+      tengah bisa membacanya atau mengubahnya.</span>
+    <span data-phrase="warn.shortener">{host} adalah sebuah pengalihan. Alamat
+      yang sebenarnya akan Anda datangi tidak ada di dalam kode ini, dan mencari
+      tahu apa isinya berarti menghubungi sebuah server &mdash; dan itu tidak
+      pernah dilakukan halaman ini.</span>
+    <span data-phrase="warn.wifi-secret">Kode ini membawa sebuah kata sandi dalam
+      teks biasa. Siapa pun yang memfoto kodenya memilikinya, dan itu layak
+      diketahui sebelum satu kode naik ke dinding.</span>
+    <span data-phrase="warn.otp-secret">Ini benih untuk sebuah aplikasi
+      autentikator: siapa pun yang memegangnya bisa menghasilkan kode Anda untuk
+      akun itu tanpa batas waktu. Ia tidak meninggalkan halaman ini, dan layak
+      berhati-hati ke mana lagi ia pergi.</span>
+    <span data-phrase="warn.not-openable">Ini bukan alamat web, jadi tidak ada
+      tautan yang bisa ditawarkan. Ia tercetak utuh di atas; apakah ada sesuatu di
+      mesin Anda yang akan menindaklanjutinya adalah urusan Anda dan program
+      itu.</span>
+
+    <span data-phrase="mode.numeric">hanya angka</span>
+    <span data-phrase="mode.alphanumeric">huruf kapital dan angka</span>
+    <span data-phrase="mode.byte">byte</span>
+    <span data-phrase="mode.kanji">kanji</span>
+
+    <span data-phrase="how.local">sebuah ambang yang dihitung blok demi blok</span>
+    <span data-phrase="how.inverted">menukar gelap dengan terang</span>
+    <span data-phrase="how.global">satu ambang untuk seluruh gambar</span>
+    <span data-phrase="how.softened">melembutkan gambarnya lebih dulu</span>
+    <span data-phrase="how.dense">, memeriksa setiap baris</span>
+
+    <span data-phrase="status.reading">Membaca gambarnya&hellip;</span>
+    <span data-phrase="status.nothing">Tidak ada kode yang ditemukan di gambar
+      itu. Ia butuh seluruh simbolnya di dalam bingkai, margin putihnya termasuk,
+      dan cahaya yang cukup supaya kotak gelapnya benar-benar gelap.</span>
+    <span data-phrase="status.broken">File itu tidak bisa dibuka sebagai sebuah
+      gambar.</span>
+    <span data-phrase="status.looking">Mencari&hellip; tahan kodenya diam dan isi
+      sekitar separuh bingkai dengannya.</span>
+    <span data-phrase="status.on">Kamera menyala. Tidak ada yang sedang
+      direkam.</span>
+
+    <span data-phrase="camera.denied">Peramban menolak kamera untuk halaman ini.
+      Itu izin yang bisa Anda ubah: cari ikon kamera di bilah alamat. Memilih
+      sebuah gambar sebagai gantinya sama sekali tidak butuh izin.</span>
+    <span data-phrase="camera.none">Tidak ada kamera yang ditemukan di mesin ini.
+      Jatuhkan sebuah foto atau tangkapan layar di atas dan ia akan dibaca dengan
+      cara yang sama.</span>
+    <span data-phrase="camera.busy">Kameranya ada tapi sesuatu yang lain sedang
+      memakainya. Tutup apa pun yang membukanya &mdash; biasanya panggilan video
+      &mdash; lalu coba lagi.</span>
+    <span data-phrase="camera.insecure">Sebuah peramban hanya menyerahkan
+      kameranya kepada halaman yang disajikan lewat https, dan yang ini bukan
+      begitu saat ini.</span>
+    <span data-phrase="camera.unsupported">Peramban ini tidak punya antarmuka
+      kamera untuk diminta sebuah halaman. Semua yang lain di sini tetap
+      bekerja.</span>
+    <span data-phrase="camera.failed">Kameranya tidak bisa dinyalakan, dan
+      perambannya tidak mengatakan kenapa.</span>
+
+    <span data-phrase="live.clean">gambar Anda tidak pergi ke mana pun. {total}
+      file dimuat, semuanya milik halaman ini sendiri.</span>
+    <span data-phrase="live.dirty">sesuatu menghubungi {hosts}, dan itu tidak
+      pernah dilakukan alat ini. Anggap itu layak diselidiki.</span>
+    <span data-phrase="live.platform">Skrip iklan, pengukuran, dan tombol donasi
+      milik halaman ini dimuat dari {count} host; tidak satu pun diberi sebuah
+      gambar, sebuah bingkai, atau satu huruf pun dari apa yang dikatakan sebuah
+      kode.</span>
+  </div>
+</main>

--- a/locales/id/tools/qr-barcode-reader.toml
+++ b/locales/id/tools/qr-barcode-reader.toml
@@ -1,0 +1,348 @@
+#
+# Pembaca QR & Barcode - Bahasa Indonesia.
+#
+# Overrides for tools/qr-barcode-reader/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama format (QR, EAN-13, UPC-A, ITF-14, Code 128, Code 39, Data Matrix,
+# PDF417, Aztec, MaxiCode, Reed-Solomon) tetap seperti adanya: itulah yang
+# tercetak di kemasan dan di lembar spesifikasi.
+#
+# "Modul" dipakai untuk kotak-kotak kecil di dalam sebuah QR, karena itulah
+# sebutan resminya dan tidak ada kata Indonesia yang lebih jelas.
+#
+
+name = "Pembaca QR & Barcode"
+heading = "Pembaca&nbsp;QR&nbsp;&amp;&nbsp;Barcode <span class=\"h1-kw\">&mdash; pindai kode QR dari sebuah gambar atau kamera Anda</span>"
+tagline = "Arahkan ke sebuah kode, atau jatuhkan gambarnya. Ia dibaca di sini, dan tidak di tempat lain."
+
+title = "Pembaca Kode QR &amp; Pemindai Barcode &mdash; Dari Sebuah Gambar, Tanpa Unggah"
+description = "Baca kode QR dari sebuah foto, tangkapan layar, atau kamera Anda, dan lihat persis ke mana tautannya pergi sebelum Anda membukanya. Barcode EAN, UPC, Code 128, Code 39, dan ITF juga. Tidak ada yang diunggah."
+og_title = "Baca kode QR tanpa mengirim gambarnya kepada siapa pun"
+og_description = "Pindai kode QR dari sebuah gambar atau kamera Anda dan lihat seluruh alamatnya sebelum Anda memutuskan untuk membukanya. Gambarnya tidak pernah meninggalkan mesin Anda, dan tidak ada bingkai kamera yang pernah direkam."
+og_image_alt = "Pembaca QR & Barcode - pindai kode dari sebuah gambar atau kamera, tanpa unggah"
+
+pledge = """
+    Membaca sebuah kode adalah hitungan atas piksel, dan pikselnya sudah ada di
+    sini. Menemukan simbolnya, membetulkan sudutnya, membuka maskernya,
+    memperbaiki kerusakannya dengan Reed-Solomon, dan membaca bitnya kembali
+    semuanya terjadi di sekitar dua ribu baris JavaScript di halaman ini yang
+    bisa Anda baca. <strong>Kameranya adalah janji yang sama, bukan
+    pengecualiannya:</strong> sebuah bingkai datang sebagai piksel di tab ini,
+    diperiksa, lalu hilang. Tidak ada yang direkam, tidak ada yang disimpan, dan
+    halaman ini tidak punya fitur jaringan dalam bentuk apa pun untuk
+    mengirimnya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu pindai sebuah kode dengan kamera menyala. Tidak satu pun permintaan
+      membawa sebuah bingkai atau satu huruf pun dari apa yang dikatakannya.
+      Atau cabut koneksi internet dan tetap baca kodenya."""
+
+read_first = """
+, <code>src/binarize.js</code>
+      dan <code>src/detect.js</code> untuk menemukan sebuah simbol di dalam
+      sebuah foto &mdash; ambangnya, pola pencarinya, dan transformasi
+      perspektifnya &mdash; <code>src/qr-decode.js</code> untuk membacanya
+      kembali, <code>src/reed-solomon.js</code> untuk memperbaiki yang salah
+      terbaca, <code>src/linear.js</code> untuk yang bergaris, dan
+      <code>src/camera.js</code>, yang berisi setiap baris di halaman ini yang
+      menyentuh sebuah kamera."""
+
+howto_heading = "Cara membaca kode QR tanpa mengunggah gambarnya"
+
+card = """
+            Baca kode QR dari sebuah foto, tangkapan layar, atau kamera Anda
+            &mdash; dan lihat seluruh alamatnya sebelum Anda membukanya. Barcode
+            juga."""
+
+[words]
+plural = "gambar dan kode di dalamnya"
+choose = "gambar yang akan dibaca"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tidak ada yang direkam"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Gambarnya tidak pernah diunggah, dan kameranya bukan pengecualian."
+body = """
+ Foto yang Anda jatuhkan
+      di sini didekodekan ke sebuah kanvas di halaman ini dan dibaca di sana.
+      Sebuah bingkai kamera adalah hal yang sama yang datang tiga puluh kali
+      sedetik: ia digambar ke kanvas itu, diperiksa, lalu ditimpa oleh yang
+      berikutnya. Tidak ada bingkai yang direkam, tidak ada yang disimpan, dan
+      lampu kamera yang padam saat Anda menekan berhenti adalah seluruhnya."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada
+      <code>fetch</code>, tidak ada <code>XMLHttpRequest</code>, dan tidak ada
+      <code>sendBeacon</code> di mana pun di dalam <code>src/</code>, dan
+      <code>Content-Security-Policy</code> halaman ini tidak menyisakan satu
+      alamat pun yang bisa dikirimi asal ini seandainya pun ada. Itulah sebabnya
+      halaman ini tidak bisa memberi tahu Anda ke mana sebuah tautan pendek
+      berakhir: mencari tahu berarti bertanya, dan ia tidak bertanya."""
+
+[[privacy]]
+title = "Ia menunjukkan alamatnya kepada Anda. Ia tidak pernah membukanya."
+body = """
+ Sebuah kode QR
+      tercetak adalah alamat yang tidak bisa dibaca siapa pun, dan justru itulah
+      yang membuat sebuah stiker di atasnya sepadan dengan repotnya seseorang.
+      Tidak ada yang dibuka di sini. Seluruh teksnya dicetak untuk Anda lihat,
+      host yang sebenarnya akan dituju disebutkan tersendiri, dan trik yang
+      membuat satu alamat tampak seperti yang lain &mdash; nama pengguna sebelum
+      sebuah <code>@</code>, nama yang ditulis dalam aksara yang hurufnya
+      berbentuk seperti huruf kita, sebuah pengalihan &mdash; disebutkan di
+      tempat ia muncul."""
+
+[[privacy]]
+title = "Ia juga menunjukkan apa yang disampelnya."
+body = """
+ Di bawah setiap hasil QR ada
+      gambar modul yang benar-benar dibaca halaman ini dari foto Anda. Kalau ia
+      tampak seperti kode yang Anda pindai, jawaban di atasnya sehat; kalau ia
+      tampak seperti semut di layar, tidak. Tidak ada pembaca yang hanya
+      menyerahkan sebuah teks dan tidak lebih yang bisa diperiksa seperti
+      itu."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan
+      pengukuran berasal dari Google, dan tombol donasi dari Buy Me a Coffee.
+      Tidak satu pun diberi sebuah gambar, sebuah bingkai, atau apa pun yang
+      dibaca darinya. Setiap baris yang mengubah piksel menjadi teks disajikan
+      dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, kamera termasuk, karena sejak awal memang tidak ada langkah
+      jaringan di dalamnya. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Berikan gambarnya."
+body = """
+ Jatuhkan sebuah foto atau tangkapan layar ke
+      kotaknya, tempelkan langsung, atau tekan tombol kameranya. Beberapa
+      sekaligus tidak masalah &mdash; masing-masing dibaca sendiri dan
+      masing-masing mendapat jawabannya sendiri. Tangkapan layar dari kode yang
+      sudah ada di layar Anda adalah jalan masuk tercepat dan paling bisa
+      diandalkan, karena tidak ada lensa, tidak ada sudut, dan tidak ada cahaya
+      yang terlibat."""
+
+[[howto]]
+title = "Masukkan seluruh simbolnya ke dalam bingkai, marginnya termasuk."
+body = """
+ Ruang putih di sekeliling
+      sebuah kode adalah bagian dari kodenya: begitulah cara sebuah pembaca
+      menemukan di mana simbolnya berakhir. Foto yang dipangkas sampai ke tepi
+      kotak-kotaknya adalah alasan tunggal yang paling umum sebuah kode tidak
+      terbaca, dan mengisi sekitar separuh bingkai dengan kodenya kira-kira pas
+      &mdash; lebih dekat dari itu dan sudut-sudutnya jatuh di luar gambar."""
+
+[[howto]]
+title = "Baca alamatnya sebelum Anda memutuskan apa pun."
+body = """
+ Maksud memindai sebuah kode di
+      poster, mesin parkir, atau surat adalah untuk tahu ke mana ia pergi, dan
+      itulah satu hal yang sebenarnya tidak diizinkan kamera ponsel Anda
+      lakukan. Host-nya dicetak di sini di barisnya sendiri. Kalau itu bukan nama
+      yang Anda harapkan, Anda sudah mendapat apa yang Anda cari dan tidak ada
+      lagi yang perlu dibuka."""
+
+[[howto]]
+title = "Anggap serius peringatannya, terutama yang tenang."
+body = """
+ Alamat
+      <code>http://</code> polos, nama dalam abjad yang bukan abjad yang tampak,
+      sebuah pemendek tautan, atau apa pun sebelum sebuah <code>@</code> di
+      alamatnya &mdash; masing-masing disebutkan di tempat ia muncul. Tidak satu
+      pun membuktikan apa-apa sendirian. Semuanya sepadan dengan sepuluh detik
+      sebelum Anda pergi ke sana."""
+
+[[howto]]
+title = "Kalau tidak mau terbaca, ubah cahayanya sebelum mengubah yang lain."
+body = """
+ Hampir setiap
+      kegagalan adalah masalah ambang: pantulan melintang di tengah, bayangan di
+      salah satu sudut, atau layar yang difoto dari sudut yang menangkap cahaya
+      latarnya. Bergeserlah supaya silaunya lepas dari kodenya, atau nyalakan
+      lampu kameranya. Kalau tetap gagal, ambil satu foto datar dari depan dan
+      jatuhkan itu &mdash; gambar diam mendapat pencarian yang jauh lebih
+      menyeluruh daripada yang bisa didapat sebuah bingkai langsung."""
+
+[[howto]]
+title = "Periksa gambar sampelnya kalau jawabannya tampak ganjil."
+body = """
+ Buka &ldquo;bagaimana yang satu ini
+      dibaca&rdquo; dan lihat kisi kecilnya. Itulah yang diyakini halaman ini
+      sebagai kodenya, digambar kembali dari modul yang disampelnya. Pembaca yang
+      salah membaca sebuah simbol lalu memperbaikinya menjadi sesuatu yang masuk
+      akal akan memperlihatkannya di sana, dan tidak di tempat lain."""
+
+[[faq]]
+q = "Apakah gambarnya diunggah ke suatu tempat?"
+a = """
+        Tidak, dan begitu juga apa pun yang dibaca darinya. Gambarnya didekodekan
+        ke sebuah kanvas di halaman ini dan dibaca di sana, oleh JavaScript yang
+        disajikan dari situs ini. Alat ini tidak punya fitur jaringan dalam bentuk
+        apa pun &mdash; ia tidak pernah mengambil apa pun dan tidak pernah
+        mengirim apa pun &mdash; dan <code>Content-Security-Policy</code> halaman
+        ini menyebut satu per satu setiap alamat yang boleh dihubunginya, dan
+        tidak satu pun milik kami. Bukti yang paling gamblang adalah memutuskan
+        koneksi internet: ia terus bekerja."""
+
+[[faq]]
+q = "Apakah kameranya merekam sesuatu?"
+a = """
+        Tidak. Sebuah bingkai kamera datang sebagai piksel di tab ini, digambar ke
+        sebuah kanvas, diperiksa, lalu ditimpa oleh bingkai berikutnya sekitar
+        sepersepuluh detik kemudian. Tidak ada yang ditulis ke disk dan tidak ada
+        yang disimpan. Alirannya berhenti pada saat Anda menekan berhenti, ketika
+        tabnya masuk ke latar belakang, dan ketika Anda meninggalkan halamannya
+        &mdash; dan lampu di kamera Anda adalah penanda yang layak dipercaya,
+        karena tidak ada halaman yang bisa mematikannya."""
+
+[[faq]]
+q = "Kenapa ia menunjukkan tautannya alih-alih membukanya?"
+a = """
+        Karena itulah bagian yang berguna. Sebuah kode QR adalah alamat yang tidak
+        bisa Anda baca, dan itulah seluruh alasan sebuah stiker di atas kode pada
+        mesin parkir berhasil: pada saat Anda tahu ke mana ia pergi, Anda sudah di
+        sana. Di sini teksnya dicetak utuh, host-nya disebutkan di barisnya
+        sendiri, dan membukanya adalah tombol terpisah yang Anda tekan setelah
+        membacanya. Itu satu klik tambahan dan itulah klik yang selalu dibutuhkan
+        format ini."""
+
+[[faq]]
+q = "Apa saja yang bisa dibacanya?"
+a = """
+        Kode QR di setiap versi dari 1 sampai 40, pada keempat tingkat koreksi
+        galatnya, dalam mode numerik, alfanumerik, byte, dan kanji, dengan set
+        karakter ECI dan simbol structured-append yang dilaporkan alih-alih
+        dibuang diam-diam. Di sisi yang bergaris: EAN-13, EAN-8, UPC-A, UPC-E,
+        ITF-14, Interleaved 2 of 5, Code 128, dan Code 39. Ia tidak membaca Data
+        Matrix, PDF417, Aztec, atau MaxiCode."""
+
+[[faq]]
+q = "Kode saya tidak mau terbaca. Apa yang salah?"
+a = """
+        Sembilan dari sepuluh kali penyebabnya salah satu dari tiga hal. Margin
+        putihnya terpangkas, padahal sebuah pembaca memakai margin itu untuk
+        menemukan di mana simbolnya berakhir. Ada pantulan atau bayangan melintang
+        di sebagian kodenya, sehingga tidak ada ambang yang memisahkan kotak
+        gelapnya dari yang terang. Atau kodenya terlalu kecil di bingkainya
+        sehingga modulnya tidak lebih dari satu dua piksel lebarnya. Pindahkan
+        cahayanya, isi sekitar separuh bingkai, dan ambil gambarnya dari depan
+        alih-alih dari sudut."""
+
+[[faq]]
+q = "Bisakah ia membaca kode yang rusak atau tertutup sebagian?"
+a = """
+        Sering kali bisa, dan itu formatnya yang bekerja sebagaimana dirancang,
+        bukan kepintaran apa pun di sini. Setiap kode QR membawa data periksa
+        Reed-Solomon, dan simbol yang dibuat pada tingkat H bisa kehilangan
+        sekitar 30% modulnya dan tetap dibangun ulang dengan persis. Halaman ini
+        mengatakan berapa banyak codeword yang harus diperbaikinya di bawah
+        &ldquo;bagaimana yang satu ini dibaca&rdquo;, jadi Anda bisa melihat
+        seberapa dekat ia dengan batasnya. Yang tidak akan dilakukannya adalah
+        menebak: simbol yang rusak melampaui yang bisa ditanggung pemeriksaannya
+        dilaporkan tidak terbaca alih-alih dijawab keliru."""
+
+[[faq]]
+q = "Kenapa ia bilang tidak bisa memberi tahu ke mana tautan bit.ly saya pergi?"
+a = """
+        Karena mencari tahu berarti bertanya kepada bit.ly, dan itu sebuah
+        permintaan jaringan. Setiap klaim lain di halaman ini bertumpu pada tidak
+        adanya kode di sini yang menghubungi apa pun, dan diam-diam membuat
+        pengecualian untuk yang satu ini akan lebih tidak berharga daripada
+        jawabannya. Jadi pemendeknya disebutkan, dan apa yang disembunyikannya
+        dibiarkan jujur tidak diketahui. Kalau Anda ingin menyelesaikannya,
+        tempelkan ke sesuatu yang memang bersedia mengambil."""
+
+[[faq]]
+q = "Apakah memindai kode QR itu aman?"
+a = """
+        Memindainya aman. Menindaklanjutinya itulah risikonya, dan risikonya
+        nyata: kode yang ditempel di atas kode asli pada mesin parkir, di meja
+        restoran, dan di kartu pengiriman paket kini cukup umum sampai punya nama
+        sendiri. Yang membuatnya berhasil adalah tidak ada orang yang bisa membaca
+        sebuah kode dengan memandanginya. Membacanya tanpa membukanya &mdash;
+        dan itulah yang dilakukan halaman ini &mdash; melenyapkan seluruh
+        keuntungan itu, dan sepuluh detik yang dibutuhkan untuk melihat host-nya
+        adalah seluruh pertahanannya."""
+
+[[faq]]
+q = "Kisi kecil di bawah setiap hasil itu apa?"
+a = """
+        Modul yang benar-benar disampel halaman ini dari gambar Anda, digambar
+        kembali dengan satu kotak per modul. Ia ada di sana supaya pembacaannya
+        bisa diperiksa dengan mata alih-alih dipercaya: kalau kisi itu tampak
+        seperti kode yang Anda foto, jawaban di atasnya datang dari piksel yang
+        benar. Hampir tidak ada pembaca yang menunjukkan ini kepada Anda, dan
+        itulah bedanya alat yang bisa Anda periksa dengan alat yang harus Anda
+        percayai."""
+
+[[faq]]
+q = "Apakah ia membaca beberapa kode dalam satu gambar?"
+a = """
+        Satu per gambar, untuk saat ini. Jatuhkan beberapa gambar sekaligus dan
+        masing-masing dibaca sendiri, dan kameranya membaca kode demi kode saat
+        Anda menggerakkannya, menyimpan setiap kode baru yang belum dilihatnya.
+        Satu foto berisi selembar penuh kode adalah pekerjaan untuk memangkasnya,
+        atau untuk mengarahkan kameranya satu per satu."""
+
+[[faq]]
+q = "Kenapa ia bilang barcode saya formatnya berbeda dari yang saya minta?"
+a = """
+        Karena sebuah barcode tidak membawa namanya sendiri. UPC-A adalah EAN-13
+        yang digit pertamanya nol, ITF-14 adalah Interleaved 2 of 5 dengan empat
+        belas digit dan digit periksa yang sah, dan Code 128 dalam mode numeriknya
+        tidak mirip apa pun yang lain. Yang dilaporkan halaman ini adalah apa yang
+        dikatakan garis-garisnya ditambah apa yang dikukuhkan digit periksanya,
+        dan itu sebanyak yang diketahui simbolnya sendiri."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia terus
+        bekerja, kamera dan semuanya. Itu juga cara paling sederhana untuk
+        membuktikan tidak ada yang diunggah: pembaca yang mengirim gambar Anda
+        pergi untuk didekodekan akan berhenti pada saat Anda mencabut koneksi."""
+
+[schema]
+description = "Baca kode QR atau barcode linear dari sebuah gambar, tangkapan layar, atau kamera langsung, sepenuhnya di peramban. Menampilkan teks hasil dekode dan, untuk tautan, host yang akan dituju, sebelum apa pun dibuka. Mendukung QR versi 1 sampai 40 dengan koreksi galat Reed-Solomon, serta EAN-13, EAN-8, UPC-A, UPC-E, ITF-14, Interleaved 2 of 5, Code 128, dan Code 39. Tidak ada yang diunggah dan tidak ada bingkai kamera yang direkam."
+features = [
+  "Membaca kode QR dari sebuah foto, tangkapan layar, gambar yang ditempelkan, atau kamera langsung",
+  "Setiap versi QR dari 1 sampai 40, keempat tingkat koreksi galat, dan mode numerik, alfanumerik, byte, serta kanji",
+  "Koreksi Reed-Solomon, jadi kode yang tergores, terlipat, atau tertutup sebagian tetap terbaca",
+  "Membetulkan sudut dan perspektif memakai pola perataannya",
+  "Membaca kode yang tercetak terang di atas gelap, dan kode yang difoto terbalik",
+  "EAN-13, EAN-8, UPC-A, UPC-E, ITF-14, Interleaved 2 of 5, Code 128, dan Code 39",
+  "Menampilkan seluruh alamatnya, dan host yang sungguh dituju, sebelum apa pun dibuka",
+  "Menyebutkan trik yang menyamarkan sebuah tautan: nama pengguna sebelum @, abjad yang mirip, sebuah pengalihan",
+  "Membongkar muatan Wi-Fi, kartu kontak, email, SMS, telepon, dan peta menjadi kolom yang terbaca",
+  "Menggambar modul yang disampelnya, jadi pembacaannya bisa diperiksa alih-alih dipercaya",
+  "Tidak ada bingkai kamera yang direkam atau disimpan; alirannya berhenti bersama tabnya",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan gambar sebuah kode di sini"
+hint = "atau klik untuk menelusuri &mdash; sebuah foto, tangkapan layar, PNG, apa pun yang bisa dibuka peramban Anda"

--- a/locales/id/tools/qr-barcode.html
+++ b/locales/id/tools/qr-barcode.html
@@ -1,0 +1,194 @@
+<!--
+  tools/qr-barcode/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. The symbology names in the menu are the
+  names of the standards and stay as they are. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; jenis kodenya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih jenis kodenya</h2>
+
+    <p class="card-lede">
+      Kode QR memuat apa saja dan itulah yang dicari kamera ponsel. Barkode
+      memuat sebuah angka, dan yang mana yang Anda butuhkan biasanya sudah
+      ditentukan untuk Anda &mdash; oleh toko, gudang, atau perusahaan pengiriman
+      yang memintanya.
+    </p>
+
+    <div class="option-row">
+      <label for="symbology">Jenis kode</label>
+      <select id="symbology">
+        <optgroup label="Persegi">
+          <option value="qr" selected>Kode QR</option>
+        </optgroup>
+        <optgroup label="Batang">
+          <option value="code128">Code 128</option>
+          <option value="ean13">EAN-13</option>
+          <option value="upca">UPC-A</option>
+          <option value="ean8">EAN-8</option>
+          <option value="itf14">ITF-14</option>
+          <option value="itf">Interleaved 2 of 5</option>
+          <option value="code39">Code 39</option>
+        </optgroup>
+      </select>
+    </div>
+
+    <p class="field-summary" id="symbology-note"></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; string-nya sendiri -->
+  <section class="card">
+    <h2><span class="step">2</span> Sebutkan apa yang masuk ke dalamnya</h2>
+
+    <div class="option-row" id="format-row">
+      <label for="format">Apa yang dimuatnya</label>
+      <select id="format"></select>
+    </div>
+
+    <p class="card-lede" id="format-note"></p>
+
+    <div id="fields" class="fields"></div>
+
+    <p id="input-error" class="error" role="alert" hidden></p>
+
+    <!--
+      The finished string, shown rather than hidden. A "Wi-Fi QR code" is an
+      ordinary QR code holding a line of text in a format phones recognise, and
+      when a phone does not act on one, this line is the thing to look at.
+    -->
+    <details class="encoded" id="encoded-panel">
+      <summary>String persis yang akan dimuat kode ini</summary>
+      <pre id="encoded"></pre>
+      <p class="field-summary" id="encoded-note"></p>
+    </details>
+  </section>
+
+  <!-- Langkah 3 &mdash; bagaimana ia digambar -->
+  <section class="card">
+    <h2><span class="step">3</span> Pilih tampilannya</h2>
+
+    <fieldset class="options" id="qr-options">
+      <legend>Kode QR-nya</legend>
+
+      <div class="option-row">
+        <label for="level">Seberapa banyak kerusakan yang bisa ditanggungnya</label>
+        <select id="level">
+          <option value="L">L &mdash; sekitar 7% bisa dipulihkan, kode terkecil</option>
+          <option value="M" selected>M &mdash; sekitar 15%, pilihan yang biasa</option>
+          <option value="Q">Q &mdash; sekitar 25%</option>
+          <option value="H">H &mdash; sekitar 30%, untuk cetakan yang akan aus</option>
+        </select>
+      </div>
+
+      <div class="option-row">
+        <label for="quiet">Margin, dalam modul</label>
+        <input type="number" id="quiet" value="4" min="0" max="16" step="1" inputmode="numeric">
+      </div>
+
+      <p class="field-summary">
+        Margin adalah bagian dari kodenya, bukan ruang di sekelilingnya. Empat
+        modul adalah yang diminta spesifikasinya, dan kode yang dipangkas sampai
+        tepinya adalah kode yang tidak akan dilihat banyak pemindai sama sekali.
+      </p>
+    </fieldset>
+
+    <fieldset class="options" id="barcode-options" hidden>
+      <legend>Barkodenya</legend>
+
+      <div class="option-row">
+        <label for="bar-width">Batang tersempit, dalam piksel</label>
+        <input type="number" id="bar-width" value="2" min="1" max="10" step="1" inputmode="numeric">
+      </div>
+
+      <div class="option-row">
+        <label for="bar-height">Tinggi batangnya, dalam piksel</label>
+        <input type="number" id="bar-height" value="120" min="20" max="600" step="10" inputmode="numeric">
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="show-text" checked>
+        <span>
+          <strong>Cetak karakternya di bawah</strong>
+          <span class="check-note">
+            Apa yang dibaca seseorang ketika pemindainya tidak mau. Pada kode
+            ritel, digitnya juga duduk di marginnya, dan itu disengaja: mereka
+            menandai ruang putih yang tidak boleh dipangkas siapa pun.
+          </span>
+        </span>
+      </label>
+
+      <label class="check" id="code39-check-row" hidden>
+        <input type="checkbox" id="code39-check">
+        <span>
+          <strong>Tambahkan karakter periksa</strong>
+          <span class="check-note">
+            Code 39 biasanya tidak membawanya. Sebagian sistem bersikeras
+            memintanya; tambahkan hanya kalau sistem Anda begitu, karena pembaca
+            yang tidak mengharapkannya akan membacanya sebagai karakter tambahan
+            di ujung.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <fieldset class="options">
+      <legend>Warna dan ukuran</legend>
+
+      <div class="colour-row">
+        <div class="option-row">
+          <label for="foreground">Kodenya</label>
+          <input type="color" id="foreground" value="#000000">
+        </div>
+        <div class="option-row">
+          <label for="background">Di belakangnya</label>
+          <input type="color" id="background" value="#ffffff">
+        </div>
+      </div>
+
+      <label class="check">
+        <input type="checkbox" id="transparent">
+        <span>
+          <strong>Tanpa latar sama sekali</strong>
+          <span class="check-note">
+            Transparan, untuk ditaruh di atas sesuatu yang sudah punya warna.
+            SVG dan PNG-nya sama-sama menjaganya; apa pun yang berakhir di
+            belakangnya harus pucat, atau pemindai tidak akan menemukan kontras.
+          </span>
+        </span>
+      </label>
+
+      <div class="option-row" id="size-row">
+        <label for="size">Ukuran gambarnya, dalam piksel</label>
+        <input type="number" id="size" value="512" min="64" max="4096" step="16" inputmode="numeric">
+      </div>
+
+      <p class="field-summary" id="size-note"></p>
+    </fieldset>
+  </section>
+
+  <!-- Langkah 4 &mdash; hasilnya -->
+  <section class="card" id="result-card">
+    <h2><span class="step">4</span> Ambil</h2>
+
+    <div class="preview" id="preview" role="img" aria-label="Kode yang Anda buat"></div>
+
+    <p class="facts" id="facts"></p>
+
+    <div class="run-row">
+      <button type="button" id="download-svg" class="primary">Unduh SVG-nya</button>
+      <button type="button" id="download-png" class="primary">Unduh PNG-nya</button>
+      <button type="button" id="copy-png" class="ghost">Salin gambarnya</button>
+    </div>
+
+    <p class="field-summary" id="download-note" role="status"></p>
+
+    <p class="field-summary">
+      SVG-lah yang layak disimpan. Ia adalah kodenya sebagai instruksi alih-alih
+      sebagai piksel, jadi ia tercetak pada ukuran apa pun tanpa melembut
+      &mdash; dan itu lebih penting di sini daripada pada kebanyakan gambar,
+      karena tepi yang kabur justru yang tidak bisa ditangkap pemindai.
+    </p>
+  </section>
+</main>

--- a/locales/id/tools/qr-barcode.toml
+++ b/locales/id/tools/qr-barcode.toml
@@ -1,0 +1,346 @@
+#
+# Pembuat QR dan Barkode - Bahasa Indonesia.
+#
+# Overrides for tools/qr-barcode/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama simbologi (EAN-13, UPC-A, ITF-14, Code 128, Code 39) dan tingkat koreksi
+# galat (L, M, Q, H) tetap Latin: itulah yang diminta orang yang akan memindai.
+#
+
+name = "Pembuat QR dan Barkode"
+heading = "QR&nbsp;dan&nbsp;Barkode <span class=\"h1-kw\">&mdash; buat kode QR atau barkode, tanpa internet</span>"
+tagline = "Ketik, dan ia menjadi sebuah kode. Tidak ada yang dikirim untuk membuatnya."
+
+title = "Pembuat Kode QR &amp; Barkode &mdash; Gratis, Tanpa Pendaftaran, Tanpa Unggah"
+description = "Buat kode QR untuk sebuah tautan, jaringan Wi-Fi, atau kartu kontak, atau barkode EAN-13, UPC-A, Code 128, atau Code 39. Unduh sebagai SVG atau PNG. Semuanya terjadi di peramban Anda."
+og_title = "Buat kode QR atau barkode tanpa mengirim apa pun ke siapa pun"
+og_description = "Tautan, kata sandi Wi-Fi, kartu kontak, dan barkode ritel, digambar di peramban Anda sendiri dan diunduh sebagai SVG atau PNG. Tanpa akun, tanpa tanda air, tanpa piksel pelacak di tengah kode Anda."
+og_image_alt = "Pembuat QR dan Barkode - buat kode QR atau barkode, tanpa ada yang diunggah"
+
+pledge = """
+    Sebuah kode QR adalah aritmetika atas sebuah string: tidak ada file untuk
+    dikirim dan tidak ada layanan untuk dimintai. Setiap langkah &mdash; memilih
+    modenya, memilih versinya, koreksi galat Reed-Solomon, maskernya, batang
+    sebuah barkode dan angka periksa di bawahnya &mdash; terjadi dalam kira-kira
+    seribu baris JavaScript di halaman ini yang bisa Anda baca. Alat ini tidak
+    punya fitur jaringan dalam bentuk apa pun, dan itu lebih penting di sini
+    daripada di sebagian besar halaman: yang dikodekan sering kali adalah kata
+    sandi Wi-Fi."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu ketik sebuah kata sandi ke formulir Wi-Fi. Tidak satu pun permintaan
+      membawa satu karakter pun darinya. Atau cabut koneksi internet dan tetap
+      buat kodenya."""
+
+read_first = """
+, <code>src/qr-encode.js</code> dan
+      <code>src/qr.js</code> untuk kode QR-nya sendiri &mdash; mode, versi, dan
+      bloknya di yang satu, dan pola, masker, serta bit formatnya di yang lain
+      &mdash; <code>src/gf256.js</code> untuk koreksi galatnya, dan
+      <code>src/barcode.js</code> untuk yang bergaris-garis."""
+
+howto_heading = "Cara membuat kode QR tanpa mengunggah apa pun"
+
+card = """
+            Kode QR untuk sebuah tautan, jaringan Wi-Fi, atau kartu kontak
+            &mdash; atau barkode ritel dengan angka periksanya sudah dihitung.
+            SVG atau PNG."""
+
+[words]
+plural = "kode dan teks di dalamnya"
+choose = "apa yang masuk ke dalamnya"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa masa berlaku"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Tidak ada tujuan ke mana pun bagi apa yang Anda ketik."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat kata sandi
+      Wi-Fi bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di mana
+      pun di dalam <code>src/</code>. Kodenya dibangun dari string itu dengan
+      aritmetika dan digambar sebagai SVG, di halaman ini, di mesin Anda."""
+
+[[privacy]]
+title = "Kodenya tidak menunjuk ke kami."
+body = """
+ Apa yang Anda ketik itulah isi kodenya.
+      Beberapa pembuat gratis mengembalikan kode yang memuat tautan ke situs
+      mereka sendiri, yang kemudian mengalihkan ke situs Anda &mdash; jadi setiap
+      pemindaian dihitung oleh mereka, dan kodenya berhenti bekerja pada hari
+      mereka berhenti membayar nama domainnya atau memutuskan kuota gratisnya
+      habis. Tidak ada di sini yang memendekkan, mengalihkan, atau melacak:
+      string yang ditampilkan di halaman adalah string di dalam gambarnya."""
+
+[[privacy]]
+title = "PNG-nya dibuat dari SVG yang ada di layar."
+body = """
+ Unduhannya bukan penggambaran kedua yang
+      mungkin berbeda dari pratinjaunya. Markah yang sama diserahkan ke peramban
+      dan dicat ke sebuah kanvas, dan itu juga sebabnya hal itu bisa dilakukan
+      tanpa menghubungi apa pun: tidak ada font untuk diambil dan tidak ada
+      gambar untuk dimuat di dalamnya."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google, dan tombol donasi dari Buy Me a Coffee. Tidak satu pun diberi
+      apa pun yang Anda ketik. Setiap baris yang mengubah sebuah string menjadi
+      sebuah kode disajikan dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih jenis kodenya."
+body = """
+ Kode QR memuat apa saja dan itulah yang
+      dicari kamera ponsel, jadi itulah jawabannya kecuali ada yang mengatakan
+      lain kepada Anda. Barkode memuat sebuah angka, dan yang mana yang Anda
+      butuhkan ditentukan oleh siapa pun yang akan memindainya &mdash; sebuah
+      toko mau EAN-13 atau UPC-A, kardus pengiriman mau ITF-14, dan apa pun yang
+      internal biasanya Code 128."""
+
+[[howto]]
+title = "Sebutkan apa yang masuk ke dalamnya."
+body = """
+ Tautan adalah kasus yang lazim, dan
+      kotak-kotak di atasnya membangun format lain yang dikenal ponsel: jaringan
+      Wi-Fi yang menawarkan diri untuk disambungkan, kartu kontak yang menawarkan
+      diri untuk disimpan, sebuah email, sebuah pesan teks, sebuah nomor telepon,
+      sebuah tempat di peta. Apa pun yang Anda pilih, string yang sudah jadi
+      ditampilkan di halaman &mdash; hanya itulah yang pernah dimuat sebuah kode
+      QR."""
+
+[[howto]]
+title = "Pilih seberapa banyak kerusakan yang boleh ditanggungnya."
+body = """
+ Empat tingkat itu memasukkan lebih
+      banyak atau lebih sedikit koreksi galat, dan lebih banyak koreksi berarti
+      kode yang lebih besar dan lebih padat. L cukup untuk layar, M untuk kertas
+      biasa, dan H untuk sesuatu yang akan dipegang-pegang, dicetak kecil, atau
+      ditempel di jendela yang kena matahari. Kode di menu yang dilap setiap hari
+      layak diberi Q atau H."""
+
+[[howto]]
+title = "Atur ukuran, margin, dan warnanya."
+body = """
+ Margin adalah bagian dari kodenya:
+      empat modul ruang sunyi mengelilinginya adalah yang diminta spesifikasinya,
+      dan memangkasnya adalah alasan tunggal yang paling umum kenapa kode
+      tercetak tidak mau terpindai. Gelap di atas terang, dengan kontras
+      sungguhan &mdash; pemindai membaca selisih antara keduanya, jadi abu-abu
+      pucat di atas putih tidak akan cukup, dan terang di atas gelap gagal
+      mentah-mentah pada cukup banyak pembaca."""
+
+[[howto]]
+title = "Periksa dengan ponsel yang Anda punya."
+body = """
+ Sebelum Anda mencetak seribu, pindai
+      yang ada di layar Anda. Itu memakan sepuluh detik dan menangkap seluruh
+      kategori kesalahan yang tidak bisa ditangkap sebuah pratinjau: kata sandi
+      Wi-Fi dengan karakter yang perlu dikaburkan, tautan yang kehilangan
+      <code>https://</code>-nya, nomor barkode yang kurang satu digit."""
+
+[[howto]]
+title = "Ambil SVG-nya."
+body = """
+ Ia adalah kodenya sebagai instruksi alih-alih
+      sebagai piksel, jadi ia tercetak pada ukuran apa pun tanpa melembut, dan
+      tepi yang lembut justru yang tidak bisa ditangkap pemindai. Ambil PNG-nya
+      juga kalau apa pun tempat Anda menempelkannya tidak menerima SVG; ia
+      digambar pada jumlah piksel bulat per modul, jadi tepinya juga tidak
+      kabur."""
+
+[[faq]]
+q = "Apakah yang saya ketik dikirim ke suatu tempat?"
+a = """
+        Tidak. Sebuah kode QR adalah aritmetika atas sebuah string, dan
+        aritmetika itu berjalan di peramban Anda sendiri di mesin Anda sendiri.
+        Alat ini tidak punya fitur jaringan dalam bentuk apa pun &mdash; ia tidak
+        pernah mengambil apa pun dan tidak pernah mengirim apa pun &mdash; dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+        ini. Itu lebih bernilai di sini daripada di sebagian besar halaman,
+        karena yang paling sering dimasukkan orang ke dalam kode QR adalah kata
+        sandi Wi-Fi mereka."""
+
+[[faq]]
+q = "Apakah kode ini kedaluwarsa, atau berhenti bekerja nanti?"
+a = """
+        Tidak, dan memang tidak bisa. Apa yang Anda ketik itulah isi kodenya,
+        jadi memindainya mengembalikan persis string itu selamanya. Kode yang
+        kedaluwarsa adalah yang di dalamnya ada alamat orang lain: kode QR
+        "dinamis" memuat tautan ke server pembuatnya, yang mengalihkan ke server
+        Anda, yang berarti mereka bisa menghitung setiap pemindaian, mengubah
+        tujuannya, atau mematikannya ketika masa coba berakhir. Tidak ada di sini
+        yang mengalihkan lewat apa pun."""
+
+[[faq]]
+q = "Apakah gratis, dan bisakah saya memakainya untuk keperluan komersial?"
+a = """
+        Gratis, tidak ada akun, tidak ada tanda air, dan tidak ada batas berapa
+        banyak yang Anda buat, dan Anda boleh menaruh hasilnya di sebuah produk,
+        poster, atau etalase. QR Code adalah merek dagang terdaftar milik Denso
+        Wave, yang telah menyatakan tidak akan menegakkannya terhadap orang yang
+        memakai kodenya &mdash; spesifikasinya diterbitkan sebagai ISO/IEC 18004
+        dan bebas diimplementasikan, dan itulah yang dilakukan halaman ini. Situs
+        ini memasang iklan, dan itulah yang membiayainya."""
+
+[[faq]]
+q = "Tingkat koreksi galat mana yang harus saya pilih?"
+a = """
+        M kecuali Anda punya alasan. L membuat kode terkecil dan cukup untuk
+        layar; M bertahan terhadap penanganan biasa; Q dan H untuk kode yang akan
+        dicetak kecil, dilaminasi, ditempel di jendela, atau tertutup sebagian
+        oleh logo. Setiap kenaikan memasukkan lebih banyak data periksa, yang
+        butuh simbol lebih besar untuk jumlah teks yang sama &mdash; naik dari L
+        ke H kira-kira menggandakan jumlah modul untuk string yang sama."""
+
+[[faq]]
+q = "Berapa banyak yang bisa dimuat sebuah kode QR?"
+a = """
+        Pada ukuran terbesar, 177 modul persegi, sampai 7.089 digit, 4.296 huruf
+        kapital dan digit, atau 2.953 byte apa pun lainnya &mdash; dan itu pada
+        koreksi galat terlemah; pada yang terkuat kira-kira sepertiganya. Dalam
+        praktik, batasnya bukan formatnya melainkan pemindainya: lewat beberapa
+        ratus karakter, modulnya menjadi begitu kecil sehingga kamera ponsel biasa
+        tidak bisa menangkapnya pada jarak lengan. Kode yang panjang biasanya
+        pertanda bahwa yang seharusnya ada di dalamnya adalah tautan pendek."""
+
+[[faq]]
+q = "Kenapa kode saya lebih besar kalau tautannya saya tulis dengan huruf kecil?"
+a = """
+        Karena kode QR punya mode untuk huruf kapital dan digit yang mengemas dua
+        karakter ke dalam sebelas bit, dan tidak punya mode seperti itu untuk
+        huruf kecil, yang memakan delapan bit masing-masing. URL yang ditulis
+        <code>HTTPS://EXAMPLE.COM/PAGE</code> bisa sepertiga lebih kecil daripada
+        URL yang sama dengan huruf kecil. Skema dan hos-nya tidak peka huruf
+        besar-kecil, jadi meneriakkannya tidak mengubah apa pun selain ukurannya;
+        jalur setelah hos-nya peka, jadi biarkan bagian itu."""
+
+[[faq]]
+q = "Bisakah ia membaca kode QR sekaligus membuatnya?"
+a = """
+        Bukan halaman ini, tapi yang di sebelah bisa:
+        <a href="../pindai-kode-qr/">pembacanya</a> menerima sebuah foto,
+        tangkapan layar, atau kamera Anda dan mengembalikan string-nya. Itu
+        pekerjaan yang jauh lebih besar daripada menggambar satu &mdash; mencari
+        simbolnya di dalam sebuah gambar, mengoreksi sudut pengambilannya, dan
+        memperbaiki kerusakannya adalah tiga masalah yang tidak dimiliki halaman
+        ini &mdash; dan itulah sebabnya ia menjadi alat tersendiri alih-alih
+        sebuah tombol di sini. Ia berjalan dengan syarat yang sama seperti segala
+        yang lain: tidak ada yang diunggah, dan tidak ada bingkai kamera yang
+        disimpan."""
+
+[[faq]]
+q = "Untuk apa marginnya, dan bisakah saya membuatnya lebih kecil?"
+a = """
+        Ruang putih di sekeliling kode QR adalah bagian dari kodenya. Sebuah
+        pembaca memakainya untuk menemukan di mana simbolnya berakhir, dan
+        spesifikasinya meminta empat modul di setiap sisi; sebuah barkode mau
+        sekitar sepuluh. Anda bisa mengaturnya ke nol di sini dan gambarnya akan
+        tampak lebih rapi, dan cukup banyak pemindai kemudian tidak akan
+        melihatnya sama sekali &mdash; terutama di atas latar yang ramai. Kalau
+        ruangnya yang jadi masalah, perkecil kodenya alih-alih memangkas
+        marginnya."""
+
+[[faq]]
+q = "Barkode mana yang saya butuhkan?"
+a = """
+        Mana pun yang diminta orang yang akan memindainya. EAN-13 adalah barkode
+        ritel di luar Amerika Utara dan UPC-A yang di Amerika Utara &mdash;
+        keduanya butuh nomor yang diterbitkan GS1 untuk Anda, karena nomornya
+        menandai perusahaan Anda, bukan sekadar produknya. EAN-8 adalah versi
+        pendek untuk kemasan kecil. ITF-14 dipasang di kardus pengiriman. Code
+        128 dan Code 39 memuat teks selain digit dan sama sekali tidak butuh
+        pendaftaran, yang membuatnya jawaban tepat untuk apa pun yang internal:
+        aset, rak, lembar kerja."""
+
+[[faq]]
+q = "Apa itu angka periksa, dan kenapa alat ini menambahkannya?"
+a = """
+        Ia adalah digit terakhir sebuah barkode ritel, dihitung dari digit-digit
+        sebelumnya, sehingga sebuah pemindai bisa membedakan salah baca dari
+        berhasil baca. EAN-13 mau dua belas digit dan menghitung yang ketiga
+        belas; UPC-A mau sebelas dan menghitung yang kedua belas. Ketik nomor
+        pendeknya dan halaman ini menambahkannya. Ketik nomor lengkapnya dan ia
+        memeriksa yang Anda berikan &mdash; dan menolak, alih-alih diam-diam
+        membetulkannya, karena digit yang salah lalu diperbaiki diam-diam adalah
+        label yang terpindai sebagai produk orang lain."""
+
+[[faq]]
+q = "Bisakah saya menaruh logo di tengah kode QR?"
+a = """
+        Tidak di sini, tapi alasan hal itu berhasil di tempat lain layak
+        diketahui: koreksi galatlah yang memungkinkannya. Pada tingkat H, kira-kira
+        30% modulnya bisa hancur dan kodenya tetap terbaca, jadi logo yang menutupi
+        kurang dari itu di bagian tengah &mdash; tempat tidak ada pola pencari
+        &mdash; adalah kerusakan yang bisa diperbaiki. Masukkan kodenya ke
+        penyunting gambar Anda pada tingkat H, jaga logonya di bawah sekitar
+        seperlima luasnya, dan ujilah dengan ponsel sungguhan alih-alih
+        mempercayainya begitu saja."""
+
+[[faq]]
+q = "Kenapa SVG lebih baik daripada PNG?"
+a = """
+        Karena sebuah kode terdiri dari tepi, dan sebuah PNG punya jumlah piksel
+        tetap untuk membuatnya. Perbesar satu dan setiap tepinya melembut; tepi
+        yang lembut justru yang menyulitkan pemindai, dan pencetak 1200 dpi yang
+        diberi PNG 512 piksel sedang diminta mengarang selisihnya. Sebuah SVG
+        adalah kotak-kotaknya sebagai instruksi, jadi ia tercetak tajam di
+        kartunama maupun di bilbor. PNG di sini digambar pada jumlah piksel bulat
+        per modul, dan itu yang terbaik yang bisa dilakukan sebuah PNG."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim teks Anda ke tempat lain untuk digambarkan
+        kodenya akan berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Buat kode QR atau barkode linear dari sebuah string di peramban. Kode QR untuk tautan, jaringan Wi-Fi, kartu kontak, email, SMS, nomor telepon, dan koordinat, dengan keempat tingkat koreksi galat; barkode EAN-13, EAN-8, UPC-A, ITF-14, Interleaved 2 of 5, Code 128, dan Code 39 beserta angka periksanya. Unduh sebagai SVG atau PNG. Tidak ada yang diunggah."
+features = [
+  "Kode QR pada setiap versi dari 1 sampai 40, dalam mode numerik, alfanumerik, dan byte",
+  "Keempat tingkat koreksi galat, dengan biaya masing-masing disebutkan terang-terangan",
+  "Format siap pakai: jaringan Wi-Fi, kartu kontak, email, pesan teks, nomor telepon, lokasi peta",
+  "Menampilkan string persis yang akan dimuat kodenya, alih-alih menyembunyikannya",
+  "EAN-13, EAN-8, dan UPC-A, dengan angka periksa dihitung atau diverifikasi",
+  "ITF-14 dan Interleaved 2 of 5 untuk kardus dan pergudangan",
+  "Code 128 dengan pemakaian otomatis mode numeriknya, dan Code 39 dengan karakter periksa opsional",
+  "Digit yang terbaca manusia dicetak di bawah barkode, di tempat yang tepat",
+  "Keluaran SVG, jadi ia tercetak tajam pada ukuran apa pun, dan PNG yang digambar pada piksel bulat per modul",
+  "Dua warna apa pun, atau tanpa latar sama sekali",
+  "Tidak pernah mengalihkan: tanpa tautan pendek, tanpa pelacakan, tanpa apa pun yang bisa kedaluwarsa",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]

--- a/locales/id/tools/redact-image.html
+++ b/locales/id/tools/redact-image.html
@@ -1,0 +1,187 @@
+<!--
+  tools/redact-image/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; gambarnya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih gambarnya</h2>
+
+    <p class="card-lede">
+      Tangkapan layar rekening koran, foto paspor, tagihan yang ada alamatnya
+      &mdash; gambar yang perlu disensor orang justru gambar yang tidak boleh
+      mereka unggah ke server orang asing untuk keperluan itu. Gambar ini dibaca
+      peramban langsung dari disk Anda.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <div id="loaded" class="loaded-row" hidden>
+      <p id="loaded-name" class="loaded-name"></p>
+      <button type="button" id="clear-image" class="ghost danger">Pilih yang lain</button>
+    </div>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; kotaknya -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Tutupi apa yang tidak boleh terlihat</h2>
+
+    <p id="edit-empty" class="field-summary">Pilih sebuah gambar; ia muncul di sini untuk digambari.</p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Seret di atas gambar untuk menggambar sebuah kotak. Seret kotaknya untuk
+        memindahkan, pegangannya untuk mengubah ukuran, atau tekan <kbd>Tab</kbd>
+        untuk mencapai salah satunya lalu pakai tombol panah &mdash; <kbd>Alt</kbd>
+        dan panah mengubah ukuran, <kbd>Delete</kbd> membuangnya. Apa yang Anda
+        lihat di bawah setiap kotak adalah hasil sungguhannya: pratinjaunya
+        digambar seukuran layar oleh kode yang sama yang menulis file-nya.
+      </p>
+
+      <!-- The picture is a canvas, not an <img>, because the redaction is
+           painted into it rather than laid over it. The boxes above it are
+           outlines and handles only; src/stage.js adds them. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="preview"></canvas>
+        </div>
+      </div>
+
+      <fieldset class="options" id="style-group">
+        <legend>Apa yang dilakukan sebuah kotak baru</legend>
+
+        <label class="check">
+          <input type="radio" name="style" value="fill" checked>
+          <span>
+            <strong>Hitamkan</strong>
+            <span class="check-note">
+              Satu warna datar dari tepi ke tepi. Tidak ada dari yang ada di sana
+              yang selamat &mdash; tidak sebuah garis luar, tidak sebuah
+              rata-rata, tidak jumlah karakternya. Ini satu-satunya dari ketiganya
+              yang menuntaskan pekerjaan, dan inilah yang dipakai untuk apa pun
+              yang terbaca sebagai teks.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="style" value="pixelate">
+          <span>
+            <strong>Pikselkan</strong>
+            <span class="check-note">
+              Setiap blok menjadi warna rata-rata blok itu. Piksel aslinya sudah
+              hilang dari file, tapi kisi rata-rata tetaplah pengukuran atas apa
+              yang ada di bawahnya &mdash; dan untuk teks dengan huruf biasa, itu
+              cukup untuk merekonstruksi aslinya dalam karya yang sudah
+              diterbitkan. Cocok untuk wajah di kerumunan; tidak untuk sebuah
+              nomor rekening.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="style" value="blur">
+          <span>
+            <strong>Buramkan</strong>
+            <span class="check-note">
+              Setiap piksel menjadi rata-rata terbobot dari tetangganya. Keberatan
+              yang sama dengan pikselisasi, sedikit lebih tajam: memburamkan
+              adalah sebuah konvolusi dan konvolusi pada prinsipnya bisa dibalik.
+              Pakai di tempat Anda ingin sesuatu melembut, bukan tersembunyi.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row">
+          <label for="strength">Seberapa keras pikselisasi dan buram diterapkan</label>
+          <select id="strength">
+            <option value="light">Ringan</option>
+            <option value="medium" selected>Sedang</option>
+            <option value="heavy">Berat</option>
+          </select>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <div class="frame-actions">
+        <button type="button" id="add-box" class="ghost">Tambah kotak di tengah</button>
+        <button type="button" id="undo" class="ghost" disabled>Batalkan</button>
+        <button type="button" id="clear-boxes" class="ghost danger" disabled>Buang setiap kotak</button>
+      </div>
+
+      <p id="box-summary" class="field-summary"></p>
+      <ul id="region-list" class="region-list"></ul>
+      <p id="risk-note" class="hint-line warn-line" hidden></p>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; file-nya -->
+  <section class="card" id="save-card">
+    <h2><span class="step">3</span> Simpan salinan yang sudah disensor</h2>
+
+    <p class="card-lede">
+      Gambar didekode menjadi piksel, kotaknya ditulis di atas piksel itu, dan
+      hasilnya dikodekan sebagai file baru. Tidak ada lapisan, anotasi, dan
+      catatan tentang di mana kotaknya berada; karena piksel yang tertutup
+      berhenti ada sebelum encoder diberi apa pun.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format">
+          <option value="auto" selected>Otomatis &mdash; JPEG untuk foto, PNG untuk selebihnya</option>
+          <option value="png">PNG (tanpa kehilangan)</option>
+          <option value="jpeg">JPEG</option>
+          <option value="webp">WebP</option>
+        </select>
+        <p class="field-note">
+          Tidak ada bedanya bagi penyensorannya: pikselnya sudah hilang sebelum
+          encoder melihatnya. Ia hanya menentukan berapa biaya sisa gambarnya dan
+          bagaimana ia dikompres.
+        </p>
+      </div>
+
+      <div class="field" id="quality-row" hidden>
+        <label for="quality">Kualitas</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="90">
+          <output id="quality-value">90%</output>
+        </div>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save" class="primary big" disabled>Sensor dan simpan</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden>
+      Menyensor pada ukuran penuh&hellip;
+    </p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>File yang sudah jadi</h3>
+        <a id="download" class="primary as-button" href="#" download>Unduh</a>
+      </div>
+
+      <!-- This is the blob itself, decoded again by the browser - not the
+           canvas it was made on. What is on screen here is the file. -->
+      <img id="result-image" class="result-image" alt="">
+
+      <ul id="result-facts" class="result-facts"></ul>
+
+      <p class="hint-line">
+        Sesudahnya, coba buka dan pilih teks yang tertutup, atau tempelkan ke
+        sebuah penyunting dan cari sebuah lapisan. Tidak ada yang bisa ditemukan:
+        yang ada satu gambar datar, dan bagian yang Anda tutup sudah ditimpa
+        sebelum file-nya ditulis.
+      </p>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/redact-image.toml
+++ b/locales/id/tools/redact-image.toml
@@ -1,0 +1,267 @@
+#
+# Penyensor Gambar - Bahasa Indonesia.
+#
+# Overrides for tools/redact-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Sensor" dipakai untuk redaction sepanjang locale ini - itu kata yang sudah
+# dipakai orang Indonesia untuk menutup bagian sebuah dokumen atau gambar.
+#
+
+name = "Penyensor Gambar"
+heading = "Penyensor&nbsp;Gambar <span class=\"h1-kw\">&mdash; hitamkan, pikselkan, atau buramkan</span>"
+tagline = "Apa yang Anda tutup dihapus dari file-nya, bukan ditutupi di dalamnya."
+
+title = "Sensor Sebuah Gambar &mdash; Hitamkan, Pikselkan, atau Buramkan, Tanpa Unggah"
+description = "Tutupi sebuah nama, alamat, atau nomor rekening di dalam foto atau tangkapan layar lalu kodekan ulang gambarnya, sehingga piksel yang disembunyikan hilang dari file alih-alih duduk di bawah sebuah persegi panjang. Berjalan sepenuhnya di peramban Anda."
+og_title = "Sensor sebuah gambar sehingga bagian yang tertutup benar-benar hilang"
+og_description = "Gambar kotak di atas apa yang tidak boleh terlihat. Piksel di bawahnya ditimpa sebelum file ditulis, jadi tidak ada lapisan untuk digeser dan tidak ada yang bisa dipulihkan. Tidak ada yang diunggah."
+og_image_alt = "Penyensor Gambar - piksel yang tertutup ditimpa, bukan disembunyikan"
+
+pledge = """
+    Gambar didekode, dicat di atasnya, dan dikodekan lagi oleh peramban Anda
+    sendiri, memakai kodek yang memang sudah dibawanya. Alat ini tidak punya
+    fitur jaringan dalam bentuk apa pun &mdash; tidak ada yang diambil, tidak ada
+    yang dikirim &mdash; dan itu lebih penting di sini daripada hampir di mana
+    pun di situs ini: gambar yang dibawa orang ke alat sensor adalah gambar yang
+    masih terbaca nama, alamat, atau nomor rekeningnya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu sensor sebuah tangkapan layar. Tidak satu pun permintaan membawa
+      gambar, gambar mini, nama file, atau posisi satu kotak pun. Atau cabut
+      koneksi internet dan tetap sensor satu."""
+
+read_first = """
+, <code>src/redact.js</code> untuk tiga fungsi yang
+      menimpa pikselnya, dan <code>src/preview.js</code> untuk alasan kenapa apa
+      yang Anda lihat di layar digambar oleh tiga fungsi yang sama itu."""
+
+howto_heading = "Cara menyensor gambar sehingga bagian yang tersembunyi benar-benar hilang"
+
+card = """
+            Hitamkan, pikselkan, atau buramkan sebagian gambar. Piksel yang
+            tertutup ditimpa sebelum file ditulis, jadi tidak ada lapisan untuk
+            digeser."""
+
+[words]
+plural = "gambar"
+choose = "sebuah gambar"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Gambar Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Piksel yang tertutup berhenti ada di sini, bukan di jalan keluar."
+body = """
+ Gambar didekode ke sebuah penyangga
+      piksel, kotaknya ditulis di atas penyangga itu, dan penyangganya diserahkan
+      ke encoder. Tidak ada versi gambar di halaman ini yang kotaknya menjadi
+      lapisan terpisah, karena versi seperti itu tidak pernah dibuat &mdash;
+      lihat <code>src/redact.js</code>."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di mana
+      pun di dalam <code>src/</code>. Pekerjaannya adalah
+      <code>getImageData</code>, tiga perulangan atas byte-nya, dan
+      <code>canvas.toBlob</code> &mdash; semuanya sudah terpasang di peramban
+      Anda."""
+
+[[privacy]]
+title = "Kotaknya tidak pernah dilaporkan ke mana pun."
+body = """
+ Di mana Anda menggambar, berapa banyak,
+      seberapa besar, dan gaya mana yang Anda pilih ditahan di memori halaman ini
+      sampai Anda menutupnya. Tidak ada peristiwa pengukuran khusus di repositori
+      ini yang membawa satu pun darinya, dan satu pertanyaan yang diajukan situs
+      ini setelah sebuah unduhan mengirim jempol ke atas atau ke bawah beserta
+      nama alatnya, tidak lebih."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana &mdash; dan yang layak dijalankan
+      sebelum Anda menyensor sebuah paspor."""
+
+[[howto]]
+title = "Pilih gambarnya."
+body = """
+ Tangkapan layar, pindaian, atau foto &mdash;
+      apa pun yang bisa dibuka peramban Anda. Ia dibaca langsung dari disk Anda;
+      tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Seret sebuah kotak di atas apa yang tidak boleh terlihat."
+body = """
+ Seret lagi untuk yang berikutnya.
+      Sebuah kotak bisa dipindahkan, diubah ukurannya lewat pegangannya, atau
+      dicapai dengan tombol Tab dan digeser dengan panahnya. Yang muncul di bawah
+      kotak itu adalah hasil sungguhan, digambar oleh kode yang sama yang menulis
+      file-nya."""
+
+[[howto]]
+title = "Pilih hitam, pikselkan, atau buramkan &mdash; dan pilihlah hitam."
+body = """
+ Isian hitam sama sekali tidak
+      meninggalkan apa pun. Memikselkan dan memburamkan mengganti pikselnya dengan
+      rata-rata dari dirinya sendiri, yang cukup untuk wajah di latar belakang dan
+      tidak cukup untuk apa pun yang terbaca sebagai teks."""
+
+[[howto]]
+title = "Tekan \"Sensor dan simpan\", lalu periksa file-nya."
+body = """
+ Gambar yang ditampilkan sesudahnya adalah
+      file yang sudah jadi, didekode lagi. Buka di sebuah penyunting dan cari
+      sebuah lapisan atau coba pilih teks yang tertutup: yang ada satu gambar
+      datar, dan bagian yang Anda tutup sudah ditimpa sebelum ia ditulis
+      keluar."""
+
+[[faq]]
+q = "Apakah gambar saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File didekode, disensor, dan dikodekan oleh peramban Anda sendiri
+        di perangkat keras Anda sendiri. Alat ini tidak punya fitur jaringan dalam
+        bentuk apa pun &mdash; ia tidak pernah mengambil apa pun dan tidak pernah
+        mengirim apa pun &mdash; dan <code>Content-Security-Policy</code> halaman
+        ini menyebut satu per satu setiap alamat yang boleh dihubunginya, dan
+        tidak satu pun milik situs ini. Muat halamannya sekali, cabut koneksi
+        internet, dan ia tetap bekerja."""
+
+[[faq]]
+q = "Apakah bagian yang tertutup benar-benar hilang dari file?"
+a = """
+        Ya, dan itulah alasan alat ini ada. Gambar didekode ke sebuah penyangga
+        piksel; kotaknya menimpa piksel di dalamnya; penyangganya lalu dikodekan
+        sebagai file baru. Nilai aslinya sudah hilang dari memori sebelum encoder
+        diberi apa pun, jadi tidak ada lapisan untuk disembunyikan, tidak ada
+        anotasi untuk dibuang, dan tidak ada riwayat untuk dibatalkan. Anda bisa
+        memeriksanya seperti Anda memeriksa klaim orang lain: buka hasilnya di
+        penyunting gambar dan cari lapisan kedua, atau coba pilih teks yang Anda
+        tutup."""
+
+[[faq]]
+q = "Bisakah area yang dipikselkan atau diburamkan dipulihkan?"
+a = """
+        Kadang, dan inilah satu hal yang layak dibaca sebelum memilih. Isian hitam
+        mengganti semua yang ada di bawahnya dengan satu warna datar, jadi tidak
+        ada yang selamat &mdash; tidak sebuah tepi, tidak sebuah rata-rata, tidak
+        jumlah karakternya. Memikselkan mengganti setiap blok dengan rata-rata
+        blok itu, dan kisi rata-rata tetaplah pengukuran atas apa yang ada di
+        bawahnya: untuk teks dengan huruf biasa pada ukuran yang bisa ditebak,
+        karya yang diterbitkan sudah merekonstruksi aslinya dengan menggambar
+        string kandidat dan membandingkan rata-ratanya. Memburamkan adalah sebuah
+        konvolusi, dan konvolusi pada prinsipnya bisa dikerjakan mundur. Jadi
+        pikselkan atau buramkan wajah di latar belakang kalau Anda mau, dan
+        hitamkan apa pun yang terbaca sebagai teks."""
+
+[[faq]]
+q = "Kenapa persegi panjang hitam yang digambar di penyunting dokumen bukan hal yang sama?"
+a = """
+        Karena kebanyakan penyunting menyimpan persegi panjang itu di samping
+        gambarnya, bukan ke dalamnya. Bentuk yang digambar di pembaca PDF, dek
+        salindia, pengolah kata, atau penyunting gambar berlapis adalah objek
+        dengan posisi, duduk di atas halamannya &mdash; dan memindahkannya,
+        menghapusnya, atau membuka file-nya di program berbeda mengembalikan
+        persis apa yang ditutupinya. Surat kabar, pengadilan, dan kementerian
+        semuanya pernah menerbitkan dokumen yang disensor dengan cara itu. Di sini
+        persegi panjangnya sama sekali tidak disimpan: ia adalah sekumpulan nilai
+        piksel yang ditulis di atas nilai yang tadinya ada."""
+
+[[faq]]
+q = "Apakah ia juga menghapus data EXIF dan GPS?"
+a = """
+        Ya, sebagai efek samping. Menyimpan berarti mengodekan sebuah kanvas penuh
+        piksel, dan sebuah kanvas tidak membawa tag, jadi lokasi, model kamera,
+        stempel waktu, dan gambar mini tertanamnya sama sekali tidak ditulis ke
+        file baru. Gambar mininya penting di sini: ia salinan kecil kedua dari
+        gambarnya, ia tidak selalu diperbarui ketika sebuah foto disunting, dan
+        foto tersensor yang bepergian bersama gambar mini yang belum disensor
+        adalah cara nyata untuk membatalkan seluruh pekerjaan ini. Kalau Anda mau
+        metadatanya hilang tanpa gambarnya dikodekan ulang sama sekali,
+        <a href="../hapus-data-exif/">Penampil dan Penghapus EXIF</a> menulis
+        ulang wadahnya saja."""
+
+[[faq]]
+q = "Format apa saja yang bisa dibaca dan ditulisnya?"
+a = """
+        Ia membaca apa pun yang bisa didekode peramban Anda, yang dalam praktiknya
+        berarti JPEG, PNG, WebP, GIF, BMP, dan &mdash; di sebagian besar peramban
+        masa kini &mdash; AVIF. Ia menulis JPEG, PNG, dan WebP, karena itulah
+        encoder yang dibawa peramban. Pada "otomatis", JPEG kembali sebagai JPEG
+        dan segala yang lain sebagai PNG, yang menjaga sebuah foto tetap seukuran
+        foto dan menjaga sisa teks di sebuah tangkapan layar tetap tajam.
+        Pilihannya tidak berpengaruh pada penyensorannya: pikselnya sudah hilang
+        sebelum encoder melihatnya."""
+
+[[faq]]
+q = "Bisakah saya melakukan ini tanpa tetikus?"
+a = """
+        Bisa. "Tambah kotak di tengah" menaruh satu di atas gambarnya, Tab
+        berpindah antar kotak, tombol panah menggeser yang terfokus dan Alt
+        bersama tombol panah mengubah ukurannya &mdash; Shift membuat setiap
+        langkah sepuluh piksel &mdash; dan Delete membuangnya. Setiap kotak juga
+        punya barisnya sendiri di bawah gambarnya dengan ukurannya, posisinya, apa
+        yang dilakukannya, dan sebuah tombol untuk membuangnya, jadi seluruh alat
+        ini bisa dipakai dari papan ketik dan bisa dibaca pembaca layar."""
+
+[[faq]]
+q = "Apakah ia jalan di ponsel?"
+a = """
+        Ya. Menggambar, memindahkan, dan mengubah ukuran semuanya adalah peristiwa
+        penunjuk alih-alih peristiwa tetikus, jadi jari bekerja dengan cara yang
+        sama, dan pegangannya digambar lebih besar di layar sentuh. Gambar di layar
+        digambar ulang seukuran layar sementara Anda bekerja &mdash; file-nya
+        sendiri selalu disensor pada resolusi penuhnya ketika Anda menekan
+        tombolnya."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Tidak ada batas ukuran gambarnya juga, karena tidak
+        ada server yang membayarnya &mdash; pekerjaannya terjadi di mesin Anda
+        sendiri. Situs ini memasang iklan, dan itulah yang membiayainya; iklan
+        tidak diberi apa pun tentang gambar Anda."""
+
+[schema]
+description = "Sensor sebuah gambar di peramban: gambar kotak di atas apa yang tidak boleh terlihat dan hitamkan, pikselkan, atau buramkan. Piksel yang tertutup ditimpa sebelum file dikodekan, jadi hasilnya tidak membawa lapisan, anotasi, maupun metadata. Tidak ada yang diunggah."
+features = [
+  "Isian hitam, pikselisasi, dan buram, dipilih per kotak",
+  "Piksel yang tertutup ditimpa sebelum pengodean, jadi tidak ada lapisan untuk digeser",
+  "Pratinjaunya digambar oleh kode yang sama yang menulis file-nya",
+  "Melaporkan sebuah mozaik terdiri dari berapa blok, alih-alih menyebutnya 'kuat'",
+  "Papan ketik dan sentuh selain tetikus: setiap kotak bisa ditambah, dipindah, diubah ukurannya, dan dibuang tanpanya",
+  "Membersihkan EXIF, GPS, dan gambar mini tertanam sebagai efek samping pengodean ulang",
+  "Keluaran JPEG, PNG, dan WebP, dengan pilihan otomatis",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan sebuah gambar di sini"
+hint = "atau klik untuk menelusuri &mdash; JPEG, PNG, WebP, dan apa pun lain yang bisa dibuka peramban Anda"

--- a/locales/id/tools/redact-pdf.html
+++ b/locales/id/tools/redact-pdf.html
@@ -1,0 +1,311 @@
+<!--
+  tools/redact-pdf/body.html, in Indonesian.
+
+  Every id, class, data-phrase key and brace placeholder below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+
+  Indonesian does not mark a noun for number, so each count.* pair reads the
+  same in both halves. They are still both here, because the JavaScript picks
+  one by the count and a missing key is a missing sentence.
+-->
+<main>
+  <!-- Langkah 1 &mdash; dokumennya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih PDF Anda</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <div id="doc-facts" class="doc-facts" hidden>
+      <p id="doc-name" class="doc-name"></p>
+      <p id="doc-sub" class="doc-sub"></p>
+      <ul id="doc-warnings" class="doc-warnings"></ul>
+    </div>
+  </section>
+
+  <!-- Langkah 2 &mdash; menemukannya -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Sebutkan apa yang harus hilang</h2>
+
+    <p class="card-lede">
+      Ketik kata-katanya &mdash; sebuah nama, sebuah alamat, sebuah nomor rujukan
+      &mdash; dan setiap tempat ia muncul didaftar di bawah lengkap dengan baris
+      tempatnya duduk. Tidak ada yang dibuang sampai langkah 4, dan tidak ada
+      yang dibuang kalau Anda belum mencentangnya.
+    </p>
+
+    <label class="find-label" for="terms">Kata dan frasa, satu per baris</label>
+    <textarea id="terms" rows="3" spellcheck="false" autocomplete="off"
+              placeholder="Santoso&#10;Jalan Merdeka 14&#10;REF-40219"></textarea>
+
+    <div class="find-row">
+      <button type="button" id="find" class="primary">Cari</button>
+      <label class="inline-check">
+        <input type="checkbox" id="match-case"> <span>Cocokkan huruf besar kecilnya</span>
+      </label>
+      <label class="inline-check">
+        <input type="checkbox" id="whole-word"> <span>Hanya kata utuh</span>
+      </label>
+    </div>
+
+    <fieldset class="finders">
+      <legend>Atau cari hal-hal yang biasanya sensitif</legend>
+      <div class="chips" id="finders"></div>
+      <p class="field-note" id="finder-note">
+        Ini adalah pola, dan sebuah pola tidak bisa membedakan nomor telepon dari
+        nomor rujukan. Nomor kartu dan IBAN dicocokkan dengan digit periksanya
+        sendiri; sisanya ditawarkan, tidak pernah dicentangkan untuk Anda, dan
+        masing-masing layak dibaca.
+      </p>
+    </fieldset>
+
+    <div class="toolbar" id="match-bar" hidden>
+      <span id="match-count" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="tick-all" class="ghost">Centang semua</button>
+        <button type="button" id="tick-none" class="ghost">Lepas semua centang</button>
+        <button type="button" id="clear-found" class="ghost danger">Bersihkan daftarnya</button>
+      </div>
+    </div>
+
+    <ul id="match-list" class="match-list" hidden></ul>
+    <p id="match-more" class="field-note" hidden></p>
+  </section>
+
+  <!-- Langkah 3 &mdash; membaca halamannya -->
+  <section class="card" id="page-card" hidden>
+    <h2><span class="step">3</span> Baca halamannya, dan pilih kata dari atasnya</h2>
+
+    <p class="card-lede">
+      Inilah teksnya sebagaimana ia disimpan di dalam dokumennya, dalam urutan
+      yang akan disalin seorang pembaca &mdash; yang tidak selalu sama dengan
+      urutan tercetaknya. Klik kata mana pun untuk mengeluarkannya, klik lagi
+      untuk menyimpannya. Semua yang tercoret di sini adalah yang akan hilang.
+    </p>
+
+    <div class="pager">
+      <button type="button" id="prev-page" class="ghost">&#8592; Sebelumnya</button>
+      <span id="page-of" class="count"></span>
+      <button type="button" id="next-page" class="ghost">Berikutnya &#8594;</button>
+      <span class="pager-spacer"></span>
+      <span id="page-picked" class="count"></span>
+      <button type="button" id="clear-page" class="ghost danger">Simpan semua di halaman ini</button>
+    </div>
+
+    <p id="page-note" class="field-summary" hidden></p>
+
+    <div id="page-text" class="page-text" role="group" aria-label="Teks halaman ini"></div>
+  </section>
+
+  <!-- Langkah 4 &mdash; melakukannya -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Keluarkan kata-katanya</h2>
+
+    <label class="check">
+      <input type="checkbox" id="opt-boxes" checked>
+      <span>
+        <strong>Gambar kotak hitam di tempat masing-masing berada</strong>
+        <span class="check-note">
+          Supaya seorang pembaca bisa melihat ada yang dibuang. Kotaknya hiasan
+          di sini dan bukan penyensorannya: hurufnya sudah hilang dari file-nya
+          pada saat kotak itu digambar. Matikan dan kata-katanya sekadar lenyap,
+          meninggalkan ruang yang ditempatinya.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-elsewhere" checked>
+      <span>
+        <strong>Keluarkan kata yang sama dari bagian dokumen lainnya</strong>
+        <span class="check-note">
+          Markah, komentar, catatan tempel, dan yang sudah diketik ke kolom
+          formulir. Kata yang dibuang dari sebuah halaman tapi ditinggalkan di
+          sebuah markah belum dibuang. Properti dokumennya hilang apa pun kata
+          pilihan ini, dan begitu juga teks pengganti yang disalin seorang
+          pembaca alih-alih huruf di halamannya &mdash; keduanya adalah dokumen
+          yang mengucapkan katanya, bukan tempat lain yang menyimpan salinannya.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-attachments" checked>
+      <span>
+        <strong>Buang lampiran dan apa pun yang berjalan</strong>
+        <span class="check-note">
+          Sebuah PDF bisa membawa file utuh di dalamnya dan JavaScript yang
+          berjalan ketika ia dibuka. Keduanya tidak bisa dicari untuk kata yang
+          sedang Anda buang, dan keduanya tidak dibutuhkan untuk membaca sebuah
+          dokumen.
+        </span>
+      </span>
+    </label>
+
+    <p class="field-summary" id="run-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Keluarkan</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Unduh</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+      <ul id="check-terms" class="check-terms" hidden></ul>
+      <ul id="result-facts" class="result-facts"></ul>
+    </div>
+  </section>
+
+  <!--
+    The sentences this tool's JavaScript puts on screen. They live here rather
+    than in src/ because src/ is copied byte for byte into all eleven
+    languages; see "The strings in the JavaScript" in the repository README.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="load.notpdf">Itu bukan PDF, jadi tidak ada teks di dalamnya untuk dikeluarkan.</span>
+    <span data-phrase="load.encrypted">PDF ini berkata sandi. Melepas
+      perlindungan sebuah dokumen adalah pekerjaan yang berbeda dari
+      mengeluarkan kata darinya, dan alat ini tidak akan melakukannya di
+      belakang Anda.</span>
+    <span data-phrase="load.broken">File ini tidak bisa dibuka sebagai PDF ({detail}).</span>
+    <span data-phrase="load.nopages">Ini terbuka, tapi tidak ada halaman yang bisa ditemukan di dalamnya.</span>
+    <span data-phrase="load.repaired">Tabel rujukan silang dokumen ini tidak
+      cocok dengan isinya, jadi ia dibaca dengan memindai objek sebagai
+      gantinya. Itu sebuah perbaikan, dan ia berhasil &mdash; periksa hasilnya
+      dengan saksama sebelum Anda mengirimnya ke mana pun.</span>
+
+    <span data-phrase="doc.sub">{pages} &middot; {words} teks &middot; {size}</span>
+    <span data-phrase="doc.notext">{count} dari halaman ini sama sekali tidak
+      punya teks di dalamnya. Halaman seperti itu adalah gambar sebuah halaman,
+      dan tidak ada apa pun di sini untuk dibuang alat ini &mdash; kata-kata di
+      dalam gambarnya tetap persis di tempatnya.</span>
+    <span data-phrase="doc.unreadable">{count} huruf di dokumen ini tidak bisa
+      dibaca sebagai karakter, karena fon yang dipakainya tidak membawa peta dari
+      glifnya kembali ke teks. Huruf-huruf itu tidak bisa dicari, jadi periksa
+      halaman tempat mereka berada alih-alih memercayai pencariannya.</span>
+    <span data-phrase="doc.scan">Sebagian halaman membawa teks tak kasatmata yang
+      diletakkan di atas sebuah gambar, dan begitulah sebuah pemindai merekam apa
+      yang dipahami pembacanya dari halamannya. Membuang teks itu membuang apa
+      yang akan ditemukan sebuah pencarian dan sebuah salinan. Ia tidak mengubah
+      gambarnya, dan di dalam gambarnya kata-katanya masih terbaca.</span>
+
+    <span data-phrase="find.none">Tidak ada di halaman mana pun yang cocok.</span>
+    <span data-phrase="find.some">{count} di {pages}.</span>
+    <span data-phrase="find.more">{shown} yang pertama didaftar. Sisanya sudah
+      ditemukan dan akan ikut dikeluarkan kalau Anda mencentang semuanya.</span>
+    <span data-phrase="find.terms">Ketik sebuah kata di atas, atau pilih sebuah pola, sebelum menekan Cari.</span>
+
+    <span data-phrase="page.of">Halaman {number} dari {total}</span>
+    <span data-phrase="page.picked">{count} akan dibuang dari halaman ini</span>
+    <span data-phrase="page.notext">Tidak ada teks di halaman ini. Entah ia
+      kosong, entah ia gambar sebuah halaman &mdash; sebuah pindaian, sebuah
+      foto, sebuah ekspor yang menggambar kata-katanya sebagai bentuk. Tidak ada
+      di atasnya yang bisa dicari, dan tidak ada di atasnya yang bisa dibuang di
+      sini.</span>
+    <span data-phrase="page.unreadable">{count} huruf di halaman ini tidak bisa
+      dibaca sebagai karakter. Mereka ditampilkan sebagai &#9647; di bawah, dan
+      pencarian tidak akan menemukannya.</span>
+    <span data-phrase="page.scan">Teks di halaman ini tak kasatmata: ia
+      diletakkan di atas sebuah gambar halamannya, dan begitulah sebuah pindaian
+      dibuat bisa dicari. Yang Anda keluarkan di sini adalah yang akan ditemukan
+      sebuah pencarian dan sebuah salinan. Gambarnya menyimpan kata-katanya.</span>
+
+    <span data-phrase="run.summary">{words} di {pages} akan dikeluarkan.</span>
+    <span data-phrase="run.nothing">Belum ada yang dicentang. Cari sebuah kata di langkah 2, atau klik satu di langkah 3.</span>
+    <span data-phrase="run.editing">Mengeluarkan kata-katanya&hellip;</span>
+    <span data-phrase="run.writing">Menulis dokumennya&hellip;</span>
+    <span data-phrase="run.checking">Membuka file jadinya dan mencarinya&hellip;</span>
+    <span data-phrase="run.failed">Ada yang tidak beres saat menulis ulang dokumen ini ({detail}).</span>
+    <span data-phrase="run.cancelled">Dibatalkan. Tidak ada yang ditulis.</span>
+
+    <span data-phrase="result.headline">{words} dibuang</span>
+    <span data-phrase="result.sub">{size} &middot; {pages} berubah &middot; {boxes}</span>
+    <span data-phrase="check.good">Dibuka lagi di sini dan dicari, dengan cara
+      yang sama seperti seorang pembaca: tidak satu pun dari mereka ada di file
+      jadinya.</span>
+    <span data-phrase="check.partial">Dibuka lagi di sini dan dicari: setiap
+      kemunculan yang Anda centang sudah hilang, dan yang Anda tinggalkan masih
+      di sana.</span>
+    <span data-phrase="check.survived">File ini TIDAK ditulis. Dokumen jadinya
+      dibuka lagi dan sebagian dari yang Anda buang masih bisa ditemukan di
+      dalamnya, yang berarti penyensorannya belum tuntas. Tidak ada yang
+      ditawarkan untuk diunduh.</span>
+    <span data-phrase="check.pages">File ini TIDAK ditulis. Dokumen jadinya
+      kembali dengan jumlah halaman yang berbeda dari saat ia masuk, jadi ada
+      yang tidak beres di luar kata-katanya. Tidak ada yang ditawarkan untuk
+      diunduh.</span>
+
+    <span data-phrase="fact.boxes">{count} digambar di atas celahnya.</span>
+    <span data-phrase="fact.noboxes">Tidak ada kotak yang digambar, jadi
+      kata-katanya hilang tanpa apa pun yang mengatakan di mana mereka
+      dulu.</span>
+    <span data-phrase="fact.elsewhere">Kata yang sama dikeluarkan dari {where}.</span>
+    <span data-phrase="fact.metadata">Properti dokumen dan paket XMP-nya dibuang,
+      jadi file jadinya tidak mengatakan apa yang membuatnya, kapan, atau dulu ia
+      bernama apa.</span>
+    <span data-phrase="fact.carried">{attachments} dan {actions} dibuang.</span>
+    <span data-phrase="fact.shared">Sebagian dari yang Anda buang digambar oleh
+      sebuah blok yang dipakai ulang dokumennya di lebih dari satu halaman, jadi
+      ia sudah hilang dari setiap halaman yang menggambarnya. Itu lebih banyak
+      daripada yang Anda centang, tidak pernah lebih sedikit.</span>
+    <span data-phrase="fact.overimage">{count} dari huruf yang Anda buang
+      terbaring di atas sebuah gambar halaman yang sama. Mereka keluar dari
+      lapisan teksnya dan masih ada di gambarnya: seorang pembaca tidak bisa lagi
+      mencari atau menyalinnya, dan tetap bisa melihatnya.</span>
+    <span data-phrase="fact.untouched">Semua yang lain di setiap halaman disalin
+      lewat byte demi byte. Tidak ada fon, gambar, atau garis yang dikodekan
+      ulang.</span>
+
+    <span data-phrase="count.pages">{count} halaman</span>
+    <span data-phrase="count.page">{count} halaman</span>
+    <span data-phrase="count.words">{count} kata</span>
+    <span data-phrase="count.word">{count} kata</span>
+    <span data-phrase="count.pieces">{count} potongan teks</span>
+    <span data-phrase="count.piece">{count} potongan teks</span>
+    <span data-phrase="count.matches">{count} kecocokan</span>
+    <span data-phrase="count.match">{count} kecocokan</span>
+    <span data-phrase="count.boxes">{count} kotak hitam</span>
+    <span data-phrase="count.box">{count} kotak hitam</span>
+    <span data-phrase="count.attachments">{count} lampiran</span>
+    <span data-phrase="count.attachment">{count} lampiran</span>
+    <span data-phrase="count.actions">{count} tindakan</span>
+    <span data-phrase="count.action">{count} tindakan</span>
+    <span data-phrase="count.hosts">{count} host</span>
+    <span data-phrase="count.host">{count} host</span>
+
+    <!-- The space before {platform} belongs to these two rather than to the
+         phrase it lets in, because phrases.js collapses and trims the markup
+         it reads and a leading space would not survive the trip. -->
+    <span data-phrase="net.clean">dokumen Anda tidak pergi ke mana pun. {total}
+      file dimuat, semuanya milik halaman ini sendiri. {platform}</span>
+    <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak
+      pernah dilakukan alat ini. Anggap itu layak diselidiki. {platform}</span>
+    <span data-phrase="net.platform">Skrip iklan, pengukuran, dan tombol donasi
+      milik halaman ini dimuat dari {hosts}; tidak satu pun diberi sebuah
+      dokumen, sepatah kata darinya, atau apa pun yang Anda cari.</span>
+
+    <span data-phrase="finder.email">Alamat email</span>
+    <span data-phrase="finder.card">Nomor kartu</span>
+    <span data-phrase="finder.iban">Rekening bank (IBAN)</span>
+    <span data-phrase="finder.nationalid">Nomor jaminan sosial &amp; asuransi nasional</span>
+    <span data-phrase="finder.phone">Nomor telepon</span>
+  </div>
+</main>

--- a/locales/id/tools/redact-pdf.toml
+++ b/locales/id/tools/redact-pdf.toml
@@ -1,0 +1,383 @@
+#
+# Penyensor PDF - Bahasa Indonesia.
+#
+# Overrides for tools/redact-pdf/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Sensor" adalah kata yang dipakai orang di sini untuk menghapus bagian yang
+# tidak boleh terbaca, jadi itulah yang dipakai di seluruh halaman - termasuk di
+# slug, sensor-pdf. Nama teknis (PDF, XMP, OCR, IBAN) tetap seperti adanya.
+#
+# Satu hal yang harus dipegang saat menyunting prosa mana pun di bawah: halaman
+# ini membuat klaim yang tidak bisa dibuat alat penyensor lain, dan klaim itu
+# tidak berharga kalau dilebih-lebihkan. Yang dihapusnya adalah teks. Halaman
+# yang berupa foto sebuah halaman tidak punya teks di atasnya dan alat ini
+# mengatakannya alih-alih berpura-pura.
+#
+
+name = "Penyensor PDF"
+heading = "Sensor&nbsp;PDF <span class=\"h1-kw\">&mdash; kata-katanya keluar, bukan kotak di atasnya</span>"
+tagline = "Hurufnya dihapus dari file-nya, dan file-nya dicari sesudahnya untuk membuktikannya."
+
+title = "Sensor PDF &mdash; Hapus Teksnya Sungguhan, Gratis, Tanpa Unggah"
+description = "Keluarkan kata dari sebuah PDF alih-alih menggambar persegi hitam di atasnya. Hurufnya dihapus dari instruksi menggambar halamannya sendiri, file jadinya dibuka lagi dan dicari untuk membuktikan hurufnya sudah hilang, dan tidak ada yang diunggah."
+og_title = "Sensor sebuah PDF dengan benar &mdash; kata-katanya dihapus, bukan ditutupi"
+og_description = "Persegi hitam di kebanyakan alat duduk di atas teksnya dan bisa disalin keluar dari bawahnya. Yang ini menghapus hurufnya dari file-nya lalu mencari hasilnya untuk menunjukkan hurufnya tidak ada di sana."
+og_image_alt = "Sensor sebuah PDF dengan menghapus teksnya, bukan dengan menutupinya"
+
+pledge = """
+    Dokumen yang Anda pilih dibuka, dibaca, disunting, dan ditulis kembali di
+    dalam memori di mesin ini, oleh kode yang disajikan dari alamat ini. Tidak
+    ada di sini yang bisa membuat sebuah unggahan, dan tidak ada server di ujung
+    lain halaman ini untuk menerimanya. Baik file-nya maupun kata yang Anda cari
+    tidak meninggalkan tabnya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu sensor sesuatu. Tidak satu pun permintaan membawa sebuah halaman,
+      sebuah kata, atau sebuah nama file. Atau cabut koneksi internet dan tetap
+      sensor."""
+
+read_first = """
+, <code>src/text.js</code> untuk cara setiap kata
+      di sebuah halaman ditemukan dan dipetakan, dan <code>src/edit.js</code>
+      untuk penghapusannya sendiri &mdash; apa yang dipotong dari instruksi
+      halamannya dan apa yang ditaruh kembali supaya sisa barisnya tidak
+      bergeser. Tidak satu pun bisa menjangkau jaringan, dan begitu juga pembaca
+      dan penulis di sebelahnya."""
+
+howto_heading = "Cara menyensor PDF supaya kata-katanya sungguh hilang"
+
+card = """
+            Hapus kata dari sebuah PDF alih-alih menutupinya. Hurufnya
+            dikeluarkan dari instruksi menggambar halamannya sendiri, celahnya
+            ditahan tetap terbuka supaya tidak ada yang lain bergeser, dan file
+            jadinya dibuka lagi lalu dicari di sini untuk membuktikan kata-katanya
+            tidak ada di dalamnya."""
+
+[words]
+plural = "dokumen"
+choose = "sebuah PDF"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "Persegi hitam bukan penyensoran, dan ini tidak menggambar satu pun di atas apa pun."
+body = """
+
+      Di hampir setiap program yang menawarkan penyensoran sebuah halaman
+      &mdash; pembaca PDF, pengolah kata, alat desain &mdash; persegi itu adalah
+      objek yang disimpan di sebelah teksnya alih-alih ke dalamnya. Teksnya masih
+      di sana, di file yang sama, di tempat yang sama, dan memilih areanya lalu
+      menekan salin menyerahkannya kembali. Kegagalan itu sudah menerbitkan
+      berkas pengadilan, laporan intelijen, dan, pada Desember 2025, nama-nama
+      yang dihitamkan di sebuah rilis besar dokumen Departemen Kehakiman yang
+      terbaca dalam hitungan jam. Alat ini menghapus hurufnya dari instruksi yang
+      menggambar halamannya. Tidak ada persegi dengan apa pun di bawahnya, karena
+      tidak ada apa pun di bawahnya."""
+
+[[privacy]]
+title = "File jadinya dibuka lagi dan dicari, di sini, sebelum ia ditawarkan kepada Anda."
+body = """
+
+      Setiap klaim di atas hanyalah alat ini menilai pekerjaannya sendiri sampai
+      hal itu terjadi. Jadi byte yang sebentar lagi menjadi unduhan Anda
+      diserahkan kembali kepada pembaca yang sama seolah-olah orang asing yang
+      mengirimnya, setiap halaman dibaca lagi, setiap markah, komentar, kolom
+      formulir, dan properti dokumen dikumpulkan, dan kata yang Anda buang
+      dicari. Jumlahnya ada di hasilnya. Kalau ada yang selamat, jalannya
+      dilaporkan gagal dan tidak ada unduhan."""
+
+[[privacy]]
+title = "Kata-katanya tidak pernah meninggalkan tabnya, dan begitu juga pencariannya."
+body = """
+ Content-Security-Policy
+      menyebut satu per satu setiap alamat yang boleh dihubungi halaman ini, dan
+      tidak satu pun milik situs ini. Alat ini tidak menambahkan apa pun ke daftar
+      itu: ia tidak punya fitur jaringan sendiri, bahkan yang opsional sekalipun.
+      Yang Anda ketik ke kotak pencarian adalah sebuah teks yang dibandingkan
+      dengan teks di dalam memori tab ini, dan tidak ada tujuan ke mana pun bagi
+      keduanya."""
+
+[[privacy]]
+title = "Penyensoran adalah pekerjaan yang paling tidak selamat sebagai sebuah unggahan."
+body = """
+
+      Apa yang disensor orang justru alasan ia tidak boleh diunggah. Keterangan
+      saksi, surat medis, rekening koran yang dikirim ke pemilik kontrakan,
+      kontrak yang memuat nama satu klien tapi hendak dikirim ke klien lain.
+      Menyerahkan itu ke server orang asing supaya bagian pribadinya dihapus
+      berarti bagian pribadinya tiba lebih dulu, utuh, dan versi itulah yang
+      mereka simpan. Halaman ini tidak punya belahan lain."""
+
+[[privacy]]
+title = "Yang tersisa disalin lewat tanpa disentuh."
+body = """
+
+      Satu-satunya byte yang berubah di sebuah halaman adalah instruksi penampil
+      teks tempat huruf yang dibuang berada. Setiap instruksi lain, dan setiap
+      fon, gambar, serta garis yang dirujuk halamannya, disalin persis seperti
+      saat ia datang &mdash; tidak ada yang digambar ulang, dikodekan ulang, atau
+      ditata ulang. Lebar dari yang dikeluarkan diukur lalu ditaruh kembali
+      sebagai instruksi jarak, sehingga sisa barisnya tetap di tempat yang
+      ditentukan dokumennya."""
+
+[[privacy]]
+title = "Ia tidak bisa mengeluarkan kata dari sebuah foto, dan ia mengatakan halaman mana saja itu."
+body = """
+
+      Halaman hasil pindaian adalah sebuah gambar. Kata di atasnya adalah piksel,
+      bukan teks, dan tidak ada di sini yang bisa menyentuhnya. Kalau pindaiannya
+      membawa lapisan teks tak kasatmata yang dihasilkan OCR sebuah pemindai,
+      alat ini akan menghapus lapisan itu &mdash; yaitu yang akan ditemukan
+      sebuah pencarian dan sebuah salinan &mdash; dan ia mengatakan terus terang
+      di halamannya bahwa gambarnya masih menampilkan kata-katanya. Menutupi
+      gambar itu pekerjaan yang berbeda;
+      <a href=\"../sensor-gambar/\">penyensor gambar</a> adalah alat yang menimpa
+      piksel."""
+
+[[privacy]]
+title = "Dokumennya berhenti mengatakan dari mana ia datang."
+body = """
+
+      Properti dan paket XMP-nya ikut hilang di setiap jalan: tidak ada baris
+      produser, tidak ada tanggal pembuatan, tidak ada penulis, tidak ada judul,
+      dan tidak ada satu pun blok pribadi yang ditinggalkan sebuah aplikasi tata
+      letak. File yang halamannya sudah dikeluarkan sebuah nama tapi propertinya
+      masih berbunyi <code>Smith settlement draft 3.docx</code> belum disensor,
+      dan itu bukan hal yang layak diserahkan kepada sebuah kotak centang."""
+
+[[privacy]]
+title = "File terenkripsi ditolak alih-alih dibuka."
+body = """
+
+      PDF yang berkata sandi ditolak, termasuk jenis yang dihasilkan pemindai
+      dengan kata sandi kosong dan yang secara teknis akan terbuka. Melepas
+      perlindungan sebuah dokumen adalah pekerjaan yang berbeda dari
+      mengeluarkan kata darinya, dan melakukannya diam-diam akan menjadi hal
+      yang mengejutkan bagi sebuah alat untuk dilakukan atas nama Anda."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan
+      pengukuran berasal dari Google. Tidak satu pun diberi apa pun tentang
+      dokumen Anda: bukan sebuah file, bukan sebuah halaman, bukan sebuah nama,
+      sebuah ukuran, sebuah jumlah halaman, atau sebuah kata yang Anda cari.
+      Setiap baris yang membaca, menyunting, atau menulis sebuah PDF disajikan
+      dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+
+      Tombol \"Buy me a coffee\" di headernya digambar oleh sebuah skrip dari
+      cdnjs.buymeacoffee.com dan mengambil hurufnya dari Google Fonts. Ia sebuah
+      tautan dan tidak lebih: ia tidak melaporkan kunjungan, dan ia tidak diberi
+      apa pun tentang Anda atau dokumen Anda. Tidak ada yang terjadi kecuali Anda
+      mengekliknya, dan yang akan Anda tuju lewat klik itu adalah situs orang
+      lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua di halaman ini
+      tetap berfungsi. Itulah bukti yang paling sederhana: alat yang mengirim
+      dokumen Anda pergi untuk disensor akan berhenti."""
+
+[[howto]]
+title = "Pilih PDF-nya."
+body = """
+ Satu dokumen sekali jalan, dan itu disengaja:
+      penyensoran adalah pekerjaan yang harus dilihat halaman demi halaman, dan
+      alat yang membiarkan Anda mencentang kata di satu file lalu diam-diam
+      menerapkannya ke file lain adalah persis cara hal yang keliru terkirim. Ia
+      dibaca langsung dari disk Anda oleh peramban."""
+
+[[howto]]
+title = "Sebutkan apa yang harus hilang."
+body = """
+ Ketik kata-katanya &mdash; sebuah nama,
+      sebuah alamat, sebuah nomor rujukan &mdash; dan setiap tempat ia muncul
+      didaftar lengkap dengan baris tempatnya duduk dan sebuah kotak untuk
+      dicentang. Pencari di sebelah kotaknya akan mencari alamat email, nomor
+      kartu, IBAN, nomor jaminan sosial, dan nomor telepon. Semua itu ditawarkan,
+      tidak pernah dicentangkan untuk Anda: sebuah pola tidak bisa membedakan
+      nomor telepon dari nomor rujukan."""
+
+[[howto]]
+title = "Baca halamannya dan pilih kata dari atasnya."
+body = """
+
+      Panelnya menampilkan teks dokumennya sebagaimana ia benar-benar disimpan,
+      dalam urutan yang akan disalin seorang pembaca. Klik kata mana pun untuk
+      mengeluarkannya dan klik lagi untuk menyimpannya. Semua yang tercoret
+      adalah yang akan hilang &mdash; dan itu membuat langkah ini menjadi
+      peninjauan sekaligus pemilihan, dan layak dilakukan di setiap halaman
+      sebelum Anda menekan tombolnya."""
+
+[[howto]]
+title = "Keluarkan, lalu baca baris yang mengatakan ia sudah diperiksa."
+body = """
+
+      Hurufnya dihapus, celah yang ditinggalkannya ditahan tetap terbuka, sebuah
+      kotak hitam digambar di atasnya kalau Anda memintanya, dan kata yang sama
+      dikeluarkan dari markah, komentar, kolom formulir, dan properti dokumennya.
+      Lalu file jadinya dibuka lagi di sini dan dicari. Kalau kata yang Anda buang
+      masih bisa ditemukan di dalamnya, Anda tidak mendapat unduhan dan sebuah
+      pesan yang mengatakannya."""
+
+[[faq]]
+q = "Apa bedanya ini dengan menggambar kotak hitam di sebuah pembaca PDF?"
+a = """
+        Persegi yang digambar di sebuah pembaca adalah sebuah anotasi: objek
+        dengan sebuah posisi, disimpan di sebelah halamannya. Teks di bawahnya
+        tidak tersentuh. Siapa pun yang memilih area itu lalu menekan salin, atau
+        membuka file-nya di program lain, atau menjalankan pengekstrak teks apa
+        pun di atasnya, mendapatkan kata-katanya kembali. Sebagian pembaca
+        menawarkan perintah \"redact\" yang memang menerapkan penghapusannya dengan
+        benar &mdash; dan beberapa hanya menawarkan gambarnya. Alat ini tidak
+        punya persegi untuk digeser: hurufnya dipotong dari instruksi menggambar
+        halamannya, dan kotak hitamnya, kalau Anda biarkan menyala, digambar
+        sesudahnya di atas celah yang sudah kosong."""
+
+[[faq]]
+q = "Bagaimana saya tahu kata-katanya sungguh hilang?"
+a = """
+        Karena alatnya memeriksa, di mesin Anda, dan menunjukkan jumlahnya kepada
+        Anda. Ketika file-nya sudah ditulis, ia dibuka lagi oleh pembaca yang sama
+        di halaman ini, setiap halaman dibaca, setiap markah, komentar, kolom
+        formulir, dan properti dikumpulkan, dan setiap kata yang Anda buang
+        dicari. Baris hasilnya mengatakan ada berapa dan tersisa berapa. Kalau
+        jawabannya bukan yang seharusnya, jalannya gagal dan tidak ada yang
+        ditawarkan untuk diunduh. Anda juga bisa memeriksanya sendiri sesudahnya
+        di pembaca mana pun: tekan Ctrl+F dan cari katanya."""
+
+[[faq]]
+q = "Apakah sisa halamannya bergeser ketika sebuah kata dibuang?"
+a = """
+        Tidak. Teks digambar dengan memajukan sebuah pena melintasi halamannya,
+        jadi menghapus lima huruf biasanya akan menarik sisa barisnya lima huruf
+        ke kiri. Lebar persis dari yang dibuang diukur dari metrik fonnya sendiri
+        lalu ditaruh kembali sebagai instruksi jarak, yang memindahkan penanya
+        tanpa menggambar apa pun. Kolomnya tetap sejajar dan totalnya tetap di
+        bawah judulnya."""
+
+[[faq]]
+q = "Bisakah ia menyensor dokumen hasil pindaian?"
+a = """
+        Gambarnya tidak, dan ia mengatakannya alih-alih berpura-pura. Pindaian
+        adalah foto sebuah halaman: kata-katanya adalah piksel dan tidak ada teks
+        untuk dibuang. Yang sering dibawa sebuah pindaian adalah lapisan teks tak
+        kasatmata yang ditulis OCR pemindainya di atas gambarnya supaya halamannya
+        bisa dicari &mdash; alat ini menemukan lapisan itu, membuang yang Anda
+        pilih darinya, dan memberi tahu Anda di halamannya bahwa gambarnya tidak
+        berubah. Jadi sebuah pencarian dan sebuah salinan berhenti menemukan
+        katanya, dan orang yang memandangi halamannya tetap membacanya. Untuk
+        sebuah gambar, <a href=\"../sensor-gambar/\">penyensor gambar</a> menimpa
+        pikselnya sendiri."""
+
+[[faq]]
+q = "Bagaimana dengan bagian dokumen yang tidak ada di halamannya?"
+a = """
+        Mereka ditangani, karena di situlah sebuah penyensoran biasanya bocor.
+        Kata yang sama dikeluarkan dari markah, komentar, dan catatan tempel, dari
+        yang sudah diketik ke kolom formulir, dari teks yang diberikan kepada
+        pembaca layar, dan dari teks pengganti yang disalin sebuah pembaca
+        <em>alih-alih</em> huruf di halamannya &mdash; yang terakhir itu ada
+        supaya ligatur dan kata bertanda hubung tersalin dengan benar, dan ia bisa
+        memuat satu kalimat penuh. Properti dokumen dan paket XMP-nya dihapus
+        sekalian. Lampiran dan apa pun yang berjalan ketika file-nya dibuka ikut
+        dibuang, karena keduanya tidak bisa dicari untuk kata yang sedang Anda
+        buang."""
+
+[[faq]]
+q = "Apakah dokumen saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File-nya dibaca, disunting, dan ditulis oleh peramban Anda sendiri
+        di perangkat keras Anda sendiri. Alat ini tidak punya sisi server, dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya &mdash; tidak satu pun milik situs
+        ini. Yang Anda ketik ke kotak pencarian dibandingkan dengan teks di dalam
+        memori tab ini dan juga tidak pergi ke mana pun."""
+
+[[faq]]
+q = "Kenapa saya tidak bisa menyeret sebuah kotak di atas halamannya seperti di alat lain?"
+a = """
+        Karena menggambar sebuah halaman berarti sebuah perender PDF utuh &mdash;
+        fon, gradasi, transparansi, mode paduan &mdash; yang berarti satu megabita
+        atau lebih mesin untuk diambil dan dijalankan, dan situs ini tidak
+        mengirimkan satu pun. Ternyata itu cocok dengan pekerjaannya: menyeret
+        sebuah persegi memilih <em>area kertas</em>, dan area kertas bukan hal
+        yang sama dengan teks di bawahnya, dan begitulah kegagalan kotak hitam
+        bermula. Yang Anda dapatkan sebagai gantinya adalah teks dokumennya, dalam
+        urutan baca, dengan setiap kata bisa diklik. Itu juga satu-satunya tampilan
+        yang bisa memberi tahu Anda hal yang tidak bisa dikatakan sebuah gambar
+        halaman: apakah kata di hadapan Anda memang teks."""
+
+[[faq]]
+q = "Apakah file jadinya akan terbuka di mana saja?"
+a = """
+        Ya. Keluarannya ditulis sebagai PDF 1.5 atau versi tertinggi yang
+        dibutuhkan file yang Anda berikan, dan 1.5 dipahami setiap pembaca yang
+        dirilis sejak 2003. Tidak ada di halamannya yang dikodekan ulang: fon,
+        gambar, dan gambar vektornya lewat byte demi byte, jadi sisa teksnya tetap
+        bisa dipilih dan dicari persis seperti sebelumnya."""
+
+[[faq]]
+q = "Bisakah ia membuka PDF yang dilindungi kata sandi?"
+a = """
+        Tidak, dan itu disengaja. Dokumen terenkripsi ditolak dengan sebuah pesan
+        yang mengatakannya, bahkan ketika kata sandinya kosong &mdash; dan begitulah
+        banyak pemindai dan mesin fotokopi menyimpan. Melepas perlindungan sebuah
+        file adalah pekerjaan yang berbeda dari mengeluarkan kata darinya, dan alat
+        yang melakukannya diam-diam akan melakukan sesuatu yang tidak Anda
+        minta."""
+
+[[faq]]
+q = "Apakah ada batas ukuran, dan apakah ada biayanya?"
+a = """
+        Tidak ada batas yang ditulis ke dalam alatnya. Batasnya adalah mesin Anda
+        sendiri: dokumennya ditahan di memori selagi dikerjakan, jadi sebuah laptop
+        akan menerima beberapa ratus megabita tanpa mengeluh dan akan kepayahan di
+        suatu titik di atasnya. Ia gratis, tidak ada akun, tidak ada masuk, dan
+        tidak ada masa uji coba. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang dokumen Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia terus
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim dokumen Anda pergi untuk disensor akan
+        berhenti pada saat Anda mencabut koneksi."""
+
+[schema]
+description = "Sensor sebuah PDF di peramban Anda dengan menghapus teksnya alih-alih menutupinya. Hurufnya dibuang dari aliran isi halamannya, file jadinya dibuka lagi dan dicari untuk membuktikan hurufnya sudah hilang, dan tidak ada yang diunggah."
+features = [
+  "Menghapus hurufnya dari halamannya alih-alih menggambar persegi di atasnya",
+  "Membuka lagi file jadinya dan mencarinya untuk membuktikan kata-katanya hilang",
+  "Menemukan setiap kemunculan sebuah kata, atau mencari email, nomor kartu, IBAN, dan nomor identitas nasional",
+  "Menampilkan teks dokumennya dalam urutan baca sehingga kata mana pun bisa diklik",
+  "Membuang kata yang sama dari markah, komentar, kolom formulir, dan properti",
+  "Menahan celahnya tetap terbuka supaya sisa barisnya tidak bergeser",
+  "Mengatakan halaman mana yang berupa pindaian, tempat tidak ada teks untuk dibuang",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa batas ukuran file",
+]
+
+[picker]
+title = "Jatuhkan PDF Anda di sini"
+hint = "atau klik untuk menelusuri &mdash; satu dokumen sekali jalan"

--- a/locales/id/tools/resize-image.html
+++ b/locales/id/tools/resize-image.html
@@ -1,0 +1,291 @@
+<!--
+  tools/resize-image/body.html, in Indonesian.
+
+  Every id, class, data-* and option value below is what src/main.js and
+  src/cropper.js reach for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file-nya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih gambar</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Keluarkan semua dari daftar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; pemangkasan -->
+  <section class="card" id="crop-card">
+    <h2><span class="step">2</span> Pangkas, kalau Anda mau</h2>
+
+    <p class="card-lede">
+      Kotaknya mulai menutupi seluruh gambar, jadi membiarkan langkah ini berarti
+      tidak memangkas apa pun. Setiap gambar menyimpan kotaknya sendiri &mdash;
+      pilih salah satu dari daftar di atas untuk menggambarinya. Pemangkasan
+      terjadi sebelum pengubahan ukuran, dan hanya urutan itulah yang masuk akal:
+      gambar yang dipotong setelah diperkecil sudah membuang piksel yang
+      dibutuhkannya.
+    </p>
+
+    <p id="crop-empty" class="field-summary">Tambahkan sebuah gambar dan kotaknya muncul di sini.</p>
+
+    <div id="crop-controls" hidden>
+      <p class="stage-hint">
+        <span id="stage-name" class="stage-name"></span>
+        Seret di dalam kotak untuk memindahkannya, atau sudut mana pun untuk
+        mengubah ukurannya. Saat kotaknya terfokus, tombol panah menggesernya satu
+        piksel sekali tekan, <kbd>Alt</kbd>&nbsp;+&nbsp;panah mengubah ukurannya,
+        dan menahan <kbd>Shift</kbd> membuat setiap langkah menjadi sepuluh.
+      </p>
+
+      <!-- The crop box itself is added here by src/cropper.js. The stage is
+           given the picture's own shape, so the box can be positioned in
+           percentages and needs no recalculating when the window is resized. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <img id="preview" alt="">
+        </div>
+      </div>
+
+      <p id="stage-note" class="stage-note" hidden></p>
+
+      <div class="crop-controls">
+        <div class="aspect-row" id="aspect-row" role="group" aria-label="Kunci pemangkasan ke sebuah bentuk">
+          <button type="button" data-aspect="free" class="active">Bebas</button>
+          <button type="button" data-aspect="source">Asli</button>
+          <button type="button" data-aspect="1:1">1:1</button>
+          <button type="button" data-aspect="4:5">4:5</button>
+          <button type="button" data-aspect="9:16">9:16</button>
+          <button type="button" data-aspect="16:9">16:9</button>
+          <button type="button" data-aspect="4:3">4:3</button>
+          <button type="button" data-aspect="3:2">3:2</button>
+          <button type="button" id="swap-aspect" class="ghost" title="Balikkan bentuk yang terkunci">
+            Balik
+          </button>
+        </div>
+
+        <div class="numbers">
+          <label>Kiri<input type="number" id="crop-x" min="0" step="1"></label>
+          <label>Atas<input type="number" id="crop-y" min="0" step="1"></label>
+          <label>Lebar<input type="number" id="crop-w" min="8" step="1"></label>
+          <label>Tinggi<input type="number" id="crop-h" min="8" step="1"></label>
+          <div class="number-actions">
+            <button type="button" id="crop-max" class="ghost">Terbesar</button>
+            <button type="button" id="crop-centre" class="ghost">Tengah</button>
+            <button type="button" id="crop-reset" class="ghost">Seluruh gambar</button>
+          </div>
+        </div>
+
+        <!--
+          Every image keeps its own box, which is the point. This is for the
+          case that is still worth one click: a folder of exports that all want
+          the same framing.
+        -->
+        <div class="apply-row" id="apply-row" hidden>
+          <button type="button" id="crop-apply-all" class="ghost">Pakai pangkasan ini di setiap gambar</button>
+          <p class="hint-line" id="apply-note"></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; ukurannya -->
+  <section class="card" id="resize-card">
+    <h2><span class="step">3</span> Sebutkan ukurannya harus berapa</h2>
+
+    <div class="option-row">
+      <label for="resize-mode">Tetapkan ukurannya lewat</label>
+      <select id="resize-mode">
+        <option value="pixels" selected>Lebar dan tinggi, dalam piksel</option>
+        <option value="longest">Sisi terpanjang</option>
+        <option value="percent">Persentase dari ukurannya sekarang</option>
+        <option value="none">Tidak ada &mdash; biarkan ukurannya persis seperti sekarang</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="pixels-fields">
+      <div class="numbers">
+        <label>Lebar<input type="number" id="size-w" min="1" step="1" placeholder="otomatis" value="1920"></label>
+        <label>Tinggi<input type="number" id="size-h" min="1" step="1" placeholder="otomatis"></label>
+        <div class="number-actions">
+          <button type="button" id="swap-size" class="ghost">Balik</button>
+        </div>
+      </div>
+
+      <!--
+        Leaving one of them blank is the common case and the one worth
+        supporting properly: "1920 wide, whatever tall that makes it" needs no
+        decision about shapes at all.
+      -->
+      <p class="hint-line">
+        Isi salah satunya dan biarkan yang lain kosong supaya gambarnya menjaga
+        bentuknya sendiri.
+      </p>
+
+      <div class="presets" id="size-presets" role="group" aria-label="Ukuran yang lazim">
+        <button type="button" class="ghost" data-w="1920" data-h="1080">1920 &times; 1080</button>
+        <button type="button" class="ghost" data-w="1280" data-h="720">1280 &times; 720</button>
+        <button type="button" class="ghost" data-w="1080" data-h="1080">1080 &times; 1080</button>
+        <button type="button" class="ghost" data-w="600" data-h="">lebar 600</button>
+      </div>
+
+      <div class="option-row" id="fit-row">
+        <label for="fit">Kalau bentuknya tidak cocok</label>
+        <select id="fit">
+          <option value="contain" selected>Muat di dalamnya &mdash; gambar utuh, satu sisi keluar lebih pendek</option>
+          <option value="cover">Isi &mdash; persis ukuran ini, dengan yang berlebih dipotong</option>
+          <option value="pad">Isi sisanya &mdash; persis ukuran ini, dengan latar mengelilinginya</option>
+          <option value="stretch">Regangkan &mdash; persis ukuran ini dan bentuknya berubah</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Sisi terpanjang<input type="number" id="size-longest" min="1" step="1" value="1920"></label>
+      </div>
+      <p class="hint-line">
+        Sisi mana pun yang lebih panjang menjadi angka ini, dan sisi satunya
+        mengikuti. Foto tegak dan melintang di kumpulan yang sama semuanya keluar
+        dengan ukuran yang sama pada sisi panjangnya, dan itulah yang biasanya
+        diinginkan sebuah galeri.
+      </p>
+      <div class="presets" id="longest-presets" role="group" aria-label="Sisi panjang yang lazim">
+        <button type="button" class="ghost" data-longest="640">640</button>
+        <button type="button" class="ghost" data-longest="1280">1280</button>
+        <button type="button" class="ghost" data-longest="1920">1920</button>
+        <button type="button" class="ghost" data-longest="2560">2560</button>
+      </div>
+    </div>
+
+    <div class="size-fields" id="percent-fields" hidden>
+      <div class="numbers">
+        <label>Persen<input type="number" id="size-percent" min="1" max="1000" step="1" value="50"></label>
+      </div>
+      <div class="presets" id="percent-presets" role="group" aria-label="Persentase yang lazim">
+        <button type="button" class="ghost" data-percent="25">25%</button>
+        <button type="button" class="ghost" data-percent="50">50%</button>
+        <button type="button" class="ghost" data-percent="75">75%</button>
+        <button type="button" class="ghost" data-percent="200">200%</button>
+      </div>
+    </div>
+
+    <label class="check" id="enlarge-row">
+      <input type="checkbox" id="no-enlarge" checked>
+      <span>
+        <strong>Jangan pernah membuat gambar lebih besar daripada asalnya</strong>
+        <span class="check-note">
+          Memperbesar mengarang piksel yang tidak pernah difoto, jadi gambar kecil
+          yang diminta mengisi bingkai besar keluar lembut alih-alih terperinci.
+          Dengan ini menyala, apa pun yang sudah lebih kecil daripada ukuran yang
+          Anda minta dibiarkan pada ukurannya sendiri.
+        </span>
+      </span>
+    </label>
+
+    <p id="size-summary" class="field-summary"></p>
+  </section>
+
+  <!-- Langkah 4 &mdash; format, dan satu klik -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Simpan</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format">
+          <option value="keep" selected>Biarkan setiap file seperti format datangnya</option>
+          <option value="image/jpeg">JPEG</option>
+          <option value="image/png">PNG</option>
+          <option value="image/webp">WebP</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kualitas &mdash; <output id="quality-value" for="quality">85</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="85">
+        <p class="field-note">
+          Hanya untuk JPEG dan WebP; PNG tidak punya tombol kualitas. 85 adalah
+          tempat kebanyakan orang berhenti bisa membedakan. Di bawah sekitar 60,
+          area datar mulai berpita.
+        </p>
+      </div>
+
+      <div class="field" id="background-field">
+        <label for="background">Latar</label>
+        <input type="color" id="background" value="#ffffff">
+        <p class="field-note">
+          Yang tampak di tempat gambarnya tidak ada: di belakang bingkai yang
+          diisi, dan di belakang transparansi kalau format keluarannya tidak
+          punya kanal alfa.
+        </p>
+      </div>
+    </div>
+
+    <p id="plan-summary" class="field-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Ubah ukuran gambarnya</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Selesai</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Unduh semua sebagai zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+
+  <!--
+    The big look at one result. A <dialog> opened with showModal() rather than
+    a div pretending to be one: the browser gives the focus trap, the Escape
+    key and the inert background for nothing, and gets all three right.
+
+    Both pictures in it are object URLs made on this page - the result, and the
+    original that was already decoded for the thumbnail. Opening this fetches
+    nothing and decodes nothing that was not already decoded.
+  -->
+  <dialog id="viewer" class="viewer" aria-labelledby="viewer-name">
+    <div class="viewer-head">
+      <h2 id="viewer-name" class="viewer-name"></h2>
+      <button type="button" id="viewer-close" class="ghost" aria-label="Tutup">Tutup</button>
+    </div>
+
+    <div class="viewer-stage">
+      <img id="viewer-image" alt="">
+    </div>
+
+    <p id="viewer-caption" class="viewer-caption"></p>
+
+    <dl class="viewer-facts" id="viewer-facts"></dl>
+
+    <div class="viewer-actions">
+      <button type="button" id="viewer-compare" class="ghost" aria-pressed="false">Tampilkan aslinya</button>
+      <a id="viewer-download" class="primary as-button" download>Unduh</a>
+    </div>
+  </dialog>
+</main>

--- a/locales/id/tools/resize-image.toml
+++ b/locales/id/tools/resize-image.toml
@@ -1,0 +1,290 @@
+#
+# Pengubah Ukuran Gambar - Bahasa Indonesia.
+#
+# Overrides for tools/resize-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Dua tautan silang di FAQ memakai slug Indonesia dari [slugs] di locale.toml -
+# ../hapus-data-exif/ dan ../kompres-gambar/ - karena locale yang sudah
+# diterbitkan diharuskan setiap tautan internalnya mendarat di halaman yang
+# benar-benar dibangun.
+#
+
+name = "Pengubah Ukuran Gambar"
+heading = "Pengubah&nbsp;Ukuran&nbsp;Gambar <span class=\"h1-kw\">&mdash; ubah ukuran, pangkas, dan ubah format</span>"
+tagline = "Sebutkan ukurannya. Gambar kotaknya. Pilih formatnya."
+
+title = "Ubah Ukuran Gambar &mdash; Pangkas dan Ubah Format Juga, Tanpa Unggah"
+description = "Ubah ukuran, pangkas, dan ubah format gambar JPEG, PNG, dan WebP di peramban Anda. Piksel yang persis, sebuah persentase, atau sisi terpanjang - satu gambar atau satu folder penuh. Tidak ada yang diunggah."
+og_title = "Ubah ukuran, pangkas, dan ubah format sebuah gambar tanpa mengunggahnya"
+og_description = "Tetapkan ukurannya dalam piksel atau persen, seret sebuah kotak pangkas, ubah formatnya - untuk satu gambar atau satu kumpulan penuh. Semuanya berjalan di mesin Anda sendiri."
+og_image_alt = "Pengubah Ukuran Gambar - ubah ukuran, pangkas, dan ubah format tanpa mengunggah"
+
+pledge = """
+    Pengubahan ukuran, pemangkasan, dan pergantian formatnya semua berjalan di
+    peramban Anda sendiri, di perangkat keras Anda sendiri, memakai encoder
+    gambar yang memang sudah dibawanya. Alat ini tidak punya fitur jaringan
+    dalam bentuk apa pun &mdash; tidak ada yang diambil, tidak ada yang dikirim
+    &mdash; dan seandainya pun ada, tidak ada server di ujung lain halaman ini
+    untuk menerima sebuah gambar."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu ubah ukuran sebuah foto. Tidak satu pun permintaan membawa gambar,
+      gambar mini, nama file, atau satu byte pun dari yang Anda pilih. Atau cabut
+      koneksi internet dan tetap ubah ukuran satu."""
+
+read_first = """
+, <code>src/geometry.js</code> untuk aritmetika yang
+      memutuskan apa yang disimpan dan seberapa besar hasilnya keluar, dan
+      <code>src/codecs.js</code> untuk satu panggilan <code>drawImage</code> yang
+      melakukan pemangkasan dan pengubahan ukurannya sekaligus."""
+
+howto_heading = "Cara mengubah ukuran gambar tanpa mengunggahnya"
+
+card = """
+            Piksel yang persis, sebuah persentase, atau sisi terpanjang &mdash;
+            dengan sebuah kotak pangkas dan pergantian format di tengah jalan.
+            Satu gambar atau satu folder."""
+
+[words]
+plural = "gambar"
+choose = "sebuah gambar"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Gambar Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di mana
+      pun di dalam <code>src/</code>. Pengubahan ukurannya adalah satu
+      <code>drawImage</code> ke sebuah kanvas dan satu
+      <code>canvas.toBlob</code> &mdash; penskala dan encoder yang memang sudah
+      terpasang di peramban Anda."""
+
+[[privacy]]
+title = "File yang tidak diminta berubah tidak diubah."
+body = """
+ Tanpa pemangkasan, tanpa pengubahan
+      ukuran, dan tanpa pergantian format, file yang Anda pilih diserahkan
+      kembali kepada Anda byte demi byte alih-alih disimpan ulang. Itu bukan
+      sekadar kesopanan: itulah sebabnya alat ini tidak bisa diam-diam mengodekan
+      ulang sebuah gambar, atau diam-diam membuang metadata gambar yang hanya
+      ingin Anda lihat."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google, dan tombol donasi dari Buy Me a Coffee. Tidak satu pun diberi
+      apa pun tentang gambar Anda. Setiap baris yang membaca, memangkas,
+      menskalakan, atau menulis sebuah file disajikan dari asal ini dan terdaftar
+      di repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih gambar Anda."
+body = """
+ Jatuhkan ke pemilih file atau pilih sendiri.
+      Peramban membacanya langsung dari disk Anda; tidak ada yang dikirim ke mana
+      pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Pangkas, kalau Anda mau."
+body = """
+ Kotaknya mulai menutupi seluruh gambar,
+      jadi membiarkannya berarti tidak memangkas apa pun. Seret, atau kunci ke
+      sebuah bentuk &mdash; 1:1 untuk foto profil, 9:16 untuk cerita, 16:9 untuk
+      gambar mini &mdash; dan tekan "Terbesar" untuk kotak terbesar yang muat.
+      Setiap gambar menyimpan kotaknya sendiri: klik baris mana pun di daftar
+      untuk menggambar di gambar itu. Kalau semuanya harus dibingkai dengan cara
+      yang sama, satu tombol juga melakukannya."""
+
+[[howto]]
+title = "Sebutkan hasilnya harus berukuran berapa."
+body = """
+ Sebuah lebar, sebuah tinggi, atau
+      keduanya; sisi terpanjang, yang membuat foto tegak dan melintang berukuran
+      sama satu sama lain; atau sekadar sebuah persentase. Biarkan salah satu dari
+      dua kotaknya kosong dan gambarnya menjaga bentuknya sendiri."""
+
+[[howto]]
+title = "Pilih formatnya, lalu tekan tombolnya."
+body = """
+ Biarkan setiap file seperti format
+      datangnya, atau tulis semuanya sebagai JPEG, PNG, atau WebP. Setiap hasil
+      mengatakan ia menjadi apa dan seberapa kecil ia jadinya; klik salah satunya
+      untuk membukanya ukuran penuh dengan setiap angka di baliknya, dan
+      aslinya di sebelahnya untuk dibandingkan. Satu kumpulan turun sebagai satu
+      zip."""
+
+[[faq]]
+q = "Apakah gambar saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File didekode, dipangkas, diskalakan, dan ditulis oleh peramban
+        Anda sendiri di perangkat keras Anda sendiri, memakai encoder JPEG, PNG,
+        dan WebP yang memang sudah dibawa peramban. Alat ini tidak punya fitur
+        jaringan dalam bentuk apa pun &mdash; ia tidak pernah mengambil apa pun
+        dan tidak pernah mengirim apa pun &mdash; dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+        ini."""
+
+[[faq]]
+q = "Apa yang terjadi kalau saya memberi lebar tapi bukan tinggi?"
+a = """
+        Tingginya mengikuti bentuk gambar itu sendiri, dan hampir selalu itulah
+        yang diinginkan: "lebar 1920" berarti "lebar 1920 dan setinggi apa pun
+        yang dihasilkannya". Isi keduanya dan keduanya bisa bertentangan dengan
+        bentuk gambarnya, dan itu satu-satunya saat pilihan "kalau bentuknya
+        tidak cocok" muncul &mdash; muat di dalam kotaknya, isi kotaknya dan
+        potong yang berlebih, isi sisanya dengan latar, atau regangkan dan terima
+        perubahan bentuknya."""
+
+[[faq]]
+q = "Apakah mengubah ukuran gambar menurunkan kualitas?"
+a = """
+        Memperkecil sebuah gambar tidak, dengan cara apa pun yang bisa Anda
+        lihat: piksel yang masuk lebih banyak daripada yang keluar, jadi detail
+        yang disimpan adalah detail sungguhan. Memperbesar tidak bisa menambahkan
+        apa yang tidak pernah difoto &mdash; hasilnya adalah salinan yang lebih
+        lembut dari gambar yang sama, bukan yang lebih tajam &mdash; dan itulah
+        sebabnya "jangan pernah membuat gambar lebih besar daripada asalnya"
+        menyala secara bawaan. Yang memang memakan sedikit biaya adalah pengodean
+        ulang sesudahnya, kalau formatnya JPEG atau WebP, dan penggeser kualitas
+        adalah tempat Anda membelanjakannya."""
+
+[[faq]]
+q = "Bisakah saya memangkas setiap gambar dengan cara berbeda?"
+a = """
+        Bisa &mdash; itulah bawaannya. Setiap gambar di daftar membawa kotaknya
+        sendiri, dalam pikselnya sendiri, dan mengeklik sebuah baris menaruh
+        gambar itu di pratinjau dengan kotaknya sendiri dan bentuk terkuncinya
+        sendiri. Apa pun yang Anda lakukan pada satu gambar tidak memengaruhi yang
+        lain. Setiap kotak juga mulai menutupi seluruh gambar, jadi gambar yang
+        tidak pernah Anda gambari sama sekali tidak dipangkas."""
+
+[[faq]]
+q = "Bisakah ia memangkas satu kumpulan penuh dengan cara yang sama sekaligus?"
+a = """
+        Bisa, dengan tombol di bawah pratinjaunya. Ia memberi setiap gambar lain
+        area relatif yang sama &mdash; pecahan yang sama dari lebar dan tingginya
+        sendiri &mdash; yang untuk sekumpulan tangkapan layar atau hasil ekspor
+        yang semuanya berukuran sama berarti persis kotak yang sama, dan halaman
+        ini mengatakannya. Dengan sebuah bentuk terkunci, ia justru memberi
+        masing-masing kotak terbesar berbentuk itu di dalam area tersebut, jadi
+        menekan 1:1 lalu tombol itu memberi Anda persegi dari satu folder berisi
+        foto tegak dan melintang yang bercampur. Setiap kotak tetap bisa disunting
+        sesudahnya."""
+
+[[faq]]
+q = "Format apa saja yang bisa dibaca dan ditulisnya?"
+a = """
+        Ia membaca apa pun yang bisa didekode peramban Anda, yang dalam praktiknya
+        berarti JPEG, PNG, WebP, GIF, BMP, dan &mdash; di sebagian besar peramban
+        masa kini &mdash; AVIF. Ia menulis JPEG, PNG, dan WebP, karena itulah
+        encoder yang dibawa peramban. Pada "biarkan formatnya", JPEG tetap JPEG
+        dan PNG tetap PNG; apa pun yang tidak bisa ditulis peramban, seperti GIF
+        atau BMP, keluar sebagai PNG, yang menjaga transparansi dan warna datar
+        tetap utuh."""
+
+[[faq]]
+q = "Apa yang terjadi pada transparansi kalau saya menyimpan sebagai JPEG?"
+a = """
+        Ia diisi dengan warna latar, karena JPEG tidak punya kanal alfa untuk
+        menyimpannya. Warnanya Anda yang pilih dan ia mulai dari putih, yang
+        diinginkan kebanyakan orang dan yang dilakukan hampir setiap alat lain
+        tanpa memberi tahu Anda. Warna yang sama dipakai di belakang bingkai yang
+        diisi. Simpan sebagai PNG atau WebP saja dan transparansinya lewat tanpa
+        disentuh."""
+
+[[faq]]
+q = "Apakah ia menghapus data EXIF dan GPS?"
+a = """
+        Apa pun yang benar-benar diprosesnya, ya, sebagai efek samping: memangkas
+        atau mengubah ukuran berarti mendekode gambarnya menjadi piksel dan
+        mengodekan piksel itu lagi, dan kanvas penuh piksel tidak membawa tag,
+        jadi lokasi, model kamera, dan stempel waktunya sama sekali tidak ditulis
+        ke file baru. File yang sama sekali tidak Anda ubah adalah kasus yang
+        berbeda &mdash; ia diserahkan kembali byte demi byte, lengkap dengan
+        tag-nya. Kalau Anda mau metadatanya hilang tapi gambarnya tidak
+        tersentuh, pakai
+        <a href="../hapus-data-exif/">Penampil dan Penghapus EXIF</a>, yang
+        menulis ulang wadahnya tanpa mengompres ulang apa pun."""
+
+[[faq]]
+q = "Apa bedanya ini dengan kompresor gambar?"
+a = """
+        Yang ini soal dimensi: Anda menyebut berapa piksel yang Anda mau dan ia
+        memberikannya. <a href="../kompres-gambar/">Kompresor Gambar</a> soal
+        ukuran file: Anda menyebut berapa kilobyte yang diizinkan dan ia mencari
+        kualitas tertinggi yang muat, mengubah ukuran hanya kalau kualitas saja
+        tidak bisa sampai ke sana. Kalau Anda diberi tahu "lebar 1200 piksel",
+        Anda berada di tempat yang tepat. Kalau Anda diberi tahu "di bawah 500
+        KB", yang satunya akan membawa Anda lebih dekat."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Tidak ada batas jumlah atau ukuran file-nya juga,
+        karena tidak ada server yang membayarnya &mdash; pekerjaannya terjadi di
+        mesin Anda sendiri. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang gambar Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim gambar Anda ke tempat lain untuk diubah
+        ukurannya akan berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Ubah ukuran, pangkas, dan ubah format gambar JPEG, PNG, dan WebP di peramban. Tetapkan ukuran piksel yang persis, sebuah persentase, atau sisi terpanjang, seret sebuah kotak pangkas atau kunci ke sebuah bentuk, dan tulis hasilnya sebagai JPEG, PNG, atau WebP. Mendukung kumpulan, dan tidak ada yang diunggah."
+features = [
+  "Mengubah ukuran lewat piksel yang persis, sisi terpanjang, atau persentase",
+  "Isi satu sisi dan sisi lainnya mengikuti bentuk gambarnya sendiri",
+  "Muat di dalam, isi lalu pangkas, isi sampai bingkai yang persis, atau regangkan",
+  "Kotak pangkas yang bisa diseret per gambar, bisa dikunci ke 1:1, 4:5, 9:16, 16:9, 4:3, atau 3:2",
+  "Memangkas setiap gambar secara berbeda, atau menerapkan satu pembingkaian ke seluruh kumpulan dalam satu klik",
+  "Membuka setiap gambar yang sudah jadi pada ukuran penuh, dengan setiap angka di baliknya dan aslinya untuk dibandingkan",
+  "Mengubah antara JPEG, PNG, dan WebP, dengan kendali kualitas dan warna latar",
+  "Tidak pernah memperbesar sebuah gambar kecuali Anda memintanya",
+  "Mengembalikan tanpa disentuh file yang tidak diminta berubah",
+  "Kumpulan, dengan semua hasilnya dalam satu zip",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan gambar di sini"
+hint = "atau klik untuk menelusuri &mdash; JPEG, PNG, WebP, dan apa pun lain yang bisa dibuka peramban Anda"

--- a/locales/id/tools/reverse-video.html
+++ b/locales/id/tools/reverse-video.html
@@ -1,0 +1,95 @@
+<!--
+  tools/reverse-video/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Ukuran</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Bingkai</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Audio</dt><dd id="src-audio">&mdash;</dd></div>
+    </dl>
+
+    <div class="stage-wrap" id="preview-wrap" hidden>
+      <video id="preview" class="stage" playsinline controls></video>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; pembalikan -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">2</span> Balik</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="quality">Kualitas</label>
+        <select id="quality">
+          <option value="low">File lebih kecil</option>
+          <option value="medium" selected>Seimbang</option>
+          <option value="high">Kualitas terbaik</option>
+        </select>
+        <p class="field-note">
+          Tidak pernah lebih dari yang dibelanjakan aslinya untuk gambar yang sama
+          &mdash; klip yang dibalik memuat bingkai yang sama, jadi membelanjakan
+          lebih hanya membuat file lebih besar.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Balik suaranya juga
+        </label>
+        <p class="field-note" id="audio-note">
+          Dibalik sampel demi sampel, lalu dikodekan lagi sebagai AAC. Biarkan
+          mati untuk klip tanpa suara, yang lebih cepat.
+        </p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Bingkai keluaran</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Bingkai</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Caranya</dt><dd id="sum-path">&mdash;</dd></div>
+    </dl>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Balik video</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh video</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/reverse-video.toml
+++ b/locales/id/tools/reverse-video.toml
@@ -1,0 +1,245 @@
+#
+# Pembalik Video - Bahasa Indonesia.
+#
+# Overrides for tools/reverse-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Pembalik Video"
+heading = "Pembalik&nbsp;Video <span class=\"h1-kw\">&mdash; putar video terbalik</span>"
+tagline = "Bingkai terakhir lebih dulu, lengkap dengan suaranya."
+
+title = "Putar Video Terbalik Daring &mdash; Gratis, Tanpa Unggah, Jalan Tanpa Internet"
+description = "Putar MP4, MOV, atau WebM secara terbalik, dengan suaranya ikut dibalik. Berjalan di peramban Anda: tidak ada yang diunggah, tidak ada tanda air, dan jalan tanpa internet."
+og_title = "Pembalik Video &mdash; putar klip terbalik tanpa mengunggahnya"
+og_description = "Balik sebuah video beserta suaranya, bingkai demi bingkai, di perangkat Anda sendiri. File dibaca, didekode, dan ditulis oleh peramban Anda sendiri."
+og_image_alt = "Pembalik Video - putar klip terbalik di peramban Anda, tanpa ada yang diunggah"
+
+pledge = """
+    Setiap bingkai didekode, dibalik, dan dikodekan lagi oleh peramban Anda
+    sendiri, di perangkat keras Anda sendiri. Tidak ada di sini yang bisa
+    mengambil atau mengirim apa pun &mdash; alat ini sama sekali tidak punya
+    fitur jaringan &mdash; dan seandainya pun ada, tidak ada server di ujung lain
+    halaman ini untuk menerima sebuah video."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu balik sebuah klip. Tidak satu pun permintaan membawa bingkai, nama
+      file, atau satu byte pun dari yang Anda pilih. Atau cabut koneksi internet
+      dan tetap balik satu &mdash; alat yang mengirim video Anda ke tempat lain
+      untuk diproses akan langsung berhenti."""
+
+read_first = """
+, <code>src/timeline.js</code> untuk aritmetika yang
+      memutuskan bingkai mana keluar kapan, dan <code>src/reverse.js</code> untuk
+      perulangan yang menelusuri file secara mundur satu kelompok bingkai sekali
+      jalan. Tidak satu pun mengimpor sesuatu yang bisa membuat permintaan."""
+
+howto_heading = "Cara memutar video terbalik"
+
+card = """
+            Putar sebuah klip terbalik &mdash; gambar dan suaranya sekaligus
+            &mdash; tanpa mengirimnya ke mana pun."""
+
+[words]
+plural = "video"
+choose = "sebuah video"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Membalik suaranya juga"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[privacy]]
+title = "Video Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Alat ini sama sekali tidak punya
+      fitur jaringan: tidak ada alamat untuk ditempelkan, tidak ada yang diunduh,
+      tidak ada mesin yang diambil saat pertama dipakai. Setiap byte yang
+      menyentuh video Anda datang dari asal ini ketika halaman dimuat."""
+
+[[privacy]]
+title = "Pendekodean dan pengodean berjalan lokal."
+body = """
+ Bingkainya melewati WebCodecs di
+      peramban Anda sendiri, atau melewati mesin pemutar yang sama yang toh akan
+      menampilkan klip itu kepada Anda. File yang sudah jadi dibangun di memori
+      mesin ini dan diserahkan langsung ke unduhan."""
+
+[[privacy]]
+title = "Suaranya juga dibalik di sini."
+body = """
+ Membalik sebuah jalur berarti
+      mendekodenya, dan pendekodean itu milik peramban sendiri, berjalan di mesin
+      ini. Tidak ada yang mendengarkannya, tidak ada yang menyimpannya, dan tidak
+      ada yang bisa meneruskannya ke mana pun: tidak ada jalur kode di sini yang
+      mengirim satu byte pun."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang video Anda: bukan file,
+      bukan bingkai, bukan nama, ukuran, atau durasi. Setiap baris yang membaca,
+      mendekode, membalik, atau mengodekan disajikan dari asal ini dan terdaftar
+      di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau video Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih sebuah video."
+body = """
+ Jatuhkan MP4, MOV, M4V, atau WebM ke
+      pemilih file, atau pilih sendiri. Peramban membacanya langsung dari disk
+      Anda; tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Putuskan soal suaranya."
+body = """
+ &ldquo;Balik suaranya juga&rdquo;
+      membalik jalurnya sampel demi sampel, dan itulah yang membuat ucapan keluar
+      sebagai ucapan yang diputar terbalik, bukan sebagai keheningan. Matikan
+      untuk klip tanpa suara, yang lebih cepat."""
+
+[[howto]]
+title = "Pilih berapa banyak kualitas yang dibelanjakan."
+body = """
+ Gambarnya harus dikodekan lagi,
+      karena bingkainya keluar dalam urutan yang tidak pernah dikodekan oleh apa
+      pun di dalam file itu. &ldquo;Seimbang&rdquo; tetap dekat dengan apa yang
+      dibelanjakan aslinya; &ldquo;Kualitas terbaik&rdquo; membelanjakan
+      lebih."""
+
+[[howto]]
+title = "Balik dan unduh."
+body = """
+ Pekerjaannya terjadi di perangkat keras Anda
+      sendiri, jadi lamanya tergantung mesin Anda, bukan pada antrean. Video yang
+      sudah jadi diserahkan langsung ke unduhan peramban Anda."""
+
+[[faq]]
+q = "Apakah video saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca, didekode, dibalik, dan dikodekan oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya sisi
+        server, dan <code>Content-Security-Policy</code> halaman ini menyebut
+        satu per satu setiap alamat yang boleh dihubunginya &mdash; tidak satu
+        pun milik situs ini. Cabut koneksi internet dan tetap balik sebuah klip
+        kalau Anda lebih suka memeriksa daripada diberi tahu."""
+
+[[faq]]
+q = "Format video apa saja yang bisa saya balik?"
+a = """
+        MP4, M4V, dan MOV dibaca langsung, apa pun isinya: H.264, HEVC, AV1, atau
+        VP9, selama peramban Anda bisa mendekode kodek itu. Apa pun lain yang
+        bisa diputar peramban Anda &mdash; yang paling jelas WebM &mdash; dibalik
+        dengan cara melangkahkan pemutar peramban sendiri mundur melewatinya,
+        yang berhasil tapi lebih lambat. File yang tidak bisa dibaca maupun
+        diputar peramban, yang dalam praktiknya berarti AVI, WMV, FLV, dan
+        sebagian besar MKV, ditolak dengan pesan alih-alih gagal di tengah jalan.
+        Yang keluar selalu berupa MP4."""
+
+[[faq]]
+q = "Apakah suaranya ikut dibalik?"
+a = """
+        Ya, kecuali Anda mematikannya. Seluruh jalur didekode, sampelnya
+        diletakkan dalam urutan terbalik, dan dikodekan lagi sebagai AAC. Tidak
+        ada cara menghindari pengodean kedua itu: sebuah paket audio adalah suara
+        selama beberapa puluh milidetik yang dikodekan terhadap paket sebelumnya,
+        jadi menulis paketnya dari belakang ke depan akan memutar potongan-potongan
+        pendek ke arah maju dalam urutan yang salah &mdash; yang terdengar seperti
+        kerusakan, bukan seperti pembalikan."""
+
+[[faq]]
+q = "Apakah membalik menurunkan kualitas?"
+a = """
+        Gambarnya dikodekan untuk kedua kalinya, dan itu memakan sedikit. Di sini
+        hal itu tidak bisa dihindari seperti saat memotong: klip yang dibalik
+        menampilkan bingkainya dalam urutan yang tidak pernah dikodekan oleh apa
+        pun di file aslinya, jadi setiap bingkai harus ditulis dari awal. Yang
+        tidak akan dilakukan alat ini adalah membelanjakan lebih banyak daripada
+        aslinya, karena mengodekan di atas itu hanya membuat file lebih besar
+        tanpa membuatnya tampak lebih baik."""
+
+[[faq]]
+q = "Adakah batas ukuran atau durasi videonya?"
+a = """
+        Tidak ada batas yang tertanam di alat ini, dan file tidak dibaca ke
+        memori sekaligus &mdash; ia ditelusuri satu kelompok bingkai demi
+        kelompok bingkai, secara mundur. Batas praktisnya adalah video yang sudah
+        jadi, yang dirakit di memori sebelum Anda mengunduhnya, dan suaranya,
+        yang harus ditahan utuh karena membalik butuh sampel terakhir sebelum
+        bisa menulis yang pertama."""
+
+[[faq]]
+q = "Kenapa pada sebagian file lebih lambat daripada yang lain?"
+a = """
+        Karena ada dua jalan masuk. MP4 atau MOV dibaca alat ini secara langsung
+        dan didekode satu kelompok bingkai sekali jalan, secepat mesin Anda bisa.
+        Selain itu, pembalikan dilakukan dengan meminta pemutar peramban sendiri
+        satu momen klip demi satu momen, dan setiap pencarian itu membuat
+        peramban mendekode dari bingkai kunci di depannya. Halaman ini
+        mengatakan yang mana dari keduanya yang dipakai, dan alasannya, sebelum
+        Anda mulai."""
+
+[[faq]]
+q = "Bisakah saya membalik hanya sebagian klip?"
+a = """
+        Tidak di sini. Alat ini membalik keseluruhannya: klip yang keluar sama
+        persis panjangnya dengan yang masuk, dengan bingkai terakhir lebih dulu.
+        Potong dulu bagian yang Anda mau dengan
+        <a href="../potong-video/">Pemotong Video</a> &mdash; yang melakukannya
+        tanpa mengodekan ulang satu bingkai pun &mdash; lalu balik hasilnya."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang video Anda."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript dan peramban dengan pengodean video WebCodecs: Chrome, Edge, Safari 16.4 atau lebih baru, atau Firefox 133 atau lebih baru."
+description = "Balik sebuah video di peramban, suaranya termasuk. MP4, MOV, dan M4V didekode kelompok demi kelompok dari ujung dan dikodekan lagi dengan waktu bingkai aslinya; apa pun lain yang bisa diputar peramban dilangkahi secara mundur. Tidak ada yang diunggah."
+features = [
+  "Membalik video MP4, MOV, M4V, dan WebM",
+  "Sumber H.264, HEVC, AV1, dan VP9, didekode lewat WebCodecs",
+  "Membalik suaranya sampel demi sampel, atau meninggalkannya",
+  "Menjaga waktu bingkai asli, termasuk laju bingkai yang tidak rata",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan video di sini"
+hint = "atau klik untuk menelusuri &mdash; MP4, MOV, M4V, WebM, dan apa pun lain yang bisa diputar peramban ini"

--- a/locales/id/tools/split-gif.html
+++ b/locales/id/tools/split-gif.html
@@ -1,0 +1,114 @@
+<!--
+  tools/split-gif/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js reaches for, so
+  they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah GIF</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Ukuran</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Gambar</dt><dd id="src-picture">&mdash;</dd></div>
+      <div><dt>Bingkai</dt><dd id="src-frames">&mdash;</dd></div>
+      <div><dt>Diputar selama</dt><dd id="src-duration">&mdash;</dd></div>
+      <div><dt>Berulang</dt><dd id="src-loop">&mdash;</dd></div>
+    </dl>
+
+    <p id="notice" class="path-note" hidden></p>
+    <p id="error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; apa yang keluar -->
+  <section class="card" id="settings-card" hidden>
+    <h2><span class="step">2</span> Bagaimana bingkainya keluar</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="mode">Setiap PNG memuat</label>
+        <select id="mode">
+          <option value="composited" selected>Bingkai seperti tampilannya</option>
+          <option value="stored">Hanya piksel yang disimpan bingkai itu</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="background">Area transparan</label>
+        <select id="background">
+          <option value="keep" selected>Jaga tetap transparan</option>
+          <option value="flatten">Isi dengan sebuah warna&hellip;</option>
+        </select>
+        <div id="colour-row" class="inline-pair" hidden>
+          <input type="color" id="colour" value="#ffffff" aria-label="Warna untuk mengisi area transparan">
+          <span id="colour-note">Ditulis ke dalam setiap bingkai. Ia tidak bisa dikeluarkan lagi.</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="every">Simpan setiap</label>
+        <div class="inline-pair">
+          <input type="number" id="every" min="1" max="100" step="1" value="1">
+          <span id="every-note">bingkai</span>
+        </div>
+        <p class="field-note">
+          Ambil setiap bingkai kedua atau kelima alih-alih semuanya, untuk lembar
+          kontak atau rekaman yang panjang.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="timing">Daftar waktu</label>
+        <select id="timing">
+          <option value="yes" selected>Sertakan frames.txt di dalam ZIP</option>
+          <option value="no">Bingkai saja</option>
+        </select>
+        <p class="field-note">
+          Berapa lama setiap bingkai ditahan, dan di mana letaknya. Satu folder
+          berisi PNG tidak bisa membawa itu sendiri.
+        </p>
+      </div>
+    </div>
+
+    <div class="export-row">
+      <button type="button" id="download-all" class="primary">Unduh setiap bingkai sebagai ZIP</button>
+      <button type="button" id="download-selected" class="ghost" hidden>Unduh bingkai yang dipilih</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; bingkainya sendiri -->
+  <section class="card" id="frames-card" hidden>
+    <h2><span class="step">3</span> Bingkainya</h2>
+
+    <div class="toolbar">
+      <p class="count" id="frames-count" role="status" aria-live="polite"></p>
+      <div class="toolbar-actions">
+        <button type="button" id="select-all" class="ghost">Pilih semua</button>
+        <button type="button" id="select-none" class="ghost">Batalkan semua pilihan</button>
+        <button type="button" id="clear" class="ghost danger">Mulai lagi</button>
+      </div>
+    </div>
+
+    <!-- Checkboxes rather than a click-to-select grid: this is a list of files
+         somebody is about to save, and a checkbox is the one control everybody
+         already knows is safe to press. -->
+    <ul class="frames" id="frames"></ul>
+  </section>
+</main>

--- a/locales/id/tools/split-gif.toml
+++ b/locales/id/tools/split-gif.toml
@@ -1,0 +1,269 @@
+#
+# Pemisah GIF - Bahasa Indonesia.
+#
+# Overrides for tools/split-gif/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Pemisah GIF"
+heading = "Pemisah&nbsp;GIF <span class=\"h1-kw\">&mdash; setiap bingkai jadi PNG sendiri</span>"
+tagline = "Setiap bingkai keluar sebagai PNG-nya sendiri."
+
+title = "Pemisah GIF &mdash; Setiap Bingkai jadi PNG, Gratis dan Tanpa Unggah"
+description = "Pisahkan GIF bergerak menjadi bingkai-bingkainya dan simpan masing-masing sebagai PNG, gratis dan sepenuhnya di peramban Anda. Menjaga transparansi dan waktunya. Tidak ada yang diunggah, dan jalan tanpa internet."
+og_title = "Pemisah GIF &mdash; bongkar sebuah animasi, di peramban Anda"
+og_description = "Setiap bingkai sebuah GIF sebagai PNG-nya sendiri, dengan jeda dan transparansinya utuh. File dibaca di perangkat Anda sendiri dan tidak pernah diunggah."
+og_image_alt = "Pemisah GIF - setiap bingkai sebuah GIF sebagai PNG-nya sendiri"
+
+pledge = """
+    GIF-nya dibaca, didekompresi, dan digambar oleh peramban Anda sendiri, dan
+    setiap PNG dikodekan di memori mesin ini. Tidak ada server di ujung lain
+    halaman ini untuk menerima sebuah animasi, bahkan seandainya ada sesuatu di
+    sini yang menginginkannya."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu pisahkan sebuah GIF. Tidak satu pun permintaan membawa gambar,
+      bingkai, atau nama file. Atau cabut koneksi internet dan tetap pisahkan
+      satu."""
+
+read_first = """
+, <code>src/gif.js</code> untuk pembaca yang
+      mendekompresi bingkainya, dan <code>src/compose.js</code> untuk aturan yang
+      menumpuknya satu di atas yang lain &mdash; keduanya tidak punya satu baris
+      pun yang bisa menjangkau jaringan."""
+
+howto_heading = "Cara memisahkan GIF menjadi bingkai"
+
+card = """
+            Bongkar sebuah animasi: setiap bingkai sebagai PNG-nya sendiri,
+            dengan transparansi terjaga dan waktunya dicatat. GIF-nya
+            didekompresi di perangkat Anda sendiri."""
+
+[words]
+plural = "GIF"
+choose = "sebuah GIF"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[facts]]
+text = "File tetap di perangkat Anda"
+
+[[privacy]]
+title = "GIF Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya ada.
+      Dulu ini tertulis <code>connect-src 'none'</code>, yang mutlak; memasang
+      iklan memakan itu, dan mengatakannya adalah bagian dari kesepakatan."""
+
+[[privacy]]
+title = "Pembaca GIF-nya adalah dua file di repositori ini."
+body = """
+ Peramban akan memutar sebuah GIF tapi
+      tidak akan menyerahkan bagian-bagiannya, jadi formatnya dibaca di sini:
+      <code>src/gif.js</code> adalah wadah dan dekompresor LZW-nya,
+      <code>src/compose.js</code> adalah aturan pembuangan yang menentukan
+      tampilan setiap bingkai begitu bingkai sebelumnya ada di bawahnya. Tidak
+      ada yang diambil untuk membuka sebuah file, dan tidak ada mesin yang
+      diunduh saat pertama dipakai."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang animasi Anda: bukan
+      file, bukan bingkai, bukan nama, ukuran, atau jumlah. Setiap baris yang
+      membaca, mendekompresi, menggambar, atau mengodekan sebuah gambar disajikan
+      dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau file Anda. Tidak ada
+      yang terjadi kecuali Anda mengekliknya, dan yang akan Anda tuju adalah
+      situs milik orang lain."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan setiap bagian
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana: alat yang
+      mengirim animasi Anda ke tempat lain untuk dibongkar akan berhenti begitu
+      Anda mencabut koneksi."""
+
+[[howto]]
+title = "Pilih GIF-nya."
+body = """
+ Jatuhkan ke pemilih file, atau pilih sendiri.
+      Peramban membacanya langsung dari disk Anda, dan halaman ini memberi tahu
+      apa yang ditemukannya: ukurannya, jumlah bingkainya, berapa lama ia
+      diputar, dan berapa kali ia berulang."""
+
+[[howto]]
+title = "Putuskan isi setiap PNG."
+body = """
+ <strong>Bingkai seperti tampilannya</strong>
+      adalah yang diinginkan hampir semua orang: gambar utuh pada momen itu dalam
+      animasi. <strong>Hanya piksel yang disimpan bingkai itu</strong> adalah
+      tambalan yang sebenarnya dibawa file, pada ukurannya sendiri dan di
+      tempatnya sendiri, yang merupakan cara GIF tetap kecil dan bukan tampilan
+      animasinya."""
+
+[[howto]]
+title = "Putuskan apa yang terjadi pada transparansinya."
+body = """
+ PNG menjaganya, dan itu bawaan yang
+      jujur. Isi dengan sebuah warna kalau bingkainya akan pergi ke tempat yang
+      mengabaikan transparansi dan akan mengubahnya menjadi hitam."""
+
+[[howto]]
+title = "Pilih bingkai yang Anda mau."
+body = """
+ Semuanya secara bawaan. "Simpan setiap
+      bingkai kedua" menipiskan rekaman yang panjang, dan kotak centang di
+      kisinya menimpanya &mdash; penomorannya tidak pernah berubah, jadi bingkai
+      42 tetap disebut bingkai 42 sesedikit apa pun tetangganya yang Anda
+      simpan."""
+
+[[howto]]
+title = "Unduh."
+body = """
+ Satu bingkai sekali jalan dari kisinya, atau semuanya
+      sebagai satu ZIP sehingga ada satu permintaan simpan alih-alih ratusan.
+      ZIP-nya bisa membawa <code>frames.txt</code> yang mencantumkan berapa lama
+      setiap bingkai ditahan, yang merupakan satu hal yang tidak bisa dikatakan
+      sendiri oleh sebuah folder berisi PNG."""
+
+[[faq]]
+q = "Apakah GIF saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File dibaca, didekompresi, dan digambar oleh peramban Anda sendiri
+        di perangkat keras Anda sendiri, dan setiap PNG dikodekan di sini di
+        memori. Alat ini tidak punya sisi server, dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya &mdash; tidak satu pun milik situs
+        ini. Cabut koneksi jaringan dan ia tetap memisahkan GIF."""
+
+[[faq]]
+q = "Kenapa satu bingkai tampak seperti potongan kecil dari gambarnya?"
+a = """
+        Karena memang itu isi file-nya. Sebuah GIF adalah gambar pertama diikuti
+        tambalan-tambalan: setiap bingkai berikutnya hanya menyimpan persegi
+        panjang yang berubah, dan segala yang lain di layar adalah apa yang
+        ditinggalkan bingkai sebelumnya di sana. Kepala orang yang berbicara di
+        depan dinding diam karena itu menyimpan satu wajah per bingkai, bukan
+        satu gambar per bingkai, dan itulah seluruh alasan format ini tidak
+        raksasa.
+        <br><br>
+        Anda melihatnya karena "Hanya piksel yang disimpan bingkai itu" sedang
+        dipilih. Beralihlah ke "Bingkai seperti tampilannya" dan setiap PNG
+        menjadi gambar utuh sebagaimana animasinya tampak pada momen itu."""
+
+[[faq]]
+q = "Apakah transparansinya terjaga?"
+a = """
+        Ya. Transparansi GIF hanya satu bit &mdash; sebuah piksel entah dicat
+        entah tidak terlihat, tanpa apa pun di antaranya &mdash; dan PNG
+        menyimpan persis itu, jadi bingkainya keluar dengan area transparannya
+        utuh. Kalau Anda lebih suka latar padat, atur "Area transparan" untuk
+        diisi dengan sebuah warna; itu ditulis ke dalam PNG dan tidak bisa
+        dibatalkan sesudahnya."""
+
+[[faq]]
+q = "Kenapa jeda bingkainya bukan angka yang saya harapkan?"
+a = """
+        Sebuah GIF menyimpan setiap jeda dalam perseratus detik, dan peramban
+        sudah membatasi apa pun di bawah dua perseratus menjadi sepersepuluh
+        detik sejak 1990-an &mdash; aturan yang ditulis untuk bola dunia berputar
+        pada zaman itu dan tidak pernah dicabut. Jadi bingkai yang file-nya
+        berkata 0,01 dtk diputar pada 0,10 dtk di mana-mana. Alat ini menampilkan
+        jeda sebagaimana ia benar-benar diputar, dan menyebutkan apa yang
+        disimpan file di sebelahnya kalau keduanya berbeda."""
+
+[[faq]]
+q = "Bisakah saya menyusun bingkainya kembali?"
+a = """
+        Bisa, dengan <a href="../buat-gif/">Pembuat GIF</a> di situs ini atau
+        dengan apa pun lain yang menerima satu folder gambar. Untuk itulah
+        <code>frames.txt</code> di dalam ZIP: memisahkan sebuah animasi membuang
+        waktunya, karena sebuah PNG tidak punya tempat untuk mencatat berapa lama
+        ia ditahan, jadi daftar itu membawa keluar jeda dan posisi setiap
+        bingkai."""
+
+[[faq]]
+q = "Bingkainya bisa disimpan dalam format apa saja?"
+a = """
+        PNG, dan sengaja hanya PNG. Satu bingkai GIF paling banyak 256 warna
+        dengan satu bit transparansi; PNG menyimpannya persis dan tanpa
+        kehilangan, sedangkan JPEG akan membuang transparansinya, mengarang warna
+        yang tidak pernah dimiliki bingkai itu, dan biasanya menghasilkan file
+        yang <em>lebih besar</em> dari gambar datar. Kalau Anda butuh JPEG,
+        ubah PNG-nya sesudahnya dengan
+        <a href="../ubah-ukuran-gambar/">Pengubah Ukuran Gambar</a>."""
+
+[[faq]]
+q = "Adakah batas berapa banyak bingkai yang akan dibacanya?"
+a = """
+        Tidak ada batas tetap. Batas praktisnya adalah memori mesin Anda sendiri:
+        sebuah GIF mengembang menjadi kira-kira satu byte per piksel per bingkai
+        saat dibaca, jadi file kecil bisa berarti memori yang sangat besar, dan
+        halaman ini berhenti membaca alih-alih membiarkan tab-nya mati. Kalau itu
+        terjadi ia mengatakannya dan menyerahkan bingkai yang sempat
+        didapatnya."""
+
+[[faq]]
+q = "Apakah ia akan membuka GIF yang rusak?"
+a = """
+        Biasanya. Unduhan yang terpotong, penanda akhir yang hilang, dan bingkai
+        terakhir yang berhenti di tengah aliran semuanya lazim, dan pembaca yang
+        menolaknya tidak berguna justru untuk file yang paling ingin dibongkar
+        orang. Bingkai mana pun yang lengkap akan kembali, dengan catatan tentang
+        apa yang salah. Hanya file yang sama sekali bukan GIF yang ditolak
+        mentah-mentah."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, dan tidak ada masa uji coba.
+        Tidak ada tanda air pada bingkainya juga. Situs ini memasang iklan, dan
+        itulah yang membiayainya; iklan tidak diberi apa pun tentang file
+        Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim animasi Anda ke tempat lain untuk diproses
+        akan berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Pisahkan GIF bergerak menjadi bingkai-bingkainya dan simpan masing-masing sebagai PNG. File-nya didekompresi di peramban Anda, jadi tidak ada animasi yang pernah diunggah."
+features = [
+  "Setiap bingkai sebuah GIF sebagai PNG-nya sendiri, dengan transparansi terjaga",
+  "Bingkai seperti tampilannya, atau hanya piksel yang disimpan bingkai itu",
+  "Jeda, posisi, ukuran, dan cara pembuangan ditampilkan untuk setiap bingkai",
+  "Simpan setiap bingkai kedua atau kelima, atau centang yang Anda mau",
+  "Satu ZIP untuk semuanya, dengan daftar waktu opsional untuk menyusun ulang animasinya",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan GIF di sini"
+hint = "atau klik untuk menelusuri &mdash; bergerak atau diam, ukuran berapa pun"

--- a/locales/id/tools/stack-images.html
+++ b/locales/id/tools/stack-images.html
@@ -1,0 +1,241 @@
+<!--
+  tools/stack-images/body.html, in Indonesian.
+
+  Every id, class, option value, data-phrase key and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language. Only
+  the words change. The #faq-raw anchor is a link target from the note in step
+  one, so it stays as it is.
+-->
+<main>
+  <!-- Langkah 1 &mdash; bingkainya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih bingkainya</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p class="note">
+      File RAW dibuka dengan membaca JPEG berukuran penuh yang sudah ditulis
+      kameranya di dalamnya &mdash; beberapa kilobita direktori, lalu satu
+      irisan. Data sensornya tidak pernah didekodekan, jadi bingkai
+      60&nbsp;MB terbuka kira-kira secepat sebuah JPEG.
+      <a href="#faq-raw">Apa artinya bagi hasilnya</a>.
+    </p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="sort-name" class="ghost">Urutkan menurut nama</button>
+        <button type="button" id="clear-all" class="ghost danger">Buang semua</button>
+      </div>
+    </div>
+
+    <ul id="frame-list" class="frame-list"></ul>
+  </section>
+
+  <!-- Langkah 2 &mdash; cara menggabungkannya -->
+  <section class="card">
+    <h2><span class="step">2</span> Cara menggabungkannya</h2>
+
+    <div class="settings">
+      <div class="field field-wide">
+        <label for="mode">Metode penumpukan</label>
+        <select id="mode">
+          <option value="mean" selected>Rata-rata &mdash; kurangi derau</option>
+          <option value="median">Median &mdash; buang orang dan mobil yang lewat</option>
+          <option value="sigma">Sigma clipping &mdash; keduanya sekaligus</option>
+          <option value="max">Terangkan &mdash; jejak bintang, kembang api, lukisan cahaya</option>
+          <option value="min">Gelapkan &mdash; buang apa pun yang terang yang bergerak</option>
+          <option value="sum">Tambahkan &mdash; tiru satu pencahayaan panjang</option>
+          <option value="focus">Penumpukan fokus &mdash; simpan apa pun yang tajam</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="align">Sejajarkan bingkainya</label>
+        <select id="align">
+          <option value="translate" selected>Ya &mdash; geser saja</option>
+          <option value="similarity">Ya &mdash; geser, rotasi, dan skala</option>
+          <option value="none">Tidak &mdash; pakai apa adanya</option>
+        </select>
+        <p class="field-note" id="align-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="scale">Resolusi kerja</label>
+        <select id="scale">
+          <option value="full" selected>Ukuran penuh</option>
+          <option value="half">Setengah &mdash; seperempat memorinya</option>
+          <option value="quarter">Seperempat &mdash; seperenam belas</option>
+        </select>
+        <p class="field-note" id="scale-note"></p>
+      </div>
+
+      <div class="field" id="kappa-field" hidden>
+        <label for="kappa">Buang di luar</label>
+        <div class="inline-pair">
+          <input type="range" id="kappa" min="0.5" max="4" step="0.1" value="2">
+          <output id="kappa-value" for="kappa">2.0&sigma;</output>
+        </div>
+        <p class="field-note">
+          Lebih rendah menolak lebih banyak, dan menolak detail yang sungguhan
+          bersamanya. Dua simpangan baku adalah titik mulai yang biasa.
+        </p>
+      </div>
+
+      <div class="field" id="radius-field" hidden>
+        <label for="radius">Ketajaman diukur di rentang</label>
+        <div class="inline-pair">
+          <input type="range" id="radius" min="1" max="12" step="1" value="3">
+          <output id="radius-value" for="radius">3 px</output>
+        </div>
+        <p class="field-note">
+          Lebih besar mengambil wilayah utuh dari satu bingkai; lebih kecil
+          mengikuti detail halus dan bisa mengacak latar yang mulus antar
+          bingkai.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="gain">Pencahayaan</label>
+        <div class="inline-pair">
+          <input type="range" id="gain" min="0.1" max="4" step="0.05" value="1">
+          <output id="gain-value" for="gain">1.00&times;</output>
+        </div>
+        <p class="field-note" id="gain-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="format">Simpan sebagai</label>
+        <select id="format">
+          <option value="png" selected>PNG &mdash; tanpa kehilangan</option>
+          <option value="jpeg">JPEG &mdash; file lebih kecil</option>
+        </select>
+        <div id="quality-row" class="inline-pair" hidden>
+          <input type="range" id="quality" min="0.5" max="1" step="0.01" value="0.92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+    </div>
+
+    <!--
+      What the run will cost, worked out before it starts. Every figure here is
+      an answer from src/plan.js rather than an estimate, which is why they are
+      shown at all: a median of twenty large frames is a genuinely different
+      proposition from an average of them, and that should be visible before
+      the button is pressed rather than afterwards.
+    -->
+    <dl class="plan" id="plan" hidden>
+      <div><dt>Hasil</dt><dd id="plan-output">&mdash;</dd></div>
+      <div><dt>Memori kerja</dt><dd id="plan-memory">&mdash;</dd></div>
+      <div><dt>Bingkai didekodekan</dt><dd id="plan-decodes">&mdash;</dd></div>
+      <div><dt>Dibaca dari disk</dt><dd id="plan-read">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-warning" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 3 &mdash; jalankan -->
+  <section class="card">
+    <h2><span class="step">3</span> Tumpuk mereka</h2>
+
+    <div class="export-row">
+      <button type="button" id="run" class="primary" disabled>Tumpuk gambarnya</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame">
+        <img id="result-image" alt="Hasil tumpukannya">
+      </div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <p id="result-moves" class="field-note"></p>
+        <a id="download" class="primary as-button" download>Unduh gambarnya</a>
+      </div>
+    </div>
+  </section>
+
+  <!--
+    Every sentence this tool's JavaScript puts on screen, kept out of the
+    JavaScript so that a translator can reach it. src/ is copied byte for byte
+    into all eleven languages, so a string written in a module is English at ten
+    of them. See shared/js/phrases.js.
+
+    A {name} is filled in by the caller. Nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="count.one">1 bingkai</span>
+    <span data-phrase="count.many">{count} bingkai</span>
+    <span data-phrase="count.none">Belum ada bingkai</span>
+
+    <span data-phrase="frame.reference">Rujukan</span>
+    <span data-phrase="frame.make-reference">Pakai sebagai rujukan</span>
+    <span data-phrase="frame.remove">Buang</span>
+    <span data-phrase="frame.size">{width} &times; {height}</span>
+    <span data-phrase="frame.raw">RAW &mdash; pratinjau {width} &times; {height} milik kameranya sendiri</span>
+    <span data-phrase="frame.raw-camera">{camera} &mdash; pratinjau {width} &times; {height}</span>
+    <span data-phrase="frame.raw-unreadable">Tidak ada pratinjau yang bisa ditemukan di dalam file RAW ini</span>
+    <span data-phrase="frame.read">{read} dibaca dari {total}</span>
+
+    <span data-phrase="mode.mean">Merata-ratakan setiap bingkai. Derau acak sama seringnya tinggi dan rendah, jadi merata-ratakan {count} bingkai memangkasnya kira-kira {factor} kali. Yang dipakai pada kumpulan yang stabil, dan yang akan dirusak satu burung yang lewat.</span>
+    <span data-phrase="mode.median">Mengambil nilai tengah setiap piksel. Apa pun yang hanya ada di sebagian bingkainya &mdash; seorang turis, sebuah mobil, sebuah pesawat &mdash; lenyap. Ia satu-satunya metode yang harus menahan setiap bingkai sekaligus, dan itulah sebabnya ia bisa berpita di bawah.</span>
+    <span data-phrase="mode.sigma">Mempelajari apa biasanya setiap piksel, lalu merata-ratakan hanya nilai yang sepakat. Hasil mediannya dengan pengurangan derau rata-ratanya. Ia membaca bingkainya dua kali.</span>
+    <span data-phrase="mode.max">Menyimpan nilai paling terang yang pernah dimiliki setiap piksel. Inilah yang mengubah runtutan pencahayaan pendek menjadi jejak bintang, dan yang merakit sebuah kembang api dari bingkainya sendiri.</span>
+    <span data-phrase="mode.min">Menyimpan nilai paling gelap yang pernah dimiliki setiap piksel. Sebuah piksel hanya tetap terang kalau ia terang di setiap bingkainya, jadi pantulan, lampu depan, dan tetes hujan yang tercahayai ikut hilang.</span>
+    <span data-phrase="mode.sum">Menjumlahkan bingkainya tanpa membagi: apa yang akan dikumpulkan satu pencahayaan {count} kali lebih panjang. Ia terpotong di puncaknya, persis seperti pencahayaan itu. Pakai penggeser pencahayaannya untuk mengembalikannya.</span>
+    <span data-phrase="mode.focus">Mengambil setiap bagian gambarnya dari bingkai mana pun yang bagian itu terfokus di dalamnya. Foto sebuah subjek kecil di sepanjang cincin fokus dan ini merakit bagian yang tajamnya.</span>
+
+    <span data-phrase="align.translate">Menemukan seberapa jauh setiap bingkai bergeser lalu memindahkannya kembali, sampai sepersekian piksel. Membetulkan goyangan tangan dan pergeseran tripod. Ia tidak bisa membetulkan rotasi.</span>
+    <span data-phrase="align.similarity">Juga menemukan rotasi dan skalanya. Berbiaya satu pengukuran lagi per bingkai dan sama sekali tidak berbiaya apa pun ketika bingkainya ternyata lurus. Rotasi hanya pernah dipulihkan di dalam setengah putaran.</span>
+    <span data-phrase="align.none">Menumpuk bingkainya persis seperti yang diberikan. Benar untuk tripod terkunci atau runtutan intervalometer, dan keliru untuk apa pun yang dipegang tangan.</span>
+
+    <span data-phrase="scale.note">Setiap bingkai didekodekan pada ukuran ini oleh dekoder milik peramban sendiri, jadi setelan yang lebih kecil berarti pekerjaan yang lebih sedikit sekaligus memori yang lebih sedikit.</span>
+    <span data-phrase="gain.note">Dikalikan ke dalam hasilnya di ujung sekali, setelah hitungannya dan sebelum pembulatannya.</span>
+    <span data-phrase="gain.sum-note">Menjumlahkan {count} bingkai hampir pasti akan terpotong di puncaknya. Turunkan ini ke sekitar {suggested} untuk melihat apa yang terkumpul.</span>
+
+    <span data-phrase="plan.output">{width} &times; {height}</span>
+    <span data-phrase="plan.memory">sekitar {mb} MB</span>
+    <span data-phrase="plan.decodes.simple">{count}, satu untuk setiap bingkai</span>
+    <span data-phrase="plan.decodes.passes">{count} &mdash; setiap bingkai, {passes} kali</span>
+    <span data-phrase="plan.decodes.banded">{count} &mdash; setiap bingkai, sekali untuk masing-masing {bands} pita</span>
+    <span data-phrase="plan.read">{read} dari {total} di disk</span>
+    <span data-phrase="plan.banded">Ini tidak akan muat di memori dalam satu potong, jadi gambarnya dipotong menjadi {bands} pita dan bingkainya dibaca lagi untuk masing-masingnya. Memilih {suggested} sebagai gantinya akan menjadikannya satu jalan.</span>
+    <span data-phrase="plan.banded-anyway">Ini tidak akan muat di memori dalam satu potong, jadi gambarnya dipotong menjadi {bands} pita dan bingkainya dibaca lagi untuk masing-masingnya. Lebih sedikit bingkai, atau resolusi kerja yang lebih kecil, akan menjadikannya satu jalan.</span>
+
+    <span data-phrase="progress.open">Melihat ke dalam {name}&hellip;</span>
+    <span data-phrase="progress.survey">Membaca {name}&hellip;</span>
+    <span data-phrase="progress.measure">Mengukur seberapa jauh {name} bergerak&hellip;</span>
+    <span data-phrase="progress.stack">Menumpuk &mdash; {done} dari {total} bingkai terbaca</span>
+    <span data-phrase="progress.stack-banded">Menumpuk &mdash; pita {band} dari {bands}, {done} dari {total} bingkai terbaca</span>
+    <span data-phrase="progress.encode">Menulis gambarnya&hellip;</span>
+
+    <span data-phrase="result.info">{width} &times; {height}, {size} &mdash; {count} bingkai digabungkan dalam {seconds} detik</span>
+    <span data-phrase="result.moves">Setiap bingkai diukur lalu dipindahkan ke tempatnya.</span>
+    <span data-phrase="result.moves-some">{count} dari {total} bingkai tidak bisa diukur dengan yakin dan dibiarkan di tempatnya.</span>
+    <span data-phrase="result.moves-none">Bingkainya ditumpuk persis seperti yang diberikan.</span>
+    <span data-phrase="result.moves-clamped">{count} bingkai melaporkan rotasi yang terlalu besar untuk sebuah burst, dan dibetulkan dengan pergeseran saja.</span>
+    <span data-phrase="result.cropped">Memindahkan mereka saling menjauh meninggalkan tepi yang tidak dicapai setiap bingkainya, dan tepi itu sudah dirapikan.</span>
+
+    <span data-phrase="error.no.files">Tambahkan setidaknya satu gambar dulu.</span>
+    <span data-phrase="error.no.size">Tidak satu pun file ini bisa dibuka sebagai sebuah gambar.</span>
+    <span data-phrase="error.one.frame">Penumpukan butuh setidaknya dua bingkai.</span>
+    <span data-phrase="error.unknown">Ada yang tidak beres saat menumpuk. Kalau salah satu file ini tidak biasa, coba ia sendirian.</span>
+    <span data-phrase="error.memory">Peramban kehabisan memori. Coba resolusi kerja yang lebih kecil, atau lebih sedikit bingkai.</span>
+    <span data-phrase="error.unreadable">{name} tidak bisa dibuka sebagai sebuah gambar dan ditinggalkan.</span>
+    <span data-phrase="error.busy">Tunggu tumpukan ini selesai sebelum menambahkan bingkai lagi, atau batalkan.</span>
+  </div>
+</main>

--- a/locales/id/tools/stack-images.toml
+++ b/locales/id/tools/stack-images.toml
@@ -1,0 +1,352 @@
+#
+# Penumpuk Gambar - Bahasa Indonesia.
+#
+# Overrides for tools/stack-images/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama format RAW (CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2) dan nama pustaka
+# (LibRaw, dcraw) tetap seperti adanya: itulah yang tertulis di kamera dan di
+# folder orang. "Worker" juga tetap, karena itu nama sebuah hal di peramban dan
+# bukan sebutan umum untuk pekerja.
+#
+
+name = "Penumpuk Gambar"
+heading = "Penumpuk&nbsp;Gambar <span class=\"h1-kw\">&mdash; gabungkan sebuah burst, file RAW termasuk</span>"
+tagline = "Dua puluh bingkai menjadi satu, tanpa dua puluh unggahan dan tanpa pengubah RAW."
+
+title = "Penumpuk Gambar &mdash; Rata-rata, Median &amp; Tumpuk Fokus di Peramban Anda"
+description = "Gabungkan sebuah burst foto menjadi satu: rata-ratakan untuk membunuh derau, ambil mediannya untuk membuang orang dari sebuah pemandangan, terangkan untuk jejak bintang, atau tumpuk fokus sebuah bidikan makro. Membaca CR2, NEF, ARW, DNG, RAF, dan CR3 dengan menarik keluar pratinjau milik kameranya sendiri. Berjalan sepenuhnya di peramban Anda."
+og_title = "Tumpuk sebuah burst foto, file RAW termasuk"
+og_description = "Rata-rata, median, sigma-clip, terangkan, gelapkan, tambahkan, atau tumpuk fokus &mdash; dengan bingkainya disejajarkan lebih dulu. File RAW dibuka dengan membaca pratinjau yang sudah ditulis kameranya, jadi bingkai 60 MB terbuka secepat sebuah JPEG. Tidak ada yang diunggah."
+og_image_alt = "Penumpuk Gambar - beberapa bingkai digabungkan menjadi satu, di peramban"
+
+pledge = """
+    Setiap bingkai dibuka, didekodekan, disejajarkan, digabungkan, dan ditulis
+    oleh peramban Anda sendiri, di mesin Anda sendiri. Setumpuk dua puluh file
+    RAW 60&nbsp;MB adalah sekitar satu gigabita foto, dan tidak satu byte pun
+    darinya berpindah: alatnya tidak punya fitur jaringan dalam bentuk apa pun,
+    dan file-nya dibaca langsung dari disk Anda oleh sebuah worker yang tidak
+    punya tujuan untuk mengirim apa pun."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu tumpuk satu folder file RAW. Tidak satu pun permintaan membawa sebuah
+      foto, gambar mini, nama file, atau model kamera. Atau cabut koneksi
+      internet lalu tetap tumpuk mereka &mdash; tidak ada yang berubah tentang
+      alatnya."""
+
+read_first = """
+, <code>src/raw.js</code> untuk cara sebuah file
+      RAW dibuka dengan membaca kilobita alih-alih megabita,
+      <code>src/stack.js</code> untuk hitungan setiap metodenya, dan
+      <code>src/plan.js</code> untuk asal angka memori dan pendekodean yang
+      ditampilkan di halamannya &mdash; mereka jawaban file itu, bukan
+      perkiraan."""
+
+howto_heading = "Cara menumpuk sekumpulan foto di peramban Anda"
+
+card = """
+            Gabungkan sebuah burst menjadi satu gambar: rata-ratakan deraunya
+            hingga hilang, ambil mediannya untuk kehilangan orang yang lewat,
+            atau terangkan untuk jejak bintang. Membaca file RAW tanpa sebuah
+            pengubah."""
+
+[words]
+plural = "foto"
+choose = "beberapa foto"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Membaca RAW"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Foto Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy
+      menyebut satu per satu setiap alamat yang boleh dihubungi halaman ini, dan
+      tidak satu pun milik situs ini. Tidak ada titik akhir di sini tempat file
+      Anda bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada &mdash; tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, tidak ada <code>sendBeacon</code>, di
+      <code>src/</code> maupun di workernya."""
+
+[[privacy]]
+title = "File RAW-nya dibaca, bukan diunggah &mdash; dan nyaris tidak dibaca."
+body = """
+ Sebuah file RAW kamera
+      sudah memuat sebuah JPEG berukuran penuh yang digambar kameranya ketika ia
+      mengambil bidikannya. Alat ini menemukannya dengan menyusuri beberapa entri
+      direktori lalu meminta satu irisan, dan pada file 60&nbsp;MB itu biasanya
+      di bawah seratus kilobita. Halamannya menunjukkan angka itu kepada Anda
+      dibandingkan dengan ukuran file Anda sambil Anda bekerja. Data sensornya
+      sama sekali tidak pernah dibaca."""
+
+[[privacy]]
+title = "Pekerjaannya terjadi di sebuah Worker di mesin ini, bukan di sebuah server."
+body = """
+ Inilah
+      satu-satunya alat di sini yang memakai satu, karena penumpukan adalah
+      hitungan bermenit-menit alih-alih berdetik-detik dan halaman yang membeku
+      tidak bisa menampilkan kemajuan atau dibatalkan. Sebuah Worker adalah utas
+      kedua di peramban yang sama ini &mdash; lihat <code>src/worker.js</code>.
+      Ia diserahi file-nya sendiri, dan itu gratis, karena sebuah pegangan file
+      bukanlah byte-nya; dan ia punya Content-Security-Policy yang persis sama
+      dengan halamannya, yang artinya tidak punya tujuan untuk mengirimnya."""
+
+[[privacy]]
+title = "Tidak ada apa pun tentang kumpulannya yang dilaporkan ke mana pun."
+body = """
+ Berapa bingkai yang
+      Anda tumpuk, kamera apa yang menulisnya, seberapa jauh masing-masing sudah
+      bergerak, metode mana yang Anda pilih, dan berapa lama waktunya ditahan di
+      memori halaman ini sampai Anda menutupnya. Tidak ada peristiwa analitik
+      khusus di repositori ini yang membawa satu pun darinya, dan satu pertanyaan
+      yang diajukan situs ini setelah sebuah unduhan mengirim sebuah jempol ke
+      atas atau ke bawah dan nama alatnya, tidak lebih."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Workernya dan setiap modul yang dimuatnya disinggahkan service worker
+      milik halaman ini sendiri, jadi salinan yang terpasang menumpuk file RAW
+      dengan jaringan tercabut."""
+
+[[howto]]
+title = "Pilih bingkainya."
+body = """
+ Sebuah burst, sekumpulan bracket, sebuah
+      runtutan intervalometer, atau satu folder file RAW. Masing-masing dibuka
+      begitu ia tiba dan barisnya memberi tahu Anda apa yang keluar darinya
+      &mdash; untuk file RAW, kameranya, ukuran pratinjau yang ditemukan di
+      dalamnya, dan betapa sedikit file-nya yang harus dibaca untuk
+      menemukannya."""
+
+[[howto]]
+title = "Pilih metode yang cocok dengan apa yang ingin Anda hilangkan."
+body = """
+ Derau:
+      rata-rata, atau sigma-clip kalau ada yang bergerak. Orang, mobil, atau
+      pesawat yang lewat: median. Langit gelap yang ingin Anda ubah menjadi jejak
+      bintang: terangkan. Bidikan makro yang diambil di sepanjang cincin fokus:
+      penumpukan fokus. Catatan di bawah menunya mengatakan apa yang dilakukan
+      masing-masing pada jumlah bingkai Anda yang tertentu itu."""
+
+[[howto]]
+title = "Putuskan apakah bingkainya perlu disejajarkan."
+body = """
+ Dipegang tangan: ya,
+      geser saja. Dipegang tangan dan Anda juga berputar: geser, rotasi, dan
+      skala. Tripod terkunci atau sebuah intervalometer: tidak, dan ia akan lebih
+      cepat. Setiap bingkai diukur terhadap yang pertama di daftarnya, dan itulah
+      sebabnya bingkai mana pun bisa dinaikkan menjadi yang pertama itu."""
+
+[[howto]]
+title = "Baca keempat angkanya, lalu tekan tombolnya."
+body = """
+ Sebelum apa pun
+      berjalan, halamannya mengatakan seberapa besar hasilnya nanti, kira-kira
+      berapa banyak memori yang akan dipakainya, berapa kali bingkainya akan
+      didekodekan, dan berapa banyak file Anda yang dibaca. Kalau kumpulannya
+      tidak akan muat di memori dalam satu potong, ia mengatakannya, dan
+      mengatakan resolusi kerja mana yang akan membereskannya."""
+
+[[faq]]
+q = "Apakah foto saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Setiap bingkai dibuka, didekodekan, disejajarkan, ditumpuk, dan
+        ditulis oleh peramban Anda sendiri di perangkat keras Anda sendiri. Alat
+        ini tidak punya fitur jaringan dalam bentuk apa pun &mdash; ia tidak
+        pernah mengambil apa pun dan tidak pernah mengirim apa pun &mdash; dan
+        <code>Content-Security-Policy</code> halaman ini menyebut satu per satu
+        setiap alamat yang boleh dihubunginya, dan tidak satu pun milik situs
+        ini. Muat halamannya sekali, cabut koneksi internet, dan ia tetap
+        bekerja. Itu lebih penting di sini daripada di kebanyakan alat semata
+        karena volumenya: setumpuk dua puluh bingkai RAW adalah sekitar satu
+        gigabita, dan mengunggah satu gigabita foto untuk diambil rata-ratanya
+        adalah hal yang justru ingin dihindari alat ini."""
+
+[[faq]]
+q = "Format RAW mana saja yang bisa dibacanya, dan bagaimana?"
+a = """
+        <span id="faq-raw"></span>CR2, CR3, NEF, NRW, ARW, SR2, SRF, DNG, ORF,
+        RAF, RW2, PEF, SRW, 3FR, IIQ, DCR, KDC, MRW, MEF, RWL, dan beberapa lagi
+        &mdash; dan itu sebagian besar dari apa yang ditulis kamera. Yang
+        dibacanya dari mereka adalah pratinjau JPEG berukuran penuh yang digambar
+        kameranya sendiri ketika ia mengambil bidikannya: gambar di punggung
+        kameranya, dan gambar yang digambar sistem operasi Anda sebagai gambar
+        mininya. Ia ditemukan dengan menyusuri struktur direktori file-nya, yang
+        berbiaya beberapa pembacaan beberapa kilobita masing-masing, lalu
+        mengambil satu irisan. <strong>Ia bukan hasil demosaik data
+        sensornya.</strong> Hasilnya membawa keseimbangan putih dan gaya gambar
+        kameranya pada delapan bit per kanal, alih-alih dua belas atau empat
+        belas bit data sensor linear yang akan diberikan sebuah pengubah RAW
+        kepada Anda."""
+
+[[faq]]
+q = "Kalau begitu kenapa tidak mendekodekan data sensornya dengan benar?"
+a = """
+        Karena itu berarti menyertakan LibRaw atau dcraw &mdash; sebuah mesin
+        kedua berukuran puluhan megabita, untuk satu keluarga format, yang
+        sebagian besarnya adalah skema kompresi per pabrikan. Pertukaran itu
+        diperdebatkan sampai tuntas di
+        <code>docs/what-can-be-built-here.md</code> di sumber situs ini, tempat
+        RAW kamera sudah ada di daftar yang dikesampingkan sejak sebelum alat ini
+        ada. Yang berubah bukan jawaban atas pertanyaan itu melainkan penemuan
+        bahwa penumpukan tidak membutuhkannya: pratinjaunya beresolusi penuh,
+        mereka toh yang akan diberikan kameranya kepada Anda sebagai sebuah JPEG,
+        dan membacanya kira-kira seratus kali lebih cepat daripada mendemosaik.
+        Kalau Anda menginginkan data sensornya, kembangkan bingkainya di sebuah
+        pengubah RAW lebih dulu lalu tumpuk TIFF atau JPEG yang dihasilkannya
+        &mdash; alat ini menerima itu juga."""
+
+[[faq]]
+q = "Berapa banyak bingkai yang bisa ditanganinya, dan seberapa besar?"
+a = """
+        Enam dari ketujuh metodenya mengalir: mereka menahan satu akumulator lalu
+        membaca setiap bingkai tepat sekali, jadi seratus bingkai berbiaya memori
+        yang sama dengan dua dan satu-satunya yang bertambah adalah waktunya.
+        Mediannya adalah pengecualiannya, karena nilai tengah sebuah kumpulan
+        tidak bisa diketahui sampai Anda punya seluruhnya, jadi ia menahan setiap
+        bingkai sekaligus &mdash; dua puluh bingkai 24 megapiksel adalah sekitar
+        1,4&nbsp;GB, dan tidak ada peramban yang akan memberikannya kepada Anda.
+        Ketika itu terjadi, gambarnya dipotong menjadi pita mendatar lalu
+        ditumpuk sepita demi sepita, dan itu berbiaya membaca ulang bingkainya
+        untuk setiap pitanya. Halamannya memperhitungkan semua ini sebelum Anda
+        menekan tombolnya lalu menunjukkan angkanya kepada Anda, jadi jalan yang
+        lambat tidak pernah menjadi kejutan."""
+
+[[faq]]
+q = "Apa sebenarnya yang dilakukan penyejajaran bingkainya?"
+a = """
+        Ia menemukan seberapa jauh setiap bingkai bergerak relatif terhadap yang
+        pertama lalu memindahkannya kembali, sampai sepersekian piksel. Metodenya
+        adalah korelasi fase: pergeseran antara dua gambar muncul sebagai
+        perbedaan fase antara spektrumnya, jadi satu transformasi Fourier
+        masing-masing menemukan pergeseran dua ratus piksel semurah pergeseran
+        dua piksel. Setelan yang kedua juga memulihkan rotasi dan skalanya,
+        dengan trik yang sama yang diterapkan pada spektrumnya dalam koordinat
+        log-polar. Semuanya bersifat menyeluruh &mdash; satu pergeseran, satu
+        sudut, satu skala untuk seluruh bingkainya &mdash; jadi ia membetulkan
+        kamera yang bergerak dan tidak bisa membetulkan subjek yang bergerak,
+        atau foto yang diambil dari satu langkah ke kiri. Satu akibat yang
+        kelihatan: bingkai yang dipindahkan dua puluh piksel ke kiri tidak lagi
+        mencapai tepi kanannya, jadi hasilnya dirapikan ke bagian yang dicakup
+        setiap bingkainya. Itulah sebabnya tumpukan yang disejajarkan kembali
+        sedikit lebih kecil daripada bingkai yang masuk ke dalamnya, dan itu
+        satu-satunya alternatif dari sebuah batas gelap yang terbuat dari bingkai
+        yang tidak ada di sana."""
+
+[[faq]]
+q = "Metode mana yang sebaiknya saya pakai?"
+a = """
+        <strong>Rata-rata</strong> untuk derau, pada kumpulan yang tidak ada yang
+        bergerak: ia memangkas derau acak kira-kira sebesar akar jumlah
+        bingkainya. <strong>Median</strong> untuk membuang hal-hal yang hanya ada
+        sebagian waktu &mdash; pemakaian klasiknya adalah memotret sebuah alun-alun
+        yang ramai selusin kali lalu mendapatkannya kosong. <strong>Sigma
+        clipping</strong> ketika Anda ingin keduanya: ia mempelajari apa biasanya
+        setiap piksel lalu merata-ratakan hanya nilai yang sepakat, jadi ia punya
+        kekebalan median terhadap mobil yang lewat dan pengurangan derau
+        rata-rata. <strong>Terangkan</strong> untuk jejak bintang, kembang api,
+        dan lukisan cahaya. <strong>Gelapkan</strong> untuk membuang apa pun yang
+        terang yang bergerak. <strong>Tambahkan</strong> untuk meniru satu
+        pencahayaan panjang. <strong>Penumpukan fokus</strong> untuk bidikan
+        makro yang diambil di sepanjang cincin fokus."""
+
+[[faq]]
+q = "Kenapa hasil saya delapan bit padahal file RAW saya empat belas?"
+a = """
+        Karena yang ditumpuk adalah pratinjau milik kameranya sendiri, yang berupa
+        sebuah JPEG. Layak dikatakan bahwa penumpukan memulihkan sebagian dari
+        yang dikorbankan itu: merata-ratakan enam belas bingkai delapan bit
+        memberi hasil dengan gradasi yang sungguh lebih halus daripada yang
+        dimiliki satu pun di antaranya, karena derau yang membuat pembulatan
+        setiap bingkai berbeda justru itulah yang membuat rata-ratanya mendarat
+        di antara tingkatannya. Hitungannya di sini dikerjakan dalam bilangan
+        titik-mengambang lalu dibulatkan sekali di ujungnya, jadi tidak ada
+        satu pun dari itu yang dibuang di tengah jalan. Ia tetap tidak sama
+        dengan menumpuk data sensor linear, dan alat ini tidak berpura-pura
+        sebaliknya."""
+
+[[faq]]
+q = "Bisakah saya menumpuk bingkai yang berbeda ukuran, atau dari kamera berbeda?"
+a = """
+        Bisa, meski itu biasanya sebuah kekeliruan dan layak diperiksa bahwa Anda
+        memang memaksudkannya. Hasilnya seukuran bingkai terbesarnya, dan setiap
+        bingkai lain diskalakan agar muat lalu diletakkan di tengahnya. Mencampur
+        kamera juga mencampur penggambaran warnanya, jadi rata-rata keduanya
+        adalah rata-rata dua tafsir berbeda atas cahaya yang sama. Tempat ia
+        memang membantu adalah sebuah kumpulan yang dibidik pada dua resolusi,
+        atau sebuah file RAW dan sebuah JPEG dari bingkai yang sama."""
+
+[[faq]]
+q = "Ia bilang jalannya akan berpita. Apa maksudnya?"
+a = """
+        Bahwa memori kerja yang dibutuhkan metodenya lebih dari yang bersedia
+        dialokasikan alatnya sekaligus, jadi gambarnya akan dipotong menjadi
+        jalur-jalur mendatar lalu ditumpuk sejalur demi sejalur. Ia tetap
+        menghasilkan hasil yang persis sama; ia hanya membaca bingkainya lagi
+        untuk setiap jalurnya, jadi ia memakan waktu lebih lama, dan halamannya
+        memberi tahu Anda berapa banyak pendekodean itu nanti. Menurunkan resolusi
+        kerjanya satu langkah memangkas memorinya menjadi seperempat, dan itu
+        hampir selalu mengubah jalan yang berpita menjadi satu jalan tunggal
+        &mdash; catatannya mengatakan setelan mana yang akan melakukannya."""
+
+[[faq]]
+q = "Kenapa alat ini memakai sebuah Worker padahal tidak satu pun yang lain?"
+a = """
+        Karena ia satu-satunya yang pekerjaannya diukur dalam menit. Setiap alat
+        lain di sini melakukan sesuatu yang memakan satu dua detik, dan di sana
+        memindahkan pekerjaannya keluar dari utas utamanya akan menjadi upacara.
+        Menumpuk dua puluh bingkai besar adalah hitungan padat atas ratusan
+        megabita, dan di utas utama itu berarti halaman yang membeku: tidak ada
+        bilah kemajuan yang bergerak, sebuah tombol Batalkan yang tidak menjawab,
+        dan akhirnya sebuah peramban yang menawarkan membunuh tabnya. Workernya
+        adalah utas kedua di peramban yang sama ini, menjalankan sebuah file dari
+        folder yang sama ini, di bawah kebijakan yang sama ini. Ia bukan sebuah
+        server dan ia bukan sebuah fitur jaringan."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis; tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Tidak ada batas berapa banyak bingkai yang Anda
+        tumpuk atau seberapa besar mereka juga, karena tidak ada server yang
+        membayarnya &mdash; pekerjaannya terjadi di mesin Anda sendiri dan
+        satu-satunya langit-langitnya adalah memori Anda sendiri. Situs ini
+        memasang iklan, dan itulah yang membiayainya; iklan tidak diberi apa pun
+        tentang foto Anda."""
+
+[schema]
+description = "Tumpuk sebuah burst foto di peramban: rata-rata, median, rata-rata dengan sigma-clip, terangkan, gelapkan, tambahkan, atau tumpuk fokus, dengan bingkainya disejajarkan lebih dulu lewat korelasi fase. Membaca file RAW kamera dengan menarik keluar pratinjau berukuran penuh yang disematkan kameranya, jadi tidak dibutuhkan pengubah RAW. Tidak ada yang diunggah."
+features = [
+  "Tujuh metode penumpukan: rata-rata, median, rata-rata dengan sigma-clip, terangkan, gelapkan, tambahkan, dan penumpukan fokus",
+  "Membaca CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2, dan lainnya dengan menarik keluar pratinjau berukuran penuh milik kameranya sendiri",
+  "Membuka file RAW 60 MB dengan membaca sekitar seratus kilobita darinya",
+  "Penyejajaran otomatis: geser saja, atau geser dengan rotasi dan skala, atau tidak sama sekali",
+  "Penyejajaran sub-piksel lewat korelasi fase, bukan lewat pencarian pergeseran",
+  "Enam dari ketujuh metodenya menahan satu akumulator, jadi seratus bingkai berbiaya memori dua bingkai",
+  "Biaya memori dan pendekodeannya diperhitungkan lalu ditampilkan sebelum jalannya dimulai",
+  "Pekerjaannya berjalan di sebuah Worker, jadi kemajuannya bergerak dan Batalkan menjawab",
+  "Keluar sebagai PNG atau JPEG; jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan bingkainya di sini"
+hint = "atau klik untuk menelusuri &mdash; JPEG, PNG, WebP, TIFF, dan RAW kamera"

--- a/locales/id/tools/svg-to-image.html
+++ b/locales/id/tools/svg-to-image.html
@@ -1,0 +1,217 @@
+<!--
+  tools/svg-to-image/body.html, in Indonesian.
+
+  Every id, class, data-* and option value below is what src/main.js reaches
+  for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file-nya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih file SVG-nya</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="clear-all" class="ghost danger">Keluarkan semua dari daftar</button>
+      </div>
+    </div>
+
+    <ul id="file-list" class="file-list"></ul>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; ukurannya -->
+  <section class="card" id="size-card">
+    <h2><span class="step">2</span> Sebutkan seberapa besar</h2>
+
+    <p class="card-lede">
+      Inilah satu pertanyaan yang tidak bisa dijawab sebuah vektor untuk Anda.
+      Sebuah SVG tidak punya piksel di dalamnya &mdash; ia punya instruksi untuk
+      menggambar, dan ia akan mengikutinya pada ukuran berapa pun yang Anda
+      sebutkan. Angka di bawah bukan batas yang sedang Anda dorong, seperti
+      halnya pada sebuah foto; 4000 piksel dari ikon 24&nbsp;piksel persis
+      setajam 24-nya.
+    </p>
+
+    <div class="option-row">
+      <label for="size-mode">Tetapkan ukurannya lewat</label>
+      <select id="size-mode">
+        <option value="scale" selected>Kelipatan dari ukuran yang diminta file-nya</option>
+        <option value="width">Lebar dalam piksel</option>
+        <option value="height">Tinggi dalam piksel</option>
+        <option value="longest">Sisi terpanjang</option>
+        <option value="box">Sebuah kotak, dengan kedua sisinya diberikan</option>
+      </select>
+    </div>
+
+    <div class="size-fields" id="scale-fields">
+      <div class="numbers">
+        <label>Kalikan dengan<input type="number" id="size-scale" min="0.01" max="200" step="0.5" value="4"></label>
+      </div>
+      <div class="presets" id="scale-presets" role="group" aria-label="Kelipatan yang lazim">
+        <button type="button" class="ghost" data-scale="1">1&times;</button>
+        <button type="button" class="ghost" data-scale="2">2&times;</button>
+        <button type="button" class="ghost" data-scale="4">4&times;</button>
+        <button type="button" class="ghost" data-scale="8">8&times;</button>
+        <button type="button" class="ghost" data-scale="16">16&times;</button>
+      </div>
+      <p class="hint-line">
+        Setiap file di daftar dikalikan dari ukurannya sendiri, jadi sekumpulan
+        ikon yang digambar pada ukuran berbeda tetap sebanding satu sama lain.
+      </p>
+    </div>
+
+    <div class="size-fields" id="width-fields" hidden>
+      <div class="numbers">
+        <label>Lebar<input type="number" id="size-width" min="1" step="1" value="1024"></label>
+      </div>
+      <div class="presets" id="width-presets" role="group" aria-label="Lebar yang lazim">
+        <button type="button" class="ghost" data-width="256">256</button>
+        <button type="button" class="ghost" data-width="512">512</button>
+        <button type="button" class="ghost" data-width="1024">1024</button>
+        <button type="button" class="ghost" data-width="2048">2048</button>
+      </div>
+      <p class="hint-line">Tingginya mengikuti bentuk gambarnya.</p>
+    </div>
+
+    <div class="size-fields" id="height-fields" hidden>
+      <div class="numbers">
+        <label>Tinggi<input type="number" id="size-height" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">Lebarnya mengikuti bentuk gambarnya.</p>
+    </div>
+
+    <div class="size-fields" id="longest-fields" hidden>
+      <div class="numbers">
+        <label>Sisi terpanjang<input type="number" id="size-longest" min="1" step="1" value="1024"></label>
+      </div>
+      <p class="hint-line">
+        Sisi mana pun yang lebih panjang menjadi angka ini dan sisi satunya
+        mengikuti; jadi logo yang lebar dan logo yang tinggi keluar dengan ukuran
+        yang sama pada sisi panjangnya.
+      </p>
+    </div>
+
+    <div class="size-fields" id="box-fields" hidden>
+      <div class="numbers">
+        <label>Lebar<input type="number" id="box-width" min="1" step="1" value="1200"></label>
+        <label>Tinggi<input type="number" id="box-height" min="1" step="1" value="630"></label>
+      </div>
+      <div class="option-row">
+        <label for="box-fit">Kalau gambarnya berbentuk lain</label>
+        <select id="box-fit">
+          <option value="fit" selected>Muat di dalamnya &mdash; gambar utuh, satu sisi keluar lebih pendek</option>
+          <option value="pad">Isi &mdash; persis ukuran ini, dengan latar di kedua sisinya</option>
+          <option value="stretch">Regangkan &mdash; persis ukuran ini dan bentuknya berubah</option>
+        </select>
+      </div>
+    </div>
+
+    <!--
+      The one thing people rasterise a vector for more than once: the same
+      drawing at 1x, 2x and 3x for a screen with more device pixels than CSS
+      pixels. Multiplied from the plan above rather than planned again, so an
+      @2x is exactly twice its @1x and cannot drift by a rounded pixel.
+    -->
+    <div class="option-row" id="density-row">
+      <label for="density">Tulis juga salinan berkepadatan tinggi</label>
+      <select id="density">
+        <option value="1" selected>Tidak &mdash; satu file per gambar</option>
+        <option value="2">Sertakan @2x &mdash; untuk layar Retina</option>
+        <option value="3">@2x dan @3x &mdash; set lengkap yang diminta sebuah ponsel</option>
+      </select>
+    </div>
+
+    <p id="size-summary" class="field-summary"></p>
+    <p id="size-warning" class="field-summary warn" hidden></p>
+  </section>
+
+  <!-- Langkah 3 &mdash; formatnya -->
+  <section class="card" id="format-card">
+    <h2><span class="step">3</span> Pilih formatnya</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="format">Format</label>
+        <select id="format">
+          <option value="image/png" selected>PNG &mdash; menjaga transparansi, tepinya utuh</option>
+          <option value="image/jpeg">JPEG &mdash; tanpa transparansi, lebih kecil untuk foto</option>
+          <option value="image/webp">WebP &mdash; transparansi dan file lebih kecil</option>
+        </select>
+        <p class="field-note" id="format-note"></p>
+      </div>
+
+      <div class="field" id="quality-field" hidden>
+        <label for="quality">Kualitas &mdash; <output id="quality-value" for="quality">90</output></label>
+        <input type="range" id="quality" min="30" max="100" step="1" value="90">
+        <p class="field-note">
+          Hanya untuk JPEG dan WebP; PNG tanpa kehilangan sehingga tidak punya
+          tombol kualitas. Warna datar dan tepi tajam &mdash; dan sebagian besar
+          sebuah SVG terdiri dari itu &mdash; justru yang paling buruk ditangani
+          encoder berjenis kehilangan; karena itu nilai ini berdiri lebih tinggi
+          di sini daripada pada sebuah foto.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="background-mode">Latar</label>
+        <select id="background-mode">
+          <option value="transparent" selected>Transparan</option>
+          <option value="colour">Sebuah warna</option>
+        </select>
+        <input type="color" id="background-colour" value="#ffffff" aria-label="Warna latar" hidden>
+        <p class="field-note" id="background-note"></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Langkah 4 &mdash; lihat, lalu ambil -->
+  <section class="card" id="run-card">
+    <h2><span class="step">4</span> Lihat, lalu simpan</h2>
+
+    <p class="card-lede">
+      Pratinjaunya digambar oleh kode yang sama yang menulis file-nya, dari file
+      yang Anda pilih, di mesin ini. Yang layak diperiksa adalah dua hal yang
+      berubah ketika sebuah gambar menjadi piksel: garis setipis rambut yang
+      menjadi abu-abu ketika lebarnya setengah piksel, dan teks kalau ada; itu
+      pun digambar dengan font yang ada di mesin ini, bukan font yang diambil
+      dari web.
+    </p>
+
+    <div id="preview" class="preview" hidden>
+      <div class="preview-stage">
+        <canvas id="preview-canvas"></canvas>
+      </div>
+      <p class="preview-note" id="preview-note"></p>
+    </div>
+
+    <p id="preview-empty" class="field-summary">Tambahkan sebuah SVG dan ia muncul di sini.</p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big" disabled>Ubah jadi piksel</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <div id="results" class="results" hidden>
+      <div class="results-head">
+        <h3>Selesai</h3>
+        <button type="button" id="download-zip" class="ghost" hidden>Unduh semua sebagai zip</button>
+      </div>
+      <p id="results-summary" class="results-summary"></p>
+      <ul id="result-list" class="result-list"></ul>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/svg-to-image.toml
+++ b/locales/id/tools/svg-to-image.toml
@@ -1,0 +1,322 @@
+#
+# SVG ke Gambar - Bahasa Indonesia.
+#
+# Overrides for tools/svg-to-image/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "SVG ke Gambar"
+heading = "SVG&nbsp;ke&nbsp;Gambar <span class=\"h1-kw\">&mdash; ubah vektor menjadi PNG, JPEG, atau WebP pada ukuran berapa pun</span>"
+tagline = "Sebutkan ukurannya. Sebuah vektor tidak punya ukuran sendiri untuk hilang."
+
+title = "SVG ke PNG &mdash; Ubah Vektor jadi Piksel pada Ukuran Berapa Pun, Tanpa Unggah"
+description = "Ubah SVG menjadi PNG, JPEG, atau WebP pada ukuran berapa pun, di peramban Anda. Sebutkan lebarnya, sebuah kelipatan, atau sebuah kotak; dapatkan salinan @2x dan @3x juga. Transparansi terjaga, tidak ada yang diunggah."
+og_title = "Ubah SVG menjadi PNG pada ukuran berapa pun, tanpa mengunggahnya"
+og_description = "Sebuah vektor tidak punya ukuran piksel sendiri, jadi angkanya Anda yang pilih - 32 atau 8000, dengan ketajaman yang sama. Semuanya berjalan di perangkat Anda sendiri."
+og_image_alt = "SVG ke Gambar - ubah vektor menjadi PNG, JPEG, atau WebP pada ukuran berapa pun"
+
+pledge = """
+    Gambarnya diubah menjadi piksel oleh mesin yang sama yang baru saja
+    menampilkannya di layar Anda. File Anda dibaca dari disk Anda, tag akarnya
+    ditulis ulang ke ukuran yang Anda minta oleh seratus baris di
+    <code>src/svg.js</code> yang bisa Anda baca, dan ia digambar ke sebuah kanvas
+    yang memang sudah dibawa peramban Anda. Alat ini tidak punya fitur jaringan
+    dalam bentuk apa pun &mdash; tidak ada yang diambil, tidak ada yang dikirim
+    &mdash; dan seandainya pun ada, tidak ada server di ujung lain halaman ini
+    untuk menerima sebuah logo."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu ubah sesuatu menjadi piksel. Tidak satu pun permintaan membawa file,
+      gambar mini, nama file, atau satu byte pun dari yang Anda pilih. Atau cabut
+      koneksi internet dan tetap ubah satu."""
+
+read_first = """
+, <code>src/svg.js</code> untuk bagaimana ukuran
+      milik sebuah file dibaca dan bagaimana tag akarnya ditulis ulang, dan
+      <code>src/render.js</code> untuk delapan baris yang melakukan pengubahannya
+      menjadi piksel &mdash; sebuah &lt;img&gt;, sebuah <code>drawImage</code>,
+      dan sebuah <code>toBlob</code>, tanpa apa pun di antaranya."""
+
+howto_heading = "Cara mengubah SVG menjadi PNG tanpa mengunggahnya"
+
+card = """
+            Sebuah SVG tidak punya ukuran piksel sendiri, jadi angkanya Anda yang
+            pilih &mdash; 32 atau 8000, dan ketajamannya sama saja."""
+
+[words]
+plural = "file SVG"
+choose = "sebuah SVG"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Karya Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di mana
+      pun di dalam <code>src/</code>. Seluruh pengubahnya adalah sebuah
+      <code>&lt;img&gt;</code> yang memuat blob dari file Anda sendiri, satu
+      <code>drawImage</code> ke sebuah kanvas, dan satu
+      <code>canvas.toBlob</code>."""
+
+[[privacy]]
+title = "Sebuah SVG adalah dokumen, dan ini mode di mana ia tidak bisa bertindak."
+body = """
+ Sebuah SVG bisa membawa
+      <code>&lt;script&gt;</code>, sebuah
+      <code>&lt;image href=&quot;https://&hellip;&quot;&gt;</code> jarak jauh,
+      sebuah lembar gaya, dan sebuah font web. Digambar lewat sebuah
+      <code>&lt;img&gt;</code>, ia berada dalam apa yang disebut spesifikasi
+      sebagai <em>mode statis aman</em>: skripnya tidak berjalan dan tidak satu
+      pun alamat itu diambil. Itu jaminan peramban, bukan janji kami, dan itulah
+      alasan halaman ini bisa membuka file yang belum pernah dilihatnya tanpa
+      file itu bisa menelepon pulang."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google, dan tombol donasi dari Buy Me a Coffee. Tidak satu pun diberi
+      apa pun tentang gambar Anda. Setiap baris yang membaca, menetapkan ukuran,
+      atau menggambar sebuah file disajikan dari asal ini dan terdaftar di
+      repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih SVG-nya."
+body = """
+ Jatuhkan satu ke pemilih file, atau pilih satu
+      folder berisi SVG dan ubah semuanya sekali jalan. File dibaca peramban
+      langsung dari disk Anda; tidak ada yang dikirim ke mana pun saat Anda
+      melakukannya. Setiap baris mengatakan file itu menganggap dirinya berukuran
+      berapa &mdash; dan mengatakannya secara berbeda kalau ukuran itu datang dari
+      <code>viewBox</code>-nya, atau diandaikan karena file-nya tidak menyatakan
+      apa pun."""
+
+[[howto]]
+title = "Sebutkan seberapa besar."
+body = """
+ Kelipatan dari ukuran milik file itu sendiri
+      adalah jawaban tercepat dan yang tepat untuk satu kumpulan: setiap gambar
+      diskalakan dari titik awalnya sendiri, jadi sekumpulan ikon tetap
+      sebanding. Selain itu, sebutkan sebuah lebar, sebuah tinggi, sisi
+      terpanjang, atau sebuah kotak dengan kedua sisinya diberikan. Tidak ada
+      hukuman untuk angka besar di sini seperti pada sebuah foto &mdash; gambarnya
+      digambar ulang pada ukuran itu, bukan diregangkan ke sana."""
+
+[[howto]]
+title = "Tambahkan salinan berkepadatan tinggi kalau Anda butuh."
+body = """
+ Ponsel dan laptop Retina menggambar dua
+      atau tiga piksel perangkat untuk setiap piksel CSS, jadi logo 200 piksel
+      butuh file 400 atau 600 piksel di belakangnya. Mintalah <code>@2x</code> dan
+      <code>@3x</code> dan mereka keluar dengan nama yang diharapkan Xcode,
+      perkakas Android, dan <code>image-set()</code> di CSS, dan masing-masing
+      persis dua atau tiga kali yang pertama alih-alih dibulatkan sendiri-sendiri."""
+
+[[howto]]
+title = "Pilih formatnya dan putuskan soal transparansinya."
+body = """
+ PNG kecuali Anda punya alasan: ia
+      tanpa kehilangan, ia menjaga transparansi, dan warna datar terkompres dengan baik di
+      dalamnya. JPEG sama sekali tidak punya transparansi, jadi sebuah warna latar
+      dicat masuk entah Anda memilihnya atau tidak &mdash; tanpanya setiap piksel
+      transparan keluar hitam. WebP melakukan keduanya dan membuat file lebih
+      kecil, dengan biaya perangkat lunak yang cukup tua sehingga tidak bisa
+      membacanya."""
+
+[[howto]]
+title = "Lihat pratinjaunya sebelum Anda mengunduh."
+body = """
+ Ia digambar oleh kode yang sama yang
+      menulis file-nya, dari file Anda, di mesin Anda. Dua hal berubah ketika
+      sebuah gambar menjadi piksel dan keduanya muncul di sini: garis setipis
+      rambut yang tadinya selebar setengah piksel menjadi abu-abu, dan teks apa
+      pun digambar dengan font yang dimiliki komputer ini alih-alih yang diambil
+      dari web."""
+
+[[howto]]
+title = "Ambil file-nya."
+body = """
+ Satu unduhan per file, atau seluruh kumpulan
+      sebagai satu zip. Namanya mengikuti SVG asalnya, dengan <code>@2x</code> dan
+      <code>@3x</code> pada salinannya, dan dua file yang akan bernama sama
+      diberi nomor alih-alih yang satu diam-diam menimpa yang lain."""
+
+[[faq]]
+q = "Apakah SVG saya diunggah ke suatu tempat?"
+a = """
+        Tidak. File dibaca oleh peramban Anda sendiri di perangkat keras Anda
+        sendiri, digambar ke sebuah kanvas oleh mesin yang sama yang menggambar
+        setiap gambar lain yang Anda lihat, dan diserahkan kembali sebagai sebuah
+        unduhan. Alat ini tidak punya fitur jaringan dalam bentuk apa pun &mdash;
+        ia tidak pernah mengambil apa pun dan tidak pernah mengirim apa pun
+        &mdash; dan <code>Content-Security-Policy</code> halaman ini menyebut satu
+        per satu setiap alamat yang boleh dihubunginya, dan tidak satu pun milik
+        situs ini."""
+
+[[faq]]
+q = "Pada ukuran berapa sebaiknya saya mengubah SVG menjadi piksel?"
+a = """
+        Berapa pun yang diminta oleh yang akan membacanya, dikalikan rasio piksel
+        perangkat layar tempat ia akan dilihat. Logo yang menempati 200 piksel CSS
+        butuh 400 untuk laptop Retina dan 600 untuk ponsel masa kini, dan itulah
+        salinan <code>@2x</code> dan <code>@3x</code> di sini. Untuk ikon aplikasi
+        atau kartu di toko aplikasi, tokonya menyebut angka yang persis dan itulah
+        angkanya. Kalau tidak ada yang memberi tahu Anda, 1024 pada sisi
+        terpanjang adalah bawaan yang berguna: cukup besar untuk hampir semua
+        keperluan dan cukup kecil untuk dikirim lewat email."""
+
+[[faq]]
+q = "Apakah memperbesarnya menurunkan kualitas?"
+a = """
+        Tidak, dan inilah satu tempat di mana jawaban itu benar-benar tidak.
+        Sebuah vektor adalah instruksi alih-alih piksel, jadi peramban menggambar
+        kurvanya lagi pada ukuran berapa pun yang diminta. 4000 piksel dari ikon
+        24 piksel persis setajam 24-nya. Yang tidak bisa Anda lakukan adalah arah
+        sebaliknya: begitu ia menjadi PNG ia adalah piksel seperti yang lain, jadi
+        ubahlah ke piksel pada ukuran yang Anda butuhkan alih-alih mengubah ukuran
+        hasilnya nanti."""
+
+[[faq]]
+q = "SVG saya tidak punya width atau height. Saya dapat ukuran berapa?"
+a = """
+        <code>viewBox</code>-nya, kalau ada &mdash; lebar dan tingginya adalah
+        satuan pengguna alih-alih piksel, tapi itulah satu-satunya angka di dalam
+        file dan peramban memperlakukannya sebagai ukuran alami gambarnya. Kalau
+        viewBox-nya juga tidak ada, halaman ini menulis <em>diandaikan</em> di
+        sebelah barisnya dan memakai 300&nbsp;&times;&nbsp;150, yang akan dipakai
+        sebuah <code>&lt;img&gt;</code> untuk menggambarnya. Bagaimanapun Anda bisa
+        menyebut ukuran yang Anda mau dan file-nya digambar pada ukuran itu."""
+
+[[faq]]
+q = "Kenapa teksnya tampak berbeda di PNG-nya?"
+a = """
+        Karena font-nya tidak ada di dalam SVG. Sebuah SVG yang menggambar teks
+        menyebut nama sebuah font dan menyerahkan pencariannya kepada mesin, dan
+        file yang menarik font dari Google Fonts lewat <code>@import</code> tidak
+        mendapat apa-apa di sini: SVG yang digambar lewat sebuah
+        <code>&lt;img&gt;</code> tidak diizinkan mengambil apa pun, dan itu aturan
+        yang sama yang menghentikannya menelepon pulang dengan file Anda.
+        Perbaikannya adalah yang sudah diketahui setiap desainer &mdash; ubah
+        teksnya menjadi jalur di program gambar sebelum mengekspor. Setelah itu ia
+        adalah geometri, dan ia tampak sama di mana-mana."""
+
+[[faq]]
+q = "Bisakah ia mengubah beberapa file sekaligus?"
+a = """
+        Bisa. Setiap SVG di daftar digambar dengan setelan yang sama dan
+        kumpulannya turun sebagai satu zip. Sebuah kelipatan &mdash; &ldquo;4&times;
+        ukuran yang diminta file-nya&rdquo; &mdash; biasanya setelan yang tepat
+        untuk satu kumpulan, karena setiap gambar diskalakan dari ukurannya
+        sendiri alih-alih semuanya dipaksa ke jumlah piksel yang sama. Klik baris
+        mana pun untuk menaruh yang itu di pratinjaunya."""
+
+[[faq]]
+q = "Adakah batas ukurannya?"
+a = """
+        Batas peramban, bukan batas kami. Sebuah kanvas menyerah di suatu titik
+        melewati 16.384 piksel di satu sisi, dan Safari di iPhone atau iPad
+        berhenti pada sekitar 16,7 megapiksel luas &mdash;
+        4096&nbsp;&times;&nbsp;4096. Di atas itu halaman ini memperingatkan Anda
+        alih-alih menyerahkan gambar kosong, yang justru dilakukan peramban ketika
+        ia kehabisan: <code>toBlob</code> tidak mengembalikan apa pun, tanpa galat
+        yang menjelaskan dirinya. Melewati 100 megapiksel alat ini menolak, karena
+        itu berarti 400&nbsp;MB kanvas sebelum satu byte pun dikodekan."""
+
+[[faq]]
+q = "Apa yang terjadi pada transparansinya?"
+a = """
+        Ia terjaga, di PNG dan di WebP. JPEG sama sekali tidak punya kanal alfa,
+        jadi sebuah warna dicat di belakang seluruh gambarnya entah Anda memintanya
+        atau tidak &mdash; tanpa itu, semua yang transparan akan keluar hitam, yang
+        tampak seperti kerusakan alih-alih seperti JPEG. Memilih warna latar dengan
+        PNG juga hal yang sangat lumrah untuk diinginkan: ia meratakan gambarnya ke
+        warna itu alih-alih meninggalkan lubang."""
+
+[[faq]]
+q = "Bisakah ia membaca SVG yang memuat skrip atau gambar eksternal?"
+a = """
+        Ia bisa membacanya, dan ia akan menggambar persis bagian yang mau digambar
+        sebuah peramban. SVG yang dimuat lewat sebuah <code>&lt;img&gt;</code>
+        berada dalam <em>mode statis aman</em>: skrip tidak berjalan, rujukan
+        eksternal tidak diambil, dan animasi tidak diputar &mdash; bingkai
+        pertamanyalah yang Anda dapat. Jadi file dengan
+        <code>&lt;image&gt;</code> jarak jauh di dalamnya keluar dengan bagian itu
+        hilang. Itu peramban yang menolak atas nama Anda, dan itulah alasan halaman
+        ini bisa dengan aman membuka file yang belum pernah dilihatnya."""
+
+[[faq]]
+q = "Apa bedanya ini dengan Pengubah Ukuran Gambar?"
+a = """
+        Sumbernya. Pengubah Ukuran Gambar mulai dari piksel &mdash; sebuah JPEG,
+        sebuah PNG &mdash; jadi memperbesarnya harus mengarang detail yang tidak
+        pernah ada. Yang ini mulai dari sebuah gambar, jadi tidak ada yang perlu
+        dikarang dan tidak ada batas atas yang layak dikhawatirkan. Kalau yang Anda
+        punya adalah SVG, inilah yang memberi hasil tajam; kalau yang Anda punya
+        adalah foto, itulah yang lain."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Tidak ada batas jumlah atau ukuran file-nya juga,
+        karena tidak ada server yang membayarnya &mdash; pekerjaannya terjadi di
+        mesin Anda sendiri. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang file Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim karya Anda ke tempat lain untuk digambar akan
+        berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Ubah SVG menjadi PNG, JPEG, atau WebP pada ukuran berapa pun, di peramban. Tetapkan ukurannya lewat sebuah kelipatan, lebar, tinggi, sisi terpanjang, atau sebuah kotak, tambahkan salinan @2x dan @3x, jaga atau ratakan transparansinya, dan ubah satu kumpulan sekaligus. Tidak ada yang diunggah."
+features = [
+  "Menggambar ulang vektornya pada setiap ukuran, jadi hasilnya tajam di semuanya",
+  "Ukuran lewat kelipatan, lebar, tinggi, sisi terpanjang, atau kotak dengan cara pas",
+  "Salinan @2x dan @3x, masing-masing kelipatan persis dari yang pertama alih-alih dibulatkan dua kali",
+  "PNG, JPEG, dan WebP, dengan transparansi dijaga atau diratakan ke sebuah warna",
+  "Membaca ukurannya dari width, height, atau viewBox, dan mengatakan yang mana yang dipakainya",
+  "Memperingatkan sebelum ukuran yang sebenarnya tidak bisa dihasilkan kanvas sebuah peramban",
+  "Pratinjau digambar oleh kode yang sama yang menulis file-nya",
+  "Kumpulan, dengan semua hasilnya dalam satu zip",
+  "Skrip dan rujukan jarak jauh di dalam file tidak pernah dijalankan atau diambil",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan sebuah SVG di sini"
+hint = "atau klik untuk menelusuri &mdash; beberapa sekaligus juga boleh"

--- a/locales/id/tools/text-tools.html
+++ b/locales/id/tools/text-tools.html
@@ -1,0 +1,206 @@
+<!--
+  tools/text-tools/body.html, in Indonesian.
+
+  Every id, class, role, data-mode and option value below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; yang mana dari empat pekerjaan ini -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih pekerjaannya</h2>
+
+    <!--
+      A tab strip rather than four pages, because the four jobs share an input:
+      the JSON you just formatted is the JSON you want to diff against the one
+      from the other branch, and retyping it into a second tool is the thing
+      this arrangement exists to avoid. `role="tablist"` and the arrow keys are
+      wired in main.js.
+    -->
+    <div class="tabs" role="tablist" aria-label="Apa yang dilakukan pada teksnya">
+      <button type="button" role="tab" id="tab-format" class="tab" data-mode="format"
+              aria-selected="true" aria-controls="options-format">Format</button>
+      <button type="button" role="tab" id="tab-convert" class="tab" data-mode="convert"
+              aria-selected="false" tabindex="-1" aria-controls="options-convert">Ubah</button>
+      <button type="button" role="tab" id="tab-encode" class="tab" data-mode="encode"
+              aria-selected="false" tabindex="-1" aria-controls="options-encode">Kodekan</button>
+      <button type="button" role="tab" id="tab-diff" class="tab" data-mode="diff"
+              aria-selected="false" tabindex="-1" aria-controls="options-diff">Bandingkan</button>
+    </div>
+
+    <div class="settings" id="options-format" role="tabpanel" aria-labelledby="tab-format">
+      <div class="field">
+        <label for="language">Bahasa</label>
+        <select id="language">
+          <option value="auto" selected>Tentukan sendiri dari teksnya</option>
+          <option value="json">JSON</option>
+          <option value="xml">XML</option>
+          <option value="html">HTML</option>
+          <option value="css">CSS</option>
+          <option value="yaml">YAML</option>
+        </select>
+        <p class="field-note" id="language-note">
+          Tebakannya hanyalah titik awal, dan membetulkannya cukup satu klik.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="indent">Indentasi</label>
+        <select id="indent">
+          <option value="2" selected>Dua spasi</option>
+          <option value="4">Empat spasi</option>
+          <option value="tab">Sebuah tab</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="style">Tata letak</label>
+        <select id="style">
+          <option value="pretty" selected>Rapikan</option>
+          <option value="minify">Mampatkan sampai rata</option>
+        </select>
+        <p class="field-note" id="style-note"></p>
+      </div>
+
+      <div class="field checks">
+        <label class="check" for="sort-keys">
+          <input type="checkbox" id="sort-keys">
+          Urutkan kunci setiap objek
+        </label>
+        <p class="field-note">
+          Menurut cara kuncinya terbaca alih-alih menurut titik kodenya, jadi
+          <code>item2</code> datang sebelum <code>item10</code>. Hanya JSON.
+        </p>
+      </div>
+    </div>
+
+    <div class="settings" id="options-convert" role="tabpanel" aria-labelledby="tab-convert" hidden>
+      <div class="field">
+        <label for="conversion">Ubah</label>
+        <select id="conversion"></select>
+        <p class="field-note" id="conversion-note"></p>
+      </div>
+
+      <div class="field" id="root-field" hidden>
+        <label for="root-name">Nama untuk elemen terluar</label>
+        <input type="text" id="root-name" value="root" spellcheck="false" autocomplete="off">
+        <p class="field-note">
+          XML punya satu elemen di puncaknya dan JSON tidak, jadi salah satunya
+          harus dikarang.
+        </p>
+      </div>
+    </div>
+
+    <div class="settings" id="options-encode" role="tabpanel" aria-labelledby="tab-encode" hidden>
+      <div class="field">
+        <label for="codec">Pengodean</label>
+        <select id="codec"></select>
+        <p class="field-note" id="codec-note"></p>
+      </div>
+
+      <div class="field">
+        <fieldset class="modes">
+          <legend>Ke arah mana</legend>
+          <label class="mode">
+            <input type="radio" name="direction" value="encode" checked>
+            <span><strong>Kodekan</strong> Teks biasa masuk, terkodekan keluar.</span>
+          </label>
+          <label class="mode">
+            <input type="radio" name="direction" value="decode">
+            <span><strong>Dekodekan</strong> Terkodekan masuk, teks biasa keluar.</span>
+          </label>
+        </fieldset>
+      </div>
+    </div>
+
+    <div class="settings" id="options-diff" role="tabpanel" aria-labelledby="tab-diff" hidden>
+      <div class="field">
+        <label for="view">Bagaimana ditampilkan</label>
+        <select id="view">
+          <option value="split" selected>Sisi demi sisi</option>
+          <option value="unified">Satu kolom</option>
+        </select>
+      </div>
+
+      <div class="field checks">
+        <label class="check" for="only-changes">
+          <input type="checkbox" id="only-changes" checked>
+          Tampilkan hanya yang berubah, dengan tiga baris di kedua sisinya
+        </label>
+        <label class="check" for="ignore-whitespace">
+          <input type="checkbox" id="ignore-whitespace">
+          Abaikan spasi
+        </label>
+        <label class="check" for="ignore-case">
+          <input type="checkbox" id="ignore-case">
+          Abaikan huruf besar dan kecil
+        </label>
+        <label class="check" for="ignore-blank">
+          <input type="checkbox" id="ignore-blank">
+          Abaikan baris kosong
+        </label>
+      </div>
+    </div>
+  </section>
+
+  <!-- Langkah 2 &mdash; teksnya sendiri -->
+  <section class="card">
+    <h2><span class="step">2</span> Tempelkan</h2>
+
+    <!--
+      The picker is here for the file that is easier to drop than to open,
+      select all and copy. Nothing about it leaves the machine: the file is
+      read with FileReader into the box below, and that is the whole journey.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div class="panes" id="panes">
+      <div class="pane">
+        <div class="pane-head">
+          <label for="input" id="input-label">Teks Anda</label>
+          <span class="count" id="input-count">kosong</span>
+        </div>
+        <textarea id="input" spellcheck="false" autocomplete="off" autocapitalize="off"
+                  autocorrect="off" wrap="off"
+                  placeholder="Tempelkan JSON, XML, HTML, CSS, atau YAML di sini - atau jatuhkan sebuah file di atas."></textarea>
+      </div>
+
+      <div class="pane" id="pane-b" hidden>
+        <div class="pane-head">
+          <label for="input-b">Yang satunya</label>
+          <span class="count" id="input-b-count">kosong</span>
+        </div>
+        <textarea id="input-b" spellcheck="false" autocomplete="off" autocapitalize="off"
+                  autocorrect="off" wrap="off"
+                  placeholder="Tempelkan versi yang akan dibandingkan."></textarea>
+      </div>
+    </div>
+
+    <div class="toolbar">
+      <p class="count" id="detected"></p>
+      <div class="toolbar-actions">
+        <button type="button" id="sample" class="ghost">Coba sebuah contoh</button>
+        <button type="button" id="swap" class="ghost" hidden>Tukar sisinya</button>
+        <button type="button" id="clear" class="ghost danger">Bersihkan</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; apa yang keluar -->
+  <section class="card">
+    <h2><span class="step">3</span> Ambil hasilnya</h2>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div class="toolbar">
+      <p class="count" id="result-note">Belum ada apa-apa.</p>
+      <div class="toolbar-actions">
+        <button type="button" id="copy" class="ghost" disabled>Salin</button>
+        <a id="download" class="ghost as-button" hidden download>Unduh</a>
+      </div>
+    </div>
+
+    <pre id="output" class="output" tabindex="0"></pre>
+
+    <div id="diff-view" class="diff" hidden></div>
+  </section>
+</main>

--- a/locales/id/tools/text-tools.toml
+++ b/locales/id/tools/text-tools.toml
@@ -1,0 +1,348 @@
+#
+# Teks dan Kode - Bahasa Indonesia.
+#
+# Overrides for tools/text-tools/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# Nama format (JSON, XML, HTML, CSS, YAML, Base64), nama perintah (git diff,
+# git apply), dan nama file tetap seperti adanya: itulah yang diketik dan
+# dicari orang. "Diff" diterjemahkan sebagai perbandingan; file yang diunduh
+# disebut tambalan.
+#
+
+name = "Teks dan Kode"
+heading = "Teks&nbsp;dan&nbsp;kode <span class=\"h1-kw\">&mdash; pemformat, pembanding, pengode, dan pengubah</span>"
+tagline = "Rapikan tata letaknya, lihat apa yang berubah, kodekan, atau ubah ke format yang lain. Tidak ada yang ditempelkan ke server orang lain."
+
+title = "Pemformat JSON, Pembanding Teks, Pengubah Base64 &amp; YAML &mdash; Tanpa Unggah"
+description = "Format JSON, XML, HTML, CSS, dan YAML, bandingkan dua teks baris demi baris, kodekan Base64 atau URL, dan ubah JSON menjadi YAML atau XML. Semuanya berjalan di peramban Anda - tidak ada yang diunggah."
+og_title = "Format, bandingkan, kodekan, dan ubah teks tanpa menempelkannya ke sebuah server"
+og_description = "Sebuah pemformat JSON, sebuah pembanding, sebuah pengode, dan sebuah pengubah dalam satu halaman, semuanya berjalan di mesin Anda sendiri. Tempelkan sebuah token atau file konfigurasi tanpa menyerahkannya kepada siapa pun."
+og_image_alt = "Teks dan Kode - pemformat, pembanding, pengode, dan pengubah, tanpa unggah"
+
+pledge = """
+    Keempat pekerjaannya masing-masing adalah aritmetika atas sebuah string,
+    dikerjakan di sini, di halaman ini. Penguraiannya ditulis sendiri dan ada di
+    dalam <code>src/</code> &mdash; <code>json.js</code>, <code>xml.js</code>,
+    <code>css.js</code>, <code>yaml.js</code> &mdash; dan pembandingannya adalah
+    algoritma Myers di dalam <code>diff.js</code>, yang sama dengan yang dipakai
+    <code>git diff</code>. Alat ini tidak punya fitur jaringan dalam bentuk apa
+    pun &mdash; tidak ada yang diambil, tidak ada yang dikirim &mdash; dan itu
+    lebih penting di sini daripada di mana pun lain di situs ini: yang
+    ditempelkan orang ke sebuah pemformat adalah token akses, cookie sesi,
+    catatan pelanggan, dan kode yang belum dirilis."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu format sesuatu. Tidak satu pun permintaan membawa satu karakter pun
+      dari yang Anda tempelkan. Atau cabut koneksi internet dan tetap format
+      teksnya."""
+
+read_first = """
+, <code>src/json.js</code> untuk pengurai yang
+      menjaga kunci Anda dalam urutan yang Anda tulis, dan
+      <code>src/diff.js</code> untuk pembandingannya &mdash; kira-kira dua ratus
+      baris, dan bagian halaman ini yang paling banyak aritmetikanya."""
+
+howto_heading = "Cara memformat, membandingkan, atau mengodekan teks tanpa mengunggahnya"
+
+card = """
+            Sebuah pemformat JSON, sebuah pembanding, sebuah pengode, dan sebuah
+            pengubah dalam satu halaman. Tempelkan sebuah token atau file
+            konfigurasi tanpa menyerahkannya kepada siapa pun."""
+
+[words]
+plural = "teks dan kode"
+choose = "sebuah file"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa batas ukuran"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[facts]]
+text = "Sumber terbuka"
+
+[[privacy]]
+title = "Apa yang Anda tempelkan tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat token yang
+      ditempelkan bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya
+      seandainya ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Tidak ada <code>fetch</code>, tidak ada
+      <code>XMLHttpRequest</code>, dan tidak ada <code>sendBeacon</code> di mana
+      pun di dalam <code>src/</code>. Setiap pengurai, setiap pengode, dan
+      pembandingannya adalah fungsi di halaman ini yang mengambil sebuah string
+      dan mengembalikan sebuah string."""
+
+[[privacy]]
+title = "Pemformatnya menjaga apa yang diberikan kepadanya."
+body = """
+ Sebuah objek JSON kembali dengan
+      kuncinya dalam urutan yang Anda tulis dan angkanya dieja sebagaimana Anda
+      mengejanya, karena <code>src/json.js</code> adalah sebuah pengurai alih-alih
+      panggilan ke <code>JSON.parse</code>, yang mengurutkan ulang kunci mirip
+      bilangan bulat dan mengubah id dua puluh digit menjadi bilangan ganda
+      terdekat. Uji di <code>tests/js/text-format.test.js</code> memeriksa persis
+      itu."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google, dan tombol donasi dari Buy Me a Coffee. Tidak satu pun diberi
+      satu karakter pun dari teks Anda. Setiap baris yang membaca, mengurai, atau
+      menulisnya disajikan dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan alat ini tidak
+      berubah, karena sejak awal memang tidak ada langkah jaringan di dalamnya.
+      Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih pekerjaannya."
+body = """
+ Empat tab, dan semuanya berbagi satu kotak:
+      <em>Format</em> merapikan atau memampatkan JSON, XML, HTML, CSS, dan YAML;
+      <em>Ubah</em> mengubah JSON menjadi YAML atau XML dan sebaliknya;
+      <em>Kodekan</em> menangani Base64, URL, entitas HTML, heksadesimal, dan
+      pelolosan garis miring terbalik, dua arah; <em>Bandingkan</em> menunjukkan
+      apa yang berubah di antara dua teks."""
+
+[[howto]]
+title = "Tempelkan, atau jatuhkan file-nya."
+body = """
+ Apa pun yang bisa Anda pilih dan salin
+      bisa dipakai. File yang dijatuhkan ke pemilihnya dibaca peramban Anda
+      sendiri dan ditaruh di kotaknya &mdash; tidak ada langkah unggah untuk
+      ditinggalkan. Jatuhkan dua file sambil membandingkan dan keduanya mendarat
+      di sisi masing-masing."""
+
+[[howto]]
+title = "Biarkan ia menentukan bahasanya, atau beri tahu."
+body = """
+ Menunya mengatakan ia membaca teksnya
+      sebagai apa, dan membetulkannya cukup satu klik. Sebuah tebakan hanyalah
+      titik awal, dan itulah sebabnya ia ditampilkan alih-alih diterapkan
+      diam-diam."""
+
+[[howto]]
+title = "Pilih indentasinya, atau mampatkan sampai rata."
+body = """
+ Dua spasi, empat, atau sebuah tab.
+      Memampatkannya sampai rata adalah dokumen yang sama dengan setiap spasi
+      yang hanya ada demi keterbacaan dikeluarkan, dan hasilnya mengatakan itu
+      menghemat berapa byte."""
+
+[[howto]]
+title = "Baca galatnya di tempat galatnya berada."
+body = """
+ Pengurai yang gagal di sini mengatakan
+      apa yang ditemukannya dan pada baris serta kolom mana, alih-alih "token tak
+      terduga di posisi 4193". Itu biasanya cukup untuk membetulkan sebuah file
+      konfigurasi tanpa membuka apa pun yang lain."""
+
+[[howto]]
+title = "Ambil hasilnya."
+body = """
+ Salin, atau unduh sebagai sebuah file. Sebuah
+      perbandingan turun sebagai <code>.patch</code> dalam format terpadu, dan
+      itulah yang diharapkan sebuah tinjauan kode, <code>git apply</code>, dan
+      setiap penampil perbandingan."""
+
+[[faq]]
+q = "Apakah teks saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Setiap pengurai, pengode, dan pembandingan di halaman ini adalah
+        fungsi yang berjalan di peramban Anda sendiri, di perangkat keras Anda
+        sendiri. Alat ini tidak punya fitur jaringan dalam bentuk apa pun &mdash;
+        ia tidak pernah mengambil apa pun dan tidak pernah mengirim apa pun
+        &mdash; dan <code>Content-Security-Policy</code> halaman ini menyebut satu
+        per satu setiap alamat yang boleh dihubunginya, dan tidak satu pun milik
+        situs ini. Itulah alasan memakainya untuk sebuah token akses, cookie
+        sesi, atau catatan pelanggan: menempelkan salah satunya ke pemformat
+        orang lain berarti memberikannya kepada mereka."""
+
+[[faq]]
+q = "Apakah memformat JSON mengubah selain tata letaknya?"
+a = """
+        Tidak, dan itu lebih sulit daripada kedengarannya. Kunci menjaga urutan
+        yang Anda tulis &mdash; pemformat yang dibangun di atas
+        <code>JSON.parse</code> diam-diam memindahkan kunci mirip bilangan bulat
+        ke depan, jadi <code>{"10":a,"2":b}</code> kembali sebagai
+        <code>{"2":b,"10":a}</code>. Angka menjaga digit yang Anda ketik, jadi id
+        dua puluh digit tidak kehilangan tiga digit terakhirnya ke sebuah bilangan
+        ganda dan <code>1e999</code> tidak menjadi <code>null</code>. Kunci
+        rangkap keduanya disimpan, karena standarnya tidak mengatakan mana yang
+        menang dan membuang salah satunya berarti memilihkannya untuk Anda."""
+
+[[faq]]
+q = "Bahasa apa saja yang bisa diformatnya?"
+a = """
+        JSON, XML, HTML, CSS, dan YAML. JSON, XML, HTML, dan CSS juga bisa
+        dimampatkan sampai rata; YAML tidak, karena bentuk pendeknya adalah gaya
+        alir, yang tidak terbaca, dan tidak terbaca adalah kebalikan dari alasan
+        menyimpan sebuah file dalam YAML. JavaScript sengaja tidak ada di daftar
+        &mdash; lihat pertanyaan tentangnya di bawah."""
+
+[[faq]]
+q = "Kenapa ia tidak memformat JavaScript, Python, atau SQL?"
+a = """
+        Karena merapikan sebuah bahasa pemrograman berarti menguraikannya dengan
+        benar, dan pemformat yang nyaris benar lebih buruk daripada tidak ada
+        sama sekali: ia menghasilkan kode yang tampak baik-baik saja dan melakukan
+        sesuatu yang lain. JSON, XML, CSS, dan YAML punya tata bahasa yang cukup
+        kecil untuk dibaca sendiri dan diperiksa dengan uji yang bisa Anda
+        jalankan. Pemformat JavaScript adalah Prettier, yang berukuran satu
+        megabyte pengurai, dan tempatnya di penyunting Anda, bukan di sebuah
+        halaman web."""
+
+[[faq]]
+q = "Apa sebenarnya yang dilakukan pembandingannya?"
+a = """
+        Ia mencari himpunan suntingan terpendek yang mengubah teks di kiri menjadi
+        yang di kanan, memakai algoritma Myers &mdash; yang dipakai
+        <code>git diff</code>. Terpendeklah yang membuat sebuah perbandingan
+        terbaca: satu baris yang disisipkan di tengah seharusnya tampil sebagai
+        satu penyisipan alih-alih sebagai setiap baris sesudahnya berubah. Di
+        dalam baris yang berubah, kata yang berbeda juga ditandai, jadi
+        perbandingan dua paragraf menunjukkan kata yang berpindah alih-alih dua
+        paragraf utuh."""
+
+[[faq]]
+q = "Bisakah ia membandingkan dua file alih-alih dua tempelan?"
+a = """
+        Bisa. Jatuhkan keduanya ke pemilihnya sementara tab Bandingkan terbuka
+        dan keduanya mendarat di sisi masing-masing, dalam urutan Anda
+        menjatuhkannya. Keduanya dibaca peramban Anda ke halaman ini, dan hanya ke
+        situlah mereka pergi. Tukar sisinya kalau Anda menjatuhkannya terbalik."""
+
+[[faq]]
+q = "Apa yang keluar dari sebuah perbandingan, dan bisakah saya menerapkannya?"
+a = """
+        Unduhannya adalah perbandingan terpadu &mdash; format
+        <code>@@ -3,5 +3,5 @@</code> yang dibaca <code>git apply</code>,
+        <code>patch</code>, dan setiap alat tinjauan kode. Salin melakukan hal
+        yang sama ke papan klip Anda. Yang ada di layar adalah tampilannya: sisi
+        demi sisi, atau satu kolom, dengan bagian yang tidak berubah diringkas
+        menjadi sebuah hitungan kecuali Anda meminta semuanya."""
+
+[[faq]]
+q = "Apakah Base64 di sini sama dengan Base64 di mana-mana?"
+a = """
+        Ya &mdash; ia diperiksa terhadap vektor uji di RFC 4648 alih-alih
+        terhadap dirinya sendiri. Kedua alfabetnya bisa didekode, jadi JWT yang
+        ditulis dengan <code>-</code> dan <code>_</code> terbaca semudah yang
+        ditulis dengan <code>+</code> dan <code>/</code>, dan masukan yang
+        dipatahkan pada 64 karakter dirapikan untuk Anda. Pengodeannya lewat byte
+        UTF-8, jadi huruf beraksen atau sebuah emoji selamat dalam perjalanan
+        bolak-balik."""
+
+[[faq]]
+q = "YAML saya berkata no dan JSON-nya keluar sebagai string. Kenapa?"
+a = """
+        Karena memang itu sebuah string, dan alat ini membaca YAML 1.2 alih-alih
+        1.1. Di YAML 1.1, <code>yes</code>, <code>no</code>, <code>on</code>, dan
+        <code>off</code> adalah nilai boolean, dan itulah bug terkenal yang
+        mengubah kode negara Norwegia menjadi <code>false</code>. YAML 1.2
+        membuangnya dan alat ini juga: hanya <code>true</code>,
+        <code>false</code>, <code>null</code>, dan <code>~</code> yang dibaca
+        sebagai selain teks. Ke arah sebaliknya, kata-kata itu ditulis kembali
+        <em>di dalam tanda kutip</em>, meski alat ini akan membacanya sebagai teks
+        tanpa tanda kutip &mdash; karena apa pun yang membuka file itu berikutnya
+        mungkin tidak. PyYAML masih memakai 1.1 secara bawaan. Membaca dengan
+        ketat dan menulis dengan hati-hati adalah satu-satunya kombinasi yang
+        benar di kedua keadaan."""
+
+[[faq]]
+q = "Apa yang hilang saat mengubah YAML menjadi JSON?"
+a = """
+        Komentar, karena JSON tidak punya tempat untuk menaruhnya. Jangkar, alias,
+        dan tag ditolak mentah-mentah alih-alih ditebak &mdash; masing-masing
+        mengatakan sesuatu yang tidak bisa dikatakan JSON, dan pengubah yang
+        diam-diam memilih sebuah tafsir akan menyerahkan dokumen yang bukan isi
+        file itu kepada Anda. Arah sebaliknya tidak kehilangan apa pun: setiap
+        dokumen JSON sudah merupakan dokumen YAML."""
+
+[[faq]]
+q = "Apa yang hilang saat mengubah JSON menjadi XML?"
+a = """
+        Perbedaan antara objek kosong, larik kosong, dan string kosong &mdash;
+        semuanya menjadi elemen kosong &mdash; dan tipe setiap nilai, karena XML
+        tidak punya tipe. Itulah sebabnya pengubahan sebaliknya membiarkan
+        semuanya sebagai string alih-alih memutuskan bahwa <code>8080</code>
+        adalah sebuah angka. Sebuah larik menjadi elemen berulang, satu-satunya
+        bentuk yang bisa dibaca kembali, dan kunci yang tidak bisa ditampung
+        sebuah nama elemen karakternya yang menyulitkan diganti alih-alih
+        dikeluarkan sebagai dokumen yang tidak akan dibaca pengurai mana pun."""
+
+[[faq]]
+q = "Apakah mengindentasi ulang HTML mengubah tampilan halamannya?"
+a = """
+        Bisa, dan alat ini jujur soal itu. Spasi di antara dua elemen sebaris
+        adalah spasi di antara dua kata, jadi memindahkannya tidak gratis. Dua hal
+        menahannya: <code>&lt;pre&gt;</code> dan <code>&lt;textarea&gt;</code>
+        disalin persis seperti adanya, dan elemen yang tidak memuat apa pun selain
+        teks tetap di satu baris. Selebihnya dirapikan."""
+
+[[faq]]
+q = "Sebesar apa file yang bisa ditanganinya?"
+a = """
+        Tidak ada batas yang ditetapkan di sini, karena tidak ada server yang
+        membayarnya. Batas praktisnya adalah mesin Anda sendiri: beberapa megabyte
+        JSON tidak masalah. Perbandingan dua teks yang sama sekali tidak punya
+        kesamaan berhenti lebih awal dan mengatakannya, alih-alih menghabiskan
+        semenit membuktikan yang sudah jelas, dan perbandingan yang sangat panjang
+        menggambar beberapa ribu baris pertama dan menyisakan sisanya untuk
+        tambalan yang diunduh."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada batas berapa banyak yang Anda tempelkan. Situs ini memasang
+        iklan, dan itulah yang membiayainya; iklan tidak diberi apa pun tentang
+        teks Anda."""
+
+[[faq]]
+q = "Apakah jalan tanpa internet?"
+a = """
+        Ya. Muat halamannya sekali, lalu putuskan koneksi internet dan ia tetap
+        bekerja. Itu juga cara paling sederhana untuk membuktikan tidak ada yang
+        diunggah: alat yang mengirim teks Anda ke tempat lain untuk diformat akan
+        berhenti begitu Anda mencabut koneksi."""
+
+[schema]
+description = "Format dan mampatkan JSON, XML, HTML, CSS, dan YAML, bandingkan dua teks dengan perbandingan baris dan kata, kodekan dan dekodekan Base64, URL, entitas HTML, dan heksadesimal, serta ubah JSON menjadi YAML atau XML dan sebaliknya. Semuanya berjalan di peramban dan tidak ada yang diunggah."
+features = [
+  "Memformat dan memampatkan JSON, XML, HTML, dan CSS, serta merapikan YAML",
+  "Menjaga urutan kunci JSON dan digit persis setiap angka",
+  "Mengatakan sebuah galat ada di baris dan kolom mana, dengan kata-kata",
+  "Membandingkan dua teks dengan algoritma Myers, sisi demi sisi atau dalam satu kolom",
+  "Menandai kata yang berubah di dalam baris yang berubah",
+  "Mengunduh sebuah perbandingan sebagai tambalan terpadu yang bisa dibaca tinjauan kode",
+  "Base64 dalam kedua alfabet, pengodean persen, entitas HTML, heksadesimal, dan pelolosan garis miring terbalik",
+  "Mengubah JSON menjadi YAML dan XML, dan sebaliknya, sambil mengatakan setiap arah kehilangan apa",
+  "Membaca YAML 1.2, jadi yes dan no tetap string",
+  "Bekerja pada file yang dijatuhkan selain pada tempelan",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun",
+]
+
+[picker]
+title = "Jatuhkan sebuah file di sini"
+hint = "atau klik untuk menelusuri &mdash; file teks apa pun. Dua sekaligus, sambil membandingkan."

--- a/locales/id/tools/timelapse-video.html
+++ b/locales/id/tools/timelapse-video.html
@@ -1,0 +1,162 @@
+<!--
+  tools/timelapse-video/body.html, in Indonesian.
+
+  Every id, class, data-speed and option value below is what src/main.js
+  reaches for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <div class="preview-wrap" id="preview-wrap" hidden>
+      <video id="preview" playsinline controls muted></video>
+      <canvas id="still" hidden></canvas>
+    </div>
+    <p id="preview-note" class="path-note" hidden></p>
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Ukuran</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Bingkai</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Laju bingkai</dt><dd id="src-fps">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; kecepatannya -->
+  <section class="card" id="speed-card" hidden>
+    <h2><span class="step">2</span> Pilih kecepatannya</h2>
+
+    <div class="speed-row" role="group" aria-label="Seberapa jauh klipnya dipercepat">
+      <button type="button" data-speed="2">2&times;</button>
+      <button type="button" data-speed="5">5&times;</button>
+      <button type="button" data-speed="10" class="active">10&times;</button>
+      <button type="button" data-speed="20">20&times;</button>
+      <button type="button" data-speed="30">30&times;</button>
+      <button type="button" data-speed="60">60&times;</button>
+      <button type="button" data-speed="120">120&times;</button>
+      <button type="button" data-speed="300">300&times;</button>
+    </div>
+
+    <!--
+      Two ways of saying the same thing, because people arrive with one of two
+      questions: "speed this up thirty times" and "make this fit in twenty
+      seconds". Typing in either box fills in the other.
+    -->
+    <div class="numbers">
+      <label>Kecepatan
+        <span class="with-unit">
+          <input type="number" id="speed" min="1.1" max="1000" step="0.1" value="10">
+          <span class="unit">&times;</span>
+        </span>
+      </label>
+      <label>Durasi akhir
+        <span class="with-unit">
+          <input type="number" id="length" min="0.1" step="0.1">
+          <span class="unit">dtk</span>
+        </span>
+      </label>
+    </div>
+
+    <p class="interval-note" id="interval-note"></p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="fps">Diputar pada</label>
+        <select id="fps">
+          <option value="24">24 bingkai per detik</option>
+          <option value="30" selected>30 bingkai per detik</option>
+          <option value="60">60 bingkai per detik</option>
+        </select>
+        <p class="field-note">
+          Laju pemutaran klip yang sudah jadi. Ia tidak mengubah seberapa cepat
+          klipnya &mdash; itu kecepatan di atas &mdash; hanya seberapa halus
+          tampaknya.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="size">Ukuran</label>
+        <select id="size">
+          <option value="0" selected>Ukuran asli</option>
+          <option value="1080">1080p</option>
+          <option value="720">720p</option>
+          <option value="480">480p</option>
+        </select>
+        <p class="field-note" id="size-note">
+          Hanya diperkecil. Sebuah time-lapse biasanya ditonton dalam ukuran
+          kecil.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="quality">Kualitas</label>
+        <select id="quality">
+          <option value="low">File lebih kecil</option>
+          <option value="medium" selected>Seimbang</option>
+          <option value="high">Kualitas terbaik</option>
+        </select>
+        <p class="field-note">
+          Lebih tinggi daripada yang biasanya dibelanjakan alat video di sini,
+          karena bingkai berurutan sebuah time-lapse sedikit sekali kesamaannya
+          untuk dikompres.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; ekspor -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Buat time-lapse-nya</h2>
+
+    <dl class="summary" id="summary">
+      <div><dt>Bingkai yang disimpan</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Satu bingkai setiap</dt><dd id="sum-interval">&mdash;</dd></div>
+      <div><dt>Durasi akhir</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Bingkai keluaran</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Yang dibaca</dt><dd id="sum-read">&mdash;</dd></div>
+      <div><dt>Sekitar</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-note" class="path-note" hidden></p>
+
+    <p class="silent-note">
+      Hasilnya tidak bersuara. Ucapan dan musik yang dipercepat tiga puluh kali
+      bukan lagi ucapan dan musik, jadi tidak ada yang layak disimpan di sini
+      &mdash; dan membuangnya adalah alasan time-lapse dari satu jam keluar
+      sebagai beberapa megabyte.
+    </p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Buat time-lapse</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline loop></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh time-lapse</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/timelapse-video.toml
+++ b/locales/id/tools/timelapse-video.toml
@@ -1,0 +1,262 @@
+#
+# Pembuat Time-Lapse - Bahasa Indonesia.
+#
+# Overrides for tools/timelapse-video/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Time-lapse" tetap dalam bentuk Latinnya: itulah yang diketik orang di kotak
+# pencarian dan yang tertulis di menu kamera mereka.
+#
+
+name = "Pembuat Time-Lapse"
+heading = "Pembuat&nbsp;Time&#8209;Lapse <span class=\"h1-kw\">&mdash; percepat video panjang</span>"
+tagline = "Rekaman satu jam, dalam dua puluh detik."
+
+title = "Pembuat Video Time-Lapse &mdash; Gratis, Tanpa Unggah, Jalan Tanpa Internet"
+description = "Ubah video panjang menjadi time-lapse: 10x, 60x, atau kecepatan berapa pun yang Anda ketik. Berjalan di peramban Anda, jadi tidak ada yang diunggah, tidak ada tanda air, dan jalan tanpa internet."
+og_title = "Pembuat Time-Lapse &mdash; percepat video tanpa mengunggahnya"
+og_description = "Ambil satu bingkai setiap beberapa detik dari klip panjang dan tulis kembali sebagai klip pendek. File dibaca, didekode, dan dikodekan oleh peramban Anda sendiri."
+og_image_alt = "Pembuat Time-Lapse - percepat video panjang di peramban Anda, tanpa ada yang diunggah"
+
+pledge = """
+    Setiap bingkai dipilih, didekode, dan dikodekan lagi oleh peramban Anda
+    sendiri, di perangkat keras Anda sendiri. Tidak ada di sini yang bisa
+    mengambil atau mengirim apa pun &mdash; alat ini sama sekali tidak punya
+    fitur jaringan &mdash; dan seandainya pun ada, tidak ada server di ujung lain
+    halaman ini untuk menerima sebuah video."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu buat sebuah time-lapse. Tidak satu pun permintaan membawa bingkai,
+      nama file, atau satu byte pun dari yang Anda pilih. Atau cabut koneksi
+      internet dan tetap buat satu &mdash; alat yang mengirim video Anda ke
+      tempat lain untuk diproses akan langsung berhenti."""
+
+read_first = """
+, <code>src/plan.js</code> untuk aritmetika yang
+      memutuskan setiap bingkai berasal dari saat yang mana, dan
+      <code>src/decode.js</code> untuk perulangan yang hanya membaca bagian file
+      yang dibutuhkan saat-saat itu. Tidak satu pun mengimpor sesuatu yang bisa
+      membuat permintaan."""
+
+howto_heading = "Cara membuat time-lapse dari video"
+
+card = """
+            Ubah klip panjang menjadi klip pendek &mdash; berjam-jam menjadi
+            beberapa detik &mdash; tanpa mengirimnya ke mana pun."""
+
+[words]
+plural = "video"
+choose = "sebuah video"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Kecepatan berapa pun yang Anda ketik"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[privacy]]
+title = "Video Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Alat ini sama sekali tidak punya
+      fitur jaringan: tidak ada alamat untuk ditempelkan, tidak ada yang diunduh,
+      tidak ada mesin yang diambil saat pertama dipakai. Setiap byte yang
+      menyentuh video Anda datang dari asal ini ketika halaman dimuat."""
+
+[[privacy]]
+title = "Pendekodean dan pengodean berjalan lokal."
+body = """
+ Bingkainya melewati WebCodecs di
+      peramban Anda sendiri, atau melewati mesin pemutar yang sama yang toh akan
+      menampilkan klip itu kepada Anda. File yang sudah jadi dibangun di memori
+      mesin ini dan diserahkan langsung ke unduhan."""
+
+[[privacy]]
+title = "Sebagian besar file bahkan tidak pernah dibaca."
+body = """
+ Sebuah time-lapse butuh satu bingkai
+      setiap beberapa detik, jadi alat ini membaca deretan pendek file di sekitar
+      masing-masingnya dan melewati sisanya. Itu keputusan soal kecepatan, bukan
+      soal privasi, dan tetap layak diketahui: bahkan secara lokal, sebagian
+      besar video Anda tidak pernah dibuka."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang video Anda: bukan file,
+      bukan bingkai, bukan nama, ukuran, atau durasi. Setiap baris yang membaca,
+      mendekode, mengambil sampel, atau mengodekan disajikan dari asal ini dan
+      terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau video Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih sebuah video."
+body = """
+ Jatuhkan MP4, MOV, M4V, atau WebM ke
+      pemilih file, atau pilih sendiri. Peramban membacanya langsung dari disk
+      Anda; tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Sebutkan berapa kali lebih cepat."
+body = """
+ Tekan salah satu kecepatannya, atau
+      ketik sendiri. Kalau Anda lebih suka menyebutkan berapa lama hasilnya nanti
+      &mdash; &ldquo;buat ini muat dalam dua puluh detik&rdquo; &mdash; ketik itu
+      saja dan kecepatannya mengikuti."""
+
+[[howto]]
+title = "Periksa selangnya."
+body = """
+ Baris di bawah kecepatan mengatakan apa yang
+      sebenarnya akan dilakukan alat ini: satu bingkai setiap sekian detik dari
+      aslinya. Itulah angka yang akan diatur seorang fotografer di kameranya, dan
+      itulah yang layak diperiksa nalarnya sebelum Anda mulai."""
+
+[[howto]]
+title = "Buat dan unduh."
+body = """
+ Pekerjaannya terjadi di perangkat keras Anda
+      sendiri, jadi lamanya tergantung mesin Anda, bukan pada antrean. Video yang
+      sudah jadi diserahkan langsung ke unduhan peramban Anda."""
+
+[[faq]]
+q = "Apakah video saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca, didekode, diambil sampelnya, dan dikodekan oleh
+        peramban Anda sendiri di perangkat keras Anda sendiri. Alat ini tidak
+        punya sisi server, dan <code>Content-Security-Policy</code> halaman ini
+        menyebut satu per satu setiap alamat yang boleh dihubunginya &mdash;
+        tidak satu pun milik situs ini. Cabut koneksi internet dan tetap buat
+        sebuah time-lapse kalau Anda lebih suka memeriksa daripada diberi
+        tahu."""
+
+[[faq]]
+q = "Apa sebenarnya arti kecepatannya?"
+a = """
+        Rasio antara yang masuk dan yang keluar. Pada 60&times;, rekaman satu jam
+        menjadi satu menit, pada laju bingkai berapa pun Anda memutarnya. Di
+        baliknya, alat ini mengambil satu bingkai setiap <em>kecepatan &divide;
+        laju bingkai</em> detik &mdash; 60&times; pada 30 bingkai per detik
+        berarti satu bingkai setiap dua detik &mdash; dan halaman ini menampilkan
+        selang itu sebelum Anda mulai, karena itulah angka yang mengatakan apa
+        yang sebenarnya terjadi."""
+
+[[faq]]
+q = "Format video apa saja yang bisa saya percepat?"
+a = """
+        MP4, M4V, dan MOV dibaca langsung, apa pun isinya: H.264, HEVC, AV1, atau
+        VP9, selama peramban Anda bisa mendekode kodek itu. Apa pun lain yang
+        bisa diputar peramban Anda &mdash; yang paling jelas WebM &mdash; dibaca
+        dengan mencari posisi pemutar peramban sendiri ke setiap saat, yang
+        berhasil pada setiap format yang bisa diputarnya. File yang tidak bisa
+        dibaca maupun diputar peramban, yang dalam praktiknya berarti AVI, WMV,
+        FLV, dan sebagian besar MKV, ditolak dengan pesan alih-alih gagal di
+        tengah jalan. Yang keluar selalu berupa MP4."""
+
+[[faq]]
+q = "Kenapa time-lapse-nya tidak bersuara?"
+a = """
+        Karena tidak ada yang layak disimpan. Suara yang diputar tiga puluh kali
+        terlalu cepat bukan ucapan atau musik, melainkan cicitan; dan
+        alternatifnya &mdash; menjaga suara pada kecepatan aslinya di bawah
+        gambar yang sudah melesat jauh mendahuluinya &mdash; akan menjadi klip
+        yang berbeda dari yang Anda minta. Jadi jalurnya dibuang, yang juga
+        merupakan sebagian besar alasan video satu jam keluar sebagai beberapa
+        megabyte. Kalau Anda mau audionya sendiri,
+        <a href="../sunting-audio/">Penyunting Audio</a> akan menyimpannya."""
+
+[[faq]]
+q = "Apakah lebih cepat daripada mengubah seluruh videonya?"
+a = """
+        Jauh lebih cepat, dan itulah gunanya membaca file secara langsung. Sebuah
+        bingkai hanya bisa didekode dengan mulai dari bingkai kunci di depannya,
+        tapi tidak ada yang mengharuskan bingkai di antaranya disimpan &mdash;
+        jadi time-lapse 60&times; dari satu jam mendekode beberapa ribu bingkai
+        dari seratus ribu, bukan semuanya. Ringkasannya mengatakan persis berapa
+        banyak yang akan dibacanya sebelum Anda menekan tombolnya."""
+
+[[faq]]
+q = "Apakah kualitasnya turun?"
+a = """
+        Bingkai yang disimpannya dikodekan untuk kedua kalinya, dan itu memakan
+        sedikit; hal itu tidak bisa dihindari, karena klip yang sudah jadi
+        menampilkannya pada waktu yang tidak pernah dikodekan oleh apa pun di
+        file aslinya. Yang justru dibelanjakan alat ini lebih banyak daripada
+        alat video lain di sini adalah bit rate-nya, dengan sengaja. Dua bingkai
+        berjarak dua detik jauh lebih sedikit kesamaannya daripada dua bingkai
+        berjarak sepertiga puluh detik, jadi kodek punya lebih sedikit yang bisa
+        dipakai ulang, dan angka yang disetel untuk rekaman biasa akan keluar
+        kotak-kotak."""
+
+[[faq]]
+q = "Adakah batas ukuran atau durasi videonya?"
+a = """
+        Tidak ada batas yang tertanam di alat ini, dan file tidak dibaca ke
+        memori sekaligus &mdash; ia dibaca dalam deretan pendek di sekitar setiap
+        saat, dan hanya itu. Batas praktisnya adalah time-lapse yang sudah jadi,
+        yang dirakit di memori sebelum Anda mengunduhnya, dan sebuah time-lapse
+        menurut definisinya pendek: ringkasannya menunjukkan kira-kira seberapa
+        besar ia nanti sebelum Anda mulai."""
+
+[[faq]]
+q = "Bisakah saya mempercepat hanya sebagian klip?"
+a = """
+        Tidak di sini. Alat ini mengambil keseluruhannya dari bingkai pertama
+        sampai terakhir. Potong dulu bagian yang Anda mau dengan
+        <a href="../potong-video/">Pemotong Video</a> &mdash; yang melakukannya
+        tanpa mengodekan ulang satu bingkai pun &mdash; lalu percepat
+        hasilnya."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang video Anda."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript dan peramban dengan pengodean video WebCodecs: Chrome, Edge, Safari 16.4 atau lebih baru, atau Firefox 133 atau lebih baru."
+description = "Ubah video panjang menjadi time-lapse di peramban. Satu bingkai diambil setiap beberapa detik dari aslinya dan bingkainya ditulis kembali sebagai MP4 pendek pada 24, 30, atau 60 bingkai per detik. MP4, MOV, dan M4V dibaca langsung dan hanya di sekitar saat-saat yang dibutuhkan; apa pun lain yang bisa diputar peramban dicari posisinya. Tidak ada yang diunggah."
+features = [
+  "Mempercepat video MP4, MOV, M4V, dan WebM dengan faktor apa pun dari 1,1x sampai 1000x",
+  "Sebutkan kecepatannya, atau sebutkan berapa lama hasilnya nanti",
+  "Hanya membaca bagian file yang dibutuhkan saat-saat yang dipilih",
+  "24, 30, atau 60 bingkai per detik, pada ukuran asli atau diperkecil",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan video di sini"
+hint = "atau klik untuk menelusuri &mdash; MP4, MOV, M4V, WebM, dan apa pun lain yang bisa diputar peramban ini"

--- a/locales/id/tools/trim-audio.html
+++ b/locales/id/tools/trim-audio.html
@@ -1,0 +1,207 @@
+<!--
+  tools/trim-audio/body.html, in Indonesian.
+
+  Every id, class, data-speed and option value below is what src/main.js,
+  src/segments.js and src/timeline.js reach for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; rekamannya -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah rekaman</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Ukuran</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Suara</dt><dd id="src-format">&mdash;</dd></div>
+      <div><dt>Dibaca sebagai</dt><dd id="src-rate">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; penanda -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> Tandai bagian yang Anda mau
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Putar sampai selesai dan tekan <kbd>I</kbd> di tempat sebuah bagian harus
+      dimulai dan <kbd>O</kbd> di tempat ia harus berakhir. Lakukan sebanyak yang
+      Anda mau &mdash; setiap pasangan menjadi satu baris di bawah, dan file yang
+      sudah jadi adalah baris-baris itu, satu demi satu. <kbd>U</kbd> membatalkan
+      yang terakhir, <kbd>Space</kbd> memutar dan menjeda, dan tombol panah
+      melompat lima detik. Tahan <kbd>Shift</kbd> bersama panah untuk bergeser
+      sepuluh milidetik sekali tekan.
+    </p>
+
+    <!-- Built by src/timeline.js: the waveform, a band for every part, the one
+         being marked, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <audio id="preview" class="player" controls preload="metadata"></audio>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Putar</button>
+      <button type="button" id="back-5" class="ghost" title="Mundur lima detik">&minus;5d</button>
+      <button type="button" id="forward-5" class="ghost" title="Maju lima detik">+5d</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Tandai awal</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Tandai akhir</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Batalkan</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Kecepatan pemutaran">
+      <span class="speed-label">Kecepatan</span>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normal</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The parts themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Bagian <span class="segment-count" id="segment-count">belum ada</span></h3>
+        <p class="segments-total">
+          Total tersimpan <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">#</th>
+            <th scope="col">Mulai</th>
+            <th scope="col">Selesai</th>
+            <th scope="col">Durasi</th>
+            <th scope="col"><span class="visually-hidden">Tindakan</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Belum ada yang ditandai. Tekan <kbd>I</kbd> lalu <kbd>O</kbd> sambil
+        diputar, atau pakai tombol di atas.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Tambah baris secara manual</button>
+        <button type="button" id="reset-segments" class="ghost danger">Bersihkan semuanya</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">Muat penanda&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Format file stempel waktu">
+          <option value="seconds" selected>detik</option>
+          <option value="HHMMSSmmm">HH:MM:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">Simpan penanda</button>
+      </div>
+
+      <p class="field-note">
+        Penanda disimpan sebagai file teks biasa &mdash; satu baris satu bagian,
+        dengan format di atas &mdash; jadi sesi penandaan yang panjang selamat
+        dari tab yang tertutup, dan file yang sama bisa diserahkan ke pemotong
+        video atau ke alat lain mana pun yang membaca tata letak itu.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>Apa yang dilakukan pada bagian yang ditandai</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Simpan bagian itu</strong>
+          File yang sudah jadi adalah bagian yang ditandai, digabungkan berurutan.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Buang yang ditandai</strong>
+          Bagian yang ditandai hilang, dan semua sisanya digabungkan.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Langkah 3 &mdash; file yang keluar -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Potong</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="depth">Apa yang ditulis</label>
+        <select id="depth">
+          <option value="16" selected>WAV 16-bit &mdash; bisa diputar di mana-mana</option>
+          <option value="32">WAV float 32-bit &mdash; persis sampelnya</option>
+        </select>
+        <p class="field-note">
+          Sebuah WAV memuat sampelnya apa adanya, jadi menulisnya tidak mungkin
+          memakan kualitas. Ia bukan file kecil: lihat perkiraan di bawah.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="fade">Lembutkan sambungannya</label>
+        <select id="fade">
+          <option value="0">Mati &mdash; potong pada sampel yang persis</option>
+          <option value="0.005" selected>5 md &mdash; cukup untuk menghentikan bunyi klik</option>
+          <option value="0.02">20 md</option>
+          <option value="0.05">50 md</option>
+        </select>
+        <p class="field-note" id="fade-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Yang disimpan</dt><dd id="sum-parts">&mdash;</dd></div>
+      <div><dt>Durasi akhir</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Mulai pada</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>Sambungan</dt><dd id="sum-joins">&mdash;</dd></div>
+      <div><dt>Suara</dt><dd id="sum-sound">&mdash;</dd></div>
+      <div><dt>Kira-kira</dt><dd id="sum-size">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Potong audio</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <canvas id="out-wave" class="wave" aria-hidden="true"></canvas>
+      <audio id="result-audio" class="player" controls></audio>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh audio</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/trim-audio.toml
+++ b/locales/id/tools/trim-audio.toml
@@ -1,0 +1,329 @@
+#
+# Pemotong Audio - Bahasa Indonesia.
+#
+# Overrides for tools/trim-audio/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Pemotong Audio"
+heading = "Pemotong&nbsp;Audio <span class=\"h1-kw\">&mdash; potong audio daring</span>"
+tagline = "Tandai bagian yang layak disimpan sambil diputar. Dapatkan kembali sebagai satu file, dipotong di tempat yang Anda sebutkan."
+
+title = "Potong Audio Daring &mdash; Simpan Hanya Bagian yang Anda Mau, Tanpa Unggah"
+description = "Putar sebuah rekaman dan tandai setiap bagian yang layak disimpan sambil berjalan, lalu simpan bagian-bagian itu sebagai satu file. Potongan persis pada sampel, tanpa bunyi klik di sambungannya, tidak ada yang diunggah."
+og_title = "Pemotong Audio &mdash; simpan hanya bagian yang Anda mau, tanpa mengunggah apa pun"
+og_description = "Tekan I dan O sambil diputar untuk menandai setiap bagian yang layak disimpan. Bagian yang ditandai ditulis kembali sebagai satu file, dipotong pada sampel yang persis, tanpa ada yang diunggah."
+og_image_alt = "Pemotong Audio - tandai bagian yang Anda mau dan simpan sebagai satu rekaman, di peramban Anda"
+
+pledge = """
+    Rekaman Anda dibaca, ditandai, dipotong, dan ditulis oleh peramban Anda
+    sendiri, di perangkat keras Anda sendiri. Tidak ada di sini yang bisa
+    mengambil atau mengirim apa pun &mdash; alat ini sama sekali tidak punya
+    fitur jaringan &mdash; dan seandainya pun ada, tidak ada server di ujung lain
+    halaman ini untuk menerima sebuah rekaman."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu potong sesuatu. Tidak satu pun permintaan membawa sampel, nama file,
+      atau satu byte pun dari yang Anda pilih. Atau cabut koneksi internet dan
+      tetap potong sebuah rekaman &mdash; alat yang mengirim audio Anda ke tempat
+      lain untuk dipotong akan langsung berhenti."""
+
+read_first = """
+, <code>src/segments.js</code> untuk penanda dan file
+      tempat menyimpannya, <code>src/decode.js</code> untuk dua puluh baris yang
+      menyerahkan file Anda ke dekoder milik peramban sendiri,
+      <code>src/trim.js</code> untuk aritmetika yang mengubah sebuah penanda
+      menjadi deretan sampel beserta perulangan yang menyalinnya, dan
+      <code>src/wav.js</code> untuk header yang dipasang di depannya. Tidak satu
+      pun mengimpor sesuatu yang bisa membuat permintaan."""
+
+howto_heading = "Cara memotong file audio"
+
+card = """
+            Tandai setiap bagian yang layak disimpan sambil diputar, lalu simpan
+            sebagai satu rekaman. Potongannya mendarat pada sampel yang persis,
+            dan sambungannya tidak berbunyi klik."""
+
+[words]
+plural = "rekaman"
+choose = "sebuah rekaman"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Sebanyak apa pun bagiannya"
+
+[[facts]]
+text = "Memotong persis di tempat yang Anda tandai"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[privacy]]
+title = "Rekaman Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Alat ini sama sekali tidak punya
+      fitur jaringan: tidak ada alamat untuk ditempelkan, tidak ada yang diunduh,
+      tidak ada mesin yang diambil saat pertama dipakai. Setiap byte yang
+      menyentuh audio Anda datang dari asal ini ketika halaman dimuat."""
+
+[[privacy]]
+title = "Dekodernya adalah yang sudah ada di peramban Anda."
+body = """
+ File diserahkan ke
+      <code>decodeAudioData</code>, kode yang sama yang memutar sebuah lagu di
+      elemen <code>&lt;audio&gt;</code>. Tidak ada yang dikirim ke sini untuk
+      membaca format Anda, dan tidak ada yang diminta dari apa pun di luar
+      halaman ini untuk membacanya."""
+
+[[privacy]]
+title = "Gambar sebuah video tidak pernah didekode sama sekali."
+body = """
+ Ketika Anda menjatuhkan sebuah video,
+      hanya jalur audionya yang diminta. Bingkainya tidak dibaca, tidak didekode,
+      tidak digambar, dan tidak dilihat &mdash; tidak ada kode di halaman ini
+      yang bisa, dan file yang keluar memuat suara dan tidak lebih."""
+
+[[privacy]]
+title = "Potongannya adalah penyalinan, di memori, di mesin ini."
+body = """
+ Memotong adalah satu <code>set</code> per
+      bagian per kanal: sampel yang Anda simpan dipindahkan ke larik baru dalam
+      urutan yang Anda tetapkan. Satu-satunya sampel yang dikalikan sesuatu
+      adalah beberapa ratus di dalam setiap peredupan, dan halaman ini
+      mengatakan berapa banyak sebelum Anda menekan tombolnya."""
+
+[[privacy]]
+title = "Sampelnya dituliskan, bukan dikodekan lagi."
+body = """
+ Sebuah WAV adalah sampel yang dimuat
+      halaman ini dengan header di depannya. Tidak ada encoder dalam
+      perulangannya yang mengambil keputusan tentang rekaman Anda, dan tidak ada
+      yang bisa disebut unggahan untuk membuat hal itu terjadi."""
+
+[[privacy]]
+title = "File penanda dibuat di dalam halaman."
+body = """
+ Menyimpan penanda Anda menulis sebuah
+      file teks dari angka-angka yang sudah ada di layar, langsung ke unduhan
+      Anda. Memuatnya membacanya di sini. Tidak satu pun mendekati jaringan, dan
+      tidak satu pun membawa apa pun selain waktu."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang rekaman Anda: bukan
+      file, bukan sampel, bukan nama, ukuran, durasi, atau di mana Anda
+      memotongnya. Setiap baris yang membaca, memotong, dan menulis disajikan
+      dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau rekaman Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih sebuah rekaman."
+body = """
+ Jatuhkan file MP3, WAV, FLAC, M4A, Ogg,
+      atau Opus ke pemilih file &mdash; atau sebuah video, kalau yang Anda mau
+      adalah sepotong suaranya. Peramban membacanya langsung dari disk Anda dan
+      menggambarnya sebagai bentuk gelombang; tidak ada yang dikirim ke mana pun
+      saat Anda melakukannya."""
+
+[[howto]]
+title = "Putar, dan tandai bagian yang Anda mau."
+body = """
+ Tekan <kbd>I</kbd> di tempat sebuah
+      bagian harus dimulai dan <kbd>O</kbd> di tempat ia harus berakhir. Lakukan
+      sebanyak yang Anda mau &mdash; setiap pasangan menjadi satu baris di tabel
+      di bawahnya, dan satu pita di bentuk gelombangnya. <kbd>U</kbd> menarik
+      kembali yang terakhir, <kbd>Space</kbd> memutar dan menjeda, tombol panah
+      melompat lima detik, dan menahan <kbd>Shift</kbd> bersamanya menggeser
+      sepuluh milidetik. Perlambat pemutarannya kalau momennya sulit
+      ditangkap."""
+
+[[howto]]
+title = "Rapikan penandanya."
+body = """
+ Setiap baris bisa diputar sendiri, diatur
+      ulang waktunya dengan mengetikkan waktu yang persis, dipindahkan naik atau
+      turun urutannya, atau dihapus. Kedua ujung bagian yang terpilih juga bisa
+      diseret di sepanjang bentuk gelombangnya, dan itu cara tercepat menempatkan
+      penanda pada keheningan alih-alih pada tarikan napas sebelumnya. Total di
+      bagian atas adalah durasi rekaman yang sudah jadi nanti."""
+
+[[howto]]
+title = "Simpan bagian itu, atau buang."
+body = """
+ Menyimpan adalah cara yang biasa:
+      rekaman yang sudah jadi adalah bagian yang Anda tandai, digabungkan
+      berurutan. Membuangnya adalah pekerjaan lain yang diinginkan orang dan
+      jarang ditemukan &mdash; tandai "eee"-nya, telepon yang berdering, atau
+      awal yang gagal, dan sisanya digabungkan tanpa itu semua."""
+
+[[howto]]
+title = "Potong, dan unduh."
+body = """
+ Setiap potongan mendarat pada sampel yang Anda
+      tandai; tidak ada pembulatan ke bingkai kunci di sini, karena suara tidak
+      punya bingkai kunci. Satu-satunya yang layak dipilih adalah seberapa banyak
+      peredupan yang dipasang di setiap sambungan &mdash; lima milidetik cukup
+      untuk menghentikan bunyi klik dan jauh terlalu pendek untuk terdengar
+      sebagai peredupan. Yang keluar adalah sebuah WAV, diputar dulu di halaman
+      ini, lalu diserahkan langsung ke unduhan peramban Anda."""
+
+[[faq]]
+q = "Apakah audio saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca, ditandai, dipotong, dan ditulis oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya sisi
+        server, dan <code>Content-Security-Policy</code> halaman ini menyebut
+        satu per satu setiap alamat yang boleh dihubunginya &mdash; tidak satu
+        pun milik situs ini. Cabut koneksi internet dan tetap potong sebuah
+        rekaman kalau Anda lebih suka memeriksa daripada diberi tahu."""
+
+[[faq]]
+q = "Bisakah saya menyimpan beberapa bagian dari rekaman yang sama?"
+a = """
+        Justru untuk itulah alat ini. Tekan <kbd>I</kbd> dan <kbd>O</kbd>
+        sebanyak yang Anda mau sambil diputar; setiap pasangan menjadi satu
+        baris, dan file yang sudah jadi adalah semua baris digabungkan berurutan
+        dengan segala yang lain hilang. Kebanyakan pemotong daring memberi Anda
+        satu pasang pegangan dan bertanya rentang tunggal mana yang disimpan,
+        yang cukup untuk merapikan awal dan akhir sebuah jingle dan sama sekali
+        tidak berguna untuk mendengarkan wawancara satu jam sekali lalu menyimpan
+        enam jawaban yang layak."""
+
+[[faq]]
+q = "Apakah potongannya mendarat persis di tempat yang saya tandai?"
+a = """
+        Ya, pada setiap bagian, di setiap pemutar. Inilah satu tempat di mana
+        audio lebih sederhana daripada video: rekaman yang sudah didekode adalah
+        deretan angka dan masing-masing berdiri sendiri, jadi tidak ada padanan
+        bingkai kunci untuk dibulatkan dan tidak ada alasan sebuah potongan mulai
+        lebih awal. Halaman ini menampilkan nomor sampel tempat hasilnya dimulai,
+        yaitu penanda yang Anda buat dikalikan laju sampel dan dibulatkan ke
+        sampel utuh terdekat."""
+
+[[faq]]
+q = "Kenapa sebuah sambungan bisa berbunyi klik, dan untuk apa peredupannya?"
+a = """
+        Karena memotong dari tengah satu kata ke tengah kata lain menempatkan dua
+        bentuk gelombang yang tidak berhubungan berdampingan, dan pengeras suara
+        yang diminta melompat di antara keduanya menghasilkan bunyi klik. Itu
+        bukan kesalahan potongannya &mdash; begitulah bunyi sebuah ketidak-
+        sinambungan. Perbaikannya adalah peredupan beberapa milidetik di kedua
+        sisi setiap sambungan: cukup panjang bagi konusnya untuk sampai, jauh
+        terlalu pendek untuk terdengar sebagai peredupan. Lima milidetik adalah
+        bawaannya dan bisa dimatikan. Peredupan hanya dipasang pada tepi yang
+        memang sebuah potongan, jadi tepi di paling awal atau paling akhir
+        rekaman dibiarkan persis seperti adanya."""
+
+[[faq]]
+q = "Bisakah saya membuang bagian yang jeleknya saja?"
+a = """
+        Bisa. Tandai bagian itu, lalu pilih "Buang yang ditandai": semua yang
+        <em>tidak</em> Anda tandai yang digabungkan, berurutan. Daftar penanda
+        yang sama menjawab kedua pertanyaan, jadi Anda bisa berpindah di antara
+        keduanya dan melihat durasinya berubah tanpa menandai apa pun dua
+        kali."""
+
+[[faq]]
+q = "Bisakah saya menyimpan penanda saya dan kembali lagi nanti?"
+a = """
+        Bisa. "Simpan penanda" menulis sebuah file teks biasa &mdash; satu baris
+        satu bagian, awal dan akhir dipisahkan koma &mdash; dan "Muat penanda"
+        membacanya kembali. Dua format ditawarkan, detik biasa dan
+        <code>HH:MM:SS.mmm</code>, dan keduanya adalah tata letak yang ditulis
+        pemotong video di situs ini, jadi file yang dibuat terhadap videonya bisa
+        dijatuhkan ke audionya dan sebaliknya. Menandai adalah pekerjaan yang
+        butuh ketelitian dan tidak ada yang seharusnya melakukannya dua kali."""
+
+[[faq]]
+q = "Format apa saja yang bisa saya buka?"
+a = """
+        Apa pun yang bisa didekode peramban Anda, yang dalam praktiknya berarti
+        MP3, WAV, FLAC, M4A dan AAC, Ogg Vorbis dan Opus, serta audio di dalam
+        video MP4, M4V, MOV, dan WebM. Yang tertinggal adalah daftar pendek yang
+        sama seperti di tempat lain: AVI, WMA, dan sebagian besar MKV. File yang
+        tidak mau dibaca peramban ini ditolak dengan pesan, alih-alih gagal di
+        tengah jalan."""
+
+[[faq]]
+q = "Kenapa ia menyimpan WAV alih-alih MP3?"
+a = """
+        Karena tidak ada peramban yang menyertakan encoder MP3, dan alat ini
+        menolak mengirim rekaman Anda ke server yang punya. Sebuah WAV sama
+        sekali tidak butuh encoder &mdash; ia adalah sampel dengan header pendek
+        di depannya &mdash; jadi ia sekaligus pilihan yang jujur dan satu-satunya
+        yang tidak mungkin memakan kualitas saat keluar. Ukurannya lebih besar:
+        sekitar sepuluh megabyte per menit dalam stereo. Setiap pemutar, ponsel,
+        dan penyunting bisa membukanya, dan apa pun yang mau MP3 bisa membuatnya
+        dari situ. Memotong MP3 dengan menyalin bingkainya justru akan menjaga
+        file tetap kecil, tapi juga akan memindahkan setiap potongan ke batas
+        bingkai terdekat, dan pembulatan itulah yang justru tidak ingin dilakukan
+        alat ini."""
+
+[[faq]]
+q = "Adakah batas durasi rekamannya?"
+a = """
+        Tidak ada batas yang tertanam di alat ini. Batas praktisnya adalah
+        memori: seluruh rekaman didekode ke halaman ini sekaligus, dan sebuah WAV
+        dirakit di memori sebelum Anda mengunduhnya, jadi satu jam stereo
+        membutuhkan ruang kerja sedikit di bawah satu gigabyte. WAV empat
+        gigabyte ditolak mentah-mentah, karena kolom ukuran milik formatnya
+        sendiri tidak bisa menggambarkannya."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang rekaman Anda."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript dan peramban dengan Web Audio, yang berarti setiap peramban masa kini. Tidak butuh dukungan kodek melebihi yang sudah dimiliki peramban untuk memutar file itu."
+description = "Tandai sebanyak apa pun bagian sebuah rekaman sambil diputar, lalu simpan bagian-bagian itu sebagai satu file - atau buang bagian itu dan simpan sisanya. Potongan mendarat pada sampel persis yang ditandai, dengan peredupan beberapa milidetik opsional agar sambungannya tidak berbunyi klik. Tidak ada yang diunggah dan hasilnya ditulis sebagai WAV, jadi tidak ada yang dikodekan ulang."
+features = [
+  "Menandai sebanyak apa pun bagian dengan I dan O sambil rekaman diputar",
+  "Menggabungkan bagian yang ditandai menjadi satu file, dalam urutan yang Anda pilih",
+  "Atau membuang bagian yang ditandai dan menyimpan semua sisanya",
+  "Memotong pada sampel yang persis, tanpa pembulatan ke bingkai atau bingkai kunci",
+  "Meredupkan setiap sambungan beberapa milidetik supaya tidak mungkin berbunyi klik",
+  "Menggambar bentuk gelombangnya, jadi keheningan dan jeda bisa ditandai dengan mata",
+  "Menyimpan dan memuat kembali penanda sebagai file teks biasa berisi stempel waktu",
+  "Memotong audio di dalam MP4, MOV, atau WebM tanpa menyentuh gambarnya",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan file audio atau video di sini"
+hint = "atau klik untuk menelusuri &mdash; MP3, WAV, FLAC, M4A, Ogg, dan suara di dalam MP4, MOV, atau WebM"

--- a/locales/id/tools/trim-video.html
+++ b/locales/id/tools/trim-video.html
@@ -1,0 +1,232 @@
+<!--
+  tools/trim-video/body.html, in Indonesian.
+
+  Every id, class, data-speed and option value below is what src/main.js,
+  src/segments.js and src/timeline.js reach for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; video -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <!-- One row a video, in the order they will be joined. Hidden until there
+         is more than one, because a list of one is furniture. -->
+    <ol class="clip-list" id="clip-list" hidden></ol>
+
+    <p id="join-note" class="path-note" hidden></p>
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; penanda -->
+  <section class="card" id="section-card" hidden>
+    <h2>
+      <span class="step">2</span> Tandai bagian yang Anda mau
+      <span class="editing" id="editing" hidden></span>
+    </h2>
+
+    <p class="stage-hint">
+      Putar sampai selesai dan tekan <kbd>I</kbd> di tempat sebuah bagian harus
+      dimulai dan <kbd>O</kbd> di tempat ia harus berakhir. Lakukan sebanyak yang
+      Anda mau &mdash; setiap pasangan menjadi satu baris di bawah, dan video yang
+      sudah jadi adalah baris-baris itu, satu demi satu. <kbd>U</kbd> membatalkan
+      yang terakhir, <kbd>Space</kbd> memutar dan menjeda, dan tombol panah
+      melompat lima detik.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- Built by src/timeline.js: a band for every segment, the one being
+         marked, a tick for every keyframe, and the playhead. -->
+    <div id="timeline"></div>
+
+    <div class="tl-scale">
+      <span id="tl-now">0:00.000</span>
+      <span id="tl-total">0:00.000</span>
+    </div>
+
+    <div class="transport">
+      <button type="button" id="play" class="primary">Putar</button>
+      <button type="button" id="back-5" class="ghost" title="Mundur lima detik">&minus;5d</button>
+      <button type="button" id="forward-5" class="ghost" title="Maju lima detik">+5d</button>
+      <button type="button" id="mark-in" class="ghost"><kbd>I</kbd> Tandai awal</button>
+      <button type="button" id="mark-out" class="ghost"><kbd>O</kbd> Tandai akhir</button>
+      <button type="button" id="undo" class="ghost"><kbd>U</kbd> Batalkan</button>
+    </div>
+
+    <div class="speed-row" role="group" aria-label="Kecepatan pemutaran">
+      <span class="speed-label">Kecepatan</span>
+      <button type="button" class="speed" data-speed="0.25">0,25&times;</button>
+      <button type="button" class="speed" data-speed="0.5">0,5&times;</button>
+      <button type="button" class="speed" data-speed="0.75">0,75&times;</button>
+      <button type="button" class="speed active" data-speed="1">Normal</button>
+      <button type="button" class="speed" data-speed="1.25">1,25&times;</button>
+      <button type="button" class="speed" data-speed="1.5">1,5&times;</button>
+      <button type="button" class="speed" data-speed="2">2&times;</button>
+    </div>
+
+    <!-- The segments themselves. This is the tool. -->
+    <div class="segments">
+      <div class="segments-head">
+        <h3>Segmen <span class="segment-count" id="segment-count">belum ada</span></h3>
+        <p class="segments-total">
+          Total tersimpan <strong id="total-kept">0:00.000</strong>
+        </p>
+      </div>
+
+      <table class="segment-table" id="segment-table" hidden>
+        <thead>
+          <tr>
+            <th scope="col" class="col-index">#</th>
+            <th scope="col">Mulai</th>
+            <th scope="col">Selesai</th>
+            <th scope="col">Durasi</th>
+            <th scope="col"><span class="visually-hidden">Tindakan</span></th>
+          </tr>
+        </thead>
+        <tbody id="segment-rows"></tbody>
+      </table>
+
+      <p class="segments-empty" id="segments-empty">
+        Belum ada yang ditandai. Tekan <kbd>I</kbd> lalu <kbd>O</kbd> sambil
+        diputar, atau pakai tombol di atas.
+      </p>
+
+      <div class="segment-actions">
+        <button type="button" id="add-segment" class="ghost">Tambah baris secara manual</button>
+        <button type="button" id="reset-segments" class="ghost danger">Bersihkan semuanya</button>
+        <span class="segment-actions-spacer"></span>
+        <button type="button" id="import-marks" class="ghost">Muat penanda&hellip;</button>
+        <input type="file" id="marks-input" accept=".txt,text/plain" class="visually-hidden">
+        <select id="marks-format" aria-label="Format file stempel waktu">
+          <option value="seconds" selected>detik</option>
+          <option value="HHMMSSmmm">HH:MM:SS.mmm</option>
+        </select>
+        <button type="button" id="export-marks" class="ghost">Simpan penanda</button>
+      </div>
+
+      <p class="field-note">
+        Penanda disimpan sebagai file teks biasa &mdash; satu baris satu segmen,
+        dengan format di atas &mdash; jadi sesi penandaan yang panjang selamat
+        dari tab yang tertutup, dan file yang sama bisa diserahkan ke alat mana
+        pun yang membaca tata letak itu.
+      </p>
+    </div>
+
+    <fieldset class="modes">
+      <legend>Apa yang dilakukan pada bagian yang ditandai</legend>
+      <label class="mode">
+        <input type="radio" name="mode" value="keep" checked>
+        <span>
+          <strong>Simpan bagian itu</strong>
+          Video yang sudah jadi adalah bagian yang ditandai, digabungkan berurutan.
+        </span>
+      </label>
+      <label class="mode">
+        <input type="radio" name="mode" value="cut">
+        <span>
+          <strong>Buang yang ditandai</strong>
+          Bagian yang ditandai hilang, dan semua sisanya digabungkan.
+        </span>
+      </label>
+    </fieldset>
+  </section>
+
+  <!-- Langkah 3 &mdash; ekspor -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Potong</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="method">Cara memotongnya</label>
+        <select id="method">
+          <option value="copy" selected>Simpan setiap byte &mdash; tidak ada yang dikodekan ulang</option>
+          <option value="exact">Potong tepat di sini &mdash; mengodekan ulang gambarnya</option>
+          <option value="record">Rekam sambil diputar</option>
+        </select>
+        <p class="field-note" id="method-note"></p>
+      </div>
+
+      <div class="field" id="frame-field" hidden>
+        <label for="frame">Ukuran bingkai</label>
+        <select id="frame">
+          <option value="first" selected>Ikuti video pertama</option>
+          <option value="largest">Ikuti yang terbesar</option>
+          <option value="1080p">1920 &times; 1080</option>
+          <option value="720p">1280 &times; 720</option>
+        </select>
+        <p class="field-note">
+          Satu ukuran berlaku untuk seluruh file. Video dengan bentuk lain
+          dipaskan di dalamnya dengan bilah hitam, tidak pernah diregangkan.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kualitas</label>
+        <select id="quality">
+          <option value="low">File lebih kecil</option>
+          <option value="medium" selected>Seimbang</option>
+          <option value="high">Kualitas terbaik</option>
+        </select>
+        <p class="field-note">
+          Tidak pernah lebih dari yang dibelanjakan aslinya &mdash; mengodekan di
+          atas itu hanya membuat file lebih besar.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="keep-audio">
+          <input type="checkbox" id="keep-audio" checked>
+          Simpan suaranya
+        </label>
+        <p class="field-note" id="audio-note"></p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Yang disimpan</dt><dd id="sum-clips">&mdash;</dd></div>
+      <div><dt>Durasi akhir</dt><dd id="sum-length">&mdash;</dd></div>
+      <div><dt>Mulai pada</dt><dd id="sum-start">&mdash;</dd></div>
+      <div><dt>Kira-kira</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Gambar</dt><dd id="sum-picture">&mdash;</dd></div>
+      <div><dt>Suara</dt><dd id="sum-sound">&mdash;</dd></div>
+    </dl>
+
+    <p id="cut-note" class="path-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Potong video</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <video id="result-video" controls playsinline></video>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh video</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/trim-video.toml
+++ b/locales/id/tools/trim-video.toml
@@ -1,0 +1,322 @@
+#
+# Pemotong Video - Bahasa Indonesia.
+#
+# Overrides for tools/trim-video/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Potong" di sini berarti memendekkan durasi; mengubah bentuk gambar adalah
+# "pangkas" dan itu alat yang berbeda.
+#
+
+name = "Pemotong Video"
+heading = "Pemotong&nbsp;Video <span class=\"h1-kw\">&mdash; potong video daring</span>"
+tagline = "Tandai bagian yang layak disimpan sambil diputar. Dapatkan kembali sebagai satu video."
+
+title = "Potong Video Daring &mdash; Simpan Hanya Bagian yang Anda Mau, Tanpa Unggah"
+description = "Tonton sebuah video dan tandai setiap bagian yang layak disimpan sambil diputar, lalu simpan bagian-bagian itu sebagai satu file. Berjalan di peramban Anda: tidak ada yang diunggah, tidak ada yang dikodekan ulang, jalan tanpa internet."
+og_title = "Pemotong Video &mdash; simpan hanya bagian yang Anda mau, tanpa mengunggah apa pun"
+og_description = "Tekan I dan O sambil diputar untuk menandai setiap bagian yang layak disimpan. Bagian yang ditandai ditulis kembali sebagai satu video, bingkai demi bingkai, tanpa ada yang diunggah."
+og_image_alt = "Pemotong Video - tandai bagian yang Anda mau dan simpan sebagai satu video, di peramban Anda"
+
+pledge = """
+    Video Anda dibaca, ditandai, dipotong, dan ditulis oleh peramban Anda
+    sendiri, di perangkat keras Anda sendiri. Tidak ada di sini yang bisa
+    mengambil atau mengirim apa pun &mdash; alat ini sama sekali tidak punya
+    fitur jaringan &mdash; dan seandainya pun ada, tidak ada server di ujung lain
+    halaman ini untuk menerima sebuah video."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu potong sebuah video. Tidak satu pun permintaan membawa bingkai, nama
+      file, atau satu byte pun dari yang Anda pilih. Atau cabut koneksi internet
+      dan tetap potong satu &mdash; alat yang mengirim video Anda ke tempat lain
+      untuk dipotong akan langsung berhenti."""
+
+read_first = """
+, <code>src/segments.js</code> untuk penanda dan file
+      tempat menyimpannya, <code>src/demux.js</code> untuk pembaca yang mencari
+      bingkai di dalam MP4, <code>src/ranges.js</code> untuk aritmetika yang
+      mengubah sebuah penanda menjadi deretan sampel, dan
+      <code>src/copy.js</code> untuk perulangan yang memindahkan sampel itu ke
+      file baru. Tidak satu pun mengimpor sesuatu yang bisa membuat
+      permintaan."""
+
+howto_heading = "Cara memotong video"
+
+card = """
+            Tandai setiap bagian yang layak disimpan sambil diputar, lalu simpan
+            sebagai satu video. Bingkainya disalin, bukan dikodekan ulang, jadi
+            tidak ada yang hilang."""
+
+[words]
+plural = "video"
+choose = "sebuah video"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Sebanyak apa pun bagiannya"
+
+[[facts]]
+text = "Tanpa kehilangan kualitas"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[privacy]]
+title = "Video Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Alat ini sama sekali tidak punya
+      fitur jaringan: tidak ada alamat untuk ditempelkan, tidak ada yang
+      diunduh, tidak ada mesin yang diambil saat pertama dipakai. Setiap byte
+      yang menyentuh video Anda datang dari asal ini ketika halaman dimuat."""
+
+[[privacy]]
+title = "Di jalur biasa, tidak ada yang bahkan didekode."
+body = """
+ Memotong tidak mengubah tampilan
+      bingkai mana pun, jadi bingkai terkode dari bagian yang Anda tandai
+      dipindahkan ke file baru persis seperti ditemukan. Masing-masing disimpan
+      sebagai potongan file di disk Anda &mdash; catatan tentang byte yang mana,
+      bukan byte-nya sendiri &mdash; dan peramban Anda membacanya untuk pertama
+      kali saat menulis unduhan. Tidak ada di sini yang pernah mengubah video
+      Anda kembali menjadi gambar."""
+
+[[privacy]]
+title = "File penanda dibuat di dalam halaman."
+body = """
+ Menyimpan penanda Anda menulis sebuah
+      file teks dari angka-angka yang sudah ada di layar, langsung ke unduhan
+      Anda. Memuatnya membacanya di sini. Tidak satu pun mendekati jaringan, dan
+      tidak satu pun membawa apa pun selain waktu."""
+
+[[privacy]]
+title = "Suaranya disalin, bukan didengarkan."
+body = """
+ Di kedua jalur MP4, sampel audio
+      dipindahkan menyeberang tanpa didekode sama sekali &mdash; tidak ada di
+      sini yang pernah mengubahnya kembali menjadi suara, dan tidak ada yang bisa
+      meneruskannya ke mana pun seandainya ada."""
+
+[[privacy]]
+title = "Kalaupun bingkai didekode, itu terjadi di sini."
+body = """
+ Pemotongan yang persis, dan pratinjau
+      untuk file yang tidak mau diputar peramban ini, melewati WebCodecs di mesin
+      Anda sendiri. Itu dekoder yang sama yang toh akan menampilkan video itu
+      kepada Anda, berjalan di tempat yang sama."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang video Anda: bukan file,
+      bukan bingkai, bukan nama, ukuran, durasi, atau di mana Anda memotongnya.
+      Setiap baris yang membaca, memotong, dan menulis disajikan dari asal ini
+      dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau video Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih sebuah video."
+body = """
+ Jatuhkan MP4, MOV, M4V, atau WebM ke
+      pemilih file. Peramban membacanya langsung dari disk Anda; tidak ada yang
+      dikirim ke mana pun saat Anda melakukannya. Jatuhkan beberapa dan mereka
+      digabungkan, dalam urutan yang Anda masukkan."""
+
+[[howto]]
+title = "Putar, dan tandai bagian yang Anda mau."
+body = """
+ Tekan <kbd>I</kbd> di tempat sebuah
+      bagian harus dimulai dan <kbd>O</kbd> di tempat ia harus berakhir. Lakukan
+      sebanyak yang Anda mau &mdash; setiap pasangan menjadi satu baris di tabel
+      di bawahnya, dan satu pita di lini masa. <kbd>U</kbd> menarik kembali yang
+      terakhir, <kbd>Space</kbd> memutar dan menjeda, dan tombol panah melompat
+      lima detik sekali tekan. Perlambat pemutarannya kalau momennya sulit
+      ditangkap."""
+
+[[howto]]
+title = "Rapikan penandanya."
+body = """
+ Setiap baris bisa diputar sendiri, diatur
+      ulang waktunya dengan mengetikkan waktu yang persis, dipindahkan naik atau
+      turun urutannya, atau dihapus. Kedua ujung bagian yang terpilih juga bisa
+      diseret di sepanjang lini masa. Total di bagian atas adalah durasi video
+      yang sudah jadi nanti."""
+
+[[howto]]
+title = "Simpan bagian itu, atau buang."
+body = """
+ Menyimpan adalah cara yang biasa:
+      video yang sudah jadi adalah bagian yang Anda tandai, digabungkan berurutan.
+      Membuangnya adalah pekerjaan lain yang diinginkan orang dan jarang
+      ditemukan &mdash; tandai iklannya, keheningannya, atau awal yang gagal, dan
+      sisanya digabungkan tanpa itu semua."""
+
+[[howto]]
+title = "Potong, dan unduh."
+body = """
+ "Simpan setiap byte" memindahkan bingkai
+      tanpa disentuh: cepat, dan tidak mungkin memakan kualitas, tapi setiap
+      bagian dimulai pada bingkai kunci sebelum penanda Anda. "Potong tepat di
+      sini" mendekode dan menulis gambarnya lagi sehingga setiap bagian mulai
+      pada bingkai yang Anda pilih. Halaman ini mengatakan mana yang akan Anda
+      dapat, dan apa biayanya, sebelum Anda menekan tombolnya."""
+
+[[faq]]
+q = "Apakah video saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca, ditandai, dipotong, dan ditulis oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya sisi
+        server, dan <code>Content-Security-Policy</code> halaman ini menyebut
+        satu per satu setiap alamat yang boleh dihubunginya &mdash; tidak satu
+        pun milik situs ini. Cabut koneksi internet dan tetap potong sebuah video
+        kalau Anda lebih suka memeriksa daripada diberi tahu."""
+
+[[faq]]
+q = "Bisakah saya menyimpan beberapa bagian dari video yang sama?"
+a = """
+        Justru untuk itulah alat ini. Tekan <kbd>I</kbd> dan <kbd>O</kbd>
+        sebanyak yang Anda mau sambil diputar; setiap pasangan menjadi satu
+        baris, dan video yang sudah jadi adalah semua baris digabungkan berurutan
+        dengan segala yang lain hilang. Kebanyakan pemotong daring memberi Anda
+        satu pasang pegangan dan bertanya rentang tunggal mana yang disimpan,
+        yang cukup untuk merapikan awal dan akhir sebuah klip dan sama sekali
+        tidak berguna untuk menonton rekaman satu jam sekali lalu menyimpan enam
+        momen yang layak."""
+
+[[faq]]
+q = "Apakah memotong menurunkan kualitas?"
+a = """
+        Tidak di jalur biasa, dan tidak dengan cara yang penting. Memotong tidak
+        mengubah tampilan bingkai mana pun, jadi bingkainya dipindahkan ke file
+        baru persis seperti adanya: byte yang sama, setelan encoder yang sama,
+        semuanya sama. Satu-satunya jalur di sini yang mengodekan ulang sesuatu
+        adalah pemotongan yang persis, dan itu tertulis di tombolnya."""
+
+[[faq]]
+q = "Kenapa sebuah bagian mulai lebih awal daripada yang saya tandai?"
+a = """
+        Karena cara video disimpan, dan hanya pada pemutar yang mengabaikan
+        bagian standar dari formatnya. Kebanyakan bingkai disimpan sebagai
+        deskripsi perbedaannya dari tetangganya, jadi tidak bisa didekode
+        tanpanya; hanya bingkai kunci yang berdiri sendiri, dan bingkai kunci
+        biasanya berjarak satu sampai sepuluh detik. Karena itu pemotongan yang
+        menyalin bingkai harus membawa deretan dari bingkai kunci di depan
+        penanda Anda &mdash; dan file itu berkata <em>mulai putar pada penanda
+        Anda</em>, yang dipatuhi setiap pemutar arus utama. Kalau Anda butuh
+        persis di semua pemutar, pilih "Potong tepat di sini", yang mengodekan
+        ulang. Halaman ini memberi tahu Anda ada di kasus yang mana, dan
+        selisihnya berapa, sebelum Anda mengekspor."""
+
+[[faq]]
+q = "Bisakah saya memotong iklannya saja?"
+a = """
+        Bisa. Tandai iklannya, lalu pilih "Buang yang ditandai": semua yang
+        <em>tidak</em> Anda tandai yang digabungkan, berurutan. Daftar penanda
+        yang sama menjawab kedua pertanyaan, jadi Anda bisa berpindah di antara
+        keduanya dan melihat durasinya berubah tanpa menandai apa pun dua
+        kali."""
+
+[[faq]]
+q = "Bisakah saya menyimpan penanda saya dan kembali lagi nanti?"
+a = """
+        Bisa. "Simpan penanda" menulis sebuah file teks biasa &mdash; satu baris
+        satu bagian, awal dan akhir dipisahkan koma &mdash; dan "Muat penanda"
+        membacanya kembali. Dua format ditawarkan, detik biasa dan
+        <code>HH:MM:SS.mmm</code>, dan keduanya mengikuti tata letak yang sudah
+        dipakai alat lain yang bekerja begini, jadi file yang ditulis di sini
+        bisa diserahkan ke salah satunya dan file yang ditulis di sana bisa
+        dijatuhkan ke halaman ini. Menandai adalah pekerjaan yang butuh
+        ketelitian dan tidak ada yang seharusnya melakukannya dua kali."""
+
+[[faq]]
+q = "Format video apa saja yang bisa saya potong?"
+a = """
+        MP4, M4V, dan MOV dibaca langsung, apa pun isinya: H.264, HEVC, AV1, atau
+        VP9. Menyalin bingkai tidak melibatkan pendekodean, jadi jalur ini
+        berhasil bahkan untuk kodek yang sama sekali tidak punya dekoder di
+        peramban Anda. Apa pun lain yang bisa diputar peramban Anda &mdash; yang
+        paling jelas WebM &mdash; dipotong dengan memutarnya dan merekam
+        hasilnya, yang berhasil, memakan waktu selama hasilnya, dan hanya bisa
+        menyimpan satu bagian. File yang tidak bisa dibaca maupun diputar
+        peramban, yang dalam praktiknya berarti AVI, WMV, FLV, dan sebagian besar
+        MKV, ditolak dengan pesan alih-alih gagal di tengah jalan."""
+
+[[faq]]
+q = "Adakah batas ukuran atau durasi videonya?"
+a = """
+        Tidak ada batas yang tertanam di alat ini, dan di jalur penyalinan file
+        nyaris tidak dibaca sama sekali: bingkai yang Anda simpan ditunjuk,
+        bukan dimuat, jadi menyimpan empat menit dari rekaman empat gigabyte
+        kira-kira sama biayanya dengan menulis empat menit itu ke disk.
+        Pemotongan yang persis menelusuri file beberapa megabyte sekali jalan.
+        Bagaimanapun, batas praktisnya adalah file yang sudah jadi, yang dirakit
+        di memori sebelum Anda mengunduhnya."""
+
+[[faq]]
+q = "Apakah suaranya selamat?"
+a = """
+        Di kedua jalur MP4 ia disalin sampel demi sampel tanpa pernah didekode,
+        jadi ia sama persis byte demi byte dengan yang ada di file, dan sebuah
+        penanda suntingan menjaga setiap bagian sejajar dengan gambarnya dalam
+        seperseribu detik. Satu pengecualian adalah menggabungkan video terpisah
+        yang suaranya dijelaskan berbeda &mdash; laju sampel yang berbeda,
+        misalnya &mdash; di mana tidak ada cara memasukkan keduanya ke satu jalur
+        tanpa mendekodenya, dan halaman ini mengatakannya sebelum melakukannya.
+        Di jalur perekaman, ia ditangkap dari pemutaran dan dikodekan ulang.
+        Bagaimanapun ada kotak centang untuk meninggalkannya sama sekali."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang video Anda."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript. Menyalin bingkai sama sekali tidak memerlukan dukungan kodek video; pemotongan yang persis memerlukan peramban dengan WebCodecs, dan format lain kembali ke perekaman."
+description = "Tandai sebanyak apa pun bagian sebuah video sambil diputar, lalu simpan bagian-bagian itu sebagai satu file - atau buang bagian itu dan simpan sisanya. MP4, MOV, dan M4V dipotong dengan memindahkan bingkai terkode ke file baru tanpa disentuh, dengan audio asli dibawa menyeberang sampel demi sampel; tidak ada yang diunggah dan tidak ada yang dikodekan ulang."
+features = [
+  "Menandai sebanyak apa pun bagian dengan I dan O sambil video diputar",
+  "Menggabungkan bagian yang ditandai menjadi satu file, dalam urutan yang Anda pilih",
+  "Atau membuang bagian yang ditandai dan menyimpan semua sisanya",
+  "Memotong tanpa mengodekan ulang, jadi tidak ada kualitas yang hilang",
+  "Menyimpan dan memuat kembali penanda sebagai file teks biasa berisi stempel waktu",
+  "Penanda akurat per bingkai, dengan bingkai kunci ditampilkan di lini masa",
+  "Menjaga audio asli tanpa mengodekannya ulang",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan video di sini"
+hint = "atau klik untuk menelusuri &mdash; MP4, MOV, M4V, WebM. Jatuhkan beberapa untuk menggabungkannya."

--- a/locales/id/tools/video-to-gif.html
+++ b/locales/id/tools/video-to-gif.html
@@ -1,0 +1,175 @@
+<!--
+  tools/video-to-gif/body.html, in Indonesian.
+
+  Every id, class and option value below is what src/main.js and src/range.js
+  reach for, so they are the same in every language. Only the words change.
+-->
+<main>
+  <!-- Langkah 1 &mdash; file -->
+  <section class="card">
+    <h2><span class="step">1</span> Pilih sebuah video</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <dl class="source" id="source" hidden>
+      <div><dt>File</dt><dd id="src-name">&mdash;</dd></div>
+      <div><dt>Ukuran</dt><dd id="src-size">&mdash;</dd></div>
+      <div><dt>Bingkai</dt><dd id="src-frame">&mdash;</dd></div>
+      <div><dt>Durasi</dt><dd id="src-length">&mdash;</dd></div>
+      <div><dt>Video</dt><dd id="src-codec">&mdash;</dd></div>
+      <div><dt>Dibaca oleh</dt><dd id="src-path">&mdash;</dd></div>
+    </dl>
+
+    <p id="path-note" class="path-note" hidden></p>
+  </section>
+
+  <!-- Langkah 2 &mdash; bagiannya -->
+  <section class="card" id="section-card" hidden>
+    <h2><span class="step">2</span> Pilih bagiannya</h2>
+
+    <p class="hint">
+      Putar klipnya dan tandai bagian yang Anda mau. <kbd>I</kbd> menetapkan
+      awalnya di posisi kepala pemutar, <kbd>O</kbd> menetapkan akhirnya, dan
+      kedua pegangan di batangnya bisa diseret.
+    </p>
+
+    <div class="stage-wrap">
+      <div class="stage" id="stage">
+        <video id="preview" playsinline controls></video>
+        <canvas id="still" hidden></canvas>
+      </div>
+    </div>
+
+    <p id="stage-note" class="stage-note" hidden></p>
+
+    <!-- The bar itself is built by src/range.js. -->
+    <div id="rangebar"></div>
+    <div class="rb-scale">
+      <span>0:00.000</span>
+      <span id="scale-end">&mdash;</span>
+    </div>
+
+    <div class="marks">
+      <label>Mulai
+        <input type="text" id="start-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-in" class="ghost" title="Tetapkan awal di posisi kepala pemutar (I)">
+        Tetapkan di kepala pemutar
+      </button>
+
+      <label>Selesai
+        <input type="text" id="end-time" inputmode="decimal" autocomplete="off" spellcheck="false">
+      </label>
+      <button type="button" id="mark-out" class="ghost" title="Tetapkan akhir di posisi kepala pemutar (O)">
+        Tetapkan di kepala pemutar
+      </button>
+
+      <div class="mark-actions">
+        <button type="button" id="play-section" class="ghost">Putar bagiannya</button>
+        <button type="button" id="whole-clip" class="ghost">Seluruh klip</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Langkah 3 &mdash; GIF-nya -->
+  <section class="card" id="export-card" hidden>
+    <h2><span class="step">3</span> Ukuran dan laju bingkai</h2>
+
+    <div class="settings">
+      <div class="field">
+        <label for="width">Lebar</label>
+        <select id="width">
+          <option value="240">240 px</option>
+          <option value="320">320 px</option>
+          <option value="480" selected>480 px</option>
+          <option value="640">640 px</option>
+          <option value="source">Ukuran asli</option>
+          <option value="custom">Persisnya&hellip;</option>
+        </select>
+        <p class="field-note">
+          Tingginya mengikuti, jadi bentuknya tidak pernah berubah. Lebar adalah
+          biaya sebuah GIF: setengah lebar berarti seperempat piksel.
+        </p>
+        <p class="field-note" id="width-note" hidden></p>
+      </div>
+
+      <div class="field" id="custom-width-field" hidden>
+        <label for="custom-width">Lebar persis</label>
+        <input type="number" id="custom-width" min="16" max="1920" step="1" value="480">
+        <p class="field-note">Dalam piksel, antara 16 dan 1920.</p>
+      </div>
+
+      <div class="field">
+        <label for="fps">Bingkai per detik</label>
+        <select id="fps">
+          <option value="5">5 &mdash; paling kecil</option>
+          <option value="10">10</option>
+          <option value="12" selected>12 &mdash; cukup halus</option>
+          <option value="15">15</option>
+          <option value="20">20</option>
+          <option value="25">25 &mdash; paling halus</option>
+        </select>
+        <p class="field-note">
+          Bukan laju milik videonya: bingkai diambil sebagai sampel darinya. Dua
+          belas sudah terbaca sebagai gerak; di atas dua puluh, file tumbuh lebih
+          cepat daripada kehalusan yang terlihat.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="dither">Titik-titik campur</label>
+        <select id="dither">
+          <option value="on" selected>Nyala &mdash; gradasi lebih halus</option>
+          <option value="off">Mati &mdash; lebih rata, lebih kecil</option>
+        </select>
+        <p class="field-note">
+          Mengaduk dua warna palet di tempat warna yang tepat tidak ada. Jenis
+          teratur, jadi latar yang diam tidak berkilat-kilat.
+        </p>
+      </div>
+
+      <div class="field">
+        <label class="check" for="loop">
+          <input type="checkbox" id="loop" checked>
+          Ulang terus
+        </label>
+        <p class="field-note">Kalau mati, ia diputar sekali lalu berhenti.</p>
+      </div>
+    </div>
+
+    <dl class="summary" id="summary">
+      <div><dt>Bagian</dt><dd id="sum-section">&mdash;</dd></div>
+      <div><dt>Keluaran</dt><dd id="sum-size">&mdash;</dd></div>
+      <div><dt>Bingkai</dt><dd id="sum-frames">&mdash;</dd></div>
+      <div><dt>Perkiraan ukuran file</dt><dd id="sum-bytes">&mdash;</dd></div>
+    </dl>
+
+    <p id="memory-note" class="field-note" hidden></p>
+
+    <div class="export-row">
+      <button type="button" id="export" class="primary" disabled>Buat GIF-nya</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <img id="result-image" alt="Animasi yang sudah jadi, sedang diputar">
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <a id="download" class="primary as-button" download>Unduh GIF</a>
+      </div>
+    </div>
+  </section>
+</main>

--- a/locales/id/tools/video-to-gif.toml
+++ b/locales/id/tools/video-to-gif.toml
@@ -1,0 +1,251 @@
+#
+# Video ke GIF - Bahasa Indonesia.
+#
+# Overrides for tools/video-to-gif/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+
+name = "Video ke GIF"
+heading = "Video&nbsp;ke&nbsp;GIF <span class=\"h1-kw\">&mdash; ubah video menjadi GIF</span>"
+tagline = "Pilih bagiannya, ukurannya, dan laju bingkainya."
+
+title = "Pengubah Video ke GIF &mdash; Gratis, Tanpa Unggah, Jalan Tanpa Internet"
+description = "Ubah sebagian MP4, MOV, atau WebM menjadi GIF bergerak. Pilih bagiannya, lebarnya, dan laju bingkainya; bingkainya dibaca dan GIF-nya ditulis di peramban Anda. Tidak ada yang diunggah."
+og_title = "Video ke GIF &mdash; buat GIF tanpa mengunggah klipnya"
+og_description = "Tandai detik yang Anda mau, pilih lebar dan laju bingkai, dan dapatkan GIF bergerak. Pengambilan bingkai, palet, titik-titik campur, dan LZW semuanya dikerjakan di perangkat Anda sendiri."
+og_image_alt = "Video ke GIF - buat GIF bergerak di peramban Anda, tanpa ada yang diunggah"
+
+pledge = """
+    Setiap bingkai dibaca, diubah ukurannya, dikuantisasi, dan ditulis oleh
+    peramban Anda sendiri, di perangkat keras Anda sendiri. Tidak ada di sini
+    yang bisa mengambil atau mengirim apa pun &mdash; alat ini sama sekali tidak
+    punya fitur jaringan &mdash; dan seandainya pun ada, tidak ada server di
+    ujung lain halaman ini untuk menerima sebuah video."""
+
+live_hint = """
+      Tidak perlu percaya begitu saja: buka DevTools, perhatikan tab Network,
+      lalu buat sebuah GIF. Tidak satu pun permintaan membawa bingkai, nama file,
+      atau satu byte pun dari yang Anda pilih. Atau cabut koneksi internet dan
+      tetap buat satu &mdash; alat yang mengirim video Anda ke tempat lain untuk
+      diubah akan langsung berhenti."""
+
+read_first = """
+, <code>src/frames.js</code> untuk dua cara bingkai
+      dibaca dari sebuah video, <code>src/quantize.js</code> untuk paletnya, dan
+      <code>src/gif.js</code> untuk file-nya sendiri, LZW dan semuanya. Tidak
+      satu pun mengimpor sesuatu yang bisa membuat permintaan."""
+
+howto_heading = "Cara mengubah video menjadi GIF"
+
+card = """
+            Tandai detik yang Anda mau, pilih lebar dan laju bingkai, dan
+            dapatkan GIF bergerak &mdash; lengkap dengan palet dan titik-titik
+            campurnya."""
+
+[words]
+plural = "video"
+choose = "sebuah video"
+
+[[facts]]
+text = "Tanpa unggah"
+
+[[facts]]
+text = "Tanpa akun"
+
+[[facts]]
+text = "Tanpa tanda air"
+
+[[facts]]
+text = "Durasi berapa pun"
+
+[[facts]]
+text = "Jalan tanpa internet"
+
+[[privacy]]
+title = "Video Anda tidak punya tujuan ke mana pun."
+body = """
+ Content-Security-Policy menyebut
+      satu per satu setiap alamat yang boleh dihubungi halaman ini, dan tidak
+      satu pun milik situs ini. Tidak ada titik akhir di sini tempat file Anda
+      bisa dikumpulkan, dan tidak ada kode yang akan mengirimnya seandainya
+      ada."""
+
+[[privacy]]
+title = "Tidak ada di sini yang mengambil apa pun."
+body = """
+ Alat ini sama sekali tidak punya
+      fitur jaringan: tidak ada alamat untuk ditempelkan, tidak ada yang diunduh,
+      tidak ada mesin yang diambil saat pertama dipakai. Setiap byte yang
+      menyentuh video Anda datang dari asal ini ketika halaman dimuat."""
+
+[[privacy]]
+title = "Pendekodean berjalan lokal."
+body = """
+ Bingkainya melewati WebCodecs di peramban
+      Anda sendiri, atau melewati mesin pemutar yang sama yang toh akan
+      menampilkan klip itu kepada Anda. Yang mana yang dipakai tertulis di bagian
+      atas halaman, karena itu mengubah cara bingkai dipilih dan Anda seharusnya
+      bisa melihatnya."""
+
+[[privacy]]
+title = "GIF-nya ditulis di sini, dalam kode yang bisa Anda baca."
+body = """
+ Palet, titik-titik campur, dan
+      kompresi LZW-nya kira-kira enam ratus baris di dalam folder alat ini
+      sendiri. Tidak ada layanan encoder, tidak ada pustaka yang diambil saat
+      dijalankan, dan tidak ada tempat di dalamnya yang bisa mengirim sebuah
+      gambar."""
+
+[[privacy]]
+title = "Apa yang dimuat Google, dan apa yang tidak diberikan kepadanya."
+body = """
+ Skrip iklan dan pengukuran berasal
+      dari Google. Tidak satu pun diberi apa pun tentang video Anda: bukan file,
+      bukan bingkai, bukan nama, ukuran, durasi, atau bagian yang Anda tandai.
+      Setiap baris yang membaca, mengambil sampel, mengkuantisasi, atau
+      mengodekan disajikan dari asal ini dan terdaftar di repositori."""
+
+[[privacy]]
+title = "Apa yang dimuat tombol donasi, dan apa yang tidak diberikan kepadanya."
+body = """
+ Tombol "Buy me a coffee" di bagian
+      atas digambar oleh skrip dari cdnjs.buymeacoffee.com dan mengambil hurufnya
+      dari Google Fonts. Ia hanyalah sebuah tautan: ia tidak melaporkan
+      kunjungan, dan tidak diberi apa pun tentang Anda atau video Anda."""
+
+[[privacy]]
+title = "Jalan tanpa internet."
+body = """
+ Putuskan koneksi jaringan dan semua yang ada di
+      halaman ini tetap bekerja. Itulah bukti yang paling sederhana."""
+
+[[howto]]
+title = "Pilih sebuah video."
+body = """
+ Jatuhkan MP4, MOV, M4V, atau WebM ke
+      pemilih file, atau pilih sendiri. Peramban membacanya langsung dari disk
+      Anda; tidak ada yang dikirim ke mana pun saat Anda melakukannya."""
+
+[[howto]]
+title = "Tandai bagiannya."
+body = """
+ Putar klipnya dan tekan <kbd>I</kbd> di
+      tempat ia harus dimulai dan <kbd>O</kbd> di tempat ia harus berakhir, atau
+      seret pegangan di batangnya. Sebuah GIF panjangnya beberapa detik &mdash;
+      inilah setelan yang menentukan file-nya kecil atau raksasa, jauh lebih
+      besar pengaruhnya daripada dua setelan lainnya."""
+
+[[howto]]
+title = "Pilih lebar dan laju bingkainya."
+body = """
+ Lebar 480 piksel dan 12 bingkai per
+      detik cocok untuk sebagian besar keperluan GIF. Melipatduakan pengurangan
+      lebar membuat pikselnya tinggal seperempat; dua belas bingkai per detik
+      sudah terbaca sebagai gerak tanpa membayar bingkai yang tidak dilihat siapa
+      pun."""
+
+[[howto]]
+title = "Buat, dan unduh."
+body = """
+ Bingkainya dibaca, satu palet berisi 256 warna
+      dipilih untuk seluruh animasi, dan setiap bingkai ditulis hanya sebagai
+      bagian gambar yang berubah. Ia diputar di halaman begitu selesai, dan itu
+      file yang sama dengan yang diberikan unduhan kepada Anda."""
+
+[[faq]]
+q = "Apakah video saya diunggah ke suatu tempat?"
+a = """
+        Tidak. Ia dibaca, diambil sampelnya, dan diubah oleh peramban Anda
+        sendiri di perangkat keras Anda sendiri. Alat ini tidak punya sisi
+        server, dan <code>Content-Security-Policy</code> halaman ini menyebut
+        satu per satu setiap alamat yang boleh dihubunginya &mdash; tidak satu
+        pun milik situs ini. Cabut koneksi internet dan tetap buat sebuah GIF
+        kalau Anda lebih suka memeriksa daripada diberi tahu."""
+
+[[faq]]
+q = "Format video apa saja yang bisa saya ubah?"
+a = """
+        MP4, M4V, dan MOV dibaca langsung, apa pun isinya: H.264, HEVC, AV1, atau
+        VP9, selama peramban Anda bisa mendekode kodek itu. Apa pun lain yang
+        bisa diputar peramban Anda &mdash; yang paling jelas WebM &mdash; dibaca
+        dengan mencari posisi pemutar ke setiap saat, yang lebih lambat dan
+        sedikit kurang persis soal bingkai mana mendarat di mana. File yang tidak
+        bisa dibaca maupun diputar peramban, yang dalam praktiknya berarti AVI,
+        WMV, FLV, dan sebagian besar MKV, ditolak dengan pesan alih-alih gagal di
+        tengah jalan."""
+
+[[faq]]
+q = "Kenapa GIF saya begitu besar?"
+a = """
+        Karena GIF adalah format dari 1987 yang menyimpan gambar utuh, bukan
+        gerak. Tidak ada cara membuat GIF dari klip lima detik yang sekecil MP4
+        lima detik asalnya &mdash; GIF dari sebuah video lazimnya sepuluh kali
+        ukuran videonya. Tiga setelan yang benar-benar menentukannya adalah,
+        berurutan: seberapa panjang bagiannya, seberapa lebar gambarnya, dan
+        berapa bingkai per detik. Melipatduakan pengurangan lebar membuat
+        pikselnya tinggal seperempat, dan piksellah yang memakan biaya."""
+
+[[faq]]
+q = "Kenapa hanya 256 warna?"
+a = """
+        Memang begitu formatnya: sebuah GIF membawa satu tabel berisi paling
+        banyak 256 warna dan menyimpan setiap piksel sebagai angka ke dalamnya.
+        Alat ini memilih 256 itu dengan menghitung warna di setiap bingkai bagian
+        yang Anda tandai dan membaginya menjadi 256 kelompok &mdash; median cut,
+        metode standarnya &mdash; jadi paletnya pas dengan klip Anda, bukan
+        sekumpulan warna tetap. Di tempat sebuah warna tidak ada, titik-titik
+        campur mengaduk dua warna terdekat sehingga gradasi tetap gradasi
+        alih-alih menjadi garis-garis."""
+
+[[faq]]
+q = "Apa yang dilakukan setelan titik-titik campur?"
+a = """
+        Ia menukar sedikit derau dengan banyak pita warna. Kalau dinyalakan,
+        langit yang tadinya akan menjadi empat pita datar tetap berupa gradasi,
+        dengan biaya tekstur samar dan file yang lebih besar. Kalau dimatikan,
+        gambarnya lebih rata dan file-nya lebih kecil, yang cocok untuk rekaman
+        layar, seni garis, dan apa pun yang memang sudah terbuat dari warna
+        datar. Titik-titik campur yang dipakai di sini adalah jenis teratur,
+        bukan jenis penyebaran galat, jadi latar yang tidak berubah tetap diam
+        sempurna di antara bingkai alih-alih berkilat-kilat."""
+
+[[faq]]
+q = "Adakah batas durasi atau ukurannya?"
+a = """
+        Yang dibatasi adalah bagiannya, dan oleh memori, bukan oleh aturan:
+        setiap bingkainya ditahan sekaligus saat palet dipilih, jadi halaman ini
+        menghitung berapa biaya setelan Anda dan mengatakannya sebelum Anda
+        mulai. Ia menolak alih-alih membiarkan tab kehabisan memori dan lenyap.
+        Bagian yang lebih pendek, lebar yang lebih kecil, atau laju bingkai yang
+        lebih rendah, semuanya menurunkannya."""
+
+[[faq]]
+q = "Apakah suaranya ikut?"
+a = """
+        Sebuah GIF tidak bisa membawa suara. Tidak ada versi format ini yang
+        punya audio, dan itulah alasan utama web sebagian besar mengganti GIF
+        dengan video berulang tanpa suara. Kalau suaranya penting, simpan
+        videonya &mdash; <a href="../potong-video/">Pemotong Video</a> akan
+        memotong sebagian darinya tanpa mengodekan ulang satu bingkai pun."""
+
+[[faq]]
+q = "Apakah gratis, dan apakah saya perlu akun?"
+a = """
+        Gratis, dan tidak ada akun, tidak ada masuk, tidak ada masa uji coba, dan
+        tidak ada tanda air. Situs ini memasang iklan, dan itulah yang
+        membiayainya; iklan tidak diberi apa pun tentang video Anda."""
+
+[schema]
+browser_requirements = "Memerlukan JavaScript. MP4 dan MOV memerlukan peramban dengan WebCodecs; apa pun yang bisa diputar peramban berhasil tanpa itu."
+description = "Ubah sebagian video menjadi GIF bergerak di peramban. Bingkainya diambil pada laju yang dipilih, satu palet 256 warna dipilih untuk seluruh animasi dengan median cut, dan setiap bingkai ditulis hanya sebagai daerah yang berubah. Tidak ada yang diunggah."
+features = [
+  "Mengubah video MP4, MOV, M4V, dan WebM menjadi GIF bergerak",
+  "Sumber H.264, HEVC, AV1, dan VP9, didekode lewat WebCodecs",
+  "Tandai bagiannya di lini masa, atau ketik waktu yang persis",
+  "Lebar berapa pun, 5 sampai 25 bingkai per detik, titik-titik campur teratur opsional",
+  "Jalan tanpa internet; tanpa unggah, tanpa akun, tanpa tanda air",
+]
+
+[picker]
+title = "Jatuhkan video di sini"
+hint = "atau klik untuk menelusuri &mdash; MP4, MOV, M4V, WebM, dan apa pun lain yang bisa diputar peramban ini"


### PR DESCRIPTION
Indonesian was at 47 of 63 pages in English when this branch opened. It is
now at 65 of 65, which is the count as of #127 — the build stops printing
an `id:` line entirely, and a locale the debt report has nothing to say
about is the only signal that it is finished.

Thirty-three tools, thirty guides, privacy and terms. Nothing outside
`locales/id/` is touched.

## The vocabulary this locale had to settle

Three verbs that English spends one word on and Indonesian does not, kept
rigidly apart because the guides depend on the distinction:

- **potong** — shorten a clip, or take a section out of one
- **pangkas** — change the shape of the picture
- **kompres** — reduce the file size

The trimming guide closes by saying that trimming is not cropping, which
only works if the two words have been kept apart on every other page. Same
for **sensor**, which is what people here call taking something out so it
cannot be read, and which the slugs already used (`sensor-pdf`,
`sensor-gambar`).

## What stays in English, and why

Anything the reader is going to type, search for, or match against
something on their screen:

- shell commands in the checksum guide — `Get-FileHash`, `shasum -a 256`,
  `sha256sum -c`; a translated flag is a command that fails
- file names — `favicon.ico`, `apple-touch-icon.png`, `site.webmanifest`,
  `browserconfig.xml`, `DICOMDIR`, `Info.plist`
- DICOM field names with their numbers — Pixel Spacing (0028,0030), Series
  Instance UID (0020,000E) — and `VR` in the tag table heading
- RAW format names, codec names, and the `abox-lang` storage key
- every identifier inside a `<pre>` block in the CSS guide, including the
  `--icon-search` custom property

## Two structural notes

**`csp_note` and `og_card` are omitted from all thirty-three tools.** They
read like prose, but `buildlib/i18n.py` lists them as structural and the
build rejects a locale file that carries them.

**Indonesian does not mark a noun for number**, so redact-pdf's sixteen
`count.*` phrases come out as eight identical pairs. Both halves are still
present: the JavaScript picks one by the count, and a missing key is a
missing sentence rather than a fallback.

## Checked

- `python build.py --out … --clean --no-minify` — clean, no `id:` line
- `python -m unittest discover -t . -s tests/python` — passes
- every `data-phrase` key and `{placeholder}` set compared against the
  English body for all six tools that carry a `#phrases` block
- every `id`, `class`, `value`, `name` and `data-*` attribute set matched
  against the English `body.html`, tool by tool
- no CRLF anywhere under `locales/id/`
- every cross-link resolves — `check_links` refuses to publish a locale
  whose page points at a page that was not built, so this one is enforced
  rather than asserted

Rebased onto current `main`, so the two pages #127 added — `stack-images`
and its guide — are translated here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
