### PR TITLE
Give Dutch the eight pages it was reading in English

### DIFF
--- a/locales/nl/locale.toml
+++ b/locales/nl/locale.toml
@@ -81,6 +81,16 @@ complete = true
 # "Scannen" is wat er getypt wordt; "lezen" is wat het programma doet.
 "qr-barcode-reader" = "qr-code-scannen"
 "hash-checksum" = "checksum-controleren"
+# DICOM blijft DICOM: dat staat er op het schijfje dat het ziekenhuis meegeeft,
+# en niemand zoekt het vertaald.
+"dicom-viewer" = "dicom-viewer"
+"document-scanner" = "documenten-scannen"
+# Hetzelfde werkwoord als bij de afbeelding, want het is dezelfde belofte: de
+# tekst gaat uit het bestand, er komt geen balk overheen.
+"redact-pdf" = "pdf-onleesbaar-maken"
+# "Stacken" is het leenwoord dat fotografen schrijven en zoeken; "stapelen"
+# gaat over doosjes.
+"stack-images" = "afbeeldingen-stacken"
 
 "guides" = "gidsen"
 "roadmap" = "roadmap"
@@ -113,6 +123,11 @@ complete = true
 "guides/trim-an-audio-file" = "gidsen/een-audiobestand-inkorten"
 "guides/whats-inside-a-gif" = "gidsen/wat-zit-er-in-een-gif"
 "guides/verify-a-file-checksum" = "gidsen/de-checksum-van-een-download-controleren"
+"guides/open-a-dicom-file" = "gidsen/een-dicom-bestand-openen"
+"guides/redact-a-pdf" = "gidsen/een-pdf-onleesbaar-maken"
+"guides/scan-a-document-with-your-phone" = "gidsen/een-document-scannen-met-je-telefoon"
+# Wie stackt zoekt niet op "stacken", maar op de ruis: dat is het probleem.
+"guides/stack-photos-to-reduce-noise" = "gidsen/fotos-stacken-tegen-ruis"
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/nl/pages/guides/open-a-dicom-file.html
+++ b/locales/nl/pages/guides/open-a-dicom-file.html
@@ -1,0 +1,255 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open de <a href="../../dicom-viewer/">DICOM-viewer</a> en sleep de hele map
+      met bestanden erop. Ze worden op je eigen machine gelezen, teruggezet in de
+      series waar ze uit komen, en gestapeld in de volgorde waarin het apparaat ze
+      heeft opgenomen. Er wordt niets ge&uuml;pload, en er wordt niets terug in je
+      bestanden geschreven.
+    </p>
+    <p>
+      Als je een schijfje hebt gekregen en je je afvraagt welk bestand je moet
+      openen: allemaal, tegelijk. Een CT of een MRI is niet &eacute;&eacute;n
+      bestand. Het is &eacute;&eacute;n bestand per coupe, en een
+      thoraxonderzoek zijn er driehonderd.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat er op een ziekenhuisschijfje staat</h2>
+    <p>
+      Meestal vier dingen, en maar &eacute;&eacute;n ervan doet ertoe.
+    </p>
+    <ul>
+      <li>
+        <strong>Een map met scans</strong>, vaak <code>DICOM</code>,
+        <code>IMAGES</code> of <code>ST0001</code> geheten, met bestanden die
+        <code>IM000001</code>, <code>I0000001</code> of een lang nummer met punten
+        heten. Vaak helemaal zonder extensie. Dit is de scan.
+      </li>
+      <li>
+        <strong>Een bestand dat <code>DICOMDIR</code> heet</strong>. Een index van
+        de rest, geschreven zodat een viewer de onderzoeken op het schijfje kan
+        opsommen zonder elk bestand te openen. Je hebt hem niet nodig.
+      </li>
+      <li>
+        <strong>Een viewer</strong>, als Windows-programma, als autorun-vermelding
+        of af en toe als Java-applet. Hij is gecompileerd voor wat er actueel was
+        toen het schijfje gebrand werd, en daarom draaien er zoveel niet meer.
+      </li>
+      <li>
+        <strong>Een HTML-pagina of een PDF</strong> met het logo van het ziekenhuis
+        erop, waarin uitgelegd wordt hoe je de viewer start.
+      </li>
+    </ul>
+    <p>
+      De scans hebben die viewer niet nodig. Het formaat is een gepubliceerde
+      standaard en de bestanden zijn op zichzelf leesbaar; het programma op het
+      schijfje is &eacute;&eacute;n programma dat ze zou kunnen lezen, niet het
+      enige.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom de bestanden geen extensie hebben</h2>
+    <p>
+      Omdat DICOM er geen nodig heeft. Elk bestand draagt zijn eigen markering: 128
+      bytes niets, dan de vier letters <code>DICM</code>, dan een klein blok velden
+      dat beschrijft hoe de rest van het bestand geschreven is. Een lezer
+      controleert op die vier letters en niet op een naam die op <code>.dcm</code>
+      eindigt.
+    </p>
+    <p>
+      Daarom verandert een bestand hernoemen naar <code>.dcm</code> ook niets, en
+      daarom is een viewer die op de extensie staat te hameren onnodig streng.
+      Bestanden die rechtstreeks van een ziekenhuisnetwerk geschreven zijn hebben
+      zelfs de 128 bytes en de markering niet &mdash; dat zijn de kale gegevens
+      zonder iets ervoor, en een lezer moet uit het eerste veld afleiden hoe ze
+      gecodeerd zijn. Dat is een normaal bestand, geen kapot bestand.
+    </p>
+  </section>
+
+  <section>
+    <h2>Venster en niveau, en dat is de knop die ertoe doet</h2>
+    <p>
+      Dit is het ene ding dat een medisch beeld anders maakt dan een foto, en de
+      reden dat een fotobewerker niet deugt om ernaar te kijken.
+    </p>
+    <p>
+      Een CT-coupe bevat zo'n vierduizend verschillende waarden. Je scherm laat
+      tweehonderdzesenvijftig grijstinten zien. Iets moet beslissen welke
+      vierduizend op welke tweehonderdzesenvijftig terechtkomen, en die beslissing
+      is het <strong>venster</strong>: alles eronder is zwart, alles erboven is
+      wit, en het bereik ertussen wordt over de grijstinten verdeeld.
+    </p>
+    <p>
+      Verschuif het venster en hetzelfde bestand lijkt een andere scan. Dat is geen
+      renderfout, dat is juist de bedoeling. Long en bot zitten allebei in de coupe
+      en zijn niet tegelijk te zien: een venster dat de structuur van een opgeblazen
+      long laat zien, zet elk bot op zuiver wit, en een venster dat het trabeculaire
+      detail in een rib laat zien, zet de hele long op zuiver zwart.
+    </p>
+    <p>
+      Op een CT zijn de getallen <strong>Hounsfield-eenheden</strong>, en die zijn
+      absoluut vastgelegd in plaats van per apparaat: water is 0 en lucht is
+      &minus;1000, per definitie, op elke CT-scanner ter wereld. Daarom kan een
+      viewer vensters met een naam aanbieden &mdash; long, bot, hersenen, zacht
+      weefsel &mdash; en betekenen die op jouw bestand hetzelfde als op het
+      werkstation waar de scan beoordeeld is. De gebruikelijke:
+    </p>
+    <ul>
+      <li><strong>Zacht weefsel</strong> &mdash; midden 40, breedte 400.</li>
+      <li><strong>Long</strong> &mdash; midden &minus;600, breedte 1500.</li>
+      <li><strong>Bot</strong> &mdash; midden 300, breedte 1500.</li>
+      <li><strong>Hersenen</strong> &mdash; midden 40, breedte 80. Een smal
+        venster, want grijze en witte stof verschillen maar een paar eenheden.</li>
+    </ul>
+    <p>
+      Op een MRI bestaat zo'n schaal niet. De waarden hangen af van de sequentie,
+      de spoel en het apparaat, dus er valt niets te vernoemen als preset en het
+      venster om mee te beginnen is het venster waar het bestand zelf om vraagt.
+      Elke scan draagt een suggestie mee.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom de coupes soms de verkeerde kant op schuiven</h2>
+    <p>
+      Een viewer moet beslissen in welke volgorde hij de bestanden zet, en er zijn
+      twee dingen in het bestand die hij zou kunnen gebruiken.
+    </p>
+    <p>
+      <strong>Instance Number</strong> is een teller. Het is de voor de hand
+      liggende keuze en hij wordt toegekend door wat de bestanden ook geschreven
+      heeft, en dat hoeft ze niet te nummeren in de richting waarin de
+      pati&euml;nt loopt. Een onderzoek dat van de voeten omhoog gereconstrueerd is
+      en van het hoofd omlaag genummerd, schuift achteruit, en een serie die uit
+      twee reconstructies is samengesteld kan de nummers ronduit herhalen.
+    </p>
+    <p>
+      <strong>Image Position (Patient)</strong> is waar de coupe fysiek ligt, in
+      millimeters, in een co&ouml;rdinatenstelsel dat aan de pati&euml;nt vastzit en
+      niet aan het apparaat. Daarop sorteren is goed, wat de nummering ook gedaan
+      heeft, en het heeft een nuttig neveneffect: zodra de coupes in fysieke
+      volgorde liggen, is de afstand ertussen meetbaar, dus een viewer kan je
+      vertellen dat de coupes 5&nbsp;mm uit elkaar liggen &mdash; en merken wanneer
+      er &eacute;&eacute;n ontbreekt, wat het bestand nooit zegt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Iets meten</h2>
+    <p>
+      Een scan is gemeten materiaal, dus een lengte erop is een echte lengte
+      &mdash; als het bestand zegt hoe ver zijn pixels uit elkaar liggen. Dat is
+      &eacute;&eacute;n veld, Pixel Spacing, in millimeters, en het staat op
+      vrijwel elke CT en MRI.
+    </p>
+    <p>
+      Het ontbreekt vaak op echobeelden, op gescande documenten en op
+      schermafbeeldingen die als DICOM zijn opgeslagen. Waar het ontbreekt is er
+      geen eerlijk antwoord in millimeters, en een viewer die er toch een geeft
+      heeft een schaal verzonnen. Een aantal pixels is het juiste antwoord op een
+      vraag die het bestand niet kan beantwoorden.
+    </p>
+    <p>
+      Let ook op pixels die niet vierkant zijn, wat buiten de CT normaal is. In
+      pixels meten en met &eacute;&eacute;n afstandsgetal vermenigvuldigen klopt
+      alleen waar de twee gelijk zijn; elke as moet met zijn eigen getal gemeten
+      worden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat een scan behalve het beeld meedraagt</h2>
+    <p>
+      Dit is het deel waarin mensen zich vergissen, en de reden om voorzichtig te
+      zijn met deze bestanden.
+    </p>
+    <p>
+      Een DICOM-bestand is geen plaatje met wat metagegevens eraan. Het is een
+      medisch dossier met een plaatje erin. De header is een lijst velden, en op
+      een gebruikelijke klinische scan bevat die:
+    </p>
+    <ul>
+      <li>de naam van de pati&euml;nt, het patientennummer, de geboortedatum en het
+        geslacht;</li>
+      <li>het aanvraagnummer, dat de sleutel is naar de aanvraag in het systeem van
+        het ziekenhuis;</li>
+      <li>de verwijzend arts, de laborant die het onderzoek uitvoerde, de radioloog
+        die het beoordeelde;</li>
+      <li>de instelling, het adres ervan en de afdeling;</li>
+      <li>de fabrikant van het apparaat, het model en het serienummer;</li>
+      <li>de datum en het tijdstip van de scan tot op de seconde;</li>
+      <li>en een reeks unieke identificatoren &mdash; onderzoek, serie, instantie
+        &mdash; die perfecte sleutels terug zijn naar het archief waar het bestand
+        vandaan komt.</li>
+    </ul>
+    <p>
+      Elk bestand dat je gekregen hebt draagt dat allemaal mee, en het reist met
+      het bestand mee waar het bestand ook heen gaat. De naam wissen is niet
+      genoeg: een geboortedatum, een instelling ter grootte van een postcode en een
+      scantijdstip wijzen ongeveer even goed &eacute;&eacute;n persoon aan als een
+      naam doet, en de onderzoeks-UID wijst hem precies aan voor iedereen met
+      toegang tot het archief.
+    </p>
+    <p>
+      Sommige apparaten bewaren ook een tweede kopie van de naam van de
+      pati&euml;nt in een priv&eacute;-veld, en dat is een veld waarvan de betekenis
+      nergens gepubliceerd is en waar de meeste anonimiseerders vanaf blijven,
+      omdat ze niet kunnen weten wat erin staat.
+    </p>
+  </section>
+
+  <section>
+    <h2>Upload de scan niet om ernaar te kijken</h2>
+    <p>
+      De gebruikelijke manier waarop dit probleem opgelost wordt is zoeken op
+      &bdquo;dicom viewer online&rdquo; en een uploadvak. Wat er dan net gebeurd is,
+      is dat een vreemde een kopie van een medisch dossier heeft: de pixels, de
+      naam, de geboortedatum, het patientennummer en de sleutel terug naar het
+      archief.
+    </p>
+    <p>
+      Daar is geen reden voor. Een DICOM-bestand lezen is een header ontleden en
+      wat gehele getallen uitpakken, en dat doet een browser prima, en daarom heeft
+      de <a href="../../dicom-viewer/">viewer hier</a> helemaal geen netwerkfunctie:
+      geen <code>fetch</code>, geen <code>XMLHttpRequest</code>, niets dat een
+      bestand zou kunnen versturen ook al probeerde iets het. Laad de pagina
+      &eacute;&eacute;n keer, verbreek de internetverbinding, en hij blijft scans
+      openen.
+    </p>
+    <p>
+      <a href="../is-bestanden-uploaden-veilig/">Is het veilig om bestanden naar
+      online omzetters te uploaden?</a> zet uiteen hoe je die bewering nakijkt, op
+      deze site of op een andere. Dit is het bestandstype waarbij dat het meest de
+      moeite waard is.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat een browser niet kan</h2>
+    <p>
+      Twee dingen, en over allebei is het de moeite waard om duidelijk te zijn.
+    </p>
+    <p>
+      <strong>Het is geen diagnostische viewer.</strong> Je scherm is niet
+      gekalibreerd, de browser is geen gevalideerde renderketen, en geen webpagina
+      heeft een regelgevingsbeoordeling doorlopen. Een scan lezen om een klinische
+      beslissing te nemen is werk voor het werkstation waarop hij beoordeeld is.
+      Kijken wat er op een schijfje staat, een coupe eruit halen voor een college of
+      een artikel, een header lezen, of uitzoeken waarom een ander programma het
+      bestand weigert, zijn allemaal prima redenen om er een in een browser te
+      openen.
+    </p>
+    <p>
+      <strong>Sommige gecomprimeerde scans decoderen niet.</strong> DICOM staat
+      verschillende compressieschema's toe en browsers implementeren er
+      &eacute;&eacute;n van. Gewone bestanden, run-length gecodeerde bestanden,
+      baseline JPEG en JPEG Lossless &mdash; en dat laatste gebruiken de meeste
+      ziekenhuisexports &mdash; gaan allemaal open. JPEG 2000, JPEG-LS en de
+      videoformaten vragen codecs die megabytes aan gecompileerde bibliotheek zijn.
+      Waar het beeld niet gedecodeerd kan worden is de header nog steeds volledig
+      leesbaar, en dat is meestal toch de helft waar je voor kwam.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/open-a-dicom-file.toml
+++ b/locales/nl/pages/guides/open-a-dicom-file.toml
@@ -1,0 +1,21 @@
+#
+# Gids: een DICOM-bestand openen - Dutch.
+#
+
+nav = "Een DICOM-bestand openen"
+title = "Hoe je een DICOM-bestand (.dcm) opent zonder iets te installeren"
+description = "Wat er op een ziekenhuisschijfje staat, waarom de bestanden geen extensie hebben, hoe je een .dcm-scan in een browser opent, wat venster en niveau nu eigenlijk doet, en wat een scan behalve het beeld over de pati&euml;nt meedraagt."
+
+heading = "Hoe je een DICOM-bestand opent, en wat erin zit"
+lede = """
+    Een ziekenhuisschijfje is een map met bestanden zonder extensie en een viewer
+    die voor Windows XP geschreven is. De bestanden zijn DICOM, en daar is niets
+    exotisch aan: een scan is een header vol velden en een blok pixels. Zo kijk je
+    ernaar, dit betekenen de knoppen, en dit draagt het bestand behalve het beeld
+    verder nog mee."""
+
+updated = "25 augustus 2026"
+
+og_title = "Hoe je een DICOM-bestand opent zonder iets te installeren"
+og_description = "Wat er op een ziekenhuisschijfje staat, waarom de bestanden geen extensie hebben, en wat een .dcm-scan behalve het beeld over de pati&euml;nt meedraagt."
+og_image_alt = "abox.tools - gereedschap dat nooit een server aanraakt"

--- a/locales/nl/pages/guides/redact-a-pdf.html
+++ b/locales/nl/pages/guides/redact-a-pdf.html
@@ -1,0 +1,240 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open <a href="../../pdf-onleesbaar-maken/">PDF onleesbaar maken</a>, sleep
+      het document erin, typ de woorden die weg moeten, vink aan welke je bedoelt,
+      en druk op &bdquo;Weghalen&rdquo;. De letters worden gewist uit de eigen
+      tekeninstructies van de pagina, dezelfde woorden worden uit de bladwijzers,
+      opmerkingen, formuliervakken en documenteigenschappen gehaald, en het klare
+      bestand wordt waar je bij staat opnieuw geopend en doorzocht voordat het je
+      aangeboden wordt.
+    </p>
+    <p>
+      Alles hieronder gaat over waarom die laatste zin de belangrijke is, en hoe je
+      kunt zien of het gereedschap dat je al gebruikt hetzelfde kan zeggen.
+    </p>
+  </section>
+
+  <section>
+    <h2>De fout waar dit over gaat</h2>
+    <p>
+      Teken een zwarte rechthoek over een naam in een PDF-lezer. Wat je ziet is een
+      naam met een zwarte rechthoek erover. Wat de meeste lezers
+      <em>opslaan</em> is een document dat de naam bevat en, apart daarvan, een
+      rechthoek met een positie, een formaat en een kleur.
+    </p>
+    <p>
+      Een rechthoek die zo getekend is, is een <strong>annotatie</strong>: een
+      object dat naast de pagina ligt in plaats van erin. De tekst eronder is
+      precies zoals hij was. Selecteer het gebied en druk op kopi&euml;ren, of haal
+      er een willekeurige tekstextractor overheen, of open het in een programma dat
+      annotaties anders tekent, en de naam komt terug. Niets op het scherm
+      onderscheidt dat van een echte onleesbaarmaking, en precies daarom blijft het
+      gebeuren bij organisaties die juristen in dienst hebben.
+    </p>
+    <p>
+      Het heeft rechtbankstukken, inlichtingenanalyses, contracten en &mdash; in
+      december 2025 &mdash; zwartgemaakte namen in een massale vrijgave van
+      documenten van het Amerikaanse ministerie van Justitie gepubliceerd, die
+      binnen enkele uren na publicatie leesbaar waren. Het patroon is altijd
+      hetzelfde. De rechthoek was de annotatie, en de annotatie was nooit de tekst.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat een echte onleesbaarmaking in plaats daarvan doet</h2>
+    <p>
+      Een pagina in een PDF is een lijst instructies: zet dit lettertype, verplaats
+      de pen hierheen, teken deze glyphen. De woorden op de pagina bestaan op
+      precies &eacute;&eacute;n plek, als de operanden van die tekeninstructies:
+    </p>
+    <pre><code>BT /F1 12 Tf 72 700 Td (Geachte heer Jansen) Tj ET</code></pre>
+    <p>
+      De naam onleesbaar maken betekent <strong>die letters uit die instructie
+      wissen</strong> en de pagina weer wegschrijven. Daarna valt er niets meer
+      terug te halen, niet omdat het bestand het goed verstopt maar omdat de
+      letters niet in het bestand staan. Er is geen rechthoek met iets eronder,
+      want er is niets eronder.
+    </p>
+    <p>
+      E&eacute;n ding moet teruggezet worden, anders is het resultaat zichtbaar
+      verkeerd. Tekst wordt getekend door een pen over de pagina te laten
+      opschuiven, dus vijf letters wissen trekt de rest van de regel vijf letters
+      naar links: kolommen lopen niet meer uit en totalen schuiven onder de
+      verkeerde koppen. Een gereedschap dat dit goed doet meet hoe ver de
+      weggehaalde letters de pen zouden hebben verplaatst en zet die afstand terug
+      als een afstandsinstructie, die de pen verplaatst zonder iets te tekenen.
+    </p>
+    <p>
+      De zwarte balk wordt, als hij er is, <em>daarna</em> getekend, over een gat
+      dat al leeg is. Het is een beleefdheid tegenover wie het document leest
+      &mdash; een teken dat er iets is weggehaald &mdash; en niet de
+      onleesbaarmaking. Dat is het hele onderscheid in &eacute;&eacute;n zin: bij
+      een echte onleesbaarmaking is de balk versiering; bij een valse
+      <em>is</em> de balk de onleesbaarmaking.
+    </p>
+  </section>
+
+  <section>
+    <h2>De vier plekken waar een woord zich verstopt die niet de pagina zijn</h2>
+    <p>
+      Dit is het deel dat mensen te grazen neemt die het eerste deel goed gedaan
+      hebben. Een PDF draagt tekst op meerdere plekken tegelijk, en een lezer toont,
+      doorzoekt of kopieert ze allemaal. Een naam van de pagina halen en hem in een
+      van deze laten staan, is hem niet weggehaald hebben.
+    </p>
+    <ul>
+      <li>
+        <strong>De documenteigenschappen.</strong> Titel, auteur, en de naam van
+        het bestand waaruit dit ge&euml;xporteerd is. Een document waaruit de
+        pagina's een naam is gehaald en waarvan de eigenschappen nog steeds
+        <code>Jansen schikking versie 3.docx</code> luiden, is niet onleesbaar
+        gemaakt. Meestal staat er een tweede kopie van dezelfde informatie in een
+        XMP-pakket, en dat moet er ook uit.
+      </li>
+      <li>
+        <strong>Bladwijzers.</strong> Het overzicht langs de zijkant van een lezer
+        is een lijst koppen met paginanummers eraan &mdash; en een kop is een regel
+        tekst waar niets op de pagina zeggenschap over heeft.
+      </li>
+      <li>
+        <strong>Formuliervakken en opmerkingen.</strong> Wat iemand in een formulier
+        getypt heeft wordt twee keer opgeslagen: &eacute;&eacute;n keer als de
+        waarde van het vak en &eacute;&eacute;n keer als de weergave die de lezer
+        tekent. Allebei moeten ze weg. Een plaknotitie draagt zijn tekst en de naam
+        van wie hem geschreven heeft.
+      </li>
+      <li>
+        <strong>De vervangtekst.</strong> Een PDF mag verklaren dat een reeks
+        glyphen iets anders &bdquo;spelt&rdquo;, zodat een ligatuur of een met een
+        koppelteken afgebroken regel kopieert als het woord waar hij voor staat.
+        Het betekent dat een document het ene kan tonen en een lezer bij Ctrl+C het
+        andere kan aanreiken, en een onleesbaarmaking die alleen weghaalde wat er
+        getekend was, zou de zin intact laten voor iedereen die de alinea
+        selecteert.
+      </li>
+    </ul>
+    <p>
+      Bijlagen zijn de vijfde. Een PDF kan hele andere bestanden in zich dragen, en
+      niets wat je met de pagina's doet raakt ze aan.
+    </p>
+  </section>
+
+  <section>
+    <h2>Hoe je een bestand nakijkt, in dertig seconden</h2>
+    <p>
+      Doe dit met alles wat je op het punt staat te versturen, welk gereedschap het
+      ook gemaakt heeft. Het is de controle die elk van de gepubliceerde fouten
+      gepakt zou hebben.
+    </p>
+    <ol>
+      <li>
+        <strong>Open het klare bestand en druk op Ctrl+F</strong> (Cmd+F op een
+        Mac). Zoek naar het woord dat je hebt weggehaald. Een echte
+        onleesbaarmaking geeft niets terug. Springt de lezer naar een zwarte
+        rechthoek, dan staat het woord er nog steeds in en ligt de rechthoek er
+        bovenop.
+      </li>
+      <li>
+        <strong>Selecteer het zwartgemaakte gebied en kopieer het.</strong> Sleep
+        over de rechthoek, druk op Ctrl+C, en plak in een tekstvak. Komt er iets
+        aan, dan heb je dezelfde fout van de andere kant gevonden.
+      </li>
+      <li>
+        <strong>Selecteer het hele document en kopieer dat.</strong> Ctrl+A en dan
+        Ctrl+C, plak in een willekeurige teksteditor, en lees wat eruit komt. Dit is
+        veruit de nuttigste van de drie, want het laat je het document zien zoals
+        een tekstextractor het ziet &mdash; inclusief tekst waarvan je niet wist dat
+        hij er was, wat op een gescande pagina gewoon is.
+      </li>
+      <li>
+        <strong>Kijk naar de eigenschappen</strong> &mdash; Bestand → Eigenschappen
+        in de meeste lezers &mdash; en naar het bladwijzerpaneel. Allebei zijn het
+        plekken waar een naam een pagina-perfecte onleesbaarmaking overleeft.
+      </li>
+    </ol>
+    <p>
+      <a href="../../pdf-onleesbaar-maken/">PDF onleesbaar maken</a> voert de eerste
+      en de derde daarvan voor je uit en laat het aantal zien, want een gereedschap
+      dat beweert iets weggehaald te hebben is geen bewijs, en een zoekopdracht in
+      het klare bestand wel.
+    </p>
+  </section>
+
+  <section>
+    <h2>Gescande documenten zijn een ander probleem</h2>
+    <p>
+      Een scan is een foto van een pagina. De woorden erop zijn pixels, geen tekst,
+      en hoeveel je ook aan de tekstlaag sleutelt, je raakt ze niet aan &mdash;
+      omdat er geen tekstlaag is, of omdat de tekstlaag die er is het beeld
+      beschrijft in plaats van het te z&iacute;jn.
+    </p>
+    <p>
+      De meeste moderne scanners en PDF-gereedschappen leggen een onzichtbare
+      tekstlaag over het beeld, geschreven door optische tekenherkenning, zodat de
+      pagina doorzoekbaar is. Die laag is echte tekst en is weg te halen. Het is de
+      moeite waard om te doen: het is wat een zoekopdracht, een kopieeractie en elk
+      geautomatiseerd systeem dat documenten leest gevonden zou hebben. Het
+      verandert niets aan het beeld, waarin de woorden nog steeds prima leesbaar
+      zijn voor wie naar de pagina kijkt.
+    </p>
+    <p>
+      Dus voor een scan is de eerlijke volgorde: haal de woorden uit de tekstlaag,
+      en pak het beeld daarna apart aan &mdash; en dat betekent pixels
+      overschrijven. Dat is wat de
+      <a href="../een-afbeelding-onleesbaar-maken/">afbeelding onleesbaar
+      maken</a> doet, en de gids ernaast legt uit waarom vervagen of een mozaiek
+      niet goed genoeg is voor tekst.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom niet gewoon afdrukken en opnieuw scannen</h2>
+    <p>
+      Omdat het werkt, en je al het andere kost. Een onleesbaar gemaakte pagina
+      afdrukken en weer inscannen levert inderdaad een document op zonder tekstlaag
+      om uit te lekken &mdash; en een document dat niemand kan doorzoeken, dat geen
+      schermlezer kan lezen, dat vijf tot vijftig keer zo groot is, en waarvan de
+      kwaliteit is wat de kantoorscanner ervan vond. Het steunt ook op de aanname
+      dat de pagina is afgedrukt zoals hij eruitzag: een annotatie kan gemarkeerd
+      zijn als zichtbaar op het scherm en niet op papier, en als dat je zwarte balk
+      was, staat de naam op het vel dat uit de printer komt.
+    </p>
+    <p>
+      Hetzelfde argument geldt voor &bdquo;platslaan tot een afbeelding&rdquo;, wat
+      sommige gereedschappen als onleesbaarmaking aanbieden. Het verandert elke
+      pagina in een foto van zichzelf. Waren de woorden afgedekt in plaats van
+      gewist, dan is de afdekking nu permanent &mdash; maar al het andere aan het
+      document is er samen mee verdwenen, en het bestand dat je verstuurt is er
+      &eacute;&eacute;n waar niemand mee kan werken.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom dit de klus is die uploaden het minst waard is</h2>
+    <p>
+      Een onleesbaarmakingsdienst moet het niet-onleesbare bestand krijgen. Dat is
+      de hele transactie: de priv&eacute;-versie komt eerst aan, ongeschonden, en is
+      de versie op de schijf van iemand anders. Wat de privacyverklaring ook zegt,
+      over de volgorde valt niet te twisten &mdash; het document waar je voorzichtig
+      mee was is het document dat je hebt afgegeven.
+    </p>
+    <p>
+      Wat mensen onleesbaar maken maakt dit erger dan het klinkt.
+      Getuigenverklaringen, brieven van de arts, bankafschriften die naar een
+      verhuurder gaan, een contract met de naam van de ene klant erin dat naar een
+      andere gaat, een stuk met een woonadres erop. Dat zijn de documenten, en
+      precies daarom zou het gereedschap ervoor geen server aan de andere kant
+      moeten hebben.
+    </p>
+    <p>
+      Alles aan <a href="../../pdf-onleesbaar-maken/">het gereedschap op deze
+      site</a> gebeurt in je eigen browser: het bestand wordt op jouw machine
+      gelezen, bewerkt, geschreven en nagekeken, en de woorden waar je op zoekt
+      verlaten het tabblad ook nooit. Trek de stekker uit het internet en het blijft
+      werken, en dat is het eenvoudigste bewijs dat er bestaat dat er nergens iets
+      heen gestuurd wordt. Zie
+      <a href="../is-bestanden-uploaden-veilig/">is het veilig om bestanden te
+      uploaden</a> voor wat een upload werkelijk inhoudt.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/redact-a-pdf.toml
+++ b/locales/nl/pages/guides/redact-a-pdf.toml
@@ -1,0 +1,21 @@
+#
+# Gids: een PDF onleesbaar maken zodat de tekst echt weg is - Dutch.
+#
+
+nav = "Een PDF onleesbaar maken"
+title = "Hoe je een PDF onleesbaar maakt zodat de tekst echt weg is"
+description = "Een zwarte balk die in een PDF-lezer getekend is laat de woorden er meestal onder staan, en met kopi&euml;ren en plakken heb je ze zo terug. Wat een echte onleesbaarmaking weghaalt, de vier plekken waar een woord zich buiten de pagina verstopt, en hoe je een bestand nakijkt voordat je het verstuurt."
+
+heading = "Hoe je een PDF onleesbaar maakt zodat de tekst echt weg is"
+lede = """
+    Een zwarte rechthoek over een naam en een naam die gewist is, zien er op het
+    scherm hetzelfde uit. Een van de twee overleeft het om geselecteerd en
+    gekopieerd te worden. Dit is het verschil, dit zijn de plekken waar een woord
+    zich verstopt die helemaal niet op de pagina staan, en dit is de controle van
+    dertig seconden die je vertelt welke van de twee je hebt."""
+
+updated = "25 augustus 2026"
+
+og_title = "Hoe je een PDF onleesbaar maakt zodat de tekst echt weg is"
+og_description = "Waarom een zwarte balk in een PDF-lezer meestal geen onleesbaarmaking is, de vier plekken waar een woord zich buiten de pagina verstopt, en hoe je een bestand nakijkt voordat je het verstuurt."
+og_image_alt = "abox.tools - gereedschap dat nooit een server aanraakt"

