### PR TITLE
Move the parts of the build that are not a kind of page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ exactly. On any feature branch it exits 1 by construction. CI does not run it.
 | Path | What it is |
 |---|---|
 | `build.py` | the generator; one function per kind of page |
-| `buildlib/` | the parts it is made of — templating, minifying, i18n, imports |
+| `buildlib/` | the parts it is made of — templating, minifying, i18n, imports, emitting, the catalogue files, `--check` |
 | `config/site.toml` | everything true of every page, the CSP included |
 | `config/planned.toml` | the roadmap list |
 | `tools/<slug>/` | one tool: `tool.toml`, `body.html`, `styles.css`, `src/`, `og.png`, `README.md` |

--- a/build.py
+++ b/build.py
@@ -83,13 +83,11 @@ The build never reaches the network, whichever way it runs.
 """
 
 import argparse
-import hashlib
 import html
 import os
 import posixpath
 import re
 import shutil
-import subprocess
 import sys
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
@@ -97,12 +95,18 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from buildlib import cards
+from buildlib import catalogue
 from buildlib import cssmin
 from buildlib import i18n
 from buildlib import imports
 from buildlib import minify
 from buildlib import screens
 from buildlib import site as sitelib
+from buildlib.deployed import check_against_branch
+# LINK comes from the emitter because that is what gathers a page's links, on
+# the way past as it writes; check_links borrows the pattern for the one path
+# where it has to re-read a finished page instead. See buildlib/emit.py.
+from buildlib.emit import Emitter, LINK, write
 from buildlib.template import Loader, TemplateError
 
 ROOT = Path(__file__).parent.resolve()
@@ -484,20 +488,23 @@ def build(out, clean=False, minify_output=True, jobs=None, only=None,
         # After the 404 and deliberately not passed it: the 404 has no address
         # of its own to list, and inviting a crawler to index it would be
         # inviting it to serve "not found" in place of a real page.
-        build_sitemap(out, templates, site, locales, tools, ordered_prose)
+        catalogue.build_sitemap(out, templates, site, locales, tools,
+                                ordered_prose)
         written.append('sitemap.xml')
 
         # And the same site again, in plain text, for something that reads one
         # file and decides from it whether any of this is worth mentioning.
         # Built from the same list as the sitemap above and holding back the
         # same languages.
-        build_llms(out, templates, site, locales, ordered_tools, ordered_prose)
+        catalogue.build_llms(out, templates, site, locales, ordered_tools,
+                             ordered_prose)
         written.append('llms.txt')
 
         # And once more as a stream, for a reader who wants to be told when a
         # tool ships rather than to come back and check. One file per published
         # language, so this adds a name per locale rather than a single one.
-        build_feeds(out, templates, site, locales, ordered_tools, ordered_prose)
+        catalogue.build_feeds(out, templates, site, locales, ordered_tools,
+                              ordered_prose)
         written += [f'{locale["prefix"]}feed.xml'
                     for locale in i18n.published(locales)]
 
@@ -1607,252 +1614,6 @@ def write_tools_index(tools):
         print(f'  wrote {path.relative_to(ROOT).as_posix()}')
 
 
-def build_sitemap(out, templates, site, locales, tools, prose):
-    """One sitemap for the whole domain, listing every published language.
-
-    Published, not built. A locale still being translated is deliberately
-    absent: it carries no hreflang tag pointing at it and no link in the
-    switcher either, and a sitemap entry would be the one remaining way a
-    crawler could still be told to go and index a page that is half in English.
-
-    The order within a language is the order it always was - the hub, the
-    tools, the guides, the roadmap, the legal pages - and the languages follow
-    each other in the order locales/ sorts in, English first.
-
-    Priority does not decay down the list. It says what a page is worth against
-    the rest of the site, not against the rest of its own language: the German
-    hub is as much a front door as the English one, and marking it lower would
-    be saying the opposite of what the hreflang tags beside it say.
-    """
-    entries = []
-    for locale in i18n.published(locales):
-        def url(slug, locale=locale):
-            return i18n.locale_url(locale, slug, site)
-
-        # A page this language has not translated yet is built and readable,
-        # but it is not listed here. Inviting a crawler to index an English
-        # page sitting at a German URL is how a site ends up ranking its own
-        # untranslated half for the wrong language, and it is the single
-        # failure this whole arrangement exists to avoid.
-        def ready(slug, locale=locale):
-            return i18n.translated(locale, slug)
-
-        if ready(''):
-            entries.append({'url': url(''), 'lastmod': site['lastmod'],
-                            'changefreq': 'weekly', 'priority': '1.0'})
-        entries += [{'url': url(tool['slug']), 'lastmod': tool['lastmod'],
-                     'changefreq': 'monthly', 'priority': '0.8'}
-                    for tool in tools if ready(tool['slug'])]
-        # Guides below the tools and above the legal pages. A tool is what
-        # somebody came for; a guide is how they find out this site exists. The
-        # index they are listed on goes first and slightly higher: it is the
-        # page that gains from being crawled as a set rather than as nine
-        # unrelated articles.
-        if ready(site['guides']['slug']):
-            entries.append({'url': url(site['guides']['slug']),
-                            'lastmod': site['guides']['lastmod'],
-                            'changefreq': 'monthly', 'priority': '0.7'})
-        entries += [{'url': url(page['slug']), 'lastmod': page['lastmod'],
-                     'changefreq': 'monthly', 'priority': '0.6'}
-                    for page in prose
-                    if page['kind'] == 'guide' and ready(page['slug'])]
-        # The roadmap: a real page, but not one anybody searches for. Below the
-        # guides, above the legal pages.
-        if ready(site['roadmap']['slug']):
-            entries.append({'url': url(site['roadmap']['slug']),
-                            'lastmod': site['roadmap']['lastmod'],
-                            'changefreq': 'monthly', 'priority': '0.5'})
-        # The legal pages last, and low: they matter for trust, not for search.
-        entries += [{'url': url(page['slug']), 'lastmod': page['lastmod'],
-                     'changefreq': 'yearly', 'priority': '0.3'}
-                    for page in prose
-                    if page['kind'] == 'legal' and ready(page['slug'])]
-
-    write(out / 'sitemap.xml', templates.render('sitemap.xml', {'pages': entries}))
-
-
-# How many entries a feed carries. The site has more tools and guides than
-# this, and deliberately so: a feed answers "what has changed lately", which a
-# reader checks repeatedly, and the whole catalogue is already two files away
-# in sitemap.xml and llms.txt. Every entry past the first screenful is weight
-# on every poll for something nobody scrolls to.
-FEED_ENTRIES = 30
-
-
-def build_feeds(out, templates, site, locales, tools, prose):
-    """One Atom feed per published language, at /feed.xml and /<lang>/feed.xml.
-
-    Per language rather than one for the site, because a feed is a reading
-    experience and not an index: a German subscriber wants German titles at
-    German URLs, and mixing fifteen languages into one file would make it
-    useless to all of them. The same rule as everywhere else decides who gets
-    one - a locale that has not finished its frame is built and readable and
-    advertised to nobody, so it has no feed and no link to one.
-
-    Tools and guides, newest first. Not the legal pages, whose dates move for
-    reasons no reader subscribed to hear about, and not the hub or the roadmap,
-    which are indexes of things that appear here already.
-    """
-    for locale in i18n.published(locales):
-        entries = []
-        for tool in tools:
-            if not i18n.translated(locale, tool['slug']):
-                continue
-            said = i18n.localize_tool(tool, locale, site)
-            entries.append({'title': said['name'], 'url': said['url'],
-                            'summary': said['description'],
-                            'lastmod': said['lastmod']})
-        for page in prose:
-            if page['kind'] != 'guide' or not i18n.translated(locale, page['slug']):
-                continue
-            said = i18n.localize_page(page, locale, site)
-            entries.append({'title': said['heading'], 'url': said['url'],
-                            'summary': said['description'],
-                            'lastmod': said['lastmod']})
-
-        # Two passes, because Python's sort is stable: alphabetical first, then
-        # by date descending. A day on which four guides shipped then reads in
-        # a fixed order rather than in whatever order the folders were walked,
-        # which is what keeps a rebuild from reshuffling a feed that did not
-        # change and re-notifying everyone who subscribes to it.
-        entries.sort(key=lambda entry: entry['title'])
-        entries.sort(key=lambda entry: entry['lastmod'], reverse=True)
-        entries = entries[:FEED_ENTRIES]
-
-        for entry in entries:
-            entry['updated'] = f'{entry["lastmod"]}T00:00:00Z'
-
-        home = i18n.locale_url(locale, '', site)
-        said_site = locale['site']
-        feed = {
-            'lang': locale['hreflang'],
-            'title': said_site['name'],
-            'subtitle': said_site['hub']['description'],
-            'home': home,
-            'self': f'{home}feed.xml',
-            'author': said_site['name'],
-            # The newest entry, not the moment of the build. A feed whose
-            # timestamp moves on every deploy teaches a reader to ignore it,
-            # which is the same reason lastmod in the sitemap is a date somebody
-            # changed on purpose.
-            'updated': entries[0]['updated'] if entries else f'{site["lastmod"]}T00:00:00Z',
-            'entries': entries,
-        }
-        write(out / locale['prefix'] / 'feed.xml',
-              templates.render('feed.xml', {'feed': feed}))
-
-
-def build_llms(out, templates, site, locales, tools, prose):
-    """/llms.txt: the whole site as plain text, for a reader that gets one fetch.
-
-    A search engine is handed a page of structured data per tool and has the
-    patience to crawl all of them. An assistant deciding whether this site is
-    worth mentioning at all does not - it fetches one address, and if that
-    address does not say what the tools are and what they cannot do, it writes
-    its own EXIF parser instead of linking to the page that already strips one.
-    This is that address.
-
-    Built from the same tool.toml files as the hub, the sitemap and
-    tools/README.md, and in the same hub order, so it cannot fall behind the
-    tools that exist. That is the whole reason it is generated rather than
-    written: a hand-kept index of twenty-four tools is an index that is wrong.
-
-    Two deliberate departures from every other generated file here:
-
-      * No GENERATED FILE banner at the top. An llms.txt begins with an H1 by
-        convention, and the readers of one are strict about that shape. The
-        sentence saying the file is generated is the last paragraph of the
-        intro instead, where it reads as a fact about the file rather than as a
-        comment standing in front of it.
-      * English only, and at the root. It is an index OF the site, not a page
-        of it: the languages are a section inside it, and each hub linked from
-        there carries the rest of that language on its own.
-
-    Everything goes through site.to_text on the way in. This file is markdown,
-    and the configs it is built from are HTML fragments full of &mdash; and
-    <code>.
-    """
-    text = sitelib.to_text
-    by_slug = {tool['slug']: tool for tool in tools}
-
-    # The hub's categories, in the hub's order, carrying the hub's own note
-    # about each - so a machine reading this groups the tools the same way a
-    # visitor looking at the front page does.
-    groups = []
-    for category in site['hub']['categories']:
-        listed = [by_slug[slug] for slug in category['order'] if slug in by_slug]
-        if not listed:
-            continue
-        groups.append({
-            'name': text(category['name']),
-            'note': text(category['note']),
-            # `schema.description` rather than the tagline. The tagline is
-            # written to be read by somebody already looking at the page; this
-            # is the sentence written to tell a machine what the tool does, and
-            # it is the one that lets a task be matched to an address.
-            'tools': [{'name': text(tool['name']),
-                       'url': tool['url'],
-                       'description': text(tool['schema']['description'])}
-                      for tool in listed],
-        })
-
-    def entry(page):
-        return {'name': text(page['heading']), 'url': page['url'],
-                'description': text(page['description'])}
-
-    guides = [entry(page) for page in prose if page['kind'] == 'guide']
-
-    # A language is listed only if it has finished the frame AND its own hub -
-    # the same test the sitemap and the hreflang tags are built from. Handing a
-    # half-English hub to something that will quote it is the one failure worth
-    # avoiding here, and it is avoided the way it is avoided everywhere else.
-    # Named in English and described by the two things a machine wants next:
-    # the word the language calls itself, which is what the switcher on the
-    # site shows, and the hreflang code, which is how the addresses are keyed.
-    # One shape for every line in the file, rather than a special one here.
-    languages = [{'name': locale['name'],
-                  'url': i18n.locale_url(locale, '', site),
-                  'description': f'{text(locale["endonym"])} - {locale["hreflang"]}'}
-                 for locale in i18n.published(locales, '')
-                 if not locale['is_base']]
-
-    optional = [
-        {'name': text(site['guides']['nav']),
-         'url': f'{site["domain"]}{site["guides"]["slug"]}/',
-         'description': text(site['guides']['description'])},
-        {'name': text(site['roadmap']['nav']),
-         'url': f'{site["domain"]}{site["roadmap"]["slug"]}/',
-         'description': text(site['roadmap']['description'])},
-        {'name': site['source_label'],
-         'url': site['source_url'],
-         'description': text(site['llms']['source_note'])},
-        {'name': 'Sitemap',
-         'url': f'{site["domain"]}sitemap.xml',
-         'description': text(site['llms']['sitemap_note'])},
-    ]
-    # The legal pages last, for the same reason the sitemap puts them last.
-    optional += [entry(page) for page in prose if page['kind'] == 'legal']
-
-    write(out / 'llms.txt', templates.render('llms.txt', {
-        'site': site,
-        # Trimmed here rather than in the template: these are TOML multi-line
-        # strings, so each arrives with the newline its closing quotes sit on,
-        # and the template spaces its own sections.
-        'llms': {key: value.strip() for key, value in site['llms'].items()},
-        # One line, whatever config/site.toml wrapped it as. It is a
-        # blockquote, and a wrapped blockquote whose second line starts with
-        # "- " is read as a list that ends the quote - which is exactly how
-        # this one is worded.
-        'summary': ' '.join(site['llms']['summary'].split()),
-        'groups': groups,
-        'guides': guides,
-        'languages': languages,
-        'optional': optional,
-    }))
-
-
-LINK = re.compile(r'(?:href|src)="([^"#?]+)(?:[#?][^"]*)?"')
-
 SKIP_LINK = ('http://', 'https://', 'mailto:', 'data:', 'blob:', '//')
 
 
@@ -2005,164 +1766,6 @@ def _redirect_path(out, old_slug):
     path = out / old_slug
     path.mkdir(parents=True, exist_ok=True)
     return path / 'index.html'
-
-
-def write(path, text):
-    """Always LF, always UTF-8. A build that produced CRLF on Windows and LF in
-    CI would show every line of every file as changed on alternate deploys.
-
-    Returns the text as written - trailing newline included - so a caller that
-    goes on to hash what the file holds can hash this instead of opening the
-    file it just closed."""
-    text = text if text.endswith('\n') else text + '\n'
-    path.write_text(text, encoding='utf-8', newline='\n')
-    return text
-
-
-class Emitter:
-    """Writes the HTML, CSS and JavaScript, minified or not.
-
-    One object rather than a flag threaded everywhere, because the two things
-    that have to stay together - whether to minify, and what banner to leave
-    behind when we do - belong together.
-
-    The banner is the one comment minifying does not remove. A page that spends
-    four links telling you to go and read the code should not then hand you a
-    file with no way back to it, so every generated file keeps one line saying
-    where it came from and how to prove it.
-
-    `page_links` records, for every page written, the links on it as written -
-    check_links' input, gathered on the way past. It used to be gathered at
-    the end instead, by reading every page back off the disk, and on Windows
-    that was half the build: the antivirus scans a freshly written file on its
-    next open, at tens of milliseconds each, a thousand pages over.
-    """
-
-    def __init__(self, minify_output, site):
-        self.enabled = bool(minify_output)
-        self.page_links = {}
-        source = site['source_url']
-
-        # The same sentence in three comment syntaxes. Each minifier wraps it
-        # itself, so what is kept here is the text with no delimiters on it.
-        verify = (f'Built from {source} by build.py. '
-                  f'Verify with: python build.py --check')
-        self.js_banner = f'/* {verify} */'
-        self.html_banner = f' {verify} '
-        self.css_banner = f' {verify} '
-
-        # What each source text minified to, so a text seen before is not
-        # minified again. Most of what the build emits is seen many times
-        # over: a tool's modules are the same bytes in every language, and
-        # within one language every prose page's analytics.js is the same
-        # script. Minifying is deterministic - the module says so and stakes
-        # its --check on it - which is what makes the answer reusable at all.
-        #
-        # build() fills the JavaScript and CSS caches with every tool's
-        # sources before the languages start, and that placing is the point:
-        # each language builds in its own process and is handed a copy of this
-        # object, so work cached here once is carried into all of them, where
-        # a cache warmed inside a worker would die with it.
-        self._js_seen = {}
-        self._css_seen = {}
-
-    def html(self, path, text):
-        text = write(path, minify.html(text, self.html_banner)
-                     if self.enabled else text)
-        self.page_links[path] = LINK.findall(text)
-        return text
-
-    def js(self, path, text, where):
-        return write(path, self.js_text(text, where))
-
-    def js_text(self, text, where):
-        """Returns rather than writes, for the one script that is hashed before
-        it is written - see the note beside lang.js in build(). Everything else
-        goes through js() and never sees the string."""
-        if not self.enabled:
-            return text
-        done = self._js_seen.get(text)
-        if done is None:
-            done = self._js_seen[text] = minify.js(text, self.js_banner, where)
-        return done
-
-    def css_text(self, text):
-        """Returns rather than writes, because a stylesheet has to be hashed
-        after minifying and before being written - the hash goes in the URL the
-        page asks for it by."""
-        if not self.enabled:
-            return text
-        done = self._css_seen.get(text)
-        if done is None:
-            done = self._css_seen[text] = cssmin.css(text, self.css_banner)
-        return done
-
-
-def check_against_branch(out, branch='dist'):
-    """Compare a fresh build with what is committed on the dist branch. This is
-    the command the pages point at: it answers "is the deployed site really a
-    build of these sources?", which matters more now that what is served is
-    minified and no longer pleasant to read straight off.
-
-    A fresh clone has the branch only as origin/dist, so try that too rather
-    than shrugging and reporting success.
-    """
-    for ref_name in (branch, f'origin/{branch}'):
-        found = subprocess.run(['git', 'rev-parse', '--verify', f'{ref_name}^{{tree}}'],
-                               capture_output=True, text=True, cwd=ROOT)
-        if found.returncode == 0:
-            branch = ref_name
-            break
-    else:
-        print(f'\n  no {branch} branch here to check against '
-              f'(try: git fetch origin {branch})', file=sys.stderr)
-        return 0
-
-    differences = compare(out, branch)
-    if differences:
-        print(f'\n  {branch} is not this build ({len(differences)} files differ):',
-              file=sys.stderr)
-        for name in differences[:20]:
-            print(f'    {name}', file=sys.stderr)
-        if len(differences) > 20:
-            print(f'    ... and {len(differences) - 20} more', file=sys.stderr)
-        return 1
-    print(f'\n  {branch} matches a fresh build of these sources')
-    return 0
-
-
-def compare(built, branch):
-    """Which files differ between the build and a branch, by content.
-
-    Read out of the object store rather than checked out into a worktree.
-    Checking out runs the files through Git's end-of-line filters, and on a
-    machine with core.autocrlf on that rewrites every text file on the way to
-    disk - which made this report all sixty-odd files as changed when not one
-    of them was. A blob id is the bytes as committed, and nothing can filter
-    it on the way past.
-    """
-    listing = subprocess.run(['git', 'ls-tree', '-r', '-z', branch],
-                             capture_output=True, text=True, cwd=ROOT, check=True)
-    committed = {}
-    for entry in listing.stdout.split('\0'):
-        if not entry:
-            continue
-        info, path = entry.split('\t', 1)
-        committed[path] = info.split()[2]
-
-    fresh = {path.relative_to(built).as_posix(): blob_id(path)
-             for path in built.rglob('*') if path.is_file()}
-
-    names = sorted(set(committed) | set(fresh))
-    return [name for name in names if committed.get(name) != fresh.get(name)]
-
-
-def blob_id(path):
-    """The id Git would give this file's contents: sha1 over the bytes with
-    Git's blob header in front. The same rule Git uses, so the two are
-    comparable without shelling out once per file."""
-    data = path.read_bytes()
-    return hashlib.sha1(b'blob %d\0' % len(data) + data).hexdigest()
 
 
 if __name__ == '__main__':

--- a/buildlib/catalogue.py
+++ b/buildlib/catalogue.py
@@ -1,0 +1,270 @@
+"""
+The whole site as one file, three times over, for something that is not a
+person: sitemap.xml, llms.txt, and one Atom feed per language.
+
+WHY THE THREE ARE TOGETHER
+
+They are the same job with three audiences. Each is built from the same two
+lists - the tools and the prose pages, in the order the site puts them in - and
+each holds back the same languages, because a locale still being translated
+carries no hreflang tag and no switcher entry, and a line in any of these files
+would be the one remaining way a crawler could still be sent to a page that is
+half in English. Getting that rule right in three places and wrong in a fourth
+is the mistake this arrangement is meant to make hard, and keeping them in one
+file is most of how.
+
+WHY THEY ARE NOT IN build.py
+
+None of them is a page. They take no frame, no stylesheet, no service worker
+and no locale to be rendered in - they take the finished lists and write one
+file at the root of the site. build.py is one function per kind of page, and
+these three were sitting in the middle of it answering a different question.
+"""
+
+from buildlib import i18n
+from buildlib import site as sitelib
+from buildlib.emit import write
+
+
+def build_sitemap(out, templates, site, locales, tools, prose):
+    """One sitemap for the whole domain, listing every published language.
+
+    Published, not built. A locale still being translated is deliberately
+    absent: it carries no hreflang tag pointing at it and no link in the
+    switcher either, and a sitemap entry would be the one remaining way a
+    crawler could still be told to go and index a page that is half in English.
+
+    The order within a language is the order it always was - the hub, the
+    tools, the guides, the roadmap, the legal pages - and the languages follow
+    each other in the order locales/ sorts in, English first.
+
+    Priority does not decay down the list. It says what a page is worth against
+    the rest of the site, not against the rest of its own language: the German
+    hub is as much a front door as the English one, and marking it lower would
+    be saying the opposite of what the hreflang tags beside it say.
+    """
+    entries = []
+    for locale in i18n.published(locales):
+        def url(slug, locale=locale):
+            return i18n.locale_url(locale, slug, site)
+
+        # A page this language has not translated yet is built and readable,
+        # but it is not listed here. Inviting a crawler to index an English
+        # page sitting at a German URL is how a site ends up ranking its own
+        # untranslated half for the wrong language, and it is the single
+        # failure this whole arrangement exists to avoid.
+        def ready(slug, locale=locale):
+            return i18n.translated(locale, slug)
+
+        if ready(''):
+            entries.append({'url': url(''), 'lastmod': site['lastmod'],
+                            'changefreq': 'weekly', 'priority': '1.0'})
+        entries += [{'url': url(tool['slug']), 'lastmod': tool['lastmod'],
+                     'changefreq': 'monthly', 'priority': '0.8'}
+                    for tool in tools if ready(tool['slug'])]
+        # Guides below the tools and above the legal pages. A tool is what
+        # somebody came for; a guide is how they find out this site exists. The
+        # index they are listed on goes first and slightly higher: it is the
+        # page that gains from being crawled as a set rather than as nine
+        # unrelated articles.
+        if ready(site['guides']['slug']):
+            entries.append({'url': url(site['guides']['slug']),
+                            'lastmod': site['guides']['lastmod'],
+                            'changefreq': 'monthly', 'priority': '0.7'})
+        entries += [{'url': url(page['slug']), 'lastmod': page['lastmod'],
+                     'changefreq': 'monthly', 'priority': '0.6'}
+                    for page in prose
+                    if page['kind'] == 'guide' and ready(page['slug'])]
+        # The roadmap: a real page, but not one anybody searches for. Below the
+        # guides, above the legal pages.
+        if ready(site['roadmap']['slug']):
+            entries.append({'url': url(site['roadmap']['slug']),
+                            'lastmod': site['roadmap']['lastmod'],
+                            'changefreq': 'monthly', 'priority': '0.5'})
+        # The legal pages last, and low: they matter for trust, not for search.
+        entries += [{'url': url(page['slug']), 'lastmod': page['lastmod'],
+                     'changefreq': 'yearly', 'priority': '0.3'}
+                    for page in prose
+                    if page['kind'] == 'legal' and ready(page['slug'])]
+
+    write(out / 'sitemap.xml', templates.render('sitemap.xml', {'pages': entries}))
+
+
+# How many entries a feed carries. The site has more tools and guides than
+# this, and deliberately so: a feed answers "what has changed lately", which a
+# reader checks repeatedly, and the whole catalogue is already two files away
+# in sitemap.xml and llms.txt. Every entry past the first screenful is weight
+# on every poll for something nobody scrolls to.
+FEED_ENTRIES = 30
+
+
+def build_feeds(out, templates, site, locales, tools, prose):
+    """One Atom feed per published language, at /feed.xml and /<lang>/feed.xml.
+
+    Per language rather than one for the site, because a feed is a reading
+    experience and not an index: a German subscriber wants German titles at
+    German URLs, and mixing fifteen languages into one file would make it
+    useless to all of them. The same rule as everywhere else decides who gets
+    one - a locale that has not finished its frame is built and readable and
+    advertised to nobody, so it has no feed and no link to one.
+
+    Tools and guides, newest first. Not the legal pages, whose dates move for
+    reasons no reader subscribed to hear about, and not the hub or the roadmap,
+    which are indexes of things that appear here already.
+    """
+    for locale in i18n.published(locales):
+        entries = []
+        for tool in tools:
+            if not i18n.translated(locale, tool['slug']):
+                continue
+            said = i18n.localize_tool(tool, locale, site)
+            entries.append({'title': said['name'], 'url': said['url'],
+                            'summary': said['description'],
+                            'lastmod': said['lastmod']})
+        for page in prose:
+            if page['kind'] != 'guide' or not i18n.translated(locale, page['slug']):
+                continue
+            said = i18n.localize_page(page, locale, site)
+            entries.append({'title': said['heading'], 'url': said['url'],
+                            'summary': said['description'],
+                            'lastmod': said['lastmod']})
+
+        # Two passes, because Python's sort is stable: alphabetical first, then
+        # by date descending. A day on which four guides shipped then reads in
+        # a fixed order rather than in whatever order the folders were walked,
+        # which is what keeps a rebuild from reshuffling a feed that did not
+        # change and re-notifying everyone who subscribes to it.
+        entries.sort(key=lambda entry: entry['title'])
+        entries.sort(key=lambda entry: entry['lastmod'], reverse=True)
+        entries = entries[:FEED_ENTRIES]
+
+        for entry in entries:
+            entry['updated'] = f'{entry["lastmod"]}T00:00:00Z'
+
+        home = i18n.locale_url(locale, '', site)
+        said_site = locale['site']
+        feed = {
+            'lang': locale['hreflang'],
+            'title': said_site['name'],
+            'subtitle': said_site['hub']['description'],
+            'home': home,
+            'self': f'{home}feed.xml',
+            'author': said_site['name'],
+            # The newest entry, not the moment of the build. A feed whose
+            # timestamp moves on every deploy teaches a reader to ignore it,
+            # which is the same reason lastmod in the sitemap is a date somebody
+            # changed on purpose.
+            'updated': entries[0]['updated'] if entries else f'{site["lastmod"]}T00:00:00Z',
+            'entries': entries,
+        }
+        write(out / locale['prefix'] / 'feed.xml',
+              templates.render('feed.xml', {'feed': feed}))
+
+
+def build_llms(out, templates, site, locales, tools, prose):
+    """/llms.txt: the whole site as plain text, for a reader that gets one fetch.
+
+    A search engine is handed a page of structured data per tool and has the
+    patience to crawl all of them. An assistant deciding whether this site is
+    worth mentioning at all does not - it fetches one address, and if that
+    address does not say what the tools are and what they cannot do, it writes
+    its own EXIF parser instead of linking to the page that already strips one.
+    This is that address.
+
+    Built from the same tool.toml files as the hub, the sitemap and
+    tools/README.md, and in the same hub order, so it cannot fall behind the
+    tools that exist. That is the whole reason it is generated rather than
+    written: a hand-kept index of twenty-four tools is an index that is wrong.
+
+    Two deliberate departures from every other generated file here:
+
+      * No GENERATED FILE banner at the top. An llms.txt begins with an H1 by
+        convention, and the readers of one are strict about that shape. The
+        sentence saying the file is generated is the last paragraph of the
+        intro instead, where it reads as a fact about the file rather than as a
+        comment standing in front of it.
+      * English only, and at the root. It is an index OF the site, not a page
+        of it: the languages are a section inside it, and each hub linked from
+        there carries the rest of that language on its own.
+
+    Everything goes through site.to_text on the way in. This file is markdown,
+    and the configs it is built from are HTML fragments full of &mdash; and
+    <code>.
+    """
+    text = sitelib.to_text
+    by_slug = {tool['slug']: tool for tool in tools}
+
+    # The hub's categories, in the hub's order, carrying the hub's own note
+    # about each - so a machine reading this groups the tools the same way a
+    # visitor looking at the front page does.
+    groups = []
+    for category in site['hub']['categories']:
+        listed = [by_slug[slug] for slug in category['order'] if slug in by_slug]
+        if not listed:
+            continue
+        groups.append({
+            'name': text(category['name']),
+            'note': text(category['note']),
+            # `schema.description` rather than the tagline. The tagline is
+            # written to be read by somebody already looking at the page; this
+            # is the sentence written to tell a machine what the tool does, and
+            # it is the one that lets a task be matched to an address.
+            'tools': [{'name': text(tool['name']),
+                       'url': tool['url'],
+                       'description': text(tool['schema']['description'])}
+                      for tool in listed],
+        })
+
+    def entry(page):
+        return {'name': text(page['heading']), 'url': page['url'],
+                'description': text(page['description'])}
+
+    guides = [entry(page) for page in prose if page['kind'] == 'guide']
+
+    # A language is listed only if it has finished the frame AND its own hub -
+    # the same test the sitemap and the hreflang tags are built from. Handing a
+    # half-English hub to something that will quote it is the one failure worth
+    # avoiding here, and it is avoided the way it is avoided everywhere else.
+    # Named in English and described by the two things a machine wants next:
+    # the word the language calls itself, which is what the switcher on the
+    # site shows, and the hreflang code, which is how the addresses are keyed.
+    # One shape for every line in the file, rather than a special one here.
+    languages = [{'name': locale['name'],
+                  'url': i18n.locale_url(locale, '', site),
+                  'description': f'{text(locale["endonym"])} - {locale["hreflang"]}'}
+                 for locale in i18n.published(locales, '')
+                 if not locale['is_base']]
+
+    optional = [
+        {'name': text(site['guides']['nav']),
+         'url': f'{site["domain"]}{site["guides"]["slug"]}/',
+         'description': text(site['guides']['description'])},
+        {'name': text(site['roadmap']['nav']),
+         'url': f'{site["domain"]}{site["roadmap"]["slug"]}/',
+         'description': text(site['roadmap']['description'])},
+        {'name': site['source_label'],
+         'url': site['source_url'],
+         'description': text(site['llms']['source_note'])},
+        {'name': 'Sitemap',
+         'url': f'{site["domain"]}sitemap.xml',
+         'description': text(site['llms']['sitemap_note'])},
+    ]
+    # The legal pages last, for the same reason the sitemap puts them last.
+    optional += [entry(page) for page in prose if page['kind'] == 'legal']
+
+    write(out / 'llms.txt', templates.render('llms.txt', {
+        'site': site,
+        # Trimmed here rather than in the template: these are TOML multi-line
+        # strings, so each arrives with the newline its closing quotes sit on,
+        # and the template spaces its own sections.
+        'llms': {key: value.strip() for key, value in site['llms'].items()},
+        # One line, whatever config/site.toml wrapped it as. It is a
+        # blockquote, and a wrapped blockquote whose second line starts with
+        # "- " is read as a list that ends the quote - which is exactly how
+        # this one is worded.
+        'summary': ' '.join(site['llms']['summary'].split()),
+        'groups': groups,
+        'guides': guides,
+        'languages': languages,
+        'optional': optional,
+    }))

--- a/buildlib/deployed.py
+++ b/buildlib/deployed.py
@@ -1,0 +1,101 @@
+"""
+Comparing a fresh build with the branch that is actually being served.
+
+WHY THIS EXISTS
+
+The whole claim of this site is that a reader can check it: the sources are
+here, the build is one command with nothing to install, and the output is
+committed to a branch anybody can look at. `python build.py --check` is the
+command that closes that loop - build it, then diff it, file by file, against
+the `dist` branch GitHub Pages serves. If they differ, the deployed site is not
+what this repository says it is.
+
+WHY IT COMPUTES GIT'S OWN HASHES
+
+Asking `git hash-object` once per file is a process per file over ten thousand
+files. `blob_id` computes the same id in-process from the rule Git uses -
+sha1 of "blob <length>\0" and the bytes - and there is a test that holds it to
+agreeing with `git hash-object` on a file full of mixed line endings, because
+an id that disagreed would make the comparison silently compare nothing.
+
+WHY IT IS NOT IN build.py
+
+It runs after a build rather than during one, it is reached only by a flag, and
+nothing else in the build calls it. Keeping it beside the page builders meant
+that a file already long enough to be awkward carried eighty lines that only
+run when somebody is verifying a deploy.
+"""
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def check_against_branch(out, branch='dist'):
+    """Compare a fresh build with what is committed on the dist branch. This is
+    the command the pages point at: it answers "is the deployed site really a
+    build of these sources?", which matters more now that what is served is
+    minified and no longer pleasant to read straight off.
+
+    A fresh clone has the branch only as origin/dist, so try that too rather
+    than shrugging and reporting success.
+    """
+    for ref_name in (branch, f'origin/{branch}'):
+        found = subprocess.run(['git', 'rev-parse', '--verify', f'{ref_name}^{{tree}}'],
+                               capture_output=True, text=True, cwd=ROOT)
+        if found.returncode == 0:
+            branch = ref_name
+            break
+    else:
+        print(f'\n  no {branch} branch here to check against '
+              f'(try: git fetch origin {branch})', file=sys.stderr)
+        return 0
+
+    differences = compare(out, branch)
+    if differences:
+        print(f'\n  {branch} is not this build ({len(differences)} files differ):',
+              file=sys.stderr)
+        for name in differences[:20]:
+            print(f'    {name}', file=sys.stderr)
+        if len(differences) > 20:
+            print(f'    ... and {len(differences) - 20} more', file=sys.stderr)
+        return 1
+    print(f'\n  {branch} matches a fresh build of these sources')
+    return 0
+
+
+def compare(built, branch):
+    """Which files differ between the build and a branch, by content.
+
+    Read out of the object store rather than checked out into a worktree.
+    Checking out runs the files through Git's end-of-line filters, and on a
+    machine with core.autocrlf on that rewrites every text file on the way to
+    disk - which made this report all sixty-odd files as changed when not one
+    of them was. A blob id is the bytes as committed, and nothing can filter
+    it on the way past.
+    """
+    listing = subprocess.run(['git', 'ls-tree', '-r', '-z', branch],
+                             capture_output=True, text=True, cwd=ROOT, check=True)
+    committed = {}
+    for entry in listing.stdout.split('\0'):
+        if not entry:
+            continue
+        info, path = entry.split('\t', 1)
+        committed[path] = info.split()[2]
+
+    fresh = {path.relative_to(built).as_posix(): blob_id(path)
+             for path in built.rglob('*') if path.is_file()}
+
+    names = sorted(set(committed) | set(fresh))
+    return [name for name in names if committed.get(name) != fresh.get(name)]
+
+
+def blob_id(path):
+    """The id Git would give this file's contents: sha1 over the bytes with
+    Git's blob header in front. The same rule Git uses, so the two are
+    comparable without shelling out once per file."""
+    data = path.read_bytes()
+    return hashlib.sha1(b'blob %d\0' % len(data) + data).hexdigest()

--- a/buildlib/emit.py
+++ b/buildlib/emit.py
@@ -1,0 +1,125 @@
+"""
+Writing a file, and deciding what is minified on the way.
+
+WHY THIS IS NOT IN build.py
+
+build.py is one function per kind of page, and this is not a kind of page: it
+is the one place that turns a string into a file on disk, used by every one of
+them and by the three catalogue files beside them. It was in build.py because
+that is where it was written, and the cost of leaving it there was that
+build.py had to be opened to change how a byte gets written.
+
+`write` is here rather than anywhere else because of what it refuses to do.
+Every text file in this repository is LF - see .gitattributes - and Python's
+own write_text() silently writes CRLF on Windows, which would make the deployed
+site differ from a local build on every line of every file, on alternate
+machines, for no reason a diff could explain. So there is exactly one function
+that writes, and it writes bytes.
+
+LINK sits with the emitter and not with check_links, which is its other caller,
+because recording a page's links is something the emitter does AS it writes:
+the links of every page are gathered on the way past rather than by reading a
+thousand finished files back off the disk afterwards. On Windows that reading
+was half the build - the antivirus prices the first open of a freshly written
+file at tens of milliseconds. check_links borrows the pattern for the path
+where it has to re-read after all.
+"""
+
+import re
+
+from buildlib import cssmin
+from buildlib import minify
+
+
+LINK = re.compile(r'(?:href|src)="([^"#?]+)(?:[#?][^"]*)?"')
+
+
+def write(path, text):
+    """Always LF, always UTF-8. A build that produced CRLF on Windows and LF in
+    CI would show every line of every file as changed on alternate deploys.
+
+    Returns the text as written - trailing newline included - so a caller that
+    goes on to hash what the file holds can hash this instead of opening the
+    file it just closed."""
+    text = text if text.endswith('\n') else text + '\n'
+    path.write_text(text, encoding='utf-8', newline='\n')
+    return text
+
+
+class Emitter:
+    """Writes the HTML, CSS and JavaScript, minified or not.
+
+    One object rather than a flag threaded everywhere, because the two things
+    that have to stay together - whether to minify, and what banner to leave
+    behind when we do - belong together.
+
+    The banner is the one comment minifying does not remove. A page that spends
+    four links telling you to go and read the code should not then hand you a
+    file with no way back to it, so every generated file keeps one line saying
+    where it came from and how to prove it.
+
+    `page_links` records, for every page written, the links on it as written -
+    check_links' input, gathered on the way past. It used to be gathered at
+    the end instead, by reading every page back off the disk, and on Windows
+    that was half the build: the antivirus scans a freshly written file on its
+    next open, at tens of milliseconds each, a thousand pages over.
+    """
+
+    def __init__(self, minify_output, site):
+        self.enabled = bool(minify_output)
+        self.page_links = {}
+        source = site['source_url']
+
+        # The same sentence in three comment syntaxes. Each minifier wraps it
+        # itself, so what is kept here is the text with no delimiters on it.
+        verify = (f'Built from {source} by build.py. '
+                  f'Verify with: python build.py --check')
+        self.js_banner = f'/* {verify} */'
+        self.html_banner = f' {verify} '
+        self.css_banner = f' {verify} '
+
+        # What each source text minified to, so a text seen before is not
+        # minified again. Most of what the build emits is seen many times
+        # over: a tool's modules are the same bytes in every language, and
+        # within one language every prose page's analytics.js is the same
+        # script. Minifying is deterministic - the module says so and stakes
+        # its --check on it - which is what makes the answer reusable at all.
+        #
+        # build() fills the JavaScript and CSS caches with every tool's
+        # sources before the languages start, and that placing is the point:
+        # each language builds in its own process and is handed a copy of this
+        # object, so work cached here once is carried into all of them, where
+        # a cache warmed inside a worker would die with it.
+        self._js_seen = {}
+        self._css_seen = {}
+
+    def html(self, path, text):
+        text = write(path, minify.html(text, self.html_banner)
+                     if self.enabled else text)
+        self.page_links[path] = LINK.findall(text)
+        return text
+
+    def js(self, path, text, where):
+        return write(path, self.js_text(text, where))
+
+    def js_text(self, text, where):
+        """Returns rather than writes, for the one script that is hashed before
+        it is written - see the note beside lang.js in build(). Everything else
+        goes through js() and never sees the string."""
+        if not self.enabled:
+            return text
+        done = self._js_seen.get(text)
+        if done is None:
+            done = self._js_seen[text] = minify.js(text, self.js_banner, where)
+        return done
+
+    def css_text(self, text):
+        """Returns rather than writes, because a stylesheet has to be hashed
+        after minifying and before being written - the hash goes in the URL the
+        page asks for it by."""
+        if not self.enabled:
+            return text
+        done = self._css_seen.get(text)
+        if done is None:
+            done = self._css_seen[text] = cssmin.css(text, self.css_banner)
+        return done

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -11,6 +11,9 @@ build.py                 the generator; run it to produce dist/
 buildlib/
   template.py            an eighty-line template engine, so this has no dependencies
   site.py                config loading, the CSP, the structured data, the checks
+  emit.py                the one function that writes a file, and what it minifies
+  catalogue.py           the whole site as one file: sitemap.xml, llms.txt, the feeds
+  deployed.py            --check: diffing a build against the branch being served
 config/
   site.toml              everything true of every page: the CSP, the ids, the hub
   planned.toml           the "Planned" list on the roadmap page

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -14,10 +14,8 @@ stopped rendering, a tool.toml that lost a key, or a page that quietly stopped
 being written. It needs nothing installed - the plain build is pure Python.
 """
 
