### PR TITLE
Let a language switch change the words and nothing else

### DIFF
--- a/build.py
+++ b/build.py
@@ -177,6 +177,16 @@ def build(out, clean=False, minify_output=True, jobs=None):
         (SHARED / 'handoff.js').read_text(encoding='utf-8'), 'shared/handoff.js')
     handoff_v = sitelib.text_hash(handoff_js)
 
+    # What a language switch carries across with it - the chosen files and the
+    # settings the visitor moved. Served and hashed like the three above, and
+    # for the same reason: it lives at the root, every tool page in every
+    # language asks for the same copy, and a version in the URL is what gets a
+    # change past a service worker that was told to cache whatever it is asked
+    # for.
+    keep_js = emit.js_text(
+        (SHARED / 'lang-keep.js').read_text(encoding='utf-8'), 'shared/lang-keep.js')
+    keep_v = sitelib.text_hash(keep_js)
+
 
     # The eight lines that register the front page's service worker. Written
     # here rather than into each language because there is nothing in it that
@@ -274,15 +284,16 @@ def build(out, clean=False, minify_output=True, jobs=None):
         for locale in locales:
             done, links = build_locale(out, templates, locale, locales, site,
                                        tools, prose, planned, css_v, lang_v,
-                                       feedback_v, offline_v, site_css, emit)
+                                       feedback_v, handoff_v, keep_v,
+                                       offline_v, site_css, emit)
             written += done
             page_links.update(links)
     else:
         with ProcessPoolExecutor(max_workers=jobs) as pool:
             pending = [
                 pool.submit(build_locale, out, templates, locale, locales, site,
-                            tools, prose, planned, css_v, lang_v, feedback_v, handoff_v,
-                            offline_v, site_css, emit)
+                            tools, prose, planned, css_v, lang_v, feedback_v,
+                            handoff_v, keep_v, offline_v, site_css, emit)
                 for locale in locales
             ]
             for future in pending:
@@ -384,6 +395,7 @@ def build(out, clean=False, minify_output=True, jobs=None):
     write(out / 'offline.js', offline_js)
     write(out / 'feedback.js', feedback_js)
     write(out / 'handoff.js', handoff_js)
+    write(out / 'lang-keep.js', keep_js)
 
     # Last, because a link is only checkable once everything it could point at
     # has been written. The pages the parent wrote itself - the 404 - joined
