### PR TITLE
Give the inventory card an empty state, at both ends

### DIFF
--- a/locales/ar/tools/compress-pdf.html
+++ b/locales/ar/tools/compress-pdf.html
@@ -32,7 +32,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/de/tools/compress-pdf.html
+++ b/locales/de/tools/compress-pdf.html
@@ -34,7 +34,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/es/tools/compress-pdf.html
+++ b/locales/es/tools/compress-pdf.html
@@ -34,7 +34,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/fr/tools/compress-pdf.html
+++ b/locales/fr/tools/compress-pdf.html
@@ -35,7 +35,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/hi/tools/compress-pdf.html
+++ b/locales/hi/tools/compress-pdf.html
@@ -34,7 +34,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/id/tools/compress-pdf.html
+++ b/locales/id/tools/compress-pdf.html
@@ -40,7 +40,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/it/tools/compress-pdf.html
+++ b/locales/it/tools/compress-pdf.html
@@ -34,7 +34,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/ja/tools/compress-pdf.html
+++ b/locales/ja/tools/compress-pdf.html
@@ -28,7 +28,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/ko/tools/compress-pdf.html
+++ b/locales/ko/tools/compress-pdf.html
@@ -33,7 +33,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/nl/tools/compress-pdf.html
+++ b/locales/nl/tools/compress-pdf.html
@@ -34,7 +34,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/pt/tools/compress-pdf.html
+++ b/locales/pt/tools/compress-pdf.html
@@ -34,7 +34,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/tr/tools/compress-pdf.html
+++ b/locales/tr/tools/compress-pdf.html
@@ -39,7 +39,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/zh-TW/tools/compress-pdf.html
+++ b/locales/zh-TW/tools/compress-pdf.html
@@ -35,7 +35,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/locales/zh/tools/compress-pdf.html
+++ b/locales/zh/tools/compress-pdf.html
@@ -35,7 +35,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/tools/compress-pdf/body.html
+++ b/tools/compress-pdf/body.html
@@ -33,7 +33,7 @@
     <p id="verdict" class="verdict"></p>
 
     <div class="breakdown">
-      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list"></div>
+      <div id="breakdown-bar" class="breakdown-bar" role="img" aria-labelledby="breakdown-list" hidden></div>
       <ul id="breakdown-list" class="breakdown-list"></ul>
     </div>
 

--- a/tools/compress-pdf/src/main.js
+++ b/tools/compress-pdf/src/main.js
@@ -150,7 +150,32 @@ function reset() {
   el.loadError.hidden = true;
   el.loadNote.hidden = true;
   el.runError.hidden = true;
+  emptyInventory();
   releaseDownload();
+}
+
+/**
+ * The inventory with no file behind it.
+ *
+ * This card is shown before a file is chosen now, so it has an empty state
+ * for the first time and needs one on the way out as well: clearing the file
+ * used to hide the card and the numbers went with it. Left alone, the last
+ * document's page counts and byte shares sat there under a picker that had
+ * been emptied, which is a strange thing to show anybody and a stranger one
+ * on a tool whose promise is that the file goes no further than the page.
+ *
+ * The bar is hidden rather than left empty. It is a role="img" named by the
+ * list beside it, so with the list empty it is a picture with no description
+ * - which is what a screen reader is told, and what an accessibility scan
+ * reports.
+ */
+function emptyInventory() {
+  el.verdict.textContent = '';
+  el.verdict.className = 'verdict';
+  el.breakdownBar.replaceChildren();
+  el.breakdownBar.hidden = true;
+  el.breakdownList.replaceChildren();
+  el.inventoryNotes.textContent = '';
 }
 
 function showLoadError(text) {
@@ -183,6 +208,7 @@ function renderInventory(inventory) {
   el.verdict.className = `verdict ${said.tone}`;
 
   el.breakdownBar.replaceChildren();
+  el.breakdownBar.hidden = false;
   el.breakdownList.replaceChildren();
 
   for (const group of inventory.groups) {


### PR DESCRIPTION
#208 shows the whole job before the file is chosen — which gave this card an empty state for the first time. It needed one on the way **out** too, and didn't get it.

## What was happening

Clearing the file used to hide the card, so the numbers went with it. Now the card stays — and so do the numbers. The last document's page counts and byte shares sit there under a picker that has just been emptied, on a tool whose promise is that the file goes no further than the page.

`reset()` hid the rows but never emptied the inventory.

## The same cause, a second symptom

`#breakdown-bar` is a `role="img"` named by the list beside it. Before a file is chosen that list is empty — so it was **a picture with no description**: nothing for a screen reader to say, and a serious violation for a scan to find.

It's now hidden until there is something in it, which is both the accessible answer and the honest one: there's no picture of a file nobody has chosen.

Hidden in **all fifteen bodies**, not just English — the markup is copied per language, so a fix to one is a fix to one.

## How it surfaced

The QA suite. The failing test was *"choosing another file clears the last result"* — which is precisely what had stopped happening. I'd assumed it was stale after #208 and nearly updated it to match the new behaviour; probing what the card actually held after a clear showed the previous document still in it.

The test now reads the card's **contents** rather than its visibility, since the card is meant to be visible either way.

Verified against a local build: both the functional test and the axe scan of `/compress-pdf/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)