### PR TITLE
Give Turkish its last two pages, and the four sentences dicom-viewer lost

### DIFF
--- a/locales/tr/locale.toml
+++ b/locales/tr/locale.toml
@@ -84,6 +84,7 @@ complete = true
 "password-generator" = "sifre-olusturucu"
 "timelapse-video" = "time-lapse-video-olusturma"
 "hash-checksum" = "saglama-toplami-hesaplama"
+"stack-images" = "goruntu-istifleme"
 
 # The indexes and the legal pages.
 "guides" = "rehberler"
@@ -120,6 +121,8 @@ complete = true
 "guides/trim-an-audio-file" = "rehberler/ses-dosyasi-kesme"
 "guides/whats-inside-a-gif" = "rehberler/gifin-icinde-ne-var"
 "guides/verify-a-file-checksum" = "rehberler/dosya-saglama-toplamini-dogrulama"
+# Istifleyen kisi "istifleme" degil, sorunun kendisini yani gurultuyu arar.
+"guides/stack-photos-to-reduce-noise" = "rehberler/gurultuyu-azaltmak-icin-fotograf-istifleme"
 
 # The three that shipped after this file was first written. The tools keep
 # their Latin acronyms in the address for the reason given at the top: DICOM

--- a/locales/tr/pages/guides/stack-photos-to-reduce-noise.html
+++ b/locales/tr/pages/guides/stack-photos-to-reduce-noise.html
@@ -1,0 +1,285 @@
+  <section>
+    <h2>Kısa yanıt</h2>
+    <p>
+      <a href="../../goruntu-istifleme/">Görüntü istifleyiciyi</a> açın, serinin
+      tamamını içine bırakın ve neden kurtulmak istediğinize göre yöntemi seçin:
+    </p>
+    <ul>
+      <li><strong>Gürültü</strong> ve hiçbir şey kımıldamadıysa &mdash; ortalama.</li>
+      <li><strong>Gürültü</strong> ve bir şey kımıldadıysa &mdash; sigma kırpma.</li>
+      <li><strong>İnsanlar, arabalar, bir uçak</strong> &mdash; medyan.</li>
+      <li><strong>Yıldız izine dönüşmesini istediğiniz karanlık bir gökyüzü</strong> &mdash; açma.</li>
+      <li><strong>Neredeyse hiç alan derinliği olmayan bir makro çekim</strong> &mdash; odak istifleme.</li>
+    </ul>
+    <p>
+      Makine elinizdeyse hizalamayı açık bırakın, tripottaysa kapatın. RAW dosyaları
+      doğrudan girebilir; önce geliştirmeye gerek yoktur.
+    </p>
+    <p>
+      Aşağıdaki her şey, o beş satırın neden öyle olduğunu anlatıyor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bir seri neden tek bir kareden fazlasını taşır</h2>
+    <p>
+      Zayıf ışıkta çekilmiş bir fotoğraf, görüntü artı gürültüdür ve gürültü her
+      seferinde başkadır. İstiflemeyi işe yaratan da işte bu son kısımdır. Aynı
+      çekimi on altı kez yapın: görüntü on altısında da aynıdır, gürültü ise değil;
+      dolayısıyla ortalamalarını almak görüntüyü bırakır ve gürültünün çoğunu
+      söndürür.
+    </p>
+    <p>
+      İyileşme, kare sayısının kareköküdür. Dört kare gürültüyü yarıya indirir. On
+      altı kare dörtte bire. Yüz kare onda bire. Üstünde bulunmak için zalim bir
+      eğridir bu &mdash; on altı kareden altmış dört kareye çıkmak aynı iyileşmeyi
+      bir kez daha satın alır, dört katı çekim karşılığında &mdash; ve neredeyse her
+      pratik istifin sekiz ile otuz kare arasında olmasının nedeni de budur.
+    </p>
+    <p>
+      İkinci ve daha sessiz bir kazanç daha var. Sekiz bitlik on altı karenin
+      ortalaması, herhangi birinde olduğundan daha ince geçişler taşıyan bir sonuç
+      verir, çünkü her karenin yuvarlanmasını farklı kılan gürültünün ta kendisi,
+      ortalamanın iki basamak arasına oturmasını sağlar. Gürültülü bir kümeyi
+      istiflemek yalnızca gürültüyü kaldırmaz; tek bir karenin nicemleyerek yitirdiği
+      tonu da geri getirir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Yöntemi seçen soru</h2>
+    <p>
+      Soru "neyi saklamak istiyorum" değil, <strong>kareler arasında neyin farklı
+      olduğu</strong>. Geri kalan her şey bundan çıkar.
+    </p>
+
+    <h3>Hiçbir şey kımıldamadı: ortalama</h3>
+    <p>
+      Düpedüz aritmetik ortalama. Kareler arasındaki tek farkın gürültü olduğu bir
+      kümede elde edilebilecek en etkili gürültü azaltmadır ve bozulması da en
+      kolayıdır: içinde bir kuş olan tek bir kare, istifin tamamına soluk bir kuş
+      koyar, çünkü ortalamanın, diğerleriyle uyuşmayan bir değer hakkında bir görüşü
+      yoktur. Onu da hesaba katar, o kadar.
+    </p>
+
+    <h3>Kareyi bir şey kesip geçti: medyan</h3>
+    <p>
+      Kalabalık bir meydanın on iki fotoğrafını üst üste getirin ve tek bir piksele
+      bakın. Çoğunda o piksel kaldırım taşıdır; birinde ikisinde birinin paltosu.
+      Bu on iki değeri sıralayıp ortadakini alın, kaldırım taşını elde edersiniz,
+      çünkü palto hiçbir zaman çoğunlukta olmadı.
+    </p>
+    <p>
+      Bunu her piksel için yapın, meydan boş çıkar. "Tatil fotoğrafınızdan turistleri
+      kaldırın" tarzı her yazının arkasındaki numara budur ve bir seri çekim ile
+      sabırdan daha zekice bir şey gerektirmez. Tek dayattığı şey, <strong>sahnenin
+      hiçbir parçasının zamanın yarısından fazlasında dolu olmaması</strong>dır. On
+      iki karenizin sekizinde kımıldamadan duran biri, o piksellerde çoğunluktur ve
+      medyan onu saklar.
+    </p>
+
+    <h3>İkisi birden: sigma kırpma</h3>
+    <p>
+      Medyan, sağlamlığını kazanmak için bilginin çoğunu atar &mdash; her pikselde
+      on iki değerinizden on biri atılır &mdash; dolayısıyla gürültüyü, aynı kümenin
+      ortalamasının indireceğinden çok daha az indirir.
+    </p>
+    <p>
+      Sigma kırpma bu uzlaşmadır ve gerçek dünyadan gelen herhangi bir küme için
+      genellikle doğru varsayılandır. Her piksele bütün kareler boyunca bakar, onun
+      genelde ne olduğunu ve ne kadar değiştiğini çıkarır, sonra yalnızca bununla
+      uyuşan değerlerin ortalamasını alır. Bir kareyi kesip geçen bir araba o
+      piksellerde dışarıda bırakılır; diğer her kare ise her yerde saymaya devam
+      eder. Böylece medyanın kımıldayan şeylere karşı bağışıklığını ve ortalamanın
+      gürültü azaltmasının çoğunu birlikte elde edersiniz.
+    </p>
+    <p>
+      Eşik standart sapma cinsindendir ve iki, alışılmış başlangıç noktasıdır. Daha
+      düşüğü daha çok eler ve arabayla birlikte gerçek ayrıntıyı da elemeye başlar.
+    </p>
+
+    <h3>Yalnızca parlak şeyler önemli: açma</h3>
+    <p>
+      Her pikselin ulaştığı en parlak değeri saklayın. Gece gökyüzünü otuz saniyelik
+      iki yüz pozlama olarak çekin ve bunları açarak birleştirin: her yıldız sonuç
+      üzerinde kendi yayını çizer &mdash; tek tek hiçbiri yanmamış kısa pozlamalardan
+      kurulmuş bir yıldız izi. Aynı yöntem bir havai fişeği kendi patlamasının
+      karelerinden kurar, karanlık bir odada elde fenerle yürümeyi de bir ışık
+      resmine çevirir.
+    </p>
+    <p>
+      Karşıtı olan koyulaştırma, bu ikilinin sessiz olanıdır: bir piksel yalnızca
+      <em>her</em> karede parlaksa parlak kalır, dolayısıyla camdaki yansımalar,
+      geçen farlar ve flaşın aydınlattığı yağmur damlaları yok olur.
+    </p>
+
+    <h3>Özne odaktan daha derin: odak istifleme</h3>
+    <p>
+      f/8'de bir makro çekimde belki bir milimetre odaktadır ve bu bir böcek için
+      yetmez. Yanıt, odak halkası boyunca yirmi kare çekmek ve her birinden yalnızca
+      o karede net olan bölümü saklamaktır. Araç, her pikselin komşularından ne kadar
+      farklı olduğunu ölçer &mdash; bir kenarda büyük, bir bulanıklıkta sıfıra yakın
+      &mdash; ve kazananı alır.
+    </p>
+    <p>
+      Bu yöntem tripodu diğerlerinin hepsinden çok ister, çünkü odak halkasını elle
+      çevirmek makineyi oynatır ve azıcık daha uzaktan çekilmiş bir kare, aynı
+      görüntünün başka bir odaktaki hâli değildir.
+    </p>
+  </section>
+
+  <section>
+    <h2>Kareleri hizalamak</h2>
+    <p>
+      İstifleme piksel başına aritmetiktir, dolayısıyla belirli bir pikselin her
+      karede sahnenin aynı parçası olduğunu varsayar. Elde tutulduğunda öyle
+      değildir: bir seri onlarca piksel kayar ve bunun ortalamasını almak temiz bir
+      görüntü yerine bir bulanıklık üretir. İstiflemedeki ilk denemenin hayal
+      kırıklığı yaratmasının en yaygın nedeni budur.
+    </p>
+    <p>
+      Bu yüzden kareler önce içlerinden birine göre ölçülür ve yerlerine geri
+      taşınır, bir pikselin kesirine varan hassasiyetle. Üç ayar vardır:
+    </p>
+    <ul>
+      <li>
+        <strong>Yalnızca kaydırma</strong> elde tutulan hemen her şey için doğrudur.
+        Kaymayı ve titremeyi düzeltir.
+      </li>
+      <li>
+        <strong>Kaydırma, döndürme ve ölçekleme</strong>, hafifçe de dönmekte
+        olduğunuz ya da yakınlaştırmanın sinsice kaydığı bir küme için. Kare başına
+        bir ölçüm fazladan maliyeti vardır ve kareler düz çıkarsa hiçbir maliyeti
+        olmaz.
+      </li>
+      <li>
+        <strong>Hiçbiri</strong>, sabitlenmiş bir tripod ya da aralıklı bir dizi
+        için; kareler zaten hizalıdır ve onları ölçmek boşa geçen zamandır.
+      </li>
+    </ul>
+    <p>
+      Hiçbir hizalamanın düzeltemeyeceği şey, kımıldamış bir makine yerine kımıldamış
+      bir öznedir; bir adım soldan çekilmiş bir fotoğrafı da düzeltemez. Yana
+      hareket etmek, yakındaki şeylerin uzaktakilere göre ne kadar kaydığını
+      değiştirir ve tek bir düzeltme ikisini birden anlatmaz. Olduğunuz yerde dönmek
+      sorun değil; yürümek sorundur.
+    </p>
+  </section>
+
+  <section>
+    <h2>RAW dosyaları bu işin neresinde</h2>
+    <p>
+      CR2, CR3, NEF, ARW, DNG, RAF, RW2, ORF ve gerisini doğrudan bırakabilirsiniz;
+      onlara ne olduğu konusunda kesin konuşmakta yarar var, çünkü bu, bir RAW
+      dönüştürücünün yaptığı şey değildir.
+    </p>
+    <p>
+      Her RAW dosyası, <strong>makinenin çekim anında oluşturduğu tam boyutlu bir
+      JPEG</strong>'i zaten içerir. Makinenin arkasında size gösterilen görüntü budur
+      ve işletim sisteminizin küçük resim olarak çizdiği de budur. İstifleyici o
+      görüntüyü bulur ve onu kullanır. Sensör verisini çözmez.
+    </p>
+    <p>
+      Bunun iki sonucu vardır; biri iyi, biri bilinmeye değer:
+    </p>
+    <ul>
+      <li>
+        <strong>Hızlıdır.</strong> Önizlemeyi bulmak birkaç kilobaytlık dizin okumak
+        ve sonra tek bir dilim almak demektir, dolayısıyla 60&nbsp;MB'lık bir kare
+        aşağı yukarı bir JPEG kadar hızlı açılır. Bir RAW dönüştürücünün tek bir
+        kareye harcayacağı sürede yirmi tanesi açılır. Sayfa, dosyalarınızın ne kadar
+        azını gerçekten okuduğunu size gösterir.
+      </li>
+      <li>
+        <strong>Bu, sizin değil makinenin yorumudur.</strong> Kanal başına sekiz bit,
+        makinenin ayarlı olduğu beyaz dengesi ve resim stiliyle &mdash; bir
+        dönüştürücüden alacağınız on iki ya da on dört bitlik doğrusal sensör verisi
+        değil.
+      </li>
+    </ul>
+    <p>
+      Gürültü azaltma, yıldız izleri, geçenleri kaldırma ve odak istifleme için bu
+      takas neredeyse her zaman kârlıdır: önizlemeler tam çözünürlüktedir ve zaten
+      JPEG olarak alacağınız görüntüdür. Gölgeleri sertçe kaldırıyorsanız ya da
+      dinamik aralığın son kırıntısının bütün mesele olduğu astrofotoğrafçılık için
+      istifliyorsanız, kareleri önce bir RAW dönüştürücüde geliştirin ve onun verdiği
+      TIFF ya da JPEG'leri istifleyin. Onlar da aynı şekilde girer.
+    </p>
+  </section>
+
+  <section>
+    <h2>Çalıştırmanın maliyeti</h2>
+    <p>
+      Bilmeye değer, çünkü sekiz saniye süren bir istif ile iki dakika süren bir
+      istif arasındaki fark budur.
+    </p>
+    <p>
+      Yedi yöntemin altısının yalnızca tek bir şeyi hatırlaması gerekir. Yürüyen bir
+      maksimum, daha önce gördüğü kareleri umursamaz; yürüyen bir toplam da öyle. Bu
+      yüzden o yöntemler her kareyi tam olarak bir kez okur ve yüz kare için iki kare
+      kadar bellek kullanır.
+    </p>
+    <p>
+      Medyan böyle çalışamaz, çünkü bir kümenin ortadaki değeri, küme tamamlanmadan
+      bilinemez. Yirmi tane 24 megapiksel kare, aynı anda tutulan yaklaşık
+      1,4&nbsp;GB pikseldir ve bunu hiçbir tarayıcı size vermez; bu yüzden görüntü
+      yatay şeritlere kesilir ve şerit şerit istiflenir &mdash; doğru, ve daha yavaş,
+      çünkü kareler her şerit için yeniden okunur.
+    </p>
+    <p>
+      Araç bunların hepsini siz düğmeye basmadan hesaplar ve size söyler: sonucun ne
+      kadar büyük olacağını, kabaca ne kadar belleğe ihtiyaç duyduğunu ve karelerinizin
+      kaç kez çözüleceğini. Çalıştırmanın şeritli olacağını söylüyorsa, çalışma
+      çözünürlüğünü bir kademe düşürmek belleği dörde böler ve bunu neredeyse her
+      zaman tek geçişe döndürür &mdash; üstelik gürültüyü kaldırmak için
+      istifliyorsanız, yarım çözünürlük zaten tamdan daha temiz görünecekti.
+    </p>
+  </section>
+
+  <section>
+    <h2>Bunun için çekmek</h2>
+    <p>
+      Bir istifin kalitesinin çoğu, herhangi bir yazılım onu görmeden önce belirlenir.
+    </p>
+    <ul>
+      <li>
+        <strong>İhtiyacınız olduğunu sandığınızdan fazla kare çekin.</strong> Karekök
+        eğrisi başta acımasız, sonda merhametlidir: dört kareden dokuza çıkmak, yirmi
+        kareden kırka çıkmaktan daha büyük bir görünür değişikliktir.
+      </li>
+      <li>
+        <strong>Kareler arasında pozlamayı değiştirmeyin.</strong> İstifleme,
+        karelerin aynı parlaklıkta aynı sahne olduğunu varsayar. Pozlamayı kilitleyin,
+        yoksa araç iki farklı görüntünün ortalamasını alıyor olur.
+      </li>
+      <li>
+        <strong>İnsanları kaldırmak için kareler arasında bekleyin.</strong> İki
+        saniyede çekilmiş bir seri, aynı kişiyi her karede aynı yerde yakalar ve
+        medyan onu saklar. Birkaç saniye arayla çekilmiş on kare, seri hâlinde çekilmiş
+        elli kareden çok daha iyi iş görür.
+      </li>
+      <li>
+        <strong>Yıldız izleri için araları kısa tutun.</strong> Açma, karelerin tam
+        olarak neyi kaydettiğini çizer, dolayısıyla iki pozlama arasındaki duraklama
+        her izde görünür bir kesinti hâline gelir.
+      </li>
+    </ul>
+  </section>
+
+  <section>
+    <h2>Bunların hiçbiri makinenizden ayrılmaz</h2>
+    <p>
+      Yirmi RAW kareden oluşan bir istif yaklaşık bir gigabayt fotoğraf eder ve
+      ortalamasının alınması için bunu bir web sitesine vermek epey fazladır.
+      <a href="../../goruntu-istifleme/">Görüntü istifleyici</a> dosyaları kendi
+      diskinizden okur ve aritmetiği kendi tarayıcınızda yapar. Yükleme adımı yok,
+      hesap yok, kuyruk yok; ve bu iddiayı herkesinkini kontrol edeceğiniz gibi
+      kontrol edebilirsiniz: çalışırken tarayıcınızın ağ panelini açın ya da doğrudan
+      internet bağlantısını kesip yine de istifleyin.
+    </p>
+    <p>
+      İlgili soru &mdash; herhangi bir araç için, ona bir dosya vermenin gerekli olup
+      olmadığını nasıl anlarsınız &mdash;
+      <a href="../dosya-yuklemek-guvenli-mi/">kendi rehberine</a> sahiptir.
+    </p>
+  </section>

