### PR TITLE
Give Portuguese the eight pages it was reading in English

### DIFF
--- a/locales/pt/locale.toml
+++ b/locales/pt/locale.toml
@@ -78,6 +78,14 @@ complete = true
 # procura, e "timelapse" aparece ate' em legenda de celular.
 "timelapse-video" = "fazer-timelapse"
 "hash-checksum" = "verificar-checksum"
+# DICOM continua DICOM: e a sigla que vem escrita no disco que o hospital
+# entrega, e ninguem a procura traduzida.
+"dicom-viewer" = "visualizador-dicom"
+"document-scanner" = "digitalizar-documentos"
+# O mesmo verbo de tarjar-imagem, porque e a mesma promessa: o texto sai do
+# arquivo, nao fica coberto por um retangulo.
+"redact-pdf" = "tarjar-pdf"
+"stack-images" = "empilhar-imagens"
 
 "guides" = "guias"
 "roadmap" = "roteiro"
@@ -110,6 +118,11 @@ complete = true
 "guides/trim-an-audio-file" = "guias/cortar-um-arquivo-de-audio"
 "guides/whats-inside-a-gif" = "guias/o-que-tem-dentro-de-um-gif"
 "guides/verify-a-file-checksum" = "guias/verificar-o-checksum-de-um-download"
+"guides/open-a-dicom-file" = "guias/abrir-um-arquivo-dicom"
+"guides/redact-a-pdf" = "guias/tarjar-um-pdf"
+"guides/scan-a-document-with-your-phone" = "guias/digitalizar-um-documento-com-o-celular"
+# Quem empilha nao procura "empilhar": procura o ruido, que e o problema.
+"guides/stack-photos-to-reduce-noise" = "guias/empilhar-fotos-para-reduzir-ruido"
 
 #
 # ---------------------------------------------------------------------------

--- a/locales/pt/pages/guides/open-a-dicom-file.html
+++ b/locales/pt/pages/guides/open-a-dicom-file.html
@@ -1,0 +1,247 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../visualizador-dicom/">Visualizador DICOM</a> e arraste a
+      pasta inteira de arquivos para ele. Eles são lidos na sua própria máquina,
+      devolvidos às séries de onde vieram, e empilhados na ordem em que o aparelho
+      os registrou. Nada é enviado, e nada é escrito de volta nos seus arquivos.
+    </p>
+    <p>
+      Se lhe deram um disco e você está se perguntando qual arquivo abrir: todos,
+      de uma vez. Uma tomografia ou uma ressonância não é um arquivo. É um arquivo
+      por corte, e um estudo de tórax são trezentos deles.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que há num disco de hospital</h2>
+    <p>
+      Normalmente quatro coisas, e só uma delas importa.
+    </p>
+    <ul>
+      <li>
+        <strong>Uma pasta de exames</strong>, muitas vezes chamada
+        <code>DICOM</code>, <code>IMAGES</code> ou <code>ST0001</code>, com
+        arquivos chamados <code>IM000001</code>, <code>I0000001</code> ou um número
+        longo com pontos. Frequentemente sem extensão alguma. Isto é o exame.
+      </li>
+      <li>
+        <strong>Um arquivo chamado <code>DICOMDIR</code></strong>. Um índice do
+        resto, escrito para que um visualizador consiga listar os estudos do disco
+        sem abrir cada arquivo. Você não precisa dele.
+      </li>
+      <li>
+        <strong>Um visualizador</strong>, como executável do Windows, como entrada
+        de autorun, ou de vez em quando como applet Java. Ele foi compilado para o
+        que era atual quando o disco foi gravado, e é por isso que tantos já não
+        rodam.
+      </li>
+      <li>
+        <strong>Uma página HTML ou um PDF</strong> com o logotipo do hospital,
+        explicando como iniciar o visualizador.
+      </li>
+    </ul>
+    <p>
+      Os exames não precisam daquele visualizador. O formato é um padrão publicado
+      e os arquivos são legíveis por si; o executável no disco é um programa que
+      poderia lê-los, não o único.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que os arquivos não têm extensão</h2>
+    <p>
+      Porque o DICOM não precisa de uma. Cada arquivo carrega a sua própria marca:
+      128 bytes de nada, depois as quatro letras <code>DICM</code>, depois um
+      pequeno bloco de campos descrevendo como o resto do arquivo está escrito. Um
+      leitor procura aquelas quatro letras, e não um nome terminado em
+      <code>.dcm</code>.
+    </p>
+    <p>
+      É também por isso que renomear um arquivo para <code>.dcm</code> não muda
+      nada, e por que um visualizador que insiste na extensão está sendo
+      desnecessariamente rígido. Arquivos escritos direto de uma rede de hospital
+      nem sequer têm os 128 bytes e a marca &mdash; são os dados nus, sem nada na
+      frente, e um leitor precisa deduzir do primeiro campo como estão codificados.
+      Isso é um arquivo normal, não um arquivo quebrado.
+    </p>
+  </section>
+
+  <section>
+    <h2>Janela e nível, que é o controle que importa</h2>
+    <p>
+      Esta é a única coisa que torna uma imagem médica diferente de uma fotografia,
+      e a razão pela qual um editor de imagens não serve para olhar uma.
+    </p>
+    <p>
+      Um corte de tomografia guarda cerca de quatro mil valores distintos. A sua
+      tela mostra duzentos e cinquenta e seis cinzas. Alguma coisa precisa decidir
+      quais quatro mil vão para quais duzentos e cinquenta e seis, e essa decisão é
+      a <strong>janela</strong>: tudo abaixo dela é preto, tudo acima é branco, e a
+      faixa do meio se espalha pelos cinzas.
+    </p>
+    <p>
+      Mova a janela e o mesmo arquivo parece um exame diferente. Isso não é um
+      artefato de renderização, é justamente o ponto. Pulmão e osso estão os dois no
+      corte e não podem ser vistos ao mesmo tempo: uma janela que mostra a textura
+      de um pulmão insuflado põe todos os ossos em branco puro, e uma que mostra o
+      detalhe trabecular de uma costela põe o pulmão inteiro em preto puro.
+    </p>
+    <p>
+      Numa tomografia os números são <strong>unidades Hounsfield</strong>, e são
+      definidas em absoluto em vez de por aparelho: a água é 0 e o ar é
+      &minus;1000, por definição, em qualquer tomógrafo do mundo. É por isso que um
+      visualizador pode oferecer janelas com nome &mdash; pulmão, osso, cérebro,
+      partes moles &mdash; e elas significarem no seu arquivo o mesmo que na estação
+      onde o exame foi laudado. As de sempre:
+    </p>
+    <ul>
+      <li><strong>Partes moles</strong> &mdash; centro 40, largura 400.</li>
+      <li><strong>Pulmão</strong> &mdash; centro &minus;600, largura 1500.</li>
+      <li><strong>Osso</strong> &mdash; centro 300, largura 1500.</li>
+      <li><strong>Cérebro</strong> &mdash; centro 40, largura 80. Uma janela
+        estreita, porque a substância cinzenta e a branca diferem por poucas
+        unidades.</li>
+    </ul>
+    <p>
+      Numa ressonância não existe escala assim. Os valores dependem da sequência, da
+      bobina e do aparelho, então não há o que batizar de preset e a janela por onde
+      começar é aquela que o próprio arquivo pede. Todo exame carrega uma sugestão.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que às vezes os cortes correm ao contrário</h2>
+    <p>
+      Um visualizador precisa decidir em que ordem pôr os arquivos, e há duas coisas
+      no arquivo que ele poderia usar.
+    </p>
+    <p>
+      <strong>Instance Number</strong> é um contador. É a escolha óbvia e é
+      atribuído por seja lá o que tenha escrito os arquivos, que não precisa
+      numerá-los no sentido em que corre o paciente. Um estudo reconstruído dos pés
+      para cima e numerado da cabeça para baixo corre de trás para frente, e uma
+      série montada a partir de duas reconstruções pode repetir os números
+      abertamente.
+    </p>
+    <p>
+      <strong>Image Position (Patient)</strong> é onde o corte está fisicamente, em
+      milímetros, num sistema de coordenadas preso ao paciente e não ao aparelho.
+      Ordenar por isso está certo faça o que fizer a numeração, e tem um efeito
+      colateral útil: uma vez que os cortes estejam em ordem física, a distância
+      entre eles é mensurável, então um visualizador pode lhe dizer que os cortes
+      estão a 5&nbsp;mm um do outro &mdash; e perceber quando falta um, coisa que o
+      arquivo nunca diz.
+    </p>
+  </section>
+
+  <section>
+    <h2>Medir alguma coisa</h2>
+    <p>
+      Um exame é dado medido, então um comprimento nele é um comprimento de verdade
+      &mdash; se o arquivo disser a que distância estão os seus pixels. Isso é um
+      campo só, Pixel Spacing, em milímetros, e está presente em essencialmente toda
+      tomografia e toda ressonância.
+    </p>
+    <p>
+      Ele costuma faltar em imagens de ultrassom, em documentos digitalizados e em
+      capturas de tela salvas como DICOM. Onde falta, não existe resposta honesta em
+      milímetros, e um visualizador que dá uma assim mesmo inventou uma escala. Uma
+      contagem de pixels é a resposta correta a uma pergunta que o arquivo não pode
+      responder.
+    </p>
+    <p>
+      Fique atento também a pixels que não são quadrados, o que fora da tomografia é
+      normal. Medir em pixels e multiplicar por um único número de espaçamento só
+      está certo onde os dois coincidem; cada eixo precisa ser medido com o seu.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que um exame carrega além da imagem</h2>
+    <p>
+      Esta é a parte sobre a qual as pessoas se enganam, e a razão para ter cuidado
+      com estes arquivos.
+    </p>
+    <p>
+      Um arquivo DICOM não é uma imagem com alguns metadados anexados. É um
+      prontuário com uma imagem dentro. O cabeçalho é uma lista de campos, e num
+      exame clínico típico ele guarda:
+    </p>
+    <ul>
+      <li>o nome do paciente, o número do prontuário, a data de nascimento e o
+        sexo;</li>
+      <li>o número do pedido, que é a chave para a solicitação no sistema do
+        hospital;</li>
+      <li>o médico solicitante, o técnico que realizou o exame, o radiologista que o
+        laudou;</li>
+      <li>a instituição, o endereço dela e o setor;</li>
+      <li>o fabricante do aparelho, o modelo e o número de série;</li>
+      <li>a data e a hora do exame ao segundo;</li>
+      <li>e um conjunto de identificadores únicos &mdash; estudo, série, instância
+        &mdash; que são chaves perfeitas de volta ao arquivo de onde ele veio.</li>
+    </ul>
+    <p>
+      Qualquer arquivo que lhe tenham dado carrega tudo isso, e tudo isso viaja com
+      o arquivo para onde quer que o arquivo vá. Apagar o nome não basta: uma data
+      de nascimento, uma instituição do tamanho de um CEP e a hora de um exame
+      identificam uma pessoa mais ou menos tão bem quanto um nome, e o UID do estudo
+      a identifica exatamente para quem tiver acesso ao arquivo.
+    </p>
+    <p>
+      Alguns aparelhos guardam ainda uma segunda cópia do nome do paciente num campo
+      privado, que é um campo cujo significado não está publicado em lugar nenhum e
+      no qual a maioria dos anonimizadores não mexe, porque não têm como saber o que
+      há nele.
+    </p>
+  </section>
+
+  <section>
+    <h2>Não envie o exame só para olhá-lo</h2>
+    <p>
+      A maneira de sempre pela qual esse problema é resolvido é uma busca por
+      &ldquo;dicom viewer online&rdquo; e uma caixa de envio. O que acabou de
+      acontecer é que um estranho tem uma cópia de um prontuário: os pixels, o nome,
+      a data de nascimento, o número do prontuário e a chave de volta ao arquivo.
+    </p>
+    <p>
+      Não há razão para isso. Ler um arquivo DICOM é analisar um cabeçalho e
+      desempacotar alguns números inteiros, e um navegador faz isso perfeitamente
+      bem, e é por isso que o
+      <a href="../../visualizador-dicom/">visualizador daqui</a> não tem função de
+      rede alguma: nenhum <code>fetch</code>, nenhum <code>XMLHttpRequest</code>,
+      nada capaz de enviar um arquivo mesmo que algo tentasse. Carregue a página uma
+      vez, desconecte da internet, e ela continua abrindo exames.
+    </p>
+    <p>
+      <a href="../e-seguro-enviar-arquivos/">É seguro enviar arquivos para
+      conversores online?</a> explica como conferir essa afirmação neste site ou em
+      qualquer outro. Este é o tipo de arquivo em que mais vale a pena conferir.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que um navegador não consegue fazer</h2>
+    <p>
+      Duas coisas, e sobre as duas vale a pena ser franco.
+    </p>
+    <p>
+      <strong>Não é um visualizador diagnóstico.</strong> A sua tela não é
+      calibrada, o navegador não é uma cadeia de renderização validada, e nenhuma
+      página web passou por avaliação regulatória. Ler um exame para tomar uma
+      decisão clínica é trabalho para a estação em que ele foi laudado. Olhar o que
+      há num disco, tirar um corte para uma aula ou um artigo, ler um cabeçalho, ou
+      descobrir por que outro programa recusa o arquivo são todos motivos
+      perfeitamente bons para abrir um num navegador.
+    </p>
+    <p>
+      <strong>Alguns exames comprimidos não decodificam.</strong> O DICOM permite
+      vários esquemas de compressão e os navegadores implementam um deles. Arquivos
+      simples, arquivos codificados em run-length, JPEG baseline e JPEG Lossless
+      &mdash; que é o que a maioria das exportações de hospital usa &mdash; abrem
+      todos. JPEG 2000, JPEG-LS e os formatos de vídeo exigem codecs que são
+      megabytes de biblioteca compilada. Onde a imagem não pode ser decodificada, o
+      cabeçalho continua inteiramente legível, e essa costuma ser de qualquer forma
+      a metade pela qual você veio.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/open-a-dicom-file.toml
+++ b/locales/pt/pages/guides/open-a-dicom-file.toml
@@ -1,0 +1,21 @@
+#
+# Guia: abrir um arquivo DICOM - Portuguese.
+#
+
+nav = "Abrir um arquivo DICOM"
+title = "Como abrir um arquivo DICOM (.dcm) sem instalar nada"
+description = "O que há num disco de hospital, por que os arquivos não têm extensão, como abrir um exame .dcm num navegador, o que janela e nível faz de fato, e o que um exame carrega sobre o paciente além da imagem."
+
+heading = "Como abrir um arquivo DICOM, e o que há dentro de um"
+lede = """
+    Um disco de hospital é uma pasta de arquivos sem extensão e um visualizador
+    escrito para o Windows XP. Os arquivos são DICOM, e não há nada de exótico
+    neles: um exame é um cabeçalho cheio de campos e um bloco de pixels. É assim
+    que se olha para um, é isso que os controles significam, e é isso que o arquivo
+    carrega além da imagem."""
+
+updated = "25 de agosto de 2026"
+
+og_title = "Como abrir um arquivo DICOM sem instalar nada"
+og_description = "O que há num disco de hospital, por que os arquivos não têm extensão, e o que um exame .dcm carrega sobre o paciente além da imagem."
+og_image_alt = "abox.tools - ferramentas que nunca tocam um servidor"

--- a/locales/pt/pages/guides/redact-a-pdf.html
+++ b/locales/pt/pages/guides/redact-a-pdf.html
@@ -1,0 +1,228 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../tarjar-pdf/">Tarjador de PDF</a>, solte o documento
+      dentro, digite as palavras que precisam sair, marque as que você quer, e
+      aperte &ldquo;Retirar&rdquo;. As letras são apagadas das próprias instruções
+      de desenho da página, as mesmas palavras são tiradas dos marcadores, dos
+      comentários, dos campos de formulário e das propriedades do documento, e o
+      arquivo pronto é reaberto e pesquisado na sua frente antes de ser oferecido a
+      você.
+    </p>
+    <p>
+      Tudo o que vem abaixo é o motivo pelo qual essa última frase é a importante,
+      e como saber se a ferramenta que você já usa consegue dizer o mesmo.
+    </p>
+  </section>
+
+  <section>
+    <h2>A falha de que se trata</h2>
+    <p>
+      Desenhe um retângulo preto sobre um nome num leitor de PDF. O que você vê é um
+      nome com um retângulo preto por cima. O que a maioria dos leitores
+      <em>salva</em> é um documento contendo o nome e, separadamente, um retângulo
+      com uma posição, um tamanho e uma cor.
+    </p>
+    <p>
+      Um retângulo desenhado assim é uma <strong>anotação</strong>: um objeto que
+      fica ao lado da página em vez de dentro dela. O texto embaixo está exatamente
+      como estava. Selecione a área e aperte copiar, ou passe no arquivo qualquer
+      extrator de texto, ou abra-o num programa que desenhe anotações de outro jeito,
+      e o nome volta. Nada na tela distingue isso de uma tarjagem de verdade, que é
+      precisamente por que isso continua acontecendo com organizações que empregam
+      advogados.
+    </p>
+    <p>
+      Isso já publicou peças judiciais, avaliações de inteligência, contratos e
+      &mdash; em dezembro de 2025 &mdash; nomes enegrecidos numa divulgação em massa
+      de documentos do Departamento de Justiça dos Estados Unidos, que estavam
+      legíveis poucas horas depois da publicação. O padrão é sempre o mesmo. O
+      retângulo era a anotação, e a anotação nunca foi o texto.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que uma tarjagem de verdade faz no lugar</h2>
+    <p>
+      Uma página num PDF é uma lista de instruções: use esta fonte, mova a caneta
+      para cá, desenhe estes glifos. As palavras na página existem em exatamente um
+      lugar, como os operandos dessas instruções de desenho:
+    </p>
+    <pre><code>BT /F1 12 Tf 72 700 Td (Prezado senhor Silva) Tj ET</code></pre>
+    <p>
+      Tarjar o nome significa <strong>apagar aquelas letras daquela
+      instrução</strong> e reescrever a página. Depois disso não há o que recuperar,
+      não porque o arquivo esconde bem, mas porque as letras não estão no arquivo.
+      Não há um retângulo com algo embaixo, porque embaixo não há nada.
+    </p>
+    <p>
+      Uma coisa precisa ser reposta, ou o resultado fica visivelmente errado. O
+      texto é desenhado avançando uma caneta pela página, então apagar cinco letras
+      puxa o resto da linha cinco letras para a esquerda: as colunas param de
+      alinhar e os totais escorregam para baixo dos títulos errados. Uma ferramenta
+      que faz isso direito mede quanto as letras retiradas teriam avançado e repõe
+      essa distância como uma instrução de espaçamento, que move a caneta sem
+      desenhar nada.
+    </p>
+    <p>
+      A tarja preta, se houver uma, é desenhada <em>depois</em>, sobre uma lacuna
+      que já está vazia. É uma gentileza com quem ler o documento &mdash; um sinal
+      de que algo foi retirado &mdash; e não é a tarjagem. É toda a distinção numa
+      frase: numa tarjagem de verdade, a tarja é enfeite; numa falsa, a tarja
+      <em>é</em> a tarjagem.
+    </p>
+  </section>
+
+  <section>
+    <h2>Os quatro lugares em que uma palavra se esconde e que não são a página</h2>
+    <p>
+      Esta é a parte que pega quem fez a primeira parte direito. Um PDF carrega
+      texto em vários lugares ao mesmo tempo, e um leitor mostra, pesquisa ou copia
+      todos eles. Retirar um nome da página e deixá-lo em qualquer um destes não é
+      tê-lo retirado.
+    </p>
+    <ul>
+      <li>
+        <strong>As propriedades do documento.</strong> Título, autor e o nome do
+        arquivo de que este foi exportado. Um documento cujas páginas tiveram um
+        nome retirado e cujas propriedades ainda dizem
+        <code>acordo Silva versao 3.docx</code> não foi tarjado. Costuma haver uma
+        segunda cópia da mesma informação num pacote XMP, que também precisa sair.
+      </li>
+      <li>
+        <strong>Os marcadores.</strong> O sumário na lateral de um leitor é uma
+        lista de títulos com números de página anexados &mdash; e um título é uma
+        linha de texto sobre a qual nada na página manda.
+      </li>
+      <li>
+        <strong>Campos de formulário e comentários.</strong> O que alguém digitou
+        num formulário é guardado duas vezes: uma como o valor do campo e outra como
+        a aparência que o leitor desenha. As duas precisam sair. Uma nota adesiva
+        carrega o seu texto e o nome de quem a escreveu.
+      </li>
+      <li>
+        <strong>O texto de substituição.</strong> Um PDF pode declarar que uma
+        sequência de glifos &ldquo;soletra&rdquo; outra coisa, para que uma ligadura
+        ou uma linha partida por hífen seja copiada como a palavra que representa.
+        Isso significa que um documento pode mostrar uma coisa e entregar outra a
+        quem aperta Ctrl+C, e uma tarjagem que retirasse só o que foi desenhado
+        deixaria a frase intacta para quem selecionasse o parágrafo.
+      </li>
+    </ul>
+    <p>
+      Os anexos são o quinto. Um PDF pode carregar outros arquivos inteiros dentro
+      de si, e nada do que você faça com as páginas os toca.
+    </p>
+  </section>
+
+  <section>
+    <h2>Como conferir um arquivo, em trinta segundos</h2>
+    <p>
+      Faça isto com qualquer coisa que você esteja prestes a mandar, seja qual for a
+      ferramenta que a produziu. É a conferência que teria pegado cada uma das
+      falhas publicadas.
+    </p>
+    <ol>
+      <li>
+        <strong>Abra o arquivo pronto e aperte Ctrl+F</strong> (Cmd+F num Mac).
+        Pesquise a palavra que você retirou. Uma tarjagem de verdade não devolve
+        nada. Se o leitor saltar para um retângulo preto, a palavra continua ali
+        dentro e o retângulo está apenas por cima dela.
+      </li>
+      <li>
+        <strong>Selecione a área enegrecida e copie.</strong> Arraste sobre o
+        retângulo, aperte Ctrl+C, e cole numa caixa de texto. Se chegar alguma
+        coisa, você encontrou a mesma falha pelo outro lado.
+      </li>
+      <li>
+        <strong>Selecione o documento inteiro e copie também.</strong> Ctrl+A e
+        depois Ctrl+C, cole em qualquer editor de texto, e leia o que sai. Esta é de
+        longe a mais útil das três, porque lhe mostra o documento como um extrator
+        de texto o vê &mdash; incluindo texto que você não sabia que estava lá, o
+        que numa página digitalizada é comum.
+      </li>
+      <li>
+        <strong>Olhe as propriedades</strong> &mdash; Arquivo → Propriedades na
+        maioria dos leitores &mdash; e o painel de marcadores. Os dois são lugares
+        onde um nome sobrevive a uma tarjagem perfeita na página.
+      </li>
+    </ol>
+    <p>
+      O <a href="../../tarjar-pdf/">Tarjador de PDF</a> faz a primeira e a terceira
+      delas por você e mostra a contagem, porque uma ferramenta afirmando que
+      retirou algo não é prova, e uma pesquisa no arquivo pronto é.
+    </p>
+  </section>
+
+  <section>
+    <h2>Documentos digitalizados são outro problema</h2>
+    <p>
+      Uma digitalização é a fotografia de uma página. As palavras nela são pixels,
+      não texto, e nenhuma edição da camada de texto as toca &mdash; porque não há
+      camada de texto, ou porque a que há descreve a imagem em vez de ser a imagem.
+    </p>
+    <p>
+      A maioria dos digitalizadores e das ferramentas de PDF modernas acrescenta uma
+      camada de texto invisível sobre a imagem, escrita por reconhecimento óptico de
+      caracteres, para que a página possa ser pesquisada. Essa camada é texto de
+      verdade e pode ser retirada. Vale a pena retirá-la: é o que uma pesquisa, uma
+      cópia e todo sistema automático que lê documentos teriam encontrado. Não muda
+      nada na imagem, na qual as palavras continuam perfeitamente legíveis para quem
+      olhar a página.
+    </p>
+    <p>
+      Então para uma digitalização a sequência honesta é: tire as palavras da camada
+      de texto e depois cuide da imagem à parte &mdash; o que significa sobrescrever
+      pixels. É isso que o <a href="../tarjar-uma-imagem/">tarjador de imagens</a>
+      faz, e o guia ao lado dele explica por que um desfoque ou um mosaico não bastam
+      para texto.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que não simplesmente imprimir e digitalizar de novo</h2>
+    <p>
+      Porque funciona, e lhe custa todo o resto. Imprimir uma página tarjada e
+      digitalizá-la de volta produz mesmo um documento sem camada de texto para
+      vazar &mdash; e um documento que ninguém consegue pesquisar, que nenhum leitor
+      de tela consegue ler, que é de cinco a cinquenta vezes maior, e cuja qualidade
+      é a que o digitalizador do escritório resolveu dar. Também depende de a página
+      ter sido impressa como se via: uma anotação pode ser marcada como visível na
+      tela e não no papel, e quando era isso que a sua tarja preta era, a folha que
+      sai da impressora tem o nome nela.
+    </p>
+    <p>
+      O mesmo argumento vale para &ldquo;achatar em imagem&rdquo;, que algumas
+      ferramentas oferecem como tarjagem. Isso converte cada página numa fotografia
+      de si mesma. Se as palavras estavam cobertas em vez de apagadas, a cobertura
+      agora é permanente &mdash; mas todo o resto do documento se foi junto, e o
+      arquivo que você manda é um com que ninguém consegue trabalhar.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que este é o trabalho que menos vale a pena enviar</h2>
+    <p>
+      Um serviço de tarjagem precisa receber o arquivo não tarjado. É toda a
+      transação: a versão privada chega primeiro, intacta, e é a versão que fica no
+      disco de outra pessoa. Diga o que disser a política de privacidade, a sequência
+      não é discutível &mdash; o documento com que você teve cuidado é aquele que
+      você entregou.
+    </p>
+    <p>
+      O que as pessoas tarjam torna isso pior do que parece. Depoimentos de
+      testemunhas, cartas médicas, extratos bancários indo para um locador, um
+      contrato com o nome de um cliente indo para outro, uma petição com um endereço
+      residencial. São esses os documentos, e é exatamente por isso que a ferramenta
+      para eles não deveria ter um servidor do outro lado.
+    </p>
+    <p>
+      Tudo no <a href="../../tarjar-pdf/">tarjador deste site</a> acontece no seu
+      próprio navegador: o arquivo é lido, editado, escrito e conferido na sua
+      máquina, e as palavras que você pesquisa também nunca saem da aba. Tire o cabo
+      da internet e ele continua funcionando, que é a prova mais simples que existe
+      de que nada está sendo mandado a lugar nenhum. Veja
+      <a href="../e-seguro-enviar-arquivos/">é seguro enviar arquivos</a> para o que
+      um envio de fato envolve.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/redact-a-pdf.toml
+++ b/locales/pt/pages/guides/redact-a-pdf.toml
@@ -1,0 +1,20 @@
+#
+# Guia: tarjar um PDF para que o texto suma de verdade - Portuguese.
+#
+
+nav = "Tarjar um PDF"
+title = "Como tarjar um PDF para que o texto suma de verdade"
+description = "Uma tarja preta desenhada num leitor de PDF normalmente deixa as palavras embaixo dela, e copiar e colar as traz de volta na hora. O que uma tarjagem de verdade retira, os quatro lugares em que uma palavra se esconde fora da página, e como conferir um arquivo antes de mandá-lo."
+
+heading = "Como tarjar um PDF para que o texto suma de verdade"
+lede = """
+    Um retângulo preto sobre um nome e um nome que foi apagado são idênticos na
+    tela. Um dos dois sobrevive a ser selecionado e copiado. Esta é a diferença, os
+    lugares em que uma palavra se esconde e que não estão na página, e a conferência
+    de trinta segundos que lhe diz qual dos dois você tem."""
+
+updated = "25 de agosto de 2026"
+
+og_title = "Como tarjar um PDF para que o texto suma de verdade"
+og_description = "Por que uma tarja preta num leitor de PDF normalmente não é uma tarjagem, os quatro lugares em que uma palavra se esconde fora da página, e como conferir um arquivo antes de mandá-lo."
+og_image_alt = "abox.tools - ferramentas que nunca tocam um servidor"

