### PR TITLE
Carry a result straight into the next tool, without the download detour

### DIFF
--- a/build.py
+++ b/build.py
@@ -173,6 +173,10 @@ def build(out, clean=False, minify_output=True, jobs=None):
     feedback_js = emit.js_text(
         (SHARED / 'feedback.js').read_text(encoding='utf-8'), 'shared/feedback.js')
     feedback_v = sitelib.text_hash(feedback_js)
+    handoff_js = emit.js_text(
+        (SHARED / 'handoff.js').read_text(encoding='utf-8'), 'shared/handoff.js')
+    handoff_v = sitelib.text_hash(handoff_js)
+
 
     # The eight lines that register the front page's service worker. Written
     # here rather than into each language because there is nothing in it that
@@ -191,6 +195,21 @@ def build(out, clean=False, minify_output=True, jobs=None):
              for path in sorted(TOOLS.glob('*/tool.toml'))]
     if not tools:
         raise sitelib.ConfigError(f'no tools found under {TOOLS}')
+
+    # A tool may declare `handoff` targets - the tools its finished result can
+    # be carried straight into (see shared/handoff.js). Checked here the way
+    # roadmap_group is checked elsewhere: against the tools that exist, before
+    # anything renders, with the file named.
+    slugs = {tool['slug'] for tool in tools}
+    for tool in tools:
+        for target in tool.get('handoff', []):
+            if target == tool['slug']:
+                raise sitelib.ConfigError(
+                    f'{tool["slug"]}: handoff names itself.')
+            if target not in slugs:
+                raise sitelib.ConfigError(
+                    f'{tool["slug"]}: handoff names {target!r}, which is not a '
+                    'tool. Name a folder under tools/.')
 
     # Nothing is bundled, so the browser fetches every module by the name an
     # import gives it. A specifier naming a file this tool does not ship is
@@ -262,7 +281,7 @@ def build(out, clean=False, minify_output=True, jobs=None):
         with ProcessPoolExecutor(max_workers=jobs) as pool:
             pending = [
                 pool.submit(build_locale, out, templates, locale, locales, site,
-                            tools, prose, planned, css_v, lang_v, feedback_v,
+                            tools, prose, planned, css_v, lang_v, feedback_v, handoff_v,
                             offline_v, site_css, emit)
                 for locale in locales
             ]
@@ -358,6 +377,7 @@ def build(out, clean=False, minify_output=True, jobs=None):
     write(out / 'lang.js', lang_js)
     write(out / 'offline.js', offline_js)
     write(out / 'feedback.js', feedback_js)
+    write(out / 'handoff.js', handoff_js)
 
     # Last, because a link is only checkable once everything it could point at
     # has been written. The pages the parent wrote itself - the 404 - joined
