### PR TITLE
Let a card cast the colour of the thing it points at when it is pointed at

### DIFF
--- a/shared/css/tool-frame.css
+++ b/shared/css/tool-frame.css
@@ -888,13 +888,18 @@ button, .as-button {
   border-radius: var(--radius);
   color: inherit;
   text-decoration: none;
-  transition: border-color 0.15s, transform 0.15s;
+  transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
+/* No shadow at rest, deliberately - see the note above about this panel being
+   recessed rather than competing with the tool. One appears only under the
+   pointer, which is the moment the tile stops being part of the band and
+   becomes the thing about to be clicked. */
 .tool-related a:hover,
 .tool-related a:focus-visible {
   border-color: var(--accent);
   transform: translateY(-2px);
+  box-shadow: 0 8px 20px -8px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/shared/site.css
+++ b/shared/site.css
@@ -212,17 +212,33 @@ code {
   box-shadow: var(--shadow);
   text-decoration: none;
   color: inherit;
-  transition: border-color 0.15s, transform 0.15s;
+  transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
 }
 
-.tool-card:hover {
+/* The card lifts two pixels and its edge turns accent, and until now the
+   shadow underneath did neither - it stayed the same flat neutral it has at
+   rest, so the card read as having slid sideways rather than risen toward the
+   reader. The accent layer is added to `--shadow` rather than replacing it,
+   which keeps the honest grey the card casts on the page in both themes and
+   adds the colour of the thing being pointed at underneath it.
+
+   `:focus-visible` gets the same treatment as `:hover`. It always should
+   have: a keyboard reader moving through thirty-seven of these was given a
+   focus ring and none of the movement a mouse reader gets, and the ring alone
+   is easy to lose in a grid. The sibling component on a tool page,
+   `.tool-related a`, already did both. */
+.tool-card:hover,
+.tool-card:focus-visible {
   border-color: var(--accent);
   transform: translateY(-2px);
+  box-shadow: var(--shadow),
+              0 10px 24px -6px color-mix(in srgb, var(--accent) 38%, transparent);
 }
 
 @media (prefers-reduced-motion: reduce) {
   .tool-card { transition: none; }
-  .tool-card:hover { transform: none; }
+  .tool-card:hover,
+  .tool-card:focus-visible { transform: none; }
 }
 
 .tool-icon { font-size: 1.6rem; line-height: 1; }
@@ -417,12 +433,27 @@ code {
   box-shadow: var(--shadow);
   color: inherit;
   text-decoration: none;
-  transition: border-color 0.12s ease, transform 0.12s ease;
+  transition: border-color 0.12s ease, transform 0.12s ease, box-shadow 0.12s ease;
 }
 
-.guide-card:hover {
+/* The same lift as a tool card, at the smaller amount a full-width row wants,
+   and for the same reasons - including the focus state, which a list read
+   top to bottom needs more than the grid does. */
+.guide-card:hover,
+.guide-card:focus-visible {
   border-color: var(--accent);
   transform: translateY(-1px);
+  box-shadow: var(--shadow),
+              0 8px 20px -8px color-mix(in srgb, var(--accent) 32%, transparent);
+}
+
+/* This one had no guard at all while .tool-card above has had one all along,
+   so a reader who had asked for less movement got it from the hub's grid and
+   not from the list of guides. */
+@media (prefers-reduced-motion: reduce) {
+  .guide-card { transition: none; }
+  .guide-card:hover,
+  .guide-card:focus-visible { transform: none; }
 }
 
 .guide-name { font-weight: 600; font-size: 1rem; color: var(--accent); }


### PR DESCRIPTION
A tool card already lifted 2px under the pointer and turned its edge accent —
but the shadow underneath stayed the same flat neutral it casts at rest. So the
card read as having **slid sideways** rather than risen toward the reader.

The accent layer is *added* to `--shadow` rather than replacing it:

```css
box-shadow: var(--shadow),
            0 10px 24px -6px color-mix(in srgb, var(--accent) 38%, transparent);
```

That keeps the honest grey the card casts on the page — and keeps it correct in
both themes, since `--shadow` is already a token — while putting the colour of
the thing being pointed at underneath it.

## Two things that were missing, not merely flat

**`:focus-visible` now gets what `:hover` gets**, on the hub's cards and the
guides' rows. A keyboard reader moving through thirty-seven cards got a focus
ring and none of the movement a mouse reader gets, and a ring alone is easy to
lose in a grid. The sibling component on a tool page, `.tool-related a`, has
always done both — so this is the odd one out being brought into line, not a
new idea.

**`.guide-card` had no `prefers-reduced-motion` guard at all**, while
`.tool-card` has had one since it was written. A reader who had asked for less
movement got less of it from the hub and the old amount from the list of
guides. Fixed here because it is the same rule being touched.

## The exception that stays one

`.tool-related a` gets the hover shadow and still has **none at rest**. That
panel is deliberately recessed — a tile glowing while nobody points at it would
compete with the tool the reader actually came for.

## Verified

Built with `--locale en` (which does write the hub and the guides index — 36
tool cards, 41 guide cards) and read out of the CSSOM, so the rules are proved
to have parsed:

| check | result |
|---|---|
| resting shadow, unchanged | `rgba(16,24,40,.06) 0 1px 2px, rgba(16,24,40,.04) 0 4px 12px` |
| `transition-property` | now includes `box-shadow` |
| hover shadow resolves to | `…, color(srgb 0.169 0.424 0.690 / 0.38) 0 10px 24px -6px` — 3 layers, accent at 38% |
| `.guide-card` reduced-motion guard | present |

**One honest gap:** I could not drive a real keyboard focus onto a card in this
harness — programmatic `.focus()` does not set `:focus-visible`, and synthetic
Tab presses would not advance focus in the preview pane. `:focus-visible` *does*
fire on this page (a neighbouring link matched it), and the rule is authored and
parsed with the right declarations, but the focus appearance on a card itself is
worth one look with a real Tab key before merging.

## Before / after

Not captured — screenshots do not composite in this harness. The frame worth
photographing is the **hub with the pointer resting on one card**, so the shadow
under it is visible against its unhovered neighbours.

- `before-tool-card-hover.png`
- `after-tool-card-hover.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
