### PR TITLE
Finish the alignment at output resolution, where its error cannot grow

### DIFF
--- a/tests/js/stack-images-plan.test.js
+++ b/tests/js/stack-images-plan.test.js
@@ -19,8 +19,8 @@ import assert from 'node:assert/strict';
 
 import {
   DEFAULT_BUDGET, MIN_BAND_ROWS, MODES, MODE_IDS, SCALES,
-  bands, bytesPerPixel, commonArea, isMode, outputSize, placement, planRun, scaleThatFits,
-  workingSize,
+  bands, bytesPerPixel, commonArea, isMode, outputSize, placement, planRun, refineMargin,
+  refineWindow, scaleThatFits, workingSize,
 } from '../../tools/stack-images/src/plan.js';
 
 const MEGAPIXEL_24 = { width: 6000, height: 4000 };
@@ -305,4 +305,32 @@ test('the crop never leaves the output, whatever it is handed', () => {
     assert.ok(area.y + area.height <= output.height, `${JSON.stringify(move)} ran off the bottom`);
     assert.ok(area.width > 0 && area.height > 0, `${JSON.stringify(move)} cropped to nothing`);
   }
+});
+
+test('the refinement window is the largest power of two the crop leaves room for', () => {
+  // The 16 held back is the two margins the crop gives up so that a refined
+  // frame still covers what the crop assumed; a window that ignored them would
+  // be measuring rows the run is about to throw away.
+  assert.equal(refineWindow({ width: 1575, height: 1179 }), 512);
+  assert.equal(refineWindow({ width: 4000, height: 3000 }), 512);
+  assert.equal(refineWindow({ width: 300, height: 528 }), 256);
+  assert.equal(refineWindow({ width: 100, height: 90 }), 64);
+});
+
+test('a crop too small to refine gets no window rather than a tiny one', () => {
+  // 64 minus the margins is the floor: below it the correlation peak is noise
+  // with a coordinate, and applying that is worse than keeping the coarse
+  // answer.
+  assert.equal(refineWindow({ width: 79, height: 200 }), 0);
+  assert.equal(refineWindow({ width: 16, height: 16 }), 0);
+});
+
+test('the margin matches how wrong the coarse answer can be', () => {
+  // The coarse error lives in the sub-pixel fraction of the shift, so a set
+  // that barely moved cannot have been mismeasured by much: it keeps a
+  // one-pixel allowance instead of being charged sixteen rows for nothing.
+  assert.equal(refineMargin([{ dx: 0, dy: 0 }, { dx: 0.2, dy: -0.3 }]), 1);
+  assert.equal(refineMargin([{ dx: 0, dy: 0 }, { dx: 7.3, dy: -4.6 }]), 8);
+  assert.equal(refineMargin([{ dx: 0, dy: 0 }, { dx: 0, dy: 0.6 }]), 8);
+  assert.equal(refineMargin([{}]), 1);
 });

--- a/tests/js/stack-images-stack.test.js
+++ b/tests/js/stack-images-stack.test.js
@@ -298,3 +298,16 @@ test('the alpha channel is written opaque rather than stacked', () => {
     assert.equal(stackFlat(mode, [10, 20, 30]).alpha, 255, `${mode} lost its alpha`);
   }
 });
+
+test('an option passed as undefined falls to its default rather than landing on it', () => {
+  // Spreading { gain: undefined } over { gain: 1 } keeps the undefined, the
+  // gain turns every channel into NaN, and NaN clamps to zero: a caller that
+  // skipped one option got an all-black picture with nothing thrown anywhere
+  // near the cause. Found the hard way, so pinned.
+  const { red, alpha } = stackFlat('mean', [100, 100], {
+    gain: undefined, kappa: undefined, radius: undefined,
+  });
+  assert.equal(red, 100);
+  assert.equal(alpha, 255);
+  assert.equal(stackFlat('sigma', [50, 50, 50], { kappa: undefined }).red, 50);
+});

--- a/tools/stack-images/README.md
+++ b/tools/stack-images/README.md
@@ -151,9 +151,27 @@ offset between them. One transform each finds a two-hundred-pixel shift as
 cheaply as a two-pixel one; searching offsets is quadratic in the range and
 would be the slowest thing in the tool.
 
