### PR TITLE
Leave one primary button on the passport photo page

### DIFF
--- a/locales/ar/tools/id-photo.html
+++ b/locales/ar/tools/id-photo.html
@@ -121,7 +121,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">اضبط الإطار على القاعدة</button>
+        <button type="button" id="fit-box" class="ghost">اضبط الإطار على القاعدة</button>
         <button type="button" id="reset-marks" class="ghost">جِد الوجه من جديد</button>
         <button type="button" id="whole-photo" class="ghost">أكبر إطار يتّسع</button>
       </div>

--- a/locales/de/tools/id-photo.html
+++ b/locales/de/tools/id-photo.html
@@ -126,7 +126,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Rahmen an die Vorschrift einpassen</button>
+        <button type="button" id="fit-box" class="ghost">Rahmen an die Vorschrift einpassen</button>
         <button type="button" id="reset-marks" class="ghost">Gesicht erneut suchen</button>
         <button type="button" id="whole-photo" class="ghost">Größter passender Rahmen</button>
       </div>

--- a/locales/es/tools/id-photo.html
+++ b/locales/es/tools/id-photo.html
@@ -124,7 +124,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Ajustar el recuadro a la norma</button>
+        <button type="button" id="fit-box" class="ghost">Ajustar el recuadro a la norma</button>
         <button type="button" id="reset-marks" class="ghost">Buscar la cara otra vez</button>
         <button type="button" id="whole-photo" class="ghost">El recuadro más grande que quepa</button>
       </div>

--- a/locales/fr/tools/id-photo.html
+++ b/locales/fr/tools/id-photo.html
@@ -128,7 +128,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Ajuster le cadre à la règle</button>
+        <button type="button" id="fit-box" class="ghost">Ajuster le cadre à la règle</button>
         <button type="button" id="reset-marks" class="ghost">Rechercher le visage</button>
         <button type="button" id="whole-photo" class="ghost">Le plus grand cadre possible</button>
       </div>

--- a/locales/hi/tools/id-photo.html
+++ b/locales/hi/tools/id-photo.html
@@ -126,7 +126,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">डिब्बे को नियम पर बिठाइए</button>
+        <button type="button" id="fit-box" class="ghost">डिब्बे को नियम पर बिठाइए</button>
         <button type="button" id="reset-marks" class="ghost">चेहरा फिर से ढूँढ़िए</button>
         <button type="button" id="whole-photo" class="ghost">जो सबसे बड़ा डिब्बा समा सके</button>
       </div>

--- a/locales/id/tools/id-photo.html
+++ b/locales/id/tools/id-photo.html
@@ -134,7 +134,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Paskan kotaknya ke aturan</button>
+        <button type="button" id="fit-box" class="ghost">Paskan kotaknya ke aturan</button>
         <button type="button" id="reset-marks" class="ghost">Cari wajahnya lagi</button>
         <button type="button" id="whole-photo" class="ghost">Kotak terbesar yang muat</button>
       </div>

--- a/locales/it/tools/id-photo.html
+++ b/locales/it/tools/id-photo.html
@@ -126,7 +126,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Adatta il riquadro alla norma</button>
+        <button type="button" id="fit-box" class="ghost">Adatta il riquadro alla norma</button>
         <button type="button" id="reset-marks" class="ghost">Cerca di nuovo il viso</button>
         <button type="button" id="whole-photo" class="ghost">Il riquadro più grande che ci sta</button>
       </div>

--- a/locales/ja/tools/id-photo.html
+++ b/locales/ja/tools/id-photo.html
@@ -112,7 +112,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">規定に合わせて枠を置く</button>
+        <button type="button" id="fit-box" class="ghost">規定に合わせて枠を置く</button>
         <button type="button" id="reset-marks" class="ghost">もう一度顔を探す</button>
         <button type="button" id="whole-photo" class="ghost">収まる最大の枠</button>
       </div>