--- a/locales/nl/pages/guides/scan-a-document-with-your-phone.html
+++ b/locales/nl/pages/guides/scan-a-document-with-your-phone.html
@@ -1,0 +1,249 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Leg de pagina op iets dat niet dezelfde kleur heeft als de pagina, ga erboven
+      staan, vul het beeld, en maak &eacute;&eacute;n foto. Open dan
+      <a href="../../documenten-scannen/">Documentscanner</a>, controleer de vier
+      hoeken die hij gevonden heeft, kies &bdquo;kleur, gelijkgetrokken&rdquo; of
+      &bdquo;zwart-wit&rdquo;, en sla de PDF op.
+    </p>
+    <p>
+      Dat is de hele klus. De rest hiervan legt uit wat elk van die stappen
+      herstelt, want weten welk onderdeel wat doet is wat je in staat stelt om in
+      drie seconden te zien of het ding dat je op het punt staat te versturen
+      geaccepteerd gaat worden.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat een foto werkelijk van een scan scheidt</h2>
+    <p>
+      Drie dingen, en ze zijn niet even belangrijk.
+    </p>
+    <ul>
+      <li>
+        <strong>De hoek.</strong> Een foto wordt genomen vanaf waar je stond, dus
+        de pagina is een vierhoek in plaats van een rechthoek. Dit is degene die
+        iedereen opmerkt en de makkelijkste om terug te draaien.
+      </li>
+      <li>
+        <strong>Het licht.</strong> Een scanner sleept een gelijkmatig licht over
+        de pagina. Een kamer doet dat niet: er is een lichte plek onder de lamp, een
+        donkere hoek er verder vandaan, en heel vaak je eigen schaduw over
+        &eacute;&eacute;n kant. Dit is degene die een foto er werkelijk als een foto
+        uit laat zien, en dit is degene die mensen met &bdquo;automatisch
+        contrast&rdquo; proberen te herstellen, wat het erger maakt.
+      </li>
+      <li>
+        <strong>De grootte.</strong> Een foto van twaalf megapixel van een pagina
+        is drie tot vijf megabyte. Twintig daarvan zijn een document dat op de helft
+        van de mailservers waar het heen gaat afketst.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>De foto maken</h2>
+    <p>
+      Vijf dingen, op volgorde van hoeveel verschil ze maken:
+    </p>
+    <ul>
+      <li>
+        <strong>Vul het beeld.</strong> Dit is de enige die achteraf niet te
+        herstellen is. Detail dat niet in de foto zat, zit niet in het bestand, en
+        een pagina die van de andere kant van de kamer gefotografeerd is, is een
+        pagina die niemand op welke resolutie dan ook kan lezen. Ga dichterbij staan
+        in plaats van in te zoomen: tenzij de telefoon overschakelt naar een tweede,
+        langere lens, is inzoomen een uitsnede van dezelfde sensor &mdash; het
+        gooit precies de pixels weg die je probeert te houden.
+      </li>
+      <li>
+        <strong>Leg hem op iets van een andere kleur.</strong> Een witte pagina op
+        een wit bureau heeft vrijwel geen rand om te vinden &mdash; niet voor
+        software, en ook niet voor jou als je de hoeken met de hand moet slepen. Een
+        donkere tafel, een boek, een jas: wat dan ook.
+      </li>
+      <li>
+        <strong>Ga niet tussen de pagina en het licht staan.</strong> Je eigen
+        schaduw over de pagina is veruit de meest voorkomende reden dat een
+        telefoonscan er slecht uitziet. Draai negentig graden en hij is weg.
+      </li>
+      <li>
+        <strong>Laat hem scherpstellen, en houd dan stil.</strong>
+        Bewegingsonscherpte is door geen enkel gereedschap terug te halen, en een
+        gemiste scherpstelling ook niet. Tik de pagina aan op het scherm, wacht tot
+        het rustig wordt, en druk dan op de knop.
+      </li>
+      <li>
+        <strong>Krijg de hele pagina erin, hoeken inbegrepen.</strong> Niet omdat de
+        hoeken kostbaar zijn, maar omdat het rechttrekken eraan gemeten wordt. Een
+        pagina die van het beeld afloopt werkt nog steeds &mdash; de rand van de
+        foto neemt de plaats in van de rand van de pagina &mdash; maar een pagina
+        met drie hoeken in beeld en &eacute;&eacute;n geraden hoek is een pagina die
+        er iets scheef uitkomt.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Rechttrekken: waarom de vorm meer uitmaakt dan de hoek</h2>
+    <p>
+      De hoek terugdraaien is een goed begrepen stukje rekenwerk. Vier hoeken van
+      een rechthoek, vanaf waar dan ook gezien, bepalen de transformatie die ze
+      terugzet, en die op elke pixel toepassen geeft een platte pagina. Elk
+      gereedschap dat beweert een pagina recht te trekken doet dat.
+    </p>
+    <p>
+      Het deel dat stilletjes misgaat is <em>hoe groot</em> de platte pagina zou
+      moeten zijn. De voor de hand liggende methode is de randen van de vierhoek
+      meten en hun verhouding gebruiken &mdash; en een foto die schuin genomen is
+      verkort de verre rand, dus een vel A4 komt er zichtbaar gedrongen uit. Het ziet
+      er nog steeds uit als een scan. Elke regel tekst erop heeft simpelweg de
+      verkeerde hoogte, en niets op het scherm zegt dat.
+    </p>
+    <p>
+      Het betere antwoord is dat het perspectief zelf de informatie draagt: mits de
+      camera een gewone is, is een foto van een rechthoek genoeg om zowel de echte
+      verhoudingen van de rechthoek als de brandpuntsafstand van de camera terug te
+      rekenen. De <a href="../../documenten-scannen/">Documentscanner</a> hier doet
+      dat, en vertelt je daarna welke vorm de pagina uitkwam en of dat een
+      standaardvel is &mdash; dus een pagina die zegt &bdquo;1:1,41, en dat is de
+      vorm van A4 of A5&rdquo; is een pagina waar je niet meer over hoeft na te
+      denken.
+    </p>
+  </section>
+
+  <section>
+    <h2>Het licht: delen, niet oprekken</h2>
+    <p>
+      Het contrast verhogen van een ongelijk belichte pagina maakt het lichte deel
+      wit en het donkere deel zwart, en wat er in het donkere deel geschreven staat
+      verdwijnt daarmee. Het probleem was nooit dat het contrast te laag was. Het is
+      dat het papier in de ene hoek niet even helder is als in de andere, dus er is
+      geen enkele aanpassing die goed is voor de hele pagina.
+    </p>
+    <p>
+      Wat wel werkt is schatten hoe helder het papier <em>op elk punt</em> is en
+      daardoor delen. Papier is de heldere meerderheid van elk klein stukje van een
+      pagina, dus de helderheid meten over een raster van kleine vakjes en in elk
+      vakje een hoge waarde nemen geeft de vorm van het licht &mdash; tekst is te
+      donker en te schaars om het te verschuiven. Deel daardoor en wat overblijft is
+      de inkt, gelijkmatig belicht, zonder de schaduw en met het papier weer wit.
+    </p>
+    <p>
+      Dat is wat &bdquo;kleur, gelijkgetrokken&rdquo; en &bdquo;grijstinten&rdquo;
+      doen. Kies kleur wanneer de kleur bij het document hoort: een stempel, een
+      handtekening in blauwe inkt, een gemarkeerde regel, alles waarvan iemand later
+      zou kunnen vragen of het origineel was.
+    </p>
+  </section>
+
+  <section>
+    <h2>Zwart-wit, en waarom het bestand ineens klein wordt</h2>
+    <p>
+      Een pagina die als foto opgeslagen is, is miljoenen pixels met elk zestien
+      miljoen mogelijke kleuren, en de codec besteedt zijn moeite aan subtiele
+      overgangen die een pagina met tekst niet heeft. Een pagina die als zwart-wit
+      opgeslagen is, is &eacute;&eacute;n bit per pixel &mdash; inkt of papier
+      &mdash; en comprimeert als het overweldigend eentonige ding dat het is.
+    </p>
+    <p>
+      Het verschil is niet klein: op dezelfde pagina's is het zoiets als achttien
+      keer. Een contract van twintig pagina's dat als foto's op vijftien megabyte
+      uitkomt, blijft als &eacute;&eacute;n-bitspagina's onder een megabyte &mdash;
+      en dat is het verschil tussen een document dat gemaild kan worden en
+      &eacute;&eacute;n dat dat niet kan, en de reden dat elke kantoorscanner er
+      standaard op staat.
+    </p>
+    <p>
+      De keerzijde is dat er geen halftonen zijn: een foto op de pagina wordt een
+      rommeltje van stippen. Gebruik het voor gedrukte en geschreven pagina's, en
+      dat zijn de meeste documenten, en gebruik grijstinten voor alles met een beeld
+      erop.
+    </p>
+    <p>
+      E&eacute;n detail dat de moeite waard is om te weten, want het verklaart
+      waarom goed gereedschap slaagt waar slecht gereedschap een pagina met een
+      zwarte hoek oplevert: de beslissing inkt of papier moet <em>plaatselijk</em>
+      genomen worden. E&eacute;n drempel voor de hele pagina kan niet werken als het
+      papier in de schaduw donkerder is dan de inkt in het licht &mdash; en op een
+      gefotografeerde pagina is het dat heel vaak. Elke pixel beoordelen tegen het
+      gemiddelde van zijn eigen kleine omgeving is wat schrift binnen een schaduw
+      leesbaar houdt.
+    </p>
+  </section>
+
+  <section>
+    <h2>Meerdere pagina's, &eacute;&eacute;n document</h2>
+    <p>
+      Fotografeer de pagina's op volgorde, voeg ze allemaal tegelijk toe, en ze
+      worden de pagina's van &eacute;&eacute;n PDF in de volgorde waarin ze zijn
+      toegevoegd. Twee dingen om op te letten:
+    </p>
+    <ul>
+      <li>
+        <strong>Bestandsnamen sorteren niet zoals je denkt.</strong>
+        <code>pagina2.jpg</code> komt na <code>pagina10.jpg</code> in een
+        alfabetische sortering, want de vergelijking gaat teken voor teken.
+        Controleer de volgorde in de strook voordat je opslaat, en niet achteraf in
+        de PDF.
+      </li>
+      <li>
+        <strong>Het opschonen is &eacute;&eacute;n instelling voor het hele
+        document</strong>, en dat met opzet. Pagina's die verschillend opgeschoond
+        zijn, zien eruit als twee documenten die aan elkaar geniet zijn, en dat is
+        precies de indruk die een scan moet vermijden. Kies de modus die past bij de
+        slechtste pagina.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Voordat je het verstuurt</h2>
+    <ul>
+      <li>
+        <strong>Open de PDF.</strong> Niet het voorbeeld &mdash; het bestand. Elke
+        pagina, met de goede kant boven, niets afgesneden aan een rand.
+      </li>
+      <li>
+        <strong>Lees het kleinste dat op de pagina staat.</strong> Een
+        kenmerknummer, een datum, een rekeningnummer. Kun je het op het scherm op
+        100% niet lezen, dan kan de persoon aan wie je het stuurt dat ook niet.
+      </li>
+      <li>
+        <strong>Controleer of de hoeken niet weggesneden zijn.</strong> Wat aan de
+        rand van een formulier staat is een paginanummer, een handtekeningregel, of
+        het vakje waarvan iemand later zegt dat het ontbrak.
+      </li>
+      <li>
+        <strong>Controleer wat het document over jou zegt.</strong> Een PDF heeft
+        velden voor de auteur, de producer en de aanmaakdatum, en de meeste
+        gereedschappen vullen ze in. Of dat uitmaakt hangt af van wie het ontvangt,
+        maar het is de moeite waard om te weten dat het er staat.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Waarom hier geen upload voor nodig is</h2>
+    <p>
+      Elke stap hierboven is rekenwerk op een beeld dat je eigen machine al
+      gedecodeerd heeft: vier hoeken, een transformatie, een deling, een drempel, en
+      een houder die byte voor byte geschreven wordt. Er zit niets in dat een server
+      kan en een browser niet, en niets dat er een gedownload model voor nodig
+      heeft.
+    </p>
+    <p>
+      En daar is het de moeite waard bij stil te staan, om wat deze bestanden zijn.
+      Mensen fotograferen niet zomaar pagina's. Ze fotograferen een paspoort, een
+      loonstrook, een huurcontract, een medisch formulier, een contract &mdash;
+      documenten met een naam, een adres en een rekeningnummer erop, die juist
+      gescand worden omdat een instantie erom gevraagd heeft. Er een uploaden naar
+      een website om de hoeken recht te laten trekken geeft een vreemde het hele
+      document. Zie
+      <a href="../is-bestanden-uploaden-veilig/">hoe je ziet of een gereedschap je
+      bestanden werkelijk nodig heeft</a> voor de vier controles die het gereedschap
+      dat je bestand m&oacute;&eacute;t zien scheiden van het gereedschap dat het
+      eenvoudigweg doet.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/scan-a-document-with-your-phone.toml
+++ b/locales/nl/pages/guides/scan-a-document-with-your-phone.toml
@@ -1,0 +1,21 @@
+#
+# Gids: een document scannen met je telefoon - Dutch.
+#
+
+nav = "Scannen met je telefoon"
+title = "Hoe je een document scant met je telefoon (geen app, geen upload)"
+description = "Wat een foto van een pagina scheidt van een scan ervan: de hoek, het ongelijke licht en de bestandsgrootte. Hoe je de foto maakt, wat je daarna herstelt, en waarom er nergens een server aan te pas komt."
+
+heading = "Hoe je een document scant met je telefoon"
+lede = """
+    Iemand heeft je gevraagd een formulier te &bdquo;scannen en terug te
+    sturen&rdquo;, en je hebt een telefoon en geen scanner. Het gat tussen een foto
+    van een pagina en een scan ervan is kleiner dan het lijkt, en het gaat niet
+    vooral over de hoek &mdash; dit is wat ze werkelijk scheidt, en wat je aan elk
+    onderdeel doet."""
+
+updated = "25 augustus 2026"
+
+og_title = "Hoe je een document scant met je telefoon"
+og_description = "De hoek, de schaduw en de bestandsgrootte - wat een foto van een pagina scheidt van een scan ervan, en hoe je elk onderdeel herstelt zonder de pagina te uploaden."
+og_image_alt = "abox.tools - gereedschap dat nooit een server aanraakt"

