### PR TITLE
Let the frame colour the native controls, not seven tools each

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -64,6 +64,18 @@ body {
   background: var(--bg);
   color: var(--text);
   font: 16px/1.55 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  /* The tick in a checkbox, the dot in a radio, the filled half of a slider.
+     `accent-color` inherits, so one declaration here reaches every native
+     control on every tool page, including the ones a tool adds tomorrow -
+     and the browser still draws the control, still picks a mark that
+     contrasts with whatever this resolves to, and still keeps the platform's
+     own shape and focus behaviour. That is the whole reason to set this
+     rather than rebuild the controls out of divs.
+
+     Seven tools each set this on their own controls, which left the other
+     twenty-four drawing the operating system's default blue next to a page
+     using this site's. It is one property and it belongs to the frame. */
+  accent-color: var(--accent);
 }
 
 h1, h2 { line-height: 1.25; }

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -99,7 +99,6 @@ audio {
 
 input[type="range"] {
   width: 100%;
-  accent-color: var(--accent);
 }
 
 .presets {

--- a/tools/grab-frame/styles.css
+++ b/tools/grab-frame/styles.css
@@ -119,7 +119,6 @@
 .transport input[type="range"] {
   flex: 1 1 12rem;
   min-width: 8rem;
-  accent-color: var(--accent);
 }
 
 .readout {
@@ -148,8 +147,6 @@
 .field { display: flex; flex-direction: column; gap: 0.3rem; }
 .field > label { font-size: 0.85rem; font-weight: 600; }
 .field-note { margin: 0; font-size: 0.78rem; color: var(--text-dim); }
-
-.field input[type="range"] { accent-color: var(--accent); }
 
 .inline-pair {
   display: flex;

--- a/tools/image-to-data-uri/styles.css
+++ b/tools/image-to-data-uri/styles.css
@@ -103,7 +103,7 @@
 
 .shape:has(input:focus-visible) { outline: 2px solid var(--accent); outline-offset: 2px; }
 
-.shape input { flex: none; margin-top: 0.15rem; accent-color: var(--accent); }
+.shape input { flex: none; margin-top: 0.15rem; }
 
 .shape-body { display: flex; flex-direction: column; gap: 0.25rem; min-width: 0; }
 .shape-body strong { font-size: 0.93rem; }
@@ -133,7 +133,7 @@
 }
 
 .check { display: flex; gap: 0.6rem; align-items: flex-start; cursor: pointer; }
-.check input { flex: none; margin-top: 0.2rem; accent-color: var(--accent); }
+.check input { flex: none; margin-top: 0.2rem; }
 .check > span { display: flex; flex-direction: column; gap: 0.25rem; }
 .check strong { font-size: 0.92rem; }
 .check-note { font-size: 0.82rem; line-height: 1.55; color: var(--text-dim); max-width: 62ch; }

--- a/tools/password-generator/styles.css
+++ b/tools/password-generator/styles.css
@@ -70,7 +70,7 @@
   align-items: center;
   gap: 0.8rem;
 }
-.slider-row input[type="range"] { flex: 1; accent-color: var(--accent); }
+.slider-row input[type="range"] { flex: 1; }
 
 .slider-row output {
   min-width: 2.6rem;

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -447,7 +447,6 @@ button.file-main-wrap:focus-visible {
 
 .field input[type="range"] {
   width: 100%;
-  accent-color: var(--accent);
   cursor: pointer;
 }
 

--- a/tools/split-gif/styles.css
+++ b/tools/split-gif/styles.css
@@ -169,7 +169,6 @@
 }
 
 .frame-pick input {
-  accent-color: var(--accent);
   width: 1rem;
   height: 1rem;
   flex: none;

--- a/tools/svg-to-image/styles.css
+++ b/tools/svg-to-image/styles.css
@@ -183,7 +183,6 @@
 
 .field input[type="range"] {
   width: 100%;
-  accent-color: var(--accent);
   cursor: pointer;
 }
 


### PR DESCRIPTION
A checkbox, a radio and a slider are drawn by the browser itself, and
`accent-color` is the one property that says which colour to draw them in.

Thirty-one tools carry at least one of those controls. **Seven** set
`accent-color` on their own; the other **twenty-four** did not, so on most of
the site the tick in a checkbox and the filled half of a slider were the
operating system's blue, sitting next to a page drawn in this site's. Which
tools looked right was an accident of who had remembered the property.

The property inherits, so this puts it on `body` in `shared/css/tool-frame.css`
once and deletes the nine hand-written declarations. What is left in each of
those rules is the layout it was really about:

```css
-.slider-row input[type="range"] { flex: 1; accent-color: var(--accent); }
+.slider-row input[type="range"] { flex: 1; }
```

Setting it in the frame also means a tool that adds a checkbox tomorrow gets
the right colour without knowing the rule exists.

## What this deliberately does not do

The controls are still the browser's. Nothing here rebuilds a checkbox out of
`div`s to style it — `accent-color` keeps each platform's own shape, focus
behaviour and hit target, and the browser goes on picking a tick colour that
contrasts with whatever `--accent` resolves to. That is the whole reason to
reach for this property instead.

## Verified

Built with `--locale en` and read in the browser, on a tool that already had
the property and one that never did:

| page | `getComputedStyle(range).accentColor` |
|---|---|
| `/password-generator/` (had it) | `rgb(43, 108, 176)` |
| `/dicom-viewer/` (**never had it**) | `rgb(43, 108, 176)` |
| `/dicom-viewer/` in dark | `rgb(91, 155, 216)` |

`#2b6cb0` and `#5b9bd8` are `--accent` in the two themes, so the token is
being followed rather than a colour being pinned.

## Before / after

I could not capture these — screenshots do not composite in the harness this
was built in. The comparison worth photographing is **`/dicom-viewer/`**, one
of the twenty-four that had no `accent-color`: its two sliders and two
checkboxes are the change, on `main` versus this branch.

- `before-dicom-controls.png`
- `after-dicom-controls.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
