### PR TITLE
Leave the test suites to the machine that already runs them

### DIFF
--- a/.claude/skills/tool-development/SKILL.md
+++ b/.claude/skills/tool-development/SKILL.md
@@ -103,8 +103,9 @@ with the steps that bite marked.
    someone reading the code. The build refuses to finish without it. Do not
    add the tool to the repository README or `tools/README.md`; the first
    covers the site, the second is generated.
-9. **Build, test, and open it in a browser** — see "Verify" below. A tool that
-   only passed its tests has not been used yet.
+9. **Build it and open it in a browser** — see "Verify" below. Write the tests
+   it owes and leave the running of them to CI; a tool that only passed its
+   tests has not been used yet, and that is the half nothing else can check.
 
 ## Job: update an existing tool
 
@@ -210,21 +211,25 @@ and unadvertised until then. What a change does owe them:
 python build.py --out _plain --clean --no-minify
 ```
 
-```bash
-python -m unittest discover -t . -s tests/python
-```
+That is exactly what CI runs, and the only thing in this section you run over
+the code rather than over the site it made. `--clean` matters: building
+several branches into one output directory leaves pages from all of them, and
+the link checker then reports dozens of broken links that look exactly like
+"main is broken". `python build.py --check` compares against the deployed
+`dist` branch, which tracks `main` — on a feature branch it exits 1 by
+construction, so do not read that as failure.
 
-```bash
-node --test "tests/js/*.test.js"
-```
-
-The first is exactly what CI runs. `--clean` matters: building several
-branches into one output directory leaves pages from all of them, and the link
-checker then reports dozens of broken links that look exactly like "main is
-broken". Node 21+ needs the glob quoted; on 20 and earlier pass the directory
-instead. `python build.py --check` compares against the deployed `dist`
-branch, which tracks `main` — on a feature branch it exits 1 by construction,
-so do not read that as failure.
+**The two test suites are not yours to run.** `tests/README.md` says how, and
+a person is welcome to; an agent working here is not. CI runs both on every
+push and every pull request and the build job needs them, so a failure stops
+the deploy without your help — while the Python suite costs the better part of
+half an hour locally, because most of its cases build the whole site before
+they assert anything. Write the tests a change owes (the checklists above still
+mean it), let CI run them, and spend the time on the browser instead. If CI
+reports a failure, reproduce that one case by name — `python -m unittest
+tests.python.test_build -v -k <name>`, or `node --test
+--test-name-pattern="<name>" "tests/js/*.test.js"` — rather than the suite
+around it.
 
 Then use the thing:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,29 @@ node screenshots/capture.mjs [<guide>]            # the guides' screenshots
 Both suites need nothing installed. Node 21+ needs the glob **quoted**; on 20
 and earlier a directory argument works and a glob does not.
 
+**Do not run either suite locally.** They are listed above because they are
+part of the repository, not because they are part of the loop. CI runs both on
+every push and every pull request and the build job needs them, so nothing
+reaches `dist` past a failure — running them here buys an answer that is
+already on its way, and the Python suite takes the better part of half an hour
+on Windows because most of its cases build the whole site first. Build, then
+open the page; that is the part CI cannot do for you and the part that finds
+what the suites do not.
+
+This is a rule about the **tests**, not about the build: `python build.py` is
+still how you check your own work, and a change is still not done until the
+page has done its job in front of you. And when CI does report a failure,
+reproduce that one case rather than the suite it lives in:
+
+```bash
+python -m unittest tests.python.test_build -v -k <name>
+```
+
+```bash
+node --test --test-name-pattern="<name>" "tests/js/*.test.js"
+```
+
+
 `--clean` matters. Building several branches into one output directory leaves
 pages from all of them, and `check_links` then reports dozens of broken links
 that do not exist on the branch under test. It looks exactly like "main is


### PR DESCRIPTION
A working rule for an agent, in the two files an agent reads before it starts. No code changes.

## Why

Both suites already run in CI on every push and every pull request, and the `build` job `needs` them — so nothing reaches `dist` past a failure. Running them again locally buys an answer that is already on its way, and the Python suite costs the better part of half an hour on Windows because most of its cases build the whole site before they assert anything. That is time taken out of the one check CI cannot make: opening the page.

## What changed

**`CLAUDE.md`** — both commands stay listed under Commands, because they are part of the repository. The rule goes underneath, and says three things rather than one:

- do not run either suite locally, and why;
- **this is about the tests, not the build** — `python build.py` is still how you check your own work, and a change is still not done until the page has done its job in front of you;
- what to do when CI *does* come back red: reproduce that one case by name (`-k <name>`, `--test-name-pattern="<name>"`) rather than the suite around it. Without that, an agent handed a CI failure has no sanctioned way to act on it.

**`.claude/skills/tool-development/SKILL.md`** — its "Verify before you call it done" section told you in as many words to run both suites, so it would have contradicted the rule. It is now one command and a browser. Step 9 of the new-tool checklist changes from *"Build, test, and open it in a browser"* to *"Build it and open it in a browser — write the tests it owes and leave the running of them to CI"*.

## What did not change

- **Nothing changes for a person.** `README.md`, `docs/running.md` and `tests/README.md` still document both suites, including how to run one file or one case, and are untouched. Running them by hand is normal.
- **Nothing changes about what a change owes.** The checklists still say to write the tests, and `tests/` still covers everything here that can be given a test. This is only about who spends the minutes running them.

## If you want it enforced rather than written down

A `deny` entry for the two commands in `.claude/settings.json` would make the harness refuse them outright. Not included here — a written rule leaves room for the CI-failure case above, and a hard block does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
