### PR TITLE
Deutsch: die letzten acht Seiten, 65 von 65

### DIFF
--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -149,6 +149,19 @@ complete = true
 "guides/whats-inside-a-gif" = "ratgeber/was-steckt-in-einem-gif"
 "guides/verify-a-file-checksum" = "ratgeber/pruefsumme-vergleichen"
 
+# Die vier Seiten, die nach dieser Liste dazugekommen sind. "dicom-viewer"
+# bleibt, wie es ist, weil genau das getippt wird - eine Eindeutschung waere
+# ein Wort, nach dem niemand sucht. "Stacken" ist in der Fotografie das
+# gelaeufige Verb und steht deshalb da statt "stapeln".
+"dicom-viewer" = "dicom-viewer"
+"document-scanner" = "dokumente-scannen"
+"redact-pdf" = "pdf-schwaerzen"
+"stack-images" = "bilder-stacken"
+"guides/open-a-dicom-file" = "ratgeber/dicom-datei-oeffnen"
+"guides/redact-a-pdf" = "ratgeber/pdf-schwaerzen"
+"guides/scan-a-document-with-your-phone" = "ratgeber/dokument-mit-handy-scannen"
+"guides/stack-photos-to-reduce-noise" = "ratgeber/fotos-stacken-gegen-bildrauschen"
+
 #
 # ---------------------------------------------------------------------------
 # The hub.

--- a/locales/de/pages/guides/open-a-dicom-file.html
+++ b/locales/de/pages/guides/open-a-dicom-file.html
@@ -1,0 +1,255 @@
+  <section>
+    <h2>Die kurze Antwort</h2>
+    <p>
+      Öffnen Sie den <a href="../../dicom-viewer/">DICOM-Viewer</a> und ziehen
+      Sie den ganzen Ordner mit den Dateien hinein. Sie werden auf Ihrem eigenen
+      Gerät gelesen, wieder ihren Serien zugeordnet und in der Reihenfolge
+      gestapelt, in der das Gerät sie aufgenommen hat. Nichts wird hochgeladen,
+      und nichts wird in Ihre Dateien zurückgeschrieben.
+    </p>
+    <p>
+      Falls Sie eine CD bekommen haben und sich fragen, welche der Dateien Sie
+      öffnen sollen: alle, auf einmal. Ein CT oder ein MRT ist nicht eine Datei.
+      Es ist eine Datei pro Schicht, und eine Thoraxstudie sind dreihundert
+      davon.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was auf einer Klinik-CD liegt</h2>
+    <p>
+      Meist vier Dinge, und nur eines davon zählt.
+    </p>
+    <ul>
+      <li>
+        <strong>Ein Ordner mit Aufnahmen</strong>, oft <code>DICOM</code>,
+        <code>IMAGES</code> oder <code>ST0001</code> genannt, mit Dateien namens
+        <code>IM000001</code>, <code>I0000001</code> oder einer langen Zahl mit
+        Punkten. Häufig ganz ohne Endung. Das ist die Aufnahme.
+      </li>
+      <li>
+        <strong>Eine Datei namens <code>DICOMDIR</code></strong>. Ein Verzeichnis
+        über den Rest, geschrieben, damit ein Viewer die Studien auf der CD
+        auflisten kann, ohne jede Datei zu öffnen. Sie brauchen sie nicht.
+      </li>
+      <li>
+        <strong>Ein Viewer</strong>, als Windows-Programm, als Autostart-Eintrag
+        oder gelegentlich als Java-Applet. Er wurde für das kompiliert, was
+        aktuell war, als die CD gebrannt wurde, und deshalb laufen so viele davon
+        nicht mehr.
+      </li>
+      <li>
+        <strong>Eine HTML-Seite oder ein PDF</strong> mit dem Logo der Klinik,
+        das erklärt, wie der Viewer zu starten ist.
+      </li>
+    </ul>
+    <p>
+      Die Aufnahmen brauchen den Viewer nicht. Das Format ist ein
+      veröffentlichter Standard, und die Dateien sind für sich lesbar; das
+      Programm auf der CD ist eines, das sie lesen könnte, und nicht das einzige.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum die Dateien keine Endung haben</h2>
+    <p>
+      Weil DICOM keine braucht. Jede Datei trägt ihre eigene Markierung: 128 Byte
+      Nichts, dann die vier Buchstaben <code>DICM</code>, dann ein kleiner Block
+      von Feldern, der beschreibt, wie der Rest der Datei geschrieben ist. Ein
+      Leser prüft auf diese vier Buchstaben und nicht auf einen Namen, der auf
+      <code>.dcm</code> endet.
+    </p>
+    <p>
+      Deshalb ändert es auch nichts, eine Datei in <code>.dcm</code> umzubenennen,
+      und deshalb ist ein Viewer, der auf der Endung besteht, unnötig streng.
+      Dateien, die direkt aus einem Kliniknetz geschrieben wurden, haben nicht
+      einmal die 128 Byte und die Markierung. Sie sind die nackten Daten ohne
+      irgendetwas davor, und ein Leser muss aus dem ersten Feld erschließen, wie
+      sie kodiert sind. Das ist eine normale Datei und keine kaputte.
+    </p>
+  </section>
+
+  <section>
+    <h2>Fenster und Zentrum, und das ist der Regler, auf den es ankommt</h2>
+    <p>
+      Das ist das eine, was ein medizinisches Bild von einem Foto unterscheidet,
+      und der Grund, warum ein Bildbearbeitungsprogramm dafür nichts taugt.
+    </p>
+    <p>
+      Eine CT-Schicht enthält rund viertausend unterscheidbare Werte. Ihr
+      Bildschirm zeigt zweihundertsechsundfünfzig Graustufen. Irgendetwas muss
+      entscheiden, welche viertausend auf welche zweihundertsechsundfünfzig
+      abgebildet werden, und diese Entscheidung ist das <strong>Fenster</strong>:
+      Alles darunter ist schwarz, alles darüber ist weiß, und der Bereich
+      dazwischen verteilt sich auf die Graustufen.
+    </p>
+    <p>
+      Verschieben Sie das Fenster, und dieselbe Datei sieht aus wie eine andere
+      Aufnahme. Das ist kein Darstellungsfehler, das ist der Sinn der Sache.
+      Lunge und Knochen sind beide in der Schicht und lassen sich nicht
+      gleichzeitig sehen: Ein Fenster, das die Textur belüfteter Lunge zeigt,
+      setzt jeden Knochen auf reines Weiß, und eines, das die Bälkchenstruktur
+      einer Rippe zeigt, setzt die ganze Lunge auf reines Schwarz.
+    </p>
+    <p>
+      Bei einem CT sind die Zahlen <strong>Hounsfield-Einheiten</strong>, und die
+      sind absolut festgelegt und nicht je Gerät: Wasser ist 0 und Luft ist
+      &minus;1000, per Definition, auf jedem CT der Welt. Deshalb kann ein Viewer
+      benannte Fenster anbieten, Lunge, Knochen, Hirn, Weichteile, und sie
+      bedeuten bei Ihrer Datei dasselbe wie an der Befundungsstation, an der die
+      Aufnahme gelesen wurde. Die üblichen:
+    </p>
+    <ul>
+      <li><strong>Weichteile</strong> &mdash; Zentrum 40, Breite 400.</li>
+      <li><strong>Lunge</strong> &mdash; Zentrum &minus;600, Breite 1500.</li>
+      <li><strong>Knochen</strong> &mdash; Zentrum 300, Breite 1500.</li>
+      <li><strong>Hirn</strong> &mdash; Zentrum 40, Breite 80. Ein schmales,
+        weil graue und weiße Substanz sich nur um wenige Einheiten
+        unterscheiden.</li>
+    </ul>
+    <p>
+      Bei einem MRT gibt es keine solche Skala. Die Werte hängen von der Sequenz,
+      der Spule und dem Gerät ab, es gibt also nichts, wonach sich ein Preset
+      benennen ließe, und das Fenster zum Anfangen ist das, um das die Datei
+      selbst bittet. Jede Aufnahme trägt einen Vorschlag.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum die Schichten manchmal falsch herum laufen</h2>
+    <p>
+      Ein Viewer muss entscheiden, in welche Reihenfolge er die Dateien bringt,
+      und dafür stehen zwei Dinge in der Datei zur Verfügung.
+    </p>
+    <p>
+      <strong>Instance Number</strong> ist ein Zähler. Das ist die naheliegende
+      Wahl, und sie wird von dem vergeben, was die Dateien geschrieben hat, und
+      das muss nicht in der Richtung nummerieren, in der die Patientin liegt.
+      Eine von den Füßen aufwärts rekonstruierte und vom Kopf abwärts nummerierte
+      Studie läuft rückwärts, und eine aus zwei Rekonstruktionen zusammengesetzte
+      Serie kann die Nummern schlicht wiederholen.
+    </p>
+    <p>
+      <strong>Image Position (Patient)</strong> ist, wo die Schicht physisch
+      liegt, in Millimetern, in einem Koordinatensystem, das an der Patientin
+      hängt und nicht am Gerät. Danach zu sortieren ist richtig, was die
+      Nummerierung auch getan hat, und es hat einen nützlichen Nebeneffekt:
+      Liegen die Schichten erst einmal in physischer Reihenfolge, ist der Abstand
+      zwischen ihnen messbar. Ein Viewer kann Ihnen also sagen, dass die
+      Schichten 5&nbsp;mm auseinanderliegen, und bemerken, wenn eine fehlt, was
+      die Datei nie sagt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Etwas messen</h2>
+    <p>
+      Eine Aufnahme ist gemessene Information, eine Länge darauf ist also eine
+      echte Länge, sofern die Datei sagt, wie weit ihre Pixel auseinanderliegen.
+      Das ist ein Feld, Pixel Spacing, in Millimetern, und bei praktisch jedem CT
+      und MRT ist es vorhanden.
+    </p>
+    <p>
+      Bei Ultraschallbildern, eingescannten Dokumenten und als DICOM
+      gespeicherten Bildschirmaufnahmen fehlt es oft. Wo es fehlt, gibt es keine
+      ehrliche Antwort in Millimetern, und ein Viewer, der trotzdem eine gibt,
+      hat einen Maßstab erfunden. Eine Anzahl Pixel ist die richtige Antwort auf
+      eine Frage, die die Datei nicht beantworten kann.
+    </p>
+    <p>
+      Achten Sie außerdem auf nicht quadratische Pixel, was außerhalb des CT
+      normal ist. In Pixeln zu messen und mit einem einzigen Abstandswert zu
+      multiplizieren stimmt nur dort, wo die beiden übereinstimmen; jede Achse
+      muss mit ihrem eigenen gemessen werden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was eine Aufnahme außer dem Bild noch trägt</h2>
+    <p>
+      Das ist der Teil, bei dem Leute sich irren, und der Grund, mit diesen
+      Dateien vorsichtig zu sein.
+    </p>
+    <p>
+      Eine DICOM-Datei ist kein Bild mit ein paar angehängten Metadaten. Sie ist
+      eine Krankenakte mit einem Bild darin. Der Header ist eine Liste von
+      Feldern, und bei einer üblichen klinischen Aufnahme enthält er:
+    </p>
+    <ul>
+      <li>Name, Patientennummer, Geburtsdatum und Geschlecht;</li>
+      <li>die Auftragsnummer, die der Schlüssel zur Anforderung im System der
+        Klinik ist;</li>
+      <li>die überweisende Ärztin, die durchführende MTR, die befundende
+        Radiologin;</li>
+      <li>die Einrichtung, ihre Adresse und die Abteilung;</li>
+      <li>Hersteller, Modell und Seriennummer des Geräts;</li>
+      <li>Datum und Uhrzeit der Aufnahme auf die Sekunde;</li>
+      <li>und eine Reihe eindeutiger Kennungen für Studie, Serie und Instanz, die
+        perfekte Schlüssel zurück in das Archiv sind, aus dem sie stammt.</li>
+    </ul>
+    <p>
+      Jede Datei, die Sie bekommen haben, trägt all das, und es reist mit der
+      Datei, wohin sie auch geht. Den Namen zu löschen genügt nicht: Ein
+      Geburtsdatum, eine Einrichtung von der Größe einer Postleitzahl und ein
+      Aufnahmezeitpunkt identifizieren eine Person etwa so gut wie ein Name, und
+      die Studien-UID identifiziert sie exakt für jeden mit Zugang zum Archiv.
+    </p>
+    <p>
+      Manche Geräte legen zusätzlich eine zweite Kopie des Patientennamens in
+      einem privaten Feld ab, also einem Feld, dessen Bedeutung nirgends
+      veröffentlicht ist und das die meisten Anonymisierer in Ruhe lassen, weil
+      sie nicht wissen können, was darin steht.
+    </p>
+  </section>
+
+  <section>
+    <h2>Laden Sie die Aufnahme nicht hoch, um sie anzusehen</h2>
+    <p>
+      Der übliche Weg, dieses Problem zu lösen, ist eine Suche nach
+      &bdquo;dicom viewer online&ldquo; und ein Upload-Feld. Was gerade passiert
+      ist: Ein Fremder hat eine Kopie einer Krankenakte, die Pixel, den Namen,
+      das Geburtsdatum, die Patientennummer und den Schlüssel zurück ins Archiv.
+    </p>
+    <p>
+      Es gibt keinen Grund dafür. Eine DICOM-Datei zu lesen heißt, einen Header
+      zu parsen und ein paar Ganzzahlen auszupacken, und ein Browser kann das
+      hervorragend. Deshalb hat der <a href="../../dicom-viewer/">Viewer hier</a>
+      überhaupt keine Netzfunktion: kein <code>fetch</code>, kein
+      <code>XMLHttpRequest</code>, nichts, was eine Datei senden könnte, selbst
+      wenn etwas es versuchte. Laden Sie die Seite einmal, trennen Sie die
+      Internetverbindung, und sie öffnet weiter Aufnahmen.
+    </p>
+    <p>
+      <a href="../ist-das-hochladen-von-dateien-sicher/">Ist das Hochladen von
+      Dateien zu Online-Konvertern sicher?</a> zeigt, wie sich diese Behauptung
+      auf dieser Seite und auf jeder anderen prüfen lässt. Das ist der Dateityp,
+      bei dem sich das Prüfen am meisten lohnt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was ein Browser nicht kann</h2>
+    <p>
+      Zwei Dinge, und beide gehören deutlich gesagt.
+    </p>
+    <p>
+      <strong>Er ist kein Befundungs-Viewer.</strong> Ihr Bildschirm ist nicht
+      kalibriert, der Browser ist keine validierte Rendering-Kette, und keine
+      Webseite hat ein Zulassungsverfahren durchlaufen. Eine Aufnahme zu lesen,
+      um eine klinische Entscheidung zu treffen, ist Sache der Station, an der
+      sie befundet wurde. Nachzusehen, was auf einer CD ist, eine Schicht für
+      eine Lehrveranstaltung herauszuziehen, einen Header zu lesen oder
+      herauszufinden, warum ein anderes Programm die Datei verweigert, sind
+      allesamt gute Gründe, eine im Browser zu öffnen.
+    </p>
+    <p>
+      <strong>Manche komprimierten Aufnahmen lassen sich nicht dekodieren.</strong>
+      DICOM erlaubt mehrere Kompressionsverfahren, und Browser bringen eines
+      davon mit. Schlichte Dateien, lauflängenkodierte, Baseline JPEG und JPEG
+      Lossless, und Letzteres verwenden die meisten Klinik-Exporte, öffnen alle.
+      JPEG 2000, JPEG-LS und die Videoformate brauchen Codecs, die als
+      kompilierte Bibliothek mehrere Megabyte wiegen. Wo sich das Bild nicht
+      dekodieren lässt, ist der Header trotzdem vollständig lesbar, und das ist
+      meist ohnehin die Hälfte, wegen der Sie gekommen sind.
+    </p>
+  </section>

--- a/locales/de/pages/guides/open-a-dicom-file.toml
+++ b/locales/de/pages/guides/open-a-dicom-file.toml
@@ -1,0 +1,25 @@
+#
+# Ratgeber: eine DICOM-Datei öffnen - German.
+#
+# Die DICOM-Feldnamen und die Dateinamen auf einer Klinik-CD bleiben englisch
+# und behalten ihre Nummern - DICOMDIR, IM000001, Instance Number, Image
+# Position (Patient). So stehen sie auf der CD und im Standard.
+#
+
+nav = "Eine DICOM-Datei öffnen"
+title = "DICOM-Datei (.dcm) öffnen, ohne etwas zu installieren"
+description = "Was auf einer Klinik-CD liegt, warum die Dateien keine Endung haben, wie sich eine .dcm-Aufnahme im Browser öffnen lässt, was Fenster und Zentrum wirklich tun und was eine Aufnahme außer dem Bild noch über die Patientin trägt."
+
+heading = "Wie Sie eine DICOM-Datei öffnen, und was in einer steckt"
+lede = """
+    Eine Klinik-CD ist ein Ordner voller Dateien ohne Endung und ein Viewer, der
+    für Windows XP geschrieben wurde. Die Dateien sind DICOM, und daran ist
+    nichts Exotisches: Eine Aufnahme ist ein Header voller Felder und ein Block
+    Pixel. Hier steht, wie Sie eine ansehen, was die Regler bedeuten und was die
+    Datei außer dem Bild noch mit sich trägt."""
+
+updated = "25. August 2026"
+
+og_title = "Eine DICOM-Datei öffnen, ohne etwas zu installieren"
+og_description = "Was auf einer Klinik-CD liegt, warum die Dateien keine Endung haben und was eine .dcm-Aufnahme außer dem Bild noch über die Patientin trägt."
+og_image_alt = "abox.tools - Werkzeuge, die ohne Server auskommen"

--- a/locales/de/pages/guides/redact-a-pdf.html
+++ b/locales/de/pages/guides/redact-a-pdf.html
@@ -1,0 +1,246 @@
+  <section>
+    <h2>Die kurze Antwort</h2>
+    <p>
+      Öffnen Sie den <a href="../../pdf-schwaerzen/">PDF-Schwärzer</a>, ziehen
+      Sie das Dokument hinein, tippen Sie die Wörter, die weg müssen, kreuzen Sie
+      die an, die Sie meinen, und drücken Sie &bdquo;Entfernen&ldquo;. Die
+      Buchstaben werden aus den Zeichenanweisungen der Seite gelöscht, dieselben
+      Wörter werden aus Lesezeichen, Kommentaren, Formularfeldern und
+      Dokumenteigenschaften entfernt, und die fertige Datei wird vor Ihren Augen
+      erneut geöffnet und durchsucht, bevor sie Ihnen angeboten wird.
+    </p>
+    <p>
+      Alles Folgende erklärt, warum der letzte Halbsatz der wichtige ist, und wie
+      Sie erkennen, ob das Werkzeug, das Sie ohnehin benutzen, dasselbe von sich
+      sagen kann.
+    </p>
+  </section>
+
+  <section>
+    <h2>Um welches Versagen es hier geht</h2>
+    <p>
+      Zeichnen Sie in einem PDF-Betrachter ein schwarzes Rechteck über einen
+      Namen. Was Sie sehen, ist ein Name mit einem schwarzen Rechteck darüber.
+      Was die meisten Betrachter <em>speichern</em>, ist ein Dokument, das den
+      Namen enthält, und daneben ein Rechteck mit Position, Größe und Farbe.
+    </p>
+    <p>
+      Ein so gezeichnetes Rechteck ist eine <strong>Anmerkung</strong>: ein
+      Objekt, das neben der Seite sitzt und nicht in ihr. Der Text darunter ist
+      genau, wie er war. Markieren Sie den Bereich und drücken Sie Kopieren,
+      öffnen Sie die Datei in einem Programm, das Anmerkungen anders zeichnet,
+      oder lassen Sie irgendeinen Text-Extraktor darüberlaufen, und der Name ist
+      zurück. Nichts auf dem Bildschirm unterscheidet das von einer echten
+      Schwärzung, und genau deshalb passiert es weiterhin Organisationen, die
+      Juristen beschäftigen.
+    </p>
+    <p>
+      Es hat Gerichtsakten veröffentlicht, nachrichtendienstliche Bewertungen,
+      Verträge und im Dezember 2025 geschwärzte Namen in einer
+      Massenveröffentlichung von Dokumenten des US-Justizministeriums, die binnen
+      Stunden nach Erscheinen lesbar waren. Das Muster ist immer dasselbe. Das
+      Rechteck war die Anmerkung, und die Anmerkung war nie der Text.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was eine echte Schwärzung stattdessen tut</h2>
+    <p>
+      Eine Seite in einem PDF ist eine Liste von Anweisungen: setze diese
+      Schrift, führe den Stift hierhin, zeichne diese Glyphen. Die Wörter auf der
+      Seite existieren an genau einer Stelle, als Operanden dieser
+      Zeichenanweisungen:
+    </p>
+    <pre><code>BT /F1 12 Tf 72 700 Td (Sehr geehrter Herr Schmidt) Tj ET</code></pre>
+    <p>
+      Den Namen zu schwärzen heißt, <strong>diese Buchstaben aus dieser Anweisung
+      zu löschen</strong> und die Seite wieder herauszuschreiben. Danach gibt es
+      nichts wiederherzustellen, nicht weil die Datei es gut versteckt, sondern
+      weil die Buchstaben nicht in der Datei sind. Es gibt kein Rechteck mit
+      etwas darunter, weil darunter nichts ist.
+    </p>
+    <p>
+      Eines muss wieder hinein, sonst ist das Ergebnis sichtbar falsch. Text wird
+      gezeichnet, indem ein Stift über die Seite vorrückt, fünf Buchstaben zu
+      löschen zieht den Rest der Zeile also um fünf Buchstaben nach links:
+      Spalten stehen nicht mehr in einer Flucht, und Summen rutschen unter die
+      falsche Überschrift. Ein Werkzeug, das das richtig macht, misst, wie weit
+      die entfernten Buchstaben den Stift vorgerückt hätten, und setzt diesen
+      Abstand als Anweisung wieder ein, die den Stift bewegt, ohne etwas zu
+      zeichnen.
+    </p>
+    <p>
+      Der schwarze Kasten wird, wenn es einen gibt, <em>danach</em> gezeichnet,
+      über eine bereits leere Lücke. Er ist eine Höflichkeit gegenüber dem, der
+      das Dokument liest, ein Zeichen, dass etwas entfernt wurde, und nicht die
+      Schwärzung. Das ist der ganze Unterschied in einem Satz: Bei einer echten
+      Schwärzung ist der Kasten Verzierung; bei einer falschen <em>ist</em> der
+      Kasten die Schwärzung.
+    </p>
+  </section>
+
+  <section>
+    <h2>Die vier Orte, an denen ein Wort steckt und die keine Seite sind</h2>
+    <p>
+      Das ist der Teil, der die erwischt, die den ersten Teil richtig gemacht
+      haben. Ein PDF trägt Text an mehreren Stellen gleichzeitig, und ein
+      Betrachter zeigt, durchsucht oder kopiert sie alle. Einen Namen von der
+      Seite zu entfernen und an einer dieser Stellen zu lassen heißt, ihn nicht
+      entfernt zu haben.
+    </p>
+    <ul>
+      <li>
+        <strong>Die Dokumenteigenschaften.</strong> Titel, Autor und der Name der
+        Datei, aus der diese exportiert wurde. Ein Dokument, aus dessen Seiten ein
+        Name entfernt wurde und dessen Eigenschaften weiterhin
+        <code>Schmidt Vergleich Entwurf 3.docx</code> lauten, ist nicht
+        geschwärzt. Meist gibt es eine zweite Kopie derselben Angaben in einem
+        XMP-Paket, das ebenfalls gehen muss.
+      </li>
+      <li>
+        <strong>Lesezeichen.</strong> Die Gliederung am Rand eines Betrachters
+        ist eine Liste von Überschriften mit angehängten Seitenzahlen, und eine
+        Überschrift ist eine Textzeile, über die nichts auf der Seite bestimmt.
+      </li>
+      <li>
+        <strong>Formularfelder und Kommentare.</strong> Was jemand in ein Formular
+        getippt hat, wird zweimal gespeichert: einmal als Wert des Feldes und
+        einmal als das Aussehen, das der Betrachter zeichnet. Beides muss gehen.
+        Ein Notizzettel trägt seinen Text und den Namen dessen, der ihn
+        geschrieben hat.
+      </li>
+      <li>
+        <strong>Der Ersatztext.</strong> Ein PDF darf erklären, dass eine Folge
+        von Glyphen etwas anderes &bdquo;buchstabiert&ldquo;, damit eine Ligatur
+        oder eine getrennte Zeile als das Wort kopiert, für das sie steht. Das
+        heißt, ein Dokument kann das eine zeigen und einem Leser bei Strg+C etwas
+        anderes übergeben, und eine Schwärzung, die nur das Gezeichnete entfernt,
+        ließe den Satz für jeden intakt, der den Absatz markiert.
+      </li>
+    </ul>
+    <p>
+      Anhänge sind der fünfte. Ein PDF kann ganze andere Dateien in sich tragen,
+      und nichts, was Sie mit den Seiten tun, berührt sie.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wie Sie eine Datei prüfen, in dreißig Sekunden</h2>
+    <p>
+      Machen Sie das mit allem, was Sie verschicken wollen, gleich welches
+      Werkzeug es erzeugt hat. Es ist die Prüfung, die jedes einzelne der
+      veröffentlichten Versagen aufgedeckt hätte.
+    </p>
+    <ol>
+      <li>
+        <strong>Öffnen Sie die fertige Datei und drücken Sie Strg+F</strong>
+        (Cmd+F auf einem Mac). Suchen Sie nach dem entfernten Wort. Eine echte
+        Schwärzung liefert nichts. Springt der Betrachter zu einem schwarzen
+        Rechteck, ist das Wort noch da und das Rechteck sitzt darauf.
+      </li>
+      <li>
+        <strong>Markieren Sie den geschwärzten Bereich und kopieren Sie ihn.</strong>
+        Ziehen Sie über das Rechteck, drücken Sie Strg+C und fügen Sie es in ein
+        Textfeld ein. Kommt irgendetwas an, haben Sie dasselbe Versagen von der
+        anderen Seite gefunden.
+      </li>
+      <li>
+        <strong>Markieren Sie das ganze Dokument und kopieren Sie das.</strong>
+        Strg+A, dann Strg+C, in einen beliebigen Texteditor einfügen und lesen,
+        was herauskommt. Das ist die nützlichste der drei, weil sie Ihnen das
+        Dokument so zeigt, wie ein Text-Extraktor es sieht, einschließlich Text,
+        von dem Sie nichts wussten, was auf einer eingescannten Seite häufig
+        vorkommt.
+      </li>
+      <li>
+        <strong>Sehen Sie in die Eigenschaften</strong>, in den meisten
+        Betrachtern unter Datei → Eigenschaften, und in die Lesezeichenleiste.
+        Beides sind Orte, an denen ein Name eine auf der Seite perfekte
+        Schwärzung überlebt.
+      </li>
+    </ol>
+    <p>
+      Der <a href="../../pdf-schwaerzen/">PDF-Schwärzer</a> führt die erste und
+      die dritte für Sie aus und zeigt die Zahl, denn ein Werkzeug, das behauptet,
+      es habe etwas entfernt, ist kein Beleg, und eine Suche in der fertigen Datei
+      ist einer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Eingescannte Dokumente sind ein anderes Problem</h2>
+    <p>
+      Ein Scan ist ein Foto einer Seite. Die Wörter darauf sind Pixel und kein
+      Text, und keine noch so gründliche Bearbeitung der Textebene berührt sie,
+      weil es keine Textebene gibt oder weil die vorhandene das Bild beschreibt,
+      statt es zu sein.
+    </p>
+    <p>
+      Die meisten heutigen Scanner und PDF-Werkzeuge legen eine unsichtbare
+      Textebene über das Bild, geschrieben von einer Zeichenerkennung, damit die
+      Seite durchsuchbar ist. Diese Ebene ist echter Text und lässt sich
+      entfernen. Sie zu entfernen lohnt sich: Sie ist das, was eine Suche, ein
+      Kopieren und jedes automatische System, das Dokumente liest, gefunden
+      hätten. Am Bild ändert es nichts, und dort sind die Wörter für jeden, der
+      auf die Seite sieht, weiterhin bestens lesbar.
+    </p>
+    <p>
+      Für einen Scan ist die ehrliche Reihenfolge also: die Wörter aus der
+      Textebene nehmen und sich dann getrennt um das Bild kümmern, und das heißt
+      Pixel überschreiben. Genau das tut der
+      <a href="../bild-unkenntlich-machen/">Bild-Schwärzer</a>, und der Ratgeber
+      daneben erklärt, warum Weichzeichnen oder ein Mosaik für Text nicht
+      genügen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum nicht einfach ausdrucken und neu einscannen</h2>
+    <p>
+      Weil es funktioniert und Sie alles andere kostet. Eine geschwärzte Seite
+      auszudrucken und wieder einzuscannen liefert tatsächlich ein Dokument ohne
+      Textebene, die lecken könnte, und ein Dokument, das niemand durchsuchen
+      kann, das kein Screenreader lesen kann, das fünf- bis fünfzigmal so groß
+      ist und dessen Qualität davon abhängt, wozu der Bürokopierer gerade
+      aufgelegt war. Es setzt außerdem voraus, dass die Seite so gedruckt hat,
+      wie sie aussah: Eine Anmerkung kann als &bdquo;am Bildschirm anzeigen, nicht
+      drucken&ldquo; markiert sein, und wenn das Ihr schwarzer Kasten war, steht
+      auf dem Blatt aus dem Drucker der Name.
+    </p>
+    <p>
+      Dasselbe Argument gilt für &bdquo;auf ein Bild reduzieren&ldquo;, das
+      manche Werkzeuge als Schwärzung anbieten. Es macht aus jeder Seite ein Foto
+      ihrer selbst. Waren die Wörter verdeckt statt gelöscht, ist die Verdeckung
+      nun dauerhaft, aber alles andere am Dokument ist mit ihr gegangen, und die
+      Datei, die Sie verschicken, ist eine, mit der niemand arbeiten kann.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum diese Aufgabe einen Upload am wenigsten verträgt</h2>
+    <p>
+      Einem Schwärzungsdienst muss die ungeschwärzte Datei übergeben werden. Das
+      ist der ganze Vorgang: Die private Fassung kommt zuerst an, vollständig,
+      und ist die Fassung, die auf einer fremden Festplatte liegt. Was die
+      Datenschutzerklärung auch sagt, an der Reihenfolge lässt sich nicht rütteln:
+      Das Dokument, mit dem Sie vorsichtig sein wollten, ist das, das Sie
+      herausgegeben haben.
+    </p>
+    <p>
+      Was Leute schwärzen, macht das schlimmer, als es klingt. Zeugenaussagen,
+      Arztbriefe, Kontoauszüge für den Vermieter, ein Vertrag mit dem Namen eines
+      Mandanten darin, der an einen anderen geht, ein Schriftsatz mit einer
+      Privatadresse. Das sind die Dokumente, und genau deshalb sollte das Werkzeug
+      dafür keinen Server am anderen Ende haben.
+    </p>
+    <p>
+      Alles am <a href="../../pdf-schwaerzen/">Schwärzer dieser Seite</a> passiert
+      in Ihrem eigenen Browser: Die Datei wird auf Ihrem Gerät gelesen,
+      bearbeitet, geschrieben und geprüft, und die Wörter, nach denen Sie suchen,
+      verlassen den Tab ebenfalls nie. Trennen Sie die Internetverbindung, und es
+      arbeitet weiter, und das ist der einfachste Beleg dafür, dass nichts
+      irgendwohin gesendet wird. Was ein Upload eigentlich bedeutet, steht unter
+      <a href="../ist-das-hochladen-von-dateien-sicher/">ist das Hochladen von
+      Dateien sicher</a>.
+    </p>
+  </section>

