### PR TITLE
Let a batch that is going the wrong way be stopped

### DIFF
--- a/locales/ar/tools/compress-image.html
+++ b/locales/ar/tools/compress-image.html
@@ -99,6 +99,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>اضغط إلى الحجم المطلوب</button>
+      <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -158,6 +159,8 @@
     <span data-phrase="format.resize.off">تحتفظ الصورة بأبعادها كاملة، فحجم مطلوب ضيّق لا بد أن يُدفع من الجودة وحدها.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; هذا المتصفح لا يدعمه</span>
 
+    <span data-phrase="progress.stopped.none">أُوقف قبل أن يكتمل الأول.</span>
+    <span data-phrase="progress.stopped">أُوقف بعد {done} من {total}. ما اكتمل موجود بالأسفل.</span>
     <span data-phrase="progress.at">{at} من {total}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">تُقرأ</span>
     <span data-phrase="step.decoding">يُفكّ ترميزها</span>

--- a/locales/ar/tools/heic-to-jpg.html
+++ b/locales/ar/tools/heic-to-jpg.html
@@ -81,6 +81,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>حوِّل</button>
+      <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
     <!--
@@ -114,6 +115,8 @@
     over the frame's one - see shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">أُوقف بعد {done} من {total}. ما اكتمل موجود بالأسفل.</span>
+    <span data-phrase="progress.stopped.none">أُوقف قبل أن يكتمل الأول.</span>
     <span data-phrase="offline.ready">جاهزة &mdash; وفاكُّ الترميز مخبَّأ
       كذلك، فهذا يعمل والشبكة مفصولة.</span>
 

--- a/locales/ar/tools/resize-image.html
+++ b/locales/ar/tools/resize-image.html
@@ -229,6 +229,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>غيّر حجم الصور</button>
+      <button type="button" id="cancel" class="ghost" hidden>ألغِ</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -282,6 +283,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">أُوقف بعد {done} من {total}. ما اكتمل موجود بالأسفل.</span>
+    <span data-phrase="progress.stopped.none">أُوقف قبل أن يكتمل الأول.</span>
     <span data-phrase="net.clean">صورك لم تذهب إلى أي مكان. {total} ملفاً
       حُمِّلت، كلها ملفات هذه الصفحة نفسها. {platform}</span>
     <span data-phrase="net.dirty">اتصل شيءٌ بـ {hosts}، وهو ما لا تفعله هذه

--- a/locales/de/tools/compress-image.html
+++ b/locales/de/tools/compress-image.html
@@ -103,6 +103,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Auf Zielgröße komprimieren</button>
+      <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -162,6 +163,8 @@
     <span data-phrase="format.resize.off">Das Bild behält seine vollen Abmessungen, eine enge Zielgröße muss also allein aus der Qualität bezahlt werden.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; von diesem Browser nicht unterstützt</span>
 
+    <span data-phrase="progress.stopped.none">Abgebrochen, bevor das erste fertig war.</span>
+    <span data-phrase="progress.stopped">Nach {done} von {total} abgebrochen. Was fertig wurde, steht unten.</span>
     <span data-phrase="progress.at">{at} von {total}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">wird gelesen</span>
     <span data-phrase="step.decoding">wird dekodiert</span>

--- a/locales/de/tools/heic-to-jpg.html
+++ b/locales/de/tools/heic-to-jpg.html
@@ -86,6 +86,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Umwandeln</button>
+      <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
     <!--
@@ -120,6 +121,8 @@
     shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Nach {done} von {total} abgebrochen. Was fertig wurde, steht unten.</span>
+    <span data-phrase="progress.stopped.none">Abgebrochen, bevor das erste fertig war.</span>
     <span data-phrase="offline.ready">bereit &mdash; der Decoder ist mit
       zwischengespeichert, das hier funktioniert also auch ohne
       Netzverbindung.</span>

--- a/locales/de/tools/resize-image.html
+++ b/locales/de/tools/resize-image.html
@@ -237,6 +237,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>Die Bilder skalieren</button>
+      <button type="button" id="cancel" class="ghost" hidden>Abbrechen</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -290,6 +291,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Nach {done} von {total} abgebrochen. Was fertig wurde, steht unten.</span>
+    <span data-phrase="progress.stopped.none">Abgebrochen, bevor das erste fertig war.</span>
     <span data-phrase="net.clean">Ihre Bilder sind nirgendwohin gegangen.
       {total} Dateien geladen, allesamt eigene dieser Seite. {platform}</span>
     <span data-phrase="net.dirty">Etwas hat {hosts} kontaktiert, und das tut

--- a/locales/es/tools/compress-image.html
+++ b/locales/es/tools/compress-image.html
@@ -102,6 +102,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Comprimir al objetivo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -161,6 +162,8 @@
     <span data-phrase="format.resize.off">La imagen conserva todas sus dimensiones, así que un objetivo ajustado hay que pagarlo solo con calidad.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; este navegador no lo admite</span>
 
+    <span data-phrase="progress.stopped.none">Detenido antes de terminar el primero.</span>
+    <span data-phrase="progress.stopped">Detenido tras {done} de {total}. Lo que se terminó está abajo.</span>
     <span data-phrase="progress.at">{at} de {total}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">leyendo</span>
     <span data-phrase="step.decoding">descodificando</span>

--- a/locales/es/tools/heic-to-jpg.html
+++ b/locales/es/tools/heic-to-jpg.html
@@ -84,6 +84,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Convertir</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
     <!--
