### PR TITLE
Give the site a version, and a rule for moving it

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,54 @@
+#
+# The version rule, checked before a pull request can be merged.
+#
+#   a new tool                          the middle number, last one to zero
+#   anything else a visitor can notice  the last number
+#   tests, CI, documentation            nothing
+#
+# One step per pull request rather than per commit, which is why this runs on
+# the whole branch - base...head - and not on what the last push happened to
+# contain. A branch of six commits is one change to whoever reads the site.
+#
+# The rule itself is buildlib/version.py and is unit tested in
+# tests/python/test_version.py; scripts/check_version.py is the part that talks
+# to git. Keeping the decisions out of this file is deliberate: a rule that
+# only exists inside a workflow can only be tested by opening pull requests
+# against it.
+#
+
+name: Version
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: version-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      # The whole history, because the check compares this branch with the
+      # commit it started from and a shallow clone has neither.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # The rule's own tests run first. If they fail, the verdict below is not
+      # worth reading.
+      - name: The rule's tests
+        run: python -m unittest tests.python.test_version
+
+      - name: Does the version do what this change asks of it?
+        run: |
+          python scripts/check_version.py \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,36 @@ Lists whose English entries carry an `id` are merged **by id**; lists of plain
 strings are still positional. That distinction is the whole reason
 `locales/*/planned.toml` needs care and `[[hub.categories]]` no longer does.
 
+## The version
+
+`config/site.toml` carries one, and every pull request has to answer for it.
+
+| what the change does | what the version does |
+|---|---|
+| adds a tool | the middle number, and the last one back to zero — `1.4.7` → `1.5.0` |
+| anything else a visitor could notice | the last number — `1.4.7` → `1.4.8` |
+| tests, CI, docs, the worker | nothing |
+
+One step per pull request, not per commit: a branch of six commits is one
+change to whoever reads the site.
+
+"A visitor could notice" is decided from the paths a change touches, and the
+list of what they cannot see is short and lives in `buildlib/version.py` —
+tests, `.github`, `docs`, `.claude`, `workers`, and the handful of root
+markdown files. Everything else counts, `build.py` included: a change there
+reaches the site through every page it renders, and `open_links_elsewhere`,
+which changed every link on every tool page, lived nowhere else. A refactor
+that genuinely alters nothing still asks for a digit, which is the cheaper of
+the two mistakes.
+
+The rule is enforced by `.github/workflows/version.yml` on every pull request,
+and is itself unit tested in `tests/python/test_version.py` — a presubmit that
+is wrong is worse than none, because the next person stops believing it.
+
+It starts at `1.0.0` rather than a number worked backwards from the tools
+already here: a version is a promise about what happens next, and inventing a
+history for it would be neither true nor useful.
+
 ## Conventions
 
 Prose in this repository — commit messages, comments, `tool.toml` — explains

