### PR TITLE
Let the deploy see the tags it measures from

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,22 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      # `fetch-tags` because the version is a tag now. Without it the default
+      # checkout brings none, `git tag --list` on the runner is empty, and
+      # scripts/next_version.py takes its "nothing has ever been tagged"
+      # branch and proposes the FIRST version on every single deploy - which
+      # the remote then rejects, because 1.0.0 has existed since the day the
+      # scheme started. That is not a hypothetical: it failed nine deploys in
+      # a row, starting with the one that introduced the script.
+      #
+      # `fetch-depth` stays at the default 1. The tags come with the commits
+      # they point at, and `git diff <tag>..HEAD` compares two commit objects
+      # rather than walking between them, so the shallow history is enough.
+      # `fetch-depth: 0` would work too and would drag in the whole of the
+      # dist branch to do it.
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       # The build uses tomllib, which is standard library from 3.11 onwards.
       # Python alone produces a working, readable site: that is what plain
@@ -225,6 +240,7 @@ jobs:
           exit $status
 
       - name: Publish to the dist branch
+        id: publish
         if: github.event_name != 'pull_request'
         env:
           SHA: ${{ github.sha }}
@@ -317,7 +333,15 @@ jobs:
           # exists - but a step that pushes a ref should say what it does when
           # it is asked twice rather than fail the workflow after the site is
           # already live.
-          if git rev-parse -q --verify "refs/tags/$version" >/dev/null; then
+          #
+          # Asked of the REMOTE, which is where the push will be refused. This
+          # used to be `git rev-parse refs/tags/$version`, a local lookup, and
+          # a local lookup is worth nothing on a checkout that has no tags -
+          # the guard and the thing it guards against were both blind to the
+          # same fact. The step above now fetches them, so the local answer
+          # would be right today; asking the remote is right whether or not
+          # that stays true.
+          if git ls-remote --exit-code --tags origin "refs/tags/$version" >/dev/null 2>&1; then
             echo "Version $version is already tagged; nothing to do."
             exit 0
           fi
@@ -354,8 +378,22 @@ jobs:
       # a refused submission does not undo it, so a red run here would say
       # something untrue about the build. The status goes to the step summary
       # instead, and the step marks itself failed without stopping the job.
+      # Named against the publish rather than against whatever happens to sit
+      # above it. It carried `continue-on-error` and no condition, which reads
+      # as "this must never fail the deploy" and is only half of that: a step
+      # with an ordinary condition is SKIPPED once an earlier one has failed,
+      # so `continue-on-error` protected the job from IndexNow and left
+      # IndexNow at the mercy of the tag step. When tagging broke, nine deploys
+      # went out and no search engine was told about any of them - the exact
+      # failure the sitemap's `lastmod` work exists to prevent, and a silent
+      # one, because a skipped step is not a red mark on the run.
+      #
+      # `!cancelled()` rather than `always()`: a cancelled run should stop.
+      # The `steps.publish` test is the real dependency - there is nothing to
+      # announce if nothing was published, and `_site/sitemap.xml` might not
+      # even exist.
       - name: Tell IndexNow what changed
-        if: github.event_name != 'pull_request'
+        if: ${{ !cancelled() && github.event_name != 'pull_request' && steps.publish.outcome == 'success' }}
         continue-on-error: true
         run: |
           set -uo pipefail

--- a/tests/python/test_version.py
+++ b/tests/python/test_version.py
@@ -176,5 +176,60 @@ class WritingTheVersionBack(unittest.TestCase):
                 self.assertEqual(version.parse(version.dotted(nxt)), nxt)
 
 
