### PR TITLE
Yep takes IndexNow too, and the list said four

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,12 +177,12 @@ jobs:
           git -C .publish commit -m "Build ${SHA:0:7}: ${subject}"
           git -C .publish push origin dist
 
-      # Bing, Yandex, Seznam and Naver accept being told that a page changed,
-      # and fetch it within hours instead of whenever a crawler next comes
-      # round. Google takes no part in this and is still reached through the
-      # sitemap alone; see the comment at the top of indexnow.py, which also
-      # explains why the URLs come from a diff of the two sitemaps rather than
-      # from a diff of the deployed files.
+      # Bing, Yandex, Seznam, Naver and Yep accept being told that a page
+      # changed, and fetch it within hours instead of whenever a crawler next
+      # comes round. Google takes no part in this and is still reached through
+      # the sitemap alone; see the comment at the top of indexnow.py, which
+      # also explains why the URLs come from a diff of the two sitemaps rather
+      # than from a diff of the deployed files.
       #
       # It runs after the publish, deliberately: it announces pages that are
       # already live, and a URL submitted a minute before it exists is fetched,

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -154,8 +154,11 @@ the timing to the crawler, which is why a new tool can sit unindexed for weeks.
 Half of that is fixable and half is not, and the two halves are worth keeping
 straight.
 
-**Bing, Yandex, Seznam and Naver take IndexNow.** POST a list of URLs and a key
-that proves the host is yours, and they fetch them within hours.
+**Bing, Yandex, Seznam, Naver and Yep take IndexNow.** POST a list of URLs
+and a key that proves the host is yours, and they fetch them within hours.
+The protocol requires each participant to pass submissions on to the others
+within ten seconds of verifying them, which is why `indexnow.py` posts to the
+shared `api.indexnow.org` endpoint rather than to any one engine.
 
 **Google does not, and there is no equivalent.** It does not participate in
 IndexNow. Its Indexing API only accepts `JobPosting` and `BroadcastEvent`

--- a/indexnow.py
+++ b/indexnow.py
@@ -2,7 +2,7 @@
 """Tell the search engines that accept being told, about the pages that changed.
 
 IndexNow is a small protocol: POST a list of URLs plus a key that proves the
-host is yours, and Bing, Yandex, Seznam and Naver fetch them within hours
+host is yours, and Bing, Yandex, Seznam, Naver and Yep fetch them within hours
 rather than whenever a crawler next comes round. Google does not take part.
 There is no equivalent for it either - its Indexing API is restricted to job
 postings and livestreams, and a tool page submitted there is discarded - so


### PR DESCRIPTION
Follow-up to #152, which named four participating engines. There are five.

[indexnow.org](https://www.indexnow.org/) names **Microsoft Bing, Yandex,
Seznam.cz, Naver and Yep** — the last being Ahrefs' search engine. This
repository wrote the list out in three places and undercounted in all three:
the `indexnow.py` docstring, the workflow comment, and `docs/deploying.md`.

## Nothing about the code was wrong

Worth saying explicitly rather than leaving to be inferred. Submissions already
go to `api.indexnow.org`, the shared endpoint, and the protocol obliges every
participant to pass what it receives on to the others within ten seconds of
verifying it. Yep was being reached the whole time.

That forwarding requirement is precisely why the shared endpoint was chosen
over `bing.com/indexnow`, and #152 never said so — so `docs/deploying.md` now
explains it in the paragraph where somebody wondering about a sixth engine
would go looking. That is the only substantive addition here; the rest is three
words and a reflow.

Google's position is unchanged and still correctly described: testing since
October 2021, never adopted.

## Note on the branch

#152 was squash-merged while this correction was being written, and `main` has
since taken on unrelated work — the workflow guides across every locale, and
the analytics change. The original branch is now well behind, so this is a
fresh branch off current `main` with the fix cherry-picked onto it rather than
a reopened one, which would have proposed deleting all of that.

Tests pass against updated `main` (15 in `test_indexnow.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