--- a/locales/nl/pages/guides/stack-photos-to-reduce-noise.html
+++ b/locales/nl/pages/guides/stack-photos-to-reduce-noise.html
@@ -1,0 +1,296 @@
+  <section>
+    <h2>Het korte antwoord</h2>
+    <p>
+      Open <a href="../../afbeeldingen-stacken/">Afbeeldingen stacken</a>, sleep de
+      hele reeks erin, en kies de methode op wat je kwijt wilt:
+    </p>
+    <ul>
+      <li><strong>Ruis</strong>, en er bewoog niets &mdash; gemiddelde.</li>
+      <li><strong>Ruis</strong>, en er bewoog iets &mdash; sigma clipping.</li>
+      <li><strong>Mensen, auto's, een vliegtuig</strong> &mdash; mediaan.</li>
+      <li><strong>Een donkere lucht die je als sterrensporen wilt</strong> &mdash; oplichten.</li>
+      <li><strong>Een macro-opname met vrijwel geen scherptediepte</strong> &mdash; focus stacking.</li>
+    </ul>
+    <p>
+      Laat het uitlijnen aan staan als de camera in je handen was en zet het uit als
+      hij op een statief stond. RAW-bestanden kunnen er rechtstreeks in; ze hoeven
+      niet eerst ontwikkeld te worden.
+    </p>
+    <p>
+      Alles hieronder gaat over waarom die vijf regels zijn wat ze zijn.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waarom een reeks meer bevat dan &eacute;&eacute;n frame</h2>
+    <p>
+      Een foto die bij weinig licht gemaakt is, is het beeld plus ruis, en de ruis
+      is elke keer anders. Dat laatste is wat stacken laat werken. Maak dezelfde
+      opname zestien keer en het beeld is in alle zestien identiek terwijl de ruis
+      dat niet is, dus ze middelen laat het beeld staan en heft de meeste ruis op.
+    </p>
+    <p>
+      De verbetering is de wortel van het aantal frames. Vier frames halveren de
+      ruis. Zestien brengen hem terug tot een kwart. Honderd snijden hem met tien.
+      Dat is een genadeloze kromme om op te zitten &mdash; van zestien naar
+      vierenzestig frames gaan koopt je dezelfde verbetering nog eens, voor vier keer
+      zoveel opnames &mdash; en het is de reden dat vrijwel elke praktische stapel
+      ergens tussen de acht en dertig frames zit.
+    </p>
+    <p>
+      Er is een tweede, stillere winst. Zestien acht-bits frames middelen geeft een
+      resultaat met fijnere overgangen dan er in &eacute;&eacute;n van de frames
+      zaten, want juist de ruis die elk frame anders liet afronden is wat het
+      gemiddelde tussen de niveaus in laat landen. Een ruizige reeks stacken haalt
+      niet alleen ruis weg; het haalt toon terug die een enkel frame had
+      weggekwantiseerd.
+    </p>
+  </section>
+
+  <section>
+    <h2>De vraag die de methode kiest</h2>
+    <p>
+      Niet &bdquo;wat wil ik houden&rdquo; maar <strong>wat was er anders tussen de
+      frames</strong>. De rest volgt daaruit.
+    </p>
+
+    <h3>Er bewoog niets: gemiddelde</h3>
+    <p>
+      Het gewone gemiddelde. Het is de meest doeltreffende ruisverlaging die er is
+      voor een reeks waarin het enige verschil tussen de frames de ruis is, en het
+      is het makkelijkst te bederven: &eacute;&eacute;n frame met een vogel erin
+      zet een vage vogel over de hele stapel, want een gemiddelde heeft geen mening
+      over een waarde die het niet eens is met de rest. Het telt hem gewoon mee.
+    </p>
+
+    <h3>Er kwam iets door het beeld: mediaan</h3>
+    <p>
+      Leg een stuk of twaalf foto's van een druk plein op elkaar en kijk naar
+      &eacute;&eacute;n pixel. In de meeste is hij bestrating; in een of twee is hij
+      iemands jas. Sorteer die twaalf waarden en neem de middelste, en je krijgt
+      bestrating, want de jas was nooit in de meerderheid.
+    </p>
+    <p>
+      Doe dat voor elke pixel en het plein komt er leeg uit. Dit is de truc achter
+      elk artikel over &bdquo;toeristen uit je vakantiefoto halen&rdquo;, en het
+      heeft niets slimmers nodig dan een reeks en geduld. Het ene dat het eist is
+      dat <strong>geen enkel deel van de sc&egrave;ne meer dan de helft van de tijd
+      bezet is</strong>. Iemand die in acht van je twaalf frames stil blijft staan,
+      is op die pixels de meerderheid, en de mediaan houdt hem.
+    </p>
+
+    <h3>Allebei: sigma clipping</h3>
+    <p>
+      De mediaan gooit de meeste informatie weg om zijn robuustheid te krijgen
+      &mdash; elf van je twaalf waarden worden bij elke pixel weggedaan, dus hij
+      verlaagt de ruis veel minder dan een gemiddelde van dezelfde reeks zou doen.
+    </p>
+    <p>
+      Sigma clipping is het compromis, en het is meestal de juiste standaardkeuze
+      voor elke reeks uit de praktijk. Het kijkt naar elke pixel over alle frames
+      heen, zoekt uit wat hij meestal is en hoeveel hij varieert, en middelt dan
+      alleen de waarden die daarmee overeenkomen. Een auto die door &eacute;&eacute;n
+      frame reed wordt bij die pixels uitgesloten; elk ander frame telt overal nog
+      steeds mee. Je krijgt de immuniteit van de mediaan voor dingen die bewogen en
+      het meeste van de ruisverlaging van het gemiddelde.
+    </p>
+    <p>
+      De drempel staat in standaardafwijkingen, en twee is het gebruikelijke
+      uitgangspunt. Lager verwerpt meer, en begint echt detail samen met de auto te
+      verwerpen.
+    </p>
+
+    <h3>Alleen de heldere dingen tellen: oplichten</h3>
+    <p>
+      Houd de helderste waarde die elke pixel ooit had. Fotografeer de nachthemel
+      als tweehonderd belichtingen van dertig seconden en licht ze samen op, en elke
+      ster tekent zijn eigen boog over het resultaat &mdash; een sterrenspoor,
+      samengesteld uit korte belichtingen die afzonderlijk nooit zijn volgelopen.
+      Dezelfde methode stelt vuurwerk samen uit de frames van zijn eigen explosie,
+      en een light painting uit een wandeling door een donkere kamer met een
+      zaklamp.
+    </p>
+    <p>
+      De tegenhanger, verdonkeren, is de stille van het paar: een pixel blijft alleen
+      helder als hij in <em>elk</em> frame helder was, dus weerspiegelingen in een
+      raam, langskomende koplampen en door een flits aangelichte regendruppels
+      verdwijnen allemaal.
+    </p>
+
+    <h3>Het onderwerp is dieper dan de scherpstelling: focus stacking</h3>
+    <p>
+      Een macro-opname op f/8 heeft misschien een millimeter scherp, en dat is niet
+      genoeg voor een insect. Het antwoord is twintig frames langs de scherpstelring
+      maken en van elk alleen het deel houden dat daarin scherp was. Het gereedschap
+      meet hoeveel elke pixel van zijn buren verschilt &mdash; veel op een rand,
+      bijna nul op een vervaging &mdash; en neemt de winnaar.
+    </p>
+    <p>
+      Deze wil meer dan alle andere een statief, want de scherpstelring met de hand
+      verdraaien verplaatst de camera, en een frame dat van iets verder weg genomen
+      is, is niet hetzelfde beeld op een andere scherpstelling.
+    </p>
+  </section>
+
+  <section>
+    <h2>De frames uitlijnen</h2>
+    <p>
+      Stacken is rekenwerk per pixel, dus het gaat ervan uit dat een bepaalde pixel
+      in elk frame hetzelfde deel van de sc&egrave;ne is. Uit de hand is dat niet zo:
+      een reeks drijft tientallen pixels weg, en dat middelen levert een vervaging
+      op in plaats van een schoon beeld. Dat is veruit de meest voorkomende reden dat
+      een eerste poging tot stacken tegenvalt.
+    </p>
+    <p>
+      Dus worden de frames eerst tegen &eacute;&eacute;n van hun aantal gemeten en
+      teruggeschoven, tot op een fractie van een pixel. Drie instellingen:
+    </p>
+    <ul>
+      <li>
+        <strong>Alleen verschuiven</strong> is goed voor vrijwel alles uit de hand.
+        Het corrigeert het wegdrijven en het wiebelen.
+      </li>
+      <li>
+        <strong>Verschuiven, draaien en schalen</strong> voor een reeks waarbij je
+        ook licht draaide, of waarbij een zoom wegkroop. Het kost &eacute;&eacute;n
+        meting meer per frame en helemaal niets als de frames recht blijken te zijn.
+      </li>
+      <li>
+        <strong>Geen</strong> voor een vast statief of een intervalreeks, waarbij de
+        frames al uitgelijnd zijn en ze opmeten verspilde tijd is.
+      </li>
+    </ul>
+    <p>
+      Wat geen enkele uitlijning kan herstellen is een onderwerp dat bewoog in plaats
+      van een camera die bewoog, en een foto die een stap naar links genomen is ook
+      niet. Opzij bewegen verandert hoeveel de dichtbije dingen verschuiven ten
+      opzichte van de verre, en geen enkele correctie beschrijft die twee tegelijk.
+      Op je plek draaien is prima; lopen niet.
+    </p>
+  </section>
+
+  <section>
+    <h2>Waar RAW-bestanden in passen</h2>
+    <p>
+      Je kunt CR2, CR3, NEF, ARW, DNG, RAF, RW2, ORF en de rest er rechtstreeks in
+      slepen, en het is de moeite waard precies te zijn over wat ermee gebeurt, want
+      het is niet wat een RAW-converter doet.
+    </p>
+    <p>
+      Elk RAW-bestand bevat al een <strong>JPEG op volledig formaat dat de camera
+      gerenderd heeft toen de opname gemaakt werd</strong>. Het is wat de achterkant
+      van de camera je laat zien en wat je besturingssysteem als miniatuur tekent.
+      De stacker vindt dat beeld en gebruikt dat. Hij decodeert de sensorgegevens
+      niet.
+    </p>
+    <p>
+      Twee gevolgen, &eacute;&eacute;n goed en &eacute;&eacute;n om te weten:
+    </p>
+    <ul>
+      <li>
+        <strong>Het is snel.</strong> Het voorbeeld vinden betekent een paar kilobyte
+        mappenstructuur lezen en dan &eacute;&eacute;n stuk, dus een frame van
+        60&nbsp;MB opent ongeveer net zo snel als een JPEG. Twintig ervan openen in
+        de tijd die een RAW-converter aan &eacute;&eacute;n zou besteden. De pagina
+        laat je zien hoe weinig van je bestanden hij werkelijk gelezen heeft.
+      </li>
+      <li>
+        <strong>Het is de weergave van de camera, niet die van jou.</strong> Acht bit
+        per kanaal, met de witbalans en de beeldstijl waarop de camera stond &mdash;
+        niet de twaalf of veertien bit lineaire sensorgegevens die je van een
+        converter zou krijgen.
+      </li>
+    </ul>
+    <p>
+      Voor ruisverlaging, sterrensporen, voorbijgangers weghalen en focus stacking is
+      die afweging vrijwel altijd de moeite waard: de voorbeelden zijn op volledige
+      resolutie en ze zijn wat je toch als JPEG gekregen zou hebben. Trek je de
+      schaduwen hard omhoog, of stack je voor astrofotografie waar juist het laatste
+      stukje dynamisch bereik het hele punt is, ontwikkel de frames dan eerst in een
+      RAW-converter en stack de TIFF's of JPEG's die eruit komen. Die gaan er op
+      dezelfde manier in.
+    </p>
+  </section>
+
+  <section>
+    <h2>Wat het kost om te draaien</h2>
+    <p>
+      De moeite waard om te weten, want het is het verschil tussen een stapel die
+      acht seconden kost en &eacute;&eacute;n die twee minuten kost.
+    </p>
+    <p>
+      Zes van de zeven methoden hoeven maar &eacute;&eacute;n ding te onthouden. Een
+      lopend maximum geeft niets om de frames die het al gezien heeft, en een lopende
+      som ook niet, dus die methoden lezen elk frame precies &eacute;&eacute;n keer
+      en gebruiken voor honderd frames evenveel geheugen als voor twee.
+    </p>
+    <p>
+      De mediaan kan zo niet werken, want je kunt de middelste waarde van een reeks
+      niet weten totdat je hem helemaal hebt. Twintig frames van 24 megapixel is
+      ongeveer 1,4&nbsp;GB aan pixels die tegelijk vastgehouden worden, en dat geeft
+      geen enkele browser je, dus wordt het beeld in horizontale banden gesneden en
+      band voor band gestackt &mdash; correct, en trager, want de frames worden voor
+      elke band opnieuw gelezen.
+    </p>
+    <p>
+      Het gereedschap rekent dit allemaal uit voordat je op de knop drukt en vertelt
+      het je: hoe groot het resultaat wordt, ruwweg hoeveel geheugen het nodig heeft,
+      en hoe vaak je frames gedecodeerd worden. Zegt het dat de run in banden gaat,
+      dan deelt de werkresolutie &eacute;&eacute;n stap verlagen het geheugen door
+      vier en maakt er bijna altijd weer &eacute;&eacute;n doorgang van &mdash; en
+      stack je om ruis te verlagen, dan zou half formaat er toch al schoner
+      uitgezien hebben dan volledig.
+    </p>
+  </section>
+
+  <section>
+    <h2>Ervoor fotograferen</h2>
+    <p>
+      Het meeste van de kwaliteit van een stapel wordt beslist voordat er software
+      aan te pas komt.
+    </p>
+    <ul>
+      <li>
+        <strong>Maak meer frames dan je denkt nodig te hebben.</strong> De
+        wortelkromme is onverbiddelijk aan de onderkant en mild aan de bovenkant: van
+        vier naar negen frames gaan is een groter zichtbaar verschil dan van twintig
+        naar veertig.
+      </li>
+      <li>
+        <strong>Verander de belichting niet tussen de frames.</strong> Stacken gaat
+        ervan uit dat de frames dezelfde sc&egrave;ne op dezelfde helderheid zijn.
+        Zet de belichting vast, of het gereedschap middelt twee verschillende
+        beelden.
+      </li>
+      <li>
+        <strong>Wacht tussen de frames als je mensen weg wilt halen.</strong> Een
+        reeks die in twee seconden gemaakt is, vangt dezelfde persoon in elk frame op
+        dezelfde plek, en de mediaan houdt hem. Tien frames met een paar seconden
+        ertussen werkt veel beter dan vijftig in een reeks.
+      </li>
+      <li>
+        <strong>Houd de gaten kort voor sterrensporen.</strong> Oplichten tekent
+        precies wat de frames vastgelegd hebben, dus een pauze tussen de belichtingen
+        wordt een zichtbare onderbreking in elk spoor.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Niets hiervan verlaat je machine</h2>
+    <p>
+      Een stapel van twintig RAW-frames is ongeveer een gigabyte aan foto's, en dat
+      is veel om aan een website te geven om er een gemiddelde van te laten nemen.
+      <a href="../../afbeeldingen-stacken/">Afbeeldingen stacken</a> leest de
+      bestanden van je eigen schijf en doet het rekenwerk in je eigen browser. Er is
+      geen uploadstap, geen account en geen wachtrij, en je kunt die bewering
+      nakijken zoals je die van wie dan ook zou nakijken: open het netwerkpaneel van
+      je browser terwijl hij draait, of trek eenvoudigweg de stekker uit het internet
+      en stack ze toch.
+    </p>
+    <p>
+      De verwante vraag &mdash; hoe je voor elk willekeurig gereedschap ziet of het
+      een bestand afgeven nodig was &mdash; heeft
+      <a href="../is-bestanden-uploaden-veilig/">een eigen gids</a>.
+    </p>
+  </section>

--- a/locales/nl/pages/guides/stack-photos-to-reduce-noise.toml
+++ b/locales/nl/pages/guides/stack-photos-to-reduce-noise.toml
@@ -1,0 +1,20 @@
+#
+# Gids: foto's stacken tegen ruis - Dutch.
+#
+
+nav = "Foto's stacken"
+title = "Hoe je foto's stackt om ruis te verlagen, of mensen weg te halen"
+description = "Stacken voegt een reeks frames samen tot &eacute;&eacute;n beeld. Welke methode je nodig hebt hangt af van wat je kwijt wilt: ruis, voorbijgangers, of de flinterdunne scherptediepte van een macro-opname. Hoe elke methode werkt, wat hij kost, en waar RAW-bestanden in passen."
+
+heading = "Hoe je foto's stackt om ruis te verlagen, of mensen weg te halen"
+lede = """
+    Een reeks frames bevat meer informatie dan &eacute;&eacute;n frame ervan. Ze
+    middelen heft de ruis op; de middelste waarde van elke pixel nemen wist alles
+    wat er maar een deel van de tijd was. Welke van de twee je wilt hangt volledig
+    af van wat er bewoog."""
+
+updated = "25 augustus 2026"
+
+og_title = "Hoe je foto's stackt om ruis te verlagen, of mensen weg te halen"
+og_description = "Middel een reeks om ruis te doden, neem de mediaan om een druk plein leeg te maken, licht op voor sterrensporen. Welke methode welk probleem oplost, en waar RAW-bestanden in passen."
+og_image_alt = "abox.tools - gereedschap dat nooit een server aanraakt"

--- a/locales/nl/tools/dicom-viewer.html
+++ b/locales/nl/tools/dicom-viewer.html
@@ -1,0 +1,265 @@
+<!--
+  tools/dicom-viewer/body.html, in Dutch.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+
+  De kolomkop "VR" blijft staan: dat is de code van twee letters die zo in het
+  bestand staat, en wie een tag in de standaard opzoekt, zoekt precies die twee
+  letters.
+-->
+<main>
+  <!--
+    One numbered step, and then the viewer.
+
+    Every other tool on this site numbers its cards because every card is
+    something the visitor does. Here there is one thing to do - choose the
+    files - and everything below it is the scan. Numbering the picture would
+    promise a sequence of decisions that does not exist.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies een scan</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p class="picker-note">
+      Sleep er een hele map in &eacute;&eacute;n keer in, en de bestanden worden
+      weer bij hun series gezet en op de goede volgorde gelegd. Er wordt niets
+      ge&uuml;pload, en er wordt niets terug in je bestanden geschreven.
+    </p>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- De viewer. -->
+  <section class="card" id="viewer-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="save-frame" class="ghost" data-download>Dit beeld opslaan als PNG</button>
+        <button type="button" id="copy-header" class="ghost">Header kopi&euml;ren</button>
+        <button type="button" id="download-header" class="ghost">Downloaden</button>
+      </div>
+    </div>
+
+    <div class="series-row" id="series-row" hidden>
+      <label for="series-pick" class="inline-label">Serie</label>
+      <select id="series-pick"></select>
+      <span class="count" id="series-note"></span>
+    </div>
+
+    <!--
+      The canvas is sized in CSS and its backing store is set to the frame's own
+      pixels, so a 512-pixel slice is drawn at 512 pixels and scaled by the
+      browser rather than resampled here. That is what makes the zoom honest:
+      what is on screen at 400% is the stored pixels made bigger, not a guess at
+      what was between them.
+    -->
+    <div class="viewport" id="viewport">
+      <canvas id="canvas" width="1" height="1" role="img"
+              aria-label="Het beeld op het scherm, getekend uit het bestand dat je gekozen hebt"></canvas>
+      <div class="overlay overlay-tl" id="overlay-tl" hidden></div>
+      <div class="overlay overlay-tr" id="overlay-tr"></div>
+      <div class="overlay overlay-bl" id="overlay-bl"></div>
+      <div class="overlay overlay-br" id="overlay-br"></div>
+      <svg class="marks" id="marks" aria-hidden="true"></svg>
+      <p class="viewport-fail" id="viewport-fail" hidden></p>
+    </div>
+
+    <div class="scrub" id="scrub-row" hidden>
+      <button type="button" id="play" class="ghost" aria-label="De beelden afspelen">▶</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" step="1"
+             aria-label="Welke coupe of welk beeld getoond wordt">
+      <span class="count" id="scrub-label">&mdash;</span>
+    </div>
+
+    <div class="tools">
+      <fieldset class="modes">
+        <legend class="visually-hidden">Wat slepen op het beeld doet</legend>
+        <label><input type="radio" name="mode" value="window" checked> Venster &amp; niveau</label>
+        <label><input type="radio" name="mode" value="pan"> Verschuiven</label>
+        <label><input type="radio" name="mode" value="measure"> Meten</label>
+      </fieldset>
+
+      <div class="zoom">
+        <label for="zoom" class="inline-label">Zoom</label>
+        <input type="range" id="zoom" min="5" max="800" step="5" value="100">
+        <span class="count" id="zoom-label">100%</span>
+        <button type="button" id="reset-view" class="ghost">Passend maken</button>
+      </div>
+    </div>
+
+    <div class="levels" id="levels">
+      <div class="level-field">
+        <label for="preset" class="inline-label">Venster</label>
+        <select id="preset"></select>
+      </div>
+      <div class="level-field">
+        <label for="center" class="inline-label">Midden</label>
+        <input type="number" id="center" step="1">
+      </div>
+      <div class="level-field">
+        <label for="width" class="inline-label">Breedte</label>
+        <input type="number" id="width" step="1" min="1">
+      </div>
+      <label class="level-check"><input type="checkbox" id="invert"> Omkeren</label>
+      <label class="level-check"><input type="checkbox" id="show-details"> Pati&euml;ntgegevens over het beeld tonen</label>
+    </div>
+
+    <p class="hint" id="mode-hint"></p>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- Wat dit bestand is. -->
+  <section class="card" id="facts-card" hidden>
+    <h2>Wat dit bestand is</h2>
+    <dl class="facts">
+      <div><dt>Object</dt><dd id="fact-sop">&mdash;</dd></div>
+      <div><dt>Modaliteit</dt><dd id="fact-modality">&mdash;</dd></div>
+      <div><dt>Beeld</dt><dd id="fact-size">&mdash;</dd></div>
+      <div><dt>Opgeslagen als</dt><dd id="fact-stored">&mdash;</dd></div>
+      <div><dt>Transfer syntax</dt><dd id="fact-syntax">&mdash;</dd></div>
+      <div><dt>Pixelafstand</dt><dd id="fact-spacing">&mdash;</dd></div>
+      <div><dt>Waardebereik</dt><dd id="fact-range">&mdash;</dd></div>
+      <div><dt>Bestand</dt><dd id="fact-file">&mdash;</dd></div>
+    </dl>
+
+    <ul class="notes" id="notes" hidden></ul>
+  </section>
+
+  <!-- Wat er over de persoon in staat. -->
+  <section class="card" id="identity-card" hidden>
+    <h2>Wat er in dit bestand de pati&euml;nt aanwijst</h2>
+    <p class="card-lede">
+      Uit dit bestand gelezen, op dit apparaat, en aan niemand anders getoond.
+      Dit gereedschap schrijft niets: het kan er niets van weghalen, en het heeft
+      er niets van ergens heen gestuurd. Het staat hier omdat een scan veel meer
+      meedraagt dan een naam, en omdat de rest precies is wat een slordige
+      anonimisering overleeft.
+    </p>
+    <ul class="identity" id="identity"></ul>
+    <p class="identity-extra" id="identity-extra"></p>
+  </section>
+
+  <!-- Elke tag in het bestand. -->
+  <section class="card" id="tags-card" hidden>
+    <div class="toolbar">
+      <h2>Elke tag in het bestand</h2>
+      <div class="toolbar-actions">
+        <label for="tag-search" class="visually-hidden">Tags doorzoeken</label>
+        <input type="search" id="tag-search" class="tag-search" placeholder="Zoek op naam, nummer of waarde">
+      </div>
+    </div>
+
+    <p class="card-lede" id="tags-lede"></p>
+
+    <div class="table-wrap">
+      <table class="tags">
+        <caption class="visually-hidden">Elk element in dit bestand</caption>
+        <thead>
+          <tr>
+            <th scope="col">Tag</th>
+            <th scope="col">VR</th>
+            <th scope="col">Naam</th>
+            <th scope="col">Waarde</th>
+          </tr>
+        </thead>
+        <tbody id="tag-rows"></tbody>
+      </table>
+    </div>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!--
+    The tool's own sentences, kept out of the JavaScript so that a translator
+    can reach them. shared/js/phrases.js reads them back, and a key defined here
+    wins over the frame's one.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="mode.window">Sleep dwars over het beeld om het venster wijder of smaller te maken, en omhoog of omlaag om het midden te verschuiven. Beide getallen staan eronder, en ze intypen doet hetzelfde.</span>
+    <span data-phrase="mode.pan">Sleep om het beeld binnen zijn kader te verschuiven. Het muiswiel zoomt, en &bdquo;Passend maken&rdquo; zet alles terug.</span>
+    <span data-phrase="mode.measure">Sleep een lijn over het beeld om te meten. Waar het bestand zegt hoe ver zijn pixels uit elkaar liggen, staat het antwoord in millimeters; waar niet, staat het in pixels en zegt het dat er ook bij.</span>
+
+    <span data-phrase="probe.value">{value} bij kolom {column}, rij {row}</span>
+    <span data-phrase="measure.pixels">{length} px &mdash; dit bestand zegt niet hoe ver zijn pixels uit elkaar liggen, dus dit kan niet in millimeters</span>
+
+    <span data-phrase="stack.position">Gestapeld naar waar elke coupe in het lichaam ligt, en dat is de volgorde waarin het apparaat ze heeft opgenomen.</span>
+    <span data-phrase="stack.number">Gestapeld op Instance Number: deze bestanden dragen geen ligging in het lichaam om op te sorteren.</span>
+    <span data-phrase="stack.gap">De afstand tussen de coupes is niet overal gelijk, dus in deze serie ontbreekt er minstens &eacute;&eacute;n.</span>
+
+    <span data-phrase="pixels.none">De pixels van dit bestand zijn gecomprimeerd met {codec}. Geen enkele browser kan dat decoderen, en een decoder ervoor brengt deze pagina niet mee. Al het andere over het bestand staat hieronder.</span>
+    <span data-phrase="pixels.failed">Het beeld kon niet gedecodeerd worden: {reason}. De header hieronder is volledig gelezen.</span>
+    <span data-phrase="pixels.absent">Dit bestand draagt helemaal geen pixelgegevens. Het is een header, en alles wat erin staat staat hieronder.</span>
+    <span data-phrase="pixels.jpeg">Deze pixels zijn baseline JPEG, dus de decoder van de browser heeft ze uitgepakt, en wat die teruggeeft is acht bit diep. Het venster blijft werken; de nauwkeurigheid die het apparaat heeft vastgelegd is er niet helemaal.</span>
+
+    <span data-phrase="tags.count">{shown} van {total} elementen. Nog {hidden}.</span>
+    <span data-phrase="tags.all">Alle {total} elementen van dit bestand.</span>
+    <span data-phrase="tags.found">{total} elementen passen bij &bdquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.found.one">E&eacute;n element past bij &bdquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.none">Niets past bij &bdquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.more">De overige {count} tonen</span>
+    <span data-phrase="tags.private">priv&eacute;-element</span>
+    <span data-phrase="tags.unknown">niet in dit woordenboek</span>
+    <span data-phrase="tags.guessed">Het bestand zei het niet; dit is wat het gegevenswoordenboek voor deze tag opgeeft.</span>
+
+    <span data-phrase="working.one">{name} wordt gelezen&hellip;</span>
+    <span data-phrase="working.many">{at} van {total} wordt gelezen&hellip;</span>
+    <span data-phrase="error.none">Hier was niets van als DICOM te lezen. {why} Dit gereedschap leest het DICOM-formaat zelf, dus over andere bestanden kan het niets zeggen.</span>
+    <span data-phrase="error.skipped.one">E&eacute;n bestand is overgeslagen: {files}</span>
+    <span data-phrase="error.skipped">{count} bestanden zijn overgeslagen: {files}</span>
+
+    <span data-phrase="series.number">Serie {number}</span>
+    <span data-phrase="series.files.one">1 bestand</span>
+    <span data-phrase="series.files">{count} bestanden</span>
+    <span data-phrase="stack.spacing">De coupes liggen {gap} uit elkaar.</span>
+
+    <span data-phrase="at.position">{at} van {total}</span>
+    <span data-phrase="net.clean">Je scan is nergens heen gegaan. {total} bestanden
+      geladen, allemaal van deze site zelf. {platform}</span>
+    <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit
+      gereedschap nooit. Dat is het waard om na te kijken. {platform}</span>
+    <span data-phrase="net.platform.one">De eigen scripts van de site voor
+      advertenties, meting en de donatieknop kwamen van {hosts} host; geen daarvan
+      heeft een scan, een pixel ervan of een woord uit de header gekregen.</span>
+    <span data-phrase="net.platform.many">De eigen scripts van de site voor
+      advertenties, meting en de donatieknop kwamen van {hosts} hosts; geen daarvan
+      heeft een scan, een pixel ervan of een woord uit de header gekregen.</span>
+    <span data-phrase="at.frame">Beeld {at} van {total}</span>
+    <span data-phrase="at.instance">Instantie {number}</span>
+
+    <span data-phrase="window.file">Uit het bestand</span>
+    <span data-phrase="window.file.n">Uit het bestand, {n}</span>
+    <span data-phrase="window.full">Alles in dit beeld</span>
+    <span data-phrase="window.custom">Met de hand gezet</span>
+    <span data-phrase="window.soft">Zacht weefsel</span>
+    <span data-phrase="window.lung">Long</span>
+    <span data-phrase="window.bone">Bot</span>
+    <span data-phrase="window.brain">Hersenen</span>
+    <span data-phrase="window.liver">Lever</span>
+    <span data-phrase="window.mediastinum">Mediastinum</span>
+    <span data-phrase="window.angio">Angiografie</span>
+
+    <span data-phrase="facts.frames">{count} beelden</span>
+    <span data-phrase="facts.nopixels">geen pixelgegevens</span>
+    <span data-phrase="facts.nospacing">in dit bestand niet opgegeven</span>
+    <span data-phrase="facts.signed">met teken</span>
+    <span data-phrase="facts.unsigned">zonder teken</span>
+    <span data-phrase="facts.stored.one">{bits} bit, {sign}, 1 kanaal per pixel, {photometric}</span>
+    <span data-phrase="facts.stored">{bits} bit, {sign}, {samples} kanalen per pixel, {photometric}</span>
+    <span data-phrase="facts.range">{low} tot {high}</span>
+    <span data-phrase="facts.colour">kleur &mdash; niets gemetens te melden</span>
+
+    <span data-phrase="identity.clean">Niets in dit bestand benoemt of nummert een persoon. De identificatoren die een scan anders meedraagt ontbreken of zijn leeg.</span>
+    <span data-phrase="identity.uids">Het draagt daarnaast {count} eigen identificatoren, de UID's van onderzoek, serie en instantie. Geen daarvan is een naam, en elk ervan is een perfecte sleutel naar het archief waar het bestand vandaan komt.</span>
+    <span data-phrase="identity.private">Daarbij {count} priv&eacute;-elementen waarvan de betekenis nergens gepubliceerd is: sommige apparaten leggen in zo'n element een tweede kopie van de pati&euml;ntnaam neer.</span>
+
+    <span data-phrase="copied">Gekopieerd.</span>
+    <span data-phrase="copy.failed">Je browser heeft de pagina het kopi&euml;ren geweigerd. De knop ernaast schrijft dezelfde tekst naar een bestand.</span>
+    <span data-phrase="saved">{name} opgeslagen.</span>
+  </div>
+</main>