@@ -386,7 +406,7 @@ def build(out, clean=False, minify_output=True, jobs=None):
 
 
 def build_locale(out, templates, locale, locales, site, tools, prose, planned,
-                 css_v, lang_v, feedback_v, offline_v, site_css, emit):
+                 css_v, lang_v, feedback_v, handoff_v, offline_v, site_css, emit):
     """The whole site, in one language, under out/<lang>/ - or at the root of
     out/ for English, whose pages keep the addresses they have always had.
 
@@ -465,8 +485,10 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
     written = []
     for tool in ltools:
         build_tool(dest_root, templates, locale, locales, site, tool, footer,
-                   links, lang_v, feedback_v, guide_of.get(tool['slug'], {}),
-                   related_of.get(tool['slug'], []), emit)
+                   links, lang_v, feedback_v, handoff_v,
+                   guide_of.get(tool['slug'], {}),
+                   related_of.get(tool['slug'], []),
+                   [by_slug[s] for s in tool.get('handoff', [])], emit)
         written.append(f'{locale["prefix"]}{tool["out_slug"]}/index.html')
 
     # Old addresses that moved. A static host cannot answer 301, so the page
@@ -743,7 +765,7 @@ def build_guides(out, templates, locale, locales, site, groups, guides, footer,
 
 
 def build_tool(out, templates, locale, locales, site, tool, footer, links,
-               lang_v, feedback_v, guide, related, emit):
+               lang_v, feedback_v, handoff_v, guide, related, handoff, emit):
     root = locale['site']
     dest = out / tool['out_slug']
     dest.mkdir(parents=True, exist_ok=True)
@@ -839,6 +861,12 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
             # Root-absolute and versioned, exactly like lang_href beside it and
             # for the same cache reason. Only a tool page asks for this one.
             'feedback_href': f'/feedback.js?v={feedback_v}',
+            # The carry-the-result-on row and its script. The row renders only
+            # where tool.toml declares targets; the script goes on every tool
+            # page, because the receiving half is what feeds a carried file
+            # through the picker. See shared/handoff.js.
+            'handoff': handoff,
+            'handoff_href': f'/handoff.js?v={handoff_v}',
             'jsonld': sitelib.tool_jsonld(root, tool),
             'body': body,
         })))

--- a/buildlib/i18n.py
+++ b/buildlib/i18n.py
@@ -180,7 +180,7 @@ TRANSLATABLE_SITE_PATHS = (
 STRUCTURAL_KEYS = frozenset({
     'slug', 'id', 'order', 'lastmod', 'published', 'category', 'group',
     'mark', 'icon', 'favicon', 'brand_mark', 'kind', 'tool',
-    'css_parts', 'js_parts', 'roadmap_group',
+    'css_parts', 'js_parts', 'roadmap_group', 'handoff',
     # `analytics_extra` is prose, and is still structure, which looks like a
     # contradiction until you see where it lands: the tail of one sentence in
     # the comment at the top of templates/analytics.js. That comment is written

--- a/config/site.toml
+++ b/config/site.toml
@@ -601,6 +601,11 @@ guide_heading = "The longer version"
 # not always related - two categories hold one tool each, and those two pages
 # get the nearest thing the hub has instead. See related_tools() in build.py.
 related_heading = "Also in the box"
+
+# The lead-in on the carry-the-result-on row - see shared/handoff.js. It ends
+# in a colon because the links that follow are the sentence's object: the
+# names of the tools the result can go straight into, in this language.
+handoff_lead = "Carry the result straight into:"
 privacy_heading = "How the privacy claim is verifiable"
 
 # The headline claim. The noun in the middle is this tool's own - "files",

--- a/locales/ar/locale.toml
+++ b/locales/ar/locale.toml
@@ -396,6 +396,7 @@ checking = "جارٍ الفحص&hellip;"
 questions_heading = "أسئلة"
 guide_heading = "النسخة الأطول"
 related_heading = "أيضا في الصندوق"
+handoff_lead = "احمل الناتج مباشرة إلى:"
 privacy_heading = "كيف يمكن التحقق من وعد الخصوصية"
 
 pledge_line = """

--- a/locales/de/locale.toml
+++ b/locales/de/locale.toml
@@ -416,6 +416,7 @@ checking = "wird geprüft&hellip;"
 questions_heading = "Fragen"
 guide_heading = "Die ausführliche Fassung"
 related_heading = "Auch im Werkzeugkasten"
+handoff_lead = "Das Ergebnis direkt weiterreichen an:"
 privacy_heading = "So lässt sich das Datenschutzversprechen nachprüfen"
 
 # Das Substantiv steht mitten im Satz, und das Verb am Ende - genau der Grund,

--- a/locales/es/locale.toml
+++ b/locales/es/locale.toml
@@ -365,6 +365,7 @@ checking = "comprobando&hellip;"
 questions_heading = "Preguntas"
 guide_heading = "La versión larga"
 related_heading = "También en la caja"
+handoff_lead = "Lleva el resultado directamente a:"
 privacy_heading = "Cómo se comprueba la promesa de privacidad"
 
 pledge_line = """

--- a/locales/fr/locale.toml
+++ b/locales/fr/locale.toml
@@ -383,6 +383,7 @@ checking = "vérification&hellip;"
 questions_heading = "Questions"
 guide_heading = "La version longue"
 related_heading = "Aussi dans la boîte"
+handoff_lead = "Poursuivre avec le résultat dans&nbsp;:"
 privacy_heading = "Comment cette promesse se vérifie"
 
 # Tournée à l'actif : le participe passé s'accorderait avec

--- a/locales/hi/locale.toml
+++ b/locales/hi/locale.toml
@@ -289,6 +289,7 @@ checking = "जाँच जारी&hellip;"
 questions_heading = "सवाल"
 guide_heading = "विस्तार से"
 related_heading = "बॉक्स में और भी टूल"
+handoff_lead = "नतीजा सीधे यहाँ ले जाइए:"
 privacy_heading = "प्राइवेसी का यह दावा कैसे जाँचा जा सकता है"
 
 pledge_line = """