--- a/locales/tr/pages/guides/stack-photos-to-reduce-noise.toml
+++ b/locales/tr/pages/guides/stack-photos-to-reduce-noise.toml
@@ -1,0 +1,20 @@
+#
+# Rehber: gürültüyü azaltmak için fotoğraf istifleme - Turkish.
+#
+
+nav = "Fotoğraf istifleme"
+title = "Gürültüyü azaltmak ya da insanları kaldırmak için fotoğraflar nasıl istiflenir"
+description = "İstifleme bir seri kareyi tek görüntüde birleştirir. Hangi yöntemi kullanacağınız neyi kaybetmek istediğinize bağlıdır: gürültü, geçenler ya da bir makro çekimin sığ alan derinliği. Her birinin nasıl çalıştığı, neye mal olduğu ve RAW dosyalarının bu işin neresinde durduğu."
+
+heading = "Gürültüyü azaltmak ya da insanları kaldırmak için fotoğraflar nasıl istiflenir"
+lede = """
+    Bir seri kare, içlerinden herhangi birinin taşıdığından daha fazla bilgi taşır.
+    Ortalamalarını almak gürültüyü söndürür; her pikselin ortadaki değerini almak
+    ise yalnızca bir süre orada olmuş her şeyi siler. Hangisini istediğiniz tümüyle
+    neyin kımıldadığına bağlıdır."""
+
+updated = "25 Ağustos 2026"
+
+og_title = "Gürültüyü azaltmak ya da insanları kaldırmak için fotoğraflar nasıl istiflenir"
+og_description = "Gürültüyü öldürmek için bir serinin ortalamasını alın, kalabalık bir meydanı boşaltmak için medyanını alın, yıldız izleri için açın. Hangi yöntemin hangi sorunu çözdüğü ve RAW dosyalarının bu işin neresinde durduğu."
+og_image_alt = "abox.tools - hiçbir zaman bir sunucuya dokunmayan araçlar"