--- a/locales/nl/tools/dicom-viewer.toml
+++ b/locales/nl/tools/dicom-viewer.toml
@@ -1,0 +1,403 @@
+#
+# DICOM Viewer - Dutch.
+#
+# Overrides for tools/dicom-viewer/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# De DICOM-veldnamen blijven Engels en houden hun nummer - Pixel Spacing
+# (0028,0030), Series Instance UID (0020,000E). Zo staan ze in het bestand en zo
+# staan ze in de standaard; wie een veld opzoekt, zoekt precies die woorden.
+# Hetzelfde geldt voor de transfer syntaxes en voor PS3.15.
+#
+# Op deze pagina heeft de belofte van de site de scherpste rand: het bestand is
+# een medisch dossier met een plaatje erin. De zinnen over wat erin staat zijn
+# daarom net zo zorgvuldig vertaald als die over waar het niet heen gaat.
+#
+
+name = "DICOM-viewer"
+heading = "DICOM-viewer <span class=\"h1-kw\">&mdash; een .dcm-scan openen in je browser</span>"
+tagline = "CT, MRI, r&ouml;ntgen en echo, met het venster, de header en de metingen."
+
+title = "DICOM-viewer &mdash; een .dcm-bestand openen in je browser, zonder uploaden"
+description = "Open CT-, MRI-, r&ouml;ntgen- en echoscans in je browser. Venster en niveau, een hele serie doorbladeren, meten in millimeters, elke DICOM-tag lezen en precies zien wat er in het bestand de pati&euml;nt aanwijst. Er wordt niets ge&uuml;pload."
+og_title = "DICOM-viewer &mdash; een scan openen zonder hem te uploaden"
+og_description = "Een .dcm-bestand geopend op je eigen machine: venster en niveau, de hele serie op volgorde gestapeld, metingen in millimeters en elke tag in de header. Geen upload, geen account."
+og_image_alt = "DICOM-viewer - een CT-, MRI- of r&ouml;ntgenscan openen in de browser"
+
+pledge = """
+    De scan wordt door je eigen browser geopend en gedecodeerd: de header, de
+    pixels, het venster, de metingen. Aan de andere kant van deze pagina staat
+    geen server om medische gegevens naartoe te sturen, ook niet als iets hier dat
+    zou willen, en niets over het bestand &mdash; niet de naam van de pati&euml;nt,
+    niet het onderzoek, niet de bestandsnaam &mdash; wordt aan wie dan ook
+    doorgegeven."""
+
+live_hint = """
+      Neem het niet van ons aan: open DevTools, kijk naar het tabblad Netwerk en
+      open een scan. Geen enkel verzoek draagt een afbeelding, een tag of een
+      bestandsnaam mee. Of trek de stekker uit het internet en open er toch
+      een."""
+
+read_first = """
+, <code>src/dicom.js</code> voor de parser die
+      door het bestand loopt, <code>src/pixels.js</code> voor het decoderen van de
+      pixels, <code>src/jpeg-lossless.js</code> voor de codec waarmee de meeste
+      ziekenhuizen exporteren, en <code>src/window.js</code> voor het venster en
+      het niveau &mdash; en in geen daarvan staat een regel die het netwerk zou
+      kunnen bereiken."""
+
+howto_heading = "Zo open je een DICOM-bestand"
+
+card = """
+            Open een CT-, MRI-, r&ouml;ntgen- of echoscan op je eigen machine.
+            Zet venster en niveau, blader de hele serie door, meet in
+            millimeters en lees elke tag in de header."""
+
+[words]
+plural = "scans"
+choose = "een scan"
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "Bestanden blijven op je apparaat"
+
+[[privacy]]
+title = "Je scan kan nergens heen."
+body = """
+ Het
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen enkel adres daarvan hoort bij deze site. Er is hier geen eindpunt waar
+      je bestand verzameld zou kunnen worden, en niets in de code dat het zou
+      versturen als dat er wel was. Er stond eerst <code>connect-src 'none'</code>,
+      wat absoluut was; advertenties toevoegen heeft dat gekost, en dat erbij
+      zeggen hoort bij de afspraak."""
+
+[[privacy]]
+title = "Hier weegt dit zwaarder dan op de andere pagina's."
+body = """
+
+      Een DICOM-bestand is geen plaatje met wat metagegevens eraan. Het is een
+      medisch dossier met een plaatje erin: de naam van de pati&euml;nt, de
+      geboortedatum, het patientennummer, het aanvraagnummer, de verwijzend arts,
+      de instelling en het serienummer van het apparaat zijn allemaal velden in de
+      header, en ze reizen met het bestand mee waar het ook heen gaat. Er een
+      uploaden naar een website om ernaar te kijken betekent dat je dat allemaal
+      afgeeft aan wie die website beheert. Dat is precies wat deze pagina bestaat
+      om niet te doen."""
+
+[[privacy]]
+title = "De lezer is veertien bestanden in deze repository."
+body = """
+ Niets hier gebruikt een
+      bibliotheek die ergens vandaan gehaald wordt. <code>src/dicom.js</code> loopt
+      door het bestand, <code>src/dictionary.js</code> weet hoe de tags heten,
+      <code>src/pixels.js</code> maakt van de bytes weer metingen,
+      <code>src/rle.js</code> en <code>src/jpeg-lossless.js</code> pakken de twee
+      gecomprimeerde vormen uit die deze pagina kan decoderen, en
+      <code>src/window.js</code> zet wat er gemeten is om naar de grijstinten van
+      je scherm."""
+
+[[privacy]]
+title = "De identificatoren staan er voor jou, en voor niemand anders."
+body = """
+
+      De pagina drukt elk veld in je bestand af dat de persoon van wie de scan is
+      benoemt of afbakent, want dat is de vraag waar iemand die op het punt staat
+      een coupe te delen antwoord op nodig heeft, en geen enkele viewer geeft dat.
+      Het komt op het scherm voor je te staan en gaat nergens anders heen: er is in
+      deze repository geen analytics-gebeurtenis die er iets van meedraagt, en de
+      pagina zou er ook geen kunnen versturen als die er wel was."""
+
+[[privacy]]
+title = "Hij leest. Hij schrijft niet."
+body = """
+ Er is hier geen knop die je
+      bestand verandert, en geen code die dat zou kunnen. Wat je mee kunt nemen is
+      een PNG van het beeld op het scherm en een tekstkopie van de header, allebei
+      in de pagina opgebouwd uit wat er al staat. Je origineel blijft onaangeroerd
+      op je schijf, wat meteen het eerlijke antwoord is op wat er gebeurt als je
+      het tabblad sluit."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De scripts voor
+      advertenties en meting komen van Google. Geen van beide krijgt iets over je
+      bestand: niet de pixels, niet een miniatuur, niet een naam, een tag, een
+      pati&euml;nt of een bestandsnaam. Elke regel die een scan inleest, decodeert
+      of tekent wordt vanaf deze oorsprong geserveerd en staat in de repository."""
+
+[[privacy]]
+title = "Wat de donatieknop laadt, en wat hij niet krijgt."
+body = """
+
+      De &bdquo;Buy me a coffee&rdquo;-knop bovenaan wordt getekend door een script
+      van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts. Het is een
+      link en verder niets: hij meldt geen bezoek, en hij krijgt niets over jou of
+      je bestanden. Er gebeurt niets tenzij je erop klikt, en waar je dan
+      terechtkomt is de site van iemand anders."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en elk onderdeel van
+      deze pagina blijft werken. Dat is het eenvoudigste bewijs van allemaal: een
+      gereedschap dat je scan wegstuurt om hem te laten tekenen, stopt op het
+      moment dat je de stekker eruit trekt."""
+
+[[howto]]
+title = "Kies de bestanden."
+body = """
+ E&eacute;n <code>.dcm</code>-bestand,
+      of de hele map van het schijfje &mdash; een CT of een MRI is &eacute;&eacute;n
+      bestand per coupe, en ze allemaal tegelijk erin slepen is wat de serie weer
+      in elkaar zet. De bestanden worden door de browser rechtstreeks van je schijf
+      gelezen; er wordt ondertussen niets ergens heen gestuurd."""
+
+[[howto]]
+title = "Kies de serie."
+body = """
+ Een onderzoek bevat er meestal
+      meerdere: de scout, en dan elke acquisitie. Elke serie wordt gestapeld in de
+      volgorde waarin het apparaat hem heeft opgenomen, afgeleid uit waar elke
+      coupe in het lichaam ligt en niet uit de nummering, die niet altijd dezelfde
+      kant op loopt."""
+
+[[howto]]
+title = "Zet het venster."
+body = """
+ Dit is de knop die een scan
+      leesbaar maakt, en die een fotobewerker niet heeft. Sleep over het beeld om
+      het venster breder te maken en omhoog of omlaag om het midden te verschuiven,
+      of kies een van de vensters met een naam &mdash; long, bot, hersenen, zacht
+      weefsel &mdash; op een CT, waar de eenheden op elk apparaat ter wereld
+      dezelfde zijn."""
+
+[[howto]]
+title = "Blader door de stapel."
+body = """
+ De schuif onder het beeld gaat
+      door de coupes heen, en de pijltjestoetsen doen hetzelfde zodra je op het
+      beeld hebt geklikt. Een bestand met meerdere frames &mdash; een echolus, een
+      angiogram &mdash; speelt af met de knop ernaast."""
+
+[[howto]]
+title = "Meet iets."
+body = """
+ Ga naar Meten en sleep een lijn. Waar het
+      bestand zegt hoe ver zijn pixels uit elkaar liggen, staat het antwoord in
+      millimeters en wordt er rekening gehouden met pixels die niet vierkant zijn;
+      waar het bestand dat niet zegt, staat het antwoord in pixels en zegt het dat
+      er ook bij in plaats van een schaal te verzinnen."""
+
+[[howto]]
+title = "Lees de header."
+body = """
+ Elk element in het bestand, met zijn
+      nummer, hoe de standaard het noemt en wat erin staat, doorzoekbaar.
+      Daarboven de lijst van wat er in dit ene bestand de pati&euml;nt aanwijst
+      &mdash; en dat is heel wat meer dan de naam."""
+
+[[howto]]
+title = "Neem mee wat je nodig hebt."
+body = """
+ Het beeld op het scherm
+      als PNG, met het venster dat je hebt gezet en zonder iets erin gebrand, of de
+      hele header als platte tekst. Allebei worden ze in de pagina opgebouwd uit
+      wat er al is."""
+
+[[faq]]
+q = "Wordt mijn scan ergens naartoe ge&uuml;pload?"
+a = """
+        Nee. Het bestand wordt door je eigen browser op je eigen hardware gelezen,
+        gedecodeerd en getekend. Dit gereedschap heeft geen serverkant, en het
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen &mdash; geen daarvan hoort bij deze site. Trek de stekker uit
+        het netwerk en hij opent nog steeds scans.
+        <br><br>
+        Dat is hier meer waard dan op welke andere pagina van deze site ook. Een
+        DICOM-bestand draagt de naam, de geboortedatum en het patientennummer in
+        zijn header, dus er een uploaden naar een viewer betekent dat je een
+        vreemde een medisch dossier geeft, en geen plaatje."""
+
+[[faq]]
+q = "Welke DICOM-bestanden kan hij openen?"
+a = """
+        Ongecomprimeerde bestanden in elk van de drie basis-transfer-syntaxes
+        &mdash; implicit en explicit little endian, en de ingetrokken big-endian
+        &mdash; plus deflated, RLE Lossless, baseline JPEG en JPEG Lossless, en dat
+        laatste is waarmee de meeste CT- en MRI-onderzoeken op een ziekenhuisschijfje
+        zijn gecomprimeerd.
+        <br><br>
+        Hij kan JPEG 2000, JPEG-LS en de MPEG- en HEVC-syntaxes voor video niet
+        decoderen. Daar zijn codecs voor nodig die megabytes aan gecompileerde
+        bibliotheek zijn, en een pagina die er een zou ophalen wanneer het uitkomt,
+        zou geen pagina zijn die offline werkt. Een bestand in zo'n vorm gaat toch
+        open: de hele header wordt gelezen en getoond, en in plaats van het beeld
+        staat er een regel die de codec noemt, in plaats van een gebroken-plaatje-icoon
+        dat je niets vertelt."""
+
+[[faq]]
+q = "Wat is &bdquo;venster en niveau&rdquo;, en waarom heb ik dat nodig?"
+a = """
+        Een CT-coupe bevat zo'n vierduizend verschillende waarden en je scherm laat
+        tweehonderdzesenvijftig grijstinten zien. Het venster is de keuze welk stuk
+        van dat bereik ze allemaal krijgt: alles eronder is zwart, alles erboven is
+        wit, en wat ertussen zit wordt over de grijstinten verdeeld.
+        <br><br>
+        Daarom lijkt hetzelfde bestand bij twee instellingen een andere scan, en
+        daarom kun je long en bot niet tegelijk zien. Op een CT zijn de getallen
+        Hounsfield-eenheden, en die zijn absoluut vastgelegd &mdash; water is 0 en
+        lucht is &minus;1000 &mdash; dus de vensters met een naam op deze pagina
+        zijn dezelfde getallen die een radioloog aan een werkstation gebruikt. Op
+        een MRI of een echo bestaat zo'n schaal niet, en het venster dat opengaat is
+        het venster waar het bestand zelf om vraagt."""
+
+[[faq]]
+q = "Waarom staat er dat mijn meting in pixels is?"
+a = """
+        Omdat dat bestand niet zegt hoe groot een pixel is. Pixel Spacing
+        (0028,0030) is het veld dat dat draagt, in millimeters, en heel veel
+        echobeelden, gescande documenten en secondary captures hebben het gewoon
+        niet.
+        <br><br>
+        Waar het er wel is, staat de meting in millimeters en wordt elke as met zijn
+        eigen afstand gemeten, wat uitmaakt bij beelden waarvan de pixels niet
+        vierkant zijn. Waar het er niet is, is het eerlijke antwoord een aantal
+        pixels, en dat zegt hij er ook bij in plaats van een schaal te kiezen en het
+        resultaat als een lengte te presenteren."""
+
+[[faq]]
+q = "Hij heeft mijn map als meerdere series geopend. Waarom?"
+a = """
+        Omdat dat is wat erin zit. Een onderzoek bestaat uit series &mdash; het
+        scout-beeld, en dan elke acquisitie of reconstructie &mdash; en elk bestand
+        zegt bij welke het hoort in Series Instance UID (0020,000E). Het uitklapmenu
+        is daaruit opgebouwd en niet uit de map, waarin ze meestal allemaal door
+        elkaar in &eacute;&eacute;n lijst met namen staan.
+        <br><br>
+        Binnen een serie worden de coupes op volgorde gezet naar waar ze in het
+        lichaam liggen, afgeleid uit Image Position en Image Orientation. Instance
+        Number is de voor de hand liggende sleutel en is de terugval en niet de
+        eerste keuze: hij wordt toegekend door wat de bestanden ook geschreven heeft
+        en hoeft niet dezelfde kant op te lopen als de pati&euml;nt."""
+
+[[faq]]
+q = "Wat betekent de lijst &bdquo;wat de pati&euml;nt aanwijst&rdquo;?"
+a = """
+        Het is elk veld in je bestand dat de persoon van wie de scan is benoemt, of
+        dat inperkt wie het zou kunnen zijn, van dit bestand op jouw machine
+        afgelezen. De lijst komt uit PS3.15 van de DICOM-standaard &mdash; het deel
+        dat zegt wat eruit moet voordat een dataset gede&iuml;dentificeerd genoemd
+        mag worden.
+        <br><br>
+        Hij staat er omdat waar mensen zich in vergissen niet is dat er een naam in
+        een scan staat. Het is hoeveel er verder nog in staat: de geboortedatum, het
+        aanvraagnummer, de verwijzend arts, de instelling, het serienummer van het
+        apparaat, en de UID's van het onderzoek, die perfecte sleutels terug zijn
+        naar het archief dat het bestand gemaakt heeft. Een scan waarbij alleen de
+        naam is weggehaald is niet anoniem.
+        <br><br>
+        Dit gereedschap laat het je alleen zien. Het schrijft niets en verandert
+        niets, dus het kan er ook niets van weghalen."""
+
+[[faq]]
+q = "Kan hij een scan anonimiseren?"
+a = """
+        Nee, en hij doet met opzet niet alsof. Deze pagina leest; er staat geen code
+        in die een DICOM-bestand schrijft. Wat hij w&eacute;l doet is je precies
+        vertellen wat er in het jouwe zit, en dat is het deel dat lastig te
+        achterhalen is en waar mensen zich in vergissen.
+        <br><br>
+        Een gereedschap dat de identificatoren eruit haalt is een aparte klus met
+        een veel hogere lat &mdash; het moet het bestand herschrijven zonder de
+        pixels aan te raken, de UID's consistent vervangen over een heel onderzoek,
+        en gelijk hebben over de priv&eacute;-elementen waar sommige apparaten een
+        tweede kopie van de naam in verstoppen. Dat staat op de roadmap van deze
+        site en wordt niet aan een viewer vastgeplakt."""
+
+[[faq]]
+q = "Kan hij een bestand openen zonder .dcm-extensie, of een kapot bestand?"
+a = """
+        Ja op allebei. Er wordt niet naar de extensie gekeken: wat gecontroleerd
+        wordt is het bestand zelf. Een dataset die zonder de gebruikelijke 128 bytes
+        preambule geschreven is &mdash; en zo ziet een scan eruit die rechtstreeks
+        van het netwerk komt &mdash; wordt gelezen door de codering af te leiden uit
+        het eerste element, en de pagina zegt dat hij dat gedaan heeft.
+        <br><br>
+        Een bestand dat halverwege ophoudt wordt gelezen tot zover het komt. Alles
+        v&oacute;&oacute;r de schade wordt getoond, met een notitie erbij die zegt
+        bij welke byte hij gestopt is. Dat is nu juist het geval waarin een viewer
+        het hardst nodig is, dus het hele bestand weggooien om de laatste twaalf
+        bytes zou verkeerd gedrag zijn."""
+
+[[faq]]
+q = "Is dit een diagnostische viewer?"
+a = """
+        Nee. Het is geen medisch hulpmiddel, het heeft geen enkele
+        regelgevingsbeoordeling doorlopen, en niets hiervan hoort gebruikt te worden
+        om een klinische beslissing te nemen. Je scherm is niet gekalibreerd, de
+        browser is geen gevalideerde renderketen, en geen van beide is vanuit een
+        webpagina op te lossen.
+        <br><br>
+        Waar hij wel goed voor is, is al het andere waarvoor mensen een scan openen:
+        kijken wat er op een schijfje staat, een coupe eruit halen voor een college
+        of een artikel, een header lezen, uitzoeken waarom een ander programma het
+        bestand weigert, en zien wat een scan meedraagt over de persoon van wie hij
+        is."""
+
+[[faq]]
+q = "Verandert hij mijn bestand?"
+a = """
+        Nee. Dit gereedschap leest alleen. Er is geen uitvoerbestand, geen
+        hercodering en geen knop hier die een DICOM schrijft &mdash; wat je kunt
+        downloaden is een PNG van het beeld op het scherm en een kopie van de header
+        als platte tekst. Je origineel blijft onaangeroerd op je schijf."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen en geen proefperiode. Er
+        is geen limiet op de bestandsgrootte of op hoeveel bestanden je opent,
+        behalve het geheugen van je eigen machine. De site draait advertenties, en
+        dat is wat hem betaalt; de adverteerders krijgen niets over je bestand."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina &eacute;&eacute;n keer, verbreek daarna de
+        internetverbinding en hij blijft werken. Dat is meteen de eenvoudigste
+        manier om te bewijzen dat er niets ge&uuml;pload wordt: een gereedschap dat
+        je scan wegstuurt om hem te laten tekenen, stopt op het moment dat je de
+        stekker eruit trekt."""
+
+[schema]
+description = "Open DICOM-bestanden (.dcm) in de browser: CT, MRI, r&ouml;ntgen en echo, met venster en niveau, een hele serie op volgorde gestapeld, metingen in millimeters en elke tag in de header. Er wordt niets ge&uuml;pload."
+features = [
+  "Opent CT, MRI, r&ouml;ntgen, echo, PET en secondary capture",
+  "Venster en niveau door slepen, door typen of via een CT-preset met een naam",
+  "Een hele map wordt tot series gebundeld en gesorteerd op de ligging in het lichaam",
+  "Bestanden met meerdere frames spelen als een lus",
+  "Meet in millimeters en rekent niet-vierkante pixels mee",
+  "Leest de pixelwaarde onder de aanwijzer in Hounsfield-eenheden",
+  "Elke DICOM-tag met naam en waarde, doorzoekbaar",
+  "Somt op wat er in het bestand de pati&euml;nt aanwijst, volgens het profiel uit PS3.15",
+  "Decodeert RLE, baseline JPEG en JPEG Lossless zonder meegeleverde bibliotheek",
+  "Slaat het beeld op als PNG en de header als platte tekst",
+  "Werkt offline; geen upload, geen account, geen wijziging aan je bestand",
+]
+
+[picker]
+title = "Sleep hier een scan naartoe"
+hint = "of klik om te bladeren &mdash; &eacute;&eacute;n .dcm-bestand, of een hele map ervan"

