### PR TITLE
Español: las últimas ocho páginas, 65 de 65

### DIFF
--- a/locales/es/locale.toml
+++ b/locales/es/locale.toml
@@ -115,6 +115,18 @@ complete = true
 "guides/whats-inside-a-gif" = "guias/que-hay-dentro-de-un-gif"
 "guides/verify-a-file-checksum" = "guias/verificar-el-checksum-de-una-descarga"
 
+# Las cuatro paginas que llegaron despues de esta lista. "telefono" en lugar de
+# "movil" o "celular", por lo mismo que "dispositivo" en lugar de "ordenador" o
+# "computadora": ninguna de las dos suena ajena a ningun lado del Atlantico.
+"dicom-viewer" = "visor-dicom"
+"document-scanner" = "escanear-documentos"
+"redact-pdf" = "censurar-pdf"
+"stack-images" = "apilar-imagenes"
+"guides/open-a-dicom-file" = "guias/abrir-un-archivo-dicom"
+"guides/redact-a-pdf" = "guias/censurar-un-pdf"
+"guides/scan-a-document-with-your-phone" = "guias/escanear-un-documento-con-el-telefono"
+"guides/stack-photos-to-reduce-noise" = "guias/apilar-fotos-para-reducir-el-ruido"
+
 #
 # ---------------------------------------------------------------------------
 # The hub.

--- a/locales/es/pages/guides/open-a-dicom-file.html
+++ b/locales/es/pages/guides/open-a-dicom-file.html
@@ -1,0 +1,254 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../visor-dicom/">Visor DICOM</a> y arrastra encima la
+      carpeta entera de archivos. Se leen en tu propio equipo, se reagrupan en
+      las series de las que salieron y se apilan en el orden en que las tomó el
+      equipo. No se sube nada, y no se escribe nada de vuelta en tus archivos.
+    </p>
+    <p>
+      Si te han dado un disco y te preguntas cuál de los archivos abrir: todos, a
+      la vez. Una TC o una resonancia no son un archivo. Son un archivo por
+      corte, y un estudio de tórax son trescientos.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué hay en un disco hospitalario</h2>
+    <p>
+      Normalmente cuatro cosas, y solo una importa.
+    </p>
+    <ul>
+      <li>
+        <strong>Una carpeta de estudios</strong>, a menudo llamada
+        <code>DICOM</code>, <code>IMAGES</code> o <code>ST0001</code>, con
+        archivos llamados <code>IM000001</code>, <code>I0000001</code> o un
+        número largo con puntos. Con frecuencia sin extensión ninguna. Eso es el
+        estudio.
+      </li>
+      <li>
+        <strong>Un archivo llamado <code>DICOMDIR</code></strong>. Un índice del
+        resto, escrito para que un visor pueda listar los estudios del disco sin
+        abrir cada archivo. No lo necesitas.
+      </li>
+      <li>
+        <strong>Un visor</strong>, como ejecutable de Windows, como entrada de
+        autoarranque o de vez en cuando como applet de Java. Se compiló para lo
+        que fuera actual cuando se grabó el disco, y por eso tantos ya no
+        arrancan.
+      </li>
+      <li>
+        <strong>Una página HTML o un PDF</strong> con el logo del hospital,
+        explicando cómo arrancar el visor.
+      </li>
+    </ul>
+    <p>
+      Los estudios no necesitan el visor. El formato es una norma publicada y los
+      archivos se leen por su cuenta; el ejecutable del disco es un programa que
+      podría leerlos, no el único.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué los archivos no tienen extensión</h2>
+    <p>
+      Porque DICOM no la necesita. Cada archivo lleva su propia marca: 128 bytes
+      de nada, después las cuatro letras <code>DICM</code>, y después un pequeño
+      bloque de campos que describe cómo está escrito el resto del archivo. Un
+      lector comprueba esas cuatro letras y no un nombre que acabe en
+      <code>.dcm</code>.
+    </p>
+    <p>
+      Por eso renombrar un archivo a <code>.dcm</code> no cambia nada, y por eso
+      un visor que exige la extensión está siendo estricto sin necesidad. Los
+      archivos escritos directamente desde una red hospitalaria ni siquiera
+      tienen los 128 bytes y la marca: son los datos desnudos sin nada delante, y
+      un lector tiene que deducir de su primer campo cómo están codificados. Eso
+      es un archivo normal, no uno roto.
+    </p>
+  </section>
+
+  <section>
+    <h2>La ventana y el centro, que es el control que importa</h2>
+    <p>
+      Es lo único que diferencia una imagen médica de una fotografía, y la razón
+      por la que un editor de imágenes no sirve para mirar una.
+    </p>
+    <p>
+      Un corte de TC contiene unos cuatro mil valores distintos. Tu pantalla
+      muestra doscientos cincuenta y seis grises. Algo tiene que decidir qué
+      cuatro mil se llevan qué doscientos cincuenta y seis, y esa decisión es la
+      <strong>ventana</strong>: por debajo todo es negro, por encima todo es
+      blanco, y el rango que queda en medio se reparte entre los grises.
+    </p>
+    <p>
+      Mueve la ventana y el mismo archivo parece un estudio distinto. Eso no es un
+      artefacto de representación, es el sentido de la cosa. El pulmón y el hueso
+      están los dos en el corte y no se pueden ver a la vez: una ventana que
+      enseña la textura del pulmón insuflado deja cualquier hueso en blanco puro,
+      y una que enseña el detalle trabecular de una costilla deja el pulmón
+      entero en negro puro.
+    </p>
+    <p>
+      En una TC los números son <strong>unidades Hounsfield</strong>, y están
+      definidos en términos absolutos y no por equipo: el agua es 0 y el aire es
+      &minus;1000, por definición, en cualquier TC del mundo. Por eso un visor
+      puede ofrecer ventanas con nombre &mdash; pulmón, hueso, cerebro, partes
+      blandas &mdash; y que signifiquen lo mismo en tu archivo que en la estación
+      donde se informó el estudio. Las habituales:
+    </p>
+    <ul>
+      <li><strong>Partes blandas</strong> &mdash; centro 40, anchura 400.</li>
+      <li><strong>Pulmón</strong> &mdash; centro &minus;600, anchura 1500.</li>
+      <li><strong>Hueso</strong> &mdash; centro 300, anchura 1500.</li>
+      <li><strong>Cerebro</strong> &mdash; centro 40, anchura 80. Una estrecha,
+        porque la sustancia gris y la blanca se diferencian en unas pocas
+        unidades.</li>
+    </ul>
+    <p>
+      En una resonancia no existe esa escala. Los valores dependen de la
+      secuencia, la antena y el equipo, así que no hay nada por lo que nombrar un
+      preajuste y la ventana con la que empezar es la que pide el propio archivo.
+      Todos los estudios llevan una sugerencia.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué a veces los cortes van al revés</h2>
+    <p>
+      Un visor tiene que decidir en qué orden pone los archivos, y hay dos cosas
+      en el archivo que podría usar.
+    </p>
+    <p>
+      <strong>Instance Number</strong> es un contador. Es la opción evidente, y la
+      asigna lo que haya escrito los archivos, que no tiene por qué numerarlos en
+      el sentido en que va el paciente. Un estudio reconstruido de los pies hacia
+      arriba y numerado de la cabeza hacia abajo se recorre al revés, y una serie
+      montada a partir de dos reconstrucciones puede repetir los números
+      directamente.
+    </p>
+    <p>
+      <strong>Image Position (Patient)</strong> es dónde está físicamente el
+      corte, en milímetros, en un sistema de coordenadas fijado al paciente y no
+      al equipo. Ordenar por eso es correcto haga lo que haga la numeración, y
+      tiene un efecto secundario útil: una vez que los cortes están en orden
+      físico, la separación entre ellos se puede medir, así que un visor puede
+      decirte que los cortes están a 5&nbsp;mm y darse cuenta de que falta uno,
+      cosa que el archivo no dice nunca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Medir algo</h2>
+    <p>
+      Un estudio son datos medidos, así que una longitud sobre él es una longitud
+      real, si el archivo dice a qué distancia están sus píxeles. Eso es un campo,
+      Pixel Spacing, en milímetros, y está presente en prácticamente todas las TC
+      y resonancias.
+    </p>
+    <p>
+      Falta a menudo en imágenes de ecografía, en documentos escaneados y en
+      capturas de pantalla guardadas como DICOM. Donde falta no hay respuesta
+      honesta en milímetros, y un visor que dé una de todas formas se ha
+      inventado una escala. Un recuento de píxeles es la respuesta correcta a una
+      pregunta que el archivo no puede responder.
+    </p>
+    <p>
+      Ojo también con los píxeles que no son cuadrados, que es lo normal fuera de
+      la TC. Medir en píxeles y multiplicar por una única cifra de espaciado solo
+      es correcto donde las dos coinciden; cada eje hay que medirlo con la suya.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué lleva un estudio además de la imagen</h2>
+    <p>
+      Esta es la parte en la que la gente se equivoca, y el motivo para tener
+      cuidado con estos archivos.
+    </p>
+    <p>
+      Un archivo DICOM no es una imagen con algunos metadatos pegados. Es un
+      historial médico con una imagen dentro. La cabecera es una lista de campos,
+      y en un estudio clínico normal contiene:
+    </p>
+    <ul>
+      <li>el nombre del paciente, su número de historia, su fecha de nacimiento y
+        su sexo;</li>
+      <li>el número de petición, que es la clave de la solicitud en el sistema del
+        hospital;</li>
+      <li>el médico que la solicitó, el técnico que la hizo, el radiólogo que la
+        informó;</li>
+      <li>el centro, su dirección y el servicio;</li>
+      <li>el fabricante, el modelo y el número de serie del equipo;</li>
+      <li>la fecha y la hora del estudio al segundo;</li>
+      <li>y un conjunto de identificadores únicos &mdash; estudio, serie,
+        instancia &mdash; que son claves perfectas de vuelta al archivo del que
+        salió.</li>
+    </ul>
+    <p>
+      Cualquier archivo que te hayan dado lleva todo eso, y viaja con el archivo
+      adonde vaya. Borrar el nombre no basta: una fecha de nacimiento, un centro
+      del tamaño de un código postal y una hora de estudio identifican a una
+      persona más o menos igual de bien que un nombre, y el UID del estudio la
+      identifica exactamente para cualquiera con acceso al archivo.
+    </p>
+    <p>
+      Algunos equipos guardan además una segunda copia del nombre del paciente en
+      un campo privado, es decir, un campo cuyo significado no está publicado en
+      ninguna parte y que la mayoría de los anonimizadores dejan en paz porque no
+      pueden saber qué hay dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>No subas el estudio para mirarlo</h2>
+    <p>
+      La forma habitual de resolver esto es una búsqueda de &laquo;dicom viewer
+      online&raquo; y un cuadro de subida. Lo que acaba de pasar es que un
+      desconocido tiene una copia de un historial médico: los píxeles, el nombre,
+      la fecha de nacimiento, el número de historia y la clave de vuelta al
+      archivo.
+    </p>
+    <p>
+      No hay ningún motivo para eso. Leer un archivo DICOM es analizar una
+      cabecera y desempaquetar unos cuantos enteros, y un navegador lo hace
+      perfectamente. Por eso el <a href="../../visor-dicom/">visor de aquí</a> no
+      tiene ninguna función de red: ni <code>fetch</code>, ni
+      <code>XMLHttpRequest</code>, ni nada que pudiera enviar un archivo aunque
+      algo lo intentara. Carga la página una vez, desconéctate de internet y
+      sigue abriendo estudios.
+    </p>
+    <p>
+      <a href="../es-seguro-subir-archivos/">¿Es seguro subir archivos a los
+      conversores online?</a> explica cómo comprobar esa afirmación en este sitio
+      o en cualquier otro. Este es el tipo de archivo en el que más merece la pena
+      comprobarlo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Lo que un navegador no puede hacer</h2>
+    <p>
+      Dos cosas, y las dos conviene decirlas claras.
+    </p>
+    <p>
+      <strong>No es un visor diagnóstico.</strong> Tu pantalla no está calibrada,
+      el navegador no es una cadena de representación validada, y ninguna página
+      web ha pasado una evaluación reglamentaria. Leer un estudio para tomar una
+      decisión clínica es cosa de la estación en la que se informó. Ver qué hay en
+      un disco, sacar un corte para una clase, leer una cabecera o averiguar por
+      qué otro programa rechaza el archivo son todos motivos perfectamente buenos
+      para abrir uno en el navegador.
+    </p>
+    <p>
+      <strong>Algunos estudios comprimidos no se podrán decodificar.</strong>
+      DICOM permite varios esquemas de compresión y los navegadores traen uno.
+      Los archivos simples, los codificados por longitud de racha, el JPEG
+      baseline y el JPEG Lossless &mdash; que es lo que usan la mayoría de las
+      exportaciones hospitalarias &mdash; se abren todos. JPEG 2000, JPEG-LS y los
+      formatos de vídeo necesitan códecs que son megabytes de biblioteca
+      compilada. Donde la imagen no se pueda decodificar, la cabecera sigue
+      siendo legible entera, que suele ser la mitad por la que venías de todas
+      formas.
+    </p>
+  </section>

--- a/locales/es/pages/guides/open-a-dicom-file.toml
+++ b/locales/es/pages/guides/open-a-dicom-file.toml
@@ -1,0 +1,25 @@
+#
+# Guía: abrir un archivo DICOM - Spanish.
+#
+# Los nombres de campo DICOM y los nombres de archivo de un disco hospitalario
+# se quedan en ingles con su numero - DICOMDIR, IM000001, Instance Number,
+# Image Position (Patient). Asi estan en el disco y asi estan en la norma.
+#
+
+nav = "Abrir un archivo DICOM"
+title = "Cómo abrir un archivo DICOM (.dcm) sin instalar nada"
+description = "Qué hay en un disco hospitalario, por qué los archivos no tienen extensión, cómo abrir un estudio .dcm en el navegador, qué hacen de verdad la ventana y el centro, y qué lleva un estudio sobre el paciente además de la imagen."
+
+heading = "Cómo abrir un archivo DICOM, y qué hay dentro de uno"
+lede = """
+    Un disco hospitalario es una carpeta de archivos sin extensión y un visor
+    escrito para Windows XP. Los archivos son DICOM, y no tienen nada de
+    exótico: un estudio es una cabecera llena de campos y un bloque de píxeles.
+    Aquí está cómo mirar uno, qué significan los controles y qué más lleva el
+    archivo además de la imagen."""
+
+updated = "25 de agosto de 2026"
+
+og_title = "Cómo abrir un archivo DICOM sin instalar nada"
+og_description = "Qué hay en un disco hospitalario, por qué los archivos no tienen extensión y qué lleva un estudio .dcm sobre el paciente además de la imagen."
+og_image_alt = "abox.tools - herramientas que nunca tocan un servidor"

--- a/locales/es/pages/guides/redact-a-pdf.html
+++ b/locales/es/pages/guides/redact-a-pdf.html
@@ -1,0 +1,232 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../censurar-pdf/">Censor de PDF</a>, suelta el
+      documento, escribe las palabras que tienen que irse, marca las que quieres
+      decir y pulsa &laquo;Sacarlas&raquo;. Las letras se borran de las propias
+      instrucciones de dibujo de la página, las mismas palabras se sacan de los
+      marcadores, los comentarios, los campos de formulario y las propiedades del
+      documento, y el archivo terminado se vuelve a abrir y se busca dentro
+      delante de ti antes de ofrecértelo.
+    </p>
+    <p>
+      Todo lo que sigue explica por qué esa última frase es la importante, y cómo
+      saber si la herramienta que ya usas puede decir lo mismo.
+    </p>
+  </section>
+
+  <section>
+    <h2>De qué fallo va esto</h2>
+    <p>
+      Pinta un rectángulo negro sobre un nombre en un lector de PDF. Lo que ves es
+      un nombre con un rectángulo negro encima. Lo que la mayoría de los lectores
+      <em>guardan</em> es un documento que contiene el nombre y, por separado, un
+      rectángulo con una posición, un tamaño y un color.
+    </p>
+    <p>
+      Un rectángulo pintado así es una <strong>anotación</strong>: un objeto que
+      está junto a la página y no dentro de ella. El texto de debajo está
+      exactamente como estaba. Selecciona la zona y pulsa copiar, o abre el
+      archivo en un programa que dibuje las anotaciones de otra manera, o pásale
+      cualquier extractor de texto, y el nombre vuelve. Nada en la pantalla
+      distingue eso de una censura de verdad, que es precisamente por lo que
+      sigue pasándoles a organizaciones que tienen abogados.
+    </p>
+    <p>
+      Ha publicado sumarios judiciales, informes de inteligencia, contratos y, en
+      diciembre de 2025, nombres tachados en una publicación masiva de documentos
+      del Departamento de Justicia de EE. UU. que eran legibles a las pocas horas
+      de publicarse. El patrón siempre es el mismo. El rectángulo era la
+      anotación, y la anotación nunca fue el texto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué hace en su lugar una censura de verdad</h2>
+    <p>
+      Una página de un PDF es una lista de instrucciones: usa esta tipografía,
+      mueve la pluma aquí, dibuja estos glifos. Las palabras de la página existen
+      exactamente en un sitio, como operandos de esas instrucciones de dibujo:
+    </p>
+    <pre><code>BT /F1 12 Tf 72 700 Td (Estimado Sr. Pérez) Tj ET</code></pre>
+    <p>
+      Censurar el nombre significa <strong>borrar esas letras de esa
+      instrucción</strong> y volver a escribir la página. Después de eso no hay
+      nada que recuperar, no porque el archivo lo esconda bien, sino porque las
+      letras no están en el archivo. No hay ningún rectángulo con algo debajo,
+      porque debajo no hay nada.
+    </p>
+    <p>
+      Hay que devolver una cosa, o el resultado queda visiblemente mal. El texto
+      se dibuja avanzando una pluma por la página, así que borrar cinco letras
+      arrastra el resto de la línea cinco letras hacia la izquierda: las columnas
+      dejan de estar alineadas y los totales se deslizan bajo el encabezado
+      equivocado. Una herramienta que hace esto bien mide cuánto habrían avanzado
+      las letras quitadas y devuelve esa distancia como una instrucción de
+      espaciado, que mueve la pluma sin dibujar nada.
+    </p>
+    <p>
+      La caja negra, si la hay, se pinta <em>después</em>, sobre un hueco que ya
+      está vacío. Es una cortesía hacia quien lea el documento &mdash; una señal
+      de que se ha quitado algo &mdash; y no la censura. Esa es toda la
+      distinción en una frase: en una censura de verdad la caja es adorno; en una
+      falsa, la caja <em>es</em> la censura.
+    </p>
+  </section>
+
+  <section>
+    <h2>Los cuatro sitios donde se esconde una palabra que no son la página</h2>
+    <p>
+      Esta es la parte que pilla a quien hizo bien la primera. Un PDF lleva texto
+      en varios sitios a la vez, y un lector los enseña, los busca o los copia
+      todos. Quitar un nombre de la página y dejarlo en cualquiera de estos es no
+      haberlo quitado.
+    </p>
+    <ul>
+      <li>
+        <strong>Las propiedades del documento.</strong> Título, autor y el nombre
+        del archivo del que se exportó este. Un documento al que se le ha quitado
+        un nombre de las páginas y cuyas propiedades siguen diciendo
+        <code>Acuerdo Pérez borrador 3.docx</code> no está censurado. Suele haber
+        una segunda copia de la misma información en un paquete XMP, que también
+        tiene que irse.
+      </li>
+      <li>
+        <strong>Los marcadores.</strong> El esquema del lateral de un lector es
+        una lista de encabezados con números de página pegados, y un encabezado es
+        una línea de texto que nada de la página controla.
+      </li>
+      <li>
+        <strong>Los campos de formulario y los comentarios.</strong> Lo que
+        alguien escribió en un formulario se guarda dos veces: una como valor del
+        campo y otra como la apariencia que dibuja el lector. Las dos tienen que
+        irse. Una nota lleva su texto y el nombre de quien la escribió.
+      </li>
+      <li>
+        <strong>El texto de reemplazo.</strong> Un PDF puede declarar que una
+        serie de glifos &laquo;deletrea&raquo; otra cosa, para que una ligadura o
+        una línea partida se copien como la palabra que representan. Eso
+        significa que un documento puede enseñar una cosa y entregarle otra a
+        quien pulse Ctrl+C, y una censura que solo quitara lo dibujado dejaría la
+        frase intacta para cualquiera que seleccionase el párrafo.
+      </li>
+    </ul>
+    <p>
+      Los adjuntos son el quinto. Un PDF puede llevar dentro archivos enteros, y
+      nada de lo que hagas con las páginas los toca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Cómo comprobar un archivo, en treinta segundos</h2>
+    <p>
+      Hazlo con todo lo que estés a punto de mandar, sea cual sea la herramienta
+      que lo produjo. Es la comprobación que habría pillado todos y cada uno de
+      los fallos publicados.
+    </p>
+    <ol>
+      <li>
+        <strong>Abre el archivo terminado y pulsa Ctrl+F</strong> (Cmd+F en un
+        Mac). Busca la palabra que quitaste. Una censura de verdad no devuelve
+        nada. Si el lector salta a un rectángulo negro, la palabra sigue ahí
+        dentro y el rectángulo está apoyado encima.
+      </li>
+      <li>
+        <strong>Selecciona la zona tachada y cópiala.</strong> Arrastra sobre el
+        rectángulo, pulsa Ctrl+C y pega en un cuadro de texto. Si llega algo, has
+        encontrado el mismo fallo por el otro lado.
+      </li>
+      <li>
+        <strong>Selecciona el documento entero y copia eso.</strong> Ctrl+A y
+        luego Ctrl+C, pega en cualquier editor de texto y lee lo que sale. Esta es
+        la más útil de las tres, porque te enseña el documento tal y como lo ve un
+        extractor de texto, incluido texto que no sabías que estaba ahí, cosa
+        habitual en una página escaneada.
+      </li>
+      <li>
+        <strong>Mira las propiedades</strong> &mdash; Archivo → Propiedades en la
+        mayoría de los lectores &mdash; y el panel de marcadores. Los dos son
+        sitios donde un nombre sobrevive a una censura perfecta en la página.
+      </li>
+    </ol>
+    <p>
+      El <a href="../../censurar-pdf/">Censor de PDF</a> hace por ti la primera y
+      la tercera y te enseña la cuenta, porque una herramienta que afirma haber
+      quitado algo no es una prueba y una búsqueda en el archivo terminado sí.
+    </p>
+  </section>
+
+  <section>
+    <h2>Los documentos escaneados son otro problema</h2>
+    <p>
+      Un escaneo es la fotografía de una página. Las palabras que hay en ella son
+      píxeles y no texto, y por mucho que edites la capa de texto no las tocas,
+      porque no hay capa de texto, o porque la que hay describe la imagen en vez
+      de ser la imagen.
+    </p>
+    <p>
+      La mayoría de los escáneres y herramientas de PDF actuales añaden una capa
+      de texto invisible sobre la imagen, escrita por reconocimiento óptico de
+      caracteres, para que la página se pueda buscar. Esa capa es texto de verdad
+      y se puede quitar. Merece la pena quitarla: es lo que habrían encontrado una
+      búsqueda, una copia y cualquier sistema automático que lea documentos. No
+      cambia nada de la imagen, en la que las palabras siguen siendo perfectamente
+      legibles para quien mire la página.
+    </p>
+    <p>
+      Así que para un escaneo la secuencia honesta es: sacar las palabras de la
+      capa de texto y después ocuparse de la imagen por separado, lo que
+      significa sobrescribir píxeles. Eso es lo que hace el
+      <a href="../censurar-una-imagen/">censor de imágenes</a>, y la guía de al
+      lado explica por qué un desenfoque o un mosaico no bastan para el texto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué no imprimirlo y volver a escanearlo</h2>
+    <p>
+      Porque funciona y te cuesta todo lo demás. Imprimir una página censurada y
+      volver a escanearla sí produce un documento sin capa de texto que pueda
+      filtrarse, y un documento que nadie puede buscar, que ningún lector de
+      pantalla puede leer, que es entre cinco y cincuenta veces más grande y cuya
+      calidad es la que le apeteciera al escáner de la oficina. Además da por
+      hecho que la página se imprimió tal y como se veía: una anotación puede
+      estar marcada como &laquo;ver en pantalla y no imprimir&raquo;, y cuando eso
+      es lo que era tu caja negra, la hoja que sale de la impresora lleva el
+      nombre.
+    </p>
+    <p>
+      El mismo argumento vale para &laquo;aplanar a imagen&raquo;, que algunas
+      herramientas ofrecen como censura. Convierte cada página en una fotografía
+      de sí misma. Si las palabras estaban tapadas en vez de borradas, ahora el
+      tapado es permanente, pero todo lo demás del documento se ha ido con él, y
+      el archivo que mandas es uno con el que nadie puede trabajar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué este es el trabajo que menos merece una subida</h2>
+    <p>
+      A un servicio de censura hay que darle el archivo sin censurar. Esa es toda
+      la transacción: la versión privada llega primero, entera, y es la versión
+      que queda en el disco de otra gente. Diga lo que diga la política de
+      privacidad, la secuencia no admite discusión: el documento con el que
+      tenías cuidado es el que entregaste.
+    </p>
+    <p>
+      Lo que la gente censura lo empeora más de lo que suena. Declaraciones
+      testificales, informes médicos, extractos bancarios que van al casero, un
+      contrato con el nombre de un cliente que va a otro, un escrito con una
+      dirección particular. Esos son los documentos, que es exactamente por lo que
+      la herramienta para ellos no debería tener un servidor al otro lado.
+    </p>
+    <p>
+      Todo lo del <a href="../../censurar-pdf/">censor de este sitio</a> ocurre en
+      tu propio navegador: el archivo se lee, se edita, se escribe y se comprueba
+      en tu equipo, y las palabras que buscas tampoco salen nunca de la pestaña.
+      Desconéctate de internet y sigue funcionando, que es la prueba más sencilla
+      que hay de que no se manda nada a ninguna parte. Qué implica de verdad una
+      subida está en <a href="../es-seguro-subir-archivos/">¿es seguro subir
+      archivos?</a>
+    </p>
+  </section>