--- a/locales/pt/pages/guides/scan-a-document-with-your-phone.html
+++ b/locales/pt/pages/guides/scan-a-document-with-your-phone.html
@@ -1,0 +1,239 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Ponha a página sobre algo que não seja da mesma cor que ela, fique por cima,
+      preencha o enquadramento, e tire uma fotografia. Depois abra o
+      <a href="../../digitalizar-documentos/">Digitalizador de documentos</a>,
+      confira os quatro cantos que ele encontrou, escolha &ldquo;cor,
+      uniformizada&rdquo; ou &ldquo;preto e branco&rdquo;, e salve o PDF.
+    </p>
+    <p>
+      O trabalho é esse. O resto explica o que cada um desses passos está
+      corrigindo, porque saber qual parte faz o quê é o que permite dizer, em três
+      segundos, se a coisa que você está prestes a mandar vai ser aceita.
+    </p>
+  </section>
+
+  <section>
+    <h2>O que de fato separa uma foto de uma digitalização</h2>
+    <p>
+      Três coisas, e elas não têm o mesmo peso.
+    </p>
+    <ul>
+      <li>
+        <strong>A inclinação.</strong> Uma fotografia é tirada de onde você estava,
+        então a página é um quadrilátero em vez de um retângulo. Esta é a que todo
+        mundo nota e a mais fácil de desfazer.
+      </li>
+      <li>
+        <strong>A luz.</strong> Um digitalizador arrasta uma luz uniforme pela
+        página. Uma sala não: há uma mancha clara debaixo da lâmpada, um canto
+        escuro longe dela, e muitas vezes a sua própria sombra sobre um dos lados.
+        Esta é a que de fato faz uma fotografia parecer uma fotografia, e é a que as
+        pessoas tentam corrigir com &ldquo;contraste automático&rdquo;, o que a
+        piora.
+      </li>
+      <li>
+        <strong>O tamanho.</strong> A fotografia de doze megapixels de uma página
+        tem de três a cinco megabytes. Vinte delas são um documento que vai quicar
+        na metade dos servidores de e-mail para onde for mandado.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Tirando a foto</h2>
+    <p>
+      Cinco coisas, na ordem de quanta diferença fazem:
+    </p>
+    <ul>
+      <li>
+        <strong>Preencha o enquadramento.</strong> Esta é a única que não dá para
+        corrigir depois. Detalhe que não estava na fotografia não está no arquivo, e
+        uma página fotografada do outro lado da sala é uma página que ninguém
+        consegue ler em resolução alguma. Chegue mais perto em vez de dar zoom: a
+        menos que o celular troque para uma segunda lente mais longa, dar zoom é um
+        recorte do mesmo sensor &mdash; ele joga fora exatamente os pixels que você
+        está tentando guardar.
+      </li>
+      <li>
+        <strong>Ponha sobre algo de outra cor.</strong> Uma página branca numa mesa
+        branca quase não tem borda para nada encontrar &mdash; nem o programa, nem
+        você, quando tiver de arrastar os cantos à mão. Uma mesa escura, um livro,
+        um casaco: qualquer coisa.
+      </li>
+      <li>
+        <strong>Não fique entre a página e a luz.</strong> A sua própria sombra
+        sobre a página é de longe o motivo mais comum de uma digitalização feita no
+        celular sair ruim. Gire noventa graus e ela some.
+      </li>
+      <li>
+        <strong>Deixe focar, e então fique parado.</strong> O tremido não é
+        recuperável por ferramenta alguma, e um foco perdido também não. Toque na
+        página na tela, espere assentar, e então aperte o botão.
+      </li>
+      <li>
+        <strong>Ponha a página inteira dentro, cantos inclusive.</strong> Não porque
+        os cantos sejam preciosos, mas porque é neles que o endireitamento é medido.
+        Uma página que sai pela borda do enquadramento ainda funciona &mdash; a
+        borda da fotografia faz as vezes da borda da página &mdash; mas uma página
+        com três cantos no enquadramento e um adivinhado é uma página que vai sair
+        um pouco errada.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Endireitar: por que a forma importa mais do que a inclinação</h2>
+    <p>
+      Desfazer a inclinação é um pedaço de aritmética bem compreendido. Quatro
+      cantos de um retângulo vistos de qualquer lugar determinam a transformação que
+      os repõe, e aplicá-la a cada pixel dá uma página plana. Qualquer ferramenta
+      que diga endireitar uma página faz isso.
+    </p>
+    <p>
+      A parte que dá errado em silêncio é <em>que tamanho</em> a página plana
+      deveria ter. O método óbvio é medir as bordas do quadrilátero e usar a
+      proporção entre elas &mdash; e uma fotografia tirada de viés encurta a borda
+      distante, então uma folha A4 sai visivelmente atarracada. Continua parecendo
+      uma digitalização. Cada linha de texto nela simplesmente tem a altura errada, e
+      nada na tela diz isso.
+    </p>
+    <p>
+      A resposta melhor é que a própria perspectiva carrega a informação: bastando
+      que a câmera seja uma comum, a fotografia de um retângulo é suficiente para
+      recuperar tanto as proporções verdadeiras do retângulo quanto a distância focal
+      da câmera. O
+      <a href="../../digitalizar-documentos/">Digitalizador de documentos</a> daqui
+      faz isso, e depois lhe diz que forma a página saiu e se aquilo é uma folha
+      padrão &mdash; então uma página que diz &ldquo;1:1,41, que é a forma de um A4
+      ou de um A5&rdquo; é uma página em que você pode parar de pensar.
+    </p>
+  </section>
+
+  <section>
+    <h2>A luz: dividir, não esticar</h2>
+    <p>
+      Aumentar o contraste de uma página com luz irregular deixa a parte clara branca
+      e a parte escura preta, e o que está escrito na parte escura some junto. O
+      problema nunca foi o contraste estar baixo demais. É que o papel não tem o
+      mesmo brilho num canto e no outro, então não existe um único ajuste que sirva
+      para a página inteira.
+    </p>
+    <p>
+      O que funciona é estimar o brilho do papel <em>em cada ponto</em> e dividir por
+      ele. O papel é a maioria clara de qualquer pedacinho de uma página, então medir
+      o brilho ao longo de uma grade de quadradinhos e pegar um valor alto em cada um
+      dá a forma da luz &mdash; o texto é escuro e esparso demais para deslocá-la.
+      Divida por isso e o que sobra é a tinta, com luz uniforme, sem a sombra e com o
+      papel de volta ao branco.
+    </p>
+    <p>
+      É isso que &ldquo;cor, uniformizada&rdquo; e &ldquo;tons de cinza&rdquo; fazem.
+      Escolha cor quando a cor faz parte do documento: um carimbo, uma assinatura em
+      tinta azul, uma linha marcada, qualquer coisa sobre a qual alguém possa depois
+      perguntar se era original.
+    </p>
+  </section>
+
+  <section>
+    <h2>Preto e branco, e por que o arquivo fica pequeno de repente</h2>
+    <p>
+      Uma página guardada como fotografia são milhões de pixels com dezesseis milhões
+      de cores possíveis cada, e o codec gasta o seu esforço em degradês sutis que
+      uma página de texto não tem. Uma página guardada em preto e branco é um bit por
+      pixel &mdash; tinta ou papel &mdash; e comprime como a coisa esmagadoramente
+      repetitiva que é.
+    </p>
+    <p>
+      A diferença não é pequena: nas mesmas páginas é algo como dezoito vezes. Um
+      contrato de vinte páginas que chega a quinze megabytes como fotografias fica
+      abaixo de um megabyte como páginas de um bit &mdash; que é a diferença entre um
+      documento que cabe num e-mail e um que não cabe, e o motivo pelo qual todo
+      digitalizador de escritório vem com isso por padrão.
+    </p>
+    <p>
+      O senão é que não há meios-tons: uma fotografia na página vira uma bagunça de
+      pontinhos. Use para páginas impressas e escritas, que é o que a maioria dos
+      documentos é, e use tons de cinza para qualquer coisa com uma imagem.
+    </p>
+    <p>
+      Um detalhe que vale a pena saber, porque explica por que uma ferramenta boa
+      acerta onde uma ruim produz uma página com um canto preto: a decisão entre
+      tinta e papel precisa ser tomada <em>localmente</em>. Um limiar único para a
+      página inteira não funciona quando o papel na sombra é mais escuro do que a
+      tinta na luz &mdash; e numa página fotografada ele muitas vezes é. Decidir cada
+      pixel contra a média da sua própria vizinhança pequena é o que mantém legível a
+      escrita dentro de uma sombra.
+    </p>
+  </section>
+
+  <section>
+    <h2>Várias páginas, um documento</h2>
+    <p>
+      Fotografe as páginas na ordem, acrescente todas de uma vez, e elas viram as
+      páginas de um só PDF na ordem em que foram acrescentadas. Duas coisas para
+      ficar de olho:
+    </p>
+    <ul>
+      <li>
+        <strong>Os nomes de arquivo não ordenam como você pensa.</strong>
+        <code>pagina2.jpg</code> vem depois de <code>pagina10.jpg</code> numa
+        ordenação alfabética, porque a comparação é caractere por caractere. Confira
+        a ordem na tira antes de salvar, e não no PDF depois.
+      </li>
+      <li>
+        <strong>A limpeza é um único ajuste para o documento inteiro</strong>, e de
+        propósito. Páginas limpas de formas diferentes parecem dois documentos
+        grampeados juntos, que é exatamente a impressão que uma digitalização deve
+        evitar. Escolha o modo que serve para a pior página.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Antes de mandar</h2>
+    <ul>
+      <li>
+        <strong>Abra o PDF.</strong> Não a prévia &mdash; o arquivo. Cada página, do
+        lado certo para cima, sem nada cortado numa borda.
+      </li>
+      <li>
+        <strong>Leia a menor coisa que há na página.</strong> Um número de
+        referência, uma data, um número de conta. Se você não conseguir ler na tela a
+        100%, a pessoa para quem você está mandando também não consegue.
+      </li>
+      <li>
+        <strong>Confira se os cantos não foram cortados.</strong> O que fica na borda
+        de um formulário é um número de página, uma linha de assinatura, ou o campo
+        que alguém depois vai dizer que faltava.
+      </li>
+      <li>
+        <strong>Confira o que o documento diz sobre você.</strong> Um PDF tem campos
+        para o autor, o produtor e a data de criação, e a maioria das ferramentas os
+        preenche. Se isso importa depende de quem vai receber, mas vale a pena saber
+        que está lá.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Por que nada disso precisa de um envio</h2>
+    <p>
+      Cada passo acima é aritmética sobre uma imagem que a sua própria máquina já
+      decodificou: quatro cantos, uma transformação, uma divisão, um limiar, e um
+      contêiner escrito byte a byte. Não há nada nisso que um servidor consiga fazer
+      e um navegador não, e nada que precise de um modelo baixado para ser feito.
+    </p>
+    <p>
+      O que vale a pena pensar um instante, por causa do que estes arquivos são. As
+      pessoas não fotografam páginas ao acaso. Elas fotografam um passaporte, um
+      holerite, um contrato de aluguel, um formulário médico, um contrato &mdash;
+      documentos com um nome, um endereço e um número de conta, sendo digitalizados
+      justamente porque uma instituição pediu. Enviar um para um site para ter os
+      cantos endireitados entrega a um estranho o documento inteiro. Veja
+      <a href="../e-seguro-enviar-arquivos/">como saber se uma ferramenta precisa
+      mesmo dos seus arquivos</a> para as quatro conferências que separam as
+      ferramentas que precisam ver o seu arquivo das que simplesmente veem.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/scan-a-document-with-your-phone.toml
+++ b/locales/pt/pages/guides/scan-a-document-with-your-phone.toml
@@ -1,0 +1,21 @@
+#
+# Guia: digitalizar um documento com o celular - Portuguese.
+#
+
+nav = "Digitalizar com o celular"
+title = "Como digitalizar um documento com o celular (sem app, sem envio)"
+description = "O que separa a fotografia de uma página de uma digitalização dela: a inclinação, a luz irregular e o tamanho do arquivo. Como tirar a foto, o que corrigir depois, e por que nada disso precisa de servidor."
+
+heading = "Como digitalizar um documento com o celular"
+lede = """
+    Alguém pediu que você &ldquo;digitalize e devolva&rdquo; um formulário, e você
+    tem um celular e não tem digitalizador. A distância entre a fotografia de uma
+    página e uma digitalização dela é menor do que parece, e não é sobretudo a
+    inclinação &mdash; isto é o que de fato as separa, e o que fazer com cada
+    parte."""
+
+updated = "25 de agosto de 2026"
+
+og_title = "Como digitalizar um documento com o celular"
+og_description = "A inclinação, a sombra e o tamanho do arquivo - o que separa a foto de uma página de uma digitalização dela, e como corrigir cada parte sem enviar a página."
+og_image_alt = "abox.tools - ferramentas que nunca tocam um servidor"