--- a/locales/nl/tools/document-scanner.html
+++ b/locales/nl/tools/document-scanner.html
@@ -1,0 +1,388 @@
+<!--
+  tools/document-scanner/body.html, in Dutch.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Stap 1 &mdash; de foto's -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies foto's</h2>
+
+    <p class="card-lede">
+      E&eacute;n foto per pagina, genomen van ergens erboven. De hele pagina moet
+      in beeld zijn, en de vier hoeken zouden zichtbaar moeten zijn of bijna. Al
+      het andere &mdash; de scheve hoek, de schaduw, de tafel eronder &mdash; is
+      waar dit gereedschap voor is. Voeg er meerdere toe en ze worden de pagina's
+      van &eacute;&eacute;n document, in de volgorde waarin je ze toevoegt.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="strip-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="detect-all" class="ghost">Alle pagina's opnieuw zoeken</button>
+        <button type="button" id="clear-all" class="ghost danger">Alles verwijderen</button>
+      </div>
+    </div>
+
+    <ul id="page-strip" class="page-strip"></ul>
+  </section>
+
+  <!-- Stap 2 &mdash; de hoeken -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Zet de hoeken op de pagina</h2>
+
+    <p id="edit-empty" class="field-summary">
+      Kies een foto, dan verschijnt hij hier, met zijn vier hoeken voor je
+      gevonden.
+    </p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Tik ergens op de foto, en de dichtstbijzijnde hoek komt naar je vinger
+        toe; sleep hem naar de hoek van de pagina. Met <kbd>Tab</kbd> bereik je
+        een hoek via het toetsenbord, de pijltjestoetsen verplaatsen hem
+        &eacute;&eacute;n pixel en met <kbd>Shift</kbd> tien. Niets hiervan is
+        definitief: de scan wordt genomen van waar de vier hoeken uiteindelijk
+        staan.
+      </p>
+
+      <!-- The photo is a canvas rather than an <img> because it is drawn at
+           screen size from the decoded picture, and because the same canvas is
+           what the corner finder reads. The outline over it is an SVG polygon
+           in percentages, so it needs no redraw when the window changes. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="photo"></canvas>
+        </div>
+      </div>
+
+      <p id="detect-note" class="hint-line" role="status" aria-live="polite"></p>
+
+      <div class="frame-actions">
+        <button type="button" id="detect-one" class="ghost">Hoeken opnieuw zoeken</button>
+        <button type="button" id="whole-photo" class="ghost">Hele foto nemen</button>
+        <button type="button" id="turn-left" class="ghost">Naar links draaien</button>
+        <button type="button" id="turn-right" class="ghost">Naar rechts draaien</button>
+        <button type="button" id="undo" class="ghost" disabled>Ongedaan maken</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Stap 3 &mdash; het opschonen -->
+  <section class="card" id="clean-card">
+    <h2><span class="step">3</span> Opschonen</h2>
+
+    <p id="clean-empty" class="field-summary">
+      De rechtgetrokken pagina verschijnt hier zodra er een foto is om recht te
+      trekken.
+    </p>
+
+    <div id="clean-controls" hidden>
+      <p class="card-lede">
+        Wat hieronder staat is het echte resultaat, gemaakt door dezelfde code die
+        het bestand schrijft: rechtgetrokken en met het ongelijke licht eruit
+        gedeeld. Op het scherm wordt het op schermgrootte getekend terwijl je
+        kiest; het bestand zelf ontstaat in de resolutie van de foto.
+      </p>
+
+      <div class="result-wrap">
+        <canvas id="scan-preview" class="scan-preview"></canvas>
+        <p id="scan-busy" class="progress-label" role="status" aria-live="polite" hidden>
+          Wordt rechtgetrokken&hellip;
+        </p>
+      </div>
+
+      <ul id="scan-facts" class="result-facts"></ul>
+
+      <fieldset class="options" id="mode-group">
+        <legend>Wat er met licht en kleur moet gebeuren</legend>
+
+        <label class="check">
+          <input type="radio" name="mode" value="colour" checked>
+          <span>
+            <strong>Kleur, gelijkgetrokken</strong>
+            <span class="check-note">
+              Het papier wordt over de pagina heen gemeten en eruit gedeeld,
+              zodat de schaduw verdwijnt en het papier weer wit wordt, terwijl
+              een stempel, een handtekening in blauwe inkt of een gemarkeerde
+              regel hun kleur houden. Dit is de modus als de kleur bij het
+              document hoort.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="grey">
+          <span>
+            <strong>Grijstinten</strong>
+            <span class="check-note">
+              Hetzelfde gelijktrekken zonder de kleur. Kleiner dan kleur en
+              vriendelijker voor een foto of een handtekening dan zwart-wit is.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="mono">
+          <span>
+            <strong>Zwart-wit</strong>
+            <span class="check-note">
+              Elke pixel wordt beoordeeld tegen zijn eigen omgeving en niet tegen
+              &eacute;&eacute;n getal voor de hele pagina, en precies dat houdt
+              het schrift binnen een schaduw leesbaar. Dit is wat een scan klein
+              maakt: een contract van twintig pagina's komt er zo onder een
+              megabyte uit en als foto's rond de vijftien. Deze modus kent geen
+              halftonen, dus niets met een foto erop zou hem moeten nemen.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="photo">
+          <span>
+            <strong>Zo laten</strong>
+            <span class="check-note">
+              Rechtgetrokken en verder niets. Voor een pagina waarbij het papier
+              zelf meetelt: iets ouds, iets kleurigs, een foto.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row" id="strength-row">
+          <label for="strength">Hoe sterk</label>
+          <div class="inline-pair">
+            <input type="range" id="strength" min="0" max="100" step="5" value="50">
+            <output id="strength-value">50</output>
+          </div>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <p class="hint-line">
+        De instelling geldt voor elke pagina. Pagina's in &eacute;&eacute;n
+        document die verschillend opgeschoond zijn, zien eruit als twee
+        documenten.
+      </p>
+    </div>
+  </section>
+
+  <!-- Stap 4 &mdash; het bestand -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Sla het document op</h2>
+
+    <p class="card-lede">
+      De PDF ontstaat hier, in het geheugen van deze pagina, pagina voor pagina.
+      Aan de andere kant van dit gereedschap staat geen server om een loonstrook,
+      een paspoort of een contract naartoe te sturen, en in de code staat niets
+      dat dat zou doen als die er wel was.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Paginagrootte</label>
+        <select id="page-size">
+          <option value="fit" selected>Vel aanpassen aan de pagina zelf</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 in</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 in</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+        </select>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Afdrukresolutie</label>
+        <select id="dpi">
+          <option value="150">150 DPI</option>
+          <option value="200" selected>200 DPI</option>
+          <option value="300">300 DPI &mdash; kantoorapparaat</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Hoe groot een vel genoemd wordt dat uit een bepaald aantal pixels
+          bestaat. Het verandert het formaat waarop het document wordt afgedrukt,
+          en geen enkele pixel van de scan.
+        </p>
+      </div>
+
+      <div class="field" id="margin-field" hidden>
+        <label for="margin">Marge</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="50" step="1" value="10"
+                 aria-label="Marge in millimeters">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Langste zijde</label>
+        <select id="max-side">
+          <option value="1600">1600 pixels &mdash; klein</option>
+          <option value="2400" selected>2400 pixels</option>
+          <option value="3500">3500 pixels</option>
+          <option value="0">Zo groot als de foto toelaat</option>
+        </select>
+        <p class="field-note">
+          Een bovengrens voor de rechtgetrokken pagina. De foto van een pagina
+          bevat veel meer pixels dan de pagina waard is, en 2400 op de lange rand
+          is ongeveer 200 DPI op A4.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Kwaliteit</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="82">
+          <output id="quality-value">82%</output>
+        </div>
+        <p class="field-note">
+          Voor de modi kleur en grijstinten, die als JPEG worden opgeslagen.
+          Zwart-witpagina's worden exact opgeslagen; voor die pagina's doet dit
+          niets.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="title">Documenttitel <span class="optional">(optioneel)</span></label>
+        <input type="text" id="title" maxlength="120" placeholder="Leeg gelaten draagt de PDF geen titel">
+        <p class="field-note">
+          Het enige wat er behalve de pagina's in het document geschreven wordt.
+          Geen datum, geen auteur en niets over dit apparaat. Zie
+          <code>src/document.js</code>.
+        </p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save-pdf" class="primary big" disabled>Opslaan als PDF</button>
+      <button type="button" id="save-images" class="ghost big" disabled>Pagina's opslaan als afbeeldingen</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden></p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>Het klaar bestand</h3>
+        <a id="download" class="primary as-button" href="#" download>Downloaden</a>
+      </div>
+      <ul id="result-facts" class="result-facts"></ul>
+      <p class="hint-line">
+        Open hem voordat je hem verstuurt. Wat er in het document staat is wat er
+        bij stap 3 op het scherm stond, pagina voor pagina.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Every sentence the JavaScript puts on this page. They live here rather than
+    in src/, because src/ is copied byte for byte into all eleven languages and
+    a sentence written there would be English in ten of them. See
+    shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="detect.found">De vier hoeken zijn gevonden. Controleer ze
+      en sleep de hoeken recht die ernaast liggen.</span>
+    <span data-phrase="detect.unsure">De randen van de pagina waren niet duidelijk
+      genoeg om zeker te zijn. Deze hoeken zijn een gok: sleep ze op de pagina
+      voordat je verdergaat.</span>
+    <span data-phrase="detect.nothing">In deze foto was geen pagina te
+      onderscheiden, daarom liggen de hoeken op de randen ervan. Sleep ze op de
+      pagina.</span>
+    <span data-phrase="detect.flat">In dit beeld valt niets te vinden, het heeft
+      helemaal geen randen.</span>
+    <span data-phrase="detect.tiny">Dit beeld is te klein om er een pagina in te
+      vinden.</span>
+    <span data-phrase="detect.edited">Deze hoeken zijn nu van jou. &bdquo;Hoeken
+      opnieuw zoeken&rdquo; meet de foto van voren af aan op.</span>
+
+    <span data-phrase="corner.tl">Hoek linksboven</span>
+    <span data-phrase="corner.tr">Hoek rechtsboven</span>
+    <span data-phrase="corner.br">Hoek rechtsonder</span>
+    <span data-phrase="corner.bl">Hoek linksonder</span>
+    <span data-phrase="corner.at">{corner}, op {x} in de breedte en {y} naar
+      beneden. De pijltjestoetsen verplaatsen hem, en met Shift erbij tien pixels
+      tegelijk.</span>
+
+    <span data-phrase="page.select">Pagina {index} bewerken</span>
+    <span data-phrase="page.remove">Pagina {index} verwijderen</span>
+    <span data-phrase="page.earlier">Pagina {index} naar voren schuiven</span>
+    <span data-phrase="page.later">Pagina {index} naar achteren schuiven</span>
+    <span data-phrase="page.count">{count} pagina</span>
+    <span data-phrase="page.counts">{count} pagina's</span>
+
+    <span data-phrase="paper.a">A4 of A5</span>
+    <span data-phrase="paper.letter">US Letter</span>
+    <span data-phrase="paper.legal">US Legal</span>
+    <span data-phrase="paper.card">een visitekaartje</span>
+    <span data-phrase="shape.known">De pagina kwam er als {ratio} uit, en dat is
+      de vorm van {paper}.</span>
+    <span data-phrase="shape.sideways">De pagina kwam er als {ratio} uit, en dat
+      is de vorm van {paper} in liggend formaat.</span>
+    <span data-phrase="shape.unknown">De pagina kwam er als {ratio} uit, en dat is
+      geen standaardformaat.</span>
+
+    <span data-phrase="method.perspective">De vorm is teruggerekend uit het
+      perspectief in de foto, dus het is de vorm van de pagina en niet die waarin
+      ze in beeld verscheen.</span>
+    <span data-phrase="method.edges">De foto is recht van voren genomen, dus de
+      vorm is rechtstreeks aan de randen gemeten.</span>
+
+    <span data-phrase="quality.good">{width} bij {height} pixels, ongeveer {dpi}
+      DPI op een pagina van dit formaat, genoeg om af te drukken.</span>
+    <span data-phrase="quality.fair">{width} bij {height} pixels, ongeveer {dpi}
+      DPI op een pagina van dit formaat. Op het scherm goed, op papier wat
+      slap.</span>
+    <span data-phrase="quality.low">{width} bij {height} pixels, ongeveer {dpi}
+      DPI op een pagina van dit formaat. Ga dichterbij staan als dit afgedrukt
+      moet worden.</span>
+    <span data-phrase="quality.pixels">{width} bij {height} pixels.</span>
+    <span data-phrase="coverage.note">De pagina vulde {percent}% van de
+      foto.</span>
+    <span data-phrase="coverage.small">De pagina vulde maar {percent}% van de
+      foto, dus het meeste van wat je gefotografeerd hebt was tafel. Volgende keer
+      dichterbij.</span>
+
+    <span data-phrase="strength.gentle">Zacht: het papier wordt gelijkgetrokken en
+      verder weinig. Voor een pagina met bleek potlood of een foto erop.</span>
+    <span data-phrase="strength.middling">De gebruikelijke instelling: het papier
+      wordt weer wit en gedrukte tekst weer zwart.</span>
+    <span data-phrase="strength.hard">Hard: alles wat grijs is wordt naar zwart of
+      wit geduwd. Het schoonst op een pagina met alleen gedrukte tekst en
+      vernietigend voor alles met een beeld erop.</span>
+
+    <span data-phrase="busy.page">Pagina {done} van {total}&hellip;</span>
+    <span data-phrase="busy.writing">Het document wordt geschreven&hellip;</span>
+
+    <span data-phrase="result.pdf">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.images">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.mono">Opgeslagen met &eacute;&eacute;n bit per pixel
+      en exact gecomprimeerd, en daarom is het zo klein.</span>
+    <span data-phrase="result.jpeg">De pagina's zijn opgeslagen als JPEG in de
+      kwaliteit die je gekozen hebt.</span>
+    <span data-phrase="result.png">De pagina's zijn opgeslagen als PNG, dat
+      verliesvrij is en dat is wat een beeld van twee kleuren wil. JPEG zou
+      tegelijk groter en rond elke letter onscherp zijn.</span>
+    <span data-phrase="result.clean">Geen datum, geen auteur, geen computernaam:
+      het enige in het document behalve de pagina's is de naam van dit
+      gereedschap.</span>
+
+    <span data-phrase="size.fit">Elk vel krijgt de grootte die zijn eigen pagina
+      werkelijk heeft, in de resolutie hierboven. Er wordt niets met balken
+      opgevuld.</span>
+    <span data-phrase="size.named">Elke pagina wordt op een vel {name} gezet,
+      binnen de marge, welke vorm ze ook gekregen heeft.</span>
+
+    <span data-phrase="error.decode">Deze browser kon {name} niet openen. Als het
+      een HEIC-foto van een iPhone is, zet hem dan eerst om.</span>
+    <span data-phrase="error.none">Kies eerst minstens &eacute;&eacute;n foto.</span>
+    <span data-phrase="error.failed">Er ging iets mis bij het maken van het
+      bestand: {detail}</span>
+  </div>
+</main>

