### PR TITLE
Give Italian the eight pages it was reading in English

### DIFF
--- a/locales/it/locale.toml
+++ b/locales/it/locale.toml
@@ -70,6 +70,14 @@ complete = true
 # Il prestito, non "ripresa accelerata": timelapse e' quello che si scrive.
 "timelapse-video" = "creare-timelapse"
 "hash-checksum" = "verificare-checksum"
+# Il DICOM resta DICOM: e la sigla che sta scritta sul CD che consegna
+# l’ospedale, e nessuno la cerca tradotta.
+"dicom-viewer" = "visualizzatore-dicom"
+"document-scanner" = "scansionare-documenti"
+# Lo stesso verbo di "oscurare-immagine", perche e la stessa promessa: il testo
+# viene tolto dal file, non coperto con un rettangolo.
+"redact-pdf" = "oscurare-pdf"
+"stack-images" = "impilare-immagini"
 
 "guides" = "guide"
 "roadmap" = "roadmap"
@@ -104,6 +112,11 @@ complete = true
 "guides/trim-an-audio-file" = "guide/tagliare-un-file-audio"
 "guides/whats-inside-a-gif" = "guide/cosa-ce-dentro-una-gif"
 "guides/verify-a-file-checksum" = "guide/verificare-il-checksum-di-un-file"
+"guides/open-a-dicom-file" = "guide/aprire-un-file-dicom"
+"guides/redact-a-pdf" = "guide/oscurare-un-pdf"
+"guides/scan-a-document-with-your-phone" = "guide/scansionare-un-documento-col-telefono"
+# Chi impila non cerca "impilare": cerca il rumore, che e il problema.
+"guides/stack-photos-to-reduce-noise" = "guide/impilare-foto-per-ridurre-il-rumore"
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/it/pages/guides/open-a-dicom-file.html
+++ b/locales/it/pages/guides/open-a-dicom-file.html
@@ -1,0 +1,256 @@
+  <section>
+    <h2>La risposta breve</h2>
+    <p>
+      Apri il <a href="../../visualizzatore-dicom/">Visualizzatore DICOM</a> e
+      trascinaci sopra tutta la cartella di file. Vengono letti sulla tua
+      macchina, rimessi nelle serie da cui venivano, e impilati nell'ordine in
+      cui l'apparecchio li ha presi. Non viene caricato niente, e nei tuoi file
+      non viene riscritto niente.
+    </p>
+    <p>
+      Se ti hanno dato un disco e ti stai chiedendo quale dei file aprire: tutti,
+      insieme. Una TC o una RM non è un file. È un file per slice, e uno studio
+      del torace sono trecento file.
+    </p>
+  </section>
+
+  <section>
+    <h2>Che cosa c'è su un disco dell'ospedale</h2>
+    <p>
+      Di solito quattro cose, e una sola conta.
+    </p>
+    <ul>
+      <li>
+        <strong>Una cartella di scansioni</strong>, spesso chiamata
+        <code>DICOM</code>, <code>IMAGES</code> o <code>ST0001</code>, che
+        contiene file chiamati <code>IM000001</code>, <code>I0000001</code> o un
+        lungo numero puntato. Spesso senza nessuna estensione. Queste sono la
+        scansione.
+      </li>
+      <li>
+        <strong>Un file chiamato <code>DICOMDIR</code></strong>. Un indice del
+        resto, scritto perché un visualizzatore possa elencare gli studi che
+        stanno sul disco senza aprire ogni file. Non ti serve.
+      </li>
+      <li>
+        <strong>Un visualizzatore</strong>, sotto forma di eseguibile Windows, di
+        voce di autorun o ogni tanto di applet Java. È stato compilato per quello
+        che era attuale quando il disco è stato masterizzato, ed è per questo che
+        così tanti non partono più.
+      </li>
+      <li>
+        <strong>Una pagina HTML o un PDF</strong> con sopra il logo
+        dell'ospedale, che spiega come avviare il visualizzatore.
+      </li>
+    </ul>
+    <p>
+      Le scansioni non hanno bisogno di quel visualizzatore. Il formato è uno
+      standard pubblicato e i file si leggono da soli; l'eseguibile sul disco è
+      un programma che potrebbe leggerli, non l'unico.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché i file non hanno estensione</h2>
+    <p>
+      Perché al DICOM non serve. Ogni file si porta dietro il suo marcatore: 128
+      byte di niente, poi le quattro lettere <code>DICM</code>, poi un piccolo
+      blocco di campi che descrive come è scritto il resto del file. Un lettore
+      cerca quelle quattro lettere, e non un nome che finisce per
+      <code>.dcm</code>.
+    </p>
+    <p>
+      Ed è anche per questo che rinominare un file in <code>.dcm</code> non
+      cambia niente, e che un visualizzatore che pretende l'estensione è
+      inutilmente rigido. I file scritti direttamente dalla rete di un ospedale
+      non hanno nemmeno i 128 byte e il marcatore &mdash; sono i dati nudi senza
+      niente davanti, e un lettore deve ricavare da sé la loro codifica dal primo
+      campo. È un file normale, non uno rotto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Finestra e livello, che è il comando che conta</h2>
+    <p>
+      È l'unica cosa che rende un'immagine medica diversa da una fotografia, ed è
+      il motivo per cui un editor di immagini non va bene per guardarne una.
+    </p>
+    <p>
+      Una slice TC contiene circa quattromila valori distinti. Il tuo schermo
+      mostra duecentocinquantasei grigi. Qualcosa deve decidere quali quattromila
+      finiscono su quali duecentocinquantasei, e quella decisione è la
+      <strong>finestra</strong>: tutto quello che sta sotto è nero, tutto quello
+      che sta sopra è bianco, e l'intervallo in mezzo viene distribuito sui
+      grigi.
+    </p>
+    <p>
+      Sposta la finestra e lo stesso file sembra una scansione diversa. Non è un
+      artefatto di rendering, è proprio il punto. Il polmone e l'osso stanno tutti
+      e due nella slice e non si possono vedere insieme: una finestra che mostra
+      la trama di un polmone gonfio mette ogni osso al bianco puro, e una che
+      mostra il dettaglio trabecolare di una costola mette tutto il polmone al
+      nero puro.
+    </p>
+    <p>
+      Su una TC i numeri sono <strong>unità Hounsfield</strong>, e sono definite
+      in assoluto e non apparecchio per apparecchio: l'acqua è 0 e l'aria è
+      &minus;1000, per definizione, su ogni TC del mondo. È per questo che un
+      visualizzatore può offrire finestre con un nome &mdash; polmone, osso,
+      cervello, tessuti molli &mdash; e fare in modo che vogliano dire la stessa
+      cosa sul tuo file e sulla postazione dove la scansione è stata refertata. Le
+      solite:
+    </p>
+    <ul>
+      <li><strong>Tessuti molli</strong> &mdash; centro 40, ampiezza 400.</li>
+      <li><strong>Polmone</strong> &mdash; centro &minus;600, ampiezza 1500.</li>
+      <li><strong>Osso</strong> &mdash; centro 300, ampiezza 1500.</li>
+      <li><strong>Cervello</strong> &mdash; centro 40, ampiezza 80. Una finestra
+        stretta, perché sostanza grigia e sostanza bianca differiscono solo di
+        qualche unità.</li>
+    </ul>
+    <p>
+      Su una RM una scala così non c'è. I valori dipendono dalla sequenza, dalla
+      bobina e dall'apparecchio, quindi non c'è niente a cui intitolare un preset
+      e la finestra da cui partire è quella che chiede il file stesso. Ogni
+      scansione porta con sé un suggerimento.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché a volte le slice scorrono al contrario</h2>
+    <p>
+      Un visualizzatore deve decidere in che ordine mettere i file, e nel file ci
+      sono due cose che potrebbe usare.
+    </p>
+    <p>
+      <strong>Instance Number</strong> è un contatore. È la scelta ovvia e lo
+      assegna qualunque cosa abbia scritto i file, che non è tenuta a numerarli
+      nella direzione in cui corre il paziente. Uno studio ricostruito dai piedi
+      in su e numerato dalla testa in giù scorre all'indietro, e una serie
+      assemblata da due ricostruzioni può ripetere i numeri di netto.
+    </p>
+    <p>
+      <strong>Image Position (Patient)</strong> è dove la slice si trova
+      fisicamente, in millimetri, in un sistema di coordinate fissato al paziente
+      e non all'apparecchio. Ordinare su quello è giusto qualunque cosa abbia
+      fatto la numerazione, e ha un effetto collaterale utile: una volta che le
+      slice sono in ordine fisico, la distanza tra loro è misurabile, quindi un
+      visualizzatore può dirti che le slice distano 5&nbsp;mm &mdash; e accorgersi
+      quando ne manca una, cosa che il file non dice mai.
+    </p>
+  </section>
+
+  <section>
+    <h2>Misurare qualcosa</h2>
+    <p>
+      Una scansione è un dato misurato, quindi una lunghezza su di essa è una
+      lunghezza vera &mdash; se il file dice quanto sono distanti i suoi pixel.
+      Quello è un campo solo, Pixel Spacing, in millimetri, ed è presente
+      praticamente su ogni TC e su ogni RM.
+    </p>
+    <p>
+      Spesso manca sulle immagini ecografiche, sui documenti scansionati e sulle
+      catture di schermo salvate come DICOM. Dove manca non c'è una risposta
+      onesta in millimetri, e un visualizzatore che la dà lo stesso si è inventato
+      una scala. Un conteggio di pixel è la risposta corretta a una domanda a cui
+      il file non può rispondere.
+    </p>
+    <p>
+      Occhio anche ai pixel che non sono quadrati, che fuori dalla TC sono la
+      norma. Misurare in pixel e moltiplicare per una sola cifra di spaziatura è
+      giusto solo dove le due coincidono; ogni asse va misurato con la sua.
+    </p>
+  </section>
+
+  <section>
+    <h2>Che cosa si porta dietro una scansione oltre all'immagine</h2>
+    <p>
+      È la parte su cui la gente si sbaglia, ed è il motivo per cui con questi
+      file bisogna stare attenti.
+    </p>
+    <p>
+      Un file DICOM non è un'immagine con attaccati dei metadati. È una cartella
+      clinica con dentro un'immagine. L'header è un elenco di campi, e su una
+      tipica scansione clinica contiene:
+    </p>
+    <ul>
+      <li>il nome del paziente, il numero di cartella, la data di nascita e il
+        sesso;</li>
+      <li>il numero di accettazione, che è la chiave della richiesta nel sistema
+        dell'ospedale;</li>
+      <li>il medico richiedente, il tecnico che ha eseguito l'esame, il radiologo
+        che l'ha refertato;</li>
+      <li>la struttura, il suo indirizzo e il reparto;</li>
+      <li>il produttore dell'apparecchio, il modello e il numero di serie;</li>
+      <li>la data e l'ora dell'esame al secondo;</li>
+      <li>e una serie di identificatori unici &mdash; studio, serie, istanza
+        &mdash; che sono chiavi perfette per tornare all'archivio da cui il file
+        viene.</li>
+    </ul>
+    <p>
+      Qualunque file ti sia stato dato si porta dietro tutto questo, e tutto
+      questo viaggia con il file ovunque il file vada. Cancellare il nome non
+      basta: una data di nascita, una struttura grande come un codice postale e
+      l'ora di un esame identificano una persona più o meno bene quanto un nome, e
+      l'UID dello studio la identifica esattamente per chiunque abbia accesso
+      all'archivio.
+    </p>
+    <p>
+      Certi apparecchi tengono anche una seconda copia del nome del paziente in un
+      campo privato, cioè un campo il cui significato non è pubblicato da nessuna
+      parte e che quasi tutti gli anonimizzatori lasciano stare, perché non
+      possono sapere che cosa ci sia dentro.
+    </p>
+  </section>
+
+  <section>
+    <h2>Non caricare la scansione per guardarla</h2>
+    <p>
+      Il modo solito in cui questo problema viene risolto è una ricerca di
+      &laquo;dicom viewer online&raquo; e una casella di caricamento. Quello che è
+      appena successo è che uno sconosciuto ha una copia di una cartella clinica:
+      i pixel, il nome, la data di nascita, il numero di cartella e la chiave per
+      rientrare nell'archivio.
+    </p>
+    <p>
+      Non c'è nessun motivo per farlo. Leggere un file DICOM vuol dire analizzare
+      un header e spacchettare degli interi, e un browser lo fa benissimo, ed è
+      per questo che il <a href="../../visualizzatore-dicom/">visualizzatore che
+      sta qui</a> non ha nessuna funzione di rete: nessun <code>fetch</code>,
+      nessun <code>XMLHttpRequest</code>, niente che potrebbe mandare un file
+      anche se qualcosa ci provasse. Carica la pagina una volta, stacca la rete, e
+      continua ad aprire scansioni.
+    </p>
+    <p>
+      <a href="../e-sicuro-caricare-i-propri-file/">È sicuro caricare i propri
+      file sui convertitori online?</a> spiega come verificare questa affermazione
+      su questo sito o su qualsiasi altro. Questo è il tipo di file su cui vale
+      più la pena verificarla.
+    </p>
+  </section>
+
+  <section>
+    <h2>Che cosa un browser non può fare</h2>
+    <p>
+      Due cose, e su tutte e due vale la pena essere chiari.
+    </p>
+    <p>
+      <strong>Non è un visualizzatore diagnostico.</strong> Il tuo schermo non è
+      calibrato, il browser non è una catena di rendering validata, e nessuna
+      pagina web è passata per una valutazione regolatoria. Leggere una scansione
+      per prendere una decisione clinica è un lavoro per la postazione su cui è
+      stata refertata. Guardare che cosa c'è su un disco, tirare fuori una slice
+      per una lezione, leggere un header o capire perché un altro programma
+      rifiuta il file sono tutti ottimi motivi per aprirne una in un browser.
+    </p>
+    <p>
+      <strong>Certe scansioni compresse non si decodificano.</strong> Il DICOM
+      ammette diversi schemi di compressione e i browser ne implementano uno. I
+      file semplici, quelli codificati run-length, il JPEG baseline e il JPEG
+      Lossless &mdash; che è quello che usa la maggior parte delle esportazioni
+      ospedaliere &mdash; si aprono tutti. JPEG 2000, JPEG-LS e i formati video
+      richiedono codec che sono megabyte di libreria compilata. Dove l'immagine
+      non si può decodificare, l'header resta interamente leggibile, che di solito
+      è comunque la metà per cui sei venuto.
+    </p>
+  </section>

--- a/locales/it/pages/guides/open-a-dicom-file.toml
+++ b/locales/it/pages/guides/open-a-dicom-file.toml
@@ -1,0 +1,21 @@
+#
+# Guida: aprire un file DICOM - Italian.
+#
+
+nav = "Aprire un file DICOM"
+title = "Come aprire un file DICOM (.dcm) senza installare niente"
+description = "Che cosa c'è su un disco dell'ospedale, perché i file non hanno estensione, come aprire una scansione .dcm in un browser, che cosa fa davvero finestra e livello, e che cosa si porta dietro una scansione sul paziente oltre all'immagine."
+
+heading = "Come aprire un file DICOM, e che cosa c'è dentro"
+lede = """
+    Un disco dell'ospedale è una cartella di file senza estensione e un
+    visualizzatore scritto per Windows XP. I file sono DICOM, e non hanno niente
+    di esotico: una scansione è un header pieno di campi e un blocco di pixel.
+    Ecco come guardarne una, che cosa vogliono dire i comandi, e che altro il file
+    si porta dietro oltre all'immagine."""
+
+updated = "25 agosto 2026"
+
+og_title = "Come aprire un file DICOM senza installare niente"
+og_description = "Che cosa c'è su un disco dell'ospedale, perché i file non hanno estensione, e che cosa si porta dietro sul paziente una scansione .dcm oltre all'immagine."
+og_image_alt = "abox.tools - strumenti che non toccano mai un server"

--- a/locales/it/pages/guides/redact-a-pdf.html
+++ b/locales/it/pages/guides/redact-a-pdf.html
@@ -1,0 +1,239 @@
+  <section>
+    <h2>La risposta breve</h2>
+    <p>
+      Apri l'<a href="../../oscurare-pdf/">Oscuratore di PDF</a>, trascinaci
+      dentro il documento, scrivi le parole che devono sparire, spunta quelle che
+      intendi davvero, e premi &laquo;Togli&raquo;. Le lettere vengono cancellate
+      dalle istruzioni con cui la pagina si disegna, le stesse parole vengono
+      tolte dai segnalibri, dai commenti, dai campi dei moduli e dalle proprietà
+      del documento, e il file finito viene riaperto e cercato davanti a te prima
+      che ti venga offerto.
+    </p>
+    <p>
+      Tutto quello che segue spiega perché è quest'ultima frase quella che conta,
+      e come capire se lo strumento che usi già può dire la stessa cosa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Il fallimento di cui si parla</h2>
+    <p>
+      Disegna un rettangolo nero sopra un nome in un lettore di PDF. Quello che
+      vedi è un nome con sopra un rettangolo nero. Quello che quasi tutti i
+      lettori <em>salvano</em> è un documento che contiene il nome e, a parte, un
+      rettangolo con una posizione, una dimensione e un colore.
+    </p>
+    <p>
+      Un rettangolo disegnato così è un'<strong>annotazione</strong>: un oggetto
+      che sta accanto alla pagina e non dentro di essa. Il testo che ci sta sotto
+      è esattamente com'era. Seleziona l'area e premi copia, oppure passa sul file
+      un qualsiasi estrattore di testo, oppure aprilo in un programma che disegna
+      le annotazioni in modo diverso, e il nome torna fuori. Sullo schermo non c'è
+      niente che distingua questo da un oscuramento vero, ed è proprio per questo
+      che continua a succedere a organizzazioni che hanno degli avvocati alle
+      dipendenze.
+    </p>
+    <p>
+      Ha pubblicato atti giudiziari, valutazioni dei servizi, contratti e &mdash;
+      nel dicembre 2025 &mdash; nomi anneriti in una diffusione di massa di
+      documenti del Dipartimento di Giustizia statunitense, che sono stati
+      leggibili nel giro di poche ore dalla pubblicazione. Lo schema è sempre lo
+      stesso. Il rettangolo era l'annotazione, e l'annotazione non è mai stata il
+      testo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Che cosa fa invece un oscuramento vero</h2>
+    <p>
+      Una pagina di un PDF è un elenco di istruzioni: imposta questo font, sposta
+      la penna qui, disegna questi glifi. Le parole sulla pagina esistono in un
+      posto solo, come operandi di quelle istruzioni di disegno:
+    </p>
+    <pre><code>BT /F1 12 Tf 72 700 Td (Gentile signor Rossi) Tj ET</code></pre>
+    <p>
+      Oscurare il nome vuol dire <strong>cancellare quelle lettere da quella
+      istruzione</strong> e riscrivere la pagina. Dopo di che non c'è più niente
+      da recuperare, non perché il file lo nasconda bene ma perché le lettere nel
+      file non ci sono. Non c'è un rettangolo con qualcosa sotto, perché sotto non
+      c'è niente.
+    </p>
+    <p>
+      Una cosa va rimessa, altrimenti il risultato è visibilmente sbagliato. Il
+      testo viene disegnato facendo avanzare una penna lungo la pagina, quindi
+      cancellare cinque lettere tira il resto della riga indietro di cinque
+      lettere: le colonne smettono di allinearsi e i totali scivolano sotto le
+      intestazioni sbagliate. Uno strumento che fa questo lavoro come si deve
+      misura di quanto sarebbero avanzate le lettere tolte e rimette quella
+      distanza come un'istruzione di spaziatura, che sposta la penna senza
+      disegnare niente.
+    </p>
+    <p>
+      Il rettangolo nero, se c'è, viene disegnato <em>dopo</em>, sopra un vuoto
+      che è già vuoto. È una cortesia verso chi legge il documento &mdash; un
+      segno che qualcosa è stato tolto &mdash; e non è l'oscuramento. È tutta qui
+      la distinzione, in una frase: in un oscuramento vero il rettangolo è un
+      ornamento; in uno finto il rettangolo <em>è</em> l'oscuramento.
+    </p>
+  </section>
+
+  <section>
+    <h2>I quattro posti in cui una parola si nasconde e che non sono la pagina</h2>
+    <p>
+      È la parte che frega chi la prima parte l'ha fatta come si deve. Un PDF
+      porta testo in più posti contemporaneamente, e un lettore li mostra, li
+      cerca o li copia tutti. Togliere un nome dalla pagina e lasciarlo in uno di
+      questi non vuol dire averlo tolto.
+    </p>
+    <ul>
+      <li>
+        <strong>Le proprietà del documento.</strong> Titolo, autore e il nome del
+        file da cui questo è stato esportato. Un documento alle cui pagine è stato
+        tolto un nome e le cui proprietà dicono ancora <code>bozza 3 transazione
+        Rossi.docx</code> non è oscurato. Di solito c'è una seconda copia delle
+        stesse informazioni in un pacchetto XMP, che deve sparire anche lui.
+      </li>
+      <li>
+        <strong>I segnalibri.</strong> L'indice laterale di un lettore è un elenco
+        di titoli con attaccati dei numeri di pagina &mdash; e un titolo è una
+        riga di testo su cui la pagina non ha nessun controllo.
+      </li>
+      <li>
+        <strong>I campi dei moduli e i commenti.</strong> Quello che qualcuno ha
+        scritto in un modulo è conservato due volte: una come valore del campo e
+        una come l'aspetto che il lettore disegna. Devono sparire tutte e due. Una
+        nota adesiva si porta dietro il suo testo e il nome di chi l'ha scritta.
+      </li>
+      <li>
+        <strong>Il testo di sostituzione.</strong> Un PDF può dichiarare che una
+        sequenza di glifi &laquo;si scrive&raquo; in un altro modo, così che una
+        legatura o una riga spezzata da un trattino si copi come la parola che
+        rappresenta. Vuol dire che un documento può mostrare una cosa e passarne
+        un'altra a chi preme Ctrl+C, e un oscuramento che togliesse solo quello
+        che era disegnato lascerebbe la frase intatta per chiunque selezioni il
+        paragrafo.
+      </li>
+    </ul>
+    <p>
+      Gli allegati sono il quinto. Un PDF può portarsi dentro interi altri file, e
+      niente di quello che fai alle pagine li tocca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Come controllare un file, in trenta secondi</h2>
+    <p>
+      Fallo su qualsiasi cosa tu stia per mandare, qualunque strumento l'abbia
+      prodotta. È il controllo che avrebbe pescato ognuno dei fallimenti
+      pubblicati.
+    </p>
+    <ol>
+      <li>
+        <strong>Apri il file finito e premi Ctrl+F</strong> (Cmd+F su un Mac).
+        Cerca la parola che hai tolto. Un oscuramento vero non restituisce niente.
+        Se il lettore salta a un rettangolo nero, la parola è ancora lì dentro e
+        il rettangolo ci sta semplicemente sopra.
+      </li>
+      <li>
+        <strong>Seleziona l'area annerita e copiala.</strong> Trascina sopra il
+        rettangolo, premi Ctrl+C e incolla in una casella di testo. Se arriva
+        qualcosa, hai trovato lo stesso fallimento dall'altra direzione.
+      </li>
+      <li>
+        <strong>Seleziona tutto il documento e copia anche quello.</strong> Ctrl+A
+        e poi Ctrl+C, incolla in un editor di testo qualsiasi, e leggi che cosa
+        viene fuori. È il più utile dei tre, perché ti mostra il documento come lo
+        vede un estrattore di testo &mdash; compreso del testo che non sapevi ci
+        fosse, cosa che su una pagina scansionata è normale.
+      </li>
+      <li>
+        <strong>Guarda le proprietà</strong> &mdash; File → Proprietà nella
+        maggior parte dei lettori &mdash; e il pannello dei segnalibri. Sono tutti
+        e due posti in cui un nome sopravvive a un oscuramento perfetto sulla
+        pagina.
+      </li>
+    </ol>
+    <p>
+      L'<a href="../../oscurare-pdf/">Oscuratore di PDF</a> esegue per te il primo
+      e il terzo di questi controlli e ti mostra il conto, perché uno strumento
+      che afferma di avere tolto qualcosa non è una prova, mentre una ricerca nel
+      file finito lo è.
+    </p>
+  </section>
+
+  <section>
+    <h2>I documenti scansionati sono un problema diverso</h2>
+    <p>
+      Una scansione è la fotografia di una pagina. Le parole che ci stanno sopra
+      sono pixel, non testo, e nessuna quantità di modifiche al livello di testo
+      le tocca &mdash; perché un livello di testo non c'è, oppure perché quello
+      che c'è descrive l'immagine invece di esserla.
+    </p>
+    <p>
+      Quasi tutti gli scanner e gli strumenti PDF moderni aggiungono sopra
+      l'immagine un livello di testo invisibile, scritto dal riconoscimento ottico
+      dei caratteri, perché la pagina si possa cercare. Quel livello è testo vero e
+      si può togliere. Vale la pena toglierlo: è quello che avrebbero trovato una
+      ricerca, una copia e ogni sistema automatico che legge documenti. Non cambia
+      niente dell'immagine, in cui le parole restano perfettamente leggibili per
+      chiunque guardi la pagina.
+    </p>
+    <p>
+      Quindi per una scansione la sequenza onesta è: togli le parole dal livello
+      di testo, poi occupati dell'immagine a parte &mdash; il che vuol dire
+      riscrivere dei pixel. È quello che fa l'<a href="../oscurare-un-immagine/">oscuratore
+      di immagini</a>, e la guida che gli sta accanto spiega perché una sfocatura
+      o un mosaico non bastano per il testo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché non stamparlo e riscansionarlo</h2>
+    <p>
+      Perché funziona, e ti costa tutto il resto. Stampare una pagina oscurata e
+      riscansionarla produce davvero un documento senza nessun livello di testo da
+      cui perdere &mdash; e un documento che nessuno può cercare, che nessun
+      lettore di schermo può leggere, che è da cinque a cinquanta volte più
+      grande, e la cui qualità è quella che è saltata in mente allo scanner
+      dell'ufficio. Si regge anche sul fatto che la pagina si sia stampata come si
+      vedeva: un'annotazione può essere marcata come visibile a schermo e non su
+      carta, e quando il tuo rettangolo nero era proprio quello, il foglio che
+      esce dalla stampante ha sopra il nome.
+    </p>
+    <p>
+      Lo stesso ragionamento vale per l'&laquo;appiattisci in immagine&raquo;, che
+      certi strumenti propongono come oscuramento. Converte ogni pagina nella
+      fotografia di se stessa. Se le parole erano coperte e non cancellate, adesso
+      la copertura è permanente &mdash; ma insieme se n'è andato tutto il resto
+      del documento, e il file che mandi è un file con cui nessuno può
+      lavorare.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché è il lavoro che meno di tutti vale la pena caricare</h2>
+    <p>
+      A un servizio di oscuramento va dato il file non oscurato. È tutta lì la
+      transazione: la versione privata arriva per prima, intatta, ed è la versione
+      che sta sul disco di qualcun altro. Qualunque cosa dica l'informativa sulla
+      privacy, sulla sequenza non si discute &mdash; il documento su cui stavi
+      attento è quello che hai consegnato.
+    </p>
+    <p>
+      Quello che la gente oscura rende la cosa peggiore di come suona.
+      Dichiarazioni di testimoni, lettere mediche, estratti conto che vanno a un
+      padrone di casa, un contratto con dentro il nome di un cliente che va a un
+      altro cliente, un atto con sopra un indirizzo di casa. Quelli sono i
+      documenti, ed è esattamente per questo che lo strumento che li tratta non
+      dovrebbe avere un server dall'altra parte.
+    </p>
+    <p>
+      Tutto quello che fa <a href="../../oscurare-pdf/">l'oscuratore di questo
+      sito</a> succede nel tuo browser: il file viene letto, modificato, scritto e
+      controllato sulla tua macchina, e nemmeno le parole che cerchi escono mai
+      dalla scheda. Stacca la rete e continua a funzionare, che è la prova più
+      semplice che esista del fatto che non viene mandato niente da nessuna parte.
+      Vedi <a href="../e-sicuro-caricare-i-propri-file/">è sicuro caricare i propri
+      file</a> per capire che cosa comporta davvero un caricamento.
+    </p>
+  </section>

