### PR TITLE
Show the whole job before asking for the file

### DIFF
--- a/locales/ar/tools/compare-text.html
+++ b/locales/ar/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> اقرأ ما تغيّر</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ar/tools/compress-image.html
+++ b/locales/ar/tools/compress-image.html
@@ -94,7 +94,7 @@
   </section>
 
   <!-- Step 3 &mdash; the one click -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> اضغط</h2>
 
     <div class="run-row">

--- a/locales/ar/tools/compress-pdf.html
+++ b/locales/ar/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- Step 2 &mdash; the screen this tool would keep if it could keep only one -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> انظر أين يقع الحجم</h2>
 
     <p class="card-lede">
@@ -40,7 +40,7 @@
   </section>
 
   <!-- Step 3 &mdash; how much to spend -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> قل بأي شدّة يُعصَر</h2>
 
     <p class="card-lede">
@@ -120,7 +120,7 @@
   </section>
 
   <!-- Step 4 &mdash; the one click -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> اضغط</h2>
 
     <div class="run-row">

--- a/locales/ar/tools/crop-video.html
+++ b/locales/ar/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Step 2 &mdash; the crop -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> اضبط الاقتصاص</h2>
 
     <p class="stage-hint">
@@ -81,7 +81,7 @@
   </section>
 
   <!-- Step 3 &mdash; the export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> اقتصصه</h2>
 
     <div class="settings">

--- a/locales/ar/tools/document-scanner.html
+++ b/locales/ar/tools/document-scanner.html
@@ -157,7 +157,7 @@
   </section>
 
   <!-- Step 4 &mdash; the file -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> احفظ المستند</h2>
 
     <p class="card-lede">

--- a/locales/ar/tools/edit-audio.html
+++ b/locales/ar/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Step 2 &mdash; the edits -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> غيّره</h2>
 
     <div class="edit-block">
@@ -128,7 +128,7 @@
   </section>
 
   <!-- Step 3 &mdash; the file that comes out -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> احفظه</h2>
 
     <div class="settings">

--- a/locales/ar/tools/encode-text.html
+++ b/locales/ar/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> خذ الناتج</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ar/tools/exif-editor.html
+++ b/locales/ar/tools/exif-editor.html
@@ -83,7 +83,7 @@
   </section>
 
   <!-- Step 3 &mdash; reading and editing -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> انظر في الداخل، وغيّر ما تشاء</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/ar/tools/format-json.html
+++ b/locales/ar/tools/format-json.html
@@ -113,7 +113,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> خذ الناتج</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ar/tools/gif-maker.html
+++ b/locales/ar/tools/gif-maker.html
@@ -148,7 +148,7 @@
   </section>
 
   <!-- Step 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> اصنع ملف GIF</h2>
 
     <div class="export-row">

--- a/locales/ar/tools/grab-frame.html
+++ b/locales/ar/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Step 2 &mdash; the moment -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> جِد الإطار</h2>
 
     <p class="stage-hint">
@@ -66,7 +66,7 @@
   </section>
 
   <!-- Step 3 &mdash; the still -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> خذ الصورة</h2>
 
     <div class="settings">
@@ -116,7 +116,7 @@
   </section>
 
   <!-- Step 4 &mdash; what came out -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> صورك</h2>
 
     <div class="toolbar">

--- a/locales/ar/tools/hash-checksum.html
+++ b/locales/ar/tools/hash-checksum.html
@@ -134,7 +134,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> افحصه في مقابل ما ينبغي أن يكون</h2>
     <p class="card-lede">
       الصق المجموع التحقّقي الذي أعطتك إياه صفحة التنزيل. والهيئة لا تهمّ

--- a/locales/ar/tools/heic-to-jpg.html
+++ b/locales/ar/tools/heic-to-jpg.html
@@ -76,7 +76,7 @@
   </section>
 
   <!-- Step 3 &mdash; the one click -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> حوِّل</h2>
 
     <div class="run-row">

--- a/locales/ar/tools/id-photo.html
+++ b/locales/ar/tools/id-photo.html
@@ -164,7 +164,7 @@
   </section>
 
   <!-- Step 5 &mdash; the files -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> احفظها</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/ar/tools/image-to-data-uri.html
+++ b/locales/ar/tools/image-to-data-uri.html
@@ -115,7 +115,7 @@
 
   <!-- Step 3 &mdash; the result. There is no button here on purpose: encoding
        is instant, so there is nothing for a "convert" press to wait for. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> انسخها</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/ar/tools/image-to-ico.html
+++ b/locales/ar/tools/image-to-ico.html
@@ -132,7 +132,7 @@
   </section>
 
   <!-- Step 3 &mdash; see it small, then take it -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> تحقّق منها بالحجم الذي سترى به</h2>
 
     <p class="card-lede">

--- a/locales/ar/tools/images-to-pdf.html
+++ b/locales/ar/tools/images-to-pdf.html
@@ -203,7 +203,7 @@
   </section>
 
   <!-- Step 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> أنشئ ملف PDF</h2>
 
     <div class="export-row">

--- a/locales/ar/tools/images-to-video.html
+++ b/locales/ar/tools/images-to-video.html
@@ -140,7 +140,7 @@
   </section>
 
   <!-- Step 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> أنشئ الفيديو</h2>
 
     <div class="export-row">

--- a/locales/ar/tools/merge-pdf.html
+++ b/locales/ar/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- Step 2 &mdash; the pages -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> رتّب الصفحات</h2>
 
     <p class="card-lede">
@@ -52,7 +52,7 @@
   </section>
 
   <!-- Step 3 &mdash; one file, or several -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> مستند واحد، أو عدة</h2>
 
     <fieldset class="presets-set">
@@ -122,7 +122,7 @@
   </section>
 
   <!-- Step 4 &mdash; the one click -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> ضُمَّه</h2>
 
     <div class="run-row">

--- a/locales/ar/tools/qr-barcode-reader.html
+++ b/locales/ar/tools/qr-barcode-reader.html
@@ -62,7 +62,7 @@
   </section>
 
   <!-- Step 2 &mdash; the answer -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> ماذا يقول</h2>
 
     <p class="card-lede">

--- a/locales/ar/tools/redact-image.html
+++ b/locales/ar/tools/redact-image.html
@@ -109,7 +109,7 @@
   </section>
 
   <!-- Step 3 &mdash; the file -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> احفظ النسخة المطموسة</h2>
 
     <p class="card-lede">

--- a/locales/ar/tools/redact-pdf.html
+++ b/locales/ar/tools/redact-pdf.html
@@ -16,7 +16,7 @@
   </section>
 
   <!-- Step 2 &mdash; finding it -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> قل ما الذي يجب أن يزول</h2>
 
     <p class="card-lede">
@@ -63,7 +63,7 @@
   </section>
 
   <!-- Step 3 &mdash; reading the page -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> اقرأ الصفحة، والتقط الكلمات منها</h2>
 
     <p class="card-lede">
@@ -87,7 +87,7 @@
   </section>
 
   <!-- Step 4 &mdash; doing it -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> أخرِج الكلمات</h2>
 
     <label class="check">

--- a/locales/ar/tools/resize-image.html
+++ b/locales/ar/tools/resize-image.html
@@ -191,7 +191,7 @@
   </section>
 
   <!-- Step 4 &mdash; the format, and the one click -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> احفظها</h2>
 
     <div class="settings">

--- a/locales/ar/tools/reverse-video.html
+++ b/locales/ar/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Step 2 &mdash; the reversal -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> اعكسه</h2>
 
     <div class="settings">

--- a/locales/ar/tools/split-gif.html
+++ b/locales/ar/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- Step 2 &mdash; what comes out -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> كيف تخرج الإطارات</h2>
 
     <div class="settings">
@@ -88,7 +88,7 @@
   </section>
 
   <!-- Step 3 &mdash; the frames themselves -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> الإطارات</h2>
 
     <div class="toolbar">

--- a/locales/ar/tools/stack-images.html
+++ b/locales/ar/tools/stack-images.html
@@ -141,7 +141,7 @@
   </section>
 
   <!-- الخطوة 3 &mdash; التشغيل -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> كدّس</h2>
 
     <div class="export-row">

--- a/locales/ar/tools/svg-to-image.html
+++ b/locales/ar/tools/svg-to-image.html
@@ -165,7 +165,7 @@
   </section>
 
   <!-- Step 4 &mdash; look at it, then take it -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> انظر إليه، ثم احفظه</h2>
 
     <p class="card-lede">

--- a/locales/ar/tools/timelapse-video.html
+++ b/locales/ar/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Step 2 &mdash; the speed -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> اختر السرعة</h2>
 
     <div class="speed-row" role="group" aria-label="كم يُسرَّع المقطع">
@@ -109,7 +109,7 @@
   </section>
 
   <!-- Step 3 &mdash; the export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> اصنع التايم لابس</h2>
 
     <dl class="summary" id="summary">

--- a/locales/ar/tools/trim-audio.html
+++ b/locales/ar/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Step 2 &mdash; the marks -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> علّم على الأجزاء التي تريدها
       <span class="editing" id="editing" hidden></span>
@@ -135,7 +135,7 @@
   </section>
 
   <!-- Step 3 &mdash; the file that comes out -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> قُصّه</h2>
 
     <div class="settings">

--- a/locales/ar/tools/trim-video.html
+++ b/locales/ar/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Step 2 &mdash; the marks -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> علّم على الأجزاء التي تريدها
       <span class="editing" id="editing" hidden></span>
@@ -138,7 +138,7 @@
   </section>
 
   <!-- Step 3 &mdash; the export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> قُصّه</h2>
 
     <div class="settings">

--- a/locales/ar/tools/video-to-gif.html
+++ b/locales/ar/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Step 2 &mdash; the section -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> اختر المقطع</h2>
 
     <p class="hint">
@@ -71,7 +71,7 @@
   </section>
 
   <!-- Step 3 &mdash; the GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> المقاس ومعدّل الإطارات</h2>
 
     <div class="settings">

--- a/locales/de/tools/compare-text.html
+++ b/locales/de/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Lesen, was sich geändert hat</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/de/tools/compress-image.html
+++ b/locales/de/tools/compress-image.html
@@ -98,7 +98,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; der eine Klick -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Komprimieren</h2>
 
     <div class="run-row">

--- a/locales/de/tools/compress-pdf.html
+++ b/locales/de/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; der Bildschirm, den dieses Werkzeug behalten würde, wenn es nur einen behalten dürfte -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> Sehen, wo die Größe steckt</h2>
 
     <p class="card-lede">
@@ -42,7 +42,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; wie viel ausgegeben werden darf -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Sagen, wie stark gepresst wird</h2>
 
     <p class="card-lede">
@@ -124,7 +124,7 @@
   </section>
 
   <!-- Schritt 4 &mdash; der eine Klick -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Komprimieren</h2>
 
     <div class="run-row">

--- a/locales/de/tools/crop-video.html
+++ b/locales/de/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; der Zuschnitt -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Den Zuschnitt festlegen</h2>
 
     <p class="stage-hint">
@@ -82,7 +82,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; der Export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Zuschneiden</h2>
 
     <div class="settings">

--- a/locales/de/tools/document-scanner.html
+++ b/locales/de/tools/document-scanner.html
@@ -173,7 +173,7 @@
   </section>
 
   <!-- Schritt 4 &mdash; die Datei -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Dokument speichern</h2>
 
     <p class="card-lede">

--- a/locales/de/tools/edit-audio.html
+++ b/locales/de/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; die Bearbeitung -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Verändern</h2>
 
     <div class="edit-block">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; die Datei, die herauskommt -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Speichern</h2>
 
     <div class="settings">

--- a/locales/de/tools/encode-text.html
+++ b/locales/de/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Das Ergebnis mitnehmen</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/de/tools/exif-editor.html
+++ b/locales/de/tools/exif-editor.html
@@ -86,7 +86,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; lesen und bearbeiten -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> Hineinsehen und ändern, was Sie möchten</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/de/tools/format-json.html
+++ b/locales/de/tools/format-json.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Das Ergebnis mitnehmen</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/de/tools/gif-maker.html
+++ b/locales/de/tools/gif-maker.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; Ausgabe -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Das GIF erstellen</h2>
 
     <div class="export-row">

--- a/locales/de/tools/grab-frame.html
+++ b/locales/de/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; die Stelle -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Das Einzelbild finden</h2>
 
     <p class="stage-hint">
@@ -67,7 +67,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; das Standbild -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Das Standbild nehmen</h2>
 
     <div class="settings">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- Schritt 4 &mdash; was herausgekommen ist -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Ihre Standbilder</h2>
 
     <div class="toolbar">

--- a/locales/de/tools/hash-checksum.html
+++ b/locales/de/tools/hash-checksum.html
@@ -136,7 +136,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Gegen den erwarteten Wert prüfen</h2>
     <p class="card-lede">
       Fügen Sie die Prüfsumme ein, die die Downloadseite Ihnen gegeben hat. Die Form

--- a/locales/de/tools/heic-to-jpg.html
+++ b/locales/de/tools/heic-to-jpg.html
@@ -81,7 +81,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; der eine Klick -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Umwandeln</h2>
 
     <div class="run-row">

--- a/locales/de/tools/id-photo.html
+++ b/locales/de/tools/id-photo.html
@@ -170,7 +170,7 @@
   </section>
 
   <!-- Schritt 5 &mdash; die Dateien -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Speichern</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/de/tools/image-to-data-uri.html
+++ b/locales/de/tools/image-to-data-uri.html
@@ -120,7 +120,7 @@
   <!-- Schritt 3 &mdash; das Ergebnis. Hier gibt es mit Absicht keine
        Schaltfläche: Das Kodieren ist sofort fertig, es gibt also nichts,
        worauf ein Klick auf "Umwandeln" warten müsste. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Kopieren</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/de/tools/image-to-ico.html
+++ b/locales/de/tools/image-to-ico.html
@@ -138,7 +138,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; klein ansehen, dann nehmen -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> In der Größe prüfen, in der es zu sehen sein wird</h2>
 
     <p class="card-lede">

--- a/locales/de/tools/images-to-pdf.html
+++ b/locales/de/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; Export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Das PDF erzeugen</h2>
 
     <div class="export-row">

--- a/locales/de/tools/images-to-video.html
+++ b/locales/de/tools/images-to-video.html
@@ -141,7 +141,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; Export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Das Video erzeugen</h2>
 
     <div class="export-row">

--- a/locales/de/tools/merge-pdf.html
+++ b/locales/de/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; die Seiten -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Die Seiten anordnen</h2>
 
     <p class="card-lede">
@@ -53,7 +53,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; ein Dokument oder mehrere -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> Ein Dokument oder mehrere</h2>
 
     <fieldset class="presets-set">
@@ -125,7 +125,7 @@
   </section>
 
   <!-- Schritt 4 &mdash; der eine Klick -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Zusammensetzen</h2>
 
     <div class="run-row">

--- a/locales/de/tools/qr-barcode-reader.html
+++ b/locales/de/tools/qr-barcode-reader.html
@@ -65,7 +65,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; die Antwort -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> Was darin steht</h2>
 
     <p class="card-lede">

--- a/locales/de/tools/redact-image.html
+++ b/locales/de/tools/redact-image.html
@@ -117,7 +117,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; die Datei -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Die geschwärzte Kopie speichern</h2>
 
     <p class="card-lede">

--- a/locales/de/tools/redact-pdf.html
+++ b/locales/de/tools/redact-pdf.html
@@ -26,7 +26,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; finden -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Sagen, was weg muss</h2>
 
     <p class="card-lede">
@@ -75,7 +75,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; die Seite lesen -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> Die Seite lesen und Wörter herauspicken</h2>
 
     <p class="card-lede">
@@ -101,7 +101,7 @@
   </section>
 
   <!-- Schritt 4 &mdash; tun -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Die Wörter entfernen</h2>
 
     <label class="check">

--- a/locales/de/tools/resize-image.html
+++ b/locales/de/tools/resize-image.html
@@ -197,7 +197,7 @@
   </section>
 
   <!-- Schritt 4 &mdash; das Format und der eine Klick -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Speichern</h2>
 
     <div class="settings">

--- a/locales/de/tools/reverse-video.html
+++ b/locales/de/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; die Umkehrung -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Umkehren</h2>
 
     <div class="settings">

--- a/locales/de/tools/split-gif.html
+++ b/locales/de/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; was herauskommt -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> Wie die Einzelbilder herauskommen</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; die Einzelbilder selbst -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> Die Einzelbilder</h2>
 
     <div class="toolbar">

--- a/locales/de/tools/stack-images.html
+++ b/locales/de/tools/stack-images.html
@@ -143,7 +143,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; laufen lassen -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Stacken</h2>
 
     <div class="export-row">

--- a/locales/de/tools/svg-to-image.html
+++ b/locales/de/tools/svg-to-image.html
@@ -169,7 +169,7 @@
   </section>
 
   <!-- Schritt 4 &mdash; ansehen, dann nehmen -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Ansehen, dann speichern</h2>
 
     <p class="card-lede">

--- a/locales/de/tools/timelapse-video.html
+++ b/locales/de/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; das Tempo -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Das Tempo wählen</h2>
 
     <div class="speed-row" role="group" aria-label="Um wie viel der Clip beschleunigt wird">
@@ -111,7 +111,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; die Ausgabe -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Zeitraffer erstellen</h2>
 
     <dl class="summary" id="summary">

--- a/locales/de/tools/trim-audio.html
+++ b/locales/de/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; die Marken -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Die gewünschten Teile markieren
       <span class="editing" id="editing" hidden></span>
@@ -138,7 +138,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; die Datei, die herauskommt -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Schneiden</h2>
 
     <div class="settings">

--- a/locales/de/tools/trim-video.html
+++ b/locales/de/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; die Markierungen -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Die gewünschten Teile markieren
       <span class="editing" id="editing" hidden></span>
@@ -141,7 +141,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; der Export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Schneiden</h2>
 
     <div class="settings">

--- a/locales/de/tools/video-to-gif.html
+++ b/locales/de/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Schritt 2 &mdash; der Abschnitt -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Den Abschnitt festlegen</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Schritt 3 &mdash; das GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Größe und Bildrate</h2>
 
     <div class="settings">

--- a/locales/es/tools/compare-text.html
+++ b/locales/es/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Lee qué cambió</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/es/tools/compress-image.html
+++ b/locales/es/tools/compress-image.html
@@ -97,7 +97,7 @@
   </section>
 
   <!-- Paso 3 &mdash; el único clic -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Comprimir</h2>
 
     <div class="run-row">

--- a/locales/es/tools/compress-pdf.html
+++ b/locales/es/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- Paso 2 &mdash; la pantalla que esta herramienta conservaría si solo pudiera conservar una -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> Mira dónde está el tamaño</h2>
 
     <p class="card-lede">
@@ -42,7 +42,7 @@
   </section>
 
   <!-- Paso 3 &mdash; cuánto gastar -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Di cuánto hay que apretar</h2>
 
     <p class="card-lede">
@@ -124,7 +124,7 @@
   </section>
 
   <!-- Paso 4 &mdash; el único clic -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Comprimir</h2>
 
     <div class="run-row">

--- a/locales/es/tools/crop-video.html
+++ b/locales/es/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Paso 2 &mdash; el recorte -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Define el recorte</h2>
 
     <p class="stage-hint">
@@ -81,7 +81,7 @@
   </section>
 
   <!-- Paso 3 &mdash; la exportación -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Recórtalo</h2>
 
     <div class="settings">

--- a/locales/es/tools/document-scanner.html
+++ b/locales/es/tools/document-scanner.html
@@ -171,7 +171,7 @@
   </section>
 
   <!-- Paso 4 &mdash; el archivo -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Guarda el documento</h2>
 
     <p class="card-lede">

--- a/locales/es/tools/edit-audio.html
+++ b/locales/es/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Paso 2 &mdash; las ediciones -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Cámbialo</h2>
 
     <div class="edit-block">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- Paso 3 &mdash; el archivo que sale -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Guárdalo</h2>
 
     <div class="settings">

--- a/locales/es/tools/encode-text.html
+++ b/locales/es/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Llévate el resultado</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/es/tools/exif-editor.html
+++ b/locales/es/tools/exif-editor.html
@@ -85,7 +85,7 @@
   </section>
 
   <!-- Paso 3 &mdash; leer y editar -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> Mira dentro y cambia lo que quieras</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/es/tools/format-json.html
+++ b/locales/es/tools/format-json.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Llévate el resultado</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/es/tools/gif-maker.html
+++ b/locales/es/tools/gif-maker.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- Paso 3 &mdash; exportar -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Haz el GIF</h2>
 
     <div class="export-row">