--- a/locales/es/pages/guides/redact-a-pdf.toml
+++ b/locales/es/pages/guides/redact-a-pdf.toml
@@ -1,0 +1,21 @@
+#
+# Guía: censurar un PDF - Spanish.
+#
+
+nav = "Censurar un PDF"
+title = "Cómo censurar un PDF para que el texto desaparezca de verdad"
+description = "Una caja negra pintada en un lector de PDF suele dejar debajo las palabras, y copiar y pegar las recupera al instante. Qué quita una censura de verdad, los cuatro sitios donde se esconde una palabra fuera de la página, y cómo comprobar un archivo antes de mandarlo."
+
+heading = "Cómo censurar un PDF para que el texto desaparezca de verdad"
+lede = """
+    Un rectángulo negro sobre un nombre y un nombre borrado se ven idénticos en
+    pantalla. Uno de los dos sobrevive a que lo seleccionen y lo copien. Aquí
+    está la diferencia, los sitios donde se esconde una palabra que no son la
+    página, y la comprobación de treinta segundos que te dice cuál de los dos
+    tienes."""
+
+updated = "25 de agosto de 2026"
+
+og_title = "Cómo censurar un PDF para que el texto desaparezca de verdad"
+og_description = "Por qué una caja negra en un lector de PDF no suele ser una censura, los cuatro sitios donde se esconde una palabra fuera de la página, y cómo comprobar un archivo antes de mandarlo."
+og_image_alt = "abox.tools - herramientas que nunca tocan un servidor"

--- a/locales/es/pages/guides/scan-a-document-with-your-phone.html
+++ b/locales/es/pages/guides/scan-a-document-with-your-phone.html
@@ -1,0 +1,243 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Pon la hoja sobre algo que no sea del mismo color que la hoja, colócate
+      encima, llena el encuadre y haz una foto. Después abre el
+      <a href="../../escanear-documentos/">Escáner de documentos</a>, comprueba
+      las cuatro esquinas que ha encontrado, elige &laquo;Color, igualado&raquo; o
+      &laquo;Blanco y negro&raquo; y guarda el PDF.
+    </p>
+    <p>
+      Ese es todo el trabajo. El resto explica qué arregla cada uno de esos pasos,
+      porque saber qué parte hace qué es lo que te deja ver, en tres segundos, si
+      lo que estás a punto de mandar te lo van a aceptar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué separa de verdad una foto de un escaneo</h2>
+    <p>
+      Tres cosas, y no importan lo mismo.
+    </p>
+    <ul>
+      <li>
+        <strong>El ángulo.</strong> Una foto se hace desde donde estuvieras, así
+        que la hoja es un cuadrilátero y no un rectángulo. Es lo que todo el mundo
+        nota y lo más fácil de deshacer.
+      </li>
+      <li>
+        <strong>La luz.</strong> Un escáner arrastra una luz uniforme por la
+        hoja. Una habitación no: hay una zona brillante bajo la lámpara, un
+        rincón apagado lejos de ella y, muy a menudo, tu propia sombra cruzando un
+        lado. Es lo que de verdad hace que una foto parezca una foto, y lo que la
+        gente intenta arreglar con el &laquo;contraste automático&raquo;, que lo
+        empeora.
+      </li>
+      <li>
+        <strong>El tamaño.</strong> La foto de una hoja a doce megapíxeles son
+        entre tres y cinco megabytes. Veinte de ellas son un documento que va a
+        rebotar en la mitad de los servidores de correo a los que se mande.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Hacer la foto</h2>
+    <p>
+      Cinco cosas, ordenadas por cuánto cambian el resultado:
+    </p>
+    <ul>
+      <li>
+        <strong>Llena el encuadre.</strong> Es lo único que no tiene arreglo
+        después. El detalle que no estaba en la foto no está en el archivo, y una
+        hoja fotografiada desde el otro lado de la habitación es una hoja que
+        nadie puede leer a ninguna resolución. Acércate en vez de usar el zoom: a
+        menos que el teléfono cambie a un segundo objetivo más largo, acercar el
+        zoom es un recorte del mismo sensor y tira justo los píxeles que intentas
+        conservar.
+      </li>
+      <li>
+        <strong>Ponla sobre algo de otro color.</strong> Una hoja blanca sobre una
+        mesa blanca casi no tiene borde que nadie pueda encontrar: ni un programa,
+        ni tú tampoco cuando vayas a arrastrar las esquinas a mano. Una mesa
+        oscura, un libro, un abrigo: cualquier cosa.
+      </li>
+      <li>
+        <strong>No te pongas entre la hoja y la luz.</strong> Tu propia sombra
+        cruzando la hoja es el motivo más común de que un escaneo hecho con el
+        teléfono se vea mal. Gira noventa grados y desaparece.
+      </li>
+      <li>
+        <strong>Deja que enfoque y después aguanta quieto.</strong> El pulso no lo
+        recupera ninguna herramienta, y un enfoque fallado tampoco. Toca la hoja
+        en la pantalla, espera a que se asiente y dispara.
+      </li>
+      <li>
+        <strong>Mete la hoja entera, con las esquinas.</strong> No porque las
+        esquinas sean preciosas, sino porque es de donde se mide el enderezado.
+        Una hoja que se sale por el borde del encuadre sigue funcionando &mdash;
+        el borde de la foto hace de borde de la hoja &mdash;, pero una hoja con
+        tres esquinas dentro y una supuesta es una hoja que va a salir un poco
+        torcida.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Enderezar: la forma importa más que el ángulo</h2>
+    <p>
+      Deshacer el ángulo es una operación bien entendida. Cuatro esquinas de un
+      rectángulo vistas desde cualquier sitio determinan la transformación que las
+      devuelve a su lugar, y aplicarla a cada píxel da una hoja plana. Cualquier
+      herramienta que diga que endereza una hoja está haciendo eso.
+    </p>
+    <p>
+      La parte que sale mal en silencio es <em>de qué tamaño</em> debería ser la
+      hoja plana. El método evidente es medir los bordes del cuadrilátero y usar
+      su proporción, y una foto tomada en ángulo escorza el borde lejano, así que
+      una hoja de A4 sale visiblemente achatada. Sigue pareciendo un escaneo.
+      Simplemente, cada línea de texto tiene la altura equivocada, y nada en la
+      pantalla lo dice.
+    </p>
+    <p>
+      La respuesta mejor es que la propia perspectiva lleva la información: con
+      tal de que sea una cámara corriente, la foto de un rectángulo basta para
+      recuperar tanto las proporciones reales del rectángulo como la distancia
+      focal de la cámara. El
+      <a href="../../escanear-documentos/">Escáner de documentos</a> de aquí hace
+      eso, y después te dice qué forma ha salido y si es un tamaño normalizado.
+      Una hoja que dice &laquo;1:1,41, que es la forma de A4 o A5&raquo; es una
+      hoja en la que ya no tienes que pensar.
+    </p>
+  </section>
+
+  <section>
+    <h2>La luz: dividir, no estirar</h2>
+    <p>
+      Subir el contraste de una hoja con luz desigual deja la parte clara en
+      blanco y la oscura en negro, y la escritura de la parte oscura desaparece
+      con ella. El problema nunca fue que el contraste fuera bajo. Es que el papel
+      no tiene el mismo brillo en una esquina que en otra, así que no hay un único
+      ajuste que sea correcto para toda la hoja.
+    </p>
+    <p>
+      Lo que sí funciona es estimar cómo de brillante es el papel
+      <em>en cada punto</em> y dividir por eso. El papel es la mayoría brillante
+      de cualquier trozo pequeño de una hoja, así que medir el brillo en una
+      rejilla de casillas pequeñas y tomar un valor alto en cada una da la forma
+      de la luz: el texto es demasiado oscuro y demasiado escaso para moverla.
+      Divide por eso y lo que queda es la tinta, con luz uniforme, sin la sombra y
+      con el papel otra vez blanco.
+    </p>
+    <p>
+      Eso es lo que hacen &laquo;Color, igualado&raquo; y &laquo;Escala de
+      grises&raquo;. Elige color cuando el color forme parte del documento: un
+      sello, una firma en tinta azul, una línea subrayada, cualquier cosa por la
+      que después alguien pueda preguntar si era el original.
+    </p>
+  </section>
+
+  <section>
+    <h2>Blanco y negro, y por qué el archivo se vuelve pequeño de golpe</h2>
+    <p>
+      Una hoja guardada como fotografía son millones de píxeles con dieciséis
+      millones de colores posibles cada uno, y el códec gasta su esfuerzo en
+      degradados sutiles que una página de texto no tiene. Una hoja guardada como
+      blanco y negro es un bit por píxel &mdash; tinta o papel &mdash; y comprime
+      como la cosa abrumadoramente repetitiva que es.
+    </p>
+    <p>
+      La diferencia no es pequeña: en las mismas páginas es unas dieciocho veces.
+      Un contrato de veinte páginas que ocupa quince megabytes como fotografías
+      cae por debajo del megabyte como páginas de un bit, que es la diferencia
+      entre un documento que se puede mandar por correo y uno que no. Por eso lo
+      trae de fábrica cualquier escáner de oficina.
+    </p>
+    <p>
+      La pega es que no hay medios tonos: una fotografía en la hoja se convierte
+      en un revoltijo de puntos. Úsalo para páginas impresas y escritas, que es lo
+      que son la mayoría de los documentos, y usa escala de grises para cualquier
+      cosa con una imagen.
+    </p>
+    <p>
+      Un detalle que merece la pena conocer, porque explica por qué una
+      herramienta buena acierta donde una mala produce una página con una esquina
+      negra: la decisión de tinta o papel hay que tomarla <em>localmente</em>. Un
+      único umbral para toda la hoja no puede funcionar cuando el papel en sombra
+      es más oscuro que la tinta a plena luz, y en una hoja fotografiada muy a
+      menudo lo es. Decidir cada píxel contra la media de su propio pequeño
+      vecindario es lo que mantiene legible la escritura dentro de una sombra.
+    </p>
+  </section>
+
+  <section>
+    <h2>Varias páginas, un documento</h2>
+    <p>
+      Fotografía las hojas en orden, añádelas todas de una vez y se convierten en
+      las páginas de un PDF en el orden en que se añadieron. Dos cosas que
+      vigilar:
+    </p>
+    <ul>
+      <li>
+        <strong>Los nombres de archivo no se ordenan como crees.</strong>
+        <code>pagina2.jpg</code> va después de <code>pagina10.jpg</code> en un
+        orden alfabético, porque la comparación es carácter a carácter. Comprueba
+        el orden en la tira antes de guardar, y no después en el PDF.
+      </li>
+      <li>
+        <strong>La limpieza es un ajuste para todo el documento</strong>, y a
+        propósito. Unas páginas limpiadas de forma distinta parecen dos documentos
+        grapados juntos, que es justo la impresión que un escaneo debería evitar.
+        Elige el modo que le convenga a la peor página.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Antes de mandarlo</h2>
+    <ul>
+      <li>
+        <strong>Abre el PDF.</strong> No la vista previa: el archivo. Todas las
+        páginas, del derecho, sin nada cortado por un borde.
+      </li>
+      <li>
+        <strong>Lee lo más pequeño de la página.</strong> Un número de
+        expediente, una fecha, un número de cuenta. Si no lo puedes leer en
+        pantalla al 100%, quien lo reciba tampoco.
+      </li>
+      <li>
+        <strong>Comprueba que no se han recortado las esquinas.</strong> Lo que
+        hay en el borde de un formulario es un número de página, una línea de
+        firma o la casilla que después alguien dirá que faltaba.
+      </li>
+      <li>
+        <strong>Comprueba qué dice el documento sobre ti.</strong> Un PDF tiene
+        campos para el autor, el productor y la fecha de creación, y la mayoría de
+        las herramientas los rellenan. Si eso importa depende de quién lo reciba,
+        pero conviene saber que está ahí.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Por qué nada de esto necesita una subida</h2>
+    <p>
+      Cada paso de arriba es aritmética sobre una imagen que tu propio equipo ya
+      ha decodificado: cuatro esquinas, una transformación, una división, un
+      umbral y un contenedor escrito byte a byte. No hay nada ahí que pueda hacer
+      un servidor y no pueda un navegador, ni nada que necesite un modelo
+      descargado para hacerlo.
+    </p>
+    <p>
+      Y merece la pena detenerse en eso, por lo que son estos archivos. La gente
+      no fotografía hojas al azar. Fotografía un pasaporte, una nómina, un
+      contrato de alquiler, un formulario médico, un contrato: documentos con un
+      nombre, una dirección y un número de cuenta encima, escaneados precisamente
+      porque una institución los ha pedido. Subir uno a una web para que le
+      enderecen las esquinas le entrega a un desconocido el documento entero. Mira
+      <a href="../es-seguro-subir-archivos/">cómo saber si una herramienta
+      necesita de verdad tus archivos</a> para las cuatro comprobaciones que
+      separan las herramientas que tienen que ver tu archivo de las que
+      simplemente lo ven.
+    </p>
+  </section>

--- a/locales/es/pages/guides/scan-a-document-with-your-phone.toml
+++ b/locales/es/pages/guides/scan-a-document-with-your-phone.toml
@@ -1,0 +1,21 @@
+#
+# Guía: escanear un documento con el teléfono - Spanish.
+#
+
+nav = "Escanear con el teléfono"
+title = "Cómo escanear un documento con el teléfono, sin app y sin subirlo"
+description = "Qué separa la foto de una hoja de un escaneo de esa misma hoja: el ángulo, la luz desigual y el tamaño del archivo. Cómo hacer la foto, qué arreglar después y por qué nada de esto necesita un servidor."
+
+heading = "Cómo escanear un documento con el teléfono"
+lede = """
+    Alguien te ha pedido un formulario &laquo;escaneado&raquo; y tienes un
+    teléfono y ningún escáner. La distancia entre la foto de una hoja y un
+    escaneo de esa hoja es menor de lo que parece, y no va sobre todo del
+    ángulo: esto es lo que de verdad los separa, y qué hacer con cada
+    parte."""
+
+updated = "25 de agosto de 2026"
+
+og_title = "Cómo escanear un documento con el teléfono"
+og_description = "El ángulo, la sombra y el tamaño del archivo: qué separa la foto de una hoja de un escaneo de esa hoja, y cómo arreglar cada cosa sin subir la página."
+og_image_alt = "abox.tools - herramientas que nunca tocan un servidor"