--- a/locales/pt/pages/guides/stack-photos-to-reduce-noise.html
+++ b/locales/pt/pages/guides/stack-photos-to-reduce-noise.html
@@ -1,0 +1,289 @@
+  <section>
+    <h2>A resposta curta</h2>
+    <p>
+      Abra o <a href="../../empilhar-imagens/">Empilhador de imagens</a>, solte a
+      sequência inteira dentro, e escolha o método pelo que você quer se livrar:
+    </p>
+    <ul>
+      <li><strong>Ruído</strong>, e nada se mexeu &mdash; média.</li>
+      <li><strong>Ruído</strong>, e alguma coisa se mexeu &mdash; sigma clipping.</li>
+      <li><strong>Pessoas, carros, um avião</strong> &mdash; mediana.</li>
+      <li><strong>Um céu escuro que você quer como rastros de estrelas</strong> &mdash; clarear.</li>
+      <li><strong>Uma macro com quase nenhuma profundidade de campo</strong> &mdash; focus stacking.</li>
+    </ul>
+    <p>
+      Deixe o alinhamento ligado se a câmera estava nas suas mãos e desligue se ela
+      estava num tripé. Arquivos RAW podem entrar direto; não é preciso revelá-los
+      antes.
+    </p>
+    <p>
+      Tudo o que vem abaixo é o motivo pelo qual aquelas cinco linhas são o que são.
+    </p>
+  </section>
+
+  <section>
+    <h2>Por que uma sequência guarda mais do que um quadro</h2>
+    <p>
+      Uma fotografia feita com pouca luz é a imagem mais o ruído, e o ruído é
+      diferente a cada vez. É essa última parte que faz o empilhamento funcionar.
+      Faça o mesmo disparo dezesseis vezes e a imagem é idêntica nas dezesseis
+      enquanto o ruído não é, então tirar a média deles deixa a imagem e cancela a
+      maior parte do ruído.
+    </p>
+    <p>
+      A melhora é a raiz quadrada do número de quadros. Quatro quadros reduzem o
+      ruído à metade. Dezesseis, a um quarto. Cem cortam por dez. É uma curva brutal
+      para se estar &mdash; ir de dezesseis para sessenta e quatro quadros compra a
+      mesma melhora de novo, por quatro vezes mais disparos &mdash; e é por isso que
+      quase toda pilha prática fica entre oito e trinta quadros.
+    </p>
+    <p>
+      Há um segundo ganho, mais discreto. Tirar a média de dezesseis quadros de oito
+      bits dá um resultado com gradações mais finas do que qualquer um deles tinha,
+      porque é justamente o ruído que fazia cada quadro arredondar de um jeito
+      diferente que permite à média cair entre os níveis. Empilhar um conjunto
+      ruidoso não só tira ruído; recupera tom que um único quadro quantizou fora.
+    </p>
+  </section>
+
+  <section>
+    <h2>A pergunta que escolhe o método</h2>
+    <p>
+      Não &ldquo;o que eu quero guardar&rdquo;, mas <strong>o que era diferente entre
+      os quadros</strong>. Todo o resto vem daí.
+    </p>
+
+    <h3>Nada se mexeu: média</h3>
+    <p>
+      A média simples. É a redução de ruído mais eficaz que existe num conjunto em
+      que a única diferença entre os quadros é o ruído, e é a mais fácil de estragar:
+      um quadro com um pássaro põe um pássaro fantasma na pilha inteira, porque uma
+      média não tem opinião sobre um valor que discorda dos outros. Ela simplesmente
+      o inclui.
+    </p>
+
+    <h3>Alguma coisa cruzou o quadro: mediana</h3>
+    <p>
+      Alinhe uma dúzia de fotografias de uma praça movimentada e olhe para um pixel.
+      Na maioria delas ele é calçada; numa ou duas ele é o casaco de alguém. Ordene
+      aqueles doze valores e pegue o do meio e você recebe calçada, porque o casaco
+      nunca esteve na maioria.
+    </p>
+    <p>
+      Faça isso para cada pixel e a praça sai vazia. Este é o truque por trás de todo
+      artigo do tipo &ldquo;tire os turistas da sua foto de férias&rdquo;, e ele não
+      precisa de nada mais esperto do que uma sequência e paciência. A única coisa
+      que ele exige é que <strong>nenhuma parte da cena esteja ocupada mais da metade
+      do tempo</strong>. Uma pessoa parada em oito dos seus doze quadros é a maioria
+      naqueles pixels, e a mediana vai mantê-la.
+    </p>
+
+    <h3>As duas coisas: sigma clipping</h3>
+    <p>
+      A mediana joga fora a maior parte da informação para conseguir a sua robustez
+      &mdash; onze dos seus doze valores são descartados em cada pixel, então ela
+      reduz o ruído bem menos do que uma média do mesmo conjunto reduziria.
+    </p>
+    <p>
+      O sigma clipping é o meio-termo, e costuma ser o padrão certo para qualquer
+      conjunto do mundo real. Ele olha para cada pixel em todos os quadros, descobre
+      o que ele costuma ser e quanto varia, e então tira a média só dos valores que
+      concordam com isso. Um carro que cruzou um quadro é excluído naqueles pixels;
+      todo outro quadro continua contando em todo lugar. Você fica com a imunidade da
+      mediana a coisas que se mexeram e com a maior parte da redução de ruído da
+      média.
+    </p>
+    <p>
+      O limiar é em desvios padrão, e dois é o ponto de partida de sempre. Mais baixo
+      rejeita mais, e começa a rejeitar detalhe verdadeiro junto com o carro.
+    </p>
+
+    <h3>Só as coisas claras importam: clarear</h3>
+    <p>
+      Guarde o valor mais claro que cada pixel já teve. Fotografe o céu noturno como
+      duzentas exposições de trinta segundos e clareie-as juntas, e cada estrela
+      desenha o seu próprio arco no resultado &mdash; um rastro de estrela, montado a
+      partir de exposições curtas que individualmente nunca estouraram. O mesmo
+      método monta um fogo de artifício a partir dos quadros da sua própria explosão,
+      e um light painting a partir de uma volta por um quarto escuro com uma
+      lanterna.
+    </p>
+    <p>
+      O oposto dele, escurecer, é o discreto do par: um pixel só continua claro se
+      estava claro em <em>todos</em> os quadros, então reflexos numa janela, faróis
+      passando e gotas de chuva iluminadas por um flash somem todos.
+    </p>
+
+    <h3>O assunto é mais fundo do que o foco: focus stacking</h3>
+    <p>
+      Uma macro em f/8 tem talvez um milímetro em foco, o que não basta para um
+      inseto. A resposta é fazer vinte quadros ao longo do anel de foco e guardar, de
+      cada um, só a parte que estava nítida nele. A ferramenta mede quanto cada pixel
+      difere dos seus vizinhos &mdash; muito numa borda, quase zero num borrão &mdash;
+      e pega o vencedor.
+    </p>
+    <p>
+      Este quer um tripé mais do que todos os outros, porque mexer no anel de foco com
+      a mão move a câmera, e um quadro feito de um pouco mais longe não é a mesma
+      imagem noutro foco.
+    </p>
+  </section>
+
+  <section>
+    <h2>Alinhar os quadros</h2>
+    <p>
+      Empilhar é aritmética por pixel, então parte do princípio de que um dado pixel é
+      a mesma parte da cena em todos os quadros. Na mão, não é: uma sequência deriva
+      dezenas de pixels, e tirar a média disso produz um borrão em vez de uma imagem
+      limpa. É de longe o motivo mais comum de uma primeira tentativa de empilhamento
+      decepcionar.
+    </p>
+    <p>
+      Então os quadros são medidos contra um deles e postos de volta no lugar antes,
+      com precisão de fração de pixel. Três ajustes:
+    </p>
+    <ul>
+      <li>
+        <strong>Só deslocamento</strong> serve para quase tudo feito na mão. Corrige
+        a deriva e o tremor.
+      </li>
+      <li>
+        <strong>Deslocamento, rotação e escala</strong> para um conjunto em que você
+        também girava de leve, ou em que um zoom escorregou. Custa uma medição a mais
+        por quadro e não custa nada quando os quadros se revelam retos.
+      </li>
+      <li>
+        <strong>Nenhum</strong> para um tripé travado ou uma série de
+        intervalômetro, em que os quadros já estão alinhados e medi-los é tempo
+        perdido.
+      </li>
+    </ul>
+    <p>
+      O que alinhamento algum conserta é um assunto que se moveu em vez de uma câmera
+      que se moveu, e nem uma fotografia tirada um passo à esquerda. Andar para o lado
+      muda quanto as coisas próximas se deslocam em relação às distantes, e nenhuma
+      correção única descreve as duas de uma vez. Girar no lugar tudo bem; caminhar
+      não.
+    </p>
+  </section>
+
+  <section>
+    <h2>Onde os arquivos RAW entram</h2>
+    <p>
+      Você pode soltar CR2, CR3, NEF, ARW, DNG, RAF, RW2, ORF e o resto direto lá
+      dentro, e vale a pena ser exato sobre o que acontece com eles, porque não é o
+      que um conversor RAW faz.
+    </p>
+    <p>
+      Todo arquivo RAW já contém um <strong>JPEG em tamanho cheio que a câmera
+      renderizou no momento do disparo</strong>. É o que a traseira da câmera lhe
+      mostra e o que o seu sistema operacional desenha como miniatura. O empilhador
+      encontra aquela imagem e usa aquilo. Ele não decodifica os dados do sensor.
+    </p>
+    <p>
+      Duas consequências, uma boa e uma que vale a pena saber:
+    </p>
+    <ul>
+      <li>
+        <strong>É rápido.</strong> Encontrar a prévia significa ler alguns kilobytes
+        de diretório e depois uma fatia, então um quadro de 60&nbsp;MB abre mais ou
+        menos tão rápido quanto um JPEG. Vinte deles abrem no tempo que um conversor
+        RAW gastaria num. A página lhe mostra quão pouco dos seus arquivos ele leu de
+        fato.
+      </li>
+      <li>
+        <strong>É a interpretação da câmera, não a sua.</strong> Oito bits por canal,
+        com o balanço de branco e o estilo de imagem em que a câmera estava &mdash;
+        não os doze ou catorze bits de dados lineares do sensor que você teria de um
+        conversor.
+      </li>
+    </ul>
+    <p>
+      Para redução de ruído, rastros de estrelas, tirar transeuntes e focus stacking,
+      essa troca quase sempre compensa: as prévias são em resolução cheia e são o que
+      você teria recebido como JPEG de qualquer jeito. Se você está puxando muito as
+      sombras, ou empilhando para astrofotografia, onde o último pedacinho de faixa
+      dinâmica é o ponto inteiro, revele os quadros num conversor RAW antes e empilhe
+      os TIFFs ou JPEGs que ele der. Esses entram do mesmo jeito.
+    </p>
+  </section>
+
+  <section>
+    <h2>Quanto custa rodar</h2>
+    <p>
+      Vale a pena saber porque é a diferença entre uma pilha que leva oito segundos e
+      uma que leva dois minutos.
+    </p>
+    <p>
+      Seis dos sete métodos só precisam lembrar de uma coisa. Um máximo corrente não
+      se importa com os quadros que já viu, e um total corrente também não, então
+      esses métodos leem cada quadro exatamente uma vez e usam a mesma memória para
+      cem quadros que para dois.
+    </p>
+    <p>
+      A mediana não pode funcionar assim, porque não dá para saber o valor do meio de
+      um conjunto até ter o conjunto inteiro. Vinte quadros de 24 megapixels são cerca
+      de 1,4&nbsp;GB de pixels segurados ao mesmo tempo, que navegador nenhum lhe dá,
+      então a imagem é cortada em faixas horizontais e empilhada uma faixa por vez
+      &mdash; correto, e mais lento, porque os quadros são lidos de novo para cada
+      faixa.
+    </p>
+    <p>
+      A ferramenta calcula tudo isso antes de você apertar o botão e lhe diz: que
+      tamanho terá o resultado, mais ou menos quanta memória precisa, e quantas vezes
+      os seus quadros serão decodificados. Se ela disser que a execução vai ser em
+      faixas, baixar um passo a resolução de trabalho divide a memória por quatro e
+      quase sempre a devolve a uma passagem única &mdash; e se você está empilhando
+      para tirar ruído, meia resolução já ia sair mais limpa do que a cheia.
+    </p>
+  </section>
+
+  <section>
+    <h2>Fotografando com isso em mente</h2>
+    <p>
+      A maior parte da qualidade de uma pilha é decidida antes de qualquer programa
+      vê-la.
+    </p>
+    <ul>
+      <li>
+        <strong>Faça mais quadros do que você acha que precisa.</strong> A curva da
+        raiz quadrada é implacável no começo e generosa no fim: ir de quatro para
+        nove quadros é uma mudança visível maior do que ir de vinte para quarenta.
+      </li>
+      <li>
+        <strong>Não mude a exposição entre os quadros.</strong> Empilhar parte do
+        princípio de que os quadros são da mesma cena com o mesmo brilho. Trave a
+        exposição, ou a ferramenta vai estar tirando a média de duas imagens
+        diferentes.
+      </li>
+      <li>
+        <strong>Para tirar pessoas, espere entre os quadros.</strong> Uma sequência
+        feita em dois segundos pega a mesma pessoa no mesmo lugar em todos os quadros,
+        e a mediana a mantém. Dez quadros com alguns segundos de intervalo funciona
+        muito melhor do que cinquenta em rajada.
+      </li>
+      <li>
+        <strong>Para rastros de estrelas, mantenha os intervalos curtos.</strong>
+        Clarear desenha exatamente o que os quadros registraram, então uma pausa entre
+        as exposições vira um tracinho visível em cada rastro.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Nada disso sai da sua máquina</h2>
+    <p>
+      Uma pilha de vinte quadros RAW é cerca de um gigabyte de fotografias, o que é
+      muito para entregar a um site a fim de que se tire uma média disso. O
+      <a href="../../empilhar-imagens/">Empilhador de imagens</a> lê os arquivos do
+      seu próprio disco e faz a aritmética no seu próprio navegador. Não há passo de
+      envio, não há conta e não há fila, e você pode conferir essa afirmação como
+      conferiria a de qualquer um: abra o painel de rede do seu navegador enquanto ele
+      roda, ou simplesmente tire o cabo da internet e empilhe mesmo assim.
+    </p>
+    <p>
+      A pergunta relacionada &mdash; como saber, para qualquer ferramenta, se
+      entregar-lhe um arquivo era necessário &mdash; tem
+      <a href="../e-seguro-enviar-arquivos/">um guia próprio</a>.
+    </p>
+  </section>

--- a/locales/pt/pages/guides/stack-photos-to-reduce-noise.toml
+++ b/locales/pt/pages/guides/stack-photos-to-reduce-noise.toml
@@ -1,0 +1,20 @@
+#
+# Guia: empilhar fotografias contra o ruído - Portuguese.
+#
+
+nav = "Empilhar fotografias"
+title = "Como empilhar fotografias para reduzir o ruído, ou tirar pessoas"
+description = "Empilhar junta uma sequência de quadros numa imagem só. Qual método usar depende do que você quer perder: ruído, transeuntes, ou a profundidade de campo rasa de uma macro. Como cada um funciona, quanto custa, e onde os arquivos RAW entram."
+
+heading = "Como empilhar fotografias para reduzir o ruído, ou tirar pessoas"
+lede = """
+    Uma sequência de quadros guarda mais informação do que qualquer um deles. Tirar
+    a média deles cancela o ruído; pegar o valor do meio de cada pixel apaga tudo o
+    que só estava ali parte do tempo. Qual dos dois você quer depende inteiramente
+    do que se mexeu."""
+
+updated = "25 de agosto de 2026"
+
+og_title = "Como empilhar fotografias para reduzir o ruído, ou tirar pessoas"
+og_description = "Tire a média de uma sequência para matar o ruído, use a mediana para esvaziar uma praça movimentada, clareie para rastros de estrelas. Qual método resolve qual problema, e onde os arquivos RAW entram."
+og_image_alt = "abox.tools - ferramentas que nunca tocam um servidor"

--- a/locales/pt/tools/dicom-viewer.html
+++ b/locales/pt/tools/dicom-viewer.html
@@ -1,0 +1,265 @@
+<!--
+  tools/dicom-viewer/body.html, in Portuguese.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+
+  O cabeçalho de coluna "VR" fica como está: é o código de duas letras que vem
+  escrito assim no arquivo, e quem procura uma tag no padrão procura exatamente
+  essas duas letras.
+-->
+<main>
+  <!--
+    One numbered step, and then the viewer.
+
+    Every other tool on this site numbers its cards because every card is
+    something the visitor does. Here there is one thing to do - choose the
+    files - and everything below it is the scan. Numbering the picture would
+    promise a sequence of decisions that does not exist.
+  -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha o exame</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p class="picker-note">
+      Arraste uma pasta inteira de uma vez, e os arquivos são devolvidos às suas
+      séries e postos na ordem certa. Nada é enviado, e nada é escrito de volta
+      nos seus arquivos.
+    </p>
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="working" class="working" role="status" aria-live="polite" hidden></p>
+  </section>
+
+  <!-- O visualizador. -->
+  <section class="card" id="viewer-card" hidden>
+    <div class="toolbar">
+      <h2 id="file-name" class="file-name">&mdash;</h2>
+      <div class="toolbar-actions">
+        <button type="button" id="save-frame" class="ghost" data-download>Salvar esta imagem como PNG</button>
+        <button type="button" id="copy-header" class="ghost">Copiar o cabeçalho</button>
+        <button type="button" id="download-header" class="ghost">Baixar</button>
+      </div>
+    </div>
+
+    <div class="series-row" id="series-row" hidden>
+      <label for="series-pick" class="inline-label">Série</label>
+      <select id="series-pick"></select>
+      <span class="count" id="series-note"></span>
+    </div>
+
+    <!--
+      The canvas is sized in CSS and its backing store is set to the frame's own
+      pixels, so a 512-pixel slice is drawn at 512 pixels and scaled by the
+      browser rather than resampled here. That is what makes the zoom honest:
+      what is on screen at 400% is the stored pixels made bigger, not a guess at
+      what was between them.
+    -->
+    <div class="viewport" id="viewport">
+      <canvas id="canvas" width="1" height="1" role="img"
+              aria-label="A imagem na tela, desenhada a partir do arquivo que você escolheu"></canvas>
+      <div class="overlay overlay-tl" id="overlay-tl" hidden></div>
+      <div class="overlay overlay-tr" id="overlay-tr"></div>
+      <div class="overlay overlay-bl" id="overlay-bl"></div>
+      <div class="overlay overlay-br" id="overlay-br"></div>
+      <svg class="marks" id="marks" aria-hidden="true"></svg>
+      <p class="viewport-fail" id="viewport-fail" hidden></p>
+    </div>
+
+    <div class="scrub" id="scrub-row" hidden>
+      <button type="button" id="play" class="ghost" aria-label="Tocar as imagens">▶</button>
+      <input type="range" id="scrub" min="0" max="0" value="0" step="1"
+             aria-label="Qual corte ou qual quadro está sendo mostrado">
+      <span class="count" id="scrub-label">&mdash;</span>
+    </div>
+
+    <div class="tools">
+      <fieldset class="modes">
+        <legend class="visually-hidden">O que arrastar sobre a imagem faz</legend>
+        <label><input type="radio" name="mode" value="window" checked> Janela e nível</label>
+        <label><input type="radio" name="mode" value="pan"> Deslocar</label>
+        <label><input type="radio" name="mode" value="measure"> Medir</label>
+      </fieldset>
+
+      <div class="zoom">
+        <label for="zoom" class="inline-label">Zoom</label>
+        <input type="range" id="zoom" min="5" max="800" step="5" value="100">
+        <span class="count" id="zoom-label">100%</span>
+        <button type="button" id="reset-view" class="ghost">Ajustar</button>
+      </div>
+    </div>
+
+    <div class="levels" id="levels">
+      <div class="level-field">
+        <label for="preset" class="inline-label">Janela</label>
+        <select id="preset"></select>
+      </div>
+      <div class="level-field">
+        <label for="center" class="inline-label">Centro</label>
+        <input type="number" id="center" step="1">
+      </div>
+      <div class="level-field">
+        <label for="width" class="inline-label">Largura</label>
+        <input type="number" id="width" step="1" min="1">
+      </div>
+      <label class="level-check"><input type="checkbox" id="invert"> Inverter</label>
+      <label class="level-check"><input type="checkbox" id="show-details"> Sobrepor os dados do paciente à imagem</label>
+    </div>
+
+    <p class="hint" id="mode-hint"></p>
+    <p id="copy-status" class="copy-status" role="status" aria-live="polite"></p>
+  </section>
+
+  <!-- O que é este arquivo. -->
+  <section class="card" id="facts-card" hidden>
+    <h2>O que é este arquivo</h2>
+    <dl class="facts">
+      <div><dt>Objeto</dt><dd id="fact-sop">&mdash;</dd></div>
+      <div><dt>Modalidade</dt><dd id="fact-modality">&mdash;</dd></div>
+      <div><dt>Imagem</dt><dd id="fact-size">&mdash;</dd></div>
+      <div><dt>Armazenado como</dt><dd id="fact-stored">&mdash;</dd></div>
+      <div><dt>Transfer syntax</dt><dd id="fact-syntax">&mdash;</dd></div>
+      <div><dt>Espaçamento dos pixels</dt><dd id="fact-spacing">&mdash;</dd></div>
+      <div><dt>Faixa de valores</dt><dd id="fact-range">&mdash;</dd></div>
+      <div><dt>Arquivo</dt><dd id="fact-file">&mdash;</dd></div>
+    </dl>
+
+    <ul class="notes" id="notes" hidden></ul>
+  </section>
+
+  <!-- O que está escrito sobre a pessoa. -->
+  <section class="card" id="identity-card" hidden>
+    <h2>O que neste arquivo identifica o paciente</h2>
+    <p class="card-lede">
+      Lido deste arquivo, neste dispositivo, e mostrado a mais ninguém. Esta
+      ferramenta não escreve nada: ela não consegue tirar nada disso, e não mandou
+      nada disso a lugar nenhum. Está aqui porque um exame carrega muito mais do
+      que um nome, e porque o resto é exatamente o que sobrevive a uma
+      anonimização feita com desleixo.
+    </p>
+    <ul class="identity" id="identity"></ul>
+    <p class="identity-extra" id="identity-extra"></p>
+  </section>
+
+  <!-- Cada tag do arquivo. -->
+  <section class="card" id="tags-card" hidden>
+    <div class="toolbar">
+      <h2>Cada tag do arquivo</h2>
+      <div class="toolbar-actions">
+        <label for="tag-search" class="visually-hidden">Pesquisar nas tags</label>
+        <input type="search" id="tag-search" class="tag-search" placeholder="Pesquise por nome, número ou valor">
+      </div>
+    </div>
+
+    <p class="card-lede" id="tags-lede"></p>
+
+    <div class="table-wrap">
+      <table class="tags">
+        <caption class="visually-hidden">Cada elemento deste arquivo</caption>
+        <thead>
+          <tr>
+            <th scope="col">Tag</th>
+            <th scope="col">VR</th>
+            <th scope="col">Nome</th>
+            <th scope="col">Valor</th>
+          </tr>
+        </thead>
+        <tbody id="tag-rows"></tbody>
+      </table>
+    </div>
+
+    <div class="more-row">
+      <button type="button" id="show-more" class="ghost" hidden></button>
+    </div>
+  </section>
+
+  <!--
+    The tool's own sentences, kept out of the JavaScript so that a translator
+    can reach them. shared/js/phrases.js reads them back, and a key defined here
+    wins over the frame's one.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="mode.window">Arraste de través sobre a imagem para alargar ou estreitar a janela, e para cima ou para baixo para deslocar o centro. Os dois números ficam logo abaixo, e digitá-los faz a mesma coisa.</span>
+    <span data-phrase="mode.pan">Arraste para deslocar a imagem dentro da moldura. A roda do mouse dá zoom, e &ldquo;Ajustar&rdquo; devolve tudo ao lugar.</span>
+    <span data-phrase="mode.measure">Trace uma linha sobre a imagem para medir. Onde o arquivo diz a que distância estão os seus pixels, o resultado vem em milímetros; onde não diz, vem em pixels e avisa.</span>
+
+    <span data-phrase="probe.value">{value} na coluna {column}, linha {row}</span>
+    <span data-phrase="measure.pixels">{length} px &mdash; este arquivo não diz a que distância estão os seus pixels, então isto não pode vir em milímetros</span>
+
+    <span data-phrase="stack.position">Empilhados por onde cada corte está no corpo, e essa é a ordem em que o aparelho os registrou.</span>
+    <span data-phrase="stack.number">Empilhados por Instance Number: estes arquivos não trazem uma posição no corpo pela qual ordenar.</span>
+    <span data-phrase="stack.gap">A distância entre os cortes não é a mesma em toda parte, então nesta série falta pelo menos um.</span>
+
+    <span data-phrase="pixels.none">Os pixels deste arquivo estão comprimidos com {codec}. Nenhum navegador sabe decodificar isso, e esta página não traz um decodificador para tanto. Todo o resto sobre o arquivo está abaixo.</span>
+    <span data-phrase="pixels.failed">Não foi possível decodificar a imagem: {reason}. O cabeçalho abaixo foi lido por inteiro.</span>
+    <span data-phrase="pixels.absent">Este arquivo não traz dado de pixel algum. É um cabeçalho, e tudo o que há nele está abaixo.</span>
+    <span data-phrase="pixels.jpeg">Estes pixels são JPEG baseline, então quem os desempacotou foi o decodificador do navegador, e o que ele devolve tem oito bits de profundidade. A janela continua funcionando; a precisão que o aparelho registrou não está toda aí.</span>
+
+    <span data-phrase="tags.count">{shown} de {total} elementos. Mais {hidden}.</span>
+    <span data-phrase="tags.all">Todos os {total} elementos deste arquivo.</span>
+    <span data-phrase="tags.found">{total} elementos correspondem a &ldquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.found.one">Um elemento corresponde a &ldquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.none">Nada corresponde a &ldquo;{query}&rdquo;.</span>
+    <span data-phrase="tags.more">Mostrar os {count} restantes</span>
+    <span data-phrase="tags.private">elemento privado</span>
+    <span data-phrase="tags.unknown">não está neste dicionário</span>
+    <span data-phrase="tags.guessed">O arquivo não disse; isto é o que o dicionário de dados indica para esta tag.</span>
+
+    <span data-phrase="working.one">Lendo {name}&hellip;</span>
+    <span data-phrase="working.many">Lendo {at} de {total}&hellip;</span>
+    <span data-phrase="error.none">Nada disto pôde ser lido como DICOM. {why} Esta ferramenta lê o formato DICOM em si, então sobre outros arquivos ela não tem o que dizer.</span>
+    <span data-phrase="error.skipped.one">Um arquivo foi pulado: {files}</span>
+    <span data-phrase="error.skipped">{count} arquivos foram pulados: {files}</span>
+
+    <span data-phrase="series.number">Série {number}</span>
+    <span data-phrase="series.files.one">1 arquivo</span>
+    <span data-phrase="series.files">{count} arquivos</span>
+    <span data-phrase="stack.spacing">Os cortes estão a {gap} um do outro.</span>
+
+    <span data-phrase="at.position">{at} de {total}</span>
+    <span data-phrase="net.clean">O seu exame não foi a lugar nenhum. {total} arquivos
+      carregados, todos do próprio site. {platform}</span>
+    <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta ferramenta
+      nunca faz isso. Vale a pena ir ver. {platform}</span>
+    <span data-phrase="net.platform.one">Os scripts do próprio site para
+      publicidade, medição e o botão de doação vieram de {hosts} host; nenhum deles
+      recebeu um exame, um pixel dele ou uma palavra do seu cabeçalho.</span>
+    <span data-phrase="net.platform.many">Os scripts do próprio site para
+      publicidade, medição e o botão de doação vieram de {hosts} hosts; nenhum deles
+      recebeu um exame, um pixel dele ou uma palavra do seu cabeçalho.</span>
+    <span data-phrase="at.frame">Quadro {at} de {total}</span>
+    <span data-phrase="at.instance">Instância {number}</span>
+
+    <span data-phrase="window.file">Do arquivo</span>
+    <span data-phrase="window.file.n">Do arquivo, {n}</span>
+    <span data-phrase="window.full">Tudo o que há nesta imagem</span>
+    <span data-phrase="window.custom">Ajustada à mão</span>
+    <span data-phrase="window.soft">Partes moles</span>
+    <span data-phrase="window.lung">Pulmão</span>
+    <span data-phrase="window.bone">Osso</span>
+    <span data-phrase="window.brain">Cérebro</span>
+    <span data-phrase="window.liver">Fígado</span>
+    <span data-phrase="window.mediastinum">Mediastino</span>
+    <span data-phrase="window.angio">Angiografia</span>
+
+    <span data-phrase="facts.frames">{count} quadros</span>
+    <span data-phrase="facts.nopixels">sem dados de pixel</span>
+    <span data-phrase="facts.nospacing">não informado neste arquivo</span>
+    <span data-phrase="facts.signed">com sinal</span>
+    <span data-phrase="facts.unsigned">sem sinal</span>
+    <span data-phrase="facts.stored.one">{bits} bits, {sign}, 1 canal por pixel, {photometric}</span>
+    <span data-phrase="facts.stored">{bits} bits, {sign}, {samples} canais por pixel, {photometric}</span>
+    <span data-phrase="facts.range">{low} a {high}</span>
+    <span data-phrase="facts.colour">cor &mdash; nada de medido a relatar</span>
+
+    <span data-phrase="identity.clean">Nada neste arquivo nomeia ou numera uma pessoa. Os identificadores que um exame costuma carregar faltam ou estão vazios.</span>
+    <span data-phrase="identity.uids">Ele carrega ainda {count} identificadores próprios, os UIDs do estudo, da série e da instância. Nenhum deles é um nome, e cada um é uma chave perfeita de volta ao arquivo de onde ele veio.</span>
+    <span data-phrase="identity.private">Além disso, {count} elementos privados cujo significado não está publicado em lugar nenhum: alguns aparelhos guardam num deles uma segunda cópia do nome do paciente.</span>
+
+    <span data-phrase="copied">Copiado.</span>
+    <span data-phrase="copy.failed">O seu navegador negou à página a permissão de copiar. O botão ao lado escreve o mesmo texto num arquivo.</span>
+    <span data-phrase="saved">{name} salvo.</span>
+  </div>
+</main>