@@ -117,6 +118,8 @@
     clave definida aquí gana a la del marco; véase shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Detenido tras {done} de {total}. Lo que se terminó está abajo.</span>
+    <span data-phrase="progress.stopped.none">Detenido antes de terminar el primero.</span>
     <span data-phrase="offline.ready">listo &mdash; el decodificador también
       queda en caché, así que esto funciona con la red desconectada.</span>
 

--- a/locales/es/tools/resize-image.html
+++ b/locales/es/tools/resize-image.html
@@ -233,6 +233,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>Redimensionar las imágenes</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -286,6 +287,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Detenido tras {done} de {total}. Lo que se terminó está abajo.</span>
+    <span data-phrase="progress.stopped.none">Detenido antes de terminar el primero.</span>
     <span data-phrase="net.clean">tus imágenes no han ido a ninguna parte.
       {total} archivos cargados, todos ellos de esta misma página. {platform}</span>
     <span data-phrase="net.dirty">algo ha contactado con {hosts}, cosa que esta

--- a/locales/fr/tools/compress-image.html
+++ b/locales/fr/tools/compress-image.html
@@ -102,6 +102,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Compresser à la taille visée</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -161,6 +162,8 @@
     <span data-phrase="format.resize.off">L&rsquo;image garde toutes ses dimensions : une taille serrée doit donc se payer sur la seule qualité.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; non pris en charge par ce navigateur</span>
 
+    <span data-phrase="progress.stopped.none">Arrêté avant que le premier soit terminé.</span>
+    <span data-phrase="progress.stopped">Arrêté après {done} sur {total}. Ce qui est terminé est ci-dessous.</span>
     <span data-phrase="progress.at">{at} sur {total} : {name} &mdash; {step}</span>
     <span data-phrase="step.reading">lecture</span>
     <span data-phrase="step.decoding">décodage</span>

--- a/locales/fr/tools/heic-to-jpg.html
+++ b/locales/fr/tools/heic-to-jpg.html
@@ -85,6 +85,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Convertir</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
     <!--
@@ -119,6 +120,8 @@
     cadre&nbsp;; voir shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Arrêté après {done} sur {total}. Ce qui est terminé est ci-dessous.</span>
+    <span data-phrase="progress.stopped.none">Arrêté avant que le premier soit terminé.</span>
     <span data-phrase="offline.ready">prêt &mdash; le décodeur est mis en cache
       lui aussi, donc ceci fonctionne sans réseau.</span>
 

--- a/locales/fr/tools/resize-image.html
+++ b/locales/fr/tools/resize-image.html
@@ -235,6 +235,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>Redimensionner les images</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuler</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -288,6 +289,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Arrêté après {done} sur {total}. Ce qui est terminé est ci-dessous.</span>
+    <span data-phrase="progress.stopped.none">Arrêté avant que le premier soit terminé.</span>
     <span data-phrase="net.clean">vos images ne sont allées nulle part. {total}
       fichiers chargés, tous appartenant à cette page. {platform}</span>
     <span data-phrase="net.dirty">quelque chose a contacté {hosts}, ce que cet

--- a/locales/hi/tools/compress-image.html
+++ b/locales/hi/tools/compress-image.html
@@ -101,6 +101,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>तय साइज़ तक कंप्रेस कीजिए</button>
+      <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -160,6 +161,8 @@
     <span data-phrase="format.resize.off">तस्वीर अपनी पूरी नाप बनाए रखती है, इसलिए तंग तय साइज़ की कीमत अकेली गुणवत्ता से चुकानी पड़ती है।</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; यह ब्राउज़र इसका समर्थन नहीं करता</span>
 
+    <span data-phrase="progress.stopped.none">पहला पूरा होने से पहले ही रोक दिया गया।</span>
+    <span data-phrase="progress.stopped">{total} में से {done} के बाद रोक दिया गया। जो पूरा हुआ वह नीचे है।</span>
     <span data-phrase="progress.at">{total} में से {at}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">पढ़ा जा रहा है</span>
     <span data-phrase="step.decoding">डिकोड हो रहा है</span>

--- a/locales/hi/tools/heic-to-jpg.html
+++ b/locales/hi/tools/heic-to-jpg.html
@@ -85,6 +85,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>बदलिए</button>
+      <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
     <!--
@@ -118,6 +119,8 @@
     कुंजी पर भारी पड़ती है - shared/js/phrases.js देखिए।
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">{total} में से {done} के बाद रोक दिया गया। जो पूरा हुआ वह नीचे है।</span>
+    <span data-phrase="progress.stopped.none">पहला पूरा होने से पहले ही रोक दिया गया।</span>
     <span data-phrase="offline.ready">तैयार &mdash; डिकोडर भी कैश में है, इसलिए
       नेटवर्क बंद होने पर भी यह चलता है।</span>
 

--- a/locales/hi/tools/resize-image.html
+++ b/locales/hi/tools/resize-image.html
@@ -235,6 +235,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>तस्वीरों का आकार बदलिए</button>
+      <button type="button" id="cancel" class="ghost" hidden>रद्द कीजिए</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -288,6 +289,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">{total} में से {done} के बाद रोक दिया गया। जो पूरा हुआ वह नीचे है।</span>
+    <span data-phrase="progress.stopped.none">पहला पूरा होने से पहले ही रोक दिया गया।</span>
     <span data-phrase="net.clean">आपकी तस्वीरें कहीं नहीं गईं। {total} फ़ाइलें
       लोड हुईं, और वे सब इसी साइट की अपनी हैं। {platform}</span>
     <span data-phrase="net.dirty">किसी चीज़ ने {hosts} से संपर्क किया, और यह टूल

