### PR TITLE
Give French the eight pages it was reading in English

### DIFF
--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -130,6 +130,18 @@ complete = true
 "guides/whats-inside-a-gif" = "guides/ce-qu-il-y-a-dans-un-gif"
 "guides/verify-a-file-checksum" = "guides/verifier-la-somme-de-controle-d-un-telechargement"
 
+# Les quatre pages arrivees apres cette liste. Toujours la locution verbale a
+# l'infinitif que l'on tape reellement, et "visionneuse" plutot que "viewer"
+# parce que c'est le mot que le milieu medical emploie en francais.
+"dicom-viewer" = "visionneuse-dicom"
+"document-scanner" = "scanner-un-document"
+"redact-pdf" = "caviarder-un-pdf"
+"stack-images" = "empiler-des-images"
+"guides/open-a-dicom-file" = "guides/ouvrir-un-fichier-dicom"
+"guides/redact-a-pdf" = "guides/caviarder-un-pdf"
+"guides/scan-a-document-with-your-phone" = "guides/scanner-un-document-avec-son-telephone"
+"guides/stack-photos-to-reduce-noise" = "guides/empiler-des-photos-contre-le-bruit"
+
 #
 # ---------------------------------------------------------------------------
 # The hub.

--- a/locales/fr/pages/guides/open-a-dicom-file.html
+++ b/locales/fr/pages/guides/open-a-dicom-file.html
@@ -1,0 +1,259 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez la <a href="../../visionneuse-dicom/">visionneuse DICOM</a> et
+      faites-y glisser le dossier entier. Les fichiers sont lus sur votre propre
+      machine, remis dans les séries dont ils viennent et empilés dans l'ordre où
+      la machine les a pris. Rien n'est envoyé, et rien n'est réécrit dans vos
+      fichiers.
+    </p>
+    <p>
+      Si l'on vous a remis un disque et que vous vous demandez lequel des
+      fichiers ouvrir&nbsp;: tous, d'un coup. Un scanner ou une IRM, ce n'est pas
+      un fichier. C'est un fichier par coupe, et un examen thoracique en compte
+      trois cents.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que contient un disque hospitalier</h2>
+    <p>
+      En général quatre choses, dont une seule compte.
+    </p>
+    <ul>
+      <li>
+        <strong>Un dossier d'examens</strong>, souvent nommé <code>DICOM</code>,
+        <code>IMAGES</code> ou <code>ST0001</code>, contenant des fichiers appelés
+        <code>IM000001</code>, <code>I0000001</code> ou un long nombre à points.
+        Fréquemment sans aucune extension. C'est l'examen.
+      </li>
+      <li>
+        <strong>Un fichier nommé <code>DICOMDIR</code></strong>. Un index du
+        reste, écrit pour qu'une visionneuse puisse lister les examens du disque
+        sans ouvrir chaque fichier. Vous n'en avez pas besoin.
+      </li>
+      <li>
+        <strong>Une visionneuse</strong>, sous forme d'exécutable Windows,
+        d'entrée d'autorun ou parfois d'applet Java. Elle a été compilée pour ce
+        qui était courant à la gravure du disque, et c'est pourquoi tant d'entre
+        elles ne se lancent plus.
+      </li>
+      <li>
+        <strong>Une page HTML ou un PDF</strong> au logo de l'hôpital, expliquant
+        comment démarrer la visionneuse.
+      </li>
+    </ul>
+    <p>
+      Les examens n'ont pas besoin de la visionneuse. Le format est une norme
+      publiée et les fichiers se lisent seuls&nbsp;; l'exécutable du disque est un
+      logiciel capable de les lire, pas le seul.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi les fichiers n'ont pas d'extension</h2>
+    <p>
+      Parce que DICOM n'en a pas besoin. Chaque fichier porte sa propre
+      marque&nbsp;: 128 octets de rien, puis les quatre lettres
+      <code>DICM</code>, puis un petit bloc de champs décrivant comment le reste
+      du fichier est écrit. Un lecteur cherche ces quatre lettres, et non un nom
+      se terminant par <code>.dcm</code>.
+    </p>
+    <p>
+      C'est aussi pourquoi renommer un fichier en <code>.dcm</code> ne change
+      rien, et pourquoi une visionneuse qui exige l'extension se montre
+      inutilement stricte. Les fichiers écrits directement depuis un réseau
+      hospitalier n'ont même pas les 128 octets ni la marque&nbsp;: ce sont les
+      données nues sans rien devant, et un lecteur doit déduire de leur premier
+      champ comment elles sont encodées. C'est un fichier normal, pas un fichier
+      cassé.
+    </p>
+  </section>
+
+  <section>
+    <h2>Le fenêtrage, la commande qui compte</h2>
+    <p>
+      C'est la seule chose qui distingue une image médicale d'une photographie, et
+      la raison pour laquelle un logiciel de retouche ne vaut rien pour en
+      regarder une.
+    </p>
+    <p>
+      Une coupe de scanner contient environ quatre mille valeurs distinctes. Votre
+      écran affiche deux cent cinquante-six gris. Quelque chose doit décider
+      quelles quatre mille valeurs se projettent sur quels deux cent
+      cinquante-six gris, et cette décision est la <strong>fenêtre</strong>&nbsp;:
+      tout ce qui est en dessous est noir, tout ce qui est au-dessus est blanc, et
+      l'intervalle du milieu se répartit sur les gris.
+    </p>
+    <p>
+      Déplacez la fenêtre et le même fichier ressemble à un autre examen. Ce n'est
+      pas un artefact d'affichage, c'est tout l'intérêt. Le poumon et l'os sont
+      tous deux dans la coupe et ne peuvent pas être vus en même temps&nbsp;: une
+      fenêtre qui montre la texture d'un poumon ventilé met chaque os en blanc
+      pur, et une qui montre le détail trabéculaire d'une côte met le poumon
+      entier en noir pur.
+    </p>
+    <p>
+      Sur un scanner, les nombres sont des <strong>unités Hounsfield</strong>, et
+      elles sont définies de façon absolue et non machine par machine&nbsp;: l'eau
+      vaut 0 et l'air &minus;1000, par définition, sur tous les scanners du monde.
+      C'est pourquoi une visionneuse peut proposer des fenêtres nommées &mdash;
+      poumon, os, cerveau, parties molles &mdash; et qu'elles signifient la même
+      chose sur votre fichier que sur la console où l'examen a été interprété. Les
+      usuelles&nbsp;:
+    </p>
+    <ul>
+      <li><strong>Parties molles</strong> &mdash; centre 40, largeur 400.</li>
+      <li><strong>Poumon</strong> &mdash; centre &minus;600, largeur 1500.</li>
+      <li><strong>Os</strong> &mdash; centre 300, largeur 1500.</li>
+      <li><strong>Cerveau</strong> &mdash; centre 40, largeur 80. Une fenêtre
+        étroite, parce que substance grise et substance blanche ne diffèrent que
+        de quelques unités.</li>
+    </ul>
+    <p>
+      Sur une IRM, une telle échelle n'existe pas. Les valeurs dépendent de la
+      séquence, de l'antenne et de la machine&nbsp;: il n'y a donc rien pour
+      nommer un préréglage, et la fenêtre de départ est celle que demande le
+      fichier lui-même. Chaque examen en porte une suggestion.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi les coupes défilent parfois à l'envers</h2>
+    <p>
+      Une visionneuse doit décider dans quel ordre ranger les fichiers, et il y a
+      deux choses dans le fichier qu'elle pourrait employer.
+    </p>
+    <p>
+      <strong>Instance Number</strong> est un compteur. C'est le choix évident, et
+      il est attribué par ce qui a écrit les fichiers, qui n'a pas à les numéroter
+      dans le sens où le patient est allongé. Un examen reconstruit des pieds vers
+      le haut et numéroté de la tête vers le bas défile à l'envers, et une série
+      assemblée à partir de deux reconstructions peut répéter les numéros purement
+      et simplement.
+    </p>
+    <p>
+      <strong>Image Position (Patient)</strong> est l'endroit où se trouve
+      physiquement la coupe, en millimètres, dans un repère fixé au patient et non
+      à la machine. Trier là-dessus est juste quoi qu'ait fait la numérotation, et
+      cela a un effet secondaire utile&nbsp;: une fois les coupes en ordre
+      physique, l'écart entre elles est mesurable, si bien qu'une visionneuse peut
+      vous dire que les coupes sont espacées de 5&nbsp;mm &mdash; et remarquer
+      qu'il en manque une, ce que le fichier ne dit jamais.
+    </p>
+  </section>
+
+  <section>
+    <h2>Mesurer quelque chose</h2>
+    <p>
+      Un examen, ce sont des données mesurées&nbsp;: une longueur dessus est donc
+      une longueur réelle, si le fichier indique l'écartement de ses pixels. C'est
+      un champ, Pixel Spacing, en millimètres, et il est présent sur pratiquement
+      tous les scanners et toutes les IRM.
+    </p>
+    <p>
+      Il manque souvent sur les images d'échographie, les documents numérisés et
+      les captures d'écran enregistrées en DICOM. Là où il manque, il n'y a pas de
+      réponse honnête en millimètres, et une visionneuse qui en donne une quand
+      même a inventé une échelle. Un décompte de pixels est la bonne réponse à une
+      question à laquelle le fichier ne peut pas répondre.
+    </p>
+    <p>
+      Attention aussi aux pixels non carrés, ce qui est normal en dehors du
+      scanner. Mesurer en pixels et multiplier par un seul chiffre d'écartement
+      n'est juste que là où les deux coïncident&nbsp;; chaque axe doit être mesuré
+      avec le sien.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qu'un examen transporte en plus de l'image</h2>
+    <p>
+      C'est la partie sur laquelle on se trompe, et la raison d'être prudent avec
+      ces fichiers.
+    </p>
+    <p>
+      Un fichier DICOM n'est pas une image avec quelques métadonnées accrochées.
+      C'est un dossier médical avec une image dedans. L'en-tête est une liste de
+      champs, et sur un examen clinique ordinaire il contient&nbsp;:
+    </p>
+    <ul>
+      <li>le nom du patient, son numéro de dossier, sa date de naissance et son
+        sexe&nbsp;;</li>
+      <li>le numéro de demande, qui est la clé vers la prescription dans le
+        système de l'hôpital&nbsp;;</li>
+      <li>le médecin prescripteur, le manipulateur qui l'a réalisé, le radiologue
+        qui l'a interprété&nbsp;;</li>
+      <li>l'établissement, son adresse et le service&nbsp;;</li>
+      <li>le constructeur, le modèle et le numéro de série de la machine&nbsp;;</li>
+      <li>la date et l'heure de l'examen à la seconde&nbsp;;</li>
+      <li>et une série d'identifiants uniques &mdash; examen, série, instance
+        &mdash; qui sont des clés parfaites vers l'archive dont il provient.</li>
+    </ul>
+    <p>
+      Tout fichier qu'on vous a remis porte tout cela, et cela voyage avec le
+      fichier partout où il va. Supprimer le nom ne suffit pas&nbsp;: une date de
+      naissance, un établissement de la taille d'un code postal et une heure
+      d'examen identifient une personne à peu près aussi bien qu'un nom, et l'UID
+      de l'examen l'identifie exactement pour quiconque a accès à l'archive.
+    </p>
+    <p>
+      Certaines machines gardent en outre une seconde copie du nom du patient dans
+      un champ privé, c'est-à-dire un champ dont la signification n'est publiée
+      nulle part et que la plupart des outils d'anonymisation laissent tranquille,
+      faute de pouvoir savoir ce qu'il contient.
+    </p>
+  </section>
+
+  <section>
+    <h2>N'envoyez pas l'examen pour le regarder</h2>
+    <p>
+      La façon habituelle de régler ce problème, c'est une recherche
+      &laquo;&nbsp;dicom viewer online&nbsp;&raquo; et un champ d'envoi. Ce qui
+      vient de se passer, c'est qu'un inconnu détient une copie d'un dossier
+      médical&nbsp;: les pixels, le nom, la date de naissance, le numéro de
+      dossier et la clé vers l'archive.
+    </p>
+    <p>
+      Il n'y a aucune raison à cela. Lire un fichier DICOM, c'est analyser un
+      en-tête et déballer quelques entiers, et un navigateur le fait parfaitement.
+      C'est pourquoi la <a href="../../visionneuse-dicom/">visionneuse d'ici</a>
+      n'a aucune fonction réseau&nbsp;: pas de <code>fetch</code>, pas de
+      <code>XMLHttpRequest</code>, rien qui puisse envoyer un fichier même si
+      quelque chose l'essayait. Chargez la page une fois, débranchez-vous
+      d'internet&nbsp;: elle continue d'ouvrir des examens.
+    </p>
+    <p>
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">Est-il sûr d'envoyer ses
+      fichiers à des convertisseurs en ligne&nbsp;?</a> explique comment vérifier
+      cette affirmation sur ce site comme sur n'importe quel autre. C'est le type
+      de fichier pour lequel la vérification en vaut le plus la peine.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qu'un navigateur ne peut pas faire</h2>
+    <p>
+      Deux choses, et il vaut mieux les dire franchement.
+    </p>
+    <p>
+      <strong>Ce n'est pas une visionneuse de diagnostic.</strong> Votre écran
+      n'est pas calibré, le navigateur n'est pas une chaîne de rendu validée, et
+      aucune page web n'a fait l'objet d'une évaluation réglementaire. Lire un
+      examen pour prendre une décision clinique est l'affaire de la console sur
+      laquelle il a été interprété. Vérifier ce qu'il y a sur un disque, extraire
+      une coupe pour un cours, lire un en-tête ou comprendre pourquoi un autre
+      logiciel refuse le fichier sont autant de raisons parfaitement valables d'en
+      ouvrir un dans un navigateur.
+    </p>
+    <p>
+      <strong>Certains examens compressés ne se décoderont pas.</strong> DICOM
+      autorise plusieurs schémas de compression et les navigateurs en implémentent
+      un. Les fichiers simples, ceux codés en longueurs de plage, le JPEG baseline
+      et le JPEG Lossless &mdash; celui qu'emploient la plupart des exports
+      hospitaliers &mdash; s'ouvrent tous. JPEG 2000, JPEG-LS et les formats vidéo
+      exigent des codecs qui pèsent plusieurs mégaoctets de bibliothèque compilée.
+      Là où l'image ne peut pas être décodée, l'en-tête reste entièrement lisible,
+      ce qui est de toute façon la moitié pour laquelle vous étiez venu.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/open-a-dicom-file.toml
+++ b/locales/fr/pages/guides/open-a-dicom-file.toml
@@ -1,0 +1,26 @@
+#
+# Guide : ouvrir un fichier DICOM - French.
+#
+# Les noms de champ DICOM et les noms de fichiers d'un disque hospitalier
+# restent en anglais avec leur numero - DICOMDIR, IM000001, Instance Number,
+# Image Position (Patient). C'est ainsi qu'ils figurent sur le disque et dans
+# la norme.
+#
+
+nav = "Ouvrir un fichier DICOM"
+title = "Comment ouvrir un fichier DICOM (.dcm) sans rien installer"
+description = "Ce que contient un disque hospitalier, pourquoi les fichiers n'ont pas d'extension, comment ouvrir un examen .dcm dans un navigateur, ce que fait vraiment le fenêtrage, et ce qu'un examen transporte sur le patient en plus de l'image."
+
+heading = "Comment ouvrir un fichier DICOM, et ce qu'il y a dedans"
+lede = """
+    Un disque hospitalier, c'est un dossier de fichiers sans extension et une
+    visionneuse écrite pour Windows XP. Les fichiers sont du DICOM, et ils n'ont
+    rien d'exotique&nbsp;: un examen est un en-tête plein de champs et un bloc de
+    pixels. Voici comment en regarder un, ce que signifient les commandes, et ce
+    que le fichier transporte d'autre en plus de l'image."""
+
+updated = "25 août 2026"
+
+og_title = "Ouvrir un fichier DICOM sans rien installer"
+og_description = "Ce que contient un disque hospitalier, pourquoi les fichiers n'ont pas d'extension, et ce qu'un examen .dcm transporte sur le patient en plus de l'image."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/redact-a-pdf.html
+++ b/locales/fr/pages/guides/redact-a-pdf.html
@@ -1,0 +1,240 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez le <a href="../../caviarder-un-pdf/">caviardeur de PDF</a>, déposez
+      le document, tapez les mots qui doivent disparaître, cochez ceux que vous
+      visez et appuyez sur &laquo;&nbsp;Les retirer&nbsp;&raquo;. Les lettres sont
+      supprimées des instructions de dessin de la page, les mêmes mots sont
+      retirés des signets, des commentaires, des champs de formulaire et des
+      propriétés du document, et le fichier terminé est rouvert et fouillé devant
+      vous avant de vous être proposé.
+    </p>
+    <p>
+      Tout ce qui suit explique pourquoi cette dernière proposition est
+      l'importante, et comment savoir si l'outil que vous employez déjà peut en
+      dire autant.
+    </p>
+  </section>
+
+  <section>
+    <h2>De quel échec il s'agit</h2>
+    <p>
+      Dessinez un rectangle noir sur un nom dans une visionneuse PDF. Ce que vous
+      voyez est un nom avec un rectangle noir dessus. Ce que la plupart des
+      visionneuses <em>enregistrent</em>, c'est un document contenant le nom et,
+      séparément, un rectangle doté d'une position, d'une taille et d'une couleur.
+    </p>
+    <p>
+      Un rectangle dessiné ainsi est une <strong>annotation</strong>&nbsp;: un
+      objet posé à côté de la page et non dedans. Le texte dessous est exactement
+      tel qu'il était. Sélectionnez la zone et copiez, ou ouvrez le fichier dans un
+      logiciel qui dessine les annotations autrement, ou passez-y n'importe quel
+      extracteur de texte&nbsp;: le nom revient. Rien à l'écran ne distingue cela
+      d'un vrai caviardage, ce qui est précisément pourquoi cela continue
+      d'arriver à des organisations qui emploient des juristes.
+    </p>
+    <p>
+      Cela a publié des dossiers judiciaires, des analyses de renseignement, des
+      contrats et, en décembre 2025, des noms caviardés dans une publication
+      massive de documents du ministère de la Justice américain, lisibles quelques
+      heures après leur parution. Le schéma est toujours le même. Le rectangle
+      était l'annotation, et l'annotation n'a jamais été le texte.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que fait un vrai caviardage à la place</h2>
+    <p>
+      Une page d'un PDF est une liste d'instructions&nbsp;: prends cette police,
+      déplace la plume ici, dessine ces glyphes. Les mots de la page existent à un
+      seul endroit, comme opérandes de ces instructions de dessin&nbsp;:
+    </p>
+    <pre><code>BT /F1 12 Tf 72 700 Td (Cher Monsieur Martin) Tj ET</code></pre>
+    <p>
+      Caviarder le nom, cela veut dire <strong>supprimer ces lettres de cette
+      instruction</strong> et réécrire la page. Après quoi il n'y a rien à
+      récupérer, non parce que le fichier le cache bien, mais parce que les lettres
+      ne sont pas dans le fichier. Il n'y a pas de rectangle avec quelque chose
+      dessous, parce qu'il n'y a rien dessous.
+    </p>
+    <p>
+      Une chose doit être remise, sinon le résultat est visiblement faux. Le texte
+      est dessiné en faisant avancer une plume sur la page&nbsp;: supprimer cinq
+      lettres tire donc le reste de la ligne de cinq lettres vers la gauche, les
+      colonnes cessent d'être alignées et les totaux glissent sous le mauvais
+      titre. Un outil qui fait cela correctement mesure de combien les lettres
+      retirées auraient fait avancer la plume et remet cette distance sous forme
+      d'instruction d'espacement, qui déplace la plume sans rien dessiner.
+    </p>
+    <p>
+      Le cadre noir, s'il y en a un, est peint <em>ensuite</em>, sur un vide déjà
+      vide. C'est une politesse envers qui lira le document &mdash; le signe que
+      quelque chose a été retiré &mdash; et non le caviardage. Voilà toute la
+      distinction en une phrase&nbsp;: dans un vrai caviardage, le cadre est un
+      ornement&nbsp;; dans un faux, le cadre <em>est</em> le caviardage.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les quatre endroits où un mot se cache et qui ne sont pas la page</h2>
+    <p>
+      C'est la partie qui piège ceux qui ont bien fait la première. Un PDF
+      transporte du texte à plusieurs endroits à la fois, et une visionneuse les
+      montre, les cherche ou les copie tous. Retirer un nom de la page et le
+      laisser dans l'un d'eux, c'est ne pas l'avoir retiré.
+    </p>
+    <ul>
+      <li>
+        <strong>Les propriétés du document.</strong> Titre, auteur, et le nom du
+        fichier dont celui-ci a été exporté. Un document dont on a retiré un nom
+        des pages et dont les propriétés annoncent toujours
+        <code>Accord Martin brouillon 3.docx</code> n'est pas caviardé. Il y a
+        généralement une seconde copie des mêmes informations dans un paquet XMP,
+        qui doit disparaître aussi.
+      </li>
+      <li>
+        <strong>Les signets.</strong> Le plan latéral d'une visionneuse est une
+        liste de titres assortis de numéros de page &mdash; et un titre est une
+        ligne de texte que rien sur la page ne commande.
+      </li>
+      <li>
+        <strong>Les champs de formulaire et les commentaires.</strong> Ce que
+        quelqu'un a saisi dans un formulaire est enregistré deux fois&nbsp;: une
+        fois comme valeur du champ et une fois comme l'apparence que dessine la
+        visionneuse. Les deux doivent disparaître. Un pense-bête porte son texte et
+        le nom de qui l'a écrit.
+      </li>
+      <li>
+        <strong>Le texte de remplacement.</strong> Un PDF peut déclarer qu'une
+        suite de glyphes &laquo;&nbsp;épelle&nbsp;&raquo; autre chose, pour qu'une
+        ligature ou un mot coupé se copie comme le mot qu'il représente. Autrement
+        dit un document peut montrer une chose et en remettre une autre à qui fait
+        Ctrl+C, et un caviardage qui n'aurait retiré que ce qui est dessiné
+        laisserait la phrase intacte pour quiconque sélectionne le paragraphe.
+      </li>
+    </ul>
+    <p>
+      Les pièces jointes sont le cinquième. Un PDF peut contenir des fichiers
+      entiers, et rien de ce que vous faites aux pages ne les touche.
+    </p>
+  </section>
+
+  <section>
+    <h2>Comment vérifier un fichier, en trente secondes</h2>
+    <p>
+      Faites-le sur tout ce que vous vous apprêtez à envoyer, quel que soit l'outil
+      qui l'a produit. C'est la vérification qui aurait attrapé chacun des échecs
+      publiés.
+    </p>
+    <ol>
+      <li>
+        <strong>Ouvrez le fichier terminé et appuyez sur Ctrl+F</strong> (Cmd+F sur
+        un Mac). Cherchez le mot que vous avez retiré. Un vrai caviardage ne
+        renvoie rien. Si la visionneuse saute à un rectangle noir, le mot est
+        toujours là et le rectangle est posé dessus.
+      </li>
+      <li>
+        <strong>Sélectionnez la zone noircie et copiez-la.</strong> Glissez sur le
+        rectangle, faites Ctrl+C et collez dans un champ de texte. Si quelque
+        chose arrive, vous avez trouvé le même échec par l'autre bout.
+      </li>
+      <li>
+        <strong>Sélectionnez le document entier et copiez cela.</strong> Ctrl+A
+        puis Ctrl+C, collez dans n'importe quel éditeur de texte et lisez ce qui en
+        sort. C'est la plus utile des trois, parce qu'elle vous montre le document
+        tel que le voit un extracteur de texte &mdash; y compris du texte dont vous
+        ignoriez la présence, ce qui est courant sur une page numérisée.
+      </li>
+      <li>
+        <strong>Regardez les propriétés</strong> &mdash; Fichier → Propriétés dans
+        la plupart des visionneuses &mdash; et le panneau des signets. Ce sont deux
+        endroits où un nom survit à un caviardage parfait sur la page.
+      </li>
+    </ol>
+    <p>
+      Le <a href="../../caviarder-un-pdf/">caviardeur de PDF</a> exécute la
+      première et la troisième pour vous et affiche le décompte, parce qu'un outil
+      qui affirme avoir retiré quelque chose n'est pas une preuve, et qu'une
+      fouille du fichier terminé en est une.
+    </p>
+  </section>
+
+  <section>
+    <h2>Les documents numérisés sont un autre problème</h2>
+    <p>
+      Un scan est la photo d'une page. Les mots qu'elle porte sont des pixels et
+      non du texte, et modifier la couche de texte n'y touche pas &mdash; parce
+      qu'il n'y a pas de couche de texte, ou parce que celle qui s'y trouve décrit
+      l'image au lieu d'en être une.
+    </p>
+    <p>
+      La plupart des scanners et des outils PDF actuels ajoutent une couche de
+      texte invisible par-dessus l'image, écrite par reconnaissance optique de
+      caractères, pour rendre la page consultable. Cette couche est du vrai texte
+      et peut être retirée. Cela vaut la peine de la retirer&nbsp;: c'est ce
+      qu'auraient trouvé une recherche, un copier et tout système automatique qui
+      lit des documents. Cela ne change rien à l'image, où les mots restent
+      parfaitement lisibles pour qui regarde la page.
+    </p>
+    <p>
+      Pour un scan, la séquence honnête est donc&nbsp;: retirer les mots de la
+      couche de texte, puis s'occuper de l'image séparément, ce qui veut dire
+      écraser des pixels. C'est ce que fait le
+      <a href="../caviarder-une-image/">caviardeur d'images</a>, et le guide d'à
+      côté explique pourquoi un flou ou une mosaïque ne suffisent pas pour du
+      texte.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi ne pas simplement imprimer et renumériser</h2>
+    <p>
+      Parce que cela marche, et que cela vous coûte tout le reste. Imprimer une
+      page caviardée et la renumériser produit bien un document sans couche de
+      texte susceptible de fuir &mdash; et un document que personne ne peut
+      chercher, qu'aucun lecteur d'écran ne peut lire, cinq à cinquante fois plus
+      gros, et dont la qualité est celle qu'a bien voulu donner le photocopieur du
+      bureau. Cela suppose en outre que la page se soit imprimée telle qu'elle
+      s'affichait&nbsp;: une annotation peut être marquée
+      &laquo;&nbsp;afficher&nbsp;à&nbsp;l'écran, ne pas imprimer&nbsp;&raquo;, et
+      quand c'était le cas de votre cadre noir, la feuille qui sort de
+      l'imprimante porte le nom.
+    </p>
+    <p>
+      Le même argument vaut pour l'&laquo;&nbsp;aplatir en image&nbsp;&raquo; que
+      certains outils proposent comme caviardage. Cela transforme chaque page en
+      photographie d'elle-même. Si les mots étaient recouverts plutôt que
+      supprimés, le recouvrement est désormais définitif &mdash; mais tout le reste
+      du document est parti avec, et le fichier que vous envoyez est un fichier
+      avec lequel personne ne peut travailler.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi c'est le travail qui mérite le moins un envoi</h2>
+    <p>
+      À un service de caviardage, il faut remettre le fichier non caviardé. C'est
+      toute la transaction&nbsp;: la version privée arrive d'abord, entière, et
+      c'est elle qui se trouve sur le disque de quelqu'un d'autre. Quoi que dise la
+      politique de confidentialité, l'ordre des choses ne se discute pas&nbsp;: le
+      document dont vous preniez soin est celui que vous avez remis.
+    </p>
+    <p>
+      Ce que les gens caviardent aggrave cela plus qu'il n'y paraît. Des
+      témoignages, des courriers médicaux, des relevés bancaires destinés à un
+      propriétaire, un contrat portant le nom d'un client et destiné à un autre, un
+      mémoire portant une adresse personnelle. Ce sont ces documents-là, et c'est
+      exactement pourquoi l'outil qui les traite ne devrait pas avoir de serveur au
+      bout.
+    </p>
+    <p>
+      Tout, dans le <a href="../../caviarder-un-pdf/">caviardeur de ce site</a>, se
+      passe dans votre propre navigateur&nbsp;: le fichier est lu, modifié, écrit
+      et vérifié sur votre machine, et les mots que vous cherchez ne quittent pas
+      l'onglet non plus. Débranchez-vous d'internet et il continue de fonctionner,
+      ce qui est la preuve la plus simple qui soit que rien n'est envoyé nulle
+      part. Ce qu'implique réellement un envoi est expliqué dans
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">est-il sûr d'envoyer ses
+      fichiers</a>.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/redact-a-pdf.toml
+++ b/locales/fr/pages/guides/redact-a-pdf.toml
@@ -1,0 +1,20 @@
+#
+# Guide : caviarder un PDF - French.
+#
+
+nav = "Caviarder un PDF"
+title = "Comment caviarder un PDF pour que le texte disparaisse vraiment"
+description = "Un cadre noir dessiné dans une visionneuse PDF laisse le plus souvent les mots dessous, et un copier-coller les récupère aussitôt. Ce qu'une vraie suppression retire, les quatre endroits où un mot se cache hors de la page, et comment vérifier un fichier avant de l'envoyer."
+
+heading = "Comment caviarder un PDF pour que le texte disparaisse vraiment"
+lede = """
+    Un rectangle noir sur un nom et un nom supprimé sont identiques à l'écran.
+    L'un des deux survit à une sélection et un copier. Voici la différence, les
+    endroits où un mot se cache et qui ne sont pas du tout la page, et la
+    vérification de trente secondes qui vous dit lequel des deux vous avez."""
+
+updated = "25 août 2026"
+
+og_title = "Comment caviarder un PDF pour que le texte disparaisse vraiment"
+og_description = "Pourquoi un cadre noir dans une visionneuse PDF n'est en général pas un caviardage, les quatre endroits où un mot se cache hors de la page, et comment vérifier un fichier avant de l'envoyer."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/scan-a-document-with-your-phone.html
+++ b/locales/fr/pages/guides/scan-a-document-with-your-phone.html
@@ -1,0 +1,250 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Posez la page sur quelque chose qui n'est pas de la même couleur qu'elle,
+      tenez-vous au-dessus, remplissez le cadre et prenez une photo. Ouvrez
+      ensuite le <a href="../../scanner-un-document/">scanner de documents</a>,
+      vérifiez les quatre coins trouvés, choisissez
+      &laquo;&nbsp;Couleur,&nbsp;égalisée&nbsp;&raquo; ou
+      &laquo;&nbsp;Noir&nbsp;et&nbsp;blanc&nbsp;&raquo; et enregistrez le PDF.
+    </p>
+    <p>
+      C'est tout le travail. Le reste explique ce que corrige chacune de ces
+      étapes, car savoir quelle partie fait quoi est ce qui permet de voir, en
+      trois secondes, si ce que vous vous apprêtez à envoyer sera accepté.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce qui sépare réellement une photo d'un scan</h2>
+    <p>
+      Trois choses, et elles n'ont pas la même importance.
+    </p>
+    <ul>
+      <li>
+        <strong>L'inclinaison.</strong> Une photo est prise d'où vous vous
+        trouviez&nbsp;: la page est donc un quadrilatère et non un rectangle.
+        C'est ce que tout le monde remarque et le plus facile à défaire.
+      </li>
+      <li>
+        <strong>La lumière.</strong> Un scanner promène une lumière uniforme sur
+        la page. Une pièce, non&nbsp;: il y a une zone claire sous la lampe, un
+        coin sombre à l'écart, et très souvent votre propre ombre en travers d'un
+        côté. C'est cela qui fait réellement qu'une photo ressemble à une photo, et
+        c'est cela qu'on essaie de corriger avec le
+        &laquo;&nbsp;contraste&nbsp;automatique&nbsp;&raquo;, ce qui l'aggrave.
+      </li>
+      <li>
+        <strong>La taille.</strong> La photo d'une page à douze mégapixels fait
+        trois à cinq mégaoctets. Vingt d'entre elles font un document que la
+        moitié des serveurs de messagerie renverront.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Prendre la photo</h2>
+    <p>
+      Cinq choses, par ordre d'importance&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Remplissez le cadre.</strong> C'est la seule qui ne se corrige pas
+        après. Le détail qui n'était pas dans la photo n'est pas dans le fichier,
+        et une page photographiée depuis l'autre bout de la pièce est une page que
+        personne ne peut lire à aucune résolution. Approchez-vous plutôt que de
+        zoomer&nbsp;: à moins que le téléphone ne bascule sur un second objectif
+        plus long, zoomer est un recadrage du même capteur et jette précisément les
+        pixels que vous cherchez à garder.
+      </li>
+      <li>
+        <strong>Posez-la sur quelque chose d'une autre couleur.</strong> Une page
+        blanche sur un bureau blanc n'a presque aucun bord à trouver &mdash; ni
+        pour un logiciel, ni pour vous non plus quand il faudra tirer les coins à
+        la main. Une table sombre, un livre, un manteau&nbsp;: n'importe quoi.
+      </li>
+      <li>
+        <strong>Ne vous mettez pas entre la page et la lumière.</strong> Votre
+        propre ombre en travers de la page est la raison la plus fréquente pour
+        laquelle un scan fait au téléphone est mauvais. Tournez de quatre-vingt-dix
+        degrés et elle disparaît.
+      </li>
+      <li>
+        <strong>Laissez la mise au point se faire, puis ne bougez plus.</strong> Le
+        bougé n'est récupérable par aucun outil, et une mise au point ratée non
+        plus. Touchez la page à l'écran, attendez que cela se stabilise, puis
+        déclenchez.
+      </li>
+      <li>
+        <strong>Prenez la page entière, coins compris.</strong> Non que les coins
+        soient précieux, mais parce que c'est sur eux que se mesure le
+        redressement. Une page qui déborde du cadre fonctionne encore &mdash; le
+        bord de la photo tient lieu de bord de page &mdash; mais une page avec
+        trois coins dans le cadre et un quatrième deviné est une page qui sortira
+        légèrement de travers.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Redresser&nbsp;: la forme compte plus que l'angle</h2>
+    <p>
+      Défaire l'inclinaison est un calcul bien compris. Quatre coins d'un
+      rectangle vus de n'importe où déterminent la transformation qui les remet en
+      place, et l'appliquer à chaque pixel donne une page plate. Tout outil qui
+      prétend redresser une page fait cela.
+    </p>
+    <p>
+      Ce qui tourne mal en silence, c'est <em>quelle taille</em> doit avoir la page
+      plate. La méthode évidente est de mesurer les bords du quadrilatère et d'en
+      prendre le rapport&nbsp;; or une photo prise de biais raccourcit le bord
+      lointain, si bien qu'une feuille A4 sort visiblement trapue. Cela ressemble
+      toujours à un scan. Simplement, chaque ligne de texte y a la mauvaise
+      hauteur, et rien à l'écran ne le dit.
+    </p>
+    <p>
+      La meilleure réponse, c'est que la perspective elle-même porte
+      l'information&nbsp;: pourvu que ce soit un appareil ordinaire, la photo d'un
+      rectangle suffit à récupérer à la fois les vraies proportions du rectangle et
+      la focale de l'appareil. Le
+      <a href="../../scanner-un-document/">scanner de documents</a> d'ici le fait,
+      puis vous dit quelle forme la page a prise et si c'est un format normalisé
+      &mdash; une page qui annonce &laquo;&nbsp;1:1,41, la forme de l'A4 ou de
+      l'A5&nbsp;&raquo; est une page à laquelle vous pouvez cesser de penser.
+    </p>
+  </section>
+
+  <section>
+    <h2>La lumière&nbsp;: diviser, pas étirer</h2>
+    <p>
+      Monter le contraste d'une page inégalement éclairée rend la partie claire
+      blanche et la partie sombre noire, et l'écriture de la partie sombre
+      disparaît avec. Le problème n'a jamais été que le contraste fût trop faible.
+      C'est que le papier n'a pas la même clarté dans un coin et dans l'autre&nbsp;:
+      aucun réglage unique n'est donc juste pour toute la page.
+    </p>
+    <p>
+      Ce qui marche, c'est d'estimer la clarté du papier <em>en chaque point</em>
+      et de diviser par elle. Le papier est la majorité claire de tout petit
+      morceau d'une page&nbsp;: mesurer la clarté sur une grille de petites tuiles
+      et prendre une valeur haute dans chacune donne donc la forme de la lumière,
+      le texte étant trop sombre et trop clairsemé pour la déplacer. Divisez par
+      cela et ce qui reste est l'encre, uniformément éclairée, sans l'ombre et avec
+      le papier redevenu blanc.
+    </p>
+    <p>
+      C'est ce que font &laquo;&nbsp;Couleur,&nbsp;égalisée&nbsp;&raquo; et
+      &laquo;&nbsp;Niveaux&nbsp;de&nbsp;gris&nbsp;&raquo;. Choisissez la couleur
+      quand la couleur fait partie du document&nbsp;: un tampon, une signature à
+      l'encre bleue, une ligne surlignée, tout ce dont on pourrait plus tard
+      demander si c'était l'original.
+    </p>
+  </section>
+
+  <section>
+    <h2>Noir et blanc, et pourquoi le fichier devient soudain petit</h2>
+    <p>
+      Une page enregistrée en photographie, ce sont des millions de pixels ayant
+      chacun seize millions de couleurs possibles, et le codec dépense son effort
+      sur des dégradés subtils qu'une page de texte n'a pas. Une page enregistrée
+      en noir et blanc, c'est un bit par pixel &mdash; encre ou papier &mdash; et
+      cela compresse comme la chose massivement répétitive que c'est.
+    </p>
+    <p>
+      L'écart n'est pas mince&nbsp;: sur les mêmes pages, c'est environ dix-huit
+      fois. Un contrat de vingt pages qui pèse quinze mégaoctets en photographies
+      passe sous le mégaoctet en pages d'un bit, ce qui fait la différence entre un
+      document qu'on peut envoyer par courriel et un document qu'on ne peut pas.
+      C'est pourquoi tous les scanners de bureau l'ont par défaut.
+    </p>
+    <p>
+      Le hic, c'est qu'il n'y a pas de demi-teintes&nbsp;: une photographie sur la
+      page devient une bouillie de points. Employez-le pour les pages imprimées et
+      manuscrites, ce que sont la plupart des documents, et employez les niveaux de
+      gris pour tout ce qui porte une image.
+    </p>
+    <p>
+      Un détail qui vaut la peine d'être connu, parce qu'il explique pourquoi un
+      bon outil réussit là où un mauvais produit une page à coin noir&nbsp;: la
+      décision encre ou papier doit se prendre <em>localement</em>. Un seuil unique
+      pour toute la page ne peut pas fonctionner quand le papier dans l'ombre est
+      plus sombre que l'encre en pleine lumière &mdash; et sur une page
+      photographiée, il l'est très souvent. Décider chaque pixel face à la moyenne
+      de son propre petit voisinage est ce qui garde lisible l'écriture prise dans
+      une ombre.
+    </p>
+  </section>
+
+  <section>
+    <h2>Plusieurs pages, un seul document</h2>
+    <p>
+      Photographiez les pages dans l'ordre, ajoutez-les toutes d'un coup et elles
+      deviennent les pages d'un même PDF, dans l'ordre où elles ont été ajoutées.
+      Deux choses à surveiller&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Les noms de fichiers ne se trient pas comme vous le pensez.</strong>
+        <code>page2.jpg</code> vient après <code>page10.jpg</code> dans un tri
+        alphabétique, parce que la comparaison se fait caractère par caractère.
+        Vérifiez l'ordre dans la bande avant d'enregistrer, plutôt que dans le PDF
+        après coup.
+      </li>
+      <li>
+        <strong>Le nettoyage est un réglage pour tout le document</strong>, et
+        c'est délibéré. Des pages nettoyées différemment ressemblent à deux
+        documents agrafés ensemble, ce qui est exactement l'impression qu'un scan
+        doit éviter. Prenez le mode qui convient à la pire page.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Avant de l'envoyer</h2>
+    <ul>
+      <li>
+        <strong>Ouvrez le PDF.</strong> Pas l'aperçu&nbsp;: le fichier. Chaque
+        page, dans le bon sens, rien de coupé sur un bord.
+      </li>
+      <li>
+        <strong>Lisez la plus petite chose de la page.</strong> Un numéro de
+        dossier, une date, un numéro de compte. Si vous ne pouvez pas le lire à
+        l'écran à 100&nbsp;%, votre destinataire non plus.
+      </li>
+      <li>
+        <strong>Vérifiez que les coins n'ont pas été rognés.</strong> Ce qui se
+        trouve au bord d'un formulaire, c'est un numéro de page, une ligne de
+        signature, ou la case dont on dira plus tard qu'elle manquait.
+      </li>
+      <li>
+        <strong>Vérifiez ce que le document dit de vous.</strong> Un PDF a des
+        champs pour l'auteur, le producteur et la date de création, et la plupart
+        des outils les remplissent. Que cela compte dépend du destinataire, mais il
+        vaut la peine de savoir que c'est là.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Pourquoi rien de tout cela n'a besoin d'un envoi</h2>
+    <p>
+      Chaque étape ci-dessus est du calcul sur une image que votre propre machine a
+      déjà décodée&nbsp;: quatre coins, une transformation, une division, un seuil
+      et un conteneur écrit octet par octet. Rien là-dedans qu'un serveur puisse
+      faire et qu'un navigateur ne puisse pas, et rien qui exige de télécharger un
+      modèle pour le faire.
+    </p>
+    <p>
+      Cela mérite qu'on s'y arrête, à cause de ce que sont ces fichiers. On ne
+      photographie pas des pages au hasard. On photographie un passeport, une fiche
+      de paie, un bail, un formulaire médical, un contrat &mdash; des documents
+      portant un nom, une adresse et un numéro de compte, numérisés précisément
+      parce qu'une institution les a réclamés. En envoyer un à un site web pour
+      qu'on lui redresse les coins revient à remettre le document entier à un
+      inconnu. Voir
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">comment savoir si un outil a
+      vraiment besoin de vos fichiers</a> pour les quatre vérifications qui
+      séparent les outils qui doivent voir votre fichier de ceux qui se contentent
+      de le voir.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/scan-a-document-with-your-phone.toml
+++ b/locales/fr/pages/guides/scan-a-document-with-your-phone.toml
@@ -1,0 +1,21 @@
+#
+# Guide : scanner un document avec son téléphone - French.
+#
+
+nav = "Scanner avec son téléphone"
+title = "Comment scanner un document avec son téléphone, sans application ni envoi"
+description = "Ce qui sépare la photo d'une page d'un scan de cette même page&nbsp;: l'inclinaison, la lumière inégale et la taille du fichier. Comment prendre la photo, quoi corriger ensuite, et pourquoi rien de tout cela n'a besoin d'un serveur."
+
+heading = "Comment scanner un document avec son téléphone"
+lede = """
+    On vous a demandé de renvoyer un formulaire &laquo;&nbsp;scanné&nbsp;&raquo;,
+    et vous avez un téléphone et pas de scanner. L'écart entre la photo d'une
+    page et un scan de cette page est plus petit qu'il n'y paraît, et il ne tient
+    pas surtout à l'inclinaison&nbsp;: voici ce qui les sépare réellement, et
+    quoi faire de chaque morceau."""
+
+updated = "25 août 2026"
+
+og_title = "Comment scanner un document avec son téléphone"
+og_description = "L'inclinaison, l'ombre et la taille du fichier &mdash; ce qui sépare la photo d'une page d'un scan de cette page, et comment corriger chacun sans envoyer la page."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/pages/guides/stack-photos-to-reduce-noise.html
+++ b/locales/fr/pages/guides/stack-photos-to-reduce-noise.html
@@ -1,0 +1,302 @@
+  <section>
+    <h2>La réponse courte</h2>
+    <p>
+      Ouvrez l'<a href="../../empiler-des-images/">empileur d'images</a>, déposez
+      la rafale entière et choisissez la méthode selon ce dont vous voulez vous
+      débarrasser&nbsp;:
+    </p>
+    <ul>
+      <li><strong>Le bruit</strong>, et rien n'a bougé &mdash; moyenne.</li>
+      <li><strong>Le bruit</strong>, et quelque chose a bougé &mdash; écrêtage sigma.</li>
+      <li><strong>Des gens, des voitures, un avion</strong> &mdash; médiane.</li>
+      <li><strong>Un ciel noir que vous voulez en filés d'étoiles</strong> &mdash; éclaircir.</li>
+      <li><strong>Une macro presque sans profondeur de champ</strong> &mdash; empilement de mise au point.</li>
+    </ul>
+    <p>
+      Laissez l'alignement activé si l'appareil était dans vos mains, et
+      désactivez-le s'il était sur un trépied. Les fichiers RAW peuvent entrer
+      directement&nbsp;; il n'est pas nécessaire de les développer d'abord.
+    </p>
+    <p>
+      Tout ce qui suit explique pourquoi ces cinq lignes disent ce qu'elles
+      disent.
+    </p>
+  </section>
+
+  <section>
+    <h2>Pourquoi une rafale porte plus qu'une prise</h2>
+    <p>
+      Une photographie faite dans une lumière médiocre, c'est l'image plus du
+      bruit, et le bruit est différent à chaque fois. C'est cette dernière partie
+      qui fait marcher l'empilement. Prenez seize fois la même vue&nbsp;: l'image
+      est identique sur les seize alors que le bruit ne l'est pas, si bien que les
+      moyenner laisse l'image et annule l'essentiel du bruit.
+    </p>
+    <p>
+      L'amélioration est la racine carrée du nombre de prises. Quatre prises
+      divisent le bruit par deux. Seize, par quatre. Cent, par dix. C'est une
+      courbe impitoyable&nbsp;: passer de seize à soixante-quatre prises apporte la
+      même amélioration une seconde fois, pour quatre fois plus de déclenchements
+      &mdash; et c'est pourquoi presque toute pile pratique se situe entre huit et
+      trente prises.
+    </p>
+    <p>
+      Il y a un second gain, plus discret. Moyenner seize prises de huit bits donne
+      un résultat aux dégradés plus fins que n'en avait aucune d'elles, parce que
+      le bruit qui faisait arrondir chaque prise différemment est précisément ce
+      qui permet à la moyenne de tomber entre les niveaux. Empiler une série
+      bruitée ne fait pas que retirer du bruit&nbsp;: cela récupère des nuances
+      qu'une prise unique avait quantifiées.
+    </p>
+  </section>
+
+  <section>
+    <h2>La question qui choisit la méthode</h2>
+    <p>
+      Non pas &laquo;&nbsp;que veux-je garder&nbsp;&raquo;, mais <strong>qu'est-ce
+      qui différait d'une prise à l'autre</strong>. Tout le reste en découle.
+    </p>
+
+    <h3>Rien n'a bougé&nbsp;: la moyenne</h3>
+    <p>
+      La moyenne toute simple. C'est la réduction de bruit la plus efficace qui
+      existe sur une série où la seule différence entre les prises est le bruit, et
+      la plus facile à ruiner&nbsp;: une prise avec un oiseau dedans pose un oiseau
+      pâle sur toute la pile, parce qu'une moyenne n'a pas d'avis sur une valeur
+      qui contredit les autres. Elle l'inclut, tout simplement.
+    </p>
+
+    <h3>Quelque chose a traversé le cadre&nbsp;: la médiane</h3>
+    <p>
+      Alignez une douzaine de photographies d'une place animée et regardez un
+      pixel. Sur la plupart c'est du pavé&nbsp;; sur une ou deux c'est le manteau
+      de quelqu'un. Triez ces douze valeurs, prenez celle du milieu, et vous
+      obtenez du pavé, parce que le manteau n'a jamais été majoritaire.
+    </p>
+    <p>
+      Faites cela pour chaque pixel et la place sort vide. C'est le tour de main
+      derrière tous les articles sur &laquo;&nbsp;retirer les touristes de vos
+      photos de vacances&nbsp;&raquo;, et il n'exige rien de plus malin qu'une
+      rafale et de la patience. La seule chose qu'il demande, c'est
+      <strong>qu'aucune partie de la scène ne soit occupée plus de la moitié du
+      temps</strong>. Une personne immobile sur huit de vos douze prises est
+      majoritaire sur ces pixels, et la médiane la garde.
+    </p>
+
+    <h3>Les deux&nbsp;: l'écrêtage sigma</h3>
+    <p>
+      La médiane jette l'essentiel de l'information pour obtenir sa robustesse
+      &mdash; onze de vos douze valeurs sont écartées à chaque pixel &mdash;, elle
+      réduit donc bien moins le bruit qu'une moyenne de la même série ne le
+      ferait.
+    </p>
+    <p>
+      L'écrêtage sigma est le compromis, et c'est en général le réglage par défaut
+      qui convient à toute série du monde réel. Il regarde chaque pixel sur toutes
+      les prises, détermine ce qu'il est habituellement et de combien il varie,
+      puis ne moyenne que les valeurs qui concordent. Une voiture qui a traversé
+      une prise est exclue sur ces pixels&nbsp;; toutes les autres prises comptent
+      encore partout. Vous obtenez l'immunité de la médiane à ce qui a bougé et
+      l'essentiel de la réduction de bruit de la moyenne.
+    </p>
+    <p>
+      Le seuil est en écarts-types, et deux est le point de départ habituel. Plus
+      bas écarte davantage, et commence à écarter du détail réel avec la voiture.
+    </p>
+
+    <h3>Seul ce qui est clair compte&nbsp;: éclaircir</h3>
+    <p>
+      Garder la valeur la plus claire qu'ait jamais eue chaque pixel. Photographiez
+      le ciel nocturne en deux cents poses de trente secondes et éclaircissez-les
+      ensemble&nbsp;: chaque étoile trace son propre arc sur le résultat &mdash; un
+      filé d'étoiles, assemblé à partir de poses courtes qui, prises isolément,
+      n'ont jamais brûlé. La même méthode recompose un feu d'artifice à partir des
+      prises de sa propre explosion, et un light painting à partir d'une promenade
+      à la lampe torche dans une pièce noire.
+    </p>
+    <p>
+      Son contraire, assombrir, est le discret de la paire&nbsp;: un pixel ne reste
+      clair que s'il l'était sur <em>toutes</em> les prises, si bien que les reflets
+      dans une vitre, les phares qui passent et les gouttes de pluie éclairées au
+      flash disparaissent tous.
+    </p>
+
+    <h3>Le sujet est plus profond que la mise au point&nbsp;: l'empilement de mise au point</h3>
+    <p>
+      Une macro à f/8 a peut-être un millimètre de net, ce qui ne suffit pas pour
+      un insecte. La réponse est de faire vingt prises le long de la bague de mise
+      au point et de ne garder, de chacune, que la partie qui y était nette.
+      L'outil mesure de combien chaque pixel diffère de ses voisins &mdash;
+      beaucoup sur un bord, presque rien sur un flou &mdash; et retient le
+      gagnant.
+    </p>
+    <p>
+      Celle-ci réclame un trépied plus que toutes les autres, parce que tourner la
+      bague à la main déplace l'appareil, et qu'une prise faite d'un peu plus loin
+      n'est pas la même image à une autre mise au point.
+    </p>
+  </section>
+
+  <section>
+    <h2>Aligner les prises</h2>
+    <p>
+      L'empilement est un calcul pixel par pixel&nbsp;: il suppose donc qu'un pixel
+      donné est la même partie de la scène sur toutes les prises. À main levée, il
+      ne l'est pas&nbsp;: une rafale dérive de plusieurs dizaines de pixels, et
+      moyenner cela produit un flou plutôt qu'une image nette. C'est la raison la
+      plus fréquente pour laquelle un premier essai d'empilement déçoit.
+    </p>
+    <p>
+      Les prises sont donc mesurées par rapport à l'une d'elles et remises en place
+      d'abord, à une fraction de pixel près. Trois réglages&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>Décalage seul</strong> convient à presque tout ce qui est pris à
+        main levée. Il corrige la dérive et le tremblement.
+      </li>
+      <li>
+        <strong>Décalage, rotation et échelle</strong> pour une série où vous
+        tourniez aussi légèrement, ou dans laquelle un zoom a glissé. Cela coûte
+        une mesure de plus par prise et rien du tout lorsque les prises se révèlent
+        droites.
+      </li>
+      <li>
+        <strong>Aucun</strong> pour un trépied fixe ou une séquence
+        d'intervallomètre, où les prises sont déjà alignées et où les mesurer est
+        du temps perdu.
+      </li>
+    </ul>
+    <p>
+      Ce qu'aucun alignement ne peut corriger, c'est un sujet qui a bougé plutôt
+      qu'un appareil qui a bougé, ni une photographie prise un pas plus à gauche. Se
+      déplacer latéralement change de combien le proche se décale par rapport au
+      lointain, et aucune correction unique ne décrit les deux à la fois. Tourner
+      sur place, c'est bon&nbsp;; marcher, non.
+    </p>
+  </section>
+
+  <section>
+    <h2>Où les fichiers RAW s'insèrent</h2>
+    <p>
+      Vous pouvez déposer directement des CR2, CR3, NEF, ARW, DNG, RAF, RW2, ORF et
+      le reste, et il vaut la peine d'être exact sur ce qui leur arrive, car ce
+      n'est pas ce que fait un dérawtiseur.
+    </p>
+    <p>
+      Tout fichier RAW contient déjà un <strong>JPEG pleine taille que l'appareil a
+      développé au déclenchement</strong>. C'est ce que vous montre le dos de
+      l'appareil et ce que votre système d'exploitation dessine en vignette.
+      L'empileur trouve cette image et l'emploie. Il ne décode pas les données du
+      capteur.
+    </p>
+    <p>
+      Deux conséquences, une bonne et une à connaître&nbsp;:
+    </p>
+    <ul>
+      <li>
+        <strong>C'est rapide.</strong> Trouver l'aperçu revient à lire quelques
+        kilooctets de répertoire puis une seule tranche, si bien qu'une prise de
+        60&nbsp;Mo s'ouvre à peu près aussi vite qu'un JPEG. Vingt d'entre elles
+        s'ouvrent dans le temps qu'un dérawtiseur consacrerait à une seule. La page
+        vous montre le peu de vos fichiers qu'elle a réellement lu.
+      </li>
+      <li>
+        <strong>C'est l'interprétation de l'appareil, pas la vôtre.</strong> Huit
+        bits par canal, avec la balance des blancs et le style d'image réglés sur
+        l'appareil &mdash; et non les douze ou quatorze bits de données linéaires
+        de capteur qu'un dérawtiseur vous donnerait.
+      </li>
+    </ul>
+    <p>
+      Pour la réduction de bruit, les filés d'étoiles, le retrait des passants et
+      l'empilement de mise au point, ce compromis vaut presque toujours la
+      peine&nbsp;: les aperçus sont en pleine résolution et ils sont ce que vous
+      auriez obtenu en JPEG de toute façon. Si vous poussez fort les ombres, ou si
+      vous empilez pour de l'astrophotographie où le dernier bit de dynamique est
+      tout l'enjeu, développez d'abord les prises dans un dérawtiseur et empilez
+      les TIFF ou les JPEG qu'il donne. Ils entrent de la même façon.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ce que cela coûte à l'exécution</h2>
+    <p>
+      Cela vaut la peine d'être su, parce que c'est la différence entre une pile qui
+      prend huit secondes et une qui en prend deux minutes.
+    </p>
+    <p>
+      Six des sept méthodes n'ont jamais besoin de se souvenir que d'une chose. Un
+      maximum courant se moque des prises qu'il a déjà vues, et un total courant
+      aussi&nbsp;: ces méthodes lisent donc chaque prise exactement une fois et
+      emploient autant de mémoire pour cent prises que pour deux.
+    </p>
+    <p>
+      La médiane ne peut pas fonctionner ainsi, parce qu'on ne peut connaître la
+      valeur centrale d'un ensemble qu'une fois qu'on l'a tout entier. Vingt prises
+      de 24 mégapixels font environ 1,4&nbsp;Go de pixels gardés à la fois, ce
+      qu'aucun navigateur ne vous accordera&nbsp;: l'image est donc découpée en
+      bandes horizontales et empilée bande par bande &mdash; correct, et plus lent,
+      parce que les prises sont relues pour chaque bande.
+    </p>
+    <p>
+      L'outil calcule tout cela avant que vous n'appuyiez sur le bouton et vous le
+      dit&nbsp;: la taille du résultat, la mémoire qu'il demandera à peu près, et
+      combien de fois vos prises seront décodées. S'il annonce un passage en bandes,
+      baisser la résolution de travail d'un cran divise la mémoire par quatre et le
+      ramène presque toujours à un seul passage &mdash; et si vous empilez pour
+      retirer du bruit, la demi-résolution allait de toute façon paraître plus
+      propre que la pleine.
+    </p>
+  </section>
+
+  <section>
+    <h2>Photographier en vue de cela</h2>
+    <p>
+      L'essentiel de la qualité d'une pile se décide avant qu'aucun logiciel ne la
+      voie.
+    </p>
+    <ul>
+      <li>
+        <strong>Faites plus de prises que vous ne le croyez nécessaire.</strong> La
+        courbe en racine carrée est impitoyable en bas et généreuse en haut&nbsp;:
+        passer de quatre à neuf prises est un changement plus visible que passer de
+        vingt à quarante.
+      </li>
+      <li>
+        <strong>Ne changez pas l'exposition entre les prises.</strong> L'empilement
+        suppose que les prises montrent la même scène à la même luminosité. Bloquez
+        l'exposition, sinon l'outil moyennera deux images différentes.
+      </li>
+      <li>
+        <strong>Pour retirer des gens, attendez entre les prises.</strong> Une
+        rafale prise en deux secondes attrape la même personne au même endroit sur
+        toutes les prises, et la médiane la garde. Dix prises espacées de quelques
+        secondes marchent bien mieux que cinquante en rafale.
+      </li>
+      <li>
+        <strong>Pour les filés d'étoiles, gardez les intervalles courts.</strong>
+        Éclaircir dessine exactement ce que les prises ont enregistré&nbsp;: une
+        pause entre deux poses devient donc un tiret visible sur chaque filé.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Rien de tout cela ne quitte votre machine</h2>
+    <p>
+      Une pile de vingt prises RAW fait environ un gigaoctet de photographies, ce
+      qui fait beaucoup à confier à un site web pour qu'il en fasse la moyenne.
+      L'<a href="../../empiler-des-images/">empileur d'images</a> lit les fichiers
+      sur votre propre disque et fait le calcul dans votre propre navigateur. Il
+      n'y a ni étape d'envoi, ni compte, ni file d'attente, et vous pouvez vérifier
+      cette affirmation comme vous vérifieriez celle de n'importe qui&nbsp;: ouvrez
+      le panneau réseau de votre navigateur pendant qu'il travaille, ou
+      débranchez-vous simplement d'internet et empilez quand même.
+    </p>
+    <p>
+      La question voisine &mdash; comment savoir, pour n'importe quel outil, si lui
+      confier un fichier était nécessaire &mdash; a
+      <a href="../est-il-sur-d-envoyer-ses-fichiers/">son propre guide</a>.
+    </p>
+  </section>

