### PR TITLE
Let a tool page keep its work when a link leads away

### DIFF
--- a/build.py
+++ b/build.py
@@ -622,6 +622,49 @@ def frame(locale, locales, site, slug, base, links, lang_v, extra=None):
     return context
 
 
+# The islands of a tool page whose links keep replacing it: the language
+# switchers, whose links ARE this page in another tongue and would only be
+# duplicated by a second tab; and the carry-on row, whose click is taken over
+# by shared/handoff.js to walk the result into the next tool.
+KEEPS_ITS_TAB = re.compile(
+    r'<details class="lang-pick".*?</details>'
+    r'|<nav class="lang-switch".*?</nav>'
+    r'|<div class="lang-auto".*?</div>'
+    r'|<nav class="handoff".*?</nav>', re.S)
+
+LEAVING_ANCHOR = re.compile(r'<a\s[^>]*>')
+
+
+def open_links_elsewhere(html):
+    """Make every link away from a tool page open in a new tab.
+
+    A tool page holds work in progress - a file loaded, marks placed, a result
+    computed - and any link that replaces the page throws that work away. So
+    on this one kind of page, leaving happens elsewhere. Done to the rendered
+    page rather than written into the markup, because the links live in
+    fifteen languages of prose - tool.toml answers, translated overrides, the
+    shared footer - and an attribute kept by hand across all of them is a rule
+    nobody could keep. The exemptions and their reasons sit on KEEPS_ITS_TAB;
+    beyond those, an anchor is left alone when it has no href to leave by,
+    already says target, stays on the page (#), starts a download, or opens a
+    mail client rather than a page.
+    """
+    def fix(match):
+        tag = match.group(0)
+        if ('href=' not in tag or 'target=' in tag or 'href="#' in tag
+                or 'href="mailto:' in tag or re.search(r'\sdownload[\s>=]', tag)):
+            return tag
+        return tag[:-1] + ' target="_blank" rel="noopener">'
+
+    out, last = [], 0
+    for kept in KEEPS_ITS_TAB.finditer(html):
+        out.append(LEAVING_ANCHOR.sub(fix, html[last:kept.start()]))
+        out.append(kept.group(0))
+        last = kept.end()
+    out.append(LEAVING_ANCHOR.sub(fix, html[last:]))
+    return ''.join(out)
+
+
 # ---------------------------------------------------------------------------
 # The guides, and how they are tied to the tools
 
@@ -869,7 +912,7 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
             'network permission the importer needs, but body.html never includes '
             '{% include "partials/url-import.html" %}. Add it, or drop [picker.urls].')
 
-    page = emit.html(dest / 'index.html', templates.render(
+    page = emit.html(dest / 'index.html', open_links_elsewhere(templates.render(
         'tool.html', frame(locale, locales, site, tool['slug'], '../', links, lang_v, {
             'tool': tool,
             'guide': guide,
@@ -892,7 +935,7 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
             'handoff_href': f'/handoff.js?v={handoff_v}',
             'jsonld': sitelib.tool_jsonld(root, tool),
             'body': body,
-        })))
+        }))))
 
     css = write(dest / 'styles.css', css)
 

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -638,6 +638,35 @@ class BuildTheSite(unittest.TestCase):
         version = page.split('styles.css?v=')[1].split('"')[0].split("'")[0]
         self.assertIn(f'styles.css?v={version}', worker)
 
+    def test_a_tool_pages_links_leave_in_a_new_tab_except_the_switcher(self):
+        """Every link away from a tool page opens elsewhere - see frame().
+
+        A tool page holds work in progress, so a footer or related-tool link
+        that replaced the page would throw a loaded file away. The exemptions
+        are each exempt for a stated reason: the language switchers, whose
+        links are this same page in another tongue; in-page anchors, which do
+        not leave; result links, which carry the download attribute; the
+        carry-on row, which is hidden until its script takes over the click;
+        and the mailto link, which opens a mail client rather than a tab.
+        Checked in the built pages so a link added anywhere - a template, a
+        tool's own body - cannot quietly go back to replacing the page.
+        """
+        exempt = re.compile(
+            r'<details class="lang-pick".*?</details>'
+            r'|<nav class="lang-switch".*?</nav>'
+            r'|<div class="lang-auto".*?</div>'
+            r'|<nav class="handoff".*?</nav>', re.S)
+        anchors = re.compile(r'<a\s[^>]*>')
+        for name in self.tool_pages():
+            text = exempt.sub('', (self.out / name).read_text(encoding='utf-8'))
+            for tag in anchors.findall(text):
+                if 'href=' not in tag or 'href="#' in tag:
+                    continue
+                if 'href="mailto:' in tag or re.search(r'\sdownload[\s>=]', tag):
+                    continue
+                with self.subTest(page=name, tag=tag):
+                    self.assertIn('target="_blank"', tag)
+
     def test_a_tool_page_asks_its_question(self):
         """The panel, and the one script that can act on it.
 


### PR DESCRIPTION
On a tool page, every link now opens in a new tab — except the language switcher and a short list of anchors that each keep their tab for a stated reason. A tool page holds work in progress (a file loaded, marks placed, a result computed), and until now any footer link, related tool, guide link, or cross-reference in the FAQ prose replaced the page and threw that work away.

## How it's done

One pass over the rendered tool page (`open_links_elsewhere` in build.py), not attributes written into the markup. The links live in fifteen languages of prose — `tool.toml` answers, translated locale overrides, the shared footer — and an attribute kept by hand across all of them is a rule nobody could keep. (The first attempt *was* template edits; the new test promptly found the cross-links inside every language's FAQ prose, at which point the pass became the design.)

Only tool pages get the pass — the hub, guides, and legal pages keep ordinary navigation, since they hold no state to lose.

## The exemptions

| Keeps its tab | Why |
|---|---|
| Language switchers (`lang-pick`, `lang-switch`, `lang-auto`) | their links are this same page in another tongue — a second tab would be a second copy |
| In-page anchors (`#…`) | they never leave |
| Result links (`download` attribute) | they save, not navigate |
| The carry-on row (`handoff`) | its click is taken over by shared/handoff.js to walk the result into the next tool |
| The mailto link | opens a mail client, not a page |

Everything else — footer columns, breadcrumb, guide link, related tools, sitemap, prose cross-links — gets `target="_blank" rel="noopener"`. Links that already declare a target (the GitHub source links) are left as they are.

## Enforcement

A new build-contract test asserts the whole rule over every built tool page in every language: any anchor with a leaving href must say `target="_blank"` unless it sits in an exempt island. A link added anywhere — a template, a tool body, a translated FAQ — cannot quietly go back to replacing the page.

Spot-checked on the minified build: 53 links per tool page open elsewhere; the only same-tab anchors left are the skip link, the switcher, the language-notice return, downloads, and mailto.

## Verification

- Full Python suite: OK (exit 0), including the new test
- JS suite: 1898 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)