--- a/locales/id/tools/compress-image.html
+++ b/locales/id/tools/compress-image.html
@@ -108,6 +108,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Kompres ke target</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -167,6 +168,8 @@
     <span data-phrase="format.resize.off">Gambarnya mempertahankan seluruh ukurannya, jadi target yang ketat harus dibayar dari kualitas saja.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; tidak didukung peramban ini</span>
 
+    <span data-phrase="progress.stopped.none">Dihentikan sebelum yang pertama selesai.</span>
+    <span data-phrase="progress.stopped">Dihentikan setelah {done} dari {total}. Yang sudah selesai ada di bawah.</span>
     <span data-phrase="progress.at">{at} dari {total}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">membaca</span>
     <span data-phrase="step.decoding">mendekode</span>

--- a/locales/id/tools/heic-to-jpg.html
+++ b/locales/id/tools/heic-to-jpg.html
@@ -94,6 +94,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Ubah</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
     <!--
@@ -127,6 +128,8 @@
     over the frame's one - see shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Dihentikan setelah {done} dari {total}. Yang sudah selesai ada di bawah.</span>
+    <span data-phrase="progress.stopped.none">Dihentikan sebelum yang pertama selesai.</span>
     <span data-phrase="offline.ready">siap &mdash; dekodernya ikut disinggahkan,
       jadi ini bekerja dengan jaringan tercabut.</span>
 

--- a/locales/id/tools/resize-image.html
+++ b/locales/id/tools/resize-image.html
@@ -243,6 +243,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>Ubah ukuran gambarnya</button>
+      <button type="button" id="cancel" class="ghost" hidden>Batalkan</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -296,6 +297,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Dihentikan setelah {done} dari {total}. Yang sudah selesai ada di bawah.</span>
+    <span data-phrase="progress.stopped.none">Dihentikan sebelum yang pertama selesai.</span>
     <span data-phrase="net.clean">gambar Anda tidak pergi ke mana pun. {total}
       file dimuat, semuanya milik halaman ini sendiri. {platform}</span>
     <span data-phrase="net.dirty">sesuatu menghubungi {hosts}, dan itu tidak

--- a/locales/it/tools/compress-image.html
+++ b/locales/it/tools/compress-image.html
@@ -102,6 +102,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Comprimi alla dimensione obiettivo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -161,6 +162,8 @@
     <span data-phrase="format.resize.off">L&rsquo;immagine tiene tutte le sue dimensioni, quindi un obiettivo stretto va pagato solo con la qualità.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; non supportato da questo browser</span>
 
+    <span data-phrase="progress.stopped.none">Fermato prima che il primo fosse finito.</span>
+    <span data-phrase="progress.stopped">Fermato dopo {done} di {total}. Quello che è stato finito è qui sotto.</span>
     <span data-phrase="progress.at">{at} di {total}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">lettura</span>
     <span data-phrase="step.decoding">decodifica</span>

--- a/locales/it/tools/heic-to-jpg.html
+++ b/locales/it/tools/heic-to-jpg.html
@@ -85,6 +85,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Converti</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
     <!--
@@ -119,6 +120,8 @@
     vedi shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Fermato dopo {done} di {total}. Quello che è stato finito è qui sotto.</span>
+    <span data-phrase="progress.stopped.none">Fermato prima che il primo fosse finito.</span>
     <span data-phrase="offline.ready">pronto &mdash; anche il decodificatore è
       in copia locale, quindi questo funziona con la rete staccata.</span>
 

--- a/locales/it/tools/resize-image.html
+++ b/locales/it/tools/resize-image.html
@@ -236,6 +236,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>Ridimensiona le immagini</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annulla</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -289,6 +290,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Fermato dopo {done} di {total}. Quello che è stato finito è qui sotto.</span>
+    <span data-phrase="progress.stopped.none">Fermato prima che il primo fosse finito.</span>
     <span data-phrase="net.clean">Le tue immagini non sono andate da nessuna
       parte. {total} file caricati, tutti quanti di questo sito. {platform}</span>
     <span data-phrase="net.dirty">Qualcosa ha contattato {hosts}, e questo

--- a/locales/ja/tools/compress-image.html
+++ b/locales/ja/tools/compress-image.html
@@ -93,6 +93,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>目標サイズまで圧縮</button>
+      <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -152,6 +153,8 @@
     <span data-phrase="format.resize.off">画像は元の寸法を保つので、厳しい目標サイズは画質だけで払うことになります。</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; このブラウザーは対応していません</span>
 
+    <span data-phrase="progress.stopped.none">最初の1件が終わる前に中止しました。</span>
+    <span data-phrase="progress.stopped">{total}件のうち{done}件で中止しました。できた分は下にあります。</span>
     <span data-phrase="progress.at">{total}件中{at}件目：{name} &mdash; {step}</span>
     <span data-phrase="step.reading">読み込み中</span>
     <span data-phrase="step.decoding">デコード中</span>

--- a/locales/ja/tools/heic-to-jpg.html
+++ b/locales/ja/tools/heic-to-jpg.html
@@ -73,6 +73,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>変換</button>
+      <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
     <!--
@@ -107,6 +108,8 @@
   -->
   <div id="phrases" hidden aria-hidden="true">
     <!-- 折り返さない。行頭の字下げが空白になって文の中に入ってしまう。 -->
