### PR TITLE
Take AdSense off the share page

### DIFF
--- a/build.py
+++ b/build.py
@@ -593,6 +593,10 @@ def frame(locale, locales, site, slug, base, links, lang_v, extra=None):
         },
         'base': base,
         'links': links,
+        # Whether this page carries the AdSense script. True everywhere unless
+        # a tool.toml turns it off; see templates/partials/head-scripts.html
+        # for the one page that does and why.
+        'ads': True,
         'canonical': i18n.locale_url(locale, slug, site),
         'alternates': i18n.alternates(locales, slug, site),
         'languages': i18n.switcher(locales, locale, slug, site),
@@ -862,6 +866,10 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
     page = emit.html(dest / 'index.html', templates.render(
         'tool.html', frame(locale, locales, site, tool['slug'], '../', links, lang_v, {
             'tool': tool,
+            # A tool may decline the ad script. Only share-text does, because
+            # AdSense posts the URL fragment - which is that tool's link name
+            # - to an ad server. See its tool.toml.
+            'ads': tool.get('ads', True),
             'guide': guide,
             'related': related,
             'ui': ui,

--- a/templates/partials/head-scripts.html
+++ b/templates/partials/head-scripts.html
@@ -1,9 +1,24 @@
 <!--
   AdSense. Async so it cannot delay the app; crossorigin="anonymous" is
   Google's own snippet, unchanged.
+
+  Left out where a page sets `ads = false` in its tool.toml, which today means
+  /share-text/ alone. The reason is specific rather than squeamish: this
+  script reads location.href and sends the whole of it, fragment included, to
+  googleads.g.doubleclick.net. Every other page on this site keeps nothing in
+  its fragment, so that is merely a URL. On the share tool the fragment is the
+  link name - the entire capability to read the share - and posting it to an
+  ad server beside the reader's IP address hands away the thing the tool
+  exists to protect.
+
+  It has to be omission rather than ordering. This script is async and the
+  tool's own module is deferred, so clearing the fragment before the ad reads
+  it is a race the page cannot reliably win.
 -->
+{% if ads %}
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client={{ site.adsense_client }}"
         crossorigin="anonymous"></script>
+{% endif %}
 
 <!-- Google tag (gtag.js). The configuration half lives in analytics.js. -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics_id }}"></script>

--- a/tools/share-text/tool.toml
+++ b/tools/share-text/tool.toml
@@ -29,6 +29,20 @@ category = "text-codes-and-passwords"
 roadmap_group = "beyond"
 lastmod = "2026-08-26"
 
+# No AdSense on this page, alone on the site.
+#
+# The link name lives in the URL fragment because browsers do not send
+# fragments to servers - that is the whole reason it is written there. The
+# AdSense script does not honour that: it reads location.href and posts all of
+# it, fragment included, to googleads.g.doubleclick.net, where it lands in a
+# log beside the reader's IP address. For an open share the link name is the
+# entire capability to read it, so that one request gives away exactly what
+# this tool promises to keep.
+#
+# Omission rather than ordering: the ad script is async and this tool's module
+# is deferred, so clearing the fragment first is a race the page cannot win.
+ads = false
+
 # --- what search engines and chat apps are told ------------------------------
 
 title = "Share Text &amp; Files Between Devices &mdash; Direct, Encrypted, Nothing Stored"


### PR DESCRIPTION
**A live privacy leak on the share tool.** Found by the QA suite's new `share-text` spec; the test failed against production this afternoon and passes against this build.

## What was happening

The link name lives in the URL fragment because **browsers do not send fragments to servers** — that's the entire reason it's written there.

`adsbygoogle.js` doesn't honour that. It reads `location.href` and posts all of it, fragment included, in its `url=` parameter:

```
url=http%3A%2F%2Fabox.tools%2Fshare-text%2F%23qa-mtay0mpe-0tt1km
```

So every reader who opened a share link handed **the link name to an ad server, logged beside their own IP address**. For an open share, the link name is the entire capability to read it. One request gave away exactly what this tool exists to protect.

## Why omission and not ordering

`adsbygoogle.js` is `async`; this tool's module is `defer`. Clearing the fragment before the ad script reads it is a race the page cannot reliably win, so the script has to not be there at all.

## Scope

`tool.toml` may now set `ads = false`. **share-text is the only page that does** — all 15 of its language versions verified clean, and **1,273 other pages still carry the script**, untouched.

I checked Google Analytics for the same fault while I was here: with the tag active, the fragment does not appear in anything it sends. AdSense was the only leak.

## Still outstanding (not fixed here)

The consent gate says *"Nothing is fetched, and nothing about you is shared, until you choose to connect"*, but `view(code)` opens the rendezvous socket on page load — so the reader's address and the link name reach the rendezvous before they've read the sentence offering the choice. The **peer** connection does wait, which is what would reveal them to the sharer. That's the code and the copy disagreeing about which connection is being consented to; it needs a decision from you on which side changes, so I've left it as a failing test rather than guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)