### PR TITLE
Carry the setting that says what to do with the file

### DIFF
--- a/shared/lang-keep.js
+++ b/shared/lang-keep.js
@@ -47,7 +47,12 @@
  *   - THE SETTINGS the visitor moved: every input, textarea and select inside
  *     <main> whose value differs from the one written in the markup. Only the
  *     difference, so a page nobody has touched carries nothing at all and the
- *     switcher stays the plain link it was built as.
+ *     switcher stays the plain link it was built as. Each is named by its id,
+ *     or - for the mode switch at the top of a dozen tools, which is a group of
+ *     radios sharing a `name` and carrying no id at all - by that name and its
+ *     own value, or by whatever `data-` attribute the markup used instead. See
+ *     keyOf() below; asking for an id alone lost exactly the setting that says
+ *     what to do with the file.
  *
  * What it does not carry is anything a tool worked out for itself. A result
  * already computed is not restored - the tool recomputes it from the file, the
@@ -174,6 +179,50 @@
     return options.length ? options[0].value : '';
   }
 
+  /**
+   * What to call a control, so that the page in the other language can be
+   * asked for the same one.
+   *
+   * An `id` where there is one, which is most of them. But the control a
+   * visitor is most likely to have moved often has no id at all: the mode
+   * switch at the top of a tool - fill or pixelate, keep or cut, colour or
+   * mono - is a group of radios sharing a `name`, and a name is all the markup
+   * gives them, because the tool reads the group with a selector rather than
+   * one button at a time. Skipping those, which is what asking for an id alone
+   * did, meant a language switch handed back the file and lost the single
+   * setting that says what to do with it.
+   *
+   * So: the id, or the name, or whatever `data-` attribute the markup used
+   * instead - hash-checksum names its algorithms `data-algorithm` and nothing
+   * else. A radio or a checkbox addressed by name carries its own `value` too,
+   * since the name belongs to the group and the value is the half that says
+   * which button. Every one of those comes from the markup, and the markup is
+   * structurally the same in all fifteen languages, which is the whole reason
+   * any of this can be named on one page and found on another.
+   */
+  function keyOf(node) {
+    if (node.id) return '#' + node.id;
+
+    var type = String(node.type || '').toLowerCase();
+    var name = node.getAttribute('name');
+    if (name) {
+      return '@' + name
+        + (type === 'radio' || type === 'checkbox' ? '=' + node.value : '');
+    }
+
+    // Sorted, so that the key does not depend on the order the attributes
+    // happen to be written in - which is not something a translator copying a
+    // body across should have to preserve.
+    var data = [];
+    var attrs = node.attributes;
+    for (var i = 0; i < attrs.length; i += 1) {
+      if (attrs[i].name.indexOf('data-') === 0) {
+        data.push(attrs[i].name + '=' + attrs[i].value);
+      }
+    }
+    return data.length ? '~' + data.sort().join('&') : '';
+  }
+
   /** Every control inside the tool no longer showing its markup value. */
   function settings() {
     var out = [];
@@ -181,16 +230,35 @@
     for (var i = 0; i < nodes.length; i += 1) {
       var node = nodes[i];
       var type = String(node.type || '').toLowerCase();
-      if (!node.id || node.disabled || node.readOnly || IGNORE[type]) continue;
+      if (node.disabled || node.readOnly || IGNORE[type]) continue;
+      var key = keyOf(node);
+      if (!key) continue;
       if (type === 'checkbox' || type === 'radio') {
-        if (node.checked !== node.defaultChecked) out.push({ id: node.id, on: node.checked });
+        if (node.checked !== node.defaultChecked) out.push({ key: key, on: node.checked });
       } else if (node.tagName === 'SELECT') {
-        if (node.value !== fallback(node)) out.push({ id: node.id, value: node.value });
+        if (node.value !== fallback(node)) out.push({ key: key, value: node.value });
       } else if (node.value !== node.defaultValue) {
-        out.push({ id: node.id, value: node.value });
+        out.push({ key: key, value: node.value });
       }
     }
     return out;
+  }
+
+  /**
+   * The control on this page that a carried key names, or nothing.
+   *
+   * Walked rather than selected. A key is assembled from attribute values the
+   * markup chose, and putting one back into a selector would mean escaping it
+   * correctly for every character a tool might have used; comparing the keys
+   * this page computes for itself asks the same question and cannot be got
+   * wrong. It is a handful of controls either way.
+   */
+  function find(key) {
+    var nodes = main.querySelectorAll('input, textarea, select');
+    for (var i = 0; i < nodes.length; i += 1) {
+      if (keyOf(nodes[i]) === key) return nodes[i];
+    }
+    return null;
   }
 
   /**
@@ -210,8 +278,8 @@
   function apply(values) {
     for (var i = 0; i < values.length; i += 1) {
       var want = values[i];
-      var node = document.getElementById(want.id);
-      if (!node || !main.contains(node)) continue;
+      var node = want.key ? find(want.key) : null;
+      if (!node) continue;
       if (typeof want.on === 'boolean') {
         if (node.checked === want.on) continue;
         node.checked = want.on;

--- a/tests/js/lang-keep.test.js
+++ b/tests/js/lang-keep.test.js
@@ -180,9 +180,15 @@ function el(selectors = [], attrs = {}) {
  * guard is worth a test.
  */
 function control(tag, id, spec = {}) {
-  const node = el([], {});
+  const node = el([], spec.attrs ? { ...spec.attrs } : {});
   node.tagName = tag.toUpperCase();
   node.id = id;
+  // What keyOf() reads when there is no id: the `name` a radio group shares,
+  // and the `data-` attributes a tool used instead of either. Modelled as real
+  // attributes rather than as properties, because that is where the source
+  // looks for them and a stub that offered properties would pass while the
+  // browser found nothing.
+  node.attributes = Object.keys(node.attrs).map((name) => ({ name, value: node.attrs[name] }));
   node.type = spec.type || (tag === 'select' ? 'select-one' : 'text');
   node.disabled = !!spec.disabled;
   node.readOnly = !!spec.readOnly;
@@ -374,7 +380,7 @@ test('only the controls moved off their markup value travel', async () => {
   page.click(page.link);
   await page.settle();
 
-  assert.deepEqual(page.record().values, [{ id: 'width', value: '640' }]);
+  assert.deepEqual(page.record().values, [{ key: '#width', value: '640' }]);
 });
 
 test('a checkbox turned off travels, and one left alone does not', async () => {
@@ -386,7 +392,7 @@ test('a checkbox turned off travels, and one left alone does not', async () => {
   page.click(page.link);
   await page.settle();
 
-  assert.deepEqual(page.record().values, [{ id: 'use-symbols', on: false }]);
+  assert.deepEqual(page.record().values, [{ key: '#use-symbols', on: false }]);
 });
 
 test('a select is measured against the option the markup selected', async () => {
@@ -402,7 +408,7 @@ test('a select is measured against the option the markup selected', async () => 
   page.click(page.link);
   await page.settle();
 
-  assert.deepEqual(page.record().values, [{ id: 'capitals', value: 'title' }]);
+  assert.deepEqual(page.record().values, [{ key: '#capitals', value: 'title' }]);
 });
 
 test('a select with nothing selected in the markup defaults to its first option', async () => {
@@ -416,7 +422,7 @@ test('a select with nothing selected in the markup defaults to its first option'
   const moved = run({ controls: [node] });
   moved.click(moved.link);
   await moved.settle();
-  assert.deepEqual(moved.record().values, [{ id: 'format', value: 'jpeg' }]);
+  assert.deepEqual(moved.record().values, [{ key: '#format', value: 'jpeg' }]);
 });
 
 test('output is not input: readonly, disabled and password never travel', async () => {
@@ -433,7 +439,7 @@ test('output is not input: readonly, disabled and password never travel', async 
   page.click(page.link);
   await page.settle();
 
-  assert.deepEqual(page.record().values, [{ id: 'length', value: '32' }]);
+  assert.deepEqual(page.record().values, [{ key: '#length', value: '32' }]);
 });
 
 test('a control with no id has no name on the other side, so it is skipped', async () => {
@@ -443,6 +449,109 @@ test('a control with no id has no name on the other side, so it is skipped', asy
   page.click(page.link);
   await page.settle();
   assert.equal(page.record(), null);
+});
+
+/* ------------------------------------------------- controls without an id */
+
+/**
+ * The mode switch, as eleven tools actually write it.
+ *
+ * `redact-image` is the one that found this: fill / pixelate / blur is a group
+ * of radios sharing `name="style"`, with no id on any of them, because the tool
+ * reads the group with a selector rather than one button at a time. The first
+ * version of this file asked every control for an id and skipped the ones that
+ * had none - so a language switch handed the image back and threw away the one
+ * setting that says what to do with it. Same shape in compress-pdf,
+ * document-scanner, dicom-viewer, edit-audio, encode-text, image-to-data-uri,
+ * merge-pdf, trim-audio and trim-video.
+ */
+function radios(name, values, checked) {
+  return values.map((value) => {
+    const node = control('input', '', {
+      type: 'radio', checked: value === checked, attrs: { name, value },
+    });
+    node.value = value;
+    return node;
+  });
+}
+
+test('a radio group with no id travels by its name and its value', async () => {
+  const group = radios('style', ['fill', 'pixelate', 'blur'], 'fill');
+  const [fill, pixelate] = group;
+  fill.checked = false;
+  pixelate.checked = true;
+
+  const page = run({ controls: group });
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.record().values, [
+    { key: '@style=fill', on: false },
+    { key: '@style=pixelate', on: true },
+  ]);
+});
+
+test('and lands on the right button on the other side', async () => {
+  const group = radios('style', ['fill', 'pixelate', 'blur'], 'fill');
+  const page = run({
+    lang: 'de',
+    ready: 'complete',
+    controls: group,
+    parked: {
+      lang: 'en',
+      time: Date.now(),
+      files: [],
+      values: [{ key: '@style=fill', on: false }, { key: '@style=pixelate', on: true }],
+    },
+  });
+  await page.settle();
+
+  assert.deepEqual(group.map((node) => node.checked), [false, true, false]);
+  assert.deepEqual(group[1].fired, ['input', 'change'], 'and the tool is told');
+});
+
+test('a control addressed by a data- attribute travels by it', async () => {
+  // hash-checksum's algorithms, which carry neither an id nor a name - only
+  // `data-algorithm`, which is what its own code reads them by.
+  const md5 = control('input', '', {
+    type: 'checkbox', checked: true, attrs: { 'data-algorithm': 'md5' },
+  });
+  const sha1 = control('input', '', {
+    type: 'checkbox', attrs: { 'data-algorithm': 'sha1' },
+  });
+  md5.checked = false;
+  sha1.checked = true;
+
+  const page = run({ controls: [md5, sha1] });
+  page.click(page.link);
+  await page.settle();
+
+  assert.deepEqual(page.record().values, [
+    { key: '~data-algorithm=md5', on: false },
+    { key: '~data-algorithm=sha1', on: true },
+  ]);
+});
+
+test('a control the markup gives no handle at all is still skipped', async () => {
+  // Nothing to call it by on the other page, so carrying it would mean
+  // guessing which control on a different document it meant.
+  const anonymous = control('input', '', { value: '1' });
+  anonymous.value = '2';
+  const page = run({ controls: [anonymous] });
+  page.click(page.link);
+  await page.settle();
+  assert.equal(page.record(), null);
+});
+
+test('an id still wins over a name, so nothing already working moves', async () => {
+  const node = control('input', 'quality', {
+    value: '85', attrs: { name: 'quality-field' },
+  });
+  node.value = '60';
+  const page = run({ controls: [node] });
+  page.click(page.link);
+  await page.settle();
+  assert.deepEqual(page.record().values, [{ key: '#quality', value: '60' }]);
 });
 
 /* ----------------------------------------------------------------- the files */
@@ -496,7 +605,7 @@ test('the far side of a switch hands the work back', async () => {
     controls: [width],
     parked: {
       lang: 'en', time: Date.now(), files: [file('holiday.jpg')],
-      values: [{ id: 'width', value: '640' }],
+      values: [{ key: '#width', value: '640' }],
     },
   });
   await page.settle();
@@ -528,7 +637,7 @@ test('a record parked in this same language is a reload, and is refused', async 
     controls: [width],
     parked: {
       lang: 'en', time: Date.now(), files: [file('a.jpg')],
-      values: [{ id: 'width', value: '640' }],
+      values: [{ key: '#width', value: '640' }],
     },
   });
   await page.settle();
@@ -592,7 +701,7 @@ test('a setting the tool has already filled in with the same value is not re-ann
     lang: 'de',
     ready: 'complete',
     controls: [width],
-    parked: { lang: 'en', time: Date.now(), files: [], values: [{ id: 'width', value: '640' }] },
+    parked: { lang: 'en', time: Date.now(), files: [], values: [{ key: '#width', value: '640' }] },
   });
   await page.settle();
   assert.deepEqual(width.fired, []);
@@ -604,7 +713,7 @@ test('a select whose options do not carry the value is left alone', async () => 
     lang: 'de',
     ready: 'complete',
     controls: [empty],
-    parked: { lang: 'en', time: Date.now(), files: [], values: [{ id: 'series', value: '3' }] },
+    parked: { lang: 'en', time: Date.now(), files: [], values: [{ key: '#series', value: '3' }] },
   });
   await page.settle();
   assert.equal(empty.value, '');
@@ -633,5 +742,5 @@ test('a page with no picker still carries its settings', async () => {
   page.click(page.link);
   await page.settle();
 
-  assert.deepEqual(page.record().values, [{ id: 'words', value: '9' }]);
+  assert.deepEqual(page.record().values, [{ key: '#words', value: '9' }]);
 });


### PR DESCRIPTION
Fixes the reported bug: switching language hands the image back and loses the configuration.

## What was happening

On `/redact-image/`, choose a photo, switch it from **black out** to **pixelate**, then change language. The photo comes back. The mode is **black out** again. The file survived and the one setting that says what to *do* with it did not, which is very nearly the worst of both.

## Why

The mode switch at the top of a tool has no `id`. It is a group of radios sharing a `name` — fill / pixelate / blur, keep / cut, colour / grey / mono / photo — with no id on any of them, because the tool reads the group with one selector rather than one button at a time. `shared/lang-keep.js` asked every control for an id and skipped the ones that had none, so those groups were never recorded and never restored.

A sweep of every `body.html` found **39 controls with no id across 11 tools**, and in every case it is the tool's primary control:

| tool | the control that was being lost |
|---|---|
| `redact-image` | fill / pixelate / blur |
| `compress-pdf` | smallest / screen / print / gentle |
| `document-scanner` | colour / grey / mono / photo |
| `dicom-viewer` | window / pan / measure |
| `edit-audio` | pitch, level |
| `encode-text` | encode / decode |
| `image-to-data-uri` | uri / css-rule / css-var / html / markdown |
| `merge-pdf` | how to split |
| `trim-audio`, `trim-video` | keep / cut |
| `hash-checksum` | the five algorithms |

34 of the 39 carry a `name`. The other five are `hash-checksum`'s algorithm checkboxes, which have neither an id nor a name and are addressed by `data-algorithm`.

## The fix

A control is now named by its `id`, or by its `name` — plus its own `value`, because the name belongs to the group and the value is the half that says which button — or by whatever `data-` attribute the markup used instead. All three come from the markup, and the markup is structurally identical in all fifteen languages, which is the whole reason a control named on one page can be found on another. **An id still wins where there is one**, so nothing that already worked has moved.

The far side matches by walking the controls and comparing the keys the page computes for itself, rather than building a selector out of a key: a key is assembled from attribute values a tool chose, and putting one back into a selector would mean escaping it correctly for every character a tool might use. Comparing asks the same question and cannot be got wrong.

A control the markup gives no handle at all is still skipped — there is nothing to call it by on a different document, and guessing is worse than losing it.

**No markup changed**, so no locale file needed touching. Everything the fix needs was already in the tools' bodies.

## Verified in a browser, against the built site

| tool | route | carried |
|---|---|---|
| `redact-image` | en → de | image **+ pixelate + heavy** — the reported bug, now fixed |
| `hash-checksum` | de → ja | file **+ md5 off, sha512 on** (the `data-algorithm` path) |
| `image-to-data-uri` | de → fr | image **+ css-var** (a third tool, a third radio group) |
| `resize-image` | en → de | image + 800px + q60 + jpeg + no-enlarge (unchanged, still passes) |
| `id-photo` | de → en | image + us-passport + 5x7 + 600dpi + manual (unchanged, still passes) |

No console errors from this code. Tests: 5 new cases in `tests/js/lang-keep.test.js` covering the radio group, the `data-` attribute, the id-still-wins rule and the no-handle skip; 27 pass. The full suites are CI's, per #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
