### PR TITLE
Fold a tool page down to the tool, and put the words one click away

### DIFF
--- a/build.py
+++ b/build.py
@@ -70,6 +70,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+from buildlib import cards
 from buildlib import cssmin
 from buildlib import i18n
 from buildlib import imports
@@ -915,6 +916,12 @@ def build_tool(out, templates, locale, locales, site, tool, footer, links,
         f'{tool["slug"]}/body.html [{locale["lang"]}]',
         {'site': root, 'tool': tool, 'ui': ui, 'base': '../',
          'links': links}).rstrip('\n')
+
+    # The explanation each step opens with, folded behind that step's heading.
+    # Done here rather than in five hundred bodies, one per tool per language,
+    # which would all be saying the same thing about the same paragraph. See
+    # buildlib/cards.py.
+    body = cards.fold_ledes(body)
 
     # Setting [picker.urls] ships the module, the stylesheet and the widened
     # img-src. If the panel itself were then left off the page, the tool would

--- a/buildlib/cards.py
+++ b/buildlib/cards.py
@@ -1,0 +1,122 @@
+"""
+Everything a step explains, folded behind that step's heading.
+
+WHAT MOVES
+
+Three kinds of prose, all of them explanation rather than state:
+
+  * `<p class="card-lede">` - the paragraph a card opens with, saying what the
+    step is for;
+  * `<span class="check-note">` - the small print under a checkbox, saying what
+    turning it on costs;
+  * the `field-summary` or `field-note` that closes an options fieldset - the
+    policy the settings above it add up to.
+
+They are gathered into one `<details>` whose summary is the card's own heading,
+with a small mark beside it. Closed, a card is the controls it operates;
+opened, it is everything it used to say.
+
+What does NOT move is anything that reports rather than explains. The line
+under the target field - "This image is over 200 KB, so it will be compressed
+until it is not" - answers a question the reader asked by typing a number, and
+a status hidden behind a fold is a status nobody reads.
+
+WHY THE BUILD DOES THIS AND NOT THE MARKUP
+
+A tool's body.html exists once in English and once in each of the fourteen
+other languages - five hundred files - and the change is the same in all of
+them: no word moves, only the wrapper around it. Written by hand it would be
+five hundred chances to get one wrong, and the next tool would arrive
+unfolded. Written here it is one rule, it reaches every language on the next
+build, and a tool author goes on writing the same paragraph they always wrote.
+
+THE ACCESSIBILITY PART, WHICH IS NOT A SIDE EFFECT
+
+A `check-note` sits inside its `<label>`, so it is part of the checkbox's
+accessible name: the control announced itself as "May make the picture smaller
+if it has to Only used once quality alone would have to drop past the point
+where compression starts to show. Below that..." - eighty words where a name
+should be a phrase. Lifting the note out of the label leaves the checkbox named
+by its own words. The note keeps its `<strong>` beside it inside the fold, so
+which control it belongs to is still on the page.
+"""
+
+import re
+
+# One card. Sections do not nest inside a card in any tool here, and if one
+# ever does this stops at the first close rather than silently swallowing the
+# rest of the page - a card that folds too little is a bug somebody sees.
+CARD = re.compile(r'(?P<open><section[^>]*class="[^"]*\bcard\b[^"]*"[^>]*>)'
+                  r'(?P<inner>(?:(?!</section>).)*)'
+                  r'(?P<close></section>)', re.S)
+
+# The heading a card opens with. The tempered close tag matters: `.*?` alone
+# backtracks past its own card to find a heading that does have a paragraph
+# under it, and folds four screens of markup into one summary.
+HEADING = re.compile(r'(?P<indent>[ \t]*)(?P<tag><h2[^>]*>(?:(?!</h2>).)*</h2>)')
+
+LEDE = re.compile(r'[ \t]*<p class="card-lede">(?:(?!</p>).)*</p>\n?', re.S)
+
+# The small print under a checkbox, and the label it belongs to. Both are
+# captured so the fold can say which control the note is about.
+CHECK_NOTE = re.compile(
+    r'(?P<strong><strong>(?:(?!</strong>).)*</strong>)\s*'
+    r'(?P<note><span class="check-note">(?:(?!</span>).)*</span>)', re.S)
+
+# The explanation a settings fieldset closes with.
+CLOSING_NOTE = re.compile(
+    r'[ \t]*(?P<note><p class="field-(?:summary|note)"[^>]*>'
+    r'(?:(?!</p>).)*</p>)\n?(?P<tail>\s*</fieldset>)', re.S)
+
+
+def fold_ledes(html):
+    """Fold each card's explanation behind its heading.
+
+    Named for the paragraph it started with, and now doing the rest of the same
+    job. The heading goes inside the `<summary>`, which is what keeps the fold
+    honest for a screen reader: the control that opens the note is named by the
+    step it belongs to, so it is announced as "Say how big it may be" rather
+    than as an unlabelled button. `<summary>` may hold one heading element, and
+    that is exactly what this puts in it.
+    """
+    return CARD.sub(_fold_card, html)
+
+
+def _fold_card(card):
+    inner = card.group('inner')
+    heading = HEADING.search(inner)
+    if not heading:
+        return card.group(0)
+
+    notes = []
+
+    def take_lede(match):
+        notes.append(match.group(0).strip())
+        return ''
+
+    def take_check_note(match):
+        # The label keeps its <strong>; the fold gets a copy of it, so the note
+        # arrives with the name of the setting it is about.
+        notes.append(f'<p class="fold-note">{match.group("strong")} '
+                     f'{match.group("note")}</p>')
+        return match.group('strong')
+
+    def take_closing_note(match):
+        notes.append(match.group('note'))
+        return match.group('tail')
+
+    body = LEDE.sub(take_lede, inner)
+    body = CHECK_NOTE.sub(take_check_note, body)
+    body = CLOSING_NOTE.sub(take_closing_note, body)
+    if not notes:
+        return card.group(0)
+
+    indent = heading.group('indent')
+    fold = (f'{indent}<details class="card-note">\n'
+            f'{indent}  <summary>{heading.group("tag")}</summary>\n'
+            + ''.join(f'{indent}  {note}\n' for note in notes)
+            + f'{indent}</details>')
+    # The heading is matched again in the rewritten body rather than reused
+    # from the first search: the passes above have moved everything after it.
+    body = HEADING.sub(lambda again: fold, body, count=1)
+    return card.group('open') + body + card.group('close')

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -368,12 +368,108 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
   box-shadow: var(--shadow);
 }
 
