### PR TITLE
Ask CI whether a change is one the tests could have an opinion about

### DIFF
--- a/.claude/skills/tool-development/SKILL.md
+++ b/.claude/skills/tool-development/SKILL.md
@@ -221,8 +221,9 @@ construction, so do not read that as failure.
 
 **The two test suites are not yours to run.** `tests/README.md` says how, and
 a person is welcome to; an agent working here is not. CI runs both on every
-push and every pull request and the build job needs them, so a failure stops
-the deploy without your help — while the Python suite costs the better part of
+push and every pull request that touches anything they cover, and the build job
+needs them, so a failure stops the deploy without your help — while the Python
+suite costs the better part of
 half an hour locally, because most of its cases build the whole site before
 they assert anything. Write the tests a change owes (the checklists above still
 mean it), let CI run them, and spend the time on the browser instead. If CI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,97 @@ jobs:
   #
   # It runs before the build rather than beside it, and the build needs it, so
   # a failing test cannot deploy.
+  #
+  # WHY THE STEPS ARE SKIPPED AND NOT THE JOB
+  #
+  # A change that touches only the repository's own prose - the READMEs, docs/,
+  # and the agent instructions in CLAUDE.md and .claude/ - cannot alter what
+  # the build produces or what a test asserts. Running either suite over it
+  # answers a question nobody asked and delays the ones somebody did, so the
+  # first step below works out whether that is the case and the rest read its
+  # answer.
+  #
+  # The obvious shape - a job of its own, an `if:` on this one - was not taken,
+  # and the reason is the line above. A skipped job skips everything that needs
+  # it, so `build` would stop running too; keeping it would mean rewriting its
+  # `needs: test` as an expression that has to accept a skipped test. That
+  # `needs` is the only thing standing between a broken test and the deployed
+  # branch, and an expression that gets it wrong is invisible until the day it
+  # matters. This way `build` is untouched. A test job that reports success
+  # having skipped its steps costs half a minute of runner, and the deploy
+  # still cannot happen without it.
   test:
     runs-on: ubuntu-latest
     steps:
+      # What this actually changed, asked of the API rather than worked out
+      # from a clone: it is one request, and fetching enough history to diff
+      # for it would cost more than the job it is deciding about. `gh` is on
+      # the runner already, so this adds no dependency - the same bargain the
+      # rest of the repository makes.
+      #
+      # NOT KNOWING MEANS RUNNING THEM. Every branch here that cannot answer -
+      # a manual run with no `before`, a new branch, a request that failed, a
+      # comparison too long to come back whole - leaves `code` at true. The
+      # failure mode is a suite that ran when it need not have, and never a
+      # change that shipped untested.
+      #
+      # The exempt list is an allowlist, and short on purpose: prose the build
+      # never reads and no test opens. Anything else - anything new, anything
+      # unrecognised - runs the suites until somebody decides otherwise here.
+      - name: Is there anything here a test could see?
+        id: covered
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+
+          code=true
+          why='could not work out what changed'
+          zero=0000000000000000000000000000000000000000
+
+          if [ -n "$BASE" ] && [ "$BASE" != "$zero" ]; then
+            range="repos/$GITHUB_REPOSITORY/compare/$BASE...$HEAD"
+            files=$(gh api "$range" --jq '.files[].filename') || files=''
+            count=$(printf '%s\n' "$files" | grep -c . || true)
+
+            # 300 is where the compare endpoint stops listing files. A reply
+            # that long may have been cut short, and the file it left out is
+            # exactly the one this is looking for.
+            if [ "$count" -gt 0 ] && [ "$count" -lt 300 ]; then
+              code=false
+              while IFS= read -r path; do
+                case "$path" in
+                  README.md|CLAUDE.md|ROADMAP.md|LICENSE|LICENSE-CONTENT) continue ;;
+                  docs/*|.claude/*) continue ;;
+                esac
+                code=true
+                why="$path"
+                break
+              done <<< "$files"
+            fi
+          fi
+
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+
+          {
+            echo '### Tests'
+            echo
+            if [ "$code" = true ]; then
+              echo "Running both suites, because of \`$why\`."
+            else
+              echo 'Skipped. Everything this changed is prose the build never'
+              echo 'reads and no test opens, so neither suite has an opinion'
+              echo 'about it. The build still runs.'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - uses: actions/checkout@v4
+        if: steps.covered.outputs.code == 'true'
 
       - uses: actions/setup-python@v5
+        if: steps.covered.outputs.code == 'true'
         with:
           python-version: '3.12'
 
@@ -58,13 +143,16 @@ jobs:
       # path that does not exist. Nothing is installed with either, so the two
       # versions are free to differ.
       - uses: actions/setup-node@v4
+        if: steps.covered.outputs.code == 'true'
         with:
           node-version: '24'
 
       - name: The build (Python)
+        if: steps.covered.outputs.code == 'true'
         run: python -m unittest discover -t . -s tests/python -v
 
       - name: The tools (JavaScript)
+        if: steps.covered.outputs.code == 'true'
         run: node --test "tests/js/*.test.js"
 
   build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,9 @@ and earlier a directory argument works and a glob does not.
 
 **Do not run either suite locally.** They are listed above because they are
 part of the repository, not because they are part of the loop. CI runs both on
-every push and every pull request and the build job needs them, so nothing
-reaches `dist` past a failure — running them here buys an answer that is
+every push and every pull request that touches anything they cover, and the
+build job needs them, so nothing reaches `dist` past a failure — running them
+here buys an answer that is
 already on its way, and the Python suite takes the better part of half an hour
 on Windows because most of its cases build the whole site first. Build, then
 open the page; that is the part CI cannot do for you and the part that finds

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,8 +25,12 @@ node --test "tests/js/*.test.js"
 ```
 
 `npm test` runs the second one, and is the only thing `package.json` is for —
-see the note in that file. Both run in CI on every push and every pull request,
-and the build will not publish if either fails.
+see the note in that file. Both run in CI on every push and
+every pull request that changes something they could have an opinion about,
+and the build will not publish if either fails. A change confined to the
+repository's own prose — the READMEs, `docs/`, `CLAUDE.md`, `.claude/` — skips
+them; the comment on the `test` job in `.github/workflows/build.yml` says how
+that is decided and why it errs towards running them.
 
 To run one file, or one test:
 


### PR DESCRIPTION
Follows #184, which said an agent should leave the suites to CI. This is the other half: CI should not run them over a change they cannot have an opinion about.

## The problem

The suites take minutes. A change to `CLAUDE.md` cannot make either of them say anything different — nothing under `docs/`, `.claude/` or the root READMEs is read by the build or opened by a test. #184 itself was two prose files and paid the full bill; the answer anyone was actually waiting on was the build.

## What it does

The `test` job asks first. One call to the compare endpoint gives the files a push or a pull request touched; if every one is on a short allowlist of prose, the remaining steps are skipped and the job reports success having installed nothing. Anything else — a module, a locale, a template, this workflow, a path nobody has classified — runs both suites exactly as before.

The allowlist is deliberately short, and it is an *allowlist*: `README.md`, `CLAUDE.md`, `ROADMAP.md`, `LICENSE`, `LICENSE-CONTENT`, `docs/**`, `.claude/**`. Anything new is covered by tests until somebody decides otherwise in that file.

**The build is untouched.** It still runs on every change, prose included, and still cannot run unless `test` passed.

## Two decisions worth reviewing

**Not knowing means running them.** A manual run with no `before`, a new branch, a request that failed, a comparison too long to come back whole — each leaves the answer at "run". The failure mode is a suite that ran when it need not have, never a change that shipped untested.

**The steps are skipped, not the job**, which looks like the long way round and is not. A skipped job skips everything that `needs` it, so `build` would stop running too — and keeping it would mean rewriting `needs: test` as an expression that has to accept a *skipped* test. That `needs` is the only thing standing between a broken test and the deployed branch, and an expression that gets it wrong is invisible until the day it matters. A test job that reports success having skipped its steps costs about half a minute of runner; the guarantee stays structural.

`gh` is already on the runner, so this asks the API rather than fetching enough history to diff, and adds no dependency to a repository that has none.

## Verified

The decision script was extracted and run against every branch it has, with `gh` stubbed:

| changed files | result |
|---|---|
| `CLAUDE.md`, `docs/…`, `.claude/…` | **skip** |
| 299 files, all under `docs/` | **skip** |
| `CLAUDE.md` + `shared/lang-keep.js` | run — names `shared/lang-keep.js` |
| `tools/compress-image/src/main.js` | run |
| `locales/de/tools/compare-text.html` | run |
| `tools/compress-image/README.md` | run |
| `.github/workflows/build.yml` | run |
| the API call fails | run |
| no `before` (manual run) | run |
| all-zero `before` (new branch) | run |
| 301 files (reply may be truncated) | run |

It also `bash -n`s clean. This PR changes the workflow, so by its own rule both suites run on it — which is the demonstration.

## Also

Three sentences claimed the suites run on every push and every pull request, full stop. `CLAUDE.md`, `.claude/skills/tool-development/SKILL.md` and `tests/README.md` now say what is true, and point at the workflow comment for how it is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
