### PR TITLE
Give the button that does the work something to say when it is pressed

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -639,6 +639,25 @@ button, .as-button {
   font-size: 0.92rem;
 }
 
+/*
+  The button that starts the work, and the only control on a tool page that
+  needs to feel like one.
+
+  It used to do exactly one thing: brighten under the pointer. That is the
+  half of the interaction a mouse gets and a finger never does - a touch does
+  not hover, it arrives already pressed - so on a phone the button that runs
+  the tool acknowledged nothing between the tap and however many seconds of
+  work came after it. The `:active` state below is the half that was missing,
+  and it is the one that matters on the devices most of this site is read on.
+
+  The shadow is mixed from `--accent` rather than the neutral `--shadow` every
+  card uses. That is deliberate and is the whole visual idea: a card is a piece
+  of paper lying on the page, and this is not a card - it is the one thing on
+  the page that is going to do something, so it is lit by its own colour. The
+  resting shadow is kept small; the lift on hover and the collapse on press are
+  what carry the gesture, so the button travels toward the pointer and then
+  back under it.
+*/
 .primary {
   background: var(--accent);
   color: var(--accent-text);
@@ -646,9 +665,36 @@ button, .as-button {
   border-color: var(--accent);
   text-decoration: none;
   display: inline-block;
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--accent) 25%, transparent);
+  transition: box-shadow 0.15s ease, transform 0.1s ease, filter 0.15s ease;
 }
-.primary:hover:not(:disabled) { filter: brightness(1.08); }
-.primary:disabled { opacity: 0.45; cursor: default; }
+
+.primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--accent) 28%, transparent),
+              0 8px 18px -6px color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+/* Under the finger or the held mouse button: back down onto the page, and a
+   shade darker rather than brighter, because a surface being pushed catches
+   less light rather than more. */
+.primary:active:not(:disabled) {
+  transform: translateY(0) scale(0.98);
+  filter: brightness(0.97);
+  box-shadow: 0 1px 1px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+/* Nothing to press, so nothing is lit. */
+.primary:disabled { opacity: 0.45; cursor: default; box-shadow: none; }
+
+/* The lift and the press are movement and carry no meaning the colour change
+   does not already carry, so they are the first thing to go. */
+@media (prefers-reduced-motion: reduce) {
+  .primary { transition: none; }
+  .primary:hover:not(:disabled),
+  .primary:active:not(:disabled) { transform: none; }
+}
 
 .ghost {
   background: var(--surface);


### PR DESCRIPTION
`.primary` — the button that runs the tool — did exactly one thing under the
pointer:

```css
.primary:hover:not(:disabled) { filter: brightness(1.08); }
```

That is the half of the interaction a **mouse** gets. A finger never hovers: a
touch arrives already pressed. So on a phone, the button that starts the work
acknowledged nothing at all between the tap and however many seconds of
encoding came after it. `:active` is the half that was missing, and it is the
half that matters on the devices most of this site is read on.

## What it does now

- **resting** — a small shadow mixed from `--accent`
- **hover** — brightens, lifts 1px, shadow grows and spreads
- **active** — settles back down and 2% smaller, and goes a shade *darker*
  rather than brighter, because a surface being pushed catches less light
- **disabled** — loses the shadow with everything else, so nothing looks lit
  until there is something to press

The shadow being mixed from `--accent` rather than the neutral `--shadow` is
the visual idea, not a detail: a card is a piece of paper lying on the page,
and this is not a card — it is the one thing on the page that is about to *do*
something, so it is lit by its own colour.

## Deliberately not included

**`.ghost` is untouched.** It is a secondary control, often a chip half this
one's height sitting in a row of three, and a lift on something that size reads
as fidgeting rather than as feedback.

**`prefers-reduced-motion` drops the lift and the press** and keeps the colour
and shadow, matching how the rest of this stylesheet already guards movement.

## Verified

Built with `--locale en` and read out of the CSSOM, so the rules are proved to
have *parsed*, not merely to be present as text:

| | value |
|---|---|
| resting shadow, light | `color(srgb 0.169 0.424 0.690 / 0.25) 0 1px 2px` → `#2b6cb0` @ 25% |
| resting shadow, dark | `color(srgb 0.357 0.608 0.847 / 0.25)` → `#5b9bd8` @ 25% |
| while `:disabled` | `none` |
| `:active` rule | `translateY(0) scale(0.98)` + `brightness(0.97)` |
| reduced-motion guard | present, matched `.primary` |

Both shadow colours are `--accent` in the two themes, so this follows the token
rather than pinning a colour.

One thing worth noting for anyone re-checking this by hand: read the shadow
*after* suppressing the transition. Toggling `disabled` and reading immediately
returns a value mid-interpolation — `oklab(0 0 0 / 0) 0px 0px 0px 0px` — which
looks like a broken `color-mix()` and is not.

## Before / after

Not captured — screenshots do not composite in the harness this was built in,
and the interesting frame here is a button *being held down*, which a still
only half tells anyway. Worth a look on a phone rather than in a screenshot:
**`/compress-image/`**, choose an image so the run button enables, then press
and hold it.

- `before-primary-button.png`
- `after-primary-button.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