--- a/locales/it/pages/guides/redact-a-pdf.toml
+++ b/locales/it/pages/guides/redact-a-pdf.toml
@@ -1,0 +1,21 @@
+#
+# Guida: oscurare un PDF perché le parole spariscano davvero - Italian.
+#
+
+nav = "Oscurare un PDF"
+title = "Come oscurare un PDF perché il testo sparisca davvero"
+description = "Un rettangolo nero disegnato in un lettore di PDF di solito lascia le parole lì sotto, e un copia-incolla se le riprende di netto. Che cosa toglie un oscuramento vero, i quattro posti in cui una parola si nasconde fuori dalla pagina, e come controllare un file prima di mandarlo."
+
+heading = "Come oscurare un PDF perché il testo sparisca davvero"
+lede = """
+    Un rettangolo nero sopra un nome e un nome cancellato sono identici sullo
+    schermo. Uno dei due sopravvive a essere selezionato e copiato. Ecco la
+    differenza, i posti in cui una parola si nasconde e che non stanno affatto
+    sulla pagina, e il controllo da trenta secondi che ti dice quale dei due
+    hai."""
+
+updated = "25 agosto 2026"
+
+og_title = "Come oscurare un PDF perché il testo sparisca davvero"
+og_description = "Perché un rettangolo nero in un lettore di PDF di solito non è un oscuramento, i quattro posti in cui una parola si nasconde fuori dalla pagina, e come controllare un file prima di mandarlo."
+og_image_alt = "abox.tools - strumenti che non toccano mai un server"

--- a/locales/it/pages/guides/scan-a-document-with-your-phone.html
+++ b/locales/it/pages/guides/scan-a-document-with-your-phone.html
@@ -1,0 +1,248 @@
+  <section>
+    <h2>La risposta breve</h2>
+    <p>
+      Metti la pagina su qualcosa che non sia dello stesso colore della pagina,
+      mettiti sopra, riempi l'inquadratura e scatta una fotografia. Poi apri lo
+      <a href="../../scansionare-documenti/">Scanner per documenti</a>, controlla
+      i quattro angoli che ha trovato, scegli &laquo;colore, uniformato&raquo; o
+      &laquo;bianco e nero&raquo;, e salva il PDF.
+    </p>
+    <p>
+      Il lavoro è tutto qui. Il resto spiega che cosa sta sistemando ognuno di
+      quei passaggi, perché sapere quale pezzo fa che cosa è quello che ti
+      permette di capire, in tre secondi, se la cosa che stai per mandare verrà
+      accettata.
+    </p>
+  </section>
+
+  <section>
+    <h2>Che cosa separa davvero una foto da una scansione</h2>
+    <p>
+      Tre cose, e non contano allo stesso modo.
+    </p>
+    <ul>
+      <li>
+        <strong>L'inclinazione.</strong> Una fotografia è scattata da dove stavi
+        tu, quindi la pagina è un quadrilatero e non un rettangolo. È quella che
+        notano tutti ed è la più facile da annullare.
+      </li>
+      <li>
+        <strong>La luce.</strong> Uno scanner trascina una luce uniforme lungo la
+        pagina. Una stanza no: c'è una zona chiara sotto la lampada, un angolo in
+        penombra lontano da lì, e molto spesso la tua stessa ombra su un lato. È
+        questa che fa sembrare una fotografia una fotografia, ed è quella che si
+        cerca di sistemare con il &laquo;contrasto automatico&raquo;, che la
+        peggiora.
+      </li>
+      <li>
+        <strong>La dimensione.</strong> La fotografia da dodici megapixel di una
+        pagina sono dai tre ai cinque megabyte. Venti fotografie così sono un
+        documento che rimbalzerà su metà dei server di posta a cui verrà mandato.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Scattare la foto</h2>
+    <p>
+      Cinque cose, in ordine di quanta differenza fanno:
+    </p>
+    <ul>
+      <li>
+        <strong>Riempi l'inquadratura.</strong> È l'unica che non si può sistemare
+        dopo. Un dettaglio che nella fotografia non c'era non è nel file, e una
+        pagina fotografata da metà stanza è una pagina che nessuno può leggere a
+        nessuna risoluzione. Avvicinati invece di zoomare: a meno che il telefono
+        non passi a un secondo obiettivo più lungo, zoomare è un ritaglio dello
+        stesso sensore &mdash; butta via esattamente i pixel che stai cercando di
+        tenere.
+      </li>
+      <li>
+        <strong>Mettila su qualcosa di un altro colore.</strong> Una pagina bianca
+        su una scrivania bianca non ha quasi nessun bordo da far trovare a
+        qualcuno &mdash; né al software, né a te, quando poi ti tocca trascinare
+        gli angoli a mano. Un tavolo scuro, un libro, un cappotto: qualsiasi cosa.
+      </li>
+      <li>
+        <strong>Non metterti tra la pagina e la luce.</strong> La tua stessa ombra
+        sulla pagina è il singolo motivo più comune per cui una scansione fatta
+        col telefono viene male. Girati di novanta gradi e sparisce.
+      </li>
+      <li>
+        <strong>Lascia che metta a fuoco, poi stai fermo.</strong> Il mosso non lo
+        recupera nessuno strumento, e nemmeno una messa a fuoco sbagliata. Tocca
+        la pagina sullo schermo, aspetta che si assesti, poi premi il pulsante.
+      </li>
+      <li>
+        <strong>Fai entrare tutta la pagina, angoli compresi.</strong> Non perché
+        gli angoli siano preziosi, ma perché sono quello su cui viene misurato il
+        raddrizzamento. Una pagina che esce dal bordo dell'inquadratura funziona
+        lo stesso &mdash; il bordo della fotografia fa le veci del bordo della
+        pagina &mdash; ma una pagina con tre angoli nell'inquadratura e uno tirato
+        a indovinare è una pagina che verrà fuori leggermente sbagliata.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Raddrizzare: perché la forma conta più dell'inclinazione</h2>
+    <p>
+      Annullare l'inclinazione è un pezzo di aritmetica ben capito. Quattro angoli
+      di un rettangolo visti da un punto qualsiasi determinano la trasformazione
+      che li rimette a posto, e applicarla a ogni pixel dà una pagina piatta.
+      Qualsiasi strumento che dice di raddrizzare una pagina fa quello.
+    </p>
+    <p>
+      La parte che va storta in silenzio è <em>quanto grande</em> debba essere la
+      pagina piatta. Il metodo ovvio è misurare i lati del quadrilatero e usarne
+      il rapporto &mdash; e una fotografia scattata di sbieco accorcia il lato
+      lontano, quindi un foglio A4 viene fuori visibilmente tozzo. Continua a
+      sembrare una scansione. Semplicemente ogni riga di testo ha l'altezza
+      sbagliata, e sullo schermo non c'è niente che lo dica.
+    </p>
+    <p>
+      La risposta migliore è che l'informazione la porta la prospettiva stessa: a
+      patto solo che la fotocamera sia una normale, la fotografia di un rettangolo
+      basta per ricavare sia le proporzioni vere del rettangolo sia la lunghezza
+      focale della fotocamera. Lo
+      <a href="../../scansionare-documenti/">Scanner per documenti</a> che sta qui
+      fa questo, e poi ti dice che forma è venuta fuori la pagina e se è un foglio
+      standard &mdash; così una pagina che dice &laquo;1:1,41, che è la forma di
+      un A4 o di un A5&raquo; è una pagina a cui puoi smettere di pensare.
+    </p>
+  </section>
+
+  <section>
+    <h2>La luce: dividi, non stirare</h2>
+    <p>
+      Aumentare il contrasto di una pagina illuminata in modo irregolare rende
+      bianca la parte chiara e nera la parte scura, e quello che c'è scritto nella
+      parte scura sparisce insieme a lei. Il problema non è mai stato che il
+      contrasto fosse troppo basso. È che la carta non ha la stessa luminosità in
+      un angolo e nell'altro, quindi non esiste una regolazione unica che vada
+      bene per tutta la pagina.
+    </p>
+    <p>
+      Quello che funziona è stimare quanto è luminosa la carta <em>in ogni
+      punto</em> e dividere per quella. La carta è la maggioranza chiara di
+      qualsiasi piccola porzione di una pagina, quindi misurare la luminosità su
+      una griglia di piccoli riquadri e prendere in ognuno un valore alto dà la
+      forma della luce &mdash; il testo è troppo scuro e troppo rado per
+      spostarla. Dividi per quella e quello che resta è l'inchiostro, illuminato
+      in modo uniforme, senza più l'ombra e con la carta tornata bianca.
+    </p>
+    <p>
+      È quello che fanno &laquo;colore, uniformato&raquo; e &laquo;scala di
+      grigi&raquo;. Scegli il colore quando il colore fa parte del documento: un
+      timbro, una firma a inchiostro blu, una riga evidenziata, qualsiasi cosa su
+      cui qualcuno potrebbe poi chiedere se fosse originale.
+    </p>
+  </section>
+
+  <section>
+    <h2>Il bianco e nero, e perché il file diventa improvvisamente piccolo</h2>
+    <p>
+      Una pagina salvata come fotografia sono milioni di pixel con sedici milioni
+      di colori possibili ciascuno, e il codec spende le sue energie su gradienti
+      sottili che una pagina di testo non ha. Una pagina salvata in bianco e nero
+      è un bit per pixel &mdash; inchiostro o carta &mdash; e si comprime come la
+      cosa straordinariamente ripetitiva che è.
+    </p>
+    <p>
+      La differenza non è piccola: sulle stesse pagine è qualcosa come diciotto
+      volte. Un contratto di venti pagine che come fotografie arriva a quindici
+      megabyte, come pagine a un bit sta sotto il megabyte &mdash; che è la
+      differenza tra un documento che si può mandare per email e uno che no, ed è
+      il motivo per cui ogni scanner da ufficio ce l'ha come impostazione
+      predefinita.
+    </p>
+    <p>
+      Il rovescio della medaglia è che non ci sono mezzitoni: una fotografia sulla
+      pagina diventa un pasticcio di puntini. Usalo per le pagine stampate e
+      scritte, che è quello che sono la maggior parte dei documenti, e usa la
+      scala di grigi per qualsiasi cosa abbia sopra un'immagine.
+    </p>
+    <p>
+      Un dettaglio che vale la pena sapere, perché spiega perché uno strumento
+      buono riesce dove uno cattivo produce una pagina con un angolo nero: la
+      decisione tra inchiostro e carta va presa <em>localmente</em>. Una soglia
+      unica per tutta la pagina non può funzionare quando la carta nell'ombra è
+      più scura dell'inchiostro nella luce &mdash; e su una pagina fotografata
+      molto spesso lo è. Decidere ogni pixel contro la media del suo piccolo
+      vicinato è quello che tiene leggibile la scrittura dentro un'ombra.
+    </p>
+  </section>
+
+  <section>
+    <h2>Più pagine, un documento solo</h2>
+    <p>
+      Fotografa le pagine in ordine, aggiungile tutte insieme, e diventano le
+      pagine di un solo PDF nell'ordine in cui sono state aggiunte. Due cose a cui
+      stare attenti:
+    </p>
+    <ul>
+      <li>
+        <strong>I nomi dei file non si ordinano come pensi.</strong>
+        <code>pagina2.jpg</code> viene dopo <code>pagina10.jpg</code> in un
+        ordinamento alfabetico, perché il confronto è carattere per carattere.
+        Controlla l'ordine nella striscia prima di salvare, e non nel PDF dopo.
+      </li>
+      <li>
+        <strong>La ripulitura è un'impostazione unica per tutto il
+        documento</strong>, ed è voluto. Pagine ripulite in modo diverso sembrano
+        due documenti pinzati insieme, che è esattamente l'impressione che una
+        scansione dovrebbe evitare. Scegli la modalità che va bene per la pagina
+        peggiore.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Prima di mandarlo</h2>
+    <ul>
+      <li>
+        <strong>Apri il PDF.</strong> Non l'anteprima &mdash; il file. Ogni
+        pagina, per il verso giusto, senza niente tagliato a un bordo.
+      </li>
+      <li>
+        <strong>Leggi la cosa più piccola che c'è sulla pagina.</strong> Un numero
+        di riferimento, una data, un numero di conto. Se non riesci a leggerla
+        sullo schermo al 100%, non ci riesce nemmeno la persona a cui la stai
+        mandando.
+      </li>
+      <li>
+        <strong>Controlla che gli angoli non siano stati tagliati.</strong> Quello
+        che sta sul bordo di un modulo è un numero di pagina, una riga per la
+        firma, o la casella che qualcuno poi dirà che mancava.
+      </li>
+      <li>
+        <strong>Controlla che cosa dice il documento su di te.</strong> Un PDF ha
+        campi per l'autore, il produttore e la data di creazione, e quasi tutti
+        gli strumenti li riempiono. Se questo conti o no dipende da chi lo riceve,
+        ma vale la pena sapere che c'è.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Perché niente di tutto questo ha bisogno di un caricamento</h2>
+    <p>
+      Ogni passaggio qui sopra è aritmetica su un'immagine che la tua macchina ha
+      già decodificato: quattro angoli, una trasformazione, una divisione, una
+      soglia, e un contenitore scritto un byte alla volta. Non c'è dentro niente
+      che un server possa fare e un browser no, e niente che abbia bisogno di
+      scaricare un modello per farlo.
+    </p>
+    <p>
+      Il che vale la pena di soppesare, per via di che cosa sono questi file. La
+      gente non fotografa pagine a caso. Fotografa un passaporto, una busta paga,
+      un contratto d'affitto, un modulo medico, un contratto &mdash; documenti con
+      sopra un nome, un indirizzo e un numero di conto, scansionati proprio perché
+      un ente li ha chiesti. Caricarne uno su un sito per farne raddrizzare gli
+      angoli consegna a uno sconosciuto il documento intero. Vedi
+      <a href="../e-sicuro-caricare-i-propri-file/">come capire se uno strumento
+      ha davvero bisogno dei tuoi file</a> per i quattro controlli che separano gli
+      strumenti che devono vedere il tuo file da quelli che semplicemente lo
+      fanno.
+    </p>
+  </section>

--- a/locales/it/pages/guides/scan-a-document-with-your-phone.toml
+++ b/locales/it/pages/guides/scan-a-document-with-your-phone.toml
@@ -1,0 +1,21 @@
+#
+# Guida: scansionare un documento col telefono - Italian.
+#
+
+nav = "Scansionare col telefono"
+title = "Come scansionare un documento col telefono (senza app, senza caricarlo)"
+description = "Che cosa separa la fotografia di una pagina dalla scansione di quella pagina: l'inclinazione, la luce irregolare e la dimensione del file. Come scattare la foto, che cosa sistemare dopo, e perché niente di tutto questo ha bisogno di un server."
+
+heading = "Come scansionare un documento col telefono"
+lede = """
+    Qualcuno ti ha chiesto di &laquo;scansionare e rispedire&raquo; un modulo, e
+    tu hai un telefono e non hai uno scanner. La distanza tra la fotografia di una
+    pagina e la scansione di quella pagina è più piccola di quanto sembri, e non
+    riguarda soprattutto l'inclinazione &mdash; ecco che cosa le separa davvero, e
+    che cosa fare per ogni pezzo."""
+
+updated = "25 agosto 2026"
+
+og_title = "Come scansionare un documento col telefono"
+og_description = "L'inclinazione, l'ombra e la dimensione del file: che cosa separa la foto di una pagina dalla scansione di quella pagina, e come sistemare ogni cosa senza caricare la pagina."
+og_image_alt = "abox.tools - strumenti che non toccano mai un server"

