### PR TITLE
Let the escaper own the ampersand in the share tool's name

### DIFF
--- a/locales/de/tools/share-text.toml
+++ b/locales/de/tools/share-text.toml
@@ -6,7 +6,7 @@
 # they are.
 #
 
-name = "Text &amp; Dateien teilen"
+name = "Text & Dateien teilen"
 heading = "Text &amp; Dateien teilen <span class=\"h1-kw\">&mdash; direkt von Ihrem Browser in ihren, ohne Upload</span>"
 tagline = "Die Freigabe lebt in diesem offenen Tab. Leser holen sie verschlüsselt direkt aus Ihrem Browser, und mit dem Schließen des Tabs endet sie - auf keinem Server ist irgendetwas gespeichert."
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -46,7 +46,7 @@ browser and uploads nothing; how the site around them is built is in the
 | [JSON Formatter](format-json/) | `/format-json/` | JSON, XML, HTML, CSS and YAML, formatted or converted. Nothing is pasted into anyone else's server. |
 | [Text Diff](compare-text/) | `/compare-text/` | Two texts in, every difference marked, line by line and word by word. Nothing is pasted into anyone else's server. |
 | [Base64 Encoder & Decoder](encode-text/) | `/encode-text/` | Base64, percent-encoding, HTML entities, hex and backslash escapes, both ways. Nothing is pasted into anyone else's server. |
-| [Share Text &amp; Files](share-text/) | `/share-text/` | The share lives in this open tab. Readers fetch it directly from your browser, encrypted, and closing the tab ends it - nothing is stored on any server. |
+| [Share Text & Files](share-text/) | `/share-text/` | The share lives in this open tab. Readers fetch it directly from your browser, encrypted, and closing the tab ends it - nothing is stored on any server. |
 | [QR & Barcode Generator](qr-barcode/) | `/qr-barcode/` | Type it, and it becomes a code. Nothing is sent to make one. |
 | [QR & Barcode Reader](qr-barcode-reader/) | `/qr-barcode-reader/` | Point it at a code, or drop a picture of one. It is read here, and nowhere else. |
 | [Hash & Checksum](hash-checksum/) | `/hash-checksum/` | Check a download against the number the publisher printed, without sending it to anyone. |

--- a/tools/share-text/tool.toml
+++ b/tools/share-text/tool.toml
@@ -20,7 +20,7 @@
 #
 
 slug = "share-text"
-name = "Share Text &amp; Files"
+name = "Share Text & Files"
 heading = "Share text &amp; files <span class=\"h1-kw\">&mdash; straight from your browser to theirs, nothing uploaded</span>"
 tagline = "The share lives in this open tab. Readers fetch it directly from your browser, encrypted, and closing the tab ends it - nothing is stored on any server."
 icon = "&#128279;"           # the mark beside the page heading


### PR DESCRIPTION
The hub card showed **Share Text &amp;amp; Files** — the literal entity. Every context that consumes a tool's `name` (hub card, footer list, app manifest, generated `tools/README.md`) escapes on output, so the name must hold a raw `&`; pre-escaping it in the TOML made the escaper escape the escape. That is exactly why password-generator's `name` carries a raw ampersand while its `title` — an HTML context — carries the entity; share-text copied the convention from the wrong field.

Three lines: the English `tool.toml`, the German override (the only two locales whose name contains an ampersand), and the regenerated index. Verified in a clean build: the hub reads *Share Text & Files*, and no page contains a double-escape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)