--- a/locales/pt/tools/dicom-viewer.toml
+++ b/locales/pt/tools/dicom-viewer.toml
@@ -1,0 +1,392 @@
+#
+# DICOM Viewer - Portuguese.
+#
+# Overrides for tools/dicom-viewer/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Os nomes dos campos DICOM ficam em inglês e carregam o número - Pixel Spacing
+# (0028,0030), Series Instance UID (0020,000E). É assim que estão escritos no
+# arquivo e é assim que estão no padrão: quem procura um campo procura
+# exatamente essas palavras. O mesmo vale para as transfer syntaxes e para a
+# PS3.15.
+#
+# Nesta página a promessa do site tem o fio mais afiado de todas: o arquivo é um
+# prontuário com uma imagem dentro. As frases sobre o que está escrito nele são
+# traduzidas com o mesmo cuidado que as frases sobre onde ele não vai parar.
+#
+
+name = "Visualizador DICOM"
+heading = "Visualizador&nbsp;DICOM <span class=\"h1-kw\">&mdash; abra um exame .dcm no navegador</span>"
+tagline = "Tomografia, ressonância, raio X e ultrassom, com a janela, o cabeçalho e as medidas."
+
+title = "Visualizador DICOM &mdash; abra um arquivo .dcm no navegador, sem enviar nada"
+description = "Abra exames de tomografia, ressonância, raio X e ultrassom no navegador. Janela e nível, percorra uma série inteira, meça em milímetros, leia cada tag DICOM e veja exatamente o que no arquivo identifica o paciente. Nada é enviado."
+og_title = "Visualizador DICOM &mdash; abra um exame sem enviá-lo"
+og_description = "Um arquivo .dcm aberto na sua própria máquina: janela e nível, a série inteira empilhada na ordem certa, medidas em milímetros e cada tag do cabeçalho. Sem envio, sem conta."
+og_image_alt = "Visualizador DICOM - abra uma tomografia, ressonância ou raio X no navegador"
+
+pledge = """
+    O exame é aberto e decodificado pelo seu próprio navegador: o cabeçalho, os
+    pixels, a janela, as medidas. Do outro lado desta página não existe servidor
+    algum para receber dados de saúde, nem se algo aqui quisesse mandar, e nada
+    sobre o arquivo &mdash; nem o nome do paciente, nem o estudo, nem o nome do
+    arquivo &mdash; é contado a ninguém."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas do desenvolvedor, olhe a
+      aba Rede e abra um exame. Nenhuma requisição carrega uma imagem, uma tag ou
+      um nome de arquivo. Ou tire o cabo da internet e abra um mesmo assim."""
+
+read_first = """
+, <code>src/dicom.js</code> para o parser que
+      percorre o arquivo, <code>src/pixels.js</code> para a decodificação dos
+      pixels, <code>src/jpeg-lossless.js</code> para o codec que a maioria dos
+      hospitais usa ao exportar, e <code>src/window.js</code> para a janela e o
+      nível &mdash; e em nenhum deles existe uma linha capaz de alcançar a
+      rede."""
+
+howto_heading = "Como abrir um arquivo DICOM"
+
+card = """
+            Abra uma tomografia, ressonância, raio X ou ultrassom na sua própria
+            máquina. Ajuste janela e nível, percorra a série inteira, meça em
+            milímetros e leia cada tag do cabeçalho."""
+
+[words]
+plural = "exames"
+choose = "um exame"
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[facts]]
+text = "Os arquivos ficam no seu dispositivo"
+
+[[privacy]]
+title = "O seu exame não tem para onde ir."
+body = """
+ A
+      Content-Security-Policy lista todos os endereços que esta página pode
+      contatar, e nenhum deles pertence a este site. Não existe aqui um endpoint
+      onde o seu arquivo pudesse ser recolhido, e não existe no código nada que o
+      enviasse se existisse. Antes estava escrito <code>connect-src 'none'</code>,
+      que era absoluto; acrescentar publicidade custou isso, e dizê-lo faz parte do
+      acordo."""
+
+[[privacy]]
+title = "Aqui isso pesa mais do que nas outras páginas."
+body = """
+
+      Um arquivo DICOM não é uma imagem com alguns metadados. É um prontuário com
+      uma imagem dentro: o nome do paciente, a data de nascimento, o número do
+      prontuário, o número do pedido, o médico solicitante, a instituição e o
+      número de série do aparelho são todos campos do cabeçalho, e viajam com o
+      arquivo para onde quer que ele vá. Enviar um para um site só para olhá-lo
+      significa entregar tudo isso a quem administra o site. É exatamente o que
+      esta página existe para não fazer."""
+
+[[privacy]]
+title = "O leitor são catorze arquivos neste repositório."
+body = """
+ Nada aqui usa uma
+      biblioteca buscada em outro lugar. <code>src/dicom.js</code> percorre o
+      arquivo, <code>src/dictionary.js</code> sabe como as tags se chamam,
+      <code>src/pixels.js</code> devolve os bytes à condição de medidas,
+      <code>src/rle.js</code> e <code>src/jpeg-lossless.js</code> expandem as duas
+      formas comprimidas que esta página sabe decodificar, e
+      <code>src/window.js</code> mapeia o que foi medido nos cinzas da sua
+      tela."""
+
+[[privacy]]
+title = "Os identificadores estão listados para você, e para mais ninguém."
+body = """
+
+      A página imprime todos os campos do seu arquivo que nomeiam ou estreitam a
+      pessoa de quem é o exame, porque essa é a pergunta que precisa de resposta
+      para quem está prestes a compartilhar um corte, e nenhum visualizador
+      responde. Fica na tela à sua frente e não vai a lugar nenhum: não existe
+      neste repositório um evento de analytics que carregue qualquer parte disso, e
+      a página não conseguiria enviá-lo mesmo que existisse."""
+
+[[privacy]]
+title = "Ele lê. Ele não escreve."
+body = """
+ Não existe aqui um botão que
+      altere o seu arquivo, nem código que pudesse fazê-lo. O que você pode levar é
+      um PNG da imagem na tela e uma cópia do cabeçalho em texto, ambos montados na
+      página a partir do que já está nela. O seu original continua intacto no seu
+      disco, o que é também a resposta honesta para o que acontece se você fechar a
+      aba."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não recebe."
+body = """
+ Os scripts de
+      publicidade e medição vêm do Google. Nenhum dos dois recebe nada sobre o seu
+      arquivo: nem os pixels, nem uma miniatura, nem um nome, uma tag, um paciente
+      ou um nome de arquivo. Cada linha que lê, decodifica ou desenha um exame é
+      servida desta origem e está listada no repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não recebe."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; no topo é desenhado por um script de
+      cdnjs.buymeacoffee.com e busca as letras no Google Fonts. É um link e nada
+      mais: não relata visita alguma, e não recebe nada sobre você nem sobre os
+      seus arquivos. Nada acontece a menos que você clique, e para onde você iria
+      ao clicar é o site de outra pessoa."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e todas as partes desta
+      página continuam funcionando. É a prova mais simples de todas: uma ferramenta
+      que mandasse o seu exame para ser desenhado em outro lugar pararia no
+      instante em que você tirasse o cabo."""
+
+[[howto]]
+title = "Escolha os arquivos."
+body = """
+ Um arquivo <code>.dcm</code>, ou a
+      pasta inteira do disco &mdash; uma tomografia ou uma ressonância é um arquivo
+      por corte, e arrastar todos de uma vez é o que remonta a série. Os arquivos
+      são lidos direto do seu disco pelo navegador; nada é enviado a lugar nenhum
+      enquanto você faz isso."""
+
+[[howto]]
+title = "Escolha a série."
+body = """
+ Um estudo costuma trazer várias: o
+      escanograma e depois cada aquisição. Cada uma é empilhada na ordem em que o
+      aparelho a registrou, deduzida de onde cada corte está no corpo e não da
+      numeração, que nem sempre corre no mesmo sentido."""
+
+[[howto]]
+title = "Ajuste a janela."
+body = """
+ É o controle que deixa um exame
+      legível, e é o que um editor de imagens não tem. Arraste sobre a imagem para
+      alargar a janela e para cima ou para baixo para deslocar o centro, ou escolha
+      uma das janelas com nome &mdash; pulmão, osso, cérebro, partes moles &mdash;
+      numa tomografia, onde as unidades são as mesmas em qualquer aparelho do
+      mundo."""
+
+[[howto]]
+title = "Percorra a pilha."
+body = """
+ O controle deslizante abaixo da
+      imagem anda pelos cortes, e as setas do teclado fazem o mesmo depois que você
+      clica na imagem. Um arquivo com vários quadros &mdash; um laço de ultrassom,
+      uma angiografia &mdash; toca com o botão ao lado."""
+
+[[howto]]
+title = "Meça alguma coisa."
+body = """
+ Passe para Medir e arraste uma
+      linha. Onde o arquivo diz a que distância estão os seus pixels, a resposta
+      vem em milímetros e leva em conta pixels que não são quadrados; onde o
+      arquivo não diz, a resposta vem em pixels e avisa, em vez de inventar uma
+      escala."""
+
+[[howto]]
+title = "Leia o cabeçalho."
+body = """
+ Cada elemento do arquivo, com o seu
+      número, o nome que o padrão lhe dá e o que ele guarda, pesquisável. Acima
+      dele, a lista do que neste arquivo em particular identifica o paciente
+      &mdash; que é bem mais do que o nome."""
+
+[[howto]]
+title = "Leve o que precisar."
+body = """
+ A imagem na tela como PNG, com a
+      janela que você ajustou e sem nada gravado por cima, ou o cabeçalho inteiro
+      em texto simples. Os dois são montados na página a partir do que já está
+      lá."""
+
+[[faq]]
+q = "O meu exame é enviado para algum lugar?"
+a = """
+        Não. O arquivo é lido, decodificado e desenhado pelo seu próprio navegador
+        no seu próprio hardware. Esta ferramenta não tem lado servidor, e a
+        <code>Content-Security-Policy</code> da página lista todos os endereços que
+        ela pode contatar &mdash; nenhum deles pertence a este site. Tire o cabo da
+        rede e ele continua abrindo exames.
+        <br><br>
+        Isso vale mais aqui do que em qualquer outra página deste site. Um arquivo
+        DICOM carrega no cabeçalho o nome do paciente, a data de nascimento e o
+        número do prontuário, então enviar um para um visualizador significa
+        entregar a um estranho um prontuário, e não uma imagem."""
+
+[[faq]]
+q = "Quais arquivos DICOM ele consegue abrir?"
+a = """
+        Arquivos não comprimidos em qualquer uma das três transfer syntaxes básicas
+        &mdash; implicit e explicit little endian, e a big endian já retirada
+        &mdash; além de deflated, RLE Lossless, JPEG baseline e JPEG Lossless, que é
+        como está comprimida a maioria dos estudos de tomografia e ressonância num
+        disco de hospital.
+        <br><br>
+        Ele não decodifica JPEG 2000, JPEG-LS, nem as sintaxes MPEG e HEVC usadas
+        para vídeo. Essas exigem codecs que são megabytes de biblioteca compilada, e
+        uma página que buscasse um deles quando desse na telha não seria uma página
+        que funciona offline. Um arquivo em uma dessas abre do mesmo jeito: o
+        cabeçalho inteiro é lido e mostrado, e no lugar da imagem aparece uma linha
+        nomeando o codec, em vez de um ícone de imagem quebrada que não diz nada."""
+
+[[faq]]
+q = "O que é &ldquo;janela e nível&rdquo;, e por que eu preciso disso?"
+a = """
+        Um corte de tomografia guarda cerca de quatro mil valores distintos e a sua
+        tela mostra duzentos e cinquenta e seis cinzas. A janela é a escolha de qual
+        fatia dessa faixa fica com todos eles: tudo abaixo é preto, tudo acima é
+        branco, e o que está no meio se espalha pelos cinzas.
+        <br><br>
+        É por isso que o mesmo arquivo parece um exame diferente sob dois ajustes, e
+        por que pulmão e osso não podem ser vistos ao mesmo tempo. Numa tomografia os
+        números são unidades Hounsfield, definidas em absoluto &mdash; a água é 0 e
+        o ar é &minus;1000 &mdash; então as janelas com nome nesta página são os
+        mesmos números que um radiologista usa na estação de trabalho. Numa
+        ressonância ou num ultrassom não existe escala assim, e a janela que abre é
+        aquela que o próprio arquivo pede."""
+
+[[faq]]
+q = "Por que ele diz que a minha medida está em pixels?"
+a = """
+        Porque aquele arquivo não diz qual é o tamanho de um pixel. Pixel Spacing
+        (0028,0030) é o campo que carrega isso, em milímetros, e muitíssimas imagens
+        de ultrassom, documentos digitalizados e secondary captures simplesmente não
+        o têm.
+        <br><br>
+        Onde ele existe, a medida vem em milímetros e cada eixo é medido com o seu
+        próprio espaçamento, o que importa nas imagens cujos pixels não são
+        quadrados. Onde não existe, a resposta honesta é uma contagem de pixels, e é
+        isso que ele diz, em vez de escolher uma escala e apresentar o resultado como
+        um comprimento."""
+
+[[faq]]
+q = "Ele abriu a minha pasta como várias séries. Por quê?"
+a = """
+        Porque é isso que há nela. Um estudo é feito de séries &mdash; o escanograma
+        e depois cada aquisição ou reconstrução &mdash; e cada arquivo declara a qual
+        pertence em Series Instance UID (0020,000E). O menu é montado a partir disso
+        e não da pasta, que normalmente tem todas misturadas numa única lista de
+        nomes.
+        <br><br>
+        Dentro de uma série os cortes são ordenados por onde cada um está no corpo,
+        deduzido de Image Position e Image Orientation. Instance Number é a chave
+        óbvia e é o recurso de reserva, não a primeira escolha: ele é atribuído por
+        seja lá o que tenha escrito os arquivos e não precisa correr no mesmo sentido
+        que o paciente."""
+
+[[faq]]
+q = "O que significa a lista &ldquo;o que identifica o paciente&rdquo;?"
+a = """
+        É cada campo do seu arquivo que nomeia a pessoa de quem é o exame, ou que
+        estreita quem ela poderia ser, lido deste arquivo na sua máquina. A lista vem
+        da PS3.15 do padrão DICOM &mdash; a parte que diz o que precisa sair antes de
+        um conjunto de dados poder ser chamado de desidentificado.
+        <br><br>
+        Ela está aí porque o que as pessoas erram não é achar que um exame tem um
+        nome dentro. É quanta coisa mais ele tem: a data de nascimento, o número do
+        pedido, o médico solicitante, a instituição, o número de série do aparelho e
+        os UIDs do estudo, que são chaves perfeitas de volta ao arquivo que o gerou.
+        Um exame de que só se apagou o nome não é anônimo.
+        <br><br>
+        Esta ferramenta apenas mostra. Ela não escreve nada e não altera nada, então
+        não consegue tirar nada disso."""
+
+[[faq]]
+q = "Ele consegue anonimizar um exame?"
+a = """
+        Não, e de propósito não finge que consegue. Esta página lê; não tem código
+        que escreva um arquivo DICOM. O que ela faz é dizer exatamente o que há no
+        seu, que é a parte difícil de descobrir e a parte sobre a qual as pessoas se
+        enganam.
+        <br><br>
+        Uma ferramenta que tira os identificadores é um trabalho à parte, com uma
+        régua bem mais alta &mdash; precisa reescrever o arquivo sem tocar nos
+        pixels, substituir os UIDs de forma coerente por um estudo inteiro e acertar
+        nos elementos privados em que alguns aparelhos escondem uma segunda cópia do
+        nome. Está no roteiro deste site, e não pregada num visualizador."""
+
+[[faq]]
+q = "Ele abre um arquivo sem a extensão .dcm, ou um arquivo danificado?"
+a = """
+        Sim para os dois. A extensão não é olhada: o que se verifica é o próprio
+        arquivo. Um conjunto de dados escrito sem o preâmbulo habitual de 128 bytes
+        &mdash; que é a cara de um exame puxado direto da rede &mdash; é lido
+        deduzindo a codificação a partir do primeiro elemento, e a página diz que foi
+        isso que ela fez.
+        <br><br>
+        Um arquivo que termina no meio é lido até onde vai. Tudo o que vem antes do
+        dano é mostrado, com uma nota dizendo em que byte ele parou. É justamente o
+        caso em que um visualizador é mais necessário, então jogar o arquivo inteiro
+        fora por causa dos últimos doze bytes seria o comportamento errado."""
+
+[[faq]]
+q = "Este é um visualizador diagnóstico?"
+a = """
+        Não. Não é um dispositivo médico, não passou por avaliação regulatória
+        alguma, e nada aqui deve ser usado para tomar uma decisão clínica. A sua tela
+        não é calibrada, o navegador não é uma cadeia de renderização validada, e
+        nenhuma das duas coisas se resolve de dentro de uma página web.
+        <br><br>
+        Para o que ele serve muito bem é todo o resto pelo qual se abre um exame:
+        conferir o que há num disco, tirar um corte para uma aula ou um artigo, ler
+        um cabeçalho, descobrir por que outro programa recusa o arquivo, e ver o que
+        um exame carrega sobre a pessoa de quem ele é."""
+
+[[faq]]
+q = "Ele altera o meu arquivo?"
+a = """
+        Não. Esta ferramenta apenas lê. Não há arquivo de saída, não há recodificação
+        e não há aqui um botão que escreva um DICOM &mdash; o que você pode baixar é
+        um PNG da imagem na tela e uma cópia do cabeçalho em texto simples. O seu
+        original continua intacto no seu disco."""
+
+[[faq]]
+q = "É grátis, e eu preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem teste. Não há limite de tamanho de
+        arquivo nem de quantos arquivos você abre, além da memória da sua própria
+        máquina. O site exibe publicidade, e é ela que o paga; os anunciantes não
+        recebem nada sobre o seu arquivo."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, depois desconecte da internet e ela continua
+        funcionando. É também a maneira mais simples de provar que nada é enviado:
+        uma ferramenta que mandasse o seu exame para ser desenhado em outro lugar
+        pararia no instante em que você tirasse o cabo."""
+
+[schema]
+description = "Abra exames DICOM (.dcm) no navegador: tomografia, ressonância, raio X e ultrassom, com janela e nível, uma série inteira empilhada na ordem certa, medidas em milímetros e cada tag do cabeçalho. Nada é enviado."
+features = [
+  "Abre tomografia, ressonância, raio X, ultrassom, PET e secondary capture",
+  "Janela e nível arrastando, digitando ou por um preset de tomografia com nome",
+  "Uma pasta inteira agrupada em séries e ordenada pela posição no corpo",
+  "Arquivos com vários quadros tocam em laço",
+  "Mede em milímetros, levando em conta pixels não quadrados",
+  "Lê o valor do pixel sob o cursor em unidades Hounsfield",
+  "Cada tag DICOM com nome e valor, pesquisável",
+  "Lista o que no arquivo identifica o paciente, segundo o perfil da PS3.15",
+  "Decodifica RLE, JPEG baseline e JPEG Lossless sem biblioteca embutida",
+  "Salva a imagem como PNG e o cabeçalho como texto simples",
+  "Funciona offline; sem envio, sem conta, sem alteração no seu arquivo",
+]
+
+[picker]
+title = "Arraste um exame para cá"
+hint = "ou clique para procurar &mdash; um arquivo .dcm, ou uma pasta inteira deles"

