### PR TITLE
Let a keyboard scroll the tag table

### DIFF
--- a/locales/ar/tools/dicom-viewer.html
+++ b/locales/ar/tools/dicom-viewer.html
@@ -133,7 +133,7 @@
   <!-- Every tag in the file. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>كل وسم في الملف</h2>
+      <h2 id="tags-heading">كل وسم في الملف</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">ابحث في الوسوم</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="ابحث بالاسم أو الرقم أو القيمة">
@@ -142,7 +142,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">كل عنصر في هذا الملف</caption>
         <thead>

--- a/locales/de/tools/dicom-viewer.html
+++ b/locales/de/tools/dicom-viewer.html
@@ -146,7 +146,7 @@
   <!-- Jeder Tag in der Datei. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Jeder Tag in der Datei</h2>
+      <h2 id="tags-heading">Jeder Tag in der Datei</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Tags durchsuchen</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Nach Name, Nummer oder Wert suchen">
@@ -155,7 +155,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Jedes Element in dieser Datei</caption>
         <thead>

--- a/locales/es/tools/dicom-viewer.html
+++ b/locales/es/tools/dicom-viewer.html
@@ -146,7 +146,7 @@
   <!-- Cada etiqueta del archivo. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Cada etiqueta del archivo</h2>
+      <h2 id="tags-heading">Cada etiqueta del archivo</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Buscar en las etiquetas</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Buscar por nombre, número o valor">
@@ -155,7 +155,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Cada elemento de este archivo</caption>
         <thead>

--- a/locales/fr/tools/dicom-viewer.html
+++ b/locales/fr/tools/dicom-viewer.html
@@ -146,7 +146,7 @@
   <!-- Chaque étiquette du fichier. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Chaque étiquette du fichier</h2>
+      <h2 id="tags-heading">Chaque étiquette du fichier</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Rechercher dans les étiquettes</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Rechercher par nom, numéro ou valeur">
@@ -155,7 +155,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Chaque élément de ce fichier</caption>
         <thead>

--- a/locales/hi/tools/dicom-viewer.html
+++ b/locales/hi/tools/dicom-viewer.html
@@ -145,7 +145,7 @@
   <!-- फ़ाइल का हर टैग। -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>फ़ाइल का हर टैग</h2>
+      <h2 id="tags-heading">फ़ाइल का हर टैग</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">टैग खोजें</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="नाम, नंबर या मान से खोजें">
@@ -154,7 +154,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">इस फ़ाइल का हर एलिमेंट</caption>
         <thead>

--- a/locales/id/tools/dicom-viewer.html
+++ b/locales/id/tools/dicom-viewer.html
@@ -146,7 +146,7 @@
   <!-- Setiap tag di dalam file-nya. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Setiap tag di dalam file-nya</h2>
+      <h2 id="tags-heading">Setiap tag di dalam file-nya</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Cari di tagnya</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Cari menurut nama, nomor, atau nilai">
@@ -155,7 +155,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Setiap elemen di dalam file ini</caption>
         <thead>

--- a/locales/it/tools/dicom-viewer.html
+++ b/locales/it/tools/dicom-viewer.html
@@ -146,7 +146,7 @@
   <!-- Ogni tag del file. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Ogni tag del file</h2>
+      <h2 id="tags-heading">Ogni tag del file</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Cerca tra i tag</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Cerca per nome, numero o valore">
@@ -155,7 +155,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Ogni elemento di questo file</caption>
         <thead>

--- a/locales/ja/tools/dicom-viewer.html
+++ b/locales/ja/tools/dicom-viewer.html
@@ -139,7 +139,7 @@
   <!-- ファイルのすべてのタグ。 -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>ファイルのすべてのタグ</h2>
+      <h2 id="tags-heading">ファイルのすべてのタグ</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">タグを検索</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="名前・番号・値で検索">
@@ -148,7 +148,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">このファイルのすべての要素</caption>
         <thead>

--- a/locales/ko/tools/dicom-viewer.html
+++ b/locales/ko/tools/dicom-viewer.html
@@ -144,7 +144,7 @@
   <!-- 파일의 모든 태그. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>파일의 모든 태그</h2>
+      <h2 id="tags-heading">파일의 모든 태그</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">태그 검색</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="이름, 번호, 값으로 검색">
@@ -153,7 +153,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">이 파일의 모든 요소</caption>
         <thead>

--- a/locales/nl/tools/dicom-viewer.html
+++ b/locales/nl/tools/dicom-viewer.html
@@ -146,7 +146,7 @@
   <!-- Elke tag in het bestand. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Elke tag in het bestand</h2>
+      <h2 id="tags-heading">Elke tag in het bestand</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Tags doorzoeken</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Zoek op naam, nummer of waarde">
@@ -155,7 +155,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Elk element in dit bestand</caption>
         <thead>

--- a/locales/pt/tools/dicom-viewer.html
+++ b/locales/pt/tools/dicom-viewer.html
@@ -146,7 +146,7 @@
   <!-- Cada tag do arquivo. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Cada tag do arquivo</h2>
