### PR TITLE
Carry a reader's session across a language switch

### DIFF
--- a/locales/ar/tools/share-text.html
+++ b/locales/ar/tools/share-text.html
@@ -156,6 +156,7 @@
     <span data-phrase="share.lost-rendezvous">انقطع الاتصال بالوسيط؛ تجري إعادة المحاولة. القراء المتصلون لا يتأثرون.</span>
     <span data-phrase="share.stopped">توقّف. لم يعد يُشارَك شيء.</span>
     <span data-phrase="share.file-too-big">&laquo;{name}&raquo; يتجاوز حد 200 MB.</span>
+    <span data-phrase="share.leave-warning">مغادرة هذه الصفحة تُنهي المشاركة للجميع. أتريد المتابعة؟</span>
 
     <span data-phrase="copy.done">نُسخ</span>
     <span data-phrase="copy.link">نسخ الرابط</span>

--- a/locales/de/tools/share-text.html
+++ b/locales/de/tools/share-text.html
@@ -162,6 +162,7 @@
     <span data-phrase="share.lost-rendezvous">Verbindung zum Vermittler verloren; neuer Versuch. Verbundene Leser sind nicht betroffen.</span>
     <span data-phrase="share.stopped">Beendet. Es wird nichts mehr geteilt.</span>
     <span data-phrase="share.file-too-big">&bdquo;{name}&ldquo; liegt über der Grenze von 200 MB.</span>
+    <span data-phrase="share.leave-warning">Wenn Sie diese Seite verlassen, endet die Freigabe für alle. Fortfahren?</span>
 
     <span data-phrase="copy.done">Kopiert</span>
     <span data-phrase="copy.link">Link kopieren</span>

--- a/locales/es/tools/share-text.html
+++ b/locales/es/tools/share-text.html
@@ -160,6 +160,7 @@
     <span data-phrase="share.lost-rendezvous">Se perdió el servidor de presentación; reintentando. Los lectores conectados no se ven afectados.</span>
     <span data-phrase="share.stopped">Detenido. Ya no se comparte nada.</span>
     <span data-phrase="share.file-too-big">«{name}» supera el límite de 200 MB.</span>
+    <span data-phrase="share.leave-warning">Salir de esta página termina la compartición para todos. ¿Continuar?</span>
 
     <span data-phrase="copy.done">Copiado</span>
     <span data-phrase="copy.link">Copiar enlace</span>

--- a/locales/fr/tools/share-text.html
+++ b/locales/fr/tools/share-text.html
@@ -161,6 +161,7 @@
     <span data-phrase="share.lost-rendezvous">Connexion à l'entremetteur perdue&nbsp;; nouvelle tentative. Les lecteurs connectés ne sont pas affectés.</span>
     <span data-phrase="share.stopped">Arrêté. Plus rien n'est partagé.</span>
     <span data-phrase="share.file-too-big">&laquo;&nbsp;{name}&nbsp;&raquo; dépasse la limite de 200 Mo.</span>
+    <span data-phrase="share.leave-warning">Quitter cette page met fin au partage pour tout le monde. Continuer ?</span>
 
     <span data-phrase="copy.done">Copié</span>
     <span data-phrase="copy.link">Copier le lien</span>

--- a/locales/hi/tools/share-text.html
+++ b/locales/hi/tools/share-text.html
@@ -158,6 +158,7 @@
     <span data-phrase="share.lost-rendezvous">बिचौलिए से संपर्क टूट गया; दोबारा कोशिश जारी। जुड़े पाठकों पर असर नहीं पड़ता।</span>
     <span data-phrase="share.stopped">रुक गया। अब कुछ साझा नहीं हो रहा।</span>
     <span data-phrase="share.file-too-big">&ldquo;{name}&rdquo; 200 MB की सीमा से बड़ी है।</span>
