### PR TITLE
Give each language a feed

### DIFF
--- a/build.py
+++ b/build.py
@@ -353,6 +353,12 @@ def build(out, clean=False, minify_output=True, jobs=None):
     build_llms(out, templates, site, locales, ordered_tools, ordered_prose)
     written.append('llms.txt')
 
+    # And once more as a stream, for a reader who wants to be told when a tool
+    # ships rather than to come back and check. One file per published
+    # language, so this adds a name per locale rather than a single one.
+    build_feeds(out, templates, site, locales, ordered_tools, ordered_prose)
+    written += [f'{locale["prefix"]}feed.xml' for locale in i18n.published(locales)]
+
     copy_shared(out)
     write(out / 'site.css', site_css)
     write(out / 'lang.js', lang_js)
@@ -572,6 +578,13 @@ def frame(locale, locales, site, slug, base, links, lang_v, extra=None):
         # that crossing from one language to another is not also a second copy
         # of this file to fetch. shared/lang.js says what it does.
         'lang_href': f'/lang.js?v={lang_v}',
+        # This language's feed, and empty for a language that has none. Only a
+        # published locale gets one built, so offering the link from an
+        # unpublished one would point at a file that is not there - the same
+        # trap the hreflang set avoids by being built from published() too.
+        'feed_href': (f'/{locale["prefix"]}feed.xml'
+                      if locale['is_base'] or locale['complete'] else ''),
+        'feed_title': locale['site']['name'],
     }
     context.update(extra or {})
     return context
@@ -1416,6 +1429,77 @@ def build_sitemap(out, templates, site, locales, tools, prose):
                     if page['kind'] == 'legal' and ready(page['slug'])]
 
     write(out / 'sitemap.xml', templates.render('sitemap.xml', {'pages': entries}))
+
+
+# How many entries a feed carries. The site has more tools and guides than
+# this, and deliberately so: a feed answers "what has changed lately", which a
+# reader checks repeatedly, and the whole catalogue is already two files away
+# in sitemap.xml and llms.txt. Every entry past the first screenful is weight
+# on every poll for something nobody scrolls to.
+FEED_ENTRIES = 30
+
+
+def build_feeds(out, templates, site, locales, tools, prose):
+    """One Atom feed per published language, at /feed.xml and /<lang>/feed.xml.
+
+    Per language rather than one for the site, because a feed is a reading
+    experience and not an index: a German subscriber wants German titles at
+    German URLs, and mixing fifteen languages into one file would make it
+    useless to all of them. The same rule as everywhere else decides who gets
+    one - a locale that has not finished its frame is built and readable and
+    advertised to nobody, so it has no feed and no link to one.
+
+    Tools and guides, newest first. Not the legal pages, whose dates move for
+    reasons no reader subscribed to hear about, and not the hub or the roadmap,
+    which are indexes of things that appear here already.
+    """
+    for locale in i18n.published(locales):
+        entries = []
+        for tool in tools:
+            if not i18n.translated(locale, tool['slug']):
+                continue
+            said = i18n.localize_tool(tool, locale, site)
+            entries.append({'title': said['name'], 'url': said['url'],
+                            'summary': said['description'],
+                            'lastmod': said['lastmod']})
+        for page in prose:
+            if page['kind'] != 'guide' or not i18n.translated(locale, page['slug']):
+                continue
+            said = i18n.localize_page(page, locale, site)
+            entries.append({'title': said['heading'], 'url': said['url'],
+                            'summary': said['description'],
+                            'lastmod': said['lastmod']})
+
+        # Two passes, because Python's sort is stable: alphabetical first, then
+        # by date descending. A day on which four guides shipped then reads in
+        # a fixed order rather than in whatever order the folders were walked,
+        # which is what keeps a rebuild from reshuffling a feed that did not
+        # change and re-notifying everyone who subscribes to it.
+        entries.sort(key=lambda entry: entry['title'])
+        entries.sort(key=lambda entry: entry['lastmod'], reverse=True)
+        entries = entries[:FEED_ENTRIES]
+
+        for entry in entries:
+            entry['updated'] = f'{entry["lastmod"]}T00:00:00Z'
+
+        home = i18n.locale_url(locale, '', site)
+        said_site = locale['site']
+        feed = {
+            'lang': locale['hreflang'],
+            'title': said_site['name'],
+            'subtitle': said_site['hub']['description'],
+            'home': home,
+            'self': f'{home}feed.xml',
+            'author': said_site['name'],
+            # The newest entry, not the moment of the build. A feed whose
+            # timestamp moves on every deploy teaches a reader to ignore it,
+            # which is the same reason lastmod in the sitemap is a date somebody
+            # changed on purpose.
+            'updated': entries[0]['updated'] if entries else f'{site["lastmod"]}T00:00:00Z',
+            'entries': entries,
+        }
+        write(out / locale['prefix'] / 'feed.xml',
+              templates.render('feed.xml', {'feed': feed}))
 
 
 def build_llms(out, templates, site, locales, tools, prose):