+    <span data-phrase="progress.stopped">{total}件のうち{done}件で中止しました。できた分は下にあります。</span>
+    <span data-phrase="progress.stopped.none">最初の1件が終わる前に中止しました。</span>
     <span data-phrase="offline.ready">準備できました。デコーダーも一緒に保存されているので、ネットワークを抜いても動きます。</span>
 
     <span data-phrase="net.clean">写真はどこへも出ていません。{total}件のファイルを読み込み、そのすべてがこのサイト自身のものです。デコーダーもその中に入っています。{platform}</span>

--- a/locales/ja/tools/resize-image.html
+++ b/locales/ja/tools/resize-image.html
@@ -217,6 +217,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>画像をリサイズする</button>
+      <button type="button" id="cancel" class="ghost" hidden>中止</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -270,6 +271,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">{total}件のうち{done}件で中止しました。できた分は下にあります。</span>
+    <span data-phrase="progress.stopped.none">最初の1件が終わる前に中止しました。</span>
     <span data-phrase="net.clean">画像はどこへも出ていません。{total}件のファイルを読み込み、そのすべてがこのサイト自身のものです。{platform}</span>
     <span data-phrase="net.dirty">何かが{hosts}へ接続しました。この道具は決してそれをしません。調べてみる価値があります。{platform}</span>
     <span data-phrase="net.platform.one">広告・計測・寄付ボタンのためのサイト自身のスクリプトが{hosts}のホストから読み込まれました。そのどれにも、画像も、その1バイトも渡っていません。</span>

--- a/locales/ko/tools/compress-image.html
+++ b/locales/ko/tools/compress-image.html
@@ -100,6 +100,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>목표 용량으로 압축</button>
+      <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -159,6 +160,8 @@
     <span data-phrase="format.resize.off">그림은 원래 크기를 그대로 지키므로, 빠듯한 목표는 화질만으로 치러야 합니다.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; 이 브라우저는 지원하지 않습니다</span>
 
+    <span data-phrase="progress.stopped.none">첫 번째가 끝나기 전에 멈췄습니다.</span>
+    <span data-phrase="progress.stopped">{total}개 중 {done}개까지 하고 멈췄습니다. 끝난 것은 아래에 있습니다.</span>
     <span data-phrase="progress.at">{total}개 중 {at}번째: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">읽는 중</span>
     <span data-phrase="step.decoding">디코딩 중</span>

--- a/locales/ko/tools/heic-to-jpg.html
+++ b/locales/ko/tools/heic-to-jpg.html
@@ -83,6 +83,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>변환</button>
+      <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
     <!--
@@ -116,6 +117,8 @@
     이긴다 - shared/js/phrases.js 참고.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">{total}개 중 {done}개까지 하고 멈췄습니다. 끝난 것은 아래에 있습니다.</span>
+    <span data-phrase="progress.stopped.none">첫 번째가 끝나기 전에 멈췄습니다.</span>
     <span data-phrase="offline.ready">준비됨 &mdash; 디코더까지 함께 저장되므로
       네트워크를 뽑아도 동작합니다.</span>
 

--- a/locales/ko/tools/resize-image.html
+++ b/locales/ko/tools/resize-image.html
@@ -231,6 +231,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>이미지 크기 바꾸기</button>
+      <button type="button" id="cancel" class="ghost" hidden>취소</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -284,6 +285,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">{total}개 중 {done}개까지 하고 멈췄습니다. 끝난 것은 아래에 있습니다.</span>
+    <span data-phrase="progress.stopped.none">첫 번째가 끝나기 전에 멈췄습니다.</span>
     <span data-phrase="net.clean">이미지는 어디로도 가지 않았습니다. 파일 {total}개를 불러왔고 모두 이
       사이트의 것입니다. {platform}</span>
     <span data-phrase="net.dirty">무언가가 {hosts}에 접속했는데, 이 도구는 절대 그러지 않습니다. 살펴볼

--- a/locales/nl/tools/compress-image.html
+++ b/locales/nl/tools/compress-image.html
@@ -101,6 +101,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Comprimeren naar het doel</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -160,6 +161,8 @@
     <span data-phrase="format.resize.off">De afbeelding houdt zijn volle afmetingen, dus een krap doel moet helemaal uit de kwaliteit betaald worden.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; niet ondersteund door deze browser</span>
 
+    <span data-phrase="progress.stopped.none">Gestopt voordat de eerste af was.</span>
+    <span data-phrase="progress.stopped">Gestopt na {done} van {total}. Wat af is, staat hieronder.</span>
     <span data-phrase="progress.at">{at} van {total}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">lezen</span>
     <span data-phrase="step.decoding">decoderen</span>

--- a/locales/nl/tools/heic-to-jpg.html
+++ b/locales/nl/tools/heic-to-jpg.html
@@ -85,6 +85,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Omzetten</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
     <!--
@@ -118,6 +119,8 @@
     hier staat wint van die van het frame - zie shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Gestopt na {done} van {total}. Wat af is, staat hieronder.</span>
+    <span data-phrase="progress.stopped.none">Gestopt voordat de eerste af was.</span>
     <span data-phrase="offline.ready">klaar &mdash; de decoder is ook bewaard,
       dus dit werkt met de netwerkkabel eruit.</span>
 

--- a/locales/nl/tools/resize-image.html
+++ b/locales/nl/tools/resize-image.html
@@ -234,6 +234,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>De afbeeldingen schalen</button>
+      <button type="button" id="cancel" class="ghost" hidden>Annuleren</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -287,6 +288,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Gestopt na {done} van {total}. Wat af is, staat hieronder.</span>
+    <span data-phrase="progress.stopped.none">Gestopt voordat de eerste af was.</span>
     <span data-phrase="net.clean">Je afbeeldingen zijn nergens heen gegaan.
       {total} bestanden geladen, allemaal van deze site zelf. {platform}</span>
     <span data-phrase="net.dirty">Iets heeft {hosts} benaderd, en dat doet dit