-It runs on a 256-pixel square, because the offset between two frames of a burst
-is a property of the picture and not of its resolution. Measuring it there and
-multiplying up is as accurate as measuring it at 6000 across.
+It measures twice. The first pass runs on a 256-pixel square, which finds a
+two-hundred-pixel shift as cheaply as a two-pixel one — but only the *integer*
+part of the answer survives the trip back up. The sub-pixel part is estimated,
+and multiplying a 256-square answer up to 6000 across multiplies its estimation
+error by twenty-three: a twentieth of a pixel of fitting error comes back as
+more than a pixel of blur, per frame, which is exactly the softness the
+alignment exists to prevent. Measured on synthetic bursts with known shifts,
+the coarse answer alone was off by one to two output pixels per frame and the
+stack came out *worse* than a single input frame.
+
+So the answer is finished during the stack itself: when each frame's full-size
+decode is first in hand — a decode the stack was going to pay for anyway — a
+512-pixel window from the middle of the crop is correlated against the same
+window of the reference at output resolution, and the residual corrects the
+coarse answer in place. At output resolution there is nothing to multiply up,
+so a twentieth of a pixel of error stays a twentieth of a pixel. The same
+synthetic bursts land within a quarter of a pixel per frame. The residual is
+gated — a weak peak, or a correction larger than the coarse pass could
+plausibly have been wrong by, leaves the coarse answer alone — and the crop
+gives up a small margin on every side up front, because a frame that moves
+after the crop was decided stops covering ground the crop assumed.
 
 Rotation and scale come from the same trick applied twice: in log-polar
 coordinates a rotation *is* a shift along one axis and a scale *is* a shift
@@ -179,14 +197,25 @@ Two limits, both on the page:
 - rotation is only ever recovered within half a turn, because the magnitude
   spectrum of a real picture is symmetric and 175° looks exactly like −5°.
 
+The refinement corrects translation only. The angle and the scale keep the
+coarse pass's answer — good to roughly a tenth of a degree — and a tenth of a
+degree is a pixel and a half at the corner of a 24-megapixel frame, so a
+similarity stack keeps a corner softness its middle does not have. Refining
+them too would mean correlating the window at a spread of candidate angles,
+which is a different cost class, and the translation-only refinement already
+removes the error that affected every pixel equally.
+
 **Aligning means cropping, and the crop is not cosmetic.** A frame moved twenty
 pixels left stops covering the right-hand edge, whatever is not covered is
 transparent, and transparent reads as zero to an accumulator — so without the
 crop an averaged hand-held burst comes back with a dark border, which somebody
 would reasonably blame on the stacking. `commonArea` in `plan.js` returns the
 largest rectangle every frame still covers, taking the inner of each pair of
-corners so a rotated quad is handled conservatively. With no alignment every
-transform is the identity and nothing is cropped. A set that overlaps in almost
+corners so a rotated quad is handled conservatively. When the refinement is
+running, the crop then gives up `refineMargin`'s allowance on every side —
+eight pixels for a set that really moved, one for a set that did not — which is
+the room the refined corrections spend. With no alignment every transform is
+the identity, nothing is refined and nothing is cropped. A set that overlaps in almost
 nothing falls back to the whole frame rather than a sliver: a stack with visible
 edges is something a person can look at and understand, and a postage stamp is
 not.

--- a/tools/stack-images/src/fft.js
+++ b/tools/stack-images/src/fft.js
@@ -9,11 +9,11 @@
  * cost, and it is the cost that decides whether a tool can align twenty
  * 24-megapixel frames while somebody waits.
  *
- * It is used on small buffers. align.js resamples each frame down to a square
- * of 256 or 512 pixels a side before any of this runs, because the shift
- * between two frames of a burst is a property of the picture and not of its
- * resolution: finding it at 512 and multiplying up is as accurate as finding it
- * at 6000, and about a hundred and forty times less work.
+ * It is used on small buffers: the 256 square the coarse alignment runs in,
+ * and the 512 window the refinement correlates at output resolution. The whole
+ * frame never goes through it - the coarse square finds the large offset
+ * cheaply, and the window finishes the sub-pixel part where there is nothing
+ * to multiply back up. See "The alignment, and the sign" in the README.
  *
  * WHY IT IS WRITTEN OUT RATHER THAN IMPORTED
  *