--- a/locales/es/pages/guides/stack-photos-to-reduce-noise.html
+++ b/locales/es/pages/guides/stack-photos-to-reduce-noise.html
@@ -1,0 +1,295 @@
+  <section>
+    <h2>La respuesta corta</h2>
+    <p>
+      Abre el <a href="../../apilar-imagenes/">Apilador de imágenes</a>, suelta la
+      ráfaga entera y elige el método por lo que quieras quitar de en medio:
+    </p>
+    <ul>
+      <li><strong>Ruido</strong>, y no se movió nada &mdash; media.</li>
+      <li><strong>Ruido</strong>, y se movió algo &mdash; recorte sigma.</li>
+      <li><strong>Gente, coches, un avión</strong> &mdash; mediana.</li>
+      <li><strong>Un cielo oscuro que quieres como estelas de estrellas</strong> &mdash; aclarar.</li>
+      <li><strong>Una macro con casi nada de profundidad de campo</strong> &mdash; apilado de enfoque.</li>
+    </ul>
+    <p>
+      Deja la alineación puesta si la cámara estaba en tus manos y quítala si
+      estaba en un trípode. Los archivos RAW pueden entrar directamente; no hace
+      falta revelarlos antes.
+    </p>
+    <p>
+      Todo lo que sigue es por qué esas cinco líneas dicen lo que dicen.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por qué una ráfaga lleva más que una toma</h2>
+    <p>
+      Una fotografía hecha con poca luz es la imagen más ruido, y el ruido es
+      distinto cada vez. Esa última parte es lo que hace que apilar funcione. Haz
+      la misma toma dieciséis veces y la imagen es idéntica en las dieciséis
+      mientras que el ruido no lo es, así que promediarlas deja la imagen y
+      cancela la mayor parte del ruido.
+    </p>
+    <p>
+      La mejora es la raíz cuadrada del número de tomas. Cuatro tomas reducen el
+      ruido a la mitad. Dieciséis, a la cuarta parte. Cien, a la décima. Es una
+      curva brutal en la que estar &mdash; pasar de dieciséis tomas a sesenta y
+      cuatro te da la misma mejora otra vez, a cambio de cuatro veces el disparo
+      &mdash; y por eso casi cualquier pila práctica está entre ocho y treinta
+      tomas.
+    </p>
+    <p>
+      Hay una segunda ganancia, más callada. Promediar dieciséis tomas de ocho
+      bits da un resultado con gradaciones más finas que las que tenía cualquiera
+      de ellas, porque el ruido que hacía que cada toma redondeara distinto es
+      justo lo que permite que la media caiga entre los niveles. Apilar un
+      conjunto ruidoso no solo quita ruido; recupera tono que una sola toma había
+      cuantizado.
+    </p>
+  </section>
+
+  <section>
+    <h2>La pregunta que elige el método</h2>
+    <p>
+      No &laquo;qué quiero conservar&raquo;, sino <strong>qué era distinto entre
+      las tomas</strong>. Todo lo demás sale de ahí.
+    </p>
+
+    <h3>No se movió nada: media</h3>
+    <p>
+      La media aritmética a secas. Es la reducción de ruido más eficaz que existe
+      en un conjunto donde lo único que cambia entre tomas es el ruido, y la más
+      fácil de arruinar: una toma con un pájaro pone un pájaro tenue sobre toda la
+      pila, porque una media no tiene opinión sobre un valor que no concuerda con
+      los demás. Simplemente lo incluye.
+    </p>
+
+    <h3>Algo cruzó el encuadre: mediana</h3>
+    <p>
+      Alinea una docena de fotografías de una plaza concurrida y mira un píxel. En
+      la mayoría es acera; en una o dos es el abrigo de alguien. Ordena esos doce
+      valores, toma el del medio y sale acera, porque el abrigo nunca fue mayoría.
+    </p>
+    <p>
+      Haz eso para cada píxel y la plaza sale vacía. Es el truco detrás de
+      cualquier artículo de &laquo;quita a los turistas de tu foto de
+      vacaciones&raquo;, y no necesita nada más listo que una ráfaga y paciencia.
+      Lo único que exige es que <strong>ninguna parte de la escena esté ocupada
+      más de la mitad del tiempo</strong>. Una persona quieta en ocho de tus doce
+      tomas es mayoría en esos píxeles, y la mediana la conserva.
+    </p>
+
+    <h3>Las dos cosas: recorte sigma</h3>
+    <p>
+      La mediana tira la mayor parte de la información para conseguir su
+      robustez: en cada píxel se descartan once de tus doce valores, así que
+      reduce el ruido mucho menos de lo que lo haría una media del mismo conjunto.
+    </p>
+    <p>
+      El recorte sigma es el término medio, y suele ser el ajuste correcto por
+      defecto para cualquier conjunto del mundo real. Mira cada píxel a lo largo
+      de todas las tomas, calcula qué suele ser y cuánto varía, y después promedia
+      solo los valores que concuerdan con eso. Un coche que cruzó una toma queda
+      excluido en esos píxeles; todas las demás tomas siguen contando en todas
+      partes. Consigues la inmunidad de la mediana ante lo que se movió y la mayor
+      parte de la reducción de ruido de la media.
+    </p>
+    <p>
+      El umbral va en desviaciones típicas, y dos es el punto de partida habitual.
+      Más bajo descarta más, y empieza a descartar detalle real junto con el
+      coche.
+    </p>
+
+    <h3>Solo importa lo brillante: aclarar</h3>
+    <p>
+      Conservar el valor más brillante que haya tenido cada píxel. Fotografía el
+      cielo nocturno como doscientas exposiciones de treinta segundos y acláralas
+      juntas, y cada estrella dibuja su propio arco sobre el resultado: una estela
+      de estrellas, montada a partir de exposiciones cortas que nunca se quemaron
+      por separado. El mismo método monta unos fuegos artificiales a partir de las
+      tomas de su propia explosión, y una pintura con luz a partir de un paseo con
+      una linterna por una habitación oscura.
+    </p>
+    <p>
+      Su contrario, oscurecer, es el callado de la pareja: un píxel solo sigue
+      brillante si lo estaba en <em>todas</em> las tomas, así que los reflejos en
+      una ventana, los faros que pasan y las gotas de lluvia iluminadas por un
+      flash desaparecen.
+    </p>
+
+    <h3>El sujeto es más profundo que el enfoque: apilado de enfoque</h3>
+    <p>
+      Una macro a f/8 tiene quizá un milímetro enfocado, y eso no basta para un
+      insecto. La respuesta es hacer veinte tomas a lo largo del anillo de enfoque
+      y conservar de cada una solo la parte que estaba nítida en ella. La
+      herramienta mide cuánto se diferencia cada píxel de sus vecinos &mdash;
+      mucho en un borde, casi nada en un desenfoque &mdash; y se queda con el
+      ganador.
+    </p>
+    <p>
+      Este quiere trípode más que ninguno de los otros, porque mover el anillo de
+      enfoque a mano mueve la cámara, y una toma hecha desde un poco más lejos no
+      es la misma imagen a otro enfoque.
+    </p>
+  </section>
+
+  <section>
+    <h2>Alinear las tomas</h2>
+    <p>
+      Apilar es aritmética píxel a píxel, así que da por hecho que un píxel dado
+      es la misma parte de la escena en todas las tomas. A pulso no lo es: una
+      ráfaga deriva decenas de píxeles, y promediar eso produce un desenfoque en
+      vez de una imagen limpia. Ese es el motivo más común de que un primer
+      intento de apilado decepcione.
+    </p>
+    <p>
+      Así que las tomas se miden contra una de ellas y se devuelven antes a su
+      sitio, con precisión de fracciones de píxel. Tres ajustes:
+    </p>
+    <ul>
+      <li>
+        <strong>Solo desplazamiento</strong> es lo correcto para casi todo lo
+        hecho a pulso. Corrige la deriva y el temblor.
+      </li>
+      <li>
+        <strong>Desplazamiento, rotación y escala</strong> para un conjunto en el
+        que además girabas un poco, o en el que se coló un zoom. Cuesta una
+        medición más por toma y nada en absoluto cuando las tomas resultan estar
+        derechas.
+      </li>
+      <li>
+        <strong>Ninguna</strong> para un trípode fijo o una secuencia de
+        intervalómetro, donde las tomas ya están alineadas y medirlas es tiempo
+        perdido.
+      </li>
+    </ul>
+    <p>
+      Lo que ninguna alineación puede arreglar es un sujeto que se movió en vez de
+      una cámara que se movió, ni una fotografía hecha un paso más a la izquierda.
+      Moverse de lado cambia cuánto se desplaza lo cercano respecto a lo lejano, y
+      ninguna corrección única describe las dos cosas a la vez. Girar sobre el
+      sitio vale; andar no.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dónde encajan los archivos RAW</h2>
+    <p>
+      Puedes soltar CR2, CR3, NEF, ARW, DNG, RAF, RW2, ORF y el resto
+      directamente, y conviene ser exacto sobre qué les pasa, porque no es lo que
+      hace un revelador RAW.
+    </p>
+    <p>
+      Todo archivo RAW ya contiene un <strong>JPEG a tamaño completo que la cámara
+      reveló al disparar</strong>. Es lo que te enseña la pantalla trasera de la
+      cámara y lo que dibuja tu sistema operativo como miniatura. El apilador
+      encuentra esa imagen y la usa. No decodifica los datos del sensor.
+    </p>
+    <p>
+      Dos consecuencias, una buena y otra que conviene conocer:
+    </p>
+    <ul>
+      <li>
+        <strong>Es rápido.</strong> Encontrar la vista previa significa leer unos
+        kilobytes de directorio y después un solo trozo, así que una toma de
+        60&nbsp;MB abre casi tan rápido como un JPEG. Veinte de ellas abren en el
+        tiempo que un revelador RAW dedicaría a una. La página te enseña qué poco
+        de tus archivos ha leído realmente.
+      </li>
+      <li>
+        <strong>Es la interpretación de la cámara, no la tuya.</strong> Ocho bits
+        por canal, con el balance de blancos y el estilo de imagen que tuviera
+        puestos la cámara, y no los doce o catorce bits de datos lineales de
+        sensor que sacarías de un revelador.
+      </li>
+    </ul>
+    <p>
+      Para reducir ruido, estelas de estrellas, quitar transeúntes y apilado de
+      enfoque, ese intercambio casi siempre compensa: las vistas previas están a
+      resolución completa y son lo que habrías obtenido como JPEG de todas formas.
+      Si estás levantando mucho las sombras, o apilando para astrofotografía donde
+      el último bit de rango dinámico es todo el objetivo, revela antes las tomas
+      en un revelador RAW y apila los TIFF o los JPEG que dé. Entran igual.
+    </p>
+  </section>
+
+  <section>
+    <h2>Qué cuesta ejecutarlo</h2>
+    <p>
+      Conviene saberlo porque es la diferencia entre una pila que tarda ocho
+      segundos y una que tarda dos minutos.
+    </p>
+    <p>
+      Seis de los siete métodos solo necesitan recordar una cosa. Un máximo
+      corriente no se preocupa por las tomas que ya ha visto, y una suma corriente
+      tampoco, así que esos métodos leen cada toma exactamente una vez y usan la
+      misma memoria para cien tomas que para dos.
+    </p>
+    <p>
+      La mediana no puede funcionar así, porque no se puede saber el valor central
+      de un conjunto hasta tenerlo entero. Veinte tomas de 24 megapíxeles son
+      alrededor de 1,4&nbsp;GB de píxeles sostenidos a la vez, y eso no te lo da
+      ningún navegador, así que la imagen se corta en bandas horizontales y se
+      apila banda a banda: correcto, y más lento, porque las tomas se releen para
+      cada banda.
+    </p>
+    <p>
+      La herramienta calcula todo esto antes de que pulses el botón y te lo dice:
+      cómo de grande será el resultado, cuánta memoria necesita aproximadamente y
+      cuántas veces se decodificarán tus tomas. Si dice que la pasada irá por
+      bandas, bajar un escalón la resolución de trabajo divide la memoria entre
+      cuatro y casi siempre la convierte otra vez en una sola pasada &mdash; y si
+      estás apilando para quitar ruido, media resolución ya iba a verse más limpia
+      que la completa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Disparar pensando en esto</h2>
+    <p>
+      La mayor parte de la calidad de una pila se decide antes de que la vea
+      ningún programa.
+    </p>
+    <ul>
+      <li>
+        <strong>Haz más tomas de las que crees necesitar.</strong> La curva de la
+        raíz cuadrada es implacable en la parte baja y generosa en la alta: pasar
+        de cuatro a nueve tomas es un cambio más visible que pasar de veinte a
+        cuarenta.
+      </li>
+      <li>
+        <strong>No cambies la exposición entre tomas.</strong> Apilar da por hecho
+        que las tomas son de la misma escena con el mismo brillo. Fija la
+        exposición, o la herramienta estará promediando dos imágenes distintas.
+      </li>
+      <li>
+        <strong>Para quitar gente, espera entre tomas.</strong> Una ráfaga hecha
+        en dos segundos pilla a la misma persona en el mismo sitio en todas las
+        tomas, y la mediana la conserva. Diez tomas separadas por unos segundos
+        funcionan mucho mejor que cincuenta en ráfaga.
+      </li>
+      <li>
+        <strong>Para estelas de estrellas, deja huecos cortos.</strong> Aclarar
+        dibuja exactamente lo que registraron las tomas, así que una pausa entre
+        exposiciones se convierte en un guion visible en todas las estelas.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Nada de esto sale de tu equipo</h2>
+    <p>
+      Una pila de veinte tomas RAW es alrededor de un gigabyte de fotografías, que
+      es mucho para entregárselo a una web para que le saque la media. El
+      <a href="../../apilar-imagenes/">Apilador de imágenes</a> lee los archivos de
+      tu propio disco y hace la aritmética en tu propio navegador. No hay paso de
+      subida, ni cuenta, ni cola, y puedes comprobar esa afirmación como
+      comprobarías la de cualquiera: abre el panel de red de tu navegador mientras
+      se ejecuta, o simplemente desconéctate de internet y apílalas igualmente.
+    </p>
+    <p>
+      La pregunta relacionada &mdash; cómo saber, para cualquier herramienta, si
+      entregarle un archivo hacía falta &mdash; tiene
+      <a href="../es-seguro-subir-archivos/">su propia guía</a>.
+    </p>
+  </section>

--- a/locales/es/pages/guides/stack-photos-to-reduce-noise.toml
+++ b/locales/es/pages/guides/stack-photos-to-reduce-noise.toml
@@ -1,0 +1,20 @@
+#
+# Guía: apilar fotos para reducir el ruido - Spanish.
+#
+
+nav = "Apilar fotografías"
+title = "Cómo apilar fotografías para reducir el ruido, o quitar gente"
+description = "Apilar combina una ráfaga de tomas en una sola imagen. Qué método te hace falta depende de qué quieras perder: el ruido, los transeúntes o la poca profundidad de campo de una macro. Cómo funciona cada uno, qué cuesta y dónde encajan los archivos RAW."
+
+heading = "Cómo apilar fotografías para reducir el ruido, o quitar gente"
+lede = """
+    Una ráfaga de tomas lleva más información que cualquiera de ellas.
+    Promediarlas cancela el ruido; tomar el valor central de cada píxel borra
+    todo lo que solo estaba parte del tiempo. Cuál de las dos quieres depende
+    enteramente de qué se movió."""
+
+updated = "25 de agosto de 2026"
+
+og_title = "Cómo apilar fotografías para reducir el ruido, o quitar gente"
+og_description = "Promedia una ráfaga para matar el ruido, toma la mediana para vaciar una plaza concurrida, aclara para dejar estelas de estrellas. Qué método resuelve qué problema, y dónde encajan los archivos RAW."
+og_image_alt = "abox.tools - herramientas que nunca tocan un servidor"

--- a/locales/es/tools/dicom-viewer.html
+++ b/locales/es/tools/dicom-viewer.html
@@ -1,0 +1,267 @@
+<!--
+  tools/dicom-viewer/body.html, in Spanish.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+
+  La cabecera de columna "VR" se queda: es el codigo de dos letras que esta
+  escrito dentro del archivo, y quien compruebe una etiqueta contra la norma
+  busca exactamente esas dos letras.
+-->
+<main>
+  <!--
+    One numbered step, and then the viewer.
+
+    Every other tool on this site numbers its cards because every card is
+    something the visitor does. Here there is one thing to do - choose the
+    files - and everything below it is the scan. Numbering the picture would
+    promise a sequence of decisions that does not exist.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige un estudio</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p class="picker-note">
+      Suelta de una vez el contenido de una carpeta entera y los archivos se
+      reagrupan en sus series y se apilan en orden. No se sube nada, y no se
+      escribe nada de vuelta en tus archivos.
+    </p>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- El visor. -->
+  <section class="card" id="viewer-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="save-frame" class="ghost" data-download>Guardar este fotograma como PNG</button>
+        <button type="button" id="copy-header" class="ghost">Copiar la cabecera</button>
+        <button type="button" id="download-header" class="ghost">Descargarla</button>
+      </div>
+    </div>
+
+    <div class="series-row" id="series-row" hidden>
+      <label for="series-pick" class="inline-label">Serie</label>
+      <select id="series-pick"></select>
+      <span class="count" id="series-note"></span>
+    </div>
+
+    <!--
+      The canvas is sized in CSS and its backing store is set to the frame's own
+      pixels, so a 512-pixel slice is drawn at 512 pixels and scaled by the
+      browser rather than resampled here. That is what makes the zoom honest:
+      what is on screen at 400% is the stored pixels made bigger, not a guess at
+      what was between them.
+    -->
+    <div class="viewport" id="viewport">
+      <canvas id="canvas" width="1" height="1" role="img"
+              aria-label="El fotograma en pantalla, dibujado a partir del archivo que has elegido"></canvas>
+      <div class="overlay overlay-tl" id="overlay-tl" hidden></div>
+      <div class="overlay overlay-tr" id="overlay-tr"></div>
+      <div class="overlay overlay-bl" id="overlay-bl"></div>
+      <div class="overlay overlay-br" id="overlay-br"></div>
+      <svg class="marks" id="marks" aria-hidden="true"></svg>
+      <p class="viewport-fail" id="viewport-fail" hidden></p>
+    </div>
+
+    <div class="scrub" id="scrub-row" hidden>
+      <button type="button" id="play" class="ghost" aria-label="Reproducir los fotogramas">▶</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" step="1"
+             aria-label="Qué corte o fotograma se muestra">
+      <span class="count" id="scrub-label">&mdash;</span>
+    </div>
+
+    <div class="tools">
+      <fieldset class="modes">
+        <legend class="visually-hidden">Qué hace arrastrar sobre la imagen</legend>
+        <label><input type="radio" name="mode" value="window" checked> Ventana y centro</label>
+        <label><input type="radio" name="mode" value="pan"> Desplazar</label>
+        <label><input type="radio" name="mode" value="measure"> Medir</label>
+      </fieldset>
+
+      <div class="zoom">
+        <label for="zoom" class="inline-label">Zoom</label>
+        <input type="range" id="zoom" min="5" max="800" step="5" value="100">
+        <span class="count" id="zoom-label">100%</span>
+        <button type="button" id="reset-view" class="ghost">Ajustar</button>
+      </div>
+    </div>
+
+    <div class="levels" id="levels">
+      <div class="level-field">
+        <label for="preset" class="inline-label">Ventana</label>
+        <select id="preset"></select>
+      </div>
+      <div class="level-field">
+        <label for="center" class="inline-label">Centro</label>
+        <input type="number" id="center" step="1">
+      </div>
+      <div class="level-field">
+        <label for="width" class="inline-label">Anchura</label>
+        <input type="number" id="width" step="1" min="1">
+      </div>
+      <label class="level-check"><input type="checkbox" id="invert"> Invertir</label>
+      <label class="level-check"><input type="checkbox" id="show-details"> Mostrar los datos del paciente sobre la imagen</label>
+    </div>
+
+    <p class="hint" id="mode-hint"></p>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- Qué es este archivo. -->
+  <section class="card" id="facts-card" hidden>
+    <h2>Qué es este archivo</h2>
+    <dl class="facts">
+      <div><dt>Objeto</dt><dd id="fact-sop">&mdash;</dd></div>
+      <div><dt>Modalidad</dt><dd id="fact-modality">&mdash;</dd></div>
+      <div><dt>Imagen</dt><dd id="fact-size">&mdash;</dd></div>
+      <div><dt>Guardada como</dt><dd id="fact-stored">&mdash;</dd></div>
+      <div><dt>Sintaxis de transferencia</dt><dd id="fact-syntax">&mdash;</dd></div>
+      <div><dt>Espaciado de píxel</dt><dd id="fact-spacing">&mdash;</dd></div>
+      <div><dt>Rango de valores</dt><dd id="fact-range">&mdash;</dd></div>
+      <div><dt>Archivo</dt><dd id="fact-file">&mdash;</dd></div>
+    </dl>
+
+    <ul class="notes" id="notes" hidden></ul>
+  </section>
+
+  <!-- Qué lleva dentro sobre la persona. -->
+  <section class="card" id="identity-card" hidden>
+    <h2>Qué hay en este archivo que identifica al paciente</h2>
+    <p class="card-lede">
+      Leído de este archivo, en este equipo, y no mostrado a nadie más. Esta
+      herramienta no escribe nada: no puede quitar nada de esto, y no ha enviado
+      nada de esto a ninguna parte. Está aquí porque un estudio lleva mucho más
+      que un nombre, y el resto es justo lo que sobrevive a una anonimización
+      descuidada.
+    </p>
+    <ul class="identity" id="identity"></ul>
+    <p class="identity-extra" id="identity-extra"></p>
+  </section>
+
+  <!-- Cada etiqueta del archivo. -->
+  <section class="card" id="tags-card" hidden>
+    <div class="toolbar">
+      <h2>Cada etiqueta del archivo</h2>
+      <div class="toolbar-actions">
+        <label for="tag-search" class="visually-hidden">Buscar en las etiquetas</label>
+        <input type="search" id="tag-search" class="tag-search" placeholder="Buscar por nombre, número o valor">
+      </div>
+    </div>
+
+    <p class="card-lede" id="tags-lede"></p>
+
+    <div class="table-wrap">
+      <table class="tags">
+        <caption class="visually-hidden">Cada elemento de este archivo</caption>
+        <thead>
+          <tr>
+            <th scope="col">Etiqueta</th>
+            <th scope="col">VR</th>
+            <th scope="col">Nombre</th>
+            <th scope="col">Valor</th>
+          </tr>
+        </thead>
+        <tbody id="tag-rows"></tbody>
+      </table>
+    </div>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!--
+    The tool's own sentences, kept out of the JavaScript so that a translator
+    can reach them. shared/js/phrases.js reads them back, and a key defined here
+    wins over the frame's one.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="mode.window">Arrastra por la imagen para ensanchar o estrechar la ventana, y hacia arriba o abajo para mover su centro. Los dos números están debajo, y escribirlos hace lo mismo.</span>
+    <span data-phrase="mode.pan">Arrastra para mover la imagen dentro de su marco. La rueda hace zoom, y &laquo;Ajustar&raquo; lo devuelve todo a su sitio.</span>
+    <span data-phrase="mode.measure">Arrastra una línea sobre la imagen para medirla. Donde el archivo dice a qué distancia están sus píxeles, la respuesta va en milímetros; donde no lo dice, va en píxeles y lo advierte.</span>
+
+    <span data-phrase="probe.value">{value} en la columna {column}, fila {row}</span>
+    <span data-phrase="measure.pixels">{length} px &mdash; este archivo no dice a qué distancia están sus píxeles, así que esto no puede ir en milímetros</span>
+
+    <span data-phrase="stack.position">Apilados por dónde cae cada corte en el paciente, que es el orden en que los tomó el equipo.</span>
+    <span data-phrase="stack.number">Apilados por número de instancia: estos archivos no llevan una posición en el paciente por la que ordenar.</span>
+    <span data-phrase="stack.gap">La separación entre cortes no es la misma de principio a fin, así que a esta serie le falta al menos uno.</span>
+
+    <span data-phrase="pixels.none">Los píxeles de este archivo están comprimidos con {codec}, que ningún navegador sabe decodificar y para el que esta página no lleva decodificador. Todo lo demás del archivo está debajo.</span>
+    <span data-phrase="pixels.failed">No se ha podido decodificar la imagen: {reason}. La cabecera de debajo se ha leído entera.</span>
+    <span data-phrase="pixels.absent">Este archivo no lleva datos de píxel en absoluto. Es una cabecera, y todo lo que hay en ella está debajo.</span>
+    <span data-phrase="pixels.jpeg">Estos píxeles son JPEG baseline, así que los ha descomprimido el propio decodificador del navegador y lo que devuelve tiene ocho bits de profundidad. La ventana sigue funcionando; la precisión que registró el equipo no está entera.</span>
+
+    <span data-phrase="tags.count">{shown} de {total} elementos. {hidden} más.</span>
+    <span data-phrase="tags.all">Los {total} elementos de este archivo.</span>
+    <span data-phrase="tags.found">{total} elementos coinciden con &laquo;{query}&raquo;.</span>
+    <span data-phrase="tags.found.one">Un elemento coincide con &laquo;{query}&raquo;.</span>
+    <span data-phrase="tags.none">Nada coincide con &laquo;{query}&raquo;.</span>
+    <span data-phrase="tags.more">Mostrar los {count} restantes</span>
+    <span data-phrase="tags.private">elemento privado</span>
+    <span data-phrase="tags.unknown">no está en este diccionario</span>
+    <span data-phrase="tags.guessed">El archivo no lo decía; esto es lo que da el diccionario de datos para esta etiqueta.</span>
+
+    <span data-phrase="working.one">Leyendo {name}&hellip;</span>
+    <span data-phrase="working.many">Leyendo {at} de {total}&hellip;</span>
+    <span data-phrase="error.none">Nada de esto se ha podido leer como DICOM. {why} Esta herramienta lee el formato DICOM en sí, así que no tiene nada que decir sobre otros archivos.</span>
+    <span data-phrase="error.skipped.one">Se ha omitido un archivo: {files}</span>
+    <span data-phrase="error.skipped">Se han omitido {count} archivos: {files}</span>
+
+    <span data-phrase="series.number">Serie {number}</span>
+    <span data-phrase="series.files.one">1 archivo</span>
+    <span data-phrase="series.files">{count} archivos</span>
+    <span data-phrase="stack.spacing">Los cortes están a {gap} unos de otros.</span>
+
+    <span data-phrase="at.position">{at} de {total}</span>
+    <span data-phrase="net.clean">tu estudio no ha ido a ninguna parte. {total}
+      archivos cargados, todos ellos de esta misma página. {platform}</span>
+    <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta
+      herramienta no hace nunca. Vale la pena investigarlo. {platform}</span>
+    <span data-phrase="net.platform.one">Los scripts propios de la página para
+      publicidad, medición y el botón de donación se han cargado desde {hosts}
+      host; a ninguno se le ha dado un estudio, un píxel de uno ni una palabra de
+      su cabecera.</span>
+    <span data-phrase="net.platform.many">Los scripts propios de la página para
+      publicidad, medición y el botón de donación se han cargado desde {hosts}
+      hosts; a ninguno se le ha dado un estudio, un píxel de uno ni una palabra de
+      su cabecera.</span>
+    <span data-phrase="at.frame">fotograma {at} de {total}</span>
+    <span data-phrase="at.instance">instancia {number}</span>
+
+    <span data-phrase="window.file">Del archivo</span>
+    <span data-phrase="window.file.n">Del archivo, {n}</span>
+    <span data-phrase="window.full">Todo lo de este fotograma</span>
+    <span data-phrase="window.custom">Puesta a mano</span>
+    <span data-phrase="window.soft">Partes blandas</span>
+    <span data-phrase="window.lung">Pulmón</span>
+    <span data-phrase="window.bone">Hueso</span>
+    <span data-phrase="window.brain">Cerebro</span>
+    <span data-phrase="window.liver">Hígado</span>
+    <span data-phrase="window.mediastinum">Mediastino</span>
+    <span data-phrase="window.angio">Angiografía</span>
+
+    <span data-phrase="facts.frames">{count} fotogramas</span>
+    <span data-phrase="facts.nopixels">sin datos de píxel</span>
+    <span data-phrase="facts.nospacing">no consta en este archivo</span>
+    <span data-phrase="facts.signed">con signo</span>
+    <span data-phrase="facts.unsigned">sin signo</span>
+    <span data-phrase="facts.stored.one">{bits} bits, {sign}, 1 muestra por píxel, {photometric}</span>
+    <span data-phrase="facts.stored">{bits} bits, {sign}, {samples} muestras por píxel, {photometric}</span>
+    <span data-phrase="facts.range">{low} a {high}</span>
+    <span data-phrase="facts.colour">color &mdash; no hay nada medido que informar</span>
+
+    <span data-phrase="identity.clean">Nada en este archivo nombra ni numera a una persona. Los identificadores que suele llevar un estudio o no están o están vacíos.</span>
+    <span data-phrase="identity.uids">Lleva además {count} identificadores propios: los UID del estudio, la serie y la instancia. Ninguno es un nombre, y cada uno de ellos es una clave perfecta de vuelta al archivo que lo generó.</span>
+    <span data-phrase="identity.private">Y {count} elementos privados, cuyo significado no está publicado en ninguna parte: algunos equipos guardan en uno de ellos una segunda copia del nombre del paciente.</span>
+
+    <span data-phrase="copied">Copiada.</span>
+    <span data-phrase="copy.failed">Tu navegador no ha dejado copiar a la página. El botón de descarga de al lado escribe el mismo texto en un archivo.</span>
+    <span data-phrase="saved">{name} guardado.</span>
+  </div>
+</main>