--- a/locales/es/tools/grab-frame.html
+++ b/locales/es/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Paso 2 &mdash; el momento -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Encuentra el fotograma</h2>
 
     <p class="stage-hint">
@@ -67,7 +67,7 @@
   </section>
 
   <!-- Paso 3 &mdash; la imagen -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Saca la imagen</h2>
 
     <div class="settings">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- Paso 4 &mdash; lo que ha salido -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Tus imágenes</h2>
 
     <div class="toolbar">

--- a/locales/es/tools/hash-checksum.html
+++ b/locales/es/tools/hash-checksum.html
@@ -135,7 +135,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Compáralo con lo que debería ser</h2>
     <p class="card-lede">
       Pega el checksum que te dio la página de descarga. La forma da igual:

--- a/locales/es/tools/heic-to-jpg.html
+++ b/locales/es/tools/heic-to-jpg.html
@@ -79,7 +79,7 @@
   </section>
 
   <!-- Paso 3 &mdash; el único clic -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Convertir</h2>
 
     <div class="run-row">

--- a/locales/es/tools/id-photo.html
+++ b/locales/es/tools/id-photo.html
@@ -168,7 +168,7 @@
   </section>
 
   <!-- Paso 5 &mdash; los archivos -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Guárdalo</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/es/tools/image-to-data-uri.html
+++ b/locales/es/tools/image-to-data-uri.html
@@ -118,7 +118,7 @@
 
   <!-- Paso 3 &mdash; el resultado. Aquí no hay botón a propósito: la codificación
        es instantánea, así que no hay nada que un botón de «convertir» pudiera esperar. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Cópialo</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/es/tools/image-to-ico.html
+++ b/locales/es/tools/image-to-ico.html
@@ -137,7 +137,7 @@
   </section>
 
   <!-- Paso 3 &mdash; míralo pequeño y llévatelo -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Compruébalo al tamaño al que se verá</h2>
 
     <p class="card-lede">

--- a/locales/es/tools/images-to-pdf.html
+++ b/locales/es/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- Paso 3 &mdash; la exportación -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Crea el PDF</h2>
 
     <div class="export-row">

--- a/locales/es/tools/images-to-video.html
+++ b/locales/es/tools/images-to-video.html
@@ -140,7 +140,7 @@
   </section>
 
   <!-- Paso 3 &mdash; la exportación -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Crea el vídeo</h2>
 
     <div class="export-row">

--- a/locales/es/tools/merge-pdf.html
+++ b/locales/es/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- Paso 2 &mdash; las páginas -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Ordena las páginas</h2>
 
     <p class="card-lede">
@@ -51,7 +51,7 @@
   </section>
 
   <!-- Paso 3 &mdash; un archivo, o varios -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> Un documento, o varios</h2>
 
     <fieldset class="presets-set">
@@ -122,7 +122,7 @@
   </section>
 
   <!-- Paso 4 &mdash; el único clic -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Móntalo</h2>
 
     <div class="run-row">

--- a/locales/es/tools/qr-barcode-reader.html
+++ b/locales/es/tools/qr-barcode-reader.html
@@ -64,7 +64,7 @@
   </section>
 
   <!-- Paso 2 &mdash; la respuesta -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> Lo que dice</h2>
 
     <p class="card-lede">

--- a/locales/es/tools/redact-image.html
+++ b/locales/es/tools/redact-image.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Paso 3 &mdash; el archivo -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Guarda la copia censurada</h2>
 
     <p class="card-lede">

--- a/locales/es/tools/redact-pdf.html
+++ b/locales/es/tools/redact-pdf.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Paso 2 &mdash; encontrarlas -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Di qué tiene que irse</h2>
 
     <p class="card-lede">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Paso 3 &mdash; leer la página -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> Lee la página y ve eligiendo palabras</h2>
 
     <p class="card-lede">
@@ -97,7 +97,7 @@
   </section>
 
   <!-- Paso 4 &mdash; hacerlo -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Saca las palabras</h2>
 
     <label class="check">

--- a/locales/es/tools/resize-image.html
+++ b/locales/es/tools/resize-image.html
@@ -193,7 +193,7 @@
   </section>
 
   <!-- Paso 4 &mdash; el formato, y el único clic -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Guárdalo</h2>
 
     <div class="settings">

--- a/locales/es/tools/reverse-video.html
+++ b/locales/es/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Paso 2 &mdash; la inversión -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Inviértelo</h2>
 
     <div class="settings">

--- a/locales/es/tools/split-gif.html
+++ b/locales/es/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- Paso 2 &mdash; qué sale -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> Cómo salen los fotogramas</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Paso 3 &mdash; los fotogramas -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> Los fotogramas</h2>
 
     <div class="toolbar">

--- a/locales/es/tools/stack-images.html
+++ b/locales/es/tools/stack-images.html
@@ -142,7 +142,7 @@
   </section>
 
   <!-- Paso 3 &mdash; ejecutarlo -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Apílalas</h2>
 
     <div class="export-row">

--- a/locales/es/tools/svg-to-image.html
+++ b/locales/es/tools/svg-to-image.html
@@ -168,7 +168,7 @@
   </section>
 
   <!-- Paso 4 &mdash; míralo y llévatelo -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Míralo y guárdalo</h2>
 
     <p class="card-lede">

--- a/locales/es/tools/timelapse-video.html
+++ b/locales/es/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Paso 2 &mdash; la velocidad -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Elige la velocidad</h2>
 
     <div class="speed-row" role="group" aria-label="Cuánto se acelera el clip">
@@ -110,7 +110,7 @@
   </section>
 
   <!-- Paso 3 &mdash; la salida -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Crea el timelapse</h2>
 
     <dl class="summary" id="summary">

--- a/locales/es/tools/trim-audio.html
+++ b/locales/es/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Paso 2 &mdash; las marcas -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Marca los trozos que quieres
       <span class="editing" id="editing" hidden></span>
@@ -137,7 +137,7 @@
   </section>
 
   <!-- Paso 3 &mdash; el archivo que sale -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Córtalo</h2>
 
     <div class="settings">

--- a/locales/es/tools/trim-video.html
+++ b/locales/es/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Paso 2 &mdash; las marcas -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Marca los trozos que quieras
       <span class="editing" id="editing" hidden></span>
@@ -141,7 +141,7 @@
   </section>
 
   <!-- Paso 3 &mdash; la exportación -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Córtalo</h2>
 
     <div class="settings">

--- a/locales/es/tools/video-to-gif.html
+++ b/locales/es/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Paso 2 &mdash; el trozo -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Elige el trozo</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Paso 3 &mdash; el GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Tamaño y cadencia</h2>
 
     <div class="settings">

--- a/locales/fr/tools/compare-text.html
+++ b/locales/fr/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Lire ce qui a changé</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/fr/tools/compress-image.html
+++ b/locales/fr/tools/compress-image.html
@@ -97,7 +97,7 @@
   </section>
 
   <!-- Étape 3 &mdash; le clic unique -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Compresser</h2>
 
     <div class="run-row">

--- a/locales/fr/tools/compress-pdf.html
+++ b/locales/fr/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- Étape 2 &mdash; l'écran que cet outil garderait s'il ne devait en garder qu'un -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> Voir où est le poids</h2>
 
     <p class="card-lede">
@@ -43,7 +43,7 @@
   </section>
 
   <!-- Étape 3 &mdash; combien dépenser -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Dire jusqu'où serrer</h2>
 
     <p class="card-lede">
@@ -126,7 +126,7 @@
   </section>
 
   <!-- Étape 4 &mdash; le clic unique -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Compresser</h2>
 
     <div class="run-row">

--- a/locales/fr/tools/crop-video.html
+++ b/locales/fr/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Étape 2 &mdash; le recadrage -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Poser le recadrage</h2>
 
     <p class="stage-hint">
@@ -82,7 +82,7 @@
   </section>
 
   <!-- Étape 3 &mdash; l'export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Recadrer</h2>
 
     <div class="settings">

--- a/locales/fr/tools/document-scanner.html
+++ b/locales/fr/tools/document-scanner.html
@@ -174,7 +174,7 @@
   </section>
 
   <!-- Étape 4 &mdash; le fichier -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Enregistrez le document</h2>
 
     <p class="card-lede">

--- a/locales/fr/tools/edit-audio.html
+++ b/locales/fr/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Étape 2 &mdash; les modifications -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Le modifier</h2>
 
     <div class="edit-block">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- Étape 3 &mdash; le fichier qui sort -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> L'enregistrer</h2>
 
     <div class="settings">

--- a/locales/fr/tools/encode-text.html
+++ b/locales/fr/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Emportez le résultat</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/fr/tools/exif-editor.html
+++ b/locales/fr/tools/exif-editor.html
@@ -85,7 +85,7 @@
   </section>
 
   <!-- Étape 3 &mdash; lire et modifier -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> Regarder dedans, et changer ce que vous voulez</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/fr/tools/format-json.html
+++ b/locales/fr/tools/format-json.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Emportez le résultat</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/fr/tools/gif-maker.html
+++ b/locales/fr/tools/gif-maker.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- Étape 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Fabriquez le GIF</h2>
 
     <div class="export-row">

--- a/locales/fr/tools/grab-frame.html
+++ b/locales/fr/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Étape 2 &mdash; le moment -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Trouvez l'image</h2>
 
     <p class="stage-hint">
@@ -67,7 +67,7 @@
   </section>
 
   <!-- Étape 3 &mdash; l'arrêt sur image -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Prenez l'image</h2>
 
     <div class="settings">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- Étape 4 &mdash; ce qui est ressorti -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Vos images</h2>
 
     <div class="toolbar">

--- a/locales/fr/tools/hash-checksum.html
+++ b/locales/fr/tools/hash-checksum.html
@@ -136,7 +136,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Comparer à ce qui est attendu</h2>
     <p class="card-lede">
       Collez la somme de contrôle donnée par la page de téléchargement. La forme

--- a/locales/fr/tools/heic-to-jpg.html
+++ b/locales/fr/tools/heic-to-jpg.html
@@ -80,7 +80,7 @@
   </section>
 
   <!-- Étape 3 &mdash; le clic unique -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Convertir</h2>
 
     <div class="run-row">

--- a/locales/fr/tools/id-photo.html
+++ b/locales/fr/tools/id-photo.html
@@ -172,7 +172,7 @@
   </section>
 
   <!-- Étape 5 &mdash; les fichiers -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Enregistrez</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/fr/tools/image-to-data-uri.html
+++ b/locales/fr/tools/image-to-data-uri.html
@@ -119,7 +119,7 @@
 
   <!-- Étape 3 &mdash; le résultat. Pas de bouton ici, volontairement : l'encodage
        est instantané, et un appui sur « convertir » n'aurait rien à attendre. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Copier</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/fr/tools/image-to-ico.html
+++ b/locales/fr/tools/image-to-ico.html
@@ -135,7 +135,7 @@
   </section>
 
   <!-- Étape 3 &mdash; la voir petite, puis la prendre -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> La vérifier à la taille où elle sera vue</h2>
 
     <p class="card-lede">

--- a/locales/fr/tools/images-to-pdf.html
+++ b/locales/fr/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- Étape 3 &mdash; l'export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Créer le PDF</h2>
 
     <div class="export-row">

--- a/locales/fr/tools/images-to-video.html
+++ b/locales/fr/tools/images-to-video.html
@@ -140,7 +140,7 @@
   </section>
 
   <!-- Étape 3 &mdash; l'export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Créer la vidéo</h2>
 
     <div class="export-row">

--- a/locales/fr/tools/merge-pdf.html
+++ b/locales/fr/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- Étape 2 &mdash; les pages -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Rangez les pages</h2>
 
     <p class="card-lede">
@@ -53,7 +53,7 @@
   </section>
 
   <!-- Étape 3 &mdash; un fichier, ou plusieurs -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> Un document, ou plusieurs</h2>
 
     <fieldset class="presets-set">
@@ -125,7 +125,7 @@
   </section>
 
   <!-- Étape 4 &mdash; le seul clic -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Assemblez</h2>
 
     <div class="run-row">

--- a/locales/fr/tools/qr-barcode-reader.html
+++ b/locales/fr/tools/qr-barcode-reader.html
@@ -65,7 +65,7 @@
   </section>
 
   <!-- Étape 2 &mdash; la réponse -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> Ce qu'il dit</h2>
 
     <p class="card-lede">

--- a/locales/fr/tools/redact-image.html
+++ b/locales/fr/tools/redact-image.html
@@ -116,7 +116,7 @@
   </section>
 
   <!-- Étape 3 &mdash; le fichier -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Enregistrer la copie caviardée</h2>
 
     <p class="card-lede">

--- a/locales/fr/tools/redact-pdf.html
+++ b/locales/fr/tools/redact-pdf.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Étape 2 &mdash; les trouver -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Dites ce qui doit disparaître</h2>
 
     <p class="card-lede">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Étape 3 &mdash; lire la page -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> Lisez la page et piochez-y des mots</h2>
 
     <p class="card-lede">
@@ -97,7 +97,7 @@
   </section>
 
   <!-- Étape 4 &mdash; le faire -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Retirez les mots</h2>
 
     <label class="check">

--- a/locales/fr/tools/resize-image.html
+++ b/locales/fr/tools/resize-image.html
@@ -195,7 +195,7 @@
   </section>
 
   <!-- Étape 4 &mdash; le format, et le clic unique -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> L'enregistrer</h2>
 
     <div class="settings">

--- a/locales/fr/tools/reverse-video.html
+++ b/locales/fr/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Étape 2 &mdash; l'inversion -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Inversez-la</h2>
 
     <div class="settings">

--- a/locales/fr/tools/split-gif.html
+++ b/locales/fr/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- Étape 2 &mdash; ce qui ressort -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> Comment les images ressortent</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Étape 3 &mdash; les images elles-mêmes -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> Les images</h2>
 
     <div class="toolbar">

--- a/locales/fr/tools/stack-images.html
+++ b/locales/fr/tools/stack-images.html
@@ -143,7 +143,7 @@
   </section>
 
   <!-- Étape 3 &mdash; lancer -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Empilez-les</h2>
 
     <div class="export-row">

--- a/locales/fr/tools/svg-to-image.html
+++ b/locales/fr/tools/svg-to-image.html
@@ -170,7 +170,7 @@
   </section>
 
   <!-- Étape 4 &mdash; le regarder, puis le prendre -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Le regarder, puis l'enregistrer</h2>
 
     <p class="card-lede">

--- a/locales/fr/tools/timelapse-video.html
+++ b/locales/fr/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Étape 2 &mdash; la vitesse -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Choisissez la vitesse</h2>
 
     <div class="speed-row" role="group" aria-label="De combien le clip est accéléré">
@@ -111,7 +111,7 @@
   </section>
 
   <!-- Étape 3 &mdash; la sortie -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Faites le timelapse</h2>
 
     <dl class="summary" id="summary">

--- a/locales/fr/tools/trim-audio.html
+++ b/locales/fr/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Étape 2 &mdash; les repères -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Marquez les passages voulus
       <span class="editing" id="editing" hidden></span>
@@ -137,7 +137,7 @@
   </section>
 
   <!-- Étape 3 &mdash; le fichier qui ressort -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Coupez</h2>
 
     <div class="settings">

--- a/locales/fr/tools/trim-video.html
+++ b/locales/fr/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Étape 2 &mdash; les marques -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Marquer les passages voulus
       <span class="editing" id="editing" hidden></span>
@@ -141,7 +141,7 @@
   </section>
 
   <!-- Étape 3 &mdash; l'export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Couper</h2>
 
     <div class="settings">

--- a/locales/fr/tools/video-to-gif.html
+++ b/locales/fr/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Étape 2 &mdash; le passage -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Choisir le passage</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Étape 3 &mdash; le GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Taille et cadence</h2>
 
     <div class="settings">

--- a/locales/hi/tools/compare-text.html
+++ b/locales/hi/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> पढ़िए कि क्या बदला</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/hi/tools/compress-image.html
+++ b/locales/hi/tools/compress-image.html
@@ -96,7 +96,7 @@
   </section>
 
   <!-- कदम 3 &mdash; वह अकेला क्लिक -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> कंप्रेस कीजिए</h2>
 
     <div class="run-row">

--- a/locales/hi/tools/compress-pdf.html
+++ b/locales/hi/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- कदम 2 &mdash; वह स्क्रीन जो यह टूल तब भी रखता, अगर सिर्फ़ एक ही रख सकता -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> देखिए कि साइज़ है कहाँ</h2>
 
     <p class="card-lede">
@@ -42,7 +42,7 @@
   </section>
 
   <!-- कदम 3 &mdash; कितना खर्च करना है -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> बताइए कि कितनी कसकर निचोड़ना है</h2>
 
     <p class="card-lede">
@@ -123,7 +123,7 @@
   </section>
 
   <!-- कदम 4 &mdash; वह अकेला क्लिक -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> कंप्रेस कीजिए</h2>
 
     <div class="run-row">

--- a/locales/hi/tools/crop-video.html
+++ b/locales/hi/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- कदम 2 &mdash; क्रॉप -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> क्रॉप तय कीजिए</h2>
 
     <p class="stage-hint">
@@ -81,7 +81,7 @@
   </section>
 
   <!-- कदम 3 &mdash; एक्सपोर्ट -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> इसे क्रॉप कीजिए</h2>
 
     <div class="settings">

--- a/locales/hi/tools/document-scanner.html
+++ b/locales/hi/tools/document-scanner.html
@@ -169,7 +169,7 @@
   </section>
 
   <!-- कदम 4 &mdash; फ़ाइल -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> डॉक्यूमेंट सेव कीजिए</h2>
 
     <p class="card-lede">

--- a/locales/hi/tools/edit-audio.html
+++ b/locales/hi/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- कदम 2 &mdash; बदलाव -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> इसे बदलिए</h2>
 
     <div class="edit-block">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- कदम 3 &mdash; जो फ़ाइल बाहर आती है -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> इसे सहेजिए</h2>
 
     <div class="settings">

--- a/locales/hi/tools/encode-text.html
+++ b/locales/hi/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> नतीजा ले जाइए</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/hi/tools/exif-editor.html
+++ b/locales/hi/tools/exif-editor.html
@@ -85,7 +85,7 @@
   </section>
 
   <!-- कदम 3 &mdash; पढ़ना और बदलना -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> भीतर झाँकिए, और जो चाहें बदल दीजिए</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/hi/tools/format-json.html
+++ b/locales/hi/tools/format-json.html
@@ -115,7 +115,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> नतीजा ले जाइए</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/hi/tools/gif-maker.html
+++ b/locales/hi/tools/gif-maker.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- कदम 3 &mdash; एक्सपोर्ट -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> GIF बनाइए</h2>
 
     <div class="export-row">

--- a/locales/hi/tools/grab-frame.html
+++ b/locales/hi/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- चरण 2 &mdash; वह पल -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> फ़्रेम ढूँढ़िए</h2>
 
     <p class="stage-hint">
@@ -67,7 +67,7 @@
   </section>
 
   <!-- चरण 3 &mdash; तस्वीर -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> तस्वीर लीजिए</h2>
 
     <div class="settings">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- चरण 4 &mdash; जो निकला -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> आपकी तस्वीरें</h2>
 
     <div class="toolbar">

--- a/locales/hi/tools/hash-checksum.html
+++ b/locales/hi/tools/hash-checksum.html
@@ -134,7 +134,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> जो आना चाहिए उससे मिलाइए</h2>
     <p class="card-lede">
       डाउनलोड पेज ने जो चेकसम दिया है उसे चिपका दीजिए। रूप कोई भी हो, फ़र्क नहीं

--- a/locales/hi/tools/heic-to-jpg.html
+++ b/locales/hi/tools/heic-to-jpg.html
@@ -80,7 +80,7 @@
   </section>
 
   <!-- कदम 3 &mdash; वह अकेला क्लिक -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> बदलिए</h2>
 
     <div class="run-row">

--- a/locales/hi/tools/id-photo.html
+++ b/locales/hi/tools/id-photo.html
@@ -170,7 +170,7 @@
   </section>
 
   <!-- कदम 5 &mdash; फ़ाइलें -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> इसे सहेजिए</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/hi/tools/image-to-data-uri.html
+++ b/locales/hi/tools/image-to-data-uri.html
@@ -119,7 +119,7 @@
   <!-- कदम 3 &mdash; नतीजा। यहाँ कोई बटन जान-बूझकर नहीं है: एनकोडिंग तुरंत
        हो जाती है, इसलिए किसी "बदलिए" बटन के दबने का इंतज़ार करने को कुछ है
        ही नहीं। -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> इसे कॉपी कीजिए</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/hi/tools/image-to-ico.html