--- a/locales/it/pages/guides/stack-photos-to-reduce-noise.html
+++ b/locales/it/pages/guides/stack-photos-to-reduce-noise.html
@@ -1,0 +1,307 @@
+  <section>
+    <h2>La risposta breve</h2>
+    <p>
+      Apri l'<a href="../../impilare-immagini/">Impilatore di immagini</a>,
+      trascinaci dentro tutta la raffica, e scegli il metodo in base a quello di
+      cui stai cercando di liberarti:
+    </p>
+    <ul>
+      <li><strong>Rumore</strong>, e non si è mosso niente &mdash; media.</li>
+      <li><strong>Rumore</strong>, e qualcosa si è mosso &mdash; sigma clipping.</li>
+      <li><strong>Persone, macchine, un aereo</strong> &mdash; mediana.</li>
+      <li><strong>Un cielo scuro che vuoi come scie stellari</strong> &mdash; schiarisci.</li>
+      <li><strong>Una macro con quasi nessuna profondità di campo</strong> &mdash; focus stacking.</li>
+    </ul>
+    <p>
+      Lascia acceso l'allineamento se la fotocamera era nelle tue mani e spegnilo
+      se stava su un treppiede. I file RAW possono entrare direttamente; non c'è
+      bisogno di svilupparli prima.
+    </p>
+    <p>
+      Tutto quello che segue spiega perché quelle cinque righe sono così.
+    </p>
+  </section>
+
+  <section>
+    <h2>Perché una raffica contiene più di un fotogramma solo</h2>
+    <p>
+      Una fotografia scattata con poca luce è l'immagine più il rumore, e il
+      rumore è diverso ogni volta. È quest'ultima parte che fa funzionare
+      l'impilamento. Scatta la stessa inquadratura sedici volte e l'immagine è
+      identica in tutte e sedici mentre il rumore no, quindi farne la media lascia
+      l'immagine e annulla quasi tutto il rumore.
+    </p>
+    <p>
+      Il miglioramento è la radice quadrata del numero di fotogrammi. Quattro
+      fotogrammi dimezzano il rumore. Sedici lo riducono a un quarto. Cento lo
+      tagliano di dieci volte. È una curva brutale su cui stare &mdash; passare da
+      sedici a sessantaquattro fotogrammi ti compra di nuovo lo stesso
+      miglioramento, per quattro volte gli scatti &mdash; ed è per questo che
+      quasi ogni pila pratica sta tra gli otto e i trenta fotogrammi.
+    </p>
+    <p>
+      C'è un secondo guadagno, più silenzioso. Fare la media di sedici fotogrammi
+      a otto bit dà un risultato con gradazioni più fini di quelle che aveva
+      ognuno di loro, perché è proprio il rumore che faceva arrotondare ogni
+      fotogramma in modo diverso a permettere alla media di cadere tra un livello
+      e l'altro. Impilare una serie rumorosa non toglie soltanto il rumore:
+      recupera del tono che un singolo fotogramma aveva quantizzato via.
+    </p>
+  </section>
+
+  <section>
+    <h2>La domanda che sceglie il metodo</h2>
+    <p>
+      Non &laquo;che cosa voglio tenere&raquo; ma <strong>che cosa era diverso
+      da un fotogramma all'altro</strong>. Tutto il resto viene di conseguenza.
+    </p>
+
+    <h3>Non si è mosso niente: media</h3>
+    <p>
+      La media semplice. È la riduzione del rumore più efficace disponibile su una
+      serie in cui l'unica differenza tra i fotogrammi è il rumore, ed è la più
+      facile da rovinare: un fotogramma con dentro un uccello mette un uccello
+      sbiadito su tutta la pila, perché una media non ha nessuna opinione su un
+      valore che non va d'accordo con gli altri. Lo include e basta.
+    </p>
+
+    <h3>Qualcosa ha attraversato l'inquadratura: mediana</h3>
+    <p>
+      Allinea una dozzina di fotografie di una piazza affollata e guarda un pixel.
+      Nella maggior parte è pavimentazione; in una o due è il cappotto di
+      qualcuno. Ordina quei dodici valori, prendi quello centrale e ottieni
+      pavimentazione, perché il cappotto non è mai stato in maggioranza.
+    </p>
+    <p>
+      Fallo per ogni pixel e la piazza viene fuori vuota. È il trucco dietro ogni
+      articolo del tipo &laquo;togli i turisti dalla tua foto delle vacanze&raquo;,
+      e non ha bisogno di niente di più ingegnoso di una raffica e di pazienza.
+      L'unica cosa che pretende è che <strong>nessuna parte della scena sia
+      occupata per più di metà del tempo</strong>. Una persona ferma in otto dei
+      tuoi dodici fotogrammi è la maggioranza su quei pixel, e la mediana se la
+      tiene.
+    </p>
+
+    <h3>Tutte e due le cose: sigma clipping</h3>
+    <p>
+      La mediana butta via quasi tutta l'informazione per ottenere la sua
+      robustezza &mdash; undici dei tuoi dodici valori vengono scartati a ogni
+      pixel, quindi riduce il rumore molto meno di quanto farebbe una media della
+      stessa serie.
+    </p>
+    <p>
+      Il sigma clipping è il compromesso, ed è di solito la scelta predefinita
+      giusta per qualsiasi serie del mondo reale. Guarda ogni pixel attraverso
+      tutti i fotogrammi, ricava che cosa di solito è e quanto varia, e poi fa la
+      media solo dei valori che vanno d'accordo con quello. Una macchina che ha
+      attraversato un fotogramma viene esclusa da quei pixel; ogni altro fotogramma
+      continua a contare dappertutto. Ottieni l'immunità della mediana alle cose
+      che si sono mosse e quasi tutta la riduzione del rumore della media.
+    </p>
+    <p>
+      La soglia è in deviazioni standard, e due è il punto di partenza solito. Più
+      bassa rifiuta di più, e comincia a rifiutare dettaglio vero insieme alla
+      macchina.
+    </p>
+
+    <h3>Contano solo le cose luminose: schiarisci</h3>
+    <p>
+      Tieni il valore più chiaro che ogni pixel abbia mai avuto. Fotografa il
+      cielo notturno come duecento esposizioni da trenta secondi e schiariscile
+      insieme, e ogni stella disegna il suo arco sul risultato &mdash; una scia
+      stellare, montata a partire da esposizioni brevi che singolarmente non hanno
+      mai bruciato. Lo stesso metodo rimette insieme un fuoco d'artificio dai
+      fotogrammi della sua stessa esplosione, e un light painting da un giro per
+      una stanza buia con una torcia.
+    </p>
+    <p>
+      Il suo contrario, scurisci, è quello silenzioso della coppia: un pixel resta
+      chiaro solo se era chiaro in <em>ogni</em> fotogramma, quindi i riflessi in
+      una finestra, i fari di passaggio e le gocce di pioggia illuminate da un
+      flash spariscono tutti.
+    </p>
+
+    <h3>Il soggetto è più profondo della messa a fuoco: focus stacking</h3>
+    <p>
+      Una macro a f/8 ha forse un millimetro a fuoco, che per un insetto non
+      basta. La risposta è scattare venti fotogrammi lungo la ghiera di messa a
+      fuoco e tenere, di ognuno, solo la parte che in quel fotogramma era nitida.
+      Lo strumento misura quanto ogni pixel differisce dai suoi vicini &mdash;
+      molto su un bordo, quasi zero su una sfocatura &mdash; e prende il
+      vincitore.
+    </p>
+    <p>
+      Questo metodo vuole un treppiede più di tutti gli altri, perché spostare la
+      ghiera di messa a fuoco a mano sposta la fotocamera, e un fotogramma scattato
+      da un pochino più lontano non è la stessa immagine a una messa a fuoco
+      diversa.
+    </p>
+  </section>
+
+  <section>
+    <h2>Allineare i fotogrammi</h2>
+    <p>
+      Impilare è aritmetica pixel per pixel, quindi dà per scontato che un certo
+      pixel sia la stessa parte della scena in ogni fotogramma. A mano libera non
+      lo è: una raffica deriva di decine di pixel, e farne la media produce una
+      sfocatura invece di un'immagine pulita. È il singolo motivo più comune per
+      cui un primo tentativo di impilamento delude.
+    </p>
+    <p>
+      Quindi i fotogrammi vengono prima misurati rispetto a uno di loro e rimessi
+      al loro posto, con la precisione di una frazione di pixel. Tre impostazioni:
+    </p>
+    <ul>
+      <li>
+        <strong>Solo traslazione</strong> va bene per quasi tutto quello che è
+        fatto a mano libera. Corregge la deriva e il tremolio.
+      </li>
+      <li>
+        <strong>Traslazione, rotazione e scala</strong> per una serie in cui
+        stavi anche ruotando leggermente, o in cui uno zoom è strisciato. Costa una
+        misurazione in più per fotogramma e non costa proprio niente quando i
+        fotogrammi risultano dritti.
+      </li>
+      <li>
+        <strong>Nessuno</strong> per un treppiede bloccato o una sequenza da
+        intervallometro, dove i fotogrammi sono già allineati e misurarli è tempo
+        sprecato.
+      </li>
+    </ul>
+    <p>
+      Quello che nessun allineamento può sistemare è un soggetto che si è mosso
+      invece di una fotocamera che si è mossa, e non può sistemare nemmeno una
+      fotografia scattata un passo più a sinistra. Spostarsi di lato cambia di
+      quanto le cose vicine si spostano rispetto a quelle lontane, e nessuna
+      correzione unica descrive tutte e due insieme. Ruotare sul posto va bene;
+      camminare no.
+    </p>
+  </section>
+
+  <section>
+    <h2>Dove si inseriscono i file RAW</h2>
+    <p>
+      Puoi trascinare dentro direttamente CR2, CR3, NEF, ARW, DNG, RAF, RW2, ORF e
+      gli altri, e vale la pena essere precisi su che cosa succede loro, perché non
+      è quello che fa un convertitore RAW.
+    </p>
+    <p>
+      Ogni file RAW contiene già un <strong>JPEG a piena risoluzione che la
+      fotocamera ha prodotto nel momento dello scatto</strong>. È quello che ti
+      mostra il retro della fotocamera ed è quello che il tuo sistema operativo
+      disegna come miniatura. L'impilatore trova quell'immagine e usa quella. Non
+      decodifica i dati del sensore.
+    </p>
+    <p>
+      Due conseguenze, una buona e una che vale la pena sapere:
+    </p>
+    <ul>
+      <li>
+        <strong>È veloce.</strong> Trovare l'anteprima vuol dire leggere qualche
+        kilobyte di directory e poi una fetta, quindi un fotogramma da 60&nbsp;MB
+        si apre più o meno alla velocità di un JPEG. Venti si aprono nel tempo che
+        un convertitore RAW spenderebbe su uno. La pagina ti mostra quanto poco dei
+        tuoi file ha davvero letto.
+      </li>
+      <li>
+        <strong>È la resa della fotocamera, non la tua.</strong> Otto bit per
+        canale, con il bilanciamento del bianco e lo stile immagine su cui la
+        fotocamera era impostata &mdash; non i dodici o quattordici bit di dati
+        lineari del sensore che ti darebbe un convertitore.
+      </li>
+    </ul>
+    <p>
+      Per la riduzione del rumore, le scie stellari, il togliere i passanti e il
+      focus stacking, quel baratto conviene quasi sempre: le anteprime sono a piena
+      risoluzione e sono quello che avresti ottenuto comunque come JPEG. Se stai
+      tirando su le ombre con forza, o stai impilando per astrofotografia dove
+      l'ultimo pezzo di gamma dinamica è tutto il punto, sviluppa prima i
+      fotogrammi in un convertitore RAW e impila i TIFF o i JPEG che ti dà. Quelli
+      entrano allo stesso modo.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quanto costa farlo girare</h2>
+    <p>
+      Vale la pena saperlo perché è la differenza tra una pila che prende otto
+      secondi e una che ne prende due minuti.
+    </p>
+    <p>
+      Sei metodi su sette hanno bisogno di ricordare una cosa sola. Un massimo
+      corrente non si cura dei fotogrammi che ha già visto, e nemmeno un totale
+      corrente, quindi quei metodi leggono ogni fotogramma esattamente una volta e
+      usano la stessa memoria per cento fotogrammi che per due.
+    </p>
+    <p>
+      La mediana non può lavorare così, perché non puoi sapere il valore centrale
+      di un insieme finché non lo hai tutto. Venti fotogrammi da 24 megapixel sono
+      circa 1,4&nbsp;GB di pixel tenuti insieme, che nessun browser ti concede,
+      quindi l'immagine viene tagliata in bande orizzontali e impilata una banda
+      per volta &mdash; corretto, e più lento, perché i fotogrammi vengono riletti
+      per ogni banda.
+    </p>
+    <p>
+      Lo strumento calcola tutto questo prima che tu prema il pulsante e te lo
+      dice: quanto sarà grande il risultato, più o meno quanta memoria serve, e
+      quante volte i tuoi fotogrammi verranno decodificati. Se dice che
+      l'esecuzione sarà a bande, abbassare di un passo la risoluzione di lavoro
+      divide per quattro la memoria e quasi sempre la riporta a un passaggio unico
+      &mdash; e se stai impilando per togliere il rumore, la mezza risoluzione
+      sarebbe comunque venuta più pulita della piena.
+    </p>
+  </section>
+
+  <section>
+    <h2>Scattare pensando all'impilamento</h2>
+    <p>
+      Quasi tutta la qualità di una pila viene decisa prima che qualsiasi software
+      la veda.
+    </p>
+    <ul>
+      <li>
+        <strong>Scatta più fotogrammi di quanti pensi ti servano.</strong> La
+        curva della radice quadrata è spietata all'inizio e clemente alla fine:
+        passare da quattro a nove fotogrammi è un cambiamento visibile più grande
+        che passare da venti a quaranta.
+      </li>
+      <li>
+        <strong>Non cambiare l'esposizione tra un fotogramma e l'altro.</strong>
+        L'impilamento dà per scontato che i fotogrammi siano della stessa scena
+        alla stessa luminosità. Blocca l'esposizione, o lo strumento starà facendo
+        la media di due immagini diverse.
+      </li>
+      <li>
+        <strong>Per togliere le persone, aspetta tra un fotogramma e
+        l'altro.</strong> Una raffica scattata in due secondi becca la stessa
+        persona nello stesso posto in ogni fotogramma, e la mediana se la tiene.
+        Dieci fotogrammi a qualche secondo di distanza funzionano molto meglio di
+        cinquanta in raffica.
+      </li>
+      <li>
+        <strong>Per le scie stellari, tieni corte le pause.</strong> Schiarisci
+        disegna esattamente quello che i fotogrammi hanno registrato, quindi una
+        pausa tra un'esposizione e l'altra diventa un trattino visibile in ogni
+        scia.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Niente di tutto questo esce dalla tua macchina</h2>
+    <p>
+      Una pila di venti fotogrammi RAW è circa un gigabyte di fotografie, che sono
+      parecchie da consegnare a un sito web per farne fare la media.
+      L'<a href="../../impilare-immagini/">Impilatore di immagini</a> legge i file
+      dal tuo disco e fa l'aritmetica nel tuo browser. Non c'è un passaggio di
+      caricamento, non c'è un account e non c'è una coda, e puoi verificare questa
+      affermazione come verificheresti quella di chiunque: apri il pannello di rete
+      del tuo browser mentre gira, oppure semplicemente stacca la rete e impilali
+      lo stesso.
+    </p>
+    <p>
+      La domanda collegata &mdash; come capire, per uno strumento qualsiasi, se
+      consegnargli un file fosse necessario &mdash; ha
+      <a href="../e-sicuro-caricare-i-propri-file/">una guida tutta sua</a>.
+    </p>
+  </section>

--- a/locales/it/pages/guides/stack-photos-to-reduce-noise.toml
+++ b/locales/it/pages/guides/stack-photos-to-reduce-noise.toml
@@ -1,0 +1,20 @@
+#
+# Guida: impilare fotografie contro il rumore - Italian.
+#
+
+nav = "Impilare fotografie"
+title = "Come impilare fotografie per ridurre il rumore, o togliere le persone"
+description = "Impilare unisce una raffica di fotogrammi in un'immagine sola. Quale metodo usare dipende da che cosa stai cercando di perdere: il rumore, i passanti, o la poca profondità di campo di una macro. Come funziona ognuno, quanto costa, e dove si inseriscono i file RAW."
+
+heading = "Come impilare fotografie per ridurre il rumore, o togliere le persone"
+lede = """
+    Una raffica di fotogrammi contiene più informazione di qualsiasi singolo
+    fotogramma. Farne la media annulla il rumore; prendere il valore centrale di
+    ogni pixel cancella tutto quello che c'era solo una parte del tempo. Quale dei
+    due ti serve dipende interamente da che cosa si è mosso."""
+
+updated = "25 agosto 2026"
+
+og_title = "Come impilare fotografie per ridurre il rumore, o togliere le persone"
+og_description = "Fai la media di una raffica per uccidere il rumore, prendi la mediana per svuotare una piazza affollata, schiarisci per le scie stellari. Quale metodo risolve quale problema, e dove si inseriscono i file RAW."
+og_image_alt = "abox.tools - strumenti che non toccano mai un server"

--- a/locales/it/tools/dicom-viewer.html
+++ b/locales/it/tools/dicom-viewer.html
@@ -1,0 +1,267 @@
+<!--
+  tools/dicom-viewer/body.html, in Italian.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+
+  L'intestazione di colonna "VR" resta com'è: è il codice di due lettere che sta
+  scritto così nel file, e chi cerca un tag nello standard cerca esattamente
+  quelle due lettere.
+-->
+<main>
+  <!--
+    One numbered step, and then the viewer.
+
+    Every other tool on this site numbers its cards because every card is
+    something the visitor does. Here there is one thing to do - choose the
+    files - and everything below it is the scan. Numbering the picture would
+    promise a sequence of decisions that does not exist.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli la scansione</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p class="picker-note">
+      Trascina dentro un'intera cartella in una volta sola, e i file vengono
+      riassegnati alle loro serie e rimessi nell'ordine giusto. Non viene caricato
+      niente, e nei tuoi file non viene riscritto niente.
+    </p>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- Il visualizzatore. -->
+  <section class="card" id="viewer-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="save-frame" class="ghost" data-download>Salva questo fotogramma come PNG</button>
+        <button type="button" id="copy-header" class="ghost">Copia l'header</button>
+        <button type="button" id="download-header" class="ghost">Scarica</button>
+      </div>
+    </div>
+
+    <div class="series-row" id="series-row" hidden>
+      <label for="series-pick" class="inline-label">Serie</label>
+      <select id="series-pick"></select>
+      <span class="count" id="series-note"></span>
+    </div>
+
+    <!--
+      The canvas is sized in CSS and its backing store is set to the frame's own
+      pixels, so a 512-pixel slice is drawn at 512 pixels and scaled by the
+      browser rather than resampled here. That is what makes the zoom honest:
+      what is on screen at 400% is the stored pixels made bigger, not a guess at
+      what was between them.
+    -->
+    <div class="viewport" id="viewport">
+      <canvas id="canvas" width="1" height="1" role="img"
+              aria-label="L'immagine sullo schermo, disegnata dal file che hai scelto"></canvas>
+      <div class="overlay overlay-tl" id="overlay-tl" hidden></div>
+      <div class="overlay overlay-tr" id="overlay-tr"></div>
+      <div class="overlay overlay-bl" id="overlay-bl"></div>
+      <div class="overlay overlay-br" id="overlay-br"></div>
+      <svg class="marks" id="marks" aria-hidden="true"></svg>
+      <p class="viewport-fail" id="viewport-fail" hidden></p>
+    </div>
+
+    <div class="scrub" id="scrub-row" hidden>
+      <button type="button" id="play" class="ghost" aria-label="Riproduci i fotogrammi">▶</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" step="1"
+             aria-label="Quale slice o quale fotogramma viene mostrato">
+      <span class="count" id="scrub-label">&mdash;</span>
+    </div>
+
+    <div class="tools">
+      <fieldset class="modes">
+        <legend class="visually-hidden">Che cosa fa il trascinamento sull'immagine</legend>
+        <label><input type="radio" name="mode" value="window" checked> Finestra e livello</label>
+        <label><input type="radio" name="mode" value="pan"> Sposta</label>
+        <label><input type="radio" name="mode" value="measure"> Misura</label>
+      </fieldset>
+
+      <div class="zoom">
+        <label for="zoom" class="inline-label">Zoom</label>
+        <input type="range" id="zoom" min="5" max="800" step="5" value="100">
+        <span class="count" id="zoom-label">100%</span>
+        <button type="button" id="reset-view" class="ghost">Adatta</button>
+      </div>
+    </div>
+
+    <div class="levels" id="levels">
+      <div class="level-field">
+        <label for="preset" class="inline-label">Finestra</label>
+        <select id="preset"></select>
+      </div>
+      <div class="level-field">
+        <label for="center" class="inline-label">Centro</label>
+        <input type="number" id="center" step="1">
+      </div>
+      <div class="level-field">
+        <label for="width" class="inline-label">Ampiezza</label>
+        <input type="number" id="width" step="1" min="1">
+      </div>
+      <label class="level-check"><input type="checkbox" id="invert"> Inverti</label>
+      <label class="level-check"><input type="checkbox" id="show-details"> Sovrapponi i dati del paziente all'immagine</label>
+    </div>
+
+    <p class="hint" id="mode-hint"></p>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- Che cos'è questo file. -->
+  <section class="card" id="facts-card" hidden>
+    <h2>Che cos'è questo file</h2>
+    <dl class="facts">
+      <div><dt>Oggetto</dt><dd id="fact-sop">&mdash;</dd></div>
+      <div><dt>Modalità</dt><dd id="fact-modality">&mdash;</dd></div>
+      <div><dt>Immagine</dt><dd id="fact-size">&mdash;</dd></div>
+      <div><dt>Memorizzato come</dt><dd id="fact-stored">&mdash;</dd></div>
+      <div><dt>Transfer syntax</dt><dd id="fact-syntax">&mdash;</dd></div>
+      <div><dt>Spaziatura dei pixel</dt><dd id="fact-spacing">&mdash;</dd></div>
+      <div><dt>Intervallo dei valori</dt><dd id="fact-range">&mdash;</dd></div>
+      <div><dt>File</dt><dd id="fact-file">&mdash;</dd></div>
+    </dl>
+
+    <ul class="notes" id="notes" hidden></ul>
+  </section>
+
+  <!-- Che cosa c'è scritto sulla persona. -->
+  <section class="card" id="identity-card" hidden>
+    <h2>Che cosa in questo file identifica il paziente</h2>
+    <p class="card-lede">
+      Letto da questo file, su questo dispositivo, e mostrato a nessun altro.
+      Questo strumento non scrive niente: non può togliere niente di tutto ciò, e
+      non ne ha mandato niente da nessuna parte. Sta qui perché una scansione porta
+      con sé molto più di un nome, e perché il resto è esattamente quello che
+      sopravvive a un'anonimizzazione fatta con sufficienza.
+    </p>
+    <ul class="identity" id="identity"></ul>
+    <p class="identity-extra" id="identity-extra"></p>
+  </section>
+
+  <!-- Ogni tag del file. -->
+  <section class="card" id="tags-card" hidden>
+    <div class="toolbar">
+      <h2>Ogni tag del file</h2>
+      <div class="toolbar-actions">
+        <label for="tag-search" class="visually-hidden">Cerca tra i tag</label>
+        <input type="search" id="tag-search" class="tag-search" placeholder="Cerca per nome, numero o valore">
+      </div>
+    </div>
+
+    <p class="card-lede" id="tags-lede"></p>
+
+    <div class="table-wrap">
+      <table class="tags">
+        <caption class="visually-hidden">Ogni elemento di questo file</caption>
+        <thead>
+          <tr>
+            <th scope="col">Tag</th>
+            <th scope="col">VR</th>
+            <th scope="col">Nome</th>
+            <th scope="col">Valore</th>
+          </tr>
+        </thead>
+        <tbody id="tag-rows"></tbody>
+      </table>
+    </div>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!--
+    The tool's own sentences, kept out of the JavaScript so that a translator
+    can reach them. shared/js/phrases.js reads them back, and a key defined here
+    wins over the frame's one.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="mode.window">Trascina di traverso sull'immagine per allargare o stringere la finestra, e in alto o in basso per spostarne il centro. Tutti e due i numeri stanno lì sotto, e digitarli fa la stessa cosa.</span>
+    <span data-phrase="mode.pan">Trascina per spostare l'immagine dentro la sua cornice. La rotella zooma, e &laquo;Adatta&raquo; rimette tutto a posto.</span>
+    <span data-phrase="mode.measure">Traccia una linea sull'immagine per misurare. Dove il file dice quanto sono distanti i suoi pixel, il risultato è in millimetri; dove non lo dice, è in pixel e lo dichiara.</span>
+
+    <span data-phrase="probe.value">{value} alla colonna {column}, riga {row}</span>
+    <span data-phrase="measure.pixels">{length} px &mdash; questo file non dice quanto sono distanti i suoi pixel, quindi la misura non può essere in millimetri</span>
+
+    <span data-phrase="stack.position">Impilate in base a dove ogni slice si trova nel corpo, ed è l'ordine in cui l'apparecchio le ha prese.</span>
+    <span data-phrase="stack.number">Impilate per Instance Number: questi file non portano una posizione nel corpo su cui ordinarli.</span>
+    <span data-phrase="stack.gap">La distanza tra una slice e l'altra non è sempre la stessa, quindi in questa serie ne manca almeno una.</span>
+
+    <span data-phrase="pixels.none">I pixel di questo file sono compressi con {codec}. Nessun browser sa decodificarlo, e questa pagina non si porta dietro un decoder apposta. Tutto il resto del file sta qui sotto.</span>
+    <span data-phrase="pixels.failed">Non è stato possibile decodificare l'immagine: {reason}. L'header qui sotto è stato letto per intero.</span>
+    <span data-phrase="pixels.absent">Questo file non porta proprio nessun dato di pixel. È un header, e tutto quello che contiene sta qui sotto.</span>
+    <span data-phrase="pixels.jpeg">Questi pixel sono JPEG baseline, quindi li ha aperti il decoder del browser, e quello che restituisce è profondo otto bit. La finestra continua a funzionare; la precisione che l'apparecchio ha registrato non c'è tutta.</span>
+
+    <span data-phrase="tags.count">{shown} elementi su {total}. Altri {hidden}.</span>
+    <span data-phrase="tags.all">Tutti i {total} elementi di questo file.</span>
+    <span data-phrase="tags.found">{total} elementi corrispondono a &laquo;{query}&raquo;.</span>
+    <span data-phrase="tags.found.one">Un elemento corrisponde a &laquo;{query}&raquo;.</span>
+    <span data-phrase="tags.none">Niente corrisponde a &laquo;{query}&raquo;.</span>
+    <span data-phrase="tags.more">Mostra gli altri {count}</span>
+    <span data-phrase="tags.private">elemento privato</span>
+    <span data-phrase="tags.unknown">non in questo dizionario</span>
+    <span data-phrase="tags.guessed">Il file non lo ha detto; è quello che il dizionario dei dati indica per questo tag.</span>
+
+    <span data-phrase="working.one">Lettura di {name}&hellip;</span>
+    <span data-phrase="working.many">Lettura di {at} su {total}&hellip;</span>
+    <span data-phrase="error.none">Non è stato possibile leggere niente di tutto questo come DICOM. {why} Questo strumento legge il formato DICOM in sé, quindi sugli altri file non ha niente da dire.</span>
+    <span data-phrase="error.skipped.one">Un file è stato saltato: {files}</span>
+    <span data-phrase="error.skipped">{count} file sono stati saltati: {files}</span>
+
+    <span data-phrase="series.number">Serie {number}</span>
+    <span data-phrase="series.files.one">1 file</span>
+    <span data-phrase="series.files">{count} file</span>
+    <span data-phrase="stack.spacing">Le slice distano {gap} l'una dall'altra.</span>
+
+    <span data-phrase="at.position">{at} di {total}</span>
+    <span data-phrase="net.clean">La tua scansione non è andata da nessuna parte. {total} file
+      caricati, tutti quanti di questo sito. {platform}</span>
+    <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo strumento non
+      lo fa mai. Vale la pena andare a vedere. {platform}</span>
+    <span data-phrase="net.platform.one">Gli script del sito per la pubblicità, la
+      misurazione e il pulsante delle donazioni sono arrivati da {hosts} host; a
+      nessuno di questi è arrivata una scansione, un suo pixel o una parola del suo
+      header.</span>
+    <span data-phrase="net.platform.many">Gli script del sito per la pubblicità, la
+      misurazione e il pulsante delle donazioni sono arrivati da {hosts} host; a
+      nessuno di questi è arrivata una scansione, un suo pixel o una parola del suo
+      header.</span>
+    <span data-phrase="at.frame">Fotogramma {at} di {total}</span>
+    <span data-phrase="at.instance">Istanza {number}</span>
+
+    <span data-phrase="window.file">Dal file</span>
+    <span data-phrase="window.file.n">Dal file, {n}</span>
+    <span data-phrase="window.full">Tutto quello che c'è in questo fotogramma</span>
+    <span data-phrase="window.custom">Impostata a mano</span>
+    <span data-phrase="window.soft">Tessuti molli</span>
+    <span data-phrase="window.lung">Polmone</span>
+    <span data-phrase="window.bone">Osso</span>
+    <span data-phrase="window.brain">Cervello</span>
+    <span data-phrase="window.liver">Fegato</span>
+    <span data-phrase="window.mediastinum">Mediastino</span>
+    <span data-phrase="window.angio">Angiografia</span>
+
+    <span data-phrase="facts.frames">{count} fotogrammi</span>
+    <span data-phrase="facts.nopixels">nessun dato di pixel</span>
+    <span data-phrase="facts.nospacing">non indicata in questo file</span>
+    <span data-phrase="facts.signed">con segno</span>
+    <span data-phrase="facts.unsigned">senza segno</span>
+    <span data-phrase="facts.stored.one">{bits} bit, {sign}, 1 canale per pixel, {photometric}</span>
+    <span data-phrase="facts.stored">{bits} bit, {sign}, {samples} canali per pixel, {photometric}</span>
+    <span data-phrase="facts.range">da {low} a {high}</span>
+    <span data-phrase="facts.colour">colore &mdash; niente di misurato da riferire</span>
+
+    <span data-phrase="identity.clean">Niente in questo file nomina o numera una persona. Gli identificatori che una scansione di solito porta con sé mancano o sono vuoti.</span>
+    <span data-phrase="identity.uids">Porta inoltre {count} identificatori propri, gli UID dello studio, della serie e dell'istanza. Nessuno di questi è un nome, e ognuno di essi è una chiave perfetta per rientrare nell'archivio da cui viene il file.</span>
+    <span data-phrase="identity.private">In più {count} elementi privati, il cui significato non è pubblicato da nessuna parte: certi apparecchi ne usano uno per tenere una seconda copia del nome del paziente.</span>
+
+    <span data-phrase="copied">Copiato.</span>
+    <span data-phrase="copy.failed">Il tuo browser ha negato alla pagina il permesso di copiare. Il pulsante qui accanto scrive lo stesso testo in un file.</span>
+    <span data-phrase="saved">{name} salvato.</span>
+  </div>
+</main>