--- a/templates/feed.xml
+++ b/templates/feed.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  GENERATED FILE - do not edit; see templates/feed.xml.
+
+  Atom rather than RSS, for one reason that matters here: Atom requires
+  `updated` on the feed and on every entry, and this site already keeps an
+  honest per-page date in `lastmod`. RSS's `pubDate` is optional and its
+  `lastBuildDate` means "when the file was generated", which on a static site
+  that rebuilds on every deploy would say a page changed when nothing about it
+  did. The sitemap makes the same choice for the same reason.
+
+  `type="html"` on the titles and summaries is not decoration. The strings come
+  from tool.toml and page.toml, where punctuation is written as entities so the
+  files stay ASCII on disk - `&mdash;` and friends. Escaped into an Atom text
+  construct they would arrive at a reader as the literal characters
+  `&mdash;`; declared as HTML they are unescaped once by the XML parser and
+  once more as markup, which is what the author wrote.
+
+  The feed lists tools and guides, newest first, and stops at a fixed count. It
+  is a "what changed lately" stream and not a second sitemap: something that
+  wants the whole site has sitemap.xml next door, and llms.txt after that.
+-->
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ feed.lang }}">
+  <title type="html">{{ feed.title | e }}</title>
+  <subtitle type="html">{{ feed.subtitle | e }}</subtitle>
+  <id>{{ feed.home }}</id>
+  <link rel="self" type="application/atom+xml" href="{{ feed.self }}"/>
+  <link rel="alternate" type="text/html" href="{{ feed.home }}"/>
+  <updated>{{ feed.updated }}</updated>
+  <author>
+    <name>{{ feed.author | e }}</name>
+    <uri>{{ feed.home }}</uri>
+  </author>
+{% for entry in feed.entries %}  <entry>
+    <title type="html">{{ entry.title | e }}</title>
+    <id>{{ entry.url }}</id>
+    <link rel="alternate" type="text/html" href="{{ entry.url }}"/>
+    <updated>{{ entry.updated }}</updated>
+    <summary type="html">{{ entry.summary | e }}</summary>
+  </entry>
+{% endfor %}</feed>

--- a/templates/guides.html
+++ b/templates/guides.html
@@ -26,6 +26,7 @@
 
 <link rel="canonical" href="{{ canonical }}">
 {% include "partials/alternates.html" %}
+{% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}
 
 <meta name="google-adsense-account" content="{{ site.adsense_client }}">

--- a/templates/hub.html
+++ b/templates/hub.html
@@ -29,6 +29,7 @@
 
 <link rel="canonical" href="{{ canonical }}">
 {% include "partials/alternates.html" %}
+{% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}
 
 <!--

--- a/templates/page.html
+++ b/templates/page.html
@@ -32,6 +32,7 @@
 
 <link rel="canonical" href="{{ page.url }}">
 {% include "partials/alternates.html" %}
+{% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}
 
 <meta name="google-adsense-account" content="{{ site.adsense_client }}">

--- a/templates/partials/feed.html
+++ b/templates/partials/feed.html
@@ -1,0 +1,11 @@
+<!--
+  This language's Atom feed, so a reader that finds any page of the site can
+  subscribe from it without being told where to look.
+
+  Root-absolute and per language, the same shape as the canonical above: a
+  German page offers the German feed, and the two never cross. A locale that
+  has not finished its frame has no feed built for it and no line here either -
+  the same rule the hreflang set and the sitemap follow, for the same reason.
+-->
+{% if feed_href %}<link rel="alternate" type="application/atom+xml" title="{{ feed_title | e }}" href="{{ feed_href }}">
+{% endif %}

--- a/templates/roadmap.html
+++ b/templates/roadmap.html
@@ -29,6 +29,7 @@
 
 <link rel="canonical" href="{{ canonical }}">
 {% include "partials/alternates.html" %}
+{% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}
 
 <meta name="google-adsense-account" content="{{ site.adsense_client }}">

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -42,6 +42,7 @@
 
 <link rel="canonical" href="{{ tool.url }}">
 {% include "partials/alternates.html" %}
+{% include "partials/feed.html" %}
 {% include "partials/lang-script.html" %}
 
 <!--

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -20,6 +20,7 @@ import re
 import subprocess
 import tempfile
 import unittest
+import xml.etree.ElementTree as ElementTree
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -898,6 +899,77 @@ class BuildTheSite(unittest.TestCase):
             slug = name[:-len('index.html')]
             with self.subTest(page=slug):
                 self.assertNotIn(f'<loc>{site["domain"]}{slug}</loc>', sitemap)
