### PR TITLE
Put the carry-on row under the result rather than beside the button

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1164,7 +1164,23 @@ ins.adsbygoogle[data-ad-status="unfilled"] { display: none !important; }
   text-decoration: none;
 }
 
-.handoff-targets a:hover {
+.handoff-targets a:hover,
+.handoff-targets a:focus-visible {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+/* Drawn here rather than written into the markup so that Arabic gets an arrow
+   pointing the way Arabic reads - the same trick .lang-auto-back plays above,
+   and the reason the icon beside it is left alone: a magnifier is not a
+   direction. */
+.handoff-targets a::after { content: "\00a0\2192"; }
+[dir="rtl"] .handoff-targets a::after { content: "\00a0\2190"; }
+
+/* The moment between the click and the next page: the file is being read back
+   out of the page and parked for the tool that is about to open. It is short,
+   and this is only here so that a slow disk does not look like a dead link. */
+.handoff-targets a[aria-busy="true"] {
+  opacity: 0.55;
+  cursor: progress;
 }

--- a/shared/handoff.js
+++ b/shared/handoff.js
@@ -157,6 +157,35 @@
     return href.indexOf('blob:') === 0 ? anchor : null;
   }
 
+  /**
+   * The block the carry row belongs at the end of.
+   *
+   * Every tool that offers a handoff puts its download link in a row beside
+   * the result's own numbers - `.result-meta`, `.results-head` - and those rows
+   * are flex containers. Dropping the nav in next to the link there makes it a
+   * flex item: it lands to the *right* of the button and squeezes the layout
+   * the tool arranged, or wraps to a half-width band on its own line, and
+   * which of the two happens depends on how long the numbers happen to be in
+   * the reader's language. Climbing out of those rows to the nearest ordinary
+   * block and appending puts the row under the finished result instead, which
+   * is where a next step belongs and is the same place in every tool, at every
+   * window width, in every language.
+   */
+  function seat(anchor) {
+    var node = anchor;
+    while (node.parentNode && node.parentNode !== document.body) {
+      var parent = node.parentNode;
+      var display = window.getComputedStyle(parent).display;
+      // `none` is the tool holding the whole result back; seating the row
+      // inside it hides the row too, which is the right answer anyway.
+      if (display === 'block' || display === 'flow-root' || display === 'none') {
+        return parent;
+      }
+      node = parent;
+    }
+    return null;
+  }
+
   function show() {
     var anchor = result();
     // Every write in here is guarded by a read. The observer below watches
@@ -168,11 +197,15 @@
       if (!nav.hidden) nav.hidden = true;
       return;
     }
-    // Beside the download it belongs to: after the row of actions when the
-    // anchor sits in one, after the anchor itself when it does not.
-    var host = anchor.closest('.toolbar') || anchor;
-    if (!host.parentNode) return;
-    if (host.nextElementSibling !== nav) host.insertAdjacentElement('afterend', nav);
+    // Under the result the download belongs to. A tool laid out in a way this
+    // finds no block in falls back to the link's own side, which is where the
+    // row used to sit unconditionally.
+    var host = seat(anchor);
+    if (host) {
+      if (host.lastElementChild !== nav) host.appendChild(nav);
+    } else if (anchor.parentNode && anchor.nextElementSibling !== nav) {
+      anchor.insertAdjacentElement('afterend', nav);
+    }
     if (nav.hidden) nav.hidden = false;
   }
 
@@ -185,14 +218,26 @@
   });
   show();
 