--- a/locales/fr/pages/guides/stack-photos-to-reduce-noise.toml
+++ b/locales/fr/pages/guides/stack-photos-to-reduce-noise.toml
@@ -1,0 +1,20 @@
+#
+# Guide : empiler des photos contre le bruit - French.
+#
+
+nav = "Empiler des photographies"
+title = "Comment empiler des photographies pour réduire le bruit, ou retirer les gens"
+description = "L'empilement combine une rafale de prises en une seule image. La méthode qu'il vous faut dépend de ce que vous cherchez à perdre&nbsp;: le bruit, les passants, ou la faible profondeur de champ d'une macro. Comment chacune fonctionne, ce qu'elle coûte, et où les fichiers RAW s'insèrent."
+
+heading = "Comment empiler des photographies pour réduire le bruit, ou retirer les gens"
+lede = """
+    Une rafale de prises porte plus d'information que n'importe laquelle d'entre
+    elles. Les moyenner annule le bruit&nbsp;; prendre la valeur centrale de
+    chaque pixel efface tout ce qui n'était là qu'une partie du temps. Laquelle
+    des deux vous voulez dépend entièrement de ce qui a bougé."""
+
+updated = "25 août 2026"
+
+og_title = "Comment empiler des photographies pour réduire le bruit, ou retirer les gens"
+og_description = "Moyennez une rafale pour tuer le bruit, prenez la médiane pour vider une place animée, éclaircissez pour des filés d'étoiles. Quelle méthode résout quel problème, et où les fichiers RAW s'insèrent."
+og_image_alt = "abox.tools - des outils qui ne touchent jamais un serveur"