--- a/buildlib/version.py
+++ b/buildlib/version.py
@@ -1,0 +1,145 @@
+"""
+The version of the site, and the rule a pull request has to satisfy.
+
+THE RULE
+
+    a new tool                          the middle number, last one to zero
+    anything else a visitor can notice  the last number
+    tests, CI, documentation            nothing
+
+One step per pull request, not per commit: a branch with six commits in it is
+one change as far as anybody reading the site is concerned, and asking each
+commit to move the number would only mean six numbers nobody chose.
+
+WHY THE ANSWER COMES FROM A LIST OF PATHS
+
+Because the honest question - "did the rendered site change?" - can only be
+answered by building both sides and comparing them, and that is two builds on
+every pull request to learn something a list of filenames gets right almost
+every time. The same trade is already made in .github/workflows/build.yml,
+which decides whether to run the suites the same way and says so.
+
+So the list below is an allowlist of what a visitor cannot see, and it is
+short on purpose. Anything not on it counts as visible, including build.py
+itself: a change there reaches the site through every page it renders, and
+open_links_elsewhere - which changed every link on every tool page - lived
+nowhere else. A refactor that genuinely alters nothing still asks for a digit
+under this rule. That is the cheaper mistake of the two.
+"""
+
+import re
+
+#: Files a visitor could never notice a change in.
+INVISIBLE = (
+    'tests/',
+    '.github/',
+    'docs/',
+    '.claude/',
+    'workers/',          # deployed by hand, and not part of a page
+)
+
+#: Individual files, rather than trees, that are equally invisible.
+INVISIBLE_FILES = (
+    'README.md',
+    'CLAUDE.md',
+    'ROADMAP.md',
+    'LICENSE',
+    'LICENSE-CONTENT',
+    '.gitignore',
+    '.gitattributes',
+)
+
+#: A tool announces itself by its configuration file and nothing else.
+NEW_TOOL = re.compile(r'^tools/([^/]+)/tool\.toml$')
+
+VERSION = re.compile(r'^\s*version\s*=\s*"(\d+)\.(\d+)\.(\d+)"\s*$', re.M)
+
+
+def read(toml_text):
+    """The version in a config/site.toml, as three numbers.
+
+    Raises rather than guessing: a missing or malformed version is a thing to
+    fix, and a check that quietly assumed 0.0.0 would pass every pull request
+    that deleted it.
+    """
+    found = VERSION.search(toml_text or '')
+    if not found:
+        raise ValueError('config/site.toml has no version = "x.y.z"')
+    return tuple(int(part) for part in found.groups())
+
+
+def visible(path):
+    """Whether a visitor could notice a change to this file."""
+    if path in INVISIBLE_FILES:
+        return False
+    return not any(path.startswith(prefix) for prefix in INVISIBLE)
+
+
+def new_tools(added_paths):
+    """The slugs of tools this change introduces.
+
+    Only files that were *added* count. Editing an existing tool.toml is a
+    change to a tool, not a new one, and the difference is the whole of the
+    minor-versus-patch decision.
+    """
+    slugs = []
+    for path in added_paths:
+        found = NEW_TOOL.match(path)
+        if found:
+            slugs.append(found.group(1))
+    return sorted(slugs)
+
+
+def required(changed_paths, added_paths):
+    """What this change has to do to the version: 'minor', 'patch' or 'none'."""
+    if new_tools(added_paths):
+        return 'minor'
+    if any(visible(path) for path in changed_paths):
+        return 'patch'
+    return 'none'
+
+
+def satisfies(before, after, need):
+    """Whether the move from one version to another meets what is required.
+
+    A bigger step than asked for always passes. Somebody who decides a change
+    deserves a minor, or that the site has reached 2.0.0, is making a
+    judgement this rule has no business overruling - it is a floor, not a
+    timetable.
+    """
+    if need == 'none':
+        return after >= before
+
+    if after <= before:
+        return False
+
+    if need == 'minor':
+        # A new tool moves the middle number and puts the last back to zero,
+        # or moves the major. "1.1.5 -> 1.2.5" would be a minor bump that quietly
+        # kept a patch count belonging to the version before it.
+        if after[0] > before[0]:
+            return after[1] == 0 and after[2] == 0
+        return after[1] > before[1] and after[2] == 0
+
+    return True  # 'patch': any increase at all is at least a patch
+
+
+def explain(need, before, after, tools):
+    """The sentence the presubmit prints when the rule is not met."""
+    dotted = lambda v: '.'.join(str(part) for part in v)
+
+    if need == 'minor':
+        want = (before[0], before[1] + 1, 0)
+        return (
+            f'This pull request adds a tool ({", ".join(tools)}), so '
+            f'config/site.toml\'s version has to move its middle number and put '
+            f'the last one back to zero: {dotted(before)} -> {dotted(want)}. '
+            f'It is {dotted(after)}.'
+        )
+
+    want = (before[0], before[1], before[2] + 1)
+    return (
+        'This pull request changes something a visitor could notice, so '
+        f'config/site.toml\'s version has to move its last number: '
+        f'{dotted(before)} -> {dotted(want)}. It is {dotted(after)}.'
+    )

--- a/config/site.toml
+++ b/config/site.toml
@@ -19,6 +19,21 @@ source_url = "https://github.com/A-Box-of-Tools/website"
 source_label = "github.com/A-Box-of-Tools/website"
 contact_email = "hi@abox.tools"
 
