### PR TITLE
Wire the share tool into the frame it ships inside

### DIFF
--- a/locales/ar/tools/share-text.html
+++ b/locales/ar/tools/share-text.html
@@ -64,7 +64,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="رابط المشاركة">
         <button type="button" id="copylink" class="ghost">نسخ الرابط</button>
-        <button type="button" id="stop" class="ghost">إيقاف المشاركة</button>
+        <button type="button" id="stop" class="danger">إيقاف المشاركة</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/de/tools/share-text.html
+++ b/locales/de/tools/share-text.html
@@ -66,7 +66,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="Der Freigabe-Link">
         <button type="button" id="copylink" class="ghost">Link kopieren</button>
-        <button type="button" id="stop" class="ghost">Freigabe beenden</button>
+        <button type="button" id="stop" class="danger">Freigabe beenden</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/es/tools/share-text.html
+++ b/locales/es/tools/share-text.html
@@ -66,7 +66,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="El enlace para compartir">
         <button type="button" id="copylink" class="ghost">Copiar enlace</button>
-        <button type="button" id="stop" class="ghost">Dejar de compartir</button>
+        <button type="button" id="stop" class="danger">Dejar de compartir</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/fr/tools/share-text.html
+++ b/locales/fr/tools/share-text.html
@@ -66,7 +66,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="Le lien de partage">
         <button type="button" id="copylink" class="ghost">Copier le lien</button>
-        <button type="button" id="stop" class="ghost">Arrêter le partage</button>
+        <button type="button" id="stop" class="danger">Arrêter le partage</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/hi/tools/share-text.html
+++ b/locales/hi/tools/share-text.html
@@ -64,7 +64,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="साझा करने का लिंक">
         <button type="button" id="copylink" class="ghost">लिंक कॉपी करें</button>
-        <button type="button" id="stop" class="ghost">साझा करना रोकें</button>
+        <button type="button" id="stop" class="danger">साझा करना रोकें</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/id/tools/share-text.html
+++ b/locales/id/tools/share-text.html
@@ -66,7 +66,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="Tautan berbagi">
         <button type="button" id="copylink" class="ghost">Salin tautan</button>
-        <button type="button" id="stop" class="ghost">Berhenti berbagi</button>
+        <button type="button" id="stop" class="danger">Berhenti berbagi</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/it/tools/share-text.html
+++ b/locales/it/tools/share-text.html
@@ -66,7 +66,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="Il link di condivisione">
         <button type="button" id="copylink" class="ghost">Copia link</button>
-        <button type="button" id="stop" class="ghost">Smetti di condividere</button>
+        <button type="button" id="stop" class="danger">Smetti di condividere</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/ja/tools/share-text.html
+++ b/locales/ja/tools/share-text.html
@@ -56,7 +56,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="共有リンク">
         <button type="button" id="copylink" class="ghost">リンクをコピー</button>
-        <button type="button" id="stop" class="ghost">共有をやめる</button>
+        <button type="button" id="stop" class="danger">共有をやめる</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/ko/tools/share-text.html
+++ b/locales/ko/tools/share-text.html
@@ -63,7 +63,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="공유 링크">
         <button type="button" id="copylink" class="ghost">링크 복사</button>
-        <button type="button" id="stop" class="ghost">공유 중지</button>
+        <button type="button" id="stop" class="danger">공유 중지</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/nl/tools/share-text.html
+++ b/locales/nl/tools/share-text.html
@@ -65,7 +65,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="De deellink">
         <button type="button" id="copylink" class="ghost">Link kopiëren</button>
-        <button type="button" id="stop" class="ghost">Stoppen met delen</button>
+        <button type="button" id="stop" class="danger">Stoppen met delen</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/pt/tools/share-text.html
+++ b/locales/pt/tools/share-text.html
@@ -66,7 +66,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="O link de compartilhamento">
         <button type="button" id="copylink" class="ghost">Copiar link</button>
-        <button type="button" id="stop" class="ghost">Parar de compartilhar</button>
+        <button type="button" id="stop" class="danger">Parar de compartilhar</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/tr/tools/share-text.html
+++ b/locales/tr/tools/share-text.html
@@ -66,7 +66,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="Paylaşım bağlantısı">
         <button type="button" id="copylink" class="ghost">Bağlantıyı kopyala</button>
-        <button type="button" id="stop" class="ghost">Paylaşmayı durdur</button>
+        <button type="button" id="stop" class="danger">Paylaşmayı durdur</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/zh-TW/tools/share-text.html
+++ b/locales/zh-TW/tools/share-text.html
@@ -56,7 +56,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="分享連結">
         <button type="button" id="copylink" class="ghost">複製連結</button>