--- a/locales/pt/tools/compress-image.html
+++ b/locales/pt/tools/compress-image.html
@@ -102,6 +102,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Comprimir até o alvo</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -161,6 +162,8 @@
     <span data-phrase="format.resize.off">A imagem mantém todas as suas dimensões, então um alvo apertado tem de ser pago só com qualidade.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; sem suporte neste navegador</span>
 
+    <span data-phrase="progress.stopped.none">Parado antes de o primeiro ficar pronto.</span>
+    <span data-phrase="progress.stopped">Parado depois de {done} de {total}. O que ficou pronto está abaixo.</span>
     <span data-phrase="progress.at">{at} de {total}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">lendo</span>
     <span data-phrase="step.decoding">decodificando</span>

--- a/locales/pt/tools/heic-to-jpg.html
+++ b/locales/pt/tools/heic-to-jpg.html
@@ -84,6 +84,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Converter</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
     <!--
@@ -117,6 +118,8 @@
     Uma chave definida aqui ganha da da moldura; veja shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Parado depois de {done} de {total}. O que ficou pronto está abaixo.</span>
+    <span data-phrase="progress.stopped.none">Parado antes de o primeiro ficar pronto.</span>
     <span data-phrase="offline.ready">pronto &mdash; o decodificador também
       fica em cache, então isto funciona com a rede desconectada.</span>
 

--- a/locales/pt/tools/resize-image.html
+++ b/locales/pt/tools/resize-image.html
@@ -233,6 +233,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>Redimensionar as imagens</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancelar</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -286,6 +287,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Parado depois de {done} de {total}. O que ficou pronto está abaixo.</span>
+    <span data-phrase="progress.stopped.none">Parado antes de o primeiro ficar pronto.</span>
     <span data-phrase="net.clean">As suas imagens não foram a lugar nenhum.
       {total} arquivos carregados, todos do próprio site. {platform}</span>
     <span data-phrase="net.dirty">Alguma coisa contatou {hosts}, e esta

--- a/locales/tr/tools/compress-image.html
+++ b/locales/tr/tools/compress-image.html
@@ -108,6 +108,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Hedefe sıkıştır</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -167,6 +168,8 @@
     <span data-phrase="format.resize.off">Görsel bütün ölçülerini korur, yani dar bir hedefin bedeli yalnızca kaliteden ödenir.</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; bu tarayıcı desteklemiyor</span>
 
+    <span data-phrase="progress.stopped.none">İlki bitmeden durduruldu.</span>
+    <span data-phrase="progress.stopped">{total} işten {done} tanesinden sonra durduruldu. Biten işler aşağıda.</span>
     <span data-phrase="progress.at">{total} içinden {at}: {name} &mdash; {step}</span>
     <span data-phrase="step.reading">okunuyor</span>
     <span data-phrase="step.decoding">çözülüyor</span>

--- a/locales/tr/tools/heic-to-jpg.html
+++ b/locales/tr/tools/heic-to-jpg.html
@@ -92,6 +92,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Dönüştür</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
     <!--
@@ -125,6 +126,8 @@
     over the frame's one - see shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">{total} işten {done} tanesinden sonra durduruldu. Bitenler aşağıda.</span>
+    <span data-phrase="progress.stopped.none">İlki bitmeden durduruldu.</span>
     <span data-phrase="offline.ready">hazır &mdash; çözücü de önbelleğe alındı,
       yani bu, ağ bağlantısı kesikken de çalışır.</span>
 

--- a/locales/tr/tools/resize-image.html
+++ b/locales/tr/tools/resize-image.html
@@ -238,6 +238,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>Görselleri boyutlandır</button>
+      <button type="button" id="cancel" class="ghost" hidden>Vazgeç</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -291,6 +292,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">{total} işten {done} tanesinden sonra durduruldu. Bitenler aşağıda.</span>
+    <span data-phrase="progress.stopped.none">İlki bitmeden durduruldu.</span>
     <span data-phrase="net.clean">görselleriniz hiçbir yere gitmedi. {total}
       dosya yüklendi, hepsi bu sayfanın kendi dosyaları. {platform}</span>
     <span data-phrase="net.dirty">bir şey {hosts} ile iletişim kurdu; bu araç

--- a/locales/zh-TW/tools/compress-image.html
+++ b/locales/zh-TW/tools/compress-image.html
@@ -98,6 +98,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>壓到這個大小</button>
+      <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -125,6 +126,8 @@
     with, and main.js, which can reach this block, resolves it.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">在 {total} 個裡完成 {done} 個之後停止。已完成的在下面。</span>
+    <span data-phrase="progress.stopped.none">在第一個完成之前就停止了。</span>
     <span data-phrase="size.bytes">{amount} 位元組</span>
     <span data-phrase="size.kb">{amount} KB</span>
     <span data-phrase="size.mb">{amount} MB</span>

--- a/locales/zh-TW/tools/heic-to-jpg.html
+++ b/locales/zh-TW/tools/heic-to-jpg.html
@@ -78,6 +78,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>轉換</button>
+      <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
     <!--
@@ -111,6 +112,8 @@
   -->
   <div id="phrases" hidden aria-hidden="true">
     <!-- 不要換行：行首的縮排會變成空格，落在句子中間。 -->