--- a/locales/id/locale.toml
+++ b/locales/id/locale.toml
@@ -391,6 +391,7 @@ checking = "memeriksa&hellip;"
 questions_heading = "Pertanyaan"
 guide_heading = "Versi lebih lengkap"
 related_heading = "Juga ada di dalam kotak"
+handoff_lead = "Bawa hasilnya langsung ke:"
 privacy_heading = "Cara memverifikasi klaim privasi ini"
 
 pledge_line = """

--- a/locales/it/locale.toml
+++ b/locales/it/locale.toml
@@ -358,6 +358,7 @@ checking = "verifica in corso&hellip;"
 questions_heading = "Domande"
 guide_heading = "La versione lunga"
 related_heading = "Anche nella cassetta"
+handoff_lead = "Porta il risultato dritto in:"
 privacy_heading = "Come si verifica quello che promette"
 
 # Il nome che sta in mezzo cambia genere da uno strumento all'altro - le

--- a/locales/ja/locale.toml
+++ b/locales/ja/locale.toml
@@ -278,6 +278,7 @@ checking = "確認中&hellip;"
 questions_heading = "よくある質問"
 guide_heading = "詳しい解説"
 related_heading = "箱の中のほかのツール"
+handoff_lead = "結果をそのまま次へ："
 privacy_heading = "この主張を確かめる方法"
 
 pledge_line = """

--- a/locales/ko/locale.toml
+++ b/locales/ko/locale.toml
@@ -396,6 +396,7 @@ checking = "확인 중&hellip;"
 questions_heading = "자주 묻는 질문"
 guide_heading = "자세한 설명"
 related_heading = "상자 속 다른 도구"
+handoff_lead = "결과를 곧바로 이어서:"
 privacy_heading = "이 약속을 직접 확인하는 방법"
 
 pledge_line = """

--- a/locales/nl/locale.toml
+++ b/locales/nl/locale.toml
@@ -369,6 +369,7 @@ checking = "bezig met controleren&hellip;"
 questions_heading = "Vragen"
 guide_heading = "De uitgebreide versie"
 related_heading = "Ook in de gereedschapskist"
+handoff_lead = "Neem het resultaat rechtstreeks mee naar:"
 privacy_heading = "Hoe je de privacybelofte controleert"
 
 pledge_line = """

--- a/locales/pt/locale.toml
+++ b/locales/pt/locale.toml
@@ -360,6 +360,7 @@ checking = "verificando&hellip;"
 questions_heading = "Perguntas"
 guide_heading = "A versão longa"
 related_heading = "Também na caixa"
+handoff_lead = "Leve o resultado direto para:"
 privacy_heading = "Como dá para conferir a promessa de privacidade"
 
 # O inglês escreve "Your {{ plural }} are never uploaded", e o particípio

--- a/locales/tr/locale.toml
+++ b/locales/tr/locale.toml
@@ -381,6 +381,7 @@ checking = "kontrol ediliyor&hellip;"
 questions_heading = "Sorular"
 guide_heading = "Uzun sürüm"
 related_heading = "Kutuda ayrıca"
+handoff_lead = "Sonucu doğrudan şuraya taşıyın:"
 privacy_heading = "Gizlilik iddiası nasıl doğrulanabilir"
 
 pledge_line = """

--- a/locales/zh-TW/locale.toml
+++ b/locales/zh-TW/locale.toml
@@ -254,6 +254,7 @@ checking = "檢查中&hellip;"
 questions_heading = "常見問題"
 guide_heading = "說得更細的版本"
 related_heading = "工具箱裡還有"
+handoff_lead = "把結果直接帶到："
 privacy_heading = "這條隱私承諾怎麼核實"
 
 pledge_line = """

--- a/locales/zh/locale.toml
+++ b/locales/zh/locale.toml
@@ -277,6 +277,7 @@ checking = "检查中&hellip;"
 questions_heading = "常见问题"
 guide_heading = "说得更细的版本"
 related_heading = "工具箱里还有"