--- a/locales/tr/tools/dicom-viewer.html
+++ b/locales/tr/tools/dicom-viewer.html
@@ -218,6 +218,16 @@
     <span data-phrase="stack.spacing">Kesitler arası {gap}.</span>
 
     <span data-phrase="at.position">{total} içinde {at}</span>
+    <span data-phrase="net.clean">taramanız hiçbir yere gitmedi. {total} dosya
+      yüklendi, hepsi bu sayfanın kendi dosyaları. {platform}</span>
+    <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç
+      bunu asla yapmaz. Bunu araştırmaya değer sayın. {platform}</span>
+    <span data-phrase="net.platform.one">Sayfanın kendi reklam, ölçüm ve bağış
+      düğmesi betikleri {hosts} sunucudan yüklendi; hiçbirine bir tarama, ondan
+      bir piksel ya da başlığından bir kelime verilmedi.</span>
+    <span data-phrase="net.platform.many">Sayfanın kendi reklam, ölçüm ve bağış
+      düğmesi betikleri {hosts} sunucudan yüklendi; hiçbirine bir tarama, ondan
+      bir piksel ya da başlığından bir kelime verilmedi.</span>
     <span data-phrase="at.frame">{total} kareden {at}. kare</span>
     <span data-phrase="at.instance">örnek {number}</span>
 

