### PR TITLE
Return the live dots to the rows that name them

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -220,21 +220,14 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
 .pledge-fold summary { list-style: none; cursor: pointer; }
 .pledge-fold summary::-webkit-details-marker { display: none; }
 
-.pledge-glance {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  margin-inline-start: auto;
-  align-self: center;
-  padding-inline-start: 0.55rem;
-}
-
 /* The affordance the hidden default marker was providing. Physical borders on
    purpose: a caret that points down or up needs no mirroring for RTL. */
 .pledge-caret {
+  flex: none;
   width: 0.5rem;
   height: 0.5rem;
-  margin-inline-start: 0.25rem;
+  margin-inline-start: auto;
+  align-self: center;
   border-right: 2px solid var(--text-dim);
   border-bottom: 2px solid var(--text-dim);
   transform: rotate(45deg);

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -234,15 +234,14 @@
   stating before the first file is asked for, not in a panel you have to go
   looking for.
 
-  Only the claim, though. The paragraph, the fact chips and the live check's
-  words used to sit open under it and together they pushed the tool itself
-  below the fold, so everything but the one sentence now folds into a native
+  Only the claim, though. The paragraph, the fact chips and the live check
+  used to sit open under it and together they pushed the tool itself below
+  the fold, so everything but the one sentence now folds into a native
   <details> - chosen over a scripted panel because it needs nothing from
   main.js (the live-check code is copied into every tool) and the folded text
-  stays in the page for a crawler to read. The two live dots live in the
-  summary line, so the measured proof stays on screen even folded; the words
-  behind them are one click away. The dots keep bare class="live-dot" because
-  every tool's main.js assigns className outright, wiping anything else.
+  stays in the page for a crawler to read. The live dots fold away with their
+  rows: parked in the summary they were two unlabelled circles, meaning
+  nothing until the fold was opened anyway.
 -->
 <section class="pledge">
   <details class="pledge-fold">
@@ -251,11 +250,7 @@
       <span class="pledge-title">
 {{ ui.tool.pledge_line }}
       </span>
-      <span class="pledge-glance" aria-hidden="true">
-        <span id="network-dot" class="live-dot"></span>
-        <span id="offline-dot" class="live-dot"></span>
-        <span class="pledge-caret"></span>
-      </span>
+      <span class="pledge-caret" aria-hidden="true"></span>
     </summary>
 
     <p class="pledge-sub">
@@ -270,10 +265,12 @@
          claim above into something a sceptical visitor can check. -->
     <div class="pledge-live">
       <p class="live-row">
-        <strong>{{ ui.tool.live_check }}</strong> <span id="network-count">{{ ui.tool.checking }}</span>
+        <span id="network-dot" class="live-dot" aria-hidden="true"></span>
+        <span><strong>{{ ui.tool.live_check }}</strong> <span id="network-count">{{ ui.tool.checking }}</span></span>
       </p>
       <p class="live-row">
-        <strong>{{ ui.tool.offline }}</strong> <span id="offline-status">{{ ui.tool.checking }}</span>
+        <span id="offline-dot" class="live-dot" aria-hidden="true"></span>
+        <span><strong>{{ ui.tool.offline }}</strong> <span id="offline-status">{{ ui.tool.checking }}</span></span>
       </p>
       <p class="live-hint">
 {{ tool.live_hint }}


### PR DESCRIPTION
## What changed

Follow-up to #165. The two live status dots moved out of the folded banner's summary line and back to their original places beside the "Live check:" and "Offline:" rows. Parked in the summary they were two unlabelled green circles — a signal with no words, meaning nothing until the fold was opened anyway. The summary line is now just the claim, with the caret alone marking the fold.

The dots keep their ids and bare `class="live-dot"`, so the untouched per-tool `main.js` keeps driving them exactly as before; the caret takes over `margin-inline-start: auto` to sit at the end of the line, mirroring correctly in RTL.

## Verified

- Built page checked in the browser: no dots in the summary, both dots back inside their rows and turning green after the live check, the fold still one line (~57px) and opening/closing on click, `main.js` boots.
- `python build.py` (minified) — pass. The CI-style build and Python suite are re-running; the change is a partial revert to the pre-#165 row markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