+++ b/locales/hi/tools/image-to-ico.html
@@ -135,7 +135,7 @@
   </section>
 
   <!-- कदम 3 &mdash; छोटा करके देखिए, फिर ले जाइए -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> उसी साइज़ पर जाँचिए जिस पर वह दिखेगा</h2>
 
     <p class="card-lede">

--- a/locales/hi/tools/images-to-pdf.html
+++ b/locales/hi/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- कदम 3 &mdash; एक्सपोर्ट -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> PDF बनाइए</h2>
 
     <div class="export-row">

--- a/locales/hi/tools/images-to-video.html
+++ b/locales/hi/tools/images-to-video.html
@@ -141,7 +141,7 @@
   </section>
 
   <!-- कदम 3 &mdash; एक्सपोर्ट -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> वीडियो बनाइए</h2>
 
     <div class="export-row">

--- a/locales/hi/tools/merge-pdf.html
+++ b/locales/hi/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- चरण 2 &mdash; पेज -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> पेज लगाइए</h2>
 
     <p class="card-lede">
@@ -51,7 +51,7 @@
   </section>
 
   <!-- चरण 3 &mdash; एक फ़ाइल, या कई -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> एक दस्तावेज़, या कई</h2>
 
     <fieldset class="presets-set">
@@ -121,7 +121,7 @@
   </section>
 
   <!-- चरण 4 &mdash; वह एक क्लिक -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> इसे बनाइए</h2>
 
     <div class="run-row">

--- a/locales/hi/tools/qr-barcode-reader.html
+++ b/locales/hi/tools/qr-barcode-reader.html
@@ -64,7 +64,7 @@
   </section>
 
   <!-- चरण 2 &mdash; जवाब -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> इसमें क्या लिखा है</h2>
 
     <p class="card-lede">

--- a/locales/hi/tools/redact-image.html
+++ b/locales/hi/tools/redact-image.html
@@ -110,7 +110,7 @@
   </section>
 
   <!-- चरण 3 &mdash; फ़ाइल -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> छिपाई हुई कॉपी सेव कीजिए</h2>
 
     <p class="card-lede">

--- a/locales/hi/tools/redact-pdf.html
+++ b/locales/hi/tools/redact-pdf.html
@@ -26,7 +26,7 @@
   </section>
 
   <!-- कदम 2 &mdash; खोजना -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> बताइए कि क्या हटना है</h2>
 
     <p class="card-lede">
@@ -73,7 +73,7 @@
   </section>
 
   <!-- कदम 3 &mdash; पन्ना पढ़ना -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> पन्ना पढ़िए और उसमें से शब्द चुनिए</h2>
 
     <p class="card-lede">
@@ -98,7 +98,7 @@
   </section>
 
   <!-- कदम 4 &mdash; करना -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> शब्द हटाइए</h2>
 
     <label class="check">

--- a/locales/hi/tools/resize-image.html
+++ b/locales/hi/tools/resize-image.html
@@ -195,7 +195,7 @@
   </section>
 
   <!-- कदम 4 &mdash; फ़ॉर्मैट, और वह अकेला क्लिक -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> इसे सहेजिए</h2>
 
     <div class="settings">

--- a/locales/hi/tools/reverse-video.html
+++ b/locales/hi/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- कदम 2 &mdash; उलटना -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> इसे उलटिए</h2>
 
     <div class="settings">

--- a/locales/hi/tools/split-gif.html
+++ b/locales/hi/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- चरण 2 &mdash; क्या बाहर आएगा -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> फ़्रेम किस रूप में निकलें</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- चरण 3 &mdash; फ़्रेम -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> फ़्रेम</h2>
 
     <div class="toolbar">

--- a/locales/hi/tools/stack-images.html
+++ b/locales/hi/tools/stack-images.html
@@ -143,7 +143,7 @@
   </section>
 
   <!-- कदम 3 &mdash; चलाना -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> स्टैक कीजिए</h2>
 
     <div class="export-row">

--- a/locales/hi/tools/svg-to-image.html
+++ b/locales/hi/tools/svg-to-image.html
@@ -169,7 +169,7 @@
   </section>
 
   <!-- कदम 4 &mdash; देखिए, फिर ले जाइए -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> देखिए, फिर सहेजिए</h2>
 
     <p class="card-lede">

--- a/locales/hi/tools/timelapse-video.html
+++ b/locales/hi/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- चरण 2 &mdash; रफ़्तार -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> रफ़्तार चुनिए</h2>
 
     <div class="speed-row" role="group" aria-label="क्लिप को कितना तेज़ करना है">
@@ -110,7 +110,7 @@
   </section>
 
   <!-- चरण 3 &mdash; नतीजा -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> टाइमलैप्स बनाइए</h2>
 
     <dl class="summary" id="summary">

--- a/locales/hi/tools/trim-audio.html
+++ b/locales/hi/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- चरण 2 &mdash; निशान -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> मनचाहे हिस्सों पर निशान लगाइए
       <span class="editing" id="editing" hidden></span>
@@ -136,7 +136,7 @@
   </section>
 
   <!-- चरण 3 &mdash; जो फ़ाइल निकलती है -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> काटिए</h2>
 
     <div class="settings">

--- a/locales/hi/tools/trim-video.html
+++ b/locales/hi/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- कदम 2 &mdash; निशान -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> जो हिस्से चाहिए उन पर निशान लगाइए
       <span class="editing" id="editing" hidden></span>
@@ -141,7 +141,7 @@
   </section>
 
   <!-- कदम 3 &mdash; एक्सपोर्ट -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> इसे काटिए</h2>
 
     <div class="settings">

--- a/locales/hi/tools/video-to-gif.html
+++ b/locales/hi/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- कदम 2 &mdash; हिस्सा -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> हिस्सा चुनिए</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- कदम 3 &mdash; GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> आकार और फ़्रेम दर</h2>
 
     <div class="settings">

--- a/locales/id/tools/compare-text.html
+++ b/locales/id/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Baca apa yang berubah</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/id/tools/compress-image.html
+++ b/locales/id/tools/compress-image.html
@@ -103,7 +103,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; satu klik -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Kompres</h2>
 
     <div class="run-row">

--- a/locales/id/tools/compress-pdf.html
+++ b/locales/id/tools/compress-pdf.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; layar yang akan dipertahankan alat ini kalau hanya boleh satu -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> Lihat di mana ukurannya berada</h2>
 
     <p class="card-lede">
@@ -48,7 +48,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; berapa banyak yang boleh dibelanjakan -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Sebutkan seberapa keras memerasnya</h2>
 
     <p class="card-lede">
@@ -130,7 +130,7 @@
   </section>
 
   <!-- Langkah 4 &mdash; satu klik -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Kompres</h2>
 
     <div class="run-row">

--- a/locales/id/tools/crop-video.html
+++ b/locales/id/tools/crop-video.html
@@ -31,7 +31,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; pangkasan -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Tentukan pangkasannya</h2>
 
     <p class="stage-hint">
@@ -88,7 +88,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; ekspor -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Pangkas</h2>
 
     <div class="settings">

--- a/locales/id/tools/document-scanner.html
+++ b/locales/id/tools/document-scanner.html
@@ -175,7 +175,7 @@
   </section>
 
   <!-- Langkah 4 &mdash; file-nya -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Simpan dokumennya</h2>
 
     <p class="card-lede">

--- a/locales/id/tools/edit-audio.html
+++ b/locales/id/tools/edit-audio.html
@@ -35,7 +35,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; suntingannya -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Ubah</h2>
 
     <div class="edit-block">
@@ -135,7 +135,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; file yang keluar -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Simpan</h2>
 
     <div class="settings">

--- a/locales/id/tools/encode-text.html
+++ b/locales/id/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Ambil hasilnya</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/id/tools/exif-editor.html
+++ b/locales/id/tools/exif-editor.html
@@ -91,7 +91,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; membaca dan menyunting -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> Lihat ke dalam, dan ubah sesuka Anda</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/id/tools/format-json.html
+++ b/locales/id/tools/format-json.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Ambil hasilnya</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/id/tools/gif-maker.html
+++ b/locales/id/tools/gif-maker.html
@@ -155,7 +155,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; ekspor -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Buat GIF-nya</h2>
 
     <div class="export-row">

--- a/locales/id/tools/grab-frame.html
+++ b/locales/id/tools/grab-frame.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; momennya -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Temukan bingkainya</h2>
 
     <p class="stage-hint">
@@ -73,7 +73,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; gambar diamnya -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Ambil gambarnya</h2>
 
     <div class="settings">
@@ -124,7 +124,7 @@
   </section>
 
   <!-- Langkah 4 &mdash; apa yang keluar -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Gambar diam Anda</h2>
 
     <div class="toolbar">

--- a/locales/id/tools/hash-checksum.html
+++ b/locales/id/tools/hash-checksum.html
@@ -142,7 +142,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Periksa terhadap seharusnya berapa</h2>
     <p class="card-lede">
       Tempelkan checksum yang diberikan halaman unduhan kepada Anda. Bentuknya

--- a/locales/id/tools/heic-to-jpg.html
+++ b/locales/id/tools/heic-to-jpg.html
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; satu klik itu -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Ubah</h2>
 
     <div class="run-row">

--- a/locales/id/tools/id-photo.html
+++ b/locales/id/tools/id-photo.html
@@ -178,7 +178,7 @@
   </section>
 
   <!-- Langkah 5 &mdash; file-nya -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Simpan</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/id/tools/image-to-data-uri.html
+++ b/locales/id/tools/image-to-data-uri.html
@@ -125,7 +125,7 @@
 
   <!-- Langkah 3 &mdash; hasilnya. Sengaja tidak ada tombol di sini: pengodeannya
        seketika, jadi tidak ada yang perlu ditunggu sebuah tekanan "ubah". -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Salin</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/id/tools/image-to-ico.html
+++ b/locales/id/tools/image-to-ico.html
@@ -143,7 +143,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; lihat kecilnya, lalu ambil -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Periksa pada ukuran ia akan dilihat</h2>
 
     <p class="card-lede">

--- a/locales/id/tools/images-to-pdf.html
+++ b/locales/id/tools/images-to-pdf.html
@@ -211,7 +211,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; ekspor -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Buat PDF-nya</h2>
 
     <div class="export-row">

--- a/locales/id/tools/images-to-video.html
+++ b/locales/id/tools/images-to-video.html
@@ -147,7 +147,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; ekspor -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Buat videonya</h2>
 
     <div class="export-row">

--- a/locales/id/tools/merge-pdf.html
+++ b/locales/id/tools/merge-pdf.html
@@ -19,7 +19,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; halamannya -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Susun halamannya</h2>
 
     <p class="card-lede">
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; satu file, atau beberapa -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> Satu dokumen, atau beberapa</h2>
 
     <fieldset class="presets-set">
@@ -130,7 +130,7 @@
   </section>
 
   <!-- Langkah 4 &mdash; satu klik -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Satukan</h2>
 
     <div class="run-row">

--- a/locales/id/tools/qr-barcode-reader.html
+++ b/locales/id/tools/qr-barcode-reader.html
@@ -73,7 +73,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; jawabannya -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> Apa yang dikatakannya</h2>
 
     <p class="card-lede">

--- a/locales/id/tools/redact-image.html
+++ b/locales/id/tools/redact-image.html
@@ -121,7 +121,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; file-nya -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Simpan salinan yang sudah disensor</h2>
 
     <p class="card-lede">

--- a/locales/id/tools/redact-pdf.html
+++ b/locales/id/tools/redact-pdf.html
@@ -27,7 +27,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; menemukannya -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Sebutkan apa yang harus hilang</h2>
 
     <p class="card-lede">
@@ -76,7 +76,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; membaca halamannya -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> Baca halamannya, dan pilih kata dari atasnya</h2>
 
     <p class="card-lede">
@@ -101,7 +101,7 @@
   </section>
 
   <!-- Langkah 4 &mdash; melakukannya -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Keluarkan kata-katanya</h2>
 
     <label class="check">

--- a/locales/id/tools/resize-image.html
+++ b/locales/id/tools/resize-image.html
@@ -203,7 +203,7 @@
   </section>
 
   <!-- Langkah 4 &mdash; format, dan satu klik -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Simpan</h2>
 
     <div class="settings">

--- a/locales/id/tools/reverse-video.html
+++ b/locales/id/tools/reverse-video.html
@@ -35,7 +35,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; pembalikan -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Balik</h2>
 
     <div class="settings">

--- a/locales/id/tools/split-gif.html
+++ b/locales/id/tools/split-gif.html
@@ -31,7 +31,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; apa yang keluar -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> Bagaimana bingkainya keluar</h2>
 
     <div class="settings">
@@ -95,7 +95,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; bingkainya sendiri -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> Bingkainya</h2>
 
     <div class="toolbar">

--- a/locales/id/tools/stack-images.html
+++ b/locales/id/tools/stack-images.html
@@ -143,7 +143,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; jalankan -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Tumpuk mereka</h2>
 
     <div class="export-row">

--- a/locales/id/tools/svg-to-image.html
+++ b/locales/id/tools/svg-to-image.html
@@ -175,7 +175,7 @@
   </section>
 
   <!-- Langkah 4 &mdash; lihat, lalu ambil -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Lihat, lalu simpan</h2>
 
     <p class="card-lede">

--- a/locales/id/tools/timelapse-video.html
+++ b/locales/id/tools/timelapse-video.html
@@ -36,7 +36,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; kecepatannya -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Pilih kecepatannya</h2>
 
     <div class="speed-row" role="group" aria-label="Seberapa jauh klipnya dipercepat">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; ekspor -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Buat time-lapse-nya</h2>
 
     <dl class="summary" id="summary">

--- a/locales/id/tools/trim-audio.html
+++ b/locales/id/tools/trim-audio.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; penanda -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Tandai bagian yang Anda mau
       <span class="editing" id="editing" hidden></span>
@@ -144,7 +144,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; file yang keluar -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Potong</h2>
 
     <div class="settings">

--- a/locales/id/tools/trim-video.html
+++ b/locales/id/tools/trim-video.html
@@ -27,7 +27,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; penanda -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Tandai bagian yang Anda mau
       <span class="editing" id="editing" hidden></span>
@@ -148,7 +148,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; ekspor -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Potong</h2>
 
     <div class="settings">

--- a/locales/id/tools/video-to-gif.html
+++ b/locales/id/tools/video-to-gif.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Langkah 2 &mdash; bagiannya -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Pilih bagiannya</h2>
 
     <p class="hint">
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Langkah 3 &mdash; GIF-nya -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Ukuran dan laju bingkai</h2>
 
     <div class="settings">

--- a/locales/it/tools/compare-text.html
+++ b/locales/it/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Leggi cos'è cambiato</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/it/tools/compress-image.html
+++ b/locales/it/tools/compress-image.html
@@ -97,7 +97,7 @@
   </section>
 
   <!-- Passo 3 &mdash; il clic unico -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Comprimi</h2>
 
     <div class="run-row">

--- a/locales/it/tools/compress-pdf.html
+++ b/locales/it/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- Passo 2 &mdash; la schermata che questo strumento terrebbe se potesse tenerne una sola -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> Guarda dove sta il peso</h2>
 
     <p class="card-lede">
@@ -42,7 +42,7 @@
   </section>
 
   <!-- Passo 3 &mdash; quanto spendere -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Di' quanto stringere</h2>
 
     <p class="card-lede">
@@ -124,7 +124,7 @@
   </section>
 
   <!-- Passo 4 &mdash; il clic unico -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Comprimi</h2>
 
     <div class="run-row">

--- a/locales/it/tools/crop-video.html
+++ b/locales/it/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Passo 2 &mdash; il ritaglio -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Imposta il ritaglio</h2>
 
     <p class="stage-hint">
@@ -81,7 +81,7 @@
   </section>
 
   <!-- Passo 3 &mdash; l'esportazione -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Ritaglialo</h2>
 
     <div class="settings">

--- a/locales/it/tools/document-scanner.html
+++ b/locales/it/tools/document-scanner.html
@@ -173,7 +173,7 @@
   </section>
 
   <!-- Passo 4 &mdash; il file -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Salva il documento</h2>
 
     <p class="card-lede">

--- a/locales/it/tools/edit-audio.html
+++ b/locales/it/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Passo 2 &mdash; le modifiche -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Modificalo</h2>
 
     <div class="edit-block">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- Passo 3 &mdash; il file che esce -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Salvalo</h2>
 
     <div class="settings">

--- a/locales/it/tools/encode-text.html
+++ b/locales/it/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Prenditi il risultato</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/it/tools/exif-editor.html
+++ b/locales/it/tools/exif-editor.html
@@ -85,7 +85,7 @@
   </section>
 
   <!-- Passo 3 &mdash; leggere e modificare -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> Guarda dentro, e cambia quello che vuoi</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/it/tools/format-json.html
+++ b/locales/it/tools/format-json.html
@@ -113,7 +113,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Prenditi il risultato</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/it/tools/gif-maker.html
+++ b/locales/it/tools/gif-maker.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- Passo 3 &mdash; esportazione -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Fai la GIF</h2>
 
     <div class="export-row">

--- a/locales/it/tools/grab-frame.html
+++ b/locales/it/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Passo 2 &mdash; il momento -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Trova il fotogramma</h2>
 
     <p class="stage-hint">
@@ -67,7 +67,7 @@
   </section>
 
   <!-- Passo 3 &mdash; il fermo immagine -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Prendi il fermo immagine</h2>
 
     <div class="settings">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- Passo 4 &mdash; cosa è uscito -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Le tue immagini</h2>
 
     <div class="toolbar">

--- a/locales/it/tools/hash-checksum.html
+++ b/locales/it/tools/hash-checksum.html
@@ -135,7 +135,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Confrontalo con quello che dovrebbe essere</h2>
     <p class="card-lede">
       Incolla il checksum che ti ha dato la pagina di download. La forma non conta:

--- a/locales/it/tools/heic-to-jpg.html
+++ b/locales/it/tools/heic-to-jpg.html
@@ -80,7 +80,7 @@
   </section>
 
   <!-- Passo 3 &mdash; il clic unico -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Converti</h2>
 
     <div class="run-row">

--- a/locales/it/tools/id-photo.html
+++ b/locales/it/tools/id-photo.html
@@ -169,7 +169,7 @@
   </section>
 
   <!-- Passo 5 &mdash; i file -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Salvalo</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/it/tools/image-to-data-uri.html
+++ b/locales/it/tools/image-to-data-uri.html
@@ -119,7 +119,7 @@
   <!-- Passo 3 &mdash; il risultato. Qui non c'è un pulsante di proposito: la
        codifica è istantanea, quindi non c'è niente che un clic su «converti»
        debba aspettare. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Copialo</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/it/tools/image-to-ico.html
+++ b/locales/it/tools/image-to-ico.html
@@ -138,7 +138,7 @@
   </section>
 
   <!-- Passo 3 &mdash; guardala piccola, poi prendila -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Controllala alla dimensione a cui verrà vista</h2>
 
     <p class="card-lede">

--- a/locales/it/tools/images-to-pdf.html
+++ b/locales/it/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- Passo 3 &mdash; l'esportazione -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Crea il PDF</h2>
 
     <div class="export-row">

--- a/locales/it/tools/images-to-video.html
+++ b/locales/it/tools/images-to-video.html
@@ -141,7 +141,7 @@
   </section>
 
   <!-- Passo 3 &mdash; l'esportazione -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Crea il video</h2>
 
     <div class="export-row">

--- a/locales/it/tools/merge-pdf.html
+++ b/locales/it/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- Passo 2 &mdash; le pagine -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Sistema le pagine</h2>
 
     <p class="card-lede">
@@ -52,7 +52,7 @@
   </section>
 
   <!-- Passo 3 &mdash; un file, o più d'uno -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> Un documento, o più d'uno</h2>
 
     <fieldset class="presets-set">
@@ -123,7 +123,7 @@
   </section>
 
   <!-- Passo 4 &mdash; l'unico clic -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Mettilo insieme</h2>
 
     <div class="run-row">

--- a/locales/it/tools/qr-barcode-reader.html
+++ b/locales/it/tools/qr-barcode-reader.html
@@ -65,7 +65,7 @@
   </section>
 
   <!-- Passo 2 &mdash; la risposta -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> Che cosa dice</h2>
 
     <p class="card-lede">

--- a/locales/it/tools/redact-image.html
+++ b/locales/it/tools/redact-image.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Passo 3 &mdash; il file -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Salva la copia oscurata</h2>
 
     <p class="card-lede">

--- a/locales/it/tools/redact-pdf.html
+++ b/locales/it/tools/redact-pdf.html
@@ -26,7 +26,7 @@
   </section>
 
   <!-- Passo 2 &mdash; trovare -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Di' che cosa deve sparire</h2>
 
     <p class="card-lede">