--- a/locales/fr/tools/dicom-viewer.html
+++ b/locales/fr/tools/dicom-viewer.html
@@ -1,0 +1,267 @@
+<!--
+  tools/dicom-viewer/body.html, in French.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+
+  L'en-tete de colonne "VR" reste tel quel : c'est le code a deux lettres ecrit
+  dans le fichier, et qui verifie une etiquette dans la norme cherche
+  exactement ces deux lettres.
+-->
+<main>
+  <!--
+    One numbered step, and then the viewer.
+
+    Every other tool on this site numbers its cards because every card is
+    something the visitor does. Here there is one thing to do - choose the
+    files - and everything below it is the scan. Numbering the picture would
+    promise a sequence of decisions that does not exist.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisissez un examen</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p class="picker-note">
+      Déposez d'un coup le contenu d'un dossier entier&nbsp;: les fichiers sont
+      remis dans leurs séries et empilés dans l'ordre. Rien n'est envoyé, et rien
+      n'est réécrit dans vos fichiers.
+    </p>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- La visionneuse. -->
+  <section class="card" id="viewer-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="save-frame" class="ghost" data-download>Enregistrer cette image en PNG</button>
+        <button type="button" id="copy-header" class="ghost">Copier l'en-tête</button>
+        <button type="button" id="download-header" class="ghost">Le télécharger</button>
+      </div>
+    </div>
+
+    <div class="series-row" id="series-row" hidden>
+      <label for="series-pick" class="inline-label">Série</label>
+      <select id="series-pick"></select>
+      <span class="count" id="series-note"></span>
+    </div>
+
+    <!--
+      The canvas is sized in CSS and its backing store is set to the frame's own
+      pixels, so a 512-pixel slice is drawn at 512 pixels and scaled by the
+      browser rather than resampled here. That is what makes the zoom honest:
+      what is on screen at 400% is the stored pixels made bigger, not a guess at
+      what was between them.
+    -->
+    <div class="viewport" id="viewport">
+      <canvas id="canvas" width="1" height="1" role="img"
+              aria-label="L'image à l'écran, dessinée à partir du fichier que vous avez choisi"></canvas>
+      <div class="overlay overlay-tl" id="overlay-tl" hidden></div>
+      <div class="overlay overlay-tr" id="overlay-tr"></div>
+      <div class="overlay overlay-bl" id="overlay-bl"></div>
+      <div class="overlay overlay-br" id="overlay-br"></div>
+      <svg class="marks" id="marks" aria-hidden="true"></svg>
+      <p class="viewport-fail" id="viewport-fail" hidden></p>
+    </div>
+
+    <div class="scrub" id="scrub-row" hidden>
+      <button type="button" id="play" class="ghost" aria-label="Faire défiler les images">▶</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" step="1"
+             aria-label="Quelle coupe ou quelle image est affichée">
+      <span class="count" id="scrub-label">&mdash;</span>
+    </div>
+
+    <div class="tools">
+      <fieldset class="modes">
+        <legend class="visually-hidden">Ce que fait le glissement sur l'image</legend>
+        <label><input type="radio" name="mode" value="window" checked> Fenêtrage</label>
+        <label><input type="radio" name="mode" value="pan"> Déplacer</label>
+        <label><input type="radio" name="mode" value="measure"> Mesurer</label>
+      </fieldset>
+
+      <div class="zoom">
+        <label for="zoom" class="inline-label">Zoom</label>
+        <input type="range" id="zoom" min="5" max="800" step="5" value="100">
+        <span class="count" id="zoom-label">100%</span>
+        <button type="button" id="reset-view" class="ghost">Ajuster</button>
+      </div>
+    </div>
+
+    <div class="levels" id="levels">
+      <div class="level-field">
+        <label for="preset" class="inline-label">Fenêtre</label>
+        <select id="preset"></select>
+      </div>
+      <div class="level-field">
+        <label for="center" class="inline-label">Centre</label>
+        <input type="number" id="center" step="1">
+      </div>
+      <div class="level-field">
+        <label for="width" class="inline-label">Largeur</label>
+        <input type="number" id="width" step="1" min="1">
+      </div>
+      <label class="level-check"><input type="checkbox" id="invert"> Inverser</label>
+      <label class="level-check"><input type="checkbox" id="show-details"> Afficher les données du patient sur l'image</label>
+    </div>
+
+    <p class="hint" id="mode-hint"></p>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- Ce qu'est ce fichier. -->
+  <section class="card" id="facts-card" hidden>
+    <h2>Ce qu'est ce fichier</h2>
+    <dl class="facts">
+      <div><dt>Objet</dt><dd id="fact-sop">&mdash;</dd></div>
+      <div><dt>Modalité</dt><dd id="fact-modality">&mdash;</dd></div>
+      <div><dt>Image</dt><dd id="fact-size">&mdash;</dd></div>
+      <div><dt>Stockée en</dt><dd id="fact-stored">&mdash;</dd></div>
+      <div><dt>Syntaxe de transfert</dt><dd id="fact-syntax">&mdash;</dd></div>
+      <div><dt>Écartement des pixels</dt><dd id="fact-spacing">&mdash;</dd></div>
+      <div><dt>Plage de valeurs</dt><dd id="fact-range">&mdash;</dd></div>
+      <div><dt>Fichier</dt><dd id="fact-file">&mdash;</dd></div>
+    </dl>
+
+    <ul class="notes" id="notes" hidden></ul>
+  </section>
+
+  <!-- Ce qu'il contient sur la personne. -->
+  <section class="card" id="identity-card" hidden>
+    <h2>Ce qui, dans ce fichier, identifie le patient</h2>
+    <p class="card-lede">
+      Lu depuis ce fichier, sur cette machine, et montré à personne d'autre. Cet
+      outil n'écrit rien&nbsp;: il ne peut rien en retirer, et il n'en a rien
+      envoyé nulle part. C'est là parce qu'un examen transporte bien plus qu'un
+      nom, et que le reste est précisément ce qui survit à une anonymisation
+      négligente.
+    </p>
+    <ul class="identity" id="identity"></ul>
+    <p class="identity-extra" id="identity-extra"></p>
+  </section>
+
+  <!-- Chaque étiquette du fichier. -->
+  <section class="card" id="tags-card" hidden>
+    <div class="toolbar">
+      <h2>Chaque étiquette du fichier</h2>
+      <div class="toolbar-actions">
+        <label for="tag-search" class="visually-hidden">Rechercher dans les étiquettes</label>
+        <input type="search" id="tag-search" class="tag-search" placeholder="Rechercher par nom, numéro ou valeur">
+      </div>
+    </div>
+
+    <p class="card-lede" id="tags-lede"></p>
+
+    <div class="table-wrap">
+      <table class="tags">
+        <caption class="visually-hidden">Chaque élément de ce fichier</caption>
+        <thead>
+          <tr>
+            <th scope="col">Étiquette</th>
+            <th scope="col">VR</th>
+            <th scope="col">Nom</th>
+            <th scope="col">Valeur</th>
+          </tr>
+        </thead>
+        <tbody id="tag-rows"></tbody>
+      </table>
+    </div>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!--
+    The tool's own sentences, kept out of the JavaScript so that a translator
+    can reach them. shared/js/phrases.js reads them back, and a key defined here
+    wins over the frame's one.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="mode.window">Faites glisser sur l'image pour élargir ou resserrer la fenêtre, et vers le haut ou le bas pour déplacer son centre. Les deux nombres sont en dessous, et les saisir fait la même chose.</span>
+    <span data-phrase="mode.pan">Faites glisser pour déplacer l'image dans son cadre. La molette zoome, et &laquo;&nbsp;Ajuster&nbsp;&raquo; remet tout en place.</span>
+    <span data-phrase="mode.measure">Tracez une ligne sur l'image pour la mesurer. Là où le fichier indique l'écartement de ses pixels, la réponse est en millimètres&nbsp;; sinon elle est en pixels et le dit.</span>
+
+    <span data-phrase="probe.value">{value} à la colonne {column}, ligne {row}</span>
+    <span data-phrase="measure.pixels">{length} px &mdash; ce fichier n'indique pas l'écartement de ses pixels, ceci ne peut donc pas être en millimètres</span>
+
+    <span data-phrase="stack.position">Empilées par la position de chaque coupe dans le patient, qui est l'ordre dans lequel la machine les a prises.</span>
+    <span data-phrase="stack.number">Empilées par numéro d'instance&nbsp;: ces fichiers ne portent aucune position dans le patient sur laquelle trier.</span>
+    <span data-phrase="stack.gap">L'écart entre les coupes n'est pas constant d'un bout à l'autre&nbsp;: il manque donc au moins une coupe à cette série.</span>
+
+    <span data-phrase="pixels.none">Les pixels de ce fichier sont compressés avec {codec}, qu'aucun navigateur ne sait décoder et dont cette page n'embarque pas de décodeur. Tout le reste du fichier est ci-dessous.</span>
+    <span data-phrase="pixels.failed">L'image n'a pas pu être décodée&nbsp;: {reason}. L'en-tête ci-dessous a été lu en entier.</span>
+    <span data-phrase="pixels.absent">Ce fichier ne contient aucune donnée de pixel. C'est un en-tête, et tout ce qu'il contient est ci-dessous.</span>
+    <span data-phrase="pixels.jpeg">Ces pixels sont du JPEG baseline&nbsp;: c'est donc le décodeur du navigateur qui les a dépaquetés, et ce qu'il rend fait huit bits de profondeur. Le fenêtrage fonctionne toujours&nbsp;; la précision enregistrée par la machine n'y est pas entièrement.</span>
+
+    <span data-phrase="tags.count">{shown} éléments sur {total}. {hidden} de plus.</span>
+    <span data-phrase="tags.all">Les {total} éléments de ce fichier.</span>
+    <span data-phrase="tags.found">{total} éléments correspondent à &laquo;&nbsp;{query}&nbsp;&raquo;.</span>
+    <span data-phrase="tags.found.one">Un élément correspond à &laquo;&nbsp;{query}&nbsp;&raquo;.</span>
+    <span data-phrase="tags.none">Rien ne correspond à &laquo;&nbsp;{query}&nbsp;&raquo;.</span>
+    <span data-phrase="tags.more">Afficher les {count} restants</span>
+    <span data-phrase="tags.private">élément privé</span>
+    <span data-phrase="tags.unknown">absent de ce dictionnaire</span>
+    <span data-phrase="tags.guessed">Le fichier ne le disait pas&nbsp;; voici ce que le dictionnaire de données donne pour cette étiquette.</span>
+
+    <span data-phrase="working.one">Lecture de {name}&hellip;</span>
+    <span data-phrase="working.many">Lecture de {at} sur {total}&hellip;</span>
+    <span data-phrase="error.none">Rien ici n'a pu être lu comme du DICOM. {why} Cet outil lit le format DICOM lui-même, il n'a donc rien à dire des autres fichiers.</span>
+    <span data-phrase="error.skipped.one">Un fichier a été ignoré&nbsp;: {files}</span>
+    <span data-phrase="error.skipped">{count} fichiers ont été ignorés&nbsp;: {files}</span>
+
+    <span data-phrase="series.number">Série {number}</span>
+    <span data-phrase="series.files.one">1 fichier</span>
+    <span data-phrase="series.files">{count} fichiers</span>
+    <span data-phrase="stack.spacing">Les coupes sont espacées de {gap}.</span>
+
+    <span data-phrase="at.position">{at} sur {total}</span>
+    <span data-phrase="net.clean">votre examen n'est allé nulle part. {total}
+      fichiers chargés, tous appartenant à cette page. {platform}</span>
+    <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet
+      outil ne fait jamais. Cela mérite d'être examiné. {platform}</span>
+    <span data-phrase="net.platform.one">Les scripts de publicité, de mesure et
+      du bouton de don propres à la page ont été chargés depuis {hosts} hôte&nbsp;;
+      aucun d'eux n'a reçu un examen, un pixel d'examen ou un mot de son
+      en-tête.</span>
+    <span data-phrase="net.platform.many">Les scripts de publicité, de mesure et
+      du bouton de don propres à la page ont été chargés depuis {hosts}
+      hôtes&nbsp;; aucun d'eux n'a reçu un examen, un pixel d'examen ou un mot de
+      son en-tête.</span>
+    <span data-phrase="at.frame">image {at} sur {total}</span>
+    <span data-phrase="at.instance">instance {number}</span>
+
+    <span data-phrase="window.file">Du fichier</span>
+    <span data-phrase="window.file.n">Du fichier, {n}</span>
+    <span data-phrase="window.full">Tout ce qu'il y a dans cette image</span>
+    <span data-phrase="window.custom">Réglée à la main</span>
+    <span data-phrase="window.soft">Parties molles</span>
+    <span data-phrase="window.lung">Poumon</span>
+    <span data-phrase="window.bone">Os</span>
+    <span data-phrase="window.brain">Cerveau</span>
+    <span data-phrase="window.liver">Foie</span>
+    <span data-phrase="window.mediastinum">Médiastin</span>
+    <span data-phrase="window.angio">Angiographie</span>
+
+    <span data-phrase="facts.frames">{count} images</span>
+    <span data-phrase="facts.nopixels">aucune donnée de pixel</span>
+    <span data-phrase="facts.nospacing">non indiqué dans ce fichier</span>
+    <span data-phrase="facts.signed">signé</span>
+    <span data-phrase="facts.unsigned">non signé</span>
+    <span data-phrase="facts.stored.one">{bits} bits, {sign}, 1 échantillon par pixel, {photometric}</span>
+    <span data-phrase="facts.stored">{bits} bits, {sign}, {samples} échantillons par pixel, {photometric}</span>
+    <span data-phrase="facts.range">{low} à {high}</span>
+    <span data-phrase="facts.colour">couleur &mdash; rien de mesuré à signaler</span>
+
+    <span data-phrase="identity.clean">Rien dans ce fichier ne nomme ni ne numérote une personne. Les identifiants qu'un examen porte d'ordinaire sont absents ou vides.</span>
+    <span data-phrase="identity.uids">Il porte en outre {count} identifiants qui lui sont propres&nbsp;: les UID de l'examen, de la série et de l'instance. Aucun n'est un nom, et chacun d'eux est une clé parfaite vers l'archive dont le fichier provient.</span>
+    <span data-phrase="identity.private">Et {count} éléments privés, dont la signification n'est publiée nulle part&nbsp;: certaines machines gardent dans l'un d'eux une seconde copie du nom du patient.</span>
+
+    <span data-phrase="copied">Copié.</span>
+    <span data-phrase="copy.failed">Votre navigateur n'a pas laissé la page copier. Le bouton de téléchargement d'à côté écrit le même texte dans un fichier.</span>
+    <span data-phrase="saved">{name} enregistré.</span>
+  </div>
+</main>