--- a/locales/nl/tools/document-scanner.toml
+++ b/locales/nl/tools/document-scanner.toml
@@ -1,0 +1,308 @@
+#
+# Document Scanner - Dutch.
+#
+# Overrides for tools/document-scanner/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Scannen" en "scan" zijn wat er getypt en gezocht wordt, ook al is het een
+# leenwoord: niemand vraagt een instantie om een formulier te "digitaliseren en
+# terug te sturen". Eigennamen blijven staan: Sauvola, Zhang en He, DPI, OCR.
+#
+
+name = "Documentscanner"
+heading = "Documentscanner <span class=\"h1-kw\">&mdash; een foto van een pagina, rechtgetrokken</span>"
+tagline = "Fotografeer de pagina. Je krijgt iets terug dat eruitziet als een scan."
+
+title = "Documentscanner &mdash; van foto naar gescande PDF, zonder uploaden"
+description = "Maak van een telefoonfoto van een pagina een rechtgetrokken, gelijkmatig belichte PDF. De hoeken worden voor je gevonden, het perspectief wordt teruggedraaid, de schaduw wordt eruit gedeeld. Draait helemaal in je browser: er wordt niets ge&uuml;pload."
+og_title = "Een document scannen met een foto, zonder het te uploaden"
+og_description = "De hoeken van de pagina worden gevonden, de hoek wordt teruggedraaid en het ongelijke licht wordt eruit gedeeld, in je eigen browser. Wat mensen zo fotograferen is een paspoort, een loonstrook of een contract, en dat is precies wat niet ge&uuml;pload zou moeten worden."
+og_image_alt = "Documentscanner - een foto van een pagina, rechtgetrokken en opgeschoond, zonder hem te uploaden"
+
+pledge = """
+    De foto wordt door je eigen browser gedecodeerd, rechtgetrokken, opgeschoond
+    en in een PDF geschreven, met niets anders dan rekenwerk en de codecs die hij
+    al meebrengt. Dit gereedschap heeft geen enkele netwerkfunctie &mdash; niets
+    op te halen, niets te versturen &mdash; en waarom dat hier uitmaakt is waar
+    mensen pagina's van fotograferen: een paspoort, een loonstrook, een
+    huurcontract, een formulier dat een instantie heeft gevraagd te
+    &bdquo;scannen en terug te sturen&rdquo;."""
+
+live_hint = """
+      Neem het niet van ons aan: open DevTools, kijk naar het tabblad Netwerk en
+      scan een pagina. Geen enkel verzoek draagt een foto, een miniatuur, een
+      bestandsnaam of de positie van &eacute;&eacute;n hoek mee. Of trek de
+      stekker uit het internet en scan er toch een."""
+
+read_first = """
+, <code>src/detect.js</code> voor hoe de hoeken
+      zonder enig model gevonden worden, <code>src/warp.js</code> voor het
+      rechttrekken, en <code>src/clean.js</code> voor hoe het ongelijke licht
+      eruit gedeeld wordt."""
+
+howto_heading = "Zo scan je een document met de camera van je telefoon"
+
+card = """
+            Een foto van een pagina, rechtgetrokken en opgeschoond tot een
+            document. De hoeken worden voor je gevonden, de hoek wordt
+            teruggedraaid en de schaduw wordt eruit gedeeld."""
+
+[words]
+plural = "documenten"
+choose = "een foto van een pagina"
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Je documenten kunnen nergens heen."
+body = """
+ Het
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen enkel adres daarvan hoort bij deze site. Er is hier geen eindpunt waar
+      je foto's verzameld zouden kunnen worden, en niets in de code dat ze zou
+      versturen als dat er wel was."""
+
+[[privacy]]
+title = "Er is geen model, dus er valt niets te downloaden en niets te vragen."
+body = """
+ De vier hoeken
+      van een pagina vinden gebeurt met rekenwerk: de gradi&euml;nt van het beeld,
+      een stem voor de rechte lijnen erin, en een controle van wat er werkelijk
+      onder elke zijde van de winnende rechthoek ligt. Geen gewichten, geen
+      inferentie-runtime, niets dat bij het eerste gebruik opgehaald wordt, en
+      niets dat zich bij het document van iemand anders anders gedraagt dan bij het
+      jouwe &mdash; zie <code>src/detect.js</code>."""
+
+[[privacy]]
+title = "Het document draagt geen datum, geen auteur en geen machinenaam."
+body = """
+ Een scan is
+      iets dat mensen naar andere mensen sturen, meestal omdat een instantie erom
+      gevraagd heeft. Het enige wat er behalve de pagina's zelf in de PDF
+      geschreven wordt is de naam van dit gereedschap, en een titel als je er een
+      typt. Er is geen aanmaakdatum, geen auteur, geen serienummer en niets dat is
+      afgeleid van je klok, je bestandsnamen of je computer &mdash; zie
+      <code>src/document.js</code>."""
+
+[[privacy]]
+title = "Hier haalt niets iets op."
+body = """
+ Er staat geen
+      <code>fetch</code>, geen <code>XMLHttpRequest</code> en geen
+      <code>sendBeacon</code> ergens in <code>src/</code>. Het werk is
+      <code>getImageData</code>, wat lussen over de bytes, en de eigen
+      JPEG-encoder van de browser &mdash; allemaal al ge&iuml;nstalleerd op je
+      machine."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en het gereedschap is
+      onveranderd, want er heeft nooit een netwerkstap in gezeten. Dat is het
+      eenvoudigste bewijs van allemaal &mdash; en het bewijs dat het waard is te
+      draaien voordat je een paspoort scant."""
+
+[[howto]]
+title = "Fotografeer de pagina."
+body = """
+ Van boven, met de hele pagina in
+      beeld en de vier hoeken zichtbaar of bijna. Hij hoeft niet recht van voren en
+      hij hoeft niet gelijkmatig belicht: de hoek en de schaduw zijn waar dit
+      gereedschap voor is. Wat wel uitmaakt is het beeld vullen &mdash; een pagina
+      die van de andere kant van de kamer gefotografeerd is, heeft geen detail meer
+      om terug te halen."""
+
+[[howto]]
+title = "Controleer de vier hoeken."
+body = """
+ Ze worden voor je gevonden
+      zodra de foto gelezen is, en de pagina zegt het als hij het niet zeker weet
+      &mdash; een pagina op een bureau van dezelfde kleur als het papier heeft
+      werkelijk een rand die nauwelijks te zien is. Druk ergens op de foto en de
+      dichtstbijzijnde hoek komt naar je vinger toe, of bereik er een met
+      <kbd>Tab</kbd> en verplaats hem met de pijltjestoetsen."""
+
+[[howto]]
+title = "Kies wat er met het licht moet gebeuren."
+body = """
+ &bdquo;Kleur,
+      gelijkgetrokken&rdquo; meet het papier over de pagina heen en deelt het eruit,
+      zodat de schaduw verdwijnt en een stempel of een handtekening zijn kleur
+      houdt. &bdquo;Zwart-wit&rdquo; gaat verder en is wat een scan klein genoeg
+      maakt om te mailen. Wat je op het scherm ziet is het echte resultaat,
+      gemaakt door dezelfde code die het bestand schrijft."""
+
+[[howto]]
+title = "Voeg de andere pagina's toe."
+body = """
+ Elke foto die je toevoegt
+      wordt een volgende pagina van hetzelfde document, in de volgorde waarin ze
+      staan, en elke pagina houdt haar eigen hoeken. De pijltjes bij een pagina in
+      de strook verplaatsen haar naar voren of naar achteren."""
+
+[[howto]]
+title = "Sla de PDF op, en open hem voordat je hem verstuurt."
+body = """
+ Het
+      document wordt hier opgebouwd, in het geheugen van deze pagina. Er is niets
+      ge&uuml;pload om het te maken, en er is nergens iets over gemeld."""
+
+[[faq]]
+q = "Wordt mijn document ergens naartoe ge&uuml;pload?"
+a = """
+        Nee. De foto wordt door je eigen browser op je eigen hardware gedecodeerd,
+        rechtgetrokken, opgeschoond en in een PDF geschreven. Dit gereedschap heeft
+        geen enkele netwerkfunctie &mdash; het haalt nooit iets op en verstuurt
+        nooit iets &mdash; en het <code>Content-Security-Policy</code> van de pagina
+        noemt elk adres dat hij mag benaderen, en geen daarvan hoort bij deze site.
+        Laad de pagina &eacute;&eacute;n keer, trek de stekker uit het internet, en
+        hij werkt nog steeds."""
+
+[[faq]]
+q = "Hoe vindt hij de hoeken van de pagina zonder model?"
+a = """
+        Door te zoeken naar de vier lange rechte randen waaruit een rechthoek
+        bestaat. De foto wordt verkleind, de gradi&euml;nt wordt genomen &mdash;
+        waar het beeld verandert, en in welke richting &mdash; en elke pixel die op
+        een rand ligt stemt op de rechte lijn waar hij op zou liggen. De sterke
+        lijnen worden tot kandidaat-rechthoeken gekoppeld, en elke kandidaat krijgt
+        een score door zijn vier zijden af te lopen en te vragen hoeveel van elke
+        zijde er werkelijk een rand onder heeft, en of die vier samen de grens van
+        &eacute;&eacute;n ding zijn: een pagina is lichter dan wat eromheen ligt, of
+        donkerder, maar op alle vier de zijden hetzelfde, en dat is wat voorkomt dat
+        een regel tekst voor de onderkant van de pagina wordt aangezien. Er zijn
+        geen gewichten, er wordt niets gedownload, en het rekenwerk is hetzelfde
+        rekenwerk voor elk document dat erdoorheen gaat."""
+
+[[faq]]
+q = "De hoeken die hij gevonden heeft kloppen niet. Wat nu?"
+a = """
+        Sleep ze. De hoeken zijn een beginpositie en nooit een beslissing: de scan
+        wordt genomen van waar de vier uiteindelijk staan. Druk ergens op de foto en
+        de dichtstbijzijnde hoek springt naar je vinger, wat makkelijker is dan een
+        klein handvat raken, en de pijltjestoetsen verplaatsen de hoek met de focus
+        &eacute;&eacute;n pixel per keer. De pagina vertelt je ook wanneer de hoeken
+        een gok zijn in plaats van een vondst, en markeert die pagina in de strook
+        &mdash; een pagina die op een bureau van ongeveer zijn eigen kleur ligt is de
+        gebruikelijke reden, want daar valt echt bijna geen rand te vinden."""
+
+[[faq]]
+q = "Waarom komt de rechtgetrokken pagina in de goede vorm uit en niet platgedrukt?"
+a = """
+        Omdat de vorm uit het perspectief wordt teruggerekend en niet van de randen
+        wordt afgemeten. Een pagina die schuin gefotografeerd is heeft een verkorte
+        verre rand, dus de voor de hand liggende methode &mdash; neem het langste
+        paar tegenoverliggende randen en noem dat de verhouding &mdash; levert een
+        zichtbaar gedrongen A4 op, en dat is wat de meeste webscanners je geven. Een
+        foto van een rechthoek draagt in werkelijkheid genoeg informatie om zowel de
+        verhouding van de rechthoek als de brandpuntsafstand van de camera terug te
+        rekenen, mits de camera een gewone is; dat is een resultaat van Zhang en He
+        uit 2003, en dat is wat <code>src/geometry.js</code> doet. Waar de foto recht
+        van voren genomen is, is er geen perspectief om mee te werken en is dat ook
+        niet nodig, want dan zijn de randen exact &mdash; dus valt hij daarop terug,
+        en de pagina zegt welke van de twee het antwoord gaf."""
+
+[[faq]]
+q = "Wat doet het &bdquo;opschonen&rdquo; nu eigenlijk met het beeld?"
+a = """
+        Het deelt het licht eruit. De eigen helderheid van het papier wordt over de
+        pagina heen gemeten &mdash; een raster van vakjes, en in elk vakje een hoog
+        percentiel van de helderheid, dat tekst te donker en te schaars is om te
+        verschuiven &mdash; en elke pixel wordt gedeeld door het papier zoals dat op
+        dat punt geschat is. Wat overblijft is de inkt, gelijkmatig belicht, zonder
+        de schaduw en zonder de afval van licht naar de randen. Dat is niet hetzelfde
+        als het contrast verhogen: het contrast van een gefotografeerde pagina
+        verhogen maakt het lichte deel wit, het donkere deel zwart, en wat er in het
+        donkere deel staat onleesbaar, en daarom maken &bdquo;automatische
+        niveaus&rdquo; deze beelden slechter in plaats van beter."""
+
+[[faq]]
+q = "Waarom is de zwart-witmodus zoveel kleiner?"
+a = """
+        Omdat een beeld met twee kleuren erin werkelijk een fractie is van de
+        gegevens van een beeld met zestien miljoen, en het wordt hier ook zo
+        opgeslagen: &eacute;&eacute;n bit per pixel, acht per byte ingepakt en exact
+        gecomprimeerd, en niet als een JPEG van een zwart-witbeeld. Op dezelfde
+        pagina's komt het er ongeveer achttien keer kleiner uit dan de kleurmodus,
+        dus een contract van twintig pagina's blijft onder een megabyte in plaats van
+        rond de vijftien te landen. De drempel is die van Sauvola, die elke pixel
+        beoordeelt tegen het gemiddelde en de spreiding van zijn eigen omgeving in
+        plaats van tegen &eacute;&eacute;n getal voor de hele pagina &mdash; en dat
+        is wat het schrift binnen een schaduw leesbaar houdt. Hij kent geen
+        halftonen, dus een pagina met een foto erop kan beter een van de andere
+        modi nemen."""
+
+[[faq]]
+q = "Kan ik meerdere pagina's in &eacute;&eacute;n PDF zetten?"
+a = """
+        Ja. Elke foto die je toevoegt wordt een volgende pagina, in de volgorde
+        waarin ze staan, en elke pagina houdt haar eigen hoeken &mdash; dus een
+        stapel pagina's die na elkaar gefotografeerd is wordt &eacute;&eacute;n
+        document. De pijltjes bij elke pagina in de strook verplaatsen haar naar
+        voren of naar achteren. De opschoon-instelling wordt met opzet door
+        allemaal gedeeld: pagina's in &eacute;&eacute;n document die verschillend
+        opgeschoond zijn, zien eruit als twee documenten."""
+
+[[faq]]
+q = "Leest hij de tekst, zodat ik de PDF kan doorzoeken?"
+a = """
+        Nee. Er is geen tekstlaag en geen tekenherkenning: wat eruit komt is een
+        beeld van de pagina op een pagina. Het goed doen zou een OCR-motor betekenen,
+        en dat zijn tientallen megabytes aan model om te downloaden &mdash; en een
+        documentscanner die een model ophaalde voordat hij je loonstrook kon lezen,
+        zou een documentscanner zijn met een reden om over loonstroken naar huis te
+        bellen. Als je de tekst nodig hebt, levert de zwart-witmodus precies het
+        soort bestand op waar OCR-software op je eigen machine het beste mee
+        werkt."""
+
+[[faq]]
+q = "Hij is wazig geworden. Waarom?"
+a = """
+        Bijna altijd omdat de pagina klein was in de foto. Het paneel onder het
+        voorbeeld zegt hoeveel van het beeld de pagina vulde en ongeveer hoeveel
+        punten per inch dat oplevert op een vel van dat formaat &mdash; onder zo'n
+        150 DPI ziet een afgedrukte scan er slap uit, en geen enkel gereedschap kan
+        iets doen aan detail dat nooit in het bestand heeft gezeten. Ga dichterbij
+        staan in plaats van in te zoomen, houd stil, en laat de camera scherpstellen
+        op de pagina voordat je op de knop drukt. Bewegingsonscherpte is de andere
+        oorzaak, en die is ook niet terug te halen."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode, geen
+        paginalimiet en geen watermerk. Er is ook geen limiet op de grootte van de
+        foto's, want er is geen server die ervoor betaalt &mdash; het werk gebeurt op
+        je eigen machine. De site draait advertenties, en dat is wat hem betaalt; de
+        adverteerders krijgen niets over je documenten."""
+
+[schema]
+description = "Scan een document in de browser: fotografeer een pagina, en de vier hoeken worden gevonden, het perspectief wordt teruggedraaid, het ongelijke licht wordt eruit gedeeld, en het resultaat wordt in een PDF geschreven. Meerdere pagina's worden &eacute;&eacute;n document. Er wordt niets ge&uuml;pload."
+features = [
+  "Vindt de vier hoeken van de pagina zonder model, zonder download en zonder iets op te halen",
+  "Rekent de echte vorm van de pagina terug uit het perspectief, zodat een schuine foto er niet platgedrukt uitkomt",
+  "Deelt ongelijk licht en schaduw eruit in plaats van het contrast te verhogen",
+  "Zwart-witpagina's opgeslagen op &eacute;&eacute;n bit per pixel, en dat is wat een scan klein genoeg maakt om te mailen",
+  "Meerdere foto's worden de pagina's van &eacute;&eacute;n PDF, elk met eigen hoeken",
+  "Hoeken zijn te slepen, of vanaf het toetsenbord per pixel te verplaatsen",
+  "Zegt wanneer de hoeken een gok zijn in plaats van een vondst",
+  "Schrijft geen datum, geen auteur en geen machinenaam in het document",
+  "Werkt offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep hier foto's van je pagina's naartoe"
+hint = "of klik om te bladeren &mdash; &eacute;&eacute;n foto per pagina, op paginavolgorde"

--- a/locales/nl/tools/redact-pdf.html
+++ b/locales/nl/tools/redact-pdf.html
@@ -1,0 +1,307 @@
+<!--
+  tools/redact-pdf/body.html, in Dutch.
+
+  Every id, class, data-phrase key and brace placeholder below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+
+  De count.*-paren blijven dubbel: het Nederlands onderscheidt enkelvoud en
+  meervoud, dus ze dragen hier werkelijk twee vormen.
+-->
+<main>
+  <!-- Stap 1 &mdash; het document -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies een PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <div id="doc-facts" class="doc-facts" hidden>
+      <p id="doc-name" class="doc-name"></p>
+      <p id="doc-sub" class="doc-sub"></p>
+      <ul id="doc-warnings" class="doc-warnings"></ul>
+    </div>
+  </section>
+
+  <!-- Stap 2 &mdash; zoeken -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Zeggen wat er weg moet</h2>
+
+    <p class="card-lede">
+      Typ de woorden, een naam, een adres, een kenmerk, en elke plek waar ze
+      voorkomen wordt hieronder met hun regel opgesomd. Tot stap 4 wordt er niets
+      weggehaald, en er wordt niets weggehaald wat je niet hebt aangevinkt.
+    </p>
+
+    <label class="find-label" for="terms">Woorden en zinsdelen, &eacute;&eacute;n per regel</label>
+    <textarea id="terms" rows="3" spellcheck="false" autocomplete="off"
+              placeholder="Jansen&#10;Brugstraat 14&#10;ZK-40219"></textarea>
+
+    <div class="find-row">
+      <button type="button" id="find" class="primary">Zoeken</button>
+      <label class="inline-check">
+        <input type="checkbox" id="match-case"> <span>Let op hoofdletters</span>
+      </label>
+      <label class="inline-check">
+        <input type="checkbox" id="whole-word"> <span>Alleen hele woorden</span>
+      </label>
+    </div>
+
+    <fieldset class="finders">
+      <legend>Of zoeken naar wat meestal gevoelig ligt</legend>
+      <div class="chips" id="finders"></div>
+      <p class="field-note" id="finder-note">
+        Dit zijn patronen, en een patroon kan een telefoonnummer niet van een
+        kenmerk onderscheiden. Kaartnummers en IBAN's worden tegen hun eigen
+        controlecijfers gecontroleerd; de rest wordt aangeboden en nooit voor je
+        aangevinkt, en elke treffer is een blik waard.
+      </p>
+    </fieldset>
+
+    <div class="toolbar" id="match-bar" hidden>
+      <span id="match-count" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="tick-all" class="ghost">Alles aanvinken</button>
+        <button type="button" id="tick-none" class="ghost">Alles uitvinken</button>
+        <button type="button" id="clear-found" class="ghost danger">Lijst leegmaken</button>
+      </div>
+    </div>
+
+    <ul id="match-list" class="match-list" hidden></ul>
+    <p id="match-more" class="field-note" hidden></p>
+  </section>
+
+  <!-- Stap 3 &mdash; de pagina lezen -->
+  <section class="card" id="page-card" hidden>
+    <h2><span class="step">3</span> De pagina lezen en er woorden vanaf pikken</h2>
+
+    <p class="card-lede">
+      Dit is de tekst zoals hij in het document is opgeslagen, in de volgorde
+      waarin een lezer hem zou kopi&euml;ren, en dat is niet altijd de volgorde
+      waarin hij gedrukt staat. Klik een woord aan om het weg te halen, en nog
+      eens om het te houden. Alles wat hier doorgestreept is, is wat er zal
+      verdwijnen.
+    </p>
+
+    <div class="pager">
+      <button type="button" id="prev-page" class="ghost">&#8592; Terug</button>
+      <span id="page-of" class="count"></span>
+      <button type="button" id="next-page" class="ghost">Verder &#8594;</button>
+      <span class="pager-spacer"></span>
+      <span id="page-picked" class="count"></span>
+      <button type="button" id="clear-page" class="ghost danger">Op deze pagina alles houden</button>
+    </div>
+
+    <p id="page-note" class="field-summary" hidden></p>
+
+    <div id="page-text" class="page-text" role="group" aria-label="De tekst van deze pagina"></div>
+  </section>
+
+  <!-- Stap 4 &mdash; doen -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> De woorden weghalen</h2>
+
+    <label class="check">
+      <input type="checkbox" id="opt-boxes" checked>
+      <span>
+        <strong>Een zwarte balk tekenen waar elk woord stond</strong>
+        <span class="check-note">
+          Zodat een lezer ziet dat er iets is weggehaald. De balk is hier
+          versiering en niet de onleesbaarmaking: de letters zijn uit het bestand
+          verdwenen voordat hij getekend wordt. Zet hem uit, en de woorden
+          verdwijnen gewoon en laten de ruimte achter die ze innamen.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-elsewhere" checked>
+      <span>
+        <strong>Dezelfde woorden uit de rest van het document halen</strong>
+        <span class="check-note">
+          Bladwijzers, opmerkingen, plaknotities en wat er in formuliervakken
+          getypt is. Een woord dat van een pagina is gehaald en in een bladwijzer
+          is blijven staan, is niet weggehaald. De eigenschappen van het document
+          gaan sowieso weg, en de vervangtekst die een lezer kopieert in plaats
+          van de letters op de pagina ook: allebei zijn ze het document dat het
+          woord zegt, en niet een andere plek die er een kopie van bewaart.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-attachments" checked>
+      <span>
+        <strong>Bijlagen en alles wat draait weggooien</strong>
+        <span class="check-note">
+          Een PDF kan hele bestanden in zich dragen en JavaScript dat draait bij
+          het openen. In geen van beide is te zoeken naar de woorden die je
+          weghaalt, en om een document te lezen is geen van beide nodig.
+        </span>
+      </span>
+    </label>
+
+    <p class="field-summary" id="run-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Weghalen</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Downloaden</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+      <ul id="check-terms" class="check-terms" hidden></ul>
+      <ul id="result-facts" class="result-facts"></ul>
+    </div>
+  </section>
+
+  <!--
+    The sentences this tool's JavaScript puts on screen. They live here rather
+    than in src/ because src/ is copied byte for byte into all eleven
+    languages; see "The strings in the JavaScript" in the repository README.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="load.notpdf">Dit is geen PDF, dus er staat geen tekst in om weg te halen.</span>
+    <span data-phrase="load.encrypted">Deze PDF heeft een wachtwoord. De
+      beveiliging van een document afhalen is een andere klus dan er woorden uit
+      halen, en dit gereedschap doet het niet achter je rug om.</span>
+    <span data-phrase="load.broken">Dit bestand kon niet als PDF geopend worden ({detail}).</span>
+    <span data-phrase="load.nopages">Hij ging open, maar er waren geen pagina's in te vinden.</span>
+    <span data-phrase="load.repaired">De kruisverwijzingstabel van dit document
+      paste niet bij de inhoud, dus is het gelezen door naar objecten te zoeken.
+      Dat is een reparatie, en hij is gelukt. Controleer het resultaat zorgvuldig
+      voordat je het ergens heen stuurt.</span>
+
+    <span data-phrase="doc.sub">{pages} &middot; {words} tekst &middot; {size}</span>
+    <span data-phrase="doc.notext">{count} van deze pagina's hebben helemaal geen
+      tekst. Zo'n pagina is een beeld van een pagina, en voor dit gereedschap valt
+      daar niets weg te halen: de woorden in het beeld blijven precies waar ze
+      zijn.</span>
+    <span data-phrase="doc.unreadable">{count} letters van dit document konden
+      niet als tekens gelezen worden, omdat de gebruikte lettertypen geen
+      koppeling van hun glyphen terug naar tekst meebrengen. Naar deze letters is
+      niet te zoeken, dus bekijk de pagina's waar ze op staan in plaats van op de
+      zoekopdracht te vertrouwen.</span>
+    <span data-phrase="doc.scan">Sommige pagina's dragen onzichtbare tekst over
+      een beeld heen, en zo legt een scanner vast wat zijn lezer van de pagina
+      gemaakt heeft. Die tekst weghalen haalt weg wat een zoekopdracht en een
+      kopieeractie zouden vinden. Het verandert niets aan het beeld, en in het
+      beeld zijn de woorden nog steeds leesbaar.</span>
+
+    <span data-phrase="find.none">Op geen enkele pagina was er een treffer.</span>
+    <span data-phrase="find.some">{count} op {pages}.</span>
+    <span data-phrase="find.more">De eerste {shown} staan in de lijst. De rest is
+      gevonden en wordt meegehaald als je alles aanvinkt.</span>
+    <span data-phrase="find.terms">Typ hierboven een woord of kies een patroon voordat je op Zoeken drukt.</span>
+
+    <span data-phrase="page.of">Pagina {number} van {total}</span>
+    <span data-phrase="page.picked">{count} worden van deze pagina gehaald</span>
+    <span data-phrase="page.notext">Op deze pagina staat geen tekst. Of hij is
+      leeg, of hij is een beeld van een pagina: een scan, een foto, een export die
+      zijn woorden als vormen getekend heeft. Niets erop is te doorzoeken, en
+      niets erop is hier weg te halen.</span>
+    <span data-phrase="page.unreadable">{count} letters op deze pagina konden niet
+      als tekens gelezen worden. Ze staan hieronder als &#9647;, en de
+      zoekopdracht vindt ze niet.</span>
+    <span data-phrase="page.scan">De tekst op deze pagina is onzichtbaar: hij ligt
+      over een beeld van de pagina heen, en zo wordt een scan doorzoekbaar
+      gemaakt. Wat je hier weghaalt is wat een zoekopdracht en een kopieeractie
+      zouden vinden. Het beeld houdt de woorden.</span>
+
+    <span data-phrase="run.summary">{words} op {pages} worden weggehaald.</span>
+    <span data-phrase="run.nothing">Er is nog niets aangevinkt. Zoek bij stap 2 een woord, of klik er bij stap 3 een aan.</span>
+    <span data-phrase="run.editing">De woorden worden weggehaald&hellip;</span>
+    <span data-phrase="run.writing">Het document wordt geschreven&hellip;</span>
+    <span data-phrase="run.checking">Het klare bestand wordt geopend en doorzocht&hellip;</span>
+    <span data-phrase="run.failed">Er ging iets mis bij het herschrijven van dit document ({detail}).</span>
+    <span data-phrase="run.cancelled">Geannuleerd. Er is niets geschreven.</span>
+
+    <span data-phrase="result.headline">{words} weggehaald</span>
+    <span data-phrase="result.sub">{size} &middot; {pages} gewijzigd &middot; {boxes}</span>
+    <span data-phrase="check.good">Hier opnieuw geopend en doorzocht, zoals een
+      lezer het zou doen: geen daarvan staat in het klare bestand.</span>
+    <span data-phrase="check.partial">Hier opnieuw geopend en doorzocht: elk
+      voorkomen dat je hebt aangevinkt is weg, en die je hebt laten staan zijn er
+      nog.</span>
+    <span data-phrase="check.survived">Dit bestand is NIET geschreven. Het klare
+      document is opnieuw geopend, en een deel van wat je hebt weggehaald was er
+      nog steeds in te vinden. De onleesbaarmaking was dus niet volledig. Er wordt
+      niets ter download aangeboden.</span>
+    <span data-phrase="check.pages">Dit bestand is NIET geschreven. Het klare
+      document kwam terug met een ander aantal pagina's dan waarmee het erin ging,
+      dus er is meer misgegaan dan alleen de woorden. Er wordt niets ter download
+      aangeboden.</span>
+
+    <span data-phrase="fact.boxes">{count} over de gaten getekend.</span>
+    <span data-phrase="fact.noboxes">Er zijn geen balken getekend, dus de woorden
+      zijn weg zonder dat iets zegt waar ze stonden.</span>
+    <span data-phrase="fact.elsewhere">Dezelfde woorden zijn weggehaald uit {where}.</span>
+    <span data-phrase="fact.metadata">De documenteigenschappen en het XMP-pakket
+      zijn verwijderd, dus het klare bestand zegt niet wat het gemaakt heeft,
+      wanneer, of hoe het eerder heette.</span>
+    <span data-phrase="fact.carried">{attachments} en {actions} zijn weggegooid.</span>
+    <span data-phrase="fact.shared">Een deel van wat je hebt weggehaald werd
+      getekend door een blok dat het document op meer dan &eacute;&eacute;n pagina
+      hergebruikt, dus het is van elke pagina verdwenen die dat blok tekent. Dat is
+      meer dan je hebt aangevinkt, en nooit minder.</span>
+    <span data-phrase="fact.overimage">{count} van de weggehaalde letters lagen
+      over een beeld van dezelfde pagina. Uit de tekstlaag zijn ze weg en in het
+      beeld staan ze nog: een lezer kan ze niet meer zoeken of kopi&euml;ren en ziet
+      ze nog steeds.</span>
+    <span data-phrase="fact.untouched">Al het andere op elke pagina is byte voor
+      byte doorgegeven. Er is geen lettertype, geen beeld en geen lijn opnieuw
+      gecodeerd.</span>
+
+    <span data-phrase="count.pages">{count} pagina's</span>
+    <span data-phrase="count.page">{count} pagina</span>
+    <span data-phrase="count.words">{count} woorden</span>
+    <span data-phrase="count.word">{count} woord</span>
+    <span data-phrase="count.pieces">{count} tekststukken</span>
+    <span data-phrase="count.piece">{count} tekststuk</span>
+    <span data-phrase="count.matches">{count} treffers</span>
+    <span data-phrase="count.match">{count} treffer</span>
+    <span data-phrase="count.boxes">{count} zwarte balken</span>
+    <span data-phrase="count.box">{count} zwarte balk</span>
+    <span data-phrase="count.attachments">{count} bijlagen</span>
+    <span data-phrase="count.attachment">{count} bijlage</span>
+    <span data-phrase="count.actions">{count} acties</span>
+    <span data-phrase="count.action">{count} actie</span>
+    <span data-phrase="count.hosts">{count} hosts</span>
+    <span data-phrase="count.host">{count} host</span>
+
+    <!-- The space before {platform} belongs to these two rather than to the
+         phrase it lets in, because phrases.js collapses and trims the markup
+         it reads and a leading space would not survive the trip. -->
+    <span data-phrase="net.clean">Je document is nergens heen gegaan. {total}
+      bestanden geladen, allemaal van deze site zelf. {platform}</span>
+    <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit
+      gereedschap nooit. Dat is het waard om na te kijken. {platform}</span>
+    <span data-phrase="net.platform">De eigen scripts van de site voor
+      advertenties, meting en de donatieknop kwamen van {hosts}; geen daarvan heeft
+      een document, een woord eruit of iets waar je op gezocht hebt
+      gekregen.</span>
+
+    <span data-phrase="finder.email">E-mailadressen</span>
+    <span data-phrase="finder.card">Kaartnummers</span>
+    <span data-phrase="finder.iban">Bankrekeningen (IBAN)</span>
+    <span data-phrase="finder.nationalid">BSN &amp; socialezekerheidsnummers</span>
+    <span data-phrase="finder.phone">Telefoonnummers</span>
+  </div>
+</main>

--- a/locales/nl/tools/redact-pdf.toml
+++ b/locales/nl/tools/redact-pdf.toml
@@ -1,0 +1,378 @@
+#
+# Redact a PDF - Dutch.
+#
+# Overrides for tools/redact-pdf/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Onleesbaar maken" is hetzelfde werkwoord als bij afbeelding-onleesbaar-maken,
+# en het draagt dezelfde belofte: de letters gaan uit het bestand, er komt geen
+# balk overheen. "Lakken" komt uit de Woo-hoek en leest als jargon; "afdekken"
+# zou precies de fout beschrijven waar deze pagina voor waarschuwt.
+#
+
+name = "PDF onleesbaar maken"
+heading = "PDF&nbsp;onleesbaar&nbsp;maken <span class=\"h1-kw\">&mdash; de woorden gaan eruit, er komt geen balk overheen</span>"
+tagline = "De letters worden uit het bestand gewist, en daarna wordt het bestand doorzocht om het te bewijzen."
+
+title = "Een PDF onleesbaar maken &mdash; de tekst echt wissen, gratis, zonder uploaden"
+description = "Haal woorden uit een PDF in plaats van er een zwarte rechthoek overheen te tekenen. De letters worden gewist uit de tekeninstructies van de pagina zelf, het klare bestand wordt opnieuw geopend en doorzocht om te bewijzen dat ze weg zijn, en er wordt niets ge&uuml;pload."
+og_title = "Een PDF goed onleesbaar maken &mdash; de woorden worden gewist, niet afgedekt"
+og_description = "Bij de meeste gereedschappen ligt de zwarte rechthoek op de tekst en is die er vanonder weg te kopi&euml;ren. Dit gereedschap wist de letters uit het bestand en doorzoekt daarna het resultaat om te laten zien dat ze er niet in staan."
+og_image_alt = "Een PDF onleesbaar maken door de tekst te wissen, niet door hem af te dekken"
+
+pledge = """
+    Het document dat je kiest wordt in het geheugen op deze machine geopend,
+    gelezen, bewerkt en weer weggeschreven, door code die vanaf dit adres wordt
+    geserveerd. Er is hier niets dat een upload kan doen, en aan de andere kant
+    van deze pagina staat geen server om er een te ontvangen. Noch het bestand
+    noch de woorden waar je op zocht verlaten het tabblad."""
+
+live_hint = """
+      Neem het niet van ons aan: open DevTools, kijk naar het tabblad Netwerk en
+      maak iets onleesbaar. Geen enkel verzoek draagt een pagina, een woord of een
+      bestandsnaam mee. Of trek de stekker uit het internet en doe het toch."""
+
+read_first = """
+, <code>src/text.js</code> voor hoe elk woord op
+      een pagina gevonden en gelokaliseerd wordt, en <code>src/edit.js</code> voor
+      het wissen zelf &mdash; wat er uit de instructies van de pagina geknipt
+      wordt en wat er teruggezet wordt zodat de rest van de regel niet verschuift.
+      Geen van deze kan het netwerk bereiken, en de lezer en de schrijver ernaast
+      ook niet."""
+
+howto_heading = "Zo maak je een PDF onleesbaar zodat de woorden echt weg zijn"
+
+card = """
+            Wis woorden uit een PDF in plaats van ze af te dekken. De letters
+            worden uit de tekeninstructies van de pagina zelf gehaald, het gat
+            wordt opengehouden zodat er niets anders verschuift, en het klare
+            bestand wordt hier opnieuw geopend en doorzocht om te bewijzen dat de
+            woorden er niet in staan."""
+
+[words]
+plural = "documenten"
+choose = "een PDF"
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[facts]]
+text = "Bestanden blijven op je apparaat"
+
+[[privacy]]
+title = "Een zwarte rechthoek is geen onleesbaarmaking, en hier wordt er geen over iets heen getekend."
+body = """
+
+      In vrijwel elk programma dat aanbiedt een pagina onleesbaar te maken &mdash;
+      een PDF-lezer, een tekstverwerker, een ontwerpprogramma &mdash; is de
+      rechthoek een object dat n&aacute;&aacute;st de tekst wordt opgeslagen en
+      niet erin. De tekst staat er nog steeds, in hetzelfde bestand, op dezelfde
+      plek, en het gebied selecteren en op kopi&euml;ren drukken geeft hem terug.
+      Die fout heeft rechtbankstukken, inlichtingenrapporten en, in december 2025,
+      zwartgemaakte namen in een massale vrijgave van documenten van het Amerikaanse
+      ministerie van Justitie gepubliceerd die binnen enkele uren leesbaar waren.
+      Dit gereedschap wist de letters uit de instructies die de pagina tekenen. Er
+      is geen rechthoek met iets eronder, want er is niets eronder."""
+
+[[privacy]]
+title = "Het klare bestand wordt hier opnieuw geopend en doorzocht, voordat het je aangeboden wordt."
+body = """
+
+      Tot dat gebeurt is elke bewering hierboven dit gereedschap dat zijn eigen
+      huiswerk nakijkt. Dus de bytes die op het punt staan je download te worden
+      gaan terug naar dezelfde lezer alsof een vreemde ze had opgestuurd, elke
+      pagina wordt opnieuw gelezen, elke bladwijzer, opmerking, formuliervak en
+      documenteigenschap wordt verzameld, en er wordt gezocht naar de woorden die je
+      hebt weggehaald. Het aantal staat bij de resultaten. Als er iets is
+      overgebleven, wordt de run als mislukt gemeld en is er geen download."""
+
+[[privacy]]
+title = "De woorden verlaten het tabblad nooit, en de zoekopdracht ook niet."
+body = """
+ Het
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen enkel adres daarvan hoort bij deze site. Dit gereedschap voegt daar
+      niets aan toe: het heeft geen eigen netwerkfunctie, ook geen optionele. Wat
+      je in het zoekvak typt is een reeks tekens die vergeleken wordt met tekst in
+      het geheugen van dit tabblad, en er is voor geen van beide ergens heen te
+      gaan."""
+
+[[privacy]]
+title = "Onleesbaar maken is de klus die een upload het slechtst overleeft."
+body = """
+
+      Wat mensen onleesbaar maken is de reden waarom het niet ge&uuml;pload mag
+      worden. Een getuigenverklaring, een brief van de arts, een bankafschrift dat
+      naar een verhuurder gaat, een contract met de naam van de ene klant erin dat
+      naar een andere gaat. Dat aan de server van een vreemde geven om er het
+      priv&eacute;-deel uit te laten halen betekent dat het priv&eacute;-deel eerst
+      aankomt, ongeschonden, en dat is de versie die zij houden. Deze pagina heeft
+      geen andere helft."""
+
+[[privacy]]
+title = "Wat er overblijft wordt onaangeroerd doorgegeven."
+body = """
+
+      De enige bytes die op een pagina veranderen zijn de tekst-tekeninstructies
+      waar de weggehaalde letters deel van uitmaakten. Elke andere instructie, en
+      elk lettertype, beeld en lijn waar de pagina naar verwijst, wordt precies
+      gekopieerd zoals het binnenkwam &mdash; er wordt niets opnieuw getekend,
+      hergecodeerd of anders afgebroken. De breedte van wat eruit is gehaald wordt
+      gemeten en teruggezet als een afstandsinstructie, zodat de rest van de regel
+      blijft staan waar het document hem gezet had."""
+
+[[privacy]]
+title = "Het kan geen woorden uit een foto halen, en het zegt om welke pagina's het gaat."
+body = """
+
+      Een gescande pagina is een beeld. De woorden erop zijn pixels, geen tekst, en
+      niets hier kan ze aanraken. Als de scan de onzichtbare doorzoekbare laag
+      draagt die de OCR van een scanner maakt, haalt dit gereedschap die laag weg
+      &mdash; en dat is wat een zoekopdracht en een kopieeractie gevonden zouden
+      hebben &mdash; en het zegt op de pagina met zoveel woorden dat het beeld de
+      woorden nog steeds toont. Dat beeld afdekken is een andere klus; de
+      <a href=\"../afbeelding-onleesbaar-maken/\">afbeelding onleesbaar maken</a> is
+      het gereedschap dat pixels overschrijft."""
+
+[[privacy]]
+title = "Het document houdt op te vertellen waar het vandaan komt."
+body = """
+
+      De eigenschappen en het XMP-pakket gaan er bij elke run uit: geen
+      producer-regel, geen aanmaakdatum, geen auteur, geen titel, en geen van de
+      priv&eacute;-blokken die een opmaakprogramma achterlaat. Een bestand waarvan
+      uit de pagina's een naam is gehaald en waarvan de eigenschappen nog steeds
+      <code>Jansen schikking versie 3.docx</code> luiden, is niet onleesbaar
+      gemaakt, en dat is niet iets om aan een vinkje over te laten."""
+
+[[privacy]]
+title = "Versleutelde bestanden worden geweigerd in plaats van geopend."
+body = """
+
+      Een PDF met een wachtwoord wordt geweigerd, ook het soort dat scanners
+      maken met een leeg wachtwoord en dat technisch gezien open zou gaan. De
+      beveiliging van een document afhalen is een andere klus dan er woorden uit
+      halen, en het stilletjes doen zou een verrassende daad zijn voor een
+      gereedschap dat namens jou handelt."""
+
+[[privacy]]
+title = "Wat Google laadt, en wat het niet krijgt."
+body = """
+ De scripts voor
+      advertenties en meting komen van Google. Geen van beide krijgt iets over je
+      document: geen bestand, geen pagina, geen naam, geen grootte, geen
+      paginatelling en geen woord waar je op gezocht hebt. Elke regel die een PDF
+      leest, bewerkt of schrijft wordt vanaf deze oorsprong geserveerd en staat in
+      de repository."""
+
+[[privacy]]
+title = "Wat de donatieknop laadt, en wat hij niet krijgt."
+body = """
+
+      De &bdquo;Buy me a coffee&rdquo;-knop bovenaan wordt getekend door een script
+      van cdnjs.buymeacoffee.com en haalt zijn letters bij Google Fonts. Het is een
+      link en verder niets: hij meldt geen bezoek, en hij krijgt niets over jou of
+      je documenten. Er gebeurt niets tenzij je erop klikt, en waar je dan
+      terechtkomt is de site van iemand anders."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en alles op deze pagina
+      blijft werken. Dat is het eenvoudigste bewijs van allemaal: een gereedschap
+      dat je document wegstuurde om het onleesbaar te laten maken, zou
+      stoppen."""
+
+[[howto]]
+title = "Kies de PDF."
+body = """
+ E&eacute;n document tegelijk, met opzet:
+      onleesbaar maken is een klus die pagina voor pagina bekeken moet worden, en
+      een gereedschap dat je woorden in het ene bestand liet aanvinken en ze
+      stilletjes op een ander toepaste, is precies hoe het verkeerde ding verstuurd
+      wordt. Hij wordt door de browser rechtstreeks van je schijf gelezen."""
+
+[[howto]]
+title = "Zeg wat er weg moet."
+body = """
+ Typ de woorden &mdash; een naam,
+      een adres, een kenmerk &mdash; en elke plek waar ze voorkomen wordt
+      opgesomd met de regel waar ze op staan en een vakje om aan te vinken. De
+      zoekers naast het vakje kijken naar e-mailadressen, kaartnummers, IBAN's,
+      BSN's en socialezekerheidsnummers, en telefoonnummers. Die worden
+      aangeboden, nooit voor je aangevinkt: een patroon kan een telefoonnummer niet
+      van een kenmerk onderscheiden."""
+
+[[howto]]
+title = "Lees de pagina en pik er woorden vanaf."
+body = """
+
+      Het paneel toont de tekst van het document zoals die werkelijk is
+      opgeslagen, in de volgorde waarin een lezer hem zou kopi&euml;ren. Klik een
+      willekeurig woord aan om het weg te halen en klik het nog eens aan om het te
+      houden. Alles wat doorgestreept is, is wat er weg zal zijn &mdash; en dat
+      maakt dit zowel de controle als de selectie, en het is de moeite waard om dit
+      op elke pagina te doen voordat je op de knop drukt."""
+
+[[howto]]
+title = "Haal ze eruit, en lees de regel die zegt dat het gecontroleerd is."
+body = """
+
+      De letters worden gewist, het gat dat ze achterlieten wordt opengehouden, er
+      wordt een zwarte balk overheen getekend als je daarom gevraagd hebt, en
+      dezelfde woorden worden uit de bladwijzers, opmerkingen, formuliervakken en
+      documenteigenschappen gehaald. Daarna wordt het klare bestand hier opnieuw
+      geopend en doorzocht. Als een woord dat je hebt weggehaald er nog steeds in te
+      vinden is, krijg je geen download en een bericht dat dat zegt."""
+
+[[faq]]
+q = "Hoe verschilt dit van een zwarte balk tekenen in een PDF-lezer?"
+a = """
+        Een rechthoek die in een lezer getekend is, is een annotatie: een object met
+        een positie, naast de pagina opgeslagen. De tekst eronder is onaangeroerd.
+        Iedereen die dat gebied selecteert en op kopi&euml;ren drukt, of het bestand
+        in een ander programma opent, of er een willekeurige tekstextractor
+        overheen haalt, krijgt de woorden terug. Sommige lezers bieden een
+        &bdquo;redact&rdquo;-opdracht die de verwijdering w&eacute;l goed toepast
+        &mdash; en verschillende bieden alleen het tekenen. Dit gereedschap heeft
+        geen rechthoek om opzij te schuiven: de letters worden uit de
+        tekeninstructies van de pagina geknipt, en de zwarte balk wordt, als je hem
+        aan laat staan, daarna getekend over een gat dat al leeg is."""
+
+[[faq]]
+q = "Hoe weet ik dat de woorden echt weg zijn?"
+a = """
+        Omdat het gereedschap het nakijkt, op jouw machine, en je het aantal laat
+        zien. Als het bestand geschreven is wordt het opnieuw geopend door dezelfde
+        lezer op deze pagina, wordt elke pagina gelezen, wordt elke bladwijzer,
+        opmerking, formuliervak en eigenschap verzameld, en wordt er naar elk woord
+        gezocht dat je hebt weggehaald. De resultatenregel zegt hoeveel er waren en
+        hoeveel er over zijn. Als het antwoord niet is wat het zou moeten zijn,
+        mislukt de run en wordt er niets ter download aangeboden. Je kunt het
+        achteraf ook zelf nakijken in elke willekeurige lezer: druk op Ctrl+F en zoek
+        het woord."""
+
+[[faq]]
+q = "Verschuift de rest van de pagina als er een woord weggehaald wordt?"
+a = """
+        Nee. Tekst wordt getekend door een pen over de pagina te laten opschuiven,
+        dus vijf letters wissen zou de rest van de regel normaal gesproken vijf
+        letters naar links trekken. De exacte breedte van wat er weggehaald is wordt
+        uit de eigen metriek van het lettertype gemeten en teruggezet als een
+        afstandsinstructie, die de pen verplaatst zonder iets te tekenen. Kolommen
+        blijven uitgelijnd en totalen blijven onder hun koppen staan."""
+
+[[faq]]
+q = "Kan het een gescand document onleesbaar maken?"
+a = """
+        Het beeld niet, en het zegt dat in plaats van te doen alsof. Een scan is een
+        foto van een pagina: de woorden zijn pixels en er is geen tekst om weg te
+        halen. Wat een scan vaak w&eacute;l draagt is een onzichtbare tekstlaag die
+        de OCR van de scanner over het beeld heen heeft geschreven zodat de pagina
+        doorzoekbaar is &mdash; dit gereedschap vindt die laag, haalt eruit wat jij
+        kiest, en vertelt je op de pagina dat het beeld onveranderd is. Dus een
+        zoekopdracht en een kopieeractie vinden het woord niet meer, en iemand die
+        naar de pagina kijkt leest het nog steeds. Voor een beeld overschrijft de
+        <a href=\"../afbeelding-onleesbaar-maken/\">afbeelding onleesbaar maken</a> de
+        pixels zelf."""
+
+[[faq]]
+q = "En de delen van een document die niet op een pagina staan?"
+a = """
+        Die worden meegenomen, want daar lekt een onleesbaarmaking meestal. Dezelfde
+        woorden worden weggehaald uit bladwijzers, opmerkingen en plaknotities, uit
+        wat er in formuliervakken getypt is, uit de tekst die een schermlezer krijgt,
+        en uit de vervangtekst die een lezer kopieert <em>in plaats van</em> de
+        letters op de pagina &mdash; dat laatste bestaat zodat ligaturen en met een
+        koppelteken afgebroken woorden goed kopi&euml;ren, en het kan een hele zin
+        bevatten. De documenteigenschappen en het XMP-pakket worden helemaal
+        verwijderd. Bijlagen en alles wat draait als het bestand opengaat worden
+        weggegooid, want in geen van beide is te zoeken naar de woorden die je
+        weghaalt."""
+
+[[faq]]
+q = "Worden mijn documenten ergens naartoe ge&uuml;pload?"
+a = """
+        Nee. Het bestand wordt door je eigen browser op je eigen hardware gelezen,
+        bewerkt en geschreven. Dit gereedschap heeft geen serverkant, en het
+        <code>Content-Security-Policy</code> van de pagina noemt elk adres dat hij
+        mag benaderen &mdash; geen daarvan hoort bij deze site. Wat je in het
+        zoekvak typt wordt vergeleken met tekst in het geheugen van dit tabblad en
+        gaat ook nergens heen."""
+
+[[faq]]
+q = "Waarom kan ik geen kader over de pagina slepen zoals bij andere gereedschappen?"
+a = """
+        Omdat een pagina tekenen een volledige PDF-renderer betekent &mdash;
+        lettertypen, verlopen, transparantie, overvloeimodi &mdash; en dat is een
+        megabyte of meer aan motor om op te halen en te draaien, en deze site levert
+        er geen. Dat blijkt bij de klus te passen: een rechthoek slepen selecteert
+        een <em>stuk papier</em>, en een stuk papier is niet hetzelfde als de tekst
+        eronder, en zo begint de zwarte-balkfout. Wat je in plaats daarvan krijgt is
+        de tekst van het document, op leesvolgorde, met elk woord aanklikbaar. Het is
+        ook de enige weergave die je kan vertellen wat een beeld van de pagina niet
+        kan: of de woorden voor je &uuml;berhaupt tekst zijn."""
+
+[[faq]]
+q = "Gaat het klare bestand overal open?"
+a = """
+        Ja. De uitvoer wordt geschreven als PDF 1.5, of de hoogste versie die het
+        bestand dat je gaf nodig had, en 1.5 wordt begrepen door elke lezer die sinds
+        2003 is uitgekomen. Er wordt niets op de pagina hergecodeerd: de
+        lettertypen, beelden en vectortekeningen komen er byte voor byte doorheen,
+        dus wat er van de tekst overblijft blijft precies zo selecteerbaar en
+        doorzoekbaar als het was."""
+
+[[faq]]
+q = "Kan het een met een wachtwoord beveiligde PDF openen?"
+a = """
+        Nee, en dat is met opzet. Een versleuteld document wordt geweigerd met een
+        bericht dat dat zegt, ook als het wachtwoord leeg is &mdash; en zo slaan veel
+        scanners en kopieerapparaten op. De beveiliging van een bestand afhalen is
+        een andere klus dan er woorden uit halen, en een gereedschap dat het
+        stilletjes deed, zou iets doen waar je niet om gevraagd hebt."""
+
+[[faq]]
+q = "Is er een groottelimiet, en kost het iets?"
+a = """
+        Er staat geen limiet in het gereedschap geschreven. De limiet is je eigen
+        machine: het document wordt in het geheugen gehouden terwijl eraan gewerkt
+        wordt, dus een laptop neemt een paar honderd megabyte zonder klagen en gaat
+        ergens daarboven worstelen. Het is gratis, er is geen account, geen inloggen
+        en geen proefperiode. De site draait advertenties, en dat is wat hem betaalt;
+        de adverteerders krijgen niets over je documenten."""
+
+[[faq]]
+q = "Werkt het offline?"
+a = """
+        Ja. Laad de pagina &eacute;&eacute;n keer, verbreek daarna de
+        internetverbinding en hij blijft werken. Dat is meteen de eenvoudigste
+        manier om te bewijzen dat er niets ge&uuml;pload wordt: een gereedschap dat
+        je document wegstuurde om het onleesbaar te laten maken, stopt op het moment
+        dat je de stekker eruit trekt."""
+
+[schema]
+description = "Maak een PDF onleesbaar in je browser door de tekst te wissen in plaats van hem af te dekken. De letters worden uit de content stream van de pagina gehaald, het klare bestand wordt opnieuw geopend en doorzocht om te bewijzen dat ze weg zijn, en er wordt niets ge&uuml;pload."
+features = [
+  "Wist de letters uit de pagina in plaats van er een rechthoek overheen te tekenen",
+  "Opent het klare bestand opnieuw en doorzoekt het om te bewijzen dat de woorden weg zijn",
+  "Vindt elk voorkomen van een woord, of zoekt naar e-mailadressen, kaartnummers, IBAN's en nationale identificatienummers",
+  "Toont de tekst van het document op leesvolgorde zodat elk woord aan te klikken is",
+  "Haalt dezelfde woorden uit bladwijzers, opmerkingen, formuliervakken en eigenschappen",
+  "Houdt het gat open zodat de rest van de regel niet verschuift",
+  "Zegt welke pagina's scans zijn, waar er geen tekst is om weg te halen",
+  "Werkt offline; geen upload, geen account, geen groottelimiet",
+]
+
+[picker]
+title = "Sleep hier je PDF naartoe"
+hint = "of klik om te bladeren &mdash; &eacute;&eacute;n document tegelijk"