@@ -74,7 +74,7 @@
   </section>
 
   <!-- Passo 3 &mdash; leggere la pagina -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> Leggi la pagina e prendi le parole da lì</h2>
 
     <p class="card-lede">
@@ -99,7 +99,7 @@
   </section>
 
   <!-- Passo 4 &mdash; fare -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Togli le parole</h2>
 
     <label class="check">

--- a/locales/it/tools/resize-image.html
+++ b/locales/it/tools/resize-image.html
@@ -196,7 +196,7 @@
   </section>
 
   <!-- Passo 4 &mdash; il formato, e il clic unico -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Salvala</h2>
 
     <div class="settings">

--- a/locales/it/tools/reverse-video.html
+++ b/locales/it/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Passo 2 &mdash; l'inversione -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Invertilo</h2>
 
     <div class="settings">

--- a/locales/it/tools/split-gif.html
+++ b/locales/it/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- Passo 2 &mdash; cosa esce -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> Come escono i fotogrammi</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Passo 3 &mdash; i fotogrammi -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> I fotogrammi</h2>
 
     <div class="toolbar">

--- a/locales/it/tools/stack-images.html
+++ b/locales/it/tools/stack-images.html
@@ -143,7 +143,7 @@
   </section>
 
   <!-- Passo 3 &mdash; farlo partire -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Impila</h2>
 
     <div class="export-row">

--- a/locales/it/tools/svg-to-image.html
+++ b/locales/it/tools/svg-to-image.html
@@ -169,7 +169,7 @@
   </section>
 
   <!-- Passo 4 &mdash; guardalo, poi prendilo -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Guardalo, poi salvalo</h2>
 
     <p class="card-lede">

--- a/locales/it/tools/timelapse-video.html
+++ b/locales/it/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Passo 2 &mdash; la velocità -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Scegli la velocità</h2>
 
     <div class="speed-row" role="group" aria-label="Di quanto viene velocizzata la clip">
@@ -110,7 +110,7 @@
   </section>
 
   <!-- Passo 3 &mdash; l'uscita -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Crea il timelapse</h2>
 
     <dl class="summary" id="summary">

--- a/locales/it/tools/trim-audio.html
+++ b/locales/it/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Passo 2 &mdash; i segni -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Segna i pezzi che vuoi
       <span class="editing" id="editing" hidden></span>
@@ -136,7 +136,7 @@
   </section>
 
   <!-- Passo 3 &mdash; il file che esce -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Taglia</h2>
 
     <div class="settings">

--- a/locales/it/tools/trim-video.html
+++ b/locales/it/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Passo 2 &mdash; i segni -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Segna i pezzi che vuoi
       <span class="editing" id="editing" hidden></span>
@@ -140,7 +140,7 @@
   </section>
 
   <!-- Passo 3 &mdash; l'esportazione -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Taglialo</h2>
 
     <div class="settings">

--- a/locales/it/tools/video-to-gif.html
+++ b/locales/it/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Passo 2 &mdash; il pezzo -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Scegli il pezzo</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Passo 3 &mdash; la GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Dimensione e frequenza</h2>
 
     <div class="settings">

--- a/locales/ja/tools/compare-text.html
+++ b/locales/ja/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 何が変わったかを読む</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ja/tools/compress-image.html
+++ b/locales/ja/tools/compress-image.html
@@ -88,7 +88,7 @@
   </section>
 
   <!-- ステップ3｜クリック一度 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 圧縮する</h2>
 
     <div class="run-row">

--- a/locales/ja/tools/compress-pdf.html
+++ b/locales/ja/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- ステップ2｜一画面しか残せないなら、このツールが残す画面 -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> 容量がどこにあるのかを見る</h2>
 
     <p class="card-lede">
@@ -36,7 +36,7 @@
   </section>
 
   <!-- ステップ3｜どこまで費やすか -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> どこまで絞るかを決める</h2>
 
     <p class="card-lede">
@@ -108,7 +108,7 @@
   </section>
 
   <!-- ステップ4｜クリック一度 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 圧縮する</h2>
 
     <div class="run-row">

--- a/locales/ja/tools/crop-video.html
+++ b/locales/ja/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- ステップ2｜切り抜き -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> 切り抜く範囲を決める</h2>
 
     <p class="stage-hint">
@@ -77,7 +77,7 @@
   </section>
 
   <!-- ステップ3｜書き出し -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 切り抜く</h2>
 
     <div class="settings">

--- a/locales/ja/tools/document-scanner.html
+++ b/locales/ja/tools/document-scanner.html
@@ -147,7 +147,7 @@
   </section>
 
   <!-- 手順4｜ファイル -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> 書類を保存する</h2>
 
     <p class="card-lede">

--- a/locales/ja/tools/edit-audio.html
+++ b/locales/ja/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- ステップ2｜編集 -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> 変える</h2>
 
     <div class="edit-block">
@@ -123,7 +123,7 @@
   </section>
 
   <!-- ステップ3｜出てくるファイル -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 保存する</h2>
 
     <div class="settings">

--- a/locales/ja/tools/encode-text.html
+++ b/locales/ja/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 結果を持ち出す</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ja/tools/exif-editor.html
+++ b/locales/ja/tools/exif-editor.html
@@ -75,7 +75,7 @@
   </section>
 
   <!-- ステップ3｜中を読む、直す -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> 中を見て、好きなところを変える</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/ja/tools/format-json.html
+++ b/locales/ja/tools/format-json.html
@@ -112,7 +112,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 結果を持ち出す</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ja/tools/gif-maker.html
+++ b/locales/ja/tools/gif-maker.html
@@ -147,7 +147,7 @@
   </section>
 
   <!-- ステップ3 &mdash; 書き出し -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> GIFを作る</h2>
 
     <div class="export-row">

--- a/locales/ja/tools/grab-frame.html
+++ b/locales/ja/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- ステップ2 &mdash; その瞬間 -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> コマを探す</h2>
 
     <p class="stage-hint">
@@ -64,7 +64,7 @@
   </section>
 
   <!-- ステップ3 &mdash; 静止画 -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> 静止画を切り出す</h2>
 
     <div class="settings">
@@ -113,7 +113,7 @@
   </section>
 
   <!-- ステップ4 &mdash; 出てきたもの -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> 切り出した静止画</h2>
 
     <div class="toolbar">

--- a/locales/ja/tools/hash-checksum.html
+++ b/locales/ja/tools/hash-checksum.html
@@ -126,7 +126,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> 本来の値と照らし合わせる</h2>
     <p class="card-lede">
       ダウンロードページに書いてあったチェックサムを貼り付けてください。書き方は問いません。十六進数そのまま、<code>sha256sum</code> の出力、

--- a/locales/ja/tools/heic-to-jpg.html
+++ b/locales/ja/tools/heic-to-jpg.html
@@ -68,7 +68,7 @@
   </section>
 
   <!-- ステップ3｜クリック一度 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 変換する</h2>
 
     <div class="run-row">

--- a/locales/ja/tools/id-photo.html
+++ b/locales/ja/tools/id-photo.html
@@ -152,7 +152,7 @@
   </section>
 
   <!-- ステップ5 &mdash; ファイル -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> 保存する</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/ja/tools/image-to-data-uri.html
+++ b/locales/ja/tools/image-to-data-uri.html
@@ -104,7 +104,7 @@
 
   <!-- ステップ3｜結果。ここにボタンがないのは意図したもの。エンコードは
        一瞬で終わるので、「変換」を押して待つべきものがない。 -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> コピーする</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/ja/tools/image-to-ico.html
+++ b/locales/ja/tools/image-to-ico.html
@@ -121,7 +121,7 @@
   </section>
 
   <!-- ステップ3｜小さく見てから受け取る -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 実際に見られる大きさで確かめる</h2>
 
     <p class="card-lede">

--- a/locales/ja/tools/images-to-pdf.html
+++ b/locales/ja/tools/images-to-pdf.html
@@ -198,7 +198,7 @@
   </section>
 
   <!-- ステップ3｜書き出し -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> PDFを作る</h2>
 
     <div class="export-row">

--- a/locales/ja/tools/images-to-video.html
+++ b/locales/ja/tools/images-to-video.html
@@ -139,7 +139,7 @@
   </section>
 
   <!-- ステップ3｜書き出し -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 動画を作る</h2>
 
     <div class="export-row">

--- a/locales/ja/tools/merge-pdf.html
+++ b/locales/ja/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- ステップ2 &mdash; ページ -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> ページを並べる</h2>
 
     <p class="card-lede">
@@ -47,7 +47,7 @@
   </section>
 
   <!-- ステップ3 &mdash; 1つか、複数か -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> 1つの書類か、複数か</h2>
 
     <fieldset class="presets-set">
@@ -112,7 +112,7 @@
   </section>
 
   <!-- ステップ4 &mdash; 最後のひと押し -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 組み立てる</h2>
 
     <div class="run-row">

--- a/locales/ja/tools/qr-barcode-reader.html
+++ b/locales/ja/tools/qr-barcode-reader.html
@@ -62,7 +62,7 @@
   </section>
 
   <!-- ステップ2｜答え -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> 中身</h2>
 
     <p class="card-lede">

--- a/locales/ja/tools/redact-image.html
+++ b/locales/ja/tools/redact-image.html
@@ -95,7 +95,7 @@
   </section>
 
   <!-- ステップ3｜ファイル -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> 黒塗りした画像を保存する</h2>
 
     <p class="card-lede">

--- a/locales/ja/tools/redact-pdf.html
+++ b/locales/ja/tools/redact-pdf.html
@@ -26,7 +26,7 @@
   </section>
 
   <!-- 手順2｜探す -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> 何を消すか伝える</h2>
 
     <p class="card-lede">
@@ -69,7 +69,7 @@
   </section>
 
   <!-- 手順3｜ページを読む -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> ページを読み、語を拾う</h2>
 
     <p class="card-lede">
@@ -91,7 +91,7 @@
   </section>
 
   <!-- 手順4｜実行 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 語を取り除く</h2>
 
     <label class="check">

--- a/locales/ja/tools/resize-image.html
+++ b/locales/ja/tools/resize-image.html
@@ -181,7 +181,7 @@
   </section>
 
   <!-- ステップ4｜形式と、クリック一度 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> 保存する</h2>
 
     <div class="settings">

--- a/locales/ja/tools/reverse-video.html
+++ b/locales/ja/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- ステップ2 &mdash; 逆にする -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> 逆にする</h2>
 
     <div class="settings">

--- a/locales/ja/tools/split-gif.html
+++ b/locales/ja/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- ステップ2 &mdash; 出力の中身 -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> コマの出し方</h2>
 
     <div class="settings">
@@ -87,7 +87,7 @@
   </section>
 
   <!-- ステップ3 &mdash; コマそのもの -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> コマ一覧</h2>
 
     <div class="toolbar">

--- a/locales/ja/tools/stack-images.html
+++ b/locales/ja/tools/stack-images.html
@@ -136,7 +136,7 @@
   </section>
 
   <!-- 手順3｜実行 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> スタックする</h2>
 
     <div class="export-row">

--- a/locales/ja/tools/svg-to-image.html
+++ b/locales/ja/tools/svg-to-image.html
@@ -157,7 +157,7 @@
   </section>
 
   <!-- ステップ4｜見てから受け取る -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 見てから保存する</h2>
 
     <p class="card-lede">

--- a/locales/ja/tools/timelapse-video.html
+++ b/locales/ja/tools/timelapse-video.html
@@ -37,7 +37,7 @@
   </section>
 
   <!-- ステップ2｜倍率 -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> 倍率を決める</h2>
 
     <div class="speed-row" role="group" aria-label="映像をどれだけ速くするか">
@@ -108,7 +108,7 @@
   </section>
 
   <!-- ステップ3｜書き出し -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> タイムラプスを作る</h2>
 
     <dl class="summary" id="summary">

--- a/locales/ja/tools/trim-audio.html
+++ b/locales/ja/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- ステップ2 &mdash; 印 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> 残したい部分に印を付ける
       <span class="editing" id="editing" hidden></span>
@@ -125,7 +125,7 @@
   </section>
 
   <!-- ステップ3 &mdash; 出てくるファイル -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 切り出す</h2>
 
     <div class="settings">

--- a/locales/ja/tools/trim-video.html
+++ b/locales/ja/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- ステップ2｜印 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> 残したい場所に印を付ける
       <span class="editing" id="editing" hidden></span>
@@ -130,7 +130,7 @@
   </section>
 
   <!-- ステップ3｜書き出し -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> カットする</h2>
 
     <div class="settings">

--- a/locales/ja/tools/video-to-gif.html
+++ b/locales/ja/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- ステップ2｜範囲 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> 範囲を選ぶ</h2>
 
     <p class="hint">
@@ -70,7 +70,7 @@
   </section>
 
   <!-- ステップ3｜GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 大きさとフレームレート</h2>
 
     <div class="settings">

--- a/locales/ko/tools/compare-text.html
+++ b/locales/ko/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 무엇이 달라졌는지 읽기</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ko/tools/compress-image.html
+++ b/locales/ko/tools/compress-image.html
@@ -95,7 +95,7 @@
   </section>
 
   <!-- 3단계 &mdash; 한 번의 클릭 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 압축</h2>
 
     <div class="run-row">

--- a/locales/ko/tools/compress-pdf.html
+++ b/locales/ko/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- 2단계 &mdash; 하나만 남길 수 있다면 이 도구가 남길 화면 -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> 용량이 어디에 있는지 보기</h2>
 
     <p class="card-lede">
@@ -41,7 +41,7 @@
   </section>
 
   <!-- 3단계 &mdash; 얼마를 쓸지 -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> 얼마나 세게 짤지 정하기</h2>
 
     <p class="card-lede">
@@ -121,7 +121,7 @@
   </section>
 
   <!-- 4단계 &mdash; 한 번의 클릭 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 압축</h2>
 
     <div class="run-row">

--- a/locales/ko/tools/crop-video.html
+++ b/locales/ko/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- 2단계 &mdash; 자를 영역 -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> 자를 영역 정하기</h2>
 
     <p class="stage-hint">
@@ -81,7 +81,7 @@
   </section>
 
   <!-- 3단계 &mdash; 내보내기 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 잘라내기</h2>
 
     <div class="settings">

--- a/locales/ko/tools/document-scanner.html
+++ b/locales/ko/tools/document-scanner.html
@@ -167,7 +167,7 @@
   </section>
 
   <!-- 4단계 &mdash; 파일 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> 문서 저장하기</h2>
 
     <p class="card-lede">

--- a/locales/ko/tools/edit-audio.html
+++ b/locales/ko/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- 2단계 &mdash; 편집 -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> 손보기</h2>
 
     <div class="edit-block">
@@ -128,7 +128,7 @@
   </section>
 
   <!-- 3단계 &mdash; 나오는 파일 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 저장하기</h2>
 
     <div class="settings">

--- a/locales/ko/tools/encode-text.html
+++ b/locales/ko/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 결과 가져가기</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ko/tools/exif-editor.html
+++ b/locales/ko/tools/exif-editor.html
@@ -84,7 +84,7 @@
   </section>
 
   <!-- 3단계 &mdash; 읽고 고치기 -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> 안을 들여다보고, 원하는 것을 고치기</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/ko/tools/format-json.html
+++ b/locales/ko/tools/format-json.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 결과 가져가기</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/ko/tools/gif-maker.html
+++ b/locales/ko/tools/gif-maker.html
@@ -148,7 +148,7 @@
   </section>
 
   <!-- 3단계 &mdash; 내보내기 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> GIF 만들기</h2>
 
     <div class="export-row">

--- a/locales/ko/tools/grab-frame.html
+++ b/locales/ko/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- 2단계 &mdash; 장면 -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> 프레임 찾기</h2>
 
     <p class="stage-hint">
@@ -67,7 +67,7 @@
   </section>
 
   <!-- 3단계 &mdash; 캡처 -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> 한 장 뽑기</h2>
 
     <div class="settings">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- 4단계 &mdash; 나온 결과 -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> 뽑은 장면들</h2>
 
     <div class="toolbar">

--- a/locales/ko/tools/hash-checksum.html
+++ b/locales/ko/tools/hash-checksum.html
@@ -133,7 +133,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> 원래 값과 맞춰 보기</h2>
     <p class="card-lede">
       다운로드 페이지가 준 체크섬을 붙여 넣으세요. 형식은 상관없습니다. 16진수만

--- a/locales/ko/tools/heic-to-jpg.html
+++ b/locales/ko/tools/heic-to-jpg.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- 3단계 &mdash; 한 번의 클릭 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 변환</h2>
 
     <div class="run-row">

--- a/locales/ko/tools/id-photo.html
+++ b/locales/ko/tools/id-photo.html
@@ -165,7 +165,7 @@
   </section>
 
   <!-- 5단계 &mdash; 파일 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> 저장하기</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/ko/tools/image-to-data-uri.html
+++ b/locales/ko/tools/image-to-data-uri.html
@@ -116,7 +116,7 @@
 
   <!-- 3단계 &mdash; 결과. 여기 버튼이 없는 것은 일부러입니다. 인코딩이 즉시
        끝나므로 "변환" 버튼이 기다릴 것이 없습니다. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> 복사하기</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/ko/tools/image-to-ico.html
+++ b/locales/ko/tools/image-to-ico.html
@@ -133,7 +133,7 @@
   </section>
 
   <!-- 3단계 &mdash; 작게 본 다음 가져가기 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 실제로 보일 크기에서 확인하기</h2>
 
     <p class="card-lede">

--- a/locales/ko/tools/images-to-pdf.html
+++ b/locales/ko/tools/images-to-pdf.html
@@ -204,7 +204,7 @@
   </section>
 
   <!-- 3단계 &mdash; 내보내기 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> PDF 만들기</h2>
 
     <div class="export-row">

--- a/locales/ko/tools/images-to-video.html
+++ b/locales/ko/tools/images-to-video.html
@@ -140,7 +140,7 @@
   </section>
 
   <!-- 3단계 &mdash; 내보내기 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 동영상 만들기</h2>
 
     <div class="export-row">

--- a/locales/ko/tools/merge-pdf.html
+++ b/locales/ko/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- 2단계 &mdash; 페이지 -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> 페이지 배열하기</h2>
 
     <p class="card-lede">
@@ -51,7 +51,7 @@
   </section>
 
   <!-- 3단계 &mdash; 한 파일, 또는 여러 파일 -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> 한 문서, 또는 여러 문서</h2>
 
     <fieldset class="presets-set">
@@ -120,7 +120,7 @@
   </section>
 
   <!-- 4단계 &mdash; 한 번의 클릭 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 조립하기</h2>
 
     <div class="run-row">

--- a/locales/ko/tools/qr-barcode-reader.html
+++ b/locales/ko/tools/qr-barcode-reader.html
@@ -63,7 +63,7 @@
   </section>
 
   <!-- 2단계 &mdash; 답 -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> 무엇이 적혀 있는지</h2>
 
     <p class="card-lede">

--- a/locales/ko/tools/redact-image.html
+++ b/locales/ko/tools/redact-image.html
@@ -108,7 +108,7 @@
   </section>
 
   <!-- 3단계 &mdash; 파일 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> 가린 사본 저장하기</h2>
 
     <p class="card-lede">

--- a/locales/ko/tools/redact-pdf.html
+++ b/locales/ko/tools/redact-pdf.html
@@ -26,7 +26,7 @@
   </section>
 
   <!-- 2단계 &mdash; 찾기 -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> 무엇이 빠져야 하는지 말하기</h2>
 
     <p class="card-lede">
@@ -73,7 +73,7 @@
   </section>
 
   <!-- 3단계 &mdash; 장 읽기 -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> 장을 읽고 낱말 집기</h2>
 
     <p class="card-lede">
@@ -97,7 +97,7 @@
   </section>
 
   <!-- 4단계 &mdash; 실행 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 낱말 빼내기</h2>
 
     <label class="check">

--- a/locales/ko/tools/resize-image.html
+++ b/locales/ko/tools/resize-image.html
@@ -192,7 +192,7 @@
   </section>
 
   <!-- 4단계 &mdash; 형식, 그리고 한 번의 클릭 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> 저장하기</h2>
 
     <div class="settings">

--- a/locales/ko/tools/reverse-video.html
+++ b/locales/ko/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- 2단계 &mdash; 뒤집기 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> 거꾸로 돌리기</h2>
 
     <div class="settings">

--- a/locales/ko/tools/split-gif.html
+++ b/locales/ko/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- 2단계 &mdash; 나오는 결과 -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> 프레임이 나오는 방식</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- 3단계 &mdash; 프레임 자체 -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> 프레임</h2>
 
     <div class="toolbar">