--- a/locales/de/pages/guides/redact-a-pdf.toml
+++ b/locales/de/pages/guides/redact-a-pdf.toml
@@ -1,0 +1,21 @@
+#
+# Ratgeber: ein PDF schwärzen - German.
+#
+
+nav = "Ein PDF schwärzen"
+title = "PDF schwärzen, sodass der Text wirklich weg ist"
+description = "Ein in einem PDF-Betrachter gezeichneter schwarzer Kasten lässt die Wörter darunter meist stehen, und Kopieren und Einfügen holt sie sofort zurück. Was eine echte Schwärzung entfernt, die vier Orte, an denen ein Wort außerhalb der Seite steckt, und wie Sie eine Datei prüfen, bevor Sie sie verschicken."
+
+heading = "So schwärzen Sie ein PDF, damit der Text wirklich weg ist"
+lede = """
+    Ein schwarzes Rechteck über einem Namen und ein gelöschter Name sehen auf
+    dem Bildschirm gleich aus. Eines von beiden übersteht das Markieren und
+    Kopieren. Hier steht der Unterschied, die Orte, an denen ein Wort steckt und
+    die gar keine Seite sind, und die Prüfung von dreißig Sekunden, die Ihnen
+    sagt, welches der beiden Sie vor sich haben."""
+
+updated = "25. August 2026"
+
+og_title = "So schwärzen Sie ein PDF, damit der Text wirklich weg ist"
+og_description = "Warum ein schwarzer Kasten in einem PDF-Betrachter meist keine Schwärzung ist, die vier Orte, an denen ein Wort außerhalb der Seite steckt, und wie Sie eine Datei prüfen, bevor Sie sie verschicken."
+og_image_alt = "abox.tools - Werkzeuge, die ohne Server auskommen"

--- a/locales/de/pages/guides/scan-a-document-with-your-phone.html
+++ b/locales/de/pages/guides/scan-a-document-with-your-phone.html
@@ -1,0 +1,253 @@
+  <section>
+    <h2>Die kurze Antwort</h2>
+    <p>
+      Legen Sie die Seite auf etwas, das nicht dieselbe Farbe hat wie die Seite,
+      stellen Sie sich darüber, füllen Sie das Bild und machen Sie ein Foto.
+      Öffnen Sie dann den <a href="../../dokumente-scannen/">Dokumentenscanner</a>,
+      prüfen Sie die vier gefundenen Ecken, wählen Sie &bdquo;Farbe,
+      ausgeglichen&ldquo; oder &bdquo;Schwarzweiß&ldquo; und speichern Sie das
+      PDF.
+    </p>
+    <p>
+      Das ist die ganze Aufgabe. Der Rest erklärt, was jeder dieser Schritte
+      behebt, denn zu wissen, welcher Teil was tut, ist das, was Sie in drei
+      Sekunden erkennen lässt, ob das, was Sie gleich verschicken, angenommen
+      wird.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was ein Foto wirklich von einem Scan unterscheidet</h2>
+    <p>
+      Drei Dinge, und sie sind nicht gleich wichtig.
+    </p>
+    <ul>
+      <li>
+        <strong>Die Schräglage.</strong> Ein Foto entsteht dort, wo Sie gerade
+        standen, die Seite ist also ein Viereck und kein Rechteck. Das ist das,
+        was jeder bemerkt, und das am leichtesten Rückgängigzumachende.
+      </li>
+      <li>
+        <strong>Das Licht.</strong> Ein Scanner zieht ein gleichmäßiges Licht
+        über die Seite. Ein Zimmer tut das nicht: Unter der Lampe ist ein heller
+        Fleck, von ihr weg eine dunkle Ecke, und sehr oft liegt Ihr eigener
+        Schatten quer über einer Seite. Das ist es, was ein Foto tatsächlich wie
+        ein Foto aussehen lässt, und das, was Leute mit
+        &bdquo;Auto-Kontrast&ldquo; zu beheben versuchen, was es schlimmer macht.
+      </li>
+      <li>
+        <strong>Die Größe.</strong> Ein Zwölf-Megapixel-Foto einer Seite sind
+        drei bis fünf Megabyte. Zwanzig davon sind ein Dokument, das an der
+        Hälfte der Mailserver abprallt, an die es geschickt wird.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Das Foto machen</h2>
+    <p>
+      Fünf Dinge, geordnet danach, wie viel sie ausmachen:
+    </p>
+    <ul>
+      <li>
+        <strong>Füllen Sie das Bild.</strong> Das ist das Einzige, was sich
+        danach nicht beheben lässt. Details, die nicht im Foto waren, sind nicht
+        in der Datei, und eine vom anderen Ende des Zimmers fotografierte Seite
+        ist eine Seite, die bei keiner Auflösung jemand lesen kann. Gehen Sie
+        näher heran, statt zu zoomen: Wenn das Handy nicht auf ein zweites,
+        längeres Objektiv umschaltet, ist Hineinzoomen ein Ausschnitt desselben
+        Sensors und wirft genau die Pixel weg, die Sie behalten wollen.
+      </li>
+      <li>
+        <strong>Legen Sie sie auf etwas mit einer anderen Farbe.</strong> Eine
+        weiße Seite auf einem weißen Schreibtisch hat fast keine Kante, an der
+        sich irgendetwas orientieren könnte, weder eine Software noch Sie selbst,
+        wenn Sie die Ecken von Hand ziehen wollen. Ein dunkler Tisch, ein Buch,
+        ein Mantel: irgendetwas.
+      </li>
+      <li>
+        <strong>Stellen Sie sich nicht zwischen Seite und Licht.</strong> Ihr
+        eigener Schatten quer über der Seite ist der häufigste einzelne Grund,
+        warum ein Handy-Scan schlecht aussieht. Drehen Sie sich um neunzig Grad,
+        und er ist weg.
+      </li>
+      <li>
+        <strong>Lassen Sie scharfstellen, dann halten Sie still.</strong>
+        Verwackeln kann kein Werkzeug zurückholen, und einen verfehlten Fokus
+        ebenso wenig. Tippen Sie die Seite auf dem Bildschirm an, warten Sie, bis
+        es steht, und lösen Sie dann aus.
+      </li>
+      <li>
+        <strong>Nehmen Sie die ganze Seite mit, samt Ecken.</strong> Nicht weil
+        die Ecken kostbar wären, sondern weil an ihnen das Geraderücken gemessen
+        wird. Eine Seite, die über den Bildrand hinausläuft, funktioniert noch;
+        dann steht der Rand des Fotos für den Rand der Seite. Eine Seite mit drei
+        Ecken im Bild und einer geratenen ist eine Seite, die leicht schief
+        herauskommt.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Geraderücken: die Form zählt mehr als der Winkel</h2>
+    <p>
+      Die Schräglage herauszurechnen ist gut verstandene Mathematik. Vier Ecken
+      eines Rechtecks, von irgendwoher gesehen, bestimmen die Transformation, die
+      sie zurücksetzt, und diese auf jedes Pixel angewandt ergibt eine flache
+      Seite. Jedes Werkzeug, das behauptet, eine Seite geradezurücken, tut das.
+    </p>
+    <p>
+      Still schiefgeht der Teil, <em>wie groß</em> die flache Seite sein soll.
+      Die naheliegende Methode ist, die Kanten des Vierecks zu messen und ihr
+      Verhältnis zu nehmen, und ein schräg aufgenommenes Foto verkürzt die
+      entfernte Kante, also kommt ein Blatt A4 sichtbar gedrungen heraus. Es sieht
+      trotzdem aus wie ein Scan. Nur ist jede Textzeile darauf schlicht falsch
+      hoch, und nichts auf dem Bildschirm sagt es.
+    </p>
+    <p>
+      Die bessere Antwort ist, dass die Perspektive selbst die Information trägt:
+      Sofern es eine gewöhnliche Kamera ist, genügt das Foto eines Rechtecks, um
+      sowohl die wahren Proportionen des Rechtecks als auch die Brennweite der
+      Kamera zurückzugewinnen. Der
+      <a href="../../dokumente-scannen/">Dokumentenscanner</a> hier tut das und
+      sagt Ihnen anschließend, welche Form die Seite bekommen hat und ob das ein
+      Standardformat ist. Eine Seite, bei der &bdquo;1:1,41, und das ist die Form
+      von A4 oder A5&ldquo; steht, ist eine Seite, über die Sie nicht mehr
+      nachdenken müssen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Das Licht: teilen, nicht spreizen</h2>
+    <p>
+      Den Kontrast einer ungleichmäßig ausgeleuchteten Seite anzuheben macht den
+      hellen Teil weiß und den dunklen schwarz, und die Schrift im dunklen Teil
+      verschwindet mit. Das Problem war nie, dass der Kontrast zu niedrig war. Es
+      ist, dass das Papier in der einen Ecke nicht so hell ist wie in der anderen,
+      es gibt also keine einzelne Korrektur, die für die ganze Seite richtig ist.
+    </p>
+    <p>
+      Was hilft, ist zu schätzen, wie hell das Papier <em>an jeder Stelle</em>
+      ist, und dadurch zu teilen. Papier ist die helle Mehrheit jedes kleinen
+      Ausschnitts einer Seite, die Helligkeit über ein Raster kleiner Kacheln zu
+      messen und in jeder einen hohen Wert zu nehmen ergibt also die Form des
+      Lichts; Text ist zu dunkel und zu spärlich, um sie zu verschieben. Teilen
+      Sie dadurch, und übrig bleibt die Tinte, gleichmäßig ausgeleuchtet, ohne
+      Schatten und mit wieder weißem Papier.
+    </p>
+    <p>
+      Das ist es, was &bdquo;Farbe, ausgeglichen&ldquo; und
+      &bdquo;Graustufen&ldquo; tun. Nehmen Sie Farbe, wenn die Farbe zum Dokument
+      gehört: ein Stempel, eine Unterschrift in blauer Tinte, eine markierte
+      Zeile, alles, wonach später jemand fragen könnte, ob es das Original war.
+    </p>
+  </section>
+
+  <section>
+    <h2>Schwarzweiß, und warum die Datei plötzlich klein wird</h2>
+    <p>
+      Eine als Foto gespeicherte Seite sind Millionen Pixel mit je sechzehn
+      Millionen möglichen Farben, und der Codec verwendet seine Mühe auf feine
+      Verläufe, die eine Textseite nicht hat. Eine als Schwarzweiß gespeicherte
+      Seite ist ein Bit pro Pixel, Tinte oder Papier, und komprimiert wie das
+      überwältigend gleichförmige Ding, das sie ist.
+    </p>
+    <p>
+      Der Unterschied ist nicht klein: Auf denselben Seiten sind es etwa
+      achtzehnmal. Ein zwanzigseitiger Vertrag, der als Fotos fünfzehn Megabyte
+      wiegt, landet als Ein-Bit-Seiten unter einem Megabyte, und das ist der
+      Unterschied zwischen einem Dokument, das sich per E-Mail schicken lässt, und
+      einem, das es nicht tut. Deshalb steht das bei jedem Bürogerät als
+      Voreinstellung.
+    </p>
+    <p>
+      Der Haken ist, dass es keine Halbtöne gibt: Ein Foto auf der Seite wird zu
+      einem Durcheinander aus Punkten. Nehmen Sie es für bedruckte und
+      beschriebene Seiten, und das sind die meisten Dokumente, und nehmen Sie
+      Graustufen für alles mit einem Bild darauf.
+    </p>
+    <p>
+      Ein Detail lohnt sich zu wissen, weil es erklärt, warum ein gutes Werkzeug
+      gelingt, wo ein schlechtes eine Seite mit schwarzer Ecke liefert: Die
+      Entscheidung Tinte oder Papier muss <em>örtlich</em> fallen. Ein einzelner
+      Schwellwert für die ganze Seite kann nicht funktionieren, wenn das Papier
+      im Schatten dunkler ist als die Tinte im Licht, und auf einer
+      fotografierten Seite ist es das sehr oft. Jedes Pixel gegen den Mittelwert
+      seiner eigenen kleinen Nachbarschaft zu entscheiden, ist das, was Schrift in
+      einem Schatten lesbar hält.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mehrere Seiten, ein Dokument</h2>
+    <p>
+      Fotografieren Sie die Seiten der Reihe nach, fügen Sie alle auf einmal
+      hinzu, und sie werden die Seiten eines PDF in der Reihenfolge, in der sie
+      hinzugefügt wurden. Zwei Dinge sind zu beachten:
+    </p>
+    <ul>
+      <li>
+        <strong>Dateinamen sortieren nicht so, wie Sie denken.</strong>
+        <code>seite2.jpg</code> kommt in einer alphabetischen Sortierung nach
+        <code>seite10.jpg</code>, weil zeichenweise verglichen wird. Prüfen Sie
+        die Reihenfolge im Streifen, bevor Sie speichern, und nicht danach im
+        PDF.
+      </li>
+      <li>
+        <strong>Das Aufräumen ist eine Einstellung für das ganze Dokument</strong>,
+        und zwar mit Absicht. Unterschiedlich aufgeräumte Seiten sehen aus wie
+        zwei zusammengeheftete Dokumente, und genau diesen Eindruck soll ein Scan
+        vermeiden. Nehmen Sie den Modus, der zur schlechtesten Seite passt.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bevor Sie es verschicken</h2>
+    <ul>
+      <li>
+        <strong>Öffnen Sie das PDF.</strong> Nicht die Vorschau, die Datei. Jede
+        Seite, richtig herum, nichts an einem Rand abgeschnitten.
+      </li>
+      <li>
+        <strong>Lesen Sie das Kleinste auf der Seite.</strong> Ein Aktenzeichen,
+        ein Datum, eine Kontonummer. Wenn Sie es am Bildschirm bei 100% nicht
+        lesen können, kann der Empfänger es auch nicht.
+      </li>
+      <li>
+        <strong>Prüfen Sie, dass die Ecken nicht abgeschnitten sind.</strong> Am
+        Rand eines Formulars steht eine Seitenzahl, eine Unterschriftszeile oder
+        das Feld, von dem später jemand sagen wird, es habe gefehlt.
+      </li>
+      <li>
+        <strong>Prüfen Sie, was das Dokument über Sie sagt.</strong> Ein PDF hat
+        Felder für Autor, Producer und Erstellungsdatum, und die meisten Werkzeuge
+        füllen sie. Ob das zählt, hängt vom Empfänger ab, aber es lohnt sich zu
+        wissen, dass es da ist.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Warum nichts davon einen Upload braucht</h2>
+    <p>
+      Jeder Schritt oben ist Rechnen auf einem Bild, das Ihr eigenes Gerät
+      ohnehin schon dekodiert hat: vier Ecken, eine Transformation, eine Division,
+      ein Schwellwert und ein Byte für Byte geschriebener Container. Nichts davon
+      kann ein Server, was ein Browser nicht kann, und nichts davon braucht ein
+      heruntergeladenes Modell.
+    </p>
+    <p>
+      Darüber lohnt sich innezuhalten, wegen dessen, was diese Dateien sind. Leute
+      fotografieren Seiten nicht zufällig. Sie fotografieren einen Reisepass, eine
+      Gehaltsabrechnung, einen Mietvertrag, ein medizinisches Formular, einen
+      Vertrag, also Dokumente mit einem Namen, einer Adresse und einer Kontonummer
+      darauf, eingescannt genau deshalb, weil eine Institution danach gefragt hat.
+      Eines davon auf eine Website zu laden, damit ihm die Ecken geradegerückt
+      werden, übergibt einem Fremden das ganze Dokument. Siehe
+      <a href="../ist-das-hochladen-von-dateien-sicher/">wie Sie erkennen, ob ein
+      Werkzeug Ihre Dateien wirklich braucht</a> für die vier Prüfungen, die die
+      Werkzeuge, die Ihre Datei sehen müssen, von denen trennen, die es einfach
+      tun.
+    </p>
+  </section>

--- a/locales/de/pages/guides/scan-a-document-with-your-phone.toml
+++ b/locales/de/pages/guides/scan-a-document-with-your-phone.toml
@@ -1,0 +1,21 @@
+#
+# Ratgeber: ein Dokument mit dem Handy scannen - German.
+#
+
+nav = "Mit dem Handy scannen"
+title = "Dokument mit dem Handy scannen, ohne App und ohne Upload"
+description = "Was ein Foto einer Seite von einem Scan derselben Seite unterscheidet: die Schräglage, das ungleichmäßige Licht und die Dateigröße. Wie Sie das Foto machen, was sich danach beheben lässt und warum nichts davon einen Server braucht."
+
+heading = "So scannen Sie ein Dokument mit dem Handy"
+lede = """
+    Jemand hat Sie gebeten, ein Formular &bdquo;eingescannt zurück&ldquo; zu
+    schicken, und Sie haben ein Handy und keinen Scanner. Der Abstand zwischen
+    einem Foto einer Seite und einem Scan derselben Seite ist kleiner, als er
+    aussieht, und es geht dabei überwiegend nicht um die Schräglage. Hier steht,
+    was die beiden wirklich trennt und was gegen jeden Teil davon hilft."""
+
+updated = "25. August 2026"
+
+og_title = "So scannen Sie ein Dokument mit dem Handy"
+og_description = "Die Schräglage, der Schatten und die Dateigröße - was ein Foto einer Seite von einem Scan unterscheidet und wie Sie jedes davon beheben, ohne die Seite hochzuladen."
+og_image_alt = "abox.tools - Werkzeuge, die ohne Server auskommen"