-import hashlib
 import json
 import re
-import subprocess
 import tempfile
 import unittest
 import xml.etree.ElementTree as ElementTree
@@ -47,119 +45,13 @@ def warm(tree):
             pass
 
 
-class Write(unittest.TestCase):
-    def setUp(self):
-        self.tmp = tempfile.TemporaryDirectory()
-        self.dir = Path(self.tmp.name)
-        self.addCleanup(self.tmp.cleanup)
-
-    def test_a_trailing_newline_is_added_when_missing(self):
-        path = self.dir / 'a.txt'
-        buildmod.write(path, 'x')
-        self.assertEqual(path.read_bytes(), b'x\n')
-
-    def test_a_trailing_newline_is_not_doubled(self):
-        path = self.dir / 'a.txt'
-        buildmod.write(path, 'x\n')
-        self.assertEqual(path.read_bytes(), b'x\n')
-
-    def test_line_endings_are_always_lf(self):
-        # Even on Windows, and even when the text already holds CRLF.
-        path = self.dir / 'a.txt'
-        buildmod.write(path, 'a\nb\n')
-        self.assertEqual(path.read_bytes(), b'a\nb\n')
-
-    def test_the_text_is_utf8(self):
-        path = self.dir / 'a.txt'
-        buildmod.write(path, 'café\n')
-        self.assertEqual(path.read_bytes(), 'café\n'.encode('utf-8'))
-
-
-class BlobId(unittest.TestCase):
-    """The id Git would give a file, computed without shelling out per file."""
-
-    def setUp(self):
-        self.tmp = tempfile.TemporaryDirectory()
-        self.dir = Path(self.tmp.name)
-        self.addCleanup(self.tmp.cleanup)
-
-    def test_it_matches_the_documented_rule(self):
-        path = self.dir / 'a.txt'
-        path.write_bytes(b'hello\n')
-        expected = hashlib.sha1(b'blob 6\x00hello\n').hexdigest()
-        self.assertEqual(buildmod.blob_id(path), expected)
-
-    def test_an_empty_file_is_the_well_known_empty_blob(self):
-        path = self.dir / 'empty'
-        path.write_bytes(b'')
-        self.assertEqual(buildmod.blob_id(path),
-                         'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391')
-
-    def test_it_agrees_with_git_itself(self):
-        path = self.dir / 'a.bin'
-        path.write_bytes(bytes(range(256)) + b'\r\n mixed \n endings \r\n')
-        found = subprocess.run(['git', 'hash-object', str(path)],
-                               capture_output=True, text=True, check=True)
-        self.assertEqual(buildmod.blob_id(path), found.stdout.strip())
-
-
-class EmitterSetup(unittest.TestCase):
-    SITE = {'source_url': 'https://example.test/repo'}
-
-    def test_the_banner_names_the_source_and_the_check_command(self):
-        emitter = buildmod.Emitter(True, self.SITE)
-        self.assertIn('https://example.test/repo', emitter.js_banner)
-        self.assertIn('build.py --check', emitter.js_banner)
-
-    def test_the_banner_does_not_claim_names_were_renamed(self):
-        # Identifiers are left alone, so nothing in the output should suggest
-        # otherwise to somebody reading a deployed file against its source.
-        emitter = buildmod.Emitter(True, self.SITE)
-        self.assertNotIn('mangl', emitter.js_banner.lower())
 
 
 
