### PR TITLE
Darken the light-mode green a step, for the one place it fell short

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -16,7 +16,7 @@
   --accent-deep: #1d4f83;
   --accent-pale: #d7e7f7;
   --danger: #b02b2b;
-  --ok: #1f7a4d;
+  --ok: #1a6a43;
   --radius: 10px;
   --shadow: 0 1px 2px rgb(16 24 40 / 6%), 0 4px 12px rgb(16 24 40 / 4%);
 }

--- a/shared/site.css
+++ b/shared/site.css
@@ -20,7 +20,7 @@
   /* Green means "this is true" across the site: the pledge ticks on a tool page
      use it, and so does the Built tag on the roadmap. Same values as
      shared/css/tool-frame.css, which defines it for the tool pages. */
-  --ok: #1f7a4d;
+  --ok: #1a6a43;
   --radius: 10px;
   --shadow: 0 1px 2px rgb(16 24 40 / 6%), 0 4px 12px rgb(16 24 40 / 4%);
 }


### PR DESCRIPTION
Found by the QA suite's new accessibility pass — the first time a scan ever touched the roadmap page.

The **Built** tag sets `var(--ok)` on a 12% tint of itself, and that tinted background drops the pair to **4.23:1** — under the 4.5:1 WCAG AA asks of text this size. Everywhere else the same green sits on the plain page and clears the bar comfortably; the tag was the one place it didn't.

## The change

Light palette only: `--ok` goes `#1f7a4d` → `#1a6a43`, in both stylesheets that define it (they are one palette written twice, and a hub whose green subtly disagreed with the tool pages' would be a new problem in the middle of fixing an old one).

| where | before | after |
|---|---|---|
| Built tag (tinted bg) | 4.23:1 ✗ | **5.24:1** ✓ |
| same green on plain page | ~5.4:1 | ~6.0:1 |
| dark palette (`#6cc79b`, untouched) | ~6.8:1 | ~6.8:1 |

Margin rather than a squeak past the threshold, and visually a near-identical green.

Verified: rebuilt, axe re-scanned the roadmap (clean), plus the hub and a tool page in both light and dark (still clean, so the global darkening broke nothing).

Note: the QA suite's roadmap scan will run **red against production until this deploys** — deliberately; it is a real defect and the suite should say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)