--- a/locales/nl/tools/stack-images.html
+++ b/locales/nl/tools/stack-images.html
@@ -1,0 +1,241 @@
+<!--
+  tools/stack-images/body.html, in Dutch.
+
+  Every id, class, option value, data-phrase key and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language. Only
+  the words change. The #faq-raw anchor is a link target from the note in step
+  one, so it stays as it is.
+-->
+<main>
+  <!-- Stap 1 &mdash; de frames -->
+  <section class="card">
+    <h2><span class="step">1</span> Kies frames</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p class="note">
+      RAW-bestanden worden geopend door het JPEG op volledig formaat te lezen dat
+      de camera er al in geschreven heeft: een paar kilobyte mappenstructuur en
+      dan &eacute;&eacute;n stuk. De sensorgegevens worden nooit gedecodeerd, dus
+      een opname van 60&nbsp;MB opent ongeveer net zo snel als een JPEG.
+      <a href="#faq-raw">Wat dat betekent voor het resultaat</a>.
+    </p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="sort-name" class="ghost">Sorteren op naam</button>
+        <button type="button" id="clear-all" class="ghost danger">Alles verwijderen</button>
+      </div>
+    </div>
+
+    <ul id="frame-list" class="frame-list"></ul>
+  </section>
+
+  <!-- Stap 2 &mdash; hoe ze samenkomen -->
+  <section class="card">
+    <h2><span class="step">2</span> Hoe ze samenkomen</h2>
+
+    <div class="settings">
+      <div class="field field-wide">
+        <label for="mode">Methode</label>
+        <select id="mode">
+          <option value="mean" selected>Gemiddelde &mdash; ruis verlagen</option>
+          <option value="median">Mediaan &mdash; mensen en langsrijdende auto's weghalen</option>
+          <option value="sigma">Sigma clipping &mdash; allebei tegelijk</option>
+          <option value="max">Oplichten &mdash; sterrensporen, vuurwerk, light painting</option>
+          <option value="min">Verdonkeren &mdash; alles helders weghalen dat bewoog</option>
+          <option value="sum">Optellen &mdash; een lange belichting nabootsen</option>
+          <option value="focus">Focus stacking &mdash; houden wat scherp was</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="align">Frames uitlijnen</label>
+        <select id="align">
+          <option value="translate" selected>Ja &mdash; alleen verschuiven</option>
+          <option value="similarity">Ja &mdash; verschuiven, draaien en schalen</option>
+          <option value="none">Nee &mdash; precies zo nemen als ze zijn</option>
+        </select>
+        <p class="field-note" id="align-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="scale">Werkresolutie</label>
+        <select id="scale">
+          <option value="full" selected>Volledig formaat</option>
+          <option value="half">Half &mdash; een kwart van het geheugen</option>
+          <option value="quarter">Kwart &mdash; een zestiende</option>
+        </select>
+        <p class="field-note" id="scale-note"></p>
+      </div>
+
+      <div class="field" id="kappa-field" hidden>
+        <label for="kappa">Verwerpen voorbij</label>
+        <div class="inline-pair">
+          <input type="range" id="kappa" min="0.5" max="4" step="0.1" value="2">
+          <output id="kappa-value" for="kappa">2.0&sigma;</output>
+        </div>
+        <p class="field-note">
+          Lager verwerpt meer, en verwerpt echt detail mee. Twee
+          standaardafwijkingen zijn het gebruikelijke uitgangspunt.
+        </p>
+      </div>
+
+      <div class="field" id="radius-field" hidden>
+        <label for="radius">Scherpte wordt gemeten over</label>
+        <div class="inline-pair">
+          <input type="range" id="radius" min="1" max="12" step="1" value="3">
+          <output id="radius-value" for="radius">3 px</output>
+        </div>
+        <p class="field-note">
+          Groter neemt hele gebieden uit &eacute;&eacute;n frame; kleiner volgt
+          fijn detail en kan een gladde achtergrond tussen de frames door
+          verrommelen.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="gain">Belichting</label>
+        <div class="inline-pair">
+          <input type="range" id="gain" min="0.1" max="4" step="0.05" value="1">
+          <output id="gain-value" for="gain">1.00&times;</output>
+        </div>
+        <p class="field-note" id="gain-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="format">Opslaan als</label>
+        <select id="format">
+          <option value="png" selected>PNG &mdash; verliesvrij</option>
+          <option value="jpeg">JPEG &mdash; kleiner bestand</option>
+        </select>
+        <div id="quality-row" class="inline-pair" hidden>
+          <input type="range" id="quality" min="0.5" max="1" step="0.01" value="0.92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+    </div>
+
+    <!--
+      What the run will cost, worked out before it starts. Every figure here is
+      an answer from src/plan.js rather than an estimate, which is why they are
+      shown at all: a median of twenty large frames is a genuinely different
+      proposition from an average of them, and that should be visible before
+      the button is pressed rather than afterwards.
+    -->
+    <dl class="plan" id="plan" hidden>
+      <div><dt>Resultaat</dt><dd id="plan-output">&mdash;</dd></div>
+      <div><dt>Werkgeheugen</dt><dd id="plan-memory">&mdash;</dd></div>
+      <div><dt>Decodeeracties</dt><dd id="plan-decodes">&mdash;</dd></div>
+      <div><dt>Van de schijf gelezen</dt><dd id="plan-read">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-warning" class="path-note" hidden></p>
+  </section>
+
+  <!-- Stap 3 &mdash; laten draaien -->
+  <section class="card">
+    <h2><span class="step">3</span> Stacken</h2>
+
+    <div class="export-row">
+      <button type="button" id="run" class="primary" disabled>Afbeeldingen stacken</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame">
+        <img id="result-image" alt="Het gestackte resultaat">
+      </div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <p id="result-moves" class="field-note"></p>
+        <a id="download" class="primary as-button" download>Afbeelding downloaden</a>
+      </div>
+    </div>
+  </section>
+
+  <!--
+    Every sentence this tool's JavaScript puts on screen, kept out of the
+    JavaScript so that a translator can reach it. src/ is copied byte for byte
+    into all eleven languages, so a string written in a module is English at ten
+    of them. See shared/js/phrases.js.
+
+    A {name} is filled in by the caller. Nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="count.one">1 frame</span>
+    <span data-phrase="count.many">{count} frames</span>
+    <span data-phrase="count.none">Nog geen frames</span>
+
+    <span data-phrase="frame.reference">Referentie</span>
+    <span data-phrase="frame.make-reference">Als referentie nemen</span>
+    <span data-phrase="frame.remove">Verwijderen</span>
+    <span data-phrase="frame.size">{width} &times; {height}</span>
+    <span data-phrase="frame.raw">RAW &mdash; het eigen voorbeeld van de camera, {width} &times; {height}</span>
+    <span data-phrase="frame.raw-camera">{camera} &mdash; voorbeeld {width} &times; {height}</span>
+    <span data-phrase="frame.raw-unreadable">In dit RAW-bestand was geen voorbeeld te vinden</span>
+    <span data-phrase="frame.read">{read} van {total} gelezen</span>
+
+    <span data-phrase="mode.mean">Middelt elk frame. Willekeurige ruis is even vaak te hoog als te laag, dus {count} frames middelen verlaagt hem ongeveer {factor} keer. De methode voor een rustige reeks, en de methode die &eacute;&eacute;n overvliegende vogel bederft.</span>
+    <span data-phrase="mode.median">Neemt de middelste waarde van elke pixel. Alles wat er maar in een deel van de frames was, een toerist, een auto, een vliegtuig, verdwijnt. Het is de enige methode die elk frame tegelijk moet vasthouden, en daarom kan hij hieronder in banden gedeeld worden.</span>
+    <span data-phrase="mode.sigma">Leert wat elke pixel meestal is, en middelt dan alleen de waarden die daarbij passen. Het resultaat van de mediaan met de ruisverlaging van het gemiddelde. Hij leest de frames twee keer.</span>
+    <span data-phrase="mode.max">Houdt de helderste waarde die elke pixel ooit had. Dat is wat van een reeks korte belichtingen sterrensporen maakt en vuurwerk uit de frames van zijn eigen explosie samenstelt.</span>
+    <span data-phrase="mode.min">Houdt de donkerste waarde die elke pixel ooit had. Een pixel blijft alleen helder als hij in elk frame helder was, dus weerspiegelingen, koplampen en aangelichte regendruppels verdwijnen.</span>
+    <span data-phrase="mode.sum">Telt de frames op zonder te delen: wat een {count} keer zo lange belichting verzameld zou hebben. Hij loopt vol, precies zoals die belichting dat zou doen. Haal het terug met de belichtingsschuif.</span>
+    <span data-phrase="mode.focus">Neemt elk deel van het beeld uit het frame waarin het scherp was. Fotografeer een klein onderwerp langs de scherpstelring, en dit zet de scherpe delen aan elkaar.</span>
+
+    <span data-phrase="align.translate">Zoekt uit hoe ver elk frame verschoven was en schuift het terug, tot op fracties van een pixel. Corrigeert wiebelen uit de hand en het wegdrijven van een statief. Draaiing kan het niet corrigeren.</span>
+    <span data-phrase="align.similarity">Zoekt daarnaast draaiing en schaal uit. Kost &eacute;&eacute;n meting meer per frame en helemaal niets als de frames recht blijken te zijn. Draaiing wordt altijd maar binnen een halve slag teruggehaald.</span>
+    <span data-phrase="align.none">Stackt de frames precies zoals ze binnenkomen. Goed voor een vast statief of een intervalreeks, verkeerd voor alles uit de hand.</span>
+
+    <span data-phrase="scale.note">Elk frame wordt door de decoder van de browser zelf op dit formaat gedecodeerd, dus een kleinere instelling is minder werk en niet alleen minder geheugen.</span>
+    <span data-phrase="gain.note">Helemaal aan het eind in het resultaat vermenigvuldigd, na het rekenwerk en voor het afronden.</span>
+    <span data-phrase="gain.sum-note">{count} frames optellen loopt vrijwel zeker vol. Zet dit terug naar ongeveer {suggested} om te zien wat er verzameld is.</span>
+
+    <span data-phrase="plan.output">{width} &times; {height}</span>
+    <span data-phrase="plan.memory">ongeveer {mb} MB</span>
+    <span data-phrase="plan.decodes.simple">{count}, &eacute;&eacute;n per frame</span>
+    <span data-phrase="plan.decodes.passes">{count} &mdash; elk frame, {passes} keer</span>
+    <span data-phrase="plan.decodes.banded">{count} &mdash; elk frame, &eacute;&eacute;n keer voor elk van de {bands} banden</span>
+    <span data-phrase="plan.read">{read} van {total} op de schijf</span>
+    <span data-phrase="plan.banded">Dit past niet in &eacute;&eacute;n stuk in het geheugen, dus het beeld wordt in {bands} banden gesneden en de frames worden voor elke band opnieuw gelezen. {suggested} kiezen zou er &eacute;&eacute;n doorgang van maken.</span>
+    <span data-phrase="plan.banded-anyway">Dit past niet in &eacute;&eacute;n stuk in het geheugen, dus het beeld wordt in {bands} banden gesneden en de frames worden voor elke band opnieuw gelezen. Minder frames of een kleinere werkresolutie zouden er &eacute;&eacute;n doorgang van maken.</span>
+
+    <span data-phrase="progress.open">Er wordt in {name} gekeken&hellip;</span>
+    <span data-phrase="progress.survey">{name} wordt gelezen&hellip;</span>
+    <span data-phrase="progress.measure">Er wordt gemeten hoe ver {name} bewogen heeft&hellip;</span>
+    <span data-phrase="progress.stack">Wordt gestackt &mdash; {done} van {total} frames gelezen</span>
+    <span data-phrase="progress.stack-banded">Wordt gestackt &mdash; band {band} van {bands}, {done} van {total} frames gelezen</span>
+    <span data-phrase="progress.encode">Het beeld wordt geschreven&hellip;</span>
+
+    <span data-phrase="result.info">{width} &times; {height}, {size} &mdash; {count} frames in {seconds} seconden bij elkaar gerekend</span>
+    <span data-phrase="result.moves">Elk frame is opgemeten en op zijn plaats geschoven.</span>
+    <span data-phrase="result.moves-some">{count} van {total} frames waren niet met zekerheid op te meten en zijn blijven staan waar ze stonden.</span>
+    <span data-phrase="result.moves-none">De frames zijn precies zo gestackt als ze binnenkwamen.</span>
+    <span data-phrase="result.moves-clamped">{count} frames meldden een draaiing die te groot is voor een reeks, en zijn alleen door verschuiven gecorrigeerd.</span>
+    <span data-phrase="result.cropped">Ze uit elkaar schuiven liet randen achter die niet elk frame bereikte, en die zijn eraf gesneden.</span>
+
+    <span data-phrase="error.no.files">Voeg eerst minstens &eacute;&eacute;n afbeelding toe.</span>
+    <span data-phrase="error.no.size">Geen van deze bestanden was als afbeelding te openen.</span>
+    <span data-phrase="error.one.frame">Stacken vraagt minstens twee frames.</span>
+    <span data-phrase="error.unknown">Er ging iets mis bij het stacken. Als een van deze bestanden ongewoon is, probeer het dan los.</span>
+    <span data-phrase="error.memory">De browser is door zijn geheugen heen. Probeer een kleinere werkresolutie of minder frames.</span>
+    <span data-phrase="error.unreadable">{name} was niet als afbeelding te openen en is buiten beschouwing gebleven.</span>
+    <span data-phrase="error.busy">Wacht tot deze stapel klaar is voordat je meer frames toevoegt, of breek hem af.</span>
+  </div>
+</main>