+    <span data-phrase="share.leave-warning">यह पन्ना छोड़ने से साझा सबके लिए खत्म हो जाएगा। जारी रखें?</span>
 
     <span data-phrase="copy.done">कॉपी हो गया</span>
     <span data-phrase="copy.link">लिंक कॉपी करें</span>

--- a/locales/id/tools/share-text.html
+++ b/locales/id/tools/share-text.html
@@ -162,6 +162,7 @@
     <span data-phrase="share.lost-rendezvous">Koneksi ke perantara terputus; mencoba lagi. Pembaca yang terhubung tidak terpengaruh.</span>
     <span data-phrase="share.stopped">Berhenti. Tidak ada lagi yang dibagikan.</span>
     <span data-phrase="share.file-too-big">&ldquo;{name}&rdquo; melebihi batas 200 MB.</span>
+    <span data-phrase="share.leave-warning">Meninggalkan halaman ini mengakhiri berbagi untuk semua. Lanjutkan?</span>
 
     <span data-phrase="copy.done">Tersalin</span>
     <span data-phrase="copy.link">Salin tautan</span>

--- a/locales/it/tools/share-text.html
+++ b/locales/it/tools/share-text.html
@@ -160,6 +160,7 @@
     <span data-phrase="share.lost-rendezvous">Perso il server delle presentazioni; riprovo. I lettori connessi non ne risentono.</span>
     <span data-phrase="share.stopped">Fermato. Non si condivide più niente.</span>
     <span data-phrase="share.file-too-big">«{name}» supera il limite di 200 MB.</span>
+    <span data-phrase="share.leave-warning">Lasciando questa pagina la condivisione finisce per tutti. Continuare?</span>
 
     <span data-phrase="copy.done">Copiato</span>
     <span data-phrase="copy.link">Copia link</span>

--- a/locales/ja/tools/share-text.html
+++ b/locales/ja/tools/share-text.html
@@ -135,6 +135,7 @@
     <span data-phrase="share.lost-rendezvous">仲介役との接続が切れました。再試行しています。接続中の読む側には影響ありません。</span>
     <span data-phrase="share.stopped">停止しました。もう何も共有されていません。</span>
     <span data-phrase="share.file-too-big">「{name}」は200 MBの上限を超えています。</span>
+    <span data-phrase="share.leave-warning">このページを離れると、共有は全員にとって終わります。続けますか？</span>
 
     <span data-phrase="copy.done">コピーしました</span>
     <span data-phrase="copy.link">リンクをコピー</span>

--- a/locales/ko/tools/share-text.html
+++ b/locales/ko/tools/share-text.html
@@ -157,6 +157,7 @@
     <span data-phrase="share.lost-rendezvous">중개자와의 연결이 끊겼습니다. 다시 시도 중입니다. 연결된 읽는 사람에게는 영향이 없습니다.</span>
     <span data-phrase="share.stopped">중지됨. 더 이상 아무것도 공유되지 않습니다.</span>
     <span data-phrase="share.file-too-big">&ldquo;{name}&rdquo;은(는) 200 MB 한도를 넘습니다.</span>
+    <span data-phrase="share.leave-warning">이 페이지를 떠나면 모두에게 공유가 끝납니다. 계속할까요?</span>
 
     <span data-phrase="copy.done">복사됨</span>
     <span data-phrase="copy.link">링크 복사</span>

--- a/locales/nl/tools/share-text.html
+++ b/locales/nl/tools/share-text.html
@@ -160,6 +160,7 @@
     <span data-phrase="share.lost-rendezvous">Verbinding met de tussenpersoon verloren; opnieuw proberen. Verbonden lezers merken er niets van.</span>
     <span data-phrase="share.stopped">Gestopt. Er wordt niets meer gedeeld.</span>
     <span data-phrase="share.file-too-big">&ldquo;{name}&rdquo; is groter dan de limiet van 200 MB.</span>
+    <span data-phrase="share.leave-warning">Deze pagina verlaten beëindigt het delen voor iedereen. Doorgaan?</span>
 
     <span data-phrase="copy.done">Gekopieerd</span>
     <span data-phrase="copy.link">Link kopiëren</span>