+handoff_lead = "把结果直接带到："
 privacy_heading = "这条隐私承诺怎么核实"
 
 pledge_line = """

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1113,3 +1113,58 @@ ins.adsbygoogle { display: block; }
 ins.adsbygoogle[data-ad-status="unfilled"] { display: none !important; }
 
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* ---------------------------------------------------------------- handoff */
+
+/*
+  "Carry the result on" - see shared/handoff.js and templates/partials/
+  handoff.html. It appears beside the download link it belongs to, so it
+  borrows the feedback panel's register: an aside in the flow of the page, on
+  --surface-2, never a second call to action shouting over the first. The
+  links are the other tools' names, which is all they need to be.
+*/
+.handoff {
+  margin-top: 0.8rem;
+  padding: 0.6rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem 0.8rem;
+}
+
+.handoff-lead {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-dim);
+}
+
+.handoff-targets {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.6rem;
+}
+
+.handoff-targets a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  font-size: 0.88rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.handoff-targets a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}

--- a/shared/handoff.js
+++ b/shared/handoff.js
@@ -1,0 +1,212 @@
+/**
+ * "Carry the result on" - the button that turns two tools into a chain.
+ *
+ * GENERATED FILE - do not edit; see shared/handoff.js.
+ *
+ * A result made on one page here so often wants to be the input of another:
+ * the trimmed clip becomes the GIF, the scanned pages join the emailed
+ * contract, the stacked photo goes to the compressor. Until this file the
+ * route was download, find the file, drop it on the next page - three manual
+ * steps carrying a file the browser already held in memory the whole time.
+ *
+ * WHAT THIS DOES, AND WHAT IT NEVER DOES
+ *
+ * When a tool that declares handoff targets finishes a result - its download
+ * link gets a blob: URL and becomes visible - a small row of links appears
+ * beside that link: the other tools this result can go straight into. Clicking
+ * one reads the result out of the page's own blob: URL, parks it in
+ * IndexedDB, and navigates. The next page finds it there, feeds it through
+ * the same file input a dropped file goes through, and deletes it.
+ *
+ * Nothing in that journey touches the network. A blob: URL names bytes inside
+ * this page; IndexedDB is the browser's own storage on this machine, the same
+ * place the service worker already keeps the page itself; and the fetch() that
+ * reads the blob is same-document plumbing that the sender's own
+ * Content-Security-Policy has to permit explicitly (connect-src blob:, in the
+ * sender's tool.toml). The promise the site makes - your files never leave
+ * your machine - is exactly as true across the handoff as on either side of
+ * it.
+ *
+ * WHY THE RECEIVER NEEDS NO CODE OF ITS OWN
+ *
+ * The parked file is delivered through the file input every tool already has,
+ * with a DataTransfer and a synthetic change event - to the receiving tool it
+ * is indistinguishable from a file the visitor picked. That is the point: the
+ * receiving page keeps exactly one way of accepting a file, and this script
+ * uses it rather than adding a second door to every tool. Records are keyed
+ * by the receiving tool's slug, consumed exactly once, and swept after ten
+ * minutes so an abandoned handoff does not sit in storage holding somebody's
+ * contract.
+ *
+ * Like shared/feedback.js beside it, this is a frame script rather than a
+ * shared module: no tool imports it, no tool.toml asks for it, and the only
+ * markup it touches is its own - templates/partials/handoff.html, rendered
+ * hidden on pages that declare targets and moved next to the download link
+ * when there is a result to carry.
+ */
+(function () {
+  'use strict';
+
+  var DB = 'abox-handoff';
+  var STORE = 'files';
+
+  // Long enough to survive a slow navigation and a service worker update on
+  // the way; short enough that a handoff nobody completed is not still holding
+  // the file when the machine changes hands at the end of the day.
+  var FRESH = 10 * 60 * 1000;
+
+  /* -------------------------------------------------------------- the store */
+
+  function open() {
+    return new Promise(function (resolve, reject) {
+      var req = window.indexedDB.open(DB, 1);
+      req.onupgradeneeded = function () { req.result.createObjectStore(STORE); };
+      req.onsuccess = function () { resolve(req.result); };
+      req.onerror = function () { reject(req.error); };
+    });
+  }
+
+  /** One transaction, promised. `use` gets the store and returns a request. */
+  function inStore(mode, use) {
+    return open().then(function (db) {
+      return new Promise(function (resolve, reject) {
+        var tx = db.transaction(STORE, mode);
+        var req = use(tx.objectStore(STORE));
+        tx.oncomplete = function () { db.close(); resolve(req && req.result); };
+        tx.onerror = function () { db.close(); reject(tx.error); };
+      });
+    });
+  }
+
+  function park(slug, record) {
+    return inStore('readwrite', function (store) { return store.put(record, slug); });
+  }
+
+  function take(slug) {
+    return inStore('readwrite', function (store) {
+      var got = store.get(slug);
+      got.onsuccess = function () { store.delete(slug); };
+      return got;
+    });
+  }
+
+  /** Anything past FRESH goes, whichever tool it was addressed to. */
+  function sweep() {
+    return inStore('readwrite', function (store) {
+      var walk = store.openCursor();
+      walk.onsuccess = function () {
+        var cursor = walk.result;
+        if (!cursor) return;
+        var record = cursor.value;
+        if (!record || !record.time || Date.now() - record.time > FRESH) cursor.delete();
+        cursor.continue();
+      };
+      return null;
+    });
+  }
+
+  /* ------------------------------------------------------------- receiving */
+
+  // The slug this page files feedback under is the same name a sender parks
+  // a file under, and it is already in the markup.
+  var page = document.getElementById('feedback');
+  var slug = page ? page.getAttribute('data-tool') : '';
+
+  function deliver(file) {
+    var input = document.getElementById('file-input');
+    if (!input || typeof DataTransfer === 'undefined') return;
+    var carrier = new DataTransfer();
+    carrier.items.add(file);
+    input.files = carrier.files;
+    // The same event a real pick fires, so the tool's own wiring - reading,
+    // thumbnails, error messages - runs unchanged and this page needs no
+    // second way of accepting a file.
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+
+  function receive() {
+    if (!slug) return;
+    take(slug).then(function (record) {
+      if (record && record.file && record.time
+          && Date.now() - record.time <= FRESH) {
+        deliver(record.file);
+      }
+      return sweep();
+    }).catch(function () {
+      // IndexedDB refused - storage disabled, or a browser mode that throws.
+      // The page is then simply a page somebody opened without a file, which
+      // is the state it was built for.
+    });
+  }
+
+  // Module scripts have all run by 'load', so the tool's change listener is
+  // wired before the synthetic event fires.
+  if (document.readyState === 'complete') receive();
+  else window.addEventListener('load', receive, { once: true });
+
+  /* --------------------------------------------------------------- sending */
+
+  var nav = document.getElementById('handoff');
+  if (!nav) return;
+
+  /** The finished result: a visible download link naming bytes in this page. */
+  function result() {
+    var anchor = document.getElementById('download');
+    if (!anchor || anchor.hidden || !anchor.hasAttribute('download')) return null;
+    var href = anchor.getAttribute('href') || '';
+    return href.indexOf('blob:') === 0 ? anchor : null;
+  }
+
+  function show() {
+    var anchor = result();
+    // Every write in here is guarded by a read. The observer below watches
+    // `hidden` across the page, and that includes this nav's own attribute:
+    // setting it to the value it already has still records a mutation, which
+    // re-runs this function, which sets it again - a microtask loop that
+    // freezes the tab. Writing only on change is what breaks the cycle.
+    if (!anchor) {
+      if (!nav.hidden) nav.hidden = true;
+      return;
+    }
+    // Beside the download it belongs to: after the row of actions when the
+    // anchor sits in one, after the anchor itself when it does not.
+    var host = anchor.closest('.toolbar') || anchor;
+    if (!host.parentNode) return;
+    if (host.nextElementSibling !== nav) host.insertAdjacentElement('afterend', nav);
+    if (nav.hidden) nav.hidden = false;
+  }
+
+  // Tools reveal the link by unhiding it and swapping its href for each new
+  // result; both are attribute changes, and new anchors never appear - the
+  // markup is static - so watching attributes is enough.
+  var watch = new MutationObserver(show);
+  watch.observe(document.body, {
+    subtree: true, attributes: true, attributeFilter: ['href', 'hidden'],
+  });
+  show();
+
+  nav.addEventListener('click', function (event) {
+    var link = event.target && event.target.closest
+      ? event.target.closest('a[data-slug]') : null;
+    if (!link) return;
+    var anchor = result();
+    if (!anchor) return;    // stale click; let the plain navigation happen
+
+    event.preventDefault();
+    var name = anchor.getAttribute('download') || 'result';
+
+    // Read the page's own bytes back out of the blob: URL, park them for the
+    // next page, and go. If any step refuses - CSP, storage, anything - the
+    // fallback is the navigation alone: the reader lands on the tool and drops
+    // the file by hand, which is exactly the journey this button shortens.
+    window.fetch(anchor.href)
+      .then(function (response) { return response.blob(); })
+      .then(function (blob) {
+        var file = new File([blob], name, { type: blob.type });
+        return park(link.getAttribute('data-slug'),
+                    { file: file, from: slug, time: Date.now() });
+      })
+      .catch(function () { /* fall through to the plain visit */ })
+      .then(function () { window.location.assign(link.href); });
+  });
+})();

--- a/templates/partials/handoff.html
+++ b/templates/partials/handoff.html
@@ -1,0 +1,24 @@
+<!--
+  "Carry the result on" - the row of tools a finished result can go straight
+  into, declared as `handoff` in the sender's tool.toml and validated against
+  the tools that exist. Rendered hidden; shared/handoff.js moves it next to
+  the download link when there is a result to carry, and parks the file in
+  IndexedDB for the next page. See that file for why nothing in the journey
+  touches the network.
+
+  Rendered rather than built in JavaScript for the same reason the feedback
+  panel is: the lead line is translated in every locale's [ui.tool], and each
+  link borrows the target tool's own localized name and address - so the row
+  cannot promise a tool the language does not have.
+-->
+<nav class="handoff" id="handoff" aria-label="{{ ui.tool.handoff_lead }}" hidden>
+  <p class="handoff-lead">{{ ui.tool.handoff_lead }}</p>
+  <ul class="handoff-targets">
+{% for other in handoff %}    <li>
+      <a href="{{ base }}{{ other.out_slug }}/" data-slug="{{ other.slug }}">
+        <span aria-hidden="true">{{ other.icon }}</span>
+        {{ other.name | e }} <span aria-hidden="true">&rarr;</span>
+      </a>
+    </li>
+{% endfor %}  </ul>
+</nav>

--- a/templates/sw.js
+++ b/templates/sw.js
@@ -91,12 +91,13 @@ self.addEventListener('fetch', (event) => {
         // is the whole point of this worker. Anything else gets the failure,
         // because handing HTML back to something that asked for a script only
         // turns "offline" into a MIME-type error in the console - which is
-        // exactly what /lang.js, one of the two root-absolute scripts a tool
+        // exactly what /lang.js, one of the three root-absolute scripts a tool
         // page asks for and does not precache, did before this line said
         // `navigate`.
-        // /feedback.js is the other, and is deliberately in the same position:
-        // offline there is nothing for it to ask about, because there is no
-        // measurement call to carry the answer.
+        // /feedback.js and /handoff.js are the others, deliberately in the
+        // same position: offline, feedback has no measurement call to carry
+        // the answer, and a missing handoff row leaves the manual journey -
+        // download, then drop - which still works entirely offline.
         request.mode === 'navigate'
           ? caches.match('index.html')
           : Promise.reject(new Error('offline and not cached'))

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -286,6 +286,10 @@
 {{ body }}
 
 {% include "partials/feedback.html" %}
+{% if handoff %}{% include "partials/handoff.html" %}
+{% endif %}<!-- On every tool page, not only the senders: the receiving half reads
+     the parked file and feeds it through the file input. -->
+<script src="{{ handoff_href }}" defer></script>
 
 <!--
   ============================================================================

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -733,6 +733,41 @@ class BuildTheSite(unittest.TestCase):
         # is minified like every other script the site serves.
         self.assertIn('abox-lang', (self.out / 'lang.js').read_text(encoding='utf-8'))
 
+    def test_the_handoff_row_names_tools_that_exist_at_their_local_address(self):
+        """The carry-the-result-on row - see shared/handoff.js.
+
+        Three claims, checked in the built pages rather than the config: a tool
+        that declares targets renders the row with each target as a link to
+        that tool's address in the same language; the link's data-slug is the
+        English slug, because that is the key the next page takes the file out
+        of storage by; and every tool page - senders and receivers alike -
+        asks for /handoff.js, since the receiving half is what feeds a carried
+        file through the picker.
+        """
+        senders = {tool.parent.name: buildmod.sitelib.load_toml(tool).get('handoff', [])
+                   for tool in ROOT.glob('tools/*/tool.toml')}
+        self.assertTrue(any(senders.values()), 'no tool declares handoff targets')
+
+        for name in self.tool_pages():
+            text = (self.out / name).read_text(encoding='utf-8')
+            with self.subTest(page=name):
+                self.assertIn('/handoff.js?v=', text)
+
+        for locale in self.locales:
+            by_slug = {slug: buildmod.i18n.locale_path(locale, slug).strip('/')
+                       for slug in senders}
+            for slug, targets in senders.items():
+                if not targets:
+                    continue
+                page = (self.out / by_slug[slug] / 'index.html'
+                        ).read_text(encoding='utf-8')
+                with self.subTest(locale=locale['lang'], tool=slug):
+                    self.assertIn('<nav class="handoff"', page)
+                    for target in targets:
+                        self.assertIn(f'data-slug="{target}"', page)
+                        folder = by_slug[target].split('/')[-1]
+                        self.assertIn(f'href="../{folder}/"', page)
+
     def test_every_page_asks_for_the_language_script_by_a_versioned_url(self):
         """One URL, root-absolute, the same on every page in every language.
 

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "video"
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["trim-video", "video-to-gif"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -289,7 +294,12 @@ features = [
 # on this machine rather than from a URL. A tool can only ever widen its own
 # page this way - it cannot narrow the site policy, and it cannot touch any
 # other tool's.
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
 [csp]
+"connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which

--- a/tools/document-scanner/tool.toml
+++ b/tools/document-scanner/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "documents"
 # for saving several pages as pictures rather than as a document, and needs crc32
 # beside it because the archive stores a checksum per entry.
 js_parts = ["file-picker", "zip", "crc32"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["merge-pdf", "compress-pdf"]
 lastmod = "2026-08-25"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -350,3 +355,10 @@ accept = "image/*,.jpg,.jpeg,.png,.webp,.gif,.bmp,.avif"
 multiple = true
 title = "Drop photos of your pages here"
 hint = "or click to browse &mdash; one photo per page, in page order"
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "audio"
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["trim-audio"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -330,7 +335,12 @@ features = [
 # on this machine rather than from a URL. A tool can only ever widen its own
 # page this way - it cannot narrow the site policy, and it cannot touch any
 # other tool's.
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
 [csp]
+"connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "gif"
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["gif-analyzer"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -294,3 +299,10 @@ accept = "image/*"
 multiple = true
 title = "Drop images here"
 hint = "or click to browse &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/images-to-pdf/tool.toml
+++ b/tools/images-to-pdf/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "documents"
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["merge-pdf", "compress-pdf"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -270,3 +275,10 @@ accept = "image/*"
 multiple = true
 title = "Drop images here"
 hint = "or click to browse &mdash; JPEG, PNG, WebP, GIF, AVIF"
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/merge-pdf/tool.toml
+++ b/tools/merge-pdf/tool.toml
@@ -21,6 +21,11 @@ category = "documents-and-audio"
 roadmap_group = "documents"
 
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["compress-pdf"]
 lastmod = "2026-08-21"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -344,3 +349,10 @@ accept = "application/pdf,.pdf"
 multiple = true
 title = "Drop your PDFs here"
 hint = "or click to browse &mdash; one file or several, and you can add more later"
+
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
+[csp]
+"connect-src" = ["blob:"]

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "video"
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["trim-video", "video-to-gif"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -295,7 +300,12 @@ features = [
 # on this machine rather than from a URL. A tool can only ever widen its own
 # page this way - it cannot narrow the site policy, and it cannot touch any
 # other tool's.
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
 [csp]
+"connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "images"
 # is this tool's own, because a row in it carries what was found inside a RAW
 # file rather than what the operating system said about the file.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["compress-image", "resize-image"]
 lastmod = "2026-08-25"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -374,7 +379,12 @@ features = [
 # by the service worker beside it - and there is no blob: on it, because nothing
 # here ever builds a script at runtime. A tool can only widen its own page this
 # way; it cannot narrow the site policy and cannot touch another tool's.
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
 [csp]
+"connect-src" = ["blob:"]
 "worker-src" = ["'self'"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "video"
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["video-to-gif"]
 lastmod = "2026-08-23"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -307,7 +312,12 @@ features = [
 # memory on this machine rather than from a URL. A tool can only ever widen its
 # own page this way - it cannot narrow the site policy, and it cannot touch any
 # other tool's.
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
 [csp]
+"connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -32,6 +32,11 @@ roadmap_group = "audio"
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["edit-audio"]
 lastmod = "2026-08-21"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -381,7 +386,12 @@ features = [
 # memory on this machine rather than from a URL. A tool can only ever widen its
 # own page this way - it cannot narrow the site policy, and it cannot touch any
 # other tool's.
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
 [csp]
+"connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -25,6 +25,11 @@ roadmap_group = "video"
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["video-to-gif", "reverse-video"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -369,7 +374,12 @@ features = [
 # memory on this machine rather than from a URL. A tool can only ever widen its
 # own page this way - it cannot narrow the site policy, and it cannot touch any
 # other tool's.
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
 [csp]
+"connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -24,6 +24,11 @@ roadmap_group = "gif"
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.
 js_parts = ["file-picker"]
+# Where a finished result can be carried without being saved first: the row of
+# links shared/handoff.js shows beside the download once there is one. Slugs of
+# tools whose picker takes what this page produces; checked against the tools
+# that exist by the build.
+handoff = ["gif-analyzer", "split-gif"]
 lastmod = "2026-08-20"
 
 # --- what search engines and chat apps are told ------------------------------
@@ -298,7 +303,12 @@ features = [
 # because the clip you chose is played from memory on this machine rather than
 # from a URL. A tool can only ever widen its own page this way - it cannot
 # narrow the site policy, and it cannot touch any other tool's.
+# The carry-on row reads the finished result back out of this page's own
+# blob: URL before parking it for the next tool (see shared/handoff.js), and
+# reading a blob: URL is a fetch the policy has to permit. blob: names bytes
+# inside this page; nothing here gains any reach over the network.
 [csp]
+"connect-src" = ["blob:"]
 "media-src" = ["'self'", "blob:"]
 
 # The drop zone. Rendered by templates/partials/file-picker.html, which


### PR DESCRIPTION
## What this adds

The cheap, honest version of a "pipeline" feature: when a tool with declared `handoff` targets finishes a result, a quiet row appears beside the download link — **"Carry the result straight into: 🎬 Video to GIF → ⏪ Video Reverser →"**. One click moves the finished file to the next tool with no download and no re-drop.

## How it works, and why nothing changes about the promise

- The click reads the result back out of the page's **own `blob:` URL** — a fetch each sender's CSP must permit by name (`connect-src blob:` in its `tool.toml`), which grants exactly nothing over the network — parks it in **IndexedDB**, and navigates.
- The receiving page delivers it through the **same file input a dropped file uses** (DataTransfer + synthetic `change`), so receivers need zero code and keep exactly one way of accepting a file. Records are keyed by the receiver's slug, consumed once, and swept after ten minutes.
- It is a **frame script** beside `feedback.js`, not a shared module: the row is rendered by the frame from the declaration, the lead line is a `[ui.tool]` string translated in all 14 locales, and each link borrows the target's own localized name and address — so the row cannot promise a tool the language does not have.

## The edges (12 senders, along the chains the workflow guides teach)

trim-video ⇄ reverse-video, both → video-to-gif; crop-video and timelapse-video → the same; video-to-gif → gif-analyzer/split-gif; gif-maker → gif-analyzer; document-scanner and images-to-pdf → merge-pdf/compress-pdf; merge-pdf → compress-pdf; stack-images → compress-image/resize-image; trim-audio ⇄ edit-audio. The build validates every edge against the tools that exist and refuses a bad one by name.

## The bug worth reading

The MutationObserver that watches for the download link also sees the row's own `hidden` attribute — and setting an attribute to the value it already has **still records a mutation**. An unguarded write in the callback is a microtask loop that freezes the tab (it froze two browsers during testing before the cause was found). Every write is now guarded by a read, with a comment explaining why.

## Verified

- Live end-to-end in Chrome: result appears → row shows beside Download with localized targets → click → file parked → landed on `/video-to-gif/` → picker showed "Reading the file..." and then the tool's own refusal of the deliberately-fake MP4 — delivery through the normal path, proven by the tool's own words — and the IndexedDB record was consumed (`recordsLeft: []`).
- `python build.py --out _plain --clean --no-minify` — debt-free; `blob:` present in senders' `connect-src`; the row renders in all 15 languages with localized names and addresses (asserted by a new test that sweeps every locale).
- `python -m unittest` — **391/391**; `node --test` — **1886/1886**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)