--- a/locales/pt/tools/document-scanner.html
+++ b/locales/pt/tools/document-scanner.html
@@ -1,0 +1,379 @@
+<!--
+  tools/document-scanner/body.html, in Portuguese.
+
+  Every id, class, name, option value, data-phrase key and brace placeholder
+  below is what the JavaScript reaches for, so they are the same in every
+  language. Only the words change.
+-->
+<main>
+  <!-- Passo 1 &mdash; as fotos -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha as fotos</h2>
+
+    <p class="card-lede">
+      Uma foto por página, tirada de algum ponto acima. A página inteira precisa
+      estar no enquadramento, e os quatro cantos devem estar visíveis ou quase.
+      Todo o resto &mdash; a inclinação, a sombra, a mesa embaixo &mdash; é o
+      motivo pelo qual esta ferramenta existe. Acrescente várias e elas viram as
+      páginas de um documento, na ordem em que você as acrescenta.
+    </p>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+
+    <div id="strip-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="detect-all" class="ghost">Procurar de novo em todas as páginas</button>
+        <button type="button" id="clear-all" class="ghost danger">Remover todas</button>
+      </div>
+    </div>
+
+    <ul id="page-strip" class="page-strip"></ul>
+  </section>
+
+  <!-- Passo 2 &mdash; os cantos -->
+  <section class="card" id="edit-card">
+    <h2><span class="step">2</span> Ponha os cantos na página</h2>
+
+    <p id="edit-empty" class="field-summary">
+      Escolha uma foto e ela aparece aqui, com os seus quatro cantos já
+      encontrados para você.
+    </p>
+
+    <div id="edit-controls" hidden>
+      <p class="stage-hint">
+        Toque em qualquer ponto da foto e o canto mais próximo vem até o seu dedo;
+        arraste-o até o canto da página. Com <kbd>Tab</kbd> você alcança um canto
+        pelo teclado, as setas o movem um pixel e com <kbd>Shift</kbd> dez. Nada
+        disso é definitivo: a digitalização é tirada de onde os quatro cantos
+        terminarem.
+      </p>
+
+      <!-- The photo is a canvas rather than an <img> because it is drawn at
+           screen size from the decoded picture, and because the same canvas is
+           what the corner finder reads. The outline over it is an SVG polygon
+           in percentages, so it needs no redraw when the window changes. -->
+      <div class="stage-wrap">
+        <div class="stage" id="stage">
+          <canvas id="photo"></canvas>
+        </div>
+      </div>
+
+      <p id="detect-note" class="hint-line" role="status" aria-live="polite"></p>
+
+      <div class="frame-actions">
+        <button type="button" id="detect-one" class="ghost">Procurar os cantos de novo</button>
+        <button type="button" id="whole-photo" class="ghost">Pegar a foto inteira</button>
+        <button type="button" id="turn-left" class="ghost">Girar para a esquerda</button>
+        <button type="button" id="turn-right" class="ghost">Girar para a direita</button>
+        <button type="button" id="undo" class="ghost" disabled>Desfazer</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- Passo 3 &mdash; a limpeza -->
+  <section class="card" id="clean-card">
+    <h2><span class="step">3</span> Limpe</h2>
+
+    <p id="clean-empty" class="field-summary">
+      A página endireitada aparece aqui assim que houver uma foto para endireitar.
+    </p>
+
+    <div id="clean-controls" hidden>
+      <p class="card-lede">
+        O que está abaixo é o resultado verdadeiro, produzido pelo mesmo código que
+        escreve o arquivo: endireitado e com a luz irregular dividida para fora. Na
+        tela ele é desenhado em tamanho de tela enquanto você escolhe; o arquivo em
+        si nasce na resolução da foto.
+      </p>
+
+      <div class="result-wrap">
+        <canvas id="scan-preview" class="scan-preview"></canvas>
+        <p id="scan-busy" class="progress-label" role="status" aria-live="polite" hidden>
+          Endireitando&hellip;
+        </p>
+      </div>
+
+      <ul id="scan-facts" class="result-facts"></ul>
+
+      <fieldset class="options" id="mode-group">
+        <legend>O que fazer com a luz e com a cor</legend>
+
+        <label class="check">
+          <input type="radio" name="mode" value="colour" checked>
+          <span>
+            <strong>Cor, uniformizada</strong>
+            <span class="check-note">
+              O papel é medido ao longo da página e dividido para fora, de modo
+              que a sombra some e o papel volte a ser branco, enquanto um carimbo,
+              uma assinatura em tinta azul ou uma linha marcada guardam a sua cor.
+              É o modo para quando a cor faz parte do documento.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="grey">
+          <span>
+            <strong>Tons de cinza</strong>
+            <span class="check-note">
+              A mesma uniformização sem a cor. Menor do que a cor e mais gentil
+              com uma fotografia ou uma assinatura do que o preto e branco é.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="mono">
+          <span>
+            <strong>Preto e branco</strong>
+            <span class="check-note">
+              Cada pixel é decidido contra a sua própria vizinhança e não contra
+              um número único para a página inteira, e é exatamente isso que
+              mantém legível a escrita dentro de uma sombra. É o que deixa uma
+              digitalização pequena: um contrato de vinte páginas sai daqui abaixo
+              de um megabyte, e como fotos chegaria a uns quinze. Este modo não
+              conhece meios-tons, então nada com uma fotografia deveria usá-lo.
+            </span>
+          </span>
+        </label>
+
+        <label class="check">
+          <input type="radio" name="mode" value="photo">
+          <span>
+            <strong>Deixar como está</strong>
+            <span class="check-note">
+              Endireitada e mais nada. Para uma página em que o próprio papel
+              conta: algo antigo, algo colorido, uma fotografia.
+            </span>
+          </span>
+        </label>
+
+        <div class="option-row" id="strength-row">
+          <label for="strength">Com que força</label>
+          <div class="inline-pair">
+            <input type="range" id="strength" min="0" max="100" step="5" value="50">
+            <output id="strength-value">50</output>
+          </div>
+        </div>
+
+        <p class="field-summary" id="strength-note"></p>
+      </fieldset>
+
+      <p class="hint-line">
+        O ajuste vale para cada página. Páginas de um mesmo documento limpas de
+        formas diferentes parecem dois documentos.
+      </p>
+    </div>
+  </section>
+
+  <!-- Passo 4 &mdash; o arquivo -->
+  <section class="card" id="save-card">
+    <h2><span class="step">4</span> Salve o documento</h2>
+
+    <p class="card-lede">
+      O PDF nasce aqui, na memória desta página, uma página de cada vez. Do outro
+      lado desta ferramenta não existe servidor algum para receber um holerite, um
+      passaporte ou um contrato, e no código não existe nada que fizesse isso se
+      existisse.
+    </p>
+
+    <div class="settings">
+      <div class="field">
+        <label for="page-size">Tamanho da página</label>
+        <select id="page-size">
+          <option value="fit" selected>Ajustar a folha à própria página</option>
+          <option value="a4">A4 &mdash; 210 &times; 297 mm</option>
+          <option value="letter">Letter &mdash; 8,5 &times; 11 pol</option>
+          <option value="legal">Legal &mdash; 8,5 &times; 14 pol</option>
+          <option value="a5">A5 &mdash; 148 &times; 210 mm</option>
+        </select>
+        <p class="field-note" id="size-note"></p>
+      </div>
+
+      <div class="field" id="dpi-field">
+        <label for="dpi">Resolução de impressão</label>
+        <select id="dpi">
+          <option value="150">150 DPI</option>
+          <option value="200" selected>200 DPI</option>
+          <option value="300">300 DPI &mdash; máquina de escritório</option>
+          <option value="600">600 DPI</option>
+        </select>
+        <p class="field-note">
+          Que tamanho recebe uma folha feita de um certo número de pixels. Muda o
+          tamanho em que o documento é impresso, e não muda um único pixel da
+          digitalização.
+        </p>
+      </div>
+
+      <div class="field" id="margin-field" hidden>
+        <label for="margin">Margem</label>
+        <div class="inline-pair">
+          <input type="number" id="margin" min="0" max="50" step="1" value="10"
+                 aria-label="Margem em milímetros">
+          <span class="unit-label">mm</span>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="max-side">Lado mais longo</label>
+        <select id="max-side">
+          <option value="1600">1600 pixels &mdash; pequeno</option>
+          <option value="2400" selected>2400 pixels</option>
+          <option value="3500">3500 pixels</option>
+          <option value="0">Tão grande quanto a foto permitir</option>
+        </select>
+        <p class="field-note">
+          Um teto para a página endireitada. A foto de uma página guarda muito mais
+          pixels do que a página vale, e 2400 no lado longo são cerca de 200 DPI num
+          A4.
+        </p>
+      </div>
+
+      <div class="field" id="quality-field">
+        <label for="quality">Qualidade</label>
+        <div class="inline-pair">
+          <input type="range" id="quality" min="40" max="100" step="1" value="82">
+          <output id="quality-value">82%</output>
+        </div>
+        <p class="field-note">
+          Para os modos cor e tons de cinza, que são salvos como JPEG. As páginas em
+          preto e branco são salvas de forma exata; para elas isto não faz nada.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="title">Título do documento <span class="optional">(opcional)</span></label>
+        <input type="text" id="title" maxlength="120" placeholder="Deixado em branco, o PDF não carrega título">
+        <p class="field-note">
+          A única coisa escrita no documento além das páginas. Sem data, sem autor e
+          sem nada sobre este dispositivo. Veja <code>src/document.js</code>.
+        </p>
+      </div>
+    </div>
+
+    <div class="run-row">
+      <button type="button" id="save-pdf" class="primary big" disabled>Salvar como PDF</button>
+      <button type="button" id="save-images" class="ghost big" disabled>Salvar as páginas como imagens</button>
+    </div>
+
+    <p id="busy" class="progress-label" role="status" aria-live="polite" hidden></p>
+
+    <div id="result" class="results" hidden>
+      <div class="results-head">
+        <h3>O arquivo pronto</h3>
+        <a id="download" class="primary as-button" href="#" download>Baixar</a>
+      </div>
+      <ul id="result-facts" class="result-facts"></ul>
+      <p class="hint-line">
+        Abra antes de mandar. O que está no documento é o que estava na tela no
+        passo 3, página por página.
+      </p>
+    </div>
+  </section>
+
+  <!--
+    Every sentence the JavaScript puts on this page. They live here rather than
+    in src/, because src/ is copied byte for byte into all eleven languages and
+    a sentence written there would be English in ten of them. See
+    shared/js/phrases.js.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="detect.found">Os quatro cantos foram encontrados. Confira e
+      ajeite os que ficaram fora do lugar.</span>
+    <span data-phrase="detect.unsure">As bordas da página não estavam nítidas o
+      bastante para haver certeza. Estes cantos são um palpite: arraste-os até a
+      página antes de seguir.</span>
+    <span data-phrase="detect.nothing">Nesta foto não foi possível distinguir uma
+      página, então os cantos estão nas bordas dela. Arraste-os até a
+      página.</span>
+    <span data-phrase="detect.flat">Nesta imagem não há o que encontrar, ela não
+      tem borda alguma.</span>
+    <span data-phrase="detect.tiny">Esta imagem é pequena demais para se encontrar
+      uma página nela.</span>
+    <span data-phrase="detect.edited">Estes cantos agora são seus. &ldquo;Procurar
+      os cantos de novo&rdquo; mede a foto do começo.</span>
+
+    <span data-phrase="corner.tl">Canto superior esquerdo</span>
+    <span data-phrase="corner.tr">Canto superior direito</span>
+    <span data-phrase="corner.br">Canto inferior direito</span>
+    <span data-phrase="corner.bl">Canto inferior esquerdo</span>
+    <span data-phrase="corner.at">{corner}, a {x} na horizontal e {y} na vertical.
+      As setas o movem, e com Shift o movem dez pixels de uma vez.</span>
+
+    <span data-phrase="page.select">Editar a página {index}</span>
+    <span data-phrase="page.remove">Remover a página {index}</span>
+    <span data-phrase="page.earlier">Mover a página {index} para antes</span>
+    <span data-phrase="page.later">Mover a página {index} para depois</span>
+    <span data-phrase="page.count">{count} página</span>
+    <span data-phrase="page.counts">{count} páginas</span>
+
+    <span data-phrase="paper.a">A4 ou A5</span>
+    <span data-phrase="paper.letter">US Letter</span>
+    <span data-phrase="paper.legal">US Legal</span>
+    <span data-phrase="paper.card">um cartão de visita</span>
+    <span data-phrase="shape.known">A página saiu como {ratio}, e essa é a forma de
+      {paper}.</span>
+    <span data-phrase="shape.sideways">A página saiu como {ratio}, e essa é a forma
+      de {paper} deitado.</span>
+    <span data-phrase="shape.unknown">A página saiu como {ratio}, e esse não é um
+      formato padrão.</span>
+
+    <span data-phrase="method.perspective">A forma foi recuperada da perspectiva na
+      foto, então é a forma da página e não aquela em que ela apareceu na
+      imagem.</span>
+    <span data-phrase="method.edges">A foto foi tirada em ângulo reto, então a
+      forma foi medida direto nas bordas.</span>
+
+    <span data-phrase="quality.good">{width} por {height} pixels, cerca de {dpi}
+      DPI numa página deste tamanho, o bastante para imprimir.</span>
+    <span data-phrase="quality.fair">{width} por {height} pixels, cerca de {dpi}
+      DPI numa página deste tamanho. Na tela vai bem, no papel fica um pouco
+      mole.</span>
+    <span data-phrase="quality.low">{width} por {height} pixels, cerca de {dpi} DPI
+      numa página deste tamanho. Chegue mais perto, se isto for para
+      imprimir.</span>
+    <span data-phrase="quality.pixels">{width} por {height} pixels.</span>
+    <span data-phrase="coverage.note">A página preencheu {percent}% da foto.</span>
+    <span data-phrase="coverage.small">A página preencheu só {percent}% da foto,
+      então quase tudo o que você fotografou era mesa. Da próxima vez, mais
+      perto.</span>
+
+    <span data-phrase="strength.gentle">Leve: o papel é uniformizado e pouco mais.
+      Para uma página com lápis claro ou uma fotografia.</span>
+    <span data-phrase="strength.middling">O ajuste de sempre: o papel volta a ser
+      branco e o texto impresso volta a ser preto.</span>
+    <span data-phrase="strength.hard">Forte: tudo o que é cinza é empurrado para o
+      preto ou para o branco. É o mais limpo numa página só de texto impresso e é
+      destrutivo em qualquer coisa com uma imagem.</span>
+
+    <span data-phrase="busy.page">Página {done} de {total}&hellip;</span>
+    <span data-phrase="busy.writing">Escrevendo o documento&hellip;</span>
+
+    <span data-phrase="result.pdf">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.images">{name} &mdash; {size}, {pages}.</span>
+    <span data-phrase="result.mono">Salvo a um bit por pixel e comprimido de forma
+      exata, e é por isso que ficou tão pequeno.</span>
+    <span data-phrase="result.jpeg">As páginas foram salvas como JPEG na qualidade
+      que você escolheu.</span>
+    <span data-phrase="result.png">As páginas foram salvas como PNG, que é sem
+      perdas e é o que uma imagem de duas cores quer. O JPEG seria ao mesmo tempo
+      maior e borrado em volta de cada letra.</span>
+    <span data-phrase="result.clean">Sem data, sem autor, sem nome de computador: a
+      única coisa no documento além das páginas é o nome desta ferramenta.</span>
+
+    <span data-phrase="size.fit">Cada folha recebe o tamanho que a sua própria
+      página tem de verdade, na resolução escolhida acima. Nada é preenchido com
+      faixas.</span>
+    <span data-phrase="size.named">Cada página é posta numa folha {name}, dentro da
+      margem, qualquer que seja a forma que ela tenha ganhado.</span>
+
+    <span data-phrase="error.decode">Este navegador não conseguiu abrir {name}. Se
+      for uma foto HEIC de um iPhone, converta antes.</span>
+    <span data-phrase="error.none">Escolha antes pelo menos uma foto.</span>
+    <span data-phrase="error.failed">Algo deu errado ao criar o arquivo:
+      {detail}</span>
+  </div>
+</main>

