### PR TITLE
Show the icon sizes when they are a question, not when they are an answer

### DIFF
--- a/tools/image-to-ico/src/main.js
+++ b/tools/image-to-ico/src/main.js
@@ -365,6 +365,17 @@ function renderList() {
 }
 
 function renderSizes() {
+  // Ten rows of tick boxes, each with a sentence saying what asks for that
+  // size, and under a named preset not one of them is a decision: they are the
+  // preset's own answer, drawn as controls. So they are shown when they are a
+  // question - "Choose the sizes yourself" - and the rest of the time the
+  // summary line underneath says which sizes went in, which is the part
+  // somebody on a preset actually wants to read.
+  //
+  // Switching to custom keeps whatever the preset had ticked, so the grid
+  // opens on the set you were already getting rather than on nothing.
+  el.sizeGrid.hidden = presetId !== 'custom';
+
   for (const label of el.sizeGrid.querySelectorAll('.size-choice')) {
     const px = Number(label.dataset.px);
     const input = label.querySelector('input');

--- a/tools/image-to-ico/styles.css
+++ b/tools/image-to-ico/styles.css
@@ -146,6 +146,14 @@
   gap: 0.35rem 0.9rem;
 }
 
+/* Under a named preset the grid is hidden and the summary is the only thing
+   left in the fieldset, so the rule that separates the two would be drawn
+   across nothing. */
+.size-grid[hidden] + .field-summary {
+  padding-top: 0;
+  border-top: none;
+}
+
 .size-choice {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
Step 2 of the icon maker listed ten sizes as ten tick boxes, each with a sentence saying what asks for that size — about three hundred pixels of the card, under every preset, whether or not the reader had any intention of choosing sizes by hand.

## Before / after

| Before | After |
|---|---|
| <img alt="before-icon-sizes" src="https://github.com/user-attachments/assets/e91a9636-aceb-4e6a-8049-276d31388902" /> | <img alt="after-icon-sizes" src="https://github.com/user-attachments/assets/956130ad-5d5c-4ce7-8006-684faa256500" /> |

## The argument

Under a named preset, none of those ticks is a decision. They are the preset's own answer drawn as controls: pick **Website favicon** and 16, 32 and 48 tick themselves, and touching one silently moves you to **Choose the sizes yourself**. A control that only ever reports is a label wearing a checkbox.

So the grid is shown when it is a question and put away when it is not. What a reader on a preset is left with is the summary line that was always underneath it — *"3 sizes - 16, 32, 48 - stored the pre-Vista way up to 64 pixels and as PNG above that"* — which is the part they wanted, plus the preset tile that already prints `16, 32, 48 px` on its face.

**Nothing is lost on the way.** The ticks keep their state while hidden, so choosing *Choose the sizes yourself* opens the grid on the set you were already getting rather than on an empty list. That is the moment somebody wants to add 256 to a favicon — not to start again. Verified in the built page: preset → grid hidden with 16/32/48 still ticked; custom → grid visible, same three ticked; back to a preset → hidden again.

## Scope

Two files, one tool: `tools/image-to-ico/src/main.js` and its stylesheet. No markup change, so the fourteen translated copies of this tool's body are untouched.

## Two things found next door, not fixed here

- **This card's text is English in all fourteen other languages.** The five preset names, their notes and the ten size descriptions live in `tools/image-to-ico/src/sizes.js`, and `src/` is copied byte for byte into every locale — the exact trap CLAUDE.md describes under *"A sentence a visitor reads never lives in the JavaScript"*. Confirmed in the built German page: the strings are in the shipped `sizes.js` and nowhere in the HTML. Roughly twenty sentences to move into `#phrases` and translate; worth its own change.
- **Two presets offer the same thing.** *Website favicon* and *Maximum compatibility* both read `16, 32, 48 px`; they differ only in storage, which the tile does not say.

## Checks

`python build.py` clean. Test suites left to CI, per #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