-.card > h2 {
+/* A step's heading, whether it stands on its own or is the summary of the fold
+   its explanation went into. buildlib/cards.py moves it inside a <summary>
+   wherever a card opens with a `card-lede`, so a rule that only knew the first
+   shape would leave half the tools with an unstyled heading. */
+.card > h2,
+.card-note > summary > h2 {
   margin: 0 0 1rem;
   font-size: 1.05rem;
   display: flex;
   align-items: center;
   gap: 0.6rem;
+}
+
+/* ------------------------------------------------------ the step's own note
+
+   The paragraph a card used to open with, folded behind the heading it
+   belongs to. Closed, a card is its controls; open, it is what it always was.
+   buildlib/cards.py says why this is done by the build rather than written
+   into each of five hundred bodies. */
+
+.card-note { margin: 0 0 1rem; }
+
+.card-note > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  /* Both spellings: the standard one, and the one Safari still needs. */
+  list-style: none;
+}
+
+.card-note > summary::-webkit-details-marker { display: none; }
+
+.card-note > summary > h2 { margin: 0; }
+
+/*
+  The mark that says there is more here, drawn rather than typed.
+
+  It is two background shapes inside a circle instead of the letter i, and that
+  is the whole reason it is written this way: generated content counts towards
+  the accessible name of the summary in most engines, so `content: "i"` gets
+  every one of these headings announced as "Say how big it may be i". The
+  summary is already named by the heading inside it, and the mark is decoration
+  on top of that, so it is drawn where a screen reader cannot reach it.
+*/
+.card-note > summary::after {
+  content: "";
+  flex: none;
+  width: 1.05rem;
+  height: 1.05rem;
+  border: 1.5px solid currentColor;
+  border-radius: 50%;
+  color: var(--text-dim);
+  background:
+    radial-gradient(circle at 50% 50%, currentColor 50%, transparent 51%)
+      50% 22% / 2.5px 2.5px no-repeat,
+    linear-gradient(currentColor, currentColor) 50% 78% / 2px 0.4rem no-repeat;
+  transition: color 0.15s;
+}
+
+.card-note > summary:hover::after,
+.card-note > summary:focus-visible::after { color: var(--accent); }
+
+/* Open, the mark stops being an invitation and becomes a state: it is the
+   accent colour, so a reader scanning a page of cards can see which ones they
+   have already opened without reading them again. */
+.card-note[open] > summary::after { color: var(--accent); }
+
+.card-note[open] > summary > h2 { margin-bottom: 0.7rem; }
+
+/* A setting's own small print, once it is in the fold rather than under the
+   control. The name of the setting comes with it - a note that says "only used
+   once quality alone would have to drop" is about nothing at all without the
+   checkbox it belongs to - so it leads with the same <strong> the label kept. */
+.card-note .fold-note {
+  margin: 0 0 0.7rem;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: var(--text-dim);
+}
+
+.card-note .fold-note strong { color: var(--text); }
+
+/* Inside the fold these are paragraphs of their own, not the trailing half of
+   a label, so the inline default they carry under a checkbox is undone. */
+.card-note .check-note {
+  display: inline;
+  font-size: inherit;
+}
+
+.card-note > .field-summary,
+.card-note > .field-note {
+  margin: 0 0 0.7rem;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  color: var(--text-dim);
+}
+
+.card-note > :last-child { margin-bottom: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .card-note > summary::after { transition: none; }
 }
 
 .step {
@@ -582,7 +678,52 @@ button, .as-button {
 
 .faq h2 + .faq-list,
 .faq-list + h2,
+.how-to-fold + h2,
 .how-to + h2 { margin-top: 1.6rem; }
+
+/* The steps, folded. They repeat what the cards above already said, so they
+   open closed and the questions - which nothing above answers - are the first
+   thing in this section a reader meets. templates/tool.html says the rest. */
+.how-to-fold > summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+.how-to-fold > summary::-webkit-details-marker { display: none; }
+
+.how-to-fold > summary > h2 {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* The same caret the pledge fold uses, for the same reason: a heading that can
+   be opened should not look exactly like one that cannot. */
+.how-to-fold > summary > h2::after {
+  content: "";
+  width: 0.5rem;
+  height: 0.5rem;
+  border-right: 2px solid var(--text-dim);
+  border-bottom: 2px solid var(--text-dim);
+  transform: rotate(45deg) translate(-0.1rem, -0.1rem);
+  transition: transform 0.15s;
+}
+
+.how-to-fold[open] > summary > h2::after {
+  transform: rotate(225deg) translate(-0.05rem, -0.05rem);
+}
+
+.how-to-fold > summary:hover > h2,
+.how-to-fold > summary:focus-visible > h2 { color: var(--accent); }
+
+.how-to-fold > summary:hover > h2::after,
+.how-to-fold > summary:focus-visible > h2::after { border-color: var(--accent); }
+
+.how-to-fold[open] > summary > h2 { margin-bottom: 0.9rem; }
+
+@media (prefers-reduced-motion: reduce) {
+  .how-to-fold > summary > h2::after { transition: none; }
+}
 
 .how-to {
   margin: 0;

--- a/templates/tool.html
+++ b/templates/tool.html
@@ -335,12 +335,27 @@
   ============================================================================
 -->
 <section class="faq" aria-labelledby="how-to-h">
-  <h2 id="how-to-h">{{ tool.howto_heading }}</h2>
-  <ol class="how-to">
-{% for step in tool.howto %}    <li>
-      <strong>{{ step.title }}</strong>{{ step.body }}
-    </li>
-{% endfor %}  </ol>
+  <!--
+    Folded, because by the time a reader reaches it the tool has already said
+    all of this. Every step names a control that is on the screen above with
+    its own heading, its own number and its own note, so open by default this
+    is the page explaining itself twice and pushing the questions - which the
+    tool does NOT answer - another screen down.
+
+    It stays in the markup rather than going away. It is the same list as the
+    HowTo in the head, it is what a search engine reads to know what this page
+    is for, and it is the thing to hand somebody who wants the order of
+    operations without hunting for it. A fold is not a deletion: the words are
+    in the page, one click from anybody who wants them.
+  -->
+  <details class="how-to-fold">
+    <summary><h2 id="how-to-h">{{ tool.howto_heading }}</h2></summary>
+    <ol class="how-to">
+{% for step in tool.howto %}      <li>
+        <strong>{{ step.title }}</strong>{{ step.body }}
+      </li>
+{% endfor %}    </ol>
+  </details>
 
   <h2 id="faq-h">{{ ui.tool.questions_heading }}</h2>
   <div class="faq-list">


### PR DESCRIPTION
A tool page opened with two screens of prose in front of its buttons: every card began with a paragraph explaining what the step was for, each checkbox carried four lines of small print, each options fieldset closed with three more — and below the whole tool, a numbered how-to explained the same steps a second time. A reader who arrived knowing what they wanted scrolled past the explanation twice to reach the control.

All of it is folded now, and none of it is gone.

## Before / after

| | Before | After |
|---|---|---|
| The tool | <img alt="before-tool-page" src="https://github.com/user-attachments/assets/7927b1ff-359c-4280-b148-007c26a2d27a" /> | <img alt="after-tool-page" src="https://github.com/user-attachments/assets/0c829aa2-952b-4654-813c-1d6c5c249948" /> |
| The written part | <img alt="before-how-to" src="https://github.com/user-attachments/assets/3c4bed57-97df-4e9f-9bd9-cf08f043f53b" /> | <img alt="after-how-to" src="https://github.com/user-attachments/assets/9851dcd3-86a8-43c3-bdf9-89fbeea9ea2b" /> |

The compressor's step 2 goes from about 470px tall to about 230px. The written section below the tool opens on **Questions** — which the tool does not answer — instead of on steps it does.

## What folds, and what deliberately does not

Behind one mark beside each step's heading:

- `card-lede` — the paragraph a card opens with
- `check-note` — the small print under a checkbox
- the `field-summary` / `field-note` that closes an options fieldset

What stays put is anything that **reports** rather than explains. "This image is over 200 KB, so it will be compressed until it is not" answers a question the reader asked by typing a number, and a status behind a fold is a status nobody reads. Eight closing notes were checked one by one before folding; none is a live readout.

The how-to list is folded in the template. It stays in the markup: it is the same list as the `HowTo` in the head, and it is what a search engine reads to know what the page is for. The link to the guide underneath is untouched — it is the one thing down there that is not said twice.

## Two decisions worth a reviewer's time

**The build does this, not the markup.** A tool's `body.html` exists once in English and once in each of the fourteen other languages — five hundred files — and the edit is identical in all of them: no word moves, only the wrapper around it. By hand that is five hundred chances to get one wrong, and the next tool would arrive unfolded. `buildlib/cards.py` is one rule, reaches every language on the next build, and lets a tool author go on writing the same paragraph they always wrote. 37 folds across the 36 tools.

**The mark is drawn in CSS, not typed.** Generated content counts towards the accessible name in most engines, so `content: "i"` would have every one of these headings announced as *"Say how big it may be i"*. It is two background shapes in a bordered circle instead, where a screen reader cannot reach it. The heading itself goes inside the `<summary>`, so the control that opens the note is named by the step it belongs to.

## An accessibility fix that came with it

`check-note` sat **inside** its `<label>`, so it was part of the checkbox's accessible name. The control announced itself as *"May make the picture smaller if it has to Only used once quality alone would have to drop past the point where compression starts to show. Below that…"* — eighty words where a name should be a phrase. Lifting the note out leaves the checkbox named by its own words; the note keeps a copy of that name beside it inside the fold, so which setting it belongs to is still on the page.

## Also in here

- The guides' screenshots photograph these cards, so 74 of them are now stale. They are retaken in **#191**, stacked on this branch, rather than here — four text files at the bottom of a hundred binary ones are not reviewable. The two should land together, or #191 immediately after.
- A merge of `origin/main`, which had moved five commits ahead.

## Not done, deliberately

`lastmod` is untouched on all 77 pages. The words did not change, only where they sit, and bumping every date would submit the whole site to IndexNow for a presentation change. Say the word if you would rather announce it.

## Checks

`python build.py` clean; verified in the built page closed and open. Test suites left to CI, per the rule added in #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


