### PR TITLE
Count the English left in the JavaScript, so that it can only fall

### DIFF
--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -1,0 +1,201 @@
+"""
+The English still living in the JavaScript, counted, so that it can only fall.
+
+WHY THIS EXISTS
+
+`shared/js/phrases.js` says it at length: nothing under `tools/<slug>/src/` is
+translated. The build copies it byte for byte into all fifteen languages, so a
+sentence written in a module is that sentence in English at fourteen of the
+addresses it appears at. The rule is that the words live in the markup, where
+the locale machinery already reaches them, and the JavaScript reads them back
+with `phrase()`.
+
+Most of the site does not do that yet. A sweep of every string literal in every
+tool finds about fifteen hundred sentences that a visitor can be shown, and
+they are not the leftovers - they are the explaining voice of the tools that
+explain most. The GIF analyser's byte budget, the DICOM viewer's header
+diagnostics and the EXIF editor's format refusals are all English, in every
+language.
+
+Moving them is a long job. This file is what stops it getting longer while it
+happens: every tool has a number below, and a tool may go down but not up.
+
+WHAT IS COUNTED
+
+String literals, from `minify.tokenize_js` so that comments and regular
+expressions are not mistaken for them, that read like a sentence a person is
+meant to understand: more than a few characters, containing a word from
+`PROSE`, and not obviously a key, a MIME type, a path or a CSS declaration.
+
+It is a heuristic and it is allowed to be. Nothing here decides whether a
+particular string is a bug - it produces a number that can be compared with the
+same number tomorrow. A count that is a little too high is harmless; what would
+be harmful is a count that moves when nothing moved, which is why the tokenizer
+does the reading rather than a regular expression over the raw file.
+
+WHEN THIS FAILS
+
+Going up means a sentence was written into a module. Put it in the tool's
+`#phrases` block and read it with `phrase()` instead; if the module is a leaf
+that cannot reach the DOM, return the key and let `main.js` resolve it, the way
+svg-to-image's `sourceKey` does.
+
+Going down means somebody moved sentences out, which is the point - lower the
+number here in the same commit, so that what is left is always what the file
+says is left.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+from buildlib import minify
+
+ROOT = Path(__file__).resolve().parents[2]
+TOOLS = ROOT / 'tools'
+
+# Sentences left in each tool's JavaScript. Lower these as they are moved into
+# the markup; nothing may raise one. See the module docstring.
+BASELINE = {
+    'compare-text': 3,
+    'compress-image': 2,
+    'compress-pdf': 66,
+    'crop-video': 55,
+    'dicom-viewer': 83,
+    'document-scanner': 13,
+    'edit-audio': 25,
+    'encode-text': 23,
+    'exif-editor': 98,
+    'format-json': 61,
+    'gif-analyzer': 108,
+    'gif-maker': 22,
+    'grab-frame': 47,
+    'hash-checksum': 10,
+    'heic-to-jpg': 35,
+    'id-photo': 106,
+    'image-to-data-uri': 20,
+    'image-to-ico': 71,
+    'images-to-pdf': 26,
+    'images-to-video': 26,
+    'merge-pdf': 63,
+    'password-generator': 8,
+    'qr-barcode': 44,
+    'qr-barcode-reader': 13,
+    'redact-image': 17,
+    'redact-pdf': 31,
+    'resize-image': 53,
+    'reverse-video': 63,
+    'share-text': 1,
+    'split-gif': 36,
+    'stack-images': 7,
+    'svg-to-image': 39,
+    'timelapse-video': 57,
+    'trim-audio': 41,
+    'trim-video': 101,
+    'video-to-gif': 47,
+}
+
+# A word here makes a string prose rather than a name. Deliberately ordinary
+# words: what marks a sentence out is that it is made of them.
+PROSE = re.compile(
+    r'\b(the|and|of|to|is|are|was|were|this|that|from|with|off|it|its|has|have'
+    r'|not|no|yes|all|one|too|but|so|than|then|what|which|when|where|why|how'
+    r'|file|files|image|images|video|frame|frames|page|pages|colour|colours'
+    r'|browser|nothing|something|anything|every|each|any|more|less|only'
+    r'|cannot|will|would|does|did|can|could|should|must|make|made|take|taken'
+    r'|show|shown|read|write|written|drawn|drawing|size|sizes|second|seconds)\b',
+    re.I)
+
+# Strings that are made of words and are still not prose.
+NOT_PROSE = (
+    # A phrase key, which is the fix rather than the fault.
+    re.compile(r'^[a-z0-9]+(?:\.[a-z0-9-]+)+$'),
+    # Addresses, types and selectors.
+    re.compile(r'^(?:\.{0,2}/|https?:|data:|blob:|mailto:)'),
+    re.compile(r'^(?:image|video|audio|application|text|font)/'),
+    re.compile(r'^[.#]?[a-z][\w-]*(?:\s*[>+~]\s*[.#]?[a-z][\w-]*)*$'),
+    # A run of CSS declarations, or one property name.
+    re.compile(r'^[a-z-]+\s*:\s*[^;]+(?:;|$)'),
+    # Markup a module builds, rather than words it shows.
+    re.compile(r'^<[a-z!/]'),
+)
+
+MIN_LENGTH = 6
+
+
+def prose_lines(tool):
+    """[(module, line, text)] for every string in a tool that reads like a sentence.
+
+    Adjacent literals are one sentence: the corpus builds long messages by
+    adding several strings together across lines, and counting each piece would
+    say a tool has three sentences where it has one.
+    """
+    found = []
+    for module in sorted((TOOLS / tool / 'src').glob('*.js')):
+        source = module.read_text(encoding='utf-8')
+        for line, token in minify.tokenize_js(source, str(module)):
+            if token[:1] not in ('"', "'", '`'):
+                continue
+            text = ' '.join(token[1:-1].split())
+            if len(text) < MIN_LENGTH or not PROSE.search(text):
+                continue
+            if any(pattern.match(text) for pattern in NOT_PROSE):
+                continue
+            found.append((module.name, line, text))
+
+    sentences, last = [], (None, -9)
+    for module, line, text in found:
+        if module != last[0] or line - last[1] > 1:
+            sentences.append((module, line, text))
+        last = (module, line)
+    return sentences
+
+
+class EnglishInJavaScript(unittest.TestCase):
+
+    def test_no_tool_grows_more_english(self):
+        for tool in sorted(p.parent.name for p in TOOLS.glob('*/src')):
+            with self.subTest(tool=tool):
+                self.assertIn(
+                    tool, BASELINE,
+                    f'{tool} is not in BASELINE. Count its sentences with this '
+                    f'file and add the number, so the next change to it can '
+                    f'only take the number down.')
+                found = prose_lines(tool)
+                allowed = BASELINE[tool]
+                if len(found) > allowed:
+                    # Which of them is new cannot be known from one number, and
+                    # guessing - showing the last few, say - points at
+                    # sentences that have been there for months. The whole list
+                    # is one command away instead.
+                    self.fail(
+                        f'{tool}: {len(found)} sentences in the JavaScript, '
+                        f'{allowed} allowed. A sentence a visitor reads has to '
+                        f'live in body.html so the other fourteen languages '
+                        f'get it too - see shared/js/phrases.js.\n'
+                        f'    All {len(found)}: '
+                        f'python -m tests.python.test_english_in_js {tool}')
+                self.assertEqual(
+                    len(found), allowed,
+                    f'{tool}: {len(found)} sentences left, and BASELINE still '
+                    f'says {allowed}. Somebody moved sentences into the markup '
+                    f'and did not lower the number; lower it to {len(found)} in '
+                    f'the same commit.')
+
+    def test_the_baseline_names_only_tools_that_exist(self):
+        on_disk = {p.parent.name for p in TOOLS.glob('*/src')}
+        self.assertEqual(
+            sorted(BASELINE), sorted(on_disk),
+            'BASELINE and the tools on disk disagree.')
+
+
+if __name__ == '__main__':
+    # `python -m tests.python.test_english_in_js <tool>` lists what it counted,
+    # which is what somebody moving one tool's sentences into the markup wants
+    # in front of them. With no argument it runs as a test like the rest.
+    import sys
+    if len(sys.argv) == 2 and (TOOLS / sys.argv[1]).is_dir():
+        for module, line, text in prose_lines(sys.argv[1]):
+            print(f'{module}:{line}  {text}')
+    else:
+        unittest.main()


### PR DESCRIPTION
Step one of the i18n programme: stop the debt growing before starting to pay it down.

## What it measures

Every string literal in every tool's `src/`, read with `minify.tokenize_js` so comments and regex literals are not mistaken for strings, filtered to the ones that read like a sentence a person is meant to understand. Adjacent literals count once, since the corpus builds long messages by adding several together across lines.

**1,521 sentences across 36 tools.** The worst are not the leftovers — they are the explaining voice of the tools that explain most:

| tool | sentences | sample |
|---|---|---|
| gif-analyzer | 108 | *"Eight bytes per frame: the delay, the disposal method, and which colour is transparent"* |
| id-photo | 106 | — |
| trim-video | 101 | *"This browser will not play this video, so the frames below are…"* |
| exif-editor | 98 | *"GIF has comment and application blocks rather than EXIF"* |
| dicom-viewer | 83 | *"The file meta group names no transfer syntax, so the dataset was read as Implicit VR Little Endian"* |

## How it behaves

A tool may go **down** but not **up**. A tool that goes down without its number following also fails — a baseline nobody lowers stops describing anything, and this way the file always says what is actually left.

It is a heuristic and the docstring says so plainly. It is not deciding whether any single string is a bug; it produces a number comparable with the same number tomorrow, which is all a ratchet needs. What would break it is a count that moves when nothing moved — hence the tokenizer rather than a regex over raw source.

## Checked in both directions, by hand

- A sentence added to `stack-images/src/main.js` → fails with `stack-images: 8 sentences in the JavaScript, 7 allowed`, naming the rule and where the words belong.
- A baseline left at 9 when 7 remain → fails with `lower it to 7 in the same commit`.

The failure message does **not** try to name which sentences are new — that is not knowable from one number, and guessing points at lines that have been there for months. It gives the command instead:

```bash
python -m tests.python.test_english_in_js gif-analyzer
```

which lists what it counted, for whoever is working through that tool.

Python suite: 465 OK.

## Next

Tools in order of what a non-English visitor loses: gif-analyzer, dicom-viewer, exif-editor, then the video tools' failure messages, then the batch progress lines. One PR each, about the size of #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)