### PR TITLE
One progress bar, in one file, under one set of names

### DIFF
--- a/docs/layout.md
+++ b/docs/layout.md
@@ -33,6 +33,7 @@ shared/
   css/
     tool-frame.css       the stylesheet every tool page starts from
     file-list.css        an optional part, for tools that show a list of files
+    progress.css         an optional part, for tools that draw a progress bar
   site.css               the stylesheet for the hub and the legal pages
   logo.svg               the site mark; also the favicon, and inlined in the pages
   icon-180.png           the same mark as a PNG, for iOS home screens

--- a/shared/css/progress.css
+++ b/shared/css/progress.css
@@ -1,0 +1,67 @@
+/*
+  The bar a tool draws while it is working: a track, the fill inside it, and a
+  line of text underneath saying what is happening.
+
+  Twenty-three tools drew one of these and every one of them wrote these four
+  rules out by hand. Worse, they had drifted into two spellings of the same
+  three elements - ten tools called the groove `.progress-track` inside a
+  `.progress`, and thirteen called it `.progress` inside a `.progress-wrap` -
+  so the same class name meant the component in one half of the site and the
+  groove it contains in the other. That is the kind of thing that is only ever
+  found by reading two stylesheets side by side, which nobody does. One
+  spelling, in one file, ends it: `.progress` is the component, `.progress-track`
+  is the groove, `.progress-bar` is the fill.
+
+  A tool that needs more can still say so - its own styles.css is appended
+  after this, so it wins. images-to-pdf does exactly that, to keep a long file
+  name on one line.
+*/
+
+.progress { margin-top: 1rem; }
+
+.progress-track {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+/* `display: block` because the fill is a <span> in one tool and a <div> in the
+   rest, and an inline box ignores height. */
+.progress-bar {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+}
+
+/*
+  Sliding the fill between two widths is opt-in, and that is the whole reason
+  this class exists rather than a transition on every bar.
+
+  A tool that encodes a video knows how far through it is at every frame, so
+  the fill really is moving continuously and animating it says something true.
+  A tool that compresses eight images knows only that it has finished the
+  third: its bar jumps, and a slide between the jumps would suggest progress it
+  cannot measure part-way through. The batch tools argued that in a comment
+  before this file existed, and they were right, so the default here is the
+  honest one and the continuous tools ask for the other.
+*/
+.progress-bar.is-smooth { transition: width 0.15s linear; }
+
+/* The thirteen tools that animate this had no such guard when each of them
+   owned the rule. */
+@media (prefers-reduced-motion: reduce) {
+  .progress-bar.is-smooth { transition: none; }
+}
+
+.progress-label {
+  margin: 0.45rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  /* These lines are nearly always a count - "3 of 12", "frame 640 of 1,000" -
+     and a proportional 1 is narrower than a 4, so the number jittered as it
+     climbed. */
+  font-variant-numeric: tabular-nums;
+}

--- a/tools/compress-image/styles.css
+++ b/tools/compress-image/styles.css
@@ -150,27 +150,6 @@
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-/* Width is set from script as each image finishes. There is no animation on
-   purpose: a bar that slides while an encode is running suggests progress the
-   tool cannot actually measure part-way through. */
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label {
-  margin: 0.5rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-}
-
 /* ----------------------------------------------------------------- results */
 
 .results { margin-top: 1.4rem; }

--- a/tools/compress-image/tool.toml
+++ b/tools/compress-image/tool.toml
@@ -23,8 +23,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list"]
-
+css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/compress-pdf/styles.css
+++ b/tools/compress-pdf/styles.css
@@ -264,22 +264,6 @@
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-/* Width is set from script as each stage finishes. No animation: a bar that
-   slides while an encode runs suggests progress the tool cannot measure. */
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label { margin: 0.45rem 0 0; font-size: 0.85rem; color: var(--text-dim); }
-
 /* ----------------------------------------------------------------- results */
 
 .result { margin-top: 1.2rem; }

--- a/tools/compress-pdf/tool.toml
+++ b/tools/compress-pdf/tool.toml
@@ -20,6 +20,10 @@ category = "documents-and-audio"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "documents"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 js_parts = ["file-picker"]
 lastmod = "2026-08-27"
 

--- a/tools/crop-video/body.html
+++ b/tools/crop-video/body.html
@@ -128,8 +128,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/crop-video/src/main.js
+++ b/tools/crop-video/src/main.js
@@ -47,7 +47,7 @@ const el = {
   sumPath: $('sum-path'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -474,7 +474,7 @@ async function runExport() {
 
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.result.hidden = true;
   cropper.setEnabled(false);
   el.preview.pause();
@@ -509,10 +509,10 @@ async function runExport() {
       result.codec,
     ].join(' · ');
     el.result.hidden = false;
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong while cropping.');
       console.error(error);

--- a/tools/crop-video/styles.css
+++ b/tools/crop-video/styles.css
@@ -292,30 +292,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/crop-video/tool.toml
+++ b/tools/crop-video/tool.toml
@@ -20,6 +20,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "video"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/edit-audio/body.html
+++ b/tools/edit-audio/body.html
@@ -151,8 +151,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/edit-audio/src/main.js
+++ b/tools/edit-audio/src/main.js
@@ -41,7 +41,7 @@ const el = {
   depth: $('depth'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -312,7 +312,7 @@ async function runExport() {
   abortController = new AbortController();
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   progress(0, 'Starting...');
 
   const chosen = settings();
@@ -345,10 +345,10 @@ async function runExport() {
       `${((performance.now() - started) / 1000).toFixed(1)}s`,
     ].filter(Boolean).join(' · ');
 
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong while editing the audio.');
       console.error(error);

--- a/tools/edit-audio/styles.css
+++ b/tools/edit-audio/styles.css
@@ -199,30 +199,6 @@ input[type="range"] {
   flex-wrap: wrap;
 }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/edit-audio/tool.toml
+++ b/tools/edit-audio/tool.toml
@@ -20,6 +20,10 @@ category = "documents-and-audio"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "audio"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.

--- a/tools/gif-maker/body.html
+++ b/tools/gif-maker/body.html
@@ -156,8 +156,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/gif-maker/src/main.js
+++ b/tools/gif-maker/src/main.js
@@ -49,7 +49,7 @@ const el = {
   sumLoop: $('sum-loop'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -587,7 +587,7 @@ async function runExport() {
 
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.result.hidden = true;
   setProgress({ phase: 'palette', done: 0, total: 1 });
 
@@ -610,10 +610,10 @@ async function runExport() {
     el.resultInfo.textContent =
       `GIF · ${settings.width}×${settings.height} · ${frames} frames · ${formatBytes(blob.size)}`;
     el.result.hidden = false;
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong while making the GIF.');
       console.error(error);

--- a/tools/gif-maker/styles.css
+++ b/tools/gif-maker/styles.css
@@ -326,30 +326,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/gif-maker/tool.toml
+++ b/tools/gif-maker/tool.toml
@@ -20,6 +20,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "gif"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.

--- a/tools/grab-frame/body.html
+++ b/tools/grab-frame/body.html
@@ -109,8 +109,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/grab-frame/src/main.js
+++ b/tools/grab-frame/src/main.js
@@ -43,7 +43,7 @@ const el = {
   grab: $('grab'),
   grabSeries: $('grab-series'),
   cancel: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -630,7 +630,7 @@ el.clear.addEventListener('click', clearShots);
 el.downloadAll.addEventListener('click', async () => {
   if (!shots.length || working) return;
   setWorking(true);
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   setProgress({ done: 0, total: shots.length, label: 'Packing...' });
 
   try {
@@ -654,7 +654,7 @@ el.downloadAll.addEventListener('click', async () => {
     showError(error?.message || 'That archive could not be built.');
   } finally {
     setWorking(false);
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
   }
 });
 
@@ -736,7 +736,7 @@ el.grabSeries.addEventListener('click', async () => {
   setWorking(true);
   abortController = new AbortController();
   el.cancel.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
 
   const options = encodeOptions();
   const { signal } = abortController;
@@ -797,7 +797,7 @@ el.grabSeries.addEventListener('click', async () => {
   } finally {
     abortController = null;
     el.cancel.hidden = true;
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     setWorking(false);
   }
 });

--- a/tools/grab-frame/styles.css
+++ b/tools/grab-frame/styles.css
@@ -176,30 +176,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/grab-frame/tool.toml
+++ b/tools/grab-frame/tool.toml
@@ -20,6 +20,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "video"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/hash-checksum/body.html
+++ b/tools/hash-checksum/body.html
@@ -69,7 +69,7 @@
     <div class="progress" id="progress" hidden>
       <div class="progress-track" role="progressbar" id="progress-track"
            aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-        <span class="progress-fill" id="progress-fill"></span>
+        <span class="progress-bar" id="progress-bar"></span>
       </div>
       <p class="progress-line">
         <span id="progress-text" role="status" aria-live="polite"></span>

--- a/tools/hash-checksum/src/main.js
+++ b/tools/hash-checksum/src/main.js
@@ -16,7 +16,7 @@ const el = {
   runCard: $('run-card'),
   progress: $('progress'),
   progressTrack: $('progress-track'),
-  progressFill: $('progress-fill'),
+  progressBar: $('progress-bar'),
   progressText: $('progress-text'),
   stop: $('stop'),
 
@@ -178,7 +178,7 @@ el.restart.addEventListener('click', () => start(outstanding()));
 
 function showProgress(done, total, speed) {
   const fraction = total ? done / total : 1;
-  el.progressFill.style.width = `${Math.min(100, fraction * 100)}%`;
+  el.progressBar.style.width = `${Math.min(100, fraction * 100)}%`;
   el.progressTrack.setAttribute('aria-valuenow', String(Math.round(fraction * 100)));
 
   const parts = [percent(fraction)];

--- a/tools/hash-checksum/styles.css
+++ b/tools/hash-checksum/styles.css
@@ -65,25 +65,6 @@
   font-size: 0.85rem;
 }
 
-/* ------------------------------------------------------------- the progress */
-
-.progress { margin-top: 1.1rem; }
-
-.progress-track {
-  height: 8px;
-  border-radius: 999px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-.progress-fill {
-  display: block;
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-}
-
 .progress-line {
   display: flex;
   align-items: center;

--- a/tools/hash-checksum/tool.toml
+++ b/tools/hash-checksum/tool.toml
@@ -28,6 +28,10 @@ category = "text-codes-and-passwords"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "beyond"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker"]
 lastmod = "2026-08-27"

--- a/tools/heic-to-jpg/styles.css
+++ b/tools/heic-to-jpg/styles.css
@@ -157,27 +157,6 @@
 .engine-status.good { color: var(--ok); font-weight: 600; }
 .engine-status.warn { color: var(--danger); font-weight: 600; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-/* Width is set from script as each photo finishes. There is no animation on
-   purpose: a bar that slides while a decode is running suggests progress the
-   tool cannot actually measure part-way through a picture. */
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label {
-  margin: 0.5rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-}
-
 /* ----------------------------------------------------------------- results */
 
 .results { margin-top: 1.4rem; }

--- a/tools/heic-to-jpg/tool.toml
+++ b/tools/heic-to-jpg/tool.toml
@@ -26,8 +26,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list"]
-
+css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker", "zip", "crc32"]
 lastmod = "2026-08-27"

--- a/tools/id-photo/styles.css
+++ b/tools/id-photo/styles.css
@@ -523,23 +523,6 @@
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-/* Width is set from script as each file finishes. There is no animation on
-   purpose: a bar that slides while an encode is running suggests progress the
-   tool cannot actually measure part-way through. */
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label { margin: 0.5rem 0 0; font-size: 0.85rem; color: var(--text-dim); }
-
 /* ----------------------------------------------------------------- results */
 
 .results { margin-top: 1.4rem; }

--- a/tools/id-photo/tool.toml
+++ b/tools/id-photo/tool.toml
@@ -19,6 +19,10 @@ category = "images"
 # Which group on the roadmap this tool joins, by the id in config/planned.toml.
 roadmap_group = "images"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. file-picker brings in the drop zone.
 js_parts = ["file-picker"]
 lastmod = "2026-08-27"

--- a/tools/image-to-ico/styles.css
+++ b/tools/image-to-ico/styles.css
@@ -294,24 +294,6 @@
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label {
-  margin: 0.5rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-}
-
 /* ----------------------------------------------------------------- results */
 
 .results { margin-top: 1.4rem; }

--- a/tools/image-to-ico/tool.toml
+++ b/tools/image-to-ico/tool.toml
@@ -23,8 +23,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list"]
-
+css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/images-to-pdf/body.html
+++ b/tools/images-to-pdf/body.html
@@ -212,8 +212,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/images-to-pdf/src/main.js
+++ b/tools/images-to-pdf/src/main.js
@@ -58,7 +58,7 @@ const el = {
 
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -632,7 +632,7 @@ async function runExport() {
   clearResult();
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.progressBar.style.width = '0%';
   el.progressLabel.textContent = 'Starting...';
 
@@ -673,7 +673,7 @@ async function runExport() {
     el.exportBtn.disabled = !items.length;
     // Left on screen after a cancel, so that pressing the button and then
     // changing your mind does not look like nothing happened.
-    el.progressWrap.hidden = !cancelled;
+    el.progress.hidden = !cancelled;
   }
 }
 

--- a/tools/images-to-pdf/styles.css
+++ b/tools/images-to-pdf/styles.css
@@ -295,28 +295,7 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
 .progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/tools/images-to-pdf/tool.toml
+++ b/tools/images-to-pdf/tool.toml
@@ -20,6 +20,10 @@ category = "documents-and-audio"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "documents"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/images-to-video/body.html
+++ b/tools/images-to-video/body.html
@@ -148,8 +148,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/images-to-video/src/main.js
+++ b/tools/images-to-video/src/main.js
@@ -49,7 +49,7 @@ const el = {
   sumFrames: $('sum-frames'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -713,7 +713,7 @@ async function runExport() {
 
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.result.hidden = true;
   setProgress({ phase: 'preparing', done: 0, total: 1 });
 
@@ -740,10 +740,10 @@ async function runExport() {
     el.resultInfo.textContent =
       `${extension.toUpperCase()} · ${settings.width}×${settings.height} · ${settings.fps} fps · ${formatBytes(blob.size)} · ${codec}`;
     el.result.hidden = false;
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong while creating the video.');
       console.error(error);

--- a/tools/images-to-video/styles.css
+++ b/tools/images-to-video/styles.css
@@ -417,32 +417,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-/* ----------------------------------------------------- buy me a coffee */
-
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/images-to-video/tool.toml
+++ b/tools/images-to-video/tool.toml
@@ -20,6 +20,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "video"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/merge-pdf/styles.css
+++ b/tools/merge-pdf/styles.css
@@ -331,22 +331,6 @@
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-/* Width is set from script as each file is finished. No animation: a bar that
-   slides while a document is written suggests progress nothing measured. */
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label { margin: 0.45rem 0 0; font-size: 0.85rem; color: var(--text-dim); }
-
 /* ----------------------------------------------------------------- results */
 
 .result { margin-top: 1.2rem; }

--- a/tools/merge-pdf/tool.toml
+++ b/tools/merge-pdf/tool.toml
@@ -20,6 +20,10 @@ category = "documents-and-audio"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "documents"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 js_parts = ["file-picker"]
 # Where a finished result can be carried without being saved first: the row of
 # links shared/handoff.js shows beside the download once there is one. Slugs of

--- a/tools/redact-pdf/styles.css
+++ b/tools/redact-pdf/styles.css
@@ -323,22 +323,6 @@
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-/* Width is set from script as each stage finishes. No animation: a bar that
-   slides while a document is rewritten suggests progress nothing measured. */
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label { margin: 0.45rem 0 0; font-size: 0.85rem; color: var(--text-dim); }
-
 /* ---------------------------------------------------------------- results */
 
 .result { margin-top: 1.2rem; }

--- a/tools/redact-pdf/tool.toml
+++ b/tools/redact-pdf/tool.toml
@@ -26,6 +26,10 @@ category = "documents-and-audio"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "documents"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 js_parts = ["file-picker"]
 lastmod = "2026-08-25"
 

--- a/tools/resize-image/styles.css
+++ b/tools/resize-image/styles.css
@@ -455,27 +455,6 @@ button.file-main-wrap:focus-visible {
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-/* Width is set from script as each image finishes. There is no animation on
-   purpose: a bar that slides while an encode is running suggests progress the
-   tool cannot actually measure part-way through. */
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label {
-  margin: 0.5rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-}
-
 /* ----------------------------------------------------------------- results */
 
 .results { margin-top: 1.4rem; }

--- a/tools/resize-image/tool.toml
+++ b/tools/resize-image/tool.toml
@@ -23,8 +23,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list"]
-
+css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/reverse-video/body.html
+++ b/tools/reverse-video/body.html
@@ -71,8 +71,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/reverse-video/src/main.js
+++ b/tools/reverse-video/src/main.js
@@ -34,7 +34,7 @@ const el = {
   sumPath: $('sum-path'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -406,7 +406,7 @@ async function runExport() {
 
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.result.hidden = true;
   el.preview.pause();
   setProgress({ phase: 'preparing', done: 0, total: 1 });
@@ -442,10 +442,10 @@ async function runExport() {
       result.codec,
     ].join(' · ');
     el.result.hidden = false;
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong while reversing.');
       console.error(error);

--- a/tools/reverse-video/styles.css
+++ b/tools/reverse-video/styles.css
@@ -109,30 +109,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/reverse-video/tool.toml
+++ b/tools/reverse-video/tool.toml
@@ -20,6 +20,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "video"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/split-gif/body.html
+++ b/tools/split-gif/body.html
@@ -82,8 +82,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
   </section>

--- a/tools/split-gif/src/main.js
+++ b/tools/split-gif/src/main.js
@@ -38,7 +38,7 @@ const el = {
   downloadSelected: $('download-selected'),
   downloadSheet: $('download-sheet'),
   cancel: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   framesCard: $('frames-card'),
@@ -558,13 +558,13 @@ function save(blob, name) {
 /* -------------------------------------------------------------- the frame */
 
 function progress(done, total, label) {
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.progressBar.style.width = `${total ? (done / total) * 100 : 0}%`;
   el.progressLabel.textContent = label;
 }
 
 function hideProgress() {
-  el.progressWrap.hidden = true;
+  el.progress.hidden = true;
   el.progressBar.style.width = '0%';
   el.progressLabel.textContent = '';
 }

--- a/tools/split-gif/styles.css
+++ b/tools/split-gif/styles.css
@@ -86,30 +86,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 /* -------------------------------------------------------------- the frames */
 
 .frames {

--- a/tools/split-gif/tool.toml
+++ b/tools/split-gif/tool.toml
@@ -20,6 +20,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "gif"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.

--- a/tools/stack-images/body.html
+++ b/tools/stack-images/body.html
@@ -141,8 +141,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/stack-images/src/main.js
+++ b/tools/stack-images/src/main.js
@@ -52,7 +52,7 @@ const el = {
 
   run: $('run'),
   cancel: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -444,7 +444,7 @@ function start() {
   el.error.hidden = true;
   el.result.hidden = true;
   el.cancel.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.progressBar.style.width = '0%';
   el.progressLabel.textContent = '';
   render();
@@ -568,7 +568,7 @@ function movesNote(moves) {
 function finishRun() {
   busy = false;
   el.cancel.hidden = true;
-  el.progressWrap.hidden = true;
+  el.progress.hidden = true;
   render();
 }
 

--- a/tools/stack-images/styles.css
+++ b/tools/stack-images/styles.css
@@ -175,30 +175,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/stack-images/tool.toml
+++ b/tools/stack-images/tool.toml
@@ -20,6 +20,10 @@ category = "images"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "images"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. Only the drop zone: the list underneath it
 # is this tool's own, because a row in it carries what was found inside a RAW
 # file rather than what the operating system said about the file.

--- a/tools/svg-to-image/styles.css
+++ b/tools/svg-to-image/styles.css
@@ -237,24 +237,6 @@
 
 .run-row { display: flex; align-items: center; gap: 0.9rem; flex-wrap: wrap; }
 
-.progress { margin-top: 1rem; }
-
-.progress-track {
-  height: 6px;
-  border-radius: 99px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-
-.progress-bar { height: 100%; width: 0; background: var(--accent); }
-
-.progress-label {
-  margin: 0.5rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-}
-
 /* ----------------------------------------------------------------- results */
 
 .results { margin-top: 1.4rem; }

--- a/tools/svg-to-image/tool.toml
+++ b/tools/svg-to-image/tool.toml
@@ -23,8 +23,7 @@ roadmap_group = "images"
 # Optional stylesheets from shared/css, dropped in between the frame and this
 # tool's own rules. file-list is the drop-a-file-then-see-a-row widget that
 # more than one tool needs and that no tool should own.
-css_parts = ["file-list"]
-
+css_parts = ["file-list", "progress"]
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/timelapse-video/body.html
+++ b/tools/timelapse-video/body.html
@@ -134,8 +134,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/timelapse-video/src/main.js
+++ b/tools/timelapse-video/src/main.js
@@ -49,7 +49,7 @@ const el = {
   planNote: $('plan-note'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -574,7 +574,7 @@ async function runExport() {
 
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.result.hidden = true;
   el.preview.pause();
   setProgress({ phase: 'preparing', done: 0, total: 1 });
@@ -627,10 +627,10 @@ async function runExport() {
       formatBytes(result.blob.size),
     ].join(' · ');
     el.result.hidden = false;
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong while making the time-lapse.');
       console.error(error);

--- a/tools/timelapse-video/styles.css
+++ b/tools/timelapse-video/styles.css
@@ -171,30 +171,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/timelapse-video/tool.toml
+++ b/tools/timelapse-video/tool.toml
@@ -20,6 +20,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "video"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.

--- a/tools/trim-audio/body.html
+++ b/tools/trim-audio/body.html
@@ -180,8 +180,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/trim-audio/src/main.js
+++ b/tools/trim-audio/src/main.js
@@ -66,7 +66,7 @@ const el = {
   cutNote: $('cut-note'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -747,7 +747,7 @@ async function runExport() {
   abortController = new AbortController();
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   progress(0, 'Starting...');
 
   const bits = Number(el.depth.value);
@@ -779,10 +779,10 @@ async function runExport() {
       `${((performance.now() - started) / 1000).toFixed(1)}s`,
     ].join(' · ');
 
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong while trimming the audio.');
       console.error(error);

--- a/tools/trim-audio/styles.css
+++ b/tools/trim-audio/styles.css
@@ -447,30 +447,6 @@ audio.player {
   flex-wrap: wrap;
 }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/trim-audio/tool.toml
+++ b/tools/trim-audio/tool.toml
@@ -28,6 +28,10 @@ category = "documents-and-audio"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "audio"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.

--- a/tools/trim-video/body.html
+++ b/tools/trim-video/body.html
@@ -205,8 +205,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/trim-video/src/main.js
+++ b/tools/trim-video/src/main.js
@@ -70,7 +70,7 @@ const el = {
   cutNote: $('cut-note'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -1184,7 +1184,7 @@ async function runExport() {
 
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.result.hidden = true;
   timeline.setEnabled(false);
   el.preview.pause();
@@ -1243,10 +1243,10 @@ async function runExport() {
       method === 'copy' ? 'not re-encoded' : result.codec,
     ].filter(Boolean).join(' · ');
     el.result.hidden = false;
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong.');
       console.error(error);

--- a/tools/trim-video/styles.css
+++ b/tools/trim-video/styles.css
@@ -513,30 +513,6 @@ kbd {
   flex-wrap: wrap;
 }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/trim-video/tool.toml
+++ b/tools/trim-video/tool.toml
@@ -21,6 +21,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "video"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts, and for
 # the same reason: a component more than one tool needs and no tool should own.
 # file-picker brings in the drop zone.

--- a/tools/video-to-gif/body.html
+++ b/tools/video-to-gif/body.html
@@ -150,8 +150,8 @@
       <button type="button" id="cancel" class="ghost" hidden>Cancel</button>
     </div>
 
-    <div id="progress-wrap" class="progress-wrap" hidden>
-      <div class="progress"><div id="progress-bar" class="progress-bar"></div></div>
+    <div id="progress" class="progress" hidden>
+      <div class="progress-track"><div id="progress-bar" class="progress-bar is-smooth"></div></div>
       <p id="progress-label" class="progress-label" role="status" aria-live="polite"></p>
     </div>
 

--- a/tools/video-to-gif/src/main.js
+++ b/tools/video-to-gif/src/main.js
@@ -49,7 +49,7 @@ const el = {
   memoryNote: $('memory-note'),
   exportBtn: $('export'),
   cancelBtn: $('cancel'),
-  progressWrap: $('progress-wrap'),
+  progress: $('progress'),
   progressBar: $('progress-bar'),
   progressLabel: $('progress-label'),
   error: $('error'),
@@ -511,7 +511,7 @@ async function runExport() {
 
   el.exportBtn.disabled = true;
   el.cancelBtn.hidden = false;
-  el.progressWrap.hidden = false;
+  el.progress.hidden = false;
   el.result.hidden = true;
   bar.setEnabled(false);
   el.preview.pause();
@@ -562,10 +562,10 @@ async function runExport() {
       formatBytes(result.blob.size),
     ].join(' · ');
     el.result.hidden = false;
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     el.result.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   } catch (error) {
-    el.progressWrap.hidden = true;
+    el.progress.hidden = true;
     if (error?.name !== 'AbortError') {
       showError(error?.message || 'Something went wrong while making the GIF.');
       console.error(error);

--- a/tools/video-to-gif/styles.css
+++ b/tools/video-to-gif/styles.css
@@ -245,30 +245,6 @@
 
 .export-row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
 
-.progress-wrap { margin-top: 1rem; }
-
-.progress {
-  height: 8px;
-  background: var(--surface-2);
-  border-radius: 99px;
-  overflow: hidden;
-  border: 1px solid var(--border);
-}
-
-.progress-bar {
-  height: 100%;
-  width: 0;
-  background: var(--accent);
-  transition: width 0.15s linear;
-}
-
-.progress-label {
-  margin: 0.45rem 0 0;
-  font-size: 0.85rem;
-  color: var(--text-dim);
-  font-variant-numeric: tabular-nums;
-}
-
 .error {
   margin: 1rem 0 0;
   padding: 0.7rem 0.9rem;

--- a/tools/video-to-gif/tool.toml
+++ b/tools/video-to-gif/tool.toml
@@ -20,6 +20,10 @@ category = "video-and-animation"
 # It sits at the top of that group as a link, above the names still to be built.
 roadmap_group = "gif"
 
+# Optional stylesheets from shared/css, dropped in between the frame and this
+# tool's own rules. progress is the bar this tool draws while it works.
+css_parts = ["progress"]
+
 # Shared modules this tool asks for. The same arrangement as css_parts,
 # and for the same reason: a component more than one tool needs and no
 # tool should own. file-picker brings in the drop zone.


### PR DESCRIPTION
Twenty-three tools draw a bar while they work, and every one of them wrote the
same four rules into its own stylesheet. Deleting the copies is the small half
of this.

## The part that was actually wrong

The copies had drifted into **two spellings of the same three elements**, and
they overlap:

| | the component | the groove | the fill |
|---|---|---|---|
| 10 tools | `.progress` | `.progress-track` | `.progress-bar` |
| 13 tools | `.progress-wrap` | `.progress` | `.progress-bar` |

So `.progress` meant *the component* in one half of the site and *the thing
inside it* in the other. Nothing catches that: each stylesheet is correct on
its own, and you only see it by opening two of them side by side.

This settles on the first spelling — `.progress` is the component,
`.progress-track` is the groove, `.progress-bar` is the fill — and moves the
thirteen over. `hash-checksum` called its fill `.progress-fill`; it is now the
same `.progress-bar` as everyone else's, and its `.progress-line` (a text row
with a Stop button) stays in its own sheet, because no other tool has one.

## The difference that was deliberate, and is kept

The two families also disagreed about animating the fill, and that one was
**not** drift. `compress-image` had written down why:

> There is no animation on purpose: a bar that slides while an encode is
> running suggests progress the tool cannot actually measure part-way through.

That is right for a batch tool, which knows only that it has finished the third
of eight images. It is wrong for a video encoder, which knows where it is at
every frame. So the shared default is **no** transition and the thirteen
continuous tools opt in:

```html
<div id="progress-bar" class="progress-bar is-smooth"></div>
```

Those thirteen also had **no `prefers-reduced-motion` guard** while each owned
the rule. There is one now, in the one place it has to be written.

## Two things that follow from having one file

- every track is 8px, rather than 8px in thirteen tools and 6px in nine;
- every label gets `tabular-nums`, which thirteen already had — a climbing
  count like "frame 640 of 1,000" no longer jitters as the digits change.

## Verified

Built with `--locale en`, then:

- **every id every tool's JS looks up was checked against the page the build
  makes** — 1,598 lookups across 36 tool pages, 0 missing. That is the exact
  failure this rename could cause (`$('progress')` against markup still saying
  `id="progress-wrap"`), and it is invisible to the build, so it was worth
  checking directly rather than by eye.
- three tools driven in the browser, one per case:

| page | boots | fill | transition | note |
|---|---|---|---|---|
| `/crop-video/` (renamed) | ✅ | `rgb(43,108,176)` | `width 0.15s` | track 8px/999px, bar half-width at 50% |
| `/compress-image/` (batch) | ✅ | `rgb(43,108,176)` | `0s` | correctly **not** animated |
| `/hash-checksum/` (span fill) | ✅ | `rgb(43,108,176)` | `0s` | `display:block` applies; `role="progressbar"` and its aria values kept |

No console errors on any of the three.

## Before / after

Not captured — screenshots do not composite in the harness this was built in.
The thing to photograph is a bar mid-run, since that is the only time it is on
screen: **`/compress-image/`** with a few images (the 6px→8px track, and the
label's figures) and **`/crop-video/`** mid-export.

- `before-progress-compress.png` / `after-progress-compress.png`
- `before-progress-crop.png` / `after-progress-crop.png`

## Note for review order

This touches the same tool stylesheets as the `accent-color` PR, but different
rules in them, so the two merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