+
+    def test_every_published_language_has_a_feed_and_no_other_does(self):
+        """The fourth thing built from i18n.published, held to the same rule.
+
+        A feed for a language nobody is told about would be a way back into the
+        half-translated pages that the sitemap, the hreflang set and the
+        switcher all exist to keep out - and a quieter one, because a feed
+        reader keeps the URL after the site stops offering it.
+        """
+        feeds = {name for name in self.written if name.endswith('feed.xml')}
+        for locale in buildmod.i18n.published(self.locales):
+            with self.subTest(lang=locale['lang']):
+                self.assertIn(f'{locale["prefix"]}feed.xml', feeds)
+        for lang in self.unfinished:
+            with self.subTest(lang=lang):
+                self.assertNotIn(f'{lang}/feed.xml', feeds)
+
+    def test_a_feed_is_well_formed_and_stays_in_its_own_language(self):
+        """Two failures at once, because they have the same cause.
+
+        A feed is XML that nothing in this build parses, so a stray character
+        in a title would ship and only break in the reader - and every title
+        here comes from a TOML file where an author may well write an ampersand.
+        The second half is the one that would be embarrassing: a German
+        subscriber sent to English pages. Both come of assembling entries by
+        hand, so both are checked on the built files rather than on the values
+        that went into them.
+        """
+        atom = '{http://www.w3.org/2005/Atom}'
+        site = buildmod.sitelib.load_toml(ROOT / 'config' / 'site.toml')
+        for locale in buildmod.i18n.published(self.locales):
+            home = buildmod.i18n.locale_url(locale, '', site)
+            with self.subTest(lang=locale['lang']):
+                feed = ElementTree.parse(
+                    self.out / locale['prefix'] / 'feed.xml').getroot()
+                entries = feed.findall(f'{atom}entry')
+                self.assertTrue(entries, 'a feed with no entries in it')
+                for entry in entries:
+                    link = entry.find(f'{atom}link').get('href')
+                    self.assertTrue(
+                        link.startswith(home),
+                        f'{locale["lang"]} feed points outside its language: {link}')
+
+    def test_every_page_offers_the_feed_of_its_own_language(self):
+        """A file nothing links to is a file nobody subscribes to.
+
+        And the language has to match: the German pages offering the English
+        feed would be the hreflang mistake again, in a place no crawler reports.
+        """
+        for locale in buildmod.i18n.published(self.locales):
+            expected = f'href="/{locale["prefix"]}feed.xml"'
+            pages = [name for name in self.written
+                     if name.endswith('index.html')
+                     and name.startswith(locale['prefix'])
+                     and self.locale_of(name) == locale['prefix']]
+            self.assertTrue(pages, f'no pages built for {locale["lang"]}')
+            for name in pages:
+                with self.subTest(page=name):
+                    text = (self.out / name).read_text(encoding='utf-8')
+                    self.assertIn(expected, text)
+
+    def locale_of(self, name):
+        """The locale prefix a built page sits under, '' for English.
+
+        Worked out from the tree rather than from the locale list, so that a
+        page under a slug that merely begins with a language's letters is not
+        mistaken for a page in that language.
+        """
+        head = name.split('/', 1)[0]
+        known = {locale['lang'] for locale in self.locales}
+        return f'{head}/' if head in known else ''
 
     def test_an_unfinished_language_is_never_offered(self):
         """The other two of the three: no page anywhere points at it.


### PR DESCRIPTION
Adds an Atom feed per published language, at `/feed.xml` and `/<lang>/feed.xml`,
and links it from every page's head.

**Why.** The site publishes 35 tools and 40 guides in 15 languages and had no
way to say that anything had changed. `sitemap.xml` answers "what exists" for a
crawler, `llms.txt` answers "what is this" for an assistant; neither is
something a person subscribes to, and the aggregators that carry a site like
this one to new readers all read feeds.

**Atom, not RSS.** Atom requires `updated` on the feed and on every entry, and
this repo already keeps an honest per-page date in `lastmod`. RSS's
`lastBuildDate` means "when the file was generated", which on a static site
that rebuilds on every deploy would claim a page changed when nothing did —
the same reasoning the sitemap comment already gives for `lastmod` being a date
somebody edits on purpose.

**Held to the same rule as everything else.** The feeds are built from
`i18n.published`, so a locale that has not finished its frame gets no feed and
no link to one. That list now backs four things rather than three — sitemap,
hreflang set, switcher, feed — and there is a test for each half.

Thirty entries, newest first, tools and guides only. Not the legal pages, whose
dates move for reasons nobody subscribed to hear about, and not the hub or
roadmap, which index things already listed.

`type="html"` on the titles and summaries is load-bearing: the strings come
from TOML where punctuation is written as entities (`&mdash;`) so the files stay
ASCII, and an Atom *text* construct would deliver those literally.

### Verification

- `python build.py --out _plain --clean --no-minify` — exit 0, 15 feeds written
- all 15 parse as well-formed XML, 30 entries each
- `python -m unittest discover -t . -s tests/python` — 393 tests, OK
- `node --test "tests/js/*.test.js"` — 1886 pass, 0 fail

Three new tests in `test_build.py`: every published language has a feed and no
unpublished one does; each feed is well-formed and every entry stays inside its
own language; every page links the feed of the language it is written in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
