### PR TITLE
Seat the guide breadcrumb inside the header, under the site mark

### DIFF
--- a/shared/site.css
+++ b/shared/site.css
@@ -360,7 +360,9 @@ code {
    one of the parts the build assembles. If one changes, change the other.
 
    Legal pages are passed an empty trail and never render the element, so these
-   rules apply to guides and to nothing else. */
+   rules apply to guides and to nothing else. On a guide the trail sits inside
+   the header, under the site mark - the scoped rule below adjusts the spacing
+   for that position and leaves this base copy identical to the tool page's. */
 
 .crumbs {
   display: flex;
@@ -380,8 +382,9 @@ code {
    mirrored rather than reworded when the trail itself reads the other way. */
 [dir="rtl"] .crumbs [aria-hidden="true"] { display: inline-block; transform: scaleX(-1); }
 
-/* A guide with a crumb above it does not also need the header's usual gap. */
-.crumbs + .hub-head { padding-top: 1.5rem; }
+/* Between the brand row and the heading, the base rule's padding-top would
+   read as a gap in the wrong place; the room it needs goes below instead. */
+.hub-head .crumbs { padding-top: 0; margin: 0 0 0.9rem; }
 
 .legal-date {
   margin: 1rem 0 0;

--- a/templates/page.html
+++ b/templates/page.html
@@ -85,19 +85,6 @@
 
 {% include "partials/lang-notice.html" %}
 
-<!--
-  The visible half of the BreadcrumbList in the head, and only where there is
-  one: a guide sits two levels down, under an index, and saying so is worth the
-  line. A legal page is passed an empty trail and this block does not render -
-  markup is meant to describe what a visitor can see, so a page with nothing to
-  show describes nothing.
--->
-{% if crumbs %}<nav class="crumbs" aria-label="{{ ui.breadcrumb }}">
-{% for crumb in crumbs %}  <a href="{{ crumb.href }}">{{ crumb.name }}</a>
-  <span aria-hidden="true">&rsaquo;</span>
-{% endfor %}  <span aria-current="page">{{ page.nav }}</span>
-</nav>
-{% endif %}
 <header class="hub-head">
   <div class="head-row">
     <p class="brand">
@@ -107,7 +94,21 @@
     </p>
     {% include "partials/lang-pick.html" %}
   </div>
-  <h1>{{ page.heading }}</h1>
+  <!--
+    The visible half of the BreadcrumbList in the head, and only where there is
+    one: a guide sits two levels down, under an index, and saying so is worth
+    the line. It sits inside the header, under the site mark, so the trail
+    shares the header's column instead of floating alone at the top of the
+    window. A legal page is passed an empty trail and this block does not
+    render - markup is meant to describe what a visitor can see, so a page
+    with nothing to show describes nothing.
+  -->
+{% if crumbs %}  <nav class="crumbs" aria-label="{{ ui.breadcrumb }}">
+{% for crumb in crumbs %}    <a href="{{ crumb.href }}">{{ crumb.name }}</a>
+    <span aria-hidden="true">&rsaquo;</span>
+{% endfor %}    <span aria-current="page">{{ page.nav }}</span>
+  </nav>
+{% endif %}  <h1>{{ page.heading }}</h1>
   <p class="lede">
 {{ page.lede }}
   </p>


### PR DESCRIPTION
## What changed

On a guide page the `All tools › Guides › …` trail rendered above the whole header, and `shared/site.css` never gave `.crumbs` the centred 940px column that `tool-frame.css` gives it on a tool page — so on a wide window the trail hugged the top-left corner of the viewport while everything else sat centred. The trail now lives inside `<header class="hub-head">`, between the brand row and the heading, where it inherits the header's column and can no longer drift.

- `templates/page.html` — the `<nav class="crumbs">` block moved inside the header; legal pages are still passed an empty trail and render nothing.
- `shared/site.css` — one scoped rule `.hub-head .crumbs` for the new spacing, and the now-dead `.crumbs + .hub-head` gap rule removed. The base `.crumbs` rules stay identical to the tool page's copy, per the "if one changes, change the other" contract between the two sheets.

## Why below the mark rather than beside it

The brand row already carries the language picker on its right, and the trail ends with the page's own title — the German trail spans the full column at 375px, so beside the brand it would collide with the picker and wrap mid-trail. Below, the header reads: site mark, then where you are, then the title.

## Reviewer notes

- Verified in a browser: English desktop (brand, trail, and heading share one left edge), German at 375px (longest trail, one line, no horizontal overflow), Arabic (trail starts at the right edge, `›` separators mirrored), and the privacy page (unchanged).
- CI-style build is clean; all 409 Python tests pass. Tool pages keep their trail above the topbar — they have no site-brand row, so nothing to seat it under.
- Guide `lastmod` dates are deliberately untouched: layout moved, wording did not, and bumping every guide would announce the whole set to IndexNow for a cosmetic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)