--- a/tools/stack-images/src/pipeline.js
+++ b/tools/stack-images/src/pipeline.js
@@ -13,7 +13,12 @@
  *             range of the preview inside it. Kilobytes are read, not files
  *   survey    every frame is decoded once, small, for its thumbnail and for the
  *             luma square the alignment works on
- *   measure   each frame is correlated against the first to find how it moved
+ *   measure   each frame is correlated against the first to find how it moved.
+ *             This answer is coarse - it was read in a small square and
+ *             multiplied up, sub-pixel error and all - and is finished during
+ *             the stack, where each frame's first full-size decode is already
+ *             in hand and a window of it can be correlated at output
+ *             resolution, where sub-pixel error stays sub-pixel
  *   stack     the real work: bands, passes and frames, exactly as plan.js said
  *   encode    the accumulated picture is written out as PNG or JPEG
  *
@@ -31,8 +36,10 @@
  * and neither the fill nor the readback pays for rows nobody is looking at.
  */
 
-import { estimate, window2d } from './align.js';
-import { bands, commonArea, outputSize, placement, planRun, workingSize } from './plan.js';
+import { WEAK_PEAK, estimate, phaseCorrelate, window2d } from './align.js';
+import {
+  bands, commonArea, outputSize, placement, planRun, refineMargin, refineWindow, workingSize,
+} from './plan.js';
 import { findPreview, jpegSize, looksRaw } from './raw.js';
 import { createStack } from './stack.js';
 
@@ -45,8 +52,14 @@ import { createStack } from './stack.js';
  */
 export const ALIGN_SIZE = 256;
 
-/** How large a thumbnail the list shows. */
-const THUMB_SIZE = 160;
+/**
+ * How large the survey decode is. It is the picture the list shows, and it is
+ * also what the coarse alignment square is built from, which is why it matches
+ * ALIGN_SIZE rather than the hundred-odd pixels a list row needs: a 256 square
+ * fed from a smaller decode holds less picture than its own area, and the
+ * alignment can only be as good as what it is shown.
+ */
+const THUMB_SIZE = 256;
 
 /** Anything at least this big is a picture worth stacking. */
 const MIN_PREVIEW_PIXELS = 640 * 480;
@@ -252,6 +265,28 @@ function lumaSquare(bitmap, spot, output, fit) {
   return window2d(out, ALIGN_SIZE);
 }
 