--- a/locales/fr/tools/dicom-viewer.toml
+++ b/locales/fr/tools/dicom-viewer.toml
@@ -1,0 +1,411 @@
+#
+# Visionneuse DICOM - French.
+#
+# Overrides for tools/dicom-viewer/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Les noms de champ DICOM restent en anglais avec leur numero - Pixel Spacing
+# (0028,0030), Series Instance UID (0020,000E). C'est ainsi qu'ils sont ecrits
+# dans le fichier et dans la norme, et quiconque verifie un champ cherche
+# exactement ces mots-la. Idem pour les syntaxes de transfert et pour PS3.15.
+#
+# C'est la page ou la promesse du site est la plus tranchante : le fichier est
+# un dossier medical avec une image dedans. Les phrases sur ce qu'il contient
+# sont traduites avec le meme soin que celles sur les endroits ou il ne va pas.
+#
+
+name = "Visionneuse DICOM"
+heading = "Visionneuse&nbsp;DICOM <span class=\"h1-kw\">&mdash; ouvrir un examen .dcm dans le navigateur</span>"
+tagline = "Scanner, IRM, radio et échographie, avec le fenêtrage, l'en-tête et les mesures."
+
+title = "Visionneuse DICOM &mdash; ouvrir un fichier .dcm dans le navigateur, sans envoi"
+description = "Ouvrez des examens de scanner, d'IRM, de radiologie et d'échographie dans votre navigateur. Fenêtrage, parcours d'une série entière, mesures en millimètres, lecture de chaque étiquette DICOM et liste exacte de ce qui, dans le fichier, identifie le patient. Rien n'est envoyé."
+og_title = "Visionneuse DICOM &mdash; ouvrir un examen sans l'envoyer"
+og_description = "Un fichier .dcm ouvert sur votre propre machine&nbsp;: fenêtrage, série entière dans l'ordre, mesures en millimètres et chaque étiquette de l'en-tête. Sans envoi, sans compte."
+og_image_alt = "Visionneuse DICOM - ouvrir un examen de scanner, d'IRM ou de radio dans le navigateur"
+
+pledge = """
+    L'examen est ouvert et décodé par votre propre navigateur&nbsp;: l'en-tête,
+    les pixels, le fenêtrage, les mesures. Il n'y a au bout de cette page aucun
+    serveur à qui envoyer des données de santé, quand bien même quelque chose
+    ici le voudrait, et rien du fichier n'est rapporté à personne&nbsp;: ni le
+    nom du patient, ni l'examen, ni le nom du fichier."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les DevTools, regardez
+      l'onglet Réseau et ouvrez un examen. Aucune requête ne transporte une
+      image, une étiquette ou un nom de fichier. Ou débranchez-vous d'internet
+      et ouvrez-en un quand même."""
+
+read_first = """
+, <code>src/dicom.js</code> pour l'analyseur qui
+      parcourt le fichier, <code>src/pixels.js</code> pour le décodage des
+      pixels, <code>src/jpeg-lossless.js</code> pour le codec qu'emploient la
+      plupart des exports hospitaliers, et <code>src/window.js</code> pour le
+      fenêtrage. Aucun d'eux n'a une ligne qui puisse atteindre le réseau."""
+
+howto_heading = "Comment ouvrir un fichier DICOM"
+
+card = """
+            Ouvrez un examen de scanner, d'IRM, de radiologie ou d'échographie
+            sur votre propre machine. Réglez le fenêtrage, parcourez la série
+            entière, mesurez en millimètres et lisez chaque étiquette de
+            l'en-tête."""
+
+[words]
+plural = "examens"
+choose = "un examen"
+
+[[facts]]
+text = "Aucun envoi"
+
+[[facts]]
+text = "Aucun compte"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[facts]]
+text = "Vos fichiers restent sur votre appareil"
+
+[[privacy]]
+title = "Votre examen n'a nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme chaque adresse que cette page peut
+      contacter, et aucune ne nous appartient. Il n'y a ici aucun point de
+      collecte où votre fichier pourrait atterrir, ni de code qui l'enverrait
+      s'il y en avait un. On lisait autrefois ici
+      <code>connect-src 'none'</code>, ce qui était absolu&nbsp;; la publicité a
+      coûté cela, et le dire fait partie du marché."""
+
+[[privacy]]
+title = "Ici, cela compte davantage que sur les autres pages."
+body = """
+
+      Un fichier DICOM n'est pas une image avec quelques métadonnées dessus.
+      C'est un dossier médical avec une image dedans&nbsp;: le nom du patient, sa
+      date de naissance, son numéro de dossier, le numéro de demande, le médecin
+      prescripteur, l'établissement et le numéro de série de la machine sont
+      autant de champs de l'en-tête, et ils voyagent avec le fichier partout où
+      il va. Envoyer un tel fichier à un site web pour le regarder revient à
+      remettre tout cela à qui exploite ce site. C'est précisément ce que cette
+      page existe pour ne pas faire."""
+
+[[privacy]]
+title = "Le lecteur, ce sont quatorze fichiers de ce dépôt."
+body = """
+ Rien ici n'utilise une
+      bibliothèque récupérée ailleurs. <code>src/dicom.js</code> parcourt le
+      fichier, <code>src/dictionary.js</code> sait comment s'appellent les
+      étiquettes, <code>src/pixels.js</code> retransforme les octets en mesures,
+      <code>src/rle.js</code> et <code>src/jpeg-lossless.js</code> décompressent
+      les deux formes compressées que cette page sait décoder, et
+      <code>src/window.js</code> projette le mesuré sur les gris de votre
+      écran."""
+
+[[privacy]]
+title = "Les identifiants vous sont énumérés, à vous et à personne d'autre."
+body = """
+
+      La page affiche chaque champ de votre fichier qui nomme la personne
+      concernée ou qui réduit le cercle de qui elle peut être, parce que c'est la
+      question à laquelle quelqu'un sur le point de partager une coupe a besoin
+      d'une réponse et qu'aucune visionneuse ne la donne. Cela apparaît sur
+      l'écran devant vous et ne va nulle part ailleurs&nbsp;: il n'existe dans ce
+      dépôt aucun événement de mesure qui transporte quoi que ce soit de cela, et
+      la page ne pourrait pas l'envoyer même s'il en existait un."""
+
+[[privacy]]
+title = "Elle lit. Elle n'écrit pas."
+body = """
+ Il n'y a ici aucun bouton qui
+      modifie votre fichier, ni de code qui le pourrait. Ce que vous pouvez
+      emporter, c'est un PNG de l'image à l'écran et une copie texte de
+      l'en-tête, construits tous deux dans la page à partir de ce qui s'y trouve
+      déjà. Votre original reste intact sur votre disque, ce qui est aussi la
+      réponse honnête à la question de ce qui se passe si vous fermez
+      l'onglet."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts de publicité
+      et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit quoi que ce
+      soit sur votre fichier&nbsp;: ni les pixels, ni une vignette, ni un nom, ni
+      une étiquette, ni un patient, ni un nom de fichier. Chaque ligne qui
+      analyse, décode ou dessine un examen est servie depuis cette origine et
+      figure dans le dépôt."""
+
+[[privacy]]
+title = "Ce que charge le bouton de don, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; de l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et va chercher sa police
+      chez Google Fonts. C'est un lien et rien de plus&nbsp;: il ne signale
+      aucune visite, et on ne lui donne rien sur vous ni sur vos fichiers. Rien
+      ne se produit tant que vous ne cliquez pas, et ce vers quoi vous cliquez
+      alors est le site de quelqu'un d'autre."""
+
+[[privacy]]
+title = "Elle fonctionne hors ligne."
+body = """
+ Débranchez-vous du réseau et chaque
+      partie de cette page continue de fonctionner. C'est la preuve la plus
+      simple de toutes&nbsp;: un outil qui enverrait votre examen ailleurs pour
+      l'afficher s'arrêterait à l'instant où vous tirez la prise."""
+
+[[howto]]
+title = "Choisissez les fichiers."
+body = """
+ Un seul fichier
+      <code>.dcm</code>, ou le dossier entier du disque&nbsp;: un scanner ou une
+      IRM, c'est un fichier par coupe, et les déposer tous d'un coup est ce qui
+      remet la série en place. Le navigateur les lit directement sur votre
+      disque&nbsp;; rien n'est envoyé nulle part pendant ce temps."""
+
+[[howto]]
+title = "Choisissez la série."
+body = """
+ Un examen en contient généralement
+      plusieurs&nbsp;: le scout, puis chaque acquisition. Chacune est empilée dans
+      l'ordre où la machine l'a prise, déduit de la position de chaque coupe dans
+      le patient plutôt que de la numérotation, qui ne va pas toujours dans le
+      même sens."""
+
+[[howto]]
+title = "Réglez le fenêtrage."
+body = """
+ C'est la commande qui rend un examen
+      lisible, et celle qu'un logiciel de retouche n'a pas. Faites glisser sur
+      l'image pour élargir la fenêtre et vers le haut ou le bas pour déplacer son
+      centre, ou prenez l'une des fenêtres nommées &mdash; poumon, os, cerveau,
+      parties molles &mdash; sur un scanner, où les unités sont les mêmes sur
+      toutes les machines du monde."""
+
+[[howto]]
+title = "Parcourez la pile."
+body = """
+ Le curseur sous l'image avance dans les
+      coupes, et les flèches du clavier font la même chose une fois que vous avez
+      cliqué sur l'image. Un fichier multi-image &mdash; une boucle
+      d'échographie, une angiographie &mdash; se lit avec le bouton d'à
+      côté."""
+
+[[howto]]
+title = "Mesurez quelque chose."
+body = """
+ Passez sur Mesurer et tracez une
+      ligne. Là où le fichier indique l'écartement de ses pixels, la réponse est
+      en millimètres et tient compte des pixels non carrés&nbsp;; là où il ne
+      l'indique pas, la réponse est en pixels et le dit, plutôt que d'inventer
+      une échelle."""
+
+[[howto]]
+title = "Lisez l'en-tête."
+body = """
+ Chaque élément du fichier, avec son
+      numéro, le nom que lui donne la norme et son contenu, le tout consultable.
+      Au-dessus, la liste de ce qui, dans ce fichier précis, identifie le
+      patient&nbsp;: bien davantage que le nom."""
+
+[[howto]]
+title = "Emportez ce dont vous avez besoin."
+body = """
+ L'image à l'écran en PNG,
+      avec le fenêtrage que vous avez réglé et sans rien d'incrusté dessus, ou
+      l'en-tête entier en texte brut. Les deux sont construits dans la page à
+      partir de ce qui s'y trouve déjà."""
+
+[[faq]]
+q = "Mon examen est-il envoyé quelque part&nbsp;?"
+a = """
+        Non. Le fichier est lu, décodé et dessiné par votre propre navigateur,
+        sur votre propre matériel. Cet outil n'a pas de partie serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme chaque adresse
+        qu'elle peut contacter, dont aucune ne nous appartient. Débranchez-vous
+        du réseau&nbsp;: elle continue d'ouvrir des examens.
+        <br><br>
+        Cela vaut ici plus que sur toute autre page du site. Un fichier DICOM
+        porte dans son en-tête le nom du patient, sa date de naissance et son
+        numéro de dossier&nbsp;; envoyer un tel fichier à une visionneuse revient
+        donc à remettre à un inconnu un dossier médical, pas une image."""
+
+[[faq]]
+q = "Quels fichiers DICOM peut-elle ouvrir&nbsp;?"
+a = """
+        Les fichiers non compressés dans les trois syntaxes de transfert de base
+        &mdash; implicit et explicit little endian, ainsi que la big-endian
+        retirée &mdash; plus deflated, RLE Lossless, JPEG baseline et JPEG
+        Lossless, avec lequel est compressée la majorité des examens de scanner
+        et d'IRM d'un disque hospitalier.
+        <br><br>
+        Elle ne sait décoder ni JPEG 2000, ni JPEG-LS, ni les syntaxes MPEG et
+        HEVC employées pour la vidéo. Celles-ci exigent des codecs qui pèsent
+        plusieurs mégaoctets de bibliothèque compilée, et une page qui en
+        téléchargerait un à la demande ne serait pas une page qui fonctionne hors
+        ligne. Un fichier dans l'une d'elles s'ouvre quand même&nbsp;: l'en-tête
+        est lu et affiché en entier, et l'image est remplacée par une ligne qui
+        nomme le codec, plutôt que par une icône d'image cassée qui ne vous
+        apprend rien."""
+
+[[faq]]
+q = "Qu'est-ce que le &laquo;&nbsp;fenêtrage&nbsp;&raquo;, et pourquoi en ai-je besoin&nbsp;?"
+a = """
+        Une coupe de scanner contient environ quatre mille valeurs distinctes et
+        votre écran affiche deux cent cinquante-six gris. La fenêtre est le choix
+        de la tranche de cette plage qui les reçoit tous&nbsp;: tout ce qui est
+        en dessous est noir, tout ce qui est au-dessus est blanc, et ce qui se
+        trouve entre les deux se répartit sur les gris.
+        <br><br>
+        C'est pourquoi le même fichier ressemble à deux examens différents sous
+        deux réglages, et pourquoi le poumon et l'os ne peuvent pas être vus en
+        même temps. Sur un scanner, les nombres sont des unités Hounsfield,
+        définies de façon absolue &mdash; l'eau vaut 0 et l'air &minus;1000
+        &mdash;, si bien que les fenêtres nommées de cette page portent les
+        nombres mêmes qu'emploie un radiologue sur sa console. Sur une IRM ou une
+        échographie, une telle échelle n'existe pas, et la fenêtre d'ouverture
+        est celle que demande le fichier lui-même."""
+
+[[faq]]
+q = "Pourquoi indique-t-elle que ma mesure est en pixels&nbsp;?"
+a = """
+        Parce que ce fichier n'indique pas la taille d'un pixel. C'est Pixel
+        Spacing (0028,0030) qui la porte, en millimètres, et quantité d'images
+        d'échographie, de documents numérisés et de captures secondaires ne
+        l'ont tout simplement pas.
+        <br><br>
+        Là où il est présent, la mesure est en millimètres et chaque axe est
+        mesuré avec son propre écartement, ce qui compte sur les images dont les
+        pixels ne sont pas carrés. Là où il est absent, la réponse honnête est un
+        décompte de pixels, et c'est celle qui s'affiche, plutôt que de choisir
+        une échelle et de présenter le résultat comme une longueur."""
+
+[[faq]]
+q = "Elle a ouvert mon dossier en plusieurs séries. Pourquoi&nbsp;?"
+a = """
+        Parce que c'est ce qu'il contient. Un examen est fait de séries &mdash; le
+        scout, puis chaque acquisition ou reconstruction &mdash; et chaque fichier
+        indique à laquelle il appartient dans Series Instance UID (0020,000E). La
+        liste déroulante est construite à partir de cela et non du dossier, qui
+        les mélange le plus souvent dans une seule liste de noms.
+        <br><br>
+        À l'intérieur d'une série, les coupes sont ordonnées par leur position
+        dans le patient, déduite d'Image Position et d'Image Orientation. Instance
+        Number serait la clé évidente et n'est ici que le recours&nbsp;: elle est
+        attribuée par ce qui a écrit les fichiers et n'a pas à suivre le sens dans
+        lequel le patient est allongé."""
+
+[[faq]]
+q = "Que signifie la liste &laquo;&nbsp;ce qui identifie le patient&nbsp;&raquo;&nbsp;?"
+a = """
+        C'est chaque champ de votre fichier qui nomme la personne concernée, ou
+        qui réduit le cercle de qui elle peut être, lu depuis ce fichier sur votre
+        machine. La liste vient de PS3.15 de la norme DICOM, la partie qui énonce
+        ce qui doit disparaître avant qu'un jeu de données puisse être dit
+        dé-identifié.
+        <br><br>
+        Elle est là parce que ce que les gens sous-estiment n'est pas qu'un examen
+        contienne un nom. C'est tout ce qu'il contient en plus&nbsp;: la date de
+        naissance, le numéro de demande, le médecin prescripteur, l'établissement,
+        le numéro de série de la machine et les UID de l'examen, qui sont des clés
+        parfaites vers l'archive dont il provient. Un examen dont on a seulement
+        effacé le nom n'est pas anonyme.
+        <br><br>
+        Cet outil se contente de vous les montrer. Il n'écrit rien et ne modifie
+        rien, il ne peut donc rien en retirer."""
+
+[[faq]]
+q = "Peut-elle anonymiser un examen&nbsp;?"
+a = """
+        Non, et elle ne fait délibérément pas semblant. Cette page lit&nbsp;; elle
+        n'a aucun code qui écrive un fichier DICOM. Ce qu'elle fait, c'est vous
+        dire exactement ce que contient le vôtre, et c'est la partie difficile à
+        découvrir et celle sur laquelle on se trompe.
+        <br><br>
+        Un outil qui retire les identifiants est un autre travail, avec une barre
+        bien plus haute&nbsp;: il doit réécrire le fichier sans toucher aux
+        pixels, remplacer les UID de façon cohérente sur un examen entier, et voir
+        juste sur les éléments privés dans lesquels certaines machines cachent une
+        seconde copie du nom. Il est à la feuille de route de ce site, plutôt que
+        greffé sur une visionneuse."""
+
+[[faq]]
+q = "Peut-elle ouvrir un fichier sans extension .dcm, ou un fichier abîmé&nbsp;?"
+a = """
+        Les deux, oui. L'extension n'est pas regardée&nbsp;: ce qui est vérifié,
+        c'est le fichier lui-même. Un jeu de données écrit sans le préambule
+        habituel de 128 octets &mdash; ce à quoi ressemble un examen tiré
+        directement du réseau &mdash; est lu en déduisant son encodage de son
+        premier élément, et la page dit que c'est ce qu'elle a fait.
+        <br><br>
+        Un fichier qui s'arrête en cours de route est lu jusqu'où il va. Tout ce
+        qui précède la coupure est affiché, avec une note indiquant à quel octet
+        cela s'est arrêté. C'est précisément le cas où l'on veut le plus une
+        visionneuse, et jeter le fichier entier pour ses douze derniers octets
+        serait le mauvais comportement."""
+
+[[faq]]
+q = "Est-ce une visionneuse de diagnostic&nbsp;?"
+a = """
+        Non. Ce n'est pas un dispositif médical, elle n'a fait l'objet d'aucune
+        évaluation réglementaire, et rien ici ne devrait servir à prendre une
+        décision clinique. Votre écran n'est pas calibré, le navigateur n'est pas
+        une chaîne de rendu validée, et ni l'un ni l'autre ne se corrige depuis
+        l'intérieur d'une page web.
+        <br><br>
+        Ce à quoi elle sert, c'est à tout le reste pour quoi on ouvre un
+        examen&nbsp;: vérifier ce qu'il y a sur un disque, extraire une coupe pour
+        un cours ou un article, lire un en-tête, comprendre pourquoi un autre
+        logiciel refuse le fichier, et voir ce qu'un examen transporte sur la
+        personne concernée."""
+
+[[faq]]
+q = "Modifie-t-elle mon fichier&nbsp;?"
+a = """
+        Non. Cet outil ne fait que lire. Il n'y a pas de fichier de sortie, pas de
+        réencodage et aucun bouton qui écrive un DICOM&nbsp;: ce que vous pouvez
+        télécharger, c'est un PNG de l'image à l'écran et une copie en texte brut
+        de l'en-tête. Votre original reste intact sur votre disque."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a ni compte, ni connexion, ni période d'essai. Il
+        n'y a pas non plus de limite de taille de fichier ni de nombre de fichiers
+        ouverts, hormis la mémoire de votre propre machine. Le site porte de la
+        publicité, et c'est elle qui le paie&nbsp;; on ne donne rien aux annonces
+        sur votre fichier."""
+
+[[faq]]
+q = "Fonctionne-t-elle hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, débranchez-vous ensuite d'internet&nbsp;:
+        elle continue de fonctionner. C'est aussi la façon la plus simple de
+        prouver que rien n'est envoyé&nbsp;: un outil qui expédierait votre examen
+        ailleurs pour l'afficher s'arrêterait à l'instant où vous tirez la
+        prise."""
+
+[schema]
+description = "Ouvrir des examens DICOM (.dcm) dans le navigateur&nbsp;: scanner, IRM, radiologie et échographie, avec fenêtrage, série entière dans l'ordre, mesures en millimètres et chaque étiquette de l'en-tête. Rien n'est envoyé."
+features = [
+  "Ouvre les fichiers de scanner, d'IRM, de radiologie, d'échographie, de TEP et de capture secondaire",
+  "Fenêtrage par glissement, par saisie ou par préréglage scanner nommé",
+  "Un dossier entier est regroupé en séries et ordonné par la position dans le patient",
+  "Les fichiers multi-images se lisent en boucle",
+  "Mesure en millimètres, en tenant compte des pixels non carrés",
+  "Lit la valeur du pixel sous le curseur en unités Hounsfield",
+  "Chaque étiquette DICOM avec son nom et sa valeur, consultable",
+  "Énumère ce qui, dans le fichier, identifie le patient, d'après le profil PS3.15",
+  "Décode RLE, JPEG baseline et JPEG Lossless sans bibliothèque embarquée",
+  "Enregistre l'image en PNG et l'en-tête en texte brut",
+  "Fonctionne hors ligne&nbsp;; aucun envoi, aucun compte, aucune modification de votre fichier",
+]
+
+[picker]
+title = "Déposez un examen ici"
+hint = "ou cliquez pour parcourir &mdash; un fichier .dcm, ou un dossier entier"

--- a/locales/fr/tools/document-scanner.html
+++ b/locales/fr/tools/document-scanner.html
@@ -1,0 +1,386 @@
+<!--
+  tools/document-scanner/body.html, in French.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Étape 1 &mdash; les photos -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisissez les photos</h2>
+
+    <p class="card-lede">
+      Une photo par page, prise de n'importe où au-dessus. La page entière doit
+      être dans le cadre, et les quatre coins doivent être visibles ou
+      presque&nbsp;; tout le reste, l'inclinaison, l'ombre, le bureau sur lequel
+      elle est posée, c'est ce à quoi sert cet outil. Ajoutez-en plusieurs et
+      elles deviennent les pages d'un même document, dans l'ordre où vous les
+      ajoutez.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="strip-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="detect-all" class="ghost">Rechercher à nouveau sur toutes</button>
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer</button>
+      </div>
+    </div>
+
+    <ul id="page-strip" class="page-strip"></ul>
+  </section>
+
+  <!-- Étape 2 &mdash; les coins -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Placez les coins sur la page</h2>
+
+    <p id="edit-empty" class="field-summary">
+      Choisissez une photo&nbsp;: elle apparaîtra ici, ses quatre coins déjà
+      trouvés.
+    </p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Appuyez n'importe où sur la photo et le coin le plus proche vient sous
+        votre doigt&nbsp;; faites-le glisser jusqu'au coin de la page.
+        <kbd>Tab</kbd> atteint un coin au clavier, les flèches le déplacent d'un
+        pixel et <kbd>Shift</kbd> de dix. Rien ici n'est définitif&nbsp;: le scan
+        est pris là où les quatre coins finissent.
+      </p>
+
+      <!-- The photo is a canvas rather than an <img> because it is drawn at
+           screen size from the decoded picture, and because the same canvas is
+           what the corner finder reads. The outline over it is an SVG polygon
+           in percentages, so it needs no redraw when the window changes. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="photo"></canvas>
+        </div>
+      </div>
+
+      <p id="detect-note" class="hint-line" role="status" aria-live="polite"></p>
+
+      <div class="frame-actions">
+        <button type="button" id="detect-one" class="ghost">Rechercher à nouveau les coins</button>
+        <button type="button" id="whole-photo" class="ghost">Prendre la photo entière</button>
+        <button type="button" id="turn-left" class="ghost">Tourner à gauche</button>
+        <button type="button" id="turn-right" class="ghost">Tourner à droite</button>
+        <button type="button" id="undo" class="ghost" disabled>Annuler</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Étape 3 &mdash; le nettoyage -->
+  <section class="card" id="clean-card">
+    <h2><span class="step">3</span> Nettoyez-la</h2>
+
+    <p id="clean-empty" class="field-summary">
+      La page redressée apparaît ici dès qu'il y a une photo à redresser.
+    </p>
+
+    <div id="clean-controls" hidden>
+      <p class="card-lede">
+        Ce qui suit est le résultat réel, produit par le code même qui écrit le
+        fichier&nbsp;: redressé, et avec la lumière inégale déjà divisée. Il est
+        dessiné à la taille de l'écran pendant que vous choisissez&nbsp;; le
+        fichier, lui, est fait à la résolution de la photo.
+      </p>
+
+      <div class="result-wrap">
+        <canvas id="scan-preview" class="scan-preview"></canvas>
+        <p id="scan-busy" class="progress-label" role="status" aria-live="polite" hidden>
+          Redressement&hellip;
+        </p>
+      </div>
+
+      <ul id="scan-facts" class="result-facts"></ul>
+
+      <fieldset class="options" id="mode-group">
+        <legend>Que faire de la lumière et de la couleur</legend>
+
+        <label class="check">
+          <input type="radio" name="mode" value="colour" checked>
+          <span>
+            <strong>Couleur, égalisée</strong>
+            <span class="check-note">
+              Le papier est mesuré sur toute la page et divisé, si bien que
+              l'ombre disparaît et que le papier redevient blanc, tandis qu'un
+              tampon, une signature à l'encre bleue ou une ligne surlignée
+              gardent la couleur qu'ils avaient. C'est le mode à prendre quand la
+              couleur fait partie du document.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="grey">
+          <span>
+            <strong>Niveaux de gris</strong>
+            <span class="check-note">
+              La même égalisation, sans la couleur. Plus petit que la couleur et
+              plus doux pour une photographie ou une signature que ne l'est le
+              noir et blanc.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="mono">
+          <span>
+            <strong>Noir et blanc</strong>
+            <span class="check-note">
+              Chaque pixel est décidé face à son propre voisinage plutôt que face
+              à un nombre unique pour toute la page, et c'est cela qui garde
+              lisible l'écriture prise dans une ombre. C'est ce qui rend un scan
+              petit&nbsp;: un contrat de vingt pages sort ainsi sous le mégaoctet,
+              et une quinzaine en photographies. Il n'a pas de demi-teintes&nbsp;:
+              rien qui porte une photographie ne devrait l'utiliser.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="photo">
+          <span>
+            <strong>Ne rien y toucher</strong>
+            <span class="check-note">
+              Redressée et rien d'autre. Pour une page où le papier lui-même
+              compte&nbsp;: quelque chose d'ancien, quelque chose de coloré, une
+              photographie.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row" id="strength-row">
+          <label for="strength">Avec quelle force</label>
+          <div class="inline-pair">
+            <input type="range" id="strength" min="0" max="100" step="5" value="50">
+            <output id="strength-value">50</output>
+          </div>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <p class="hint-line">
+        Le réglage s'applique à toutes les pages. Des pages nettoyées
+        différemment dans un même document ressemblent à deux documents.
+      </p>
+    </div>
+  </section>
+
+  <!-- Étape 4 &mdash; le fichier -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Enregistrez le document</h2>
+
+    <p class="card-lede">
+      Le PDF est écrit ici, dans la mémoire de cette page, page après page. Il
+      n'y a au bout de cet outil aucun serveur à qui envoyer une fiche de paie,
+      un passeport ou un contrat, ni de code qui le ferait s'il y en avait un.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Format de page</label>
+        <select id="page-size">
+          <option value="fit" selected>Ajuster la feuille à la page elle-même</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 po</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 po</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+        </select>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Résolution d'impression</label>
+        <select id="dpi">
+          <option value="150">150 DPI</option>
+          <option value="200" selected>200 DPI</option>
+          <option value="300">300 DPI &mdash; scanner de bureau</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          La taille qu'on déclare pour une feuille faite d'un nombre donné de
+          pixels. Cela change la taille à laquelle le document s'imprime, et pas
+          un seul pixel du scan.
+        </p>
+      </div>
+
+      <div class="field" id="margin-field" hidden>
+        <label for="margin">Marge</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="50" step="1" value="10"
+                 aria-label="Marge en millimètres">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Plus grand côté</label>
+        <select id="max-side">
+          <option value="1600">1600 pixels &mdash; petit</option>
+          <option value="2400" selected>2400 pixels</option>
+          <option value="3500">3500 pixels</option>
+          <option value="0">Aussi grand que la photo le permet</option>
+        </select>
+        <p class="field-note">
+          Un plafond pour la page redressée. La photo d'une page contient bien
+          plus de pixels que la page ne le mérite, et 2400 sur le grand côté font
+          environ 200 DPI sur de l'A4.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualité</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="82">
+          <output id="quality-value">82%</output>
+        </div>
+        <p class="field-note">
+          Pour les modes couleur et niveaux de gris, stockés en JPEG. Les pages en
+          noir et blanc sont stockées exactement, ce réglage ne leur fait donc
+          rien.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="title">Titre du document <span class="optional">(facultatif)</span></label>
+        <input type="text" id="title" maxlength="120" placeholder="Laissé vide, le PDF ne porte aucun titre">
+        <p class="field-note">
+          La seule chose écrite dans le document en dehors des pages. Aucune date,
+          aucun auteur et rien sur cette machine. Voir
+          <code>src/document.js</code>.
+        </p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save-pdf" class="primary big" disabled>Enregistrer en PDF</button>
+      <button type="button" id="save-images" class="ghost big" disabled>Enregistrer les pages en images</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden></p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>Le fichier terminé</h3>
+        <a id="download" class="primary as-button" href="#" download>Télécharger</a>
+      </div>
+      <ul id="result-facts" class="result-facts"></ul>
+      <p class="hint-line">
+        Ouvrez-le avant de l'envoyer. Ce qu'il y a dans le document est ce qu'il y
+        avait à l'écran à l'étape 3, page pour page.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Every sentence the JavaScript puts on this page. They live here rather than
+    in src/, because src/ is copied byte for byte into all eleven languages and
+    a sentence written there would be English in ten of them. See
+    shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="detect.found">Les quatre coins ont été trouvés.
+      Vérifiez-les et faites glisser ceux qui sont tombés à côté.</span>
+    <span data-phrase="detect.unsure">Les bords de la page n'étaient pas assez
+      nets pour en être sûr. Ces coins sont une supposition&nbsp;: faites-les
+      glisser sur la page avant de continuer.</span>
+    <span data-phrase="detect.nothing">Aucune page n'a pu être distinguée sur
+      cette photo&nbsp;: les coins sont donc sur ses bords. Faites-les glisser sur
+      la page.</span>
+    <span data-phrase="detect.flat">Il n'y a rien à trouver sur cette image&nbsp;:
+      elle n'a aucun bord.</span>
+    <span data-phrase="detect.tiny">Cette image est trop petite pour y trouver une
+      page.</span>
+    <span data-phrase="detect.edited">Ces coins sont désormais les vôtres.
+      &laquo;&nbsp;Rechercher à nouveau les coins&nbsp;&raquo; remesure la photo
+      depuis le début.</span>
+
+    <span data-phrase="corner.tl">Coin supérieur gauche</span>
+    <span data-phrase="corner.tr">Coin supérieur droit</span>
+    <span data-phrase="corner.br">Coin inférieur droit</span>
+    <span data-phrase="corner.bl">Coin inférieur gauche</span>
+    <span data-phrase="corner.at">{corner}, à {x} en largeur et {y} en hauteur.
+      Les flèches le déplacent, et Shift avec elles le déplace de dix pixels à la
+      fois.</span>
+
+    <span data-phrase="page.select">Modifier la page {index}</span>
+    <span data-phrase="page.remove">Retirer la page {index}</span>
+    <span data-phrase="page.earlier">Déplacer la page {index} vers l'avant</span>
+    <span data-phrase="page.later">Déplacer la page {index} vers l'arrière</span>
+    <span data-phrase="page.count">{count} page</span>
+    <span data-phrase="page.counts">{count} pages</span>
+
+    <span data-phrase="paper.a">A4 ou A5</span>
+    <span data-phrase="paper.letter">US Letter</span>
+    <span data-phrase="paper.legal">US Legal</span>
+    <span data-phrase="paper.card">une carte de visite</span>
+    <span data-phrase="shape.known">La page est sortie en {ratio}, qui est la
+      forme du {paper}.</span>
+    <span data-phrase="shape.sideways">La page est sortie en {ratio}, qui est la
+      forme du {paper} à l'italienne.</span>
+    <span data-phrase="shape.unknown">La page est sortie en {ratio}, qui n'est pas
+      un format normalisé.</span>
+
+    <span data-phrase="method.perspective">La forme a été déduite de la
+      perspective de la photo&nbsp;: c'est donc la forme de la page et non celle
+      qu'elle avait sur l'image.</span>
+    <span data-phrase="method.edges">La photo a été prise perpendiculairement&nbsp;:
+      la forme est donc mesurée directement sur les bords.</span>
+
+    <span data-phrase="quality.good">{width} sur {height} pixels, environ {dpi}
+      DPI sur une page de cette taille &mdash; assez pour imprimer.</span>
+    <span data-phrase="quality.fair">{width} sur {height} pixels, environ {dpi}
+      DPI sur une page de cette taille. Bien à l'écran, un peu mou sur
+      papier.</span>
+    <span data-phrase="quality.low">{width} sur {height} pixels, environ {dpi}
+      DPI sur une page de cette taille. Approchez-vous si cela doit être
+      imprimé.</span>
+    <span data-phrase="quality.pixels">{width} sur {height} pixels.</span>
+    <span data-phrase="coverage.note">La page occupait {percent}% de la photo.</span>
+    <span data-phrase="coverage.small">La page n'occupait que {percent}% de la
+      photo&nbsp;: l'essentiel de ce qui a été photographié était donc le bureau.
+      Plus près la prochaine fois.</span>
+
+    <span data-phrase="strength.gentle">Doux&nbsp;: le papier est égalisé et
+      guère plus. Pour une page au crayon pâle ou portant une photographie.</span>
+    <span data-phrase="strength.middling">Le réglage habituel&nbsp;: le papier
+      redevient blanc et le texte imprimé redevient noir.</span>
+    <span data-phrase="strength.hard">Fort&nbsp;: tout ce qui est gris est poussé
+      vers le noir ou vers le blanc. Le plus net sur une page simplement imprimée,
+      et destructeur sur tout ce qui porte une image.</span>
+
+    <span data-phrase="busy.page">Page {done} sur {total}&hellip;</span>
+    <span data-phrase="busy.writing">Écriture du document&hellip;</span>
+
+    <span data-phrase="result.pdf">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.images">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.mono">Stocké à un bit par pixel et compressé
+      exactement, et c'est pourquoi c'est aussi petit.</span>
+    <span data-phrase="result.jpeg">Les pages sont stockées en JPEG à la qualité
+      que vous avez choisie.</span>
+    <span data-phrase="result.png">Les pages sont stockées en PNG, qui est sans
+      perte et qui est ce que veut une image à deux couleurs &mdash; le JPEG
+      serait à la fois plus gros et flou autour de chaque lettre.</span>
+    <span data-phrase="result.clean">Aucune date, aucun auteur, aucun nom de
+      machine&nbsp;: la seule chose dans le document en dehors des pages est le
+      nom de cet outil.</span>
+
+    <span data-phrase="size.fit">Chaque feuille prend la taille que sa propre page
+      a réellement, à la résolution ci-dessus. Rien n'est encadré de bandes.</span>
+    <span data-phrase="size.named">Chaque page est posée sur une feuille {name},
+      à l'intérieur de la marge, quelle que soit la forme obtenue.</span>
+
+    <span data-phrase="error.decode">Ce navigateur n'a pas pu ouvrir {name}. Si
+      c'est une photo HEIC d'iPhone, convertissez-la d'abord.</span>
+    <span data-phrase="error.none">Choisissez d'abord au moins une photo.</span>
+    <span data-phrase="error.failed">Quelque chose s'est mal passé pendant la
+      création du fichier&nbsp;: {detail}</span>
+  </div>
+</main>

--- a/locales/fr/tools/document-scanner.toml
+++ b/locales/fr/tools/document-scanner.toml
@@ -1,0 +1,311 @@
+#
+# Scanner de documents - French.
+#
+# Overrides for tools/document-scanner/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Les noms de la litterature restent tels quels - Zhang et He pour la
+# recuperation des proportions, Sauvola pour le seuillage. Qui veut verifier
+# cherche exactement ces noms-la.
+#
+
+name = "Scanner de documents"
+heading = "Scanner&nbsp;de&nbsp;documents <span class=\"h1-kw\">&mdash; une photo de page, redressée</span>"
+tagline = "Photographiez la page. Vous récupérez quelque chose qui a l'air scanné."
+
+title = "Scanner de documents &mdash; d'une photo à un PDF scanné, sans envoi"
+description = "Transformez la photo d'une page prise au téléphone en un PDF redressé et éclairé uniformément. Les coins sont trouvés pour vous, la perspective est défaite, l'ombre est divisée. Tout se passe dans votre navigateur&nbsp;: rien n'est envoyé."
+og_title = "Scanner un document avec une photo, sans l'envoyer"
+og_description = "Les coins de la page sont trouvés, l'inclinaison est défaite et la lumière inégale est divisée, dans votre propre navigateur. Ce que l'on photographie ainsi, c'est un passeport, une fiche de paie ou un contrat&nbsp;: précisément ce qui n'a pas à être envoyé."
+og_image_alt = "Scanner de documents - une photo de page, redressée et nettoyée, sans envoi"
+
+pledge = """
+    La photo est décodée, redressée, nettoyée et écrite dans un PDF par votre
+    propre navigateur, avec rien d'autre que du calcul et les codecs qu'il
+    embarque déjà. Cet outil n'a aucune fonction réseau, ni pour récupérer ni
+    pour envoyer, et la raison pour laquelle cela compte ici tient à ce dont les
+    gens photographient les pages&nbsp;: un passeport, une fiche de paie, un
+    bail, un formulaire qu'une administration a demandé
+    &laquo;&nbsp;scanné&nbsp;&raquo;."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les DevTools, regardez
+      l'onglet Réseau et scannez une page. Aucune requête ne transporte une
+      photo, une vignette, un nom de fichier ou la position d'un seul coin. Ou
+      débranchez-vous d'internet et scannez-en une quand même."""
+
+read_first = """
+, <code>src/detect.js</code> pour la façon dont les
+      coins sont trouvés sans le moindre modèle, <code>src/warp.js</code> pour le
+      redressement, et <code>src/clean.js</code> pour la façon dont la lumière
+      inégale est divisée."""
+
+howto_heading = "Comment scanner un document avec l'appareil photo du téléphone"
+
+card = """
+            Une photo de page, redressée et nettoyée jusqu'à devenir un
+            document. Les coins sont trouvés pour vous, l'inclinaison est défaite
+            et l'ombre est divisée."""
+
+[words]
+plural = "documents"
+choose = "une photo de page"
+
+[[facts]]
+text = "Aucun envoi"
+
+[[facts]]
+text = "Aucun compte"
+
+[[facts]]
+text = "Aucun filigrane"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Vos documents n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme chaque adresse que cette page peut
+      contacter, et aucune ne nous appartient. Il n'y a ici aucun point de
+      collecte où vos photos pourraient atterrir, ni de code qui les enverrait
+      s'il y en avait un."""
+
+[[privacy]]
+title = "Il n'y a pas de modèle, donc rien à télécharger et rien à demander."
+body = """
+ Trouver les quatre coins
+      d'une page est du calcul&nbsp;: le gradient de l'image, un vote pour les
+      droites qu'elle contient, et une vérification de ce qui se trouve
+      réellement sous chaque côté du rectangle gagnant. Aucun poids, aucun moteur
+      d'inférence, rien qui se télécharge à la première utilisation, et rien qui
+      se comporte autrement sur le document de quelqu'un d'autre que sur le
+      vôtre. Voir <code>src/detect.js</code>."""
+
+[[privacy]]
+title = "Le document ne porte ni date, ni auteur, ni nom de machine."
+body = """
+ Un scan est une chose que
+      l'on envoie à d'autres, le plus souvent parce qu'une administration l'a
+      demandé. La seule chose écrite dans le PDF en dehors des pages elles-mêmes
+      est le nom de cet outil, et un titre si vous en saisissez un. Aucune date
+      de création, aucun auteur, aucun numéro de série, et rien tiré de votre
+      horloge, de vos noms de fichiers ou de votre ordinateur. Voir
+      <code>src/document.js</code>."""
+
+[[privacy]]
+title = "Rien ici ne va chercher quoi que ce soit."
+body = """
+ Il n'y a aucun
+      <code>fetch</code>, aucun <code>XMLHttpRequest</code> et aucun
+      <code>sendBeacon</code> nulle part dans <code>src/</code>. Le travail, c'est
+      un <code>getImageData</code>, quelques boucles sur les octets et l'encodeur
+      JPEG du navigateur lui-même&nbsp;: tout cela est déjà installé sur votre
+      machine."""
+
+[[privacy]]
+title = "Il fonctionne hors ligne."
+body = """
+ Débranchez-vous du réseau et l'outil ne
+      change pas, parce qu'il n'y a jamais eu d'étape réseau dedans. C'est la
+      preuve la plus simple de toutes, et celle qu'il vaut la peine de faire
+      avant de scanner un passeport."""
+
+[[howto]]
+title = "Photographiez la page."
+body = """
+ D'au-dessus, avec la page entière dans
+      le cadre et les quatre coins visibles ou presque. Il n'est pas nécessaire
+      d'être perpendiculaire ni d'avoir un éclairage uniforme&nbsp;: l'inclinaison
+      et l'ombre sont précisément ce à quoi sert cet outil. Ce qui compte, c'est
+      de remplir le cadre&nbsp;: une page photographiée depuis l'autre bout de la
+      pièce n'a plus de détail à récupérer."""
+
+[[howto]]
+title = "Vérifiez les quatre coins."
+body = """
+ Ils sont trouvés pour vous à la
+      lecture de la photo, et la page le dit quand elle n'est pas sûre&nbsp;: une
+      page posée sur un bureau de la même couleur a un bord réellement difficile à
+      voir. Appuyez n'importe où sur la photo et le coin le plus proche vient sous
+      votre doigt, ou atteignez-en un avec <kbd>Tab</kbd> et déplacez-le avec les
+      flèches."""
+
+[[howto]]
+title = "Décidez du sort de la lumière."
+body = """
+ &laquo;&nbsp;Couleur,
+      égalisée&nbsp;&raquo; mesure le papier sur toute la page et le divise, si
+      bien que l'ombre disparaît et qu'un tampon ou une signature gardent leur
+      couleur. &laquo;&nbsp;Noir et blanc&nbsp;&raquo; va plus loin et c'est ce
+      qui rend un scan assez petit pour un courriel. Ce que vous voyez à l'écran
+      est le résultat réel, produit par le code même qui écrit le fichier."""
+
+[[howto]]
+title = "Ajoutez les autres pages."
+body = """
+ Chaque photo ajoutée devient une page
+      de plus du même document, dans l'ordre de la liste, et chacune garde ses
+      propres coins. Les flèches d'une page dans la bande la déplacent vers
+      l'avant ou vers l'arrière."""
+
+[[howto]]
+title = "Enregistrez le PDF, et ouvrez-le avant de l'envoyer."
+body = """
+ Le document est écrit
+      ici, dans la mémoire de cette page. Rien n'a été envoyé pour le faire, et
+      rien à son sujet n'a été rapporté nulle part."""
+
+[[faq]]
+q = "Mon document est-il envoyé quelque part&nbsp;?"
+a = """
+        Non. La photo est décodée, redressée, nettoyée et écrite dans un PDF par
+        votre propre navigateur, sur votre propre matériel. Cet outil n'a aucune
+        fonction réseau, il ne va jamais rien chercher et n'envoie jamais rien, et
+        la <code>Content-Security-Policy</code> de la page nomme chaque adresse
+        qu'elle peut contacter, dont aucune ne nous appartient. Chargez la page
+        une fois, débranchez-vous d'internet&nbsp;: elle continue de
+        fonctionner."""
+
+[[faq]]
+q = "Comment trouve-t-il les coins de la page sans modèle&nbsp;?"
+a = """
+        En cherchant les quatre longues droites dont un rectangle est fait. La
+        photo est réduite, le gradient est calculé &mdash; où l'image change, et
+        dans quelle direction &mdash; et chaque pixel posé sur un bord vote pour la
+        droite sur laquelle il se trouverait. Les droites fortes sont appariées en
+        rectangles candidats, et chaque candidat est noté en parcourant ses quatre
+        côtés&nbsp;: quelle part de chacun a réellement un bord dessous, et les
+        quatre forment-ils la frontière d'une seule et même chose&nbsp;? Une page
+        est plus claire que ce qui l'entoure, ou plus sombre, mais elle l'est de la
+        même façon sur ses quatre côtés, et c'est cela qui empêche de prendre une
+        ligne de texte pour le bas de la page. Il n'y a aucun poids, rien n'est
+        téléchargé, et le calcul est le même pour tous les documents qui y
+        passent."""
+
+[[faq]]
+q = "Les coins trouvés sont faux. Et maintenant&nbsp;?"
+a = """
+        Faites-les glisser. Les coins sont une position de départ et jamais une
+        décision&nbsp;: le scan est pris là où les quatre finissent. Appuyez
+        n'importe où sur la photo et le coin le plus proche saute sous votre
+        doigt, ce qui est plus facile que d'atteindre une petite poignée, et les
+        flèches déplacent le coin sélectionné pixel par pixel. La page vous dit
+        aussi quand les coins sont une supposition plutôt qu'une trouvaille, et
+        marque cette page dans la bande&nbsp;: la raison habituelle est une page
+        posée sur un bureau à peu près de sa couleur, parce qu'il n'y a alors
+        vraiment presque aucun bord à trouver."""
+
+[[faq]]
+q = "Pourquoi la page redressée sort-elle à la bonne forme et non écrasée&nbsp;?"
+a = """
+        Parce que la forme est récupérée depuis la perspective plutôt que mesurée
+        sur les bords. Une page photographiée de biais a son bord lointain
+        raccourci, si bien que la méthode évidente &mdash; prendre la plus longue
+        paire de bords opposés et appeler cela le rapport &mdash; produit un A4
+        visiblement trapu, ce que donnent la plupart des scanners en ligne. La
+        photo d'un rectangle porte en réalité assez d'information pour récupérer à
+        la fois les proportions du rectangle et la focale de l'appareil, pourvu que
+        ce soit un appareil ordinaire&nbsp;; c'est un résultat de Zhang et He de
+        2003, et c'est ce que fait <code>src/geometry.js</code>. Là où la photo a
+        été prise perpendiculairement, il n'y a pas de perspective d'où partir et
+        il n'en faut pas, puisque les bords sont alors exacts&nbsp;: l'outil s'y
+        rabat, et la page dit laquelle des deux a répondu."""
+
+[[faq]]
+q = "Que fait exactement le &laquo;&nbsp;nettoyage&nbsp;&raquo; à l'image&nbsp;?"
+a = """
+        Il divise la lumière. La clarté du papier lui-même est mesurée sur toute la
+        page &mdash; une grille de tuiles, et dans chaque tuile un centile élevé de
+        la clarté, que le texte est trop sombre et trop clairsemé pour déplacer
+        &mdash; et chaque pixel est divisé par le papier estimé en ce point. Ce
+        qui reste, c'est l'encre, uniformément éclairée, sans l'ombre et sans la
+        chute vers les bords. Ce n'est pas la même chose que de monter le
+        contraste&nbsp;: monter le contraste d'une page photographiée rend la
+        partie claire blanche, la partie sombre noire et l'écriture de la partie
+        sombre illisible, et c'est pourquoi les
+        &laquo;&nbsp;niveaux&nbsp;automatiques&nbsp;&raquo; empirent ces images au
+        lieu de les améliorer."""
+
+[[faq]]
+q = "Pourquoi le mode noir et blanc est-il tellement plus petit&nbsp;?"
+a = """
+        Parce qu'une image à deux couleurs représente réellement une fraction des
+        données d'une image à seize millions, et parce qu'elle est stockée ainsi
+        ici&nbsp;: un bit par pixel, empaquetés par huit dans un octet et
+        compressés exactement, plutôt qu'en JPEG d'une image en noir et blanc. Sur
+        les mêmes pages, cela sort environ dix-huit fois plus petit que le mode
+        couleur, si bien qu'un contrat de vingt pages passe sous le mégaoctet au
+        lieu d'en peser une quinzaine. Le seuil est celui de Sauvola, qui décide
+        chaque pixel face à la moyenne et à la dispersion de son propre voisinage
+        plutôt que face à un nombre unique pour toute la page, et c'est cela qui
+        garde lisible l'écriture prise dans une ombre. Il n'a pas de demi-teintes,
+        une page portant une photographie devrait donc utiliser l'un des autres
+        modes."""
+
+[[faq]]
+q = "Puis-je mettre plusieurs pages dans un seul PDF&nbsp;?"
+a = """
+        Oui. Chaque photo ajoutée devient une page de plus, dans l'ordre de la
+        liste, et chaque page garde ses propres coins&nbsp;: une pile de pages
+        photographiées les unes après les autres devient donc un document. Les
+        flèches de chaque page dans la bande la déplacent vers l'avant ou vers
+        l'arrière. Le réglage de nettoyage est commun à toutes, et c'est
+        volontaire&nbsp;: des pages nettoyées différemment dans un même document
+        ressemblent à deux documents."""
+
+[[faq]]
+q = "Lit-il le texte, pour que je puisse chercher dans le PDF&nbsp;?"
+a = """
+        Non. Il n'y a ni couche de texte ni reconnaissance de caractères&nbsp;: ce
+        qui sort est une image de la page sur une page. Le faire correctement
+        supposerait un moteur d'OCR, soit des dizaines de mégaoctets de modèle à
+        télécharger, et un scanner de documents qui irait chercher un modèle avant
+        de pouvoir lire votre fiche de paie serait un scanner de documents ayant
+        une raison de téléphoner à la maison au sujet des fiches de paie. Si vous
+        avez besoin du texte, le mode noir et blanc produit exactement le type de
+        fichier avec lequel les logiciels d'OCR de votre propre machine travaillent
+        le mieux."""
+
+[[faq]]
+q = "C'est sorti flou. Pourquoi&nbsp;?"
+a = """
+        Presque toujours parce que la page était petite dans la photo. Le panneau
+        sous l'aperçu indique quelle part du cadre la page occupait et à combien de
+        points par pouce cela revient à peu près sur une feuille de cette
+        taille&nbsp;: en dessous d'environ 150 DPI, un scan imprimé paraît mou, et
+        contre du détail qui n'a jamais été dans le fichier, aucun outil ne peut
+        rien. Approchez-vous plutôt que de zoomer, tenez immobile, et laissez
+        l'appareil faire le point sur la page avant de déclencher. Le bougé est
+        l'autre cause, et il ne se récupère pas davantage."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a ni compte, ni connexion, ni période d'essai, ni
+        limite de pages, ni filigrane. Il n'y a pas non plus de limite à la taille
+        des photos, parce qu'aucun serveur ne les paie&nbsp;: le travail se fait
+        sur votre propre machine. Le site porte de la publicité, et c'est elle qui
+        le paie&nbsp;; on ne donne rien aux annonces sur vos documents."""
+
+[schema]
+description = "Scanner un document dans le navigateur&nbsp;: photographiez une page, et les quatre coins sont trouvés, la perspective est défaite, la lumière inégale est divisée et le résultat est écrit dans un PDF. Plusieurs pages font un seul document. Rien n'est envoyé."
+features = [
+  "Trouve les quatre coins de la page sans modèle, sans téléchargement et sans requête",
+  "Récupère la forme réelle de la page depuis la perspective, si bien qu'une photo de biais ne sort pas écrasée",
+  "Divise la lumière inégale et l'ombre au lieu de monter le contraste",
+  "Pages en noir et blanc stockées à un bit par pixel, ce qui rend un scan assez petit pour un courriel",
+  "Plusieurs photos deviennent les pages d'un même PDF, chacune avec ses coins",
+  "Les coins se déplacent à la souris, ou au clavier pixel par pixel",
+  "Dit quand les coins sont une supposition plutôt qu'une trouvaille",
+  "N'écrit ni date, ni auteur, ni nom de machine dans le document",
+  "Fonctionne hors ligne&nbsp;; aucun envoi, aucun compte",
+]
+
+[picker]
+title = "Déposez ici les photos de vos pages"
+hint = "ou cliquez pour parcourir &mdash; une photo par page, dans l'ordre des pages"

