### PR TITLE
Give amber the token the other two status colours already had

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -16,6 +16,11 @@
   --accent-deep: #1d4f83;
   --accent-pale: #d7e7f7;
   --danger: #b02b2b;
+  /* Amber, for something that needs attention without having failed. It is a
+     token for the reason the other two are: three tools had each grown their
+     own, every one of them picked against the dark ground, and every one of
+     them under the contrast floor on the light one. */
+  --warn: #8a5300;
   --ok: #1a6a43;
   --radius: 10px;
   --shadow: 0 1px 2px rgb(16 24 40 / 6%), 0 4px 12px rgb(16 24 40 / 4%);
@@ -34,6 +39,7 @@
     --accent-deep: #3772ab;
     --accent-pale: #cfe3f8;
     --danger: #e07777;
+    --warn: #c9923a;
     --ok: #6cc79b;
     --shadow: 0 1px 2px rgb(0 0 0 / 30%), 0 4px 12px rgb(0 0 0 / 20%);
   }

--- a/tools/gif-analyzer/styles.css
+++ b/tools/gif-analyzer/styles.css
@@ -113,12 +113,12 @@
 }
 
 .finding.bad { border-inline-start-color: var(--danger); }
-.finding.warn { border-inline-start-color: #c08a2b; }
+.finding.warn { border-inline-start-color: var(--warn); }
 .finding.note { border-inline-start-color: var(--accent); }
 
 .finding-mark { flex: none; font-size: 0.9rem; line-height: 1.5; }
 .finding.bad .finding-mark { color: var(--danger); }
-.finding.warn .finding-mark { color: #c08a2b; }
+.finding.warn .finding-mark { color: var(--warn); }
 .finding.note .finding-mark { color: var(--accent); }
 
 .finding strong { display: block; margin-bottom: 0.2rem; }

--- a/tools/id-photo/styles.css
+++ b/tools/id-photo/styles.css
@@ -463,10 +463,10 @@
 .check-good .check-mark { color: var(--ok); }
 
 .check-warn {
-  border-color: color-mix(in srgb, #c98a00 40%, var(--border));
-  background: color-mix(in srgb, #c98a00 8%, var(--surface));
+  border-color: color-mix(in srgb, var(--warn) 40%, var(--border));
+  background: color-mix(in srgb, var(--warn) 8%, var(--surface));
 }
-.check-warn .check-mark { color: #c98a00; }
+.check-warn .check-mark { color: var(--warn); }
 
 .check-bad {
   border-color: color-mix(in srgb, var(--danger) 38%, var(--border));

--- a/tools/password-generator/styles.css
+++ b/tools/password-generator/styles.css
@@ -169,7 +169,7 @@
 */
 .strength[data-rating="very-weak"] .verdict,
 .strength[data-rating="weak"] .verdict { color: var(--danger); }
-.strength[data-rating="fair"] .verdict { color: #b07d2b; }
+.strength[data-rating="fair"] .verdict { color: var(--warn); }
 .strength[data-rating="strong"] .verdict,
 .strength[data-rating="very-strong"] .verdict { color: var(--ok); }
 

--- a/tools/qr-barcode-reader/styles.css
+++ b/tools/qr-barcode-reader/styles.css
@@ -254,8 +254,8 @@ kbd {
   border-radius: 7px;
   font-size: 0.86rem;
   line-height: 1.55;
-  background: color-mix(in srgb, #c8860d 14%, var(--surface));
-  border: 1px solid color-mix(in srgb, #c8860d 45%, transparent);
+  background: color-mix(in srgb, var(--warn) 14%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, transparent);
 }
 
 .result-warnings li::before {

--- a/tools/redact-image/styles.css
+++ b/tools/redact-image/styles.css
@@ -342,8 +342,8 @@ kbd {
   margin-top: 0.7rem;
   padding: 0.55rem 0.75rem;
   border-radius: 7px;
-  border: 1px solid color-mix(in srgb, #c98a00 45%, transparent);
-  background: color-mix(in srgb, #c98a00 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, transparent);
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
   color: var(--text);
 }
 


### PR DESCRIPTION
First of the changes from the UI review. `--danger` and `--ok` are tokens with a value per theme; amber never was, so three tools each grew their own literal and each of them was tuned against the dark ground alone.

## The problem, measured

| Where | Was | Light | Dark |
|---|---|---|---|
| password-generator, "Fair" verdict | `#b07d2b` | **3.61** | 4.52 |
| gif-analyzer, warn mark | `#c08a2b` | **2.71** | 4.88 |
| id-photo, check mark | `#c98a00` | **2.73** | 5.03 |
| `--danger`, for comparison | token | 5.8–6.5 | 5.0–5.5 |

AA wants 4.5:1 for normal text. The password verdict is the one that counts: there the colour carries the judgement — "Fair" — on a page whose whole job is telling you whether a password is good enough, while "weak" and "strong" beside it sat at 6.5.

## The change

One `--warn` token in `tool-frame.css`: `#8a5300` light, `#c9923a` dark, picked to sit beside `--danger` in weight rather than to look bright. Ten call sites across five tools now point at it — the three text colours, plus the tint-and-border pairs in id-photo, qr-barcode-reader and redact-image that were mixing the same amber by hand.

`document-scanner`'s warn badge deliberately keeps its literal: it is white text on solid amber, so it needs a colour that stays dark in both themes — the opposite of what a token that must work as text can be.

## Verified in a browser, both themes

| | Before | After |
|---|---|---|
| password-generator "Fair" (light) | 3.61 | **6.33** |
| gif-analyzer warn mark (light) | 2.71 | **5.64** |
| id-photo check mark (light) | 2.73 | **5.64** |
| gif-analyzer warn mark (dark) | 4.88 | 5.41 |
| password-generator "Fair" (dark) | 4.52 | 5.96 |

Dark mode moves by a tenth or two; light mode is the fix.

Build exit 0, Python suite OK, JS suite 1935 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)