--- a/locales/pt/tools/share-text.html
+++ b/locales/pt/tools/share-text.html
@@ -161,6 +161,7 @@
     <span data-phrase="share.lost-rendezvous">Conexão com o intermediário perdida; tentando de novo. Os leitores conectados não são afetados.</span>
     <span data-phrase="share.stopped">Parado. Nada mais está sendo compartilhado.</span>
     <span data-phrase="share.file-too-big">&ldquo;{name}&rdquo; passa do limite de 200 MB.</span>
+    <span data-phrase="share.leave-warning">Sair desta página encerra o compartilhamento para todos. Continuar?</span>
 
     <span data-phrase="copy.done">Copiado</span>
     <span data-phrase="copy.link">Copiar link</span>

--- a/locales/tr/tools/share-text.html
+++ b/locales/tr/tools/share-text.html
@@ -161,6 +161,7 @@
     <span data-phrase="share.lost-rendezvous">Aracıyla bağlantı koptu; yeniden deneniyor. Bağlı okuyucular etkilenmez.</span>
     <span data-phrase="share.stopped">Durduruldu. Artık hiçbir şey paylaşılmıyor.</span>
     <span data-phrase="share.file-too-big">&ldquo;{name}&rdquo; 200 MB sınırını aşıyor.</span>
+    <span data-phrase="share.leave-warning">Bu sayfadan ayrılmak paylaşımı herkes için bitirir. Devam edilsin mi?</span>
 
     <span data-phrase="copy.done">Kopyalandı</span>
     <span data-phrase="copy.link">Bağlantıyı kopyala</span>

--- a/locales/zh-TW/tools/share-text.html
+++ b/locales/zh-TW/tools/share-text.html
@@ -135,6 +135,7 @@
     <span data-phrase="share.lost-rendezvous">與引介伺服器失聯；正在重試。已連線的讀者不受影響。</span>
     <span data-phrase="share.stopped">已停止。什麼都不再分享了。</span>
     <span data-phrase="share.file-too-big">「{name}」超出了200 MB的上限。</span>
+    <span data-phrase="share.leave-warning">離開此頁面，分享對所有人結束。繼續嗎？</span>
 
     <span data-phrase="copy.done">已複製</span>
     <span data-phrase="copy.link">複製連結</span>

--- a/locales/zh/tools/share-text.html
+++ b/locales/zh/tools/share-text.html
@@ -135,6 +135,7 @@
     <span data-phrase="share.lost-rendezvous">与引见服务器失联；正在重试。已连接的读者不受影响。</span>
     <span data-phrase="share.stopped">已停止。什么都不再分享了。</span>
     <span data-phrase="share.file-too-big">"{name}"超出了200 MB的上限。</span>
+    <span data-phrase="share.leave-warning">离开此页面，分享对所有人结束。继续吗？</span>
 
     <span data-phrase="copy.done">已复制</span>
     <span data-phrase="copy.link">复制链接</span>

--- a/tools/share-text/body.html
+++ b/tools/share-text/body.html
@@ -164,6 +164,7 @@
     <span data-phrase="share.lost-rendezvous">Lost the introduction server; retrying. Connected readers are not affected.</span>
     <span data-phrase="share.stopped">Stopped. Nothing is shared any more.</span>
     <span data-phrase="share.file-too-big">&ldquo;{name}&rdquo; is over the 200 MB limit.</span>
+    <span data-phrase="share.leave-warning">Leaving this page ends the share for everyone. Continue?</span>
 
     <span data-phrase="copy.done">Copied</span>
     <span data-phrase="copy.link">Copy link</span>

--- a/tools/share-text/src/main.js
+++ b/tools/share-text/src/main.js
@@ -109,6 +109,24 @@ function refreshCount() {
   setStatus(`${parts.join(', ')}. ${phrase('share.closing-note')}`);
 }
 
