### PR TITLE
Make the two secrets a toggle, and the info mark mean one thing

### DIFF
--- a/locales/ar/tools/password-generator.html
+++ b/locales/ar/tools/password-generator.html
@@ -9,11 +9,15 @@
       the answer to "which is stronger" visible on both sides of it.
       `role="tablist"` and the arrow keys are wired in main.js.
     -->
-    <div class="tabs" role="tablist" aria-label="ماذا تصنع">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">كلمة مرور</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">عبارة مرور</button>
+    <div class="segmented" role="radiogroup" aria-label="ماذا تصنع">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>كلمة مرور</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>عبارة مرور</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -29,7 +33,7 @@
   <section class="card">
     <h2><span class="step">2</span> اضبطها</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">الطول</label>
         <div class="slider-row">
@@ -99,7 +103,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">الكلمات</label>
         <div class="slider-row">

--- a/locales/de/tools/password-generator.html
+++ b/locales/de/tools/password-generator.html
@@ -9,11 +9,15 @@
       kosten, und die Antwort auf &bdquo;was ist stärker&ldquo; soll auf beiden
       Seiten davon sichtbar bleiben.
     -->
-    <div class="tabs" role="tablist" aria-label="Was erzeugt werden soll">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Passwort</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Passphrase</button>
+    <div class="segmented" role="radiogroup" aria-label="Was erzeugt werden soll">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Passwort</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Passphrase</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -31,7 +35,7 @@
   <section class="card">
     <h2><span class="step">2</span> Einstellen</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Länge</label>
         <div class="slider-row">
@@ -104,7 +108,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Wörter</label>
         <div class="slider-row">

--- a/locales/es/tools/password-generator.html
+++ b/locales/es/tools/password-generator.html
@@ -9,11 +9,15 @@
       respuesta a &laquo;cuál es más fuerte&raquo; tiene que verse desde ambos
       lados.
     -->
-    <div class="tabs" role="tablist" aria-label="Qué crear">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Contraseña</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Frase de contraseña</button>
+    <div class="segmented" role="radiogroup" aria-label="Qué crear">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Contraseña</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Frase de contraseña</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -30,7 +34,7 @@
   <section class="card">
     <h2><span class="step">2</span> Configúrala</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Longitud</label>
         <div class="slider-row">
@@ -103,7 +107,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Palabras</label>
         <div class="slider-row">

--- a/locales/fr/tools/password-generator.html
+++ b/locales/fr/tools/password-generator.html
@@ -9,11 +9,15 @@
       un clic, et la réponse à &laquo;&nbsp;lequel est le plus solide&nbsp;&raquo;
       doit rester visible des deux côtés.
     -->
-    <div class="tabs" role="tablist" aria-label="Quoi fabriquer">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Mot de passe</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Phrase secrète</button>
+    <div class="segmented" role="radiogroup" aria-label="Quoi fabriquer">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Mot de passe</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Phrase secrète</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -31,7 +35,7 @@
   <section class="card">
     <h2><span class="step">2</span> Réglez-le</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Longueur</label>
         <div class="slider-row">
@@ -104,7 +108,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Mots</label>
         <div class="slider-row">

--- a/locales/hi/tools/password-generator.html
+++ b/locales/hi/tools/password-generator.html
@@ -9,11 +9,15 @@
       और &ldquo;कौन ज़्यादा मज़बूत है&rdquo; का जवाब दोनों तरफ़ से दिखता रहना
       चाहिए।
     -->
-    <div class="tabs" role="tablist" aria-label="क्या बनाना है">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">पासवर्ड</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">पासफ़्रेज़</button>
+    <div class="segmented" role="radiogroup" aria-label="क्या बनाना है">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>पासवर्ड</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>पासफ़्रेज़</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -29,7 +33,7 @@
   <section class="card">
     <h2><span class="step">2</span> सेट कीजिए</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">लंबाई</label>
         <div class="slider-row">
@@ -100,7 +104,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">शब्द</label>
         <div class="slider-row">

--- a/locales/id/tools/password-generator.html
+++ b/locales/id/tools/password-generator.html
@@ -18,11 +18,15 @@
       the answer to "which is stronger" visible on both sides of it.
       `role="tablist"` and the arrow keys are wired in main.js.
     -->
-    <div class="tabs" role="tablist" aria-label="Apa yang dibuat">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Kata sandi</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Frasa sandi</button>
+    <div class="segmented" role="radiogroup" aria-label="Apa yang dibuat">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Kata sandi</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Frasa sandi</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -39,7 +43,7 @@
   <section class="card">
     <h2><span class="step">2</span> Siapkan</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Panjang</label>
         <div class="slider-row">
