### PR TITLE
Keep automated browsers out of the analytics

### DIFF
--- a/templates/analytics.js
+++ b/templates/analytics.js
@@ -32,5 +32,25 @@ function gtag() { dataLayer.push(arguments); }
 // everything in every test.
 window.gtag = gtag;
 
+// An automated browser is not a visit, and says as much: Playwright, Selenium
+// and Puppeteer all set navigator.webdriver. This site's own QA suite opens
+// every page several times a day, and without this every one of those loads
+// arrives as a session - a bounce rate, a country, an audience of robots
+// averaged in with the people the numbers are kept for.
+//
+// `ga-disable-<id>` is Google's own switch rather than something invented
+// here, and it is the reason this is two lines and not a fork in the code
+// below: gtag stays defined and callable, so this file, shared/feedback.js
+// and anything else that calls it carry on working unchanged. The calls
+// simply stop leaving the machine.
+//
+// It is set before the config call below, which is what sends the page view;
+// the tag script above is async and sends nothing on its own. Deliberately
+// not an inline script in the head, for the same CSP reason this whole file
+// exists.
+if (navigator.webdriver) {
+  window['ga-disable-{{ site.analytics_id }}'] = true;
+}
+
 gtag('js', new Date());
 gtag('config', '{{ site.analytics_id }}');


### PR DESCRIPTION
The QA suite opens every page on this site several times a day, in fifteen languages, across two device profiles. **Every one of those loads arrived in Google Analytics as a session** — a bounce rate, a country, a device mix, an audience of robots averaged in with the people the numbers are kept for. The busiest visitor to this site was the thing checking it still worked.

## The change

Automated browsers announce themselves — Playwright, Selenium and Puppeteer all set `navigator.webdriver`. Where that's set, the page now sets `ga-disable-<id>` before the `config` call that sends the page view.

Two reasons this is two lines rather than a fork in the code:

- **`ga-disable` is Google's own switch**, so `gtag` stays defined and callable. This file and `shared/feedback.js` carry on unchanged; the calls simply stop leaving the machine.
- **It lives in `analytics.js`, not inline in the head** — for the same reason this file exists at all: an inline script would need `script-src 'unsafe-inline'`, which would permit every other inline script too.

It excludes *any* automation, not just this project's. That's intended, not a side effect — a crawler driving a real browser isn't a reader either.

## Verified, including the half that matters

Against a local build, both device profiles:

| | `ga-disable` | `gtag` | hits sent |
|---|---|---|---|
| `navigator.webdriver` true (the suite) | set | still a function | **0** |
| overridden to false (an ordinary visitor) | absent | function | **3** |

The second row is the important one. *"No hits"* on its own is also exactly what a tag that had stopped working entirely would look like — which is precisely how the Cloudflare beacon on this site sat dead behind its own CSP until something went looking.

The QA suite now carries both checks permanently ([qa `tests/analytics.spec.ts`](https://github.com/A-Box-of-Tools/qa/blob/main/tests/analytics.spec.ts)), so a future regression in either direction is caught. Its measurement hits are intercepted and answered with a 204, so the test that verifies robots aren't counted doesn't itself put robot traffic in the numbers.

**Note:** that spec runs red against production until this merges and deploys — correctly, since until then the traffic really is being counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)