@@ -412,7 +424,8 @@ def build(out, clean=False, minify_output=True, jobs=None):
 
 
 def build_locale(out, templates, locale, locales, site, tools, prose, planned,
-                 css_v, lang_v, feedback_v, handoff_v, offline_v, site_css, emit):
+                 css_v, lang_v, feedback_v, handoff_v, keep_v, offline_v,
+                 site_css, emit):
     """The whole site, in one language, under out/<lang>/ - or at the root of
     out/ for English, whose pages keep the addresses they have always had.
 
@@ -491,7 +504,7 @@ def build_locale(out, templates, locale, locales, site, tools, prose, planned,
     written = []
     for tool in ltools:
         build_tool(dest_root, templates, locale, locales, site, tool, footer,
-                   links, lang_v, feedback_v, handoff_v,
+                   links, lang_v, feedback_v, handoff_v, keep_v,
                    guide_of.get(tool['slug'], {}),
                    related_of.get(tool['slug'], []),
                    [by_slug[s] for s in tool.get('handoff', [])], emit)
@@ -778,7 +791,8 @@ def build_guides(out, templates, locale, locales, site, groups, guides, footer,
 
 
 def build_tool(out, templates, locale, locales, site, tool, footer, links,
-               lang_v, feedback_v, handoff_v, guide, related, handoff, emit):
+               lang_v, feedback_v, handoff_v, keep_v, guide, related, handoff,
+               emit):
     root = locale['site']
     dest = out / tool['out_slug']
     dest.mkdir(parents=True, exist_ok=True)
@@ -880,6 +894,10 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
             # through the picker. See shared/handoff.js.
             'handoff': handoff,
             'handoff_href': f'/handoff.js?v={handoff_v}',
+            # The work already on the page when somebody changes the language.
+            # Every tool page, in every language, because either side of a
+            # switch can be the one doing the carrying. See shared/lang-keep.js.
+            'keep_href': f'/lang-keep.js?v={keep_v}',
             'jsonld': sitelib.tool_jsonld(root, tool),
             'body': body,
         })))
@@ -1734,10 +1752,11 @@ def copy_shared(out):
         # shared/css feeds the stylesheets the build assembles, and shared/js is
         # copied into each tool's src/shared/ by build_tool - minified, cached by
         # that tool's service worker. Copying either here would publish a second,
-        # raw copy at the site root that nothing references; site.css, lang.js
-        # and feedback.js are written separately, minified, by the caller -
+        # raw copy at the site root that nothing references; site.css and the
+        # frame scripts are written separately, minified, by the caller -
         # copying the source over one of them here would undo that.
-        if path.name in ('css', 'js', 'site.css', 'lang.js', 'feedback.js'):
+        if path.name in ('css', 'js', 'site.css', 'lang.js', 'feedback.js',
+                         'handoff.js', 'lang-keep.js'):
             continue
         if path.is_dir():
             shutil.copytree(path, out / path.name, dirs_exist_ok=True)

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -115,6 +115,45 @@ The switcher itself is in two places and is plain links in both: a `<details>`
 control in the header of every page, and the row at the foot of the footer.
 Both work with the script blocked.
 
+## Switching language without losing the work
+
+A language switch is a navigation to a different document — that is what makes
+each language its own address, its own canonical and its own translated slug —
+and a navigation empties the tool you were in the middle of using. Choosing
+German after picking a photo and settling on a quality used to mean picking the
+photo again.
+
+`shared/lang-keep.js` carries the work across. On a tool page, and only there,
+it watches the two doors work arrives through and hands what it finds back on
+the other side:
+
+- **the files**, seen at the `change` event on `#file-input` and at a drop on
+  the dropzone around it, given back through the same file input
+  `shared/handoff.js` delivers through — a `DataTransfer` and a synthetic
+  `change`, which is indistinguishable from a file the visitor chose;
+- **the settings the visitor moved** — every `input`, `textarea` and `select`
+  inside `<main>` whose value differs from the one in the markup. The ids are
+  structural and identical in every language, which is what makes them nameable
+  on the far side; the values are compared against the markup's own, so a page
+  nobody has touched carries nothing and the switcher stays the plain link it
+  was built as.
+
+The record is parked in IndexedDB — the only storage a `File` survives —
+addressed by the `data-tool` slug, which is the English slug in every language
+and therefore the one thing the two sides of a switch agree on. It is consumed
+once, refused if it is more than two minutes old or if the language on it
+matches the page reading it (that is a reload, not a switch), and swept if a
+switch is ever abandoned. Nothing in it touches the network, so no tool's CSP
+has to widen for it.
+
+Two things it deliberately does not do. A control the tool *fills in from the
+file* — a width read off an image, a duration read off a clip — is filled in
+from the file again rather than from the record, because there is no generic
+way to tell that apart from a setting somebody chose and re-deriving it cannot
+go stale. And a file a tool has since dropped from a list of its own comes back
+with the rest: the doors above see files arriving, and nothing announces a
+removal.
+
 ## Adding a language
 
 1. Make `locales/<lang>/locale.toml` with `lang`, `name` (in English, for the

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -1184,3 +1184,15 @@ ins.adsbygoogle[data-ad-status="unfilled"] { display: none !important; }
   opacity: 0.55;
   cursor: progress;
 }
+
+/* The same moment on the language switcher: the work already on this page is
+   being parked for the page in the other language, which shared/lang-keep.js
+   is about to open. Longer than the handoff's when the tool is holding a
+   video, and a switcher that looked inert for a second would be clicked
+   again. */
+.lang-pick a[aria-busy="true"],
+.lang-switch a[aria-busy="true"],
+.lang-auto a[aria-busy="true"] {
+  opacity: 0.55;
+  cursor: progress;
+}

--- a/shared/lang-keep.js
+++ b/shared/lang-keep.js
@@ -1,0 +1,348 @@
+/**
+ * The work a language switch must not throw away.
+ *
+ * GENERATED FILE - do not edit; see shared/lang-keep.js.
+ *
+ * WHAT THIS DOES, IN ONE SENTENCE
+ *
+ * A click on the language switcher is a navigation, and until this file it was
+ * a navigation that emptied the tool: the file you had chosen, the quality you
+ * had settled on, the text you had pasted. This carries all three across and
+ * hands them back on the other side, so that changing the language changes the
+ * words and nothing else.
+ *
+ * WHY IT IS NOT SIMPLY A PAGE THAT SWAPS ITS OWN WORDS
+ *
+ * Because there is no such page. Every language here is its own document at
+ * its own address, with its own canonical, its own hreflang set and its own
+ * translated slug - which is what makes the site legible to a crawler and
+ * linkable in fourteen languages. Rewriting the page in place would throw all
+ * of that away to save one navigation. So the navigation stays, and the work
+ * travels with it.
+ *
+ * WHERE THE WORK IS PUT WHILE THE PAGE CHANGES
+ *
+ * In IndexedDB, exactly as shared/handoff.js parks a result on its way to
+ * another tool, and for the same reason: it is the only storage a File
+ * survives, and it is the browser's own store on this machine. Nothing here
+ * touches the network - there is no fetch, no blob: URL to read back, and
+ * therefore nothing for a tool's Content-Security-Policy to have to permit.
+ * The record is addressed to one tool, consumed exactly once, refused if it is
+ * more than a couple of minutes old, and swept if it is ever left behind.
+ *
+ * The address is the slug in `data-tool`, which is the English slug in every
+ * language - the one thing about a tool page that does not change when the
+ * language does, and so the only thing the two sides of a switch can agree on.
+ *
+ * WHAT IT CARRIES, AND WHAT IT DOES NOT
+ *
+ * Two things, both taken through doors that already exist:
+ *
+ *   - THE FILES, watched at the one place every file enters a tool: the change
+ *     event on #file-input, and a drop on the dropzone around it. They are
+ *     handed back through the same file input shared/handoff.js delivers
+ *     through, with a DataTransfer and a synthetic change event, so the
+ *     receiving page needs no code of its own and the tool re-reads them
+ *     exactly as if they had been dropped again.
+ *   - THE SETTINGS the visitor moved: every input, textarea and select inside
+ *     <main> whose value differs from the one written in the markup. Only the
+ *     difference, so a page nobody has touched carries nothing at all and the
+ *     switcher stays the plain link it was built as.
+ *
+ * What it does not carry is anything a tool worked out for itself. A result
+ * already computed is not restored - the tool recomputes it from the file, the
+ * way it would have anyway - and a control the tool FILLS IN from the file it
+ * was given, a width read off an image or a duration read off a clip, is
+ * filled in from the file again rather than from the record. There is no
+ * generic way to tell those apart from a setting the visitor chose, and
+ * re-deriving them is the answer that cannot be stale.
+ *
+ * Nor does it know about a file a tool has since dropped from a list of its
+ * own: the doors above see files arriving and no tool announces a removal. A
+ * list the visitor pruned therefore comes back whole. That is a smaller loss
+ * than the one this file exists to fix, and the fix for it - a removal every
+ * tool has to remember to announce - is a promise thirty-six tools would have
+ * to keep for it to mean anything.
+ *
+ * Like shared/feedback.js and shared/handoff.js beside it, this is a frame
+ * script rather than a shared module: no tool imports it, no tool.toml asks
+ * for it, and it says nothing on screen - so there is no sentence in here to
+ * arrive in the wrong language, which on this file of all files would be a
+ * joke at its own expense.
+ */
+(function () {
+  'use strict';
+
+  var DB = 'abox-lang-keep';
+  var STORE = 'work';
+
+  // Long enough for a slow navigation and a service worker update on the way;
+  // short enough that work nobody came back for is not still sitting in
+  // storage. Shorter than the handoff's ten minutes because this describes one
+  // click and the page it lands on, not an errand somebody might finish later.
+  var FRESH = 2 * 60 * 1000;
+
+  // Output, not input. A control the tool wrote and locked is not a change the
+  // visitor made, and a password field is the one value that should not be
+  // written down anywhere on the way to a page that would have generated it
+  // again.
+  var IGNORE = {
+    file: true, hidden: true, password: true,
+    button: true, submit: true, reset: true, image: true,
+    'select-multiple': true,
+  };
+
+  var page = document.getElementById('feedback');
+  var slug = page ? page.getAttribute('data-tool') : '';
+  var main = document.getElementById('main');
+  var here = document.documentElement.getAttribute('lang') || '';
+  var input = document.getElementById('file-input');
+
+  // Not a tool page, or one built before this file existed. Either way there is
+  // no work here to keep and nowhere to file it.
+  if (!slug || !main) return;
+
+  /* -------------------------------------------------------------- the store */
+
+  function open() {
+    return new Promise(function (resolve, reject) {
+      var req = window.indexedDB.open(DB, 1);
+      req.onupgradeneeded = function () { req.result.createObjectStore(STORE); };
+      req.onsuccess = function () { resolve(req.result); };
+      req.onerror = function () { reject(req.error); };
+    });
+  }
+
+  /** One transaction, promised. `use` gets the store and returns a request. */
+  function inStore(mode, use) {
+    return open().then(function (db) {
+      return new Promise(function (resolve, reject) {
+        var tx = db.transaction(STORE, mode);
+        var req = use(tx.objectStore(STORE));
+        tx.oncomplete = function () { db.close(); resolve(req && req.result); };
+        tx.onerror = function () { db.close(); reject(tx.error); };
+      });
+    });
+  }
+
+  function park(record) {
+    return inStore('readwrite', function (store) { return store.put(record, slug); });
+  }
+
+  function take() {
+    return inStore('readwrite', function (store) {
+      var got = store.get(slug);
+      got.onsuccess = function () { store.delete(slug); };
+      return got;
+    });
+  }
+
+  /**
+   * Anything past FRESH goes, whichever tool it was addressed to.
+   *
+   * A switch that was parked and then abandoned - the back button, a closed
+   * tab, a page that never finished loading - leaves a record nobody will ever
+   * take. This is the only thing that collects them.
+   */
+  function sweep() {
+    return inStore('readwrite', function (store) {
+      var walk = store.openCursor();
+      walk.onsuccess = function () {
+        var cursor = walk.result;
+        if (!cursor) return;
+        var record = cursor.value;
+        if (!record || !record.time || Date.now() - record.time > FRESH) cursor.delete();
+        cursor.continue();
+      };
+      return null;
+    });
+  }
+
+  /* ----------------------------------------------------------- the settings */
+
+  /**
+   * What a select shows when nobody has touched it.
+   *
+   * The option carrying the `selected` attribute, or - if the markup names
+   * none - the first one, which is what the browser shows.
+   */
+  function fallback(node) {
+    var options = node.options;
+    for (var i = 0; i < options.length; i += 1) {
+      if (options[i].defaultSelected) return options[i].value;
+    }
+    return options.length ? options[0].value : '';
+  }
+
+  /** Every control inside the tool no longer showing its markup value. */
+  function settings() {
+    var out = [];
+    var nodes = main.querySelectorAll('input, textarea, select');
+    for (var i = 0; i < nodes.length; i += 1) {
+      var node = nodes[i];
+      var type = String(node.type || '').toLowerCase();
+      if (!node.id || node.disabled || node.readOnly || IGNORE[type]) continue;
+      if (type === 'checkbox' || type === 'radio') {
+        if (node.checked !== node.defaultChecked) out.push({ id: node.id, on: node.checked });
+      } else if (node.tagName === 'SELECT') {
+        if (node.value !== fallback(node)) out.push({ id: node.id, value: node.value });
+      } else if (node.value !== node.defaultValue) {
+        out.push({ id: node.id, value: node.value });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Put them back, and tell the tool.
+   *
+   * Setting `value` from script fires nothing, so a tool that recomputes on
+   * input - which is most of them - would show the restored setting and ignore
+   * it. Both events are sent because tools listen for one or the other, and the
+   * pair is what a person moving the control would have produced.
+   *
+   * Every write is guarded by a read of what is already there: a control the
+   * tool has since filled in with the same value needs no event, and one whose
+   * options do not include the carried value - a select the tool populates
+   * itself, and has not yet - is left alone rather than told about a change
+   * that did not take.
+   */
+  function apply(values) {
+    for (var i = 0; i < values.length; i += 1) {
+      var want = values[i];
+      var node = document.getElementById(want.id);
+      if (!node || !main.contains(node)) continue;
+      if (typeof want.on === 'boolean') {
+        if (node.checked === want.on) continue;
+        node.checked = want.on;
+      } else {
+        if (node.value === want.value) continue;
+        node.value = want.value;
+        if (node.value !== want.value) continue;
+      }
+      node.dispatchEvent(new Event('input', { bubbles: true }));
+      node.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
+  /* -------------------------------------------------------------- the files */
+
+  /** What this page has been given, in the order it was given them. */
+  var held = [];
+
+  // True only while this file is handing files back, so that the change event
+  // it fires is not read as the visitor choosing them a second time and
+  // appended to the very set it was restored from.
+  var restoring = false;
+
+  function note(files) {
+    var picked = [];
+    for (var i = 0; i < (files ? files.length : 0); i += 1) picked.push(files[i]);
+    if (!picked.length) return;
+    // A picker marked `multiple` belongs to a tool that adds to a list; one
+    // without it replaces what it had. Following the input's own attribute is
+    // how this gets both right without knowing which tool it is on.
+    held = (input && input.multiple && !restoring) ? held.concat(picked) : picked;
+  }
+
+  if (input) {
+    // Registered here rather than in the tool, and therefore first: this file
+    // is a deferred script and src/main.js is a module, so the picker's own
+    // listener is added after this one and runs after it. That matters,
+    // because the first thing the picker does is empty `input.value` - which
+    // is what lets somebody choose the same file twice, and would leave
+    // nothing here to read.
+    input.addEventListener('change', function () { note(input.files); });
+  }
+
+  // A dropped file never touches the input at all, so it is caught where it
+  // lands. Capturing, for the same reason as above: the dropzone's own handler
+  // must not have had the chance to consume the event first. Only drops on the
+  // dropzone count - the frame swallows a drop anywhere else on the page
+  // precisely so that nothing happens.
+  document.addEventListener('drop', function (event) {
+    var target = event.target;
+    if (!target || !target.closest || !target.closest('#dropzone')) return;
+    if (event.dataTransfer) note(event.dataTransfer.files);
+  }, true);
+
+  /** Hand them to the tool the way a visitor would have. */
+  function deliver(files) {
+    if (!input || !files.length || typeof DataTransfer === 'undefined') return;
+    var carrier = new DataTransfer();
+    for (var i = 0; i < files.length; i += 1) carrier.items.add(files[i]);
+    input.files = carrier.files;
+    restoring = true;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    restoring = false;
+  }
+
+  /* -------------------------------------------------------------- receiving */
+
+  function receive() {
+    take().then(function (record) {
+      if (record && record.time && Date.now() - record.time <= FRESH
+          // The language it was parked in, which is the proof that this is the
+          // far side of a switch rather than a reload of the page it was parked
+          // on. Without it, a refresh would restore work the visitor had just
+          // cleared by refreshing.
+          && record.lang && record.lang !== here) {
+        // Files first: a tool clears its controls when a new file arrives, and
+        // a setting restored before that would be cleared along with them.
+        if (record.files) deliver(record.files);
+        if (record.values) apply(record.values);
+      }
+      return sweep();
+    }).catch(function () {
+      // IndexedDB refused - storage disabled, or a browser mode that throws.
+      // The page is then a page somebody opened, which is the state it was
+      // built for.
+    });
+  }
+
+  // Module scripts have all run by 'load', so the tool's own listeners are
+  // wired before the synthetic events above are fired at them.
+  if (document.readyState === 'complete') receive();
+  else window.addEventListener('load', receive, { once: true });
+
+  /* ---------------------------------------------------------------- sending */
+
+  // One switch at a time: a second click while the first is still writing would
+  // park a second record over the first and then race it to the navigation.
+  var carrying = false;
+
+  document.addEventListener('click', function (event) {
+    // A modified click opens a second tab. That tab is a fresh page and this
+    // one keeps everything it has, so there is nothing to carry and nothing to
+    // intercept.
+    if (event.defaultPrevented || event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    var target = event.target;
+    if (!target || !target.closest) return;
+    var link = target.closest('a[hreflang]');
+    if (!link || !link.closest('.lang-switch, .lang-pick, .lang-auto')) return;
+    if (carrying) { event.preventDefault(); return; }
+
+    var values = settings();
+    // Nothing has been done to this page yet. The switcher is a plain link and
+    // stays one: no storage is touched, no navigation is intercepted, and a
+    // reader who is only browsing pays nothing for a feature they are not
+    // using.
+    if (!values.length && !held.length) return;
+
+    event.preventDefault();
+    carrying = true;
+    // Says the click landed, for the moment before the page changes. The
+    // styling is in shared/css/tool-frame.css, beside the handoff's.
+    link.setAttribute('aria-busy', 'true');
+
+    park({ lang: here, values: values, files: held, time: Date.now() })
+      .catch(function () {
+        // Storage refused, or the work is more than it will hold. The switch
+        // itself is not worth blocking over: the reader asked for another
+        // language and gets it, on the empty page they would have got before
+        // this file existed.
+      })
+      .then(function () { window.location.assign(link.href); });
+  });
+}());

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -293,6 +293,19 @@
 <script src="{{ handoff_href }}" defer></script>
 
 <!--
+  What a language switch carries with it: the files this page was given and the
+  settings the visitor moved, parked while the page changes and handed back on
+  the other side. Every tool page in every language, because either side of a
+  switch can be the one doing the carrying.
+
+  `defer` rather than a module, and deliberately above src/main.js: it listens
+  on the file input, and it has to be listening BEFORE the picker does - the
+  first thing the picker does with a chosen file is clear the input, which
+  would leave nothing to carry. See shared/lang-keep.js.
+-->
+<script src="{{ keep_href }}" defer></script>
+
+<!--
   ============================================================================
   THE WRITTEN PART OF THE PAGE
 

--- a/tests/js/lang-keep.test.js
+++ b/tests/js/lang-keep.test.js
@@ -1,0 +1,637 @@
+/**
+ * shared/lang-keep.js - the work a language switch carries across with it.
+ *
+ * Run the way tests/js/lang.test.js and tests/js/feedback.test.js run theirs,
+ * and for the same reason: the file is a frame script rather than a module, so
+ * there is nothing to import. The source is read off disk and evaluated with a
+ * hand-built window, document and IndexedDB in front of it.
+ *
+ * The stub is the point. Every decision this file makes is a function of what
+ * is in the DOM and what is in the store, and both are faked here so that the
+ * questions can be asked at all. Three in particular are worth checking here
+ * and nowhere else, because a browser answers them only after a deploy:
+ *
+ *   - that a page NOBODY HAS TOUCHED is left completely alone. The switcher is
+ *     a plain link and the whole design of it depends on staying one; a version
+ *     of this file that intercepted every click would have looked identical in
+ *     use and quietly put the switcher behind IndexedDB.
+ *   - that only what CHANGED travels. The record is the visitor's work, and a
+ *     file that carried every control on the page would carry the tool's own
+ *     defaults over the top of the next language's - which are the same
+ *     defaults, so nothing would ever look wrong while the record grew to the
+ *     size of the form.
+ *   - that a record is refused unless the language on it DIFFERS from the page
+ *     reading it. That single comparison is what separates "the far side of a
+ *     switch" from "a reload", and getting it wrong means a refresh hands back
+ *     work the visitor refreshed to be rid of.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const SOURCE = readFileSync(
+  fileURLToPath(new URL('../../shared/lang-keep.js', import.meta.url)),
+  'utf8',
+);
+
+/* -------------------------------------------------------------- the storage */
+
+/**
+ * An IndexedDB that behaves like one, or one that refuses to open.
+ *
+ * The shape matters more than it looks. Every request here fires its
+ * `onsuccess` in a microtask rather than immediately, because the source
+ * attaches that handler AFTER the call that returns the request - `take()`
+ * sets `got.onsuccess` on the line below `store.get()` - and a fake that
+ * called back synchronously would run a handler nobody had set yet and pass a
+ * file the browser would fail.
+ */
+function indexed(held, refuse = false) {
+  function store(pending) {
+    return {
+      put(value, key) {
+        const req = { result: undefined, onsuccess: null };
+        held.set(key, value);
+        pending.push(() => { if (req.onsuccess) req.onsuccess(); });
+        return req;
+      },
+      get(key) {
+        const req = { result: held.get(key), onsuccess: null };
+        pending.push(() => { if (req.onsuccess) req.onsuccess(); });
+        return req;
+      },
+      delete(key) {
+        held.delete(key);
+        return { result: undefined, onsuccess: null };
+      },
+      openCursor() {
+        const keys = Array.from(held.keys());
+        const req = { result: null, onsuccess: null };
+        let at = 0;
+        const step = () => {
+          if (at >= keys.length) {
+            req.result = null;
+          } else {
+            const key = keys[at];
+            at += 1;
+            req.result = {
+              value: held.get(key),
+              delete: () => held.delete(key),
+              continue: step,
+            };
+          }
+          if (req.onsuccess) req.onsuccess();
+        };
+        pending.push(step);
+        return req;
+      },
+    };
+  }
+
+  const database = {
+    createObjectStore: () => {},
+    close: () => {},
+    transaction() {
+      const pending = [];
+      const tx = { objectStore: () => store(pending), oncomplete: null, onerror: null };
+      // After the synchronous body of inStore() has run, which is the only
+      // moment at which every handler it means to attach has been attached.
+      Promise.resolve().then(() => {
+        while (pending.length) pending.shift()();
+        if (tx.oncomplete) tx.oncomplete();
+      });
+      return tx;
+    },
+  };
+
+  return {
+    open() {
+      const req = {
+        result: database, error: new Error('refused'),
+        onupgradeneeded: null, onsuccess: null, onerror: null,
+      };
+      Promise.resolve().then(() => {
+        if (refuse) {
+          if (req.onerror) req.onerror();
+          return;
+        }
+        if (req.onupgradeneeded) req.onupgradeneeded();
+        if (req.onsuccess) req.onsuccess();
+      });
+      return req;
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ the DOM */
+
+/**
+ * One element.
+ *
+ * `selectors` is the set of selector strings it answers to, and closest()
+ * matches against exactly the strings the source passes - so a test fails if
+ * the source starts asking for something the markup does not offer, which is
+ * the failure this stub exists to catch.
+ */
+function el(selectors = [], attrs = {}) {
+  const node = {
+    selectors: new Set(selectors),
+    attrs,
+    parentNode: null,
+    fired: [],
+    getAttribute: (name) => (name in attrs ? attrs[name] : null),
+    setAttribute: (name, value) => { attrs[name] = value; },
+    closest(query) {
+      const wanted = query.split(',').map((part) => part.trim());
+      let at = node;
+      while (at) {
+        if (wanted.some((part) => at.selectors.has(part))) return at;
+        at = at.parentNode;
+      }
+      return null;
+    },
+    addEventListener: (type, fn) => node.listeners.set(type, fn),
+    // Records what was dispatched AND runs what is listening, because the
+    // source relies on both: it reads `fired` nowhere, but the change event it
+    // sends into the file input is caught by its own listener on that same
+    // input, and a stub that only recorded events would hide the loop that
+    // guard exists to break.
+    dispatchEvent: (event) => {
+      node.fired.push(event.type);
+      const fn = node.listeners.get(event.type);
+      if (fn) fn(event);
+      return true;
+    },
+    listeners: new Map(),
+  };
+  return node;
+}
+
+/**
+ * One form control, as the markup declares it.
+ *
+ * `value`/`checked` start at the markup's own, which is what makes "has this
+ * been changed?" answerable at all: `defaultValue` and `defaultChecked` are
+ * the attribute, and the live property is what the visitor left behind. A
+ * select is given the real refusal too - assigning a value none of its options
+ * carry does nothing - because the source guards against exactly that and the
+ * guard is worth a test.
+ */
+function control(tag, id, spec = {}) {
+  const node = el([], {});
+  node.tagName = tag.toUpperCase();
+  node.id = id;
+  node.type = spec.type || (tag === 'select' ? 'select-one' : 'text');
+  node.disabled = !!spec.disabled;
+  node.readOnly = !!spec.readOnly;
+  node.defaultValue = spec.value ?? '';
+  node.defaultChecked = !!spec.checked;
+  node.checked = !!spec.checked;
+
+  if (tag === 'select') {
+    node.options = (spec.options || []).map((value, at) => ({
+      value, defaultSelected: at === (spec.selected ?? -1),
+    }));
+    let held = node.options.length
+      ? (node.options.find((one) => one.defaultSelected) || node.options[0]).value
+      : '';
+    Object.defineProperty(node, 'value', {
+      get: () => held,
+      set: (want) => {
+        if (node.options.some((one) => one.value === want)) held = want;
+      },
+    });
+  } else {
+    node.value = spec.value ?? '';
+  }
+  return node;
+}
+
+/* --------------------------------------------------------------- the harness */
+
+/**
+ * A tool page, in one language, with a switcher and whatever the visitor has
+ * done to it.
+ *
+ * `parked` seeds the store with a record already waiting, which is how the
+ * receiving half is put on trial: the page loads complete, finds it, and
+ * either hands the work back or refuses to.
+ */
+function run({
+  lang = 'en',
+  tool = 'compress-image',
+  controls = [],
+  multiple = false,
+  parked = null,
+  held = new Map(),
+  ready = 'loading',
+  refuseStorage = false,
+  hasInput = true,
+} = {}) {
+  if (parked) held.set(tool, parked);
+
+  const feedback = el(['#feedback'], { 'data-tool': tool });
+  const main = el(['#main']);
+  main.querySelectorAll = () => controls;
+  main.contains = (other) => controls.indexOf(other) >= 0;
+  for (const node of controls) node.parentNode = main;
+
+  const input = hasInput ? el(['#file-input']) : null;
+  if (input) {
+    input.multiple = multiple;
+    input.files = [];
+  }
+
+  const dropzone = el(['#dropzone']);
+  const inside = el([]);
+  inside.parentNode = dropzone;
+
+  const pick = el(['.lang-pick']);
+  const link = el(['a[hreflang]'], { hreflang: 'de' });
+  link.href = '/de/bild-komprimieren/';
+  link.parentNode = pick;
+  const elsewhere = el(['a[hreflang]'], { hreflang: 'de' });
+  elsewhere.href = '/de/';
+
+  const byId = { feedback, main, 'file-input': input };
+  for (const node of controls) byId[node.id] = node;
+
+  const on = { document: new Map(), window: new Map() };
+  const went = [];
+
+  const document = {
+    readyState: ready,
+    documentElement: { getAttribute: (name) => (name === 'lang' ? lang : null) },
+    getElementById: (id) => byId[id] || null,
+    addEventListener: (type, fn, capture) => on.document.set(capture ? `${type}!` : type, fn),
+  };
+
+  const window = {
+    indexedDB: indexed(held, refuseStorage),
+    location: { assign: (to) => went.push(to) },
+    addEventListener: (type, fn) => on.window.set(type, fn),
+  };
+
+  // `DataTransfer` is a browser type Node does not have, and the source checks
+  // for it before using it - so it is handed in here rather than faked onto a
+  // global, which keeps the "no DataTransfer, no delivery" branch honest.
+  function DataTransfer() {
+    this.files = [];
+    this.items = { add: (file) => this.files.push(file) };
+  }
+
+  // eslint-disable-next-line no-new-func
+  new Function('window', 'document', 'DataTransfer', SOURCE)(
+    window, document, DataTransfer,
+  );
+
+  /** Let every promise chain the source started run to the end. */
+  const settle = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+
+  const click = (target, extra = {}) => {
+    const event = {
+      target,
+      button: 0,
+      defaultPrevented: false,
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      preventDefault() { event.defaultPrevented = true; },
+      ...extra,
+    };
+    const fn = on.document.get('click');
+    if (fn) fn(event);
+    return event;
+  };
+
+  return {
+    input, link, elsewhere, dropzone, inside, held, went, settle, click,
+    /** A file arriving the way the picker delivers it. */
+    choose: (...files) => {
+      input.files = files;
+      input.listeners.get('change')({});
+    },
+    /** A file arriving the way a drop delivers it. */
+    drop: (target, ...files) => {
+      on.document.get('drop!')({ target, dataTransfer: { files } });
+    },
+    load: () => {
+      const fn = on.window.get('load');
+      if (fn) fn();
+    },
+    record: () => held.get(tool) || null,
+  };
+}
+
+/** A File, near enough: the source only ever moves them from A to B. */
+const file = (name) => ({ name });
+
+/* ---------------------------------------------- a page nobody has touched */
+
+test('an untouched page leaves the switcher the plain link it was built as', () => {
+  const page = run({ controls: [control('input', 'quality', { value: '80' })] });
+  const event = page.click(page.link);
+  assert.equal(event.defaultPrevented, false);
+  assert.equal(page.record(), null, 'and nothing is written down');
+});
+
+test('a link outside the switcher is not a language switch', () => {
+  const page = run({ controls: [control('textarea', 'input', { value: '' })] });
+  const changed = page.click(page.link); // nothing changed yet either
+  assert.equal(changed.defaultPrevented, false);
+  const page2 = run({ controls: [(() => {
+    const node = control('textarea', 'input', { value: '' });
+    node.value = 'typed';
+    return node;
+  })()] });
+  const event = page2.click(page2.elsewhere);
+  assert.equal(event.defaultPrevented, false, 'an hreflang link loose on the page is left alone');
+});
+
+test('a modified click is left alone: that tab keeps its own work', () => {
+  const typed = control('textarea', 'input', { value: '' });
+  typed.value = 'a paragraph';
+  const page = run({ controls: [typed] });
+  for (const key of ['metaKey', 'ctrlKey', 'shiftKey', 'altKey']) {
+    const event = page.click(page.link, { [key]: true });
+    assert.equal(event.defaultPrevented, false, key);
+  }
+  const middle = page.click(page.link, { button: 1 });
+  assert.equal(middle.defaultPrevented, false, 'and neither is the middle button');
+});
+
+/* --------------------------------------------------- what counts as changed */
+
+test('only the controls moved off their markup value travel', async () => {
+  const untouched = control('input', 'quality', { value: '80' });
+  const moved = control('input', 'width', { value: '1200' });
+  moved.value = '640';
+  const page = run({ controls: [untouched, moved] });
+
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.record().values, [{ id: 'width', value: '640' }]);
+});
+
+test('a checkbox turned off travels, and one left alone does not', async () => {
+  const off = control('input', 'use-symbols', { type: 'checkbox', checked: true });
+  off.checked = false;
+  const on = control('input', 'use-digits', { type: 'checkbox', checked: true });
+  const page = run({ controls: [off, on] });
+
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.record().values, [{ id: 'use-symbols', on: false }]);
+});
+
+test('a select is measured against the option the markup selected', async () => {
+  const kept = control('select', 'separator', {
+    options: ['hyphen', 'space'], selected: 0,
+  });
+  const changed = control('select', 'capitals', {
+    options: ['lower', 'title'], selected: 0,
+  });
+  changed.value = 'title';
+  const page = run({ controls: [kept, changed] });
+
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.record().values, [{ id: 'capitals', value: 'title' }]);
+});
+
+test('a select with nothing selected in the markup defaults to its first option', async () => {
+  const node = control('select', 'format', { options: ['png', 'jpeg'] });
+  const page = run({ controls: [node] });
+  page.click(page.link);
+  await page.settle();
+  assert.equal(page.record(), null, 'showing "png" is showing the default');
+
+  node.value = 'jpeg';
+  const moved = run({ controls: [node] });
+  moved.click(moved.link);
+  await moved.settle();
+  assert.deepEqual(moved.record().values, [{ id: 'format', value: 'jpeg' }]);
+});
+
+test('output is not input: readonly, disabled and password never travel', async () => {
+  const shown = control('input', 'result', { value: '', readOnly: true });
+  shown.value = 'the answer the tool worked out';
+  const locked = control('input', 'depth', { value: '8', disabled: true });
+  locked.value = '16';
+  const secret = control('input', 'passphrase', { type: 'password', value: '' });
+  secret.value = 'correct horse battery staple';
+  const real = control('input', 'length', { value: '20' });
+  real.value = '32';
+
+  const page = run({ controls: [shown, locked, secret, real] });
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.record().values, [{ id: 'length', value: '32' }]);
+});
+
+test('a control with no id has no name on the other side, so it is skipped', async () => {
+  const anonymous = control('input', '', { value: '1' });
+  anonymous.value = '2';
+  const page = run({ controls: [anonymous] });
+  page.click(page.link);
+  await page.settle();
+  assert.equal(page.record(), null);
+});
+
+/* ----------------------------------------------------------------- the files */
+
+test('the file the visitor chose travels with the language', async () => {
+  const page = run();
+  page.choose(file('holiday.jpg'));
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.record().files, [file('holiday.jpg')]);
+  assert.deepEqual(page.went, ['/de/bild-komprimieren/']);
+});
+
+test('a picker that takes one file replaces; one marked multiple adds', async () => {
+  const single = run();
+  single.choose(file('a.jpg'));
+  single.choose(file('b.jpg'));
+  single.click(single.link);
+  await single.settle();
+  assert.deepEqual(single.record().files, [file('b.jpg')]);
+
+  const many = run({ multiple: true });
+  many.choose(file('a.jpg'));
+  many.choose(file('b.jpg'));
+  many.click(many.link);
+  await many.settle();
+  assert.deepEqual(many.record().files, [file('a.jpg'), file('b.jpg')]);
+});
+
+test('a drop on the dropzone counts; a drop anywhere else does not', async () => {
+  const page = run();
+  page.drop(page.inside, file('dropped.png'));
+  page.click(page.link);
+  await page.settle();
+  assert.deepEqual(page.record().files, [file('dropped.png')]);
+
+  const stray = run();
+  stray.drop(el([]), file('nowhere.png'));
+  const event = stray.click(stray.link);
+  assert.equal(event.defaultPrevented, false, 'the frame swallowed that drop, so nothing was chosen');
+});
+
+/* ------------------------------------------------------------ the other side */
+
+test('the far side of a switch hands the work back', async () => {
+  const width = control('input', 'width', { value: '1200' });
+  const page = run({
+    lang: 'de',
+    ready: 'complete',
+    controls: [width],
+    parked: {
+      lang: 'en', time: Date.now(), files: [file('holiday.jpg')],
+      values: [{ id: 'width', value: '640' }],
+    },
+  });
+  await page.settle();
+
+  assert.deepEqual(page.input.files, [file('holiday.jpg')], 'through the file input');
+  assert.deepEqual(page.input.fired, ['change'], 'as if it had been chosen');
+  assert.equal(width.value, '640');
+  assert.deepEqual(width.fired, ['input', 'change'], 'and the tool is told, or it would ignore it');
+});
+
+test('it waits for load, so the tool is listening before it is told anything', async () => {
+  const page = run({
+    lang: 'de',
+    parked: { lang: 'en', time: Date.now(), files: [file('a.jpg')], values: [] },
+  });
+  await page.settle();
+  assert.deepEqual(page.input.files, [], 'nothing yet');
+
+  page.load();
+  await page.settle();
+  assert.deepEqual(page.input.files, [file('a.jpg')]);
+});
+
+test('a record parked in this same language is a reload, and is refused', async () => {
+  const width = control('input', 'width', { value: '1200' });
+  const page = run({
+    lang: 'en',
+    ready: 'complete',
+    controls: [width],
+    parked: {
+      lang: 'en', time: Date.now(), files: [file('a.jpg')],
+      values: [{ id: 'width', value: '640' }],
+    },
+  });
+  await page.settle();
+
+  assert.deepEqual(page.input.files, []);
+  assert.equal(width.value, '1200', 'a refresh is how somebody clears a tool');
+});
+
+test('a record older than the switch it describes is refused', async () => {
+  const page = run({
+    lang: 'de',
+    ready: 'complete',
+    parked: {
+      lang: 'en', time: Date.now() - 10 * 60 * 1000, files: [file('a.jpg')], values: [],
+    },
+  });
+  await page.settle();
+  assert.deepEqual(page.input.files, []);
+});
+
+test('a record is taken exactly once, and what is left behind is swept', async () => {
+  const held = new Map();
+  const first = run({
+    lang: 'de',
+    ready: 'complete',
+    held,
+    parked: { lang: 'en', time: Date.now(), files: [file('a.jpg')], values: [] },
+  });
+  await first.settle();
+  assert.deepEqual(first.input.files, [file('a.jpg')]);
+  assert.equal(held.size, 0, 'consumed');
+
+  held.set('some-other-tool', { lang: 'en', time: Date.now() - 10 * 60 * 1000, files: [] });
+  const later = run({ lang: 'de', ready: 'complete', held });
+  await later.settle();
+  assert.equal(held.size, 0, 'and an abandoned one does not sit there holding a file');
+});
+
+test('what comes back is not then read as a fresh choice', async () => {
+  const page = run({
+    lang: 'de',
+    ready: 'complete',
+    multiple: true,
+    parked: {
+      lang: 'en', time: Date.now(), files: [file('a.jpg'), file('b.jpg')], values: [],
+    },
+  });
+  await page.settle();
+
+  // Switch again without touching anything: the set must be the two files it
+  // was handed, not those two appended to themselves.
+  page.click(page.link);
+  await page.settle();
+  assert.deepEqual(page.record().files, [file('a.jpg'), file('b.jpg')]);
+});
+
+test('a setting the tool has already filled in with the same value is not re-announced', async () => {
+  const width = control('input', 'width', { value: '1200' });
+  width.value = '640';
+  const page = run({
+    lang: 'de',
+    ready: 'complete',
+    controls: [width],
+    parked: { lang: 'en', time: Date.now(), files: [], values: [{ id: 'width', value: '640' }] },
+  });
+  await page.settle();
+  assert.deepEqual(width.fired, []);
+});
+
+test('a select whose options do not carry the value is left alone', async () => {
+  const empty = control('select', 'series', { options: [] });
+  const page = run({
+    lang: 'de',
+    ready: 'complete',
+    controls: [empty],
+    parked: { lang: 'en', time: Date.now(), files: [], values: [{ id: 'series', value: '3' }] },
+  });
+  await page.settle();
+  assert.equal(empty.value, '');
+  assert.deepEqual(empty.fired, [], 'telling a tool about a change that did not take is a lie');
+});
+
+/* ---------------------------------------------------- when nothing will hold */
+
+test('storage refusing loses the work but never the switch', async () => {
+  const typed = control('textarea', 'input', { value: '' });
+  typed.value = 'a paragraph';
+  const page = run({ controls: [typed], refuseStorage: true });
+
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.went, ['/de/bild-komprimieren/'],
+                   'the reader asked for another language and gets it');
+});
+
+test('a page with no picker still carries its settings', async () => {
+  const words = control('input', 'words', { value: '6' });
+  words.value = '9';
+  const page = run({ controls: [words], hasInput: false, tool: 'password-generator' });
+
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.record().values, [{ id: 'words', value: '9' }]);
+});

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -769,6 +769,38 @@ class BuildTheSite(unittest.TestCase):
                         folder = by_slug[target].split('/')[-1]
                         self.assertIn(f'href="../{folder}/"', page)
 
+    def test_a_tool_page_carries_its_work_across_a_language_switch(self):
+        """shared/lang-keep.js, on every tool page and nowhere else.
+
+        Three claims, and each of them is a way the feature silently does
+        nothing. The script has to be on the page at a versioned URL, or a
+        service worker keeps the copy it cached before this existed. It has to
+        be ABOVE src/main.js, because it listens on the file input and the
+        picker's own listener - added when that module runs - clears the input
+        as its first act, so a script registered afterwards would find nothing
+        to carry. And it belongs on tool pages only: a guide has no work to
+        keep, and putting it there would be a database opened for nothing.
+        """
+        version = buildmod.sitelib.text_hash(
+            (self.out / 'lang-keep.js').read_text(encoding='utf-8'))
+        asked = f'<script src="/lang-keep.js?v={version}" defer></script>'
+
+        pages = self.tool_pages()
+        self.assertTrue(pages)
+        for name in pages:
+            text = (self.out / name).read_text(encoding='utf-8')
+            with self.subTest(page=name):
+                self.assertIn(asked, text)
+                self.assertLess(text.index(asked), text.index('src="src/main.js"'),
+                                'it has to be listening before the picker is')
+
+        for name in self.written:
+            if not name.endswith('.html') or name in pages:
+                continue
+            with self.subTest(page=name):
+                self.assertNotIn('lang-keep.js',
+                                 (self.out / name).read_text(encoding='utf-8'))
+
     def test_every_page_asks_for_the_language_script_by_a_versioned_url(self):
         """One URL, root-absolute, the same on every page in every language.
 


