### PR TITLE
A sprite sheet, for everything that cannot play a GIF

### DIFF
--- a/locales/ar/tools/split-gif.html
+++ b/locales/ar/tools/split-gif.html
@@ -77,6 +77,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">نزِّل كل إطار في ملف ZIP</button>
       <button type="button" id="download-selected" class="ghost" hidden>نزِّل الإطارات المحدَّدة</button>
+      <button type="button" id="download-sheet" class="ghost">تنزيل كورقة سبرايت واحدة</button>
       <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
@@ -112,6 +113,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">يجري رسم الورقة&hellip;</span>
+    <span data-phrase="sheet.toobig">ستكون الورقة {width} &times; {height} بكسل، ولا يرسم أي متصفح هذا الحجم. احتفظ بإطار من كل إطارين، أو احفظ الإطارات في ملف ZIP.</span>
+    <span data-phrase="sheet.stored">تحتاج الورقة إلى خلايا متساوية الحجم، لذا تستخدم الإطار كما يظهر لا البكسلات التي يخزّنها ذلك الإطار وحدها.</span>
     <span data-phrase="net.clean">صورة GIF الخاصة بك لم تذهب إلى أي مكان.
       {total} ملفاً حُمِّلت. {platform}</span>
     <span data-phrase="net.dirty">اتصل شيءٌ بـ {hosts}، وهو ما لا تفعله هذه

--- a/locales/de/tools/split-gif.html
+++ b/locales/de/tools/split-gif.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Alle Einzelbilder als ZIP herunterladen</button>
       <button type="button" id="download-selected" class="ghost" hidden>Die ausgewählten Einzelbilder herunterladen</button>
+      <button type="button" id="download-sheet" class="ghost">Als ein Spritesheet herunterladen</button>
       <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
@@ -113,6 +114,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Das Blatt wird gezeichnet&hellip;</span>
+    <span data-phrase="sheet.toobig">Dieses Blatt w&auml;re {width} mal {height} Pixel gro&szlig;, und das zeichnet kein Browser. Behalten Sie stattdessen jedes zweite Einzelbild, oder speichern Sie die Einzelbilder als ZIP.</span>
+    <span data-phrase="sheet.stored">Ein Blatt braucht in jeder Zelle dieselbe Gr&ouml;&szlig;e und nimmt deshalb das Einzelbild, wie es erscheint, statt nur der Pixel, die ein Einzelbild speichert.</span>
     <span data-phrase="net.clean">Ihr GIF ist nirgendwohin gegangen. {total}
       Dateien geladen. {platform}</span>
     <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut

--- a/locales/es/tools/split-gif.html
+++ b/locales/es/tools/split-gif.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Descargar todos los fotogramas en un ZIP</button>
       <button type="button" id="download-selected" class="ghost" hidden>Descargar los fotogramas marcados</button>
+      <button type="button" id="download-sheet" class="ghost">Descargar como una hoja de sprites</button>
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
@@ -113,6 +114,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Dibujando la hoja&hellip;</span>
+    <span data-phrase="sheet.toobig">Esa hoja medir&iacute;a {width} por {height} p&iacute;xeles, y ning&uacute;n navegador la dibuja. Conserva un fotograma de cada dos, o guarda los fotogramas en un ZIP.</span>
+    <span data-phrase="sheet.stored">Una hoja necesita que todas las celdas midan lo mismo, as&iacute; que usa el fotograma tal como se ve y no s&oacute;lo los p&iacute;xeles que ese fotograma guarda.</span>
     <span data-phrase="net.clean">tu GIF no ha ido a ninguna parte. {total}
       archivos cargados. {platform}</span>
     <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta

--- a/locales/fr/tools/split-gif.html
+++ b/locales/fr/tools/split-gif.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Télécharger toutes les images en ZIP</button>
       <button type="button" id="download-selected" class="ghost" hidden>Télécharger les images cochées</button>
+      <button type="button" id="download-sheet" class="ghost">T&eacute;l&eacute;charger en une planche de sprites</button>
       <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
@@ -113,6 +114,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Dessin de la planche&hellip;</span>
+    <span data-phrase="sheet.toobig">Cette planche ferait {width} sur {height} pixels, ce qu'aucun navigateur ne dessine. Gardez plut&ocirc;t une image sur deux, ou enregistrez les images dans un ZIP.</span>
+    <span data-phrase="sheet.stored">Une planche exige des cases de m&ecirc;me taille : elle utilise donc l'image telle qu'elle appara&icirc;t, et non les seuls pixels que cette image stocke.</span>
     <span data-phrase="net.clean">votre GIF n'est allé nulle part. {total}
       fichiers chargés. {platform}</span>
     <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet

--- a/locales/hi/tools/split-gif.html
+++ b/locales/hi/tools/split-gif.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">सारे फ़्रेम ZIP में डाउनलोड कीजिए</button>
       <button type="button" id="download-selected" class="ghost" hidden>चुने हुए फ़्रेम डाउनलोड कीजिए</button>
+      <button type="button" id="download-sheet" class="ghost">एक स्प्राइट शीट के रूप में डाउनलोड करें</button>
       <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
@@ -113,6 +114,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">शीट बनाई जा रही है&hellip;</span>
+    <span data-phrase="sheet.toobig">यह शीट {width} &times; {height} पिक्सेल की होगी, जिसे कोई भी ब्राउज़र नहीं बना सकता। इसके बजाय हर दूसरा फ़्रेम रखें, या फ़्रेम को ZIP में सहेजें।</span>
+    <span data-phrase="sheet.stored">शीट में हर ख़ाने का आकार एक जैसा होना चाहिए, इसलिए यह फ़्रेम को वैसा ही लेती है जैसा दिखता है, न कि केवल उन पिक्सेल को जो वह फ़्रेम संग्रहीत करता है।</span>
     <span data-phrase="net.clean">आपका GIF कहीं नहीं गया। {total} फ़ाइलें लोड
       हुईं। {platform}</span>
     <span data-phrase="net.dirty">किसी चीज़ ने {hosts} से संपर्क किया, और यह टूल

--- a/locales/id/tools/split-gif.html
+++ b/locales/id/tools/split-gif.html
@@ -84,6 +84,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Unduh setiap bingkai sebagai ZIP</button>
       <button type="button" id="download-selected" class="ghost" hidden>Unduh bingkai yang dipilih</button>
+      <button type="button" id="download-sheet" class="ghost">Unduh sebagai satu lembar sprite</button>
       <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
@@ -119,6 +120,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Menggambar lembar&hellip;</span>
+    <span data-phrase="sheet.toobig">Lembar itu akan berukuran {width} kali {height} piksel, dan tidak ada peramban yang menggambarnya. Simpan satu bingkai dari setiap dua, atau simpan bingkai sebagai ZIP.</span>
+    <span data-phrase="sheet.stored">Sebuah lembar memerlukan setiap sel berukuran sama, jadi ia memakai bingkai sebagaimana tampak, bukan hanya piksel yang disimpan bingkai itu.</span>
     <span data-phrase="net.clean">GIF Anda tidak pergi ke mana pun. {total} file
       dimuat. {platform}</span>
     <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak

--- a/locales/it/tools/split-gif.html
+++ b/locales/it/tools/split-gif.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Scarica tutti i fotogrammi in uno ZIP</button>
       <button type="button" id="download-selected" class="ghost" hidden>Scarica i fotogrammi spuntati</button>
+      <button type="button" id="download-sheet" class="ghost">Scarica come un unico foglio di sprite</button>
       <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
@@ -113,6 +114,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Disegno del foglio&hellip;</span>
+    <span data-phrase="sheet.toobig">Il foglio sarebbe di {width} per {height} pixel, e nessun browser lo disegna. Tieni un fotogramma su due, oppure salva i fotogrammi in uno ZIP.</span>
+    <span data-phrase="sheet.stored">Un foglio richiede celle tutte della stessa dimensione, quindi usa il fotogramma come appare e non i soli pixel che quel fotogramma memorizza.</span>
     <span data-phrase="net.clean">La tua GIF non è andata da nessuna parte.
       {total} file caricati. {platform}</span>
     <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo

--- a/locales/ja/tools/split-gif.html
+++ b/locales/ja/tools/split-gif.html
@@ -76,6 +76,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">全コマをZIPでダウンロード</button>
       <button type="button" id="download-selected" class="ghost" hidden>選んだコマをダウンロード</button>
+      <button type="button" id="download-sheet" class="ghost">1枚のスプライトシートとしてダウンロード</button>
       <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
@@ -111,6 +112,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">シートを描いています&hellip;</span>
+    <span data-phrase="sheet.toobig">そのシートは{width}×{height}ピクセルになり、どのブラウザーも描画できません。2コマに1枚だけ残すか、コマをZIPで保存してください。</span>
+    <span data-phrase="sheet.stored">シートはすべてのセルが同じ大きさである必要があるため、そのコマが保存している画素だけではなく、表示されるままのコマを使います。</span>
     <span data-phrase="net.clean">GIFはどこへも出ていません。{total}件のファイルを読み込みました。{platform}</span>
     <span data-phrase="net.dirty">何かが{hosts}へ接続しました。この道具は決してそれをしません。{platform}</span>
     <span data-phrase="net.platform.one">広告・計測・寄付ボタンのためのサイト自身のスクリプトが{hosts}のホストから読み込まれました。そのどれにも、ファイルは渡っていません。</span>