--- a/locales/tr/tools/stack-images.html
+++ b/locales/tr/tools/stack-images.html
@@ -1,0 +1,240 @@
+<!--
+  tools/stack-images/body.html, in Turkish.
+
+  Every id, class, option value, data-phrase key and brace placeholder below is
+  what the JavaScript reaches for, so they are the same in every language. Only
+  the words change. The #faq-raw anchor is a link target from the note in step
+  one, so it stays as it is.
+-->
+<main>
+  <!-- Adım 1 &mdash; kareler -->
+  <section class="card">
+    <h2><span class="step">1</span> Kareleri seçin</h2>
+
+    <!--
+      A real <label> drives the file picker natively. Calling .click() on a
+      display:none input is refused by Safari and some Chrome configurations,
+      so the input stays in the layout: visually hidden, still focusable, and
+      reachable by keyboard. There is no JavaScript in this path at all.
+    -->
+    {% include "partials/file-picker.html" %}
+
+    <p class="note">
+      RAW dosyaları, fotoğraf makinesinin içlerine çoktan yazdığı tam boyutlu
+      JPEG okunarak açılır: birkaç kilobaytlık dizin, sonra tek bir dilim. Sensör
+      verisi hiçbir zaman çözülmez, dolayısıyla 60&nbsp;MB'lık bir kare aşağı
+      yukarı bir JPEG kadar hızlı açılır.
+      <a href="#faq-raw">Bunun sonuç için ne anlama geldiği</a>.
+    </p>
+
+    <div id="list-toolbar" class="toolbar" hidden>
+      <span id="count-label" class="count"></span>
+      <div class="toolbar-actions">
+        <button type="button" id="sort-name" class="ghost">Ada göre sırala</button>
+        <button type="button" id="clear-all" class="ghost danger">Hepsini kaldır</button>
+      </div>
+    </div>
+
+    <ul id="frame-list" class="frame-list"></ul>
+  </section>
+
+  <!-- Adım 2 &mdash; nasıl birleşecekleri -->
+  <section class="card">
+    <h2><span class="step">2</span> Nasıl birleşecekler</h2>
+
+    <div class="settings">
+      <div class="field field-wide">
+        <label for="mode">Yöntem</label>
+        <select id="mode">
+          <option value="mean" selected>Ortalama &mdash; gürültüyü düşür</option>
+          <option value="median">Medyan &mdash; insanları ve geçen arabaları kaldır</option>
+          <option value="sigma">Sigma kırpma &mdash; ikisi birden</option>
+          <option value="max">Açma &mdash; yıldız izleri, havai fişek, ışıkla boyama</option>
+          <option value="min">Koyulaştırma &mdash; kımıldamış her parlak şeyi kaldır</option>
+          <option value="sum">Toplama &mdash; uzun bir pozlamayı taklit et</option>
+          <option value="focus">Odak istifleme &mdash; net olanı sakla</option>
+        </select>
+        <p class="field-note" id="mode-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="align">Kareleri hizala</label>
+        <select id="align">
+          <option value="translate" selected>Evet &mdash; yalnızca kaydırma</option>
+          <option value="similarity">Evet &mdash; kaydırma, döndürme ve ölçekleme</option>
+          <option value="none">Hayır &mdash; tam olduğu gibi al</option>
+        </select>
+        <p class="field-note" id="align-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="scale">Çalışma çözünürlüğü</label>
+        <select id="scale">
+          <option value="full" selected>Tam boyut</option>
+          <option value="half">Yarım &mdash; belleğin dörtte biri</option>
+          <option value="quarter">Çeyrek &mdash; on altıda biri</option>
+        </select>
+        <p class="field-note" id="scale-note"></p>
+      </div>
+
+      <div class="field" id="kappa-field" hidden>
+        <label for="kappa">Şunun ötesini at</label>
+        <div class="inline-pair">
+          <input type="range" id="kappa" min="0.5" max="4" step="0.1" value="2">
+          <output id="kappa-value" for="kappa">2.0&sigma;</output>
+        </div>
+        <p class="field-note">
+          Düşürdükçe daha çok atar, gerçek ayrıntıyı da beraberinde atar. İki
+          standart sapma alışılmış başlangıç noktasıdır.
+        </p>
+      </div>
+
+      <div class="field" id="radius-field" hidden>
+        <label for="radius">Netlik şu genişlikte ölçülür</label>
+        <div class="inline-pair">
+          <input type="range" id="radius" min="1" max="12" step="1" value="3">
+          <output id="radius-value" for="radius">3 px</output>
+        </div>
+        <p class="field-note">
+          Büyüğü tek bir kareden bütün bölgeleri alır; küçüğü ince ayrıntının
+          peşine düşer ve düz bir arka planı kareler arasında dağıtabilir.
+        </p>
+      </div>
+
+      <div class="field">
+        <label for="gain">Pozlama</label>
+        <div class="inline-pair">
+          <input type="range" id="gain" min="0.1" max="4" step="0.05" value="1">
+          <output id="gain-value" for="gain">1.00&times;</output>
+        </div>
+        <p class="field-note" id="gain-note"></p>
+      </div>
+
+      <div class="field">
+        <label for="format">Şu biçimde kaydet</label>
+        <select id="format">
+          <option value="png" selected>PNG &mdash; kayıpsız</option>
+          <option value="jpeg">JPEG &mdash; daha küçük dosya</option>
+        </select>
+        <div id="quality-row" class="inline-pair" hidden>
+          <input type="range" id="quality" min="0.5" max="1" step="0.01" value="0.92">
+          <output id="quality-value" for="quality">92</output>
+        </div>
+      </div>
+    </div>
+
+    <!--
+      What the run will cost, worked out before it starts. Every figure here is
+      an answer from src/plan.js rather than an estimate, which is why they are
+      shown at all: a median of twenty large frames is a genuinely different
+      proposition from an average of them, and that should be visible before
+      the button is pressed rather than afterwards.
+    -->
+    <dl class="plan" id="plan" hidden>
+      <div><dt>Sonuç</dt><dd id="plan-output">&mdash;</dd></div>
+      <div><dt>Çalışma belleği</dt><dd id="plan-memory">&mdash;</dd></div>
+      <div><dt>Çözme sayısı</dt><dd id="plan-decodes">&mdash;</dd></div>
+      <div><dt>Diskten okunan</dt><dd id="plan-read">&mdash;</dd></div>
+    </dl>
+
+    <p id="plan-warning" class="path-note" hidden></p>
+  </section>
+
+  <!-- Adım 3 &mdash; çalıştırma -->
+  <section class="card">
+    <h2><span class="step">3</span> İstifle</h2>
+
+    <div class="export-row">
+      <button type="button" id="run" class="primary" disabled>Görüntüleri istifle</button>
+      <button type="button" id="cancel" class="ghost" hidden>İptal</button>
+    </div>
+
+    <div id="progress-wrap" class="progress-wrap" hidden>
+      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+      <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
+    </div>
+
+    <p id="error" class="error" role="alert" hidden></p>
+
+    <div id="result" class="result" hidden>
+      <div class="result-frame">
+        <img id="result-image" alt="İstiflenmiş sonuç">
+      </div>
+      <div class="result-meta">
+        <p id="result-info"></p>
+        <p id="result-moves" class="field-note"></p>
+        <a id="download" class="primary as-button" download>Görüntüyü indir</a>
+      </div>
+    </div>
+  </section>
+
+  <!--
+    Every sentence this tool's JavaScript puts on screen, kept out of the
+    JavaScript so that a translator can reach it. src/ is copied byte for byte
+    into all eleven languages, so a string written in a module is English at ten
+    of them. See shared/js/phrases.js.
+
+    A {name} is filled in by the caller. Nothing else is substituted.
+  -->
+  <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="count.one">1 kare</span>
+    <span data-phrase="count.many">{count} kare</span>
+    <span data-phrase="count.none">Henüz kare yok</span>
+
+    <span data-phrase="frame.reference">Referans</span>
+    <span data-phrase="frame.make-reference">Referans yap</span>
+    <span data-phrase="frame.remove">Kaldır</span>
+    <span data-phrase="frame.size">{width} &times; {height}</span>
+    <span data-phrase="frame.raw">RAW &mdash; makinenin kendi önizlemesi, {width} &times; {height}</span>
+    <span data-phrase="frame.raw-camera">{camera} &mdash; {width} &times; {height} önizleme</span>
+    <span data-phrase="frame.raw-unreadable">Bu RAW dosyasında önizleme bulunamadı</span>
+    <span data-phrase="frame.read">{total} içinde {read} okundu</span>
+
+    <span data-phrase="mode.mean">Her karenin ortalamasını alır. Rastgele gürültü ne kadar yüksek çıkarsa o kadar da alçak çıkar, dolayısıyla {count} karenin ortalamasını almak onu kabaca {factor} kat düşürür. Sakin bir küme için doğru yöntem, tek bir geçen kuşun bozduğu yöntem de bu.</span>
+    <span data-phrase="mode.median">Her pikselin ortadaki değerini alır. Yalnızca karelerin bir kısmında bulunan her şey &mdash; bir turist, bir araba, bir uçak &mdash; yok olur. Her kareyi aynı anda tutmak zorunda olan tek yöntemdir; aşağıda şeritlere bölünebilmesinin nedeni de budur.</span>
+    <span data-phrase="mode.sigma">Her pikselin genelde ne olduğunu öğrenir, sonra yalnızca bununla uyuşan değerlerin ortalamasını alır. Medyanın sonucu, ortalamanın gürültü azaltmasıyla birlikte. Kareleri iki kez okur.</span>
+    <span data-phrase="mode.max">Her pikselin ulaştığı en parlak değeri saklar. Bir dizi kısa pozlamayı yıldız izine çeviren ve bir havai fişeği kendi patlamasının karelerinden kuran şey budur.</span>
+    <span data-phrase="mode.min">Her pikselin ulaştığı en koyu değeri saklar. Bir piksel yalnızca her karede parlaksa parlak kalır, dolayısıyla camdaki yansımalar, geçen farlar ve flaşın aydınlattığı yağmur damlaları yok olur.</span>
+    <span data-phrase="mode.sum">Kareleri bölmeden toplar: {count} kat uzun bir pozlamanın toplayacağı şey. Tıpkı o pozlamanın yapacağı gibi yanar. Pozlama kaydırıcısıyla geri getirin.</span>
+    <span data-phrase="mode.focus">Görüntünün her parçasını, o parçanın net olduğu kareden alır. Küçük bir özneyi odak halkası boyunca çekin, bu da net parçaları birleştirsin.</span>
+
+    <span data-phrase="align.translate">Her karenin ne kadar kaydığını bulur ve geri taşır, bir pikselin kesirine varan hassasiyetle. Elde tutmanın titremesini ve tripodun kaymasını düzeltir. Dönmeyi düzeltemez.</span>
+    <span data-phrase="align.similarity">Ayrıca dönmeyi ve ölçeği de bulur. Kare başına bir ölçüm fazladan maliyeti vardır, kareler düz çıkarsa hiçbir maliyeti olmaz. Dönme her zaman yalnızca yarım tur içinde geri kazanılır.</span>
+    <span data-phrase="align.none">Kareleri tam geldikleri gibi istifler. Sabit bir tripod ya da aralıklı bir dizi için doğru, elde tutulan her şey için yanlış.</span>
+
+    <span data-phrase="scale.note">Her kare tarayıcının kendi çözücüsü tarafından bu boyutta çözülür, dolayısıyla küçük bir ayar yalnızca daha az bellek değil, daha az iş demektir.</span>
+    <span data-phrase="gain.note">Hesaptan sonra, yuvarlamadan önce, en sonda sonuca çarpılır.</span>
+    <span data-phrase="gain.sum-note">{count} kareyi toplamak neredeyse kesinlikle yanacaktır. Neyin toplandığını görmek için bunu {suggested} civarına düşürün.</span>
+
+    <span data-phrase="plan.output">{width} &times; {height}</span>
+    <span data-phrase="plan.memory">yaklaşık {mb} MB</span>
+    <span data-phrase="plan.decodes.simple">{count}, kare başına bir tane</span>
+    <span data-phrase="plan.decodes.passes">{count} &mdash; her kare, {passes} kez</span>
+    <span data-phrase="plan.decodes.banded">{count} &mdash; her kare, {bands} şeridin her biri için bir kez</span>
+    <span data-phrase="plan.read">diskte {total} içinde {read}</span>
+    <span data-phrase="plan.banded">Bu belleğe tek parça sığmıyor, bu yüzden görüntü {bands} şeride kesilecek ve kareler her şerit için yeniden okunacak. {suggested} seçmek bunu tek geçişe çevirirdi.</span>
+    <span data-phrase="plan.banded-anyway">Bu belleğe tek parça sığmıyor, bu yüzden görüntü {bands} şeride kesilecek ve kareler her şerit için yeniden okunacak. Daha az kare ya da daha küçük bir çalışma çözünürlüğü bunu tek geçişe çevirirdi.</span>
+
+    <span data-phrase="progress.open">{name} içine bakılıyor&hellip;</span>
+    <span data-phrase="progress.survey">{name} okunuyor&hellip;</span>
+    <span data-phrase="progress.measure">{name} ne kadar kımıldadı, ölçülüyor&hellip;</span>
+    <span data-phrase="progress.stack">İstifleniyor &mdash; {total} karenin {done} tanesi okundu</span>
+    <span data-phrase="progress.stack-banded">İstifleniyor &mdash; {bands} şeritten {band}. şerit, {total} karenin {done} tanesi okundu</span>
+    <span data-phrase="progress.encode">Görüntü yazılıyor&hellip;</span>
+
+    <span data-phrase="result.info">{width} &times; {height}, {size} &mdash; {count} kare {seconds} saniyede birleştirildi</span>
+    <span data-phrase="result.moves">Her kare ölçüldü ve yerine itildi.</span>
+    <span data-phrase="result.moves-some">{total} karenin {count} tanesi güvenle ölçülemedi ve olduğu yerde bırakıldı.</span>
+    <span data-phrase="result.moves-none">Kareler tam geldikleri gibi istiflendi.</span>
+    <span data-phrase="result.moves-clamped">{count} kare, bir seri için fazla büyük bir dönme bildirdi ve yalnızca kaydırmayla düzeltildi.</span>
+    <span data-phrase="result.cropped">Onları birbirinden ayırmak, her karenin ulaşamadığı kenarlar bıraktı ve oralar kırpıldı.</span>
+
+    <span data-phrase="error.no.files">Önce en az bir görüntü ekleyin.</span>
+    <span data-phrase="error.no.size">Bu dosyaların hiçbiri görüntü olarak açılamadı.</span>
+    <span data-phrase="error.one.frame">İstifleme en az iki kare ister.</span>
+    <span data-phrase="error.unknown">İstifleme sırasında bir şeyler ters gitti. Bu dosyalardan biri alışılmadıksa onu tek başına deneyin.</span>
+    <span data-phrase="error.memory">Tarayıcının belleği tükendi. Daha küçük bir çalışma çözünürlüğü ya da daha az kare deneyin.</span>
+    <span data-phrase="error.unreadable">{name} görüntü olarak açılamadı ve dışarıda kaldı.</span>
+    <span data-phrase="error.busy">Daha fazla kare eklemeden önce bu istifin bitmesini bekleyin ya da onu iptal edin.</span>
+  </div>
+</main>