@@ -111,7 +115,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Kata</label>
         <div class="slider-row">

--- a/locales/it/tools/password-generator.html
+++ b/locales/it/tools/password-generator.html
@@ -8,11 +8,15 @@
       per cui questo strumento esiste. Deve costare un clic, e la risposta a
       &laquo;quale è più forte&raquo; deve restare visibile da entrambe le parti.
     -->
-    <div class="tabs" role="tablist" aria-label="Cosa generare">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Password</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Passphrase</button>
+    <div class="segmented" role="radiogroup" aria-label="Cosa generare">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Password</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Passphrase</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -29,7 +33,7 @@
   <section class="card">
     <h2><span class="step">2</span> Impostala</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Lunghezza</label>
         <div class="slider-row">
@@ -101,7 +105,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Parole</label>
         <div class="slider-row">

--- a/locales/ja/tools/password-generator.html
+++ b/locales/ja/tools/password-generator.html
@@ -8,11 +8,15 @@
       助けたい問いだからです。切り替えは一回のクリックで済み、「どちらが強いか」
       の答えは両側から見えたままになります。
     -->
-    <div class="tabs" role="tablist" aria-label="何を作るか">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">パスワード</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">パスフレーズ</button>
+    <div class="segmented" role="radiogroup" aria-label="何を作るか">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>パスワード</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>パスフレーズ</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -24,7 +28,7 @@
   <section class="card">
     <h2><span class="step">2</span> 設定する</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">長さ</label>
         <div class="slider-row">
@@ -86,7 +90,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">単語数</label>
         <div class="slider-row">

--- a/locales/ko/tools/password-generator.html
+++ b/locales/ko/tools/password-generator.html
@@ -8,11 +8,15 @@
       도구가 도우려는 질문이기 때문입니다. 그 전환은 클릭 한 번이어야 하고,
       &lsquo;어느 쪽이 더 강한가&rsquo;의 답은 양쪽에서 다 보여야 합니다.
     -->
-    <div class="tabs" role="tablist" aria-label="무엇을 만들지">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">비밀번호</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">패스프레이즈</button>
+    <div class="segmented" role="radiogroup" aria-label="무엇을 만들지">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>비밀번호</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>패스프레이즈</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -28,7 +32,7 @@
   <section class="card">
     <h2><span class="step">2</span> 설정하기</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">길이</label>
         <div class="slider-row">
@@ -98,7 +102,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">단어 수</label>
         <div class="slider-row">

--- a/locales/nl/tools/password-generator.html
+++ b/locales/nl/tools/password-generator.html
@@ -9,11 +9,15 @@
       antwoord op &bdquo;welke is sterker&rdquo; moet aan beide kanten zichtbaar
       blijven.
     -->
-    <div class="tabs" role="tablist" aria-label="Wat je wilt maken">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Wachtwoord</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Wachtwoordzin</button>
+    <div class="segmented" role="radiogroup" aria-label="Wat je wilt maken">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Wachtwoord</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Wachtwoordzin</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -30,7 +34,7 @@
   <section class="card">
     <h2><span class="step">2</span> Stel het in</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Lengte</label>
         <div class="slider-row">
@@ -102,7 +106,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Woorden</label>
         <div class="slider-row">

--- a/locales/pt/tools/password-generator.html
+++ b/locales/pt/tools/password-generator.html
@@ -8,11 +8,15 @@
       dúvida com que esta ferramenta ajuda. Deve custar um clique, e a resposta
       para &ldquo;qual é mais forte&rdquo; precisa ficar visível dos dois lados.
     -->
-    <div class="tabs" role="tablist" aria-label="O que gerar">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Senha</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Frase secreta</button>
+    <div class="segmented" role="radiogroup" aria-label="O que gerar">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Senha</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Frase secreta</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -29,7 +33,7 @@
   <section class="card">
     <h2><span class="step">2</span> Ajuste</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Comprimento</label>
         <div class="slider-row">
@@ -100,7 +104,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Palavras</label>
         <div class="slider-row">

--- a/locales/tr/tools/password-generator.html
+++ b/locales/tr/tools/password-generator.html
@@ -17,11 +17,15 @@
       the answer to "which is stronger" visible on both sides of it.
       `role="tablist"` and the arrow keys are wired in main.js.
     -->
-    <div class="tabs" role="tablist" aria-label="Ne üretilecek">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Şifre</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Parola cümlesi</button>
+    <div class="segmented" role="radiogroup" aria-label="Ne üretilecek">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Şifre</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Parola cümlesi</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -38,7 +42,7 @@
   <section class="card">
     <h2><span class="step">2</span> Ayarlayın</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Uzunluk</label>
         <div class="slider-row">