--- a/locales/ko/tools/split-gif.html
+++ b/locales/ko/tools/split-gif.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">모든 프레임 ZIP으로 내려받기</button>
       <button type="button" id="download-selected" class="ghost" hidden>고른 프레임 내려받기</button>
+      <button type="button" id="download-sheet" class="ghost">하나의 스프라이트 시트로 내려받기</button>
       <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
@@ -113,6 +114,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">시트를 그리는 중&hellip;</span>
+    <span data-phrase="sheet.toobig">이 시트는 {width} × {height}픽셀이 되어 어떤 브라우저도 그리지 못합니다. 두 프레임 중 하나만 남기거나, 프레임을 ZIP으로 저장하세요.</span>
+    <span data-phrase="sheet.stored">시트는 모든 칸의 크기가 같아야 하므로, 그 프레임이 저장한 픽셀만이 아니라 보이는 그대로의 프레임을 사용합니다.</span>
     <span data-phrase="net.clean">GIF는 어디로도 가지 않았습니다. 파일 {total}개를 불러왔습니다.
       {platform}</span>
     <span data-phrase="net.dirty">무언가가 {hosts}에 접속했는데, 이 도구는 절대 그러지 않습니다.

--- a/locales/nl/tools/split-gif.html
+++ b/locales/nl/tools/split-gif.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Alle frames als ZIP downloaden</button>
       <button type="button" id="download-selected" class="ghost" hidden>De aangevinkte frames downloaden</button>
+      <button type="button" id="download-sheet" class="ghost">Downloaden als &eacute;&eacute;n spritesheet</button>
       <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
@@ -113,6 +114,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Het blad wordt getekend&hellip;</span>
+    <span data-phrase="sheet.toobig">Dat blad zou {width} bij {height} pixels worden, en dat tekent geen enkele browser. Houd elk tweede beeld over, of sla de beelden op als ZIP.</span>
+    <span data-phrase="sheet.stored">Een blad heeft cellen van gelijke grootte nodig en gebruikt daarom het beeld zoals het eruitziet, niet alleen de pixels die dat beeld opslaat.</span>
     <span data-phrase="net.clean">Je GIF is nergens heen gegaan. {total}
       bestanden geladen. {platform}</span>
     <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit

--- a/locales/pt/tools/split-gif.html
+++ b/locales/pt/tools/split-gif.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Baixar todos os quadros em um ZIP</button>
       <button type="button" id="download-selected" class="ghost" hidden>Baixar os quadros marcados</button>
+      <button type="button" id="download-sheet" class="ghost">Baixar como uma folha de sprites</button>
       <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
@@ -113,6 +114,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Desenhando a folha&hellip;</span>
+    <span data-phrase="sheet.toobig">Essa folha teria {width} por {height} pixels, e nenhum navegador desenha isso. Guarde um quadro a cada dois, ou salve os quadros num ZIP.</span>
+    <span data-phrase="sheet.stored">Uma folha precisa que todas as c&eacute;lulas tenham o mesmo tamanho, por isso usa o quadro como ele aparece e n&atilde;o apenas os pixels que aquele quadro guarda.</span>
     <span data-phrase="net.clean">O seu GIF não foi a lugar nenhum. {total}
       arquivos carregados. {platform}</span>
     <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta

--- a/locales/tr/tools/split-gif.html
+++ b/locales/tr/tools/split-gif.html
@@ -84,6 +84,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Her kareyi ZIP olarak indir</button>
       <button type="button" id="download-selected" class="ghost" hidden>Seçili kareleri indir</button>
+      <button type="button" id="download-sheet" class="ghost">Tek bir sprite sayfas&#305; olarak indir</button>
       <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
@@ -119,6 +120,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Sayfa &ccedil;iziliyor&hellip;</span>
+    <span data-phrase="sheet.toobig">Bu sayfa {width} &times; {height} piksel olurdu; hi&ccedil;bir taray&#305;c&#305; bunu &ccedil;izmez. Bunun yerine iki kareden birini tutun ya da kareleri ZIP olarak kaydedin.</span>
+    <span data-phrase="sheet.stored">Bir sayfada b&uuml;t&uuml;n h&uuml;creler ayn&#305; boyutta olmal&#305;d&#305;r; bu y&uuml;zden karenin saklad&#305;&#287;&#305; piksellerle de&#287;il, g&ouml;r&uuml;nd&uuml;&#287;&uuml; h&acirc;liyle kullan&#305;l&#305;r.</span>
     <span data-phrase="net.clean">GIF'iniz hiçbir yere gitmedi. {total} dosya
       yüklendi. {platform}</span>
     <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç

--- a/locales/zh-TW/tools/split-gif.html
+++ b/locales/zh-TW/tools/split-gif.html
@@ -76,6 +76,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">打包成 ZIP 下載全部幀</button>
       <button type="button" id="download-selected" class="ghost" hidden>下載勾選的幀</button>
+      <button type="button" id="download-sheet" class="ghost">下載為一張精靈圖</button>
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
@@ -111,6 +112,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">正在繪製精靈圖&hellip;</span>
+    <span data-phrase="sheet.toobig">這張圖會是 {width} &times; {height} 像素，任何瀏覽器都畫不出來。可以改成每兩幀留一幀，或者把各幀存成 ZIP。</span>
+    <span data-phrase="sheet.stored">精靈圖要求每個格子大小一致，所以它用的是這一幀顯示出來的樣子，而不是這一幀單獨存下的那些像素。</span>
     <span data-phrase="net.clean">你的 GIF 沒有去任何地方。載入了 {total} 個檔案。{platform}</span>
     <span data-phrase="net.dirty">有東西聯絡了 {hosts}，而這個工具從不這麼做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用於廣告、統計和捐贈按鈕的指令碼來自 {hosts} 個主機，它們誰也沒拿到任何檔案。</span>

--- a/locales/zh/tools/split-gif.html
+++ b/locales/zh/tools/split-gif.html
@@ -76,6 +76,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">打包成 ZIP 下载全部帧</button>
       <button type="button" id="download-selected" class="ghost" hidden>下载勾选的帧</button>
+      <button type="button" id="download-sheet" class="ghost">下载为一张精灵图</button>
       <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
@@ -111,6 +112,9 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">正在绘制精灵图&hellip;</span>
+    <span data-phrase="sheet.toobig">这张图会是 {width} &times; {height} 像素，任何浏览器都画不出来。可以改成每两帧留一帧，或者把各帧存成 ZIP。</span>
+    <span data-phrase="sheet.stored">精灵图要求每个格子大小一致，所以它用的是这一帧显示出来的样子，而不是这一帧单独存下的那些像素。</span>
     <span data-phrase="net.clean">你的 GIF 没有去任何地方。加载了 {total} 个文件。{platform}</span>
     <span data-phrase="net.dirty">有东西联系了 {hosts}，而这个工具从不这么做。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用于广告、统计和捐赠按钮的脚本来自 {hosts} 个主机，它们谁也没拿到任何文件。</span>