--- a/locales/tr/tools/stack-images.toml
+++ b/locales/tr/tools/stack-images.toml
@@ -1,0 +1,319 @@
+#
+# Image Stacker - Turkish.
+#
+# Overrides for tools/stack-images/tool.toml. Only words: the slug, the
+# category, the icon, the CSP and the list of shared parts stay where they are.
+#
+# Yöntem adları Türkçe fotoğraf yazısında geçtiği gibi kalıyor: ortalama, medyan,
+# sigma kırpma, odak istifleme. RAW çevrilmiyor, biçim kısaltmaları da öyle.
+#
+
+name = "Görüntü istifleyici"
+heading = "Görüntü&nbsp;istifleme <span class=\"h1-kw\">&mdash; bir seri kareyi birleştirin, RAW dosyaları dahil</span>"
+tagline = "Yirmi kare tek karede, yirmi yükleme ve RAW dönüştürücü olmadan."
+
+title = "Görüntü istifleme &mdash; tarayıcınızda ortalama, medyan ve odak istifleme"
+description = "Bir seri fotoğrafı tek karede birleştirin: gürültüyü öldürmek için ortalamasını alın, sahneden insanları çıkarmak için medyanını alın, yıldız izleri için açın ya da bir makro çekimi odak istifleyin. CR2, NEF, ARW, DNG, RAF ve CR3 dosyalarını, fotoğraf makinesinin kendi önizlemesini çıkararak okur. Tümüyle tarayıcınızda çalışır."
+og_title = "Bir seri fotoğrafı istifleyin, RAW dosyaları dahil"
+og_description = "Ortalama, medyan, sigma kırpma, açma, koyulaştırma, toplama ya da odak istifleme &mdash; kareler önce hizalanarak. RAW dosyaları, fotoğraf makinesinin çoktan yazdığı önizleme okunarak açılır; 60 MB'lık bir kare bir JPEG kadar hızlı açılır. Hiçbir şey yüklenmez."
+og_image_alt = "Görüntü istifleyici - birkaç kare tarayıcıda tek karede birleştirilmiş"
+
+pledge = """
+    Her kare kendi tarayıcınızda, kendi makinenizde açılır, çözülür, hizalanır,
+    birleştirilir ve yazılır. Yirmi tane 60&nbsp;MB'lık RAW dosyası yaklaşık bir
+    gigabayt fotoğraf eder ve bunun tek baytı yerinden kıpırdamaz: aracın hiçbir
+    ağ özelliği yoktur ve dosyaları, hiçbir yere gönderemeyecek bir işçi doğrudan
+    diskinizden okur."""
+
+live_hint = """
+      Sözümüze güvenmeyin: geliştirici araçlarını açın, Ağ sekmesini izleyin ve
+      RAW dosyalarıyla dolu bir klasörü istifleyin. Tek bir istek bile ne bir
+      fotoğraf, ne bir küçük resim, ne bir dosya adı, ne de bir makine modeli
+      taşır. Ya da internet bağlantısını kesin ve yine de istifleyin; araçta hiçbir
+      şey değişmez."""
+
+read_first = """
+, bir RAW dosyasının megabaytlar yerine kilobaytlar
+      okunarak nasıl açıldığı için <code>src/raw.js</code>, her yöntemin aritmetiği
+      için <code>src/stack.js</code>, sayfada görünen bellek ve çözme sayılarının
+      nereden geldiği için de <code>src/plan.js</code> &mdash; bunlar tahmin değil,
+      o dosyanın verdiği yanıtlardır."""
+
+howto_heading = "Tarayıcınızda bir dizi fotoğrafı nasıl istiflersiniz"
+
+card = """
+            Bir seriyi tek karede birleştirin: gürültüyü ortalamayla silin,
+            geçenleri medyanla atın ya da yıldız izleri için açın. RAW dosyalarını
+            dönüştürücü olmadan okur."""
+
+[words]
+plural = "fotoğraf"
+choose = "birkaç fotoğraf"
+
+[[facts]]
+text = "Yükleme yok"
+
+[[facts]]
+text = "Hesap yok"
+
+[[facts]]
+text = "Filigran yok"
+
+[[facts]]
+text = "RAW okur"
+
+[[facts]]
+text = "Çevrimdışı çalışır"
+
+[[facts]]
+text = "Açık kaynak"
+
+[[privacy]]
+title = "Fotoğraflarınızın gidecek bir yeri yok."
+body = """
+ Content-Security-Policy bu
+      sayfanın iletişim kurabileceği her adresi adıyla sayar ve hiçbiri bu siteye
+      ait değildir. Burada dosyalarınızın toplanabileceği bir uç nokta yoktur,
+      olsaydı da onları gönderecek bir kod yoktur &mdash; ne <code>src/</code>
+      içinde ne de işçide bir <code>fetch</code>, bir <code>XMLHttpRequest</code>
+      ya da bir <code>sendBeacon</code> bulunur."""
+
+[[privacy]]
+title = "RAW dosyaları yüklenmez, okunur &mdash; hem de zar zor."
+body = """
+ Bir fotoğraf makinesinin RAW
+      dosyası, makinenin çekim anında oluşturduğu tam boyutlu bir JPEG'i zaten
+      içerir. Bu araç onu birkaç dizin girdisini gezerek bulur, sonra tek bir dilim
+      ister; 60&nbsp;MB'lık bir dosyada bu genellikle yüz kilobaytın altındadır.
+      Siz çalışırken sayfa o sayıyı dosyalarınızın boyutunun yanında gösterir.
+      Sensör verisi ise hiç okunmaz."""
+
+[[privacy]]
+title = "İş, bir sunucuda değil, bu makinedeki bir Worker'da yapılır."
+body = """
+ Burada Worker kullanan tek
+      araç budur, çünkü istifleme saniyelerin değil dakikaların aritmetiğidir ve
+      donmuş bir sayfa ne ilerleme gösterebilir ne de iptal edilebilir. Worker,
+      aynı tarayıcının içindeki ikinci bir iş parçacığıdır &mdash;
+      <code>src/worker.js</code>'ye bakın. Ona dosyaların kendisi verilir ve bu
+      bedavadır, çünkü bir dosya tutamacı baytlar değildir; üstelik sayfayla tıpatıp
+      aynı Content-Security-Policy altındadır, yani gönderecek bir yeri yoktur."""
+
+[[privacy]]
+title = "Bu küme hakkında hiçbir yere hiçbir şey bildirilmez."
+body = """
+ Kaç kare istiflediğiniz, onları hangi
+      makinenin yazdığı, her birinin ne kadar kaydığı, hangi yöntemi seçtiğiniz ve
+      ne kadar sürdüğü, siz kapatana dek bu sayfanın belleğinde kalır. Bu depoda
+      bunların herhangi birini taşıyan özel bir analitik olayı yoktur ve bu sitenin
+      indirmeden sonra sorduğu tek soru, bir başparmağın yönünü ve aracın adını
+      gönderir, başka hiçbir şeyi değil."""
+
+[[privacy]]
+title = "Çevrimdışı çalışır."
+body = """
+ Ağ bağlantısını kesin, araçta hiçbir şey değişmez,
+      çünkü içinde hiçbir zaman bir ağ adımı olmadı. Worker ve yüklediği her modül
+      bu sayfanın kendi service worker'ı tarafından önbelleğe alınır, dolayısıyla
+      kurulu bir kopya ağ fişi çekiliyken de RAW dosyalarını istifler."""
+
+[[howto]]
+title = "Kareleri seçin."
+body = """
+ Bir seri çekim, basamaklı pozlanmış bir
+      küme, bir aralıklı çekim dizisi ya da RAW dosyalarıyla dolu bir klasör. Her
+      biri geldiği anda açılır ve satırı ondan ne çıktığını söyler &mdash; bir RAW
+      dosyası için makinenin adı, içinde bulunan önizlemenin boyutu ve onu bulmak
+      için dosyanın ne kadar azının okunması gerektiği."""
+
+[[howto]]
+title = "Neyi kaybetmek istediğinize uyan yöntemi seçin."
+body = """
+ Gürültü:
+      ortalama, bir şey kımıldadıysa sigma kırpma. İnsanlar, arabalar ya da geçen
+      bir uçak: medyan. Yıldız izine dönüşmesini istediğiniz karanlık bir gökyüzü:
+      açma. Odak halkası boyunca çekilmiş bir makro: odak istifleme. Menünün
+      altındaki not, her birinin sizin kare sayınıza ne yapacağını söyler."""
+
+[[howto]]
+title = "Karelerin hizalanması gerekip gerekmediğine karar verin."
+body = """
+ Elde tutuluyorsa: evet,
+      yalnızca kaydırma. Elde tutuluyor ve aynı zamanda dönüyorsanız: kaydırma,
+      döndürme ve ölçekleme. Sabitlenmiş tripod ya da aralıklı çekim: hayır, ve daha
+      hızlı olur. Her kare listedeki ilk kareye göre ölçülür; herhangi bir kareyi
+      ilk sıraya yükseltebilmenizin nedeni de budur."""
+
+[[howto]]
+title = "Dört sayıyı okuyun, sonra düğmeye basın."
+body = """
+ Hiçbir şey çalışmadan önce
+      sayfa, sonucun ne kadar büyük olacağını, kabaca ne kadar bellek alacağını,
+      karelerin kaç kez çözüleceğini ve dosyalarınızın ne kadarının okunduğunu
+      söyler. Küme belleğe tek parça sığmayacaksa bunu da söyler ve hangi çalışma
+      çözünürlüğünün bunu düzelteceğini de belirtir."""
+
+[[faq]]
+q = "Fotoğraflarım bir yere yükleniyor mu?"
+a = """
+        Hayır. Her kare kendi tarayıcınızda, kendi donanımınızda açılır, çözülür,
+        hizalanır, istiflenir ve yazılır. Bu aracın hiçbir ağ özelliği yoktur
+        &mdash; hiçbir zaman bir şey getirmez ve hiçbir zaman bir şey göndermez
+        &mdash; ve sayfanın <code>Content-Security-Policy</code> başlığı iletişim
+        kurabileceği her adresi adıyla sayar; hiçbiri bu siteye ait değildir.
+        Sayfayı bir kez yükleyin, internet bağlantısını kesin, yine de çalışır.
+        Bu, çoğu araçta olduğundan burada daha çok önemlidir ve nedeni yalnızca
+        hacimdir: yirmi RAW kare yaklaşık bir gigabayttır ve ortalamasının
+        alınması için bir gigabaytlık fotoğrafı yüklemek, bu aracın var oluş
+        nedeni olan şeyden kaçınmak istediği durumun ta kendisidir."""
+
+[[faq]]
+q = "Hangi RAW biçimlerini okuyabilir, nasıl?"
+a = """
+        <span id="faq-raw"></span>CR2, CR3, NEF, NRW, ARW, SR2, SRF, DNG, ORF, RAF,
+        RW2, PEF, SRW, 3FR, IIQ, DCR, KDC, MRW, MEF, RWL ve birkaçı daha &mdash;
+        yani fotoğraf makinelerinin yazdıklarının çoğu. Bunlardan okuduğu şey,
+        makinenin çekim anında kendi oluşturduğu tam boyutlu JPEG önizlemedir:
+        makinenin arkasındaki ekranda gördüğünüz görüntü ve işletim sisteminizin
+        küçük resim olarak çizdiği görüntü. Dosyanın dizin yapısı gezilerek bulunur;
+        bu, her biri birkaç kilobaytlık birkaç okuma eder, sonra tek bir dilim
+        alınır. <strong>Bu, sensör verisinin mozaik çözümü değildir.</strong> Sonuç,
+        bir RAW dönüştürücünün vereceği on iki ya da on dört bitlik doğrusal sensör
+        verisi yerine, makinenin beyaz dengesini ve resim stilini kanal başına sekiz
+        bitle taşır."""
+
+[[faq]]
+q = "Peki neden sensör verisi düzgünce çözülmüyor?"
+a = """
+        Çünkü bu, LibRaw ya da dcraw'ı beraberinde taşımak demek olurdu &mdash; tek
+        bir biçim ailesi için onlarca megabaytlık ikinci bir motor, üstelik büyük
+        bölümü üreticiye özgü sıkıştırma şemaları. Bu takas, bu sitenin kaynağındaki
+        <code>docs/what-can-be-built-here.md</code> dosyasında tartışılmıştır ve
+        fotoğraf makinesi RAW'ı, bu araç var olmadan önce de eleme listesindeydi.
+        Değişen şey o sorunun yanıtı değil, istiflemenin buna ihtiyaç duymadığının
+        anlaşılmasıdır: önizlemeler tam çözünürlüktedir, zaten makinenin size JPEG
+        olarak vereceği görüntüdür ve onları okumak mozaik çözmekten kabaca yüz kat
+        hızlıdır. Sensör verisini istiyorsanız kareleri önce bir RAW dönüştürücüde
+        geliştirin ve onun ürettiği TIFF ya da JPEG'leri istifleyin &mdash; bu araç
+        onları da alır."""
+
+[[faq]]
+q = "Kaç kareyi ve ne büyüklükte kaldırabilir?"
+a = """
+        Yedi yöntemin altısı akış hâlinde çalışır: tek bir toplayıcı tutar ve her
+        kareyi tam olarak bir kez okur, dolayısıyla yüz kare iki kareyle aynı belleği
+        harcar ve büyüyen tek şey süredir. Medyan istisnadır, çünkü bir kümenin
+        ortadaki değeri, küme tamamlanmadan bilinemez; bu yüzden her kareyi aynı anda
+        tutar &mdash; yirmi tane 24 megapiksel kare yaklaşık 1,4&nbsp;GB eder ve bunu
+        hiçbir tarayıcı size vermez. Bu olduğunda görüntü yatay şeritlere kesilir ve
+        şerit şerit istiflenir; bunun bedeli, her şerit için karelerin yeniden
+        okunmasıdır. Sayfa bunların hepsini siz düğmeye basmadan hesaplar ve sayıyı
+        gösterir, böylece yavaş bir çalıştırma asla sürpriz olmaz."""
+
+[[faq]]
+q = "Kareleri hizalamak aslında ne yapar?"
+a = """
+        Her karenin ilkine göre ne kadar kaydığını bulur ve onu bir pikselin
+        kesirine varan hassasiyetle geri taşır. Yöntem faz korelasyonudur: iki
+        görüntü arasındaki kayma, tayfları arasında bir faz farkı olarak ortaya
+        çıkar; dolayısıyla her birine bir Fourier dönüşümü, iki piksellik bir kaymayı
+        bulduğu ucuzlukta iki yüz piksellik bir kaymayı da bulur. İkinci ayar, aynı
+        numarayı log-polar koordinatlardaki tayfa uygulayarak dönmeyi ve ölçeği de
+        geri kazanır. Bunların hepsi geneldir &mdash; tüm kare için tek bir kayma,
+        tek bir açı, tek bir ölçek &mdash; yani kımıldamış bir makineyi düzeltir,
+        kımıldamış bir özneyi düzeltemez, bir adım soldan çekilmiş bir fotoğrafı da
+        düzeltemez. Görünür tek bir sonucu vardır: yirmi piksel sola taşınmış bir
+        kare artık sağ kenara ulaşmaz, bu yüzden sonuç her karenin kapsadığı bölüme
+        kırpılır. Hizalanmış bir istifin, içine giren karelerden azıcık daha küçük
+        dönmesinin nedeni budur ve orada olmayan karelerden oluşan koyu bir kenara
+        tek alternatif de budur."""
+
+[[faq]]
+q = "Hangi yöntemi kullanmalıyım?"
+a = """
+        Hiçbir şeyin kımıldamadığı bir kümede gürültü için <strong>ortalama</strong>:
+        rastgele gürültüyü kabaca kare sayısının kareköküne göre azaltır. Yalnızca
+        bir süre orada olmuş şeyleri kaldırmak için <strong>medyan</strong> &mdash;
+        klasik kullanımı, kalabalık bir meydanı on iki kez fotoğraflayıp onu boş
+        elde etmektir. İkisini birden istiyorsanız <strong>sigma kırpma</strong>: her
+        pikselin genelde ne olduğunu öğrenir ve yalnızca bununla uyuşan değerlerin
+        ortalamasını alır, böylece medyanın geçen bir arabaya karşı bağışıklığı ile
+        ortalamanın gürültü azaltması bir arada olur. Yıldız izleri, havai fişek ve
+        ışıkla boyama için <strong>açma</strong>. Kımıldamış her parlak şeyi kaldırmak
+        için <strong>koyulaştırma</strong>. Tek bir uzun pozlamayı taklit etmek için
+        <strong>toplama</strong>. Odak halkası boyunca çekilmiş bir makro için
+        <strong>odak istifleme</strong>."""
+
+[[faq]]
+q = "RAW dosyalarım on dört bitken sonucum neden sekiz bit?"
+a = """
+        Çünkü istiflenen şey makinenin kendi önizlemesidir ve o bir JPEG'dir. Yine de
+        istiflemenin bu bedelin bir kısmını geri kazandırdığını söylemekte yarar var:
+        sekiz bitlik on altı karenin ortalaması, herhangi birinde olduğundan gerçekten
+        daha ince geçişler taşıyan bir sonuç verir, çünkü her karenin yuvarlanmasını
+        farklı kılan gürültünün ta kendisi, ortalamanın iki basamak arasına
+        oturmasını sağlar. Buradaki aritmetik kayan noktayla yapılır ve yalnızca en
+        sonda bir kez yuvarlanır, dolayısıyla yol boyunca hiçbir şey atılmaz. Yine de
+        bu, doğrusal sensör verisini istiflemekle aynı şey değildir ve bu araç öyleymiş
+        gibi davranmaz."""
+
+[[faq]]
+q = "Farklı boyutlarda ya da farklı makinelerden kareleri istifleyebilir miyim?"
+a = """
+        Evet, ama bu genellikle bir hatadır ve gerçekten öyle istediğinizi bir kez
+        kontrol etmeye değer. Sonuç en büyük karenin boyutunda olur ve diğer her kare
+        sığacak şekilde ölçeklenip ortalanır. Makineleri karıştırmak renk yorumunu da
+        karıştırır, dolayısıyla ikisinin ortalaması, aynı ışığın iki farklı yorumunun
+        ortalaması olur. Gerçekten işe yaradığı yer, iki çözünürlükte çekilmiş bir küme
+        ya da aynı karenin RAW dosyası ile JPEG'idir."""
+
+[[faq]]
+q = "Çalıştırmanın şeritli olacağını söylüyor. Bu ne demek?"
+a = """
+        Yöntemin ihtiyaç duyduğu çalışma belleğinin, aracın tek seferde ayırmaya razı
+        olduğu miktardan fazla olduğu demek; bu yüzden görüntü yatay şeritlere kesilip
+        şerit şerit istiflenecek. Sonuç yine tıpatıp aynıdır; yalnızca her şerit için
+        kareleri yeniden okur, bu yüzden daha uzun sürer ve sayfa bunun kaç çözme
+        işlemi edeceğini söyler. Çalışma çözünürlüğünü bir kademe düşürmek belleği
+        dörde böler ve şeritli bir çalıştırmayı neredeyse her zaman tek geçişe
+        döndürür &mdash; not, hangi ayarın bunu yapacağını söyler."""
+
+[[faq]]
+q = "Neden diğerleri kullanmazken bu araç bir Worker kullanıyor?"
+a = """
+        Çünkü işi dakikalarla ölçülen tek araç budur. Buradaki her diğer araç bir iki
+        saniye süren bir şey yapar ve orada işi ana iş parçacığından çıkarmak yalnızca
+        merasim olurdu. Yirmi büyük kareyi istiflemek yüzlerce megabayt üzerinde
+        yoğun bir aritmetiktir ve ana iş parçacığında bu, donmuş bir sayfa demektir:
+        ilerleme çubuğu kımıldamaz, İptal düğmesi yanıt vermez ve sonunda tarayıcı
+        sekmeyi kapatmayı önerir. Worker, aynı tarayıcının içindeki ikinci bir iş
+        parçacığıdır; aynı klasördeki bir dosyayı, aynı politika altında çalıştırır.
+        Ne bir sunucudur ne de bir ağ özelliği."""
+
+[[faq]]
+q = "Ücretsiz mi, hesap gerekiyor mu?"
+a = """
+        Ücretsizdir; hesap, oturum açma, deneme süresi ve filigran yoktur. Kaç kare
+        istiflediğinize ya da ne kadar büyük olduklarına dair bir sınır da yoktur,
+        çünkü bunun bedelini ödeyen bir sunucu yoktur &mdash; iş kendi makinenizde
+        yapılır ve tek tavan kendi belleğinizdir. Site reklam gösterir, masrafını
+        karşılayan da odur; reklamlara fotoğraflarınız hakkında hiçbir şey
+        verilmez."""
+
+[schema]
+description = "Tarayıcıda bir seri fotoğrafı istifleyin: ortalama, medyan, sigma kırpılmış ortalama, açma, koyulaştırma, toplama ya da odak istifleme; kareler önce faz korelasyonuyla hizalanır. Fotoğraf makinesi RAW dosyalarını, makinenin gömdüğü tam boyutlu önizlemeyi çıkararak okur, dolayısıyla RAW dönüştürücü gerekmez. Hiçbir şey yüklenmez."
+features = [
+  "Yedi istifleme yöntemi: ortalama, medyan, sigma kırpılmış ortalama, açma, koyulaştırma, toplama ve odak istifleme",
+  "CR2, CR3, NEF, ARW, DNG, ORF, RAF, RW2 ve fazlasını, makinenin kendi tam boyutlu önizlemesini çıkararak okur",
+  "60 MB'lık bir RAW dosyasını, yaklaşık yüz kilobaytını okuyarak açar",
+  "Otomatik hizalama: yalnızca kaydırma, ya da kaydırma ile döndürme ve ölçekleme, ya da hiç",
+  "Kaymaları tek tek arayarak değil, faz korelasyonuyla piksel altı hizalama",
+  "Yedi yöntemin altısı tek bir toplayıcı tutar, böylece yüz kare iki karenin belleğini harcar",
+  "Bellek ve çözme maliyeti, çalıştırma başlamadan hesaplanıp gösterilir",
+  "İş bir Worker'da çalışır, böylece ilerleme ilerler ve İptal yanıt verir",
+  "Çıktı PNG ya da JPEG; çevrimdışı çalışır; yükleme yok, hesap yok",
+]
+
+[picker]
+title = "Kareleri buraya bırakın"
+hint = "ya da seçmek için tıklayın &mdash; JPEG, PNG, WebP, TIFF ve fotoğraf makinesi RAW"