--- a/locales/de/pages/guides/stack-photos-to-reduce-noise.html
+++ b/locales/de/pages/guides/stack-photos-to-reduce-noise.html
@@ -1,0 +1,310 @@
+  <section>
+    <h2>Die kurze Antwort</h2>
+    <p>
+      Öffnen Sie den <a href="../../bilder-stacken/">Bild-Stacker</a>, ziehen Sie
+      die ganze Serie hinein und wählen Sie die Methode danach, was weg soll:
+    </p>
+    <ul>
+      <li><strong>Rauschen</strong>, und nichts hat sich bewegt &mdash; Mittelwert.</li>
+      <li><strong>Rauschen</strong>, und etwas hat sich bewegt &mdash; Sigma-Clipping.</li>
+      <li><strong>Leute, Autos, ein Flugzeug</strong> &mdash; Median.</li>
+      <li><strong>Ein dunkler Himmel, der Sternspuren werden soll</strong> &mdash; Aufhellen.</li>
+      <li><strong>Eine Makroaufnahme mit fast keiner Schärfentiefe</strong> &mdash; Focus Stacking.</li>
+    </ul>
+    <p>
+      Lassen Sie das Ausrichten an, wenn die Kamera in Ihren Händen war, und
+      schalten Sie es ab, wenn sie auf einem Stativ stand. RAW-Dateien können
+      direkt hinein; sie müssen vorher nicht entwickelt werden.
+    </p>
+    <p>
+      Alles Folgende erklärt, warum diese fünf Zeilen so lauten, wie sie lauten.
+    </p>
+  </section>
+
+  <section>
+    <h2>Warum eine Serie mehr trägt als eine Aufnahme</h2>
+    <p>
+      Ein bei schlechtem Licht aufgenommenes Foto ist das Bild plus Rauschen, und
+      das Rauschen ist jedes Mal ein anderes. Genau dieser letzte Teil lässt
+      Stacken funktionieren. Machen Sie dieselbe Aufnahme sechzehnmal, und das
+      Bild ist in allen sechzehn dasselbe, während das Rauschen es nicht ist; sie
+      zu mitteln lässt das Bild stehen und hebt das meiste Rauschen auf.
+    </p>
+    <p>
+      Die Verbesserung ist die Wurzel aus der Anzahl der Aufnahmen. Vier
+      Aufnahmen halbieren das Rauschen. Sechzehn vierteln es. Hundert senken es
+      auf ein Zehntel. Das ist eine unbarmherzige Kurve, auf der man sitzt: Von
+      sechzehn auf vierundsechzig Aufnahmen zu gehen bringt dieselbe Verbesserung
+      noch einmal, für die vierfache Fotografiererei. Deshalb liegt fast jeder
+      praktische Stapel zwischen acht und dreißig Aufnahmen.
+    </p>
+    <p>
+      Es gibt einen zweiten, leiseren Gewinn. Sechzehn Acht-Bit-Aufnahmen zu
+      mitteln ergibt ein Bild mit feineren Abstufungen, als eine einzelne von
+      ihnen hatte, weil genau das Rauschen, das jede Aufnahme anders runden ließ,
+      den Mittelwert zwischen den Stufen landen lässt. Eine verrauschte Serie zu
+      stacken entfernt nicht nur Rauschen; es holt Tonwerte zurück, die eine
+      einzelne Aufnahme wegquantisiert hat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Die Frage, die die Methode wählt</h2>
+    <p>
+      Nicht &bdquo;was will ich behalten&ldquo;, sondern <strong>was war zwischen
+      den Aufnahmen verschieden</strong>. Alles andere folgt daraus.
+    </p>
+
+    <h3>Nichts hat sich bewegt: Mittelwert</h3>
+    <p>
+      Das schlichte arithmetische Mittel. Es ist die wirksamste Rauschminderung,
+      die es für eine Serie gibt, in der sich die Aufnahmen nur im Rauschen
+      unterscheiden, und die am leichtesten zu ruinierende: Eine Aufnahme mit
+      einem Vogel darin legt einen blassen Vogel über den ganzen Stapel, weil ein
+      Mittelwert keine Meinung zu einem Wert hat, der den anderen widerspricht.
+      Er nimmt ihn einfach mit.
+    </p>
+
+    <h3>Etwas ist durchs Bild gelaufen: Median</h3>
+    <p>
+      Legen Sie ein Dutzend Fotos eines belebten Platzes übereinander und sehen
+      Sie sich ein Pixel an. In den meisten ist es Pflaster; in ein, zwei ist es
+      der Mantel von jemandem. Sortieren Sie diese zwölf Werte und nehmen Sie den
+      mittleren, und Sie bekommen Pflaster, weil der Mantel nie in der Mehrheit
+      war.
+    </p>
+    <p>
+      Tun Sie das für jedes Pixel, und der Platz kommt leer heraus. Das ist der
+      Kniff hinter jedem Artikel über &bdquo;Touristen aus dem Urlaubsfoto
+      entfernen&ldquo;, und er braucht nichts Klügeres als eine Serie und Geduld.
+      Das Einzige, was er verlangt, ist, dass <strong>kein Teil der Szene mehr
+      als die Hälfte der Zeit besetzt ist</strong>. Eine Person, die in acht Ihrer
+      zwölf Aufnahmen stillsteht, ist an diesen Pixeln die Mehrheit, und der
+      Median behält sie.
+    </p>
+
+    <h3>Beides: Sigma-Clipping</h3>
+    <p>
+      Der Median wirft den größten Teil der Information weg, um seine
+      Unempfindlichkeit zu bekommen: Elf Ihrer zwölf Werte werden an jedem Pixel
+      verworfen, er senkt das Rauschen also weit weniger, als ein Mittelwert
+      derselben Serie es täte.
+    </p>
+    <p>
+      Sigma-Clipping ist der Kompromiss, und er ist für jede Serie aus der
+      wirklichen Welt meist die richtige Voreinstellung. Er sieht sich jedes Pixel
+      über alle Aufnahmen hinweg an, ermittelt, was es üblicherweise ist und wie
+      stark es schwankt, und mittelt dann nur die Werte, die dazu passen. Ein
+      Auto, das durch eine Aufnahme gefahren ist, wird an diesen Pixeln
+      ausgeschlossen; jede andere Aufnahme zählt überall weiter. Sie bekommen die
+      Unempfindlichkeit des Medians gegenüber Bewegtem und den größten Teil der
+      Rauschminderung des Mittelwerts.
+    </p>
+    <p>
+      Die Schwelle steht in Standardabweichungen, und zwei sind der übliche
+      Ausgangspunkt. Niedriger verwirft mehr und fängt an, echte Details
+      mitzuverwerfen.
+    </p>
+
+    <h3>Nur das Helle zählt: Aufhellen</h3>
+    <p>
+      Den hellsten Wert behalten, den jedes Pixel je hatte. Fotografieren Sie den
+      Nachthimmel als zweihundert Dreißigsekunden-Belichtungen und hellen Sie sie
+      zusammen auf, und jeder Stern zeichnet seinen eigenen Bogen über das
+      Ergebnis: eine Sternspur, zusammengesetzt aus kurzen Belichtungen, die für
+      sich nie ausgefressen sind. Dieselbe Methode setzt ein Feuerwerk aus den
+      Aufnahmen seiner eigenen Explosion zusammen und eine Lichtmalerei aus einem
+      Gang mit der Taschenlampe durch einen dunklen Raum.
+    </p>
+    <p>
+      Das Gegenstück, Abdunkeln, ist das stille der beiden: Ein Pixel bleibt nur
+      hell, wenn es in <em>jeder</em> Aufnahme hell war, also verschwinden
+      Spiegelungen in einer Scheibe, vorbeifahrende Scheinwerfer und vom Blitz
+      angeleuchtete Regentropfen.
+    </p>
+
+    <h3>Das Motiv ist tiefer als die Schärfe: Focus Stacking</h3>
+    <p>
+      Eine Makroaufnahme bei f/8 hat vielleicht einen Millimeter in der Schärfe,
+      und das genügt für ein Insekt nicht. Die Antwort ist, zwanzig Aufnahmen
+      entlang des Fokusrings zu machen und von jeder nur den Teil zu behalten, der
+      darin scharf war. Das Werkzeug misst, wie stark sich jedes Pixel von seinen
+      Nachbarn unterscheidet, groß an einer Kante, nahe null in einer Unschärfe,
+      und nimmt den Sieger.
+    </p>
+    <p>
+      Diese Methode will ein Stativ mehr als jede andere, weil der Fokusring von
+      Hand die Kamera bewegt, und eine Aufnahme aus etwas größerer Entfernung ist
+      nicht dasselbe Bild bei anderer Schärfe.
+    </p>
+  </section>
+
+  <section>
+    <h2>Die Aufnahmen ausrichten</h2>
+    <p>
+      Stacken ist Rechnen Pixel für Pixel, es setzt also voraus, dass ein
+      bestimmtes Pixel in jeder Aufnahme derselbe Teil der Szene ist. Aus der Hand
+      ist es das nicht: Eine Serie driftet um Dutzende Pixel, und das zu mitteln
+      ergibt eine Unschärfe statt eines sauberen Bildes. Das ist der häufigste
+      einzelne Grund, warum ein erster Versuch mit Stacken enttäuscht.
+    </p>
+    <p>
+      Also werden die Aufnahmen gegen eine von ihnen vermessen und zuerst an ihren
+      Platz zurückgeschoben, auf Bruchteile eines Pixels genau. Drei
+      Einstellungen:
+    </p>
+    <ul>
+      <li>
+        <strong>Nur verschieben</strong> ist für fast alles aus der Hand richtig.
+        Es korrigiert die Drift und das Wackeln.
+      </li>
+      <li>
+        <strong>Verschieben, drehen und skalieren</strong> für eine Serie, bei der
+        Sie sich zusätzlich leicht gedreht haben oder bei der ein Zoom
+        gewandert ist. Es kostet eine Messung mehr je Aufnahme und gar nichts,
+        wenn die Aufnahmen sich als gerade erweisen.
+      </li>
+      <li>
+        <strong>Gar nicht</strong> für ein festes Stativ oder eine Intervallserie,
+        wo die Aufnahmen bereits ausgerichtet sind und sie zu vermessen verlorene
+        Zeit ist.
+      </li>
+    </ul>
+    <p>
+      Was kein Ausrichten beheben kann, ist ein Motiv, das sich bewegt hat, statt
+      einer Kamera, die sich bewegt hat, und ein Foto, das einen Schritt weiter
+      links aufgenommen wurde, ebenso wenig. Sich seitwärts zu bewegen ändert, wie
+      stark das Nahe sich gegenüber dem Fernen verschiebt, und keine einzelne
+      Korrektur beschreibt beides zugleich. Sich auf der Stelle zu drehen ist in
+      Ordnung; zu gehen nicht.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wo RAW-Dateien hineinpassen</h2>
+    <p>
+      Sie können CR2, CR3, NEF, ARW, DNG, RAF, RW2, ORF und den Rest direkt
+      hineinziehen, und es lohnt sich, genau zu sagen, was mit ihnen geschieht,
+      denn es ist nicht das, was ein RAW-Konverter tut.
+    </p>
+    <p>
+      Jede RAW-Datei enthält bereits ein <strong>JPEG in voller Größe, das die
+      Kamera beim Auslösen gerendert hat</strong>. Es ist das, was das
+      Kameradisplay Ihnen zeigt, und das, was Ihr Betriebssystem als Vorschaubild
+      zeichnet. Der Stacker findet dieses Bild und verwendet es. Er dekodiert die
+      Sensordaten nicht.
+    </p>
+    <p>
+      Zwei Folgen, eine gute und eine, die man kennen sollte:
+    </p>
+    <ul>
+      <li>
+        <strong>Es ist schnell.</strong> Die Vorschau zu finden heißt, ein paar
+        Kilobyte Verzeichnis und dann einen Ausschnitt zu lesen, eine 60&nbsp;MB
+        große Aufnahme öffnet also ungefähr so schnell wie ein JPEG. Zwanzig davon
+        öffnen in der Zeit, die ein RAW-Konverter für eine bräuchte. Die Seite
+        zeigt Ihnen, wie wenig von Ihren Dateien sie tatsächlich gelesen hat.
+      </li>
+      <li>
+        <strong>Es ist die Interpretation der Kamera, nicht Ihre.</strong> Acht
+        Bit pro Kanal, mit dem Weißabgleich und dem Bildstil, auf die die Kamera
+        eingestellt war, und nicht die zwölf oder vierzehn Bit linearer
+        Sensordaten, die Sie aus einem Konverter bekämen.
+      </li>
+    </ul>
+    <p>
+      Für Rauschminderung, Sternspuren, das Entfernen von Passanten und Focus
+      Stacking lohnt sich dieser Tausch fast immer: Die Vorschauen haben volle
+      Auflösung, und sie sind das, was Sie ohnehin als JPEG bekommen hätten. Wenn
+      Sie die Schatten stark anheben oder für Astrofotografie stacken, wo das
+      letzte bisschen Dynamikumfang der ganze Punkt ist, entwickeln Sie die
+      Aufnahmen zuerst in einem RAW-Konverter und stacken Sie die TIFFs oder
+      JPEGs, die er ausgibt. Die gehen genauso hinein.
+    </p>
+  </section>
+
+  <section>
+    <h2>Was es zur Laufzeit kostet</h2>
+    <p>
+      Das ist der Unterschied zwischen einem Stapel, der acht Sekunden dauert, und
+      einem, der zwei Minuten braucht.
+    </p>
+    <p>
+      Sechs der sieben Methoden müssen sich immer nur eines merken. Ein laufendes
+      Maximum kümmert sich nicht um die Aufnahmen, die es schon gesehen hat, und
+      eine laufende Summe ebenso wenig, diese Methoden lesen jede Aufnahme also
+      genau einmal und brauchen für hundert Aufnahmen so viel Speicher wie für
+      zwei.
+    </p>
+    <p>
+      Der Median kann so nicht arbeiten, weil sich der mittlere Wert einer Menge
+      nicht kennen lässt, bevor man sie ganz hat. Zwanzig Aufnahmen mit 24
+      Megapixeln sind rund 1,4&nbsp;GB Pixel, gleichzeitig gehalten, und so viel
+      gibt kein Browser heraus. Also wird das Bild in waagerechte Bänder
+      geschnitten und Band für Band gestackt: richtig, und langsamer, weil die
+      Aufnahmen für jedes Band erneut gelesen werden.
+    </p>
+    <p>
+      Das Werkzeug rechnet das alles aus, bevor Sie den Knopf drücken, und sagt es
+      Ihnen: wie groß das Ergebnis wird, wie viel Speicher es ungefähr braucht und
+      wie oft Ihre Aufnahmen dekodiert werden. Sagt es, der Durchlauf werde in
+      Bänder geteilt, viertelt eine Stufe weniger Arbeitsauflösung den Speicher
+      und macht daraus fast immer wieder einen einzigen Durchlauf. Und wenn Sie
+      gegen Rauschen stacken, hätte halbe Auflösung ohnehin sauberer ausgesehen
+      als volle.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dafür fotografieren</h2>
+    <p>
+      Der größte Teil der Qualität eines Stapels entscheidet sich, bevor
+      irgendeine Software ihn sieht.
+    </p>
+    <ul>
+      <li>
+        <strong>Machen Sie mehr Aufnahmen, als Sie zu brauchen glauben.</strong>
+        Die Wurzelkurve ist am unteren Ende unbarmherzig und am oberen gnädig: Von
+        vier auf neun Aufnahmen zu gehen ist eine sichtbar größere Veränderung als
+        von zwanzig auf vierzig.
+      </li>
+      <li>
+        <strong>Ändern Sie die Belichtung zwischen den Aufnahmen nicht.</strong>
+        Stacken setzt voraus, dass die Aufnahmen dieselbe Szene in derselben
+        Helligkeit zeigen. Fixieren Sie die Belichtung, sonst mittelt das Werkzeug
+        zwei verschiedene Bilder.
+      </li>
+      <li>
+        <strong>Warten Sie zwischen den Aufnahmen, wenn Leute weg sollen.</strong>
+        Eine Serie in zwei Sekunden erwischt dieselbe Person in jeder Aufnahme an
+        derselben Stelle, und der Median behält sie. Zehn Aufnahmen im Abstand
+        einiger Sekunden wirken weit besser als fünfzig in einer Serie.
+      </li>
+      <li>
+        <strong>Halten Sie die Lücken kurz, wenn es Sternspuren werden
+        sollen.</strong> Aufhellen zeichnet genau das, was die Aufnahmen
+        festgehalten haben, eine Pause zwischen den Belichtungen wird also in
+        jeder Spur zu einem sichtbaren Strich.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Nichts davon verlässt Ihr Gerät</h2>
+    <p>
+      Ein Stapel aus zwanzig RAW-Aufnahmen ist rund ein Gigabyte Fotos, und das
+      ist viel, um es einer Website zu übergeben, damit sie den Mittelwert daraus
+      bildet. Der <a href="../../bilder-stacken/">Bild-Stacker</a> liest die
+      Dateien von Ihrer eigenen Festplatte und rechnet in Ihrem eigenen Browser.
+      Es gibt keinen Upload-Schritt, kein Konto und keine Warteschlange, und Sie
+      können diese Behauptung so prüfen, wie Sie jede fremde prüfen würden: Öffnen
+      Sie die Netzwerkanzeige Ihres Browsers, während es läuft, oder trennen Sie
+      einfach die Internetverbindung und stacken Sie trotzdem.
+    </p>
+    <p>
+      Die verwandte Frage, wie sich bei einem beliebigen Werkzeug erkennen lässt,
+      ob es Ihre Datei überhaupt braucht, hat
+      <a href="../ist-das-hochladen-von-dateien-sicher/">einen eigenen
+      Ratgeber</a>.
+    </p>
+  </section>

--- a/locales/de/pages/guides/stack-photos-to-reduce-noise.toml
+++ b/locales/de/pages/guides/stack-photos-to-reduce-noise.toml
@@ -1,0 +1,20 @@
+#
+# Ratgeber: Fotos stacken gegen Bildrauschen - German.
+#
+
+nav = "Fotos stacken"
+title = "Fotos stacken gegen Bildrauschen &mdash; oder um Leute zu entfernen"
+description = "Stacken rechnet eine Serie von Aufnahmen zu einem Bild zusammen. Welche Methode Sie brauchen, hängt davon ab, was weg soll: das Rauschen, die Passanten oder die geringe Schärfentiefe einer Makroaufnahme. Wie jede funktioniert, was sie kostet und wo RAW-Dateien hineinpassen."
+
+heading = "So stacken Sie Fotos gegen Bildrauschen oder um Leute zu entfernen"
+lede = """
+    Eine Serie von Aufnahmen trägt mehr Information als jede einzelne davon. Sie
+    zu mitteln hebt das Rauschen auf; den mittleren Wert jedes Pixels zu nehmen
+    löscht alles, was nur zeitweise da war. Welches von beidem Sie wollen, hängt
+    ganz davon ab, was sich bewegt hat."""
+
+updated = "25. August 2026"
+
+og_title = "So stacken Sie Fotos gegen Bildrauschen oder um Leute zu entfernen"
+og_description = "Eine Serie mitteln gegen das Rauschen, den Median nehmen, um einen belebten Platz zu leeren, aufhellen für Sternspuren. Welche Methode welches Problem löst und wo RAW-Dateien hineinpassen."
+og_image_alt = "abox.tools - Werkzeuge, die ohne Server auskommen"

--- a/locales/de/tools/dicom-viewer.html
+++ b/locales/de/tools/dicom-viewer.html
@@ -1,0 +1,265 @@
+<!--
+  tools/dicom-viewer/body.html, in German.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+
+  Die Spaltenüberschrift "VR" bleibt stehen: das ist der zweibuchstabige Code,
+  der so in der Datei steht, und wer einen Tag im Standard nachschlägt, sucht
+  genau diese beiden Buchstaben.
+-->
+<main>
+  <!--
+    One numbered step, and then the viewer.
+
+    Every other tool on this site numbers its cards because every card is
+    something the visitor does. Here there is one thing to do - choose the
+    files - and everything below it is the scan. Numbering the picture would
+    promise a sequence of decisions that does not exist.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Aufnahme wählen</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p class="picker-note">
+      Ziehen Sie einen ganzen Ordner auf einmal hinein, und die Dateien werden
+      wieder ihren Serien zugeordnet und in die richtige Reihenfolge gebracht.
+      Nichts wird hochgeladen, und nichts wird in Ihre Dateien zurückgeschrieben.
+    </p>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Der Viewer. -->
+  <section class="card" id="viewer-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="save-frame" class="ghost" data-download>Dieses Bild als PNG speichern</button>
+        <button type="button" id="copy-header" class="ghost">Header kopieren</button>
+        <button type="button" id="download-header" class="ghost">Herunterladen</button>
+      </div>
+    </div>
+
+    <div class="series-row" id="series-row" hidden>
+      <label for="series-pick" class="inline-label">Serie</label>
+      <select id="series-pick"></select>
+      <span class="count" id="series-note"></span>
+    </div>
+
+    <!--
+      The canvas is sized in CSS and its backing store is set to the frame's own
+      pixels, so a 512-pixel slice is drawn at 512 pixels and scaled by the
+      browser rather than resampled here. That is what makes the zoom honest:
+      what is on screen at 400% is the stored pixels made bigger, not a guess at
+      what was between them.
+    -->
+    <div class="viewport" id="viewport">
+      <canvas id="canvas" width="1" height="1" role="img"
+              aria-label="Das Bild auf dem Schirm, gezeichnet aus der Datei, die Sie gewählt haben"></canvas>
+      <div class="overlay overlay-tl" id="overlay-tl" hidden></div>
+      <div class="overlay overlay-tr" id="overlay-tr"></div>
+      <div class="overlay overlay-bl" id="overlay-bl"></div>
+      <div class="overlay overlay-br" id="overlay-br"></div>
+      <svg class="marks" id="marks" aria-hidden="true"></svg>
+      <p class="viewport-fail" id="viewport-fail" hidden></p>
+    </div>
+
+    <div class="scrub" id="scrub-row" hidden>
+      <button type="button" id="play" class="ghost" aria-label="Die Bilder abspielen">▶</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" step="1"
+             aria-label="Welche Schicht oder welches Bild gezeigt wird">
+      <span class="count" id="scrub-label">&mdash;</span>
+    </div>
+
+    <div class="tools">
+      <fieldset class="modes">
+        <legend class="visually-hidden">Was das Ziehen auf dem Bild bewirkt</legend>
+        <label><input type="radio" name="mode" value="window" checked> Fenster &amp; Zentrum</label>
+        <label><input type="radio" name="mode" value="pan"> Verschieben</label>
+        <label><input type="radio" name="mode" value="measure"> Messen</label>
+      </fieldset>
+
+      <div class="zoom">
+        <label for="zoom" class="inline-label">Zoom</label>
+        <input type="range" id="zoom" min="5" max="800" step="5" value="100">
+        <span class="count" id="zoom-label">100%</span>
+        <button type="button" id="reset-view" class="ghost">Einpassen</button>
+      </div>
+    </div>
+
+    <div class="levels" id="levels">
+      <div class="level-field">
+        <label for="preset" class="inline-label">Fenster</label>
+        <select id="preset"></select>
+      </div>
+      <div class="level-field">
+        <label for="center" class="inline-label">Zentrum</label>
+        <input type="number" id="center" step="1">
+      </div>
+      <div class="level-field">
+        <label for="width" class="inline-label">Breite</label>
+        <input type="number" id="width" step="1" min="1">
+      </div>
+      <label class="level-check"><input type="checkbox" id="invert"> Invertieren</label>
+      <label class="level-check"><input type="checkbox" id="show-details"> Patientendaten ins Bild einblenden</label>
+    </div>
+
+    <p class="hint" id="mode-hint"></p>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- Was diese Datei ist. -->
+  <section class="card" id="facts-card" hidden>
+    <h2>Was diese Datei ist</h2>
+    <dl class="facts">
+      <div><dt>Objekt</dt><dd id="fact-sop">&mdash;</dd></div>
+      <div><dt>Modalität</dt><dd id="fact-modality">&mdash;</dd></div>
+      <div><dt>Bild</dt><dd id="fact-size">&mdash;</dd></div>
+      <div><dt>Gespeichert als</dt><dd id="fact-stored">&mdash;</dd></div>
+      <div><dt>Transfersyntax</dt><dd id="fact-syntax">&mdash;</dd></div>
+      <div><dt>Pixelabstand</dt><dd id="fact-spacing">&mdash;</dd></div>
+      <div><dt>Wertebereich</dt><dd id="fact-range">&mdash;</dd></div>
+      <div><dt>Datei</dt><dd id="fact-file">&mdash;</dd></div>
+    </dl>
+
+    <ul class="notes" id="notes" hidden></ul>
+  </section>
+
+  <!-- Was über die Person darin steht. -->
+  <section class="card" id="identity-card" hidden>
+    <h2>Was in dieser Datei die Patientin oder den Patienten benennt</h2>
+    <p class="card-lede">
+      Aus dieser Datei gelesen, auf diesem Gerät, und niemandem sonst gezeigt.
+      Dieses Werkzeug schreibt nichts: Es kann nichts davon entfernen, und es hat
+      nichts davon irgendwohin gesendet. Es steht hier, weil eine Aufnahme weit
+      mehr trägt als einen Namen, und weil der Rest genau das ist, was eine
+      nachlässige Anonymisierung überlebt.
+    </p>
+    <ul class="identity" id="identity"></ul>
+    <p class="identity-extra" id="identity-extra"></p>
+  </section>
+
+  <!-- Jeder Tag in der Datei. -->
+  <section class="card" id="tags-card" hidden>
+    <div class="toolbar">
+      <h2>Jeder Tag in der Datei</h2>
+      <div class="toolbar-actions">
+        <label for="tag-search" class="visually-hidden">Tags durchsuchen</label>
+        <input type="search" id="tag-search" class="tag-search" placeholder="Nach Name, Nummer oder Wert suchen">
+      </div>
+    </div>
+
+    <p class="card-lede" id="tags-lede"></p>
+
+    <div class="table-wrap">
+      <table class="tags">
+        <caption class="visually-hidden">Jedes Element in dieser Datei</caption>
+        <thead>
+          <tr>
+            <th scope="col">Tag</th>
+            <th scope="col">VR</th>
+            <th scope="col">Name</th>
+            <th scope="col">Wert</th>
+          </tr>
+        </thead>
+        <tbody id="tag-rows"></tbody>
+      </table>
+    </div>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!--
+    The tool's own sentences, kept out of the JavaScript so that a translator
+    can reach them. shared/js/phrases.js reads them back, and a key defined here
+    wins over the frame's one.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="mode.window">Ziehen Sie quer über das Bild, um das Fenster zu weiten oder zu verengen, und nach oben oder unten, um sein Zentrum zu verschieben. Beide Zahlen stehen darunter, und sie einzutippen bewirkt dasselbe.</span>
+    <span data-phrase="mode.pan">Ziehen Sie, um das Bild in seinem Rahmen zu verschieben. Das Mausrad zoomt, und &bdquo;Einpassen&ldquo; setzt alles zurück.</span>
+    <span data-phrase="mode.measure">Ziehen Sie eine Linie über das Bild, um zu messen. Wo die Datei sagt, wie weit ihre Pixel auseinanderliegen, steht das Ergebnis in Millimetern; wo nicht, steht es in Pixeln und sagt das auch.</span>
+
+    <span data-phrase="probe.value">{value} bei Spalte {column}, Zeile {row}</span>
+    <span data-phrase="measure.pixels">{length} px &mdash; diese Datei sagt nicht, wie weit ihre Pixel auseinanderliegen, deshalb kann das nicht in Millimetern stehen</span>
+
+    <span data-phrase="stack.position">Nach der Lage jeder Schicht im Körper gestapelt, und das ist die Reihenfolge, in der das Gerät sie aufgenommen hat.</span>
+    <span data-phrase="stack.number">Nach Instance Number gestapelt: Diese Dateien tragen keine Lage im Körper, nach der sich sortieren ließe.</span>
+    <span data-phrase="stack.gap">Der Abstand zwischen den Schichten ist nicht durchgehend gleich, in dieser Serie fehlt also mindestens eine.</span>
+
+    <span data-phrase="pixels.none">Die Pixel dieser Datei sind mit {codec} komprimiert. Das kann kein Browser dekodieren, und einen Decoder dafür bringt diese Seite nicht mit. Alles andere über die Datei steht unten.</span>
+    <span data-phrase="pixels.failed">Das Bild ließ sich nicht dekodieren: {reason}. Der Header unten wurde vollständig gelesen.</span>
+    <span data-phrase="pixels.absent">Diese Datei trägt überhaupt keine Pixeldaten. Sie ist ein Header, und alles darin steht unten.</span>
+    <span data-phrase="pixels.jpeg">Diese Pixel sind Baseline JPEG, also hat der Decoder des Browsers sie ausgepackt, und was er zurückgibt, ist acht Bit tief. Das Fenster arbeitet weiter; die Genauigkeit, die das Gerät aufgezeichnet hat, ist nicht vollständig da.</span>
+
+    <span data-phrase="tags.count">{shown} von {total} Elementen. {hidden} weitere.</span>
+    <span data-phrase="tags.all">Alle {total} Elemente dieser Datei.</span>
+    <span data-phrase="tags.found">{total} Elemente passen zu &bdquo;{query}&ldquo;.</span>
+    <span data-phrase="tags.found.one">Ein Element passt zu &bdquo;{query}&ldquo;.</span>
+    <span data-phrase="tags.none">Nichts passt zu &bdquo;{query}&ldquo;.</span>
+    <span data-phrase="tags.more">Die restlichen {count} anzeigen</span>
+    <span data-phrase="tags.private">privates Element</span>
+    <span data-phrase="tags.unknown">nicht in diesem Wörterbuch</span>
+    <span data-phrase="tags.guessed">Die Datei hat es nicht gesagt; das ist, was das Datenwörterbuch für diesen Tag angibt.</span>
+
+    <span data-phrase="working.one">{name} wird gelesen&hellip;</span>
+    <span data-phrase="working.many">{at} von {total} wird gelesen&hellip;</span>
+    <span data-phrase="error.none">Nichts hiervon ließ sich als DICOM lesen. {why} Dieses Werkzeug liest das DICOM-Format selbst, zu anderen Dateien kann es deshalb nichts sagen.</span>
+    <span data-phrase="error.skipped.one">Eine Datei wurde übersprungen: {files}</span>
+    <span data-phrase="error.skipped">{count} Dateien wurden übersprungen: {files}</span>
+
+    <span data-phrase="series.number">Serie {number}</span>
+    <span data-phrase="series.files.one">1 Datei</span>
+    <span data-phrase="series.files">{count} Dateien</span>
+    <span data-phrase="stack.spacing">Die Schichten liegen {gap} auseinander.</span>
+
+    <span data-phrase="at.position">{at} von {total}</span>
+    <span data-phrase="net.clean">Ihre Aufnahme ist nirgendwohin gegangen. {total} Dateien
+      geladen, allesamt eigene dieser Seite. {platform}</span>
+    <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut dieses
+      Werkzeug nie. Das ist es wert, nachgesehen zu werden. {platform}</span>
+    <span data-phrase="net.platform.one">Die eigenen Skripte der Seite für Werbung,
+      Messung und den Spenden-Knopf kamen von {hosts} Host; keines davon hat eine
+      Aufnahme, ein Pixel davon oder ein Wort aus ihrem Header bekommen.</span>
+    <span data-phrase="net.platform.many">Die eigenen Skripte der Seite für Werbung,
+      Messung und den Spenden-Knopf kamen von {hosts} Hosts; keines davon hat eine
+      Aufnahme, ein Pixel davon oder ein Wort aus ihrem Header bekommen.</span>
+    <span data-phrase="at.frame">Bild {at} von {total}</span>
+    <span data-phrase="at.instance">Instanz {number}</span>
+
+    <span data-phrase="window.file">Aus der Datei</span>
+    <span data-phrase="window.file.n">Aus der Datei, {n}</span>
+    <span data-phrase="window.full">Alles in diesem Bild</span>
+    <span data-phrase="window.custom">Von Hand gesetzt</span>
+    <span data-phrase="window.soft">Weichteile</span>
+    <span data-phrase="window.lung">Lunge</span>
+    <span data-phrase="window.bone">Knochen</span>
+    <span data-phrase="window.brain">Hirn</span>
+    <span data-phrase="window.liver">Leber</span>
+    <span data-phrase="window.mediastinum">Mediastinum</span>
+    <span data-phrase="window.angio">Angiografie</span>
+
+    <span data-phrase="facts.frames">{count} Bilder</span>
+    <span data-phrase="facts.nopixels">keine Pixeldaten</span>
+    <span data-phrase="facts.nospacing">in dieser Datei nicht angegeben</span>
+    <span data-phrase="facts.signed">vorzeichenbehaftet</span>
+    <span data-phrase="facts.unsigned">vorzeichenlos</span>
+    <span data-phrase="facts.stored.one">{bits} Bit, {sign}, 1 Kanal pro Pixel, {photometric}</span>
+    <span data-phrase="facts.stored">{bits} Bit, {sign}, {samples} Kanäle pro Pixel, {photometric}</span>
+    <span data-phrase="facts.range">{low} bis {high}</span>
+    <span data-phrase="facts.colour">Farbe &mdash; nichts Gemessenes zu berichten</span>
+
+    <span data-phrase="identity.clean">Nichts in dieser Datei benennt oder nummeriert eine Person. Die Identifikatoren, die eine Aufnahme sonst trägt, fehlen oder sind leer.</span>
+    <span data-phrase="identity.uids">Sie trägt außerdem {count} eigene Identifikatoren, die UIDs von Studie, Serie und Instanz. Keiner davon ist ein Name, und jeder einzelne ist ein perfekter Schlüssel in das Archiv, aus dem die Datei stammt.</span>
+    <span data-phrase="identity.private">Dazu {count} private Elemente, deren Bedeutung nirgends veröffentlicht ist: Manche Geräte legen in einem davon eine zweite Kopie des Patientennamens ab.</span>
+
+    <span data-phrase="copied">Kopiert.</span>
+    <span data-phrase="copy.failed">Ihr Browser hat der Seite das Kopieren verwehrt. Der Knopf daneben schreibt denselben Text in eine Datei.</span>
+    <span data-phrase="saved">{name} gespeichert.</span>
+  </div>
+</main>