--- a/tests/js/split-gif-sheet.test.js
+++ b/tests/js/split-gif-sheet.test.js
@@ -1,0 +1,90 @@
+/**
+ * tools/split-gif/src/sheet.js - the sprite-sheet geometry.
+ *
+ * Arithmetic rather than pixels, which is the reason it is a module of its own:
+ * the drawing needs a canvas and a browser, and the part that decides how many
+ * columns there are, whether the result will fit in one, and what the file is
+ * called needs neither.
+ *
+ * The cases worth holding are the ones that are not a neat square: a prime
+ * number of frames, one frame, a column count larger than the frame count, and
+ * the sizes no engine will allocate.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CAUTION_SIDE, MAX_SIDE, cellAt, sheetName, sheetPlan, suggestColumns,
+} from '../../tools/split-gif/src/sheet.js';
+
+test('the suggested grid is the squarest one that holds the frames', () => {
+  assert.equal(suggestColumns(16), 4);
+  assert.equal(suggestColumns(1), 1);
+  // 17 does not factor into a rectangle, so the last row is short rather than
+  // the grid being wrong.
+  assert.equal(suggestColumns(17), 5);
+  assert.equal(suggestColumns(0), 0);
+});
+
+test('a short last row is a short last row, not a smaller grid', () => {
+  const plan = sheetPlan(17, 10, 10, 0);
+  assert.equal(plan.columns, 5);
+  assert.equal(plan.rows, 4);          // 20 cells for 17 frames
+  assert.equal(plan.width, 50);
+  assert.equal(plan.height, 40);
+});
+
+test('asking for more columns than there are frames gives one row', () => {
+  const plan = sheetPlan(6, 32, 32, 99);
+  assert.equal(plan.columns, 6);
+  assert.equal(plan.rows, 1);
+});
+
+test('a column count of zero falls back to the suggestion', () => {
+  assert.equal(sheetPlan(9, 8, 8, 0).columns, 3);
+  assert.equal(sheetPlan(9, 8, 8, -4).columns, 3);
+});
+
+test('one frame is a one-by-one sheet the size of the frame', () => {
+  const plan = sheetPlan(1, 120, 90, 0);
+  assert.deepEqual(
+    [plan.columns, plan.rows, plan.width, plan.height], [1, 1, 120, 90]);
+  assert.equal(plan.tooBig, false);
+});
+
+test('no frames is an empty plan rather than a division by zero', () => {
+  const plan = sheetPlan(0, 10, 10, 0);
+  assert.equal(plan.rows, 0);
+  assert.equal(plan.height, 0);
+  assert.ok(Number.isFinite(plan.width));
+});
+
+test('a sheet past the universal canvas limit is refused', () => {
+  // 400 frames of 500x500 in a square grid is 20 cells a side: 10000px, which
+  // is allowed. Forcing it into two columns is not.
+  const square = sheetPlan(400, 500, 500, 0);
+  assert.equal(square.tooBig, false);
+  const tall = sheetPlan(400, 500, 500, 2);
+  assert.ok(tall.height > MAX_SIDE);
+  assert.equal(tall.tooBig, true);
+});
+
+test('the phone warning fires below the refusal, not with it', () => {
+  const plan = sheetPlan(64, 640, 640, 8);   // 5120px a side
+  assert.ok(plan.width > CAUTION_SIDE);
+  assert.equal(plan.risky, true);
+  assert.equal(plan.tooBig, false, 'a desktop should not be stopped by this');
+});
+
+test('cells run left to right, then down', () => {
+  const plan = sheetPlan(6, 16, 16, 3);
+  assert.deepEqual(cellAt(0, plan, 16, 16), { x: 0, y: 0 });
+  assert.deepEqual(cellAt(2, plan, 16, 16), { x: 32, y: 0 });
+  assert.deepEqual(cellAt(3, plan, 16, 16), { x: 0, y: 16 });
+  assert.deepEqual(cellAt(5, plan, 16, 16), { x: 32, y: 16 });
+});
+
+test('the grid is in the filename, because the image cannot carry it', () => {
+  assert.equal(sheetName('walk', sheetPlan(48, 32, 32, 6)), 'walk-sheet-6x8.png');
+});

--- a/tools/split-gif/README.md
+++ b/tools/split-gif/README.md
@@ -199,6 +199,38 @@ the way out but still drawn on the way through: frame 40 depends on frames 1–3
 whether or not you wanted them. In the stored view they do not, so those frames
 are never touched at all.
 
+## The sprite sheet, and why it is one button rather than a mode
+
+Nothing but a GIF player can play a GIF. Every other thing that wants to show
+one - a game engine, a shader, a CSS `steps()` animation - wants the frames in
+a grid instead, plus the two numbers saying how to cut it. That is the whole
+feature: the same forward walk the ZIP export makes, painting each frame into
+its cell rather than encoding it on its own, so a sheet costs one working
+canvas plus the sheet and not four hundred frames at once.
+
+It is a second button and not a third option under "Each PNG holds", because it
+does not change what a frame *is* - it changes how many files come out. The
+frame settings still apply: keep every fifth frame and the sheet has a fifth as
+many cells; fill the transparency and every cell is filled.
+
+Three decisions worth recording:
+
+- **Always the composited view.** A sheet's cells have to share a size and a
+  grid, and a stored frame is a patch of its own size at its own offset. Laid
+  out in a grid those are unrelated rectangles that nothing could cut back up.
+  The page says so when the setting is on rather than ignoring it quietly.
+- **Nothing is scaled**, which is the tool's rule everywhere but matters most
+  here: resampling a sheet lays a hairline of the neighbouring cell down every
+  edge, and pixel art is what most of these GIFs are.
+- **The grid is in the filename** - `walk-sheet-6x8.png` - because the image
+  cannot carry it. Forty-eight cells in a 1536x512 sheet could be 6x8 or 12x4
+  and both look plausible; whatever reads the sheet has to be told, and a
+  filename is the one place the answer survives being emailed to somebody.
+
+`src/sheet.js` is the arithmetic on its own, so the cases with edges - a prime
+number of frames, one frame, a column count larger than the frame count - are
+testable without a canvas.
+
 ## Limitations
 
 - **No editing.** This takes a GIF apart; it does not put one back together.
@@ -213,6 +245,11 @@ are never touched at all.
 - **The plain-text extension is skipped.** It is a block of text the renderer of
   1990 was meant to draw in a grid of cells. Nothing has honoured it in thirty
   years, and drawing it would mean shipping a bitmap font.
+- **A sheet has a ceiling.** Past 16384 pixels on a side no browser will
+  allocate the canvas, and the tool refuses with the size it would have been.
+  Past 4096 a phone may hand back a blank sheet instead of an error, so that
+  one is said rather than enforced. Keeping every second frame is usually the
+  cheaper answer than a narrower grid.
 - **Frames are not deduplicated.** A GIF that stores the same picture twice comes
   out as two identical PNGs, because it is two frames.
 

--- a/tools/split-gif/body.html
+++ b/tools/split-gif/body.html
@@ -78,6 +78,7 @@
     <div class="export-row">
       <button type="button" id="download-all" class="primary">Download every frame as a ZIP</button>
       <button type="button" id="download-selected" class="ghost" hidden>Download the selected frames</button>
+      <button type="button" id="download-sheet" class="ghost">Download as one sprite sheet</button>
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
@@ -113,6 +114,12 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="sheet.drawing">Drawing the sheet&hellip;</span>
+    <span data-phrase="sheet.toobig">That sheet would be {width} by {height} pixels,
+      which no browser will draw. Keep every second frame instead, or save the
+      frames as a ZIP.</span>
+    <span data-phrase="sheet.stored">A sheet needs every cell the same size, so it
+      uses the frame as it appears rather than only the pixels a frame stores.</span>
     <span data-phrase="net.clean">your GIF has gone nowhere. {total} files
       loaded. {platform}</span>
     <span data-phrase="net.dirty">something contacted {hosts}, which this tool

--- a/tools/split-gif/src/main.js
+++ b/tools/split-gif/src/main.js
@@ -6,9 +6,10 @@ import { decodeGif, GifFormatError, playedDelay, totalDuration } from './gif.js'
 import { GifCanvas, flatten, parseColour, patchPixels } from './compose.js';
 import {
   disposalLabel, encodePng, formatBytes, formatSeconds,
-  frameName, thumbnail, timingList, zipName,
+  baseName, frameName, thumbnail, timingList, zipName,
 } from './frames.js';
 import { makeZip } from './shared/zip.js';
+import { cellAt, sheetName, sheetPlan } from './sheet.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -35,6 +36,7 @@ const el = {
   timing: $('timing'),
   downloadAll: $('download-all'),
   downloadSelected: $('download-selected'),
+  downloadSheet: $('download-sheet'),
   cancel: $('cancel'),
   progressWrap: $('progress-wrap'),
   progressBar: $('progress-bar'),
@@ -366,6 +368,106 @@ async function downloadOne(row) {
  * runs forward through the animation exactly once, so a long GIF costs memory
  * for one canvas plus the PNGs themselves.
  */