--- a/locales/it/tools/dicom-viewer.toml
+++ b/locales/it/tools/dicom-viewer.toml
@@ -1,0 +1,398 @@
+#
+# DICOM Viewer - Italian.
+#
+# Overrides for tools/dicom-viewer/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# I nomi dei campi DICOM restano in inglese e si portano dietro il numero -
+# Pixel Spacing (0028,0030), Series Instance UID (0020,000E). Così stanno
+# scritti nel file e così stanno nello standard: chi cerca un campo cerca
+# esattamente quelle parole. Lo stesso vale per le transfer syntax e per
+# PS3.15.
+#
+# Qui la promessa del sito ha il filo più tagliente di tutte le pagine: il file
+# è una cartella clinica con dentro un'immagine. Le frasi su che cosa c'è
+# scritto dentro sono quindi tradotte con la stessa cura di quelle su dove non
+# va a finire.
+#
+
+name = "Visualizzatore DICOM"
+heading = "Visualizzatore&nbsp;DICOM <span class=\"h1-kw\">&mdash; apri una scansione .dcm nel browser</span>"
+tagline = "TC, RM, radiografie ed ecografie, con la finestra, l'header e le misure."
+
+title = "Visualizzatore DICOM &mdash; apri un file .dcm nel browser, senza caricarlo"
+description = "Apri scansioni TC, RM, radiografie ed ecografie nel browser. Finestra e livello, scorri un'intera serie, misura in millimetri, leggi ogni tag DICOM e vedi esattamente che cosa nel file identifica il paziente. Non viene caricato niente."
+og_title = "Visualizzatore DICOM &mdash; apri una scansione senza caricarla"
+og_description = "Un file .dcm aperto sulla tua macchina: finestra e livello, tutta la serie impilata nell'ordine giusto, misure in millimetri e ogni tag dell'header. Nessun caricamento, nessun account."
+og_image_alt = "Visualizzatore DICOM - apri una TC, una RM o una radiografia nel browser"
+
+pledge = """
+    La scansione viene aperta e decodificata dal tuo browser: l'header, i pixel, la
+    finestra, le misure. Dall'altra parte di questa pagina non c'è nessun server a
+    cui mandare dati sanitari, nemmeno se qualcosa qui dentro volesse farlo, e
+    niente di questo file &mdash; non il nome del paziente, non lo studio, non il
+    nome del file &mdash; viene riferito a qualcuno."""
+
+live_hint = """
+      Non fidarti sulla parola: apri gli strumenti di sviluppo, guarda la scheda
+      Rete e apri una scansione. Non una richiesta porta con sé un'immagine, un tag
+      o un nome di file. Oppure stacca la rete e aprine una lo stesso."""
+
+read_first = """
+, <code>src/dicom.js</code> per il parser che
+      percorre il file, <code>src/pixels.js</code> per la decodifica dei pixel,
+      <code>src/jpeg-lossless.js</code> per il codec con cui esporta la maggior
+      parte degli ospedali, e <code>src/window.js</code> per la finestra e il
+      livello &mdash; e in nessuno di questi c'è una riga che potrebbe raggiungere
+      la rete."""
+
+howto_heading = "Come aprire un file DICOM"
+
+card = """
+            Apri una TC, una RM, una radiografia o un'ecografia sulla tua
+            macchina. Regola finestra e livello, scorri tutta la serie, misura
+            in millimetri e leggi ogni tag dell'header."""
+
+[words]
+plural = "scansioni"
+choose = "una scansione"
+
+[[facts]]
+text = "Nessun caricamento"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Codice aperto"
+
+[[facts]]
+text = "I file restano sul tuo dispositivo"
+
+[[privacy]]
+title = "La tua scansione non ha nessun posto dove andare."
+body = """
+ La
+      Content-Security-Policy elenca ogni indirizzo che questa pagina può
+      contattare, e nemmeno uno appartiene a questo sito. Qui non c'è un endpoint
+      dove il tuo file possa essere raccolto, e non c'è niente nel codice che lo
+      manderebbe se ci fosse. Prima diceva <code>connect-src 'none'</code>, che era
+      assoluto; aggiungere la pubblicità è costato quello, e dirlo fa parte del
+      patto."""
+
+[[privacy]]
+title = "Qui questo pesa più che nelle altre pagine."
+body = """
+
+      Un file DICOM non è un'immagine con sopra dei metadati. È una cartella
+      clinica con dentro un'immagine: il nome del paziente, la data di nascita, il
+      numero di cartella, il numero di accettazione, il medico che ha richiesto
+      l'esame, la struttura e il numero di serie dell'apparecchio sono tutti campi
+      dell'header, e viaggiano con il file ovunque vada. Caricarne uno su un sito
+      per guardarlo vuol dire consegnare tutto questo a chi gestisce quel sito. È
+      precisamente la cosa che questa pagina esiste per non fare."""
+
+[[privacy]]
+title = "Il lettore sono quattordici file in questo repository."
+body = """
+ Niente qui dentro usa una
+      libreria scaricata da qualche parte. <code>src/dicom.js</code> percorre il
+      file, <code>src/dictionary.js</code> sa come si chiamano i tag,
+      <code>src/pixels.js</code> riporta i byte a essere misure,
+      <code>src/rle.js</code> e <code>src/jpeg-lossless.js</code> espandono le due
+      forme compresse che questa pagina sa decodificare, e
+      <code>src/window.js</code> mappa quello che è stato misurato sui grigi del
+      tuo schermo."""
+
+[[privacy]]
+title = "Gli identificatori sono elencati per te, e per nessun altro."
+body = """
+
+      La pagina stampa ogni campo del tuo file che nomina o restringe la persona di
+      cui è la scansione, perché è la domanda a cui ha bisogno di rispondere chi sta
+      per condividere una slice, e nessun visualizzatore risponde. Finisce sullo
+      schermo davanti a te e non va da nessun'altra parte: in questo repository non
+      c'è un evento di analytics che ne porti un pezzo, e la pagina non potrebbe
+      mandarlo neanche se ci fosse."""
+
+[[privacy]]
+title = "Legge. Non scrive."
+body = """
+ Qui non c'è un pulsante che
+      cambi il tuo file, e non c'è codice che potrebbe. Quello che puoi portarti via
+      è un PNG del fotogramma sullo schermo e una copia dell'header in testo
+      semplice, costruiti tutti e due nella pagina a partire da quello che c'è già.
+      L'originale resta intatto sul tuo disco, che è anche la risposta onesta a
+      cosa succede se chiudi la scheda."""
+
+[[privacy]]
+title = "Che cosa carica Google, e che cosa non gli viene dato."
+body = """
+ Gli script della
+      pubblicità e della misurazione arrivano da Google. A nessuno dei due viene
+      passato niente del tuo file: non i pixel, non una miniatura, non un nome, un
+      tag, un paziente o un nome di file. Ogni riga che analizza, decodifica o
+      disegna una scansione è servita da questa origine ed è elencata nel
+      repository."""
+
+[[privacy]]
+title = "Che cosa carica il pulsante delle donazioni, e che cosa non gli viene dato."
+body = """
+
+      Il pulsante &laquo;Buy me a coffee&raquo; in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non segnala nessuna visita e non gli viene passato niente su di
+      te o sui tuoi file. Non succede nulla se non lo clicchi, e quello a cui
+      arriveresti cliccando è il sito di qualcun altro."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e ogni parte di questa pagina
+      continua a funzionare. È la prova più semplice di tutte: uno strumento che
+      mandasse via la tua scansione per farla disegnare altrove si fermerebbe
+      nell'istante in cui stacchi la spina."""
+
+[[howto]]
+title = "Scegli i file."
+body = """
+ Un file <code>.dcm</code>, oppure
+      l'intera cartella del disco &mdash; una TC o una RM è un file per slice, e
+      trascinarli tutti insieme è quello che rimette insieme la serie. I file
+      vengono letti direttamente dal tuo disco dal browser; mentre lo fai non viene
+      mandato niente da nessuna parte."""
+
+[[howto]]
+title = "Scegli la serie."
+body = """
+ Uno studio di solito ne contiene
+      diverse: lo scout, poi ogni acquisizione. Ognuna viene impilata nell'ordine in
+      cui l'apparecchio l'ha presa, ricavato da dove ogni slice si trova nel corpo
+      e non dalla numerazione, che non va sempre nella stessa direzione."""
+
+[[howto]]
+title = "Imposta la finestra."
+body = """
+ È il comando che rende leggibile
+      una scansione, ed è quello che un editor di immagini non ha. Trascina sopra
+      l'immagine per allargare la finestra e in alto o in basso per spostarne il
+      centro, oppure scegli una delle finestre con un nome &mdash; polmone, osso,
+      cervello, tessuti molli &mdash; su una TC, dove le unità sono le stesse su
+      ogni apparecchio del mondo."""
+
+[[howto]]
+title = "Scorri la pila."
+body = """
+ Il cursore sotto l'immagine si muove
+      tra le slice, e i tasti freccia fanno lo stesso una volta che hai cliccato
+      sull'immagine. Un file multi-frame &mdash; un loop ecografico, un angiogramma
+      &mdash; parte con il pulsante lì accanto."""
+
+[[howto]]
+title = "Misura qualcosa."
+body = """
+ Passa a Misura e traccia una linea.
+      Dove il file dice quanto sono distanti i suoi pixel, la risposta è in
+      millimetri e tiene conto dei pixel che non sono quadrati; dove il file non lo
+      dice, la risposta è in pixel e lo dichiara, invece di inventarsi una scala."""
+
+[[howto]]
+title = "Leggi l'header."
+body = """
+ Ogni elemento del file, con il suo
+      numero, il nome che gli dà lo standard e quello che contiene, ricercabile.
+      Sopra, l'elenco di che cosa in questo file identifica il paziente &mdash; che
+      è parecchio di più del nome."""
+
+[[howto]]
+title = "Prendi quello che ti serve."
+body = """
+ Il fotogramma sullo schermo
+      come PNG, con la finestra che hai impostato e niente scritto sopra, oppure
+      tutto l'header in testo semplice. Sono costruiti tutti e due nella pagina a
+      partire da quello che c'è già."""
+
+[[faq]]
+q = "La mia scansione viene caricata da qualche parte?"
+a = """
+        No. Il file viene letto, decodificato e disegnato dal tuo browser sul tuo
+        hardware. Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina elenca ogni indirizzo che
+        può contattare &mdash; nessuno dei quali appartiene a questo sito. Stacca la
+        rete e continua ad aprire scansioni.
+        <br><br>
+        Qui questo vale più che in qualsiasi altra pagina del sito. Un file DICOM
+        porta nell'header il nome del paziente, la data di nascita e il numero di
+        cartella, quindi caricarne uno su un visualizzatore vuol dire consegnare a
+        uno sconosciuto una cartella clinica, non un'immagine."""
+
+[[faq]]
+q = "Quali file DICOM riesce ad aprire?"
+a = """
+        File non compressi in una qualsiasi delle tre transfer syntax di base
+        &mdash; implicit e explicit little endian, e quella big endian ritirata
+        &mdash; più deflated, RLE Lossless, JPEG baseline e JPEG Lossless, che è
+        quello con cui è compressa la maggioranza degli studi TC e RM su un disco
+        ospedaliero.
+        <br><br>
+        Non sa decodificare JPEG 2000, JPEG-LS, né le sintassi MPEG e HEVC usate per
+        il video. Servono codec che sono megabyte di libreria compilata, e una
+        pagina che ne scaricasse uno alla bisogna non sarebbe una pagina che
+        funziona offline. Un file in una di queste si apre lo stesso: tutto l'header
+        viene letto e mostrato, e al posto dell'immagine c'è una riga che nomina il
+        codec, invece dell'icona di immagine rotta che non dice niente."""
+
+[[faq]]
+q = "Che cosa sono &laquo;finestra e livello&raquo;, e perché mi servono?"
+a = """
+        Una slice TC contiene circa quattromila valori distinti e il tuo schermo
+        mostra duecentocinquantasei grigi. La finestra è la scelta di quale fetta di
+        quell'intervallo se li prende tutti: sotto è tutto nero, sopra è tutto
+        bianco, e quello che sta in mezzo viene distribuito sui grigi.
+        <br><br>
+        È per questo che lo stesso file sembra una scansione diversa con due
+        impostazioni, e perché polmone e osso non si possono vedere insieme. Su una
+        TC i numeri sono unità Hounsfield, che sono definite in assoluto &mdash;
+        l'acqua è 0 e l'aria è &minus;1000 &mdash; quindi le finestre con un nome su
+        questa pagina sono gli stessi numeri che usa un radiologo alla sua
+        postazione. Su una RM o un'ecografia una scala così non c'è, e la finestra
+        che si apre è quella che chiede il file stesso."""
+
+[[faq]]
+q = "Perché dice che la mia misura è in pixel?"
+a = """
+        Perché quel file non dice quanto è grande un pixel. È Pixel Spacing
+        (0028,0030) a portare quel dato, in millimetri, e moltissime immagini
+        ecografiche, documenti scansionati e secondary capture semplicemente non ce
+        l'hanno.
+        <br><br>
+        Dove c'è, la misura è in millimetri e ogni asse viene misurato con la sua
+        spaziatura, cosa che conta sulle immagini i cui pixel non sono quadrati.
+        Dove non c'è, la risposta onesta è un conteggio di pixel, e lo dice invece
+        di scegliersi una scala e presentare il risultato come una lunghezza."""
+
+[[faq]]
+q = "Ha aperto la mia cartella come più serie. Perché?"
+a = """
+        Perché è quello che c'è dentro. Uno studio è fatto di serie &mdash; lo scout,
+        poi ogni acquisizione o ricostruzione &mdash; e ogni file dichiara a quale
+        appartiene in Series Instance UID (0020,000E). Il menù è costruito da lì e
+        non dalla cartella, che di solito le tiene tutte mescolate in un unico
+        elenco di nomi.
+        <br><br>
+        Dentro una serie le slice vengono messe in ordine in base a dove ognuna si
+        trova nel corpo, ricavato da Image Position e Image Orientation. Instance
+        Number è la chiave ovvia ed è il ripiego, non la prima scelta: lo assegna
+        qualunque cosa abbia scritto i file e non è detto che corra nella stessa
+        direzione del paziente."""
+
+[[faq]]
+q = "Che cosa vuol dire l'elenco &laquo;che cosa identifica il paziente&raquo;?"
+a = """
+        È ogni campo del tuo file che nomina la persona di cui è la scansione, o che
+        restringe il campo su chi potrebbe essere, letto da questo file sulla tua
+        macchina. L'elenco viene da PS3.15 dello standard DICOM &mdash; la parte che
+        dice che cosa deve sparire prima che un dataset possa dirsi
+        de-identificato.
+        <br><br>
+        C'è perché la cosa che si sbaglia non è pensare che una scansione abbia
+        dentro un nome. È quanto altro ha dentro: la data di nascita, il numero di
+        accettazione, il medico richiedente, la struttura, il numero di serie
+        dell'apparecchio e gli UID dello studio, che sono chiavi perfette per
+        tornare all'archivio che ha prodotto il file. Una scansione a cui è stato
+        cancellato il nome e nient'altro non è anonima.
+        <br><br>
+        Questo strumento si limita a mostrartelo. Non scrive niente e non cambia
+        niente, quindi non può toglierne nemmeno un pezzo."""
+
+[[faq]]
+q = "Può anonimizzare una scansione?"
+a = """
+        No, e non fa finta di poterlo fare. Questa pagina legge; non ha codice che
+        scriva un file DICOM. Quello che fa è dirti esattamente che cosa c'è nel
+        tuo, che è la parte difficile da scoprire e la parte su cui la gente si
+        sbaglia.
+        <br><br>
+        Uno strumento che toglie gli identificatori è un lavoro a sé, con un'asticella
+        molto più alta &mdash; deve riscrivere il file senza toccare i pixel,
+        sostituire gli UID in modo coerente su tutto lo studio, e non sbagliarsi sugli
+        elementi privati in cui certi apparecchi nascondono una seconda copia del
+        nome. Sta nella roadmap di questo sito, non attaccato a un
+        visualizzatore."""
+
+[[faq]]
+q = "Può aprire un file senza estensione .dcm, o rovinato?"
+a = """
+        Sì a entrambe le cose. L'estensione non viene guardata: quello che si
+        controlla è il file. Un dataset scritto senza il solito preambolo di 128 byte
+        &mdash; che è l'aspetto di una scansione presa direttamente dalla rete
+        &mdash; viene letto ricavandone la codifica dal primo elemento, e la pagina
+        dice che è quello che ha fatto.
+        <br><br>
+        Un file che si interrompe a metà viene letto fin dove arriva. Tutto quello
+        che precede il danno viene mostrato, con una nota che dice a quale byte si è
+        fermato. È il caso in cui un visualizzatore serve di più, quindi buttare via
+        tutto il file per i suoi ultimi dodici byte sarebbe il comportamento
+        sbagliato."""
+
+[[faq]]
+q = "È un visualizzatore diagnostico?"
+a = """
+        No. Non è un dispositivo medico, non è passato per nessuna valutazione
+        regolatoria, e niente di quello che c'è qui va usato per prendere una
+        decisione clinica. Il tuo schermo non è calibrato, il browser non è una
+        catena di rendering validata, e nessuna delle due cose si può sistemare da
+        dentro una pagina web.
+        <br><br>
+        Va benissimo invece per tutto il resto per cui si apre una scansione:
+        controllare che cosa c'è su un disco, tirare fuori una slice per una lezione
+        o per un articolo, leggere un header, capire perché un altro programma
+        rifiuta il file, e vedere che cosa si porta dietro una scansione sulla
+        persona di cui è."""
+
+[[faq]]
+q = "Modifica il mio file?"
+a = """
+        No. Questo strumento si limita a leggere. Non c'è un file in uscita, non c'è
+        una ricodifica e non c'è un pulsante che scriva un DICOM &mdash; quello che
+        puoi scaricare è un PNG del fotogramma sullo schermo e una copia
+        dell'header in testo semplice. L'originale resta intatto sul tuo disco."""
+
+[[faq]]
+q = "È gratis, e serve un account?"
+a = """
+        È gratis, e non c'è un account, né un accesso né una prova. Non c'è un limite
+        alla dimensione dei file o a quanti ne apri, oltre alla memoria della tua
+        macchina. Il sito ospita pubblicità, ed è quella che lo paga; agli
+        inserzionisti non viene dato niente del tuo file."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la rete e continua a funzionare.
+        È anche il modo più semplice per dimostrare che non viene caricato niente:
+        uno strumento che mandasse via la tua scansione per farla disegnare altrove
+        si fermerebbe nell'istante in cui stacchi la spina."""
+
+[schema]
+description = "Apri scansioni DICOM (.dcm) nel browser: TC, RM, radiografie ed ecografie, con finestra e livello, un'intera serie impilata nell'ordine giusto, misure in millimetri e ogni tag dell'header. Non viene caricato niente."
+features = [
+  "Apre file TC, RM, radiografie, ecografie, PET e secondary capture",
+  "Finestra e livello trascinando, digitando o con un preset TC con un nome",
+  "Un'intera cartella raccolta in serie e ordinata per posizione nel corpo",
+  "I file multi-frame vengono riprodotti come un loop",
+  "Misura in millimetri, tenendo conto dei pixel non quadrati",
+  "Legge il valore del pixel sotto il puntatore in unità Hounsfield",
+  "Ogni tag DICOM con il suo nome e il suo valore, ricercabile",
+  "Elenca che cosa nel file identifica il paziente, secondo il profilo PS3.15",
+  "Decodifica RLE, JPEG baseline e JPEG Lossless senza librerie incorporate",
+  "Salva il fotogramma come PNG e l'header come testo semplice",
+  "Funziona offline; nessun caricamento, nessun account, nessuna modifica al file",
+]
+
+[picker]
+title = "Trascina qui una scansione"
+hint = "oppure clicca per sfogliare &mdash; un file .dcm, o un'intera cartella"