+    <span data-phrase="progress.stopped">在 {total} 個裡完成 {done} 個之後停止。已完成的在下面。</span>
+    <span data-phrase="progress.stopped.none">在第一個完成之前就停止了。</span>
     <span data-phrase="offline.ready">已就緒——解碼器也一起快取了，所以拔掉網線這一頁照樣能用。</span>
 
     <span data-phrase="net.clean">你的照片沒有去任何地方。載入了 {total} 個檔案，全都是本站自己的——解碼器也在其中。{platform}</span>

--- a/locales/zh-TW/tools/resize-image.html
+++ b/locales/zh-TW/tools/resize-image.html
@@ -222,6 +222,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>開始處理</button>
+      <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -275,6 +276,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">在 {total} 個裡完成 {done} 個之後停止。已完成的在下面。</span>
+    <span data-phrase="progress.stopped.none">在第一個完成之前就停止了。</span>
     <span data-phrase="net.clean">你的圖片沒有去任何地方。載入了 {total} 個檔案，全都是本站自己的。{platform}</span>
     <span data-phrase="net.dirty">有東西聯絡了 {hosts}，而這個工具從不這麼做。值得去查一查。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用於廣告、統計和捐贈按鈕的指令碼來自 {hosts} 個主機，它們誰也沒拿到圖片，或圖片裡的一個位元組。</span>

--- a/locales/zh/tools/compress-image.html
+++ b/locales/zh/tools/compress-image.html
@@ -98,6 +98,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>压到这个大小</button>
+      <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -157,6 +158,8 @@
     <span data-phrase="format.resize.off">图保持原来的尺寸，所以紧的目标只能从画质里出。</span>
     <span data-phrase="format.webp.unavailable">WebP &mdash; 这个浏览器不支持</span>
 
+    <span data-phrase="progress.stopped.none">在第一个完成之前就停止了。</span>
+    <span data-phrase="progress.stopped">在 {total} 个中的第 {done} 个之后停止。已完成的在下面。</span>
     <span data-phrase="progress.at">第 {at} 张，共 {total} 张：{name} &mdash; {step}</span>
     <span data-phrase="step.reading">正在读取</span>
     <span data-phrase="step.decoding">正在解码</span>

--- a/locales/zh/tools/heic-to-jpg.html
+++ b/locales/zh/tools/heic-to-jpg.html
@@ -78,6 +78,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>转换</button>
+      <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
     <!--
@@ -111,6 +112,8 @@
   -->
   <div id="phrases" hidden aria-hidden="true">
     <!-- 不要换行：行首的缩进会变成空格，落在句子中间。 -->
+    <span data-phrase="progress.stopped">在 {total} 个中的第 {done} 个之后停止。已完成的在下面。</span>
+    <span data-phrase="progress.stopped.none">在第一个完成之前就停止了。</span>
     <span data-phrase="offline.ready">已就绪——解码器也一起缓存了，所以拔掉网线这一页照样能用。</span>
 
     <span data-phrase="net.clean">你的照片没有去任何地方。加载了 {total} 个文件，全都是本站自己的——解码器也在其中。{platform}</span>

--- a/locales/zh/tools/resize-image.html
+++ b/locales/zh/tools/resize-image.html
@@ -222,6 +222,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>开始处理</button>
+      <button type="button" id="cancel" class="ghost" hidden>取消</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -275,6 +276,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">在 {total} 个中的第 {done} 个之后停止。已完成的在下面。</span>
+    <span data-phrase="progress.stopped.none">在第一个完成之前就停止了。</span>
     <span data-phrase="net.clean">你的图片没有去任何地方。加载了 {total} 个文件，全都是本站自己的。{platform}</span>
     <span data-phrase="net.dirty">有东西联系了 {hosts}，而这个工具从不这么做。值得去查一查。{platform}</span>
     <span data-phrase="net.platform.one">本站自己用于广告、统计和捐赠按钮的脚本来自 {hosts} 个主机，它们谁也没拿到图片，或图片里的一个字节。</span>

--- a/tools/compress-image/body.html
+++ b/tools/compress-image/body.html
@@ -100,6 +100,7 @@
 
     <div class="run-row">
       <button type="button" id="compress-all" class="primary big" disabled>Compress to the target</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -177,6 +178,8 @@
       The progress line, and the steps the search reports into it. Those arrive
       from compress.js as keys; the sentences they name are here.
     -->
+    <span data-phrase="progress.stopped.none">Stopped before the first one was finished.</span>
+    <span data-phrase="progress.stopped">Stopped after {done} of {total}. What was finished is below.</span>
     <span data-phrase="progress.at">{at} of {total}: {name} - {step}</span>
     <span data-phrase="step.reading">reading</span>
     <span data-phrase="step.decoding">decoding</span>