+      <h2 id="tags-heading">Cada tag do arquivo</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Pesquisar nas tags</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Pesquise por nome, número ou valor">
@@ -155,7 +155,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Cada elemento deste arquivo</caption>
         <thead>

--- a/locales/tr/tools/dicom-viewer.html
+++ b/locales/tr/tools/dicom-viewer.html
@@ -145,7 +145,7 @@
   <!-- Every tag in the file. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Dosyadaki her etiket</h2>
+      <h2 id="tags-heading">Dosyadaki her etiket</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Etiketlerde ara</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Ada, numaraya ya da değere göre ara">
@@ -154,7 +154,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Bu dosyadaki her öğe</caption>
         <thead>

--- a/locales/zh-TW/tools/dicom-viewer.html
+++ b/locales/zh-TW/tools/dicom-viewer.html
@@ -141,7 +141,7 @@
   <!-- 檔案裡的每一個標籤。 -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>檔案裡的每一個標籤</h2>
+      <h2 id="tags-heading">檔案裡的每一個標籤</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">搜尋標籤</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="按名字、編號或者數值搜尋">
@@ -150,7 +150,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">這個檔案裡的每一個元素</caption>
         <thead>

--- a/locales/zh/tools/dicom-viewer.html
+++ b/locales/zh/tools/dicom-viewer.html
@@ -141,7 +141,7 @@
   <!-- 文件里的每一个标签。 -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>文件里的每一个标签</h2>
+      <h2 id="tags-heading">文件里的每一个标签</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">搜索标签</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="按名字、编号或者数值搜索">
@@ -150,7 +150,7 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">这个文件里的每一个元素</caption>
         <thead>

--- a/tools/dicom-viewer/body.html
+++ b/tools/dicom-viewer/body.html
@@ -149,7 +149,7 @@
          that ends up out of view is Value, which is the whole point of the
          page. role and aria-labelledby give the stop a name when it gets
          one, borrowed from the heading above so there is no new string for
-         eleven locales to translate. -->
+         fourteen locales to translate. -->
     <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Every element in this file</caption>

--- a/tools/dicom-viewer/body.html
+++ b/tools/dicom-viewer/body.html
@@ -134,7 +134,7 @@
   <!-- Every tag in the file. -->
   <section class="card" id="tags-card" hidden>
     <div class="toolbar">
-      <h2>Every tag in the file</h2>
+      <h2 id="tags-heading">Every tag in the file</h2>
       <div class="toolbar-actions">
         <label for="tag-search" class="visually-hidden">Search the tags</label>
         <input type="search" id="tag-search" class="tag-search" placeholder="Search by name, number or value">
@@ -143,7 +143,14 @@
 
     <p class="card-lede" id="tags-lede"></p>
 
-    <div class="table-wrap">
+    <!-- Focusable, because it scrolls. A box with overflow can be dragged
+         sideways with a mouse and reached with a finger, but without a tab
+         stop a keyboard cannot move it at all - and on this tool the column
+         that ends up out of view is Value, which is the whole point of the
+         page. role and aria-labelledby give the stop a name when it gets
+         one, borrowed from the heading above so there is no new string for
+         eleven locales to translate. -->
+    <div class="table-wrap" tabindex="0" role="region" aria-labelledby="tags-heading">
       <table class="tags">
         <caption class="visually-hidden">Every element in this file</caption>
         <thead>


### PR DESCRIPTION
Found by the QA suite's new accessibility pass — which scans tool pages with a file **actually loaded**, not just at rest. This state had never been scanned before, because until now nothing opened a file and looked.

## The defect

`.table-wrap` holds the table of every tag in a DICOM file. It's wider than a phone and can't honestly be narrowed, so it scrolls sideways in its own box. A mouse can drag it; a finger can swipe it. **A keyboard could not move it at all** — no tab stop, so nothing could focus it and nothing could send it an arrow key.

The column that ends up out of view is **Value** — on the tool whose entire purpose is showing people what their medical images carry about them.

axe rates it `scrollable-region-focusable`, serious.

## The fix

`tabindex="0"` for the stop; `role="region"` + `aria-labelledby` pointing at the heading above so the stop has a name when it lands — borrowed from existing translated text, so **no new string arrives for 14 locales**.

## Applied to all 15 copies, not just English

Each locale keeps its own translated copy of the tool body under `locales/<lang>/tools/`, so editing `tools/dicom-viewer/body.html` alone would have fixed this for English readers and left everyone else exactly as stuck. Structural attributes only — no translated text touched.

Worth flagging separately: **nothing currently checks that those copies still match structurally.** (#124's trust block did reach all 14, so this isn't systematically broken — but it's unguarded.) I can add a parity check to the QA suite if you want it.

Verified: rebuilt, and the DICOM loaded-state scan passes on both Desktop and Mobile Chrome. 15 of 15 real pages carry the change; the 5 that don't are stale local `dist` directories from before those slugs were translated, and production 404s on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)