--- a/locales/ko/tools/stack-images.html
+++ b/locales/ko/tools/stack-images.html
@@ -141,7 +141,7 @@
   </section>
 
   <!-- 3단계 &mdash; 실행 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 스택하기</h2>
 
     <div class="export-row">

--- a/locales/ko/tools/svg-to-image.html
+++ b/locales/ko/tools/svg-to-image.html
@@ -165,7 +165,7 @@
   </section>
 
   <!-- 4단계 &mdash; 보고 나서 가져가기 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 보고 나서 저장하기</h2>
 
     <p class="card-lede">

--- a/locales/ko/tools/timelapse-video.html
+++ b/locales/ko/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- 2단계 &mdash; 배속 -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> 배속 정하기</h2>
 
     <div class="speed-row" role="group" aria-label="영상을 얼마나 빠르게 할지">
@@ -109,7 +109,7 @@
   </section>
 
   <!-- 3단계 &mdash; 결과 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 타임랩스 만들기</h2>
 
     <dl class="summary" id="summary">

--- a/locales/ko/tools/trim-audio.html
+++ b/locales/ko/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- 2단계 &mdash; 표시 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> 원하는 부분에 표시하기
       <span class="editing" id="editing" hidden></span>
@@ -134,7 +134,7 @@
   </section>
 
   <!-- 3단계 &mdash; 나오는 파일 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 자르기</h2>
 
     <div class="settings">

--- a/locales/ko/tools/trim-video.html
+++ b/locales/ko/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- 2단계 &mdash; 표시 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> 원하는 구간 표시하기
       <span class="editing" id="editing" hidden></span>
@@ -139,7 +139,7 @@
   </section>
 
   <!-- 3단계 &mdash; 내보내기 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 잘라내기</h2>
 
     <div class="settings">

--- a/locales/ko/tools/video-to-gif.html
+++ b/locales/ko/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- 2단계 &mdash; 구간 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> 구간 고르기</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- 3단계 &mdash; GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 크기와 프레임 레이트</h2>
 
     <div class="settings">

--- a/locales/nl/tools/compare-text.html
+++ b/locales/nl/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Lees wat er veranderde</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/nl/tools/compress-image.html
+++ b/locales/nl/tools/compress-image.html
@@ -96,7 +96,7 @@
   </section>
 
   <!-- Stap 3 &mdash; de ene klik -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Comprimeren</h2>
 
     <div class="run-row">

--- a/locales/nl/tools/compress-pdf.html
+++ b/locales/nl/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- Stap 2 &mdash; het scherm dat deze tool zou houden als hij er maar één mocht houden -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> Zie waar de grootte zit</h2>
 
     <p class="card-lede">
@@ -42,7 +42,7 @@
   </section>
 
   <!-- Stap 3 &mdash; hoeveel eraan uitgegeven mag worden -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Zeg hoe hard er geknepen mag worden</h2>
 
     <p class="card-lede">
@@ -124,7 +124,7 @@
   </section>
 
   <!-- Stap 4 &mdash; de ene klik -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Comprimeren</h2>
 
     <div class="run-row">

--- a/locales/nl/tools/crop-video.html
+++ b/locales/nl/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Stap 2 &mdash; de bijsnijding -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Stel de bijsnijding in</h2>
 
     <p class="stage-hint">
@@ -81,7 +81,7 @@
   </section>
 
   <!-- Stap 3 &mdash; de export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Snijd het bij</h2>
 
     <div class="settings">

--- a/locales/nl/tools/document-scanner.html
+++ b/locales/nl/tools/document-scanner.html
@@ -174,7 +174,7 @@
   </section>
 
   <!-- Stap 4 &mdash; het bestand -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Sla het document op</h2>
 
     <p class="card-lede">

--- a/locales/nl/tools/edit-audio.html
+++ b/locales/nl/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Stap 2 &mdash; de bewerkingen -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Verander hem</h2>
 
     <div class="edit-block">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- Stap 3 &mdash; het bestand dat eruit komt -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Sla hem op</h2>
 
     <div class="settings">

--- a/locales/nl/tools/encode-text.html
+++ b/locales/nl/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Neem het resultaat mee</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/nl/tools/exif-editor.html
+++ b/locales/nl/tools/exif-editor.html
@@ -85,7 +85,7 @@
   </section>
 
   <!-- Stap 3 &mdash; lezen en bewerken -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> Kijk erin, en verander wat je wilt</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/nl/tools/format-json.html
+++ b/locales/nl/tools/format-json.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Neem het resultaat mee</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/nl/tools/gif-maker.html
+++ b/locales/nl/tools/gif-maker.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- Stap 3 &mdash; exporteren -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Maak de GIF</h2>
 
     <div class="export-row">

--- a/locales/nl/tools/grab-frame.html
+++ b/locales/nl/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Stap 2 &mdash; het moment -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Zoek het frame</h2>
 
     <p class="stage-hint">
@@ -67,7 +67,7 @@
   </section>
 
   <!-- Stap 3 &mdash; het stilstaande beeld -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Pak het beeld</h2>
 
     <div class="settings">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- Stap 4 &mdash; wat eruit kwam -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Je beelden</h2>
 
     <div class="toolbar">

--- a/locales/nl/tools/hash-checksum.html
+++ b/locales/nl/tools/hash-checksum.html
@@ -136,7 +136,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Vergelijk met wat het hoort te zijn</h2>
     <p class="card-lede">
       Plak de checksum die de downloadpagina je gaf. De vorm maakt niet uit: kale hex,

--- a/locales/nl/tools/heic-to-jpg.html
+++ b/locales/nl/tools/heic-to-jpg.html
@@ -80,7 +80,7 @@
   </section>
 
   <!-- Stap 3 &mdash; de ene klik -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Omzetten</h2>
 
     <div class="run-row">

--- a/locales/nl/tools/id-photo.html
+++ b/locales/nl/tools/id-photo.html
@@ -169,7 +169,7 @@
   </section>
 
   <!-- Stap 5 &mdash; de bestanden -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Sla het op</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/nl/tools/image-to-data-uri.html
+++ b/locales/nl/tools/image-to-data-uri.html
@@ -118,7 +118,7 @@
 
   <!-- Stap 3 &mdash; het resultaat. Hier staat met opzet geen knop: coderen is
        ogenblikkelijk, dus er is niets waar een "omzetten"-druk op zou wachten. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Kopieer hem</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/nl/tools/image-to-ico.html
+++ b/locales/nl/tools/image-to-ico.html
@@ -136,7 +136,7 @@
   </section>
 
   <!-- Stap 3 &mdash; klein bekijken, dan meenemen -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Bekijk het op het formaat waarop het gezien wordt</h2>
 
     <p class="card-lede">

--- a/locales/nl/tools/images-to-pdf.html
+++ b/locales/nl/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- Stap 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Maak de pdf</h2>
 
     <div class="export-row">

--- a/locales/nl/tools/images-to-video.html
+++ b/locales/nl/tools/images-to-video.html
@@ -140,7 +140,7 @@
   </section>
 
   <!-- Stap 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Maak de video</h2>
 
     <div class="export-row">

--- a/locales/nl/tools/merge-pdf.html
+++ b/locales/nl/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- Stap 2 &mdash; de pagina's -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Zet de pagina's op volgorde</h2>
 
     <p class="card-lede">
@@ -53,7 +53,7 @@
   </section>
 
   <!-- Stap 3 &mdash; één bestand, of meerdere -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> Eén document, of meerdere</h2>
 
     <fieldset class="presets-set">
@@ -125,7 +125,7 @@
   </section>
 
   <!-- Stap 4 &mdash; die ene klik -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Zet het in elkaar</h2>
 
     <div class="run-row">

--- a/locales/nl/tools/qr-barcode-reader.html
+++ b/locales/nl/tools/qr-barcode-reader.html
@@ -66,7 +66,7 @@
   </section>
 
   <!-- Stap 2 &mdash; het antwoord -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> Wat erin staat</h2>
 
     <p class="card-lede">

--- a/locales/nl/tools/redact-image.html
+++ b/locales/nl/tools/redact-image.html
@@ -115,7 +115,7 @@
   </section>
 
   <!-- Stap 3 &mdash; het bestand -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Sla de onleesbaar gemaakte kopie op</h2>
 
     <p class="card-lede">

--- a/locales/nl/tools/redact-pdf.html
+++ b/locales/nl/tools/redact-pdf.html
@@ -26,7 +26,7 @@
   </section>
 
   <!-- Stap 2 &mdash; zoeken -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Zeggen wat er weg moet</h2>
 
     <p class="card-lede">
@@ -74,7 +74,7 @@
   </section>
 
   <!-- Stap 3 &mdash; de pagina lezen -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> De pagina lezen en er woorden vanaf pikken</h2>
 
     <p class="card-lede">
@@ -100,7 +100,7 @@
   </section>
 
   <!-- Stap 4 &mdash; doen -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> De woorden weghalen</h2>
 
     <label class="check">

--- a/locales/nl/tools/resize-image.html
+++ b/locales/nl/tools/resize-image.html
@@ -194,7 +194,7 @@
   </section>
 
   <!-- Stap 4 &mdash; het bestandstype, en de ene klik -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Sla het op</h2>
 
     <div class="settings">

--- a/locales/nl/tools/reverse-video.html
+++ b/locales/nl/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Stap 2 &mdash; het omkeren -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Keer hem om</h2>
 
     <div class="settings">

--- a/locales/nl/tools/split-gif.html
+++ b/locales/nl/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- Stap 2 &mdash; wat eruit komt -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> Hoe de frames eruit komen</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Stap 3 &mdash; de frames zelf -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> De frames</h2>
 
     <div class="toolbar">

--- a/locales/nl/tools/stack-images.html
+++ b/locales/nl/tools/stack-images.html
@@ -143,7 +143,7 @@
   </section>
 
   <!-- Stap 3 &mdash; laten draaien -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Stacken</h2>
 
     <div class="export-row">

--- a/locales/nl/tools/svg-to-image.html
+++ b/locales/nl/tools/svg-to-image.html
@@ -167,7 +167,7 @@
   </section>
 
   <!-- Stap 4 &mdash; bekijken, dan meenemen -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Bekijk het, en sla het dan op</h2>
 
     <p class="card-lede">

--- a/locales/nl/tools/timelapse-video.html
+++ b/locales/nl/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Stap 2 &mdash; de snelheid -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Kies de snelheid</h2>
 
     <div class="speed-row" role="group" aria-label="Hoeveel sneller het filmpje wordt">
@@ -110,7 +110,7 @@
   </section>
 
   <!-- Stap 3 &mdash; de uitvoer -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Maak de timelapse</h2>
 
     <dl class="summary" id="summary">

--- a/locales/nl/tools/trim-audio.html
+++ b/locales/nl/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Stap 2 &mdash; de markeringen -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Markeer de stukken die je wilt
       <span class="editing" id="editing" hidden></span>
@@ -137,7 +137,7 @@
   </section>
 
   <!-- Stap 3 &mdash; het bestand dat eruit komt -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Knip het</h2>
 
     <div class="settings">

--- a/locales/nl/tools/trim-video.html
+++ b/locales/nl/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Stap 2 &mdash; de markeringen -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Markeer de stukken die je wilt
       <span class="editing" id="editing" hidden></span>
@@ -141,7 +141,7 @@
   </section>
 
   <!-- Stap 3 &mdash; de export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Knip hem</h2>
 
     <div class="settings">

--- a/locales/nl/tools/video-to-gif.html
+++ b/locales/nl/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Stap 2 &mdash; het stuk -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Kies het stuk</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Stap 3 &mdash; de gif -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Formaat en beeldsnelheid</h2>
 
     <div class="settings">

--- a/locales/pt/tools/compare-text.html
+++ b/locales/pt/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Leia o que mudou</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/pt/tools/compress-image.html
+++ b/locales/pt/tools/compress-image.html
@@ -97,7 +97,7 @@
   </section>
 
   <!-- Passo 3: o único clique -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Comprimir</h2>
 
     <div class="run-row">

--- a/locales/pt/tools/compress-pdf.html
+++ b/locales/pt/tools/compress-pdf.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- Passo 2: a tela que esta ferramenta manteria se pudesse manter só uma -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> Veja onde está o tamanho</h2>
 
     <p class="card-lede">
@@ -42,7 +42,7 @@
   </section>
 
   <!-- Passo 3: quanto gastar -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Diga com que força apertar</h2>
 
     <p class="card-lede">
@@ -124,7 +124,7 @@
   </section>
 
   <!-- Passo 4: o único clique -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Comprimir</h2>
 
     <div class="run-row">

--- a/locales/pt/tools/crop-video.html
+++ b/locales/pt/tools/crop-video.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Passo 2: o corte -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Defina o corte</h2>
 
     <p class="stage-hint">
@@ -81,7 +81,7 @@
   </section>
 
   <!-- Passo 3: a exportação -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Corte</h2>
 
     <div class="settings">

--- a/locales/pt/tools/document-scanner.html
+++ b/locales/pt/tools/document-scanner.html
@@ -170,7 +170,7 @@
   </section>
 
   <!-- Passo 4 &mdash; o arquivo -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Salve o documento</h2>
 
     <p class="card-lede">

--- a/locales/pt/tools/edit-audio.html
+++ b/locales/pt/tools/edit-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Passo 2: as edições -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Mude</h2>
 
     <div class="edit-block">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- Passo 3: o arquivo que sai -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Salve</h2>
 
     <div class="settings">

--- a/locales/pt/tools/encode-text.html
+++ b/locales/pt/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Leve o resultado</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/pt/tools/exif-editor.html
+++ b/locales/pt/tools/exif-editor.html
@@ -85,7 +85,7 @@
   </section>
 
   <!-- Passo 3: ler e editar -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> Olhe por dentro e mude o que quiser</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/pt/tools/format-json.html
+++ b/locales/pt/tools/format-json.html
@@ -113,7 +113,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Leve o resultado</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/pt/tools/gif-maker.html
+++ b/locales/pt/tools/gif-maker.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- Passo 3 &mdash; exportar -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Faça o GIF</h2>
 
     <div class="export-row">

--- a/locales/pt/tools/grab-frame.html
+++ b/locales/pt/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Passo 2 &mdash; o momento -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Ache o quadro</h2>
 
     <p class="stage-hint">
@@ -66,7 +66,7 @@
   </section>
 
   <!-- Passo 3 &mdash; a imagem -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Tire a imagem</h2>
 
     <div class="settings">
@@ -117,7 +117,7 @@
   </section>
 
   <!-- Passo 4 &mdash; o que saiu -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Suas imagens</h2>
 
     <div class="toolbar">

--- a/locales/pt/tools/hash-checksum.html
+++ b/locales/pt/tools/hash-checksum.html
@@ -134,7 +134,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Compare com o que deveria ser</h2>
     <p class="card-lede">
       Cole o checksum que a página de download te deu. A forma não importa:

--- a/locales/pt/tools/heic-to-jpg.html
+++ b/locales/pt/tools/heic-to-jpg.html
@@ -79,7 +79,7 @@
   </section>
 
   <!-- Passo 3: o único clique -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Converter</h2>
 
     <div class="run-row">

--- a/locales/pt/tools/id-photo.html
+++ b/locales/pt/tools/id-photo.html
@@ -167,7 +167,7 @@
   </section>
 
   <!-- Passo 5 &mdash; os arquivos -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Salve</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/pt/tools/image-to-data-uri.html
+++ b/locales/pt/tools/image-to-data-uri.html
@@ -118,7 +118,7 @@
 
   <!-- Passo 3 &mdash; o resultado. Não há botão aqui de propósito: codificar é
        instantâneo, então não há nada que um "converter" tivesse que esperar. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Copie</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/pt/tools/image-to-ico.html
+++ b/locales/pt/tools/image-to-ico.html
@@ -136,7 +136,7 @@
   </section>
 
   <!-- Passo 3: veja pequeno, e então leve -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Confira no tamanho em que ele vai ser visto</h2>
 
     <p class="card-lede">

--- a/locales/pt/tools/images-to-pdf.html
+++ b/locales/pt/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- Passo 3: exportar -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Crie o PDF</h2>
 
     <div class="export-row">

--- a/locales/pt/tools/images-to-video.html
+++ b/locales/pt/tools/images-to-video.html
@@ -140,7 +140,7 @@
   </section>
 
   <!-- Passo 3: exportar -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Crie o vídeo</h2>
 
     <div class="export-row">

--- a/locales/pt/tools/merge-pdf.html
+++ b/locales/pt/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- Passo 2 &mdash; as páginas -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Organize as páginas</h2>
 
     <p class="card-lede">
@@ -51,7 +51,7 @@
   </section>
 
   <!-- Passo 3 &mdash; um arquivo, ou vários -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> Um documento, ou vários</h2>
 
     <fieldset class="presets-set">
@@ -122,7 +122,7 @@
   </section>
 
   <!-- Passo 4 &mdash; o único clique -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Monte tudo</h2>
 
     <div class="run-row">

--- a/locales/pt/tools/qr-barcode-reader.html
+++ b/locales/pt/tools/qr-barcode-reader.html
@@ -64,7 +64,7 @@
   </section>
 
   <!-- Passo 2 &mdash; a resposta -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> O que está escrito</h2>
 
     <p class="card-lede">

--- a/locales/pt/tools/redact-image.html
+++ b/locales/pt/tools/redact-image.html
@@ -113,7 +113,7 @@
   </section>
 
   <!-- Passo 3 &mdash; o arquivo -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Salve a cópia tarjada</h2>
 
     <p class="card-lede">

--- a/locales/pt/tools/redact-pdf.html
+++ b/locales/pt/tools/redact-pdf.html
@@ -26,7 +26,7 @@
   </section>
 
   <!-- Passo 2 &mdash; encontrar -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Diga o que precisa sair</h2>
 
     <p class="card-lede">
@@ -74,7 +74,7 @@
   </section>
 
   <!-- Passo 3 &mdash; ler a página -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> Leia a página e escolha palavras nela</h2>
 
     <p class="card-lede">
@@ -99,7 +99,7 @@
   </section>
 
   <!-- Passo 4 &mdash; fazer -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Retire as palavras</h2>
 
     <label class="check">

--- a/locales/pt/tools/resize-image.html
+++ b/locales/pt/tools/resize-image.html
@@ -193,7 +193,7 @@
   </section>
 
   <!-- Passo 4: o formato, e o único clique -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Salve</h2>
 
     <div class="settings">

--- a/locales/pt/tools/reverse-video.html
+++ b/locales/pt/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Passo 2 &mdash; a inversão -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Inverta</h2>
 
     <div class="settings">

--- a/locales/pt/tools/split-gif.html
+++ b/locales/pt/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- Passo 2 &mdash; o que sai -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> Como os quadros saem</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Passo 3 &mdash; os quadros -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> Os quadros</h2>
 
     <div class="toolbar">

--- a/locales/pt/tools/stack-images.html
+++ b/locales/pt/tools/stack-images.html
@@ -142,7 +142,7 @@
   </section>
 
   <!-- Passo 3 &mdash; rodar -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Empilhar</h2>
 
     <div class="export-row">

--- a/locales/pt/tools/svg-to-image.html
+++ b/locales/pt/tools/svg-to-image.html
@@ -168,7 +168,7 @@
   </section>
 
   <!-- Passo 4: olhe, e então leve -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Olhe, e então salve</h2>
 
     <p class="card-lede">

--- a/locales/pt/tools/timelapse-video.html
+++ b/locales/pt/tools/timelapse-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Passo 2 &mdash; a velocidade -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Escolha a velocidade</h2>
 
     <div class="speed-row" role="group" aria-label="Quanto o clipe é acelerado">
@@ -110,7 +110,7 @@
   </section>
 
   <!-- Passo 3 &mdash; a saída -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Faça o timelapse</h2>
 
     <dl class="summary" id="summary">

--- a/locales/pt/tools/trim-audio.html
+++ b/locales/pt/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Passo 2 &mdash; as marcas -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Marque os trechos que você quer
       <span class="editing" id="editing" hidden></span>
@@ -136,7 +136,7 @@
   </section>
 
   <!-- Passo 3 &mdash; o arquivo que sai -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Corte</h2>
 
     <div class="settings">

--- a/locales/pt/tools/trim-video.html
+++ b/locales/pt/tools/trim-video.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Passo 2: as marcações -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Marque os trechos que você quer
       <span class="editing" id="editing" hidden></span>
@@ -140,7 +140,7 @@
   </section>
 
   <!-- Passo 3: a exportação -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Apare</h2>
 
     <div class="settings">