--- a/locales/es/tools/dicom-viewer.toml
+++ b/locales/es/tools/dicom-viewer.toml
@@ -1,0 +1,399 @@
+#
+# Visor DICOM - Spanish.
+#
+# Overrides for tools/dicom-viewer/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Los nombres de los campos DICOM se quedan en ingles con su numero - Pixel
+# Spacing (0028,0030), Series Instance UID (0020,000E). Asi estan escritos
+# dentro del archivo y asi estan en la norma; quien vaya a comprobar un campo
+# busca exactamente esas palabras. Lo mismo vale para las sintaxis de
+# transferencia y para PS3.15.
+#
+# Esta es la pagina donde la promesa del sitio tiene el filo mas afilado: el
+# archivo es un historial medico con una imagen dentro. Las frases sobre lo que
+# lleva dentro estan traducidas con el mismo cuidado que las que dicen adonde
+# no va.
+#
+
+name = "Visor DICOM"
+heading = "Visor&nbsp;DICOM <span class=\"h1-kw\">&mdash; abre un estudio .dcm en el navegador</span>"
+tagline = "TC, resonancia, radiografía y ecografía, con la ventana, la cabecera y las medidas."
+
+title = "Visor DICOM &mdash; abre un archivo .dcm en el navegador, sin subirlo"
+description = "Abre estudios de TC, resonancia, radiografía y ecografía en el navegador. Ventana y centro, recorre una serie entera, mide en milímetros, lee cada etiqueta DICOM y comprueba qué hay en el archivo que identifica al paciente. No se sube nada."
+og_title = "Visor DICOM &mdash; abre un estudio sin subirlo"
+og_description = "Un archivo .dcm abierto en tu propio equipo: ventana y centro, la serie entera en orden, medidas en milímetros y cada etiqueta de la cabecera. Sin subidas y sin cuenta."
+og_image_alt = "Visor DICOM - abre un estudio de TC, resonancia o radiografía en el navegador"
+
+pledge = """
+    El navegador abre y decodifica el estudio: la cabecera, los píxeles, la
+    ventana, las medidas. Al otro lado de esta página no hay ningún servidor al
+    que mandar información sanitaria protegida, aunque algo aquí quisiera
+    hacerlo, y nada del archivo se le cuenta a nadie: ni el nombre del paciente,
+    ni el estudio, ni el nombre del archivo."""
+
+live_hint = """
+      No hace falta que nos creas: abre las DevTools, mira la pestaña Red y abre
+      un estudio. Ninguna petición lleva una imagen, una etiqueta ni un nombre de
+      archivo. O desconéctate de internet y ábrelo igualmente."""
+
+read_first = """
+, <code>src/dicom.js</code> para el analizador que
+      recorre el archivo, <code>src/pixels.js</code> para la decodificación de
+      los píxeles, <code>src/jpeg-lossless.js</code> para el códec que usan casi
+      todas las exportaciones hospitalarias y <code>src/window.js</code> para la
+      ventana y el centro. En ninguno de ellos hay una línea que pueda salir a la
+      red."""
+
+howto_heading = "Cómo abrir un archivo DICOM"
+
+card = """
+            Abre un estudio de TC, resonancia, radiografía o ecografía en tu
+            propio equipo. Ajusta la ventana y el centro, recorre la serie
+            entera, mide en milímetros y lee cada etiqueta de la cabecera."""
+
+[words]
+plural = "estudios"
+choose = "un estudio"
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[facts]]
+text = "Los archivos no salen de tu equipo"
+
+[[privacy]]
+title = "Tu estudio no tiene adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es nuestra. Aquí no hay ningún destino donde recoger
+      tu archivo, ni código que lo enviaría si lo hubiera. Antes esto decía
+      <code>connect-src 'none'</code>, que era absoluto; la publicidad costó eso,
+      y decirlo forma parte del trato."""
+
+[[privacy]]
+title = "Aquí esto pesa más que en las demás páginas."
+body = """
+
+      Un archivo DICOM no es una imagen con algunos metadatos encima. Es un
+      historial médico con una imagen dentro: el nombre del paciente, la fecha de
+      nacimiento, el número de historia, el número de petición, el médico que la
+      solicitó, el centro y el número de serie del equipo son campos de la
+      cabecera, y viajan con el archivo adonde vaya. Subir uno a una web para
+      verlo significa entregarle todo eso a quien lleve esa web. Eso es
+      exactamente lo que esta página existe para no hacer."""
+
+[[privacy]]
+title = "El lector son catorce archivos de este repositorio."
+body = """
+ Aquí nada usa una
+      biblioteca traída de ninguna parte. <code>src/dicom.js</code> recorre el
+      archivo, <code>src/dictionary.js</code> sabe cómo se llaman las etiquetas,
+      <code>src/pixels.js</code> convierte los bytes otra vez en medidas,
+      <code>src/rle.js</code> y <code>src/jpeg-lossless.js</code> descomprimen las
+      dos formas comprimidas que esta página sabe decodificar, y
+      <code>src/window.js</code> lleva lo medido a los grises de tu pantalla."""
+
+[[privacy]]
+title = "Los identificadores se te enumeran a ti, y a nadie más."
+body = """
+
+      La página imprime cada campo de tu archivo que nombra o acota a la persona
+      retratada, porque esa es la pregunta que necesita respuesta quien está a
+      punto de compartir un corte, y ningún visor la responde. Aparece en la
+      pantalla que tienes delante y no va a ninguna otra parte: en este
+      repositorio no hay ningún evento de analítica que lleve nada de eso, y la
+      página no podría enviarlo aunque lo hubiera."""
+
+[[privacy]]
+title = "Lee. No escribe."
+body = """
+ Aquí no hay ningún botón que cambie tu
+      archivo, ni código que pudiera hacerlo. Lo que puedes llevarte es un PNG
+      del fotograma en pantalla y una copia en texto de la cabecera, construidos
+      los dos en la página a partir de lo que ya está ahí. Tu original sigue
+      intacto en tu disco, que es además la respuesta honesta a qué pasa si
+      cierras la pestaña."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le entrega."
+body = """
+ Los scripts de publicidad
+      y de medición vienen de Google. A ninguno de los dos se le entrega nada de
+      tu archivo: ni los píxeles, ni una miniatura, ni un nombre, ni una
+      etiqueta, ni un paciente, ni un nombre de archivo. Todas las líneas que
+      analizan, decodifican o dibujan un estudio se sirven desde este origen y
+      están en el repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le entrega."
+body = """
+
+      El botón &laquo;Buy me a coffee&raquo; de la cabecera lo dibuja un script
+      de cdnjs.buymeacoffee.com y toma su tipografía de Google Fonts. Es un
+      enlace y nada más: no informa de ninguna visita y no se le entrega nada
+      sobre ti ni sobre tus archivos. No pasa nada hasta que lo pulsas, y
+      entonces estás en el sitio de otra gente."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo en esta
+      página sigue funcionando. Es la prueba más sencilla de todas: una
+      herramienta que mandara tu estudio fuera para dibujarlo se pararía en el
+      momento en que tiraras del cable."""
+
+[[howto]]
+title = "Elige los archivos."
+body = """
+ Un archivo <code>.dcm</code> suelto, o la
+      carpeta entera del disco: una TC o una resonancia son un archivo por corte,
+      y soltarlos todos a la vez es lo que vuelve a montar la serie. El navegador
+      los lee directamente de tu disco; mientras lo haces no se manda nada a
+      ninguna parte."""
+
+[[howto]]
+title = "Elige la serie."
+body = """
+ Un estudio suele llevar varias: el
+      localizador y después cada adquisición. Cada una se apila en el orden en
+      que la tomó el equipo, deducido de dónde cae cada corte en el paciente y no
+      de la numeración, que no siempre va en el mismo sentido."""
+
+[[howto]]
+title = "Ajusta la ventana."
+body = """
+ Este es el control que hace legible un
+      estudio, y el que no tiene un editor de imágenes. Arrastra por la imagen
+      para ensanchar la ventana y hacia arriba o abajo para mover su centro, o
+      elige una de las ventanas con nombre &mdash; pulmón, hueso, cerebro, partes
+      blandas &mdash; en una TC, donde las unidades son las mismas en cualquier
+      equipo del mundo."""
+
+[[howto]]
+title = "Recorre la pila."
+body = """
+ El deslizador de debajo de la imagen avanza
+      por los cortes, y las flechas del teclado hacen lo mismo una vez que has
+      pulsado sobre la imagen. Un archivo multifotograma &mdash; un lazo de
+      ecografía, una angiografía &mdash; se reproduce con el botón de al
+      lado."""
+
+[[howto]]
+title = "Mide algo."
+body = """
+ Cambia a Medir y arrastra una línea. Donde el
+      archivo dice a qué distancia están sus píxeles, la respuesta va en
+      milímetros y tiene en cuenta los píxeles que no son cuadrados; donde no lo
+      dice, la respuesta va en píxeles y lo advierte, en vez de inventarse una
+      escala."""
+
+[[howto]]
+title = "Lee la cabecera."
+body = """
+ Cada elemento del archivo, con su número,
+      cómo lo llama la norma y qué contiene, y todo ello se puede buscar. Encima,
+      la lista de lo que en este archivo concreto identifica al paciente, que es
+      bastante más que el nombre."""
+
+[[howto]]
+title = "Llévate lo que necesites."
+body = """
+ El fotograma en pantalla como
+      PNG, con la ventana que hayas puesto y sin nada grabado encima, o la
+      cabecera entera como texto plano. Los dos se construyen en la página a
+      partir de lo que ya está ahí."""
+
+[[faq]]
+q = "¿Se sube mi estudio a alguna parte?"
+a = """
+        No. El archivo lo lee, decodifica y dibuja tu propio navegador en tu
+        propio equipo. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es nuestra.
+        Desconéctate de la red y sigue abriendo estudios.
+        <br><br>
+        Aquí eso vale más que en cualquier otra página del sitio. Un archivo
+        DICOM lleva en la cabecera el nombre del paciente, su fecha de nacimiento
+        y su número de historia, así que subir uno a un visor es entregarle a un
+        desconocido un historial médico, no una imagen."""
+
+[[faq]]
+q = "¿Qué archivos DICOM puede abrir?"
+a = """
+        Archivos sin comprimir en cualquiera de las tres sintaxis de
+        transferencia básicas &mdash; implicit y explicit little endian, y la
+        big-endian retirada &mdash; además de deflated, RLE Lossless, JPEG
+        baseline y JPEG Lossless, que es con lo que están comprimidos la mayoría
+        de los estudios de TC y resonancia de un disco hospitalario.
+        <br><br>
+        No puede decodificar JPEG 2000, JPEG-LS ni las sintaxis MPEG y HEVC que
+        se usan para vídeo. Esas necesitan códecs que son megabytes de biblioteca
+        compilada, y una página que descargara uno cuando hiciera falta no sería
+        una página que funciona sin conexión. Un archivo en alguna de ellas se
+        abre igualmente: la cabecera se lee y se muestra entera, y en lugar de la
+        imagen aparece una línea que nombra el códec, en vez de un icono de
+        imagen rota que no te dice nada."""
+
+[[faq]]
+q = "¿Qué son la ventana y el centro, y para qué los necesito?"
+a = """
+        Un corte de TC contiene unos cuatro mil valores distintos y tu pantalla
+        muestra doscientos cincuenta y seis grises. La ventana es la decisión de
+        qué tramo de ese rango se lleva todos: por debajo todo es negro, por
+        encima todo es blanco, y lo que queda en medio se reparte entre los
+        grises.
+        <br><br>
+        Por eso el mismo archivo parece un estudio distinto con dos ajustes, y por
+        eso el pulmón y el hueso no se pueden ver a la vez. En una TC los números
+        son unidades Hounsfield, definidas en términos absolutos &mdash; el agua
+        es 0 y el aire es &minus;1000 &mdash;, así que las ventanas con nombre de
+        esta página llevan los mismos números que usa un radiólogo en su estación
+        de trabajo. En una resonancia o una ecografía no existe esa escala, y la
+        ventana con la que se abre es la que pide el propio archivo."""
+
+[[faq]]
+q = "¿Por qué dice que mi medida está en píxeles?"
+a = """
+        Porque ese archivo no dice cómo de grande es un píxel. Eso lo lleva Pixel
+        Spacing (0028,0030), en milímetros, y muchísimas ecografías, documentos
+        escaneados y capturas secundarias sencillamente no lo tienen.
+        <br><br>
+        Donde está, la medida va en milímetros y cada eje se mide con su propio
+        espaciado, que es lo que importa en las imágenes cuyos píxeles no son
+        cuadrados. Donde no está, la respuesta honesta es un recuento de píxeles,
+        y eso es lo que aparece, en vez de elegir una escala y presentar el
+        resultado como una longitud."""
+
+[[faq]]
+q = "Me ha abierto la carpeta como varias series. ¿Por qué?"
+a = """
+        Porque eso es lo que hay dentro. Un estudio se compone de series &mdash;
+        el localizador y después cada adquisición o reconstrucción &mdash; y cada
+        archivo dice a cuál pertenece en Series Instance UID (0020,000E). La
+        lista desplegable se construye a partir de eso y no de la carpeta, que
+        suele tenerlas todas mezcladas en una única lista de nombres.
+        <br><br>
+        Dentro de una serie, los cortes se ordenan por dónde cae cada uno en el
+        paciente, deducido de Image Position e Image Orientation. Instance Number
+        sería la clave evidente y aquí es el recurso de reserva: la asigna lo que
+        haya escrito los archivos y no tiene por qué ir en el mismo sentido que el
+        paciente."""
+
+[[faq]]
+q = "¿Qué significa la lista de &laquo;qué identifica al paciente&raquo;?"
+a = """
+        Es cada campo de tu archivo que nombra a la persona del estudio, o que
+        acota quién puede ser, leído de este archivo en tu equipo. La lista sale
+        de PS3.15 de la norma DICOM, la parte que dice qué tiene que
+        desaparecer antes de que un conjunto de datos pueda llamarse
+        anonimizado.
+        <br><br>
+        Está ahí porque lo que la gente calcula mal no es que un estudio lleve un
+        nombre. Es cuánto más lleva: la fecha de nacimiento, el número de
+        petición, el médico que la solicitó, el centro, el número de serie del
+        equipo y los UID del estudio, que son claves perfectas de vuelta al
+        archivo que lo generó. Un estudio al que solo se le ha borrado el nombre
+        no es anónimo.
+        <br><br>
+        Esta herramienta solo te lo enseña. No escribe nada y no cambia nada, así
+        que tampoco puede quitar nada de eso."""
+
+[[faq]]
+q = "¿Puede anonimizar un estudio?"
+a = """
+        No, y no finge lo contrario. Esta página lee; no tiene código que escriba
+        un archivo DICOM. Lo que hace es decirte exactamente qué hay dentro del
+        tuyo, que es la parte difícil de averiguar y en la que la gente se
+        equivoca.
+        <br><br>
+        Una herramienta que quite los identificadores es otro trabajo, y con el
+        listón mucho más alto: tiene que reescribir el archivo sin tocar los
+        píxeles, sustituir los UID de forma coherente en un estudio entero y
+        acertar con los elementos privados en los que algunos equipos esconden una
+        segunda copia del nombre. Está en la hoja de ruta del sitio, y no
+        atornillada a un visor."""
+
+[[faq]]
+q = "¿Puede abrir un archivo sin extensión .dcm, o uno dañado?"
+a = """
+        Las dos cosas, sí. La extensión no se mira: lo que se comprueba es el
+        archivo. Un conjunto de datos escrito sin el preámbulo habitual de 128
+        bytes &mdash; que es el aspecto de un estudio sacado directamente de la
+        red &mdash; se lee deduciendo su codificación de su primer elemento, y la
+        página avisa de que eso es lo que ha hecho.
+        <br><br>
+        Un archivo que se corta a medias se lee hasta donde llega. Todo lo
+        anterior al daño se muestra, con una nota que dice en qué byte se paró.
+        Ese es justo el caso en que más falta hace un visor, así que tirar el
+        archivo entero por sus últimos doce bytes sería el comportamiento
+        equivocado."""
+
+[[faq]]
+q = "¿Es un visor diagnóstico?"
+a = """
+        No. No es un producto sanitario, no ha pasado ninguna evaluación
+        reglamentaria y nada de lo que hay aquí debería usarse para tomar una
+        decisión clínica. Tu pantalla no está calibrada, el navegador no es una
+        cadena de representación validada, y ninguna de las dos cosas se arregla
+        desde dentro de una página web.
+        <br><br>
+        Para lo que sí sirve es para todo lo demás por lo que se abre un estudio:
+        comprobar qué hay en un disco, sacar un corte para una clase o un
+        artículo, leer una cabecera, averiguar por qué otro programa rechaza el
+        archivo y ver qué lleva un estudio sobre la persona retratada."""
+
+[[faq]]
+q = "¿Cambia mi archivo?"
+a = """
+        No. Esta herramienta solo lee. No hay archivo de salida, ni recodificación,
+        ni ningún botón que escriba un DICOM: lo que puedes descargar es un PNG
+        del fotograma en pantalla y una copia en texto plano de la cabecera. Tu
+        original sigue intacto en tu disco."""
+
+[[faq]]
+q = "¿Es gratis y hace falta cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni registro, ni prueba. Tampoco hay límite de
+        tamaño ni de cuántos archivos abres más allá de la memoria de tu propio
+        equipo. El sitio lleva publicidad, que es lo que lo paga; a los anuncios
+        no se les da nada sobre tu archivo."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Es además la forma más sencilla de comprobar que no se sube
+        nada: una herramienta que mandara tu estudio fuera para dibujarlo se
+        pararía en el momento en que tiraras del cable."""
+
+[schema]
+description = "Abre estudios DICOM (.dcm) en el navegador: TC, resonancia, radiografía y ecografía, con ventana y centro, la serie entera en orden, medidas en milímetros y cada etiqueta de la cabecera. No se sube nada."
+features = [
+  "Abre archivos de TC, resonancia, radiografía, ecografía, PET y captura secundaria",
+  "Ventana y centro arrastrando, escribiendo o con un preajuste de TC con nombre",
+  "Una carpeta entera se agrupa en series y se ordena por la posición en el paciente",
+  "Los archivos multifotograma se reproducen en bucle",
+  "Mide en milímetros, teniendo en cuenta los píxeles no cuadrados",
+  "Lee el valor del píxel bajo el cursor en unidades Hounsfield",
+  "Cada etiqueta DICOM con su nombre y su valor, y se puede buscar",
+  "Enumera qué hay en el archivo que identifica al paciente, según el perfil de PS3.15",
+  "Decodifica RLE, JPEG baseline y JPEG Lossless sin biblioteca incorporada",
+  "Guarda el fotograma como PNG y la cabecera como texto plano",
+  "Funciona sin conexión; sin subidas, sin cuenta y sin tocar tu archivo",
+]
+
+[picker]
+title = "Suelta aquí un estudio"
+hint = "o pulsa para elegir &mdash; un archivo .dcm, o una carpeta entera de ellos"