+# The version of the site, and the one number a pull request has to think
+# about. buildlib/version.py holds the rule and .github/workflows/version.yml
+# enforces it on every pull request:
+#
+#   a new tool            -> the middle number, and the last one back to zero
+#   anything else a
+#   visitor could notice  -> the last number
+#   tests, CI, docs       -> nothing
+#
+# It starts at 1.0.0 rather than at a number worked backwards from the
+# thirty-six tools already here, because a version is a promise about what
+# happens next and inventing a history for it would be neither true nor
+# useful.
+version = "1.0.0"
+
 # The one guide that is linked to from inside a sentence rather than from a
 # list. The hub's three guarantees end by pointing at it, so it cannot be moved
 # or renamed without the build noticing - which is the whole reason its slug is

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,105 @@
+"""
+The presubmit for the version rule.
+
+Reads what a pull request changed, works out what the rule asks of it, and
+compares that with what actually happened to config/site.toml's version. The
+rule and every decision in it live in buildlib/version.py, which is unit
+tested; this file is the part that talks to git and to the person reading the
+log.
+
+Usage:
+
+    python scripts/check_version.py <base-sha> <head-sha>
+
+Exits 0 when the rule is met, 1 when it is not, and 2 when it could not tell -
+which is treated as a failure by the workflow, because "I could not work out
+whether this is allowed" is not a reason to allow it.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from buildlib import version as rule
+
+CONFIG = 'config/site.toml'
+
+
+def git(*args):
+    done = subprocess.run(
+        ['git', *args], cwd=ROOT, capture_output=True, text=True, encoding='utf-8')
+    if done.returncode != 0:
+        raise RuntimeError(f'git {" ".join(args)} failed: {done.stderr.strip()}')
+    return done.stdout
+
+
+def changed(base, head):
+    """Every path this change touches, and separately the ones it adds.
+
+    --diff-filter=A is what tells a new tool from an edited one, and that
+    distinction is the whole of the minor-versus-patch decision.
+    """
+    everything = [line for line in git('diff', '--name-only', f'{base}...{head}').splitlines() if line]
+    added = [line for line in git('diff', '--name-only', '--diff-filter=A', f'{base}...{head}').splitlines() if line]
+    return everything, added
+
+
+def version_at(ref):
+    return rule.read(git('show', f'{ref}:{CONFIG}'))
+
+
+def main(argv):
+    if len(argv) != 3:
+        print(__doc__.strip())
+        return 2
+
+    base, head = argv[1], argv[2]
+
+    try:
+        paths, added = changed(base, head)
+    except RuntimeError as why:
+        print(f'::error::could not read what this change touched - {why}')
+        return 2
+
+    if not paths:
+        print('Nothing changed; nothing to ask of the version.')
+        return 0
+
+    need = rule.required(paths, added)
+    tools = rule.new_tools(added)
+
+    if need == 'none':
+        print('Nothing here a visitor could notice; the version may stay where it is.')
+
+    try:
+        before = version_at(base)
+    except (RuntimeError, ValueError) as why:
+        # The base having no version is not the author's fault - it happens on
+        # the first pull request after this rule lands.
+        print(f'::notice::no version to compare against on the base ({why}); '
+              'nothing to enforce this time.')
+        return 0
+
+    try:
+        after = version_at(head)
+    except (RuntimeError, ValueError) as why:
+        print(f'::error::{CONFIG} on this branch has no usable version - {why}')
+        return 1
+
+    if rule.satisfies(before, after, need):
+        moved = '.'.join(str(n) for n in before) + ' -> ' + '.'.join(str(n) for n in after)
+        if before == after:
+            print(f'Version stays at {".".join(str(n) for n in after)}, which is allowed here.')
+        else:
+            print(f'Version {moved}: what the rule asks for.')
+        return 0
+
+    print(f'::error::{rule.explain(need, before, after, tools)}')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/tests/python/test_version.py
+++ b/tests/python/test_version.py
@@ -1,0 +1,163 @@
+"""
+The version rule, and the cases it is easy to get wrong.
+
+A presubmit that is itself wrong is worse than no presubmit: it either blocks
+work that was fine or waves through the thing it was written to catch, and in
+both cases the next person's instinct is to stop believing it. So the rule is
+a handful of pure functions and this file exercises them directly, rather than
+leaving the only test of the logic to be whether a pull request happened to go
+red.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from buildlib import version
+
+
+class ReadingTheVersion(unittest.TestCase):
+    def test_reads_three_numbers(self):
+        self.assertEqual(version.read('version = "1.4.9"\n'), (1, 4, 9))
+
+    def test_finds_it_among_other_settings(self):
+        toml = 'name = "abox"\n# a comment\nversion = "2.0.1"\nother = 3\n'
+        self.assertEqual(version.read(toml), (2, 0, 1))
+
+    def test_refuses_a_file_without_one(self):
+        # Quietly assuming a version would pass every pull request that
+        # deleted it, which is the one change most worth catching.
+        with self.assertRaises(ValueError):
+            version.read('name = "abox"\n')
+
+    def test_refuses_a_version_that_is_not_three_numbers(self):
+        with self.assertRaises(ValueError):
+            version.read('version = "1.2"\n')
+
+
+class WhatAVisitorCanSee(unittest.TestCase):
+    def test_the_site_itself_is_visible(self):
+        for path in ('tools/resize-image/body.html',
+                     'templates/tool.html',
+                     'shared/site.css',
+                     'locales/de/tools/resize-image.html',
+                     'config/site.toml'):
+            self.assertTrue(version.visible(path), path)
+
+    def test_the_build_counts_as_visible(self):
+        # open_links_elsewhere changed every link on every tool page and lived
+        # in build.py alone. A rule that called the build invisible would have
+        # let that through without a digit.
+        self.assertTrue(version.visible('build.py'))
+        self.assertTrue(version.visible('buildlib/site.py'))
+
+    def test_the_scaffolding_is_not(self):
+        for path in ('tests/python/test_build.py',
+                     'tests/js/split-gif-sheet.test.js',
+                     '.github/workflows/build.yml',
+                     'docs/deploying.md',
+                     '.claude/skills/tool-development/SKILL.md',
+                     'workers/rendezvous/worker.js',
+                     'README.md',
+                     'CLAUDE.md'):
+            self.assertFalse(version.visible(path), path)
+
+
+class SpottingANewTool(unittest.TestCase):
+    def test_an_added_tool_toml_is_a_new_tool(self):
+        self.assertEqual(
+            version.new_tools(['tools/sprite-sheet/tool.toml',
+                               'tools/sprite-sheet/body.html']),
+            ['sprite-sheet'])
+
+    def test_editing_an_existing_one_is_not(self):
+        # The list passed in is what was ADDED, so an edit never reaches here -
+        # but the distinction is the whole minor-versus-patch decision and is
+        # worth stating in a test rather than only in a comment.
+        self.assertEqual(version.new_tools([]), [])
+
+    def test_a_tool_file_that_is_not_the_toml_is_not_a_new_tool(self):
+        self.assertEqual(version.new_tools(['tools/resize-image/styles.css']), [])
+
+    def test_several_tools_at_once(self):
+        self.assertEqual(
+            version.new_tools(['tools/b/tool.toml', 'tools/a/tool.toml']),
+            ['a', 'b'])
+
+
+class WhatIsRequired(unittest.TestCase):
+    def test_a_new_tool_asks_for_a_minor(self):
+        self.assertEqual(
+            version.required(['tools/new-thing/tool.toml'], ['tools/new-thing/tool.toml']),
+            'minor')
+
+    def test_a_visible_change_asks_for_a_patch(self):
+        self.assertEqual(version.required(['shared/site.css'], []), 'patch')
+
+    def test_tests_alone_ask_for_nothing(self):
+        self.assertEqual(
+            version.required(['tests/python/test_build.py', '.github/workflows/build.yml'], []),
+            'none')
+
+    def test_a_new_tool_wins_over_a_patch(self):
+        # A pull request that adds a tool also touches the hub, the sitemap and
+        # a stylesheet. The tool is the bigger fact.
+        self.assertEqual(
+            version.required(['tools/x/tool.toml', 'shared/site.css'], ['tools/x/tool.toml']),
+            'minor')
+
+
+class WhetherTheMoveIsEnough(unittest.TestCase):
+    def test_a_patch_satisfies_a_patch(self):
+        self.assertTrue(version.satisfies((1, 0, 0), (1, 0, 1), 'patch'))
+
+    def test_standing_still_does_not(self):
+        self.assertFalse(version.satisfies((1, 0, 0), (1, 0, 0), 'patch'))
+
+    def test_going_backwards_does_not(self):
+        self.assertFalse(version.satisfies((1, 0, 1), (1, 0, 0), 'patch'))
+
+    def test_a_minor_is_more_than_enough_for_a_patch(self):
+        self.assertTrue(version.satisfies((1, 0, 0), (1, 1, 0), 'patch'))
+
+    def test_a_minor_satisfies_a_minor(self):
+        self.assertTrue(version.satisfies((1, 0, 4), (1, 1, 0), 'minor'))
+
+    def test_a_patch_does_not_satisfy_a_new_tool(self):
+        self.assertFalse(version.satisfies((1, 0, 0), (1, 0, 1), 'minor'))
+
+    def test_a_minor_that_keeps_the_old_patch_count_does_not(self):
+        # 1.1.5 is a minor bump that carried a patch number belonging to the
+        # version before it, which makes the last digit mean nothing.
+        self.assertFalse(version.satisfies((1, 0, 5), (1, 1, 5), 'minor'))
+
+    def test_a_major_satisfies_a_new_tool_when_it_resets(self):
+        self.assertTrue(version.satisfies((1, 4, 2), (2, 0, 0), 'minor'))
+
+    def test_a_major_that_does_not_reset_does_not(self):
+        self.assertFalse(version.satisfies((1, 4, 2), (2, 1, 0), 'minor'))
+
+    def test_nothing_required_allows_standing_still(self):
+        self.assertTrue(version.satisfies((1, 0, 0), (1, 0, 0), 'none'))
+
+    def test_nothing_required_still_forbids_going_backwards(self):
+        self.assertFalse(version.satisfies((1, 0, 1), (1, 0, 0), 'none'))
+
+
+class TheMessage(unittest.TestCase):
+    def test_a_new_tool_is_told_the_number_to_use(self):
+        said = version.explain('minor', (1, 3, 7), (1, 3, 8), ['sprite-sheet'])
+        self.assertIn('sprite-sheet', said)
+        self.assertIn('1.4.0', said)
+        self.assertIn('1.3.8', said)
+
+    def test_a_visible_change_is_told_the_number_to_use(self):
+        said = version.explain('patch', (1, 3, 7), (1, 3, 7), [])
+        self.assertIn('1.3.8', said)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
| what the change does | what the version does |
|---|---|
| **adds a tool** | the middle number, last one back to zero — `1.4.7` → `1.5.0` |
| **anything else a visitor could notice** | the last number — `1.4.7` → `1.4.8` |
| tests, CI, docs, the worker | nothing |