+/**
+ * The luma window the refinement correlates, cut from the middle of the crop
+ * at output resolution, with the frame's coarse correction already applied.
+ *
+ * Drawn through drawAligned exactly as the stack will draw it - the window's
+ * corner standing in for the crop - so what the correlation sees is what the
+ * accumulator would have seen, and the residual it reports is in output pixels
+ * with nothing to multiply back up. That is the whole point of measuring
+ * twice: here, an error of a twentieth of a pixel is a twentieth of a pixel.
+ */
+function refineSquare(bitmap, spot, output, move, at, size) {
+  const { canvas, context } = surface(size, size);
+  drawAligned(context, bitmap, spot, output, move, at, 0);
+  const pixels = context.getImageData(0, 0, size, size).data;
+  const out = new Float64Array(size * size);
+  for (let i = 0, p = 0; i < out.length; i += 1, p += 4) {
+    out[i] = pixels[p] * 0.299 + pixels[p + 1] * 0.587 + pixels[p + 2] * 0.114;
+  }
+  canvas.width = 0;
+  return window2d(out, size);
+}
+
 /* -------------------------------------------------------------------- run */
 
 /**
@@ -349,6 +384,30 @@ export async function runStack(request, hooks) {
   // What every frame covers once moved. With no alignment this is the whole
   // output; with alignment it is the output less however far the frames went.
   const crop = commonArea(moves, output);
+
+  // The refinement the measure stage promised. The moves above were read in a
+  // small square and multiplied back up to output pixels, and the multiply-up
+  // scales their sub-pixel error with them - enough to blur the stack by more
+  // than it blurs a frame. So during the stack, when each frame's full-size
+  // decode is in hand anyway, a window of it is correlated against the same
+  // window of the reference at output resolution and the answer is corrected in
+  // place. It costs no extra decode, which is why it happens there and not
+  // here. The margin is the room those corrections need: a frame moved after
+  // the crop was decided stops covering ground the crop assumed, so the crop
+  // gives up that much on every side up front.
+  const refine = align === 'none' ? 0 : refineWindow(crop);
+  const margin = refine ? refineMargin(moves) : 0;
+  crop.x += margin;
+  crop.y += margin;
+  crop.width -= margin * 2;
+  crop.height -= margin * 2;
+  const refineAt = refine ? {
+    x: Math.round(crop.x + (crop.width - refine) / 2),
+    y: Math.round(crop.y + (crop.height - refine) / 2),
+  } : null;
+  let referenceWindow = null;
+  const refined = frames.map(() => false);
+
   const plan = planRun({
     width: crop.width, height: crop.height, frames: frames.length, mode,
     budget: request.budget,
@@ -385,6 +444,28 @@ export async function runStack(request, hooks) {
         const spot = placement(frame, output);
         const working = workingSize(frame.width, frame.height, 1);
         const bitmap = await decodeAt(frame.blob, working, spot);
+
+        // Each frame's first full-size appearance settles its final position.
+        // Later bands and passes reuse the answer, so a banded run stays
+        // consistent with itself. The gates keep a bad peak from undoing a
+        // good coarse answer: a window without enough texture to correlate, or
+        // a residual larger than the coarse pass could plausibly have been
+        // wrong by, leaves the frame where the coarse measurement put it.
+        if (refine && !refined[index]) {
+          refined[index] = true;
+          const square = refineSquare(bitmap, spot, output, moves[index], refineAt, refine);
+          if (index === 0) {
+            referenceWindow = square;
+          } else if (referenceWindow) {
+            const residual = phaseCorrelate(referenceWindow, square, refine);
+            if (residual.confidence >= WEAK_PEAK
+                && Math.abs(residual.dx) <= margin && Math.abs(residual.dy) <= margin) {
+              moves[index].dx += residual.dx;
+              moves[index].dy += residual.dy;
+            }
+          }
+        }
+
         context.setTransform(1, 0, 0, 1, 0, 0);
         context.clearRect(0, 0, crop.width, band.readRows);
         drawAligned(context, bitmap, spot, output, moves[index], crop, band.readY);

--- a/tools/stack-images/src/plan.js
+++ b/tools/stack-images/src/plan.js
@@ -302,6 +302,52 @@ export function commonArea(moves, output) {
 }
 
 /**
+ * The square the alignment's refinement pass measures in, or 0 when the crop
+ * has no room for one worth trusting.
+ *
+ * The coarse measurement happens in a small square and is multiplied back up,
+ * which multiplies its sub-pixel error with it - at 6000 pixels across, a
+ * twentieth of a pixel of estimation error comes back as more than one whole
+ * pixel of blur. The refinement corrects that by correlating a window cut from
+ * the frames at output resolution, where an error of a twentieth of a pixel is
+ * an error of a twentieth of a pixel. 512 is plenty of texture to lock onto;
+ * below 64 there is too little for the peak to mean anything, and no window is
+ * the honest answer.
+ *
+ * The 16 the window keeps back from the crop is the two margins the caller
+ * shrinks the crop by; asking for a window the margin then makes impossible
+ * would be answering a different question than the one asked.
+ */
+export function refineWindow({ width, height }) {
+  const room = Math.min(width, height) - 16;
+  if (room < 64) return 0;
+  let size = 64;
+  while (size * 2 <= Math.min(room, 512)) size *= 2;
+  return size;
+}
+
+/**
+ * How far the refinement may move a frame beyond its coarse answer, in output
+ * pixels. Also how much the crop must shrink on every side, because a frame
+ * moved after the crop was decided stops covering ground the crop assumed.
+ *
+ * The bound is the coarse pass's own error budget: its sub-pixel mistake is a
+ * fraction of one alignment-square pixel, which the multiply-up turns into a
+ * handful of output pixels. Eight covers that with room to spare. A set whose
+ * frames barely moved cannot have been mismeasured by much - the error lives
+ * in the sub-pixel fraction of the shift - so it keeps a one-pixel allowance
+ * and a tripod burst is not charged sixteen rows for a correction it does not
+ * need.
+ */
+export function refineMargin(moves) {
+  let most = 0;
+  for (const move of moves) {
+    most = Math.max(most, Math.abs(move.dx ?? 0), Math.abs(move.dy ?? 0));
+  }
+  return most < 0.5 ? 1 : 8;
+}
+
+/**
  * The largest scale whose plan fits the budget without banding, or null if even
  * the smallest one does not.
  *

--- a/tools/stack-images/src/stack.js
+++ b/tools/stack-images/src/stack.js
@@ -73,7 +73,16 @@ export function createStack(mode, options) {
   const { width, height, frames } = options;
   if (!(width > 0) || !(height > 0)) throw new RangeError('a band with no size');
   if (!(frames > 0)) throw new RangeError('a stack of no frames');
-  return build({ kappa: 2, gain: 1, radius: 3, ...options, pixels: width * height });
+  // A field passed explicitly as undefined must fall to its default rather
+  // than land on it: spreading `{ gain: undefined }` over `{ gain: 1 }` keeps
+  // the undefined, the gain multiplies every channel into NaN, and NaN clamps
+  // to zero - a caller that skipped one option gets an all-black picture with
+  // nothing thrown anywhere near the cause.
+  const given = {};
+  for (const [key, value] of Object.entries(options)) {
+    if (value !== undefined) given[key] = value;
+  }
+  return build({ kappa: 2, gain: 1, radius: 3, ...given, pixels: width * height });
 }
 
 /**


### PR DESCRIPTION
## What was wrong

The stacker's alignment measured each frame's shift in a 256-pixel square and multiplied the answer up to output size — which multiplies the sub-pixel estimation error with it, ×6 at 1600 across and ×23 at 6000. The square was also fed from the 160-pixel list thumbnail, so it held less picture than its own area. Measured end-to-end on synthetic bursts with known shifts (6 frames, noise σ=10, shifts up to 13 px), frames landed **0.2–1.6 px off**, and the averaged stack came out *farther from the true picture than a single noisy input frame* (RMS 17.1 vs 9.9 against ground truth, two-thirds of the Laplacian detail gone). That is the "stacked but soft" result a visitor reasonably blames on the stacking — while the result panel says every frame was moved into place.

## What changed

The coarse 256-square measurement stays — it finds a 200-pixel shift as cheaply as a 2-pixel one. It is now the first half of the answer: during the stack, when each frame's full-size decode is in hand anyway, a 512-pixel window from the middle of the crop is correlated against the same window of the reference **at output resolution**, and the residual corrects the move in place. At output resolution there is nothing to multiply up.

- **No extra decodes.** The refine reuses the stack loop's own decode, so the "Frames decoded" figure the page quotes stays true, and no visitor-facing string changes (nothing for the ten locales).
- **A small crop margin** pays for it — a correction made after the crop was decided needs room. `refineMargin` charges 8 px per side for a set that really moved, 1 px for a tripod set.
- The survey decode grows from 160 to 256 so the coarse square is no longer fed less picture than it measures.
- Gates: a weak correlation peak, or a residual larger than the coarse pass could plausibly be wrong by, leaves the coarse answer alone.
- Also fixed while verifying: `createStack`'s documented defaults were dead through `runStack` — `{ gain: 1, ...options }` with `options.gain === undefined` keeps the `undefined`, and the NaN it produces clamps to an **all-black picture**. Unreachable from the page (it always sends every option) but now pinned by a test.

## Measured, same seed before and after

| burst (6 frames, σ=10, shifts ≤13 px, mean + shift-only align) | before | after | ideal (true shifts) |
|---|---|---|---|
| per-frame alignment error | 0.2–1.6 px | **0.00–0.28 px** | — |
| RMS vs clean ground truth | 17.07 | **7.96** | 8.13 |
| detail kept (mean \|Laplacian\|; clean = 38.3) | 12.37 | **20.94** | 20.04 |
| single noisy input frame, for scale | RMS 9.90 | | |

The fixed stack sits at the ceiling of what sub-pixel bilinear stacking can reach — indistinguishable from aligning with the true shifts.

Regressions checked: a tripod set still stacks to RMS 4.08 (theoretical σ/√6 = 4.08) and loses only ~3 px of border to the margin; alignment "No" is byte-identical in behaviour; the worker/UI path produces the same output as the pipeline.

## What this does not fix

Rotation-and-scale mode keeps its coarse angle (~0.1–0.25° error), so a similarity stack keeps some corner softness the middle no longer has — the refinement corrects translation only, and the README now says so. Refining the angle means correlating the window at a spread of candidate angles, a different cost class, left for its own change.

Both suites pass: 1886 JS (4 new), Python generator suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)