--- a/locales/de/tools/dicom-viewer.toml
+++ b/locales/de/tools/dicom-viewer.toml
@@ -1,0 +1,405 @@
+#
+# DICOM-Viewer - German.
+#
+# Overrides for tools/dicom-viewer/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Die DICOM-Feldnamen bleiben englisch und behalten ihre Nummern - Pixel
+# Spacing (0028,0030), Series Instance UID (0020,000E). So stehen sie in der
+# Datei und so stehen sie im Standard; wer ein Feld nachschlagen will, sucht
+# genau diese Wörter. Dasselbe gilt für die Transfersyntaxen und für PS3.15.
+#
+# Auf dieser Seite hat das Versprechen der Seite die schärfste Kante: die Datei
+# ist eine Krankenakte mit einem Bild darin. Die Sätze darüber, was in ihr
+# steht, sind deshalb genauso sorgfältig übersetzt wie die darüber, wohin sie
+# nicht geht.
+#
+
+name = "DICOM-Viewer"
+heading = "DICOM-Viewer <span class=\"h1-kw\">&mdash; eine .dcm-Aufnahme im Browser öffnen</span>"
+tagline = "CT, MRT, Röntgen und Ultraschall, mit Fenster, Header und Messungen."
+
+title = "DICOM-Viewer &mdash; .dcm-Datei im Browser öffnen, ohne Upload"
+description = "Öffnen Sie CT-, MRT-, Röntgen- und Ultraschallaufnahmen im Browser. Fenster und Zentrum, eine ganze Serie durchblättern, in Millimetern messen, jeden DICOM-Tag lesen und genau sehen, was in der Datei die Patientin oder den Patienten benennt. Nichts wird hochgeladen."
+og_title = "DICOM-Viewer &mdash; eine Aufnahme öffnen, ohne sie hochzuladen"
+og_description = "Eine .dcm-Datei, geöffnet auf Ihrem eigenen Gerät: Fenster und Zentrum, die ganze Serie in der richtigen Reihenfolge, Messungen in Millimetern und jeder Tag im Header. Kein Upload, kein Konto."
+og_image_alt = "DICOM-Viewer - eine CT-, MRT- oder Röntgenaufnahme im Browser öffnen"
+
+pledge = """
+    Die Aufnahme wird von Ihrem eigenen Browser geöffnet und dekodiert: der
+    Header, die Pixel, das Fenster, die Messungen. Am anderen Ende dieser Seite
+    steht kein Server, an den sich geschützte Gesundheitsdaten senden ließen,
+    selbst wenn hier etwas das wollte, und nichts über die Datei wird
+    irgendwem mitgeteilt, weder der Name der Patientin noch die Studie noch der
+    Dateiname."""
+
+live_hint = """
+      Sie müssen uns nicht glauben. Öffnen Sie die DevTools, sehen Sie im Tab
+      &bdquo;Netzwerk&ldquo; zu und öffnen Sie eine Aufnahme. Keine einzige
+      Anfrage trägt ein Bild, einen Tag oder einen Dateinamen. Oder trennen Sie
+      die Internetverbindung und öffnen Sie trotzdem eine."""
+
+read_first = """
+, <code>src/dicom.js</code> für den Parser, der
+      durch die Datei läuft, <code>src/pixels.js</code> für das Dekodieren der
+      Pixel, <code>src/jpeg-lossless.js</code> für den Codec, den die meisten
+      Klinik-Exporte verwenden, und <code>src/window.js</code> für Fenster und
+      Zentrum. In keiner dieser Dateien steht eine Zeile, die ins Netz käme."""
+
+howto_heading = "So öffnen Sie eine DICOM-Datei"
+
+card = """
+            Öffnen Sie eine CT-, MRT-, Röntgen- oder Ultraschallaufnahme auf
+            Ihrem eigenen Gerät. Fenster und Zentrum einstellen, die ganze Serie
+            durchblättern, in Millimetern messen und jeden Tag im Header
+            lesen."""
+
+[words]
+plural = "Aufnahmen"
+choose = "eine Aufnahme"
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Läuft offline"
+
+[[facts]]
+text = "Quelloffen"
+
+[[facts]]
+text = "Dateien bleiben auf Ihrem Gerät"
+
+[[privacy]]
+title = "Ihre Aufnahme hat keinen Ort, an den sie gehen könnte."
+body = """
+ In der
+      Content-Security-Policy steht jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehört uns. Es gibt hier keinen Endpunkt, an dem
+      Ihre Datei gesammelt werden könnte, und keinen Code, der sie senden würde,
+      wenn es ihn gäbe. Früher stand hier <code>connect-src 'none'</code>, und
+      das war absolut. Die Werbung hat das gekostet, und das gehört dazugesagt."""
+
+[[privacy]]
+title = "Hier wiegt das schwerer als auf den anderen Seiten."
+body = """
+
+      Eine DICOM-Datei ist kein Bild mit ein paar Metadaten daran. Sie ist eine
+      Krankenakte mit einem Bild darin: Name, Geburtsdatum, Patientennummer,
+      Auftragsnummer, überweisende Ärztin, Einrichtung und die Seriennummer des
+      Geräts stehen alle als Felder im Header und reisen mit der Datei, wohin sie
+      auch geht. Wer so eine Datei auf eine Website hochlädt, um sie anzusehen,
+      übergibt all das an die Leute, die diese Website betreiben. Genau das tut
+      diese Seite nicht."""
+
+[[privacy]]
+title = "Der Leser besteht aus vierzehn Dateien in diesem Repository."
+body = """
+ Nichts hier verwendet
+      eine Bibliothek, die von irgendwoher geladen wird.
+      <code>src/dicom.js</code> läuft durch die Datei,
+      <code>src/dictionary.js</code> weiß, wie die Tags heißen,
+      <code>src/pixels.js</code> macht aus den Bytes wieder Messwerte,
+      <code>src/rle.js</code> und <code>src/jpeg-lossless.js</code> packen die
+      zwei komprimierten Formen aus, die diese Seite dekodieren kann, und
+      <code>src/window.js</code> bildet das Gemessene auf die Grauwerte Ihres
+      Bildschirms ab."""
+
+[[privacy]]
+title = "Die Identifikatoren werden für Sie aufgelistet, und für sonst niemanden."
+body = """
+
+      Die Seite zeigt jedes Feld Ihrer Datei an, das die abgebildete Person
+      benennt oder eingrenzt. Das ist die Frage, die jemand beantwortet haben
+      möchte, bevor er eine Schicht weitergibt, und kein Viewer beantwortet sie.
+      Sie steht auf dem Bildschirm vor Ihnen und geht nirgendwo sonst hin: In
+      diesem Repository gibt es kein Analytics-Ereignis, das irgendetwas davon
+      trüge, und die Seite könnte es auch nicht senden, wenn es eines gäbe."""
+
+[[privacy]]
+title = "Sie liest. Sie schreibt nicht."
+body = """
+ Es gibt hier keinen Knopf, der Ihre
+      Datei verändert, und keinen Code, der das könnte. Mitnehmen können Sie ein
+      PNG des Bildes auf dem Schirm und eine Textfassung des Headers, beide in
+      der Seite aus dem gebaut, was ohnehin schon da ist. Ihr Original liegt
+      unberührt auf Ihrer Festplatte, was zugleich die ehrliche Antwort darauf
+      ist, was passiert, wenn Sie den Tab schließen."""
+
+[[privacy]]
+title = "Was Google lädt und was es nicht bekommt."
+body = """
+ Die Skripte für Werbung
+      und Messung kommen von Google. Keines von beiden bekommt irgendetwas über
+      Ihre Datei: nicht die Pixel, kein Vorschaubild, keinen Namen, keinen Tag,
+      keine Patientin, keinen Dateinamen. Jede Zeile, die eine Aufnahme liest,
+      dekodiert oder zeichnet, wird von dieser Domain ausgeliefert und steht im
+      Repository."""
+
+[[privacy]]
+title = "Was der Spenden-Knopf lädt und was er nicht bekommt."
+body = """
+
+      Der Knopf &bdquo;Buy me a coffee&ldquo; im Kopfbereich wird von einem
+      Skript von cdnjs.buymeacoffee.com gezeichnet und holt seine Schrift von
+      Google Fonts. Er ist ein Link und sonst nichts: Er meldet keinen Besuch,
+      und er bekommt nichts über Sie oder Ihre Dateien. Es passiert nichts, bis
+      Sie ihn anklicken, und dann sind Sie auf einer fremden Seite."""
+
+[[privacy]]
+title = "Läuft offline."
+body = """
+ Trennen Sie die Netzverbindung, und jeder Teil
+      dieser Seite arbeitet weiter. Das ist der einfachste Beweis von allen: Ein
+      Werkzeug, das Ihre Aufnahme zum Rendern wegschickt, hört in dem Moment auf,
+      in dem Sie den Stecker ziehen."""
+
+[[howto]]
+title = "Wählen Sie die Dateien."
+body = """
+ Eine einzelne
+      <code>.dcm</code>-Datei oder gleich den ganzen Ordner von der CD. Ein CT
+      oder ein MRT ist eine Datei pro Schicht, und erst wenn Sie alle auf einmal
+      hineinziehen, setzt sich die Serie wieder zusammen. Der Browser liest sie
+      direkt von Ihrer Festplatte, dabei geht nichts irgendwohin."""
+
+[[howto]]
+title = "Wählen Sie die Serie."
+body = """
+ Eine Studie enthält meist mehrere: die
+      Übersichtsaufnahme und dann jede Akquisition. Jede wird in der Reihenfolge
+      gestapelt, in der das Gerät sie aufgenommen hat, ermittelt aus der Lage
+      jeder Schicht im Körper und nicht aus der Nummerierung, die nicht immer in
+      dieselbe Richtung läuft."""
+
+[[howto]]
+title = "Stellen Sie das Fenster ein."
+body = """
+ Das ist der Regler, der eine
+      Aufnahme lesbar macht, und der, den ein Bildbearbeitungsprogramm nicht hat.
+      Ziehen Sie quer über das Bild, um das Fenster zu weiten, und nach oben oder
+      unten, um sein Zentrum zu verschieben. Oder nehmen Sie bei einem CT eines
+      der benannten Fenster: Lunge, Knochen, Hirn, Weichteile. Dort bedeuten die
+      Werte auf jedem Gerät der Welt dasselbe."""
+
+[[howto]]
+title = "Blättern Sie durch den Stapel."
+body = """
+ Der Regler unter dem Bild geht
+      durch die Schichten, und sobald Sie das Bild angeklickt haben, tun das die
+      Pfeiltasten auch. Eine Mehrbild-Datei, eine Ultraschallschleife oder ein
+      Angiogramm, läuft über den Knopf daneben als Film."""
+
+[[howto]]
+title = "Messen Sie etwas."
+body = """
+ Wechseln Sie auf Messen und ziehen Sie eine
+      Linie. Wo die Datei sagt, wie weit ihre Pixel auseinanderliegen, steht das
+      Ergebnis in Millimetern und rechnet nicht quadratische Pixel mit ein. Wo
+      sie es nicht sagt, steht es in Pixeln und sagt das auch, statt einen
+      Maßstab zu erfinden."""
+
+[[howto]]
+title = "Lesen Sie den Header."
+body = """
+ Jedes Element der Datei, mit seiner
+      Nummer, seinem Namen aus dem Standard und seinem Inhalt, durchsuchbar.
+      Darüber die Liste dessen, was in genau dieser Datei die Patientin oder den
+      Patienten benennt, und das ist erheblich mehr als der Name."""
+
+[[howto]]
+title = "Nehmen Sie mit, was Sie brauchen."
+body = """
+ Das Bild auf dem Schirm als
+      PNG, mit dem Fenster, das Sie eingestellt haben, und ohne eingebrannte
+      Beschriftung. Oder den ganzen Header als Text. Beides entsteht in der Seite
+      aus dem, was ohnehin schon da ist."""
+
+[[faq]]
+q = "Wird meine Aufnahme irgendwohin hochgeladen?"
+a = """
+        Nein. Die Datei wird von Ihrem eigenen Browser auf Ihrer eigenen Hardware
+        gelesen, dekodiert und gezeichnet. Dieses Werkzeug hat keine Serverseite,
+        und in der <code>Content-Security-Policy</code> der Seite steht jede
+        Adresse, die sie kontaktieren darf. Keine davon gehört uns. Trennen Sie
+        die Netzverbindung, und sie öffnet weiter Aufnahmen.
+        <br><br>
+        Das wiegt hier schwerer als auf jeder anderen Seite dieser Website. Eine
+        DICOM-Datei trägt Name, Geburtsdatum und Patientennummer im Header. Wer
+        sie in einen Online-Viewer lädt, übergibt einem Fremden eine
+        Krankenakte, kein Bild."""
+
+[[faq]]
+q = "Welche DICOM-Dateien kann er öffnen?"
+a = """
+        Unkomprimierte Dateien in allen drei Basis-Transfersyntaxen, also
+        implicit und explicit little endian sowie die zurückgezogene
+        big-endian-Variante, dazu deflated, RLE Lossless, Baseline JPEG und JPEG
+        Lossless. Letzteres ist das, womit die meisten CT- und MRT-Studien auf
+        einer Klinik-CD komprimiert sind.
+        <br><br>
+        Nicht dekodieren kann er JPEG 2000, JPEG-LS und die MPEG- und
+        HEVC-Syntaxen für Video. Dafür bräuchte es Codecs, die als kompilierte
+        Bibliothek mehrere Megabyte wiegen, und eine Seite, die so etwas bei
+        Bedarf nachlädt, wäre keine Seite, die offline arbeitet. Eine Datei in
+        einem dieser Formate öffnet trotzdem: Der ganze Header wird gelesen und
+        angezeigt, und an die Stelle des Bildes tritt eine Zeile, die den Codec
+        benennt, statt eines Platzhaltersymbols, das Ihnen nichts sagt."""
+
+[[faq]]
+q = "Was ist &bdquo;Fenster und Zentrum&ldquo;, und wozu brauche ich das?"
+a = """
+        Eine CT-Schicht enthält rund viertausend unterscheidbare Werte, Ihr
+        Bildschirm zeigt zweihundertsechsundfünfzig Graustufen. Das Fenster ist
+        die Entscheidung, welcher Ausschnitt dieses Bereichs alle davon bekommt:
+        Alles darunter ist schwarz, alles darüber weiß, und was dazwischen liegt,
+        verteilt sich auf die Graustufen.
+        <br><br>
+        Deshalb sieht dieselbe Datei unter zwei Einstellungen aus wie zwei
+        verschiedene Aufnahmen, und deshalb lassen sich Lunge und Knochen nicht
+        gleichzeitig sehen. Bei einem CT sind die Zahlen Hounsfield-Einheiten,
+        und die sind absolut festgelegt: Wasser ist 0 und Luft ist &minus;1000.
+        Die benannten Fenster auf dieser Seite tragen deshalb genau die Werte,
+        die eine Radiologin an ihrer Befundungsstation verwendet. Bei einem MRT
+        oder einem Ultraschall gibt es keine solche Skala, und das Fenster, mit
+        dem geöffnet wird, ist das, um das die Datei selbst bittet."""
+
+[[faq]]
+q = "Warum steht meine Messung in Pixeln?"
+a = """
+        Weil diese Datei nicht sagt, wie groß ein Pixel ist. Das trägt Pixel
+        Spacing (0028,0030), in Millimetern, und sehr vielen Ultraschallbildern,
+        eingescannten Dokumenten und Secondary Captures fehlt es schlicht.
+        <br><br>
+        Wo es da ist, steht die Messung in Millimetern, und jede Achse wird mit
+        ihrem eigenen Abstand gerechnet, was bei den Bildern zählt, deren Pixel
+        nicht quadratisch sind. Wo es fehlt, ist eine Anzahl Pixel die ehrliche
+        Antwort, und die steht dann da, statt dass ein Maßstab gewählt und das
+        Ergebnis als Länge ausgegeben würde."""
+
+[[faq]]
+q = "Er hat meinen Ordner als mehrere Serien geöffnet. Warum?"
+a = """
+        Weil das drinsteht. Eine Studie besteht aus Serien, der Übersichtsaufnahme
+        und dann jeder Akquisition oder Rekonstruktion, und jede Datei sagt in
+        Series Instance UID (0020,000E), zu welcher sie gehört. Die Auswahlliste
+        wird daraus gebaut und nicht aus dem Ordner, in dem meist alles
+        durcheinander in einer Namensliste liegt.
+        <br><br>
+        Innerhalb einer Serie werden die Schichten nach ihrer Lage im Körper
+        sortiert, ermittelt aus Image Position und Image Orientation. Instance
+        Number wäre der naheliegende Schlüssel und ist hier nur der Rückfall: Sie
+        wird von dem vergeben, was die Dateien geschrieben hat, und muss nicht in
+        dieselbe Richtung laufen wie die Patientin auf dem Tisch."""
+
+[[faq]]
+q = "Was bedeutet die Liste &bdquo;was in dieser Datei die Patientin benennt&ldquo;?"
+a = """
+        Sie enthält jedes Feld Ihrer Datei, das die abgebildete Person benennt
+        oder eingrenzt, wer sie sein könnte, ausgelesen aus dieser Datei auf Ihrem
+        Gerät. Die Liste stammt aus PS3.15 des DICOM-Standards, also aus dem Teil,
+        der festlegt, was weg muss, bevor ein Datensatz anonymisiert heißen darf.
+        <br><br>
+        Sie steht da, weil das, was Leute falsch einschätzen, nicht die Tatsache
+        ist, dass ein Name in einer Aufnahme steht. Es ist, wie viel sonst noch
+        darin steht: Geburtsdatum, Auftragsnummer, überweisende Ärztin,
+        Einrichtung, Seriennummer des Geräts und die Studien-UIDs, die perfekte
+        Schlüssel zurück in das Archiv sind, aus dem die Datei stammt. Eine
+        Aufnahme, bei der nur der Name geleert wurde, ist nicht anonym.
+        <br><br>
+        Dieses Werkzeug zeigt Ihnen das nur. Es schreibt nichts und ändert nichts,
+        also kann es auch nichts davon entfernen."""
+
+[[faq]]
+q = "Kann er eine Aufnahme anonymisieren?"
+a = """
+        Nein, und er tut auch nicht so. Diese Seite liest; sie hat keinen Code,
+        der eine DICOM-Datei schreibt. Was sie tut, ist Ihnen genau zu sagen, was
+        in Ihrer drinsteht, und das ist der Teil, der schwer herauszufinden ist
+        und bei dem sich Leute irren.
+        <br><br>
+        Ein Werkzeug, das die Identifikatoren entfernt, ist eine eigene Aufgabe
+        mit deutlich höherer Messlatte: Es muss die Datei neu schreiben, ohne die
+        Pixel anzufassen, die UIDs über eine ganze Studie hinweg konsistent
+        ersetzen und bei den privaten Elementen richtig liegen, in denen manche
+        Geräte eine zweite Kopie des Namens verstecken. Es steht auf der Roadmap
+        dieser Seite und wird nicht an einen Viewer angeflanscht."""
+
+[[faq]]
+q = "Kann er eine Datei ohne .dcm-Endung öffnen, oder eine beschädigte?"
+a = """
+        Beides ja. Die Endung wird nicht angesehen, geprüft wird die Datei selbst.
+        Ein Datensatz ohne die üblichen 128 Byte Vorspann, und so sieht eine
+        Aufnahme aus, die direkt aus dem Netz gezogen wurde, wird gelesen, indem
+        seine Kodierung aus dem ersten Element erschlossen wird, und die Seite
+        sagt Ihnen, dass sie das getan hat.
+        <br><br>
+        Eine Datei, die mittendrin endet, wird so weit gelesen, wie sie reicht.
+        Alles vor dem Bruch wird angezeigt, mit einem Hinweis, bei welchem Byte
+        Schluss war. Genau dafür will man einen Viewer am dringendsten, und die
+        ganze Datei wegen ihrer letzten zwölf Byte wegzuwerfen wäre das falsche
+        Verhalten."""
+
+[[faq]]
+q = "Ist das ein Befundungs-Viewer?"
+a = """
+        Nein. Er ist kein Medizinprodukt, hat kein Zulassungsverfahren durchlaufen,
+        und nichts hier gehört zur Grundlage einer klinischen Entscheidung. Ihr
+        Bildschirm ist nicht kalibriert, der Browser ist keine validierte
+        Rendering-Kette, und beides lässt sich aus einer Webseite heraus nicht
+        beheben.
+        <br><br>
+        Gut ist er für alles andere, wofür Leute eine Aufnahme öffnen: nachsehen,
+        was auf einer CD ist, eine Schicht für eine Lehrveranstaltung oder ein
+        Paper herausziehen, einen Header lesen, herausfinden, warum ein anderes
+        Programm die Datei verweigert, und sehen, was eine Aufnahme über die
+        abgebildete Person mit sich trägt."""
+
+[[faq]]
+q = "Verändert er meine Datei?"
+a = """
+        Nein. Dieses Werkzeug liest nur. Es gibt keine Ausgabedatei, keine
+        Neukodierung und keinen Knopf, der ein DICOM schreibt. Herunterladen
+        können Sie ein PNG des Bildes auf dem Schirm und eine Textfassung des
+        Headers. Ihr Original liegt unberührt auf Ihrer Festplatte."""
+
+[[faq]]
+q = "Ist das kostenlos, und brauche ich ein Konto?"
+a = """
+        Es ist kostenlos, und es gibt kein Konto, keine Anmeldung und keine
+        Testphase. Es gibt auch keine Grenze für die Dateigröße oder die Anzahl
+        der Dateien außer dem Speicher Ihres eigenen Geräts. Die Seite trägt
+        Werbung, und die bezahlt sie; die Werbung bekommt nichts über Ihre
+        Datei."""
+
+[[faq]]
+q = "Läuft er offline?"
+a = """
+        Ja. Laden Sie die Seite einmal, trennen Sie danach die
+        Internetverbindung, und sie arbeitet weiter. Das ist zugleich der
+        einfachste Weg zu prüfen, dass nichts hochgeladen wird: Ein Werkzeug, das
+        Ihre Aufnahme zum Rendern wegschickt, hört in dem Moment auf, in dem Sie
+        den Stecker ziehen."""
+
+[schema]
+description = "DICOM-Dateien (.dcm) im Browser öffnen: CT, MRT, Röntgen und Ultraschall, mit Fenster und Zentrum, einer ganzen Serie in der richtigen Reihenfolge, Messungen in Millimetern und jedem Tag im Header. Nichts wird hochgeladen."
+features = [
+  "Öffnet CT, MRT, Röntgen, Ultraschall, PET und Secondary Capture",
+  "Fenster und Zentrum durch Ziehen, durch Eingabe oder über ein benanntes CT-Preset",
+  "Ein ganzer Ordner wird zu Serien gebündelt und nach der Lage im Körper sortiert",
+  "Mehrbild-Dateien laufen als Schleife",
+  "Misst in Millimetern und rechnet nicht quadratische Pixel mit ein",
+  "Liest den Pixelwert unter dem Zeiger in Hounsfield-Einheiten",
+  "Jeder DICOM-Tag mit Name und Wert, durchsuchbar",
+  "Listet auf, was in der Datei die Patientin oder den Patienten benennt, nach dem Profil aus PS3.15",
+  "Dekodiert RLE, Baseline JPEG und JPEG Lossless ohne mitgelieferte Bibliothek",
+  "Speichert das Bild als PNG und den Header als Text",
+  "Läuft offline; kein Upload, kein Konto, keine Änderung an Ihrer Datei",
+]
+
+[picker]
+title = "Aufnahme hier ablegen"
+hint = "oder klicken zum Auswählen &mdash; eine .dcm-Datei oder ein ganzer Ordner davon"