+class TheCheckoutTheDeployRunsOn(unittest.TestCase):
+    """The rule above is pure, and the deploy still got the version wrong.
+
+    Not because the arithmetic failed. Because the checkout it runs on carried
+    no tags: `git tag --list` came back empty, `latest` returned None, and
+    next_version.py took its "nothing has ever been tagged" branch and proposed
+    FIRST. The remote has held 1.0.0 since the day the scheme started, so every
+    push was rejected - nine deploys in a row, each failing after the site was
+    already live and taking the IndexNow submission down with it.
+
+    Nothing in the rule could have caught that, because the rule was right. The
+    wrong thing was the ground it stood on, and the only place that is written
+    down is the workflow.
+
+    Read as text rather than parsed. The test job installs Python and Node and
+    nothing else, so there is no YAML parser here to reach for - and the
+    alternative to a crude assertion is the one the workflow's own comments
+    warn about: a decision that can only be tested by opening a pull request
+    against it.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        text = (ROOT / '.github' / 'workflows' / 'build.yml').read_text(
+            encoding='utf-8')
+        # The build job, and not the test job above it: both check out, and
+        # only one of them works out a version.
+        head, sep, tail = text.partition('\n  build:\n')
+        assert sep, 'build.yml has no build job'
+        cls.build = tail
+
+    def test_it_asks_for_the_tags(self):
+        # Without this the version is worked out on a checkout that cannot see
+        # a single tag, and the answer is always FIRST.
+        checkout = self.build.partition('actions/checkout')[2]
+        self.assertIn('fetch-tags: true', checkout.partition('- name:')[0])
+
+    def test_the_tag_guard_asks_the_remote(self):
+        # A local `git rev-parse refs/tags/...` is worth nothing on a checkout
+        # with no tags, which is exactly the case it existed to survive: the
+        # guard and the failure were blind to the same fact.
+        self.assertIn('git ls-remote --exit-code --tags origin', self.build)
+        self.assertNotIn('git rev-parse -q --verify "refs/tags/$version"',
+                         self.build)
+
+    def test_indexnow_does_not_ride_on_the_tag_step(self):
+        # `continue-on-error` stops IndexNow failing the deploy. It does not
+        # stop IndexNow being SKIPPED when an earlier step fails, which is how
+        # nine deploys went out with no search engine told about any of them.
+        indexnow = self.build.partition('Tell IndexNow what changed')[2]
+        condition = indexnow.partition('run:')[0]
+        self.assertIn('!cancelled()', condition)
+        self.assertIn("steps.publish.outcome == 'success'", condition)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
[#210](https://github.com/A-Box-of-Tools/website/pull/210) moved the version out
of `config/site.toml` and into a tag the deploy works out. **It has never once
succeeded.** Every Build run on `main` since that merge has failed — nine in a
row, starting with the run that merged it — and each one failed the same way:

```
! [rejected]  1.0.0 -> 1.0.0 (already exists)
```

## What is actually wrong

The rule is fine. The ground it stands on is not.

`actions/checkout` defaults to `fetch-depth: 1` and brings **no tags**. So on the
runner `git tag --list` is empty, `version.latest` returns `None`, and
`scripts/next_version.py` takes this branch:

```python
current = rule.latest(git('tag', '--list').splitlines())
if current is None:
    print(rule.dotted(rule.FIRST))          # 1.0.0
```

`1.0.0` has existed since the day the scheme started, so the push is refused —
and it would have proposed `1.0.0` on every deploy from now until somebody
looked.

Reproduced by cloning `main` the way the runner does:

```
$ git clone --depth 1 --branch main …
$ git tag --list | wc -l
0
$ python scripts/next_version.py
1.0.0
1.0.0: the first version.
```

and with the tags fetched, on the same checkout:

```
1.0.3
1.0.2 -> 1.0.3: a change a visitor could notice.
```

## The fix, and the two things around it that were wrong the same way

**The build job asks for the tags.** `fetch-depth` stays at `1` — the tags
arrive with the commits they point at, and `git diff <tag>..HEAD` compares two
commit objects rather than walking between them, so a shallow history is enough.
`fetch-depth: 0` would work too and would drag the whole `dist` branch along to
do it.

**The idempotence guard asked the wrong machine.** It was
`git rev-parse -q --verify "refs/tags/$version"` — a *local* ref lookup, worth
nothing on a checkout with no tags. The guard and the failure were blind to the
same fact, so the belt-and-braces never fired and the workflow failed *after the
site was already live*. It asks the remote now, which is where the push gets
refused. Its own comment ("next_version measures from the highest tag, so it
cannot propose one that exists") was the assumption that broke.

**IndexNow was riding on the tag step.** It carried `continue-on-error: true`
and an ordinary condition. That reads as "this can never fail the deploy" and is
only half of it: a step with an ordinary condition is *skipped* once an earlier
one has failed. So `continue-on-error` protected the job from IndexNow and left
IndexNow at the mercy of whatever sat above it. It now names what it actually
depends on — the publish — via `steps.publish.outcome` and `!cancelled()`.

## Why this one is worth more than a red mark

The site kept publishing throughout; `Publish to the dist branch` runs before
the tag step and passed every time. What did not happen, nine times, is the
IndexNow submission — so nine deploys' worth of changed pages went live and no
search engine was told about any of them. That is precisely the failure
CLAUDE.md describes under "`lastmod` now decides who hears about a change", and
it was silent, because a skipped step is not a red mark on a run.

It also means the tag history has a hole in it: `1.0.0`, then `1.0.2`, no
`1.0.1`. `1.0.2` was the *old* mechanism's last act, tagged by the bot in
[#205](https://github.com/A-Box-of-Tools/website/pull/205)'s run — the last
green Build on main.

## Notes for a reviewer

- **The three new assertions read `build.yml` as text rather than parsing it.**
  The test job installs Python and Node and nothing else, so there is no YAML
  parser to reach for, and adding `pyyaml` to test one file is a dependency
  this repository does not otherwise carry. The alternative to a crude
  assertion is the one the workflow's own comment warns about: "a decision that
  only exists inside a workflow can only be tested by opening pull requests
  against it."
- **All three fail against `build.yml` as `main` has it today.** I checked that
  rather than assuming it — a guard that passes either way is not a guard.
- **This PR itself will not move the version**, by the rule: it touches
  `.github` and `tests` only, which `buildlib/version.py` classifies as invisible.
  The first merge *after* it that touches anything else should tag `1.0.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