-class EmitterOutput(unittest.TestCase):
-    SITE = {'source_url': 'https://example.test/repo'}
 
-    def setUp(self):
-        self.tmp = tempfile.TemporaryDirectory()
-        self.dir = Path(self.tmp.name)
-        self.addCleanup(self.tmp.cleanup)
 
-    def test_minifying_off_writes_the_source_through(self):
-        emitter = buildmod.Emitter(False, self.SITE)
-        source = '// a note\nlet x = 1\n'
-        emitter.js(self.dir / 'a.js', source, where='a.js')
-        self.assertEqual((self.dir / 'a.js').read_text(encoding='utf-8'), source)
 
-    def test_minifying_on_strips_comments_and_keeps_the_banner(self):
-        emitter = buildmod.Emitter(True, self.SITE)
-        emitter.js(self.dir / 'a.js', '// a note\nlet x = 1\n', where='a.js')
-        out = (self.dir / 'a.js').read_text(encoding='utf-8')
-        self.assertNotIn('a note', out)
-        self.assertIn('let x=1', out)
-        self.assertIn('build.py --check', out)
 
-    def test_html_carries_the_banner_as_a_comment(self):
-        emitter = buildmod.Emitter(True, self.SITE)
-        emitter.html(self.dir / 'a.html', '<p>\n  a\n</p>\n')
-        out = (self.dir / 'a.html').read_text(encoding='utf-8')
-        self.assertTrue(out.startswith('<!--'))
-        self.assertIn('<p> a </p>', out)
-
-    def test_css_text_returns_rather_than_writes(self):
-        # The stylesheet has to be hashed after minifying and before being
-        # written, because the hash goes in the URL the page asks for it by.
-        emitter = buildmod.Emitter(True, self.SITE)
-        out = emitter.css_text('a {\n  color: red;\n}\n')
-        self.assertIn('a{color:red}', out)
-        self.assertEqual(list(self.dir.iterdir()), [])
-
-    def test_css_text_is_untouched_when_minifying_is_off(self):
-        source = 'a {\n  color: red;\n}\n'
-        self.assertEqual(buildmod.Emitter(False, self.SITE).css_text(source),
-                         source)
 
 
 class GuideGroups(unittest.TestCase):