--- a/locales/de/tools/document-scanner.html
+++ b/locales/de/tools/document-scanner.html
@@ -1,0 +1,388 @@
+<!--
+  tools/document-scanner/body.html, in German.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Schritt 1 &mdash; die Fotos -->
+  <section class="card">
+    <h2><span class="step">1</span> Fotos wählen</h2>
+
+    <p class="card-lede">
+      Ein Foto pro Seite, aufgenommen von irgendwo darüber. Die ganze Seite muss
+      im Bild sein, und die vier Ecken sollten sichtbar sein oder beinahe. Alles
+      andere, die Schräglage, der Schatten, der Tisch darunter, ist der Zweck
+      dieses Werkzeugs. Fügen Sie mehrere hinzu, und sie werden die Seiten eines
+      Dokuments, in der Reihenfolge, in der Sie sie hinzufügen.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="strip-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="detect-all" class="ghost">Alle Seiten neu suchen</button>
+        <button type="button" id="clear-all" class="ghost danger">Alle entfernen</button>
+      </div>
+    </div>
+
+    <ul id="page-strip" class="page-strip"></ul>
+  </section>
+
+  <!-- Schritt 2 &mdash; die Ecken -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Ecken auf die Seite setzen</h2>
+
+    <p id="edit-empty" class="field-summary">
+      Wählen Sie ein Foto, dann erscheint es hier, mit seinen vier Ecken für Sie
+      gefunden.
+    </p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Tippen Sie irgendwo auf das Foto, und die nächste Ecke kommt zu Ihrem
+        Finger; ziehen Sie sie auf die Ecke der Seite. Mit <kbd>Tab</kbd>
+        erreichen Sie eine Ecke über die Tastatur, die Pfeiltasten bewegen sie um
+        ein Pixel und mit <kbd>Shift</kbd> um zehn. Nichts hiervon ist endgültig:
+        Der Scan wird von dort genommen, wo die vier Ecken am Ende stehen.
+      </p>
+
+      <!-- The photo is a canvas rather than an <img> because it is drawn at
+           screen size from the decoded picture, and because the same canvas is
+           what the corner finder reads. The outline over it is an SVG polygon
+           in percentages, so it needs no redraw when the window changes. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="photo"></canvas>
+        </div>
+      </div>
+
+      <p id="detect-note" class="hint-line" role="status" aria-live="polite"></p>
+
+      <div class="frame-actions">
+        <button type="button" id="detect-one" class="ghost">Ecken neu suchen</button>
+        <button type="button" id="whole-photo" class="ghost">Ganzes Foto nehmen</button>
+        <button type="button" id="turn-left" class="ghost">Nach links drehen</button>
+        <button type="button" id="turn-right" class="ghost">Nach rechts drehen</button>
+        <button type="button" id="undo" class="ghost" disabled>Rückgängig</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Schritt 3 &mdash; das Aufräumen -->
+  <section class="card" id="clean-card">
+    <h2><span class="step">3</span> Aufräumen</h2>
+
+    <p id="clean-empty" class="field-summary">
+      Die geradegerückte Seite erscheint hier, sobald es ein Foto zum
+      Geraderücken gibt.
+    </p>
+
+    <div id="clean-controls" hidden>
+      <p class="card-lede">
+        Was unten steht, ist das echte Ergebnis, erzeugt von demselben Code, der
+        die Datei schreibt: geradegerückt und mit herausgeteiltem ungleichmäßigem
+        Licht. Auf dem Bildschirm wird es in Bildschirmgröße gezeichnet, während
+        Sie wählen; die Datei selbst entsteht in der Auflösung des Fotos.
+      </p>
+
+      <div class="result-wrap">
+        <canvas id="scan-preview" class="scan-preview"></canvas>
+        <p id="scan-busy" class="progress-label" role="status" aria-live="polite" hidden>
+          Wird geradegerückt&hellip;
+        </p>
+      </div>
+
+      <ul id="scan-facts" class="result-facts"></ul>
+
+      <fieldset class="options" id="mode-group">
+        <legend>Was mit Licht und Farbe geschehen soll</legend>
+
+        <label class="check">
+          <input type="radio" name="mode" value="colour" checked>
+          <span>
+            <strong>Farbe, ausgeglichen</strong>
+            <span class="check-note">
+              Das Papier wird über die Seite hinweg gemessen und herausgeteilt,
+              sodass der Schatten verschwindet und das Papier wieder weiß wird,
+              während ein Stempel, eine Unterschrift in blauer Tinte oder eine
+              markierte Zeile ihre Farbe behalten. Das ist der Modus, wenn die
+              Farbe zum Dokument gehört.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="grey">
+          <span>
+            <strong>Graustufen</strong>
+            <span class="check-note">
+              Dasselbe Ausgleichen ohne die Farbe. Kleiner als Farbe und
+              freundlicher zu einem Foto oder einer Unterschrift, als Schwarzweiß
+              es ist.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="mono">
+          <span>
+            <strong>Schwarzweiß</strong>
+            <span class="check-note">
+              Jedes Pixel wird gegen seine eigene Umgebung entschieden und nicht
+              gegen eine Zahl für die ganze Seite, und genau das hält die Schrift
+              in einem Schatten lesbar. Das ist es, was einen Scan klein macht:
+              Ein zwanzigseitiger Vertrag kommt so unter einem Megabyte heraus
+              und als Fotos bei etwa fünfzehn. Halbtöne kennt der Modus nicht,
+              also sollte nichts mit einem Foto darauf ihn nehmen.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="photo">
+          <span>
+            <strong>So lassen</strong>
+            <span class="check-note">
+              Geradegerückt und sonst nichts. Für eine Seite, bei der das Papier
+              selbst zählt: etwas Altes, etwas Farbiges, ein Foto.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row" id="strength-row">
+          <label for="strength">Wie stark</label>
+          <div class="inline-pair">
+            <input type="range" id="strength" min="0" max="100" step="5" value="50">
+            <output id="strength-value">50</output>
+          </div>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <p class="hint-line">
+        Die Einstellung gilt für jede Seite. Seiten in einem Dokument, die
+        unterschiedlich aufgeräumt wurden, sehen aus wie zwei Dokumente.
+      </p>
+    </div>
+  </section>
+
+  <!-- Schritt 4 &mdash; die Datei -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Dokument speichern</h2>
+
+    <p class="card-lede">
+      Das PDF entsteht hier, im Speicher dieser Seite, Seite für Seite. Am
+      anderen Ende dieses Werkzeugs steht kein Server, an den sich eine
+      Gehaltsabrechnung, ein Reisepass oder ein Vertrag senden ließe, und im Code
+      steht nichts, was das täte, wenn es ihn gäbe.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Seitengröße</label>
+        <select id="page-size">
+          <option value="fit" selected>Blatt an die Seite selbst anpassen</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 in</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+        </select>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Druckauflösung</label>
+        <select id="dpi">
+          <option value="150">150 DPI</option>
+          <option value="200" selected>200 DPI</option>
+          <option value="300">300 DPI &mdash; Bürogerät</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Wie groß ein Blatt genannt wird, das aus einer bestimmten Anzahl Pixel
+          besteht. Es ändert die Größe, in der das Dokument gedruckt wird, und
+          kein einziges Pixel des Scans.
+        </p>
+      </div>
+
+      <div class="field" id="margin-field" hidden>
+        <label for="margin">Rand</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="50" step="1" value="10"
+                 aria-label="Rand in Millimetern">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Längste Seite</label>
+        <select id="max-side">
+          <option value="1600">1600 Pixel &mdash; klein</option>
+          <option value="2400" selected>2400 Pixel</option>
+          <option value="3500">3500 Pixel</option>
+          <option value="0">So groß, wie das Foto es zulässt</option>
+        </select>
+        <p class="field-note">
+          Eine Obergrenze für die geradegerückte Seite. Das Foto einer Seite hält
+          weit mehr Pixel, als die Seite wert ist, und 2400 auf der langen Kante
+          sind etwa 200 DPI auf A4.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualität</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="82">
+          <output id="quality-value">82%</output>
+        </div>
+        <p class="field-note">
+          Für die Modi Farbe und Graustufen, die als JPEG gespeichert werden.
+          Schwarzweiße Seiten werden exakt gespeichert, für sie bewirkt das
+          nichts.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="title">Dokumenttitel <span class="optional">(optional)</span></label>
+        <input type="text" id="title" maxlength="120" placeholder="Leer gelassen trägt das PDF keinen Titel">
+        <p class="field-note">
+          Das Einzige, was außer den Seiten in das Dokument geschrieben wird. Kein
+          Datum, kein Autor und nichts über dieses Gerät. Siehe
+          <code>src/document.js</code>.
+        </p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save-pdf" class="primary big" disabled>Als PDF speichern</button>
+      <button type="button" id="save-images" class="ghost big" disabled>Seiten als Bilder speichern</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden></p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>Die fertige Datei</h3>
+        <a id="download" class="primary as-button" href="#" download>Herunterladen</a>
+      </div>
+      <ul id="result-facts" class="result-facts"></ul>
+      <p class="hint-line">
+        Öffnen Sie sie, bevor Sie sie verschicken. Was im Dokument steht, ist
+        das, was in Schritt 3 auf dem Bildschirm stand, Seite für Seite.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Every sentence the JavaScript puts on this page. They live here rather than
+    in src/, because src/ is copied byte for byte into all eleven languages and
+    a sentence written there would be English in ten of them. See
+    shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="detect.found">Die vier Ecken wurden gefunden. Prüfen Sie
+      sie und ziehen Sie die zurecht, die danebenliegen.</span>
+    <span data-phrase="detect.unsure">Die Kanten der Seite waren nicht deutlich
+      genug, um sicher zu sein. Diese Ecken sind geraten: Ziehen Sie sie auf die
+      Seite, bevor Sie weitermachen.</span>
+    <span data-phrase="detect.nothing">In diesem Foto war keine Seite
+      auszumachen, deshalb liegen die Ecken an seinen Rändern. Ziehen Sie sie auf
+      die Seite.</span>
+    <span data-phrase="detect.flat">In diesem Bild gibt es nichts zu finden, es
+      hat überhaupt keine Kanten.</span>
+    <span data-phrase="detect.tiny">Dieses Bild ist zu klein, um eine Seite darin
+      zu finden.</span>
+    <span data-phrase="detect.edited">Diese Ecken gehören jetzt Ihnen.
+      &bdquo;Ecken neu suchen&ldquo; vermisst das Foto von vorn.</span>
+
+    <span data-phrase="corner.tl">Ecke oben links</span>
+    <span data-phrase="corner.tr">Ecke oben rechts</span>
+    <span data-phrase="corner.br">Ecke unten rechts</span>
+    <span data-phrase="corner.bl">Ecke unten links</span>
+    <span data-phrase="corner.at">{corner}, bei {x} quer und {y} hinunter. Die
+      Pfeiltasten bewegen sie, und Shift dazu bewegt sie um zehn Pixel auf
+      einmal.</span>
+
+    <span data-phrase="page.select">Seite {index} bearbeiten</span>
+    <span data-phrase="page.remove">Seite {index} entfernen</span>
+    <span data-phrase="page.earlier">Seite {index} nach vorn schieben</span>
+    <span data-phrase="page.later">Seite {index} nach hinten schieben</span>
+    <span data-phrase="page.count">{count} Seite</span>
+    <span data-phrase="page.counts">{count} Seiten</span>
+
+    <span data-phrase="paper.a">A4 oder A5</span>
+    <span data-phrase="paper.letter">US Letter</span>
+    <span data-phrase="paper.legal">US Legal</span>
+    <span data-phrase="paper.card">eine Visitenkarte</span>
+    <span data-phrase="shape.known">Die Seite kam als {ratio} heraus, und das ist
+      die Form von {paper}.</span>
+    <span data-phrase="shape.sideways">Die Seite kam als {ratio} heraus, und das
+      ist die Form von {paper} im Querformat.</span>
+    <span data-phrase="shape.unknown">Die Seite kam als {ratio} heraus, und das
+      ist kein Standardformat.</span>
+
+    <span data-phrase="method.perspective">Die Form wurde aus der Perspektive im
+      Foto zurückgerechnet, es ist also die Form der Seite und nicht die, in der
+      sie im Bild erschien.</span>
+    <span data-phrase="method.edges">Das Foto wurde im rechten Winkel
+      aufgenommen, die Form ist also direkt an den Kanten gemessen.</span>
+
+    <span data-phrase="quality.good">{width} mal {height} Pixel, etwa {dpi} DPI
+      auf einer Seite dieser Größe, genug zum Drucken.</span>
+    <span data-phrase="quality.fair">{width} mal {height} Pixel, etwa {dpi} DPI
+      auf einer Seite dieser Größe. Am Bildschirm gut, auf Papier etwas
+      weich.</span>
+    <span data-phrase="quality.low">{width} mal {height} Pixel, etwa {dpi} DPI
+      auf einer Seite dieser Größe. Gehen Sie näher heran, wenn das gedruckt
+      werden soll.</span>
+    <span data-phrase="quality.pixels">{width} mal {height} Pixel.</span>
+    <span data-phrase="coverage.note">Die Seite hat {percent}% des Fotos
+      gefüllt.</span>
+    <span data-phrase="coverage.small">Die Seite hat nur {percent}% des Fotos
+      gefüllt, das meiste Fotografierte war also Tisch. Nächstes Mal
+      näher.</span>
+
+    <span data-phrase="strength.gentle">Sanft: Das Papier wird ausgeglichen und
+      sonst wenig. Für eine Seite mit blassem Bleistift oder einem Foto
+      darauf.</span>
+    <span data-phrase="strength.middling">Die übliche Einstellung: Das Papier
+      wird wieder weiß und gedruckter Text wieder schwarz.</span>
+    <span data-phrase="strength.hard">Hart: Alles Graue wird nach Schwarz oder
+      Weiß gedrückt. Am saubersten auf einer schlicht bedruckten Seite und
+      zerstörerisch auf allem mit einem Bild darauf.</span>
+
+    <span data-phrase="busy.page">Seite {done} von {total}&hellip;</span>
+    <span data-phrase="busy.writing">Das Dokument wird geschrieben&hellip;</span>
+
+    <span data-phrase="result.pdf">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.images">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.mono">Mit einem Bit pro Pixel gespeichert und exakt
+      komprimiert, und deshalb ist es so klein.</span>
+    <span data-phrase="result.jpeg">Die Seiten sind als JPEG in der von Ihnen
+      gewählten Qualität gespeichert.</span>
+    <span data-phrase="result.png">Die Seiten sind als PNG gespeichert, das
+      verlustfrei ist und das ist, was ein Bild aus zwei Farben will. JPEG wäre
+      zugleich größer und um jeden Buchstaben herum unscharf.</span>
+    <span data-phrase="result.clean">Kein Datum, kein Autor, kein Rechnername:
+      Das Einzige im Dokument außer den Seiten ist der Name dieses
+      Werkzeugs.</span>
+
+    <span data-phrase="size.fit">Jedes Blatt bekommt die Größe, die seine eigene
+      Seite wirklich hat, in der Auflösung von oben. Nichts wird mit Balken
+      aufgefüllt.</span>
+    <span data-phrase="size.named">Jede Seite wird auf ein Blatt {name} gesetzt,
+      innerhalb des Randes, welche Form sie auch bekommen hat.</span>
+
+    <span data-phrase="error.decode">Dieser Browser konnte {name} nicht öffnen.
+      Wenn es ein HEIC-Foto von einem iPhone ist, wandeln Sie es zuerst um.</span>
+    <span data-phrase="error.none">Wählen Sie zuerst mindestens ein Foto.</span>
+    <span data-phrase="error.failed">Beim Erstellen der Datei ist etwas
+      schiefgegangen: {detail}</span>
+  </div>
+</main>

--- a/locales/de/tools/document-scanner.toml
+++ b/locales/de/tools/document-scanner.toml
@@ -1,0 +1,312 @@
+#
+# Dokumentenscanner - German.
+#
+# Overrides for tools/document-scanner/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Die Namen aus der Literatur bleiben stehen - Zhang und He für die
+# Seitenverhältnis-Rückrechnung, Sauvola für die Schwellwertmethode. Wer das
+# nachschlagen will, sucht genau diese Namen.
+#
+
+name = "Dokumentenscanner"
+heading = "Dokumenten&shy;scanner <span class=\"h1-kw\">&mdash; ein Foto einer Seite, geradegerückt</span>"
+tagline = "Fotografieren Sie die Seite. Zurück kommt etwas, das wie gescannt aussieht."
+
+title = "Dokumentenscanner &mdash; Foto zu PDF-Scan, ohne Upload"
+description = "Machen Sie aus einem Handyfoto einer Seite ein geradegerücktes, gleichmäßig ausgeleuchtetes PDF. Die Ecken werden für Sie gefunden, die Perspektive herausgerechnet, der Schatten herausgeteilt. Läuft komplett im Browser: nichts wird hochgeladen."
+og_title = "Ein Dokument mit einem Foto scannen, ohne es hochzuladen"
+og_description = "Die Ecken der Seite werden gefunden, die Schräglage herausgerechnet und das ungleichmäßige Licht herausgeteilt, in Ihrem eigenen Browser. Fotografiert werden auf diese Weise Reisepässe, Gehaltsabrechnungen und Verträge, also genau das, was nicht hochgeladen gehört."
+og_image_alt = "Dokumentenscanner - ein Foto einer Seite, geradegerückt und aufgeräumt, ohne Upload"
+
+pledge = """
+    Das Foto wird von Ihrem eigenen Browser dekodiert, geradegerückt,
+    aufgeräumt und in ein PDF geschrieben, mit nichts als Rechnen und den
+    Codecs, die er ohnehin mitbringt. Netzfunktionen hat dieses Werkzeug keine,
+    weder zum Abrufen noch zum Senden, und warum das hier zählt, sagt die Liste
+    dessen, wovon Leute Seiten abfotografieren: ein Reisepass, eine
+    Gehaltsabrechnung, ein Mietvertrag, ein Formular, das ein Amt
+    &bdquo;eingescannt zurück&ldquo; haben will."""
+
+live_hint = """
+      Sie müssen uns nicht glauben. Öffnen Sie die DevTools, sehen Sie im Tab
+      &bdquo;Netzwerk&ldquo; zu und scannen Sie eine Seite. Keine einzige
+      Anfrage trägt ein Foto, ein Vorschaubild, einen Dateinamen oder die
+      Position einer einzigen Ecke. Oder trennen Sie die Internetverbindung und
+      scannen Sie trotzdem eine."""
+
+read_first = """
+, <code>src/detect.js</code> dafür, wie die Ecken
+      ohne jedes Modell gefunden werden, <code>src/warp.js</code> für das
+      Geraderücken und <code>src/clean.js</code> dafür, wie das ungleichmäßige
+      Licht herausgeteilt wird."""
+
+howto_heading = "So scannen Sie ein Dokument mit der Handykamera"
+
+card = """
+            Ein Foto einer Seite, geradegerückt und zu einem Dokument
+            aufgeräumt. Die Ecken werden für Sie gefunden, die Schräglage
+            herausgerechnet und der Schatten herausgeteilt."""
+
+[words]
+plural = "Dokumente"
+choose = "ein Foto einer Seite"
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Kein Wasserzeichen"
+
+[[facts]]
+text = "Läuft offline"
+
+[[facts]]
+text = "Quelloffen"
+
+[[privacy]]
+title = "Ihre Dokumente haben keinen Ort, an den sie gehen könnten."
+body = """
+ In der
+      Content-Security-Policy steht jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehört uns. Es gibt hier keinen Endpunkt, an dem
+      Ihre Fotos gesammelt werden könnten, und keinen Code, der sie senden
+      würde, wenn es ihn gäbe."""
+
+[[privacy]]
+title = "Es gibt kein Modell, also nichts herunterzuladen und nichts zu fragen."
+body = """
+ Die vier Ecken einer
+      Seite zu finden ist Rechnen: der Gradient des Bildes, eine Abstimmung über
+      die geraden Linien darin und eine Prüfung, was unter jeder Seite des
+      siegreichen Rechtecks tatsächlich liegt. Keine Gewichte, keine
+      Inferenz-Laufzeit, nichts, was beim ersten Gebrauch nachgeladen wird, und
+      nichts, was sich beim Dokument einer anderen Person anders verhält als bei
+      Ihrem. Siehe <code>src/detect.js</code>."""
+
+[[privacy]]
+title = "Das Dokument trägt kein Datum, keinen Autor und keinen Rechnernamen."
+body = """
+ Ein Scan ist etwas, das
+      Leute anderen Leuten schicken, meist weil ein Amt darum gebeten hat. Das
+      Einzige, was außer den Seiten selbst in das PDF geschrieben wird, ist der
+      Name dieses Werkzeugs, und ein Titel, wenn Sie einen eintippen. Kein
+      Erstellungsdatum, kein Autor, keine Seriennummer und nichts, was aus Ihrer
+      Uhr, Ihren Dateinamen oder Ihrem Rechner abgeleitet wäre. Siehe
+      <code>src/document.js</code>."""
+
+[[privacy]]
+title = "Hier ruft nichts irgendetwas ab."
+body = """
+ Es gibt kein
+      <code>fetch</code>, kein <code>XMLHttpRequest</code> und kein
+      <code>sendBeacon</code>, nirgends in <code>src/</code>. Die Arbeit ist ein
+      <code>getImageData</code>, ein paar Schleifen über die Bytes und der
+      JPEG-Encoder des Browsers, und all das ist längst auf Ihrem Gerät
+      installiert."""
+
+[[privacy]]
+title = "Läuft offline."
+body = """
+ Trennen Sie die Netzverbindung, und das Werkzeug
+      bleibt, wie es ist, weil nie ein Netzschritt darin war. Das ist der
+      einfachste Beweis von allen, und der, den man führen sollte, bevor man
+      einen Reisepass scannt."""
+
+[[howto]]
+title = "Fotografieren Sie die Seite."
+body = """
+ Von oben, mit der ganzen Seite im
+      Bild und den vier Ecken sichtbar oder beinahe. Sie muss nicht im rechten
+      Winkel aufgenommen und nicht gleichmäßig ausgeleuchtet sein: Die
+      Schräglage und der Schatten sind der Zweck dieses Werkzeugs. Worauf es
+      ankommt, ist das Bild zu füllen. Eine Seite, die vom anderen Ende des
+      Zimmers aufgenommen wurde, hat keine Details mehr, die sich zurückholen
+      ließen."""
+
+[[howto]]
+title = "Prüfen Sie die vier Ecken."
+body = """
+ Sie werden beim Einlesen des Fotos
+      für Sie gefunden, und die Seite sagt es, wenn sie sich nicht sicher ist.
+      Bei einer Seite auf einem Tisch derselben Farbe ist die Kante wirklich
+      schwer zu sehen. Tippen Sie irgendwo auf das Foto, und die nächste Ecke
+      kommt zu Ihrem Finger, oder gehen Sie mit <kbd>Tab</kbd> zu einer und
+      bewegen Sie sie mit den Pfeiltasten."""
+
+[[howto]]
+title = "Entscheiden Sie über das Licht."
+body = """
+ &bdquo;Farbe,
+      ausgeglichen&ldquo; misst das Papier über die Seite hinweg und teilt es
+      heraus, sodass der Schatten verschwindet und ein Stempel oder eine
+      Unterschrift ihre Farbe behält. &bdquo;Schwarzweiß&ldquo; geht weiter und
+      ist das, was einen Scan klein genug für eine E-Mail macht. Was Sie auf dem
+      Bildschirm sehen, ist das echte Ergebnis, erzeugt von demselben Code, der
+      die Datei schreibt."""
+
+[[howto]]
+title = "Fügen Sie die anderen Seiten hinzu."
+body = """
+ Jedes Foto, das Sie
+      hinzufügen, wird eine weitere Seite desselben Dokuments, in der
+      Reihenfolge der Liste, und jede behält ihre eigenen Ecken. Die Pfeile an
+      einer Seite im Streifen schieben sie nach vorn oder nach hinten."""
+
+[[howto]]
+title = "Speichern Sie das PDF und öffnen Sie es, bevor Sie es verschicken."
+body = """
+ Das Dokument entsteht
+      hier, im Speicher dieser Seite. Nichts wurde dafür hochgeladen, und nichts
+      darüber wurde irgendwohin gemeldet."""
+
+[[faq]]
+q = "Wird mein Dokument irgendwohin hochgeladen?"
+a = """
+        Nein. Das Foto wird von Ihrem eigenen Browser auf Ihrer eigenen Hardware
+        dekodiert, geradegerückt, aufgeräumt und in ein PDF geschrieben.
+        Netzfunktionen hat dieses Werkzeug keine, es ruft nie etwas ab und
+        sendet nie etwas, und in der <code>Content-Security-Policy</code> der
+        Seite steht jede Adresse, die sie kontaktieren darf. Keine davon gehört
+        uns. Laden Sie die Seite einmal, trennen Sie die Internetverbindung, und
+        sie arbeitet weiter."""
+
+[[faq]]
+q = "Wie findet er die Ecken der Seite ohne ein Modell?"
+a = """
+        Indem er nach den vier langen geraden Kanten sucht, aus denen ein
+        Rechteck besteht. Das Foto wird verkleinert, der Gradient gebildet, also
+        wo sich das Bild ändert und in welche Richtung, und jedes Pixel, das auf
+        einer Kante liegt, stimmt für die Gerade ab, auf der es läge. Die starken
+        Geraden werden zu Rechteck-Kandidaten gepaart, und jeder Kandidat wird
+        bewertet, indem seine vier Seiten abgelaufen werden: Wie viel von jeder
+        hat wirklich eine Kante unter sich, und sind die vier zusammen der Rand
+        ein und derselben Sache? Eine Seite ist heller als ihre Umgebung, oder
+        dunkler, aber auf allen vier Seiten dasselbe, und das ist es, was
+        verhindert, dass eine Textzeile für den unteren Seitenrand gehalten wird.
+        Es gibt keine Gewichte, es wird nichts heruntergeladen, und die Rechnung
+        ist für jedes Dokument dieselbe."""
+
+[[faq]]
+q = "Die gefundenen Ecken stimmen nicht. Was jetzt?"
+a = """
+        Ziehen Sie sie. Die Ecken sind eine Ausgangslage und nie eine
+        Entscheidung: Der Scan wird von dort genommen, wo die vier am Ende
+        stehen. Tippen Sie irgendwo auf das Foto, und die nächste Ecke springt zu
+        Ihrem Finger, was leichter ist als einen kleinen Griff zu treffen, und
+        die Pfeiltasten bewegen die fokussierte Ecke pixelweise. Die Seite sagt
+        Ihnen außerdem, wenn die Ecken geraten statt gefunden sind, und markiert
+        diese Seite im Streifen. Der übliche Grund ist eine Seite auf einem Tisch
+        von ungefähr ihrer eigenen Farbe, weil da wirklich fast keine Kante zu
+        finden ist."""
+
+[[faq]]
+q = "Warum kommt die geradegerückte Seite in der richtigen Form heraus und nicht gestaucht?"
+a = """
+        Weil die Form aus der Perspektive zurückgerechnet und nicht an den Kanten
+        gemessen wird. Bei einer schräg fotografierten Seite ist die entfernte
+        Kante verkürzt, deshalb liefert die naheliegende Methode, das längste
+        Paar gegenüberliegender Kanten zu nehmen und das Verhältnis zu nennen,
+        ein sichtbar gedrungenes A4. Das ist es, was die meisten Web-Scanner
+        Ihnen geben. Tatsächlich trägt das Foto eines Rechtecks genug
+        Information, um sowohl das Seitenverhältnis des Rechtecks als auch die
+        Brennweite der Kamera zurückzugewinnen, sofern es eine gewöhnliche
+        Kamera ist. Das ist ein Ergebnis von Zhang und He aus dem Jahr 2003, und
+        genau das tut <code>src/geometry.js</code>. Wo das Foto im rechten Winkel
+        aufgenommen wurde, gibt es keine Perspektive, aus der sich rechnen ließe,
+        und es braucht auch keine, weil die Kanten dann exakt sind. Dann fällt er
+        auf sie zurück, und die Seite sagt, welche der beiden geantwortet hat."""
+
+[[faq]]
+q = "Was macht &bdquo;aufgeräumt&ldquo; eigentlich mit dem Bild?"
+a = """
+        Es teilt das Licht heraus. Die Helligkeit des Papiers selbst wird über die
+        Seite hinweg gemessen, in einem Raster aus Kacheln und in jeder Kachel als
+        hohes Perzentil der Helligkeit, das Text zu dunkel und zu spärlich ist, um
+        es zu verschieben, und jedes Pixel wird durch das an dieser Stelle
+        geschätzte Papier geteilt. Übrig bleibt die Tinte, gleichmäßig
+        ausgeleuchtet, ohne Schatten und ohne Abfall zum Rand hin. Das ist nicht
+        dasselbe wie den Kontrast anzuheben: Den Kontrast einer fotografierten
+        Seite anzuheben macht den hellen Teil weiß, den dunklen schwarz und die
+        Schrift im dunklen Teil unlesbar. Deshalb macht &bdquo;Auto-Tonwert&ldquo;
+        solche Bilder schlechter statt besser."""
+
+[[faq]]
+q = "Warum ist der Schwarzweiß-Modus so viel kleiner?"
+a = """
+        Weil ein Bild mit zwei Farben tatsächlich ein Bruchteil der Daten eines
+        Bildes mit sechzehn Millionen ist, und weil es hier auch so gespeichert
+        wird: ein Bit pro Pixel, zu acht in ein Byte gepackt und exakt
+        komprimiert, statt als JPEG eines schwarzweißen Bildes. Auf denselben
+        Seiten kommt es rund achtzehnmal kleiner heraus als der Farbmodus, sodass
+        ein zwanzigseitiger Vertrag unter einem Megabyte landet statt bei etwa
+        fünfzehn. Der Schwellwert ist der von Sauvola, der jedes Pixel gegen den
+        Mittelwert und die Streuung seiner eigenen Nachbarschaft entscheidet statt
+        gegen eine Zahl für die ganze Seite, und genau das hält die Schrift
+        innerhalb eines Schattens lesbar. Halbtöne kennt er nicht, also sollte
+        eine Seite mit einem Foto darauf einen der anderen Modi nehmen."""
+
+[[faq]]
+q = "Kann ich mehrere Seiten in ein PDF legen?"
+a = """
+        Ja. Jedes Foto, das Sie hinzufügen, wird eine weitere Seite, in der
+        Reihenfolge der Liste, und jede Seite behält ihre eigenen Ecken. Ein
+        Stapel nacheinander fotografierter Seiten wird so zu einem Dokument. Die
+        Pfeile an jeder Seite im Streifen schieben sie nach vorn oder nach hinten.
+        Die Aufräum-Einstellung gilt absichtlich für alle: Seiten in einem
+        Dokument, die unterschiedlich aufgeräumt wurden, sehen aus wie zwei
+        Dokumente."""
+
+[[faq]]
+q = "Liest er den Text, damit ich das PDF durchsuchen kann?"
+a = """
+        Nein. Es gibt keine Textebene und keine Zeichenerkennung: Heraus kommt
+        ein Bild der Seite auf einer Seite. Es richtig zu machen hieße, eine
+        OCR-Engine mitzuliefern, also zig Megabyte Modell zum Herunterladen, und
+        ein Dokumentenscanner, der ein Modell holt, bevor er Ihre
+        Gehaltsabrechnung lesen kann, wäre ein Dokumentenscanner mit einem Grund,
+        wegen Gehaltsabrechnungen nach Hause zu telefonieren. Wenn Sie den Text
+        brauchen, liefert der Schwarzweiß-Modus genau die Art von Datei, mit der
+        OCR-Software auf Ihrem eigenen Gerät am besten zurechtkommt."""
+
+[[faq]]
+q = "Es ist unscharf geworden. Warum?"
+a = """
+        Fast immer, weil die Seite im Foto klein war. Die Leiste unter der
+        Vorschau sagt, wie viel des Bildes die Seite gefüllt hat und wie viele
+        Punkte pro Zoll das auf einem Blatt dieser Größe ungefähr ergibt.
+        Unterhalb von etwa 150 DPI sieht ein gedruckter Scan weich aus, und gegen
+        Details, die nie in der Datei waren, kann kein Werkzeug etwas ausrichten.
+        Gehen Sie näher heran, statt zu zoomen, halten Sie still, und lassen Sie
+        die Kamera auf die Seite scharfstellen, bevor Sie auslösen. Verwackeln
+        ist die andere Ursache, und die lässt sich ebenso wenig zurückholen."""
+
+[[faq]]
+q = "Ist das kostenlos, und brauche ich ein Konto?"
+a = """
+        Es ist kostenlos, und es gibt kein Konto, keine Anmeldung, keine
+        Testphase, kein Seitenlimit und kein Wasserzeichen. Es gibt auch keine
+        Grenze für die Größe der Fotos, weil kein Server dafür bezahlt: Die
+        Arbeit passiert auf Ihrem eigenen Gerät. Die Seite trägt Werbung, und die
+        bezahlt sie; die Werbung bekommt nichts über Ihre Dokumente."""
+
+[schema]
+description = "Ein Dokument im Browser scannen: Fotografieren Sie eine Seite, und die vier Ecken werden gefunden, die Perspektive herausgerechnet, das ungleichmäßige Licht herausgeteilt und das Ergebnis in ein PDF geschrieben. Mehrere Seiten werden ein Dokument. Nichts wird hochgeladen."
+features = [
+  "Findet die vier Ecken der Seite ohne Modell, ohne Download und ohne Abruf",
+  "Rechnet die wahre Form der Seite aus der Perspektive zurück, sodass ein schräges Foto nicht gestaucht herauskommt",
+  "Teilt ungleichmäßiges Licht und Schatten heraus, statt den Kontrast anzuheben",
+  "Schwarzweiße Seiten mit einem Bit pro Pixel, und genau das macht einen Scan klein genug für eine E-Mail",
+  "Mehrere Fotos werden die Seiten eines PDF, jede mit ihren eigenen Ecken",
+  "Ecken lassen sich ziehen oder mit der Tastatur pixelweise bewegen",
+  "Sagt es, wenn die Ecken geraten statt gefunden sind",
+  "Schreibt kein Datum, keinen Autor und keinen Rechnernamen in das Dokument",
+  "Läuft offline; kein Upload, kein Konto",
+]
+
+[picker]
+title = "Fotos Ihrer Seiten hier ablegen"
+hint = "oder klicken zum Auswählen &mdash; ein Foto pro Seite, in der Reihenfolge der Seiten"