--- a/locales/fr/tools/redact-pdf.html
+++ b/locales/fr/tools/redact-pdf.html
@@ -1,0 +1,305 @@
+<!--
+  tools/redact-pdf/body.html, in French.
+
+  Every id, class, data-phrase key and brace placeholder below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+-->
+<main>
+  <!-- Étape 1 &mdash; le document -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisissez votre PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <div id="doc-facts" class="doc-facts" hidden>
+      <p id="doc-name" class="doc-name"></p>
+      <p id="doc-sub" class="doc-sub"></p>
+      <ul id="doc-warnings" class="doc-warnings"></ul>
+    </div>
+  </section>
+
+  <!-- Étape 2 &mdash; les trouver -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Dites ce qui doit disparaître</h2>
+
+    <p class="card-lede">
+      Tapez les mots &mdash; un nom, une adresse, une référence &mdash; et chaque
+      endroit où ils apparaissent est listé ci-dessous avec la ligne sur laquelle
+      il se trouve. Rien n'est retiré avant l'étape 4, et rien n'est retiré que
+      vous n'ayez coché.
+    </p>
+
+    <label class="find-label" for="terms">Mots et expressions, un par ligne</label>
+    <textarea id="terms" rows="3" spellcheck="false" autocomplete="off"
+              placeholder="Martin&#10;14 rue du Pont&#10;REF-40219"></textarea>
+
+    <div class="find-row">
+      <button type="button" id="find" class="primary">Les chercher</button>
+      <label class="inline-check">
+        <input type="checkbox" id="match-case"> <span>Respecter la casse</span>
+      </label>
+      <label class="inline-check">
+        <input type="checkbox" id="whole-word"> <span>Mots entiers uniquement</span>
+      </label>
+    </div>
+
+    <fieldset class="finders">
+      <legend>Ou cherchez ce qui est habituellement sensible</legend>
+      <div class="chips" id="finders"></div>
+      <p class="field-note" id="finder-note">
+        Ce sont des motifs, et un motif ne distingue pas un numéro de téléphone
+        d'un numéro de dossier. Les numéros de carte et les IBAN sont vérifiés
+        par leurs propres clés de contrôle&nbsp;; le reste est proposé, jamais
+        coché pour vous, et chacun mérite d'être lu.
+      </p>
+    </fieldset>
+
+    <div class="toolbar" id="match-bar" hidden>
+      <span id="match-count" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="tick-all" class="ghost">Tout cocher</button>
+        <button type="button" id="tick-none" class="ghost">Tout décocher</button>
+        <button type="button" id="clear-found" class="ghost danger">Vider la liste</button>
+      </div>
+    </div>
+
+    <ul id="match-list" class="match-list" hidden></ul>
+    <p id="match-more" class="field-note" hidden></p>
+  </section>
+
+  <!-- Étape 3 &mdash; lire la page -->
+  <section class="card" id="page-card" hidden>
+    <h2><span class="step">3</span> Lisez la page et piochez-y des mots</h2>
+
+    <p class="card-lede">
+      Voici le texte tel qu'il est stocké dans le document, dans l'ordre où un
+      lecteur le copierait, qui n'est pas toujours celui dans lequel il est
+      imprimé. Cliquez sur un mot pour le retirer, cliquez de nouveau pour le
+      garder. Tout ce qui est barré ici est ce qui va disparaître.
+    </p>
+
+    <div class="pager">
+      <button type="button" id="prev-page" class="ghost">&#8592; Précédente</button>
+      <span id="page-of" class="count"></span>
+      <button type="button" id="next-page" class="ghost">Suivante &#8594;</button>
+      <span class="pager-spacer"></span>
+      <span id="page-picked" class="count"></span>
+      <button type="button" id="clear-page" class="ghost danger">Tout garder sur cette page</button>
+    </div>
+
+    <p id="page-note" class="field-summary" hidden></p>
+
+    <div id="page-text" class="page-text" role="group" aria-label="Le texte de cette page"></div>
+  </section>
+
+  <!-- Étape 4 &mdash; le faire -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Retirez les mots</h2>
+
+    <label class="check">
+      <input type="checkbox" id="opt-boxes" checked>
+      <span>
+        <strong>Peindre un cadre noir là où chacun se trouvait</strong>
+        <span class="check-note">
+          Pour qu'un lecteur voie que quelque chose a été retiré. Ici le cadre est
+          un ornement et non le caviardage&nbsp;: les lettres ont déjà disparu du
+          fichier au moment où il est peint. Désactivez-le et les mots
+          disparaissent simplement, laissant la place qu'ils occupaient.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-elsewhere" checked>
+      <span>
+        <strong>Retirer les mêmes mots du reste du document</strong>
+        <span class="check-note">
+          Signets, commentaires, pense-bêtes, et ce qui a été saisi dans les
+          champs de formulaire. Un mot retiré d'une page et laissé dans un signet
+          n'a pas été retiré. Les propriétés du document partent quoi que dise
+          cette case, et le texte de remplacement qu'une visionneuse copie à la
+          place des lettres de la page aussi&nbsp;: l'un et l'autre sont le
+          document qui prononce le mot, et non un autre endroit qui en garde une
+          copie.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-attachments" checked>
+      <span>
+        <strong>Écarter les pièces jointes et tout ce qui s'exécute</strong>
+        <span class="check-note">
+          Un PDF peut contenir des fichiers entiers et du JavaScript qui s'exécute
+          à l'ouverture. On ne peut chercher dans ni l'un ni l'autre les mots que
+          vous retirez, et ni l'un ni l'autre n'est nécessaire pour lire un
+          document.
+        </span>
+      </span>
+    </label>
+
+    <p class="field-summary" id="run-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Les retirer</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Télécharger</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+      <ul id="check-terms" class="check-terms" hidden></ul>
+      <ul id="result-facts" class="result-facts"></ul>
+    </div>
+  </section>
+
+  <!--
+    The sentences this tool's JavaScript puts on screen. They live here rather
+    than in src/ because src/ is copied byte for byte into all eleven
+    languages; see "The strings in the JavaScript" in the repository README.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="load.notpdf">Ce n'est pas un PDF, il n'y a donc pas de texte à en retirer.</span>
+    <span data-phrase="load.encrypted">Ce PDF est protégé par un mot de passe.
+      Retirer sa protection à un document est un autre travail que d'en retirer
+      des mots, et cet outil ne le fera pas dans votre dos.</span>
+    <span data-phrase="load.broken">Ce fichier n'a pas pu être ouvert comme PDF ({detail}).</span>
+    <span data-phrase="load.nopages">Il s'est ouvert, mais aucune page n'a pu y être trouvée.</span>
+    <span data-phrase="load.repaired">La table de références croisées de ce
+      document ne correspondait pas à son contenu&nbsp;: il a donc été lu en
+      cherchant les objets. C'est une réparation, et elle a fonctionné &mdash;
+      vérifiez soigneusement le résultat avant de l'envoyer où que ce soit.</span>
+
+    <span data-phrase="doc.sub">{pages} &middot; {words} de texte &middot; {size}</span>
+    <span data-phrase="doc.notext">{count} de ces pages ne contiennent aucun
+      texte. Une telle page est l'image d'une page, et il n'y a rien ici que cet
+      outil puisse retirer&nbsp;: les mots de l'image restent exactement où ils
+      sont.</span>
+    <span data-phrase="doc.unreadable">{count} lettres de ce document n'ont pas pu
+      être lues comme des caractères, parce que les polices qu'elles emploient ne
+      portent aucune correspondance de leurs glyphes vers du texte. Ces lettres ne
+      peuvent pas être cherchées&nbsp;: vérifiez donc les pages où elles se
+      trouvent plutôt que de vous fier à la recherche.</span>
+    <span data-phrase="doc.scan">Certaines pages portent du texte invisible posé
+      sur une image, façon dont un scanner consigne ce que son lecteur a compris de
+      la page. Retirer ce texte retire ce qu'une recherche et un copier auraient
+      trouvé. Cela ne change rien à l'image, et dans l'image les mots restent
+      lisibles.</span>
+
+    <span data-phrase="find.none">Rien n'a correspondu sur aucune page.</span>
+    <span data-phrase="find.some">{count} sur {pages}.</span>
+    <span data-phrase="find.more">Les {shown} premières sont listées. Le reste est
+      trouvé et sera retiré aussi si vous les cochez toutes.</span>
+    <span data-phrase="find.terms">Tapez un mot ci-dessus, ou choisissez un motif, avant d'appuyer sur Chercher.</span>
+
+    <span data-phrase="page.of">Page {number} sur {total}</span>
+    <span data-phrase="page.picked">{count} seront retirés de cette page</span>
+    <span data-phrase="page.notext">Il n'y a pas de texte sur cette page. Soit
+      elle est vide, soit c'est l'image d'une page&nbsp;: un scan, une photo, un
+      export qui a dessiné ses mots comme des formes. Rien dessus ne peut être
+      cherché, et rien dessus ne peut être retiré ici.</span>
+    <span data-phrase="page.unreadable">{count} lettres de cette page n'ont pas pu
+      être lues comme des caractères. Elles apparaissent ci-dessous en &#9647;, et
+      la recherche ne les trouve pas.</span>
+    <span data-phrase="page.scan">Le texte de cette page est invisible&nbsp;: il
+      est posé sur une image de la page, façon dont on rend un scan consultable. Ce
+      que vous retirez ici est ce qu'une recherche et un copier auraient trouvé.
+      L'image, elle, garde les mots.</span>
+
+    <span data-phrase="run.summary">{words} sur {pages} seront retirés.</span>
+    <span data-phrase="run.nothing">Rien n'est encore coché. Cherchez un mot à l'étape 2, ou cliquez-en un à l'étape 3.</span>
+    <span data-phrase="run.editing">Retrait des mots&hellip;</span>
+    <span data-phrase="run.writing">Écriture du document&hellip;</span>
+    <span data-phrase="run.checking">Ouverture du fichier terminé et fouille&hellip;</span>
+    <span data-phrase="run.failed">Quelque chose s'est mal passé pendant la réécriture de ce document ({detail}).</span>
+    <span data-phrase="run.cancelled">Annulé. Rien n'a été écrit.</span>
+
+    <span data-phrase="result.headline">{words} retirés</span>
+    <span data-phrase="result.sub">{size} &middot; {pages} modifiées &middot; {boxes}</span>
+    <span data-phrase="check.good">Rouvert ici et fouillé, comme l'aurait fait un
+      lecteur&nbsp;: aucun d'eux n'est dans le fichier terminé.</span>
+    <span data-phrase="check.partial">Rouvert ici et fouillé&nbsp;: chaque
+      occurrence que vous aviez cochée a disparu, et celles que vous avez laissées
+      sont toujours là.</span>
+    <span data-phrase="check.survived">Ce fichier n'a PAS été écrit. Le document
+      terminé a été rouvert et une partie de ce que vous aviez retiré s'y trouvait
+      encore, ce qui signifie que le caviardage n'était pas complet. Rien n'est
+      proposé au téléchargement.</span>
+    <span data-phrase="check.pages">Ce fichier n'a PAS été écrit. Le document
+      terminé est revenu avec un nombre de pages différent de celui qu'il avait en
+      entrant&nbsp;: quelque chose s'est donc mal passé au-delà des mots. Rien
+      n'est proposé au téléchargement.</span>
+
+    <span data-phrase="fact.boxes">{count} peints sur les vides.</span>
+    <span data-phrase="fact.noboxes">Aucun cadre n'a été peint&nbsp;: les mots ont
+      donc disparu sans que rien n'indique où ils se trouvaient.</span>
+    <span data-phrase="fact.elsewhere">Les mêmes mots ont été retirés de {where}.</span>
+    <span data-phrase="fact.metadata">Les propriétés du document et le paquet XMP
+      ont été supprimés&nbsp;: le fichier terminé ne dit donc pas ce qui l'a
+      produit, ni quand, ni comment il s'appelait avant.</span>
+    <span data-phrase="fact.carried">{attachments} et {actions} ont été écartés.</span>
+    <span data-phrase="fact.shared">Une partie de ce que vous avez retiré était
+      dessinée par un bloc que le document réutilise sur plus d'une page&nbsp;:
+      elle a donc disparu de toutes les pages qui le dessinent. C'est plus que ce
+      que vous aviez coché, jamais moins.</span>
+    <span data-phrase="fact.overimage">{count} des lettres retirées reposaient sur
+      une image de la même page. Elles sont sorties de la couche de texte et sont
+      toujours dans l'image&nbsp;: un lecteur ne peut plus les chercher ni les
+      copier, et peut toujours les voir.</span>
+    <span data-phrase="fact.untouched">Tout le reste de chaque page a été recopié
+      octet pour octet. Aucune police, image ni ligne n'a été réencodée.</span>
+
+    <span data-phrase="count.pages">{count} pages</span>
+    <span data-phrase="count.page">{count} page</span>
+    <span data-phrase="count.words">{count} mots</span>
+    <span data-phrase="count.word">{count} mot</span>
+    <span data-phrase="count.pieces">{count} fragments de texte</span>
+    <span data-phrase="count.piece">{count} fragment de texte</span>
+    <span data-phrase="count.matches">{count} occurrences</span>
+    <span data-phrase="count.match">{count} occurrence</span>
+    <span data-phrase="count.boxes">{count} cadres noirs</span>
+    <span data-phrase="count.box">{count} cadre noir</span>
+    <span data-phrase="count.attachments">{count} pièces jointes</span>
+    <span data-phrase="count.attachment">{count} pièce jointe</span>
+    <span data-phrase="count.actions">{count} actions</span>
+    <span data-phrase="count.action">{count} action</span>
+    <span data-phrase="count.hosts">{count} hôtes</span>
+    <span data-phrase="count.host">{count} hôte</span>
+
+    <!-- The space before {platform} belongs to these two rather than to the
+         phrase it lets in, because phrases.js collapses and trims the markup
+         it reads and a leading space would not survive the trip. -->
+    <span data-phrase="net.clean">votre document n'est allé nulle part. {total}
+      fichiers chargés, tous appartenant à cette page. {platform}</span>
+    <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet
+      outil ne fait jamais. Cela mérite d'être examiné. {platform}</span>
+    <span data-phrase="net.platform">Les scripts de publicité, de mesure et du
+      bouton de don propres à la page ont été chargés depuis {hosts}&nbsp;; aucun
+      d'eux n'a reçu un document, un mot de document ou quoi que ce soit que vous
+      ayez cherché.</span>
+
+    <span data-phrase="finder.email">Adresses e-mail</span>
+    <span data-phrase="finder.card">Numéros de carte</span>
+    <span data-phrase="finder.iban">Comptes bancaires (IBAN)</span>
+    <span data-phrase="finder.nationalid">Numéros de sécurité sociale</span>
+    <span data-phrase="finder.phone">Numéros de téléphone</span>
+  </div>
+</main>