--- a/locales/it/tools/document-scanner.html
+++ b/locales/it/tools/document-scanner.html
@@ -1,0 +1,388 @@
+<!--
+  tools/document-scanner/body.html, in Italian.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Passo 1 &mdash; le foto -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli le foto</h2>
+
+    <p class="card-lede">
+      Una foto per pagina, scattata da qualche punto sopra. Tutta la pagina deve
+      stare nell'inquadratura, e i quattro angoli dovrebbero essere visibili o
+      quasi. Tutto il resto &mdash; l'inclinazione, l'ombra, il tavolo sotto
+      &mdash; è il motivo per cui questo strumento esiste. Aggiungine più di una e
+      diventano le pagine di un documento, nell'ordine in cui le aggiungi.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="strip-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="detect-all" class="ghost">Ricerca di nuovo su tutte le pagine</button>
+        <button type="button" id="clear-all" class="ghost danger">Togli tutte</button>
+      </div>
+    </div>
+
+    <ul id="page-strip" class="page-strip"></ul>
+  </section>
+
+  <!-- Passo 2 &mdash; gli angoli -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Metti gli angoli sulla pagina</h2>
+
+    <p id="edit-empty" class="field-summary">
+      Scegli una foto e comparirà qui, con i suoi quattro angoli già trovati per
+      te.
+    </p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Tocca un punto qualsiasi della foto e l'angolo più vicino viene al tuo
+        dito; trascinalo sull'angolo della pagina. Con <kbd>Tab</kbd> raggiungi un
+        angolo da tastiera, i tasti freccia lo spostano di un pixel e con
+        <kbd>Shift</kbd> di dieci. Niente di tutto questo è definitivo: la
+        scansione viene presa da dove i quattro angoli finiscono.
+      </p>
+
+      <!-- The photo is a canvas rather than an <img> because it is drawn at
+           screen size from the decoded picture, and because the same canvas is
+           what the corner finder reads. The outline over it is an SVG polygon
+           in percentages, so it needs no redraw when the window changes. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="photo"></canvas>
+        </div>
+      </div>
+
+      <p id="detect-note" class="hint-line" role="status" aria-live="polite"></p>
+
+      <div class="frame-actions">
+        <button type="button" id="detect-one" class="ghost">Cerca di nuovo gli angoli</button>
+        <button type="button" id="whole-photo" class="ghost">Prendi tutta la foto</button>
+        <button type="button" id="turn-left" class="ghost">Ruota a sinistra</button>
+        <button type="button" id="turn-right" class="ghost">Ruota a destra</button>
+        <button type="button" id="undo" class="ghost" disabled>Annulla</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; la ripulitura -->
+  <section class="card" id="clean-card">
+    <h2><span class="step">3</span> Ripulisci</h2>
+
+    <p id="clean-empty" class="field-summary">
+      La pagina raddrizzata compare qui, appena c'è una foto da raddrizzare.
+    </p>
+
+    <div id="clean-controls" hidden>
+      <p class="card-lede">
+        Quello che c'è qui sotto è il risultato vero, prodotto dallo stesso codice
+        che scrive il file: raddrizzato e con la luce irregolare divisa via. Sullo
+        schermo viene disegnato a dimensione di schermo mentre scegli; il file
+        vero e proprio nasce alla risoluzione della foto.
+      </p>
+
+      <div class="result-wrap">
+        <canvas id="scan-preview" class="scan-preview"></canvas>
+        <p id="scan-busy" class="progress-label" role="status" aria-live="polite" hidden>
+          Raddrizzamento in corso&hellip;
+        </p>
+      </div>
+
+      <ul id="scan-facts" class="result-facts"></ul>
+
+      <fieldset class="options" id="mode-group">
+        <legend>Che cosa fare con la luce e con il colore</legend>
+
+        <label class="check">
+          <input type="radio" name="mode" value="colour" checked>
+          <span>
+            <strong>Colore, uniformato</strong>
+            <span class="check-note">
+              La carta viene misurata lungo tutta la pagina e divisa via, così
+              l'ombra sparisce e la carta torna bianca, mentre un timbro, una
+              firma a inchiostro blu o una riga evidenziata si tengono il loro
+              colore. È la modalità da usare quando il colore fa parte del
+              documento.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="grey">
+          <span>
+            <strong>Scala di grigi</strong>
+            <span class="check-note">
+              Lo stesso uniformamento senza il colore. Più piccola del colore e
+              più gentile con una fotografia o con una firma di quanto lo sia il
+              bianco e nero.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="mono">
+          <span>
+            <strong>Bianco e nero</strong>
+            <span class="check-note">
+              Ogni pixel viene deciso contro il suo vicinato e non contro un
+              numero unico per tutta la pagina, ed è esattamente questo che tiene
+              leggibile la scrittura dentro un'ombra. È quello che rende piccola
+              una scansione: un contratto di venti pagine viene fuori sotto il
+              megabyte, e come foto arriverebbe a una quindicina. Questa modalità
+              non conosce i mezzitoni, quindi niente che abbia sopra una
+              fotografia dovrebbe usarla.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="photo">
+          <span>
+            <strong>Lascia com'è</strong>
+            <span class="check-note">
+              Raddrizzata e nient'altro. Per una pagina in cui conta la carta
+              stessa: qualcosa di vecchio, qualcosa di colorato, una fotografia.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row" id="strength-row">
+          <label for="strength">Quanto forte</label>
+          <div class="inline-pair">
+            <input type="range" id="strength" min="0" max="100" step="5" value="50">
+            <output id="strength-value">50</output>
+          </div>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <p class="hint-line">
+        L'impostazione vale per ogni pagina. Pagine di uno stesso documento
+        ripulite in modo diverso sembrano due documenti.
+      </p>
+    </div>
+  </section>
+
+  <!-- Passo 4 &mdash; il file -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Salva il documento</h2>
+
+    <p class="card-lede">
+      Il PDF nasce qui, nella memoria di questa pagina, una pagina alla volta.
+      Dall'altra parte di questo strumento non c'è nessun server a cui mandare una
+      busta paga, un passaporto o un contratto, e nel codice non c'è niente che lo
+      farebbe se ci fosse.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Dimensione della pagina</label>
+        <select id="page-size">
+          <option value="fit" selected>Adatta il foglio alla pagina stessa</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 in</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+        </select>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Risoluzione di stampa</label>
+        <select id="dpi">
+          <option value="150">150 DPI</option>
+          <option value="200" selected>200 DPI</option>
+          <option value="300">300 DPI &mdash; macchina da ufficio</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Quanto grande viene chiamato un foglio fatto di un certo numero di
+          pixel. Cambia la dimensione con cui il documento viene stampato, e non
+          cambia un solo pixel della scansione.
+        </p>
+      </div>
+
+      <div class="field" id="margin-field" hidden>
+        <label for="margin">Margine</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="50" step="1" value="10"
+                 aria-label="Margine in millimetri">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Lato più lungo</label>
+        <select id="max-side">
+          <option value="1600">1600 pixel &mdash; piccolo</option>
+          <option value="2400" selected>2400 pixel</option>
+          <option value="3500">3500 pixel</option>
+          <option value="0">Grande quanto la foto lo consente</option>
+        </select>
+        <p class="field-note">
+          Un tetto per la pagina raddrizzata. La foto di una pagina contiene molti
+          più pixel di quanti la pagina ne valga, e 2400 sul lato lungo sono circa
+          200 DPI su un A4.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualità</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="82">
+          <output id="quality-value">82%</output>
+        </div>
+        <p class="field-note">
+          Per le modalità a colori e in scala di grigi, che vengono salvate come
+          JPEG. Le pagine in bianco e nero sono salvate in modo esatto, e per loro
+          questo non cambia niente.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="title">Titolo del documento <span class="optional">(facoltativo)</span></label>
+        <input type="text" id="title" maxlength="120" placeholder="Se lo lasci vuoto il PDF non porta nessun titolo">
+        <p class="field-note">
+          L'unica cosa che viene scritta nel documento oltre alle pagine. Nessuna
+          data, nessun autore e niente su questo dispositivo. Vedi
+          <code>src/document.js</code>.
+        </p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save-pdf" class="primary big" disabled>Salva come PDF</button>
+      <button type="button" id="save-images" class="ghost big" disabled>Salva le pagine come immagini</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden></p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>Il file finito</h3>
+        <a id="download" class="primary as-button" href="#" download>Scarica</a>
+      </div>
+      <ul id="result-facts" class="result-facts"></ul>
+      <p class="hint-line">
+        Aprilo prima di mandarlo. Quello che c'è nel documento è quello che stava
+        sullo schermo al passo 3, pagina per pagina.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Every sentence the JavaScript puts on this page. They live here rather than
+    in src/, because src/ is copied byte for byte into all eleven languages and
+    a sentence written there would be English in ten of them. See
+    shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="detect.found">I quattro angoli sono stati trovati.
+      Controllali e sistema quelli che stanno fuori posto.</span>
+    <span data-phrase="detect.unsure">I bordi della pagina non erano abbastanza
+      netti per esserne sicuri. Questi angoli sono un'ipotesi: trascinali sulla
+      pagina prima di andare avanti.</span>
+    <span data-phrase="detect.nothing">In questa foto non si è riusciti a
+      distinguere una pagina, quindi gli angoli stanno sui suoi bordi.
+      Trascinali sulla pagina.</span>
+    <span data-phrase="detect.flat">In questa immagine non c'è niente da trovare,
+      non ha proprio nessun bordo.</span>
+    <span data-phrase="detect.tiny">Questa immagine è troppo piccola perché ci si
+      trovi dentro una pagina.</span>
+    <span data-phrase="detect.edited">Questi angoli adesso sono tuoi. &laquo;Cerca
+      di nuovo gli angoli&raquo; rimisura la foto da capo.</span>
+
+    <span data-phrase="corner.tl">Angolo in alto a sinistra</span>
+    <span data-phrase="corner.tr">Angolo in alto a destra</span>
+    <span data-phrase="corner.br">Angolo in basso a destra</span>
+    <span data-phrase="corner.bl">Angolo in basso a sinistra</span>
+    <span data-phrase="corner.at">{corner}, a {x} in orizzontale e {y} in
+      verticale. I tasti freccia lo spostano, e con Shift lo spostano di dieci
+      pixel per volta.</span>
+
+    <span data-phrase="page.select">Modifica la pagina {index}</span>
+    <span data-phrase="page.remove">Togli la pagina {index}</span>
+    <span data-phrase="page.earlier">Sposta la pagina {index} più avanti</span>
+    <span data-phrase="page.later">Sposta la pagina {index} più indietro</span>
+    <span data-phrase="page.count">{count} pagina</span>
+    <span data-phrase="page.counts">{count} pagine</span>
+
+    <span data-phrase="paper.a">A4 o A5</span>
+    <span data-phrase="paper.letter">US Letter</span>
+    <span data-phrase="paper.legal">US Legal</span>
+    <span data-phrase="paper.card">un biglietto da visita</span>
+    <span data-phrase="shape.known">La pagina è venuta fuori {ratio}, ed è la
+      forma di {paper}.</span>
+    <span data-phrase="shape.sideways">La pagina è venuta fuori {ratio}, ed è la
+      forma di {paper} in orizzontale.</span>
+    <span data-phrase="shape.unknown">La pagina è venuta fuori {ratio}, e non è un
+      formato standard.</span>
+
+    <span data-phrase="method.perspective">La forma è stata ricavata dalla
+      prospettiva della foto, quindi è la forma della pagina e non quella con cui
+      appariva nell'immagine.</span>
+    <span data-phrase="method.edges">La foto è stata scattata ad angolo retto,
+      quindi la forma è misurata direttamente sui bordi.</span>
+
+    <span data-phrase="quality.good">{width} per {height} pixel, circa {dpi} DPI
+      su una pagina di questa misura, abbastanza per stampare.</span>
+    <span data-phrase="quality.fair">{width} per {height} pixel, circa {dpi} DPI
+      su una pagina di questa misura. Sullo schermo va bene, su carta è un po'
+      molle.</span>
+    <span data-phrase="quality.low">{width} per {height} pixel, circa {dpi} DPI su
+      una pagina di questa misura. Avvicinati, se questo deve essere
+      stampato.</span>
+    <span data-phrase="quality.pixels">{width} per {height} pixel.</span>
+    <span data-phrase="coverage.note">La pagina ha riempito il {percent}% della
+      foto.</span>
+    <span data-phrase="coverage.small">La pagina ha riempito solo il {percent}%
+      della foto, quindi quasi tutto quello che hai fotografato era tavolo. La
+      prossima volta più vicino.</span>
+
+    <span data-phrase="strength.gentle">Leggera: la carta viene uniformata e
+      poco altro. Per una pagina con sopra una matita chiara o una
+      fotografia.</span>
+    <span data-phrase="strength.middling">L'impostazione solita: la carta torna
+      bianca e il testo stampato torna nero.</span>
+    <span data-phrase="strength.hard">Dura: tutto quello che è grigio viene spinto
+      verso il nero o verso il bianco. È la più pulita su una pagina di solo testo
+      stampato ed è distruttiva su qualsiasi cosa abbia sopra un'immagine.</span>
+
+    <span data-phrase="busy.page">Pagina {done} di {total}&hellip;</span>
+    <span data-phrase="busy.writing">Scrittura del documento&hellip;</span>
+
+    <span data-phrase="result.pdf">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.images">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.mono">Salvato a un bit per pixel e compresso in modo
+      esatto, ed è per questo che è così piccolo.</span>
+    <span data-phrase="result.jpeg">Le pagine sono salvate come JPEG nella qualità
+      che hai scelto.</span>
+    <span data-phrase="result.png">Le pagine sono salvate come PNG, che è senza
+      perdite ed è quello che vuole un'immagine di due colori. Il JPEG sarebbe
+      insieme più grande e sfocato intorno a ogni lettera.</span>
+    <span data-phrase="result.clean">Nessuna data, nessun autore, nessun nome di
+      computer: l'unica cosa nel documento oltre alle pagine è il nome di questo
+      strumento.</span>
+
+    <span data-phrase="size.fit">Ogni foglio prende la misura che la sua pagina ha
+      davvero, alla risoluzione scelta sopra. Non viene riempito niente con delle
+      bande.</span>
+    <span data-phrase="size.named">Ogni pagina viene messa su un foglio {name},
+      dentro il margine, qualunque forma abbia preso.</span>
+
+    <span data-phrase="error.decode">Questo browser non è riuscito ad aprire
+      {name}. Se è una foto HEIC di un iPhone, convertila prima.</span>
+    <span data-phrase="error.none">Scegli prima almeno una foto.</span>
+    <span data-phrase="error.failed">Qualcosa è andato storto nel creare il file:
+      {detail}</span>
+  </div>
+</main>

--- a/locales/it/tools/document-scanner.toml
+++ b/locales/it/tools/document-scanner.toml
@@ -1,0 +1,304 @@
+#
+# Document Scanner - Italian.
+#
+# Overrides for tools/document-scanner/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Scansionare" e "scansione" sono le parole che si usano e si cercano, anche se
+# il verbo è un prestito adattato: nessuno chiede a un ufficio di "digitalizzare
+# e rispedire" un modulo. I nomi propri restano com'è giusto che siano: Sauvola,
+# Zhang e He, DPI, OCR.
+#
+
+name = "Scanner per documenti"
+heading = "Scanner&nbsp;per&nbsp;documenti <span class=\"h1-kw\">&mdash; la foto di una pagina, raddrizzata</span>"
+tagline = "Fotografa la pagina. Ti torna indietro qualcosa che sembra scansionato."
+
+title = "Scanner per documenti &mdash; da foto a PDF scansionato, senza caricare niente"
+description = "Trasforma la foto di una pagina scattata col telefono in un PDF raddrizzato e illuminato in modo uniforme. Gli angoli te li trova lui, la prospettiva viene annullata, l'ombra viene divisa via. Funziona interamente nel tuo browser: non viene caricato niente."
+og_title = "Scansiona un documento con una foto, senza caricarlo"
+og_description = "Gli angoli della pagina vengono trovati, l'inclinazione annullata e la luce irregolare divisa via, nel tuo browser. Quello che si fotografa così è un passaporto, una busta paga o un contratto, cioè esattamente quello che non andrebbe caricato."
+og_image_alt = "Scanner per documenti - la foto di una pagina, raddrizzata e ripulita, senza caricarla"
+
+pledge = """
+    La foto viene decodificata, raddrizzata, ripulita e scritta in un PDF dal tuo
+    browser, usando soltanto aritmetica e i codec che si porta già dietro. Questo
+    strumento non ha nessuna funzione di rete &mdash; niente da recuperare, niente
+    da mandare &mdash; e il motivo per cui qui la cosa conta è di che cosa si
+    fotografano le pagine: un passaporto, una busta paga, un contratto d'affitto,
+    un modulo che un ufficio ha chiesto di &laquo;scansionare e rispedire&raquo;."""
+
+live_hint = """
+      Non fidarti sulla parola: apri gli strumenti di sviluppo, guarda la scheda
+      Rete e scansiona una pagina. Non una richiesta porta con sé una foto, una
+      miniatura, un nome di file o la posizione di un singolo angolo. Oppure stacca
+      la rete e scansionane una lo stesso."""
+
+read_first = """
+, <code>src/detect.js</code> per come gli angoli
+      vengono trovati senza nessun modello, <code>src/warp.js</code> per il
+      raddrizzamento, e <code>src/clean.js</code> per come la luce irregolare viene
+      divisa via."""
+
+howto_heading = "Come scansionare un documento con la fotocamera del telefono"
+
+card = """
+            La foto di una pagina, raddrizzata e ripulita fino a diventare un
+            documento. Gli angoli te li trova lui, l'inclinazione viene annullata
+            e l'ombra viene divisa via."""
+
+[words]
+plural = "documenti"
+choose = "la foto di una pagina"
+
+[[facts]]
+text = "Nessun caricamento"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Codice aperto"
+
+[[privacy]]
+title = "I tuoi documenti non hanno nessun posto dove andare."
+body = """
+ La
+      Content-Security-Policy elenca ogni indirizzo che questa pagina può
+      contattare, e nemmeno uno appartiene a questo sito. Qui non c'è un endpoint
+      dove le tue foto possano essere raccolte, e non c'è niente nel codice che le
+      manderebbe se ci fosse."""
+
+[[privacy]]
+title = "Non c'è nessun modello, quindi non c'è niente da scaricare e niente da chiedere."
+body = """
+ Trovare
+      i quattro angoli di una pagina si fa con l'aritmetica: il gradiente
+      dell'immagine, un voto per le linee dritte che ci sono dentro, e una verifica
+      di che cosa ci sia davvero sotto ogni lato del rettangolo che vince. Nessun
+      peso, nessun runtime di inferenza, niente da recuperare al primo uso, e
+      niente che si comporti in modo diverso sul documento di qualcun altro
+      rispetto al tuo &mdash; vedi <code>src/detect.js</code>."""
+
+[[privacy]]
+title = "Il documento non porta né data, né autore, né nome della macchina."
+body = """
+ Una scansione
+      è una cosa che si manda ad altre persone, di solito perché un ufficio l'ha
+      chiesta. L'unica cosa scritta nel PDF oltre alle pagine stesse è il nome di
+      questo strumento, più un titolo se ne scrivi uno. Non c'è una data di
+      creazione, non c'è un autore, non c'è un numero di serie e non c'è niente
+      ricavato dal tuo orologio, dai tuoi nomi di file o dal tuo computer &mdash;
+      vedi <code>src/document.js</code>."""
+
+[[privacy]]
+title = "Qui dentro niente va a prendere niente."
+body = """
+ In <code>src/</code>
+      non c'è nessun <code>fetch</code>, nessun <code>XMLHttpRequest</code> e
+      nessun <code>sendBeacon</code>. Il lavoro è <code>getImageData</code>,
+      qualche ciclo sui byte e l'encoder JPEG del browser &mdash; tutta roba già
+      installata sulla tua macchina."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento è identico,
+      perché un passaggio di rete non c'è mai stato. È la prova più semplice di
+      tutte &mdash; e quella che vale la pena fare prima di scansionare un
+      passaporto."""
+
+[[howto]]
+title = "Fotografa la pagina."
+body = """
+ Dall'alto, con tutta la pagina
+      nell'inquadratura e i quattro angoli visibili o quasi. Non deve essere
+      perfettamente frontale e non deve essere illuminata in modo uniforme:
+      l'inclinazione e l'ombra sono il motivo per cui questo strumento esiste.
+      Quello che conta è riempire l'inquadratura &mdash; una pagina fotografata da
+      metà stanza non ha dentro nessun dettaglio da recuperare."""
+
+[[howto]]
+title = "Controlla i quattro angoli."
+body = """
+ Te li trova lui quando la foto
+      viene letta, e la pagina lo dice quando non ne è sicura &mdash; una pagina su
+      una scrivania dello stesso colore della carta ha davvero un bordo difficile
+      da vedere. Premi in un punto qualsiasi della foto e l'angolo più vicino viene
+      al tuo dito, oppure raggiungine uno con <kbd>Tab</kbd> e spostalo con i tasti
+      freccia."""
+
+[[howto]]
+title = "Scegli che cosa fare con la luce."
+body = """
+ &laquo;Colore,
+      uniformato&raquo; misura la carta lungo tutta la pagina e la divide via, così
+      l'ombra sparisce e un timbro o una firma si tengono il loro colore.
+      &laquo;Bianco e nero&raquo; va oltre ed è quello che rende una scansione
+      abbastanza piccola da mandarla per email. Quello che vedi sullo schermo è il
+      risultato vero, prodotto dallo stesso codice che scrive il file."""
+
+[[howto]]
+title = "Aggiungi le altre pagine."
+body = """
+ Ogni foto che aggiungi diventa
+      un'altra pagina dello stesso documento, nell'ordine in cui sono elencate, e
+      ognuna si tiene i suoi angoli. Le frecce su una pagina nella striscia la
+      spostano più avanti o più indietro."""
+
+[[howto]]
+title = "Salva il PDF, e aprilo prima di mandarlo."
+body = """
+ Il
+      documento viene scritto qui, nella memoria di questa pagina. Per farlo non è
+      stato caricato niente, e di lui non è stato riferito niente da nessuna
+      parte."""
+
+[[faq]]
+q = "Il mio documento viene caricato da qualche parte?"
+a = """
+        No. La foto viene decodificata, raddrizzata, ripulita e scritta in un PDF
+        dal tuo browser sul tuo hardware. Questo strumento non ha nessuna funzione
+        di rete &mdash; non va mai a prendere niente e non manda mai niente &mdash;
+        e la <code>Content-Security-Policy</code> della pagina elenca ogni indirizzo
+        che può contattare, nessuno dei quali appartiene a questo sito. Carica la
+        pagina una volta, stacca la rete, e continua a funzionare."""
+
+[[faq]]
+q = "Come fa a trovare gli angoli della pagina senza un modello?"
+a = """
+        Cercando i quattro lunghi bordi dritti di cui è fatto un rettangolo. La foto
+        viene rimpicciolita, se ne prende il gradiente &mdash; dove l'immagine cambia,
+        e in quale direzione &mdash; e ogni pixel che sta su un bordo vota per la
+        linea dritta su cui si troverebbe. Le linee forti vengono accoppiate in
+        rettangoli candidati, e ogni candidato prende un punteggio percorrendo i suoi
+        quattro lati e chiedendosi quanta parte di ognuno abbia davvero un bordo
+        sotto, e se i quattro insieme siano il contorno di una cosa sola: una pagina
+        è più chiara di quello che le sta intorno, o più scura, ma lo è nello stesso
+        modo su tutti e quattro i lati, ed è questo che impedisce di scambiare una
+        riga di testo per il fondo della pagina. Non ci sono pesi, non viene scaricato
+        niente, e l'aritmetica è la stessa per ogni documento che ci passa dentro."""
+
+[[faq]]
+q = "Gli angoli che ha trovato sono sbagliati. E adesso?"
+a = """
+        Trascinali. Gli angoli sono una posizione di partenza e mai una decisione: la
+        scansione viene presa da dove finiscono tutti e quattro. Premi in un punto
+        qualsiasi della foto e l'angolo più vicino salta al tuo dito, che è più facile
+        che centrare una maniglia piccola, e i tasti freccia spostano l'angolo che ha
+        il fuoco un pixel per volta. La pagina ti dice anche quando gli angoli sono
+        un'ipotesi e non un ritrovamento, e segna quella pagina nella striscia &mdash;
+        una pagina appoggiata su una scrivania più o meno del suo stesso colore è il
+        motivo solito, perché lì di bordo da trovare non ce n'è quasi."""
+
+[[faq]]
+q = "Perché la pagina raddrizzata viene fuori della forma giusta, e non schiacciata?"
+a = """
+        Perché la forma viene ricavata dalla prospettiva e non misurata sui bordi. Una
+        pagina fotografata di sbieco ha il bordo lontano accorciato, quindi il metodo
+        ovvio &mdash; prendere la coppia di bordi opposti più lunga e chiamare quello
+        il rapporto &mdash; produce un A4 visibilmente tozzo, che è quello che ti dà
+        la maggior parte degli scanner sul web. La fotografia di un rettangolo porta
+        in realtà abbastanza informazione da ricavare sia il rapporto d'aspetto del
+        rettangolo sia la lunghezza focale della fotocamera, a patto solo che la
+        fotocamera sia una normale; è un risultato di Zhang e He del 2003, ed è quello
+        che fa <code>src/geometry.js</code>. Dove la foto è stata scattata frontale non
+        c'è prospettiva da cui partire e non serve, perché allora i bordi sono esatti
+        &mdash; quindi ripiega su quelli, e la pagina dice quale delle due ha
+        risposto."""
+
+[[faq]]
+q = "Che cosa fa davvero all'immagine la &laquo;ripulitura&raquo;?"
+a = """
+        Divide via la luce. La luminosità propria della carta viene misurata lungo
+        tutta la pagina &mdash; una griglia di riquadri, e in ogni riquadro un
+        percentile alto della luminosità, che il testo è troppo scuro e troppo rado
+        per spostare &mdash; e ogni pixel viene diviso per la carta stimata in quel
+        punto. Quello che resta è l'inchiostro, illuminato in modo uniforme, senza più
+        l'ombra e senza la caduta di luce. Non è la stessa cosa che alzare il
+        contrasto: alzare il contrasto di una pagina fotografata rende bianca la parte
+        chiara, nera la parte scura e illeggibile quello che c'è scritto nella parte
+        scura, ed è per questo che i &laquo;livelli automatici&raquo; peggiorano queste
+        immagini invece di migliorarle."""
+
+[[faq]]
+q = "Perché la modalità bianco e nero è così tanto più piccola?"
+a = """
+        Perché un'immagine con dentro due colori è davvero una frazione dei dati di
+        un'immagine con sedici milioni, e qui viene salvata proprio così: un bit per
+        pixel, impacchettati otto per byte e compressi in modo esatto, e non come il
+        JPEG di un'immagine in bianco e nero. Sulle stesse pagine viene fuori circa
+        diciotto volte più piccola della modalità a colori, così un contratto di venti
+        pagine sta sotto il megabyte invece di arrivare a una quindicina. La soglia è
+        quella di Sauvola, che decide ogni pixel confrontandolo con la media e la
+        dispersione del suo vicinato invece che con un numero unico per tutta la
+        pagina &mdash; ed è questo che tiene leggibile quello che è scritto dentro
+        un'ombra. Non ha mezzitoni, quindi una pagina con sopra una fotografia
+        conviene farla con una delle altre modalità."""
+
+[[faq]]
+q = "Posso mettere più pagine in un solo PDF?"
+a = """
+        Sì. Ogni foto che aggiungi diventa un'altra pagina, nell'ordine in cui sono
+        elencate, e ogni pagina si tiene i suoi angoli &mdash; così una pila di pagine
+        fotografate una dopo l'altra diventa un documento solo. Le frecce su ogni
+        pagina nella striscia la spostano più avanti o più indietro. L'impostazione
+        della ripulitura è condivisa da tutte apposta: pagine dello stesso documento
+        ripulite in modo diverso sembrano due documenti."""
+
+[[faq]]
+q = "Legge il testo, così posso cercare dentro il PDF?"
+a = """
+        No. Non c'è un livello di testo e non c'è riconoscimento dei caratteri: quello
+        che esce è l'immagine della pagina su una pagina. Farlo per bene vorrebbe dire
+        un motore OCR, che sono decine di megabyte di modello da scaricare &mdash; e
+        uno scanner per documenti che andasse a prendere un modello prima di poter
+        leggere la tua busta paga sarebbe uno scanner per documenti con un motivo per
+        telefonare a casa a proposito di buste paga. Se ti serve il testo, la modalità
+        bianco e nero produce esattamente il tipo di file su cui il software OCR sulla
+        tua macchina lavora meglio."""
+
+[[faq]]
+q = "È venuta sfocata. Perché?"
+a = """
+        Quasi sempre perché la pagina era piccola nella foto. Il pannello sotto
+        l'anteprima dice quanta parte dell'inquadratura ha riempito la pagina e più o
+        meno a quanti punti per pollice corrisponde su un foglio di quella misura
+        &mdash; sotto i 150 DPI circa una scansione stampata sembra molle, e non c'è
+        strumento che possa fare qualcosa per un dettaglio che nel file non c'è mai
+        stato. Avvicinati invece di zoomare, stai fermo, e lascia che la fotocamera
+        metta a fuoco la pagina prima di premere. Il mosso è l'altra causa, e non è
+        recuperabile nemmeno quello."""
+
+[[faq]]
+q = "È gratis, e serve un account?"
+a = """
+        È gratis, e non c'è un account, né un accesso, né una prova, né un limite di
+        pagine, né una filigrana. Non c'è nemmeno un limite alla dimensione delle
+        foto, perché non c'è un server a pagarlo &mdash; il lavoro succede sulla tua
+        macchina. Il sito ospita pubblicità, ed è quella che lo paga; agli
+        inserzionisti non viene dato niente dei tuoi documenti."""
+
+[schema]
+description = "Scansiona un documento nel browser: fotografa una pagina, e i quattro angoli vengono trovati, la prospettiva annullata, la luce irregolare divisa via, e il risultato scritto in un PDF. Più pagine diventano un documento solo. Non viene caricato niente."
+features = [
+  "Trova i quattro angoli della pagina senza modelli, senza scaricare niente e senza andare a prendere niente",
+  "Ricava la forma vera della pagina dalla prospettiva, così una foto di sbieco non viene fuori schiacciata",
+  "Divide via la luce irregolare e l'ombra invece di alzare il contrasto",
+  "Pagine in bianco e nero salvate a un bit per pixel, che è quello che rende una scansione abbastanza piccola da mandarla per email",
+  "Più foto diventano le pagine di un solo PDF, ognuna con i suoi angoli",
+  "Gli angoli si possono trascinare, o spostare da tastiera un pixel per volta",
+  "Dice quando gli angoli sono un'ipotesi e non un ritrovamento",
+  "Non scrive nel documento né data, né autore, né nome della macchina",
+  "Funziona offline; nessun caricamento, nessun account",
+]
+
+[picker]
+title = "Trascina qui le foto delle tue pagine"
+hint = "oppure clicca per sfogliare &mdash; una foto per pagina, in ordine di pagina"