### PR DESCRIPTION
Clicking **Deutsch** halfway through compressing a photo used to empty the tool: the file gone, the target size back to 500 KB, and the reader who wanted the instructions in their own language paying for them by starting again.

That is not a bug in the switcher — it is what a navigation does, and every language here being its own document at its own address is exactly what makes the site legible to a crawler and linkable in fourteen languages. So the navigation stays and the work travels with it.

## What this adds

`shared/lang-keep.js`, a frame script beside `feedback.js` and `handoff.js`, on every tool page in every language. It takes both halves of the visitor's work through doors that already exist:

- **The files** — seen at the `change` event on `#file-input` and at a drop on `#dropzone`, handed back through the same file input `shared/handoff.js` delivers through (a `DataTransfer` and a synthetic `change`), so **no tool needed a line of code**. A picker marked `multiple` accumulates and one without it replaces, following the input's own attribute rather than knowing which tool it is on.
- **The settings the visitor moved** — every `input`, `textarea` and `select` inside `<main>` whose value differs from the one in the markup. Only the difference, so a page nobody has touched carries nothing, no storage is opened and no click is intercepted. The switcher stays the plain link it was built as; there is a test for that, because a version of this that intercepted every click would have looked identical in use.

`readonly`, `disabled` and `password` controls are output rather than input, and never travel.