--- a/locales/es/tools/document-scanner.html
+++ b/locales/es/tools/document-scanner.html
@@ -1,0 +1,380 @@
+<!--
+  tools/document-scanner/body.html, in Spanish.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Paso 1 &mdash; las fotos -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige las fotos</h2>
+
+    <p class="card-lede">
+      Una foto de cada hoja, tomada desde cualquier punto por encima. La hoja
+      entera tiene que estar en el encuadre, y conviene que las cuatro esquinas
+      se vean o casi; todo lo demás, el ángulo, la sombra, la mesa sobre la que
+      está, es para lo que existe esta herramienta. Añade varias y se convierten
+      en las páginas de un documento, en el orden en que las añadas.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="strip-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="detect-all" class="ghost">Volver a buscar en todas</button>
+        <button type="button" id="clear-all" class="ghost danger">Quitar todas</button>
+      </div>
+    </div>
+
+    <ul id="page-strip" class="page-strip"></ul>
+  </section>
+
+  <!-- Paso 2 &mdash; las esquinas -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Pon las esquinas sobre la hoja</h2>
+
+    <p id="edit-empty" class="field-summary">
+      Elige una foto y aparecerá aquí, con sus cuatro esquinas ya encontradas.
+    </p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Pulsa en cualquier punto de la foto y la esquina más cercana viene a tu
+        dedo; arrástrala hasta la esquina de la hoja. Con <kbd>Tab</kbd> llegas a
+        una esquina desde el teclado, las flechas la mueven un píxel y
+        <kbd>Shift</kbd> diez. Nada de esto es definitivo: el escaneo se toma de
+        donde acaben las cuatro esquinas.
+      </p>
+
+      <!-- The photo is a canvas rather than an <img> because it is drawn at
+           screen size from the decoded picture, and because the same canvas is
+           what the corner finder reads. The outline over it is an SVG polygon
+           in percentages, so it needs no redraw when the window changes. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="photo"></canvas>
+        </div>
+      </div>
+
+      <p id="detect-note" class="hint-line" role="status" aria-live="polite"></p>
+
+      <div class="frame-actions">
+        <button type="button" id="detect-one" class="ghost">Volver a buscar las esquinas</button>
+        <button type="button" id="whole-photo" class="ghost">Usar la foto entera</button>
+        <button type="button" id="turn-left" class="ghost">Girar a la izquierda</button>
+        <button type="button" id="turn-right" class="ghost">Girar a la derecha</button>
+        <button type="button" id="undo" class="ghost" disabled>Deshacer</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Paso 3 &mdash; la limpieza -->
+  <section class="card" id="clean-card">
+    <h2><span class="step">3</span> Límpiala</h2>
+
+    <p id="clean-empty" class="field-summary">
+      La hoja enderezada aparece aquí en cuanto haya una foto que enderezar.
+    </p>
+
+    <div id="clean-controls" hidden>
+      <p class="card-lede">
+        Lo de abajo es el resultado real, producido por el mismo código que
+        escribe el archivo: enderezado y con la luz desigual ya dividida. En
+        pantalla se dibuja al tamaño de la pantalla mientras eliges; el archivo
+        se hace a la resolución de la propia foto.
+      </p>
+
+      <div class="result-wrap">
+        <canvas id="scan-preview" class="scan-preview"></canvas>
+        <p id="scan-busy" class="progress-label" role="status" aria-live="polite" hidden>
+          Enderezando&hellip;
+        </p>
+      </div>
+
+      <ul id="scan-facts" class="result-facts"></ul>
+
+      <fieldset class="options" id="mode-group">
+        <legend>Qué hacer con la luz y con el color</legend>
+
+        <label class="check">
+          <input type="radio" name="mode" value="colour" checked>
+          <span>
+            <strong>Color, igualado</strong>
+            <span class="check-note">
+              El papel se mide a lo largo de la hoja y se divide, así que la
+              sombra desaparece y el papel vuelve a ser blanco, mientras que un
+              sello, una firma en tinta azul o una línea subrayada conservan el
+              color que tenían. Es el que hay que usar cuando el color forma
+              parte del documento.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="grey">
+          <span>
+            <strong>Escala de grises</strong>
+            <span class="check-note">
+              El mismo igualado, sin el color. Más pequeño que el color y más
+              amable con una fotografía o una firma de lo que es el blanco y
+              negro.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="mono">
+          <span>
+            <strong>Blanco y negro</strong>
+            <span class="check-note">
+              Cada píxel se decide contra su propio entorno en vez de contra un
+              número único para toda la hoja, y eso es lo que mantiene legible la
+              escritura que cae en una sombra. Es lo que hace pequeño un escaneo:
+              un contrato de veinte páginas sale así por debajo del megabyte, y
+              como fotografías ronda los quince. No tiene medios tonos, así que
+              nada con una fotografía debería usarlo.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="photo">
+          <span>
+            <strong>Dejarla como está</strong>
+            <span class="check-note">
+              Enderezada y nada más. Para una hoja en la que importa el propio
+              papel: algo antiguo, algo de color, una fotografía.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row" id="strength-row">
+          <label for="strength">Con cuánta fuerza</label>
+          <div class="inline-pair">
+            <input type="range" id="strength" min="0" max="100" step="5" value="50">
+            <output id="strength-value">50</output>
+          </div>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <p class="hint-line">
+        El ajuste vale para todas las páginas. Unas páginas limpiadas de forma
+        distinta dentro de un mismo documento parecen dos documentos.
+      </p>
+    </div>
+  </section>
+
+  <!-- Paso 4 &mdash; el archivo -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Guarda el documento</h2>
+
+    <p class="card-lede">
+      El PDF se escribe aquí, en la memoria de esta página, página a página. Al
+      otro lado de esta herramienta no hay ningún servidor al que mandar una
+      nómina, un pasaporte o un contrato, ni código que lo enviaría si lo
+      hubiera.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Tamaño de página</label>
+        <select id="page-size">
+          <option value="fit" selected>Ajustar la hoja a la propia página</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Carta &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Oficio &mdash; 8,5 &times; 14 in</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+        </select>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Resolución de impresión</label>
+        <select id="dpi">
+          <option value="150">150 DPI</option>
+          <option value="200" selected>200 DPI</option>
+          <option value="300">300 DPI &mdash; escáner de oficina</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          De qué tamaño se dice que es una hoja hecha con un número dado de
+          píxeles. Cambia el tamaño al que se imprime el documento, y ni un solo
+          píxel del escaneo.
+        </p>
+      </div>
+
+      <div class="field" id="margin-field" hidden>
+        <label for="margin">Margen</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="50" step="1" value="10"
+                 aria-label="Margen en milímetros">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Lado más largo</label>
+        <select id="max-side">
+          <option value="1600">1600 píxeles &mdash; pequeño</option>
+          <option value="2400" selected>2400 píxeles</option>
+          <option value="3500">3500 píxeles</option>
+          <option value="0">Todo lo grande que permita la foto</option>
+        </select>
+        <p class="field-note">
+          Un techo para la hoja enderezada. La foto de una hoja lleva muchos más
+          píxeles de los que la hoja vale, y 2400 en el lado largo son unos 200
+          DPI en A4.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Calidad</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="82">
+          <output id="quality-value">82%</output>
+        </div>
+        <p class="field-note">
+          Para los modos color y escala de grises, que se guardan como JPEG. Las
+          páginas en blanco y negro se guardan de forma exacta, así que esto no
+          les hace nada.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="title">Título del documento <span class="optional">(opcional)</span></label>
+        <input type="text" id="title" maxlength="120" placeholder="En blanco, el PDF no lleva título">
+        <p class="field-note">
+          Lo único que se escribe en el documento además de las páginas. No hay
+          fecha, ni autor, ni nada sobre este equipo. Mira
+          <code>src/document.js</code>.
+        </p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save-pdf" class="primary big" disabled>Guardar como PDF</button>
+      <button type="button" id="save-images" class="ghost big" disabled>Guardar las páginas como imágenes</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden></p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>El archivo terminado</h3>
+        <a id="download" class="primary as-button" href="#" download>Descargar</a>
+      </div>
+      <ul id="result-facts" class="result-facts"></ul>
+      <p class="hint-line">
+        Ábrelo antes de mandarlo. Lo que hay en el documento es lo que había en
+        pantalla en el paso 3, página por página.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Every sentence the JavaScript puts on this page. They live here rather than
+    in src/, because src/ is copied byte for byte into all eleven languages and
+    a sentence written there would be English in ten of them. See
+    shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="detect.found">Se han encontrado las cuatro esquinas.
+      Compruébalas y arrastra las que hayan caído mal.</span>
+    <span data-phrase="detect.unsure">Los bordes de la hoja no estaban lo
+      bastante claros como para estar seguros. Estas esquinas son una suposición:
+      arrástralas sobre la hoja antes de seguir.</span>
+    <span data-phrase="detect.nothing">No se ha podido distinguir ninguna hoja en
+      esta foto, así que las esquinas están en sus bordes. Arrástralas sobre la
+      hoja.</span>
+    <span data-phrase="detect.flat">En esta imagen no hay nada que encontrar: no
+      tiene ni un borde.</span>
+    <span data-phrase="detect.tiny">Esta imagen es demasiado pequeña para
+      encontrar una hoja dentro.</span>
+    <span data-phrase="detect.edited">Estas esquinas ya son tuyas. &laquo;Volver
+      a buscar las esquinas&raquo; mide la foto otra vez desde cero.</span>
+
+    <span data-phrase="corner.tl">Esquina superior izquierda</span>
+    <span data-phrase="corner.tr">Esquina superior derecha</span>
+    <span data-phrase="corner.br">Esquina inferior derecha</span>
+    <span data-phrase="corner.bl">Esquina inferior izquierda</span>
+    <span data-phrase="corner.at">{corner}, a {x} de ancho y {y} de alto. Las
+      flechas la mueven, y Shift con ellas la mueve diez píxeles de una vez.</span>
+
+    <span data-phrase="page.select">Editar la página {index}</span>
+    <span data-phrase="page.remove">Quitar la página {index}</span>
+    <span data-phrase="page.earlier">Mover la página {index} antes</span>
+    <span data-phrase="page.later">Mover la página {index} después</span>
+    <span data-phrase="page.count">{count} página</span>
+    <span data-phrase="page.counts">{count} páginas</span>
+
+    <span data-phrase="paper.a">A4 o A5</span>
+    <span data-phrase="paper.letter">Carta de EE. UU.</span>
+    <span data-phrase="paper.legal">Oficio de EE. UU.</span>
+    <span data-phrase="paper.card">una tarjeta de visita</span>
+    <span data-phrase="shape.known">La hoja ha salido {ratio}, que es la forma de
+      {paper}.</span>
+    <span data-phrase="shape.sideways">La hoja ha salido {ratio}, que es la forma
+      de {paper} en horizontal.</span>
+    <span data-phrase="shape.unknown">La hoja ha salido {ratio}, que no es un
+      tamaño normalizado.</span>
+
+    <span data-phrase="method.perspective">La forma se ha deducido de la
+      perspectiva de la foto, así que es la forma de la hoja y no la que aparentaba
+      en la imagen.</span>
+    <span data-phrase="method.edges">La foto se tomó perpendicular, así que la
+      forma está medida directamente en los bordes.</span>
+
+    <span data-phrase="quality.good">{width} por {height} píxeles, unos {dpi} DPI
+      en una hoja de ese tamaño: suficiente para imprimir.</span>
+    <span data-phrase="quality.fair">{width} por {height} píxeles, unos {dpi} DPI
+      en una hoja de ese tamaño. Bien en pantalla, algo blando en papel.</span>
+    <span data-phrase="quality.low">{width} por {height} píxeles, unos {dpi} DPI
+      en una hoja de ese tamaño. Acércate más si esto hay que imprimirlo.</span>
+    <span data-phrase="quality.pixels">{width} por {height} píxeles.</span>
+    <span data-phrase="coverage.note">La hoja ocupaba el {percent}% de la foto.</span>
+    <span data-phrase="coverage.small">La hoja ocupaba solo el {percent}% de la
+      foto, así que casi todo lo fotografiado era mesa. Más cerca la próxima
+      vez.</span>
+
+    <span data-phrase="strength.gentle">Suave: se iguala el papel y poco más.
+      Para una hoja con lápiz flojo o con una fotografía.</span>
+    <span data-phrase="strength.middling">El ajuste habitual: el papel vuelve a
+      blanco y el texto impreso vuelve a negro.</span>
+    <span data-phrase="strength.hard">Fuerte: todo lo gris se empuja a negro o a
+      blanco. Lo más limpio en una hoja impresa normal, y destructivo en cualquier
+      cosa con una imagen.</span>
+
+    <span data-phrase="busy.page">Página {done} de {total}&hellip;</span>
+    <span data-phrase="busy.writing">Escribiendo el documento&hellip;</span>
+
+    <span data-phrase="result.pdf">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.images">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.mono">Guardado a un bit por píxel y comprimido de
+      forma exacta, y por eso es así de pequeño.</span>
+    <span data-phrase="result.jpeg">Las páginas se guardan como JPEG con la
+      calidad que has elegido.</span>
+    <span data-phrase="result.png">Las páginas se guardan como PNG, que es sin
+      pérdida y es lo que quiere una imagen de dos colores: JPEG sería a la vez
+      más grande y borroso alrededor de cada letra.</span>
+    <span data-phrase="result.clean">Sin fecha, sin autor, sin nombre de equipo:
+      lo único que hay en el documento además de las páginas es el nombre de esta
+      herramienta.</span>
+
+    <span data-phrase="size.fit">Cada hoja toma el tamaño que su propia página
+      tiene de verdad, a la resolución de arriba. Nada se rodea de bandas.</span>
+    <span data-phrase="size.named">Cada página se coloca en una hoja {name},
+      dentro del margen, con la forma que le haya salido.</span>
+
+    <span data-phrase="error.decode">Este navegador no ha podido abrir {name}. Si
+      es una foto HEIC de un iPhone, conviértela primero.</span>
+    <span data-phrase="error.none">Elige antes al menos una foto.</span>
+    <span data-phrase="error.failed">Algo ha salido mal al hacer el archivo:
+      {detail}</span>
+  </div>
+</main>