--- a/locales/pt/tools/document-scanner.toml
+++ b/locales/pt/tools/document-scanner.toml
@@ -1,0 +1,299 @@
+#
+# Document Scanner - Portuguese.
+#
+# Overrides for tools/document-scanner/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Digitalizar" e "digitalização" são o que se escreve e o que se procura;
+# "escanear" existe na fala mas quase ninguém digita. Nomes próprios ficam como
+# são: Sauvola, Zhang e He, DPI, OCR.
+#
+
+name = "Digitalizador de documentos"
+heading = "Digitalizador&nbsp;de&nbsp;documentos <span class=\"h1-kw\">&mdash; a foto de uma página, endireitada</span>"
+tagline = "Fotografe a página. Você recebe de volta algo com cara de digitalização."
+
+title = "Digitalizador de documentos &mdash; de foto a PDF digitalizado, sem enviar nada"
+description = "Transforme a foto de uma página feita no celular num PDF endireitado e com luz uniforme. Os cantos são encontrados para você, a perspectiva é desfeita, a sombra é dividida para fora. Roda inteiramente no seu navegador: nada é enviado."
+og_title = "Digitalize um documento com uma foto, sem enviá-lo"
+og_description = "Os cantos da página são encontrados, a inclinação é desfeita e a luz irregular é dividida para fora, no seu próprio navegador. O que se fotografa assim é um passaporte, um holerite ou um contrato, que é exatamente o que não deveria ser enviado."
+og_image_alt = "Digitalizador de documentos - a foto de uma página, endireitada e limpa, sem enviá-la"
+
+pledge = """
+    A foto é decodificada, endireitada, limpa e escrita num PDF pelo seu próprio
+    navegador, usando apenas aritmética e os codecs que ele já traz. Esta
+    ferramenta não tem função de rede alguma &mdash; nada a buscar, nada a enviar
+    &mdash; e o motivo pelo qual isso importa aqui é do que as pessoas fotografam
+    páginas: um passaporte, um holerite, um contrato de aluguel, um formulário que
+    uma repartição pediu para &ldquo;digitalizar e devolver&rdquo;."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas do desenvolvedor, olhe a
+      aba Rede e digitalize uma página. Nenhuma requisição carrega uma foto, uma
+      miniatura, um nome de arquivo ou a posição de um único canto. Ou tire o cabo
+      da internet e digitalize uma mesmo assim."""
+
+read_first = """
+, <code>src/detect.js</code> para como os cantos
+      são encontrados sem modelo algum, <code>src/warp.js</code> para o
+      endireitamento, e <code>src/clean.js</code> para como a luz irregular é
+      dividida para fora."""
+
+howto_heading = "Como digitalizar um documento com a câmera do celular"
+
+card = """
+            A foto de uma página, endireitada e limpa até virar um documento. Os
+            cantos são encontrados para você, a inclinação é desfeita e a sombra
+            é dividida para fora."""
+
+[words]
+plural = "documentos"
+choose = "a foto de uma página"
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca-d'água"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "Os seus documentos não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy lista todos os endereços que esta página pode
+      contatar, e nenhum deles pertence a este site. Não existe aqui um endpoint
+      onde as suas fotos pudessem ser recolhidas, e não existe no código nada que
+      as enviasse se existisse."""
+
+[[privacy]]
+title = "Não há modelo algum, então não há o que baixar nem o que perguntar."
+body = """
+ Encontrar os
+      quatro cantos de uma página é feito com aritmética: o gradiente da imagem, um
+      voto para as linhas retas nela, e uma conferência do que está de fato embaixo
+      de cada lado do retângulo vencedor. Sem pesos, sem runtime de inferência, sem
+      nada buscado no primeiro uso, e sem nada que se comporte de um jeito no
+      documento de outra pessoa e de outro no seu &mdash; veja
+      <code>src/detect.js</code>."""
+
+[[privacy]]
+title = "O documento não carrega data, nem autor, nem nome de máquina."
+body = """
+ Uma digitalização
+      é algo que as pessoas mandam para outras pessoas, geralmente porque uma
+      repartição pediu. A única coisa escrita no PDF além das próprias páginas é o
+      nome desta ferramenta, e um título se você digitar um. Não há data de
+      criação, não há autor, não há número de série e não há nada derivado do seu
+      relógio, dos seus nomes de arquivo ou do seu computador &mdash; veja
+      <code>src/document.js</code>."""
+
+[[privacy]]
+title = "Aqui nada busca nada."
+body = """
+ Não há <code>fetch</code>,
+      não há <code>XMLHttpRequest</code> e não há <code>sendBeacon</code> em lugar
+      algum de <code>src/</code>. O trabalho é <code>getImageData</code>, alguns
+      laços sobre os bytes e o codificador JPEG do próprio navegador &mdash; tudo
+      já instalado na sua máquina."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua a
+      mesma, porque nunca houve um passo de rede nela. É a prova mais simples de
+      todas &mdash; e a que vale a pena fazer antes de digitalizar um
+      passaporte."""
+
+[[howto]]
+title = "Fotografe a página."
+body = """
+ De cima, com a página inteira no
+      enquadramento e os quatro cantos visíveis ou quase. Não precisa ser de frente
+      e não precisa ter luz uniforme: a inclinação e a sombra são o motivo pelo
+      qual esta ferramenta existe. O que importa é preencher o enquadramento
+      &mdash; uma página fotografada do outro lado da sala não tem detalhe algum a
+      recuperar."""
+
+[[howto]]
+title = "Confira os quatro cantos."
+body = """
+ Eles são encontrados para você
+      quando a foto é lida, e a página avisa quando não tem certeza &mdash; uma
+      página sobre uma mesa da mesma cor do papel tem mesmo uma borda difícil de
+      enxergar. Toque em qualquer ponto da foto e o canto mais próximo vem até o
+      seu dedo, ou alcance um com <kbd>Tab</kbd> e mova-o com as setas."""
+
+[[howto]]
+title = "Escolha o que fazer com a luz."
+body = """
+ &ldquo;Cor,
+      uniformizada&rdquo; mede o papel ao longo da página e o divide para fora, de
+      modo que a sombra some e um carimbo ou uma assinatura guardam a sua cor.
+      &ldquo;Preto e branco&rdquo; vai além e é o que deixa uma digitalização
+      pequena o bastante para caber num e-mail. O que você vê na tela é o resultado
+      verdadeiro, produzido pelo mesmo código que escreve o arquivo."""
+
+[[howto]]
+title = "Acrescente as outras páginas."
+body = """
+ Cada foto que você
+      acrescenta vira mais uma página do mesmo documento, na ordem em que estão
+      listadas, e cada uma guarda os seus próprios cantos. As setas numa página da
+      tira a movem para antes ou para depois."""
+
+[[howto]]
+title = "Salve o PDF, e abra antes de mandar."
+body = """
+ O documento é
+      montado aqui, na memória desta página. Nada foi enviado para fazê-lo, e nada
+      sobre ele foi relatado em lugar nenhum."""
+
+[[faq]]
+q = "O meu documento é enviado para algum lugar?"
+a = """
+        Não. A foto é decodificada, endireitada, limpa e escrita num PDF pelo seu
+        próprio navegador no seu próprio hardware. Esta ferramenta não tem função de
+        rede alguma &mdash; nunca busca nada e nunca envia nada &mdash; e a
+        <code>Content-Security-Policy</code> da página lista todos os endereços que
+        ela pode contatar, e nenhum deles pertence a este site. Carregue a página uma
+        vez, tire o cabo da internet, e ela continua funcionando."""
+
+[[faq]]
+q = "Como ele encontra os cantos da página sem modelo?"
+a = """
+        Procurando as quatro bordas retas e longas de que um retângulo é feito. A
+        foto é reduzida, tira-se o gradiente &mdash; onde a imagem muda, e em que
+        direção &mdash; e cada pixel que está sobre uma borda vota na linha reta em
+        que estaria. As linhas fortes são emparelhadas em retângulos candidatos, e
+        cada candidato recebe uma nota percorrendo os seus quatro lados e perguntando
+        quanto de cada um tem mesmo uma borda embaixo, e se os quatro juntos são o
+        contorno de uma coisa só: uma página é mais clara do que o que está em volta,
+        ou mais escura, mas do mesmo jeito nos quatro lados, e é isso que impede que
+        uma linha de texto seja confundida com o pé da página. Não há pesos, nada é
+        baixado, e a aritmética é a mesma aritmética para qualquer documento que
+        passe por ela."""
+
+[[faq]]
+q = "Os cantos que ele encontrou estão errados. E agora?"
+a = """
+        Arraste-os. Os cantos são uma posição de partida e nunca uma decisão: a
+        digitalização é tirada de onde os quatro terminarem. Toque em qualquer ponto
+        da foto e o canto mais próximo salta para o seu dedo, o que é mais fácil do
+        que acertar uma alça pequena, e as setas movem o canto em foco um pixel por
+        vez. A página também avisa quando os cantos são um palpite e não um achado, e
+        marca aquela página na tira &mdash; uma página apoiada numa mesa mais ou
+        menos da mesma cor é o motivo de sempre, porque ali realmente quase não há
+        borda a encontrar."""
+
+[[faq]]
+q = "Por que a página endireitada sai na forma certa, e não achatada?"
+a = """
+        Porque a forma é recuperada da perspectiva em vez de medida nas bordas. Uma
+        página fotografada de viés tem a borda distante encurtada, então o método
+        óbvio &mdash; pegar o par de bordas opostas mais longo e chamar aquilo de
+        proporção &mdash; produz um A4 visivelmente atarracado, que é o que a maioria
+        dos digitalizadores da web entrega. A fotografia de um retângulo carrega, na
+        verdade, informação suficiente para recuperar tanto a proporção do retângulo
+        quanto a distância focal da câmera, bastando que a câmera seja uma comum;
+        isso é um resultado de Zhang e He de 2003, e é o que
+        <code>src/geometry.js</code> faz. Onde a foto foi tirada de frente não há
+        perspectiva de onde partir e nem é preciso, porque então as bordas são
+        exatas &mdash; então ele recorre a elas, e a página diz qual das duas
+        respondeu."""
+
+[[faq]]
+q = "O que a &ldquo;limpeza&rdquo; faz de fato com a imagem?"
+a = """
+        Ela divide a luz para fora. O brilho próprio do papel é medido ao longo da
+        página &mdash; uma grade de quadradinhos, e em cada quadradinho um percentil
+        alto do brilho, que o texto é escuro e esparso demais para deslocar &mdash;
+        e cada pixel é dividido pelo papel estimado naquele ponto. O que sobra é a
+        tinta, com luz uniforme, sem a sombra e sem a queda de luz. Isso não é a
+        mesma coisa que aumentar o contraste: aumentar o contraste de uma página
+        fotografada deixa a parte clara branca, a parte escura preta e o que está
+        escrito na parte escura ilegível, e é por isso que os &ldquo;níveis
+        automáticos&rdquo; pioram essas imagens em vez de melhorá-las."""
+
+[[faq]]
+q = "Por que o modo preto e branco é tão menor?"
+a = """
+        Porque uma imagem com duas cores é mesmo uma fração dos dados de uma imagem
+        com dezesseis milhões, e aqui ela é guardada assim: um bit por pixel,
+        empacotados oito por byte e comprimidos de forma exata, e não como o JPEG de
+        uma imagem em preto e branco. Nas mesmas páginas ele sai cerca de dezoito
+        vezes menor do que o modo em cores, então um contrato de vinte páginas fica
+        abaixo de um megabyte em vez de chegar a uns quinze. O limiar é o de Sauvola,
+        que decide cada pixel contra a média e a dispersão da sua própria vizinhança
+        em vez de contra um número único para a página inteira &mdash; e é isso que
+        mantém legível o que está escrito dentro de uma sombra. Ele não tem
+        meios-tons, então uma página com uma fotografia deve usar um dos outros
+        modos."""
+
+[[faq]]
+q = "Posso pôr várias páginas num só PDF?"
+a = """
+        Sim. Cada foto que você acrescenta vira mais uma página, na ordem em que
+        estão listadas, e cada página guarda os seus próprios cantos &mdash; então
+        uma pilha de páginas fotografadas uma depois da outra vira um documento só.
+        As setas em cada página da tira a movem para antes ou para depois. O ajuste de
+        limpeza é compartilhado por todas de propósito: páginas de um mesmo documento
+        limpas de formas diferentes parecem dois documentos."""
+
+[[faq]]
+q = "Ele lê o texto, para eu poder pesquisar dentro do PDF?"
+a = """
+        Não. Não há camada de texto e não há reconhecimento de caracteres: o que sai
+        é a imagem da página numa página. Fazer isso direito significaria um motor de
+        OCR, que são dezenas de megabytes de modelo para baixar &mdash; e um
+        digitalizador de documentos que buscasse um modelo antes de conseguir ler o
+        seu holerite seria um digitalizador de documentos com um motivo para telefonar
+        para casa a respeito de holerites. Se você precisa do texto, o modo preto e
+        branco produz exatamente o tipo de arquivo com que os programas de OCR na sua
+        própria máquina trabalham melhor."""
+
+[[faq]]
+q = "Saiu borrada. Por quê?"
+a = """
+        Quase sempre porque a página estava pequena na foto. O painel abaixo da
+        prévia diz quanto do enquadramento a página preencheu e mais ou menos a
+        quantos pontos por polegada isso corresponde numa folha daquele tamanho
+        &mdash; abaixo de uns 150 DPI uma digitalização impressa fica mole, e não há
+        ferramenta que dê jeito num detalhe que nunca esteve no arquivo. Chegue mais
+        perto em vez de dar zoom, fique parado, e deixe a câmera focar a página antes
+        de apertar o botão. O tremido é a outra causa, e também não se recupera."""
+
+[[faq]]
+q = "É grátis, e eu preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem teste, nem limite de páginas, nem
+        marca-d'água. Também não há limite para o tamanho das fotos, porque não há um
+        servidor pagando por isso &mdash; o trabalho acontece na sua própria máquina.
+        O site exibe publicidade, e é ela que o paga; os anunciantes não recebem nada
+        sobre os seus documentos."""
+
+[schema]
+description = "Digitalize um documento no navegador: fotografe uma página, e os quatro cantos são encontrados, a perspectiva é desfeita, a luz irregular é dividida para fora, e o resultado é escrito num PDF. Várias páginas viram um documento só. Nada é enviado."
+features = [
+  "Encontra os quatro cantos da página sem modelo, sem baixar nada e sem buscar nada",
+  "Recupera a forma real da página a partir da perspectiva, para que uma foto de viés não saia achatada",
+  "Divide para fora a luz irregular e a sombra em vez de aumentar o contraste",
+  "Páginas em preto e branco guardadas a um bit por pixel, que é o que deixa uma digitalização pequena o bastante para caber num e-mail",
+  "Várias fotos viram as páginas de um só PDF, cada uma com os seus cantos",
+  "Os cantos podem ser arrastados, ou movidos pelo teclado um pixel por vez",
+  "Avisa quando os cantos são um palpite e não um achado",
+  "Não escreve data, nem autor, nem nome de máquina no documento",
+  "Funciona offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste para cá as fotos das suas páginas"
+hint = "ou clique para procurar &mdash; uma foto por página, na ordem das páginas"

--- a/locales/pt/tools/redact-pdf.html
+++ b/locales/pt/tools/redact-pdf.html
@@ -1,0 +1,302 @@
+<!--
+  tools/redact-pdf/body.html, in Portuguese.
+
+  Every id, class, data-phrase key and brace placeholder below is what the
+  JavaScript reaches for, so they are the same in every language. Only the
+  words change.
+
+  Os pares count.* continuam duplos: o português distingue singular e plural,
+  então aqui eles carregam mesmo duas formas.
+-->
+<main>
+  <!-- Passo 1 &mdash; o documento -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha o PDF</h2>
+
+    {% include "partials/file-picker.html" %}
+
+    <p id="load-error" class="error" role="alert" hidden></p>
+    <p id="load-note" class="field-summary" role="status" aria-live="polite" hidden></p>
+
+    <div id="doc-facts" class="doc-facts" hidden>
+      <p id="doc-name" class="doc-name"></p>
+      <p id="doc-sub" class="doc-sub"></p>
+      <ul id="doc-warnings" class="doc-warnings"></ul>
+    </div>
+  </section>
+
+  <!-- Passo 2 &mdash; encontrar -->
+  <section class="card" id="find-card" hidden>
+    <h2><span class="step">2</span> Diga o que precisa sair</h2>
+
+    <p class="card-lede">
+      Digite as palavras, um nome, um endereço, um número de processo, e cada
+      lugar em que aparecerem é listado abaixo com a sua linha. Até o passo 4 nada
+      é retirado, e nada que você não tenha marcado é retirado.
+    </p>
+
+    <label class="find-label" for="terms">Palavras e expressões, uma por linha</label>
+    <textarea id="terms" rows="3" spellcheck="false" autocomplete="off"
+              placeholder="Silva&#10;Rua das Palmeiras, 14&#10;PR-40219"></textarea>
+
+    <div class="find-row">
+      <button type="button" id="find" class="primary">Pesquisar</button>
+      <label class="inline-check">
+        <input type="checkbox" id="match-case"> <span>Diferenciar maiúsculas de minúsculas</span>
+      </label>
+      <label class="inline-check">
+        <input type="checkbox" id="whole-word"> <span>Somente palavras inteiras</span>
+      </label>
+    </div>
+
+    <fieldset class="finders">
+      <legend>Ou pesquise o que costuma ser delicado</legend>
+      <div class="chips" id="finders"></div>
+      <p class="field-note" id="finder-note">
+        São padrões, e um padrão não sabe distinguir um telefone de um número de
+        processo. Números de cartão e IBANs são conferidos contra os seus próprios
+        dígitos verificadores; o resto é oferecido e nunca marcado por você, e cada
+        resultado merece uma olhada.
+      </p>
+    </fieldset>
+
+    <div class="toolbar" id="match-bar" hidden>
+      <span id="match-count" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="tick-all" class="ghost">Marcar tudo</button>
+        <button type="button" id="tick-none" class="ghost">Desmarcar tudo</button>
+        <button type="button" id="clear-found" class="ghost danger">Esvaziar a lista</button>
+      </div>
+    </div>
+
+    <ul id="match-list" class="match-list" hidden></ul>
+    <p id="match-more" class="field-note" hidden></p>
+  </section>
+
+  <!-- Passo 3 &mdash; ler a página -->
+  <section class="card" id="page-card" hidden>
+    <h2><span class="step">3</span> Leia a página e escolha palavras nela</h2>
+
+    <p class="card-lede">
+      Este é o texto como está guardado no documento, na ordem em que um leitor o
+      copiaria, e ela nem sempre é a ordem em que ele está impresso. Clique numa
+      palavra para tirá-la, e clique de novo para mantê-la. Tudo o que estiver
+      riscado aqui é o que vai sumir.
+    </p>
+
+    <div class="pager">
+      <button type="button" id="prev-page" class="ghost">&#8592; Voltar</button>
+      <span id="page-of" class="count"></span>
+      <button type="button" id="next-page" class="ghost">Avançar &#8594;</button>
+      <span class="pager-spacer"></span>
+      <span id="page-picked" class="count"></span>
+      <button type="button" id="clear-page" class="ghost danger">Manter tudo nesta página</button>
+    </div>
+
+    <p id="page-note" class="field-summary" hidden></p>
+
+    <div id="page-text" class="page-text" role="group" aria-label="O texto desta página"></div>
+  </section>
+
+  <!-- Passo 4 &mdash; fazer -->
+  <section class="card" id="run-card" hidden>
+    <h2><span class="step">4</span> Retire as palavras</h2>
+
+    <label class="check">
+      <input type="checkbox" id="opt-boxes" checked>
+      <span>
+        <strong>Desenhar uma tarja preta onde cada uma estava</strong>
+        <span class="check-note">
+          Para que quem ler veja que algo foi retirado. Aqui a tarja é enfeite e
+          não a tarjagem: as letras já sumiram do arquivo antes de ela ser
+          desenhada. Desligue, e as palavras somem e pronto, deixando o espaço
+          que ocupavam.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-elsewhere" checked>
+      <span>
+        <strong>Retirar as mesmas palavras do resto do documento</strong>
+        <span class="check-note">
+          Marcadores, comentários, notas adesivas e o que foi digitado em campos
+          de formulário. Uma palavra retirada de uma página e deixada num marcador
+          não foi retirada. As propriedades do documento saem de qualquer jeito, e
+          o texto de substituição que um leitor copia no lugar das letras da
+          página também: os dois são o documento dizendo a palavra, e não outro
+          lugar que guarda uma cópia dela.
+        </span>
+      </span>
+    </label>
+
+    <label class="check">
+      <input type="checkbox" id="opt-attachments" checked>
+      <span>
+        <strong>Descartar anexos e tudo o que roda</strong>
+        <span class="check-note">
+          Um PDF pode carregar arquivos inteiros dentro de si e JavaScript que
+          roda ao abrir. Em nenhum dos dois é possível pesquisar as palavras que
+          você está retirando, e para ler um documento nenhum dos dois é preciso.
+        </span>
+      </span>
+    </label>
+
+    <p class="field-summary" id="run-summary"></p>
+
+    <div class="run-row">
+      <button type="button" id="run" class="primary big">Retirar</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="run-error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-head">
+        <div>
+          <p id="result-size" class="result-size"></p>
+          <p id="result-sub" class="result-sub"></p>
+        </div>
+        <a id="download" class="primary big" download>Baixar</a>
+      </div>
+
+      <p id="check-line" class="check-line"></p>
+      <ul id="check-terms" class="check-terms" hidden></ul>
+      <ul id="result-facts" class="result-facts"></ul>
+    </div>
+  </section>
+
+  <!--
+    The sentences this tool's JavaScript puts on screen. They live here rather
+    than in src/ because src/ is copied byte for byte into all eleven
+    languages; see "The strings in the JavaScript" in the repository README.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="load.notpdf">Isto não é um PDF, então não há texto nele para retirar.</span>
+    <span data-phrase="load.encrypted">Este PDF tem senha. Tirar a proteção de um
+      documento é um trabalho diferente de tirar palavras dele, e esta ferramenta
+      não faz isso pelas suas costas.</span>
+    <span data-phrase="load.broken">Não foi possível abrir este arquivo como PDF ({detail}).</span>
+    <span data-phrase="load.nopages">Ele abriu, mas não se encontraram páginas dentro.</span>
+    <span data-phrase="load.repaired">A tabela de referências cruzadas deste
+      documento não batia com o conteúdo, então ele foi lido procurando objetos.
+      Isso é um reparo, e deu certo. Confira o resultado com cuidado antes de
+      mandá-lo para algum lugar.</span>
+
+    <span data-phrase="doc.sub">{pages} &middot; {words} de texto &middot; {size}</span>
+    <span data-phrase="doc.notext">{count} destas páginas não têm texto algum. Uma
+      página assim é a imagem de uma página, e para esta ferramenta não há ali nada
+      a retirar: as palavras na imagem ficam exatamente onde estão.</span>
+    <span data-phrase="doc.unreadable">{count} letras deste documento não puderam
+      ser lidas como caracteres, porque as fontes usadas não trazem uma
+      correspondência dos seus glifos de volta para texto. Essas letras não podem
+      ser pesquisadas, então olhe as páginas em que estão em vez de confiar na
+      pesquisa.</span>
+    <span data-phrase="doc.scan">Algumas páginas carregam texto invisível sobre uma
+      imagem, e é assim que um digitalizador registra o que o seu leitor tirou da
+      página. Retirar esse texto retira o que uma pesquisa e uma cópia
+      encontrariam. Não muda nada na imagem, e na imagem as palavras continuam
+      legíveis.</span>
+
+    <span data-phrase="find.none">Não houve resultado em página alguma.</span>
+    <span data-phrase="find.some">{count} em {pages}.</span>
+    <span data-phrase="find.more">Os primeiros {shown} estão listados. O resto foi
+      encontrado e sai junto, se você marcar tudo.</span>
+    <span data-phrase="find.terms">Digite uma palavra acima ou escolha um padrão antes de apertar Pesquisar.</span>
+
+    <span data-phrase="page.of">Página {number} de {total}</span>
+    <span data-phrase="page.picked">{count} serão retiradas desta página</span>
+    <span data-phrase="page.notext">Nesta página não há texto. Ou ela está vazia,
+      ou é a imagem de uma página: uma digitalização, uma foto, uma exportação que
+      desenhou as suas palavras como formas. Nada nela pode ser pesquisado, e nada
+      nela pode ser retirado aqui.</span>
+    <span data-phrase="page.unreadable">{count} letras desta página não puderam ser
+      lidas como caracteres. Elas aparecem abaixo como &#9647;, e a pesquisa não as
+      encontra.</span>
+    <span data-phrase="page.scan">O texto desta página é invisível: ele está sobre
+      uma imagem da página, e é assim que uma digitalização é tornada pesquisável. O
+      que você retira aqui é o que uma pesquisa e uma cópia encontrariam. A imagem
+      fica com as palavras.</span>
+
+    <span data-phrase="run.summary">{words} em {pages} serão retiradas.</span>
+    <span data-phrase="run.nothing">Ainda não há nada marcado. Pesquise uma palavra no passo 2, ou clique numa no passo 3.</span>
+    <span data-phrase="run.editing">Retirando as palavras&hellip;</span>
+    <span data-phrase="run.writing">Escrevendo o documento&hellip;</span>
+    <span data-phrase="run.checking">Reabrindo e pesquisando o arquivo pronto&hellip;</span>
+    <span data-phrase="run.failed">Algo deu errado ao reescrever este documento ({detail}).</span>
+    <span data-phrase="run.cancelled">Cancelado. Nada foi escrito.</span>
+
+    <span data-phrase="result.headline">{words} retiradas</span>
+    <span data-phrase="result.sub">{size} &middot; {pages} alteradas &middot; {boxes}</span>
+    <span data-phrase="check.good">Reaberto e pesquisado aqui, como um leitor
+      faria: nenhuma delas está no arquivo pronto.</span>
+    <span data-phrase="check.partial">Reaberto e pesquisado aqui: cada ocorrência
+      que você marcou sumiu, e as que você deixou continuam lá.</span>
+    <span data-phrase="check.survived">Este arquivo NÃO foi escrito. O documento
+      pronto foi reaberto, e parte do que você retirou ainda podia ser encontrada
+      nele. A tarjagem, portanto, não estava completa. Nada é oferecido para
+      download.</span>
+    <span data-phrase="check.pages">Este arquivo NÃO foi escrito. O documento
+      pronto voltou com um número de páginas diferente do que entrou, então algo
+      deu errado além das palavras. Nada é oferecido para download.</span>
+
+    <span data-phrase="fact.boxes">{count} desenhadas sobre as lacunas.</span>
+    <span data-phrase="fact.noboxes">Nenhuma tarja foi desenhada, então as palavras
+      sumiram sem que nada diga onde estavam.</span>
+    <span data-phrase="fact.elsewhere">As mesmas palavras foram retiradas de {where}.</span>
+    <span data-phrase="fact.metadata">As propriedades do documento e o pacote XMP
+      foram removidos, então o arquivo pronto não diz o que o produziu, quando, nem
+      como ele se chamava antes.</span>
+    <span data-phrase="fact.carried">{attachments} e {actions} foram descartados.</span>
+    <span data-phrase="fact.shared">Parte do que você retirou era desenhada por um
+      bloco que o documento reaproveita em mais de uma página, então ela sumiu de
+      todas as páginas que o desenham. Isso é mais do que você marcou, e nunca
+      menos.</span>
+    <span data-phrase="fact.overimage">{count} das letras retiradas estavam sobre
+      uma imagem da mesma página. Da camada de texto elas saíram e na imagem
+      continuam: um leitor não consegue mais pesquisá-las nem copiá-las, e continua
+      vendo-as.</span>
+    <span data-phrase="fact.untouched">Todo o resto de cada página passou byte a
+      byte. Nenhuma fonte, nenhuma imagem e nenhuma linha foi recodificada.</span>
+
+    <span data-phrase="count.pages">{count} páginas</span>
+    <span data-phrase="count.page">{count} página</span>
+    <span data-phrase="count.words">{count} palavras</span>
+    <span data-phrase="count.word">{count} palavra</span>
+    <span data-phrase="count.pieces">{count} pedaços de texto</span>
+    <span data-phrase="count.piece">{count} pedaço de texto</span>
+    <span data-phrase="count.matches">{count} resultados</span>
+    <span data-phrase="count.match">{count} resultado</span>
+    <span data-phrase="count.boxes">{count} tarjas pretas</span>
+    <span data-phrase="count.box">{count} tarja preta</span>
+    <span data-phrase="count.attachments">{count} anexos</span>
+    <span data-phrase="count.attachment">{count} anexo</span>
+    <span data-phrase="count.actions">{count} ações</span>
+    <span data-phrase="count.action">{count} ação</span>
+    <span data-phrase="count.hosts">{count} hosts</span>
+    <span data-phrase="count.host">{count} host</span>
+
+    <!-- The space before {platform} belongs to these two rather than to the
+         phrase it lets in, because phrases.js collapses and trims the markup
+         it reads and a leading space would not survive the trip. -->
+    <span data-phrase="net.clean">O seu documento não foi a lugar nenhum. {total}
+      arquivos carregados, todos do próprio site. {platform}</span>
+    <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta ferramenta
+      nunca faz isso. Vale a pena ir ver. {platform}</span>
+    <span data-phrase="net.platform">Os scripts do próprio site para publicidade,
+      medição e o botão de doação vieram de {hosts}; nenhum deles recebeu um
+      documento, uma palavra dele ou qualquer coisa que você tenha
+      pesquisado.</span>
+
+    <span data-phrase="finder.email">Endereços de e-mail</span>
+    <span data-phrase="finder.card">Números de cartão</span>
+    <span data-phrase="finder.iban">Contas bancárias (IBAN)</span>
+    <span data-phrase="finder.nationalid">CPF e números de seguridade social</span>
+    <span data-phrase="finder.phone">Telefones</span>
+  </div>
+</main>

--- a/locales/pt/tools/redact-pdf.toml
+++ b/locales/pt/tools/redact-pdf.toml
@@ -1,0 +1,362 @@
+#
+# Redact a PDF - Portuguese.
+#
+# Overrides for tools/redact-pdf/tool.toml. Only words: the slug, the category,
+# the icon, the CSP and the list of shared parts stay where they are.
+#
+# "Tarjar" é o mesmo verbo de tarjar-imagem, e carrega a mesma promessa: as
+# letras saem do arquivo, não ficam cobertas por um retângulo. "Cobrir" nomearia
+# exatamente a falha contra a qual esta página existe para avisar.
+#
+
+name = "Tarjador de PDF"
+heading = "Tarjar&nbsp;PDF <span class=\"h1-kw\">&mdash; as palavras saem, não é uma tarja por cima</span>"
+tagline = "As letras são apagadas do arquivo, e depois o arquivo é pesquisado para provar."
+
+title = "Tarjar um PDF &mdash; apagar mesmo o texto, grátis, sem enviar nada"
+description = "Tire palavras de um PDF em vez de desenhar um retângulo preto por cima. As letras são apagadas das próprias instruções de desenho da página, o arquivo pronto é reaberto e pesquisado para provar que sumiram, e nada é enviado."
+og_title = "Tarjar um PDF direito &mdash; as palavras são apagadas, não cobertas"
+og_description = "Na maioria das ferramentas o retângulo preto fica em cima do texto e dá para copiá-lo por baixo. Esta apaga as letras do arquivo e depois pesquisa o resultado para mostrar que elas não estão lá."
+og_image_alt = "Tarjar um PDF apagando o texto, não cobrindo"
+
+pledge = """
+    O documento que você escolhe é aberto, lido, editado e reescrito na memória
+    desta máquina, por código servido deste endereço. Não há aqui nada capaz de
+    fazer um envio, e do outro lado desta página não existe servidor algum para
+    receber um. Nem o arquivo nem as palavras que você pesquisou saem da aba."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas do desenvolvedor, olhe a
+      aba Rede e tarje alguma coisa. Nenhuma requisição carrega uma página, uma
+      palavra ou um nome de arquivo. Ou tire o cabo da internet e tarje mesmo
+      assim."""
+
+read_first = """
+, <code>src/text.js</code> para como cada palavra
+      de uma página é encontrada e localizada, e <code>src/edit.js</code> para o
+      apagamento em si &mdash; o que é recortado das instruções da página e o que é
+      reposto para que o resto da linha não se desloque. Nenhum deles consegue
+      alcançar a rede, e o leitor e o escritor ao lado também não."""
+
+howto_heading = "Como tarjar um PDF para que as palavras sumam de verdade"
+
+card = """
+            Apague palavras de um PDF em vez de cobri-las. As letras são tiradas
+            das próprias instruções de desenho da página, a lacuna é mantida
+            aberta para que nada mais se desloque, e o arquivo pronto é reaberto
+            e pesquisado aqui para provar que as palavras não estão nele."""
+
+[words]
+plural = "documentos"
+choose = "um PDF"
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[facts]]
+text = "Os arquivos ficam no seu dispositivo"
+
+[[privacy]]
+title = "Um retângulo preto não é uma tarja, e aqui não se desenha um por cima de nada."
+body = """
+
+      Em quase todo programa que se oferece para tarjar uma página &mdash; um
+      leitor de PDF, um editor de texto, um programa de design &mdash; o retângulo
+      é um objeto salvo ao lado do texto e não dentro dele. O texto continua lá, no
+      mesmo arquivo, no mesmo lugar, e selecionar a área e apertar copiar o devolve.
+      Essa falha publicou peças judiciais, relatórios de inteligência e, em dezembro
+      de 2025, nomes enegrecidos numa divulgação em massa de documentos do
+      Departamento de Justiça dos Estados Unidos que estavam legíveis em poucas
+      horas. Esta ferramenta apaga as letras das instruções que desenham a página.
+      Não há um retângulo com algo embaixo, porque embaixo não há nada."""
+
+[[privacy]]
+title = "O arquivo pronto é reaberto e pesquisado, aqui, antes de ser oferecido a você."
+body = """
+
+      Até isso acontecer, toda afirmação acima é esta ferramenta corrigindo a
+      própria prova. Então os bytes que estão prestes a virar o seu download são
+      devolvidos ao mesmo leitor como se um estranho os tivesse mandado, cada página
+      é lida de novo, cada marcador, comentário, campo de formulário e propriedade
+      do documento é recolhido, e as palavras que você tirou são pesquisadas. A
+      contagem fica nos resultados. Se alguma coisa sobreviveu, a execução é
+      relatada como falha e não há download."""
+
+[[privacy]]
+title = "As palavras nunca saem da aba, e a pesquisa também não."
+body = """
+ A
+      Content-Security-Policy lista todos os endereços que esta página pode
+      contatar, e nenhum deles pertence a este site. Esta ferramenta não acrescenta
+      nada a essa lista: ela não tem função de rede própria, nem opcional. O que
+      você digita na caixa de pesquisa é uma sequência de caracteres comparada com
+      texto na memória desta aba, e não há para onde nenhum dos dois ir."""
+
+[[privacy]]
+title = "Tarjar é o trabalho que menos sobrevive a um envio."
+body = """
+
+      O que as pessoas tarjam é o motivo pelo qual aquilo não deve ser enviado. Um
+      depoimento de testemunha, uma carta médica, um extrato bancário indo para um
+      locador, um contrato com o nome de um cliente indo para outro. Entregar isso
+      ao servidor de um estranho para que a parte privada seja tirada significa que
+      a parte privada chega primeiro, intacta, e é essa a versão que eles guardam.
+      Esta página não tem outra metade."""
+
+[[privacy]]
+title = "O que sobra é copiado intacto."
+body = """
+
+      Os únicos bytes que mudam numa página são as instruções de escrita de texto
+      de que as letras removidas faziam parte. Todas as outras instruções, e cada
+      fonte, imagem e linha a que a página se refere, são copiadas exatamente como
+      chegaram &mdash; nada é redesenhado, recodificado ou refluído. A largura do
+      que foi tirado é medida e reposta como uma instrução de espaçamento, de modo
+      que o resto da linha continua onde o documento o pôs."""
+
+[[privacy]]
+title = "Ele não consegue tirar palavras de uma fotografia, e diz quais páginas são essas."
+body = """
+
+      Uma página digitalizada é uma imagem. As palavras nela são pixels, não texto,
+      e nada aqui consegue tocá-las. Se a digitalização carrega a camada invisível e
+      pesquisável que o OCR de um digitalizador produz, esta ferramenta remove essa
+      camada &mdash; que é o que uma pesquisa e uma cópia teriam encontrado &mdash;
+      e diz com todas as letras na página que a imagem continua mostrando as
+      palavras. Cobrir essa imagem é outro trabalho; o
+      <a href=\"../tarjar-imagem/\">tarjador de imagens</a> é a ferramenta que
+      sobrescreve pixels."""
+
+[[privacy]]
+title = "O documento para de dizer de onde veio."
+body = """
+
+      As propriedades e o pacote XMP saem a cada execução: sem linha de produtor,
+      sem data de criação, sem autor, sem título, e sem nenhum dos blocos privados
+      que um programa de diagramação deixa para trás. Um arquivo cujas páginas
+      tiveram um nome retirado e cujas propriedades ainda dizem
+      <code>acordo Silva versao 3.docx</code> não foi tarjado, e isso não é coisa
+      para se deixar a cargo de uma caixinha marcada."""
+
+[[privacy]]
+title = "Arquivos criptografados são recusados em vez de abertos."
+body = """
+
+      Um PDF com senha é recusado, inclusive do tipo que os digitalizadores produzem
+      com senha vazia e que tecnicamente abriria. Tirar a proteção de um documento é
+      um trabalho diferente de tirar palavras dele, e fazê-lo em silêncio seria uma
+      coisa surpreendente para uma ferramenta fazer em seu nome."""
+
+[[privacy]]
+title = "O que o Google carrega, e o que não recebe."
+body = """
+ Os scripts de
+      publicidade e medição vêm do Google. Nenhum dos dois recebe nada sobre o seu
+      documento: nem um arquivo, nem uma página, nem um nome, um tamanho, uma
+      contagem de páginas ou uma palavra que você pesquisou. Cada linha que lê,
+      edita ou escreve um PDF é servida desta origem e está listada no
+      repositório."""
+
+[[privacy]]
+title = "O que o botão de doação carrega, e o que não recebe."
+body = """
+
+      O botão &ldquo;Buy me a coffee&rdquo; no topo é desenhado por um script de
+      cdnjs.buymeacoffee.com e busca as letras no Google Fonts. É um link e nada
+      mais: não relata visita alguma, e não recebe nada sobre você nem sobre os seus
+      documentos. Nada acontece a menos que você clique, e para onde você iria ao
+      clicar é o site de outra pessoa."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e tudo nesta página continua
+      funcionando. É a prova mais simples de todas: uma ferramenta que mandasse o
+      seu documento para ser tarjado em outro lugar pararia."""
+
+[[howto]]
+title = "Escolha o PDF."
+body = """
+ Um documento por vez, de propósito:
+      tarjar é um trabalho que precisa ser olhado página por página, e uma
+      ferramenta que deixasse você marcar palavras num arquivo e as aplicasse em
+      silêncio a outro é exatamente como a coisa errada acaba sendo enviada. Ele é
+      lido direto do seu disco pelo navegador."""
+
+[[howto]]
+title = "Diga o que precisa sair."
+body = """
+ Digite as palavras &mdash; um
+      nome, um endereço, um número de processo &mdash; e cada lugar em que
+      aparecerem é listado com a linha em que está e uma caixinha para marcar. Os
+      localizadores ao lado da caixinha procuram endereços de e-mail, números de
+      cartão, IBANs, CPFs e números de seguridade social, e telefones. Eles são
+      oferecidos, nunca marcados por você: um padrão não sabe distinguir um telefone
+      de um número de processo."""
+
+[[howto]]
+title = "Leia a página e escolha palavras nela."
+body = """
+
+      O painel mostra o texto do documento como ele está de fato guardado, na ordem
+      em que um leitor o copiaria. Clique em qualquer palavra para tirá-la e clique
+      de novo para mantê-la. Tudo o que está riscado é o que vai sumir &mdash; o que
+      faz disto tanto a revisão quanto a seleção, e vale a pena fazer isso em cada
+      página antes de apertar o botão."""
+
+[[howto]]
+title = "Tire-as, e leia a linha que diz que foi conferido."
+body = """
+
+      As letras são apagadas, a lacuna que deixaram é mantida aberta, uma tarja
+      preta é desenhada por cima se você pediu, e as mesmas palavras são tiradas dos
+      marcadores, dos comentários, dos campos de formulário e das propriedades do
+      documento. Depois o arquivo pronto é reaberto aqui e pesquisado. Se uma
+      palavra que você tirou ainda puder ser encontrada nele, você não recebe
+      download algum e recebe uma mensagem dizendo isso."""
+
+[[faq]]
+q = "Qual a diferença entre isto e desenhar uma tarja preta num leitor de PDF?"
+a = """
+        Um retângulo desenhado num leitor é uma anotação: um objeto com uma posição,
+        salvo ao lado da página. O texto embaixo está intacto. Qualquer um que
+        selecione aquela área e aperte copiar, ou abra o arquivo em outro programa,
+        ou passe nele qualquer extrator de texto, recebe as palavras de volta. Alguns
+        leitores oferecem um comando &ldquo;redact&rdquo; que aplica a remoção
+        direito &mdash; e vários oferecem só o desenho. Esta ferramenta não tem
+        retângulo para tirar do caminho: as letras são recortadas das instruções de
+        desenho da página, e a tarja preta, se você a deixar ligada, é desenhada
+        depois sobre uma lacuna que já está vazia."""
+
+[[faq]]
+q = "Como eu sei que as palavras sumiram mesmo?"
+a = """
+        Porque a ferramenta confere, na sua máquina, e mostra a contagem. Quando o
+        arquivo é escrito, ele é reaberto pelo mesmo leitor desta página, cada página
+        é lida, cada marcador, comentário, campo de formulário e propriedade é
+        recolhido, e cada palavra que você tirou é pesquisada. A linha de resultados
+        diz quantas havia e quantas restam. Se a resposta não for a que deveria ser,
+        a execução falha e nada é oferecido para download. Você também pode conferir
+        depois, em qualquer leitor: aperte Ctrl+F e procure a palavra."""
+
+[[faq]]
+q = "O resto da página se desloca quando uma palavra é retirada?"
+a = """
+        Não. O texto é desenhado avançando uma caneta pela página, então apagar cinco
+        letras normalmente puxaria o resto da linha cinco letras para a esquerda. A
+        largura exata do que foi retirado é medida a partir das próprias métricas da
+        fonte e reposta como uma instrução de espaçamento, que move a caneta sem
+        desenhar nada. As colunas continuam alinhadas e os totais continuam sob os
+        seus títulos."""
+
+[[faq]]
+q = "Ele consegue tarjar um documento digitalizado?"
+a = """
+        A imagem não, e ele diz isso em vez de fingir. Uma digitalização é a
+        fotografia de uma página: as palavras são pixels e não há texto a retirar. O
+        que uma digitalização muitas vezes carrega é uma camada de texto invisível
+        que o OCR do digitalizador escreveu sobre a imagem para que a página possa
+        ser pesquisada &mdash; esta ferramenta encontra essa camada, tira dela o que
+        você escolher, e diz na página que a imagem continua inalterada. Assim uma
+        pesquisa e uma cópia param de achar a palavra, e uma pessoa olhando a página
+        continua lendo. Para uma imagem, o
+        <a href=\"../tarjar-imagem/\">tarjador de imagens</a> sobrescreve os próprios
+        pixels."""
+
+[[faq]]
+q = "E as partes de um documento que não estão numa página?"
+a = """
+        Elas são tratadas, porque é por ali que uma tarja costuma vazar. As mesmas
+        palavras são tiradas dos marcadores, dos comentários e das notas adesivas, do
+        que foi digitado em campos de formulário, do texto que um leitor de tela
+        recebe, e do texto de substituição que um leitor copia <em>no lugar</em> das
+        letras da página &mdash; esse último existe para que ligaduras e palavras
+        partidas por hífen sejam copiadas direito, e pode guardar uma frase inteira.
+        As propriedades do documento e o pacote XMP são removidos por completo.
+        Anexos e tudo o que roda quando o arquivo abre são descartados, porque em
+        nenhum dos dois é possível pesquisar as palavras que você está tirando."""
+
+[[faq]]
+q = "Os meus documentos são enviados para algum lugar?"
+a = """
+        Não. O arquivo é lido, editado e escrito pelo seu próprio navegador no seu
+        próprio hardware. Esta ferramenta não tem lado servidor, e a
+        <code>Content-Security-Policy</code> da página lista todos os endereços que
+        ela pode contatar &mdash; nenhum deles pertence a este site. O que você
+        digita na caixa de pesquisa é comparado com texto na memória desta aba e
+        também não vai a lugar nenhum."""
+
+[[faq]]
+q = "Por que não posso arrastar uma caixa sobre a página como em outras ferramentas?"
+a = """
+        Porque desenhar uma página significa um renderizador de PDF completo &mdash;
+        fontes, degradês, transparência, modos de mesclagem &mdash; que é um megabyte
+        ou mais de motor para buscar e rodar, e este site não entrega nenhum. Acontece
+        que isso combina com o trabalho: arrastar um retângulo seleciona uma
+        <em>área de papel</em>, e uma área de papel não é a mesma coisa que o texto
+        embaixo dela, e é assim que a falha da tarja preta começa. O que você recebe
+        no lugar é o texto do documento, na ordem de leitura, com cada palavra
+        clicável. É também a única visão capaz de lhe dizer o que uma imagem da página
+        não pode: se as palavras à sua frente são texto."""
+
+[[faq]]
+q = "O arquivo pronto vai abrir em qualquer lugar?"
+a = """
+        Sim. A saída é escrita como PDF 1.5, ou a versão mais alta de que o arquivo
+        que você deu precisou, e a 1.5 é entendida por todo leitor lançado desde
+        2003. Nada na página é recodificado: as fontes, as imagens e o desenho
+        vetorial passam byte a byte, então o que sobra do texto continua selecionável
+        e pesquisável exatamente como era."""
+
+[[faq]]
+q = "Ele abre um PDF protegido por senha?"
+a = """
+        Não, e isso é de propósito. Um documento criptografado é recusado com uma
+        mensagem dizendo isso, mesmo quando a senha é vazia &mdash; que é como muitos
+        digitalizadores e copiadoras salvam. Tirar a proteção de um arquivo é um
+        trabalho diferente de tirar palavras dele, e uma ferramenta que fizesse isso
+        em silêncio estaria fazendo algo que você não pediu."""
+
+[[faq]]
+q = "Há limite de tamanho, e custa alguma coisa?"
+a = """
+        Não há limite escrito na ferramenta. O limite é a sua própria máquina: o
+        documento fica na memória enquanto se trabalha nele, então um notebook aguenta
+        algumas centenas de megabytes sem reclamar e começa a penar acima disso. É
+        grátis, não há conta, não há login e não há teste. O site exibe publicidade, e
+        é ela que o paga; os anunciantes não recebem nada sobre os seus
+        documentos."""
+
+[[faq]]
+q = "Funciona offline?"
+a = """
+        Sim. Carregue a página uma vez, depois desconecte da internet e ela continua
+        funcionando. É também a maneira mais simples de provar que nada é enviado:
+        uma ferramenta que mandasse o seu documento para ser tarjado em outro lugar
+        pararia no instante em que você tirasse o cabo."""
+
+[schema]
+description = "Tarje um PDF no navegador apagando o texto em vez de cobri-lo. As letras são retiradas do content stream da página, o arquivo pronto é reaberto e pesquisado para provar que sumiram, e nada é enviado."
+features = [
+  "Apaga as letras da página em vez de desenhar um retângulo por cima",
+  "Reabre o arquivo pronto e pesquisa nele para provar que as palavras sumiram",
+  "Encontra cada ocorrência de uma palavra, ou procura e-mails, números de cartão, IBANs e documentos de identificação nacionais",
+  "Mostra o texto do documento na ordem de leitura para que cada palavra seja clicável",
+  "Tira as mesmas palavras de marcadores, comentários, campos de formulário e propriedades",
+  "Mantém a lacuna aberta para que o resto da linha não se desloque",
+  "Diz quais páginas são digitalizações, onde não há texto a retirar",
+  "Funciona offline; sem envio, sem conta, sem limite de tamanho",
+]
+
+[picker]
+title = "Arraste o seu PDF para cá"
+hint = "ou clique para procurar &mdash; um documento por vez"