+/**
+ * Every kept frame on one sheet, in a grid.
+ *
+ * The same forward walk the ZIP export makes, painting each frame into its cell
+ * instead of encoding it on its own, so the cost is one working canvas plus the
+ * sheet rather than every frame at once - which is the whole reason `GifCanvas`
+ * exists and the one rule a sheet could easily have broken.
+ *
+ * Always the composited view. A sheet's cells have to be the same size and sit
+ * on the same grid, and a stored frame is a patch of its own size at its own
+ * offset; laying those out would produce a grid of unrelated rectangles that no
+ * sprite-sheet reader could cut back up. The page says so when it applies
+ * rather than silently ignoring the setting.
+ *
+ * `putImageData` rather than `drawImage`, because it writes the pixels through
+ * untouched: no smoothing, no compositing, no alpha applied twice. Cells do not
+ * overlap, so nothing is lost by skipping the blend - and a resampled sheet
+ * would put a hairline of the next cell down every edge, which is exactly what
+ * ruins pixel art.
+ */
+async function downloadSheet() {
+  if (working) return;
+
+  const options = settings();
+  const wanted = rows.filter((row) => row.checked);
+  const kept = wanted.length ? wanted : rows;
+  if (!kept.length) return;
+
+  const plan = sheetPlan(kept.length, gif.width, gif.height, 0);
+  if (plan.tooBig) {
+    showError(phrase('sheet.toobig', { width: plan.width, height: plan.height }));
+    return;
+  }
+
+  working = true;
+  cancelled = false;
+  clearError();
+  el.cancel.hidden = false;
+  el.downloadAll.disabled = true;
+  el.downloadSelected.disabled = true;
+  el.downloadSheet.disabled = true;
+
+  try {
+    const sheet = document.createElement('canvas');
+    sheet.width = plan.width;
+    sheet.height = plan.height;
+    const context = sheet.getContext('2d');
+
+    const picked = new Set(kept.map((row) => row.index));
+    const canvas = new GifCanvas(gif);
+    let done = 0;
+
+    for (const row of rows) {
+      if (cancelled) break;
+
+      // Every frame is drawn even when only every fifth is kept: frame 40 is
+      // frames 1 to 39 underneath it whether or not anybody asked for them.
+      const step = canvas.next();
+      if (!picked.has(row.index)) continue;
+
+      const pixels = step.pixels.slice();
+      if (options.colour) flatten(pixels, options.colour);
+
+      const { x, y } = cellAt(done, plan, gif.width, gif.height);
+      context.putImageData(new ImageData(pixels, gif.width, gif.height), x, y);
+
+      done += 1;
+      // The stored setting cannot apply to a sheet, and saying so while the
+      // sheet is drawing is the one moment somebody is looking at this line.
+      progress(done, kept.length,
+        options.stored ? phrase('sheet.stored') : phrase('sheet.drawing'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    if (cancelled) {
+      hideProgress();
+      return;
+    }
+
+    const blob = await new Promise((resolve, reject) => {
+      sheet.toBlob((made) => {
+        if (made) resolve(made);
+        else reject(new Error('This browser would not write a PNG.'));
+      }, 'image/png');
+    });
+    save(blob, sheetName(baseName(file.name), plan));
+    hideProgress();
+  } catch (error) {
+    hideProgress();
+    showError(`That sheet could not be written: ${error.message}`);
+  } finally {
+    working = false;
+    el.cancel.hidden = true;
+    el.downloadAll.disabled = false;
+    el.downloadSelected.disabled = false;
+    el.downloadSheet.disabled = false;
+  }
+}
+
+
 async function downloadZip(wanted) {
   if (working || !wanted.length) return;
 
@@ -544,6 +646,7 @@ el.clear.addEventListener('click', () => { reset(); clearError(); });
 
 el.downloadAll.addEventListener('click', () => downloadZip(rows));
 el.downloadSelected.addEventListener('click', () => downloadZip(rows.filter((row) => row.checked)));
+el.downloadSheet.addEventListener('click', () => downloadSheet());
 el.cancel.addEventListener('click', () => { cancelled = true; });
 
 window.addEventListener('beforeunload', (event) => {

--- a/tools/split-gif/src/sheet.js
+++ b/tools/split-gif/src/sheet.js
@@ -1,0 +1,101 @@
+/**
+ * Laying the frames out as one picture: a sprite sheet.
+ *
+ * A GIF is an animation that only a GIF player can play. Every engine that
+ * wants to show it - a game engine, a shader, a CSS `steps()` animation -
+ * wants the same thing instead: one image with the frames in a grid, plus the
+ * two numbers saying how the grid is cut. So this is the same forward walk the
+ * ZIP export already does, with each frame painted into a cell rather than
+ * encoded on its own.
+ *
+ * The geometry is here, away from the DOM and away from the canvas, because it
+ * is arithmetic with edges worth testing: a prime number of frames, a single
+ * frame, a column count somebody typed that is larger than the frame count,
+ * and the sizes that no browser will allocate.
+ *
+ * Cells are the size the GIF holds its frames at and nothing is scaled on the
+ * way in. That is the tool's existing rule - see "No resizing on the way out"
+ * in README.md - and it matters more here than anywhere else: a sprite sheet
+ * resampled by a hair puts a seam of a neighbouring frame's pixels down the
+ * edge of every cell, and pixel art is what most of these GIFs are.
+ */
+
+/**
+ * The largest side any of the three engines will allocate. Chrome and Safari
+ * both stop at 16384; Firefox goes further, and matching the lowest of the
+ * three is the only way a refusal here means the same thing everywhere.
+ */
+export const MAX_SIDE = 16384;
+
+/**
+ * Above this, a phone may refuse what a desktop allows. iOS Safari has long
+ * capped a canvas far below the desktop limit, and the failure is silent - a
+ * blank sheet rather than an error - so it is worth saying before rather than
+ * explaining after.
+ */
+export const CAUTION_SIDE = 4096;
+
+/**
+ * How many columns to suggest for a given number of frames.
+ *
+ * The squarest grid that holds them, because a sheet that is 300 cells wide
+ * and one tall is legal, useless to look at, and hits the side limit at a
+ * frame count the square version would not have. Ties go to the wider grid:
+ * screens are wider than they are tall, and so is every sheet anybody checks
+ * by eye.
+ */
+export function suggestColumns(count) {
+  if (count <= 0) return 0;
+  return Math.ceil(Math.sqrt(count));
+}
+
+/**
+ * The grid, and whether a browser will allocate it.
+ *
+ * Returns the shape of the sheet rather than drawing it, so the page can show
+ * the numbers - and the refusal - before anybody presses a button. `columns`
+ * is what the reader asked for; it is clamped rather than rejected, because a
+ * column count above the frame count means one row and that is a legitimate
+ * thing to want.
+ */
+export function sheetPlan(count, frameWidth, frameHeight, columns) {
+  const cells = Math.max(0, Math.floor(count));
+  const wanted = Math.floor(columns) > 0 ? Math.floor(columns) : suggestColumns(cells);
+  const cols = Math.max(1, Math.min(wanted, cells || 1));
+  const rows = cells > 0 ? Math.ceil(cells / cols) : 0;
+  const width = cols * frameWidth;
+  const height = rows * frameHeight;
+  return {
+    cells, columns: cols, rows, width, height,
+    // Two separate answers rather than one "ok". The first is a fact about
+    // every browser; the second is a warning about one, and a reader on a
+    // desktop should not be stopped by it.
+    tooBig: width > MAX_SIDE || height > MAX_SIDE,
+    risky: width > CAUTION_SIDE || height > CAUTION_SIDE,
+  };
+}
+
+/**
+ * Where one cell sits, in pixels, given its position in the sequence.
+ *
+ * Row-major - left to right, then down - which is the order every sprite-sheet
+ * consumer assumes and the order the frames were already in.
+ */
+export function cellAt(index, plan, frameWidth, frameHeight) {
+  return {
+    x: (index % plan.columns) * frameWidth,
+    y: Math.floor(index / plan.columns) * frameHeight,
+  };
+}
+
+/**
+ * The name the file goes out under.
+ *
+ * The grid is in the filename because the two numbers are not recoverable from
+ * the image: 48 cells in a 1536x512 sheet could be 6x8 or 12x4 and both look
+ * plausible. Whatever reads the sheet has to be told, and the filename is the
+ * one place the answer survives being emailed to somebody.
+ */
+export function sheetName(base, plan) {
+  return `${base}-sheet-${plan.columns}x${plan.rows}.png`;
+}


### PR DESCRIPTION
Adds a second export to **GIF Splitter**: every kept frame on one sheet, in a
grid, as a single PNG.

**Why.** Nothing but a GIF player can play a GIF. A game engine, a shader, a CSS
`steps()` animation all want the frames laid out in a grid plus the two numbers
saying how to cut it — the tool got people the frames and stopped one step
short, and that step is what the sprite-sheet threads on every forum are about.

### The decisions

- **A second button, not a third option** under "Each PNG holds". It does not
  change what a frame *is*, only how many files come out. The frame settings
  still apply — keep every fifth frame and the sheet has a fifth as many cells.
- **Always the composited view.** Cells must share a size and a grid; a stored
  frame is a patch of its own size at its own offset. The page says so while it
  draws rather than ignoring the setting quietly.
- **Nothing is scaled**, per the tool's existing rule, and it matters most here:
  a resampled sheet lays a hairline of the neighbouring cell down every edge,
  and pixel art is what most of these GIFs are.
- **The grid is in the filename** — `walk-sheet-6x8.png` — because the image
  cannot carry it. 48 cells in a 1536×512 sheet could be 6×8 or 12×4.
- **The memory rule holds.** It is the walk `GifCanvas` already makes, painting
  into a cell instead of encoding, so a sheet costs one working canvas plus the
  sheet — not every frame at once.
- **Two refusals.** Past 16384px a side no browser allocates the canvas; past
  4096px a phone may hand back a blank sheet, so that one is said, not enforced.

### All fifteen bodies together

`main.js` is copied byte for byte into every language and reads these ids, so a
locale body without them would not be a missing feature but a broken tool. The
button and phrases land in all fifteen at once, translated — using each
locale's own word for a frame (`幀` in zh-TW, `コマ` in ja, not the ones I would
have guessed), and the CJK phrases on one line each, since `phrase()` collapses
whitespace and a wrapped line ships as a hole mid-sentence.

### Verification

- `python build.py --out _plain --clean --no-minify` — exit 0
- `node --test "tests/js/*.test.js"` — 1930 pass, 0 fail (11 new)
- `python -m unittest discover -t . -s tests/python` — 425 pass
- `tests.python.test_accessibility` re-run after the final edits — 10 pass

Driven in a browser against the built site, not just tested: a six-frame 20×10
GIF built in the page produced a **60×20** sheet named `swatches-sheet-3x2.png`
with all six cells the correct colour in row-major order; the Japanese page
produced `コマ-sheet-2x2.png` with the translated button and no stray space in
the status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