@@ -109,7 +113,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Kelimeler</label>
         <div class="slider-row">

--- a/locales/zh-TW/tools/password-generator.html
+++ b/locales/zh-TW/tools/password-generator.html
@@ -7,11 +7,15 @@
       用標籤而不是兩個頁面，因為在兩者之間怎麼選，正是這個工具想幫上忙的問題。切換
       應該只花一次點選，而「哪個更強」的答案在兩邊都看得見。
     -->
-    <div class="tabs" role="tablist" aria-label="產生什麼">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">密碼</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">密碼短語</button>
+    <div class="segmented" role="radiogroup" aria-label="產生什麼">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>密碼</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>密碼短語</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -23,7 +27,7 @@
   <section class="card">
     <h2><span class="step">2</span> 設定</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">長度</label>
         <div class="slider-row">
@@ -85,7 +89,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">詞數</label>
         <div class="slider-row">

--- a/locales/zh/tools/password-generator.html
+++ b/locales/zh/tools/password-generator.html
@@ -7,11 +7,15 @@
       用标签而不是两个页面，因为在两者之间怎么选，正是这个工具想帮上忙的问题。切换
       应该只花一次点击，而“哪个更强”的答案在两边都看得见。
     -->
-    <div class="tabs" role="tablist" aria-label="生成什么">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">密码</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">密码短语</button>
+    <div class="segmented" role="radiogroup" aria-label="生成什么">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>密码</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>密码短语</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -23,7 +27,7 @@
   <section class="card">
     <h2><span class="step">2</span> 设置</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">长度</label>
         <div class="slider-row">
@@ -85,7 +89,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">词数</label>
         <div class="slider-row">