--- a/locales/de/tools/redact-pdf.html
+++ b/locales/de/tools/redact-pdf.html
@@ -1,0 +1,310 @@
+<!--
+  tools/redact-pdf/body.html, in German.
+
+  Every id, class, data-phrase key and brace placeholder below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+
+  Die count.*-Paare gibt es weiterhin doppelt: Deutsch unterscheidet Singular
+  und Plural, also tragen sie hier tatsächlich zwei Formen.
+-->
+<main>
+  <!-- Schritt 1 &mdash; das Dokument -->
+  <section class="card">
+    <h2><span class="step">1</span> PDF wählen</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <div id="doc-facts" class="doc-facts" hidden>
+      <p id="doc-name" class="doc-name"></p>
+      <p id="doc-sub" class="doc-sub"></p>
+      <ul id="doc-warnings" class="doc-warnings"></ul>
+    </div>
+  </section>
+
+  <!-- Schritt 2 &mdash; finden -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Sagen, was weg muss</h2>
+
+    <p class="card-lede">
+      Tippen Sie die Wörter, einen Namen, eine Adresse, ein Aktenzeichen, und
+      jede Stelle, an der sie vorkommen, wird unten mit ihrer Zeile aufgelistet.
+      Bis Schritt 4 wird nichts entfernt, und nichts wird entfernt, was Sie nicht
+      angekreuzt haben.
+    </p>
+
+    <label class="find-label" for="terms">Wörter und Wendungen, eines pro Zeile</label>
+    <textarea id="terms" rows="3" spellcheck="false" autocomplete="off"
+              placeholder="Schmidt&#10;Brückenstraße 14&#10;AZ-40219"></textarea>
+
+    <div class="find-row">
+      <button type="button" id="find" class="primary">Suchen</button>
+      <label class="inline-check">
+        <input type="checkbox" id="match-case"> <span>Groß- und Kleinschreibung beachten</span>
+      </label>
+      <label class="inline-check">
+        <input type="checkbox" id="whole-word"> <span>Nur ganze Wörter</span>
+      </label>
+    </div>
+
+    <fieldset class="finders">
+      <legend>Oder nach dem suchen, was üblicherweise heikel ist</legend>
+      <div class="chips" id="finders"></div>
+      <p class="field-note" id="finder-note">
+        Das sind Muster, und ein Muster kann eine Telefonnummer nicht von einem
+        Aktenzeichen unterscheiden. Kartennummern und IBANs werden gegen ihre
+        eigenen Prüfziffern geprüft; der Rest wird angeboten und nie für Sie
+        angekreuzt, und jeder Treffer lohnt einen Blick.
+      </p>
+    </fieldset>
+
+    <div class="toolbar" id="match-bar" hidden>
+      <span id="match-count" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="tick-all" class="ghost">Alle ankreuzen</button>
+        <button type="button" id="tick-none" class="ghost">Alle abwählen</button>
+        <button type="button" id="clear-found" class="ghost danger">Liste leeren</button>
+      </div>
+    </div>
+
+    <ul id="match-list" class="match-list" hidden></ul>
+    <p id="match-more" class="field-note" hidden></p>
+  </section>
+
+  <!-- Schritt 3 &mdash; die Seite lesen -->
+  <section class="card" id="page-card" hidden>
+    <h2><span class="step">3</span> Die Seite lesen und Wörter herauspicken</h2>
+
+    <p class="card-lede">
+      Das ist der Text, wie er im Dokument gespeichert ist, in der Reihenfolge,
+      in der ein Leser ihn kopieren würde, und die ist nicht immer die, in der er
+      gedruckt ist. Klicken Sie ein Wort an, um es zu entfernen, und noch einmal,
+      um es zu behalten. Alles hier Durchgestrichene ist das, was verschwinden
+      wird.
+    </p>
+
+    <div class="pager">
+      <button type="button" id="prev-page" class="ghost">&#8592; Zurück</button>
+      <span id="page-of" class="count"></span>
+      <button type="button" id="next-page" class="ghost">Weiter &#8594;</button>
+      <span class="pager-spacer"></span>
+      <span id="page-picked" class="count"></span>
+      <button type="button" id="clear-page" class="ghost danger">Auf dieser Seite alles behalten</button>
+    </div>
+
+    <p id="page-note" class="field-summary" hidden></p>
+
+    <div id="page-text" class="page-text" role="group" aria-label="Der Text dieser Seite"></div>
+  </section>
+
+  <!-- Schritt 4 &mdash; tun -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Die Wörter entfernen</h2>
+
+    <label class="check">
+      <input type="checkbox" id="opt-boxes" checked>
+      <span>
+        <strong>Einen schwarzen Kasten zeichnen, wo jedes stand</strong>
+        <span class="check-note">
+          Damit ein Leser sieht, dass etwas entfernt wurde. Der Kasten ist hier
+          Verzierung und nicht die Schwärzung: Die Buchstaben sind aus der Datei
+          verschwunden, bevor er gezeichnet wird. Schalten Sie ihn ab, und die
+          Wörter verschwinden einfach und lassen den Platz zurück, den sie
+          belegt haben.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-elsewhere" checked>
+      <span>
+        <strong>Dieselben Wörter aus dem übrigen Dokument entfernen</strong>
+        <span class="check-note">
+          Lesezeichen, Kommentare, Notizzettel und das, was in Formularfelder
+          getippt wurde. Ein Wort, das von einer Seite entfernt und in einem
+          Lesezeichen gelassen wurde, ist nicht entfernt. Die Eigenschaften des
+          Dokuments gehen unabhängig davon, und der Ersatztext, den ein
+          Betrachter anstelle der Buchstaben auf der Seite kopiert, ebenso: Beides
+          ist das Dokument, das das Wort sagt, und nicht ein anderer Ort, der eine
+          Kopie davon behält.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-attachments" checked>
+      <span>
+        <strong>Anhänge und alles, was ausgeführt wird, verwerfen</strong>
+        <span class="check-note">
+          Ein PDF kann ganze Dateien in sich tragen und JavaScript, das beim
+          Öffnen läuft. In beidem lässt sich nicht nach den Wörtern suchen, die
+          Sie entfernen, und für das Lesen eines Dokuments braucht es beides
+          nicht.
+        </span>
+      </span>
+    </label>
+
+    <p class="field-summary" id="run-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Entfernen</button>
+      <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Herunterladen</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+      <ul id="check-terms" class="check-terms" hidden></ul>
+      <ul id="result-facts" class="result-facts"></ul>
+    </div>
+  </section>
+
+  <!--
+    The sentences this tool's JavaScript puts on screen. They live here rather
+    than in src/ because src/ is copied byte for byte into all eleven
+    languages; see "The strings in the JavaScript" in the repository README.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="load.notpdf">Das ist kein PDF, es gibt darin also keinen Text zum Entfernen.</span>
+    <span data-phrase="load.encrypted">Dieses PDF hat ein Passwort. Einem
+      Dokument den Schutz zu nehmen ist eine andere Aufgabe, als Wörter daraus zu
+      entfernen, und dieses Werkzeug tut es nicht hinter Ihrem Rücken.</span>
+    <span data-phrase="load.broken">Diese Datei ließ sich nicht als PDF öffnen ({detail}).</span>
+    <span data-phrase="load.nopages">Sie öffnete, aber es waren keine Seiten darin zu finden.</span>
+    <span data-phrase="load.repaired">Die Querverweistabelle dieses Dokuments
+      passte nicht zu seinem Inhalt, deshalb wurde es gelesen, indem nach Objekten
+      gesucht wurde. Das ist eine Reparatur, und sie hat funktioniert. Prüfen Sie
+      das Ergebnis sorgfältig, bevor Sie es irgendwohin schicken.</span>
+
+    <span data-phrase="doc.sub">{pages} &middot; {words} Text &middot; {size}</span>
+    <span data-phrase="doc.notext">{count} dieser Seiten haben überhaupt keinen
+      Text. Eine solche Seite ist ein Bild einer Seite, und für dieses Werkzeug
+      gibt es dort nichts zu entfernen: Die Wörter im Bild bleiben genau, wo sie
+      sind.</span>
+    <span data-phrase="doc.unreadable">{count} Buchstaben dieses Dokuments ließen
+      sich nicht als Zeichen lesen, weil die verwendeten Schriften keine Zuordnung
+      von ihren Glyphen zurück zu Text mitbringen. Nach diesen Buchstaben lässt
+      sich nicht suchen, sehen Sie sich also die Seiten an, auf denen sie stehen,
+      statt der Suche zu vertrauen.</span>
+    <span data-phrase="doc.scan">Manche Seiten tragen unsichtbaren Text über
+      einem Bild, und so hält ein Scanner fest, was sein Leser aus der Seite
+      gemacht hat. Diesen Text zu entfernen entfernt das, was eine Suche und ein
+      Kopieren finden würden. Es ändert nichts am Bild, und im Bild sind die
+      Wörter weiterhin lesbar.</span>
+
+    <span data-phrase="find.none">Auf keiner Seite gab es einen Treffer.</span>
+    <span data-phrase="find.some">{count} auf {pages}.</span>
+    <span data-phrase="find.more">Die ersten {shown} sind aufgelistet. Der Rest
+      ist gefunden und wird mit entfernt, wenn Sie alle ankreuzen.</span>
+    <span data-phrase="find.terms">Tippen Sie oben ein Wort oder wählen Sie ein Muster, bevor Sie Suchen drücken.</span>
+
+    <span data-phrase="page.of">Seite {number} von {total}</span>
+    <span data-phrase="page.picked">{count} werden von dieser Seite entfernt</span>
+    <span data-phrase="page.notext">Auf dieser Seite gibt es keinen Text.
+      Entweder ist sie leer, oder sie ist ein Bild einer Seite: ein Scan, ein
+      Foto, ein Export, der seine Wörter als Formen gezeichnet hat. Nichts darauf
+      lässt sich durchsuchen, und nichts darauf lässt sich hier entfernen.</span>
+    <span data-phrase="page.unreadable">{count} Buchstaben auf dieser Seite
+      ließen sich nicht als Zeichen lesen. Sie stehen unten als &#9647;, und die
+      Suche findet sie nicht.</span>
+    <span data-phrase="page.scan">Der Text auf dieser Seite ist unsichtbar: Er
+      liegt über einem Bild der Seite, und so wird ein Scan durchsuchbar gemacht.
+      Was Sie hier entfernen, ist das, was eine Suche und ein Kopieren finden
+      würden. Das Bild behält die Wörter.</span>
+
+    <span data-phrase="run.summary">{words} auf {pages} werden entfernt.</span>
+    <span data-phrase="run.nothing">Es ist noch nichts angekreuzt. Suchen Sie in Schritt 2 ein Wort, oder klicken Sie in Schritt 3 eines an.</span>
+    <span data-phrase="run.editing">Die Wörter werden entfernt&hellip;</span>
+    <span data-phrase="run.writing">Das Dokument wird geschrieben&hellip;</span>
+    <span data-phrase="run.checking">Die fertige Datei wird geöffnet und durchsucht&hellip;</span>
+    <span data-phrase="run.failed">Beim Neuschreiben dieses Dokuments ist etwas schiefgegangen ({detail}).</span>
+    <span data-phrase="run.cancelled">Abgebrochen. Es wurde nichts geschrieben.</span>
+
+    <span data-phrase="result.headline">{words} entfernt</span>
+    <span data-phrase="result.sub">{size} &middot; {pages} geändert &middot; {boxes}</span>
+    <span data-phrase="check.good">Hier erneut geöffnet und durchsucht, so wie
+      ein Leser es täte: Keines davon steht in der fertigen Datei.</span>
+    <span data-phrase="check.partial">Hier erneut geöffnet und durchsucht: Jedes
+      Vorkommen, das Sie angekreuzt haben, ist weg, und die, die Sie gelassen
+      haben, sind noch da.</span>
+    <span data-phrase="check.survived">Diese Datei wurde NICHT geschrieben. Das
+      fertige Dokument wurde erneut geöffnet, und ein Teil dessen, was Sie
+      entfernt haben, war darin weiterhin zu finden. Die Schwärzung war also
+      nicht vollständig. Es wird nichts zum Herunterladen angeboten.</span>
+    <span data-phrase="check.pages">Diese Datei wurde NICHT geschrieben. Das
+      fertige Dokument kam mit einer anderen Seitenzahl zurück, als es
+      hineinging, es ist also über die Wörter hinaus etwas schiefgegangen. Es wird
+      nichts zum Herunterladen angeboten.</span>
+
+    <span data-phrase="fact.boxes">{count} über die Lücken gezeichnet.</span>
+    <span data-phrase="fact.noboxes">Es wurden keine Kästen gezeichnet, die
+      Wörter sind also weg, ohne dass irgendetwas sagt, wo sie standen.</span>
+    <span data-phrase="fact.elsewhere">Dieselben Wörter wurden aus {where} entfernt.</span>
+    <span data-phrase="fact.metadata">Die Dokumenteigenschaften und das XMP-Paket
+      wurden entfernt, die fertige Datei sagt also nicht, was sie erzeugt hat,
+      wann, oder wie sie früher hieß.</span>
+    <span data-phrase="fact.carried">{attachments} und {actions} wurden verworfen.</span>
+    <span data-phrase="fact.shared">Ein Teil dessen, was Sie entfernt haben,
+      wurde von einem Block gezeichnet, den das Dokument auf mehr als einer Seite
+      wiederverwendet, es ist also von jeder Seite verschwunden, die ihn zeichnet.
+      Das ist mehr, als Sie angekreuzt haben, und nie weniger.</span>
+    <span data-phrase="fact.overimage">{count} der entfernten Buchstaben lagen
+      über einem Bild derselben Seite. Aus der Textebene sind sie heraus und im
+      Bild sind sie noch: Ein Leser kann sie nicht mehr suchen oder kopieren und
+      weiterhin sehen.</span>
+    <span data-phrase="fact.untouched">Alles andere auf jeder Seite wurde Byte
+      für Byte durchgereicht. Keine Schrift, kein Bild und keine Linie wurde neu
+      kodiert.</span>
+
+    <span data-phrase="count.pages">{count} Seiten</span>
+    <span data-phrase="count.page">{count} Seite</span>
+    <span data-phrase="count.words">{count} Wörter</span>
+    <span data-phrase="count.word">{count} Wort</span>
+    <span data-phrase="count.pieces">{count} Textstücke</span>
+    <span data-phrase="count.piece">{count} Textstück</span>
+    <span data-phrase="count.matches">{count} Treffer</span>
+    <span data-phrase="count.match">{count} Treffer</span>
+    <span data-phrase="count.boxes">{count} schwarze Kästen</span>
+    <span data-phrase="count.box">{count} schwarzer Kasten</span>
+    <span data-phrase="count.attachments">{count} Anhänge</span>
+    <span data-phrase="count.attachment">{count} Anhang</span>
+    <span data-phrase="count.actions">{count} Aktionen</span>
+    <span data-phrase="count.action">{count} Aktion</span>
+    <span data-phrase="count.hosts">{count} Hosts</span>
+    <span data-phrase="count.host">{count} Host</span>
+
+    <!-- The space before {platform} belongs to these two rather than to the
+         phrase it lets in, because phrases.js collapses and trims the markup
+         it reads and a leading space would not survive the trip. -->
+    <span data-phrase="net.clean">Ihr Dokument ist nirgendwohin gegangen. {total}
+      Dateien geladen, allesamt eigene dieser Seite. {platform}</span>
+    <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut
+      dieses Werkzeug nie. Das ist es wert, nachgesehen zu werden. {platform}</span>
+    <span data-phrase="net.platform">Die eigenen Skripte der Seite für Werbung,
+      Messung und den Spenden-Knopf kamen von {hosts}; keines davon hat ein
+      Dokument, ein Wort daraus oder irgendetwas Gesuchtes bekommen.</span>
+
+    <span data-phrase="finder.email">E-Mail-Adressen</span>
+    <span data-phrase="finder.card">Kartennummern</span>
+    <span data-phrase="finder.iban">Bankkonten (IBAN)</span>
+    <span data-phrase="finder.nationalid">Sozialversicherungs- &amp; Rentenversicherungsnummern</span>
+    <span data-phrase="finder.phone">Telefonnummern</span>
+  </div>
+</main>