+// Admission survives a reader's language switch: each admitted channel gets
+// a token, and a knock that carries a valid one is let straight back in -
+// so switching languages does not knock on the sharer's door twice. The
+// tokens live only in this tab's memory and die with the share.
+const admitTokens = new Set();
+
+function admitViewer(id, dc) {
+  channels.set(id, dc);
+  const token = crypto.randomUUID();
+  admitTokens.add(token);
+  try {
+    dc.send(JSON.stringify({ type: 'token', token }));
+    dc.send(payload());
+    dc.send(filesMsg());
+  } catch {}
+  refreshCount();
+}
+
 function addRequest(id, dc, note) {
   const row = document.createElement('div');
   row.className = 'request';
@@ -120,9 +138,7 @@ function addRequest(id, dc, note) {
   admit.onclick = () => {
     pending.delete(id);
     row.remove();
-    channels.set(id, dc);
-    try { dc.send(payload()); dc.send(filesMsg()); } catch {}
-    refreshCount();
+    admitViewer(id, dc);
   };
   const deny = document.createElement('button');
   deny.type = 'button';
@@ -292,9 +308,8 @@ async function hostSignal(from, data) {
       const dc = e.channel;
       dc.binaryType = 'arraybuffer';
       dc.onopen = () => {
-        if (isPrivate) dc.send(JSON.stringify({ type: 'private' }));
-        else { channels.set(from, dc); dc.send(payload()); dc.send(filesMsg()); }
-        refreshCount();
+        if (isPrivate) { dc.send(JSON.stringify({ type: 'private' })); refreshCount(); }
+        else admitViewer(from, dc);
       };
       dc.onmessage = (ev) => {
         if (typeof ev.data !== 'string') return;
@@ -307,6 +322,12 @@ async function hostSignal(from, data) {
           return;
         }
         if (m.type === 'knock' && isPrivate && !channels.has(from) && !pending.has(from)) {
+          // A knock carrying a token this share issued is a reader who was
+          // already let in and merely switched language - no second knock.
+          if (typeof m.token === 'string' && admitTokens.has(m.token)) {
+            admitViewer(from, dc);
+            return;
+          }
           addRequest(from, dc, String(m.note ?? '').slice(0, 200));
         }
       };
@@ -409,9 +430,21 @@ function fail(text) {
   $('view-status').textContent = text;
 }
 
+let viewerLive = false;
+
 function view(code) {
   $('share').hidden = true;
   $('view').hidden = false;
+
+  // A language switch made while connected sets this flag on the way out.
+  // It stands in for the consent the same reader gave moments ago on the
+  // same share, so the gate is not shown twice for one session.
+  let carried = false;
+  try {
+    const stamp = Number(sessionStorage.getItem(`share-text-carry:${code}`) ?? 0);
+    carried = Date.now() - stamp < 5 * 60 * 1000;
+    sessionStorage.removeItem(`share-text-carry:${code}`);
+  } catch {}
 
   const ws = new WebSocket(wsUrl(code, 'viewer'));
   let pc = null;
@@ -503,6 +536,7 @@ function view(code) {
   const sharerGone = () => {
     if (done) return;
     done = true;
+    viewerLive = false;
     $('knockrow').hidden = true;
     $('filelist').textContent = '';
     rx = null;
@@ -552,7 +586,7 @@ function view(code) {
     const dc = pc.createDataChannel('share');
     dc.binaryType = 'arraybuffer';
     dcRef = dc;
-    dc.onopen = () => { connected = true; };
+    dc.onopen = () => { connected = true; viewerLive = true; };
     dc.onmessage = (ev) => {
       if (typeof ev.data !== 'string') { fileChunk(ev.data); return; }
       const msg = JSON.parse(ev.data);
@@ -560,7 +594,19 @@ function view(code) {
       if (msg.type === 'file-begin') { fileBegin(msg); return; }
       if (msg.type === 'file-end') { fileEnd(); return; }
       if (msg.type === 'file-gone') { fileGone(); return; }
+      if (msg.type === 'token') {
+        try { sessionStorage.setItem(`share-text-token:${code}`, String(msg.token)); } catch {}
+        return;
+      }
       if (msg.type === 'private') {
+        // A reader who was admitted and switched language knocks again with
+        // the token the sharer issued, silently; anyone else knocks aloud.
+        let token = null;
+        try { token = carried ? sessionStorage.getItem(`share-text-token:${code}`) : null; } catch {}
+        if (token !== null) {
+          dc.send(JSON.stringify({ type: 'knock', note: '', token }));
+          return;
+        }
         $('view-status').textContent = phrase('view.private');
         $('knockrow').hidden = false;
         $('knock').focus();
@@ -605,8 +651,12 @@ function view(code) {
     const m = JSON.parse(e.data);
     try {
       if (m.type === 'ready') {
-        $('view-status').textContent = phrase('view.someone');
-        $('consent').hidden = false;
+        if (carried) {
+          await dial();
+        } else {
+          $('view-status').textContent = phrase('view.someone');
+          $('consent').hidden = false;
+        }
       } else if (m.type === 'signal' && pc) {
         if (m.data.sdp) await pc.setRemoteDescription(m.data.sdp);
         else if (m.data.candidate) await pc.addIceCandidate(m.data.candidate);
@@ -759,11 +809,24 @@ const alternates = new Set(
     .map((link) => new URL(link.href).pathname),
 );
 addEventListener('click', (event) => {
-  if (location.hash === '') return;
   const anchor = event.target.closest('a[href]');
-  if (anchor && anchor.origin === location.origin && alternates.has(anchor.pathname)) {
-    anchor.href = anchor.pathname + location.hash;
+  if (!anchor || anchor.origin !== location.origin || !alternates.has(anchor.pathname)) return;
+  // A sharer's tab is the server: navigating it anywhere ends the share,
+  // and that deserves a question rather than a silent loss.
+  if ($('share').hidden === false && $('publish').hidden) {
+    if (!window.confirm(phrase('share.leave-warning'))) {
+      event.preventDefault();
+      return;
+    }
   }
+  if (location.hash === '') return;
+  // A reader keeps their session across the switch: the flag stands in for
+  // the consent they gave moments ago, and the admission token (if any)
+  // lets them straight back into a private share.
+  if (viewerLive) {
+    try { sessionStorage.setItem(`share-text-carry:${code}`, String(Date.now())); } catch {}
+  }
+  anchor.href = anchor.pathname + location.hash;
 }, true);
 
 monitorNetwork();


### PR DESCRIPTION
Switching language is a navigation, and a navigation tears down a
reader's WebRTC session — so until now it also meant consenting again
and, on a private share, knocking on the sharer's door a second time.
Both are ceremony once the same person, in the same browser session, is
rejoining the same share they were reading moments ago.

## The reader's session is carried

- Clicking a language link while connected stamps a five-minute flag
  scoped to the share's name (`sessionStorage`); the new language's page
  sees it and dials without showing the consent gate again.
- Admission survives too: when the sharer admits a reader, the reader's
  page quietly receives a token, and a knock carrying a valid one is let
  straight back in — the sharer's request list never stirs. Tokens live
  only in the sharer's tab memory and the reader's session storage, and
  die with the share.

## The sharer is asked, not carried

That tab is the server — navigating it anywhere ends the share for
everyone, so the switcher asks first: *"Leaving this page ends the share
for everyone. Continue?"* One new phrase, translated in all fifteen
bodies.

## Verification

End to end against the production rendezvous: an admitted reader on a
private share clicked the real German switcher link, landed on
`/de/text-teilen/#name` in full German UI, and had the content back with
no consent gate, no knock box, and zero new request cards on the
sharer's screen. Declining the sharer's confirm keeps the share alive.
The worker is untouched, as with every feature since the first version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