+  // Reading the bytes back and parking them is fast - a blob: URL is a
+  // reference, not a copy, and IndexedDB stores it as one - but it is not
+  // instant, and the navigation only starts once it is done. A second click in
+  // that window would park a second file, addressed to a tool the reader is
+  // not about to open, where it would sit until the sweep. One carry at a time.
+  var carrying = false;
+
   nav.addEventListener('click', function (event) {
     var link = event.target && event.target.closest
       ? event.target.closest('a[data-slug]') : null;
     if (!link) return;
+    if (carrying) { event.preventDefault(); return; }
     var anchor = result();
     if (!anchor) return;    // stale click; let the plain navigation happen
 
     event.preventDefault();
+    carrying = true;
+    // Says "this click landed" for the moment before the page changes, in the
+    // one way that needs no words: the styling is in tool-frame.css.
+    link.setAttribute('aria-busy', 'true');
     var name = anchor.getAttribute('download') || 'result';
 
     // Read the page's own bytes back out of the blob: URL, park them for the

--- a/templates/partials/handoff.html
+++ b/templates/partials/handoff.html
@@ -10,14 +10,19 @@
   panel is: the lead line is translated in every locale's [ui.tool], and each
   link borrows the target tool's own localized name and address - so the row
   cannot promise a tool the language does not have.
+
+  The lead names the nav through aria-labelledby rather than a second copy of
+  itself in aria-label, so the sentence is translated once. The arrow after
+  each name is drawn in CSS, where Arabic can turn it around; written here it
+  would point out of the page in the one language that reads the other way.
 -->
-<nav class="handoff" id="handoff" aria-label="{{ ui.tool.handoff_lead }}" hidden>
-  <p class="handoff-lead">{{ ui.tool.handoff_lead }}</p>
+<nav class="handoff" id="handoff" aria-labelledby="handoff-lead" hidden>
+  <p class="handoff-lead" id="handoff-lead">{{ ui.tool.handoff_lead }}</p>
   <ul class="handoff-targets">
 {% for other in handoff %}    <li>
       <a href="{{ base }}{{ other.out_slug }}/" data-slug="{{ other.slug }}">
         <span aria-hidden="true">{{ other.icon }}</span>
-        {{ other.name | e }} <span aria-hidden="true">&rarr;</span>
+        {{ other.name | e }}
       </a>
     </li>
 {% endfor %}  </ul>


### PR DESCRIPTION
The "Carry the result straight into:" row shipped in 0618d5248 looked for a
`.toolbar` to sit after, and no tool that offers a handoff has one. All twelve
senders put the download link in a flex row beside the result's own numbers -
`.result-meta`, `.results-head`, `.result-head` - so the nav was inserted as a
**flex item** and landed to the right of the Download button, squeezing the
layout the tool arranged.

Measured on the built site, before and after:

| | before | after |
|---|---|---|
| video-to-gif @1280px | same row as the button, 522px, pushed right | below the result, 893px, block |
| document-scanner @894px | same row, 619px, shoving the head layout | below the facts list, full width |
| video-to-gif @420px | wrapped, full width | below, full width |

It appeared below the button only when the meta line ("480 x 260 · 14 frames ·
…") happened to be long enough to force a wrap - so the row moved between
tools, between window widths, and between languages.

## What changed

- **`shared/handoff.js`** climbs out of flex and grid rows to the nearest
  ordinary block and appends there, so the row is the last thing in the result
  block every time. A layout with no block to find falls back to the link's own
  side, which is where the row used to sit unconditionally.
- **The arrow is drawn in CSS**, with an RTL flip, the way `.lang-auto-back`
  already does it in the same file. Written into the markup it pointed out of
  the page in Arabic. The emoji icon is deliberately left alone: a magnifier is
  not a direction.
- **`aria-labelledby`** on the nav instead of a second translated copy of the
  lead in `aria-label`.
- **One carry at a time**: a click marks the link busy and refuses a second.
  Clicking two targets parked two files, one addressed to a tool the reader
  never opens, where it sat until the ten-minute sweep.

## Verification

- End to end in the browser: video-to-gif → gif-analyzer carried `carried.gif`
  through and the receiving tool analyzed it; the IndexedDB record was consumed.
- Arabic `ar/إنشاء-gif/` renders `←`; the row is still the last child.
- Reading a 100 MB blob back and parking it measured 117ms - a blob URL is a
  reference and IndexedDB stores it as one - so the busy state is insurance
  against a slow disk, not a real wait.
- 409 python tests and 1886 JS tests pass.

No `lastmod` bumps: nothing a crawler reads changed, and 12 tools × 14 locales
is not a submission worth spending.

Still silent on the receiving side - no "carried over from GIF Maker:
clip.gif". That needs a new placeholder string in `[ui.tool]` and all fourteen
locales, so it is left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
