### PR TITLE
Read git's output as UTF-8 rather than as whatever the machine prefers

### DIFF
--- a/buildlib/deployed.py
+++ b/buildlib/deployed.py
@@ -44,8 +44,12 @@ def check_against_branch(out, branch='dist'):
     than shrugging and reporting success.
     """
     for ref_name in (branch, f'origin/{branch}'):
+        # utf-8 for the same reason as the call in compare() below. This one
+        # reads back a hex id and would survive any codec, but it captures
+        # git's stderr too, and a git that has been translated writes that in
+        # whatever it likes.
         found = subprocess.run(['git', 'rev-parse', '--verify', f'{ref_name}^{{tree}}'],
-                               capture_output=True, text=True, cwd=ROOT)
+                               capture_output=True, encoding='utf-8', cwd=ROOT)
         if found.returncode == 0:
             branch = ref_name
             break
@@ -77,8 +81,18 @@ def compare(built, branch):
     of them was. A blob id is the bytes as committed, and nothing can filter
     it on the way past.
     """
+    # encoding rather than text=True, and this is not a style choice.
+    # text=True decodes with the machine's locale encoding, and this site has
+    # 1,512 paths that are not ASCII - the translated slugs, in Arabic,
+    # Japanese and Chinese. On a Windows install whose locale is not UTF-8
+    # (cp936 is a common one) those bytes cannot be decoded, the reader thread
+    # dies, and `stdout` arrives as None. What reached the person running
+    # --check was "AttributeError: 'NoneType' object has no attribute 'split'",
+    # which names neither git nor an encoding. Git writes paths as UTF-8, so
+    # that is what this reads them as, on every machine.
     listing = subprocess.run(['git', 'ls-tree', '-r', '-z', branch],
-                             capture_output=True, text=True, cwd=ROOT, check=True)
+                             capture_output=True, encoding='utf-8', cwd=ROOT,
+                             check=True)
     committed = {}
     for entry in listing.stdout.split('\0'):
         if not entry:

--- a/tests/python/test_deployed.py
+++ b/tests/python/test_deployed.py
@@ -13,6 +13,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from buildlib import deployed
 
@@ -43,6 +44,53 @@ class BlobId(unittest.TestCase):
         found = subprocess.run(['git', 'hash-object', str(path)],
                                capture_output=True, text=True, check=True)
         self.assertEqual(deployed.blob_id(path), found.stdout.strip())
+
+
+class GitOutputDecoding(unittest.TestCase):
+    """Git's output is read as UTF-8, whatever the machine's locale is.
+
+    `text=True` decodes with the locale encoding. This site has 1,512 paths
+    that are not ASCII - the translated slugs, in Arabic, Japanese and Chinese
+    - so on a Windows install whose locale is not UTF-8 (cp936 is a common
+    one) the reader thread died mid-decode and `stdout` arrived as None. What
+    reached the person running --check was `AttributeError: 'NoneType' object
+    has no attribute 'split'`, which names neither git nor an encoding. That
+    is the one command this whole site asks people to run.
+
+    These assert the MECHANISM and not the symptom, deliberately. CI runs on a
+    UTF-8 machine, where the broken version works perfectly and a test that
+    only checked the result would have passed either way.
+    """
+
+    ARABIC = 'ar/' + 'قارئ-رموز' + '/index.html'
+
+    def run_compare(self, stdout):
+        """compare() against a canned `git ls-tree`, capturing how it was
+        called. The build directory is empty, so every committed path comes
+        back as a difference - which is what makes the parsed names visible.
+        """
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout)
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(deployed.subprocess, 'run',
+                                   return_value=result) as run:
+                differences = deployed.compare(Path(tmp), 'dist')
+        return run.call_args, differences
+
+    def test_git_is_asked_for_utf8_and_never_the_locale(self):
+        call, _ = self.run_compare('')
+        self.assertEqual(call.kwargs.get('encoding'), 'utf-8')
+        self.assertNotIn(
+            'text', call.kwargs,
+            'text=True decodes with the machine locale, which is the bug this '
+            'guards. Ask for encoding="utf-8" so every machine reads git alike.')
+
+    def test_a_path_that_is_not_ascii_survives_being_read(self):
+        # One entry in the -z format: "<mode> <type> <id>\t<path>\0". The path
+        # is the Arabic slug for the QR reader, which is the shape of the 1,512
+        # that cp936 could not decode.
+        entry = '100644 blob ' + '0' * 40 + '\t' + self.ARABIC + '\0'
+        _, differences = self.run_compare(entry)
+        self.assertEqual(differences, [self.ARABIC])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`python build.py --check` is the command this site points people at. It is the
whole of the claim that the deployed pages are a build of these sources — one
command, nothing to install, build it and diff it against the branch being
served. **On any machine whose locale encoding is not UTF-8 it did not work at
all.**

`text=True` asks Python to decode a subprocess's output with the locale
encoding. `git ls-tree` lists every path on the `dist` branch, and 1,512 of
those are not ASCII — the translated slugs, in Arabic, Japanese and Chinese. On
a Windows install running cp936, which is where this was found, the decode fails
inside the reader thread, `stdout` arrives as `None`, and what the person sees
is:

```
AttributeError: 'NoneType' object has no attribute 'split'
```

That names neither git, nor an encoding, nor the fact that it would have worked
on a colleague's machine. Somebody checking this site's central claim, on a
perfectly ordinary computer, is told the build is broken in a way that leads
nowhere.

## The fix

Git writes paths as UTF-8, so both calls now say so. The `rev-parse` call only
reads back a hex id and would survive any codec, but it captures git's stderr
too, and a git that has been translated writes that in whatever it likes.

`build.py` already knew about this class of bug from the other direction —
`main()` reconfigures stdout to UTF-8 with a comment about consoles that are
not, *"which is the default on a good many Windows installations"*. Same fact
about the same machines, one layer down; writing was covered and reading was
missed.

## Verification

- **`python build.py --clean --check` now runs to completion on this cp936
  machine**, and prints the Arabic paths correctly while doing it. Before this
  commit it raised the `AttributeError` above.
- `python -m unittest tests.python.test_deployed -v -k GitOutputDecoding` — 2
  tests, both pass.

The two tests assert the **mechanism**, not the symptom, deliberately: CI runs
on a UTF-8 machine where the broken version works perfectly, so a test that only
checked the result would have passed either way. One pins `encoding='utf-8'` and
refuses `text=True`; the other feeds a canned `ls-tree` entry carrying an Arabic
path and checks it survives being parsed.

Nothing a visitor sees changes, so there are no before/after pictures to attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)