### PR DESCRIPTION
Image stacking and its guide shipped after Turkish was last brought
level, so those two pages were still English while the other sixty-three
were not. This closes them, and fixes the same defect Arabic had.

## The dicom-viewer defect

`locales/tr/tools/dicom-viewer.html` carried **60 `data-phrase` spans
against the English 63**. The four missing ones were `net.clean`,
`net.dirty`, `net.platform.one` and `net.platform.many`.

Those are the sentences the **live network check** writes after a run, so
a Turkish reader was getting the frame's generic wording in exactly the
place where this tool makes its sharpest claim &mdash; that a medical
record went nowhere. Nothing broke; the page just said something blander
than every other language said.

The wording follows the `net.*` phrases already in
`locales/tr/tools/redact-pdf.html`, so the two pages agree.

## The two pages

- `locales/tr/tools/stack-images.{toml,html}`
- `locales/tr/pages/guides/stack-photos-to-reduce-noise.{toml,html}`
- two new `[slugs]` entries: `goruntu-istifleme` and
  `rehberler/gurultuyu-azaltmak-icin-fotograf-istifleme`

The guide slug names the **problem rather than the technique**, because
someone who stacks does not search for `istifleme`, they search for the
noise. Method names use what Turkish photography writing uses &mdash;
ortalama, medyan, sigma kırpma, odak istifleme. RAW and the format
abbreviations stay Latin.

## Verification

`python build.py --out _plain --clean --no-minify` exits 0 and Turkish is
**absent from the locale debt list** &mdash; 65 of 65.
`dicom-viewer.html` now has 63 spans, matching the English source. The
structural check passes clean with no findings. No CRLF anywhere under
`locales/tr/`.

This is the twelfth and last of the branches closing this hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