--- a/locales/nl/tools/stack-images.toml
+++ b/locales/nl/tools/stack-images.toml
@@ -1,0 +1,341 @@
+#
+# Image Stacker - Dutch.
+#
+# Overrides for tools/stack-images/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Stacken" is het leenwoord dat fotografen schrijven en zoeken; "stapelen" gaat
+# over doosjes. De namen van de methodes blijven wat er in Nederlandse
+# fotografieteksten staat: mediaan, sigma clipping, focus stacking. RAW wordt
+# niet vertaald, en de formaatafkortingen ook niet.
+#
+
+name = "Afbeeldingen stacken"
+heading = "Afbeeldingen&nbsp;stacken <span class=\"h1-kw\">&mdash; een reeks samenvoegen, RAW-bestanden inbegrepen</span>"
+tagline = "Twintig frames tot &eacute;&eacute;n, zonder twintig uploads en zonder RAW-converter."
+
+title = "Afbeeldingen stacken &mdash; gemiddelde, mediaan en focus stacking in je browser"
+description = "Voeg een reeks foto's samen tot &eacute;&eacute;n: middel ze om ruis te doden, neem de mediaan om mensen uit een sc&egrave;ne te halen, licht op voor sterrensporen, of focus-stack een macro-opname. Leest CR2, NEF, ARW, DNG, RAF en CR3 door het eigen voorbeeld van de camera eruit te halen. Draait helemaal in je browser."
+og_title = "Een reeks foto's stacken, RAW-bestanden inbegrepen"
+og_description = "Gemiddelde, mediaan, sigma clipping, oplichten, verdonkeren, optellen of focus stacking &mdash; met de frames eerst uitgelijnd. RAW-bestanden worden geopend door het voorbeeld te lezen dat de camera er al in heeft geschreven, dus een frame van 60 MB opent net zo snel als een JPEG. Er wordt niets ge&uuml;pload."
+og_image_alt = "Afbeeldingen stacken - meerdere frames samengevoegd tot &eacute;&eacute;n, in de browser"
+
+pledge = """
+    Elk frame wordt door je eigen browser geopend, gedecodeerd, uitgelijnd,
+    samengevoegd en weggeschreven, op je eigen machine. Een stapel van twintig
+    RAW-bestanden van 60&nbsp;MB is ongeveer een gigabyte aan foto's, en er
+    verplaatst zich geen byte van: het gereedschap heeft geen enkele
+    netwerkfunctie, en de bestanden worden rechtstreeks van je schijf gelezen door
+    een worker die nergens iets heen kan sturen."""
+
+live_hint = """
+      Neem het niet van ons aan: open DevTools, kijk naar het tabblad Netwerk en
+      stack een map met RAW-bestanden. Geen enkel verzoek draagt een foto, een
+      miniatuur, een bestandsnaam of een cameramodel mee. Of trek de stekker uit
+      het internet en stack ze toch &mdash; aan het gereedschap verandert
+      niets."""
+
+read_first = """
+, <code>src/raw.js</code> voor hoe een
+      RAW-bestand geopend wordt door kilobytes te lezen in plaats van megabytes,
+      <code>src/stack.js</code> voor het rekenwerk van elke methode, en
+      <code>src/plan.js</code> voor waar de geheugen- en decodeergetallen op de
+      pagina vandaan komen &mdash; dat zijn de antwoorden van dat bestand, geen
+      schattingen."""
+
+howto_heading = "Zo stack je een reeks foto's in je browser"
+
+card = """
+            Voeg een reeks samen tot &eacute;&eacute;n beeld: middel de ruis
+            weg, neem de mediaan om de voorbijgangers kwijt te raken, of licht
+            op voor sterrensporen. Leest RAW-bestanden zonder converter."""
+
+[words]
+plural = "foto's"
+choose = "een paar foto's"
+
+[[facts]]
+text = "Geen upload"
+
+[[facts]]
+text = "Geen account"
+
+[[facts]]
+text = "Geen watermerk"
+
+[[facts]]
+text = "Leest RAW"
+
+[[facts]]
+text = "Werkt offline"
+
+[[facts]]
+text = "Open source"
+
+[[privacy]]
+title = "Je foto's kunnen nergens heen."
+body = """
+ Het
+      Content-Security-Policy noemt elk adres dat deze pagina mag benaderen, en
+      geen enkel adres daarvan hoort bij deze site. Er is hier geen eindpunt waar
+      je bestanden verzameld zouden kunnen worden, en niets in de code dat ze zou
+      versturen als dat er wel was &mdash; geen <code>fetch</code>, geen
+      <code>XMLHttpRequest</code>, geen <code>sendBeacon</code>, niet in
+      <code>src/</code> en niet in de worker."""
+
+[[privacy]]
+title = "De RAW-bestanden worden gelezen, niet ge&uuml;pload &mdash; en nauwelijks gelezen."
+body = """
+ Een RAW-bestand van
+      een camera bevat al een JPEG op volledig formaat dat de camera bij het
+      maken van de opname heeft gerenderd. Dit gereedschap vindt het door een paar
+      mappenverwijzingen af te lopen en dan om &eacute;&eacute;n stuk te vragen,
+      wat bij een bestand van 60&nbsp;MB meestal onder de honderd kilobyte blijft.
+      De pagina laat je dat getal zien naast de grootte van je bestanden terwijl je
+      werkt. De sensorgegevens worden helemaal nooit gelezen."""
+
+[[privacy]]
+title = "Het werk gebeurt in een Worker op deze machine, niet op een server."
+body = """
+ Dit is het enige
+      gereedschap hier dat er een gebruikt, want stacken is minuten rekenwerk in
+      plaats van seconden, en een bevroren pagina kan geen voortgang tonen en niet
+      afgebroken worden. Een Worker is een tweede draad in deze zelfde browser
+      &mdash; zie <code>src/worker.js</code>. Hij krijgt de bestanden zelf, wat
+      gratis is, want een verwijzing naar een bestand is niet de bytes; en hij
+      heeft precies hetzelfde Content-Security-Policy als de pagina, oftewel
+      nergens om ze heen te sturen."""
+
+[[privacy]]
+title = "Over de reeks wordt nergens iets gemeld."
+body = """
+ Hoeveel frames je hebt
+      gestackt, welke camera ze geschreven heeft, hoe ver elk frame verschoven was,
+      welke methode je hebt gekozen en hoe lang het duurde, blijven in het geheugen
+      van deze pagina tot je hem sluit. Er is in deze repository geen eigen
+      analytics-gebeurtenis die er iets van meedraagt, en de ene vraag die deze
+      site na een download stelt, stuurt een duim omhoog of omlaag en de naam van
+      het gereedschap, verder niets."""
+
+[[privacy]]
+title = "Het werkt offline."
+body = """
+ Verbreek de verbinding en het gereedschap is
+      onveranderd, want er heeft nooit een netwerkstap in gezeten. De worker en elke
+      module die hij laadt worden gecachet door de eigen service worker van deze
+      pagina, dus een ge&iuml;nstalleerde kopie stackt RAW-bestanden met de stekker
+      uit het netwerk."""
+
+[[howto]]
+title = "Kies de frames."
+body = """
+ Een reeks, een bracketserie, een
+      intervalopname of een map met RAW-bestanden. Elk bestand wordt geopend zodra
+      het binnenkomt en de regel vertelt je wat eruit kwam &mdash; bij een
+      RAW-bestand de camera, de grootte van het voorbeeld dat erin gevonden is, en
+      hoe weinig van het bestand gelezen hoefde te worden om het te vinden."""
+
+[[howto]]
+title = "Kies de methode die past bij wat je kwijt wilt."
+body = """
+ Ruis:
+      gemiddelde, of sigma clipping als er iets bewogen heeft. Mensen, auto's of
+      een overvliegend vliegtuig: mediaan. Een donkere lucht die je als
+      sterrensporen wilt: oplichten. Een macro-opname langs de scherpstelring:
+      focus stacking. De notitie onder het menu zegt wat elke methode doet met
+      jouw aantal frames."""
+
+[[howto]]
+title = "Bepaal of de frames uitgelijnd moeten worden."
+body = """
+ Uit de hand: ja,
+      alleen verschuiven. Uit de hand en je draaide ook: verschuiven, draaien en
+      schalen. Vast statief of intervalmeter: nee, en het gaat sneller. Elk frame
+      wordt gemeten tegen het eerste in de lijst, en daarom kan elk frame tot dat
+      eerste gepromoveerd worden."""
+
+[[howto]]
+title = "Lees de vier getallen, druk dan op de knop."
+body = """
+ Voordat er iets
+      draait, zegt de pagina hoe groot het resultaat wordt, ruwweg hoeveel geheugen
+      het kost, hoe vaak de frames gedecodeerd worden en hoeveel van je bestanden
+      er gelezen is. Als de reeks niet in &eacute;&eacute;n stuk in het geheugen
+      past, zegt hij dat, en zegt hij welke werkresolutie dat zou oplossen."""
+
+[[faq]]
+q = "Worden mijn foto's ergens naartoe ge&uuml;pload?"
+a = """
+        Nee. Elk frame wordt door je eigen browser op je eigen hardware geopend,
+        gedecodeerd, uitgelijnd, gestackt en weggeschreven. Dit gereedschap heeft
+        geen enkele netwerkfunctie &mdash; het haalt nooit iets op en verstuurt
+        nooit iets &mdash; en het <code>Content-Security-Policy</code> van de pagina
+        noemt elk adres dat hij mag benaderen, en geen daarvan hoort bij deze site.
+        Laad de pagina &eacute;&eacute;n keer, trek de stekker uit het internet, en
+        hij werkt nog steeds. Dat telt hier zwaarder dan bij de meeste gereedschappen
+        alleen al door het volume: een stapel van twintig RAW-frames is ongeveer een
+        gigabyte, en een gigabyte aan foto's uploaden om er een gemiddelde van te
+        laten nemen is nu juist waar dit gereedschap voor bestaat om te
+        vermijden."""
+
+[[faq]]
+q = "Welke RAW-formaten kan het lezen, en hoe?"
+a = """
+        <span id="faq-raw"></span>CR2, CR3, NEF, NRW, ARW, SR2, SRF, DNG, ORF, RAF,
+        RW2, PEF, SRW, 3FR, IIQ, DCR, KDC, MRW, MEF, RWL en nog een paar &mdash; en
+        dat is het meeste van wat camera's schrijven. Wat het eruit leest is het
+        JPEG-voorbeeld op volledig formaat dat de camera zelf gerenderd heeft toen de
+        opname gemaakt werd: het beeld op de achterkant van de camera, en het beeld
+        dat je besturingssysteem als miniatuur tekent. Het wordt gevonden door de
+        mappenstructuur van het bestand af te lopen, wat een paar leesacties van een
+        paar kilobyte elk kost, en dan &eacute;&eacute;n stuk te nemen. <strong>Het
+        is geen demosaicing van de sensorgegevens.</strong> Het resultaat draagt de
+        witbalans en de beeldstijl van de camera op acht bit per kanaal, in plaats
+        van de twaalf of veertien bit lineaire sensorgegevens die een RAW-converter
+        je zou geven."""
+
+[[faq]]
+q = "Waarom dan niet de sensorgegevens netjes decoderen?"
+a = """
+        Omdat dat zou betekenen dat LibRaw of dcraw meegeleverd moet worden &mdash;
+        een tweede motor van tientallen megabytes, voor &eacute;&eacute;n familie
+        formaten, waarvan het meeste compressieschema's per fabrikant zijn. Die
+        afweging wordt uitgevochten in
+        <code>docs/what-can-be-built-here.md</code> in de broncode van deze site,
+        waar camera-RAW al op de uitgesloten lijst stond voordat dit gereedschap
+        bestond. Wat er veranderd is, is niet het antwoord op die vraag maar de
+        ontdekking dat stacken het niet nodig heeft: de voorbeelden zijn op volledige
+        resolutie, ze zijn wat de camera je toch als JPEG gegeven zou hebben, en ze
+        lezen is ongeveer honderd keer sneller dan demosaicing zou zijn. Wil je de
+        sensorgegevens, ontwikkel de frames dan eerst in een RAW-converter en stack
+        de TIFF's of JPEG's die eruit komen &mdash; dit gereedschap neemt die ook
+        aan."""
+
+[[faq]]
+q = "Hoeveel frames kan het aan, en hoe groot?"
+a = """
+        Zes van de zeven methoden stromen: ze houden &eacute;&eacute;n accumulator
+        vast en lezen elk frame precies &eacute;&eacute;n keer, dus honderd frames
+        kosten evenveel geheugen als twee en het enige dat groeit is de tijd. De
+        mediaan is de uitzondering, want de middelste waarde van een reeks is niet te
+        weten totdat je hem helemaal hebt, dus die houdt elk frame tegelijk vast
+        &mdash; twintig frames van 24 megapixel is ongeveer 1,4&nbsp;GB, en dat geeft
+        geen enkele browser je. Als dat gebeurt wordt het beeld in horizontale banden
+        gesneden en band voor band gestackt, wat kost dat de frames voor elke band
+        opnieuw gelezen worden. De pagina rekent dit allemaal uit voordat je op de
+        knop drukt en laat je het getal zien, zodat een trage run nooit een
+        verrassing is."""
+
+[[faq]]
+q = "Wat doet het uitlijnen van de frames nu eigenlijk?"
+a = """
+        Het zoekt uit hoe ver elk frame ten opzichte van het eerste verschoven is en
+        schuift het terug, tot op een fractie van een pixel. De methode is
+        fasecorrelatie: de verschuiving tussen twee beelden komt naar voren als een
+        faseverschil tussen hun spectra, dus &eacute;&eacute;n Fouriertransformatie
+        per beeld vindt een verschuiving van tweehonderd pixels net zo goedkoop als
+        een van twee. De tweede instelling haalt ook draaiing en schaal terug, met
+        dezelfde truc toegepast op het spectrum in log-polaire co&ouml;rdinaten. Het
+        is allemaal globaal &mdash; &eacute;&eacute;n verschuiving, &eacute;&eacute;n
+        hoek, &eacute;&eacute;n schaal voor het hele frame &mdash; dus het corrigeert
+        een camera die bewoog en het kan een onderwerp dat bewoog niet corrigeren, en
+        een foto die een stap naar links genomen is ook niet. E&eacute;n zichtbaar
+        gevolg: een frame dat twintig pixels naar links geschoven is, reikt niet meer
+        tot de rechterrand, dus het resultaat wordt bijgesneden tot het deel dat elk
+        frame bedekt. Daarom komt een uitgelijnde stapel er heel iets kleiner uit dan
+        de frames die erin gingen, en het is het enige alternatief voor een donkere
+        rand gemaakt van de frames die er niet waren."""
+
+[[faq]]
+q = "Welke methode moet ik gebruiken?"
+a = """
+        <strong>Gemiddelde</strong> voor ruis, op een reeks waarin niets bewoog: het
+        snijdt willekeurige ruis met ongeveer de wortel van het aantal frames.
+        <strong>Mediaan</strong> om dingen weg te halen die er maar een deel van de
+        tijd waren &mdash; het klassieke gebruik is een druk plein een stuk of twaalf
+        keer fotograferen en het leeg terugkrijgen. <strong>Sigma clipping</strong>
+        als je allebei wilt: het leert wat elke pixel meestal is en middelt alleen de
+        waarden die daarmee overeenkomen, dus het heeft de immuniteit van de mediaan
+        voor een langsrijdende auto en de ruisreductie van het gemiddelde.
+        <strong>Oplichten</strong> voor sterrensporen, vuurwerk en light painting.
+        <strong>Verdonkeren</strong> om alles helders weg te halen dat bewoog.
+        <strong>Optellen</strong> om &eacute;&eacute;n lange belichting na te bootsen.
+        <strong>Focus stacking</strong> voor een macro-opname langs de
+        scherpstelring."""
+
+[[faq]]
+q = "Waarom is mijn resultaat acht bit als mijn RAW-bestanden veertien zijn?"
+a = """
+        Omdat wat er gestackt wordt het eigen voorbeeld van de camera is, en dat is
+        een JPEG. Het is het vermelden waard dat stacken een deel terugwint van wat
+        dat kost: zestien acht-bits frames middelen geeft een resultaat met werkelijk
+        fijnere overgangen dan er in &eacute;&eacute;n van de frames zaten, want juist
+        de ruis die elk frame anders liet afronden is wat het gemiddelde tussen de
+        niveaus in laat landen. Het rekenwerk gebeurt hier in drijvende komma en
+        wordt &eacute;&eacute;n keer helemaal aan het eind afgerond, dus er wordt
+        onderweg niets van weggegooid. Het is nog steeds niet hetzelfde als lineaire
+        sensorgegevens stacken, en dit gereedschap doet niet alsof."""
+
+[[faq]]
+q = "Kan ik frames van verschillende afmetingen stacken, of van verschillende camera's?"
+a = """
+        Ja, al is het meestal een vergissing en de moeite waard om te controleren of
+        je het bedoelde. Het resultaat krijgt de grootte van het grootste frame, en
+        elk ander frame wordt passend geschaald en erin gecentreerd. Camera's mengen
+        mengt ook de kleurweergave, dus een gemiddelde van de twee is een gemiddelde
+        van twee verschillende interpretaties van hetzelfde licht. Waar het echt
+        helpt is een reeks die op twee resoluties is opgenomen, of een RAW-bestand en
+        een JPEG van hetzelfde frame."""
+
+[[faq]]
+q = "Er staat dat de run in banden gaat. Wat betekent dat?"
+a = """
+        Dat het werkgeheugen dat de methode nodig heeft meer is dan het gereedschap
+        in &eacute;&eacute;n keer wil reserveren, dus het beeld wordt in horizontale
+        stroken gesneden en strook voor strook gestackt. Het levert nog steeds precies
+        hetzelfde resultaat; het leest de frames alleen opnieuw voor elke strook, dus
+        het duurt langer, en de pagina vertelt je hoeveel decodeeracties dat worden.
+        De werkresolutie &eacute;&eacute;n stap verlagen deelt het geheugen door vier,
+        wat een run in banden bijna altijd terugbrengt tot &eacute;&eacute;n doorgang
+        &mdash; de notitie zegt welke instelling dat zou doen."""
+
+[[faq]]
+q = "Waarom gebruikt dit gereedschap een Worker en geen van de andere?"
+a = """
+        Omdat het het enige is waarvan het werk in minuten gemeten wordt. Elk ander
+        gereedschap hier doet iets dat een seconde of twee kost, waar het werk van de
+        hoofddraad halen ceremonie zou zijn. Twintig grote frames stacken is stevig
+        rekenwerk over honderden megabytes, en op de hoofddraad betekent dat een
+        bevroren pagina: geen voortgangsbalk die beweegt, een Annuleren-knop die niet
+        antwoordt, en uiteindelijk een browser die aanbiedt het tabblad af te sluiten.
+        De Worker is een tweede draad in deze zelfde browser, die een bestand uit
+        deze zelfde map draait, onder dit zelfde beleid. Het is geen server en het is
+        geen netwerkfunctie."""
+
+[[faq]]
+q = "Is het gratis, en heb ik een account nodig?"
+a = """
+        Het is gratis, en er is geen account, geen inloggen, geen proefperiode en geen
+        watermerk. Er is ook geen limiet op hoeveel frames je stackt of hoe groot ze
+        zijn, want er is geen server die ervoor betaalt &mdash; het werk gebeurt op je
+        eigen machine en het enige plafond is je eigen geheugen. De site draait
+        advertenties, en dat is wat hem betaalt; de adverteerders krijgen niets over
+        je foto's."""
+
+[schema]
+description = "Stack een reeks foto's in de browser: gemiddelde, mediaan, sigma-geklipt gemiddelde, oplichten, verdonkeren, optellen of focus stacking, met de frames eerst uitgelijnd door fasecorrelatie. Leest camera-RAW-bestanden door het ingebedde voorbeeld op volledig formaat eruit te halen, dus er is geen RAW-converter nodig. Er wordt niets ge&uuml;pload."
+features = [
+  "Zeven stackmethoden: gemiddelde, mediaan, sigma-geklipt gemiddelde, oplichten, verdonkeren, optellen en focus stacking",
+  "Leest CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2 en meer door het eigen voorbeeld op volledig formaat van de camera eruit te halen",
+  "Opent een RAW-bestand van 60 MB door er ongeveer honderd kilobyte van te lezen",
+  "Automatisch uitlijnen: alleen verschuiven, of verschuiven met draaiing en schaal, of niet",
+  "Uitlijning onder de pixel door fasecorrelatie, niet door verschuivingen af te zoeken",
+  "Zes van de zeven methoden houden &eacute;&eacute;n accumulator vast, dus honderd frames kosten het geheugen van twee",
+  "Geheugen- en decodeerkosten uitgerekend en getoond voordat de run begint",
+  "Het werk draait in een Worker, dus de voortgang beweegt en Annuleren antwoordt",
+  "PNG of JPEG eruit; werkt offline; geen upload, geen account",
+]
+
+[picker]
+title = "Sleep de frames hierheen"
+hint = "of klik om te bladeren &mdash; JPEG, PNG, WebP, TIFF en camera-RAW"


### PR DESCRIPTION
Four tools and four guides shipped after Dutch was last brought level, so
a reader with the site set to Dutch landed on English for the DICOM
viewer, the document scanner, the PDF redactor and image stacking, plus
the four guides beside them.

## What is here

- `locales/nl/tools/` &mdash; `dicom-viewer`, `document-scanner`,
  `redact-pdf`, `stack-images`, each a `.toml` and a `.html`
- `locales/nl/pages/guides/` &mdash; `open-a-dicom-file`, `redact-a-pdf`,
  `scan-a-document-with-your-phone`, `stack-photos-to-reduce-noise`
- eight new entries in `locales/nl/locale.toml`, added to the tool block
  and the guide block separately rather than appended in a lump

## The slugs, and two word choices

They follow the rule the Dutch table states about itself: noun first,
verb last, which is both the word order and how the search gets typed.
`check_links` fails the build when a published locale page links to a
page that was not built, so `een-pdf-onleesbaar-maken`,
`een-afbeelding-onleesbaar-maken` and `is-bestanden-uploaden-veilig` are
load bearing rather than decorative.

**`onleesbaar maken`** is deliberately the same verb as the existing
`afbeelding-onleesbaar-maken`. It says what happens, and it keeps the
distinction both redaction pages live on &mdash; the text leaves the
file, it is not covered over. `lakken` comes out of the
freedom-of-information world and reads as jargon; `afdekken` would have
named the exact failure those pages exist to warn about.

**`stacken`** stays the loanword photographers write and search for.
`stapelen` is what you do to boxes.

## Register

Read off the Dutch pages already in the tree: `je` throughout, `je eigen
browser` for the promise that nothing leaves the machine, `gereedschap`
for tool, `&bdquo;&rdquo;` for quotation. DICOM field names keep their
English and their numbers &mdash; Pixel Spacing (0028,0030), Series
Instance UID (0020,000E) &mdash; because that is how they appear in the
file and in the standard.

The `#phrases` blocks keep every `data-phrase` key and `{placeholder}`
byte for byte, checked with a script that diffs ids, classes, `for`,
`scope`, option values and placeholder sets against the English source.
The `count.*` pairs stay doubled, since Dutch distinguishes singular from
plural. `finder.nationalid` is localised to BSN and social security
numbers.

## Verification

`python build.py --out _plain --clean --no-minify` exits 0 and Dutch is
now **absent from the locale debt list**, which is how the build reports
65 of 65. No CRLF anywhere under `locales/nl/`.

One of twelve branches closing the same eight-page hole, one language per
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