--- a/locales/it/tools/redact-pdf.html
+++ b/locales/it/tools/redact-pdf.html
@@ -1,0 +1,305 @@
+<!--
+  tools/redact-pdf/body.html, in Italian.
+
+  Every id, class, data-phrase key and brace placeholder below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+
+  Le coppie count.* restano doppie: l'italiano distingue singolare e plurale,
+  quindi qui portano davvero due forme.
+-->
+<main>
+  <!-- Passo 1 &mdash; il documento -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli il PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <div id="doc-facts" class="doc-facts" hidden>
+      <p id="doc-name" class="doc-name"></p>
+      <p id="doc-sub" class="doc-sub"></p>
+      <ul id="doc-warnings" class="doc-warnings"></ul>
+    </div>
+  </section>
+
+  <!-- Passo 2 &mdash; trovare -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Di' che cosa deve sparire</h2>
+
+    <p class="card-lede">
+      Scrivi le parole, un nome, un indirizzo, un numero di pratica, e ogni punto
+      in cui compaiono viene elencato qui sotto con la sua riga. Fino al passo 4
+      non viene tolto niente, e non viene tolto niente che tu non abbia spuntato.
+    </p>
+
+    <label class="find-label" for="terms">Parole ed espressioni, una per riga</label>
+    <textarea id="terms" rows="3" spellcheck="false" autocomplete="off"
+              placeholder="Rossi&#10;Via Roma 14&#10;RG-40219"></textarea>
+
+    <div class="find-row">
+      <button type="button" id="find" class="primary">Cerca</button>
+      <label class="inline-check">
+        <input type="checkbox" id="match-case"> <span>Distingui maiuscole e minuscole</span>
+      </label>
+      <label class="inline-check">
+        <input type="checkbox" id="whole-word"> <span>Solo parole intere</span>
+      </label>
+    </div>
+
+    <fieldset class="finders">
+      <legend>Oppure cerca quello che di solito è delicato</legend>
+      <div class="chips" id="finders"></div>
+      <p class="field-note" id="finder-note">
+        Sono schemi, e uno schema non sa distinguere un numero di telefono da un
+        numero di pratica. I numeri di carta e gli IBAN vengono verificati con le
+        loro cifre di controllo; il resto viene proposto e mai spuntato per te, e
+        ogni risultato merita un'occhiata.
+      </p>
+    </fieldset>
+
+    <div class="toolbar" id="match-bar" hidden>
+      <span id="match-count" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="tick-all" class="ghost">Spunta tutto</button>
+        <button type="button" id="tick-none" class="ghost">Togli tutte le spunte</button>
+        <button type="button" id="clear-found" class="ghost danger">Svuota l'elenco</button>
+      </div>
+    </div>
+
+    <ul id="match-list" class="match-list" hidden></ul>
+    <p id="match-more" class="field-note" hidden></p>
+  </section>
+
+  <!-- Passo 3 &mdash; leggere la pagina -->
+  <section class="card" id="page-card" hidden>
+    <h2><span class="step">3</span> Leggi la pagina e prendi le parole da lì</h2>
+
+    <p class="card-lede">
+      Questo è il testo come sta salvato nel documento, nell'ordine in cui lo
+      copierebbe un lettore, che non è sempre quello in cui è stampato. Clicca una
+      parola per toglierla, e ricliccala per tenerla. Tutto quello che qui è
+      barrato è quello che sparirà.
+    </p>
+
+    <div class="pager">
+      <button type="button" id="prev-page" class="ghost">&#8592; Indietro</button>
+      <span id="page-of" class="count"></span>
+      <button type="button" id="next-page" class="ghost">Avanti &#8594;</button>
+      <span class="pager-spacer"></span>
+      <span id="page-picked" class="count"></span>
+      <button type="button" id="clear-page" class="ghost danger">Tieni tutto su questa pagina</button>
+    </div>
+
+    <p id="page-note" class="field-summary" hidden></p>
+
+    <div id="page-text" class="page-text" role="group" aria-label="Il testo di questa pagina"></div>
+  </section>
+
+  <!-- Passo 4 &mdash; fare -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Togli le parole</h2>
+
+    <label class="check">
+      <input type="checkbox" id="opt-boxes" checked>
+      <span>
+        <strong>Disegna un rettangolo nero dove stava ognuna</strong>
+        <span class="check-note">
+          Perché chi legge veda che qualcosa è stato tolto. Qui il rettangolo è
+          un ornamento e non l'oscuramento: le lettere sono sparite dal file
+          prima che venga disegnato. Spegnilo, e le parole spariscono e basta,
+          lasciando lo spazio che occupavano.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-elsewhere" checked>
+      <span>
+        <strong>Togli le stesse parole dal resto del documento</strong>
+        <span class="check-note">
+          Segnalibri, commenti, note adesive e quello che è stato scritto nei
+          campi dei moduli. Una parola tolta da una pagina e lasciata in un
+          segnalibro non è tolta. Le proprietà del documento se ne vanno
+          comunque, e così il testo di sostituzione che un lettore copia al posto
+          delle lettere sulla pagina: tutti e due sono il documento che dice la
+          parola, non un altro posto che ne tiene una copia.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-attachments" checked>
+      <span>
+        <strong>Butta via gli allegati e tutto quello che viene eseguito</strong>
+        <span class="check-note">
+          Un PDF può portarsi dentro interi file e del JavaScript che parte
+          all'apertura. In nessuno dei due si possono cercare le parole che stai
+          togliendo, e per leggere un documento non servono né l'uno né l'altro.
+        </span>
+      </span>
+    </label>
+
+    <p class="field-summary" id="run-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Togli</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Scarica</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+      <ul id="check-terms" class="check-terms" hidden></ul>
+      <ul id="result-facts" class="result-facts"></ul>
+    </div>
+  </section>
+
+  <!--
+    The sentences this tool's JavaScript puts on screen. They live here rather
+    than in src/ because src/ is copied byte for byte into all eleven
+    languages; see "The strings in the JavaScript" in the repository README.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="load.notpdf">Questo non è un PDF, quindi non c'è dentro nessun testo da togliere.</span>
+    <span data-phrase="load.encrypted">Questo PDF ha una password. Togliere la
+      protezione a un documento è un lavoro diverso dal togliergli delle parole, e
+      questo strumento non lo fa alle tue spalle.</span>
+    <span data-phrase="load.broken">Non è stato possibile aprire questo file come PDF ({detail}).</span>
+    <span data-phrase="load.nopages">Si è aperto, ma non ci si sono trovate pagine dentro.</span>
+    <span data-phrase="load.repaired">La tabella dei riferimenti incrociati di
+      questo documento non corrispondeva al suo contenuto, quindi è stato letto
+      andando a cercare gli oggetti. È una riparazione, ed è riuscita. Controlla
+      bene il risultato prima di mandarlo da qualche parte.</span>
+
+    <span data-phrase="doc.sub">{pages} &middot; {words} di testo &middot; {size}</span>
+    <span data-phrase="doc.notext">{count} di queste pagine non hanno proprio
+      nessun testo. Una pagina così è l'immagine di una pagina, e per questo
+      strumento lì non c'è niente da togliere: le parole nell'immagine restano
+      esattamente dove sono.</span>
+    <span data-phrase="doc.unreadable">{count} lettere di questo documento non si
+      sono potute leggere come caratteri, perché i font usati non si portano
+      dietro una corrispondenza dai loro glifi al testo. Queste lettere non si
+      possono cercare, quindi guarda le pagine su cui stanno invece di fidarti
+      della ricerca.</span>
+    <span data-phrase="doc.scan">Certe pagine portano del testo invisibile sopra
+      un'immagine, ed è così che uno scanner registra quello che il suo lettore ha
+      ricavato dalla pagina. Togliere quel testo toglie quello che troverebbero una
+      ricerca e una copia. Non cambia niente dell'immagine, e nell'immagine le
+      parole restano leggibili.</span>
+
+    <span data-phrase="find.none">Non c'è stato nessun risultato in nessuna pagina.</span>
+    <span data-phrase="find.some">{count} su {pages}.</span>
+    <span data-phrase="find.more">Sono elencati i primi {shown}. Il resto è stato
+      trovato e viene tolto insieme agli altri, se spunti tutto.</span>
+    <span data-phrase="find.terms">Scrivi una parola qui sopra o scegli uno schema, prima di premere Cerca.</span>
+
+    <span data-phrase="page.of">Pagina {number} di {total}</span>
+    <span data-phrase="page.picked">{count} verranno tolte da questa pagina</span>
+    <span data-phrase="page.notext">Su questa pagina non c'è testo. O è vuota, o è
+      l'immagine di una pagina: una scansione, una foto, un'esportazione che ha
+      disegnato le sue parole come forme. Niente di quello che c'è sopra si può
+      cercare, e niente di quello che c'è sopra si può togliere qui.</span>
+    <span data-phrase="page.unreadable">{count} lettere di questa pagina non si
+      sono potute leggere come caratteri. Qui sotto stanno come &#9647;, e la
+      ricerca non le trova.</span>
+    <span data-phrase="page.scan">Il testo di questa pagina è invisibile: sta sopra
+      un'immagine della pagina, ed è così che una scansione viene resa
+      ricercabile. Quello che togli qui è quello che troverebbero una ricerca e una
+      copia. L'immagine si tiene le parole.</span>
+
+    <span data-phrase="run.summary">{words} su {pages} verranno tolte.</span>
+    <span data-phrase="run.nothing">Non è ancora stato spuntato niente. Cerca una parola al passo 2, oppure cliccane una al passo 3.</span>
+    <span data-phrase="run.editing">Rimozione delle parole&hellip;</span>
+    <span data-phrase="run.writing">Scrittura del documento&hellip;</span>
+    <span data-phrase="run.checking">Il file finito viene riaperto e cercato&hellip;</span>
+    <span data-phrase="run.failed">Qualcosa è andato storto nel riscrivere questo documento ({detail}).</span>
+    <span data-phrase="run.cancelled">Annullato. Non è stato scritto niente.</span>
+
+    <span data-phrase="result.headline">{words} tolte</span>
+    <span data-phrase="result.sub">{size} &middot; {pages} modificate &middot; {boxes}</span>
+    <span data-phrase="check.good">Riaperto e cercato qui, come farebbe un
+      lettore: nessuna di queste sta nel file finito.</span>
+    <span data-phrase="check.partial">Riaperto e cercato qui: ogni occorrenza che
+      hai spuntato è sparita, e quelle che hai lasciato ci sono ancora.</span>
+    <span data-phrase="check.survived">Questo file NON è stato scritto. Il
+      documento finito è stato riaperto, e una parte di quello che avevi tolto ci
+      si trovava ancora. L'oscuramento quindi non era completo. Non viene offerto
+      niente da scaricare.</span>
+    <span data-phrase="check.pages">Questo file NON è stato scritto. Il documento
+      finito è tornato indietro con un numero di pagine diverso da quello con cui
+      era entrato, quindi è andato storto qualcosa oltre alle parole. Non viene
+      offerto niente da scaricare.</span>
+
+    <span data-phrase="fact.boxes">{count} disegnati sopra i vuoti.</span>
+    <span data-phrase="fact.noboxes">Non è stato disegnato nessun rettangolo,
+      quindi le parole sono sparite senza che niente dica dove stavano.</span>
+    <span data-phrase="fact.elsewhere">Le stesse parole sono state tolte da {where}.</span>
+    <span data-phrase="fact.metadata">Le proprietà del documento e il pacchetto
+      XMP sono stati rimossi, quindi il file finito non dice che cosa lo ha
+      prodotto, quando, né come si chiamava prima.</span>
+    <span data-phrase="fact.carried">{attachments} e {actions} sono stati buttati via.</span>
+    <span data-phrase="fact.shared">Una parte di quello che hai tolto era
+      disegnata da un blocco che il documento riusa su più di una pagina, quindi è
+      sparita da ogni pagina che lo disegna. È più di quello che avevi spuntato, e
+      non è mai di meno.</span>
+    <span data-phrase="fact.overimage">{count} delle lettere tolte stavano sopra
+      un'immagine della stessa pagina. Dal livello di testo sono uscite e
+      nell'immagine ci sono ancora: chi legge non può più cercarle o copiarle, e
+      continua a vederle.</span>
+    <span data-phrase="fact.untouched">Tutto il resto di ogni pagina è passato
+      byte per byte. Non è stato ricodificato nessun font, nessuna immagine e
+      nessuna linea.</span>
+
+    <span data-phrase="count.pages">{count} pagine</span>
+    <span data-phrase="count.page">{count} pagina</span>
+    <span data-phrase="count.words">{count} parole</span>
+    <span data-phrase="count.word">{count} parola</span>
+    <span data-phrase="count.pieces">{count} pezzi di testo</span>
+    <span data-phrase="count.piece">{count} pezzo di testo</span>
+    <span data-phrase="count.matches">{count} risultati</span>
+    <span data-phrase="count.match">{count} risultato</span>
+    <span data-phrase="count.boxes">{count} rettangoli neri</span>
+    <span data-phrase="count.box">{count} rettangolo nero</span>
+    <span data-phrase="count.attachments">{count} allegati</span>
+    <span data-phrase="count.attachment">{count} allegato</span>
+    <span data-phrase="count.actions">{count} azioni</span>
+    <span data-phrase="count.action">{count} azione</span>
+    <span data-phrase="count.hosts">{count} host</span>
+    <span data-phrase="count.host">{count} host</span>
+
+    <!-- The space before {platform} belongs to these two rather than to the
+         phrase it lets in, because phrases.js collapses and trims the markup
+         it reads and a leading space would not survive the trip. -->
+    <span data-phrase="net.clean">Il tuo documento non è andato da nessuna parte.
+      {total} file caricati, tutti quanti di questo sito. {platform}</span>
+    <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo
+      strumento non lo fa mai. Vale la pena andare a vedere. {platform}</span>
+    <span data-phrase="net.platform">Gli script del sito per la pubblicità, la
+      misurazione e il pulsante delle donazioni sono arrivati da {hosts}; a
+      nessuno di questi è arrivato un documento, una sua parola o qualcosa che hai
+      cercato.</span>
+
+    <span data-phrase="finder.email">Indirizzi email</span>
+    <span data-phrase="finder.card">Numeri di carta</span>
+    <span data-phrase="finder.iban">Conti bancari (IBAN)</span>
+    <span data-phrase="finder.nationalid">Codici fiscali e numeri di previdenza</span>
+    <span data-phrase="finder.phone">Numeri di telefono</span>
+  </div>
+</main>