-        <button type="button" id="stop" class="ghost">停止分享</button>
+        <button type="button" id="stop" class="danger">停止分享</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/locales/zh/tools/share-text.html
+++ b/locales/zh/tools/share-text.html
@@ -56,7 +56,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="分享链接">
         <button type="button" id="copylink" class="ghost">复制链接</button>
-        <button type="button" id="stop" class="ghost">停止分享</button>
+        <button type="button" id="stop" class="danger">停止分享</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/tools/share-text/body.html
+++ b/tools/share-text/body.html
@@ -69,7 +69,7 @@
       <div class="namerow" id="linkrow" hidden>
         <input id="link" readonly aria-label="The share link">
         <button type="button" id="copylink" class="ghost">Copy link</button>
-        <button type="button" id="stop" class="ghost">Stop sharing</button>
+        <button type="button" id="stop" class="danger">Stop sharing</button>
       </div>
       <p id="status" role="status" aria-live="polite"></p>
       <div id="requests"></div>

--- a/tools/share-text/src/main.js
+++ b/tools/share-text/src/main.js
@@ -635,6 +635,108 @@ $('copytext').addEventListener('click', () => {
 
 $('retry').addEventListener('click', () => location.reload());
 
+/* ----------------------------------------------------- the frame's panels */
+
+$('privacy-toggle').addEventListener('click', () => {
+  const panel = $('privacy-panel');
+  const open = panel.hidden;
+  panel.hidden = !open;
+  $('privacy-toggle').setAttribute('aria-expanded', String(open));
+});
+
+const PLATFORM_HOSTS = /(^|\.)(googlesyndication\.com|doubleclick\.net|googleadservices\.com|googletagservices\.com|adtrafficquality\.google|googletagmanager\.com|google-analytics\.com|gstatic\.com|googleapis\.com|buymeacoffee\.com|cloudflareinsights\.com|google\.[a-z]{2,3}(\.[a-z]{2})?)$/;
+const RENDEZVOUS_HOST = new URL(RENDEZVOUS.replace('wss:', 'https:')).hostname;
+
+/**
+ * Report what this page has actually fetched.
+ *
+ * The claim on trial here is sharper than on the rest of the site: this page
+ * does talk to a server, and says so. What must still be true is that no
+ * request carried the content - the rendezvous WebSocket ferries only the
+ * introduction, and everything else on the wire is the frame's own ads and
+ * measurement.
+ */
+function monitorNetwork() {
+  const platform = new Set();
+  const external = new Set();
+
+  const inspect = (entries) => {
+    for (const entry of entries) {
+      if (entry.name.startsWith('blob:') || entry.name.startsWith('data:')) continue;
+      const url = new URL(entry.name, location.href);
+      if (url.origin === location.origin) continue;
+      if (url.hostname === RENDEZVOUS_HOST) continue; // the introduction, declared on this page
+      if (PLATFORM_HOSTS.test(url.hostname)) platform.add(url.hostname);
+      else external.add(url.hostname);
+    }
+    const total = performance.getEntriesByType('resource')
+      .filter((entry) => !entry.name.startsWith('blob:') && !entry.name.startsWith('data:')).length;
+
+    const clean = external.size === 0;
+    const platformNote = platform.size === 0
+      ? ''
+      : ` The page's own ad, measurement and donate-button scripts loaded from ${platform.size} `
+        + `host${platform.size === 1 ? '' : 's'}; not one of them was given a character of it.`;
+
+    $('network-count').textContent = clean
+      ? `what this page shares has gone through no server. ${total} files loaded.${platformNote}`
+      : `something contacted ${[...external].join(', ')}, which this tool never does.${platformNote}`;
+
+    $('network-count').className = clean ? 'good' : 'warn';
+    $('network-dot').className = `live-dot ${clean ? 'good' : 'warn'}`;
+  };
+
+  inspect(performance.getEntriesByType('resource'));
+  try {
+    new PerformanceObserver((list) => inspect(list.getEntries()))
+      .observe({ type: 'resource', buffered: true });
+  } catch {
+    // PerformanceObserver is unavailable; the one-time snapshot above stands.
+  }
+}
+
+async function registerServiceWorker() {
+  const fail = (message, detail) => {
+    $('offline-status').textContent = message;
+    $('offline-dot').className = 'live-dot';
+    if (detail) {
+      $('offline-status').title = detail;
+      console.info('Offline caching unavailable:', detail);
+    }
+  };
+
+  if (!('serviceWorker' in navigator)) {
+    fail(phrase('offline.none'));
+    return;
+  }
+  if (!window.isSecureContext) {
+    fail(phrase('offline.insecure'));
+    return;
+  }
+
+  try {
+    await navigator.serviceWorker.register('sw.js');
+    await navigator.serviceWorker.ready;
+    $('offline-status').textContent = phrase('offline.ready');
+    $('offline-status').className = 'good';
+    $('offline-dot').className = 'live-dot good';
+  } catch (error) {
+    fail(phrase('offline.failed'), error.message);
+  }
+}
+
+// An error thrown after boot would otherwise only reach the console, leaving
+// the page looking functional but doing nothing. Whichever half is showing
+// carries the message.
+function bootError(detail) {
+  const target = $('share').hidden ? $('view-status') : $('status');
+  target.hidden = false;
+  target.classList.add('warn');
+  target.textContent = phrase('error.broke', { detail });
+}
+window.addEventListener('error', (event) => bootError(event.message));
+window.addEventListener('unhandledrejection', (event) => bootError(event.reason?.message ?? event.reason));
+
 /* --------------------------------------------------------------- routing */
 
 const code = location.hash.replace(/^#/, '').toLowerCase();
@@ -645,3 +747,27 @@ else { suggest(); restore(); }
 // hash navigation never reloads the document on its own - so make it, or
 // the page stays frozen on whatever the last share ended as.
 addEventListener('hashchange', () => location.reload());
+
+// The language switcher links to this page's siblings, and a fragment never
+// survives a plain navigation - so a reader who switched language landed on
+// the sharer's empty editor. Carry the share name across instead. Compared
+// by pathname, because the head's alternate links carry the deployed
+// domain and the switcher's anchors resolve against wherever the page is
+// actually being served from.
+const alternates = new Set(
+  [...document.querySelectorAll('link[rel="alternate"][hreflang]')]
+    .map((link) => new URL(link.href).pathname),
+);
+addEventListener('click', (event) => {
+  if (location.hash === '') return;
+  const anchor = event.target.closest('a[href]');
+  if (anchor && anchor.origin === location.origin && alternates.has(anchor.pathname)) {
+    anchor.href = anchor.pathname + location.hash;
+  }
+}, true);
+
+monitorNetwork();
+registerServiceWorker();
+
+// Reached only if every step above ran without throwing.
+document.getElementById('boot-warning')?.remove();

--- a/tools/share-text/styles.css
+++ b/tools/share-text/styles.css
@@ -95,7 +95,16 @@
 }
 .namerow input:focus { outline: none; border-color: var(--accent); }
 
-#status.warn { color: var(--danger, #b4552d); }
+#status.warn,
+#view-status.warn { color: var(--danger); }
+
+/* Ending the share is the one destructive act on the page, and the button
+   that does it should not dress like its neighbours. */
+button.danger {
+  background: var(--danger);
+  border: 1px solid var(--danger);
+  color: #fff;
+}
 
 /* ------------------------------------------- reader requests and file rows */
 


### PR DESCRIPTION
Three field reports from the first hours of `/share-text/` in production,
all fixed and verified against a local build.

## The boot warning showed on a working page

Root cause: `main.js` was ported from the proof of concept without the
frame-wiring block every tool's `main.js` owes the page it ships inside.
Nothing removed `#boot-warning` (so the red "this page's code did not run"
banner sat over a functioning page), nothing fed the live network check or
registered the service worker (both trust lines stuck at "checking…"), and
the how-this-is-verified toggle was dead. The wiring is now the same block
`password-generator` carries — privacy panel, network monitor, service
worker, error handlers, boot-warning removal last. One tool-specific line:
the network monitor treats the rendezvous host as declared rather than
foreign, since this page names it and explains it.

## Switching language kicked a reader back to the sharer UI

The switcher's links carry no fragment. A capture-phase click handler now
appends the share name to any link whose **pathname** matches one of the
page's own `hreflang` alternates — pathname, not href, because the head's
alternates carry the deployed domain while the anchors resolve against
wherever the page is served. Verified: `/de/text-teilen/` becomes
`/de/text-teilen/#name` at click time, so a reader stays a reader.

## Stop sharing is now red

The one destructive act on the page wears the frame's `--danger` token via
a new `button.danger` style — a one-class change across the English body
and all fourteen locale bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