--- a/locales/de/tools/redact-pdf.toml
+++ b/locales/de/tools/redact-pdf.toml
@@ -1,0 +1,386 @@
+#
+# PDF-Schwärzer - German.
+#
+# Overrides for tools/redact-pdf/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Schwärzen" ist der Begriff, den deutsche Behörden und Gerichte für genau
+# diese Sache verwenden, und er trägt die Bedeutung mit, auf die es hier
+# ankommt: entfernt, nicht verdeckt. Der Bild-Schwärzer nebenan verwendet ihn
+# aus demselben Grund.
+#
+# Das eine, was beim Bearbeiten dieser Prosa nicht verloren gehen darf: Diese
+# Seite erhebt einen Anspruch, den andere Schwärzungswerkzeuge nicht erheben
+# können, und der Anspruch ist nichts wert, wenn er überzogen wird. Entfernt
+# wird Text. Eine Seite, die ein Foto einer Seite ist, hat keinen Text darauf,
+# und dieses Werkzeug sagt das, statt so zu tun.
+#
+
+name = "PDF-Schwärzer"
+heading = "PDF&nbsp;schwärzen <span class=\"h1-kw\">&mdash; die Wörter kommen heraus, kein Kasten darüber</span>"
+tagline = "Die Buchstaben werden aus der Datei gelöscht, und danach wird die Datei durchsucht, um es zu belegen."
+
+title = "PDF schwärzen &mdash; den Text wirklich löschen, kostenlos, ohne Upload"
+description = "Wörter aus einem PDF entfernen, statt ein schwarzes Rechteck darüber zu legen. Die Buchstaben werden aus den Zeichenanweisungen der Seite gelöscht, die fertige Datei wird erneut geöffnet und durchsucht, um zu belegen, dass sie weg sind, und nichts wird hochgeladen."
+og_title = "Ein PDF richtig schwärzen &mdash; die Wörter werden gelöscht, nicht verdeckt"
+og_description = "Ein schwarzes Rechteck liegt in den meisten Werkzeugen auf dem Text und lässt sich darunter hervorkopieren. Dieses hier löscht die Buchstaben aus der Datei und durchsucht anschließend das Ergebnis, um zu zeigen, dass sie nicht darin sind."
+og_image_alt = "Ein PDF schwärzen, indem der Text gelöscht und nicht verdeckt wird"
+
+pledge = """
+    Das Dokument, das Sie wählen, wird auf diesem Gerät im Speicher geöffnet,
+    gelesen, bearbeitet und wieder herausgeschrieben, von Code, der von dieser
+    Adresse ausgeliefert wird. Nichts hier kann etwas hochladen, und am anderen
+    Ende dieser Seite steht kein Server, der etwas entgegennähme. Weder die
+    Datei noch die Wörter, nach denen Sie gesucht haben, verlassen den Tab."""
+
+live_hint = """
+      Sie müssen uns nicht glauben. Öffnen Sie die DevTools, sehen Sie im Tab
+      &bdquo;Netzwerk&ldquo; zu und schwärzen Sie etwas. Keine einzige Anfrage
+      trägt eine Seite, ein Wort oder einen Dateinamen. Oder trennen Sie die
+      Internetverbindung und schwärzen Sie es trotzdem."""
+
+read_first = """
+, <code>src/text.js</code> dafür, wie jedes Wort
+      einer Seite gefunden und verortet wird, und <code>src/edit.js</code> für
+      das Löschen selbst: was aus den Anweisungen der Seite herausgeschnitten
+      wird und was wieder hineinkommt, damit der Rest der Zeile stehen bleibt.
+      Keine dieser Dateien kommt ins Netz, und der Leser und der Schreiber
+      daneben auch nicht."""
+
+howto_heading = "So schwärzen Sie ein PDF, damit die Wörter wirklich weg sind"
+
+card = """
+            Wörter aus einem PDF löschen, statt sie zu verdecken. Die Buchstaben
+            kommen aus den Zeichenanweisungen der Seite heraus, die Lücke wird
+            offen gehalten, damit sonst nichts verrutscht, und die fertige Datei
+            wird hier erneut geöffnet und durchsucht, um zu belegen, dass die
+            Wörter nicht darin sind."""
+
+[words]
+plural = "Dokumente"
+choose = "ein PDF"
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Läuft offline"
+
+[[facts]]
+text = "Quelloffen"
+
+[[facts]]
+text = "Dateien bleiben auf Ihrem Gerät"
+
+[[privacy]]
+title = "Ein schwarzes Rechteck ist keine Schwärzung, und hier wird keines über irgendetwas gelegt."
+body = """
+
+      In fast jedem Programm, das anbietet, eine Seite zu schwärzen, sei es ein
+      PDF-Betrachter, eine Textverarbeitung oder ein Layoutprogramm, ist das
+      Rechteck ein Objekt, das neben dem Text gespeichert wird und nicht in ihm.
+      Der Text ist weiterhin da, in derselben Datei, an derselben Stelle, und wer
+      den Bereich markiert und Kopieren drückt, bekommt ihn zurück. Dieses
+      Versagen hat Gerichtsakten veröffentlicht, Geheimdienstberichte und im
+      Dezember 2025 geschwärzte Namen in einer Massenveröffentlichung von
+      Dokumenten des US-Justizministeriums, die binnen Stunden lesbar waren.
+      Dieses Werkzeug löscht die Buchstaben aus den Anweisungen, die die Seite
+      zeichnen. Es gibt kein Rechteck mit etwas darunter, weil darunter nichts
+      ist."""
+
+[[privacy]]
+title = "Die fertige Datei wird hier erneut geöffnet und durchsucht, bevor sie Ihnen angeboten wird."
+body = """
+
+      Bis das geschehen ist, korrigiert dieses Werkzeug nur seine eigene
+      Hausaufgabe. Also werden die Bytes, die gleich Ihr Download werden,
+      demselben Leser übergeben, als hätte sie ein Fremder geschickt, jede Seite
+      wird erneut gelesen, jedes Lesezeichen, jeder Kommentar, jedes Formularfeld
+      und jede Dokumenteigenschaft wird eingesammelt, und nach den Wörtern, die
+      Sie entfernt haben, wird gesucht. Die Zahl steht bei den Ergebnissen. Hat
+      etwas überlebt, gilt der Durchlauf als gescheitert, und es gibt keinen
+      Download."""
+
+[[privacy]]
+title = "Die Wörter verlassen den Tab nie, und die Suche auch nicht."
+body = """
+ In der
+      Content-Security-Policy steht jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehört uns. Dieses Werkzeug fügt dieser Liste nichts
+      hinzu: Es hat keine eigene Netzfunktion, nicht einmal eine optionale. Was
+      Sie in das Suchfeld tippen, ist eine Zeichenkette, die mit Text im Speicher
+      dieses Tabs verglichen wird, und für beides gibt es keinen Ort, an den es
+      gehen könnte."""
+
+[[privacy]]
+title = "Schwärzen ist die Aufgabe, die einen Upload am wenigsten verträgt."
+body = """
+
+      Was Leute schwärzen, ist der Grund, warum es nicht hochgeladen werden darf.
+      Eine Zeugenaussage, ein Arztbrief, ein Kontoauszug für den Vermieter, ein
+      Vertrag mit dem Namen eines Mandanten darin, der an einen anderen gehen
+      soll. Das einem fremden Server zu übergeben, damit er den privaten Teil
+      entfernt, heißt: Der private Teil kommt zuerst an, vollständig, und das ist
+      die Fassung, die dort bleibt. Diese Seite hat keine andere Hälfte."""
+
+[[privacy]]
+title = "Was übrig bleibt, wird unverändert durchgereicht."
+body = """
+
+      Die einzigen Bytes, die sich auf einer Seite ändern, sind die
+      Textanweisungen, zu denen die entfernten Buchstaben gehörten. Jede andere
+      Anweisung und jede Schrift, jedes Bild und jede Linie, auf die die Seite
+      sich bezieht, wird genau so kopiert, wie sie ankam. Nichts wird neu
+      gerendert, neu kodiert oder neu umbrochen. Die Breite des Entfernten wird
+      gemessen und als Abstandsanweisung wieder eingesetzt, damit der Rest der
+      Zeile dort bleibt, wo das Dokument ihn hingesetzt hat."""
+
+[[privacy]]
+title = "Aus einem Foto kann es keine Wörter entfernen, und es sagt, welche Seiten das sind."
+body = """
+
+      Eine eingescannte Seite ist ein Bild. Die Wörter darauf sind Pixel und kein
+      Text, und nichts hier kann sie anfassen. Trägt der Scan die unsichtbare
+      durchsuchbare Ebene, die die OCR eines Scanners erzeugt, entfernt dieses
+      Werkzeug diese Ebene, also genau das, was eine Suche und ein Kopieren
+      gefunden hätten, und sagt auf der Seite deutlich, dass das Bild die Wörter
+      weiterhin zeigt. Dieses Bild zu verdecken ist eine andere Aufgabe; der
+      <a href=\"../bild-schwaerzen/\">Bild-Schwärzer</a> ist das Werkzeug, das
+      Pixel überschreibt."""
+
+[[privacy]]
+title = "Das Dokument hört auf zu sagen, woher es kommt."
+body = """
+
+      Die Eigenschaften und das XMP-Paket gehen bei jedem Durchlauf: keine
+      Producer-Zeile, kein Erstellungsdatum, kein Autor, kein Titel und keiner
+      der privaten Blöcke, die ein Layoutprogramm hinterlässt. Eine Datei, aus
+      deren Seiten ein Name entfernt wurde und deren Eigenschaften weiterhin
+      <code>Schmidt Vergleich Entwurf 3.docx</code> lauten, ist nicht geschwärzt,
+      und das sollte man nicht einem Häkchen überlassen."""
+
+[[privacy]]
+title = "Verschlüsselte Dateien werden abgewiesen statt geöffnet."
+body = """
+
+      Ein PDF mit Passwort wird abgelehnt, auch die Sorte, die Scanner mit leerem
+      Passwort erzeugen und die sich technisch öffnen ließe. Einem Dokument den
+      Schutz zu nehmen ist eine andere Aufgabe, als Wörter daraus zu entfernen,
+      und es stillschweigend zu tun wäre für ein Werkzeug eine überraschende
+      Sache, in Ihrem Namen zu erledigen."""
+
+[[privacy]]
+title = "Was Google lädt und was es nicht bekommt."
+body = """
+ Die Skripte für Werbung
+      und Messung kommen von Google. Keines von beiden bekommt irgendetwas über
+      Ihr Dokument: keine Datei, keine Seite, keinen Namen, keine Größe, keine
+      Seitenzahl und kein Wort, nach dem Sie gesucht haben. Jede Zeile, die ein
+      PDF liest, bearbeitet oder schreibt, wird von dieser Domain ausgeliefert
+      und steht im Repository."""
+
+[[privacy]]
+title = "Was der Spenden-Knopf lädt und was er nicht bekommt."
+body = """
+
+      Der Knopf &bdquo;Buy me a coffee&ldquo; im Kopfbereich wird von einem
+      Skript von cdnjs.buymeacoffee.com gezeichnet und holt seine Schrift von
+      Google Fonts. Er ist ein Link und sonst nichts: Er meldet keinen Besuch,
+      und er bekommt nichts über Sie oder Ihre Dokumente. Es passiert nichts, bis
+      Sie ihn anklicken, und dann sind Sie auf einer fremden Seite."""
+
+[[privacy]]
+title = "Läuft offline."
+body = """
+ Trennen Sie die Netzverbindung, und alles auf dieser
+      Seite arbeitet weiter. Das ist der einfachste Beweis von allen: Ein
+      Werkzeug, das Ihr Dokument zum Schwärzen wegschickt, hörte auf."""
+
+[[howto]]
+title = "Wählen Sie das PDF."
+body = """
+ Ein Dokument nach dem anderen, und zwar
+      mit Absicht: Schwärzen ist eine Aufgabe, die Seite für Seite angesehen
+      werden muss, und ein Werkzeug, in dem Sie Wörter in einer Datei ankreuzen
+      und das sie stillschweigend auf eine andere anwendet, ist genau der Weg,
+      auf dem das Falsche verschickt wird. Der Browser liest es direkt von Ihrer
+      Festplatte."""
+
+[[howto]]
+title = "Sagen Sie, was weg muss."
+body = """
+ Tippen Sie die Wörter, einen Namen,
+      eine Adresse, ein Aktenzeichen, und jede Stelle, an der sie vorkommen, wird
+      mit ihrer Zeile und einem Kästchen zum Ankreuzen aufgelistet. Die Suchen
+      daneben finden E-Mail-Adressen, Kartennummern, IBANs, Sozialversicherungs-
+      und Rentenversicherungsnummern und Telefonnummern. Die werden angeboten und
+      nie für Sie angekreuzt: Ein Muster kann eine Telefonnummer nicht von einem
+      Aktenzeichen unterscheiden."""
+
+[[howto]]
+title = "Lesen Sie die Seite und picken Sie Wörter heraus."
+body = """
+
+      Die Leiste zeigt den Text des Dokuments so, wie er tatsächlich gespeichert
+      ist, in der Reihenfolge, in der ein Leser ihn kopieren würde. Klicken Sie
+      ein Wort an, um es zu entfernen, und noch einmal, um es zu behalten. Alles
+      Durchgestrichene ist das, was verschwinden wird, und damit ist dieser
+      Schritt zugleich die Durchsicht und die Auswahl. Er lohnt sich auf jeder
+      Seite, bevor Sie den Knopf drücken."""
+
+[[howto]]
+title = "Entfernen Sie sie und lesen Sie die Zeile, die sagt, dass geprüft wurde."
+body = """
+
+      Die Buchstaben werden gelöscht, die Lücke wird offen gehalten, ein
+      schwarzer Kasten wird darüber gezeichnet, wenn Sie einen wollten, und
+      dieselben Wörter werden aus Lesezeichen, Kommentaren, Formularfeldern und
+      den Eigenschaften des Dokuments entfernt. Dann wird die fertige Datei hier
+      erneut geöffnet und durchsucht. Ist ein entferntes Wort darin noch zu
+      finden, bekommen Sie keinen Download und eine Meldung, die das sagt."""
+
+[[faq]]
+q = "Was ist daran anders als an einem schwarzen Kasten in einem PDF-Betrachter?"
+a = """
+        Ein in einem Betrachter gezeichnetes Rechteck ist eine Anmerkung: ein
+        Objekt mit einer Position, neben der Seite gespeichert. Der Text darunter
+        ist unberührt. Wer diesen Bereich markiert und Kopieren drückt, wer die
+        Datei in einem anderen Programm öffnet oder wer irgendeinen
+        Text-Extraktor darüberlaufen lässt, bekommt die Wörter zurück. Manche
+        Betrachter haben einen &bdquo;Schwärzen&ldquo;-Befehl, der die Entfernung
+        tatsächlich anwendet, und einige bieten nur das Zeichnen an. Dieses
+        Werkzeug hat kein Rechteck zum Beiseiteschieben: Die Buchstaben werden
+        aus den Zeichenanweisungen der Seite herausgeschnitten, und der schwarze
+        Kasten wird, wenn Sie ihn eingeschaltet lassen, danach über eine Lücke
+        gezeichnet, die bereits leer ist."""
+
+[[faq]]
+q = "Woher weiß ich, dass die Wörter wirklich weg sind?"
+a = """
+        Weil das Werkzeug es auf Ihrem Gerät nachprüft und Ihnen die Zahl zeigt.
+        Ist die Datei geschrieben, wird sie von demselben Leser auf dieser Seite
+        erneut geöffnet, jede Seite wird gelesen, jedes Lesezeichen, jeder
+        Kommentar, jedes Formularfeld und jede Eigenschaft wird eingesammelt, und
+        nach jedem entfernten Wort wird gesucht. Die Ergebniszeile sagt, wie viele
+        es waren und wie viele übrig sind. Stimmt die Antwort nicht, scheitert der
+        Durchlauf, und es wird nichts zum Herunterladen angeboten. Nachprüfen
+        können Sie es anschließend auch selbst in jedem Betrachter: Strg+F, und
+        suchen Sie nach dem Wort."""
+
+[[faq]]
+q = "Verrutscht der Rest der Seite, wenn ein Wort entfernt wird?"
+a = """
+        Nein. Text wird gezeichnet, indem ein Stift über die Seite vorrückt, also
+        würde das Löschen von fünf Buchstaben den Rest der Zeile um fünf
+        Buchstaben nach links ziehen. Die genaue Breite des Entfernten wird aus
+        den Metriken der Schrift selbst gemessen und als Abstandsanweisung wieder
+        eingesetzt, die den Stift bewegt, ohne etwas zu zeichnen. Spalten bleiben
+        in einer Flucht, und Summen bleiben unter ihren Überschriften."""
+
+[[faq]]
+q = "Kann er ein eingescanntes Dokument schwärzen?"
+a = """
+        Das Bild nicht, und er sagt das, statt so zu tun. Ein Scan ist ein Foto
+        einer Seite: Die Wörter sind Pixel, und es gibt keinen Text zum Entfernen.
+        Was ein Scan häufig doch trägt, ist eine unsichtbare Textebene, die die
+        OCR des Scanners über das Bild geschrieben hat, damit die Seite
+        durchsuchbar ist. Dieses Werkzeug findet diese Ebene, entfernt daraus,
+        was Sie wählen, und sagt Ihnen auf der Seite, dass das Bild unverändert
+        ist. Eine Suche und ein Kopieren finden das Wort also nicht mehr, und wer
+        auf die Seite sieht, liest es weiterhin. Für ein Bild überschreibt der
+        <a href=\"../bild-schwaerzen/\">Bild-Schwärzer</a> die Pixel selbst."""
+
+[[faq]]
+q = "Was ist mit den Teilen eines Dokuments, die nicht auf einer Seite stehen?"
+a = """
+        Die werden mitbehandelt, denn dort läuft eine Schwärzung meist aus.
+        Dieselben Wörter werden aus Lesezeichen, Kommentaren und Notizzetteln
+        entfernt, aus dem, was in Formularfelder getippt wurde, aus dem Text, der
+        einem Screenreader übergeben wird, und aus dem Ersatztext, den ein
+        Betrachter <em>anstelle</em> der Buchstaben auf der Seite kopiert. Den
+        letzten gibt es, damit Ligaturen und getrennte Wörter sauber kopieren, und
+        er kann einen ganzen Satz enthalten. Die Dokumenteigenschaften und das
+        XMP-Paket werden ganz entfernt. Anhänge und alles, was beim Öffnen der
+        Datei ausgeführt wird, fallen weg, weil sich in beidem nicht nach den
+        Wörtern suchen lässt, die Sie entfernen."""
+
+[[faq]]
+q = "Werden meine Dokumente irgendwohin hochgeladen?"
+a = """
+        Nein. Die Datei wird von Ihrem eigenen Browser auf Ihrer eigenen Hardware
+        gelesen, bearbeitet und geschrieben. Dieses Werkzeug hat keine
+        Serverseite, und in der <code>Content-Security-Policy</code> der Seite
+        steht jede Adresse, die sie kontaktieren darf. Keine davon gehört uns.
+        Was Sie in das Suchfeld tippen, wird mit Text im Speicher dieses Tabs
+        verglichen und geht ebenfalls nirgendwohin."""
+
+[[faq]]
+q = "Warum kann ich keinen Kasten über die Seite ziehen wie in anderen Werkzeugen?"
+a = """
+        Weil eine Seite zu zeichnen einen vollständigen PDF-Renderer bedeutet, mit
+        Schriften, Verläufen, Transparenz und Mischmodi, also ein Megabyte oder
+        mehr an Engine zum Nachladen und Ausführen, und diese Seite liefert davon
+        nichts mit. Das passt zur Aufgabe: Ein gezogenes Rechteck wählt eine
+        <em>Fläche Papier</em>, und eine Fläche Papier ist nicht dasselbe wie der
+        Text darunter. Genau so fängt das Versagen mit dem schwarzen Kasten an.
+        Was Sie stattdessen bekommen, ist der Text des Dokuments in Lesereihenfolge
+        mit jedem Wort anklickbar. Und es ist die einzige Ansicht, die Ihnen sagen
+        kann, was ein Bild der Seite nicht kann: ob die Wörter vor Ihnen überhaupt
+        Text sind."""
+
+[[faq]]
+q = "Öffnet die fertige Datei überall?"
+a = """
+        Ja. Die Ausgabe wird als PDF 1.5 geschrieben oder in der höchsten Version,
+        die die übergebene Datei gebraucht hat, und 1.5 versteht jeder Betrachter,
+        der seit 2003 erschienen ist. Nichts auf der Seite wird neu kodiert: Die
+        Schriften, Bilder und Vektorzeichnungen kommen Byte für Byte durch, und
+        was vom Text übrig ist, bleibt markierbar und durchsuchbar wie zuvor."""
+
+[[faq]]
+q = "Kann er ein passwortgeschütztes PDF öffnen?"
+a = """
+        Nein, und das ist Absicht. Ein verschlüsseltes Dokument wird mit einer
+        Meldung abgewiesen, auch wenn das Passwort leer ist, und so speichern
+        viele Scanner und Kopierer. Einer Datei den Schutz zu nehmen ist eine
+        andere Aufgabe, als Wörter daraus zu entfernen, und ein Werkzeug, das das
+        stillschweigend täte, täte etwas, worum Sie nicht gebeten haben."""
+
+[[faq]]
+q = "Gibt es eine Größenbeschränkung, und kostet es etwas?"
+a = """
+        In das Werkzeug ist keine Grenze geschrieben. Die Grenze ist Ihr eigenes
+        Gerät: Das Dokument liegt während der Bearbeitung im Speicher, ein Laptop
+        nimmt also ein paar hundert Megabyte klaglos hin und kommt irgendwo
+        darüber ins Straucheln. Es ist kostenlos, es gibt kein Konto, keine
+        Anmeldung und keine Testphase. Die Seite trägt Werbung, und die bezahlt
+        sie; die Werbung bekommt nichts über Ihre Dokumente."""
+
+[[faq]]
+q = "Läuft er offline?"
+a = """
+        Ja. Laden Sie die Seite einmal, trennen Sie danach die
+        Internetverbindung, und sie arbeitet weiter. Das ist zugleich der
+        einfachste Weg zu prüfen, dass nichts hochgeladen wird: Ein Werkzeug, das
+        Ihr Dokument zum Schwärzen wegschickt, hörte in dem Moment auf, in dem Sie
+        den Stecker ziehen."""
+
+[schema]
+description = "Ein PDF im Browser schwärzen, indem der Text gelöscht und nicht verdeckt wird. Die Buchstaben werden aus dem Inhaltsstrom der Seite entfernt, die fertige Datei wird erneut geöffnet und durchsucht, um zu belegen, dass sie weg sind, und nichts wird hochgeladen."
+features = [
+  "Löscht die Buchstaben aus der Seite, statt ein Rechteck darüber zu zeichnen",
+  "Öffnet die fertige Datei erneut und durchsucht sie, um zu belegen, dass die Wörter weg sind",
+  "Findet jedes Vorkommen eines Wortes, oder sucht nach E-Mails, Kartennummern, IBANs und Ausweisnummern",
+  "Zeigt den Text des Dokuments in Lesereihenfolge, sodass jedes Wort anklickbar ist",
+  "Entfernt dieselben Wörter aus Lesezeichen, Kommentaren, Formularfeldern und Eigenschaften",
+  "Hält die Lücke offen, damit der Rest der Zeile nicht verrutscht",
+  "Sagt, welche Seiten Scans sind, auf denen es keinen Text zu entfernen gibt",
+  "Läuft offline; kein Upload, kein Konto, keine Größenbeschränkung",
+]
+
+[picker]
+title = "PDF hier ablegen"
+hint = "oder klicken zum Auswählen &mdash; ein Dokument nach dem anderen"

--- a/locales/de/tools/stack-images.html
+++ b/locales/de/tools/stack-images.html
@@ -1,0 +1,241 @@
+<!--
+  tools/stack-images/body.html, in German.
+
+  Every id, class, option value, data-phrase key and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language. Only
+  the words change. The #faq-raw anchor is a link target from the note in step
+  one, so it stays as it is.
+-->
+<main>
+  <!-- Schritt 1 &mdash; die Aufnahmen -->
+  <section class="card">
+    <h2><span class="step">1</span> Aufnahmen wählen</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p class="note">
+      RAW-Dateien werden geöffnet, indem das JPEG in voller Größe gelesen wird,
+      das die Kamera bereits hineingeschrieben hat: ein paar Kilobyte
+      Verzeichnis und dann ein Ausschnitt. Die Sensordaten werden nie dekodiert,
+      eine 60&nbsp;MB große Aufnahme öffnet also ungefähr so schnell wie ein
+      JPEG. <a href="#faq-raw">Was das für das Ergebnis bedeutet</a>.
+    </p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="sort-name" class="ghost">Nach Namen sortieren</button>
+        <button type="button" id="clear-all" class="ghost danger">Alle entfernen</button>
+      </div>
+    </div>
+
+    <ul id="frame-list" class="frame-list"></ul>
+  </section>
+
+  <!-- Schritt 2 &mdash; wie sie zusammenkommen -->
+  <section class="card">
+    <h2><span class="step">2</span> Wie sie zusammenkommen</h2>
+
+    <div class="settings">
+      <div class="field field-wide">
+        <label for="mode">Methode</label>
+        <select id="mode">
+          <option value="mean" selected>Mittelwert &mdash; Rauschen senken</option>
+          <option value="median">Median &mdash; Leute und vorbeifahrende Autos entfernen</option>
+          <option value="sigma">Sigma-Clipping &mdash; beides auf einmal</option>
+          <option value="max">Aufhellen &mdash; Sternspuren, Feuerwerk, Lichtmalerei</option>
+          <option value="min">Abdunkeln &mdash; alles Helle entfernen, das sich bewegt hat</option>
+          <option value="sum">Addieren &mdash; eine lange Belichtung nachbilden</option>
+          <option value="focus">Focus Stacking &mdash; behalten, was scharf war</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="align">Aufnahmen ausrichten</label>
+        <select id="align">
+          <option value="translate" selected>Ja &mdash; nur verschieben</option>
+          <option value="similarity">Ja &mdash; verschieben, drehen und skalieren</option>
+          <option value="none">Nein &mdash; genau so nehmen, wie sie sind</option>
+        </select>
+        <p class="field-note" id="align-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="scale">Arbeitsauflösung</label>
+        <select id="scale">
+          <option value="full" selected>Volle Größe</option>
+          <option value="half">Halb &mdash; ein Viertel des Speichers</option>
+          <option value="quarter">Viertel &mdash; ein Sechzehntel</option>
+        </select>
+        <p class="field-note" id="scale-note"></p>
+      </div>
+
+      <div class="field" id="kappa-field" hidden>
+        <label for="kappa">Verwerfen jenseits von</label>
+        <div class="inline-pair">
+          <input type="range" id="kappa" min="0.5" max="4" step="0.1" value="2">
+          <output id="kappa-value" for="kappa">2.0&sigma;</output>
+        </div>
+        <p class="field-note">
+          Niedriger verwirft mehr, und verwirft echte Details mit. Zwei
+          Standardabweichungen sind der übliche Ausgangspunkt.
+        </p>
+      </div>
+
+      <div class="field" id="radius-field" hidden>
+        <label for="radius">Schärfe wird gemessen über</label>
+        <div class="inline-pair">
+          <input type="range" id="radius" min="1" max="12" step="1" value="3">
+          <output id="radius-value" for="radius">3 px</output>
+        </div>
+        <p class="field-note">
+          Größer nimmt ganze Bereiche aus einer Aufnahme; kleiner folgt feinen
+          Details und kann einen glatten Hintergrund zwischen den Aufnahmen
+          zerwürfeln.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="gain">Belichtung</label>
+        <div class="inline-pair">
+          <input type="range" id="gain" min="0.1" max="4" step="0.05" value="1">
+          <output id="gain-value" for="gain">1.00&times;</output>
+        </div>
+        <p class="field-note" id="gain-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="format">Speichern als</label>
+        <select id="format">
+          <option value="png" selected>PNG &mdash; verlustfrei</option>
+          <option value="jpeg">JPEG &mdash; kleinere Datei</option>
+        </select>
+        <div id="quality-row" class="inline-pair" hidden>
+          <input type="range" id="quality" min="0.5" max="1" step="0.01" value="0.92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+    </div>
+
+    <!--
+      What the run will cost, worked out before it starts. Every figure here is
+      an answer from src/plan.js rather than an estimate, which is why they are
+      shown at all: a median of twenty large frames is a genuinely different
+      proposition from an average of them, and that should be visible before
+      the button is pressed rather than afterwards.
+    -->
+    <dl class="plan" id="plan" hidden>
+      <div><dt>Ergebnis</dt><dd id="plan-output">&mdash;</dd></div>
+      <div><dt>Arbeitsspeicher</dt><dd id="plan-memory">&mdash;</dd></div>
+      <div><dt>Dekodiervorgänge</dt><dd id="plan-decodes">&mdash;</dd></div>
+      <div><dt>Von der Platte gelesen</dt><dd id="plan-read">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-warning" class="path-note" hidden></p>
+  </section>
+
+  <!-- Schritt 3 &mdash; laufen lassen -->
+  <section class="card">
+    <h2><span class="step">3</span> Stacken</h2>
+
+    <div class="export-row">
+      <button type="button" id="run" class="primary" disabled>Bilder stacken</button>
+      <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame">
+        <img id="result-image" alt="Das gestackte Ergebnis">
+      </div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <p id="result-moves" class="field-note"></p>
+        <a id="download" class="primary as-button" download>Bild herunterladen</a>
+      </div>
+    </div>
+  </section>
+
+  <!--
+    Every sentence this tool's JavaScript puts on screen, kept out of the
+    JavaScript so that a translator can reach it. src/ is copied byte for byte
+    into all eleven languages, so a string written in a module is English at ten
+    of them. See shared/js/phrases.js.
+
+    A {name} is filled in by the caller. Nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="count.one">1 Aufnahme</span>
+    <span data-phrase="count.many">{count} Aufnahmen</span>
+    <span data-phrase="count.none">Noch keine Aufnahmen</span>
+
+    <span data-phrase="frame.reference">Bezug</span>
+    <span data-phrase="frame.make-reference">Als Bezug nehmen</span>
+    <span data-phrase="frame.remove">Entfernen</span>
+    <span data-phrase="frame.size">{width} &times; {height}</span>
+    <span data-phrase="frame.raw">RAW &mdash; die kamera-eigene Vorschau mit {width} &times; {height}</span>
+    <span data-phrase="frame.raw-camera">{camera} &mdash; Vorschau mit {width} &times; {height}</span>
+    <span data-phrase="frame.raw-unreadable">In dieser RAW-Datei war keine Vorschau zu finden</span>
+    <span data-phrase="frame.read">{read} von {total} gelesen</span>
+
+    <span data-phrase="mode.mean">Mittelt jede Aufnahme. Zufälliges Rauschen ist so oft zu hoch wie zu niedrig, {count} Aufnahmen zu mitteln senkt es also um rund das {factor}-fache. Die Methode für eine ruhige Serie, und die, die ein einzelner vorbeifliegender Vogel verdirbt.</span>
+    <span data-phrase="mode.median">Nimmt den mittleren Wert jedes Pixels. Alles, was nur in einem Teil der Aufnahmen da war, ein Tourist, ein Auto, ein Flugzeug, verschwindet. Es ist die einzige Methode, die jede Aufnahme gleichzeitig halten muss, und deshalb kann sie unten in Bänder geteilt werden.</span>
+    <span data-phrase="mode.sigma">Lernt, was jedes Pixel üblicherweise ist, und mittelt dann nur die Werte, die dazu passen. Das Ergebnis des Medians mit der Rauschminderung des Mittelwerts. Er liest die Aufnahmen zweimal.</span>
+    <span data-phrase="mode.max">Behält den hellsten Wert, den jedes Pixel je hatte. Das ist es, was aus einer Reihe kurzer Belichtungen Sternspuren macht und ein Feuerwerk aus seinen eigenen Aufnahmen zusammensetzt.</span>
+    <span data-phrase="mode.min">Behält den dunkelsten Wert, den jedes Pixel je hatte. Ein Pixel bleibt nur hell, wenn es in jeder Aufnahme hell war, also gehen Spiegelungen, Scheinwerfer und angeleuchtete Regentropfen.</span>
+    <span data-phrase="mode.sum">Addiert die Aufnahmen, ohne zu teilen: was eine {count}-mal so lange Belichtung gesammelt hätte. Sie läuft an, genau wie diese Belichtung es täte. Holen Sie es mit dem Belichtungsregler zurück.</span>
+    <span data-phrase="mode.focus">Nimmt jeden Teil des Bildes aus der Aufnahme, in der er scharf war. Fotografieren Sie ein kleines Motiv entlang des Fokusrings, und das hier setzt die scharfen Teile zusammen.</span>
+
+    <span data-phrase="align.translate">Findet, wie weit jede Aufnahme verschoben war, und schiebt sie zurück, auf Bruchteile eines Pixels genau. Korrigiert Wackeln aus der Hand und Stativdrift. Drehung kann es nicht korrigieren.</span>
+    <span data-phrase="align.similarity">Findet zusätzlich Drehung und Maßstab. Kostet eine Messung mehr je Aufnahme und gar nichts, wenn die Aufnahmen sich als gerade erweisen. Drehung wird immer nur innerhalb einer halben Umdrehung zurückgewonnen.</span>
+    <span data-phrase="align.none">Stackt die Aufnahmen genau so, wie sie kommen. Richtig für ein festes Stativ oder eine Intervallserie, falsch für alles aus der Hand.</span>
+
+    <span data-phrase="scale.note">Jede Aufnahme wird vom Decoder des Browsers selbst in dieser Größe dekodiert, eine kleinere Einstellung ist also weniger Arbeit und nicht nur weniger Speicher.</span>
+    <span data-phrase="gain.note">Ganz am Ende in das Ergebnis multipliziert, nach der Rechnung und vor dem Runden.</span>
+    <span data-phrase="gain.sum-note">{count} Aufnahmen zu addieren wird mit ziemlicher Sicherheit anlaufen. Nehmen Sie das auf etwa {suggested} herunter, um zu sehen, was gesammelt wurde.</span>
+
+    <span data-phrase="plan.output">{width} &times; {height}</span>
+    <span data-phrase="plan.memory">etwa {mb} MB</span>
+    <span data-phrase="plan.decodes.simple">{count}, einer je Aufnahme</span>
+    <span data-phrase="plan.decodes.passes">{count} &mdash; jede Aufnahme, {passes} mal</span>
+    <span data-phrase="plan.decodes.banded">{count} &mdash; jede Aufnahme, einmal für jedes der {bands} Bänder</span>
+    <span data-phrase="plan.read">{read} von {total} auf der Platte</span>
+    <span data-phrase="plan.banded">Das passt nicht am Stück in den Speicher, deshalb wird das Bild in {bands} Bänder geschnitten und die Aufnahmen werden für jedes erneut gelesen. {suggested} zu wählen machte daraus einen einzigen Durchlauf.</span>
+    <span data-phrase="plan.banded-anyway">Das passt nicht am Stück in den Speicher, deshalb wird das Bild in {bands} Bänder geschnitten und die Aufnahmen werden für jedes erneut gelesen. Weniger Aufnahmen oder eine kleinere Arbeitsauflösung machten daraus einen einzigen Durchlauf.</span>
+
+    <span data-phrase="progress.open">In {name} wird hineingesehen&hellip;</span>
+    <span data-phrase="progress.survey">{name} wird gelesen&hellip;</span>
+    <span data-phrase="progress.measure">Es wird gemessen, wie weit {name} sich bewegt hat&hellip;</span>
+    <span data-phrase="progress.stack">Wird gestackt &mdash; {done} von {total} Aufnahmen gelesen</span>
+    <span data-phrase="progress.stack-banded">Wird gestackt &mdash; Band {band} von {bands}, {done} von {total} Aufnahmen gelesen</span>
+    <span data-phrase="progress.encode">Das Bild wird geschrieben&hellip;</span>
+
+    <span data-phrase="result.info">{width} &times; {height}, {size} &mdash; {count} Aufnahmen in {seconds} Sekunden zusammengerechnet</span>
+    <span data-phrase="result.moves">Jede Aufnahme wurde vermessen und an ihren Platz geschoben.</span>
+    <span data-phrase="result.moves-some">{count} von {total} Aufnahmen ließen sich nicht sicher vermessen und blieben, wo sie waren.</span>
+    <span data-phrase="result.moves-none">Die Aufnahmen wurden genau so gestackt, wie sie kamen.</span>
+    <span data-phrase="result.moves-clamped">{count} Aufnahmen meldeten eine Drehung, die für eine Serie zu groß ist, und wurden allein durch Verschieben korrigiert.</span>
+    <span data-phrase="result.cropped">Sie auseinanderzuschieben ließ Ränder zurück, die nicht jede Aufnahme erreichte, und die wurden abgeschnitten.</span>
+
+    <span data-phrase="error.no.files">Fügen Sie zuerst mindestens ein Bild hinzu.</span>
+    <span data-phrase="error.no.size">Keine dieser Dateien ließ sich als Bild öffnen.</span>
+    <span data-phrase="error.one.frame">Stacken braucht mindestens zwei Aufnahmen.</span>
+    <span data-phrase="error.unknown">Beim Stacken ist etwas schiefgegangen. Wenn eine dieser Dateien ungewöhnlich ist, versuchen Sie sie einzeln.</span>
+    <span data-phrase="error.memory">Dem Browser ist der Speicher ausgegangen. Versuchen Sie eine kleinere Arbeitsauflösung oder weniger Aufnahmen.</span>
+    <span data-phrase="error.unreadable">{name} ließ sich nicht als Bild öffnen und blieb außen vor.</span>
+    <span data-phrase="error.busy">Warten Sie, bis dieser Stapel fertig ist, bevor Sie weitere Aufnahmen hinzufügen, oder brechen Sie ihn ab.</span>
+  </div>
+</main>