--- a/locales/it/tools/redact-pdf.toml
+++ b/locales/it/tools/redact-pdf.toml
@@ -1,0 +1,377 @@
+#
+# Redact a PDF - Italian.
+#
+# Overrides for tools/redact-pdf/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Oscurare" è lo stesso verbo di oscurare-immagine, e porta con sé la stessa
+# distinzione su cui vive la pagina: le lettere vengono tolte dal file, non
+# coperte con un rettangolo. Dove l'inglese dice "redaction" e non "covering",
+# l'italiano deve tenere la coppia togliere / coprire, perché è tutta lì la
+# differenza che questo strumento rivendica.
+#
+
+name = "Oscuratore di PDF"
+heading = "Oscura&nbsp;un&nbsp;PDF <span class=\"h1-kw\">&mdash; le parole escono, non ci va sopra un rettangolo</span>"
+tagline = "Le lettere vengono cancellate dal file, e poi il file viene cercato per dimostrarlo."
+
+title = "Oscurare un PDF &mdash; cancellare davvero il testo, gratis, senza caricarlo"
+description = "Togli le parole da un PDF invece di disegnarci sopra un rettangolo nero. Le lettere vengono cancellate dalle istruzioni con cui la pagina si disegna, il file finito viene riaperto e cercato per dimostrare che non ci sono più, e non viene caricato niente."
+og_title = "Oscurare un PDF come si deve &mdash; le parole sono cancellate, non coperte"
+og_description = "Nella maggior parte degli strumenti il rettangolo nero sta sopra il testo, e da sotto lo si può copiare via. Questo cancella le lettere dal file e poi cerca nel risultato per mostrare che non ci sono."
+og_image_alt = "Oscurare un PDF cancellando il testo, non coprendolo"
+
+pledge = """
+    Il documento che scegli viene aperto, letto, modificato e riscritto in memoria
+    su questa macchina, da codice servito da questo indirizzo. Qui dentro non c'è
+    niente che possa fare un caricamento, e dall'altra parte di questa pagina non
+    c'è nessun server che possa riceverlo. Né il file né le parole che hai cercato
+    escono dalla scheda."""
+
+live_hint = """
+      Non fidarti sulla parola: apri gli strumenti di sviluppo, guarda la scheda
+      Rete e oscura qualcosa. Non una richiesta porta con sé una pagina, una parola
+      o un nome di file. Oppure stacca la rete e oscuralo lo stesso."""
+
+read_first = """
+, <code>src/text.js</code> per come ogni parola di
+      una pagina viene trovata e localizzata, e <code>src/edit.js</code> per la
+      cancellazione vera e propria &mdash; che cosa viene tagliato dalle istruzioni
+      della pagina e che cosa viene rimesso perché il resto della riga non si
+      sposti. Nessuno di questi può raggiungere la rete, e non possono nemmeno il
+      lettore e lo scrittore che stanno lì accanto."""
+
+howto_heading = "Come oscurare un PDF in modo che le parole spariscano davvero"
+
+card = """
+            Cancella le parole da un PDF invece di coprirle. Le lettere vengono
+            tolte dalle istruzioni con cui la pagina si disegna, il vuoto viene
+            tenuto aperto perché niente si sposti, e il file finito viene
+            riaperto e cercato qui per dimostrare che quelle parole non ci
+            sono."""
+
+[words]
+plural = "documenti"
+choose = "un PDF"
+
+[[facts]]
+text = "Nessun caricamento"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Codice aperto"
+
+[[facts]]
+text = "I file restano sul tuo dispositivo"
+
+[[privacy]]
+title = "Un rettangolo nero non è un oscuramento, e qui non ne viene disegnato uno sopra niente."
+body = """
+
+      In quasi tutti i programmi che si offrono di oscurare una pagina &mdash; un
+      lettore di PDF, un elaboratore di testi, un programma di grafica &mdash; il
+      rettangolo è un oggetto salvato accanto al testo e non dentro di esso. Il
+      testo è ancora lì, nello stesso file, nello stesso punto, e selezionare
+      l'area e premere copia te lo restituisce. Quel modo di sbagliare ha
+      pubblicato atti giudiziari, rapporti dei servizi e, nel dicembre 2025, nomi
+      anneriti in una diffusione di massa di documenti del Dipartimento di
+      Giustizia statunitense che erano leggibili nel giro di poche ore. Questo
+      strumento cancella le lettere dalle istruzioni che disegnano la pagina. Non
+      c'è un rettangolo con qualcosa sotto, perché sotto non c'è niente."""
+
+[[privacy]]
+title = "Il file finito viene riaperto e cercato, qui, prima che ti venga offerto."
+body = """
+
+      Finché non succede, ogni affermazione qui sopra è questo strumento che si
+      corregge i compiti da solo. Quindi i byte che stanno per diventare il tuo
+      download vengono ripassati allo stesso lettore come se li avesse mandati uno
+      sconosciuto, ogni pagina viene riletta, ogni segnalibro, commento, campo di
+      modulo e proprietà del documento viene raccolto, e le parole che hai tolto
+      vengono cercate. Il conto sta nei risultati. Se è sopravvissuto qualcosa,
+      l'operazione viene dichiarata fallita e non c'è nessun download."""
+
+[[privacy]]
+title = "Le parole non escono mai dalla scheda, e non ne esce nemmeno la ricerca."
+body = """
+ La
+      Content-Security-Policy elenca ogni indirizzo che questa pagina può
+      contattare, e nemmeno uno appartiene a questo sito. Questo strumento non
+      aggiunge niente a quella lista: non ha una funzione di rete propria, nemmeno
+      facoltativa. Quello che scrivi nella casella di ricerca è una stringa
+      confrontata con del testo nella memoria di questa scheda, e non c'è nessun
+      posto dove l'uno o l'altro possano andare."""
+
+[[privacy]]
+title = "L'oscuramento è il lavoro che meno di tutti sopravvive a un caricamento."
+body = """
+
+      Quello che si oscura è il motivo per cui non va caricato. La dichiarazione di
+      un testimone, una lettera medica, un estratto conto che va a un padrone di
+      casa, un contratto con dentro il nome di un cliente che va a un altro
+      cliente. Consegnare quella roba al server di uno sconosciuto perché ne tolga
+      la parte privata vuol dire che la parte privata arriva per prima, intatta, ed
+      è quella la versione che loro si tengono. Questa pagina non ha un'altra
+      metà."""
+
+[[privacy]]
+title = "Quello che resta viene copiato intatto."
+body = """
+
+      Gli unici byte che cambiano in una pagina sono le istruzioni di scrittura del
+      testo di cui facevano parte le lettere tolte. Ogni altra istruzione, e ogni
+      font, immagine e linea a cui la pagina fa riferimento, viene copiata
+      esattamente come è arrivata &mdash; non viene ridisegnato, ricodificato o
+      riflusso niente. La larghezza di quello che è stato tolto viene misurata e
+      rimessa come un'istruzione di spaziatura, così il resto della riga resta dove
+      il documento lo aveva messo."""
+
+[[privacy]]
+title = "Non può togliere parole da una fotografia, e dice quali pagine sono."
+body = """
+
+      Una pagina scansionata è un'immagine. Le parole che ci stanno sopra sono
+      pixel, non testo, e qui dentro niente può toccarle. Se la scansione porta con
+      sé il livello invisibile e ricercabile che produce l'OCR di uno scanner,
+      questo strumento quel livello lo toglie &mdash; ed è quello che avrebbero
+      trovato una ricerca e una copia &mdash; e dice chiaramente sulla pagina che
+      l'immagine continua a mostrare le parole. Coprire quell'immagine è un altro
+      lavoro; l'<a href=\"../oscurare-immagine/\">oscuratore di immagini</a> è lo
+      strumento che riscrive i pixel."""
+
+[[privacy]]
+title = "Il documento smette di dire da dove viene."
+body = """
+
+      Le proprietà e il pacchetto XMP se ne vanno a ogni esecuzione: nessuna riga
+      di produttore, nessuna data di creazione, nessun autore, nessun titolo, e
+      nessuno dei blocchi privati che un programma di impaginazione si lascia
+      dietro. Un file alle cui pagine è stato tolto un nome e le cui proprietà
+      dicono ancora <code>bozza 3 transazione Rossi.docx</code> non è stato
+      oscurato, e non è una cosa da lasciare a una casella da spuntare."""
+
+[[privacy]]
+title = "I file cifrati vengono respinti invece che aperti."
+body = """
+
+      Un PDF con una password viene rifiutato, compreso quello che gli scanner
+      producono con la password vuota e che tecnicamente si aprirebbe. Togliere la
+      protezione a un documento è un lavoro diverso dal togliergli delle parole, e
+      farlo in silenzio sarebbe una cosa sorprendente da parte di uno strumento che
+      agisce per conto tuo."""
+
+[[privacy]]
+title = "Che cosa carica Google, e che cosa non gli viene dato."
+body = """
+ Gli script della
+      pubblicità e della misurazione arrivano da Google. A nessuno dei due viene
+      passato niente del tuo documento: non un file, non una pagina, non un nome,
+      una dimensione, un numero di pagine o una parola che hai cercato. Ogni riga
+      che legge, modifica o scrive un PDF è servita da questa origine ed è elencata
+      nel repository."""
+
+[[privacy]]
+title = "Che cosa carica il pulsante delle donazioni, e che cosa non gli viene dato."
+body = """
+
+      Il pulsante &laquo;Buy me a coffee&raquo; in cima è disegnato da uno script di
+      cdnjs.buymeacoffee.com e prende i caratteri da Google Fonts. È un link e
+      niente di più: non segnala nessuna visita e non gli viene passato niente su di
+      te o sui tuoi documenti. Non succede nulla se non lo clicchi, e quello a cui
+      arriveresti cliccando è il sito di qualcun altro."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e tutto quello che c'è su questa
+      pagina continua a funzionare. È la prova più semplice di tutte: uno strumento
+      che mandasse via il tuo documento per farlo oscurare altrove si
+      fermerebbe."""
+
+[[howto]]
+title = "Scegli il PDF."
+body = """
+ Un documento per volta, apposta:
+      l'oscuramento è un lavoro che va guardato pagina per pagina, e uno strumento
+      che ti lasciasse spuntare delle parole in un file e le applicasse in silenzio
+      a un altro è esattamente il modo in cui parte la cosa sbagliata. Viene letto
+      direttamente dal tuo disco dal browser."""
+
+[[howto]]
+title = "Di' che cosa deve sparire."
+body = """
+ Scrivi le parole &mdash; un
+      nome, un indirizzo, un riferimento &mdash; e ogni punto in cui compaiono
+      viene elencato con la riga su cui si trova e una casella da spuntare. I
+      cercatori accanto alla casella cercano indirizzi email, numeri di carta,
+      IBAN, codici fiscali e numeri di previdenza, e numeri di telefono. Vengono
+      proposti, mai spuntati per te: uno schema non sa distinguere un numero di
+      telefono da un riferimento."""
+
+[[howto]]
+title = "Leggi la pagina e prendi le parole da lì."
+body = """
+
+      Il pannello mostra il testo del documento come è davvero conservato,
+      nell'ordine in cui lo copierebbe un lettore. Clicca una parola qualsiasi per
+      toglierla e ricliccala per tenerla. Tutto quello che è barrato è quello che
+      sparirà &mdash; il che rende questa la revisione oltre che la selezione, ed è
+      una cosa che vale la pena fare su ogni pagina prima di premere il
+      pulsante."""
+
+[[howto]]
+title = "Toglile, e leggi la riga che dice che è stato verificato."
+body = """
+
+      Le lettere vengono cancellate, il vuoto che hanno lasciato viene tenuto
+      aperto, ci viene disegnato sopra un rettangolo nero se lo hai chiesto, e le
+      stesse parole vengono tolte dai segnalibri, dai commenti, dai campi dei
+      moduli e dalle proprietà del documento. Poi il file finito viene riaperto qui
+      e cercato. Se una parola che hai tolto si trova ancora, non ottieni nessun
+      download e un messaggio che te lo dice."""
+
+[[faq]]
+q = "In che cosa è diverso dal disegnare un rettangolo nero in un lettore di PDF?"
+a = """
+        Un rettangolo disegnato in un lettore è un'annotazione: un oggetto con una
+        posizione, salvato accanto alla pagina. Il testo che ci sta sotto è
+        intatto. Chiunque selezioni quell'area e prema copia, o apra il file in un
+        altro programma, o ci passi sopra un qualsiasi estrattore di testo, si
+        riprende le parole. Certi lettori offrono un comando &laquo;oscura&raquo;
+        che la rimozione la applica davvero &mdash; e parecchi offrono solo il
+        disegno. Questo strumento non ha nessun rettangolo da spostare: le lettere
+        vengono tagliate via dalle istruzioni di disegno della pagina, e il
+        rettangolo nero, se lo lasci acceso, viene disegnato dopo sopra un vuoto
+        che è già vuoto."""
+
+[[faq]]
+q = "Come faccio a sapere che le parole sono sparite davvero?"
+a = """
+        Perché lo strumento controlla, sulla tua macchina, e ti mostra il conto.
+        Quando il file è stato scritto viene riaperto dallo stesso lettore che sta
+        in questa pagina, ogni pagina viene riletta, ogni segnalibro, commento,
+        campo di modulo e proprietà viene raccolto, e ogni parola che hai tolto
+        viene cercata. La riga dei risultati dice quante ce n'erano e quante ne
+        restano. Se la risposta non è quella che dovrebbe essere, l'operazione
+        fallisce e non viene offerto niente da scaricare. Puoi anche controllare da
+        te, dopo, in un lettore qualsiasi: premi Ctrl+F e cerca la parola."""
+
+[[faq]]
+q = "Il resto della pagina si sposta quando si toglie una parola?"
+a = """
+        No. Il testo viene disegnato facendo avanzare una penna lungo la pagina,
+        quindi cancellare cinque lettere tirerebbe normalmente il resto della riga
+        indietro di cinque lettere. La larghezza esatta di quello che è stato tolto
+        viene misurata sulle metriche del font stesso e rimessa come un'istruzione
+        di spaziatura, che sposta la penna senza disegnare niente. Le colonne
+        restano allineate e i totali restano sotto le loro intestazioni."""
+
+[[faq]]
+q = "Può oscurare un documento scansionato?"
+a = """
+        Non l'immagine, e lo dice invece di fare finta. Una scansione è la
+        fotografia di una pagina: le parole sono pixel e non c'è testo da togliere.
+        Quello che una scansione spesso porta con sé è un livello di testo
+        invisibile che l'OCR dello scanner ha scritto sopra l'immagine perché la
+        pagina si possa cercare &mdash; questo strumento quel livello lo trova, ne
+        toglie quello che scegli, e ti dice sulla pagina che l'immagine è rimasta
+        com'era. Così una ricerca e una copia smettono di trovare la parola, e una
+        persona che guarda la pagina continua a leggerla. Per un'immagine, è
+        l'<a href=\"../oscurare-immagine/\">oscuratore di immagini</a> a riscrivere
+        i pixel stessi."""
+
+[[faq]]
+q = "E le parti di un documento che non stanno su una pagina?"
+a = """
+        Vengono gestite, perché sono il punto da cui di solito un oscuramento
+        perde. Le stesse parole vengono tolte dai segnalibri, dai commenti e dalle
+        note adesive, da quello che è stato scritto nei campi dei moduli, dal testo
+        che viene dato a un lettore di schermo, e dal testo di sostituzione che un
+        lettore copia <em>al posto</em> delle lettere sulla pagina &mdash;
+        quest'ultimo esiste perché le legature e le parole spezzate a fine riga si
+        copino come si deve, e può contenere una frase intera. Le proprietà del
+        documento e il pacchetto XMP vengono rimossi del tutto. Gli allegati e
+        qualunque cosa parta all'apertura del file vengono buttati via, perché in
+        nessuno dei due si possono cercare le parole che stai togliendo."""
+
+[[faq]]
+q = "I miei documenti vengono caricati da qualche parte?"
+a = """
+        No. Il file viene letto, modificato e scritto dal tuo browser sul tuo
+        hardware. Questo strumento non ha un lato server, e la
+        <code>Content-Security-Policy</code> della pagina elenca ogni indirizzo che
+        può contattare &mdash; nessuno dei quali appartiene a questo sito. Quello
+        che scrivi nella casella di ricerca viene confrontato con del testo nella
+        memoria di questa scheda e non va da nessuna parte nemmeno lui."""
+
+[[faq]]
+q = "Perché non posso trascinare un riquadro sulla pagina come negli altri strumenti?"
+a = """
+        Perché disegnare una pagina vuol dire un motore di rendering PDF completo
+        &mdash; font, sfumature, trasparenza, modalità di fusione &mdash; che è un
+        megabyte o più di motore da scaricare e far girare, e questo sito non ne
+        spedisce nessuno. Il che si scopre essere adatto al lavoro: trascinare un
+        rettangolo seleziona un'<em>area di carta</em>, e un'area di carta non è la
+        stessa cosa del testo che ci sta sotto, ed è così che comincia il fallimento
+        del rettangolo nero. Quello che ottieni invece è il testo del documento,
+        nell'ordine di lettura, con ogni parola cliccabile. Ed è anche l'unica vista
+        capace di dirti quello che un'immagine della pagina non può: se le parole
+        che hai davanti siano testo o no."""
+
+[[faq]]
+q = "Il file finito si aprirà dappertutto?"
+a = """
+        Sì. Il risultato viene scritto come PDF 1.5, o la versione più alta di cui
+        aveva bisogno il file che gli hai dato, e la 1.5 la capisce ogni lettore
+        uscito dal 2003 in poi. Sulla pagina non viene ricodificato niente: i font,
+        le immagini e il disegno vettoriale passano byte per byte, quindi quello che
+        resta del testo resta selezionabile e ricercabile esattamente com'era."""
+
+[[faq]]
+q = "Può aprire un PDF protetto da password?"
+a = """
+        No, ed è voluto. Un documento cifrato viene rifiutato con un messaggio che
+        lo dice, anche quando la password è vuota &mdash; che è il modo in cui
+        salvano parecchi scanner e fotocopiatrici. Togliere la protezione a un file
+        è un lavoro diverso dal togliergli delle parole, e uno strumento che lo
+        facesse in silenzio starebbe facendo una cosa che non hai chiesto."""
+
+[[faq]]
+q = "C'è un limite di dimensione, e costa qualcosa?"
+a = """
+        Nello strumento non c'è nessun limite scritto. Il limite è la tua macchina:
+        il documento viene tenuto in memoria mentre ci si lavora, quindi un portatile
+        regge qualche centinaio di megabyte senza lamentarsi e comincia a faticare da
+        lì in su. È gratis, non c'è un account, non c'è un accesso e non c'è una
+        prova. Il sito ospita pubblicità, ed è quella che lo paga; agli inserzionisti
+        non viene dato niente dei tuoi documenti."""
+
+[[faq]]
+q = "Funziona offline?"
+a = """
+        Sì. Carica la pagina una volta, poi stacca la rete e continua a funzionare.
+        È anche il modo più semplice per dimostrare che non viene caricato niente:
+        uno strumento che mandasse via il tuo documento per farlo oscurare altrove
+        si fermerebbe nell'istante in cui stacchi la spina."""
+
+[schema]
+description = "Oscura un PDF nel browser cancellando il testo invece di coprirlo. Le lettere vengono tolte dal content stream della pagina, il file finito viene riaperto e cercato per dimostrare che non ci sono più, e non viene caricato niente."
+features = [
+  "Cancella le lettere dalla pagina invece di disegnarci sopra un rettangolo",
+  "Riapre il file finito e ci cerca dentro per dimostrare che le parole sono sparite",
+  "Trova ogni occorrenza di una parola, oppure cerca email, numeri di carta, IBAN e codici identificativi nazionali",
+  "Mostra il testo del documento nell'ordine di lettura, così ogni parola è cliccabile",
+  "Toglie le stesse parole da segnalibri, commenti, campi dei moduli e proprietà",
+  "Tiene aperto il vuoto perché il resto della riga non si sposti",
+  "Dice quali pagine sono scansioni, dove non c'è testo da togliere",
+  "Funziona offline; nessun caricamento, nessun account, nessun limite di dimensione",
+]
+
+[picker]
+title = "Trascina qui il tuo PDF"
+hint = "oppure clicca per sfogliare &mdash; un documento per volta"

--- a/locales/it/tools/stack-images.html
+++ b/locales/it/tools/stack-images.html
@@ -1,0 +1,241 @@
+<!--
+  tools/stack-images/body.html, in Italian.
+
+  Every id, class, option value, data-phrase key and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language. Only
+  the words change. The #faq-raw anchor is a link target from the note in step
+  one, so it stays as it is.
+-->
+<main>
+  <!-- Passo 1 &mdash; i fotogrammi -->
+  <section class="card">
+    <h2><span class="step">1</span> Scegli i fotogrammi</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p class="note">
+      I file RAW vengono aperti leggendo il JPEG a piena risoluzione che la
+      fotocamera ci ha già scritto dentro: qualche kilobyte di directory e poi una
+      fetta. I dati del sensore non vengono decodificati mai, quindi un fotogramma
+      da 60&nbsp;MB si apre più o meno alla velocità di un JPEG.
+      <a href="#faq-raw">Che cosa vuol dire per il risultato</a>.
+    </p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="sort-name" class="ghost">Ordina per nome</button>
+        <button type="button" id="clear-all" class="ghost danger">Togli tutti</button>
+      </div>
+    </div>
+
+    <ul id="frame-list" class="frame-list"></ul>
+  </section>
+
+  <!-- Passo 2 &mdash; come si mettono insieme -->
+  <section class="card">
+    <h2><span class="step">2</span> Come si mettono insieme</h2>
+
+    <div class="settings">
+      <div class="field field-wide">
+        <label for="mode">Metodo</label>
+        <select id="mode">
+          <option value="mean" selected>Media &mdash; abbassare il rumore</option>
+          <option value="median">Mediana &mdash; togliere persone e macchine di passaggio</option>
+          <option value="sigma">Sigma clipping &mdash; tutte e due le cose insieme</option>
+          <option value="max">Schiarisci &mdash; scie stellari, fuochi d'artificio, light painting</option>
+          <option value="min">Scurisci &mdash; togliere tutto quello di luminoso che si è mosso</option>
+          <option value="sum">Somma &mdash; simulare una lunga esposizione</option>
+          <option value="focus">Focus stacking &mdash; tenere quello che era a fuoco</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="align">Allinea i fotogrammi</label>
+        <select id="align">
+          <option value="translate" selected>Sì &mdash; solo traslazione</option>
+          <option value="similarity">Sì &mdash; trasla, ruota e scala</option>
+          <option value="none">No &mdash; prendili esattamente come sono</option>
+        </select>
+        <p class="field-note" id="align-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="scale">Risoluzione di lavoro</label>
+        <select id="scale">
+          <option value="full" selected>Piena</option>
+          <option value="half">Metà &mdash; un quarto della memoria</option>
+          <option value="quarter">Un quarto &mdash; un sedicesimo</option>
+        </select>
+        <p class="field-note" id="scale-note"></p>
+      </div>
+
+      <div class="field" id="kappa-field" hidden>
+        <label for="kappa">Scarta oltre</label>
+        <div class="inline-pair">
+          <input type="range" id="kappa" min="0.5" max="4" step="0.1" value="2">
+          <output id="kappa-value" for="kappa">2.0&sigma;</output>
+        </div>
+        <p class="field-note">
+          Più basso scarta di più, e scarta insieme del dettaglio vero. Due
+          deviazioni standard sono il punto di partenza solito.
+        </p>
+      </div>
+
+      <div class="field" id="radius-field" hidden>
+        <label for="radius">La nitidezza viene misurata su</label>
+        <div class="inline-pair">
+          <input type="range" id="radius" min="1" max="12" step="1" value="3">
+          <output id="radius-value" for="radius">3 px</output>
+        </div>
+        <p class="field-note">
+          Più grande prende intere zone da un fotogramma; più piccolo segue i
+          dettagli fini e può scompigliare uno sfondo liscio da un fotogramma
+          all'altro.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="gain">Esposizione</label>
+        <div class="inline-pair">
+          <input type="range" id="gain" min="0.1" max="4" step="0.05" value="1">
+          <output id="gain-value" for="gain">1.00&times;</output>
+        </div>
+        <p class="field-note" id="gain-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="format">Salva come</label>
+        <select id="format">
+          <option value="png" selected>PNG &mdash; senza perdite</option>
+          <option value="jpeg">JPEG &mdash; file più piccolo</option>
+        </select>
+        <div id="quality-row" class="inline-pair" hidden>
+          <input type="range" id="quality" min="0.5" max="1" step="0.01" value="0.92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+    </div>
+
+    <!--
+      What the run will cost, worked out before it starts. Every figure here is
+      an answer from src/plan.js rather than an estimate, which is why they are
+      shown at all: a median of twenty large frames is a genuinely different
+      proposition from an average of them, and that should be visible before
+      the button is pressed rather than afterwards.
+    -->
+    <dl class="plan" id="plan" hidden>
+      <div><dt>Risultato</dt><dd id="plan-output">&mdash;</dd></div>
+      <div><dt>Memoria di lavoro</dt><dd id="plan-memory">&mdash;</dd></div>
+      <div><dt>Decodifiche</dt><dd id="plan-decodes">&mdash;</dd></div>
+      <div><dt>Letto dal disco</dt><dd id="plan-read">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-warning" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 3 &mdash; farlo partire -->
+  <section class="card">
+    <h2><span class="step">3</span> Impila</h2>
+
+    <div class="export-row">
+      <button type="button" id="run" class="primary" disabled>Impila le immagini</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame">
+        <img id="result-image" alt="Il risultato impilato">
+      </div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <p id="result-moves" class="field-note"></p>
+        <a id="download" class="primary as-button" download>Scarica l'immagine</a>
+      </div>
+    </div>
+  </section>
+
+  <!--
+    Every sentence this tool's JavaScript puts on screen, kept out of the
+    JavaScript so that a translator can reach it. src/ is copied byte for byte
+    into all eleven languages, so a string written in a module is English at ten
+    of them. See shared/js/phrases.js.
+
+    A {name} is filled in by the caller. Nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="count.one">1 fotogramma</span>
+    <span data-phrase="count.many">{count} fotogrammi</span>
+    <span data-phrase="count.none">Ancora nessun fotogramma</span>
+
+    <span data-phrase="frame.reference">Riferimento</span>
+    <span data-phrase="frame.make-reference">Prendi come riferimento</span>
+    <span data-phrase="frame.remove">Togli</span>
+    <span data-phrase="frame.size">{width} &times; {height}</span>
+    <span data-phrase="frame.raw">RAW &mdash; l'anteprima della fotocamera, {width} &times; {height}</span>
+    <span data-phrase="frame.raw-camera">{camera} &mdash; anteprima {width} &times; {height}</span>
+    <span data-phrase="frame.raw-unreadable">In questo file RAW non si è trovata nessuna anteprima</span>
+    <span data-phrase="frame.read">letti {read} su {total}</span>
+
+    <span data-phrase="mode.mean">Fa la media di ogni fotogramma. Il rumore casuale è troppo alto tante volte quante è troppo basso, quindi fare la media di {count} fotogrammi lo abbassa di circa {factor} volte. È il metodo per una serie tranquilla, ed è quello che un solo uccello di passaggio rovina.</span>
+    <span data-phrase="mode.median">Prende il valore centrale di ogni pixel. Tutto quello che c'era solo in una parte dei fotogrammi, un turista, una macchina, un aereo, sparisce. È l'unico metodo che deve tenere tutti i fotogrammi insieme, ed è per questo che qui sotto può essere diviso in bande.</span>
+    <span data-phrase="mode.sigma">Impara che cosa ogni pixel di solito è, e poi fa la media solo dei valori che ci vanno d'accordo. Il risultato della mediana con la riduzione del rumore della media. Legge i fotogrammi due volte.</span>
+    <span data-phrase="mode.max">Tiene il valore più chiaro che ogni pixel abbia mai avuto. È quello che trasforma una serie di brevi esposizioni in scie stellari e rimette insieme un fuoco d'artificio dai suoi stessi fotogrammi.</span>
+    <span data-phrase="mode.min">Tiene il valore più scuro che ogni pixel abbia mai avuto. Un pixel resta chiaro solo se era chiaro in ogni fotogramma, quindi se ne vanno riflessi, fari e gocce di pioggia illuminate.</span>
+    <span data-phrase="mode.sum">Somma i fotogrammi senza dividere: quello che avrebbe raccolto un'esposizione {count} volte più lunga. Va a fuoco, esattamente come ci andrebbe quell'esposizione. Recuperalo con il cursore dell'esposizione.</span>
+    <span data-phrase="mode.focus">Prende ogni parte dell'immagine dal fotogramma in cui era a fuoco. Fotografa un soggetto piccolo lungo la ghiera di messa a fuoco, e questo rimette insieme le parti nitide.</span>
+
+    <span data-phrase="align.translate">Trova di quanto era spostato ogni fotogramma e lo rimette indietro, con la precisione di frazioni di pixel. Corregge il tremolio a mano libera e la deriva del treppiede. La rotazione non la può correggere.</span>
+    <span data-phrase="align.similarity">Trova anche rotazione e scala. Costa una misurazione in più per fotogramma e non costa niente se i fotogrammi risultano dritti. La rotazione viene sempre recuperata solo entro mezzo giro.</span>
+    <span data-phrase="align.none">Impila i fotogrammi esattamente come arrivano. Giusto per un treppiede fisso o una serie a intervalli, sbagliato per qualsiasi cosa fatta a mano libera.</span>
+
+    <span data-phrase="scale.note">Ogni fotogramma viene decodificato a questa dimensione dal decoder del browser stesso, quindi un'impostazione più piccola è meno lavoro e non solo meno memoria.</span>
+    <span data-phrase="gain.note">Moltiplicato nel risultato proprio alla fine, dopo il calcolo e prima dell'arrotondamento.</span>
+    <span data-phrase="gain.sum-note">Sommare {count} fotogrammi andrà quasi di sicuro a fuoco. Abbassalo a circa {suggested} per vedere che cosa è stato raccolto.</span>
+
+    <span data-phrase="plan.output">{width} &times; {height}</span>
+    <span data-phrase="plan.memory">circa {mb} MB</span>
+    <span data-phrase="plan.decodes.simple">{count}, una per fotogramma</span>
+    <span data-phrase="plan.decodes.passes">{count} &mdash; ogni fotogramma, {passes} volte</span>
+    <span data-phrase="plan.decodes.banded">{count} &mdash; ogni fotogramma, una volta per ognuna delle {bands} bande</span>
+    <span data-phrase="plan.read">{read} su {total} sul disco</span>
+    <span data-phrase="plan.banded">Questo non entra in memoria in un pezzo solo, quindi l'immagine viene tagliata in {bands} bande e i fotogrammi vengono riletti per ognuna. Scegliere {suggested} ne farebbe un passaggio unico.</span>
+    <span data-phrase="plan.banded-anyway">Questo non entra in memoria in un pezzo solo, quindi l'immagine viene tagliata in {bands} bande e i fotogrammi vengono riletti per ognuna. Meno fotogrammi o una risoluzione di lavoro più piccola ne farebbero un passaggio unico.</span>
+
+    <span data-phrase="progress.open">Si sta guardando dentro {name}&hellip;</span>
+    <span data-phrase="progress.survey">Lettura di {name}&hellip;</span>
+    <span data-phrase="progress.measure">Si misura di quanto si è mosso {name}&hellip;</span>
+    <span data-phrase="progress.stack">Impilamento &mdash; letti {done} fotogrammi su {total}</span>
+    <span data-phrase="progress.stack-banded">Impilamento &mdash; banda {band} di {bands}, letti {done} fotogrammi su {total}</span>
+    <span data-phrase="progress.encode">Scrittura dell'immagine&hellip;</span>
+
+    <span data-phrase="result.info">{width} &times; {height}, {size} &mdash; {count} fotogrammi messi insieme in {seconds} secondi</span>
+    <span data-phrase="result.moves">Ogni fotogramma è stato misurato e spinto al suo posto.</span>
+    <span data-phrase="result.moves-some">{count} fotogrammi su {total} non si sono potuti misurare con sicurezza e sono rimasti dov'erano.</span>
+    <span data-phrase="result.moves-none">I fotogrammi sono stati impilati esattamente come sono arrivati.</span>
+    <span data-phrase="result.moves-clamped">{count} fotogrammi hanno segnalato una rotazione troppo grande per una serie, e sono stati corretti con la sola traslazione.</span>
+    <span data-phrase="result.cropped">Spostarli ha lasciato dei bordi che non tutti i fotogrammi raggiungevano, e quelli sono stati tagliati.</span>
+
+    <span data-phrase="error.no.files">Aggiungi prima almeno un'immagine.</span>
+    <span data-phrase="error.no.size">Nessuno di questi file si è potuto aprire come immagine.</span>
+    <span data-phrase="error.one.frame">Per impilare servono almeno due fotogrammi.</span>
+    <span data-phrase="error.unknown">Qualcosa è andato storto nell'impilamento. Se uno di questi file è particolare, prova a farlo da solo.</span>
+    <span data-phrase="error.memory">Il browser ha esaurito la memoria. Prova una risoluzione di lavoro più piccola o meno fotogrammi.</span>
+    <span data-phrase="error.unreadable">{name} non si è potuto aprire come immagine ed è rimasto fuori.</span>
+    <span data-phrase="error.busy">Aspetta che questa pila sia finita prima di aggiungere altri fotogrammi, oppure annullala.</span>
+  </div>
+</main>