--- a/locales/pt/tools/video-to-gif.html
+++ b/locales/pt/tools/video-to-gif.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Passo 2: o trecho -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Escolha o trecho</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Passo 3: o GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Tamanho e taxa de quadros</h2>
 
     <div class="settings">

--- a/locales/tr/tools/compare-text.html
+++ b/locales/tr/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Neyin değiştiğini okuyun</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/tr/tools/compress-image.html
+++ b/locales/tr/tools/compress-image.html
@@ -103,7 +103,7 @@
   </section>
 
   <!-- Adım 3 &mdash; tek tıklama -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Sıkıştır</h2>
 
     <div class="run-row">

--- a/locales/tr/tools/compress-pdf.html
+++ b/locales/tr/tools/compress-pdf.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Adım 2 &mdash; bu araç tek bir ekran tutabilseydi tutacağı ekran -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> Boyutun nerede olduğunu görün</h2>
 
     <p class="card-lede">
@@ -47,7 +47,7 @@
   </section>
 
   <!-- Adım 3 &mdash; ne kadar harcanacağı -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Ne kadar sıkacağını söyleyin</h2>
 
     <p class="card-lede">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- Adım 4 &mdash; tek tıklama -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Sıkıştırın</h2>
 
     <div class="run-row">

--- a/locales/tr/tools/crop-video.html
+++ b/locales/tr/tools/crop-video.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Adım 2 &mdash; kırpma -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Kırpmayı ayarlayın</h2>
 
     <p class="stage-hint">
@@ -87,7 +87,7 @@
   </section>
 
   <!-- Adım 3 &mdash; dışa aktarma -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Kırpın</h2>
 
     <div class="settings">

--- a/locales/tr/tools/document-scanner.html
+++ b/locales/tr/tools/document-scanner.html
@@ -173,7 +173,7 @@
   </section>
 
   <!-- Adım 4 &mdash; dosya -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Belgeyi kaydedin</h2>
 
     <p class="card-lede">

--- a/locales/tr/tools/edit-audio.html
+++ b/locales/tr/tools/edit-audio.html
@@ -35,7 +35,7 @@
   </section>
 
   <!-- Adım 2 &mdash; düzenlemeler -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Değiştirin</h2>
 
     <div class="edit-block">
@@ -134,7 +134,7 @@
   </section>
 
   <!-- Adım 3 &mdash; çıkan dosya -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Kaydedin</h2>
 
     <div class="settings">

--- a/locales/tr/tools/encode-text.html
+++ b/locales/tr/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Sonucu alın</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/tr/tools/exif-editor.html
+++ b/locales/tr/tools/exif-editor.html
@@ -91,7 +91,7 @@
   </section>
 
   <!-- Adım 3 &mdash; okuma ve düzenleme -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> İçine bakın ve istediğinizi değiştirin</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/tr/tools/format-json.html
+++ b/locales/tr/tools/format-json.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Sonucu alın</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/tr/tools/gif-maker.html
+++ b/locales/tr/tools/gif-maker.html
@@ -156,7 +156,7 @@
   </section>
 
   <!-- Adım 3 &mdash; dışa aktarma -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> GIF'i yapın</h2>
 
     <div class="export-row">

--- a/locales/tr/tools/grab-frame.html
+++ b/locales/tr/tools/grab-frame.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Adım 2 &mdash; an -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Kareyi bulun</h2>
 
     <p class="stage-hint">
@@ -73,7 +73,7 @@
   </section>
 
   <!-- Adım 3 &mdash; kare -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Kareyi alın</h2>
 
     <div class="settings">
@@ -124,7 +124,7 @@
   </section>
 
   <!-- Adım 4 &mdash; çıkanlar -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Kareleriniz</h2>
 
     <div class="toolbar">

--- a/locales/tr/tools/hash-checksum.html
+++ b/locales/tr/tools/hash-checksum.html
@@ -142,7 +142,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Olması gerekene karşı denetleyin</h2>
     <p class="card-lede">
       İndirme sayfasının size verdiği sağlama toplamını yapıştırın. Şekli önemli

--- a/locales/tr/tools/heic-to-jpg.html
+++ b/locales/tr/tools/heic-to-jpg.html
@@ -87,7 +87,7 @@
   </section>
 
   <!-- Adım 3 &mdash; tek tıklama -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Dönüştürün</h2>
 
     <div class="run-row">

--- a/locales/tr/tools/id-photo.html
+++ b/locales/tr/tools/id-photo.html
@@ -175,7 +175,7 @@
   </section>
 
   <!-- Adım 5 &mdash; dosyalar -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Kaydedin</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/tr/tools/image-to-data-uri.html
+++ b/locales/tr/tools/image-to-data-uri.html
@@ -125,7 +125,7 @@
 
   <!-- Adım 3 &mdash; sonuç. Burada bilerek bir düğme yok: kodlama anında olur,
        yani bir "dönüştür" basışının bekleyeceği bir şey yok. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Kopyalayın</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/tr/tools/image-to-ico.html
+++ b/locales/tr/tools/image-to-ico.html
@@ -142,7 +142,7 @@
   </section>
 
   <!-- Adım 3 &mdash; küçük hâline bakın, sonra alın -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Görüleceği boyutta denetleyin</h2>
 
     <p class="card-lede">

--- a/locales/tr/tools/images-to-pdf.html
+++ b/locales/tr/tools/images-to-pdf.html
@@ -210,7 +210,7 @@
   </section>
 
   <!-- Adım 3 &mdash; dışa aktarma -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> PDF'i oluşturun</h2>
 
     <div class="export-row">

--- a/locales/tr/tools/images-to-video.html
+++ b/locales/tr/tools/images-to-video.html
@@ -147,7 +147,7 @@
   </section>
 
   <!-- Adım 3 &mdash; dışa aktarma -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Videoyu oluşturun</h2>
 
     <div class="export-row">

--- a/locales/tr/tools/merge-pdf.html
+++ b/locales/tr/tools/merge-pdf.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Adım 2 &mdash; sayfalar -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Sayfaları düzenleyin</h2>
 
     <p class="card-lede">
@@ -60,7 +60,7 @@
   </section>
 
   <!-- Adım 3 &mdash; tek dosya ya da birkaçı -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> Tek belge mi, birkaç belge mi</h2>
 
     <fieldset class="presets-set">
@@ -132,7 +132,7 @@
   </section>
 
   <!-- Adım 4 &mdash; tek tıklama -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Bir araya getirin</h2>
 
     <div class="run-row">

--- a/locales/tr/tools/qr-barcode-reader.html
+++ b/locales/tr/tools/qr-barcode-reader.html
@@ -70,7 +70,7 @@
   </section>
 
   <!-- Adım 2 &mdash; cevap -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> Ne diyor</h2>
 
     <p class="card-lede">

--- a/locales/tr/tools/redact-image.html
+++ b/locales/tr/tools/redact-image.html
@@ -120,7 +120,7 @@
   </section>
 
   <!-- Adım 3 &mdash; dosya -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Karartılmış kopyayı kaydedin</h2>
 
     <p class="card-lede">

--- a/locales/tr/tools/redact-pdf.html
+++ b/locales/tr/tools/redact-pdf.html
@@ -27,7 +27,7 @@
   </section>
 
   <!-- Adım 2 &mdash; bulma -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Neyin gitmesi gerektiğini söyleyin</h2>
 
     <p class="card-lede">
@@ -76,7 +76,7 @@
   </section>
 
   <!-- Adım 3 &mdash; sayfayı okuma -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> Sayfayı okuyun ve kelimeleri üzerinden seçin</h2>
 
     <p class="card-lede">
@@ -101,7 +101,7 @@
   </section>
 
   <!-- Adım 4 &mdash; işi yapma -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Kelimeleri çıkarın</h2>
 
     <label class="check">

--- a/locales/tr/tools/resize-image.html
+++ b/locales/tr/tools/resize-image.html
@@ -199,7 +199,7 @@
   </section>
 
   <!-- Adım 4 &mdash; biçim ve tek tıklama -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Kaydedin</h2>
 
     <div class="settings">

--- a/locales/tr/tools/reverse-video.html
+++ b/locales/tr/tools/reverse-video.html
@@ -35,7 +35,7 @@
   </section>
 
   <!-- Adım 2 &mdash; ters çevirme -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Ters çevirin</h2>
 
     <div class="settings">

--- a/locales/tr/tools/split-gif.html
+++ b/locales/tr/tools/split-gif.html
@@ -31,7 +31,7 @@
   </section>
 
   <!-- Adım 2 &mdash; ne çıkacağı -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> Kareler nasıl çıksın</h2>
 
     <div class="settings">
@@ -95,7 +95,7 @@
   </section>
 
   <!-- Adım 3 &mdash; karelerin kendisi -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> Kareler</h2>
 
     <div class="toolbar">

--- a/locales/tr/tools/stack-images.html
+++ b/locales/tr/tools/stack-images.html
@@ -142,7 +142,7 @@
   </section>
 
   <!-- Adım 3 &mdash; çalıştırma -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> İstifle</h2>
 
     <div class="export-row">

--- a/locales/tr/tools/svg-to-image.html
+++ b/locales/tr/tools/svg-to-image.html
@@ -173,7 +173,7 @@
   </section>
 
   <!-- Adım 4 &mdash; bakın, sonra alın -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Bakın, sonra kaydedin</h2>
 
     <p class="card-lede">

--- a/locales/tr/tools/timelapse-video.html
+++ b/locales/tr/tools/timelapse-video.html
@@ -36,7 +36,7 @@
   </section>
 
   <!-- Adım 2 &mdash; hız -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Hızı seçin</h2>
 
     <div class="speed-row" role="group" aria-label="Klip ne kadar hızlandırılsın">
@@ -117,7 +117,7 @@
   </section>
 
   <!-- Adım 3 &mdash; dışa aktarma -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Time-lapse'i yapın</h2>
 
     <dl class="summary" id="summary">

--- a/locales/tr/tools/trim-audio.html
+++ b/locales/tr/tools/trim-audio.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Adım 2 &mdash; işaretler -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> İstediğiniz parçaları işaretleyin
       <span class="editing" id="editing" hidden></span>
@@ -143,7 +143,7 @@
   </section>
 
   <!-- Adım 3 &mdash; çıkan dosya -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Kesin</h2>
 
     <div class="settings">

--- a/locales/tr/tools/trim-video.html
+++ b/locales/tr/tools/trim-video.html
@@ -26,7 +26,7 @@
   </section>
 
   <!-- Adım 2 &mdash; işaretler -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> İstediğiniz parçaları işaretleyin
       <span class="editing" id="editing" hidden></span>
@@ -146,7 +146,7 @@
   </section>
 
   <!-- Adım 3 &mdash; dışa aktarma -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Kesin</h2>
 
     <div class="settings">

--- a/locales/tr/tools/video-to-gif.html
+++ b/locales/tr/tools/video-to-gif.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Adım 2 &mdash; bölüm -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Bölümü seçin</h2>
 
     <p class="hint">
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Adım 3 &mdash; GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Boyut ve kare hızı</h2>
 
     <div class="settings">

--- a/locales/zh-TW/tools/compare-text.html
+++ b/locales/zh-TW/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 讀一讀改了什麼</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/zh-TW/tools/compress-image.html
+++ b/locales/zh-TW/tools/compress-image.html
@@ -93,7 +93,7 @@
   </section>
 
   <!-- 第 3 步，按一下就完 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 壓縮</h2>
 
     <div class="run-row">

--- a/locales/zh-TW/tools/compress-pdf.html
+++ b/locales/zh-TW/tools/compress-pdf.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- 第 2 步，只留一個介面的話，這個工具會留這個 -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> 看清體積壓在哪裡</h2>
 
     <p class="card-lede">
@@ -43,7 +43,7 @@
   </section>
 
   <!-- 第 3 步，願意花多少 -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> 定個力度</h2>
 
     <p class="card-lede">
@@ -113,7 +113,7 @@
   </section>
 
   <!-- 第 4 步，按一下就完 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 壓縮</h2>
 
     <div class="run-row">

--- a/locales/zh-TW/tools/crop-video.html
+++ b/locales/zh-TW/tools/crop-video.html
@@ -31,7 +31,7 @@
   </section>
 
   <!-- 第 2 步，裁剪框 -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> 拉出裁剪框</h2>
 
     <p class="stage-hint">
@@ -84,7 +84,7 @@
   </section>
 
   <!-- 第 3 步，匯出 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 開裁</h2>
 
     <div class="settings">

--- a/locales/zh-TW/tools/document-scanner.html
+++ b/locales/zh-TW/tools/document-scanner.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- 第 4 步 | 檔案 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> 儲存文件</h2>
 
     <p class="card-lede">

--- a/locales/zh-TW/tools/edit-audio.html
+++ b/locales/zh-TW/tools/edit-audio.html
@@ -36,7 +36,7 @@
   </section>
 
   <!-- 第 2 步，改點什麼 -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> 動手改</h2>
 
     <div class="edit-block">
@@ -130,7 +130,7 @@
   </section>
 
   <!-- 第 3 步，出檔案 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 儲存</h2>
 
     <div class="settings">

--- a/locales/zh-TW/tools/encode-text.html
+++ b/locales/zh-TW/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 把結果帶走</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/zh-TW/tools/exif-editor.html
+++ b/locales/zh-TW/tools/exif-editor.html
@@ -79,7 +79,7 @@
   </section>
 
   <!-- 第 3 步，細看和修改 -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> 翻開看看，想改哪條改哪條</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/zh-TW/tools/format-json.html
+++ b/locales/zh-TW/tools/format-json.html
@@ -113,7 +113,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 把結果帶走</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/zh-TW/tools/gif-maker.html
+++ b/locales/zh-TW/tools/gif-maker.html
@@ -147,7 +147,7 @@
   </section>
 
   <!-- 第三步 &mdash; 匯出 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 做出 GIF</h2>
 
     <div class="export-row">

--- a/locales/zh-TW/tools/grab-frame.html
+++ b/locales/zh-TW/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- 第二步 &mdash; 那個瞬間 -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> 找到那一幀</h2>
 
     <p class="stage-hint">
@@ -65,7 +65,7 @@
   </section>
 
   <!-- 第三步 &mdash; 截圖 -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> 把這一幀取下來</h2>
 
     <div class="settings">
@@ -114,7 +114,7 @@
   </section>
 
   <!-- 第四步 &mdash; 截出來的東西 -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> 截出來的圖</h2>
 
     <div class="toolbar">

--- a/locales/zh-TW/tools/hash-checksum.html
+++ b/locales/zh-TW/tools/hash-checksum.html
@@ -124,7 +124,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> 和本該是的值對一下</h2>
     <p class="card-lede">
       把下載頁面給你的校驗和貼進來。什麼形式都不要緊：光是十六進位、

--- a/locales/zh-TW/tools/heic-to-jpg.html
+++ b/locales/zh-TW/tools/heic-to-jpg.html
@@ -73,7 +73,7 @@
   </section>
 
   <!-- 第 3 步，按一下就完 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 轉換</h2>
 
     <div class="run-row">

--- a/locales/zh-TW/tools/id-photo.html
+++ b/locales/zh-TW/tools/id-photo.html
@@ -152,7 +152,7 @@
   </section>
 
   <!-- 第五步 &mdash; 檔案 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> 儲存</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/zh-TW/tools/image-to-data-uri.html
+++ b/locales/zh-TW/tools/image-to-data-uri.html
@@ -110,7 +110,7 @@
 
   <!-- Step 3 &mdash; the result. There is no button here on purpose: encoding
        is instant, so there is nothing for a "convert" press to wait for. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> 複製</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/zh-TW/tools/image-to-ico.html
+++ b/locales/zh-TW/tools/image-to-ico.html
@@ -128,7 +128,7 @@
   </section>
 
   <!-- 第 3 步，先按真實大小看看，再拿走 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 按它真正被看到的大小檢查一遍</h2>
 
     <p class="card-lede">

--- a/locales/zh-TW/tools/images-to-pdf.html
+++ b/locales/zh-TW/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- 第 3 步，匯出 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 產生 PDF</h2>
 
     <div class="export-row">

--- a/locales/zh-TW/tools/images-to-video.html
+++ b/locales/zh-TW/tools/images-to-video.html
@@ -146,7 +146,7 @@
   </section>
 
   <!-- 第 3 步，匯出 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 產生影片</h2>
 
     <div class="export-row">

--- a/locales/zh-TW/tools/merge-pdf.html
+++ b/locales/zh-TW/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- 第二步 &mdash; 頁面 -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> 安排頁面</h2>
 
     <p class="card-lede">
@@ -48,7 +48,7 @@
   </section>
 
   <!-- 第三步 &mdash; 一個檔案，還是好幾個 -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> 一份文件，還是好幾份</h2>
 
     <fieldset class="presets-set">
@@ -113,7 +113,7 @@
   </section>
 
   <!-- 第四步 &mdash; 那一下點選 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 拼起來</h2>
 
     <div class="run-row">

--- a/locales/zh-TW/tools/qr-barcode-reader.html
+++ b/locales/zh-TW/tools/qr-barcode-reader.html
@@ -62,7 +62,7 @@
   </section>
 
   <!-- 第 2 步，答案 -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> 裡面寫了什麼</h2>
 
     <p class="card-lede">

--- a/locales/zh-TW/tools/redact-image.html
+++ b/locales/zh-TW/tools/redact-image.html
@@ -101,7 +101,7 @@
   </section>
 
   <!-- 第三步：檔案 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> 儲存塗好的那一份</h2>
 
     <p class="card-lede">

--- a/locales/zh-TW/tools/redact-pdf.html
+++ b/locales/zh-TW/tools/redact-pdf.html
@@ -28,7 +28,7 @@
   </section>
 
   <!-- 第 2 步 | 找 -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> 說清什麼要走</h2>
 
     <p class="card-lede">
@@ -71,7 +71,7 @@
   </section>
 
   <!-- 第 3 步 | 讀頁面 -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> 讀這一頁，從上面挑詞</h2>
 
     <p class="card-lede">
@@ -93,7 +93,7 @@
   </section>
 
   <!-- 第 4 步 | 動手 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 拿掉這些詞</h2>
 
     <label class="check">

--- a/locales/zh-TW/tools/resize-image.html
+++ b/locales/zh-TW/tools/resize-image.html
@@ -186,7 +186,7 @@
   </section>
 
   <!-- 第 4 步，格式，然後按一下 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> 儲存</h2>
 
     <div class="settings">

--- a/locales/zh-TW/tools/reverse-video.html
+++ b/locales/zh-TW/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- 第二步 &mdash; 倒過來 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> 倒過來</h2>
 
     <div class="settings">

--- a/locales/zh-TW/tools/split-gif.html
+++ b/locales/zh-TW/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- 第二步 &mdash; 出來的東西 -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> 幀怎麼出</h2>
 
     <div class="settings">
@@ -87,7 +87,7 @@
   </section>
 
   <!-- 第三步 &mdash; 幀本身 -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> 拆出來的幀</h2>
 
     <div class="toolbar">

--- a/locales/zh-TW/tools/stack-images.html
+++ b/locales/zh-TW/tools/stack-images.html
@@ -138,7 +138,7 @@
   </section>
 
   <!-- 第 3 步 | 跑 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 堆疊</h2>
 
     <div class="export-row">

--- a/locales/zh-TW/tools/svg-to-image.html
+++ b/locales/zh-TW/tools/svg-to-image.html
@@ -164,7 +164,7 @@
   </section>
 
   <!-- 第 4 步，先看，再拿走 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 先看一眼，再儲存</h2>
 
     <p class="card-lede">

--- a/locales/zh-TW/tools/timelapse-video.html
+++ b/locales/zh-TW/tools/timelapse-video.html
@@ -37,7 +37,7 @@
   </section>
 
   <!-- 第 2 步，倍數 -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> 選倍數</h2>
 
     <div class="speed-row" role="group" aria-label="片子要加速多少">
@@ -108,7 +108,7 @@
   </section>
 
   <!-- 第 3 步，匯出 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 做延時影片</h2>
 
     <dl class="summary" id="summary">

--- a/locales/zh-TW/tools/trim-audio.html
+++ b/locales/zh-TW/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- 第二步 &mdash; 標記 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> 標出你要的段落
       <span class="editing" id="editing" hidden></span>
@@ -126,7 +126,7 @@
   </section>
 
   <!-- 第三步 &mdash; 出來的檔案 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 剪</h2>
 
     <div class="settings">

--- a/locales/zh-TW/tools/trim-video.html
+++ b/locales/zh-TW/tools/trim-video.html
@@ -27,7 +27,7 @@
   </section>
 
   <!-- 第 2 步，標記 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> 把要留的段落標出來
       <span class="editing" id="editing" hidden></span>