--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -731,25 +731,40 @@ button, .as-button {
 
 /* The same caret the pledge fold uses, for the same reason: a heading that can
    be opened should not look exactly like one that cannot. */
+/* The same mark the steps above use.
+
+   It was a caret, and a caret and a circled i side by side on one page are two
+   answers to the same question: what happens if I click this. Both of these
+   open explanation - a step's, and the whole list of steps - so both wear the
+   mark that means explanation. The caret is left to the pledge, which is not
+   an explanation but a claim with its evidence folded under it, and whose
+   summary already carries two live status dots that an i would compete with.
+
+   Drawn the same way and for the same reason as the card mark: generated
+   content counts towards the accessible name, so this is background shapes in
+   a circle where a screen reader cannot reach it. */
 .how-to-fold > summary > h2::after {
   content: "";
-  width: 0.5rem;
-  height: 0.5rem;
-  border-right: 2px solid var(--text-dim);
-  border-bottom: 2px solid var(--text-dim);
-  transform: rotate(45deg) translate(-0.1rem, -0.1rem);
-  transition: transform 0.15s;
+  flex: none;
+  width: 1.05rem;
+  height: 1.05rem;
+  border: 1.5px solid currentColor;
+  border-radius: 50%;
+  color: var(--text-dim);
+  background:
+    radial-gradient(circle at 50% 50%, currentColor 50%, transparent 51%)
+      50% 22% / 2.5px 2.5px no-repeat,
+    linear-gradient(currentColor, currentColor) 50% 78% / 2px 0.4rem no-repeat;
+  transition: color 0.15s;
 }
 
-.how-to-fold[open] > summary > h2::after {
-  transform: rotate(225deg) translate(-0.05rem, -0.05rem);
-}
+.how-to-fold[open] > summary > h2::after { color: var(--accent); }
 
 .how-to-fold > summary:hover > h2,
 .how-to-fold > summary:focus-visible > h2 { color: var(--accent); }
 
 .how-to-fold > summary:hover > h2::after,
-.how-to-fold > summary:focus-visible > h2::after { border-color: var(--accent); }
+.how-to-fold > summary:focus-visible > h2::after { color: var(--accent); }
 
 .how-to-fold[open] > summary > h2 { margin-bottom: 0.9rem; }
 

--- a/tools/password-generator/body.html
+++ b/tools/password-generator/body.html
@@ -9,11 +9,15 @@
       the answer to "which is stronger" visible on both sides of it.
       `role="tablist"` and the arrow keys are wired in main.js.
     -->
-    <div class="tabs" role="tablist" aria-label="What to make">
-      <button type="button" role="tab" id="tab-password" class="tab" data-mode="password"
-              aria-selected="true" aria-controls="options-password">Password</button>
-      <button type="button" role="tab" id="tab-passphrase" class="tab" data-mode="passphrase"
-              aria-selected="false" tabindex="-1" aria-controls="options-passphrase">Passphrase</button>
+    <div class="segmented" role="radiogroup" aria-label="What to make">
+      <label class="segment">
+        <input type="radio" name="mode" value="password" checked>
+        <span>Password</span>
+      </label>
+      <label class="segment">
+        <input type="radio" name="mode" value="passphrase">
+        <span>Passphrase</span>
+      </label>
     </div>
 
     <p class="card-lede" id="mode-note">
@@ -30,7 +34,7 @@
   <section class="card">
     <h2><span class="step">2</span> Set it up</h2>
 
-    <div class="settings" id="options-password" role="tabpanel" aria-labelledby="tab-password">
+    <div class="settings" id="options-password">
       <div class="field">
         <label for="length">Length</label>
         <div class="slider-row">
@@ -102,7 +106,7 @@
       </div>
     </div>
 
-    <div class="settings" id="options-passphrase" role="tabpanel" aria-labelledby="tab-passphrase" hidden>
+    <div class="settings" id="options-passphrase" hidden>
       <div class="field">
         <label for="words">Words</label>
         <div class="slider-row">

--- a/tools/password-generator/src/main.js
+++ b/tools/password-generator/src/main.js
@@ -10,7 +10,7 @@ import { wordlist } from './wordlist.js';
 const $ = (id) => document.getElementById(id);
 
 const el = {
-  tabs: Array.from(document.querySelectorAll('.tab')),
+  modes: Array.from(document.querySelectorAll('input[name="mode"]')),
   panels: {
     password: $('options-password'),
     passphrase: $('options-passphrase'),
@@ -104,27 +104,19 @@ let mode = 'password';
 
 function setMode(next) {
   mode = next;
-  for (const tab of el.tabs) {
-    const on = tab.dataset.mode === next;
-    tab.setAttribute('aria-selected', String(on));
-    tab.tabIndex = on ? 0 : -1;
-  }
+  for (const radio of el.modes) radio.checked = radio.value === next;
   for (const [name, panel] of Object.entries(el.panels)) panel.hidden = name !== next;
   make();
 }
 
-for (const tab of el.tabs) {
-  tab.addEventListener('click', () => setMode(tab.dataset.mode));
-  // The arrow keys move between tabs, which is what a tab strip is expected to
-  // do and what a row of buttons does not do on its own.
-  tab.addEventListener('keydown', (event) => {
-    const step = event.key === 'ArrowRight' ? 1 : event.key === 'ArrowLeft' ? -1 : 0;
-    if (!step) return;
-    event.preventDefault();
-    const index = el.tabs.indexOf(tab);
-    const next = el.tabs[(index + step + el.tabs.length) % el.tabs.length];
-    next.focus();
-    setMode(next.dataset.mode);
+// Radios rather than a tab strip. The choice is between two kinds of secret,
+// not between two views of one thing, and a radio group says that: the arrow
+// keys move within it and the roving tabindex a tablist needs is the browser's
+// job rather than ours. It also means the two words are labels, which is what
+// they always were.
+for (const radio of el.modes) {
+  radio.addEventListener('change', () => {
+    if (radio.checked) setMode(radio.value);
   });
 }
 

--- a/tools/password-generator/styles.css
+++ b/tools/password-generator/styles.css
@@ -2,35 +2,64 @@
 
 /* ---------------------------------------------------------------- the tabs */
 
-.tabs {
-  display: flex;
-  gap: 0.3rem;
-  flex-wrap: wrap;
+/* The two kinds of secret, as a segmented control.
+
+   It was a tab strip, and a tab strip says "two views of one thing". These are
+   two different things to make, with different settings and different advice,
+   which is a choice rather than a view - so it is a radio group wearing one
+   border, and the browser handles the arrow keys and the focus ring itself. */
+.segmented {
+  display: inline-flex;
+  padding: 0.2rem;
+  gap: 0.2rem;
   margin-bottom: 1.1rem;
-  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
 }
 
-.tab {
-  background: none;
-  border: 1px solid transparent;
-  border-bottom: none;
-  border-radius: 8px 8px 0 0;
-  padding: 0.5rem 0.95rem;
-  margin-bottom: -1px;
+.segment { position: relative; }
+
+/* Visually hidden rather than display:none, so it keeps its place in the focus
+   order and the ring below has something to hang on. */
+.segment input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.segment span {
+  display: block;
+  padding: 0.42rem 1.05rem;
+  border-radius: 999px;
   color: var(--text-dim);
   font-weight: 600;
   font-size: 0.92rem;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
 }
 
-.tab:hover { color: var(--text); }
+.segment span:hover { color: var(--text); }
 
-.tab[aria-selected="true"] {
+.segment input:checked + span {
   background: var(--surface);
-  border-color: var(--border);
   color: var(--accent);
-  /* The selected tab covers the line under the strip, which is what joins it
-     to the panel below rather than leaving it floating above one. */
-  box-shadow: 0 1px 0 0 var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.segment input:focus-visible + span {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .segment span { transition: none; }
 }
 
 .card-lede { margin: 0; font-size: 0.88rem; color: var(--text-dim); }
@@ -199,7 +228,45 @@
   color: var(--text-dim);
   margin-bottom: 1.2rem;
 }
-.assumptions summary { cursor: pointer; font-weight: 600; color: var(--text); }
+/* The same mark the steps and the how-to list wear. This is the third fold on
+   the page that opens explanation, and it was the only one saying so with a
+   bare bold line: the reader had to click it to find out it was a fold at all.
+   Drawn as background shapes rather than the letter, for the reason
+   shared/css/tool-frame.css gives where it draws the other two. */
+.assumptions summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text);
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.assumptions summary::-webkit-details-marker { display: none; }
+
+.assumptions summary::after {
+  content: "";
+  flex: none;
+  width: 1.05rem;
+  height: 1.05rem;
+  border: 1.5px solid currentColor;
+  border-radius: 50%;
+  color: var(--text-dim);
+  background:
+    radial-gradient(circle at 50% 50%, currentColor 50%, transparent 51%)
+      50% 22% / 2.5px 2.5px no-repeat,
+    linear-gradient(currentColor, currentColor) 50% 78% / 2px 0.4rem no-repeat;
+  transition: color 0.15s;
+}
+
+.assumptions summary:hover::after,
+.assumptions summary:focus-visible::after,
+.assumptions[open] summary::after { color: var(--accent); }
+
+@media (prefers-reduced-motion: reduce) {
+  .assumptions summary::after { transition: none; }
+}
 .assumptions p { margin: 0.6rem 0 0; }
 
 /* ----------------------------------------------------------------- the list */


### PR DESCRIPTION
Two changes that both come down to the same thing: one control should say one thing.

## Before / after

| Before | After |
|---|---|
| <img alt="before-toggle" src="https://github.com/user-attachments/assets/c2922453-7526-487c-8fac-a8e02e271ff8" /> | <img alt="after-toggle" src="https://github.com/user-attachments/assets/771e87ef-893c-4f9e-8f61-389e84f4829d" /> |

And the two folds that changed their mark:

<img alt="after-howto-mark" src="https://github.com/user-attachments/assets/443d3882-2e1f-4aa6-ae03-1de1ffc6c904" />

<img alt="after-assumptions-mark" src="https://github.com/user-attachments/assets/6d99e30a-df9a-4569-8945-664ba7f7a8c4" />

## Two kinds of secret, as a toggle

The password generator opened with a tab strip. A tab strip says *two views of one thing* — but a password and a passphrase are two different things to make, with different settings and different advice. That is a choice, not a view.

It is a radio group wearing one border now. The browser handles the arrow keys and the focus ring itself, the two words are labels rather than tabs, and the panels stop claiming to be `tabpanel`s of a `tablist` that no longer exists. Checked in the built page: **0 tablist, 0 tabpanel, 1 radiogroup**, and switching still swaps the panel and regenerates.

The same edit landed in fifteen bodies — English and the fourteen translations — with each one's own three strings carried across rather than retyped.

## One mark for one question

A tool page had two answers to "what happens if I click this":

| fold | was | now |
|---|---|---|
| a step's explanation | ⓘ | ⓘ |
| the how-to list at the foot of the page | caret | **ⓘ** |
| the password generator's estimate assumptions | a bare bold line | **ⓘ** |
| the pledge | caret | caret — see below |

**The pledge keeps its caret, deliberately.** It is not an explanation but the page's central claim with its evidence folded under it, and its summary already carries two live status dots that an ⓘ beside them would compete with. Easy to change if you would rather it matched.

Two other `<details>` were left alone for the same kind of reason: gif-analyzer's per-frame tables and id-photo's manual number fields reveal data and controls, not prose, and an ⓘ there would be the wrong promise.

## Note on the branch

The first version of this work was pushed to #217's branch after that PR had already been squash-merged, so those commits never reached `main`. This is the same end state re-applied cleanly on top of `main` — which is also why the one-line fix for the old tab strip's hanging underline is not here: the strip it patched no longer exists.

## Checks

`python build.py` clean; the toggle exercised in the built page, and all three marks read at full size. Suites left to CI, per #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