--- a/locales/ko/tools/id-photo.html
+++ b/locales/ko/tools/id-photo.html
@@ -122,7 +122,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">규정에 맞춰 상자 맞추기</button>
+        <button type="button" id="fit-box" class="ghost">규정에 맞춰 상자 맞추기</button>
         <button type="button" id="reset-marks" class="ghost">얼굴 다시 찾기</button>
         <button type="button" id="whole-photo" class="ghost">들어가는 가장 큰 상자</button>
       </div>

--- a/locales/nl/tools/id-photo.html
+++ b/locales/nl/tools/id-photo.html
@@ -125,7 +125,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Kader passend maken op de regel</button>
+        <button type="button" id="fit-box" class="ghost">Kader passend maken op de regel</button>
         <button type="button" id="reset-marks" class="ghost">Zoek het gezicht opnieuw</button>
         <button type="button" id="whole-photo" class="ghost">Grootste kader dat past</button>
       </div>

--- a/locales/pt/tools/id-photo.html
+++ b/locales/pt/tools/id-photo.html
@@ -124,7 +124,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Ajustar o quadro à regra</button>
+        <button type="button" id="fit-box" class="ghost">Ajustar o quadro à regra</button>
         <button type="button" id="reset-marks" class="ghost">Procurar o rosto de novo</button>
         <button type="button" id="whole-photo" class="ghost">Maior quadro que couber</button>
       </div>

--- a/locales/tr/tools/id-photo.html
+++ b/locales/tr/tools/id-photo.html
@@ -131,7 +131,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Kutuyu kurala yerleştir</button>
+        <button type="button" id="fit-box" class="ghost">Kutuyu kurala yerleştir</button>
         <button type="button" id="reset-marks" class="ghost">Yüzü yeniden bul</button>
         <button type="button" id="whole-photo" class="ghost">Sığan en büyük kutu</button>
       </div>

--- a/locales/zh-TW/tools/id-photo.html
+++ b/locales/zh-TW/tools/id-photo.html
@@ -112,7 +112,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">按規定套用裁切框</button>
+        <button type="button" id="fit-box" class="ghost">按規定套用裁切框</button>
         <button type="button" id="reset-marks" class="ghost">重新找一次臉</button>
         <button type="button" id="whole-photo" class="ghost">能放下的最大框</button>
       </div>

--- a/locales/zh/tools/id-photo.html
+++ b/locales/zh/tools/id-photo.html
@@ -112,7 +112,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">按规定套用裁切框</button>
+        <button type="button" id="fit-box" class="ghost">按规定套用裁切框</button>
         <button type="button" id="reset-marks" class="ghost">重新找一次脸</button>
         <button type="button" id="whole-photo" class="ghost">能放下的最大框</button>
       </div>

--- a/tools/id-photo/body.html
+++ b/tools/id-photo/body.html
@@ -125,7 +125,7 @@
       </div>
 
       <div class="frame-actions">
-        <button type="button" id="fit-box" class="primary">Fit the box to the rule</button>
+        <button type="button" id="fit-box" class="ghost">Fit the box to the rule</button>
         <button type="button" id="reset-marks" class="ghost">Find the face again</button>
         <button type="button" id="whole-photo" class="ghost">Largest box that fits</button>
       </div>


### PR DESCRIPTION
Fourth of the changes from the UI review, and the smallest.

id-photo carried two `.primary` buttons. `Make the files` is the one the page exists for — correctly disabled until a photo is loaded. `Fit the box to the rule` is one of three crop-box helpers sitting together in `.frame-actions`, and the other two (`Find the face again`, `Largest box that fits`) are ghosts. The odd one out wore the filled accent colour, so during the part of the flow where you are adjusting the box, a helper competed with the button that finishes the job.

It is a ghost now, matching the two beside it.

Confirmed in the built page: the three helpers render identically (white ground, `#d9dee5` border) and exactly one filled button remains — `Make the files`, in accent blue.

Applied to the English body and all fourteen locale copies, since each carries its own markup. No text changes, no behaviour changes; `main.js` never referenced the class.

`test_build` and `test_accessibility`: 97 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)