### PR TITLE
Lower svg-to-image's baseline to the count its markup move left

### DIFF
--- a/tests/python/test_english_in_js.py
+++ b/tests/python/test_english_in_js.py
@@ -88,7 +88,7 @@ BASELINE = {
     'share-text': 1,
     'split-gif': 36,
     'stack-images': 7,
-    'svg-to-image': 39,
+    'svg-to-image': 27,
     'timelapse-video': 57,
     'trim-audio': 41,
     'trim-video': 101,


### PR DESCRIPTION
main has failed on every push since e3bc02947. The build itself is fine; the
failure is the ratchet in `tests/python/test_english_in_js.py`, which counts the
English sentences left in each tool's JavaScript:

```
FAIL: test_no_tool_grows_more_english (tool='svg-to-image')
AssertionError: 27 != 39 : svg-to-image: 27 sentences left, and BASELINE still
says 39. Somebody moved sentences into the markup and did not lower the number;
lower it to 27 in the same commit.
```

## Why it happened

Two pull requests that could not see each other, merged back to back:

| order | | |
|---|---|---|
| `156234f31` | #209 | added the ratchet, recording `'svg-to-image': 39` |
| `e3bc02947` | #202 | moved twelve of those sentences into the markup |

Each was branched before the other existed, so each passed its own CI against a
tree where it was right. The number has been wrong ever since, and neither
author could have known.

The assertion is an equality in both directions, deliberately — a baseline that
only refused to rise would drift quietly upwards from every move nobody
recorded. The cost of that choice is a line like this one when two pull requests
touch the same tool from opposite ends, which is the same shape as any counter
kept in a file and written by concurrent branches.

## What is here

One line: `39` → `27`. `svg-to-image` is the only tool out of step — every other
number in the table still agrees with the sweep.

## Checking it

```
python -m tests.python.test_english_in_js svg-to-image   # lists exactly 27
python -m unittest tests.python.test_english_in_js -v    # both tests, OK
```

The first is the command the failure message itself recommends, and its output
is the twelve-sentence drop #202 made: the run flow's prose now lives in
`body.html`, and what remains is the sizing arithmetic and the format
descriptions.

## Before and after

Nothing a visitor can see — this file is a test and renders no page.

Worth noting for whoever merges: the build job gates on these tests, so #204
through #211 have not deployed. Once this lands, `scripts/next_version.py` says
the deploy tags **1.0.3**, one patch covering that whole backlog, since the span
measured is the last tag to what is deployed rather than the previous commit.
This commit is under `tests/` and adds nothing to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