--- a/locales/de/tools/stack-images.toml
+++ b/locales/de/tools/stack-images.toml
@@ -1,0 +1,344 @@
+#
+# Bild-Stacker - German.
+#
+# Overrides for tools/stack-images/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Stacken" ist in der deutschen Fotografie das gängige Verb, und "Stacking"
+# das gängige Substantiv; beide stehen so in jedem Fotoforum und in jeder
+# Zeitschrift. Die RAW-Kürzel (CR2, NEF, ARW, DNG) und die Bibliotheksnamen
+# (LibRaw, dcraw) bleiben, wie sie sind - so heißen die Dateien im Ordner.
+#
+# "Worker" bleibt ebenfalls stehen: Das benennt eine bestimmte Sache im
+# Browser, und ein deutsches Wort dafür wäre eine andere Behauptung darüber,
+# was die Seite tut.
+#
+
+name = "Bild-Stacker"
+heading = "Bild-Stacker <span class=\"h1-kw\">&mdash; eine Serie zusammenrechnen, RAW eingeschlossen</span>"
+tagline = "Zwanzig Aufnahmen werden eine, ohne zwanzig Uploads und ohne RAW-Konverter."
+
+title = "Bild-Stacker &mdash; Mittelwert, Median und Focus Stacking im Browser"
+description = "Eine Serie von Fotos zu einem Bild zusammenrechnen: mitteln gegen das Rauschen, den Median nehmen, um Passanten aus einer Szene zu entfernen, aufhellen für Sternspuren oder eine Makroaufnahme fokusstacken. Liest CR2, NEF, ARW, DNG, RAF und CR3, indem es die Vorschau der Kamera selbst herausholt. Läuft komplett im Browser."
+og_title = "Eine Fotoserie stacken, RAW-Dateien eingeschlossen"
+og_description = "Mittelwert, Median, Sigma-Clipping, Aufhellen, Abdunkeln, Addieren oder Focus Stacking, mit vorher ausgerichteten Aufnahmen. RAW-Dateien werden geöffnet, indem die Vorschau gelesen wird, die die Kamera bereits geschrieben hat, sodass eine 60-MB-Aufnahme so schnell öffnet wie ein JPEG. Nichts wird hochgeladen."
+og_image_alt = "Bild-Stacker - mehrere Aufnahmen zu einer zusammengerechnet, im Browser"
+
+pledge = """
+    Jede Aufnahme wird von Ihrem eigenen Browser auf Ihrem eigenen Gerät
+    geöffnet, dekodiert, ausgerichtet, zusammengerechnet und geschrieben. Ein
+    Stapel aus zwanzig 60&nbsp;MB großen RAW-Dateien ist rund ein Gigabyte
+    Fotos, und kein einziges Byte davon bewegt sich: Netzfunktionen hat dieses
+    Werkzeug keine, und die Dateien werden direkt von Ihrer Festplatte gelesen,
+    von einem Worker, der nirgendwohin etwas senden könnte."""
+
+live_hint = """
+      Sie müssen uns nicht glauben. Öffnen Sie die DevTools, sehen Sie im Tab
+      &bdquo;Netzwerk&ldquo; zu und stacken Sie einen Ordner voller RAW-Dateien.
+      Keine einzige Anfrage trägt ein Foto, ein Vorschaubild, einen Dateinamen
+      oder ein Kameramodell. Oder trennen Sie die Internetverbindung und stacken
+      Sie sie trotzdem, am Werkzeug ändert sich dadurch nichts."""
+
+read_first = """
+, <code>src/raw.js</code> dafür, wie eine
+      RAW-Datei geöffnet wird, indem Kilobyte statt Megabyte gelesen werden,
+      <code>src/stack.js</code> für die Rechnung hinter jeder Methode und
+      <code>src/plan.js</code> dafür, woher die Speicher- und Dekodierzahlen auf
+      der Seite kommen: Sie sind die Antworten dieser Datei und keine
+      Schätzungen."""
+
+howto_heading = "So stacken Sie eine Reihe von Fotos im Browser"
+
+card = """
+            Eine Serie zu einem Bild zusammenrechnen: das Rauschen wegmitteln,
+            den Median nehmen, um die Passanten loszuwerden, oder aufhellen für
+            Sternspuren. Liest RAW-Dateien ohne Konverter."""
+
+[words]
+plural = "Fotos"
+choose = "ein paar Fotos"
+
+[[facts]]
+text = "Kein Upload"
+
+[[facts]]
+text = "Kein Konto"
+
+[[facts]]
+text = "Kein Wasserzeichen"
+
+[[facts]]
+text = "Liest RAW"
+
+[[facts]]
+text = "Läuft offline"
+
+[[facts]]
+text = "Quelloffen"
+
+[[privacy]]
+title = "Ihre Fotos haben keinen Ort, an den sie gehen könnten."
+body = """
+ In der
+      Content-Security-Policy steht jede Adresse, die diese Seite kontaktieren
+      darf, und keine davon gehört uns. Es gibt hier keinen Endpunkt, an dem Ihre
+      Dateien gesammelt werden könnten, und keinen Code, der sie senden würde,
+      wenn es ihn gäbe: kein <code>fetch</code>, kein
+      <code>XMLHttpRequest</code>, kein <code>sendBeacon</code>, weder in
+      <code>src/</code> noch im Worker."""
+
+[[privacy]]
+title = "Die RAW-Dateien werden gelesen, nicht hochgeladen, und kaum gelesen."
+body = """
+ Eine RAW-Datei aus einer
+      Kamera enthält bereits ein JPEG in voller Größe, das die Kamera beim
+      Auslösen gerendert hat. Dieses Werkzeug findet es, indem es ein paar
+      Verzeichniseinträge abläuft und dann um genau einen Ausschnitt bittet, was
+      bei einer 60&nbsp;MB großen Datei meist unter hundert Kilobyte sind. Die
+      Seite zeigt Ihnen diese Zahl neben der Größe Ihrer Dateien, während Sie
+      arbeiten. Die Sensordaten werden überhaupt nicht gelesen."""
+
+[[privacy]]
+title = "Die Arbeit passiert in einem Worker auf diesem Gerät, nicht auf einem Server."
+body = """
+ Das ist das einzige
+      Werkzeug hier, das einen verwendet, weil Stacken Minuten an Rechnerei ist
+      statt Sekunden und eine eingefrorene Seite weder Fortschritt zeigen noch
+      abgebrochen werden kann. Ein Worker ist ein zweiter Strang in genau diesem
+      Browser, siehe <code>src/worker.js</code>. Ihm werden die Dateien selbst
+      übergeben, was nichts kostet, weil ein Dateihandle nicht die Bytes ist, und
+      er hat genau dieselbe Content-Security-Policy wie die Seite, also ebenso
+      wenig einen Ort, an den er sie senden könnte."""
+
+[[privacy]]
+title = "Über die Serie wird nirgendwohin etwas gemeldet."
+body = """
+ Wie viele Aufnahmen Sie
+      gestackt haben, welche Kamera sie geschrieben hat, wie weit jede sich bewegt
+      hatte, welche Methode Sie gewählt haben und wie lange es gedauert hat,
+      liegen im Speicher dieser Seite, bis Sie sie schließen. In diesem Repository
+      gibt es kein Analytics-Ereignis, das irgendetwas davon trüge, und die eine
+      Frage, die diese Seite nach einem Download stellt, sendet einen Daumen hoch
+      oder runter und den Namen des Werkzeugs, sonst nichts."""
+
+[[privacy]]
+title = "Läuft offline."
+body = """
+ Trennen Sie die Netzverbindung, und das Werkzeug
+      bleibt, wie es ist, weil nie ein Netzschritt darin war. Der Worker und jedes
+      Modul, das er lädt, werden vom Service Worker dieser Seite
+      zwischengespeichert, eine installierte Kopie stackt RAW-Dateien also mit
+      gezogenem Stecker."""
+
+[[howto]]
+title = "Wählen Sie die Aufnahmen."
+body = """
+ Eine Serie, eine Belichtungsreihe,
+      eine Intervallaufnahme oder ein Ordner voller RAW-Dateien. Jede wird beim
+      Ankommen geöffnet, und die Zeile sagt Ihnen, was herauskam: bei einer
+      RAW-Datei die Kamera, die Größe der darin gefundenen Vorschau und wie wenig
+      von der Datei gelesen werden musste, um sie zu finden."""
+
+[[howto]]
+title = "Nehmen Sie die Methode, die zu dem passt, was weg soll."
+body = """
+ Rauschen: Mittelwert,
+      oder Sigma-Clipping, wenn sich etwas bewegt hat. Leute, Autos oder ein
+      vorbeifliegendes Flugzeug: Median. Ein dunkler Himmel, der zu Sternspuren
+      werden soll: Aufhellen. Eine Makroaufnahme entlang des Fokusrings: Focus
+      Stacking. Der Hinweis unter dem Menü sagt, was jede Methode mit genau Ihrer
+      Anzahl Aufnahmen macht."""
+
+[[howto]]
+title = "Entscheiden Sie, ob die Aufnahmen ausgerichtet werden müssen."
+body = """
+ Aus der Hand: ja, nur
+      verschieben. Aus der Hand und dabei gedreht: verschieben, drehen und
+      skalieren. Festes Stativ oder Intervallauslöser: nein, und es geht
+      schneller. Jede Aufnahme wird gegen die erste in der Liste vermessen, und
+      deshalb lässt sich jede Aufnahme zu dieser ersten machen."""
+
+[[howto]]
+title = "Lesen Sie die vier Zahlen und drücken Sie dann den Knopf."
+body = """
+ Bevor irgendetwas läuft,
+      sagt die Seite, wie groß das Ergebnis wird, wie viel Speicher es ungefähr
+      braucht, wie oft die Aufnahmen dekodiert werden und wie viel von Ihren
+      Dateien gelesen wurde. Passt die Serie nicht am Stück in den Speicher, sagt
+      sie das und nennt die Arbeitsauflösung, die es beheben würde."""
+
+[[faq]]
+q = "Werden meine Fotos irgendwohin hochgeladen?"
+a = """
+        Nein. Jede Aufnahme wird von Ihrem eigenen Browser auf Ihrer eigenen
+        Hardware geöffnet, dekodiert, ausgerichtet, gestackt und geschrieben.
+        Netzfunktionen hat dieses Werkzeug keine, es ruft nie etwas ab und sendet
+        nie etwas, und in der <code>Content-Security-Policy</code> der Seite steht
+        jede Adresse, die sie kontaktieren darf. Keine davon gehört uns. Laden Sie
+        die Seite einmal, trennen Sie die Internetverbindung, und sie arbeitet
+        weiter. Das zählt hier schwerer als bei den meisten Werkzeugen, schlicht
+        wegen der Menge: Ein Stapel aus zwanzig RAW-Aufnahmen ist rund ein
+        Gigabyte, und ein Gigabyte Fotos hochzuladen, damit jemand den Mittelwert
+        daraus bildet, ist genau das, wozu es dieses Werkzeug gibt."""
+
+[[faq]]
+q = "Welche RAW-Formate kann er lesen, und wie?"
+a = """
+        <span id="faq-raw"></span>CR2, CR3, NEF, NRW, ARW, SR2, SRF, DNG, ORF,
+        RAF, RW2, PEF, SRW, 3FR, IIQ, DCR, KDC, MRW, MEF, RWL und ein paar mehr,
+        also das meiste, was Kameras schreiben. Gelesen wird daraus das JPEG in
+        voller Größe, das die Kamera beim Auslösen selbst gerendert hat: das Bild
+        auf dem Kameradisplay und das, was Ihr Betriebssystem als Vorschaubild
+        zeichnet. Gefunden wird es, indem die Verzeichnisstruktur der Datei
+        abgelaufen wird, was ein paar Lesevorgänge von je ein paar Kilobyte
+        kostet, und dann ein Ausschnitt genommen wird.
+        <strong>Es ist kein Demosaicing der Sensordaten.</strong> Das Ergebnis
+        trägt den Weißabgleich und den Bildstil der Kamera mit acht Bit pro Kanal
+        und nicht die zwölf oder vierzehn Bit linearer Sensordaten, die ein
+        RAW-Konverter Ihnen gäbe."""
+
+[[faq]]
+q = "Warum dann nicht die Sensordaten richtig dekodieren?"
+a = """
+        Weil das hieße, LibRaw oder dcraw mitzuliefern, also eine zweite Engine
+        von zig Megabyte für eine einzige Formatfamilie, und der größte Teil davon
+        sind herstellereigene Kompressionsverfahren. Diese Abwägung wird in
+        <code>docs/what-can-be-built-here.md</code> im Quelltext dieser Seite
+        ausgetragen, wo Kamera-RAW schon auf der Ausschlussliste stand, bevor es
+        dieses Werkzeug gab. Geändert hat sich nicht die Antwort auf diese Frage,
+        sondern die Erkenntnis, dass Stacken sie nicht braucht: Die Vorschauen
+        haben volle Auflösung, sie sind das, was die Kamera Ihnen ohnehin als JPEG
+        gegeben hätte, und sie zu lesen ist rund hundertmal schneller als
+        Demosaicing. Wenn Sie die Sensordaten wollen, entwickeln Sie die Aufnahmen
+        zuerst in einem RAW-Konverter und stacken Sie die TIFFs oder JPEGs, die er
+        ausgibt. Die nimmt dieses Werkzeug auch."""
+
+[[faq]]
+q = "Wie viele Aufnahmen schafft er, und wie groß?"
+a = """
+        Sechs der sieben Methoden strömen: Sie halten einen Akkumulator und lesen
+        jede Aufnahme genau einmal, hundert Aufnahmen kosten also so viel Speicher
+        wie zwei, und größer wird allein die Zeit. Der Median ist die Ausnahme,
+        weil sich der mittlere Wert einer Menge nicht kennen lässt, bevor man sie
+        ganz hat, und er deshalb jede Aufnahme gleichzeitig hält. Zwanzig Aufnahmen
+        mit 24 Megapixeln sind rund 1,4&nbsp;GB, und so viel gibt kein Browser
+        heraus. Dann wird das Bild in waagerechte Bänder geschnitten und Band für
+        Band gestackt, was das erneute Lesen der Aufnahmen für jedes Band kostet.
+        Die Seite rechnet das alles aus, bevor Sie den Knopf drücken, und zeigt
+        Ihnen die Zahl, ein langsamer Durchlauf ist also nie eine Überraschung."""
+
+[[faq]]
+q = "Was macht das Ausrichten der Aufnahmen eigentlich?"
+a = """
+        Es findet heraus, wie weit jede Aufnahme sich gegenüber der ersten bewegt
+        hat, und schiebt sie zurück, auf Bruchteile eines Pixels genau. Die
+        Methode ist Phasenkorrelation: Die Verschiebung zwischen zwei Bildern
+        zeigt sich als Phasenunterschied zwischen ihren Spektren, eine
+        Fouriertransformation je Bild findet einen Versatz von zweihundert Pixeln
+        also so billig wie einen von zwei. Die zweite Einstellung holt zusätzlich
+        Drehung und Maßstab zurück, mit demselben Kniff, angewandt auf das
+        Spektrum in logarithmisch-polaren Koordinaten. Das alles ist global, eine
+        Verschiebung, ein Winkel, ein Maßstab für das ganze Bild, und es
+        korrigiert deshalb eine Kamera, die sich bewegt hat, und kein Motiv, das
+        sich bewegt hat, und kein Foto, das einen Schritt weiter links aufgenommen
+        wurde. Eine sichtbare Folge: Eine um zwanzig Pixel nach links geschobene
+        Aufnahme reicht nicht mehr bis an den rechten Rand, deshalb wird das
+        Ergebnis auf den Teil beschnitten, den jede Aufnahme abdeckt. Darum kommt
+        ein ausgerichteter Stapel ein wenig kleiner heraus als die Aufnahmen, die
+        hineingingen, und das ist die einzige Alternative zu einem dunklen Rand
+        aus den Aufnahmen, die dort nicht waren."""
+
+[[faq]]
+q = "Welche Methode soll ich nehmen?"
+a = """
+        <strong>Mittelwert</strong> gegen Rauschen, auf einer Serie, in der sich
+        nichts bewegt hat: Er senkt zufälliges Rauschen um rund die Wurzel aus der
+        Anzahl der Aufnahmen. <strong>Median</strong>, um Dinge zu entfernen, die
+        nur zeitweise da waren; der klassische Fall ist, einen belebten Platz ein
+        Dutzend Mal zu fotografieren und ihn leer zu bekommen.
+        <strong>Sigma-Clipping</strong>, wenn Sie beides wollen: Es lernt, was
+        jedes Pixel üblicherweise ist, und mittelt nur die Werte, die dazu passen,
+        hat also die Unempfindlichkeit des Medians gegen ein vorbeifahrendes Auto
+        und die Rauschminderung des Mittelwerts. <strong>Aufhellen</strong> für
+        Sternspuren, Feuerwerk und Lichtmalerei. <strong>Abdunkeln</strong>, um
+        alles Helle zu entfernen, das sich bewegt hat. <strong>Addieren</strong>,
+        um eine einzelne lange Belichtung nachzubilden. <strong>Focus
+        Stacking</strong> für eine Makroaufnahme entlang des Fokusrings."""
+
+[[faq]]
+q = "Warum hat mein Ergebnis acht Bit, wenn meine RAW-Dateien vierzehn haben?"
+a = """
+        Weil gestackt wird, was die Kamera selbst als Vorschau abgelegt hat, und
+        das ist ein JPEG. Dazu gehört gesagt, dass Stacken einen Teil davon
+        zurückholt: Sechzehn Acht-Bit-Aufnahmen zu mitteln ergibt ein Bild mit
+        tatsächlich feineren Abstufungen, als eine einzelne von ihnen hatte, weil
+        genau das Rauschen, das jede Aufnahme anders runden ließ, den Mittelwert
+        zwischen den Stufen landen lässt. Gerechnet wird hier in Fließkomma und
+        erst ganz am Ende einmal gerundet, dazwischen geht davon also nichts
+        verloren. Dasselbe wie lineare Sensordaten zu stacken ist es trotzdem
+        nicht, und dieses Werkzeug tut nicht so."""
+
+[[faq]]
+q = "Kann ich Aufnahmen unterschiedlicher Größe oder aus verschiedenen Kameras stacken?"
+a = """
+        Ja, auch wenn es meist ein Versehen ist und einen prüfenden Blick lohnt.
+        Das Ergebnis hat die Größe der größten Aufnahme, und jede andere wird
+        eingepasst und mittig gesetzt. Kameras zu mischen mischt auch die
+        Farbwiedergabe, ein Mittelwert aus beiden ist also ein Mittelwert aus zwei
+        verschiedenen Deutungen desselben Lichts. Wirklich hilfreich ist es bei
+        einer Serie, die in zwei Auflösungen aufgenommen wurde, oder bei einer
+        RAW-Datei und einem JPEG derselben Aufnahme."""
+
+[[faq]]
+q = "Er sagt, der Durchlauf werde in Bänder geteilt. Was heißt das?"
+a = """
+        Dass der Arbeitsspeicher, den die Methode braucht, mehr ist, als das
+        Werkzeug am Stück belegen will, und das Bild deshalb in waagerechte
+        Streifen geschnitten und Streifen für Streifen gestackt wird. Das Ergebnis
+        ist genau dasselbe; es liest die Aufnahmen nur für jeden Streifen erneut,
+        dauert also länger, und die Seite sagt Ihnen, wie viele Dekodiervorgänge
+        das werden. Die Arbeitsauflösung eine Stufe zu senken viertelt den
+        Speicher und macht aus einem gebänderten Durchlauf fast immer einen
+        einzigen; der Hinweis nennt die Einstellung, die das täte."""
+
+[[faq]]
+q = "Warum verwendet dieses Werkzeug einen Worker und keines der anderen?"
+a = """
+        Weil es das einzige ist, dessen Arbeit in Minuten gemessen wird. Jedes
+        andere Werkzeug hier tut etwas, das ein bis zwei Sekunden dauert, und
+        dabei wäre es Zeremonie, die Arbeit vom Hauptstrang zu holen. Zwanzig
+        große Aufnahmen zu stacken ist solide Rechnerei über hunderte Megabyte,
+        und auf dem Hauptstrang heißt das eine eingefrorene Seite: ein
+        Fortschrittsbalken, der sich nicht bewegt, ein Abbrechen-Knopf, der nicht
+        antwortet, und irgendwann ein Browser, der anbietet, den Tab zu beenden.
+        Der Worker ist ein zweiter Strang in genau diesem Browser, der eine Datei
+        aus genau diesem Ordner unter genau dieser Policy ausführt. Er ist kein
+        Server und keine Netzfunktion."""
+
+[[faq]]
+q = "Ist das kostenlos, und brauche ich ein Konto?"
+a = """
+        Es ist kostenlos, und es gibt kein Konto, keine Anmeldung, keine Testphase
+        und kein Wasserzeichen. Es gibt auch keine Grenze dafür, wie viele
+        Aufnahmen Sie stacken oder wie groß sie sind, weil kein Server dafür
+        bezahlt: Die Arbeit passiert auf Ihrem eigenen Gerät, und die einzige
+        Decke ist Ihr eigener Speicher. Die Seite trägt Werbung, und die bezahlt
+        sie; die Werbung bekommt nichts über Ihre Fotos."""
+
+[schema]
+description = "Eine Fotoserie im Browser stacken: Mittelwert, Median, sigma-geclippter Mittelwert, Aufhellen, Abdunkeln, Addieren oder Focus Stacking, mit vorher per Phasenkorrelation ausgerichteten Aufnahmen. Liest Kamera-RAW-Dateien, indem die eingebettete Vorschau in voller Größe herausgeholt wird, ein RAW-Konverter ist also nicht nötig. Nichts wird hochgeladen."
+features = [
+  "Sieben Methoden: Mittelwert, Median, sigma-geclippter Mittelwert, Aufhellen, Abdunkeln, Addieren und Focus Stacking",
+  "Liest CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2 und mehr, indem die Vorschau der Kamera in voller Größe herausgeholt wird",
+  "Öffnet eine 60-MB-RAW-Datei, indem rund hundert Kilobyte davon gelesen werden",
+  "Automatisches Ausrichten: nur verschieben, verschieben mit Drehung und Maßstab, oder gar nicht",
+  "Ausrichtung auf Subpixel genau per Phasenkorrelation statt durch Absuchen von Versätzen",
+  "Sechs der sieben Methoden halten einen Akkumulator, hundert Aufnahmen kosten also den Speicher von zweien",
+  "Speicher- und Dekodierkosten werden vor dem Start ausgerechnet und angezeigt",
+  "Die Arbeit läuft in einem Worker, der Fortschritt bewegt sich und Abbrechen antwortet",
+  "PNG oder JPEG heraus; läuft offline; kein Upload, kein Konto",
+]
+
+[picker]
+title = "Aufnahmen hier ablegen"
+hint = "oder klicken zum Auswählen &mdash; JPEG, PNG, WebP, TIFF und Kamera-RAW"


### PR DESCRIPTION
German was at 57 of 65. The eight pages missing were the four tools and four
guides that shipped after this locale was last worked on: `dicom-viewer`,
`document-scanner`, `redact-pdf`, `stack-images`, and a guide for each.

All eight are here, so the build no longer prints a `de:` line at all — a
locale the debt report has nothing to say about is the only signal that it is
finished. Nothing outside `locales/de/` is touched.

## The four new addresses

```
"dicom-viewer"      = "dicom-viewer"
"document-scanner"  = "dokumente-scannen"
"redact-pdf"        = "pdf-schwaerzen"
"stack-images"      = "bilder-stacken"
```

Two of those are worth a sentence. **`dicom-viewer` stays as it is** — that is
what a German speaker types, and an invented German compound would be a word
nobody searches for; the list already has `roadmap` on the same reasoning.
**`bilder-stacken`** uses the verb German photographers actually use. "Stacking"
and "stacken" are what appear in every photography magazine and forum, and
"stapeln" would read as a translation of the English rather than as the German
term.

`pdf-schwaerzen` matches `bild-schwaerzen`, which the image redactor already
used, and for the same reason its own header gives: *schwärzen* is what German
courts and authorities call this, and it carries the meaning that matters —
removed, not covered.

## What stays in English

Anything the reader types, looks up, or matches against something on their own
screen:

- DICOM field names with their numbers — Pixel Spacing (0028,0030), Series
  Instance UID (0020,000E) — and `VR` as the tag table heading
- the transfer syntaxes, and PS3.15
- the RAW extensions, and LibRaw/dcraw
- `Worker`, which names a specific thing in a browser
- Zhang, He and Sauvola, where the scanner cites the work it is built on

The Hounsfield presets keep their figures unchanged: water is 0 and air is
&minus;1000 on every CT scanner in the world, which is the whole reason the
named windows mean the same thing here as at a workstation.

## One structural note

`csp_note` and `og_card` are omitted from all four tool files. They read like
prose, but `buildlib/i18n.py` lists them as structural and the build rejects a
locale file that carries them.

## Checked

- `python build.py --out … --clean --no-minify` — clean, and no `de:` line
- every `id`, `class`, `name`, `value`, `data-phrase` key, `data-fact` name and
  `{placeholder}` compared against the English `body.html`, page by page
- no CRLF anywhere under `locales/de/`
- every cross-link resolves — `check_links` refuses to publish a locale whose
  page points at a page that was not built, so `../bild-schwaerzen/` and
  `../ist-das-hochladen-von-dateien-sicher/` are enforced rather than asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