--- a/tests/python/test_deployed.py
+++ b/tests/python/test_deployed.py
@@ -1,0 +1,49 @@
+"""
+buildlib/deployed.py - comparing a build with the branch that is served.
+
+Only `blob_id` is unit-testable without a deploy to compare against, and it is
+the part that has to be exactly right: it computes the id Git would give a
+file, in-process, because asking `git hash-object` once per file is a process
+per file over ten thousand files. An id that disagreed with Git would make
+`--check` compare nothing and say everything matched.
+"""
+
+import hashlib
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from buildlib import deployed
+
+
+class BlobId(unittest.TestCase):
+    """The id Git would give a file, computed without shelling out per file."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_it_matches_the_documented_rule(self):
+        path = self.dir / 'a.txt'
+        path.write_bytes(b'hello\n')
+        expected = hashlib.sha1(b'blob 6\x00hello\n').hexdigest()
+        self.assertEqual(deployed.blob_id(path), expected)
+
+    def test_an_empty_file_is_the_well_known_empty_blob(self):
+        path = self.dir / 'empty'
+        path.write_bytes(b'')
+        self.assertEqual(deployed.blob_id(path),
+                         'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391')
+
+    def test_it_agrees_with_git_itself(self):
+        path = self.dir / 'a.bin'
+        path.write_bytes(bytes(range(256)) + b'\r\n mixed \n endings \r\n')
+        found = subprocess.run(['git', 'hash-object', str(path)],
+                               capture_output=True, text=True, check=True)
+        self.assertEqual(deployed.blob_id(path), found.stdout.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_emit.py
+++ b/tests/python/test_emit.py
@@ -1,0 +1,104 @@
+"""
+buildlib/emit.py - writing a file, and what is minified on the way.
+
+`write` is here because of what it refuses to do: every text file in this
+repository is LF, and a build that produced CRLF on Windows and LF in CI would
+show every line of every file as changed on alternate deploys. `Emitter` is
+here because it decides what gets minified and what banner is left behind.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from buildlib import emit as emitlib
+
+
+class Write(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_a_trailing_newline_is_added_when_missing(self):
+        path = self.dir / 'a.txt'
+        emitlib.write(path, 'x')
+        self.assertEqual(path.read_bytes(), b'x\n')
+
+    def test_a_trailing_newline_is_not_doubled(self):
+        path = self.dir / 'a.txt'
+        emitlib.write(path, 'x\n')
+        self.assertEqual(path.read_bytes(), b'x\n')
+
+    def test_line_endings_are_always_lf(self):
+        # Even on Windows, and even when the text already holds CRLF.
+        path = self.dir / 'a.txt'
+        emitlib.write(path, 'a\nb\n')
+        self.assertEqual(path.read_bytes(), b'a\nb\n')
+
+    def test_the_text_is_utf8(self):
+        path = self.dir / 'a.txt'
+        emitlib.write(path, 'café\n')
+        self.assertEqual(path.read_bytes(), 'café\n'.encode('utf-8'))
+
+
+class EmitterSetup(unittest.TestCase):
+    SITE = {'source_url': 'https://example.test/repo'}
+
+    def test_the_banner_names_the_source_and_the_check_command(self):
+        emitter = emitlib.Emitter(True, self.SITE)
+        self.assertIn('https://example.test/repo', emitter.js_banner)
+        self.assertIn('build.py --check', emitter.js_banner)
+
+    def test_the_banner_does_not_claim_names_were_renamed(self):
+        # Identifiers are left alone, so nothing in the output should suggest
+        # otherwise to somebody reading a deployed file against its source.
+        emitter = emitlib.Emitter(True, self.SITE)
+        self.assertNotIn('mangl', emitter.js_banner.lower())
+
+
+class EmitterOutput(unittest.TestCase):
+    SITE = {'source_url': 'https://example.test/repo'}
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_minifying_off_writes_the_source_through(self):
+        emitter = emitlib.Emitter(False, self.SITE)
+        source = '// a note\nlet x = 1\n'
+        emitter.js(self.dir / 'a.js', source, where='a.js')
+        self.assertEqual((self.dir / 'a.js').read_text(encoding='utf-8'), source)
+
+    def test_minifying_on_strips_comments_and_keeps_the_banner(self):
+        emitter = emitlib.Emitter(True, self.SITE)
+        emitter.js(self.dir / 'a.js', '// a note\nlet x = 1\n', where='a.js')
+        out = (self.dir / 'a.js').read_text(encoding='utf-8')
+        self.assertNotIn('a note', out)
+        self.assertIn('let x=1', out)
+        self.assertIn('build.py --check', out)
+
+    def test_html_carries_the_banner_as_a_comment(self):
+        emitter = emitlib.Emitter(True, self.SITE)
+        emitter.html(self.dir / 'a.html', '<p>\n  a\n</p>\n')
+        out = (self.dir / 'a.html').read_text(encoding='utf-8')
+        self.assertTrue(out.startswith('<!--'))
+        self.assertIn('<p> a </p>', out)
+
+    def test_css_text_returns_rather_than_writes(self):
+        # The stylesheet has to be hashed after minifying and before being
+        # written, because the hash goes in the URL the page asks for it by.
+        emitter = emitlib.Emitter(True, self.SITE)
+        out = emitter.css_text('a {\n  color: red;\n}\n')
+        self.assertIn('a{color:red}', out)
+        self.assertEqual(list(self.dir.iterdir()), [])
+
+    def test_css_text_is_untouched_when_minifying_is_off(self):
+        source = 'a {\n  color: red;\n}\n'
+        self.assertEqual(emitlib.Emitter(False, self.SITE).css_text(source),
+                         source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`build.py` is one function per kind of page, and it had grown ~400 lines that
are not a kind of page. Reading it to change how the hub renders meant loading
the sitemap writer, the Atom feeds, the emitter and the whole of `--check`
first. `buildlib/` was already the answer to that question — templating,
minifying, i18n and imports each have a file, and #190 has just added
`cards.py` on the same instinct — so these three groups had simply never been
asked to leave.

**build.py: 2,162 → 1,772 lines.**

| New module | Lines | What |
|---|---|---|
| `buildlib/catalogue.py` | 270 | `sitemap.xml`, `llms.txt`, the Atom feeds |
| `buildlib/emit.py` | 125 | `write`, `LINK`, `Emitter` |
| `buildlib/deployed.py` | 101 | `--check` against the served branch |

The groupings are not arbitrary. The three catalogue files are the same job with
three audiences: each is built from the same two lists and each holds back the
same languages, because a locale still being translated carries no hreflang tag
and no switcher entry, and a line in any of them would be the last remaining way
to send a crawler at a page that is half in English. Getting that right in three
places and wrong in a fourth is the mistake one file is meant to make hard.

`LINK` moved to `emit.py` rather than staying with `check_links` because
gathering a page's links is something the emitter does *as it writes*;
`check_links` borrows the pattern for the one path where it has to re-read.

## The tests followed the code

`buildlib/X.py` has always had `tests/python/test_X.py` beside it. So `Write`,
`EmitterSetup` and `EmitterOutput` are now `test_emit.py` (11 tests) and `BlobId`
is `test_deployed.py` (3 tests) — same assertions, same names, moved. All 14
still collect, and `test_build.py` loses 101 lines.

## Verification

This is a pure move, and that is checked rather than claimed:

- **A full build of `main` (dfcf160) and one of this branch produce 11,543 files
  with zero differing bytes.** Measured by SHA-1 over every file, and confirmed
  independently by `diff -rq`.
- `python build.py --out _plain --clean --no-minify` — passes, 1,248 pages, link
  check clean
- Every `tests/python/test_*.py` module still imports and collects
- All new files are LF

Nothing a visitor sees changes, so there are no before/after pictures to attach.

## One thing found on the way, not fixed here

`python build.py --check` is broken on any machine whose locale encoding is not
UTF-8. It dies with a misleading `AttributeError: 'NoneType' object has no
attribute 'split'`; the cause is `text=True` in `compare()`, which decodes git's
output with the locale codec. This machine is `cp936`/GBK and the `dist` tree has
1,512 non-ASCII paths, so it cannot decode. `build.py` already knew about this
class of bug — `main()` reconfigures stdout to UTF-8 with a comment about
non-UTF-8 Windows consoles — and `compare()` was missed.

It is pre-existing and byte-identical to what is on `main`, so it is deliberately
**not** fixed here: this PR's whole evidence is that it changes nothing. Fix
follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)