--- a/tools/compress-image/src/main.js
+++ b/tools/compress-image/src/main.js
@@ -45,6 +45,7 @@ const el = {
   allowResize: $('allow-resize'),
   formatNote: $('format-note'),
   compressAll: $('compress-all'),
+  cancel: $('cancel'),
   progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
@@ -72,6 +73,7 @@ const el = {
 let items = [];
 let nextId = 1;
 let busy = false;
+let stopping = false;
 
 /** Everything the run produced, kept so the rows can be redrawn and the zip
  *  built without compressing anything twice. */
@@ -375,22 +377,32 @@ el.compressAll.addEventListener('click', async () => {
   if (!target || !items.length || busy) return;
 
   busy = true;
+  stopping = false;
   clearResults();
   clearLoadError();
   render();
   el.progress.hidden = false;
+  el.cancel.hidden = false;
 
   const collected = [];
   const failures = [];
+  let stopped = false;
 
   try {
     for (const [index, item] of items.entries()) {
+      if (stopping) { stopped = true; break; }
       showProgress(index, items.length, item.file.name, 'step.reading');
       try {
         collected.push(await compressOne(item, target, (step, values) => {
+          // The search calls back between attempts, so Cancel is felt inside a
+          // picture rather than only between two of them - which on a large
+          // photograph is the difference between stopping and watching it
+          // finish.
+          if (stopping) throw new DOMException('Cancelled', 'AbortError');
           showProgress(index, items.length, item.file.name, step, values);
         }));
       } catch (error) {
+        if (error?.name === 'AbortError') { stopped = true; break; }
         // Through phrase() because compress.js throws the key of a sentence
         // when it gives up. Anything else - a real message from the encoder -
         // is a key phrase() does not know, and comes back out unchanged.
@@ -402,14 +414,28 @@ el.compressAll.addEventListener('click', async () => {
     }
   } finally {
     busy = false;
-    el.progress.hidden = true;
+    stopping = false;
+    el.cancel.hidden = true;
+    // Left up after a stop, so that pressing Cancel and watching the bar
+    // vanish does not read as nothing having happened.
+    el.progress.hidden = !stopped;
     render();
   }
 
+  if (stopped) {
+    el.progressLabel.textContent = collected.length
+      ? phrase('progress.stopped', { done: collected.length, total: items.length })
+      : phrase('progress.stopped.none');
+  }
   if (failures.length) showLoadError(failures.join('\n'));
+  // What finished is kept. One file per picture means a run stopped halfway
+  // still leaves half of them done, and dropping those would be taking work
+  // back off somebody who only asked it to stop.
   results = collected;
   showResults();
 });
+
+el.cancel.addEventListener('click', () => { stopping = true; });
 
 function showProgress(index, total, name, step, values) {
   const done = index / total;

--- a/tools/heic-to-jpg/body.html
+++ b/tools/heic-to-jpg/body.html
@@ -84,6 +84,7 @@
 
     <div class="run-row">
       <button type="button" id="convert-all" class="primary big" disabled>Convert</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
     <!--
@@ -117,6 +118,8 @@
     over the frame's one - see shared/js/phrases.js.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Stopped after {done} of {total}. What was finished is below.</span>
+    <span data-phrase="progress.stopped.none">Stopped before the first one was finished.</span>
     <span data-phrase="offline.ready">ready &mdash; the decoder is cached too,
       so this works with the network unplugged.</span>
 

--- a/tools/heic-to-jpg/src/main.js
+++ b/tools/heic-to-jpg/src/main.js
@@ -28,6 +28,7 @@ const el = {
   formatNote: $('format-note'),
   keepExif: $('keep-exif'),
   convertAll: $('convert-all'),
+  cancel: $('cancel'),
   engineStatus: $('engine-status'),
   progress: $('progress'),
   progressBar: $('progress-bar'),
@@ -69,6 +70,7 @@ const HEAD_BYTES = 256 * 1024;
 let items = [];
 let nextId = 1;
 let busy = false;
+let stopping = false;
 
 /** Everything the run produced, kept so the rows can be redrawn and the zip
  *  built without decoding anything twice. */
@@ -305,13 +307,16 @@ el.convertAll.addEventListener('click', async () => {
   if (!items.length || busy) return;
 
   busy = true;
+  stopping = false;
   clearResults();
   clearLoadError();
   render();
   el.progress.hidden = false;
+  el.cancel.hidden = false;
 
   const collected = [];
   const failures = [];
+  let stopped = false;
 
   try {
     // Waited for here, once, rather than inside the loop: the first photo
@@ -320,14 +325,20 @@ el.convertAll.addEventListener('click', async () => {
     await engine();
 
     for (const [index, item] of items.entries()) {
+      if (stopping) { stopped = true; break; }
       showProgress(index, items.length, item.file.name, 'reading');
       try {
         for (const result of await convertOne(item, (note) => {
+          // convertOne reports as it decodes, so a press of Cancel lands
+          // inside a photo rather than after it. The largest HEIC on a phone
+          // is the slowest single thing this site does.
+          if (stopping) throw new DOMException('Cancelled', 'AbortError');
           showProgress(index, items.length, item.file.name, note);
         })) {
           collected.push(result);
         }
       } catch (error) {
+        if (error?.name === 'AbortError') { stopped = true; break; }
         failures.push(`${item.file.name}: ${error.message}`);
       }
       // One turn of the event loop between photos, so the progress bar is a
@@ -338,14 +349,27 @@ el.convertAll.addEventListener('click', async () => {
     failures.push(error.message);
   } finally {
     busy = false;
-    el.progress.hidden = true;
+    stopping = false;
+    el.cancel.hidden = true;
+    // Left up after a stop, so pressing Cancel and watching the bar vanish
+    // does not read as nothing having happened.
+    el.progress.hidden = !stopped;
     render();
   }
 
+  if (stopped) {
+    el.progressLabel.textContent = collected.length
+      ? phrase('progress.stopped', { done: collected.length, total: items.length })
+      : phrase('progress.stopped.none');
+  }
   if (failures.length) showLoadError(failures.join('\n'));
+  // What finished is kept: one JPEG per photo means a run stopped halfway
+  // still leaves half of them converted.
   results = collected;
   showResults();
 });
+
+el.cancel.addEventListener('click', () => { stopping = true; });
 
 function showProgress(index, total, name, note) {
   el.progressBar.style.width = `${Math.round((index / total) * 100)}%`;

--- a/tools/resize-image/body.html
+++ b/tools/resize-image/body.html
@@ -231,6 +231,7 @@
 
     <div class="run-row">
       <button type="button" id="run" class="primary big" disabled>Resize the images</button>
+      <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
     <div id="progress" class="progress" hidden>
@@ -284,6 +285,8 @@
     a {name} is filled in by the caller.
   -->
   <div id="phrases" hidden aria-hidden="true">
+    <span data-phrase="progress.stopped">Stopped after {done} of {total}. What was finished is below.</span>
+    <span data-phrase="progress.stopped.none">Stopped before the first one was finished.</span>
     <span data-phrase="net.clean">your images have gone nowhere. {total} files
       loaded, all of them this page's own. {platform}</span>
     <span data-phrase="net.dirty">something contacted {hosts}, which this tool

--- a/tools/resize-image/src/main.js
+++ b/tools/resize-image/src/main.js
@@ -72,6 +72,7 @@ const el = {
   planSummary: $('plan-summary'),
 
   run: $('run'),
+  cancel: $('cancel'),
   progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
@@ -113,6 +114,7 @@ const el = {
 let items = [];
 let nextId = 1;
 let busy = false;
+let stopping = false;
 
 /** Which image the crop box is currently drawn on. Only the preview: every
  *  image carries its own box, so this decides what you are looking at and
@@ -842,16 +844,22 @@ el.run.addEventListener('click', async () => {
   if (!items.length || busy) return;
 
   busy = true;
+  stopping = false;
   clearResults();
   clearLoadError();
   render();
   el.progress.hidden = false;
+  el.cancel.hidden = false;
 
   const collected = [];
   const failures = [];
+  let stopped = false;
 
   try {
     for (const [index, item] of items.entries()) {
+      // Between pictures rather than inside one: a single resize is one draw
+      // and one encode, so the wait for the turn to end is not a wait.
+      if (stopping) { stopped = true; break; }
       showProgress(index, items.length, item.file.name);
       try {
         collected.push(await processOne(item));
@@ -864,14 +872,27 @@ el.run.addEventListener('click', async () => {
     }
   } finally {
     busy = false;
-    el.progress.hidden = true;
+    stopping = false;
+    el.cancel.hidden = true;
+    // Left up after a stop, so pressing Cancel and watching the bar vanish
+    // does not read as nothing having happened.
+    el.progress.hidden = !stopped;
     render();
   }
 
+  if (stopped) {
+    el.progressLabel.textContent = collected.length
+      ? phrase('progress.stopped', { done: collected.length, total: items.length })
+      : phrase('progress.stopped.none');
+  }
   if (failures.length) showLoadError(failures.join('\n'));
+  // What finished is kept: one file per picture means a run stopped halfway
+  // still leaves half of them done.
   results = collected;
   showResults();
 });
+
+el.cancel.addEventListener('click', () => { stopping = true; });
 
 function showProgress(index, total, name) {
   el.progressBar.style.width = `${Math.round((index / total) * 100)}%`;


### PR DESCRIPTION
Fifth of the changes from the UI review. Three tools showed a progress bar and gave you no way out of it: drop forty photographs into the compressor with the target set wrong and the only exit was closing the tab — which on this site also loses the list you just built. Their siblings (images-to-pdf, images-to-video, stack-images, gif-maker) have had Cancel all along, so this was a gap, not a decision.

## Where the check goes, and why it differs

| Tool | Cancel is felt | Why |
|---|---|---|
| compress-image | **inside a picture** | it searches for the best quality under the target and already calls back between attempts — on a 20 MP JPEG that is the difference between stopping and watching it finish |
| heic-to-jpg | **inside a photo** | same shape, and a large HEIC is the slowest single item on the site |
| resize-image | between pictures | one resize is a draw and an encode; waiting for the turn to end is not a wait |

## What finished is kept

images-to-pdf discards its work when stopped, and is right to — it builds **one** document, so half of it is nothing. These three write one file per picture, so six of thirty is six usable files. Taking those back from somebody who only asked the run to stop would be worse than useless.

The progress line stays up afterwards and says what happened:

- `Stopped after 6 of 30. What was finished is below.`
- `Stopped before the first one was finished.` — when nothing had completed, rather than pointing at an empty list

Both are phrases, in all fifteen languages, using the site's existing word for Cancel (`Abbrechen`, `Annuler`, `Vazgeç`, `中止`, …) taken from the tools that already had one.

## Verified by running real batches

Thirty generated photographs into compress-image, cancelled mid-run: stopped in under a second, `Stopped after 6 of 30`, six result rows kept, bar left on screen, button re-enabled. Fourteen into resize-image: `Stopped after 1 of 14`, results shown.

heic-to-jpg is wired identically and its button renders correctly (`#cancel` beside `#convert-all`, both phrases resolving), but its cancel path is **not** exercised here — nothing inside a page can forge a real HEIC to feed it. Worth a manual check with a phone photo before merging.

Python 461 OK, JS 1935 OK.

## Two notes

**Not in this PR:** image-to-ico, svg-to-image and id-photo also show progress without a cancel. Their run functions need restructuring first (no try/finally around `busy`, and progress strings still hardcoded in English), so they belong with the phrases work rather than here.

**Found on the way:** `zh-tw-sync.py` is not safe to re-run. It rewrites neighbouring lines it should not touch — `清單` → `列表`, which is the wrong side of the strait — and converts `个` to the archaic `箇`. The zh-TW lines here are written by hand for that reason, and the script deserves its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)