--- a/locales/fr/tools/redact-pdf.toml
+++ b/locales/fr/tools/redact-pdf.toml
@@ -1,0 +1,386 @@
+#
+# Caviardeur de PDF - French.
+#
+# Overrides for tools/redact-pdf/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Caviarder" est le verbe qu'emploie deja l'outil d'a cote pour les images, et
+# pour la meme raison : c'est le terme francais consacre, et il porte le sens
+# qui compte ici, celui d'un texte retire et non recouvert.
+#
+# La seule chose a ne pas perdre en retouchant cette prose : cette page avance
+# une affirmation que les autres outils de caviardage ne peuvent pas avancer,
+# et l'affirmation ne vaut rien si elle est exageree. Ce qui est retire, c'est
+# du texte. Une page qui est la photo d'une page ne porte pas de texte, et cet
+# outil le dit au lieu de faire semblant.
+#
+
+name = "Caviardeur de PDF"
+heading = "Caviarder&nbsp;un&nbsp;PDF <span class=\"h1-kw\">&mdash; les mots sortent, on ne les recouvre pas</span>"
+tagline = "Les lettres sont supprimées du fichier, puis le fichier est fouillé pour le prouver."
+
+title = "Caviarder un PDF &mdash; supprimer vraiment le texte, gratuit, sans envoi"
+description = "Retirez des mots d'un PDF au lieu de peindre un rectangle noir par-dessus. Les lettres sont supprimées des instructions de dessin de la page, le fichier terminé est rouvert et fouillé pour prouver qu'elles ont disparu, et rien n'est envoyé."
+og_title = "Caviarder un PDF comme il faut &mdash; les mots sont supprimés, pas recouverts"
+og_description = "Dans la plupart des outils, le rectangle noir se pose sur le texte et l'on peut copier ce qui est dessous. Celui-ci supprime les lettres du fichier puis fouille le résultat pour vous montrer qu'elles n'y sont plus."
+og_image_alt = "Caviarder un PDF en supprimant le texte, non en le recouvrant"
+
+pledge = """
+    Le document que vous choisissez est ouvert, lu, modifié et réécrit en
+    mémoire sur cette machine, par du code servi depuis cette adresse. Rien ici
+    ne peut faire d'envoi, et il n'y a au bout de cette page aucun serveur pour
+    le recevoir. Ni le fichier ni les mots que vous avez cherchés ne quittent
+    l'onglet."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les DevTools, regardez
+      l'onglet Réseau et caviardez quelque chose. Aucune requête ne transporte
+      une page, un mot ou un nom de fichier. Ou débranchez-vous d'internet et
+      caviardez quand même."""
+
+read_first = """
+, <code>src/text.js</code> pour la façon dont
+      chaque mot d'une page est trouvé et situé, et <code>src/edit.js</code> pour
+      la suppression elle-même&nbsp;: ce qui est découpé dans les instructions de
+      la page et ce qui y est remis pour que le reste de la ligne ne bouge pas.
+      Aucun des deux ne peut atteindre le réseau, et le lecteur et l'écrivain
+      d'à côté non plus."""
+
+howto_heading = "Comment caviarder un PDF pour que les mots aient vraiment disparu"
+
+card = """
+            Supprimez des mots d'un PDF au lieu de les recouvrir. Les lettres
+            sortent des instructions de dessin de la page, le vide est maintenu
+            ouvert pour que rien d'autre ne bouge, et le fichier terminé est
+            rouvert et fouillé ici pour prouver que les mots n'y sont pas."""
+
+[words]
+plural = "documents"
+choose = "un PDF"
+
+[[facts]]
+text = "Aucun envoi"
+
+[[facts]]
+text = "Aucun compte"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[facts]]
+text = "Vos fichiers restent sur votre appareil"
+
+[[privacy]]
+title = "Un rectangle noir n'est pas un caviardage, et ici on n'en peint aucun sur quoi que ce soit."
+body = """
+
+      Dans presque tous les logiciels qui proposent de caviarder une page &mdash;
+      une visionneuse PDF, un traitement de texte, un outil de mise en page
+      &mdash; le rectangle est un objet enregistré à côté du texte et non dedans.
+      Le texte est toujours là, dans le même fichier, au même endroit, et
+      sélectionner la zone puis copier vous le rend. Cet échec a publié des
+      dossiers judiciaires, des rapports de renseignement et, en décembre 2025,
+      des noms caviardés dans une publication massive de documents du ministère
+      de la Justice américain, lisibles en quelques heures. Cet outil supprime les
+      lettres des instructions qui dessinent la page. Il n'y a pas de rectangle
+      avec quelque chose dessous, parce qu'il n'y a rien dessous."""
+
+[[privacy]]
+title = "Le fichier terminé est rouvert et fouillé, ici, avant de vous être proposé."
+body = """
+
+      Tant que cela n'a pas eu lieu, tout ce qui précède n'est que cet outil
+      corrigeant sa propre copie. Les octets qui vont devenir votre téléchargement
+      sont donc rendus au même lecteur comme si un inconnu les avait envoyés,
+      chaque page est relue, chaque signet, commentaire, champ de formulaire et
+      propriété du document est collecté, et les mots que vous avez retirés sont
+      cherchés. Le décompte figure dans les résultats. Si quelque chose a survécu,
+      le passage est déclaré en échec et il n'y a pas de téléchargement."""
+
+[[privacy]]
+title = "Les mots ne quittent jamais l'onglet, la recherche non plus."
+body = """
+ La
+      Content-Security-Policy nomme chaque adresse que cette page peut contacter,
+      et aucune ne nous appartient. Cet outil n'ajoute rien à cette liste&nbsp;:
+      il n'a aucune fonction réseau propre, pas même facultative. Ce que vous
+      tapez dans le champ de recherche est une chaîne comparée à du texte présent
+      dans la mémoire de cet onglet, et ni l'une ni l'autre n'a nulle part où
+      aller."""
+
+[[privacy]]
+title = "Le caviardage est le travail qui survit le plus mal à un envoi."
+body = """
+
+      Ce que les gens caviardent est la raison même pour laquelle cela ne doit pas
+      être envoyé. Un témoignage, un courrier médical, un relevé bancaire destiné
+      à un propriétaire, un contrat portant le nom d'un client et destiné à un
+      autre. Confier cela au serveur d'un inconnu pour qu'il en retire la partie
+      privée signifie que la partie privée arrive d'abord, entière, et que c'est
+      la version qu'il conserve. Cette page n'a pas d'autre moitié."""
+
+[[privacy]]
+title = "Ce qui reste est recopié sans être touché."
+body = """
+
+      Les seuls octets qui changent sur une page sont les instructions d'affichage
+      de texte dont les lettres retirées faisaient partie. Toute autre
+      instruction, et chaque police, image et trait auxquels la page se réfère,
+      sont recopiés exactement tels qu'ils sont arrivés&nbsp;: rien n'est redessiné,
+      réencodé ni remis en page. La largeur de ce qui a été retiré est mesurée et
+      remise sous forme d'instruction d'espacement, pour que le reste de la ligne
+      demeure là où le document l'avait posé."""
+
+[[privacy]]
+title = "Il ne peut pas retirer de mots d'une photographie, et il dit de quelles pages il s'agit."
+body = """
+
+      Une page numérisée est une image. Les mots qu'elle porte sont des pixels et
+      non du texte, et rien ici ne peut y toucher. Si le scan porte la couche de
+      texte invisible que produit l'OCR d'un scanner, cet outil retire cette
+      couche &mdash; c'est-à-dire ce qu'une recherche et un copier auraient trouvé
+      &mdash; et dit clairement sur la page que l'image montre toujours les mots.
+      Recouvrir cette image est un autre travail&nbsp;; le
+      <a href=\"../caviarder-une-image/\">caviardeur d'images</a> est l'outil qui
+      écrase des pixels."""
+
+[[privacy]]
+title = "Le document cesse de dire d'où il vient."
+body = """
+
+      Les propriétés et le paquet XMP disparaissent à chaque passage&nbsp;: pas de
+      ligne de producteur, pas de date de création, pas d'auteur, pas de titre, et
+      aucun des blocs privés qu'un logiciel de mise en page laisse derrière lui.
+      Un fichier dont on a retiré un nom des pages et dont les propriétés
+      annoncent toujours <code>Accord Martin brouillon 3.docx</code> n'est pas
+      caviardé, et ce n'est pas quelque chose à laisser à une case à cocher."""
+
+[[privacy]]
+title = "Les fichiers chiffrés sont refusés plutôt qu'ouverts."
+body = """
+
+      Un PDF protégé par mot de passe est refusé, y compris celui, produit par les
+      scanners, dont le mot de passe est vide et qui s'ouvrirait techniquement.
+      Retirer sa protection à un document est un autre travail que d'en retirer
+      des mots, et le faire en silence serait une chose surprenante à faire en
+      votre nom."""
+
+[[privacy]]
+title = "Ce que Google charge, et ce qu'on ne lui donne pas."
+body = """
+ Les scripts de publicité
+      et de mesure viennent de Google. Ni l'un ni l'autre ne reçoit quoi que ce
+      soit sur votre document&nbsp;: ni un fichier, ni une page, ni un nom, ni une
+      taille, ni un nombre de pages, ni un mot que vous auriez cherché. Chaque
+      ligne qui lit, modifie ou écrit un PDF est servie depuis cette origine et
+      figure dans le dépôt."""
+
+[[privacy]]
+title = "Ce que charge le bouton de don, et ce qu'on ne lui donne pas."
+body = """
+
+      Le bouton &laquo;&nbsp;Buy me a coffee&nbsp;&raquo; de l'en-tête est
+      dessiné par un script de cdnjs.buymeacoffee.com et va chercher sa police
+      chez Google Fonts. C'est un lien et rien de plus&nbsp;: il ne signale aucune
+      visite, et on ne lui donne rien sur vous ni sur vos documents. Rien ne se
+      produit tant que vous ne cliquez pas, et ce vers quoi vous cliquez alors est
+      le site de quelqu'un d'autre."""
+
+[[privacy]]
+title = "Il fonctionne hors ligne."
+body = """
+ Débranchez-vous du réseau et tout sur cette
+      page continue de fonctionner. C'est la preuve la plus simple de
+      toutes&nbsp;: un outil qui enverrait votre document ailleurs pour le
+      caviarder s'arrêterait."""
+
+[[howto]]
+title = "Choisissez le PDF."
+body = """
+ Un document à la fois, et c'est
+      volontaire&nbsp;: le caviardage est un travail qu'il faut regarder page par
+      page, et un outil qui vous laisserait cocher des mots dans un fichier pour
+      les appliquer en silence à un autre est exactement la façon dont on finit
+      par envoyer ce qu'il ne fallait pas. Le navigateur le lit directement sur
+      votre disque."""
+
+[[howto]]
+title = "Dites ce qui doit disparaître."
+body = """
+ Tapez les mots &mdash; un nom,
+      une adresse, une référence &mdash; et chaque endroit où ils apparaissent est
+      listé avec la ligne sur laquelle il se trouve et une case à cocher. Les
+      détecteurs d'à côté cherchent les adresses e-mail, les numéros de carte, les
+      IBAN, les numéros de sécurité sociale et les numéros de téléphone. Ils sont
+      proposés, jamais cochés pour vous&nbsp;: un motif ne distingue pas un numéro
+      de téléphone d'un numéro de dossier."""
+
+[[howto]]
+title = "Lisez la page et piochez-y des mots."
+body = """
+
+      Le panneau montre le texte du document tel qu'il est réellement stocké, dans
+      l'ordre où un lecteur le copierait. Cliquez sur un mot pour le retirer,
+      cliquez de nouveau pour le garder. Tout ce qui est barré est ce qui va
+      disparaître, ce qui fait de cette étape la relecture autant que la
+      sélection&nbsp;: elle vaut la peine sur chaque page avant d'appuyer sur le
+      bouton."""
+
+[[howto]]
+title = "Retirez-les, et lisez la ligne qui dit que c'est vérifié."
+body = """
+
+      Les lettres sont supprimées, le vide qu'elles laissent est maintenu ouvert,
+      un cadre noir est peint dessus si vous en avez demandé un, et les mêmes mots
+      sont retirés des signets, des commentaires, des champs de formulaire et des
+      propriétés du document. Puis le fichier terminé est rouvert ici et fouillé.
+      Si un mot que vous avez retiré s'y trouve encore, vous n'avez pas de
+      téléchargement mais un message qui le dit."""
+
+[[faq]]
+q = "En quoi est-ce différent d'un cadre noir dessiné dans une visionneuse PDF&nbsp;?"
+a = """
+        Un rectangle dessiné dans une visionneuse est une annotation&nbsp;: un
+        objet doté d'une position, enregistré à côté de la page. Le texte dessous
+        est intact. Quiconque sélectionne cette zone et copie, ou ouvre le fichier
+        dans un autre logiciel, ou y passe n'importe quel extracteur de texte,
+        récupère les mots. Certaines visionneuses proposent une commande
+        &laquo;&nbsp;caviarder&nbsp;&raquo; qui applique réellement la
+        suppression, et plusieurs ne proposent que le dessin. Cet outil n'a aucun
+        rectangle à écarter&nbsp;: les lettres sont découpées des instructions de
+        dessin de la page, et le cadre noir, si vous le laissez activé, est peint
+        ensuite sur un vide déjà vide."""
+
+[[faq]]
+q = "Comment puis-je savoir que les mots ont vraiment disparu&nbsp;?"
+a = """
+        Parce que l'outil le vérifie, sur votre machine, et vous montre le
+        décompte. Une fois le fichier écrit, il est rouvert par le lecteur même de
+        cette page, chaque page est lue, chaque signet, commentaire, champ de
+        formulaire et propriété est collecté, et chaque mot retiré est cherché. La
+        ligne de résultat indique combien il y en avait et combien il en reste. Si
+        la réponse n'est pas celle attendue, le passage échoue et rien n'est
+        proposé au téléchargement. Vous pouvez aussi le vérifier ensuite
+        vous-même dans n'importe quelle visionneuse&nbsp;: Ctrl+F, et cherchez le
+        mot."""
+
+[[faq]]
+q = "Le reste de la page bouge-t-il quand un mot est retiré&nbsp;?"
+a = """
+        Non. Le texte est dessiné en faisant avancer une plume sur la page&nbsp;:
+        supprimer cinq lettres tirerait donc normalement le reste de la ligne de
+        cinq lettres vers la gauche. La largeur exacte de ce qui a été retiré est
+        mesurée sur les métriques de la police elle-même et remise sous forme
+        d'instruction d'espacement, qui déplace la plume sans rien dessiner. Les
+        colonnes restent alignées et les totaux restent sous leur titre."""
+
+[[faq]]
+q = "Peut-il caviarder un document numérisé&nbsp;?"
+a = """
+        Pas l'image, et il le dit au lieu de faire semblant. Un scan est la photo
+        d'une page&nbsp;: les mots sont des pixels et il n'y a pas de texte à
+        retirer. Ce qu'un scan porte souvent, en revanche, c'est une couche de
+        texte invisible que l'OCR du scanner a écrite par-dessus l'image pour
+        rendre la page consultable&nbsp;; cet outil trouve cette couche, en retire
+        ce que vous choisissez, et vous dit sur la page que l'image est inchangée.
+        Une recherche et un copier cessent donc de trouver le mot, et qui regarde
+        la page le lit toujours. Pour une image, le
+        <a href=\"../caviarder-une-image/\">caviardeur d'images</a> écrase les
+        pixels eux-mêmes."""
+
+[[faq]]
+q = "Et les parties d'un document qui ne sont pas sur une page&nbsp;?"
+a = """
+        Elles sont traitées, car c'est là qu'un caviardage fuit d'ordinaire. Les
+        mêmes mots sont retirés des signets, des commentaires et des pense-bêtes,
+        de ce qui a été saisi dans les champs de formulaire, du texte remis à un
+        lecteur d'écran, et du texte de remplacement qu'une visionneuse copie
+        <em>à la place</em> des lettres de la page. Ce dernier existe pour que les
+        ligatures et les mots coupés se copient correctement, et il peut contenir
+        une phrase entière. Les propriétés du document et le paquet XMP sont
+        supprimés purement et simplement. Les pièces jointes et tout ce qui
+        s'exécute à l'ouverture du fichier sont écartés, car on ne peut chercher
+        dans ni l'un ni l'autre les mots que vous retirez."""
+
+[[faq]]
+q = "Mes documents sont-ils envoyés quelque part&nbsp;?"
+a = """
+        Non. Le fichier est lu, modifié et écrit par votre propre navigateur, sur
+        votre propre matériel. Cet outil n'a pas de partie serveur, et la
+        <code>Content-Security-Policy</code> de la page nomme chaque adresse
+        qu'elle peut contacter, dont aucune ne nous appartient. Ce que vous tapez
+        dans le champ de recherche est comparé à du texte présent dans la mémoire
+        de cet onglet et ne va nulle part non plus."""
+
+[[faq]]
+q = "Pourquoi ne puis-je pas tracer un cadre sur la page comme dans d'autres outils&nbsp;?"
+a = """
+        Parce que dessiner une page suppose un moteur PDF complet &mdash; polices,
+        dégradés, transparence, modes de fusion &mdash;, soit un mégaoctet ou plus
+        de moteur à télécharger et à exécuter, et ce site n'en embarque aucun. Cela
+        se trouve convenir au travail&nbsp;: tracer un rectangle sélectionne une
+        <em>surface de papier</em>, et une surface de papier n'est pas la même
+        chose que le texte qui se trouve dessous, ce par quoi l'échec du cadre noir
+        commence. Ce que vous obtenez à la place, c'est le texte du document, dans
+        l'ordre de lecture, chaque mot cliquable. C'est aussi la seule vue capable
+        de vous dire ce qu'une image de la page ne peut pas&nbsp;: si les mots
+        devant vous sont seulement du texte."""
+
+[[faq]]
+q = "Le fichier terminé s'ouvrira-t-il partout&nbsp;?"
+a = """
+        Oui. La sortie est écrite en PDF 1.5, ou dans la version la plus élevée
+        qu'exigeait le fichier que vous avez fourni, et la 1.5 est comprise par
+        toute visionneuse parue depuis 2003. Rien sur la page n'est réencodé&nbsp;:
+        les polices, les images et le dessin vectoriel passent octet pour octet, et
+        ce qui reste du texte demeure sélectionnable et consultable comme
+        avant."""
+
+[[faq]]
+q = "Peut-il ouvrir un PDF protégé par mot de passe&nbsp;?"
+a = """
+        Non, et c'est délibéré. Un document chiffré est refusé avec un message qui
+        le dit, même lorsque le mot de passe est vide, ce qui est la façon dont
+        enregistrent beaucoup de scanners et de photocopieurs. Retirer sa
+        protection à un fichier est un autre travail que d'en retirer des mots, et
+        un outil qui le ferait en silence ferait quelque chose que vous n'avez pas
+        demandé."""
+
+[[faq]]
+q = "Y a-t-il une limite de taille, et cela coûte-t-il quelque chose&nbsp;?"
+a = """
+        Aucune limite n'est écrite dans l'outil. La limite, c'est votre propre
+        machine&nbsp;: le document est tenu en mémoire pendant le travail, un
+        portable encaissera donc quelques centaines de mégaoctets sans broncher et
+        peinera quelque part au-dessus. C'est gratuit, il n'y a ni compte, ni
+        connexion, ni période d'essai. Le site porte de la publicité, et c'est elle
+        qui le paie&nbsp;; on ne donne rien aux annonces sur vos documents."""
+
+[[faq]]
+q = "Fonctionne-t-il hors ligne&nbsp;?"
+a = """
+        Oui. Chargez la page une fois, débranchez-vous ensuite d'internet&nbsp;:
+        elle continue de fonctionner. C'est aussi la façon la plus simple de
+        prouver que rien n'est envoyé&nbsp;: un outil qui expédierait votre
+        document ailleurs pour le caviarder s'arrêterait à l'instant où vous tirez
+        la prise."""
+
+[schema]
+description = "Caviarder un PDF dans le navigateur en supprimant le texte plutôt qu'en le recouvrant. Les lettres sont retirées du flux de contenu de la page, le fichier terminé est rouvert et fouillé pour prouver qu'elles ont disparu, et rien n'est envoyé."
+features = [
+  "Supprime les lettres de la page au lieu de peindre un rectangle par-dessus",
+  "Rouvre le fichier terminé et le fouille pour prouver que les mots ont disparu",
+  "Trouve chaque occurrence d'un mot, ou cherche e-mails, numéros de carte, IBAN et numéros d'identité",
+  "Montre le texte du document dans l'ordre de lecture, chaque mot cliquable",
+  "Retire les mêmes mots des signets, commentaires, champs de formulaire et propriétés",
+  "Maintient le vide ouvert pour que le reste de la ligne ne bouge pas",
+  "Dit quelles pages sont des scans, où il n'y a pas de texte à retirer",
+  "Fonctionne hors ligne&nbsp;; aucun envoi, aucun compte, aucune limite de taille",
+]
+
+[picker]
+title = "Déposez votre PDF ici"
+hint = "ou cliquez pour parcourir &mdash; un document à la fois"