@@ -137,7 +137,7 @@
   </section>
 
   <!-- 第 3 步，匯出 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 開剪</h2>
 
     <div class="settings">

--- a/locales/zh-TW/tools/video-to-gif.html
+++ b/locales/zh-TW/tools/video-to-gif.html
@@ -31,7 +31,7 @@
   </section>
 
   <!-- 第 2 步，挑段落 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> 挑出那一段</h2>
 
     <p class="hint">
@@ -77,7 +77,7 @@
   </section>
 
   <!-- 第 3 步，出 GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 尺寸和幀率</h2>
 
     <div class="settings">

--- a/locales/zh/tools/compare-text.html
+++ b/locales/zh/tools/compare-text.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 读一读改了什么</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/zh/tools/compress-image.html
+++ b/locales/zh/tools/compress-image.html
@@ -93,7 +93,7 @@
   </section>
 
   <!-- 第 3 步，按一下就完 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 压缩</h2>
 
     <div class="run-row">

--- a/locales/zh/tools/compress-pdf.html
+++ b/locales/zh/tools/compress-pdf.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- 第 2 步，只留一个界面的话，这个工具会留这个 -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> 看清体积压在哪儿</h2>
 
     <p class="card-lede">
@@ -43,7 +43,7 @@
   </section>
 
   <!-- 第 3 步，愿意花多少 -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> 定个力度</h2>
 
     <p class="card-lede">
@@ -113,7 +113,7 @@
   </section>
 
   <!-- 第 4 步，按一下就完 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 压缩</h2>
 
     <div class="run-row">

--- a/locales/zh/tools/crop-video.html
+++ b/locales/zh/tools/crop-video.html
@@ -31,7 +31,7 @@
   </section>
 
   <!-- 第 2 步，裁剪框 -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> 拉出裁剪框</h2>
 
     <p class="stage-hint">
@@ -84,7 +84,7 @@
   </section>
 
   <!-- 第 3 步，导出 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 开裁</h2>
 
     <div class="settings">

--- a/locales/zh/tools/document-scanner.html
+++ b/locales/zh/tools/document-scanner.html
@@ -149,7 +149,7 @@
   </section>
 
   <!-- 第 4 步 | 文件 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> 保存文档</h2>
 
     <p class="card-lede">

--- a/locales/zh/tools/edit-audio.html
+++ b/locales/zh/tools/edit-audio.html
@@ -36,7 +36,7 @@
   </section>
 
   <!-- 第 2 步，改点什么 -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> 动手改</h2>
 
     <div class="edit-block">
@@ -130,7 +130,7 @@
   </section>
 
   <!-- 第 3 步，出文件 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 保存</h2>
 
     <div class="settings">

--- a/locales/zh/tools/encode-text.html
+++ b/locales/zh/tools/encode-text.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 把结果带走</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/zh/tools/exif-editor.html
+++ b/locales/zh/tools/exif-editor.html
@@ -79,7 +79,7 @@
   </section>
 
   <!-- 第 3 步，细看和修改 -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> 翻开看看，想改哪条改哪条</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/locales/zh/tools/format-json.html
+++ b/locales/zh/tools/format-json.html
@@ -113,7 +113,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 把结果带走</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/locales/zh/tools/gif-maker.html
+++ b/locales/zh/tools/gif-maker.html
@@ -147,7 +147,7 @@
   </section>
 
   <!-- 第三步 &mdash; 导出 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 做出 GIF</h2>
 
     <div class="export-row">

--- a/locales/zh/tools/grab-frame.html
+++ b/locales/zh/tools/grab-frame.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- 第二步 &mdash; 那个瞬间 -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> 找到那一帧</h2>
 
     <p class="stage-hint">
@@ -65,7 +65,7 @@
   </section>
 
   <!-- 第三步 &mdash; 截图 -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> 把这一帧取下来</h2>
 
     <div class="settings">
@@ -114,7 +114,7 @@
   </section>
 
   <!-- 第四步 &mdash; 截出来的东西 -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> 截出来的图</h2>
 
     <div class="toolbar">

--- a/locales/zh/tools/hash-checksum.html
+++ b/locales/zh/tools/hash-checksum.html
@@ -124,7 +124,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> 和本该是的值对一下</h2>
     <p class="card-lede">
       把下载页面给你的校验和粘进来。什么形式都不要紧：光是十六进制、

--- a/locales/zh/tools/heic-to-jpg.html
+++ b/locales/zh/tools/heic-to-jpg.html
@@ -73,7 +73,7 @@
   </section>
 
   <!-- 第 3 步，按一下就完 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 转换</h2>
 
     <div class="run-row">

--- a/locales/zh/tools/id-photo.html
+++ b/locales/zh/tools/id-photo.html
@@ -152,7 +152,7 @@
   </section>
 
   <!-- 第五步 &mdash; 文件 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> 保存</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/locales/zh/tools/image-to-data-uri.html
+++ b/locales/zh/tools/image-to-data-uri.html
@@ -110,7 +110,7 @@
 
   <!-- Step 3 &mdash; the result. There is no button here on purpose: encoding
        is instant, so there is nothing for a "convert" press to wait for. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> 复制</h2>
 
     <p id="empty-note" class="card-lede">

--- a/locales/zh/tools/image-to-ico.html
+++ b/locales/zh/tools/image-to-ico.html
@@ -128,7 +128,7 @@
   </section>
 
   <!-- 第 3 步，先按真实大小看看，再拿走 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> 按它真正被看到的大小检查一遍</h2>
 
     <p class="card-lede">

--- a/locales/zh/tools/images-to-pdf.html
+++ b/locales/zh/tools/images-to-pdf.html
@@ -205,7 +205,7 @@
   </section>
 
   <!-- 第 3 步，导出 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 生成 PDF</h2>
 
     <div class="export-row">

--- a/locales/zh/tools/images-to-video.html
+++ b/locales/zh/tools/images-to-video.html
@@ -146,7 +146,7 @@
   </section>
 
   <!-- 第 3 步，导出 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 生成视频</h2>
 
     <div class="export-row">

--- a/locales/zh/tools/merge-pdf.html
+++ b/locales/zh/tools/merge-pdf.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- 第二步 &mdash; 页面 -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> 安排页面</h2>
 
     <p class="card-lede">
@@ -48,7 +48,7 @@
   </section>
 
   <!-- 第三步 &mdash; 一个文件，还是好几个 -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> 一份文档，还是好几份</h2>
 
     <fieldset class="presets-set">
@@ -113,7 +113,7 @@
   </section>
 
   <!-- 第四步 &mdash; 那一下点击 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 拼起来</h2>
 
     <div class="run-row">

--- a/locales/zh/tools/qr-barcode-reader.html
+++ b/locales/zh/tools/qr-barcode-reader.html
@@ -62,7 +62,7 @@
   </section>
 
   <!-- 第 2 步，答案 -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> 里面写了什么</h2>
 
     <p class="card-lede">

--- a/locales/zh/tools/redact-image.html
+++ b/locales/zh/tools/redact-image.html
@@ -101,7 +101,7 @@
   </section>
 
   <!-- 第三步：文件 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> 保存涂好的那一份</h2>
 
     <p class="card-lede">

--- a/locales/zh/tools/redact-pdf.html
+++ b/locales/zh/tools/redact-pdf.html
@@ -28,7 +28,7 @@
   </section>
 
   <!-- 第 2 步 | 找 -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> 说清什么要走</h2>
 
     <p class="card-lede">
@@ -71,7 +71,7 @@
   </section>
 
   <!-- 第 3 步 | 读页面 -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> 读这一页，从上面挑词</h2>
 
     <p class="card-lede">
@@ -93,7 +93,7 @@
   </section>
 
   <!-- 第 4 步 | 动手 -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 拿掉这些词</h2>
 
     <label class="check">

--- a/locales/zh/tools/resize-image.html
+++ b/locales/zh/tools/resize-image.html
@@ -186,7 +186,7 @@
   </section>
 
   <!-- 第 4 步，格式，然后按一下 -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> 保存</h2>
 
     <div class="settings">

--- a/locales/zh/tools/reverse-video.html
+++ b/locales/zh/tools/reverse-video.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- 第二步 &mdash; 倒过来 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> 倒过来</h2>
 
     <div class="settings">

--- a/locales/zh/tools/split-gif.html
+++ b/locales/zh/tools/split-gif.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- 第二步 &mdash; 出来的东西 -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> 帧怎么出</h2>
 
     <div class="settings">
@@ -87,7 +87,7 @@
   </section>
 
   <!-- 第三步 &mdash; 帧本身 -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> 拆出来的帧</h2>
 
     <div class="toolbar">

--- a/locales/zh/tools/stack-images.html
+++ b/locales/zh/tools/stack-images.html
@@ -138,7 +138,7 @@
   </section>
 
   <!-- 第 3 步 | 跑 -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> 堆栈</h2>
 
     <div class="export-row">

--- a/locales/zh/tools/svg-to-image.html
+++ b/locales/zh/tools/svg-to-image.html
@@ -164,7 +164,7 @@
   </section>
 
   <!-- 第 4 步，先看，再拿走 -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> 先看一眼，再保存</h2>
 
     <p class="card-lede">

--- a/locales/zh/tools/timelapse-video.html
+++ b/locales/zh/tools/timelapse-video.html
@@ -37,7 +37,7 @@
   </section>
 
   <!-- 第 2 步，倍数 -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> 选倍数</h2>
 
     <div class="speed-row" role="group" aria-label="片子要加速多少">
@@ -108,7 +108,7 @@
   </section>
 
   <!-- 第 3 步，导出 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 做延时视频</h2>
 
     <dl class="summary" id="summary">

--- a/locales/zh/tools/trim-audio.html
+++ b/locales/zh/tools/trim-audio.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- 第二步 &mdash; 标记 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> 标出你要的段落
       <span class="editing" id="editing" hidden></span>
@@ -126,7 +126,7 @@
   </section>
 
   <!-- 第三步 &mdash; 出来的文件 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 剪</h2>
 
     <div class="settings">

--- a/locales/zh/tools/trim-video.html
+++ b/locales/zh/tools/trim-video.html
@@ -27,7 +27,7 @@
   </section>
 
   <!-- 第 2 步，标记 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> 把要留的段落标出来
       <span class="editing" id="editing" hidden></span>
@@ -137,7 +137,7 @@
   </section>
 
   <!-- 第 3 步，导出 -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 开剪</h2>
 
     <div class="settings">

--- a/locales/zh/tools/video-to-gif.html
+++ b/locales/zh/tools/video-to-gif.html
@@ -31,7 +31,7 @@
   </section>
 
   <!-- 第 2 步，挑段落 -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> 挑出那一段</h2>
 
     <p class="hint">
@@ -77,7 +77,7 @@
   </section>
 
   <!-- 第 3 步，出 GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> 尺寸和帧率</h2>
 
     <div class="settings">

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -374,6 +374,32 @@ main, .topbar, .crumbs, .privacy, .pledge, .faq, .tool-next, footer {
   box-shadow: var(--shadow);
 }
 
+/* A step that cannot do anything yet.
+
+   Every numbered step is on the page from the first moment, so the whole job
+   is readable before a file is handed over - which is the point of a site
+   that asks for your files. The last step is the one that acts, so it waits:
+   greyed, and inert, until there is something to act on.
+
+   `inert` does the real work - it takes the whole card out of the tab order
+   and stops every control in it - and the two lines under it are for the
+   browsers that do not know the attribute yet, where the card would otherwise
+   look disabled and not be. The buttons inside are disabled in their own
+   right, so this is the belt rather than the braces.
+
+   No transition on the opacity. One was tried and the card stayed grey: a
+   transition begun inside an inert subtree sits at currentTime 0 and never
+   advances, so the card kept the value it was animating away from long after
+   the attribute had gone. Instant is also the honest reading - the step
+   becomes usable the moment the file lands, and a fade would say it was still
+   thinking. */
+.card[inert] {
+  opacity: 0.55;
+  pointer-events: none;
+  user-select: none;
+}
+
+
 /* A step's heading, whether it stands on its own or is the summary of the fold
    its explanation went into. buildlib/cards.py moves it inside a <summary>
    wherever a card opens with a `card-lede`, so a rule that only knew the first
@@ -1293,6 +1319,11 @@ ins.adsbygoogle[data-ad-status="unfilled"] { display: none !important; }
   --surface-2, never a second call to action shouting over the first. The
   links are the other tools' names, which is all they need to be.
 */
+/* Greyed while there is nothing to carry, the same way a step that cannot act
+   yet is greyed. It is readable throughout - the point of showing it early is
+   that somebody can see where this tool leads before they commit a file. */
+.handoff[inert] { opacity: 0.55; pointer-events: none; }
+
 .handoff {
   margin-top: 0.8rem;
   padding: 0.6rem 0.9rem;

--- a/shared/handoff.js
+++ b/shared/handoff.js
@@ -194,7 +194,8 @@
     // re-runs this function, which sets it again - a microtask loop that
     // freezes the tab. Writing only on change is what breaks the cycle.
     if (!anchor) {
-      if (!nav.hidden) nav.hidden = true;
+      // No result yet. The row stays where the markup put it, saying what this
+      // tool feeds; whether it is still inert is file-picker.js's business.
       return;
     }
     // Under the result the download belongs to. A tool laid out in a way this
@@ -207,6 +208,9 @@
       anchor.insertAdjacentElement('afterend', nav);
     }
     if (nav.hidden) nav.hidden = false;
+    // A result is the strongest possible sign there is something to carry, so
+    // the row is live from here whatever the picker did.
+    if (nav.hasAttribute('inert')) nav.removeAttribute('inert');
   }
 
   // Tools reveal the link by unhiding it and swapping its href for each new