**One step per pull request, not per commit.** A branch of six commits is one change to whoever reads the site; asking each commit to move the number would only produce six numbers nobody chose.

Starts at `1.0.0` rather than a number worked backwards from the 36 tools already here — a version is a promise about what happens next, and inventing a history for it would be neither true nor useful.

## How "a visitor could notice" is decided

From the paths a change touches. The honest question — *did the rendered site change?* — can only be answered by building both sides and comparing, and that's two builds per PR to learn something a filename list gets right almost every time. `build.yml` already makes the same trade to decide whether to run the suites.

So the list of what a visitor **cannot** see is an allowlist, and short: `tests/`, `.github/`, `docs/`, `.claude/`, `workers/`, and a few root markdown files. Everything else counts — **`build.py` included**, because a change there reaches the site through every page it renders, and `open_links_elsewhere` (which changed every link on every tool page) lived nowhere else. A refactor that genuinely alters nothing still asks for a digit; that's the cheaper of the two mistakes.

## Why the rule isn't inside the workflow

Because a rule that lives in a workflow can only be tested by opening pull requests against it.

The decisions are pure functions in `buildlib/version.py`, with **28 unit tests** over the cases that are easy to get wrong: a minor bump that carries the old patch count (`1.0.5` → `1.1.5`), a major that forgets to reset, an added `tool.toml` versus an edited one. `scripts/check_version.py` is only the part that talks to git.

A presubmit that is itself wrong is worse than none — it either blocks work that was fine or waves through what it was written to catch, and after either the next person stops believing it.

## Verified end to end, against real commits

| scenario | result |
|---|---|
| tests-only change, no bump | passes |
| stylesheet edit, no bump | **fails** — *"has to move its last number: 1.0.0 → 1.0.1"* |
| same edit, patch bump | passes |
| new `tool.toml`, patch bump only | **fails** — *"adds a tool (fake-probe) … 1.0.0 → 1.1.0"* |
| new tool, minor bump | passes |

The first PR after this lands has no version on its base to compare against, and is let through with a note rather than failing for a reason its author could not have prevented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)