--- a/locales/fr/tools/stack-images.html
+++ b/locales/fr/tools/stack-images.html
@@ -1,0 +1,241 @@
+<!--
+  tools/stack-images/body.html, in French.
+
+  Every id, class, option value, data-phrase key and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language. Only
+  the words change. The #faq-raw anchor is a link target from the note in step
+  one, so it stays as it is.
+-->
+<main>
+  <!-- Étape 1 &mdash; les prises -->
+  <section class="card">
+    <h2><span class="step">1</span> Choisissez les prises</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p class="note">
+      Les fichiers RAW sont ouverts en lisant le JPEG pleine taille que
+      l'appareil y a déjà écrit&nbsp;: quelques kilooctets de répertoire, puis une
+      seule tranche. Les données du capteur ne sont jamais décodées, si bien
+      qu'une prise de 60&nbsp;Mo s'ouvre à peu près aussi vite qu'un JPEG.
+      <a href="#faq-raw">Ce que cela signifie pour le résultat</a>.
+    </p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="sort-name" class="ghost">Trier par nom</button>
+        <button type="button" id="clear-all" class="ghost danger">Tout retirer</button>
+      </div>
+    </div>
+
+    <ul id="frame-list" class="frame-list"></ul>
+  </section>
+
+  <!-- Étape 2 &mdash; comment les combiner -->
+  <section class="card">
+    <h2><span class="step">2</span> Comment les combiner</h2>
+
+    <div class="settings">
+      <div class="field field-wide">
+        <label for="mode">Méthode d'empilement</label>
+        <select id="mode">
+          <option value="mean" selected>Moyenne &mdash; réduire le bruit</option>
+          <option value="median">Médiane &mdash; retirer les gens et les voitures qui passent</option>
+          <option value="sigma">Écrêtage sigma &mdash; les deux à la fois</option>
+          <option value="max">Éclaircir &mdash; filés d'étoiles, feux d'artifice, light painting</option>
+          <option value="min">Assombrir &mdash; retirer ce qui est clair et qui a bougé</option>
+          <option value="sum">Additionner &mdash; simuler une longue pose</option>
+          <option value="focus">Empilement de mise au point &mdash; garder ce qui était net</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="align">Aligner les prises</label>
+        <select id="align">
+          <option value="translate" selected>Oui &mdash; décalage seul</option>
+          <option value="similarity">Oui &mdash; décalage, rotation et échelle</option>
+          <option value="none">Non &mdash; les prendre exactement telles quelles</option>
+        </select>
+        <p class="field-note" id="align-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="scale">Résolution de travail</label>
+        <select id="scale">
+          <option value="full" selected>Pleine taille</option>
+          <option value="half">Moitié &mdash; un quart de la mémoire</option>
+          <option value="quarter">Quart &mdash; un seizième</option>
+        </select>
+        <p class="field-note" id="scale-note"></p>
+      </div>
+
+      <div class="field" id="kappa-field" hidden>
+        <label for="kappa">Écarter au-delà de</label>
+        <div class="inline-pair">
+          <input type="range" id="kappa" min="0.5" max="4" step="0.1" value="2">
+          <output id="kappa-value" for="kappa">2.0&sigma;</output>
+        </div>
+        <p class="field-note">
+          Plus bas écarte davantage, et écarte du détail réel avec. Deux
+          écarts-types sont le point de départ habituel.
+        </p>
+      </div>
+
+      <div class="field" id="radius-field" hidden>
+        <label for="radius">La netteté est mesurée sur</label>
+        <div class="inline-pair">
+          <input type="range" id="radius" min="1" max="12" step="1" value="3">
+          <output id="radius-value" for="radius">3 px</output>
+        </div>
+        <p class="field-note">
+          Plus grand prend des régions entières à une seule prise&nbsp;; plus
+          petit suit le détail fin et peut brouiller un fond lisse d'une prise à
+          l'autre.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="gain">Exposition</label>
+        <div class="inline-pair">
+          <input type="range" id="gain" min="0.1" max="4" step="0.05" value="1">
+          <output id="gain-value" for="gain">1.00&times;</output>
+        </div>
+        <p class="field-note" id="gain-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="format">Enregistrer en</label>
+        <select id="format">
+          <option value="png" selected>PNG &mdash; sans perte</option>
+          <option value="jpeg">JPEG &mdash; fichier plus petit</option>
+        </select>
+        <div id="quality-row" class="inline-pair" hidden>
+          <input type="range" id="quality" min="0.5" max="1" step="0.01" value="0.92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+    </div>
+
+    <!--
+      What the run will cost, worked out before it starts. Every figure here is
+      an answer from src/plan.js rather than an estimate, which is why they are
+      shown at all: a median of twenty large frames is a genuinely different
+      proposition from an average of them, and that should be visible before
+      the button is pressed rather than afterwards.
+    -->
+    <dl class="plan" id="plan" hidden>
+      <div><dt>Résultat</dt><dd id="plan-output">&mdash;</dd></div>
+      <div><dt>Mémoire de travail</dt><dd id="plan-memory">&mdash;</dd></div>
+      <div><dt>Prises décodées</dt><dd id="plan-decodes">&mdash;</dd></div>
+      <div><dt>Lu sur le disque</dt><dd id="plan-read">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-warning" class="path-note" hidden></p>
+  </section>
+
+  <!-- Étape 3 &mdash; lancer -->
+  <section class="card">
+    <h2><span class="step">3</span> Empilez-les</h2>
+
+    <div class="export-row">
+      <button type="button" id="run" class="primary" disabled>Empiler les images</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame">
+        <img id="result-image" alt="Le résultat empilé">
+      </div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <p id="result-moves" class="field-note"></p>
+        <a id="download" class="primary as-button" download>Télécharger l'image</a>
+      </div>
+    </div>
+  </section>
+
+  <!--
+    Every sentence this tool's JavaScript puts on screen, kept out of the
+    JavaScript so that a translator can reach it. src/ is copied byte for byte
+    into all eleven languages, so a string written in a module is English at ten
+    of them. See shared/js/phrases.js.
+
+    A {name} is filled in by the caller. Nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="count.one">1 prise</span>
+    <span data-phrase="count.many">{count} prises</span>
+    <span data-phrase="count.none">Aucune prise pour l'instant</span>
+
+    <span data-phrase="frame.reference">Référence</span>
+    <span data-phrase="frame.make-reference">Prendre comme référence</span>
+    <span data-phrase="frame.remove">Retirer</span>
+    <span data-phrase="frame.size">{width} &times; {height}</span>
+    <span data-phrase="frame.raw">RAW &mdash; l'aperçu {width} &times; {height} de l'appareil lui-même</span>
+    <span data-phrase="frame.raw-camera">{camera} &mdash; aperçu {width} &times; {height}</span>
+    <span data-phrase="frame.raw-unreadable">Aucun aperçu n'a été trouvé dans ce fichier RAW</span>
+    <span data-phrase="frame.read">{read} lus sur {total}</span>
+
+    <span data-phrase="mode.mean">Moyenne toutes les prises. Le bruit aléatoire est aussi souvent au-dessus qu'en dessous, si bien que moyenner {count} prises le réduit d'environ {factor} fois. La méthode pour une série stable, et celle qu'un seul oiseau de passage gâche.</span>
+    <span data-phrase="mode.median">Prend la valeur centrale de chaque pixel. Tout ce qui n'était présent que sur une partie des prises &mdash; un touriste, une voiture, un avion &mdash; disparaît. C'est la seule méthode qui doit garder toutes les prises à la fois, et c'est pourquoi elle peut passer en bandes ci-dessous.</span>
+    <span data-phrase="mode.sigma">Apprend ce qu'est habituellement chaque pixel, puis ne moyenne que les valeurs qui concordent. Le résultat de la médiane avec la réduction de bruit de la moyenne. Elle lit les prises deux fois.</span>
+    <span data-phrase="mode.max">Garde la valeur la plus claire qu'ait jamais eue chaque pixel. C'est ce qui transforme une suite de poses courtes en filés d'étoiles, et ce qui recompose un feu d'artifice à partir de ses propres prises.</span>
+    <span data-phrase="mode.min">Garde la valeur la plus sombre qu'ait jamais eue chaque pixel. Un pixel ne reste clair que s'il l'était sur toutes les prises&nbsp;: les reflets, les phares et les gouttes de pluie éclairées disparaissent donc.</span>
+    <span data-phrase="mode.sum">Additionne les prises sans diviser&nbsp;: ce qu'aurait recueilli une seule pose {count} fois plus longue. Cela sature, exactement comme cette pose l'aurait fait. Servez-vous du curseur d'exposition pour le récupérer.</span>
+    <span data-phrase="mode.focus">Prend chaque partie de l'image dans la prise où elle était nette. Photographiez un petit sujet le long de la bague de mise au point et ceci recompose les parties qui étaient nettes.</span>
+
+    <span data-phrase="align.translate">Trouve de combien chaque prise s'est décalée et la remet en place, à une fraction de pixel près. Corrige le tremblement à main levée et la dérive du trépied. Il ne peut pas corriger la rotation.</span>
+    <span data-phrase="align.similarity">Trouve aussi la rotation et l'échelle. Coûte une mesure de plus par prise et rien du tout lorsque les prises se révèlent droites. La rotation n'est jamais récupérée qu'à une demi-tour près.</span>
+    <span data-phrase="align.none">Empile les prises exactement telles qu'elles sont données. Juste pour un trépied fixe ou une séquence d'intervallomètre, et faux pour tout ce qui est pris à main levée.</span>
+
+    <span data-phrase="scale.note">Chaque prise est décodée à cette taille par le décodeur du navigateur lui-même&nbsp;: un réglage plus petit, c'est donc moins de travail autant que moins de mémoire.</span>
+    <span data-phrase="gain.note">Multiplié dans le résultat tout à la fin, après le calcul et avant l'arrondi.</span>
+    <span data-phrase="gain.sum-note">Additionner {count} prises va presque certainement saturer. Descendez ceci vers {suggested} pour voir ce qui a été recueilli.</span>
+
+    <span data-phrase="plan.output">{width} &times; {height}</span>
+    <span data-phrase="plan.memory">environ {mb} Mo</span>
+    <span data-phrase="plan.decodes.simple">{count}, un par prise</span>
+    <span data-phrase="plan.decodes.passes">{count} &mdash; toutes les prises, {passes} fois</span>
+    <span data-phrase="plan.decodes.banded">{count} &mdash; toutes les prises, une fois pour chacune des {bands} bandes</span>
+    <span data-phrase="plan.read">{read} sur {total} sur le disque</span>
+    <span data-phrase="plan.banded">Cela ne tient pas en mémoire d'un seul tenant&nbsp;: l'image est donc découpée en {bands} bandes et les prises sont relues pour chacune. Choisir {suggested} en ferait un seul passage.</span>
+    <span data-phrase="plan.banded-anyway">Cela ne tient pas en mémoire d'un seul tenant&nbsp;: l'image est donc découpée en {bands} bandes et les prises sont relues pour chacune. Moins de prises, ou une résolution de travail plus petite, en feraient un seul passage.</span>
+
+    <span data-phrase="progress.open">Examen de {name}&hellip;</span>
+    <span data-phrase="progress.survey">Lecture de {name}&hellip;</span>
+    <span data-phrase="progress.measure">Mesure du déplacement de {name}&hellip;</span>
+    <span data-phrase="progress.stack">Empilement &mdash; {done} prises lues sur {total}</span>
+    <span data-phrase="progress.stack-banded">Empilement &mdash; bande {band} sur {bands}, {done} prises lues sur {total}</span>
+    <span data-phrase="progress.encode">Écriture de l'image&hellip;</span>
+
+    <span data-phrase="result.info">{width} &times; {height}, {size} &mdash; {count} prises combinées en {seconds} secondes</span>
+    <span data-phrase="result.moves">Chaque prise a été mesurée et remise en place.</span>
+    <span data-phrase="result.moves-some">{count} prises sur {total} n'ont pas pu être mesurées avec certitude et ont été laissées où elles étaient.</span>
+    <span data-phrase="result.moves-none">Les prises ont été empilées exactement telles qu'elles ont été données.</span>
+    <span data-phrase="result.moves-clamped">{count} prises ont annoncé une rotation trop grande pour une rafale, et ont été corrigées par simple décalage.</span>
+    <span data-phrase="result.cropped">Les écarter a laissé des bords que toutes les prises n'atteignaient pas, et ceux-ci ont été rognés.</span>
+
+    <span data-phrase="error.no.files">Ajoutez d'abord au moins une image.</span>
+    <span data-phrase="error.no.size">Aucun de ces fichiers n'a pu être ouvert comme image.</span>
+    <span data-phrase="error.one.frame">L'empilement demande au moins deux prises.</span>
+    <span data-phrase="error.unknown">Quelque chose s'est mal passé pendant l'empilement. Si l'un de ces fichiers est inhabituel, essayez-le seul.</span>
+    <span data-phrase="error.memory">Le navigateur est à court de mémoire. Essayez une résolution de travail plus petite, ou moins de prises.</span>
+    <span data-phrase="error.unreadable">{name} n'a pas pu être ouvert comme image et a été laissé de côté.</span>
+    <span data-phrase="error.busy">Attendez la fin de cette pile avant d'ajouter d'autres prises, ou annulez-la.</span>
+  </div>
+</main>