The record goes in IndexedDB — the only storage a `File` survives — addressed by the `data-tool` slug, which is the English slug in every language and so the one thing the two sides of a switch agree on. It is consumed once, refused if it is more than two minutes old or if the language on it matches the page reading it (a reload is how somebody clears a tool), and swept if a switch is ever abandoned. **Nothing in it touches the network**: no fetch, no `blob:` URL to read back, and therefore nothing for any tool's CSP to widen for.

## What it deliberately does not do

Both are recorded at length in the file's header comment.

- A control the tool fills in **from the file** — a width read off an image, a duration off a clip — is filled in from the file again rather than from the record. There is no generic way to tell that apart from a setting somebody chose, and re-deriving it cannot go stale.
- A file a tool has since **dropped from a list of its own** comes back with the rest. The doors above see files arriving; nothing announces a removal. Fixing it means all thirty-six tools remembering to announce one, which is a promise that has to be kept everywhere to mean anything.

## Reviewer notes

- **The script tag sits above `src/main.js` on purpose.** It listens on the file input, and the picker's first act with a chosen file is to clear that input — a listener registered afterwards would find nothing to carry. Deferred classic scripts and module scripts run in document order, so being written above `main.js` is what wins the race. The Python test asserts the order rather than trusting the template to keep it.
- **A drive-by fix in `build()`**: the sequential branch had not been given `handoff_v` when that argument was added, so `--jobs 1` would have raised a `TypeError`. Threading `keep_v` through made it visible; both builds are verified below. `handoff.js` and `lang-keep.js` also joined the `copy_shared` exclusion list, which order alone was saving.
- Nothing under `locales/` changed. The script says nothing on screen, so there is no sentence in it to arrive in the wrong language — which on this file would have been a joke at its own expense.

## Verified

- `python build.py --out _plain --clean --no-minify` (what CI runs), the minified build, and `--jobs 1`.
- 409 Python tests and 1,920 JS tests pass, including 22 new ones in `tests/js/lang-keep.test.js` and one in `test_build.py`.
- **In a real browser**, against the built site: typed text carried `en → de` on Text Compare and the diff recomputed itself; a chosen image plus its target size, format and checkbox carried `de → en → fr` on Compress Image; a reload restored nothing; an untouched page was not intercepted; no console errors from this code.

## Found in passing, not touched here

Two tools put visitor-facing English sentences directly in their JavaScript — `compare-text`'s diff summary (`src/main.js:190`) and a `compress-image` row note — so they read as English on the translated pages. Pre-existing, unrelated to this change, and being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