--- a/shared/js/file-picker.js
+++ b/shared/js/file-picker.js
@@ -48,7 +48,17 @@ export function wireFilePicker({ input, dropzone, onFiles, idleTitle }) {
 
   const hand = (files) => {
     const picked = Array.from(files ?? []);
-    if (picked.length) onFiles(picked);
+    if (!picked.length) return;
+    // The last step of a tool is on the page from the start but inert, so the
+    // whole job can be read before anything is handed over. This is the moment
+    // it stops waiting, and it is done here because this is the one place every
+    // tool's files arrive through - from the input or from a drop - so no tool
+    // has to remember to do it. `inert` is used for nothing else on these
+    // pages; see .card[inert] in tool-frame.css.
+    for (const card of document.querySelectorAll('main .card[inert]')) {
+      card.removeAttribute('inert');
+    }
+    onFiles(picked);
   };
 
   input.addEventListener('change', () => {

--- a/templates/partials/handoff.html
+++ b/templates/partials/handoff.html
@@ -6,6 +6,12 @@
   IndexedDB for the next page. See that file for why nothing in the journey
   touches the network.
 
+  Rendered inert rather than hidden: the row says which tools this one feeds,
+  and that is worth reading before you have handed anything over - it is half
+  of what the page is for. shared/js/file-picker.js takes the attribute off
+  when a file arrives, and handoff.js moves the row under the result once
+  there is one.
+
   Rendered rather than built in JavaScript for the same reason the feedback
   panel is: the lead line is translated in every locale's [ui.tool], and each
   link borrows the target tool's own localized name and address - so the row
@@ -16,7 +22,7 @@
   each name is drawn in CSS, where Arabic can turn it around; written here it
   would point out of the page in the one language that reads the other way.
 -->
-<nav class="handoff" id="handoff" aria-labelledby="handoff-lead" hidden>
+<nav class="handoff" id="handoff" aria-labelledby="handoff-lead" inert>
   <p class="handoff-lead" id="handoff-lead">{{ ui.tool.handoff_lead }}</p>
   <ul class="handoff-targets">
 {% for other in handoff %}    <li>

--- a/tests/python/test_build.py
+++ b/tests/python/test_build.py
@@ -559,6 +559,58 @@ class BuildTheSite(unittest.TestCase):
                 with self.subTest(page=name, tag=tag):
                     self.assertIn('target="_blank"', tag)
 
+    def test_every_numbered_step_is_on_the_page_and_only_the_last_one_waits(self):
+        """What a tool can do is readable before a file is handed over.
+
+        A step that appears only once the work has started tells somebody
+        nothing while they are deciding whether to start it, and this site asks
+        for people's files - so the whole job is on the page from the first
+        paint. The step that acts is the exception: it is there, and greyed,
+        until there is something to act on, which shared/js/file-picker.js
+        clears the moment a file arrives.
+
+        Panels that are not numbered steps are not covered. The GIF analyser's
+        findings and the DICOM viewer's facts have nothing to say before a
+        file, and four empty boxes would be worse than none.
+
+        The last rule is the one that matters most: the card holding the file
+        input can never be the waiting one. Two tools have a single numbered
+        step, and that step IS the picker - marking it inert made the tool
+        impossible to use at all, which is how this test came to exist.
+        """
+        card = re.compile(r'<section class="card"([^>]*)>(.*?)</section>', re.S)
+        step = re.compile(r'class="step"')
+
+        for name in self.tool_pages():
+            text = (self.out / name).read_text(encoding='utf-8')
+            cards = [(m.group(1), m.group(2)) for m in card.finditer(text)]
+            steps = [(attrs, inner) for attrs, inner in cards if step.search(inner)]
+            if not steps:
+                continue
+
+            with self.subTest(page=name):
+                for attrs, inner in steps:
+                    heading = re.search(r'<h2[^>]*>(.*?)</h2>', inner, re.S)
+                    where = ' '.join(re.sub(r'<[^>]+>', '', heading.group(1)).split())[:40]
+                    self.assertNotIn(
+                        ' hidden', attrs,
+                        f'the step "{where}" starts hidden, so what this tool '
+                        f'does cannot be read before a file is chosen')
+
+                waiting = [(attrs, inner) for attrs, inner in cards if ' inert' in attrs]
+                self.assertLessEqual(
+                    len(waiting), 1,
+                    'more than one card waits; only the step that acts should')
+                for attrs, inner in waiting:
+                    self.assertNotIn(
+                        'id="file-input"', inner,
+                        'the card holding the file input is inert, so there is '
+                        'no way to give the tool a file at all')
+                if waiting:
+                    self.assertIs(
+                        waiting[0][0], steps[-1][0],
+                        'the waiting card is not the last numbered step')
+
     def test_a_tool_page_asks_its_question(self):
         """The panel, and the one script that can act on it.
 

--- a/tools/compare-text/body.html
+++ b/tools/compare-text/body.html
@@ -78,7 +78,7 @@
   </section>
 
   <!-- Step 3 &mdash; what changed -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Read what changed</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/tools/compress-image/body.html
+++ b/tools/compress-image/body.html
@@ -95,7 +95,7 @@
   </section>
 
   <!-- Step 3 &mdash; the one click -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Compress</h2>
 
     <div class="run-row">

--- a/tools/compress-pdf/body.html
+++ b/tools/compress-pdf/body.html
@@ -18,7 +18,7 @@
   </section>
 
   <!-- Step 2 &mdash; the screen this tool would keep if it could keep only one -->
-  <section class="card" id="inventory-card" hidden>
+  <section class="card" id="inventory-card">
     <h2><span class="step">2</span> See where the size is</h2>
 
     <p class="card-lede">
@@ -41,7 +41,7 @@
   </section>
 
   <!-- Step 3 &mdash; how much to spend -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">3</span> Say how hard to squeeze</h2>
 
     <p class="card-lede">
@@ -121,7 +121,7 @@
   </section>
 
   <!-- Step 4 &mdash; the one click -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Compress</h2>
 
     <div class="run-row">

--- a/tools/compress-pdf/src/main.js
+++ b/tools/compress-pdf/src/main.js
@@ -112,9 +112,6 @@ async function load(file) {
     el.fileRow.hidden = false;
 
     renderInventory(inventory);
-    el.inventoryCard.hidden = false;
-    el.settingsCard.hidden = false;
-    el.runCard.hidden = false;
     renderSettings();
 
     if (doc.repaired) {
@@ -148,9 +145,6 @@ function messageFor(error) {
 function reset() {
   loaded = null;
   el.fileRow.hidden = true;
-  el.inventoryCard.hidden = true;
-  el.settingsCard.hidden = true;
-  el.runCard.hidden = true;
   el.result.hidden = true;
   el.progress.hidden = true;
   el.loadError.hidden = true;

--- a/tools/crop-video/body.html
+++ b/tools/crop-video/body.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Step 2 &mdash; the crop -->
-  <section class="card" id="crop-card" hidden>
+  <section class="card" id="crop-card">
     <h2><span class="step">2</span> Set the crop</h2>
 
     <p class="stage-hint">
@@ -81,7 +81,7 @@
   </section>
 
   <!-- Step 3 &mdash; the export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Crop it</h2>
 
     <div class="settings">

--- a/tools/crop-video/src/main.js
+++ b/tools/crop-video/src/main.js
@@ -194,8 +194,6 @@ async function loadFile(picked) {
     cropper.setSource(source.width, source.height);
     setAspect('free', el.aspectRow.querySelector('[data-aspect="free"]'));
 
-    el.cropCard.hidden = false;
-    el.exportCard.hidden = false;
     el.exportBtn.disabled = false;
     updateFormatOptions();
     updateSummary();
@@ -286,8 +284,6 @@ function releaseFile() {
 
 function resetView() {
   el.source.hidden = true;
-  el.cropCard.hidden = true;
-  el.exportCard.hidden = true;
   el.pathNote.hidden = true;
   releaseFile();
 }

--- a/tools/document-scanner/body.html
+++ b/tools/document-scanner/body.html
@@ -162,7 +162,7 @@
   </section>
 
   <!-- Step 4 &mdash; the file -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Save the document</h2>
 
     <p class="card-lede">

--- a/tools/edit-audio/body.html
+++ b/tools/edit-audio/body.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Step 2 &mdash; the edits -->
-  <section class="card" id="edit-card" hidden>
+  <section class="card" id="edit-card">
     <h2><span class="step">2</span> Change it</h2>
 
     <div class="edit-block">
@@ -129,7 +129,7 @@
   </section>
 
   <!-- Step 3 &mdash; the file that comes out -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Save it</h2>
 
     <div class="settings">

--- a/tools/edit-audio/src/main.js
+++ b/tools/edit-audio/src/main.js
@@ -112,8 +112,6 @@ async function loadFile(picked) {
     sourcePeak = peak(decoded.channels);
 
     showSource();
-    el.editCard.hidden = false;
-    el.exportCard.hidden = false;
     updateSummary();
   } catch (error) {
     if (error instanceof UnreadableFile) showError(error.message);

--- a/tools/encode-text/body.html
+++ b/tools/encode-text/body.html
@@ -59,7 +59,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Take the result</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/tools/exif-editor/body.html
+++ b/tools/exif-editor/body.html
@@ -83,7 +83,7 @@
   </section>
 
   <!-- Step 3 &mdash; reading and editing -->
-  <section class="card" id="inspect-card">
+  <section class="card" id="inspect-card" inert>
     <h2><span class="step">3</span> Look inside, and change what you like</h2>
 
     <p id="inspect-empty" class="empty-note">

--- a/tools/format-json/body.html
+++ b/tools/format-json/body.html
@@ -114,7 +114,7 @@
   </section>
 
   <!-- Step 3 &mdash; what came out -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Take the result</h2>
 
     <p id="error" class="error" role="alert" hidden></p>

--- a/tools/gif-maker/body.html
+++ b/tools/gif-maker/body.html
@@ -148,7 +148,7 @@
   </section>
 
   <!-- Step 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Make the GIF</h2>
 
     <div class="export-row">

--- a/tools/grab-frame/body.html
+++ b/tools/grab-frame/body.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Step 2 &mdash; the moment -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Find the frame</h2>
 
     <p class="stage-hint">
@@ -67,7 +67,7 @@
   </section>
 
   <!-- Step 3 &mdash; the still -->
-  <section class="card" id="grab-card" hidden>
+  <section class="card" id="grab-card">
     <h2><span class="step">3</span> Take the still</h2>
 
     <div class="settings">
@@ -118,7 +118,7 @@
   </section>
 
   <!-- Step 4 &mdash; what came out -->
-  <section class="card" id="shots-card" hidden>
+  <section class="card" id="shots-card" inert>
     <h2><span class="step">4</span> Your stills</h2>
 
     <div class="toolbar">

--- a/tools/grab-frame/src/main.js
+++ b/tools/grab-frame/src/main.js
@@ -218,8 +218,6 @@ async function loadFile(picked) {
     updateFormatNote();
     setUpTransport();
 
-    el.findCard.hidden = false;
-    el.grabCard.hidden = false;
 
     await goTo(0);
   } catch (error) {
@@ -290,8 +288,6 @@ function releaseFile() {
 
 function resetView() {
   el.source.hidden = true;
-  el.findCard.hidden = true;
-  el.grabCard.hidden = true;
   el.pathNote.hidden = true;
   releaseFile();
 }
@@ -568,7 +564,6 @@ function addShot({ blob, time, width, height, type }) {
 }
 
 function renderShots() {
-  el.shotsCard.hidden = shots.length === 0;
   el.shotsCount.textContent = shots.length === 1
     ? '1 still, held in this page only'
     : `${shots.length} stills, held in this page only`;

--- a/tools/hash-checksum/body.html
+++ b/tools/hash-checksum/body.html
@@ -135,7 +135,7 @@
     </div>
   </section>
 
-  <section class="card" id="compare-card">
+  <section class="card" id="compare-card" inert>
     <h2><span class="step">3</span> Check it against what it should be</h2>
     <p class="card-lede">
       Paste the checksum the download page gave you. The shape does not matter

--- a/tools/heic-to-jpg/body.html
+++ b/tools/heic-to-jpg/body.html
@@ -79,7 +79,7 @@
   </section>
 
   <!-- Step 3 &mdash; the one click -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Convert</h2>
 
     <div class="run-row">

--- a/tools/id-photo/body.html
+++ b/tools/id-photo/body.html
@@ -169,7 +169,7 @@
   </section>
 
   <!-- Step 5 &mdash; the files -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">5</span> Save it</h2>
 
     <p class="card-lede" id="ready-line"></p>

--- a/tools/image-to-data-uri/body.html
+++ b/tools/image-to-data-uri/body.html
@@ -118,7 +118,7 @@
 
   <!-- Step 3 &mdash; the result. There is no button here on purpose: encoding
        is instant, so there is nothing for a "convert" press to wait for. -->
-  <section class="card" id="output-card">
+  <section class="card" id="output-card" inert>
     <h2><span class="step">3</span> Copy it</h2>
 
     <p id="empty-note" class="card-lede">

--- a/tools/image-to-ico/body.html
+++ b/tools/image-to-ico/body.html
@@ -135,7 +135,7 @@
   </section>
 
   <!-- Step 3 &mdash; see it small, then take it -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">3</span> Check it at the size it will be seen</h2>
 
     <p class="card-lede">

--- a/tools/images-to-pdf/body.html
+++ b/tools/images-to-pdf/body.html
@@ -204,7 +204,7 @@
   </section>
 
   <!-- Step 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Create the PDF</h2>
 
     <div class="export-row">

--- a/tools/images-to-video/body.html
+++ b/tools/images-to-video/body.html
@@ -140,7 +140,7 @@
   </section>
 
   <!-- Step 3 &mdash; export -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Create the video</h2>
 
     <div class="export-row">

--- a/tools/merge-pdf/body.html
+++ b/tools/merge-pdf/body.html
@@ -12,7 +12,7 @@
   </section>
 
   <!-- Step 2 &mdash; the pages -->
-  <section class="card" id="pages-card" hidden>
+  <section class="card" id="pages-card">
     <h2><span class="step">2</span> Arrange the pages</h2>
 
     <p class="card-lede">
@@ -51,7 +51,7 @@
   </section>
 
   <!-- Step 3 &mdash; one file, or several -->
-  <section class="card" id="output-card" hidden>
+  <section class="card" id="output-card">
     <h2><span class="step">3</span> One document, or several</h2>
 
     <fieldset class="presets-set">
@@ -122,7 +122,7 @@
   </section>
 
   <!-- Step 4 &mdash; the one click -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Put it together</h2>
 
     <div class="run-row">

--- a/tools/merge-pdf/src/main.js
+++ b/tools/merge-pdf/src/main.js
@@ -579,9 +579,6 @@ function render() {
   renderSources();
 
   const has = entries.length > 0;
-  el.pagesCard.hidden = sources.length === 0;
-  el.outputCard.hidden = !has;
-  el.runCard.hidden = !has;
 
   el.countLabel.textContent = has
     ? `${count(entries.length, 'page')} in the running order`

--- a/tools/qr-barcode-reader/body.html
+++ b/tools/qr-barcode-reader/body.html
@@ -62,7 +62,7 @@
   </section>
 
   <!-- Step 2 &mdash; the answer -->
-  <section class="card" id="results-card" hidden>
+  <section class="card" id="results-card" inert>
     <h2><span class="step">2</span> What it says</h2>
 
     <p class="card-lede">

--- a/tools/qr-barcode-reader/src/main.js
+++ b/tools/qr-barcode-reader/src/main.js
@@ -266,7 +266,6 @@ function report(found) {
 
   el.results.prepend(render(found));
   while (el.results.children.length > MOST_KEPT) el.results.lastElementChild.remove();
-  el.resultsCard.hidden = false;
   return true;
 }
 

--- a/tools/redact-image/body.html
+++ b/tools/redact-image/body.html
@@ -113,7 +113,7 @@
   </section>
 
   <!-- Step 3 &mdash; the file -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">3</span> Save the redacted copy</h2>
 
     <p class="card-lede">

--- a/tools/redact-pdf/body.html
+++ b/tools/redact-pdf/body.html
@@ -16,7 +16,7 @@
   </section>
 
   <!-- Step 2 &mdash; finding it -->
-  <section class="card" id="find-card" hidden>
+  <section class="card" id="find-card">
     <h2><span class="step">2</span> Say what has to go</h2>
 
     <p class="card-lede">
@@ -64,7 +64,7 @@
   </section>
 
   <!-- Step 3 &mdash; reading the page -->
-  <section class="card" id="page-card" hidden>
+  <section class="card" id="page-card">
     <h2><span class="step">3</span> Read the page, and pick words off it</h2>
 
     <p class="card-lede">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Step 4 &mdash; doing it -->
-  <section class="card" id="run-card" hidden>
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Take the words out</h2>
 
     <label class="check">

--- a/tools/redact-pdf/src/main.js
+++ b/tools/redact-pdf/src/main.js
@@ -207,9 +207,6 @@ function breathe() {
 function renderDocument() {
   const ready = pages.length > 0 && source !== null;
   el.docFacts.hidden = !ready;
-  el.findCard.hidden = !ready;
-  el.pageCard.hidden = !ready;
-  el.runCard.hidden = !ready;
   if (!ready) return;
 
   el.docName.textContent = source.file.name;

--- a/tools/resize-image/body.html
+++ b/tools/resize-image/body.html
@@ -193,7 +193,7 @@
   </section>
 
   <!-- Step 4 &mdash; the format, and the one click -->
-  <section class="card" id="save-card">
+  <section class="card" id="save-card" inert>
     <h2><span class="step">4</span> Save it</h2>
 
     <div class="settings">

--- a/tools/reverse-video/body.html
+++ b/tools/reverse-video/body.html
@@ -29,7 +29,7 @@
   </section>
 
   <!-- Step 2 &mdash; the reversal -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">2</span> Reverse it</h2>
 
     <div class="settings">

--- a/tools/reverse-video/src/main.js
+++ b/tools/reverse-video/src/main.js
@@ -221,7 +221,6 @@ async function loadFile(picked) {
     showPreview(played.ok);
     describeSource(played);
 
-    el.exportCard.hidden = false;
     el.exportBtn.disabled = false;
     updateAudioNote();
     updateSummary();
@@ -297,7 +296,6 @@ function resetView() {
   el.source.hidden = true;
   el.previewWrap.hidden = true;
   el.stageNote.hidden = true;
-  el.exportCard.hidden = true;
   el.pathNote.hidden = true;
   releaseFile();
 }

--- a/tools/split-gif/body.html
+++ b/tools/split-gif/body.html
@@ -25,7 +25,7 @@
   </section>
 
   <!-- Step 2 &mdash; what comes out -->
-  <section class="card" id="settings-card" hidden>
+  <section class="card" id="settings-card">
     <h2><span class="step">2</span> How the frames come out</h2>
 
     <div class="settings">
@@ -89,7 +89,7 @@
   </section>
 
   <!-- Step 3 &mdash; the frames themselves -->
-  <section class="card" id="frames-card" hidden>
+  <section class="card" id="frames-card" inert>
     <h2><span class="step">3</span> The frames</h2>
 
     <div class="toolbar">

--- a/tools/split-gif/src/main.js
+++ b/tools/split-gif/src/main.js
@@ -165,8 +165,6 @@ function build() {
   }));
 
   el.frames.replaceChildren(...rows.map(makeRow));
-  el.settingsCard.hidden = false;
-  el.framesCard.hidden = false;
   applyEvery();
 }
 
@@ -593,8 +591,6 @@ function reset() {
   el.frames.replaceChildren();
   el.source.hidden = true;
   el.notice.hidden = true;
-  el.settingsCard.hidden = true;
-  el.framesCard.hidden = true;
   hideProgress();
 }
 

--- a/tools/stack-images/body.html
+++ b/tools/stack-images/body.html
@@ -133,7 +133,7 @@
   </section>
 
   <!-- Step 3 &mdash; run it -->
-  <section class="card">
+  <section class="card" inert>
     <h2><span class="step">3</span> Stack them</h2>
 
     <div class="export-row">

--- a/tools/svg-to-image/body.html
+++ b/tools/svg-to-image/body.html
@@ -166,7 +166,7 @@
   </section>
 
   <!-- Step 4 &mdash; look at it, then take it -->
-  <section class="card" id="run-card">
+  <section class="card" id="run-card" inert>
     <h2><span class="step">4</span> Look at it, then save it</h2>
 
     <p class="card-lede">

--- a/tools/timelapse-video/body.html
+++ b/tools/timelapse-video/body.html
@@ -30,7 +30,7 @@
   </section>
 
   <!-- Step 2 &mdash; the speed -->
-  <section class="card" id="speed-card" hidden>
+  <section class="card" id="speed-card">
     <h2><span class="step">2</span> Choose the speed</h2>
 
     <div class="speed-row" role="group" aria-label="How much to speed the clip up">
@@ -109,7 +109,7 @@
   </section>
 
   <!-- Step 3 &mdash; the export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Make the time-lapse</h2>
 
     <dl class="summary" id="summary">

--- a/tools/timelapse-video/src/main.js
+++ b/tools/timelapse-video/src/main.js
@@ -282,8 +282,6 @@ async function loadFile(picked) {
     describeSource();
     fitSizeOptions();
 
-    el.speedCard.hidden = false;
-    el.exportCard.hidden = false;
     el.exportBtn.disabled = false;
     setSpeed(defaultSpeed(), null);
   } catch (error) {
@@ -384,8 +382,6 @@ function resetView() {
   el.source.hidden = true;
   el.previewWrap.hidden = true;
   el.previewNote.hidden = true;
-  el.speedCard.hidden = true;
-  el.exportCard.hidden = true;
   el.pathNote.hidden = true;
   releaseFile();
 }

--- a/tools/trim-audio/body.html
+++ b/tools/trim-audio/body.html
@@ -23,7 +23,7 @@
   </section>
 
   <!-- Step 2 &mdash; the marks -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Mark the parts you want
       <span class="editing" id="editing" hidden></span>
@@ -136,7 +136,7 @@
   </section>
 
   <!-- Step 3 &mdash; the file that comes out -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Trim it</h2>
 
     <div class="settings">

--- a/tools/trim-audio/src/main.js
+++ b/tools/trim-audio/src/main.js
@@ -151,8 +151,6 @@ async function loadFile(picked) {
     watchUntil = null;
 
     showSource();
-    el.sectionCard.hidden = false;
-    el.exportCard.hidden = false;
 
     timeline.setSource({ duration: decoded.duration, summary });
     timeline.setEnabled(true);

--- a/tools/trim-video/body.html
+++ b/tools/trim-video/body.html
@@ -20,7 +20,7 @@
   </section>
 
   <!-- Step 2 &mdash; the marks -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2>
       <span class="step">2</span> Mark the parts you want
       <span class="editing" id="editing" hidden></span>
@@ -139,7 +139,7 @@
   </section>
 
   <!-- Step 3 &mdash; the export -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Cut it</h2>
 
     <div class="settings">

--- a/tools/trim-video/src/main.js
+++ b/tools/trim-video/src/main.js
@@ -147,8 +147,6 @@ async function addFiles(files) {
   if (!clips.length) return;
   describeSelection();
   renderClips();
-  el.sectionCard.hidden = false;
-  el.exportCard.hidden = false;
   updateMethodOptions();
 }
 
@@ -378,8 +376,6 @@ function removeClip(index) {
 
   if (!clips.length) {
     selected = -1;
-    el.sectionCard.hidden = true;
-    el.exportCard.hidden = true;
     el.preview.removeAttribute('src');
     el.preview.load();
     renderClips();

--- a/tools/video-to-gif/body.html
+++ b/tools/video-to-gif/body.html
@@ -24,7 +24,7 @@
   </section>
 
   <!-- Step 2 &mdash; the section -->
-  <section class="card" id="section-card" hidden>
+  <section class="card" id="section-card">
     <h2><span class="step">2</span> Pick the section</h2>
 
     <p class="hint">
@@ -72,7 +72,7 @@
   </section>
 
   <!-- Step 3 &mdash; the GIF -->
-  <section class="card" id="export-card" hidden>
+  <section class="card" id="export-card" inert>
     <h2><span class="step">3</span> Size and frame rate</h2>
 
     <div class="settings">

--- a/tools/video-to-gif/src/main.js
+++ b/tools/video-to-gif/src/main.js
@@ -222,8 +222,6 @@ async function loadFile(picked) {
     setSection(0, Math.min(duration, DEFAULT_SECTION || duration));
     chooseDefaultWidth();
 
-    el.sectionCard.hidden = false;
-    el.exportCard.hidden = false;
     el.exportBtn.disabled = false;
     updateSummary();
   } catch (error) {
@@ -294,8 +292,6 @@ function releaseFile() {
 
 function resetView() {
   el.source.hidden = true;
-  el.sectionCard.hidden = true;
-  el.exportCard.hidden = true;
   el.pathNote.hidden = true;
   releaseFile();
 }


### PR DESCRIPTION
The step-card inconsistency from the UI review, resolved the way you asked: everything visible and usable up front, with only the last step and the hand-off row greyed until a file is selected.

## What changed

**28 numbered step cards across 14 tools stop hiding.** Fifteen tools revealed their later steps only once a file arrived, so somebody deciding whether to hand over a passport photo or a contract saw one box and a promise. Twenty-one showed everything already — same numbered cards, two different meanings for a visible step 3.

**The last step waits, greyed.** It uses `inert`, so it is out of the tab order rather than merely looking disabled, with `opacity`/`pointer-events` behind it for browsers that do not know the attribute. The buttons inside were already disabled in their own right, so this is belt rather than braces.

**The carry-on row is greyed rather than hidden.** Where a tool leads is worth reading before you commit to it; it used to appear only once a result existed. It now sits on the page from the start, showing its targets, and goes live when a file arrives (and moves under the result once there is one, as before).

## How it knows when to stop waiting

Nothing per-tool. Every file a tool receives arrives through `wireFilePicker` — from the input or from a drop — so the attribute comes off there. One place, thirty-three tools, none of them aware of it. The 39 `card.hidden = …` lines the old behaviour needed are deleted.

## What still hides

Panels that are not numbered steps. The GIF analyser's *What stands out*, *Where the bytes went*, *The colours* and the DICOM viewer's *What this file is* have nothing to say before a file — four empty boxes tell a visitor less than none. The rule is "numbered step", not "card".

## Two traps, both found by running it

**A card holding the file input can never be the one that waits.** gif-analyzer and dicom-viewer have a single numbered step, and it *is* the picker — so the first pass marked it inert and made both tools impossible to use at all. There was no way to give them a file. The new test refuses that arrangement by name.

**The greyed card stayed grey.** I had added a 120 ms opacity transition; a transition begun inside an inert subtree sits at `currentTime: 0` and never advances, so the card kept the value it was animating away from long after the attribute had gone. Diagnosed with `getAnimations()`, and removed — instant is also the honest reading, since the step becomes usable the moment the file lands.

## Verified

Driven in the browser rather than inferred:

| | before a file | after a file |
|---|---|---|
| trim-video steps 1–2 | visible, interactive | unchanged |
| trim-video step 3 "Cut it" | visible, `inert`, opacity 0.55 | opacity 1, interactive |
| hand-off row | visible, greyed, listing *Video to GIF* and *Video Reverser* | live |
| compress-image "3 Compress" | inert, run button disabled | inert cleared, button enabled |
| gif-analyzer, dicom-viewer | picker usable, result panels hidden | — |

A new build test holds all of it: no numbered step may start hidden, at most one card may wait, it must be the last step, and it must not contain the file input. I planted both violations to check the test bites — it fails with the message naming the step.

Python 464 OK, JS 1935 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)