### PR TITLE
Tell Bing what changed, from the dates the sitemap already keeps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,14 @@ jobs:
             git -C .publish checkout --orphan dist
           fi
 
+          # The sitemap as it is deployed right now, saved before the line
+          # below deletes it. It is the baseline the IndexNow step diffs
+          # against to work out which pages actually changed, and this is the
+          # last moment it exists.
+          if [ -f .publish/sitemap.xml ]; then
+            cp .publish/sitemap.xml "$RUNNER_TEMP/deployed-sitemap.xml"
+          fi
+
           # Replace the tree wholesale rather than copying over it: a page that
           # was deleted from the sources has to disappear from the branch too.
           git -C .publish rm -rq --cached . --ignore-unmatch
@@ -168,6 +176,58 @@ jobs:
           subject=$(git log -1 --pretty=%s "$SHA")
           git -C .publish commit -m "Build ${SHA:0:7}: ${subject}"
           git -C .publish push origin dist
+
+      # Bing, Yandex, Seznam and Naver accept being told that a page changed,
+      # and fetch it within hours instead of whenever a crawler next comes
+      # round. Google takes no part in this and is still reached through the
+      # sitemap alone; see the comment at the top of indexnow.py, which also
+      # explains why the URLs come from a diff of the two sitemaps rather than
+      # from a diff of the deployed files.
+      #
+      # It runs after the publish, deliberately: it announces pages that are
+      # already live, and a URL submitted a minute before it exists is fetched,
+      # found stale, and believed.
+      #
+      # It cannot fail the workflow. The deploy has already happened by now and
+      # a refused submission does not undo it, so a red run here would say
+      # something untrue about the build. The status goes to the step summary
+      # instead, and the step marks itself failed without stopping the job.
+      - name: Tell IndexNow what changed
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+
+          status=0
+          python indexnow.py \
+            --old "$RUNNER_TEMP/deployed-sitemap.xml" \
+            --new _site/sitemap.xml \
+            --out "$RUNNER_TEMP/submitted.txt" \
+            --submit || status=$?
+
+          {
+            echo '### IndexNow'
+            echo
+            # The list is written even when it is empty, so a missing file
+            # means the script did not get that far - which is worth reading
+            # as nothing submitted rather than as an error in the summary.
+            count=0
+            if [ -f "$RUNNER_TEMP/submitted.txt" ]; then
+              count=$(wc -l < "$RUNNER_TEMP/submitted.txt")
+            fi
+            if [ "$count" -gt 0 ]; then
+              if [ "$count" -eq 1 ]; then echo 'Submitted 1 URL:'
+              else echo "Submitted $count URLs:"; fi
+              echo
+              echo '```'
+              cat "$RUNNER_TEMP/submitted.txt"
+              echo '```'
+            else
+              echo 'No page moved its `lastmod`, so nothing was submitted.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit $status
 
       - name: Summary
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,15 @@ of them but one. Put it in the markup - `#phrases` in the tool's `body.html`, or
 it asks. A module too deep to reach the DOM returns a *key* and lets the caller
 resolve it. See "The strings in the JavaScript" in [README.md](README.md).
 
+**`lastmod` now decides who hears about a change.** It used to be a hint in
+`sitemap.xml`; since `indexnow.py` joined the deploy it is also the signal that
+tells Bing which pages to refetch. Change the wording on a page and leave its
+`lastmod` alone and the deploy announces nothing — the change is live and no
+crawler is told. The reverse is worse: bumping every date to be safe submits
+the whole site and spends the host's standing with the protocol. Bump the dates
+that moved. See "Telling the search engines a page changed" in
+[docs/deploying.md](docs/deploying.md).
+
 **Some modules are deliberately copied, and must stay in step.** The MP4
 reader is in five tools and the writer in two, because the rule above blocks
 sharing them. `tests/python/test_duplicates.py` declares which copies must

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -147,6 +147,95 @@ address. If the site ever answers on a second hostname — a staging deployment,
 mirror, `www`, the `github.io` address — this keeps search engines treating one of
 them as the original rather than splitting the ranking between duplicates.
 
+## Telling the search engines a page changed
+
+A sitemap is an invitation, not a notification: it says what exists and leaves
+the timing to the crawler, which is why a new tool can sit unindexed for weeks.
+Half of that is fixable and half is not, and the two halves are worth keeping
+straight.
+
+**Bing, Yandex, Seznam and Naver take IndexNow.** POST a list of URLs and a key
+that proves the host is yours, and they fetch them within hours.
+
+**Google does not, and there is no equivalent.** It does not participate in
+IndexNow. Its Indexing API only accepts `JobPosting` and `BroadcastEvent`
+markup, so a tool page submitted there is discarded — and using it for anything
+else is against its terms, whatever the blog posts say. The sitemap ping
+endpoint was withdrawn in 2023. What is left is *URL Inspection → Request
+indexing* in Search Console, by hand, about a dozen a day: useful for a page
+that has just launched, useless against a thousand. For Google, indexing speed
+is an outcome of crawl budget and how much the site is worth crawling, not
+something a deploy can ask for.
+
+So the deploy submits to IndexNow and leaves Google to the sitemap.
+
+### Which URLs get submitted
+
+This is the whole design, and the obvious answer is wrong. A diff of the
+deployed files would submit almost every page almost every time: the footer
+lists every tool, so shipping one rewrites all thousand-odd pages, and a change
+to the frame or the stylesheet rewrites them without moving a word anybody
+reads. Submitting URLs that did not change is how a host stops being trusted
+with the protocol, which would cost the site the one lever it has here.
+
+What does track real change is already in the repository. `lastmod` in
+`sitemap.xml` is one date per page, written by hand in `tool.toml` and
+`config/site.toml`, and moved only when the wording on that page moves — see
+the comment in [`templates/sitemap.xml`](../templates/sitemap.xml). So
+[`indexnow.py`](../indexnow.py) compares the sitemap about to be deployed
+against the one already deployed, and submits the entries that are new or whose
+date moved:
+
+| What changed | What is submitted |
+|---|---|
+| A tool's wording, with its `lastmod` bumped | that tool, in all fifteen languages |
+| A new tool | its pages, and the hubs, if their dates moved |
+| The footer, the CSS, the build | nothing |
+
+Because the list comes from the sitemap rather than from the output directory,
+it inherits every rule the sitemap already applies: an untranslated page is not
+in it, a locale still being translated is not in it, and the redirect stub left
+behind by a renamed tool is not in it either.
+
+The [Build workflow](../.github/workflows/build.yml) saves the deployed
+`sitemap.xml` before it replaces the `dist` tree, and submits after the push —
+announcing a URL a minute before it exists gets it fetched, found stale, and
+believed. The step cannot fail the build: by the time it runs the deploy has
+happened, and a refused submission does not undo it. It writes what it sent to
+the run summary instead.
+
+To see what a deploy would submit, without submitting it:
+
+```bash
+python indexnow.py --old deployed-sitemap.xml --new _site/sitemap.xml
+```
+
+### The key file
+
+`shared/dce2cc4dac3134c897d6caccad94d0c2.txt` contains that same hex string and
+nothing else. `shared/` is copied to the site root, so it is served at
+`https://abox.tools/dce2cc4dac3134c897d6caccad94d0c2.txt`, which is where the
+protocol looks to confirm that whoever submitted the URLs controls the host.
+
+**It is not a secret.** Publishing it is the point. What matters is that it and
+the `KEY` constant in `indexnow.py` stay identical: a submission carrying a key
+the file does not match is accepted, fails validation out of band, and is
+dropped without an error anywhere. `tests/python/test_indexnow.py` asserts the
+two agree, which is the only thing standing between that and silence.
+
+The file has no explanatory comment at the top, unlike everything else in
+`shared/`, because the format has no room for one — the key is the entire
+contents.
+
+### Cloudflare's Crawler Hints
+
+*Caching → Configuration → Crawler Hints* in the dashboard is a second,
+independent route to the same protocol: Cloudflare notices content changing at
+the edge and sends IndexNow itself. It is one toggle and it costs nothing, so it
+is worth having on, but it is a guess made from cache behaviour rather than from
+the dates in the sitemap. The workflow above is the accurate one; this is a net
+underneath it.
+
 ## HTTPS
 
 Service workers require a secure context, so offline mode activates on `https://`

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -73,6 +73,7 @@ LICENSE-CONTENT          CC BY 4.0: the words the site publishes
 package.json             says the .js files are ES modules; no dependencies
 og-image.ps1             draws the share cards and the icons from shared/logo.svg
 serve.ps1                builds, then serves dist/ locally
+indexnow.py              tells Bing which pages a deploy actually changed
 cloudflare/              the edge config that adds the security headers
 ```
 

--- a/indexnow.py
+++ b/indexnow.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Tell the search engines that accept being told, about the pages that changed.
+
+IndexNow is a small protocol: POST a list of URLs plus a key that proves the
+host is yours, and Bing, Yandex, Seznam and Naver fetch them within hours
+rather than whenever a crawler next comes round. Google does not take part.
+There is no equivalent for it either - its Indexing API is restricted to job
+postings and livestreams, and a tool page submitted there is discarded - so
+Google is still reached the slow way, through the sitemap, and nothing here
+changes that.
+
+The only real question is which URLs to send, and this repository already
+answers it. A byte diff of the deployed tree is the obvious idea and it is
+wrong: the footer lists every tool, so shipping one rewrites all six hundred
+pages, and a change to the frame rewrites them without moving a word anybody
+reads. What does track real change is `lastmod` in sitemap.xml - one date per
+page, written by hand, moved only when that page's wording moves, for the
+reasons set out in templates/sitemap.xml. So this compares the sitemap about
+to be deployed against the one already deployed, and sends the entries that
+are new or whose date moved. A frame change sends nothing, which is correct.
+
+Sending more than that is not free. Pushing URLs that did not change is how a
+host stops being trusted with the protocol, and that trust is the only lever
+the site has here.
+
+Two sitemaps in, the list of URLs out:
+
+    python indexnow.py --old deployed/sitemap.xml --new _site/sitemap.xml
+
+Add --submit to actually send them. The key is deliberately not a secret: it
+is served at the site root, because being able to fetch it there is how the
+protocol proves the sender owns the host.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from urllib.parse import quote, urlsplit, urlunsplit
+
+# The key, and the name of the file it is served from. The two cannot be
+# allowed to drift - a key file that does not match what was submitted fails
+# validation and the submission is dropped without saying so - which is why
+# tests/python/test_indexnow.py asserts that shared/<KEY>.txt exists and holds
+# exactly this string. build.py copies shared/ to the site root, so putting
+# the file there is the whole of publishing it.
+KEY = 'dce2cc4dac3134c897d6caccad94d0c2'
+
+# The shared endpoint, which forwards one submission to every participating
+# engine. Posting to bing.com/indexnow directly would reach only Bing.
+ENDPOINT = 'https://api.indexnow.org/indexnow'
+
+# The protocol's own ceiling on a single request. Nothing this site can
+# honestly do comes close - the largest real change is one new tool in fifteen
+# languages - so reaching it means the caller asked for something it did not
+# mean, and saying so beats quietly sending the first ten thousand.
+MAX_URLS = 10000
+
+SITEMAP_NS = 'http://www.sitemaps.org/schemas/sitemap/0.9'
+
+
+def read_sitemap(path):
+    """A sitemap as {url: lastmod}, in the order it lists them.
+
+    The order is worth keeping: within each language the sitemap runs hub,
+    tools, guides, roadmap, legal, so a submission built from it arrives in
+    the order the site would like the pages read.
+    """
+    root = ET.fromstring(pathlib.Path(path).read_bytes())
+    pages = {}
+    for url in root.findall(f'{{{SITEMAP_NS}}}url'):
+        loc = url.findtext(f'{{{SITEMAP_NS}}}loc')
+        if loc is None:
+            continue
+        lastmod = url.findtext(f'{{{SITEMAP_NS}}}lastmod') or ''
+        pages[loc.strip()] = lastmod.strip()
+    return pages
+
+
+def changed(old, new):
+    """The URLs worth submitting: the new ones, and the ones whose date moved.
+
+    A URL that has left the sitemap is not returned. IndexNow does accept a
+    removed page - it gets fetched, found to be gone, and dropped - but a tool
+    retired here becomes a redirect stub rather than a 404, so the address
+    goes on answering 200 and there is nothing to report. Submitting URLs that
+    do not resolve is also a quick way to spend the host's standing with the
+    protocol.
+    """
+    return [url for url, lastmod in new.items()
+            if url not in old or old[url] != lastmod]
+
+
+def host_of(urls):
+    """The one host every URL shares, or an error naming what disagreed.
+
+    A submission carries a host and a key location beside the list, and every
+    URL in the list has to be on that host or the request is rejected whole.
+    Deriving it from the URLs rather than reading it from config is what stops
+    the two from ever disagreeing.
+    """
+    hosts = {urlsplit(url).netloc for url in urls}
+    if len(hosts) != 1:
+        raise ValueError(f'expected one host, found {sorted(hosts)}')
+    return hosts.pop()
+
+
+def as_uri(url):
+    """A sitemap loc, percent-encoded so it is a URI and not just an IRI.
+
+    Nine of the fifteen languages have slugs that are not ASCII - Arabic,
+    Hindi, Japanese, Korean, both Chinese - and the sitemap carries them as the
+    characters themselves. That is what a person reads, and it is what the site
+    links to, so it is what stays in the sitemap and in everything this script
+    prints. But a URI is defined over ASCII, and the far end is entitled to
+    reject anything else, so the escaping happens here at the last moment
+    rather than being pushed back into the sitemap.
+
+    Only the path is touched. The host is ASCII and the site has no query
+    strings, and quoting a '/' or a ':' would break the address rather than
+    encode it.
+    """
+    parts = urlsplit(url)
+    return urlunsplit(parts._replace(path=quote(parts.path, safe='/')))
+
+
+def submit(urls, endpoint=ENDPOINT, key=KEY, opener=urllib.request.urlopen):
+    """POST the list, and return the HTTP status.
+
+    200 is accepted. 202 is accepted with the key still to be validated, which
+    is the ordinary answer to a first submission from a host and not a
+    problem. Anything else is worth reading, so it is printed rather than
+    raised: by the time this runs the deploy has already happened, and a
+    refused submission is not a reason to paint it red.
+    """
+    host = host_of(urls)
+    body = json.dumps({
+        'host': host,
+        'key': key,
+        'keyLocation': f'https://{host}/{key}.txt',
+        'urlList': [as_uri(url) for url in urls],
+    }).encode('utf-8')
+    request = urllib.request.Request(
+        endpoint, data=body, method='POST',
+        headers={'Content-Type': 'application/json; charset=utf-8'})
+    try:
+        with opener(request, timeout=30) as response:
+            return response.status
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode('utf-8', 'replace').strip()[:500]
+        print(f'{error.code} {error.reason}: {detail}', file=sys.stderr)
+        return error.code
+
+
+def main(argv=None):
+    # A hundred and thirty-seven of this site's URLs are Arabic, Hindi,
+    # Japanese, Korean or Chinese rather than ASCII, and a Windows console
+    # defaults to a codepage that cannot spell them: printing the list raises
+    # UnicodeEncodeError and takes an otherwise working submission down with
+    # it. Say which encoding these streams speak instead of inheriting a guess.
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, 'reconfigure'):
+            stream.reconfigure(encoding='utf-8')
+
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('--new', required=True,
+                        help='the sitemap about to be deployed')
+    parser.add_argument('--old',
+                        help='the sitemap already deployed; leaving it out, '
+                             'or naming a file that is not there, means there '
+                             'is no baseline and nothing is sent')
+    parser.add_argument('--all', action='store_true',
+                        help='every URL in --new, whatever --old says; for a '
+                             'deliberate resubmission, not for a deploy')
+    parser.add_argument('--submit', action='store_true',
+                        help='send them. Without it the list is only printed')
+    parser.add_argument('--out', help='also write the list to this file')
+    args = parser.parse_args(argv)
+
+    new = read_sitemap(args.new)
+    if args.all:
+        urls = list(new)
+    elif args.old and pathlib.Path(args.old).exists():
+        urls = changed(read_sitemap(args.old), new)
+    else:
+        # No baseline: the first run after this was added, or a dist branch
+        # being created from scratch. Submitting the whole site is precisely
+        # the noise this script exists to avoid, and it would tell the engines
+        # nothing the sitemap does not already tell them - so send nothing and
+        # let the next deploy have something to compare against. --all is
+        # there for when somebody really does mean the whole site.
+        print('no previous sitemap to compare against; nothing to submit',
+              file=sys.stderr)
+        urls = []
+
+    if len(urls) > MAX_URLS:
+        parser.error(f'{len(urls)} URLs is more than the {MAX_URLS} one '
+                     f'submission may carry; that is not a change, it is a '
+                     f'mistake')
+
+    for url in urls:
+        print(url)
+    if args.out:
+        pathlib.Path(args.out).write_bytes(
+            ''.join(f'{url}\n' for url in urls).encode('utf-8'))
+
+    if not urls or not args.submit:
+        return 0
+
+    status = submit(urls)
+    print(f'submitted {len(urls)} URLs to {ENDPOINT}: HTTP {status}',
+          file=sys.stderr)
+    return 0 if status in (200, 202) else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/shared/dce2cc4dac3134c897d6caccad94d0c2.txt
+++ b/shared/dce2cc4dac3134c897d6caccad94d0c2.txt
@@ -1,0 +1,1 @@
+dce2cc4dac3134c897d6caccad94d0c2

--- a/tests/python/test_indexnow.py
+++ b/tests/python/test_indexnow.py
@@ -1,0 +1,200 @@
+"""
+indexnow.py: which URLs a deploy tells Bing about, and the key that lets it.
+
+Two things here are worth a test and the rest is not. The first is the
+selection rule, because getting it wrong is invisible: submitting too few
+means the protocol quietly does nothing for the site, and submitting every
+page on every deploy means the host stops being trusted and the protocol
+quietly does nothing for the site. Neither shows up anywhere but in a Bing
+Webmaster Tools chart weeks later.
+
+The second is that the key in the script and the key file served at the site
+root have to be the same string. A mismatch is not an error either: the
+submission is accepted, validation fails out of band, and the URLs are
+dropped. That one is a single assertion and it removes a whole class of
+silent breakage.
+"""
+
+import json
+import pathlib
+import tempfile
+import unittest
+
+import indexnow
+
+ROOT = pathlib.Path(indexnow.__file__).resolve().parent
+
+
+def sitemap(*pages):
+    """A sitemap holding the given (url, lastmod) pairs.
+
+    Written out in full rather than assembled from the real template, because
+    the point is to test the reader against the format, not against whatever
+    the template happens to emit today.
+    """
+    entries = ''.join(
+        f'  <url>\n'
+        f'    <loc>{url}</loc>\n'
+        f'    <lastmod>{lastmod}</lastmod>\n'
+        f'    <changefreq>monthly</changefreq>\n'
+        f'    <priority>0.8</priority>\n'
+        f'  </url>\n'
+        for url, lastmod in pages)
+    return ('<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            f'{entries}</urlset>')
+
+
+class ReadingASitemap(unittest.TestCase):
+
+    def read(self, text):
+        path = pathlib.Path(
+            self.enterContext(tempfile.TemporaryDirectory())) / 'sitemap.xml'
+        path.write_bytes(text.encode('utf-8'))
+        return indexnow.read_sitemap(path)
+
+    def test_the_namespace_does_not_hide_the_entries(self):
+        """The real sitemap declares a default namespace, so every element is
+        named {sitemaps.org/...}url rather than url. A reader written against
+        an example without one finds nothing and reports no change, forever."""
+        pages = self.read(sitemap(('https://abox.tools/', '2026-08-01')))
+        self.assertEqual(pages, {'https://abox.tools/': '2026-08-01'})
+
+    def test_the_order_is_the_sitemaps(self):
+        pages = self.read(sitemap(('https://abox.tools/', '2026-08-01'),
+                                  ('https://abox.tools/crop-video/', '2026-07-02'),
+                                  ('https://abox.tools/de/', '2026-08-01')))
+        self.assertEqual(list(pages), ['https://abox.tools/',
+                                       'https://abox.tools/crop-video/',
+                                       'https://abox.tools/de/'])
+
+
+class ChoosingWhatToSubmit(unittest.TestCase):
+
+    def test_a_new_page_is_submitted(self):
+        old = {'https://abox.tools/': '2026-08-01'}
+        new = {'https://abox.tools/': '2026-08-01',
+               'https://abox.tools/split-pdf/': '2026-08-26'}
+        self.assertEqual(indexnow.changed(old, new),
+                         ['https://abox.tools/split-pdf/'])
+
+    def test_a_moved_lastmod_is_submitted(self):
+        old = {'https://abox.tools/crop-video/': '2026-07-02'}
+        new = {'https://abox.tools/crop-video/': '2026-08-26'}
+        self.assertEqual(indexnow.changed(old, new),
+                         ['https://abox.tools/crop-video/'])
+
+    def test_a_frame_change_submits_nothing(self):
+        """The case this whole design exists for. Changing the footer or the
+        stylesheet rewrites the bytes of every page on the site and moves no
+        lastmod, because lastmod is written by hand and says when the wording
+        changed. A byte diff of dist would submit six hundred URLs here."""
+        pages = {'https://abox.tools/': '2026-08-01',
+                 'https://abox.tools/crop-video/': '2026-07-02',
+                 'https://abox.tools/de/': '2026-08-01'}
+        self.assertEqual(indexnow.changed(pages, dict(pages)), [])
+
+    def test_a_page_that_left_the_sitemap_is_not_submitted(self):
+        """A retired tool becomes a redirect stub, so its address goes on
+        answering 200 and there is nothing to tell anyone about."""
+        old = {'https://abox.tools/text-tools/': '2026-07-02'}
+        self.assertEqual(indexnow.changed(old, {}), [])
+
+    def test_the_submitted_order_follows_the_new_sitemap(self):
+        old = {}
+        new = {'https://abox.tools/': '2026-08-26',
+               'https://abox.tools/split-pdf/': '2026-08-26'}
+        self.assertEqual(indexnow.changed(old, new), list(new))
+
+
+class TheHostInTheSubmission(unittest.TestCase):
+
+    def test_one_host_is_taken_from_the_urls(self):
+        self.assertEqual(
+            indexnow.host_of(['https://abox.tools/', 'https://abox.tools/de/']),
+            'abox.tools')
+
+    def test_two_hosts_are_refused(self):
+        """Every URL in a submission has to be on the host the submission
+        names, or the request is rejected whole. Finding that out here beats
+        finding it out from a 422 in a deploy log."""
+        with self.assertRaises(ValueError):
+            indexnow.host_of(['https://abox.tools/', 'https://example.com/'])
+
+
+class EscapingTheTranslatedSlugs(unittest.TestCase):
+    """Nine of the fifteen languages have slugs that are not ASCII, and the
+    sitemap carries them as the characters themselves - 137 of its 1047 URLs
+    on the day this was written. They read correctly and they resolve, but a
+    URI is defined over ASCII, so they are escaped on the way out."""
+
+    def test_an_arabic_slug_is_percent_encoded(self):
+        self.assertEqual(
+            indexnow.as_uri('https://abox.tools/ar/محرر/'),
+            'https://abox.tools/ar/%D9%85%D8%AD%D8%B1%D8%B1/')
+
+    def test_an_ascii_url_is_left_exactly_as_it_was(self):
+        for url in ('https://abox.tools/',
+                    'https://abox.tools/crop-video/',
+                    'https://abox.tools/de/video-zuschneiden/'):
+            with self.subTest(url=url):
+                self.assertEqual(indexnow.as_uri(url), url)
+
+    def test_the_separators_are_not_encoded(self):
+        """quote() with the wrong safe list turns the slashes into %2F, which
+        is not an escaped address but a different one."""
+        encoded = indexnow.as_uri('https://abox.tools/ja/画像/')
+        self.assertTrue(encoded.startswith('https://abox.tools/ja/'))
+        self.assertTrue(encoded.endswith('/'))
+        self.assertNotIn('%2F', encoded)
+
+    def test_what_goes_on_the_wire_is_ascii_and_still_points_home(self):
+        sent = {}
+
+        class Response:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        def opener(request, timeout=None):
+            sent['body'] = json.loads(request.data.decode('utf-8'))
+            return Response()
+
+        indexnow.submit(['https://abox.tools/ko/자르기/',
+                         'https://abox.tools/crop-video/'], opener=opener)
+        self.assertEqual(sent['body']['host'], 'abox.tools')
+        self.assertEqual(sent['body']['keyLocation'],
+                         f'https://abox.tools/{indexnow.KEY}.txt')
+        for url in sent['body']['urlList']:
+            with self.subTest(url=url):
+                self.assertTrue(url.isascii())
+                self.assertTrue(url.startswith('https://abox.tools/'))
+
+
+class TheKeyFile(unittest.TestCase):
+
+    def test_the_key_is_served_at_the_root_under_its_own_name(self):
+        """The protocol proves the sender owns the host by fetching
+        https://<host>/<key>.txt and finding the key inside. shared/ is copied
+        to the site root, so the file living there is the whole of publishing
+        it - but nothing in the build would notice if the two strings drifted
+        apart, and a submission with a stale key is accepted and then silently
+        dropped."""
+        path = ROOT / 'shared' / f'{indexnow.KEY}.txt'
+        self.assertTrue(path.is_file(), f'{path.name} is not in shared/')
+        self.assertEqual(path.read_bytes().decode('utf-8').strip(),
+                         indexnow.KEY)
+
+    def test_the_key_is_the_shape_the_protocol_accepts(self):
+        """Eight to 128 characters, and only hex digits and dashes. A key
+        outside that is refused at submission time."""
+        self.assertTrue(8 <= len(indexnow.KEY) <= 128)
+        self.assertTrue(set(indexnow.KEY) <= set('0123456789abcdef-'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A sitemap is an invitation, not a notification: it says what exists and leaves
the timing to the crawler, which is why a new tool can sit unindexed for weeks.
Half of that is fixable, and this does the fixable half.

## The asymmetry

**Bing, Yandex, Seznam and Naver take IndexNow.** POST a list of URLs and a key
proving the host is yours, and they fetch within hours. The deploy now does
that.

**Google does not, and nothing here pretends otherwise.** It does not
participate in IndexNow. Its Indexing API accepts only `JobPosting` and
`BroadcastEvent` markup, so a tool page submitted there is discarded — and
using it for anything else is against its terms, whatever the blog posts say.
The sitemap ping endpoint was withdrawn in 2023. Google is left to the sitemap,
exactly as before. Indexing speed there is an outcome of crawl budget and how
much the site is worth crawling, not something a deploy can ask for.

## Which URLs get submitted — the part worth reviewing

A diff of the deployed files is the first idea and it is wrong. The footer
lists every tool, so shipping one rewrites all thousand-odd pages, and a change
to the frame or the stylesheet rewrites them without moving a word anybody
reads. Submitting URLs that did not change is how a host stops being trusted
with the protocol, which would cost the site the one lever it has here.

The signal was already in the repository. `lastmod` is one date per page,
written by hand in `tool.toml` and `config/site.toml`, moved only when that
page's wording moves — `templates/sitemap.xml` has said so for as long as it
has existed. So `indexnow.py` compares the sitemap about to be deployed against
the one already deployed and sends what is new or redated:

| What changed | What is submitted |
|---|---|
| A tool's wording, with its `lastmod` bumped | that tool, in all fifteen languages |
| A new tool | its pages, and the hubs, if their dates moved |
| The footer, the CSS, the build | nothing |

Because the list comes from the sitemap rather than from the output directory,
it inherits every rule the sitemap already applies for free: an untranslated
page is not in it, a locale still being translated is not in it, and the
redirect stub left behind by a renamed tool is not in it either.

**This gives `lastmod` teeth it did not have.** Leaving it alone on a real edit
now means the change ships and nobody is told; bumping every date to be safe
submits the whole site. `CLAUDE.md` warns about both.

## A bug found on the way

137 of the 1047 URLs are Arabic, Hindi, Japanese, Korean or Chinese rather than
ASCII, because the slugs are translated. Two consequences, both fixed:

- printing them crashed on a Windows console, whose default codepage cannot
  spell them — and the traceback took an otherwise working submission with it,
  so the streams are now told they speak UTF-8;
- a URI is defined over ASCII, so they are percent-encoded at the last moment,
  on the way to the wire only. The deploy log and the `--out` list stay
  readable; the payload is ASCII.

## The key

`shared/dce2cc4dac3134c897d6caccad94d0c2.txt` is served at the site root
because `shared/` already lands there — no build change was needed — and that
is where the protocol looks to confirm the sender controls the host.

**It is deliberately not a secret; publishing it is the point.** What matters
is that it and the `KEY` constant stay identical: a submission carrying a key
the file does not match is accepted, fails validation out of band, and is
dropped with no error anywhere. `tests/python/test_indexnow.py` asserts the two
agree, which is the only thing standing between that and silence. The file
carries no explanatory comment, unlike everything else in `shared/`, because
the format has no room for one — the key is the entire contents.

## The workflow step

It saves the deployed `sitemap.xml` before the `dist` tree is replaced, and
submits after the push: announcing a URL a minute before it exists gets it
fetched, found stale, and believed. It cannot fail the build — by then the
deploy has happened and a refused submission does not undo it — so it marks
itself failed and writes what it sent to the run summary instead.

## Testing

- 405 Python tests (15 new) and 1886 JavaScript tests pass.
- The workflow's `run:` block was extracted verbatim from the YAML and executed
  locally across three cases — a tool's wording changed, a frame-only change,
  and no baseline at all — with `--submit` stripped. Correct in all three.
- **Nothing was submitted to the live endpoint.** The first real submission
  happens on the first deploy to `main` after this merges.

## Left to do by hand

- **Cloudflare Crawler Hints** (*Caching → Configuration → Crawler Hints*) is a
  second, independent route to the same protocol. One toggle, worth having on,
  but it guesses from cache behaviour rather than from the dates — a net under
  the accurate path, not a replacement. `docs/deploying.md` says so.
- Verifying the site in **Bing Webmaster Tools**, to watch submissions land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