--- a/locales/pt/tools/stack-images.html
+++ b/locales/pt/tools/stack-images.html
@@ -1,0 +1,240 @@
+<!--
+  tools/stack-images/body.html, in Portuguese.
+
+  Every id, class, option value, data-phrase key and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language. Only
+  the words change. The #faq-raw anchor is a link target from the note in step
+  one, so it stays as it is.
+-->
+<main>
+  <!-- Passo 1 &mdash; os quadros -->
+  <section class="card">
+    <h2><span class="step">1</span> Escolha os quadros</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p class="note">
+      Arquivos RAW são abertos lendo o JPEG em tamanho cheio que a câmera já
+      escreveu dentro deles: alguns kilobytes de diretório e depois uma fatia. Os
+      dados do sensor não são decodificados nunca, então um quadro de 60&nbsp;MB
+      abre mais ou menos tão rápido quanto um JPEG.
+      <a href="#faq-raw">O que isso significa para o resultado</a>.
+    </p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="sort-name" class="ghost">Ordenar por nome</button>
+        <button type="button" id="clear-all" class="ghost danger">Remover todos</button>
+      </div>
+    </div>
+
+    <ul id="frame-list" class="frame-list"></ul>
+  </section>
+
+  <!-- Passo 2 &mdash; como eles se juntam -->
+  <section class="card">
+    <h2><span class="step">2</span> Como eles se juntam</h2>
+
+    <div class="settings">
+      <div class="field field-wide">
+        <label for="mode">Método</label>
+        <select id="mode">
+          <option value="mean" selected>Média &mdash; baixar o ruído</option>
+          <option value="median">Mediana &mdash; tirar pessoas e carros passando</option>
+          <option value="sigma">Sigma clipping &mdash; as duas coisas de uma vez</option>
+          <option value="max">Clarear &mdash; rastros de estrelas, fogos, light painting</option>
+          <option value="min">Escurecer &mdash; tirar tudo o que é claro e se mexeu</option>
+          <option value="sum">Somar &mdash; simular uma exposição longa</option>
+          <option value="focus">Focus stacking &mdash; guardar o que estava em foco</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="align">Alinhar os quadros</label>
+        <select id="align">
+          <option value="translate" selected>Sim &mdash; só deslocamento</option>
+          <option value="similarity">Sim &mdash; deslocar, girar e redimensionar</option>
+          <option value="none">Não &mdash; pegar exatamente como estão</option>
+        </select>
+        <p class="field-note" id="align-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="scale">Resolução de trabalho</label>
+        <select id="scale">
+          <option value="full" selected>Tamanho cheio</option>
+          <option value="half">Metade &mdash; um quarto da memória</option>
+          <option value="quarter">Um quarto &mdash; um dezesseis avos</option>
+        </select>
+        <p class="field-note" id="scale-note"></p>
+      </div>
+
+      <div class="field" id="kappa-field" hidden>
+        <label for="kappa">Descartar além de</label>
+        <div class="inline-pair">
+          <input type="range" id="kappa" min="0.5" max="4" step="0.1" value="2">
+          <output id="kappa-value" for="kappa">2.0&sigma;</output>
+        </div>
+        <p class="field-note">
+          Mais baixo descarta mais, e descarta detalhe verdadeiro junto. Dois
+          desvios padrão são o ponto de partida de sempre.
+        </p>
+      </div>
+
+      <div class="field" id="radius-field" hidden>
+        <label for="radius">A nitidez é medida ao longo de</label>
+        <div class="inline-pair">
+          <input type="range" id="radius" min="1" max="12" step="1" value="3">
+          <output id="radius-value" for="radius">3 px</output>
+        </div>
+        <p class="field-note">
+          Maior pega áreas inteiras de um quadro; menor segue detalhes finos e pode
+          embaralhar um fundo liso de um quadro para outro.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="gain">Exposição</label>
+        <div class="inline-pair">
+          <input type="range" id="gain" min="0.1" max="4" step="0.05" value="1">
+          <output id="gain-value" for="gain">1.00&times;</output>
+        </div>
+        <p class="field-note" id="gain-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="format">Salvar como</label>
+        <select id="format">
+          <option value="png" selected>PNG &mdash; sem perdas</option>
+          <option value="jpeg">JPEG &mdash; arquivo menor</option>
+        </select>
+        <div id="quality-row" class="inline-pair" hidden>
+          <input type="range" id="quality" min="0.5" max="1" step="0.01" value="0.92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+    </div>
+
+    <!--
+      What the run will cost, worked out before it starts. Every figure here is
+      an answer from src/plan.js rather than an estimate, which is why they are
+      shown at all: a median of twenty large frames is a genuinely different
+      proposition from an average of them, and that should be visible before
+      the button is pressed rather than afterwards.
+    -->
+    <dl class="plan" id="plan" hidden>
+      <div><dt>Resultado</dt><dd id="plan-output">&mdash;</dd></div>
+      <div><dt>Memória de trabalho</dt><dd id="plan-memory">&mdash;</dd></div>
+      <div><dt>Decodificações</dt><dd id="plan-decodes">&mdash;</dd></div>
+      <div><dt>Lido do disco</dt><dd id="plan-read">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-warning" class="path-note" hidden></p>
+  </section>
+
+  <!-- Passo 3 &mdash; rodar -->
+  <section class="card">
+    <h2><span class="step">3</span> Empilhar</h2>
+
+    <div class="export-row">
+      <button type="button" id="run" class="primary" disabled>Empilhar as imagens</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame">
+        <img id="result-image" alt="O resultado empilhado">
+      </div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <p id="result-moves" class="field-note"></p>
+        <a id="download" class="primary as-button" download>Baixar a imagem</a>
+      </div>
+    </div>
+  </section>
+
+  <!--
+    Every sentence this tool's JavaScript puts on screen, kept out of the
+    JavaScript so that a translator can reach it. src/ is copied byte for byte
+    into all eleven languages, so a string written in a module is English at ten
+    of them. See shared/js/phrases.js.
+
+    A {name} is filled in by the caller. Nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="count.one">1 quadro</span>
+    <span data-phrase="count.many">{count} quadros</span>
+    <span data-phrase="count.none">Ainda sem quadros</span>
+
+    <span data-phrase="frame.reference">Referência</span>
+    <span data-phrase="frame.make-reference">Usar como referência</span>
+    <span data-phrase="frame.remove">Remover</span>
+    <span data-phrase="frame.size">{width} &times; {height}</span>
+    <span data-phrase="frame.raw">RAW &mdash; a prévia da própria câmera, {width} &times; {height}</span>
+    <span data-phrase="frame.raw-camera">{camera} &mdash; prévia de {width} &times; {height}</span>
+    <span data-phrase="frame.raw-unreadable">Neste arquivo RAW não se encontrou prévia alguma</span>
+    <span data-phrase="frame.read">{read} de {total} lidos</span>
+
+    <span data-phrase="mode.mean">Tira a média de cada quadro. O ruído aleatório é alto tantas vezes quantas é baixo, então tirar a média de {count} quadros o baixa em cerca de {factor} vezes. É o método para uma sequência tranquila, e é o que um único pássaro passando estraga.</span>
+    <span data-phrase="mode.median">Pega o valor do meio de cada pixel. Tudo o que só estava em parte dos quadros, um turista, um carro, um avião, some. É o único método que precisa segurar todos os quadros ao mesmo tempo, e é por isso que ele pode ser dividido em faixas aqui embaixo.</span>
+    <span data-phrase="mode.sigma">Aprende o que cada pixel costuma ser, e então tira a média só dos valores que combinam com isso. O resultado da mediana com a redução de ruído da média. Ele lê os quadros duas vezes.</span>
+    <span data-phrase="mode.max">Guarda o valor mais claro que cada pixel já teve. É isso que transforma uma série de exposições curtas em rastros de estrelas e monta um fogo de artifício a partir dos quadros da sua própria explosão.</span>
+    <span data-phrase="mode.min">Guarda o valor mais escuro que cada pixel já teve. Um pixel só continua claro se estava claro em todos os quadros, então reflexos, faróis e gotas de chuva iluminadas somem.</span>
+    <span data-phrase="mode.sum">Soma os quadros sem dividir: o que uma exposição {count} vezes mais longa teria recolhido. Ele estoura, exatamente como aquela exposição estouraria. Traga de volta com o controle de exposição.</span>
+    <span data-phrase="mode.focus">Pega cada parte da imagem do quadro em que ela estava em foco. Fotografe um assunto pequeno ao longo do anel de foco, e isto junta as partes nítidas.</span>
+
+    <span data-phrase="align.translate">Descobre quanto cada quadro se deslocou e o desloca de volta, com precisão de frações de pixel. Corrige o tremor da mão e a deriva do tripé. Rotação ele não corrige.</span>
+    <span data-phrase="align.similarity">Descobre também rotação e escala. Custa uma medição a mais por quadro e não custa nada quando os quadros se revelam retos. A rotação só é recuperada dentro de meia volta.</span>
+    <span data-phrase="align.none">Empilha os quadros exatamente como chegam. Certo para um tripé fixo ou uma série de intervalos, errado para qualquer coisa feita na mão.</span>
+
+    <span data-phrase="scale.note">Cada quadro é decodificado neste tamanho pelo próprio decodificador do navegador, então um ajuste menor é menos trabalho e não só menos memória.</span>
+    <span data-phrase="gain.note">Multiplicado no resultado bem no fim, depois da conta e antes do arredondamento.</span>
+    <span data-phrase="gain.sum-note">Somar {count} quadros vai estourar com quase toda a certeza. Baixe para uns {suggested} para ver o que foi recolhido.</span>
+
+    <span data-phrase="plan.output">{width} &times; {height}</span>
+    <span data-phrase="plan.memory">cerca de {mb} MB</span>
+    <span data-phrase="plan.decodes.simple">{count}, uma por quadro</span>
+    <span data-phrase="plan.decodes.passes">{count} &mdash; cada quadro, {passes} vezes</span>
+    <span data-phrase="plan.decodes.banded">{count} &mdash; cada quadro, uma vez para cada uma das {bands} faixas</span>
+    <span data-phrase="plan.read">{read} de {total} no disco</span>
+    <span data-phrase="plan.banded">Isto não cabe na memória de uma vez, então a imagem é cortada em {bands} faixas e os quadros são lidos de novo para cada uma. Escolher {suggested} transformaria isso numa passagem única.</span>
+    <span data-phrase="plan.banded-anyway">Isto não cabe na memória de uma vez, então a imagem é cortada em {bands} faixas e os quadros são lidos de novo para cada uma. Menos quadros ou uma resolução de trabalho menor transformariam isso numa passagem única.</span>
+
+    <span data-phrase="progress.open">Olhando dentro de {name}&hellip;</span>
+    <span data-phrase="progress.survey">Lendo {name}&hellip;</span>
+    <span data-phrase="progress.measure">Medindo quanto {name} se moveu&hellip;</span>
+    <span data-phrase="progress.stack">Empilhando &mdash; {done} de {total} quadros lidos</span>
+    <span data-phrase="progress.stack-banded">Empilhando &mdash; faixa {band} de {bands}, {done} de {total} quadros lidos</span>
+    <span data-phrase="progress.encode">Escrevendo a imagem&hellip;</span>
+
+    <span data-phrase="result.info">{width} &times; {height}, {size} &mdash; {count} quadros somados em {seconds} segundos</span>
+    <span data-phrase="result.moves">Cada quadro foi medido e empurrado para o seu lugar.</span>
+    <span data-phrase="result.moves-some">{count} de {total} quadros não puderam ser medidos com segurança e ficaram onde estavam.</span>
+    <span data-phrase="result.moves-none">Os quadros foram empilhados exatamente como chegaram.</span>
+    <span data-phrase="result.moves-clamped">{count} quadros relataram uma rotação grande demais para uma sequência, e foram corrigidos só por deslocamento.</span>
+    <span data-phrase="result.cropped">Afastá-los deixou bordas que nem todo quadro alcançava, e elas foram cortadas.</span>
+
+    <span data-phrase="error.no.files">Acrescente antes pelo menos uma imagem.</span>
+    <span data-phrase="error.no.size">Nenhum destes arquivos pôde ser aberto como imagem.</span>
+    <span data-phrase="error.one.frame">Empilhar precisa de pelo menos dois quadros.</span>
+    <span data-phrase="error.unknown">Algo deu errado ao empilhar. Se um destes arquivos for incomum, tente-o sozinho.</span>
+    <span data-phrase="error.memory">O navegador ficou sem memória. Tente uma resolução de trabalho menor ou menos quadros.</span>
+    <span data-phrase="error.unreadable">{name} não pôde ser aberto como imagem e ficou de fora.</span>
+    <span data-phrase="error.busy">Espere esta pilha terminar antes de acrescentar mais quadros, ou cancele-a.</span>
+  </div>
+</main>

