### PR TITLE
Fold the pledge banner down to its one-line claim

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -190,7 +190,7 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
 
 .pledge {
   margin-bottom: 1.25rem;
-  padding: 1.2rem 1.4rem;
+  padding: 0.9rem 1.4rem;
   border-radius: var(--radius);
   border: 1px solid color-mix(in srgb, var(--ok) 40%, var(--border));
   background:
@@ -213,6 +213,36 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
 
 .pledge-line strong { color: var(--ok); }
 .pledge-mark { color: var(--ok); font-size: 0.7em; flex: none; }
+
+/* The fold. Everything under the headline sits in a native <details>, so the
+   tool itself starts near the top of the page; the summary - the claim and
+   the two live dots - never leaves the screen, folded or not. */
+.pledge-fold summary { list-style: none; cursor: pointer; }
+.pledge-fold summary::-webkit-details-marker { display: none; }
+
+.pledge-glance {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-inline-start: auto;
+  align-self: center;
+  padding-inline-start: 0.55rem;
+}
+
+/* The affordance the hidden default marker was providing. Physical borders on
+   purpose: a caret that points down or up needs no mirroring for RTL. */
+.pledge-caret {
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-inline-start: 0.25rem;
+  border-right: 2px solid var(--text-dim);
+  border-bottom: 2px solid var(--text-dim);
+  transform: rotate(45deg);
+  transition: transform 0.15s ease;
+}
+
+.pledge-fold[open] .pledge-caret { transform: rotate(-135deg); }
+.pledge-fold summary:hover .pledge-caret { border-color: var(--accent); }
 
 .pledge-sub {
   margin: 0.5rem 0 0;
@@ -289,11 +319,11 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
   max-width: 66ch;
 }
 
-/* On a phone the full-size pledge pushed the drop zone off screen entirely.
-   Tighten it rather than dropping anything: the "check it yourself" line is
-   exactly what a privacy-minded visitor on mobile came to read. */
+/* The fold above already keeps the pledge to one line, but on a phone even
+   that line is tight, and the folded-open text still deserves the smaller
+   sizes it had before the fold existed. */
 @media (max-width: 620px) {
-  .pledge { padding: 0.95rem 1rem; }
+  .pledge { padding: 0.8rem 1rem; }
   .pledge-line { font-size: 1.02rem; gap: 0.4rem; }
   .pledge-sub { font-size: 0.85rem; margin-top: 0.4rem; }
   .pledge-facts { margin-top: 0.7rem; gap: 0.3rem 0.35rem; }

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -233,35 +233,53 @@
   to your files does it by taking them off you first, so the difference is worth
   stating before the first file is asked for, not in a panel you have to go
   looking for.
+
+  Only the claim, though. The paragraph, the fact chips and the live check's
+  words used to sit open under it and together they pushed the tool itself
+  below the fold, so everything but the one sentence now folds into a native
+  <details> - chosen over a scripted panel because it needs nothing from
+  main.js (the live-check code is copied into every tool) and the folded text
+  stays in the page for a crawler to read. The two live dots live in the
+  summary line, so the measured proof stays on screen even folded; the words
+  behind them are one click away. The dots keep bare class="live-dot" because
+  every tool's main.js assigns className outright, wiping anything else.
 -->
 <section class="pledge">
-  <p class="pledge-line">
-    <span class="pledge-mark" aria-hidden="true">&#9679;</span>
+  <details class="pledge-fold">
+    <summary class="pledge-line">
+      <span class="pledge-mark" aria-hidden="true">&#9679;</span>
+      <span class="pledge-title">
 {{ ui.tool.pledge_line }}
-  </p>
-  <p class="pledge-sub">
+      </span>
+      <span class="pledge-glance" aria-hidden="true">
+        <span id="network-dot" class="live-dot"></span>
+        <span id="offline-dot" class="live-dot"></span>
+        <span class="pledge-caret"></span>
+      </span>
+    </summary>
+
+    <p class="pledge-sub">
 {{ tool.pledge }}
-  </p>
-
-  <ul class="pledge-facts">
-{% for fact in tool.facts %}    <li><span aria-hidden="true">{{ fact.mark }}</span> {{ fact.text }}</li>
-{% endfor %}  </ul>
-
-  <!-- Live, measured, and wrong-provable: this is the part that turns the
-       claim above into something a sceptical visitor can check. -->
-  <div class="pledge-live">
-    <p class="live-row">
-      <span id="network-dot" class="live-dot" aria-hidden="true"></span>
-      <span><strong>{{ ui.tool.live_check }}</strong> <span id="network-count">{{ ui.tool.checking }}</span></span>
     </p>
-    <p class="live-row">
-      <span id="offline-dot" class="live-dot" aria-hidden="true"></span>
-      <span><strong>{{ ui.tool.offline }}</strong> <span id="offline-status">{{ ui.tool.checking }}</span></span>
-    </p>
-    <p class="live-hint">
+
+    <ul class="pledge-facts">
+{% for fact in tool.facts %}      <li><span aria-hidden="true">{{ fact.mark }}</span> {{ fact.text }}</li>
+{% endfor %}    </ul>
+
+    <!-- Live, measured, and wrong-provable: this is the part that turns the
+         claim above into something a sceptical visitor can check. -->
+    <div class="pledge-live">
+      <p class="live-row">
+        <strong>{{ ui.tool.live_check }}</strong> <span id="network-count">{{ ui.tool.checking }}</span>
+      </p>
+      <p class="live-row">
+        <strong>{{ ui.tool.offline }}</strong> <span id="offline-status">{{ ui.tool.checking }}</span>
+      </p>
+      <p class="live-hint">
 {{ tool.live_hint }}
-    </p>
-  </div>
+      </p>
+    </div>
+  </details>
 </section>
 
 <section id="privacy-panel" class="privacy" hidden>


### PR DESCRIPTION
## What changed

The pledge banner on every tool page — headline, explanatory paragraph, five fact chips, the live-check rows and the DevTools hint — collapsed the tool itself below the fold. Everything under the headline now sits inside a native `<details>`: the banner is one line (the claim, the two live status dots, a caret) until the visitor opens it. Collapsed it measures ~57px against ~372px before, on every tool page in every language.

## Why a fold rather than a status icon

- The claim is the product; the template's own comment records that it should be seen before the first file is asked for. An icon-hidden panel would also duplicate the "How this is verified" button already in the header.
- A native `<details>` needs no JavaScript. The live-check code is deliberately copied into every tool's `main.js`, so any scripted collapse would have touched ~40 tools; this touches only `templates/tool.html` and `shared/css/tool-frame.css`.
- The folded text stays in the DOM for crawlers.

## Details a reviewer should know

- The two live dots (`#network-dot`, `#offline-dot`) moved into the `<summary>`, so the measured proof stays on screen even folded. They keep a bare `class="live-dot"` because every tool's `main.js` assigns `className` outright and would wipe any extra class.
- The caret uses physical borders deliberately: a down/up chevron needs no RTL mirroring. The rest of the summary line mirrors via logical properties — verified on the built Arabic page, where the dots and caret flow to the left edge and the fold opens and closes on click.
- No `lastmod` moves: no wording changed, and docs/deploying.md is explicit that a frame change that moves no words submits nothing to IndexNow.
- Verified in the browser on the built site: collapsed by default, opens/closes on click, dots turn green after the live check runs, `main.js` boots, and the header's verification panel still works.

## Tests

- `python build.py --out _plain --clean --no-minify` — pass
- `python -m unittest discover -t . -s tests/python` — pass
- `node --test "tests/js/*.test.js"` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