--- a/locales/es/tools/document-scanner.toml
+++ b/locales/es/tools/document-scanner.toml
@@ -1,0 +1,297 @@
+#
+# Escáner de documentos - Spanish.
+#
+# Overrides for tools/document-scanner/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Los nombres de la literatura se quedan como estan - Zhang y He para la
+# recuperacion de la proporcion, Sauvola para el umbral. Quien vaya a
+# consultarlo busca exactamente esos nombres.
+#
+
+name = "Escáner de documentos"
+heading = "Escáner&nbsp;de&nbsp;documentos <span class=\"h1-kw\">&mdash; una foto de una hoja, enderezada</span>"
+tagline = "Fotografía la hoja. Te devuelve algo que parece escaneado."
+
+title = "Escáner de documentos &mdash; de foto a PDF escaneado, sin subir nada"
+description = "Convierte la foto de una hoja hecha con el teléfono en un PDF enderezado y con luz uniforme. Las esquinas se buscan solas, la perspectiva se deshace y la sombra se divide. Funciona entero en el navegador: no se sube nada."
+og_title = "Escanea un documento con una foto, sin subirlo"
+og_description = "Las esquinas de la hoja se encuentran, el ángulo se deshace y la luz desigual se divide, en tu propio navegador. Lo que la gente fotografía así es un pasaporte, una nómina o un contrato, que es justo lo que no debería subirse."
+og_image_alt = "Escáner de documentos - una foto de una hoja, enderezada y limpiada, sin subirla"
+
+pledge = """
+    El navegador decodifica la foto, la endereza, la limpia y la escribe en un
+    PDF, sin más que aritmética y los códecs que ya trae. Esta herramienta no
+    tiene ninguna función de red, ni para pedir ni para enviar, y aquí eso
+    importa por lo que la gente fotografía: un pasaporte, una nómina, un
+    contrato de alquiler, un formulario que una oficina pidió
+    &laquo;escaneado&raquo;."""
+
+live_hint = """
+      No hace falta que nos creas: abre las DevTools, mira la pestaña Red y
+      escanea una hoja. Ninguna petición lleva una foto, una miniatura, un nombre
+      de archivo ni la posición de una sola esquina. O desconéctate de internet y
+      escanéala igualmente."""
+
+read_first = """
+, <code>src/detect.js</code> para cómo se
+      encuentran las esquinas sin ningún modelo, <code>src/warp.js</code> para el
+      enderezado y <code>src/clean.js</code> para cómo se divide la luz
+      desigual."""
+
+howto_heading = "Cómo escanear un documento con la cámara del teléfono"
+
+card = """
+            Una foto de una hoja, enderezada y limpiada hasta convertirse en un
+            documento. Las esquinas se buscan solas, el ángulo se deshace y la
+            sombra se divide."""
+
+[words]
+plural = "documentos"
+choose = "una foto de una hoja"
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Tus documentos no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es nuestra. Aquí no hay ningún destino donde recoger
+      tus fotos, ni código que las enviaría si lo hubiera."""
+
+[[privacy]]
+title = "No hay modelo, así que no hay nada que descargar ni nada que preguntar."
+body = """
+ Encontrar las cuatro
+      esquinas de una hoja es aritmética: el gradiente de la imagen, una votación
+      de las rectas que hay en ella y una comprobación de qué hay realmente
+      debajo de cada lado del rectángulo que gana. Sin pesos, sin motor de
+      inferencia, sin nada que se descargue la primera vez y sin nada que se
+      comporte distinto con el documento de otra persona que con el tuyo. Mira
+      <code>src/detect.js</code>."""
+
+[[privacy]]
+title = "El documento no lleva fecha, ni autor, ni nombre de equipo."
+body = """
+ Un escaneo es algo que la
+      gente manda a otra gente, normalmente porque una oficina lo ha pedido. Lo
+      único que se escribe en el PDF además de las propias páginas es el nombre
+      de esta herramienta, y un título si escribes uno. No hay fecha de creación,
+      ni autor, ni número de serie, ni nada sacado de tu reloj, de tus nombres de
+      archivo o de tu equipo. Mira <code>src/document.js</code>."""
+
+[[privacy]]
+title = "Aquí nada pide nada."
+body = """
+ No hay ningún <code>fetch</code>, ni
+      <code>XMLHttpRequest</code>, ni <code>sendBeacon</code> en ninguna parte de
+      <code>src/</code>. El trabajo es un <code>getImageData</code>, unos cuantos
+      bucles sobre los bytes y el propio codificador JPEG del navegador, y todo
+      eso ya está instalado en tu equipo."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta no
+      cambia, porque nunca hubo un paso de red dentro. Es la prueba más sencilla
+      de todas, y la que conviene hacer antes de escanear un pasaporte."""
+
+[[howto]]
+title = "Fotografía la hoja."
+body = """
+ Desde arriba, con la hoja entera en el
+      encuadre y las cuatro esquinas visibles o casi. No hace falta que sea
+      perpendicular ni que la luz sea uniforme: el ángulo y la sombra son para lo
+      que existe esta herramienta. Lo que sí importa es llenar el encuadre; una
+      hoja fotografiada desde el otro lado de la habitación no tiene detalle que
+      recuperar."""
+
+[[howto]]
+title = "Comprueba las cuatro esquinas."
+body = """
+ Se encuentran solas al leer la
+      foto, y la página lo dice cuando no está segura: la de una hoja sobre una
+      mesa del mismo color es una orilla realmente difícil de ver. Pulsa en
+      cualquier punto de la foto y la esquina más cercana viene a tu dedo, o
+      llega a una con <kbd>Tab</kbd> y muévela con las flechas."""
+
+[[howto]]
+title = "Decide qué hacer con la luz."
+body = """
+ &laquo;Color, igualado&raquo; mide
+      el papel a lo largo de la hoja y lo divide, así que la sombra desaparece y
+      un sello o una firma conservan su color. &laquo;Blanco y negro&raquo; va
+      más allá y es lo que hace que un escaneo quepa en un correo. Lo que ves en
+      pantalla es el resultado real, producido por el mismo código que escribe el
+      archivo."""
+
+[[howto]]
+title = "Añade las demás páginas."
+body = """
+ Cada foto que añadas se convierte en
+      otra página del mismo documento, en el orden de la lista, y cada una
+      conserva sus propias esquinas. Las flechas de una página de la tira la
+      mueven antes o después."""
+
+[[howto]]
+title = "Guarda el PDF y ábrelo antes de mandarlo."
+body = """
+ El documento se escribe
+      aquí, en la memoria de esta página. No se ha subido nada para hacerlo, y no
+      se ha informado de nada a ninguna parte."""
+
+[[faq]]
+q = "¿Se sube mi documento a alguna parte?"
+a = """
+        No. La foto la decodifica, endereza, limpia y escribe en un PDF tu propio
+        navegador en tu propio equipo. Esta herramienta no tiene ninguna función
+        de red, nunca pide ni envía nada, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es nuestra. Carga
+        la página una vez, desconéctate de internet y sigue funcionando."""
+
+[[faq]]
+q = "¿Cómo encuentra las esquinas de la hoja sin un modelo?"
+a = """
+        Buscando las cuatro rectas largas de las que se compone un rectángulo. La
+        foto se reduce, se toma el gradiente &mdash; dónde cambia la imagen y en
+        qué dirección &mdash; y cada píxel que cae sobre un borde vota por la
+        recta sobre la que estaría. Las rectas fuertes se emparejan en
+        rectángulos candidatos, y cada candidato se puntúa recorriendo sus cuatro
+        lados y preguntando cuánto de cada uno tiene realmente un borde debajo, y
+        si los cuatro son la frontera de una misma cosa: una hoja es más clara
+        que lo que la rodea, o más oscura, pero es la misma en los cuatro lados, y
+        eso es lo que impide confundir una línea de texto con el borde inferior de
+        la hoja. No hay pesos, no se descarga nada, y la aritmética es la misma
+        para cualquier documento que pase por ella."""
+
+[[faq]]
+q = "Las esquinas que ha encontrado están mal. ¿Y ahora?"
+a = """
+        Arrástralas. Las esquinas son una posición de partida y nunca una
+        decisión: el escaneo se toma de donde acaben las cuatro. Pulsa en
+        cualquier punto de la foto y la esquina más cercana salta a tu dedo, que
+        es más fácil que acertar con un tirador pequeño, y las flechas mueven la
+        esquina enfocada píxel a píxel. La página además te dice cuándo las
+        esquinas son una suposición y no un hallazgo, y marca esa página en la
+        tira: el motivo habitual es una hoja apoyada en una mesa más o menos de su
+        mismo color, porque ahí de verdad casi no hay borde que encontrar."""
+
+[[faq]]
+q = "¿Por qué la hoja enderezada sale con la forma correcta y no achatada?"
+a = """
+        Porque la forma se recupera de la perspectiva en vez de medirse en los
+        bordes. Una hoja fotografiada en ángulo tiene el borde lejano escorzado,
+        así que el método evidente &mdash; tomar el par de bordes opuestos más
+        largo y llamar a eso la proporción &mdash; produce un A4 visiblemente
+        achatado, que es lo que dan la mayoría de los escáneres web. La foto de un
+        rectángulo lleva en realidad información suficiente para recuperar tanto
+        la proporción del rectángulo como la distancia focal de la cámara, con tal
+        de que sea una cámara corriente; es un resultado de Zhang y He de 2003, y
+        es lo que hace <code>src/geometry.js</code>. Cuando la foto se ha tomado
+        perpendicular no hay perspectiva de la que partir y tampoco hace falta,
+        porque entonces los bordes son exactos: ahí recurre a ellos, y la página
+        dice cuál de los dos ha respondido."""
+
+[[faq]]
+q = "¿Qué le hace exactamente a la imagen eso de &laquo;limpiar&raquo;?"
+a = """
+        Divide la luz. El brillo del propio papel se mide a lo largo de la hoja
+        &mdash; una rejilla de casillas, y en cada casilla un percentil alto del
+        brillo, que el texto es demasiado oscuro y demasiado escaso para mover
+        &mdash; y cada píxel se divide por el papel estimado en ese punto. Lo que
+        queda es la tinta, con luz uniforme, sin la sombra y sin la caída hacia
+        los bordes. No es lo mismo que subir el contraste: subir el contraste de
+        una hoja fotografiada deja la parte clara en blanco, la oscura en negro y
+        la escritura de la parte oscura ilegible, y por eso el
+        &laquo;autonivel&raquo; empeora estas imágenes en lugar de mejorarlas."""
+
+[[faq]]
+q = "¿Por qué el modo blanco y negro es tanto más pequeño?"
+a = """
+        Porque una imagen con dos colores es de verdad una fracción de los datos
+        de una imagen con dieciséis millones, y aquí se guarda así: un bit por
+        píxel, empaquetados de ocho en ocho y comprimidos de forma exacta, en vez
+        de como un JPEG de una imagen en blanco y negro. En las mismas páginas
+        sale unas dieciocho veces más pequeño que el modo en color, así que un
+        contrato de veinte páginas se queda por debajo del megabyte en lugar de
+        rondar los quince. El umbral es el de Sauvola, que decide cada píxel
+        contra la media y la dispersión de su propio vecindario en vez de contra
+        un número único para toda la hoja, y eso es lo que mantiene legible la
+        escritura dentro de una sombra. No tiene medios tonos, así que una hoja
+        con una fotografía debería usar alguno de los otros modos."""
+
+[[faq]]
+q = "¿Puedo meter varias páginas en un PDF?"
+a = """
+        Sí. Cada foto que añadas se convierte en otra página, en el orden de la
+        lista, y cada página conserva sus propias esquinas, así que un montón de
+        hojas fotografiadas una detrás de otra se convierte en un documento. Las
+        flechas de cada página de la tira la mueven antes o después. El ajuste de
+        limpieza es común a todas a propósito: unas páginas limpiadas de forma
+        distinta dentro de un mismo documento parecen dos documentos."""
+
+[[faq]]
+q = "¿Lee el texto, para que pueda buscar dentro del PDF?"
+a = """
+        No. No hay capa de texto ni reconocimiento de caracteres: lo que sale es
+        una imagen de la hoja sobre una página. Hacerlo bien significaría un motor
+        de OCR, que son decenas de megabytes de modelo que descargar, y un escáner
+        de documentos que se bajara un modelo antes de poder leer tu nómina sería
+        un escáner de documentos con un motivo para llamar a casa a propósito de
+        nóminas. Si necesitas el texto, el modo blanco y negro produce justo el
+        tipo de archivo con el que mejor trabaja el software de OCR de tu propio
+        equipo."""
+
+[[faq]]
+q = "Ha salido borroso. ¿Por qué?"
+a = """
+        Casi siempre porque la hoja era pequeña dentro de la foto. El panel de
+        debajo de la vista previa dice cuánto del encuadre ocupaba la hoja y a
+        cuántos puntos por pulgada equivale eso aproximadamente en una hoja de ese
+        tamaño: por debajo de unos 150 DPI un escaneo impreso se ve blando, y
+        contra el detalle que nunca estuvo en el archivo no puede hacer nada
+        ninguna herramienta. Acércate en vez de usar el zoom, aguanta quieto y
+        deja que la cámara enfoque la hoja antes de disparar. El pulso es la otra
+        causa, y tampoco se recupera."""
+
+[[faq]]
+q = "¿Es gratis y hace falta cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni registro, ni prueba, ni límite de páginas,
+        ni marca de agua. Tampoco hay límite para el tamaño de las fotos, porque
+        no hay ningún servidor pagándolas: el trabajo ocurre en tu propio equipo.
+        El sitio lleva publicidad, que es lo que lo paga; a los anuncios no se les
+        da nada sobre tus documentos."""
+
+[schema]
+description = "Escanea un documento en el navegador: fotografía una hoja y se encuentran las cuatro esquinas, se deshace la perspectiva, se divide la luz desigual y el resultado se escribe en un PDF. Varias páginas se convierten en un documento. No se sube nada."
+features = [
+  "Encuentra las cuatro esquinas de la hoja sin modelo, sin descargas y sin peticiones",
+  "Recupera la forma real de la hoja a partir de la perspectiva, así que una foto en ángulo no sale achatada",
+  "Divide la luz desigual y la sombra en vez de subir el contraste",
+  "Páginas en blanco y negro a un bit por píxel, que es lo que hace que un escaneo quepa en un correo",
+  "Varias fotos se convierten en las páginas de un PDF, cada una con sus esquinas",
+  "Las esquinas se pueden arrastrar, o mover con el teclado píxel a píxel",
+  "Dice cuándo las esquinas son una suposición y no un hallazgo",
+  "No escribe fecha, ni autor, ni nombre de equipo en el documento",
+  "Funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí las fotos de tus hojas"
+hint = "o pulsa para elegir &mdash; una foto por hoja, en el orden de las páginas"

--- a/locales/es/tools/redact-pdf.html
+++ b/locales/es/tools/redact-pdf.html
@@ -1,0 +1,304 @@
+<!--
+  tools/redact-pdf/body.html, in Spanish.
+
+  Every id, class, data-phrase key and brace placeholder below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Paso 1 &mdash; el documento -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige tu PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <div id="doc-facts" class="doc-facts" hidden>
+      <p id="doc-name" class="doc-name"></p>
+      <p id="doc-sub" class="doc-sub"></p>
+      <ul id="doc-warnings" class="doc-warnings"></ul>
+    </div>
+  </section>
+
+  <!-- Paso 2 &mdash; encontrarlas -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Di qué tiene que irse</h2>
+
+    <p class="card-lede">
+      Escribe las palabras &mdash; un nombre, una dirección, una referencia
+      &mdash; y cada sitio donde aparecen se enumera abajo con la línea en la que
+      está. No se quita nada hasta el paso 4, y no se quita nada que no hayas
+      marcado.
+    </p>
+
+    <label class="find-label" for="terms">Palabras y frases, una por línea</label>
+    <textarea id="terms" rows="3" spellcheck="false" autocomplete="off"
+              placeholder="Pérez&#10;Calle del Puente 14&#10;REF-40219"></textarea>
+
+    <div class="find-row">
+      <button type="button" id="find" class="primary">Buscarlas</button>
+      <label class="inline-check">
+        <input type="checkbox" id="match-case"> <span>Distinguir mayúsculas</span>
+      </label>
+      <label class="inline-check">
+        <input type="checkbox" id="whole-word"> <span>Solo palabras completas</span>
+      </label>
+    </div>
+
+    <fieldset class="finders">
+      <legend>O busca lo que suele ser sensible</legend>
+      <div class="chips" id="finders"></div>
+      <p class="field-note" id="finder-note">
+        Esto son patrones, y un patrón no distingue un número de teléfono de un
+        número de expediente. Los números de tarjeta y los IBAN se comprueban
+        contra sus propios dígitos de control; el resto se ofrece, nunca se marca
+        por ti, y merece la pena leer cada uno.
+      </p>
+    </fieldset>
+
+    <div class="toolbar" id="match-bar" hidden>
+      <span id="match-count" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="tick-all" class="ghost">Marcar todas</button>
+        <button type="button" id="tick-none" class="ghost">Desmarcar todas</button>
+        <button type="button" id="clear-found" class="ghost danger">Vaciar la lista</button>
+      </div>
+    </div>
+
+    <ul id="match-list" class="match-list" hidden></ul>
+    <p id="match-more" class="field-note" hidden></p>
+  </section>
+
+  <!-- Paso 3 &mdash; leer la página -->
+  <section class="card" id="page-card" hidden>
+    <h2><span class="step">3</span> Lee la página y ve eligiendo palabras</h2>
+
+    <p class="card-lede">
+      Este es el texto tal y como está guardado en el documento, en el orden en
+      que lo copiaría un lector, que no siempre es el orden en que está impreso.
+      Pulsa cualquier palabra para sacarla, vuelve a pulsarla para conservarla.
+      Todo lo tachado aquí es lo que va a desaparecer.
+    </p>
+
+    <div class="pager">
+      <button type="button" id="prev-page" class="ghost">&#8592; Anterior</button>
+      <span id="page-of" class="count"></span>
+      <button type="button" id="next-page" class="ghost">Siguiente &#8594;</button>
+      <span class="pager-spacer"></span>
+      <span id="page-picked" class="count"></span>
+      <button type="button" id="clear-page" class="ghost danger">Conservarlo todo en esta página</button>
+    </div>
+
+    <p id="page-note" class="field-summary" hidden></p>
+
+    <div id="page-text" class="page-text" role="group" aria-label="El texto de esta página"></div>
+  </section>
+
+  <!-- Paso 4 &mdash; hacerlo -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Saca las palabras</h2>
+
+    <label class="check">
+      <input type="checkbox" id="opt-boxes" checked>
+      <span>
+        <strong>Pintar una caja negra donde estaba cada una</strong>
+        <span class="check-note">
+          Para que quien lea vea que se ha quitado algo. Aquí la caja es adorno y
+          no la censura: las letras ya han desaparecido del archivo cuando se
+          pinta. Desactívala y las palabras simplemente desaparecen, dejando el
+          espacio que ocupaban.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-elsewhere" checked>
+      <span>
+        <strong>Sacar las mismas palabras del resto del documento</strong>
+        <span class="check-note">
+          Marcadores, comentarios, notas y lo que se haya escrito en los campos
+          de formulario. Una palabra quitada de una página y dejada en un
+          marcador no está quitada. Las propiedades del documento se van diga lo
+          que diga esta casilla, y también el texto de reemplazo que un lector
+          copia en lugar de las letras de la página: los dos son el documento
+          diciendo la palabra, no otro sitio guardando una copia.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-attachments" checked>
+      <span>
+        <strong>Descartar los adjuntos y todo lo que se ejecute</strong>
+        <span class="check-note">
+          Un PDF puede llevar archivos enteros dentro y JavaScript que se ejecuta
+          al abrirlo. En ninguno de los dos se puede buscar las palabras que
+          estás quitando, y ninguno hace falta para leer un documento.
+        </span>
+      </span>
+    </label>
+
+    <p class="field-summary" id="run-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Sacarlas</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Descargar</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+      <ul id="check-terms" class="check-terms" hidden></ul>
+      <ul id="result-facts" class="result-facts"></ul>
+    </div>
+  </section>
+
+  <!--
+    The sentences this tool's JavaScript puts on screen. They live here rather
+    than in src/ because src/ is copied byte for byte into all eleven
+    languages; see "The strings in the JavaScript" in the repository README.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="load.notpdf">Eso no es un PDF, así que no hay texto dentro que sacar.</span>
+    <span data-phrase="load.encrypted">Este PDF tiene contraseña. Quitarle la
+      protección a un documento es otro trabajo distinto de sacarle palabras, y
+      esta herramienta no lo va a hacer a tus espaldas.</span>
+    <span data-phrase="load.broken">Este archivo no se ha podido abrir como PDF ({detail}).</span>
+    <span data-phrase="load.nopages">Se ha abierto, pero no se han encontrado páginas dentro.</span>
+    <span data-phrase="load.repaired">La tabla de referencias cruzadas de este
+      documento no coincidía con su contenido, así que se ha leído buscando
+      objetos. Eso es una reparación, y ha funcionado: revisa el resultado con
+      cuidado antes de mandarlo a ninguna parte.</span>
+
+    <span data-phrase="doc.sub">{pages} &middot; {words} de texto &middot; {size}</span>
+    <span data-phrase="doc.notext">{count} de estas páginas no tienen texto en
+      absoluto. Una página así es la imagen de una página, y aquí no hay nada que
+      esta herramienta pueda quitar: las palabras de la imagen se quedan
+      exactamente donde están.</span>
+    <span data-phrase="doc.unreadable">{count} letras de este documento no se han
+      podido leer como caracteres, porque las tipografías que usan no llevan un
+      mapa de sus glifos de vuelta al texto. Esas letras no se pueden buscar, así
+      que revisa las páginas en las que están en vez de fiarte de la
+      búsqueda.</span>
+    <span data-phrase="doc.scan">Algunas páginas llevan texto invisible colocado
+      sobre una imagen, que es como un escáner registra lo que su lector entendió
+      de la página. Quitar ese texto quita lo que encontrarían una búsqueda y una
+      copia. No cambia la imagen, y en la imagen las palabras siguen siendo
+      legibles.</span>
+
+    <span data-phrase="find.none">No ha coincidido nada en ninguna página.</span>
+    <span data-phrase="find.some">{count} en {pages}.</span>
+    <span data-phrase="find.more">Se enumeran las primeras {shown}. El resto está
+      encontrado y se sacará también si las marcas todas.</span>
+    <span data-phrase="find.terms">Escribe arriba una palabra, o elige un patrón, antes de pulsar Buscar.</span>
+
+    <span data-phrase="page.of">Página {number} de {total}</span>
+    <span data-phrase="page.picked">{count} se quitarán de esta página</span>
+    <span data-phrase="page.notext">En esta página no hay texto. O está en blanco,
+      o es la imagen de una página: un escaneo, una foto, una exportación que
+      dibujó sus palabras como formas. Nada de lo que hay en ella se puede buscar,
+      y nada de lo que hay en ella se puede quitar aquí.</span>
+    <span data-phrase="page.unreadable">{count} letras de esta página no se han
+      podido leer como caracteres. Aparecen abajo como &#9647;, y la búsqueda no
+      las encuentra.</span>
+    <span data-phrase="page.scan">El texto de esta página es invisible: está
+      colocado sobre una imagen de la página, que es como se hace buscable un
+      escaneo. Lo que saques aquí es lo que encontrarían una búsqueda y una copia.
+      La imagen conserva las palabras.</span>
+
+    <span data-phrase="run.summary">Se quitarán {words} en {pages}.</span>
+    <span data-phrase="run.nothing">Todavía no hay nada marcado. Busca una palabra en el paso 2, o pulsa una en el paso 3.</span>
+    <span data-phrase="run.editing">Sacando las palabras&hellip;</span>
+    <span data-phrase="run.writing">Escribiendo el documento&hellip;</span>
+    <span data-phrase="run.checking">Abriendo el archivo terminado y buscando dentro&hellip;</span>
+    <span data-phrase="run.failed">Algo ha salido mal al reescribir este documento ({detail}).</span>
+    <span data-phrase="run.cancelled">Cancelado. No se ha escrito nada.</span>
+
+    <span data-phrase="result.headline">{words} quitadas</span>
+    <span data-phrase="result.sub">{size} &middot; {pages} cambiadas &middot; {boxes}</span>
+    <span data-phrase="check.good">Abierto otra vez aquí y buscado, igual que
+      haría un lector: ninguna de ellas está en el archivo terminado.</span>
+    <span data-phrase="check.partial">Abierto otra vez aquí y buscado: todas las
+      apariciones que marcaste han desaparecido, y las que dejaste siguen
+      ahí.</span>
+    <span data-phrase="check.survived">Este archivo NO se ha escrito. El documento
+      terminado se abrió otra vez y parte de lo que quitaste seguía
+      encontrándose dentro, lo que significa que la censura no estaba completa. No
+      se ofrece nada para descargar.</span>
+    <span data-phrase="check.pages">Este archivo NO se ha escrito. El documento
+      terminado ha vuelto con un número de páginas distinto del que tenía al
+      entrar, así que algo ha salido mal más allá de las palabras. No se ofrece
+      nada para descargar.</span>
+
+    <span data-phrase="fact.boxes">{count} pintadas sobre los huecos.</span>
+    <span data-phrase="fact.noboxes">No se ha pintado ninguna caja, así que las
+      palabras han desaparecido sin nada que diga dónde estaban.</span>
+    <span data-phrase="fact.elsewhere">Las mismas palabras se han sacado de {where}.</span>
+    <span data-phrase="fact.metadata">Las propiedades del documento y el paquete
+      XMP se han eliminado, así que el archivo terminado no dice qué lo hizo, ni
+      cuándo, ni cómo se llamaba antes.</span>
+    <span data-phrase="fact.carried">Se han descartado {attachments} y {actions}.</span>
+    <span data-phrase="fact.shared">Parte de lo que quitaste lo dibujaba un bloque
+      que el documento reutiliza en más de una página, así que ha desaparecido de
+      todas las páginas que lo dibujan. Eso es más de lo que marcaste, nunca
+      menos.</span>
+    <span data-phrase="fact.overimage">{count} de las letras que quitaste estaban
+      sobre una imagen de la misma página. Están fuera de la capa de texto y
+      siguen dentro de la imagen: un lector ya no puede buscarlas ni copiarlas, y
+      sigue pudiendo verlas.</span>
+    <span data-phrase="fact.untouched">Todo lo demás de cada página se ha copiado
+      byte a byte. No se ha recodificado ninguna tipografía, imagen ni
+      línea.</span>
+
+    <span data-phrase="count.pages">{count} páginas</span>
+    <span data-phrase="count.page">{count} página</span>
+    <span data-phrase="count.words">{count} palabras</span>
+    <span data-phrase="count.word">{count} palabra</span>
+    <span data-phrase="count.pieces">{count} fragmentos de texto</span>
+    <span data-phrase="count.piece">{count} fragmento de texto</span>
+    <span data-phrase="count.matches">{count} coincidencias</span>
+    <span data-phrase="count.match">{count} coincidencia</span>
+    <span data-phrase="count.boxes">{count} cajas negras</span>
+    <span data-phrase="count.box">{count} caja negra</span>
+    <span data-phrase="count.attachments">{count} adjuntos</span>
+    <span data-phrase="count.attachment">{count} adjunto</span>
+    <span data-phrase="count.actions">{count} acciones</span>
+    <span data-phrase="count.action">{count} acción</span>
+    <span data-phrase="count.hosts">{count} hosts</span>
+    <span data-phrase="count.host">{count} host</span>
+
+    <!-- The space before {platform} belongs to these two rather than to the
+         phrase it lets in, because phrases.js collapses and trims the markup
+         it reads and a leading space would not survive the trip. -->
+    <span data-phrase="net.clean">tu documento no ha ido a ninguna parte. {total}
+      archivos cargados, todos ellos de esta misma página. {platform}</span>
+    <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta
+      herramienta no hace nunca. Vale la pena investigarlo. {platform}</span>
+    <span data-phrase="net.platform">Los scripts propios de la página para
+      publicidad, medición y el botón de donación se han cargado desde {hosts}; a
+      ninguno se le ha dado un documento, una palabra de uno ni nada de lo que
+      hayas buscado.</span>
+
+    <span data-phrase="finder.email">Direcciones de correo</span>
+    <span data-phrase="finder.card">Números de tarjeta</span>
+    <span data-phrase="finder.iban">Cuentas bancarias (IBAN)</span>
+    <span data-phrase="finder.nationalid">Números de la seguridad social</span>
+    <span data-phrase="finder.phone">Números de teléfono</span>
+  </div>
+</main>

--- a/locales/es/tools/redact-pdf.toml
+++ b/locales/es/tools/redact-pdf.toml
@@ -1,0 +1,377 @@
+#
+# Censor de PDF - Spanish.
+#
+# Overrides for tools/redact-pdf/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Censurar" es el verbo que ya usa el censor de imagenes de al lado, por lo
+# mismo: es lo que la gente escribe en el buscador. "Tachar" aparece donde hace
+# falta el gesto concreto de la raya encima.
+#
+# Lo unico que no puede perderse al tocar cualquier frase de aqui: esta pagina
+# hace una afirmacion que otras herramientas de censura no pueden hacer, y la
+# afirmacion no vale nada si se exagera. Lo que se quita es texto. Una pagina
+# que es la foto de una pagina no tiene texto encima, y esta herramienta lo
+# dice en vez de fingir.
+#
+
+name = "Censor de PDF"
+heading = "Censurar&nbsp;PDF <span class=\"h1-kw\">&mdash; las palabras salen, no se tapan</span>"
+tagline = "Las letras se borran del archivo, y después se busca en el archivo para demostrarlo."
+
+title = "Censurar un PDF &mdash; borrar el texto de verdad, gratis y sin subidas"
+description = "Saca palabras de un PDF en vez de pintar un rectángulo negro encima. Las letras se borran de las propias instrucciones de dibujo de la página, el archivo terminado se vuelve a abrir y se busca dentro para demostrar que ya no están, y no se sube nada."
+og_title = "Censurar un PDF como es debido &mdash; las palabras se borran, no se tapan"
+og_description = "En casi todas las herramientas el rectángulo negro se apoya sobre el texto y este se puede copiar desde debajo. Esta borra las letras del archivo y después busca en el resultado para enseñarte que no están."
+og_image_alt = "Censurar un PDF borrando el texto, no tapándolo"
+
+pledge = """
+    El documento que elijas se abre, se lee, se edita y se vuelve a escribir en
+    memoria en este equipo, con código servido desde esta dirección. Aquí nada
+    puede subir nada, y al otro lado de esta página no hay ningún servidor que
+    lo reciba. Ni el archivo ni las palabras que has buscado salen de la
+    pestaña."""
+
+live_hint = """
+      No hace falta que nos creas: abre las DevTools, mira la pestaña Red y
+      censura algo. Ninguna petición lleva una página, una palabra ni un nombre
+      de archivo. O desconéctate de internet y censúralo igualmente."""
+
+read_first = """
+, <code>src/text.js</code> para cómo se encuentra y
+      se sitúa cada palabra de una página, y <code>src/edit.js</code> para el
+      borrado en sí: qué se recorta de las instrucciones de la página y qué se
+      pone en su lugar para que el resto de la línea no se mueva. Ninguno de los
+      dos llega a la red, y el lector y el escritor de al lado tampoco."""
+
+howto_heading = "Cómo censurar un PDF para que las palabras desaparezcan de verdad"
+
+card = """
+            Borra palabras de un PDF en vez de taparlas. Las letras salen de las
+            propias instrucciones de dibujo de la página, el hueco se mantiene
+            abierto para que no se mueva nada más, y el archivo terminado se
+            vuelve a abrir y se busca aquí para demostrar que las palabras no
+            están."""
+
+[words]
+plural = "documentos"
+choose = "un PDF"
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[facts]]
+text = "Los archivos no salen de tu equipo"
+
+[[privacy]]
+title = "Un rectángulo negro no es una censura, y esto no pinta ninguno encima de nada."
+body = """
+
+      En casi todos los programas que ofrecen censurar una página &mdash; un
+      lector de PDF, un procesador de textos, una herramienta de diseño &mdash;
+      el rectángulo es un objeto guardado junto al texto y no dentro de él. El
+      texto sigue ahí, en el mismo archivo, en el mismo sitio, y seleccionar la
+      zona y pulsar copiar te lo devuelve. Ese fallo ha publicado sumarios
+      judiciales, informes de inteligencia y, en diciembre de 2025, nombres
+      tachados en una publicación masiva de documentos del Departamento de
+      Justicia de EE. UU. que eran legibles en cuestión de horas. Esta
+      herramienta borra las letras de las instrucciones que dibujan la página. No
+      hay ningún rectángulo con algo debajo, porque debajo no hay nada."""
+
+[[privacy]]
+title = "El archivo terminado se vuelve a abrir y se busca dentro, aquí, antes de ofrecértelo."
+body = """
+
+      Hasta que eso pasa, todo lo de arriba es esta herramienta corrigiéndose sus
+      propios deberes. Así que los bytes que están a punto de ser tu descarga se
+      le entregan al mismo lector como si los hubiera mandado un desconocido,
+      cada página se lee otra vez, se recogen todos los marcadores, comentarios,
+      campos de formulario y propiedades del documento, y se buscan las palabras
+      que has quitado. La cuenta aparece en los resultados. Si algo ha
+      sobrevivido, la pasada se da por fallida y no hay descarga."""
+
+[[privacy]]
+title = "Las palabras no salen nunca de la pestaña, y la búsqueda tampoco."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es nuestra. Esta herramienta no añade nada a esa
+      lista: no tiene función de red propia, ni siquiera opcional. Lo que
+      escribes en el cuadro de búsqueda es una cadena que se compara con texto
+      que está en la memoria de esta pestaña, y ninguna de las dos cosas tiene
+      adónde ir."""
+
+[[privacy]]
+title = "Censurar es el trabajo que peor sobrevive a una subida."
+body = """
+
+      Lo que la gente censura es el motivo por el que no debe subirse. Una
+      declaración testifical, un informe médico, un extracto bancario que va al
+      casero, un contrato con el nombre de un cliente que va a otro. Entregarle
+      eso al servidor de un desconocido para que quite la parte privada
+      significa que la parte privada llega primero, entera, y esa es la versión
+      que ellos se quedan. Esta página no tiene otra mitad."""
+
+[[privacy]]
+title = "Lo que queda se copia intacto."
+body = """
+
+      Los únicos bytes que cambian en una página son las instrucciones de texto
+      de las que formaban parte las letras quitadas. Cualquier otra instrucción,
+      y cada tipografía, imagen y línea a las que se refiera la página, se copian
+      exactamente como llegaron: nada se vuelve a dibujar, ni a codificar, ni a
+      recomponer. La anchura de lo quitado se mide y se devuelve como una
+      instrucción de espaciado, para que el resto de la línea se quede donde el
+      documento lo puso."""
+
+[[privacy]]
+title = "No puede sacar palabras de una fotografía, y dice qué páginas son esas."
+body = """
+
+      Una página escaneada es una imagen. Las palabras que hay en ella son
+      píxeles y no texto, y aquí nada puede tocarlas. Si el escaneo lleva la capa
+      invisible de búsqueda que produce el OCR de un escáner, esta herramienta
+      quita esa capa &mdash; que es lo que habrían encontrado una búsqueda y una
+      copia &mdash; y dice claramente en la página que la imagen sigue enseñando
+      las palabras. Tapar esa imagen es otro trabajo; el
+      <a href=\"../censurar-imagen/\">censor de imágenes</a> es la herramienta que
+      sobrescribe píxeles."""
+
+[[privacy]]
+title = "El documento deja de decir de dónde viene."
+body = """
+
+      Las propiedades y el paquete XMP se van en cada pasada: sin línea de
+      productor, sin fecha de creación, sin autor, sin título y sin ninguno de
+      los bloques privados que deja detrás un programa de maquetación. Un archivo
+      al que se le ha quitado un nombre de las páginas y cuyas propiedades siguen
+      diciendo <code>Acuerdo Pérez borrador 3.docx</code> no está censurado, y eso
+      no es algo que convenga dejar en manos de una casilla."""
+
+[[privacy]]
+title = "Los archivos cifrados se rechazan en vez de abrirse."
+body = """
+
+      Un PDF con contraseña se rechaza, incluidos los que producen los escáneres
+      con contraseña vacía y que técnicamente se abrirían. Quitarle la protección
+      a un documento es otro trabajo distinto de sacarle palabras, y hacerlo sin
+      avisar sería una cosa sorprendente para que una herramienta la hiciera en tu
+      nombre."""
+
+[[privacy]]
+title = "Qué carga Google y qué no se le entrega."
+body = """
+ Los scripts de publicidad
+      y de medición vienen de Google. A ninguno de los dos se le entrega nada de
+      tu documento: ni un archivo, ni una página, ni un nombre, ni un tamaño, ni
+      un número de páginas, ni una palabra que hayas buscado. Todas las líneas que
+      leen, editan o escriben un PDF se sirven desde este origen y están en el
+      repositorio."""
+
+[[privacy]]
+title = "Qué carga el botón de donación y qué no se le entrega."
+body = """
+
+      El botón &laquo;Buy me a coffee&raquo; de la cabecera lo dibuja un script
+      de cdnjs.buymeacoffee.com y toma su tipografía de Google Fonts. Es un
+      enlace y nada más: no informa de ninguna visita y no se le entrega nada
+      sobre ti ni sobre tus documentos. No pasa nada hasta que lo pulsas, y
+      entonces estás en el sitio de otra gente."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y todo en esta página
+      sigue funcionando. Es la prueba más sencilla de todas: una herramienta que
+      mandara tu documento fuera para censurarlo se pararía."""
+
+[[howto]]
+title = "Elige el PDF."
+body = """
+ Un documento cada vez, y a propósito:
+      censurar es un trabajo que hay que mirar página a página, y una herramienta
+      que te dejara marcar palabras en un archivo y las aplicara sin avisar a otro
+      es exactamente la forma en que se manda lo que no se debía. El navegador lo
+      lee directamente de tu disco."""
+
+[[howto]]
+title = "Di qué tiene que irse."
+body = """
+ Escribe las palabras &mdash; un
+      nombre, una dirección, una referencia &mdash; y cada sitio donde aparecen
+      se enumera con la línea en la que está y una casilla para marcarlo. Los
+      buscadores de al lado buscan direcciones de correo, números de tarjeta,
+      IBAN, números de la seguridad social y números de teléfono. Se ofrecen, y
+      nunca se marcan por ti: un patrón no distingue un número de teléfono de un
+      número de expediente."""
+
+[[howto]]
+title = "Lee la página y ve eligiendo palabras."
+body = """
+
+      El panel enseña el texto del documento tal y como está guardado, en el
+      orden en que lo copiaría un lector. Pulsa cualquier palabra para sacarla y
+      vuelve a pulsarla para conservarla. Todo lo tachado es lo que va a
+      desaparecer, y eso convierte este paso en la revisión además de en la
+      selección: merece la pena hacerlo en cada página antes de pulsar el
+      botón."""
+
+[[howto]]
+title = "Sácalas y lee la línea que dice que se ha comprobado."
+body = """
+
+      Las letras se borran, el hueco que dejan se mantiene abierto, se pinta una
+      caja negra encima si la has pedido, y las mismas palabras se sacan de los
+      marcadores, los comentarios, los campos de formulario y las propiedades del
+      documento. Después el archivo terminado se vuelve a abrir aquí y se busca
+      dentro. Si una palabra que has quitado sigue encontrándose, no hay descarga
+      y sí un mensaje que lo dice."""
+
+[[faq]]
+q = "¿En qué se diferencia de pintar una caja negra en un lector de PDF?"
+a = """
+        Un rectángulo pintado en un lector es una anotación: un objeto con una
+        posición, guardado junto a la página. El texto de debajo está intacto.
+        Cualquiera que seleccione esa zona y pulse copiar, o abra el archivo en
+        otro programa, o le pase cualquier extractor de texto, recupera las
+        palabras. Algunos lectores tienen una orden de &laquo;censurar&raquo; que
+        sí aplica el borrado como es debido, y varios ofrecen solo el dibujo. Esta
+        herramienta no tiene ningún rectángulo que apartar: las letras se recortan
+        de las instrucciones de dibujo de la página, y la caja negra, si la dejas
+        activada, se pinta después sobre un hueco que ya está vacío."""
+
+[[faq]]
+q = "¿Cómo sé que las palabras han desaparecido de verdad?"
+a = """
+        Porque la herramienta lo comprueba, en tu equipo, y te enseña la cuenta.
+        Cuando el archivo está escrito, lo vuelve a abrir el mismo lector de esta
+        página, se lee cada página, se recogen todos los marcadores, comentarios,
+        campos de formulario y propiedades, y se busca cada palabra que has
+        quitado. La línea de resultados dice cuántas había y cuántas quedan. Si la
+        respuesta no es la que debería, la pasada falla y no se ofrece nada para
+        descargar. También puedes comprobarlo tú después en cualquier lector:
+        pulsa Ctrl+F y busca la palabra."""
+
+[[faq]]
+q = "¿Se mueve el resto de la página cuando se quita una palabra?"
+a = """
+        No. El texto se dibuja avanzando una pluma por la página, así que borrar
+        cinco letras arrastraría normalmente el resto de la línea cinco letras
+        hacia la izquierda. La anchura exacta de lo quitado se mide con las
+        propias métricas de la tipografía y se devuelve como una instrucción de
+        espaciado, que mueve la pluma sin dibujar nada. Las columnas siguen
+        alineadas y los totales siguen bajo su encabezado."""
+
+[[faq]]
+q = "¿Puede censurar un documento escaneado?"
+a = """
+        La imagen no, y lo dice en vez de fingir. Un escaneo es la fotografía de
+        una página: las palabras son píxeles y no hay texto que quitar. Lo que un
+        escaneo sí suele llevar es una capa de texto invisible que el OCR del
+        escáner escribió sobre la imagen para que la página se pueda buscar; esta
+        herramienta encuentra esa capa, quita de ella lo que elijas y te dice en
+        la página que la imagen no ha cambiado. Así que una búsqueda y una copia
+        dejan de encontrar la palabra, y quien mire la página la sigue leyendo.
+        Para una imagen, el <a href=\"../censurar-imagen/\">censor de imágenes</a>
+        sobrescribe los píxeles."""
+
+[[faq]]
+q = "¿Y las partes de un documento que no están en una página?"
+a = """
+        Se tratan, porque ahí es donde una censura suele escaparse. Las mismas
+        palabras se sacan de los marcadores, los comentarios y las notas, de lo
+        que se haya escrito en los campos de formulario, del texto que se le
+        entrega a un lector de pantalla y del texto de reemplazo que un lector
+        copia <em>en lugar de</em> las letras de la página. Este último existe
+        para que las ligaduras y las palabras partidas se copien bien, y puede
+        contener una frase entera. Las propiedades del documento y el paquete XMP
+        se eliminan directamente. Los adjuntos y todo lo que se ejecute al abrir
+        el archivo se descartan, porque en ninguno de los dos se puede buscar las
+        palabras que estás quitando."""
+
+[[faq]]
+q = "¿Se suben mis documentos a alguna parte?"
+a = """
+        No. El archivo lo lee, edita y escribe tu propio navegador en tu propio
+        equipo. Esta herramienta no tiene lado servidor, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es nuestra. Lo que
+        escribes en el cuadro de búsqueda se compara con texto que está en la
+        memoria de esta pestaña y tampoco va a ninguna parte."""
+
+[[faq]]
+q = "¿Por qué no puedo arrastrar una caja sobre la página como en otras herramientas?"
+a = """
+        Porque dibujar una página significa un motor de PDF completo &mdash;
+        tipografías, degradados, transparencia, modos de fusión &mdash;, que es un
+        megabyte o más de motor que descargar y ejecutar, y este sitio no lleva
+        ninguno. Resulta que eso encaja con el trabajo: arrastrar un rectángulo
+        selecciona un <em>trozo de papel</em>, y un trozo de papel no es lo mismo
+        que el texto que hay debajo, que es justo por donde empieza el fallo de la
+        caja negra. Lo que obtienes en su lugar es el texto del documento, en
+        orden de lectura, con cada palabra pulsable. Y es además la única vista
+        que puede decirte lo que una imagen de la página no puede: si las palabras
+        que tienes delante son texto siquiera."""
+
+[[faq]]
+q = "¿El archivo terminado se abrirá en todas partes?"
+a = """
+        Sí. La salida se escribe como PDF 1.5, o como la versión más alta que
+        necesitara el archivo que le diste, y la 1.5 la entiende cualquier lector
+        publicado desde 2003. Nada de la página se vuelve a codificar: las
+        tipografías, las imágenes y el dibujo vectorial pasan byte a byte, así que
+        lo que quede del texto sigue siendo seleccionable y buscable igual que
+        antes."""
+
+[[faq]]
+q = "¿Puede abrir un PDF protegido con contraseña?"
+a = """
+        No, y es a propósito. Un documento cifrado se rechaza con un mensaje que
+        lo dice, incluso cuando la contraseña está en blanco, que es como guardan
+        muchos escáneres y fotocopiadoras. Quitarle la protección a un archivo es
+        otro trabajo distinto de sacarle palabras, y una herramienta que lo hiciera
+        en silencio estaría haciendo algo que no le has pedido."""
+
+[[faq]]
+q = "¿Hay límite de tamaño y cuesta algo?"
+a = """
+        No hay ningún límite escrito en la herramienta. El límite es tu propio
+        equipo: el documento se sostiene en memoria mientras se trabaja con él,
+        así que un portátil aguantará unos cientos de megabytes sin quejarse y
+        empezará a sufrir en algún punto por encima. Es gratis, no hay cuenta, ni
+        registro, ni prueba. El sitio lleva publicidad, que es lo que lo paga; a
+        los anuncios no se les da nada sobre tus documentos."""
+
+[[faq]]
+q = "¿Funciona sin conexión?"
+a = """
+        Sí. Carga la página una vez, desconéctate de internet y sigue
+        funcionando. Es además la forma más sencilla de comprobar que no se sube
+        nada: una herramienta que mandara tu documento fuera para censurarlo se
+        pararía en el momento en que tiraras del cable."""
+
+[schema]
+description = "Censura un PDF en el navegador borrando el texto en vez de taparlo. Las letras se quitan del flujo de contenido de la página, el archivo terminado se vuelve a abrir y se busca dentro para demostrar que ya no están, y no se sube nada."
+features = [
+  "Borra las letras de la página en vez de pintar un rectángulo encima",
+  "Vuelve a abrir el archivo terminado y busca dentro para demostrar que las palabras no están",
+  "Encuentra cada aparición de una palabra, o busca correos, tarjetas, IBAN y números de identidad",
+  "Enseña el texto del documento en orden de lectura, para poder pulsar cualquier palabra",
+  "Quita las mismas palabras de marcadores, comentarios, campos de formulario y propiedades",
+  "Mantiene el hueco abierto para que el resto de la línea no se mueva",
+  "Dice qué páginas son escaneos, donde no hay texto que quitar",
+  "Funciona sin conexión; sin subidas, sin cuenta y sin límite de tamaño",
+]
+
+[picker]
+title = "Suelta aquí tu PDF"
+hint = "o pulsa para elegir &mdash; un documento cada vez"

--- a/locales/es/tools/stack-images.html
+++ b/locales/es/tools/stack-images.html
@@ -1,0 +1,240 @@
+<!--
+  tools/stack-images/body.html, in Spanish.
+
+  Every id, class, option value, data-phrase key and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language. Only
+  the words change. The #faq-raw anchor is a link target from the note in step
+  one, so it stays as it is.
+-->
+<main>
+  <!-- Paso 1 &mdash; las tomas -->
+  <section class="card">
+    <h2><span class="step">1</span> Elige las tomas</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p class="note">
+      Los archivos RAW se abren leyendo el JPEG a tamaño completo que la cámara
+      ya escribió dentro: unos kilobytes de directorio y después un solo trozo.
+      Los datos del sensor no se decodifican nunca, así que una toma de
+      60&nbsp;MB abre casi tan rápido como un JPEG.
+      <a href="#faq-raw">Qué significa eso para el resultado</a>.
+    </p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="sort-name" class="ghost">Ordenar por nombre</button>
+        <button type="button" id="clear-all" class="ghost danger">Quitar todas</button>
+      </div>
+    </div>
+
+    <ul id="frame-list" class="frame-list"></ul>
+  </section>
+
+  <!-- Paso 2 &mdash; cómo combinarlas -->
+  <section class="card">
+    <h2><span class="step">2</span> Cómo combinarlas</h2>
+
+    <div class="settings">
+      <div class="field field-wide">
+        <label for="mode">Método de apilado</label>
+        <select id="mode">
+          <option value="mean" selected>Media &mdash; reducir el ruido</option>
+          <option value="median">Mediana &mdash; quitar gente y coches que pasan</option>
+          <option value="sigma">Recorte sigma &mdash; las dos cosas a la vez</option>
+          <option value="max">Aclarar &mdash; estelas de estrellas, fuegos artificiales, pintura con luz</option>
+          <option value="min">Oscurecer &mdash; quitar lo brillante que se movió</option>
+          <option value="sum">Sumar &mdash; simular una exposición larga</option>
+          <option value="focus">Apilado de enfoque &mdash; conservar lo que estaba nítido</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="align">Alinear las tomas</label>
+        <select id="align">
+          <option value="translate" selected>Sí &mdash; solo desplazamiento</option>
+          <option value="similarity">Sí &mdash; desplazamiento, rotación y escala</option>
+          <option value="none">No &mdash; usarlas exactamente como están</option>
+        </select>
+        <p class="field-note" id="align-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="scale">Resolución de trabajo</label>
+        <select id="scale">
+          <option value="full" selected>Tamaño completo</option>
+          <option value="half">Mitad &mdash; una cuarta parte de la memoria</option>
+          <option value="quarter">Cuarto &mdash; una dieciseisava parte</option>
+        </select>
+        <p class="field-note" id="scale-note"></p>
+      </div>
+
+      <div class="field" id="kappa-field" hidden>
+        <label for="kappa">Descartar más allá de</label>
+        <div class="inline-pair">
+          <input type="range" id="kappa" min="0.5" max="4" step="0.1" value="2">
+          <output id="kappa-value" for="kappa">2.0&sigma;</output>
+        </div>
+        <p class="field-note">
+          Más bajo descarta más, y descarta detalle real con ello. Dos
+          desviaciones típicas son el punto de partida habitual.
+        </p>
+      </div>
+
+      <div class="field" id="radius-field" hidden>
+        <label for="radius">La nitidez se mide sobre</label>
+        <div class="inline-pair">
+          <input type="range" id="radius" min="1" max="12" step="1" value="3">
+          <output id="radius-value" for="radius">3 px</output>
+        </div>
+        <p class="field-note">
+          Más grande toma regiones enteras de una sola toma; más pequeño sigue el
+          detalle fino y puede revolver un fondo liso entre tomas.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="gain">Exposición</label>
+        <div class="inline-pair">
+          <input type="range" id="gain" min="0.1" max="4" step="0.05" value="1">
+          <output id="gain-value" for="gain">1.00&times;</output>
+        </div>
+        <p class="field-note" id="gain-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="format">Guardar como</label>
+        <select id="format">
+          <option value="png" selected>PNG &mdash; sin pérdida</option>
+          <option value="jpeg">JPEG &mdash; archivo más pequeño</option>
+        </select>
+        <div id="quality-row" class="inline-pair" hidden>
+          <input type="range" id="quality" min="0.5" max="1" step="0.01" value="0.92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+    </div>
+
+    <!--
+      What the run will cost, worked out before it starts. Every figure here is
+      an answer from src/plan.js rather than an estimate, which is why they are
+      shown at all: a median of twenty large frames is a genuinely different
+      proposition from an average of them, and that should be visible before
+      the button is pressed rather than afterwards.
+    -->
+    <dl class="plan" id="plan" hidden>
+      <div><dt>Resultado</dt><dd id="plan-output">&mdash;</dd></div>
+      <div><dt>Memoria de trabajo</dt><dd id="plan-memory">&mdash;</dd></div>
+      <div><dt>Tomas decodificadas</dt><dd id="plan-decodes">&mdash;</dd></div>
+      <div><dt>Leído del disco</dt><dd id="plan-read">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-warning" class="path-note" hidden></p>
+  </section>
+
+  <!-- Paso 3 &mdash; ejecutarlo -->
+  <section class="card">
+    <h2><span class="step">3</span> Apílalas</h2>
+
+    <div class="export-row">
+      <button type="button" id="run" class="primary" disabled>Apilar imágenes</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame">
+        <img id="result-image" alt="El resultado apilado">
+      </div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <p id="result-moves" class="field-note"></p>
+        <a id="download" class="primary as-button" download>Descargar la imagen</a>
+      </div>
+    </div>
+  </section>
+
+  <!--
+    Every sentence this tool's JavaScript puts on screen, kept out of the
+    JavaScript so that a translator can reach it. src/ is copied byte for byte
+    into all eleven languages, so a string written in a module is English at ten
+    of them. See shared/js/phrases.js.
+
+    A {name} is filled in by the caller. Nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="count.one">1 toma</span>
+    <span data-phrase="count.many">{count} tomas</span>
+    <span data-phrase="count.none">Todavía no hay tomas</span>
+
+    <span data-phrase="frame.reference">Referencia</span>
+    <span data-phrase="frame.make-reference">Usar como referencia</span>
+    <span data-phrase="frame.remove">Quitar</span>
+    <span data-phrase="frame.size">{width} &times; {height}</span>
+    <span data-phrase="frame.raw">RAW &mdash; la propia vista previa de {width} &times; {height} de la cámara</span>
+    <span data-phrase="frame.raw-camera">{camera} &mdash; vista previa de {width} &times; {height}</span>
+    <span data-phrase="frame.raw-unreadable">No se ha encontrado ninguna vista previa dentro de este archivo RAW</span>
+    <span data-phrase="frame.read">{read} leídos de {total}</span>
+
+    <span data-phrase="mode.mean">Promedia todas las tomas. El ruido aleatorio está tan a menudo por encima como por debajo, así que promediar {count} tomas lo reduce unas {factor} veces. El método para un conjunto estable, y el que echa a perder un solo pájaro que pase.</span>
+    <span data-phrase="mode.median">Toma el valor central de cada píxel. Todo lo que solo estaba en algunas tomas &mdash; un turista, un coche, un avión &mdash; desaparece. Es el único método que tiene que sostener todas las tomas a la vez, y por eso puede ir por bandas más abajo.</span>
+    <span data-phrase="mode.sigma">Aprende qué suele ser cada píxel y después promedia solo los valores que concuerdan. El resultado de la mediana con la reducción de ruido de la media. Lee las tomas dos veces.</span>
+    <span data-phrase="mode.max">Conserva el valor más brillante que haya tenido cada píxel. Es lo que convierte una secuencia de exposiciones cortas en estelas de estrellas, y lo que monta unos fuegos artificiales a partir de sus propias tomas.</span>
+    <span data-phrase="mode.min">Conserva el valor más oscuro que haya tenido cada píxel. Un píxel solo sigue brillante si lo estaba en todas las tomas, así que los reflejos, los faros y las gotas de lluvia iluminadas desaparecen.</span>
+    <span data-phrase="mode.sum">Suma las tomas sin dividir: lo que habría recogido una única exposición {count} veces más larga. Se satura, exactamente como se habría saturado esa exposición. Usa el deslizador de exposición para recuperarlo.</span>
+    <span data-phrase="mode.focus">Toma cada parte de la imagen de la toma en la que estaba enfocada. Fotografía un sujeto pequeño a lo largo del anillo de enfoque y esto monta las partes que estaban nítidas.</span>
+
+    <span data-phrase="align.translate">Encuentra cuánto se ha desplazado cada toma y la devuelve a su sitio, con precisión de fracciones de píxel. Corrige el pulso y la deriva del trípode. No puede corregir la rotación.</span>
+    <span data-phrase="align.similarity">Encuentra además la rotación y la escala. Cuesta una medición más por toma y nada en absoluto cuando las tomas resultan estar derechas. La rotación solo se recupera dentro de media vuelta.</span>
+    <span data-phrase="align.none">Apila las tomas exactamente como se le dan. Correcto para un trípode fijo o una secuencia de intervalómetro, y equivocado para cualquier cosa a pulso.</span>
+
+    <span data-phrase="scale.note">Cada toma la decodifica a este tamaño el propio decodificador del navegador, así que un ajuste más pequeño es menos trabajo además de menos memoria.</span>
+    <span data-phrase="gain.note">Se multiplica en el resultado al final del todo, después de la aritmética y antes de redondear.</span>
+    <span data-phrase="gain.sum-note">Sumar {count} tomas se saturará casi con toda seguridad. Baja esto a alrededor de {suggested} para ver lo que se recogió.</span>
+
+    <span data-phrase="plan.output">{width} &times; {height}</span>
+    <span data-phrase="plan.memory">unos {mb} MB</span>
+    <span data-phrase="plan.decodes.simple">{count}, una por toma</span>
+    <span data-phrase="plan.decodes.passes">{count} &mdash; todas las tomas, {passes} veces</span>
+    <span data-phrase="plan.decodes.banded">{count} &mdash; todas las tomas, una vez por cada una de las {bands} bandas</span>
+    <span data-phrase="plan.read">{read} de {total} en el disco</span>
+    <span data-phrase="plan.banded">Esto no cabe entero en memoria, así que la imagen se corta en {bands} bandas y las tomas se releen para cada una. Elegir {suggested} lo convertiría en una sola pasada.</span>
+    <span data-phrase="plan.banded-anyway">Esto no cabe entero en memoria, así que la imagen se corta en {bands} bandas y las tomas se releen para cada una. Menos tomas, o una resolución de trabajo más pequeña, lo convertirían en una sola pasada.</span>
+
+    <span data-phrase="progress.open">Mirando dentro de {name}&hellip;</span>
+    <span data-phrase="progress.survey">Leyendo {name}&hellip;</span>
+    <span data-phrase="progress.measure">Midiendo cuánto se ha movido {name}&hellip;</span>
+    <span data-phrase="progress.stack">Apilando &mdash; {done} de {total} tomas leídas</span>
+    <span data-phrase="progress.stack-banded">Apilando &mdash; banda {band} de {bands}, {done} de {total} tomas leídas</span>
+    <span data-phrase="progress.encode">Escribiendo la imagen&hellip;</span>
+
+    <span data-phrase="result.info">{width} &times; {height}, {size} &mdash; {count} tomas combinadas en {seconds} segundos</span>
+    <span data-phrase="result.moves">Todas las tomas se han medido y se han llevado a su sitio.</span>
+    <span data-phrase="result.moves-some">{count} de {total} tomas no se han podido medir con confianza y se han dejado donde estaban.</span>
+    <span data-phrase="result.moves-none">Las tomas se han apilado exactamente como se dieron.</span>
+    <span data-phrase="result.moves-clamped">{count} tomas han dado una rotación demasiado grande para una ráfaga, y se han corregido solo desplazándolas.</span>
+    <span data-phrase="result.cropped">Separarlas ha dejado bordes a los que no llegaban todas las tomas, y esos se han recortado.</span>
+
+    <span data-phrase="error.no.files">Añade antes al menos una imagen.</span>
+    <span data-phrase="error.no.size">Ninguno de estos archivos se ha podido abrir como imagen.</span>
+    <span data-phrase="error.one.frame">Apilar necesita al menos dos tomas.</span>
+    <span data-phrase="error.unknown">Algo ha salido mal al apilar. Si alguno de estos archivos es raro, pruébalo por su cuenta.</span>
+    <span data-phrase="error.memory">El navegador se ha quedado sin memoria. Prueba con una resolución de trabajo más pequeña, o con menos tomas.</span>
+    <span data-phrase="error.unreadable">{name} no se ha podido abrir como imagen y se ha dejado fuera.</span>
+    <span data-phrase="error.busy">Espera a que termine esta pila antes de añadir más tomas, o cancélala.</span>
+  </div>
+</main>

--- a/locales/es/tools/stack-images.toml
+++ b/locales/es/tools/stack-images.toml
@@ -1,0 +1,336 @@
+#
+# Apilador de imágenes - Spanish.
+#
+# Overrides for tools/stack-images/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Apilar" es el verbo, y "apilado" el sustantivo, que usa la fotografia en
+# espanol; "stacking" aparece entre comillas la primera vez porque es lo que
+# esta escrito en los menus en ingles que mucha gente tiene delante. Las siglas
+# RAW (CR2, NEF, ARW, DNG) y los nombres de biblioteca (LibRaw, dcraw) se
+# quedan como estan: asi se llaman los archivos de la carpeta.
+#
+# "Worker" tambien se queda: nombra una cosa concreta del navegador, y una
+# palabra en espanol seria otra afirmacion sobre lo que hace la pagina.
+#
+
+name = "Apilador de imágenes"
+heading = "Apilador&nbsp;de&nbsp;imágenes <span class=\"h1-kw\">&mdash; combina una ráfaga, con RAW incluido</span>"
+tagline = "Veinte tomas se convierten en una, sin veinte subidas y sin revelador RAW."
+
+title = "Apilador de imágenes &mdash; media, mediana y apilado de enfoque en el navegador"
+description = "Combina una ráfaga de fotografías en una sola: promédialas para matar el ruido, toma la mediana para quitar a la gente de una escena, aclara para dejar estelas de estrellas o apila el enfoque de una macro. Lee CR2, NEF, ARW, DNG, RAF y CR3 sacando la propia vista previa de la cámara. Funciona entero en el navegador."
+og_title = "Apila una ráfaga de fotografías, con archivos RAW incluidos"
+og_description = "Media, mediana, recorte sigma, aclarar, oscurecer, sumar o apilado de enfoque, con las tomas alineadas antes. Los archivos RAW se abren leyendo la vista previa que la cámara ya escribió, así que una toma de 60 MB abre tan rápido como un JPEG. No se sube nada."
+og_image_alt = "Apilador de imágenes - varias tomas combinadas en una, en el navegador"
+
+pledge = """
+    El navegador abre, decodifica, alinea, combina y escribe cada toma en tu
+    propio equipo. Una pila de veinte archivos RAW de 60&nbsp;MB es alrededor de
+    un gigabyte de fotografías, y no se mueve ni un byte: la herramienta no
+    tiene ninguna función de red, y los archivos los lee directamente de tu
+    disco un worker que no tiene adónde mandar nada."""
+
+live_hint = """
+      No hace falta que nos creas: abre las DevTools, mira la pestaña Red y apila
+      una carpeta de archivos RAW. Ninguna petición lleva una fotografía, una
+      miniatura, un nombre de archivo ni un modelo de cámara. O desconéctate de
+      internet y apílalos igualmente: la herramienta no cambia en nada."""
+
+read_first = """
+, <code>src/raw.js</code> para cómo se abre un
+      archivo RAW leyendo kilobytes en vez de megabytes,
+      <code>src/stack.js</code> para la aritmética de cada método y
+      <code>src/plan.js</code> para de dónde salen las cifras de memoria y de
+      decodificación que aparecen en la página: son las respuestas de ese
+      archivo, no estimaciones."""
+
+howto_heading = "Cómo apilar un conjunto de fotografías en el navegador"
+
+card = """
+            Combina una ráfaga en una sola imagen: promedia el ruido hasta que
+            desaparece, toma la mediana para perder a los transeúntes, o aclara
+            para dejar estelas de estrellas. Lee archivos RAW sin revelador."""
+
+[words]
+plural = "fotografías"
+choose = "unas fotografías"
+
+[[facts]]
+text = "Sin subidas"
+
+[[facts]]
+text = "Sin cuenta"
+
+[[facts]]
+text = "Sin marca de agua"
+
+[[facts]]
+text = "Lee RAW"
+
+[[facts]]
+text = "Funciona sin conexión"
+
+[[facts]]
+text = "Código abierto"
+
+[[privacy]]
+title = "Tus fotografías no tienen adónde ir."
+body = """
+ La
+      Content-Security-Policy nombra todas las direcciones que esta página puede
+      contactar, y ninguna es nuestra. Aquí no hay ningún destino donde recoger
+      tus archivos, ni código que los enviaría si lo hubiera: no hay
+      <code>fetch</code>, ni <code>XMLHttpRequest</code>, ni
+      <code>sendBeacon</code>, ni en <code>src/</code> ni en el worker."""
+
+[[privacy]]
+title = "Los archivos RAW se leen, no se suben, y apenas se leen."
+body = """
+ Un archivo RAW de cámara ya
+      contiene un JPEG a tamaño completo que la cámara reveló al disparar. Esta
+      herramienta lo encuentra recorriendo unas cuantas entradas de directorio y
+      pidiendo después un solo trozo, que en un archivo de 60&nbsp;MB suele ser
+      menos de cien kilobytes. La página te enseña esa cifra junto al tamaño de
+      tus archivos mientras trabajas. Los datos del sensor no se leen nunca."""
+
+[[privacy]]
+title = "El trabajo ocurre en un Worker de este equipo, no en un servidor."
+body = """
+ Es la única herramienta de
+      aquí que usa uno, porque apilar son minutos de aritmética en vez de
+      segundos, y una página congelada no puede enseñar el progreso ni dejarse
+      cancelar. Un Worker es un segundo hilo dentro de este mismo navegador
+      &mdash; mira <code>src/worker.js</code>. Se le entregan los archivos en sí,
+      lo cual es gratis, porque un descriptor de archivo no son los bytes; y
+      tiene exactamente la misma Content-Security-Policy que la página, es decir,
+      ningún sitio adonde mandarlos."""
+
+[[privacy]]
+title = "No se informa a ninguna parte de nada sobre el conjunto."
+body = """
+ Cuántas tomas has apilado,
+      qué cámara las escribió, cuánto se había movido cada una, qué método has
+      elegido y cuánto ha tardado se quedan en la memoria de esta página hasta que
+      la cierras. En este repositorio no hay ningún evento de analítica que lleve
+      nada de eso, y la única pregunta que hace este sitio después de una descarga
+      manda un pulgar arriba o abajo y el nombre de la herramienta, nada más."""
+
+[[privacy]]
+title = "Funciona sin conexión."
+body = """
+ Desconéctate de la red y la herramienta no
+      cambia, porque nunca hubo un paso de red dentro. El worker y cada módulo
+      que carga los guarda el service worker de esta misma página, así que una
+      copia instalada apila archivos RAW con el cable desenchufado."""
+
+[[howto]]
+title = "Elige las tomas."
+body = """
+ Una ráfaga, un conjunto horquillado, una
+      secuencia de intervalómetro o una carpeta de archivos RAW. Cada una se abre
+      según llega, y la fila te dice qué ha salido de ella: en un archivo RAW, la
+      cámara, el tamaño de la vista previa encontrada dentro y qué poco del
+      archivo ha habido que leer para encontrarla."""
+
+[[howto]]
+title = "Elige el método que corresponda a lo que quieres perder."
+body = """
+ Ruido: media, o recorte
+      sigma si se ha movido algo. Gente, coches o un avión que pasa: mediana. Un
+      cielo oscuro que quieres convertir en estelas de estrellas: aclarar. Una
+      macro tomada a lo largo del anillo de enfoque: apilado de enfoque. La nota
+      de debajo del menú dice qué hace cada uno con tu número concreto de
+      tomas."""
+
+[[howto]]
+title = "Decide si hay que alinear las tomas."
+body = """
+ A pulso: sí, solo
+      desplazamiento. A pulso y además girando: desplazamiento, rotación y
+      escala. Trípode fijo o intervalómetro: no, y así irá más rápido. Cada toma
+      se mide contra la primera de la lista, y por eso cualquier toma puede
+      ascender a ser esa primera."""
+
+[[howto]]
+title = "Lee las cuatro cifras y después pulsa el botón."
+body = """
+ Antes de que se ejecute
+      nada, la página dice cómo de grande será el resultado, cuánta memoria
+      necesitará aproximadamente, cuántas veces se decodificarán las tomas y
+      cuánto de tus archivos se ha leído. Si el conjunto no cabe entero en
+      memoria, lo dice, y dice qué resolución de trabajo lo arreglaría."""
+
+[[faq]]
+q = "¿Se suben mis fotografías a alguna parte?"
+a = """
+        No. Cada toma la abre, decodifica, alinea, apila y escribe tu propio
+        navegador en tu propio equipo. Esta herramienta no tiene ninguna función
+        de red, nunca pide ni envía nada, y la
+        <code>Content-Security-Policy</code> de la página nombra todas las
+        direcciones que puede contactar, ninguna de las cuales es nuestra. Carga
+        la página una vez, desconéctate de internet y sigue funcionando. Aquí eso
+        importa más que en la mayoría de las herramientas simplemente por el
+        volumen: una pila de veinte tomas RAW es alrededor de un gigabyte, y subir
+        un gigabyte de fotografías para que alguien les saque la media es
+        justamente lo que esta herramienta existe para evitar."""
+
+[[faq]]
+q = "¿Qué formatos RAW puede leer, y cómo?"
+a = """
+        <span id="faq-raw"></span>CR2, CR3, NEF, NRW, ARW, SR2, SRF, DNG, ORF,
+        RAF, RW2, PEF, SRW, 3FR, IIQ, DCR, KDC, MRW, MEF, RWL y algunos más, que
+        es casi todo lo que escriben las cámaras. Lo que lee dentro de ellos es la
+        vista previa JPEG a tamaño completo que reveló la propia cámara al
+        disparar: la imagen de la pantalla trasera, y la que dibuja tu sistema
+        operativo como miniatura. Se encuentra recorriendo la estructura de
+        directorios del archivo, lo que cuesta unas pocas lecturas de unos pocos
+        kilobytes cada una, y tomando después un solo trozo.
+        <strong>No es un revelado de los datos del sensor.</strong> El resultado
+        lleva el balance de blancos y el estilo de imagen de la cámara a ocho bits
+        por canal, en vez de los doce o catorce bits de datos lineales de sensor
+        que te daría un revelador RAW."""
+
+[[faq]]
+q = "¿Y por qué no decodificar bien los datos del sensor?"
+a = """
+        Porque significaría incorporar LibRaw o dcraw: un segundo motor de decenas
+        de megabytes, para una sola familia de formatos, y la mayor parte de él son
+        esquemas de compresión propios de cada fabricante. Ese intercambio se
+        discute en <code>docs/what-can-be-built-here.md</code>, en el código de
+        este sitio, donde el RAW de cámara estaba en la lista de descartes desde
+        antes de que esta herramienta existiera. Lo que ha cambiado no es la
+        respuesta a esa pregunta, sino descubrir que apilar no lo necesita: las
+        vistas previas están a resolución completa, son lo que la cámara te habría
+        dado como JPEG de todas formas, y leerlas es unas cien veces más rápido
+        que revelar. Si quieres los datos del sensor, revela las tomas antes en un
+        revelador RAW y apila los TIFF o los JPEG que produzca; esta herramienta
+        también los acepta."""
+
+[[faq]]
+q = "¿Cuántas tomas admite, y de qué tamaño?"
+a = """
+        Seis de los siete métodos van en flujo: mantienen un acumulador y leen
+        cada toma exactamente una vez, así que cien tomas cuestan la misma memoria
+        que dos y lo único que crece es el tiempo. La mediana es la excepción,
+        porque el valor central de un conjunto no se puede saber hasta tenerlo
+        entero, así que sostiene todas las tomas a la vez: veinte tomas de 24
+        megapíxeles son alrededor de 1,4&nbsp;GB, y eso no te lo da ningún
+        navegador. Cuando pasa, la imagen se corta en bandas horizontales y se
+        apila banda a banda, lo que cuesta releer las tomas para cada banda. La
+        página calcula todo esto antes de que pulses el botón y te enseña el
+        número, así que una pasada lenta no es nunca una sorpresa."""
+
+[[faq]]
+q = "¿Qué hace exactamente alinear las tomas?"
+a = """
+        Encuentra cuánto se ha movido cada toma respecto a la primera y la
+        devuelve a su sitio, con precisión de fracciones de píxel. El método es
+        la correlación de fase: el desplazamiento entre dos imágenes aparece como
+        una diferencia de fase entre sus espectros, así que una transformada de
+        Fourier de cada una encuentra un desplazamiento de doscientos píxeles tan
+        barato como uno de dos. El segundo ajuste recupera además la rotación y la
+        escala, con el mismo truco aplicado al espectro en coordenadas
+        log-polares. Todo ello es global &mdash; un desplazamiento, un ángulo, una
+        escala para toda la toma &mdash;, así que corrige una cámara que se movió
+        y no puede corregir un sujeto que se movió, ni una fotografía tomada un
+        paso más a la izquierda. Una consecuencia visible: una toma desplazada
+        veinte píxeles a la izquierda ya no llega al borde derecho, así que el
+        resultado se recorta a la parte que cubren todas las tomas. Por eso una
+        pila alineada sale ligeramente más pequeña que las tomas que entraron, y
+        es la única alternativa a un borde oscuro hecho de las tomas que no
+        estaban."""
+
+[[faq]]
+q = "¿Qué método debería usar?"
+a = """
+        <strong>Media</strong> para el ruido, en un conjunto donde no se movió
+        nada: reduce el ruido aleatorio aproximadamente en la raíz cuadrada del
+        número de tomas. <strong>Mediana</strong> para quitar cosas que solo
+        estaban parte del tiempo; el uso clásico es fotografiar una plaza
+        concurrida una docena de veces y conseguirla vacía. <strong>Recorte
+        sigma</strong> cuando quieres las dos cosas: aprende qué suele ser cada
+        píxel y promedia solo los valores que concuerdan, así que tiene la
+        inmunidad de la mediana ante un coche que pasa y la reducción de ruido de
+        la media. <strong>Aclarar</strong> para estelas de estrellas, fuegos
+        artificiales y pintura con luz. <strong>Oscurecer</strong> para quitar
+        cualquier cosa brillante que se moviera. <strong>Sumar</strong> para
+        simular una única exposición larga. <strong>Apilado de enfoque</strong>
+        para una macro tomada a lo largo del anillo de enfoque."""
+
+[[faq]]
+q = "¿Por qué mi resultado tiene ocho bits si mis archivos RAW tienen catorce?"
+a = """
+        Porque lo que se apila es la propia vista previa de la cámara, que es un
+        JPEG. Conviene decir que apilar recupera parte de lo que eso cuesta:
+        promediar dieciséis tomas de ocho bits da un resultado con gradaciones de
+        verdad más finas que las que tenía cualquiera de ellas, porque el ruido
+        que hacía que cada toma redondeara distinto es justo lo que permite que la
+        media caiga entre los niveles. Aquí la aritmética se hace en coma flotante
+        y se redondea una sola vez al final, así que nada de eso se tira por el
+        camino. Sigue sin ser lo mismo que apilar datos lineales de sensor, y esta
+        herramienta no finge lo contrario."""
+
+[[faq]]
+q = "¿Puedo apilar tomas de distinto tamaño, o de cámaras distintas?"
+a = """
+        Sí, aunque suele ser un error y merece la pena comprobar que era lo que
+        querías. El resultado tiene el tamaño de la toma más grande, y todas las
+        demás se escalan para caber y se centran dentro. Mezclar cámaras mezcla
+        también la interpretación del color, así que una media de las dos es una
+        media de dos lecturas distintas de la misma luz. Donde de verdad ayuda es
+        en un conjunto disparado a dos resoluciones, o en un archivo RAW y un JPEG
+        de la misma toma."""
+
+[[faq]]
+q = "Dice que la pasada irá por bandas. ¿Qué significa?"
+a = """
+        Que la memoria de trabajo que necesita el método es más de la que la
+        herramienta está dispuesta a reservar de una vez, así que la imagen se
+        cortará en tiras horizontales y se apilará tira a tira. Sigue produciendo
+        exactamente el mismo resultado; solo relee las tomas para cada tira, así
+        que tarda más, y la página te dice cuántas decodificaciones serán. Bajar
+        un escalón la resolución de trabajo divide la memoria entre cuatro, y eso
+        casi siempre convierte una pasada por bandas en una sola pasada; la nota
+        dice qué ajuste lo haría."""
+
+[[faq]]
+q = "¿Por qué esta herramienta usa un Worker y ninguna de las otras?"
+a = """
+        Porque es la única cuyo trabajo se mide en minutos. Cualquier otra
+        herramienta de aquí hace algo que tarda uno o dos segundos, y ahí sacar el
+        trabajo del hilo principal sería ceremonia. Apilar veinte tomas grandes es
+        aritmética sólida sobre cientos de megabytes, y en el hilo principal eso
+        significa una página congelada: ninguna barra de progreso moviéndose, un
+        botón de Cancelar que no responde y, al final, un navegador que ofrece
+        matar la pestaña. El Worker es un segundo hilo dentro de este mismo
+        navegador, ejecutando un archivo de esta misma carpeta, bajo esta misma
+        política. No es un servidor y no es una función de red."""
+
+[[faq]]
+q = "¿Es gratis y hace falta cuenta?"
+a = """
+        Es gratis, y no hay cuenta, ni registro, ni prueba, ni marca de agua.
+        Tampoco hay límite de cuántas tomas apilas ni de cómo de grandes son,
+        porque no hay ningún servidor pagándolo: el trabajo ocurre en tu propio
+        equipo y el único techo es tu propia memoria. El sitio lleva publicidad,
+        que es lo que lo paga; a los anuncios no se les da nada sobre tus
+        fotografías."""
+
+[schema]
+description = "Apila una ráfaga de fotografías en el navegador: media, mediana, media con recorte sigma, aclarar, oscurecer, sumar o apilado de enfoque, con las tomas alineadas antes por correlación de fase. Lee archivos RAW de cámara extrayendo la vista previa a tamaño completo que la cámara incrustó, así que no hace falta revelador RAW. No se sube nada."
+features = [
+  "Siete métodos: media, mediana, media con recorte sigma, aclarar, oscurecer, sumar y apilado de enfoque",
+  "Lee CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2 y más extrayendo la propia vista previa a tamaño completo de la cámara",
+  "Abre un archivo RAW de 60 MB leyendo unos cien kilobytes",
+  "Alineación automática: solo desplazamiento, desplazamiento con rotación y escala, o ninguna",
+  "Alineación con precisión de subpíxel por correlación de fase, no buscando desplazamientos",
+  "Seis de los siete métodos mantienen un acumulador, así que cien tomas cuestan la memoria de dos",
+  "El coste de memoria y de decodificación se calcula y se enseña antes de empezar",
+  "El trabajo va en un Worker, así que el progreso se mueve y Cancelar responde",
+  "PNG o JPEG de salida; funciona sin conexión; sin subidas y sin cuenta",
+]
+
+[picker]
+title = "Suelta aquí las tomas"
+hint = "o pulsa para elegir &mdash; JPEG, PNG, WebP, TIFF y RAW de cámara"


### PR DESCRIPTION
Spanish was at 57 of 65. The eight pages missing were the four tools and four
guides that shipped after this locale was last worked on: `dicom-viewer`,
`document-scanner`, `redact-pdf`, `stack-images`, and a guide for each.

All eight are here, so the build no longer prints an `es:` line at all — a
locale the debt report has nothing to say about is the only signal that it is
finished. Nothing outside `locales/es/` is touched.

## The four new addresses

```
"dicom-viewer"      = "visor-dicom"
"document-scanner"  = "escanear-documentos"
"redact-pdf"        = "censurar-pdf"
"stack-images"      = "apilar-imagenes"
```

`censurar-pdf` matches `censurar-imagen`, which the image redactor already
used. The guide slug for the phone scanner says `con-el-telefono` rather than
`con-el-movil` or `con-el-celular`, for the same reason this file already
sidesteps *ordenador* and *computadora*: the locale header commits to
pan-regional Spanish, and neither of those reads as native on both sides of the
Atlantic.

## What stays in English

Anything the reader types, looks up, or matches against something on their own
screen:

- DICOM field names with their numbers — Pixel Spacing (0028,0030), Series
  Instance UID (0020,000E) — and `VR` as the tag table heading
- the transfer syntaxes, and PS3.15
- the RAW extensions, and LibRaw/dcraw
- `Worker`, which names a specific thing in a browser
- Zhang, He and Sauvola, where the scanner cites the work it is built on

The Hounsfield presets keep their figures unchanged: water is 0 and air is
&minus;1000 on every CT scanner in the world, which is the whole reason the
named windows mean the same thing here as at a workstation.

## One structural note

`csp_note` and `og_card` are omitted from all four tool files. They read like
prose, but `buildlib/i18n.py` lists them as structural and the build rejects a
locale file that carries them.

## Checked

- `python build.py --out … --clean --no-minify` — clean, and no `es:` line
- every `id`, `class`, `name`, `value`, `data-phrase` key, `data-fact` name and
  `{placeholder}` compared against the English `body.html`, page by page
- no CRLF anywhere under `locales/es/`
- every cross-link resolves — `check_links` refuses to publish a locale whose
  page points at a page that was not built, so `../censurar-imagen/` and
  `../es-seguro-subir-archivos/` are enforced rather than asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
