### PR TITLE
Ask a visible change to show its face

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,28 @@ Prose in this repository — commit messages, comments, `tool.toml` — explains
 **why**, in full sentences, and assumes the reader can see the code. Match it.
 Comments that restate the line below them do not belong; the ones here earn
 their space by recording a decision or a trap.
+
+**A pull request that changes what a visitor sees carries before and after
+pictures.** Layout, a control, a colour, a sentence on screen, a translated
+string: the diff for any of those is unreadable as evidence, and a reviewer
+should not have to build and serve the site to find out whether the change
+looks right. Two screenshots in the description settle it. They also catch what
+prose cannot — a phrase that reads correctly in the source and arrives with a
+space in the middle of a Japanese sentence is only ever visible in a rendered
+page.
+
+Photograph the **built** site, never a mock-up: build, serve `dist/` or
+`_plain/`, and capture the real page. `node screenshots/capture.mjs` is the
+guides' harness and is recipe-driven, so it is not the tool for this; drive a
+browser directly. Take the "before" shot *first* — once the change is applied
+there is nothing left to photograph, short of a second build of the base
+commit.
+
+GitHub has no public API for the images a PR body embeds: the
+`user-attachments/assets/…` URLs come from the web uploader's own session
+endpoint, and neither `gh` nor `gh api` can reach it. So an agent opening a PR
+writes the Before/After section with the filenames as visible placeholders and
+hands the files to whoever is at the keyboard to drop in. Do not commit
+screenshots to get a raw URL — see the `git add -A` trap above for what stray
+files cost here. A change with nothing visible in it says so in one line
+instead of shipping empty placeholders.


### PR DESCRIPTION
Adds one convention to `CLAUDE.md`: **a pull request that changes what a visitor
sees carries before and after pictures in its description.**

## Why

The diff for a visible change is unreadable as evidence. [#181](https://github.com/A-Box-of-Tools/website/pull/181)
described eight verified locale screens in prose — the German summary line, the
French row note, the Japanese progress steps — and shipped none of them, leaving
a reviewer to build and serve the site to find out whether any of it looked
right.

Two screenshots settle that, and they catch what prose cannot. The
inter-sentence space that made `format.note` read wrong in Japanese was only
ever visible in a rendered page; the source it came from looked correct.

## What the paragraph says

- Photograph the **built** site, never a mock-up.
- `node screenshots/capture.mjs` is the guides' harness and is recipe-driven, so
  it is not the tool for this — drive a browser directly.
- Take the "before" shot *first*. Once the change is applied there is nothing
  left to photograph, short of a second build of the base commit.
- **GitHub has no public API for PR-body images.** The
  `user-attachments/assets/…` URLs come from the web uploader's own session
  endpoint; neither `gh` nor `gh api` can reach it. So an agent writes the
  Before/After section with filenames as visible placeholders and hands the
  files over. Writing that constraint down is what stops the next attempt being
  a screenshot committed to the repository for the sake of a raw URL.
- A change with nothing visible in it says so in one line rather than shipping
  empty placeholders.

## Note

Docs only — one paragraph in `CLAUDE.md`, no code touched. Python suite still
423 passing on this branch. Per its own rule, there is nothing on screen to
photograph here.

Kept off [#181](https://github.com/A-Box-of-Tools/website/pull/181) deliberately:
that PR is the phrase extraction, and bolting an unrelated convention onto it
would muddy its review. Merge order does not matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
