### PR TITLE
Have the step say out loud which answer it gave

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
           set -uo pipefail
 
           code=true
-          why='could not work out what changed'
+          why='what changed could not be worked out'
           zero=0000000000000000000000000000000000000000
 
           if [ -n "$BASE" ] && [ "$BASE" != "$zero" ]; then
@@ -110,24 +110,29 @@ jobs:
                   docs/*|.claude/*) continue ;;
                 esac
                 code=true
-                why="$path"
+                why="\`$path\` is a file a test could see"
                 break
               done <<< "$files"
             fi
           fi
 
-          echo "code=$code" >> "$GITHUB_OUTPUT"
+          if [ "$code" = true ]; then
+            said="Running both suites, because $why."
+          else
+            said="Skipping both suites: everything this changed is prose the build never reads and no test opens. The build still runs."
+          fi
 
+          # Twice on purpose. The summary is where somebody looks to find out
+          # why a pull request did not run the tests; the log is where somebody
+          # looks when they suspect this step of never having worked. Said only
+          # in the summary, a step that always answered "run" because the API
+          # call was failing would look exactly like one doing its job.
+          echo "$said"
+          echo "code=$code" >> "$GITHUB_OUTPUT"
           {
             echo '### Tests'
             echo
-            if [ "$code" = true ]; then
-              echo "Running both suites, because of \`$why\`."
-            else
-              echo 'Skipped. Everything this changed is prose the build never'
-              echo 'reads and no test opens, so neither suite has an opinion'
-              echo 'about it. The build still runs.'
-            fi
+            echo "$said"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
Follow-up to #187, which taught the `test` job to skip the suites on a prose-only change. It works — but it works silently, and that turns out to matter.

## The problem

The verdict went to the step summary and nowhere else, so the step's own log is empty. That makes the two "run the suites" answers indistinguishable: *"I looked, and `shared/lang-keep.js` is covered"* and *"I could not reach the API, so I am running them to be safe"* produce identical output and identical behaviour.

That is the failure this feature is most likely to have. If the compare call ever starts failing — a permissions change, a rename, a rate limit — the job falls back to running both suites every time, which is correct and completely invisible. The feature would be dead and every run would look healthy. I hit this immediately: I could not tell from #187's own green run which of the two answers it had given without opening the summary page.

## What changed

The verdict is built once and said twice — to stdout and to the step summary. The summary is where somebody looks to find out why a pull request did not run the tests; the log is where somebody looks when they suspect this step of never having worked.

The reason is now a clause rather than a bare path, so both answers read as sentences:

```
Running both suites, because `shared/lang-keep.js` is a file a test could see.
Running both suites, because what changed could not be worked out.
Skipping both suites: everything this changed is prose the build never reads and no test opens. The build still runs.
```

No logic changed — same allowlist, same conservative fallbacks, same guarded steps.

## Verified

Re-extracted the script from the YAML and dry-ran it with `gh` stubbed. `bash -n` clean, and every branch still lands where it did:

| changed files | verdict |
|---|---|
| `CLAUDE.md`, `docs/guides.md` | skip |
| `shared/lang-keep.js` | run — names the file |
| `locales/de/tools/x.html` | run — names the file |
| `.github/workflows/build.yml` | run — names the file |
| the API call fails | run — *"could not be worked out"* |
| no `before` (manual run) | run — *"could not be worked out"* |
| 301 files (reply may be truncated) | run — *"could not be worked out"* |

This PR changes the workflow, so it runs both suites on itself and its log will now say why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