--- a/locales/fr/tools/stack-images.toml
+++ b/locales/fr/tools/stack-images.toml
@@ -1,0 +1,350 @@
+#
+# Empileur d'images - French.
+#
+# Overrides for tools/stack-images/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Empiler" est le verbe employe en photographie francaise, et "empilement" le
+# substantif ; "stacking" figure entre guillemets a la premiere occurrence
+# parce que c'est le mot des menus anglais que beaucoup ont sous les yeux. Les
+# sigles RAW (CR2, NEF, ARW, DNG) et les noms de bibliotheque (LibRaw, dcraw)
+# restent tels quels : ce sont les noms des fichiers du dossier.
+#
+# "Worker" reste aussi : il nomme une chose precise du navigateur, et un mot
+# francais serait une autre affirmation sur ce que fait la page.
+#
+
+name = "Empileur d'images"
+heading = "Empileur&nbsp;d'images <span class=\"h1-kw\">&mdash; combiner une rafale, fichiers RAW compris</span>"
+tagline = "Vingt prises n'en font plus qu'une, sans vingt envois et sans dérawtiseur."
+
+title = "Empileur d'images &mdash; moyenne, médiane et empilement de mise au point dans le navigateur"
+description = "Combinez une rafale de photographies en une seule&nbsp;: moyennez-les pour tuer le bruit, prenez la médiane pour retirer les gens d'une scène, éclaircissez pour des filés d'étoiles, ou empilez la mise au point d'une macro. Lit CR2, NEF, ARW, DNG, RAF et CR3 en extrayant l'aperçu de l'appareil lui-même. Tout se passe dans votre navigateur."
+og_title = "Empiler une rafale de photographies, fichiers RAW compris"
+og_description = "Moyenne, médiane, écrêtage sigma, éclaircir, assombrir, additionner ou empilement de mise au point &mdash; avec les prises alignées d'abord. Les fichiers RAW sont ouverts en lisant l'aperçu que l'appareil a déjà écrit, si bien qu'une prise de 60 Mo s'ouvre aussi vite qu'un JPEG. Rien n'est envoyé."
+og_image_alt = "Empileur d'images - plusieurs prises combinées en une seule, dans le navigateur"
+
+pledge = """
+    Chaque prise est ouverte, décodée, alignée, combinée et écrite par votre
+    propre navigateur, sur votre propre machine. Une pile de vingt fichiers RAW
+    de 60&nbsp;Mo, c'est environ un gigaoctet de photographies, et pas un octet
+    ne bouge&nbsp;: l'outil n'a aucune fonction réseau, et les fichiers sont lus
+    directement sur votre disque par un worker qui n'a nulle part où envoyer
+    quoi que ce soit."""
+
+live_hint = """
+      Ne nous croyez pas sur parole&nbsp;: ouvrez les DevTools, regardez
+      l'onglet Réseau et empilez un dossier de fichiers RAW. Aucune requête ne
+      transporte une photographie, une vignette, un nom de fichier ou un modèle
+      d'appareil. Ou débranchez-vous d'internet et empilez-les quand
+      même&nbsp;: rien ne change à l'outil."""
+
+read_first = """
+, <code>src/raw.js</code> pour la façon dont un
+      fichier RAW est ouvert en lisant des kilooctets plutôt que des mégaoctets,
+      <code>src/stack.js</code> pour le calcul de chaque méthode, et
+      <code>src/plan.js</code> pour l'origine des chiffres de mémoire et de
+      décodage affichés sur la page&nbsp;: ce sont les réponses de ce fichier, et
+      non des estimations."""
+
+howto_heading = "Comment empiler une série de photographies dans votre navigateur"
+
+card = """
+            Combinez une rafale en une seule image&nbsp;: moyennez le bruit
+            jusqu'à le faire disparaître, prenez la médiane pour perdre les
+            passants, ou éclaircissez pour des filés d'étoiles. Lit les fichiers
+            RAW sans dérawtiseur."""
+
+[words]
+plural = "photographies"
+choose = "quelques photographies"
+
+[[facts]]
+text = "Aucun envoi"
+
+[[facts]]
+text = "Aucun compte"
+
+[[facts]]
+text = "Aucun filigrane"
+
+[[facts]]
+text = "Lit le RAW"
+
+[[facts]]
+text = "Fonctionne hors ligne"
+
+[[facts]]
+text = "Code ouvert"
+
+[[privacy]]
+title = "Vos photographies n'ont nulle part où aller."
+body = """
+ La
+      Content-Security-Policy nomme chaque adresse que cette page peut contacter,
+      et aucune ne nous appartient. Il n'y a ici aucun point de collecte où vos
+      fichiers pourraient atterrir, ni de code qui les enverrait s'il y en avait
+      un&nbsp;: pas de <code>fetch</code>, pas de <code>XMLHttpRequest</code>, pas
+      de <code>sendBeacon</code>, ni dans <code>src/</code> ni dans le worker."""
+
+[[privacy]]
+title = "Les fichiers RAW sont lus, pas envoyés &mdash; et à peine lus."
+body = """
+ Un fichier RAW d'appareil
+      contient déjà un JPEG pleine taille que l'appareil a développé au moment du
+      déclenchement. Cet outil le trouve en parcourant quelques entrées de
+      répertoire puis en demandant une seule tranche, ce qui, sur un fichier de
+      60&nbsp;Mo, fait généralement moins de cent kilooctets. La page vous montre
+      ce chiffre en regard de la taille de vos fichiers pendant que vous
+      travaillez. Les données du capteur ne sont jamais lues."""
+
+[[privacy]]
+title = "Le travail se fait dans un Worker sur cette machine, pas sur un serveur."
+body = """
+ C'est le seul outil d'ici
+      qui en emploie un, parce qu'empiler se compte en minutes de calcul plutôt
+      qu'en secondes, et qu'une page figée ne peut ni montrer sa progression ni
+      être annulée. Un Worker est un second fil dans ce même navigateur &mdash;
+      voir <code>src/worker.js</code>. On lui remet les fichiers eux-mêmes, ce qui
+      ne coûte rien, car une poignée de fichier n'est pas les octets&nbsp;; et il
+      a exactement la même Content-Security-Policy que la page, c'est-à-dire nulle
+      part où les envoyer."""
+
+[[privacy]]
+title = "Rien de la série n'est rapporté nulle part."
+body = """
+ Combien de prises vous avez
+      empilées, quel appareil les a écrites, de combien chacune avait bougé,
+      quelle méthode vous avez choisie et combien de temps cela a pris restent
+      dans la mémoire de cette page jusqu'à ce que vous la fermiez. Il n'existe
+      dans ce dépôt aucun événement de mesure qui transporte quoi que ce soit de
+      cela, et la seule question que ce site pose après un téléchargement envoie
+      un pouce en haut ou en bas et le nom de l'outil, rien d'autre."""
+
+[[privacy]]
+title = "Il fonctionne hors ligne."
+body = """
+ Débranchez-vous du réseau et l'outil ne
+      change pas, parce qu'il n'y a jamais eu d'étape réseau dedans. Le worker et
+      chaque module qu'il charge sont mis en cache par le service worker de cette
+      page&nbsp;: une copie installée empile donc des fichiers RAW la prise
+      débranchée."""
+
+[[howto]]
+title = "Choisissez les prises."
+body = """
+ Une rafale, une série en fourchette,
+      une séquence d'intervallomètre, ou un dossier de fichiers RAW. Chacune est
+      ouverte à mesure qu'elle arrive, et la ligne vous dit ce qui en est
+      sorti&nbsp;: pour un fichier RAW, l'appareil, la taille de l'aperçu trouvé
+      dedans, et le peu du fichier qu'il a fallu lire pour le trouver."""
+
+[[howto]]
+title = "Prenez la méthode qui correspond à ce que vous cherchez à perdre."
+body = """
+ Le bruit&nbsp;:
+      moyenne, ou écrêtage sigma si quelque chose a bougé. Des gens, des voitures
+      ou un avion qui passe&nbsp;: médiane. Un ciel noir que vous voulez en filés
+      d'étoiles&nbsp;: éclaircir. Une macro prise le long de la bague de mise au
+      point&nbsp;: empilement de mise au point. La note sous le menu dit ce que
+      chacune fait à votre nombre de prises précis."""
+
+[[howto]]
+title = "Décidez si les prises ont besoin d'être alignées."
+body = """
+ À main levée&nbsp;: oui,
+      décalage seul. À main levée et en tournant aussi&nbsp;: décalage, rotation
+      et échelle. Trépied fixe ou intervallomètre&nbsp;: non, et ce sera plus
+      rapide. Chaque prise est mesurée par rapport à la première de la liste,
+      et c'est pourquoi n'importe quelle prise peut être promue à cette
+      place."""
+
+[[howto]]
+title = "Lisez les quatre chiffres, puis appuyez sur le bouton."
+body = """
+ Avant que quoi que ce soit
+      ne s'exécute, la page indique la taille du résultat, la mémoire qu'il
+      demandera à peu près, combien de fois les prises seront décodées et quelle
+      part de vos fichiers a été lue. Si la série ne tient pas en mémoire d'un
+      seul tenant, elle le dit, et nomme la résolution de travail qui y
+      remédierait."""
+
+[[faq]]
+q = "Mes photographies sont-elles envoyées quelque part&nbsp;?"
+a = """
+        Non. Chaque prise est ouverte, décodée, alignée, empilée et écrite par
+        votre propre navigateur, sur votre propre matériel. Cet outil n'a aucune
+        fonction réseau, il ne va jamais rien chercher et n'envoie jamais rien, et
+        la <code>Content-Security-Policy</code> de la page nomme chaque adresse
+        qu'elle peut contacter, dont aucune ne nous appartient. Chargez la page
+        une fois, débranchez-vous d'internet&nbsp;: elle continue de fonctionner.
+        Cela compte ici plus que sur la plupart des outils, simplement à cause du
+        volume&nbsp;: une pile de vingt prises RAW fait environ un gigaoctet, et
+        envoyer un gigaoctet de photographies pour qu'on en fasse la moyenne est
+        précisément ce que cet outil existe pour éviter."""
+
+[[faq]]
+q = "Quels formats RAW peut-il lire, et comment&nbsp;?"
+a = """
+        <span id="faq-raw"></span>CR2, CR3, NEF, NRW, ARW, SR2, SRF, DNG, ORF,
+        RAF, RW2, PEF, SRW, 3FR, IIQ, DCR, KDC, MRW, MEF, RWL et quelques autres,
+        soit l'essentiel de ce qu'écrivent les appareils. Ce qu'il en lit, c'est
+        l'aperçu JPEG pleine taille que l'appareil lui-même a développé au moment
+        du déclenchement&nbsp;: l'image du dos de l'appareil, et celle que votre
+        système d'exploitation dessine en vignette. Il est trouvé en parcourant la
+        structure de répertoires du fichier, ce qui coûte quelques lectures de
+        quelques kilooctets chacune, puis en prenant une seule tranche.
+        <strong>Ce n'est pas un dématriçage des données du capteur.</strong> Le
+        résultat porte la balance des blancs et le style d'image de l'appareil sur
+        huit bits par canal, plutôt que les douze ou quatorze bits de données
+        linéaires de capteur que vous donnerait un dérawtiseur."""
+
+[[faq]]
+q = "Alors pourquoi ne pas décoder correctement les données du capteur&nbsp;?"
+a = """
+        Parce que cela supposerait d'embarquer LibRaw ou dcraw&nbsp;: un second
+        moteur de plusieurs dizaines de mégaoctets, pour une seule famille de
+        formats, dont l'essentiel est fait de schémas de compression propres à
+        chaque fabricant. Cet arbitrage est débattu dans
+        <code>docs/what-can-be-built-here.md</code>, dans les sources de ce site,
+        où le RAW d'appareil figurait sur la liste des exclusions avant même que
+        cet outil n'existe. Ce qui a changé, ce n'est pas la réponse à cette
+        question, mais la découverte qu'empiler n'en a pas besoin&nbsp;: les
+        aperçus sont en pleine résolution, ils sont ce que l'appareil vous aurait
+        donné en JPEG de toute façon, et les lire est environ cent fois plus rapide
+        qu'un dématriçage. Si vous voulez les données du capteur, développez
+        d'abord les prises dans un dérawtiseur et empilez les TIFF ou les JPEG
+        qu'il produit&nbsp;: cet outil les accepte aussi."""
+
+[[faq]]
+q = "Combien de prises peut-il traiter, et de quelle taille&nbsp;?"
+a = """
+        Six des sept méthodes travaillent au fil de l'eau&nbsp;: elles gardent un
+        accumulateur et lisent chaque prise exactement une fois, si bien que cent
+        prises coûtent la même mémoire que deux et que seule la durée augmente. La
+        médiane fait exception, parce qu'on ne peut connaître la valeur centrale
+        d'un ensemble qu'une fois qu'on l'a tout entier&nbsp;: elle garde donc
+        toutes les prises à la fois, et vingt prises de 24 mégapixels font environ
+        1,4&nbsp;Go, ce qu'aucun navigateur ne vous accordera. Quand cela arrive,
+        l'image est découpée en bandes horizontales et empilée bande par bande, ce
+        qui coûte de relire les prises pour chaque bande. La page calcule tout cela
+        avant que vous n'appuyiez sur le bouton et vous montre le nombre&nbsp;: un
+        passage lent n'est donc jamais une surprise."""
+
+[[faq]]
+q = "Que fait réellement l'alignement des prises&nbsp;?"
+a = """
+        Il trouve de combien chaque prise a bougé par rapport à la première et la
+        remet en place, à une fraction de pixel près. La méthode est la corrélation
+        de phase&nbsp;: le décalage entre deux images apparaît comme une différence
+        de phase entre leurs spectres, si bien qu'une transformée de Fourier
+        chacune trouve un décalage de deux cents pixels aussi bon marché qu'un
+        décalage de deux. Le second réglage récupère en outre la rotation et
+        l'échelle, par le même tour appliqué au spectre en coordonnées
+        log-polaires. Tout cela est global &mdash; un décalage, un angle, une
+        échelle pour toute la prise &mdash;, si bien qu'il corrige un appareil qui
+        a bougé et ne peut pas corriger un sujet qui a bougé, ni une photographie
+        prise un pas plus à gauche. Une conséquence visible&nbsp;: une prise
+        décalée de vingt pixels vers la gauche n'atteint plus le bord droit, et le
+        résultat est donc rogné à la partie que toutes les prises couvrent. C'est
+        pourquoi une pile alignée revient très légèrement plus petite que les
+        prises qui y sont entrées, et c'est la seule solution de rechange à une
+        bordure sombre faite des prises qui n'étaient pas là."""
+
+[[faq]]
+q = "Quelle méthode dois-je utiliser&nbsp;?"
+a = """
+        <strong>Moyenne</strong> pour le bruit, sur une série où rien n'a
+        bougé&nbsp;: elle réduit le bruit aléatoire d'à peu près la racine carrée
+        du nombre de prises. <strong>Médiane</strong> pour retirer ce qui n'était
+        là qu'une partie du temps &mdash; l'usage classique est de photographier
+        une place animée une douzaine de fois et de l'obtenir vide.
+        <strong>Écrêtage sigma</strong> quand vous voulez les deux&nbsp;: il
+        apprend ce qu'est habituellement chaque pixel et ne moyenne que les valeurs
+        qui concordent, il a donc l'immunité de la médiane à une voiture qui passe
+        et la réduction de bruit de la moyenne. <strong>Éclaircir</strong> pour les
+        filés d'étoiles, les feux d'artifice et le light painting.
+        <strong>Assombrir</strong> pour retirer tout ce qui est clair et qui a
+        bougé. <strong>Additionner</strong> pour simuler une seule longue pose.
+        <strong>Empilement de mise au point</strong> pour une macro prise le long
+        de la bague."""
+
+[[faq]]
+q = "Pourquoi mon résultat fait-il huit bits alors que mes RAW en font quatorze&nbsp;?"
+a = """
+        Parce que ce qui est empilé, c'est l'aperçu de l'appareil lui-même, qui est
+        un JPEG. Il vaut la peine de dire qu'empiler récupère une partie de ce que
+        cela coûte&nbsp;: moyenner seize prises de huit bits donne un résultat aux
+        dégradés réellement plus fins que n'en avait aucune d'elles, parce que le
+        bruit qui faisait arrondir chaque prise différemment est précisément ce qui
+        permet à la moyenne de tomber entre les niveaux. Le calcul se fait ici en
+        virgule flottante et n'est arrondi qu'une seule fois tout à la fin, rien de
+        cela n'est donc jeté en chemin. Ce n'est pour autant pas la même chose
+        qu'empiler des données linéaires de capteur, et cet outil ne prétend pas le
+        contraire."""
+
+[[faq]]
+q = "Puis-je empiler des prises de tailles différentes, ou de plusieurs appareils&nbsp;?"
+a = """
+        Oui, même si c'est le plus souvent une erreur et qu'il vaut la peine de
+        vérifier que c'était voulu. Le résultat a la taille de la plus grande
+        prise, et toutes les autres sont mises à l'échelle pour y tenir et
+        centrées. Mélanger les appareils mélange aussi le rendu des couleurs&nbsp;:
+        une moyenne des deux est donc une moyenne de deux interprétations
+        différentes de la même lumière. Là où cela aide vraiment, c'est sur une
+        série prise à deux résolutions, ou sur un fichier RAW et un JPEG de la même
+        prise."""
+
+[[faq]]
+q = "Il dit que le passage se fera en bandes. Qu'est-ce que cela veut dire&nbsp;?"
+a = """
+        Que la mémoire de travail dont la méthode a besoin dépasse ce que l'outil
+        est prêt à réserver d'un coup&nbsp;: l'image sera donc découpée en bandes
+        horizontales et empilée bande par bande. Le résultat est exactement le
+        même&nbsp;; l'outil relit simplement les prises pour chaque bande, cela
+        prend donc plus longtemps, et la page vous dit combien de décodages cela
+        représentera. Baisser la résolution de travail d'un cran divise la mémoire
+        par quatre, ce qui transforme presque toujours un passage en bandes en un
+        seul passage&nbsp;; la note indique le réglage qui le ferait."""
+
+[[faq]]
+q = "Pourquoi cet outil emploie-t-il un Worker et aucun des autres&nbsp;?"
+a = """
+        Parce qu'il est le seul dont le travail se compte en minutes. Tous les
+        autres outils d'ici font quelque chose qui prend une seconde ou deux, et
+        sortir ce travail du fil principal y serait une cérémonie. Empiler vingt
+        grandes prises, c'est du calcul massif sur des centaines de mégaoctets, et
+        sur le fil principal cela veut dire une page figée&nbsp;: aucune barre de
+        progression qui bouge, un bouton Annuler qui ne répond pas, et pour finir
+        un navigateur qui propose de tuer l'onglet. Le Worker est un second fil
+        dans ce même navigateur, exécutant un fichier de ce même dossier, sous
+        cette même politique. Ce n'est pas un serveur et ce n'est pas une fonction
+        réseau."""
+
+[[faq]]
+q = "Est-ce gratuit, et faut-il un compte&nbsp;?"
+a = """
+        C'est gratuit, et il n'y a ni compte, ni connexion, ni période d'essai, ni
+        filigrane. Il n'y a pas non plus de limite au nombre de prises empilées ni
+        à leur taille, parce qu'aucun serveur ne les paie&nbsp;: le travail se fait
+        sur votre propre machine et le seul plafond est votre propre mémoire. Le
+        site porte de la publicité, et c'est elle qui le paie&nbsp;; on ne donne
+        rien aux annonces sur vos photographies."""
+
+[schema]
+description = "Empiler une rafale de photographies dans le navigateur&nbsp;: moyenne, médiane, moyenne à écrêtage sigma, éclaircir, assombrir, additionner ou empilement de mise au point, avec les prises alignées d'abord par corrélation de phase. Lit les fichiers RAW d'appareil en extrayant l'aperçu pleine taille que l'appareil y a incorporé, aucun dérawtiseur n'est donc nécessaire. Rien n'est envoyé."
+features = [
+  "Sept méthodes&nbsp;: moyenne, médiane, moyenne à écrêtage sigma, éclaircir, assombrir, additionner et empilement de mise au point",
+  "Lit CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2 et d'autres en extrayant l'aperçu pleine taille de l'appareil",
+  "Ouvre un fichier RAW de 60 Mo en en lisant environ cent kilooctets",
+  "Alignement automatique&nbsp;: décalage seul, décalage avec rotation et échelle, ou aucun",
+  "Alignement au sous-pixel par corrélation de phase, et non par recherche de décalages",
+  "Six des sept méthodes gardent un accumulateur&nbsp;: cent prises coûtent la mémoire de deux",
+  "Coût en mémoire et en décodages calculé et affiché avant le départ",
+  "Le travail s'exécute dans un Worker&nbsp;: la progression avance et Annuler répond",
+  "Sortie PNG ou JPEG&nbsp;; fonctionne hors ligne&nbsp;; aucun envoi, aucun compte",
+]
+
+[picker]
+title = "Déposez les prises ici"
+hint = "ou cliquez pour parcourir &mdash; JPEG, PNG, WebP, TIFF et RAW d'appareil"


### PR DESCRIPTION
Four tools and four guides shipped after French was last brought level, so
a reader with the site set to French landed on English for the DICOM
viewer, the document scanner, the PDF redactor and image stacking, plus
the four guides that go with them. The build was doing the right thing by
keeping them out of the sitemap and the hreflang sets, but the pages were
still there to read, in the wrong language.

## What is here

- `locales/fr/tools/` &mdash; `dicom-viewer`, `document-scanner`,
  `redact-pdf`, `stack-images`, each a `.toml` and a `.html`
- `locales/fr/pages/guides/` &mdash; `open-a-dicom-file`, `redact-a-pdf`,
  `scan-a-document-with-your-phone`, `stack-photos-to-reduce-noise`
- eight new entries in the `[slugs]` table of `locales/fr/locale.toml`

## The slugs are load bearing

`check_links` fails the build when a published locale page links to a page
that was not built, so every cross-link had to name its target by the
translated slug: `caviarder-une-image`, `est-il-sur-d-envoyer-ses-fichiers`
and the four new guide slugs. They are written as search phrases rather
than transliterations, matching what the French slug table already does.

## Register

Read off the French pages that were already there, not invented: `vous`
throughout, `votre propre navigateur` for the promise that nothing leaves
the machine, `caviarder` for redaction, `matiere`/`materiel` rather than a
calque, the no-break space before `: ; ! ?`, and `&laquo;&nbsp;&raquo;`
for quotation.

The six `#phrases` blocks keep their `data-phrase` keys and every
`{placeholder}` byte for byte &mdash; checked with a script that diffs
ids, classes, `for`, `scope` and the placeholder sets against the English
source.

## Verification

`python build.py --out _plain --clean --no-minify` exits 0 and French is
now **absent from the locale debt list**, which is how the build reports
65 of 65. No CRLF anywhere under `locales/fr/`.

One of twelve branches closing the same eight-page hole, one language per
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