--- a/locales/pt/tools/stack-images.toml
+++ b/locales/pt/tools/stack-images.toml
@@ -1,0 +1,325 @@
+#
+# Image Stacker - Portuguese.
+#
+# Overrides for tools/stack-images/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Os nomes dos métodos ficam como estão escritos nos textos de fotografia em
+# português: mediana, sigma clipping, focus stacking. RAW não se traduz, e as
+# siglas dos formatos também não.
+#
+
+name = "Empilhador de imagens"
+heading = "Empilhar&nbsp;imagens <span class=\"h1-kw\">&mdash; junte uma sequência, arquivos RAW inclusive</span>"
+tagline = "Vinte quadros em um, sem vinte envios e sem um conversor RAW."
+
+title = "Empilhar imagens &mdash; média, mediana e focus stacking no navegador"
+description = "Junte uma sequência de fotografias numa só: tire a média para matar o ruído, use a mediana para tirar as pessoas de uma cena, clareie para rastros de estrelas, ou faça focus stacking de uma macro. Lê CR2, NEF, ARW, DNG, RAF e CR3 puxando a prévia da própria câmera. Roda inteiramente no seu navegador."
+og_title = "Empilhe uma sequência de fotografias, arquivos RAW inclusive"
+og_description = "Média, mediana, sigma clipping, clarear, escurecer, somar ou focus stacking &mdash; com os quadros alinhados antes. Os arquivos RAW são abertos lendo a prévia que a câmera já escreveu, então um quadro de 60 MB abre tão rápido quanto um JPEG. Nada é enviado."
+og_image_alt = "Empilhador de imagens - vários quadros juntos num só, no navegador"
+
+pledge = """
+    Cada quadro é aberto, decodificado, alinhado, combinado e escrito pelo seu
+    próprio navegador, na sua própria máquina. Uma pilha de vinte arquivos RAW de
+    60&nbsp;MB é cerca de um gigabyte de fotografias, e nenhum byte disso se move:
+    a ferramenta não tem função de rede alguma, e os arquivos são lidos direto do
+    seu disco por um worker que não tem para onde mandar nada."""
+
+live_hint = """
+      Não acredite na nossa palavra: abra as ferramentas do desenvolvedor, olhe a
+      aba Rede e empilhe uma pasta de arquivos RAW. Nenhuma requisição carrega uma
+      fotografia, uma miniatura, um nome de arquivo ou um modelo de câmera. Ou tire
+      o cabo da internet e empilhe mesmo assim &mdash; nada na ferramenta muda."""
+
+read_first = """
+, <code>src/raw.js</code> para como um arquivo RAW
+      é aberto lendo kilobytes em vez de megabytes, <code>src/stack.js</code> para
+      a aritmética de cada método, e <code>src/plan.js</code> para de onde vêm os
+      números de memória e de decodificação mostrados na página &mdash; são as
+      respostas daquele arquivo, não estimativas."""
+
+howto_heading = "Como empilhar um conjunto de fotografias no navegador"
+
+card = """
+            Junte uma sequência numa imagem só: tire a média para acabar com o
+            ruído, use a mediana para perder os transeuntes, ou clareie para
+            rastros de estrelas. Lê arquivos RAW sem conversor."""
+
+[words]
+plural = "fotografias"
+choose = "algumas fotografias"
+
+[[facts]]
+text = "Sem envio"
+
+[[facts]]
+text = "Sem conta"
+
+[[facts]]
+text = "Sem marca-d'água"
+
+[[facts]]
+text = "Lê RAW"
+
+[[facts]]
+text = "Funciona offline"
+
+[[facts]]
+text = "Código aberto"
+
+[[privacy]]
+title = "As suas fotografias não têm para onde ir."
+body = """
+ A
+      Content-Security-Policy lista todos os endereços que esta página pode
+      contatar, e nenhum deles pertence a este site. Não existe aqui um endpoint
+      onde os seus arquivos pudessem ser recolhidos, e não existe no código nada
+      que os enviasse se existisse &mdash; nenhum <code>fetch</code>, nenhum
+      <code>XMLHttpRequest</code>, nenhum <code>sendBeacon</code>, nem em
+      <code>src/</code> nem no worker."""
+
+[[privacy]]
+title = "Os arquivos RAW são lidos, não enviados &mdash; e mal lidos."
+body = """
+ Um arquivo RAW de câmera já
+      contém um JPEG em tamanho cheio que a câmera renderizou no momento do
+      disparo. Esta ferramenta o encontra percorrendo algumas entradas de diretório
+      e depois pedindo uma única fatia, o que num arquivo de 60&nbsp;MB costuma
+      ficar abaixo de cem kilobytes. A página mostra esse número ao lado do tamanho
+      dos seus arquivos enquanto você trabalha. Os dados do sensor não são lidos
+      nunca."""
+
+[[privacy]]
+title = "O trabalho acontece num Worker nesta máquina, não num servidor."
+body = """
+ Esta é a única
+      ferramenta aqui que usa um, porque empilhar são minutos de aritmética em vez
+      de segundos, e uma página congelada não consegue mostrar progresso nem ser
+      cancelada. Um Worker é uma segunda linha de execução neste mesmo navegador
+      &mdash; veja <code>src/worker.js</code>. Ele recebe os próprios arquivos, o
+      que sai de graça, porque a referência a um arquivo não são os bytes; e ele tem
+      exatamente a mesma Content-Security-Policy da página, ou seja, lugar nenhum
+      para onde mandá-los."""
+
+[[privacy]]
+title = "Sobre o conjunto não se relata nada em lugar nenhum."
+body = """
+ Quantos quadros você
+      empilhou, que câmera os escreveu, quanto cada um tinha se deslocado, que
+      método você escolheu e quanto tempo levou ficam na memória desta página até
+      você fechá-la. Não existe neste repositório um evento de analytics próprio que
+      carregue qualquer parte disso, e a única pergunta que este site faz depois de
+      um download manda um polegar para cima ou para baixo e o nome da ferramenta,
+      mais nada."""
+
+[[privacy]]
+title = "Funciona offline."
+body = """
+ Desconecte da rede e a ferramenta continua a
+      mesma, porque nunca houve um passo de rede nela. O worker e cada módulo que
+      ele carrega ficam em cache pelo service worker desta página, então uma cópia
+      instalada empilha arquivos RAW com a rede desligada."""
+
+[[howto]]
+title = "Escolha os quadros."
+body = """
+ Uma sequência, um conjunto em
+      bracketing, uma série de intervalômetro ou uma pasta de arquivos RAW. Cada um
+      é aberto conforme chega e a linha diz o que saiu dele &mdash; para um arquivo
+      RAW, a câmera, o tamanho da prévia encontrada dentro, e quão pouco do arquivo
+      precisou ser lido para encontrá-la."""
+
+[[howto]]
+title = "Escolha o método que combina com o que você quer perder."
+body = """
+ Ruído:
+      média, ou sigma clipping se alguma coisa se mexeu. Pessoas, carros ou um
+      avião passando: mediana. Um céu escuro que você quer como rastros de
+      estrelas: clarear. Uma macro feita ao longo do anel de foco: focus stacking. A
+      nota abaixo do menu diz o que cada um faz com o seu número de quadros."""
+
+[[howto]]
+title = "Decida se os quadros precisam de alinhamento."
+body = """
+ Na mão: sim,
+      só deslocamento. Na mão e você também girava: deslocamento, rotação e escala.
+      Tripé travado ou intervalômetro: não, e vai ser mais rápido. Cada quadro é
+      medido contra o primeiro da lista, e é por isso que qualquer quadro pode ser
+      promovido a primeiro."""
+
+[[howto]]
+title = "Leia os quatro números, e então aperte o botão."
+body = """
+ Antes de qualquer
+      coisa rodar, a página diz que tamanho terá o resultado, mais ou menos quanta
+      memória vai levar, quantas vezes os quadros serão decodificados e quanto dos
+      seus arquivos foi lido. Se o conjunto não couber na memória de uma vez, ela
+      diz, e diz qual resolução de trabalho resolveria."""
+
+[[faq]]
+q = "As minhas fotografias são enviadas para algum lugar?"
+a = """
+        Não. Cada quadro é aberto, decodificado, alinhado, empilhado e escrito pelo
+        seu próprio navegador no seu próprio hardware. Esta ferramenta não tem função
+        de rede alguma &mdash; nunca busca nada e nunca envia nada &mdash; e a
+        <code>Content-Security-Policy</code> da página lista todos os endereços que
+        ela pode contatar, e nenhum deles pertence a este site. Carregue a página uma
+        vez, tire o cabo da internet, e ela continua funcionando. Isso importa mais
+        aqui do que na maioria das ferramentas simplesmente pelo volume: uma pilha de
+        vinte quadros RAW é cerca de um gigabyte, e enviar um gigabyte de fotografias
+        para que se tire uma média delas é justamente o que esta ferramenta existe
+        para evitar."""
+
+[[faq]]
+q = "Quais formatos RAW ele consegue ler, e como?"
+a = """
+        <span id="faq-raw"></span>CR2, CR3, NEF, NRW, ARW, SR2, SRF, DNG, ORF, RAF,
+        RW2, PEF, SRW, 3FR, IIQ, DCR, KDC, MRW, MEF, RWL e mais alguns &mdash; que é
+        quase tudo o que as câmeras escrevem. O que ele lê deles é a prévia JPEG em
+        tamanho cheio que a própria câmera renderizou no momento do disparo: a imagem
+        na traseira da câmera, e a que o seu sistema operacional desenha como
+        miniatura. Ela é encontrada percorrendo a estrutura de diretórios do arquivo,
+        o que custa algumas leituras de poucos kilobytes cada, e depois pegando uma
+        única fatia. <strong>Não é um demosaicing dos dados do sensor.</strong> O
+        resultado carrega o balanço de branco e o estilo de imagem da câmera a oito
+        bits por canal, em vez dos doze ou catorze bits de dados lineares do sensor
+        que um conversor RAW lhe daria."""
+
+[[faq]]
+q = "Então por que não decodificar os dados do sensor direito?"
+a = """
+        Porque significaria embutir a LibRaw ou o dcraw &mdash; um segundo motor de
+        dezenas de megabytes, para uma única família de formatos, cuja maior parte
+        são esquemas de compressão de cada fabricante. Essa troca é discutida em
+        <code>docs/what-can-be-built-here.md</code> no código-fonte deste site, onde
+        o RAW de câmera está na lista dos descartados desde antes de esta ferramenta
+        existir. O que mudou não foi a resposta àquela pergunta, mas a descoberta de
+        que empilhar não precisa disso: as prévias são em resolução cheia, são o que
+        a câmera teria lhe dado como JPEG de qualquer jeito, e lê-las é cerca de cem
+        vezes mais rápido do que o demosaicing seria. Se você quer os dados do
+        sensor, revele os quadros num conversor RAW antes e empilhe os TIFFs ou JPEGs
+        que ele produzir &mdash; esta ferramenta aceita esses também."""
+
+[[faq]]
+q = "Quantos quadros ele aguenta, e de que tamanho?"
+a = """
+        Seis dos sete métodos trabalham em fluxo: mantêm um acumulador e leem cada
+        quadro exatamente uma vez, então cem quadros custam a mesma memória que dois
+        e a única coisa que cresce é o tempo. A mediana é a exceção, porque o valor
+        do meio de um conjunto não se sabe até que se tenha o conjunto inteiro, então
+        ela segura todos os quadros ao mesmo tempo &mdash; vinte quadros de 24
+        megapixels são cerca de 1,4&nbsp;GB, que navegador nenhum lhe dá. Quando isso
+        acontece, a imagem é cortada em faixas horizontais e empilhada uma faixa por
+        vez, o que custa reler os quadros para cada faixa. A página calcula tudo isso
+        antes de você apertar o botão e mostra o número, para que uma execução lenta
+        nunca seja surpresa."""
+
+[[faq]]
+q = "O que o alinhamento dos quadros faz de fato?"
+a = """
+        Ele descobre quanto cada quadro se deslocou em relação ao primeiro e o
+        desloca de volta, com precisão de fração de pixel. O método é a correlação de
+        fase: o deslocamento entre duas imagens aparece como uma diferença de fase
+        entre os seus espectros, então uma transformada de Fourier em cada uma acha
+        um desvio de duzentos pixels tão barato quanto um de dois. O segundo ajuste
+        recupera também rotação e escala, pelo mesmo truque aplicado ao espectro em
+        coordenadas log-polares. Tudo isso é global &mdash; um deslocamento, um
+        ângulo, uma escala para o quadro inteiro &mdash; então corrige uma câmera que
+        se moveu e não corrige um assunto que se moveu, nem uma fotografia tirada um
+        passo à esquerda. Uma consequência visível: um quadro deslocado vinte pixels
+        para a esquerda já não alcança a borda direita, então o resultado é aparado
+        até a parte que todos os quadros cobrem. É por isso que uma pilha alinhada
+        volta um tantinho menor do que os quadros que entraram nela, e é a única
+        alternativa a uma borda escura feita dos quadros que ali não estavam."""
+
+[[faq]]
+q = "Qual método eu devo usar?"
+a = """
+        <strong>Média</strong> para ruído, num conjunto em que nada se mexeu: ela
+        corta o ruído aleatório em cerca da raiz quadrada do número de quadros.
+        <strong>Mediana</strong> para tirar coisas que só estavam ali parte do tempo
+        &mdash; o uso clássico é fotografar uma praça movimentada umas doze vezes e
+        recebê-la vazia. <strong>Sigma clipping</strong> quando você quer as duas
+        coisas: ele aprende o que cada pixel costuma ser e tira a média só dos
+        valores que concordam com isso, então tem a imunidade da mediana a um carro
+        passando e a redução de ruído da média. <strong>Clarear</strong> para rastros
+        de estrelas, fogos de artifício e light painting.
+        <strong>Escurecer</strong> para tirar qualquer coisa clara que tenha se
+        mexido. <strong>Somar</strong> para simular uma única exposição longa.
+        <strong>Focus stacking</strong> para uma macro feita ao longo do anel de
+        foco."""
+
+[[faq]]
+q = "Por que o meu resultado tem oito bits se os meus arquivos RAW têm catorze?"
+a = """
+        Porque o que está sendo empilhado é a prévia da própria câmera, que é um
+        JPEG. Vale dizer que empilhar recupera parte do que isso custa: tirar a média
+        de dezesseis quadros de oito bits dá um resultado com gradações realmente
+        mais finas do que qualquer um deles tinha, porque é justamente o ruído que
+        fazia o arredondamento de cada quadro ser diferente que permite à média cair
+        entre os níveis. Aqui a aritmética é feita em ponto flutuante e arredondada
+        uma única vez no fim, então nada disso é jogado fora no meio do caminho.
+        Continua não sendo a mesma coisa que empilhar dados lineares de sensor, e
+        esta ferramenta não finge o contrário."""
+
+[[faq]]
+q = "Posso empilhar quadros de tamanhos diferentes, ou de câmeras diferentes?"
+a = """
+        Pode, embora costume ser um engano e valha a pena conferir se era o que você
+        queria. O resultado fica do tamanho do maior quadro, e cada outro quadro é
+        redimensionado para caber e centralizado nele. Misturar câmeras mistura
+        também a interpretação de cor, então uma média das duas é uma média de duas
+        leituras diferentes da mesma luz. Onde ajuda de verdade é num conjunto feito
+        em duas resoluções, ou num arquivo RAW e um JPEG do mesmo quadro."""
+
+[[faq]]
+q = "Ele diz que a execução vai ser em faixas. O que isso quer dizer?"
+a = """
+        Que a memória de trabalho de que o método precisa é mais do que a ferramenta
+        está disposta a reservar de uma vez, então a imagem vai ser cortada em tiras
+        horizontais e empilhada uma tira por vez. Ela ainda produz exatamente o mesmo
+        resultado; só relê os quadros para cada tira, então demora mais, e a página
+        lhe diz quantas decodificações serão. Baixar um passo a resolução de trabalho
+        divide a memória por quatro, o que quase sempre transforma uma execução em
+        faixas numa passagem única &mdash; a nota diz qual ajuste faria isso."""
+
+[[faq]]
+q = "Por que esta ferramenta usa um Worker e nenhuma das outras usa?"
+a = """
+        Porque é a única cujo trabalho se mede em minutos. Toda outra ferramenta aqui
+        faz algo que leva um segundo ou dois, onde tirar o trabalho da linha principal
+        seria cerimônia. Empilhar vinte quadros grandes é aritmética densa sobre
+        centenas de megabytes, e na linha principal isso significa uma página
+        congelada: nenhuma barra de progresso andando, um botão Cancelar que não
+        responde, e no fim um navegador se oferecendo para fechar a aba. O Worker é
+        uma segunda linha de execução neste mesmo navegador, rodando um arquivo desta
+        mesma pasta, sob esta mesma política. Não é um servidor e não é uma função de
+        rede."""
+
+[[faq]]
+q = "É grátis, e eu preciso de conta?"
+a = """
+        É grátis, e não há conta, nem login, nem teste, nem marca-d'água. Também não
+        há limite de quantos quadros você empilha ou de que tamanho eles são, porque
+        não há um servidor pagando por isso &mdash; o trabalho acontece na sua própria
+        máquina e o único teto é a sua memória. O site exibe publicidade, e é ela que
+        o paga; os anunciantes não recebem nada sobre as suas fotografias."""
+
+[schema]
+description = "Empilhe uma sequência de fotografias no navegador: média, mediana, média com sigma clipping, clarear, escurecer, somar ou focus stacking, com os quadros alinhados antes por correlação de fase. Lê arquivos RAW de câmera extraindo a prévia em tamanho cheio que a câmera embutiu, então nenhum conversor RAW é preciso. Nada é enviado."
+features = [
+  "Sete métodos de empilhamento: média, mediana, média com sigma clipping, clarear, escurecer, somar e focus stacking",
+  "Lê CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2 e outros extraindo a prévia em tamanho cheio da própria câmera",
+  "Abre um arquivo RAW de 60 MB lendo cerca de cem kilobytes dele",
+  "Alinhamento automático: só deslocamento, ou deslocamento com rotação e escala, ou nenhum",
+  "Alinhamento abaixo do pixel por correlação de fase, não por busca de desvios",
+  "Seis dos sete métodos mantêm um acumulador, então cem quadros custam a memória de dois",
+  "Custo de memória e de decodificação calculado e mostrado antes de a execução começar",
+  "O trabalho roda num Worker, então o progresso anda e o Cancelar responde",
+  "Saída em PNG ou JPEG; funciona offline; sem envio, sem conta",
+]
+
+[picker]
+title = "Arraste os quadros para cá"
+hint = "ou clique para procurar &mdash; JPEG, PNG, WebP, TIFF e RAW de câmera"


### PR DESCRIPTION
Four tools and four guides shipped after Portuguese was last brought
level, so a reader with the site set to Portuguese landed on English for
the DICOM viewer, the document scanner, the PDF redactor and image
stacking, plus the four guides beside them.

## What is here

- `locales/pt/tools/` &mdash; `dicom-viewer`, `document-scanner`,
  `redact-pdf`, `stack-images`, each a `.toml` and a `.html`
- `locales/pt/pages/guides/` &mdash; `open-a-dicom-file`, `redact-a-pdf`,
  `scan-a-document-with-your-phone`, `stack-photos-to-reduce-noise`
- eight new entries in `locales/pt/locale.toml`, in the tool block and
  the guide block separately

## The slugs, and two word choices

Unaccented and without cedilla, which the Portuguese table already states
about itself. `check_links` fails the build when a published locale page
links to a page that was not built, so `tarjar-um-pdf`,
`tarjar-uma-imagem` and `e-seguro-enviar-arquivos` are load bearing
rather than decorative.

**`tarjar`** is deliberately the same verb as the existing
`tarjar-imagem`. It is what gets written and searched, and it carries the
distinction both redaction pages live on &mdash; the text comes out of
the file, it is not covered over. `cobrir` would have named the exact
failure those pages exist to warn about.

**`digitalizar`** is the written form. `escanear` exists in speech but
almost nobody types it.

## Register

Read off the Portuguese pages already in the tree: `você` throughout, `o
seu próprio navegador` for the promise that nothing leaves the machine,
`ferramenta` for tool. DICOM field names keep their English and their
numbers &mdash; Pixel Spacing (0028,0030), Series Instance UID
(0020,000E) &mdash; because that is how they appear in the file and in
the standard.

The `#phrases` blocks keep every `data-phrase` key and `{placeholder}`
byte for byte, checked with a script that diffs ids, classes, `for`,
`scope`, option values and placeholder sets against the English source.
The `count.*` pairs stay doubled. `finder.nationalid` is localised to CPF
and social security numbers.

## Verification

`python build.py --out _plain --clean --no-minify` exits 0 and Portuguese
is now **absent from the locale debt list**, which is how the build
reports 65 of 65. No CRLF anywhere under `locales/pt/`.

One of twelve branches closing the same eight-page hole, one language per
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