--- a/locales/it/tools/stack-images.toml
+++ b/locales/it/tools/stack-images.toml
@@ -1,0 +1,337 @@
+#
+# Image Stacker - Italian.
+#
+# Overrides for tools/stack-images/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# I nomi dei metodi restano quelli che si trovano scritti nei manuali e nei
+# forum di fotografia in italiano: mediana, sigma clipping, focus stacking. Il
+# "RAW" non si traduce, e nemmeno le sigle dei formati.
+#
+
+name = "Impilatore di immagini"
+heading = "Impila&nbsp;immagini <span class=\"h1-kw\">&mdash; unisci una raffica, file RAW compresi</span>"
+tagline = "Venti fotogrammi in uno, senza venti caricamenti e senza un convertitore RAW."
+
+title = "Impilatore di immagini &mdash; media, mediana e focus stacking nel browser"
+description = "Unisci una raffica di fotografie in una sola: fanne la media per uccidere il rumore, prendi la mediana per togliere le persone da una scena, schiarisci per le scie stellari, oppure fai il focus stacking di una macro. Legge CR2, NEF, ARW, DNG, RAF e CR3 tirando fuori l'anteprima della fotocamera. Funziona interamente nel tuo browser."
+og_title = "Impila una raffica di fotografie, file RAW compresi"
+og_description = "Media, mediana, sigma clipping, schiarisci, scurisci, somma o focus stacking &mdash; con i fotogrammi prima allineati. I file RAW vengono aperti leggendo l'anteprima che la fotocamera ha già scritto, così un fotogramma da 60 MB si apre veloce come un JPEG. Non viene caricato niente."
+og_image_alt = "Impilatore di immagini - più fotogrammi uniti in uno, nel browser"
+
+pledge = """
+    Ogni fotogramma viene aperto, decodificato, allineato, combinato e scritto dal
+    tuo browser, sulla tua macchina. Una pila di venti file RAW da 60&nbsp;MB è
+    circa un gigabyte di fotografie, e non se ne sposta un byte: lo strumento non
+    ha nessuna funzione di rete, e i file vengono letti direttamente dal tuo disco
+    da un worker che non ha nessun posto dove mandare niente."""
+
+live_hint = """
+      Non fidarti sulla parola: apri gli strumenti di sviluppo, guarda la scheda
+      Rete e impila una cartella di file RAW. Non una richiesta porta con sé una
+      fotografia, una miniatura, un nome di file o un modello di fotocamera. Oppure
+      stacca la rete e impilali lo stesso &mdash; dello strumento non cambia
+      niente."""
+
+read_first = """
+, <code>src/raw.js</code> per come un file RAW
+      viene aperto leggendo kilobyte invece di megabyte, <code>src/stack.js</code>
+      per l'aritmetica di ogni metodo, e <code>src/plan.js</code> per sapere da
+      dove vengono le cifre di memoria e di decodifica mostrate sulla pagina
+      &mdash; sono le risposte di quel file, non delle stime."""
+
+howto_heading = "Come impilare una serie di fotografie nel browser"
+
+card = """
+            Unisci una raffica in un'immagine sola: fai la media per togliere il
+            rumore, prendi la mediana per perdere i passanti, o schiarisci per le
+            scie stellari. Legge i file RAW senza un convertitore."""
+
+[words]
+plural = "fotografie"
+choose = "delle fotografie"
+
+[[facts]]
+text = "Nessun caricamento"
+
+[[facts]]
+text = "Nessun account"
+
+[[facts]]
+text = "Nessuna filigrana"
+
+[[facts]]
+text = "Legge il RAW"
+
+[[facts]]
+text = "Funziona offline"
+
+[[facts]]
+text = "Codice aperto"
+
+[[privacy]]
+title = "Le tue fotografie non hanno nessun posto dove andare."
+body = """
+ La
+      Content-Security-Policy elenca ogni indirizzo che questa pagina può
+      contattare, e nemmeno uno appartiene a questo sito. Qui non c'è un endpoint
+      dove i tuoi file possano essere raccolti, e non c'è niente nel codice che li
+      manderebbe se ci fosse &mdash; nessun <code>fetch</code>, nessun
+      <code>XMLHttpRequest</code>, nessun <code>sendBeacon</code>, né in
+      <code>src/</code> né nel worker."""
+
+[[privacy]]
+title = "I file RAW vengono letti, non caricati &mdash; e letti appena."
+body = """
+ Un file RAW di una
+      fotocamera contiene già un JPEG a piena risoluzione che la fotocamera ha
+      prodotto nel momento dello scatto. Questo strumento lo trova percorrendo
+      qualche voce di directory e poi chiedendo una sola fetta, che su un file da
+      60&nbsp;MB di solito sta sotto il centinaio di kilobyte. La pagina ti mostra
+      quella cifra accanto alla dimensione dei tuoi file mentre lavori. I dati del
+      sensore non vengono letti mai."""
+
+[[privacy]]
+title = "Il lavoro succede in un Worker su questa macchina, non su un server."
+body = """
+ È l'unico
+      strumento qui dentro che ne usa uno, perché impilare è questione di minuti di
+      aritmetica e non di secondi, e una pagina congelata non può mostrare un
+      avanzamento né essere annullata. Un Worker è un secondo thread in questo
+      stesso browser &mdash; vedi <code>src/worker.js</code>. Gli vengono passati i
+      file stessi, cosa che non costa niente, perché il riferimento a un file non
+      sono i byte; e ha esattamente la stessa Content-Security-Policy della pagina,
+      vale a dire nessun posto dove mandarli."""
+
+[[privacy]]
+title = "Della serie non viene riferito niente da nessuna parte."
+body = """
+ Quanti fotogrammi hai
+      impilato, quale fotocamera li ha scritti, di quanto si era spostato ognuno,
+      quale metodo hai scelto e quanto ci è voluto restano nella memoria di questa
+      pagina finché non la chiudi. In questo repository non c'è un evento di
+      analytics personalizzato che ne porti un pezzo, e l'unica domanda che questo
+      sito fa dopo un download manda un pollice su o giù e il nome dello strumento,
+      niente altro."""
+
+[[privacy]]
+title = "Funziona offline."
+body = """
+ Stacca la rete e lo strumento è identico,
+      perché un passaggio di rete non c'è mai stato. Il worker e ogni modulo che
+      carica sono messi in cache dal service worker di questa pagina, quindi una
+      copia installata impila file RAW con la rete staccata."""
+
+[[howto]]
+title = "Scegli i fotogrammi."
+body = """
+ Una raffica, una serie a forcella,
+      una sequenza da intervallometro, o una cartella di file RAW. Ognuno viene
+      aperto man mano che arriva e la sua riga ti dice che cosa ne è venuto fuori
+      &mdash; per un file RAW, la fotocamera, la dimensione dell'anteprima trovata
+      dentro, e quanto poco del file si è dovuto leggere per trovarla."""
+
+[[howto]]
+title = "Scegli il metodo in base a quello che stai cercando di perdere."
+body = """
+ Rumore:
+      media, oppure sigma clipping se qualcosa si è mosso. Persone, macchine o un
+      aereo di passaggio: mediana. Un cielo scuro che vuoi trasformare in scie
+      stellari: schiarisci. Una macro scattata lungo la ghiera di messa a fuoco:
+      focus stacking. La nota sotto il menù dice che cosa fa ognuno di questi al
+      tuo particolare numero di fotogrammi."""
+
+[[howto]]
+title = "Decidi se i fotogrammi vanno allineati."
+body = """
+ A mano libera: sì,
+      solo traslazione. A mano libera e stavi anche ruotando: traslazione,
+      rotazione e scala. Treppiede bloccato o intervallometro: no, e sarà più
+      veloce. Ogni fotogramma viene misurato rispetto al primo dell'elenco, ed è
+      per questo che qualsiasi fotogramma può essere promosso a primo."""
+
+[[howto]]
+title = "Leggi le quattro cifre, poi premi il pulsante."
+body = """
+ Prima che parta
+      qualsiasi cosa, la pagina dice quanto sarà grande il risultato, più o meno
+      quanta memoria prenderà, quante volte i fotogrammi verranno decodificati e
+      quanto dei tuoi file è stato letto. Se la serie non entra in memoria in un
+      pezzo solo lo dice, e dice quale risoluzione di lavoro lo
+      sistemerebbe."""
+
+[[faq]]
+q = "Le mie fotografie vengono caricate da qualche parte?"
+a = """
+        No. Ogni fotogramma viene aperto, decodificato, allineato, impilato e
+        scritto dal tuo browser sul tuo hardware. Questo strumento non ha nessuna
+        funzione di rete &mdash; non va mai a prendere niente e non manda mai niente
+        &mdash; e la <code>Content-Security-Policy</code> della pagina elenca ogni
+        indirizzo che può contattare, nessuno dei quali appartiene a questo sito.
+        Carica la pagina una volta, stacca la rete, e continua a funzionare. Qui
+        conta più che nella maggior parte degli strumenti semplicemente per una
+        questione di volume: una pila di venti fotogrammi RAW è circa un gigabyte, e
+        caricare un gigabyte di fotografie per farne fare la media è esattamente la
+        cosa che questo strumento esiste per evitare."""
+
+[[faq]]
+q = "Quali formati RAW riesce a leggere, e come?"
+a = """
+        <span id="faq-raw"></span>CR2, CR3, NEF, NRW, ARW, SR2, SRF, DNG, ORF, RAF,
+        RW2, PEF, SRW, 3FR, IIQ, DCR, KDC, MRW, MEF, RWL e qualcun altro &mdash; che
+        è quasi tutto quello che scrivono le fotocamere. Quello che ne legge è
+        l'anteprima JPEG a piena risoluzione che la fotocamera stessa ha prodotto nel
+        momento dello scatto: l'immagine sul retro della fotocamera, e quella che il
+        tuo sistema operativo disegna come miniatura. Viene trovata percorrendo la
+        struttura di directory del file, il che costa qualche lettura da pochi
+        kilobyte l'una, e poi prendendo una sola fetta. <strong>Non è un demosaicing
+        dei dati del sensore.</strong> Il risultato si porta dietro il bilanciamento
+        del bianco e lo stile immagine della fotocamera a otto bit per canale, invece
+        dei dodici o quattordici bit di dati lineari del sensore che ti darebbe un
+        convertitore RAW."""
+
+[[faq]]
+q = "E allora perché non decodificare per bene i dati del sensore?"
+a = """
+        Perché vorrebbe dire incorporare LibRaw o dcraw &mdash; un secondo motore da
+        decine di megabyte, per una sola famiglia di formati, fatto per la maggior
+        parte di schemi di compressione diversi per ogni produttore. Quel baratto è
+        discusso in <code>docs/what-can-be-built-here.md</code> nel sorgente di
+        questo sito, dove il RAW delle fotocamere sta nella lista delle cose escluse
+        da prima che questo strumento esistesse. Quello che è cambiato non è la
+        risposta a quella domanda, ma la scoperta che per impilare non serve: le
+        anteprime sono a piena risoluzione, sono quello che la fotocamera ti avrebbe
+        dato comunque come JPEG, e leggerle è circa cento volte più veloce di quanto
+        sarebbe il demosaicing. Se vuoi i dati del sensore, sviluppa prima i
+        fotogrammi in un convertitore RAW e impila i TIFF o i JPEG che produce
+        &mdash; questo strumento prende anche quelli."""
+
+[[faq]]
+q = "Quanti fotogrammi regge, e quanto grandi?"
+a = """
+        Sei metodi su sette lavorano in flusso: tengono un solo accumulatore e
+        leggono ogni fotogramma esattamente una volta, quindi cento fotogrammi
+        costano la stessa memoria di due e l'unica cosa che cresce è il tempo. La
+        mediana è l'eccezione, perché il valore centrale di un insieme non si può
+        sapere finché non lo hai tutto, quindi tiene tutti i fotogrammi insieme
+        &mdash; venti fotogrammi da 24 megapixel sono circa 1,4&nbsp;GB, che nessun
+        browser ti concede. Quando succede, l'immagine viene tagliata in bande
+        orizzontali e impilata una banda per volta, il che costa rileggere i
+        fotogrammi per ogni banda. La pagina calcola tutto questo prima che tu prema
+        il pulsante e ti mostra il numero, così un'esecuzione lenta non è mai una
+        sorpresa."""
+
+[[faq]]
+q = "Che cosa fa davvero l'allineamento dei fotogrammi?"
+a = """
+        Trova di quanto si è spostato ogni fotogramma rispetto al primo e lo rimette
+        a posto, con la precisione di una frazione di pixel. Il metodo è la
+        correlazione di fase: lo spostamento tra due immagini compare come una
+        differenza di fase tra i loro spettri, quindi una trasformata di Fourier per
+        ciascuna trova uno scarto di duecento pixel al prezzo di uno da due pixel. La
+        seconda impostazione ricava anche rotazione e scala, con lo stesso trucco
+        applicato allo spettro in coordinate log-polari. È tutto globale &mdash; una
+        traslazione, un angolo, una scala per tutto il fotogramma &mdash; quindi
+        corregge una fotocamera che si è mossa e non può correggere un soggetto che
+        si è mosso, né una fotografia scattata un passo più a sinistra. Una
+        conseguenza visibile: un fotogramma spostato di venti pixel a sinistra non
+        arriva più al bordo destro, quindi il risultato viene tagliato alla parte che
+        tutti i fotogrammi coprono. È per questo che una pila allineata torna
+        indietro appena appena più piccola dei fotogrammi che ci sono entrati, ed è
+        l'unica alternativa a un bordo scuro fatto dei fotogrammi che lì non
+        c'erano."""
+
+[[faq]]
+q = "Quale metodo dovrei usare?"
+a = """
+        <strong>Media</strong> per il rumore, su una serie in cui non si è mosso
+        niente: taglia il rumore casuale di circa la radice quadrata del numero di
+        fotogrammi. <strong>Mediana</strong> per togliere le cose che c'erano solo
+        una parte del tempo &mdash; l'uso classico è fotografare una piazza affollata
+        una dozzina di volte e ottenerla vuota. <strong>Sigma clipping</strong>
+        quando vuoi tutte e due le cose: impara che cosa un pixel di solito è e fa la
+        media solo dei valori che vanno d'accordo, quindi ha l'immunità della mediana
+        a una macchina di passaggio e la riduzione del rumore della media.
+        <strong>Schiarisci</strong> per scie stellari, fuochi d'artificio e light
+        painting. <strong>Scurisci</strong> per togliere qualsiasi cosa luminosa si
+        sia mossa. <strong>Somma</strong> per simulare una sola lunga esposizione.
+        <strong>Focus stacking</strong> per una macro scattata lungo la ghiera di
+        messa a fuoco."""
+
+[[faq]]
+q = "Perché il mio risultato è a otto bit se i miei file RAW sono a quattordici?"
+a = """
+        Perché quello che viene impilato è l'anteprima della fotocamera, che è un
+        JPEG. Vale la pena dire che impilare recupera una parte di quello che questo
+        costa: fare la media di sedici fotogrammi a otto bit dà un risultato con
+        gradazioni davvero più fini di quelle che aveva ognuno di loro, perché è
+        proprio il rumore che rendeva diverso l'arrotondamento di ogni fotogramma a
+        permettere alla media di cadere tra un livello e l'altro. Qui l'aritmetica è
+        fatta in virgola mobile e arrotondata una volta sola alla fine, quindi in
+        mezzo non se ne butta via niente. Non è comunque la stessa cosa che impilare
+        dati lineari di sensore, e questo strumento non fa finta del contrario."""
+
+[[faq]]
+q = "Posso impilare fotogrammi di dimensioni diverse, o di fotocamere diverse?"
+a = """
+        Sì, anche se di solito è un errore e vale la pena controllare di averlo
+        voluto. Il risultato ha la dimensione del fotogramma più grande, e ogni altro
+        fotogramma viene scalato per entrarci e centrato dentro. Mescolare fotocamere
+        mescola anche la resa del colore, quindi la media delle due è la media di due
+        interpretazioni diverse della stessa luce. Dove aiuta davvero è una serie
+        scattata a due risoluzioni, o un file RAW e un JPEG dello stesso
+        fotogramma."""
+
+[[faq]]
+q = "Dice che l'esecuzione sarà a bande. Che cosa vuol dire?"
+a = """
+        Che la memoria di lavoro di cui il metodo ha bisogno è più di quella che lo
+        strumento è disposto ad allocare in una volta sola, quindi l'immagine verrà
+        tagliata in strisce orizzontali e impilata una striscia per volta. Produce
+        comunque esattamente lo stesso risultato; semplicemente rilegge i fotogrammi
+        per ogni striscia, quindi ci mette di più, e la pagina ti dice quante
+        decodifiche saranno. Abbassare di un passo la risoluzione di lavoro divide
+        per quattro la memoria, il che quasi sempre trasforma un'esecuzione a bande
+        in un passaggio unico &mdash; la nota dice quale impostazione lo
+        farebbe."""
+
+[[faq]]
+q = "Perché questo strumento usa un Worker e nessuno degli altri lo fa?"
+a = """
+        Perché è l'unico il cui lavoro si misura in minuti. Ogni altro strumento qui
+        fa qualcosa che prende un secondo o due, dove spostare il lavoro fuori dal
+        thread principale sarebbe cerimonia. Impilare venti fotogrammi grandi è
+        aritmetica compatta su centinaia di megabyte, e sul thread principale vuol
+        dire una pagina congelata: nessuna barra di avanzamento che si muove, un
+        pulsante Annulla che non risponde, e alla fine un browser che si offre di
+        chiudere la scheda. Il Worker è un secondo thread in questo stesso browser,
+        che esegue un file di questa stessa cartella, sotto questa stessa policy. Non
+        è un server e non è una funzione di rete."""
+
+[[faq]]
+q = "È gratis, e serve un account?"
+a = """
+        È gratis, e non c'è un account, né un accesso, né una prova, né una
+        filigrana. Non c'è nemmeno un limite a quanti fotogrammi impili o a quanto
+        sono grandi, perché non c'è un server a pagarlo &mdash; il lavoro succede
+        sulla tua macchina e l'unico tetto è la tua memoria. Il sito ospita
+        pubblicità, ed è quella che lo paga; agli inserzionisti non viene dato niente
+        delle tue fotografie."""
+
+[schema]
+description = "Impila una raffica di fotografie nel browser: media, mediana, media con sigma clipping, schiarisci, scurisci, somma o focus stacking, con i fotogrammi prima allineati per correlazione di fase. Legge i file RAW delle fotocamere estraendo l'anteprima a piena risoluzione che la fotocamera ha incorporato, quindi non serve un convertitore RAW. Non viene caricato niente."
+features = [
+  "Sette metodi di impilamento: media, mediana, media con sigma clipping, schiarisci, scurisci, somma e focus stacking",
+  "Legge CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2 e altri estraendo l'anteprima a piena risoluzione della fotocamera",
+  "Apre un file RAW da 60 MB leggendone circa un centinaio di kilobyte",
+  "Allineamento automatico: solo traslazione, oppure traslazione con rotazione e scala, oppure nessuno",
+  "Allineamento sotto il pixel per correlazione di fase, non cercando gli scarti a tentativi",
+  "Sei metodi su sette tengono un solo accumulatore, quindi cento fotogrammi costano la memoria di due",
+  "Costo di memoria e di decodifica calcolato e mostrato prima che l'esecuzione parta",
+  "Il lavoro gira in un Worker, così l'avanzamento si muove e Annulla risponde",
+  "In uscita PNG o JPEG; funziona offline; nessun caricamento, nessun account",
+]
+
+[picker]
+title = "Trascina qui i fotogrammi"
+hint = "oppure clicca per sfogliare &mdash; JPEG, PNG, WebP, TIFF e RAW delle fotocamere"


### PR DESCRIPTION
Four tools and four guides shipped after Italian was last brought level,
so a reader with the site set to Italian landed on English for the DICOM
viewer, the document scanner, the PDF redactor and image stacking, plus
the four guides beside them.

## What is here

- `locales/it/tools/` &mdash; `dicom-viewer`, `document-scanner`,
  `redact-pdf`, `stack-images`, each a `.toml` and a `.html`
- `locales/it/pages/guides/` &mdash; `open-a-dicom-file`, `redact-a-pdf`,
  `scan-a-document-with-your-phone`, `stack-photos-to-reduce-noise`
- eight new entries in `locales/it/locale.toml`, added to the two blocks
  that file already keeps separate rather than appended in a lump

## The slugs

They follow the rule the Italian table states at the top of itself: the
infinitive plus the bare noun, unaccented, because that is how the search
gets typed. `check_links` fails the build when a published locale page
links to a page that was not built, so `oscurare-un-pdf`,
`oscurare-un-immagine` and `e-sicuro-caricare-i-propri-file` are load
bearing rather than decorative.

`oscurare` is deliberately the same verb as the existing
`oscurare-immagine`. It is the one used in public records, and it carries
the distinction both redaction pages live on &mdash; the text comes out of
the file, it is not covered over. Reaching for `coprire` or `nascondere`
would have named exactly the failure those pages exist to warn about.

## Register

Read off the Italian pages already in the tree, not invented: `tu`
throughout, `il tuo browser` for the promise that nothing leaves the
machine, `strumento` for tool, `&laquo;&raquo;` for quotation. DICOM field
names keep their English and their numbers &mdash; Pixel Spacing
(0028,0030), Series Instance UID (0020,000E) &mdash; because that is how
they appear in the file and in the standard, and looking one up means
searching those exact words.

The `#phrases` blocks keep every `data-phrase` key and `{placeholder}`
byte for byte, checked with a script that diffs ids, classes, `for`,
`scope`, option values and placeholder sets against the English source.
The `count.*` pairs stay doubled, since Italian distinguishes singular
from plural.

## Verification

`python build.py --out _plain --clean --no-minify` exits 0 and Italian is
now **absent from the locale debt list**, which is how the build reports
65 of 65. No CRLF anywhere under `locales/it/`.

One of twelve branches closing the same eight-page hole, one language per
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
